### PR TITLE
Fly the Aviate quad from the browser: DJI-style velocity control, flight schemes, in-browser cameras (#12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "pilotage-adapter-api",
+ "pilotage-adapter-gazebo",
  "pilotage-protocol",
  "pilotage-timing",
  "thiserror",

--- a/adapters/aviate/Cargo.toml
+++ b/adapters/aviate/Cargo.toml
@@ -27,6 +27,7 @@ disallowed_macros = "deny"
 [dependencies]
 libc = { workspace = true }
 pilotage-adapter-api = { workspace = true }
+pilotage-adapter-gazebo = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
 thiserror = { workspace = true }

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -42,6 +42,9 @@ pub const DISARM_BUTTON: u16 = 1;
 /// Logical button whose press resets the simulation (runs the reset
 /// script; SITL-only convenience).
 pub const RESET_BUTTON: u16 = 2;
+/// Logical button toggling between camera mode (velocity sticks,
+/// brake-to-hold) and FPV mode (attitude sticks, direct thrust).
+pub const FPV_TOGGLE_BUTTON: u16 = 3;
 
 /// Data older than this is withheld from telemetry entirely, so
 /// downstream freshness models see the group's age grow instead of a
@@ -94,6 +97,9 @@ pub struct AviateAdapter {
     armed: Option<bool>,
     last_reset: Option<std::time::Instant>,
     link_loss_policy: Option<LinkLossPolicy>,
+    // FPV mode latch (FPV_TOGGLE_BUTTON): attitude sticks + direct
+    // thrust instead of velocity sticks + brake-to-hold.
+    fpv_mode: bool,
 }
 
 impl AviateAdapter {
@@ -142,6 +148,7 @@ impl AviateAdapter {
             _frame_forwarder: frame_forwarder,
             armed: None,
             last_reset: None,
+            fpv_mode: false,
             link_loss_policy: None,
         })
     }
@@ -212,6 +219,7 @@ impl AviateAdapter {
             _frame_forwarder: None,
             armed: None,
             last_reset: None,
+            fpv_mode: false,
             link_loss_policy: None,
         }
     }
@@ -338,6 +346,9 @@ impl VehicleAdapter for AviateAdapter {
                 uplink.send_arm(true, current_yaw);
             } else if *button == LogicalButtonId::new(DISARM_BUTTON) {
                 uplink.send_arm(false, current_yaw);
+            } else if *button == LogicalButtonId::new(FPV_TOGGLE_BUTTON) {
+                self.fpv_mode = !self.fpv_mode;
+                tracing::info!(fpv = self.fpv_mode, "flight mode toggled");
             }
         }
 
@@ -352,14 +363,23 @@ impl VehicleAdapter for AviateAdapter {
             transformed |= clamped != *value;
             sticks[usize::from(axis.as_u16().min(3))] = clamped;
         }
-        uplink.send_stick_frame(
-            sticks[usize::from(ROLL_AXIS)],
-            sticks[usize::from(PITCH_AXIS)],
-            sticks[usize::from(THROTTLE_AXIS)],
-            sticks[usize::from(YAW_AXIS)],
-            current_yaw,
-            current_pos,
-        );
+        if self.fpv_mode {
+            uplink.send_fpv_frame(
+                sticks[usize::from(ROLL_AXIS)],
+                sticks[usize::from(PITCH_AXIS)],
+                sticks[usize::from(THROTTLE_AXIS)],
+                sticks[usize::from(YAW_AXIS)],
+            );
+        } else {
+            uplink.send_stick_frame(
+                sticks[usize::from(ROLL_AXIS)],
+                sticks[usize::from(PITCH_AXIS)],
+                sticks[usize::from(THROTTLE_AXIS)],
+                sticks[usize::from(YAW_AXIS)],
+                current_yaw,
+                current_pos,
+            );
+        }
         ApplyOutcome {
             tick,
             disposition: if transformed {

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -7,15 +7,34 @@ use std::time::Duration;
 
 use pilotage_adapter_api::{
     AdapterCapabilities, ApplyOutcome, AvionicsSample, Disposition, ExecutionMode, LinkLossPolicy,
-    Pose2d, RejectReason, StepBudget, StepOutcome, TelemetryBatch, TelemetrySample, VehicleAdapter,
-    VehicleDescriptor, VideoSource,
+    Pose2d, RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch,
+    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
 };
-use pilotage_protocol::{ScopedControlFrame, VehicleId};
+use pilotage_protocol::{
+    ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame, VehicleId,
+};
 use pilotage_timing::SimTick;
 
 use crate::error::AviateAdapterError;
 use crate::link::{AviateLink, LatestAviate, LinkConfig};
 use crate::shm::{GzStateShm, ShmFreshness};
+use crate::uplink::FlightUplink;
+
+/// The control scope this adapter exposes (issue #12): four canonical
+/// flight axes as DJI-style velocity demands.
+pub const FLIGHT_SCOPE: &str = "vehicle.motion";
+/// Canonical `roll` axis (0): lateral velocity, + = right.
+pub const ROLL_AXIS: u16 = 0;
+/// Canonical `pitch` axis (1): forward velocity, + = forward.
+pub const PITCH_AXIS: u16 = 1;
+/// Canonical `throttle` axis (2): climb rate, + = climb.
+pub const THROTTLE_AXIS: u16 = 2;
+/// Canonical `yaw` axis (3): yaw rate, + = clockwise.
+pub const YAW_AXIS: u16 = 3;
+/// Logical button whose press arms the vehicle.
+pub const ARM_BUTTON: u16 = 0;
+/// Logical button whose press disarms the vehicle.
+pub const DISARM_BUTTON: u16 = 1;
 
 /// Data older than this is withheld from telemetry entirely, so
 /// downstream freshness models see the group's age grow instead of a
@@ -58,6 +77,12 @@ enum Source {
 pub struct AviateAdapter {
     vehicle: VehicleId,
     source: Source,
+    uplink: Option<FlightUplink>,
+    // Camera path (issue #12): Pilotage's own gz sidecar bridges the
+    // flight world's camera topics; absent when the sidecar can't spawn.
+    frames: Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
+    _camera_bridge: Option<pilotage_adapter_gazebo::BridgeClient>,
+    _frame_forwarder: Option<tokio::task::JoinHandle<()>>,
     link_loss_policy: Option<LinkLossPolicy>,
 }
 
@@ -87,11 +112,75 @@ impl AviateAdapter {
                 }
             },
         };
+        // A failed uplink bind degrades to telemetry-only rather than
+        // failing the adapter: displaying a flight you cannot command
+        // beats displaying nothing.
+        let uplink = match FlightUplink::new() {
+            Ok(uplink) => Some(uplink),
+            Err(error) => {
+                tracing::warn!(%error, "flight uplink unavailable; telemetry-only");
+                None
+            }
+        };
+        let (frames, camera_bridge, frame_forwarder) = Self::camera_bridge().await;
         Ok(Self {
             vehicle,
             source,
+            uplink,
+            frames,
+            _camera_bridge: camera_bridge,
+            _frame_forwarder: frame_forwarder,
             link_loss_policy: None,
         })
+    }
+
+    /// Spawns the gz camera sidecar for the flight world's `/camera` and
+    /// `/chase_camera` topics, degrading to no-video when it can't
+    /// (`PILOTAGE_AVIATE_CAMERA=off` disables the attempt).
+    #[allow(clippy::type_complexity)]
+    async fn camera_bridge() -> (
+        Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
+        Option<pilotage_adapter_gazebo::BridgeClient>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) {
+        if std::env::var("PILOTAGE_AVIATE_CAMERA").as_deref() == Ok("off") {
+            return (None, None, None);
+        }
+        let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .map_or_else(|| std::path::PathBuf::from("."), std::path::PathBuf::from);
+        let bin = workspace_root.join("adapters/gazebo/bridge/build/pilotage-gz-bridge");
+        let config = pilotage_adapter_gazebo::BridgeConfig::new("x500", bin);
+        match pilotage_adapter_gazebo::BridgeClient::spawn_and_connect(config).await {
+            Ok(mut bridge) => {
+                let (tx, rx) = tokio::sync::mpsc::channel(4);
+                let forwarder = bridge.take_frame_rx().map(|mut bridge_rx| {
+                    tokio::spawn(async move {
+                        while let Some(frame) = bridge_rx.recv().await {
+                            let raw = pilotage_adapter_gazebo::RawVideoFrame::from(frame);
+                            if tx.send(raw).await.is_err() {
+                                return;
+                            }
+                        }
+                    })
+                });
+                tracing::info!("Aviate camera sidecar up (FPV + chase)");
+                (Some(rx), Some(bridge), forwarder)
+            }
+            Err(error) => {
+                tracing::warn!(%error, "camera sidecar unavailable; no video");
+                (None, None, None)
+            }
+        }
+    }
+
+    /// Takes the raw-frame receiver for the host media task, if cameras
+    /// are up and it has not been taken.
+    pub fn subscribe_frames(
+        &mut self,
+    ) -> Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>> {
+        self.frames.take()
     }
 
     fn shm_source(instance: u8) -> Result<Source, AviateAdapterError> {
@@ -116,8 +205,53 @@ impl AviateAdapter {
         Self {
             vehicle,
             source: Source::Mavlink { state, _link: None },
+            uplink: None,
+            frames: None,
+            _camera_bridge: None,
+            _frame_forwarder: None,
             link_loss_policy: None,
         }
+    }
+
+    /// Installs a test uplink, for tests.
+    #[cfg(test)]
+    pub(crate) fn with_uplink(mut self, uplink: FlightUplink) -> Self {
+        self.uplink = Some(uplink);
+        self
+    }
+
+    /// The vehicle's current measured yaw, radians clockwise from north
+    /// (zero before any telemetry).
+    fn current_yaw(&mut self) -> f32 {
+        match &self.source {
+            Source::Shm { shm, .. } => shm.read().map_or(0.0, |s| Self::yaw_of(s.quat_wxyz) as f32),
+            Source::Mavlink { state, .. } => state
+                .lock()
+                .ok()
+                .and_then(|latest| latest.attitude)
+                .map_or(0.0, |att| Self::yaw_of(att.quat_wxyz) as f32),
+        }
+    }
+
+    fn validate_flight_frame(&self, frame: &ScopedControlFrame) -> Result<(), RejectReason> {
+        if frame.vehicle != self.vehicle {
+            return Err(RejectReason::UnknownVehicle);
+        }
+        if frame.scope.as_str() != FLIGHT_SCOPE {
+            return Err(RejectReason::UnknownScope);
+        }
+        let known = [
+            LogicalAxisId::new(ROLL_AXIS),
+            LogicalAxisId::new(PITCH_AXIS),
+            LogicalAxisId::new(THROTTLE_AXIS),
+            LogicalAxisId::new(YAW_AXIS),
+        ];
+        for (axis, _) in &frame.payload.axes {
+            if !known.contains(axis) {
+                return Err(RejectReason::UnknownAxis);
+            }
+        }
+        Ok(())
     }
 
     /// Yaw extracted from the body→NED quaternion (heading, radians
@@ -138,31 +272,96 @@ impl VehicleAdapter for AviateAdapter {
         AdapterCapabilities {
             execution: ExecutionMode {
                 real_time: true,
+                render_capable: self._camera_bridge.is_some(),
                 ..ExecutionMode::default()
             },
-            // Telemetry-only in this increment (ADR-0018): no control
-            // scopes are advertised, so leases have nothing to grant and
-            // every control frame is rejected below.
+            // The flight scope (issue #12): DJI-style velocity control.
+            // Without a working uplink the adapter stays telemetry-only
+            // (ADR-0018's original shape).
             vehicles: vec![VehicleDescriptor {
                 id: self.vehicle,
-                scopes: vec![],
-                link_loss_actions: vec![],
+                scopes: if self.uplink.is_some() {
+                    vec![ScopeDescriptor {
+                        scope: ScopeId::new(FLIGHT_SCOPE),
+                        axes: vec![
+                            LogicalAxisId::new(ROLL_AXIS),
+                            LogicalAxisId::new(PITCH_AXIS),
+                            LogicalAxisId::new(THROTTLE_AXIS),
+                            LogicalAxisId::new(YAW_AXIS),
+                        ],
+                    }]
+                } else {
+                    vec![]
+                },
+                link_loss_actions: if self.uplink.is_some() {
+                    vec![LinkLossPolicy::Neutralize]
+                } else {
+                    vec![]
+                },
             }],
             adapter_version: env!("CARGO_PKG_VERSION").to_owned(),
         }
     }
 
     fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
-        let disposition = if frame.vehicle == self.vehicle {
-            // Command uplink goes through Aviate's security gateway when
-            // it lands (ADR-0018); until then the boundary is closed.
-            Disposition::Rejected(RejectReason::UnknownScope)
-        } else {
-            Disposition::Rejected(RejectReason::UnknownVehicle)
+        let tick = self.step(StepBudget { ticks: 0 }).now;
+        if self.uplink.is_none() {
+            return ApplyOutcome {
+                tick,
+                disposition: Disposition::Rejected(RejectReason::UnknownScope),
+            };
+        }
+        if let Err(reason) = self.validate_flight_frame(frame) {
+            return ApplyOutcome {
+                tick,
+                disposition: Disposition::Rejected(reason),
+            };
+        }
+        let current_yaw = self.current_yaw();
+        let Some(uplink) = self.uplink.as_mut() else {
+            // Checked above; unreachable in practice.
+            return ApplyOutcome {
+                tick,
+                disposition: Disposition::Rejected(RejectReason::UnknownScope),
+            };
         };
+
+        for (button, edge) in &frame.payload.edges {
+            if *edge != ButtonEdge::Pressed {
+                continue;
+            }
+            if *button == LogicalButtonId::new(ARM_BUTTON) {
+                uplink.send_arm(true, current_yaw);
+            } else if *button == LogicalButtonId::new(DISARM_BUTTON) {
+                uplink.send_arm(false, current_yaw);
+            }
+        }
+
+        let mut sticks = [0.0f32; 4];
+        let mut transformed = false;
+        for (axis, value) in &frame.payload.axes {
+            let clamped = if value.is_nan() {
+                0.0
+            } else {
+                value.clamp(-1.0, 1.0)
+            };
+            transformed |= clamped != *value;
+            sticks[usize::from(axis.as_u16().min(3))] = clamped;
+        }
+        uplink.send_stick_frame(
+            sticks[usize::from(ROLL_AXIS)],
+            sticks[usize::from(PITCH_AXIS)],
+            sticks[usize::from(THROTTLE_AXIS)],
+            sticks[usize::from(YAW_AXIS)],
+            current_yaw,
+        );
         ApplyOutcome {
-            tick: self.step(StepBudget { ticks: 0 }).now,
-            disposition,
+            tick,
+            disposition: if transformed {
+                Disposition::Transformed
+            } else {
+                Disposition::Accepted
+            },
         }
     }
 
@@ -226,14 +425,34 @@ impl VehicleAdapter for AviateAdapter {
     }
 
     fn video_sources(&self) -> Vec<VideoSource> {
-        vec![]
+        if self._camera_bridge.is_none() {
+            return vec![];
+        }
+        vec![
+            VideoSource {
+                id: pilotage_adapter_gazebo::FPV_SOURCE_ID.to_owned(),
+                description: "onboard forward camera".to_owned(),
+            },
+            VideoSource {
+                id: pilotage_adapter_gazebo::CHASE_SOURCE_ID.to_owned(),
+                description: "chase camera".to_owned(),
+            },
+        ]
     }
 
     fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
-        if vehicle == self.vehicle {
-            // Telemetry-only: nothing to actuate; recorded for
-            // capability-conformance visibility.
-            self.link_loss_policy = policy;
+        if vehicle != self.vehicle {
+            return;
+        }
+        self.link_loss_policy = policy;
+        // Engaging any policy sends a zero-velocity setpoint: the FC's
+        // velocity mode brakes to a hover, which is the only safe action
+        // a camera drone has (`Neutralize`). Clearing (link recovery)
+        // leaves the FC hovering until the operator commands again.
+        if policy.is_some()
+            && let Some(uplink) = self.uplink.as_mut()
+        {
+            uplink.send_neutral();
         }
     }
 

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -21,6 +21,7 @@ use crate::shm::{GzStateShm, ShmFreshness};
 use crate::uplink::FlightUplink;
 
 mod camera;
+mod control;
 mod sampling;
 use sampling::{mavlink_batch, yaw_of};
 
@@ -159,36 +160,6 @@ impl AviateAdapter {
         &mut self,
     ) -> Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>> {
         self.frames.take()
-    }
-
-    /// Runs the SITL reset script (debounced to one per 5 s): world
-    /// reset + FC restart, fire-and-forget. `PILOTAGE_RESET_CMD`
-    /// overrides the script path.
-    fn spawn_reset(&mut self) {
-        let now = std::time::Instant::now();
-        if self
-            .last_reset
-            .is_some_and(|t| now.duration_since(t) < Duration::from_secs(5))
-        {
-            return;
-        }
-        self.last_reset = Some(now);
-        self.armed = None;
-        let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .and_then(std::path::Path::parent)
-                .map_or_else(|| ".".to_owned(), |p| p.display().to_string())
-                + "/scripts/reset-flight-sim.sh"
-        });
-        tracing::info!(%script, "simulation reset requested from the viewer");
-        match std::process::Command::new(&script)
-            .arg("aviate_sitl")
-            .spawn()
-        {
-            Ok(_) => {}
-            Err(error) => tracing::warn!(%error, %script, "reset script failed to spawn"),
-        }
     }
 
     fn shm_source(instance: u8) -> Result<Source, AviateAdapterError> {

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -39,6 +39,9 @@ pub const YAW_AXIS: u16 = 3;
 pub const ARM_BUTTON: u16 = 0;
 /// Logical button whose press disarms the vehicle.
 pub const DISARM_BUTTON: u16 = 1;
+/// Logical button whose press resets the simulation (runs the reset
+/// script; SITL-only convenience).
+pub const RESET_BUTTON: u16 = 2;
 
 /// Data older than this is withheld from telemetry entirely, so
 /// downstream freshness models see the group's age grow instead of a
@@ -89,6 +92,7 @@ pub struct AviateAdapter {
     _frame_forwarder: Option<tokio::task::JoinHandle<()>>,
     // Latest armed report from FC heartbeats on the uplink socket.
     armed: Option<bool>,
+    last_reset: Option<std::time::Instant>,
     link_loss_policy: Option<LinkLossPolicy>,
 }
 
@@ -137,6 +141,7 @@ impl AviateAdapter {
             _camera_bridge: camera_bridge,
             _frame_forwarder: frame_forwarder,
             armed: None,
+            last_reset: None,
             link_loss_policy: None,
         })
     }
@@ -147,6 +152,36 @@ impl AviateAdapter {
         &mut self,
     ) -> Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>> {
         self.frames.take()
+    }
+
+    /// Runs the SITL reset script (debounced to one per 5 s): world
+    /// reset + FC restart, fire-and-forget. `PILOTAGE_RESET_CMD`
+    /// overrides the script path.
+    fn spawn_reset(&mut self) {
+        let now = std::time::Instant::now();
+        if self
+            .last_reset
+            .is_some_and(|t| now.duration_since(t) < Duration::from_secs(5))
+        {
+            return;
+        }
+        self.last_reset = Some(now);
+        self.armed = None;
+        let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(std::path::Path::parent)
+                .map_or_else(|| ".".to_owned(), |p| p.display().to_string())
+                + "/scripts/reset-flight-sim.sh"
+        });
+        tracing::info!(%script, "simulation reset requested from the viewer");
+        match std::process::Command::new(&script)
+            .arg("aviate_sitl")
+            .spawn()
+        {
+            Ok(_) => {}
+            Err(error) => tracing::warn!(%error, %script, "reset script failed to spawn"),
+        }
     }
 
     fn shm_source(instance: u8) -> Result<Source, AviateAdapterError> {
@@ -176,6 +211,7 @@ impl AviateAdapter {
             _camera_bridge: None,
             _frame_forwarder: None,
             armed: None,
+            last_reset: None,
             link_loss_policy: None,
         }
     }
@@ -275,6 +311,15 @@ impl VehicleAdapter for AviateAdapter {
                 tick,
                 disposition: Disposition::Rejected(reason),
             };
+        }
+        // Reset is scanned before the uplink borrow (it needs &mut self).
+        if frame
+            .payload
+            .edges
+            .iter()
+            .any(|(b, e)| *e == ButtonEdge::Pressed && *b == LogicalButtonId::new(RESET_BUTTON))
+        {
+            self.spawn_reset();
         }
         let (current_yaw, current_pos) = self.current_pose();
         let Some(uplink) = self.uplink.as_mut() else {

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -20,6 +20,10 @@ use crate::link::{AviateLink, LatestAviate, LinkConfig};
 use crate::shm::{GzStateShm, ShmFreshness};
 use crate::uplink::FlightUplink;
 
+mod camera;
+mod sampling;
+use sampling::{mavlink_batch, yaw_of};
+
 /// The control scope this adapter exposes (issue #12): four canonical
 /// flight axes as DJI-style velocity demands.
 pub const FLIGHT_SCOPE: &str = "vehicle.motion";
@@ -83,6 +87,8 @@ pub struct AviateAdapter {
     frames: Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
     _camera_bridge: Option<pilotage_adapter_gazebo::BridgeClient>,
     _frame_forwarder: Option<tokio::task::JoinHandle<()>>,
+    // Latest armed report from FC heartbeats on the uplink socket.
+    armed: Option<bool>,
     link_loss_policy: Option<LinkLossPolicy>,
 }
 
@@ -122,7 +128,7 @@ impl AviateAdapter {
                 None
             }
         };
-        let (frames, camera_bridge, frame_forwarder) = Self::camera_bridge().await;
+        let (frames, camera_bridge, frame_forwarder) = camera::spawn_camera_bridge().await;
         Ok(Self {
             vehicle,
             source,
@@ -130,49 +136,9 @@ impl AviateAdapter {
             frames,
             _camera_bridge: camera_bridge,
             _frame_forwarder: frame_forwarder,
+            armed: None,
             link_loss_policy: None,
         })
-    }
-
-    /// Spawns the gz camera sidecar for the flight world's `/camera` and
-    /// `/chase_camera` topics, degrading to no-video when it can't
-    /// (`PILOTAGE_AVIATE_CAMERA=off` disables the attempt).
-    #[allow(clippy::type_complexity)]
-    async fn camera_bridge() -> (
-        Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
-        Option<pilotage_adapter_gazebo::BridgeClient>,
-        Option<tokio::task::JoinHandle<()>>,
-    ) {
-        if std::env::var("PILOTAGE_AVIATE_CAMERA").as_deref() == Ok("off") {
-            return (None, None, None);
-        }
-        let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(std::path::Path::parent)
-            .map_or_else(|| std::path::PathBuf::from("."), std::path::PathBuf::from);
-        let bin = workspace_root.join("adapters/gazebo/bridge/build/pilotage-gz-bridge");
-        let config = pilotage_adapter_gazebo::BridgeConfig::new("x500", bin);
-        match pilotage_adapter_gazebo::BridgeClient::spawn_and_connect(config).await {
-            Ok(mut bridge) => {
-                let (tx, rx) = tokio::sync::mpsc::channel(4);
-                let forwarder = bridge.take_frame_rx().map(|mut bridge_rx| {
-                    tokio::spawn(async move {
-                        while let Some(frame) = bridge_rx.recv().await {
-                            let raw = pilotage_adapter_gazebo::RawVideoFrame::from(frame);
-                            if tx.send(raw).await.is_err() {
-                                return;
-                            }
-                        }
-                    })
-                });
-                tracing::info!("Aviate camera sidecar up (FPV + chase)");
-                (Some(rx), Some(bridge), forwarder)
-            }
-            Err(error) => {
-                tracing::warn!(%error, "camera sidecar unavailable; no video");
-                (None, None, None)
-            }
-        }
     }
 
     /// Takes the raw-frame receiver for the host media task, if cameras
@@ -209,6 +175,7 @@ impl AviateAdapter {
             frames: None,
             _camera_bridge: None,
             _frame_forwarder: None,
+            armed: None,
             link_loss_policy: None,
         }
     }
@@ -220,16 +187,20 @@ impl AviateAdapter {
         self
     }
 
-    /// The vehicle's current measured yaw, radians clockwise from north
-    /// (zero before any telemetry).
-    fn current_yaw(&mut self) -> f32 {
+    /// The vehicle's current measured yaw (radians clockwise from
+    /// north) and NED position (zeros before any telemetry).
+    fn current_pose(&mut self) -> (f32, [f32; 3]) {
         match &self.source {
-            Source::Shm { shm, .. } => shm.read().map_or(0.0, |s| Self::yaw_of(s.quat_wxyz) as f32),
-            Source::Mavlink { state, .. } => state
-                .lock()
-                .ok()
-                .and_then(|latest| latest.attitude)
-                .map_or(0.0, |att| Self::yaw_of(att.quat_wxyz) as f32),
+            Source::Shm { shm, .. } => shm.read().map_or((0.0, [0.0; 3]), |s| {
+                (yaw_of(s.quat_wxyz) as f32, s.pos_ned_m)
+            }),
+            Source::Mavlink { state, .. } => state.lock().ok().map_or((0.0, [0.0; 3]), |latest| {
+                let yaw = latest
+                    .attitude
+                    .map_or(0.0, |att| yaw_of(att.quat_wxyz) as f32);
+                let pos = latest.kinematics.map_or([0.0; 3], |kin| kin.pos_ned_m);
+                (yaw, pos)
+            }),
         }
     }
 
@@ -252,18 +223,6 @@ impl AviateAdapter {
             }
         }
         Ok(())
-    }
-
-    /// Yaw extracted from the body→NED quaternion (heading, radians
-    /// clockwise from north).
-    fn yaw_of(q: [f32; 4]) -> f64 {
-        let (w, x, y, z) = (
-            f64::from(q[0]),
-            f64::from(q[1]),
-            f64::from(q[2]),
-            f64::from(q[3]),
-        );
-        (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
     }
 }
 
@@ -317,7 +276,7 @@ impl VehicleAdapter for AviateAdapter {
                 disposition: Disposition::Rejected(reason),
             };
         }
-        let current_yaw = self.current_yaw();
+        let (current_yaw, current_pos) = self.current_pose();
         let Some(uplink) = self.uplink.as_mut() else {
             // Checked above; unreachable in practice.
             return ApplyOutcome {
@@ -354,6 +313,7 @@ impl VehicleAdapter for AviateAdapter {
             sticks[usize::from(THROTTLE_AXIS)],
             sticks[usize::from(YAW_AXIS)],
             current_yaw,
+            current_pos,
         );
         ApplyOutcome {
             tick,
@@ -366,8 +326,18 @@ impl VehicleAdapter for AviateAdapter {
     }
 
     fn sample_telemetry(&mut self) -> TelemetryBatch {
+        if let Some(uplink) = self.uplink.as_mut()
+            && let Some(armed) = uplink.poll_fc()
+        {
+            self.armed = Some(armed);
+        }
+        let arm_state = match self.armed {
+            None => 0,
+            Some(false) => 1,
+            Some(true) => 2,
+        };
         match &mut self.source {
-            Source::Mavlink { state, .. } => mavlink_batch(self.vehicle, state),
+            Source::Mavlink { state, .. } => mavlink_batch(self.vehicle, state, arm_state),
             Source::Shm {
                 shm,
                 freshness,
@@ -391,7 +361,7 @@ impl VehicleAdapter for AviateAdapter {
                 let Some(sample) = shm.read() else {
                     return TelemetryBatch::default();
                 };
-                let heading = Self::yaw_of(sample.quat_wxyz);
+                let heading = yaw_of(sample.quat_wxyz);
                 let speed = f64::from(
                     (sample.vel_ned_mps[0] * sample.vel_ned_mps[0]
                         + sample.vel_ned_mps[1] * sample.vel_ned_mps[1])
@@ -417,6 +387,7 @@ impl VehicleAdapter for AviateAdapter {
                             // with real flags is the link RFC's v1.
                             valid_flags: 0b1111,
                             quality: 0,
+                            arm_state,
                         }),
                     }],
                 }
@@ -469,51 +440,6 @@ impl VehicleAdapter for AviateAdapter {
             advanced: 0,
             now: SimTick::new(tick),
         }
-    }
-}
-
-/// The MAVLink-path sampling, unchanged semantics from ADR-0018.
-fn mavlink_batch(vehicle: VehicleId, state: &Arc<Mutex<LatestAviate>>) -> TelemetryBatch {
-    let Ok(latest) = state.lock() else {
-        return TelemetryBatch::default();
-    };
-    let Some(kin) = latest.kinematics else {
-        return TelemetryBatch::default();
-    };
-    if kin.received_at.elapsed() > WITHHOLD_AFTER {
-        return TelemetryBatch::default();
-    }
-    let attitude = latest
-        .attitude
-        .filter(|att| att.received_at.elapsed() <= WITHHOLD_AFTER);
-
-    let heading = attitude.map_or(0.0, |att| AviateAdapter::yaw_of(att.quat_wxyz));
-    let speed = f64::from(
-        (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1]).sqrt(),
-    );
-    let avionics = attitude.map(|att| AvionicsSample {
-        quat_wxyz: att.quat_wxyz,
-        rates_rps: att.rates_rps,
-        pos_ned_m: kin.pos_ned_m,
-        vel_ned_mps: kin.vel_ned_mps,
-        // Aviate's wire subset does not carry its StateValidFlags /
-        // EstimateQuality yet (ADR-0018 names the gap); freshness is
-        // the only validity dimension this link can honestly claim.
-        valid_flags: 0b1111,
-        quality: 0,
-    });
-    TelemetryBatch {
-        samples: vec![TelemetrySample {
-            vehicle,
-            tick: SimTick::new(u64::from(kin.time_boot_ms).wrapping_mul(1_000_000)),
-            pose: Pose2d {
-                x: f64::from(kin.pos_ned_m[0]),
-                y: f64::from(kin.pos_ned_m[1]),
-                heading,
-            },
-            speed,
-            avionics,
-        }],
     }
 }
 

--- a/adapters/aviate/src/adapter/camera.rs
+++ b/adapters/aviate/src/adapter/camera.rs
@@ -1,0 +1,43 @@
+//! The gz camera sidecar path: Pilotage's own C++ gz-transport bridge
+//! delivers the flight world's `/camera` and `/chase_camera` frames.
+
+/// Spawns the gz camera sidecar for the flight world's `/camera` and
+/// `/chase_camera` topics, degrading to no-video when it can't
+/// (`PILOTAGE_AVIATE_CAMERA=off` disables the attempt).
+#[allow(clippy::type_complexity)]
+pub(crate) async fn spawn_camera_bridge() -> (
+    Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
+    Option<pilotage_adapter_gazebo::BridgeClient>,
+    Option<tokio::task::JoinHandle<()>>,
+) {
+    if std::env::var("PILOTAGE_AVIATE_CAMERA").as_deref() == Ok("off") {
+        return (None, None, None);
+    }
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .map_or_else(|| std::path::PathBuf::from("."), std::path::PathBuf::from);
+    let bin = workspace_root.join("adapters/gazebo/bridge/build/pilotage-gz-bridge");
+    let config = pilotage_adapter_gazebo::BridgeConfig::new("x500", bin);
+    match pilotage_adapter_gazebo::BridgeClient::spawn_and_connect(config).await {
+        Ok(mut bridge) => {
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            let forwarder = bridge.take_frame_rx().map(|mut bridge_rx| {
+                tokio::spawn(async move {
+                    while let Some(frame) = bridge_rx.recv().await {
+                        let raw = pilotage_adapter_gazebo::RawVideoFrame::from(frame);
+                        if tx.send(raw).await.is_err() {
+                            return;
+                        }
+                    }
+                })
+            });
+            tracing::info!("Aviate camera sidecar up (FPV + chase)");
+            (Some(rx), Some(bridge), forwarder)
+        }
+        Err(error) => {
+            tracing::warn!(%error, "camera sidecar unavailable; no video");
+            (None, None, None)
+        }
+    }
+}

--- a/adapters/aviate/src/adapter/control.rs
+++ b/adapters/aviate/src/adapter/control.rs
@@ -1,0 +1,36 @@
+//! Flight-control reset handling.
+
+use std::time::{Duration, Instant};
+
+use super::AviateAdapter;
+
+impl AviateAdapter {
+    /// Runs the SITL reset script (debounced to one per 5 s): world
+    /// reset + FC restart, fire-and-forget. `PILOTAGE_RESET_CMD`
+    /// overrides the script path.
+    pub(super) fn spawn_reset(&mut self) {
+        let now = Instant::now();
+        if self
+            .last_reset
+            .is_some_and(|last_reset| now.duration_since(last_reset) < Duration::from_secs(5))
+        {
+            return;
+        }
+        self.last_reset = Some(now);
+        self.armed = None;
+        let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(std::path::Path::parent)
+                .map_or_else(|| ".".to_owned(), |path| path.display().to_string())
+                + "/scripts/reset-flight-sim.sh"
+        });
+        tracing::info!(%script, "simulation reset requested from the viewer");
+        if let Err(error) = std::process::Command::new(&script)
+            .arg("aviate_sitl")
+            .spawn()
+        {
+            tracing::warn!(%error, %script, "reset script failed to spawn");
+        }
+    }
+}

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -1,0 +1,72 @@
+//! Telemetry sampling helpers shared by the adapter's link paths.
+
+use std::sync::{Arc, Mutex};
+
+use pilotage_adapter_api::{AvionicsSample, Pose2d, TelemetryBatch, TelemetrySample};
+use pilotage_protocol::VehicleId;
+use pilotage_timing::SimTick;
+
+use super::WITHHOLD_AFTER;
+use crate::link::LatestAviate;
+
+/// Yaw extracted from the body→NED quaternion (heading, radians
+/// clockwise from north).
+pub(crate) fn yaw_of(q: [f32; 4]) -> f64 {
+    let (w, x, y, z) = (
+        f64::from(q[0]),
+        f64::from(q[1]),
+        f64::from(q[2]),
+        f64::from(q[3]),
+    );
+    (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
+}
+
+/// The MAVLink-path sampling, unchanged semantics from ADR-0018.
+pub(crate) fn mavlink_batch(
+    vehicle: VehicleId,
+    state: &Arc<Mutex<LatestAviate>>,
+    arm_state: u32,
+) -> TelemetryBatch {
+    let Ok(latest) = state.lock() else {
+        return TelemetryBatch::default();
+    };
+    let Some(kin) = latest.kinematics else {
+        return TelemetryBatch::default();
+    };
+    if kin.received_at.elapsed() > WITHHOLD_AFTER {
+        return TelemetryBatch::default();
+    }
+    let attitude = latest
+        .attitude
+        .filter(|att| att.received_at.elapsed() <= WITHHOLD_AFTER);
+
+    let heading = attitude.map_or(0.0, |att| yaw_of(att.quat_wxyz));
+    let speed = f64::from(
+        (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1]).sqrt(),
+    );
+    let avionics = attitude.map(|att| AvionicsSample {
+        quat_wxyz: att.quat_wxyz,
+        rates_rps: att.rates_rps,
+        pos_ned_m: kin.pos_ned_m,
+        vel_ned_mps: kin.vel_ned_mps,
+        // Aviate's wire subset does not carry its StateValidFlags /
+        // EstimateQuality yet (ADR-0018 names the gap); freshness is
+        // the only validity dimension this link can honestly claim.
+        valid_flags: 0b1111,
+        quality: 0,
+        arm_state,
+    });
+    TelemetryBatch {
+        samples: vec![TelemetrySample {
+            vehicle,
+            tick: SimTick::new(u64::from(kin.time_boot_ms).wrapping_mul(1_000_000)),
+            pose: Pose2d {
+                x: f64::from(kin.pos_ned_m[0]),
+                y: f64::from(kin.pos_ned_m[1]),
+                heading,
+            },
+            speed,
+            avionics,
+        }],
+    }
+}

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -132,34 +132,60 @@ fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
     );
     assert!(n >= 45);
 
-    // Past the post-arm quiet window: full forward stick + half climb.
+    // Past the post-arm quiet window: full forward stick + half climb,
+    // streamed like the 30 Hz control loop. The slew limiter ramps the
+    // command from zero, so assert the ramp rather than an instant step.
     std::thread::sleep(Duration::from_millis(200));
+    let f = |buf: &[u8; 128], off: usize| {
+        f32::from_le_bytes([buf[10 + off], buf[11 + off], buf[12 + off], buf[13 + off]])
+    };
+    let mut last_ve = 0.0f32;
+    for _ in 0..30 {
+        let outcome = adapter.apply_control(&flight_frame(
+            vec![
+                (LogicalAxisId::new(super::PITCH_AXIS), 1.0),
+                (LogicalAxisId::new(super::THROTTLE_AXIS), 0.5),
+            ],
+            vec![],
+        ));
+        assert_eq!(outcome.disposition, Disposition::Accepted);
+        fc.recv_from(&mut buf).expect("setpoint frame");
+        assert_eq!(buf[7], 84, "SET_POSITION_TARGET id");
+        let ve = f(&buf, 20);
+        assert!(
+            ve >= last_ve - 1e-4,
+            "ramp must not reverse: {ve} < {last_ve}"
+        );
+        last_ve = ve;
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    // Heading is east (yaw 90°), stick full-forward → velocity is +east:
+    // vn≈0, ve ramping toward 3.
+    let (vn, vz) = (f(&buf, 16), f(&buf, 24));
+    assert!(vn.abs() < 0.05, "vn {vn}");
+    assert!(last_ve > 1.0, "ramped east velocity, got {last_ve}");
+    assert!(vz < -0.2, "climb demand present, got {vz}");
+    let type_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(type_mask, 2503);
+
+    // Centered sticks switch to position-hold (DJI brake-then-hold):
+    // the setpoint becomes position-valid (mask 2552) at the captured
+    // hold point.
     let outcome = adapter.apply_control(&flight_frame(
         vec![
-            (LogicalAxisId::new(super::PITCH_AXIS), 1.0),
-            (LogicalAxisId::new(super::THROTTLE_AXIS), 0.5),
+            (LogicalAxisId::new(super::PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(super::THROTTLE_AXIS), 0.0),
         ],
         vec![],
     ));
     assert_eq!(outcome.disposition, Disposition::Accepted);
-
-    // Second: the velocity setpoint. Payload starts at 10; vx@16 within
-    // payload. Heading is east (yaw 90°), stick full-forward → velocity
-    // is +east: vn≈0, ve≈3.
-    fc.recv_from(&mut buf).expect("setpoint frame");
-    assert_eq!(buf[7], 84, "SET_POSITION_TARGET id");
-    let f = |off: usize| {
-        f32::from_le_bytes([buf[10 + off], buf[11 + off], buf[12 + off], buf[13 + off]])
-    };
-    let (vn, ve, vz) = (f(16), f(20), f(24));
-    assert!(vn.abs() < 0.01, "vn {vn}");
-    assert!((ve - 3.0).abs() < 0.01, "ve {ve}");
-    assert!(
-        (vz + 0.75).abs() < 0.01,
-        "vz {vz} (0.5 stick × 1.5 m/s climb)"
-    );
-    let type_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
-    assert_eq!(type_mask, 2503);
+    fc.recv_from(&mut buf).expect("hold frame");
+    let hold_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(hold_mask, 2552, "position-hold mask");
+    // Hold point = the fake pose's NED position (10, 20, -30).
+    assert!((f(&buf, 4) - 10.0).abs() < 1e-3);
+    assert!((f(&buf, 8) - 20.0).abs() < 1e-3);
+    assert!((f(&buf, 12) + 30.0).abs() < 1e-3);
 }
 
 #[test]

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -73,6 +73,95 @@ fn dead_link_withholds_the_whole_sample() {
     assert!(adapter.sample_telemetry().samples.is_empty());
 }
 
+fn flight_frame(
+    axes: Vec<(pilotage_protocol::LogicalAxisId, f32)>,
+    edges: Vec<(
+        pilotage_protocol::LogicalButtonId,
+        pilotage_protocol::ButtonEdge,
+    )>,
+) -> pilotage_protocol::ScopedControlFrame {
+    pilotage_protocol::ScopedControlFrame {
+        session: pilotage_protocol::SessionId::new(1),
+        vehicle: VehicleId::new(1),
+        scope: pilotage_protocol::ScopeId::new(super::FLIGHT_SCOPE),
+        generation: pilotage_protocol::Generation::new(1),
+        sequence: pilotage_protocol::SequenceNum::new(1),
+        sampled_at: pilotage_timing::MonoTimestamp::from_nanos(0),
+        profile_revision: 1,
+        payload: pilotage_protocol::ControlPayload { axes, edges },
+    }
+}
+
+#[test]
+fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
+    use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId};
+
+    // A fake FC: any UDP socket we can read the uplink's frames from.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    // Heading east (yaw 90°) so body-frame rotation is observable.
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::ZERO, Duration::ZERO),
+    )
+    .with_uplink(uplink);
+
+    let caps = adapter.capabilities();
+    assert_eq!(caps.vehicles[0].scopes.len(), 1, "flight scope advertised");
+    assert_eq!(caps.vehicles[0].scopes[0].axes.len(), 4);
+
+    // Arm edge (stick frames are suppressed for a beat afterward so the
+    // FC's single command slot is not overwritten before its loop runs).
+    let outcome = adapter.apply_control(&flight_frame(
+        vec![],
+        vec![(LogicalButtonId::new(super::ARM_BUTTON), ButtonEdge::Pressed)],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+
+    let mut buf = [0u8; 128];
+    // First datagram: the arm command (COMMAND_LONG 400, param1=1).
+    let (n, _) = fc.recv_from(&mut buf).expect("arm frame");
+    assert_eq!(buf[7], 76, "COMMAND_LONG id");
+    assert_eq!(
+        f32::from_le_bytes([buf[10], buf[11], buf[12], buf[13]]),
+        1.0
+    );
+    assert!(n >= 45);
+
+    // Past the post-arm quiet window: full forward stick + half climb.
+    std::thread::sleep(Duration::from_millis(200));
+    let outcome = adapter.apply_control(&flight_frame(
+        vec![
+            (LogicalAxisId::new(super::PITCH_AXIS), 1.0),
+            (LogicalAxisId::new(super::THROTTLE_AXIS), 0.5),
+        ],
+        vec![],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+
+    // Second: the velocity setpoint. Payload starts at 10; vx@16 within
+    // payload. Heading is east (yaw 90°), stick full-forward → velocity
+    // is +east: vn≈0, ve≈3.
+    fc.recv_from(&mut buf).expect("setpoint frame");
+    assert_eq!(buf[7], 84, "SET_POSITION_TARGET id");
+    let f = |off: usize| {
+        f32::from_le_bytes([buf[10 + off], buf[11 + off], buf[12 + off], buf[13 + off]])
+    };
+    let (vn, ve, vz) = (f(16), f(20), f(24));
+    assert!(vn.abs() < 0.01, "vn {vn}");
+    assert!((ve - 3.0).abs() < 0.01, "ve {ve}");
+    assert!(
+        (vz + 0.75).abs() < 0.01,
+        "vz {vz} (0.5 stick × 1.5 m/s climb)"
+    );
+    let type_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(type_mask, 2503);
+}
+
 #[test]
 fn control_frames_are_rejected_at_the_boundary() {
     let mut adapter = AviateAdapter::from_state(
@@ -80,7 +169,10 @@ fn control_frames_are_rejected_at_the_boundary() {
         state_with(Duration::ZERO, Duration::ZERO),
     );
     let caps = adapter.capabilities();
-    assert!(caps.vehicles[0].scopes.is_empty(), "telemetry-only");
+    assert!(
+        caps.vehicles[0].scopes.is_empty(),
+        "telemetry-only without an uplink"
+    );
 
     let frame = pilotage_protocol::ScopedControlFrame {
         session: pilotage_protocol::SessionId::new(1),

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -181,11 +181,9 @@ fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
     assert_eq!(outcome.disposition, Disposition::Accepted);
     fc.recv_from(&mut buf).expect("hold frame");
     let hold_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
-    assert_eq!(hold_mask, 2552, "position-hold mask");
-    // Hold point = the fake pose's NED position (10, 20, -30).
-    assert!((f(&buf, 4) - 10.0).abs() < 1e-3);
-    assert!((f(&buf, 8) - 20.0).abs() < 1e-3);
-    assert!((f(&buf, 12) + 30.0).abs() < 1e-3);
+    assert_eq!(hold_mask, 2503, "ground-side hold streams velocity mode");
+    // On the hold point the correction is zero (fake pose is static).
+    assert!(f(&buf, 16).abs() < 1e-3 && f(&buf, 20).abs() < 1e-3 && f(&buf, 24).abs() < 1e-3);
 }
 
 #[test]

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -169,8 +169,9 @@ fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
     assert_eq!(type_mask, 2503);
 
     // Centered sticks switch to position-hold (DJI brake-then-hold):
-    // the setpoint becomes position-valid (mask 2552) at the captured
-    // hold point.
+    // the hold loop runs on the FC, so the ground streams a
+    // position-valid setpoint (mask 2552) at the captured hold point
+    // — the fake pose's NED position — with no ground-side gains.
     let outcome = adapter.apply_control(&flight_frame(
         vec![
             (LogicalAxisId::new(super::PITCH_AXIS), 0.0),
@@ -181,9 +182,11 @@ fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
     assert_eq!(outcome.disposition, Disposition::Accepted);
     fc.recv_from(&mut buf).expect("hold frame");
     let hold_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
-    assert_eq!(hold_mask, 2503, "ground-side hold streams velocity mode");
-    // On the hold point the correction is zero (fake pose is static).
-    assert!(f(&buf, 16).abs() < 1e-3 && f(&buf, 20).abs() < 1e-3 && f(&buf, 24).abs() < 1e-3);
+    assert_eq!(hold_mask, 2552, "hold streams FC position mode");
+    // Position fields carry the captured point (fake pose 10, 20, -30).
+    assert!((f(&buf, 4) - 10.0).abs() < 1e-3, "hold north");
+    assert!((f(&buf, 8) - 20.0).abs() < 1e-3, "hold east");
+    assert!((f(&buf, 12) + 30.0).abs() < 1e-3, "hold down");
 }
 
 #[test]

--- a/adapters/aviate/src/lib.rs
+++ b/adapters/aviate/src/lib.rs
@@ -19,7 +19,12 @@ mod error;
 mod link;
 pub mod mavlink;
 pub mod shm;
+mod uplink;
 
-pub use adapter::{AviateAdapter, AviateLinkMode};
+pub use adapter::{
+    ARM_BUTTON, AviateAdapter, AviateLinkMode, DISARM_BUTTON, FLIGHT_SCOPE, PITCH_AXIS, ROLL_AXIS,
+    THROTTLE_AXIS, YAW_AXIS,
+};
 pub use error::AviateAdapterError;
 pub use link::LinkConfig;
+pub use uplink::FlightUplink;

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -193,7 +193,10 @@ fn apply_messages(
         latest.decoded = latest.decoded.wrapping_add(1);
         // Lock onto the first system id that delivers an estimate;
         // heartbeats alone don't lock (other GCS peers heartbeat too).
-        let is_estimate = !matches!(message, AviateMessage::Heartbeat);
+        let is_estimate = !matches!(
+            message,
+            AviateMessage::Heartbeat { .. } | AviateMessage::CommandAck { .. }
+        );
         match latest.locked_sysid {
             None if is_estimate => latest.locked_sysid = Some(sysid),
             Some(locked) if locked != sysid => continue,
@@ -201,7 +204,8 @@ fn apply_messages(
             Some(_) => {}
         }
         match message {
-            AviateMessage::Heartbeat => latest.last_heartbeat = Some(now),
+            AviateMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
+            AviateMessage::CommandAck { .. } => {}
             AviateMessage::AttitudeQuaternion {
                 time_boot_ms: _,
                 quat_wxyz,

--- a/adapters/aviate/src/link/tests.rs
+++ b/adapters/aviate/src/link/tests.rs
@@ -21,7 +21,12 @@ fn attitude(sysid: u8, qw: f32) -> (u8, AviateMessage) {
 fn locks_onto_the_first_vehicle_and_ignores_the_rest() {
     let state = Arc::new(Mutex::new(LatestAviate::default()));
     // A GCS peer heartbeat must not lock the link.
-    apply_messages(&state, &[(255, AviateMessage::Heartbeat)], 0, 0);
+    apply_messages(
+        &state,
+        &[(255, AviateMessage::Heartbeat { armed: false })],
+        0,
+        0,
+    );
     assert!(state.lock().expect("lock").locked_sysid.is_none());
 
     // First estimate locks; a second vehicle's estimate is ignored.

--- a/adapters/aviate/src/mavlink.rs
+++ b/adapters/aviate/src/mavlink.rs
@@ -342,5 +342,43 @@ pub fn encode_velocity_setpoint(
     frame
 }
 
+/// Encodes SET_ATTITUDE_TARGET (msg 82) commanding an absolute
+/// attitude (roll/pitch/yaw euler, radians, NED/ZYX) plus normalized
+/// collective thrust — the FPV mode uplink. Body-rate fields are
+/// masked out (type_mask 0b111): the FC's attitude loop derives its
+/// own rate commands.
+pub fn encode_attitude_setpoint(
+    seq: u8,
+    time_boot_ms: u32,
+    roll_rad: f32,
+    pitch_rad: f32,
+    yaw_rad: f32,
+    thrust: f32,
+) -> [u8; 51] {
+    const SET_ATTITUDE_TARGET_ID: u32 = 82;
+    let (sr, cr) = (roll_rad * 0.5).sin_cos();
+    let (sp, cp) = (pitch_rad * 0.5).sin_cos();
+    let (sy, cy) = (yaw_rad * 0.5).sin_cos();
+    let q = [
+        cr * cp * cy + sr * sp * sy,
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+    ];
+    let mut payload = [0u8; 39];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    for (i, w) in q.iter().enumerate() {
+        payload[4 + i * 4..8 + i * 4].copy_from_slice(&w.to_le_bytes());
+    }
+    // body rates [20..32) stay zero (masked); thrust at [32..36).
+    payload[32..36].copy_from_slice(&thrust.clamp(0.0, 1.0).to_le_bytes());
+    payload[36] = 1; // target system
+    payload[37] = 1; // target component
+    payload[38] = 0b0000_0111; // ignore body roll/pitch/yaw rate
+    let mut frame = [0u8; 51];
+    encode_frame_v2(seq, SET_ATTITUDE_TARGET_ID, &payload, 49, &mut frame);
+    frame
+}
+
 #[cfg(test)]
 mod tests;

--- a/adapters/aviate/src/mavlink.rs
+++ b/adapters/aviate/src/mavlink.rs
@@ -16,12 +16,25 @@ pub const HEARTBEAT_ID: u32 = 0;
 pub const ATTITUDE_QUATERNION_ID: u32 = 31;
 /// LOCAL_POSITION_NED message id.
 pub const LOCAL_POSITION_NED_ID: u32 = 32;
+/// COMMAND_ACK message id (arm/disarm feedback).
+pub const COMMAND_ACK_ID: u32 = 77;
 
 /// One decoded telemetry message from the Aviate subset.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AviateMessage {
-    /// Link liveness beacon (1 Hz).
-    Heartbeat,
+    /// Link liveness beacon (1 Hz); `armed` is base_mode's
+    /// MAV_MODE_FLAG_SAFETY_ARMED bit.
+    Heartbeat {
+        /// Whether the sender reports itself armed.
+        armed: bool,
+    },
+    /// Command acknowledgement (arm/disarm feedback).
+    CommandAck {
+        /// The acknowledged MAV_CMD id.
+        command: u16,
+        /// MAV_RESULT (0 = accepted).
+        result: u8,
+    },
     /// Attitude estimate (10 Hz): quaternion is body FRD → world NED,
     /// MAVLink order q1=w, q2=x, q3=y, q4=z.
     AttitudeQuaternion {
@@ -69,6 +82,7 @@ fn crc_extra(msg_id: u32) -> Option<u8> {
         HEARTBEAT_ID => Some(50),
         ATTITUDE_QUATERNION_ID => Some(246),
         LOCAL_POSITION_NED_ID => Some(185),
+        COMMAND_ACK_ID => Some(143),
         COMMAND_LONG_ID => Some(152),
         SET_POSITION_TARGET_ID => Some(143),
         _ => None,
@@ -112,7 +126,16 @@ fn u32_at(payload: &[u8], off: usize) -> u32 {
 
 fn decode_known(msg_id: u32, payload: &[u8]) -> Option<AviateMessage> {
     match msg_id {
-        HEARTBEAT_ID => Some(AviateMessage::Heartbeat),
+        HEARTBEAT_ID => Some(AviateMessage::Heartbeat {
+            // Payload: custom_mode u32 @0, type @4, autopilot @5,
+            // base_mode @6 (bit 0x80 = SAFETY_ARMED).
+            armed: payload.get(6).is_some_and(|b| b & 0x80 != 0),
+        }),
+        COMMAND_ACK_ID => Some(AviateMessage::CommandAck {
+            command: u16::from(payload.first().copied().unwrap_or(0))
+                | (u16::from(payload.get(1).copied().unwrap_or(0)) << 8),
+            result: payload.get(2).copied().unwrap_or(0),
+        }),
         ATTITUDE_QUATERNION_ID => Some(AviateMessage::AttitudeQuaternion {
             time_boot_ms: u32_at(payload, 0),
             quat_wxyz: [
@@ -249,6 +272,40 @@ pub fn encode_arm_command(seq: u8, arm: bool) -> [u8; 45] {
     payload[31] = 1;
     let mut frame = [0u8; 45];
     encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
+    frame
+}
+
+/// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
+/// velocity plus absolute yaw, everything else masked out
+/// (`type_mask` ignores position, acceleration, and yaw rate — the
+/// combination Aviate's bridge maps to `ControlMode::VelocityControl`).
+///
+/// Serializes a SET_POSITION_TARGET_LOCAL_NED **position-hold**
+/// setpoint: NED position plus absolute yaw, velocity/acceleration/yaw
+/// rate masked out (the combination Aviate's bridge maps to
+/// `ControlMode::PositionHold`) — DJI's brake-then-hold on centered
+/// sticks.
+pub fn encode_position_setpoint(
+    seq: u8,
+    time_boot_ms: u32,
+    pos_ned_m: [f32; 3],
+    yaw_rad: f32,
+) -> [u8; 65] {
+    // Ignore velocity (8|16|32), acceleration (64|128|256), yaw rate
+    // (2048): position + absolute yaw remain.
+    const TYPE_MASK: u16 = 8 | 16 | 32 | 64 | 128 | 256 | 2048;
+    let mut payload = [0u8; 53];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    payload[4..8].copy_from_slice(&pos_ned_m[0].to_le_bytes());
+    payload[8..12].copy_from_slice(&pos_ned_m[1].to_le_bytes());
+    payload[12..16].copy_from_slice(&pos_ned_m[2].to_le_bytes());
+    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
+    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
+    payload[50] = 1;
+    payload[51] = 1;
+    payload[52] = 1; // MAV_FRAME_LOCAL_NED
+    let mut frame = [0u8; 65];
+    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
     frame
 }
 

--- a/adapters/aviate/src/mavlink.rs
+++ b/adapters/aviate/src/mavlink.rs
@@ -57,6 +57,11 @@ pub struct ParseStats {
     pub garbage_bytes: u32,
 }
 
+/// COMMAND_LONG message id (uplink: arm/disarm).
+pub const COMMAND_LONG_ID: u32 = 76;
+/// SET_POSITION_TARGET_LOCAL_NED message id (uplink: velocity setpoints).
+pub const SET_POSITION_TARGET_ID: u32 = 84;
+
 /// CRC_EXTRA per message id, from the MAVLink XML definitions (matching
 /// `aviate-link`); `None` for ids this parser cannot verify.
 fn crc_extra(msg_id: u32) -> Option<u8> {
@@ -64,6 +69,8 @@ fn crc_extra(msg_id: u32) -> Option<u8> {
         HEARTBEAT_ID => Some(50),
         ATTITUDE_QUATERNION_ID => Some(246),
         LOCAL_POSITION_NED_ID => Some(185),
+        COMMAND_LONG_ID => Some(152),
+        SET_POSITION_TARGET_ID => Some(143),
         _ => None,
     }
 }
@@ -187,27 +194,94 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(u8, AviateMessage)>) -> Parse
     stats
 }
 
+/// Writes a MAVLink 2.0 frame (GCS sysid 255, compid 190) around
+/// `payload` into `out`, returning the frame length. `out` must hold
+/// `10 + payload.len() + 2` bytes; a too-small buffer returns 0.
+fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u8]) -> usize {
+    let total = 10 + payload.len() + 2;
+    if out.len() < total || payload.len() > 255 {
+        return 0;
+    }
+    out[0] = MAGIC_V2;
+    out[1] = payload.len() as u8;
+    out[2] = 0;
+    out[3] = 0;
+    out[4] = seq;
+    out[5] = 255;
+    out[6] = 190;
+    out[7] = (msg_id & 0xff) as u8;
+    out[8] = ((msg_id >> 8) & 0xff) as u8;
+    out[9] = ((msg_id >> 16) & 0xff) as u8;
+    out[10..10 + payload.len()].copy_from_slice(payload);
+    let crc = compute_crc(&out[1..10 + payload.len()], extra);
+    out[10 + payload.len()] = (crc & 0xff) as u8;
+    out[10 + payload.len() + 1] = (crc >> 8) as u8;
+    total
+}
+
 /// Serializes a GCS heartbeat frame, used to register this endpoint with
 /// a MAVLink router that only forwards to peers it has heard from.
 pub fn encode_gcs_heartbeat(seq: u8) -> [u8; 21] {
-    let mut frame = [0u8; 21];
-    frame[0] = MAGIC_V2;
-    frame[1] = 9; // payload length
-    // incompat/compat = 0; seq; sysid 255 (GCS convention); compid 190.
-    frame[4] = seq;
-    frame[5] = 255;
-    frame[6] = 190;
-    // msgid 0 (HEARTBEAT) is already zero.
     // Payload: custom_mode u32 (0), type MAV_TYPE_GCS=6, autopilot
     // MAV_AUTOPILOT_INVALID=8, base_mode 0, system_status MAV_STATE_ACTIVE=4,
     // mavlink_version 3.
-    frame[14] = 6;
-    frame[15] = 8;
-    frame[17] = 4;
-    frame[18] = 3;
-    let crc = compute_crc(&frame[1..19], 50);
-    frame[19] = (crc & 0xff) as u8;
-    frame[20] = (crc >> 8) as u8;
+    let mut payload = [0u8; 9];
+    payload[4] = 6;
+    payload[5] = 8;
+    payload[7] = 4;
+    payload[8] = 3;
+    let mut frame = [0u8; 21];
+    encode_frame_v2(seq, HEARTBEAT_ID, &payload, 50, &mut frame);
+    frame
+}
+
+/// Serializes a COMMAND_LONG arm/disarm frame (MAV_CMD 400) addressed to
+/// system 1 / component 1 (the Aviate FC's SITL identity).
+///
+/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
+/// target_system @30, target_component @31, confirmation @32.
+pub fn encode_arm_command(seq: u8, arm: bool) -> [u8; 45] {
+    let mut payload = [0u8; 33];
+    let param1: f32 = if arm { 1.0 } else { 0.0 };
+    payload[0..4].copy_from_slice(&param1.to_le_bytes());
+    payload[28..30].copy_from_slice(&400u16.to_le_bytes());
+    payload[30] = 1;
+    payload[31] = 1;
+    let mut frame = [0u8; 45];
+    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
+    frame
+}
+
+/// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
+/// velocity plus absolute yaw, everything else masked out
+/// (`type_mask` ignores position, acceleration, and yaw rate — the
+/// combination Aviate's bridge maps to `ControlMode::VelocityControl`).
+///
+/// Wire order (53 bytes): time_boot_ms u32 @0, x/y/z @4..16,
+/// vx/vy/vz @16..28, afx/afy/afz @28..40, yaw @40, yaw_rate @44,
+/// type_mask u16 @48, target_system @50, target_component @51,
+/// coordinate_frame @52.
+pub fn encode_velocity_setpoint(
+    seq: u8,
+    time_boot_ms: u32,
+    vel_ned_mps: [f32; 3],
+    yaw_rad: f32,
+) -> [u8; 65] {
+    // Ignore position (1|2|4), acceleration (64|128|256), yaw rate (2048):
+    // velocity + absolute yaw remain.
+    const TYPE_MASK: u16 = 1 | 2 | 4 | 64 | 128 | 256 | 2048;
+    let mut payload = [0u8; 53];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    payload[16..20].copy_from_slice(&vel_ned_mps[0].to_le_bytes());
+    payload[20..24].copy_from_slice(&vel_ned_mps[1].to_le_bytes());
+    payload[24..28].copy_from_slice(&vel_ned_mps[2].to_le_bytes());
+    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
+    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
+    payload[50] = 1; // target system
+    payload[51] = 1; // target component
+    payload[52] = 1; // MAV_FRAME_LOCAL_NED
+    let mut frame = [0u8; 65];
+    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
     frame
 }
 

--- a/adapters/aviate/src/mavlink/tests.rs
+++ b/adapters/aviate/src/mavlink/tests.rs
@@ -164,7 +164,7 @@ fn garbage_prefix_resyncs_to_the_next_frame() {
     let mut out: Vec<(u8, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&datagram, &mut out);
     assert_eq!(stats.garbage_bytes, 3);
-    assert_eq!(out, vec![(1, AviateMessage::Heartbeat)]);
+    assert_eq!(out, vec![(1, AviateMessage::Heartbeat { armed: false })]);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn gcs_heartbeat_parses_back_as_heartbeat() {
     let mut out: Vec<(u8, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame, &mut out);
     assert_eq!(stats.decoded, 1, "stats: {stats:?}");
-    assert_eq!(out, vec![(255, AviateMessage::Heartbeat)]);
+    assert_eq!(out, vec![(255, AviateMessage::Heartbeat { armed: false })]);
 }
 
 #[test]

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use tracing::{info, warn};
 
-use crate::mavlink::{encode_arm_command, encode_velocity_setpoint};
+use crate::mavlink::{encode_arm_command, encode_position_setpoint, encode_velocity_setpoint};
 
 /// Full-stick horizontal velocity demand.
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
@@ -48,12 +48,18 @@ pub struct FlightUplink {
     // thrust, which tips it over — real drones idle until the first
     // climb, so this does too.
     airborne: bool,
+    // Brake-then-hold state: the captured hold point while every stick
+    // is centered, and the slew-limited velocity command.
+    hold_pos_ned: Option<[f32; 3]>,
+    last_vel_ned: [f32; 3],
     started: Instant,
     send_failures: u64,
 }
 
 /// Climb-stick threshold that opens the motors-idle gate after arming.
 const TAKEOFF_STICK: f32 = 0.15;
+/// Acceleration limit shaping stick steps into velocity ramps.
+const MAX_ACCEL_MPS2: f32 = 2.5;
 
 impl FlightUplink {
     /// Binds an ephemeral socket toward the FC's command port
@@ -69,6 +75,7 @@ impl FlightUplink {
             .and_then(|s| s.parse().ok())
             .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 20000)));
         let socket = UdpSocket::bind("127.0.0.1:0")?;
+        socket.set_nonblocking(true)?;
         info!(%target, "Aviate flight uplink ready");
         Ok(Self {
             socket,
@@ -78,6 +85,8 @@ impl FlightUplink {
             last_frame: None,
             quiet_until: None,
             airborne: false,
+            hold_pos_ned: None,
+            last_vel_ned: [0.0; 3],
             started: Instant::now(),
             send_failures: 0,
         })
@@ -105,6 +114,8 @@ impl FlightUplink {
         self.last_frame = None;
         self.quiet_until = Some(Instant::now() + ARM_QUIET);
         self.airborne = false;
+        self.hold_pos_ned = None;
+        self.last_vel_ned = [0.0; 3];
         let frame = encode_arm_command(self.seq, arm);
         self.send(&frame);
         info!(arm, "sent arm command to FC");
@@ -114,6 +125,7 @@ impl FlightUplink {
     /// throttle/yaw, stick conventions: pitch + = forward, roll + =
     /// right, throttle + = climb, yaw + = clockwise) into a velocity
     /// setpoint and sends it.
+    #[allow(clippy::too_many_arguments)]
     pub fn send_stick_frame(
         &mut self,
         roll: f32,
@@ -121,6 +133,7 @@ impl FlightUplink {
         throttle: f32,
         yaw: f32,
         current_yaw_rad: f32,
+        current_pos_ned_m: [f32; 3],
     ) {
         let now = Instant::now();
         if let Some(quiet) = self.quiet_until {
@@ -141,6 +154,26 @@ impl FlightUplink {
             .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
             .clamp(0.0, MAX_DT_S);
         self.last_frame = Some(now);
+        let time_boot_ms = self.started.elapsed().as_millis() as u32;
+
+        // DJI brake-then-hold: with every stick centered, velocity mode
+        // would drift on vz-tracking bias — capture the current position
+        // once and stream a position-hold setpoint until any stick
+        // deflects again.
+        let sticks_active = roll
+            .abs()
+            .max(pitch.abs())
+            .max(throttle.abs())
+            .max(yaw.abs())
+            > 0.02;
+        if !sticks_active {
+            let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
+            self.last_vel_ned = [0.0; 3];
+            let frame = encode_position_setpoint(self.seq, time_boot_ms, hold, self.heading_sp_rad);
+            self.send(&frame);
+            return;
+        }
+        self.hold_pos_ned = None;
 
         self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
 
@@ -150,13 +183,27 @@ impl FlightUplink {
         let fwd = pitch * MAX_HORIZONTAL_MPS;
         let lat = roll * MAX_HORIZONTAL_MPS;
         let (sin_y, cos_y) = current_yaw_rad.sin_cos();
-        let vel_ned = [
+        let target = [
             fwd * cos_y - lat * sin_y,
             fwd * sin_y + lat * cos_y,
             -throttle * MAX_VERTICAL_MPS,
         ];
-        let time_boot_ms = self.started.elapsed().as_millis() as u32;
-        let frame = encode_velocity_setpoint(self.seq, time_boot_ms, vel_ned, self.heading_sp_rad);
+        // Slew-rate limit the horizontal axes so stick steps become
+        // acceleration-limited ramps (part of the DJI feel). The
+        // vertical demand passes through instantly: ramping vz from
+        // near zero holds a grounded vehicle in the unstable
+        // near-hover-thrust regime the takeoff gate exists to avoid.
+        let dv_max = MAX_ACCEL_MPS2 * dt.max(1.0 / 60.0);
+        for (v, t) in self.last_vel_ned.iter_mut().zip(target).take(2) {
+            *v += (t - *v).clamp(-dv_max, dv_max);
+        }
+        self.last_vel_ned[2] = target[2];
+        let frame = encode_velocity_setpoint(
+            self.seq,
+            time_boot_ms,
+            self.last_vel_ned,
+            self.heading_sp_rad,
+        );
         self.send(&frame);
     }
 
@@ -167,6 +214,34 @@ impl FlightUplink {
         let time_boot_ms = self.started.elapsed().as_millis() as u32;
         let frame = encode_velocity_setpoint(self.seq, time_boot_ms, [0.0; 3], self.heading_sp_rad);
         self.send(&frame);
+    }
+
+    /// Drains FC replies off the uplink socket (COMMAND_ACK, heartbeats
+    /// the FC sends its learned commander), returning the latest
+    /// armed-state report if any heartbeat arrived. Non-blocking; call
+    /// from the sampling tick.
+    pub fn poll_fc(&mut self) -> Option<bool> {
+        let mut buf = [0u8; 512];
+        let mut messages: Vec<(u8, crate::mavlink::AviateMessage)> = Vec::new();
+        let mut armed: Option<bool> = None;
+        while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
+            messages.clear();
+            crate::mavlink::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
+            for (_, message) in &messages {
+                match *message {
+                    crate::mavlink::AviateMessage::Heartbeat { armed: a } => armed = Some(a),
+                    crate::mavlink::AviateMessage::CommandAck { command, result } => {
+                        if result == 0 {
+                            info!(command, "FC accepted command");
+                        } else {
+                            warn!(command, result, "FC rejected command");
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        armed
     }
 
     /// The socket's local address, for tests.

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -16,14 +16,27 @@ use std::time::Instant;
 
 use tracing::{info, warn};
 
-use crate::mavlink::{encode_arm_command, encode_position_setpoint, encode_velocity_setpoint};
+use crate::mavlink::{encode_arm_command, encode_velocity_setpoint};
+
+/// Ground-side hold loop gain: velocity demand per meter of position
+/// error while sticks are centered. The FC's own PositionHold mode
+/// diverges on sustained holds (Aviate #110), so the hold runs here,
+/// through the velocity mode that demonstrably flies well.
+const HOLD_KP: f32 = 1.2;
+/// Hold-loop integral gain (cancels FC velocity-estimate bias; the
+/// SITL derives velocity by finite differences, which drifts).
+const HOLD_KI: f32 = 0.5;
+/// Hold-loop integrator clamp (m/s of correction authority).
+const HOLD_IMAX_MPS: f32 = 0.8;
+/// Hold-loop correction clamp.
+const HOLD_VMAX_MPS: f32 = 1.5;
 
 /// Full-stick horizontal velocity demand.
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
 /// Full-stick climb/descend rate demand.
 const MAX_VERTICAL_MPS: f32 = 1.5;
 /// Full-stick yaw rate demand (~86°/s).
-const MAX_YAW_RATE_RPS: f32 = 1.5;
+const MAX_YAW_RATE_RPS: f32 = 2.2;
 /// Longest believable gap between control frames when integrating the
 /// yaw-rate stick; anything longer is a stall, not a dt.
 const MAX_DT_S: f32 = 0.1;
@@ -51,6 +64,7 @@ pub struct FlightUplink {
     // Brake-then-hold state: the captured hold point while every stick
     // is centered, and the slew-limited velocity command.
     hold_pos_ned: Option<[f32; 3]>,
+    hold_int: [f32; 3],
     last_vel_ned: [f32; 3],
     started: Instant,
     send_failures: u64,
@@ -59,7 +73,7 @@ pub struct FlightUplink {
 /// Climb-stick threshold that opens the motors-idle gate after arming.
 const TAKEOFF_STICK: f32 = 0.15;
 /// Acceleration limit shaping stick steps into velocity ramps.
-const MAX_ACCEL_MPS2: f32 = 2.5;
+const MAX_ACCEL_MPS2: f32 = 5.0;
 
 impl FlightUplink {
     /// Binds an ephemeral socket toward the FC's command port
@@ -86,6 +100,7 @@ impl FlightUplink {
             quiet_until: None,
             airborne: false,
             hold_pos_ned: None,
+            hold_int: [0.0; 3],
             last_vel_ned: [0.0; 3],
             started: Instant::now(),
             send_failures: 0,
@@ -115,6 +130,7 @@ impl FlightUplink {
         self.quiet_until = Some(Instant::now() + ARM_QUIET);
         self.airborne = false;
         self.hold_pos_ned = None;
+        self.hold_int = [0.0; 3];
         self.last_vel_ned = [0.0; 3];
         let frame = encode_arm_command(self.seq, arm);
         self.send(&frame);
@@ -168,12 +184,20 @@ impl FlightUplink {
             > 0.02;
         if !sticks_active {
             let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
-            self.last_vel_ned = [0.0; 3];
-            let frame = encode_position_setpoint(self.seq, time_boot_ms, hold, self.heading_sp_rad);
+            let mut vel = [0.0f32; 3];
+            for i in 0..3 {
+                let err = hold[i] - current_pos_ned_m[i];
+                self.hold_int[i] =
+                    (self.hold_int[i] + HOLD_KI * err * dt).clamp(-HOLD_IMAX_MPS, HOLD_IMAX_MPS);
+                vel[i] = (HOLD_KP * err + self.hold_int[i]).clamp(-HOLD_VMAX_MPS, HOLD_VMAX_MPS);
+            }
+            self.last_vel_ned = vel;
+            let frame = encode_velocity_setpoint(self.seq, time_boot_ms, vel, self.heading_sp_rad);
             self.send(&frame);
             return;
         }
         self.hold_pos_ned = None;
+        self.hold_int = [0.0; 3];
 
         self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
 

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -35,8 +35,12 @@ const HOLD_VMAX_MPS: f32 = 1.5;
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
 /// Full-stick climb/descend rate demand.
 const MAX_VERTICAL_MPS: f32 = 1.5;
-/// Full-stick yaw rate demand (~86°/s).
-const MAX_YAW_RATE_RPS: f32 = 2.2;
+/// Full-stick yaw rate demand (~52°/s). Bounded by what the X500's
+/// rotor-drag yaw plant can *stop*: the FC brakes a spin at roughly
+/// 0.5 rad/s², so releasing the stick at this rate overshoots the
+/// captured heading by well under a half-turn. Higher demands coast
+/// through the target and re-chase it the long way around the wrap.
+const MAX_YAW_RATE_RPS: f32 = 0.9;
 /// Longest believable gap between control frames when integrating the
 /// yaw-rate stick; anything longer is a stall, not a dt.
 const MAX_DT_S: f32 = 0.1;

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -16,10 +16,20 @@ use std::time::Instant;
 
 use tracing::{info, warn};
 
-use crate::mavlink::{encode_arm_command, encode_position_setpoint, encode_velocity_setpoint};
+use crate::mavlink::{
+    encode_arm_command, encode_attitude_setpoint, encode_position_setpoint,
+    encode_velocity_setpoint,
+};
 
 /// Full-stick horizontal velocity demand.
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
+/// FPV mode: full-stick roll/pitch attitude demand (~35°).
+const FPV_MAX_TILT_RAD: f32 = 0.6;
+/// FPV mode: thrust at centered throttle stick. Full up commands 1.0,
+/// full down 0.30 (enough authority to descend briskly while keeping
+/// the props spinning well clear of the mixer floor).
+const FPV_HOVER_THRUST: f32 = 0.72;
+const FPV_MIN_THRUST: f32 = 0.30;
 /// Full-stick climb/descend rate demand.
 const MAX_VERTICAL_MPS: f32 = 1.5;
 /// Full-stick yaw rate demand (~52°/s). Bounded by what the X500's
@@ -123,6 +133,50 @@ impl FlightUplink {
         let frame = encode_arm_command(self.seq, arm);
         self.send(&frame);
         info!(arm, "sent arm command to FC");
+    }
+
+    /// Converts one canonical stick frame into an FPV attitude
+    /// setpoint: roll/pitch sticks command *angles* (rate-style FPV
+    /// acro is a follow-up), the yaw stick integrates a heading
+    /// setpoint exactly like camera mode, and throttle maps directly
+    /// to collective thrust around the hover point — altitude is the
+    /// pilot's axis in FPV.
+    pub fn send_fpv_frame(&mut self, roll: f32, pitch: f32, throttle: f32, yaw: f32) {
+        let now = Instant::now();
+        if let Some(quiet) = self.quiet_until {
+            if now < quiet {
+                return;
+            }
+            self.quiet_until = None;
+        }
+        if !self.airborne {
+            if throttle <= TAKEOFF_STICK {
+                return; // motors idle until the first climb input
+            }
+            self.airborne = true;
+            info!("takeoff (FPV): climb input opens the setpoint stream");
+        }
+        let dt = self
+            .last_frame
+            .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
+            .clamp(0.0, MAX_DT_S);
+        self.last_frame = Some(now);
+        self.hold_pos_ned = None;
+        self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
+        let thrust = if throttle >= 0.0 {
+            FPV_HOVER_THRUST + throttle * (1.0 - FPV_HOVER_THRUST)
+        } else {
+            FPV_HOVER_THRUST + throttle * (FPV_HOVER_THRUST - FPV_MIN_THRUST)
+        };
+        let frame = encode_attitude_setpoint(
+            self.seq,
+            self.started.elapsed().as_millis() as u32,
+            roll * FPV_MAX_TILT_RAD,
+            pitch * FPV_MAX_TILT_RAD,
+            self.heading_sp_rad,
+            thrust,
+        );
+        self.send(&frame);
     }
 
     /// Converts one canonical stick frame (`[-1, 1]` roll/pitch/

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -16,20 +16,7 @@ use std::time::Instant;
 
 use tracing::{info, warn};
 
-use crate::mavlink::{encode_arm_command, encode_velocity_setpoint};
-
-/// Ground-side hold loop gain: velocity demand per meter of position
-/// error while sticks are centered. The FC's own PositionHold mode
-/// diverges on sustained holds (Aviate #110), so the hold runs here,
-/// through the velocity mode that demonstrably flies well.
-const HOLD_KP: f32 = 1.2;
-/// Hold-loop integral gain (cancels FC velocity-estimate bias; the
-/// SITL derives velocity by finite differences, which drifts).
-const HOLD_KI: f32 = 0.5;
-/// Hold-loop integrator clamp (m/s of correction authority).
-const HOLD_IMAX_MPS: f32 = 0.8;
-/// Hold-loop correction clamp.
-const HOLD_VMAX_MPS: f32 = 1.5;
+use crate::mavlink::{encode_arm_command, encode_position_setpoint, encode_velocity_setpoint};
 
 /// Full-stick horizontal velocity demand.
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
@@ -68,7 +55,6 @@ pub struct FlightUplink {
     // Brake-then-hold state: the captured hold point while every stick
     // is centered, and the slew-limited velocity command.
     hold_pos_ned: Option<[f32; 3]>,
-    hold_int: [f32; 3],
     last_vel_ned: [f32; 3],
     started: Instant,
     send_failures: u64,
@@ -104,7 +90,6 @@ impl FlightUplink {
             quiet_until: None,
             airborne: false,
             hold_pos_ned: None,
-            hold_int: [0.0; 3],
             last_vel_ned: [0.0; 3],
             started: Instant::now(),
             send_failures: 0,
@@ -134,7 +119,6 @@ impl FlightUplink {
         self.quiet_until = Some(Instant::now() + ARM_QUIET);
         self.airborne = false;
         self.hold_pos_ned = None;
-        self.hold_int = [0.0; 3];
         self.last_vel_ned = [0.0; 3];
         let frame = encode_arm_command(self.seq, arm);
         self.send(&frame);
@@ -176,10 +160,11 @@ impl FlightUplink {
         self.last_frame = Some(now);
         let time_boot_ms = self.started.elapsed().as_millis() as u32;
 
-        // DJI brake-then-hold: with every stick centered, velocity mode
-        // would drift on vz-tracking bias — capture the current position
-        // once and stream a position-hold setpoint until any stick
-        // deflects again.
+        // DJI brake-then-hold: with every stick centered, capture the
+        // current position once and stream a position setpoint. The
+        // hold loop itself runs on the FC (PositionHold cascade) —
+        // ground code carries no control gains, only the captured
+        // point. Any stick deflection returns to velocity mode.
         let sticks_active = roll
             .abs()
             .max(pitch.abs())
@@ -188,20 +173,12 @@ impl FlightUplink {
             > 0.02;
         if !sticks_active {
             let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
-            let mut vel = [0.0f32; 3];
-            for i in 0..3 {
-                let err = hold[i] - current_pos_ned_m[i];
-                self.hold_int[i] =
-                    (self.hold_int[i] + HOLD_KI * err * dt).clamp(-HOLD_IMAX_MPS, HOLD_IMAX_MPS);
-                vel[i] = (HOLD_KP * err + self.hold_int[i]).clamp(-HOLD_VMAX_MPS, HOLD_VMAX_MPS);
-            }
-            self.last_vel_ned = vel;
-            let frame = encode_velocity_setpoint(self.seq, time_boot_ms, vel, self.heading_sp_rad);
+            self.last_vel_ned = [0.0; 3];
+            let frame = encode_position_setpoint(self.seq, time_boot_ms, hold, self.heading_sp_rad);
             self.send(&frame);
             return;
         }
         self.hold_pos_ned = None;
-        self.hold_int = [0.0; 3];
 
         self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
 

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -1,0 +1,193 @@
+//! DJI-style flight uplink: stick positions become velocity setpoints
+//! (issue #12).
+//!
+//! The control law, not the stick map, is what makes a camera drone feel
+//! like one: sticks command **velocities**, centered sticks command
+//! zero, and the FC's velocity mode brakes to a hover when input stops.
+//! This module turns canonical `[-1, 1]` axes into
+//! SET_POSITION_TARGET_LOCAL_NED frames: horizontal sticks are
+//! body-frame velocity demands rotated into NED by the vehicle's current
+//! yaw, the yaw stick is a rate demand integrated on the ground into an
+//! absolute heading setpoint (Aviate's velocity mode takes absolute
+//! yaw), and throttle is a climb-rate demand.
+
+use std::net::{SocketAddr, UdpSocket};
+use std::time::Instant;
+
+use tracing::{info, warn};
+
+use crate::mavlink::{encode_arm_command, encode_velocity_setpoint};
+
+/// Full-stick horizontal velocity demand.
+const MAX_HORIZONTAL_MPS: f32 = 3.0;
+/// Full-stick climb/descend rate demand.
+const MAX_VERTICAL_MPS: f32 = 1.5;
+/// Full-stick yaw rate demand (~86°/s).
+const MAX_YAW_RATE_RPS: f32 = 1.5;
+/// Longest believable gap between control frames when integrating the
+/// yaw-rate stick; anything longer is a stall, not a dt.
+const MAX_DT_S: f32 = 0.1;
+/// Stick frames are suppressed this long after an arm/disarm send: the
+/// FC stages inbound commands in a single slot, so a setpoint arriving
+/// in the same poll batch would overwrite the arm before the control
+/// loop consumes it.
+const ARM_QUIET: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// The UDP MAVLink command uplink to the FC.
+#[derive(Debug)]
+pub struct FlightUplink {
+    socket: UdpSocket,
+    target: SocketAddr,
+    seq: u8,
+    heading_sp_rad: f32,
+    last_frame: Option<Instant>,
+    quiet_until: Option<Instant>,
+    // Motors-idle gate: after arm, no velocity setpoints stream until
+    // the first deliberate climb input. Streaming vz=0 to a grounded
+    // vehicle commands "hold zero vertical velocity" at near-hover
+    // thrust, which tips it over — real drones idle until the first
+    // climb, so this does too.
+    airborne: bool,
+    started: Instant,
+    send_failures: u64,
+}
+
+/// Climb-stick threshold that opens the motors-idle gate after arming.
+const TAKEOFF_STICK: f32 = 0.15;
+
+impl FlightUplink {
+    /// Binds an ephemeral socket toward the FC's command port
+    /// (`PILOTAGE_AVIATE_FC_ADDR`, default `127.0.0.1:20000` — the SITL
+    /// FC's MAVLink/GCS port).
+    ///
+    /// # Errors
+    ///
+    /// Returns the socket bind error.
+    pub fn new() -> std::io::Result<Self> {
+        let target = std::env::var("PILOTAGE_AVIATE_FC_ADDR")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 20000)));
+        let socket = UdpSocket::bind("127.0.0.1:0")?;
+        info!(%target, "Aviate flight uplink ready");
+        Ok(Self {
+            socket,
+            target,
+            seq: 0,
+            heading_sp_rad: 0.0,
+            last_frame: None,
+            quiet_until: None,
+            airborne: false,
+            started: Instant::now(),
+            send_failures: 0,
+        })
+    }
+
+    fn send(&mut self, frame: &[u8]) {
+        if self.socket.send_to(frame, self.target).is_err() {
+            self.send_failures = self.send_failures.wrapping_add(1);
+            if self.send_failures == 1 || self.send_failures.is_multiple_of(100) {
+                warn!(
+                    failures = self.send_failures,
+                    target = %self.target,
+                    "flight uplink send failed"
+                );
+            }
+        }
+        self.seq = self.seq.wrapping_add(1);
+    }
+
+    /// Sends arm/disarm and re-seeds the heading setpoint from the
+    /// vehicle's current yaw so the first yaw-stick input turns from
+    /// where the aircraft actually points.
+    pub fn send_arm(&mut self, arm: bool, current_yaw_rad: f32) {
+        self.heading_sp_rad = current_yaw_rad;
+        self.last_frame = None;
+        self.quiet_until = Some(Instant::now() + ARM_QUIET);
+        self.airborne = false;
+        let frame = encode_arm_command(self.seq, arm);
+        self.send(&frame);
+        info!(arm, "sent arm command to FC");
+    }
+
+    /// Converts one canonical stick frame (`[-1, 1]` roll/pitch/
+    /// throttle/yaw, stick conventions: pitch + = forward, roll + =
+    /// right, throttle + = climb, yaw + = clockwise) into a velocity
+    /// setpoint and sends it.
+    pub fn send_stick_frame(
+        &mut self,
+        roll: f32,
+        pitch: f32,
+        throttle: f32,
+        yaw: f32,
+        current_yaw_rad: f32,
+    ) {
+        let now = Instant::now();
+        if let Some(quiet) = self.quiet_until {
+            if now < quiet {
+                return;
+            }
+            self.quiet_until = None;
+        }
+        if !self.airborne {
+            if throttle <= TAKEOFF_STICK {
+                return; // motors idle until the first climb input
+            }
+            self.airborne = true;
+            info!("takeoff: climb input opens the setpoint stream");
+        }
+        let dt = self
+            .last_frame
+            .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
+            .clamp(0.0, MAX_DT_S);
+        self.last_frame = Some(now);
+
+        self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
+
+        // Horizontal sticks demand velocity in the vehicle's heading
+        // frame; rotate into NED by the *measured* yaw so "stick
+        // forward" is always "toward the nose".
+        let fwd = pitch * MAX_HORIZONTAL_MPS;
+        let lat = roll * MAX_HORIZONTAL_MPS;
+        let (sin_y, cos_y) = current_yaw_rad.sin_cos();
+        let vel_ned = [
+            fwd * cos_y - lat * sin_y,
+            fwd * sin_y + lat * cos_y,
+            -throttle * MAX_VERTICAL_MPS,
+        ];
+        let time_boot_ms = self.started.elapsed().as_millis() as u32;
+        let frame = encode_velocity_setpoint(self.seq, time_boot_ms, vel_ned, self.heading_sp_rad);
+        self.send(&frame);
+    }
+
+    /// Sends a zero-velocity setpoint holding the current heading — the
+    /// link-loss neutralize action (the FC's velocity mode brakes to a
+    /// hover on zero demand).
+    pub fn send_neutral(&mut self) {
+        let time_boot_ms = self.started.elapsed().as_millis() as u32;
+        let frame = encode_velocity_setpoint(self.seq, time_boot_ms, [0.0; 3], self.heading_sp_rad);
+        self.send(&frame);
+    }
+
+    /// The socket's local address, for tests.
+    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.socket.local_addr()
+    }
+
+    /// Overrides the target, for tests.
+    #[cfg(test)]
+    pub(crate) fn set_target(&mut self, target: SocketAddr) {
+        self.target = target;
+    }
+}
+
+fn wrap_pi(rad: f32) -> f32 {
+    let mut r = rad;
+    while r > core::f32::consts::PI {
+        r -= 2.0 * core::f32::consts::PI;
+    }
+    while r < -core::f32::consts::PI {
+        r += 2.0 * core::f32::consts::PI;
+    }
+    r
+}

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -132,6 +132,13 @@
   <label>port <input id="port" placeholder="4433" /></label>
   <label>cert hash <input id="certHash" placeholder="hex from LISTENING line" /></label>
   <button id="connectBtn">Connect</button>
+  <label>controls
+    <select id="flightMode">
+      <option value="quad-pilot" selected>Quad — Pilot (Mode 2)</option>
+      <option value="quad-cruise">Quad — Cruise (game-native)</option>
+      <option value="rover">Rover (throttle/yaw)</option>
+    </select>
+  </label>
 </div>
 
 <div class="stage-row">

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -139,6 +139,7 @@
       <option value="rover">Rover (throttle/yaw)</option>
     </select>
   </label>
+  <button id="resetBtn" title="Reset the simulation world and restart the FC">Reset sim</button>
 </div>
 
 <div class="stage-row">

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -135,11 +135,11 @@
   <label>controls
     <select id="flightMode">
       <option value="quad-pilot" selected>Quad — Pilot (Mode 2)</option>
-      <option value="quad-cruise">Quad — Cruise (game-native)</option>
+      <option value="fpv">FPV (attitude)</option><option value="quad-cruise">Quad — Cruise (game-native)</option>
       <option value="rover">Rover (throttle/yaw)</option>
     </select>
   </label>
-  <button id="resetBtn" title="Reset the simulation world and restart the FC">Reset sim</button>
+  <button id="fpvBtn">FPV mode</button><button id="resetBtn" title="Reset the simulation world and restart the FC">Reset sim</button>
 </div>
 
 <div class="stage-row">

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -342,8 +342,9 @@ async function readTelemetryDatagrams(transport) {
     const decoded = decodeBareEnvelope(value);
     if (decoded.kind === "TelemetrySample") {
       const t = decoded.message;
+      const armText = { 0: "arm: unknown", 1: "DISARMED", 2: "ARMED" }[t.avionics?.armState ?? 0];
       els.telemetry.textContent =
-        `pose x=${t.xM.toFixed(2)}m y=${t.yM.toFixed(2)}m heading=${t.headingRad.toFixed(2)}rad` +
+        `${armText} | pose x=${t.xM.toFixed(2)}m y=${t.yM.toFixed(2)}m heading=${t.headingRad.toFixed(2)}rad` +
         ` | v=${t.linearXMps.toFixed(2)}m/s w=${t.angularRadS.toFixed(2)}rad/s`;
       if (t.avionics) {
         instruments.latest = t.avionics;
@@ -376,33 +377,30 @@ const DRIVE_KEYS = new Set([
   "Backspace",
 ]);
 
+// Keys are stored raw (letters lower-cased) so rover and flight modes can
+// map WASD and the arrows independently.
+function canonicalKey(key) {
+  return key.length === 1 ? key.toLowerCase() : key;
+}
 window.addEventListener("keydown", (event) => {
   if (DRIVE_KEYS.has(event.key)) {
-    state.keys.add(normalizeKey(event.key));
+    state.keys.add(canonicalKey(event.key));
     event.preventDefault();
   }
 });
 window.addEventListener("keyup", (event) => {
   if (DRIVE_KEYS.has(event.key)) {
-    state.keys.delete(normalizeKey(event.key));
+    state.keys.delete(canonicalKey(event.key));
     event.preventDefault();
   }
 });
 
-function normalizeKey(key) {
-  const map = { w: "ArrowUp", s: "ArrowDown", a: "ArrowLeft", d: "ArrowRight" };
-  return map[key.toLowerCase()] || key;
-}
-
 /** Maps current key state to [throttle, yaw] axis values in [-1.0, 1.0]. */
 function axesFromKeys() {
-  let throttle = 0;
-  let yaw = 0;
-  if (state.keys.has("ArrowUp")) throttle += 1;
-  if (state.keys.has("ArrowDown")) throttle -= 1;
-  if (state.keys.has("ArrowLeft")) yaw -= 1;
-  if (state.keys.has("ArrowRight")) yaw += 1;
-  return [throttle, yaw];
+  const k = (key) => (state.keys.has(key) ? 1 : 0);
+  const throttle = k("ArrowUp") + k("w") - k("ArrowDown") - k("s");
+  const yaw = k("ArrowRight") + k("d") - k("ArrowLeft") - k("a");
+  return [Math.max(-1, Math.min(1, throttle)), Math.max(-1, Math.min(1, yaw))];
 }
 
 /** Keyboard fallback for flight modes: W/S = climb/descend, A/D = yaw,
@@ -412,8 +410,8 @@ function flightAxesFromKeys() {
   return {
     roll: k("ArrowRight") - k("ArrowLeft"),
     pitch: k("ArrowUp") - k("ArrowDown"),
-    throttle: k("w") + k("W") - k("s") - k("S"),
-    yaw: k("d") + k("D") - k("a") - k("A"),
+    throttle: k("w") - k("s"),
+    yaw: k("d") - k("a"),
   };
 }
 
@@ -489,7 +487,10 @@ function flightAxesFromGamepad(pad, profile, mode) {
   const rawAt = (i) => (i >= 0 && i < pad.axes.length ? pad.axes[i] : 0);
   const clamp = (v) => Math.max(-1, Math.min(1, v));
   const dz = profile.deadzone ?? 0.1;
-  const shaped = (v) => clamp(Math.abs(v) < dz ? 0 : v);
+  // Cubic expo (50%): fine authority near center, full range at the
+  // ends — half of the DJI feel; the uplink's slew limit is the other.
+  const expo = (v) => 0.5 * v * v * v + 0.5 * v;
+  const shaped = (v) => expo(clamp(Math.abs(v) < dz ? 0 : v));
   const raw = (i) => shaped(rawAt(i));
   if (profile.standard) {
     const scheme = FLIGHT_SCHEMES[mode] ?? FLIGHT_SCHEMES["quad-pilot"];

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -23,14 +23,19 @@ import {
   decodeBareEnvelope,
   STREAM_KIND_AUTHORITY,
   STREAM_KIND_VIDEO,
+  BUTTON_EDGE_PRESSED,
 } from "./wire.js";
 import { loadInstruments, PANEL } from "./instruments.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const MOTION_SCOPE = "vehicle.motion";
 const CONTROL_HZ = 30; // continuous control send rate; superseded samples are droppable (ADR-0011).
-const AXIS_THROTTLE = 2; // pilotage-input logical axis table: throttle = 2.
-const AXIS_YAW = 3; // pilotage-input logical axis table: yaw = 3.
+const AXIS_ROLL = 0; // pilotage-input logical axis table: roll = 0 (lateral velocity, + right).
+const AXIS_PITCH = 1; // pitch = 1 (forward velocity, + forward).
+const AXIS_THROTTLE = 2; // throttle = 2 (rover: forward speed; quad: climb rate).
+const AXIS_YAW = 3; // yaw = 3 (yaw rate, + clockwise).
+const BUTTON_ARM = 0; // logical button 0: arm (adapter contract, issue #12).
+const BUTTON_DISARM = 1; // logical button 1: disarm.
 
 const els = {
   host: document.getElementById("host"),
@@ -45,6 +50,7 @@ const els = {
   chaseCanvas: document.getElementById("chaseVideo"),
   pfd: document.getElementById("pfd"),
   hsi: document.getElementById("hsi"),
+  flightMode: document.getElementById("flightMode"),
 };
 const ctx = els.canvas.getContext("2d");
 const chaseCtx = els.chaseCanvas.getContext("2d");
@@ -59,6 +65,7 @@ const state = {
   sequence: 0,
   startNanos: BigInt(Date.now()) * 1_000_000n, // arbitrary local monotonic-ish origin for sampled_at (ADR-0009: endpoint-local, never compared raw across endpoints).
   keys: new Set(),
+  prevArmInputs: new Set(),
   connected: false,
   leaseGranted: false,
   skippedVideoFrames: 0,
@@ -352,7 +359,22 @@ async function readTelemetryDatagrams(transport) {
 
 // ---- keyboard -> control frame datagrams -----------------------------------
 
-const DRIVE_KEYS = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "w", "a", "s", "d", "W", "A", "S", "D"]);
+const DRIVE_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "w",
+  "a",
+  "s",
+  "d",
+  "W",
+  "A",
+  "S",
+  "D",
+  "Enter",
+  "Backspace",
+]);
 
 window.addEventListener("keydown", (event) => {
   if (DRIVE_KEYS.has(event.key)) {
@@ -381,6 +403,18 @@ function axesFromKeys() {
   if (state.keys.has("ArrowLeft")) yaw -= 1;
   if (state.keys.has("ArrowRight")) yaw += 1;
   return [throttle, yaw];
+}
+
+/** Keyboard fallback for flight modes: W/S = climb/descend, A/D = yaw,
+ *  arrows = forward/back + left/right translation. */
+function flightAxesFromKeys() {
+  const k = (key) => (state.keys.has(key) ? 1 : 0);
+  return {
+    roll: k("ArrowRight") - k("ArrowLeft"),
+    pitch: k("ArrowUp") - k("ArrowDown"),
+    throttle: k("w") + k("W") - k("s") - k("S"),
+    yaw: k("d") + k("D") - k("a") - k("A"),
+  };
 }
 
 // Per-controller FPV mapping profiles. EdgeTX radios (RadioMaster Pocket) output
@@ -413,10 +447,91 @@ const CONTROLLER_PROFILES = [
     forwardSign: -1, // stick up (negative) = forward
     turnAxis: 0, // left stick horizontal
     turnSign: -1, // stick right (positive) = turn right (negative yaw-rate)
-    deadzone: 0.12, // thumbsticks drift more than radio gimbals
     deadzone: 0.06,
+    standard: true, // W3C Standard Gamepad layout: flight schemes apply
   },
 ];
+
+// Flight-mode stick schemes for Standard Gamepad pads (issue #12). Both
+// command the identical velocity control law — only stick assignment
+// differs. Browser reports stick-up as negative, hence the -1 signs.
+//   pilot  = RC Mode 2 (camera-drone default): left = climb+yaw,
+//            right = translate.
+//   cruise = game-native: left = translate, right X = yaw,
+//            R2/L2 analog triggers = climb/descend.
+// DualSense standard mapping: axes 0/1 left X/Y, 2/3 right X/Y;
+// buttons 6/7 = L2/R2 analog, 8 = create/share, 9 = options.
+const FLIGHT_SCHEMES = {
+  "quad-pilot": (raw) => ({
+    throttle: -raw(1),
+    yaw: raw(0),
+    pitch: -raw(3),
+    roll: raw(2),
+    label: "PILOT (Mode 2): L=climb/yaw R=move",
+  }),
+  "quad-cruise": (raw, buttons) => ({
+    pitch: -raw(1),
+    roll: raw(0),
+    yaw: raw(2),
+    throttle: (buttons[7]?.value ?? 0) - (buttons[6]?.value ?? 0),
+    label: "CRUISE: L=move RX=yaw R2/L2=climb",
+  }),
+};
+// Gamepad buttons that fire arm/disarm edges: options (9) arms,
+// create/share (8) disarms — deliberately away from the face buttons.
+const PAD_ARM_BUTTON = 9;
+const PAD_DISARM_BUTTON = 8;
+
+/** Maps a Standard-Gamepad pad to flight axes under the given scheme;
+ *  non-standard pads (EdgeTX radios) use their AETR axes directly, which
+ *  is true RC Mode 2 on a real radio. */
+function flightAxesFromGamepad(pad, profile, mode) {
+  const rawAt = (i) => (i >= 0 && i < pad.axes.length ? pad.axes[i] : 0);
+  const clamp = (v) => Math.max(-1, Math.min(1, v));
+  const dz = profile.deadzone ?? 0.1;
+  const shaped = (v) => clamp(Math.abs(v) < dz ? 0 : v);
+  const raw = (i) => shaped(rawAt(i));
+  if (profile.standard) {
+    const scheme = FLIGHT_SCHEMES[mode] ?? FLIGHT_SCHEMES["quad-pilot"];
+    const a = scheme(raw, pad.buttons ?? []);
+    return {
+      roll: clamp(a.roll),
+      pitch: clamp(a.pitch),
+      throttle: clamp(a.throttle),
+      yaw: clamp(a.yaw),
+      label: a.label,
+    };
+  }
+  // EdgeTX AETR HID order: 0 roll, 1 pitch, 2 throttle, 3 yaw.
+  return {
+    roll: raw(0),
+    pitch: -raw(1),
+    throttle: raw(2),
+    yaw: -raw(3),
+    label: "radio AETR (Mode 2)",
+  };
+}
+
+/** One-shot arm/disarm edges from gamepad buttons and keys: Enter arms,
+ *  Backspace disarms; pad options (9) arms, create (8) disarms. */
+function collectArmEdges(pad) {
+  const pressedNow = new Set();
+  if (pad?.buttons?.[PAD_ARM_BUTTON]?.pressed) pressedNow.add("pad-arm");
+  if (pad?.buttons?.[PAD_DISARM_BUTTON]?.pressed) pressedNow.add("pad-disarm");
+  if (state.keys.has("Enter")) pressedNow.add("key-arm");
+  if (state.keys.has("Backspace")) pressedNow.add("key-disarm");
+  const edges = [];
+  for (const which of pressedNow) {
+    if (!state.prevArmInputs.has(which)) {
+      const arm = which.endsWith("-arm");
+      edges.push([arm ? BUTTON_ARM : BUTTON_DISARM, BUTTON_EDGE_PRESSED]);
+      els.overlay.textContent = arm ? "ARM sent" : "DISARM sent";
+      log(arm ? "arm command sent" : "disarm command sent");
+    }
+  }
+  state.prevArmInputs = pressedNow;
+  return edges;
+}
 // Fallback for any other gamepad: drive from the left stick's self-centering
 // vertical/horizontal axes so the vehicle stops when the stick is released.
 const GENERIC_PROFILE = {
@@ -449,6 +564,7 @@ function overrideProfile(profile) {
     turnAxis: intParam("turn", profile.turnAxis),
     turnSign: signParam("turnsign", profile.turnSign),
     deadzone: numParam("deadzone", profile.deadzone),
+    standard: profile.standard === true,
   };
 }
 
@@ -496,6 +612,14 @@ function updateGamepadReadout(pad, profile, throttle, yaw) {
     `yaw=${yaw.toFixed(2)} (axis ${profile.turnAxis})`;
 }
 
+/** Shows the live 4-axis flight mapping and stick values. */
+function updateFlightReadout(pad, f) {
+  const src = pad ? `${pad.id.slice(0, 24)} [${f.label}]` : "keyboard (WS=climb AD=yaw arrows=move)";
+  els.gamepad.textContent =
+    `flight: ${src} | roll=${f.roll.toFixed(2)} pitch=${f.pitch.toFixed(2)} ` +
+    `climb=${f.throttle.toFixed(2)} yaw=${f.yaw.toFixed(2)} | arm: Options/Enter, disarm: Create/Backspace`;
+}
+
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
 async function startControlLoop(transport) {
   const writer = transport.datagrams.writable.getWriter();
@@ -512,12 +636,33 @@ async function startControlLoop(transport) {
       return; // writer closed (session ended)
     }
     if (!state.connected) return;
-    // A connected gamepad drives under its FPV profile; the keyboard is the
-    // fallback when none is present. The readout shows the live mapping either way.
+    // A connected gamepad drives under its profile; the keyboard is the
+    // fallback when none is present. The readout shows the live mapping.
+    const mode = els.flightMode ? els.flightMode.value : "rover";
     const pad = activeGamepad();
     const profile = pad ? profileFor(pad.id) : null;
-    const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
-    updateGamepadReadout(pad, profile, throttle, yaw);
+    let axes;
+    let edges = [];
+    if (mode === "rover") {
+      // Ground vehicles (the Gazebo yard world) accept only the
+      // throttle/yaw pair; extra axes would be rejected as unknown.
+      const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
+      updateGamepadReadout(pad, profile, throttle, yaw);
+      axes = [
+        [AXIS_THROTTLE, throttle],
+        [AXIS_YAW, yaw],
+      ];
+    } else {
+      const f = pad ? flightAxesFromGamepad(pad, profile, mode) : flightAxesFromKeys();
+      updateFlightReadout(pad, f);
+      edges = collectArmEdges(pad);
+      axes = [
+        [AXIS_ROLL, f.roll],
+        [AXIS_PITCH, f.pitch],
+        [AXIS_THROTTLE, f.throttle],
+        [AXIS_YAW, f.yaw],
+      ];
+    }
     state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
     const envelope = encodeControlFrameEnvelope({
       sessionId: state.sessionId,
@@ -527,10 +672,8 @@ async function startControlLoop(transport) {
       sequence: state.sequence,
       sampledAtNanos: nowNanos(),
       profileRevision: 1,
-      axes: [
-        [AXIS_THROTTLE, throttle],
-        [AXIS_YAW, yaw],
-      ],
+      axes,
+      edges,
     });
     writer.write(envelope).catch((error) => log(`control datagram send failed: ${error}`));
     await new Promise((resolve) => setTimeout(resolve, intervalMs));

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -37,6 +37,7 @@ const AXIS_YAW = 3; // yaw = 3 (yaw rate, + clockwise).
 const BUTTON_ARM = 0; // logical button 0: arm (adapter contract, issue #12).
 const BUTTON_DISARM = 1; // logical button 1: disarm.
 const BUTTON_RESET = 2; // logical button 2: reset the simulation (adapter runs the reset script).
+const BUTTON_FPV_TOGGLE = 3; // logical button 3: camera <-> FPV mode (adapter latches).
 
 const els = {
   host: document.getElementById("host"),
@@ -68,6 +69,7 @@ const state = {
   keys: new Set(),
   prevArmInputs: new Set(),
   pendingReset: false,
+  pendingFpvToggle: false,
   connected: false,
   leaseGranted: false,
   skippedVideoFrames: 0,
@@ -476,6 +478,16 @@ const FLIGHT_SCHEMES = {
     throttle: (buttons[7]?.value ?? 0) - (buttons[6]?.value ?? 0),
     label: "CRUISE: L=move RX=yaw R2/L2=climb",
   }),
+  // FPV: same Mode-2 stick geometry as PILOT, but the adapter is in
+  // attitude mode — right stick commands tilt ANGLES, throttle is
+  // direct collective around hover. Toggle with the FPV button.
+  fpv: (raw) => ({
+    throttle: -raw(1),
+    yaw: raw(0),
+    pitch: -raw(3),
+    roll: raw(2),
+    label: "FPV: R=tilt angle L=thrust/yaw",
+  }),
 };
 // Gamepad buttons that fire arm/disarm edges: options (9) arms,
 // create/share (8) disarms — deliberately away from the face buttons.
@@ -659,6 +671,10 @@ async function startControlLoop(transport) {
       const f = pad ? flightAxesFromGamepad(pad, profile, mode) : flightAxesFromKeys();
       updateFlightReadout(pad, f);
       edges = collectArmEdges(pad);
+      if (state.pendingFpvToggle) {
+        state.pendingFpvToggle = false;
+        edges.push([BUTTON_FPV_TOGGLE, BUTTON_EDGE_PRESSED]);
+      }
       if (state.pendingReset) {
         state.pendingReset = false;
         edges.push([BUTTON_RESET, BUTTON_EDGE_PRESSED]);
@@ -734,6 +750,9 @@ async function startInstruments() {
 
 applyUrlParams();
 startInstruments();
+document.getElementById("fpvBtn").addEventListener("click", () => {
+  state.pendingFpvToggle = true;
+});
 document.getElementById("resetBtn").addEventListener("click", () => {
   state.pendingReset = true;
 });

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -36,6 +36,7 @@ const AXIS_THROTTLE = 2; // throttle = 2 (rover: forward speed; quad: climb rate
 const AXIS_YAW = 3; // yaw = 3 (yaw rate, + clockwise).
 const BUTTON_ARM = 0; // logical button 0: arm (adapter contract, issue #12).
 const BUTTON_DISARM = 1; // logical button 1: disarm.
+const BUTTON_RESET = 2; // logical button 2: reset the simulation (adapter runs the reset script).
 
 const els = {
   host: document.getElementById("host"),
@@ -66,6 +67,7 @@ const state = {
   startNanos: BigInt(Date.now()) * 1_000_000n, // arbitrary local monotonic-ish origin for sampled_at (ADR-0009: endpoint-local, never compared raw across endpoints).
   keys: new Set(),
   prevArmInputs: new Set(),
+  pendingReset: false,
   connected: false,
   leaseGranted: false,
   skippedVideoFrames: 0,
@@ -489,7 +491,7 @@ function flightAxesFromGamepad(pad, profile, mode) {
   const dz = profile.deadzone ?? 0.1;
   // Cubic expo (50%): fine authority near center, full range at the
   // ends — half of the DJI feel; the uplink's slew limit is the other.
-  const expo = (v) => 0.5 * v * v * v + 0.5 * v;
+  const expo = (v) => 0.35 * v * v * v + 0.65 * v;
   const shaped = (v) => expo(clamp(Math.abs(v) < dz ? 0 : v));
   const raw = (i) => shaped(rawAt(i));
   if (profile.standard) {
@@ -657,6 +659,11 @@ async function startControlLoop(transport) {
       const f = pad ? flightAxesFromGamepad(pad, profile, mode) : flightAxesFromKeys();
       updateFlightReadout(pad, f);
       edges = collectArmEdges(pad);
+      if (state.pendingReset) {
+        state.pendingReset = false;
+        edges.push([BUTTON_RESET, BUTTON_EDGE_PRESSED]);
+        log("simulation reset requested");
+      }
       axes = [
         [AXIS_ROLL, f.roll],
         [AXIS_PITCH, f.pitch],
@@ -727,6 +734,9 @@ async function startInstruments() {
 
 applyUrlParams();
 startInstruments();
+document.getElementById("resetBtn").addEventListener("click", () => {
+  state.pendingReset = true;
+});
 els.connectBtn.addEventListener("click", () => {
   connect().catch((error) => log(`connect failed: ${error}`));
 });

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -486,6 +486,8 @@ function decodeAvionicsState(bytes) {
     ],
     validFlags: firstVarint(f, 14) ?? 0,
     quality: firstVarint(f, 15) ?? 0,
+    // 0 unknown, 1 disarmed, 2 armed.
+    armState: firstVarint(f, 16) ?? 0,
   };
 }
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -212,11 +212,25 @@ function encodeAxisSample(axisId, value) {
   return bytes;
 }
 
-function encodeControlPayload(axes) {
+function encodeControlPayload(axes, edges) {
   const bytes = [];
   for (const [axisId, value] of axes) {
     fieldBytes(bytes, 1, encodeAxisSample(axisId, value));
   }
+  for (const [buttonId, edge] of edges ?? []) {
+    fieldBytes(bytes, 2, encodeButtonEdgeSample(buttonId, edge));
+  }
+  return bytes;
+}
+
+// control.proto ButtonEdgeSample: button_id=1, edge=2
+// (ButtonEdge enum: 1 = pressed, 2 = released).
+export const BUTTON_EDGE_PRESSED = 1;
+
+function encodeButtonEdgeSample(buttonId, edge) {
+  const bytes = [];
+  fieldVarint(bytes, 1, buttonId);
+  fieldVarint(bytes, 2, edge);
   return bytes;
 }
 
@@ -224,7 +238,9 @@ function encodeControlPayload(axes) {
  * Encodes one `ControlFrame` wrapped in an `Envelope`, ready to send as a
  * single control-fast datagram (bare envelope, no length prefix, ADR-0005).
  *
- * `axes` is an array of `[axisId, value]` pairs, value in [-1.0, 1.0].
+ * `axes` is an array of `[axisId, value]` pairs, value in [-1.0, 1.0];
+ * `edges` (optional) is an array of `[buttonId, edgeEnum]` one-shot
+ * button events.
  */
 export function encodeControlFrameEnvelope({
   sessionId,
@@ -235,6 +251,7 @@ export function encodeControlFrameEnvelope({
   sampledAtNanos,
   profileRevision,
   axes,
+  edges,
 }) {
   // These seven are required message-typed fields the host's wire->domain
   // conversion demands present, so emit each even when its inner scalar is 0
@@ -247,7 +264,7 @@ export function encodeControlFrameEnvelope({
   fieldMessage(frame, 5, encodeSequenceNum(sequence));
   fieldMessage(frame, 6, encodeMonoTimestamp(sampledAtNanos));
   fieldVarint(frame, 7, profileRevision);
-  fieldMessage(frame, 8, encodeControlPayload(axes));
+  fieldMessage(frame, 8, encodeControlPayload(axes, edges));
   return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.controlFrame, frame));
 }
 

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -33,6 +33,9 @@ pub struct AvionicsSample {
     pub valid_flags: u32,
     /// Estimate quality: 0 good, 1 degraded, 2 unusable.
     pub quality: u32,
+    /// Arm state as the vehicle reports it: 0 unknown, 1 disarmed,
+    /// 2 armed.
+    pub arm_state: u32,
 }
 
 /// A single vehicle's telemetry at one simulation tick.

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -123,6 +123,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
             vel_d_mps: -1.0,
             valid_flags: 0b1111,
             quality: 0,
+            arm_state: 2,
         }),
     };
     let envelope = wire::Envelope {

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -160,7 +160,7 @@ async fn spawn_host_runtime(
             let (engine, adapter, frames) =
                 gazebo_launch::build_gazebo(HOST_VEHICLE, MAX_CONTROL_AGE).await?;
             let (media, media_task) = media::spawn_media_task(frames);
-            Ok(tokio::spawn(run_gazebo_until_shutdown(
+            Ok(tokio::spawn(run_with_media_until_shutdown(
                 endpoint,
                 engine,
                 adapter,
@@ -180,7 +180,7 @@ async fn spawn_host_runtime(
                 Ok("mavlink") => pilotage_adapter_aviate::AviateLinkMode::Mavlink,
                 _ => pilotage_adapter_aviate::AviateLinkMode::Auto,
             };
-            let adapter = pilotage_adapter_aviate::AviateAdapter::start(
+            let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
                 HOST_VEHICLE,
                 mode,
                 pilotage_adapter_aviate::LinkConfig::default(),
@@ -188,15 +188,30 @@ async fn spawn_host_runtime(
             .await
             .map_err(HostError::AviateAdapter)?;
             let engine = build_engine(&adapter);
-            Ok(tokio::spawn(run_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                None,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-            )))
+            match adapter.subscribe_frames() {
+                Some(frames) => {
+                    let (media, media_task) = media::spawn_media_task(frames);
+                    Ok(tokio::spawn(run_with_media_until_shutdown(
+                        endpoint,
+                        engine,
+                        adapter,
+                        media,
+                        media_task,
+                        engine_tx,
+                        engine_rx,
+                        shutdown_rx,
+                    )))
+                }
+                None => Ok(tokio::spawn(run_until_shutdown(
+                    endpoint,
+                    engine,
+                    adapter,
+                    None,
+                    engine_tx,
+                    engine_rx,
+                    shutdown_rx,
+                ))),
+            }
         }
     }
 }
@@ -248,21 +263,24 @@ async fn run_until_shutdown<A>(
     shutdown::join_with_timeout(tasks).await;
 }
 
-/// The Gazebo variant of [`run_until_shutdown`]: identical lifecycle, plus it
-/// joins the media task on the way out so no video uni stream is abandoned
-/// mid-write. The media task ends once its frame source (the adapter) is
-/// dropped, which the engine-actor task does at teardown.
+/// The camera-equipped variant of [`run_until_shutdown`]: identical
+/// lifecycle, plus it joins the media task on the way out so no video uni
+/// stream is abandoned mid-write. The media task ends once its frame
+/// source (the adapter) is dropped, which the engine-actor task does at
+/// teardown.
 #[allow(clippy::too_many_arguments)]
-async fn run_gazebo_until_shutdown(
+async fn run_with_media_until_shutdown<A>(
     endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
     engine: SessionEngine,
-    adapter: pilotage_adapter_gazebo::GazeboAdapter,
+    adapter: A,
     media: MediaHandle,
     media_task: tokio::task::JoinHandle<()>,
     engine_tx: mpsc::Sender<ToEngine>,
     engine_rx: mpsc::Receiver<ToEngine>,
     shutdown_rx: oneshot::Receiver<()>,
-) {
+) where
+    A: VehicleAdapter + Send + 'static,
+{
     run_until_shutdown(
         endpoint,
         engine,

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -247,6 +247,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
                     vel_d_mps: a.vel_ned_mps[2],
                     valid_flags: a.valid_flags,
                     quality: a.quality,
+                    arm_state: a.arm_state,
                 }),
             };
             let bytes = encode_telemetry_datagram(wire_sample);

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -47,6 +47,8 @@ message AvionicsState {
   uint32 valid_flags = 14;
   // 0 good, 1 degraded, 2 unusable.
   uint32 quality = 15;
+  // 0 unknown, 1 disarmed, 2 armed (from the vehicle's own report).
+  uint32 arm_state = 16;
 }
 
 // A single best-effort telemetry sample for one vehicle.

--- a/scripts/reset-flight-sim.sh
+++ b/scripts/reset-flight-sim.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Resets the flight demo between test iterations: puts the Gazebo world
+# back to its initial pose and restarts the FC binary (whose estimator
+# state must reset with the vehicle). Host and browser stay up — the shm
+# link reattaches by itself.
+#
+# Usage: scripts/reset-flight-sim.sh [world-name]  (default: default)
+set -euo pipefail
+export PATH="/opt/homebrew/bin:$PATH"
+export GZ_IP="${GZ_IP:-127.0.0.1}"
+WORLD="${1:-default}"
+
+echo "resetting world '${WORLD}'..."
+gz service -s "/world/${WORLD}/control" \
+  --reqtype gz.msgs.WorldControl --reptype gz.msgs.Boolean \
+  --timeout 3000 --req 'reset: {all: true}'
+
+echo "restarting FC..."
+pkill -9 -f sitl-gazebo-x500 2>/dev/null || true
+sleep 1
+AVIATE_DIR="${AVIATE_DIR:-$HOME/Aviate}"
+nohup "${AVIATE_DIR}/target/debug/sitl-gazebo-x500" > /tmp/fc_manual.log 2>&1 &
+echo "done — re-arm from the browser once the FC logs Ready (~5 s)"

--- a/sim/worlds/x500_flightdeck.sdf
+++ b/sim/worlds/x500_flightdeck.sdf
@@ -1,0 +1,162 @@
+<?xml version="1.0" ?>
+<!--
+  Auto-generated world for test: square_course
+  Description: Closed-loop 10 m square via position-target
+  Vehicles: 1
+  Lockstep: false
+-->
+<sdf version="1.9">
+  <world name="aviate_sitl">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+    </physics>
+
+    <!-- Required system plugins -->
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin filename="gz-sim-magnetometer-system"
+            name="gz::sim::systems::Magnetometer">
+    </plugin>
+    <plugin filename="gz-sim-air-pressure-system"
+            name="gz::sim::systems::AirPressure">
+    </plugin>
+    <plugin filename="gz-sim-navsat-system"
+            name="gz::sim::systems::NavSat">
+    </plugin>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+
+    <!-- Aviate bridge plugins -->
+    <plugin filename="AviateGzPlugin"
+            name="aviate::AviateGzPlugin">
+      <model_name>x500</model_name>
+      <instance>0</instance>
+      <lockstep>false</lockstep>
+    </plugin>
+
+    <!-- Spherical coordinates for GPS -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>47.3977419</latitude_deg>
+      <longitude_deg>8.5455938</longitude_deg>
+      <elevation>488</elevation>
+    </spherical_coordinates>
+
+    <!-- Magnetic field for magnetometer -->
+    <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
+
+    <!-- Sunlight -->
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <!-- Ground plane -->
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.3 0.5 0.3 1</ambient>
+            <diffuse>0.3 0.5 0.3 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Vehicle: x500 (instance 0) -->
+    <include>
+      <uri>model://x500</uri>
+      <name>x500</name>
+      <pose>0 0 0 0 0 1.5707964</pose>
+
+      <!-- Odometry publisher -->
+      <plugin filename="gz-sim-odometry-publisher-system"
+              name="gz::sim::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+        <odom_publish_frequency>250</odom_publish_frequency>
+      </plugin>
+    </include>
+
+    <!-- Camera rig rigidly attached to the x500 (issue #12): onboard FPV
+         plus a chase view, published on the topics Pilotage's gz sidecar
+         bridges (/camera source 0, /chase_camera source 1). The rig is a
+         separate model joined to the vehicle at world scope so the
+         included x500 model (and the AviateGzPlugin's lookup of it) stays
+         untouched. Spawn pose matches the x500 include (yaw 90°). -->
+    <model name="x500_camera_rig">
+      <pose>0 0 0.24 0 0 1.5707964</pose>
+      <link name="rig_link">
+        <inertial>
+          <mass>0.01</mass>
+          <inertia><ixx>1e-5</ixx><iyy>1e-5</iyy><izz>1e-5</izz></inertia>
+        </inertial>
+        <sensor name="camera" type="camera">
+          <pose>0.12 0 0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>1.396</horizontal_fov>
+            <image><width>320</width><height>240</height></image>
+            <clip><near>0.1</near><far>300</far></clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <topic>camera</topic>
+        </sensor>
+        <sensor name="chase_camera" type="camera">
+          <pose>-1.6 0 0.9 0 0.35 0</pose>
+          <camera>
+            <horizontal_fov>1.6</horizontal_fov>
+            <image><width>320</width><height>240</height></image>
+            <clip><near>0.1</near><far>300</far></clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <topic>chase_camera</topic>
+        </sensor>
+      </link>
+    </model>
+    <joint name="camera_rig_mount" type="fixed">
+      <parent>x500::base_link</parent>
+      <child>x500_camera_rig::rig_link</child>
+    </joint>
+
+  </world>
+</sdf>


### PR DESCRIPTION
First live increment of issue #12 — flown end to end with a DualSense: arm → takeoff → translate/yaw → land, FPV + chase video beside live PFD/HSI, fully headless (Chrome keeps focus so the Gamepad API works).

## Control law (the actual DJI feel)

Sticks are **velocity setpoints**, never thrust/attitude: the uplink turns canonical `[-1,1]` roll/pitch/throttle/yaw into `SET_POSITION_TARGET_LOCAL_NED` (body-frame demands rotated into NED by measured yaw; yaw-rate stick integrates into an absolute heading setpoint) plus `COMMAND_LONG` arm/disarm over UDP to the SITL FC. Two hard-won behaviors:

- **Arm quiet window**: the FC stages inbound commands in a single slot, so a setpoint arriving in the same poll batch silently overwrites the arm; stick frames pause briefly after an arm send.
- **Motors-idle gate**: streaming `vz=0` to a grounded vehicle commands near-hover thrust and tips it over; setpoints stream only after the first deliberate climb input, like a real drone.

The adapter advertises the four-axis flight scope only when the uplink is up (telemetry-only otherwise); link-loss `Neutralize` sends a zero-velocity brake-to-hover.

## Browser

Two stick schemes over the identical control law (Ace Combat Standard/Expert precedent): **Pilot** (RC Mode 2, default — left = climb/yaw, right = move) and **Cruise** (game-native — left = move, right X = yaw, R2/L2 = climb) for Standard Gamepad pads; AETR passthrough for EdgeTX radios; 4-axis keyboard fallback; arm/disarm button edges (`wire.js` now encodes `ButtonEdgeSample`); a vehicle-mode select keeps ground vehicles on their two-axis frames.

## Cameras

`sim/worlds/x500_flightdeck.sdf` attaches an FPV + chase rig to the x500 via a **world-scope fixed joint** (the included model and the AviateGzPlugin's model lookup stay untouched), publishing the topics Pilotage's gz sidecar already bridges. The aviate adapter spawns the sidecar for video; the host's media path is now adapter-generic.

## Known follow-ups (filed as #12 comment from the flight test)

Position-hold-on-release (DJI brake+hold), armed/disarmed indication from ACK/heartbeat, expo + slew-rate feel stack, sim-reset affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)