### PR TITLE
AIR-01: define instrument intended functions and boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: check-structure
         run: bash scripts/check-structure.sh
 
+      - name: instrument requirement references
+        run: bash scripts/check-instrument-requirements.sh
+
       - name: instrument crates are no_std (ADR-0017)
         # Compiling the instrument family for a bare-metal target proves the
         # no_std/no-alloc claim instead of trusting a comment.

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -91,6 +91,18 @@
     border-radius: 3px;
     color: #ccc;
   }
+  .sim-label {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.35rem;
+    background: rgba(0, 0, 0, 0.8);
+    border: 1px solid #ffbf00;
+    color: #ffdf70;
+    padding: 0.2rem 0.4rem;
+    font: 700 0.65rem monospace;
+    letter-spacing: 0.04em;
+    pointer-events: none;
+  }
   #telemetry {
     margin-top: 0.5rem;
     font-family: monospace;
@@ -146,18 +158,22 @@
   <div class="stage">
     <canvas id="video" width="320" height="240"></canvas>
     <div id="overlay"></div>
+    <div class="sim-label">SIM / NOT FOR FLIGHT</div>
     <div class="caption">FPV / onboard</div>
   </div>
   <div class="stage">
     <canvas id="chaseVideo" width="320" height="240"></canvas>
+    <div class="sim-label">SIM / NOT FOR FLIGHT</div>
     <div class="caption">chase / 3rd person</div>
   </div>
   <div class="stage">
     <canvas id="pfd" width="480" height="360"></canvas>
+    <div class="sim-label">SIM / NOT FOR FLIGHT</div>
     <div class="caption">PFD</div>
   </div>
   <div class="stage">
     <canvas id="hsi" width="480" height="360"></canvas>
+    <div class="sim-label">SIM / NOT FOR FLIGHT</div>
     <div class="caption">HSI</div>
   </div>
 </div>

--- a/docs/instruments/README.md
+++ b/docs/instruments/README.md
@@ -1,0 +1,51 @@
+# Instrument intended-function baseline
+
+The files in this directory define what Pilotage instrument displays may do,
+where their responsibility ends, and which assumptions must be made explicit.
+They are engineering inputs for later safety assessment and implementation.
+They are not an FAA/EASA finding, TSO authorization, TC/STC approval, or a claim
+that any Pilotage display is suitable for airborne use.
+
+The baseline is split into four controlled artifacts:
+
+- [Intended functions](intended-functions.md) defines each display function,
+  operating mode, failure presentation, and source assumption.
+- [System boundary](system-boundary.md) identifies trusted and untrusted
+  interfaces, simulator-only components, and deterministic reversion paths.
+- [Requirements](requirements.md) is the registry of stable instrument
+  requirement identifiers.
+- [Review record](review-record.md) records the approvals required before the
+  baseline can be treated as reviewed.
+
+All browser, WebAssembly, Canvas, WebTransport, Gazebo, and test-harness output
+is **SIM / NOT FOR FLIGHT**. A visual resemblance to an aircraft display does
+not make the output primary flight information or authorize operational credit.
+
+## Change control
+
+Every new or changed display feature must cite at least one requirement from
+[the registry](requirements.md) in its issue and pull request. If no applicable
+requirement exists, the intended-function baseline is changed and reviewed
+before the feature is accepted. Requirement identifiers are permanent: changed
+meaning receives a new identifier, while retired requirements remain in the
+registry with their disposition.
+
+`scripts/check-instrument-requirements.sh` rejects duplicate identifiers,
+undefined references, and mismatched requirement links.
+
+## Design inputs
+
+The conservative architecture reference is a dual-pilot Part 25 IFR flight deck
+that may present primary flight information. The target aircraft, operating
+rules, certification authority, certification basis, and installed equipment
+have not been selected. Consequently, this baseline makes no blanket Design
+Assurance Level allocation.
+
+Forward-looking industry material is an engineering input only until the
+selected certification authority identifies an accepted revision:
+
+- [FAA AC 25-11B, Electronic Flight Deck Displays](https://www.faa.gov/documentlibrary/media/advisory_circular/ac_25-11b.pdf)
+- [FAA AC 25.1309-1B, System Design and Analysis](https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1043037)
+- [FAA AC 20-185A, Synthetic Vision Guidance Systems](https://www.faa.gov/documentLibrary/media/Advisory_Circular/AC_20-185A.pdf)
+- [SAE ARP4754B, Development of Civil Aircraft and Systems](https://saemobilus.sae.org/standards/arp4754b-guidelines-development-civil-aircraft-systems)
+

--- a/docs/instruments/README.md
+++ b/docs/instruments/README.md
@@ -24,14 +24,16 @@ not make the output primary flight information or authorize operational credit.
 ## Change control
 
 Every new or changed display feature must cite at least one requirement from
-[the registry](requirements.md) in its issue and pull request. If no applicable
+[the registry](requirements.md) in its issue and pull request
+([`AIR-BAS-005`](requirements.md#air-bas-005)). If no applicable
 requirement exists, the intended-function baseline is changed and reviewed
 before the feature is accepted. Requirement identifiers are permanent: changed
 meaning receives a new identifier, while retired requirements remain in the
 registry with their disposition.
 
 `scripts/check-instrument-requirements.sh` rejects duplicate identifiers,
-undefined references, and mismatched requirement links.
+malformed identifiers, undefined references, unreferenced requirements, and
+mismatched requirement links.
 
 ## Design inputs
 

--- a/docs/instruments/README.md
+++ b/docs/instruments/README.md
@@ -50,4 +50,3 @@ selected certification authority identifies an accepted revision:
 - [FAA AC 25.1309-1B, System Design and Analysis](https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1043037)
 - [FAA AC 20-185A, Synthetic Vision Guidance Systems](https://www.faa.gov/documentLibrary/media/Advisory_Circular/AC_20-185A.pdf)
 - [SAE ARP4754B, Development of Civil Aircraft and Systems](https://saemobilus.sae.org/standards/arp4754b-guidelines-development-civil-aircraft-systems)
-

--- a/docs/instruments/intended-functions.md
+++ b/docs/instruments/intended-functions.md
@@ -1,0 +1,108 @@
+# Instrument intended functions
+
+## Baseline statement
+
+Pilotage instrument software is an engineering simulator display. Its browser,
+WebAssembly, Canvas, network, and Gazebo paths are **SIM / NOT FOR FLIGHT** under
+[`AIR-BAS-001`](requirements.md#air-bas-001). The visual vocabulary may support
+a later aircraft project, but no output is approved primary flight information,
+navigation guidance, terrain alerting, or HUD imagery.
+
+The target architecture uses conservative dual-pilot Part 25 IFR behavior as a
+reference under [`AIR-BAS-002`](requirements.md#air-bas-002). The selected
+aircraft, certification authority, certification basis, operational rules,
+installation, and credited functions remain open. Assurance is therefore
+hazard-derived per function rather than assigned to the application as a whole
+under [`AIR-BAS-003`](requirements.md#air-bas-003).
+
+## Function matrix
+
+| Function | Intended role in this baseline | Inputs | Output and modes | Failure presentation | Source assumptions |
+|---|---|---|---|---|---|
+| PFD | Supplemental simulator awareness; architecture reference for a possible PFI function | [`AIR-IN-001`](requirements.md#air-in-001) through [`AIR-IN-009`](requirements.md#air-in-009), alerts under [`AIR-IN-012`](requirements.md#air-in-012), renderer health under [`AIR-IN-013`](requirements.md#air-in-013) | [`AIR-OUT-001`](requirements.md#air-out-001); conventional, unusual-attitude, and degraded/reversionary modes | Per-signal flags and explicit display failure under [`AIR-OUT-004`](requirements.md#air-out-004) | Simulator truth and network telemetry are untrusted until their source, time, range, integrity, and coherence evidence passes the applicable checks |
+| HSI | Supplemental simulator navigation awareness; no navigation or approach credit | Heading/navigation, velocity, wind, selections, timing, validity, and renderer health under [`AIR-IN-003`](requirements.md#air-in-003), [`AIR-IN-005`](requirements.md#air-in-005) through [`AIR-IN-009`](requirements.md#air-in-009), and [`AIR-IN-013`](requirements.md#air-in-013) | [`AIR-OUT-002`](requirements.md#air-out-002); conventional and degraded/reversionary modes | Heading/navigation loss under [`AIR-UNAV-003`](requirements.md#air-unav-003), time/coherence loss, and display failure | No magnetic/true reference, datum, navigation mode, or integrity is inferred from a local yaw or unlabeled simulator field |
+| Conventional instruments | Simulator comparison/reversion surface; no independent standby credit | The validated sources used by the corresponding PFD quantities | [`AIR-OUT-003`](requirements.md#air-out-003); conventional and degraded/reversionary modes | Each instrument flags its own missing, stale, failed, or miscompared source | Drawing a separate instrument does not establish source, power, processing, or display independence |
+| SVS | Planned removable background supplying supplemental situation awareness only | Validated position, attitude, timing, databases, selections, and renderer health under [`AIR-IN-001`](requirements.md#air-in-001), [`AIR-IN-002`](requirements.md#air-in-002), [`AIR-IN-008`](requirements.md#air-in-008), [`AIR-IN-009`](requirements.md#air-in-009), [`AIR-IN-011`](requirements.md#air-in-011), and [`AIR-IN-013`](requirements.md#air-in-013) | [`AIR-OUT-005`](requirements.md#air-out-005); synthetic-vision mode with deterministic conventional-horizon reversion | [`AIR-UNAV-005`](requirements.md#air-unav-005); primary symbology and external alerts remain available if their own paths are valid | Database graphics are not sensor observations, TAWS, or assurance evidence; each database and navigation dependency must be independently valid |
+| SVGS | Not supplied | None accepted by this baseline | No guidance output and no low-visibility operational credit under [`AIR-OUT-009`](requirements.md#air-out-009) | No silent fallback to an SVGS-like pathway | A future function requires a separate intended function and applicable accepted performance standard |
+| HUD-SIM | Planned fixed-design-eye conformal simulator overlay; no airborne HUD credit | Validated flight state plus video/calibration under [`AIR-IN-010`](requirements.md#air-in-010) | [`AIR-OUT-006`](requirements.md#air-out-006) in HUD-SIM mode | Remove conformal cues or revert to a conspicuously non-conformal mode under [`AIR-UNAV-006`](requirements.md#air-unav-006) | Conformality exists only for the declared camera, design eye, calibration revision, FOV, pose, and time alignment |
+| Non-conformal repeater | Planned simulator display when conformal prerequisites are absent | Validated flight state; no camera calibration is claimed | [`AIR-OUT-007`](requirements.md#air-out-007) in non-conformal repeater mode | Persistent **NON-CONFORMAL / NOT A HUD** identification; invalid flight signals retain their own flags | Similar color or stroke symbology does not make a repeater an optical or conformal HUD |
+| Airborne optical HUD/HWD | Outside boundary | Not specified | No output or operational credit under [`AIR-OUT-008`](requirements.md#air-out-008) | Not applicable | Optical, installation, alignment, continued-airworthiness, and human-factors evidence belong to an aircraft project |
+| TAWS alerts | External future input, not an SVS function | Independently monitored alert input under [`AIR-IN-012`](requirements.md#air-in-012) | Display/aural annunciation only after a separate alert-management intended function is defined | Alert loss or invalidity must not be hidden by terrain graphics | SVS shall remain independent of TAWS under [`AIR-OUT-010`](requirements.md#air-out-010) |
+
+## Modes and deterministic reversion
+
+The defined display modes are conventional horizon, synthetic vision,
+unusual attitude, degraded/reversionary, HUD-SIM, non-conformal repeater, and
+test/demonstration. Their requirements are
+[`AIR-MODE-001`](requirements.md#air-mode-001) through
+[`AIR-MODE-007`](requirements.md#air-mode-007).
+
+Mode changes are explicit display state, not incidental renderer behavior. The
+same coherent snapshot and configuration produces the same transition. An SVS
+failure returns to the conventional sky/ground background. A conformal-
+calibration failure removes conformal cues or enters non-conformal repeater
+mode. An input failure flags the affected data. A renderer/output failure
+replaces the last-good frame with a display-failure presentation. Reversion
+never upgrades an unverified source or hides the reason for the transition.
+
+| Operating condition | Entered state | Required crew-visible result |
+|---|---|---|
+| Normal, validated basic inputs | Conventional horizon, HSI, or conventional instrument mode | Declared source/reference and **SIM / NOT FOR FLIGHT** label remain visible |
+| Normal, all SVS dependencies valid | Synthetic-vision mode if selected | SVS remains below primary symbology; loss returns to conventional horizon |
+| Normal, all conformal dependencies valid | HUD-SIM mode if selected | Conformal cues and **HUD-SIM / NOT FOR FLIGHT** mode are visible |
+| Abnormal aircraft attitude | Unusual-attitude mode | Unambiguous sky/ground, recovery direction, and priority declutter remain independent of SVS |
+| Degraded, stale, missing, or miscompared source | Degraded/reversionary mode | Affected data is flagged; remaining data keeps its identity and reference |
+| Invalid conformal dependency | Non-conformal repeater or cue removal | **NON-CONFORMAL / NOT A HUD** is visible and no conformal claim remains |
+| Renderer, command, buffer, output, or progress-monitor failure | Display failure | The retained last-good image is replaced within the allocated monitor time |
+
+## Validity and unavailable behavior
+
+The only baseline validity classes are `Valid`, `Degraded`, `Stale`, `Missing`,
+`Failed`, and `Miscompare`, defined by
+[`AIR-FLAG-001`](requirements.md#air-flag-001) through
+[`AIR-FLAG-006`](requirements.md#air-flag-006). Unknown values, absent metadata,
+non-finite values, impossible ranges, incoherent snapshots, and unsupported
+enumerations fail closed. Labels required by
+[`AIR-FLAG-007`](requirements.md#air-flag-007) remain part of the rendered
+surface.
+
+Each function uses the unavailable conditions in
+[`AIR-UNAV-001`](requirements.md#air-unav-001) through
+[`AIR-UNAV-008`](requirements.md#air-unav-008). Independent valid information
+may remain, but the display never represents local height as pressure altitude,
+groundspeed as indicated airspeed, track as heading, retransmission time as
+source time, SVS as TAWS, or a repeater as HUD.
+
+## Operational scope
+
+Flight phases and crew tasks requiring analysis are defined by
+[`AIR-ENV-001`](requirements.md#air-env-001) and
+[`AIR-ENV-004`](requirements.md#air-env-004). The complete orientation domain is
+inside the robustness and failure-presentation scope under
+[`AIR-ENV-002`](requirements.md#air-env-002); this includes vertical and inverted
+attitudes even when an aircraft later prohibits intentional operation there.
+
+No credited speed, altitude, load, angular-rate, acceleration, environmental,
+or viewing envelope exists until selected under
+[`AIR-ENV-003`](requirements.md#air-env-003). Likewise, freshness, end-to-end
+latency, display-monitor, and reversion timing are allocations to be derived,
+not inherited from simulator constants; see
+[`AIR-TIM-001`](requirements.md#air-tim-001) through
+[`AIR-TIM-003`](requirements.md#air-tim-003).
+
+## Flight phases and crew tasks
+
+The following table scopes analysis and simulation test cases; it grants no
+operational credit. “PF” and “PM” are reference roles for a possible dual-pilot
+aircraft project. Simulator operation uses an operator and may use an instructor.
+
+| Phase | Reference display task | Exclusion or required follow-on evidence |
+|---|---|---|
+| Preflight / postflight | Operator verifies simulation mode, sources, flags, configuration, databases, and test setup | No dispatch, built-in-test, or maintenance-release credit |
+| Taxi | Operator maintains ground orientation and monitors declared navigation/SVS data | No SafeTaxi, runway-incursion, low-visibility taxi, or external-visual-reference credit |
+| Takeoff / go-around | PF reference task is attitude, airspeed, altitude, vertical trend, mode, and alert scan; PM reference task is source/mode cross-check | No flight-director, command guidance, V-speed, takeoff-performance, or HUD credit without separate intended functions and validation |
+| Climb / cruise / descent | PF reference task is flight-path control scan; PM reference task is navigation/source, trend, mode, and alert monitoring | Air-data, heading, navigation, and alert sources remain uncredited simulator inputs |
+| Approach / landing | PF/PM reference tasks include approach-source, deviation, altitude, mode, and alert cross-check | No approach, landing, EFVS, SVGS, minima, or low-visibility credit |
+| Unusual attitude / high workload | PF reference task is recognize attitude and recover; PM reference task is call out mode/source failures and monitor recovery | Thresholds, declutter, recovery cues, recognition time, workload, and transition behavior require aircraft-specific human-factors validation |
+| Source or display failure | PF reference task is maintain control from valid independent information; PM reference task is identify the failed source/mode and execute the selected reversion procedure | No independence, redundancy, dispatch, or reversion credit until the aircraft architecture and failure assessment establish it |
+| Maintenance / test / replay | Maintainer or instructor identifies injected data, test mode, configuration, and expected failure response | Test inputs cannot enter an operational path without explicit inhibition and indication |

--- a/docs/instruments/requirements.md
+++ b/docs/instruments/requirements.md
@@ -1,0 +1,451 @@
+# Instrument intended-function requirements
+
+This registry assigns stable identifiers to the inputs, outputs, modes, flags,
+unavailable conditions, operating assumptions, and process constraints in the
+instrument boundary. “Shall” marks a requirement; it does not claim that the
+implementation already satisfies it.
+
+References use links such as
+[`AIR-BAS-001`](requirements.md#air-bas-001). Identifiers are never reused.
+
+## Basis and governance
+
+<a id="air-bas-001"></a>
+### AIR-BAS-001 — Simulation identification
+
+Every browser, WebAssembly, Canvas, WebTransport, Gazebo, and test-harness
+instrument surface shall continuously and conspicuously identify itself as
+**SIM / NOT FOR FLIGHT**.
+
+<a id="air-bas-002"></a>
+### AIR-BAS-002 — Reference architecture without approval claim
+
+The architecture shall use conservative dual-pilot Part 25 IFR primary-flight-
+information behavior as a design reference while recording the target aircraft,
+certification authority, certification basis, and installed equipment as
+unselected; the reference shall not be represented as approval or operational
+credit.
+
+<a id="air-bas-003"></a>
+### AIR-BAS-003 — Hazard-derived assurance
+
+Development assurance shall be allocated per function and item only after the
+applicable aircraft-level hazard assessment; no single DAL shall be assigned to
+the complete Pilotage application by this baseline.
+
+<a id="air-bas-004"></a>
+### AIR-BAS-004 — Explicit reference metadata
+
+No display function shall infer an unspecified unit, coordinate frame, altitude
+datum, heading reference, time domain, source identity, integrity level, or
+camera calibration; missing required metadata shall drive a declared unavailable
+condition.
+
+<a id="air-bas-005"></a>
+### AIR-BAS-005 — Feature traceability
+
+Every new or changed display feature shall cite at least one intended-function
+requirement in its issue and pull request, and changes in intended behavior shall
+update this baseline before implementation acceptance.
+
+<a id="air-bas-006"></a>
+### AIR-BAS-006 — Required independent reviews
+
+The intended-function baseline shall not be approved or its issue closed until
+the project owner and qualified safety and human-factors reviewers have recorded
+their review disposition in the version-controlled review record.
+
+<a id="air-bas-007"></a>
+### AIR-BAS-007 — Deterministic presentation
+
+An identical coherent input snapshot, display configuration, and renderer
+version shall produce the same display state, including flags, reversion, layer
+priority, and command ordering.
+
+## Inputs
+
+<a id="air-in-001"></a>
+### AIR-IN-001 — Attitude input
+
+Attitude input shall contain a finite normalized orientation, body angular
+rates, declared body and navigation frames, source identity, source time,
+sequence or equivalent ordering evidence, quality, integrity, and accuracy.
+
+<a id="air-in-002"></a>
+### AIR-IN-002 — Position and altitude input
+
+Position and altitude input shall declare coordinate frame, horizontal datum,
+altitude type and datum, units, source identity, source time, quality, integrity,
+and accuracy; local NED height shall not be labelled barometric altitude.
+
+<a id="air-in-003"></a>
+### AIR-IN-003 — Velocity input
+
+Velocity input shall declare axes, reference frame, air-relative or ground-
+relative meaning, units, source identity, source time, quality, integrity, and
+accuracy.
+
+<a id="air-in-004"></a>
+### AIR-IN-004 — Air-data input
+
+Indicated airspeed, pressure altitude, barometric correction, vertical speed,
+and related air-data values shall each identify their measurement or derivation,
+datum, units, source identity, source time, quality, integrity, and accuracy.
+
+<a id="air-in-005"></a>
+### AIR-IN-005 — Heading and navigation input
+
+Heading, track, course, bearing, deviations, distance, and vertical guidance
+shall declare true or magnetic reference, magnetic variation source where
+applicable, navigation source and mode, units, source time, quality, integrity,
+and accuracy.
+
+<a id="air-in-006"></a>
+### AIR-IN-006 — Wind input
+
+Wind direction and speed shall declare “from” or “to” convention, true or
+magnetic reference, reference frame, units, source identity, source time,
+quality, integrity, and accuracy.
+
+<a id="air-in-007"></a>
+### AIR-IN-007 — Crew selections and aircraft configuration
+
+Selected altitude, heading, course, barometric correction, V-speeds, display
+mode, and airframe display profile shall identify source, authority, units,
+range, configuration revision, and validity.
+
+<a id="air-in-008"></a>
+### AIR-IN-008 — Time and ordering evidence
+
+Each independently updated input group shall carry source identity, source epoch,
+monotonic sequence, source or capture time, receive time, and a declared mapping
+between time domains sufficient to detect replay, reordering, reset, and age.
+
+<a id="air-in-009"></a>
+### AIR-IN-009 — Per-signal validity evidence
+
+Quality, integrity, accuracy, freshness, range, and fault reason shall be carried
+per independently sourced signal; a global quality value shall not make a signal
+valid when its own evidence is absent or failed.
+
+<a id="air-in-010"></a>
+### AIR-IN-010 — Video and conformal calibration input
+
+Video used for conformal simulation shall provide capture time, image dimensions,
+lens model and intrinsics, camera-to-body extrinsics, design eye, field of view,
+boresight calibration, calibration revision, and validity.
+
+<a id="air-in-011"></a>
+### AIR-IN-011 — Synthetic-vision database input
+
+Synthetic-vision terrain, obstacle, runway, taxiway, and airport data shall
+identify datum, coverage, resolution, effective period, provenance, database
+revision, integrity result, and load status; absent evidence shall make the
+affected synthetic-vision content unavailable.
+
+<a id="air-in-012"></a>
+### AIR-IN-012 — Independent alert input
+
+Alerts supplied by TAWS, traffic, weather, flight-guidance, or other aircraft
+systems shall identify the originating function, alert identity, priority,
+latch/acknowledgement state, source time, integrity, and availability; the
+display shall not derive an undeclared alert from synthetic-vision graphics.
+
+<a id="air-in-013"></a>
+### AIR-IN-013 — Renderer health input
+
+The display function shall receive independent evidence of renderer progress,
+frame generation, command-buffer integrity, backend status, and output-path
+health sufficient to detect a retained last-good image.
+
+## Outputs and functions
+
+<a id="air-out-001"></a>
+### AIR-OUT-001 — Primary flight display surface
+
+The PFD function shall consume validated attitude, air data, altitude, heading,
+vertical state, crew selections, modes, and alert state and shall output a
+prioritized two-dimensional flight display with an explicit status for every
+required input; browser output remains simulation-only and is not approved PFI.
+
+<a id="air-out-002"></a>
+### AIR-OUT-002 — Horizontal situation display surface
+
+The HSI function shall consume validated heading, track, navigation source,
+course, deviation, distance, wind, selections, and alert state and shall output
+their reference and navigation mode or an explicit unavailable presentation.
+
+<a id="air-out-003"></a>
+### AIR-OUT-003 — Conventional instrument surface
+
+The conventional-instrument function shall consume the same validated state as
+the integrated display and shall output independently identifiable attitude,
+airspeed, altitude, heading, turn/slip, and vertical-speed indications without
+fabricating a missing source.
+
+<a id="air-out-004"></a>
+### AIR-OUT-004 — Failure and miscompare presentation
+
+Every credited display output shall present stale, missing, failed, invalid,
+miscompared, out-of-range, and renderer-failure states conspicuously and shall
+not silently retain or substitute a last-good value.
+
+<a id="air-out-005"></a>
+### AIR-OUT-005 — Synthetic-vision background
+
+SVS may output registered terrain, obstacle, airport, runway, and pathway
+graphics beneath primary symbology only when every required database, position,
+attitude, time, and integrity input is available; it supplies supplemental
+situation awareness unless a separately approved intended function grants
+additional credit.
+
+<a id="air-out-006"></a>
+### AIR-OUT-006 — HUD-SIM conformal output
+
+HUD-SIM may output simulation-only conformal symbology from validated flight
+state, video timing, camera calibration, design eye, and projection geometry;
+it shall remain labelled **HUD-SIM / NOT FOR FLIGHT** and conveys no airborne
+HUD operational credit.
+
+<a id="air-out-007"></a>
+### AIR-OUT-007 — Non-conformal repeater output
+
+A display lacking valid design-eye and camera/optical calibration may output a
+simulation repeater, but it shall be labelled **NON-CONFORMAL / NOT A HUD** and
+shall not display conformal flight-path, horizon, runway, or guidance claims.
+
+<a id="air-out-008"></a>
+### AIR-OUT-008 — Airborne optical HUD exclusion
+
+An installed airborne HUD, head-worn display, combiner, optical collimation,
+eyebox, luminance, alignment, installation, and continued-airworthiness function
+is outside this system boundary and shall not be claimed by HUD-SIM output.
+
+<a id="air-out-009"></a>
+### AIR-OUT-009 — SVGS exclusion
+
+This baseline supplies no Synthetic Vision Guidance System function, low-
+visibility operational credit, or synthetic guidance for landing; adding SVGS
+requires a distinct intended function, safety assessment, applicable performance
+standard, guidance source, monitoring, failure presentation, and approval basis.
+
+<a id="air-out-010"></a>
+### AIR-OUT-010 — TAWS independence
+
+SVS shall not be described as TAWS and shall not suppress, replace, generate, or
+claim the terrain-alerting function; a future TAWS interface remains an
+independent monitored input whose alerts have priority over SVS graphics.
+
+## Modes
+
+<a id="air-mode-001"></a>
+### AIR-MODE-001 — Conventional horizon mode
+
+Conventional horizon mode shall present a deterministic sky/ground attitude
+background and required primary symbology without dependence on terrain,
+obstacle, airport, video, or camera-calibration data.
+
+<a id="air-mode-002"></a>
+### AIR-MODE-002 — Synthetic-vision mode
+
+Synthetic-vision mode shall be entered only when its declared dependencies are
+available and valid; loss of a dependency shall revert deterministically to
+conventional horizon mode while preserving higher-priority symbology and alerts.
+
+<a id="air-mode-003"></a>
+### AIR-MODE-003 — Unusual-attitude mode
+
+Unusual-attitude mode shall use airframe-profile thresholds and hysteresis,
+preserve an unambiguous sky/ground and recovery direction through the full
+orientation domain, declutter lower-priority content, and never depend on SVS.
+
+<a id="air-mode-004"></a>
+### AIR-MODE-004 — Degraded and reversionary mode
+
+Degraded or reversionary mode shall identify the failed source or function,
+retain only valid information, use a predetermined layout and priority, and
+avoid automatic transitions whose cause or resulting source is hidden from the
+crew.
+
+<a id="air-mode-005"></a>
+### AIR-MODE-005 — HUD-SIM mode
+
+HUD-SIM mode shall enable conformal cues only while projection and time-alignment
+requirements are valid; loss of calibration shall remove conformal cues or enter
+non-conformal repeater mode with an explicit mode annunciation.
+
+<a id="air-mode-006"></a>
+### AIR-MODE-006 — Non-conformal repeater mode
+
+Non-conformal repeater mode shall use a layout that cannot be confused with
+registered outside-world symbology and shall continuously display its mode and
+simulation limitation.
+
+<a id="air-mode-007"></a>
+### AIR-MODE-007 — Test and demonstration mode
+
+Harness, injected-data, replay, and demonstration modes shall be visibly
+distinguishable from operational data paths and shall preserve **SIM / NOT FOR
+FLIGHT** identification in captures and recordings.
+
+## Validity and annunciation flags
+
+<a id="air-flag-001"></a>
+### AIR-FLAG-001 — Valid
+
+`Valid` shall mean all required range, format, source, time, quality, integrity,
+accuracy, and coherence checks for that signal and intended use have passed.
+
+<a id="air-flag-002"></a>
+### AIR-FLAG-002 — Degraded
+
+`Degraded` shall identify a value that remains usable only for its explicitly
+declared degraded function, with the limitation visible wherever it matters to
+the crew task.
+
+<a id="air-flag-003"></a>
+### AIR-FLAG-003 — Stale
+
+`Stale` shall derive from original source or capture time in a declared time
+domain and shall never be reset by forwarding, retransmission, or rendering.
+
+<a id="air-flag-004"></a>
+### AIR-FLAG-004 — Missing
+
+`Missing` shall identify an input that is not installed or has not been supplied;
+the display shall not invent a substitute value with the original label.
+
+<a id="air-flag-005"></a>
+### AIR-FLAG-005 — Failed
+
+`Failed` shall identify an input or output that cannot support its intended use
+because a validity, integrity, monitor, or availability requirement failed.
+
+<a id="air-flag-006"></a>
+### AIR-FLAG-006 — Miscompare
+
+`Miscompare` shall identify disagreement between independent eligible sources
+when the declared comparison threshold and persistence are exceeded; source
+selection shall not hide the disagreement.
+
+<a id="air-flag-007"></a>
+### AIR-FLAG-007 — Simulation and conformality labels
+
+`SIM / NOT FOR FLIGHT`, `HUD-SIM`, and `NON-CONFORMAL / NOT A HUD` labels shall
+be rendered by the applicable surface itself, not supplied solely by surrounding
+instructions or operator memory.
+
+## Unavailable conditions
+
+<a id="air-unav-001"></a>
+### AIR-UNAV-001 — Attitude unavailable
+
+Invalid, non-finite, out-of-range, stale, incoherent, or failed attitude evidence
+shall remove normal attitude guidance and present an attitude-failure flag while
+leaving independent valid information identifiable.
+
+<a id="air-unav-002"></a>
+### AIR-UNAV-002 — Air data or altitude unavailable
+
+Unavailable airspeed, pressure altitude, vertical speed, or barometric reference
+shall flag only the affected indication and shall not relabel groundspeed or local
+height as the missing air-data quantity.
+
+<a id="air-unav-003"></a>
+### AIR-UNAV-003 — Heading or navigation unavailable
+
+Unavailable heading, reference, navigation source, or guidance shall remove or
+flag dependent cues while preserving independent track or position data under
+its correct label and reference.
+
+<a id="air-unav-004"></a>
+### AIR-UNAV-004 — Time or coherence unavailable
+
+Unknown time-domain mapping, source reset, replay, reordering, excessive skew, or
+an incomplete atomic snapshot shall make every dependent function unavailable
+rather than presenting mutually inconsistent values as one observation.
+
+<a id="air-unav-005"></a>
+### AIR-UNAV-005 — Synthetic vision unavailable
+
+Unavailable terrain/obstacle data, database integrity, position, attitude,
+coverage, or rendering shall remove SVS content, announce the loss when relevant,
+and revert to conventional horizon mode without removing primary alerts.
+
+<a id="air-unav-006"></a>
+### AIR-UNAV-006 — Conformal projection unavailable
+
+Unavailable or invalid video time alignment, design eye, intrinsics, extrinsics,
+field of view, boresight, or calibration revision shall remove conformal claims
+and cues and identify the resulting non-conformal mode.
+
+<a id="air-unav-007"></a>
+### AIR-UNAV-007 — Renderer or output unavailable
+
+Command failure, buffer exhaustion, stalled frame generation, backend error,
+corrupt output, or failed output-path monitoring shall replace the last-good
+image with an explicit display-failure presentation within the allocated time.
+
+<a id="air-unav-008"></a>
+### AIR-UNAV-008 — Configuration unavailable
+
+Missing, incompatible, unauthenticated, or corrupt aircraft/display configuration
+shall inhibit dependent modes and values and identify the configuration failure;
+generic defaults shall not silently acquire aircraft-specific meaning.
+
+## Operating envelope and timing
+
+<a id="air-env-001"></a>
+### AIR-ENV-001 — Flight phases
+
+Requirements analysis shall address preflight, taxi, takeoff, climb, cruise,
+descent, approach, landing, go-around, postflight, and applicable ground
+maintenance; no phase receives operational credit until its crew tasks and
+failure effects are validated for the selected aircraft.
+
+<a id="air-env-002"></a>
+### AIR-ENV-002 — Attitude envelope
+
+Attitude processing and failure presentation shall remain finite, deterministic,
+and unambiguous for pitch and bank through the complete orientation domain,
+including inverted flight, vertical attitudes, heading wrap, high angular rate,
+and transitions across representation singularities.
+
+<a id="air-env-003"></a>
+### AIR-ENV-003 — Aircraft envelope
+
+Speed, altitude, load, angular-rate, acceleration, environmental, and display
+viewing envelopes shall come from the selected aircraft and installation; until
+selected, browser demonstrations provide no credited envelope and shall flag
+values outside their explicitly configured simulation range.
+
+<a id="air-env-004"></a>
+### AIR-ENV-004 — Crew tasks and workload
+
+Each mode shall identify pilot flying, pilot monitoring, instructor, maintenance,
+or demonstration tasks, expected scan and control transitions, alert response,
+and reversion action; human-factors validation shall cover normal, abnormal,
+failure, high-workload, and unusual-attitude cases.
+
+<a id="air-tim-001"></a>
+### AIR-TIM-001 — Freshness allocation
+
+Freshness limits shall be allocated per signal and function from aircraft-level
+latency and hazard analysis, measured from original source or capture time, and
+shall define valid, degraded, stale, and failed transitions without extending age
+at transport boundaries.
+
+<a id="air-tim-002"></a>
+### AIR-TIM-002 — End-to-end latency allocation
+
+The selected installation shall allocate and verify acquisition, transport,
+coherence, processing, rendering, scan-out, video, and conformal-overlay latency
+and jitter, including worst-case load and failure/recovery behavior.
+
+<a id="air-tim-003"></a>
+### AIR-TIM-003 — Reversion and monitor timing
+
+Every unavailable condition shall define a bounded detection, annunciation, and
+reversion time derived from its safety assessment; a browser demonstration
+threshold shall not be treated as an aircraft allocation.
+

--- a/docs/instruments/requirements.md
+++ b/docs/instruments/requirements.md
@@ -448,4 +448,3 @@ and jitter, including worst-case load and failure/recovery behavior.
 Every unavailable condition shall define a bounded detection, annunciation, and
 reversion time derived from its safety assessment; a browser demonstration
 threshold shall not be treated as an aircraft allocation.
-

--- a/docs/instruments/review-record.md
+++ b/docs/instruments/review-record.md
@@ -64,4 +64,3 @@ subsequent aircraft-specific validation.
 - Tracking issue may close: NO
 - Decision revision/commit: PENDING
 - Decision owner and date: PENDING
-

--- a/docs/instruments/review-record.md
+++ b/docs/instruments/review-record.md
@@ -1,0 +1,67 @@
+# Instrument intended-function review record
+
+This record is the closure gate required by
+[`AIR-BAS-006`](requirements.md#air-bas-006). Empty or `PENDING` fields mean the
+baseline is not approved and its tracking issue remains open. A pull-request
+approval without the qualifications and disposition below is not a substitute.
+
+## Baseline under review
+
+- Tracking issue: AIR-01 / GitHub issue 24
+- Artifacts: `README.md`, `intended-functions.md`, `system-boundary.md`, and
+  `requirements.md` in this directory
+- Implementation conformance: not asserted by this review
+- Certification or operational approval: not asserted by this review
+
+## Project-owner review
+
+- Reviewer: PENDING
+- Role and authority: PENDING
+- Review revision/commit: PENDING
+- Date: PENDING
+- Disposition (`APPROVED`, `APPROVED WITH ACTIONS`, or `REJECTED`): PENDING
+- Open actions and linked issues: PENDING
+- Recorded rationale: PENDING
+
+The project owner confirms that the stated functions, exclusions, product
+boundary, and change-control policy match the intended Pilotage product.
+
+## Safety review
+
+- Reviewer: PENDING
+- Qualification and relevant experience: PENDING
+- Independence from the author: PENDING
+- Review revision/commit: PENDING
+- Date: PENDING
+- Disposition (`APPROVED`, `APPROVED WITH ACTIONS`, or `REJECTED`): PENDING
+- Open actions and linked issues: PENDING
+- Recorded rationale: PENDING
+
+The safety reviewer confirms that the baseline does not pre-allocate a blanket
+DAL, hide source assumptions, conflate SVS with TAWS, or foreclose later hazard
+assessment, independence, monitoring, and failure-containment work.
+
+## Human-factors review
+
+- Reviewer: PENDING
+- Qualification and relevant experience: PENDING
+- Independence from the author: PENDING
+- Review revision/commit: PENDING
+- Date: PENDING
+- Disposition (`APPROVED`, `APPROVED WITH ACTIONS`, or `REJECTED`): PENDING
+- Open actions and linked issues: PENDING
+- Recorded rationale: PENDING
+
+The human-factors reviewer confirms that crew roles, operating phases, mode
+awareness, unusual-attitude behavior, declutter priorities, failure cues,
+reversion, conformality labels, and simulator limitations are suitable inputs to
+subsequent aircraft-specific validation.
+
+## Closure decision
+
+- All three reviews complete: NO
+- All blocking actions resolved or accepted by the responsible authority: NO
+- Tracking issue may close: NO
+- Decision revision/commit: PENDING
+- Decision owner and date: PENDING
+

--- a/docs/instruments/system-boundary.md
+++ b/docs/instruments/system-boundary.md
@@ -1,0 +1,130 @@
+# Instrument system boundary
+
+## Boundary diagram
+
+```text
+UNTRUSTED SOURCES AND TRANSPORTS                 DISPLAY FUNCTION
+
+ simulator truth   USB CDC   future aircraft bus
+       |               |              |
+       +---------- adapter / decoder --+
+                         |
+          network / shared memory / replay
+                         |
+                         v
+        +---------------------------------------+
+        | input validation and time/integrity  |
+        | ordering, range, coherence, compare  |
+        +-------------------+-------------------+
+                            |
+                 atomic DisplaySnapshot
+                            |
+          +-----------------+------------------+
+          |                                    |
+          v                                    v
+  display/mode/alert model              optional SVS model
+          |                                    |
+          v                                    v
+  critical 2D scene commands          terrain/depth background
+          +-----------------+------------------+
+                            |
+                 explicit-priority compositor
+                            |
+                 deterministic output backend
+                            |
+          +-----------------+------------------+
+          |                                    |
+          v                                    v
+     display surface               independent progress/output monitor
+          |                                    |
+          +---------- failure state <----------+
+
+SIMULATOR PORTS: WebTransport, WASM, Canvas, browser video, Gazebo, harness
+AIRCRAFT PROJECT PORTS: sensor/bus adapters, qualified renderer and display,
+                       independent monitor, installation-specific I/O
+OUTSIDE BOUNDARY: sensors and source estimators, TAWS logic, flight guidance,
+                  optical HUD/HWD installation, aircraft alert source logic
+```
+
+## Responsibilities inside the boundary
+
+The instrument boundary owns:
+
+- validation of every consumed value and its reference metadata under
+  [`AIR-BAS-004`](requirements.md#air-bas-004);
+- ordering, age, source-reset, replay, and coherent-snapshot decisions under
+  [`AIR-IN-008`](requirements.md#air-in-008) and
+  [`AIR-UNAV-004`](requirements.md#air-unav-004);
+- per-signal validity, miscompare, and fault reason under
+  [`AIR-IN-009`](requirements.md#air-in-009);
+- deterministic display modes, reversion, priorities, and command output under
+  [`AIR-BAS-007`](requirements.md#air-bas-007);
+- visible failure, simulation, and conformality presentation; and
+- monitoring that detects a renderer or output path retaining a last-good image
+  under [`AIR-IN-013`](requirements.md#air-in-013).
+
+Transport delivery is not evidence that a measurement is fresh or trustworthy.
+Adapters and transports may duplicate, delay, reorder, replay, corrupt, or
+re-time data. They remain outside the trusted display core until input evidence
+passes the relevant checks.
+
+## Simulator-only components
+
+The following components are useful test and integration ports but provide no
+airborne assurance or operational credit:
+
+| Component | Boundary role | Limitation |
+|---|---|---|
+| Gazebo and deterministic simulation adapters | Supply test state and images | Simulated truth has no sensor-error, installation, or integrity claim unless a test explicitly injects and measures it |
+| Aviate SITL and USB CDC development links | Exercise a vehicle-source adapter | Link format and successful parsing do not qualify a sensor, estimator, cable, power source, or installation |
+| Session host and WebTransport | Forward telemetry and media | Receipt time is not source time; forwarding does not refresh age or integrity |
+| Browser and JavaScript bridge | Drive the display core and test operator interaction | Browser scheduling, lifecycle, fonts, memory, and DOM/Canvas behavior are not a qualified display platform |
+| WebAssembly instrument module | Exercises portable core behavior | A build target alone provides no tool, platform, or airborne software approval |
+| Canvas renderer and browser display | Render simulator scene commands | It is nondeterministic across browser/platform combinations and is always **SIM / NOT FOR FLIGHT** |
+| Instrument slider harness and replay | Inject boundary and failure cases | Injected values are test data and test mode remains visibly identified |
+
+An aircraft project may retain the portable pure-state and scene contracts only
+after allocating their intended functions and verification evidence. Sensor/bus
+adapters, platform services, renderer, display hardware, independent monitor,
+power, installation, and continued-airworthiness data require their own safety
+and assurance treatment. This document does not allocate DALs.
+
+## SVS, TAWS, and compositor containment
+
+SVS is an optional removable background under
+[`AIR-OUT-005`](requirements.md#air-out-005). It consumes database and navigation
+evidence, but it neither supplies nor validates primary attitude/air data. The
+critical two-dimensional symbology path must remain available when the SVS
+model, database, terrain renderer, or GPU fails. The compositor enforces the
+priority `SVS background < primary symbology < warning/caution`.
+
+TAWS logic is outside this boundary. If a later display consumes TAWS alerts,
+they arrive as independent monitored inputs under
+[`AIR-IN-012`](requirements.md#air-in-012) and remain visually and functionally
+distinct from terrain shading. This preserves
+[`AIR-OUT-010`](requirements.md#air-out-010): **SVS is not TAWS**.
+
+## HUD-SIM boundary
+
+HUD-SIM ends at a calibrated simulator projection under
+[`AIR-OUT-006`](requirements.md#air-out-006). It may claim conformality only for
+the declared fixed design eye, camera, lens/intrinsics, camera-to-body
+extrinsics, field of view, boresight calibration, video capture time, display
+geometry, and latency budget. Invalid or absent evidence invokes
+[`AIR-UNAV-006`](requirements.md#air-unav-006).
+
+Without those inputs, the output is a non-conformal repeater under
+[`AIR-OUT-007`](requirements.md#air-out-007), visibly marked **NON-CONFORMAL /
+NOT A HUD**. Optical collimation, combiner, head motion/eyebox, luminance,
+alignment, installation, maintenance, and operational credit are excluded by
+[`AIR-OUT-008`](requirements.md#air-out-008).
+
+## Safety and review boundary
+
+This baseline defines inputs to future functional hazard assessment; it does not
+perform that assessment or select an assurance level. Aircraft-level functions,
+failure conditions, independence, common causes, crew procedures, dispatch
+configuration, and certification basis must be selected before assurance is
+allocated. Closure requires the independent review record specified by
+[`AIR-BAS-006`](requirements.md#air-bas-006).
+

--- a/docs/instruments/system-boundary.md
+++ b/docs/instruments/system-boundary.md
@@ -127,4 +127,3 @@ failure conditions, independence, common causes, crew procedures, dispatch
 configuration, and certification basis must be selected before assurance is
 allocated. Closure requires the independent review record specified by
 [`AIR-BAS-006`](requirements.md#air-bas-006).
-

--- a/scripts/check-instrument-requirements.sh
+++ b/scripts/check-instrument-requirements.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Verifies the stable instrument requirement registry and its Markdown links.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+catalog="docs/instruments/requirements.md"
+document_dir="docs/instruments"
+status=0
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+definitions="$tmp_dir/definitions"
+all_ids="$tmp_dir/all-ids"
+
+if [ ! -f "$catalog" ]; then
+    echo "instrument-requirements: missing $catalog" >&2
+    exit 1
+fi
+
+awk '
+    /^### AIR-[A-Z0-9]+-[0-9][0-9][0-9] — / {
+        id = $2
+        expected = "<a id=\"" tolower(id) "\"></a>"
+        if (previous != expected) {
+            printf "BROKEN ANCHOR: %s:%d %s requires preceding %s\n", FILENAME, NR, id, expected > "/dev/stderr"
+            bad = 1
+        }
+        printf "%s\t%d\n", id, NR
+    }
+    { previous = $0 }
+    END { exit bad }
+' "$catalog" > "$definitions" || status=1
+
+if [ ! -s "$definitions" ]; then
+    echo "instrument-requirements: no requirement definitions found" >&2
+    status=1
+fi
+
+duplicates="$(cut -f1 "$definitions" | LC_ALL=C sort | uniq -d)"
+if [ -n "$duplicates" ]; then
+    while IFS= read -r id; do
+        echo "DUPLICATE REQUIREMENT: $id" >&2
+    done <<< "$duplicates"
+    status=1
+fi
+
+while IFS= read -r file; do
+    grep -Eo 'AIR-[A-Z0-9]+-[0-9]{3}' "$file" || true
+done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort) \
+    | LC_ALL=C sort -u > "$all_ids"
+
+while IFS= read -r id; do
+    if ! cut -f1 "$definitions" | grep -Fqx "$id"; then
+        echo "UNDEFINED REQUIREMENT: $id" >&2
+        status=1
+    fi
+done < "$all_ids"
+
+while IFS= read -r file; do
+    [ "$file" = "$catalog" ] && continue
+    awk '
+        {
+            rest = $0
+            while (match(rest, /AIR-[A-Z0-9]+-[0-9][0-9][0-9]/)) {
+                id = substr(rest, RSTART, RLENGTH)
+                expected = "[`" id "`](requirements.md#" tolower(id) ")"
+                prefix = substr(rest, RSTART - 2, 2)
+                suffix = substr(rest, RSTART + RLENGTH)
+                expected_suffix = "`](requirements.md#" tolower(id) ")"
+                if (RSTART < 3 || prefix != "[`" || index(suffix, expected_suffix) != 1) {
+                    printf "BROKEN REQUIREMENT LINK: %s:%d %s must use %s\n", FILENAME, NR, id, expected > "/dev/stderr"
+                    bad = 1
+                }
+                rest = substr(rest, RSTART + RLENGTH)
+            }
+        }
+        END { exit bad }
+    ' "$file" || status=1
+done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort)
+
+if [ "$status" -ne 0 ]; then
+    echo "instrument-requirements: FAILED" >&2
+    exit 1
+fi
+
+count="$(wc -l < "$definitions" | tr -d ' ')"
+echo "instrument-requirements: OK ($count unique requirements)"

--- a/scripts/check-instrument-requirements.sh
+++ b/scripts/check-instrument-requirements.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root_dir"
 
-catalog="docs/instruments/requirements.md"
-document_dir="docs/instruments"
+document_dir="${PILOTAGE_INSTRUMENT_DOCUMENT_DIR:-docs/instruments}"
+catalog="$document_dir/requirements.md"
 status=0
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -129,7 +129,10 @@ referenced="$tmp_dir/referenced"
                     split(ids[i], a, "-")
                     split(ids[i + 1], b, "-")
                     between = substr(gaps[i], 1, length(gaps[i]) - length(gaps[i + 1]) - length(ids[i + 1]))
-                    if (a[2] == b[2] && a[3] + 0 < b[3] + 0 && between ~ /[[:space:]]through[[:space:]]/) {
+                    normalized = between
+                    gsub(/[[:space:]]+/, " ", normalized)
+                    expected = "`](requirements.md#" tolower(ids[i]) ") through [`"
+                    if (a[2] == b[2] && a[3] + 0 < b[3] + 0 && normalized == expected) {
                         for (k = a[3] + 0; k <= b[3] + 0; k++) {
                             printf "AIR-%s-%03d\n", a[2], k
                         }
@@ -146,6 +149,10 @@ while IFS= read -r id; do
         status=1
     fi
 done < <(cut -f1 "$definitions")
+
+if [ "${PILOTAGE_INSTRUMENT_SELFTEST_CHILD:-0}" != "1" ]; then
+    "$root_dir/scripts/test-instrument-requirements.sh" || status=1
+fi
 
 if [ "$status" -ne 0 ]; then
     echo "instrument-requirements: FAILED" >&2

--- a/scripts/check-instrument-requirements.sh
+++ b/scripts/check-instrument-requirements.sh
@@ -45,6 +45,26 @@ if [ -n "$duplicates" ]; then
     status=1
 fi
 
+# A requirement token with the wrong digit count would otherwise be
+# invisible: too short matches nothing, one digit too many mis-parses as
+# a different id plus a stray character. Catch both before extraction.
+malformed="$tmp_dir/malformed"
+: > "$malformed"
+while IFS= read -r file; do
+    grep -nEo 'AIR-[A-Z0-9]+-[0-9]+' "$file" \
+        | grep -Ev '^[0-9]+:AIR-[A-Z0-9]+-[0-9]{3}$' \
+        | sed "s|^|$file:|" >> "$malformed" || true
+done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort)
+grep -nE '^### AIR-' "$catalog" \
+    | grep -Ev '^[0-9]+:### AIR-[A-Z0-9]+-[0-9]{3} — ' \
+    | sed "s|^|$catalog:|" >> "$malformed" || true
+if [ -s "$malformed" ]; then
+    while IFS= read -r hit; do
+        echo "MALFORMED REQUIREMENT ID: $hit" >&2
+    done < "$malformed"
+    status=1
+fi
+
 while IFS= read -r file; do
     grep -Eo 'AIR-[A-Z0-9]+-[0-9]{3}' "$file" || true
 done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort) \
@@ -78,6 +98,54 @@ while IFS= read -r file; do
         END { exit bad }
     ' "$file" || status=1
 done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort)
+
+# Every definition must be reachable from at least one reference, so a
+# requirement cannot silently drop out of the documentation set. A
+# reference is an occurrence outside the definition header/anchor, or
+# membership in a documented "A through B" span (ranges may wrap lines).
+referenced="$tmp_dir/referenced"
+{
+    while IFS= read -r file; do
+        if [ "$file" = "$catalog" ]; then
+            # Definition headers and anchors are not references; catalog
+            # prose can cross-reference, but "A through B" spans are only
+            # trusted from the narrative documents (a requirement body
+            # using the word "through" must not fabricate a span).
+            grep -Ev '^### AIR-|^<a id=' "$file" | grep -Eo 'AIR-[A-Z0-9]+-[0-9]{3}' || true
+            continue
+        fi
+        grep -Eo 'AIR-[A-Z0-9]+-[0-9]{3}' "$file" || true
+        tr '\n' ' ' < "$file" | awk '
+            {
+                rest = $0
+                n = 0
+                while (match(rest, /AIR-[A-Z0-9]+-[0-9][0-9][0-9]/)) {
+                    n += 1
+                    ids[n] = substr(rest, RSTART, RLENGTH)
+                    rest = substr(rest, RSTART + RLENGTH)
+                    gaps[n] = rest
+                }
+                for (i = 1; i < n; i++) {
+                    split(ids[i], a, "-")
+                    split(ids[i + 1], b, "-")
+                    between = substr(gaps[i], 1, length(gaps[i]) - length(gaps[i + 1]) - length(ids[i + 1]))
+                    if (a[2] == b[2] && a[3] + 0 < b[3] + 0 && between ~ /[[:space:]]through[[:space:]]/) {
+                        for (k = a[3] + 0; k <= b[3] + 0; k++) {
+                            printf "AIR-%s-%03d\n", a[2], k
+                        }
+                    }
+                }
+            }
+        '
+    done < <(find "$document_dir" -type f -name '*.md' -print | LC_ALL=C sort)
+} | LC_ALL=C sort -u > "$referenced"
+
+while IFS= read -r id; do
+    if ! grep -Fqx "$id" "$referenced"; then
+        echo "UNREFERENCED REQUIREMENT: $id" >&2
+        status=1
+    fi
+done < <(cut -f1 "$definitions")
 
 if [ "$status" -ne 0 ]; then
     echo "instrument-requirements: FAILED" >&2

--- a/scripts/test-instrument-requirements.sh
+++ b/scripts/test-instrument-requirements.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Exercises failure modes that a successful repository-only check cannot reach.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+checker="$root_dir/scripts/check-instrument-requirements.sh"
+source_dir="$root_dir/docs/instruments"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+prepare_case() {
+    case_dir="$tmp_dir/$1"
+    mkdir -p "$case_dir"
+    cp -R "$source_dir/." "$case_dir"
+}
+
+run_checker() {
+    env \
+        "PILOTAGE_INSTRUMENT_DOCUMENT_DIR=$case_dir" \
+        PILOTAGE_INSTRUMENT_SELFTEST_CHILD=1 \
+        bash "$checker"
+}
+
+show_failure() {
+    echo "instrument-requirements-selftest: $1" >&2
+    sed 's/^/    /' "$output_file" >&2
+    exit 1
+}
+
+expect_success() {
+    output_file="$tmp_dir/$1.output"
+    if ! run_checker > "$output_file" 2>&1; then
+        show_failure "$1 unexpectedly failed"
+    fi
+}
+
+expect_failure() {
+    output_file="$tmp_dir/$1.output"
+    if run_checker > "$output_file" 2>&1; then
+        show_failure "$1 unexpectedly passed"
+    fi
+    if ! grep -Fq "$2" "$output_file"; then
+        show_failure "$1 did not report: $2"
+    fi
+}
+
+prepare_case baseline
+expect_success baseline
+
+prepare_case short-id
+printf "\n[\`AIR-TST-01\`](requirements.md#air-tst-01)\n" \
+    >> "$case_dir/intended-functions.md"
+expect_failure short-id 'MALFORMED REQUIREMENT ID:'
+
+prepare_case long-id
+printf "\n[\`AIR-TST-0001\`](requirements.md#air-tst-0001)\n" \
+    >> "$case_dir/intended-functions.md"
+expect_failure long-id 'MALFORMED REQUIREMENT ID:'
+
+prepare_case orphan
+printf '\n<a id="air-tst-999"></a>\n### AIR-TST-999 — Self-test orphan\n' \
+    >> "$case_dir/requirements.md"
+expect_failure orphan 'UNREFERENCED REQUIREMENT: AIR-TST-999'
+
+prepare_case valid-range
+printf '\n<a id="air-tst-991"></a>\n### AIR-TST-991 — Range start\n<a id="air-tst-992"></a>\n### AIR-TST-992 — Range member\n<a id="air-tst-993"></a>\n### AIR-TST-993 — Range end\n' \
+    >> "$case_dir/requirements.md"
+printf "\n[\`AIR-TST-991\`](requirements.md#air-tst-991) through [\`AIR-TST-993\`](requirements.md#air-tst-993)\n" \
+    >> "$case_dir/intended-functions.md"
+expect_success valid-range
+
+prepare_case false-range
+printf '\n<a id="air-tst-981"></a>\n### AIR-TST-981 — Phrase start\n<a id="air-tst-982"></a>\n### AIR-TST-982 — Unreferenced member\n<a id="air-tst-983"></a>\n### AIR-TST-983 — Phrase end\n' \
+    >> "$case_dir/requirements.md"
+printf "\n[\`AIR-TST-981\`](requirements.md#air-tst-981) is evaluated through a separate process before [\`AIR-TST-983\`](requirements.md#air-tst-983).\n" \
+    >> "$case_dir/intended-functions.md"
+expect_failure false-range 'UNREFERENCED REQUIREMENT: AIR-TST-982'
+
+echo "instrument-requirements-selftest: OK (6 cases)"


### PR DESCRIPTION
## Summary

- define intended functions, modes, inputs, outputs, failure presentation, and source assumptions for every display function (PFD, HSI, conventional/SVS/SVGS variants, HUD-SIM modes, and the TAWS non-goal)
- record the simulator/airborne system boundary and the permanent SIM / NOT FOR FLIGHT designation, including an always-visible, non-dismissable banner on every viewer stage
- register 59 stable requirements with permanent identifiers and enforce the registry in CI (malformed/duplicate/undefined/unreferenced identifiers and broken links all fail, with a 6-case self-test)

**Merging this PR establishes the version-controlled AIR-01 engineering baseline. It does not complete — and must not be read as implying — the independent-review criterion of issue #24.** The project-owner, qualified safety, and qualified human-factors review records in `docs/instruments/review-record.md` remain `PENDING`, the closure decision block remains `NO`, and issue #24 stays open until those records are completed with reviewer identity/qualification, reviewed revision, disposition, rationale, and resolution or accepted disposition of blocking actions.

## Acceptance criteria — evidence

| Issue #24 criterion | Status | Evidence |
|---|---|---|
| Version-controlled intended-function and system-boundary documents exist | ✅ | `docs/instruments/intended-functions.md`, `docs/instruments/system-boundary.md` (plus `README.md`, `requirements.md`, `review-record.md`) |
| Every display function identifies inputs, outputs, modes, failure presentation, and source assumptions | ✅ | `intended-functions.md` function matrix: every row fills all five columns, including the SVS/SVGS/HUD-SIM rows that only exist as roadmap non-goals today |
| No requirement silently assumes an altitude datum, heading reference, time domain, or camera calibration | ✅ | `AIR-BAS-004` forbids the inference outright; `AIR-IN-002`, `AIR-IN-005`, `AIR-IN-008`, `AIR-IN-010` pin the specific hazards. Cross-checked against the actual Aviate wire: no doc claim exceeds what the wire carries |
| SVS is not described as TAWS; non-conformal output is not described as HUD | ✅ | `AIR-OUT-010`, `AIR-OUT-007` (“NON-CONFORMAL / NOT A HUD”), `AIR-OUT-008`, `AIR-OUT-009`; repeated in `system-boundary.md` |
| No single DAL assigned to the entire application before hazard analysis | ✅ | `AIR-BAS-003`; README and `system-boundary.md` state no blanket DAL allocation — allocation waits for AIR-02 (#27) |
| Requirement IDs unique and linkable; CI rejects duplicates and broken references | ✅ | `scripts/check-instrument-requirements.sh` + `scripts/test-instrument-requirements.sh` (self-test runs inside the gate): duplicates, undefined references, broken anchors/links, malformed identifiers, and unreferenced definitions all fail with named diagnostics |
| New display features must cite an intended-function requirement | ✅ (policy) | `AIR-BAS-005` + README change control; CI enforces citation integrity, citation presence stays a human review gate |
| Project-owner and qualified safety/human-factors review records are required before closure | ✅ (open by design) | `review-record.md`: three review blocks `PENDING`, “Tracking issue may close: NO”. This criterion is intentionally not satisfiable by engineering work — it is why issue #24 outlives this merge |

## What this merge does not claim

Engineering acceptance of the baseline only. No FAA/EASA finding, no DAL assignment, no airborne-use permission, no completed independent review. All artifacts remain SIM / NOT FOR FLIGHT.

Refs #24 (deliberately non-closing).
