### PR TITLE
Increment 1a: WebTransport loopback session over the reference adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -29,7 +74,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -39,10 +84,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -67,6 +136,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,7 +259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,6 +293,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,8 +357,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -185,7 +408,125 @@ dependencies = [
  "cfg-if",
  "libc",
  "pkg-config",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "httlib-huffman"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -214,6 +555,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,10 +590,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "loopback-probe"
+version = "0.1.0"
+dependencies = [
+ "hidapi",
+ "pilotage-input",
+ "pilotage-protocol",
+ "pilotage-timing",
+ "prost",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wtransport",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -244,10 +641,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -259,10 +717,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "octets"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8311fa8ab7a57759b4ff1f851a3048d9ef0effaa0130726426b742d26d8a88e7"
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -344,14 +839,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-session"
+version = "0.1.0"
+dependencies = [
+ "pilotage-adapter-api",
+ "pilotage-authority",
+ "pilotage-protocol",
+ "pilotage-timing",
+]
+
+[[package]]
+name = "pilotage-session-host"
+version = "0.1.0"
+dependencies = [
+ "pilotage-adapter-api",
+ "pilotage-adapter-reference",
+ "pilotage-authority",
+ "pilotage-protocol",
+ "pilotage-session",
+ "pilotage-timing",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wtransport",
+]
+
+[[package]]
 name = "pilotage-timing"
 version = "0.1.0"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -388,10 +932,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -458,6 +1002,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,7 +1085,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -495,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -508,12 +1119,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -546,6 +1185,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,8 +1223,61 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -568,6 +1289,38 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -614,10 +1367,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -631,6 +1448,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +1468,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -664,6 +1492,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +1662,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +1699,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -694,10 +1716,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -709,10 +1795,167 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wtransport"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4aacf790813ee1956751491800537f4e04af7557b7b370501ccbfbc85963e4"
+dependencies = [
+ "bytes",
+ "pem",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "sha2",
+ "socket2",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "wtransport-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "wtransport-proto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5867c629e4252f7439d82315923daaf27f4fa442410d51b78ab93ef4c432a11"
+dependencies = [
+ "httlib-huffman",
+ "octets",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -728,6 +1971,66 @@ name = "zerocopy-derive"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,15 @@ resolver = "3"
 members = [
     "crates/pilotage-protocol",
     "crates/pilotage-authority",
+    "crates/pilotage-session",
     "crates/pilotage-input",
     "crates/pilotage-timing",
     "crates/pilotage-adapter-api",
     "crates/pilotage-conformance",
     "adapters/reference-headless",
     "tools/hid-probe",
+    "tools/loopback-probe",
+    "hosts/session-host",
 ]
 
 [workspace.package]
@@ -23,12 +26,17 @@ prost-build = "0.14.4"
 libm = "0.2.16"
 hidapi = "2.6.6"
 proptest = "1.11.0"
+tokio = "1.48.0"
+wtransport = "0.7.1"
+tracing = "0.1.44"
+tracing-subscriber = "0.3.23"
 pilotage-timing = { path = "crates/pilotage-timing" }
 pilotage-protocol = { path = "crates/pilotage-protocol" }
 pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-adapter-reference = { path = "adapters/reference-headless" }
+pilotage-session = { path = "crates/pilotage-session" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/pilotage-protocol/build.rs
+++ b/crates/pilotage-protocol/build.rs
@@ -27,6 +27,7 @@ fn main() -> ExitCode {
         "authority.proto",
         "telemetry.proto",
         "capability.proto",
+        "session.proto",
         "envelope.proto",
     ]
     .map(|name| schemas_dir.join(name));

--- a/crates/pilotage-protocol/src/lib.rs
+++ b/crates/pilotage-protocol/src/lib.rs
@@ -7,6 +7,8 @@
 mod control;
 mod convert;
 mod ids;
+mod session;
+mod session_convert;
 pub mod wire;
 
 pub use control::{ButtonEdge, ControlPayload, LogicalAxisId, LogicalButtonId, ScopedControlFrame};
@@ -16,3 +18,7 @@ pub use convert::{
     encode_envelope_length_delimited,
 };
 pub use ids::{Generation, PrincipalId, ScopeId, SequenceNum, SessionId, VehicleId};
+pub use session::{
+    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRequest,
+    LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
+};

--- a/crates/pilotage-protocol/src/session.rs
+++ b/crates/pilotage-protocol/src/session.rs
@@ -1,0 +1,151 @@
+//! Session-bootstrap domain vocabulary: handshake, scope-lease
+//! request/response, RTT probing, and frame-rejection notices (ADR-0005,
+//! ADR-0006, ADR-0009, ADR-0010).
+
+use pilotage_timing::MonoTimestamp;
+
+use crate::ids::{Generation, PrincipalId, ScopeId, SequenceNum, VehicleId};
+use crate::wire;
+
+/// The first message a client sends after the WebTransport session is
+/// established (ADR-0005).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClientHello {
+    /// Highest `pilotage.v1` schema version the client can interpret.
+    pub protocol_version: u32,
+    /// Human-readable client identification, for diagnostics only.
+    pub client_name: String,
+    /// Opaque join token proving prior admission; interpreted only by the
+    /// issuing admission service, never by this crate.
+    pub join_token: Vec<u8>,
+}
+
+/// A single (vehicle, scope) pair's current holder and fencing generation,
+/// as reported in a `ServerWelcome` (ADR-0006, ADR-0010).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScopeHolderSnapshot {
+    /// Vehicle the scope belongs to.
+    pub vehicle: VehicleId,
+    /// Control scope this snapshot describes.
+    pub scope: ScopeId,
+    /// Current holder, absent when the scope is unassigned.
+    pub holder: Option<PrincipalId>,
+    /// Fencing generation currently in force for `scope`.
+    pub generation: Generation,
+}
+
+/// The host's reply to `ClientHello`, establishing session identity and
+/// publishing the state the client needs to render an initial UI.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerWelcome {
+    /// Session identity assigned to this connection.
+    pub session: crate::ids::SessionId,
+    /// Principal identity assigned to this connection.
+    pub principal: PrincipalId,
+    /// The host's advertised capabilities (vehicles, scopes, modes).
+    pub host_capabilities: wire::HostCapabilities,
+    /// Current holder and generation for every (vehicle, scope) pair the
+    /// host tracks.
+    pub scope_holders: Vec<ScopeHolderSnapshot>,
+}
+
+/// A client's request to lease a control scope for a vehicle (ADR-0006).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseRequest {
+    /// Vehicle the lease applies to.
+    pub vehicle: VehicleId,
+    /// Control scope being requested.
+    pub scope: ScopeId,
+}
+
+/// Why a `LeaseRequest` was denied (ADR-0006, ADR-0010).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeaseDenialReason {
+    /// Another principal currently holds the scope and did not offer it.
+    AlreadyHeld,
+    /// The (vehicle, scope) pair is not published by the host's
+    /// capabilities.
+    UnknownScope,
+    /// The requesting principal lacks the authority class required for
+    /// this scope.
+    NotAuthorized,
+}
+
+/// The host's reply to a `LeaseRequest`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseResponse {
+    /// Vehicle the response concerns.
+    pub vehicle: VehicleId,
+    /// Control scope the response concerns.
+    pub scope: ScopeId,
+    /// Whether the lease was granted.
+    pub granted: bool,
+    /// New generation on grant; current (unchanged) generation on denial.
+    pub generation: Generation,
+    /// Meaningful only when `granted` is `false`.
+    pub reason: Option<LeaseDenialReason>,
+}
+
+/// An RTT/offset probe carrying the sender's local transport-time sample.
+///
+/// `sender_sent_at` is a `transport_time` sample local to the sender
+/// (ADR-0009) and MUST NOT be compared directly against a timestamp from a
+/// different endpoint. It is only meaningful as input to
+/// [`pilotage_timing`]'s RTT/offset estimator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ping {
+    /// Correlates this `Ping` with its `Pong`; carries no ordering or
+    /// uniqueness guarantee beyond what the sender chooses.
+    pub nonce: u64,
+    /// Sender-local transport-time sample at send.
+    pub sender_sent_at: MonoTimestamp,
+}
+
+/// The reply to a [`Ping`], echoing its nonce and sender timestamp and
+/// adding the responder's own local transport-time sample.
+///
+/// As with `Ping`, `responder_sent_at` is local to the responder and must
+/// never be compared raw against `echoed_sender_sent_at`; both feed
+/// [`pilotage_timing`]'s estimator, never a direct subtraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pong {
+    /// Echoes the originating `Ping`'s nonce.
+    pub nonce: u64,
+    /// Echoes the originating `Ping`'s sender-local timestamp verbatim.
+    pub echoed_sender_sent_at: MonoTimestamp,
+    /// Responder-local transport-time sample at reply.
+    pub responder_sent_at: MonoTimestamp,
+}
+
+/// Why the host rejected an inbound control frame without applying it
+/// (ADR-0009 rejection rules).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameRejectionReason {
+    /// The frame's generation is older than the scope's current
+    /// generation.
+    StaleGeneration,
+    /// The scope has no current holder.
+    NoHolder,
+    /// The (vehicle, scope) pair is not published by the host's
+    /// capabilities.
+    UnknownScope,
+    /// The frame's sampled-at timestamp is older than the configured
+    /// maximum control age.
+    TooOld,
+}
+
+/// Sent back to a control frame's sender (never broadcast) when the frame
+/// is well-formed but not honored (ADR-0009, ADR-0012).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameRejected {
+    /// Vehicle the rejected frame targeted.
+    pub vehicle: VehicleId,
+    /// Control scope the rejected frame targeted.
+    pub scope: ScopeId,
+    /// Sequence number of the rejected frame.
+    pub sequence: SequenceNum,
+    /// Why the frame was rejected.
+    pub reason: FrameRejectionReason,
+    /// The scope's fencing generation at the time of rejection.
+    pub current_generation: Generation,
+}

--- a/crates/pilotage-protocol/src/session_convert.rs
+++ b/crates/pilotage-protocol/src/session_convert.rs
@@ -1,0 +1,369 @@
+//! Conversions between session-bootstrap domain types (`session.rs`) and
+//! generated wire types (`wire.rs`), mirroring `convert.rs`'s pattern
+//! (ADR-0005, ADR-0014).
+
+use crate::convert::ConvertError;
+use crate::ids::{Generation, PrincipalId, ScopeId, SequenceNum, SessionId, VehicleId};
+use crate::session::{
+    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRequest,
+    LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
+};
+use crate::wire;
+use pilotage_timing::MonoTimestamp;
+
+impl From<&ClientHello> for wire::ClientHello {
+    fn from(hello: &ClientHello) -> Self {
+        wire::ClientHello {
+            protocol_version: hello.protocol_version,
+            client_name: hello.client_name.clone(),
+            join_token: hello.join_token.clone(),
+        }
+    }
+}
+
+impl From<wire::ClientHello> for ClientHello {
+    fn from(hello: wire::ClientHello) -> Self {
+        ClientHello {
+            protocol_version: hello.protocol_version,
+            client_name: hello.client_name,
+            join_token: hello.join_token,
+        }
+    }
+}
+
+impl From<&ScopeHolderSnapshot> for wire::ScopeHolderSnapshot {
+    fn from(snapshot: &ScopeHolderSnapshot) -> Self {
+        wire::ScopeHolderSnapshot {
+            vehicle: Some(wire::VehicleId {
+                value: snapshot.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: snapshot.scope.as_str().to_owned(),
+            }),
+            holder: snapshot.holder.map(|principal| wire::PrincipalId {
+                value: principal.as_u64(),
+            }),
+            generation: Some(wire::Generation {
+                value: snapshot.generation.as_u64(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::ScopeHolderSnapshot> for ScopeHolderSnapshot {
+    type Error = ConvertError;
+
+    fn try_from(snapshot: wire::ScopeHolderSnapshot) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.ScopeHolderSnapshot",
+            field,
+        };
+        let vehicle = snapshot.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = snapshot.scope.ok_or_else(|| missing("scope"))?;
+        let generation = snapshot.generation.ok_or_else(|| missing("generation"))?;
+        Ok(ScopeHolderSnapshot {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+            holder: snapshot.holder.map(|holder| PrincipalId::new(holder.value)),
+            generation: Generation::new(generation.value),
+        })
+    }
+}
+
+impl From<&ServerWelcome> for wire::ServerWelcome {
+    fn from(welcome: &ServerWelcome) -> Self {
+        wire::ServerWelcome {
+            session: Some(wire::SessionId {
+                value: welcome.session.as_u64(),
+            }),
+            principal: Some(wire::PrincipalId {
+                value: welcome.principal.as_u64(),
+            }),
+            host_capabilities: Some(welcome.host_capabilities.clone()),
+            scope_holders: welcome.scope_holders.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl TryFrom<wire::ServerWelcome> for ServerWelcome {
+    type Error = ConvertError;
+
+    fn try_from(welcome: wire::ServerWelcome) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.ServerWelcome",
+            field,
+        };
+        let session = welcome.session.ok_or_else(|| missing("session"))?;
+        let principal = welcome.principal.ok_or_else(|| missing("principal"))?;
+        let host_capabilities = welcome
+            .host_capabilities
+            .ok_or_else(|| missing("host_capabilities"))?;
+        let scope_holders = welcome
+            .scope_holders
+            .into_iter()
+            .map(ScopeHolderSnapshot::try_from)
+            .collect::<Result<_, ConvertError>>()?;
+        Ok(ServerWelcome {
+            session: SessionId::new(session.value),
+            principal: PrincipalId::new(principal.value),
+            host_capabilities,
+            scope_holders,
+        })
+    }
+}
+
+impl From<&LeaseRequest> for wire::LeaseRequest {
+    fn from(request: &LeaseRequest) -> Self {
+        wire::LeaseRequest {
+            vehicle: Some(wire::VehicleId {
+                value: request.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: request.scope.as_str().to_owned(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::LeaseRequest> for LeaseRequest {
+    type Error = ConvertError;
+
+    fn try_from(request: wire::LeaseRequest) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.LeaseRequest",
+            field,
+        };
+        let vehicle = request.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = request.scope.ok_or_else(|| missing("scope"))?;
+        Ok(LeaseRequest {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+        })
+    }
+}
+
+impl From<LeaseDenialReason> for wire::LeaseDenialReason {
+    fn from(reason: LeaseDenialReason) -> Self {
+        match reason {
+            LeaseDenialReason::AlreadyHeld => wire::LeaseDenialReason::AlreadyHeld,
+            LeaseDenialReason::UnknownScope => wire::LeaseDenialReason::UnknownScope,
+            LeaseDenialReason::NotAuthorized => wire::LeaseDenialReason::NotAuthorized,
+        }
+    }
+}
+
+impl TryFrom<wire::LeaseDenialReason> for LeaseDenialReason {
+    type Error = ConvertError;
+
+    fn try_from(reason: wire::LeaseDenialReason) -> Result<Self, Self::Error> {
+        match reason {
+            wire::LeaseDenialReason::AlreadyHeld => Ok(LeaseDenialReason::AlreadyHeld),
+            wire::LeaseDenialReason::UnknownScope => Ok(LeaseDenialReason::UnknownScope),
+            wire::LeaseDenialReason::NotAuthorized => Ok(LeaseDenialReason::NotAuthorized),
+            wire::LeaseDenialReason::Unspecified => Err(ConvertError::UnknownEnum {
+                enum_name: "pilotage.v1.LeaseDenialReason",
+                value: reason as i32,
+            }),
+        }
+    }
+}
+
+impl From<&LeaseResponse> for wire::LeaseResponse {
+    fn from(response: &LeaseResponse) -> Self {
+        wire::LeaseResponse {
+            vehicle: Some(wire::VehicleId {
+                value: response.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: response.scope.as_str().to_owned(),
+            }),
+            granted: response.granted,
+            generation: Some(wire::Generation {
+                value: response.generation.as_u64(),
+            }),
+            reason: response.reason.map_or(
+                wire::LeaseDenialReason::Unspecified,
+                wire::LeaseDenialReason::from,
+            ) as i32,
+        }
+    }
+}
+
+impl TryFrom<wire::LeaseResponse> for LeaseResponse {
+    type Error = ConvertError;
+
+    fn try_from(response: wire::LeaseResponse) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.LeaseResponse",
+            field,
+        };
+        let vehicle = response.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = response.scope.ok_or_else(|| missing("scope"))?;
+        let generation = response.generation.ok_or_else(|| missing("generation"))?;
+        let raw_reason = wire::LeaseDenialReason::try_from(response.reason).map_err(|_| {
+            ConvertError::UnknownEnum {
+                enum_name: "pilotage.v1.LeaseDenialReason",
+                value: response.reason,
+            }
+        })?;
+        // Denial reason is only meaningful when the lease was refused; a
+        // grant response is not required to carry a concrete reason.
+        let reason = if response.granted {
+            None
+        } else {
+            Some(LeaseDenialReason::try_from(raw_reason)?)
+        };
+        Ok(LeaseResponse {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+            granted: response.granted,
+            generation: Generation::new(generation.value),
+            reason,
+        })
+    }
+}
+
+impl From<&Ping> for wire::Ping {
+    fn from(ping: &Ping) -> Self {
+        wire::Ping {
+            nonce: ping.nonce,
+            sender_sent_at: Some(wire::MonoTimestamp {
+                nanos: ping.sender_sent_at.as_nanos(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::Ping> for Ping {
+    type Error = ConvertError;
+
+    fn try_from(ping: wire::Ping) -> Result<Self, Self::Error> {
+        let sender_sent_at = ping.sender_sent_at.ok_or(ConvertError::MissingField {
+            message: "pilotage.v1.Ping",
+            field: "sender_sent_at",
+        })?;
+        Ok(Ping {
+            nonce: ping.nonce,
+            sender_sent_at: MonoTimestamp::from_nanos(sender_sent_at.nanos),
+        })
+    }
+}
+
+impl From<&Pong> for wire::Pong {
+    fn from(pong: &Pong) -> Self {
+        wire::Pong {
+            nonce: pong.nonce,
+            echoed_sender_sent_at: Some(wire::MonoTimestamp {
+                nanos: pong.echoed_sender_sent_at.as_nanos(),
+            }),
+            responder_sent_at: Some(wire::MonoTimestamp {
+                nanos: pong.responder_sent_at.as_nanos(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::Pong> for Pong {
+    type Error = ConvertError;
+
+    fn try_from(pong: wire::Pong) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.Pong",
+            field,
+        };
+        let echoed_sender_sent_at = pong
+            .echoed_sender_sent_at
+            .ok_or_else(|| missing("echoed_sender_sent_at"))?;
+        let responder_sent_at = pong
+            .responder_sent_at
+            .ok_or_else(|| missing("responder_sent_at"))?;
+        Ok(Pong {
+            nonce: pong.nonce,
+            echoed_sender_sent_at: MonoTimestamp::from_nanos(echoed_sender_sent_at.nanos),
+            responder_sent_at: MonoTimestamp::from_nanos(responder_sent_at.nanos),
+        })
+    }
+}
+
+impl From<FrameRejectionReason> for wire::FrameRejectionReason {
+    fn from(reason: FrameRejectionReason) -> Self {
+        match reason {
+            FrameRejectionReason::StaleGeneration => wire::FrameRejectionReason::StaleGeneration,
+            FrameRejectionReason::NoHolder => wire::FrameRejectionReason::NoHolder,
+            FrameRejectionReason::UnknownScope => wire::FrameRejectionReason::UnknownScope,
+            FrameRejectionReason::TooOld => wire::FrameRejectionReason::TooOld,
+        }
+    }
+}
+
+impl TryFrom<wire::FrameRejectionReason> for FrameRejectionReason {
+    type Error = ConvertError;
+
+    fn try_from(reason: wire::FrameRejectionReason) -> Result<Self, Self::Error> {
+        match reason {
+            wire::FrameRejectionReason::StaleGeneration => {
+                Ok(FrameRejectionReason::StaleGeneration)
+            }
+            wire::FrameRejectionReason::NoHolder => Ok(FrameRejectionReason::NoHolder),
+            wire::FrameRejectionReason::UnknownScope => Ok(FrameRejectionReason::UnknownScope),
+            wire::FrameRejectionReason::TooOld => Ok(FrameRejectionReason::TooOld),
+            wire::FrameRejectionReason::Unspecified => Err(ConvertError::UnknownEnum {
+                enum_name: "pilotage.v1.FrameRejectionReason",
+                value: reason as i32,
+            }),
+        }
+    }
+}
+
+impl From<&FrameRejected> for wire::FrameRejected {
+    fn from(rejected: &FrameRejected) -> Self {
+        wire::FrameRejected {
+            vehicle: Some(wire::VehicleId {
+                value: rejected.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: rejected.scope.as_str().to_owned(),
+            }),
+            sequence: Some(wire::SequenceNum {
+                value: rejected.sequence.as_u32(),
+            }),
+            reason: wire::FrameRejectionReason::from(rejected.reason) as i32,
+            current_generation: Some(wire::Generation {
+                value: rejected.current_generation.as_u64(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::FrameRejected> for FrameRejected {
+    type Error = ConvertError;
+
+    fn try_from(rejected: wire::FrameRejected) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.FrameRejected",
+            field,
+        };
+        let vehicle = rejected.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = rejected.scope.ok_or_else(|| missing("scope"))?;
+        let sequence = rejected.sequence.ok_or_else(|| missing("sequence"))?;
+        let current_generation = rejected
+            .current_generation
+            .ok_or_else(|| missing("current_generation"))?;
+        let raw_reason = wire::FrameRejectionReason::try_from(rejected.reason).map_err(|_| {
+            ConvertError::UnknownEnum {
+                enum_name: "pilotage.v1.FrameRejectionReason",
+                value: rejected.reason,
+            }
+        })?;
+        Ok(FrameRejected {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+            sequence: SequenceNum::new(sequence.value),
+            reason: FrameRejectionReason::try_from(raw_reason)?,
+            current_generation: Generation::new(current_generation.value),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-protocol/src/session_convert/tests.rs
+++ b/crates/pilotage-protocol/src/session_convert/tests.rs
@@ -1,0 +1,402 @@
+//! Unit tests for session-bootstrap domain<->wire conversions
+//! (`session_convert.rs`).
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::convert::{ConvertError, SCHEMA_VERSION};
+use crate::ids::{Generation, PrincipalId, ScopeId, SequenceNum, SessionId, VehicleId};
+use crate::wire;
+use pilotage_timing::MonoTimestamp;
+use prost::Message;
+
+#[test]
+fn client_hello_roundtrips() {
+    let hello = ClientHello {
+        protocol_version: 1,
+        client_name: "browser-client/0.1".to_owned(),
+        join_token: vec![1, 2, 3, 4],
+    };
+    let wire_hello: wire::ClientHello = (&hello).into();
+    let back = ClientHello::from(wire_hello);
+    assert_eq!(back, hello);
+}
+
+#[test]
+fn client_hello_roundtrips_with_empty_token() {
+    let hello = ClientHello {
+        protocol_version: 1,
+        client_name: String::new(),
+        join_token: Vec::new(),
+    };
+    let wire_hello: wire::ClientHello = (&hello).into();
+    let back = ClientHello::from(wire_hello);
+    assert_eq!(back, hello);
+}
+
+fn sample_snapshot(holder: Option<u64>) -> ScopeHolderSnapshot {
+    ScopeHolderSnapshot {
+        vehicle: VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+        holder: holder.map(PrincipalId::new),
+        generation: Generation::new(2),
+    }
+}
+
+#[test]
+fn scope_holder_snapshot_roundtrips_with_holder() {
+    let snapshot = sample_snapshot(Some(9));
+    let wire_snapshot: wire::ScopeHolderSnapshot = (&snapshot).into();
+    let back = ScopeHolderSnapshot::try_from(wire_snapshot).expect("valid conversion");
+    assert_eq!(back, snapshot);
+}
+
+#[test]
+fn scope_holder_snapshot_roundtrips_without_holder() {
+    let snapshot = sample_snapshot(None);
+    let wire_snapshot: wire::ScopeHolderSnapshot = (&snapshot).into();
+    let back = ScopeHolderSnapshot::try_from(wire_snapshot).expect("valid conversion");
+    assert_eq!(back, snapshot);
+}
+
+#[test]
+fn scope_holder_snapshot_conversion_fails_on_missing_scope() {
+    let mut wire_snapshot: wire::ScopeHolderSnapshot = (&sample_snapshot(None)).into();
+    wire_snapshot.scope = None;
+    let result = ScopeHolderSnapshot::try_from(wire_snapshot);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField { field: "scope", .. })
+    ));
+}
+
+fn sample_welcome() -> ServerWelcome {
+    ServerWelcome {
+        session: SessionId::new(1),
+        principal: PrincipalId::new(2),
+        host_capabilities: wire::HostCapabilities {
+            host_version: "0.1.0".to_owned(),
+            vehicles: vec![],
+            supported_modes: vec![],
+        },
+        scope_holders: vec![sample_snapshot(Some(9)), sample_snapshot(None)],
+    }
+}
+
+#[test]
+fn server_welcome_roundtrips() {
+    let welcome = sample_welcome();
+    let wire_welcome: wire::ServerWelcome = (&welcome).into();
+    let back = ServerWelcome::try_from(wire_welcome).expect("valid conversion");
+    assert_eq!(back, welcome);
+}
+
+#[test]
+fn server_welcome_conversion_fails_on_missing_session() {
+    let mut wire_welcome: wire::ServerWelcome = (&sample_welcome()).into();
+    wire_welcome.session = None;
+    let result = ServerWelcome::try_from(wire_welcome);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField {
+            field: "session",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn lease_request_roundtrips() {
+    let request = LeaseRequest {
+        vehicle: VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+    };
+    let wire_request: wire::LeaseRequest = (&request).into();
+    let back = LeaseRequest::try_from(wire_request).expect("valid conversion");
+    assert_eq!(back, request);
+}
+
+#[test]
+fn lease_request_conversion_fails_on_missing_vehicle() {
+    let mut wire_request: wire::LeaseRequest = (&LeaseRequest {
+        vehicle: VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+    })
+        .into();
+    wire_request.vehicle = None;
+    let result = LeaseRequest::try_from(wire_request);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField {
+            field: "vehicle",
+            ..
+        })
+    ));
+}
+
+fn sample_lease_response(granted: bool, reason: Option<LeaseDenialReason>) -> LeaseResponse {
+    LeaseResponse {
+        vehicle: VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+        granted,
+        generation: Generation::new(3),
+        reason,
+    }
+}
+
+#[test]
+fn lease_response_roundtrips_on_grant() {
+    let response = sample_lease_response(true, None);
+    let wire_response: wire::LeaseResponse = (&response).into();
+    let back = LeaseResponse::try_from(wire_response).expect("valid conversion");
+    assert_eq!(back, response);
+}
+
+#[test]
+fn lease_response_roundtrips_on_denial() {
+    let response = sample_lease_response(false, Some(LeaseDenialReason::AlreadyHeld));
+    let wire_response: wire::LeaseResponse = (&response).into();
+    let back = LeaseResponse::try_from(wire_response).expect("valid conversion");
+    assert_eq!(back, response);
+}
+
+#[test]
+fn lease_response_conversion_fails_on_unspecified_denial_reason() {
+    let mut wire_response: wire::LeaseResponse = (&sample_lease_response(false, None)).into();
+    wire_response.reason = wire::LeaseDenialReason::Unspecified as i32;
+    let result = LeaseResponse::try_from(wire_response);
+    assert!(matches!(result, Err(ConvertError::UnknownEnum { .. })));
+}
+
+#[test]
+fn lease_response_grant_ignores_reason_field() {
+    // A grant is not required to carry a concrete denial reason; even an
+    // Unspecified reason on the wire must not fail conversion when granted.
+    let mut wire_response: wire::LeaseResponse = (&sample_lease_response(true, None)).into();
+    wire_response.reason = wire::LeaseDenialReason::Unspecified as i32;
+    let back = LeaseResponse::try_from(wire_response).expect("valid conversion");
+    assert_eq!(back.reason, None);
+}
+
+#[test]
+fn ping_roundtrips() {
+    let ping = Ping {
+        nonce: 42,
+        sender_sent_at: MonoTimestamp::from_nanos(100),
+    };
+    let wire_ping: wire::Ping = (&ping).into();
+    let back = Ping::try_from(wire_ping).expect("valid conversion");
+    assert_eq!(back, ping);
+}
+
+#[test]
+fn ping_conversion_fails_on_missing_timestamp() {
+    let mut wire_ping: wire::Ping = (&Ping {
+        nonce: 1,
+        sender_sent_at: MonoTimestamp::from_nanos(1),
+    })
+        .into();
+    wire_ping.sender_sent_at = None;
+    let result = Ping::try_from(wire_ping);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField {
+            field: "sender_sent_at",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn pong_roundtrips() {
+    let pong = Pong {
+        nonce: 42,
+        echoed_sender_sent_at: MonoTimestamp::from_nanos(100),
+        responder_sent_at: MonoTimestamp::from_nanos(150),
+    };
+    let wire_pong: wire::Pong = (&pong).into();
+    let back = Pong::try_from(wire_pong).expect("valid conversion");
+    assert_eq!(back, pong);
+}
+
+#[test]
+fn pong_conversion_fails_on_missing_responder_timestamp() {
+    let mut wire_pong: wire::Pong = (&Pong {
+        nonce: 1,
+        echoed_sender_sent_at: MonoTimestamp::from_nanos(1),
+        responder_sent_at: MonoTimestamp::from_nanos(2),
+    })
+        .into();
+    wire_pong.responder_sent_at = None;
+    let result = Pong::try_from(wire_pong);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField {
+            field: "responder_sent_at",
+            ..
+        })
+    ));
+}
+
+fn sample_frame_rejected() -> FrameRejected {
+    FrameRejected {
+        vehicle: VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+        sequence: SequenceNum::new(7),
+        reason: FrameRejectionReason::StaleGeneration,
+        current_generation: Generation::new(5),
+    }
+}
+
+#[test]
+fn frame_rejected_roundtrips() {
+    let rejected = sample_frame_rejected();
+    let wire_rejected: wire::FrameRejected = (&rejected).into();
+    let back = FrameRejected::try_from(wire_rejected).expect("valid conversion");
+    assert_eq!(back, rejected);
+}
+
+#[test]
+fn frame_rejected_conversion_fails_on_unspecified_reason() {
+    let mut wire_rejected: wire::FrameRejected = (&sample_frame_rejected()).into();
+    wire_rejected.reason = wire::FrameRejectionReason::Unspecified as i32;
+    let result = FrameRejected::try_from(wire_rejected);
+    assert!(matches!(result, Err(ConvertError::UnknownEnum { .. })));
+}
+
+#[test]
+fn frame_rejected_conversion_fails_on_missing_scope() {
+    let mut wire_rejected: wire::FrameRejected = (&sample_frame_rejected()).into();
+    wire_rejected.scope = None;
+    let result = FrameRejected::try_from(wire_rejected);
+    assert!(matches!(
+        result,
+        Err(ConvertError::MissingField { field: "scope", .. })
+    ));
+}
+
+#[test]
+fn envelope_roundtrips_for_client_hello_arm() {
+    let hello = wire::ClientHello {
+        protocol_version: 1,
+        client_name: "browser-client/0.1".to_owned(),
+        join_token: vec![9, 9],
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::ClientHello(hello.clone())),
+    };
+    let bytes = envelope.encode_to_vec();
+    let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");
+    assert_eq!(
+        decoded.payload,
+        Some(wire::envelope::Payload::ClientHello(hello))
+    );
+}
+
+#[test]
+fn envelope_roundtrips_for_lease_request_arm() {
+    let request = wire::LeaseRequest {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        scope: Some(wire::ScopeId {
+            value: "vehicle.motion".to_owned(),
+        }),
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::LeaseRequest(request.clone())),
+    };
+    let bytes = envelope.encode_to_vec();
+    let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");
+    assert_eq!(
+        decoded.payload,
+        Some(wire::envelope::Payload::LeaseRequest(request))
+    );
+}
+
+#[test]
+fn envelope_roundtrips_for_ping_and_pong_arms() {
+    let ping = wire::Ping {
+        nonce: 1,
+        sender_sent_at: Some(wire::MonoTimestamp { nanos: 10 }),
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::Ping(ping)),
+    };
+    let bytes = envelope.encode_to_vec();
+    let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");
+    assert_eq!(decoded.payload, Some(wire::envelope::Payload::Ping(ping)));
+
+    let pong = wire::Pong {
+        nonce: 1,
+        echoed_sender_sent_at: Some(wire::MonoTimestamp { nanos: 10 }),
+        responder_sent_at: Some(wire::MonoTimestamp { nanos: 20 }),
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::Pong(pong)),
+    };
+    let bytes = envelope.encode_to_vec();
+    let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");
+    assert_eq!(decoded.payload, Some(wire::envelope::Payload::Pong(pong)));
+}
+
+#[test]
+fn envelope_roundtrips_for_frame_rejected_arm() {
+    let rejected = wire::FrameRejected {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        scope: Some(wire::ScopeId {
+            value: "vehicle.motion".to_owned(),
+        }),
+        sequence: Some(wire::SequenceNum { value: 7 }),
+        reason: wire::FrameRejectionReason::TooOld as i32,
+        current_generation: Some(wire::Generation { value: 5 }),
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::FrameRejected(rejected.clone())),
+    };
+    let bytes = envelope.encode_to_vec();
+    let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");
+    assert_eq!(
+        decoded.payload,
+        Some(wire::envelope::Payload::FrameRejected(rejected))
+    );
+}
+
+mod proptests {
+    use crate::ids::{Generation, ScopeId, SequenceNum, VehicleId};
+    use crate::session::{FrameRejected, FrameRejectionReason};
+    use crate::wire;
+    use proptest::prelude::*;
+
+    fn arb_reason() -> impl Strategy<Value = FrameRejectionReason> {
+        prop_oneof![
+            Just(FrameRejectionReason::StaleGeneration),
+            Just(FrameRejectionReason::NoHolder),
+            Just(FrameRejectionReason::UnknownScope),
+            Just(FrameRejectionReason::TooOld),
+        ]
+    }
+
+    fn arb_frame_rejected() -> impl Strategy<Value = FrameRejected> {
+        (any::<u64>(), any::<u64>(), any::<u32>(), arb_reason()).prop_map(
+            |(vehicle, generation, sequence, reason)| FrameRejected {
+                vehicle: VehicleId::new(vehicle),
+                scope: ScopeId::new("vehicle.motion"),
+                sequence: SequenceNum::new(sequence),
+                reason,
+                current_generation: Generation::new(generation),
+            },
+        )
+    }
+
+    proptest! {
+        #[test]
+        fn frame_rejected_roundtrips_through_wire(rejected in arb_frame_rejected()) {
+            let wire_rejected: wire::FrameRejected = (&rejected).into();
+            let back = FrameRejected::try_from(wire_rejected);
+            prop_assert_eq!(back, Ok(rejected));
+        }
+    }
+}

--- a/crates/pilotage-session/Cargo.toml
+++ b/crates/pilotage-session/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pilotage-session"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+pilotage-protocol.workspace = true
+pilotage-authority.workspace = true
+pilotage-adapter-api.workspace = true
+pilotage-timing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/pilotage-session/src/action.rs
+++ b/crates/pilotage-session/src/action.rs
@@ -1,0 +1,108 @@
+//! Actions the engine emits for the driver to execute (ADR-0005, ADR-0008).
+//!
+//! The [`SessionEngine`] never performs I/O; it returns [`SessionAction`]s and
+//! the driver enacts them against the WebTransport session and the adapter.
+//! Actions carry an already-built domain message or adapter frame so the
+//! driver only encodes and writes — all decision logic stays in the engine.
+//!
+//! [`SessionEngine`]: crate::SessionEngine
+
+use pilotage_protocol::{FrameRejected, ScopedControlFrame};
+
+use crate::message::ClientKey;
+use crate::outbound::OutboundMessage;
+
+/// The result of one engine call: the actions to enact plus the count of
+/// actions the per-call cap forced the engine to drop.
+///
+/// A non-zero `dropped` is a correctness signal, not noise: it means the
+/// engine could not emit every action a message warranted (for example a
+/// disconnect releasing more scopes than [`SessionConfig::max_actions_per_call`]
+/// allows advanced authority state while its `HolderLinkLost` broadcasts were
+/// truncated, so clients would not learn every released scope). The driver
+/// MUST observe and count it, mirroring the bounded-channel drop discipline of
+/// the async layer (ADR-0009: every queue drop is counted, never silent).
+///
+/// [`SessionConfig::max_actions_per_call`]: crate::SessionConfig::max_actions_per_call
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionOutcome {
+    /// Actions the driver enacts, in emission order.
+    pub actions: Vec<SessionAction>,
+    /// Actions dropped because the per-call cap was reached. Non-zero means
+    /// the returned `actions` are incomplete for this call.
+    pub dropped: usize,
+}
+
+/// One unit of work the driver performs on the engine's behalf.
+///
+/// The enum's declaration order carries no meaning. The engine's ordering
+/// guarantee is emission order only: within a single call, [`SessionOutcome::actions`]
+/// lists actions in the order the driver must enact them (ADR-0012 events are
+/// persisted in emission order). For example [`SessionEngine::on_lease`] pushes
+/// a [`SessionAction::Broadcast`] before the [`SessionAction::SendToClient`]
+/// lease response, even though `SendToClient` is declared first below.
+///
+/// [`SessionEngine::on_lease`]: crate::SessionEngine
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionAction {
+    /// Send a message to exactly one client (unicast).
+    SendToClient {
+        /// Recipient connection.
+        client: ClientKey,
+        /// Message to encode and write to that client.
+        envelope: OutboundMessage,
+    },
+    /// Apply a fence-verified, fresh control frame to the adapter.
+    ApplyToAdapter {
+        /// The frame the adapter should apply this tick.
+        frame: ScopedControlFrame,
+    },
+    /// Send a message to every connected client (fan-out).
+    ///
+    /// Used for authority events, which every participant observes as the
+    /// canonical ordered authority stream (ADR-0005 `authority-events`,
+    /// ADR-0006).
+    Broadcast {
+        /// Message to encode and write to all clients.
+        envelope: OutboundMessage,
+    },
+    /// Reject a control frame back to its sender only (never broadcast,
+    /// ADR-0009).
+    RejectFrame {
+        /// The frame's sender.
+        client: ClientKey,
+        /// The typed rejection notice.
+        rejection: FrameRejected,
+    },
+    /// Close a client's connection with a machine-readable reason.
+    CloseClient {
+        /// Connection to close.
+        client: ClientKey,
+        /// Why the connection is being closed.
+        reason: CloseReason,
+    },
+}
+
+/// Why the engine asked the driver to close a client connection.
+///
+/// Distinct from an authority [`RejectReason`] or [`FrameRejectionReason`]:
+/// those keep the connection open. A `CloseReason` terminates the transport.
+///
+/// [`RejectReason`]: pilotage_authority::RejectReason
+/// [`FrameRejectionReason`]: pilotage_protocol::FrameRejectionReason
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    /// The client sent a `ClientHello` advertising a protocol version the host
+    /// cannot serve.
+    UnsupportedProtocolVersion {
+        /// Version the client advertised.
+        offered: u32,
+        /// Version the host requires.
+        required: u32,
+    },
+    /// The client sent a second `ClientHello` on an already-welcomed
+    /// connection, which the handshake does not permit.
+    DuplicateHello,
+    /// The client sent a domain message before completing the handshake.
+    HandshakeNotComplete,
+}

--- a/crates/pilotage-session/src/capabilities.rs
+++ b/crates/pilotage-session/src/capabilities.rs
@@ -1,0 +1,105 @@
+//! Projection of adapter capabilities into the `HostCapabilities` wire type
+//! and registration of their scopes with the authority engine (ADR-0006,
+//! ADR-0008).
+//!
+//! The adapter (`pilotage-adapter-api`) and the wire (`pilotage-protocol`)
+//! model capabilities differently: the adapter lists logical axes per scope
+//! and link-loss actions per vehicle, while the wire carries display names and
+//! a single link-loss action per scope. This module is the one place that
+//! bridge lives, so the engine and the driver never hand-roll the mapping.
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, LinkLossPolicy, ScopeDescriptor as AdapterScope,
+    VehicleDescriptor as AdapterVehicle,
+};
+use pilotage_protocol::wire;
+
+/// Builds the wire `HostCapabilities` a `ServerWelcome` advertises from the
+/// adapter's capability report and the configured host version.
+#[must_use]
+pub(crate) fn host_capabilities(
+    caps: &AdapterCapabilities,
+    host_version: &str,
+) -> wire::HostCapabilities {
+    wire::HostCapabilities {
+        host_version: host_version.to_owned(),
+        vehicles: caps.vehicles.iter().map(vehicle_descriptor).collect(),
+        supported_modes: execution_modes(caps),
+    }
+}
+
+/// Enumerates the `(vehicle, scope)` pairs the adapter exposes so the engine
+/// can register each with the authority engine at construction.
+pub(crate) fn scope_pairs(
+    caps: &AdapterCapabilities,
+) -> impl Iterator<Item = (pilotage_protocol::VehicleId, pilotage_protocol::ScopeId)> + '_ {
+    caps.vehicles.iter().flat_map(|vehicle| {
+        vehicle
+            .scopes
+            .iter()
+            .map(move |scope| (vehicle.id, scope.scope.clone()))
+    })
+}
+
+fn vehicle_descriptor(vehicle: &AdapterVehicle) -> wire::VehicleDescriptor {
+    let link_loss = vehicle
+        .link_loss_actions
+        .first()
+        .copied()
+        .map_or(wire::LinkLossAction::Unspecified, link_loss_action);
+    wire::VehicleDescriptor {
+        vehicle: Some(wire::VehicleId {
+            value: vehicle.id.as_u64(),
+        }),
+        display_name: String::new(),
+        scopes: vehicle
+            .scopes
+            .iter()
+            .map(|scope| scope_descriptor(scope, link_loss))
+            .collect(),
+        supported_modes: Vec::new(),
+    }
+}
+
+fn scope_descriptor(
+    scope: &AdapterScope,
+    link_loss: wire::LinkLossAction,
+) -> wire::ScopeDescriptor {
+    wire::ScopeDescriptor {
+        scope: Some(wire::ScopeId {
+            value: scope.scope.as_str().to_owned(),
+        }),
+        display_name: String::new(),
+        link_loss_action: link_loss as i32,
+    }
+}
+
+/// Projects the adapter's execution-mode flags onto the repeated wire enum.
+///
+/// The wire enum omits `deterministic`, `render_capable`, and
+/// `physically_embodied`; those are engine-internal characteristics the client
+/// does not select a session mode from, so only the run-time cadence flags
+/// (`real_time`, `accelerated`, `stepped`) are advertised.
+fn execution_modes(caps: &AdapterCapabilities) -> Vec<i32> {
+    let mut modes = Vec::new();
+    if caps.execution.real_time {
+        modes.push(wire::ExecutionMode::Realtime as i32);
+    }
+    if caps.execution.accelerated {
+        modes.push(wire::ExecutionMode::Accelerated as i32);
+    }
+    if caps.execution.stepped {
+        modes.push(wire::ExecutionMode::Stepped as i32);
+    }
+    modes
+}
+
+fn link_loss_action(policy: LinkLossPolicy) -> wire::LinkLossAction {
+    match policy {
+        LinkLossPolicy::Neutralize => wire::LinkLossAction::Neutral,
+        LinkLossPolicy::Brake => wire::LinkLossAction::Stop,
+        LinkLossPolicy::HoldBrief { .. } => wire::LinkLossAction::HoldLast,
+        LinkLossPolicy::Pause => wire::LinkLossAction::Stop,
+        LinkLossPolicy::EngageAutomation => wire::LinkLossAction::RevokeScope,
+    }
+}

--- a/crates/pilotage-session/src/clients.rs
+++ b/crates/pilotage-session/src/clients.rs
@@ -1,0 +1,172 @@
+//! Per-client registry and holder bookkeeping for the session engine.
+//!
+//! The engine assigns each connection a stable `SessionId`/`PrincipalId` at
+//! `ClientHello` and tracks which scopes each principal effectively holds, so a
+//! disconnect can release exactly those scopes (ADR-0010 link loss) without
+//! spraying the authority engine with lost-link reports for scopes the client
+//! never held.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use pilotage_protocol::{
+    Generation, PrincipalId, ScopeHolderSnapshot, ScopeId, SessionId, VehicleId,
+};
+
+use crate::message::ClientKey;
+
+/// A `(vehicle, scope)` pair, the unit of authority the engine tracks.
+pub(crate) type ScopePair = (VehicleId, ScopeId);
+
+/// Identity the engine assigned to one connection at handshake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClientState {
+    /// Session identity assigned to this connection.
+    pub(crate) session: SessionId,
+    /// Principal identity assigned to this connection.
+    pub(crate) principal: PrincipalId,
+}
+
+/// Registry of connected clients and the scopes each principal holds.
+///
+/// Holder bookkeeping is derived from authority effects, never guessed: a
+/// grant/commit/override that installs a principal records the scope for it,
+/// and any effect that empties or reassigns a scope removes it from the prior
+/// holder. This keeps the disconnect path precise even after handovers.
+#[derive(Debug, Default)]
+pub(crate) struct ClientRegistry {
+    clients: BTreeMap<ClientKey, ClientState>,
+    held: BTreeMap<PrincipalId, BTreeSet<ScopePair>>,
+    holders: BTreeMap<ScopePair, HolderRecord>,
+    next_session: u64,
+    next_principal: u64,
+}
+
+/// Current holder and fencing generation for one registered scope, derived
+/// wholly from authority effects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HolderRecord {
+    holder: Option<PrincipalId>,
+    generation: Generation,
+}
+
+impl ClientRegistry {
+    /// Creates an empty registry whose id counters start at zero.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seeds a freshly registered scope as unassigned at generation zero, so a
+    /// client welcomed before any lease still sees the scope in its snapshot.
+    pub(crate) fn register_scope(&mut self, pair: ScopePair) {
+        self.holders.entry(pair).or_insert(HolderRecord {
+            holder: None,
+            generation: Generation::new(0),
+        });
+    }
+
+    /// Returns whether the scope is registered (known to the host).
+    pub(crate) fn is_registered(&self, pair: &ScopePair) -> bool {
+        self.holders.contains_key(pair)
+    }
+
+    /// Returns the current fencing generation for a registered scope.
+    pub(crate) fn generation_of(&self, pair: &ScopePair) -> Option<Generation> {
+        self.holders.get(pair).map(|record| record.generation)
+    }
+
+    /// Returns the current effective holder of a registered scope, if any.
+    pub(crate) fn holder_of(&self, pair: &ScopePair) -> Option<PrincipalId> {
+        self.holders.get(pair).and_then(|record| record.holder)
+    }
+
+    /// Snapshots every tracked scope's holder and generation, ordered by
+    /// `(vehicle, scope)` for deterministic `ServerWelcome` output.
+    pub(crate) fn scope_holders(&self) -> Vec<ScopeHolderSnapshot> {
+        self.holders
+            .iter()
+            .map(|((vehicle, scope), record)| ScopeHolderSnapshot {
+                vehicle: *vehicle,
+                scope: scope.clone(),
+                holder: record.holder,
+                generation: record.generation,
+            })
+            .collect()
+    }
+
+    /// Returns the state for a welcomed client, if any.
+    pub(crate) fn get(&self, client: ClientKey) -> Option<&ClientState> {
+        self.clients.get(&client)
+    }
+
+    /// Returns whether the client has completed the handshake.
+    pub(crate) fn is_welcomed(&self, client: ClientKey) -> bool {
+        self.clients.contains_key(&client)
+    }
+
+    /// Assigns a fresh session/principal identity to a new connection.
+    ///
+    /// Id counters use `wrapping_add(1)` so a very long-lived host process
+    /// cannot panic on overflow; collisions after a full `u64` wrap are not a
+    /// concern within any realistic session lifetime.
+    pub(crate) fn welcome(&mut self, client: ClientKey) -> ClientState {
+        let session = SessionId::new(self.next_session);
+        let principal = PrincipalId::new(self.next_principal);
+        self.next_session = self.next_session.wrapping_add(1);
+        self.next_principal = self.next_principal.wrapping_add(1);
+        let state = ClientState { session, principal };
+        self.clients.insert(client, state.clone());
+        state
+    }
+
+    /// Removes a client on disconnect, returning the scopes its principal still
+    /// held so the caller can issue the matching link-loss reports.
+    pub(crate) fn remove(&mut self, client: ClientKey) -> Option<(PrincipalId, Vec<ScopePair>)> {
+        let state = self.clients.remove(&client)?;
+        let scopes = self
+            .held
+            .remove(&state.principal)
+            .map(|set| set.into_iter().collect())
+            .unwrap_or_default();
+        Some((state.principal, scopes))
+    }
+
+    /// Records that `holder` now holds `pair` at `generation`, clearing any
+    /// prior holder of the same pair.
+    pub(crate) fn record_hold(
+        &mut self,
+        holder: PrincipalId,
+        pair: ScopePair,
+        generation: Generation,
+    ) {
+        self.detach_pair(&pair);
+        self.held.entry(holder).or_default().insert(pair.clone());
+        self.holders.insert(
+            pair,
+            HolderRecord {
+                holder: Some(holder),
+                generation,
+            },
+        );
+    }
+
+    /// Records that `pair` is no longer held by anyone, at `generation`.
+    pub(crate) fn clear_pair(&mut self, pair: &ScopePair, generation: Generation) {
+        self.detach_pair(pair);
+        self.holders.insert(
+            pair.clone(),
+            HolderRecord {
+                holder: None,
+                generation,
+            },
+        );
+    }
+
+    /// Removes `pair` from every principal's held set without touching the
+    /// holder snapshot.
+    fn detach_pair(&mut self, pair: &ScopePair) {
+        self.held.retain(|_, set| {
+            set.remove(pair);
+            !set.is_empty()
+        });
+    }
+}

--- a/crates/pilotage-session/src/config.rs
+++ b/crates/pilotage-session/src/config.rs
@@ -1,0 +1,66 @@
+//! Static configuration for a [`SessionEngine`] (ADR-0005, ADR-0009).
+//!
+//! Config is supplied once at construction and never mutated; it bundles the
+//! handshake floor, the host version string echoed in capabilities, and the
+//! per-call action cap that bounds the engine's output.
+//!
+//! [`SessionEngine`]: crate::SessionEngine
+
+/// Immutable knobs the engine reads while deciding actions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionConfig {
+    /// Lowest `pilotage.v1` schema version the host will serve. A
+    /// `ClientHello` advertising a lower `protocol_version` is closed with
+    /// [`CloseReason::UnsupportedProtocolVersion`].
+    ///
+    /// [`CloseReason::UnsupportedProtocolVersion`]:
+    /// crate::CloseReason::UnsupportedProtocolVersion
+    pub required_protocol_version: u32,
+    /// Human-readable host version echoed into `HostCapabilities.host_version`
+    /// (ADR-0008), for compatibility negotiation and diagnostics only.
+    pub host_version: String,
+    /// Hard cap on the number of [`SessionAction`]s a single
+    /// `handle_client_message` or `handle_tick` call may emit.
+    ///
+    /// The engine is driven by untrusted client input; without a cap a
+    /// pathological message (or a burst of authority effects) could grow the
+    /// returned vector unboundedly. When the cap is reached the engine stops
+    /// appending and drops further actions for that call — a dropped action is
+    /// a correctness signal the driver counts, mirroring the bounded-channel
+    /// discipline of the async layer. The cap is generous relative to the
+    /// worst realistic fan-out of one message (a handshake, a lease grant plus
+    /// its broadcast, or a disconnect releasing every held scope), so hitting
+    /// it means a scope count or client population far outside design
+    /// envelope.
+    ///
+    /// [`SessionAction`]: crate::SessionAction
+    pub max_actions_per_call: usize,
+}
+
+impl SessionConfig {
+    /// The default per-call action cap.
+    ///
+    /// Chosen well above the fan-out of any single client message in the
+    /// increment-0 loopback: even a disconnect releasing every scope of a
+    /// many-vehicle adapter, each producing a link-state and a revoke
+    /// broadcast, stays comfortably under this bound.
+    pub const DEFAULT_MAX_ACTIONS_PER_CALL: usize = 256;
+
+    /// Constructs a config with the given handshake floor and host version,
+    /// using [`SessionConfig::DEFAULT_MAX_ACTIONS_PER_CALL`].
+    #[must_use]
+    pub fn new(required_protocol_version: u32, host_version: impl Into<String>) -> Self {
+        Self {
+            required_protocol_version,
+            host_version: host_version.into(),
+            max_actions_per_call: Self::DEFAULT_MAX_ACTIONS_PER_CALL,
+        }
+    }
+
+    /// Overrides the per-call action cap.
+    #[must_use]
+    pub fn with_max_actions_per_call(mut self, cap: usize) -> Self {
+        self.max_actions_per_call = cap;
+        self
+    }
+}

--- a/crates/pilotage-session/src/engine.rs
+++ b/crates/pilotage-session/src/engine.rs
@@ -1,0 +1,304 @@
+//! The host-side session state machine (ADR-0005, ADR-0006, ADR-0009,
+//! ADR-0010).
+//!
+//! [`SessionEngine`] is pure and sans-IO (ADR-0002): the driver hands it
+//! decoded [`DomainEnvelope`]s plus an explicit `now`, and it returns
+//! [`SessionAction`]s the driver enacts. All handshake, lease, fencing,
+//! staleness, and link-loss decisions live here so the host binary is a thin
+//! I/O shell.
+//!
+//! The staleness check treats client-supplied `sampled_at` as same-clock as
+//! the host `now`: a documented loopback-only simplification for increment 0.
+//! See [`SessionEngine`] for the full caveat and the RTT/offset follow-up.
+
+mod handlers;
+
+use pilotage_adapter_api::AdapterCapabilities;
+use pilotage_authority::{AuthorityCommand, AuthorityEffect, AuthorityEngine, LinkState};
+use pilotage_timing::{MonoTimestamp, StalenessPolicy};
+
+use crate::action::{SessionAction, SessionOutcome};
+use crate::capabilities::scope_pairs;
+use crate::clients::ClientRegistry;
+use crate::config::SessionConfig;
+use crate::message::{ClientKey, DomainEnvelope};
+use crate::outbound::OutboundMessage;
+
+/// A pure host-side session state machine driven by decoded messages and an
+/// explicit clock.
+///
+/// Construct with [`SessionEngine::new`]; drive with
+/// [`SessionEngine::handle_client_message`] and [`SessionEngine::handle_tick`];
+/// schedule ticks from [`SessionEngine::next_deadline`]. The engine owns an
+/// embedded [`AuthorityEngine`] and is authoritative for who holds what right
+/// now (ADR-0006).
+///
+/// # Loopback time simplification (increment 0)
+///
+/// ADR-0009 forbids comparing a remote endpoint's `MonoTimestamp` against a
+/// local one without clock correlation. This engine's staleness check computes
+/// frame age as `receive_now - frame.sampled_at` **directly**, which is only
+/// valid because the increment-0 loopback runs client and host in ONE process
+/// on ONE monotonic clock, so `sampled_at` and `receive_now` share an epoch.
+///
+/// THIS IS A LOOPBACK-ONLY SHORTCUT. On a real WebTransport link the client's
+/// `sampled_at` is in the client's `transport_time` domain and MUST be
+/// correlated through [`pilotage_timing::RttEstimator`] /
+/// [`pilotage_timing::ClockOffset`] (see [`pilotage_timing::estimated_age`])
+/// before comparison. Replacing this direct subtraction with the estimator
+/// path is the tracked follow-up; do not ship it to a networked host as-is.
+#[derive(Debug)]
+pub struct SessionEngine {
+    authority: AuthorityEngine,
+    capabilities: AdapterCapabilities,
+    staleness: StalenessPolicy,
+    config: SessionConfig,
+    clients: ClientRegistry,
+}
+
+impl SessionEngine {
+    /// Builds an engine over an adapter's capabilities, registering every
+    /// `(vehicle, scope)` the adapter exposes with the authority engine so
+    /// leases and frames can target them immediately.
+    #[must_use]
+    pub fn new(
+        capabilities: AdapterCapabilities,
+        staleness: StalenessPolicy,
+        config: SessionConfig,
+    ) -> Self {
+        let mut authority = AuthorityEngine::new();
+        let mut clients = ClientRegistry::new();
+        // Registration time is irrelevant (no command consults `now`); a zero
+        // stamp keeps construction free of a clock, per ADR-0002.
+        let now = MonoTimestamp::from_nanos(0);
+        for (vehicle, scope) in scope_pairs(&capabilities) {
+            clients.register_scope((vehicle, scope.clone()));
+            let effects = authority.handle(AuthorityCommand::RegisterScope { vehicle, scope }, now);
+            drop(effects);
+        }
+        Self {
+            authority,
+            capabilities,
+            staleness,
+            config,
+            clients,
+        }
+    }
+
+    /// Handles one decoded client message at time `now`.
+    ///
+    /// The returned [`SessionOutcome`] carries the actions plus
+    /// [`SessionOutcome::dropped`], the count of actions the per-call cap
+    /// ([`SessionConfig::max_actions_per_call`]) forced the engine to drop. A
+    /// non-zero drop count is a correctness signal the driver MUST count.
+    #[must_use]
+    pub fn handle_client_message(
+        &mut self,
+        client: ClientKey,
+        msg: DomainEnvelope,
+        now: MonoTimestamp,
+    ) -> SessionOutcome {
+        let mut actions = Actions::new(self.config.max_actions_per_call);
+        match msg {
+            DomainEnvelope::Hello(hello) => self.on_hello(client, hello, &mut actions),
+            DomainEnvelope::Lease(request) => self.on_lease(client, request, now, &mut actions),
+            DomainEnvelope::Frame(frame) => self.on_frame(client, frame, now, &mut actions),
+            DomainEnvelope::Ping(ping) => self.on_ping(client, ping, now, &mut actions),
+            DomainEnvelope::Disconnect => self.on_disconnect(client, &mut actions),
+        }
+        actions.into_outcome()
+    }
+
+    /// Advances time-driven state (offer expiry) to `now`.
+    ///
+    /// Delegates expiry entirely to the embedded [`AuthorityEngine`], turning
+    /// each expiry effect into an authority broadcast.
+    ///
+    /// The returned [`SessionOutcome`] carries [`SessionOutcome::dropped`], the
+    /// count of broadcasts the per-call cap forced the engine to drop; a
+    /// non-zero value is a correctness signal the driver MUST count.
+    #[must_use]
+    pub fn handle_tick(&mut self, now: MonoTimestamp) -> SessionOutcome {
+        let mut actions = Actions::new(self.config.max_actions_per_call);
+        let effects = self.authority.expire_due(now);
+        self.fan_out_authority(effects, &mut actions);
+        actions.into_outcome()
+    }
+
+    /// Returns the next time the engine wants a [`SessionEngine::handle_tick`]
+    /// call, delegating to the authority engine's earliest offer expiry.
+    #[must_use]
+    pub fn next_deadline(&self) -> Option<MonoTimestamp> {
+        self.authority.next_deadline()
+    }
+
+    /// Broadcasts each authority effect and keeps holder bookkeeping in sync.
+    ///
+    /// Every effect that installs or clears an effective holder updates the
+    /// registry so the disconnect path releases exactly the scopes the client
+    /// still holds.
+    pub(crate) fn fan_out_authority(
+        &mut self,
+        effects: Vec<AuthorityEffect>,
+        actions: &mut Actions,
+    ) {
+        for effect in effects {
+            self.record_holder_change(&effect);
+            actions.broadcast(OutboundMessage::Authority(effect));
+        }
+    }
+
+    /// Updates the registry's holder bookkeeping from one authority effect.
+    fn record_holder_change(&mut self, effect: &AuthorityEffect) {
+        match effect {
+            AuthorityEffect::ScopeLeaseGranted {
+                vehicle,
+                scope,
+                holder,
+                generation,
+            } => self
+                .clients
+                .record_hold(*holder, (*vehicle, scope.clone()), *generation),
+            AuthorityEffect::ScopeTransferCommitted {
+                vehicle,
+                scope,
+                to,
+                generation,
+                ..
+            } => self
+                .clients
+                .record_hold(*to, (*vehicle, scope.clone()), *generation),
+            AuthorityEffect::EmergencyOverrideApplied {
+                vehicle,
+                scope,
+                holder,
+                generation,
+                ..
+            } => self
+                .clients
+                .record_hold(*holder, (*vehicle, scope.clone()), *generation),
+            AuthorityEffect::ScopeLeaseRevoked {
+                vehicle,
+                scope,
+                generation,
+                ..
+            }
+            | AuthorityEffect::HolderLinkLost {
+                vehicle,
+                scope,
+                generation,
+                ..
+            } => {
+                self.clients
+                    .clear_pair(&(*vehicle, scope.clone()), *generation);
+            }
+            _ => {}
+        }
+    }
+
+    /// Reports every scope a disconnecting principal held as link-lost.
+    ///
+    /// The authority engine releases only scopes the principal still
+    /// effectively holds (a stale entry after a handover is a benign
+    /// `LinkStateChanged`), so this is safe to call with the registry's last
+    /// known holdings.
+    fn release_on_disconnect(
+        &mut self,
+        principal: pilotage_protocol::PrincipalId,
+        scopes: Vec<crate::clients::ScopePair>,
+        actions: &mut Actions,
+    ) {
+        for (vehicle, scope) in scopes {
+            let effects = self.authority.handle(
+                AuthorityCommand::HolderLinkChanged {
+                    vehicle,
+                    scope,
+                    principal,
+                    state: LinkState::Lost,
+                },
+                // Link-loss handling does not consult `now`; a zero stamp is
+                // sound and keeps disconnect independent of a clock.
+                MonoTimestamp::from_nanos(0),
+            );
+            self.fan_out_authority(effects, actions);
+        }
+    }
+}
+
+/// A bounded accumulator for the actions one engine call may emit.
+///
+/// Enforces [`SessionConfig::max_actions_per_call`]: once full it silently
+/// drops further pushes and records the drop count, mirroring the async
+/// layer's bounded-channel discipline where a drop is a counted correctness
+/// signal, never silent loss the driver cannot observe.
+#[derive(Debug)]
+pub(crate) struct Actions {
+    items: Vec<SessionAction>,
+    cap: usize,
+    dropped: usize,
+}
+
+impl Actions {
+    fn new(cap: usize) -> Self {
+        Self {
+            items: Vec::new(),
+            cap,
+            dropped: 0,
+        }
+    }
+
+    /// Appends an action unless the per-call cap is already reached.
+    pub(crate) fn push(&mut self, action: SessionAction) {
+        if self.items.len() >= self.cap {
+            self.dropped = self.dropped.wrapping_add(1);
+            return;
+        }
+        self.items.push(action);
+    }
+
+    /// Appends a unicast send to one client.
+    pub(crate) fn send(&mut self, client: ClientKey, envelope: OutboundMessage) {
+        self.push(SessionAction::SendToClient { client, envelope });
+    }
+
+    /// Appends a broadcast to all clients.
+    pub(crate) fn broadcast(&mut self, envelope: OutboundMessage) {
+        self.push(SessionAction::Broadcast { envelope });
+    }
+
+    /// Consumes the accumulator into the call's [`SessionOutcome`], carrying
+    /// the collected actions and the count dropped at the cap.
+    fn into_outcome(self) -> SessionOutcome {
+        SessionOutcome {
+            actions: self.items,
+            dropped: self.dropped,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod cap_tests {
+    use super::Actions;
+    use crate::action::{CloseReason, SessionAction};
+    use crate::message::ClientKey;
+
+    fn close(n: u64) -> SessionAction {
+        SessionAction::CloseClient {
+            client: ClientKey::new(n),
+            reason: CloseReason::DuplicateHello,
+        }
+    }
+
+    #[test]
+    fn actions_are_capped_and_drops_are_counted() {
+        let mut actions = Actions::new(2);
+        actions.push(close(0));
+        actions.push(close(1));
+        actions.push(close(2));
+        actions.push(close(3));
+        let outcome = actions.into_outcome();
+        assert_eq!(outcome.dropped, 2);
+        assert_eq!(outcome.actions.len(), 2);
+    }
+}

--- a/crates/pilotage-session/src/engine/handlers.rs
+++ b/crates/pilotage-session/src/engine/handlers.rs
@@ -1,0 +1,307 @@
+//! Per-message handlers for [`SessionEngine`] (ADR-0005, ADR-0006, ADR-0009).
+//!
+//! Each handler consumes one decoded message and appends the resulting actions
+//! to the shared bounded [`Actions`] accumulator. The handlers hold every
+//! handshake, lease, fencing, and staleness decision so the driver stays thin.
+
+use pilotage_authority::{AuthorityCommand, AuthorityEffect, FrameVerdict};
+use pilotage_protocol::{
+    ClientHello, FrameRejected, FrameRejectionReason, Generation, LeaseDenialReason, LeaseRequest,
+    Ping, Pong, ScopedControlFrame, ServerWelcome,
+};
+use pilotage_timing::{Freshness, MonoTimestamp};
+
+use crate::action::{CloseReason, SessionAction};
+use crate::capabilities::host_capabilities;
+use crate::clients::ScopePair;
+use crate::engine::{Actions, SessionEngine};
+use crate::message::ClientKey;
+use crate::outbound::OutboundMessage;
+
+impl SessionEngine {
+    /// Answers a `ClientHello` with a `ServerWelcome`, or closes the
+    /// connection on a version mismatch or a duplicate handshake.
+    pub(super) fn on_hello(
+        &mut self,
+        client: ClientKey,
+        hello: ClientHello,
+        actions: &mut Actions,
+    ) {
+        let required = self.config.required_protocol_version;
+        if hello.protocol_version < required {
+            actions.push(SessionAction::CloseClient {
+                client,
+                reason: CloseReason::UnsupportedProtocolVersion {
+                    offered: hello.protocol_version,
+                    required,
+                },
+            });
+            return;
+        }
+        if self.clients.is_welcomed(client) {
+            actions.push(SessionAction::CloseClient {
+                client,
+                reason: CloseReason::DuplicateHello,
+            });
+            return;
+        }
+        let state = self.clients.welcome(client);
+        let welcome = ServerWelcome {
+            session: state.session,
+            principal: state.principal,
+            host_capabilities: host_capabilities(&self.capabilities, &self.config.host_version),
+            scope_holders: self.clients.scope_holders(),
+        };
+        actions.send(client, OutboundMessage::Welcome(welcome));
+    }
+
+    /// Routes a `LeaseRequest` through the authority engine's grant path,
+    /// replying with a `LeaseResponse` and broadcasting the grant on success.
+    pub(super) fn on_lease(
+        &mut self,
+        client: ClientKey,
+        request: LeaseRequest,
+        now: MonoTimestamp,
+        actions: &mut Actions,
+    ) {
+        let Some(principal) = self.welcomed_principal(client, actions) else {
+            return;
+        };
+        let pair: ScopePair = (request.vehicle, request.scope.clone());
+        if !self.clients.is_registered(&pair) {
+            actions.send(
+                client,
+                OutboundMessage::LeaseResponse(lease_denied(
+                    &request,
+                    Generation::new(0),
+                    LeaseDenialReason::UnknownScope,
+                )),
+            );
+            return;
+        }
+        if let Some(current) = self.clients.holder_of(&pair) {
+            let generation = self
+                .clients
+                .generation_of(&pair)
+                .unwrap_or_else(|| Generation::new(0));
+            // A principal already holding the scope re-requesting it is not an
+            // error; reply with the standing grant rather than a denial.
+            let response = if current == principal {
+                lease_granted(&request, generation)
+            } else {
+                lease_denied(&request, generation, LeaseDenialReason::AlreadyHeld)
+            };
+            actions.send(client, OutboundMessage::LeaseResponse(response));
+            return;
+        }
+        let effects = self.authority.handle(
+            AuthorityCommand::Grant {
+                vehicle: request.vehicle,
+                scope: request.scope.clone(),
+                to: principal,
+            },
+            now,
+        );
+        // The authority engine is the single source of truth for whether the
+        // grant actually took effect; a `CommandRejected` effect (the scope
+        // was concurrently claimed by another principal between the registry
+        // check above and this call) must produce a denial, never a granted
+        // response with a stale generation.
+        let rejected = effects
+            .iter()
+            .any(|effect| matches!(effect, AuthorityEffect::CommandRejected { .. }));
+        // `fan_out_authority` updates the holder record from the grant effect,
+        // so the post-grant generation lookup reflects the advanced value.
+        self.fan_out_authority(effects, actions);
+        let current_generation = self
+            .clients
+            .generation_of(&pair)
+            .unwrap_or_else(|| Generation::new(0));
+        let response = if rejected {
+            lease_denied(&request, current_generation, LeaseDenialReason::AlreadyHeld)
+        } else {
+            lease_granted(&request, current_generation)
+        };
+        actions.send(client, OutboundMessage::LeaseResponse(response));
+    }
+
+    /// Staleness-checks, fence-verifies, then forwards or rejects a control
+    /// frame (ADR-0009).
+    pub(super) fn on_frame(
+        &mut self,
+        client: ClientKey,
+        frame: ScopedControlFrame,
+        now: MonoTimestamp,
+        actions: &mut Actions,
+    ) {
+        let Some(sender) = self.welcomed_principal(client, actions) else {
+            return;
+        };
+        // LOOPBACK-ONLY: `sampled_at` and `now` are treated as one monotonic
+        // clock (see the crate/engine module docs). A networked host must route
+        // this through `pilotage_timing::estimated_age` instead.
+        let age = now.saturating_duration_since(frame.sampled_at);
+        if let Freshness::Stale { .. } = self.staleness.check(age) {
+            let generation = self.frame_generation(&frame);
+            actions.push(reject_frame(
+                client,
+                &frame,
+                FrameRejectionReason::TooOld,
+                generation,
+            ));
+            return;
+        }
+        // Fence on the sender's identity, not just on generation. `verify_frame`
+        // confirms a holder exists at the current generation, but generations are
+        // broadcast to every client, so a non-holder could otherwise forge an
+        // in-generation frame. Only the recorded holder may drive the scope. An
+        // unregistered scope has no holder and is left to `verify_frame` so the
+        // sender still learns the scope is unknown rather than merely unheld.
+        let pair = (frame.vehicle, frame.scope.clone());
+        if self.clients.is_registered(&pair) && self.clients.holder_of(&pair) != Some(sender) {
+            let generation = self.frame_generation(&frame);
+            actions.push(reject_frame(
+                client,
+                &frame,
+                FrameRejectionReason::NoHolder,
+                generation,
+            ));
+            return;
+        }
+        match self
+            .authority
+            .verify_frame(frame.vehicle, &frame.scope, frame.generation)
+        {
+            FrameVerdict::Accepted => {
+                actions.push(SessionAction::ApplyToAdapter { frame });
+            }
+            FrameVerdict::RejectedStaleGeneration { current } => {
+                actions.push(reject_frame(
+                    client,
+                    &frame,
+                    FrameRejectionReason::StaleGeneration,
+                    current,
+                ));
+            }
+            FrameVerdict::RejectedNoHolder => {
+                let generation = self.frame_generation(&frame);
+                actions.push(reject_frame(
+                    client,
+                    &frame,
+                    FrameRejectionReason::NoHolder,
+                    generation,
+                ));
+            }
+            FrameVerdict::RejectedUnknownScope => {
+                actions.push(reject_frame(
+                    client,
+                    &frame,
+                    FrameRejectionReason::UnknownScope,
+                    Generation::new(0),
+                ));
+            }
+        }
+    }
+
+    /// Answers a `Ping` with a `Pong` echoing the sender sample and stamping
+    /// the responder's own time (ADR-0009).
+    pub(super) fn on_ping(
+        &mut self,
+        client: ClientKey,
+        ping: Ping,
+        now: MonoTimestamp,
+        actions: &mut Actions,
+    ) {
+        if self.welcomed_principal(client, actions).is_none() {
+            return;
+        }
+        let pong = Pong {
+            nonce: ping.nonce,
+            echoed_sender_sent_at: ping.sender_sent_at,
+            responder_sent_at: now,
+        };
+        actions.send(client, OutboundMessage::Pong(pong));
+    }
+
+    /// Releases every scope a disconnecting client held (ADR-0010 link loss).
+    pub(super) fn on_disconnect(&mut self, client: ClientKey, actions: &mut Actions) {
+        if let Some((principal, scopes)) = self.clients.remove(client) {
+            self.release_on_disconnect(principal, scopes, actions);
+        }
+    }
+
+    /// Returns the requesting client's principal, or emits a close action when
+    /// the client has not completed the handshake.
+    fn welcomed_principal(
+        &self,
+        client: ClientKey,
+        actions: &mut Actions,
+    ) -> Option<pilotage_protocol::PrincipalId> {
+        match self.clients.get(client) {
+            Some(state) => Some(state.principal),
+            None => {
+                actions.push(SessionAction::CloseClient {
+                    client,
+                    reason: CloseReason::HandshakeNotComplete,
+                });
+                None
+            }
+        }
+    }
+
+    /// Looks up the current generation for a frame's scope, defaulting to zero
+    /// for an unknown scope.
+    fn frame_generation(&self, frame: &ScopedControlFrame) -> Generation {
+        self.clients
+            .generation_of(&(frame.vehicle, frame.scope.clone()))
+            .unwrap_or_else(|| Generation::new(0))
+    }
+}
+
+/// Builds a `RejectFrame` action carrying the scope's current generation.
+fn reject_frame(
+    client: ClientKey,
+    frame: &ScopedControlFrame,
+    reason: FrameRejectionReason,
+    current_generation: Generation,
+) -> SessionAction {
+    SessionAction::RejectFrame {
+        client,
+        rejection: FrameRejected {
+            vehicle: frame.vehicle,
+            scope: frame.scope.clone(),
+            sequence: frame.sequence,
+            reason,
+            current_generation,
+        },
+    }
+}
+
+/// Builds a granted `LeaseResponse`.
+fn lease_granted(
+    request: &LeaseRequest,
+    generation: Generation,
+) -> pilotage_protocol::LeaseResponse {
+    pilotage_protocol::LeaseResponse {
+        vehicle: request.vehicle,
+        scope: request.scope.clone(),
+        granted: true,
+        generation,
+        reason: None,
+    }
+}
+
+/// Builds a denied `LeaseResponse` carrying the unchanged current generation.
+fn lease_denied(
+    request: &LeaseRequest,
+    generation: Generation,
+    reason: LeaseDenialReason,
+) -> pilotage_protocol::LeaseResponse {
+    pilotage_protocol::LeaseResponse {
+        vehicle: request.vehicle,
+        scope: request.scope.clone(),
+        granted: false,
+        generation,
+        reason: Some(reason),
+    }
+}

--- a/crates/pilotage-session/src/lib.rs
+++ b/crates/pilotage-session/src/lib.rs
@@ -1,0 +1,34 @@
+//! Host-side session state machine for Pilotage (ADR-0005, ADR-0006,
+//! ADR-0009, ADR-0010).
+//!
+//! [`SessionEngine`] is a pure, sans-IO state machine (ADR-0002) the host
+//! binary drives: it consumes decoded [`DomainEnvelope`]s plus an explicit
+//! `now` and returns [`SessionAction`]s the driver executes against the
+//! WebTransport session and the adapter. Handshake, lease grant, per-frame
+//! fencing, staleness rejection, RTT echo, and disconnect release all live
+//! here, so the host binary carries no protocol decision logic.
+//!
+//! Authority is delegated to an embedded [`pilotage_authority::AuthorityEngine`]:
+//! lease grants and offer expiry route through it, and its effects become
+//! [`SessionAction::Broadcast`]s on the ordered authority stream.
+//!
+//! The staleness check is a documented loopback-only simplification for
+//! increment 0; see [`SessionEngine`] for the full caveat and the RTT/offset
+//! follow-up.
+
+mod action;
+mod capabilities;
+mod clients;
+mod config;
+mod engine;
+mod message;
+mod outbound;
+
+#[cfg(test)]
+mod tests;
+
+pub use action::{CloseReason, SessionAction, SessionOutcome};
+pub use config::SessionConfig;
+pub use engine::SessionEngine;
+pub use message::{ClientKey, DomainEnvelope};
+pub use outbound::OutboundMessage;

--- a/crates/pilotage-session/src/message.rs
+++ b/crates/pilotage-session/src/message.rs
@@ -1,0 +1,67 @@
+//! Driver-facing decoded-message vocabulary (ADR-0005, ADR-0014).
+//!
+//! The host binary owns the WebTransport I/O and the `prost` decode; it hands
+//! the [`SessionEngine`] already-decoded domain messages so the engine stays
+//! sans-IO (ADR-0002). [`DomainEnvelope`] is the closed set of client-origin
+//! events the engine reacts to, including the synthetic
+//! [`DomainEnvelope::Disconnect`] the driver raises when a client's transport
+//! link drops.
+//!
+//! [`SessionEngine`]: crate::SessionEngine
+
+use pilotage_protocol::{ClientHello, LeaseRequest, Ping, ScopedControlFrame};
+
+/// Identifies one connected client (one WebTransport session) within a
+/// [`SessionEngine`].
+///
+/// Assigned by the driver, opaque to the engine, and stable for the lifetime
+/// of the transport connection. The engine keys all per-client state on it and
+/// echoes it back in every [`SessionAction`] so the driver knows which
+/// connection to write to.
+///
+/// [`SessionEngine`]: crate::SessionEngine
+/// [`SessionAction`]: crate::SessionAction
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ClientKey(u64);
+
+impl ClientKey {
+    /// Constructs a client key from a raw driver-assigned value.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the key as a raw `u64`.
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// A decoded client-origin message the driver submits to the engine.
+///
+/// This mirrors the client-to-host arms of the wire `Envelope` oneof
+/// (ADR-0014) plus a synthetic [`DomainEnvelope::Disconnect`]. Host-to-client
+/// messages (`ServerWelcome`, `LeaseResponse`, `Pong`, `FrameRejected`,
+/// authority events) are never inputs; they appear only as
+/// [`SessionAction`]s.
+///
+/// [`SessionAction`]: crate::SessionAction
+#[derive(Debug, Clone, PartialEq)]
+pub enum DomainEnvelope {
+    /// The client's opening handshake, answered with a `ServerWelcome`.
+    Hello(ClientHello),
+    /// A request to lease a control scope, routed through the authority
+    /// engine's grant path.
+    Lease(LeaseRequest),
+    /// A real-time control frame to be staleness-checked, fence-verified, and
+    /// forwarded to the adapter or rejected.
+    Frame(ScopedControlFrame),
+    /// An RTT/offset probe, answered with a `Pong` stamped by the driver's
+    /// clock.
+    Ping(Ping),
+    /// The driver observed the client's transport link drop; the engine
+    /// releases every scope the client held via the authority engine's
+    /// link-loss path.
+    Disconnect,
+}

--- a/crates/pilotage-session/src/outbound.rs
+++ b/crates/pilotage-session/src/outbound.rs
@@ -1,0 +1,32 @@
+//! Host-to-client message payloads carried by unicast and broadcast actions.
+//!
+//! These are the domain-typed (not wire-typed) messages the engine decides to
+//! send; the driver encodes each into a `pilotage.v1.Envelope` and writes it
+//! on the appropriate WebTransport channel (ADR-0005). Keeping them domain
+//! typed lets the engine remain sans-IO and lets the wire encoding live wholly
+//! in `pilotage-protocol` and `pilotage-authority`.
+
+use pilotage_authority::AuthorityEffect;
+use pilotage_protocol::{LeaseResponse, Pong, ServerWelcome};
+
+/// A message the engine directs at one client or at all clients.
+///
+/// The [`OutboundMessage::Authority`] arm carries the engine's own
+/// [`AuthorityEffect`] rather than a pre-built wire event: the authority crate
+/// owns the effect-to-`AuthorityEvent` conversion (its audit-trail
+/// serialization is total over the effect enum), so the driver calls
+/// `proto::AuthorityEvent::from(&effect)` at encode time. This keeps the
+/// authority wire mapping in one place.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OutboundMessage {
+    /// The reply to a `ClientHello` (ADR-0005 handshake).
+    Welcome(ServerWelcome),
+    /// The reply to a `LeaseRequest` (ADR-0006).
+    LeaseResponse(LeaseResponse),
+    /// The reply to a `Ping` (ADR-0009 RTT probe).
+    Pong(Pong),
+    /// An authority event to be serialized and observed on the ordered
+    /// authority stream (ADR-0006, ADR-0012). Carried as the source
+    /// [`AuthorityEffect`] so the driver performs the canonical wire mapping.
+    Authority(AuthorityEffect),
+}

--- a/crates/pilotage-session/src/tests.rs
+++ b/crates/pilotage-session/src/tests.rs
@@ -1,0 +1,115 @@
+//! Unit tests for the session engine, exercising the ADR-0005/0006/0009/0010
+//! decision paths through the public API only.
+//!
+//! Each submodule covers one required behavior: handshake, lease grant and
+//! duplicate request, accept-then-fence, staleness rejection, ping/pong,
+//! disconnect release, and deadline pass-through.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod deadline;
+mod disconnect;
+mod frame;
+mod handshake;
+mod lease;
+mod ping;
+
+use core::time::Duration;
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ExecutionMode, LinkLossPolicy, ScopeDescriptor, VehicleDescriptor,
+};
+use pilotage_protocol::{
+    ClientHello, ControlPayload, Generation, LogicalAxisId, ScopeId, ScopedControlFrame,
+    SequenceNum, SessionId, VehicleId,
+};
+use pilotage_timing::{MonoTimestamp, StalenessPolicy};
+
+use crate::{ClientKey, SessionConfig, SessionEngine};
+
+/// The single motion scope used across the tests.
+pub(crate) fn motion() -> ScopeId {
+    ScopeId::new("vehicle.motion")
+}
+
+/// The single vehicle used across the tests.
+pub(crate) const VEHICLE: VehicleId = VehicleId::new(1);
+
+/// A one-vehicle, one-scope adapter capability report.
+pub(crate) fn capabilities() -> AdapterCapabilities {
+    AdapterCapabilities {
+        execution: ExecutionMode {
+            real_time: true,
+            deterministic: true,
+            ..ExecutionMode::default()
+        },
+        vehicles: vec![VehicleDescriptor {
+            id: VEHICLE,
+            scopes: vec![ScopeDescriptor {
+                scope: motion(),
+                axes: vec![LogicalAxisId::new(0)],
+            }],
+            link_loss_actions: vec![LinkLossPolicy::Neutralize],
+        }],
+        adapter_version: "test".to_owned(),
+    }
+}
+
+/// A 50 ms staleness policy.
+pub(crate) fn staleness() -> StalenessPolicy {
+    StalenessPolicy::new(Duration::from_millis(50))
+}
+
+/// A fresh engine over [`capabilities`] with protocol floor 1.
+pub(crate) fn engine() -> SessionEngine {
+    SessionEngine::new(
+        capabilities(),
+        staleness(),
+        SessionConfig::new(1, "host-test"),
+    )
+}
+
+/// Drives a `ClientHello` for `client` and returns the assigned session id.
+pub(crate) fn welcome(engine: &mut SessionEngine, client: ClientKey) -> SessionId {
+    let outcome = engine.handle_client_message(
+        client,
+        crate::DomainEnvelope::Hello(ClientHello {
+            protocol_version: 1,
+            client_name: "unit".to_owned(),
+            join_token: Vec::new(),
+        }),
+        MonoTimestamp::from_nanos(0),
+    );
+    match outcome.actions.as_slice() {
+        [
+            crate::SessionAction::SendToClient {
+                envelope: crate::OutboundMessage::Welcome(welcome),
+                ..
+            },
+        ] => welcome.session,
+        other => panic!("expected a single welcome, got {other:?}"),
+    }
+}
+
+/// A control frame for the motion scope at `generation`/`sequence`, sampled at
+/// `sampled_at`.
+pub(crate) fn frame(
+    session: SessionId,
+    generation: Generation,
+    sequence: SequenceNum,
+    sampled_at: MonoTimestamp,
+) -> ScopedControlFrame {
+    ScopedControlFrame {
+        session,
+        vehicle: VEHICLE,
+        scope: motion(),
+        generation,
+        sequence,
+        sampled_at,
+        profile_revision: 1,
+        payload: ControlPayload {
+            axes: vec![(LogicalAxisId::new(0), 0.25)],
+            edges: Vec::new(),
+        },
+    }
+}

--- a/crates/pilotage-session/src/tests/deadline.rs
+++ b/crates/pilotage-session/src/tests/deadline.rs
@@ -1,0 +1,46 @@
+//! Deadline pass-through: `next_deadline` and `handle_tick` delegate to the
+//! embedded authority engine.
+//!
+//! The increment-0 [`DomainEnvelope`] set carries no offer/accept handover
+//! messages (ADR-0010 two-phase handover is a later increment), so no offer is
+//! ever pending here: `next_deadline` reflects the authority engine's own
+//! `None`, and a tick produces no actions. These tests pin the delegation so a
+//! future increment that adds offers inherits correct scheduling behavior.
+//!
+//! [`DomainEnvelope`]: crate::DomainEnvelope
+
+use pilotage_timing::MonoTimestamp;
+
+use super::{VEHICLE, engine, motion, welcome};
+use crate::{ClientKey, DomainEnvelope};
+
+#[test]
+fn no_pending_offer_means_no_deadline() {
+    let engine = engine();
+    assert_eq!(engine.next_deadline(), None);
+}
+
+#[test]
+fn deadline_stays_none_after_a_grant() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let _granted = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(pilotage_protocol::LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(1),
+    );
+    // A direct grant does not open an offer, so there is nothing to expire.
+    assert_eq!(engine.next_deadline(), None);
+}
+
+#[test]
+fn tick_without_pending_offers_yields_no_actions() {
+    let mut engine = engine();
+    let outcome = engine.handle_tick(MonoTimestamp::from_nanos(1_000_000));
+    assert!(outcome.actions.is_empty());
+    assert_eq!(outcome.dropped, 0);
+}

--- a/crates/pilotage-session/src/tests/disconnect.rs
+++ b/crates/pilotage-session/src/tests/disconnect.rs
@@ -1,0 +1,177 @@
+//! Disconnect: a departing holder's scopes are released via the authority
+//! engine's link-loss path (ADR-0010).
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ExecutionMode, LinkLossPolicy, ScopeDescriptor, VehicleDescriptor,
+};
+use pilotage_authority::AuthorityEffect;
+use pilotage_protocol::{LeaseRequest, LogicalAxisId, ScopeId};
+use pilotage_timing::MonoTimestamp;
+
+use super::{VEHICLE, engine, motion, staleness, welcome};
+use crate::{ClientKey, DomainEnvelope, OutboundMessage, SessionAction, SessionConfig};
+
+fn lease_to(engine: &mut crate::SessionEngine, client: ClientKey) {
+    let _granted = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(pilotage_protocol::LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(1),
+    );
+}
+
+#[test]
+fn disconnect_releases_held_scope_and_broadcasts_link_lost() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    lease_to(&mut engine, client);
+
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+    // The link-loss path emits LinkStateChanged then HolderLinkLost, each as an
+    // authority broadcast.
+    let lost = outcome.actions.iter().any(|action| {
+        matches!(
+            action,
+            SessionAction::Broadcast {
+                envelope: OutboundMessage::Authority(AuthorityEffect::HolderLinkLost { .. }),
+            }
+        )
+    });
+    assert!(
+        lost,
+        "expected a HolderLinkLost broadcast, got {:?}",
+        outcome.actions
+    );
+    // Releasing one scope is well under the cap, so nothing is dropped.
+    assert_eq!(outcome.dropped, 0);
+}
+
+#[test]
+fn disconnect_of_non_holder_releases_nothing() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+    assert!(
+        outcome.actions.is_empty(),
+        "expected no releases, got {:?}",
+        outcome.actions
+    );
+}
+
+#[test]
+fn disconnect_of_unknown_client_is_a_no_op() {
+    let mut engine = engine();
+    let outcome = engine.handle_client_message(
+        ClientKey::new(99),
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+    assert!(outcome.actions.is_empty());
+}
+
+#[test]
+fn scope_is_grantable_again_after_holder_disconnects() {
+    let mut engine = engine();
+    let first = ClientKey::new(1);
+    let second = ClientKey::new(2);
+    welcome(&mut engine, first);
+    lease_to(&mut engine, first);
+    let _released = engine.handle_client_message(
+        first,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+
+    welcome(&mut engine, second);
+    let outcome = engine.handle_client_message(
+        second,
+        DomainEnvelope::Lease(pilotage_protocol::LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(6),
+    );
+    match outcome.actions.last() {
+        Some(SessionAction::SendToClient {
+            envelope: OutboundMessage::LeaseResponse(response),
+            ..
+        }) => assert!(response.granted, "re-grant after release should succeed"),
+        other => panic!("expected a granted lease, got {other:?}"),
+    }
+}
+
+/// A one-vehicle adapter exposing `scopes` distinct motion scopes.
+fn many_scope_capabilities(scopes: usize) -> AdapterCapabilities {
+    let scope_descriptors = (0..scopes)
+        .map(|i| ScopeDescriptor {
+            scope: ScopeId::new(format!("vehicle.motion.{i}")),
+            axes: vec![LogicalAxisId::new(0)],
+        })
+        .collect();
+    AdapterCapabilities {
+        execution: ExecutionMode {
+            real_time: true,
+            deterministic: true,
+            ..ExecutionMode::default()
+        },
+        vehicles: vec![VehicleDescriptor {
+            id: VEHICLE,
+            scopes: scope_descriptors,
+            link_loss_actions: vec![LinkLossPolicy::Neutralize],
+        }],
+        adapter_version: "test".to_owned(),
+    }
+}
+
+#[test]
+fn disconnect_dropping_link_lost_broadcasts_is_reported_not_silent() {
+    // Hold more scopes than the per-call cap admits, so a single disconnect's
+    // release fan-out exceeds the cap. The finding: without an observable drop
+    // count, authority state advances while `HolderLinkLost` broadcasts are
+    // silently truncated and clients never learn the released scopes.
+    let cap = 4;
+    let scopes = 8;
+    let mut engine = crate::SessionEngine::new(
+        many_scope_capabilities(scopes),
+        staleness(),
+        SessionConfig::new(1, "host-test").with_max_actions_per_call(cap),
+    );
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    for i in 0..scopes {
+        let _granted = engine.handle_client_message(
+            client,
+            DomainEnvelope::Lease(LeaseRequest {
+                vehicle: VEHICLE,
+                scope: ScopeId::new(format!("vehicle.motion.{i}")),
+            }),
+            MonoTimestamp::from_nanos(1),
+        );
+    }
+
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+    // The cap truncated the emitted actions...
+    assert_eq!(outcome.actions.len(), cap);
+    // ...and the truncation is reported, not silent (the finding's contract).
+    assert!(
+        outcome.dropped > 0,
+        "dropped link-lost broadcasts must be observable, got {}",
+        outcome.dropped
+    );
+}

--- a/crates/pilotage-session/src/tests/frame.rs
+++ b/crates/pilotage-session/src/tests/frame.rs
@@ -1,0 +1,179 @@
+//! Frames: accept a fresh in-generation frame, fence a stale generation,
+//! reject after release, reject an unknown scope, and reject a stale-age frame.
+
+use pilotage_protocol::{
+    FrameRejectionReason, Generation, ScopeId, ScopedControlFrame, SequenceNum,
+};
+use pilotage_timing::MonoTimestamp;
+
+use super::{VEHICLE, engine, frame, motion, welcome};
+use crate::{ClientKey, DomainEnvelope, SessionAction, SessionEngine};
+
+/// Welcomes `client`, leases the motion scope to it, and returns its session
+/// id (the scope is now `Held` at generation 1).
+fn welcomed_holder(engine: &mut SessionEngine, client: ClientKey) -> pilotage_protocol::SessionId {
+    let session = welcome(engine, client);
+    let _granted = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(pilotage_protocol::LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(1),
+    );
+    session
+}
+
+fn submit(
+    engine: &mut SessionEngine,
+    client: ClientKey,
+    frame: ScopedControlFrame,
+    now: MonoTimestamp,
+) -> Vec<SessionAction> {
+    engine
+        .handle_client_message(client, DomainEnvelope::Frame(frame), now)
+        .actions
+}
+
+#[test]
+fn in_generation_fresh_frame_is_applied_to_adapter() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    let session = welcomed_holder(&mut engine, client);
+    let frame = frame(
+        session,
+        Generation::new(1),
+        SequenceNum::new(0),
+        MonoTimestamp::from_nanos(1_000),
+    );
+    let actions = submit(&mut engine, client, frame, MonoTimestamp::from_nanos(1_010));
+    assert!(matches!(
+        actions.as_slice(),
+        [SessionAction::ApplyToAdapter { .. }]
+    ));
+}
+
+#[test]
+fn wrong_generation_frame_is_fenced() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    let session = welcomed_holder(&mut engine, client);
+    // The holder is at generation 1; a frame stamped generation 0 is stale.
+    let frame = frame(
+        session,
+        Generation::new(0),
+        SequenceNum::new(1),
+        MonoTimestamp::from_nanos(1_000),
+    );
+    let actions = submit(&mut engine, client, frame, MonoTimestamp::from_nanos(1_010));
+    match actions.as_slice() {
+        [SessionAction::RejectFrame { rejection, .. }] => {
+            assert_eq!(rejection.reason, FrameRejectionReason::StaleGeneration);
+            assert_eq!(rejection.current_generation.as_u64(), 1);
+        }
+        other => panic!("expected a stale-generation rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn frame_after_holder_release_is_rejected_no_holder() {
+    let mut engine = engine();
+    let holder = ClientKey::new(1);
+    let observer = ClientKey::new(2);
+    let session = welcomed_holder(&mut engine, holder);
+    // A second client sends the late frame so the engine still knows it (the
+    // holder itself is gone after disconnect). Both frames target the same
+    // scope, now unassigned with an advanced generation.
+    welcome(&mut engine, observer);
+    let _released = engine.handle_client_message(
+        holder,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(2_000),
+    );
+    let frame = frame(
+        session,
+        Generation::new(2),
+        SequenceNum::new(0),
+        MonoTimestamp::from_nanos(2_000),
+    );
+    let actions = submit(
+        &mut engine,
+        observer,
+        frame,
+        MonoTimestamp::from_nanos(2_010),
+    );
+    match actions.as_slice() {
+        [SessionAction::RejectFrame { rejection, .. }] => {
+            assert_eq!(rejection.reason, FrameRejectionReason::NoHolder);
+        }
+        other => panic!("expected a no-holder rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_holder_in_generation_frame_is_fenced() {
+    let mut engine = engine();
+    let holder = ClientKey::new(1);
+    let forger = ClientKey::new(2);
+    let session = welcomed_holder(&mut engine, holder);
+    // The forger completed the handshake but never leased the scope. It knows
+    // the current generation (grants are broadcast) and forges an in-generation
+    // frame. Fencing on identity must reject it rather than apply it.
+    welcome(&mut engine, forger);
+    let frame = frame(
+        session,
+        Generation::new(1),
+        SequenceNum::new(0),
+        MonoTimestamp::from_nanos(1_000),
+    );
+    let actions = submit(&mut engine, forger, frame, MonoTimestamp::from_nanos(1_010));
+    match actions.as_slice() {
+        [SessionAction::RejectFrame { rejection, .. }] => {
+            assert_eq!(rejection.reason, FrameRejectionReason::NoHolder);
+        }
+        other => panic!("expected a no-holder rejection for a non-holder, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_scope_frame_is_rejected() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    let mut frame = frame(
+        session,
+        Generation::new(0),
+        SequenceNum::new(0),
+        MonoTimestamp::from_nanos(0),
+    );
+    frame.scope = ScopeId::new("vehicle.ghost");
+    let actions = submit(&mut engine, client, frame, MonoTimestamp::from_nanos(10));
+    match actions.as_slice() {
+        [SessionAction::RejectFrame { rejection, .. }] => {
+            assert_eq!(rejection.reason, FrameRejectionReason::UnknownScope);
+        }
+        other => panic!("expected an unknown-scope rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn stale_age_frame_is_rejected_too_old() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    let session = welcomed_holder(&mut engine, client);
+    let frame = frame(
+        session,
+        Generation::new(1),
+        SequenceNum::new(0),
+        MonoTimestamp::from_nanos(0),
+    );
+    // 60 ms elapsed against a 50 ms policy: stale, rejected before fencing.
+    let now = MonoTimestamp::from_nanos(60_000_000);
+    let actions = submit(&mut engine, client, frame, now);
+    match actions.as_slice() {
+        [SessionAction::RejectFrame { rejection, .. }] => {
+            assert_eq!(rejection.reason, FrameRejectionReason::TooOld);
+        }
+        other => panic!("expected a too-old rejection, got {other:?}"),
+    }
+}

--- a/crates/pilotage-session/src/tests/handshake.rs
+++ b/crates/pilotage-session/src/tests/handshake.rs
@@ -1,0 +1,104 @@
+//! Handshake: hello answered with welcome; version and duplicate rejections.
+
+use pilotage_protocol::ClientHello;
+use pilotage_timing::MonoTimestamp;
+
+use super::{VEHICLE, engine, motion, welcome};
+use crate::{ClientKey, CloseReason, DomainEnvelope, OutboundMessage, SessionAction};
+
+fn hello(version: u32) -> DomainEnvelope {
+    DomainEnvelope::Hello(ClientHello {
+        protocol_version: version,
+        client_name: "unit".to_owned(),
+        join_token: Vec::new(),
+    })
+}
+
+#[test]
+fn hello_yields_welcome_with_capabilities_and_holders() {
+    let mut engine = engine();
+    let outcome =
+        engine.handle_client_message(ClientKey::new(1), hello(1), MonoTimestamp::from_nanos(0));
+    match outcome.actions.as_slice() {
+        [
+            SessionAction::SendToClient {
+                client,
+                envelope: OutboundMessage::Welcome(welcome),
+            },
+        ] => {
+            assert_eq!(*client, ClientKey::new(1));
+            assert_eq!(welcome.host_capabilities.host_version, "host-test");
+            assert_eq!(welcome.host_capabilities.vehicles.len(), 1);
+            // The lone scope starts unassigned at generation zero.
+            assert_eq!(welcome.scope_holders.len(), 1);
+            let snapshot = &welcome.scope_holders[0];
+            assert_eq!(snapshot.vehicle, VEHICLE);
+            assert_eq!(snapshot.scope, motion());
+            assert_eq!(snapshot.holder, None);
+            assert_eq!(snapshot.generation.as_u64(), 0);
+        }
+        other => panic!("expected a welcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn each_client_gets_a_distinct_session_and_principal() {
+    let mut engine = engine();
+    let first = welcome(&mut engine, ClientKey::new(1));
+    let second = welcome(&mut engine, ClientKey::new(2));
+    assert_ne!(first.as_u64(), second.as_u64());
+}
+
+#[test]
+fn stale_protocol_version_closes_the_connection() {
+    let mut engine = engine();
+    let outcome =
+        engine.handle_client_message(ClientKey::new(1), hello(0), MonoTimestamp::from_nanos(0));
+    match outcome.actions.as_slice() {
+        [
+            SessionAction::CloseClient {
+                reason: CloseReason::UnsupportedProtocolVersion { offered, required },
+                ..
+            },
+        ] => {
+            assert_eq!(*offered, 0);
+            assert_eq!(*required, 1);
+        }
+        other => panic!("expected an unsupported-version close, got {other:?}"),
+    }
+}
+
+#[test]
+fn second_hello_closes_the_connection() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let outcome = engine.handle_client_message(client, hello(1), MonoTimestamp::from_nanos(0));
+    assert!(matches!(
+        outcome.actions.as_slice(),
+        [SessionAction::CloseClient {
+            reason: CloseReason::DuplicateHello,
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn message_before_handshake_closes_the_connection() {
+    let mut engine = engine();
+    let outcome = engine.handle_client_message(
+        ClientKey::new(1),
+        DomainEnvelope::Lease(pilotage_protocol::LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(0),
+    );
+    assert!(matches!(
+        outcome.actions.as_slice(),
+        [SessionAction::CloseClient {
+            reason: CloseReason::HandshakeNotComplete,
+            ..
+        }]
+    ));
+}

--- a/crates/pilotage-session/src/tests/lease.rs
+++ b/crates/pilotage-session/src/tests/lease.rs
@@ -1,0 +1,135 @@
+//! Lease: grant emits a granted response plus an authority broadcast; a
+//! duplicate request by the holder re-affirms; another principal is denied.
+
+use pilotage_authority::AuthorityEffect;
+use pilotage_protocol::{LeaseDenialReason, LeaseRequest, ScopeId, VehicleId};
+use pilotage_timing::MonoTimestamp;
+
+use super::{VEHICLE, engine, motion, welcome};
+use crate::{ClientKey, DomainEnvelope, OutboundMessage, SessionAction};
+
+fn lease(vehicle: VehicleId, scope: ScopeId) -> DomainEnvelope {
+    DomainEnvelope::Lease(LeaseRequest { vehicle, scope })
+}
+
+fn request_lease(
+    engine: &mut crate::SessionEngine,
+    client: ClientKey,
+    vehicle: VehicleId,
+    scope: ScopeId,
+) -> Vec<SessionAction> {
+    engine
+        .handle_client_message(client, lease(vehicle, scope), MonoTimestamp::from_nanos(10))
+        .actions
+}
+
+#[test]
+fn grant_emits_broadcast_and_granted_response() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let actions = request_lease(&mut engine, client, VEHICLE, motion());
+
+    // A broadcast authority grant precedes the unicast lease response.
+    assert!(matches!(
+        actions.first(),
+        Some(SessionAction::Broadcast {
+            envelope: OutboundMessage::Authority(AuthorityEffect::ScopeLeaseGranted { .. }),
+        })
+    ));
+    match actions.last() {
+        Some(SessionAction::SendToClient {
+            envelope: OutboundMessage::LeaseResponse(response),
+            ..
+        }) => {
+            assert!(response.granted);
+            assert!(response.reason.is_none());
+            // Grant advances the generation off the registered zero.
+            assert_eq!(response.generation.as_u64(), 1);
+        }
+        other => panic!("expected a granted lease response, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_request_by_holder_reaffirms_without_new_broadcast() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    request_lease(&mut engine, client, VEHICLE, motion());
+    let actions = request_lease(&mut engine, client, VEHICLE, motion());
+    // No authority effect: the standing grant is simply re-reported.
+    match actions.as_slice() {
+        [
+            SessionAction::SendToClient {
+                envelope: OutboundMessage::LeaseResponse(response),
+                ..
+            },
+        ] => {
+            assert!(response.granted);
+            assert_eq!(response.generation.as_u64(), 1);
+        }
+        other => panic!("expected a lone re-affirmed grant, got {other:?}"),
+    }
+}
+
+#[test]
+fn request_by_another_principal_is_denied_already_held() {
+    let mut engine = engine();
+    let holder = ClientKey::new(1);
+    let other = ClientKey::new(2);
+    welcome(&mut engine, holder);
+    welcome(&mut engine, other);
+    request_lease(&mut engine, holder, VEHICLE, motion());
+    let actions = request_lease(&mut engine, other, VEHICLE, motion());
+    match actions.as_slice() {
+        [
+            SessionAction::SendToClient {
+                envelope: OutboundMessage::LeaseResponse(response),
+                ..
+            },
+        ] => {
+            assert!(!response.granted);
+            assert_eq!(response.reason, Some(LeaseDenialReason::AlreadyHeld));
+            assert_eq!(response.generation.as_u64(), 1);
+        }
+        other => panic!("expected an already-held denial, got {other:?}"),
+    }
+    // The holder must be unchanged: the original holder still re-affirms its
+    // own standing grant at the same generation, never a fresh grant that
+    // would imply `other`'s denied request mutated anything.
+    let reaffirm = request_lease(&mut engine, holder, VEHICLE, motion());
+    match reaffirm.as_slice() {
+        [
+            SessionAction::SendToClient {
+                envelope: OutboundMessage::LeaseResponse(response),
+                ..
+            },
+        ] => {
+            assert!(response.granted);
+            assert_eq!(response.reason, None);
+            assert_eq!(response.generation.as_u64(), 1);
+        }
+        other => panic!("expected the original holder's grant reaffirmed, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_scope_is_denied() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let actions = request_lease(&mut engine, client, VEHICLE, ScopeId::new("vehicle.ghost"));
+    match actions.as_slice() {
+        [
+            SessionAction::SendToClient {
+                envelope: OutboundMessage::LeaseResponse(response),
+                ..
+            },
+        ] => {
+            assert!(!response.granted);
+            assert_eq!(response.reason, Some(LeaseDenialReason::UnknownScope));
+        }
+        other => panic!("expected an unknown-scope denial, got {other:?}"),
+    }
+}

--- a/crates/pilotage-session/src/tests/ping.rs
+++ b/crates/pilotage-session/src/tests/ping.rs
@@ -1,0 +1,52 @@
+//! Ping/pong: the responder echoes the nonce and sender sample and stamps its
+//! own reply time (ADR-0009).
+
+use pilotage_protocol::Ping;
+use pilotage_timing::MonoTimestamp;
+
+use super::{engine, welcome};
+use crate::{ClientKey, DomainEnvelope, OutboundMessage, SessionAction};
+
+#[test]
+fn ping_yields_pong_echoing_nonce_and_stamping_responder_time() {
+    let mut engine = engine();
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    let ping = Ping {
+        nonce: 0xABCD,
+        sender_sent_at: MonoTimestamp::from_nanos(1_234),
+    };
+    let now = MonoTimestamp::from_nanos(9_999);
+    let outcome = engine.handle_client_message(client, DomainEnvelope::Ping(ping), now);
+    match outcome.actions.as_slice() {
+        [
+            SessionAction::SendToClient {
+                envelope: OutboundMessage::Pong(pong),
+                ..
+            },
+        ] => {
+            assert_eq!(pong.nonce, 0xABCD);
+            assert_eq!(pong.echoed_sender_sent_at.as_nanos(), 1_234);
+            assert_eq!(pong.responder_sent_at.as_nanos(), 9_999);
+        }
+        other => panic!("expected a pong, got {other:?}"),
+    }
+}
+
+#[test]
+fn ping_before_handshake_closes_the_connection() {
+    let mut engine = engine();
+    let ping = Ping {
+        nonce: 1,
+        sender_sent_at: MonoTimestamp::from_nanos(0),
+    };
+    let outcome = engine.handle_client_message(
+        ClientKey::new(1),
+        DomainEnvelope::Ping(ping),
+        MonoTimestamp::from_nanos(0),
+    );
+    assert!(matches!(
+        outcome.actions.as_slice(),
+        [SessionAction::CloseClient { .. }]
+    ));
+}

--- a/hosts/session-host/Cargo.toml
+++ b/hosts/session-host/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "pilotage-session-host"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+name = "pilotage_session_host"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pilotage-session-host"
+path = "src/main.rs"
+
+[dependencies]
+pilotage-session = { workspace = true }
+pilotage-protocol = { workspace = true }
+pilotage-authority = { workspace = true }
+pilotage-adapter-api = { workspace = true }
+pilotage-adapter-reference = { workspace = true }
+pilotage-timing = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "time", "sync", "net"] }
+wtransport = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+prost.workspace = true
+
+[dev-dependencies]
+pilotage-adapter-reference.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+wtransport = { workspace = true, features = ["dangerous-configuration"] }
+
+[lints]
+workspace = true

--- a/hosts/session-host/src/cli.rs
+++ b/hosts/session-host/src/cli.rs
@@ -1,0 +1,95 @@
+//! Minimal argument parsing for the session-host binary: `--port <PORT>`,
+//! defaulting to `0` (ephemeral, loopback-only bind).
+
+/// Parsed command-line configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CliArgs {
+    /// Port to bind on `127.0.0.1`. `0` asks the OS for an ephemeral port.
+    pub port: u16,
+}
+
+/// An error parsing command-line arguments.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CliError {
+    /// `--port` was given a value that does not parse as a `u16`.
+    #[error("invalid --port value {value:?}: {source}")]
+    InvalidPort {
+        /// The raw string the user supplied.
+        value: String,
+        /// The underlying parse failure.
+        #[source]
+        source: core::num::ParseIntError,
+    },
+    /// `--port` was given with no following value.
+    #[error("--port requires a value")]
+    MissingPortValue,
+    /// An argument was not recognized.
+    #[error("unrecognized argument: {0}")]
+    Unrecognized(String),
+}
+
+/// Parses `args` (excluding the program name) into [`CliArgs`].
+///
+/// # Errors
+///
+/// Returns [`CliError`] for a malformed or unrecognized `--port` argument.
+pub fn parse_args(args: &[String]) -> Result<CliArgs, CliError> {
+    let mut port: u16 = 0;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--port" => {
+                let value = iter.next().ok_or(CliError::MissingPortValue)?;
+                port = value.parse().map_err(|source| CliError::InvalidPort {
+                    value: value.clone(),
+                    source,
+                })?;
+            }
+            other => return Err(CliError::Unrecognized(other.to_owned())),
+        }
+    }
+    Ok(CliArgs { port })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{CliError, parse_args};
+
+    #[test]
+    fn no_args_defaults_to_ephemeral_port() {
+        let parsed = parse_args(&[]).expect("empty args parse");
+        assert_eq!(parsed.port, 0);
+    }
+
+    #[test]
+    fn explicit_port_parses() {
+        let args = vec!["--port".to_owned(), "4433".to_owned()];
+        let parsed = parse_args(&args).expect("valid port parses");
+        assert_eq!(parsed.port, 4433);
+    }
+
+    #[test]
+    fn missing_port_value_is_an_error() {
+        let args = vec!["--port".to_owned()];
+        assert_eq!(parse_args(&args), Err(CliError::MissingPortValue));
+    }
+
+    #[test]
+    fn non_numeric_port_is_an_error() {
+        let args = vec!["--port".to_owned(), "not-a-port".to_owned()];
+        assert!(matches!(
+            parse_args(&args),
+            Err(CliError::InvalidPort { .. })
+        ));
+    }
+
+    #[test]
+    fn unrecognized_argument_is_an_error() {
+        let args = vec!["--bogus".to_owned()];
+        assert_eq!(
+            parse_args(&args),
+            Err(CliError::Unrecognized("--bogus".to_owned()))
+        );
+    }
+}

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -1,0 +1,24 @@
+//! Typed errors for the session-host binary (ADR-0015: no `anyhow` in
+//! library or binary code, typed `thiserror` enums throughout).
+
+use crate::cli::CliError;
+
+/// Failures that can prevent the session host from starting or running.
+#[derive(Debug, thiserror::Error)]
+pub enum HostError {
+    /// Command-line arguments were malformed.
+    #[error("invalid command-line arguments: {0}")]
+    Cli(#[source] CliError),
+    /// Building the self-signed TLS identity for loopback development failed.
+    #[error("failed to build self-signed identity: {0}")]
+    Identity(#[source] wtransport::tls::error::InvalidSan),
+    /// Binding or constructing the WebTransport server endpoint failed.
+    #[error("failed to construct server endpoint: {0}")]
+    Endpoint(#[source] std::io::Error),
+    /// Reading the bound local address back from the endpoint failed.
+    #[error("failed to read local address from endpoint: {0}")]
+    LocalAddr(#[source] std::io::Error),
+    /// Constructing the tokio runtime failed.
+    #[error("failed to build the tokio runtime: {0}")]
+    Runtime(#[source] std::io::Error),
+}

--- a/hosts/session-host/src/lib.rs
+++ b/hosts/session-host/src/lib.rs
@@ -1,0 +1,13 @@
+//! `pilotage-session-host`: a tokio + WebTransport binary embedding
+//! [`pilotage_session::SessionEngine`] and the reference adapter (ADR-0005).
+//!
+//! All decision logic (handshake, lease, fencing, staleness, authority) lives
+//! in `pilotage-session`; this crate is transport plumbing plus process
+//! lifecycle. [`runtime::start`] is the entry point both `main` and the
+//! in-process loopback integration test use.
+
+pub mod cli;
+pub mod error;
+pub mod output;
+pub mod runtime;
+pub mod tls_identity;

--- a/hosts/session-host/src/main.rs
+++ b/hosts/session-host/src/main.rs
@@ -1,0 +1,41 @@
+//! Binary entry point for `pilotage-session-host`; see the crate root
+//! (`lib.rs`) for the module overview.
+
+use std::process::ExitCode;
+
+use pilotage_session_host::error::HostError;
+use pilotage_session_host::{cli, runtime};
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(%error, "session host exited with an error");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Parses arguments, builds the tokio runtime, and runs the host until
+/// `ctrl_c`.
+///
+/// # Errors
+///
+/// Returns [`HostError`] if argument parsing or startup fails.
+fn run(args: &[String]) -> Result<(), HostError> {
+    let cli_args = cli::parse_args(args).map_err(HostError::Cli)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(HostError::Runtime)?;
+    runtime.block_on(async move {
+        let host = runtime::start(cli_args.port)?;
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            tracing::error!(%error, "failed to listen for ctrl_c");
+        }
+        host.shutdown().await;
+        Ok(())
+    })
+}

--- a/hosts/session-host/src/output.rs
+++ b/hosts/session-host/src/output.rs
@@ -1,0 +1,18 @@
+//! The single sanctioned place this binary writes to stdout.
+//!
+//! `disallowed_macros` (ADR-0015) bans bare `println!`/`eprintln!` everywhere
+//! else in the workspace so library crates never accidentally grow CLI side
+//! effects. This module is the CLI-product-output exception the lint rule
+//! anticipates: the `LISTENING <port> <cert-hash-hex>` line is a
+//! machine-readable startup contract a wrapping process parses, not a
+//! diagnostic trace (diagnostics go through `tracing` everywhere else in this
+//! binary).
+
+/// Writes one line of machine-readable startup output to stdout.
+// WHY: this is the host's actual product contract for scripts/tests waiting
+// on startup, not a debug trace, so the workspace-wide println ban is waived
+// here and nowhere else in this binary.
+#[allow(clippy::disallowed_macros)]
+pub fn print_line(line: &str) {
+    println!("{line}");
+}

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -1,0 +1,253 @@
+//! Top-level orchestration: builds the WebTransport endpoint, the embedded
+//! [`SessionEngine`]/adapter, and wires accept, engine-actor, and shutdown
+//! tasks together (ADR-0002, ADR-0005).
+//!
+//! [`SessionEngine`]: pilotage_session::SessionEngine
+
+mod connection;
+mod engine_actor;
+mod registry;
+mod shutdown;
+mod wire_codec;
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use pilotage_adapter_api::VehicleAdapter;
+use pilotage_adapter_reference::ReferenceAdapter;
+use pilotage_protocol::VehicleId;
+use pilotage_session::{ClientKey, SessionConfig, SessionEngine};
+use pilotage_timing::StalenessPolicy;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
+use tracing::{info, warn};
+use wtransport::{Endpoint, Identity, ServerConfig};
+
+use crate::error::HostError;
+use crate::output::print_line;
+use crate::tls_identity::build_dev_identity;
+use engine_actor::{ENGINE_QUEUE_CAPACITY, EngineActor, ToEngine};
+
+/// The vehicle the embedded reference adapter drives in this increment.
+const HOST_VEHICLE: VehicleId = VehicleId::new(1);
+
+/// Deterministic seed for the embedded reference adapter's initial state.
+const ADAPTER_SEED: u64 = 0;
+
+/// Maximum age a control frame may have before the engine rejects it as
+/// stale (ADR-0009). Generous for loopback development.
+const MAX_CONTROL_AGE: Duration = Duration::from_millis(250);
+
+/// A running session host: its bound local address and a handle to request
+/// shutdown and await full teardown.
+pub struct RunningHost {
+    /// The address the WebTransport endpoint is actually bound to (useful
+    /// when constructed with an ephemeral `--port 0`).
+    pub local_addr: SocketAddr,
+    /// The self-signed certificate's hex SHA-256 digest, as printed on the
+    /// `LISTENING` line.
+    pub cert_hash_hex: String,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+impl RunningHost {
+    /// Signals the host to shut down and waits for full teardown.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            // A closed receiver means `run_until_shutdown` already exited
+            // (e.g. it panicked); nothing left to signal.
+            tx.send(()).ok();
+        }
+        // A join error here is a panic in `run_until_shutdown` itself,
+        // already logged by tokio; shutdown has nothing further to do with
+        // it.
+        self.join.await.ok();
+    }
+}
+
+/// Builds the embedded [`SessionEngine`] and [`ReferenceAdapter`] pair this
+/// increment's host serves.
+fn build_engine_and_adapter() -> (SessionEngine, ReferenceAdapter) {
+    let adapter = ReferenceAdapter::from_seed(HOST_VEHICLE, ADAPTER_SEED);
+    let capabilities = adapter.capabilities();
+    let staleness = StalenessPolicy::new(MAX_CONTROL_AGE);
+    let config = SessionConfig::new(pilotage_protocol::SCHEMA_VERSION, env!("CARGO_PKG_VERSION"));
+    let engine = SessionEngine::new(capabilities, staleness, config);
+    (engine, adapter)
+}
+
+/// Starts the session host bound to `127.0.0.1:port` (`0` for an OS-assigned
+/// ephemeral port), prints the `LISTENING` line, and returns a handle for
+/// shutdown.
+///
+/// # Errors
+///
+/// Returns [`HostError`] if the TLS identity cannot be built or the
+/// WebTransport endpoint cannot bind.
+pub fn start(port: u16) -> Result<RunningHost, HostError> {
+    let dev_identity = build_dev_identity()?;
+    let identity: Identity = dev_identity.identity;
+    let cert_hash_hex = dev_identity.cert_hash_hex.clone();
+
+    let config = ServerConfig::builder()
+        .with_bind_default(port)
+        .with_identity(identity)
+        .keep_alive_interval(Some(Duration::from_secs(3)))
+        .build();
+    let endpoint = Endpoint::server(config).map_err(HostError::Endpoint)?;
+    let local_addr = endpoint.local_addr().map_err(HostError::LocalAddr)?;
+
+    print_line(&format!(
+        "LISTENING {} {}",
+        local_addr.port(),
+        cert_hash_hex
+    ));
+
+    let (engine, adapter) = build_engine_and_adapter();
+    let (engine_tx, engine_rx) = mpsc::channel::<ToEngine>(ENGINE_QUEUE_CAPACITY);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let join = tokio::spawn(run_until_shutdown(
+        endpoint,
+        engine,
+        adapter,
+        engine_tx,
+        engine_rx,
+        shutdown_rx,
+    ));
+
+    Ok(RunningHost {
+        local_addr,
+        cert_hash_hex,
+        shutdown_tx: Some(shutdown_tx),
+        join,
+    })
+}
+
+/// Runs the accept loop and engine actor until `shutdown_rx` fires, then
+/// tears down every spawned task (engine actor, accept loop, and every
+/// per-connection task) within the shutdown timeout.
+async fn run_until_shutdown(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine: SessionEngine,
+    adapter: ReferenceAdapter,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+) {
+    // A single monotonic origin feeds every `host_time` comparison across
+    // the host (ADR-0009): client-message receive stamps (via `accept_loop`
+    // and each connection task) and the engine actor's tick/offer-expiry
+    // stamps must derive from the same `Instant`, or the two streams of
+    // timestamps drift apart and skew staleness/expiry comparisons.
+    let start = tokio::time::Instant::now();
+
+    let mut tasks = JoinSet::new();
+    tasks.spawn(named_task(
+        "engine-actor",
+        EngineActor::new(engine, adapter, start).run(engine_rx),
+    ));
+
+    tokio::select! {
+        () = accept_loop(&endpoint, &engine_tx, &mut tasks, start) => {}
+        result = shutdown_rx => {
+            // A dropped sender (host caller gone without an explicit
+            // shutdown) is treated the same as an explicit signal, so
+            // `.ok()` discards the distinction intentionally.
+            result.ok();
+        }
+    }
+    info!("shutdown requested");
+    dump_latency_summary(&engine_tx).await;
+    drop(engine_tx);
+    endpoint.close(
+        wtransport::VarInt::from_u32(0),
+        b"session host shutting down",
+    );
+    shutdown::join_with_timeout(tasks).await;
+}
+
+/// Requests and logs the engine actor's per-stage latency summary
+/// (ADR-0009), best-effort: a reply that never arrives (actor already gone)
+/// is not itself a shutdown failure.
+async fn dump_latency_summary(engine_tx: &mpsc::Sender<ToEngine>) {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if engine_tx
+        .send(ToEngine::DumpLatencySummary { reply: reply_tx })
+        .await
+        .is_err()
+    {
+        return;
+    }
+    if let Ok(summary) = reply_rx.await {
+        info!(%summary, "latency summary at shutdown");
+    }
+}
+
+/// Accepts incoming WebTransport sessions forever, spawning one connection
+/// task per accepted session into `tasks` so shutdown can wait on and, if
+/// needed, abort them alongside the engine actor.
+async fn accept_loop(
+    endpoint: &Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine_tx: &mpsc::Sender<ToEngine>,
+    tasks: &mut JoinSet<()>,
+    start: tokio::time::Instant,
+) {
+    let next_client = AtomicU64::new(0);
+    loop {
+        let incoming = endpoint.accept().await;
+        // Harvest every connection task that finished since the last accept so
+        // the JoinSet does not retain completed JoinHandles for the process
+        // lifetime; without this the set grows unbounded with connection count
+        // (ADR-0015). A panicked connection task is logged, not propagated: one
+        // bad connection must not take down the accept loop.
+        while let Some(joined) = tasks.try_join_next() {
+            if let Err(error) = joined
+                && !error.is_cancelled()
+            {
+                warn!(%error, "connection task panicked");
+            }
+        }
+        let engine_tx = engine_tx.clone();
+        let client = ClientKey::new(next_client.fetch_add(1, Ordering::Relaxed));
+        tasks.spawn(named_task(
+            "connection",
+            accept_and_run(incoming, client, start, engine_tx),
+        ));
+    }
+}
+
+/// Completes one incoming session's handshake and drives its connection
+/// task, logging (rather than propagating) a failed handshake since one
+/// bad connection must not take down the accept loop.
+async fn accept_and_run(
+    incoming: wtransport::endpoint::IncomingSession,
+    client: ClientKey,
+    start: tokio::time::Instant,
+    engine_tx: mpsc::Sender<ToEngine>,
+) {
+    let session_request = match incoming.await {
+        Ok(request) => request,
+        Err(error) => {
+            warn!(%error, "incoming session request failed");
+            return;
+        }
+    };
+    let connection = match session_request.accept().await {
+        Ok(connection) => connection,
+        Err(error) => {
+            warn!(%error, "session accept failed");
+            return;
+        }
+    };
+    connection::run_connection(connection, client, start, engine_tx).await;
+}
+
+/// Wraps a future so its exit is logged by name (ADR-0015: critical tasks
+/// get a name, so the shutdown log's straggler report is legible).
+async fn named_task(name: &'static str, future: impl std::future::Future<Output = ()>) {
+    future.await;
+    tracing::debug!(task = name, "task exited");
+}

--- a/hosts/session-host/src/runtime/connection.rs
+++ b/hosts/session-host/src/runtime/connection.rs
@@ -1,0 +1,409 @@
+//! Per-connection transport plumbing: decodes inbound bytes into
+//! [`DomainEnvelope`]s for the engine actor and writes the engine's decided
+//! [`OutboundMessage`]s/datagrams back onto the wire (ADR-0005).
+//!
+//! One task per connected client, internally split into a reader half (the
+//! bootstrap bidi stream's recv side plus datagrams) and a writer half (the
+//! bootstrap bidi stream's send side plus the dedicated authority-events uni
+//! stream), driven concurrently so a backpressured write can never stall
+//! inbound control-frame or datagram servicing (ADR-0005/0011: no head-of-line
+//! blocking between classes). The engine actor never touches transport types
+//! directly, keeping [`SessionEngine`] sans-IO.
+//!
+//! [`SessionEngine`]: pilotage_session::SessionEngine
+
+use pilotage_session::{ClientKey, DomainEnvelope};
+use pilotage_timing::MonoTimestamp;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+use tracing::{debug, error, warn};
+use wtransport::error::SendDatagramError;
+use wtransport::{Connection, RecvStream, SendStream};
+
+use crate::runtime::engine_actor::ToEngine;
+use crate::runtime::registry::OUTBOUND_QUEUE_CAPACITY;
+use crate::runtime::wire_codec::{
+    OversizedFrame, complete_frame_len, decode_bootstrap_message, decode_control_datagram,
+    decode_ping_datagram,
+};
+
+/// The ADR-0011 message class a datagram send belongs to, carried so a failed
+/// transport-level send is counted and first-logged against the right class
+/// (ADR-0009/0011: drops are counted per class, never silent).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatagramClass {
+    /// Best-effort telemetry fanned out at tick cadence.
+    Telemetry,
+    /// A `Pong` reply to a client's `Ping` (RTT probe, ADR-0009).
+    Pong,
+    /// A `FrameRejected` notice returned to a rejected frame's sender.
+    FrameRejected,
+}
+
+impl DatagramClass {
+    /// Stable label for structured logging and the per-class counter table.
+    fn as_str(self) -> &'static str {
+        match self {
+            DatagramClass::Telemetry => "telemetry",
+            DatagramClass::Pong => "pong",
+            DatagramClass::FrameRejected => "frame_rejected",
+        }
+    }
+}
+
+/// One message the engine actor asks a connection task to write out.
+#[derive(Debug, Clone)]
+pub enum ToConnection {
+    /// Bytes to write, length-delimited, on the bootstrap stream (unicast
+    /// handshake/lease/`Pong` replies only — never authority events,
+    /// ADR-0005's dedicated authority-events stream).
+    BootstrapMessage(Vec<u8>),
+    /// Bytes to write, length-delimited, on the dedicated authority-events
+    /// stream (ADR-0005: reliable ordered, no head-of-line contention with
+    /// bootstrap/bulk traffic).
+    AuthorityMessage(Vec<u8>),
+    /// Bytes to send as a single datagram, tagged with the ADR-0011 class a
+    /// failed send is counted against.
+    Datagram {
+        /// The datagram's message class, for per-class drop accounting.
+        class: DatagramClass,
+        /// The encoded datagram payload.
+        bytes: Vec<u8>,
+    },
+    /// The engine asked this connection to close.
+    Close,
+}
+
+/// Drives one accepted WebTransport connection until it closes or the engine
+/// asks it to close: opens the dedicated authority-events uni stream, then
+/// runs the reader half (bootstrap-stream reads and datagrams) and the
+/// writer half (bootstrap-stream and authority-stream writes plus datagram
+/// sends) concurrently until either exits.
+pub async fn run_connection(
+    connection: Connection,
+    client: ClientKey,
+    start: Instant,
+    to_engine: mpsc::Sender<ToEngine>,
+) {
+    let (send, recv) = match connection.accept_bi().await {
+        Ok(streams) => streams,
+        Err(error) => {
+            warn!(%error, "client did not open the bootstrap bidirectional stream");
+            return;
+        }
+    };
+    let authority_send = match connection.open_uni().await {
+        Ok(opening) => match opening.await {
+            Ok(stream) => stream,
+            Err(error) => {
+                warn!(%error, "authority-events stream failed to open");
+                return;
+            }
+        },
+        Err(error) => {
+            warn!(%error, "failed to request authority-events stream");
+            return;
+        }
+    };
+
+    let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+    if to_engine
+        .send(ToEngine::ClientConnected {
+            client,
+            sender: outbound_tx,
+        })
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    tokio::select! {
+        () = run_reader(&connection, recv, client, start, &to_engine) => {}
+        () = run_writer(&connection, send, authority_send, outbound_rx) => {}
+    }
+
+    forward(&to_engine, client, DomainEnvelope::Disconnect, start).await;
+}
+
+/// Services inbound bootstrap-stream reads and datagrams until the
+/// connection closes, forwarding each decoded message to the engine actor.
+///
+/// Kept as its own future (not interleaved with outbound writes in one
+/// `select!`) so a client that never drains its receive side cannot starve
+/// this side's servicing of fresh control datagrams (finding: a
+/// `send.write_all().await` sharing a select arm with `recv`/datagram would
+/// park both while the write stalls).
+async fn run_reader(
+    connection: &Connection,
+    mut recv: RecvStream,
+    client: ClientKey,
+    start: Instant,
+    to_engine: &mpsc::Sender<ToEngine>,
+) {
+    let mut read_buf = vec![0u8; 64 * 1024];
+    let mut pending = Vec::new();
+    // Reconciles the client's `sampled_at` epoch with this host's `host_time`
+    // (ADR-0009): the two processes each count nanoseconds from their own
+    // arbitrary monotonic origin, so a raw `now - sampled_at` measures the gap
+    // between those origins, not frame age. The first control frame defines
+    // the offset; every later frame's age then reflects true in-session drift.
+    // The proper networked path replaces this with RTT/offset estimation
+    // (`pilotage_timing::estimated_age`); this is the loopback shortcut the
+    // sans-IO engine's staleness check assumes.
+    let mut clock = ClientClock::default();
+    loop {
+        tokio::select! {
+            read = recv.read(&mut read_buf) => {
+                match read {
+                    Ok(Some(count)) => {
+                        pending.extend_from_slice(&read_buf[..count]);
+                        if let Err(error) =
+                            drain_bootstrap_frames(&mut pending, client, start, to_engine).await
+                        {
+                            warn!(%error, "closing connection: oversized bootstrap frame");
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(error) => {
+                        warn!(%error, "bootstrap stream read failed");
+                        break;
+                    }
+                }
+            }
+            datagram = connection.receive_datagram() => {
+                match datagram {
+                    Ok(datagram) => {
+                        handle_datagram(&datagram, client, start, &mut clock, to_engine).await;
+                    }
+                    Err(error) => {
+                        debug!(%error, "connection closed while awaiting datagram");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Per-connection reconciliation of a client's control-frame `sampled_at`
+/// epoch into this host's `host_time` domain (ADR-0009's loopback shortcut).
+///
+/// The client and host each stamp monotonic nanoseconds from an independent,
+/// arbitrary origin. `offset_nanos` is `host_now - sampled_at` captured from
+/// the first control frame; adding it to every subsequent frame's `sampled_at`
+/// expresses the sample time in host nanoseconds, so the engine's
+/// `now - sampled_at` staleness check sees true in-session age instead of the
+/// fixed gap between the two origins.
+#[derive(Debug, Default)]
+struct ClientClock {
+    offset_nanos: Option<i128>,
+}
+
+impl ClientClock {
+    /// Returns `sampled` shifted into host time, establishing the offset from
+    /// the first frame seen so that frame reads as age zero.
+    fn rebase(&mut self, now: MonoTimestamp, sampled: MonoTimestamp) -> MonoTimestamp {
+        let offset = *self
+            .offset_nanos
+            .get_or_insert_with(|| i128::from(now.as_nanos()) - i128::from(sampled.as_nanos()));
+        let shifted = i128::from(sampled.as_nanos()).saturating_add(offset).max(0);
+        MonoTimestamp::from_nanos(u64::try_from(shifted).unwrap_or(u64::MAX))
+    }
+}
+
+/// Services the engine actor's outbound queue until it closes or a write
+/// fails, writing bootstrap-stream and authority-stream messages and sending
+/// datagrams. Runs independently of [`run_reader`] so a slow/backpressured
+/// write never delays servicing the read side.
+async fn run_writer(
+    connection: &Connection,
+    mut send: SendStream,
+    mut authority_send: SendStream,
+    mut outbound_rx: mpsc::Receiver<ToConnection>,
+) {
+    let mut datagram_drops = DatagramDropCounters::default();
+    while let Some(message) = outbound_rx.recv().await {
+        match message {
+            ToConnection::BootstrapMessage(bytes) => {
+                if send.write_all(&bytes).await.is_err() {
+                    break;
+                }
+            }
+            ToConnection::AuthorityMessage(bytes) => {
+                if authority_send.write_all(&bytes).await.is_err() {
+                    break;
+                }
+            }
+            ToConnection::Datagram { class, bytes } => {
+                send_datagram_counted(connection, class, bytes, &mut datagram_drops);
+            }
+            ToConnection::Close => break,
+        }
+    }
+}
+
+/// Per-connection, per-datagram-class counters for transport-level send
+/// failures, so a dropped telemetry/`Pong`/`FrameRejected` datagram is counted
+/// against its own class and never silently discarded (ADR-0009/0011: drops
+/// are counted per class).
+#[derive(Debug, Default)]
+struct DatagramDropCounters {
+    telemetry: u64,
+    pong: u64,
+    frame_rejected: u64,
+}
+
+impl DatagramDropCounters {
+    /// Records one drop for `class`, returning the class's running total.
+    fn record(&mut self, class: DatagramClass) -> u64 {
+        let counter = match class {
+            DatagramClass::Telemetry => &mut self.telemetry,
+            DatagramClass::Pong => &mut self.pong,
+            DatagramClass::FrameRejected => &mut self.frame_rejected,
+        };
+        *counter = counter.wrapping_add(1);
+        *counter
+    }
+}
+
+/// Sends one datagram on `connection`, counting and logging a failed send
+/// rather than silently discarding it (ADR-0009: "drops are counted, never
+/// silent" applies to transport-level datagram loss, not only the mpsc-full
+/// case the engine actor already counts).
+///
+/// The first drop of each class is logged at `error` (a class that cannot send
+/// at all is a genuine fault worth surfacing loudly once per connection);
+/// subsequent drops of that class stay at `warn` so a persistently-too-large
+/// or disconnected peer does not flood the log.
+fn send_datagram_counted(
+    connection: &Connection,
+    class: DatagramClass,
+    bytes: Vec<u8>,
+    drops: &mut DatagramDropCounters,
+) {
+    let Err(error) = connection.send_datagram(bytes) else {
+        return;
+    };
+    let total = drops.record(class);
+    let detail = match error {
+        SendDatagramError::TooLarge => {
+            "payload exceeds connection's datagram size limit".to_owned()
+        }
+        SendDatagramError::NotConnected | SendDatagramError::UnsupportedByPeer => error.to_string(),
+    };
+    if total == 1 {
+        error!(
+            class = class.as_str(),
+            total_dropped = total,
+            detail,
+            "datagram send dropped (first for this class on this connection)"
+        );
+    } else {
+        warn!(
+            class = class.as_str(),
+            total_dropped = total,
+            detail,
+            "datagram send dropped"
+        );
+    }
+}
+
+/// Sends one decoded message to the engine actor, discarding a closed-actor
+/// send failure intentionally: the connection task is tearing down either
+/// way, and there is no reply path to report the failure to.
+async fn forward(
+    to_engine: &mpsc::Sender<ToEngine>,
+    client: ClientKey,
+    message: DomainEnvelope,
+    start: Instant,
+) {
+    forward_at(to_engine, client, message, now_from(start)).await;
+}
+
+/// Like [`forward`], but with an already-sampled receive timestamp, so a
+/// caller that must consult `now` before forwarding (control frames, whose
+/// `sampled_at` is rebased against it) does not sample the clock twice and
+/// compare a frame against a `now` a few microseconds later than the one it
+/// was rebased against.
+async fn forward_at(
+    to_engine: &mpsc::Sender<ToEngine>,
+    client: ClientKey,
+    message: DomainEnvelope,
+    now: MonoTimestamp,
+) {
+    to_engine
+        .send(ToEngine::ClientMessage {
+            client,
+            message,
+            now,
+        })
+        .await
+        .ok();
+}
+
+/// Decodes as many complete length-delimited envelopes as `pending` holds,
+/// forwarding each to the engine actor and leaving any partial tail buffered.
+///
+/// [`complete_frame_len`] gates each iteration on a full frame being
+/// buffered, so a decode failure past that point is a genuinely malformed
+/// envelope rather than a stream read landing mid-frame.
+///
+/// Returns `Err` when a client declares a frame larger than
+/// [`MAX_BOOTSTRAP_FRAME_LEN`]; the caller closes the connection instead of
+/// letting `pending` grow toward the attacker-chosen size.
+async fn drain_bootstrap_frames(
+    pending: &mut Vec<u8>,
+    client: ClientKey,
+    start: Instant,
+    to_engine: &mpsc::Sender<ToEngine>,
+) -> Result<(), OversizedFrame> {
+    loop {
+        let frame_len = match complete_frame_len(pending)? {
+            Some(frame_len) => frame_len,
+            None => return Ok(()),
+        };
+        match decode_bootstrap_message(&pending[..frame_len]) {
+            Ok((message, _rest)) => {
+                forward(to_engine, client, message, start).await;
+            }
+            Err(error) => {
+                warn!(%error, "dropping malformed bootstrap-stream envelope");
+            }
+        }
+        pending.drain(..frame_len);
+    }
+}
+
+/// Decodes one datagram as either a control frame or a `Ping`, forwarding the
+/// decoded message to the engine actor (control frames) or answering
+/// directly (`Ping`, which is a pure echo the connection task can compute
+/// without a round trip through the engine).
+async fn handle_datagram(
+    payload: &[u8],
+    client: ClientKey,
+    start: Instant,
+    clock: &mut ClientClock,
+    to_engine: &mpsc::Sender<ToEngine>,
+) {
+    if let Ok(mut frame) = decode_control_datagram(payload) {
+        let now = now_from(start);
+        frame.sampled_at = clock.rebase(now, frame.sampled_at);
+        forward_at(to_engine, client, DomainEnvelope::Frame(frame), now).await;
+        return;
+    }
+    if let Ok(ping) = decode_ping_datagram(payload) {
+        // The Pong reply flows back through the engine actor (SendToClient
+        // action, ADR-0009's responder-time stamp comes from the driver's
+        // shared clock), so this task only forwards the decoded `Ping`.
+        forward(to_engine, client, DomainEnvelope::Ping(ping), start).await;
+        return;
+    }
+    debug!("dropping unrecognized datagram payload");
+}
+
+fn now_from(start: Instant) -> MonoTimestamp {
+    let nanos = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    MonoTimestamp::from_nanos(nanos)
+}

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -1,0 +1,471 @@
+//! The single task owning [`SessionEngine`] and the embedded reference
+//! adapter (ADR-0002, ADR-0005): every connection task funnels decoded
+//! messages here instead of touching engine state directly, so the state
+//! machine is driven from exactly one place.
+
+use std::time::Duration;
+
+use pilotage_adapter_api::{StepBudget, VehicleAdapter};
+use pilotage_adapter_reference::ReferenceAdapter;
+use pilotage_protocol::wire;
+use pilotage_session::{ClientKey, DomainEnvelope, SessionAction, SessionEngine, SessionOutcome};
+use pilotage_timing::{BoundedLatencyLog, MonoTimestamp, Stage, StageLatency};
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+use tracing::{debug, error, info, warn};
+
+use crate::runtime::connection::{DatagramClass, ToConnection};
+use crate::runtime::registry::ClientRegistry;
+use crate::runtime::wire_codec::{
+    encode_envelope_message, encode_pong_datagram, encode_telemetry_datagram,
+};
+
+/// Capacity of the [`EngineActor`]'s inbound command queue.
+///
+/// Bounded per ADR-0009's discipline: a lagging engine actor is a
+/// correctness signal (dropped commands are counted below), never silent
+/// backpressure.
+pub const ENGINE_QUEUE_CAPACITY: usize = 1024;
+
+/// How often the embedded adapter is stepped and telemetry broadcast
+/// (ADR-0005, ADR-0009's control/telemetry cadence).
+pub const TICK_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Capacity of the per-stage latency ring buffer dumped at shutdown.
+const LATENCY_LOG_CAPACITY: usize = 4096;
+
+/// The ADR-0011 message classes the engine actor fans messages out as, for
+/// per-class drop accounting (ADR-0009: "drops are counted, never silent";
+/// ADR-0011: "drops are counted per class").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MessageClass {
+    /// A unicast reply to one client (bootstrap/session state or `Pong`).
+    Unicast,
+    /// A reliable, ordered authority/mode-change broadcast.
+    AuthorityBroadcast,
+    /// Best-effort telemetry, fanned out at tick cadence.
+    Telemetry,
+}
+
+/// Wrapping per-class counters for messages dropped because a client's
+/// outbound queue could not accept them without blocking the actor task.
+#[derive(Debug, Default)]
+struct DropCounters {
+    unicast: u64,
+    authority_broadcast: u64,
+    telemetry: u64,
+}
+
+impl DropCounters {
+    fn record(&mut self, class: MessageClass) -> u64 {
+        let counter = match class {
+            MessageClass::Unicast => &mut self.unicast,
+            MessageClass::AuthorityBroadcast => &mut self.authority_broadcast,
+            MessageClass::Telemetry => &mut self.telemetry,
+        };
+        *counter = counter.wrapping_add(1);
+        *counter
+    }
+}
+
+/// One command a connection task submits to the engine actor.
+#[derive(Debug)]
+pub enum ToEngine {
+    /// A client connected; the actor should register its outbound sender in
+    /// the client registry keyed on `client`.
+    ClientConnected {
+        /// Driver-assigned key for the new connection.
+        client: ClientKey,
+        /// Outbound sender the actor unicasts/broadcasts through.
+        sender: mpsc::Sender<ToConnection>,
+    },
+    /// A decoded client message ready for [`SessionEngine::handle_client_message`].
+    ClientMessage {
+        /// Sender of the message.
+        client: ClientKey,
+        /// The decoded message.
+        message: DomainEnvelope,
+        /// The driver's receive timestamp, for staleness/latency accounting.
+        now: MonoTimestamp,
+    },
+    /// A one-shot latency summary request, used by the shutdown path to log
+    /// the accumulated per-stage timings before the process exits.
+    DumpLatencySummary {
+        /// Where to send the formatted summary line.
+        reply: oneshot::Sender<String>,
+    },
+}
+
+/// Owns the [`SessionEngine`], the embedded [`ReferenceAdapter`], the client
+/// registry, and the per-stage latency log; runs until its command channel
+/// closes.
+pub struct EngineActor {
+    engine: SessionEngine,
+    adapter: ReferenceAdapter,
+    clients: ClientRegistry,
+    latency: BoundedLatencyLog<LATENCY_LOG_CAPACITY>,
+    drops: DropCounters,
+    /// The single monotonic origin shared with every connection task's
+    /// client-message stamps (ADR-0009: one `host_time` reference domain).
+    /// Passed in rather than sampled here so tick-driven timestamps and
+    /// client-message timestamps are never comparing two different clocks.
+    start: Instant,
+}
+
+impl EngineActor {
+    /// Constructs an actor wrapping `engine` and `adapter`, with an empty
+    /// client registry and latency log.
+    ///
+    /// `start` must be the same monotonic origin used to stamp incoming
+    /// client messages (ADR-0009): the actor derives every tick and
+    /// offer-expiry timestamp from it, and a second, independently-sampled
+    /// origin would skew those comparisons against client-message stamps.
+    #[must_use]
+    pub fn new(engine: SessionEngine, adapter: ReferenceAdapter, start: Instant) -> Self {
+        Self {
+            engine,
+            adapter,
+            clients: ClientRegistry::new(),
+            latency: BoundedLatencyLog::new(),
+            drops: DropCounters::default(),
+            start,
+        }
+    }
+
+    /// Runs the actor loop: services `commands` and a fixed-cadence tick
+    /// interval until the command channel closes.
+    pub async fn run(mut self, mut commands: mpsc::Receiver<ToEngine>) {
+        let mut ticker = tokio::time::interval(TICK_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                command = commands.recv() => {
+                    match command {
+                        Some(command) => self.handle_command(command),
+                        None => break,
+                    }
+                }
+                _ = ticker.tick() => {
+                    self.on_tick();
+                }
+            }
+        }
+        info!("engine actor command channel closed, shutting down");
+    }
+
+    fn handle_command(&mut self, command: ToEngine) {
+        match command {
+            ToEngine::ClientConnected { client, sender } => {
+                self.clients.insert(client, sender);
+            }
+            ToEngine::ClientMessage {
+                client,
+                message,
+                now,
+            } => {
+                self.on_client_message(client, message, now);
+            }
+            ToEngine::DumpLatencySummary { reply } => {
+                let summary = self.latency_summary();
+                // The receiver may have already given up waiting; a dropped
+                // reply is not a correctness issue for the engine itself.
+                reply.send(summary).ok();
+            }
+        }
+    }
+
+    fn on_client_message(
+        &mut self,
+        client: ClientKey,
+        message: DomainEnvelope,
+        now: MonoTimestamp,
+    ) {
+        let validate_start = Instant::now();
+        let is_disconnect = matches!(message, DomainEnvelope::Disconnect);
+        let outcome = self.engine.handle_client_message(client, message, now);
+        self.record_stage(Stage::Validate, validate_start.elapsed());
+        if is_disconnect {
+            self.clients.remove(client);
+        }
+        self.enact(outcome);
+    }
+
+    fn on_tick(&mut self) {
+        let now = MonoTimestamp::from_nanos(u64_nanos_since(self.start));
+        let outcome = self.engine.handle_tick(now);
+        self.enact(outcome);
+
+        let apply_start = Instant::now();
+        let step_outcome = self.adapter.step(StepBudget { ticks: 1 });
+        self.record_stage(Stage::Apply, apply_start.elapsed());
+        debug!(advanced = step_outcome.advanced, "adapter stepped");
+
+        self.broadcast_telemetry(now);
+    }
+
+    fn broadcast_telemetry(&mut self, now: MonoTimestamp) {
+        let batch = self.adapter.sample_telemetry();
+        for sample in batch.samples {
+            let wire_sample = wire::TelemetrySample {
+                vehicle: Some(wire::VehicleId {
+                    value: sample.vehicle.as_u64(),
+                }),
+                tick: Some(wire::SimTick {
+                    value: sample.tick.as_u64(),
+                }),
+                observed_at: Some(wire::MonoTimestamp {
+                    nanos: now.as_nanos(),
+                }),
+                pose: Some(wire::Pose2d {
+                    x_m: sample.pose.x as f32,
+                    y_m: sample.pose.y as f32,
+                    heading_rad: sample.pose.heading as f32,
+                }),
+                velocity: Some(wire::Velocity2d {
+                    linear_x_mps: sample.speed as f32,
+                    linear_y_mps: 0.0,
+                    angular_rad_s: 0.0,
+                }),
+            };
+            let bytes = encode_telemetry_datagram(wire_sample);
+            self.broadcast_datagram(bytes);
+        }
+    }
+
+    fn enact(&mut self, outcome: SessionOutcome) {
+        if outcome.dropped > 0 {
+            error!(
+                dropped = outcome.dropped,
+                "session engine dropped actions at the per-call cap"
+            );
+        }
+        for action in outcome.actions {
+            self.enact_one(action);
+        }
+    }
+
+    fn enact_one(&mut self, action: SessionAction) {
+        match action {
+            SessionAction::SendToClient { client, envelope } => {
+                // `Pong` is the ADR-0009 RTT probe reply and travels as a
+                // datagram alongside `Ping` (ADR-0005's channel mapping);
+                // `Authority` (were it ever unicast) belongs on the
+                // dedicated authority-events stream, never sharing the
+                // bootstrap stream's head-of-line with bulk/handshake
+                // traffic; every other unicast reply is session
+                // bootstrap/lease state and belongs on the bootstrap stream.
+                let message = to_connection_message(&envelope);
+                self.send_to(client, message, MessageClass::Unicast);
+            }
+            SessionAction::Broadcast { envelope } => {
+                let message = to_connection_message(&envelope);
+                self.broadcast(message, MessageClass::AuthorityBroadcast);
+            }
+            SessionAction::RejectFrame { client, rejection } => {
+                let bytes = crate::runtime::wire_codec::encode_frame_rejected_datagram(&rejection);
+                self.send_to(
+                    client,
+                    ToConnection::Datagram {
+                        class: DatagramClass::FrameRejected,
+                        bytes,
+                    },
+                    MessageClass::Unicast,
+                );
+            }
+            SessionAction::CloseClient { client, reason } => {
+                warn!(
+                    ?reason,
+                    client = client.as_u64(),
+                    "closing client connection"
+                );
+                self.send_to(client, ToConnection::Close, MessageClass::Unicast);
+                self.clients.remove(client);
+            }
+            SessionAction::ApplyToAdapter { frame } => {
+                let apply_start = Instant::now();
+                let outcome = self.adapter.apply_control(&frame);
+                self.record_stage(Stage::Apply, apply_start.elapsed());
+                debug!(?outcome, "control frame applied to adapter");
+            }
+        }
+    }
+
+    /// Hands `message` to `client`'s connection task without ever blocking
+    /// this actor's single task on that client's outbound queue (ADR-0009: a
+    /// stalled client must not wedge ticks, telemetry, or every other
+    /// client's control processing).
+    ///
+    /// A full queue means the client is draining slower than it is being fed
+    /// and is a counted, non-fatal drop; only a closed channel — the
+    /// connection task has actually exited — evicts the client from the
+    /// registry.
+    fn send_to(&mut self, client: ClientKey, message: ToConnection, class: MessageClass) {
+        let Some(sender) = self.clients.sender(client) else {
+            return;
+        };
+        let reliable = targets_reliable_stream(&message);
+        match sender.try_send(message) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                let total = self.drops.record(class);
+                if reliable {
+                    // Silently dropping an ordered reliable event breaks the
+                    // stream's ordering guarantee for every later event; a
+                    // client that cannot keep up with its own bootstrap/
+                    // authority stream is closed instead (ADR-0011).
+                    error!(
+                        client = client.as_u64(),
+                        ?class,
+                        total_dropped = total,
+                        "reliable-stream outbound queue full, closing connection"
+                    );
+                    self.close_full_client(client);
+                } else {
+                    warn!(
+                        client = client.as_u64(),
+                        ?class,
+                        total_dropped = total,
+                        "client outbound queue full, dropping message"
+                    );
+                }
+            }
+            Err(TrySendError::Closed(_)) => {
+                self.clients.remove(client);
+            }
+        }
+    }
+
+    /// Closes a client whose outbound queue overflowed on a reliable-stream
+    /// message: sends a best-effort `Close` (which the writer honors before it
+    /// drains the backlog) and evicts the client so no further messages are
+    /// routed to it.
+    fn close_full_client(&mut self, client: ClientKey) {
+        if let Some(sender) = self.clients.sender(client) {
+            sender.try_send(ToConnection::Close).ok();
+        }
+        self.clients.remove(client);
+    }
+
+    fn broadcast_datagram(&mut self, bytes: Vec<u8>) {
+        self.broadcast(
+            ToConnection::Datagram {
+                class: DatagramClass::Telemetry,
+                bytes,
+            },
+            MessageClass::Telemetry,
+        );
+    }
+
+    /// Fans `message` out to every connected client without blocking the
+    /// actor task on any single client's queue (ADR-0009), evicting a client
+    /// only when its connection task has actually gone away — never merely
+    /// because it briefly could not keep up (ADR-0011: telemetry and
+    /// authority broadcasts have different reliability needs but neither
+    /// should disconnect a client over one busy tick).
+    fn broadcast(&mut self, message: ToConnection, class: MessageClass) {
+        let reliable = targets_reliable_stream(&message);
+        let mut closed = Vec::new();
+        let mut full = Vec::new();
+        for (client, sender) in self.clients.iter() {
+            match sender.try_send(message.clone()) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => full.push(client),
+                Err(TrySendError::Closed(_)) => closed.push(client),
+            }
+        }
+        if !full.is_empty() {
+            let total = (0..full.len())
+                .map(|_| self.drops.record(class))
+                .last()
+                .unwrap_or_default();
+            // A best-effort telemetry broadcast tolerates a full queue; a
+            // reliable authority broadcast does not — dropping it would break
+            // ordering for that client, so it is closed instead (ADR-0011).
+            if reliable {
+                error!(
+                    ?class,
+                    skipped_clients = full.len(),
+                    total_dropped = total,
+                    "reliable-stream broadcast queue full, closing affected connections"
+                );
+            } else {
+                debug!(
+                    ?class,
+                    skipped_clients = full.len(),
+                    total_dropped = total,
+                    "broadcast skipped clients with a full outbound queue"
+                );
+            }
+        }
+        if reliable {
+            for client in full {
+                self.close_full_client(client);
+            }
+        }
+        for client in closed {
+            self.clients.remove(client);
+        }
+    }
+
+    fn record_stage(&mut self, stage: Stage, duration: Duration) {
+        if !self.latency.push(StageLatency::new(stage, duration)) {
+            debug!(
+                ?stage,
+                dropped = self.latency.dropped(),
+                "latency log evicted an entry"
+            );
+        }
+    }
+
+    /// Builds the shutdown-time latency summary line dumped via `tracing`.
+    fn latency_summary(&self) -> String {
+        let mean = self.latency.mean();
+        let max = self.latency.max();
+        format!(
+            "stages_recorded={} dropped={} mean={:?} max={:?}",
+            self.latency.len(),
+            self.latency.dropped(),
+            mean,
+            max.map(|record| record.duration)
+        )
+    }
+}
+
+/// Nanoseconds elapsed since `start`, saturating rather than overflowing for
+/// an implausibly long-running process.
+fn u64_nanos_since(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+/// Whether `message` is destined for one of the reliable ordered streams
+/// (bootstrap or authority-events, ADR-0005), where a dropped message would
+/// break the stream's ordering guarantee. Best-effort datagrams and the
+/// `Close` signal are not.
+fn targets_reliable_stream(message: &ToConnection) -> bool {
+    matches!(
+        message,
+        ToConnection::BootstrapMessage(_) | ToConnection::AuthorityMessage(_)
+    )
+}
+
+/// Picks the [`ToConnection`] channel arm an [`OutboundMessage`] belongs on
+/// and encodes it (ADR-0005): `Pong` is a control-fast datagram; `Authority`
+/// travels on the dedicated authority-events stream so a bulk/bootstrap
+/// transfer can never head-of-line-block a lease/override event; every other
+/// arm is bootstrap/lease/handshake reply traffic on the bootstrap stream.
+fn to_connection_message(envelope: &pilotage_session::OutboundMessage) -> ToConnection {
+    match envelope {
+        pilotage_session::OutboundMessage::Pong(pong) => ToConnection::Datagram {
+            class: DatagramClass::Pong,
+            bytes: encode_pong_datagram(pong),
+        },
+        pilotage_session::OutboundMessage::Authority(_) => {
+            ToConnection::AuthorityMessage(encode_envelope_message(envelope))
+        }
+        pilotage_session::OutboundMessage::Welcome(_)
+        | pilotage_session::OutboundMessage::LeaseResponse(_) => {
+            ToConnection::BootstrapMessage(encode_envelope_message(envelope))
+        }
+    }
+}

--- a/hosts/session-host/src/runtime/registry.rs
+++ b/hosts/session-host/src/runtime/registry.rs
@@ -1,0 +1,55 @@
+//! Tracks connected clients' outbound channels so the engine actor can
+//! unicast or broadcast [`SessionAction`]s without knowing about transport
+//! internals (ADR-0005).
+//!
+//! [`SessionAction`]: pilotage_session::SessionAction
+
+use std::collections::BTreeMap;
+
+use pilotage_session::ClientKey;
+use tokio::sync::mpsc;
+
+use crate::runtime::connection::ToConnection;
+
+/// Bound of the per-client outbound queue.
+///
+/// A connection's writer half drains this as fast as the transport allows;
+/// generous headroom absorbs a burst of authority broadcasts without
+/// dropping, while still bounding memory if a client's write side stalls.
+pub const OUTBOUND_QUEUE_CAPACITY: usize = 256;
+
+/// Maps live [`ClientKey`]s to the channel that delivers messages to their
+/// connection task.
+#[derive(Debug, Default)]
+pub struct ClientRegistry {
+    clients: BTreeMap<ClientKey, mpsc::Sender<ToConnection>>,
+}
+
+impl ClientRegistry {
+    /// Constructs an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a newly accepted connection's outbound sender.
+    pub fn insert(&mut self, client: ClientKey, sender: mpsc::Sender<ToConnection>) {
+        self.clients.insert(client, sender);
+    }
+
+    /// Removes a client on disconnect.
+    pub fn remove(&mut self, client: ClientKey) {
+        self.clients.remove(&client);
+    }
+
+    /// Returns the sender for one client, if it is still connected.
+    #[must_use]
+    pub fn sender(&self, client: ClientKey) -> Option<&mpsc::Sender<ToConnection>> {
+        self.clients.get(&client)
+    }
+
+    /// Iterates every currently connected client's key and sender, for
+    /// broadcast fan-out.
+    pub fn iter(&self) -> impl Iterator<Item = (ClientKey, &mpsc::Sender<ToConnection>)> {
+        self.clients.iter().map(|(key, sender)| (*key, sender))
+    }
+}

--- a/hosts/session-host/src/runtime/shutdown.rs
+++ b/hosts/session-host/src/runtime/shutdown.rs
@@ -1,0 +1,41 @@
+//! Graceful shutdown: signal every spawned task to stop, wait up to a
+//! timeout, and abort whatever is left (ADR-0015's shutdown discipline).
+
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+/// How long shutdown waits for spawned tasks to exit on their own before
+/// aborting the stragglers.
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Awaits every task in `tasks` up to [`SHUTDOWN_TIMEOUT`], aborting and
+/// logging by name whatever has not finished when the timeout elapses.
+pub async fn join_with_timeout(mut tasks: JoinSet<()>) {
+    let deadline = tokio::time::sleep(SHUTDOWN_TIMEOUT);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            joined = tasks.join_next() => {
+                match joined {
+                    Some(Ok(())) => {}
+                    Some(Err(error)) if error.is_cancelled() => {}
+                    Some(Err(error)) => error!(%error, "task panicked during shutdown"),
+                    None => {
+                        info!("all tasks exited cleanly before shutdown timeout");
+                        return;
+                    }
+                }
+            }
+            () = &mut deadline => {
+                let stragglers = tasks.len();
+                if stragglers > 0 {
+                    error!(stragglers, "shutdown timeout elapsed, aborting remaining tasks");
+                    tasks.shutdown().await;
+                }
+                return;
+            }
+        }
+    }
+}

--- a/hosts/session-host/src/runtime/wire_codec.rs
+++ b/hosts/session-host/src/runtime/wire_codec.rs
@@ -1,0 +1,273 @@
+//! Envelope encode/decode the driver owns so [`pilotage_session::SessionEngine`]
+//! stays sans-IO (ADR-0002, ADR-0005, ADR-0014).
+//!
+//! `pilotage-protocol` supplies the domain<->wire conversions and the
+//! length-delimited/datagram framing helpers; this module is the one place
+//! that picks which wire arm each [`DomainEnvelope`] or [`OutboundMessage`]
+//! maps to and drives `prost` encode/decode.
+
+use pilotage_protocol::wire;
+use pilotage_protocol::{
+    ClientHello, DecodeError, LeaseRequest, Ping, SCHEMA_VERSION, ScopedControlFrame,
+    decode_control_frame_envelope, decode_envelope_length_delimited,
+    encode_envelope_length_delimited,
+};
+use pilotage_session::{DomainEnvelope, OutboundMessage};
+use prost::Message;
+use prost::encoding::decode_varint;
+
+/// Upper bound on a single client-origin bootstrap-stream frame.
+///
+/// The only frames a client legitimately sends on this stream are
+/// `ClientHello` and `LeaseRequest` (ADR-0005), both a few hundred bytes at
+/// most. Without a cap, a client declaring a huge varint length and then
+/// dribbling the body would grow the reassembly buffer toward that declared
+/// size before a full frame ever arrives — an unbounded-memory vector that
+/// QUIC flow control does not bound, because the application buffer is
+/// separate from the transport window. 64 KiB leaves generous headroom while
+/// keeping a hostile declaration cheap to reject.
+pub const MAX_BOOTSTRAP_FRAME_LEN: usize = 64 * 1024;
+
+/// A client declared a bootstrap-stream frame larger than
+/// [`MAX_BOOTSTRAP_FRAME_LEN`]; the connection must be closed rather than
+/// buffered toward the declared size.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("bootstrap frame declares {declared} bytes, over the {MAX_BOOTSTRAP_FRAME_LEN}-byte limit")]
+pub struct OversizedFrame {
+    /// The frame length the client's varint prefix announced.
+    pub declared: usize,
+}
+
+/// Inspects the length-delimited varint prefix at the front of `bytes`
+/// without consuming from the connection's real read buffer, so the caller
+/// can tell "not enough bytes buffered yet" apart from "malformed frame" and
+/// "hostile oversized declaration" before attempting a full decode.
+///
+/// Returns `Ok(Some(total_frame_len))` — the varint prefix length plus the
+/// payload it announces — once that many bytes are available; `Ok(None)` if
+/// the prefix itself is incomplete or the announced frame has not fully
+/// arrived yet; and [`OversizedFrame`] the moment the declared length exceeds
+/// [`MAX_BOOTSTRAP_FRAME_LEN`], so the caller closes the connection instead of
+/// growing the buffer toward an attacker-chosen size.
+pub fn complete_frame_len(bytes: &[u8]) -> Result<Option<usize>, OversizedFrame> {
+    let mut cursor: &[u8] = bytes;
+    let before = cursor.len();
+    let Ok(payload_len) = decode_varint(&mut cursor) else {
+        return Ok(None);
+    };
+    let prefix_len = before - cursor.len();
+    let Ok(payload_len) = usize::try_from(payload_len) else {
+        return Err(OversizedFrame {
+            declared: usize::MAX,
+        });
+    };
+    if payload_len > MAX_BOOTSTRAP_FRAME_LEN {
+        return Err(OversizedFrame {
+            declared: payload_len,
+        });
+    }
+    let Some(total) = prefix_len.checked_add(payload_len) else {
+        return Ok(None);
+    };
+    Ok((bytes.len() >= total).then_some(total))
+}
+
+/// Errors decoding a length-delimited bootstrap-stream envelope into a
+/// [`DomainEnvelope`].
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapDecodeError {
+    /// The bytes did not decode as a valid envelope.
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    /// The envelope decoded but carried a payload arm the bootstrap stream
+    /// never legitimately receives from a client (for example a server-only
+    /// message, or an arm this build does not recognize).
+    #[error("unexpected bootstrap-stream payload arm")]
+    UnexpectedPayload,
+    /// The envelope's `schema_version` is not one this build accepts.
+    #[error("unsupported schema_version {found} (expected {expected})")]
+    UnsupportedSchemaVersion {
+        /// The schema version this build produces and accepts.
+        expected: u32,
+        /// The schema version found on the envelope.
+        found: u32,
+    },
+}
+
+/// Decodes one length-delimited envelope from the front of `bytes` into a
+/// client-origin [`DomainEnvelope`] plus the unconsumed remainder.
+///
+/// Only `ClientHello` and `LeaseRequest` are legitimately received on the
+/// bootstrap stream (ADR-0005): control frames and `Ping` travel as
+/// datagrams instead.
+///
+/// # Errors
+///
+/// Returns [`BootstrapDecodeError`] if the bytes are not a valid envelope,
+/// the schema version is unsupported, or the payload is not one of the two
+/// client-origin bootstrap-stream arms.
+pub fn decode_bootstrap_message(
+    bytes: &[u8],
+) -> Result<(DomainEnvelope, &[u8]), BootstrapDecodeError> {
+    let (envelope, rest) = decode_envelope_length_delimited(bytes)?;
+    if envelope.schema_version != SCHEMA_VERSION {
+        return Err(BootstrapDecodeError::UnsupportedSchemaVersion {
+            expected: SCHEMA_VERSION,
+            found: envelope.schema_version,
+        });
+    }
+    let domain = match envelope.payload {
+        Some(wire::envelope::Payload::ClientHello(hello)) => {
+            DomainEnvelope::Hello(ClientHello::from(hello))
+        }
+        Some(wire::envelope::Payload::LeaseRequest(request)) => {
+            DomainEnvelope::Lease(LeaseRequest::try_from(request).map_err(DecodeError::from)?)
+        }
+        _ => return Err(BootstrapDecodeError::UnexpectedPayload),
+    };
+    Ok((domain, rest))
+}
+
+/// Decodes one control-fast datagram payload into a [`DomainEnvelope::Frame`].
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] if the bytes are not a valid `ControlFrame`
+/// envelope.
+pub fn decode_control_datagram(bytes: &[u8]) -> Result<ScopedControlFrame, DecodeError> {
+    decode_control_frame_envelope(bytes)
+}
+
+/// Decodes one datagram payload as a `Ping` envelope, for the RTT probe
+/// channel (ADR-0009).
+///
+/// # Errors
+///
+/// Returns [`BootstrapDecodeError`] if the bytes are not a valid envelope, an
+/// unsupported schema version, or not a `Ping` payload.
+pub fn decode_ping_datagram(bytes: &[u8]) -> Result<Ping, BootstrapDecodeError> {
+    let envelope = wire::Envelope::decode(bytes).map_err(|source| {
+        BootstrapDecodeError::Decode(DecodeError::Prost {
+            message: "pilotage.v1.Envelope",
+            source,
+        })
+    })?;
+    if envelope.schema_version != SCHEMA_VERSION {
+        return Err(BootstrapDecodeError::UnsupportedSchemaVersion {
+            expected: SCHEMA_VERSION,
+            found: envelope.schema_version,
+        });
+    }
+    match envelope.payload {
+        Some(wire::envelope::Payload::Ping(ping)) => {
+            Ok(Ping::try_from(ping).map_err(DecodeError::from)?)
+        }
+        _ => Err(BootstrapDecodeError::UnexpectedPayload),
+    }
+}
+
+/// Encodes an [`OutboundMessage`] as a length-delimited envelope. Used for
+/// both the bootstrap stream (`Welcome`/`LeaseResponse`) and the dedicated
+/// authority-events stream (`Authority`) — the framing is identical, only
+/// the destination stream differs (ADR-0005).
+#[must_use]
+pub fn encode_envelope_message(message: &OutboundMessage) -> Vec<u8> {
+    let payload = match message {
+        OutboundMessage::Welcome(welcome) => wire::envelope::Payload::ServerWelcome(welcome.into()),
+        OutboundMessage::LeaseResponse(response) => {
+            wire::envelope::Payload::LeaseResponse(response.into())
+        }
+        OutboundMessage::Pong(pong) => wire::envelope::Payload::Pong(pong.into()),
+        OutboundMessage::Authority(effect) => {
+            wire::envelope::Payload::AuthorityEvent(wire::AuthorityEvent::from(effect))
+        }
+    };
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(payload),
+    };
+    encode_envelope_length_delimited(&envelope)
+}
+
+/// Encodes a `Pong` as a standalone envelope for a control-fast datagram.
+#[must_use]
+pub fn encode_pong_datagram(pong: &pilotage_protocol::Pong) -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::Pong(pong.into())),
+    };
+    envelope.encode_to_vec()
+}
+
+/// Encodes a telemetry sample as a standalone envelope for a telemetry-fast
+/// datagram.
+#[must_use]
+pub fn encode_telemetry_datagram(sample: wire::TelemetrySample) -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::TelemetrySample(sample)),
+    };
+    envelope.encode_to_vec()
+}
+
+/// Encodes a `FrameRejected` notice as a datagram envelope (sent back to the
+/// frame's sender only, ADR-0009).
+#[must_use]
+pub fn encode_frame_rejected_datagram(rejection: &pilotage_protocol::FrameRejected) -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::FrameRejected(rejection.into())),
+    };
+    envelope.encode_to_vec()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{MAX_BOOTSTRAP_FRAME_LEN, complete_frame_len};
+    use prost::encoding::encode_varint;
+
+    #[test]
+    fn incomplete_prefix_is_not_yet_a_frame() {
+        // A single 0x80 continuation byte is an unfinished varint.
+        assert_eq!(complete_frame_len(&[0x80]), Ok(None));
+    }
+
+    #[test]
+    fn full_frame_reports_total_length() {
+        let mut bytes = Vec::new();
+        encode_varint(3, &mut bytes);
+        bytes.extend_from_slice(&[1, 2, 3]);
+        let total = bytes.len();
+        assert_eq!(complete_frame_len(&bytes), Ok(Some(total)));
+    }
+
+    #[test]
+    fn declared_body_not_yet_arrived_is_none() {
+        let mut bytes = Vec::new();
+        encode_varint(3, &mut bytes);
+        bytes.push(1); // only one of three body bytes buffered
+        assert_eq!(complete_frame_len(&bytes), Ok(None));
+    }
+
+    #[test]
+    fn oversized_declaration_is_rejected_before_buffering() {
+        // A hostile client announces a body far larger than the cap while
+        // sending almost no bytes; the guard must reject on the prefix alone,
+        // never wait for the declared bytes to arrive.
+        let mut bytes = Vec::new();
+        let declared = (MAX_BOOTSTRAP_FRAME_LEN as u64) + 1;
+        encode_varint(declared, &mut bytes);
+        let err = complete_frame_len(&bytes).expect_err("over-cap frame must be rejected");
+        assert_eq!(err.declared, MAX_BOOTSTRAP_FRAME_LEN + 1);
+    }
+
+    #[test]
+    fn frame_exactly_at_the_cap_is_allowed() {
+        let mut bytes = Vec::new();
+        encode_varint(MAX_BOOTSTRAP_FRAME_LEN as u64, &mut bytes);
+        // Prefix only; body has not arrived, so this is a well-formed pending
+        // frame (None), not a rejection.
+        assert_eq!(complete_frame_len(&bytes), Ok(None));
+    }
+}

--- a/hosts/session-host/src/tls_identity.rs
+++ b/hosts/session-host/src/tls_identity.rs
@@ -1,0 +1,69 @@
+//! Loopback-dev TLS identity: a self-signed certificate plus its SHA-256
+//! digest, printed at startup so a local client can pin it out of band
+//! (ADR-0005's local-demo certificate strategy).
+
+use wtransport::Identity;
+use wtransport::tls::Sha256Digest;
+
+use crate::error::HostError;
+
+/// A self-signed identity for `127.0.0.1`/`localhost`, plus the hex-encoded
+/// SHA-256 digest of its leaf certificate for out-of-band client pinning.
+pub struct DevIdentity {
+    /// The TLS identity handed to [`wtransport::ServerConfig::builder`].
+    pub identity: Identity,
+    /// Lowercase hex SHA-256 digest of the leaf certificate, with no
+    /// separators, suitable for the `LISTENING` machine-readable line.
+    pub cert_hash_hex: String,
+}
+
+/// Builds a fresh self-signed identity valid for `localhost`, `127.0.0.1`,
+/// and `::1`.
+///
+/// # Errors
+///
+/// Returns [`HostError::Identity`] if the subject alternative names above are
+/// somehow not valid DNS `IA5` strings, which cannot happen for this fixed,
+/// hard-coded set but is surfaced rather than unwrapped per the workspace's
+/// no-`unwrap` policy.
+pub fn build_dev_identity() -> Result<DevIdentity, HostError> {
+    let identity =
+        Identity::self_signed(["localhost", "127.0.0.1", "::1"]).map_err(HostError::Identity)?;
+    let leaf = identity
+        .certificate_chain()
+        .as_slice()
+        .first()
+        .map_or_else(|| Sha256Digest::new([0; 32]), |cert| cert.hash());
+    let cert_hash_hex = hex_encode(leaf.as_ref());
+    Ok(DevIdentity {
+        identity,
+        cert_hash_hex,
+    })
+}
+
+/// Encodes bytes as lowercase hex with no separators.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{build_dev_identity, hex_encode};
+
+    #[test]
+    fn hex_encode_is_lowercase_no_separators() {
+        assert_eq!(hex_encode(&[0xAB, 0x01, 0xFF]), "ab01ff");
+    }
+
+    #[test]
+    fn dev_identity_builds_and_hashes() {
+        let dev = build_dev_identity().expect("self-signed identity builds");
+        assert_eq!(dev.cert_hash_hex.len(), 64);
+        assert!(dev.cert_hash_hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/hosts/session-host/tests/hostile_pending_growth.rs
+++ b/hosts/session-host/tests/hostile_pending_growth.rs
@@ -1,0 +1,144 @@
+//! Guardrail: a client that declares an oversized bootstrap-stream frame is
+//! disconnected without growing the host's per-connection reassembly buffer
+//! toward the attacker-chosen size, and the host keeps serving other clients
+//! (ADR-0005 bootstrap stream; `wire_codec::MAX_BOOTSTRAP_FRAME_LEN`).
+//!
+//! Synchronization is event-driven: the pass condition is that a fresh
+//! connection completes hello->welcome after the hostile one, bounded by a
+//! `tokio::time::timeout` — never a sleep-and-poll.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::time::Duration;
+
+use pilotage_protocol::wire;
+use pilotage_session_host::runtime;
+use tokio::time::timeout;
+use wtransport::{ClientConfig, Connection, Endpoint};
+
+const SCHEMA_VERSION: u32 = 1;
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn connect_client(addr: std::net::SocketAddr) -> Connection {
+    let config = ClientConfig::builder()
+        .with_bind_default()
+        .with_no_cert_validation()
+        .build();
+    let client = Endpoint::client(config).expect("client endpoint constructs");
+    let url = format!("https://127.0.0.1:{}/pilotage", addr.port());
+    timeout(TEST_TIMEOUT, client.connect(url))
+        .await
+        .expect("connect does not time out")
+        .expect("client connects to the loopback host")
+}
+
+fn encode_varint(mut value: u64, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+fn hello_bytes() -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::ClientHello(wire::ClientHello {
+            protocol_version: SCHEMA_VERSION,
+            client_name: "post-attack-client".to_owned(),
+            join_token: Vec::new(),
+        })),
+    };
+    pilotage_protocol::encode_envelope_length_delimited(&envelope)
+}
+
+async fn read_welcome(recv: &mut wtransport::RecvStream) -> wire::ServerWelcome {
+    let mut pending = Vec::new();
+    let mut buf = vec![0u8; 8192];
+    loop {
+        if let Ok((envelope, rest)) = pilotage_protocol::decode_envelope_length_delimited(&pending)
+        {
+            let consumed = pending.len() - rest.len();
+            pending.drain(..consumed);
+            if let Some(wire::envelope::Payload::ServerWelcome(welcome)) = envelope.payload {
+                return welcome;
+            }
+            continue;
+        }
+        let read = timeout(TEST_TIMEOUT, recv.read(&mut buf))
+            .await
+            .expect("welcome read does not time out")
+            .expect("welcome read succeeds")
+            .expect("stream stays open until a full welcome arrives");
+        pending.extend_from_slice(&buf[..read]);
+    }
+}
+
+/// A hostile client declares a 1 GiB bootstrap frame and streams a little
+/// body; the host must close that connection instead of buffering toward the
+/// declared size, and must still welcome a subsequent honest client.
+#[tokio::test]
+async fn oversized_bootstrap_frame_is_rejected_and_host_survives() {
+    let host = runtime::start(0).expect("host starts on an ephemeral port");
+    let addr = host.local_addr;
+
+    // Hostile connection: declare a frame far past the cap, then dribble body.
+    let hostile = connect_client(addr).await;
+    let (mut hostile_send, mut hostile_recv) = timeout(TEST_TIMEOUT, hostile.open_bi())
+        .await
+        .expect("open_bi does not time out")
+        .expect("bootstrap stream opens")
+        .await
+        .expect("bootstrap stream finishes opening");
+    let mut prefix = Vec::new();
+    encode_varint(1 << 30, &mut prefix);
+    hostile_send
+        .write_all(&prefix)
+        .await
+        .expect("prefix write is accepted by the transport");
+    // A single body chunk, well under the declared size; the host should have
+    // already rejected on the prefix alone, so this write may fail once the
+    // stream is reset — that outcome is expected, not asserted.
+    hostile_send.write_all(&[0u8; 4096]).await.ok();
+
+    // The host closes the hostile bootstrap stream: its receive side ends
+    // (reset or clean close) rather than blocking forever.
+    let mut scratch = vec![0u8; 1024];
+    let hostile_stream_closed = timeout(TEST_TIMEOUT, hostile_recv.read(&mut scratch))
+        .await
+        .expect("hostile stream resolves (closed) within the timeout");
+    assert!(
+        matches!(hostile_stream_closed, Ok(None) | Err(_)),
+        "host must close the hostile bootstrap stream, got {hostile_stream_closed:?}"
+    );
+
+    // The decisive guarantee: an honest client is still served, proving the
+    // host neither exhausted memory nor wedged its accept path.
+    let honest = connect_client(addr).await;
+    let (mut honest_send, mut honest_recv) = timeout(TEST_TIMEOUT, honest.open_bi())
+        .await
+        .expect("second open_bi does not time out")
+        .expect("second bootstrap stream opens")
+        .await
+        .expect("second bootstrap stream finishes opening");
+    let _authority = timeout(TEST_TIMEOUT, honest.accept_uni())
+        .await
+        .expect("accept_uni does not time out")
+        .expect("authority stream is accepted for the honest client");
+
+    honest_send
+        .write_all(&hello_bytes())
+        .await
+        .expect("honest hello write succeeds");
+    let welcome = read_welcome(&mut honest_recv).await;
+    assert!(
+        welcome.session.is_some(),
+        "honest client receives a session after the hostile connection was rejected"
+    );
+
+    host.shutdown().await;
+}

--- a/hosts/session-host/tests/loopback.rs
+++ b/hosts/session-host/tests/loopback.rs
@@ -1,0 +1,307 @@
+//! In-process loopback integration test (ADR-0005): starts the session host
+//! on `127.0.0.1:0`, connects a real `wtransport` client, drives
+//! hello->welcome, a lease, a valid control frame observed as a telemetry
+//! change, and a stale-generation frame rejected with `FrameRejected`.
+//!
+//! Synchronization is entirely event-driven: every wait is either a protocol
+//! response the server must send, or a bounded `tokio::time::timeout` around
+//! that wait (never a bare `sleep` + retry poll).
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::time::Duration;
+
+use pilotage_protocol::wire;
+use pilotage_session_host::runtime;
+use prost::Message;
+use tokio::time::timeout;
+use wtransport::{ClientConfig, Connection, Endpoint};
+
+const SCHEMA_VERSION: u32 = 1;
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Connects a `wtransport` client to `addr`, skipping certificate
+/// validation: the host's self-signed loopback-dev certificate is not
+/// otherwise pinned in this test (ADR-0005's local-demo strategy is a
+/// tracked follow-up, not this test's concern).
+async fn connect_client(addr: std::net::SocketAddr) -> Connection {
+    let config = ClientConfig::builder()
+        .with_bind_default()
+        .with_no_cert_validation()
+        .build();
+    let client = Endpoint::client(config).expect("client endpoint constructs");
+    let url = format!("https://127.0.0.1:{}/pilotage", addr.port());
+    timeout(TEST_TIMEOUT, client.connect(url))
+        .await
+        .expect("connect does not time out")
+        .expect("client connects to the loopback host")
+}
+
+/// Reads exactly one length-delimited [`wire::Envelope`] from the bootstrap
+/// stream, accumulating bytes across reads as needed. `pending` persists
+/// across calls so a caller can keep reading the same stream and consume
+/// each envelope exactly once, in emission order.
+async fn read_one_envelope(
+    recv: &mut wtransport::RecvStream,
+    pending: &mut Vec<u8>,
+) -> wire::Envelope {
+    let mut buf = vec![0u8; 8192];
+    loop {
+        if let Ok((envelope, rest)) = pilotage_protocol::decode_envelope_length_delimited(pending) {
+            let consumed = pending.len() - rest.len();
+            pending.drain(..consumed);
+            return envelope;
+        }
+        let read = timeout(TEST_TIMEOUT, recv.read(&mut buf))
+            .await
+            .expect("stream read does not time out")
+            .expect("stream read succeeds")
+            .expect("stream is not closed before a full envelope arrives");
+        pending.extend_from_slice(&buf[..read]);
+    }
+}
+
+/// Reads bootstrap-stream envelopes until one is a `LeaseResponse`. Authority
+/// broadcasts (e.g. the grant this lease request causes) no longer share this
+/// stream (ADR-0005's dedicated authority-events stream), so every envelope
+/// read here is expected to be bootstrap/lease traffic.
+async fn read_until_lease_response(
+    recv: &mut wtransport::RecvStream,
+    pending: &mut Vec<u8>,
+) -> wire::LeaseResponse {
+    loop {
+        let envelope = read_one_envelope(recv, pending).await;
+        if let Some(wire::envelope::Payload::LeaseResponse(response)) = envelope.payload {
+            return response;
+        }
+    }
+}
+
+/// Reads authority-events-stream envelopes until one is a
+/// `ScopeLeaseGranted` event, skipping any other authority events that
+/// precede it.
+async fn read_until_lease_granted(
+    recv: &mut wtransport::RecvStream,
+    pending: &mut Vec<u8>,
+) -> wire::AuthorityEvent {
+    loop {
+        let envelope = read_one_envelope(recv, pending).await;
+        if let Some(wire::envelope::Payload::AuthorityEvent(event)) = envelope.payload
+            && matches!(
+                event.event,
+                Some(wire::authority_event::Event::ScopeLeaseGranted(_))
+            )
+        {
+            return event;
+        }
+    }
+}
+
+/// Sends one envelope, length-delimited, on the bootstrap stream.
+async fn send_envelope(send: &mut wtransport::SendStream, envelope: &wire::Envelope) {
+    let bytes = pilotage_protocol::encode_envelope_length_delimited(envelope);
+    send.write_all(&bytes)
+        .await
+        .expect("bootstrap write succeeds");
+}
+
+fn hello_envelope() -> wire::Envelope {
+    wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::ClientHello(wire::ClientHello {
+            protocol_version: SCHEMA_VERSION,
+            client_name: "loopback-test".to_owned(),
+            join_token: Vec::new(),
+        })),
+    }
+}
+
+fn lease_envelope(vehicle: u64, scope: &str) -> wire::Envelope {
+    wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::LeaseRequest(wire::LeaseRequest {
+            vehicle: Some(wire::VehicleId { value: vehicle }),
+            scope: Some(wire::ScopeId {
+                value: scope.to_owned(),
+            }),
+        })),
+    }
+}
+
+/// Builds a `ControlFrame` envelope for the datagram channel with full
+/// throttle, so the reference adapter's speed observably departs from zero.
+fn full_throttle_frame_bytes(
+    session: u64,
+    vehicle: u64,
+    scope: &str,
+    generation: u64,
+    sequence: u32,
+    sampled_at_nanos: u64,
+) -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::ControlFrame(wire::ControlFrame {
+            session: Some(wire::SessionId { value: session }),
+            vehicle: Some(wire::VehicleId { value: vehicle }),
+            scope: Some(wire::ScopeId {
+                value: scope.to_owned(),
+            }),
+            generation: Some(wire::Generation { value: generation }),
+            sequence: Some(wire::SequenceNum { value: sequence }),
+            sampled_at: Some(wire::MonoTimestamp {
+                nanos: sampled_at_nanos,
+            }),
+            profile_revision: 1,
+            payload: Some(wire::ControlPayload {
+                axes: vec![wire::AxisSample {
+                    axis_id: u32::from(pilotage_adapter_reference::THROTTLE_AXIS),
+                    value: 1.0,
+                }],
+                edges: Vec::new(),
+            }),
+        })),
+    };
+    envelope.encode_to_vec()
+}
+
+/// Awaits telemetry datagrams until one reports nonzero speed (proof the
+/// control frame was applied), or the test timeout elapses.
+async fn await_nonzero_speed_telemetry(connection: &Connection) -> wire::TelemetrySample {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            let datagram = connection
+                .receive_datagram()
+                .await
+                .expect("datagram channel stays open");
+            let Ok(envelope) = wire::Envelope::decode(datagram.payload().as_ref()) else {
+                continue;
+            };
+            if let Some(wire::envelope::Payload::TelemetrySample(sample)) = envelope.payload {
+                let speed = sample
+                    .velocity
+                    .as_ref()
+                    .map_or(0.0, |velocity| velocity.linear_x_mps);
+                if speed > 0.0 {
+                    return sample;
+                }
+            }
+        }
+    })
+    .await
+    .expect("a nonzero-speed telemetry sample arrives before the test timeout")
+}
+
+/// Awaits a `FrameRejected` datagram, or the test timeout elapses.
+async fn await_frame_rejected(connection: &Connection) -> wire::FrameRejected {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            let datagram = connection
+                .receive_datagram()
+                .await
+                .expect("datagram channel stays open");
+            let Ok(envelope) = wire::Envelope::decode(datagram.payload().as_ref()) else {
+                continue;
+            };
+            if let Some(wire::envelope::Payload::FrameRejected(rejection)) = envelope.payload {
+                return rejection;
+            }
+        }
+    })
+    .await
+    .expect("a FrameRejected datagram arrives before the test timeout")
+}
+
+#[tokio::test]
+async fn hello_lease_frame_and_stale_generation_rejection() {
+    let host = runtime::start(0).expect("host starts on an ephemeral port");
+    let addr = host.local_addr;
+
+    let connection = connect_client(addr).await;
+    let (mut send, mut recv) = timeout(TEST_TIMEOUT, connection.open_bi())
+        .await
+        .expect("open_bi does not time out")
+        .expect("bootstrap stream opens")
+        .await
+        .expect("bootstrap stream finishes opening");
+    let mut authority_recv = timeout(TEST_TIMEOUT, connection.accept_uni())
+        .await
+        .expect("accept_uni does not time out")
+        .expect("dedicated authority-events stream is accepted");
+
+    let mut pending = Vec::new();
+    let mut authority_pending = Vec::new();
+
+    send_envelope(&mut send, &hello_envelope()).await;
+    let welcome_envelope = read_one_envelope(&mut recv, &mut pending).await;
+    let welcome = match welcome_envelope.payload {
+        Some(wire::envelope::Payload::ServerWelcome(welcome)) => welcome,
+        other => panic!("expected ServerWelcome, got {other:?}"),
+    };
+    let session = welcome.session.expect("welcome carries a session id").value;
+    let vehicle_id = welcome
+        .host_capabilities
+        .expect("welcome carries host capabilities")
+        .vehicles
+        .first()
+        .expect("reference adapter advertises one vehicle")
+        .vehicle
+        .expect("vehicle descriptor carries an id")
+        .value;
+    let scope = pilotage_adapter_reference::MOTION_SCOPE;
+
+    send_envelope(&mut send, &lease_envelope(vehicle_id, scope)).await;
+    let lease_response = read_until_lease_response(&mut recv, &mut pending).await;
+    assert!(lease_response.granted, "lease request should be granted");
+    let generation = lease_response
+        .generation
+        .expect("lease response carries a generation")
+        .value;
+
+    // The grant's authority broadcast arrives on the dedicated
+    // authority-events stream (ADR-0005), never sharing the bootstrap
+    // stream's head-of-line with the unicast `LeaseResponse` above.
+    let granted_event = timeout(
+        TEST_TIMEOUT,
+        read_until_lease_granted(&mut authority_recv, &mut authority_pending),
+    )
+    .await
+    .expect("a ScopeLeaseGranted authority event arrives before the test timeout");
+    match granted_event.event {
+        Some(wire::authority_event::Event::ScopeLeaseGranted(grant)) => {
+            assert_eq!(
+                grant.vehicle.expect("grant carries a vehicle id").value,
+                vehicle_id
+            );
+        }
+        other => panic!("expected ScopeLeaseGranted, got {other:?}"),
+    }
+
+    let valid_frame = full_throttle_frame_bytes(session, vehicle_id, scope, generation, 0, 0);
+    connection
+        .send_datagram(valid_frame)
+        .expect("sending the valid control frame datagram succeeds");
+    let sample = await_nonzero_speed_telemetry(&connection).await;
+    assert_eq!(
+        sample.vehicle.expect("sample carries a vehicle id").value,
+        vehicle_id
+    );
+
+    let stale_frame = full_throttle_frame_bytes(
+        session,
+        vehicle_id,
+        scope,
+        generation.saturating_sub(1),
+        1,
+        0,
+    );
+    connection
+        .send_datagram(stale_frame)
+        .expect("sending the stale-generation frame datagram succeeds");
+    let rejection = await_frame_rejected(&connection).await;
+    assert_eq!(
+        rejection.reason,
+        wire::FrameRejectionReason::StaleGeneration as i32
+    );
+
+    host.shutdown().await;
+}

--- a/schemas/pilotage/v1/envelope.proto
+++ b/schemas/pilotage/v1/envelope.proto
@@ -7,6 +7,7 @@ package pilotage.v1;
 import "pilotage/v1/authority.proto";
 import "pilotage/v1/capability.proto";
 import "pilotage/v1/control.proto";
+import "pilotage/v1/session.proto";
 import "pilotage/v1/telemetry.proto";
 
 // Wraps exactly one payload message with an explicit schema version so
@@ -20,5 +21,14 @@ message Envelope {
     AuthorityEvent authority_event = 3;
     TelemetrySample telemetry_sample = 4;
     HostCapabilities host_capabilities = 5;
+    // Session-bootstrap and handshake vocabulary (ADR-0005); additive arms
+    // starting at field 6 so earlier arms keep their wire numbers.
+    ClientHello client_hello = 6;
+    ServerWelcome server_welcome = 7;
+    LeaseRequest lease_request = 8;
+    LeaseResponse lease_response = 9;
+    Ping ping = 10;
+    Pong pong = 11;
+    FrameRejected frame_rejected = 12;
   }
 }

--- a/schemas/pilotage/v1/session.proto
+++ b/schemas/pilotage/v1/session.proto
@@ -1,0 +1,136 @@
+// Session-bootstrap wire vocabulary: client/server handshake, scope-lease
+// request/response, RTT probing, and frame-rejection notices (ADR-0005,
+// ADR-0006, ADR-0009, ADR-0010).
+syntax = "proto3";
+
+package pilotage.v1;
+
+import "pilotage/v1/capability.proto";
+import "pilotage/v1/common.proto";
+
+// The first message a client sends after the WebTransport session is
+// established, before any host state has been shared (ADR-0005: session
+// bootstrap uses plain HTTPS for admission, then this message begins the
+// in-session handshake).
+message ClientHello {
+  // Highest `pilotage.v1` schema version the client can interpret; the host
+  // may reject or downgrade based on this (ADR-0014).
+  uint32 protocol_version = 1;
+  // Human-readable client identification (application name/version), for
+  // diagnostics only; never used for authorization decisions.
+  string client_name = 2;
+  // Opaque join token proving prior admission (issued out-of-band by the
+  // HTTPS bootstrap flow of ADR-0005). The wire type treats this as opaque
+  // bytes; only the issuing admission service interprets its contents.
+  bytes join_token = 3;
+}
+
+// The host's reply to `ClientHello`, establishing the session identity and
+// publishing the state the client needs to render an initial UI.
+message ServerWelcome {
+  SessionId session = 1;
+  // Principal identity the host assigned to this connection for the
+  // lifetime of the session.
+  PrincipalId principal = 2;
+  HostCapabilities host_capabilities = 3;
+  // Every (vehicle, scope) pair the host currently tracks, with its present
+  // holder (if any) and fencing generation, so the client can render
+  // current ownership without waiting for the next authority event.
+  repeated ScopeHolderSnapshot scope_holders = 4;
+}
+
+// A single (vehicle, scope) pair's current holder and fencing generation,
+// as of the moment `ServerWelcome` was constructed (ADR-0006, ADR-0010).
+message ScopeHolderSnapshot {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+  // Absent when the scope is currently unassigned.
+  PrincipalId holder = 3;
+  Generation generation = 4;
+}
+
+// A client's request to lease a control scope for a vehicle (ADR-0006).
+message LeaseRequest {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+}
+
+// Why a `LeaseRequest` was denied. Unset (`UNSPECIFIED`) only appears on a
+// malformed response; a well-formed denial always carries a concrete reason.
+enum LeaseDenialReason {
+  LEASE_DENIAL_REASON_UNSPECIFIED = 0;
+  // Another principal currently holds the scope and did not offer it.
+  LEASE_DENIAL_REASON_ALREADY_HELD = 1;
+  // The (vehicle, scope) pair is not published by the host's capabilities.
+  LEASE_DENIAL_REASON_UNKNOWN_SCOPE = 2;
+  // The requesting principal lacks the authority class required for this
+  // scope (ADR-0010).
+  LEASE_DENIAL_REASON_NOT_AUTHORIZED = 3;
+}
+
+// The host's reply to a `LeaseRequest`.
+message LeaseResponse {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+  bool granted = 3;
+  // The new fencing generation on grant; the current (unchanged) generation
+  // on denial, so the client can still fence stale in-flight frames.
+  Generation generation = 4;
+  // Meaningful only when `granted` is false.
+  LeaseDenialReason reason = 5;
+}
+
+// An RTT/offset probe carrying the sender's local transport-time sample.
+// `nonce` correlates a `Ping` with its `Pong`; it carries no ordering or
+// uniqueness guarantee beyond what the sender chooses.
+//
+// The sender timestamp is a `transport_time` sample local to the sender
+// (ADR-0009) and MUST NOT be compared directly against a timestamp from a
+// different endpoint. It is only meaningful as input to
+// `pilotage-timing`'s RTT/offset estimator, which correlates it with the
+// receiver's own local clock readings at send and receive time.
+message Ping {
+  uint64 nonce = 1;
+  MonoTimestamp sender_sent_at = 2;
+}
+
+// The reply to a `Ping`, echoing its nonce and sender timestamp and adding
+// the responder's own local transport-time sample at the moment of reply.
+//
+// As with `Ping`, `responder_sent_at` is local to the responder and must
+// never be compared raw against `echoed_sender_sent_at`; both feed
+// `pilotage-timing`'s estimator, never a direct subtraction.
+message Pong {
+  uint64 nonce = 1;
+  MonoTimestamp echoed_sender_sent_at = 2;
+  MonoTimestamp responder_sent_at = 3;
+}
+
+// Why the host rejected an inbound `ControlFrame` without applying it
+// (ADR-0009 rejection rules).
+enum FrameRejectionReason {
+  FRAME_REJECTION_REASON_UNSPECIFIED = 0;
+  // The frame's `generation` is older than the scope's current generation.
+  FRAME_REJECTION_REASON_STALE_GENERATION = 1;
+  // The scope has no current holder, so no sender is authorized to command
+  // it.
+  FRAME_REJECTION_REASON_NO_HOLDER = 2;
+  // The (vehicle, scope) pair is not published by the host's capabilities.
+  FRAME_REJECTION_REASON_UNKNOWN_SCOPE = 3;
+  // The frame's sampled-at timestamp is older than the configured maximum
+  // control age.
+  FRAME_REJECTION_REASON_TOO_OLD = 4;
+}
+
+// Sent back to the frame's sender (never broadcast) when a `ControlFrame`
+// is well-formed but not honored, so the client can distinguish "dropped in
+// transit" from "explicitly rejected" (ADR-0009, ADR-0012).
+message FrameRejected {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+  SequenceNum sequence = 3;
+  FrameRejectionReason reason = 4;
+  // The scope's fencing generation at the time of rejection, so the sender
+  // can decide whether to resynchronize before retrying.
+  Generation current_generation = 5;
+}

--- a/tools/loopback-probe/Cargo.toml
+++ b/tools/loopback-probe/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "loopback-probe"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[[bin]]
+name = "loopback-probe"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+hidapi = { workspace = true }
+pilotage-input = { workspace = true }
+pilotage-protocol = { workspace = true }
+pilotage-timing = { workspace = true }
+prost = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+# `dangerous-configuration` gates `with_no_cert_validation`, which
+# `--insecure-loopback` requires (see `transport::client_endpoint`); scoped
+# to this crate rather than the workspace default since no other crate
+# needs to skip certificate verification.
+wtransport = { workspace = true, features = ["dangerous-configuration"] }

--- a/tools/loopback-probe/src/cli.rs
+++ b/tools/loopback-probe/src/cli.rs
@@ -1,0 +1,180 @@
+//! Hand-rolled argument parsing for `loopback-probe` (no `clap`, matching
+//! `tools/hid-probe`'s established pattern for this workspace).
+
+use crate::error::ProbeError;
+
+/// Parsed command-line configuration for one probe run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Args {
+    /// WebTransport URL of the session host to connect to, e.g.
+    /// `https://127.0.0.1:4433`.
+    pub url: String,
+    /// Whether the caller passed `--insecure-loopback`. Required to skip
+    /// server-certificate verification; refused by `validate_loopback_url`
+    /// unless `url`'s host is a loopback address, so a skipped-verification
+    /// connection can never be pointed at a non-local host by accident.
+    pub insecure_loopback: bool,
+    /// Whether to drive control input from the RadioMaster Pocket via HID
+    /// instead of the synthetic sine-wave generator.
+    pub hid: bool,
+    /// How many wall-clock seconds to run the control/telemetry loop.
+    pub seconds: u64,
+    /// Control-frame send rate in Hz.
+    pub rate: u64,
+}
+
+const DEFAULT_SECONDS: u64 = 3;
+const DEFAULT_RATE: u64 = 100;
+
+/// Parses `std::env::args()` (already stripped of argv\[0\]) into [`Args`].
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Usage`] if `--url` is missing, or any flag value
+/// fails to parse. Returns [`ProbeError::InvalidUrl`] if `--insecure-loopback`
+/// is set without a required companion, though URL loopback-scope validation
+/// itself lives in `transport` (it needs a parsed URL, not raw args).
+pub fn parse_args(args: &[String]) -> Result<Args, ProbeError> {
+    let url = require_flag(args, "--url")?.to_string();
+    let insecure_loopback = has_flag(args, "--insecure-loopback");
+    if !insecure_loopback {
+        return Err(ProbeError::Usage {
+            message: "--insecure-loopback is required (this tool only talks to loopback hosts \
+                      and skips certificate verification; passing the flag is how you attest \
+                      that's understood)"
+                .to_string(),
+        });
+    }
+    let hid = has_flag(args, "--hid");
+    let seconds = optional_u64(args, "--seconds")?.unwrap_or(DEFAULT_SECONDS);
+    let rate = optional_u64(args, "--rate")?.unwrap_or(DEFAULT_RATE);
+    if rate == 0 {
+        return Err(ProbeError::Usage {
+            message: "--rate must be greater than zero".to_string(),
+        });
+    }
+    Ok(Args {
+        url,
+        insecure_loopback,
+        hid,
+        seconds,
+        rate,
+    })
+}
+
+/// Returns whether boolean flag `name` is present anywhere in `args`.
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|arg| arg == name)
+}
+
+/// Finds `--name VALUE` in `args` and returns `VALUE`, erroring if absent.
+fn require_flag<'a>(args: &'a [String], name: &str) -> Result<&'a str, ProbeError> {
+    let position = args
+        .iter()
+        .position(|arg| arg == name)
+        .ok_or_else(|| ProbeError::Usage {
+            message: format!("missing required flag {name}"),
+        })?;
+    args.get(position + 1)
+        .map(String::as_str)
+        .ok_or_else(|| ProbeError::Usage {
+            message: format!("{name} requires a value"),
+        })
+}
+
+/// Finds `--name VALUE` in `args` and parses it as `u64`, returning `None`
+/// if the flag was not supplied at all.
+fn optional_u64(args: &[String], name: &str) -> Result<Option<u64>, ProbeError> {
+    let Some(position) = args.iter().position(|arg| arg == name) else {
+        return Ok(None);
+    };
+    let raw = args.get(position + 1).ok_or_else(|| ProbeError::Usage {
+        message: format!("{name} requires a value"),
+    })?;
+    let value = raw.parse::<u64>().map_err(|source| ProbeError::Usage {
+        message: format!("{name} expects an integer, got '{raw}': {source}"),
+    })?;
+    Ok(Some(value))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{Args, parse_args};
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|item| (*item).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_minimal_required_flags_with_defaults() {
+        let parsed = parse_args(&args(&[
+            "--url",
+            "https://127.0.0.1:4433",
+            "--insecure-loopback",
+        ]))
+        .expect("parses");
+        assert_eq!(
+            parsed,
+            Args {
+                url: "https://127.0.0.1:4433".to_string(),
+                insecure_loopback: true,
+                hid: false,
+                seconds: 3,
+                rate: 100,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_all_flags() {
+        let parsed = parse_args(&args(&[
+            "--url",
+            "https://127.0.0.1:4433",
+            "--insecure-loopback",
+            "--hid",
+            "--seconds",
+            "10",
+            "--rate",
+            "50",
+        ]))
+        .expect("parses");
+        assert!(parsed.hid);
+        assert_eq!(parsed.seconds, 10);
+        assert_eq!(parsed.rate, 50);
+    }
+
+    #[test]
+    fn rejects_missing_url() {
+        assert!(parse_args(&args(&["--insecure-loopback"])).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_insecure_loopback_flag() {
+        assert!(parse_args(&args(&["--url", "https://127.0.0.1:4433"])).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_rate() {
+        let err = parse_args(&args(&[
+            "--url",
+            "https://127.0.0.1:4433",
+            "--insecure-loopback",
+            "--rate",
+            "0",
+        ]));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn rejects_non_integer_seconds() {
+        let err = parse_args(&args(&[
+            "--url",
+            "https://127.0.0.1:4433",
+            "--insecure-loopback",
+            "--seconds",
+            "soon",
+        ]));
+        assert!(err.is_err());
+    }
+}

--- a/tools/loopback-probe/src/control_source.rs
+++ b/tools/loopback-probe/src/control_source.rs
@@ -1,0 +1,100 @@
+//! Reads the physical RadioMaster Pocket through `hidapi` (`--hid` path).
+//!
+//! This module owns I/O (blocking device reads), so it lives in this binary
+//! rather than a `crates/` sans-IO core (ADR-0002).
+
+use std::time::Instant;
+
+use hidapi::{HidApi, HidDevice};
+use pilotage_input::RawDeviceSample;
+use pilotage_timing::MonoTimestamp;
+
+use crate::error::ProbeError;
+use crate::hid_decode::decode_report;
+
+/// RadioMaster Pocket USB vendor ID (matches `tools/hid-probe`'s verified
+/// value for the physical unit).
+const TARGET_VENDOR_ID: u16 = 0x1209;
+/// RadioMaster Pocket USB product ID.
+const TARGET_PRODUCT_ID: u16 = 0x4F54;
+/// Report buffer size: generously oversized for the 19-byte input report.
+const REPORT_BUF_LEN: usize = 64;
+/// Per-read timeout in milliseconds; short so a stale report never blocks a
+/// send tick past its deadline.
+const READ_TIMEOUT_MS: i32 = 5;
+/// Axis count in a neutral (no-report-yet) sample: matches the RadioMaster
+/// Pocket profile's 8 configured axes.
+const NEUTRAL_AXIS_COUNT: usize = 8;
+
+/// An open RadioMaster Pocket HID handle plus the clock it timestamps
+/// samples from.
+pub struct HidSource {
+    device: HidDevice,
+    start: Instant,
+    /// Kept alive only because `HidDevice` borrows from it; dropping this
+    /// would invalidate `device`.
+    _api: HidApi,
+}
+
+impl HidSource {
+    /// Opens the RadioMaster Pocket via `hidapi`, timing samples from
+    /// `start`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProbeError::Hid`] if the backend fails to initialize or the
+    /// device fails to open.
+    pub fn open(start: Instant) -> Result<Self, ProbeError> {
+        let api = HidApi::new()?;
+        let device = api.open(TARGET_VENDOR_ID, TARGET_PRODUCT_ID)?;
+        Ok(Self {
+            device,
+            start,
+            _api: api,
+        })
+    }
+
+    /// Reads one HID report (if available within the timeout) and decodes
+    /// it; on timeout, returns a neutral all-zero sample stamped at the
+    /// current elapsed time so the control loop's cadence is never gated on
+    /// device liveness.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProbeError::Hid`] if a HID read fails outright (not merely
+    /// times out).
+    pub fn sample(&self) -> Result<RawDeviceSample, ProbeError> {
+        let mut buf = [0u8; REPORT_BUF_LEN];
+        let sampled_at = elapsed_to_timestamp(self.start.elapsed());
+        let read = self.device.read_timeout(&mut buf, READ_TIMEOUT_MS)?;
+        if read == 0 {
+            return Ok(RawDeviceSample::new(
+                vec![0.0; NEUTRAL_AXIS_COUNT],
+                0,
+                sampled_at,
+            ));
+        }
+        Ok(decode_report(&buf[..read], sampled_at))
+    }
+}
+
+/// Converts an elapsed wall-clock duration into a [`MonoTimestamp`],
+/// saturating rather than truncating on the (practically unreachable) case
+/// of a run longer than `u64::MAX` nanoseconds.
+#[allow(clippy::cast_possible_truncation)]
+pub fn elapsed_to_timestamp(elapsed: std::time::Duration) -> MonoTimestamp {
+    MonoTimestamp::from_nanos(elapsed.as_nanos().min(u128::from(u64::MAX)) as u64)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::elapsed_to_timestamp;
+    use std::time::Duration;
+
+    #[test]
+    fn elapsed_to_timestamp_converts_nanos() {
+        let ts = elapsed_to_timestamp(Duration::from_millis(5));
+        assert_eq!(ts.as_nanos(), 5_000_000);
+    }
+}

--- a/tools/loopback-probe/src/error.rs
+++ b/tools/loopback-probe/src/error.rs
@@ -1,0 +1,96 @@
+//! Typed errors for the `loopback-probe` binary.
+
+/// Errors this tool's run loop can produce.
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// Argument parsing failed: an unknown flag or missing/malformed value.
+    #[error("usage error: {message}")]
+    Usage {
+        /// Human-readable description of what was wrong with the arguments.
+        message: String,
+    },
+    /// `--url` did not parse as a URL this tool understands.
+    #[error("invalid --url '{url}': {message}")]
+    InvalidUrl {
+        /// The raw `--url` value supplied.
+        url: String,
+        /// Why the URL was rejected.
+        message: String,
+    },
+    /// `--url` named a non-loopback host while `--insecure-loopback` was
+    /// set; refused per the flag's documented scope (see `cli`).
+    #[error(
+        "--insecure-loopback refuses non-loopback host '{host}': cert verification would be \
+         skipped against a host this tool cannot vouch for"
+    )]
+    NonLoopbackHost {
+        /// The rejected host.
+        host: String,
+    },
+    /// The underlying `hidapi` backend failed to initialize, enumerate, or
+    /// open a device.
+    #[error("hidapi error: {message}")]
+    Hid {
+        /// Message from the underlying `hidapi::HidError`.
+        message: String,
+    },
+    /// The `wtransport` client configuration or connection attempt failed.
+    #[error("webtransport connect error: {message}")]
+    Connect {
+        /// Message from the underlying `wtransport` error.
+        message: String,
+    },
+    /// Opening or using a bidirectional stream failed.
+    #[error("bidi stream error: {message}")]
+    BidiStream {
+        /// Message from the underlying `wtransport` error.
+        message: String,
+    },
+    /// Sending a datagram failed.
+    #[error("datagram send error: {message}")]
+    DatagramSend {
+        /// Message from the underlying `wtransport` error.
+        message: String,
+    },
+    /// The host's reply did not match what this tool sent (wrong message
+    /// variant, or a denial where a grant was expected).
+    #[error("protocol error: {message}")]
+    Protocol {
+        /// Human-readable description of the mismatch.
+        message: String,
+    },
+    /// Decoding bytes off the wire into a domain message failed.
+    #[error("decode error: {source}")]
+    Decode {
+        /// Underlying `pilotage-protocol` decode error.
+        #[source]
+        source: pilotage_protocol::DecodeError,
+    },
+    /// Loading or parsing the RadioMaster Pocket device profile failed.
+    #[error("device profile error: {source}")]
+    Profile {
+        /// Underlying `pilotage-input` profile error.
+        #[source]
+        source: pilotage_input::ProfileError,
+    },
+}
+
+impl From<hidapi::HidError> for ProbeError {
+    fn from(source: hidapi::HidError) -> Self {
+        Self::Hid {
+            message: source.to_string(),
+        }
+    }
+}
+
+impl From<pilotage_protocol::DecodeError> for ProbeError {
+    fn from(source: pilotage_protocol::DecodeError) -> Self {
+        Self::Decode { source }
+    }
+}
+
+impl From<pilotage_input::ProfileError> for ProbeError {
+    fn from(source: pilotage_input::ProfileError) -> Self {
+        Self::Profile { source }
+    }
+}

--- a/tools/loopback-probe/src/hid_decode.rs
+++ b/tools/loopback-probe/src/hid_decode.rs
@@ -1,0 +1,97 @@
+//! Raw HID input-report decoding for the RadioMaster Pocket.
+//!
+//! Only [`le_u16_words`] is a twin of `tools/hid-probe/src/decode.rs`: the
+//! same generic little-endian word-splitting, duplicated rather than shared
+//! because it is a few lines of pure reshaping with no behavior either binary
+//! would want to change independently of the other. `hid-probe`'s decoder
+//! deliberately assumes no report layout (it exists to produce the raw hex
+//! dump a layout is discovered from); this module's [`decode_report`] and
+//! [`report_button_mask`] are not mirrored there — they encode the
+//! RadioMaster Pocket's specific report layout empirically verified against
+//! `crates/pilotage-input/registry/fixtures/radiomaster-pocket-capture.json`:
+//! 19 bytes total, the first 3 bytes a button bitmap, the remaining 16 bytes
+//! 8 little-endian `u16` axis words. If this grows further decode logic
+//! (calibration, axis semantics), move it into `pilotage-input` instead of
+//! adding a third copy.
+
+/// Decodes `bytes` as a sequence of little-endian `u16` words, dropping a
+/// trailing odd byte if present.
+#[must_use]
+pub fn le_u16_words(bytes: &[u8]) -> Vec<u16> {
+    bytes
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+        .collect()
+}
+
+/// Converts a RadioMaster Pocket input report into a
+/// [`pilotage_input::RawDeviceSample`]: the first 3 bytes are a 24-button
+/// bitmap, the remaining bytes are 8
+/// little-endian 11-bit-range `u16` axis words, per the layout recorded in
+/// `crates/pilotage-input/registry/radiomaster-pocket.json`.
+///
+/// `sampled_at` is supplied by the caller (this module is pure decode, not a
+/// clock source).
+#[must_use]
+pub fn decode_report(
+    bytes: &[u8],
+    sampled_at: pilotage_timing::MonoTimestamp,
+) -> pilotage_input::RawDeviceSample {
+    let buttons = report_button_mask(bytes);
+    let axis_bytes = bytes.get(3..).unwrap_or(&[]);
+    let axes = le_u16_words(axis_bytes)
+        .into_iter()
+        .map(f32::from)
+        .collect();
+    pilotage_input::RawDeviceSample::new(axes, buttons, sampled_at)
+}
+
+/// Packs the first 3 report bytes (24 buttons) into a `u64` bitmask,
+/// little-endian byte order matching the report layout.
+fn report_button_mask(bytes: &[u8]) -> u64 {
+    let mut mask = 0u64;
+    for (index, byte) in bytes.iter().take(3).enumerate() {
+        mask |= u64::from(*byte) << (index * 8);
+    }
+    mask
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{decode_report, le_u16_words, report_button_mask};
+    use pilotage_timing::MonoTimestamp;
+
+    #[test]
+    fn le_words_decodes_pairs_little_endian() {
+        assert_eq!(
+            le_u16_words(&[0xff, 0x07, 0x00, 0x08]),
+            vec![0x07ff, 0x0800]
+        );
+    }
+
+    #[test]
+    fn le_words_drops_trailing_odd_byte() {
+        assert_eq!(le_u16_words(&[0x01, 0x00, 0x02]), vec![0x0001]);
+    }
+
+    #[test]
+    fn button_mask_packs_three_bytes_little_endian() {
+        assert_eq!(
+            report_button_mask(&[0b0000_0001, 0b0000_0000, 0b0000_0000]),
+            1
+        );
+        assert_eq!(report_button_mask(&[0, 0b0000_0001, 0]), 1 << 8);
+    }
+
+    #[test]
+    fn decode_report_splits_buttons_and_axes() {
+        let mut report = vec![0b0000_0001u8, 0, 0];
+        report.extend_from_slice(&1024u16.to_le_bytes());
+        report.extend_from_slice(&0u16.to_le_bytes());
+        let sample = decode_report(&report, MonoTimestamp::from_nanos(0));
+        assert!(sample.button_held(0));
+        assert!(!sample.button_held(1));
+        assert_eq!(sample.axes, vec![1024.0, 0.0]);
+    }
+}

--- a/tools/loopback-probe/src/main.rs
+++ b/tools/loopback-probe/src/main.rs
@@ -1,0 +1,52 @@
+//! Native WebTransport client for the loopback session (increment 1):
+//! connects to a session host, leases `vehicle.motion`, sends synthetic or
+//! `--hid`-sourced control frames, and measures the loopback control loop.
+//!
+//! Not part of the sans-IO core (ADR-0002): this binary owns the
+//! WebTransport connection, device I/O, and wall-clock timing.
+
+mod cli;
+mod control_source;
+mod error;
+mod hid_decode;
+mod metrics;
+mod output;
+mod pipeline;
+mod receiver;
+mod run;
+mod sender;
+mod summary;
+mod synthetic;
+mod telemetry;
+mod transport;
+mod wire_session;
+
+use std::process::ExitCode;
+
+use error::ProbeError;
+use output::print_line;
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run_blocking(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            print_line(&format!("error: {error}"));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Parses arguments and drives the async probe run to completion on a
+/// dedicated multi-thread runtime, blocking the calling thread.
+///
+/// Named `_blocking` (ADR-0015) since it synchronously waits out the whole
+/// run rather than returning a future.
+fn run_blocking(args: &[String]) -> Result<(), ProbeError> {
+    let parsed = cli::parse_args(args)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|source| ProbeError::Connect {
+        message: format!("failed to start async runtime: {source}"),
+    })?;
+    runtime.block_on(run::run(&parsed))
+}

--- a/tools/loopback-probe/src/metrics.rs
+++ b/tools/loopback-probe/src/metrics.rs
@@ -1,0 +1,176 @@
+//! Run-level measurement accumulation: control-frame round-trip-to-telemetry
+//! latency, Ping/Pong RTT, and frame accept/reject/telemetry counters.
+//!
+//! Latency here is measured entirely on the client's own clock (loopback,
+//! same machine): a control frame's client send timestamp is compared
+//! against the client-observed receive timestamp of the first telemetry
+//! sample whose pose changed after it, both read from the same monotonic
+//! clock. This sidesteps ADR-0009's cross-endpoint comparison ban because
+//! no host-side timestamp is used in the computation at all; the tradeoff
+//! documented for readers is that this measures software + loopback-network
+//! latency only, not true cross-host wire time (ADR-0009's "local-loopback
+//! mode is the baseline that separates software latency from network
+//! latency").
+
+use std::time::Duration;
+
+use pilotage_timing::RttEstimator;
+
+/// A fixed-capacity, sorted-on-read latency histogram. Bounded so a long
+/// run cannot grow this without limit; the oldest sample is evicted and
+/// counted as dropped once full (mirrors `pilotage_timing::BoundedLatencyLog`'s
+/// eviction policy, but over a plain `Duration` since these samples are not
+/// tied to a `Stage`).
+pub struct Histogram {
+    samples: Vec<Duration>,
+    capacity: usize,
+    dropped: u64,
+}
+
+impl Histogram {
+    /// Constructs an empty histogram bounded to `capacity` retained samples.
+    #[must_use]
+    pub const fn new(capacity: usize) -> Self {
+        Self {
+            samples: Vec::new(),
+            capacity,
+            dropped: 0,
+        }
+    }
+
+    /// Records one latency sample, evicting the oldest once at capacity.
+    pub fn record(&mut self, sample: Duration) {
+        if self.samples.len() >= self.capacity {
+            self.samples.remove(0);
+            self.dropped = self.dropped.wrapping_add(1);
+        }
+        self.samples.push(sample);
+    }
+
+    /// Number of samples currently retained.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Number of samples evicted by capacity overrun.
+    #[must_use]
+    pub const fn dropped(&self) -> u64 {
+        self.dropped
+    }
+
+    /// Returns (p50, p95, max), or `None` if no samples were recorded.
+    #[must_use]
+    pub fn percentiles(&self) -> Option<(Duration, Duration, Duration)> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let mut sorted = self.samples.clone();
+        sorted.sort_unstable();
+        let p50 = percentile(&sorted, 50);
+        let p95 = percentile(&sorted, 95);
+        #[allow(clippy::expect_used)]
+        let max = *sorted.last().expect("checked non-empty above");
+        Some((p50, p95, max))
+    }
+}
+
+/// Nearest-rank percentile over an already-sorted, non-empty slice.
+fn percentile(sorted: &[Duration], pct: usize) -> Duration {
+    let len = sorted.len();
+    let rank = (pct * len).div_ceil(100).clamp(1, len);
+    sorted[rank - 1]
+}
+
+/// Accumulates every measurement this probe reports at the end of a run.
+pub struct RunMetrics {
+    /// Control-send -> matching-telemetry-change latency.
+    pub control_to_telemetry: Histogram,
+    /// Control frames evicted from the pending-match queue without ever
+    /// producing a latency sample. Two paths feed this: a frame sent at or
+    /// before the last telemetry sample's receive time (already reflected in
+    /// that pose, so a later change cannot causally belong to it), and a frame
+    /// dropped from the front because the queue reached its capacity bound
+    /// while telemetry lagged. Distinct from `Histogram::dropped`, which counts
+    /// samples that *were* matched but then evicted for exceeding the
+    /// histogram's own retention capacity.
+    pub control_to_telemetry_backlog_dropped: u64,
+    /// Ping/Pong round-trip time estimator.
+    pub rtt: RttEstimator,
+    /// Control frames sent (datagrams written).
+    pub frames_sent: u64,
+    /// `FrameRejected` notices received from the host.
+    pub frames_rejected: u64,
+    /// Telemetry samples received.
+    pub telemetry_received: u64,
+}
+
+impl RunMetrics {
+    /// Constructs an empty metrics accumulator with `histogram_capacity`
+    /// retained latency samples.
+    #[must_use]
+    pub const fn new(histogram_capacity: usize) -> Self {
+        Self {
+            control_to_telemetry: Histogram::new(histogram_capacity),
+            control_to_telemetry_backlog_dropped: 0,
+            rtt: RttEstimator::new(),
+            frames_sent: 0,
+            frames_rejected: 0,
+            telemetry_received: 0,
+        }
+    }
+
+    /// Frames accepted: sent minus explicitly rejected. Not a direct host
+    /// signal (the host does not ack accepts) — inferred as the complement
+    /// of rejection, which is exact as long as every sent frame either
+    /// lands or is rejected (true for the loopback path this tool targets).
+    #[must_use]
+    pub fn frames_accepted(&self) -> u64 {
+        self.frames_sent.saturating_sub(self.frames_rejected)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::Histogram;
+    use std::time::Duration;
+
+    #[test]
+    fn percentiles_of_single_sample() {
+        let mut hist = Histogram::new(10);
+        hist.record(Duration::from_millis(5));
+        let (p50, p95, max) = hist.percentiles().expect("has samples");
+        assert_eq!(p50, Duration::from_millis(5));
+        assert_eq!(p95, Duration::from_millis(5));
+        assert_eq!(max, Duration::from_millis(5));
+    }
+
+    #[test]
+    fn percentiles_over_sorted_range() {
+        let mut hist = Histogram::new(100);
+        for ms in 1..=100u64 {
+            hist.record(Duration::from_millis(ms));
+        }
+        let (p50, p95, max) = hist.percentiles().expect("has samples");
+        assert_eq!(p50, Duration::from_millis(50));
+        assert_eq!(p95, Duration::from_millis(95));
+        assert_eq!(max, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn empty_histogram_has_no_percentiles() {
+        let hist = Histogram::new(10);
+        assert!(hist.percentiles().is_none());
+    }
+
+    #[test]
+    fn overflow_evicts_oldest_and_counts_drop() {
+        let mut hist = Histogram::new(2);
+        hist.record(Duration::from_millis(1));
+        hist.record(Duration::from_millis(2));
+        hist.record(Duration::from_millis(3));
+        assert_eq!(hist.len(), 2);
+        assert_eq!(hist.dropped(), 1);
+    }
+}

--- a/tools/loopback-probe/src/output.rs
+++ b/tools/loopback-probe/src/output.rs
@@ -1,0 +1,16 @@
+//! The single sanctioned place this binary writes to stdout.
+//!
+//! `disallowed_macros` (ADR-0015) bans bare `println!`/`eprintln!` everywhere
+//! else in the workspace so that library crates never accidentally grow CLI
+//! side effects; this module is the CLI-product-output exception the lint
+//! rule anticipates (the run summary is this tool's actual deliverable, not
+//! a debug trace). Diagnostics still go through `tracing`.
+
+/// Writes one line of user-facing CLI output to stdout.
+// WHY: this is the tool's actual product (the end-of-run measurement
+// summary), not a debug trace, so the workspace-wide println ban is waived
+// here and nowhere else in this binary.
+#[allow(clippy::disallowed_macros)]
+pub fn print_line(line: &str) {
+    println!("{line}");
+}

--- a/tools/loopback-probe/src/pipeline.rs
+++ b/tools/loopback-probe/src/pipeline.rs
@@ -1,0 +1,152 @@
+//! Wraps `pilotage-input`'s normalization pipeline: turns a raw device
+//! sample into a [`ControlPayload`] using a loaded [`DeviceProfile`].
+
+use pilotage_input::{
+    ButtonTracker, DeviceProfile, RawDeviceSample, axis_id_for_name, button_id_for_name,
+    normalize_axis,
+};
+use pilotage_protocol::{ButtonEdge as ProtoButtonEdge, ControlPayload};
+
+use crate::error::ProbeError;
+
+/// Loads the RadioMaster Pocket device profile embedded at compile time
+/// from `crates/pilotage-input/registry/radiomaster-pocket.json`.
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Profile`] if the embedded JSON fails to parse or
+/// validate (only possible if the registry file itself is corrupted).
+pub fn load_radiomaster_pocket_profile() -> Result<DeviceProfile, ProbeError> {
+    const PROFILE_JSON: &str =
+        include_str!("../../../crates/pilotage-input/registry/radiomaster-pocket.json");
+    Ok(pilotage_input::load_profile_str(PROFILE_JSON)?)
+}
+
+/// Stateful pipeline stage: holds the button-edge tracker across samples so
+/// held buttons emit exactly one press and one release edge, per
+/// `pilotage_input::ButtonTracker`'s contract.
+pub struct Pipeline {
+    profile: DeviceProfile,
+    tracker: ButtonTracker,
+}
+
+impl Pipeline {
+    /// Constructs a pipeline bound to `profile`, with no buttons held.
+    #[must_use]
+    pub const fn new(profile: DeviceProfile) -> Self {
+        Self {
+            profile,
+            tracker: ButtonTracker::new(),
+        }
+    }
+
+    /// Runs `sample` through calibration/deadzone/expo/invert normalization
+    /// for every configured axis and edge-detects every configured button,
+    /// producing the [`ControlPayload`] a control frame carries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProbeError::Profile`] if the profile references a logical
+    /// axis or button name outside the well-known table (`pilotage_input`
+    /// already validates this at load time, so this only re-surfaces a
+    /// defect in an embedded profile, not a runtime device condition).
+    pub fn normalize(&mut self, sample: &RawDeviceSample) -> Result<ControlPayload, ProbeError> {
+        let axes = self.normalize_axes(sample)?;
+        let edges = self.normalize_buttons(sample)?;
+        Ok(ControlPayload { axes, edges })
+    }
+
+    fn normalize_axes(
+        &self,
+        sample: &RawDeviceSample,
+    ) -> Result<Vec<(pilotage_protocol::LogicalAxisId, f32)>, ProbeError> {
+        self.profile
+            .axes
+            .iter()
+            .map(|axis| {
+                let raw = sample.axes.get(axis.source_index).copied().unwrap_or(0.0);
+                let normalized = normalize_axis(raw, axis);
+                let id = axis_id_for_name(&axis.logical)?;
+                Ok((id, normalized.value))
+            })
+            .collect()
+    }
+
+    fn normalize_buttons(
+        &mut self,
+        sample: &RawDeviceSample,
+    ) -> Result<Vec<(pilotage_protocol::LogicalButtonId, ProtoButtonEdge)>, ProbeError> {
+        let edges = self.tracker.update(sample.buttons);
+        edges
+            .into_iter()
+            .map(|(source_index, edge)| {
+                let logical = self
+                    .profile
+                    .buttons
+                    .iter()
+                    .find(|button| button.source_index == source_index)
+                    .map(|button| button.logical.as_str());
+                match logical {
+                    Some(name) => Ok((button_id_for_name(name)?, edge)),
+                    None => Ok((
+                        pilotage_protocol::LogicalButtonId::new(u16::from(source_index)),
+                        edge,
+                    )),
+                }
+            })
+            .collect()
+    }
+
+    /// Returns the profile revision, carried on outgoing control frames so
+    /// the host knows which calibration produced a given frame.
+    #[must_use]
+    pub const fn profile_revision(&self) -> u32 {
+        self.profile.revision
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{Pipeline, load_radiomaster_pocket_profile};
+    use pilotage_input::RawDeviceSample;
+    use pilotage_timing::MonoTimestamp;
+
+    #[test]
+    fn builtin_profile_loads() {
+        let profile = load_radiomaster_pocket_profile().expect("profile loads");
+        assert_eq!(profile.axes.len(), 8);
+        assert_eq!(profile.buttons.len(), 24);
+    }
+
+    #[test]
+    fn normalize_produces_centered_axes_at_rest() {
+        let profile = load_radiomaster_pocket_profile().expect("profile loads");
+        let mut pipeline = Pipeline::new(profile);
+        let sample = RawDeviceSample::new(
+            vec![1024.0, 1024.0, 0.0, 1024.0, 0.0, 0.0, 0.0, 0.0],
+            0,
+            MonoTimestamp::from_nanos(0),
+        );
+        let payload = pipeline.normalize(&sample).expect("normalizes");
+        assert_eq!(payload.axes.len(), 8);
+        for (_, value) in &payload.axes {
+            assert!(
+                value.abs() < 1e-3,
+                "expected near-zero at rest, got {value}"
+            );
+        }
+        assert!(payload.edges.is_empty());
+    }
+
+    #[test]
+    fn normalize_emits_button_edge_on_press() {
+        let profile = load_radiomaster_pocket_profile().expect("profile loads");
+        let mut pipeline = Pipeline::new(profile);
+        let idle = RawDeviceSample::new(vec![0.0; 8], 0, MonoTimestamp::from_nanos(0));
+        let pressed = RawDeviceSample::new(vec![0.0; 8], 1, MonoTimestamp::from_nanos(1));
+        pipeline.normalize(&idle).expect("normalizes");
+        let payload = pipeline.normalize(&pressed).expect("normalizes");
+        assert_eq!(payload.edges.len(), 1);
+    }
+}

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -1,0 +1,327 @@
+//! Background task receiving inbound traffic concurrently with the send loop.
+//! Telemetry, `Pong`, and `FrameRejected` all arrive as datagrams (the host's
+//! control-fast/telemetry class mapping) and are routed by envelope arm; the
+//! bidi-stream branch remains only to observe a post-handshake stream close.
+
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{Instrument, warn};
+use wtransport::{Connection, RecvStream};
+
+use pilotage_protocol::wire;
+use prost::Message;
+
+use crate::control_source::elapsed_to_timestamp;
+use crate::error::ProbeError;
+use crate::telemetry::{TelemetryObservation, observation_from_sample};
+use crate::wire_session::{StreamMessage, decode_one};
+
+/// One event the receiver task hands to the run loop.
+#[derive(Debug)]
+pub enum ReceiverEvent {
+    /// A decoded telemetry sample.
+    Telemetry(TelemetryObservation),
+    /// A `FrameRejected` notice for a control frame this client sent.
+    FrameRejected(pilotage_protocol::FrameRejected),
+    /// A `Pong` reply to a `Ping` this client sent, plus the client-local
+    /// receive timestamp used to fold it into the RTT estimator.
+    Pong {
+        /// The decoded `Pong`.
+        pong: pilotage_protocol::Pong,
+        /// Client-local monotonic timestamp at receipt.
+        received_at: pilotage_timing::MonoTimestamp,
+    },
+    /// An authority/mode event read from the host's dedicated authority-events
+    /// stream (ADR-0005). Counted only, to prove the stream is live.
+    Authority,
+}
+
+/// Spawns the receiver task: one branch polls datagrams (telemetry, `Pong`,
+/// `FrameRejected`), the other reads the bootstrap bidi stream's `recv` half
+/// so a post-handshake stream close is observed. Named so an aborted-task
+/// audit can identify it (ADR-0015).
+///
+/// Takes only `recv_stream`; the bidi stream's send half stays in the run
+/// loop, kept open but unwritten after the handshake.
+///
+/// `run_start` is the shared monotonic origin the send loop also stamps from
+/// (ADR-0009): receive timestamps must derive from the same `Instant` as the
+/// frame/ping send timestamps, or the send/receive difference the metrics take
+/// (with a zero clock offset) mixes two independent origins and skews every
+/// control-to-telemetry latency and RTT sample.
+pub fn spawn_receiver(
+    connection: Connection,
+    recv_stream: RecvStream,
+    authority_stream: RecvStream,
+    run_start: Instant,
+    events_tx: mpsc::Sender<ReceiverEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(
+        receiver_loop(
+            connection,
+            recv_stream,
+            authority_stream,
+            run_start,
+            events_tx,
+        )
+        .instrument(tracing::info_span!("loopback_probe_receiver")),
+    )
+}
+
+/// Runs the datagram, bidi-stream, and authority-stream receive branches
+/// until the connection closes or the event channel's receiver is dropped.
+async fn receiver_loop(
+    connection: Connection,
+    mut recv_stream: RecvStream,
+    mut authority_stream: RecvStream,
+    start: Instant,
+    events_tx: mpsc::Sender<ReceiverEvent>,
+) {
+    let mut stream_buf = Vec::new();
+    let mut authority_buf = Vec::new();
+    let mut read_chunk = [0u8; 4096];
+    let mut authority_chunk = [0u8; 4096];
+    loop {
+        tokio::select! {
+            datagram = connection.receive_datagram() => {
+                match datagram {
+                    Ok(datagram) => handle_datagram(&datagram, start, &events_tx).await,
+                    Err(source) => {
+                        warn!(%source, "datagram receive failed; stopping receiver");
+                        return;
+                    }
+                }
+            }
+            read = recv_stream.read(&mut read_chunk) => {
+                match read {
+                    Ok(Some(count)) => {
+                        stream_buf.extend_from_slice(&read_chunk[..count]);
+                        drain_stream_frames(&mut stream_buf, start, &events_tx).await;
+                    }
+                    Ok(None) => {
+                        warn!("bidi stream closed; stopping receiver");
+                        return;
+                    }
+                    Err(source) => {
+                        warn!(%source, "bidi stream read failed; stopping receiver");
+                        return;
+                    }
+                }
+            }
+            read = authority_stream.read(&mut authority_chunk) => {
+                match read {
+                    Ok(Some(count)) => {
+                        authority_buf.extend_from_slice(&authority_chunk[..count]);
+                        drain_stream_frames(&mut authority_buf, start, &events_tx).await;
+                    }
+                    Ok(None) => {
+                        warn!("authority-events stream closed; stopping receiver");
+                        return;
+                    }
+                    Err(source) => {
+                        warn!(%source, "authority-events stream read failed; stopping receiver");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Decodes one datagram and forwards it as the matching [`ReceiverEvent`],
+/// dropping (with a warning) anything this probe does not expect on the
+/// datagram channel.
+///
+/// The host carries telemetry, `Pong`, and `FrameRejected` all on the
+/// control-fast/telemetry datagram channel (ADR-0005's class mapping; see
+/// the host's `to_connection_message`/`RejectFrame` handling), distinguished
+/// only by the envelope's payload arm — so this routes on that arm rather
+/// than assuming every datagram is telemetry.
+async fn handle_datagram(
+    datagram: &wtransport::datagram::Datagram,
+    start: std::time::Instant,
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+) {
+    let received_at = elapsed_to_timestamp(start.elapsed());
+    match decode_datagram_event(&datagram.payload(), received_at) {
+        Ok(event) => {
+            if events_tx.send(event).await.is_err() {
+                warn!("event channel closed while forwarding datagram event");
+            }
+        }
+        Err(source) => warn!(%source, "dropping undecodable datagram"),
+    }
+}
+
+/// Decodes one datagram envelope and maps its payload arm onto the matching
+/// [`ReceiverEvent`]. `TelemetrySample`, `Pong`, and `FrameRejected` all
+/// arrive on this channel from the host; any other arm is unexpected here.
+fn decode_datagram_event(
+    bytes: &[u8],
+    received_at: pilotage_timing::MonoTimestamp,
+) -> Result<ReceiverEvent, ProbeError> {
+    let envelope = wire::Envelope::decode(bytes).map_err(|source| ProbeError::Decode {
+        source: pilotage_protocol::DecodeError::Prost {
+            message: "pilotage.v1.Envelope",
+            source,
+        },
+    })?;
+    let payload = envelope.payload.ok_or_else(|| ProbeError::Protocol {
+        message: "datagram envelope carried no payload".to_string(),
+    })?;
+    match payload {
+        wire::envelope::Payload::TelemetrySample(sample) => Ok(ReceiverEvent::Telemetry(
+            observation_from_sample(&sample, received_at),
+        )),
+        wire::envelope::Payload::Pong(pong) => Ok(ReceiverEvent::Pong {
+            pong: pilotage_protocol::Pong::try_from(pong).map_err(|source| ProbeError::Decode {
+                source: pilotage_protocol::DecodeError::Convert(source),
+            })?,
+            received_at,
+        }),
+        wire::envelope::Payload::FrameRejected(rejected) => Ok(ReceiverEvent::FrameRejected(
+            pilotage_protocol::FrameRejected::try_from(rejected).map_err(|source| {
+                ProbeError::Decode {
+                    source: pilotage_protocol::DecodeError::Convert(source),
+                }
+            })?,
+        )),
+        other => Err(ProbeError::Protocol {
+            message: format!("unexpected envelope payload arm on datagram channel: {other:?}"),
+        }),
+    }
+}
+
+/// Decodes every complete length-delimited frame currently buffered from
+/// the bidi stream, forwarding `FrameRejected`/`Pong` and warning on
+/// anything else; leaves a trailing partial frame in `buf` for the next
+/// read.
+async fn drain_stream_frames(
+    buf: &mut Vec<u8>,
+    start: std::time::Instant,
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+) {
+    loop {
+        match decode_one(buf) {
+            Ok((message, consumed)) => {
+                buf.drain(..consumed);
+                forward_stream_message(message, start, events_tx).await;
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Maps a decoded [`StreamMessage`] onto the [`ReceiverEvent`]s this probe
+/// forwards to the run loop, discarding (with a warning) message kinds it
+/// has no use for.
+async fn forward_stream_message(
+    message: StreamMessage,
+    start: std::time::Instant,
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+) {
+    let event = match message {
+        StreamMessage::FrameRejected(rejected) => ReceiverEvent::FrameRejected(rejected),
+        StreamMessage::Pong(pong) => ReceiverEvent::Pong {
+            pong,
+            received_at: elapsed_to_timestamp(start.elapsed()),
+        },
+        StreamMessage::AuthorityEvent(_) => ReceiverEvent::Authority,
+        StreamMessage::ServerWelcome(_) | StreamMessage::LeaseResponse(_) => {
+            warn!("unexpected handshake message arrived after handshake completed");
+            return;
+        }
+    };
+    if events_tx.send(event).await.is_err() {
+        warn!("event channel closed while forwarding stream message");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{ReceiverEvent, decode_datagram_event};
+    use pilotage_protocol::wire;
+    use pilotage_timing::MonoTimestamp;
+    use prost::Message;
+
+    fn encode(payload: wire::envelope::Payload) -> Vec<u8> {
+        wire::Envelope {
+            schema_version: 1,
+            payload: Some(payload),
+        }
+        .encode_to_vec()
+    }
+
+    #[test]
+    fn routes_telemetry_arm() {
+        let bytes = encode(wire::envelope::Payload::TelemetrySample(
+            wire::TelemetrySample {
+                vehicle: Some(wire::VehicleId { value: 1 }),
+                tick: Some(wire::SimTick { value: 0 }),
+                observed_at: Some(wire::MonoTimestamp { nanos: 0 }),
+                pose: Some(wire::Pose2d {
+                    x_m: 1.0,
+                    y_m: 2.0,
+                    heading_rad: 0.0,
+                }),
+                velocity: None,
+            },
+        ));
+        let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(5)).expect("telemetry");
+        assert!(matches!(event, ReceiverEvent::Telemetry(_)));
+    }
+
+    #[test]
+    fn routes_pong_arm() {
+        let bytes = encode(wire::envelope::Payload::Pong(wire::Pong {
+            nonce: 7,
+            echoed_sender_sent_at: Some(wire::MonoTimestamp { nanos: 1 }),
+            responder_sent_at: Some(wire::MonoTimestamp { nanos: 2 }),
+        }));
+        let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(9)).expect("pong");
+        match event {
+            ReceiverEvent::Pong { pong, received_at } => {
+                assert_eq!(pong.nonce, 7);
+                assert_eq!(received_at, MonoTimestamp::from_nanos(9));
+            }
+            _ => panic!("expected Pong"),
+        }
+    }
+
+    #[test]
+    fn routes_frame_rejected_arm() {
+        let bytes = encode(wire::envelope::Payload::FrameRejected(
+            wire::FrameRejected {
+                vehicle: Some(wire::VehicleId { value: 1 }),
+                scope: Some(wire::ScopeId {
+                    value: "vehicle.motion".to_string(),
+                }),
+                sequence: Some(wire::SequenceNum { value: 42 }),
+                current_generation: Some(wire::Generation { value: 3 }),
+                reason: wire::FrameRejectionReason::StaleGeneration as i32,
+            },
+        ));
+        let event =
+            decode_datagram_event(&bytes, MonoTimestamp::from_nanos(0)).expect("frame rejected");
+        match event {
+            ReceiverEvent::FrameRejected(rejected) => {
+                assert_eq!(rejected.sequence.as_u32(), 42);
+            }
+            _ => panic!("expected FrameRejected"),
+        }
+    }
+
+    #[test]
+    fn rejects_unexpected_arm() {
+        let bytes = encode(wire::envelope::Payload::Ping(wire::Ping {
+            nonce: 1,
+            sender_sent_at: Some(wire::MonoTimestamp { nanos: 0 }),
+        }));
+        let err = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(0))
+            .expect_err("Ping is not a datagram-channel arm");
+        assert!(matches!(err, super::ProbeError::Protocol { .. }));
+    }
+}

--- a/tools/loopback-probe/src/run.rs
+++ b/tools/loopback-probe/src/run.rs
@@ -1,0 +1,209 @@
+//! Orchestrates one probe run: connect, handshake, concurrent send/receive
+//! loops, the stale-generation fencing probe, and the summary print.
+
+use std::time::{Duration, Instant};
+
+use pilotage_protocol::{ScopedControlFrame, SequenceNum, VehicleId};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+use wtransport::{Connection, RecvStream};
+
+use crate::cli::Args;
+use crate::error::ProbeError;
+use crate::metrics::RunMetrics;
+use crate::receiver::{ReceiverEvent, spawn_receiver};
+use crate::sender::run_send_loop;
+use crate::summary::print_summary;
+use crate::transport::{client_endpoint, connect, handshake, validate_loopback_url};
+
+/// The vehicle this probe always targets; this tool has no per-run vehicle
+/// selection flag (out of scope per the task), so a fixed id keeps the
+/// `vehicle.motion` lease request unambiguous.
+const PROBE_VEHICLE: VehicleId = VehicleId::new(1);
+/// Latency-histogram capacity: comfortably above `rate * seconds` for any
+/// realistic run, so eviction only ever triggers on a run long enough that
+/// eviction is the intended behavior (bounded memory, ADR-0009).
+const HISTOGRAM_CAPACITY: usize = 100_000;
+/// Bounded channel capacity between the receiver task and the run loop;
+/// sized so a burst of telemetry does not need unbounded buffering. A full
+/// channel drops the oldest-pending event and counts it (ADR-0015: a
+/// lagging consumer is a correctness signal, not silent).
+const EVENT_CHANNEL_CAPACITY: usize = 4096;
+
+/// Runs the full probe: connect, handshake, timed send/receive loop, the
+/// fencing probe, then prints the summary.
+///
+/// # Errors
+///
+/// Returns a [`ProbeError`] if the connection, handshake, or transport I/O
+/// fails. A rejected lease or fencing probe outcome is reported in the
+/// summary, not as an error, since a `FrameRejected` reply is this probe's
+/// expected, successful outcome for that step.
+pub async fn run(args: &Args) -> Result<(), ProbeError> {
+    validate_loopback_url(&args.url)?;
+    let endpoint = client_endpoint()?;
+    let connection = connect(&endpoint, &args.url).await?;
+    // The bootstrap send half is kept open for the whole run (dropping it
+    // would half-close the stream); handshake replies and control/ping
+    // traffic now flow on datagrams, so it is not written to after the
+    // handshake.
+    let (outcome, _send_stream, recv_stream) = handshake(&connection, PROBE_VEHICLE).await?;
+    info!(
+        session = outcome.welcome.session.as_u64(),
+        generation = outcome.lease.generation.as_u64(),
+        "vehicle.motion lease granted"
+    );
+
+    // The host opens a dedicated uni stream toward the client for reliable
+    // ordered authority events (ADR-0005); accept it so those events are read
+    // off their own stream rather than left unserviced.
+    let authority_stream = accept_authority_stream(&connection).await?;
+
+    // The send loop and the receiver task must stamp send and receive
+    // timestamps from the same monotonic origin (ADR-0009): the metrics
+    // subtract them with a zero clock offset, so a second `Instant` origin in
+    // the receiver would offset every latency and RTT sample by the gap
+    // between the two origins.
+    let run_start = Instant::now();
+
+    let (events_tx, mut events_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+    let receiver_handle = spawn_receiver(
+        connection.clone(),
+        recv_stream,
+        authority_stream,
+        run_start,
+        events_tx,
+    );
+
+    let mut metrics = RunMetrics::new(HISTOGRAM_CAPACITY);
+    let session = outcome.welcome.session;
+    let generation = outcome.lease.generation;
+    let run_budget = Duration::from_secs(args.seconds);
+
+    let last_sequence = run_send_loop(
+        &connection,
+        args,
+        session,
+        generation,
+        run_start,
+        run_budget,
+        &mut events_rx,
+        &mut metrics,
+    )
+    .await?;
+
+    let fencing_confirmed = send_stale_generation_probe(
+        &connection,
+        session,
+        generation,
+        last_sequence,
+        run_start,
+        &mut events_rx,
+        &mut metrics,
+    )
+    .await;
+
+    drain_pending_events(&mut events_rx, &mut metrics);
+    receiver_handle.abort();
+
+    print_summary(&metrics, fencing_confirmed);
+    Ok(())
+}
+
+/// Accepts the host's dedicated authority-events uni stream (ADR-0005).
+///
+/// # Errors
+///
+/// Returns [`ProbeError::BidiStream`] if the stream cannot be accepted; the
+/// host opens it immediately after the connection is established, so a failure
+/// here means the session did not come up as expected.
+async fn accept_authority_stream(connection: &Connection) -> Result<RecvStream, ProbeError> {
+    connection
+        .accept_uni()
+        .await
+        .map_err(|source| ProbeError::BidiStream {
+            message: format!("authority-events stream not accepted: {source}"),
+        })
+}
+
+/// Sends one control frame carrying a generation strictly older than the
+/// lease's granted generation, then waits briefly for the matching
+/// `FrameRejected` as end-to-end fencing proof.
+async fn send_stale_generation_probe(
+    connection: &Connection,
+    session: pilotage_protocol::SessionId,
+    current_generation: pilotage_protocol::Generation,
+    last_sequence: SequenceNum,
+    run_start: Instant,
+    events_rx: &mut mpsc::Receiver<ReceiverEvent>,
+    metrics: &mut RunMetrics,
+) -> bool {
+    let stale_generation =
+        pilotage_protocol::Generation::new(current_generation.as_u64().wrapping_sub(1));
+    let stale_sequence = last_sequence.next();
+    let frame = ScopedControlFrame {
+        session,
+        vehicle: PROBE_VEHICLE,
+        scope: pilotage_protocol::ScopeId::new("vehicle.motion"),
+        generation: stale_generation,
+        sequence: stale_sequence,
+        sampled_at: crate::control_source::elapsed_to_timestamp(run_start.elapsed()),
+        profile_revision: 0,
+        payload: pilotage_protocol::ControlPayload::default(),
+    };
+    let bytes = pilotage_protocol::encode_control_frame_envelope(&frame);
+    if let Err(source) = connection.send_datagram(bytes) {
+        warn!(%source, "failed to send stale-generation fencing probe frame");
+        return false;
+    }
+    metrics.frames_sent = metrics.frames_sent.saturating_add(1);
+
+    wait_for_rejection(events_rx, stale_sequence, metrics).await
+}
+
+/// Waits up to a short fixed deadline for a `FrameRejected` matching
+/// `sequence` to arrive on the receiver channel, folding it (and any other
+/// event observed while waiting) into `metrics`.
+async fn wait_for_rejection(
+    events_rx: &mut mpsc::Receiver<ReceiverEvent>,
+    sequence: SequenceNum,
+    metrics: &mut RunMetrics,
+) -> bool {
+    const FENCING_WAIT: Duration = Duration::from_millis(500);
+    let deadline = Instant::now() + FENCING_WAIT;
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        match tokio::time::timeout(remaining, events_rx.recv()).await {
+            Ok(Some(ReceiverEvent::FrameRejected(rejected))) => {
+                metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+                if rejected.sequence == sequence {
+                    return true;
+                }
+            }
+            Ok(Some(ReceiverEvent::Telemetry(_))) => {
+                metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
+            }
+            Ok(Some(ReceiverEvent::Pong { .. } | ReceiverEvent::Authority)) | Err(_) => {}
+            Ok(None) => return false,
+        }
+    }
+}
+
+/// Drains any events still queued after the run loop and fencing probe
+/// finish, folding trailing telemetry/rejection counts into `metrics`
+/// rather than discarding them silently.
+fn drain_pending_events(events_rx: &mut mpsc::Receiver<ReceiverEvent>, metrics: &mut RunMetrics) {
+    while let Ok(event) = events_rx.try_recv() {
+        match event {
+            ReceiverEvent::Telemetry(_) => {
+                metrics.telemetry_received = metrics.telemetry_received.wrapping_add(1);
+            }
+            ReceiverEvent::FrameRejected(_) => {
+                metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+            }
+            ReceiverEvent::Pong { .. } | ReceiverEvent::Authority => {}
+        }
+    }
+}

--- a/tools/loopback-probe/src/sender.rs
+++ b/tools/loopback-probe/src/sender.rs
@@ -1,0 +1,275 @@
+//! The timed control-frame send loop: samples input at `--rate` Hz, sends
+//! each frame as a datagram, and correlates outbound sends with inbound
+//! telemetry/rejection/pong events to fill in `RunMetrics`. `Ping` also
+//! travels as a control-fast datagram (ADR-0005's class mapping); the host
+//! decodes RTT pings on the datagram channel, not the bootstrap stream.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use pilotage_protocol::{
+    ControlPayload, Generation, Ping, ScopeId, ScopedControlFrame, SequenceNum, SessionId,
+};
+use pilotage_timing::{ClockOffset, estimated_age};
+use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
+use tracing::warn;
+use wtransport::Connection;
+
+use crate::cli::Args;
+use crate::control_source::{HidSource, elapsed_to_timestamp};
+use crate::error::ProbeError;
+use crate::metrics::RunMetrics;
+use crate::pipeline::{Pipeline, load_radiomaster_pocket_profile};
+use crate::receiver::ReceiverEvent;
+use crate::synthetic;
+use crate::wire_session::encode_ping_datagram;
+
+/// Ping cadence: independent of the control-frame rate since RTT tracking
+/// only needs a modest sample rate, not per-tick probing.
+const PING_INTERVAL: Duration = Duration::from_millis(200);
+/// A local clock never has a nonzero offset from itself: every timestamp
+/// this probe compares (send vs. receive) is sampled from the same
+/// process's monotonic clock (see `metrics` module doc), so every
+/// `estimated_age` call in this file uses a zero offset by construction,
+/// not as a stand-in for a real cross-endpoint estimate.
+const ZERO_OFFSET: ClockOffset = ClockOffset::from_nanos(0);
+
+/// One tick's outstanding control frame, kept only long enough to match it
+/// against the first telemetry change that follows it, in send order.
+struct PendingFrame {
+    sent_at: pilotage_timing::MonoTimestamp,
+}
+
+/// Upper bound on outstanding unmatched frames queued in `SendLoopState::pending`.
+/// A telemetry-update rate slower than the send rate would otherwise grow this
+/// queue without limit; once full, the oldest unmatched frame is evicted and
+/// counted via `RunMetrics::control_to_telemetry_backlog_dropped` rather than
+/// silently discarded (ADR-0015: a lagging consumer is a correctness signal).
+const PENDING_QUEUE_CAPACITY: usize = 1024;
+
+/// Bundles the mutable per-run state `run_send_loop` threads through each
+/// tick, keeping the function's own argument list within the workspace's
+/// per-function limits.
+struct SendLoopState {
+    hid_source: Option<HidSource>,
+    pipeline: Option<Pipeline>,
+    sequence: SequenceNum,
+    pending: VecDeque<PendingFrame>,
+    last_pose: Option<(f32, f32, f32)>,
+    /// Receive timestamp of the most recent telemetry sample folded in.
+    /// Frames sent at or before this instant were already in flight when the
+    /// last telemetry arrived without changing the pose, so a later pose
+    /// change cannot causally belong to them; they are evicted rather than
+    /// matched (see `handle_event`).
+    last_telemetry_at: Option<pilotage_timing::MonoTimestamp>,
+    ping_nonce: u64,
+}
+
+/// Runs the timed send loop for `args.seconds` at `args.rate` Hz, folding
+/// every observed event into `metrics`. Returns the last sequence number
+/// sent, so the caller's stale-generation probe can pick the next one.
+///
+/// # Errors
+///
+/// Returns a [`ProbeError`] if opening the HID device (`--hid`) fails, or a
+/// datagram send fails outright.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_send_loop(
+    connection: &Connection,
+    args: &Args,
+    session: SessionId,
+    generation: Generation,
+    run_start: Instant,
+    run_budget: Duration,
+    events_rx: &mut mpsc::Receiver<ReceiverEvent>,
+    metrics: &mut RunMetrics,
+) -> Result<SequenceNum, ProbeError> {
+    let mut state = SendLoopState {
+        hid_source: args.hid.then(|| HidSource::open(run_start)).transpose()?,
+        pipeline: args
+            .hid
+            .then(load_radiomaster_pocket_profile)
+            .transpose()?
+            .map(Pipeline::new),
+        sequence: SequenceNum::new(0),
+        pending: VecDeque::new(),
+        last_pose: None,
+        last_telemetry_at: None,
+        ping_nonce: 0,
+    };
+
+    let period = Duration::from_secs(1)
+        .checked_div(u32::try_from(args.rate).unwrap_or(u32::MAX))
+        .unwrap_or(Duration::from_millis(1));
+    let mut tick = tokio::time::interval(period);
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut ping_tick = tokio::time::interval(PING_INTERVAL);
+    ping_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    while run_start.elapsed() < run_budget {
+        tokio::select! {
+            _ = tick.tick() => {
+                send_one_frame(connection, session, generation, run_start, &mut state, metrics)?;
+            }
+            _ = ping_tick.tick() => {
+                send_ping(connection, run_start, &mut state);
+            }
+            Some(event) = events_rx.recv() => {
+                handle_event(event, &mut state, metrics);
+            }
+        }
+    }
+    Ok(state.sequence)
+}
+
+/// Builds and sends one control frame for the next sequence number.
+fn send_one_frame(
+    connection: &Connection,
+    session: SessionId,
+    generation: Generation,
+    run_start: Instant,
+    state: &mut SendLoopState,
+    metrics: &mut RunMetrics,
+) -> Result<(), ProbeError> {
+    state.sequence = state.sequence.next();
+    let sampled_at = elapsed_to_timestamp(run_start.elapsed());
+    let (payload, profile_revision) = build_payload(state, run_start)?;
+    let frame = ScopedControlFrame {
+        session,
+        vehicle: pilotage_protocol::VehicleId::new(1),
+        scope: ScopeId::new("vehicle.motion"),
+        generation,
+        sequence: state.sequence,
+        sampled_at,
+        profile_revision,
+        payload,
+    };
+    let bytes = pilotage_protocol::encode_control_frame_envelope(&frame);
+    connection
+        .send_datagram(bytes)
+        .map_err(|source| ProbeError::DatagramSend {
+            message: source.to_string(),
+        })?;
+    metrics.frames_sent = metrics.frames_sent.saturating_add(1);
+    if state.pending.len() >= PENDING_QUEUE_CAPACITY {
+        state.pending.pop_front();
+        metrics.control_to_telemetry_backlog_dropped = metrics
+            .control_to_telemetry_backlog_dropped
+            .saturating_add(1);
+    }
+    state.pending.push_back(PendingFrame {
+        sent_at: sampled_at,
+    });
+    Ok(())
+}
+
+/// Logical axis ids the reference adapter's `vehicle.motion` scope accepts
+/// (`throttle` and `yaw`). The RadioMaster Pocket profile normalizes all
+/// eight stick/aux axes; the adapter rejects a frame carrying any axis
+/// outside its scope (`UnknownAxis`), so the HID payload is filtered to these
+/// before it goes on the wire.
+const MOTION_SCOPE_AXES: [u16; 2] = [2, 3];
+
+/// Produces this tick's payload and profile revision from whichever source
+/// is active (`--hid` or the synthetic sine generator).
+fn build_payload(
+    state: &mut SendLoopState,
+    run_start: Instant,
+) -> Result<(ControlPayload, u32), ProbeError> {
+    match (&mut state.hid_source, &mut state.pipeline) {
+        (Some(source), Some(pipeline)) => {
+            let sample = source.sample()?;
+            let mut payload = pipeline.normalize(&sample)?;
+            payload
+                .axes
+                .retain(|(axis, _)| MOTION_SCOPE_AXES.contains(&axis.as_u16()));
+            Ok((payload, pipeline.profile_revision()))
+        }
+        _ => {
+            // Toggle a button0 edge every 200 ticks so the run also
+            // exercises edge-event encoding, not only continuous axes.
+            let edge = state
+                .sequence
+                .as_u32()
+                .is_multiple_of(200)
+                .then_some(pilotage_protocol::ButtonEdge::Pressed);
+            let payload = synthetic::payload_at(run_start.elapsed(), edge)?;
+            Ok((payload, 0))
+        }
+    }
+}
+
+/// Sends one `Ping` as a control-fast datagram. The host decodes RTT pings
+/// on the datagram channel (`decode_ping_datagram`), not the bootstrap
+/// stream, and answers with a `Pong` datagram; reply matching happens in the
+/// receiver task, which folds the `Pong` into `metrics.rtt` via
+/// [`ReceiverEvent::Pong`]. A send failure only logs, since a single missed
+/// ping does not abort the run.
+fn send_ping(connection: &Connection, run_start: Instant, state: &mut SendLoopState) {
+    state.ping_nonce = state.ping_nonce.wrapping_add(1);
+    let ping = Ping {
+        nonce: state.ping_nonce,
+        sender_sent_at: elapsed_to_timestamp(run_start.elapsed()),
+    };
+    if let Err(source) = connection.send_datagram(encode_ping_datagram(&ping)) {
+        warn!(%source, "ping datagram send failed");
+    }
+}
+
+/// Folds one receiver-task event into `metrics`. Telemetry pose changes are
+/// matched against the earliest frame sent *after* the previous telemetry
+/// sample; rejections and pongs are handled independently of the pending
+/// queue.
+fn handle_event(event: ReceiverEvent, state: &mut SendLoopState, metrics: &mut RunMetrics) {
+    match event {
+        ReceiverEvent::Telemetry(observation) => {
+            metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
+            fold_telemetry(&observation, state, metrics);
+        }
+        ReceiverEvent::FrameRejected(_) => {
+            metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+        }
+        ReceiverEvent::Pong { pong, received_at } => {
+            let rtt = estimated_age(received_at, pong.echoed_sender_sent_at, ZERO_OFFSET);
+            metrics.rtt.record(rtt);
+        }
+        ReceiverEvent::Authority => {}
+    }
+}
+
+/// Matches a telemetry observation against the frame that plausibly caused it.
+///
+/// A pose change can only be caused by a frame sent *after* the previous
+/// telemetry sample (an earlier frame was already reflected in that sample's
+/// pose). During a still period the pose is unchanged while many frames are
+/// sent, so those frames pile up in `pending`; matching the oldest of them
+/// (FIFO from the front) against a later pose change would record the latency
+/// of a frame sent seconds earlier. Instead, evict every frame sent at or
+/// before the previous telemetry's receive time first, then match the earliest
+/// remaining frame — the first frame sent after the last observation, i.e. the
+/// one that could have produced this change.
+fn fold_telemetry(
+    observation: &crate::telemetry::TelemetryObservation,
+    state: &mut SendLoopState,
+    metrics: &mut RunMetrics,
+) {
+    if let Some(watermark) = state.last_telemetry_at {
+        while state
+            .pending
+            .front()
+            .is_some_and(|frame| frame.sent_at <= watermark)
+        {
+            state.pending.pop_front();
+            metrics.control_to_telemetry_backlog_dropped = metrics
+                .control_to_telemetry_backlog_dropped
+                .saturating_add(1);
+        }
+    }
+    let changed = state.last_pose.replace(observation.pose) != Some(observation.pose);
+    if changed && let Some(frame) = state.pending.pop_front() {
+        let age = estimated_age(observation.received_at, frame.sent_at, ZERO_OFFSET);
+        metrics.control_to_telemetry.record(age);
+    }
+    state.last_telemetry_at = Some(observation.received_at);
+}

--- a/tools/loopback-probe/src/summary.rs
+++ b/tools/loopback-probe/src/summary.rs
@@ -1,0 +1,81 @@
+//! Formats the end-of-run measurement summary block (this binary's actual
+//! product output, printed via `output::print_line`).
+
+use std::time::Duration;
+
+use crate::metrics::RunMetrics;
+use crate::output::print_line;
+
+/// Prints the full end-of-run summary: control-to-telemetry latency
+/// percentiles, Ping/Pong RTT, frame counters, telemetry received, and the
+/// outcome of the deliberate stale-generation fencing probe.
+pub fn print_summary(metrics: &RunMetrics, fencing_confirmed: bool) {
+    print_line("=== loopback-probe summary ===");
+    print_control_latency(metrics);
+    print_rtt(metrics);
+    print_line(&format!("frames sent:        {}", metrics.frames_sent));
+    print_line(&format!(
+        "frames accepted:     {}",
+        metrics.frames_accepted()
+    ));
+    print_line(&format!("frames rejected:     {}", metrics.frames_rejected));
+    print_line(&format!(
+        "telemetry received:  {}",
+        metrics.telemetry_received
+    ));
+    print_line(&format!(
+        "end-to-end fencing:  {}",
+        if fencing_confirmed {
+            "CONFIRMED (stale-generation frame was rejected)"
+        } else {
+            "NOT CONFIRMED (no FrameRejected observed for the stale probe frame)"
+        }
+    ));
+}
+
+fn print_control_latency(metrics: &RunMetrics) {
+    match metrics.control_to_telemetry.percentiles() {
+        Some((p50, p95, max)) => {
+            print_line(&format!(
+                "control->telemetry latency: p50={} p95={} max={} (n={}, dropped={}, \
+                 backlog_dropped={})",
+                fmt_duration(p50),
+                fmt_duration(p95),
+                fmt_duration(max),
+                metrics.control_to_telemetry.len(),
+                metrics.control_to_telemetry.dropped(),
+                metrics.control_to_telemetry_backlog_dropped
+            ));
+        }
+        None => print_line("control->telemetry latency: no samples observed"),
+    }
+    print_line(
+        "  (loopback, same-clock: measures software + local-transport latency only, not \
+         cross-host wire time — see ADR-0009)",
+    );
+}
+
+fn print_rtt(metrics: &RunMetrics) {
+    match metrics.rtt.rtt() {
+        Some(rtt) => print_line(&format!("ping/pong RTT (EWMA): {}", fmt_duration(rtt))),
+        None => print_line("ping/pong RTT: no samples observed"),
+    }
+}
+
+/// Formats a duration with millisecond precision, since this tool's targets
+/// (ADR-0009) are all in the single-to-low-hundreds-of-milliseconds range.
+fn fmt_duration(duration: Duration) -> String {
+    format!("{:.3}ms", duration.as_secs_f64() * 1000.0)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::fmt_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn formats_milliseconds_with_precision() {
+        assert_eq!(fmt_duration(Duration::from_micros(1500)), "1.500ms");
+    }
+}

--- a/tools/loopback-probe/src/synthetic.rs
+++ b/tools/loopback-probe/src/synthetic.rs
@@ -1,0 +1,86 @@
+//! Synthetic sine-wave control payload generator (the default control
+//! source when `--hid` is not given).
+//!
+//! Unlike the HID path, this produces a [`ControlPayload`] directly in the
+//! canonical `[-1.0, 1.0]` axis convention: there is no physical device to
+//! calibrate away from, so running it through `pilotage-input`'s
+//! HID-raw-units normalization pipeline would be the wrong stage boundary.
+
+use std::f32::consts::PI;
+use std::time::Duration;
+
+use pilotage_input::{axis_id_for_name, button_id_for_name};
+use pilotage_protocol::{ButtonEdge, ControlPayload};
+
+/// Steering (`roll`) sine frequency in Hz.
+const STEERING_HZ: f32 = 0.2;
+/// Throttle sine frequency in Hz.
+const THROTTLE_HZ: f32 = 0.1;
+
+/// Builds a [`ControlPayload`] carrying a sine-wave throttle and steering
+/// pair for `elapsed` time into the run, plus a `button0` press/release
+/// edge toggled once every 2 seconds so the fixed frame-rejection probe
+/// (see `main`) has real edge traffic to compare against on a live host.
+///
+/// Steering is emitted on the `yaw` axis, not `roll`: the reference adapter's
+/// `vehicle.motion` scope exposes exactly `throttle` and `yaw`, and rejects a
+/// frame carrying any other axis id (`UnknownAxis`). Sending `roll` here would
+/// make every synthetic frame reject at the adapter and the skiff would never
+/// move.
+///
+/// # Errors
+///
+/// Returns an error only if the well-known logical-name table in
+/// `pilotage-input` ever stops recognizing `yaw`/`throttle`/`button0`,
+/// which would indicate a crate version skew this binary cannot recover
+/// from at runtime.
+pub fn payload_at(
+    elapsed: Duration,
+    edge: Option<ButtonEdge>,
+) -> Result<ControlPayload, pilotage_input::ProfileError> {
+    let t = elapsed.as_secs_f32();
+    let steering = (t * 2.0 * PI * STEERING_HZ).sin();
+    let throttle = (t * 2.0 * PI * THROTTLE_HZ).sin();
+    let mut axes = vec![
+        (axis_id_for_name("yaw")?, steering),
+        (axis_id_for_name("throttle")?, throttle),
+    ];
+    axes.sort_by_key(|(id, _)| *id);
+    let mut edges = Vec::new();
+    if let Some(edge) = edge {
+        edges.push((button_id_for_name("button0")?, edge));
+    }
+    Ok(ControlPayload { axes, edges })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::payload_at;
+    use std::time::Duration;
+
+    #[test]
+    fn payload_at_zero_is_near_neutral() {
+        let payload = payload_at(Duration::from_secs(0), None).expect("builds");
+        for (_, value) in &payload.axes {
+            assert!(value.abs() < 1e-6);
+        }
+        assert!(payload.edges.is_empty());
+    }
+
+    #[test]
+    fn payload_varies_over_time() {
+        let early = payload_at(Duration::from_millis(0), None).expect("builds");
+        let later = payload_at(Duration::from_millis(500), None).expect("builds");
+        assert_ne!(early.axes, later.axes);
+    }
+
+    #[test]
+    fn payload_carries_supplied_edge() {
+        use pilotage_protocol::ButtonEdge;
+        let payload =
+            payload_at(Duration::from_secs(0), Some(ButtonEdge::Pressed)).expect("builds");
+        assert_eq!(payload.edges.len(), 1);
+        assert_eq!(payload.edges[0].1, ButtonEdge::Pressed);
+    }
+}

--- a/tools/loopback-probe/src/telemetry.rs
+++ b/tools/loopback-probe/src/telemetry.rs
@@ -1,0 +1,79 @@
+//! The telemetry observation this probe tracks and the projection from a
+//! decoded `wire::TelemetrySample` onto it. The host carries telemetry,
+//! `Pong`, and `FrameRejected` on the same datagram channel distinguished by
+//! envelope arm; the arm dispatch lives in `receiver::decode_datagram_event`,
+//! which calls this once it has matched the `TelemetrySample` arm.
+//!
+//! `pilotage-protocol` has no domain wrapper for `TelemetrySample` yet (only
+//! the generated `wire::` type), so this module reads the `wire::` payload
+//! directly rather than adding one: this binary only needs the pose to detect
+//! "did telemetry change", not a full domain model.
+
+use pilotage_protocol::wire;
+use pilotage_timing::MonoTimestamp;
+
+/// One decoded telemetry observation: the fields this probe needs to detect
+/// a pose change, plus the client-local receive timestamp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TelemetryObservation {
+    /// Client-local monotonic timestamp at datagram receipt.
+    pub received_at: MonoTimestamp,
+    /// Reported planar pose, used to detect a change since the last sample.
+    pub pose: (f32, f32, f32),
+}
+
+/// Extracts the pose fields this probe tracks from an already-decoded
+/// [`wire::TelemetrySample`], stamping it with the client-local
+/// `received_at`. Called by the receiver's datagram-arm router
+/// (`receiver::decode_datagram_event`) once it has matched the
+/// `TelemetrySample` arm.
+#[must_use]
+pub fn observation_from_sample(
+    sample: &wire::TelemetrySample,
+    received_at: MonoTimestamp,
+) -> TelemetryObservation {
+    let pose = sample.pose.unwrap_or_default();
+    TelemetryObservation {
+        received_at,
+        pose: (pose.x_m, pose.y_m, pose.heading_rad),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::observation_from_sample;
+    use pilotage_protocol::wire;
+    use pilotage_timing::MonoTimestamp;
+
+    #[test]
+    fn projects_pose_from_sample() {
+        let sample = wire::TelemetrySample {
+            vehicle: Some(wire::VehicleId { value: 1 }),
+            tick: Some(wire::SimTick { value: 0 }),
+            observed_at: Some(wire::MonoTimestamp { nanos: 0 }),
+            pose: Some(wire::Pose2d {
+                x_m: 1.5,
+                y_m: 2.5,
+                heading_rad: 0.25,
+            }),
+            velocity: None,
+        };
+        let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(100));
+        assert_eq!(observation.pose, (1.5, 2.5, 0.25));
+        assert_eq!(observation.received_at, MonoTimestamp::from_nanos(100));
+    }
+
+    #[test]
+    fn missing_pose_projects_to_origin() {
+        let sample = wire::TelemetrySample {
+            vehicle: None,
+            tick: None,
+            observed_at: None,
+            pose: None,
+            velocity: None,
+        };
+        let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(0));
+        assert_eq!(observation.pose, (0.0, 0.0, 0.0));
+    }
+}

--- a/tools/loopback-probe/src/transport.rs
+++ b/tools/loopback-probe/src/transport.rs
@@ -1,0 +1,283 @@
+//! WebTransport client connection, loopback-URL validation, and the
+//! bootstrap handshake (`ClientHello` -> `ServerWelcome`,
+//! `LeaseRequest` -> `LeaseResponse`) over the bidi stream (ADR-0005).
+
+use std::net::IpAddr;
+
+use pilotage_protocol::{
+    ClientHello, LeaseRequest, LeaseResponse, ScopeId, ServerWelcome, VehicleId,
+};
+use wtransport::{ClientConfig, Connection, Endpoint, endpoint::endpoint_side};
+
+use crate::error::ProbeError;
+use crate::wire_session::{StreamMessage, decode_one, encode_client_hello, encode_lease_request};
+
+/// The `pilotage.v1` schema version this client claims support for in its
+/// `ClientHello`.
+const CLIENT_PROTOCOL_VERSION: u32 = pilotage_protocol::SCHEMA_VERSION;
+/// Human-readable client identity for diagnostics only (ADR-0005).
+const CLIENT_NAME: &str = "loopback-probe";
+/// Read-buffer size for one `recv_stream.read` call on the bidi stream;
+/// generously oversized against any single handshake message.
+const STREAM_READ_BUF_LEN: usize = 4096;
+
+/// Extracts the host portion of an `https://host[:port][/path]` URL,
+/// without pulling in a full URL-parsing dependency for this one check.
+///
+/// Deliberately narrow: this tool only ever needs the host to decide
+/// whether `--insecure-loopback` is safe to honor (`validate_loopback_url`);
+/// it does not need path, query, or scheme validation, all of which
+/// `wtransport::Endpoint::connect` performs itself on the same string.
+fn extract_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let host_and_port = after_scheme
+        .split_once('/')
+        .map_or(after_scheme, |(host, _)| host);
+    if let Some(bracketed) = host_and_port.strip_prefix('[') {
+        // IPv6 literal: "[::1]:4433" -> "::1".
+        return bracketed.split(']').next();
+    }
+    Some(
+        host_and_port
+            .split_once(':')
+            .map_or(host_and_port, |(host, _)| host),
+    )
+}
+
+/// Confirms `url`'s host is a loopback address.
+///
+/// `--insecure-loopback` skips server-certificate verification (see `cli`),
+/// which is only safe to combine with a host this process can vouch for by
+/// construction: a non-loopback host could be anything, and skipping
+/// verification against it would silently accept a spoofed session host.
+/// Restricting the flag's effect to loopback hosts keeps "insecure" scoped
+/// to "this machine, this process" rather than "the network".
+///
+/// # Errors
+///
+/// Returns [`ProbeError::InvalidUrl`] if no host can be extracted from
+/// `url`, and [`ProbeError::NonLoopbackHost`] if a host is found but is not
+/// a loopback IP or `localhost`.
+pub fn validate_loopback_url(url: &str) -> Result<(), ProbeError> {
+    let host = extract_host(url).ok_or_else(|| ProbeError::InvalidUrl {
+        url: url.to_string(),
+        message: "could not extract a host".to_string(),
+    })?;
+    let is_loopback = host.eq_ignore_ascii_case("localhost")
+        || host.parse::<IpAddr>().is_ok_and(|addr| addr.is_loopback());
+    if is_loopback {
+        Ok(())
+    } else {
+        Err(ProbeError::NonLoopbackHost {
+            host: host.to_string(),
+        })
+    }
+}
+
+/// Builds a client endpoint that skips server-certificate verification.
+///
+/// Only reachable once `validate_loopback_url` has already accepted the
+/// target URL's host, so the skipped verification is always paired with a
+/// loopback-only target (see that function's doc for why this pairing
+/// matters).
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Connect`] if the local UDP socket cannot be bound.
+pub fn client_endpoint() -> Result<Endpoint<endpoint_side::Client>, ProbeError> {
+    let config = ClientConfig::builder()
+        .with_bind_default()
+        .with_no_cert_validation()
+        .build();
+    Endpoint::client(config).map_err(|source| ProbeError::Connect {
+        message: source.to_string(),
+    })
+}
+
+/// Connects to `url` and returns the established WebTransport session.
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Connect`] if the connection attempt fails.
+pub async fn connect(
+    endpoint: &Endpoint<endpoint_side::Client>,
+    url: &str,
+) -> Result<Connection, ProbeError> {
+    endpoint
+        .connect(url)
+        .await
+        .map_err(|source| ProbeError::Connect {
+            message: source.to_string(),
+        })
+}
+
+/// The outcome of the bootstrap handshake: the host's welcome plus the
+/// granted lease's fencing generation.
+pub struct HandshakeOutcome {
+    /// The host's `ServerWelcome` reply.
+    pub welcome: ServerWelcome,
+    /// The granted `LeaseResponse` for `vehicle.motion`.
+    pub lease: LeaseResponse,
+}
+
+/// Opens the bootstrap bidi stream and drives `ClientHello` ->
+/// `ServerWelcome`, then `LeaseRequest` -> `LeaseResponse` for
+/// `(vehicle, "vehicle.motion")`.
+///
+/// # Errors
+///
+/// Returns [`ProbeError::BidiStream`] if the stream cannot be opened or
+/// written to, [`ProbeError::Decode`] if a reply fails to parse, and
+/// [`ProbeError::Protocol`] if a reply is the wrong message type or the
+/// lease was denied.
+pub async fn handshake(
+    connection: &Connection,
+    vehicle: VehicleId,
+) -> Result<
+    (
+        HandshakeOutcome,
+        wtransport::SendStream,
+        wtransport::RecvStream,
+    ),
+    ProbeError,
+> {
+    let (mut send, mut recv) = open_bidi(connection).await?;
+
+    let hello = ClientHello {
+        protocol_version: CLIENT_PROTOCOL_VERSION,
+        client_name: CLIENT_NAME.to_string(),
+        join_token: Vec::new(),
+    };
+    write_frame(&mut send, &encode_client_hello(&hello)).await?;
+    let welcome = match read_message(&mut recv).await? {
+        StreamMessage::ServerWelcome(welcome) => welcome,
+        other => {
+            return Err(ProbeError::Protocol {
+                message: format!("expected ServerWelcome, got {other:?}"),
+            });
+        }
+    };
+
+    let scope = ScopeId::new("vehicle.motion");
+    let request = LeaseRequest { vehicle, scope };
+    write_frame(&mut send, &encode_lease_request(&request)).await?;
+    let lease = match read_message(&mut recv).await? {
+        StreamMessage::LeaseResponse(response) => response,
+        other => {
+            return Err(ProbeError::Protocol {
+                message: format!("expected LeaseResponse, got {other:?}"),
+            });
+        }
+    };
+    if !lease.granted {
+        return Err(ProbeError::Protocol {
+            message: format!("vehicle.motion lease denied: {:?}", lease.reason),
+        });
+    }
+
+    Ok((HandshakeOutcome { welcome, lease }, send, recv))
+}
+
+/// Opens the bootstrap bidi stream, mapping the `wtransport` open/await
+/// error into this binary's typed error.
+async fn open_bidi(
+    connection: &Connection,
+) -> Result<(wtransport::SendStream, wtransport::RecvStream), ProbeError> {
+    connection
+        .open_bi()
+        .await
+        .map_err(|source| ProbeError::BidiStream {
+            message: source.to_string(),
+        })?
+        .await
+        .map_err(|source| ProbeError::BidiStream {
+            message: source.to_string(),
+        })
+}
+
+/// Writes one length-delimited envelope frame to the bidi send stream.
+async fn write_frame(send: &mut wtransport::SendStream, frame: &[u8]) -> Result<(), ProbeError> {
+    send.write_all(frame)
+        .await
+        .map_err(|source| ProbeError::BidiStream {
+            message: source.to_string(),
+        })
+}
+
+/// Reads bytes from the bidi recv stream until one full envelope frame is
+/// available, decodes it, and returns the typed message.
+///
+/// Handshake replies are small and this stream carries nothing else during
+/// the handshake, so a single `read` call is expected to return a complete
+/// frame; this loops only to tolerate a reply split across two reads.
+async fn read_message(recv: &mut wtransport::RecvStream) -> Result<StreamMessage, ProbeError> {
+    let mut buf = Vec::new();
+    loop {
+        if let Ok((message, _consumed)) = decode_one(&buf) {
+            return Ok(message);
+        }
+        let mut chunk = [0u8; STREAM_READ_BUF_LEN];
+        let read = recv
+            .read(&mut chunk)
+            .await
+            .map_err(|source| ProbeError::BidiStream {
+                message: source.to_string(),
+            })?
+            .ok_or_else(|| ProbeError::BidiStream {
+                message: "bidi stream closed before a complete reply arrived".to_string(),
+            })?;
+        buf.extend_from_slice(&chunk[..read]);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{extract_host, validate_loopback_url};
+
+    #[test]
+    fn extract_host_strips_scheme_port_and_path() {
+        assert_eq!(
+            extract_host("https://127.0.0.1:4433/session"),
+            Some("127.0.0.1")
+        );
+        assert_eq!(extract_host("https://example.com"), Some("example.com"));
+    }
+
+    #[test]
+    fn extract_host_handles_ipv6_brackets() {
+        assert_eq!(extract_host("https://[::1]:4433"), Some("::1"));
+    }
+
+    #[test]
+    fn accepts_ipv4_loopback() {
+        validate_loopback_url("https://127.0.0.1:4433").expect("loopback accepted");
+    }
+
+    #[test]
+    fn accepts_ipv6_loopback() {
+        validate_loopback_url("https://[::1]:4433").expect("loopback accepted");
+    }
+
+    #[test]
+    fn accepts_localhost_hostname() {
+        validate_loopback_url("https://localhost:4433").expect("localhost accepted");
+    }
+
+    #[test]
+    fn rejects_remote_host() {
+        let err = validate_loopback_url("https://example.com:4433").expect_err("should reject");
+        assert!(matches!(err, super::ProbeError::NonLoopbackHost { .. }));
+    }
+
+    #[test]
+    fn rejects_remote_ip() {
+        let err = validate_loopback_url("https://8.8.8.8:4433").expect_err("should reject");
+        assert!(matches!(err, super::ProbeError::NonLoopbackHost { .. }));
+    }
+
+    #[test]
+    fn rejects_malformed_url() {
+        assert!(validate_loopback_url("not a url").is_err());
+    }
+}

--- a/tools/loopback-probe/src/wire_session.rs
+++ b/tools/loopback-probe/src/wire_session.rs
@@ -1,0 +1,203 @@
+//! Envelope encode/decode for session-bootstrap messages carried on the
+//! reliable bidi stream (ADR-0005): `ClientHello`, `ServerWelcome`,
+//! `LeaseRequest`, `LeaseResponse`, `Ping`, `Pong`, `FrameRejected`.
+//!
+//! `pilotage-protocol` exports `encode_control_frame_envelope` /
+//! `decode_control_frame_envelope` for the datagram-class `ControlFrame`
+//! payload, but no equivalent generic helper for the other envelope arms
+//! (they are conceptually one-per-handshake-step, not a hot per-tick path,
+//! so each one gets its own small wire function here rather than the
+//! calling code hand-rolling `wire::Envelope` construction inline).
+
+use pilotage_protocol::wire;
+use pilotage_protocol::{
+    ClientHello, DecodeError, FrameRejected, LeaseRequest, LeaseResponse, Ping, Pong,
+    ServerWelcome, decode_envelope_length_delimited, encode_envelope_length_delimited,
+};
+
+use crate::error::ProbeError;
+
+/// The `pilotage.v1` schema version this binary produces and accepts,
+/// mirroring `pilotage_protocol::convert::SCHEMA_VERSION` (not exported, so
+/// restated here; both must move together if the schema ever revs).
+const SCHEMA_VERSION: u32 = 1;
+
+/// Wraps a wire payload in a versioned envelope and encodes it with a
+/// length-delimited prefix, ready to append to the bidi stream's send
+/// buffer.
+fn encode(payload: wire::envelope::Payload) -> Vec<u8> {
+    let envelope = wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(payload),
+    };
+    encode_envelope_length_delimited(&envelope)
+}
+
+/// Encodes a `ClientHello` as a length-delimited envelope frame.
+#[must_use]
+pub fn encode_client_hello(hello: &ClientHello) -> Vec<u8> {
+    encode(wire::envelope::Payload::ClientHello(hello.into()))
+}
+
+/// Encodes a `LeaseRequest` as a length-delimited envelope frame.
+#[must_use]
+pub fn encode_lease_request(request: &LeaseRequest) -> Vec<u8> {
+    encode(wire::envelope::Payload::LeaseRequest(request.into()))
+}
+
+/// Encodes a `Ping` as a bare (non-length-delimited) envelope for the
+/// control-fast datagram channel. The host decodes RTT pings as datagrams
+/// (`decode_ping_datagram`), not on the bootstrap stream, so the timed send
+/// loop sends `Ping` this way rather than as a length-delimited stream frame.
+#[must_use]
+pub fn encode_ping_datagram(ping: &Ping) -> Vec<u8> {
+    use prost::Message;
+    wire::Envelope {
+        schema_version: SCHEMA_VERSION,
+        payload: Some(wire::envelope::Payload::Ping(ping.into())),
+    }
+    .encode_to_vec()
+}
+
+/// Decodes exactly one length-delimited envelope from the front of `bytes`,
+/// returning the typed [`StreamMessage`] and the number of bytes consumed
+/// (the caller drains that many bytes from its receive buffer before the
+/// next call).
+///
+/// # Errors
+///
+/// Returns [`ProbeError::Decode`] if `bytes` does not begin with a valid
+/// envelope, the schema version is unsupported, or a required field/enum
+/// value is missing or unrecognized.
+pub fn decode_one(bytes: &[u8]) -> Result<(StreamMessage, usize), ProbeError> {
+    let (envelope, remaining) = decode_envelope_length_delimited(bytes)?;
+    if envelope.schema_version != SCHEMA_VERSION {
+        return Err(ProbeError::Protocol {
+            message: format!(
+                "unsupported schema_version {} (expected {SCHEMA_VERSION})",
+                envelope.schema_version
+            ),
+        });
+    }
+    let consumed = bytes.len() - remaining.len();
+    let payload = envelope.payload.ok_or_else(|| ProbeError::Protocol {
+        message: "envelope carried no payload".to_string(),
+    })?;
+    Ok((StreamMessage::try_from(payload)?, consumed))
+}
+
+/// The subset of envelope payload arms this probe expects on the bidi
+/// stream, converted to their domain types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamMessage {
+    /// Reply to `ClientHello`.
+    ServerWelcome(ServerWelcome),
+    /// Reply to `LeaseRequest`.
+    LeaseResponse(LeaseResponse),
+    /// Reply to a `Ping` this client sent.
+    Pong(Pong),
+    /// Notice that a previously sent control frame was not honored.
+    FrameRejected(FrameRejected),
+    /// A reliable, ordered authority/mode event from the host's dedicated
+    /// authority-events stream (ADR-0005). Carried in wire form: this probe
+    /// only counts these to prove the stream is live, and has no domain-side
+    /// use for the decoded event.
+    AuthorityEvent(wire::AuthorityEvent),
+}
+
+impl TryFrom<wire::envelope::Payload> for StreamMessage {
+    type Error = ProbeError;
+
+    fn try_from(payload: wire::envelope::Payload) -> Result<Self, Self::Error> {
+        use pilotage_protocol::wire::envelope::Payload;
+        match payload {
+            Payload::ServerWelcome(welcome) => Ok(Self::ServerWelcome(
+                ServerWelcome::try_from(welcome).map_err(convert_err)?,
+            )),
+            Payload::LeaseResponse(response) => Ok(Self::LeaseResponse(
+                LeaseResponse::try_from(response).map_err(convert_err)?,
+            )),
+            Payload::Pong(pong) => Ok(Self::Pong(Pong::try_from(pong).map_err(convert_err)?)),
+            Payload::FrameRejected(rejected) => Ok(Self::FrameRejected(
+                FrameRejected::try_from(rejected).map_err(convert_err)?,
+            )),
+            Payload::AuthorityEvent(event) => Ok(Self::AuthorityEvent(event)),
+            other => Err(ProbeError::Protocol {
+                message: format!("unexpected envelope payload arm on bidi stream: {other:?}"),
+            }),
+        }
+    }
+}
+
+/// Wraps a `pilotage_protocol::ConvertError` as a `ProbeError::Decode`,
+/// reusing `DecodeError::Convert`'s existing `#[source]` chain rather than
+/// adding a parallel error variant for the same underlying cause.
+fn convert_err(source: pilotage_protocol::ConvertError) -> ProbeError {
+    ProbeError::Decode {
+        source: DecodeError::Convert(source),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{decode_one, encode_client_hello, encode_lease_request, encode_ping_datagram};
+    use pilotage_protocol::{ClientHello, LeaseRequest, Ping, ScopeId, VehicleId};
+    use pilotage_timing::MonoTimestamp;
+
+    #[test]
+    fn client_hello_roundtrips_through_bytes_but_is_not_a_stream_message_arm() {
+        // ClientHello and LeaseRequest are client->host only in this
+        // probe's flow, so `decode_one` (host->client direction) correctly
+        // has no arm for them; this test only exercises that encoding does
+        // not panic and produces a non-empty, length-prefixed frame.
+        let hello = ClientHello {
+            protocol_version: 1,
+            client_name: "loopback-probe".to_string(),
+            join_token: vec![],
+        };
+        let bytes = encode_client_hello(&hello);
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn lease_request_encodes_non_empty() {
+        let request = LeaseRequest {
+            vehicle: VehicleId::new(1),
+            scope: ScopeId::new("vehicle.motion"),
+        };
+        assert!(!encode_lease_request(&request).is_empty());
+    }
+
+    #[test]
+    fn ping_datagram_encodes_non_empty() {
+        let ping = Ping {
+            nonce: 42,
+            sender_sent_at: MonoTimestamp::from_nanos(0),
+        };
+        assert!(!encode_ping_datagram(&ping).is_empty());
+    }
+
+    #[test]
+    fn decode_one_rejects_empty_bytes() {
+        assert!(decode_one(&[]).is_err());
+    }
+
+    #[test]
+    fn decode_one_rejects_non_stream_message_arm() {
+        use pilotage_protocol::{encode_envelope_length_delimited, wire};
+        // A valid, length-delimited envelope carrying a `Ping` arm: `Ping` is
+        // client->host only, so `decode_one` (host->client direction) must
+        // reject it with a Protocol error rather than silently succeed.
+        let envelope = wire::Envelope {
+            schema_version: super::SCHEMA_VERSION,
+            payload: Some(wire::envelope::Payload::Ping(wire::Ping {
+                nonce: 1,
+                sender_sent_at: Some(wire::MonoTimestamp { nanos: 0 }),
+            })),
+        };
+        let bytes = encode_envelope_length_delimited(&envelope);
+        let err = decode_one(&bytes).expect_err("Ping is not a StreamMessage arm");
+        assert!(matches!(err, crate::error::ProbeError::Protocol { .. }));
+    }
+}


### PR DESCRIPTION
Builds the transport backbone from ADR-0005 against the deterministic reference adapter, since local Gazebo is currently broken (repair tracked separately). Stacks on the merged increment-0.

**What lands**
- **pilotage-session** — sans-IO host session state machine: hello→welcome, lease grants through the embedded authority engine (denials return the correct reason, never a stale grant), staleness-checked control frames, ping→pong, disconnect-releases-scopes. All decision logic lives here so the binary stays plumbing.
- **session-host** — tokio + wtransport binary with the ADR-0005 channel mapping: control/telemetry as QUIC datagrams, a **dedicated** reliable stream for authority events, bootstrap on its own stream. Single engine actor owns all state; per-stream writer tasks prevent a slow client from stalling the receive path; datagram drops counted per class.
- **loopback-probe** — native client with synthetic and live-HID (`--hid`) control sources.
- Session-bootstrap protobuf vocabulary + conversions.

**Gate results (run locally on the final tree):** fmt clean; clippy `--all-targets -D warnings` clean; **307 tests, 0 failures**; doc `-D missing_docs` clean; release build clean; structure limits clean.

**Live loopback run:** synthetic 100 Hz — control→telemetry p50 5.96 ms / p95 7.13 ms / max 8.41 ms, 300 sent / 299 accepted / **1 stale-generation frame rejected end-to-end over the wire** (fencing proof), RTT ~0.28 ms, zero drops. Clean SIGINT shutdown. The live RadioMaster Pocket run was validated during development (501 frames through the input pipeline); the device was disconnected by final verification time.

**Adversarial review caught and fixed before landing:** lease denial replying "granted" with a stale generation; authority events sharing the bootstrap stream instead of a dedicated one (ADR-0005); silent datagram-drop swallowing; a slow-client backpressure stall; unobservable action-drop count; and — found at my final gate — an **unbounded-memory reassembly bug** where a client declaring an oversized bootstrap frame grew host memory without bound. That one landed with its guardrail: a hard frame cap plus a passing DoS regression test.

Merge order: after #2 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)