### PR TITLE
Increment 1b: real Gazebo vehicle end-to-end (video, telemetry, control) to native and browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: check-structure
         run: bash scripts/check-structure.sh
 
+      - name: web viewer wire conformance
+        run: node clients/web/wire.test.mjs
+
       - name: Setup buf
         if: hashFiles('schemas/**/*.proto') != ''
         uses: bufbuild/buf-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ wasm-pack.log
 # Generated protobuf code (generated at build time; schemas/ is the source of truth)
 **/src/generated/
 
+# CMake build output for the C++ gz-transport bridge (objects, binary, and
+# protobuf C++ generated from schemas/ at build time)
+adapters/**/bridge/build/
+
 # Environment and secrets
 .env
 .env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +120,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -269,6 +296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +315,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -530,6 +576,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +614,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jpeg-encoder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
 
 [[package]]
 name = "js-sys"
@@ -606,6 +673,7 @@ name = "loopback-probe"
 version = "0.1.0"
 dependencies = [
  "hidapi",
+ "image",
  "pilotage-input",
  "pilotage-protocol",
  "pilotage-timing",
@@ -647,6 +715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +733,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -781,6 +869,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-adapter-gazebo"
+version = "0.1.0"
+dependencies = [
+ "pilotage-adapter-api",
+ "pilotage-protocol",
+ "pilotage-timing",
+ "prost",
+ "prost-build",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "pilotage-adapter-reference"
 version = "0.1.0"
 dependencies = [
@@ -852,7 +954,9 @@ dependencies = [
 name = "pilotage-session-host"
 version = "0.1.0"
 dependencies = [
+ "jpeg-encoder",
  "pilotage-adapter-api",
+ "pilotage-adapter-gazebo",
  "pilotage-adapter-reference",
  "pilotage-authority",
  "pilotage-protocol",
@@ -881,6 +985,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "potential_utf"
@@ -994,6 +1111,12 @@ checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -1401,6 +1524,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2042,3 +2171,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "tools/hid-probe",
     "tools/loopback-probe",
     "hosts/session-host",
+    "adapters/gazebo",
 ]
 
 [workspace.package]
@@ -36,6 +37,7 @@ pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-adapter-reference = { path = "adapters/reference-headless" }
+pilotage-adapter-gazebo = { path = "adapters/gazebo" }
 pilotage-session = { path = "crates/pilotage-session" }
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # Pilotage
 
-Rust-first, engine-independent platform for low-latency remote control, supervision,
-simulation, and training of maritime, aerial, and terrestrial vehicles.
+Engine-independent platform for low-latency remote control, supervision, simulation,
+and training of maritime, aerial, and terrestrial vehicles.
 
-**Status:** architecture phase. The decision records under [docs/adr](docs/adr/README.md)
-are the authoritative design; no implementation code has landed yet.
+**Status:** early implementation. The core protocol/authority/input crates, a
+WebTransport session host, and a Gazebo adapter are in place; a browser and a native
+client drive a real Gazebo vehicle end-to-end (video, telemetry, and control). The
+decision records under [docs/adr](docs/adr/README.md) are the authoritative design.
 
-## What v1 delivers
+## Working demo
 
-A browser client controlling a server-hosted Gazebo simulation: rendered video and
-telemetry stream down over WebTransport, sequenced control frames stream up, and channel-level
-control authority (vehicle helm, camera helm, payload helm) is enforced with scoped
-leases and fencing generations. The same binaries run over loopback or LAN for local
-demonstrations.
+A diff-drive vehicle in Gazebo, driven from a browser or native client: the onboard
+camera streams down as MJPEG over WebTransport, odometry streams down as telemetry,
+and keyboard/gamepad control streams up — with channel-level authority (scoped leases
+and fencing generations) enforced on every frame. A C++ gz-transport sidecar bridges
+Gazebo to the Rust adapter; a deterministic headless adapter stands in when Gazebo is
+not present. Runs over loopback or LAN.
 
 ## What the architecture protects
 
 - **Portable sans-IO core.** All protocol, authority, input, timing, and replay logic
-  lives in portable Rust crates shared by the browser (WebAssembly) and future native
-  clients. Platform code stays thin; domain logic is never duplicated.
+  lives in portable crates shared by the browser and native clients. Platform code
+  stays thin; domain logic is never duplicated.
 - **Engine independence.** Gazebo is the first adapter, not the platform boundary.
   Unreal, Unity, deterministic headless trainers, and real-vehicle gateways are peer
   implementations of the same adapter contract.
@@ -36,9 +39,11 @@ demonstrations.
 | `docs/` | Architecture overview and supporting design docs |
 | `schemas/` | Protobuf wire-schema sources — the protocol's source of truth |
 | `crates/` | Portable sans-IO core crates |
-| `hosts/` | Session-host binaries |
-| `adapters/` | Simulator and vehicle adapters (Gazebo first, reference-headless alongside) |
-| `clients/` | Browser (wasm) and future native front ends |
+| `hosts/` | Session-host binary |
+| `adapters/` | Vehicle adapters: Gazebo (with its C++ bridge) and the deterministic reference |
+| `sim/` | Gazebo demo worlds |
+| `clients/` | Browser demo viewer (native viewer lives under `tools/`) |
+| `tools/` | Native viewer/probe and the HID device probe |
 | `services/` | Identity, rendezvous/signaling, and other optional central services |
 
 Start with [docs/architecture.md](docs/architecture.md), then the

--- a/adapters/gazebo/Cargo.toml
+++ b/adapters/gazebo/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pilotage-adapter-gazebo"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-adapter-api = { workspace = true }
+pilotage-protocol = { workspace = true }
+pilotage-timing = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "io-util", "time", "process"] }
+prost = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[build-dependencies]
+prost-build = { workspace = true }

--- a/adapters/gazebo/bridge/CMakeLists.txt
+++ b/adapters/gazebo/bridge/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.16)
+project(pilotage_gz_bridge CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# gz-transport / gz-msgs are discovered via pkg-config: their .pc files pull in
+# protobuf, abseil, gz-math, and gz-utils transitively, so no separate
+# find_package cascade is needed.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GZ_TRANSPORT REQUIRED IMPORTED_TARGET gz-transport13)
+pkg_check_modules(GZ_MSGS REQUIRED IMPORTED_TARGET gz-msgs10)
+
+find_program(PROTOC_EXECUTABLE protoc REQUIRED)
+
+# Generate C++ bindings for the private host<->sidecar bridge schema. The
+# schema lives at the workspace root; regenerate whenever it changes.
+set(SCHEMA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../schemas")
+set(BRIDGE_PROTO "${SCHEMA_ROOT}/pilotage/bridge/v1/bridge.proto")
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(BRIDGE_PB_CC "${GENERATED_DIR}/pilotage/bridge/v1/bridge.pb.cc")
+set(BRIDGE_PB_H "${GENERATED_DIR}/pilotage/bridge/v1/bridge.pb.h")
+
+file(MAKE_DIRECTORY "${GENERATED_DIR}")
+
+add_custom_command(
+  OUTPUT "${BRIDGE_PB_CC}" "${BRIDGE_PB_H}"
+  COMMAND "${PROTOC_EXECUTABLE}"
+          --proto_path "${SCHEMA_ROOT}"
+          --cpp_out "${GENERATED_DIR}"
+          "${BRIDGE_PROTO}"
+  DEPENDS "${BRIDGE_PROTO}"
+  COMMENT "Generating C++ bindings for pilotage.bridge.v1"
+  VERBATIM)
+
+add_executable(pilotage-gz-bridge
+  src/main.cpp
+  src/framing.cpp
+  src/bridge_node.cpp
+  "${BRIDGE_PB_CC}")
+
+target_include_directories(pilotage-gz-bridge PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  "${GENERATED_DIR}")
+
+target_link_libraries(pilotage-gz-bridge PRIVATE
+  PkgConfig::GZ_TRANSPORT
+  PkgConfig::GZ_MSGS)
+
+target_compile_options(pilotage-gz-bridge PRIVATE -Wall -Wextra)

--- a/adapters/gazebo/bridge/src/bridge_node.cpp
+++ b/adapters/gazebo/bridge/src/bridge_node.cpp
@@ -1,0 +1,123 @@
+#include "bridge_node.hpp"
+
+#include <cmath>
+#include <cstdint>
+
+#include <gz/msgs/vector3d.pb.h>
+
+namespace pilotage::bridge {
+
+namespace {
+
+// Yaw (heading about +Z) from a unit quaternion, standard ZYX extraction.
+double YawFromQuaternion(double x, double y, double z, double w) {
+  const double siny_cosp = 2.0 * (w * z + x * y);
+  const double cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+  return std::atan2(siny_cosp, cosy_cosp);
+}
+
+// Maps a gz.msgs.Header stamp (sec + nsec) to a flat nanosecond count. A
+// negative sec would only arise from a malformed message; clamp to 0 so the
+// unsigned field never underflows.
+std::uint64_t StampToNanos(const gz::msgs::Header &header) {
+  const auto &stamp = header.stamp();
+  const std::int64_t sec = stamp.sec();
+  if (sec <= 0) {
+    return static_cast<std::uint64_t>(stamp.nsec() < 0 ? 0 : stamp.nsec());
+  }
+  return static_cast<std::uint64_t>(sec) * 1000000000ULL +
+         static_cast<std::uint64_t>(stamp.nsec() < 0 ? 0 : stamp.nsec());
+}
+
+// Human-readable name for a gz pixel format enum, so the host can decide how
+// to interpret BridgeFrame.rgb. The camera world publishes RGB_INT8; anything
+// else is passed through with its label rather than silently mislabeled.
+const char *PixelFormatName(gz::msgs::PixelFormatType format) {
+  switch (format) {
+    case gz::msgs::PixelFormatType::RGB_INT8:
+      return "RGB_INT8";
+    case gz::msgs::PixelFormatType::RGBA_INT8:
+      return "RGBA_INT8";
+    case gz::msgs::PixelFormatType::BGR_INT8:
+      return "BGR_INT8";
+    case gz::msgs::PixelFormatType::BGRA_INT8:
+      return "BGRA_INT8";
+    case gz::msgs::PixelFormatType::L_INT8:
+      return "L_INT8";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+}  // namespace
+
+BridgeNode::BridgeNode(BridgeConfig config, BridgeConnection *connection)
+    : config_(std::move(config)), connection_(connection) {}
+
+bool BridgeNode::Start(std::string &error_out) {
+  const std::string cmd_vel_topic = "/model/" + config_.vehicle + "/cmd_vel";
+  const std::string odom_topic = "/model/" + config_.vehicle + "/odometry";
+
+  cmd_vel_pub_ = node_.Advertise<gz::msgs::Twist>(cmd_vel_topic);
+  if (!cmd_vel_pub_) {
+    error_out = "failed to advertise " + cmd_vel_topic;
+    return false;
+  }
+
+  if (!node_.Subscribe(odom_topic, &BridgeNode::OnOdometry, this)) {
+    error_out = "failed to subscribe " + odom_topic;
+    return false;
+  }
+
+  if (!node_.Subscribe(config_.camera_topic, &BridgeNode::OnImage, this)) {
+    error_out = "failed to subscribe " + config_.camera_topic;
+    return false;
+  }
+
+  return true;
+}
+
+void BridgeNode::OnOdometry(const gz::msgs::Odometry &msg) {
+  pilotage::bridge::v1::BridgeEnvelope envelope;
+  auto *odom = envelope.mutable_odometry();
+
+  const auto &position = msg.pose().position();
+  odom->set_x(position.x());
+  odom->set_y(position.y());
+
+  const auto &q = msg.pose().orientation();
+  odom->set_heading(YawFromQuaternion(q.x(), q.y(), q.z(), q.w()));
+
+  odom->set_speed(msg.twist().linear().x());
+  odom->set_sim_time_ns(StampToNanos(msg.header()));
+
+  // Odometry is control-critical: never dropped on congestion. A false return
+  // means the host link died; exiting is handled by the reader thread on the
+  // same disconnect, so here we simply drop the sample.
+  connection_->WriteEnvelope(envelope, /*droppable=*/false);
+}
+
+void BridgeNode::OnImage(const gz::msgs::Image &msg) {
+  pilotage::bridge::v1::BridgeEnvelope envelope;
+  auto *frame = envelope.mutable_frame();
+
+  frame->set_width(msg.width());
+  frame->set_height(msg.height());
+  frame->set_pixel_format(PixelFormatName(msg.pixel_format_type()));
+  frame->set_sim_time_ns(StampToNanos(msg.header()));
+  frame->set_rgb(msg.data());
+
+  // Camera frames are best-effort: a slow host drops frames rather than
+  // stalling the shared writer and starving odometry behind them.
+  connection_->WriteEnvelope(envelope, /*droppable=*/true);
+}
+
+void BridgeNode::PublishControl(
+    const pilotage::bridge::v1::BridgeControl &control) {
+  gz::msgs::Twist twist;
+  twist.mutable_linear()->set_x(control.linear_x());
+  twist.mutable_angular()->set_z(control.angular_z());
+  cmd_vel_pub_.Publish(twist);
+}
+
+}  // namespace pilotage::bridge

--- a/adapters/gazebo/bridge/src/bridge_node.hpp
+++ b/adapters/gazebo/bridge/src/bridge_node.hpp
@@ -1,0 +1,53 @@
+// Bridges gz-transport to the length-delimited bridge protocol. This is the
+// ONLY component that speaks gz-transport (ADR-0008): it subscribes odometry
+// and camera image, publishes cmd_vel Twist, and translates each direction to
+// / from the private `pilotage.bridge.v1` wire types before they touch the
+// TCP link. No raw gz.msgs type crosses into the Rust adapter.
+#ifndef PILOTAGE_GZ_BRIDGE_NODE_HPP
+#define PILOTAGE_GZ_BRIDGE_NODE_HPP
+
+#include <string>
+
+#include <gz/msgs/image.pb.h>
+#include <gz/msgs/odometry.pb.h>
+#include <gz/msgs/twist.pb.h>
+#include <gz/transport/Node.hh>
+
+#include "framing.hpp"
+
+namespace pilotage::bridge {
+
+// Static configuration for one bridge session.
+struct BridgeConfig {
+  std::string vehicle;       // e.g. "vehicle_blue"
+  std::string camera_topic;  // e.g. "/camera"
+};
+
+// Wires gz-transport subscriptions/publisher to a BridgeConnection. The node
+// keeps a non-owning pointer to the connection; the connection must outlive
+// the node.
+class BridgeNode {
+ public:
+  BridgeNode(BridgeConfig config, BridgeConnection *connection);
+
+  // Advertises cmd_vel and subscribes odometry + camera. Returns false with a
+  // populated error_out if any gz-transport wiring step fails.
+  bool Start(std::string &error_out);
+
+  // Publishes a Twist onto <vehicle>/cmd_vel from a decoded control message.
+  void PublishControl(const pilotage::bridge::v1::BridgeControl &control);
+
+ private:
+  // gz-transport member-function callbacks (run on gz reader threads).
+  void OnOdometry(const gz::msgs::Odometry &msg);
+  void OnImage(const gz::msgs::Image &msg);
+
+  BridgeConfig config_;
+  BridgeConnection *connection_;  // not owned
+  gz::transport::Node node_;
+  gz::transport::Node::Publisher cmd_vel_pub_;
+};
+
+}  // namespace pilotage::bridge
+
+#endif  // PILOTAGE_GZ_BRIDGE_NODE_HPP

--- a/adapters/gazebo/bridge/src/framing.cpp
+++ b/adapters/gazebo/bridge/src/framing.cpp
@@ -1,0 +1,282 @@
+#include "framing.hpp"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <utility>
+
+namespace pilotage::bridge {
+
+namespace {
+
+// Max envelope size we will accept from the peer. A raw 320x240 RGB frame is
+// ~230 KB; this cap leaves generous headroom while rejecting a corrupt length
+// prefix that would otherwise demand an unbounded allocation.
+constexpr std::size_t kMaxEnvelopeBytes = 16 * 1024 * 1024;
+
+// Bounded outbound queue: at most this many droppable (camera-frame) payloads
+// may sit pending. Odometry and other control-critical payloads bypass this cap
+// so a slow peer's frame backlog can never starve them; frames beyond the cap
+// are dropped rather than growing memory or back-pressuring the gz thread. A
+// small depth keeps latency low while absorbing a brief send stall.
+constexpr std::size_t kMaxPendingDroppable = 2;
+
+// Blocking send timeout. A wedged peer that never drains its receive buffer
+// would otherwise park the writer thread forever; on timeout the send fails and
+// the connection is treated as dead.
+constexpr time_t kSendTimeoutSeconds = 5;
+
+// Appends a base-128 varint encoding of value to out (protobuf length prefix).
+void AppendVarint(std::vector<std::uint8_t> &out, std::uint64_t value) {
+  while (value >= 0x80) {
+    out.push_back(static_cast<std::uint8_t>((value & 0x7F) | 0x80));
+    value >>= 7;
+  }
+  out.push_back(static_cast<std::uint8_t>(value));
+}
+
+}  // namespace
+
+BridgeConnection::BridgeConnection(int fd)
+    : state_(std::make_unique<WriterState>()) {
+  state_->fd = fd;
+  WriterState *state = state_.get();
+  writer_thread_ = std::thread([state] { state->WriterLoop(); });
+}
+
+std::optional<BridgeConnection> BridgeConnection::Connect(std::uint16_t port,
+                                                          std::string &error_out) {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    error_out = std::string("socket() failed: ") + std::strerror(errno);
+    return std::nullopt;
+  }
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+  if (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+    error_out = std::string("connect() to 127.0.0.1:") + std::to_string(port) +
+                " failed: " + std::strerror(errno);
+    ::close(fd);
+    return std::nullopt;
+  }
+
+  timeval send_timeout{};
+  send_timeout.tv_sec = kSendTimeoutSeconds;
+  send_timeout.tv_usec = 0;
+  if (::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout,
+                   sizeof(send_timeout)) != 0) {
+    error_out = std::string("setsockopt(SO_SNDTIMEO) failed: ") +
+                std::strerror(errno);
+    ::close(fd);
+    return std::nullopt;
+  }
+
+  return BridgeConnection(fd);
+}
+
+BridgeConnection::BridgeConnection(BridgeConnection &&other) noexcept
+    : state_(std::move(other.state_)),
+      writer_thread_(std::move(other.writer_thread_)) {}
+
+BridgeConnection &BridgeConnection::operator=(BridgeConnection &&other) noexcept {
+  if (this != &other) {
+    Shutdown();
+    if (writer_thread_.joinable()) {
+      writer_thread_.join();
+    }
+    state_ = std::move(other.state_);
+    writer_thread_ = std::move(other.writer_thread_);
+  }
+  return *this;
+}
+
+BridgeConnection::~BridgeConnection() {
+  Shutdown();
+  if (writer_thread_.joinable()) {
+    writer_thread_.join();
+  }
+  if (state_ && state_->fd >= 0) {
+    ::close(state_->fd);
+    state_->fd = -1;
+  }
+}
+
+void BridgeConnection::Shutdown() {
+  if (!state_) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> guard(state_->queue_mutex);
+    state_->stop = true;
+  }
+  state_->queue_cv.notify_all();
+  int fd = state_->fd;
+  if (fd >= 0) {
+    // SHUT_RDWR unblocks any thread parked in recv/send; the fd is closed by
+    // the destructor so the parent's poll detects our exit.
+    ::shutdown(fd, SHUT_RDWR);
+  }
+}
+
+bool BridgeConnection::WriterState::WriteAll(const std::uint8_t *data,
+                                             std::size_t len) {
+  std::size_t sent = 0;
+  while (sent < len) {
+    ssize_t n = ::send(fd, data + sent, len - sent, 0);
+    if (n > 0) {
+      sent += static_cast<std::size_t>(n);
+      continue;
+    }
+    if (n < 0 && errno == EINTR) {
+      continue;
+    }
+    // EAGAIN/EWOULDBLOCK here is the SO_SNDTIMEO firing on a wedged peer: treat
+    // it as a fatal disconnect rather than spinning.
+    return false;
+  }
+  return true;
+}
+
+void BridgeConnection::WriterState::WriterLoop() {
+  for (;;) {
+    QueuedFrame frame;
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex);
+      queue_cv.wait(lock, [this] { return stop || !queue.empty(); });
+      if (stop) {
+        // Shutdown requested: abandon any pending frames; the socket is being
+        // torn down and further sends would fail anyway.
+        return;
+      }
+      frame = std::move(queue.front());
+      queue.pop_front();
+      if (frame.droppable && pending_droppable > 0) {
+        --pending_droppable;
+      }
+    }
+    if (!WriteAll(frame.bytes.data(), frame.bytes.size())) {
+      // Send failed (peer dead or wedged): stop draining and shut the read side
+      // so a reader loop parked in recv observes the same disconnect promptly.
+      {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        stop = true;
+        queue.clear();
+        pending_droppable = 0;
+      }
+      if (fd >= 0) {
+        ::shutdown(fd, SHUT_RD);
+      }
+      return;
+    }
+  }
+}
+
+bool BridgeConnection::WriteEnvelope(
+    const pilotage::bridge::v1::BridgeEnvelope &envelope, bool droppable) {
+  if (!state_) {
+    return false;
+  }
+
+  const std::size_t body_size = envelope.ByteSizeLong();
+  if (body_size > kMaxEnvelopeBytes) {
+    return false;
+  }
+
+  std::string body;
+  if (!envelope.SerializeToString(&body)) {
+    return false;
+  }
+
+  std::vector<std::uint8_t> frame;
+  frame.reserve(body.size() + 10);
+  AppendVarint(frame, static_cast<std::uint64_t>(body.size()));
+  frame.insert(frame.end(), body.begin(), body.end());
+
+  {
+    std::lock_guard<std::mutex> guard(state_->queue_mutex);
+    if (state_->stop) {
+      return false;
+    }
+    if (droppable && state_->pending_droppable >= kMaxPendingDroppable) {
+      // Queue congested: drop this best-effort frame so the producer thread
+      // returns immediately instead of parking behind a slow peer.
+      return true;
+    }
+    if (droppable) {
+      ++state_->pending_droppable;
+    }
+    state_->queue.push_back(QueuedFrame{std::move(frame), droppable});
+  }
+  state_->queue_cv.notify_one();
+  return true;
+}
+
+bool BridgeConnection::ReadAll(std::uint8_t *data, std::size_t len) {
+  const int fd = state_ ? state_->fd : -1;
+  std::size_t got = 0;
+  while (got < len) {
+    ssize_t n = ::recv(fd, data + got, len - got, 0);
+    if (n > 0) {
+      got += static_cast<std::size_t>(n);
+      continue;
+    }
+    if (n == 0) {
+      return false;  // orderly EOF
+    }
+    if (errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool BridgeConnection::ReadEnvelope(
+    pilotage::bridge::v1::BridgeEnvelope &envelope_out) {
+  if (!state_) {
+    return false;
+  }
+  // Decode a varint length prefix one byte at a time so we never over-read
+  // into the next frame's body.
+  std::uint64_t body_size = 0;
+  int shift = 0;
+  while (true) {
+    std::uint8_t byte = 0;
+    if (!ReadAll(&byte, 1)) {
+      return false;
+    }
+    body_size |= static_cast<std::uint64_t>(byte & 0x7F) << shift;
+    if ((byte & 0x80) == 0) {
+      break;
+    }
+    shift += 7;
+    if (shift >= 64) {
+      return false;  // malformed varint
+    }
+  }
+
+  if (body_size > kMaxEnvelopeBytes) {
+    return false;
+  }
+
+  auto &read_buffer = state_->read_buffer;
+  read_buffer.resize(static_cast<std::size_t>(body_size));
+  if (body_size > 0 && !ReadAll(read_buffer.data(), read_buffer.size())) {
+    return false;
+  }
+
+  return envelope_out.ParseFromArray(read_buffer.data(),
+                                     static_cast<int>(read_buffer.size()));
+}
+
+}  // namespace pilotage::bridge

--- a/adapters/gazebo/bridge/src/framing.hpp
+++ b/adapters/gazebo/bridge/src/framing.hpp
@@ -1,0 +1,108 @@
+// Length-delimited protobuf framing over a blocking TCP socket. A single
+// dedicated writer thread owns the send path; gz-transport callback threads
+// hand off already-framed bytes through a bounded queue and never block on the
+// socket. This keeps a slow or wedged host peer from stalling a control-
+// critical odometry callback behind a fat camera frame.
+//
+// The wire format is a protobuf varint byte length prefix followed by the
+// encoded `BridgeEnvelope` payload, matching prost's
+// `encode_length_delimited` / `decode_length_delimited` on the Rust side.
+#ifndef PILOTAGE_GZ_BRIDGE_FRAMING_HPP
+#define PILOTAGE_GZ_BRIDGE_FRAMING_HPP
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "pilotage/bridge/v1/bridge.pb.h"
+
+namespace pilotage::bridge {
+
+// Owns the connected TCP socket file descriptor for the sidecar<->host link.
+// A dedicated writer thread drains a bounded outbound queue and performs every
+// blocking send; producers only briefly hold the queue mutex to hand off bytes.
+// Reads are single-threaded (only the inbound control loop calls ReadEnvelope).
+class BridgeConnection {
+ public:
+  // Dials 127.0.0.1:port and returns a connected instance, or an error string
+  // describing why the connect failed. On success the writer thread is running.
+  static std::optional<BridgeConnection> Connect(std::uint16_t port,
+                                                  std::string &error_out);
+
+  BridgeConnection(BridgeConnection &&other) noexcept;
+  BridgeConnection &operator=(BridgeConnection &&other) noexcept;
+  BridgeConnection(const BridgeConnection &) = delete;
+  BridgeConnection &operator=(const BridgeConnection &) = delete;
+  ~BridgeConnection();
+
+  // Encodes an envelope and hands the framed bytes to the writer thread's
+  // bounded queue. Never blocks on the socket, so it is safe to call from a
+  // gz-transport callback thread. `droppable` marks best-effort payloads
+  // (camera frames): when the queue is congested they are dropped rather than
+  // enqueued, so a slow peer cannot back-pressure the producer. Non-droppable
+  // payloads (odometry) are always enqueued and are never starved behind a
+  // pending frame. Returns false only once the connection is torn down; a
+  // congestion drop of a droppable payload still returns true.
+  bool WriteEnvelope(const pilotage::bridge::v1::BridgeEnvelope &envelope,
+                     bool droppable);
+
+  // Blocks reading exactly one length-delimited envelope from the socket.
+  // Returns false on EOF or a read error (peer closed / broken pipe). Not
+  // thread-safe; a single reader thread owns it.
+  bool ReadEnvelope(pilotage::bridge::v1::BridgeEnvelope &envelope_out);
+
+  // Marks the connection closed, shuts the socket down so a blocked
+  // ReadEnvelope returns promptly, and wakes the writer thread to exit. Safe to
+  // call from a signal-driven thread.
+  void Shutdown();
+
+ private:
+  // Serialized outbound frame plus its priority. Frames are pre-encoded on the
+  // producer thread so the writer thread only touches the socket.
+  struct QueuedFrame {
+    std::vector<std::uint8_t> bytes;
+    bool droppable;
+  };
+
+  // Shared socket + outbound queue, heap-allocated so its address is stable
+  // across a BridgeConnection move: the writer thread captures a raw pointer to
+  // this block, never to the (movable) BridgeConnection itself.
+  struct WriterState {
+    int fd = -1;
+    std::vector<std::uint8_t> read_buffer;
+
+    // Bounded outbound queue drained by the writer thread. queue_mutex is held
+    // only to push/pop; the blocking send happens with the lock released so a
+    // stalled peer never parks a producer.
+    std::mutex queue_mutex;
+    std::condition_variable queue_cv;
+    std::deque<QueuedFrame> queue;
+    std::size_t pending_droppable = 0;
+    bool stop = false;
+
+    // Pops frames and sends them until stop or a send error, then closes the
+    // send path so the peer sees EOF.
+    void WriterLoop();
+    // Writes exactly len bytes, retrying short writes; false on hard error or a
+    // send timeout (a wedged peer). Runs only on the writer thread.
+    bool WriteAll(const std::uint8_t *data, std::size_t len);
+  };
+
+  explicit BridgeConnection(int fd);
+
+  // Reads exactly len bytes; false on EOF or hard error.
+  bool ReadAll(std::uint8_t *data, std::size_t len);
+
+  std::unique_ptr<WriterState> state_;
+  std::thread writer_thread_;
+};
+
+}  // namespace pilotage::bridge
+
+#endif  // PILOTAGE_GZ_BRIDGE_FRAMING_HPP

--- a/adapters/gazebo/bridge/src/main.cpp
+++ b/adapters/gazebo/bridge/src/main.cpp
@@ -1,0 +1,141 @@
+// pilotage-gz-bridge: C++ gz-transport sidecar (ADR-0008).
+//
+// Connects a TCP client to the Rust adapter on 127.0.0.1:<port>, subscribes
+// the vehicle's odometry and camera topics, advertises its cmd_vel, and
+// translates in both directions over the length-delimited bridge protocol.
+// It is the only process in Pilotage that links gz-transport.
+//
+// Exit codes: 0 clean shutdown (signal or peer close); non-zero on a fatal
+// wiring/connect error, with a diagnostic on stderr.
+
+#include <atomic>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include "bridge_node.hpp"
+#include "framing.hpp"
+
+namespace {
+
+// Set from a signal handler; async-signal-safe atomic flag only.
+std::atomic<bool> g_shutdown_requested{false};
+
+// Non-owning handle to the live connection so the signal handler can unblock a
+// parked ReadEnvelope. Written once before the reader loop starts.
+std::atomic<pilotage::bridge::BridgeConnection *> g_connection{nullptr};
+
+void HandleSignal(int /*signum*/) {
+  g_shutdown_requested.store(true, std::memory_order_relaxed);
+  auto *conn = g_connection.load(std::memory_order_relaxed);
+  if (conn != nullptr) {
+    conn->Shutdown();
+  }
+}
+
+struct Args {
+  std::uint16_t port = 0;
+  std::string vehicle = "vehicle_blue";
+  std::string camera_topic = "/camera";
+};
+
+// Parses --port/--vehicle/--camera-topic. Returns nullopt and writes a usage
+// diagnostic on a missing or malformed argument.
+std::optional<Args> ParseArgs(int argc, char **argv) {
+  Args args;
+  bool have_port = false;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string flag = argv[i];
+    const bool has_value = (i + 1) < argc;
+
+    if (flag == "--port" && has_value) {
+      const long value = std::strtol(argv[++i], nullptr, 10);
+      if (value <= 0 || value > 65535) {
+        std::cerr << "pilotage-gz-bridge: --port must be 1..65535\n";
+        return std::nullopt;
+      }
+      args.port = static_cast<std::uint16_t>(value);
+      have_port = true;
+    } else if (flag == "--vehicle" && has_value) {
+      args.vehicle = argv[++i];
+    } else if (flag == "--camera-topic" && has_value) {
+      args.camera_topic = argv[++i];
+    } else {
+      std::cerr << "pilotage-gz-bridge: unexpected argument '" << flag << "'\n";
+      return std::nullopt;
+    }
+  }
+
+  if (!have_port) {
+    std::cerr << "usage: pilotage-gz-bridge --port N [--vehicle NAME] "
+                 "[--camera-topic TOPIC]\n";
+    return std::nullopt;
+  }
+  return args;
+}
+
+void InstallSignalHandlers() {
+  struct sigaction sa{};
+  sa.sa_handler = HandleSignal;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigaction(SIGINT, &sa, nullptr);
+  sigaction(SIGTERM, &sa, nullptr);
+  // A dead peer would otherwise raise SIGPIPE and kill us mid-write; ignore it
+  // and rely on send() returning an error instead.
+  std::signal(SIGPIPE, SIG_IGN);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  const std::optional<Args> parsed = ParseArgs(argc, argv);
+  if (!parsed.has_value()) {
+    return EXIT_FAILURE;
+  }
+  const Args &args = *parsed;
+
+  InstallSignalHandlers();
+
+  std::string error;
+  std::optional<pilotage::bridge::BridgeConnection> connection =
+      pilotage::bridge::BridgeConnection::Connect(args.port, error);
+  if (!connection.has_value()) {
+    std::cerr << "pilotage-gz-bridge: " << error << "\n";
+    return EXIT_FAILURE;
+  }
+  g_connection.store(&(*connection), std::memory_order_relaxed);
+
+  pilotage::bridge::BridgeConfig config{args.vehicle, args.camera_topic};
+  pilotage::bridge::BridgeNode bridge(config, &(*connection));
+  if (!bridge.Start(error)) {
+    std::cerr << "pilotage-gz-bridge: " << error << "\n";
+    return EXIT_FAILURE;
+  }
+
+  std::cerr << "pilotage-gz-bridge: connected to 127.0.0.1:" << args.port
+            << ", vehicle=" << args.vehicle
+            << ", camera=" << args.camera_topic << "\n";
+
+  // Inbound control loop: block on the socket, publish each BridgeControl as a
+  // Twist. A false read is EOF/error/shutdown -> exit so the parent detects
+  // our death. gz callbacks continue to fire on their own threads meanwhile.
+  pilotage::bridge::v1::BridgeEnvelope envelope;
+  while (!g_shutdown_requested.load(std::memory_order_relaxed)) {
+    if (!connection->ReadEnvelope(envelope)) {
+      break;
+    }
+    if (envelope.has_control()) {
+      bridge.PublishControl(envelope.control());
+    }
+  }
+
+  g_connection.store(nullptr, std::memory_order_relaxed);
+  std::cerr << "pilotage-gz-bridge: shutting down\n";
+  return EXIT_SUCCESS;
+}

--- a/adapters/gazebo/build.rs
+++ b/adapters/gazebo/build.rs
@@ -1,0 +1,40 @@
+//! Generates `prost` wire types from
+//! `schemas/pilotage/bridge/v1/bridge.proto` into `OUT_DIR` at build time,
+//! mirroring `pilotage-protocol`'s build script. This is the internal
+//! host<->sidecar bridge schema (ADR-0008), never the public client
+//! protocol.
+//!
+//! `println!` is the only channel Cargo defines for a build script to emit
+//! `cargo:rerun-if-changed` and `cargo:warning` directives, so it is allowed
+//! here even though the workspace otherwise bans it in favor of `tracing`.
+#![allow(clippy::disallowed_macros)]
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let bridge_dir = manifest_dir
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("pilotage")
+        .join("bridge")
+        .join("v1");
+    let schema_root = manifest_dir.join("..").join("..").join("schemas");
+
+    let protos = [bridge_dir.join("bridge.proto")];
+
+    println!("cargo:rerun-if-changed={}", bridge_dir.display());
+
+    // A build script cannot propagate `Result` to `main`'s caller the way a
+    // library can (ADR-0015 bans `process::exit`), so a non-zero `ExitCode`
+    // is the sanctioned way to fail the build without `expect`/`panic`.
+    match prost_build::Config::new().compile_protos(&protos, &[schema_root]) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            println!("cargo:warning=failed to compile pilotage.bridge.v1 schemas: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -1,0 +1,372 @@
+//! `VehicleAdapter` implementation backed by a real Gazebo diff-drive vehicle,
+//! driven through the C++ gz-transport sidecar bridge (ADR-0008).
+//!
+//! Canonical control axes map to the diff-drive command frame: throttle =
+//! `LogicalAxisId(2)` -> `linear.x`, yaw = `LogicalAxisId(3)` -> `angular.z`.
+//! Cached `BridgeOdometry` becomes a canonical `TelemetrySample`. Raw camera
+//! frames are exposed alongside the trait via [`GazeboAdapter::subscribe_frames`]
+//! because streaming video does not fit the pull-based `sample_telemetry` shape.
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossPolicy, Pose2d,
+    RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch, TelemetrySample,
+    VehicleAdapter, VehicleDescriptor, VideoSource,
+};
+use pilotage_protocol::{LogicalAxisId, ScopeId, ScopedControlFrame, VehicleId};
+use pilotage_timing::SimTick;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::bridge_client::{BridgeClient, BridgeConfig};
+use crate::error::GazeboAdapterError;
+use crate::wire::{BridgeControl, BridgeFrame, BridgeOdometry};
+
+/// The control scope this adapter exposes for the diff-drive vehicle.
+pub const MOTION_SCOPE: &str = "vehicle.motion";
+/// Canonical logical axis carrying throttle (`linear.x`) commands.
+pub const THROTTLE_AXIS: u16 = 2;
+/// Canonical logical axis carrying yaw (`angular.z`) commands.
+pub const YAW_AXIS: u16 = 3;
+/// Identifier of the single onboard camera video source.
+pub const CAMERA_SOURCE_ID: &str = "onboard-camera";
+
+/// A decoded raw camera frame from the sidecar bridge, paired with the
+/// simulation tick it was captured at.
+///
+/// Exposed via [`GazeboAdapter::subscribe_frames`] alongside the
+/// `VehicleAdapter` trait rather than through it: frame delivery is a
+/// streaming, backpressure-sensitive concern that does not fit the pull-based
+/// `sample_telemetry` shape (ADR-0008).
+#[derive(Debug, Clone)]
+pub struct RawVideoFrame {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Sidecar-reported pixel format (e.g. `"RGB_INT8"`).
+    pub pixel_format: String,
+    /// Simulation tick this frame was captured at (sidecar sim time, ns).
+    pub tick: SimTick,
+    /// Raw pixel bytes, row-major, no padding.
+    pub rgb: Vec<u8>,
+}
+
+impl From<BridgeFrame> for RawVideoFrame {
+    fn from(frame: BridgeFrame) -> Self {
+        Self {
+            width: frame.width,
+            height: frame.height,
+            pixel_format: frame.pixel_format,
+            tick: SimTick::new(frame.sim_time_ns),
+            rgb: frame.rgb,
+        }
+    }
+}
+
+/// `VehicleAdapter` implementation that drives a real Gazebo diff-drive
+/// vehicle through the gz-transport sidecar bridge.
+///
+/// The adapter is real-time (ADR-0013): it observes sim time from the bridge's
+/// odometry stream and does not itself advance the simulation, so `step` is a
+/// no-op reporting the latest observed sim tick.
+#[derive(Debug)]
+pub struct GazeboAdapter {
+    vehicle: VehicleId,
+    bridge: BridgeClient,
+    frame_rx: Option<mpsc::Receiver<RawVideoFrame>>,
+    frame_forwarder: Option<JoinHandle<()>>,
+    link_loss_policy: Option<LinkLossPolicy>,
+}
+
+impl GazeboAdapter {
+    /// Spawns the sidecar bridge, connects to it, and returns a ready adapter
+    /// for `vehicle`.
+    ///
+    /// A background forwarder converts inbound `BridgeFrame`s into
+    /// [`RawVideoFrame`]s on a bounded channel drained through
+    /// [`Self::subscribe_frames`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`GazeboAdapterError`] if the listener cannot bind, the bridge
+    /// child cannot be spawned, or its inbound connection cannot be accepted.
+    pub async fn new(vehicle: VehicleId, config: BridgeConfig) -> Result<Self, GazeboAdapterError> {
+        let depth = config.frame_channel_depth.max(1);
+        let mut bridge = BridgeClient::spawn_and_connect(config).await?;
+
+        let (raw_tx, raw_rx) = mpsc::channel::<RawVideoFrame>(depth);
+        let frame_forwarder = bridge
+            .take_frame_rx()
+            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx)));
+
+        Ok(Self {
+            vehicle,
+            bridge,
+            frame_rx: Some(raw_rx),
+            frame_forwarder,
+            link_loss_policy: None,
+        })
+    }
+
+    /// Wires an adapter around a caller-supplied bridge client (no child
+    /// process), for in-process fake-bridge tests.
+    #[cfg(test)]
+    fn from_bridge(vehicle: VehicleId, mut bridge: BridgeClient) -> Self {
+        let (raw_tx, raw_rx) = mpsc::channel::<RawVideoFrame>(4);
+        let frame_forwarder = bridge
+            .take_frame_rx()
+            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx)));
+        Self {
+            vehicle,
+            bridge,
+            frame_rx: Some(raw_rx),
+            frame_forwarder,
+            link_loss_policy: None,
+        }
+    }
+
+    /// Takes ownership of the receiver for decoded raw video frames, if not
+    /// already taken.
+    ///
+    /// Frames do not fit the sans-IO `VehicleAdapter` trait's pull-based
+    /// telemetry model, so they are exposed through this concrete method for
+    /// the host's media pipeline instead (ADR-0008, ADR-0005).
+    pub fn subscribe_frames(&mut self) -> Option<mpsc::Receiver<RawVideoFrame>> {
+        self.frame_rx.take()
+    }
+
+    /// Number of camera frames the bridge reader dropped due to a full frame
+    /// channel (a slow media consumer), for diagnostics.
+    #[must_use]
+    pub fn dropped_frames(&self) -> u64 {
+        self.bridge.dropped_frames()
+    }
+
+    /// Reports whether the bridge's background reader is still alive.
+    ///
+    /// This is exposed alongside the `VehicleAdapter` trait (like
+    /// [`Self::subscribe_frames`]) because the trait's pull-based
+    /// `sample_telemetry` has no channel for a liveness error. Once this
+    /// returns `Err`, cached telemetry is permanently frozen and
+    /// [`Self::sample_telemetry`] stops emitting the stale sample, so a host
+    /// polling this can neutralize the vehicle instead of trusting dead
+    /// odometry (a teleop safety gap).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GazeboAdapterError::ReaderTaskEnded`] once the bridge reader
+    /// has exited, carrying the reason.
+    pub fn reader_health(&self) -> Result<(), GazeboAdapterError> {
+        self.bridge.reader_health()
+    }
+
+    fn validate_frame(&self, frame: &ScopedControlFrame) -> Result<(), RejectReason> {
+        if frame.vehicle != self.vehicle {
+            return Err(RejectReason::UnknownVehicle);
+        }
+        if frame.scope.as_str() != MOTION_SCOPE {
+            return Err(RejectReason::UnknownScope);
+        }
+        let known = [
+            LogicalAxisId::new(THROTTLE_AXIS),
+            LogicalAxisId::new(YAW_AXIS),
+        ];
+        for (axis, _) in &frame.payload.axes {
+            if !known.contains(axis) {
+                return Err(RejectReason::UnknownAxis);
+            }
+        }
+        Ok(())
+    }
+
+    /// Simulation tick derived from the latest observed odometry, or tick 0
+    /// before any odometry has arrived.
+    fn latest_tick(&self) -> SimTick {
+        self.bridge
+            .latest_cached()
+            .odometry
+            .map_or_else(|| SimTick::new(0), |odom| SimTick::new(odom.sim_time_ns))
+    }
+}
+
+/// Maps canonical axis values in a validated frame onto a diff-drive command.
+///
+/// Axis values follow the `[-1.0, 1.0]` canonical convention; they are passed
+/// through as `linear.x` / `angular.z` in the vehicle's native m/s and rad/s.
+/// Absent axes hold neutral (`0.0`) rather than the last value: the host
+/// resends the full motion frame each tick under latest-valid-value semantics.
+fn control_from_frame(frame: &ScopedControlFrame) -> (BridgeControl, bool) {
+    let mut linear_x = 0.0_f64;
+    let mut angular_z = 0.0_f64;
+    let mut transformed = false;
+    for (axis, value) in &frame.payload.axes {
+        let (clamped, changed) = clamp_axis(f64::from(*value));
+        transformed |= changed;
+        if *axis == LogicalAxisId::new(THROTTLE_AXIS) {
+            linear_x = clamped;
+        } else if *axis == LogicalAxisId::new(YAW_AXIS) {
+            angular_z = clamped;
+        }
+    }
+    (
+        BridgeControl {
+            linear_x,
+            angular_z,
+        },
+        transformed,
+    )
+}
+
+/// Coerces a raw axis value into `[-1.0, 1.0]`, returning the clamped value and
+/// whether it differed from the input. NaN maps to neutral `0.0`; infinities
+/// map to the range bounds, so a non-finite value never reaches the bridge.
+fn clamp_axis(value: f64) -> (f64, bool) {
+    let clamped = if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(-1.0, 1.0)
+    };
+    (clamped, clamped != value)
+}
+
+/// Builds a `TelemetrySample` from a bridge odometry reading.
+fn telemetry_from_odometry(vehicle: VehicleId, odom: &BridgeOdometry) -> TelemetrySample {
+    TelemetrySample {
+        vehicle,
+        tick: SimTick::new(odom.sim_time_ns),
+        pose: Pose2d {
+            x: odom.x,
+            y: odom.y,
+            heading: odom.heading,
+        },
+        speed: odom.speed,
+    }
+}
+
+/// Forwards `BridgeFrame`s to the adapter's `RawVideoFrame` channel until
+/// either end closes.
+async fn forward_frames(
+    mut bridge_rx: mpsc::Receiver<BridgeFrame>,
+    raw_tx: mpsc::Sender<RawVideoFrame>,
+) {
+    while let Some(frame) = bridge_rx.recv().await {
+        if raw_tx.send(RawVideoFrame::from(frame)).await.is_err() {
+            return;
+        }
+    }
+}
+
+impl Drop for GazeboAdapter {
+    fn drop(&mut self) {
+        if let Some(handle) = self.frame_forwarder.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl VehicleAdapter for GazeboAdapter {
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            execution: ExecutionMode {
+                real_time: true,
+                render_capable: true,
+                physically_embodied: false,
+                ..ExecutionMode::default()
+            },
+            vehicles: vec![VehicleDescriptor {
+                id: self.vehicle,
+                scopes: vec![ScopeDescriptor {
+                    scope: ScopeId::new(MOTION_SCOPE),
+                    axes: vec![
+                        LogicalAxisId::new(THROTTLE_AXIS),
+                        LogicalAxisId::new(YAW_AXIS),
+                    ],
+                }],
+                link_loss_actions: vec![LinkLossPolicy::Neutralize],
+            }],
+            adapter_version: env!("CARGO_PKG_VERSION").to_owned(),
+        }
+    }
+
+    fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
+        if let Err(reason) = self.validate_frame(frame) {
+            return ApplyOutcome {
+                tick: self.latest_tick(),
+                disposition: Disposition::Rejected(reason),
+            };
+        }
+        let (control, transformed) = control_from_frame(frame);
+        if !self.bridge.try_send_control(control) {
+            return ApplyOutcome {
+                tick: self.latest_tick(),
+                disposition: Disposition::Rejected(RejectReason::Other(
+                    "sidecar bridge control link is closed".to_owned(),
+                )),
+            };
+        }
+        ApplyOutcome {
+            tick: self.latest_tick(),
+            disposition: if transformed {
+                Disposition::Transformed
+            } else {
+                Disposition::Accepted
+            },
+        }
+    }
+
+    fn sample_telemetry(&mut self) -> TelemetryBatch {
+        // Once the reader has died the odometry cache is frozen; emitting the
+        // last sample would present stale pose/speed as live. The trait has no
+        // error channel, so withhold the sample and let a host that cares poll
+        // `reader_health` for the reason (a teleop safety gap).
+        if self.bridge.reader_health().is_err() {
+            return TelemetryBatch::default();
+        }
+        match self.bridge.latest_cached().odometry {
+            Some(odom) => TelemetryBatch {
+                samples: vec![telemetry_from_odometry(self.vehicle, &odom)],
+            },
+            None => TelemetryBatch::default(),
+        }
+    }
+
+    fn video_sources(&self) -> Vec<VideoSource> {
+        vec![VideoSource {
+            id: CAMERA_SOURCE_ID.to_owned(),
+            description: "onboard forward camera".to_owned(),
+        }]
+    }
+
+    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
+        if vehicle != self.vehicle {
+            return;
+        }
+        self.link_loss_policy = policy;
+        // On link loss, halt the vehicle immediately. Only `Neutralize` is
+        // advertised (a diff-drive without onboard automation has no richer
+        // safe action), so any engaged policy stops the wheels; clearing the
+        // policy (`None`, link recovery) leaves the last operator command in
+        // effect. A closed control link means the vehicle is already stopping
+        // on its own bridge-side timeout, so a failed send is not fatal here.
+        if policy.is_some() {
+            let stopped = self.bridge.try_send_control(BridgeControl {
+                linear_x: 0.0,
+                angular_z: 0.0,
+            });
+            let _ = stopped;
+        }
+    }
+
+    fn step(&mut self, _budget: StepBudget) -> StepOutcome {
+        // Real-time adapter (ADR-0013): the simulation advances on Gazebo's own
+        // clock, observed through the odometry stream. `step` never drives it,
+        // so it advances zero ticks and reports the latest observed sim tick.
+        StepOutcome {
+            advanced: 0,
+            now: self.latest_tick(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/adapters/gazebo/src/adapter/tests.rs
+++ b/adapters/gazebo/src/adapter/tests.rs
@@ -1,0 +1,308 @@
+//! Unit tests for the Gazebo `VehicleAdapter` implementation in `adapter.rs`:
+//! axis clamping and mapping, telemetry conversion, and end-to-end control /
+//! odometry / camera flow against an in-process fake bridge on a loopback
+//! socket (no child process, no live Gazebo).
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{
+    GazeboAdapter, MOTION_SCOPE, THROTTLE_AXIS, YAW_AXIS, clamp_axis, control_from_frame,
+    telemetry_from_odometry,
+};
+use crate::bridge_client::BridgeClient;
+use crate::error::GazeboAdapterError;
+use crate::framing::read_envelope;
+use crate::wire::{BridgeEnvelope, BridgeFrame, BridgeOdometry, bridge_envelope};
+use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_protocol::{
+    ControlPayload, Generation, LogicalAxisId, ScopeId, ScopedControlFrame, SequenceNum, SessionId,
+    VehicleId,
+};
+use pilotage_timing::MonoTimestamp;
+use prost::Message;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+
+fn frame(scope: &str, axes: Vec<(LogicalAxisId, f32)>, vehicle: VehicleId) -> ScopedControlFrame {
+    ScopedControlFrame {
+        session: SessionId::new(1),
+        vehicle,
+        scope: ScopeId::new(scope),
+        generation: Generation::new(1),
+        sequence: SequenceNum::new(1),
+        sampled_at: MonoTimestamp::from_nanos(0),
+        profile_revision: 1,
+        payload: ControlPayload {
+            axes,
+            edges: vec![],
+        },
+    }
+}
+
+/// Binds a loopback listener and returns both ends of an accepted stream,
+/// standing in for the sidecar<->host socket without any child process.
+async fn connected_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind loopback listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let connect = tokio::spawn(async move { TcpStream::connect(addr).await });
+    let (host_side, _peer) = listener.accept().await.expect("accept fake bridge");
+    let bridge_side = connect.await.expect("join connect").expect("connect");
+    (host_side, bridge_side)
+}
+
+async fn send_envelope(stream: &mut TcpStream, envelope: &BridgeEnvelope) {
+    let bytes = envelope.encode_length_delimited_to_vec();
+    stream.write_all(&bytes).await.expect("fake bridge write");
+}
+
+#[test]
+fn clamp_axis_neutralizes_nan_and_bounds_infinity() {
+    assert_eq!(clamp_axis(f64::NAN), (0.0, true));
+    assert_eq!(clamp_axis(2.0), (1.0, true));
+    assert_eq!(clamp_axis(-5.0), (-1.0, true));
+    assert_eq!(clamp_axis(0.5), (0.5, false));
+}
+
+#[test]
+fn control_maps_throttle_to_linear_and_yaw_to_angular() {
+    let vehicle = VehicleId::new(7);
+    let (control, transformed) = control_from_frame(&frame(
+        MOTION_SCOPE,
+        vec![
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.8),
+            (LogicalAxisId::new(YAW_AXIS), -0.4),
+        ],
+        vehicle,
+    ));
+    assert!(!transformed);
+    assert!((control.linear_x - 0.8).abs() < 1e-6);
+    assert!((control.angular_z - -0.4).abs() < 1e-6);
+}
+
+#[test]
+fn control_clamps_out_of_range_and_reports_transformed() {
+    let vehicle = VehicleId::new(7);
+    let (control, transformed) = control_from_frame(&frame(
+        MOTION_SCOPE,
+        vec![(LogicalAxisId::new(THROTTLE_AXIS), 9.0)],
+        vehicle,
+    ));
+    assert!(transformed);
+    assert!((control.linear_x - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn odometry_maps_to_canonical_telemetry() {
+    let sample = telemetry_from_odometry(
+        VehicleId::new(3),
+        &BridgeOdometry {
+            x: 1.0,
+            y: 2.0,
+            heading: 0.5,
+            speed: 4.0,
+            sim_time_ns: 900,
+        },
+    );
+    assert_eq!(sample.vehicle, VehicleId::new(3));
+    assert_eq!(sample.tick.as_u64(), 900);
+    assert!((sample.pose.x - 1.0).abs() < 1e-6);
+    assert!((sample.speed - 4.0).abs() < 1e-6);
+}
+
+#[tokio::test]
+async fn apply_control_sends_mapped_command_over_the_bridge() {
+    let vehicle = VehicleId::new(1);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+
+    let outcome = adapter.apply_control(&frame(
+        MOTION_SCOPE,
+        vec![
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.5),
+            (LogicalAxisId::new(YAW_AXIS), 0.25),
+        ],
+        vehicle,
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+
+    let received = read_envelope(&mut bridge_side)
+        .await
+        .expect("fake bridge reads control")
+        .expect("control envelope present");
+    match received.payload {
+        Some(bridge_envelope::Payload::Control(control)) => {
+            assert!((control.linear_x - 0.5).abs() < 1e-6);
+            assert!((control.angular_z - 0.25).abs() < 1e-6);
+        }
+        other => panic!("expected a control payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unknown_scope_is_rejected_without_sending() {
+    let vehicle = VehicleId::new(1);
+    let (host_side, _bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+    let outcome = adapter.apply_control(&frame("vehicle.camera", vec![], vehicle));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::UnknownScope)
+    );
+}
+
+#[tokio::test]
+async fn cached_odometry_becomes_telemetry_sample() {
+    let vehicle = VehicleId::new(2);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+
+    send_envelope(
+        &mut bridge_side,
+        &BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Odometry(BridgeOdometry {
+                x: 5.0,
+                y: -1.0,
+                heading: 1.5,
+                speed: 2.5,
+                sim_time_ns: 1234,
+            })),
+        },
+    )
+    .await;
+
+    // Poll until the reader task has published the odometry.
+    let mut telemetry = adapter.sample_telemetry();
+    for _ in 0..200 {
+        if !telemetry.samples.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        telemetry = adapter.sample_telemetry();
+    }
+    let sample = telemetry.samples.first().expect("telemetry sample present");
+    assert_eq!(sample.tick.as_u64(), 1234);
+    assert!((sample.pose.x - 5.0).abs() < 1e-6);
+    assert!((sample.speed - 2.5).abs() < 1e-6);
+}
+
+#[tokio::test]
+async fn camera_frame_reaches_the_subscriber() {
+    let vehicle = VehicleId::new(4);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+    let mut frames = adapter.subscribe_frames().expect("frame receiver present");
+
+    send_envelope(
+        &mut bridge_side,
+        &BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Frame(BridgeFrame {
+                width: 4,
+                height: 2,
+                pixel_format: "RGB_INT8".to_owned(),
+                sim_time_ns: 77,
+                rgb: vec![9_u8; 24],
+            })),
+        },
+    )
+    .await;
+
+    let frame = frames.recv().await.expect("a frame arrives");
+    assert_eq!(frame.width, 4);
+    assert_eq!(frame.height, 2);
+    assert_eq!(frame.tick.as_u64(), 77);
+    assert_eq!(frame.rgb.len(), 24);
+}
+
+#[tokio::test]
+async fn reader_death_surfaces_liveness_and_withholds_stale_telemetry() {
+    let vehicle = VehicleId::new(6);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+
+    // Seed a cached odometry sample so there is a "last value" to go stale.
+    send_envelope(
+        &mut bridge_side,
+        &BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Odometry(BridgeOdometry {
+                x: 3.0,
+                y: 3.0,
+                heading: 0.0,
+                speed: 1.0,
+                sim_time_ns: 500,
+            })),
+        },
+    )
+    .await;
+    let mut telemetry = adapter.sample_telemetry();
+    for _ in 0..200 {
+        if !telemetry.samples.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        telemetry = adapter.sample_telemetry();
+    }
+    assert!(!telemetry.samples.is_empty(), "odometry should be cached");
+    assert!(adapter.reader_health().is_ok(), "reader alive before EOF");
+
+    // Drop the bridge end: the reader hits EOF and must publish its death.
+    drop(bridge_side);
+    let mut health = adapter.reader_health();
+    for _ in 0..200 {
+        if health.is_err() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        health = adapter.reader_health();
+    }
+    assert!(
+        matches!(health, Err(GazeboAdapterError::ReaderTaskEnded { .. })),
+        "reader death must surface as ReaderTaskEnded, got {health:?}"
+    );
+    // The stale sample must no longer be presented as live telemetry.
+    assert!(
+        adapter.sample_telemetry().samples.is_empty(),
+        "telemetry must be withheld once the reader is dead"
+    );
+}
+
+#[tokio::test]
+async fn set_link_loss_policy_sends_stop() {
+    use pilotage_adapter_api::LinkLossPolicy;
+    let vehicle = VehicleId::new(9);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+
+    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
+    let received = read_envelope(&mut bridge_side)
+        .await
+        .expect("stop is read")
+        .expect("stop envelope present");
+    match received.payload {
+        Some(bridge_envelope::Payload::Control(control)) => {
+            assert_eq!(control.linear_x, 0.0);
+            assert_eq!(control.angular_z, 0.0);
+        }
+        other => panic!("expected a control payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn capabilities_report_motion_scope_and_camera_source() {
+    let vehicle = VehicleId::new(1);
+    let (host_side, _bridge_side) = connected_pair().await;
+    let adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+    let caps = adapter.capabilities();
+    assert!(caps.execution.real_time);
+    assert!(caps.execution.render_capable);
+    assert_eq!(caps.vehicles.len(), 1);
+    assert_eq!(caps.vehicles[0].scopes[0].scope.as_str(), MOTION_SCOPE);
+    assert_eq!(adapter.video_sources().len(), 1);
+}

--- a/adapters/gazebo/src/bridge_client.rs
+++ b/adapters/gazebo/src/bridge_client.rs
@@ -1,0 +1,357 @@
+//! Owns the localhost TCP link to the C++ gz-transport sidecar bridge
+//! (ADR-0008): binds a listener, spawns the bridge child, accepts its
+//! connection, then runs a background reader task (odometry -> shared
+//! latest-value state; camera frames -> a bounded channel) and a writer task
+//! (outbound `BridgeControl`).
+//!
+//! This module is intentionally I/O-heavy (`adapters/` is exempt from the
+//! sans-IO rule, ADR-0002): it is the only place in this crate that touches a
+//! socket or a child process. No raw gz-transport type crosses into
+//! `pilotage-protocol`; only the internal `pilotage.bridge.v1` wire types do.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use prost::Message;
+use tokio::io::{AsyncWriteExt, WriteHalf};
+use tokio::net::TcpListener;
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+use crate::error::GazeboAdapterError;
+use crate::framing::read_envelope;
+use crate::wire::{BridgeControl, BridgeEnvelope, BridgeFrame, BridgeOdometry, bridge_envelope};
+
+/// Environment variable overriding the sidecar bridge binary path.
+pub const BRIDGE_BIN_ENV: &str = "PILOTAGE_GZ_BRIDGE_BIN";
+
+/// Default bounded depth of the raw-frame channel. Small so a slow media
+/// consumer drops stale frames rather than growing memory or adding latency.
+const DEFAULT_FRAME_CHANNEL_DEPTH: usize = 4;
+
+/// Configuration for spawning and connecting to the sidecar bridge.
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    /// Path to the built C++ bridge binary. Overridden by [`BRIDGE_BIN_ENV`]
+    /// when that environment variable is set.
+    pub bridge_bin: PathBuf,
+    /// Gazebo model name passed to the bridge as `--vehicle`.
+    pub vehicle_name: String,
+    /// Bounded depth of the raw-frame channel.
+    pub frame_channel_depth: usize,
+}
+
+impl BridgeConfig {
+    /// Builds a config for `vehicle_name`, resolving the bridge binary path
+    /// from [`BRIDGE_BIN_ENV`] if set, else from `default_bridge_bin`.
+    #[must_use]
+    pub fn new(vehicle_name: impl Into<String>, default_bridge_bin: PathBuf) -> Self {
+        let bridge_bin = std::env::var_os(BRIDGE_BIN_ENV).map_or(default_bridge_bin, PathBuf::from);
+        Self {
+            bridge_bin,
+            vehicle_name: vehicle_name.into(),
+            frame_channel_depth: DEFAULT_FRAME_CHANNEL_DEPTH,
+        }
+    }
+}
+
+/// Latest cached odometry read from the sidecar bridge, shared between the
+/// background reader task and `sample_telemetry` callers.
+///
+/// Camera frames are delivered separately through a bounded channel (see
+/// [`BridgeClient::take_frame_rx`]) rather than this struct: raw video does
+/// not fit the pull-based, latest-value `sample_telemetry` shape (ADR-0008).
+#[derive(Debug, Clone, Default)]
+pub struct LatestBridgeState {
+    /// Most recent odometry sample, if any has arrived yet.
+    pub odometry: Option<BridgeOdometry>,
+}
+
+/// Liveness of the background reader task that feeds odometry and frames.
+///
+/// Once the reader exits (bridge EOF, a read/decode error, or the sidecar
+/// child dying), the odometry cache can never advance again. Callers poll
+/// [`BridgeClient::reader_health`] to distinguish a live-but-idle cache from a
+/// permanently frozen one, so stale telemetry is not mistaken for current.
+#[derive(Debug, Clone)]
+enum ReaderHealth {
+    /// The reader loop is still running.
+    Alive,
+    /// The reader loop has exited; the string describes why.
+    Ended(String),
+}
+
+/// A live connection to the gz-transport sidecar bridge and the child process
+/// hosting it.
+///
+/// Dropping the client kills the bridge child and aborts both background
+/// tasks, so no orphan process or task outlives the adapter.
+#[derive(Debug)]
+pub struct BridgeClient {
+    child: Option<Child>,
+    reader_task: JoinHandle<()>,
+    writer_task: JoinHandle<()>,
+    control_tx: watch::Sender<Option<BridgeControl>>,
+    state_rx: watch::Receiver<LatestBridgeState>,
+    reader_health_rx: watch::Receiver<ReaderHealth>,
+    frame_rx: Option<mpsc::Receiver<BridgeFrame>>,
+    dropped_frames: Arc<AtomicU64>,
+}
+
+impl BridgeClient {
+    /// Binds a localhost listener, spawns the sidecar bridge child pointed at
+    /// the bound port, accepts its inbound connection, and starts the reader
+    /// and writer tasks.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`GazeboAdapterError`] if the listener cannot bind, the child
+    /// cannot be spawned, or the inbound connection cannot be accepted.
+    pub async fn spawn_and_connect(config: BridgeConfig) -> Result<Self, GazeboAdapterError> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .map_err(|source| GazeboAdapterError::ListenerBind { source })?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|source| GazeboAdapterError::ListenerAddr { source })?;
+
+        let child = Self::spawn_child(&config, local_addr.port())?;
+        let stream = Self::accept(&listener, local_addr).await?;
+        Ok(Self::from_stream(
+            stream,
+            Some(child),
+            config.frame_channel_depth,
+        ))
+    }
+
+    /// Wires the reader/writer tasks around an already-connected stream. Shared
+    /// by [`Self::spawn_and_connect`] and, in tests, an in-process fake bridge.
+    fn from_stream(
+        stream: tokio::net::TcpStream,
+        child: Option<Child>,
+        frame_channel_depth: usize,
+    ) -> Self {
+        let (read_half, write_half) = tokio::io::split(stream);
+        let (state_tx, state_rx) = watch::channel(LatestBridgeState::default());
+        let (frame_tx, frame_rx) = mpsc::channel(frame_channel_depth.max(1));
+        let (control_tx, control_rx) = watch::channel::<Option<BridgeControl>>(None);
+        let (reader_health_tx, reader_health_rx) = watch::channel(ReaderHealth::Alive);
+        let dropped_frames = Arc::new(AtomicU64::new(0));
+
+        let reader_task = tokio::spawn(reader_loop(
+            read_half,
+            state_tx,
+            frame_tx,
+            reader_health_tx,
+            Arc::clone(&dropped_frames),
+        ));
+        let writer_task = tokio::spawn(writer_loop(write_half, control_rx));
+
+        Self {
+            child,
+            reader_task,
+            writer_task,
+            control_tx,
+            state_rx,
+            reader_health_rx,
+            frame_rx: Some(frame_rx),
+            dropped_frames,
+        }
+    }
+
+    fn spawn_child(config: &BridgeConfig, port: u16) -> Result<Child, GazeboAdapterError> {
+        Command::new(&config.bridge_bin)
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--vehicle")
+            .arg(&config.vehicle_name)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|source| GazeboAdapterError::BridgeSpawn {
+                path: config.bridge_bin.display().to_string(),
+                source,
+            })
+    }
+
+    async fn accept(
+        listener: &TcpListener,
+        local_addr: SocketAddr,
+    ) -> Result<tokio::net::TcpStream, GazeboAdapterError> {
+        let (stream, _peer) =
+            listener
+                .accept()
+                .await
+                .map_err(|source| GazeboAdapterError::BridgeAccept {
+                    addr: local_addr.to_string(),
+                    source,
+                })?;
+        Ok(stream)
+    }
+
+    /// Returns the latest cached bridge state (odometry).
+    #[must_use]
+    pub fn latest_cached(&self) -> LatestBridgeState {
+        self.state_rx.borrow().clone()
+    }
+
+    /// Reports whether the background reader task is still consuming the bridge
+    /// connection.
+    ///
+    /// The reader is the sole updater of the odometry cache and frame channel;
+    /// once it exits, [`Self::latest_cached`] can never advance again. Callers
+    /// poll this to detect that liveness gap rather than silently trusting a
+    /// frozen telemetry cache (a teleop safety concern).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GazeboAdapterError::ReaderTaskEnded`] once the reader loop has
+    /// exited (bridge EOF, a read/decode error, or the sidecar child dying),
+    /// carrying the reason it ended.
+    pub fn reader_health(&self) -> Result<(), GazeboAdapterError> {
+        match &*self.reader_health_rx.borrow() {
+            ReaderHealth::Alive => Ok(()),
+            ReaderHealth::Ended(reason) => Err(GazeboAdapterError::ReaderTaskEnded {
+                reason: reason.clone(),
+            }),
+        }
+    }
+
+    /// Publishes an outbound `BridgeControl` as the single latest command for
+    /// the writer task without blocking on the socket. Returns `false` if the
+    /// writer path is gone (the bridge disconnected), so callers can surface a
+    /// rejection.
+    #[must_use]
+    pub fn try_send_control(&self, control: BridgeControl) -> bool {
+        // Latest-valid-value: a single-slot watch always overwrites, so a
+        // wedged writer never drains stale commands and the newest control is
+        // never the one dropped (ADR-0009). `send` fails only once every
+        // receiver is gone (the writer task exited), which is the sole "link
+        // closed" signal callers care about.
+        self.control_tx.send(Some(control)).is_ok()
+    }
+
+    /// Takes the raw-frame receiver, if not already taken. Frames are exposed
+    /// here rather than through `sample_telemetry` because streaming video is
+    /// backpressure-sensitive and does not fit the pull-based trait model.
+    pub fn take_frame_rx(&mut self) -> Option<mpsc::Receiver<BridgeFrame>> {
+        self.frame_rx.take()
+    }
+
+    /// Number of camera frames dropped because the frame channel was full.
+    #[must_use]
+    pub fn dropped_frames(&self) -> u64 {
+        self.dropped_frames.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for BridgeClient {
+    fn drop(&mut self) {
+        // Abort the tasks first so neither races the socket teardown, then let
+        // `kill_on_drop` reap the child. No orphan process or task survives.
+        self.reader_task.abort();
+        self.writer_task.abort();
+        if let Some(child) = self.child.as_mut()
+            && let Err(err) = child.start_kill()
+        {
+            warn!(error = %err, "failed to signal sidecar bridge child on drop");
+        }
+    }
+}
+
+/// Reads length-delimited envelopes until EOF or error: odometry updates the
+/// shared latest-value state; frames go to the bounded channel, counting drops.
+///
+/// On every exit path it publishes an [`ReaderHealth::Ended`] status carrying
+/// the reason, so `reader_health` can surface the liveness loss instead of
+/// letting `sample_telemetry` return a frozen odometry cache forever.
+async fn reader_loop(
+    mut read_half: tokio::io::ReadHalf<tokio::net::TcpStream>,
+    state_tx: watch::Sender<LatestBridgeState>,
+    frame_tx: mpsc::Sender<BridgeFrame>,
+    reader_health_tx: watch::Sender<ReaderHealth>,
+    dropped_frames: Arc<AtomicU64>,
+) {
+    let reason = loop {
+        match read_envelope(&mut read_half).await {
+            Ok(Some(envelope)) => {
+                handle_envelope(envelope, &state_tx, &frame_tx, &dropped_frames);
+            }
+            Ok(None) => {
+                debug!("sidecar bridge closed the connection");
+                break "sidecar bridge closed the connection".to_owned();
+            }
+            Err(err) => {
+                warn!(error = %err, "sidecar bridge read failed; stopping reader");
+                break format!("sidecar bridge read failed: {err}");
+            }
+        }
+    };
+    // A closed receiver is impossible while the client is alive: the client
+    // owns the sole `reader_health_rx`, and dropping it aborts this task. So
+    // this publish is the client's one liveness signal for a self-terminated
+    // reader.
+    reader_health_tx.send_replace(ReaderHealth::Ended(reason));
+}
+
+fn handle_envelope(
+    envelope: BridgeEnvelope,
+    state_tx: &watch::Sender<LatestBridgeState>,
+    frame_tx: &mpsc::Sender<BridgeFrame>,
+    dropped_frames: &Arc<AtomicU64>,
+) {
+    match envelope.payload {
+        Some(bridge_envelope::Payload::Odometry(odometry)) => {
+            // A closed receiver is impossible here: the client owns the sole
+            // `state_rx`, so `send` only fails after the client is dropped,
+            // which also aborts this task.
+            state_tx.send_replace(LatestBridgeState {
+                odometry: Some(odometry),
+            });
+        }
+        Some(bridge_envelope::Payload::Frame(frame)) => {
+            if let Err(mpsc::error::TrySendError::Full(_)) = frame_tx.try_send(frame) {
+                dropped_frames.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        // The host never receives control envelopes; ignore anything else.
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+impl BridgeClient {
+    /// Wires a client around a caller-supplied stream with no child process,
+    /// for in-process fake-bridge tests.
+    pub(crate) fn connect_stream_for_test(stream: tokio::net::TcpStream) -> Self {
+        Self::from_stream(stream, None, DEFAULT_FRAME_CHANNEL_DEPTH)
+    }
+}
+
+/// Writes the latest published control as a length-delimited envelope whenever
+/// it changes. A slow socket coalesces intervening updates to the newest value
+/// (latest-valid-value, ADR-0009). Exits on channel close (client dropped) or a
+/// socket write error.
+async fn writer_loop(
+    mut write_half: WriteHalf<tokio::net::TcpStream>,
+    mut control_rx: watch::Receiver<Option<BridgeControl>>,
+) {
+    while control_rx.changed().await.is_ok() {
+        let Some(control) = *control_rx.borrow_and_update() else {
+            continue;
+        };
+        let envelope = BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Control(control)),
+        };
+        let bytes = envelope.encode_length_delimited_to_vec();
+        if let Err(err) = write_half.write_all(&bytes).await {
+            warn!(error = %err, "sidecar bridge write failed; stopping writer");
+            return;
+        }
+    }
+}

--- a/adapters/gazebo/src/error.rs
+++ b/adapters/gazebo/src/error.rs
@@ -1,0 +1,79 @@
+//! Typed errors for the `pilotage-adapter-gazebo` crate.
+
+/// Errors this adapter's bridge connection and control/telemetry paths can
+/// produce.
+#[derive(Debug, thiserror::Error)]
+pub enum GazeboAdapterError {
+    /// Binding the localhost TCP listener the sidecar dials back into failed.
+    #[error("failed to bind bridge listener on 127.0.0.1:0: {source}")]
+    ListenerBind {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Reading the bound listener's local address failed.
+    #[error("failed to read bound bridge listener address: {source}")]
+    ListenerAddr {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Spawning the C++ sidecar bridge child process failed.
+    #[error("failed to spawn gz-transport sidecar bridge at {path}: {source}")]
+    BridgeSpawn {
+        /// The bridge binary path the adapter attempted to execute.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Accepting the sidecar bridge's inbound TCP connection failed.
+    #[error("failed to accept sidecar bridge connection on {addr}: {source}")]
+    BridgeAccept {
+        /// The listener address the adapter was accepting on.
+        addr: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Connecting to the sidecar bridge's TCP endpoint failed.
+    #[error("failed to connect to gz-transport sidecar at {addr}: {source}")]
+    BridgeConnect {
+        /// The address the adapter attempted to connect to.
+        addr: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Reading a length-delimited `BridgeEnvelope` from the sidecar
+    /// connection failed.
+    #[error("failed to read bridge envelope: {source}")]
+    BridgeRead {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Writing a length-delimited `BridgeEnvelope` to the sidecar
+    /// connection failed.
+    #[error("failed to write bridge envelope: {source}")]
+    BridgeWrite {
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Decoding bytes read from the sidecar connection as a
+    /// `BridgeEnvelope` protobuf message failed.
+    #[error("failed to decode bridge envelope: {source}")]
+    BridgeDecode {
+        /// Underlying `prost` decode error.
+        #[source]
+        source: prost::DecodeError,
+    },
+    /// The background bridge-reader task exited before the adapter was
+    /// dropped, so cached telemetry or frames can no longer be updated.
+    #[error("bridge reader task ended unexpectedly: {reason}")]
+    ReaderTaskEnded {
+        /// Human-readable description of why the task ended.
+        reason: String,
+    },
+}

--- a/adapters/gazebo/src/framing.rs
+++ b/adapters/gazebo/src/framing.rs
@@ -1,0 +1,147 @@
+//! Async length-delimited framing for the host<->sidecar bridge connection
+//! (ADR-0008).
+//!
+//! The wire format is a protobuf base-128 varint byte-length prefix followed
+//! by the encoded [`crate::wire::BridgeEnvelope`], matching the C++ sidecar's
+//! `framing.cpp` and prost's `encode_length_delimited` on the outbound side.
+//! This module is I/O-bearing (`adapters/` is exempt from the sans-IO rule,
+//! ADR-0002): it is the byte-level read half of the socket.
+
+use prost::Message;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::error::GazeboAdapterError;
+use crate::wire::BridgeEnvelope;
+
+/// Upper bound on an inbound envelope body, matching the sidecar's own cap. A
+/// raw 320x240 RGB frame is ~230 KB; this leaves headroom while rejecting a
+/// corrupt length prefix that would otherwise demand an unbounded allocation.
+const MAX_ENVELOPE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Reads one base-128 varint length prefix, then that many body bytes, and
+/// decodes them as a [`BridgeEnvelope`].
+///
+/// Returns `Ok(None)` on a clean end-of-stream observed before any byte of a
+/// frame (the peer closed the connection between frames).
+///
+/// # Errors
+///
+/// Returns [`GazeboAdapterError::BridgeRead`] on an I/O error or a truncated
+/// frame, and [`GazeboAdapterError::BridgeDecode`] if the body is not a valid
+/// envelope. A length prefix over [`MAX_ENVELOPE_BYTES`] is reported as a read
+/// error rather than triggering a huge allocation.
+pub async fn read_envelope<R>(reader: &mut R) -> Result<Option<BridgeEnvelope>, GazeboAdapterError>
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(body_len) = read_varint(reader).await? else {
+        return Ok(None);
+    };
+    if body_len > MAX_ENVELOPE_BYTES {
+        return Err(GazeboAdapterError::BridgeRead {
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "bridge envelope length prefix exceeds maximum",
+            ),
+        });
+    }
+
+    let mut body = vec![0_u8; usize_from_u64(body_len)];
+    reader
+        .read_exact(&mut body)
+        .await
+        .map_err(|source| GazeboAdapterError::BridgeRead { source })?;
+
+    BridgeEnvelope::decode(body.as_slice())
+        .map(Some)
+        .map_err(|source| GazeboAdapterError::BridgeDecode { source })
+}
+
+/// Reads a base-128 varint from `reader`.
+///
+/// Returns `Ok(None)` if EOF is seen before the first byte; a partial varint
+/// (EOF mid-value) is a truncation error.
+async fn read_varint<R>(reader: &mut R) -> Result<Option<u64>, GazeboAdapterError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    let mut first = true;
+    loop {
+        let mut byte = [0_u8; 1];
+        match reader.read(&mut byte).await {
+            Ok(0) => {
+                if first {
+                    return Ok(None);
+                }
+                return Err(GazeboAdapterError::BridgeRead {
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "eof in the middle of a bridge length prefix",
+                    ),
+                });
+            }
+            Ok(_) => {}
+            Err(source) => return Err(GazeboAdapterError::BridgeRead { source }),
+        }
+        first = false;
+        value |= u64::from(byte[0] & 0x7F) << shift;
+        if byte[0] & 0x80 == 0 {
+            return Ok(Some(value));
+        }
+        shift = shift.wrapping_add(7);
+        if shift >= 64 {
+            return Err(GazeboAdapterError::BridgeRead {
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "malformed bridge length prefix varint",
+                ),
+            });
+        }
+    }
+}
+
+/// Narrows a `u64` byte length to `usize` without a `panic`-on-overflow cast.
+///
+/// On 64-bit hosts this is lossless; the guard only matters on a hypothetical
+/// 32-bit target, where an over-large (already `MAX_ENVELOPE_BYTES`-bounded)
+/// value would otherwise wrap.
+fn usize_from_u64(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::read_envelope;
+    use crate::wire::{BridgeEnvelope, BridgeOdometry, bridge_envelope};
+    use prost::Message;
+
+    #[tokio::test]
+    async fn round_trips_a_length_delimited_odometry_envelope() {
+        let envelope = BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Odometry(BridgeOdometry {
+                x: 1.5,
+                y: -2.0,
+                heading: 0.25,
+                speed: 3.0,
+                sim_time_ns: 42,
+            })),
+        };
+        let bytes = envelope.encode_length_delimited_to_vec();
+        let mut cursor = std::io::Cursor::new(bytes);
+        let decoded = read_envelope(&mut cursor)
+            .await
+            .expect("read succeeds")
+            .expect("frame present");
+        assert_eq!(decoded, envelope);
+    }
+
+    #[tokio::test]
+    async fn clean_eof_between_frames_yields_none() {
+        let mut cursor = std::io::Cursor::new(Vec::<u8>::new());
+        let decoded = read_envelope(&mut cursor).await.expect("read succeeds");
+        assert!(decoded.is_none());
+    }
+}

--- a/adapters/gazebo/src/lib.rs
+++ b/adapters/gazebo/src/lib.rs
@@ -1,0 +1,17 @@
+//! `VehicleAdapter` implementation backed by a real Gazebo diff-drive
+//! vehicle, driven through a C++ gz-transport sidecar bridge over a
+//! localhost TCP connection (ADR-0008). This crate owns all I/O
+//! (`adapters/` is exempt from the sans-IO rule, ADR-0002); no raw
+//! gz-transport type crosses into `pilotage-protocol`.
+
+mod adapter;
+mod bridge_client;
+mod error;
+mod framing;
+pub mod wire;
+
+pub use adapter::{
+    CAMERA_SOURCE_ID, GazeboAdapter, MOTION_SCOPE, RawVideoFrame, THROTTLE_AXIS, YAW_AXIS,
+};
+pub use bridge_client::{BRIDGE_BIN_ENV, BridgeClient, BridgeConfig, LatestBridgeState};
+pub use error::GazeboAdapterError;

--- a/adapters/gazebo/src/wire.rs
+++ b/adapters/gazebo/src/wire.rs
@@ -1,0 +1,12 @@
+//! Generated `prost` wire types for the internal `pilotage.bridge.v1`
+//! package (ADR-0008).
+//!
+//! Produced by `build.rs` from `schemas/pilotage/bridge/v1/bridge.proto`
+//! and neither hand-edited nor committed; `missing_docs` is allowed here
+//! because `prost` does not emit doc comments for every generated item, and
+//! the schema `.proto` file (the source of truth) already carries the
+//! documentation. This is the host<->sidecar bridge wire format only — it
+//! MUST NOT be re-exported into the public client protocol surface.
+#![allow(missing_docs)]
+
+include!(concat!(env!("OUT_DIR"), "/pilotage.bridge.v1.rs"));

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -1,0 +1,115 @@
+<!--
+  Pilotage demo browser viewer (increment 1b). Not the v1 client — a minimal,
+  self-contained page demonstrating command uplink, telemetry downlink, and
+  MJPEG video downlink against a real session host over WebTransport
+  (ADR-0004 local-demo shortcut, ADR-0005).
+
+  Serve statically, no build step:
+    python3 -m http.server 8000
+  then open http://localhost:8000/clients/web/index.html
+
+  The session host prints `LISTENING <port> <cert-hash-hex>` on startup; paste
+  those two values (plus the host, usually 127.0.0.1) into the boxes below, or
+  pass them as URL query params: ?host=127.0.0.1&port=4433&cert=<hex>.
+-->
+<title>Pilotage demo viewer</title>
+<meta charset="utf-8" />
+<style>
+  body {
+    background: #111;
+    color: #eee;
+    font-family: system-ui, sans-serif;
+    margin: 0;
+    padding: 1rem;
+  }
+  h1 {
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+  .bootstrap {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 0.75rem;
+  }
+  input {
+    background: #222;
+    color: #eee;
+    border: 1px solid #444;
+    padding: 0.35rem;
+    font-family: monospace;
+  }
+  #host,
+  #port {
+    width: 8rem;
+  }
+  #certHash {
+    width: 28rem;
+  }
+  button {
+    padding: 0.4rem 0.9rem;
+    cursor: pointer;
+  }
+  .stage {
+    position: relative;
+    display: inline-block;
+    border: 1px solid #333;
+  }
+  #video {
+    display: block;
+    background: #000;
+    max-width: 100%;
+  }
+  #overlay {
+    position: absolute;
+    top: 0.4rem;
+    left: 0.4rem;
+    background: rgba(0, 0, 0, 0.55);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.85rem;
+    border-radius: 3px;
+  }
+  #telemetry {
+    margin-top: 0.5rem;
+    font-family: monospace;
+    font-size: 0.9rem;
+  }
+  #status {
+    margin-top: 0.75rem;
+    white-space: pre-wrap;
+    font-family: monospace;
+    font-size: 0.75rem;
+    color: #9c9;
+    max-height: 16rem;
+    overflow-y: auto;
+    border-top: 1px solid #333;
+    padding-top: 0.5rem;
+  }
+  .hint {
+    color: #888;
+    font-size: 0.8rem;
+  }
+</style>
+
+<h1>Pilotage demo viewer</h1>
+<p class="hint">
+  Drive with arrow keys or WASD once connected. Video and telemetry arrive from the real
+  Gazebo vehicle through the session host.
+</p>
+
+<div class="bootstrap">
+  <label>host <input id="host" value="127.0.0.1" /></label>
+  <label>port <input id="port" placeholder="4433" /></label>
+  <label>cert hash <input id="certHash" placeholder="hex from LISTENING line" /></label>
+  <button id="connectBtn">Connect</button>
+</div>
+
+<div class="stage">
+  <canvas id="video" width="320" height="240"></canvas>
+  <div id="overlay"></div>
+</div>
+<div id="telemetry">no telemetry yet</div>
+<div id="status"></div>
+
+<script type="module" src="./main.js"></script>

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -1,0 +1,364 @@
+// Pilotage demo browser viewer (ADR-0004 local-demo shortcut; ADR-0005
+// WebTransport as the primary real-time transport). Not the v1 client — a
+// minimal, self-contained page proving command uplink, telemetry downlink,
+// and MJPEG video downlink work end to end against a real session host.
+//
+// Serve statically, no build step:
+//   python3 -m http.server 8000
+// then open http://localhost:8000/clients/web/index.html
+//
+// Bootstrap sequence (ADR-0005): open one WebTransport session pinned to the
+// host's dev cert hash, open a bidi stream, send ClientHello, read
+// ServerWelcome, send a LeaseRequest for vehicle.motion, read LeaseResponse.
+// Then: accept host-initiated uni streams and dispatch on their leading
+// kind-tag byte (0x01 authority-events, 0x02 one video frame); read
+// telemetry-fast datagrams for live pose; send control-fast datagrams
+// (bare Envelope, ControlFrame arm) from arrow/WASD key state.
+
+import {
+  encodeClientHelloEnvelope,
+  encodeLeaseRequestEnvelope,
+  encodeControlFrameEnvelope,
+  decodeLengthDelimitedEnvelope,
+  decodeBareEnvelope,
+  STREAM_KIND_AUTHORITY,
+  STREAM_KIND_VIDEO,
+} from "./wire.js";
+
+const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
+const MOTION_SCOPE = "vehicle.motion";
+const CONTROL_HZ = 30; // continuous control send rate; superseded samples are droppable (ADR-0011).
+const AXIS_THROTTLE = 2; // pilotage-input logical axis table: throttle = 2.
+const AXIS_YAW = 3; // pilotage-input logical axis table: yaw = 3.
+
+const els = {
+  host: document.getElementById("host"),
+  port: document.getElementById("port"),
+  certHash: document.getElementById("certHash"),
+  connectBtn: document.getElementById("connectBtn"),
+  status: document.getElementById("status"),
+  overlay: document.getElementById("overlay"),
+  telemetry: document.getElementById("telemetry"),
+  canvas: document.getElementById("video"),
+};
+const ctx = els.canvas.getContext("2d");
+
+/** Session-scoped mutable state the connect flow and background loops share. */
+const state = {
+  transport: null,
+  sessionId: 0,
+  generation: 0n,
+  sequence: 0,
+  startNanos: BigInt(Date.now()) * 1_000_000n, // arbitrary local monotonic-ish origin for sampled_at (ADR-0009: endpoint-local, never compared raw across endpoints).
+  keys: new Set(),
+  connected: false,
+};
+
+function log(line) {
+  const time = new Date().toISOString().split("T")[1].replace("Z", "");
+  els.status.textContent = `[${time}] ${line}\n${els.status.textContent}`.slice(0, 8000);
+}
+
+function nowNanos() {
+  return state.startNanos + BigInt(Math.round(performance.now() * 1_000_000));
+}
+
+/** Parses the URL's `?host=&port=&cert=` params into the input boxes, if present. */
+function applyUrlParams() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("host")) els.host.value = params.get("host");
+  if (params.has("port")) els.port.value = params.get("port");
+  if (params.has("cert")) els.certHash.value = params.get("cert");
+}
+
+/** Decodes a lowercase-hex cert hash string into a Uint8Array digest. */
+function hexToBytes(hex) {
+  const clean = hex.trim().toLowerCase();
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(clean.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+async function connect() {
+  const host = els.host.value.trim();
+  const port = els.port.value.trim();
+  const certHashHex = els.certHash.value.trim();
+  if (!host || !port || !certHashHex) {
+    log("host, port, and cert hash are all required");
+    return;
+  }
+  const url = `https://${host}:${port}/pilotage`;
+  const certHash = hexToBytes(certHashHex);
+
+  log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
+  const transport = new WebTransport(url, {
+    serverCertificateHashes: [{ algorithm: "sha-256", value: certHash }],
+  });
+  state.transport = transport;
+
+  transport.closed
+    .then(() => {
+      state.connected = false;
+      log("WebTransport session closed");
+    })
+    .catch((error) => {
+      state.connected = false;
+      log(`WebTransport session errored: ${error}`);
+    });
+
+  await transport.ready;
+  log("WebTransport session ready");
+
+  const bidi = await transport.createBidirectionalStream();
+  const writer = bidi.writable.getWriter();
+  const reader = bidi.readable.getReader();
+
+  await sendClientHello(writer);
+  await runBootstrapReader(reader, writer);
+
+  state.connected = true;
+  acceptIncomingUniStreams(transport);
+  readTelemetryDatagrams(transport);
+  startControlLoop(transport);
+}
+
+/** Writes a length-delimited `ClientHello` envelope onto the bootstrap bidi stream. */
+async function sendClientHello(writer) {
+  const hello = encodeClientHelloEnvelope({
+    protocolVersion: 1,
+    clientName: "pilotage-web-viewer",
+    joinToken: new Uint8Array(0),
+  });
+  await writer.write(lengthDelimit(hello));
+  log("sent ClientHello");
+}
+
+/** Writes a length-delimited `LeaseRequest` for the motion scope. */
+async function sendLeaseRequest(writer) {
+  const request = encodeLeaseRequestEnvelope({ vehicleId: VEHICLE_ID, scope: MOTION_SCOPE });
+  await writer.write(lengthDelimit(request));
+  log(`sent LeaseRequest for ${MOTION_SCOPE}`);
+}
+
+/** Prefixes an already-encoded `Envelope` with a protobuf varint byte-length, matching `encode_length_delimited` on the host. */
+function lengthDelimit(envelopeBytes) {
+  const prefix = [];
+  let v = envelopeBytes.length;
+  for (;;) {
+    let byte = v & 0x7f;
+    v >>>= 7;
+    if (v !== 0) {
+      prefix.push(byte | 0x80);
+    } else {
+      prefix.push(byte);
+      break;
+    }
+  }
+  const out = new Uint8Array(prefix.length + envelopeBytes.length);
+  out.set(prefix, 0);
+  out.set(envelopeBytes, prefix.length);
+  return out;
+}
+
+/** Reads bootstrap-stream frames until ServerWelcome and LeaseResponse are both seen, then keeps forwarding any later frames (Pong/FrameRejected) to the log. */
+async function runBootstrapReader(reader, writer) {
+  let pending = new Uint8Array(0);
+  let sentLease = false;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    pending = appendBytes(pending, value);
+    for (;;) {
+      const decoded = decodeLengthDelimitedEnvelope(pending);
+      if (!decoded) break;
+      pending = pending.subarray(decoded.consumed);
+      handleBootstrapMessage(decoded);
+      if (decoded.kind === "ServerWelcome" && !sentLease) {
+        sentLease = true;
+        await sendLeaseRequest(writer);
+      }
+      if (decoded.kind === "LeaseResponse") {
+        return; // bootstrap complete; later frames are drained by a background reader.
+      }
+    }
+  }
+}
+
+function handleBootstrapMessage(decoded) {
+  if (decoded.kind === "ServerWelcome") {
+    state.sessionId = decoded.message.sessionId;
+    log(`ServerWelcome: session=${decoded.message.sessionId} principal=${decoded.message.principalId}`);
+  } else if (decoded.kind === "LeaseResponse") {
+    state.generation = BigInt(decoded.message.generation || 0);
+    log(`LeaseResponse: granted=${decoded.message.granted} generation=${decoded.message.generation}`);
+    if (!decoded.message.granted) {
+      els.overlay.textContent = `lease denied (reason ${decoded.message.reason})`;
+    }
+  }
+}
+
+function appendBytes(existing, incoming) {
+  const out = new Uint8Array(existing.length + incoming.length);
+  out.set(existing, 0);
+  out.set(incoming, existing.length);
+  return out;
+}
+
+/** Accepts every host-initiated uni stream and dispatches on its leading kind-tag byte. */
+async function acceptIncomingUniStreams(transport) {
+  const uniStreams = transport.incomingUnidirectionalStreams;
+  const streamReader = uniStreams.getReader();
+  for (;;) {
+    const { value: stream, done } = await streamReader.read();
+    if (done) return;
+    readOneUniStream(stream).catch((error) => log(`uni stream read failed: ${error}`));
+  }
+}
+
+/** Drains one uni stream to completion, buffering bytes, reading the kind tag, then dispatching. */
+async function readOneUniStream(stream) {
+  const reader = stream.getReader();
+  let buf = new Uint8Array(0);
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (value) buf = appendBytes(buf, value);
+    if (done) break;
+  }
+  if (buf.length === 0) return;
+  const kind = buf[0];
+  const body = buf.subarray(1);
+  if (kind === STREAM_KIND_AUTHORITY) {
+    dispatchAuthorityStream(body);
+  } else if (kind === STREAM_KIND_VIDEO) {
+    await renderVideoFrame(body);
+  } else {
+    log(`unrecognized uni stream kind tag 0x${kind.toString(16)}`);
+  }
+}
+
+/** The dedicated authority-events stream is opened once at connection start and may carry several length-delimited envelopes over the stream's lifetime; decode every complete one buffered. */
+function dispatchAuthorityStream(body) {
+  let pending = body;
+  for (;;) {
+    const decoded = decodeLengthDelimitedEnvelope(pending);
+    if (!decoded) return;
+    pending = pending.subarray(decoded.consumed);
+    if (decoded.kind === "AuthorityEvent") {
+      els.overlay.textContent = `authority: ${decoded.message.arm}`;
+      log(`authority event: ${decoded.message.arm}`);
+    }
+  }
+}
+
+// Video body is `[fourcc: 4 bytes][u32 LE len][payload]` after the kind tag
+// (ADR-0016; host stream_tag.rs `frame_video_payload`). An unknown FourCC is
+// skipped with a log line, never a hard failure, so a host streaming a codec
+// this viewer lacks degrades gracefully. Only "MJPG" is decoded here.
+const FOURCC_MJPEG = "MJPG";
+async function renderVideoFrame(body) {
+  if (body.length < 8) return;
+  const fourcc = String.fromCharCode(body[0], body[1], body[2], body[3]);
+  const view = new DataView(body.buffer, body.byteOffset + 4, 4);
+  const len = view.getUint32(0, true);
+  const payload = body.subarray(8, 8 + len);
+  if (payload.length !== len) {
+    log(`video frame length mismatch: declared ${len}, got ${payload.length}`);
+    return;
+  }
+  if (fourcc !== FOURCC_MJPEG) {
+    log(`unknown video codec FourCC "${fourcc}"; skipping frame`);
+    return;
+  }
+  const bitmap = await createImageBitmap(new Blob([payload], { type: "image/jpeg" }));
+  if (els.canvas.width !== bitmap.width || els.canvas.height !== bitmap.height) {
+    els.canvas.width = bitmap.width;
+    els.canvas.height = bitmap.height;
+  }
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close();
+}
+
+/** Reads telemetry-fast datagrams (bare Envelope, TelemetrySample arm) forever, updating the pose overlay. */
+async function readTelemetryDatagrams(transport) {
+  const reader = transport.datagrams.readable.getReader();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    const decoded = decodeBareEnvelope(value);
+    if (decoded.kind === "TelemetrySample") {
+      const t = decoded.message;
+      els.telemetry.textContent =
+        `pose x=${t.xM.toFixed(2)}m y=${t.yM.toFixed(2)}m heading=${t.headingRad.toFixed(2)}rad` +
+        ` | v=${t.linearXMps.toFixed(2)}m/s w=${t.angularRadS.toFixed(2)}rad/s`;
+    } else if (decoded.kind === "Pong") {
+      // RTT probing is out of scope for this demo viewer; ignored.
+    } else if (decoded.kind === "FrameRejected") {
+      log(`control frame rejected (reason ${decoded.message.reason})`);
+    }
+  }
+}
+
+// ---- keyboard -> control frame datagrams -----------------------------------
+
+const DRIVE_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "w", "a", "s", "d", "W", "A", "S", "D"]);
+
+window.addEventListener("keydown", (event) => {
+  if (DRIVE_KEYS.has(event.key)) {
+    state.keys.add(normalizeKey(event.key));
+    event.preventDefault();
+  }
+});
+window.addEventListener("keyup", (event) => {
+  if (DRIVE_KEYS.has(event.key)) {
+    state.keys.delete(normalizeKey(event.key));
+    event.preventDefault();
+  }
+});
+
+function normalizeKey(key) {
+  const map = { w: "ArrowUp", s: "ArrowDown", a: "ArrowLeft", d: "ArrowRight" };
+  return map[key.toLowerCase()] || key;
+}
+
+/** Maps current key state to [throttle, yaw] axis values in [-1.0, 1.0]. */
+function axesFromKeys() {
+  let throttle = 0;
+  let yaw = 0;
+  if (state.keys.has("ArrowUp")) throttle += 1;
+  if (state.keys.has("ArrowDown")) throttle -= 1;
+  if (state.keys.has("ArrowLeft")) yaw -= 1;
+  if (state.keys.has("ArrowRight")) yaw += 1;
+  return [throttle, yaw];
+}
+
+/** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
+function startControlLoop(transport) {
+  const writer = transport.datagrams.writable.getWriter();
+  const intervalMs = 1000 / CONTROL_HZ;
+  setInterval(() => {
+    if (!state.connected) return;
+    const [throttle, yaw] = axesFromKeys();
+    state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
+    const envelope = encodeControlFrameEnvelope({
+      sessionId: state.sessionId,
+      vehicleId: VEHICLE_ID,
+      scope: MOTION_SCOPE,
+      generation: state.generation,
+      sequence: state.sequence,
+      sampledAtNanos: nowNanos(),
+      profileRevision: 1,
+      axes: [
+        [AXIS_THROTTLE, throttle],
+        [AXIS_YAW, yaw],
+      ],
+    });
+    writer.write(envelope).catch((error) => log(`control datagram send failed: ${error}`));
+  }, intervalMs);
+}
+
+applyUrlParams();
+els.connectBtn.addEventListener("click", () => {
+  connect().catch((error) => log(`connect failed: ${error}`));
+});

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -1,0 +1,469 @@
+// Minimal hand-rolled protobuf wire codec for the `pilotage.v1` schemas this
+// demo viewer speaks (ADR-0014: protobuf is the wire-schema source of truth;
+// this file is a by-hand JS mirror of a subset of it, since the browser has
+// no generated bindings). Field numbers below are read directly from
+// schemas/pilotage/v1/*.proto — see the comment above each builder/parser for
+// the exact (message, field) pairs relied on.
+//
+// Wire layout this file implements (matches hosts/session-host exactly):
+//   - Datagrams carry exactly one bare `Envelope` proto message, no length
+//     prefix (ADR-0014, ADR-0005).
+//   - The bootstrap bidi stream and every host-initiated uni stream carry
+//     length-delimited `Envelope` messages: a protobuf varint byte-length
+//     prefix followed by that many bytes of `Envelope` (ADR-0014). Every
+//     host-initiated uni stream additionally leads with one raw kind-tag
+//     byte before the first length-delimited envelope
+//     (hosts/session-host/src/runtime/stream_tag.rs): 0x01 = authority-events
+//     stream, 0x02 = one video frame (`[fourcc: 4 bytes][u32 LE len][jpeg]`
+//     after the tag, ADR-0016, not an Envelope at all).
+
+export const STREAM_KIND_AUTHORITY = 0x01;
+export const STREAM_KIND_VIDEO = 0x02;
+
+// The `pilotage.v1` schema version this build produces and accepts
+// (pilotage_protocol::convert::SCHEMA_VERSION mirrors this constant).
+export const SCHEMA_VERSION = 1;
+
+// ---- varint + protobuf tag primitives -------------------------------------
+
+/** Appends an unsigned LEB128 varint to `bytes` (protobuf's varint encoding). */
+function writeVarint(bytes, value) {
+  let v = BigInt(value);
+  for (;;) {
+    let byte = Number(v & 0x7fn);
+    v >>= 7n;
+    if (v !== 0n) {
+      bytes.push(byte | 0x80);
+    } else {
+      bytes.push(byte);
+      return;
+    }
+  }
+}
+
+/** Reads an unsigned LEB128 varint starting at `view[offset]`; returns [value, nextOffset]. */
+function readVarint(view, offset) {
+  let result = 0n;
+  let shift = 0n;
+  let pos = offset;
+  for (;;) {
+    const byte = view[pos];
+    pos += 1;
+    result |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      return [Number(result), pos];
+    }
+    shift += 7n;
+  }
+}
+
+/** Writes a protobuf field tag: (fieldNumber << 3) | wireType. */
+function writeTag(bytes, fieldNumber, wireType) {
+  writeVarint(bytes, (fieldNumber << 3) | wireType);
+}
+
+const WIRE_VARINT = 0;
+const WIRE_64BIT = 1;
+const WIRE_LEN = 2;
+const WIRE_32BIT = 5;
+
+/** Writes a varint-typed field, skipping it entirely when `value` is falsy/zero (proto3 default-omission). */
+function fieldVarint(bytes, fieldNumber, value) {
+  if (!value) return;
+  writeTag(bytes, fieldNumber, WIRE_VARINT);
+  writeVarint(bytes, value);
+}
+
+/** Writes a length-delimited (bytes/string/submessage) field, skipping it when
+ *  the payload is empty (proto3 default-omission for optional fields). */
+function fieldBytes(bytes, fieldNumber, payload) {
+  if (!payload || payload.length === 0) return;
+  writeTag(bytes, fieldNumber, WIRE_LEN);
+  writeVarint(bytes, payload.length);
+  for (const b of payload) bytes.push(b);
+}
+
+/** Writes a required message-typed field, emitting it even when the submessage
+ *  is empty (i.e. all its scalars are the proto3 default). The host's
+ *  wire->domain conversion requires these submessages present, so — like the
+ *  Rust encoder — an all-zero id (e.g. session 0) must still appear on the
+ *  wire as an empty submessage, not be omitted. */
+function fieldMessage(bytes, fieldNumber, payload) {
+  writeTag(bytes, fieldNumber, WIRE_LEN);
+  writeVarint(bytes, payload.length);
+  for (const b of payload) bytes.push(b);
+}
+
+/** Writes a UTF-8 string field. */
+function fieldString(bytes, fieldNumber, str) {
+  if (!str) return;
+  fieldBytes(bytes, fieldNumber, Array.from(new TextEncoder().encode(str)));
+}
+
+/** Writes a fixed 32-bit float field (proto3 `float`). */
+function fieldFloat(bytes, fieldNumber, value) {
+  if (!value) return;
+  writeTag(bytes, fieldNumber, WIRE_32BIT);
+  const buf = new ArrayBuffer(4);
+  new DataView(buf).setFloat32(0, value, true);
+  for (const b of new Uint8Array(buf)) bytes.push(b);
+}
+
+/** Concatenates an array of byte arrays into a plain array of numbers. */
+function concatBytes(parts) {
+  const out = [];
+  for (const part of parts) for (const b of part) out.push(b);
+  return out;
+}
+
+// ---- common.proto message builders ----------------------------------------
+// message VehicleId { uint64 value = 1; }
+// message ScopeId { string value = 1; }
+// message SessionId { uint64 value = 1; }
+// message Generation { uint64 value = 1; }
+
+function encodeVehicleId(value) {
+  const bytes = [];
+  fieldVarint(bytes, 1, value);
+  return bytes;
+}
+
+function encodeScopeId(value) {
+  const bytes = [];
+  fieldString(bytes, 1, value);
+  return bytes;
+}
+
+// ---- session.proto: ClientHello (field numbers 1,2,3) ----------------------
+// message ClientHello {
+//   uint32 protocol_version = 1;
+//   string client_name = 2;
+//   bytes join_token = 3;
+// }
+function encodeClientHello({ protocolVersion, clientName, joinToken }) {
+  const bytes = [];
+  fieldVarint(bytes, 1, protocolVersion);
+  fieldString(bytes, 2, clientName);
+  fieldBytes(bytes, 3, joinToken || []);
+  return bytes;
+}
+
+// ---- session.proto: LeaseRequest (field numbers 1,2) -----------------------
+// message LeaseRequest { VehicleId vehicle = 1; ScopeId scope = 2; }
+function encodeLeaseRequest({ vehicleId, scope }) {
+  const bytes = [];
+  fieldBytes(bytes, 1, encodeVehicleId(vehicleId));
+  fieldBytes(bytes, 2, encodeScopeId(scope));
+  return bytes;
+}
+
+// ---- envelope.proto: Envelope oneof arm numbers ----------------------------
+// (envelope.proto): schema_version = 1; oneof payload: control_frame=2,
+// authority_event=3, telemetry_sample=4, host_capabilities=5, client_hello=6,
+// server_welcome=7, lease_request=8, lease_response=9, ping=10, pong=11,
+// frame_rejected=12.
+const ENVELOPE_FIELD = {
+  schemaVersion: 1,
+  controlFrame: 2,
+  authorityEvent: 3,
+  telemetrySample: 4,
+  hostCapabilities: 5,
+  clientHello: 6,
+  serverWelcome: 7,
+  leaseRequest: 8,
+  leaseResponse: 9,
+  ping: 10,
+  pong: 11,
+  frameRejected: 12,
+};
+
+/** Wraps an already-encoded payload submessage bytes in an `Envelope`. */
+function encodeEnvelope(payloadFieldNumber, payloadBytes) {
+  const bytes = [];
+  fieldVarint(bytes, ENVELOPE_FIELD.schemaVersion, SCHEMA_VERSION);
+  fieldBytes(bytes, payloadFieldNumber, payloadBytes);
+  return bytes;
+}
+
+/** Encodes a `ClientHello` as a bare `Envelope` (payload field 6). */
+export function encodeClientHelloEnvelope(hello) {
+  return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.clientHello, encodeClientHello(hello)));
+}
+
+/** Encodes a `LeaseRequest` as a bare `Envelope` (payload field 8). */
+export function encodeLeaseRequestEnvelope(request) {
+  return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.leaseRequest, encodeLeaseRequest(request)));
+}
+
+// ---- control.proto: ControlFrame (field numbers per schema) ----------------
+// message AxisSample { uint32 axis_id = 1; float value = 2; }
+// message ControlPayload { repeated AxisSample axes = 1; repeated ButtonEdgeSample edges = 2; }
+// message ControlFrame {
+//   SessionId session = 1; VehicleId vehicle = 2; ScopeId scope = 3;
+//   Generation generation = 4; SequenceNum sequence = 5;
+//   MonoTimestamp sampled_at = 6; uint32 profile_revision = 7;
+//   ControlPayload payload = 8;
+// }
+function encodeAxisSample(axisId, value) {
+  const bytes = [];
+  fieldVarint(bytes, 1, axisId);
+  fieldFloat(bytes, 2, value);
+  return bytes;
+}
+
+function encodeControlPayload(axes) {
+  const bytes = [];
+  for (const [axisId, value] of axes) {
+    fieldBytes(bytes, 1, encodeAxisSample(axisId, value));
+  }
+  return bytes;
+}
+
+/**
+ * Encodes one `ControlFrame` wrapped in an `Envelope`, ready to send as a
+ * single control-fast datagram (bare envelope, no length prefix, ADR-0005).
+ *
+ * `axes` is an array of `[axisId, value]` pairs, value in [-1.0, 1.0].
+ */
+export function encodeControlFrameEnvelope({
+  sessionId,
+  vehicleId,
+  scope,
+  generation,
+  sequence,
+  sampledAtNanos,
+  profileRevision,
+  axes,
+}) {
+  // These seven are required message-typed fields the host's wire->domain
+  // conversion demands present, so emit each even when its inner scalar is 0
+  // (e.g. session id 0) — matching the Rust encoder, which never omits them.
+  const frame = [];
+  fieldMessage(frame, 1, encodeSessionId(sessionId));
+  fieldMessage(frame, 2, encodeVehicleId(vehicleId));
+  fieldMessage(frame, 3, encodeScopeId(scope));
+  fieldMessage(frame, 4, encodeGeneration(generation));
+  fieldMessage(frame, 5, encodeSequenceNum(sequence));
+  fieldMessage(frame, 6, encodeMonoTimestamp(sampledAtNanos));
+  fieldVarint(frame, 7, profileRevision);
+  fieldMessage(frame, 8, encodeControlPayload(axes));
+  return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.controlFrame, frame));
+}
+
+function encodeSessionId(value) {
+  const bytes = [];
+  fieldVarint(bytes, 1, value);
+  return bytes;
+}
+
+function encodeGeneration(value) {
+  const bytes = [];
+  fieldVarint(bytes, 1, value);
+  return bytes;
+}
+
+function encodeSequenceNum(value) {
+  const bytes = [];
+  fieldVarint(bytes, 1, value);
+  return bytes;
+}
+
+// message MonoTimestamp { uint64 nanos = 1; }
+function encodeMonoTimestamp(nanos) {
+  const bytes = [];
+  fieldVarint(bytes, 1, nanos);
+  return bytes;
+}
+
+// ---- generic decode: enough to read ServerWelcome / LeaseResponse fields --
+// This is a tiny generic protobuf reader (any field, any wire type), used to
+// pull out just the handful of scalar fields this viewer displays, without a
+// full descriptor-driven decoder.
+
+/** Parses a top-level protobuf message into a Map<fieldNumber, list-of-values>.
+ * Each value is either a number (varint), a Uint8Array (length-delimited), or
+ * a number (32/64-bit fixed, returned as a BigInt-safe Number when possible).
+ */
+function parseFields(bytes) {
+  const fields = new Map();
+  let offset = 0;
+  while (offset < bytes.length) {
+    const [tag, afterTag] = readVarint(bytes, offset);
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 0x7;
+    offset = afterTag;
+    let value;
+    if (wireType === WIRE_VARINT) {
+      const [v, next] = readVarint(bytes, offset);
+      value = v;
+      offset = next;
+    } else if (wireType === WIRE_LEN) {
+      const [len, next] = readVarint(bytes, offset);
+      value = bytes.subarray(next, next + len);
+      offset = next + len;
+    } else if (wireType === WIRE_64BIT) {
+      value = bytes.subarray(offset, offset + 8);
+      offset += 8;
+    } else if (wireType === WIRE_32BIT) {
+      value = bytes.subarray(offset, offset + 4);
+      offset += 4;
+    } else {
+      throw new Error(`unsupported wire type ${wireType} decoding envelope`);
+    }
+    if (!fields.has(fieldNumber)) fields.set(fieldNumber, []);
+    fields.get(fieldNumber).push(value);
+  }
+  return fields;
+}
+
+function firstBytes(fields, fieldNumber) {
+  const values = fields.get(fieldNumber);
+  return values && values.length > 0 ? values[0] : undefined;
+}
+
+function firstVarint(fields, fieldNumber) {
+  const values = fields.get(fieldNumber);
+  return values && values.length > 0 ? values[0] : 0;
+}
+
+function decodeUint64Message(bytes) {
+  if (!bytes) return 0;
+  const fields = parseFields(bytes);
+  return firstVarint(fields, 1);
+}
+
+function decodeStringMessage(bytes) {
+  if (!bytes) return "";
+  const fields = parseFields(bytes);
+  const raw = firstBytes(fields, 1);
+  return raw ? new TextDecoder().decode(raw) : "";
+}
+
+function decodeFloat32(view) {
+  if (!view || view.length < 4) return 0;
+  return new DataView(view.buffer, view.byteOffset, 4).getFloat32(0, true);
+}
+
+/**
+ * Decodes exactly one length-delimited `Envelope` frame from the front of
+ * `bytes` (varint byte-length prefix + that many bytes), returning
+ * `{ kind, message, consumed }` where `kind` is one of `"ServerWelcome"`,
+ * `"LeaseResponse"`, `"AuthorityEvent"`, `"TelemetrySample"`, `"Pong"`,
+ * `"FrameRejected"`, or `"unknown"`, and `consumed` is the total byte count
+ * (prefix + payload) so the caller can advance its buffer.
+ *
+ * Returns `null` if the prefix or payload has not fully arrived yet.
+ */
+export function decodeLengthDelimitedEnvelope(bytes) {
+  if (bytes.length === 0) return null;
+  let len, afterLen;
+  try {
+    [len, afterLen] = readVarint(bytes, 0);
+  } catch {
+    return null;
+  }
+  if (afterLen + len > bytes.length) return null;
+  const body = bytes.subarray(afterLen, afterLen + len);
+  const consumed = afterLen + len;
+  return { ...decodeEnvelopeBody(body), consumed };
+}
+
+/** Decodes a bare (non-length-delimited) `Envelope`, e.g. a telemetry datagram. */
+export function decodeBareEnvelope(bytes) {
+  return decodeEnvelopeBody(bytes);
+}
+
+function decodeEnvelopeBody(body) {
+  const fields = parseFields(body);
+  if (fields.has(ENVELOPE_FIELD.serverWelcome)) {
+    return { kind: "ServerWelcome", message: decodeServerWelcome(firstBytes(fields, ENVELOPE_FIELD.serverWelcome)) };
+  }
+  if (fields.has(ENVELOPE_FIELD.leaseResponse)) {
+    return { kind: "LeaseResponse", message: decodeLeaseResponse(firstBytes(fields, ENVELOPE_FIELD.leaseResponse)) };
+  }
+  if (fields.has(ENVELOPE_FIELD.authorityEvent)) {
+    return { kind: "AuthorityEvent", message: decodeAuthorityEvent(firstBytes(fields, ENVELOPE_FIELD.authorityEvent)) };
+  }
+  if (fields.has(ENVELOPE_FIELD.telemetrySample)) {
+    return { kind: "TelemetrySample", message: decodeTelemetrySample(firstBytes(fields, ENVELOPE_FIELD.telemetrySample)) };
+  }
+  if (fields.has(ENVELOPE_FIELD.pong)) {
+    return { kind: "Pong", message: {} };
+  }
+  if (fields.has(ENVELOPE_FIELD.frameRejected)) {
+    return { kind: "FrameRejected", message: decodeFrameRejected(firstBytes(fields, ENVELOPE_FIELD.frameRejected)) };
+  }
+  return { kind: "unknown", message: {} };
+}
+
+// session.proto ServerWelcome: session=1, principal=2, host_capabilities=3, scope_holders=4
+function decodeServerWelcome(bytes) {
+  if (!bytes) return {};
+  const fields = parseFields(bytes);
+  return {
+    sessionId: decodeUint64Message(firstBytes(fields, 1)),
+    principalId: decodeUint64Message(firstBytes(fields, 2)),
+  };
+}
+
+// session.proto LeaseResponse: vehicle=1, scope=2, granted=3, generation=4, reason=5
+function decodeLeaseResponse(bytes) {
+  if (!bytes) return {};
+  const fields = parseFields(bytes);
+  return {
+    granted: !!firstVarint(fields, 3),
+    generation: decodeUint64Message(firstBytes(fields, 4)),
+    reason: firstVarint(fields, 5),
+  };
+}
+
+// telemetry.proto TelemetrySample: vehicle=1, tick=2, observed_at=3, pose=4, velocity=5
+// Pose2d: x_m=1, y_m=2, heading_rad=3 (all float, wire type 5)
+function decodeTelemetrySample(bytes) {
+  if (!bytes) return {};
+  const fields = parseFields(bytes);
+  const poseBytes = firstBytes(fields, 4);
+  const velBytes = firstBytes(fields, 5);
+  const pose = poseBytes ? parseFields(poseBytes) : new Map();
+  const vel = velBytes ? parseFields(velBytes) : new Map();
+  return {
+    xM: decodeFloat32(firstBytes(pose, 1)),
+    yM: decodeFloat32(firstBytes(pose, 2)),
+    headingRad: decodeFloat32(firstBytes(pose, 3)),
+    linearXMps: decodeFloat32(firstBytes(vel, 1)),
+    angularRadS: decodeFloat32(firstBytes(vel, 3)),
+  };
+}
+
+// authority.proto AuthorityEvent: a oneof; we only care which arm fired and a
+// human-readable label, not full field decode, for the demo overlay.
+const AUTHORITY_ARM_NAMES = {
+  1: "ScopeLeaseGranted",
+  2: "ScopeTransferOffered",
+  3: "ScopeTransferAccepted",
+  4: "ScopeTransferCommitted",
+  5: "ScopeLeaseRevoked",
+  6: "EmergencyOverrideApplied",
+  7: "ScopeRegistered",
+  8: "ScopeTransferExpired",
+  9: "LinkStateChanged",
+  10: "WarningRaised",
+};
+
+function decodeAuthorityEvent(bytes) {
+  if (!bytes) return { arm: "unknown" };
+  const fields = parseFields(bytes);
+  for (const fieldNumber of fields.keys()) {
+    if (AUTHORITY_ARM_NAMES[fieldNumber]) {
+      return { arm: AUTHORITY_ARM_NAMES[fieldNumber] };
+    }
+  }
+  return { arm: "unknown" };
+}
+
+// session.proto FrameRejected: vehicle=1, scope=2, sequence=3, reason=4, current_generation=5
+function decodeFrameRejected(bytes) {
+  if (!bytes) return {};
+  const fields = parseFields(bytes);
+  return { reason: firstVarint(fields, 4) };
+}

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -1,0 +1,108 @@
+// Conformance checks for the hand-rolled protobuf encoder (wire.js).
+//
+// Run: node clients/web/wire.test.mjs
+//
+// The host's wire->domain ControlFrame conversion requires every message-typed
+// field present (session, vehicle, scope, generation, sequence, sampled_at,
+// payload). proto3 omits scalar defaults, so a naive encoder drops a
+// message-typed field whose inner id is 0 (e.g. session 0), and the host then
+// rejects the datagram as unrecognized. These checks pin the invariant that the
+// required fields are emitted even when their ids are zero.
+
+import { encodeControlFrameEnvelope, SCHEMA_VERSION } from "./wire.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// Minimal protobuf field walker: returns a Map of field number -> the raw bytes
+// (length-delimited fields) or numeric value (varint), enough to assert field
+// presence and descend into one submessage.
+function walk(bytes) {
+  const out = new Map();
+  let i = 0;
+  while (i < bytes.length) {
+    let tag = 0;
+    let shift = 0;
+    for (;;) {
+      const b = bytes[i++];
+      tag |= (b & 0x7f) << shift;
+      if ((b & 0x80) === 0) break;
+      shift += 7;
+    }
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 0x7;
+    if (wireType === 0) {
+      let v = 0n;
+      let s = 0n;
+      for (;;) {
+        const b = bytes[i++];
+        v |= BigInt(b & 0x7f) << s;
+        if ((b & 0x80) === 0) break;
+        s += 7n;
+      }
+      out.set(fieldNumber, v);
+    } else if (wireType === 5) {
+      out.set(fieldNumber, bytes.subarray(i, i + 4));
+      i += 4;
+    } else if (wireType === 2) {
+      let len = 0;
+      let s = 0;
+      for (;;) {
+        const b = bytes[i++];
+        len |= (b & 0x7f) << s;
+        if ((b & 0x80) === 0) break;
+        s += 7;
+      }
+      out.set(fieldNumber, bytes.subarray(i, i + len));
+      i += len;
+    } else {
+      throw new Error(`unexpected wire type ${wireType}`);
+    }
+  }
+  return out;
+}
+
+// The dangerous case: session id, vehicle id, generation, sequence all 0.
+const envelope = encodeControlFrameEnvelope({
+  sessionId: 0,
+  vehicleId: 0n,
+  scope: "vehicle.motion",
+  generation: 0n,
+  sequence: 0,
+  sampledAtNanos: 0n,
+  profileRevision: 1,
+  axes: [
+    [2, 0.0],
+    [3, 0.0],
+  ],
+});
+
+const top = walk(envelope);
+check("envelope carries the supported schema version", top.get(1) === BigInt(SCHEMA_VERSION));
+check("envelope carries the control_frame arm (field 2)", top.has(2));
+
+const frame = walk(top.get(2));
+for (const [num, name] of [
+  [1, "session"],
+  [2, "vehicle"],
+  [3, "scope"],
+  [4, "generation"],
+  [5, "sequence"],
+  [6, "sampled_at"],
+  [8, "payload"],
+]) {
+  check(`control frame emits required field ${num} (${name}) even when zero`, frame.has(num));
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall wire conformance checks passed");

--- a/docs/adr/0016-codec-pluggable-media-plane.md
+++ b/docs/adr/0016-codec-pluggable-media-plane.md
@@ -1,0 +1,92 @@
+# ADR-0016: The media plane is codec-pluggable; the control core never sees the codec
+
+- Status: Accepted
+- Date: 2026-07-05
+
+## Context
+
+The first Gazebo demo streams video as MJPEG: per-frame JPEG, encoded in software.
+That is right for a proof of concept — trivial to encode, decode-anywhere (native
+`image`, browser `createImageBitmap`), no inter-frame state. It does not survive
+contact with real resolutions. Software encode runs out somewhere around 1080p60;
+4K low-latency is hardware-only, and hardware encoders are platform-specific
+(VideoToolbox on macOS, NVENC/VAAPI on Linux).
+
+Platform-specific means the codec is platform code by ADR-0002's rule, so it cannot
+live in the portable sans-IO core, and by ADR-0003 it belongs to the media plane,
+which is already a separate responsibility from the real-time data plane
+(control / telemetry / authority). The risk is not the codec choice — it is letting
+a video or codec type leak into the control or authority messages, which would couple
+the portable control model to a platform concern and make the eventual hardware swap
+a protocol change across independently deployed hosts and clients (exactly what
+ADR-0014 exists to avoid).
+
+## Decision
+
+- Video is a **codec-pluggable** concern of the media plane. The control, telemetry,
+  and authority messages MUST remain codec-agnostic: no video or codec type appears
+  in any non-media message.
+- Each video frame on the wire carries a **FourCC codec tag** (32 bits, four ASCII
+  bytes as written) in its header, distinct from the payload length and bytes:
+
+  ```text
+  video uni-stream: [0x02 stream-kind][fourcc: 4 bytes][u32 LE payload_len][payload]
+  fourcc: "MJPG" MJPEG (only one implemented) · "avc1" H.264 · "hvc1" H.265 · "av01" AV1 · "vp09" VP9
+  ```
+
+  The client dispatches on the FourCC. Adding a codec is then a non-event: a new
+  tag value, a new decoder branch, no change to the envelope, the control path, or
+  the authority path.
+
+  **Why FourCC and not a private byte.** There is no widely-accepted 1-byte codec
+  enumeration; a private byte would interoperate with nothing and force us to run our
+  own registry. FourCC is the de-facto convention for naming a codec in a fixed-width
+  field, and the video-codec tags (`avc1`, `hvc1`, `av01`, `vp09`) are the ISO-BMFF
+  sample-entry codes governed by MP4RA, so the value space is already arbitrated. It
+  self-documents in packet captures and muxes directly into MP4/MKV. The three extra
+  bytes per frame are negligible.
+
+### Codec identity has two levels; RFC 6381 owns the second, not the first
+
+- **Per-frame — FourCC (routing).** "Which decoder does this frame belong to." Fixed
+  width, and it has a real value for the demo codec (`"MJPG"`). This is all a per-frame
+  field should carry.
+- **Per-stream — RFC 6381 codec string (configuration).** "How is that decoder
+  configured" — profile, level, tier. It is variable-length and stream-constant, so
+  it belongs in a **media-config message** sent once (reliably) when a video source is
+  announced, referenced by frames via a source id. It is consumed verbatim by the
+  browser's WebCodecs `VideoDecoder.configure({codec})`.
+
+  RFC 6381 is **not** adopted for the PoC, deliberately: MJPEG has no established RFC
+  6381 codec string (inventing one would be the same namespace-squatting a private
+  byte would be), the PoC browser path decodes MJPEG via `createImageBitmap` rather
+  than WebCodecs, and profile/level do not exist for MJPEG. RFC 6381 and the per-stream
+  media-config message land together with the first parameterized codec
+  (software H.264 + WebCodecs), where they first do real work. Until then the FourCC
+  routing tag is sufficient on its own.
+- Encoding is confined to **one isolated module** in the session host, so replacing
+  the encoder is a local change.
+- Hardware and additional software encoders are **media-plane platform ports** when
+  they land (ADR-0002), never core code.
+
+### The ladder (informative, not a commitment to build ahead)
+
+1. MJPEG, software — the demo (this increment).
+2. Software H.264 + browser WebCodecs decode — next, for bitrate and quality.
+3. Hardware H.264 (VideoToolbox / NVENC / VAAPI) as platform ports — for 1080p60/4K.
+
+Each rung is a drop-in behind the FourCC tag: the wire envelope and the control/
+authority core are unchanged across all three.
+
+## Consequences
+
+- The FourCC tag is the one thing that would be expensive to retrofit (it spans
+  independently deployed hosts and clients), so it ships **now**, with only MJPEG
+  (`"MJPG"`) implemented.
+- A `VideoEncoder` trait is deliberately **not** introduced yet: one implementation
+  does not justify the abstraction. The codec id plus an isolated encode module is
+  the right amount of seam; the trait earns its place when the second encoder
+  actually lands.
+- Decoders MUST treat an unknown FourCC as a skipped frame with a counted, logged
+  warning — never a hard failure — so a newer host streaming a codec an older client
+  lacks degrades gracefully.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ One file per decision, numbered in acceptance order. See
 | [0013](0013-interactive-and-accelerated-sessions.md) | Single-vehicle operation and horizontally scalable accelerated training | Accepted |
 | [0014](0014-protobuf-wire-schema.md) | Protobuf as the wire-schema source of truth | Accepted |
 | [0015](0015-workspace-quality-gates.md) | Workspace-enforced quality gates | Accepted |
+| [0016](0016-codec-pluggable-media-plane.md) | Codec-pluggable media plane; the control core never sees the codec | Accepted |
 
 ## Provenance
 

--- a/hosts/session-host/Cargo.toml
+++ b/hosts/session-host/Cargo.toml
@@ -17,6 +17,7 @@ pilotage-protocol = { workspace = true }
 pilotage-authority = { workspace = true }
 pilotage-adapter-api = { workspace = true }
 pilotage-adapter-reference = { workspace = true }
+pilotage-adapter-gazebo = { workspace = true }
 pilotage-timing = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "time", "sync", "net"] }
@@ -24,6 +25,7 @@ wtransport = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 prost.workspace = true
+jpeg-encoder = "0.7.0"
 
 [dev-dependencies]
 pilotage-adapter-reference.workspace = true

--- a/hosts/session-host/src/cli.rs
+++ b/hosts/session-host/src/cli.rs
@@ -1,11 +1,24 @@
-//! Minimal argument parsing for the session-host binary: `--port <PORT>`,
-//! defaulting to `0` (ephemeral, loopback-only bind).
+//! Minimal argument parsing for the session-host binary: `--port <PORT>` and
+//! `--adapter reference|gazebo`, defaulting to port `0` (ephemeral,
+//! loopback-only bind) and the reference adapter.
+
+/// Which vehicle adapter the host embeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdapterKind {
+    /// The deterministic headless reference adapter (default; 1a behavior).
+    #[default]
+    Reference,
+    /// The real Gazebo diff-drive adapter driven through the sidecar bridge.
+    Gazebo,
+}
 
 /// Parsed command-line configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CliArgs {
     /// Port to bind on `127.0.0.1`. `0` asks the OS for an ephemeral port.
     pub port: u16,
+    /// Which vehicle adapter to embed.
+    pub adapter: AdapterKind,
 }
 
 /// An error parsing command-line arguments.
@@ -23,6 +36,12 @@ pub enum CliError {
     /// `--port` was given with no following value.
     #[error("--port requires a value")]
     MissingPortValue,
+    /// `--adapter` was given with no following value.
+    #[error("--adapter requires a value")]
+    MissingAdapterValue,
+    /// `--adapter` was given a value other than `reference` or `gazebo`.
+    #[error("invalid --adapter value {0:?} (expected reference or gazebo)")]
+    InvalidAdapter(String),
     /// An argument was not recognized.
     #[error("unrecognized argument: {0}")]
     Unrecognized(String),
@@ -35,6 +54,7 @@ pub enum CliError {
 /// Returns [`CliError`] for a malformed or unrecognized `--port` argument.
 pub fn parse_args(args: &[String]) -> Result<CliArgs, CliError> {
     let mut port: u16 = 0;
+    let mut adapter = AdapterKind::default();
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
@@ -45,21 +65,30 @@ pub fn parse_args(args: &[String]) -> Result<CliArgs, CliError> {
                     source,
                 })?;
             }
+            "--adapter" => {
+                let value = iter.next().ok_or(CliError::MissingAdapterValue)?;
+                adapter = match value.as_str() {
+                    "reference" => AdapterKind::Reference,
+                    "gazebo" => AdapterKind::Gazebo,
+                    other => return Err(CliError::InvalidAdapter(other.to_owned())),
+                };
+            }
             other => return Err(CliError::Unrecognized(other.to_owned())),
         }
     }
-    Ok(CliArgs { port })
+    Ok(CliArgs { port, adapter })
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{CliError, parse_args};
+    use super::{AdapterKind, CliError, parse_args};
 
     #[test]
     fn no_args_defaults_to_ephemeral_port() {
         let parsed = parse_args(&[]).expect("empty args parse");
         assert_eq!(parsed.port, 0);
+        assert_eq!(parsed.adapter, AdapterKind::Reference);
     }
 
     #[test]
@@ -67,6 +96,35 @@ mod tests {
         let args = vec!["--port".to_owned(), "4433".to_owned()];
         let parsed = parse_args(&args).expect("valid port parses");
         assert_eq!(parsed.port, 4433);
+    }
+
+    #[test]
+    fn gazebo_adapter_parses() {
+        let args = vec!["--adapter".to_owned(), "gazebo".to_owned()];
+        let parsed = parse_args(&args).expect("gazebo adapter parses");
+        assert_eq!(parsed.adapter, AdapterKind::Gazebo);
+    }
+
+    #[test]
+    fn reference_adapter_parses() {
+        let args = vec!["--adapter".to_owned(), "reference".to_owned()];
+        let parsed = parse_args(&args).expect("reference adapter parses");
+        assert_eq!(parsed.adapter, AdapterKind::Reference);
+    }
+
+    #[test]
+    fn unknown_adapter_is_an_error() {
+        let args = vec!["--adapter".to_owned(), "unreal".to_owned()];
+        assert_eq!(
+            parse_args(&args),
+            Err(CliError::InvalidAdapter("unreal".to_owned()))
+        );
+    }
+
+    #[test]
+    fn missing_adapter_value_is_an_error() {
+        let args = vec!["--adapter".to_owned()];
+        assert_eq!(parse_args(&args), Err(CliError::MissingAdapterValue));
     }
 
     #[test]

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -21,4 +21,7 @@ pub enum HostError {
     /// Constructing the tokio runtime failed.
     #[error("failed to build the tokio runtime: {0}")]
     Runtime(#[source] std::io::Error),
+    /// Spawning or connecting the Gazebo sidecar bridge failed.
+    #[error("failed to start the Gazebo adapter: {0}")]
+    GazeboAdapter(#[source] pilotage_adapter_gazebo::GazeboAdapterError),
 }

--- a/hosts/session-host/src/main.rs
+++ b/hosts/session-host/src/main.rs
@@ -31,7 +31,7 @@ fn run(args: &[String]) -> Result<(), HostError> {
     let cli_args = cli::parse_args(args).map_err(HostError::Cli)?;
     let runtime = tokio::runtime::Runtime::new().map_err(HostError::Runtime)?;
     runtime.block_on(async move {
-        let host = runtime::start(cli_args.port)?;
+        let host = runtime::start(cli_args.port, cli_args.adapter).await?;
         if let Err(error) = tokio::signal::ctrl_c().await {
             tracing::error!(%error, "failed to listen for ctrl_c");
         }

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -6,8 +6,11 @@
 
 mod connection;
 mod engine_actor;
+mod gazebo_launch;
+mod media;
 mod registry;
 mod shutdown;
+mod stream_tag;
 mod wire_codec;
 
 use std::net::SocketAddr;
@@ -24,10 +27,12 @@ use tokio::task::JoinSet;
 use tracing::{info, warn};
 use wtransport::{Endpoint, Identity, ServerConfig};
 
+use crate::cli::AdapterKind;
 use crate::error::HostError;
 use crate::output::print_line;
 use crate::tls_identity::build_dev_identity;
 use engine_actor::{ENGINE_QUEUE_CAPACITY, EngineActor, ToEngine};
+use media::MediaHandle;
 
 /// The vehicle the embedded reference adapter drives in this increment.
 const HOST_VEHICLE: VehicleId = VehicleId::new(1);
@@ -69,24 +74,35 @@ impl RunningHost {
 
 /// Builds the embedded [`SessionEngine`] and [`ReferenceAdapter`] pair this
 /// increment's host serves.
-fn build_engine_and_adapter() -> (SessionEngine, ReferenceAdapter) {
+fn build_reference() -> (SessionEngine, ReferenceAdapter) {
     let adapter = ReferenceAdapter::from_seed(HOST_VEHICLE, ADAPTER_SEED);
+    let engine = build_engine(&adapter);
+    (engine, adapter)
+}
+
+/// Builds the session engine from an adapter's advertised capabilities and
+/// this host's staleness/config policy, shared by every adapter path.
+fn build_engine<A: VehicleAdapter>(adapter: &A) -> SessionEngine {
     let capabilities = adapter.capabilities();
     let staleness = StalenessPolicy::new(MAX_CONTROL_AGE);
     let config = SessionConfig::new(pilotage_protocol::SCHEMA_VERSION, env!("CARGO_PKG_VERSION"));
-    let engine = SessionEngine::new(capabilities, staleness, config);
-    (engine, adapter)
+    SessionEngine::new(capabilities, staleness, config)
 }
 
 /// Starts the session host bound to `127.0.0.1:port` (`0` for an OS-assigned
 /// ephemeral port), prints the `LISTENING` line, and returns a handle for
 /// shutdown.
 ///
+/// `adapter` selects the embedded vehicle adapter: [`AdapterKind::Reference`]
+/// (default, 1a behavior, no video) or [`AdapterKind::Gazebo`] (real Gazebo
+/// diff-drive through the sidecar bridge, with an MJPEG video downlink).
+///
 /// # Errors
 ///
-/// Returns [`HostError`] if the TLS identity cannot be built or the
-/// WebTransport endpoint cannot bind.
-pub fn start(port: u16) -> Result<RunningHost, HostError> {
+/// Returns [`HostError`] if the TLS identity cannot be built, the
+/// WebTransport endpoint cannot bind, or the Gazebo sidecar bridge cannot be
+/// spawned and connected.
+pub async fn start(port: u16, adapter: AdapterKind) -> Result<RunningHost, HostError> {
     let dev_identity = build_dev_identity()?;
     let identity: Identity = dev_identity.identity;
     let cert_hash_hex = dev_identity.cert_hash_hex.clone();
@@ -105,18 +121,10 @@ pub fn start(port: u16) -> Result<RunningHost, HostError> {
         cert_hash_hex
     ));
 
-    let (engine, adapter) = build_engine_and_adapter();
     let (engine_tx, engine_rx) = mpsc::channel::<ToEngine>(ENGINE_QUEUE_CAPACITY);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-    let join = tokio::spawn(run_until_shutdown(
-        endpoint,
-        engine,
-        adapter,
-        engine_tx,
-        engine_rx,
-        shutdown_rx,
-    ));
+    let join = spawn_host_runtime(adapter, endpoint, engine_tx, engine_rx, shutdown_rx).await?;
 
     Ok(RunningHost {
         local_addr,
@@ -126,17 +134,61 @@ pub fn start(port: u16) -> Result<RunningHost, HostError> {
     })
 }
 
-/// Runs the accept loop and engine actor until `shutdown_rx` fires, then
-/// tears down every spawned task (engine actor, accept loop, and every
-/// per-connection task) within the shutdown timeout.
-async fn run_until_shutdown(
+/// Builds the chosen adapter (and, for Gazebo, its media task) and spawns the
+/// per-adapter `run_until_shutdown` task.
+async fn spawn_host_runtime(
+    adapter: AdapterKind,
     endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
-    engine: SessionEngine,
-    adapter: ReferenceAdapter,
     engine_tx: mpsc::Sender<ToEngine>,
     engine_rx: mpsc::Receiver<ToEngine>,
     shutdown_rx: oneshot::Receiver<()>,
-) {
+) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    match adapter {
+        AdapterKind::Reference => {
+            let (engine, adapter) = build_reference();
+            Ok(tokio::spawn(run_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                None,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+            )))
+        }
+        AdapterKind::Gazebo => {
+            let (engine, adapter, frames) =
+                gazebo_launch::build_gazebo(HOST_VEHICLE, MAX_CONTROL_AGE).await?;
+            let (media, media_task) = media::spawn_media_task(frames);
+            Ok(tokio::spawn(run_gazebo_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                media,
+                media_task,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+            )))
+        }
+    }
+}
+
+/// Runs the accept loop and engine actor until `shutdown_rx` fires, then
+/// tears down every spawned task (engine actor, accept loop, and every
+/// per-connection task) within the shutdown timeout. `media` is `Some` only
+/// for the Gazebo path, wiring each connection into the video downlink.
+async fn run_until_shutdown<A>(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine: SessionEngine,
+    adapter: A,
+    media: Option<MediaHandle>,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+) where
+    A: VehicleAdapter + Send + 'static,
+{
     // A single monotonic origin feeds every `host_time` comparison across
     // the host (ADR-0009): client-message receive stamps (via `accept_loop`
     // and each connection task) and the engine actor's tick/offer-expiry
@@ -151,7 +203,7 @@ async fn run_until_shutdown(
     ));
 
     tokio::select! {
-        () = accept_loop(&endpoint, &engine_tx, &mut tasks, start) => {}
+        () = accept_loop(&endpoint, &engine_tx, &mut tasks, start, media.clone()) => {}
         result = shutdown_rx => {
             // A dropped sender (host caller gone without an explicit
             // shutdown) is treated the same as an explicit signal, so
@@ -167,6 +219,37 @@ async fn run_until_shutdown(
         b"session host shutting down",
     );
     shutdown::join_with_timeout(tasks).await;
+}
+
+/// The Gazebo variant of [`run_until_shutdown`]: identical lifecycle, plus it
+/// joins the media task on the way out so no video uni stream is abandoned
+/// mid-write. The media task ends once its frame source (the adapter) is
+/// dropped, which the engine-actor task does at teardown.
+#[allow(clippy::too_many_arguments)]
+async fn run_gazebo_until_shutdown(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine: SessionEngine,
+    adapter: pilotage_adapter_gazebo::GazeboAdapter,
+    media: MediaHandle,
+    media_task: tokio::task::JoinHandle<()>,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+) {
+    run_until_shutdown(
+        endpoint,
+        engine,
+        adapter,
+        Some(media),
+        engine_tx,
+        engine_rx,
+        shutdown_rx,
+    )
+    .await;
+    // The engine actor (owner of the adapter and its frame sender) has now
+    // been torn down, closing the media task's frame source; wait for it to
+    // drain and finish its writers.
+    media_task.await.ok();
 }
 
 /// Requests and logs the engine actor's per-stage latency summary
@@ -194,6 +277,7 @@ async fn accept_loop(
     engine_tx: &mpsc::Sender<ToEngine>,
     tasks: &mut JoinSet<()>,
     start: tokio::time::Instant,
+    media: Option<MediaHandle>,
 ) {
     let next_client = AtomicU64::new(0);
     loop {
@@ -214,7 +298,7 @@ async fn accept_loop(
         let client = ClientKey::new(next_client.fetch_add(1, Ordering::Relaxed));
         tasks.spawn(named_task(
             "connection",
-            accept_and_run(incoming, client, start, engine_tx),
+            accept_and_run(incoming, client, start, engine_tx, media.clone()),
         ));
     }
 }
@@ -227,6 +311,7 @@ async fn accept_and_run(
     client: ClientKey,
     start: tokio::time::Instant,
     engine_tx: mpsc::Sender<ToEngine>,
+    media: Option<MediaHandle>,
 ) {
     let session_request = match incoming.await {
         Ok(request) => request,
@@ -242,7 +327,7 @@ async fn accept_and_run(
             return;
         }
     };
-    connection::run_connection(connection, client, start, engine_tx).await;
+    connection::run_connection(connection, client, start, engine_tx, media).await;
 }
 
 /// Wraps a future so its exit is logged by name (ADR-0015: critical tasks

--- a/hosts/session-host/src/runtime/connection.rs
+++ b/hosts/session-host/src/runtime/connection.rs
@@ -21,7 +21,9 @@ use wtransport::error::SendDatagramError;
 use wtransport::{Connection, RecvStream, SendStream};
 
 use crate::runtime::engine_actor::ToEngine;
+use crate::runtime::media::MediaHandle;
 use crate::runtime::registry::OUTBOUND_QUEUE_CAPACITY;
+use crate::runtime::stream_tag::AUTHORITY_EVENTS;
 use crate::runtime::wire_codec::{
     OversizedFrame, complete_frame_len, decode_bootstrap_message, decode_control_datagram,
     decode_ping_datagram,
@@ -84,6 +86,7 @@ pub async fn run_connection(
     client: ClientKey,
     start: Instant,
     to_engine: mpsc::Sender<ToEngine>,
+    media: Option<MediaHandle>,
 ) {
     let (send, recv) = match connection.accept_bi().await {
         Ok(streams) => streams,
@@ -92,7 +95,7 @@ pub async fn run_connection(
             return;
         }
     };
-    let authority_send = match connection.open_uni().await {
+    let mut authority_send = match connection.open_uni().await {
         Ok(opening) => match opening.await {
             Ok(stream) => stream,
             Err(error) => {
@@ -105,6 +108,20 @@ pub async fn run_connection(
             return;
         }
     };
+    // Every host-initiated uni stream leads with its kind tag so a reader can
+    // tell authority events from video frames (ADR-0005); the authority stream
+    // emits its tag once, before any envelope.
+    if authority_send.write_all(&[AUTHORITY_EVENTS]).await.is_err() {
+        warn!("authority-events stream closed before its kind tag was written");
+        return;
+    }
+
+    // Video is served only when a media task is running (the Gazebo adapter
+    // path); the reference path passes `None` and serves no video, unchanged
+    // from 1a.
+    if let Some(media) = &media {
+        media.register(client, connection.clone());
+    }
 
     let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
     if to_engine
@@ -115,6 +132,9 @@ pub async fn run_connection(
         .await
         .is_err()
     {
+        if let Some(media) = &media {
+            media.deregister(client);
+        }
         return;
     }
 
@@ -123,6 +143,9 @@ pub async fn run_connection(
         () = run_writer(&connection, send, authority_send, outbound_rx) => {}
     }
 
+    if let Some(media) = &media {
+        media.deregister(client);
+    }
     forward(&to_engine, client, DomainEnvelope::Disconnect, start).await;
 }
 

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -6,7 +6,6 @@
 use std::time::Duration;
 
 use pilotage_adapter_api::{StepBudget, VehicleAdapter};
-use pilotage_adapter_reference::ReferenceAdapter;
 use pilotage_protocol::wire;
 use pilotage_session::{ClientKey, DomainEnvelope, SessionAction, SessionEngine, SessionOutcome};
 use pilotage_timing::{BoundedLatencyLog, MonoTimestamp, Stage, StageLatency};
@@ -97,12 +96,17 @@ pub enum ToEngine {
     },
 }
 
-/// Owns the [`SessionEngine`], the embedded [`ReferenceAdapter`], the client
+/// Owns the [`SessionEngine`], the embedded vehicle adapter, the client
 /// registry, and the per-stage latency log; runs until its command channel
 /// closes.
-pub struct EngineActor {
+///
+/// Generic over the [`VehicleAdapter`] so the same actor drives either the
+/// deterministic reference adapter or the real Gazebo adapter for control,
+/// telemetry, and stepping. Video frames are not part of this trait and are
+/// wired separately (the media task, ADR-0005/0008).
+pub struct EngineActor<A: VehicleAdapter> {
     engine: SessionEngine,
-    adapter: ReferenceAdapter,
+    adapter: A,
     clients: ClientRegistry,
     latency: BoundedLatencyLog<LATENCY_LOG_CAPACITY>,
     drops: DropCounters,
@@ -113,7 +117,7 @@ pub struct EngineActor {
     start: Instant,
 }
 
-impl EngineActor {
+impl<A: VehicleAdapter> EngineActor<A> {
     /// Constructs an actor wrapping `engine` and `adapter`, with an empty
     /// client registry and latency log.
     ///
@@ -122,7 +126,7 @@ impl EngineActor {
     /// offer-expiry timestamp from it, and a second, independently-sampled
     /// origin would skew those comparisons against client-message stamps.
     #[must_use]
-    pub fn new(engine: SessionEngine, adapter: ReferenceAdapter, start: Instant) -> Self {
+    pub fn new(engine: SessionEngine, adapter: A, start: Instant) -> Self {
         Self {
             engine,
             adapter,

--- a/hosts/session-host/src/runtime/gazebo_launch.rs
+++ b/hosts/session-host/src/runtime/gazebo_launch.rs
@@ -1,0 +1,78 @@
+//! Constructs the real Gazebo adapter and wires its raw-frame receiver out to
+//! the media task (ADR-0008): spawns the sidecar bridge, builds the session
+//! engine from the adapter's advertised capabilities, and hands back the frame
+//! stream the video downlink drains.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use pilotage_adapter_api::VehicleAdapter;
+use pilotage_adapter_gazebo::{BridgeConfig, GazeboAdapter, RawVideoFrame};
+use pilotage_protocol::VehicleId;
+use pilotage_session::{SessionConfig, SessionEngine};
+use pilotage_timing::StalenessPolicy;
+use tokio::sync::mpsc;
+
+use crate::error::HostError;
+
+/// Gazebo model name of the diff-drive vehicle the bridge subscribes to.
+const GAZEBO_VEHICLE_NAME: &str = "vehicle_blue";
+
+/// Default path to the built C++ sidecar bridge binary, relative to the
+/// workspace root, used when `PILOTAGE_GZ_BRIDGE_BIN` is unset. The CMake
+/// build writes the binary here; an operator with a different layout points
+/// the env var at it instead.
+const DEFAULT_BRIDGE_REL: &str = "adapters/gazebo/bridge/build/pilotage-gz-bridge";
+
+/// Builds the Gazebo adapter and session engine, returning the adapter's raw
+/// frame receiver for the media task to drain.
+///
+/// # Errors
+///
+/// Returns [`HostError::GazeboAdapter`] if the sidecar bridge cannot be
+/// spawned or its connection cannot be accepted.
+pub async fn build_gazebo(
+    vehicle: VehicleId,
+    max_control_age: Duration,
+) -> Result<(SessionEngine, GazeboAdapter, mpsc::Receiver<RawVideoFrame>), HostError> {
+    let config = BridgeConfig::new(GAZEBO_VEHICLE_NAME, default_bridge_bin());
+    let mut adapter = GazeboAdapter::new(vehicle, config)
+        .await
+        .map_err(HostError::GazeboAdapter)?;
+    let frames = adapter
+        .subscribe_frames()
+        .ok_or(HostError::GazeboAdapter(gazebo_frames_already_taken()))?;
+    let engine = build_engine(&adapter, max_control_age);
+    Ok((engine, adapter, frames))
+}
+
+/// Resolves the default sidecar bridge binary path from the workspace root.
+fn default_bridge_bin() -> PathBuf {
+    workspace_root().join(DEFAULT_BRIDGE_REL)
+}
+
+/// Workspace root, two levels up from this crate's manifest
+/// (`hosts/session-host`).
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .map_or_else(|| PathBuf::from("."), PathBuf::from)
+}
+
+/// Constructs the video-frame error for the impossible "frames already taken"
+/// case: `build_gazebo` is the sole caller of `subscribe_frames`, so this is a
+/// defensive guard, not an expected path.
+fn gazebo_frames_already_taken() -> pilotage_adapter_gazebo::GazeboAdapterError {
+    pilotage_adapter_gazebo::GazeboAdapterError::ReaderTaskEnded {
+        reason: "frame receiver already taken before the media task started".to_owned(),
+    }
+}
+
+/// Builds the session engine from the adapter's advertised capabilities.
+fn build_engine(adapter: &GazeboAdapter, max_control_age: Duration) -> SessionEngine {
+    let capabilities = adapter.capabilities();
+    let staleness = StalenessPolicy::new(max_control_age);
+    let config = SessionConfig::new(pilotage_protocol::SCHEMA_VERSION, env!("CARGO_PKG_VERSION"));
+    SessionEngine::new(capabilities, staleness, config)
+}

--- a/hosts/session-host/src/runtime/media.rs
+++ b/hosts/session-host/src/runtime/media.rs
@@ -1,0 +1,354 @@
+//! Host-side video media pipeline (ADR-0005 media = one uni stream per
+//! frame; ADR-0011 best-effort with counted drops).
+//!
+//! A single media task drains the Gazebo adapter's raw RGB frame receiver,
+//! encodes each frame to JPEG once, and fans the encoded frame out to every
+//! connected client. Each client has its own writer task and a
+//! capacity-1 handoff channel, so a client that drains video slower than
+//! frames arrive drops to the latest frame (the stale one is discarded and
+//! counted) rather than growing memory or delaying control/telemetry. Encode
+//! happens once per frame regardless of client count; the JPEG is shared as an
+//! `Arc`.
+
+use std::sync::Arc;
+
+use jpeg_encoder::{ColorType, Encoder};
+use pilotage_adapter_gazebo::RawVideoFrame;
+use pilotage_session::ClientKey;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::task::JoinSet;
+use tracing::{debug, error, warn};
+use wtransport::Connection;
+
+use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME, frame_video_payload};
+
+/// JPEG quality (1-100) for encoded camera frames. 75 balances size against
+/// visible quality for a teleop preview (ADR-0005: owned, tunable pipeline).
+const JPEG_QUALITY: u8 = 75;
+
+/// A client the media task should start sending video to.
+struct MediaClient {
+    client: ClientKey,
+    connection: Connection,
+}
+
+/// One command the media task accepts from connection tasks.
+enum MediaCommand {
+    /// Register a client so the next encoded frame is sent to it.
+    Register(MediaClient),
+    /// Deregister a client whose connection task has exited.
+    Deregister(ClientKey),
+}
+
+/// Handle connection tasks use to register/deregister with the media task.
+///
+/// Cloneable and cheap; only the Gazebo adapter path constructs one. Dropping
+/// every clone closes the command channel and lets the media task drain its
+/// last frame and exit.
+#[derive(Clone)]
+pub struct MediaHandle {
+    commands: mpsc::Sender<MediaCommand>,
+}
+
+impl MediaHandle {
+    /// Registers `client`'s connection to receive video frames. Best-effort:
+    /// a closed channel (media task gone) is ignored, since a host without a
+    /// running media task simply serves no video.
+    pub fn register(&self, client: ClientKey, connection: Connection) {
+        self.commands
+            .try_send(MediaCommand::Register(MediaClient { client, connection }))
+            .ok();
+    }
+
+    /// Deregisters `client` on disconnect. Best-effort for the same reason as
+    /// [`Self::register`].
+    pub fn deregister(&self, client: ClientKey) {
+        self.commands
+            .try_send(MediaCommand::Deregister(client))
+            .ok();
+    }
+}
+
+/// Capacity of the media task's command queue. Registrations and
+/// deregistrations are infrequent (one per connection lifecycle), so a small
+/// bound is ample.
+const COMMAND_QUEUE_CAPACITY: usize = 256;
+
+/// Spawns the media task and returns a [`MediaHandle`] connection tasks use to
+/// register. The task drains `frames` until it closes (adapter gone), then
+/// exits after its per-client writers finish.
+pub fn spawn_media_task(
+    frames: mpsc::Receiver<RawVideoFrame>,
+) -> (MediaHandle, tokio::task::JoinHandle<()>) {
+    let (commands_tx, commands_rx) = mpsc::channel(COMMAND_QUEUE_CAPACITY);
+    let handle = tokio::spawn(media_loop(frames, commands_rx));
+    (
+        MediaHandle {
+            commands: commands_tx,
+        },
+        handle,
+    )
+}
+
+/// Per-client outbound handoff of the latest encoded JPEG. Capacity 1 bounds
+/// in-flight frames to one per client: `try_send` on a full channel means the
+/// client's writer is still busy with the previous frame, so the new frame is
+/// dropped-to-latest and counted (ADR-0011 best-effort media).
+type FrameTx = mpsc::Sender<Arc<Vec<u8>>>;
+
+/// The media task's own view of a connected client: the handoff channel to its
+/// writer task, plus the running drop count for frames its writer could not
+/// keep up with.
+struct ClientSink {
+    frames: FrameTx,
+    dropped: u64,
+}
+
+/// Drains raw frames, encodes each once, and fans the encoded frame out to
+/// every registered client, servicing register/deregister commands between
+/// frames.
+async fn media_loop(
+    mut frames: mpsc::Receiver<RawVideoFrame>,
+    mut commands: mpsc::Receiver<MediaCommand>,
+) {
+    let mut sinks: std::collections::BTreeMap<ClientKey, ClientSink> =
+        std::collections::BTreeMap::new();
+    let mut writers = JoinSet::new();
+    loop {
+        // Harvest every writer task that finished since the last iteration so
+        // the JoinSet does not retain completed JoinHandles for the task
+        // lifetime; without this the set grows unbounded under connection churn
+        // on the video path (ADR-0015). A panicked writer is logged, not
+        // propagated: one bad client must not tear down the media pipeline.
+        while let Some(joined) = writers.try_join_next() {
+            if let Err(error) = joined
+                && !error.is_cancelled()
+            {
+                warn!(%error, "video writer task panicked");
+            }
+        }
+        tokio::select! {
+            command = commands.recv() => {
+                match command {
+                    Some(command) => apply_command(command, &mut sinks, &mut writers),
+                    None => break,
+                }
+            }
+            frame = frames.recv() => {
+                match frame {
+                    Some(frame) => fan_out_frame(frame, &mut sinks),
+                    None => break,
+                }
+            }
+        }
+    }
+    // Dropping every sink closes each writer's handoff channel, so the writers
+    // finish their in-flight frame and exit; wait for them so no uni stream is
+    // abandoned mid-write on shutdown.
+    drop(sinks);
+    while writers.join_next().await.is_some() {}
+    debug!("media task exited");
+}
+
+/// Applies one register/deregister command, spawning or dropping the client's
+/// writer task.
+fn apply_command(
+    command: MediaCommand,
+    sinks: &mut std::collections::BTreeMap<ClientKey, ClientSink>,
+    writers: &mut JoinSet<()>,
+) {
+    match command {
+        MediaCommand::Register(MediaClient { client, connection }) => {
+            let (frame_tx, frame_rx) = mpsc::channel::<Arc<Vec<u8>>>(1);
+            writers.spawn(client_writer(client, connection, frame_rx));
+            sinks.insert(
+                client,
+                ClientSink {
+                    frames: frame_tx,
+                    dropped: 0,
+                },
+            );
+        }
+        MediaCommand::Deregister(client) => {
+            sinks.remove(&client);
+        }
+    }
+}
+
+/// Encodes `frame` to JPEG once and hands it to every client sink, counting a
+/// drop for any client whose in-flight slot is still full (slow consumer) and
+/// evicting any whose writer task has exited.
+fn fan_out_frame(
+    frame: RawVideoFrame,
+    sinks: &mut std::collections::BTreeMap<ClientKey, ClientSink>,
+) {
+    if sinks.is_empty() {
+        return;
+    }
+    let Some(jpeg) = encode_jpeg(&frame) else {
+        return;
+    };
+    let jpeg = Arc::new(jpeg);
+    let mut closed = Vec::new();
+    for (client, sink) in sinks.iter_mut() {
+        match sink.frames.try_send(Arc::clone(&jpeg)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                sink.dropped = sink.dropped.wrapping_add(1);
+                warn!(
+                    client = client.as_u64(),
+                    total_dropped = sink.dropped,
+                    "video frame dropped: client writer still busy with the previous frame"
+                );
+            }
+            Err(TrySendError::Closed(_)) => closed.push(*client),
+        }
+    }
+    for client in closed {
+        sinks.remove(&client);
+    }
+}
+
+/// Encodes one raw RGB frame to JPEG. Returns `None` (and logs) on a
+/// non-RGB pixel format or an encoder failure, so the media task skips a bad
+/// frame rather than tearing down the whole pipeline.
+fn encode_jpeg(frame: &RawVideoFrame) -> Option<Vec<u8>> {
+    if frame.pixel_format != "RGB_INT8" {
+        warn!(
+            format = frame.pixel_format,
+            "skipping frame: only RGB_INT8 is supported by the media encoder"
+        );
+        return None;
+    }
+    let (width, height) = match (u16::try_from(frame.width), u16::try_from(frame.height)) {
+        (Ok(w), Ok(h)) => (w, h),
+        _ => {
+            warn!(
+                width = frame.width,
+                height = frame.height,
+                "skipping frame: dimensions exceed the JPEG encoder's 16-bit limit"
+            );
+            return None;
+        }
+    };
+    let mut jpeg = Vec::new();
+    let encoder = Encoder::new(&mut jpeg, JPEG_QUALITY);
+    if let Err(error) = encoder.encode(&frame.rgb, width, height, ColorType::Rgb) {
+        warn!(%error, "JPEG encode failed; skipping frame");
+        return None;
+    }
+    Some(jpeg)
+}
+
+/// Per-client writer: receives the latest encoded JPEG and writes it as one
+/// host-initiated uni stream tagged [`VIDEO_FRAME`], one stream per frame
+/// (ADR-0005). Exits when the handoff channel closes (client deregistered or
+/// media task shutting down).
+async fn client_writer(
+    client: ClientKey,
+    connection: Connection,
+    mut frames: mpsc::Receiver<Arc<Vec<u8>>>,
+) {
+    while let Some(jpeg) = frames.recv().await {
+        if let Err(reason) = write_one_frame(&connection, &jpeg).await {
+            // A failed uni-stream open/write means the connection is going
+            // away; stop writing video to it. The connection task's own
+            // teardown deregisters this client.
+            debug!(client = client.as_u64(), reason, "video writer stopping");
+            return;
+        }
+    }
+}
+
+/// Opens one host-initiated uni stream, writes the [`VIDEO_FRAME`] tag then
+/// the codec-tagged length-prefixed JPEG, and finishes the stream (ADR-0005
+/// media unit; ADR-0016 FourCC codec tag).
+async fn write_one_frame(connection: &Connection, jpeg: &[u8]) -> Result<(), &'static str> {
+    let Some(body) = frame_video_payload(FOURCC_MJPEG, jpeg) else {
+        // A frame larger than u32::MAX cannot be length-prefixed; skip it
+        // without failing the writer (no real camera frame reaches this).
+        error!("video frame exceeds u32 length prefix; skipping");
+        return Ok(());
+    };
+    let mut stream = connection
+        .open_uni()
+        .await
+        .map_err(|_| "uni stream request failed")?
+        .await
+        .map_err(|_| "uni stream failed to open")?;
+    stream
+        .write_all(&[VIDEO_FRAME])
+        .await
+        .map_err(|_| "tag write failed")?;
+    stream
+        .write_all(&body)
+        .await
+        .map_err(|_| "payload write failed")?;
+    stream.finish().await.map_err(|_| "stream finish failed")?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::encode_jpeg;
+    use crate::runtime::stream_tag::{
+        FOURCC_MJPEG, VIDEO_FRAME, frame_video_payload, parse_video_payload,
+    };
+    use pilotage_adapter_gazebo::RawVideoFrame;
+    use pilotage_timing::SimTick;
+
+    /// Builds a synthetic RGB frame with a simple gradient so the encoder has
+    /// real (non-constant) pixel data to work with.
+    fn synthetic_rgb(width: u32, height: u32) -> RawVideoFrame {
+        let mut rgb = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                rgb.push((x % 256) as u8);
+                rgb.push((y % 256) as u8);
+                rgb.push(((x + y) % 256) as u8);
+            }
+        }
+        RawVideoFrame {
+            width,
+            height,
+            pixel_format: "RGB_INT8".to_owned(),
+            tick: SimTick::new(0),
+            rgb,
+        }
+    }
+
+    #[test]
+    fn encodes_frames_and_wire_frames_round_trip() {
+        let frame = synthetic_rgb(16, 12);
+        let jpeg = encode_jpeg(&frame).expect("synthetic RGB frame encodes to JPEG");
+        // A JPEG stream begins with the SOI marker 0xFFD8 and ends with EOI
+        // 0xFFD9; check both so a garbage encode is caught.
+        assert_eq!(&jpeg[..2], &[0xFF, 0xD8], "JPEG starts with SOI");
+        assert_eq!(&jpeg[jpeg.len() - 2..], &[0xFF, 0xD9], "JPEG ends with EOI");
+
+        // Frame the JPEG exactly as the media task writes it after the tag,
+        // then parse the codec-tagged length-prefixed body back (ADR-0016).
+        let body = frame_video_payload(FOURCC_MJPEG, &jpeg).expect("JPEG frames");
+        let (codec, parsed) = parse_video_payload(&body).expect("framed body parses back");
+        assert_eq!(codec, FOURCC_MJPEG, "carries the MJPG FourCC");
+        assert_eq!(parsed, jpeg.as_slice(), "round-trips the exact JPEG bytes");
+
+        // The full on-wire unit is [tag][fourcc][u32 len][jpeg]; assemble and
+        // dissect it the way a client reader would.
+        let mut wire = vec![VIDEO_FRAME];
+        wire.extend_from_slice(&body);
+        assert_eq!(wire[0], VIDEO_FRAME, "leads with the video kind tag");
+        let (codec, parsed) = parse_video_payload(&wire[1..]).expect("payload after tag parses");
+        assert_eq!(codec, FOURCC_MJPEG);
+        assert_eq!(parsed, jpeg.as_slice());
+    }
+
+    #[test]
+    fn non_rgb_frame_is_skipped() {
+        let mut frame = synthetic_rgb(4, 4);
+        frame.pixel_format = "BGR_INT8".to_owned();
+        assert!(encode_jpeg(&frame).is_none());
+    }
+}

--- a/hosts/session-host/src/runtime/stream_tag.rs
+++ b/hosts/session-host/src/runtime/stream_tag.rs
@@ -1,0 +1,103 @@
+//! Kind tags that disambiguate the host's several host-initiated
+//! unidirectional streams (ADR-0005).
+//!
+//! Both authority events and video frames travel on host-initiated uni
+//! streams, so a reader accepting a fresh uni stream cannot tell them apart
+//! from the QUIC stream type alone. Every host-initiated uni stream therefore
+//! begins with a single kind-tag byte before its payload; the reader consumes
+//! that byte first and routes on it.
+
+/// Tag prefixing the dedicated authority-events stream: the reliable, ordered
+/// stream of lease/handover/override events (ADR-0005) carries
+/// length-delimited envelopes after this byte.
+pub const AUTHORITY_EVENTS: u8 = 0x01;
+
+/// Tag prefixing a per-frame video stream: a
+/// `[fourcc: 4 bytes][u32 LE len][payload]` media unit follows this byte
+/// (ADR-0005 media = one uni stream per frame; ADR-0016 codec tag).
+pub const VIDEO_FRAME: u8 = 0x02;
+
+/// FourCC codec tag for Motion JPEG frames (ADR-0016).
+///
+/// The per-frame video body is `[fourcc][u32 LE len][payload]`; the client
+/// routes on the FourCC and MUST treat an unknown one as a skipped frame, so
+/// a host streaming a codec an older client lacks degrades gracefully rather
+/// than hard-failing. Motion JPEG has a real FourCC (`MJPG`); the reserved
+/// video codecs (`avc1`, `hvc1`, `av01`, `vp09`) are ISO-BMFF sample-entry
+/// codes from MP4RA, so the value space is already arbitrated.
+pub const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
+
+/// Serializes one encoded frame as the on-wire video-stream body that follows
+/// the [`VIDEO_FRAME`] tag: the 4-byte `codec` FourCC (ADR-0016), a
+/// little-endian `u32` length prefix, and the encoded bytes. The tag itself is
+/// written separately by the media task, so this is only the codec-tagged,
+/// length-prefixed payload.
+///
+/// Returns the framed bytes, or `None` if `payload` is larger than `u32::MAX`
+/// (far beyond any real camera frame; a length that cannot be expressed in
+/// the 4-byte prefix must not be silently truncated).
+#[must_use]
+pub fn frame_video_payload(codec: [u8; 4], payload: &[u8]) -> Option<Vec<u8>> {
+    let len = u32::try_from(payload.len()).ok()?;
+    let mut out = Vec::with_capacity(4 + 4 + payload.len());
+    out.extend_from_slice(&codec);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(payload);
+    Some(out)
+}
+
+/// Parses a codec-tagged, length-prefixed video-stream body produced by
+/// [`frame_video_payload`] (the bytes after the [`VIDEO_FRAME`] tag),
+/// returning the `(fourcc, payload)` pair.
+///
+/// Returns `None` if fewer than the four FourCC plus four length bytes are
+/// present or the declared length does not match the remaining bytes exactly.
+/// Only the framing round-trip tests parse the payload back host-side; the
+/// real client readers live in the native viewer and the browser.
+#[cfg(test)]
+#[must_use]
+pub fn parse_video_payload(body: &[u8]) -> Option<([u8; 4], &[u8])> {
+    let (fourcc, rest) = body.split_at_checked(4)?;
+    let (len_bytes, rest) = rest.split_at_checked(4)?;
+    let declared = u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]]);
+    let declared = usize::try_from(declared).ok()?;
+    let fourcc = [fourcc[0], fourcc[1], fourcc[2], fourcc[3]];
+    (rest.len() == declared).then_some((fourcc, rest))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{FOURCC_MJPEG, frame_video_payload, parse_video_payload};
+
+    #[test]
+    fn framing_round_trips() {
+        let jpeg = vec![0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3, 0xFF, 0xD9];
+        let framed = frame_video_payload(FOURCC_MJPEG, &jpeg).expect("small frame frames");
+        assert_eq!(&framed[..4], b"MJPG");
+        assert_eq!(&framed[4..8], &(jpeg.len() as u32).to_le_bytes());
+        let (codec, parsed) = parse_video_payload(&framed).expect("body parses back");
+        assert_eq!(codec, FOURCC_MJPEG);
+        assert_eq!(parsed, jpeg.as_slice());
+    }
+
+    #[test]
+    fn empty_jpeg_frames_and_parses() {
+        let framed = frame_video_payload(FOURCC_MJPEG, &[]).expect("empty frames");
+        assert_eq!(framed, vec![b'M', b'J', b'P', b'G', 0, 0, 0, 0]);
+        assert_eq!(parse_video_payload(&framed), Some((FOURCC_MJPEG, &[][..])));
+    }
+
+    #[test]
+    fn truncated_header_is_rejected() {
+        // Fewer than the 8-byte fourcc+length header.
+        assert_eq!(parse_video_payload(&[b'M', b'J', 0, 0]), None);
+    }
+
+    #[test]
+    fn length_mismatch_is_rejected() {
+        // Declares 5 bytes but only 2 follow.
+        let body = vec![b'M', b'J', b'P', b'G', 5, 0, 0, 0, 1, 2];
+        assert_eq!(parse_video_payload(&body), None);
+    }
+}

--- a/hosts/session-host/tests/hostile_pending_growth.rs
+++ b/hosts/session-host/tests/hostile_pending_growth.rs
@@ -12,6 +12,7 @@
 use std::time::Duration;
 
 use pilotage_protocol::wire;
+use pilotage_session_host::cli::AdapterKind;
 use pilotage_session_host::runtime;
 use tokio::time::timeout;
 use wtransport::{ClientConfig, Connection, Endpoint};
@@ -83,7 +84,9 @@ async fn read_welcome(recv: &mut wtransport::RecvStream) -> wire::ServerWelcome 
 /// declared size, and must still welcome a subsequent honest client.
 #[tokio::test]
 async fn oversized_bootstrap_frame_is_rejected_and_host_survives() {
-    let host = runtime::start(0).expect("host starts on an ephemeral port");
+    let host = runtime::start(0, AdapterKind::Reference)
+        .await
+        .expect("host starts on an ephemeral port");
     let addr = host.local_addr;
 
     // Hostile connection: declare a frame far past the cap, then dribble body.

--- a/hosts/session-host/tests/loopback.rs
+++ b/hosts/session-host/tests/loopback.rs
@@ -12,6 +12,7 @@
 use std::time::Duration;
 
 use pilotage_protocol::wire;
+use pilotage_session_host::cli::AdapterKind;
 use pilotage_session_host::runtime;
 use prost::Message;
 use tokio::time::timeout;
@@ -75,6 +76,32 @@ async fn read_until_lease_response(
             return response;
         }
     }
+}
+
+/// Kind tag prefixing the host's authority-events uni stream (ADR-0005:
+/// every host-initiated uni stream leads with a 1-byte kind tag; `0x01`
+/// distinguishes authority events from `0x02` video frames).
+const AUTHORITY_EVENTS_TAG: u8 = 0x01;
+
+/// Reads the single leading kind-tag byte from a freshly accepted
+/// host-initiated uni stream, asserting it identifies the authority-events
+/// stream. Any bytes read past the tag are left in `pending` for the envelope
+/// parser.
+async fn read_authority_tag(recv: &mut wtransport::RecvStream, pending: &mut Vec<u8>) {
+    let mut buf = vec![0u8; 8192];
+    while pending.is_empty() {
+        let read = timeout(TEST_TIMEOUT, recv.read(&mut buf))
+            .await
+            .expect("stream read does not time out")
+            .expect("stream read succeeds")
+            .expect("authority stream is not closed before its kind tag arrives");
+        pending.extend_from_slice(&buf[..read]);
+    }
+    let tag = pending.remove(0);
+    assert_eq!(
+        tag, AUTHORITY_EVENTS_TAG,
+        "authority-events stream must lead with its kind tag"
+    );
 }
 
 /// Reads authority-events-stream envelopes until one is a
@@ -213,7 +240,9 @@ async fn await_frame_rejected(connection: &Connection) -> wire::FrameRejected {
 
 #[tokio::test]
 async fn hello_lease_frame_and_stale_generation_rejection() {
-    let host = runtime::start(0).expect("host starts on an ephemeral port");
+    let host = runtime::start(0, AdapterKind::Reference)
+        .await
+        .expect("host starts on an ephemeral port");
     let addr = host.local_addr;
 
     let connection = connect_client(addr).await;
@@ -230,6 +259,10 @@ async fn hello_lease_frame_and_stale_generation_rejection() {
 
     let mut pending = Vec::new();
     let mut authority_pending = Vec::new();
+
+    // The authority-events uni stream now leads with a 1-byte kind tag
+    // (ADR-0005); consume it before parsing length-delimited envelopes.
+    read_authority_tag(&mut authority_recv, &mut authority_pending).await;
 
     send_envelope(&mut send, &hello_envelope()).await;
     let welcome_envelope = read_one_envelope(&mut recv, &mut pending).await;

--- a/schemas/pilotage/bridge/v1/bridge.proto
+++ b/schemas/pilotage/bridge/v1/bridge.proto
@@ -1,0 +1,48 @@
+// Internal host<->sidecar bridge wire types (ADR-0008). This package is
+// deliberately separate from `pilotage.v1`: it is the private protocol
+// between the Rust `pilotage-adapter-gazebo` host process and the C++
+// gz-transport sidecar bridge over a localhost TCP connection, and MUST
+// NOT be exposed to, or confused with, the public client protocol.
+syntax = "proto3";
+
+package pilotage.bridge.v1;
+
+// A control command from the host to the sidecar, mapped from canonical
+// control axes (throttle, yaw) to the vehicle's differential-drive
+// command frame.
+message BridgeControl {
+  double linear_x = 1;
+  double angular_z = 2;
+}
+
+// A single odometry sample from the sidecar to the host, already reduced
+// to the planar pose and scalar speed the host's canonical telemetry model
+// needs (ADR-0008): no raw gz.msgs.Odometry crosses this boundary.
+message BridgeOdometry {
+  double x = 1;
+  double y = 2;
+  double heading = 3;
+  double speed = 4;
+  uint64 sim_time_ns = 5;
+}
+
+// A single raw camera frame from the sidecar to the host, ahead of the
+// host's own MJPEG encode step (ADR-0005): no raw gz.msgs.Image crosses
+// this boundary.
+message BridgeFrame {
+  uint32 width = 1;
+  uint32 height = 2;
+  string pixel_format = 3;
+  uint64 sim_time_ns = 4;
+  bytes rgb = 5;
+}
+
+// Wraps exactly one bridge payload for length-delimited framing over the
+// host<->sidecar TCP connection.
+message BridgeEnvelope {
+  oneof payload {
+    BridgeControl control = 1;
+    BridgeOdometry odometry = 2;
+    BridgeFrame frame = 3;
+  }
+}

--- a/sim/worlds/pilotage_yard.sdf
+++ b/sim/worlds/pilotage_yard.sdf
@@ -1,0 +1,415 @@
+<?xml version="1.0" ?>
+<!--
+  Pilotage demo world (increment 1b): a diff-drive vehicle_blue (from the
+  upstream diff_drive.sdf demo) with an onboard forward camera rigidly
+  attached to the chassis, plus a few colored primitive obstacles so the
+  camera view visibly changes while driving.
+
+  Command:
+    gz topic -t "/model/vehicle_blue/cmd_vel" -m gz.msgs.Twist -p "linear: {x: 0.5}, angular: {z: 0.05}"
+
+  Telemetry:
+    gz topic -e -t /model/vehicle_blue/odometry
+
+  Camera:
+    gz topic -e -t /camera
+-->
+<sdf version="1.6">
+  <world name="pilotage_yard">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+      <grid>false</grid>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Colored primitive obstacles ahead of vehicle_blue's start pose and
+         heading, so the onboard camera view visibly changes while driving
+         forward. -->
+    <model name="obstacle_red_box">
+      <static>true</static>
+      <pose>4 3.4 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="obstacle_green_sphere">
+      <static>true</static>
+      <pose>5 1.3 0.4 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.4</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0 1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.4</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name="obstacle_yellow_cylinder">
+      <static>true</static>
+      <pose>7 2.6 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 0 1</ambient>
+            <diffuse>1 1 0 1</diffuse>
+            <specular>1 1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.3</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <model name='vehicle_blue'>
+      <pose>0 2 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <!-- Onboard forward-facing camera, rigidly attached to the chassis
+             (ADR-0008: capture as close as practical to the render
+             pipeline; here, mounted directly on the vehicle body). -->
+        <sensor name="camera" type="camera">
+          <pose>1.1 0 0.3 0 0 0</pose>
+          <camera>
+            <horizontal_fov>1.396</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+          <topic>camera</topic>
+        </sensor>
+      </link>
+
+      <link name='left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>1</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name='right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>1</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name='caster'>
+        <pose>-0.957138 -0 -0.125 0 -0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name='left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='caster_wheel' type='ball'>
+        <parent>chassis</parent>
+        <child>caster</child>
+      </joint>
+
+      <plugin
+        filename="gz-sim-diff-drive-system"
+        name="gz::sim::systems::DiffDrive">
+        <left_joint>left_wheel_joint</left_joint>
+        <right_joint>right_wheel_joint</right_joint>
+        <wheel_separation>1.25</wheel_separation>
+        <wheel_radius>0.3</wheel_radius>
+        <odom_publish_frequency>30</odom_publish_frequency>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>

--- a/tools/loopback-probe/Cargo.toml
+++ b/tools/loopback-probe/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 
 [dependencies]
 hidapi = { workspace = true }
+# JPEG decode for the video downlink (`--save-frames`) and PNG encode for the
+# saved proof frames; both formats only, to keep this CLI-tool dependency lean.
+image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
 pilotage-input = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
@@ -20,7 +23,7 @@ prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync", "fs"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # `dangerous-configuration` gates `with_no_cert_validation`, which

--- a/tools/loopback-probe/src/cli.rs
+++ b/tools/loopback-probe/src/cli.rs
@@ -21,6 +21,14 @@ pub struct Args {
     pub seconds: u64,
     /// Control-frame send rate in Hz.
     pub rate: u64,
+    /// Whether to send the scripted forward-then-arc drive pattern instead of
+    /// the default synthetic sine-wave generator. Takes precedence over
+    /// `--hid` if both are somehow given, since `--drive` is this tool's
+    /// deliberate "move the real vehicle" demo mode.
+    pub drive: bool,
+    /// If set, save the first, a middle, and the last decoded video frame as
+    /// PNG files under this directory.
+    pub save_frames: Option<String>,
 }
 
 const DEFAULT_SECONDS: u64 = 3;
@@ -46,6 +54,7 @@ pub fn parse_args(args: &[String]) -> Result<Args, ProbeError> {
         });
     }
     let hid = has_flag(args, "--hid");
+    let drive = has_flag(args, "--drive");
     let seconds = optional_u64(args, "--seconds")?.unwrap_or(DEFAULT_SECONDS);
     let rate = optional_u64(args, "--rate")?.unwrap_or(DEFAULT_RATE);
     if rate == 0 {
@@ -53,12 +62,15 @@ pub fn parse_args(args: &[String]) -> Result<Args, ProbeError> {
             message: "--rate must be greater than zero".to_string(),
         });
     }
+    let save_frames = optional_flag(args, "--save-frames")?;
     Ok(Args {
         url,
         insecure_loopback,
         hid,
         seconds,
         rate,
+        drive,
+        save_frames,
     })
 }
 
@@ -80,6 +92,18 @@ fn require_flag<'a>(args: &'a [String], name: &str) -> Result<&'a str, ProbeErro
         .ok_or_else(|| ProbeError::Usage {
             message: format!("{name} requires a value"),
         })
+}
+
+/// Finds `--name VALUE` in `args` and returns `VALUE` as an owned `String`,
+/// returning `None` if the flag was not supplied at all.
+fn optional_flag(args: &[String], name: &str) -> Result<Option<String>, ProbeError> {
+    let Some(position) = args.iter().position(|arg| arg == name) else {
+        return Ok(None);
+    };
+    let value = args.get(position + 1).ok_or_else(|| ProbeError::Usage {
+        message: format!("{name} requires a value"),
+    })?;
+    Ok(Some(value.clone()))
 }
 
 /// Finds `--name VALUE` in `args` and parses it as `u64`, returning `None`
@@ -122,6 +146,8 @@ mod tests {
                 hid: false,
                 seconds: 3,
                 rate: 100,
+                drive: false,
+                save_frames: None,
             }
         );
     }
@@ -133,15 +159,20 @@ mod tests {
             "https://127.0.0.1:4433",
             "--insecure-loopback",
             "--hid",
+            "--drive",
             "--seconds",
             "10",
             "--rate",
             "50",
+            "--save-frames",
+            "/tmp/frames",
         ]))
         .expect("parses");
         assert!(parsed.hid);
+        assert!(parsed.drive);
         assert_eq!(parsed.seconds, 10);
         assert_eq!(parsed.rate, 50);
+        assert_eq!(parsed.save_frames.as_deref(), Some("/tmp/frames"));
     }
 
     #[test]

--- a/tools/loopback-probe/src/drive.rs
+++ b/tools/loopback-probe/src/drive.rs
@@ -1,0 +1,83 @@
+//! `--drive` scripted control pattern: forward for the first half of the run,
+//! then an arcing turn for the second half, so a real vehicle (Gazebo adapter)
+//! visibly moves and turns rather than sitting still or oscillating in place
+//! like the default synthetic sine generator.
+//!
+//! Unlike `synthetic::payload_at`, this is a one-shot script keyed on elapsed
+//! run time and the run's total budget, not a continuous waveform: the demo
+//! goal is "prove the real vehicle moved", which reads more clearly from two
+//! distinct phases than from a sine sweep.
+
+use std::time::Duration;
+
+use pilotage_input::axis_id_for_name;
+use pilotage_protocol::ControlPayload;
+
+use crate::error::ProbeError;
+
+/// Forward throttle command during the drive script's first phase, in the
+/// canonical `[-1.0, 1.0]` axis convention.
+const DRIVE_THROTTLE: f32 = 0.6;
+/// Yaw command during the drive script's arc phase.
+const DRIVE_YAW: f32 = 0.5;
+/// Reduced throttle during the arc phase so the turn is visibly an arc, not a
+/// straight line with added spin.
+const ARC_THROTTLE: f32 = 0.35;
+
+/// Builds the `--drive` script's [`ControlPayload`] for `elapsed` time into a
+/// run budgeted for `total`: forward-only for the first half, then a
+/// forward-arcing turn for the second half.
+///
+/// # Errors
+///
+/// Returns an error only if `pilotage-input`'s well-known logical-name table
+/// ever stops recognizing `throttle`/`yaw`, indicating a crate version skew
+/// this binary cannot recover from at runtime.
+pub fn payload_at(elapsed: Duration, total: Duration) -> Result<ControlPayload, ProbeError> {
+    let halfway = total / 2;
+    let (throttle, yaw) = if elapsed < halfway {
+        (DRIVE_THROTTLE, 0.0)
+    } else {
+        (ARC_THROTTLE, DRIVE_YAW)
+    };
+    let mut axes = vec![
+        (axis_id_for_name("throttle")?, throttle),
+        (axis_id_for_name("yaw")?, yaw),
+    ];
+    axes.sort_by_key(|(id, _)| *id);
+    Ok(ControlPayload {
+        axes,
+        edges: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::payload_at;
+    use std::time::Duration;
+
+    #[test]
+    fn first_half_drives_forward_only() {
+        let total = Duration::from_secs(10);
+        let payload = payload_at(Duration::from_secs(1), total).expect("builds");
+        for (axis, value) in &payload.axes {
+            if axis.as_u16() == 2 {
+                assert!(*value > 0.0, "throttle should be positive");
+            } else if axis.as_u16() == 3 {
+                assert_eq!(*value, 0.0, "yaw should be neutral in the forward phase");
+            }
+        }
+    }
+
+    #[test]
+    fn second_half_arcs() {
+        let total = Duration::from_secs(10);
+        let payload = payload_at(Duration::from_secs(6), total).expect("builds");
+        for (axis, value) in &payload.axes {
+            if axis.as_u16() == 3 {
+                assert!(*value > 0.0, "yaw should be nonzero in the arc phase");
+            }
+        }
+    }
+}

--- a/tools/loopback-probe/src/main.rs
+++ b/tools/loopback-probe/src/main.rs
@@ -7,6 +7,7 @@
 
 mod cli;
 mod control_source;
+mod drive;
 mod error;
 mod hid_decode;
 mod metrics;
@@ -14,11 +15,13 @@ mod output;
 mod pipeline;
 mod receiver;
 mod run;
+mod save_frames;
 mod sender;
 mod summary;
 mod synthetic;
 mod telemetry;
 mod transport;
+mod video;
 mod wire_session;
 
 use std::process::ExitCode;

--- a/tools/loopback-probe/src/metrics.rs
+++ b/tools/loopback-probe/src/metrics.rs
@@ -103,6 +103,17 @@ pub struct RunMetrics {
     pub frames_rejected: u64,
     /// Telemetry samples received.
     pub telemetry_received: u64,
+    /// The most recently observed telemetry pose (`x_m`, `y_m`,
+    /// `heading_rad`), so the end-of-run summary can report the vehicle's
+    /// final observed position.
+    pub last_pose: Option<(f32, f32, f32)>,
+    /// Events the receiver task dropped because the bounded channel to the
+    /// run loop was full (`receiver::forward_event`), rather than blocking
+    /// delivery of everything queued behind a slow consumer. Distinct from
+    /// `control_to_telemetry_backlog_dropped`: this counts events never
+    /// handed to the run loop at all, not matched-then-evicted latency
+    /// samples.
+    pub dropped_events: u64,
 }
 
 impl RunMetrics {
@@ -117,6 +128,8 @@ impl RunMetrics {
             frames_sent: 0,
             frames_rejected: 0,
             telemetry_received: 0,
+            last_pose: None,
+            dropped_events: 0,
         }
     }
 

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -1,8 +1,28 @@
 //! Background task receiving inbound traffic concurrently with the send loop.
 //! Telemetry, `Pong`, and `FrameRejected` all arrive as datagrams (the host's
-//! control-fast/telemetry class mapping) and are routed by envelope arm; the
-//! bidi-stream branch remains only to observe a post-handshake stream close.
+//! control-fast/telemetry class mapping) and are routed by envelope arm.
+//!
+//! Host-initiated uni streams carry two kinds of traffic (ADR-0005): the
+//! dedicated authority-events stream, opened once per connection, and one
+//! fresh stream per video frame (media = one uni stream per frame). Every
+//! host-initiated uni stream leads with a 1-byte kind tag; this module accepts
+//! every such stream in a loop and dispatches each on that tag, spawning a
+//! short-lived reader task per video-frame stream so a slow video decode never
+//! blocks accepting the next stream.
+//!
+//! Every hand-off to the run loop's bounded event channel uses `try_send`,
+//! never the blocking `send().await`: the channel's consumer (`handle_event`)
+//! does inline JPEG decode, and a channel that blocks its producers on a slow
+//! consumer would stall delivery of everything behind the slow item —
+//! telemetry and `Pong` queued behind video frames would skew latency/RTT
+//! measurements instead of being counted as dropped (ADR-0015: a lagging
+//! consumer is a correctness signal, not silent). A full channel drops the
+//! new event and increments the shared `dropped_events` counter instead.
 
+mod uni_stream;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use tokio::sync::mpsc;
@@ -36,12 +56,22 @@ pub enum ReceiverEvent {
     /// An authority/mode event read from the host's dedicated authority-events
     /// stream (ADR-0005). Counted only, to prove the stream is live.
     Authority,
+    /// One raw JPEG frame body read off a per-frame video uni stream
+    /// (ADR-0005 media = one uni stream per frame). Inter-arrival latency is
+    /// measured by the run loop's own wall clock at the point it receives
+    /// this event, not by a timestamp carried on the event itself.
+    VideoFrame {
+        /// The JPEG bytes (tag and length prefix already stripped).
+        jpeg: Vec<u8>,
+    },
 }
 
-/// Spawns the receiver task: one branch polls datagrams (telemetry, `Pong`,
-/// `FrameRejected`), the other reads the bootstrap bidi stream's `recv` half
-/// so a post-handshake stream close is observed. Named so an aborted-task
-/// audit can identify it (ADR-0015).
+/// Spawns the receiver task: branches poll datagrams (telemetry, `Pong`,
+/// `FrameRejected`), the bootstrap bidi stream's `recv` half (to observe a
+/// post-handshake stream close), and every host-initiated uni stream accepted
+/// over the connection's lifetime (the dedicated authority-events stream plus
+/// one fresh stream per video frame, ADR-0005). Named so an aborted-task audit
+/// can identify it (ADR-0015).
 ///
 /// Takes only `recv_stream`; the bidi stream's send half stays in the run
 /// loop, kept open but unwritten after the handshake.
@@ -51,46 +81,72 @@ pub enum ReceiverEvent {
 /// frame/ping send timestamps, or the send/receive difference the metrics take
 /// (with a zero clock offset) mixes two independent origins and skews every
 /// control-to-telemetry latency and RTT sample.
+///
+/// Returns the join handle plus a shared counter of events dropped because
+/// the bounded `events_tx` channel was full (see module doc); the caller
+/// folds it into `RunMetrics` once the run completes.
 pub fn spawn_receiver(
     connection: Connection,
     recv_stream: RecvStream,
-    authority_stream: RecvStream,
     run_start: Instant,
     events_tx: mpsc::Sender<ReceiverEvent>,
-) -> JoinHandle<()> {
-    tokio::spawn(
+) -> (JoinHandle<()>, Arc<AtomicU64>) {
+    let dropped_events = Arc::new(AtomicU64::new(0));
+    let handle = tokio::spawn(
         receiver_loop(
             connection,
             recv_stream,
-            authority_stream,
             run_start,
             events_tx,
+            Arc::clone(&dropped_events),
         )
         .instrument(tracing::info_span!("loopback_probe_receiver")),
-    )
+    );
+    (handle, dropped_events)
 }
 
-/// Runs the datagram, bidi-stream, and authority-stream receive branches
-/// until the connection closes or the event channel's receiver is dropped.
+/// Forwards one event to the run loop via `try_send`, incrementing
+/// `dropped_events` (and warning) if the bounded channel is full rather than
+/// awaiting free capacity (see module doc).
+fn forward_event(
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
+    event: ReceiverEvent,
+) {
+    if let Err(source) = events_tx.try_send(event) {
+        dropped_events.fetch_add(1, Ordering::Relaxed);
+        match source {
+            mpsc::error::TrySendError::Full(_) => {
+                warn!("event channel full; dropping event instead of stalling delivery");
+            }
+            mpsc::error::TrySendError::Closed(_) => {
+                warn!("event channel closed while forwarding event");
+            }
+        }
+    }
+}
+
+/// Runs the datagram and bidi-stream receive branches, and accepts every
+/// host-initiated uni stream, until the connection closes or the event
+/// channel's receiver is dropped.
 async fn receiver_loop(
     connection: Connection,
     mut recv_stream: RecvStream,
-    mut authority_stream: RecvStream,
     start: Instant,
     events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
 ) {
     let mut stream_buf = Vec::new();
-    let mut authority_buf = Vec::new();
     let mut read_chunk = [0u8; 4096];
-    let mut authority_chunk = [0u8; 4096];
+    let mut uni_streams = tokio::task::JoinSet::new();
     loop {
         tokio::select! {
             datagram = connection.receive_datagram() => {
                 match datagram {
-                    Ok(datagram) => handle_datagram(&datagram, start, &events_tx).await,
+                    Ok(datagram) => handle_datagram(&datagram, start, &events_tx, &dropped_events),
                     Err(source) => {
                         warn!(%source, "datagram receive failed; stopping receiver");
-                        return;
+                        break;
                     }
                 }
             }
@@ -98,36 +154,42 @@ async fn receiver_loop(
                 match read {
                     Ok(Some(count)) => {
                         stream_buf.extend_from_slice(&read_chunk[..count]);
-                        drain_stream_frames(&mut stream_buf, start, &events_tx).await;
+                        drain_stream_frames(&mut stream_buf, start, &events_tx, &dropped_events);
                     }
                     Ok(None) => {
                         warn!("bidi stream closed; stopping receiver");
-                        return;
+                        break;
                     }
                     Err(source) => {
                         warn!(%source, "bidi stream read failed; stopping receiver");
-                        return;
+                        break;
                     }
                 }
             }
-            read = authority_stream.read(&mut authority_chunk) => {
-                match read {
-                    Ok(Some(count)) => {
-                        authority_buf.extend_from_slice(&authority_chunk[..count]);
-                        drain_stream_frames(&mut authority_buf, start, &events_tx).await;
-                    }
-                    Ok(None) => {
-                        warn!("authority-events stream closed; stopping receiver");
-                        return;
+            accepted = connection.accept_uni() => {
+                match accepted {
+                    Ok(uni) => {
+                        uni_streams.spawn(uni_stream::read_one_uni_stream(
+                            uni,
+                            start,
+                            events_tx.clone(),
+                            Arc::clone(&dropped_events),
+                        ));
                     }
                     Err(source) => {
-                        warn!(%source, "authority-events stream read failed; stopping receiver");
-                        return;
+                        warn!(%source, "stopped accepting uni streams");
+                        break;
                     }
+                }
+            }
+            Some(joined) = uni_streams.join_next(), if !uni_streams.is_empty() => {
+                if let Err(error) = joined {
+                    warn!(%error, "uni-stream reader task panicked");
                 }
             }
         }
     }
+    uni_streams.shutdown().await;
 }
 
 /// Decodes one datagram and forwards it as the matching [`ReceiverEvent`],
@@ -139,18 +201,15 @@ async fn receiver_loop(
 /// the host's `to_connection_message`/`RejectFrame` handling), distinguished
 /// only by the envelope's payload arm — so this routes on that arm rather
 /// than assuming every datagram is telemetry.
-async fn handle_datagram(
+fn handle_datagram(
     datagram: &wtransport::datagram::Datagram,
     start: std::time::Instant,
     events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
 ) {
     let received_at = elapsed_to_timestamp(start.elapsed());
     match decode_datagram_event(&datagram.payload(), received_at) {
-        Ok(event) => {
-            if events_tx.send(event).await.is_err() {
-                warn!("event channel closed while forwarding datagram event");
-            }
-        }
+        Ok(event) => forward_event(events_tx, dropped_events, event),
         Err(source) => warn!(%source, "dropping undecodable datagram"),
     }
 }
@@ -198,16 +257,17 @@ fn decode_datagram_event(
 /// the bidi stream, forwarding `FrameRejected`/`Pong` and warning on
 /// anything else; leaves a trailing partial frame in `buf` for the next
 /// read.
-async fn drain_stream_frames(
+fn drain_stream_frames(
     buf: &mut Vec<u8>,
     start: std::time::Instant,
     events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
 ) {
     loop {
         match decode_one(buf) {
             Ok((message, consumed)) => {
                 buf.drain(..consumed);
-                forward_stream_message(message, start, events_tx).await;
+                forward_stream_message(message, start, events_tx, dropped_events);
             }
             Err(_) => return,
         }
@@ -217,10 +277,11 @@ async fn drain_stream_frames(
 /// Maps a decoded [`StreamMessage`] onto the [`ReceiverEvent`]s this probe
 /// forwards to the run loop, discarding (with a warning) message kinds it
 /// has no use for.
-async fn forward_stream_message(
+fn forward_stream_message(
     message: StreamMessage,
     start: std::time::Instant,
     events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
 ) {
     let event = match message {
         StreamMessage::FrameRejected(rejected) => ReceiverEvent::FrameRejected(rejected),
@@ -234,9 +295,7 @@ async fn forward_stream_message(
             return;
         }
     };
-    if events_tx.send(event).await.is_err() {
-        warn!("event channel closed while forwarding stream message");
-    }
+    forward_event(events_tx, dropped_events, event);
 }
 
 #[cfg(test)]

--- a/tools/loopback-probe/src/receiver/uni_stream.rs
+++ b/tools/loopback-probe/src/receiver/uni_stream.rs
@@ -1,0 +1,198 @@
+//! Reading of host-initiated unidirectional streams (ADR-0005): the dedicated
+//! authority-events stream and the per-frame video streams.
+//!
+//! Every host-initiated uni stream leads with a 1-byte kind tag; each accepted
+//! stream is read to completion by a short-lived task so a slow video decode
+//! never blocks accepting the next stream. The authority-events stream stays
+//! open for the connection's lifetime (repeated length-delimited envelopes); a
+//! video-frame stream carries exactly one `[fourcc][u32 LE len][jpeg]` body
+//! (ADR-0016) and closes.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+use tracing::warn;
+use wtransport::RecvStream;
+
+use super::{ReceiverEvent, drain_stream_frames, forward_event};
+
+/// Kind tag prefixing the host's authority-events uni stream (ADR-0005).
+const AUTHORITY_EVENTS_TAG: u8 = 0x01;
+/// Kind tag prefixing a per-frame video uni stream (ADR-0005).
+const VIDEO_FRAME_TAG: u8 = 0x02;
+
+/// Reads exactly one host-initiated uni stream to completion: the leading
+/// kind-tag byte, then the tag-specific body, forwarding the decoded
+/// [`ReceiverEvent`]s. The authority-events stream stays open for the
+/// connection's lifetime and is read incrementally (repeated envelopes); a
+/// video-frame stream carries exactly one framed JPEG and then closes.
+pub(super) async fn read_one_uni_stream(
+    mut stream: RecvStream,
+    start: Instant,
+    events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
+) {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    let Some(tag) = read_kind_tag(&mut stream, &mut buf, &mut chunk).await else {
+        return;
+    };
+    match tag {
+        AUTHORITY_EVENTS_TAG => {
+            read_authority_stream(stream, buf, chunk, start, events_tx, dropped_events).await;
+        }
+        VIDEO_FRAME_TAG => read_video_stream(stream, buf, chunk, events_tx, dropped_events).await,
+        other => warn!(
+            tag = other,
+            "unrecognized uni-stream kind tag; dropping stream"
+        ),
+    }
+}
+
+/// Reads bytes until at least one is available, then returns the leading
+/// kind-tag byte, leaving any further bytes already read in `buf`.
+async fn read_kind_tag(stream: &mut RecvStream, buf: &mut Vec<u8>, chunk: &mut [u8]) -> Option<u8> {
+    while buf.is_empty() {
+        match stream.read(chunk).await {
+            Ok(Some(count)) => buf.extend_from_slice(&chunk[..count]),
+            Ok(None) => {
+                warn!("uni stream closed before its kind tag arrived");
+                return None;
+            }
+            Err(source) => {
+                warn!(%source, "uni stream read failed before its kind tag arrived");
+                return None;
+            }
+        }
+    }
+    Some(buf.remove(0))
+}
+
+/// Reads the dedicated authority-events stream for the remainder of its
+/// (connection-lifetime) duration, decoding and forwarding every
+/// length-delimited envelope as it arrives.
+async fn read_authority_stream(
+    mut stream: RecvStream,
+    mut buf: Vec<u8>,
+    mut chunk: [u8; 64 * 1024],
+    start: Instant,
+    events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
+) {
+    drain_stream_frames(&mut buf, start, &events_tx, &dropped_events);
+    loop {
+        match stream.read(&mut chunk).await {
+            Ok(Some(count)) => {
+                buf.extend_from_slice(&chunk[..count]);
+                drain_stream_frames(&mut buf, start, &events_tx, &dropped_events);
+            }
+            Ok(None) => {
+                warn!("authority-events stream closed");
+                return;
+            }
+            Err(source) => {
+                warn!(%source, "authority-events stream read failed");
+                return;
+            }
+        }
+    }
+}
+
+/// FourCC of the only video codec this viewer decodes: Motion JPEG (ADR-0016).
+const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
+
+/// Reads one video-frame stream to completion (`[fourcc][u32 LE len][payload]`,
+/// ADR-0016), then forwards the JPEG bytes as a single
+/// [`ReceiverEvent::VideoFrame`]. A frame whose FourCC is not [`FOURCC_MJPEG`]
+/// is skipped with a warning, never a hard failure, so a host streaming a
+/// codec this viewer lacks degrades gracefully.
+async fn read_video_stream(
+    mut stream: RecvStream,
+    mut buf: Vec<u8>,
+    mut chunk: [u8; 64 * 1024],
+    events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
+) {
+    loop {
+        if let Some((fourcc, payload)) = try_take_video_payload(&mut buf) {
+            if fourcc != FOURCC_MJPEG {
+                warn!(
+                    codec = %String::from_utf8_lossy(&fourcc),
+                    "unknown video codec FourCC; skipping frame"
+                );
+                return;
+            }
+            forward_event(
+                &events_tx,
+                &dropped_events,
+                ReceiverEvent::VideoFrame { jpeg: payload },
+            );
+            return;
+        }
+        match stream.read(&mut chunk).await {
+            Ok(Some(count)) => buf.extend_from_slice(&chunk[..count]),
+            Ok(None) => {
+                warn!("video-frame stream closed before a complete frame arrived");
+                return;
+            }
+            Err(source) => {
+                warn!(%source, "video-frame stream read failed");
+                return;
+            }
+        }
+    }
+}
+
+/// Parses a `[fourcc: 4 bytes][u32 LE len][payload]` body (ADR-0016) once
+/// `buf` holds the declared length in full, returning the `(fourcc, payload)`
+/// pair and leaving `buf` empty. Returns `None` if fewer than the 8-byte
+/// fourcc+length header, or fewer than the declared payload length, have
+/// arrived yet.
+fn try_take_video_payload(buf: &mut Vec<u8>) -> Option<([u8; 4], Vec<u8>)> {
+    const HEADER: usize = 8;
+    if buf.len() < HEADER {
+        return None;
+    }
+    let fourcc = [buf[0], buf[1], buf[2], buf[3]];
+    let declared = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    let declared = usize::try_from(declared).ok()?;
+    if buf.len() < HEADER + declared {
+        return None;
+    }
+    let payload = buf[HEADER..HEADER + declared].to_vec();
+    buf.drain(..HEADER + declared);
+    Some((fourcc, payload))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{FOURCC_MJPEG, try_take_video_payload};
+
+    #[test]
+    fn video_payload_waits_for_full_declared_length() {
+        // [MJPG][len=3][1,2] — one payload byte still missing.
+        let mut buf = vec![b'M', b'J', b'P', b'G', 3, 0, 0, 0, 1, 2];
+        assert_eq!(
+            try_take_video_payload(&mut buf),
+            None,
+            "only 2 of 3 payload bytes present"
+        );
+        buf.push(3);
+        let (codec, jpeg) = try_take_video_payload(&mut buf).expect("full frame present");
+        assert_eq!(codec, FOURCC_MJPEG);
+        assert_eq!(jpeg, vec![1, 2, 3]);
+        assert!(buf.is_empty(), "consumed bytes are drained");
+    }
+
+    #[test]
+    fn video_payload_leaves_trailing_bytes_for_the_next_frame() {
+        // [MJPG][len=1][0xAB] then the start of a second frame.
+        let mut buf = vec![b'M', b'J', b'P', b'G', 1, 0, 0, 0, 0xAB, b'M', b'J'];
+        let (_, first) = try_take_video_payload(&mut buf).expect("first frame present");
+        assert_eq!(first, vec![0xAB]);
+        assert_eq!(buf, vec![b'M', b'J']);
+    }
+}

--- a/tools/loopback-probe/src/run.rs
+++ b/tools/loopback-probe/src/run.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use pilotage_protocol::{ScopedControlFrame, SequenceNum, VehicleId};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
-use wtransport::{Connection, RecvStream};
+use wtransport::Connection;
 
 use crate::cli::Args;
 use crate::error::ProbeError;
@@ -15,6 +15,7 @@ use crate::receiver::{ReceiverEvent, spawn_receiver};
 use crate::sender::run_send_loop;
 use crate::summary::print_summary;
 use crate::transport::{client_endpoint, connect, handshake, validate_loopback_url};
+use crate::video::VideoStats;
 
 /// The vehicle this probe always targets; this tool has no per-run vehicle
 /// selection flag (out of scope per the task), so a fixed id keeps the
@@ -26,8 +27,10 @@ const PROBE_VEHICLE: VehicleId = VehicleId::new(1);
 const HISTOGRAM_CAPACITY: usize = 100_000;
 /// Bounded channel capacity between the receiver task and the run loop;
 /// sized so a burst of telemetry does not need unbounded buffering. A full
-/// channel drops the oldest-pending event and counts it (ADR-0015: a
-/// lagging consumer is a correctness signal, not silent).
+/// channel drops the newly arrived event via `try_send` and counts it
+/// (`receiver::forward_event`) rather than blocking delivery of everything
+/// queued behind a slow consumer (ADR-0015: a lagging consumer is a
+/// correctness signal, not silent).
 const EVENT_CHANNEL_CAPACITY: usize = 4096;
 
 /// Runs the full probe: connect, handshake, timed send/receive loop, the
@@ -54,11 +57,6 @@ pub async fn run(args: &Args) -> Result<(), ProbeError> {
         "vehicle.motion lease granted"
     );
 
-    // The host opens a dedicated uni stream toward the client for reliable
-    // ordered authority events (ADR-0005); accept it so those events are read
-    // off their own stream rather than left unserviced.
-    let authority_stream = accept_authority_stream(&connection).await?;
-
     // The send loop and the receiver task must stamp send and receive
     // timestamps from the same monotonic origin (ADR-0009): the metrics
     // subtract them with a zero clock offset, so a second `Instant` origin in
@@ -67,15 +65,14 @@ pub async fn run(args: &Args) -> Result<(), ProbeError> {
     let run_start = Instant::now();
 
     let (events_tx, mut events_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
-    let receiver_handle = spawn_receiver(
-        connection.clone(),
-        recv_stream,
-        authority_stream,
-        run_start,
-        events_tx,
-    );
+    // The receiver task accepts every host-initiated uni stream itself (the
+    // dedicated authority-events stream plus one fresh stream per video
+    // frame, ADR-0005), so no uni stream is accepted here.
+    let (receiver_handle, dropped_events) =
+        spawn_receiver(connection.clone(), recv_stream, run_start, events_tx);
 
     let mut metrics = RunMetrics::new(HISTOGRAM_CAPACITY);
+    let mut video = VideoStats::new();
     let session = outcome.welcome.session;
     let generation = outcome.lease.generation;
     let run_budget = Duration::from_secs(args.seconds);
@@ -89,6 +86,7 @@ pub async fn run(args: &Args) -> Result<(), ProbeError> {
         run_budget,
         &mut events_rx,
         &mut metrics,
+        &mut video,
     )
     .await?;
 
@@ -100,35 +98,26 @@ pub async fn run(args: &Args) -> Result<(), ProbeError> {
         run_start,
         &mut events_rx,
         &mut metrics,
+        &mut video,
     )
     .await;
 
-    drain_pending_events(&mut events_rx, &mut metrics);
+    drain_pending_events(&mut events_rx, &mut metrics, &mut video);
     receiver_handle.abort();
+    metrics.dropped_events = dropped_events.load(std::sync::atomic::Ordering::Relaxed);
 
-    print_summary(&metrics, fencing_confirmed);
+    if let Some(dir) = &args.save_frames {
+        crate::save_frames::save_proof_frames(&video, dir).await;
+    }
+
+    print_summary(&metrics, &video, run_start.elapsed(), fencing_confirmed);
     Ok(())
-}
-
-/// Accepts the host's dedicated authority-events uni stream (ADR-0005).
-///
-/// # Errors
-///
-/// Returns [`ProbeError::BidiStream`] if the stream cannot be accepted; the
-/// host opens it immediately after the connection is established, so a failure
-/// here means the session did not come up as expected.
-async fn accept_authority_stream(connection: &Connection) -> Result<RecvStream, ProbeError> {
-    connection
-        .accept_uni()
-        .await
-        .map_err(|source| ProbeError::BidiStream {
-            message: format!("authority-events stream not accepted: {source}"),
-        })
 }
 
 /// Sends one control frame carrying a generation strictly older than the
 /// lease's granted generation, then waits briefly for the matching
 /// `FrameRejected` as end-to-end fencing proof.
+#[allow(clippy::too_many_arguments)]
 async fn send_stale_generation_probe(
     connection: &Connection,
     session: pilotage_protocol::SessionId,
@@ -137,6 +126,7 @@ async fn send_stale_generation_probe(
     run_start: Instant,
     events_rx: &mut mpsc::Receiver<ReceiverEvent>,
     metrics: &mut RunMetrics,
+    video: &mut VideoStats,
 ) -> bool {
     let stale_generation =
         pilotage_protocol::Generation::new(current_generation.as_u64().wrapping_sub(1));
@@ -158,19 +148,21 @@ async fn send_stale_generation_probe(
     }
     metrics.frames_sent = metrics.frames_sent.saturating_add(1);
 
-    wait_for_rejection(events_rx, stale_sequence, metrics).await
+    wait_for_rejection(events_rx, stale_sequence, metrics, video).await
 }
 
 /// Waits up to a short fixed deadline for a `FrameRejected` matching
 /// `sequence` to arrive on the receiver channel, folding it (and any other
-/// event observed while waiting) into `metrics`.
+/// event observed while waiting) into `metrics`/`video`.
 async fn wait_for_rejection(
     events_rx: &mut mpsc::Receiver<ReceiverEvent>,
     sequence: SequenceNum,
     metrics: &mut RunMetrics,
+    video: &mut VideoStats,
 ) -> bool {
     const FENCING_WAIT: Duration = Duration::from_millis(500);
     let deadline = Instant::now() + FENCING_WAIT;
+    let mut last_video_at: Option<Instant> = None;
     loop {
         let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
             return false;
@@ -182,8 +174,12 @@ async fn wait_for_rejection(
                     return true;
                 }
             }
-            Ok(Some(ReceiverEvent::Telemetry(_))) => {
+            Ok(Some(ReceiverEvent::Telemetry(observation))) => {
                 metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
+                metrics.last_pose = Some(observation.pose);
+            }
+            Ok(Some(ReceiverEvent::VideoFrame { jpeg, .. })) => {
+                fold_video_frame(&jpeg, video, &mut last_video_at);
             }
             Ok(Some(ReceiverEvent::Pong { .. } | ReceiverEvent::Authority)) | Err(_) => {}
             Ok(None) => return false,
@@ -192,18 +188,39 @@ async fn wait_for_rejection(
 }
 
 /// Drains any events still queued after the run loop and fencing probe
-/// finish, folding trailing telemetry/rejection counts into `metrics`
-/// rather than discarding them silently.
-fn drain_pending_events(events_rx: &mut mpsc::Receiver<ReceiverEvent>, metrics: &mut RunMetrics) {
+/// finish, folding trailing telemetry/rejection/video counts into
+/// `metrics`/`video` rather than discarding them silently.
+fn drain_pending_events(
+    events_rx: &mut mpsc::Receiver<ReceiverEvent>,
+    metrics: &mut RunMetrics,
+    video: &mut VideoStats,
+) {
+    let mut last_video_at: Option<Instant> = None;
     while let Ok(event) = events_rx.try_recv() {
         match event {
-            ReceiverEvent::Telemetry(_) => {
+            ReceiverEvent::Telemetry(observation) => {
                 metrics.telemetry_received = metrics.telemetry_received.wrapping_add(1);
+                metrics.last_pose = Some(observation.pose);
             }
             ReceiverEvent::FrameRejected(_) => {
                 metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
             }
+            ReceiverEvent::VideoFrame { jpeg, .. } => {
+                fold_video_frame(&jpeg, video, &mut last_video_at);
+            }
             ReceiverEvent::Pong { .. } | ReceiverEvent::Authority => {}
         }
     }
+}
+
+/// Folds one arrived video frame into `video`, recording the inter-arrival
+/// gap against `last_video_at` (this call's own local timing, independent of
+/// the frame's `received_at` field — both derive from the same wall clock, so
+/// either would do; this uses a plain `Instant` since the gap is all that
+/// matters here, not an absolute timestamp).
+fn fold_video_frame(jpeg: &[u8], video: &mut VideoStats, last_video_at: &mut Option<Instant>) {
+    let now = Instant::now();
+    let gap = last_video_at.map(|previous| now.duration_since(previous));
+    *last_video_at = Some(now);
+    video.record(jpeg, gap);
 }

--- a/tools/loopback-probe/src/save_frames.rs
+++ b/tools/loopback-probe/src/save_frames.rs
@@ -1,0 +1,36 @@
+//! `--save-frames DIR`: writes the first, a middle, and the last decoded
+//! video frame as PNG files, giving visual proof the video downlink carried
+//! real, decodable camera frames.
+
+use tracing::warn;
+
+use crate::video::VideoStats;
+
+/// Saves whichever of the first/middle/last decoded frames `video` retained,
+/// as `first.png`, `middle.png`, and `last.png` under `dir`. Best-effort: a
+/// missing frame (e.g. no video arrived at all) or a save failure only logs a
+/// warning, since this is proof output, not a step the run's success depends
+/// on.
+pub async fn save_proof_frames(video: &VideoStats, dir: &str) {
+    let dir = std::path::Path::new(dir);
+    save_one(video.first_frame.as_ref(), &dir.join("first.png"), "first").await;
+    save_one(
+        video.middle_frame.as_ref(),
+        &dir.join("middle.png"),
+        "middle",
+    )
+    .await;
+    save_one(video.last_frame.as_ref(), &dir.join("last.png"), "last").await;
+}
+
+/// Saves one optional frame, logging a warning instead of failing the run if
+/// the frame is absent or the save itself fails.
+async fn save_one(frame: Option<&crate::video::DecodedFrame>, path: &std::path::Path, label: &str) {
+    let Some(frame) = frame else {
+        warn!(label, "no frame available to save (no video decoded yet)");
+        return;
+    };
+    if let Err(message) = crate::video::save_frame_png(frame, path).await {
+        warn!(label, %message, "failed to save proof frame");
+    }
+}

--- a/tools/loopback-probe/src/sender.rs
+++ b/tools/loopback-probe/src/sender.rs
@@ -18,11 +18,13 @@ use wtransport::Connection;
 
 use crate::cli::Args;
 use crate::control_source::{HidSource, elapsed_to_timestamp};
+use crate::drive;
 use crate::error::ProbeError;
 use crate::metrics::RunMetrics;
 use crate::pipeline::{Pipeline, load_radiomaster_pocket_profile};
 use crate::receiver::ReceiverEvent;
 use crate::synthetic;
+use crate::video::VideoStats;
 use crate::wire_session::encode_ping_datagram;
 
 /// Ping cadence: independent of the control-frame rate since RTT tracking
@@ -54,6 +56,12 @@ const PENDING_QUEUE_CAPACITY: usize = 1024;
 struct SendLoopState {
     hid_source: Option<HidSource>,
     pipeline: Option<Pipeline>,
+    /// Whether this run sends the `--drive` scripted forward-then-arc
+    /// pattern instead of HID input or the default synthetic sine wave.
+    drive: bool,
+    /// The run's total time budget, needed by the `--drive` script to decide
+    /// which half of the run it is in.
+    run_budget: Duration,
     sequence: SequenceNum,
     pending: VecDeque<PendingFrame>,
     last_pose: Option<(f32, f32, f32)>,
@@ -64,6 +72,9 @@ struct SendLoopState {
     /// matched (see `handle_event`).
     last_telemetry_at: Option<pilotage_timing::MonoTimestamp>,
     ping_nonce: u64,
+    /// Wall-clock instant of the most recent video-frame arrival, so
+    /// consecutive frames' inter-arrival gap is recorded into `VideoStats`.
+    last_video_at: Option<Instant>,
 }
 
 /// Runs the timed send loop for `args.seconds` at `args.rate` Hz, folding
@@ -84,19 +95,26 @@ pub async fn run_send_loop(
     run_budget: Duration,
     events_rx: &mut mpsc::Receiver<ReceiverEvent>,
     metrics: &mut RunMetrics,
+    video: &mut VideoStats,
 ) -> Result<SequenceNum, ProbeError> {
+    // `--drive` takes precedence over `--hid`: it is this tool's deliberate
+    // "move the real vehicle" demo mode, so a HID device (present or absent)
+    // never overrides it.
+    let hid_active = args.hid && !args.drive;
     let mut state = SendLoopState {
-        hid_source: args.hid.then(|| HidSource::open(run_start)).transpose()?,
-        pipeline: args
-            .hid
+        hid_source: hid_active.then(|| HidSource::open(run_start)).transpose()?,
+        pipeline: hid_active
             .then(load_radiomaster_pocket_profile)
             .transpose()?
             .map(Pipeline::new),
+        drive: args.drive,
+        run_budget,
         sequence: SequenceNum::new(0),
         pending: VecDeque::new(),
         last_pose: None,
         last_telemetry_at: None,
         ping_nonce: 0,
+        last_video_at: None,
     };
 
     let period = Duration::from_secs(1)
@@ -116,7 +134,7 @@ pub async fn run_send_loop(
                 send_ping(connection, run_start, &mut state);
             }
             Some(event) = events_rx.recv() => {
-                handle_event(event, &mut state, metrics);
+                handle_event(event, &mut state, metrics, video, run_start.elapsed());
             }
         }
     }
@@ -172,11 +190,16 @@ fn send_one_frame(
 const MOTION_SCOPE_AXES: [u16; 2] = [2, 3];
 
 /// Produces this tick's payload and profile revision from whichever source
-/// is active (`--hid` or the synthetic sine generator).
+/// is active: `--drive`'s scripted pattern, `--hid`, or the default synthetic
+/// sine generator, in that precedence order (see `run_send_loop`).
 fn build_payload(
     state: &mut SendLoopState,
     run_start: Instant,
 ) -> Result<(ControlPayload, u32), ProbeError> {
+    if state.drive {
+        let payload = drive::payload_at(run_start.elapsed(), state.run_budget)?;
+        return Ok((payload, 0));
+    }
     match (&mut state.hid_source, &mut state.pipeline) {
         (Some(source), Some(pipeline)) => {
             let sample = source.sample()?;
@@ -217,11 +240,17 @@ fn send_ping(connection: &Connection, run_start: Instant, state: &mut SendLoopSt
     }
 }
 
-/// Folds one receiver-task event into `metrics`. Telemetry pose changes are
-/// matched against the earliest frame sent *after* the previous telemetry
-/// sample; rejections and pongs are handled independently of the pending
-/// queue.
-fn handle_event(event: ReceiverEvent, state: &mut SendLoopState, metrics: &mut RunMetrics) {
+/// Folds one receiver-task event into `metrics`/`video`. Telemetry pose
+/// changes are matched against the earliest frame sent *after* the previous
+/// telemetry sample; rejections and pongs are handled independently of the
+/// pending queue; video frames are decoded and folded into `video`.
+fn handle_event(
+    event: ReceiverEvent,
+    state: &mut SendLoopState,
+    metrics: &mut RunMetrics,
+    video: &mut VideoStats,
+    elapsed: Duration,
+) {
     match event {
         ReceiverEvent::Telemetry(observation) => {
             metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
@@ -233,6 +262,14 @@ fn handle_event(event: ReceiverEvent, state: &mut SendLoopState, metrics: &mut R
         ReceiverEvent::Pong { pong, received_at } => {
             let rtt = estimated_age(received_at, pong.echoed_sender_sent_at, ZERO_OFFSET);
             metrics.rtt.record(rtt);
+        }
+        ReceiverEvent::VideoFrame { jpeg, .. } => {
+            let now = Instant::now();
+            let gap = state
+                .last_video_at
+                .map(|previous| now.duration_since(previous));
+            state.last_video_at = Some(now);
+            video.record_at(&jpeg, gap, Some((elapsed, state.run_budget)));
         }
         ReceiverEvent::Authority => {}
     }
@@ -267,6 +304,7 @@ fn fold_telemetry(
         }
     }
     let changed = state.last_pose.replace(observation.pose) != Some(observation.pose);
+    metrics.last_pose = Some(observation.pose);
     if changed && let Some(frame) = state.pending.pop_front() {
         let age = estimated_age(observation.received_at, frame.sent_at, ZERO_OFFSET);
         metrics.control_to_telemetry.record(age);

--- a/tools/loopback-probe/src/summary.rs
+++ b/tools/loopback-probe/src/summary.rs
@@ -5,11 +5,18 @@ use std::time::Duration;
 
 use crate::metrics::RunMetrics;
 use crate::output::print_line;
+use crate::video::VideoStats;
 
 /// Prints the full end-of-run summary: control-to-telemetry latency
-/// percentiles, Ping/Pong RTT, frame counters, telemetry received, and the
-/// outcome of the deliberate stale-generation fencing probe.
-pub fn print_summary(metrics: &RunMetrics, fencing_confirmed: bool) {
+/// percentiles, Ping/Pong RTT, frame counters, telemetry received, video
+/// downlink statistics, and the outcome of the deliberate stale-generation
+/// fencing probe.
+pub fn print_summary(
+    metrics: &RunMetrics,
+    video: &VideoStats,
+    elapsed: Duration,
+    fencing_confirmed: bool,
+) {
     print_line("=== loopback-probe summary ===");
     print_control_latency(metrics);
     print_rtt(metrics);
@@ -24,6 +31,12 @@ pub fn print_summary(metrics: &RunMetrics, fencing_confirmed: bool) {
         metrics.telemetry_received
     ));
     print_line(&format!(
+        "events dropped (channel full): {}",
+        metrics.dropped_events
+    ));
+    print_final_pose(metrics);
+    print_video(video, elapsed);
+    print_line(&format!(
         "end-to-end fencing:  {}",
         if fencing_confirmed {
             "CONFIRMED (stale-generation frame was rejected)"
@@ -31,6 +44,43 @@ pub fn print_summary(metrics: &RunMetrics, fencing_confirmed: bool) {
             "NOT CONFIRMED (no FrameRejected observed for the stale probe frame)"
         }
     ));
+}
+
+/// Prints the vehicle's final observed pose, or a placeholder if no
+/// telemetry arrived.
+fn print_final_pose(metrics: &RunMetrics) {
+    match metrics.last_pose {
+        Some((x, y, heading)) => print_line(&format!(
+            "final pose:          x={x:.3}m y={y:.3}m heading={heading:.3}rad"
+        )),
+        None => print_line("final pose:          no telemetry observed"),
+    }
+}
+
+/// Prints the video downlink section: frames received/decoded/failed,
+/// average fps, decoded dimensions, and inter-arrival latency percentiles.
+fn print_video(video: &VideoStats, elapsed: Duration) {
+    print_line(&format!(
+        "video frames received: {} (decoded {}, decode failed {})",
+        video.frames_received, video.frames_decoded, video.frames_decode_failed
+    ));
+    match video.avg_fps(elapsed) {
+        Some(fps) => print_line(&format!("video avg fps:       {fps:.2}")),
+        None => print_line("video avg fps:       no frames decoded"),
+    }
+    match video.last_dims {
+        Some((w, h)) => print_line(&format!("video dimensions:    {w}x{h}")),
+        None => print_line("video dimensions:    n/a"),
+    }
+    match video.inter_arrival.percentiles() {
+        Some((p50, p95, max)) => print_line(&format!(
+            "video inter-arrival: p50={} p95={} max={}",
+            fmt_duration(p50),
+            fmt_duration(p95),
+            fmt_duration(max)
+        )),
+        None => print_line("video inter-arrival: no samples observed"),
+    }
 }
 
 fn print_control_latency(metrics: &RunMetrics) {

--- a/tools/loopback-probe/src/transport.rs
+++ b/tools/loopback-probe/src/transport.rs
@@ -143,13 +143,15 @@ pub async fn handshake(
 > {
     let (mut send, mut recv) = open_bidi(connection).await?;
 
+    let mut buf = Vec::new();
+
     let hello = ClientHello {
         protocol_version: CLIENT_PROTOCOL_VERSION,
         client_name: CLIENT_NAME.to_string(),
         join_token: Vec::new(),
     };
     write_frame(&mut send, &encode_client_hello(&hello)).await?;
-    let welcome = match read_message(&mut recv).await? {
+    let welcome = match read_message(&mut recv, &mut buf).await? {
         StreamMessage::ServerWelcome(welcome) => welcome,
         other => {
             return Err(ProbeError::Protocol {
@@ -161,7 +163,7 @@ pub async fn handshake(
     let scope = ScopeId::new("vehicle.motion");
     let request = LeaseRequest { vehicle, scope };
     write_frame(&mut send, &encode_lease_request(&request)).await?;
-    let lease = match read_message(&mut recv).await? {
+    let lease = match read_message(&mut recv, &mut buf).await? {
         StreamMessage::LeaseResponse(response) => response,
         other => {
             return Err(ProbeError::Protocol {
@@ -207,13 +209,20 @@ async fn write_frame(send: &mut wtransport::SendStream, frame: &[u8]) -> Result<
 /// Reads bytes from the bidi recv stream until one full envelope frame is
 /// available, decodes it, and returns the typed message.
 ///
-/// Handshake replies are small and this stream carries nothing else during
-/// the handshake, so a single `read` call is expected to return a complete
-/// frame; this loops only to tolerate a reply split across two reads.
-async fn read_message(recv: &mut wtransport::RecvStream) -> Result<StreamMessage, ProbeError> {
-    let mut buf = Vec::new();
+/// `buf` is the caller's persisted reassembly buffer, carried across calls:
+/// a `recv.read()` can return more than one envelope's worth of bytes (e.g.
+/// `ServerWelcome` and a following `LeaseResponse` arriving in the same
+/// read), and any bytes trailing the decoded envelope must survive for the
+/// next call rather than be dropped with a fresh empty buffer, or the
+/// trailing message would be silently lost (mirrors `receiver.rs`'s
+/// `stream_buf` reassembly).
+async fn read_message(
+    recv: &mut wtransport::RecvStream,
+    buf: &mut Vec<u8>,
+) -> Result<StreamMessage, ProbeError> {
     loop {
-        if let Ok((message, _consumed)) = decode_one(&buf) {
+        if let Ok((message, consumed)) = decode_one(buf) {
+            buf.drain(..consumed);
             return Ok(message);
         }
         let mut chunk = [0u8; STREAM_READ_BUF_LEN];

--- a/tools/loopback-probe/src/video.rs
+++ b/tools/loopback-probe/src/video.rs
@@ -1,0 +1,262 @@
+//! Decodes MJPEG video frames received on host-initiated uni streams
+//! (ADR-0005 media = one uni stream per frame) and tracks the run's video
+//! statistics: frame count, decoded dimensions, and arrival-to-display
+//! latency.
+//!
+//! Decode uses the `image` crate's JPEG decoder; this binary owns I/O and
+//! decode work (ADR-0002 sans-IO applies only to `crates/`).
+
+use std::time::Duration;
+
+use image::ImageFormat;
+use tracing::warn;
+
+use crate::metrics::Histogram;
+
+/// One decoded video frame this probe has received, cheap enough to keep the
+/// first/middle/last copies around for `--save-frames` without re-decoding.
+#[derive(Clone)]
+pub struct DecodedFrame {
+    /// Decoded pixel width.
+    pub width: u32,
+    /// Decoded pixel height.
+    pub height: u32,
+    /// Decoded RGB8 pixel buffer, row-major, no padding.
+    pub rgb: Vec<u8>,
+}
+
+/// Decodes one JPEG byte buffer into a [`DecodedFrame`].
+///
+/// Returns `None` (and logs) on a malformed JPEG, so one bad frame is skipped
+/// rather than aborting the run.
+#[must_use]
+pub fn decode_jpeg(bytes: &[u8]) -> Option<DecodedFrame> {
+    match image::load_from_memory_with_format(bytes, ImageFormat::Jpeg) {
+        Ok(image) => {
+            let rgb = image.to_rgb8();
+            let (width, height) = rgb.dimensions();
+            Some(DecodedFrame {
+                width,
+                height,
+                rgb: rgb.into_raw(),
+            })
+        }
+        Err(source) => {
+            warn!(%source, "dropping undecodable video frame");
+            None
+        }
+    }
+}
+
+/// Running video statistics accumulated over a probe run.
+pub struct VideoStats {
+    /// JPEG byte buffers received (whether or not they decoded).
+    pub frames_received: u64,
+    /// Frames that decoded successfully.
+    pub frames_decoded: u64,
+    /// Frames that failed to decode.
+    pub frames_decode_failed: u64,
+    /// Arrival-to-decoded-display latency, measured from the client's own
+    /// clock: the gap between this frame's uni stream finishing and the
+    /// previous frame's, i.e. inter-arrival time, folded into a histogram so
+    /// p50/p95/max frame cadence is reportable alongside true fps.
+    pub inter_arrival: Histogram,
+    /// Decoded width/height of the most recently decoded frame, if any.
+    pub last_dims: Option<(u32, u32)>,
+    /// The first successfully decoded frame, retained for `--save-frames`.
+    pub first_frame: Option<DecodedFrame>,
+    /// The most recently decoded frame; at run end this is also the "last"
+    /// frame for `--save-frames`.
+    pub last_frame: Option<DecodedFrame>,
+    /// A frame decoded roughly at the run's midpoint, for `--save-frames`.
+    /// Updated by the caller (which knows the run's time budget), not by this
+    /// module, since `VideoStats` has no notion of run duration.
+    pub middle_frame: Option<DecodedFrame>,
+}
+
+/// Latency-histogram capacity for inter-arrival timing: comfortably above any
+/// realistic frame count for a short demo run.
+const VIDEO_HISTOGRAM_CAPACITY: usize = 10_000;
+
+impl VideoStats {
+    /// Constructs an empty video-stats accumulator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            frames_received: 0,
+            frames_decoded: 0,
+            frames_decode_failed: 0,
+            inter_arrival: Histogram::new(VIDEO_HISTOGRAM_CAPACITY),
+            last_dims: None,
+            first_frame: None,
+            last_frame: None,
+            middle_frame: None,
+        }
+    }
+
+    /// Folds one arrived JPEG buffer into the stats: decodes it, records
+    /// inter-arrival latency against `since_last`, and updates the retained
+    /// first/last frames.
+    pub fn record(&mut self, jpeg: &[u8], since_last: Option<Duration>) {
+        self.record_at(jpeg, since_last, None);
+    }
+
+    /// Like [`Self::record`], additionally capturing this frame as the
+    /// retained "middle" frame (for `--save-frames`) when `run_progress` is
+    /// supplied and reports the run is past its halfway point for the first
+    /// time. `run_progress` is `(elapsed, total_budget)`.
+    pub fn record_at(
+        &mut self,
+        jpeg: &[u8],
+        since_last: Option<Duration>,
+        run_progress: Option<(Duration, Duration)>,
+    ) {
+        self.frames_received = self.frames_received.saturating_add(1);
+        let Some(frame) = decode_jpeg(jpeg) else {
+            self.frames_decode_failed = self.frames_decode_failed.saturating_add(1);
+            return;
+        };
+        self.frames_decoded = self.frames_decoded.saturating_add(1);
+        self.last_dims = Some((frame.width, frame.height));
+        if let Some(gap) = since_last {
+            self.inter_arrival.record(gap);
+        }
+        if self.first_frame.is_none() {
+            self.first_frame = Some(frame.clone());
+        }
+        if self.middle_frame.is_none()
+            && let Some((elapsed, total)) = run_progress
+            && elapsed >= total / 2
+        {
+            self.middle_frame = Some(frame.clone());
+        }
+        self.last_frame = Some(frame);
+    }
+
+    /// Average frames-per-second over `elapsed`, or `None` if no frames
+    /// decoded or `elapsed` is zero.
+    #[must_use]
+    pub fn avg_fps(&self, elapsed: Duration) -> Option<f64> {
+        if self.frames_decoded == 0 || elapsed.is_zero() {
+            return None;
+        }
+        Some(self.frames_decoded as f64 / elapsed.as_secs_f64())
+    }
+}
+
+impl Default for VideoStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Saves `frame` as a PNG file at `path`, creating parent directories as
+/// needed.
+///
+/// # Errors
+///
+/// Returns a formatted error string on I/O or encode failure; this tool's
+/// video-save path is best-effort proof output, not a correctness-critical
+/// step, so callers log and continue rather than aborting the run.
+pub async fn save_frame_png(frame: &DecodedFrame, path: &std::path::Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|source| format!("creating {}: {source}", parent.display()))?;
+    }
+    let Some(buffer) = image::RgbImage::from_raw(frame.width, frame.height, frame.rgb.clone())
+    else {
+        return Err("decoded RGB buffer length does not match its own dimensions".to_string());
+    };
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        buffer
+            .save_with_format(&path, ImageFormat::Png)
+            .map_err(|source| format!("saving {}: {source}", path.display()))
+    })
+    .await
+    .map_err(|source| format!("save task panicked: {source}"))?
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{VideoStats, decode_jpeg};
+    use std::time::Duration;
+
+    /// Encodes a small synthetic RGB gradient to JPEG for round-trip tests.
+    fn synthetic_jpeg(width: u32, height: u32) -> Vec<u8> {
+        let mut rgb = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                rgb.push((x % 256) as u8);
+                rgb.push((y % 256) as u8);
+                rgb.push(((x + y) % 256) as u8);
+            }
+        }
+        let mut jpeg = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut jpeg);
+        let mut encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, 80);
+        encoder
+            .encode(&rgb, width, height, image::ExtendedColorType::Rgb8)
+            .expect("encodes");
+        jpeg
+    }
+
+    #[test]
+    fn decodes_valid_jpeg() {
+        let jpeg = synthetic_jpeg(16, 12);
+        let frame = decode_jpeg(&jpeg).expect("decodes");
+        assert_eq!((frame.width, frame.height), (16, 12));
+        assert_eq!(frame.rgb.len(), 16 * 12 * 3);
+    }
+
+    #[test]
+    fn rejects_garbage_bytes() {
+        assert!(decode_jpeg(&[0, 1, 2, 3]).is_none());
+    }
+
+    #[test]
+    fn record_tracks_counts_and_dims() {
+        let jpeg = synthetic_jpeg(8, 8);
+        let mut stats = VideoStats::new();
+        stats.record(&jpeg, None);
+        stats.record(&jpeg, Some(Duration::from_millis(33)));
+        assert_eq!(stats.frames_received, 2);
+        assert_eq!(stats.frames_decoded, 2);
+        assert_eq!(stats.frames_decode_failed, 0);
+        assert_eq!(stats.last_dims, Some((8, 8)));
+        assert_eq!(stats.inter_arrival.len(), 1);
+    }
+
+    #[test]
+    fn record_counts_decode_failures_without_touching_dims() {
+        let mut stats = VideoStats::new();
+        stats.record(&[0xFF, 0x00], None);
+        assert_eq!(stats.frames_received, 1);
+        assert_eq!(stats.frames_decoded, 0);
+        assert_eq!(stats.frames_decode_failed, 1);
+        assert_eq!(stats.last_dims, None);
+    }
+
+    #[test]
+    fn avg_fps_requires_decoded_frames_and_nonzero_elapsed() {
+        let mut stats = VideoStats::new();
+        assert_eq!(stats.avg_fps(Duration::from_secs(1)), None);
+        stats.record(&synthetic_jpeg(4, 4), None);
+        assert_eq!(stats.avg_fps(Duration::ZERO), None);
+        let fps = stats.avg_fps(Duration::from_secs(2)).expect("has fps");
+        assert!((fps - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn first_frame_is_retained_across_records() {
+        let mut stats = VideoStats::new();
+        stats.record(&synthetic_jpeg(4, 4), None);
+        stats.record(&synthetic_jpeg(6, 6), None);
+        let first = stats.first_frame.as_ref().expect("first frame retained");
+        assert_eq!((first.width, first.height), (4, 4));
+        let last = stats.last_frame.as_ref().expect("last frame retained");
+        assert_eq!((last.width, last.height), (6, 6));
+    }
+}


### PR DESCRIPTION
Replaces the reference adapter with a real Gazebo diff-drive vehicle and demonstrates the full loop to both a native and a browser client. Stacks on the merged increment-1a.

## What lands
- **C++ gz-transport sidecar bridge** (`adapters/gazebo/bridge`) — the only component that speaks gz-transport; bridges odometry/camera/cmd_vel to Rust over localhost TCP. No gz type reaches the public protocol (ADR-0008).
- **`pilotage-adapter-gazebo`** — implements the `VehicleAdapter` trait; spawns and owns the bridge (no orphan processes), maps axes↔cmd_vel, odometry↔telemetry, and streams camera frames to the host.
- **Host media pipeline** — `--adapter reference|gazebo`; MJPEG encode, one WebTransport uni-stream per frame, best-effort drop-to-latest so video never blocks control/telemetry. Uni-streams are kind-tagged (authority vs video) and each video frame carries a **FourCC codec tag** ([ADR-0016](docs/adr/0016-codec-pluggable-media-plane.md)).
- **Two viewers** — native (`tools/loopback-probe`, headlessly testable) and browser (`clients/web`, plain HTML/JS over the browser WebTransport + WebCodecs-free MJPEG path).
- **[ADR-0016](docs/adr/0016-codec-pluggable-media-plane.md)** — media plane is codec-pluggable; per-frame FourCC routes decoding, RFC 6381 reserved for a future per-stream config, control/authority core never sees the codec.

## Acceptance (verified live on a real Gazebo vehicle)
- **Command uplink**: driving moves the vehicle (odometry Δ > 2 m); stale-generation frames fenced end-to-end.
- **Telemetry downlink**: viewer pose tracks the real motion.
- **Video downlink**: ~175 MJPEG frames decoded at 320×240 / ~30 fps, non-blank FPV frames.
- **Browser**: connected over WebTransport, rendered live FPV to canvas, and drove the vehicle from the keyboard (verified in Chrome).
- No orphan `gz`/bridge processes after shutdown. Full gate battery green (340 tests); new node conformance test guards the browser encoder's required-field invariant.

## Notes
- Video codec is MJPEG for the PoC; hardware H.264 (VideoToolbox/NVENC/VAAPI) is a future media-plane platform port behind the same FourCC (ADR-0016).
- A browser control-encoding bug was found and fixed during verification: the hand-rolled encoder omitted required message-typed fields when their ids were 0, which the host rejected; it now matches the Rust encoder, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)