### PR TITLE
Chase camera: second video source with per-frame source id

### DIFF
--- a/adapters/gazebo/bridge/src/bridge_node.cpp
+++ b/adapters/gazebo/bridge/src/bridge_node.cpp
@@ -69,8 +69,14 @@ bool BridgeNode::Start(std::string &error_out) {
     return false;
   }
 
-  if (!node_.Subscribe(config_.camera_topic, &BridgeNode::OnImage, this)) {
+  if (!node_.Subscribe(config_.camera_topic, &BridgeNode::OnFpvImage, this)) {
     error_out = "failed to subscribe " + config_.camera_topic;
+    return false;
+  }
+
+  if (!node_.Subscribe(config_.chase_camera_topic, &BridgeNode::OnChaseImage,
+                       this)) {
+    error_out = "failed to subscribe " + config_.chase_camera_topic;
     return false;
   }
 
@@ -97,7 +103,11 @@ void BridgeNode::OnOdometry(const gz::msgs::Odometry &msg) {
   connection_->WriteEnvelope(envelope, /*droppable=*/false);
 }
 
-void BridgeNode::OnImage(const gz::msgs::Image &msg) {
+void BridgeNode::OnFpvImage(const gz::msgs::Image &msg) { OnImage(msg, 0); }
+
+void BridgeNode::OnChaseImage(const gz::msgs::Image &msg) { OnImage(msg, 1); }
+
+void BridgeNode::OnImage(const gz::msgs::Image &msg, std::uint32_t camera_id) {
   pilotage::bridge::v1::BridgeEnvelope envelope;
   auto *frame = envelope.mutable_frame();
 
@@ -106,9 +116,13 @@ void BridgeNode::OnImage(const gz::msgs::Image &msg) {
   frame->set_pixel_format(PixelFormatName(msg.pixel_format_type()));
   frame->set_sim_time_ns(StampToNanos(msg.header()));
   frame->set_rgb(msg.data());
+  frame->set_camera_id(camera_id);
 
   // Camera frames are best-effort: a slow host drops frames rather than
-  // stalling the shared writer and starving odometry behind them.
+  // stalling the shared writer and starving odometry behind them. The write
+  // mutex inside WriteEnvelope only guards the queue hand-off, never the
+  // blocking socket send, so concurrent callbacks from both camera topics
+  // never stall each other or odometry.
   connection_->WriteEnvelope(envelope, /*droppable=*/true);
 }
 

--- a/adapters/gazebo/bridge/src/bridge_node.hpp
+++ b/adapters/gazebo/bridge/src/bridge_node.hpp
@@ -6,6 +6,7 @@
 #ifndef PILOTAGE_GZ_BRIDGE_NODE_HPP
 #define PILOTAGE_GZ_BRIDGE_NODE_HPP
 
+#include <cstdint>
 #include <string>
 
 #include <gz/msgs/image.pb.h>
@@ -19,8 +20,9 @@ namespace pilotage::bridge {
 
 // Static configuration for one bridge session.
 struct BridgeConfig {
-  std::string vehicle;       // e.g. "vehicle_blue"
-  std::string camera_topic;  // e.g. "/camera"
+  std::string vehicle;             // e.g. "vehicle_blue"
+  std::string camera_topic;        // e.g. "/camera" (FPV, camera_id = 0)
+  std::string chase_camera_topic;  // e.g. "/chase_camera" (camera_id = 1)
 };
 
 // Wires gz-transport subscriptions/publisher to a BridgeConnection. The node
@@ -30,8 +32,8 @@ class BridgeNode {
  public:
   BridgeNode(BridgeConfig config, BridgeConnection *connection);
 
-  // Advertises cmd_vel and subscribes odometry + camera. Returns false with a
-  // populated error_out if any gz-transport wiring step fails.
+  // Advertises cmd_vel and subscribes odometry + both cameras. Returns false
+  // with a populated error_out if any gz-transport wiring step fails.
   bool Start(std::string &error_out);
 
   // Publishes a Twist onto <vehicle>/cmd_vel from a decoded control message.
@@ -40,7 +42,13 @@ class BridgeNode {
  private:
   // gz-transport member-function callbacks (run on gz reader threads).
   void OnOdometry(const gz::msgs::Odometry &msg);
-  void OnImage(const gz::msgs::Image &msg);
+  // Per-topic thunks (gz-transport::Subscribe needs a fixed-arity callback)
+  // that both forward to the shared OnImage body with their camera_id.
+  void OnFpvImage(const gz::msgs::Image &msg);
+  void OnChaseImage(const gz::msgs::Image &msg);
+  // Shared onImage body for both camera subscriptions; camera_id tags the
+  // emitted BridgeFrame so the host can route it to the right video source.
+  void OnImage(const gz::msgs::Image &msg, std::uint32_t camera_id);
 
   BridgeConfig config_;
   BridgeConnection *connection_;  // not owned

--- a/adapters/gazebo/bridge/src/main.cpp
+++ b/adapters/gazebo/bridge/src/main.cpp
@@ -41,10 +41,11 @@ struct Args {
   std::uint16_t port = 0;
   std::string vehicle = "vehicle_blue";
   std::string camera_topic = "/camera";
+  std::string chase_camera_topic = "/chase_camera";
 };
 
-// Parses --port/--vehicle/--camera-topic. Returns nullopt and writes a usage
-// diagnostic on a missing or malformed argument.
+// Parses --port/--vehicle/--camera-topic/--chase-camera-topic. Returns
+// nullopt and writes a usage diagnostic on a missing or malformed argument.
 std::optional<Args> ParseArgs(int argc, char **argv) {
   Args args;
   bool have_port = false;
@@ -65,6 +66,8 @@ std::optional<Args> ParseArgs(int argc, char **argv) {
       args.vehicle = argv[++i];
     } else if (flag == "--camera-topic" && has_value) {
       args.camera_topic = argv[++i];
+    } else if (flag == "--chase-camera-topic" && has_value) {
+      args.chase_camera_topic = argv[++i];
     } else {
       std::cerr << "pilotage-gz-bridge: unexpected argument '" << flag << "'\n";
       return std::nullopt;
@@ -73,7 +76,7 @@ std::optional<Args> ParseArgs(int argc, char **argv) {
 
   if (!have_port) {
     std::cerr << "usage: pilotage-gz-bridge --port N [--vehicle NAME] "
-                 "[--camera-topic TOPIC]\n";
+                 "[--camera-topic TOPIC] [--chase-camera-topic TOPIC]\n";
     return std::nullopt;
   }
   return args;
@@ -111,7 +114,8 @@ int main(int argc, char **argv) {
   }
   g_connection.store(&(*connection), std::memory_order_relaxed);
 
-  pilotage::bridge::BridgeConfig config{args.vehicle, args.camera_topic};
+  pilotage::bridge::BridgeConfig config{args.vehicle, args.camera_topic,
+                                        args.chase_camera_topic};
   pilotage::bridge::BridgeNode bridge(config, &(*connection));
   if (!bridge.Start(error)) {
     std::cerr << "pilotage-gz-bridge: " << error << "\n";
@@ -120,7 +124,8 @@ int main(int argc, char **argv) {
 
   std::cerr << "pilotage-gz-bridge: connected to 127.0.0.1:" << args.port
             << ", vehicle=" << args.vehicle
-            << ", camera=" << args.camera_topic << "\n";
+            << ", camera=" << args.camera_topic
+            << ", chase_camera=" << args.chase_camera_topic << "\n";
 
   // Inbound control loop: block on the socket, publish each BridgeControl as a
   // Twist. A false read is EOF/error/shutdown -> exit so the parent detects

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -27,8 +27,14 @@ pub const MOTION_SCOPE: &str = "vehicle.motion";
 pub const THROTTLE_AXIS: u16 = 2;
 /// Canonical logical axis carrying yaw (`angular.z`) commands.
 pub const YAW_AXIS: u16 = 3;
-/// Identifier of the single onboard camera video source.
-pub const CAMERA_SOURCE_ID: &str = "onboard-camera";
+/// Identifier of the onboard FPV camera video source (source id 0).
+pub const FPV_SOURCE_ID: &str = "onboard-fpv";
+/// Identifier of the chase camera video source (source id 1).
+pub const CHASE_SOURCE_ID: &str = "chase";
+/// Wire source id of the onboard FPV camera.
+pub const FPV_CAMERA: u8 = 0;
+/// Wire source id of the chase camera.
+pub const CHASE_CAMERA: u8 = 1;
 
 /// A decoded raw camera frame from the sidecar bridge, paired with the
 /// simulation tick it was captured at.
@@ -39,6 +45,10 @@ pub const CAMERA_SOURCE_ID: &str = "onboard-camera";
 /// `sample_telemetry` shape (ADR-0008).
 #[derive(Debug, Clone)]
 pub struct RawVideoFrame {
+    /// Video source this frame came from: 0 = onboard FPV, 1 = chase. Carried
+    /// end to end so the host media pipeline and every reader can route each
+    /// frame to the right video source (the wire `source_id` byte).
+    pub source_id: u8,
     /// Frame width in pixels.
     pub width: u32,
     /// Frame height in pixels.
@@ -54,6 +64,11 @@ pub struct RawVideoFrame {
 impl From<BridgeFrame> for RawVideoFrame {
     fn from(frame: BridgeFrame) -> Self {
         Self {
+            // Bridge `camera_id` is a u32 for wire headroom, but only ids 0
+            // (FPV) / 1 (chase) are assigned; an out-of-range id saturates to
+            // u8::MAX so the reader routes it to no known source rather than
+            // aliasing onto a valid one.
+            source_id: u8::try_from(frame.camera_id).unwrap_or(u8::MAX),
             width: frame.width,
             height: frame.height,
             pixel_format: frame.pixel_format,
@@ -331,10 +346,16 @@ impl VehicleAdapter for GazeboAdapter {
     }
 
     fn video_sources(&self) -> Vec<VideoSource> {
-        vec![VideoSource {
-            id: CAMERA_SOURCE_ID.to_owned(),
-            description: "onboard forward camera".to_owned(),
-        }]
+        vec![
+            VideoSource {
+                id: FPV_SOURCE_ID.to_owned(),
+                description: "onboard forward camera".to_owned(),
+            },
+            VideoSource {
+                id: CHASE_SOURCE_ID.to_owned(),
+                description: "chase camera".to_owned(),
+            },
+        ]
     }
 
     fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {

--- a/adapters/gazebo/src/adapter/tests.rs
+++ b/adapters/gazebo/src/adapter/tests.rs
@@ -206,16 +206,49 @@ async fn camera_frame_reaches_the_subscriber() {
                 pixel_format: "RGB_INT8".to_owned(),
                 sim_time_ns: 77,
                 rgb: vec![9_u8; 24],
+                camera_id: 0,
             })),
         },
     )
     .await;
 
     let frame = frames.recv().await.expect("a frame arrives");
+    assert_eq!(frame.source_id, 0, "camera_id 0 maps to the FPV source id");
     assert_eq!(frame.width, 4);
     assert_eq!(frame.height, 2);
     assert_eq!(frame.tick.as_u64(), 77);
     assert_eq!(frame.rgb.len(), 24);
+}
+
+#[tokio::test]
+async fn chase_camera_frame_carries_its_source_id() {
+    let vehicle = VehicleId::new(5);
+    let (host_side, mut bridge_side) = connected_pair().await;
+    let mut adapter =
+        GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
+    let mut frames = adapter.subscribe_frames().expect("frame receiver present");
+
+    send_envelope(
+        &mut bridge_side,
+        &BridgeEnvelope {
+            payload: Some(bridge_envelope::Payload::Frame(BridgeFrame {
+                width: 2,
+                height: 2,
+                pixel_format: "RGB_INT8".to_owned(),
+                sim_time_ns: 88,
+                rgb: vec![7_u8; 12],
+                camera_id: 1,
+            })),
+        },
+    )
+    .await;
+
+    let frame = frames.recv().await.expect("a chase frame arrives");
+    assert_eq!(
+        frame.source_id, 1,
+        "camera_id 1 maps to the chase source id"
+    );
+    assert_eq!(frame.tick.as_u64(), 88);
 }
 
 #[tokio::test]
@@ -304,5 +337,8 @@ async fn capabilities_report_motion_scope_and_camera_source() {
     assert!(caps.execution.render_capable);
     assert_eq!(caps.vehicles.len(), 1);
     assert_eq!(caps.vehicles[0].scopes[0].scope.as_str(), MOTION_SCOPE);
-    assert_eq!(adapter.video_sources().len(), 1);
+    let sources = adapter.video_sources();
+    assert_eq!(sources.len(), 2, "FPV and chase are both advertised");
+    assert_eq!(sources[0].id, super::FPV_SOURCE_ID);
+    assert_eq!(sources[1].id, super::CHASE_SOURCE_ID);
 }

--- a/adapters/gazebo/src/lib.rs
+++ b/adapters/gazebo/src/lib.rs
@@ -11,7 +11,8 @@ mod framing;
 pub mod wire;
 
 pub use adapter::{
-    CAMERA_SOURCE_ID, GazeboAdapter, MOTION_SCOPE, RawVideoFrame, THROTTLE_AXIS, YAW_AXIS,
+    CHASE_CAMERA, CHASE_SOURCE_ID, FPV_CAMERA, FPV_SOURCE_ID, GazeboAdapter, MOTION_SCOPE,
+    RawVideoFrame, THROTTLE_AXIS, YAW_AXIS,
 };
 pub use bridge_client::{BRIDGE_BIN_ENV, BridgeClient, BridgeConfig, LatestBridgeState};
 pub use error::GazeboAdapterError;

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -51,12 +51,23 @@
     padding: 0.4rem 0.9rem;
     cursor: pointer;
   }
+  .stage-row {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
   .stage {
     position: relative;
     display: inline-block;
     border: 1px solid #333;
   }
   #video {
+    display: block;
+    background: #000;
+    max-width: 100%;
+  }
+  #chaseVideo {
     display: block;
     background: #000;
     max-width: 100%;
@@ -69,6 +80,16 @@
     padding: 0.25rem 0.5rem;
     font-size: 0.85rem;
     border-radius: 3px;
+  }
+  .caption {
+    position: absolute;
+    bottom: 0.4rem;
+    left: 0.4rem;
+    background: rgba(0, 0, 0, 0.55);
+    padding: 0.2rem 0.45rem;
+    font-size: 0.75rem;
+    border-radius: 3px;
+    color: #ccc;
   }
   #telemetry {
     margin-top: 0.5rem;
@@ -113,9 +134,16 @@
   <button id="connectBtn">Connect</button>
 </div>
 
-<div class="stage">
-  <canvas id="video" width="320" height="240"></canvas>
-  <div id="overlay"></div>
+<div class="stage-row">
+  <div class="stage">
+    <canvas id="video" width="320" height="240"></canvas>
+    <div id="overlay"></div>
+    <div class="caption">FPV / onboard</div>
+  </div>
+  <div class="stage">
+    <canvas id="chaseVideo" width="320" height="240"></canvas>
+    <div class="caption">chase / 3rd person</div>
+  </div>
 </div>
 <div id="telemetry">no telemetry yet</div>
 <div id="gamepad">gamepad: none (move a stick to detect)</div>

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -41,8 +41,10 @@ const els = {
   telemetry: document.getElementById("telemetry"),
   gamepad: document.getElementById("gamepad"),
   canvas: document.getElementById("video"),
+  chaseCanvas: document.getElementById("chaseVideo"),
 };
 const ctx = els.canvas.getContext("2d");
+const chaseCtx = els.chaseCanvas.getContext("2d");
 
 /** Session-scoped mutable state the connect flow and background loops share. */
 const state = {
@@ -53,6 +55,7 @@ const state = {
   startNanos: BigInt(Date.now()) * 1_000_000n, // arbitrary local monotonic-ish origin for sampled_at (ADR-0009: endpoint-local, never compared raw across endpoints).
   keys: new Set(),
   connected: false,
+  skippedVideoFrames: 0,
 };
 
 function log(line) {
@@ -253,31 +256,49 @@ function dispatchAuthorityStream(body) {
   }
 }
 
-// Video body is `[fourcc: 4 bytes][u32 LE len][payload]` after the kind tag
-// (ADR-0016; host stream_tag.rs `frame_video_payload`). An unknown FourCC is
-// skipped with a log line, never a hard failure, so a host streaming a codec
-// this viewer lacks degrades gracefully. Only "MJPG" is decoded here.
+// Video body is `[source_id: u8][fourcc: 4 bytes][u32 LE len][payload]` after
+// the kind tag (ADR-0016; host stream_tag.rs `frame_video_payload`). The
+// source_id (0 = onboard FPV, 1 = chase) routes the frame to its canvas. An
+// unknown source_id or unknown FourCC is counted and logged, never a hard
+// failure, so a host streaming a source or codec this viewer lacks degrades
+// gracefully. Only "MJPG" is decoded here.
 const FOURCC_MJPEG = "MJPG";
+const SOURCE_FPV = 0;
+const SOURCE_CHASE = 1;
+const VIDEO_TARGETS = {
+  [SOURCE_FPV]: { canvas: els.canvas, ctx },
+  [SOURCE_CHASE]: { canvas: els.chaseCanvas, ctx: chaseCtx },
+};
+
 async function renderVideoFrame(body) {
-  if (body.length < 8) return;
-  const fourcc = String.fromCharCode(body[0], body[1], body[2], body[3]);
-  const view = new DataView(body.buffer, body.byteOffset + 4, 4);
+  if (body.length < 9) return;
+  const sourceId = body[0];
+  const fourcc = String.fromCharCode(body[1], body[2], body[3], body[4]);
+  const view = new DataView(body.buffer, body.byteOffset + 5, 4);
   const len = view.getUint32(0, true);
-  const payload = body.subarray(8, 8 + len);
+  const payload = body.subarray(9, 9 + len);
   if (payload.length !== len) {
     log(`video frame length mismatch: declared ${len}, got ${payload.length}`);
     return;
   }
+  const target = VIDEO_TARGETS[sourceId];
+  if (!target) {
+    state.skippedVideoFrames += 1;
+    log(`unknown video source_id ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
+    return;
+  }
   if (fourcc !== FOURCC_MJPEG) {
-    log(`unknown video codec FourCC "${fourcc}"; skipping frame`);
+    state.skippedVideoFrames += 1;
+    log(`unknown video codec FourCC "${fourcc}" for source ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
     return;
   }
   const bitmap = await createImageBitmap(new Blob([payload], { type: "image/jpeg" }));
-  if (els.canvas.width !== bitmap.width || els.canvas.height !== bitmap.height) {
-    els.canvas.width = bitmap.width;
-    els.canvas.height = bitmap.height;
+  const { canvas, ctx: targetCtx } = target;
+  if (canvas.width !== bitmap.width || canvas.height !== bitmap.height) {
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
   }
-  ctx.drawImage(bitmap, 0, 0);
+  targetCtx.drawImage(bitmap, 0, 0);
   bitmap.close();
 }
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -14,8 +14,9 @@
 //     host-initiated uni stream additionally leads with one raw kind-tag
 //     byte before the first length-delimited envelope
 //     (hosts/session-host/src/runtime/stream_tag.rs): 0x01 = authority-events
-//     stream, 0x02 = one video frame (`[fourcc: 4 bytes][u32 LE len][jpeg]`
-//     after the tag, ADR-0016, not an Envelope at all).
+//     stream, 0x02 = one video frame
+//     (`[source_id: u8][fourcc: 4 bytes][u32 LE len][jpeg]` after the tag,
+//     ADR-0016, not an Envelope at all). source_id 0 = onboard FPV, 1 = chase.
 
 export const STREAM_KIND_AUTHORITY = 0x01;
 export const STREAM_KIND_VIDEO = 0x02;

--- a/hosts/session-host/src/runtime/media.rs
+++ b/hosts/session-host/src/runtime/media.rs
@@ -3,10 +3,11 @@
 //!
 //! A single media task drains the Gazebo adapter's raw RGB frame receiver,
 //! encodes each frame to JPEG once, and fans the encoded frame out to every
-//! connected client. Each client has its own writer task and a
-//! capacity-1 handoff channel, so a client that drains video slower than
-//! frames arrive drops to the latest frame (the stale one is discarded and
-//! counted) rather than growing memory or delaying control/telemetry. Encode
+//! connected client. Frames carry a `source_id` (0 = onboard FPV, 1 = chase);
+//! each client gets a separate writer task and capacity-1 handoff channel
+//! *per source*, so a client that drains one source slower than frames arrive
+//! drops that source to its latest frame (the stale one is discarded and
+//! counted) without stalling the other source or control/telemetry. Encode
 //! happens once per frame regardless of client count; the JPEG is shared as an
 //! `Arc`.
 
@@ -91,18 +92,27 @@ pub fn spawn_media_task(
     )
 }
 
-/// Per-client outbound handoff of the latest encoded JPEG. Capacity 1 bounds
-/// in-flight frames to one per client: `try_send` on a full channel means the
-/// client's writer is still busy with the previous frame, so the new frame is
-/// dropped-to-latest and counted (ADR-0011 best-effort media).
+/// Per-(client, source) outbound handoff of the latest encoded JPEG. Capacity
+/// 1 bounds in-flight frames to one per source per client: `try_send` on a
+/// full channel means that source's writer is still busy with its previous
+/// frame, so the new frame is dropped-to-latest and counted (ADR-0011
+/// best-effort media).
 type FrameTx = mpsc::Sender<Arc<Vec<u8>>>;
 
-/// The media task's own view of a connected client: the handoff channel to its
-/// writer task, plus the running drop count for frames its writer could not
-/// keep up with.
+/// The media task's own view of one video source of a connected client: the
+/// handoff channel to that source's writer task, plus the running drop count
+/// for frames its writer could not keep up with.
 struct ClientSink {
     frames: FrameTx,
     dropped: u64,
+}
+
+/// The media task's view of a connected client: its connection (so per-source
+/// writer tasks can be spawned lazily on the first frame seen for each source)
+/// and the per-source sinks already opened.
+struct ClientEntry {
+    connection: Connection,
+    sources: std::collections::BTreeMap<u8, ClientSink>,
 }
 
 /// Drains raw frames, encodes each once, and fans the encoded frame out to
@@ -112,7 +122,7 @@ async fn media_loop(
     mut frames: mpsc::Receiver<RawVideoFrame>,
     mut commands: mpsc::Receiver<MediaCommand>,
 ) {
-    let mut sinks: std::collections::BTreeMap<ClientKey, ClientSink> =
+    let mut clients: std::collections::BTreeMap<ClientKey, ClientEntry> =
         std::collections::BTreeMap::new();
     let mut writers = JoinSet::new();
     loop {
@@ -131,73 +141,89 @@ async fn media_loop(
         tokio::select! {
             command = commands.recv() => {
                 match command {
-                    Some(command) => apply_command(command, &mut sinks, &mut writers),
+                    Some(command) => apply_command(command, &mut clients),
                     None => break,
                 }
             }
             frame = frames.recv() => {
                 match frame {
-                    Some(frame) => fan_out_frame(frame, &mut sinks),
+                    Some(frame) => fan_out_frame(frame, &mut clients, &mut writers),
                     None => break,
                 }
             }
         }
     }
-    // Dropping every sink closes each writer's handoff channel, so the writers
-    // finish their in-flight frame and exit; wait for them so no uni stream is
-    // abandoned mid-write on shutdown.
-    drop(sinks);
+    // Dropping every client (and its sinks) closes each writer's handoff
+    // channel, so the writers finish their in-flight frame and exit; wait for
+    // them so no uni stream is abandoned mid-write on shutdown.
+    drop(clients);
     while writers.join_next().await.is_some() {}
     debug!("media task exited");
 }
 
-/// Applies one register/deregister command, spawning or dropping the client's
-/// writer task.
+/// Applies one register/deregister command. Registration only records the
+/// client's connection; a per-source writer task is spawned lazily the first
+/// time a frame for that source is fanned out (see [`fan_out_frame`]), so a
+/// client is not charged a writer for a source that never streams.
 fn apply_command(
     command: MediaCommand,
-    sinks: &mut std::collections::BTreeMap<ClientKey, ClientSink>,
-    writers: &mut JoinSet<()>,
+    clients: &mut std::collections::BTreeMap<ClientKey, ClientEntry>,
 ) {
     match command {
         MediaCommand::Register(MediaClient { client, connection }) => {
-            let (frame_tx, frame_rx) = mpsc::channel::<Arc<Vec<u8>>>(1);
-            writers.spawn(client_writer(client, connection, frame_rx));
-            sinks.insert(
+            clients.insert(
                 client,
-                ClientSink {
-                    frames: frame_tx,
-                    dropped: 0,
+                ClientEntry {
+                    connection,
+                    sources: std::collections::BTreeMap::new(),
                 },
             );
         }
         MediaCommand::Deregister(client) => {
-            sinks.remove(&client);
+            clients.remove(&client);
         }
     }
 }
 
-/// Encodes `frame` to JPEG once and hands it to every client sink, counting a
-/// drop for any client whose in-flight slot is still full (slow consumer) and
-/// evicting any whose writer task has exited.
+/// Encodes `frame` to JPEG once and hands it to every client's writer for the
+/// frame's source, lazily spawning that per-source writer on first use,
+/// counting a drop for any source whose in-flight slot is still full (slow
+/// consumer), and evicting any client whose connection has gone away.
 fn fan_out_frame(
     frame: RawVideoFrame,
-    sinks: &mut std::collections::BTreeMap<ClientKey, ClientSink>,
+    clients: &mut std::collections::BTreeMap<ClientKey, ClientEntry>,
+    writers: &mut JoinSet<()>,
 ) {
-    if sinks.is_empty() {
+    if clients.is_empty() {
         return;
     }
+    let source_id = frame.source_id;
     let Some(jpeg) = encode_jpeg(&frame) else {
         return;
     };
     let jpeg = Arc::new(jpeg);
     let mut closed = Vec::new();
-    for (client, sink) in sinks.iter_mut() {
+    for (client, entry) in clients.iter_mut() {
+        let sink = entry.sources.entry(source_id).or_insert_with(|| {
+            let (frame_tx, frame_rx) = mpsc::channel::<Arc<Vec<u8>>>(1);
+            writers.spawn(client_writer(
+                *client,
+                source_id,
+                entry.connection.clone(),
+                frame_rx,
+            ));
+            ClientSink {
+                frames: frame_tx,
+                dropped: 0,
+            }
+        });
         match sink.frames.try_send(Arc::clone(&jpeg)) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 sink.dropped = sink.dropped.wrapping_add(1);
                 warn!(
                     client = client.as_u64(),
+                    source_id,
                     total_dropped = sink.dropped,
                     "video frame dropped: client writer still busy with the previous frame"
                 );
@@ -206,7 +232,7 @@ fn fan_out_frame(
         }
     }
     for client in closed {
-        sinks.remove(&client);
+        clients.remove(&client);
     }
 }
 
@@ -241,31 +267,39 @@ fn encode_jpeg(frame: &RawVideoFrame) -> Option<Vec<u8>> {
     Some(jpeg)
 }
 
-/// Per-client writer: receives the latest encoded JPEG and writes it as one
-/// host-initiated uni stream tagged [`VIDEO_FRAME`], one stream per frame
-/// (ADR-0005). Exits when the handoff channel closes (client deregistered or
-/// media task shutting down).
+/// Per-(client, source) writer: receives the latest encoded JPEG and writes it
+/// as one host-initiated uni stream tagged [`VIDEO_FRAME`], one stream per
+/// frame (ADR-0005), stamped with `source_id`. Exits when the handoff channel
+/// closes (client deregistered or media task shutting down).
 async fn client_writer(
     client: ClientKey,
+    source_id: u8,
     connection: Connection,
     mut frames: mpsc::Receiver<Arc<Vec<u8>>>,
 ) {
     while let Some(jpeg) = frames.recv().await {
-        if let Err(reason) = write_one_frame(&connection, &jpeg).await {
+        if let Err(reason) = write_one_frame(&connection, source_id, &jpeg).await {
             // A failed uni-stream open/write means the connection is going
             // away; stop writing video to it. The connection task's own
             // teardown deregisters this client.
-            debug!(client = client.as_u64(), reason, "video writer stopping");
+            debug!(
+                client = client.as_u64(),
+                source_id, reason, "video writer stopping"
+            );
             return;
         }
     }
 }
 
 /// Opens one host-initiated uni stream, writes the [`VIDEO_FRAME`] tag then
-/// the codec-tagged length-prefixed JPEG, and finishes the stream (ADR-0005
-/// media unit; ADR-0016 FourCC codec tag).
-async fn write_one_frame(connection: &Connection, jpeg: &[u8]) -> Result<(), &'static str> {
-    let Some(body) = frame_video_payload(FOURCC_MJPEG, jpeg) else {
+/// the source-tagged, codec-tagged, length-prefixed JPEG, and finishes the
+/// stream (ADR-0005 media unit; ADR-0016 FourCC codec tag).
+async fn write_one_frame(
+    connection: &Connection,
+    source_id: u8,
+    jpeg: &[u8],
+) -> Result<(), &'static str> {
+    let Some(body) = frame_video_payload(source_id, FOURCC_MJPEG, jpeg) else {
         // A frame larger than u32::MAX cannot be length-prefixed; skip it
         // without failing the writer (no real camera frame reaches this).
         error!("video frame exceeds u32 length prefix; skipping");
@@ -311,6 +345,7 @@ mod tests {
             }
         }
         RawVideoFrame {
+            source_id: 0,
             width,
             height,
             pixel_format: "RGB_INT8".to_owned(),
@@ -329,18 +364,23 @@ mod tests {
         assert_eq!(&jpeg[jpeg.len() - 2..], &[0xFF, 0xD9], "JPEG ends with EOI");
 
         // Frame the JPEG exactly as the media task writes it after the tag,
-        // then parse the codec-tagged length-prefixed body back (ADR-0016).
-        let body = frame_video_payload(FOURCC_MJPEG, &jpeg).expect("JPEG frames");
-        let (codec, parsed) = parse_video_payload(&body).expect("framed body parses back");
+        // then parse the source-tagged, codec-tagged length-prefixed body back
+        // (ADR-0016).
+        let body = frame_video_payload(1, FOURCC_MJPEG, &jpeg).expect("JPEG frames");
+        let (source_id, codec, parsed) =
+            parse_video_payload(&body).expect("framed body parses back");
+        assert_eq!(source_id, 1, "carries the chase source id");
         assert_eq!(codec, FOURCC_MJPEG, "carries the MJPG FourCC");
         assert_eq!(parsed, jpeg.as_slice(), "round-trips the exact JPEG bytes");
 
-        // The full on-wire unit is [tag][fourcc][u32 len][jpeg]; assemble and
-        // dissect it the way a client reader would.
+        // The full on-wire unit is [tag][source_id][fourcc][u32 len][jpeg];
+        // assemble and dissect it the way a client reader would.
         let mut wire = vec![VIDEO_FRAME];
         wire.extend_from_slice(&body);
         assert_eq!(wire[0], VIDEO_FRAME, "leads with the video kind tag");
-        let (codec, parsed) = parse_video_payload(&wire[1..]).expect("payload after tag parses");
+        let (source_id, codec, parsed) =
+            parse_video_payload(&wire[1..]).expect("payload after tag parses");
+        assert_eq!(source_id, 1);
         assert_eq!(codec, FOURCC_MJPEG);
         assert_eq!(parsed, jpeg.as_slice());
     }

--- a/hosts/session-host/src/runtime/stream_tag.rs
+++ b/hosts/session-host/src/runtime/stream_tag.rs
@@ -13,8 +13,10 @@
 pub const AUTHORITY_EVENTS: u8 = 0x01;
 
 /// Tag prefixing a per-frame video stream: a
-/// `[fourcc: 4 bytes][u32 LE len][payload]` media unit follows this byte
-/// (ADR-0005 media = one uni stream per frame; ADR-0016 codec tag).
+/// `[source_id: u8][fourcc: 4 bytes][u32 LE len][payload]` media unit follows
+/// this byte (ADR-0005 media = one uni stream per frame; ADR-0016 codec tag).
+/// `source_id` names the video source (0 = onboard FPV, 1 = chase) so a client
+/// with several sources routes each frame to the right one.
 pub const VIDEO_FRAME: u8 = 0x02;
 
 /// FourCC codec tag for Motion JPEG frames (ADR-0016).
@@ -28,41 +30,45 @@ pub const VIDEO_FRAME: u8 = 0x02;
 pub const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
 
 /// Serializes one encoded frame as the on-wire video-stream body that follows
-/// the [`VIDEO_FRAME`] tag: the 4-byte `codec` FourCC (ADR-0016), a
-/// little-endian `u32` length prefix, and the encoded bytes. The tag itself is
-/// written separately by the media task, so this is only the codec-tagged,
-/// length-prefixed payload.
+/// the [`VIDEO_FRAME`] tag: a 1-byte `source_id` (0 = onboard FPV, 1 = chase),
+/// the 4-byte `codec` FourCC (ADR-0016), a little-endian `u32` length prefix,
+/// and the encoded bytes. The tag itself is written separately by the media
+/// task, so this is only the source-tagged, codec-tagged, length-prefixed
+/// payload.
 ///
 /// Returns the framed bytes, or `None` if `payload` is larger than `u32::MAX`
 /// (far beyond any real camera frame; a length that cannot be expressed in
 /// the 4-byte prefix must not be silently truncated).
 #[must_use]
-pub fn frame_video_payload(codec: [u8; 4], payload: &[u8]) -> Option<Vec<u8>> {
+pub fn frame_video_payload(source_id: u8, codec: [u8; 4], payload: &[u8]) -> Option<Vec<u8>> {
     let len = u32::try_from(payload.len()).ok()?;
-    let mut out = Vec::with_capacity(4 + 4 + payload.len());
+    let mut out = Vec::with_capacity(1 + 4 + 4 + payload.len());
+    out.push(source_id);
     out.extend_from_slice(&codec);
     out.extend_from_slice(&len.to_le_bytes());
     out.extend_from_slice(payload);
     Some(out)
 }
 
-/// Parses a codec-tagged, length-prefixed video-stream body produced by
-/// [`frame_video_payload`] (the bytes after the [`VIDEO_FRAME`] tag),
-/// returning the `(fourcc, payload)` pair.
+/// Parses a source-tagged, codec-tagged, length-prefixed video-stream body
+/// produced by [`frame_video_payload`] (the bytes after the [`VIDEO_FRAME`]
+/// tag), returning the `(source_id, fourcc, payload)` triple.
 ///
-/// Returns `None` if fewer than the four FourCC plus four length bytes are
-/// present or the declared length does not match the remaining bytes exactly.
-/// Only the framing round-trip tests parse the payload back host-side; the
-/// real client readers live in the native viewer and the browser.
+/// Returns `None` if fewer than the one source-id plus four FourCC plus four
+/// length bytes are present or the declared length does not match the
+/// remaining bytes exactly. Only the framing round-trip tests parse the
+/// payload back host-side; the real client readers live in the native viewer
+/// and the browser.
 #[cfg(test)]
 #[must_use]
-pub fn parse_video_payload(body: &[u8]) -> Option<([u8; 4], &[u8])> {
-    let (fourcc, rest) = body.split_at_checked(4)?;
+pub fn parse_video_payload(body: &[u8]) -> Option<(u8, [u8; 4], &[u8])> {
+    let (source_id, rest) = body.split_first()?;
+    let (fourcc, rest) = rest.split_at_checked(4)?;
     let (len_bytes, rest) = rest.split_at_checked(4)?;
     let declared = u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]]);
     let declared = usize::try_from(declared).ok()?;
     let fourcc = [fourcc[0], fourcc[1], fourcc[2], fourcc[3]];
-    (rest.len() == declared).then_some((fourcc, rest))
+    (rest.len() == declared).then_some((*source_id, fourcc, rest))
 }
 
 #[cfg(test)]
@@ -73,31 +79,36 @@ mod tests {
     #[test]
     fn framing_round_trips() {
         let jpeg = vec![0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3, 0xFF, 0xD9];
-        let framed = frame_video_payload(FOURCC_MJPEG, &jpeg).expect("small frame frames");
-        assert_eq!(&framed[..4], b"MJPG");
-        assert_eq!(&framed[4..8], &(jpeg.len() as u32).to_le_bytes());
-        let (codec, parsed) = parse_video_payload(&framed).expect("body parses back");
+        let framed = frame_video_payload(1, FOURCC_MJPEG, &jpeg).expect("small frame frames");
+        assert_eq!(framed[0], 1, "leads with the source id");
+        assert_eq!(&framed[1..5], b"MJPG");
+        assert_eq!(&framed[5..9], &(jpeg.len() as u32).to_le_bytes());
+        let (source_id, codec, parsed) = parse_video_payload(&framed).expect("body parses back");
+        assert_eq!(source_id, 1);
         assert_eq!(codec, FOURCC_MJPEG);
         assert_eq!(parsed, jpeg.as_slice());
     }
 
     #[test]
     fn empty_jpeg_frames_and_parses() {
-        let framed = frame_video_payload(FOURCC_MJPEG, &[]).expect("empty frames");
-        assert_eq!(framed, vec![b'M', b'J', b'P', b'G', 0, 0, 0, 0]);
-        assert_eq!(parse_video_payload(&framed), Some((FOURCC_MJPEG, &[][..])));
+        let framed = frame_video_payload(0, FOURCC_MJPEG, &[]).expect("empty frames");
+        assert_eq!(framed, vec![0, b'M', b'J', b'P', b'G', 0, 0, 0, 0]);
+        assert_eq!(
+            parse_video_payload(&framed),
+            Some((0, FOURCC_MJPEG, &[][..]))
+        );
     }
 
     #[test]
     fn truncated_header_is_rejected() {
-        // Fewer than the 8-byte fourcc+length header.
-        assert_eq!(parse_video_payload(&[b'M', b'J', 0, 0]), None);
+        // Fewer than the 1-byte source id plus 8-byte fourcc+length header.
+        assert_eq!(parse_video_payload(&[0, b'M', b'J', 0, 0]), None);
     }
 
     #[test]
     fn length_mismatch_is_rejected() {
         // Declares 5 bytes but only 2 follow.
-        let body = vec![b'M', b'J', b'P', b'G', 5, 0, 0, 0, 1, 2];
+        let body = vec![0, b'M', b'J', b'P', b'G', 5, 0, 0, 0, 1, 2];
         assert_eq!(parse_video_payload(&body), None);
     }
 }

--- a/schemas/pilotage/bridge/v1/bridge.proto
+++ b/schemas/pilotage/bridge/v1/bridge.proto
@@ -35,6 +35,9 @@ message BridgeFrame {
   string pixel_format = 3;
   uint64 sim_time_ns = 4;
   bytes rgb = 5;
+  // Video source this frame came from: 0 = onboard FPV camera, 1 = chase
+  // camera. Additional sources may be assigned higher ids later.
+  uint32 camera_id = 6;
 }
 
 // Wraps exactly one bridge payload for length-delimited framing over the

--- a/sim/worlds/pilotage_yard.sdf
+++ b/sim/worlds/pilotage_yard.sdf
@@ -226,6 +226,29 @@
           <visualize>true</visualize>
           <topic>camera</topic>
         </sensor>
+
+        <!-- Chase camera, rigidly attached to the same chassis link so it
+             moves and yaws with the vehicle: a 3rd-person view positioned
+             behind and above, pitched down to frame the vehicle plus the
+             scene ahead. -->
+        <sensor name="chase_camera" type="camera">
+          <pose>-3.0 0 1.8 0 0.30 0</pose>
+          <camera>
+            <horizontal_fov>1.6</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+          <topic>chase_camera</topic>
+        </sensor>
       </link>
 
       <link name='left_wheel'>

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -61,7 +61,9 @@ pub enum ReceiverEvent {
     /// measured by the run loop's own wall clock at the point it receives
     /// this event, not by a timestamp carried on the event itself.
     VideoFrame {
-        /// The JPEG bytes (tag and length prefix already stripped).
+        /// Video source this frame came from: 0 = onboard FPV, 1 = chase.
+        source_id: u8,
+        /// The JPEG bytes (tag, source id, and length prefix already stripped).
         jpeg: Vec<u8>,
     },
 }

--- a/tools/loopback-probe/src/receiver/uni_stream.rs
+++ b/tools/loopback-probe/src/receiver/uni_stream.rs
@@ -5,8 +5,8 @@
 //! stream is read to completion by a short-lived task so a slow video decode
 //! never blocks accepting the next stream. The authority-events stream stays
 //! open for the connection's lifetime (repeated length-delimited envelopes); a
-//! video-frame stream carries exactly one `[fourcc][u32 LE len][jpeg]` body
-//! (ADR-0016) and closes.
+//! video-frame stream carries exactly one
+//! `[source_id][fourcc][u32 LE len][jpeg]` body (ADR-0016) and closes.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -103,8 +103,9 @@ async fn read_authority_stream(
 /// FourCC of the only video codec this viewer decodes: Motion JPEG (ADR-0016).
 const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
 
-/// Reads one video-frame stream to completion (`[fourcc][u32 LE len][payload]`,
-/// ADR-0016), then forwards the JPEG bytes as a single
+/// Reads one video-frame stream to completion
+/// (`[source_id][fourcc][u32 LE len][payload]`, ADR-0016), then forwards the
+/// JPEG bytes (tagged with their `source_id`) as a single
 /// [`ReceiverEvent::VideoFrame`]. A frame whose FourCC is not [`FOURCC_MJPEG`]
 /// is skipped with a warning, never a hard failure, so a host streaming a
 /// codec this viewer lacks degrades gracefully.
@@ -116,7 +117,7 @@ async fn read_video_stream(
     dropped_events: Arc<AtomicU64>,
 ) {
     loop {
-        if let Some((fourcc, payload)) = try_take_video_payload(&mut buf) {
+        if let Some((source_id, fourcc, payload)) = try_take_video_payload(&mut buf) {
             if fourcc != FOURCC_MJPEG {
                 warn!(
                     codec = %String::from_utf8_lossy(&fourcc),
@@ -127,7 +128,10 @@ async fn read_video_stream(
             forward_event(
                 &events_tx,
                 &dropped_events,
-                ReceiverEvent::VideoFrame { jpeg: payload },
+                ReceiverEvent::VideoFrame {
+                    source_id,
+                    jpeg: payload,
+                },
             );
             return;
         }
@@ -145,25 +149,26 @@ async fn read_video_stream(
     }
 }
 
-/// Parses a `[fourcc: 4 bytes][u32 LE len][payload]` body (ADR-0016) once
-/// `buf` holds the declared length in full, returning the `(fourcc, payload)`
-/// pair and leaving `buf` empty. Returns `None` if fewer than the 8-byte
-/// fourcc+length header, or fewer than the declared payload length, have
-/// arrived yet.
-fn try_take_video_payload(buf: &mut Vec<u8>) -> Option<([u8; 4], Vec<u8>)> {
-    const HEADER: usize = 8;
+/// Parses a `[source_id: 1 byte][fourcc: 4 bytes][u32 LE len][payload]` body
+/// (ADR-0016) once `buf` holds the declared length in full, returning the
+/// `(source_id, fourcc, payload)` triple and leaving `buf` empty. Returns
+/// `None` if fewer than the 9-byte source-id+fourcc+length header, or fewer
+/// than the declared payload length, have arrived yet.
+fn try_take_video_payload(buf: &mut Vec<u8>) -> Option<(u8, [u8; 4], Vec<u8>)> {
+    const HEADER: usize = 9;
     if buf.len() < HEADER {
         return None;
     }
-    let fourcc = [buf[0], buf[1], buf[2], buf[3]];
-    let declared = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    let source_id = buf[0];
+    let fourcc = [buf[1], buf[2], buf[3], buf[4]];
+    let declared = u32::from_le_bytes([buf[5], buf[6], buf[7], buf[8]]);
     let declared = usize::try_from(declared).ok()?;
     if buf.len() < HEADER + declared {
         return None;
     }
     let payload = buf[HEADER..HEADER + declared].to_vec();
     buf.drain(..HEADER + declared);
-    Some((fourcc, payload))
+    Some((source_id, fourcc, payload))
 }
 
 #[cfg(test)]
@@ -173,15 +178,17 @@ mod tests {
 
     #[test]
     fn video_payload_waits_for_full_declared_length() {
-        // [MJPG][len=3][1,2] — one payload byte still missing.
-        let mut buf = vec![b'M', b'J', b'P', b'G', 3, 0, 0, 0, 1, 2];
+        // [src=1][MJPG][len=3][1,2] — one payload byte still missing.
+        let mut buf = vec![1, b'M', b'J', b'P', b'G', 3, 0, 0, 0, 1, 2];
         assert_eq!(
             try_take_video_payload(&mut buf),
             None,
             "only 2 of 3 payload bytes present"
         );
         buf.push(3);
-        let (codec, jpeg) = try_take_video_payload(&mut buf).expect("full frame present");
+        let (source_id, codec, jpeg) =
+            try_take_video_payload(&mut buf).expect("full frame present");
+        assert_eq!(source_id, 1, "reads the chase source id");
         assert_eq!(codec, FOURCC_MJPEG);
         assert_eq!(jpeg, vec![1, 2, 3]);
         assert!(buf.is_empty(), "consumed bytes are drained");
@@ -189,9 +196,10 @@ mod tests {
 
     #[test]
     fn video_payload_leaves_trailing_bytes_for_the_next_frame() {
-        // [MJPG][len=1][0xAB] then the start of a second frame.
-        let mut buf = vec![b'M', b'J', b'P', b'G', 1, 0, 0, 0, 0xAB, b'M', b'J'];
-        let (_, first) = try_take_video_payload(&mut buf).expect("first frame present");
+        // [src=0][MJPG][len=1][0xAB] then the start of a second frame.
+        let mut buf = vec![0, b'M', b'J', b'P', b'G', 1, 0, 0, 0, 0xAB, b'M', b'J'];
+        let (source_id, _, first) = try_take_video_payload(&mut buf).expect("first frame present");
+        assert_eq!(source_id, 0, "reads the FPV source id");
         assert_eq!(first, vec![0xAB]);
         assert_eq!(buf, vec![b'M', b'J']);
     }

--- a/tools/loopback-probe/src/run.rs
+++ b/tools/loopback-probe/src/run.rs
@@ -178,8 +178,8 @@ async fn wait_for_rejection(
                 metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
                 metrics.last_pose = Some(observation.pose);
             }
-            Ok(Some(ReceiverEvent::VideoFrame { jpeg, .. })) => {
-                fold_video_frame(&jpeg, video, &mut last_video_at);
+            Ok(Some(ReceiverEvent::VideoFrame { source_id, jpeg })) => {
+                fold_video_frame(source_id, &jpeg, video, &mut last_video_at);
             }
             Ok(Some(ReceiverEvent::Pong { .. } | ReceiverEvent::Authority)) | Err(_) => {}
             Ok(None) => return false,
@@ -205,8 +205,8 @@ fn drain_pending_events(
             ReceiverEvent::FrameRejected(_) => {
                 metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
             }
-            ReceiverEvent::VideoFrame { jpeg, .. } => {
-                fold_video_frame(&jpeg, video, &mut last_video_at);
+            ReceiverEvent::VideoFrame { source_id, jpeg } => {
+                fold_video_frame(source_id, &jpeg, video, &mut last_video_at);
             }
             ReceiverEvent::Pong { .. } | ReceiverEvent::Authority => {}
         }
@@ -218,9 +218,14 @@ fn drain_pending_events(
 /// the frame's `received_at` field — both derive from the same wall clock, so
 /// either would do; this uses a plain `Instant` since the gap is all that
 /// matters here, not an absolute timestamp).
-fn fold_video_frame(jpeg: &[u8], video: &mut VideoStats, last_video_at: &mut Option<Instant>) {
+fn fold_video_frame(
+    source_id: u8,
+    jpeg: &[u8],
+    video: &mut VideoStats,
+    last_video_at: &mut Option<Instant>,
+) {
     let now = Instant::now();
     let gap = last_video_at.map(|previous| now.duration_since(previous));
     *last_video_at = Some(now);
-    video.record(jpeg, gap);
+    video.record(source_id, jpeg, gap);
 }

--- a/tools/loopback-probe/src/save_frames.rs
+++ b/tools/loopback-probe/src/save_frames.rs
@@ -1,6 +1,7 @@
 //! `--save-frames DIR`: writes the first, a middle, and the last decoded
-//! video frame as PNG files, giving visual proof the video downlink carried
-//! real, decodable camera frames.
+//! video frame as PNG files, plus one PNG per video source (`fpv.png`,
+//! `chase.png`), giving visual proof the video downlink carried real,
+//! decodable camera frames from each source.
 
 use tracing::warn;
 
@@ -21,6 +22,13 @@ pub async fn save_proof_frames(video: &VideoStats, dir: &str) {
     )
     .await;
     save_one(video.last_frame.as_ref(), &dir.join("last.png"), "last").await;
+    save_one(video.fpv_first_frame.as_ref(), &dir.join("fpv.png"), "fpv").await;
+    save_one(
+        video.chase_first_frame.as_ref(),
+        &dir.join("chase.png"),
+        "chase",
+    )
+    .await;
 }
 
 /// Saves one optional frame, logging a warning instead of failing the run if

--- a/tools/loopback-probe/src/sender.rs
+++ b/tools/loopback-probe/src/sender.rs
@@ -263,13 +263,13 @@ fn handle_event(
             let rtt = estimated_age(received_at, pong.echoed_sender_sent_at, ZERO_OFFSET);
             metrics.rtt.record(rtt);
         }
-        ReceiverEvent::VideoFrame { jpeg, .. } => {
+        ReceiverEvent::VideoFrame { source_id, jpeg } => {
             let now = Instant::now();
             let gap = state
                 .last_video_at
                 .map(|previous| now.duration_since(previous));
             state.last_video_at = Some(now);
-            video.record_at(&jpeg, gap, Some((elapsed, state.run_budget)));
+            video.record_at(source_id, &jpeg, gap, Some((elapsed, state.run_budget)));
         }
         ReceiverEvent::Authority => {}
     }

--- a/tools/loopback-probe/src/summary.rs
+++ b/tools/loopback-probe/src/summary.rs
@@ -64,6 +64,10 @@ fn print_video(video: &VideoStats, elapsed: Duration) {
         "video frames received: {} (decoded {}, decode failed {})",
         video.frames_received, video.frames_decoded, video.frames_decode_failed
     ));
+    print_line(&format!(
+        "video frames by source: fpv={} chase={}",
+        video.fpv_received, video.chase_received
+    ));
     match video.avg_fps(elapsed) {
         Some(fps) => print_line(&format!("video avg fps:       {fps:.2}")),
         None => print_line("video avg fps:       no frames decoded"),

--- a/tools/loopback-probe/src/video.rs
+++ b/tools/loopback-probe/src/video.rs
@@ -52,6 +52,10 @@ pub fn decode_jpeg(bytes: &[u8]) -> Option<DecodedFrame> {
 pub struct VideoStats {
     /// JPEG byte buffers received (whether or not they decoded).
     pub frames_received: u64,
+    /// Frames received on the onboard FPV source (source id 0).
+    pub fpv_received: u64,
+    /// Frames received on the chase source (source id 1).
+    pub chase_received: u64,
     /// Frames that decoded successfully.
     pub frames_decoded: u64,
     /// Frames that failed to decode.
@@ -65,6 +69,12 @@ pub struct VideoStats {
     pub last_dims: Option<(u32, u32)>,
     /// The first successfully decoded frame, retained for `--save-frames`.
     pub first_frame: Option<DecodedFrame>,
+    /// First successfully decoded frame from the onboard FPV source (id 0),
+    /// retained so `--save-frames` can prove each source streamed separately.
+    pub fpv_first_frame: Option<DecodedFrame>,
+    /// First successfully decoded frame from the chase source (id 1), retained
+    /// so `--save-frames` can prove each source streamed separately.
+    pub chase_first_frame: Option<DecodedFrame>,
     /// The most recently decoded frame; at run end this is also the "last"
     /// frame for `--save-frames`.
     pub last_frame: Option<DecodedFrame>,
@@ -84,21 +94,26 @@ impl VideoStats {
     pub fn new() -> Self {
         Self {
             frames_received: 0,
+            fpv_received: 0,
+            chase_received: 0,
             frames_decoded: 0,
             frames_decode_failed: 0,
             inter_arrival: Histogram::new(VIDEO_HISTOGRAM_CAPACITY),
             last_dims: None,
             first_frame: None,
+            fpv_first_frame: None,
+            chase_first_frame: None,
             last_frame: None,
             middle_frame: None,
         }
     }
 
     /// Folds one arrived JPEG buffer into the stats: decodes it, records
-    /// inter-arrival latency against `since_last`, and updates the retained
-    /// first/last frames.
-    pub fn record(&mut self, jpeg: &[u8], since_last: Option<Duration>) {
-        self.record_at(jpeg, since_last, None);
+    /// inter-arrival latency against `since_last`, counts the frame against its
+    /// `source_id` (0 = FPV, 1 = chase), and updates the retained first/last
+    /// frames.
+    pub fn record(&mut self, source_id: u8, jpeg: &[u8], since_last: Option<Duration>) {
+        self.record_at(source_id, jpeg, since_last, None);
     }
 
     /// Like [`Self::record`], additionally capturing this frame as the
@@ -107,11 +122,17 @@ impl VideoStats {
     /// time. `run_progress` is `(elapsed, total_budget)`.
     pub fn record_at(
         &mut self,
+        source_id: u8,
         jpeg: &[u8],
         since_last: Option<Duration>,
         run_progress: Option<(Duration, Duration)>,
     ) {
         self.frames_received = self.frames_received.saturating_add(1);
+        match source_id {
+            0 => self.fpv_received = self.fpv_received.saturating_add(1),
+            1 => self.chase_received = self.chase_received.saturating_add(1),
+            _ => {}
+        }
         let Some(frame) = decode_jpeg(jpeg) else {
             self.frames_decode_failed = self.frames_decode_failed.saturating_add(1);
             return;
@@ -123,6 +144,15 @@ impl VideoStats {
         }
         if self.first_frame.is_none() {
             self.first_frame = Some(frame.clone());
+        }
+        match source_id {
+            0 if self.fpv_first_frame.is_none() => {
+                self.fpv_first_frame = Some(frame.clone());
+            }
+            1 if self.chase_first_frame.is_none() => {
+                self.chase_first_frame = Some(frame.clone());
+            }
+            _ => {}
         }
         if self.middle_frame.is_none()
             && let Some((elapsed, total)) = run_progress
@@ -220,9 +250,11 @@ mod tests {
     fn record_tracks_counts_and_dims() {
         let jpeg = synthetic_jpeg(8, 8);
         let mut stats = VideoStats::new();
-        stats.record(&jpeg, None);
-        stats.record(&jpeg, Some(Duration::from_millis(33)));
+        stats.record(0, &jpeg, None);
+        stats.record(1, &jpeg, Some(Duration::from_millis(33)));
         assert_eq!(stats.frames_received, 2);
+        assert_eq!(stats.fpv_received, 1, "one FPV frame counted");
+        assert_eq!(stats.chase_received, 1, "one chase frame counted");
         assert_eq!(stats.frames_decoded, 2);
         assert_eq!(stats.frames_decode_failed, 0);
         assert_eq!(stats.last_dims, Some((8, 8)));
@@ -232,7 +264,7 @@ mod tests {
     #[test]
     fn record_counts_decode_failures_without_touching_dims() {
         let mut stats = VideoStats::new();
-        stats.record(&[0xFF, 0x00], None);
+        stats.record(0, &[0xFF, 0x00], None);
         assert_eq!(stats.frames_received, 1);
         assert_eq!(stats.frames_decoded, 0);
         assert_eq!(stats.frames_decode_failed, 1);
@@ -243,7 +275,7 @@ mod tests {
     fn avg_fps_requires_decoded_frames_and_nonzero_elapsed() {
         let mut stats = VideoStats::new();
         assert_eq!(stats.avg_fps(Duration::from_secs(1)), None);
-        stats.record(&synthetic_jpeg(4, 4), None);
+        stats.record(0, &synthetic_jpeg(4, 4), None);
         assert_eq!(stats.avg_fps(Duration::ZERO), None);
         let fps = stats.avg_fps(Duration::from_secs(2)).expect("has fps");
         assert!((fps - 0.5).abs() < 1e-9);
@@ -252,8 +284,8 @@ mod tests {
     #[test]
     fn first_frame_is_retained_across_records() {
         let mut stats = VideoStats::new();
-        stats.record(&synthetic_jpeg(4, 4), None);
-        stats.record(&synthetic_jpeg(6, 6), None);
+        stats.record(0, &synthetic_jpeg(4, 4), None);
+        stats.record(0, &synthetic_jpeg(6, 6), None);
         let first = stats.first_frame.as_ref().expect("first frame retained");
         assert_eq!((first.width, first.height), (4, 4));
         let last = stats.last_frame.as_ref().expect("last frame retained");


### PR DESCRIPTION
Adds a 3rd-person chase camera to the demo, streamed as a second video source alongside the onboard FPV camera, and shown side by side in the browser viewer.

**What lands**
- **World** — a `chase_camera` on the vehicle chassis (behind + above, pitched down) that yaws with the vehicle, so it's a true follow-cam. Publishes on its own `chase_camera` topic.
- **Bridge** — the C++ gz-transport sidecar subscribes both camera topics and tags each `BridgeFrame` with `camera_id` (0 onboard / 1 chase).
- **Wire** — the video uni-stream body gains a leading `source_id` byte: `[0x02][source_id][MJPG][u32 len][jpeg]` (ADR-0016). The host opens a per-(client, source) drop-to-latest writer so a slow chase feed never starves FPV; `loopback-probe` and the browser both route on the source id.
- **Viewer** — two labeled canvases (FPV / onboard, chase / 3rd person); unknown source id or codec is a counted, logged skip.

**Gate results (run locally):** cmake bridge built; fmt clean; clippy `--all-targets -D warnings` clean; **341 tests, 0 failures**; doc `-D missing_docs` clean; release build; structure limits clean.

**Live-verified on real Gazebo:** both sources decode (fpv 181 / chase 182 frames, 0 failures, ~30 fps each), vehicle odometry moves under control, stale-generation fencing intact, clean SIGINT shutdown with no orphans. Confirmed in-browser: both canvases render side by side (screenshots in the session), FPV = onboard forward view, chase = the vehicle seen from behind — not swapped.

Built by an orchestrated workflow (world/proto → bridge → adapter+host wire → viewer) with per-layer adversarial review; the source-id byte order was the coupling-critical contract and is consistent across all six layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)