### PR TITLE
Browser viewer: RadioMaster Pocket (HID gamepad) FPV control

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -75,6 +75,12 @@
     font-family: monospace;
     font-size: 0.9rem;
   }
+  #gamepad {
+    margin-top: 0.35rem;
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: #9ac;
+  }
   #status {
     margin-top: 0.75rem;
     white-space: pre-wrap;
@@ -94,8 +100,10 @@
 
 <h1>Pilotage demo viewer</h1>
 <p class="hint">
-  Drive with arrow keys or WASD once connected. Video and telemetry arrive from the real
-  Gazebo vehicle through the session host.
+  Drive with a connected USB gamepad (e.g. RadioMaster Pocket) if present, otherwise the
+  arrow keys or WASD. Video and telemetry arrive from the real Gazebo vehicle through the
+  session host. A gamepad appears to the browser only after you move a stick or press a
+  button once.
 </p>
 
 <div class="bootstrap">
@@ -110,6 +118,7 @@
   <div id="overlay"></div>
 </div>
 <div id="telemetry">no telemetry yet</div>
+<div id="gamepad">gamepad: none (move a stick to detect)</div>
 <div id="status"></div>
 
 <script type="module" src="./main.js"></script>

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -351,6 +351,20 @@ const CONTROLLER_PROFILES = [
     forwardSign: 1, // stick up = forward, center = stop, down = reverse
     turnAxis: 3, // rudder
     turnSign: -1, // rudder right = turn right (negative yaw-rate in Gazebo)
+  },
+  {
+    // PS4 (DualShock 4) / PS5 (DualSense) map to the browser "Standard Gamepad"
+    // layout: axis 0 = left stick X, 1 = left stick Y, 2 = right stick X,
+    // 3 = right stick Y, with stick-up reported as negative. Both sticks
+    // self-center, so releasing stops the vehicle. Drive from the left stick
+    // (throttle = vertical, yaw = horizontal), matching the FPV convention.
+    name: "PS4/PS5 pad (Standard Gamepad)",
+    match: (id) => /054c|dualshock|dualsense|wireless controller|standard gamepad/i.test(id),
+    forwardAxis: 1, // left stick vertical
+    forwardSign: -1, // stick up (negative) = forward
+    turnAxis: 0, // left stick horizontal
+    turnSign: -1, // stick right (positive) = turn right (negative yaw-rate)
+    deadzone: 0.12, // thumbsticks drift more than radio gimbals
     deadzone: 0.06,
   },
 ];
@@ -361,7 +375,7 @@ const GENERIC_PROFILE = {
   forwardAxis: 1,
   forwardSign: -1, // browsers report stick-up as negative
   turnAxis: 0,
-  turnSign: 1,
+  turnSign: -1, // stick right (positive) = turn right (negative yaw-rate in Gazebo)
   deadzone: 0.1,
 };
 

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -39,6 +39,7 @@ const els = {
   status: document.getElementById("status"),
   overlay: document.getElementById("overlay"),
   telemetry: document.getElementById("telemetry"),
+  gamepad: document.getElementById("gamepad"),
   canvas: document.getElementById("video"),
 };
 const ctx = els.canvas.getContext("2d");
@@ -121,7 +122,7 @@ async function connect() {
   state.connected = true;
   acceptIncomingUniStreams(transport);
   readTelemetryDatagrams(transport);
-  startControlLoop(transport);
+  startControlLoop(transport).catch((error) => log(`control loop stopped: ${error}`));
 }
 
 /** Writes a length-delimited `ClientHello` envelope onto the bootstrap bidi stream. */
@@ -333,13 +334,127 @@ function axesFromKeys() {
   return [throttle, yaw];
 }
 
+// Per-controller FPV mapping profiles. EdgeTX radios (RadioMaster Pocket) output
+// the "Classic Joystick" report in AETR channel order over 8 HID axes, and
+// EdgeTX maps CH1->axis0, CH2->axis1, CH3->axis2, CH4->axis3, so:
+//   axis 0 = Aileron (roll), 1 = Elevator (pitch), 2 = Throttle, 3 = Rudder (yaw).
+// The FPV convention drives with throttle for speed and rudder for yaw (both the
+// left stick in Mode 2). Throttle does not self-center — it holds its position
+// like an aircraft throttle — so centering it stops the vehicle.
+// Field of a profile: forwardAxis/turnAxis (HID axis index), forwardSign/turnSign
+// (+1 or -1), deadzone. A `match(id)` picks the profile from the gamepad id.
+const CONTROLLER_PROFILES = [
+  {
+    name: "RadioMaster Pocket (EdgeTX, FPV AETR)",
+    match: (id) => /radiomaster|pocket|1209/i.test(id),
+    forwardAxis: 2, // throttle
+    forwardSign: 1, // stick up = forward, center = stop, down = reverse
+    turnAxis: 3, // rudder
+    turnSign: -1, // rudder right = turn right (negative yaw-rate in Gazebo)
+    deadzone: 0.06,
+  },
+];
+// Fallback for any other gamepad: drive from the left stick's self-centering
+// vertical/horizontal axes so the vehicle stops when the stick is released.
+const GENERIC_PROFILE = {
+  name: "generic gamepad",
+  forwardAxis: 1,
+  forwardSign: -1, // browsers report stick-up as negative
+  turnAxis: 0,
+  turnSign: 1,
+  deadzone: 0.1,
+};
+
+// User overrides for the active profile, taken from URL query params today; this
+// is the seam a future in-app remapping UI plugs into. Any of ?fwd= ?turn=
+// ?fwdsign= ?turnsign= ?deadzone= replaces the corresponding profile field.
+function overrideProfile(profile) {
+  const q = new URLSearchParams(window.location.search);
+  const intParam = (name, fallback) => {
+    const v = Number.parseInt(q.get(name) ?? "", 10);
+    return Number.isInteger(v) ? v : fallback;
+  };
+  const numParam = (name, fallback) => {
+    const v = Number.parseFloat(q.get(name) ?? "");
+    return Number.isFinite(v) ? v : fallback;
+  };
+  const signParam = (name, fallback) => (intParam(name, fallback) < 0 ? -1 : 1);
+  return {
+    name: q.has("fwd") || q.has("turn") ? `${profile.name} (overridden)` : profile.name,
+    forwardAxis: intParam("fwd", profile.forwardAxis),
+    forwardSign: signParam("fwdsign", profile.forwardSign),
+    turnAxis: intParam("turn", profile.turnAxis),
+    turnSign: signParam("turnsign", profile.turnSign),
+    deadzone: numParam("deadzone", profile.deadzone),
+  };
+}
+
+/** Returns the first connected gamepad that matches a known profile, else any
+ *  connected gamepad, else null. A gamepad is exposed to the page only after the
+ *  user moves a stick or presses a button once. */
+function activeGamepad() {
+  const pads = (navigator.getGamepads && navigator.getGamepads()) || [];
+  let firstConnected = null;
+  for (const pad of pads) {
+    if (!pad || !pad.connected) continue;
+    firstConnected = firstConnected || pad;
+    if (CONTROLLER_PROFILES.some((p) => p.match(pad.id))) return pad;
+  }
+  return firstConnected;
+}
+
+/** Picks the FPV profile for a gamepad id and applies user overrides. */
+function profileFor(id) {
+  const base = CONTROLLER_PROFILES.find((p) => p.match(id)) || GENERIC_PROFILE;
+  return overrideProfile(base);
+}
+
+/** Maps a gamepad's axes to [throttle, yaw] in [-1.0, 1.0] under `profile`. */
+function axesFromGamepad(pad, profile) {
+  const raw = (i) => (i >= 0 && i < pad.axes.length ? pad.axes[i] : 0);
+  const clamp = (v) => Math.max(-1, Math.min(1, v));
+  const deadzone = (v) => (Math.abs(v) < profile.deadzone ? 0 : v);
+  const throttle = clamp(deadzone(profile.forwardSign * raw(profile.forwardAxis)));
+  const yaw = clamp(deadzone(profile.turnSign * raw(profile.turnAxis)));
+  return [throttle, yaw];
+}
+
+/** Updates the gamepad readout so the active profile and axis-to-control mapping
+ *  are visible while driving (and easy to re-map with the ?fwd=/?turn= overrides). */
+function updateGamepadReadout(pad, profile, throttle, yaw) {
+  if (!pad) {
+    els.gamepad.textContent = "gamepad: none (move a stick to detect) — using keyboard";
+    return;
+  }
+  const axes = Array.from(pad.axes, (v) => v.toFixed(2)).join(", ");
+  els.gamepad.textContent =
+    `gamepad: ${pad.id} [${profile.name}] | axes[${axes}] | ` +
+    `throttle=${throttle.toFixed(2)} (axis ${profile.forwardAxis}) ` +
+    `yaw=${yaw.toFixed(2)} (axis ${profile.turnAxis})`;
+}
+
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
-function startControlLoop(transport) {
+async function startControlLoop(transport) {
   const writer = transport.datagrams.writable.getWriter();
   const intervalMs = 1000 / CONTROL_HZ;
-  setInterval(() => {
+  // Self-paced async loop rather than setInterval: it awaits the writer's
+  // backpressure signal (`ready`) before each send, so datagrams never queue up
+  // in the WritableStream and get flushed in a burst with stale `sampled_at`
+  // (which the host rejects as too old, ADR-0009). `sampled_at` is stamped right
+  // before the write, after `ready`, so it reflects the real send moment.
+  while (state.connected) {
+    try {
+      await writer.ready;
+    } catch {
+      return; // writer closed (session ended)
+    }
     if (!state.connected) return;
-    const [throttle, yaw] = axesFromKeys();
+    // A connected gamepad drives under its FPV profile; the keyboard is the
+    // fallback when none is present. The readout shows the live mapping either way.
+    const pad = activeGamepad();
+    const profile = pad ? profileFor(pad.id) : null;
+    const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
+    updateGamepadReadout(pad, profile, throttle, yaw);
     state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
     const envelope = encodeControlFrameEnvelope({
       sessionId: state.sessionId,
@@ -355,7 +470,8 @@ function startControlLoop(transport) {
       ],
     });
     writer.write(envelope).catch((error) => log(`control datagram send failed: ${error}`));
-  }, intervalMs);
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
 }
 
 applyUrlParams();


### PR DESCRIPTION
Adds USB gamepad control to the browser demo viewer so the RadioMaster Pocket drives the real Gazebo vehicle, with the FPV mapping this radio expects.

## What lands
- **Gamepad API control** in `clients/web`: a connected gamepad drives the vehicle; the keyboard stays as the fallback.
- **Device-keyed FPV profile**: the RadioMaster Pocket (EdgeTX) outputs the Classic Joystick report in AETR channel order over 8 HID axes (CH1→axis0 … CH4→axis3), so axis 0=aileron, 1=elevator, 2=throttle, 3=rudder. The profile maps **throttle→forward speed, rudder→yaw** — the standard FPV convention (both the left stick in Mode 2), which also matches the committed native device profile. Confirmed against the physical device (axis 2 is the non-centering throttle gimbal).
- **Overridable**: `?fwd=`/`?turn=`/`?fwdsign=`/`?turnsign=`/`?deadzone=` override the detected profile — the seam a future in-app remapping UI plugs into. A live readout shows the active profile and axis-to-control mapping.
- **Backpressure fix**: control datagrams now await the WebTransport writer's `ready` and stamp `sampled_at` right before sending, instead of firing from `setInterval` without awaiting. Previously they queued in the WritableStream and flushed in bursts whose oldest frames exceeded the host's 250 ms control-age limit and were rejected as too old (ADR-0009).

## Verified live
Drove the vehicle from the physical RadioMaster Pocket through the browser: FPV profile auto-detected, throttle stick moved the vehicle (telemetry v tracked the stick), and after the backpressure fix the host logged **zero `too old` rejections** during continuous driving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)