### PR TITLE
Architecture baseline: ADRs 0001-0015 and repository skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Rust
+/target/
+**/*.rs.bk
+# Cargo.lock is committed: the workspace ships binaries (hosts, services, clients).
+
+# Web client / Node
+node_modules/
+dist/
+.vite/
+*.tsbuildinfo
+
+# WebAssembly build output
+pkg/
+wasm-pack.log
+
+# Generated protobuf code (generated at build time; schemas/ is the source of truth)
+**/src/generated/
+
+# Environment and secrets
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store
+
+# Editors
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Stray copies from interactive shell mishaps
+* 2.*
+*.bak
+*.orig

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Pilotage
+
+Rust-first, engine-independent platform for low-latency remote control, supervision,
+simulation, and training of maritime, aerial, and terrestrial vehicles.
+
+**Status:** architecture phase. The decision records under [docs/adr](docs/adr/README.md)
+are the authoritative design; no implementation code has landed yet.
+
+## What v1 delivers
+
+A browser client controlling a server-hosted Gazebo simulation: rendered video and
+telemetry stream down over WebTransport, sequenced control frames stream up, and channel-level
+control authority (vehicle helm, camera helm, payload helm) is enforced with scoped
+leases and fencing generations. The same binaries run over loopback or LAN for local
+demonstrations.
+
+## What the architecture protects
+
+- **Portable sans-IO core.** All protocol, authority, input, timing, and replay logic
+  lives in portable Rust crates shared by the browser (WebAssembly) and future native
+  clients. Platform code stays thin; domain logic is never duplicated.
+- **Engine independence.** Gazebo is the first adapter, not the platform boundary.
+  Unreal, Unity, deterministic headless trainers, and real-vehicle gateways are peer
+  implementations of the same adapter contract.
+- **No mandatory center.** Central services may provide identity, rendezvous, or relay,
+  but a session must never require a centrally operated simulator or vehicle fleet.
+- **Authority correctness.** Explicit state machines govern handover, emergency
+  override, and link loss; every control frame carries a scope and a fencing
+  generation, so stale controllers are invalidated immediately.
+
+## Repository layout
+
+| Path | Contents |
+|---|---|
+| `docs/adr/` | Architecture decision records (authoritative) |
+| `docs/` | Architecture overview and supporting design docs |
+| `schemas/` | Protobuf wire-schema sources — the protocol's source of truth |
+| `crates/` | Portable sans-IO core crates |
+| `hosts/` | Session-host binaries |
+| `adapters/` | Simulator and vehicle adapters (Gazebo first, reference-headless alongside) |
+| `clients/` | Browser (wasm) and future native front ends |
+| `services/` | Identity, rendezvous/signaling, and other optional central services |
+
+Start with [docs/architecture.md](docs/architecture.md), then the
+[ADR index](docs/adr/README.md).

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,16 @@
+# adapters/ — simulator and vehicle adapters
+
+Implementations of the adapter contract from `pilotage-adapter-api`
+([ADR-0008](../docs/adr/0008-engine-independent-adapter-boundary.md)). The public
+client protocol never exposes adapter-native messages (Gazebo, ROS, DDS, CAN,
+MAVLink, …).
+
+Planned contents:
+
+- `reference-headless/` — deterministic headless adapter; the conformance, replay,
+  and accelerated-training anchor. A v1 deliverable.
+- `gazebo/` — first graphical adapter: Gazebo integration, renderer capture,
+  vehicle bridge.
+
+Unreal, Unity, and real-vehicle gateways join as peer adapters when scheduled —
+directories are created when their code lands, not before.

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,14 @@
+# clients/ — operator front ends
+
+Thin platform layers over the portable core
+([ADR-0002](../docs/adr/0002-cargo-workspace-portable-sans-io-core.md)). No business
+rule or wire-level state machine may live only here.
+
+Planned contents:
+
+- `web/` — v1 browser client: wasm build of the core plus browser ports (Gamepad,
+  WebAuthn, WebTransport, WebCodecs, workers, rendering) and the UI application.
+- `native/` — future native operator station: platform HID, OS credentials, native
+  transport and codecs. Required architectural target; created when work begins.
+
+Both clients must pass the same conformance suite through their ports.

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,21 @@
+# crates/ — portable sans-IO core
+
+Domain logic shared by every client, host, and tool. Rules
+([ADR-0002](../docs/adr/0002-cargo-workspace-portable-sans-io-core.md)):
+
+- Pure state machines and data types: inputs are messages, events, and explicit
+  `now` timestamps; outputs are messages, actions, and requested timer deadlines.
+- No tokio, wasm-bindgen, web-sys, sockets, threads, system clocks, or engine SDKs.
+- Everything here must be exercisable by `cargo test` alone.
+
+Seed crates (created as implementation starts, split further per the size limits in
+[ADR-0015](../docs/adr/0015-workspace-quality-gates.md)):
+
+| Crate | Responsibility |
+|---|---|
+| `pilotage-protocol` | Wire types generated from `schemas/`, envelopes, version negotiation |
+| `pilotage-authority` | Lease, generation, handover, override, link-loss state machines |
+| `pilotage-input` | Canonical input model, device profiles, normalization pipeline |
+| `pilotage-timing` | Time model, latency accounting, staleness policy |
+| `pilotage-adapter-api` | Adapter traits and capability model |
+| `pilotage-conformance` | Shared fixtures and behavioral test suites |

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,34 @@
+# ADR-0001: Record architecture decisions as versioned files in this repository
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Pilotage spans protocol design, authority semantics, real-time transport, simulator
+integration, and future decentralized deployment. Decisions made now will be
+re-examined by contributors who need the reasoning, not just the outcome. A single
+monolithic design document (the pre-repository draft) proved hard to evolve: unrelated
+decisions shared one version number and one review cycle, and individual decisions
+could not be superseded independently.
+
+## Decision
+
+- Every significant architectural commitment is recorded as one file under
+  `docs/adr/`, named `NNNN-short-slug.md`, numbered in acceptance order.
+- Records use a compact MADR-style template: Status, Date, Context, Decision,
+  Consequences, and — where a real choice was weighed — Alternatives considered.
+- Statuses: `Proposed`, `Accepted`, `Deprecated`, `Superseded by ADR-NNNN`.
+- An Accepted record is immutable except for status changes and factual errata. A
+  changed decision gets a new record that supersedes the old one; history is never
+  rewritten.
+- Requirement words `MUST`, `SHOULD`, `MAY` follow RFC 2119 usage.
+- Open questions listed inside a record are commitments to decide, not decisions;
+  resolving one produces either an amendment before acceptance or a new record.
+
+## Consequences
+
+- Design review happens per decision, matching the one-issue-per-PR discipline.
+- The index in `docs/adr/README.md` is the entry point and MUST stay current.
+- The pre-repository draft (v0.3) is superseded by these records; the provenance
+  table in the index maps its sections to their successors.

--- a/docs/adr/0002-cargo-workspace-portable-sans-io-core.md
+++ b/docs/adr/0002-cargo-workspace-portable-sans-io-core.md
@@ -1,0 +1,74 @@
+# ADR-0002: One Cargo workspace with a portable sans-IO core
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+The v1 deliverable is a browser client (partly compiled to WebAssembly) controlling a
+server-hosted Gazebo simulation. Native operator stations are a required future
+target, and hosts, adapters, services, and conformance tooling are all Rust. Two risks
+pull in opposite directions:
+
+- If domain logic leaks into browser-specific code, native clients later require a
+  second implementation of protocol, input, authority, and timing behavior.
+- If browser and native are forced through one lowest-common-denominator platform
+  abstraction, their genuinely different device, credential, and media APIs get
+  obscured rather than isolated.
+
+A further constraint: identical behavior must be *provable* across browser, native,
+and test targets. An authority or timing bug reproducible only inside a wasm build in
+a live transport session would be nearly undiagnosable.
+
+## Decision
+
+1. The repository is a single Cargo workspace (monorepo) containing core crates,
+   hosts, adapters, clients, and services.
+2. Domain logic lives in **portable sans-IO core crates** under `crates/`:
+   - They contain pure state machines and data types. Inputs are messages, events,
+     and explicit `now` timestamps; outputs are messages, actions, and requested
+     timer deadlines.
+   - They MUST NOT depend on tokio, wasm-bindgen, web-sys, sockets, threads, system
+     clocks, or engine SDKs. Nondeterminism is what is excluded, not the standard
+     library.
+3. Platform ports drive the state machines and own all I/O:
+   - Browser ports: Gamepad, WebAuthn, WebTransport, WebCodecs, Web Workers,
+     rendering (wasm/JS/TS).
+   - Native ports (future): HID/SDL/gilrs, OS credential APIs, native QUIC,
+     hardware codecs, windowing.
+   - Host runtime: tokio, network listeners, adapter process management.
+4. No business rule or wire-level state machine may exist solely in JavaScript,
+   TypeScript, or any single platform layer.
+5. Core crates materialize on demand rather than all up front. The seed set:
+
+   | Crate | Responsibility |
+   |---|---|
+   | `pilotage-protocol` | Wire types generated from `schemas/`, envelopes, version negotiation |
+   | `pilotage-authority` | Lease, generation, handover, override, link-loss state machines |
+   | `pilotage-input` | Canonical input model, device profiles, normalization pipeline |
+   | `pilotage-timing` | Time model, latency accounting, staleness policy |
+   | `pilotage-adapter-api` | Adapter traits and capability model |
+   | `pilotage-conformance` | Shared fixtures and behavioral test suites |
+
+   Recording/replay, telemetry modelling, and transport-session logic split into
+   their own crates when they exceed the size limits in ADR-0015, not before.
+
+## Consequences
+
+- Every core behavior is testable with `cargo test` on a development machine — no
+  browser, simulator, or network required.
+- Deterministic replay (ADR-0012) falls out of the sans-IO discipline: replaying
+  recorded inputs and timestamps through the same state machines *is* the test.
+- Browser and native clients MUST pass the same conformance suite through their
+  respective ports.
+- Thin platform-specific code is accepted; duplicated domain logic is not.
+- Core crates must not grow `async fn`, clock reads, or I/O; CI enforces the
+  dependency bans (ADR-0015).
+
+## Alternatives considered
+
+- **Multiple repositories per plane:** rejected; protocol, host, and client evolve in
+  lockstep during early development, and cross-repo atomic changes are costly.
+- **Async-first core (tokio everywhere):** rejected; it would force a runtime into
+  wasm builds, entangle timing with the scheduler, and make deterministic replay and
+  conformance testing far harder.

--- a/docs/adr/0003-separate-responsibility-planes.md
+++ b/docs/adr/0003-separate-responsibility-planes.md
@@ -1,0 +1,71 @@
+# ADR-0003: Separate identity, authority, real-time data, media, and host planes
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+The system combines authentication, group membership, session admission,
+channel-level control ownership, low-latency input, telemetry, video streaming, and
+simulator integration. A single undifferentiated service or protocol would couple
+slow management operations to the real-time path and would obstruct future
+peer-hosted deployment. The platform also needs a clean split between globally or
+organizationally managed functions and session-local functions running next to the
+active simulator or vehicle gateway.
+
+## Decision
+
+Five responsibility planes are defined. They are **contract boundaries, not process
+boundaries** — how many binaries or services implement them is a deployment decision.
+
+1. **Identity and admission plane** — passkey/WebAuthn authentication; user,
+   organization, and group membership; session discovery and admission; issuance of
+   short-lived session capabilities.
+2. **Authority plane** — ownership of independently assignable control scopes;
+   handover, takeover requests, emergency override, revocation; lease generations and
+   effective authority; vehicle-level link-loss policy selection.
+3. **Real-time data plane** — control frames, fast telemetry, reliable authority and
+   mode events, capability and configuration exchange.
+4. **Media plane** — rendered-video capture, encoding and delivery, camera-source
+   selection, congestion and quality adaptation, timing correlation with telemetry
+   and control.
+5. **Session host** — simulator process(es) or vehicle gateway, rendering capture,
+   vehicle adapter, session-local real-time endpoint, host health and capability
+   publication.
+
+v1 ships exactly two deployables: a small identity/signaling service, and the session
+host, which embeds the authority engine (ADR-0006), the real-time data plane, and the
+media plane.
+
+```text
+Passkey authentication
+        |
+        v
+Identity/admission ----> short-lived session capability
+        |
+        v
+Browser <==== HTTPS bootstrap / WebTransport ====> Session host
+                                                  |- authority engine
+                                                  |- Gazebo + renderer capture
+                                                  |- vehicle adapter
+                                                  `- telemetry/control/media endpoint
+```
+
+## Consequences
+
+- The real-time path MUST NOT query an external identity or policy service per input
+  frame; per-frame verification uses compact session-local state.
+- Authoritative lease state MUST live at the session host or a directly connected
+  authority endpoint (placement decided in ADR-0006).
+- The session host MUST expose a versioned capability description.
+- Correlation identifiers and monotonic timestamps MUST cross the authority, data,
+  media, and host boundaries (ADR-0009, ADR-0012).
+- A peer-hosted deployment MAY use a central identity or rendezvous service, but MUST
+  NOT require a centrally operated simulator fleet.
+
+## Alternatives considered
+
+- **Single monolithic session gateway:** simple to start, but couples identity,
+  video, control, and simulator integration, and blocks peer hosting.
+- **One microservice per crate:** rejected; source-code modularity and process
+  topology are separate decisions.

--- a/docs/adr/0004-host-oriented-topology.md
+++ b/docs/adr/0004-host-oriented-topology.md
@@ -1,0 +1,66 @@
+# ADR-0004: Host-oriented topology spanning hosted, peer-hosted, and real-vehicle sessions
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+v1 runs Gazebo and its rendering workload on an application-controlled server,
+streaming video and telemetry to a browser and receiving control input. The same
+implementation must support a local demonstration over loopback or LAN. Beyond v1,
+the same abstraction must cover peer-hosted simulators, organization-operated
+clusters, and independently operated real vehicles, where the host endpoint may run
+onboard, on an edge companion computer, or at a nearby gateway.
+
+## Decision
+
+- A **session host** is the unit of deployment: it runs one or more adapters and the
+  session-local real-time media/control endpoint. In v1 it runs Gazebo and renderer
+  capture; for a real vehicle it bridges cameras, sensors, actuators, and vehicle
+  control networks.
+- The first production topology deploys the session host on an application-controlled
+  server. A local demonstration uses the same host binary and browser application
+  over loopback or LAN; local mode MUST NOT diverge from production behavior through
+  a special integration path.
+- The session host MUST be versioned, self-contained, and independently deployable.
+- Host registration, capability advertisement, and session admission use explicit
+  protocols; the browser treats the host endpoint as session-specific, never as a
+  permanent central media server.
+- Direct client-to-host connectivity SHOULD be used when reachability and policy
+  permit; relayed connectivity (a MASQUE-style QUIC relay) MAY be used when a host
+  is not directly dialable. A centrally supplied relay does not constitute a central
+  simulator fleet.
+- The platform operator MUST NOT be required to own or schedule simulator compute or
+  vehicle fleets. Fleet orchestration is an optional deployment concern outside the
+  session data plane.
+
+```text
+Hosted v1                          Peer-hosted (future)
+
+Browser                            Browser
+   | HTTPS bootstrap + WebTransport   | direct WebTransport where dialable,
+   v                                  v QUIC relay where necessary
+Server-hosted session host         User/org-operated session host
+   |- Gazebo + render capture         |- simulator or vehicle gateway
+   |- vehicle adapter                 |- vehicle adapter
+   `- telemetry/control endpoint      `- telemetry/control endpoint
+
+                       Optional central services:
+                identity | rendezvous | policy | QUIC relay
+```
+
+## Consequences
+
+- One deployment boundary covers simulation, rendering, telemetry, and control across
+  local testing, centralized v1 hosting, and decentralized future hosting.
+- Certificates, origins, and browser secure-context requirements for local and
+  peer-hosted hosts need an explicit strategy (open question below).
+- Peer-hosted and real-vehicle operation require a trust model for host software,
+  adapter integrity, telemetry authenticity, and actuator safety boundaries.
+
+## Open questions
+
+- Browser secure-origin strategy for local and peer-hosted hosts. Leaning: a
+  development origin plus locally provisioned certificates for the local demo;
+  decide during the first local-loop increment.
+- How hosts are updated, attested, and permitted to join organizational deployments.

--- a/docs/adr/0005-webtransport-primary-transport.md
+++ b/docs/adr/0005-webtransport-primary-transport.md
@@ -1,0 +1,86 @@
+# ADR-0005: WebTransport as the primary real-time transport, including media
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+The browser must receive low-latency rendered video and send control input, for
+centrally hosted, local, and future peer-hosted session hosts. WebSocket's ordered
+reliable delivery delays fresh control behind retransmissions, so a
+head-of-line-blocking-free transport is required.
+
+WebTransport (QUIC/HTTP-3) is Baseline across engines: Chrome 97+, Edge 98+,
+Firefox 114+, and — since Safari 26.4 (March 2026) — macOS, iOS, and iPadOS,
+including datagrams, unidirectional and bidirectional streams, and backpressure.
+WebCodecs `VideoDecoder` has shipped in Safari since 16.4 and in Blink/Gecko for
+years. The historical reason to adopt WebRTC (the only browser path with unreliable
+delivery and a media pipeline) no longer holds.
+
+## Decision
+
+- One **WebTransport session** per browser↔host connection carries all real-time
+  traffic. Session bootstrap (authentication, admission, connect URL + token) uses
+  plain HTTPS; there is no SDP/ICE negotiation.
+- Message classes (ADR-0011) map onto WebTransport mechanisms:
+
+  | Class | Mechanism | Semantics |
+  |---|---|---|
+  | `control-fast` | Datagrams | Unordered, unreliable; superseded samples droppable |
+  | `control-edges` | Reliable ordered stream | Button edges and one-shots; never silently dropped |
+  | `telemetry-fast` | Datagrams | Unordered, best effort |
+  | `authority-events` | Reliable ordered stream (dedicated) | Lease grants, handover, override, revocation, acknowledgements |
+  | `bulk` | One stream per transfer | Profiles, capabilities, configuration, log fragments; no head-of-line contention with authority events |
+  | `media` | Unidirectional stream per frame or GOP | Encoded video units with bounded lifetime; late units abandoned, not awaited |
+
+- **Video** is encoded on the host (low-latency H.264 first; AV1/HEVC as adapters
+  and hardware allow), carried as media-class streams, decoded in the browser with
+  WebCodecs, and rendered to canvas/WebGPU. The client owns its jitter buffer and
+  exposes per-stage timing (ADR-0009).
+- **Bandwidth adaptation is ours to build**: delay- and loss-driven encoder rate
+  control plus explicit keyframe-request messages. This is deliberate — an owned
+  pipeline is instrumentable end to end, where WebRTC's congestion controller and
+  jitter buffer are opaque.
+- The host side is a pure-Rust QUIC/WebTransport endpoint (quinn-family stack),
+  keeping the host free of SDP/ICE/DTLS-SRTP machinery.
+- Message schemas remain transport-independent (ADR-0014): datagrams carry exactly
+  one envelope-wrapped message; streams carry length-delimited envelopes.
+
+### Browser floor
+
+WebTransport-capable browsers: Safari 26.4+ (macOS/iOS/iPadOS), Chrome 97+,
+Edge 98+, Firefox 114+. On iOS/iPadOS all browsers inherit WebKit, so the 26.4
+system floor governs.
+
+## Consequences
+
+- No STUN/TURN/ICE planning; instead, the session host must be **dialable**: a
+  reachable UDP/443 QUIC endpoint (with the platform-level HTTP/2 fallback where
+  QUIC is blocked). For future peer-hosted topologies behind NAT, a QUIC relay
+  (MASQUE-style) replaces WebRTC's hole-punching; hosted v1 is unaffected.
+- TLS certificates are mandatory. Server-hosted v1 uses ordinary certificates. The
+  local-demo strategy (locally provisioned dev certificate vs
+  `serverCertificateHashes`, whose Safari support is unverified) is the open
+  question tracked in ADR-0004.
+- Datagram payloads must fit one QUIC packet (~1200 B MTU budget) — control frames
+  are tens of bytes, so this constrains telemetry batching, not control.
+- Media-pipeline work (WebCodecs decode, jitter buffer, rate control, keyframe
+  recovery) is scheduled as an explicit spike in the first local-loop increment and
+  validated under impaired networks in the hosted increment.
+- Spectator fan-out later means host-side or relay-side stream replication rather
+  than an SFU.
+
+## Alternatives considered
+
+- **WebRTC (media tracks + DataChannels):** the previous baseline while Safari
+  lacked WebTransport. Mature congestion control and NAT traversal, but: two
+  protocol stacks in one host (signaling + ICE + DTLS-SRTP alongside HTTPS), opaque
+  jitter/CC behavior that fights the latency-instrumentation requirement, and a
+  heavy host-side library choice (str0m vs webrtc-rs). Revisit trigger: field data
+  showing NAT-blocked peer-hosted sessions that a relay cannot serve acceptably, or
+  DIY rate control failing to converge under real network profiles.
+- **WebSocket for everything:** head-of-line blocking puts retransmitted history
+  ahead of fresh control samples; unacceptable for the control loop.
+- **WebTransport for data + WebRTC for media only:** doubles the transport surface
+  for one feature (built-in CC) that we intend to own anyway; worst of both worlds
+  for a small team.

--- a/docs/adr/0006-capability-auth-scoped-leases-fencing.md
+++ b/docs/adr/0006-capability-auth-scoped-leases-fencing.md
@@ -1,0 +1,75 @@
+# ADR-0006: Capability-based authorization with scoped leases and fencing generations
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+A vehicle may have multiple independently controlled subsystems: one user may hold
+the **vehicle helm** while another holds the **camera helm** or **payload helm**.
+Passkeys are right for login and sensitive re-authorization but cannot sign every
+real-time input frame. Revocation and handover must invalidate a stale controller
+immediately, even while its transport connection remains open.
+
+## Decision
+
+### Authentication and capabilities
+
+- Authentication uses passkey/WebAuthn and produces a short-lived **session
+  capability** binding principal → session → grantable scopes.
+- The capability admits the principal to a session; it does not itself confer
+  real-time control.
+
+### Leases and fencing
+
+- Real-time authority is one **lease per independently assignable control scope**.
+- Each scope lease carries a monotonically increasing **fencing generation**.
+- Every control frame identifies its target scope and lease generation; the host
+  rejects (and counts) any frame whose generation is not *equal* to the current
+  generation for that scope.
+- A principal MAY hold multiple scope leases; different principals MAY hold
+  different scopes on the same vehicle.
+- Generations advance on every handover, revocation, override, or reassignment.
+
+Scopes are published by host capability discovery, not hard-coded globally
+(e.g. `vehicle.motion`, `vehicle.camera`, `vehicle.payload`,
+`vehicle.automation-mode`). Operational vocabulary (*helm*, *watch*, *handover*,
+*relief*) is a UI concern; wire identifiers stay stable, neutral, and
+machine-readable.
+
+```rust
+struct ControlLease {
+    holder: PrincipalId,
+    vehicle: VehicleId,
+    scope: ControlScope,
+    generation: u64,
+    authority_class: AuthorityClass,
+    priority: u16,
+    valid_until: MonotonicDeadline,
+}
+```
+
+### Authority engine placement (resolves a draft open question)
+
+The authority engine is a **sans-IO library crate (`pilotage-authority`) embedded in
+the session host** for v1. The identity plane decides *who may enter and what they
+may request*; the host-local engine is authoritative for *who holds what right now*.
+
+Rationale: the per-frame verifier needs session-local state regardless, and a
+central authority service would add a network dependency in the path that changes
+effective control — exactly where partitions are most dangerous. Because clients
+observe authority only through ordered authority events, the same engine can later be
+fronted by a central or organizational authority service for fleet-wide policy
+without protocol change.
+
+## Consequences
+
+- The per-frame verifier operates on compact session-local state and MUST NOT perform
+  external policy lookups.
+- A camera controller can be replaced without disturbing the motion controller.
+- UI MUST show the current holder of each active scope separately.
+- Authorization policy MAY grant rights to request, approve, release, or forcibly
+  override specific scopes; the policy matrix is an open product question tracked in
+  the backlog, not blocking the engine design.
+- Rejected-frame counts per scope/generation are mandatory observability signals
+  (ADR-0012).

--- a/docs/adr/0007-canonical-input-model-device-profiles.md
+++ b/docs/adr/0007-canonical-input-model-device-profiles.md
@@ -1,0 +1,46 @@
+# ADR-0007: Canonical input model and versioned device-profile registry
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Browser Gamepad API representations vary by device, platform, firmware, and browser.
+Serious control arrangements combine a joystick, throttle quadrant, pedals, and a
+gamepad. Binding raw browser axis/button indexes directly to simulator commands makes
+profiles fragile, prevents reuse across devices, and couples the client to one
+simulator's vocabulary.
+
+## Decision
+
+- Separate the pipeline stages: physical sampling → device identification →
+  normalization → calibration → deadzone/saturation → response curve → logical
+  binding → scoped simulator command → control frame.
+- Define a **canonical logical input model** independent of Gamepad API indexes and
+  independent of any vehicle type's control vocabulary.
+- Maintain a **versioned registry of device profiles** with layered precedence:
+
+  ```text
+  built-in registry < organization registry < user profile
+      < vehicle-specific profile < current-session override
+  ```
+
+- Support multi-device composition, dead zones, saturation, inversion, response
+  curves, chords, mode shifts, and button-edge semantics.
+- Perform latency-sensitive normalization and profile evaluation client-side (in the
+  browser for v1), inside the portable input crate (ADR-0002), so native clients
+  reuse it unchanged.
+- Bind canonical logical inputs to a host-published control scope (ADR-0006); the
+  control frame carries the profile revision in effect (ADR-0009).
+- Emergency actions (deadman release, emergency stop) are protocol-level semantics
+  with dedicated messages — never merely one more device binding.
+
+## Consequences
+
+- Device profiles need schema versions and migration support from day one.
+- Calibration MUST be visible and testable before control is enabled; the client
+  SHOULD display raw and normalized values side by side for diagnosis.
+- Profile evaluation is deterministic and sans-IO, so recorded raw samples plus a
+  profile revision reproduce the exact command stream in tests.
+- The registry is data, not code: new devices ship as registry entries, not client
+  releases (signed online registry updates are a backlog item).

--- a/docs/adr/0008-engine-independent-adapter-boundary.md
+++ b/docs/adr/0008-engine-independent-adapter-boundary.md
@@ -1,0 +1,59 @@
+# ADR-0008: Engine-independent adapter boundary; Gazebo first, reference adapter always
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Gazebo is the first integration, but control, telemetry, media, timing, and authority
+semantics must not depend on Gazebo, Unreal, Unity, any game engine, or one vehicle
+model. The same contracts must support headless accelerated simulation and
+real-vehicle gateways. Different vehicles expose different commands, telemetry
+fields, cameras, update rates, and link-loss actions.
+
+## Decision
+
+- The session host defines canonical host, vehicle, control-scope, telemetry,
+  media-source, and lifecycle contracts in `pilotage-adapter-api`. Gazebo is the
+  first implementation; other engines, deterministic headless trainers, and
+  real-vehicle gateways are peer adapters.
+- A **deterministic headless reference adapter** is a v1 deliverable, not future
+  work: it anchors protocol, timing, replay, accelerated-training, and conformance
+  tests independently of all graphical or commercial engines.
+
+```rust
+trait VehicleAdapter {
+    fn capabilities(&self) -> AdapterCapabilities;
+    fn apply_control(&mut self, frame: ScopedControlFrame) -> ApplyOutcome;
+    fn sample_telemetry(&mut self) -> TelemetryBatch;
+    fn video_sources(&self) -> Vec<VideoSource>;
+    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: LinkLossPolicy);
+    /// Stepped execution for deterministic and accelerated modes (ADR-0013).
+    fn step(&mut self, budget: StepBudget) -> StepOutcome;
+}
+```
+
+The capability description includes: vehicles present; assignable control scopes per
+vehicle; command schemas and units; telemetry fields, units, reference frames, and
+expected update rates; camera and rendered-video sources; supported link-loss
+actions; execution mode (real-time, stepped, accelerated, deterministic,
+render-capable, physically embodied); adapter and schema versions.
+
+### Placement and Gazebo v1
+
+- The Gazebo adapter SHOULD run on the same machine as Gazebo, in-process, over
+  Gazebo Transport, or as a local sidecar.
+- Rendering capture SHOULD occur as close as practical to the Gazebo rendering
+  pipeline to minimize copies and latency.
+- The public client protocol MUST NOT expose raw Gazebo, Unreal, Unity, ROS, DDS,
+  CAN, MAVLink, or other adapter-native messages as its canonical API.
+
+## Consequences
+
+- Vehicle motion and camera control are advertised as separate scopes.
+- The canonical model MUST NOT assume an aircraft-only or car-only vocabulary.
+- `ApplyOutcome` reports the simulation tick and whether a command was accepted,
+  transformed, constrained, or rejected — required for latency accounting
+  (ADR-0009) and replay (ADR-0012).
+- Real vehicles advertise that stepping, reset, snapshot, or deterministic replay are
+  unsupported rather than being forced into simulator semantics.

--- a/docs/adr/0009-time-model-and-latency-budget.md
+++ b/docs/adr/0009-time-model-and-latency-budget.md
@@ -1,0 +1,69 @@
+# ADR-0009: Explicit time model, end-to-end latency budget, stale-input rejection
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+The user experience is the complete loop: simulation state → render → encode →
+network → decode → presentation → human response → input sampling → network →
+validation → simulation application. Average latency alone is insufficient — jitter,
+frame age, queue growth, and tail latency determine controllability. Additionally,
+accelerated training (ADR-0013) breaks any assumption that simulation time tracks
+wall-clock time, so time domains must be explicit from the start.
+
+## Decision
+
+### Time model
+
+The protocol distinguishes three time domains; they are never conflated:
+
+- `transport_time` — monotonic clock local to each endpoint; used for sampling
+  timestamps, age estimation, and staleness decisions. Never compared raw across
+  endpoints; offset/RTT estimation handles cross-endpoint correlation.
+- `host_time` — the session host's monotonic clock; the reference for per-session
+  event ordering and latency accounting.
+- `simulation_time` — the adapter's simulated clock (ticks); may run slower, faster,
+  or stepped relative to wall clock.
+
+### Control-frame requirements
+
+Every real-time control frame MUST include: scope, fencing generation, sequence
+number, client monotonic sample timestamp, profile revision, and the current logical
+input state with required edge events.
+
+The session host MUST record or derive: receive timestamp, estimated frame age,
+simulation application tick, and the accepted / transformed / constrained / rejected
+outcome — plus video capture and presentation timing signals where available.
+
+### Rejection rules
+
+The host MUST reject: stale generations; duplicates and reordered frames according to
+each message class's semantics (ADR-0011); and frames older than the configured
+maximum control age. Continuous axes use latest-valid-value semantics; one-shot and
+button-edge commands use explicit consumption or acknowledgement semantics.
+
+### Initial engineering budget (targets, not guarantees, until validated)
+
+| Stage | Initial target |
+|---|---:|
+| Device sampling → serialized frame | < 4–8 ms under normal load |
+| Control one-way network path | < 20–40 ms preferred |
+| Host validation → simulator application | ≤ 1 simulation tick in the normal path |
+| Render + encode | < 16–30 ms preferred |
+| Video network + jitter buffer | < 30–60 ms preferred |
+| Decode + presentation | < 16–30 ms preferred |
+| Machine closed loop (excluding human) | < 100–150 ms design target |
+
+## Consequences
+
+- Latency observability is a core product requirement; every stage above is
+  instrumented via structured events (ADR-0012).
+- Local-loopback mode is the baseline that separates software latency from network
+  latency; it is measured first in every increment.
+- Every queue in the real-time path has an explicit maximum depth and drop policy;
+  drops are counted, never silent.
+- The validation suite MUST include jitter, loss, reordering, bandwidth reduction,
+  encoder overload, browser main-thread contention, and simulator tick slowdown.
+- p95/p99 closed-loop targets under specified network profiles remain to be set
+  after first measurements (tracked in the backlog).

--- a/docs/adr/0010-authority-state-machines.md
+++ b/docs/adr/0010-authority-state-machines.md
@@ -1,0 +1,84 @@
+# ADR-0010: Handover, override, and link loss as explicit state machines
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Normal handover should feel like the positive three-call exchange used in aviation
+and maritime practice ("You have control." / "I have control." / "You have
+control."), with both parties certain who is expected to act. This normal process
+must coexist with emergency takeover, supervisory authority, disconnected operators,
+and automation agents — without ambiguity about the exact instant authority changes.
+
+## Decision
+
+Authority is maintained per control scope by the authority engine (ADR-0006) as an
+explicit state machine.
+
+### States and transitions
+
+```text
+Unassigned -> Held(A)
+Held(A)    -> Offered(A -> B) -> Held(B)          normal handover
+Held(A)    -> Released        -> Unassigned
+Held(A)    -> Revoked         -> Unassigned | Held(C)
+Held(A)    -> EmergencyOverride(C) -> Held(C)
+Held(A)    -> LinkDegraded(A) -> Held(A) | LinkLost(A) -> VehicleConfiguredFailover
+```
+
+### Commit point (resolves a draft open question)
+
+Effective authority changes at **exactly one atomic point: the authority engine
+committing the recipient's ACCEPT**, which reassigns the lease and advances the
+fencing generation.
+
+```text
+A: OFFER_CONTROL(scope, B)            engine: Offered; A remains effective holder
+B: ACCEPT_CONTROL(scope, expected_generation)
+                                      engine: atomic commit -> Held(B), generation+1
+B: I_HAVE_CONTROL(scope, new_gen)     confirmation, audited, surfaced in UI
+A: YOU_HAVE_CONTROL(scope, new_gen)   confirmation, audited, surfaced in UI
+```
+
+The three-call phraseology is the UX and audit layer on top of the two-phase
+offer/accept commit. The confirmations do not gate the transfer: after commit, A's
+frames are already fenced out by generation. Missing confirmations raise a UI warning
+and an audit event, not a rollback. Offers expire after a configurable TTL; expiry
+returns the scope to `Held(A)` with an audit event.
+
+### Emergency and higher-authority operations
+
+Distinct policy-controlled operations exist for: voluntary handover; requested
+takeover requiring current-holder approval; emergency override; supervisory or
+instructor override; administrative revocation; automatic reassignment after link
+loss; automation-agent acquisition or release.
+
+Emergency override MUST: be explicitly authorized for actor and scope; advance the
+generation atomically; invalidate the previous holder immediately; be idempotent;
+carry an override reason and authority class; produce conspicuous UI and audit
+events; and never depend on the displaced holder's acknowledgement.
+
+### Link loss
+
+Link-loss behavior is configured per vehicle instance (vehicle class MAY supply a
+default). The adapter publishes its supported actions (neutralize, brake, hold
+briefly, pause, engage automation mode); the platform prescribes no universal action.
+
+## Consequences
+
+- UI MUST show the *effective* holder of every scope and distinguish pending from
+  completed transfer.
+- Callouts SHOULD be generated for normal handover and MUST be generated for forced
+  override.
+- State-machine tests MUST cover duplicate, delayed, reordered, and contradictory
+  acknowledgements, offer expiry racing accept, and override racing normal transfer.
+  The sans-IO engine (ADR-0002) makes these plain table-driven unit tests.
+
+## Open questions (policy, not mechanism)
+
+- Which authority classes may force-override which scopes.
+- Whether the current holder can veto a requested (non-emergency) takeover.
+- Which actions require renewed passkey verification.
+- Whether physical-control acknowledgement is required or UI acknowledgement
+  suffices, per deployment class.

--- a/docs/adr/0011-message-classes-and-channel-semantics.md
+++ b/docs/adr/0011-message-classes-and-channel-semantics.md
@@ -1,0 +1,38 @@
+# ADR-0011: Separate control, telemetry, authority-event, and bulk message classes
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Continuous axis samples, camera commands, telemetry snapshots, authority changes,
+emergency actions, and configuration objects have different reliability, ordering,
+and freshness needs. One reliable ordered stream would create head-of-line blocking
+and unpredictable overload behavior exactly when the link degrades.
+
+## Decision
+
+- Messages are grouped into classes with explicit delivery semantics, mapped onto the
+  channel layout of ADR-0005:
+  - **Continuous control** — superseded samples MAY be dropped; only freshness
+    matters.
+  - **Edges and one-shots** — button edges and one-shot commands are preserved under
+    explicit consumption/acknowledgement semantics; never silently dropped.
+  - **Authority and mode events** — reliable, ordered, idempotent.
+  - **Telemetry** — best-effort by default; individual fields may declare
+    reliability requirements.
+  - **Bulk configuration** — reliable, ordered, latency-insensitive.
+- Telemetry stays separate from encoded video; telemetry and authority overlays are
+  rendered client-side by default, so stale data is never baked into encoded frames.
+- Camera-control commands are ordinary scoped control messages under the camera
+  scope — not media-plane implementation details — so the camera helm can be held
+  independently of the vehicle helm.
+
+## Consequences
+
+- Each message class requires an explicit queue, overload, and drop policy; drops
+  are counted per class (ADR-0009, ADR-0012).
+- Telemetry schemas MUST state units, reference frames, validity, and update-rate
+  expectations (published via adapter capabilities, ADR-0008).
+- Class semantics are part of the protocol contract (ADR-0014), independent of the
+  transport that carries them.

--- a/docs/adr/0012-structured-session-events.md
+++ b/docs/adr/0012-structured-session-events.md
@@ -1,0 +1,46 @@
+# ADR-0012: Structured session events for observability, recording, and replay
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Latency and authority failures cannot be diagnosed from ordinary application logs.
+The system must distinguish operator intent, accepted authority, network arrival,
+host validation, simulator application, telemetry, and rendered-video timing — and
+correlate them across plane boundaries.
+
+## Decision
+
+- A versioned structured event model covers, at minimum: session and host lifecycle
+  (`SessionCreated`, `HostRegistered`, `UserJoined`, `CapabilityIssued`), authority
+  (`ScopeLeaseGranted`, `ScopeTransferOffered`, `ScopeTransferCommitted`,
+  `ScopeLeaseRevoked`, `EmergencyOverrideApplied`), the control path
+  (`ControlReceived`, `ControlRejected`, `ControlApplied`), and the sensing path
+  (`TelemetryObserved`, `VideoFrameCaptured`, `MediaTimingObserved`,
+  `LinkStateChanged`, `VehicleFailoverApplied`, `WarningRaised`).
+- Events distinguish the stages of one intent: client-observed device input →
+  normalized operator intent → host-received control → authority-valid control →
+  simulator-applied control → resulting telemetry. Correlation identifiers tie the
+  chain together (ADR-0003, ADR-0009).
+- Event production MUST be non-blocking with respect to the real-time path: bounded
+  queues, and when a consumer lags, drops are **counted, logged at error level, and
+  surfaced as a health signal** — a lagging observer is a correctness signal, never
+  silent noise.
+- Persistence MAY be sampled or disabled by policy for high-rate control and
+  telemetry events. Authority events are always persisted: they are the audit trail
+  for handover and override disputes.
+- Replay tooling targets the deterministic reference adapter (ADR-0008) first;
+  Gazebo scenario replay is supported where determinism permits.
+
+## Consequences
+
+- The event schema and correlation identifiers are part of the base protocol design
+  (ADR-0014), not an add-on.
+- High-rate events may need chunked binary storage or aggregation; the recording
+  format supports both event streams and dense batch trajectories (ADR-0013).
+- Privacy and retention policy must be resolved before production recording
+  (backlog).
+- Because core logic is sans-IO (ADR-0002), replaying a recorded session through the
+  state machines reproduces authority transitions and applied-control ordering
+  exactly; conformance tests assert this.

--- a/docs/adr/0013-interactive-and-accelerated-sessions.md
+++ b/docs/adr/0013-interactive-and-accelerated-sessions.md
@@ -1,0 +1,52 @@
+# ADR-0013: Single-vehicle operation and horizontally scalable accelerated training
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Pilotage must serve an interactive operator controlling one vehicle *and* large
+in-silico workloads with many vehicles, environments, policies, and simulation
+instances. ADAS and autonomy development needs faster-than-wall-clock simulation,
+deterministic seeds, batch stepping, headless execution, and distributed workers.
+Interactive video streaming and human control must not be imposed on every training
+instance — and real vehicles must not be forced into simulator semantics.
+
+## Decision
+
+- A session MAY contain one vehicle, multiple coordinated vehicles, or a simulation
+  shard containing many independently addressed vehicles. Vehicle identity, control
+  scopes, telemetry streams, authority, and lifecycle are namespaced by session and
+  vehicle identifiers.
+- The adapter contract supports both real-time streaming and explicit stepped
+  execution (`step()` in ADR-0008); capability negotiation states whether an adapter
+  is real-time, accelerated, deterministic, step-driven, render-capable, or
+  physically embodied.
+- Headless operation, deterministic reset, seeded scenarios, snapshot/restore,
+  batched observations, batched actions, and accelerated execution are first-class
+  adapter capabilities.
+- Video and human-facing media are optional capabilities; training workers operate
+  without rendering or media streaming.
+- Canonical action and observation models MAY have efficient batch encodings but
+  MUST preserve the semantics of the interactive control and telemetry models — one
+  vocabulary, two densities.
+- A fleet orchestrator MAY schedule workers, scenarios, policies, and datasets, but
+  is outside the session data-plane correctness boundary (ADR-0004).
+- Real vehicles advertise unsupported capabilities (stepping, reset, snapshot,
+  deterministic replay) explicitly.
+
+## Consequences
+
+- The three-domain time model (ADR-0009) is what lets simulation time run
+  decoupled from wall clock.
+- Interactive operator services and training orchestration may become separate
+  binaries while sharing protocol and model crates.
+- Performance testing covers both one low-latency interactive session and many
+  headless accelerated instances.
+
+## Alternatives considered
+
+- **Training as a separate product:** rejected; it would duplicate vehicle schemas,
+  actions, telemetry, scenario definitions, and replay infrastructure.
+- **Forcing all simulation through a video/game-session abstraction:** rejected;
+  rendering and wall-clock pacing would make large-scale training inefficient.

--- a/docs/adr/0014-protobuf-wire-schema.md
+++ b/docs/adr/0014-protobuf-wire-schema.md
@@ -1,0 +1,59 @@
+# ADR-0014: Protobuf as the wire-schema source of truth
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Every plane boundary carries versioned messages: control frames, telemetry,
+authority events, capabilities, device profiles, and recorded events. Three forces
+shape the format choice:
+
+- **Independent deployment.** Peer-hosted session hosts and clients will not upgrade
+  in lockstep; schema evolution must be safe across versions by construction.
+- **Polyglot edges.** Adapters and gateways (ROS 2 bridges, MAVLink gateways,
+  onboard companions) and debug tooling will not all be Rust, even though the core
+  is.
+- **Hot path.** Control frames flow at roughly 100–250 Hz per operator and telemetry
+  somewhat faster; encoding must be compact and cheap, but this is not a
+  zero-copy-or-die regime.
+
+## Decision
+
+- All cross-boundary messages are defined in **Protobuf** under `schemas/`, which is
+  the single source of truth for the protocol.
+- Rust code is generated at build time via `prost` into `pilotage-protocol`;
+  generated code is neither hand-edited nor committed.
+- Evolution rules: field numbers are never reused; unknown fields are tolerated;
+  every enum has an `UNSPECIFIED = 0` sentinel; breaking changes require a new
+  message or package version, negotiated at session setup.
+- Framing: a WebTransport datagram carries exactly one envelope-wrapped protobuf
+  message; streams carry length-delimited envelopes. The recording format adds
+  explicit length-and-type framing.
+- The canonical JSON mapping (protojson) MAY be used for diagnostics and
+  configuration files, never on the real-time path.
+- Once schemas exist, CI runs `buf lint` and `buf breaking` against the base branch
+  (ADR-0015).
+
+## Consequences
+
+- Protocol changes are reviewed as API changes in one place (`schemas/`), with
+  mechanical breaking-change detection.
+- The hot path pays a small encode/decode cost; acceptable at these rates and
+  message sizes (control frames are tens of bytes).
+- Protobuf serialization is not canonical: replay, hashing, and signatures operate
+  on recorded bytes, never on re-serialized messages.
+- TypeScript types for browser debug tooling and any future non-Rust adapter come
+  from the same schemas for free.
+
+## Alternatives considered
+
+- **serde + postcard/bincode:** lowest friction for Rust↔Rust and attractive with a
+  wasm client, but it locks the protocol into Rust struct layout, and evolution
+  discipline rests on convention — silent breakage across independently deployed
+  versions is exactly the failure mode to exclude.
+- **JSON everywhere:** transparent and debuggable, but allocation-heavy and verbose
+  on the control/telemetry path; kept only as the diagnostic mapping.
+- **FlatBuffers / Cap'n Proto:** zero-copy advantages don't pay off at these message
+  sizes and rates, and Rust ergonomics plus review tooling are weaker than the
+  protobuf ecosystem's.

--- a/docs/adr/0015-workspace-quality-gates.md
+++ b/docs/adr/0015-workspace-quality-gates.md
@@ -1,0 +1,78 @@
+# ADR-0015: Workspace-enforced quality gates
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+Authority and timing defects in this domain are safety-relevant: a panic in the
+session host is a dropped vehicle link, and a swallowed error in the authority engine
+is an ownership dispute. Conventions that live only in review culture decay; the
+repository must make its rules mechanical, and every fix must land together with the
+guardrail that prevents its regression.
+
+## Decision
+
+### Workspace lint policy (`[workspace.lints]`, inherited by every crate)
+
+- `unsafe_code = "forbid"`.
+- `clippy::unwrap_used`, `clippy::expect_used`, `clippy::panic` = deny. Tests may
+  `#[allow(clippy::expect_used, clippy::panic)]`.
+- `let_underscore_must_use` and `let_underscore_future` = deny; intentional discard
+  is written `.ok()`.
+- `clippy::await_holding_lock = "deny"`.
+- `clippy::disallowed_types` bans `anyhow::Error` in library crates;
+  `clippy::disallowed_macros` bans `println!`/`eprintln!` outside explicit CLI
+  output modules — diagnostics use `tracing`.
+
+### Error handling
+
+- Library crates use `thiserror` typed enums; `anyhow` appears only in binary
+  `main`. Error context is never discarded (`#[source]`/`#[from]`), each variant
+  carries what its message needs, and there is no `From<anyhow::Error>` back door
+  into typed errors.
+- No `process::exit()`; errors propagate to `main`.
+
+### Structure limits (enforced by a CI script, not convention)
+
+- ≤ 500 lines per `.rs` file; ≤ 80 lines per function; ≤ 30 fields per struct and
+  variants per enum; `lib.rs` ≤ 100 lines, re-exports and module declarations only,
+  opening with a crate-level `//!` doc comment.
+- No `mod.rs` (use `foo.rs` + `foo/`); no `utils.rs`/`helpers.rs`/`common.rs` —
+  modules are named by domain.
+
+### Idioms
+
+- Monotonic counters (IDs, generations, epochs) advance with `wrapping_add(1)`.
+- No module-level mutable state with I/O side effects; configuration flows through a
+  central config struct, not scattered `env::var` reads.
+- Blocking functions carry a `_blocking` suffix; possibly-stale reads carry
+  `_cached`.
+
+### CI pipeline (in order, all blocking)
+
+```text
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+cargo doc  (RUSTDOCFLAGS: -D missing_docs -D rustdoc::broken_intra_doc_links)
+cargo build --release
+structure-limits script
+buf lint && buf breaking   (once schemas/ is populated)
+```
+
+### Process
+
+- Every bug-fix PR lands its regression guardrail (test, lint, or CI script) in the
+  same PR.
+- Tests synchronize on events (`Notify`, channels, completion handles), never
+  sleep-and-retry; test servers bind `127.0.0.1:0`.
+
+## Consequences
+
+- The first workspace commit must carry the lint table and CI workflow — gates
+  precede the code they gate.
+- Some prototyping friction is accepted deliberately; spike code that needs `unwrap`
+  lives in tests or examples, not in library crates.
+- Structure limits force early module splits, which keeps the sans-IO core
+  reviewable as it grows.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,46 @@
+# Architecture Decision Records
+
+One file per decision, numbered in acceptance order. See
+[ADR-0001](0001-record-architecture-decisions.md) for the format and lifecycle rules.
+
+## Index
+
+| ADR | Decision | Status |
+|---|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions as versioned files in this repository | Accepted |
+| [0002](0002-cargo-workspace-portable-sans-io-core.md) | One Cargo workspace with a portable sans-IO core | Accepted |
+| [0003](0003-separate-responsibility-planes.md) | Separate identity, authority, real-time data, media, and host planes | Accepted |
+| [0004](0004-host-oriented-topology.md) | Host-oriented topology spanning hosted, peer-hosted, and real-vehicle sessions | Accepted |
+| [0005](0005-webtransport-primary-transport.md) | WebTransport as the primary real-time transport, including media | Accepted |
+| [0006](0006-capability-auth-scoped-leases-fencing.md) | Capability-based authorization with scoped leases and fencing generations | Accepted |
+| [0007](0007-canonical-input-model-device-profiles.md) | Canonical input model and versioned device-profile registry | Accepted |
+| [0008](0008-engine-independent-adapter-boundary.md) | Engine-independent adapter boundary; Gazebo first, reference adapter always | Accepted |
+| [0009](0009-time-model-and-latency-budget.md) | Explicit time model, end-to-end latency budget, stale-input rejection | Accepted |
+| [0010](0010-authority-state-machines.md) | Handover, override, and link loss as explicit state machines | Accepted |
+| [0011](0011-message-classes-and-channel-semantics.md) | Separate control, telemetry, authority-event, and bulk message classes | Accepted |
+| [0012](0012-structured-session-events.md) | Structured session events for observability, recording, and replay | Accepted |
+| [0013](0013-interactive-and-accelerated-sessions.md) | Single-vehicle operation and horizontally scalable accelerated training | Accepted |
+| [0014](0014-protobuf-wire-schema.md) | Protobuf as the wire-schema source of truth | Accepted |
+| [0015](0015-workspace-quality-gates.md) | Workspace-enforced quality gates | Accepted |
+
+## Provenance
+
+These records supersede the pre-repository draft *Pilotage Architecture Decision
+Records v0.3* (2026-07-05). Mapping from draft sections:
+
+| Draft v0.3 | Successor | Notable changes |
+|---|---|---|
+| ADR-001 planes | ADR-0003 | Planes clarified as contract boundaries, not process boundaries; v1 ships two deployables |
+| ADR-002 portable core | ADR-0002 | Core made explicitly sans-IO; crate list slimmed to a seed set that grows on demand |
+| ADR-003 topology | ADR-0004 | Unchanged in substance |
+| ADR-004 WebRTC | ADR-0005 | Replaced in redesign: WebTransport became Baseline across engines (Safari 26.4, 2026-03), so WebRTC is dropped from v1; media rides WebTransport + WebCodecs |
+| ADR-005 capabilities/leases | ADR-0006 | Open question resolved: authority engine is host-embedded in v1 |
+| ADR-006 input model | ADR-0007 | Unchanged in substance |
+| ADR-007 adapter boundary | ADR-0008 | Reference headless adapter promoted to a v1 conformance deliverable |
+| ADR-008 latency | ADR-0009 | Merged with the three-clock time model from draft ADR-012 |
+| ADR-009 handover | ADR-0010 | Open question resolved: transfer commits at ACCEPT; third call is confirmation, not a gate |
+| ADR-010 message classes | ADR-0011 | Unchanged in substance |
+| ADR-011 events | ADR-0012 | Backpressure and drop accounting made explicit |
+| ADR-012 training scale | ADR-0013 | Time model moved to ADR-0009 |
+| — | ADR-0014 | New decision: wire format and schema evolution |
+| — | ADR-0015 | New decision: repo-enforced lint, size, and CI gates |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,122 @@
+# Pilotage architecture overview
+
+Pilotage is a Rust-first, engine-independent platform for low-latency control,
+supervision, simulation, and training of maritime, aerial, and terrestrial vehicles.
+This document is the orientation map; the [ADRs](adr/README.md) are the authoritative
+decisions.
+
+## System shape (v1 hosted deployment)
+
+```text
+                 Passkey / WebAuthn
+                        |
+                        v
+              Identity & admission service ──> short-lived session capability
+                        |
+             session bootstrap (HTTPS)
+                        |
+   Browser client <═ WebTransport (QUIC) ═> Session host
+   (wasm core +        │                     ├─ authority engine (scoped leases, generations)
+    browser ports)     │                     ├─ Gazebo + renderer capture
+                       │                     ├─ vehicle adapter
+      video ◄──────────┤                     └─ telemetry / control / media endpoint
+      telemetry ◄──────┤
+      control ─────────►
+      authority events ◄──►
+```
+
+The same two deployables run a local demonstration over loopback or LAN with no
+special integration path. Peer-hosted simulators and real-vehicle gateways are future
+session hosts behind the same contracts; central services stay optional
+([ADR-0004](adr/0004-host-oriented-topology.md)).
+
+## The five planes
+
+| Plane | Owns | Decided in |
+|---|---|---|
+| Identity & admission | Passkeys, membership, session capabilities | [ADR-0003](adr/0003-separate-responsibility-planes.md), [ADR-0006](adr/0006-capability-auth-scoped-leases-fencing.md) |
+| Authority | Scoped leases, fencing generations, handover/override state machines | [ADR-0006](adr/0006-capability-auth-scoped-leases-fencing.md), [ADR-0010](adr/0010-authority-state-machines.md) |
+| Real-time data | Control frames, fast telemetry, authority events, bulk config | [ADR-0005](adr/0005-webtransport-primary-transport.md), [ADR-0011](adr/0011-message-classes-and-channel-semantics.md) |
+| Media | Capture, encode, delivery, adaptation, timing correlation | [ADR-0005](adr/0005-webtransport-primary-transport.md) |
+| Session host | Simulator/vehicle gateway, adapter, real-time endpoint | [ADR-0004](adr/0004-host-oriented-topology.md), [ADR-0008](adr/0008-engine-independent-adapter-boundary.md) |
+
+Planes are contract boundaries; v1 ships them as two deployables (identity/signaling
+service + session host).
+
+## Load-bearing principles
+
+1. **Sans-IO core** ([ADR-0002](adr/0002-cargo-workspace-portable-sans-io-core.md)):
+   all domain logic is pure state machines fed messages and explicit timestamps.
+   Browser, native, host, and tests drive the same code; deterministic replay is a
+   property, not a feature.
+2. **Fencing generations** ([ADR-0006](adr/0006-capability-auth-scoped-leases-fencing.md)):
+   authority changes advance a per-scope generation, and the host rejects frames
+   from any other generation — a displaced controller is fenced out even if its
+   connection stays up.
+3. **Engine independence** ([ADR-0008](adr/0008-engine-independent-adapter-boundary.md)):
+   Gazebo is adapter #1; the deterministic headless reference adapter ships in v1 and
+   anchors conformance.
+4. **Explicit time** ([ADR-0009](adr/0009-time-model-and-latency-budget.md)):
+   `transport_time`, `host_time`, and `simulation_time` are distinct; staleness is
+   rejected, queues are bounded, drops are counted.
+5. **Schema-first protocol** ([ADR-0014](adr/0014-protobuf-wire-schema.md)):
+   `schemas/` (protobuf) is the source of truth; hosts and clients evolve
+   independently under mechanical breaking-change detection.
+
+## Implementation increments
+
+| # | Deliverable | Acceptance signal |
+|---|---|---|
+| 0 | Workspace + quality gates + protocol skeleton + deterministic reference adapter + conformance harness | Client core and test host exchange fixture sessions; CI gates green |
+| 1 | Local Gazebo loop: session host, Gazebo adapter, one video source, one vehicle, browser gamepad input; media-over-WebTransport spike (WebCodecs decode, jitter buffer, encoder rate control) | Browser controls local Gazebo over loopback with measured per-stage timing |
+| 2 | Server-hosted demo: deployable host, HTTPS bootstrap, reachable QUIC endpoint | Remote browser receives video and controls Gazebo under defined network profiles |
+| 3 | Channel scopes: separate motion and camera leases, independent users | One user drives while another controls the camera; stale-scope frames rejected |
+| 4 | Normal handover: offer/accept commit + positive confirmations | No ambiguous holder under delayed, duplicated, or reordered events |
+| 5 | Override and failure: emergency override, revocation, link-loss policy | Previous generation ineffective immediately; configured failover executes |
+| 6 | Peer-host preparation: self-contained host package, registration, direct + relay paths | A non-platform-operated host creates a session without central simulator scheduling |
+| 7 | Recording and replay: structured authority/timing log, deterministic replay | A recorded session reproduces authority transitions and applied-control ordering |
+
+## Backlog
+
+### P0 — resolve before the corresponding increment freezes
+
+- Certificate strategy for local and peer-hosted hosts: locally provisioned dev
+  certificate vs `serverCertificateHashes` (Safari support unverified)
+  (increment 1).
+- Video bandwidth-adaptation and keyframe-recovery strategy validated under
+  impaired networks (increments 1–2). Browser floor is already set by ADR-0005:
+  WebTransport-capable browsers, i.e. Safari 26.4+/iOS 26.4+/iPadOS 26.4+,
+  Chrome 97+, Edge 98+, Firefox 114+.
+- p95/p99 closed-loop latency targets under specified network profiles (after
+  increment 2 measurements).
+- Expected simultaneous operators and spectators per host (increment 3).
+- Emergency-override authority-class matrix and takeover-veto policy (increment 5).
+- Host registration and trust model; threat model for malicious hosts, clients, and
+  compromised tokens (increment 6).
+- Recording retention and privacy policy (increment 7).
+
+### P1 — design now, implement after the core path is stable
+
+WebTransport for control/telemetry; multiple camera sources and picture-in-picture;
+spectator stream fan-out (host- or relay-side replication); instructor and supervisory modes; organization
+policy and temporary guests; automation-assisted blended control; signed online
+device-registry updates; repeatable network-impairment benchmark harness; peer-host
+update and attestation.
+
+### P2 — preserve compatibility, defer implementation
+
+Haptics; VR and head tracking; vendor-specific joystick extensions; spatial audio;
+advanced SVC and spectator quality tiers; tournament/adjudication tooling.
+
+## Validation matrix
+
+| Area | Required validation |
+|---|---|
+| Client input | Device enumeration, hot-plug, calibration, focus loss, background throttling, multiple devices |
+| Authority | Per-scope isolation, stale-generation rejection, handover races, override races, duplicate acknowledgement |
+| Network | Delay, jitter, loss, reordering, NAT, QUIC relay, UDP-blocked fallback, connection migration, loopback |
+| Media | Capture latency, encoder queueing, bitrate collapse, keyframe recovery, decode and presentation |
+| Simulator | Tick delay, renderer slowdown, adapter restart, vehicle respawn, dynamic camera addition |
+| Host lifecycle | Registration, update, reconnect, crash recovery, peer-host trust and revocation |
+| Link loss | Per-vehicle configuration, default inheritance, stale-input hold limit, neutralization or automation transition |
+| Observability | Correlation from client sample through simulator application to resulting telemetry/video |

--- a/hosts/README.md
+++ b/hosts/README.md
@@ -1,0 +1,12 @@
+# hosts/ — session-host binaries
+
+The session host is the unit of deployment
+([ADR-0004](../docs/adr/0004-host-oriented-topology.md)): it runs one or more
+adapters, the embedded authority engine, and the session-local real-time
+telemetry/control/media endpoint. The same binary serves server-hosted production,
+loopback/LAN demos, and (later) peer-hosted operation.
+
+Planned contents:
+
+- `session-host/` — the main host binary: WebTransport (QUIC) endpoint, authority
+  engine, adapter lifecycle, capability publication, structured event emission.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,15 @@
+# schemas/ — wire-schema source of truth
+
+Protobuf definitions for every cross-boundary message
+([ADR-0014](../docs/adr/0014-protobuf-wire-schema.md)): protocol envelopes, control
+frames, telemetry, authority events, host capabilities, device profiles, and the
+recorded-event format.
+
+Rules:
+
+- This directory is the single source of truth; Rust code is generated at build time
+  (`prost`) and never committed or hand-edited.
+- Field numbers are never reused; unknown fields are tolerated; enums carry an
+  `UNSPECIFIED = 0` sentinel.
+- Schema changes are API changes: reviewed as such, and gated by `buf lint` and
+  `buf breaking` in CI once populated.

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,15 @@
+# services/ — optional central services
+
+Central services support sessions but must never be required for the real-time data
+path or for session existence
+([ADR-0003](../docs/adr/0003-separate-responsibility-planes.md),
+[ADR-0004](../docs/adr/0004-host-oriented-topology.md)).
+
+Planned contents:
+
+- `identity-admission/` — passkey/WebAuthn authentication, membership, session
+  capabilities, signaling/rendezvous for v1.
+
+Fleet orchestration, organizational policy services, and QUIC-relay provisioning join
+later as separate deployables; none of them enter the session data-plane correctness
+boundary.


### PR DESCRIPTION
Redesigned architecture from the v0.3 ADR draft, recorded as 15 per-decision ADRs plus overview, directory skeleton with intent READMEs, and .gitignore.

Headline decisions:
- Portable core is sans-IO (pure state machines; no runtime/clock/socket deps)
- WebTransport (QUIC) is the primary transport including media via WebCodecs — now Baseline across engines incl. Safari 26.4 on macOS/iOS/iPadOS; WebRTC dropped from v1
- Authority engine host-embedded; scoped leases + fencing generations; handover commits atomically at ACCEPT
- Protobuf schemas as protocol source of truth with mechanical breaking-change gates
- Workspace quality gates (lints, size limits, CI order) recorded as ADR-0015

🤖 Generated with [Claude Code](https://claude.com/claude-code)