### PR TITLE
REN-01: freeze the scene-layer and safety compositor contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,9 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-scene"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "pilotage-instrument-state"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ name = "pilotage-instrument-scene"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 prost = "0.14.4"

--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -5,7 +5,7 @@
 //! no process-global or thread-local mutable state.
 
 use pilotage_instrument_panels::{PfdConfig, VSpeeds, draw_hsi, draw_pfd};
-use pilotage_instrument_scene::{SceneCmds, SceneError, SceneWriter};
+use pilotage_instrument_scene::{LayerError, LayerId, SceneError, SceneWriter, validate_layers};
 use pilotage_instrument_state::abi::{AbiError, STATE_ABI_SIZE, STATE_ABI_VERSION, decode_state};
 use pilotage_instrument_state::{FreshnessPolicy, resolve};
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -17,6 +17,17 @@ const PACKED_SCENE_LEN_MAX: usize = 0x00ff_ffff;
 const PANEL_PFD: u32 = 0;
 const PANEL_HSI: u32 = 1;
 const PANEL_COUNT: usize = 2;
+
+const fn layer_bit(layer: LayerId) -> u8 {
+    1u8 << layer.to_u8()
+}
+
+const PFD_CRITICAL_LAYERS: u8 =
+    layer_bit(LayerId::Attitude) | layer_bit(LayerId::Tapes) | layer_bit(LayerId::Annunciation);
+const HSI_CRITICAL_LAYERS: u8 = layer_bit(LayerId::Attitude)
+    | layer_bit(LayerId::Tapes)
+    | layer_bit(LayerId::Guidance)
+    | layer_bit(LayerId::Annunciation);
 
 pub(crate) struct Runtime {
     pub(crate) state: Vec<u8>,
@@ -77,17 +88,25 @@ fn panel_generation(runtime: &Runtime, panel_idx: usize) -> u32 {
     runtime.generation.get(panel_idx).copied().unwrap_or(0)
 }
 
-/// Whether every command in `scene` decodes cleanly; a partially paintable
-/// but structurally broken scene must never reach a backend.
-fn scene_is_structurally_valid(scene: &[u8]) -> bool {
-    match SceneCmds::new(scene) {
-        Ok(mut cmds) => cmds.all(|cmd| cmd.is_ok()),
-        Err(_) => false,
+fn validate_panel_scene(panel_idx: usize, scene: &[u8]) -> RenderStatus {
+    let required = match panel_idx {
+        0 => PFD_CRITICAL_LAYERS,
+        1 => HSI_CRITICAL_LAYERS,
+        _ => return RenderStatus::InvalidPanel,
+    };
+    let report = match validate_layers(scene) {
+        Ok(report) => report,
+        Err(LayerError::Decode(_)) => return RenderStatus::SceneStructure,
+        Err(_) => return RenderStatus::SceneLayerContract,
+    };
+    if report.present & required != required {
+        return RenderStatus::SceneCriticalLayersMissing;
     }
+    RenderStatus::Ok
 }
 
-/// Commits a generated scene only after its structure validates. Buffer bytes
-/// are scratch until this returns success.
+/// Commits a generated scene only after the complete panel-layer contract has
+/// validated. Buffer bytes are scratch until this returns success.
 pub(crate) fn validate_and_commit_scene(
     runtime: &mut Runtime,
     panel_idx: usize,
@@ -100,8 +119,9 @@ pub(crate) fn validate_and_commit_scene(
     let Some(scene) = runtime.scene.get(..len) else {
         return RenderAttempt::failure(RenderStatus::SceneStructure, generation);
     };
-    if !scene_is_structurally_valid(scene) {
-        return RenderAttempt::failure(RenderStatus::SceneStructure, generation);
+    let status = validate_panel_scene(panel_idx, scene);
+    if status != RenderStatus::Ok {
+        return RenderAttempt::failure(status, generation);
     }
     let Some(next_generation) = runtime.generation.get_mut(panel_idx) else {
         return RenderAttempt::failure(RenderStatus::InvalidPanel, 0);

--- a/clients/web-instruments/src/render_status.rs
+++ b/clients/web-instruments/src/render_status.rs
@@ -1,4 +1,4 @@
-//! Stable render-status reason codes shared with the JS backend (DISP-01).
+//! Stable render-status reason codes shared with the JS backend.
 
 /// Stable status field carried by the packed WASM render result.
 ///

--- a/clients/web-instruments/src/render_status.rs
+++ b/clients/web-instruments/src/render_status.rs
@@ -30,4 +30,8 @@ pub enum RenderStatus {
     SceneCommandLimit = 7,
     /// The encoded scene failed structural self-validation.
     SceneStructure = 8,
+    /// The scene violated layer ordering, ownership, state isolation, or bounds.
+    SceneLayerContract = 9,
+    /// The scene omitted a critical layer required by the selected panel.
+    SceneCriticalLayersMissing = 10,
 }

--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use pilotage_instrument_panels::PfdConfig;
-use pilotage_instrument_scene::SceneCmds;
+use pilotage_instrument_scene::{
+    LayerId, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES, SceneCmds, SceneWriter,
+};
 use pilotage_instrument_state::abi::{STATE_ABI_SIZE, STATE_ABI_VERSION, encode_state};
 use pilotage_instrument_state::{AircraftState, Attitude, Quat, Stamped};
 
@@ -56,6 +58,48 @@ fn assert_attempt(attempt: RenderAttempt, status: RenderStatus, scene_len: usize
     assert_eq!(attempt.generation, generation);
 }
 
+fn encoded_scene(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+    let mut scene = vec![0u8; MAX_SCENE_BYTES];
+    let mut writer = SceneWriter::new(&mut scene).expect("writer");
+    build(&mut writer);
+    let len = writer.finish();
+    scene.truncate(len);
+    scene
+}
+
+fn simple_layer(writer: &mut SceneWriter<'_>, layer: LayerId) {
+    writer.begin_layer(layer).expect("begin layer");
+    writer.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    writer.end_layer(layer).expect("end layer");
+}
+
+fn panel_scene(layers: &[LayerId]) -> Vec<u8> {
+    encoded_scene(|writer| {
+        for layer in layers {
+            simple_layer(writer, *layer);
+        }
+    })
+}
+
+fn scene_runtime(scene: &[u8]) -> Runtime {
+    let mut buffer = vec![0u8; scene.len().max(MAX_SCENE_BYTES)];
+    buffer[..scene.len()].copy_from_slice(scene);
+    Runtime {
+        state: encoded_state_block(&attitude_state()),
+        scene: buffer,
+        generation: [7, 11],
+        pfd_cfg: PfdConfig::default(),
+    }
+}
+
+fn assert_scene_rejected(panel_idx: usize, scene: &[u8], expected: RenderStatus) {
+    let mut runtime = scene_runtime(scene);
+    let generations = runtime.generation;
+    let expected_generation = runtime.generation.get(panel_idx).copied().unwrap_or(0);
+    let attempt = validate_and_commit_scene(&mut runtime, panel_idx, scene.len());
+    assert_attempt(attempt, expected, 0, expected_generation);
+    assert_eq!(runtime.generation, generations, "failure must not advance");
+}
 #[test]
 fn exported_surface_packs_one_atomic_render_result() {
     assert_eq!(abi_version(), STATE_ABI_VERSION);
@@ -250,4 +294,98 @@ fn every_encode_error_maps_to_its_own_status() {
         scene_error_status(SceneError::TextTooLong),
         RenderStatus::SceneCommandLimit
     );
+}
+
+#[test]
+fn critical_layer_masks_gate_visible_commit() {
+    let pfd = panel_scene(&[LayerId::Attitude, LayerId::Tapes, LayerId::Annunciation]);
+    let hsi = panel_scene(&[
+        LayerId::Attitude,
+        LayerId::Tapes,
+        LayerId::Guidance,
+        LayerId::Annunciation,
+    ]);
+    for (panel_idx, scene, expected_generation) in [(0, pfd, [8, 11]), (1, hsi, [7, 12])] {
+        let mut runtime = scene_runtime(&scene);
+        let attempt = validate_and_commit_scene(&mut runtime, panel_idx, scene.len());
+        assert_attempt(
+            attempt,
+            RenderStatus::Ok,
+            scene.len(),
+            expected_generation[panel_idx],
+        );
+        assert_eq!(runtime.generation, expected_generation);
+    }
+
+    let background_only = panel_scene(&[LayerId::Background]);
+    let failure_only = panel_scene(&[LayerId::Failure]);
+    assert_scene_rejected(
+        0,
+        &background_only,
+        RenderStatus::SceneCriticalLayersMissing,
+    );
+    assert_scene_rejected(1, &failure_only, RenderStatus::SceneCriticalLayersMissing);
+
+    let pfd_missing_annunciation = panel_scene(&[LayerId::Attitude, LayerId::Tapes]);
+    let hsi_missing_guidance =
+        panel_scene(&[LayerId::Attitude, LayerId::Tapes, LayerId::Annunciation]);
+    assert_scene_rejected(
+        0,
+        &pfd_missing_annunciation,
+        RenderStatus::SceneCriticalLayersMissing,
+    );
+    assert_scene_rejected(
+        1,
+        &hsi_missing_guidance,
+        RenderStatus::SceneCriticalLayersMissing,
+    );
+}
+
+#[test]
+fn layer_order_ownership_and_nesting_gate_visible_commit() {
+    let duplicate = panel_scene(&[LayerId::Attitude, LayerId::Attitude]);
+    let out_of_order = panel_scene(&[LayerId::Tapes, LayerId::Attitude]);
+    let nested = encoded_scene(|writer| {
+        writer.begin_layer(LayerId::Attitude).expect("outer layer");
+        writer.begin_layer(LayerId::Tapes).expect("nested layer");
+    });
+    for scene in [duplicate, out_of_order, nested] {
+        assert_scene_rejected(0, &scene, RenderStatus::SceneLayerContract);
+    }
+}
+
+#[test]
+fn layer_state_and_budgets_gate_visible_commit() {
+    let unbalanced = encoded_scene(|writer| {
+        writer.begin_layer(LayerId::Attitude).expect("begin layer");
+        writer.save().expect("nested state");
+        writer.end_layer(LayerId::Attitude).expect("end layer");
+    });
+    assert_scene_rejected(0, &unbalanced, RenderStatus::SceneLayerContract);
+
+    let over_budget = encoded_scene(|writer| {
+        writer.begin_layer(LayerId::Attitude).expect("begin layer");
+        for _ in 0..(MAX_LAYER_COMMANDS - 2) / 2 {
+            writer.save().expect("save");
+            writer.restore().expect("restore");
+        }
+        writer.rotate(0.1).expect("over-budget command");
+        writer.end_layer(LayerId::Attitude).expect("end layer");
+    });
+    assert_scene_rejected(0, &over_budget, RenderStatus::SceneLayerContract);
+
+    let oversized = vec![0u8; MAX_SCENE_BYTES + 1];
+    assert_scene_rejected(0, &oversized, RenderStatus::SceneLayerContract);
+}
+
+#[test]
+fn malformed_scene_framing_gates_visible_commit() {
+    let mut truncated = panel_scene(&[LayerId::Attitude, LayerId::Tapes, LayerId::Annunciation]);
+    truncated.pop();
+    assert_scene_rejected(0, &truncated, RenderStatus::SceneStructure);
+
+    let outside_layer = encoded_scene(|writer| {
+        writer.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    });
+    assert_scene_rejected(0, &outside_layer, RenderStatus::SceneLayerContract);
 }

--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -1,5 +1,5 @@
 // Display-pipeline health: failure latch, recovery, liveness watchdog, and
-// the backend-owned failure page (DISP-01).
+// the backend-owned failure page.
 //
 // A renderer or display-pipeline failure must never leave a valid-looking
 // last successful image visible. Every failure carries a stable reason
@@ -26,6 +26,8 @@ export const REASON = Object.freeze({
   SCENE_BUFFER_FULL: 6,
   SCENE_COMMAND_LIMIT: 7,
   SCENE_STRUCTURE: 8,
+  SCENE_LAYER_CONTRACT: 9,
+  SCENE_CRITICAL_LAYERS_MISSING: 10,
   // Backend-observed.
   WASM_LOAD: 100,
   ABI_MISMATCH: 101,

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -27,7 +27,7 @@ const SCENE_FORMAT_VERSION = 1;
 export const STATE_ABI_VERSION = 1;
 export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
-const MAX_WASM_RENDER_STATUS = 8;
+const MAX_WASM_RENDER_STATUS = 10;
 
 // A resource missing any required method is incompatible and must fail as an
 // ABI mismatch rather than as a TypeError mid-frame.

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -475,6 +475,14 @@ export function interpretScene(view, ctx) {
         ctx.rect(f(0), f(1), f(2), f(3));
         ctx.clip();
         break;
+      case 0x50:
+      case 0x51:
+        // Layer markers: part of the known vocabulary, painted as
+        // no-ops. Z-order and layer structure are enforced by the
+        // renderer before commit, and the embedded save/restore
+        // envelope carries the state isolation. Counting them as
+        // unknown would permanently poison the version-skew diagnostic.
+        break;
       default:
         unknown += 1;
         break;

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -19,6 +19,7 @@ import {
   STATE_ABI_SIZE_BY_VERSION,
   STATE_ABI_VERSION,
   decodeRenderResult,
+  interpretScene,
   loadInstruments,
   validateSceneStructure,
 } from "./instruments.js";
@@ -203,6 +204,33 @@ function buildScene() {
 }
 
 const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+// ---- layer markers are known vocabulary ------------------------------------
+
+{
+  const layered = Uint8Array.from([
+    1,
+    ...cmd(0x50, [0]),
+    ...cmd(0x01, []),
+    ...cmd(0x23, [1, ...f32(0), ...f32(0), ...f32(4), ...f32(4)]),
+    ...cmd(0x02, []),
+    ...cmd(0x51, [0]),
+  ]);
+  const ctx = new RecordingCtx();
+  check(
+    "layer markers paint as known no-ops, not unknown opcodes",
+    interpretScene(view(layered), ctx) === 0,
+  );
+  check(
+    "marker envelope still paints its commands",
+    ctx.calls("fillRect").length === 1,
+  );
+  const trulyUnknown = Uint8Array.from([1, ...cmd(0x7f, [])]);
+  check(
+    "a genuinely unknown opcode still counts",
+    interpretScene(view(trulyUnknown), new RecordingCtx()) === 1,
+  );
+}
 
 // ---- scene framing validation ----------------------------------------------
 

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -470,21 +470,27 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
 }
 
 {
-  let created = 0;
-  const mod = new InstrumentModule(fakeExports({ status: REASON.SCENE_BUFFER_FULL }), {
-    createCanvas: () => {
-      created += 1;
-      return recordingCanvas();
-    },
-  });
-  const visible = new RecordingCtx();
-  const result = mod.renderPanel(PANEL.PFD, visible, 480, 360);
-  check(
-    "wasm failure code passes through untouched",
-    !result.ok && result.reason === REASON.SCENE_BUFFER_FULL,
-  );
-  check("no back buffer touched on wasm failure", created === 0);
-  check("visible target untouched on wasm failure", visible.log.length === 0);
+  for (const reason of [
+    REASON.SCENE_BUFFER_FULL,
+    REASON.SCENE_LAYER_CONTRACT,
+    REASON.SCENE_CRITICAL_LAYERS_MISSING,
+  ]) {
+    let created = 0;
+    const mod = new InstrumentModule(fakeExports({ status: reason }), {
+      createCanvas: () => {
+        created += 1;
+        return recordingCanvas();
+      },
+    });
+    const visible = new RecordingCtx();
+    const result = mod.renderPanel(PANEL.PFD, visible, 480, 360);
+    check(
+      `wasm failure code ${reason} passes through untouched`,
+      !result.ok && result.reason === reason,
+    );
+    check(`failure ${reason} touches no back buffer`, created === 0);
+    check(`failure ${reason} leaves visible target untouched`, visible.log.length === 0);
+  }
 }
 
 {

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -974,6 +974,10 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
     const lastSceneLen = lastResult?.sceneLen ?? 0;
     check("atomic result carries a non-trivial scene length", lastSceneLen > 1);
     check("real scene passed framing before visible commit", lastResult?.ok === true);
+    check(
+      "a real layered frame leaves the unknown-opcode diagnostic clean",
+      mod.unknownOpcodes === 0,
+    );
     // Linear-memory growth detaches every previously created view; the
     // module must re-derive views per frame, never cache one.
     capturedWasm.memory.grow(1);

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -2,7 +2,7 @@
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
 use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
-use pilotage_instrument_state::{NavSource, PanelData};
+use pilotage_instrument_state::{NavSource, PanelData, SignalStatus};
 
 use crate::palette;
 use crate::status_paint;
@@ -59,6 +59,12 @@ pub fn draw_hsi(data: &PanelData, scene: &mut SceneWriter<'_>) -> Result<(), Sce
     scene.end_layer(LayerId::Guidance)?;
 
     scene.begin_layer(LayerId::Annunciation)?;
+    if data.nav.data.source != NavSource::None
+        && data.nav.status.shows_value()
+        && data.nav.status != SignalStatus::Valid
+    {
+        status_paint::draw_flag(scene, CX, CY + 60.0, "NAV")?;
+    }
     if !hdg.status.shows_value() {
         status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
     }

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -1,7 +1,7 @@
 //! The Horizontal Situation Indicator: rotating compass rose, heading
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
-use pilotage_instrument_scene::{PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{NavSource, PanelData};
 
 use crate::palette;
@@ -19,31 +19,50 @@ pub(crate) const CY: f32 = 190.0;
 /// Compass rose radius.
 pub(crate) const ROSE_R: f32 = 160.0;
 
-/// Draws the HSI from resolved state.
+/// Draws the HSI from resolved state, in the REN-01 layer bands: the
+/// black backdrop, the rotating orientation symbology, the readout
+/// boxes, course guidance, and — above everything it annunciates — the
+/// heading failure flag.
 pub fn draw_hsi(data: &PanelData, scene: &mut SceneWriter<'_>) -> Result<(), SceneError> {
+    scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
     scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
+    scene.end_layer(LayerId::Background)?;
 
     let hdg = data.heading_rad;
+    scene.begin_layer(LayerId::Attitude)?;
     if hdg.status.shows_value() {
         rose::draw_rose(scene, hdg.value)?;
         rose::draw_heading_bug(scene, hdg.value, data.selections.heading_bug_rad)?;
         if data.track_rad.status.shows_value() {
             rose::draw_track_diamond(scene, hdg.value, data.track_rad.value)?;
         }
-        if data.nav.data.source != NavSource::None && data.nav.status.shows_value() {
-            cdi::draw_cdi(scene, &data.nav, hdg.value)?;
-        }
-    } else {
-        status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
     }
+    scene.end_layer(LayerId::Attitude)?;
 
+    scene.begin_layer(LayerId::Tapes)?;
     rose::draw_heading_box(scene, hdg)?;
     boxes::wind_box(scene, data)?;
     boxes::dist_box(scene, data)?;
     boxes::course_box(scene, data)?;
     boxes::heading_sel_box(scene, data)?;
+    scene.end_layer(LayerId::Tapes)?;
+
+    scene.begin_layer(LayerId::Guidance)?;
+    if hdg.status.shows_value()
+        && data.nav.data.source != NavSource::None
+        && data.nav.status.shows_value()
+    {
+        cdi::draw_cdi(scene, &data.nav, hdg.value)?;
+    }
     boxes::vertical_deviation(scene, data)?;
+    scene.end_layer(LayerId::Guidance)?;
+
+    scene.begin_layer(LayerId::Annunciation)?;
+    if !hdg.status.shows_value() {
+        status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
+    }
+    scene.end_layer(LayerId::Annunciation)?;
     Ok(())
 }
 

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -19,7 +19,7 @@ pub(crate) const CY: f32 = 190.0;
 /// Compass rose radius.
 pub(crate) const ROSE_R: f32 = 160.0;
 
-/// Draws the HSI from resolved state, in the REN-01 layer bands: the
+/// Draws the HSI from resolved state in the scene-layer bands: the
 /// black backdrop, the rotating orientation symbology, the readout
 /// boxes, course guidance, and — above everything it annunciates — the
 /// heading failure flag.

--- a/crates/pilotage-instrument-panels/src/hsi/cdi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/cdi.rs
@@ -2,7 +2,7 @@
 //! dots, and TO/FROM triangle.
 
 use pilotage_instrument_scene::{PaintMode, Rgba8, SceneError, SceneWriter};
-use pilotage_instrument_state::{NavFromTo, NavResolved, NavSource, SignalStatus};
+use pilotage_instrument_state::{NavFromTo, NavResolved, NavSource};
 
 use crate::palette;
 
@@ -62,16 +62,5 @@ pub fn draw_cdi(
         NavFromTo::Off => {}
     }
     scene.restore()?;
-
-    if nav.status != SignalStatus::Valid {
-        scene.fill_color(palette::AMBER)?;
-        scene.text(
-            super::CX,
-            super::CY + 60.0,
-            12.0,
-            pilotage_instrument_scene::Anchor::CENTER,
-            "NAV",
-        )?;
-    }
     Ok(())
 }

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -147,7 +147,7 @@ fn failed_heading_renders_red_x() {
     );
 }
 
-// ---- REN-01 layer contract ---------------------------------------------------
+// ---- layer contract ----------------------------------------------------------
 
 use pilotage_instrument_scene::{LayerId, validate_layers};
 

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -57,6 +57,22 @@ fn texts(scene: &[u8]) -> Vec<String> {
         .collect()
 }
 
+fn layer_texts(scene: &[u8], wanted: LayerId) -> Vec<(String, [f32; 3])> {
+    let mut inside = false;
+    let mut found = Vec::new();
+    for command in SceneCmds::new(scene).expect("valid scene") {
+        match command.expect("valid command") {
+            Cmd::BeginLayer { layer } => inside = layer == wanted,
+            Cmd::EndLayer { layer } if layer == wanted => inside = false,
+            Cmd::Text {
+                x, y, size, text, ..
+            } if inside => found.push((String::from(text), [x, y, size])),
+            _ => {}
+        }
+    }
+    found
+}
+
 #[test]
 fn north_heading_reads_360() {
     let scene = render(&heading_only(0.0));
@@ -121,6 +137,11 @@ fn failed_heading_renders_red_x() {
     let labels = texts(&scene);
     assert!(labels.iter().any(|t| t == "HDG"), "HDG flag: {labels:?}");
     assert!(
+        layer_texts(&scene, LayerId::Annunciation)
+            .contains(&(String::from("HDG"), [240.0, 190.0, 20.0])),
+        "HDG failure must be an annunciation"
+    );
+    assert!(
         labels.iter().any(|t| t == "---"),
         "readout dashes: {labels:?}"
     );
@@ -153,4 +174,30 @@ fn scenes_are_layered_for_every_heading_status() {
             assert!(report.contains(layer), "{status:?} missing {layer:?}");
         }
     }
+}
+
+#[test]
+fn degraded_navigation_cue_is_an_annunciation() {
+    let mut data = heading_only(0.0);
+    data.nav = NavResolved {
+        data: NavData {
+            source: NavSource::Gps,
+            course_rad: 0.35,
+            cdi_dots: -1.2,
+            fromto: NavFromTo::To,
+            vdev_dots: Some(0.4),
+            dist_nm: Some(40.3),
+        },
+        status: SignalStatus::Degraded,
+    };
+    let scene = render(&data);
+    let expected = (String::from("NAV"), [240.0, 250.0, 11.0]);
+    assert!(
+        layer_texts(&scene, LayerId::Annunciation).contains(&expected),
+        "NAV cue must be above guidance"
+    );
+    assert!(
+        !layer_texts(&scene, LayerId::Guidance).contains(&expected),
+        "NAV cue must not share the guidance band"
+    );
 }

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -125,3 +125,32 @@ fn failed_heading_renders_red_x() {
         "readout dashes: {labels:?}"
     );
 }
+
+// ---- REN-01 layer contract ---------------------------------------------------
+
+use pilotage_instrument_scene::{LayerId, validate_layers};
+
+#[test]
+fn scenes_are_layered_for_every_heading_status() {
+    for status in [
+        SignalStatus::Valid,
+        SignalStatus::Degraded,
+        SignalStatus::Stale,
+        SignalStatus::Missing,
+        SignalStatus::Failed,
+    ] {
+        let mut data = heading_only(0.0);
+        data.heading_rad = Sig::with_status(0.0, status);
+        let scene = render(&data);
+        let report = validate_layers(&scene).expect("layered scene validates");
+        for layer in [
+            LayerId::Background,
+            LayerId::Attitude,
+            LayerId::Tapes,
+            LayerId::Guidance,
+            LayerId::Annunciation,
+        ] {
+            assert!(report.contains(layer), "{status:?} missing {layer:?}");
+        }
+    }
+}

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -2,7 +2,7 @@
 //! and turn-rate cue, composed in fixed layers (background → attitude →
 //! tapes → symbology → annunciation, ADR-0017).
 
-use pilotage_instrument_scene::{PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{PanelData, SignalStatus};
 
 use crate::palette;
@@ -29,15 +29,20 @@ pub struct VSpeeds {
 
 /// What fills the attitude background.
 ///
-/// `Horizon` is the phase-1 2D sky/ground ball. A synthetic-vision
-/// background slots in here as a further variant carrying its viewport
-/// and quality tier (reserved, ADR-0017) without touching the ladder,
-/// tapes, or symbology layers.
+/// `Horizon` is the phase-1 2D sky/ground ball. `None` emits no
+/// background layer at all: the safety compositor owns that band (a
+/// future SVS raster composes strictly below the critical overlay,
+/// REN-01), and the layers above it are byte-identical either way. A
+/// synthetic-vision *scene* background would slot in as a further
+/// variant carrying its viewport and quality tier (reserved, ADR-0017)
+/// without touching the ladder, tapes, or symbology layers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BackgroundMode {
     /// Flat-shaded sky-over-ground attitude ball.
     #[default]
     Horizon,
+    /// No background layer; the compositor supplies that band.
+    None,
 }
 
 /// PFD panel configuration.
@@ -49,35 +54,54 @@ pub struct PfdConfig {
     pub v_speeds: Option<VSpeeds>,
 }
 
-/// Draws the PFD from resolved state.
+/// Draws the PFD from resolved state, in the REN-01 layer bands:
+/// optional background, then attitude symbology, tapes, and
+/// annunciations, in ascending z-order. The layers above `Background`
+/// never depend on the background mode, so the critical overlay stays
+/// complete — byte-identical — when the background is absent.
 pub fn draw_pfd(
     data: &PanelData,
     cfg: &PfdConfig,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
-    scene.fill_color(palette::BLACK)?;
-    scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
-
     let att_status = data.roll_rad.status.worst(data.pitch_rad.status);
-    if att_status.shows_value() {
-        match cfg.background {
-            BackgroundMode::Horizon => {
+
+    match cfg.background {
+        BackgroundMode::Horizon => {
+            scene.begin_layer(LayerId::Background)?;
+            scene.fill_color(palette::BLACK)?;
+            scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
+            if att_status.shows_value() {
                 horizon::draw_ball(scene, data.roll_rad.value, data.pitch_rad.value)?;
             }
+            scene.end_layer(LayerId::Background)?;
         }
+        BackgroundMode::None => {}
+    }
+
+    scene.begin_layer(LayerId::Attitude)?;
+    if att_status.shows_value() {
         horizon::draw_roll_scale(scene, data.roll_rad.value)?;
         horizon::draw_aircraft_symbol(scene)?;
+    }
+    scene.end_layer(LayerId::Attitude)?;
+
+    scene.begin_layer(LayerId::Tapes)?;
+    tapes::speed_tape(scene, data, cfg.v_speeds.as_ref())?;
+    tapes::altitude_tape(scene, data)?;
+    tapes::vsi(scene, data)?;
+    draw_turn_rate(scene, data)?;
+    scene.end_layer(LayerId::Tapes)?;
+
+    scene.begin_layer(LayerId::Annunciation)?;
+    if att_status.shows_value() {
         if att_status != SignalStatus::Valid {
             status_paint::draw_flag(scene, 240.0, 60.0, "ATT")?;
         }
     } else {
         status_paint::draw_red_x(scene, 110.0, 50.0, 260.0, 240.0, "ATT")?;
     }
-
-    tapes::speed_tape(scene, data, cfg.v_speeds.as_ref())?;
-    tapes::altitude_tape(scene, data)?;
-    tapes::vsi(scene, data)?;
-    draw_turn_rate(scene, data)?;
+    scene.end_layer(LayerId::Annunciation)?;
     Ok(())
 }
 

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -51,7 +51,7 @@ pub struct PfdConfig {
     pub v_speeds: Option<VSpeeds>,
 }
 
-/// Draws the PFD from resolved state, in the REN-01 layer bands:
+/// Draws the PFD from resolved state in the scene-layer bands:
 /// optional background, then attitude symbology, tapes, and
 /// annunciations, in ascending z-order. The layers above `Background`
 /// never depend on the background mode, so the critical overlay stays

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -29,13 +29,10 @@ pub struct VSpeeds {
 
 /// What fills the attitude background.
 ///
-/// `Horizon` is the phase-1 2D sky/ground ball. `None` emits no
+/// `Horizon` is the 2D sky/ground fill. `None` emits no
 /// background layer at all: the safety compositor owns that band (a
-/// future SVS raster composes strictly below the critical overlay,
-/// REN-01), and the layers above it are byte-identical either way. A
-/// synthetic-vision *scene* background would slot in as a further
-/// variant carrying its viewport and quality tier (reserved, ADR-0017)
-/// without touching the ladder, tapes, or symbology layers.
+/// hypothetical SVS raster composes strictly below the critical overlay),
+/// and the layers above it are byte-identical either way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BackgroundMode {
     /// Flat-shaded sky-over-ground attitude ball.
@@ -72,7 +69,7 @@ pub fn draw_pfd(
             scene.fill_color(palette::BLACK)?;
             scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
             if att_status.shows_value() {
-                horizon::draw_ball(scene, data.roll_rad.value, data.pitch_rad.value)?;
+                horizon::draw_background(scene, data.roll_rad.value, data.pitch_rad.value)?;
             }
             scene.end_layer(LayerId::Background)?;
         }
@@ -81,6 +78,7 @@ pub fn draw_pfd(
 
     scene.begin_layer(LayerId::Attitude)?;
     if att_status.shows_value() {
+        horizon::draw_horizon_cues(scene, data.roll_rad.value, data.pitch_rad.value)?;
         horizon::draw_roll_scale(scene, data.roll_rad.value)?;
         horizon::draw_aircraft_symbol(scene)?;
     }
@@ -100,6 +98,12 @@ pub fn draw_pfd(
         }
     } else {
         status_paint::draw_red_x(scene, 110.0, 50.0, 260.0, 240.0, "ATT")?;
+    }
+    if data.ias_kt.status == SignalStatus::Failed {
+        status_paint::draw_red_x(scene, 8.0, 60.0, 74.0, 200.0, "IAS")?;
+    }
+    if data.alt_ft.status == SignalStatus::Failed {
+        status_paint::draw_red_x(scene, 398.0, 60.0, 74.0, 200.0, "ALT")?;
     }
     scene.end_layer(LayerId::Annunciation)?;
     Ok(())

--- a/crates/pilotage-instrument-panels/src/pfd/horizon.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/horizon.rs
@@ -1,4 +1,4 @@
-//! Attitude ball: sky/ground, pitch ladder, roll scale, aircraft symbol.
+//! Optional sky/ground fill and critical attitude symbology.
 //!
 //! Geometry follows the G5 proportions: 7.2 px per degree of pitch
 //! (±25° across the 360-px panel height), roll arc radius 144 px
@@ -18,8 +18,8 @@ const ROLL_ARC_R: f32 = 144.0;
 /// the roll arc (the pyG5 clip).
 const LADDER_MAX_Y: f32 = 104.0;
 
-/// Sky, ground, horizon line, and pitch ladder, in the roll-rotated frame.
-pub fn draw_ball(
+/// Optional sky/ground fill in the roll-rotated attitude frame.
+pub fn draw_background(
     scene: &mut SceneWriter<'_>,
     roll_rad: f32,
     pitch_rad: f32,
@@ -36,21 +36,30 @@ pub fn draw_ball(
     scene.rect(PaintMode::Fill, -600.0, -600.0, 1200.0, 600.0 + horizon_y)?;
     scene.fill_color(palette::GROUND)?;
     scene.rect(PaintMode::Fill, -600.0, horizon_y, 1200.0, 1200.0)?;
+    scene.restore()?;
+    Ok(())
+}
+
+/// Critical horizon line and pitch ladder in the attitude frame.
+pub fn draw_horizon_cues(
+    scene: &mut SceneWriter<'_>,
+    roll_rad: f32,
+    pitch_rad: f32,
+) -> Result<(), SceneError> {
+    let horizon_y = pitch_rad * RAD_TO_DEG * PX_PER_DEG_PITCH;
+    scene.save()?;
+    scene.translate(240.0, 180.0)?;
+    scene.rotate(-roll_rad)?;
     scene.stroke(palette::WHITE, 2.0)?;
     scene.line(-600.0, horizon_y, 600.0, horizon_y)?;
-
-    draw_pitch_ladder(scene, pitch_deg, horizon_y)?;
+    draw_pitch_ladder(scene, horizon_y)?;
     scene.restore()?;
     Ok(())
 }
 
 /// Ladder marks every 2.5°, wide labeled bars every 10° (pyG5's
 /// half-width cycle 10/20/10/30).
-fn draw_pitch_ladder(
-    scene: &mut SceneWriter<'_>,
-    _pitch_deg: f32,
-    horizon_y: f32,
-) -> Result<(), SceneError> {
+fn draw_pitch_ladder(scene: &mut SceneWriter<'_>, horizon_y: f32) -> Result<(), SceneError> {
     scene.stroke(palette::WHITE, 2.0)?;
     scene.fill_color(palette::WHITE)?;
     for i in -36..=36i32 {

--- a/crates/pilotage-instrument-panels/src/pfd/tapes.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tapes.rs
@@ -47,10 +47,7 @@ pub fn speed_tape(
             }
         }
         scene.restore()?;
-    } else if ias.status == pilotage_instrument_state::SignalStatus::Failed {
-        status_paint::draw_red_x(scene, 8.0, 60.0, 74.0, 200.0, "IAS")?;
     } else {
-        // Unequipped (`Missing`) is a blank tape, not a failure X.
         scene.fill_color(palette::GREY)?;
         scene.text(45.0, 130.0, 16.0, Anchor::CENTER, "IAS")?;
     }
@@ -181,8 +178,6 @@ pub fn altitude_tape(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<()
             )?;
         }
         scene.restore()?;
-    } else if alt.status == pilotage_instrument_state::SignalStatus::Failed {
-        status_paint::draw_red_x(scene, 398.0, 60.0, 74.0, 200.0, "ALT")?;
     } else {
         scene.fill_color(palette::GREY)?;
         scene.text(435.0, 130.0, 16.0, Anchor::CENTER, "ALT")?;

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -59,6 +59,22 @@ fn texts(scene: &[u8]) -> Vec<String> {
         .collect()
 }
 
+fn layer_texts(scene: &[u8], wanted: LayerId) -> Vec<(String, [f32; 3])> {
+    let mut inside = false;
+    let mut found = Vec::new();
+    for command in SceneCmds::new(scene).expect("valid scene") {
+        match command.expect("valid command") {
+            Cmd::BeginLayer { layer } => inside = layer == wanted,
+            Cmd::EndLayer { layer } if layer == wanted => inside = false,
+            Cmd::Text {
+                x, y, size, text, ..
+            } if inside => found.push((String::from(text), [x, y, size])),
+            _ => {}
+        }
+    }
+    found
+}
+
 fn save_restore_balance(scene: &[u8]) -> i32 {
     SceneCmds::new(scene)
         .expect("valid scene")
@@ -90,6 +106,11 @@ fn missing_attitude_renders_red_x_not_horizon() {
     let scene = render(&data, &PfdConfig::default());
     let labels = texts(&scene);
     assert!(labels.iter().any(|t| t == "ATT"), "ATT flag: {labels:?}");
+    assert!(
+        layer_texts(&scene, LayerId::Annunciation)
+            .contains(&(String::from("ATT"), [240.0, 170.0, 20.0])),
+        "ATT failure must be an annunciation"
+    );
     assert_eq!(save_restore_balance(&scene), 0);
 }
 
@@ -161,7 +182,13 @@ fn scenes_are_layered_for_every_attitude_status() {
 
 #[test]
 fn critical_overlay_is_byte_identical_without_background() {
-    for status in [SignalStatus::Valid, SignalStatus::Failed] {
+    for status in [
+        SignalStatus::Valid,
+        SignalStatus::Degraded,
+        SignalStatus::Stale,
+        SignalStatus::Missing,
+        SignalStatus::Failed,
+    ] {
         let mut data = flying();
         data.roll_rad.status = status;
         data.pitch_rad.status = status;
@@ -185,5 +212,44 @@ fn critical_overlay_is_byte_identical_without_background() {
                 "{status:?} layer {layer:?} content changed with the background"
             );
         }
+        if status.shows_value() {
+            let attitude_text = layer_texts(&without, LayerId::Attitude);
+            assert!(
+                attitude_text.iter().any(|(text, _)| text == "10"),
+                "{status:?} background-free PFD lost its pitch ladder"
+            );
+            assert!(
+                !layer_texts(&with_horizon, LayerId::Background)
+                    .iter()
+                    .any(|(text, _)| text == "10"),
+                "{status:?} pitch ladder must not belong to Background"
+            );
+        }
+    }
+}
+
+#[test]
+fn air_data_failure_cues_are_annunciations() {
+    let mut data = flying();
+    data.ias_kt =
+        pilotage_instrument_state::Sig::with_status(data.ias_kt.value, SignalStatus::Failed);
+    data.alt_ft =
+        pilotage_instrument_state::Sig::with_status(data.alt_ft.value, SignalStatus::Failed);
+    let scene = render(&data, &PfdConfig::default());
+    let annunciations = layer_texts(&scene, LayerId::Annunciation);
+    let tapes = layer_texts(&scene, LayerId::Tapes);
+    for expected in [("IAS", [45.0, 160.0, 20.0]), ("ALT", [435.0, 160.0, 20.0])] {
+        assert!(
+            annunciations
+                .iter()
+                .any(|(text, geometry)| text == expected.0 && *geometry == expected.1),
+            "missing annunciation {expected:?}: {annunciations:?}"
+        );
+        assert!(
+            !tapes
+                .iter()
+                .any(|(text, geometry)| text == expected.0 && *geometry == expected.1),
+            "failure cue leaked into tapes: {tapes:?}"
+        );
     }
 }

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -150,7 +150,7 @@ fn empty_state_still_renders_a_scene() {
     assert_eq!(save_restore_balance(&scene), 0);
 }
 
-// ---- REN-01 layer contract ---------------------------------------------------
+// ---- layer contract ----------------------------------------------------------
 
 use pilotage_instrument_scene::{LayerId, validate_layers};
 use pilotage_instrument_state::SignalStatus;

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -128,3 +128,62 @@ fn empty_state_still_renders_a_scene() {
     assert!(labels.iter().any(|t| t == "ATT"));
     assert_eq!(save_restore_balance(&scene), 0);
 }
+
+// ---- REN-01 layer contract ---------------------------------------------------
+
+use pilotage_instrument_scene::{LayerId, validate_layers};
+use pilotage_instrument_state::SignalStatus;
+
+use super::BackgroundMode;
+
+const PFD_CRITICAL: [LayerId; 3] = [LayerId::Attitude, LayerId::Tapes, LayerId::Annunciation];
+
+#[test]
+fn scenes_are_layered_for_every_attitude_status() {
+    for status in [
+        SignalStatus::Valid,
+        SignalStatus::Degraded,
+        SignalStatus::Stale,
+        SignalStatus::Missing,
+        SignalStatus::Failed,
+    ] {
+        let mut data = flying();
+        data.roll_rad.status = status;
+        data.pitch_rad.status = status;
+        let scene = render(&data, &PfdConfig::default());
+        let report = validate_layers(&scene).expect("layered scene validates");
+        assert!(report.contains(LayerId::Background), "{status:?}");
+        for layer in PFD_CRITICAL {
+            assert!(report.contains(layer), "{status:?} missing {layer:?}");
+        }
+    }
+}
+
+#[test]
+fn critical_overlay_is_byte_identical_without_background() {
+    for status in [SignalStatus::Valid, SignalStatus::Failed] {
+        let mut data = flying();
+        data.roll_rad.status = status;
+        data.pitch_rad.status = status;
+        let with_horizon = render(&data, &PfdConfig::default());
+        let without = render(
+            &data,
+            &PfdConfig {
+                background: BackgroundMode::None,
+                ..PfdConfig::default()
+            },
+        );
+        let horizon_report = validate_layers(&with_horizon).expect("validates");
+        let bare_report = validate_layers(&without).expect("validates");
+        assert!(!bare_report.contains(LayerId::Background));
+        for layer in PFD_CRITICAL {
+            let (hs, he) = horizon_report.ranges[layer.to_u8() as usize].expect("range");
+            let (bs, be) = bare_report.ranges[layer.to_u8() as usize].expect("range");
+            assert_eq!(
+                &with_horizon[hs..he],
+                &without[bs..be],
+                "{status:?} layer {layer:?} content changed with the background"
+            );
+        }
+    }
+}

--- a/crates/pilotage-instrument-scene/Cargo.toml
+++ b/crates/pilotage-instrument-scene/Cargo.toml
@@ -9,3 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/pilotage-instrument-scene/Cargo.toml
+++ b/crates/pilotage-instrument-scene/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 workspace = true
 
 [dependencies]
+thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/pilotage-instrument-scene/src/cmd.rs
+++ b/crates/pilotage-instrument-scene/src/cmd.rs
@@ -1,6 +1,7 @@
 //! The decoded command vocabulary.
 
 use crate::color::Rgba8;
+use crate::layer::LayerId;
 
 /// Longest text payload a single [`Cmd::Text`] may carry, in UTF-8 bytes.
 pub const MAX_TEXT_BYTES: usize = 250;
@@ -253,6 +254,19 @@ pub enum Cmd<'a> {
         w: f32,
         /// Height.
         h: f32,
+    },
+    /// Opens a z-ordered criticality layer (REN-01). Layered scenes obey
+    /// the contract [`crate::validate_layers`] enforces: ascending,
+    /// non-nested, non-repeating, every drawing command inside exactly
+    /// one layer.
+    BeginLayer {
+        /// The layer being opened.
+        layer: LayerId,
+    },
+    /// Closes the open layer; must name the layer that is open.
+    EndLayer {
+        /// The layer being closed.
+        layer: LayerId,
     },
     /// A command from a newer format revision this decoder does not know;
     /// its payload was skipped. Consumers should count these, not fail.

--- a/crates/pilotage-instrument-scene/src/cmd.rs
+++ b/crates/pilotage-instrument-scene/src/cmd.rs
@@ -255,15 +255,14 @@ pub enum Cmd<'a> {
         /// Height.
         h: f32,
     },
-    /// Opens a z-ordered criticality layer (REN-01). Layered scenes obey
-    /// the contract [`crate::validate_layers`] enforces: ascending,
-    /// non-nested, non-repeating, every drawing command inside exactly
-    /// one layer.
+    /// Opens a z-ordered criticality layer. The next command must be the
+    /// outer [`Cmd::Save`] of its state-isolation envelope.
     BeginLayer {
         /// The layer being opened.
         layer: LayerId,
     },
-    /// Closes the open layer; must name the layer that is open.
+    /// Closes the open layer after its outer [`Cmd::Restore`]; must name
+    /// the layer that is open.
     EndLayer {
         /// The layer being closed.
         layer: LayerId,

--- a/crates/pilotage-instrument-scene/src/decode.rs
+++ b/crates/pilotage-instrument-scene/src/decode.rs
@@ -7,16 +7,19 @@ use crate::layer::LayerId;
 use crate::opcode;
 
 /// Why decoding stopped.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeError {
     /// The scene does not start with a version this decoder reads.
+    #[error("unsupported scene format version {found}")]
     BadVersion {
         /// The version byte found.
         found: u8,
     },
     /// The bytes end mid-command.
+    #[error("scene ends in a partial command")]
     Truncated,
     /// A command payload is malformed for its opcode.
+    #[error("opcode 0x{opcode:02x} has a malformed payload")]
     BadPayload {
         /// The opcode whose payload was malformed.
         opcode: u8,
@@ -96,6 +99,13 @@ fn f32_at(payload: &[u8], i: usize) -> Option<f32> {
 fn u32_at(payload: &[u8], byte_at: usize) -> Option<u32> {
     let b = payload.get(byte_at..byte_at.checked_add(4)?)?;
     Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+fn layer_id(opcode: u8, payload: &[u8]) -> Result<LayerId, DecodeError> {
+    let [value] = payload else {
+        return Err(DecodeError::BadPayload { opcode });
+    };
+    LayerId::from_u8(*value).ok_or(DecodeError::BadPayload { opcode })
 }
 
 fn decode_payload(op: u8, payload: &[u8]) -> Result<Cmd<'_>, DecodeError> {
@@ -184,10 +194,10 @@ fn decode_payload(op: u8, payload: &[u8]) -> Result<Cmd<'_>, DecodeError> {
         // opcode: content whose criticality cannot be placed must not
         // be painted (REN-01). New layer ids require a version bump.
         opcode::BEGIN_LAYER => Ok(Cmd::BeginLayer {
-            layer: LayerId::from_u8(*payload.first().ok_or(bad)?).ok_or(bad)?,
+            layer: layer_id(op, payload)?,
         }),
         opcode::END_LAYER => Ok(Cmd::EndLayer {
-            layer: LayerId::from_u8(*payload.first().ok_or(bad)?).ok_or(bad)?,
+            layer: layer_id(op, payload)?,
         }),
         other => Ok(Cmd::Unknown { opcode: other }),
     }

--- a/crates/pilotage-instrument-scene/src/decode.rs
+++ b/crates/pilotage-instrument-scene/src/decode.rs
@@ -192,7 +192,7 @@ fn decode_payload(op: u8, payload: &[u8]) -> Result<Cmd<'_>, DecodeError> {
         }),
         // An unknown layer *id* is a hard error, unlike an unknown
         // opcode: content whose criticality cannot be placed must not
-        // be painted (REN-01). New layer ids require a version bump.
+        // be painted. New layer ids require a version bump.
         opcode::BEGIN_LAYER => Ok(Cmd::BeginLayer {
             layer: layer_id(op, payload)?,
         }),

--- a/crates/pilotage-instrument-scene/src/decode.rs
+++ b/crates/pilotage-instrument-scene/src/decode.rs
@@ -3,6 +3,7 @@
 use crate::SCENE_FORMAT_VERSION;
 use crate::cmd::{Anchor, Cmd, PaintMode, PointsRef};
 use crate::color::Rgba8;
+use crate::layer::LayerId;
 use crate::opcode;
 
 /// Why decoding stopped.
@@ -44,6 +45,13 @@ impl<'a> SceneCmds<'a> {
             Some((&v, _)) => Err(DecodeError::BadVersion { found: v }),
             None => Err(DecodeError::Truncated),
         }
+    }
+
+    /// Bytes not yet consumed. `scene.len() - remaining()` is the offset
+    /// of the next command, which is how [`crate::validate_layers`]
+    /// reports per-layer byte ranges without allocating.
+    pub fn remaining(&self) -> usize {
+        self.rest.len()
     }
 
     fn take_cmd(&mut self) -> Result<Cmd<'a>, DecodeError> {
@@ -171,6 +179,15 @@ fn decode_payload(op: u8, payload: &[u8]) -> Result<Cmd<'_>, DecodeError> {
             y: f32_at(payload, 1).ok_or(bad)?,
             w: f32_at(payload, 2).ok_or(bad)?,
             h: f32_at(payload, 3).ok_or(bad)?,
+        }),
+        // An unknown layer *id* is a hard error, unlike an unknown
+        // opcode: content whose criticality cannot be placed must not
+        // be painted (REN-01). New layer ids require a version bump.
+        opcode::BEGIN_LAYER => Ok(Cmd::BeginLayer {
+            layer: LayerId::from_u8(*payload.first().ok_or(bad)?).ok_or(bad)?,
+        }),
+        opcode::END_LAYER => Ok(Cmd::EndLayer {
+            layer: LayerId::from_u8(*payload.first().ok_or(bad)?).ok_or(bad)?,
         }),
         other => Ok(Cmd::Unknown { opcode: other }),
     }

--- a/crates/pilotage-instrument-scene/src/encode.rs
+++ b/crates/pilotage-instrument-scene/src/encode.rs
@@ -238,6 +238,19 @@ impl<'a> SceneWriter<'a> {
     pub fn clip_rect(&mut self, x: f32, y: f32, w: f32, h: f32) -> Result<(), SceneError> {
         self.cmd_f32(opcode::CLIP_RECT, &[], &[x, y, w, h])
     }
+
+    /// Opens layer `layer` (REN-01). Layered scenes emit each layer at
+    /// most once, in ascending order, unnested, with every drawing
+    /// command inside a layer — [`crate::validate_layers`] enforces the
+    /// contract.
+    pub fn begin_layer(&mut self, layer: crate::layer::LayerId) -> Result<(), SceneError> {
+        self.cmd(opcode::BEGIN_LAYER, &[&[layer.to_u8()]])
+    }
+
+    /// Closes layer `layer`; must match the open layer.
+    pub fn end_layer(&mut self, layer: crate::layer::LayerId) -> Result<(), SceneError> {
+        self.cmd(opcode::END_LAYER, &[&[layer.to_u8()]])
+    }
 }
 
 #[cfg(test)]

--- a/crates/pilotage-instrument-scene/src/encode.rs
+++ b/crates/pilotage-instrument-scene/src/encode.rs
@@ -239,17 +239,31 @@ impl<'a> SceneWriter<'a> {
         self.cmd_f32(opcode::CLIP_RECT, &[], &[x, y, w, h])
     }
 
-    /// Opens layer `layer` (REN-01). Layered scenes emit each layer at
-    /// most once, in ascending order, unnested, with every drawing
-    /// command inside a layer — [`crate::validate_layers`] enforces the
-    /// contract.
+    /// Opens layer `layer` and saves the complete graphics state.
+    ///
+    /// The save is part of the wire contract, so a backend that skips the
+    /// layer marker as an unknown opcode still isolates transforms, clips,
+    /// and paint state. [`crate::validate_layers`] requires the matching
+    /// outer restore before [`Self::end_layer`].
     pub fn begin_layer(&mut self, layer: crate::layer::LayerId) -> Result<(), SceneError> {
-        self.cmd(opcode::BEGIN_LAYER, &[&[layer.to_u8()]])
+        let rollback = self.len;
+        self.cmd(opcode::BEGIN_LAYER, &[&[layer.to_u8()]])?;
+        if let Err(error) = self.save() {
+            self.len = rollback;
+            return Err(error);
+        }
+        Ok(())
     }
 
-    /// Closes layer `layer`; must match the open layer.
+    /// Restores the layer-entry graphics state and closes `layer`.
     pub fn end_layer(&mut self, layer: crate::layer::LayerId) -> Result<(), SceneError> {
-        self.cmd(opcode::END_LAYER, &[&[layer.to_u8()]])
+        let rollback = self.len;
+        self.restore()?;
+        if let Err(error) = self.cmd(opcode::END_LAYER, &[&[layer.to_u8()]]) {
+            self.len = rollback;
+            return Err(error);
+        }
+        Ok(())
     }
 }
 

--- a/crates/pilotage-instrument-scene/src/encode/tests.rs
+++ b/crates/pilotage-instrument-scene/src/encode/tests.rs
@@ -5,6 +5,7 @@ use crate::cmd::{Anchor, Cmd, PaintMode};
 use crate::color::Rgba8;
 use crate::decode::SceneCmds;
 use crate::encode::{SceneError, SceneWriter};
+use crate::layer::LayerId;
 
 fn decode_all(scene: &[u8]) -> alloc_free_vec::CmdVec<'_> {
     let cmds = SceneCmds::new(scene).expect("valid scene header");
@@ -123,6 +124,27 @@ fn overflowing_command_rolls_back_whole() {
     // The failed command must leave no partial bytes behind.
     assert_eq!(w.len(), 1);
     w.save().expect("small command still fits after rollback");
+}
+
+#[test]
+fn layer_state_envelope_rolls_back_as_one_unit() {
+    let mut begin_buf = [0u8; 7];
+    let mut begin = SceneWriter::new(&mut begin_buf).expect("version fits");
+    assert_eq!(
+        begin.begin_layer(LayerId::Background),
+        Err(SceneError::BufferFull)
+    );
+    assert_eq!(begin.len(), 1, "orphan begin marker must roll back");
+
+    let mut end_buf = [0u8; 11];
+    let mut end = SceneWriter::new(&mut end_buf).expect("version fits");
+    end.begin_layer(LayerId::Background)
+        .expect("begin envelope fits");
+    assert_eq!(
+        end.end_layer(LayerId::Background),
+        Err(SceneError::BufferFull)
+    );
+    assert_eq!(end.len(), 8, "orphan restore must roll back");
 }
 
 #[test]

--- a/crates/pilotage-instrument-scene/src/layer.rs
+++ b/crates/pilotage-instrument-scene/src/layer.rs
@@ -1,0 +1,285 @@
+//! The frozen scene-layer and safety-compositor contract (REN-01).
+//!
+//! A *layered scene* partitions its commands into bounded, named,
+//! z-ordered criticality bands so a compositor can guarantee that
+//! optional background imagery never covers, suppresses, or prevents
+//! primary flight information, warnings, or failure indications
+//! (AC 25-11B's mixed-criticality display concern, applied to this IR).
+//!
+//! Contract rules, enforced by [`validate_layers`]:
+//!
+//! - Each present layer appears at most once, opened and closed by
+//!   matching [`Cmd::BeginLayer`]/[`Cmd::EndLayer`] markers, in strictly
+//!   ascending [`LayerId`] order. Encoding order *is* z-order: painters
+//!   run the commands front to back exactly as encoded, so a validated
+//!   scene cannot paint background over a critical band.
+//! - Layers never nest, and every drawing command sits inside exactly
+//!   one layer.
+//! - Transform/clip state saved inside a layer is restored inside it:
+//!   a restore below the layer's entry depth or a save left open at the
+//!   layer's end fails the frame, so one band's clip or transform can
+//!   never leak into a higher-criticality band.
+//! - Frames are bounded: at most [`MAX_LAYER_COMMANDS`] commands per
+//!   layer and [`MAX_SCENE_BYTES`] encoded bytes per scene.
+//! - Unknown *opcodes* inside a layer are counted skips (version
+//!   policy, ADR-0017); an unknown *layer id* fails the whole frame at
+//!   decode, because content whose criticality cannot be placed must
+//!   not be painted. Extending [`LayerId`] therefore requires a scene
+//!   format version bump, unlike ordinary appended opcodes.
+//! - One frame is one encoded scene; frame generation/identity is the
+//!   transport's concern (e.g. the WASM render generation), not encoded
+//!   per layer. Each layer is owned by exactly one producer per frame —
+//!   the duplicate rule makes split ownership structurally impossible.
+//!
+//! The SVS/raster boundary: backend-owned raster or depth imagery (a
+//! future SVS terrain layer) composes strictly *below* [`LayerId::Attitude`],
+//! in the band [`LayerId::Background`] occupies. A scene rendered with no
+//! background layer at all must still contain its complete critical
+//! overlay — panels guarantee that, and the invariance is pinned by
+//! tests in `pilotage-instrument-panels`.
+
+use crate::cmd::Cmd;
+use crate::decode::{DecodeError, SceneCmds};
+
+/// Number of defined layers.
+pub const LAYER_COUNT: usize = 6;
+
+/// Most commands one layer may carry.
+pub const MAX_LAYER_COMMANDS: usize = 4096;
+
+/// Largest encoded scene a conforming backend must accept.
+pub const MAX_SCENE_BYTES: usize = 64 * 1024;
+
+/// Z-ordered, criticality-banded scene layers.
+///
+/// The discriminant is both the wire encoding and the z-order: greater
+/// values paint later (above) and carry higher display criticality.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LayerId {
+    /// Optional imagery only: attitude ball shading today, SVS raster
+    /// later. The single band a compositor may replace or drop.
+    Background = 0,
+    /// Primary attitude symbology: pitch ladder frame, roll scale,
+    /// aircraft reference.
+    Attitude = 1,
+    /// Tapes and readouts: speed/altitude/VSI tapes, data boxes.
+    Tapes = 2,
+    /// Navigation guidance: CDI, deviation scales.
+    Guidance = 3,
+    /// Flags, miscompares, and failure annunciations over everything
+    /// they annunciate.
+    Annunciation = 4,
+    /// Display-level failure/reversion content; nothing may cover it.
+    Failure = 5,
+}
+
+impl LayerId {
+    /// Wire encoding.
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte; `None` for ids this revision cannot place.
+    pub const fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Background),
+            1 => Some(Self::Attitude),
+            2 => Some(Self::Tapes),
+            3 => Some(Self::Guidance),
+            4 => Some(Self::Annunciation),
+            5 => Some(Self::Failure),
+            _ => None,
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Why a scene failed layer validation. Any of these fails the whole
+/// frame before anything becomes visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerError {
+    /// The command stream itself is malformed (truncated, bad version,
+    /// bad payload — including an unknown layer id).
+    Decode(DecodeError),
+    /// A layer was opened twice in one frame.
+    DuplicateLayer {
+        /// The layer opened again.
+        layer: LayerId,
+    },
+    /// A layer was opened at or below the previously opened layer's
+    /// z-order.
+    OutOfOrder {
+        /// The layer opened out of order.
+        layer: LayerId,
+    },
+    /// A layer was opened while another was still open.
+    NestedLayer {
+        /// The layer whose open marker nested.
+        layer: LayerId,
+    },
+    /// An end marker appeared with no layer open.
+    EndWithoutBegin {
+        /// The layer the stray end marker named.
+        layer: LayerId,
+    },
+    /// An end marker named a different layer than the open one.
+    EndMismatch {
+        /// The layer currently open.
+        open: LayerId,
+        /// The layer the end marker named.
+        end: LayerId,
+    },
+    /// The scene ended with a layer still open (typically truncation at
+    /// a command boundary).
+    UnclosedLayer {
+        /// The layer left open.
+        layer: LayerId,
+    },
+    /// A command appeared outside any layer.
+    CommandOutsideLayer,
+    /// A restore below the layer's entry depth, or a save left open at
+    /// the layer's end — state would leak across criticality bands.
+    UnbalancedState {
+        /// The layer whose save/restore pairing broke.
+        layer: LayerId,
+    },
+    /// A layer exceeded [`MAX_LAYER_COMMANDS`].
+    OverCapacity {
+        /// The over-budget layer.
+        layer: LayerId,
+    },
+    /// The encoded scene exceeds [`MAX_SCENE_BYTES`].
+    SceneTooLarge {
+        /// The encoded byte length.
+        bytes: usize,
+    },
+}
+
+impl From<DecodeError> for LayerError {
+    fn from(error: DecodeError) -> Self {
+        Self::Decode(error)
+    }
+}
+
+/// What a validated layered scene contains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LayerReport {
+    /// Bit `i` set means the layer with discriminant `i` is present.
+    pub present: u8,
+    /// Command count per layer (markers excluded).
+    pub commands: [u16; LAYER_COUNT],
+    /// Byte range of each present layer's contents (between, excluding,
+    /// its markers), as offsets into the encoded scene. Byte-identical
+    /// ranges across two scenes mean byte-identical layer content —
+    /// the hook for critical-overlay invariance tests.
+    pub ranges: [Option<(usize, usize)>; LAYER_COUNT],
+    /// Unknown opcodes skipped inside layers (version policy).
+    pub unknown: u32,
+}
+
+impl LayerReport {
+    /// Whether `layer` is present.
+    pub const fn contains(&self, layer: LayerId) -> bool {
+        self.present & (1 << layer.index()) != 0
+    }
+}
+
+struct OpenLayer {
+    id: LayerId,
+    content_start: usize,
+    saves: u32,
+}
+
+/// Validates the layered-scene contract over an encoded scene and
+/// reports what it contains. Structural corruption, ordering violations,
+/// state leaks, and budget violations all fail the frame — a backend
+/// must run this (or enforce the same rules) before anything becomes
+/// visible.
+pub fn validate_layers(scene: &[u8]) -> Result<LayerReport, LayerError> {
+    if scene.len() > MAX_SCENE_BYTES {
+        return Err(LayerError::SceneTooLarge { bytes: scene.len() });
+    }
+    let mut cmds = SceneCmds::new(scene)?;
+    let mut report = LayerReport::default();
+    let mut open: Option<OpenLayer> = None;
+    let mut last_opened: Option<LayerId> = None;
+
+    loop {
+        let at = scene.len() - cmds.remaining();
+        let Some(cmd) = cmds.next() else { break };
+        match cmd? {
+            Cmd::BeginLayer { layer } => {
+                if open.is_some() {
+                    return Err(LayerError::NestedLayer { layer });
+                }
+                if report.contains(layer) {
+                    return Err(LayerError::DuplicateLayer { layer });
+                }
+                if let Some(prev) = last_opened
+                    && layer <= prev
+                {
+                    return Err(LayerError::OutOfOrder { layer });
+                }
+                last_opened = Some(layer);
+                open = Some(OpenLayer {
+                    id: layer,
+                    content_start: scene.len() - cmds.remaining(),
+                    saves: 0,
+                });
+            }
+            Cmd::EndLayer { layer } => {
+                let Some(inside) = open.take() else {
+                    return Err(LayerError::EndWithoutBegin { layer });
+                };
+                if inside.id != layer {
+                    return Err(LayerError::EndMismatch {
+                        open: inside.id,
+                        end: layer,
+                    });
+                }
+                if inside.saves != 0 {
+                    return Err(LayerError::UnbalancedState { layer });
+                }
+                report.present |= 1 << layer.index();
+                if let Some(range) = report.ranges.get_mut(layer.index()) {
+                    *range = Some((inside.content_start, at));
+                }
+            }
+            other => {
+                let Some(inside) = open.as_mut() else {
+                    return Err(LayerError::CommandOutsideLayer);
+                };
+                match other {
+                    Cmd::Save => inside.saves += 1,
+                    Cmd::Restore => {
+                        inside.saves = inside
+                            .saves
+                            .checked_sub(1)
+                            .ok_or(LayerError::UnbalancedState { layer: inside.id })?;
+                    }
+                    Cmd::Unknown { .. } => report.unknown += 1,
+                    _ => {}
+                }
+                let count = report
+                    .commands
+                    .get_mut(inside.id.index())
+                    .ok_or(LayerError::OverCapacity { layer: inside.id })?;
+                if usize::from(*count) >= MAX_LAYER_COMMANDS {
+                    return Err(LayerError::OverCapacity { layer: inside.id });
+                }
+                *count += 1;
+            }
+        }
+    }
+    if let Some(inside) = open {
+        return Err(LayerError::UnclosedLayer { layer: inside.id });
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-scene/src/layer.rs
+++ b/crates/pilotage-instrument-scene/src/layer.rs
@@ -1,4 +1,4 @@
-//! The frozen scene-layer and safety-compositor contract (REN-01).
+//! The frozen scene-layer and safety-compositor contract.
 //!
 //! A *layered scene* partitions its commands into bounded, named,
 //! z-ordered criticality bands so a compositor can guarantee that
@@ -119,7 +119,7 @@ pub enum LayerError {
         /// The layer opened again.
         layer: LayerId,
     },
-    /// A layer was opened at or below the previously opened layer's
+    /// A layer was opened at or below the most recently opened layer's
     /// z-order.
     #[error("layer {layer:?} is not in strictly ascending order")]
     OutOfOrder {

--- a/crates/pilotage-instrument-scene/src/layer.rs
+++ b/crates/pilotage-instrument-scene/src/layer.rs
@@ -15,12 +15,13 @@
 //!   scene cannot paint background over a critical band.
 //! - Layers never nest, and every drawing command sits inside exactly
 //!   one layer.
-//! - Transform/clip state saved inside a layer is restored inside it:
-//!   a restore below the layer's entry depth or a save left open at the
-//!   layer's end fails the frame, so one band's clip or transform can
-//!   never leak into a higher-criticality band.
+//! - Every layer contains one mandatory outer save/restore envelope.
+//!   Commands outside that envelope, a restore below it, or a save left
+//!   open at layer end fail the frame. The envelope covers transform,
+//!   clip, and paint state, so no lower band can affect a higher band.
 //! - Frames are bounded: at most [`MAX_LAYER_COMMANDS`] commands per
-//!   layer and [`MAX_SCENE_BYTES`] encoded bytes per scene.
+//!   layer, [`MAX_STACK_DEPTH`] saved graphics states, and
+//!   [`MAX_SCENE_BYTES`] encoded bytes per scene.
 //! - Unknown *opcodes* inside a layer are counted skips (version
 //!   policy, ADR-0017); an unknown *layer id* fails the whole frame at
 //!   decode, because content whose criticality cannot be placed must
@@ -31,8 +32,8 @@
 //!   per layer. Each layer is owned by exactly one producer per frame —
 //!   the duplicate rule makes split ownership structurally impossible.
 //!
-//! The SVS/raster boundary: backend-owned raster or depth imagery (a
-//! future SVS terrain layer) composes strictly *below* [`LayerId::Attitude`],
+//! The SVS/raster boundary: backend-owned raster or depth imagery (such
+//! as an SVS terrain layer) composes strictly *below* [`LayerId::Attitude`],
 //! in the band [`LayerId::Background`] occupies. A scene rendered with no
 //! background layer at all must still contain its complete critical
 //! overlay — panels guarantee that, and the invariance is pinned by
@@ -47,6 +48,12 @@ pub const LAYER_COUNT: usize = 6;
 /// Most commands one layer may carry.
 pub const MAX_LAYER_COMMANDS: usize = 4096;
 
+/// Deepest graphics-state stack accepted inside one layer.
+///
+/// The mandatory layer-isolation save occupies depth one. Panel drawing
+/// code may therefore nest at most 31 additional saves.
+pub const MAX_STACK_DEPTH: usize = 32;
+
 /// Largest encoded scene a conforming backend must accept.
 pub const MAX_SCENE_BYTES: usize = 64 * 1024;
 
@@ -57,8 +64,8 @@ pub const MAX_SCENE_BYTES: usize = 64 * 1024;
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LayerId {
-    /// Optional imagery only: attitude ball shading today, SVS raster
-    /// later. The single band a compositor may replace or drop.
+    /// Optional imagery only: flat attitude shading or an SVS raster.
+    /// The single band a compositor may replace or drop.
     Background = 0,
     /// Primary attitude symbology: pitch ladder frame, roll scale,
     /// aircraft reference.
@@ -100,33 +107,39 @@ impl LayerId {
 
 /// Why a scene failed layer validation. Any of these fails the whole
 /// frame before anything becomes visible.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum LayerError {
     /// The command stream itself is malformed (truncated, bad version,
     /// bad payload — including an unknown layer id).
-    Decode(DecodeError),
+    #[error("scene decoding failed: {0}")]
+    Decode(#[from] DecodeError),
     /// A layer was opened twice in one frame.
+    #[error("layer {layer:?} appears more than once")]
     DuplicateLayer {
         /// The layer opened again.
         layer: LayerId,
     },
     /// A layer was opened at or below the previously opened layer's
     /// z-order.
+    #[error("layer {layer:?} is not in strictly ascending order")]
     OutOfOrder {
         /// The layer opened out of order.
         layer: LayerId,
     },
     /// A layer was opened while another was still open.
+    #[error("layer {layer:?} is nested inside another layer")]
     NestedLayer {
         /// The layer whose open marker nested.
         layer: LayerId,
     },
     /// An end marker appeared with no layer open.
+    #[error("layer {layer:?} ends without a matching begin marker")]
     EndWithoutBegin {
         /// The layer the stray end marker named.
         layer: LayerId,
     },
     /// An end marker named a different layer than the open one.
+    #[error("layer {end:?} ends while {open:?} is open")]
     EndMismatch {
         /// The layer currently open.
         open: LayerId,
@@ -135,34 +148,48 @@ pub enum LayerError {
     },
     /// The scene ended with a layer still open (typically truncation at
     /// a command boundary).
+    #[error("layer {layer:?} is not closed")]
     UnclosedLayer {
         /// The layer left open.
         layer: LayerId,
     },
     /// A command appeared outside any layer.
+    #[error("drawing command appears outside a layer")]
     CommandOutsideLayer,
-    /// A restore below the layer's entry depth, or a save left open at
-    /// the layer's end — state would leak across criticality bands.
+    /// A command appeared before the isolation save or after its matching
+    /// restore.
+    #[error("layer {layer:?} has a command outside its state-isolation envelope")]
+    UnisolatedState {
+        /// The layer that did not isolate all commands.
+        layer: LayerId,
+    },
+    /// A restore crossed the layer isolation boundary, or a save was left
+    /// open at layer end.
+    #[error("layer {layer:?} has unbalanced graphics state")]
     UnbalancedState {
         /// The layer whose save/restore pairing broke.
         layer: LayerId,
     },
+    /// A layer exceeded [`MAX_STACK_DEPTH`].
+    #[error("layer {layer:?} requests graphics-state depth {depth}")]
+    StackOverCapacity {
+        /// The over-budget layer.
+        layer: LayerId,
+        /// The depth the rejected save would create.
+        depth: usize,
+    },
     /// A layer exceeded [`MAX_LAYER_COMMANDS`].
+    #[error("layer {layer:?} exceeds the command budget")]
     OverCapacity {
         /// The over-budget layer.
         layer: LayerId,
     },
     /// The encoded scene exceeds [`MAX_SCENE_BYTES`].
+    #[error("scene uses {bytes} encoded bytes")]
     SceneTooLarge {
         /// The encoded byte length.
         bytes: usize,
     },
-}
-
-impl From<DecodeError> for LayerError {
-    fn from(error: DecodeError) -> Self {
-        Self::Decode(error)
-    }
 }
 
 /// What a validated layered scene contains.
@@ -172,10 +199,9 @@ pub struct LayerReport {
     pub present: u8,
     /// Command count per layer (markers excluded).
     pub commands: [u16; LAYER_COUNT],
-    /// Byte range of each present layer's contents (between, excluding,
-    /// its markers), as offsets into the encoded scene. Byte-identical
-    /// ranges across two scenes mean byte-identical layer content —
-    /// the hook for critical-overlay invariance tests.
+    /// Byte range of each present layer's contents, including its outer
+    /// Save/Restore but excluding its markers, as offsets into the encoded
+    /// scene. Equal ranges across two scenes identify equal layer content.
     pub ranges: [Option<(usize, usize)>; LAYER_COUNT],
     /// Unknown opcodes skipped inside layers (version policy).
     pub unknown: u32,
@@ -188,10 +214,137 @@ impl LayerReport {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IsolationState {
+    AwaitingSave,
+    Active,
+    Closed,
+}
+
 struct OpenLayer {
     id: LayerId,
     content_start: usize,
-    saves: u32,
+    depth: usize,
+    isolation: IsolationState,
+}
+
+impl OpenLayer {
+    fn new(id: LayerId, content_start: usize) -> Self {
+        Self {
+            id,
+            content_start,
+            depth: 0,
+            isolation: IsolationState::AwaitingSave,
+        }
+    }
+
+    fn accept(&mut self, command: &Cmd<'_>) -> Result<(), LayerError> {
+        match command {
+            Cmd::Save => self.push_state(),
+            Cmd::Restore => self.pop_state(),
+            _ if self.isolation == IsolationState::Active => Ok(()),
+            _ => Err(LayerError::UnisolatedState { layer: self.id }),
+        }
+    }
+
+    fn push_state(&mut self) -> Result<(), LayerError> {
+        if self.isolation == IsolationState::Closed {
+            return Err(LayerError::UnisolatedState { layer: self.id });
+        }
+        let depth = self.depth.saturating_add(1);
+        if depth > MAX_STACK_DEPTH {
+            return Err(LayerError::StackOverCapacity {
+                layer: self.id,
+                depth,
+            });
+        }
+        self.depth = depth;
+        self.isolation = IsolationState::Active;
+        Ok(())
+    }
+
+    fn pop_state(&mut self) -> Result<(), LayerError> {
+        if self.isolation != IsolationState::Active || self.depth == 0 {
+            return Err(LayerError::UnbalancedState { layer: self.id });
+        }
+        self.depth -= 1;
+        if self.depth == 0 {
+            self.isolation = IsolationState::Closed;
+        }
+        Ok(())
+    }
+
+    fn finish(&self) -> Result<(), LayerError> {
+        if self.isolation == IsolationState::Closed && self.depth == 0 {
+            Ok(())
+        } else {
+            Err(LayerError::UnbalancedState { layer: self.id })
+        }
+    }
+}
+
+fn open_layer(
+    report: &LayerReport,
+    open: &mut Option<OpenLayer>,
+    last_opened: &mut Option<LayerId>,
+    layer: LayerId,
+    content_start: usize,
+) -> Result<(), LayerError> {
+    if open.is_some() {
+        return Err(LayerError::NestedLayer { layer });
+    }
+    if report.contains(layer) {
+        return Err(LayerError::DuplicateLayer { layer });
+    }
+    if last_opened.is_some_and(|previous| layer <= previous) {
+        return Err(LayerError::OutOfOrder { layer });
+    }
+    *last_opened = Some(layer);
+    *open = Some(OpenLayer::new(layer, content_start));
+    Ok(())
+}
+
+fn close_layer(
+    report: &mut LayerReport,
+    open: &mut Option<OpenLayer>,
+    layer: LayerId,
+    content_end: usize,
+) -> Result<(), LayerError> {
+    let Some(inside) = open.take() else {
+        return Err(LayerError::EndWithoutBegin { layer });
+    };
+    if inside.id != layer {
+        return Err(LayerError::EndMismatch {
+            open: inside.id,
+            end: layer,
+        });
+    }
+    inside.finish()?;
+    report.present |= 1 << layer.index();
+    if let Some(range) = report.ranges.get_mut(layer.index()) {
+        *range = Some((inside.content_start, content_end));
+    }
+    Ok(())
+}
+
+fn record_command(
+    report: &mut LayerReport,
+    inside: &mut OpenLayer,
+    command: Cmd<'_>,
+) -> Result<(), LayerError> {
+    inside.accept(&command)?;
+    let count = report
+        .commands
+        .get_mut(inside.id.index())
+        .ok_or(LayerError::OverCapacity { layer: inside.id })?;
+    if usize::from(*count) >= MAX_LAYER_COMMANDS {
+        return Err(LayerError::OverCapacity { layer: inside.id });
+    }
+    *count = count.wrapping_add(1);
+    if matches!(command, Cmd::Unknown { .. }) {
+        report.unknown = report.unknown.wrapping_add(1);
+    }
+    Ok(())
 }
 
 /// Validates the layered-scene contract over an encoded scene and
@@ -213,65 +366,17 @@ pub fn validate_layers(scene: &[u8]) -> Result<LayerReport, LayerError> {
         let Some(cmd) = cmds.next() else { break };
         match cmd? {
             Cmd::BeginLayer { layer } => {
-                if open.is_some() {
-                    return Err(LayerError::NestedLayer { layer });
-                }
-                if report.contains(layer) {
-                    return Err(LayerError::DuplicateLayer { layer });
-                }
-                if let Some(prev) = last_opened
-                    && layer <= prev
-                {
-                    return Err(LayerError::OutOfOrder { layer });
-                }
-                last_opened = Some(layer);
-                open = Some(OpenLayer {
-                    id: layer,
-                    content_start: scene.len() - cmds.remaining(),
-                    saves: 0,
-                });
+                let content_start = scene.len() - cmds.remaining();
+                open_layer(&report, &mut open, &mut last_opened, layer, content_start)?;
             }
             Cmd::EndLayer { layer } => {
-                let Some(inside) = open.take() else {
-                    return Err(LayerError::EndWithoutBegin { layer });
-                };
-                if inside.id != layer {
-                    return Err(LayerError::EndMismatch {
-                        open: inside.id,
-                        end: layer,
-                    });
-                }
-                if inside.saves != 0 {
-                    return Err(LayerError::UnbalancedState { layer });
-                }
-                report.present |= 1 << layer.index();
-                if let Some(range) = report.ranges.get_mut(layer.index()) {
-                    *range = Some((inside.content_start, at));
-                }
+                close_layer(&mut report, &mut open, layer, at)?;
             }
-            other => {
+            command => {
                 let Some(inside) = open.as_mut() else {
                     return Err(LayerError::CommandOutsideLayer);
                 };
-                match other {
-                    Cmd::Save => inside.saves += 1,
-                    Cmd::Restore => {
-                        inside.saves = inside
-                            .saves
-                            .checked_sub(1)
-                            .ok_or(LayerError::UnbalancedState { layer: inside.id })?;
-                    }
-                    Cmd::Unknown { .. } => report.unknown += 1,
-                    _ => {}
-                }
-                let count = report
-                    .commands
-                    .get_mut(inside.id.index())
-                    .ok_or(LayerError::OverCapacity { layer: inside.id })?;
-                if usize::from(*count) >= MAX_LAYER_COMMANDS {
-                    return Err(LayerError::OverCapacity { layer: inside.id });
-                }
-                *count += 1;
+                record_command(&mut report, inside, command)?;
             }
         }
     }

--- a/crates/pilotage-instrument-scene/src/layer/tests.rs
+++ b/crates/pilotage-instrument-scene/src/layer/tests.rs
@@ -7,7 +7,8 @@ use crate::cmd::PaintMode;
 use crate::decode::DecodeError;
 use crate::encode::SceneWriter;
 use crate::layer::{
-    LAYER_COUNT, LayerError, LayerId, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES, validate_layers,
+    LAYER_COUNT, LayerError, LayerId, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES, MAX_STACK_DEPTH,
+    validate_layers,
 };
 
 const ALL: [LayerId; LAYER_COUNT] = [
@@ -34,6 +35,25 @@ fn simple_layer(w: &mut SceneWriter<'_>, layer: LayerId) {
     w.end_layer(layer).expect("end");
 }
 
+fn layer_without_entry_save(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+    let mut bytes = scene(|writer| {
+        writer.begin_layer(LayerId::Background).expect("begin");
+        build(writer);
+        writer.end_layer(LayerId::Background).expect("end");
+    });
+    assert_eq!(&bytes[5..8], &[0x01, 0, 0], "mandatory entry save");
+    bytes.drain(5..8);
+    bytes
+}
+
+fn single_raw_command(opcode: u8, payload: &[u8]) -> Vec<u8> {
+    let payload_len = u16::try_from(payload.len()).expect("test payload fits");
+    let mut bytes = std::vec![crate::SCENE_FORMAT_VERSION, opcode];
+    bytes.extend_from_slice(&payload_len.to_le_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
 #[test]
 fn every_ascending_subset_is_legal() {
     for mask in 0u8..(1 << LAYER_COUNT) {
@@ -49,7 +69,7 @@ fn every_ascending_subset_is_legal() {
         for layer in ALL {
             assert_eq!(report.contains(layer), mask & (1 << layer.to_u8()) != 0);
             if report.contains(layer) {
-                assert_eq!(report.commands[layer.to_u8() as usize], 1);
+                assert_eq!(report.commands[layer.to_u8() as usize], 3);
             }
         }
     }
@@ -93,9 +113,7 @@ fn structural_violations_fail_the_frame() {
         })
     );
 
-    let stray_end = scene(|w| {
-        w.end_layer(LayerId::Tapes).expect("end");
-    });
+    let stray_end = single_raw_command(0x51, &[LayerId::Tapes.to_u8()]);
     assert_eq!(
         validate_layers(&stray_end),
         Err(LayerError::EndWithoutBegin {
@@ -174,6 +192,20 @@ fn state_leaks_across_layers_fail_the_frame() {
         w.end_layer(LayerId::Background).expect("end");
     });
     assert!(validate_layers(&balanced).is_ok());
+
+    let base_state_leaks = [
+        layer_without_entry_save(|w| w.translate(10.0, 20.0).expect("translate")),
+        layer_without_entry_save(|w| w.clip_rect(0.0, 0.0, 1.0, 1.0).expect("clip")),
+        layer_without_entry_save(|w| w.fill_color(crate::Rgba8::rgb(1, 2, 3)).expect("fill")),
+    ];
+    for bytes in base_state_leaks {
+        assert_eq!(
+            validate_layers(&bytes),
+            Err(LayerError::UnisolatedState {
+                layer: LayerId::Background
+            })
+        );
+    }
 }
 
 #[test]
@@ -184,11 +216,11 @@ fn unknown_opcodes_skip_inside_layers_but_unknown_layer_ids_fail() {
         w.begin_layer(LayerId::Background).expect("begin");
         w.end_layer(LayerId::Background).expect("end");
     });
-    // Splice an unknown 0x7f command (empty payload) between the markers.
-    inside.splice(5..5, [0x7f, 0, 0]);
+    // Splice an unknown 0x7f command inside the state-isolation envelope.
+    inside.splice(8..8, [0x7f, 0, 0]);
     let report = validate_layers(&inside).expect("skips unknown opcode");
     assert_eq!(report.unknown, 1);
-    assert_eq!(report.commands[0], 1);
+    assert_eq!(report.commands[0], 3);
 
     // The same unknown opcode outside any layer cannot be placed.
     let outside = {
@@ -211,6 +243,18 @@ fn unknown_opcodes_skip_inside_layers_but_unknown_layer_ids_fail() {
         validate_layers(&bad_id),
         Err(LayerError::Decode(DecodeError::BadPayload { opcode: 0x50 }))
     );
+
+    for (opcode, payload) in [
+        (0x50, &[][..]),
+        (0x50, &[0, 0][..]),
+        (0x51, &[][..]),
+        (0x51, &[0, 0][..]),
+    ] {
+        assert_eq!(
+            validate_layers(&single_raw_command(opcode, payload)),
+            Err(LayerError::Decode(DecodeError::BadPayload { opcode }))
+        );
+    }
 }
 
 #[test]
@@ -241,7 +285,7 @@ fn budgets_are_enforced() {
     // Exactly at the per-layer command budget: legal.
     let at_budget = scene(|w| {
         w.begin_layer(LayerId::Background).expect("begin");
-        for _ in 0..MAX_LAYER_COMMANDS / 2 {
+        for _ in 0..(MAX_LAYER_COMMANDS - 2) / 2 {
             w.save().expect("save");
             w.restore().expect("restore");
         }
@@ -253,7 +297,7 @@ fn budgets_are_enforced() {
     // One command past the budget: the frame fails.
     let over_budget = scene(|w| {
         w.begin_layer(LayerId::Background).expect("begin");
-        for _ in 0..MAX_LAYER_COMMANDS / 2 {
+        for _ in 0..(MAX_LAYER_COMMANDS - 2) / 2 {
             w.save().expect("save");
             w.restore().expect("restore");
         }
@@ -277,6 +321,70 @@ fn budgets_are_enforced() {
 }
 
 #[test]
+fn graphics_state_stack_budget_is_enforced() {
+    let at_budget = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        for _ in 1..MAX_STACK_DEPTH {
+            w.save().expect("save");
+        }
+        for _ in 1..MAX_STACK_DEPTH {
+            w.restore().expect("restore");
+        }
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert!(validate_layers(&at_budget).is_ok());
+
+    let over_budget = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        for _ in 0..MAX_STACK_DEPTH {
+            w.save().expect("save");
+        }
+    });
+    assert_eq!(
+        validate_layers(&over_budget),
+        Err(LayerError::StackOverCapacity {
+            layer: LayerId::Background,
+            depth: MAX_STACK_DEPTH + 1,
+        })
+    );
+}
+
+#[test]
+fn layer_marker_corpus_pins_wire_and_legacy_state_isolation() {
+    let bytes = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert_eq!(
+        bytes,
+        std::vec![
+            crate::SCENE_FORMAT_VERSION,
+            0x50,
+            1,
+            0,
+            0,
+            0x01,
+            0,
+            0,
+            0x02,
+            0,
+            0,
+            0x51,
+            1,
+            0,
+            0,
+        ]
+    );
+    assert!(validate_layers(&bytes).is_ok());
+}
+
+#[test]
+fn layer_decode_error_preserves_its_source() {
+    let error = LayerError::from(DecodeError::Truncated);
+    assert!(std::error::Error::source(&error).is_some());
+}
+
+#[test]
 fn ranges_slice_out_exact_layer_content() {
     let bytes = scene(|w| {
         w.begin_layer(LayerId::Background).expect("begin");
@@ -288,10 +396,11 @@ fn ranges_slice_out_exact_layer_content() {
     });
     let report = validate_layers(&bytes).expect("validates");
 
-    // The attitude range must contain exactly the bytes the same command
-    // encodes in isolation.
+    // The attitude range includes the mandatory compatibility envelope.
     let isolated = scene(|w| {
+        w.save().expect("save");
         w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+        w.restore().expect("restore");
     });
     let (start, end) = report.ranges[LayerId::Attitude.to_u8() as usize].expect("range");
     assert_eq!(&bytes[start..end], &isolated[1..], "content bytes match");

--- a/crates/pilotage-instrument-scene/src/layer/tests.rs
+++ b/crates/pilotage-instrument-scene/src/layer/tests.rs
@@ -1,0 +1,331 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use proptest::prelude::*;
+use std::vec::Vec;
+
+use crate::cmd::PaintMode;
+use crate::decode::DecodeError;
+use crate::encode::SceneWriter;
+use crate::layer::{
+    LAYER_COUNT, LayerError, LayerId, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES, validate_layers,
+};
+
+const ALL: [LayerId; LAYER_COUNT] = [
+    LayerId::Background,
+    LayerId::Attitude,
+    LayerId::Tapes,
+    LayerId::Guidance,
+    LayerId::Annunciation,
+    LayerId::Failure,
+];
+
+fn scene(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+    let mut writer = SceneWriter::new(&mut buf).expect("writer");
+    build(&mut writer);
+    let len = writer.finish();
+    buf.truncate(len);
+    buf
+}
+
+fn simple_layer(w: &mut SceneWriter<'_>, layer: LayerId) {
+    w.begin_layer(layer).expect("begin");
+    w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    w.end_layer(layer).expect("end");
+}
+
+#[test]
+fn every_ascending_subset_is_legal() {
+    for mask in 0u8..(1 << LAYER_COUNT) {
+        let bytes = scene(|w| {
+            for layer in ALL {
+                if mask & (1 << layer.to_u8()) != 0 {
+                    simple_layer(w, layer);
+                }
+            }
+        });
+        let report = validate_layers(&bytes).expect("legal subset validates");
+        assert_eq!(report.present, mask, "mask {mask:#08b}");
+        for layer in ALL {
+            assert_eq!(report.contains(layer), mask & (1 << layer.to_u8()) != 0);
+            if report.contains(layer) {
+                assert_eq!(report.commands[layer.to_u8() as usize], 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn every_non_ascending_pair_is_illegal() {
+    for first in ALL {
+        for second in ALL {
+            if second > first {
+                continue;
+            }
+            let bytes = scene(|w| {
+                simple_layer(w, first);
+                simple_layer(w, second);
+            });
+            let expected = if second == first {
+                LayerError::DuplicateLayer { layer: second }
+            } else {
+                LayerError::OutOfOrder { layer: second }
+            };
+            assert_eq!(
+                validate_layers(&bytes),
+                Err(expected),
+                "{first:?} then {second:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn structural_violations_fail_the_frame() {
+    let nested = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.begin_layer(LayerId::Attitude).expect("begin");
+    });
+    assert_eq!(
+        validate_layers(&nested),
+        Err(LayerError::NestedLayer {
+            layer: LayerId::Attitude
+        })
+    );
+
+    let stray_end = scene(|w| {
+        w.end_layer(LayerId::Tapes).expect("end");
+    });
+    assert_eq!(
+        validate_layers(&stray_end),
+        Err(LayerError::EndWithoutBegin {
+            layer: LayerId::Tapes
+        })
+    );
+
+    let mismatch = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.end_layer(LayerId::Attitude).expect("end");
+    });
+    assert_eq!(
+        validate_layers(&mismatch),
+        Err(LayerError::EndMismatch {
+            open: LayerId::Background,
+            end: LayerId::Attitude,
+        })
+    );
+
+    let unclosed = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    });
+    assert_eq!(
+        validate_layers(&unclosed),
+        Err(LayerError::UnclosedLayer {
+            layer: LayerId::Background
+        })
+    );
+
+    let outside = scene(|w| {
+        w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    });
+    assert_eq!(
+        validate_layers(&outside),
+        Err(LayerError::CommandOutsideLayer)
+    );
+}
+
+#[test]
+fn state_leaks_across_layers_fail_the_frame() {
+    // A save left open at the layer's end would carry its transform and
+    // clip into every band above it.
+    let open_save = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.save().expect("save");
+        w.clip_rect(0.0, 0.0, 1.0, 1.0).expect("clip");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert_eq!(
+        validate_layers(&open_save),
+        Err(LayerError::UnbalancedState {
+            layer: LayerId::Background
+        })
+    );
+
+    // A restore below the entry depth would pop state a *lower* band
+    // established for itself.
+    let deep_restore = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.restore().expect("restore");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert_eq!(
+        validate_layers(&deep_restore),
+        Err(LayerError::UnbalancedState {
+            layer: LayerId::Background
+        })
+    );
+
+    let balanced = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.save().expect("save");
+        w.rotate(1.0).expect("rotate");
+        w.restore().expect("restore");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert!(validate_layers(&balanced).is_ok());
+}
+
+#[test]
+fn unknown_opcodes_skip_inside_layers_but_unknown_layer_ids_fail() {
+    // An unknown opcode with sound framing inside a layer is a counted
+    // skip (version policy).
+    let mut inside = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    // Splice an unknown 0x7f command (empty payload) between the markers.
+    inside.splice(5..5, [0x7f, 0, 0]);
+    let report = validate_layers(&inside).expect("skips unknown opcode");
+    assert_eq!(report.unknown, 1);
+    assert_eq!(report.commands[0], 1);
+
+    // The same unknown opcode outside any layer cannot be placed.
+    let outside = {
+        let mut bytes = scene(|_| {});
+        bytes.extend_from_slice(&[0x7f, 0, 0]);
+        bytes
+    };
+    assert_eq!(
+        validate_layers(&outside),
+        Err(LayerError::CommandOutsideLayer)
+    );
+
+    // An unknown layer id fails the frame at decode: its criticality
+    // cannot be placed, so nothing may be painted.
+    let mut bad_id = scene(|w| {
+        simple_layer(w, LayerId::Background);
+    });
+    bad_id[4] = 9; // BEGIN_LAYER payload byte
+    assert_eq!(
+        validate_layers(&bad_id),
+        Err(LayerError::Decode(DecodeError::BadPayload { opcode: 0x50 }))
+    );
+}
+
+#[test]
+fn truncation_at_every_byte_boundary_is_never_silently_complete() {
+    let bytes = scene(|w| {
+        simple_layer(w, LayerId::Background);
+        w.begin_layer(LayerId::Attitude).expect("begin");
+        w.rect(PaintMode::Fill, 0.0, 0.0, 2.0, 2.0).expect("rect");
+        w.end_layer(LayerId::Attitude).expect("end");
+    });
+    let full = validate_layers(&bytes).expect("full scene validates");
+    for len in 0..bytes.len() {
+        // A prefix ending exactly at a layer boundary is a valid
+        // *smaller* scene; it must never report the full content.
+        // Detecting a missing required layer is the consumer's check
+        // via `LayerReport::contains`. Every other prefix must error.
+        if let Ok(report) = validate_layers(&bytes[..len]) {
+            assert_ne!(
+                report.present, full.present,
+                "truncation to {len} bytes reported the full layer set"
+            );
+        }
+    }
+}
+
+#[test]
+fn budgets_are_enforced() {
+    // Exactly at the per-layer command budget: legal.
+    let at_budget = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        for _ in 0..MAX_LAYER_COMMANDS / 2 {
+            w.save().expect("save");
+            w.restore().expect("restore");
+        }
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    let report = validate_layers(&at_budget).expect("at budget validates");
+    assert_eq!(usize::from(report.commands[0]), MAX_LAYER_COMMANDS);
+
+    // One command past the budget: the frame fails.
+    let over_budget = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        for _ in 0..MAX_LAYER_COMMANDS / 2 {
+            w.save().expect("save");
+            w.restore().expect("restore");
+        }
+        w.rotate(0.1).expect("rotate");
+        w.end_layer(LayerId::Background).expect("end");
+    });
+    assert_eq!(
+        validate_layers(&over_budget),
+        Err(LayerError::OverCapacity {
+            layer: LayerId::Background
+        })
+    );
+
+    let oversized = std::vec![0u8; MAX_SCENE_BYTES + 1];
+    assert_eq!(
+        validate_layers(&oversized),
+        Err(LayerError::SceneTooLarge {
+            bytes: MAX_SCENE_BYTES + 1
+        })
+    );
+}
+
+#[test]
+fn ranges_slice_out_exact_layer_content() {
+    let bytes = scene(|w| {
+        w.begin_layer(LayerId::Background).expect("begin");
+        w.fill_color(crate::Rgba8::rgb(1, 2, 3)).expect("fill");
+        w.end_layer(LayerId::Background).expect("end");
+        w.begin_layer(LayerId::Attitude).expect("begin");
+        w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+        w.end_layer(LayerId::Attitude).expect("end");
+    });
+    let report = validate_layers(&bytes).expect("validates");
+
+    // The attitude range must contain exactly the bytes the same command
+    // encodes in isolation.
+    let isolated = scene(|w| {
+        w.line(0.0, 0.0, 1.0, 1.0).expect("line");
+    });
+    let (start, end) = report.ranges[LayerId::Attitude.to_u8() as usize].expect("range");
+    assert_eq!(&bytes[start..end], &isolated[1..], "content bytes match");
+    assert!(report.ranges[LayerId::Tapes.to_u8() as usize].is_none());
+}
+
+proptest! {
+    // Any ascending subset of layers filled with balanced simple command
+    // runs is a legal frame with the reported content.
+    #[test]
+    fn legal_layered_scenes_always_validate(
+        mask in 0u8..(1 << LAYER_COUNT),
+        fills in proptest::collection::vec(0usize..40, LAYER_COUNT),
+    ) {
+        let bytes = scene(|w| {
+            for layer in ALL {
+                if mask & (1 << layer.to_u8()) == 0 {
+                    continue;
+                }
+                w.begin_layer(layer).expect("begin");
+                for i in 0..fills[layer.to_u8() as usize] {
+                    match i % 3 {
+                        0 => w.line(0.0, 0.0, i as f32, 1.0).expect("line"),
+                        1 => w.rect(PaintMode::Fill, 0.0, 0.0, 1.0, 1.0).expect("rect"),
+                        _ => {
+                            w.save().expect("save");
+                            w.restore().expect("restore");
+                        }
+                    }
+                }
+                w.end_layer(layer).expect("end");
+            }
+        });
+        let report = validate_layers(&bytes).expect("legal scene validates");
+        prop_assert_eq!(report.present, mask);
+    }
+}

--- a/crates/pilotage-instrument-scene/src/lib.rs
+++ b/crates/pilotage-instrument-scene/src/lib.rs
@@ -30,7 +30,7 @@ pub use decode::{DecodeError, SceneCmds};
 pub use encode::{SceneError, SceneWriter};
 pub use layer::{
     LAYER_COUNT, LayerError, LayerId, LayerReport, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES,
-    validate_layers,
+    MAX_STACK_DEPTH, validate_layers,
 };
 
 /// Format version written as the first byte of every encoded scene.

--- a/crates/pilotage-instrument-scene/src/lib.rs
+++ b/crates/pilotage-instrument-scene/src/lib.rs
@@ -14,16 +14,24 @@
 
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 mod cmd;
 mod color;
 mod decode;
 mod encode;
+mod layer;
 mod opcode;
 
 pub use cmd::{Anchor, Cmd, HAlign, MAX_TEXT_BYTES, PaintMode, PointsRef, VAlign};
 pub use color::Rgba8;
 pub use decode::{DecodeError, SceneCmds};
 pub use encode::{SceneError, SceneWriter};
+pub use layer::{
+    LAYER_COUNT, LayerError, LayerId, LayerReport, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES,
+    validate_layers,
+};
 
 /// Format version written as the first byte of every encoded scene.
 pub const SCENE_FORMAT_VERSION: u8 = 1;

--- a/crates/pilotage-instrument-scene/src/opcode.rs
+++ b/crates/pilotage-instrument-scene/src/opcode.rs
@@ -1,7 +1,7 @@
 //! Wire opcodes shared by the encoder and decoder.
 //!
 //! Opcode space is append-only: values are never reused or redefined
-//! (ADR-0017). 0x50–0x51 are the layer markers (REN-01); 0x52–0x5F stay
+//! (ADR-0017). 0x50–0x51 are the layer markers; 0x52–0x5F stay
 //! reserved for the layer vocabulary.
 
 pub(crate) const SAVE: u8 = 0x01;

--- a/crates/pilotage-instrument-scene/src/opcode.rs
+++ b/crates/pilotage-instrument-scene/src/opcode.rs
@@ -1,7 +1,8 @@
 //! Wire opcodes shared by the encoder and decoder.
 //!
 //! Opcode space is append-only: values are never reused or redefined
-//! (ADR-0017). 0x50–0x5F is reserved for future layer markers.
+//! (ADR-0017). 0x50–0x51 are the layer markers (REN-01); 0x52–0x5F stay
+//! reserved for the layer vocabulary.
 
 pub(crate) const SAVE: u8 = 0x01;
 pub(crate) const RESTORE: u8 = 0x02;
@@ -17,3 +18,5 @@ pub(crate) const CIRCLE: u8 = 0x24;
 pub(crate) const ARC: u8 = 0x25;
 pub(crate) const TEXT: u8 = 0x30;
 pub(crate) const CLIP_RECT: u8 = 0x40;
+pub(crate) const BEGIN_LAYER: u8 = 0x50;
+pub(crate) const END_LAYER: u8 = 0x51;

--- a/docs/adr/0017-instrument-display-runtime.md
+++ b/docs/adr/0017-instrument-display-runtime.md
@@ -122,12 +122,60 @@ so SVS and embedded degradation never require re-architecture:
   symbology without touching tapes or ladder. SVS fidelity is a
   backend-class decision (survey lesson: every vendor scales SVS to the
   processor), so the slot carries a quality tier, not a renderer.
-- **Overlay layers**: scene output is ordered in named layers (background,
-  attitude, tapes, symbology, annunciation) so terrain, obstacle, runway,
-  and conformal overlays insert at a defined z-order.
+- **Overlay layers**: implemented — see "The scene-layer and safety
+  compositor contract" below.
 - **Data-source abstraction**: instrument state is fed by writers, never by
   transports; local-sensor, bus, and network sources all converge on the same
   state struct (the thin-display vs. smart-display axis stays open).
+
+### The scene-layer and safety compositor contract
+
+Scene commands partition into six bounded, named, z-ordered criticality
+bands, delimited by begin/end layer markers in the reserved 0x50 opcode
+space: `Background` (0), `Attitude` (1), `Tapes` (2), `Guidance` (3),
+`Annunciation` (4), `Failure` (5). The contract exists so optional
+background imagery can never cover, suppress, or prevent primary flight
+information, warnings, or failure indications (AC 25-11B's
+mixed-criticality display concern, as a design input — not a compliance
+claim). The byte-level contract is specified in the
+[scene-layer protocol](../instruments/scene-layer-protocol.md).
+
+- Encoding order **is** z-order: layers appear at most once each, in
+  strictly ascending id order, unnested, with every drawing command
+  inside exactly one layer. A validated scene therefore cannot paint
+  background over a critical band, on any conforming backend.
+- Every layer carries a mandatory outer Save/Restore envelope immediately
+  inside its markers. No command may sit outside that envelope. It isolates
+  transform, clip, and paint state even on an older backend that skips the
+  markers themselves.
+- Frames are bounded: per-layer command count, graphics-state stack depth,
+  and scene byte budgets are compile-time constants in
+  `pilotage-instrument-scene::layer`. `validate_layers` enforces these with
+  the duplicate, ordering, nesting, state-isolation, and framing rules.
+- Version policy: unknown *opcodes* inside a layer remain counted skips;
+  an unknown *layer id* fails the whole frame, because content whose
+  criticality cannot be placed must not be painted. Layer marker payloads
+  are exactly one byte. Growing the layer vocabulary or marker shape
+  therefore requires a scene format version bump.
+- The SVS/raster boundary: backend-owned raster or depth imagery (a
+  hypothetical SVS terrain layer) composes strictly below `Attitude`, in the
+  band `Background` occupies. The PFD renders with `BackgroundMode::None`
+  to cede that band. Horizon line, pitch ladder, roll scale, aircraft
+  reference, tapes, and annunciations remain in the critical overlay and
+  are byte-identical with the background present or absent.
+- One frame is one encoded scene; frame generation and identity ride the
+  transport (the WASM render generation), not the encoding. Each layer
+  is owned by exactly one producer per frame — the duplicate rule makes
+  split ownership structurally impossible.
+- The layer validator accepts any legal ascending subset because different
+  panel types use different bands. Before visible commit, the panel host
+  must additionally require the critical-layer mask for the selected panel.
+
+Backends that predate the layer markers skip them as unknown opcodes and
+paint in encoded order. They still execute the ordinary Save/Restore
+envelope, preserving state isolation and z-order, but they do not enforce
+layer structure or resource budgets and are therefore not conforming
+high-assurance consumers.
 
 ## Consequences
 

--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -113,11 +113,16 @@ enforce its required layer mask before visible commit:
 | Panel | Required layers | Optional layers |
 |---|---|---|
 | PFD | `Attitude`, `Tapes`, `Annunciation` | `Background`, `Guidance`, `Failure` |
-| HSI | `Background`, `Attitude`, `Tapes`, `Guidance`, `Annunciation` | `Failure` |
+| HSI | `Attitude`, `Tapes`, `Guidance`, `Annunciation` | `Background`, `Failure` |
 
 A well-framed prefix that ends at a layer boundary is a smaller structural
 scene, not proof of a complete panel frame. Missing a required layer is a
 display failure and must not advance the visible render generation.
+
+`Failure` does not substitute for a required panel layer. A non-success render
+status bypasses scene consumption and is covered by the backend-owned failure
+page, so the failed producer is not required to generate its own failure
+content.
 
 Frame generation, snapshot identity, transport integrity, and panel selection
 remain outside the scene bytes. A consumer combines those transport checks

--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -1,0 +1,134 @@
+# Instrument scene-layer protocol
+
+This document specifies the bounded layer vocabulary carried by the
+instrument scene IR. It is a deterministic engineering contract for simulator
+and embedded backends; it does not claim certification credit for a backend.
+
+## Frame and command encoding
+
+A scene starts with `SCENE_FORMAT_VERSION` and then contains zero or more
+commands:
+
+```text
+[format_version u8]
+[opcode u8][payload_len u16 little-endian][payload bytes]...
+```
+
+The layer vocabulary in format version 1 is:
+
+| Opcode | Name | Payload |
+|---|---|---|
+| `0x50` | `BeginLayer` | exactly one `LayerId` byte |
+| `0x51` | `EndLayer` | exactly one `LayerId` byte |
+
+A zero-length or extended layer-marker payload is malformed. An unknown layer
+identifier is malformed even though an unknown ordinary drawing opcode may be
+counted and skipped. Changing the marker shape or adding a layer identifier
+requires a scene format version change.
+
+## Layers and z-order
+
+The numeric identifier is the z-order. Commands paint in encoding order.
+
+| ID | Layer | Content |
+|---:|---|---|
+| 0 | `Background` | Replaceable sky/ground or raster/depth imagery only |
+| 1 | `Attitude` | Horizon line, pitch ladder, roll scale, aircraft reference, primary orientation |
+| 2 | `Tapes` | Air-data tapes, readouts, and HSI data boxes |
+| 3 | `Guidance` | CDI, course/deviation scales, and navigation guidance |
+| 4 | `Annunciation` | Flags, miscompares, and source or sensor failure cues |
+| 5 | `Failure` | Display-level failure and reversion content |
+
+Each present layer appears exactly once, layers are strictly ascending, and
+layers do not nest. A drawing or state command outside a layer fails the
+frame. The end marker must name the open layer.
+
+## Graphics-state isolation
+
+Every layer has this exact structural envelope:
+
+```text
+BeginLayer(id)
+Save
+    zero or more drawing/state commands
+Restore
+EndLayer(id)
+```
+
+The outer Save and Restore use the ordinary `0x01` and `0x02` opcodes. They
+isolate transform, clip, fill, stroke, and other backend graphics state. No
+command may precede the Save or follow its matching Restore within the layer.
+Nested Save/Restore pairs are allowed inside the envelope up to the stack
+budget and must balance before the outer Restore.
+
+This shape preserves state isolation on a decoder that understands the
+drawing vocabulary but skips `0x50` and `0x51` as unknown opcodes.
+
+The byte-exact empty `Background` layer corpus is:
+
+```text
+01
+50 01 00 00
+01 00 00
+02 00 00
+51 01 00 00
+```
+
+## Resource bounds
+
+The conforming engineering profile is fixed by constants exported from
+`pilotage-instrument-scene`:
+
+| Resource | Bound |
+|---|---:|
+| Defined layers | 6 |
+| Commands per layer, including the isolation Save/Restore | 4096 |
+| Graphics-state depth, including the isolation Save | 32 |
+| Encoded bytes per scene | 65,536 |
+
+Exceeding any bound fails the whole frame. Validation is allocation-free and
+must finish before a backend makes any part of the frame visible.
+
+## Unknown commands and corruption
+
+An unknown ordinary opcode is accepted only when it is well framed and lies
+inside the active state-isolation envelope. It counts against the layer
+command budget and increments the unknown-command report.
+
+The frame fails on:
+
+- a bad format version, truncated command, or malformed known payload;
+- an unknown layer identifier;
+- a command outside a layer or outside its isolation envelope;
+- a nested, duplicate, descending, mismatched, or unclosed layer;
+- an unbalanced or over-depth graphics-state stack;
+- a per-layer command or scene-byte budget overrun.
+
+## Required panel profiles
+
+Structural validation deliberately accepts any ascending subset because panel
+types do not all use the same bands. The host that selects the panel must
+enforce its required layer mask before visible commit:
+
+| Panel | Required layers | Optional layers |
+|---|---|---|
+| PFD | `Attitude`, `Tapes`, `Annunciation` | `Background`, `Guidance`, `Failure` |
+| HSI | `Background`, `Attitude`, `Tapes`, `Guidance`, `Annunciation` | `Failure` |
+
+A well-framed prefix that ends at a layer boundary is a smaller structural
+scene, not proof of a complete panel frame. Missing a required layer is a
+display failure and must not advance the visible render generation.
+
+Frame generation, snapshot identity, transport integrity, and panel selection
+remain outside the scene bytes. A consumer combines those transport checks
+with the required-layer mask and `validate_layers` before commit.
+
+## Background and SVS boundary
+
+`Background` is the only replaceable band. An SVS raster or depth compositor
+occupies that band and remains below `Attitude`. `BackgroundMode::None` omits
+the scene background while retaining the horizon line, pitch ladder, roll
+scale, aircraft reference, tapes, guidance, and annunciations as applicable.
+
+No background producer owns a critical layer. Duplicate-layer rejection
+prevents two producers from claiming the same band in one scene.


### PR DESCRIPTION
## Summary

- freeze six bounded, named, z-ordered criticality layers in the reserved 0x50 opcode space: `Background(0) → Attitude → Tapes → Guidance → Annunciation → Failure(5)`; encoding order **is** z-order
- `validate_layers` fails a frame on duplicate, out-of-order, nested, or unbalanced layers, commands outside a layer, save/restore leaks across bands, truncation, and command/state-stack/scene-byte budget violations; unknown layer ids fail closed at decode (extending the vocabulary requires a version bump)
- PFD and HSI emit layered scenes; the optional background band never carries primary flight information, and the renderer refuses to commit any frame missing its panel's critical-layer mask
- specify the SVS boundary: backend raster/depth imagery composes strictly below `Attitude`, in the band `Background` occupies; `BackgroundMode::None` cedes that band with a byte-identical critical overlay

## Acceptance criteria — evidence

| Issue #25 criterion | Status | Evidence |
|---|---|---|
| Layer encode/decode round-trip and backward compatibility specified and tested | ✅ | All 64 ascending layer subsets validate (`every_ascending_subset_is_legal`) plus property tests over generated legal scenes; backward compatibility is structural — `begin_layer` emits the marker **then** a save/restore envelope, so a marker-skipping legacy decoder still paints in z-order with state isolation (pinned by the wire corpus test); the browser painter knows the markers as first-class no-ops so the unknown-opcode diagnostic stays meaningful |
| Structural corruption fails before visible commit | ✅ | `validate_layers` runs inside the WASM `render_result` before the scene length or generation commits; truncation at every byte boundary, framing corruption, and every structural violation are corpus-tested at both the crate and renderer levels |
| Critical overlays remain complete with absent, failed, unknown, or stale backgrounds | ✅ | Horizon line and pitch ladder live in the **critical Attitude band** (`draw_horizon_cues`), not the optional background fill; Attitude/Tapes/Annunciation emit unconditionally across all five signal statuses (`scenes_are_layered_for_every_attitude_status`) |
| SVS/background cannot cover PFI, warning, failure, or reversion layers | ✅ | Ascending-order + single-occurrence rules make background-above-critical structurally unencodable; `critical_overlay_is_byte_identical_without_background` proves via `LayerReport.ranges` that the critical bands are literally the same bytes with and without the background, for valid **and** failed attitude |
| Layer/command/stack/buffer bounds compile-time or configuration-validated | ✅ | `MAX_LAYER_COMMANDS`, state-stack depth, and `MAX_SCENE_BYTES` are `pub const` budgets enforced by the validator, tested at exact boundaries (4096 legal / 4097 fails; depth 32 legal / 33 fails; 65536 == renderer capacity, +1 fails) |
| The three instrument core crates keep no_std/no-allocation guarantees | ✅ | `#![no_std]`, allocation-free validator over fixed arrays; proven by the thumbv7em-none-eabihf cross-compile CI gate, not asserted in a comment |

Deterministic verification per the issue — legal combinations, every illegal ordering, truncation at every byte boundary, unknown opcodes, maximum capacity, critical-overlay invariance — all map to named corpus/property tests in `pilotage-instrument-scene/src/layer/tests.rs`, `pilotage-instrument-panels` tests, and the renderer gate tests in `pilotage-instruments-web`.

## Review findings addressed in this PR

- The Canvas2D interpreter counted the layer markers as *unknown* opcodes while the Rust decoder knew them — every valid layered frame permanently raised the version-skew diagnostic (8 on a PFD frame) and the two backends disagreed on the v1 vocabulary. Markers now paint as known no-ops, a genuinely unknown opcode still counts, and a real layered frame asserts a clean diagnostic end to end.
- Shared scene-length, command-limit, memory-growth, and invalid-aircraft-data guards live in base PR #43; this PR adds only the layer vocabulary and compositor contract on top.

## Beyond the baseline

- Compositor safety is enforced twice: statically by the encoding rules and dynamically by the renderer, which refuses to commit a frame missing its panel's critical-layer mask (`SceneCriticalLayersMissing`, distinct from `SceneLayerContract` and `SceneStructure`).
- Cross-band state leaks (a background clip or transform surviving into a critical band) are validation failures, tested in both directions (unpopped save, restore below entry depth).
- The full wire contract is written down in `docs/instruments/scene-layer-protocol.md` and amended into ADR-0017, including the version policy asymmetry: unknown opcodes degrade gracefully, unknown layer *ids* fail the frame because unplaceable criticality must not paint.

SIM / NOT FOR FLIGHT: engineering acceptance only, no certification claim. Refs #25. Merge after #43 (the renderer gate builds on the resource contract).

