### PR TITLE
AV-01: preserve measurement identity and publish coherent, reorder-safe display snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
       - name: web viewer wire conformance
         run: node clients/web/wire.test.mjs
 
+      - name: telemetry ingress gate contract
+        run: node clients/web/telemetry-ingress.test.mjs
+
+      - name: telemetry display retirement contract
+        run: node clients/web/telemetry-display.test.mjs
+
+      - name: transport session identity contract
+        run: node clients/web/transport-session.test.mjs
+
       - name: instrument display fail-visible contract
         run: node clients/web/instruments.test.mjs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
 name = "pilotage-adapter-aviate"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "libc",
  "pilotage-adapter-api",
  "pilotage-adapter-gazebo",

--- a/adapters/aviate/Cargo.toml
+++ b/adapters/aviate/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 # Not `workspace = true`: the workspace forbids unsafe_code outright,
 # but the shared-memory vehicle link (ADR-0019) needs shm_open/mmap.
-# This crate denies unsafe_code and allows it at the three mapped-memory
-# sites in shm.rs, each with a SAFETY justification; everything else
+# This crate denies unsafe_code and allows it only at contained sites in
+# shm.rs, each with a SAFETY justification; everything else
 # matches the workspace wall.
 [lints.rust]
 unsafe_code = "deny"
@@ -25,6 +25,7 @@ disallowed_types = "deny"
 disallowed_macros = "deny"
 
 [dependencies]
+getrandom = { version = "0.3.4", features = ["std"] }
 libc = { workspace = true }
 pilotage-adapter-api = { workspace = true }
 pilotage-adapter-gazebo = { workspace = true }

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -24,11 +24,11 @@ mod camera;
 mod control;
 mod sampling;
 mod shm_sampling;
-use sampling::{mavlink_batch, yaw_of};
+use sampling::{mavlink_batch, measurement_pair_is_coherent, yaw_of};
 use shm_sampling::ShmSource;
 
-/// The control scope this adapter exposes (issue #12): four canonical
-/// flight axes as DJI-style velocity demands.
+/// The control scope exposes four canonical flight axes as DJI-style
+/// velocity demands.
 pub const FLIGHT_SCOPE: &str = "vehicle.motion";
 /// Canonical `roll` axis (0): lateral velocity, + = right.
 pub const ROLL_AXIS: u16 = 0;
@@ -48,6 +48,34 @@ pub const RESET_BUTTON: u16 = 2;
 /// Logical button toggling between camera mode (velocity sticks,
 /// brake-to-hold) and FPV mode (attitude sticks, direct thrust).
 pub const FPV_TOGGLE_BUTTON: u16 = 3;
+
+fn flight_button_pressed(frame: &ScopedControlFrame, button: u16) -> bool {
+    frame.payload.edges.iter().any(|(candidate, edge)| {
+        *edge == ButtonEdge::Pressed && *candidate == LogicalButtonId::new(button)
+    })
+}
+
+fn rejected_control(tick: SimTick, reason: RejectReason) -> ApplyOutcome {
+    ApplyOutcome {
+        tick,
+        disposition: Disposition::Rejected(reason),
+    }
+}
+
+fn normalized_flight_sticks(frame: &ScopedControlFrame) -> ([f32; 4], bool) {
+    let mut sticks = [0.0_f32; 4];
+    let mut transformed = false;
+    for (axis, value) in &frame.payload.axes {
+        let clamped = if value.is_nan() {
+            0.0
+        } else {
+            value.clamp(-1.0, 1.0)
+        };
+        transformed |= clamped != *value;
+        sticks[usize::from(axis.as_u16().min(3))] = clamped;
+    }
+    (sticks, transformed)
+}
 
 /// Data older than this is withheld from telemetry entirely, so
 /// downstream freshness models see the group's age grow instead of a
@@ -87,8 +115,8 @@ pub struct AviateAdapter {
     vehicle: VehicleId,
     source: Source,
     uplink: Option<FlightUplink>,
-    // Camera path (issue #12): Pilotage's own gz sidecar bridges the
-    // flight world's camera topics; absent when the sidecar can't spawn.
+    // Pilotage's Gazebo sidecar bridges the flight world's camera topics;
+    // the adapter remains usable without video when the sidecar cannot spawn.
     frames: Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
     _camera_bridge: Option<pilotage_adapter_gazebo::BridgeClient>,
     _frame_forwarder: Option<tokio::task::JoinHandle<()>>,
@@ -226,17 +254,27 @@ impl AviateAdapter {
     }
 
     /// The vehicle's current measured yaw (radians clockwise from
-    /// north) and NED position (zeros before any telemetry).
-    fn current_pose(&mut self) -> (f32, [f32; 3]) {
-        match &self.source {
+    /// north) and NED position.
+    fn current_pose(&mut self) -> Option<(f32, [f32; 3])> {
+        match &mut self.source {
             Source::Shm(source) => source.current_pose(),
-            Source::Mavlink { state, .. } => state.lock().ok().map_or((0.0, [0.0; 3]), |latest| {
-                let yaw = latest
+            Source::Mavlink { state, .. } => {
+                let latest = state.lock().ok()?;
+                let attitude = latest
                     .attitude
-                    .map_or(0.0, |att| yaw_of(att.quat_wxyz) as f32);
-                let pos = latest.kinematics.map_or([0.0; 3], |kin| kin.pos_ned_m);
-                (yaw, pos)
-            }),
+                    .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)?;
+                let kinematics = latest
+                    .kinematics
+                    .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)?;
+                if !measurement_pair_is_coherent(
+                    attitude,
+                    kinematics,
+                    latest.maximum_inter_group_skew_ms,
+                ) {
+                    return None;
+                }
+                Some((yaw_of(attitude.quat_wxyz) as f32, kinematics.pos_ned_m))
+            }
         }
     }
 
@@ -270,9 +308,8 @@ impl VehicleAdapter for AviateAdapter {
                 render_capable: self._camera_bridge.is_some(),
                 ..ExecutionMode::default()
             },
-            // The flight scope (issue #12): DJI-style velocity control.
-            // Without a working uplink the adapter stays telemetry-only
-            // (ADR-0018's original shape).
+            // Without a working velocity-control uplink, the adapter stays
+            // telemetry-only as required by ADR-0018.
             vehicles: vec![VehicleDescriptor {
                 id: self.vehicle,
                 scopes: if self.uplink.is_some() {
@@ -301,33 +338,29 @@ impl VehicleAdapter for AviateAdapter {
     fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
         let tick = self.step(StepBudget { ticks: 0 }).now;
         if self.uplink.is_none() {
-            return ApplyOutcome {
-                tick,
-                disposition: Disposition::Rejected(RejectReason::UnknownScope),
-            };
+            return rejected_control(tick, RejectReason::UnknownScope);
         }
         if let Err(reason) = self.validate_flight_frame(frame) {
-            return ApplyOutcome {
-                tick,
-                disposition: Disposition::Rejected(reason),
-            };
+            return rejected_control(tick, reason);
         }
-        // Reset is scanned before the uplink borrow (it needs &mut self).
-        if frame
-            .payload
-            .edges
-            .iter()
-            .any(|(b, e)| *e == ButtonEdge::Pressed && *b == LogicalButtonId::new(RESET_BUTTON))
-        {
+        if flight_button_pressed(frame, RESET_BUTTON) {
             self.spawn_reset();
         }
-        let (current_yaw, current_pos) = self.current_pose();
-        let Some(uplink) = self.uplink.as_mut() else {
-            // Checked above; unreachable in practice.
+        if flight_button_pressed(frame, DISARM_BUTTON) {
+            let Some(uplink) = self.uplink.as_mut() else {
+                return rejected_control(tick, RejectReason::UnknownScope);
+            };
+            uplink.send_disarm();
             return ApplyOutcome {
                 tick,
-                disposition: Disposition::Rejected(RejectReason::UnknownScope),
+                disposition: Disposition::Accepted,
             };
+        }
+        let Some((current_yaw, current_pos)) = self.current_pose() else {
+            return rejected_control(tick, RejectReason::MeasurementUnavailable);
+        };
+        let Some(uplink) = self.uplink.as_mut() else {
+            return rejected_control(tick, RejectReason::UnknownScope);
         };
 
         for (button, edge) in &frame.payload.edges {
@@ -335,26 +368,14 @@ impl VehicleAdapter for AviateAdapter {
                 continue;
             }
             if *button == LogicalButtonId::new(ARM_BUTTON) {
-                uplink.send_arm(true, current_yaw);
-            } else if *button == LogicalButtonId::new(DISARM_BUTTON) {
-                uplink.send_arm(false, current_yaw);
+                uplink.send_arm(current_yaw);
             } else if *button == LogicalButtonId::new(FPV_TOGGLE_BUTTON) {
                 self.fpv_mode = !self.fpv_mode;
                 tracing::info!(fpv = self.fpv_mode, "flight mode toggled");
             }
         }
 
-        let mut sticks = [0.0f32; 4];
-        let mut transformed = false;
-        for (axis, value) in &frame.payload.axes {
-            let clamped = if value.is_nan() {
-                0.0
-            } else {
-                value.clamp(-1.0, 1.0)
-            };
-            transformed |= clamped != *value;
-            sticks[usize::from(axis.as_u16().min(3))] = clamped;
-        }
+        let (sticks, transformed) = normalized_flight_sticks(frame);
         if self.fpv_mode {
             uplink.send_fpv_frame(
                 sticks[usize::from(ROLL_AXIS)],

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -6,9 +6,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use pilotage_adapter_api::{
-    AdapterCapabilities, ApplyOutcome, AvionicsSample, Disposition, ExecutionMode, LinkLossPolicy,
-    MeasurementClock, MeasurementStamp, Pose2d, RejectReason, ScopeDescriptor, StepBudget,
-    StepOutcome, TelemetryBatch, TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
+    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossPolicy, RejectReason,
+    ScopeDescriptor, SourceIncarnation, StepBudget, StepOutcome, TelemetryBatch, VehicleAdapter,
+    VehicleDescriptor, VideoSource,
 };
 use pilotage_protocol::{
     ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame, VehicleId,
@@ -16,14 +16,16 @@ use pilotage_protocol::{
 use pilotage_timing::SimTick;
 
 use crate::error::AviateAdapterError;
+use crate::incarnation::{IncarnationProvider, OsIncarnationProvider};
 use crate::link::{AviateLink, LatestAviate, LinkConfig};
-use crate::shm::{GzStateShm, ShmFreshness};
 use crate::uplink::FlightUplink;
 
 mod camera;
 mod control;
 mod sampling;
+mod shm_sampling;
 use sampling::{mavlink_batch, yaw_of};
+use shm_sampling::ShmSource;
 
 /// The control scope this adapter exposes (issue #12): four canonical
 /// flight axes as DJI-style velocity demands.
@@ -72,12 +74,7 @@ enum Source {
         // Kept alive for its receive task; dropped with the adapter.
         _link: Option<AviateLink>,
     },
-    Shm {
-        shm: GzStateShm,
-        freshness: ShmFreshness,
-        instance: u8,
-        epoch: u32,
-    },
+    Shm(ShmSource),
 }
 
 /// Telemetry-only adapter for the Aviate flight controller (ADR-0018).
@@ -116,17 +113,37 @@ impl AviateAdapter {
         mode: AviateLinkMode,
         config: LinkConfig,
     ) -> Result<Self, AviateAdapterError> {
+        let mut provider = OsIncarnationProvider;
+        Self::start_with_incarnation_provider(vehicle, mode, config, &mut provider).await
+    }
+
+    /// Binds the vehicle link using a caller-owned attachment identity source.
+    ///
+    /// Aircraft integrations use this entry point to supply a persistent boot
+    /// counter or source-issued UUID instead of the simulator CSPRNG provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateAdapterError`] when identity creation or the selected
+    /// vehicle link fails.
+    pub async fn start_with_incarnation_provider<P: IncarnationProvider>(
+        vehicle: VehicleId,
+        mode: AviateLinkMode,
+        config: LinkConfig,
+        provider: &mut P,
+    ) -> Result<Self, AviateAdapterError> {
+        let incarnation = provider.next_incarnation_blocking()?;
         let source = match mode {
-            AviateLinkMode::Shm => Self::shm_source(0)?,
-            AviateLinkMode::Mavlink => Self::mavlink_source(config).await?,
-            AviateLinkMode::Auto => match Self::shm_source(0) {
+            AviateLinkMode::Shm => Self::shm_source(0, incarnation)?,
+            AviateLinkMode::Mavlink => Self::mavlink_source(config, incarnation).await?,
+            AviateLinkMode::Auto => match Self::shm_source(0, incarnation) {
                 Ok(source) => {
                     tracing::info!("Aviate link: shared-memory state block");
                     source
                 }
                 Err(error) => {
                     tracing::info!(%error, "Aviate shm not available; using MAVLink/UDP");
-                    Self::mavlink_source(config).await?
+                    Self::mavlink_source(config, incarnation).await?
                 }
             },
         };
@@ -134,7 +151,10 @@ impl AviateAdapter {
         // failing the adapter: displaying a flight you cannot command
         // beats displaying nothing.
         let uplink = match FlightUplink::new() {
-            Ok(uplink) => Some(uplink),
+            Ok(mut uplink) => {
+                uplink.set_expected_source(config.system_id, config.component_id);
+                Some(uplink)
+            }
             Err(error) => {
                 tracing::warn!(%error, "flight uplink unavailable; telemetry-only");
                 None
@@ -163,17 +183,18 @@ impl AviateAdapter {
         self.frames.take()
     }
 
-    fn shm_source(instance: u8) -> Result<Source, AviateAdapterError> {
-        Ok(Source::Shm {
-            shm: GzStateShm::open(instance)?,
-            freshness: ShmFreshness::new(),
-            instance,
-            epoch: 1,
-        })
+    fn shm_source(
+        instance: u8,
+        incarnation: SourceIncarnation,
+    ) -> Result<Source, AviateAdapterError> {
+        Ok(Source::Shm(ShmSource::open(instance, incarnation)?))
     }
 
-    async fn mavlink_source(config: LinkConfig) -> Result<Source, AviateAdapterError> {
-        let link = AviateLink::start(config).await?;
+    async fn mavlink_source(
+        config: LinkConfig,
+        incarnation: SourceIncarnation,
+    ) -> Result<Source, AviateAdapterError> {
+        let link = AviateLink::start(config, incarnation).await?;
         Ok(Source::Mavlink {
             state: link.state(),
             _link: Some(link),
@@ -208,9 +229,7 @@ impl AviateAdapter {
     /// north) and NED position (zeros before any telemetry).
     fn current_pose(&mut self) -> (f32, [f32; 3]) {
         match &self.source {
-            Source::Shm { shm, .. } => shm.read().map_or((0.0, [0.0; 3]), |s| {
-                (yaw_of(s.quat_wxyz) as f32, s.pos_ned_m)
-            }),
+            Source::Shm(source) => source.current_pose(),
             Source::Mavlink { state, .. } => state.lock().ok().map_or((0.0, [0.0; 3]), |latest| {
                 let yaw = latest
                     .attitude
@@ -376,71 +395,7 @@ impl VehicleAdapter for AviateAdapter {
         };
         match &mut self.source {
             Source::Mavlink { state, .. } => mavlink_batch(self.vehicle, state, arm_state),
-            Source::Shm {
-                shm,
-                freshness,
-                instance,
-                epoch,
-            } => {
-                let frozen = match shm.read() {
-                    Some(sample) => freshness.observe(sample.seq) > WITHHOLD_AFTER,
-                    None => freshness.observe_absent() > WITHHOLD_AFTER,
-                };
-                if frozen {
-                    // A frozen or vanished block usually means the
-                    // simulator restarted and re-created the shm object;
-                    // an old mapping keeps pointing at the orphaned one,
-                    // so reattach by name.
-                    if let Ok(new_shm) = GzStateShm::open(*instance) {
-                        *shm = new_shm;
-                        *freshness = ShmFreshness::new();
-                        *epoch = epoch.wrapping_add(1);
-                    }
-                    return TelemetryBatch::default();
-                }
-                let Some(sample) = shm.read() else {
-                    return TelemetryBatch::default();
-                };
-                let heading = yaw_of(sample.quat_wxyz);
-                let stamp = MeasurementStamp {
-                    source_id: u64::from(*instance).wrapping_add(1),
-                    source_epoch: *epoch,
-                    sequence: sample.seq,
-                    acquired_at_ns: sample.time_us.wrapping_mul(1_000),
-                    clock: MeasurementClock::Simulation,
-                };
-                let speed = f64::from(
-                    (sample.vel_ned_mps[0] * sample.vel_ned_mps[0]
-                        + sample.vel_ned_mps[1] * sample.vel_ned_mps[1])
-                        .sqrt(),
-                );
-                TelemetryBatch {
-                    samples: vec![TelemetrySample {
-                        vehicle: self.vehicle,
-                        tick: SimTick::new(sample.time_us.wrapping_mul(1_000)),
-                        pose: Pose2d {
-                            x: f64::from(sample.pos_ned_m[0]),
-                            y: f64::from(sample.pos_ned_m[1]),
-                            heading,
-                        },
-                        speed,
-                        avionics: Some(AvionicsSample {
-                            quat_wxyz: sample.quat_wxyz,
-                            rates_rps: sample.rates_rps,
-                            pos_ned_m: sample.pos_ned_m,
-                            vel_ned_mps: sample.vel_ned_mps,
-                            // Simulator ground truth (ADR-0019 v0): fully
-                            // valid by construction; the FC-estimate block
-                            // with real flags is the link RFC's v1.
-                            valid_flags: 0b1111,
-                            quality: 0,
-                            arm_state,
-                            attitude_stamp: Some(stamp),
-                            kinematics_stamp: Some(stamp),
-                        }),
-                    }],
-                }
-            }
+            Source::Shm(source) => source.sample(self.vehicle, arm_state),
         }
     }
 
@@ -483,7 +438,7 @@ impl VehicleAdapter for AviateAdapter {
                 .ok()
                 .and_then(|latest| latest.kinematics)
                 .map_or(0, |kin| u64::from(kin.time_boot_ms).wrapping_mul(1_000_000)),
-            Source::Shm { shm, .. } => shm.read().map_or(0, |s| s.time_us.wrapping_mul(1_000)),
+            Source::Shm(source) => source.tick(),
         };
         StepOutcome {
             advanced: 0,

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use pilotage_adapter_api::{
     AdapterCapabilities, ApplyOutcome, AvionicsSample, Disposition, ExecutionMode, LinkLossPolicy,
-    Pose2d, RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch,
-    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
+    MeasurementClock, MeasurementStamp, Pose2d, RejectReason, ScopeDescriptor, StepBudget,
+    StepOutcome, TelemetryBatch, TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
 };
 use pilotage_protocol::{
     ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame, VehicleId,
@@ -76,6 +76,7 @@ enum Source {
         shm: GzStateShm,
         freshness: ShmFreshness,
         instance: u8,
+        epoch: u32,
     },
 }
 
@@ -167,6 +168,7 @@ impl AviateAdapter {
             shm: GzStateShm::open(instance)?,
             freshness: ShmFreshness::new(),
             instance,
+            epoch: 1,
         })
     }
 
@@ -378,6 +380,7 @@ impl VehicleAdapter for AviateAdapter {
                 shm,
                 freshness,
                 instance,
+                epoch,
             } => {
                 let frozen = match shm.read() {
                     Some(sample) => freshness.observe(sample.seq) > WITHHOLD_AFTER,
@@ -391,6 +394,7 @@ impl VehicleAdapter for AviateAdapter {
                     if let Ok(new_shm) = GzStateShm::open(*instance) {
                         *shm = new_shm;
                         *freshness = ShmFreshness::new();
+                        *epoch = epoch.wrapping_add(1);
                     }
                     return TelemetryBatch::default();
                 }
@@ -398,6 +402,13 @@ impl VehicleAdapter for AviateAdapter {
                     return TelemetryBatch::default();
                 };
                 let heading = yaw_of(sample.quat_wxyz);
+                let stamp = MeasurementStamp {
+                    source_id: u64::from(*instance).wrapping_add(1),
+                    source_epoch: *epoch,
+                    sequence: sample.seq,
+                    acquired_at_ns: sample.time_us.wrapping_mul(1_000),
+                    clock: MeasurementClock::Simulation,
+                };
                 let speed = f64::from(
                     (sample.vel_ned_mps[0] * sample.vel_ned_mps[0]
                         + sample.vel_ned_mps[1] * sample.vel_ned_mps[1])
@@ -424,6 +435,8 @@ impl VehicleAdapter for AviateAdapter {
                             valid_flags: 0b1111,
                             quality: 0,
                             arm_state,
+                            attitude_stamp: Some(stamp),
+                            kinematics_stamp: Some(stamp),
                         }),
                     }],
                 }

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -44,17 +44,19 @@ pub(crate) fn mavlink_batch(
     let speed = f64::from(
         (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1]).sqrt(),
     );
-    let avionics = attitude.map(|att| AvionicsSample {
-        quat_wxyz: att.quat_wxyz,
-        rates_rps: att.rates_rps,
+    let avionics = Some(AvionicsSample {
+        quat_wxyz: attitude.map_or([1.0, 0.0, 0.0, 0.0], |att| att.quat_wxyz),
+        rates_rps: attitude.map_or([0.0; 3], |att| att.rates_rps),
         pos_ned_m: kin.pos_ned_m,
         vel_ned_mps: kin.vel_ned_mps,
         // Aviate's wire subset does not carry its StateValidFlags /
         // EstimateQuality yet (ADR-0018 names the gap); freshness is
         // the only validity dimension this link can honestly claim.
-        valid_flags: 0b1111,
+        valid_flags: if attitude.is_some() { 0b1111 } else { 0b1100 },
         quality: 0,
         arm_state,
+        attitude_stamp: attitude.map(|att| att.stamp),
+        kinematics_stamp: Some(kin.stamp),
     });
     TelemetryBatch {
         samples: vec![TelemetrySample {

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -2,12 +2,15 @@
 
 use std::sync::{Arc, Mutex};
 
-use pilotage_adapter_api::{AvionicsSample, Pose2d, TelemetryBatch, TelemetrySample};
+use pilotage_adapter_api::{
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, Pose2d, TelemetryBatch,
+    TelemetrySample,
+};
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
 use super::WITHHOLD_AFTER;
-use crate::link::LatestAviate;
+use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
 
 /// Yaw extracted from the body→NED quaternion (heading, radians
 /// clockwise from north).
@@ -21,7 +24,23 @@ pub(crate) fn yaw_of(q: [f32; 4]) -> f64 {
     (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
 }
 
-/// The MAVLink-path sampling, unchanged semantics from ADR-0018.
+pub(super) fn measurement_pair_is_coherent(
+    attitude: AttitudeUpdate,
+    kinematics: KinematicsUpdate,
+    maximum_skew_ms: u32,
+) -> bool {
+    let attitude_stamp = attitude.stamp;
+    let kinematics_stamp = kinematics.stamp;
+    attitude_stamp.source_id == kinematics_stamp.source_id
+        && attitude_stamp.source_incarnation == kinematics_stamp.source_incarnation
+        && attitude_stamp.source_epoch == kinematics_stamp.source_epoch
+        && attitude_stamp.clock == kinematics_stamp.clock
+        && attitude_stamp
+            .acquired_at_ns
+            .abs_diff(kinematics_stamp.acquired_at_ns)
+            <= u64::from(maximum_skew_ms) * 1_000_000
+}
+
 pub(crate) fn mavlink_batch(
     vehicle: VehicleId,
     state: &Arc<Mutex<LatestAviate>>,
@@ -40,25 +59,42 @@ pub(crate) fn mavlink_batch(
         return TelemetryBatch::default();
     }
 
-    let heading = attitude.map_or(0.0, |att| yaw_of(att.quat_wxyz));
-    let pos_ned_m = kinematics.map_or([0.0; 3], |kin| kin.pos_ned_m);
-    let vel_ned_mps = kinematics.map_or([0.0; 3], |kin| kin.vel_ned_mps);
-    let speed =
-        f64::from((vel_ned_mps[0] * vel_ned_mps[0] + vel_ned_mps[1] * vel_ned_mps[1]).sqrt());
+    let planar = attitude
+        .zip(kinematics)
+        .filter(|(att, kin)| {
+            measurement_pair_is_coherent(*att, *kin, latest.maximum_inter_group_skew_ms)
+        })
+        .map(|(att, kin)| {
+            let speed = f64::from(
+                (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1])
+                    .sqrt(),
+            );
+            (
+                Pose2d {
+                    x: f64::from(kin.pos_ned_m[0]),
+                    y: f64::from(kin.pos_ned_m[1]),
+                    heading: yaw_of(att.quat_wxyz),
+                },
+                speed,
+            )
+        });
     let avionics = Some(AvionicsSample {
-        quat_wxyz: attitude.map_or([1.0, 0.0, 0.0, 0.0], |att| att.quat_wxyz),
-        rates_rps: attitude.map_or([0.0; 3], |att| att.rates_rps),
-        pos_ned_m,
-        vel_ned_mps,
-        // Aviate's wire subset does not carry its StateValidFlags /
-        // EstimateQuality yet (ADR-0018 names the gap); freshness is
-        // the only validity dimension this link can honestly claim.
+        attitude: attitude.map(|att| AvionicsAttitudeSample {
+            quat_wxyz: att.quat_wxyz,
+            rates_rps: att.rates_rps,
+            stamp: att.stamp,
+        }),
+        kinematics: kinematics.map(|kin| AvionicsKinematicsSample {
+            pos_ned_m: kin.pos_ned_m,
+            vel_ned_mps: kin.vel_ned_mps,
+            stamp: kin.stamp,
+        }),
+        // The source messages do not carry estimator validity or quality;
+        // freshness is the only validity dimension this link can claim.
         valid_flags: (u32::from(attitude.is_some()) * 0b0011)
             | (u32::from(kinematics.is_some()) * 0b1100),
         quality: 0,
         arm_state,
-        attitude_stamp: attitude.map(|att| att.stamp),
-        kinematics_stamp: kinematics.map(|kin| kin.stamp),
     });
     let source_time_ms = kinematics
         .map(|kin| kin.time_boot_ms)
@@ -68,12 +104,8 @@ pub(crate) fn mavlink_batch(
         samples: vec![TelemetrySample {
             vehicle,
             tick: SimTick::new(u64::from(source_time_ms).wrapping_mul(1_000_000)),
-            pose: Pose2d {
-                x: f64::from(pos_ned_m[0]),
-                y: f64::from(pos_ned_m[1]),
-                heading,
-            },
-            speed,
+            pose: planar.map(|(pose, _)| pose),
+            speed: planar.map(|(_, speed)| speed),
             avionics,
         }],
     }

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -30,41 +30,47 @@ pub(crate) fn mavlink_batch(
     let Ok(latest) = state.lock() else {
         return TelemetryBatch::default();
     };
-    let Some(kin) = latest.kinematics else {
-        return TelemetryBatch::default();
-    };
-    if kin.received_at.elapsed() > WITHHOLD_AFTER {
-        return TelemetryBatch::default();
-    }
+    let kinematics = latest
+        .kinematics
+        .filter(|kin| kin.received_at.elapsed() <= WITHHOLD_AFTER);
     let attitude = latest
         .attitude
         .filter(|att| att.received_at.elapsed() <= WITHHOLD_AFTER);
+    if attitude.is_none() && kinematics.is_none() {
+        return TelemetryBatch::default();
+    }
 
     let heading = attitude.map_or(0.0, |att| yaw_of(att.quat_wxyz));
-    let speed = f64::from(
-        (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1]).sqrt(),
-    );
+    let pos_ned_m = kinematics.map_or([0.0; 3], |kin| kin.pos_ned_m);
+    let vel_ned_mps = kinematics.map_or([0.0; 3], |kin| kin.vel_ned_mps);
+    let speed =
+        f64::from((vel_ned_mps[0] * vel_ned_mps[0] + vel_ned_mps[1] * vel_ned_mps[1]).sqrt());
     let avionics = Some(AvionicsSample {
         quat_wxyz: attitude.map_or([1.0, 0.0, 0.0, 0.0], |att| att.quat_wxyz),
         rates_rps: attitude.map_or([0.0; 3], |att| att.rates_rps),
-        pos_ned_m: kin.pos_ned_m,
-        vel_ned_mps: kin.vel_ned_mps,
+        pos_ned_m,
+        vel_ned_mps,
         // Aviate's wire subset does not carry its StateValidFlags /
         // EstimateQuality yet (ADR-0018 names the gap); freshness is
         // the only validity dimension this link can honestly claim.
-        valid_flags: if attitude.is_some() { 0b1111 } else { 0b1100 },
+        valid_flags: (u32::from(attitude.is_some()) * 0b0011)
+            | (u32::from(kinematics.is_some()) * 0b1100),
         quality: 0,
         arm_state,
         attitude_stamp: attitude.map(|att| att.stamp),
-        kinematics_stamp: Some(kin.stamp),
+        kinematics_stamp: kinematics.map(|kin| kin.stamp),
     });
+    let source_time_ms = kinematics
+        .map(|kin| kin.time_boot_ms)
+        .or_else(|| attitude.map(|att| att.time_boot_ms))
+        .unwrap_or_default();
     TelemetryBatch {
         samples: vec![TelemetrySample {
             vehicle,
-            tick: SimTick::new(u64::from(kin.time_boot_ms).wrapping_mul(1_000_000)),
+            tick: SimTick::new(u64::from(source_time_ms).wrapping_mul(1_000_000)),
             pose: Pose2d {
-                x: f64::from(kin.pos_ned_m[0]),
-                y: f64::from(kin.pos_ned_m[1]),
+                x: f64::from(pos_ned_m[0]),
+                y: f64::from(pos_ned_m[1]),
                 heading,
             },
             speed,

--- a/adapters/aviate/src/adapter/shm_sampling.rs
+++ b/adapters/aviate/src/adapter/shm_sampling.rs
@@ -1,0 +1,168 @@
+//! Shared-memory source sampling and incarnation transitions.
+
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{
+    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch,
+    TelemetrySample,
+};
+use pilotage_protocol::VehicleId;
+use pilotage_timing::SimTick;
+
+use super::{WITHHOLD_AFTER, yaw_of};
+use crate::error::AviateAdapterError;
+use crate::shm::{GzStateSample, GzStateShm, ShmFreshness, ShmObservation};
+
+const REATTACH_INTERVAL: Duration = Duration::from_millis(250);
+
+#[derive(Debug)]
+pub(super) struct ShmSource {
+    shm: GzStateShm,
+    freshness: ShmFreshness,
+    instance: u8,
+    epoch: u32,
+    incarnation: SourceIncarnation,
+    last_reattach_attempt: Option<Instant>,
+}
+
+impl ShmSource {
+    pub(super) fn open(
+        instance: u8,
+        incarnation: SourceIncarnation,
+    ) -> Result<Self, AviateAdapterError> {
+        Ok(Self {
+            shm: GzStateShm::open(instance)?,
+            freshness: ShmFreshness::new(),
+            instance,
+            epoch: 1,
+            incarnation,
+            last_reattach_attempt: None,
+        })
+    }
+
+    pub(super) fn current_pose(&self) -> (f32, [f32; 3]) {
+        self.shm.read().map_or((0.0, [0.0; 3]), |sample| {
+            (yaw_of(sample.quat_wxyz) as f32, sample.pos_ned_m)
+        })
+    }
+
+    pub(super) fn tick(&self) -> u64 {
+        self.shm
+            .read()
+            .map_or(0, |sample| sample.time_us.wrapping_mul(1_000))
+    }
+
+    pub(super) fn sample(&mut self, vehicle: VehicleId, arm_state: u32) -> TelemetryBatch {
+        let now = Instant::now();
+        let Some(sample) = self.usable_sample(now) else {
+            return TelemetryBatch::default();
+        };
+        batch_from_sample(
+            vehicle,
+            arm_state,
+            sample,
+            self.instance,
+            self.epoch,
+            self.incarnation,
+        )
+    }
+
+    fn usable_sample(&mut self, now: Instant) -> Option<GzStateSample> {
+        let sample = self.shm.read();
+        let usable = match sample {
+            Some(sample) => match self.freshness.observe_at(sample.seq, sample.time_us, now) {
+                ShmObservation::Advancing => true,
+                ShmObservation::Unchanged(age) => age <= WITHHOLD_AFTER,
+                ShmObservation::Quarantined => false,
+            },
+            None => false,
+        };
+        if usable {
+            return sample;
+        }
+        let absent_stale =
+            sample.is_none() && self.freshness.observe_absent_at(now) > WITHHOLD_AFTER;
+        let frozen_or_quarantined = sample.is_some();
+        if absent_stale || frozen_or_quarantined {
+            self.try_reattach(now);
+        }
+        None
+    }
+
+    fn try_reattach(&mut self, now: Instant) {
+        if self.last_reattach_attempt.is_some_and(|last| {
+            now.checked_duration_since(last).unwrap_or_default() < REATTACH_INTERVAL
+        }) {
+            return;
+        }
+        self.last_reattach_attempt = Some(now);
+        let Ok(candidate) = GzStateShm::open(self.instance) else {
+            return;
+        };
+        if candidate.identity() == self.shm.identity() {
+            return;
+        }
+        let Some(first) = candidate.read() else {
+            return;
+        };
+        let mut freshness = ShmFreshness::new_at(now);
+        if freshness.observe_at(first.seq, first.time_us, now) != ShmObservation::Advancing {
+            return;
+        }
+        self.shm = candidate;
+        self.freshness = freshness;
+        self.epoch = self.epoch.wrapping_add(1);
+        self.last_reattach_attempt = None;
+        tracing::warn!(
+            source_epoch = self.epoch,
+            "Aviate SHM object entered a new attachment epoch"
+        );
+    }
+}
+
+fn batch_from_sample(
+    vehicle: VehicleId,
+    arm_state: u32,
+    sample: GzStateSample,
+    instance: u8,
+    epoch: u32,
+    incarnation: SourceIncarnation,
+) -> TelemetryBatch {
+    let heading = yaw_of(sample.quat_wxyz);
+    let stamp = MeasurementStamp {
+        source_id: u64::from(instance).wrapping_add(1),
+        source_incarnation: incarnation,
+        source_epoch: epoch,
+        sequence: sample.seq,
+        acquired_at_ns: sample.time_us.wrapping_mul(1_000),
+        clock: MeasurementClock::Simulation,
+    };
+    let speed = f64::from(
+        (sample.vel_ned_mps[0] * sample.vel_ned_mps[0]
+            + sample.vel_ned_mps[1] * sample.vel_ned_mps[1])
+            .sqrt(),
+    );
+    TelemetryBatch {
+        samples: vec![TelemetrySample {
+            vehicle,
+            tick: SimTick::new(sample.time_us.wrapping_mul(1_000)),
+            pose: Pose2d {
+                x: f64::from(sample.pos_ned_m[0]),
+                y: f64::from(sample.pos_ned_m[1]),
+                heading,
+            },
+            speed,
+            avionics: Some(AvionicsSample {
+                quat_wxyz: sample.quat_wxyz,
+                rates_rps: sample.rates_rps,
+                pos_ned_m: sample.pos_ned_m,
+                vel_ned_mps: sample.vel_ned_mps,
+                valid_flags: 0b1111,
+                quality: 0,
+                arm_state,
+                attitude_stamp: Some(stamp),
+                kinematics_stamp: Some(stamp),
+            }),
+        }],
+    }
+}

--- a/adapters/aviate/src/adapter/shm_sampling.rs
+++ b/adapters/aviate/src/adapter/shm_sampling.rs
@@ -3,8 +3,8 @@
 use std::time::{Duration, Instant};
 
 use pilotage_adapter_api::{
-    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch,
-    TelemetrySample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, MeasurementClock,
+    MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch, TelemetrySample,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
@@ -40,10 +40,9 @@ impl ShmSource {
         })
     }
 
-    pub(super) fn current_pose(&self) -> (f32, [f32; 3]) {
-        self.shm.read().map_or((0.0, [0.0; 3]), |sample| {
-            (yaw_of(sample.quat_wxyz) as f32, sample.pos_ned_m)
-        })
+    pub(super) fn current_pose(&mut self) -> Option<(f32, [f32; 3])> {
+        self.usable_sample(Instant::now())
+            .map(|sample| (yaw_of(sample.quat_wxyz) as f32, sample.pos_ned_m))
     }
 
     pub(super) fn tick(&self) -> u64 {
@@ -146,22 +145,26 @@ fn batch_from_sample(
         samples: vec![TelemetrySample {
             vehicle,
             tick: SimTick::new(sample.time_us.wrapping_mul(1_000)),
-            pose: Pose2d {
+            pose: Some(Pose2d {
                 x: f64::from(sample.pos_ned_m[0]),
                 y: f64::from(sample.pos_ned_m[1]),
                 heading,
-            },
-            speed,
+            }),
+            speed: Some(speed),
             avionics: Some(AvionicsSample {
-                quat_wxyz: sample.quat_wxyz,
-                rates_rps: sample.rates_rps,
-                pos_ned_m: sample.pos_ned_m,
-                vel_ned_mps: sample.vel_ned_mps,
+                attitude: Some(AvionicsAttitudeSample {
+                    quat_wxyz: sample.quat_wxyz,
+                    rates_rps: sample.rates_rps,
+                    stamp,
+                }),
+                kinematics: Some(AvionicsKinematicsSample {
+                    pos_ned_m: sample.pos_ned_m,
+                    vel_ned_mps: sample.vel_ned_mps,
+                    stamp,
+                }),
                 valid_flags: 0b1111,
                 quality: 0,
                 arm_state,
-                attitude_stamp: Some(stamp),
-                kinematics_stamp: Some(stamp),
             }),
         }],
     }

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -4,7 +4,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use pilotage_adapter_api::{
-    Disposition, MeasurementClock, MeasurementStamp, RejectReason, VehicleAdapter,
+    Disposition, MeasurementClock, MeasurementStamp, RejectReason, SourceIncarnation,
+    VehicleAdapter,
 };
 use pilotage_protocol::VehicleId;
 
@@ -16,6 +17,7 @@ fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> 
     let now = Instant::now();
     let attitude_stamp = MeasurementStamp {
         source_id: 1,
+        source_incarnation: SourceIncarnation::new([1; 16]),
         source_epoch: 1,
         sequence: 10,
         acquired_at_ns: 5_000_000_000,
@@ -92,6 +94,23 @@ fn stale_attitude_is_withheld_but_kinematics_still_flow() {
         Some(5)
     );
     assert_eq!(avionics.valid_flags, 0b1100);
+}
+
+#[test]
+fn stale_kinematics_is_withheld_but_attitude_still_flows() {
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::ZERO, Duration::from_secs(10)),
+    );
+    let batch = adapter.sample_telemetry();
+    assert_eq!(batch.samples.len(), 1);
+    let avionics = batch.samples[0].avionics.expect("attitude attached");
+    assert_eq!(
+        avionics.attitude_stamp.map(|stamp| stamp.sequence),
+        Some(10)
+    );
+    assert!(avionics.kinematics_stamp.is_none());
+    assert_eq!(avionics.valid_flags, 0b0011);
 }
 
 #[test]

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -3,7 +3,9 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_adapter_api::{
+    Disposition, MeasurementClock, MeasurementStamp, RejectReason, VehicleAdapter,
+};
 use pilotage_protocol::VehicleId;
 
 use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
@@ -12,6 +14,17 @@ use super::AviateAdapter;
 
 fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> {
     let now = Instant::now();
+    let attitude_stamp = MeasurementStamp {
+        source_id: 1,
+        source_epoch: 1,
+        sequence: 10,
+        acquired_at_ns: 5_000_000_000,
+        clock: MeasurementClock::VehicleBoot,
+    };
+    let kinematics_stamp = MeasurementStamp {
+        sequence: 5,
+        ..attitude_stamp
+    };
     let state = LatestAviate {
         attitude: Some(AttitudeUpdate {
             // 90° yaw: heading east.
@@ -22,12 +35,15 @@ fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> 
                 core::f32::consts::FRAC_1_SQRT_2,
             ],
             rates_rps: [0.0, 0.0, 0.1],
+            time_boot_ms: 5000,
+            stamp: attitude_stamp,
             received_at: now.checked_sub(att_age).unwrap_or(now),
         }),
         kinematics: Some(KinematicsUpdate {
             pos_ned_m: [10.0, 20.0, -30.0],
             vel_ned_mps: [3.0, 4.0, -1.0],
             time_boot_ms: 5000,
+            stamp: kinematics_stamp,
             received_at: now.checked_sub(kin_age).unwrap_or(now),
         }),
         ..LatestAviate::default()
@@ -51,6 +67,14 @@ fn fresh_state_samples_pose_speed_and_avionics() {
     let avionics = sample.avionics.expect("avionics attached");
     assert_eq!(avionics.pos_ned_m, [10.0, 20.0, -30.0]);
     assert_eq!(avionics.valid_flags, 0b1111);
+    assert_eq!(
+        avionics.attitude_stamp.map(|stamp| stamp.sequence),
+        Some(10)
+    );
+    assert_eq!(
+        avionics.kinematics_stamp.map(|stamp| stamp.sequence),
+        Some(5)
+    );
 }
 
 #[test]
@@ -61,7 +85,13 @@ fn stale_attitude_is_withheld_but_kinematics_still_flow() {
     );
     let batch = adapter.sample_telemetry();
     assert_eq!(batch.samples.len(), 1);
-    assert!(batch.samples[0].avionics.is_none());
+    let avionics = batch.samples[0].avionics.expect("kinematics attached");
+    assert!(avionics.attitude_stamp.is_none());
+    assert_eq!(
+        avionics.kinematics_stamp.map(|stamp| stamp.sequence),
+        Some(5)
+    );
+    assert_eq!(avionics.valid_flags, 0b1100);
 }
 
 #[test]

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -7,13 +7,21 @@ use pilotage_adapter_api::{
     Disposition, MeasurementClock, MeasurementStamp, RejectReason, SourceIncarnation,
     VehicleAdapter,
 };
-use pilotage_protocol::VehicleId;
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
 
 use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
 
-use super::AviateAdapter;
+use super::{AviateAdapter, sampling::measurement_pair_is_coherent};
 
 fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> {
+    state_with_acquisition_skew(att_age, kin_age, 0)
+}
+
+fn state_with_acquisition_skew(
+    att_age: Duration,
+    kin_age: Duration,
+    acquisition_skew_ns: u64,
+) -> Arc<Mutex<LatestAviate>> {
     let now = Instant::now();
     let attitude_stamp = MeasurementStamp {
         source_id: 1,
@@ -25,8 +33,12 @@ fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> 
     };
     let kinematics_stamp = MeasurementStamp {
         sequence: 5,
+        acquired_at_ns: attitude_stamp
+            .acquired_at_ns
+            .saturating_sub(acquisition_skew_ns),
         ..attitude_stamp
     };
+    let skew_ms = u32::try_from(acquisition_skew_ns / 1_000_000).unwrap_or(u32::MAX);
     let state = LatestAviate {
         attitude: Some(AttitudeUpdate {
             // 90° yaw: heading east.
@@ -44,13 +56,55 @@ fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> 
         kinematics: Some(KinematicsUpdate {
             pos_ned_m: [10.0, 20.0, -30.0],
             vel_ned_mps: [3.0, 4.0, -1.0],
-            time_boot_ms: 5000,
+            time_boot_ms: 5000_u32.saturating_sub(skew_ms),
             stamp: kinematics_stamp,
             received_at: now.checked_sub(kin_age).unwrap_or(now),
         }),
+        maximum_inter_group_skew_ms: 300,
         ..LatestAviate::default()
     };
     Arc::new(Mutex::new(state))
+}
+
+#[test]
+fn measurement_pair_requires_full_identity_clock_and_bounded_skew() {
+    let state = state_with_acquisition_skew(Duration::ZERO, Duration::ZERO, 300_000_000);
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("attitude");
+    let kinematics = latest.kinematics.expect("kinematics");
+    assert!(measurement_pair_is_coherent(
+        attitude,
+        kinematics,
+        latest.maximum_inter_group_skew_ms
+    ));
+
+    for stamp in [
+        MeasurementStamp {
+            source_id: 2,
+            ..kinematics.stamp
+        },
+        MeasurementStamp {
+            source_incarnation: SourceIncarnation::new([2; 16]),
+            ..kinematics.stamp
+        },
+        MeasurementStamp {
+            source_epoch: 2,
+            ..kinematics.stamp
+        },
+        MeasurementStamp {
+            clock: MeasurementClock::Simulation,
+            ..kinematics.stamp
+        },
+    ] {
+        assert!(!measurement_pair_is_coherent(
+            attitude,
+            KinematicsUpdate {
+                stamp,
+                ..kinematics
+            },
+            latest.maximum_inter_group_skew_ms
+        ));
+    }
 }
 
 #[test]
@@ -62,21 +116,40 @@ fn fresh_state_samples_pose_speed_and_avionics() {
     let batch = adapter.sample_telemetry();
     assert_eq!(batch.samples.len(), 1);
     let sample = &batch.samples[0];
-    assert_eq!(sample.pose.x, 10.0);
-    assert_eq!(sample.pose.y, 20.0);
-    assert!((sample.pose.heading - core::f64::consts::FRAC_PI_2).abs() < 1e-3);
-    assert!((sample.speed - 5.0).abs() < 1e-6);
+    let pose = sample.pose.expect("coherent planar pose");
+    assert_eq!(pose.x, 10.0);
+    assert_eq!(pose.y, 20.0);
+    assert!((pose.heading - core::f64::consts::FRAC_PI_2).abs() < 1e-3);
+    assert!((sample.speed.expect("coherent speed") - 5.0).abs() < 1e-6);
     let avionics = sample.avionics.expect("avionics attached");
-    assert_eq!(avionics.pos_ned_m, [10.0, 20.0, -30.0]);
+    assert_eq!(
+        avionics.kinematics.expect("kinematics").pos_ned_m,
+        [10.0, 20.0, -30.0]
+    );
     assert_eq!(avionics.valid_flags, 0b1111);
     assert_eq!(
-        avionics.attitude_stamp.map(|stamp| stamp.sequence),
+        avionics.attitude.map(|group| group.stamp.sequence),
         Some(10)
     );
     assert_eq!(
-        avionics.kinematics_stamp.map(|stamp| stamp.sequence),
+        avionics.kinematics.map(|group| group.stamp.sequence),
         Some(5)
     );
+}
+
+#[test]
+fn over_skew_groups_flow_without_a_planar_projection() {
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with_acquisition_skew(Duration::ZERO, Duration::ZERO, 301_000_000),
+    );
+    let batch = adapter.sample_telemetry();
+    let sample = batch.samples.first().expect("sample");
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+    let avionics = sample.avionics.expect("avionics");
+    assert!(avionics.attitude.is_some());
+    assert!(avionics.kinematics.is_some());
 }
 
 #[test]
@@ -87,11 +160,18 @@ fn stale_attitude_is_withheld_but_kinematics_still_flow() {
     );
     let batch = adapter.sample_telemetry();
     assert_eq!(batch.samples.len(), 1);
-    let avionics = batch.samples[0].avionics.expect("kinematics attached");
-    assert!(avionics.attitude_stamp.is_none());
+    let sample = &batch.samples[0];
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+    let avionics = sample.avionics.expect("kinematics attached");
+    assert!(avionics.attitude.is_none());
     assert_eq!(
-        avionics.kinematics_stamp.map(|stamp| stamp.sequence),
+        avionics.kinematics.map(|group| group.stamp.sequence),
         Some(5)
+    );
+    assert_eq!(
+        avionics.kinematics.expect("kinematics").vel_ned_mps,
+        [3.0, 4.0, -1.0]
     );
     assert_eq!(avionics.valid_flags, 0b1100);
 }
@@ -104,12 +184,19 @@ fn stale_kinematics_is_withheld_but_attitude_still_flows() {
     );
     let batch = adapter.sample_telemetry();
     assert_eq!(batch.samples.len(), 1);
-    let avionics = batch.samples[0].avionics.expect("attitude attached");
+    let sample = &batch.samples[0];
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+    let avionics = sample.avionics.expect("attitude attached");
     assert_eq!(
-        avionics.attitude_stamp.map(|stamp| stamp.sequence),
+        avionics.attitude.map(|group| group.stamp.sequence),
         Some(10)
     );
-    assert!(avionics.kinematics_stamp.is_none());
+    assert_eq!(
+        avionics.attitude.expect("attitude").rates_rps,
+        [0.0, 0.0, 0.1]
+    );
+    assert!(avionics.kinematics.is_none());
     assert_eq!(avionics.valid_flags, 0b0011);
 }
 
@@ -120,6 +207,70 @@ fn dead_link_withholds_the_whole_sample() {
         state_with(Duration::from_secs(10), Duration::from_secs(10)),
     );
     assert!(adapter.sample_telemetry().samples.is_empty());
+}
+
+#[test]
+fn incomplete_measurement_pair_cannot_seed_a_control_setpoint() {
+    for (attitude_age, kinematics_age) in [
+        (Duration::from_secs(10), Duration::ZERO),
+        (Duration::ZERO, Duration::from_secs(10)),
+    ] {
+        let uplink = crate::uplink::FlightUplink::new().expect("uplink");
+        let mut adapter =
+            AviateAdapter::from_state(VehicleId::new(1), state_with(attitude_age, kinematics_age))
+                .with_uplink(uplink);
+        let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
+        assert_eq!(
+            outcome.disposition,
+            Disposition::Rejected(RejectReason::MeasurementUnavailable)
+        );
+    }
+}
+
+#[test]
+fn over_skew_measurement_pair_cannot_seed_a_control_setpoint() {
+    let uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with_acquisition_skew(Duration::ZERO, Duration::ZERO, 301_000_000),
+    )
+    .with_uplink(uplink);
+    let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::MeasurementUnavailable)
+    );
+}
+
+#[test]
+fn disarm_does_not_require_a_current_measurement_pair() {
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::from_secs(10), Duration::from_secs(10)),
+    )
+    .with_uplink(uplink);
+
+    let outcome = adapter.apply_control(&flight_frame(
+        vec![],
+        vec![(
+            LogicalButtonId::new(super::DISARM_BUTTON),
+            ButtonEdge::Pressed,
+        )],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    let mut buf = [0_u8; 128];
+    let len = fc.recv(&mut buf).expect("receive disarm");
+    assert!(len >= 45);
+    assert_eq!(buf[7], crate::mavlink::COMMAND_LONG_ID as u8);
+    assert_eq!(
+        f32::from_le_bytes(buf[10..14].try_into().expect("param1")),
+        0.0
+    );
 }
 
 fn flight_frame(
@@ -143,8 +294,6 @@ fn flight_frame(
 
 #[test]
 fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
-    use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId};
-
     // A fake FC: any UDP socket we can read the uplink's frames from.
     let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
     fc.set_read_timeout(Some(Duration::from_secs(2)))

--- a/adapters/aviate/src/error.rs
+++ b/adapters/aviate/src/error.rs
@@ -3,6 +3,13 @@
 /// Why the Aviate adapter could not start or has stopped.
 #[derive(Debug, thiserror::Error)]
 pub enum AviateAdapterError {
+    /// The attachment identity provider could not obtain a new incarnation.
+    #[error("creating an Aviate source incarnation failed: {source}")]
+    IncarnationUnavailable {
+        /// The operating-system entropy failure.
+        #[source]
+        source: getrandom::Error,
+    },
     /// Neither the direct MAVLink port nor an ephemeral fallback socket
     /// could be bound.
     #[error("binding a UDP socket for MAVLink telemetry failed: {source}")]
@@ -11,13 +18,34 @@ pub enum AviateAdapterError {
         #[source]
         source: std::io::Error,
     },
-    /// The shared-memory state block could not be opened or mapped
-    /// (usually: no Aviate SITL is running yet).
-    #[error("Aviate state shm {name} unavailable: {detail}")]
-    ShmUnavailable {
+    /// The generated POSIX shared-memory name was not a valid C string.
+    #[error("Aviate state shm name {name} is invalid: {source}")]
+    ShmName {
         /// The POSIX shm object name.
         name: String,
-        /// What failed.
-        detail: String,
+        /// The embedded-NUL error.
+        #[source]
+        source: std::ffi::NulError,
+    },
+    /// A POSIX shared-memory operation failed.
+    #[error("Aviate state shm {name} operation {operation} failed: {source}")]
+    ShmIo {
+        /// The POSIX shm object name.
+        name: String,
+        /// The operation that failed.
+        operation: &'static str,
+        /// The operating-system failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The shared-memory object's ABI size does not match the reader.
+    #[error("Aviate state shm {name} has {actual} bytes; expected {expected}")]
+    ShmSizeMismatch {
+        /// The POSIX shm object name.
+        name: String,
+        /// Required byte size.
+        expected: usize,
+        /// Observed byte size.
+        actual: u64,
     },
 }

--- a/adapters/aviate/src/incarnation.rs
+++ b/adapters/aviate/src/incarnation.rs
@@ -1,0 +1,35 @@
+//! Source-attachment identity providers.
+
+use pilotage_adapter_api::SourceIncarnation;
+
+use crate::error::AviateAdapterError;
+
+/// Supplies a non-repeating identity for one adapter attachment.
+///
+/// Aircraft integrations should implement this with a source-issued boot UUID
+/// or a persistent monotonic boot counter. The OS provider is appropriate for
+/// simulator and development attachments.
+pub trait IncarnationProvider {
+    /// Returns the next attachment identity.
+    ///
+    /// The `_blocking` suffix makes the possible operating-system entropy I/O
+    /// visible to callers.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed adapter error when the identity source is unavailable.
+    fn next_incarnation_blocking(&mut self) -> Result<SourceIncarnation, AviateAdapterError>;
+}
+
+/// Operating-system CSPRNG identity provider for simulator attachments.
+#[derive(Debug, Default)]
+pub struct OsIncarnationProvider;
+
+impl IncarnationProvider for OsIncarnationProvider {
+    fn next_incarnation_blocking(&mut self) -> Result<SourceIncarnation, AviateAdapterError> {
+        let mut bytes = [0_u8; 16];
+        getrandom::fill(&mut bytes)
+            .map_err(|source| AviateAdapterError::IncarnationUnavailable { source })?;
+        Ok(SourceIncarnation::new(bytes))
+    }
+}

--- a/adapters/aviate/src/lib.rs
+++ b/adapters/aviate/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod adapter;
 mod error;
+mod incarnation;
 mod link;
 pub mod mavlink;
 pub mod shm;
@@ -26,5 +27,6 @@ pub use adapter::{
     THROTTLE_AXIS, YAW_AXIS,
 };
 pub use error::AviateAdapterError;
-pub use link::LinkConfig;
+pub use incarnation::{IncarnationProvider, OsIncarnationProvider};
+pub use link::{LinkConfig, ResetPolicy};
 pub use uplink::FlightUplink;

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -10,10 +10,24 @@ use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use pilotage_adapter_api::{MeasurementClock, MeasurementStamp};
+use pilotage_adapter_api::{MeasurementStamp, SourceIncarnation};
 
 use crate::error::AviateAdapterError;
-use crate::mavlink::{AviateMessage, encode_gcs_heartbeat, parse_datagram};
+use crate::mavlink::{AviateMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
+
+mod measurement;
+use measurement::{next_attitude_stamp, next_kinematics_stamp};
+
+/// Whether an unstamped MAVLink boot-clock regression may use the simulator
+/// reset heuristic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ResetPolicy {
+    /// Never infer a reboot from replayable MAVLink telemetry.
+    #[default]
+    Conservative,
+    /// Permit a quarantined, silence-and-dwell-qualified simulator reset.
+    SimulatorHeuristic,
+}
 
 /// Where the Aviate MAVLink telemetry is reachable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,12 +37,40 @@ pub struct LinkConfig {
     /// taken (a MAVLink router owns it), the adapter binds an ephemeral
     /// port and registers with the router via 1 Hz GCS heartbeats.
     pub endpoint: SocketAddr,
+    /// Expected MAVLink vehicle system id.
+    pub system_id: u8,
+    /// Expected MAVLink producer component id.
+    pub component_id: u8,
+    /// Logical source id published above the MAVLink transport.
+    pub source_id: u64,
+    /// Policy for a boot-clock regression without a source boot UUID.
+    pub reset_policy: ResetPolicy,
+    /// Largest source-clock lag admitted when a second measurement group
+    /// first joins or advances behind the epoch high-water mark.
+    pub maximum_inter_group_skew_ms: u32,
 }
 
 impl Default for LinkConfig {
     fn default() -> Self {
         Self {
             endpoint: SocketAddr::from(([127, 0, 0, 1], 14550)),
+            system_id: 1,
+            component_id: 1,
+            source_id: 1,
+            reset_policy: ResetPolicy::Conservative,
+            maximum_inter_group_skew_ms: 0,
+        }
+    }
+}
+
+impl LinkConfig {
+    /// Simulator profile with the bounded boot-clock reset heuristic enabled.
+    #[must_use]
+    pub fn simulator() -> Self {
+        Self {
+            reset_policy: ResetPolicy::SimulatorHeuristic,
+            maximum_inter_group_skew_ms: 300,
+            ..Self::default()
         }
     }
 }
@@ -36,13 +78,20 @@ impl Default for LinkConfig {
 /// Latest state received from the FC, with receive stamps so staleness
 /// can propagate to consumers (ADR-0018: loss of data marks groups
 /// stale rather than freezing them).
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LatestAviate {
-    /// The vehicle system id this link is locked onto. A routed link
-    /// carries several vehicles plus other GCS peers; the first system
-    /// id to deliver an estimate wins and everything else is ignored
-    /// (one adapter, one vehicle — ADR-0008).
-    pub locked_sysid: Option<u8>,
+    /// Configured MAVLink vehicle system id.
+    pub system_id: u8,
+    /// Configured MAVLink producer component id.
+    pub component_id: u8,
+    /// Logical source id published above MAVLink.
+    pub source_id: u64,
+    /// Opaque identity of this adapter attachment.
+    pub source_incarnation: SourceIncarnation,
+    /// Reset inference policy for this source.
+    pub reset_policy: ResetPolicy,
+    /// Configured epoch-wide inter-group source-clock lag bound.
+    pub maximum_inter_group_skew_ms: u32,
     /// Latest attitude estimate: quaternion (w,x,y,z), body rates,
     /// FC boot time, receive stamp.
     pub attitude: Option<AttitudeUpdate>,
@@ -59,16 +108,65 @@ pub struct LatestAviate {
     pub unknown_ids: u64,
     /// Acquisition-clock generation for this FC connection.
     pub source_epoch: u32,
-    /// Highest current-epoch FC boot timestamp observed across groups.
+    /// Highest current-epoch FC boot timestamp accepted across groups.
     pub last_source_time_ms: Option<u32>,
-    /// Candidate low timestamps awaiting confirmation of an FC reboot.
-    pub(crate) pending_reset: Option<ResetCandidate>,
+    /// Receive time of the last accepted new group measurement.
+    pub last_accepted_at: Option<Instant>,
+    /// Candidate low timestamps awaiting simulator-only confirmation.
+    pub(crate) pending_reset: Option<measurement::ResetCandidate>,
     /// Duplicate group measurements rejected before entering the cache.
     pub duplicate_measurements: u64,
     /// Older group measurements rejected before entering the cache.
     pub reordered_measurements: u64,
     /// Confirmed reboot or acquisition-clock-wrap transitions.
     pub source_resets: u64,
+    /// Low-clock reset candidates quarantined for confirmation.
+    pub suspected_resets: u64,
+    /// Frames rejected because their system or component id was not selected.
+    pub wrong_sources: u64,
+}
+
+impl Default for LatestAviate {
+    fn default() -> Self {
+        Self {
+            system_id: 1,
+            component_id: 1,
+            source_id: 1,
+            source_incarnation: SourceIncarnation::new([0; 16]),
+            reset_policy: ResetPolicy::Conservative,
+            maximum_inter_group_skew_ms: 0,
+            attitude: None,
+            kinematics: None,
+            last_heartbeat: None,
+            decoded: 0,
+            crc_failures: 0,
+            unknown_ids: 0,
+            source_epoch: 1,
+            last_source_time_ms: None,
+            last_accepted_at: None,
+            pending_reset: None,
+            duplicate_measurements: 0,
+            reordered_measurements: 0,
+            source_resets: 0,
+            suspected_resets: 0,
+            wrong_sources: 0,
+        }
+    }
+}
+
+impl LatestAviate {
+    fn for_source(config: LinkConfig, source_incarnation: SourceIncarnation) -> Self {
+        Self {
+            system_id: config.system_id,
+            component_id: config.component_id,
+            source_id: config.source_id,
+            source_incarnation,
+            reset_policy: config.reset_policy,
+            maximum_inter_group_skew_ms: config.maximum_inter_group_skew_ms,
+            source_epoch: 1,
+            ..Self::default()
+        }
+    }
 }
 
 /// One attitude update with its receive stamp.
@@ -101,37 +199,6 @@ pub struct KinematicsUpdate {
     pub received_at: Instant,
 }
 
-const RESET_PREVIOUS_MIN_MS: u32 = 30_000;
-const RESET_CANDIDATE_MAX_MS: u32 = 5_000;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ResetCandidate {
-    latest_time_ms: u32,
-    groups: u8,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MeasurementGroup {
-    Attitude,
-    Kinematics,
-}
-
-impl MeasurementGroup {
-    const fn bit(self) -> u8 {
-        match self {
-            Self::Attitude => 1,
-            Self::Kinematics => 2,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TimeObservation {
-    CurrentEpoch,
-    PendingReset,
-    NewEpoch,
-}
-
 /// A running MAVLink link: the receive task plus the shared latest-state
 /// cache the adapter samples from.
 #[derive(Debug)]
@@ -147,7 +214,10 @@ impl AviateLink {
     /// # Errors
     ///
     /// Returns [`AviateAdapterError::Bind`] when no socket can be bound.
-    pub async fn start(config: LinkConfig) -> Result<Self, AviateAdapterError> {
+    pub async fn start(
+        config: LinkConfig,
+        source_incarnation: SourceIncarnation,
+    ) -> Result<Self, AviateAdapterError> {
         let (socket, router_mode) = match UdpSocket::bind(config.endpoint).await {
             Ok(socket) => (socket, false),
             Err(direct_err) => {
@@ -163,7 +233,10 @@ impl AviateLink {
             endpoint = %config.endpoint,
             "Aviate MAVLink link listening"
         );
-        let state = Arc::new(Mutex::new(LatestAviate::default()));
+        let state = Arc::new(Mutex::new(LatestAviate::for_source(
+            config,
+            source_incarnation,
+        )));
         let task = tokio::spawn(run_link(
             socket,
             config.endpoint,
@@ -226,169 +299,34 @@ async fn run_link(
     }
 }
 
-fn serial_is_newer(candidate: u32, current: u32) -> bool {
-    let distance = candidate.wrapping_sub(current);
-    distance != 0 && distance < (1_u32 << 31)
-}
-
-fn begin_source_epoch(latest: &mut LatestAviate, time_boot_ms: u32) {
-    latest.source_epoch = latest.source_epoch.wrapping_add(1);
-    latest.last_source_time_ms = Some(time_boot_ms);
-    latest.pending_reset = None;
-    latest.attitude = None;
-    latest.kinematics = None;
-    latest.source_resets = latest.source_resets.wrapping_add(1);
-    warn!(
-        source_epoch = latest.source_epoch,
-        time_boot_ms, "MAVLink acquisition clock entered a new epoch"
-    );
-}
-
-fn observe_source_time(
-    latest: &mut LatestAviate,
-    group: MeasurementGroup,
-    time_boot_ms: u32,
-) -> TimeObservation {
-    let Some(current) = latest.last_source_time_ms else {
-        latest.last_source_time_ms = Some(time_boot_ms);
-        return TimeObservation::CurrentEpoch;
-    };
-    if serial_is_newer(time_boot_ms, current) {
-        if time_boot_ms < current {
-            begin_source_epoch(latest, time_boot_ms);
-            return TimeObservation::NewEpoch;
-        }
-        latest.last_source_time_ms = Some(time_boot_ms);
-        latest.pending_reset = None;
-        return TimeObservation::CurrentEpoch;
-    }
-    if time_boot_ms == current
-        || current < RESET_PREVIOUS_MIN_MS
-        || time_boot_ms > RESET_CANDIDATE_MAX_MS
-    {
-        latest.pending_reset = None;
-        return TimeObservation::CurrentEpoch;
-    }
-
-    let bit = group.bit();
-    match latest.pending_reset {
-        Some(candidate)
-            if serial_is_newer(time_boot_ms, candidate.latest_time_ms)
-                || candidate.groups & bit == 0 =>
-        {
-            begin_source_epoch(latest, time_boot_ms);
-            TimeObservation::NewEpoch
-        }
-        Some(_) => TimeObservation::PendingReset,
-        None => {
-            latest.pending_reset = Some(ResetCandidate {
-                latest_time_ms: time_boot_ms,
-                groups: bit,
-            });
-            TimeObservation::PendingReset
-        }
-    }
-}
-
-fn next_attitude_stamp(
-    latest: &mut LatestAviate,
-    sysid: u8,
-    time_boot_ms: u32,
-) -> Option<MeasurementStamp> {
-    if observe_source_time(latest, MeasurementGroup::Attitude, time_boot_ms)
-        == TimeObservation::PendingReset
-    {
-        return None;
-    }
-    next_group_stamp(
-        latest
-            .attitude
-            .map(|update| (update.time_boot_ms, update.stamp)),
-        latest,
-        sysid,
-        time_boot_ms,
-    )
-}
-
-fn next_kinematics_stamp(
-    latest: &mut LatestAviate,
-    sysid: u8,
-    time_boot_ms: u32,
-) -> Option<MeasurementStamp> {
-    if observe_source_time(latest, MeasurementGroup::Kinematics, time_boot_ms)
-        == TimeObservation::PendingReset
-    {
-        return None;
-    }
-    next_group_stamp(
-        latest
-            .kinematics
-            .map(|update| (update.time_boot_ms, update.stamp)),
-        latest,
-        sysid,
-        time_boot_ms,
-    )
-}
-
-fn next_group_stamp(
-    current: Option<(u32, MeasurementStamp)>,
-    latest: &mut LatestAviate,
-    sysid: u8,
-    time_boot_ms: u32,
-) -> Option<MeasurementStamp> {
-    let sequence = match current {
-        None => 0,
-        Some((current_time, _)) if current_time == time_boot_ms => {
-            latest.duplicate_measurements = latest.duplicate_measurements.wrapping_add(1);
-            return None;
-        }
-        Some((current_time, stamp)) if serial_is_newer(time_boot_ms, current_time) => {
-            stamp.sequence.wrapping_add(1)
-        }
-        Some(_) => {
-            latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
-            return None;
-        }
-    };
-    Some(MeasurementStamp {
-        source_id: u64::from(sysid),
-        source_epoch: latest.source_epoch,
-        sequence,
-        acquired_at_ns: u64::from(time_boot_ms).wrapping_mul(1_000_000),
-        clock: MeasurementClock::VehicleBoot,
-    })
-}
-
 /// Folds decoded messages into the shared cache. Kept synchronous and
 /// lock-scoped: the lock is never held across an await.
 fn apply_messages(
     state: &Arc<Mutex<LatestAviate>>,
-    messages: &[(u8, AviateMessage)],
+    messages: &[(FrameSource, AviateMessage)],
     crc_failures: u32,
     unknown_ids: u32,
 ) {
-    let now = Instant::now();
+    apply_messages_at(state, messages, crc_failures, unknown_ids, Instant::now());
+}
+
+fn apply_messages_at(
+    state: &Arc<Mutex<LatestAviate>>,
+    messages: &[(FrameSource, AviateMessage)],
+    crc_failures: u32,
+    unknown_ids: u32,
+    now: Instant,
+) {
     let Ok(mut latest) = state.lock() else {
         return;
     };
     latest.crc_failures = latest.crc_failures.wrapping_add(u64::from(crc_failures));
     latest.unknown_ids = latest.unknown_ids.wrapping_add(u64::from(unknown_ids));
-    for &(sysid, message) in messages {
+    for &(source, message) in messages {
         latest.decoded = latest.decoded.wrapping_add(1);
-        // Lock onto the first system id that delivers an estimate;
-        // heartbeats alone don't lock (other GCS peers heartbeat too).
-        let is_estimate = !matches!(
-            message,
-            AviateMessage::Heartbeat { .. } | AviateMessage::CommandAck { .. }
-        );
-        match latest.locked_sysid {
-            None if is_estimate => {
-                latest.locked_sysid = Some(sysid);
-                latest.source_epoch = 1;
-            }
-            Some(locked) if locked != sysid => continue,
-            None => continue,
-            Some(_) => {}
+        if source.system_id != latest.system_id || source.component_id != latest.component_id {
+            latest.wrong_sources = latest.wrong_sources.wrapping_add(1);
+            continue;
         }
         match message {
             AviateMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
@@ -398,7 +336,7 @@ fn apply_messages(
                 quat_wxyz,
                 rates_rps,
             } => {
-                if let Some(stamp) = next_attitude_stamp(&mut latest, sysid, time_boot_ms) {
+                if let Some(stamp) = next_attitude_stamp(&mut latest, time_boot_ms, now) {
                     latest.attitude = Some(AttitudeUpdate {
                         quat_wxyz,
                         rates_rps,
@@ -413,7 +351,7 @@ fn apply_messages(
                 pos_ned_m,
                 vel_ned_mps,
             } => {
-                if let Some(stamp) = next_kinematics_stamp(&mut latest, sysid, time_boot_ms) {
+                if let Some(stamp) = next_kinematics_stamp(&mut latest, time_boot_ms, now) {
                     latest.kinematics = Some(KinematicsUpdate {
                         pos_ned_m,
                         vel_ned_mps,

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -47,6 +47,14 @@ pub struct LinkConfig {
     pub reset_policy: ResetPolicy,
     /// Largest source-clock lag admitted when a second measurement group
     /// first joins or advances behind the epoch high-water mark.
+    ///
+    /// Zero (the fail-safe default) admits no inter-group lag at all: on
+    /// an interleaved multi-rate stream the slower group is rejected as
+    /// reordered every time the faster group advances the high-water
+    /// mark. Every real deployment must set a budget derived from its
+    /// source's publication rates — [`LinkConfig::simulator`] shows the
+    /// Aviate-derived example — and the link warns at startup when the
+    /// budget is zero so the rejection is loud, never silent.
     pub maximum_inter_group_skew_ms: u32,
 }
 
@@ -218,6 +226,13 @@ impl AviateLink {
         config: LinkConfig,
         source_incarnation: SourceIncarnation,
     ) -> Result<Self, AviateAdapterError> {
+        if config.maximum_inter_group_skew_ms == 0 {
+            warn!(
+                "inter-group skew budget is zero: the slower of any \
+                 interleaved measurement groups will be rejected as \
+                 reordered until a rate-derived budget is configured"
+            );
+        }
         let (socket, router_mode) = match UdpSocket::bind(config.endpoint).await {
             Ok(socket) => (socket, false),
             Err(direct_err) => {

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -10,6 +10,8 @@ use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+use pilotage_adapter_api::{MeasurementClock, MeasurementStamp};
+
 use crate::error::AviateAdapterError;
 use crate::mavlink::{AviateMessage, encode_gcs_heartbeat, parse_datagram};
 
@@ -55,6 +57,18 @@ pub struct LatestAviate {
     pub crc_failures: u64,
     /// Total structurally-valid frames with unknown ids.
     pub unknown_ids: u64,
+    /// Acquisition-clock generation for this FC connection.
+    pub source_epoch: u32,
+    /// Highest current-epoch FC boot timestamp observed across groups.
+    pub last_source_time_ms: Option<u32>,
+    /// Candidate low timestamps awaiting confirmation of an FC reboot.
+    pub(crate) pending_reset: Option<ResetCandidate>,
+    /// Duplicate group measurements rejected before entering the cache.
+    pub duplicate_measurements: u64,
+    /// Older group measurements rejected before entering the cache.
+    pub reordered_measurements: u64,
+    /// Confirmed reboot or acquisition-clock-wrap transitions.
+    pub source_resets: u64,
 }
 
 /// One attitude update with its receive stamp.
@@ -64,6 +78,10 @@ pub struct AttitudeUpdate {
     pub quat_wxyz: [f32; 4],
     /// Body rates (p, q, r) rad/s.
     pub rates_rps: [f32; 3],
+    /// Milliseconds since FC boot.
+    pub time_boot_ms: u32,
+    /// Identity and acquisition stamp for this group update.
+    pub stamp: MeasurementStamp,
     /// When this update was received.
     pub received_at: Instant,
 }
@@ -77,8 +95,41 @@ pub struct KinematicsUpdate {
     pub vel_ned_mps: [f32; 3],
     /// Milliseconds since FC boot.
     pub time_boot_ms: u32,
+    /// Identity and acquisition stamp for this group update.
+    pub stamp: MeasurementStamp,
     /// When this update was received.
     pub received_at: Instant,
+}
+
+const RESET_PREVIOUS_MIN_MS: u32 = 30_000;
+const RESET_CANDIDATE_MAX_MS: u32 = 5_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResetCandidate {
+    latest_time_ms: u32,
+    groups: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MeasurementGroup {
+    Attitude,
+    Kinematics,
+}
+
+impl MeasurementGroup {
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Attitude => 1,
+            Self::Kinematics => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeObservation {
+    CurrentEpoch,
+    PendingReset,
+    NewEpoch,
 }
 
 /// A running MAVLink link: the receive task plus the shared latest-state
@@ -175,6 +226,139 @@ async fn run_link(
     }
 }
 
+fn serial_is_newer(candidate: u32, current: u32) -> bool {
+    let distance = candidate.wrapping_sub(current);
+    distance != 0 && distance < (1_u32 << 31)
+}
+
+fn begin_source_epoch(latest: &mut LatestAviate, time_boot_ms: u32) {
+    latest.source_epoch = latest.source_epoch.wrapping_add(1);
+    latest.last_source_time_ms = Some(time_boot_ms);
+    latest.pending_reset = None;
+    latest.attitude = None;
+    latest.kinematics = None;
+    latest.source_resets = latest.source_resets.wrapping_add(1);
+    warn!(
+        source_epoch = latest.source_epoch,
+        time_boot_ms, "MAVLink acquisition clock entered a new epoch"
+    );
+}
+
+fn observe_source_time(
+    latest: &mut LatestAviate,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+) -> TimeObservation {
+    let Some(current) = latest.last_source_time_ms else {
+        latest.last_source_time_ms = Some(time_boot_ms);
+        return TimeObservation::CurrentEpoch;
+    };
+    if serial_is_newer(time_boot_ms, current) {
+        if time_boot_ms < current {
+            begin_source_epoch(latest, time_boot_ms);
+            return TimeObservation::NewEpoch;
+        }
+        latest.last_source_time_ms = Some(time_boot_ms);
+        latest.pending_reset = None;
+        return TimeObservation::CurrentEpoch;
+    }
+    if time_boot_ms == current
+        || current < RESET_PREVIOUS_MIN_MS
+        || time_boot_ms > RESET_CANDIDATE_MAX_MS
+    {
+        latest.pending_reset = None;
+        return TimeObservation::CurrentEpoch;
+    }
+
+    let bit = group.bit();
+    match latest.pending_reset {
+        Some(candidate)
+            if serial_is_newer(time_boot_ms, candidate.latest_time_ms)
+                || candidate.groups & bit == 0 =>
+        {
+            begin_source_epoch(latest, time_boot_ms);
+            TimeObservation::NewEpoch
+        }
+        Some(_) => TimeObservation::PendingReset,
+        None => {
+            latest.pending_reset = Some(ResetCandidate {
+                latest_time_ms: time_boot_ms,
+                groups: bit,
+            });
+            TimeObservation::PendingReset
+        }
+    }
+}
+
+fn next_attitude_stamp(
+    latest: &mut LatestAviate,
+    sysid: u8,
+    time_boot_ms: u32,
+) -> Option<MeasurementStamp> {
+    if observe_source_time(latest, MeasurementGroup::Attitude, time_boot_ms)
+        == TimeObservation::PendingReset
+    {
+        return None;
+    }
+    next_group_stamp(
+        latest
+            .attitude
+            .map(|update| (update.time_boot_ms, update.stamp)),
+        latest,
+        sysid,
+        time_boot_ms,
+    )
+}
+
+fn next_kinematics_stamp(
+    latest: &mut LatestAviate,
+    sysid: u8,
+    time_boot_ms: u32,
+) -> Option<MeasurementStamp> {
+    if observe_source_time(latest, MeasurementGroup::Kinematics, time_boot_ms)
+        == TimeObservation::PendingReset
+    {
+        return None;
+    }
+    next_group_stamp(
+        latest
+            .kinematics
+            .map(|update| (update.time_boot_ms, update.stamp)),
+        latest,
+        sysid,
+        time_boot_ms,
+    )
+}
+
+fn next_group_stamp(
+    current: Option<(u32, MeasurementStamp)>,
+    latest: &mut LatestAviate,
+    sysid: u8,
+    time_boot_ms: u32,
+) -> Option<MeasurementStamp> {
+    let sequence = match current {
+        None => 0,
+        Some((current_time, _)) if current_time == time_boot_ms => {
+            latest.duplicate_measurements = latest.duplicate_measurements.wrapping_add(1);
+            return None;
+        }
+        Some((current_time, stamp)) if serial_is_newer(time_boot_ms, current_time) => {
+            stamp.sequence.wrapping_add(1)
+        }
+        Some(_) => {
+            latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
+            return None;
+        }
+    };
+    Some(MeasurementStamp {
+        source_id: u64::from(sysid),
+        source_epoch: latest.source_epoch,
+        sequence,
+        acquired_at_ns: u64::from(time_boot_ms).wrapping_mul(1_000_000),
+        clock: MeasurementClock::VehicleBoot,
+    })
+}
+
 /// Folds decoded messages into the shared cache. Kept synchronous and
 /// lock-scoped: the lock is never held across an await.
 fn apply_messages(
@@ -198,7 +382,10 @@ fn apply_messages(
             AviateMessage::Heartbeat { .. } | AviateMessage::CommandAck { .. }
         );
         match latest.locked_sysid {
-            None if is_estimate => latest.locked_sysid = Some(sysid),
+            None if is_estimate => {
+                latest.locked_sysid = Some(sysid);
+                latest.source_epoch = 1;
+            }
             Some(locked) if locked != sysid => continue,
             None => continue,
             Some(_) => {}
@@ -207,27 +394,34 @@ fn apply_messages(
             AviateMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
             AviateMessage::CommandAck { .. } => {}
             AviateMessage::AttitudeQuaternion {
-                time_boot_ms: _,
+                time_boot_ms,
                 quat_wxyz,
                 rates_rps,
             } => {
-                latest.attitude = Some(AttitudeUpdate {
-                    quat_wxyz,
-                    rates_rps,
-                    received_at: now,
-                });
+                if let Some(stamp) = next_attitude_stamp(&mut latest, sysid, time_boot_ms) {
+                    latest.attitude = Some(AttitudeUpdate {
+                        quat_wxyz,
+                        rates_rps,
+                        time_boot_ms,
+                        stamp,
+                        received_at: now,
+                    });
+                }
             }
             AviateMessage::LocalPositionNed {
                 time_boot_ms,
                 pos_ned_m,
                 vel_ned_mps,
             } => {
-                latest.kinematics = Some(KinematicsUpdate {
-                    pos_ned_m,
-                    vel_ned_mps,
-                    time_boot_ms,
-                    received_at: now,
-                });
+                if let Some(stamp) = next_kinematics_stamp(&mut latest, sysid, time_boot_ms) {
+                    latest.kinematics = Some(KinematicsUpdate {
+                        pos_ned_m,
+                        vel_ned_mps,
+                        time_boot_ms,
+                        stamp,
+                        received_at: now,
+                    });
+                }
             }
         }
     }

--- a/adapters/aviate/src/link/measurement.rs
+++ b/adapters/aviate/src/link/measurement.rs
@@ -227,6 +227,10 @@ fn next_group_stamp(
         Some((current_time, stamp)) if serial_is_newer(time_boot_ms, current_time) => {
             stamp.sequence.wrapping_add(1)
         }
+        // observe_source_time admits only equal or serially newer times
+        // for a group that already has a measurement, so this arm is the
+        // exhaustiveness fail-safe: an older time that ever slipped
+        // through would still reject rather than regress the sequence.
         Some(_) => return reject_group(latest),
     };
     update_high_water(latest, time_boot_ms);

--- a/adapters/aviate/src/link/measurement.rs
+++ b/adapters/aviate/src/link/measurement.rs
@@ -1,0 +1,256 @@
+//! Measurement ordering and simulator reset quarantine.
+
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{MeasurementClock, MeasurementStamp};
+use tracing::warn;
+
+use super::{LatestAviate, ResetPolicy};
+
+const RESET_CANDIDATE_MAX_MS: u32 = 5_000;
+pub(super) const RESET_SILENCE: Duration = Duration::from_secs(3);
+pub(super) const RESET_RECEIVE_DWELL: Duration = Duration::from_millis(250);
+pub(super) const RESET_SOURCE_DWELL_MS: u32 = 250;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MeasurementGroup {
+    Attitude,
+    Kinematics,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResetCandidate {
+    group: MeasurementGroup,
+    first_time_ms: u32,
+    latest_time_ms: u32,
+    started_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeObservation {
+    CurrentEpoch,
+    PendingReset,
+    NewEpoch,
+    Rejected,
+}
+
+pub(super) fn serial_is_newer(candidate: u32, current: u32) -> bool {
+    let distance = candidate.wrapping_sub(current);
+    distance != 0 && distance < (1_u32 << 31)
+}
+
+fn begin_source_epoch(latest: &mut LatestAviate, time_boot_ms: u32) {
+    latest.source_epoch = latest.source_epoch.wrapping_add(1);
+    latest.last_source_time_ms = Some(time_boot_ms);
+    latest.last_accepted_at = None;
+    latest.pending_reset = None;
+    latest.attitude = None;
+    latest.kinematics = None;
+    latest.source_resets = latest.source_resets.wrapping_add(1);
+    warn!(
+        source_epoch = latest.source_epoch,
+        time_boot_ms, "MAVLink acquisition clock entered a new epoch"
+    );
+}
+
+fn accepted_stream_is_silent(latest: &LatestAviate, now: Instant) -> bool {
+    latest.last_accepted_at.is_none_or(|accepted| {
+        now.checked_duration_since(accepted)
+            .unwrap_or(Duration::ZERO)
+            >= RESET_SILENCE
+    })
+}
+
+fn reject_reordered(latest: &mut LatestAviate) -> TimeObservation {
+    latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
+    TimeObservation::Rejected
+}
+
+fn reset_candidate_or_reject(
+    latest: &mut LatestAviate,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    if time_boot_ms > RESET_CANDIDATE_MAX_MS
+        || latest.reset_policy == ResetPolicy::Conservative
+        || !accepted_stream_is_silent(latest, now)
+    {
+        reject_reordered(latest)
+    } else {
+        advance_reset_candidate(latest, group, time_boot_ms, now)
+    }
+}
+
+fn advance_reset_candidate(
+    latest: &mut LatestAviate,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    let Some(mut candidate) = latest.pending_reset else {
+        latest.pending_reset = Some(ResetCandidate {
+            group,
+            first_time_ms: time_boot_ms,
+            latest_time_ms: time_boot_ms,
+            started_at: now,
+        });
+        latest.suspected_resets = latest.suspected_resets.wrapping_add(1);
+        return TimeObservation::PendingReset;
+    };
+    if candidate.group != group || !serial_is_newer(time_boot_ms, candidate.latest_time_ms) {
+        return reject_reordered(latest);
+    }
+    candidate.latest_time_ms = time_boot_ms;
+    latest.pending_reset = Some(candidate);
+    let source_dwell = time_boot_ms.wrapping_sub(candidate.first_time_ms);
+    let receive_dwell = now
+        .checked_duration_since(candidate.started_at)
+        .unwrap_or(Duration::ZERO);
+    if source_dwell < RESET_SOURCE_DWELL_MS || receive_dwell < RESET_RECEIVE_DWELL {
+        return TimeObservation::PendingReset;
+    }
+    begin_source_epoch(latest, time_boot_ms);
+    TimeObservation::NewEpoch
+}
+
+fn observe_source_time(
+    latest: &mut LatestAviate,
+    group: MeasurementGroup,
+    current_time_ms: Option<u32>,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    if let Some(high_water) = latest.last_source_time_ms
+        && time_boot_ms < high_water
+        && serial_is_newer(time_boot_ms, high_water)
+    {
+        begin_source_epoch(latest, time_boot_ms);
+        return TimeObservation::NewEpoch;
+    }
+    if let Some(high_water) = latest.last_source_time_ms
+        && time_boot_ms < high_water
+        && high_water.wrapping_sub(time_boot_ms) > latest.maximum_inter_group_skew_ms
+    {
+        return reset_candidate_or_reject(latest, group, time_boot_ms, now);
+    }
+    let Some(current) = current_time_ms else {
+        latest.pending_reset = None;
+        return observe_initial_group(latest, time_boot_ms);
+    };
+    if time_boot_ms == current {
+        return TimeObservation::CurrentEpoch;
+    }
+    if time_boot_ms > current && serial_is_newer(time_boot_ms, current) {
+        latest.pending_reset = None;
+        return TimeObservation::CurrentEpoch;
+    }
+    reset_candidate_or_reject(latest, group, time_boot_ms, now)
+}
+
+fn observe_initial_group(latest: &mut LatestAviate, time_boot_ms: u32) -> TimeObservation {
+    let Some(high_water) = latest.last_source_time_ms else {
+        return TimeObservation::CurrentEpoch;
+    };
+    if time_boot_ms == high_water
+        || (time_boot_ms > high_water && serial_is_newer(time_boot_ms, high_water))
+    {
+        return TimeObservation::CurrentEpoch;
+    }
+    if time_boot_ms < high_water
+        && high_water.wrapping_sub(time_boot_ms) <= latest.maximum_inter_group_skew_ms
+    {
+        return TimeObservation::CurrentEpoch;
+    }
+    reject_reordered(latest)
+}
+
+pub(super) fn next_attitude_stamp(
+    latest: &mut LatestAviate,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .attitude
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::Attitude,
+        time_boot_ms,
+        now,
+    )
+}
+
+pub(super) fn next_kinematics_stamp(
+    latest: &mut LatestAviate,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .kinematics
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::Kinematics,
+        time_boot_ms,
+        now,
+    )
+}
+
+fn next_group_stamp(
+    current: Option<(u32, MeasurementStamp)>,
+    latest: &mut LatestAviate,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let observation = observe_source_time(
+        latest,
+        group,
+        current.map(|(time, _)| time),
+        time_boot_ms,
+        now,
+    );
+    let current = match observation {
+        TimeObservation::CurrentEpoch => current,
+        TimeObservation::NewEpoch => None,
+        TimeObservation::PendingReset | TimeObservation::Rejected => return None,
+    };
+    let sequence = match current {
+        None => 0,
+        Some((current_time, _)) if current_time == time_boot_ms => {
+            latest.duplicate_measurements = latest.duplicate_measurements.wrapping_add(1);
+            return None;
+        }
+        Some((current_time, stamp)) if serial_is_newer(time_boot_ms, current_time) => {
+            stamp.sequence.wrapping_add(1)
+        }
+        Some(_) => return reject_group(latest),
+    };
+    update_high_water(latest, time_boot_ms);
+    latest.last_accepted_at = Some(now);
+    Some(MeasurementStamp {
+        source_id: latest.source_id,
+        source_incarnation: latest.source_incarnation,
+        source_epoch: latest.source_epoch,
+        sequence,
+        acquired_at_ns: u64::from(time_boot_ms).wrapping_mul(1_000_000),
+        clock: MeasurementClock::VehicleBoot,
+    })
+}
+
+fn update_high_water(latest: &mut LatestAviate, time_boot_ms: u32) {
+    if latest
+        .last_source_time_ms
+        .is_none_or(|current| serial_is_newer(time_boot_ms, current))
+    {
+        latest.last_source_time_ms = Some(time_boot_ms);
+    }
+}
+
+fn reject_group(latest: &mut LatestAviate) -> Option<MeasurementStamp> {
+    latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
+    None
+}

--- a/adapters/aviate/src/link/tests.rs
+++ b/adapters/aviate/src/link/tests.rs
@@ -16,13 +16,21 @@ const SELECTED: FrameSource = FrameSource {
 };
 
 fn state(policy: ResetPolicy) -> Arc<Mutex<LatestAviate>> {
+    let maximum_inter_group_skew_ms = if policy == ResetPolicy::SimulatorHeuristic {
+        300
+    } else {
+        0
+    };
+    state_with_skew(policy, maximum_inter_group_skew_ms)
+}
+
+fn state_with_skew(
+    policy: ResetPolicy,
+    maximum_inter_group_skew_ms: u32,
+) -> Arc<Mutex<LatestAviate>> {
     Arc::new(Mutex::new(LatestAviate {
         reset_policy: policy,
-        maximum_inter_group_skew_ms: if policy == ResetPolicy::SimulatorHeuristic {
-            300
-        } else {
-            0
-        },
+        maximum_inter_group_skew_ms,
         source_incarnation: SourceIncarnation::new([0xA5; 16]),
         ..LatestAviate::default()
     }))
@@ -102,7 +110,7 @@ fn duplicate_and_reordered_group_updates_do_not_replace_the_cache() {
 
 #[test]
 fn advancing_groups_keep_independent_sequences() {
-    let state = state(ResetPolicy::Conservative);
+    let state = state_with_skew(ResetPolicy::Conservative, 20);
     let now = Instant::now();
     apply_at(
         &state,

--- a/adapters/aviate/src/link/tests.rs
+++ b/adapters/aviate/src/link/tests.rs
@@ -7,12 +7,27 @@ use crate::mavlink::AviateMessage;
 use super::{LatestAviate, apply_messages};
 
 fn attitude(sysid: u8, qw: f32) -> (u8, AviateMessage) {
+    attitude_at(sysid, 1, qw)
+}
+
+fn attitude_at(sysid: u8, time_boot_ms: u32, qw: f32) -> (u8, AviateMessage) {
     (
         sysid,
         AviateMessage::AttitudeQuaternion {
-            time_boot_ms: 1,
+            time_boot_ms,
             quat_wxyz: [qw, 0.0, 0.0, 0.0],
             rates_rps: [0.0; 3],
+        },
+    )
+}
+
+fn kinematics_at(sysid: u8, time_boot_ms: u32, north: f32) -> (u8, AviateMessage) {
+    (
+        sysid,
+        AviateMessage::LocalPositionNed {
+            time_boot_ms,
+            pos_ned_m: [north, 0.0, 0.0],
+            vel_ned_mps: [0.0; 3],
         },
     )
 }
@@ -35,4 +50,103 @@ fn locks_onto_the_first_vehicle_and_ignores_the_rest() {
     assert_eq!(latest.locked_sysid, Some(1));
     let att = latest.attitude.expect("attitude cached");
     assert_eq!(att.quat_wxyz[0], 0.5, "vehicle 2's estimate must not win");
+    assert_eq!(att.stamp.source_id, 1);
+    assert_eq!(att.stamp.source_epoch, 1);
+}
+
+#[test]
+fn duplicate_and_reordered_group_updates_do_not_replace_the_cache() {
+    let state = Arc::new(Mutex::new(LatestAviate::default()));
+    apply_messages(&state, &[attitude_at(1, 100, 0.5)], 0, 0);
+    apply_messages(&state, &[attitude_at(1, 100, 0.7)], 0, 0);
+    apply_messages(&state, &[attitude_at(1, 99, 0.9)], 0, 0);
+
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("attitude cached");
+    assert_eq!(att.quat_wxyz[0], 0.5);
+    assert_eq!(att.stamp.sequence, 0);
+    assert_eq!(latest.duplicate_measurements, 1);
+    assert_eq!(latest.reordered_measurements, 1);
+}
+
+#[test]
+fn advancing_groups_keep_independent_sequences() {
+    let state = Arc::new(Mutex::new(LatestAviate::default()));
+    apply_messages(
+        &state,
+        &[attitude_at(1, 100, 0.5), kinematics_at(1, 90, 1.0)],
+        0,
+        0,
+    );
+    apply_messages(
+        &state,
+        &[attitude_at(1, 110, 0.6), kinematics_at(1, 100, 2.0)],
+        0,
+        0,
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.attitude.expect("attitude").stamp.sequence, 1);
+    assert_eq!(latest.kinematics.expect("kinematics").stamp.sequence, 1);
+}
+
+#[test]
+fn reboot_requires_confirming_low_clock_progress() {
+    let state = Arc::new(Mutex::new(LatestAviate::default()));
+    apply_messages(
+        &state,
+        &[attitude_at(1, 60_000, 0.5), kinematics_at(1, 60_000, 1.0)],
+        0,
+        0,
+    );
+    apply_messages(&state, &[attitude_at(1, 100, 0.7)], 0, 0);
+    {
+        let latest = state.lock().expect("lock");
+        assert_eq!(latest.source_epoch, 1);
+        assert_eq!(latest.attitude.expect("old attitude").time_boot_ms, 60_000);
+    }
+
+    apply_messages(&state, &[kinematics_at(1, 100, 2.0)], 0, 0);
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 2);
+    assert!(latest.attitude.is_none());
+    assert_eq!(
+        latest
+            .kinematics
+            .expect("new epoch sample")
+            .stamp
+            .source_epoch,
+        2
+    );
+    assert_eq!(latest.source_resets, 1);
+}
+
+#[test]
+fn current_epoch_progress_cancels_an_unconfirmed_reset() {
+    let state = Arc::new(Mutex::new(LatestAviate::default()));
+    apply_messages(&state, &[attitude_at(1, 60_000, 0.5)], 0, 0);
+    apply_messages(&state, &[attitude_at(1, 100, 0.6)], 0, 0);
+    apply_messages(&state, &[attitude_at(1, 60_010, 0.7)], 0, 0);
+    apply_messages(&state, &[kinematics_at(1, 100, 2.0)], 0, 0);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(
+        latest.attitude.expect("current attitude").time_boot_ms,
+        60_010
+    );
+    assert!(latest.kinematics.is_none());
+}
+
+#[test]
+fn boot_clock_wrap_starts_an_explicit_epoch() {
+    let state = Arc::new(Mutex::new(LatestAviate::default()));
+    apply_messages(&state, &[attitude_at(1, u32::MAX - 5, 0.5)], 0, 0);
+    apply_messages(&state, &[attitude_at(1, 3, 0.6)], 0, 0);
+
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("wrapped sample");
+    assert_eq!(latest.source_epoch, 2);
+    assert_eq!(att.stamp.source_epoch, 2);
+    assert_eq!(att.stamp.sequence, 0);
 }

--- a/adapters/aviate/src/link/tests.rs
+++ b/adapters/aviate/src/link/tests.rs
@@ -1,18 +1,36 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
-use crate::mavlink::AviateMessage;
+use pilotage_adapter_api::SourceIncarnation;
 
-use super::{LatestAviate, apply_messages};
+use crate::mavlink::{AviateMessage, FrameSource};
 
-fn attitude(sysid: u8, qw: f32) -> (u8, AviateMessage) {
-    attitude_at(sysid, 1, qw)
+use super::{LatestAviate, ResetPolicy, apply_messages_at};
+
+const SELECTED: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 0,
+};
+
+fn state(policy: ResetPolicy) -> Arc<Mutex<LatestAviate>> {
+    Arc::new(Mutex::new(LatestAviate {
+        reset_policy: policy,
+        maximum_inter_group_skew_ms: if policy == ResetPolicy::SimulatorHeuristic {
+            300
+        } else {
+            0
+        },
+        source_incarnation: SourceIncarnation::new([0xA5; 16]),
+        ..LatestAviate::default()
+    }))
 }
 
-fn attitude_at(sysid: u8, time_boot_ms: u32, qw: f32) -> (u8, AviateMessage) {
+fn attitude_at(time_boot_ms: u32, qw: f32) -> (FrameSource, AviateMessage) {
     (
-        sysid,
+        SELECTED,
         AviateMessage::AttitudeQuaternion {
             time_boot_ms,
             quat_wxyz: [qw, 0.0, 0.0, 0.0],
@@ -21,9 +39,9 @@ fn attitude_at(sysid: u8, time_boot_ms: u32, qw: f32) -> (u8, AviateMessage) {
     )
 }
 
-fn kinematics_at(sysid: u8, time_boot_ms: u32, north: f32) -> (u8, AviateMessage) {
+fn kinematics_at(time_boot_ms: u32, north: f32) -> (FrameSource, AviateMessage) {
     (
-        sysid,
+        SELECTED,
         AviateMessage::LocalPositionNed {
             time_boot_ms,
             pos_ned_m: [north, 0.0, 0.0],
@@ -32,34 +50,47 @@ fn kinematics_at(sysid: u8, time_boot_ms: u32, north: f32) -> (u8, AviateMessage
     )
 }
 
-#[test]
-fn locks_onto_the_first_vehicle_and_ignores_the_rest() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    // A GCS peer heartbeat must not lock the link.
-    apply_messages(
-        &state,
-        &[(255, AviateMessage::Heartbeat { armed: false })],
-        0,
-        0,
-    );
-    assert!(state.lock().expect("lock").locked_sysid.is_none());
+fn apply_at(
+    state: &Arc<Mutex<LatestAviate>>,
+    messages: &[(FrameSource, AviateMessage)],
+    now: Instant,
+) {
+    apply_messages_at(state, messages, 0, 0, now);
+}
 
-    // First estimate locks; a second vehicle's estimate is ignored.
-    apply_messages(&state, &[attitude(1, 0.5), attitude(2, 0.9)], 0, 0);
+#[test]
+fn accepts_only_the_configured_system_and_component() {
+    let state = state(ResetPolicy::Conservative);
+    let mut wrong_system = attitude_at(1, 0.8);
+    wrong_system.0.system_id = 2;
+    let mut wrong_component = attitude_at(2, 0.9);
+    wrong_component.0.component_id = 42;
+    apply_at(
+        &state,
+        &[wrong_system, wrong_component, attitude_at(3, 0.5)],
+        Instant::now(),
+    );
+
     let latest = state.lock().expect("lock");
-    assert_eq!(latest.locked_sysid, Some(1));
-    let att = latest.attitude.expect("attitude cached");
-    assert_eq!(att.quat_wxyz[0], 0.5, "vehicle 2's estimate must not win");
-    assert_eq!(att.stamp.source_id, 1);
-    assert_eq!(att.stamp.source_epoch, 1);
+    assert_eq!(
+        latest.attitude.expect("selected attitude").quat_wxyz[0],
+        0.5
+    );
+    assert_eq!(latest.wrong_sources, 2);
+    assert_eq!(latest.attitude.expect("attitude").stamp.source_id, 1);
+    assert_eq!(
+        latest.attitude.expect("attitude").stamp.source_incarnation,
+        SourceIncarnation::new([0xA5; 16])
+    );
 }
 
 #[test]
 fn duplicate_and_reordered_group_updates_do_not_replace_the_cache() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    apply_messages(&state, &[attitude_at(1, 100, 0.5)], 0, 0);
-    apply_messages(&state, &[attitude_at(1, 100, 0.7)], 0, 0);
-    apply_messages(&state, &[attitude_at(1, 99, 0.9)], 0, 0);
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(&state, &[attitude_at(100, 0.5)], now);
+    apply_at(&state, &[attitude_at(100, 0.7)], now);
+    apply_at(&state, &[attitude_at(99, 0.9)], now);
 
     let latest = state.lock().expect("lock");
     let att = latest.attitude.expect("attitude cached");
@@ -71,82 +102,215 @@ fn duplicate_and_reordered_group_updates_do_not_replace_the_cache() {
 
 #[test]
 fn advancing_groups_keep_independent_sequences() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    apply_messages(
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(
         &state,
-        &[attitude_at(1, 100, 0.5), kinematics_at(1, 90, 1.0)],
-        0,
-        0,
+        &[attitude_at(100, 0.5), kinematics_at(90, 1.0)],
+        now,
     );
-    apply_messages(
+    apply_at(
         &state,
-        &[attitude_at(1, 110, 0.6), kinematics_at(1, 100, 2.0)],
-        0,
-        0,
+        &[attitude_at(110, 0.6), kinematics_at(100, 2.0)],
+        now + Duration::from_millis(10),
     );
 
     let latest = state.lock().expect("lock");
     assert_eq!(latest.attitude.expect("attitude").stamp.sequence, 1);
     assert_eq!(latest.kinematics.expect("kinematics").stamp.sequence, 1);
+    assert_eq!(latest.last_source_time_ms, Some(110));
 }
 
 #[test]
-fn reboot_requires_confirming_low_clock_progress() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    apply_messages(
+fn active_stream_low_clock_replay_is_rejected() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    apply_at(
         &state,
-        &[attitude_at(1, 60_000, 0.5), kinematics_at(1, 60_000, 1.0)],
-        0,
-        0,
+        &[attitude_at(100, 0.9)],
+        start + Duration::from_millis(100),
     );
-    apply_messages(&state, &[attitude_at(1, 100, 0.7)], 0, 0);
-    {
-        let latest = state.lock().expect("lock");
-        assert_eq!(latest.source_epoch, 1);
-        assert_eq!(latest.attitude.expect("old attitude").time_boot_ms, 60_000);
-    }
 
-    apply_messages(&state, &[kinematics_at(1, 100, 2.0)], 0, 0);
     let latest = state.lock().expect("lock");
-    assert_eq!(latest.source_epoch, 2);
-    assert!(latest.attitude.is_none());
-    assert_eq!(
-        latest
-            .kinematics
-            .expect("new epoch sample")
-            .stamp
-            .source_epoch,
-        2
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(latest.attitude.expect("current").time_boot_ms, 60_000);
+    assert!(latest.pending_reset.is_none());
+    assert_eq!(latest.reordered_measurements, 1);
+}
+
+#[test]
+fn delayed_single_replay_stays_quarantined() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    apply_at(
+        &state,
+        &[attitude_at(100, 0.9)],
+        start + Duration::from_secs(4),
     );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(latest.attitude.expect("old attitude").time_boot_ms, 60_000);
+    assert!(latest.pending_reset.is_some());
+    assert_eq!(latest.suspected_resets, 1);
+}
+
+#[test]
+fn same_datagram_cross_group_replay_cannot_confirm_reset() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(
+        &state,
+        &[attitude_at(60_000, 0.5), kinematics_at(60_000, 1.0)],
+        start,
+    );
+    apply_at(
+        &state,
+        &[attitude_at(100, 0.9), kinematics_at(100, 9.0)],
+        start + Duration::from_secs(4),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(latest.attitude.expect("old attitude").time_boot_ms, 60_000);
+    assert_eq!(
+        latest.kinematics.expect("old kinematics").time_boot_ms,
+        60_000
+    );
+    assert_eq!(latest.source_resets, 0);
+}
+
+fn confirm_attitude_reset(state: &Arc<Mutex<LatestAviate>>, start: Instant, first_low_ms: u32) {
+    apply_at(
+        state,
+        &[attitude_at(first_low_ms, 0.6)],
+        start + Duration::from_secs(4),
+    );
+    apply_at(
+        state,
+        &[attitude_at(first_low_ms.wrapping_add(100), 0.7)],
+        start + Duration::from_millis(4_100),
+    );
+    apply_at(
+        state,
+        &[attitude_at(first_low_ms.wrapping_add(300), 0.8)],
+        start + Duration::from_millis(4_400),
+    );
+}
+
+#[test]
+fn simulator_reset_requires_same_group_source_and_receive_dwell() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    confirm_attitude_reset(&state, start, 100);
+
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("new epoch sample");
+    assert_eq!(latest.source_epoch, 2);
+    assert_eq!(attitude.time_boot_ms, 400);
+    assert_eq!(attitude.stamp.source_epoch, 2);
+    assert_eq!(attitude.stamp.sequence, 0);
     assert_eq!(latest.source_resets, 1);
 }
 
 #[test]
-fn current_epoch_progress_cancels_an_unconfirmed_reset() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    apply_messages(&state, &[attitude_at(1, 60_000, 0.5)], 0, 0);
-    apply_messages(&state, &[attitude_at(1, 100, 0.6)], 0, 0);
-    apply_messages(&state, &[attitude_at(1, 60_010, 0.7)], 0, 0);
-    apply_messages(&state, &[kinematics_at(1, 100, 2.0)], 0, 0);
-
-    let latest = state.lock().expect("lock");
-    assert_eq!(latest.source_epoch, 1);
-    assert_eq!(
-        latest.attitude.expect("current attitude").time_boot_ms,
-        60_010
-    );
-    assert!(latest.kinematics.is_none());
+fn short_prior_boot_can_transition_only_after_silence_and_dwell() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(1_000, 0.5)], start);
+    confirm_attitude_reset(&state, start, 10);
+    assert_eq!(state.lock().expect("lock").source_epoch, 2);
 }
 
 #[test]
-fn boot_clock_wrap_starts_an_explicit_epoch() {
-    let state = Arc::new(Mutex::new(LatestAviate::default()));
-    apply_messages(&state, &[attitude_at(1, u32::MAX - 5, 0.5)], 0, 0);
-    apply_messages(&state, &[attitude_at(1, 3, 0.6)], 0, 0);
+fn conservative_policy_never_infers_replayable_reset() {
+    let state = state(ResetPolicy::Conservative);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    confirm_attitude_reset(&state, start, 100);
 
     let latest = state.lock().expect("lock");
-    let att = latest.attitude.expect("wrapped sample");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(latest.attitude.expect("old attitude").time_boot_ms, 60_000);
+}
+
+#[test]
+fn boot_clock_wrap_starts_an_explicit_epoch_without_reboot_heuristic() {
+    let state = state(ResetPolicy::Conservative);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(u32::MAX - 5, 0.5)], start);
+    apply_at(
+        &state,
+        &[attitude_at(3, 0.8)],
+        start + Duration::from_millis(10),
+    );
+
+    let latest = state.lock().expect("lock");
     assert_eq!(latest.source_epoch, 2);
-    assert_eq!(att.stamp.source_epoch, 2);
-    assert_eq!(att.stamp.sequence, 0);
+    assert_eq!(latest.attitude.expect("wrapped sample").time_boot_ms, 3);
+}
+
+#[test]
+fn absent_group_quarantines_low_clock_replay_below_epoch_high_water() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    apply_at(
+        &state,
+        &[kinematics_at(100, 9.0)],
+        start + Duration::from_secs(4),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert!(latest.kinematics.is_none());
+    assert_eq!(latest.last_source_time_ms, Some(60_000));
+    assert_eq!(latest.suspected_resets, 1);
+    assert!(latest.pending_reset.is_some());
+}
+
+#[test]
+fn established_group_cannot_advance_far_behind_epoch_high_water() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[kinematics_at(1_000, 1.0)], start);
+    apply_at(
+        &state,
+        &[attitude_at(10_000, 0.5)],
+        start + Duration::from_millis(1),
+    );
+    apply_at(
+        &state,
+        &[kinematics_at(1_100, 9.0)],
+        start + Duration::from_millis(2),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.last_source_time_ms, Some(10_000));
+    assert_eq!(latest.kinematics.expect("current").time_boot_ms, 1_000);
+    assert_eq!(latest.reordered_measurements, 1);
+}
+
+#[test]
+fn current_epoch_progress_cancels_an_unconfirmed_reset() {
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let start = Instant::now();
+    apply_at(&state, &[attitude_at(60_000, 0.5)], start);
+    apply_at(
+        &state,
+        &[attitude_at(100, 0.6)],
+        start + Duration::from_secs(4),
+    );
+    apply_at(
+        &state,
+        &[attitude_at(60_010, 0.7)],
+        start + Duration::from_millis(4_010),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(latest.attitude.expect("current").time_boot_ms, 60_010);
+    assert!(latest.pending_reset.is_none());
 }

--- a/adapters/aviate/src/mavlink.rs
+++ b/adapters/aviate/src/mavlink.rs
@@ -70,6 +70,17 @@ pub struct ParseStats {
     pub garbage_bytes: u32,
 }
 
+/// Sender identity retained from one MAVLink frame header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameSource {
+    /// MAVLink system identifier.
+    pub system_id: u8,
+    /// MAVLink component identifier within the system.
+    pub component_id: u8,
+    /// Sender's wrapping frame sequence, retained for diagnostics.
+    pub frame_sequence: u8,
+}
+
 /// COMMAND_LONG message id (uplink: arm/disarm).
 pub const COMMAND_LONG_ID: u32 = 76;
 /// SET_POSITION_TARGET_LOCAL_NED message id (uplink: velocity setpoints).
@@ -164,12 +175,12 @@ fn decode_known(msg_id: u32, payload: &[u8]) -> Option<AviateMessage> {
 }
 
 /// Parses every MAVLink 2.0 frame in `bytes` (a UDP datagram may carry
-/// several), appending `(sender system id, message)` pairs to `out` and
-/// returning parse accounting. The system id lets a consumer on a routed
-/// link (several vehicles, plus other GCS peers) lock onto one vehicle.
+/// several), appending `(sender identity, message)` pairs to `out` and
+/// returning parse accounting. Consumers match both system and component ids;
+/// first-packet source selection is not an identity policy.
 /// Unknown ids and CRC failures skip the frame; stray bytes before a
 /// frame start are discarded byte-by-byte.
-pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(u8, AviateMessage)>) -> ParseStats {
+pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>) -> ParseStats {
     let mut stats = ParseStats::default();
     let mut at = 0usize;
     while at < bytes.len() {
@@ -192,7 +203,11 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(u8, AviateMessage)>) -> Parse
             stats.garbage_bytes = stats.garbage_bytes.wrapping_add((bytes.len() - at) as u32);
             break;
         };
-        let sysid = frame[5];
+        let source = FrameSource {
+            frame_sequence: frame[4],
+            system_id: frame[5],
+            component_id: frame[6],
+        };
         let msg_id = u32::from(frame[7]) | (u32::from(frame[8]) << 8) | (u32::from(frame[9]) << 16);
         let crc_at = 10 + payload_len;
         let wire_crc = u16::from(frame[crc_at]) | (u16::from(frame[crc_at + 1]) << 8);
@@ -201,7 +216,7 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(u8, AviateMessage)>) -> Parse
                 let computed = compute_crc(&frame[1..crc_at], extra);
                 if computed == wire_crc {
                     if let Some(msg) = decode_known(msg_id, &frame[10..crc_at]) {
-                        out.push((sysid, msg));
+                        out.push((source, msg));
                         stats.decoded = stats.decoded.wrapping_add(1);
                     }
                 } else {
@@ -258,18 +273,18 @@ pub fn encode_gcs_heartbeat(seq: u8) -> [u8; 21] {
     frame
 }
 
-/// Serializes a COMMAND_LONG arm/disarm frame (MAV_CMD 400) addressed to
-/// system 1 / component 1 (the Aviate FC's SITL identity).
+/// Serializes a COMMAND_LONG arm/disarm frame (MAV_CMD 400) for the selected
+/// MAVLink system and component.
 ///
 /// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
 /// target_system @30, target_component @31, confirmation @32.
-pub fn encode_arm_command(seq: u8, arm: bool) -> [u8; 45] {
+pub fn encode_arm_command(seq: u8, arm: bool, target_system: u8, target_component: u8) -> [u8; 45] {
     let mut payload = [0u8; 33];
     let param1: f32 = if arm { 1.0 } else { 0.0 };
     payload[0..4].copy_from_slice(&param1.to_le_bytes());
     payload[28..30].copy_from_slice(&400u16.to_le_bytes());
-    payload[30] = 1;
-    payload[31] = 1;
+    payload[30] = target_system;
+    payload[31] = target_component;
     let mut frame = [0u8; 45];
     encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
     frame
@@ -290,6 +305,8 @@ pub fn encode_position_setpoint(
     time_boot_ms: u32,
     pos_ned_m: [f32; 3],
     yaw_rad: f32,
+    target_system: u8,
+    target_component: u8,
 ) -> [u8; 65] {
     // Ignore velocity (8|16|32), acceleration (64|128|256), yaw rate
     // (2048): position + absolute yaw remain.
@@ -301,8 +318,8 @@ pub fn encode_position_setpoint(
     payload[12..16].copy_from_slice(&pos_ned_m[2].to_le_bytes());
     payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
     payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
-    payload[50] = 1;
-    payload[51] = 1;
+    payload[50] = target_system;
+    payload[51] = target_component;
     payload[52] = 1; // MAV_FRAME_LOCAL_NED
     let mut frame = [0u8; 65];
     encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
@@ -323,6 +340,8 @@ pub fn encode_velocity_setpoint(
     time_boot_ms: u32,
     vel_ned_mps: [f32; 3],
     yaw_rad: f32,
+    target_system: u8,
+    target_component: u8,
 ) -> [u8; 65] {
     // Ignore position (1|2|4), acceleration (64|128|256), yaw rate (2048):
     // velocity + absolute yaw remain.
@@ -334,31 +353,44 @@ pub fn encode_velocity_setpoint(
     payload[24..28].copy_from_slice(&vel_ned_mps[2].to_le_bytes());
     payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
     payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
-    payload[50] = 1; // target system
-    payload[51] = 1; // target component
+    payload[50] = target_system;
+    payload[51] = target_component;
     payload[52] = 1; // MAV_FRAME_LOCAL_NED
     let mut frame = [0u8; 65];
     encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
     frame
 }
 
-/// Encodes SET_ATTITUDE_TARGET (msg 82) commanding an absolute
-/// attitude (roll/pitch/yaw euler, radians, NED/ZYX) plus normalized
-/// collective thrust — the FPV mode uplink. Body-rate fields are
-/// masked out (type_mask 0b111): the FC's attitude loop derives its
-/// own rate commands.
-pub fn encode_attitude_setpoint(
+/// Absolute FPV attitude demand and the component selected to receive it.
+///
+/// Body-rate demand is intentionally absent because the FC attitude loop
+/// derives rate commands from this target.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct AttitudeTarget {
+    /// Roll demand in radians.
+    pub roll_rad: f32,
+    /// Pitch demand in radians.
+    pub pitch_rad: f32,
+    /// Yaw demand in radians.
+    pub yaw_rad: f32,
+    /// Normalized collective thrust.
+    pub thrust: f32,
+    /// Selected MAVLink system id.
+    pub system_id: u8,
+    /// Selected MAVLink component id.
+    pub component_id: u8,
+}
+
+/// Encodes one absolute attitude target for the selected component.
+pub(crate) fn encode_attitude_setpoint(
     seq: u8,
     time_boot_ms: u32,
-    roll_rad: f32,
-    pitch_rad: f32,
-    yaw_rad: f32,
-    thrust: f32,
+    target: AttitudeTarget,
 ) -> [u8; 51] {
     const SET_ATTITUDE_TARGET_ID: u32 = 82;
-    let (sr, cr) = (roll_rad * 0.5).sin_cos();
-    let (sp, cp) = (pitch_rad * 0.5).sin_cos();
-    let (sy, cy) = (yaw_rad * 0.5).sin_cos();
+    let (sr, cr) = (target.roll_rad * 0.5).sin_cos();
+    let (sp, cp) = (target.pitch_rad * 0.5).sin_cos();
+    let (sy, cy) = (target.yaw_rad * 0.5).sin_cos();
     let q = [
         cr * cp * cy + sr * sp * sy,
         sr * cp * cy - cr * sp * sy,
@@ -371,9 +403,9 @@ pub fn encode_attitude_setpoint(
         payload[4 + i * 4..8 + i * 4].copy_from_slice(&w.to_le_bytes());
     }
     // body rates [20..32) stay zero (masked); thrust at [32..36).
-    payload[32..36].copy_from_slice(&thrust.clamp(0.0, 1.0).to_le_bytes());
-    payload[36] = 1; // target system
-    payload[37] = 1; // target component
+    payload[32..36].copy_from_slice(&target.thrust.clamp(0.0, 1.0).to_le_bytes());
+    payload[36] = target.system_id;
+    payload[37] = target.component_id;
     payload[38] = 0b0000_0111; // ignore body roll/pitch/yaw rate
     let mut frame = [0u8; 51];
     encode_frame_v2(seq, SET_ATTITUDE_TARGET_ID, &payload, 49, &mut frame);

--- a/adapters/aviate/src/mavlink/tests.rs
+++ b/adapters/aviate/src/mavlink/tests.rs
@@ -1,8 +1,14 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use super::{
-    ATTITUDE_QUATERNION_ID, AviateMessage, LOCAL_POSITION_NED_ID, MAGIC_V2, encode_gcs_heartbeat,
-    parse_datagram,
+    ATTITUDE_QUATERNION_ID, AviateMessage, FrameSource, LOCAL_POSITION_NED_ID, MAGIC_V2,
+    encode_gcs_heartbeat, parse_datagram,
+};
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 7,
 };
 
 /// Test-side serializer: builds a MAVLink 2.0 frame the way Aviate's
@@ -75,14 +81,14 @@ fn decodes_attitude_and_position_from_one_datagram() {
         false,
     ));
 
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&datagram, &mut out);
     assert_eq!(stats.decoded, 2);
     assert_eq!(stats.crc_failures, 0);
     assert_eq!(
         out[0],
         (
-            1,
+            SOURCE,
             AviateMessage::AttitudeQuaternion {
                 time_boot_ms: 1234,
                 quat_wxyz: q,
@@ -93,7 +99,7 @@ fn decodes_attitude_and_position_from_one_datagram() {
     assert_eq!(
         out[1],
         (
-            1,
+            SOURCE,
             AviateMessage::LocalPositionNed {
                 time_boot_ms: 1250,
                 pos_ned_m: pos,
@@ -112,13 +118,13 @@ fn v2_truncated_payload_zero_extends() {
         &attitude_payload(q, [0.0; 3], 99),
         true,
     );
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame, &mut out);
     assert_eq!(stats.decoded, 1, "stats: {stats:?}");
     assert_eq!(
         out[0],
         (
-            1,
+            SOURCE,
             AviateMessage::AttitudeQuaternion {
                 time_boot_ms: 99,
                 quat_wxyz: q,
@@ -136,7 +142,7 @@ fn corrupted_frame_fails_crc_and_is_skipped() {
         false,
     );
     frame[12] ^= 0xff;
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame, &mut out);
     assert_eq!(stats.crc_failures, 1);
     assert!(out.is_empty());
@@ -151,7 +157,7 @@ fn unknown_message_id_is_counted_and_skipped_whole() {
         &local_position_payload([0.0; 3], [1.0; 3], 1),
         false,
     ));
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&datagram, &mut out);
     assert_eq!(stats.unknown_ids, 1);
     assert_eq!(stats.decoded, 1, "the frame after the unknown id decodes");
@@ -161,25 +167,38 @@ fn unknown_message_id_is_counted_and_skipped_whole() {
 fn garbage_prefix_resyncs_to_the_next_frame() {
     let mut datagram = vec![0x00, 0x42, 0x13];
     datagram.extend_from_slice(&encode_frame(0, &[0u8; 9], false));
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&datagram, &mut out);
     assert_eq!(stats.garbage_bytes, 3);
-    assert_eq!(out, vec![(1, AviateMessage::Heartbeat { armed: false })]);
+    assert_eq!(
+        out,
+        vec![(SOURCE, AviateMessage::Heartbeat { armed: false })]
+    );
 }
 
 #[test]
 fn gcs_heartbeat_parses_back_as_heartbeat() {
     let frame = encode_gcs_heartbeat(4);
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame, &mut out);
     assert_eq!(stats.decoded, 1, "stats: {stats:?}");
-    assert_eq!(out, vec![(255, AviateMessage::Heartbeat { armed: false })]);
+    assert_eq!(
+        out,
+        vec![(
+            FrameSource {
+                system_id: 255,
+                component_id: 190,
+                frame_sequence: 4,
+            },
+            AviateMessage::Heartbeat { armed: false }
+        )]
+    );
 }
 
 #[test]
 fn truncated_tail_is_garbage_not_panic() {
     let frame = encode_frame(0, &[0u8; 9], false);
-    let mut out: Vec<(u8, AviateMessage)> = Vec::new();
+    let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame[..frame.len() - 3], &mut out);
     assert!(out.is_empty());
     assert!(stats.garbage_bytes > 0);

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -17,6 +17,12 @@ use std::time::Instant;
 
 use crate::error::AviateAdapterError;
 
+// libc::dev_t differs in signedness and width across supported Unix targets.
+#[allow(clippy::unnecessary_cast)]
+const fn device_identity(device: libc::dev_t) -> u64 {
+    device as u64
+}
+
 /// Byte size of `AviateSharedState` (natural C alignment, all fields
 /// 8-byte aligned or packed tail).
 const SHM_SIZE: usize = 216;
@@ -151,7 +157,7 @@ impl GzStateShm {
             (
                 ptr.cast::<u8>().cast_const(),
                 ShmIdentity {
-                    device: metadata.st_dev as u64,
+                    device: device_identity(metadata.st_dev),
                     inode: metadata.st_ino,
                     size,
                 },

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -52,6 +52,26 @@ pub struct GzStateSample {
 #[derive(Debug)]
 pub struct GzStateShm {
     base: *const u8,
+    identity: ShmIdentity,
+}
+
+/// Stable operating-system identity of one POSIX shared-memory object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShmIdentity {
+    device: u64,
+    inode: u64,
+    size: u64,
+}
+
+/// Progress classification for one coherent SHM observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShmObservation {
+    /// Sequence and acquisition time advanced in the same incarnation.
+    Advancing,
+    /// The same coherent sample remains mapped, with its frozen duration.
+    Unchanged(std::time::Duration),
+    /// Sequence or acquisition time rolled back on the same SHM object.
+    Quarantined,
 }
 
 // SAFETY: the mapping is process-private, read-only, and lives for the
@@ -66,30 +86,50 @@ impl GzStateShm {
     ///
     /// # Errors
     ///
-    /// Returns [`AviateAdapterError::ShmUnavailable`] when the region
-    /// does not exist (no SITL running) or cannot be mapped.
+    /// Returns a typed [`AviateAdapterError`] when the region does not
+    /// exist, its ABI size differs, or it cannot be mapped.
     pub fn open(instance: u8) -> Result<Self, AviateAdapterError> {
         let name = if instance == 0 {
             "/aviate_gz_bridge".to_owned()
         } else {
             format!("/aviate_gz_bridge_{instance}")
         };
-        let c_name =
-            CString::new(name.clone()).map_err(|_| AviateAdapterError::ShmUnavailable {
-                name: name.clone(),
-                detail: "name contains a NUL byte".to_owned(),
-            })?;
+        let c_name = CString::new(name.clone()).map_err(|source| AviateAdapterError::ShmName {
+            name: name.clone(),
+            source,
+        })?;
         // SAFETY: shm_open/mmap with a valid, NUL-terminated name;
         // read-only PROT_READ/O_RDONLY so no writer state can be
         // corrupted; fd is closed after mapping (POSIX keeps the mapping
         // alive); MAP_FAILED and negative fds are checked before use.
         #[allow(unsafe_code)]
-        let base = unsafe {
+        let (base, identity) = unsafe {
             let fd = libc::shm_open(c_name.as_ptr(), libc::O_RDONLY, 0);
             if fd < 0 {
-                return Err(AviateAdapterError::ShmUnavailable {
+                return Err(AviateAdapterError::ShmIo {
                     name,
-                    detail: std::io::Error::last_os_error().to_string(),
+                    operation: "shm_open",
+                    source: std::io::Error::last_os_error(),
+                });
+            }
+            let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+            if libc::fstat(fd, metadata.as_mut_ptr()) != 0 {
+                let source = std::io::Error::last_os_error();
+                libc::close(fd);
+                return Err(AviateAdapterError::ShmIo {
+                    name,
+                    operation: "fstat",
+                    source,
+                });
+            }
+            let metadata = metadata.assume_init();
+            let size = u64::try_from(metadata.st_size).unwrap_or(u64::MAX);
+            if size != SHM_SIZE as u64 {
+                libc::close(fd);
+                return Err(AviateAdapterError::ShmSizeMismatch {
+                    name,
+                    expected: SHM_SIZE,
+                    actual: size,
                 });
             }
             let ptr = libc::mmap(
@@ -102,14 +142,28 @@ impl GzStateShm {
             );
             libc::close(fd);
             if ptr == libc::MAP_FAILED {
-                return Err(AviateAdapterError::ShmUnavailable {
+                return Err(AviateAdapterError::ShmIo {
                     name,
-                    detail: std::io::Error::last_os_error().to_string(),
+                    operation: "mmap",
+                    source: std::io::Error::last_os_error(),
                 });
             }
-            ptr.cast::<u8>().cast_const()
+            (
+                ptr.cast::<u8>().cast_const(),
+                ShmIdentity {
+                    device: metadata.st_dev as u64,
+                    inode: metadata.st_ino,
+                    size,
+                },
+            )
         };
-        Ok(Self { base })
+        Ok(Self { base, identity })
+    }
+
+    /// Returns the POSIX object identity captured before the mapping opened.
+    #[must_use]
+    pub const fn identity(&self) -> ShmIdentity {
+        self.identity
     }
 
     /// Copies the block byte-by-byte (volatile: the plugin writes
@@ -233,26 +287,62 @@ fn enu_quat_to_ned(q: [f64; 4]) -> [f32; 4] {
 #[derive(Debug)]
 pub struct ShmFreshness {
     last_seq: Option<u32>,
+    last_time_us: Option<u64>,
     last_progress: Instant,
+    quarantined: bool,
 }
 
 impl ShmFreshness {
     /// Starts tracking.
     pub fn new() -> Self {
+        Self::new_at(Instant::now())
+    }
+
+    pub(crate) fn new_at(now: Instant) -> Self {
         Self {
             last_seq: None,
-            last_progress: Instant::now(),
+            last_time_us: None,
+            last_progress: now,
+            quarantined: false,
         }
     }
 
     /// Feeds the latest observed `seq`; returns how long the block has
     /// been frozen (zero while it keeps advancing).
-    pub fn observe(&mut self, seq: u32) -> std::time::Duration {
-        if self.last_seq != Some(seq) {
-            self.last_seq = Some(seq);
-            self.last_progress = Instant::now();
+    pub fn observe(&mut self, seq: u32, time_us: u64) -> ShmObservation {
+        self.observe_at(seq, time_us, Instant::now())
+    }
+
+    pub(crate) fn observe_at(&mut self, seq: u32, time_us: u64, now: Instant) -> ShmObservation {
+        if self.quarantined {
+            return ShmObservation::Quarantined;
         }
-        self.last_progress.elapsed()
+        let observation = match (self.last_seq, self.last_time_us) {
+            (Some(previous_seq), Some(previous_time))
+                if seq == previous_seq && time_us == previous_time =>
+            {
+                ShmObservation::Unchanged(
+                    now.checked_duration_since(self.last_progress)
+                        .unwrap_or_default(),
+                )
+            }
+            (Some(previous_seq), Some(previous_time))
+                if serial_is_newer(seq, previous_seq) && time_us > previous_time =>
+            {
+                ShmObservation::Advancing
+            }
+            (None, None) => ShmObservation::Advancing,
+            _ => {
+                self.quarantined = true;
+                ShmObservation::Quarantined
+            }
+        };
+        if observation == ShmObservation::Advancing {
+            self.last_seq = Some(seq);
+            self.last_time_us = Some(time_us);
+            self.last_progress = now;
+        }
+        observation
     }
 
     /// Marks an unreadable/invalid block; returns how long since the
@@ -260,6 +350,16 @@ impl ShmFreshness {
     pub fn observe_absent(&mut self) -> std::time::Duration {
         self.last_progress.elapsed()
     }
+
+    pub(crate) fn observe_absent_at(&self, now: Instant) -> std::time::Duration {
+        now.checked_duration_since(self.last_progress)
+            .unwrap_or_default()
+    }
+}
+
+fn serial_is_newer(candidate: u32, current: u32) -> bool {
+    let distance = candidate.wrapping_sub(current);
+    distance != 0 && distance < (1_u32 << 31)
 }
 
 impl Default for ShmFreshness {

--- a/adapters/aviate/src/shm/tests.rs
+++ b/adapters/aviate/src/shm/tests.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use super::{SHM_SIZE, decode_sample, enu_quat_to_ned, enu_to_ned};
+use std::time::{Duration, Instant};
+
+use super::{SHM_SIZE, ShmFreshness, ShmObservation, decode_sample, enu_quat_to_ned, enu_to_ned};
 
 fn put_f64(buf: &mut [u8; SHM_SIZE], off: usize, v: f64) {
     buf[off..off + 8].copy_from_slice(&v.to_ne_bytes());
@@ -50,4 +52,57 @@ fn block_decodes_positions_velocities_and_time() {
     assert_eq!(s.vel_ned_mps, [0.0, 0.5, 1.0]);
     assert_eq!(s.time_us, 42_000_000);
     assert_eq!(s.seq, 7);
+}
+
+#[test]
+fn frozen_sample_never_revives_without_a_new_identity() {
+    let start = Instant::now();
+    let mut freshness = ShmFreshness::new_at(start);
+    assert_eq!(
+        freshness.observe_at(7, 42_000, start),
+        ShmObservation::Advancing
+    );
+    assert_eq!(
+        freshness.observe_at(7, 42_000, start + Duration::from_secs(4)),
+        ShmObservation::Unchanged(Duration::from_secs(4))
+    );
+    assert_eq!(
+        freshness.observe_at(7, 42_000, start + Duration::from_secs(8)),
+        ShmObservation::Unchanged(Duration::from_secs(8))
+    );
+}
+
+#[test]
+fn same_object_rollback_is_quarantined_but_sequence_wrap_is_valid() {
+    let start = Instant::now();
+    let mut wrapped = ShmFreshness::new_at(start);
+    assert_eq!(
+        wrapped.observe_at(u32::MAX, 100, start),
+        ShmObservation::Advancing
+    );
+    assert_eq!(
+        wrapped.observe_at(0, 101, start + Duration::from_millis(1)),
+        ShmObservation::Advancing
+    );
+
+    let mut reset = ShmFreshness::new_at(start);
+    assert_eq!(reset.observe_at(100, 100, start), ShmObservation::Advancing);
+    assert_eq!(
+        reset.observe_at(1, 1, start + Duration::from_millis(1)),
+        ShmObservation::Quarantined
+    );
+    assert_eq!(
+        reset.observe_at(101, 101, start + Duration::from_secs(1)),
+        ShmObservation::Quarantined
+    );
+
+    let mut unchanged_clock = ShmFreshness::new_at(start);
+    assert_eq!(
+        unchanged_clock.observe_at(10, 500, start),
+        ShmObservation::Advancing
+    );
+    assert_eq!(
+        unchanged_clock.observe_at(11, 500, start + Duration::from_millis(1)),
+        ShmObservation::Quarantined
+    );
 }

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -1,5 +1,4 @@
-//! DJI-style flight uplink: stick positions become velocity setpoints
-//! (issue #12).
+//! DJI-style flight uplink: stick positions become velocity setpoints.
 //!
 //! The control law, not the stick map, is what makes a camera drone feel
 //! like one: sticks command **velocities**, centered sticks command
@@ -130,11 +129,18 @@ impl FlightUplink {
         self.seq = self.seq.wrapping_add(1);
     }
 
-    /// Sends arm/disarm and re-seeds the heading setpoint from the
-    /// vehicle's current yaw so the first yaw-stick input turns from
-    /// where the aircraft actually points.
-    pub fn send_arm(&mut self, arm: bool, current_yaw_rad: f32) {
+    /// Arms and re-seeds heading from the measured yaw.
+    pub fn send_arm(&mut self, current_yaw_rad: f32) {
         self.heading_sp_rad = current_yaw_rad;
+        self.send_arm_command(true);
+    }
+
+    /// Disarms without requiring a measurement that may have failed.
+    pub fn send_disarm(&mut self) {
+        self.send_arm_command(false);
+    }
+
+    fn send_arm_command(&mut self, arm: bool) {
         self.last_frame = None;
         self.quiet_until = Some(Instant::now() + ARM_QUIET);
         self.airborne = false;
@@ -151,9 +157,8 @@ impl FlightUplink {
     }
 
     /// Converts one canonical stick frame into an FPV attitude
-    /// setpoint: roll/pitch sticks command *angles* (rate-style FPV
-    /// acro is a follow-up), the yaw stick integrates a heading
-    /// setpoint exactly like camera mode, and throttle maps directly
+    /// setpoint: roll/pitch sticks command angles, the yaw stick integrates
+    /// a heading setpoint exactly like camera mode, and throttle maps directly
     /// to collective thrust around the hover point — altitude is the
     /// pilot's axis in FPV.
     pub fn send_fpv_frame(&mut self, roll: f32, pitch: f32, throttle: f32, yaw: f32) {

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -68,6 +68,8 @@ pub struct FlightUplink {
     last_vel_ned: [f32; 3],
     started: Instant,
     send_failures: u64,
+    expected_system_id: u8,
+    expected_component_id: u8,
 }
 
 /// Climb-stick threshold that opens the motors-idle gate after arming.
@@ -103,7 +105,15 @@ impl FlightUplink {
             last_vel_ned: [0.0; 3],
             started: Instant::now(),
             send_failures: 0,
+            expected_system_id: 1,
+            expected_component_id: 1,
         })
+    }
+
+    /// Selects the MAVLink system/component whose replies may affect state.
+    pub fn set_expected_source(&mut self, system_id: u8, component_id: u8) {
+        self.expected_system_id = system_id;
+        self.expected_component_id = component_id;
     }
 
     fn send(&mut self, frame: &[u8]) {
@@ -130,7 +140,12 @@ impl FlightUplink {
         self.airborne = false;
         self.hold_pos_ned = None;
         self.last_vel_ned = [0.0; 3];
-        let frame = encode_arm_command(self.seq, arm);
+        let frame = encode_arm_command(
+            self.seq,
+            arm,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
         self.send(&frame);
         info!(arm, "sent arm command to FC");
     }
@@ -171,10 +186,14 @@ impl FlightUplink {
         let frame = encode_attitude_setpoint(
             self.seq,
             self.started.elapsed().as_millis() as u32,
-            roll * FPV_MAX_TILT_RAD,
-            pitch * FPV_MAX_TILT_RAD,
-            self.heading_sp_rad,
-            thrust,
+            crate::mavlink::AttitudeTarget {
+                roll_rad: roll * FPV_MAX_TILT_RAD,
+                pitch_rad: pitch * FPV_MAX_TILT_RAD,
+                yaw_rad: self.heading_sp_rad,
+                thrust,
+                system_id: self.expected_system_id,
+                component_id: self.expected_component_id,
+            },
         );
         self.send(&frame);
     }
@@ -228,7 +247,14 @@ impl FlightUplink {
         if !sticks_active {
             let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
             self.last_vel_ned = [0.0; 3];
-            let frame = encode_position_setpoint(self.seq, time_boot_ms, hold, self.heading_sp_rad);
+            let frame = encode_position_setpoint(
+                self.seq,
+                time_boot_ms,
+                hold,
+                self.heading_sp_rad,
+                self.expected_system_id,
+                self.expected_component_id,
+            );
             self.send(&frame);
             return;
         }
@@ -262,6 +288,8 @@ impl FlightUplink {
             time_boot_ms,
             self.last_vel_ned,
             self.heading_sp_rad,
+            self.expected_system_id,
+            self.expected_component_id,
         );
         self.send(&frame);
     }
@@ -271,7 +299,14 @@ impl FlightUplink {
     /// hover on zero demand).
     pub fn send_neutral(&mut self) {
         let time_boot_ms = self.started.elapsed().as_millis() as u32;
-        let frame = encode_velocity_setpoint(self.seq, time_boot_ms, [0.0; 3], self.heading_sp_rad);
+        let frame = encode_velocity_setpoint(
+            self.seq,
+            time_boot_ms,
+            [0.0; 3],
+            self.heading_sp_rad,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
         self.send(&frame);
     }
 
@@ -281,12 +316,18 @@ impl FlightUplink {
     /// from the sampling tick.
     pub fn poll_fc(&mut self) -> Option<bool> {
         let mut buf = [0u8; 512];
-        let mut messages: Vec<(u8, crate::mavlink::AviateMessage)> = Vec::new();
+        let mut messages: Vec<(crate::mavlink::FrameSource, crate::mavlink::AviateMessage)> =
+            Vec::new();
         let mut armed: Option<bool> = None;
         while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
             messages.clear();
             crate::mavlink::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
-            for (_, message) in &messages {
+            for (source, message) in &messages {
+                if source.system_id != self.expected_system_id
+                    || source.component_id != self.expected_component_id
+                {
+                    continue;
+                }
                 match *message {
                     crate::mavlink::AviateMessage::Heartbeat { armed: a } => armed = Some(a),
                     crate::mavlink::AviateMessage::CommandAck { command, result } => {

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -249,12 +249,12 @@ fn telemetry_from_odometry(vehicle: VehicleId, odom: &BridgeOdometry) -> Telemet
     TelemetrySample {
         vehicle,
         tick: SimTick::new(odom.sim_time_ns),
-        pose: Pose2d {
+        pose: Some(Pose2d {
             x: odom.x,
             y: odom.y,
             heading: odom.heading,
-        },
-        speed: odom.speed,
+        }),
+        speed: Some(odom.speed),
         avionics: None,
     }
 }

--- a/adapters/gazebo/src/adapter/tests.rs
+++ b/adapters/gazebo/src/adapter/tests.rs
@@ -106,8 +106,8 @@ fn odometry_maps_to_canonical_telemetry() {
     );
     assert_eq!(sample.vehicle, VehicleId::new(3));
     assert_eq!(sample.tick.as_u64(), 900);
-    assert!((sample.pose.x - 1.0).abs() < 1e-6);
-    assert!((sample.speed - 4.0).abs() < 1e-6);
+    assert!((sample.pose.expect("pose").x - 1.0).abs() < 1e-6);
+    assert!((sample.speed.expect("speed") - 4.0).abs() < 1e-6);
 }
 
 #[tokio::test]
@@ -185,8 +185,8 @@ async fn cached_odometry_becomes_telemetry_sample() {
     }
     let sample = telemetry.samples.first().expect("telemetry sample present");
     assert_eq!(sample.tick.as_u64(), 1234);
-    assert!((sample.pose.x - 5.0).abs() < 1e-6);
-    assert!((sample.speed - 2.5).abs() < 1e-6);
+    assert!((sample.pose.expect("pose").x - 5.0).abs() < 1e-6);
+    assert!((sample.speed.expect("speed") - 2.5).abs() < 1e-6);
 }
 
 #[tokio::test]

--- a/adapters/reference-headless/src/adapter.rs
+++ b/adapters/reference-headless/src/adapter.rs
@@ -201,12 +201,12 @@ impl VehicleAdapter for ReferenceAdapter {
             samples: vec![TelemetrySample {
                 vehicle: self.vehicle,
                 tick: self.tick,
-                pose: Pose2d {
+                pose: Some(Pose2d {
                     x: self.skiff.pos[0],
                     y: self.skiff.pos[1],
                     heading: self.skiff.heading,
-                },
-                speed: self.skiff.speed,
+                }),
+                speed: Some(self.skiff.speed),
                 avionics: None,
             }],
         }
@@ -305,7 +305,7 @@ mod tests {
         let step_outcome = adapter.step(StepBudget { ticks: 1 });
         assert_eq!(step_outcome.advanced, 1);
         let telemetry = adapter.sample_telemetry();
-        assert!(telemetry.samples[0].speed > 0.0);
+        assert!(telemetry.samples[0].speed.expect("speed") > 0.0);
     }
 
     #[test]
@@ -326,10 +326,11 @@ mod tests {
         adapter.step(StepBudget { ticks: 64 });
         let telemetry = adapter.sample_telemetry();
         let sample = &telemetry.samples[0];
-        assert!(sample.speed.is_finite());
-        assert!(sample.pose.x.is_finite());
-        assert!(sample.pose.y.is_finite());
-        assert!(sample.pose.heading.is_finite());
+        let pose = sample.pose.expect("pose");
+        assert!(sample.speed.expect("speed").is_finite());
+        assert!(pose.x.is_finite());
+        assert!(pose.y.is_finite());
+        assert!(pose.heading.is_finite());
     }
 
     #[test]
@@ -344,7 +345,7 @@ mod tests {
         assert_eq!(outcome.disposition, Disposition::Transformed);
         adapter.step(StepBudget { ticks: 4 });
         let telemetry = adapter.sample_telemetry();
-        assert!(telemetry.samples[0].speed.is_finite());
+        assert!(telemetry.samples[0].speed.expect("speed").is_finite());
         // A finite snapshot restores cleanly, preserving the replay contract.
         let json = adapter.snapshot().expect("snapshot encodes");
         let restored = ReferenceAdapter::restore(&json).expect("snapshot restores");

--- a/adapters/reference-headless/tests/golden_trajectory.rs
+++ b/adapters/reference-headless/tests/golden_trajectory.rs
@@ -44,21 +44,21 @@ fn fixed_seed_and_schedule_reach_exact_checkpoints() {
     for tick in 0..100u32 {
         if tick == 50 {
             let telemetry = adapter.sample_telemetry();
-            let pose = telemetry.samples[0].pose;
+            let pose = telemetry.samples[0].pose.expect("pose");
             assert_eq!(pose.x, 2.334_679_171_762_922_5);
             assert_eq!(pose.y, -2.955_190_172_055_212_7);
             assert_eq!(pose.heading, 1.750_502_528_182_713_3);
-            assert_eq!(telemetry.samples[0].speed, 1.773_499_543_450_863_6);
+            assert_eq!(telemetry.samples[0].speed, Some(1.773_499_543_450_863_6));
         }
         adapter.step(StepBudget { ticks: 1 });
     }
 
     let telemetry = adapter.sample_telemetry();
-    let pose = telemetry.samples[0].pose;
+    let pose = telemetry.samples[0].pose.expect("pose");
     assert_eq!(pose.x, 2.113_161_393_120_975_6);
     assert_eq!(pose.y, -1.735_821_899_795_127_1);
     assert_eq!(pose.heading, 1.750_502_528_182_713_3);
-    assert_eq!(telemetry.samples[0].speed, 3.153_836_508_074_175_7);
+    assert_eq!(telemetry.samples[0].speed, Some(3.153_836_508_074_175_7));
 
     adapter.apply_control(&control_frame(vehicle, 0.5, 0.3));
     for _ in 0..100u32 {
@@ -66,9 +66,9 @@ fn fixed_seed_and_schedule_reach_exact_checkpoints() {
     }
 
     let telemetry = adapter.sample_telemetry();
-    let pose = telemetry.samples[0].pose;
+    let pose = telemetry.samples[0].pose.expect("pose");
     assert_eq!(pose.x, 0.807_294_101_753_173);
     assert_eq!(pose.y, 1.300_095_689_237_339_2);
     assert_eq!(pose.heading, 2.200_502_546_064_115_4);
-    assert_eq!(telemetry.samples[0].speed, 3.487_419_172_153_574_6);
+    assert_eq!(telemetry.samples[0].speed, Some(3.487_419_172_153_574_6));
 }

--- a/adapters/reference-headless/tests/link_loss.rs
+++ b/adapters/reference-headless/tests/link_loss.rs
@@ -26,6 +26,12 @@ fn full_throttle_frame(vehicle: VehicleId) -> ScopedControlFrame {
     }
 }
 
+fn measured_speed(adapter: &mut ReferenceAdapter) -> f64 {
+    adapter.sample_telemetry().samples[0]
+        .speed
+        .expect("reference adapter speed")
+}
+
 #[test]
 fn neutralize_zeroes_controls_and_speed_decays_via_drag() {
     let vehicle = VehicleId::new(1);
@@ -36,12 +42,12 @@ fn neutralize_zeroes_controls_and_speed_decays_via_drag() {
     for _ in 0..50u32 {
         adapter.step(StepBudget { ticks: 1 });
     }
-    let speed_before_loss = adapter.sample_telemetry().samples[0].speed;
+    let speed_before_loss = measured_speed(&mut adapter);
     assert!(speed_before_loss > 0.0);
 
     adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
     adapter.step(StepBudget { ticks: 1 });
-    let speed_after_one_tick = adapter.sample_telemetry().samples[0].speed;
+    let speed_after_one_tick = measured_speed(&mut adapter);
     assert!(speed_after_one_tick < speed_before_loss);
 
     // With controls neutralized, speed keeps decaying toward zero under drag
@@ -49,7 +55,7 @@ fn neutralize_zeroes_controls_and_speed_decays_via_drag() {
     for _ in 0..500u32 {
         adapter.step(StepBudget { ticks: 1 });
     }
-    let speed_far_after = adapter.sample_telemetry().samples[0].speed;
+    let speed_far_after = measured_speed(&mut adapter);
     assert!(speed_far_after < speed_after_one_tick);
     assert!(speed_far_after >= 0.0);
 }
@@ -62,7 +68,7 @@ fn clearing_link_loss_policy_restores_normal_control() {
 
     adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
     adapter.step(StepBudget { ticks: 1 });
-    let speed_while_neutralized = adapter.sample_telemetry().samples[0].speed;
+    let speed_while_neutralized = measured_speed(&mut adapter);
 
     // Link recovery: clearing the policy and re-applying full throttle must
     // resume acceleration rather than staying neutralized permanently.
@@ -71,7 +77,7 @@ fn clearing_link_loss_policy_restores_normal_control() {
     for _ in 0..50u32 {
         adapter.step(StepBudget { ticks: 1 });
     }
-    let speed_after_recovery = adapter.sample_telemetry().samples[0].speed;
+    let speed_after_recovery = measured_speed(&mut adapter);
     assert!(speed_after_recovery > speed_while_neutralized);
 }
 
@@ -92,17 +98,17 @@ fn hold_brief_holds_controls_then_neutralizes() {
         adapter.step(StepBudget { ticks: 1 });
         without_loss.step(StepBudget { ticks: 1 });
     }
-    let held_speed = adapter.sample_telemetry().samples[0].speed;
-    let unaffected_speed = without_loss.sample_telemetry().samples[0].speed;
+    let held_speed = measured_speed(&mut adapter);
+    let unaffected_speed = measured_speed(&mut without_loss);
     assert_eq!(held_speed, unaffected_speed);
 
     // After the hold window elapses, controls neutralize: further stepping
     // must decay speed rather than keep climbing under throttle.
     adapter.step(StepBudget { ticks: 1 });
-    let speed_after_neutralize_tick = adapter.sample_telemetry().samples[0].speed;
+    let speed_after_neutralize_tick = measured_speed(&mut adapter);
 
     without_loss.step(StepBudget { ticks: 1 });
-    let unaffected_speed_next = without_loss.sample_telemetry().samples[0].speed;
+    let unaffected_speed_next = measured_speed(&mut without_loss);
 
     assert!(speed_after_neutralize_tick < unaffected_speed_next);
 }
@@ -116,7 +122,7 @@ fn hold_brief_expiry_is_not_undone_by_a_later_apply_control() {
 
     // Run past the hold window so the policy has neutralized.
     adapter.step(StepBudget { ticks: 2 });
-    let speed_after_neutralize = adapter.sample_telemetry().samples[0].speed;
+    let speed_after_neutralize = measured_speed(&mut adapter);
 
     // A new control frame arrives without the link ever being recovered via
     // `set_link_loss_policy(vehicle, None)`. Per the `VehicleAdapter` trait's
@@ -124,7 +130,7 @@ fn hold_brief_expiry_is_not_undone_by_a_later_apply_control() {
     // so this frame must not un-neutralize the vehicle.
     adapter.apply_control(&full_throttle_frame(vehicle));
     adapter.step(StepBudget { ticks: 50 });
-    let speed_after_new_frame = adapter.sample_telemetry().samples[0].speed;
+    let speed_after_new_frame = measured_speed(&mut adapter);
 
     assert!(speed_after_new_frame <= speed_after_neutralize);
 }

--- a/adapters/reference-headless/tests/snapshot_restore.rs
+++ b/adapters/reference-headless/tests/snapshot_restore.rs
@@ -52,12 +52,7 @@ fn restore_then_step_matches_uninterrupted_run() {
     }
     let actual = restored.sample_telemetry();
 
-    assert_eq!(actual.samples[0].pose.x, expected.samples[0].pose.x);
-    assert_eq!(actual.samples[0].pose.y, expected.samples[0].pose.y);
-    assert_eq!(
-        actual.samples[0].pose.heading,
-        expected.samples[0].pose.heading
-    );
+    assert_eq!(actual.samples[0].pose, expected.samples[0].pose);
     assert_eq!(actual.samples[0].speed, expected.samples[0].speed);
     assert_eq!(actual.samples[0].tick, expected.samples[0].tick);
 }
@@ -81,5 +76,5 @@ fn snapshot_round_trip_preserves_link_loss_hold_countdown() {
     let expected = adapter.sample_telemetry();
     let actual = restored.sample_telemetry();
     assert_eq!(actual.samples[0].speed, expected.samples[0].speed);
-    assert_eq!(actual.samples[0].pose.x, expected.samples[0].pose.x);
+    assert_eq!(actual.samples[0].pose, expected.samples[0].pose);
 }

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -24,7 +24,7 @@ export const LOGICAL_W = 480;
 export const LOGICAL_H = 360;
 
 const SCENE_FORMAT_VERSION = 1;
-export const STATE_ABI_VERSION = 1;
+export const STATE_ABI_VERSION = 2;
 export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
 const MAX_WASM_RENDER_STATUS = 10;
@@ -278,6 +278,11 @@ export class InstrumentModule {
       f(108, state.selections?.altitudeSelM ?? NaN);
       f(112, state.wind?.fromRad ?? 0);
       f(116, state.wind?.speedMps ?? 0);
+      view.setUint32(120, state.snapshot?.generation ?? 0, true);
+      b(124, state.snapshot?.coherence ?? 0);
+      b(125, 0);
+      b(126, 0);
+      b(127, 0);
       return { ok: true };
     } catch {
       return { ok: false, reason: REASON.STATE_WRITE_FAILED };

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -36,7 +36,9 @@ import {
   startDisplayLoop,
   tickInstrumentSet,
 } from "./instrument-health.js";
+import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
 import { AvionicsIngress, INCARNATION_POLICY } from "./telemetry-ingress.js";
+import { TransportSessionLifecycle } from "./transport-session.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -50,7 +52,7 @@ const AXIS_ROLL = 0; // pilotage-input logical axis table: roll = 0 (lateral vel
 const AXIS_PITCH = 1; // pitch = 1 (forward velocity, + forward).
 const AXIS_THROTTLE = 2; // throttle = 2 (rover: forward speed; quad: climb rate).
 const AXIS_YAW = 3; // yaw = 3 (yaw rate, + clockwise).
-const BUTTON_ARM = 0; // logical button 0: arm (adapter contract, issue #12).
+const BUTTON_ARM = 0; // logical button 0: arm (adapter contract).
 const BUTTON_DISARM = 1; // logical button 1: disarm.
 const BUTTON_RESET = 2; // logical button 2: reset the simulation (adapter runs the reset script).
 const BUTTON_FPV_TOGGLE = 3; // logical button 3: camera <-> FPV mode (adapter latches).
@@ -92,6 +94,7 @@ const state = {
   leaseGranted: false,
   skippedVideoFrames: 0,
 };
+const transportSessions = new TransportSessionLifecycle();
 
 // Ingestion accepts only source advancement for the selected vehicle. Drawing
 // remains on requestAnimationFrame, decoupled from telemetry publication.
@@ -107,6 +110,11 @@ function newSimulatorAvionicsIngress() {
     incarnationPolicy: INCARNATION_POLICY.SIM_ACCEPT_UNSEEN,
     maximumSkewNanos: SIM_COHERENCE_LIMIT_NS,
   });
+}
+
+function retireSessionPresentation(phase) {
+  instruments.ingress = newSimulatorAvionicsIngress();
+  setTelemetrySessionState(els, phase);
 }
 
 const instruments = {
@@ -170,65 +178,116 @@ async function connect() {
   const url = `https://${host}:${port}/pilotage`;
   const certHash = hexToBytes(certHashHex);
 
-  log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
-  const transport = new WebTransport(url, {
-    serverCertificateHashes: [{ algorithm: "sha-256", value: certHash }],
-  });
-  state.transport = transport;
-
-  transport.closed
-    .then(() => {
-      state.connected = false;
-      log("WebTransport session closed");
-    })
-    .catch((error) => {
-      state.connected = false;
-      log(`WebTransport session errored: ${error}`);
+  let transport;
+  try {
+    transport = new WebTransport(url, {
+      serverCertificateHashes: [{ algorithm: "sha-256", value: certHash }],
     });
+  } catch (error) {
+    log(`WebTransport creation failed: ${error}`);
+    return;
+  }
+  const token = transportSessions.begin(transport);
+  transportSessions.runIfActive(token, () => {
+    state.transport = transport;
+    state.sessionId = 0;
+    state.generation = 0n;
+    state.sequence = 0;
+    state.prevArmInputs = new Set();
+    state.pendingReset = false;
+    state.pendingFpvToggle = false;
+    state.connected = false;
+    state.leaseGranted = false;
+    state.skippedVideoFrames = 0;
+    retireSessionPresentation("connecting");
+    log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
+  });
 
-  await transport.ready;
-  log("WebTransport session ready");
+  transport.closed.then(
+    () => handleTransportClosed(token, null),
+    (error) => handleTransportClosed(token, error),
+  );
 
-  const bidi = await transport.createBidirectionalStream();
-  const writer = bidi.writable.getWriter();
-  const reader = bidi.readable.getReader();
+  try {
+    await transport.ready;
+    if (!transportSessions.isActive(token)) return;
+    log("WebTransport session ready");
 
-  await sendClientHello(writer);
-  await runBootstrapReader(reader, writer);
+    const bidi = await transport.createBidirectionalStream();
+    if (!transportSessions.isActive(token)) return;
+    const writer = bidi.writable.getWriter();
+    const reader = bidi.readable.getReader();
+    if (!transportSessions.trackWriter(token, writer)) return;
+    if (!transportSessions.trackReader(token, reader)) return;
 
-  // A negotiated transport session is the lifecycle boundary that replaces
-  // all ordering history from a prior host process. Cached datagrams cannot
-  // cross this boundary because the replaced transport is already closed.
-  instruments.ingress = newSimulatorAvionicsIngress();
-  state.connected = true;
-  acceptIncomingUniStreams(transport);
-  readTelemetryDatagrams(transport);
-  if (state.leaseGranted) {
-    startControlLoop(transport).catch((error) => log(`control loop stopped: ${error}`));
-  } else {
-    // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
-    // advertises no controllable scopes; sending control frames anyway
-    // would only generate a 30 Hz stream of rejections.
-    log("no control lease granted; viewer is telemetry/video only");
+    if (!(await sendClientHello(writer, token))) return;
+    const negotiated = await runBootstrapReader(reader, writer, token);
+    if (!transportSessions.isActive(token)) return;
+    if (!negotiated) throw new Error("bootstrap stream closed before LeaseResponse");
+
+    // Negotiation is the lifecycle boundary for measurement ordering. The
+    // token prevents readers from the replaced transport from reaching this
+    // newly empty ingress even if their promises settle later.
+    instruments.ingress = newSimulatorAvionicsIngress();
+    setTelemetrySessionState(els, "awaiting");
+    state.connected = true;
+    acceptIncomingUniStreams(transport, token).catch((error) => {
+      transportSessions.runIfActive(token, () => log(`uni stream accept failed: ${error}`));
+    });
+    readTelemetryDatagrams(transport, token).catch((error) => {
+      transportSessions.runIfActive(token, () => log(`telemetry reader stopped: ${error}`));
+    });
+    if (state.leaseGranted) {
+      startControlLoop(transport, token).catch((error) => {
+        transportSessions.runIfActive(token, () => log(`control loop stopped: ${error}`));
+      });
+    } else {
+      // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
+      // advertises no controllable scopes; sending control frames anyway
+      // would only generate a 30 Hz stream of rejections.
+      log("no control lease granted; viewer is telemetry/video only");
+    }
+  } catch (error) {
+    if (!transportSessions.isActive(token)) return;
+    state.connected = false;
+    state.transport = null;
+    retireSessionPresentation("failed");
+    log(`connect failed: ${error}`);
+    transportSessions.close(token);
   }
 }
 
+function handleTransportClosed(token, error) {
+  if (!transportSessions.isActive(token)) return;
+  state.connected = false;
+  state.transport = null;
+  retireSessionPresentation(error === null ? "disconnected" : "failed");
+  log(error === null ? "WebTransport session closed" : `WebTransport session errored: ${error}`);
+  transportSessions.retire(token);
+}
+
 /** Writes a length-delimited `ClientHello` envelope onto the bootstrap bidi stream. */
-async function sendClientHello(writer) {
+async function sendClientHello(writer, token) {
+  if (!transportSessions.isActive(token)) return false;
   const hello = encodeClientHelloEnvelope({
     protocolVersion: 1,
     clientName: "pilotage-web-viewer",
     joinToken: new Uint8Array(0),
   });
   await writer.write(lengthDelimit(hello));
+  if (!transportSessions.isActive(token)) return false;
   log("sent ClientHello");
+  return true;
 }
 
 /** Writes a length-delimited `LeaseRequest` for the motion scope. */
-async function sendLeaseRequest(writer) {
+async function sendLeaseRequest(writer, token) {
+  if (!transportSessions.isActive(token)) return false;
   const request = encodeLeaseRequestEnvelope({ vehicleId: VEHICLE_ID, scope: MOTION_SCOPE });
   await writer.write(lengthDelimit(request));
+  if (!transportSessions.isActive(token)) return false;
   log(`sent LeaseRequest for ${MOTION_SCOPE}`);
+  return true;
 }
 
 /** Prefixes an already-encoded `Envelope` with a protobuf varint byte-length, matching `encode_length_delimited` on the host. */
@@ -251,31 +310,33 @@ function lengthDelimit(envelopeBytes) {
   return out;
 }
 
-/** Reads bootstrap-stream frames until ServerWelcome and LeaseResponse are both seen, then keeps forwarding any later frames (Pong/FrameRejected) to the log. */
-async function runBootstrapReader(reader, writer) {
+/** Reads bootstrap frames until ServerWelcome and LeaseResponse establish the session. */
+async function runBootstrapReader(reader, writer, token) {
   let pending = new Uint8Array(0);
   let sentLease = false;
   for (;;) {
     const { value, done } = await reader.read();
-    if (done) return;
+    if (!transportSessions.isActive(token)) return false;
+    if (done) return false;
     pending = appendBytes(pending, value);
     for (;;) {
       const decoded = decodeLengthDelimitedEnvelope(pending);
       if (!decoded) break;
       pending = pending.subarray(decoded.consumed);
-      handleBootstrapMessage(decoded);
+      handleBootstrapMessage(decoded, token);
       if (decoded.kind === "ServerWelcome" && !sentLease) {
         sentLease = true;
-        await sendLeaseRequest(writer);
+        if (!(await sendLeaseRequest(writer, token))) return false;
       }
       if (decoded.kind === "LeaseResponse") {
-        return; // bootstrap complete; later frames are drained by a background reader.
+        return true;
       }
     }
   }
 }
 
-function handleBootstrapMessage(decoded) {
+function handleBootstrapMessage(decoded, token) {
+  if (!transportSessions.isActive(token)) return;
   if (decoded.kind === "ServerWelcome") {
     state.sessionId = decoded.message.sessionId;
     log(`ServerWelcome: session=${decoded.message.sessionId} principal=${decoded.message.principalId}`);
@@ -297,39 +358,56 @@ function appendBytes(existing, incoming) {
 }
 
 /** Accepts every host-initiated uni stream and dispatches on its leading kind-tag byte. */
-async function acceptIncomingUniStreams(transport) {
+async function acceptIncomingUniStreams(transport, token) {
+  if (!transportSessions.isActive(token)) return;
   const uniStreams = transport.incomingUnidirectionalStreams;
   const streamReader = uniStreams.getReader();
-  for (;;) {
-    const { value: stream, done } = await streamReader.read();
-    if (done) return;
-    readOneUniStream(stream).catch((error) => log(`uni stream read failed: ${error}`));
+  if (!transportSessions.trackReader(token, streamReader)) return;
+  try {
+    for (;;) {
+      const { value: stream, done } = await streamReader.read();
+      if (!transportSessions.isActive(token)) return;
+      if (done) return;
+      readOneUniStream(stream, token).catch((error) => {
+        transportSessions.runIfActive(token, () => log(`uni stream read failed: ${error}`));
+      });
+    }
+  } finally {
+    transportSessions.untrackReader(token, streamReader);
   }
 }
 
 /** Drains one uni stream to completion, buffering bytes, reading the kind tag, then dispatching. */
-async function readOneUniStream(stream) {
+async function readOneUniStream(stream, token) {
+  if (!transportSessions.isActive(token)) return;
   const reader = stream.getReader();
+  if (!transportSessions.trackReader(token, reader)) return;
   let buf = new Uint8Array(0);
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (value) buf = appendBytes(buf, value);
-    if (done) break;
-  }
-  if (buf.length === 0) return;
-  const kind = buf[0];
-  const body = buf.subarray(1);
-  if (kind === STREAM_KIND_AUTHORITY) {
-    dispatchAuthorityStream(body);
-  } else if (kind === STREAM_KIND_VIDEO) {
-    await renderVideoFrame(body);
-  } else {
-    log(`unrecognized uni stream kind tag 0x${kind.toString(16)}`);
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (!transportSessions.isActive(token)) return;
+      if (value) buf = appendBytes(buf, value);
+      if (done) break;
+    }
+    if (buf.length === 0) return;
+    const kind = buf[0];
+    const body = buf.subarray(1);
+    if (kind === STREAM_KIND_AUTHORITY) {
+      dispatchAuthorityStream(body, token);
+    } else if (kind === STREAM_KIND_VIDEO) {
+      await renderVideoFrame(body, token);
+    } else {
+      log(`unrecognized uni stream kind tag 0x${kind.toString(16)}`);
+    }
+  } finally {
+    transportSessions.untrackReader(token, reader);
   }
 }
 
 /** The dedicated authority-events stream is opened once at connection start and may carry several length-delimited envelopes over the stream's lifetime; decode every complete one buffered. */
-function dispatchAuthorityStream(body) {
+function dispatchAuthorityStream(body, token) {
+  if (!transportSessions.isActive(token)) return;
   let pending = body;
   for (;;) {
     const decoded = decodeLengthDelimitedEnvelope(pending);
@@ -356,7 +434,8 @@ const VIDEO_TARGETS = {
   [SOURCE_CHASE]: { canvas: els.chaseCanvas, ctx: chaseCtx },
 };
 
-async function renderVideoFrame(body) {
+async function renderVideoFrame(body, token) {
+  if (!transportSessions.isActive(token)) return;
   if (body.length < 9) return;
   const sourceId = body[0];
   const fourcc = String.fromCharCode(body[1], body[2], body[3], body[4]);
@@ -379,6 +458,10 @@ async function renderVideoFrame(body) {
     return;
   }
   const bitmap = await createImageBitmap(new Blob([payload], { type: "image/jpeg" }));
+  if (!transportSessions.isActive(token)) {
+    bitmap.close();
+    return;
+  }
   const { canvas, ctx: targetCtx } = target;
   if (canvas.width !== bitmap.width || canvas.height !== bitmap.height) {
     canvas.width = bitmap.width;
@@ -389,27 +472,31 @@ async function renderVideoFrame(body) {
 }
 
 /** Reads telemetry-fast datagrams (bare Envelope, TelemetrySample arm) forever, updating the pose overlay. */
-async function readTelemetryDatagrams(transport) {
+async function readTelemetryDatagrams(transport, token) {
+  if (!transportSessions.isActive(token)) return;
   const reader = transport.datagrams.readable.getReader();
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) return;
-    const decoded = decodeBareEnvelope(value);
-    if (decoded.kind === "TelemetrySample") {
-      const t = decoded.message;
-      if (t.avionics) {
-        instruments.ingress.ingest(t, performance.now());
+  if (!transportSessions.trackReader(token, reader)) return;
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (!transportSessions.isActive(token)) return;
+      if (done) return;
+      const decoded = decodeBareEnvelope(value);
+      if (decoded.kind === "TelemetrySample") {
+        const t = decoded.message;
+        if (t.avionics) {
+          instruments.ingress.ingest(t, performance.now());
+        }
+        if (t.vehicleId !== VEHICLE_ID) continue;
+        els.telemetry.textContent = formatTelemetrySummary(t);
+      } else if (decoded.kind === "Pong") {
+        // RTT probing is out of scope for this demo viewer; ignored.
+      } else if (decoded.kind === "FrameRejected") {
+        log(`control frame rejected (reason ${decoded.message.reason})`);
       }
-      if (t.vehicleId !== VEHICLE_ID) continue;
-      const armText = { 0: "arm: unknown", 1: "DISARMED", 2: "ARMED" }[t.avionics?.armState ?? 0];
-      els.telemetry.textContent =
-        `${armText} | pose x=${t.xM.toFixed(2)}m y=${t.yM.toFixed(2)}m heading=${t.headingRad.toFixed(2)}rad` +
-        ` | v=${t.linearXMps.toFixed(2)}m/s w=${t.angularRadS.toFixed(2)}rad/s`;
-    } else if (decoded.kind === "Pong") {
-      // RTT probing is out of scope for this demo viewer; ignored.
-    } else if (decoded.kind === "FrameRejected") {
-      log(`control frame rejected (reason ${decoded.message.reason})`);
     }
+  } finally {
+    transportSessions.untrackReader(token, reader);
   }
 }
 
@@ -505,7 +592,7 @@ const CONTROLLER_PROFILES = [
   },
 ];
 
-// Flight-mode stick schemes for Standard Gamepad pads (issue #12). Both
+// Flight-mode stick schemes for Standard Gamepad pads. Both
 // command the identical velocity control law — only stick assignment
 // differs. Browser reports stick-up as negative, hence the -1 signs.
 //   pilot  = RC Mode 2 (camera-drone default): left = climb+yaw,
@@ -687,71 +774,79 @@ function updateFlightReadout(pad, f) {
 }
 
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
-async function startControlLoop(transport) {
+async function startControlLoop(transport, token) {
+  if (!transportSessions.isActive(token)) return;
   const writer = transport.datagrams.writable.getWriter();
+  if (!transportSessions.trackWriter(token, writer)) return;
   const intervalMs = 1000 / CONTROL_HZ;
   // Self-paced async loop rather than setInterval: it awaits the writer's
   // backpressure signal (`ready`) before each send, so datagrams never queue up
   // in the WritableStream and get flushed in a burst with stale `sampled_at`
   // (which the host rejects as too old, ADR-0009). `sampled_at` is stamped right
   // before the write, after `ready`, so it reflects the real send moment.
-  while (state.connected) {
-    try {
-      await writer.ready;
-    } catch {
-      return; // writer closed (session ended)
-    }
-    if (!state.connected) return;
-    // A connected gamepad drives under its profile; the keyboard is the
-    // fallback when none is present. The readout shows the live mapping.
-    const mode = els.flightMode ? els.flightMode.value : "rover";
-    const pad = activeGamepad();
-    const profile = pad ? profileFor(pad.id) : null;
-    let axes;
-    let edges = [];
-    if (mode === "rover") {
-      // Ground vehicles (the Gazebo yard world) accept only the
-      // throttle/yaw pair; extra axes would be rejected as unknown.
-      const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
-      updateGamepadReadout(pad, profile, throttle, yaw);
-      axes = [
-        [AXIS_THROTTLE, throttle],
-        [AXIS_YAW, yaw],
-      ];
-    } else {
-      const f = pad ? flightAxesFromGamepad(pad, profile, mode) : flightAxesFromKeys();
-      updateFlightReadout(pad, f);
-      edges = collectArmEdges(pad);
-      if (state.pendingFpvToggle) {
-        state.pendingFpvToggle = false;
-        edges.push([BUTTON_FPV_TOGGLE, BUTTON_EDGE_PRESSED]);
+  try {
+    while (transportSessions.isActive(token) && state.connected) {
+      try {
+        await writer.ready;
+      } catch {
+        return; // writer closed (session ended)
       }
-      if (state.pendingReset) {
-        state.pendingReset = false;
-        edges.push([BUTTON_RESET, BUTTON_EDGE_PRESSED]);
-        log("simulation reset requested");
+      if (!transportSessions.isActive(token) || !state.connected) return;
+      // A connected gamepad drives under its profile; the keyboard is the
+      // fallback when none is present. The readout shows the live mapping.
+      const mode = els.flightMode ? els.flightMode.value : "rover";
+      const pad = activeGamepad();
+      const profile = pad ? profileFor(pad.id) : null;
+      let axes;
+      let edges = [];
+      if (mode === "rover") {
+        // Ground vehicles (the Gazebo yard world) accept only the
+        // throttle/yaw pair; extra axes would be rejected as unknown.
+        const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
+        updateGamepadReadout(pad, profile, throttle, yaw);
+        axes = [
+          [AXIS_THROTTLE, throttle],
+          [AXIS_YAW, yaw],
+        ];
+      } else {
+        const f = pad ? flightAxesFromGamepad(pad, profile, mode) : flightAxesFromKeys();
+        updateFlightReadout(pad, f);
+        edges = collectArmEdges(pad);
+        if (state.pendingFpvToggle) {
+          state.pendingFpvToggle = false;
+          edges.push([BUTTON_FPV_TOGGLE, BUTTON_EDGE_PRESSED]);
+        }
+        if (state.pendingReset) {
+          state.pendingReset = false;
+          edges.push([BUTTON_RESET, BUTTON_EDGE_PRESSED]);
+          log("simulation reset requested");
+        }
+        axes = [
+          [AXIS_ROLL, f.roll],
+          [AXIS_PITCH, f.pitch],
+          [AXIS_THROTTLE, f.throttle],
+          [AXIS_YAW, f.yaw],
+        ];
       }
-      axes = [
-        [AXIS_ROLL, f.roll],
-        [AXIS_PITCH, f.pitch],
-        [AXIS_THROTTLE, f.throttle],
-        [AXIS_YAW, f.yaw],
-      ];
+      state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
+      const envelope = encodeControlFrameEnvelope({
+        sessionId: state.sessionId,
+        vehicleId: VEHICLE_ID,
+        scope: MOTION_SCOPE,
+        generation: state.generation,
+        sequence: state.sequence,
+        sampledAtNanos: nowNanos(),
+        profileRevision: 1,
+        axes,
+        edges,
+      });
+      writer.write(envelope).catch((error) => {
+        transportSessions.runIfActive(token, () => log(`control datagram send failed: ${error}`));
+      });
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
-    state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
-    const envelope = encodeControlFrameEnvelope({
-      sessionId: state.sessionId,
-      vehicleId: VEHICLE_ID,
-      scope: MOTION_SCOPE,
-      generation: state.generation,
-      sequence: state.sequence,
-      sampledAtNanos: nowNanos(),
-      profileRevision: 1,
-      axes,
-      edges,
-    });
-    writer.write(envelope).catch((error) => log(`control datagram send failed: ${error}`));
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  } finally {
+    transportSessions.untrackWriter(token, writer);
   }
 }
 
@@ -851,5 +946,5 @@ document.getElementById("resetBtn").addEventListener("click", () => {
   state.pendingReset = true;
 });
 els.connectBtn.addEventListener("click", () => {
-  connect().catch((error) => log(`connect failed: ${error}`));
+  void connect();
 });

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -198,7 +198,7 @@ async function connect() {
 
   // A negotiated transport session is the lifecycle boundary that replaces
   // all ordering history from a prior host process. Cached datagrams cannot
-  // cross this boundary because the old transport has already closed.
+  // cross this boundary because the replaced transport is already closed.
   instruments.ingress = newSimulatorAvionicsIngress();
   state.connected = true;
   acceptIncomingUniStreams(transport);

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -36,7 +36,7 @@ import {
   startDisplayLoop,
   tickInstrumentSet,
 } from "./instrument-health.js";
-import { AvionicsIngress } from "./telemetry-ingress.js";
+import { AvionicsIngress, INCARNATION_POLICY } from "./telemetry-ingress.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -95,16 +95,24 @@ const state = {
 
 // Ingestion accepts only source advancement for the selected vehicle. Drawing
 // remains on requestAnimationFrame, decoupled from telemetry publication.
-// Each panel latches display failures independently (DISP-01); a fault in
-// the shared wasm backend (load/ABI/init) fails both.
+// Each panel latches display failures independently; a fault in the shared
+// wasm backend (load/ABI/init) fails both.
+function newSimulatorAvionicsIngress() {
+  return new AvionicsIngress({
+    vehicleId: VEHICLE_ID,
+    sourceId: INSTRUMENT_SOURCE_ID,
+    // SIM-only policy permits a bounded number of unseen attachment tokens.
+    // Aircraft profiles pin a source-issued incarnation at authenticated
+    // bootstrap and do not infer transitions from telemetry.
+    incarnationPolicy: INCARNATION_POLICY.SIM_ACCEPT_UNSEEN,
+    maximumSkewNanos: SIM_COHERENCE_LIMIT_NS,
+  });
+}
+
 const instruments = {
   mod: null,
   moduleFault: null,
-  ingress: new AvionicsIngress({
-    vehicleId: VEHICLE_ID,
-    sourceId: INSTRUMENT_SOURCE_ID,
-    maximumSkewNanos: SIM_COHERENCE_LIMIT_NS,
-  }),
+  ingress: newSimulatorAvionicsIngress(),
   health: {
     [PANEL.PFD]: new PanelHealth(),
     [PANEL.HSI]: new PanelHealth(),
@@ -188,6 +196,10 @@ async function connect() {
   await sendClientHello(writer);
   await runBootstrapReader(reader, writer);
 
+  // A negotiated transport session is the lifecycle boundary that replaces
+  // all ordering history from a prior host process. Cached datagrams cannot
+  // cross this boundary because the old transport has already closed.
+  instruments.ingress = newSimulatorAvionicsIngress();
   state.connected = true;
   acceptIncomingUniStreams(transport);
   readTelemetryDatagrams(transport);

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -36,8 +36,14 @@ import {
   startDisplayLoop,
   tickInstrumentSet,
 } from "./instrument-health.js";
+import { AvionicsIngress } from "./telemetry-ingress.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
+const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
+// Aviate publishes attitude at 10 Hz and kinematics at 4 Hz. This simulator
+// profile admits one kinematics period plus transport jitter; an aircraft
+// profile must derive its own limit from the intended function.
+const SIM_COHERENCE_LIMIT_NS = 300_000_000n;
 const MOTION_SCOPE = "vehicle.motion";
 const CONTROL_HZ = 30; // continuous control send rate; superseded samples are droppable (ADR-0011).
 const AXIS_ROLL = 0; // pilotage-input logical axis table: roll = 0 (lateral velocity, + right).
@@ -87,17 +93,18 @@ const state = {
   skippedVideoFrames: 0,
 };
 
-// Instrument panel state (ADR-0017/0018): the latest raw avionics
-// estimate plus its receive stamp. Ingest only records; drawing happens
-// on the display's own requestAnimationFrame cadence, so telemetry rate
-// and frame rate stay decoupled.
+// Ingestion accepts only source advancement for the selected vehicle. Drawing
+// remains on requestAnimationFrame, decoupled from telemetry publication.
 // Each panel latches display failures independently (DISP-01); a fault in
 // the shared wasm backend (load/ABI/init) fails both.
 const instruments = {
   mod: null,
   moduleFault: null,
-  latest: null,
-  receivedAtMs: null,
+  ingress: new AvionicsIngress({
+    vehicleId: VEHICLE_ID,
+    sourceId: INSTRUMENT_SOURCE_ID,
+    maximumSkewNanos: SIM_COHERENCE_LIMIT_NS,
+  }),
   health: {
     [PANEL.PFD]: new PanelHealth(),
     [PANEL.HSI]: new PanelHealth(),
@@ -378,14 +385,14 @@ async function readTelemetryDatagrams(transport) {
     const decoded = decodeBareEnvelope(value);
     if (decoded.kind === "TelemetrySample") {
       const t = decoded.message;
+      if (t.avionics) {
+        instruments.ingress.ingest(t, performance.now());
+      }
+      if (t.vehicleId !== VEHICLE_ID) continue;
       const armText = { 0: "arm: unknown", 1: "DISARMED", 2: "ARMED" }[t.avionics?.armState ?? 0];
       els.telemetry.textContent =
         `${armText} | pose x=${t.xM.toFixed(2)}m y=${t.yM.toFixed(2)}m heading=${t.headingRad.toFixed(2)}rad` +
         ` | v=${t.linearXMps.toFixed(2)}m/s w=${t.angularRadS.toFixed(2)}rad/s`;
-      if (t.avionics) {
-        instruments.latest = t.avionics;
-        instruments.receivedAtMs = performance.now();
-      }
     } else if (decoded.kind === "Pong") {
       // RTT probing is out of scope for this demo viewer; ignored.
     } else if (decoded.kind === "FrameRejected") {
@@ -754,24 +761,30 @@ function renderInstruments() {
     }
     return;
   }
-  const a = instruments.latest;
-  const ageMs = a ? performance.now() - instruments.receivedAtMs : NaN;
+  const snapshot = instruments.ingress.snapshot(performance.now());
+  const attitude = snapshot.attitude;
+  const kinematics = snapshot.kinematics;
+  const quality = Math.max(attitude?.quality ?? 0, kinematics?.quality ?? 0);
+  const coherence = {
+    insufficient: 0,
+    coherent: 1,
+    "excessive-skew": 2,
+  }[snapshot.coherence.status];
   const panelState = {
-    attitude: a ? { quat: a.quat, rates: a.rates, ageMs } : null,
-    kinematics: a ? { posNed: a.posNed, velNed: a.velNed, ageMs } : null,
+    attitude,
+    kinematics,
     air: null, // no airspeed/baro sensor on Aviate's wire yet (ADR-0018): honest Missing.
     nav: null,
     wind: null,
     selections: { headingBugRad: 0 },
-    quality: a ? a.quality : 0,
-    valid: a
-      ? {
-          attitude: !!(a.validFlags & 1),
-          rates: !!(a.validFlags & 2),
-          position: !!(a.validFlags & 4),
-          velocity: !!(a.validFlags & 8),
-        }
-      : {},
+    quality,
+    valid: {
+      attitude: !!(attitude?.validFlags & 1),
+      rates: !!(attitude?.validFlags & 2),
+      position: !!(kinematics?.validFlags & 4),
+      velocity: !!(kinematics?.validFlags & 8),
+    },
+    snapshot: { generation: snapshot.generation, coherence },
   };
   const nowMs = performance.now();
   renderInstrumentSet(mod, instruments.health, instrumentTargets(), panelState, nowMs);

--- a/clients/web/telemetry-display.js
+++ b/clients/web/telemetry-display.js
@@ -1,0 +1,36 @@
+function finiteFields(value, names) {
+  return value !== null && value !== undefined && names.every((name) => Number.isFinite(value[name]));
+}
+
+const SESSION_COPY = Object.freeze({
+  connecting: ["telemetry Missing (connecting)", "connecting"],
+  awaiting: ["telemetry Missing (awaiting first sample)", "connected — awaiting telemetry"],
+  disconnected: ["telemetry Missing (disconnected)", "disconnected"],
+  failed: ["telemetry Missing (session failed)", "connection failed"],
+});
+
+export function setTelemetrySessionState(elements, phase) {
+  const copy = SESSION_COPY[phase];
+  if (!copy) throw new RangeError(`unknown telemetry session phase ${phase}`);
+  elements.telemetry.textContent = copy[0];
+  elements.overlay.textContent = copy[1];
+}
+
+export function formatTelemetrySummary(sample) {
+  const arm = { 0: "arm: unknown", 1: "DISARMED", 2: "ARMED" }[
+    sample.avionics?.armState ?? 0
+  ] ?? "arm: invalid";
+  let pose = "pose Missing";
+  if (sample.pose !== null && sample.pose !== undefined) {
+    pose = finiteFields(sample.pose, ["xM", "yM", "headingRad"])
+      ? `pose x=${sample.pose.xM.toFixed(2)}m y=${sample.pose.yM.toFixed(2)}m heading=${sample.pose.headingRad.toFixed(2)}rad`
+      : "pose Invalid";
+  }
+  let velocity = "velocity Missing";
+  if (sample.velocity !== null && sample.velocity !== undefined) {
+    velocity = finiteFields(sample.velocity, ["linearXMps", "angularRadS"])
+      ? `v=${sample.velocity.linearXMps.toFixed(2)}m/s w=${sample.velocity.angularRadS.toFixed(2)}rad/s`
+      : "velocity Invalid";
+  }
+  return `${arm} | ${pose} | ${velocity}`;
+}

--- a/clients/web/telemetry-display.test.mjs
+++ b/clients/web/telemetry-display.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
+
+function completeSample() {
+  return {
+    avionics: { armState: 2 },
+    pose: { xM: 1.25, yM: -2.5, headingRad: 0.75 },
+    velocity: { linearXMps: 3.5, angularRadS: -0.25 },
+  };
+}
+
+function testCompleteSampleFormatsMeasuredValues() {
+  assert.equal(
+    formatTelemetrySummary(completeSample()),
+    "ARMED | pose x=1.25m y=-2.50m heading=0.75rad | v=3.50m/s w=-0.25rad/s",
+  );
+}
+
+function testMissingGroupsNeverBecomeZeroMeasurements() {
+  const text = formatTelemetrySummary({ avionics: { armState: 1 }, pose: null, velocity: null });
+  assert.equal(text, "DISARMED | pose Missing | velocity Missing");
+  assert.equal(text.includes("0.00"), false);
+}
+
+function testNonFiniteLegacyValuesFailVisibly() {
+  const sample = completeSample();
+  sample.pose.headingRad = Number.NaN;
+  sample.velocity.linearXMps = Number.POSITIVE_INFINITY;
+  assert.equal(formatTelemetrySummary(sample), "ARMED | pose Invalid | velocity Invalid");
+}
+
+function testSessionTransitionsRetireDisplayedMeasurements() {
+  const elements = {
+    telemetry: { textContent: "pose x=42.00m" },
+    overlay: { textContent: "authority: old session" },
+  };
+  setTelemetrySessionState(elements, "connecting");
+  assert.deepEqual(elements, {
+    telemetry: { textContent: "telemetry Missing (connecting)" },
+    overlay: { textContent: "connecting" },
+  });
+  setTelemetrySessionState(elements, "disconnected");
+  assert.deepEqual(elements, {
+    telemetry: { textContent: "telemetry Missing (disconnected)" },
+    overlay: { textContent: "disconnected" },
+  });
+}
+
+for (const test of [
+  testCompleteSampleFormatsMeasuredValues,
+  testMissingGroupsNeverBecomeZeroMeasurements,
+  testNonFiniteLegacyValuesFailVisibly,
+  testSessionTransitionsRetireDisplayedMeasurements,
+]) {
+  test();
+  console.log(`ok - ${test.name}`);
+}

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -1,4 +1,4 @@
-// Reorder-safe avionics ingestion for the simulator viewer (AV-01).
+// Reorder-safe avionics ingestion for the simulator viewer.
 // Publication/receipt time is transport metadata: freshness advances only
 // when a source group presents a new epoch/sequence.
 

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -1,0 +1,241 @@
+// Reorder-safe avionics ingestion for the simulator viewer (AV-01).
+// Publication/receipt time is transport metadata: freshness advances only
+// when a source group presents a new epoch/sequence.
+
+export const COHERENCE = Object.freeze({
+  INSUFFICIENT: "insufficient",
+  COHERENT: "coherent",
+  EXCESSIVE_SKEW: "excessive-skew",
+});
+
+const SERIAL_HALF_RANGE = 0x80000000;
+const CLOCK_VEHICLE_BOOT = 1;
+const CLOCK_SIMULATION = 2;
+
+function increment(value, amount = 1) {
+  return (value + amount) >>> 0;
+}
+
+function serialDistance(candidate, current) {
+  return (candidate - current) >>> 0;
+}
+
+export function serialIsNewer(candidate, current) {
+  const distance = serialDistance(candidate, current);
+  return distance !== 0 && distance < SERIAL_HALF_RANGE;
+}
+
+function isStampValid(stamp) {
+  return (
+    stamp !== null &&
+    typeof stamp === "object" &&
+    typeof stamp.sourceId === "bigint" &&
+    Number.isInteger(stamp.sourceEpoch) &&
+    Number.isInteger(stamp.sequence) &&
+    typeof stamp.acquiredAtNanos === "bigint" &&
+    stamp.acquiredAtNanos >= 0n &&
+    (stamp.clock === CLOCK_VEHICLE_BOOT || stamp.clock === CLOCK_SIMULATION)
+  );
+}
+
+function copyAttitude(avionics) {
+  return Object.freeze({
+    quat: Object.freeze({ ...avionics.quat }),
+    rates: Object.freeze([...avionics.rates]),
+    validFlags: avionics.validFlags >>> 0,
+    quality: avionics.quality >>> 0,
+    armState: avionics.armState >>> 0,
+  });
+}
+
+function copyKinematics(avionics) {
+  return Object.freeze({
+    posNed: Object.freeze([...avionics.posNed]),
+    velNed: Object.freeze([...avionics.velNed]),
+    validFlags: avionics.validFlags >>> 0,
+    quality: avionics.quality >>> 0,
+    armState: avionics.armState >>> 0,
+  });
+}
+
+function stampCopy(stamp) {
+  return Object.freeze({ ...stamp });
+}
+
+function groupSnapshot(group, nowMs) {
+  if (!group) return null;
+  return Object.freeze({
+    ...group.data,
+    stamp: group.stamp,
+    ageMs: Math.max(0, nowMs - group.acceptedAtMs),
+  });
+}
+
+function coherenceOf(attitude, kinematics, maximumSkewNanos) {
+  if (!attitude || !kinematics) {
+    return Object.freeze({ status: COHERENCE.INSUFFICIENT, skewNanos: null });
+  }
+  const a = attitude.stamp;
+  const k = kinematics.stamp;
+  if (
+    a.sourceId !== k.sourceId ||
+    a.sourceEpoch !== k.sourceEpoch ||
+    a.clock !== k.clock
+  ) {
+    return Object.freeze({ status: COHERENCE.INSUFFICIENT, skewNanos: null });
+  }
+  const skew = a.acquiredAtNanos >= k.acquiredAtNanos
+    ? a.acquiredAtNanos - k.acquiredAtNanos
+    : k.acquiredAtNanos - a.acquiredAtNanos;
+  return Object.freeze({
+    status: skew <= maximumSkewNanos ? COHERENCE.COHERENT : COHERENCE.EXCESSIVE_SKEW,
+    skewNanos: skew,
+  });
+}
+
+export class AvionicsIngress {
+  constructor({ vehicleId, sourceId = null, maximumSkewNanos }) {
+    if (typeof vehicleId !== "bigint") throw new TypeError("vehicleId must be a bigint");
+    if (sourceId !== null && typeof sourceId !== "bigint") {
+      throw new TypeError("sourceId must be null or a bigint");
+    }
+    if (typeof maximumSkewNanos !== "bigint" || maximumSkewNanos < 0n) {
+      throw new TypeError("maximumSkewNanos must be a non-negative bigint");
+    }
+    this.vehicleId = vehicleId;
+    this.sourceId = sourceId;
+    this.maximumSkewNanos = maximumSkewNanos;
+    this.sourceEpoch = null;
+    this.attitude = null;
+    this.kinematics = null;
+    this.generation = 0;
+    this.lastCoherence = COHERENCE.INSUFFICIENT;
+    this.counters = {
+      duplicates: 0,
+      reordered: 0,
+      wrongVehicle: 0,
+      wrongSource: 0,
+      oldEpoch: 0,
+      sourceResets: 0,
+      invalidStamps: 0,
+      sequenceGaps: 0,
+      excessiveSkew: 0,
+    };
+  }
+
+  ingest(message, nowMs) {
+    if (!Number.isFinite(nowMs)) throw new TypeError("nowMs must be finite");
+    if (message.vehicleId !== this.vehicleId) {
+      this.bump("wrongVehicle");
+      return false;
+    }
+    const avionics = message.avionics;
+    if (!avionics) return false;
+
+    let changed = false;
+    changed = this.acceptGroup("attitude", avionics.attitudeStamp, copyAttitude, avionics, nowMs)
+      || changed;
+    changed = this.acceptGroup(
+      "kinematics",
+      avionics.kinematicsStamp,
+      copyKinematics,
+      avionics,
+      nowMs,
+    ) || changed;
+    if (changed) {
+      this.generation = increment(this.generation);
+      this.recordCoherenceTransition();
+    }
+    return changed;
+  }
+
+  acceptGroup(name, stamp, copyData, avionics, nowMs) {
+    if (stamp === null) return false;
+    if (!isStampValid(stamp)) {
+      this.bump("invalidStamps");
+      return false;
+    }
+    if (!this.acceptSource(stamp.sourceId)) return false;
+    if (!this.acceptEpoch(stamp.sourceEpoch)) return false;
+
+    const current = this[name];
+    if (current && current.stamp.sequence === stamp.sequence) {
+      this.bump("duplicates");
+      return false;
+    }
+    if (current && !serialIsNewer(stamp.sequence, current.stamp.sequence)) {
+      this.bump("reordered");
+      return false;
+    }
+    if (current) {
+      const gap = serialDistance(stamp.sequence, current.stamp.sequence);
+      if (gap > 1) this.bump("sequenceGaps", gap - 1);
+    }
+    this[name] = Object.freeze({
+      stamp: stampCopy(stamp),
+      data: copyData(avionics),
+      acceptedAtMs: nowMs,
+    });
+    return true;
+  }
+
+  acceptSource(candidate) {
+    if (this.sourceId === null) {
+      this.sourceId = candidate;
+      return true;
+    }
+    if (candidate === this.sourceId) return true;
+    this.bump("wrongSource");
+    return false;
+  }
+
+  acceptEpoch(candidate) {
+    if (this.sourceEpoch === null) {
+      this.sourceEpoch = candidate;
+      return true;
+    }
+    if (candidate === this.sourceEpoch) return true;
+    if (!serialIsNewer(candidate, this.sourceEpoch)) {
+      this.bump("oldEpoch");
+      return false;
+    }
+    this.sourceEpoch = candidate;
+    this.attitude = null;
+    this.kinematics = null;
+    this.bump("sourceResets");
+    return true;
+  }
+
+  recordCoherenceTransition() {
+    const coherence = coherenceOf(this.attitude, this.kinematics, this.maximumSkewNanos);
+    if (
+      coherence.status === COHERENCE.EXCESSIVE_SKEW &&
+      this.lastCoherence !== COHERENCE.EXCESSIVE_SKEW
+    ) {
+      this.bump("excessiveSkew");
+    }
+    this.lastCoherence = coherence.status;
+  }
+
+  snapshot(nowMs) {
+    if (!Number.isFinite(nowMs)) throw new TypeError("nowMs must be finite");
+    const attitude = groupSnapshot(this.attitude, nowMs);
+    const kinematics = groupSnapshot(this.kinematics, nowMs);
+    return Object.freeze({
+      generation: this.generation,
+      sourceId: this.sourceId,
+      sourceEpoch: this.sourceEpoch,
+      attitude,
+      kinematics,
+      coherence: coherenceOf(this.attitude, this.kinematics, this.maximumSkewNanos),
+    });
+  }
+
+  diagnostics() {
+    return Object.freeze({ ...this.counters });
+  }
+
+  bump(name, amount = 1) {
+    this.counters[name] = increment(this.counters[name], amount);
+  }
+}

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -8,6 +8,11 @@ export const COHERENCE = Object.freeze({
   EXCESSIVE_SKEW: "excessive-skew",
 });
 
+export const INCARNATION_POLICY = Object.freeze({
+  PIN_FIRST: "pin-first",
+  SIM_ACCEPT_UNSEEN: "sim-accept-unseen",
+});
+
 const SERIAL_HALF_RANGE = 0x80000000;
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
@@ -30,8 +35,14 @@ function isStampValid(stamp) {
     stamp !== null &&
     typeof stamp === "object" &&
     typeof stamp.sourceId === "bigint" &&
+    typeof stamp.sourceIncarnation === "string" &&
+    /^[0-9a-f]{32}$/.test(stamp.sourceIncarnation) &&
     Number.isInteger(stamp.sourceEpoch) &&
+    stamp.sourceEpoch >= 0 &&
+    stamp.sourceEpoch <= 0xffff_ffff &&
     Number.isInteger(stamp.sequence) &&
+    stamp.sequence >= 0 &&
+    stamp.sequence <= 0xffff_ffff &&
     typeof stamp.acquiredAtNanos === "bigint" &&
     stamp.acquiredAtNanos >= 0n &&
     (stamp.clock === CLOCK_VEHICLE_BOOT || stamp.clock === CLOCK_SIMULATION)
@@ -79,6 +90,7 @@ function coherenceOf(attitude, kinematics, maximumSkewNanos) {
   const k = kinematics.stamp;
   if (
     a.sourceId !== k.sourceId ||
+    a.sourceIncarnation !== k.sourceIncarnation ||
     a.sourceEpoch !== k.sourceEpoch ||
     a.clock !== k.clock
   ) {
@@ -94,16 +106,37 @@ function coherenceOf(attitude, kinematics, maximumSkewNanos) {
 }
 
 export class AvionicsIngress {
-  constructor({ vehicleId, sourceId = null, maximumSkewNanos }) {
+  constructor({
+    vehicleId,
+    sourceId = null,
+    sourceIncarnation = null,
+    incarnationPolicy = INCARNATION_POLICY.PIN_FIRST,
+    maximumSeenIncarnations = 8,
+    maximumSkewNanos,
+  }) {
     if (typeof vehicleId !== "bigint") throw new TypeError("vehicleId must be a bigint");
     if (sourceId !== null && typeof sourceId !== "bigint") {
       throw new TypeError("sourceId must be null or a bigint");
+    }
+    if (sourceIncarnation !== null && !/^[0-9a-f]{32}$/.test(sourceIncarnation)) {
+      throw new TypeError("sourceIncarnation must be null or 32 lowercase hex characters");
+    }
+    if (!Object.values(INCARNATION_POLICY).includes(incarnationPolicy)) {
+      throw new TypeError("unknown incarnationPolicy");
+    }
+    if (!Number.isInteger(maximumSeenIncarnations) || maximumSeenIncarnations < 1) {
+      throw new TypeError("maximumSeenIncarnations must be a positive integer");
     }
     if (typeof maximumSkewNanos !== "bigint" || maximumSkewNanos < 0n) {
       throw new TypeError("maximumSkewNanos must be a non-negative bigint");
     }
     this.vehicleId = vehicleId;
     this.sourceId = sourceId;
+    this.sourceIncarnation = sourceIncarnation;
+    this.incarnationPolicy = incarnationPolicy;
+    this.maximumSeenIncarnations = maximumSeenIncarnations;
+    this.seenIncarnations = new Set();
+    if (sourceIncarnation !== null) this.seenIncarnations.add(sourceIncarnation);
     this.maximumSkewNanos = maximumSkewNanos;
     this.sourceEpoch = null;
     this.attitude = null;
@@ -115,11 +148,17 @@ export class AvionicsIngress {
       reordered: 0,
       wrongVehicle: 0,
       wrongSource: 0,
+      wrongIncarnation: 0,
+      oldIncarnation: 0,
+      incarnationTransitions: 0,
+      incarnationCapacity: 0,
       oldEpoch: 0,
       sourceResets: 0,
       invalidStamps: 0,
       sequenceGaps: 0,
       excessiveSkew: 0,
+      timeRegressions: 0,
+      clockChanges: 0,
     };
   }
 
@@ -156,6 +195,7 @@ export class AvionicsIngress {
       return false;
     }
     if (!this.acceptSource(stamp.sourceId)) return false;
+    if (!this.acceptIncarnation(stamp.sourceIncarnation)) return false;
     if (!this.acceptEpoch(stamp.sourceEpoch)) return false;
 
     const current = this[name];
@@ -165,6 +205,14 @@ export class AvionicsIngress {
     }
     if (current && !serialIsNewer(stamp.sequence, current.stamp.sequence)) {
       this.bump("reordered");
+      return false;
+    }
+    if (current && stamp.clock !== current.stamp.clock) {
+      this.bump("clockChanges");
+      return false;
+    }
+    if (current && stamp.acquiredAtNanos <= current.stamp.acquiredAtNanos) {
+      this.bump("timeRegressions");
       return false;
     }
     if (current) {
@@ -187,6 +235,35 @@ export class AvionicsIngress {
     if (candidate === this.sourceId) return true;
     this.bump("wrongSource");
     return false;
+  }
+
+  acceptIncarnation(candidate) {
+    if (this.sourceIncarnation === null) {
+      this.sourceIncarnation = candidate;
+      this.seenIncarnations.add(candidate);
+      return true;
+    }
+    if (candidate === this.sourceIncarnation) return true;
+    if (this.seenIncarnations.has(candidate)) {
+      this.bump("oldIncarnation");
+      return false;
+    }
+    if (this.incarnationPolicy !== INCARNATION_POLICY.SIM_ACCEPT_UNSEEN) {
+      this.bump("wrongIncarnation");
+      return false;
+    }
+    if (this.seenIncarnations.size >= this.maximumSeenIncarnations) {
+      this.bump("incarnationCapacity");
+      return false;
+    }
+    this.seenIncarnations.add(candidate);
+    this.sourceIncarnation = candidate;
+    this.sourceEpoch = null;
+    this.attitude = null;
+    this.kinematics = null;
+    this.lastCoherence = COHERENCE.INSUFFICIENT;
+    this.bump("incarnationTransitions");
+    return true;
   }
 
   acceptEpoch(candidate) {
@@ -224,6 +301,7 @@ export class AvionicsIngress {
     return Object.freeze({
       generation: this.generation,
       sourceId: this.sourceId,
+      sourceIncarnation: this.sourceIncarnation,
       sourceEpoch: this.sourceEpoch,
       attitude,
       kinematics,

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -1,13 +1,27 @@
 import assert from "node:assert/strict";
 
-import { AvionicsIngress, COHERENCE, serialIsNewer } from "./telemetry-ingress.js";
+import {
+  AvionicsIngress,
+  COHERENCE,
+  INCARNATION_POLICY,
+  serialIsNewer,
+} from "./telemetry-ingress.js";
 
 const VEHICLE = 1n;
 const SOURCE = 7n;
 const CLOCK = 1;
+const INCARNATION_A = "a5".repeat(16);
+const INCARNATION_B = "5a".repeat(16);
+const INCARNATION_C = "3c".repeat(16);
 
-function stamp(sequence, acquiredAtNanos, sourceEpoch = 1, sourceId = SOURCE) {
-  return { sourceId, sourceEpoch, sequence, acquiredAtNanos, clock: CLOCK };
+function stamp(
+  sequence,
+  acquiredAtNanos,
+  sourceEpoch = 1,
+  sourceId = SOURCE,
+  sourceIncarnation = INCARNATION_A,
+) {
+  return { sourceId, sourceIncarnation, sourceEpoch, sequence, acquiredAtNanos, clock: CLOCK };
 }
 
 function avionics(attitudeStamp, kinematicsStamp, value = 1) {
@@ -73,6 +87,12 @@ function testSequenceAndEpochWrap() {
   assert.equal(gate.diagnostics().sourceResets, 1);
   assert.equal(gate.ingest(packet(stamp(1, 30n, 1), null, 4), 3), false);
   assert.equal(gate.diagnostics().oldEpoch, 1);
+
+  const epochGate = ingress();
+  epochGate.ingest(packet(stamp(0, 10n, 0xffff_ffff), null), 0);
+  assert.equal(epochGate.ingest(packet(stamp(0, 20n, 0), null, 5), 1), true);
+  assert.equal(epochGate.snapshot(1).sourceEpoch, 0);
+  assert.equal(epochGate.diagnostics().sourceResets, 1);
 }
 
 function testVehicleAndSourceIsolation() {
@@ -83,6 +103,54 @@ function testVehicleAndSourceIsolation() {
   assert.equal(gate.snapshot(2).attitude.quat.w, 1);
   assert.equal(gate.diagnostics().wrongVehicle, 1);
   assert.equal(gate.diagnostics().wrongSource, 1);
+}
+
+function testDefaultPolicyPinsFirstIncarnation() {
+  const gate = ingress();
+  assert.equal(gate.ingest(packet(stamp(1, 10n), null), 0), true);
+  assert.equal(
+    gate.ingest(packet(stamp(0, 1n, 1, SOURCE, INCARNATION_B), null, 2), 1),
+    false,
+  );
+  assert.equal(gate.snapshot(1).attitude.quat.w, 1);
+  assert.equal(gate.diagnostics().wrongIncarnation, 1);
+}
+
+function testSimulatorPolicyAcceptsUnseenAndRejectsSeenIncarnations() {
+  const gate = new AvionicsIngress({
+    vehicleId: VEHICLE,
+    maximumSkewNanos: 100n,
+    incarnationPolicy: INCARNATION_POLICY.SIM_ACCEPT_UNSEEN,
+    maximumSeenIncarnations: 2,
+  });
+  gate.ingest(packet(stamp(1, 10n), null), 0);
+  assert.equal(
+    gate.ingest(packet(stamp(0, 1n, 1, SOURCE, INCARNATION_B), null, 2), 1),
+    true,
+  );
+  assert.equal(gate.snapshot(1).sourceIncarnation, INCARNATION_B);
+  assert.equal(gate.diagnostics().incarnationTransitions, 1);
+  assert.equal(gate.ingest(packet(stamp(2, 20n), null, 3), 2), false);
+  assert.equal(gate.diagnostics().oldIncarnation, 1);
+  assert.equal(
+    gate.ingest(packet(stamp(0, 1n, 1, SOURCE, INCARNATION_C), null, 4), 3),
+    false,
+  );
+  assert.equal(gate.diagnostics().incarnationCapacity, 1);
+}
+
+function testAcquisitionTimeRegressionDoesNotRefreshAge() {
+  const gate = ingress();
+  gate.ingest(packet(stamp(10, 1_000n), null), 100);
+  assert.equal(gate.ingest(packet(stamp(11, 900n), null, 2), 500), false);
+  const snapshot = gate.snapshot(850);
+  assert.equal(snapshot.attitude.quat.w, 1);
+  assert.equal(snapshot.attitude.ageMs, 750);
+  assert.equal(gate.diagnostics().timeRegressions, 1);
+
+  assert.equal(gate.ingest(packet(stamp(12, 1_000n), null, 3), 900), false);
+  assert.equal(gate.snapshot(1_100).attitude.ageMs, 1_000);
+  assert.equal(gate.diagnostics().timeRegressions, 2);
 }
 
 function testIndependentGroupsAndCoherenceBoundary() {
@@ -129,6 +197,12 @@ function testInvalidStampIsRejected() {
   assert.equal(gate.ingest(packet(invalid, null), 0), false);
   assert.equal(gate.snapshot(0).attitude, null);
   assert.equal(gate.diagnostics().invalidStamps, 1);
+  assert.equal(gate.ingest(packet({ ...stamp(1, 10n), sourceEpoch: -1 }, null), 1), false);
+  assert.equal(
+    gate.ingest(packet({ ...stamp(1, 10n), sequence: 0x1_0000_0000 }, null), 2),
+    false,
+  );
+  assert.equal(gate.diagnostics().invalidStamps, 3);
 }
 
 function testCountersAndGenerationWrap() {
@@ -147,6 +221,9 @@ for (const test of [
   testReorderAndGapHandling,
   testSequenceAndEpochWrap,
   testVehicleAndSourceIsolation,
+  testDefaultPolicyPinsFirstIncarnation,
+  testSimulatorPolicyAcceptsUnseenAndRejectsSeenIncarnations,
+  testAcquisitionTimeRegressionDoesNotRefreshAge,
   testIndependentGroupsAndCoherenceBoundary,
   testSnapshotsAreAtomicAndImmutable,
   testInvalidStampIsRejected,

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+
+import { AvionicsIngress, COHERENCE, serialIsNewer } from "./telemetry-ingress.js";
+
+const VEHICLE = 1n;
+const SOURCE = 7n;
+const CLOCK = 1;
+
+function stamp(sequence, acquiredAtNanos, sourceEpoch = 1, sourceId = SOURCE) {
+  return { sourceId, sourceEpoch, sequence, acquiredAtNanos, clock: CLOCK };
+}
+
+function avionics(attitudeStamp, kinematicsStamp, value = 1) {
+  return {
+    quat: { w: value, x: 0, y: 0, z: 0 },
+    rates: [value, 0, 0],
+    posNed: [value, 0, 0],
+    velNed: [value, 0, 0],
+    validFlags: 0b1111,
+    quality: 0,
+    armState: 2,
+    attitudeStamp,
+    kinematicsStamp,
+  };
+}
+
+function packet(attitudeStamp, kinematicsStamp, value = 1, vehicleId = VEHICLE) {
+  return { vehicleId, avionics: avionics(attitudeStamp, kinematicsStamp, value) };
+}
+
+function ingress(maximumSkewNanos = 100n) {
+  return new AvionicsIngress({ vehicleId: VEHICLE, maximumSkewNanos });
+}
+
+function testDuplicateDoesNotRefreshAge() {
+  const gate = ingress();
+  const first = packet(stamp(10, 1_000n), stamp(20, 1_000n));
+  assert.equal(gate.ingest(first, 100), true);
+  assert.equal(gate.ingest(first, 600), false);
+  assert.equal(gate.snapshot(850).attitude.ageMs, 750);
+  assert.equal(gate.snapshot(3_100).attitude.ageMs, 3_000);
+  const snapshot = gate.snapshot(1_100);
+  assert.equal(snapshot.attitude.ageMs, 1_000);
+  assert.equal(snapshot.kinematics.ageMs, 1_000);
+  assert.equal(gate.diagnostics().duplicates, 2);
+}
+
+function testReorderAndGapHandling() {
+  const gate = ingress();
+  assert.equal(gate.ingest(packet(stamp(10, 100n), null), 0), true);
+  assert.equal(gate.ingest(packet(stamp(12, 120n), null, 2), 20), true);
+  assert.equal(gate.ingest(packet(stamp(11, 110n), null, 3), 30), false);
+  const snapshot = gate.snapshot(30);
+  assert.equal(snapshot.attitude.quat.w, 2);
+  assert.equal(gate.diagnostics().sequenceGaps, 1);
+  assert.equal(gate.diagnostics().reordered, 1);
+}
+
+function testSequenceAndEpochWrap() {
+  assert.equal(serialIsNewer(0, 0xffff_ffff), true);
+  assert.equal(serialIsNewer(0xffff_ffff, 0), false);
+  assert.equal(serialIsNewer(0x8000_0000, 0), false);
+  const gate = ingress();
+  gate.ingest(packet(stamp(0xffff_ffff, 10n), null), 0);
+  assert.equal(gate.ingest(packet(stamp(0, 20n), null, 2), 1), true);
+  assert.equal(gate.snapshot(1).attitude.quat.w, 2);
+
+  assert.equal(gate.ingest(packet(stamp(0, 1n, 2), stamp(0, 1n, 2), 3), 2), true);
+  const reset = gate.snapshot(2);
+  assert.equal(reset.sourceEpoch, 2);
+  assert.equal(reset.attitude.quat.w, 3);
+  assert.equal(reset.kinematics.posNed[0], 3);
+  assert.equal(gate.diagnostics().sourceResets, 1);
+  assert.equal(gate.ingest(packet(stamp(1, 30n, 1), null, 4), 3), false);
+  assert.equal(gate.diagnostics().oldEpoch, 1);
+}
+
+function testVehicleAndSourceIsolation() {
+  const gate = ingress();
+  assert.equal(gate.ingest(packet(stamp(1, 10n), null, 1, 2n), 0), false);
+  assert.equal(gate.ingest(packet(stamp(1, 10n), null), 1), true);
+  assert.equal(gate.ingest(packet(stamp(2, 20n, 1, 8n), null, 9), 2), false);
+  assert.equal(gate.snapshot(2).attitude.quat.w, 1);
+  assert.equal(gate.diagnostics().wrongVehicle, 1);
+  assert.equal(gate.diagnostics().wrongSource, 1);
+}
+
+function testIndependentGroupsAndCoherenceBoundary() {
+  const gate = ingress(100n);
+  gate.ingest(packet(stamp(1, 1_000n), stamp(1, 1_100n)), 10);
+  let snapshot = gate.snapshot(10);
+  assert.equal(snapshot.coherence.status, COHERENCE.COHERENT);
+  assert.equal(snapshot.coherence.skewNanos, 100n);
+
+  gate.ingest(packet(stamp(2, 1_500n), null, 2), 20);
+  snapshot = gate.snapshot(30);
+  assert.equal(snapshot.attitude.ageMs, 10);
+  assert.equal(snapshot.kinematics.ageMs, 20);
+  assert.equal(snapshot.coherence.status, COHERENCE.EXCESSIVE_SKEW);
+  assert.equal(gate.diagnostics().excessiveSkew, 1);
+
+  gate.ingest(packet(null, stamp(2, 1_450n), 3), 40);
+  snapshot = gate.snapshot(40);
+  assert.equal(snapshot.coherence.status, COHERENCE.COHERENT);
+  assert.equal(snapshot.attitude.quat.w, 2);
+  assert.equal(snapshot.kinematics.posNed[0], 3);
+}
+
+function testSnapshotsAreAtomicAndImmutable() {
+  const gate = ingress();
+  gate.ingest(packet(stamp(1, 10n), stamp(1, 10n), 1), 0);
+  const before = gate.snapshot(0);
+  gate.ingest(packet(stamp(2, 20n), stamp(2, 20n), 2), 1);
+  const after = gate.snapshot(1);
+
+  assert.equal(before.generation, 1);
+  assert.equal(before.attitude.quat.w, 1);
+  assert.equal(before.kinematics.posNed[0], 1);
+  assert.equal(after.generation, 2);
+  assert.equal(after.attitude.quat.w, 2);
+  assert.equal(after.kinematics.posNed[0], 2);
+  assert.equal(Object.isFrozen(before), true);
+  assert.equal(Object.isFrozen(before.attitude.quat), true);
+}
+
+function testInvalidStampIsRejected() {
+  const gate = ingress();
+  const invalid = { ...stamp(1, 10n), clock: 0 };
+  assert.equal(gate.ingest(packet(invalid, null), 0), false);
+  assert.equal(gate.snapshot(0).attitude, null);
+  assert.equal(gate.diagnostics().invalidStamps, 1);
+}
+
+function testCountersAndGenerationWrap() {
+  const gate = ingress();
+  gate.generation = 0xffff_ffff;
+  gate.counters.duplicates = 0xffff_ffff;
+  const first = packet(stamp(1, 10n), null);
+  assert.equal(gate.ingest(first, 0), true);
+  assert.equal(gate.snapshot(0).generation, 0);
+  assert.equal(gate.ingest(first, 1), false);
+  assert.equal(gate.diagnostics().duplicates, 0);
+}
+
+for (const test of [
+  testDuplicateDoesNotRefreshAge,
+  testReorderAndGapHandling,
+  testSequenceAndEpochWrap,
+  testVehicleAndSourceIsolation,
+  testIndependentGroupsAndCoherenceBoundary,
+  testSnapshotsAreAtomicAndImmutable,
+  testInvalidStampIsRejected,
+  testCountersAndGenerationWrap,
+]) {
+  test();
+  console.log(`ok - ${test.name}`);
+}

--- a/clients/web/transport-session.js
+++ b/clients/web/transport-session.js
@@ -1,0 +1,116 @@
+// WebTransport lifecycle ownership for the demo viewer. A token is an object,
+// not only its wrapping generation, so a delayed callback cannot become active
+// again after the numeric generation wraps.
+
+function discardTeardownRejection(pending) {
+  if (pending && typeof pending.catch === "function") pending.catch(() => {});
+}
+
+function cancelReader(reader) {
+  try {
+    discardTeardownRejection(reader.cancel());
+  } catch {
+    // Teardown is already fail-closed because the token was invalidated first.
+  }
+}
+
+function abortWriter(writer) {
+  try {
+    discardTeardownRejection(writer.abort());
+  } catch {
+    // Teardown is already fail-closed because the token was invalidated first.
+  }
+}
+
+function closeTransport(transport) {
+  try {
+    transport.close();
+  } catch {
+    // An already-failed transport still loses authority through its token.
+  }
+}
+
+function disposeSession(session, shouldCloseTransport) {
+  for (const reader of session.readers) cancelReader(reader);
+  for (const writer of session.writers) abortWriter(writer);
+  session.readers.clear();
+  session.writers.clear();
+  if (shouldCloseTransport) closeTransport(session.token.transport);
+}
+
+export class TransportSessionLifecycle {
+  constructor() {
+    this.generation = 0;
+    this.active = null;
+  }
+
+  begin(transport) {
+    if (!transport || typeof transport.close !== "function") {
+      throw new TypeError("transport must provide close()");
+    }
+    const previous = this.active;
+    this.generation = (this.generation + 1) >>> 0;
+    const token = Object.freeze({ generation: this.generation, transport });
+    this.active = { token, readers: new Set(), writers: new Set() };
+    if (previous) disposeSession(previous, true);
+    return token;
+  }
+
+  isActive(token) {
+    return this.active?.token === token;
+  }
+
+  runIfActive(token, action) {
+    if (!this.isActive(token)) return false;
+    action();
+    return true;
+  }
+
+  trackReader(token, reader) {
+    if (!reader || typeof reader.cancel !== "function") {
+      throw new TypeError("reader must provide cancel()");
+    }
+    if (!this.isActive(token)) {
+      cancelReader(reader);
+      return false;
+    }
+    this.active.readers.add(reader);
+    return true;
+  }
+
+  untrackReader(token, reader) {
+    if (this.isActive(token)) this.active.readers.delete(reader);
+  }
+
+  trackWriter(token, writer) {
+    if (!writer || typeof writer.abort !== "function") {
+      throw new TypeError("writer must provide abort()");
+    }
+    if (!this.isActive(token)) {
+      abortWriter(writer);
+      return false;
+    }
+    this.active.writers.add(writer);
+    return true;
+  }
+
+  untrackWriter(token, writer) {
+    if (this.isActive(token)) this.active.writers.delete(writer);
+  }
+
+  close(token) {
+    if (!this.isActive(token)) return false;
+    const session = this.active;
+    this.active = null;
+    disposeSession(session, true);
+    return true;
+  }
+
+  retire(token) {
+    if (!this.isActive(token)) return false;
+    const session = this.active;
+    this.active = null;
+    disposeSession(session, false);
+    return true;
+  }
+}

--- a/clients/web/transport-session.test.mjs
+++ b/clients/web/transport-session.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+
+import { TransportSessionLifecycle } from "./transport-session.js";
+
+function fakeTransport(name) {
+  return {
+    name,
+    closeCount: 0,
+    close() {
+      this.closeCount += 1;
+    },
+  };
+}
+
+function fakeReader() {
+  return {
+    cancelCount: 0,
+    cancel() {
+      this.cancelCount += 1;
+      return Promise.resolve();
+    },
+  };
+}
+
+function fakeWriter() {
+  return {
+    abortCount: 0,
+    abort() {
+      this.abortCount += 1;
+      return Promise.resolve();
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function testInterleavedReplacementRejectsOldDataAndCallbacks() {
+  const lifecycle = new TransportSessionLifecycle();
+  const oldTransport = fakeTransport("old");
+  const oldToken = lifecycle.begin(oldTransport);
+  const oldReader = fakeReader();
+  const oldWriter = fakeWriter();
+  lifecycle.trackReader(oldToken, oldReader);
+  lifecycle.trackWriter(oldToken, oldWriter);
+
+  const viewer = { connected: true, ingress: "old", status: "old ready" };
+  const oldDatagram = deferred();
+  const oldClosed = deferred();
+  const delayedDatagram = oldDatagram.promise.then((value) => {
+    lifecycle.runIfActive(oldToken, () => {
+      viewer.ingress = value;
+    });
+  });
+  const delayedClose = oldClosed.promise.then(() => {
+    lifecycle.runIfActive(oldToken, () => {
+      viewer.connected = false;
+      viewer.status = "old closed";
+    });
+    lifecycle.retire(oldToken);
+  });
+
+  const newTransport = fakeTransport("new");
+  const newToken = lifecycle.begin(newTransport);
+  lifecycle.runIfActive(newToken, () => {
+    viewer.connected = true;
+    viewer.ingress = "new";
+    viewer.status = "new ready";
+  });
+
+  assert.equal(oldTransport.closeCount, 1);
+  assert.equal(oldReader.cancelCount, 1);
+  assert.equal(oldWriter.abortCount, 1);
+  oldDatagram.resolve("old datagram");
+  oldClosed.resolve();
+  await Promise.all([delayedDatagram, delayedClose]);
+  assert.equal(lifecycle.isActive(newToken), true);
+  assert.deepEqual(viewer, { connected: true, ingress: "new", status: "new ready" });
+
+  assert.equal(
+    lifecycle.runIfActive(newToken, () => {
+      viewer.ingress = "new datagram";
+    }),
+    true,
+  );
+  assert.equal(viewer.ingress, "new datagram");
+}
+
+function testTokenIdentitySurvivesGenerationWrap() {
+  const lifecycle = new TransportSessionLifecycle();
+  lifecycle.generation = 0xffff_ffff;
+  const oldToken = lifecycle.begin(fakeTransport("before wrap"));
+  lifecycle.generation = 0xffff_ffff;
+  const newToken = lifecycle.begin(fakeTransport("after wrap"));
+
+  assert.equal(oldToken.generation, 0);
+  assert.equal(newToken.generation, 0);
+  assert.notEqual(oldToken, newToken);
+  assert.equal(lifecycle.isActive(oldToken), false);
+  assert.equal(lifecycle.isActive(newToken), true);
+}
+
+for (const test of [
+  testInterleavedReplacementRejectsOldDataAndCallbacks,
+  testTokenIdentitySurvivesGenerationWrap,
+]) {
+  await test();
+  console.log(`ok - ${test.name}`);
+}

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -42,8 +42,8 @@ function writeVarint(bytes, value) {
   }
 }
 
-/** Reads an unsigned LEB128 varint starting at `view[offset]`; returns [value, nextOffset]. */
-function readVarint(view, offset) {
+/** Reads an unsigned LEB128 varint without losing uint64 precision. */
+function readVarintBigInt(view, offset) {
   let result = 0n;
   let shift = 0n;
   let pos = offset;
@@ -52,10 +52,19 @@ function readVarint(view, offset) {
     pos += 1;
     result |= BigInt(byte & 0x7f) << shift;
     if ((byte & 0x80) === 0) {
-      return [Number(result), pos];
+      return [result, pos];
     }
     shift += 7n;
   }
+}
+
+/** Reads a varint used as a protobuf tag or byte length. */
+function readVarint(view, offset) {
+  const [value, next] = readVarintBigInt(view, offset);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("protobuf tag/length exceeds the safe integer range");
+  }
+  return [Number(value), next];
 }
 
 /** Writes a protobuf field tag: (fieldNumber << 3) | wireType. */
@@ -299,8 +308,8 @@ function encodeMonoTimestamp(nanos) {
 // full descriptor-driven decoder.
 
 /** Parses a top-level protobuf message into a Map<fieldNumber, list-of-values>.
- * Each value is either a number (varint), a Uint8Array (length-delimited), or
- * a number (32/64-bit fixed, returned as a BigInt-safe Number when possible).
+ * Each value is either a bigint (varint) or a Uint8Array (length-delimited or
+ * fixed-width). Callers explicitly narrow protocol enums and u32 values.
  */
 function parseFields(bytes) {
   const fields = new Map();
@@ -312,7 +321,7 @@ function parseFields(bytes) {
     offset = afterTag;
     let value;
     if (wireType === WIRE_VARINT) {
-      const [v, next] = readVarint(bytes, offset);
+      const [v, next] = readVarintBigInt(bytes, offset);
       value = v;
       offset = next;
     } else if (wireType === WIRE_LEN) {
@@ -341,13 +350,18 @@ function firstBytes(fields, fieldNumber) {
 
 function firstVarint(fields, fieldNumber) {
   const values = fields.get(fieldNumber);
-  return values && values.length > 0 ? values[0] : 0;
+  return values && values.length > 0 ? Number(values[0]) : 0;
+}
+
+function firstBigVarint(fields, fieldNumber) {
+  const values = fields.get(fieldNumber);
+  return values && values.length > 0 ? values[0] : 0n;
 }
 
 function decodeUint64Message(bytes) {
-  if (!bytes) return 0;
+  if (!bytes) return 0n;
   const fields = parseFields(bytes);
-  return firstVarint(fields, 1);
+  return firstBigVarint(fields, 1);
 }
 
 function decodeStringMessage(bytes) {
@@ -446,6 +460,9 @@ function decodeTelemetrySample(bytes) {
   const pose = poseBytes ? parseFields(poseBytes) : new Map();
   const vel = velBytes ? parseFields(velBytes) : new Map();
   return {
+    vehicleId: decodeUint64Message(firstBytes(fields, 1)),
+    tick: decodeUint64Message(firstBytes(fields, 2)),
+    publishedAtNanos: decodeUint64Message(firstBytes(fields, 3)),
     xM: decodeFloat32(firstBytes(pose, 1)),
     yM: decodeFloat32(firstBytes(pose, 2)),
     headingRad: decodeFloat32(firstBytes(pose, 3)),
@@ -457,7 +474,8 @@ function decodeTelemetrySample(bytes) {
 
 // telemetry.proto AvionicsState (ADR-0018): quat_w..z=1..4,
 // rate_p/q/r_rad_s=5..7, pos_n/e/d_m=8..10, vel_n/e/d_mps=11..13 (float),
-// valid_flags=14, quality=15 (varint). Raw estimate; display derivation
+// valid_flags=14, quality=15, arm_state=16 (varint), group stamps=17/18.
+// Raw estimate; display derivation
 // happens in the instrument runtime (ADR-0017).
 function decodeAvionicsState(bytes) {
   if (!bytes) return null;
@@ -488,6 +506,20 @@ function decodeAvionicsState(bytes) {
     quality: firstVarint(f, 15) ?? 0,
     // 0 unknown, 1 disarmed, 2 armed.
     armState: firstVarint(f, 16) ?? 0,
+    attitudeStamp: decodeMeasurementStamp(firstBytes(f, 17)),
+    kinematicsStamp: decodeMeasurementStamp(firstBytes(f, 18)),
+  };
+}
+
+function decodeMeasurementStamp(bytes) {
+  if (!bytes) return null;
+  const f = parseFields(bytes);
+  return {
+    sourceId: firstBigVarint(f, 1),
+    sourceEpoch: firstVarint(f, 2) >>> 0,
+    sequence: firstVarint(f, 3) >>> 0,
+    acquiredAtNanos: firstBigVarint(f, 4),
+    clock: firstVarint(f, 5),
   };
 }
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -455,20 +455,40 @@ function decodeLeaseResponse(bytes) {
 function decodeTelemetrySample(bytes) {
   if (!bytes) return {};
   const fields = parseFields(bytes);
-  const poseBytes = firstBytes(fields, 4);
-  const velBytes = firstBytes(fields, 5);
-  const pose = poseBytes ? parseFields(poseBytes) : new Map();
-  const vel = velBytes ? parseFields(velBytes) : new Map();
+  const pose = decodePose2d(firstBytes(fields, 4));
+  const velocity = decodeVelocity2d(firstBytes(fields, 5));
   return {
     vehicleId: decodeUint64Message(firstBytes(fields, 1)),
     tick: decodeUint64Message(firstBytes(fields, 2)),
     publishedAtNanos: decodeUint64Message(firstBytes(fields, 3)),
-    xM: decodeFloat32(firstBytes(pose, 1)),
-    yM: decodeFloat32(firstBytes(pose, 2)),
-    headingRad: decodeFloat32(firstBytes(pose, 3)),
-    linearXMps: decodeFloat32(firstBytes(vel, 1)),
-    angularRadS: decodeFloat32(firstBytes(vel, 3)),
+    pose,
+    velocity,
+    xM: pose?.xM ?? null,
+    yM: pose?.yM ?? null,
+    headingRad: pose?.headingRad ?? null,
+    linearXMps: velocity?.linearXMps ?? null,
+    angularRadS: velocity?.angularRadS ?? null,
     avionics: decodeAvionicsState(firstBytes(fields, 6)),
+  };
+}
+
+function decodePose2d(bytes) {
+  if (!bytes) return null;
+  const fields = parseFields(bytes);
+  return {
+    xM: decodeFloat32(firstBytes(fields, 1)),
+    yM: decodeFloat32(firstBytes(fields, 2)),
+    headingRad: decodeFloat32(firstBytes(fields, 3)),
+  };
+}
+
+function decodeVelocity2d(bytes) {
+  if (!bytes) return null;
+  const fields = parseFields(bytes);
+  return {
+    linearXMps: decodeFloat32(firstBytes(fields, 1)),
+    linearYMps: decodeFloat32(firstBytes(fields, 2)),
+    angularRadS: decodeFloat32(firstBytes(fields, 3)),
   };
 }
 
@@ -480,7 +500,9 @@ function decodeTelemetrySample(bytes) {
 function decodeAvionicsState(bytes) {
   if (!bytes) return null;
   const f = parseFields(bytes);
-  return {
+  const attitudeStamp = decodeMeasurementStamp(firstBytes(f, 17));
+  const kinematicsStamp = decodeMeasurementStamp(firstBytes(f, 18));
+  const attitude = attitudeStamp === null ? null : {
     quat: {
       w: decodeFloat32(firstBytes(f, 1)),
       x: decodeFloat32(firstBytes(f, 2)),
@@ -492,6 +514,8 @@ function decodeAvionicsState(bytes) {
       decodeFloat32(firstBytes(f, 6)),
       decodeFloat32(firstBytes(f, 7)),
     ],
+  };
+  const kinematics = kinematicsStamp === null ? null : {
     posNed: [
       decodeFloat32(firstBytes(f, 8)),
       decodeFloat32(firstBytes(f, 9)),
@@ -502,12 +526,20 @@ function decodeAvionicsState(bytes) {
       decodeFloat32(firstBytes(f, 12)),
       decodeFloat32(firstBytes(f, 13)),
     ],
+  };
+  return {
+    attitude,
+    kinematics,
+    quat: attitude?.quat ?? null,
+    rates: attitude?.rates ?? null,
+    posNed: kinematics?.posNed ?? null,
+    velNed: kinematics?.velNed ?? null,
     validFlags: firstVarint(f, 14) ?? 0,
     quality: firstVarint(f, 15) ?? 0,
     // 0 unknown, 1 disarmed, 2 armed.
     armState: firstVarint(f, 16) ?? 0,
-    attitudeStamp: decodeMeasurementStamp(firstBytes(f, 17)),
-    kinematicsStamp: decodeMeasurementStamp(firstBytes(f, 18)),
+    attitudeStamp,
+    kinematicsStamp,
   };
 }
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -516,11 +516,17 @@ function decodeMeasurementStamp(bytes) {
   const f = parseFields(bytes);
   return {
     sourceId: firstBigVarint(f, 1),
+    sourceIncarnation: decodeIncarnation(firstBytes(f, 6)),
     sourceEpoch: firstVarint(f, 2) >>> 0,
     sequence: firstVarint(f, 3) >>> 0,
     acquiredAtNanos: firstBigVarint(f, 4),
     clock: firstVarint(f, 5),
   };
+}
+
+function decodeIncarnation(bytes) {
+  if (!bytes || bytes.length !== 16) return null;
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
 }
 
 // authority.proto AuthorityEvent: a oneof; we only care which arm fired and a

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -10,6 +10,7 @@
 // required fields are emitted even when their ids are zero.
 
 import { encodeControlFrameEnvelope, decodeBareEnvelope, SCHEMA_VERSION } from "./wire.js";
+import "./telemetry-ingress.test.mjs";
 
 let failures = 0;
 function check(name, cond) {
@@ -131,6 +132,28 @@ function bytesField(out, fieldNumber, bytes) {
   out.push(...bytes);
 }
 
+function uint64Message(value) {
+  const out = [];
+  varint(out, (1 << 3) | 0);
+  varint(out, value);
+  return out;
+}
+
+function measurementStamp(sourceId, epoch, sequence, acquiredAtNanos, clock) {
+  const out = [];
+  for (const [field, value] of [
+    [1, sourceId],
+    [2, epoch],
+    [3, sequence],
+    [4, acquiredAtNanos],
+    [5, clock],
+  ]) {
+    varint(out, (field << 3) | 0);
+    varint(out, value);
+  }
+  return out;
+}
+
 const avionics = [];
 f32Field(avionics, 1, 0.9); // quat_w; x/y/z stay 0 and are omitted
 f32Field(avionics, 7, 0.05); // rate_r
@@ -138,8 +161,13 @@ f32Field(avionics, 10, -304.8); // pos_d
 f32Field(avionics, 11, 10.0); // vel_n
 varint(avionics, (14 << 3) | 0);
 varint(avionics, 0b1111); // valid_flags
+bytesField(avionics, 17, measurementStamp(7, 3, 10, 1_000_000, 1));
+bytesField(avionics, 18, measurementStamp(7, 3, 5, 900_000, 1));
 
 const sample = [];
+bytesField(sample, 1, uint64Message(1));
+bytesField(sample, 2, uint64Message(42));
+bytesField(sample, 3, uint64Message(2_000_000));
 bytesField(sample, 6, avionics);
 const bare = [];
 varint(bare, (1 << 3) | 0);
@@ -150,11 +178,18 @@ const decoded = decodeBareEnvelope(new Uint8Array(bare));
 check("telemetry datagram decodes as TelemetrySample", decoded.kind === "TelemetrySample");
 const av = decoded.message.avionics;
 check("avionics arm is surfaced", !!av);
+check("telemetry vehicle identity is preserved", decoded.message.vehicleId === 1n);
+check("telemetry source tick is preserved", decoded.message.tick === 42n);
+check("host publication time is preserved separately", decoded.message.publishedAtNanos === 2_000_000n);
 check("avionics quat_w decodes", Math.abs(av.quat.w - 0.9) < 1e-6);
 check("omitted zero quat components decode as 0", av.quat.x === 0 && av.quat.y === 0 && av.quat.z === 0);
 check("avionics pos_d decodes", Math.abs(av.posNed[2] + 304.8) < 1e-3);
 check("avionics vel_n decodes", Math.abs(av.velNed[0] - 10.0) < 1e-6);
 check("avionics valid_flags decode", Number(av.validFlags) === 0b1111);
+check("attitude measurement identity decodes", av.attitudeStamp.sourceId === 7n);
+check("attitude epoch and sequence decode", av.attitudeStamp.sourceEpoch === 3 && av.attitudeStamp.sequence === 10);
+check("attitude acquisition time and clock decode", av.attitudeStamp.acquiredAtNanos === 1_000_000n && av.attitudeStamp.clock === 1);
+check("kinematics sequence remains independent", av.kinematicsStamp.sequence === 5);
 check("a sample without avionics decodes to null", (() => {
   const bareNoAv = [];
   varint(bareNoAv, (1 << 3) | 0);

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -10,9 +10,6 @@
 // required fields are emitted even when their ids are zero.
 
 import { encodeControlFrameEnvelope, decodeBareEnvelope, SCHEMA_VERSION } from "./wire.js";
-import "./telemetry-ingress.test.mjs";
-import "./telemetry-display.test.mjs";
-import "./transport-session.test.mjs";
 
 let failures = 0;
 function check(name, cond) {

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -108,11 +108,11 @@ for (const [num, name] of [
 // proto3's omitted zero-valued fields (quat_x/y/z absent -> 0).
 
 function varint(out, v) {
-  let n = v;
+  let n = BigInt(v);
   for (;;) {
-    const b = n & 0x7f;
-    n >>>= 7;
-    if (n === 0) {
+    const b = Number(n & 0x7fn);
+    n >>= 7n;
+    if (n === 0n) {
       out.push(b);
       return;
     }
@@ -139,7 +139,7 @@ function uint64Message(value) {
   return out;
 }
 
-function measurementStamp(sourceId, epoch, sequence, acquiredAtNanos, clock) {
+function measurementStamp(sourceId, epoch, sequence, acquiredAtNanos, clock, incarnationByte) {
   const out = [];
   for (const [field, value] of [
     [1, sourceId],
@@ -151,6 +151,7 @@ function measurementStamp(sourceId, epoch, sequence, acquiredAtNanos, clock) {
     varint(out, (field << 3) | 0);
     varint(out, value);
   }
+  bytesField(out, 6, new Uint8Array(16).fill(incarnationByte));
   return out;
 }
 
@@ -161,8 +162,10 @@ f32Field(avionics, 10, -304.8); // pos_d
 f32Field(avionics, 11, 10.0); // vel_n
 varint(avionics, (14 << 3) | 0);
 varint(avionics, 0b1111); // valid_flags
-bytesField(avionics, 17, measurementStamp(7, 3, 10, 1_000_000, 1));
-bytesField(avionics, 18, measurementStamp(7, 3, 5, 900_000, 1));
+const sourceId = 0xfedc_ba98_7654_3210n;
+const acquiredAt = 0xffff_ffff_ffff_fffen;
+bytesField(avionics, 17, measurementStamp(sourceId, 3, 10, acquiredAt, 1, 0xa5));
+bytesField(avionics, 18, measurementStamp(sourceId, 3, 5, acquiredAt - 100_000n, 1, 0xa5));
 
 const sample = [];
 bytesField(sample, 1, uint64Message(1));
@@ -186,9 +189,10 @@ check("omitted zero quat components decode as 0", av.quat.x === 0 && av.quat.y =
 check("avionics pos_d decodes", Math.abs(av.posNed[2] + 304.8) < 1e-3);
 check("avionics vel_n decodes", Math.abs(av.velNed[0] - 10.0) < 1e-6);
 check("avionics valid_flags decode", Number(av.validFlags) === 0b1111);
-check("attitude measurement identity decodes", av.attitudeStamp.sourceId === 7n);
+check("attitude uint64 identity decodes without precision loss", av.attitudeStamp.sourceId === sourceId);
+check("attitude incarnation decodes exactly", av.attitudeStamp.sourceIncarnation === "a5".repeat(16));
 check("attitude epoch and sequence decode", av.attitudeStamp.sourceEpoch === 3 && av.attitudeStamp.sequence === 10);
-check("attitude acquisition time and clock decode", av.attitudeStamp.acquiredAtNanos === 1_000_000n && av.attitudeStamp.clock === 1);
+check("attitude uint64 acquisition time and clock decode", av.attitudeStamp.acquiredAtNanos === acquiredAt && av.attitudeStamp.clock === 1);
 check("kinematics sequence remains independent", av.kinematicsStamp.sequence === 5);
 check("a sample without avionics decodes to null", (() => {
   const bareNoAv = [];

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -11,6 +11,8 @@
 
 import { encodeControlFrameEnvelope, decodeBareEnvelope, SCHEMA_VERSION } from "./wire.js";
 import "./telemetry-ingress.test.mjs";
+import "./telemetry-display.test.mjs";
+import "./transport-session.test.mjs";
 
 let failures = 0;
 function check(name, cond) {
@@ -155,6 +157,18 @@ function measurementStamp(sourceId, epoch, sequence, acquiredAtNanos, clock, inc
   return out;
 }
 
+function decodeAvionicsOnly(avionicsBytes) {
+  const telemetry = [];
+  bytesField(telemetry, 1, uint64Message(1));
+  bytesField(telemetry, 2, uint64Message(42));
+  bytesField(telemetry, 6, avionicsBytes);
+  const envelopeBytes = [];
+  varint(envelopeBytes, (1 << 3) | 0);
+  varint(envelopeBytes, SCHEMA_VERSION);
+  bytesField(envelopeBytes, 4, telemetry);
+  return decodeBareEnvelope(new Uint8Array(envelopeBytes)).message;
+}
+
 const avionics = [];
 f32Field(avionics, 1, 0.9); // quat_w; x/y/z stay 0 and are omitted
 f32Field(avionics, 7, 0.05); // rate_r
@@ -184,6 +198,9 @@ check("avionics arm is surfaced", !!av);
 check("telemetry vehicle identity is preserved", decoded.message.vehicleId === 1n);
 check("telemetry source tick is preserved", decoded.message.tick === 42n);
 check("host publication time is preserved separately", decoded.message.publishedAtNanos === 2_000_000n);
+check("absent top-level pose remains null", decoded.message.pose === null && decoded.message.xM === null);
+check("absent top-level velocity remains null", decoded.message.velocity === null && decoded.message.linearXMps === null);
+check("both stamped avionics groups are present", av.attitude !== null && av.kinematics !== null);
 check("avionics quat_w decodes", Math.abs(av.quat.w - 0.9) < 1e-6);
 check("omitted zero quat components decode as 0", av.quat.x === 0 && av.quat.y === 0 && av.quat.z === 0);
 check("avionics pos_d decodes", Math.abs(av.posNed[2] + 304.8) < 1e-3);
@@ -194,6 +211,42 @@ check("attitude incarnation decodes exactly", av.attitudeStamp.sourceIncarnation
 check("attitude epoch and sequence decode", av.attitudeStamp.sourceEpoch === 3 && av.attitudeStamp.sequence === 10);
 check("attitude uint64 acquisition time and clock decode", av.attitudeStamp.acquiredAtNanos === acquiredAt && av.attitudeStamp.clock === 1);
 check("kinematics sequence remains independent", av.kinematicsStamp.sequence === 5);
+
+const attitudeOnly = [];
+f32Field(attitudeOnly, 1, 0.7);
+f32Field(attitudeOnly, 7, 0.2);
+f32Field(attitudeOnly, 8, 99.0); // ignored without a kinematics stamp
+bytesField(attitudeOnly, 17, measurementStamp(sourceId, 3, 11, acquiredAt, 1, 0xa5));
+const decodedAttitudeOnly = decodeAvionicsOnly(attitudeOnly);
+check(
+  "attitude-only publication omits top-level pose and velocity",
+  decodedAttitudeOnly.pose === null && decodedAttitudeOnly.velocity === null,
+);
+check(
+  "attitude-only publication preserves only the attitude group",
+  decodedAttitudeOnly.avionics.attitude !== null
+    && decodedAttitudeOnly.avionics.kinematics === null
+    && decodedAttitudeOnly.avionics.quat !== null
+    && decodedAttitudeOnly.avionics.posNed === null,
+);
+
+const kinematicsOnly = [];
+f32Field(kinematicsOnly, 1, 0.9); // ignored without an attitude stamp
+f32Field(kinematicsOnly, 8, 12.0);
+f32Field(kinematicsOnly, 11, 5.0);
+bytesField(kinematicsOnly, 18, measurementStamp(sourceId, 3, 6, acquiredAt, 1, 0xa5));
+const decodedKinematicsOnly = decodeAvionicsOnly(kinematicsOnly);
+check(
+  "kinematics-only publication omits top-level pose and velocity",
+  decodedKinematicsOnly.pose === null && decodedKinematicsOnly.velocity === null,
+);
+check(
+  "kinematics-only publication preserves only the kinematics group",
+  decodedKinematicsOnly.avionics.attitude === null
+    && decodedKinematicsOnly.avionics.kinematics !== null
+    && decodedKinematicsOnly.avionics.quat === null
+    && decodedKinematicsOnly.avionics.posNed[0] === 12,
+);
 check("a sample without avionics decodes to null", (() => {
   const bareNoAv = [];
   varint(bareNoAv, (1 << 3) | 0);

--- a/crates/pilotage-adapter-api/src/control.rs
+++ b/crates/pilotage-adapter-api/src/control.rs
@@ -14,6 +14,8 @@ pub enum RejectReason {
     UnknownVehicle,
     /// The frame failed a fencing check (stale generation or sequence).
     Fenced,
+    /// A measurement required to apply the frame is unavailable.
+    MeasurementUnavailable,
     /// The adapter rejected the frame for a reason not covered above.
     Other(String),
 }

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -15,7 +15,7 @@ pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, Vehicl
 pub use control::{ApplyOutcome, Disposition, LinkLossPolicy, RejectReason};
 pub use step::{StepBudget, StepOutcome};
 pub use telemetry::{
-    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch,
-    TelemetrySample, VideoSource,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, MeasurementClock,
+    MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch, TelemetrySample, VideoSource,
 };
 pub use vehicle_adapter::VehicleAdapter;

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -15,7 +15,7 @@ pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, Vehicl
 pub use control::{ApplyOutcome, Disposition, LinkLossPolicy, RejectReason};
 pub use step::{StepBudget, StepOutcome};
 pub use telemetry::{
-    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, TelemetryBatch, TelemetrySample,
-    VideoSource,
+    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch,
+    TelemetrySample, VideoSource,
 };
 pub use vehicle_adapter::VehicleAdapter;

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -14,5 +14,8 @@ mod vehicle_adapter;
 pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, VehicleDescriptor};
 pub use control::{ApplyOutcome, Disposition, LinkLossPolicy, RejectReason};
 pub use step::{StepBudget, StepOutcome};
-pub use telemetry::{AvionicsSample, Pose2d, TelemetryBatch, TelemetrySample, VideoSource};
+pub use telemetry::{
+    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, TelemetryBatch, TelemetrySample,
+    VideoSource,
+};
 pub use vehicle_adapter::VehicleAdapter;

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -3,6 +3,33 @@
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
+/// The monotonic clock in which a measurement's acquisition timestamp is
+/// expressed. Timestamps from different domains are never subtracted without
+/// an explicit correlation supplied by the adapter boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeasurementClock {
+    /// Monotonic time since the producing vehicle computer booted.
+    VehicleBoot,
+    /// Monotonic simulation time supplied by the simulator.
+    Simulation,
+}
+
+/// Identity and acquisition stamp for one independently advancing
+/// measurement group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeasurementStamp {
+    /// Adapter-defined source identifier, stable within one vehicle.
+    pub source_id: u64,
+    /// Source boot/attachment generation. A reset changes this value.
+    pub source_epoch: u32,
+    /// Wrapping group sequence, advanced only for a new measurement.
+    pub sequence: u32,
+    /// Acquisition time in nanoseconds in [`Self::clock`].
+    pub acquired_at_ns: u64,
+    /// Clock domain for [`Self::acquired_at_ns`].
+    pub clock: MeasurementClock,
+}
+
 /// A planar pose: position and heading, independent of any specific vehicle
 /// model's internal representation.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -36,6 +63,12 @@ pub struct AvionicsSample {
     /// Arm state as the vehicle reports it: 0 unknown, 1 disarmed,
     /// 2 armed.
     pub arm_state: u32,
+    /// Identity of the attitude/rates measurement. `None` means that group
+    /// was not supplied in this publication.
+    pub attitude_stamp: Option<MeasurementStamp>,
+    /// Identity of the position/velocity measurement. `None` means that
+    /// group was not supplied in this publication.
+    pub kinematics_stamp: Option<MeasurementStamp>,
 }
 
 /// A single vehicle's telemetry at one simulation tick.

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -14,12 +14,36 @@ pub enum MeasurementClock {
     Simulation,
 }
 
+/// Opaque identity of one source attachment or boot instance.
+///
+/// Unlike [`MeasurementStamp::source_epoch`], this value is compared only for
+/// equality. A new incarnation cannot be ordered relative to an earlier one;
+/// the receiver must authorize that transition at a lifecycle boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SourceIncarnation([u8; 16]);
+
+impl SourceIncarnation {
+    /// Constructs an incarnation from its complete 128-bit representation.
+    #[must_use]
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the complete opaque representation.
+    #[must_use]
+    pub const fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
 /// Identity and acquisition stamp for one independently advancing
 /// measurement group.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MeasurementStamp {
     /// Adapter-defined source identifier, stable within one vehicle.
     pub source_id: u64,
+    /// Opaque attachment/boot identity for the producing source.
+    pub source_incarnation: SourceIncarnation,
     /// Source boot/attachment generation. A reset changes this value.
     pub source_epoch: u32,
     /// Wrapping group sequence, advanced only for a new measurement.

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -66,19 +66,37 @@ pub struct Pose2d {
     pub heading: f64,
 }
 
+/// One independently published attitude/rates measurement group.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AvionicsAttitudeSample {
+    /// Attitude quaternion (w, x, y, z), body FRD → world NED.
+    pub quat_wxyz: [f32; 4],
+    /// Body rates (p, q, r) in radians/second.
+    pub rates_rps: [f32; 3],
+    /// Identity and acquisition time of this group measurement.
+    pub stamp: MeasurementStamp,
+}
+
+/// One independently published position/velocity measurement group.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AvionicsKinematicsSample {
+    /// Position (north, east, down) in meters from the local origin.
+    pub pos_ned_m: [f32; 3],
+    /// Velocity (north, east, down) in meters/second.
+    pub vel_ned_mps: [f32; 3],
+    /// Identity and acquisition time of this group measurement.
+    pub stamp: MeasurementStamp,
+}
+
 /// Raw avionics state estimate for flight vehicles (ADR-0018): the
 /// estimator's output, not display-ready numbers. Ground vehicles leave
 /// [`TelemetrySample::avionics`] as `None`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AvionicsSample {
-    /// Attitude quaternion (w, x, y, z), body FRD → world NED.
-    pub quat_wxyz: [f32; 4],
-    /// Body rates (p, q, r) in radians/second.
-    pub rates_rps: [f32; 3],
-    /// Position (north, east, down) in meters from the local origin.
-    pub pos_ned_m: [f32; 3],
-    /// Velocity (north, east, down) in meters/second.
-    pub vel_ned_mps: [f32; 3],
+    /// Attitude/rates group, or `None` when it was not supplied.
+    pub attitude: Option<AvionicsAttitudeSample>,
+    /// Position/velocity group, or `None` when it was not supplied.
+    pub kinematics: Option<AvionicsKinematicsSample>,
     /// Validity bitmask: bit0 attitude, bit1 rates, bit2 position,
     /// bit3 velocity.
     pub valid_flags: u32,
@@ -87,12 +105,6 @@ pub struct AvionicsSample {
     /// Arm state as the vehicle reports it: 0 unknown, 1 disarmed,
     /// 2 armed.
     pub arm_state: u32,
-    /// Identity of the attitude/rates measurement. `None` means that group
-    /// was not supplied in this publication.
-    pub attitude_stamp: Option<MeasurementStamp>,
-    /// Identity of the position/velocity measurement. `None` means that
-    /// group was not supplied in this publication.
-    pub kinematics_stamp: Option<MeasurementStamp>,
 }
 
 /// A single vehicle's telemetry at one simulation tick.
@@ -102,10 +114,10 @@ pub struct TelemetrySample {
     pub vehicle: VehicleId,
     /// Simulation tick this sample was taken at.
     pub tick: SimTick,
-    /// Planar pose at this tick.
-    pub pose: Pose2d,
-    /// Scalar speed at this tick, in the adapter's native units.
-    pub speed: f64,
+    /// Planar pose at this tick, or `None` when its source groups are absent.
+    pub pose: Option<Pose2d>,
+    /// Scalar speed at this tick, or `None` when it is not measured.
+    pub speed: Option<f64>,
     /// Raw avionics estimate for flight vehicles; `None` for ground
     /// vehicles (ADR-0018).
     pub avionics: Option<AvionicsSample>,
@@ -147,16 +159,16 @@ mod tests {
         let sample = TelemetrySample {
             vehicle: VehicleId::new(1),
             tick: SimTick::new(2),
-            pose: Pose2d {
+            pose: Some(Pose2d {
                 x: 1.0,
                 y: 2.0,
                 heading: 0.5,
-            },
-            speed: 3.0,
+            }),
+            speed: Some(3.0),
             avionics: None,
         };
-        assert_eq!(sample.pose.x, 1.0);
-        assert_eq!(sample.speed, 3.0);
+        assert_eq!(sample.pose.expect("pose").x, 1.0);
+        assert_eq!(sample.speed, Some(3.0));
     }
 
     #[test]

--- a/crates/pilotage-conformance/src/checkpoint.rs
+++ b/crates/pilotage-conformance/src/checkpoint.rs
@@ -41,27 +41,32 @@ impl TrajectoryCheckpoint {
     /// pose/speed field bit-for-bit.
     #[must_use]
     pub fn matches(&self, sample: &TelemetrySample) -> bool {
+        let (Some(pose), Some(speed)) = (sample.pose, sample.speed) else {
+            return false;
+        };
         sample.tick == SimTick::new(self.tick)
-            && sample.pose.x.to_bits() == self.x_bits
-            && sample.pose.y.to_bits() == self.y_bits
-            && sample.pose.heading.to_bits() == self.heading_bits
-            && sample.speed.to_bits() == self.speed_bits
+            && pose.x.to_bits() == self.x_bits
+            && pose.y.to_bits() == self.y_bits
+            && pose.heading.to_bits() == self.heading_bits
+            && speed.to_bits() == self.speed_bits
     }
 
     /// Captures a checkpoint from the adapter's current telemetry, for
     /// regenerating golden values or asserting against a live run.
     #[must_use]
-    pub fn capture(label: &'static str, adapter: &mut ReferenceAdapter) -> Self {
+    pub fn capture(label: &'static str, adapter: &mut ReferenceAdapter) -> Option<Self> {
         let batch = adapter.sample_telemetry();
-        let sample = &batch.samples[0];
-        Self {
+        let sample = batch.samples.first()?;
+        let pose = sample.pose?;
+        let speed = sample.speed?;
+        Some(Self {
             label,
             tick: sample.tick.as_u64(),
-            x_bits: sample.pose.x.to_bits(),
-            y_bits: sample.pose.y.to_bits(),
-            heading_bits: sample.pose.heading.to_bits(),
-            speed_bits: sample.speed.to_bits(),
-        }
+            x_bits: pose.x.to_bits(),
+            y_bits: pose.y.to_bits(),
+            heading_bits: pose.heading.to_bits(),
+            speed_bits: speed.to_bits(),
+        })
     }
 }
 

--- a/crates/pilotage-conformance/tests/increment_zero.rs
+++ b/crates/pilotage-conformance/tests/increment_zero.rs
@@ -190,7 +190,10 @@ fn captured_checkpoints() -> Vec<TrajectoryCheckpoint> {
         if matches!(step, ScriptStep::Step(_)) {
             let label = label_iter.next().expect("one label per stepped phase");
             let mut adapter = session.adapter().clone();
-            captured.push(TrajectoryCheckpoint::capture(label, &mut adapter));
+            captured.push(
+                TrajectoryCheckpoint::capture(label, &mut adapter)
+                    .expect("reference telemetry is complete"),
+            );
         }
     }
     captured
@@ -379,5 +382,10 @@ fn harness_runs_a_minimal_grant_and_drive_script() {
     let outcomes = frame_outcomes(&events);
     assert_eq!(outcomes.len(), 1);
     assert_eq!(outcomes[0].verdict, FrameVerdict::Accepted);
-    assert!(adapter.sample_telemetry().samples[0].speed > 0.0);
+    assert!(
+        adapter.sample_telemetry().samples[0]
+            .speed
+            .expect("reference speed")
+            > 0.0
+    );
 }

--- a/crates/pilotage-instrument-state/src/abi.rs
+++ b/crates/pilotage-instrument-state/src/abi.rs
@@ -11,7 +11,7 @@
 //!
 //! | off | type | field |
 //! |----:|------|-------|
-//! | 0   | u32  | version (=1) |
+//! | 0   | u32  | version (=2) |
 //! | 4   | f32×4| attitude quaternion w, x, y, z |
 //! | 20  | f32×3| body rates p, q, r (rad/s) |
 //! | 32  | f32×3| position NED n, e, d (m) |
@@ -31,18 +31,21 @@
 //! | 108 | f32  | selected altitude (m, NaN none) |
 //! | 112 | f32  | wind from (rad) |
 //! | 116 | f32  | wind speed (m/s) |
+//! | 120 | u32  | snapshot generation (wrapping) |
+//! | 124 | u8   | coherence (0 insufficient, 1 coherent, 2 excessive skew) |
+//! | 125 | u8×3 | reserved, zero |
 
 use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
-    Selections, Stamped, ValidFlags, Wind,
+    Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 use crate::quat::Quat;
 
 /// Version stamped in the block's first four bytes.
-pub const STATE_ABI_VERSION: u32 = 1;
+pub const STATE_ABI_VERSION: u32 = 2;
 
 /// Size of the packed block in bytes.
-pub const STATE_ABI_SIZE: usize = 120;
+pub const STATE_ABI_SIZE: usize = 128;
 
 /// Why a state block failed to decode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -173,6 +176,11 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         position: flags & 0b0100 != 0,
         velocity: flags & 0b1000 != 0,
     };
+    let coherence = match u8_at(buf, 124)? {
+        1 => SnapshotCoherence::Coherent,
+        2 => SnapshotCoherence::ExcessiveSkew,
+        _ => SnapshotCoherence::Insufficient,
+    };
 
     Ok(AircraftState {
         attitude,
@@ -186,7 +194,16 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         },
         quality,
         valid,
+        snapshot: SnapshotMeta {
+            generation: u32_at(buf, 120)?,
+            coherence,
+        },
     })
+}
+
+fn u32_at(buf: &[u8], off: usize) -> Result<u32, AbiError> {
+    let b = buf.get(off..off + 4).ok_or(AbiError::Truncated)?;
+    Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
 }
 
 fn put_f32(buf: &mut [u8], off: usize, v: f32) -> Result<(), AbiError> {
@@ -197,6 +214,12 @@ fn put_f32(buf: &mut [u8], off: usize, v: f32) -> Result<(), AbiError> {
 
 fn put_u8(buf: &mut [u8], off: usize, v: u8) -> Result<(), AbiError> {
     *buf.get_mut(off).ok_or(AbiError::Truncated)? = v;
+    Ok(())
+}
+
+fn put_u32(buf: &mut [u8], off: usize, v: u32) -> Result<(), AbiError> {
+    let b = buf.get_mut(off..off + 4).ok_or(AbiError::Truncated)?;
+    b.copy_from_slice(&v.to_le_bytes());
     Ok(())
 }
 
@@ -295,6 +318,19 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
     });
     put_f32(buf, 112, wind.from_rad)?;
     put_f32(buf, 116, wind.speed_mps)?;
+    put_u32(buf, 120, state.snapshot.generation)?;
+    put_u8(
+        buf,
+        124,
+        match state.snapshot.coherence {
+            SnapshotCoherence::Insufficient => 0,
+            SnapshotCoherence::Coherent => 1,
+            SnapshotCoherence::ExcessiveSkew => 2,
+        },
+    )?;
+    for offset in 125..128 {
+        put_u8(buf, offset, 0)?;
+    }
     Ok(())
 }
 

--- a/crates/pilotage-instrument-state/src/abi/tests.rs
+++ b/crates/pilotage-instrument-state/src/abi/tests.rs
@@ -3,7 +3,7 @@
 use super::{AbiError, STATE_ABI_SIZE, decode_state, encode_state};
 use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
-    Selections, Stamped, Wind,
+    Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
 };
 use crate::quat::Quat;
 
@@ -63,6 +63,10 @@ fn full_state() -> AircraftState {
             rates: false,
             position: true,
             velocity: true,
+        },
+        snapshot: SnapshotMeta {
+            generation: u32::MAX,
+            coherence: SnapshotCoherence::Coherent,
         },
     }
 }

--- a/crates/pilotage-instrument-state/src/aircraft.rs
+++ b/crates/pilotage-instrument-state/src/aircraft.rs
@@ -147,6 +147,27 @@ impl<T> Default for Stamped<T> {
     }
 }
 
+/// Whether independently acquired groups form one coherent display snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SnapshotCoherence {
+    /// Too few stamped groups are present to establish coherence.
+    #[default]
+    Insufficient,
+    /// Required groups share a source epoch/clock and meet the skew budget.
+    Coherent,
+    /// Required groups exceed the configured acquisition-time skew budget.
+    ExcessiveSkew,
+}
+
+/// Metadata assigned by the ingress gate to one immutable state generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SnapshotMeta {
+    /// Wrapping generation advanced only when a source group advances.
+    pub generation: u32,
+    /// Coherence result for the independently stamped input groups.
+    pub coherence: SnapshotCoherence,
+}
+
 /// The unified input state every instrument reads (ADR-0017).
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct AircraftState {
@@ -166,4 +187,6 @@ pub struct AircraftState {
     pub quality: EstimateQuality,
     /// Source validity flags.
     pub valid: ValidFlags,
+    /// Ingress generation and group-coherence result.
+    pub snapshot: SnapshotMeta,
 }

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -30,7 +30,7 @@ pub mod units;
 
 pub use aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
-    Selections, Stamped, ValidFlags, Wind,
+    Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 pub use quat::Quat;
 pub use resolve::{NavResolved, PanelData, resolve};

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -2,7 +2,9 @@
 
 use libm::{atan2f, sqrtf};
 
-use crate::aircraft::{AircraftState, EstimateQuality, NavData, Selections, Wind};
+use crate::aircraft::{
+    AircraftState, EstimateQuality, NavData, Selections, SnapshotCoherence, Wind,
+};
 use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
 use crate::units::{M_TO_FT, MPS_TO_FPM, MPS_TO_KT};
 
@@ -66,14 +68,28 @@ fn flag_status(valid: bool) -> SignalStatus {
     }
 }
 
+/// Attitude and kinematics are stamped independently; when the ingress
+/// gate reports their acquisition times exceed the skew budget, each
+/// value is individually usable but the pair must not present as one
+/// coherent aircraft state, so both groups degrade (amber, value shown).
+/// `Insufficient` means too few stamped groups to judge — the ordinary
+/// missing/freshness handling already covers that case.
+fn coherence_status(coherence: SnapshotCoherence) -> SignalStatus {
+    match coherence {
+        SnapshotCoherence::ExcessiveSkew => SignalStatus::Degraded,
+        SnapshotCoherence::Insufficient | SnapshotCoherence::Coherent => SignalStatus::Valid,
+    }
+}
+
 /// Resolves raw input state into display-ready signals.
 ///
 /// Each signal's status is the worst of: its group's freshness under
-/// `policy`, the source quality, and the source's validity flag for that
-/// group. Values behind `Missing`/`Failed` are quiet zeros a panel never
-/// paints.
+/// `policy`, the source quality, the snapshot's group-coherence result,
+/// and the source's validity flag for that group. Values behind
+/// `Missing`/`Failed` are quiet zeros a panel never paints.
 pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
     let quality = quality_status(state.quality);
+    let coherence = coherence_status(state.snapshot.coherence);
 
     let att_fresh = if state.attitude.data.is_none() {
         SignalStatus::Missing
@@ -82,9 +98,11 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
     };
     let att_status = att_fresh
         .worst(quality)
+        .worst(coherence)
         .worst(flag_status(state.valid.attitude));
     let rate_status = att_fresh
         .worst(quality)
+        .worst(coherence)
         .worst(flag_status(state.valid.rates));
     let (roll, pitch, yaw, turn_rate) = match state.attitude.data {
         Some(att) => {
@@ -101,9 +119,11 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
     };
     let pos_status = kin_fresh
         .worst(quality)
+        .worst(coherence)
         .worst(flag_status(state.valid.position));
     let vel_status = kin_fresh
         .worst(quality)
+        .worst(coherence)
         .worst(flag_status(state.valid.velocity));
     let (alt_ft, vsi_fpm, gs_kt, track_rad, gs_mps) = match state.kinematics.data {
         Some(kin) => {

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -109,3 +109,50 @@ fn empty_state_resolves_all_missing() {
     assert_eq!(p.nav.status, SignalStatus::Missing);
     assert_eq!(p.wind.status, SignalStatus::Missing);
 }
+
+#[test]
+fn excessive_skew_degrades_both_stamped_groups() {
+    use crate::aircraft::{SnapshotCoherence, SnapshotMeta};
+    let mut s = flying_state();
+    s.snapshot = SnapshotMeta {
+        generation: 7,
+        coherence: SnapshotCoherence::ExcessiveSkew,
+    };
+    let p = resolve(&s, &FreshnessPolicy::default());
+    // Each value stays individually usable (amber, shown) but the pair
+    // must not present as one coherent aircraft state.
+    assert_eq!(p.roll_rad.status, SignalStatus::Degraded);
+    assert_eq!(p.turn_rate_rps.status, SignalStatus::Degraded);
+    assert_eq!(p.alt_ft.status, SignalStatus::Degraded);
+    assert_eq!(p.vsi_fpm.status, SignalStatus::Degraded);
+    // Groups outside the stamped attitude/kinematics pair are untouched.
+    assert_eq!(p.baro_hpa.status, SignalStatus::Valid);
+}
+
+#[test]
+fn coherent_and_insufficient_snapshots_do_not_degrade() {
+    use crate::aircraft::{SnapshotCoherence, SnapshotMeta};
+    for coherence in [SnapshotCoherence::Coherent, SnapshotCoherence::Insufficient] {
+        let mut s = flying_state();
+        s.snapshot = SnapshotMeta {
+            generation: 1,
+            coherence,
+        };
+        let p = resolve(&s, &FreshnessPolicy::default());
+        assert_eq!(p.roll_rad.status, SignalStatus::Valid, "{coherence:?}");
+        assert_eq!(p.alt_ft.status, SignalStatus::Valid, "{coherence:?}");
+    }
+}
+
+#[test]
+fn skew_degradation_never_upgrades_a_worse_status() {
+    use crate::aircraft::{SnapshotCoherence, SnapshotMeta};
+    let mut s = flying_state();
+    s.valid.attitude = false;
+    s.snapshot = SnapshotMeta {
+        generation: 1,
+        coherence: SnapshotCoherence::ExcessiveSkew,
+    };
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Failed);
+}

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -126,6 +126,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
             arm_state: 2,
             attitude_stamp: Some(wire::MeasurementStamp {
                 source_id: 7,
+                source_incarnation: vec![0xA5; 16],
                 source_epoch: 3,
                 sequence: 10,
                 acquired_at_ns: 1_000_000,
@@ -133,6 +134,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
             }),
             kinematics_stamp: Some(wire::MeasurementStamp {
                 source_id: 7,
+                source_incarnation: vec![0xA5; 16],
                 source_epoch: 3,
                 sequence: 5,
                 acquired_at_ns: 900_000,
@@ -142,7 +144,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
     };
     let envelope = wire::Envelope {
         schema_version: SCHEMA_VERSION,
-        payload: Some(wire::envelope::Payload::TelemetrySample(sample)),
+        payload: Some(wire::envelope::Payload::TelemetrySample(sample.clone())),
     };
     let bytes = envelope.encode_to_vec();
     let decoded = wire::Envelope::decode(bytes.as_slice()).expect("valid envelope");

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -124,6 +124,20 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
             valid_flags: 0b1111,
             quality: 0,
             arm_state: 2,
+            attitude_stamp: Some(wire::MeasurementStamp {
+                source_id: 7,
+                source_epoch: 3,
+                sequence: 10,
+                acquired_at_ns: 1_000_000,
+                clock: wire::MeasurementClock::VehicleBoot as i32,
+            }),
+            kinematics_stamp: Some(wire::MeasurementStamp {
+                source_id: 7,
+                source_epoch: 3,
+                sequence: 5,
+                acquired_at_ns: 900_000,
+                clock: wire::MeasurementClock::VehicleBoot as i32,
+            }),
         }),
     };
     let envelope = wire::Envelope {

--- a/docs/adr/0017-instrument-display-runtime.md
+++ b/docs/adr/0017-instrument-display-runtime.md
@@ -112,6 +112,13 @@ comparators, Stratux invalid sentinels) treats validity as data, and the
 reference hobby implementations that skip it (pyG5's lone avionics-on flag)
 cannot express "this one tape is lying to you."
 
+The packed state ABI also carries a wrapping ingress generation and an
+explicit attitude/kinematics coherence result. The transport-facing ingress
+gate owns vehicle/source routing, epoch and sequence ordering, and acquisition
+clock comparison (ADR-0018); the leaf crates receive one immutable state copy
+plus already-derived group ages. A duplicate publication cannot advance the
+generation or reset an age.
+
 ### Reserved, unbuilt extension points
 
 Phase 1 implements 2D PFD, HSI, and six-pack only. Three seams are reserved

--- a/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
+++ b/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
@@ -26,8 +26,27 @@ Two constraints from standing decisions: schema evolution must be additive
 the raw state estimate, not display-ready numbers: attitude quaternion
 (w, x, y, z), body angular rates, NED position, NED velocity, a validity
 bitmask and quality enum mirroring Aviate's `StateValidFlags` /
-`EstimateQuality`, and the estimate timestamp. Ground vehicles simply never
-set the field; nothing existing changes shape.
+`EstimateQuality`, plus independent attitude/rates and kinematics measurement
+stamps. Ground vehicles simply never set the field; nothing existing changes
+shape.
+
+Each group stamp carries a vehicle-scoped source identity, a source epoch, a
+wrapping group sequence, a monotonic acquisition timestamp, and its clock
+domain. Re-publishing a cached value preserves the complete stamp. The host's
+top-level `observed_at` remains publication/transport metadata and never
+relabels source acquisition time.
+
+The receiver accepts a group only when its epoch/sequence advances under
+wrap-safe serial arithmetic. Duplicates, reordering, older epochs, other
+vehicles, and unselected sources are counted and cannot replace display state
+or refresh its age. A newer epoch clears every group from the earlier epoch so
+one display generation cannot mix values across a source reset.
+
+Attitude and kinematics retain separate stamps. The ingress gate publishes an
+immutable display generation and an explicit coherence result derived only
+when source identity, epoch, and clock domain match and acquisition-time skew
+meets the selected display profile. Publication in one `AvionicsState` does not
+by itself imply coherent acquisition.
 
 The wire stays raw because derivation is display policy: barometric-style
 altitude (−z), vertical speed (−vz), groundspeed (√(vx²+vy²)), and
@@ -48,9 +67,12 @@ A new adapter crate owns the Aviate vehicle end to end:
   the frame math is unit-testable byte-for-byte.
 - **Mapping**: ATTITUDE_QUATERNION + LOCAL_POSITION_NED fold into the
   vehicle's `TelemetrySample` (planar pose from x/y + yaw for existing
-  consumers; full estimate into `AvionicsState`). HEARTBEAT drives link
-  liveness; loss of heartbeat marks the avionics groups stale rather than
-  freezing them.
+  consumers; full estimate into `AvionicsState`). MAVLink `time_boot_ms` is
+  retained for both groups. Independently advancing wrapping sequences reject
+  duplicate and reordered measurements before they enter the cache. A
+  confirmed boot-clock reset or clock wrap starts a new explicit source epoch.
+  Group receive time controls withholding, while display freshness advances
+  only with the source stamp, so cached publications age rather than freezing.
 - **Control**: the adapter is telemetry-only in this increment. Its
   capabilities advertise no controllable scopes; control frames are rejected
   at the boundary. Command uplink (arm/disarm via COMMAND_LONG through
@@ -77,7 +99,9 @@ one-way.
 
 - `buf breaking` passes by construction; old clients ignore the new field.
 - The browser wire decoder and the host fill site each grow one arm; the
-  instrument bridge (ADR-0017) is the only consumer that interprets it.
+  instrument bridge (ADR-0017) is the only consumer that interprets it. The
+  decoder preserves uint64 identities/timestamps without narrowing them to an
+  imprecise JavaScript number.
 - Aviate's current wire gap becomes visible instead of papered over: no
   airspeed or barometric sensor message exists yet, so IAS renders `Missing`
   on the PFD — the honest display is the feature, and the gap is Aviate's to

--- a/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
+++ b/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
@@ -30,17 +30,25 @@ bitmask and quality enum mirroring Aviate's `StateValidFlags` /
 stamps. Ground vehicles simply never set the field; nothing existing changes
 shape.
 
-Each group stamp carries a vehicle-scoped source identity, a source epoch, a
-wrapping group sequence, a monotonic acquisition timestamp, and its clock
-domain. Re-publishing a cached value preserves the complete stamp. The host's
-top-level `observed_at` remains publication/transport metadata and never
-relabels source acquisition time.
+Each group stamp carries a vehicle-scoped logical source identity, an opaque
+128-bit source incarnation, a source epoch, a wrapping group sequence, a
+monotonic acquisition timestamp, and its clock domain. Incarnations are
+equality-only attachment or boot tokens; epoch ordering is meaningful only
+inside one incarnation. Re-publishing a cached value preserves the complete
+stamp. The host's top-level `observed_at` remains publication/transport
+metadata and never relabels source acquisition time.
 
-The receiver accepts a group only when its epoch/sequence advances under
-wrap-safe serial arithmetic. Duplicates, reordering, older epochs, other
-vehicles, and unselected sources are counted and cannot replace display state
-or refresh its age. A newer epoch clears every group from the earlier epoch so
-one display generation cannot mix values across a source reset.
+The receiver accepts a group only when its incarnation is authorized and its
+epoch/sequence advances under wrap-safe serial arithmetic. Duplicates,
+reordering, previously seen incarnations, older epochs, acquisition-time
+regressions, other vehicles, and unselected sources are counted and cannot
+replace display state or refresh its age. A new incarnation or epoch clears
+every group from the earlier identity so one display generation cannot mix
+values across a source reset. Aircraft profiles pin a source-issued
+incarnation during authenticated bootstrap. The browser simulator profile may
+accept a bounded number of unseen incarnations and resets all ingress history
+after each newly negotiated WebTransport session; that policy is explicitly
+ineligible for operational credit.
 
 Attitude and kinematics retain separate stamps. The ingress gate publishes an
 immutable display generation and an explicit coherence result derived only
@@ -63,21 +71,35 @@ A new adapter crate owns the Aviate vehicle end to end:
   24-bit message id, CRC-16/MCRF4XX seeded with each message's CRC_EXTRA,
   and v2 payload-truncation zero-extension — for exactly the three message
   ids Aviate emits. Frames that fail CRC or carry unknown ids are counted
-  and skipped. The parser is a plain `no_std`-style module with no I/O so
+  and skipped. Every accepted frame must match the configured MAVLink system
+  and component; the logical source is configured rather than selected by the
+  first estimate. The parser is a plain `no_std`-style module with no I/O so
   the frame math is unit-testable byte-for-byte.
 - **Mapping**: ATTITUDE_QUATERNION + LOCAL_POSITION_NED fold into the
   vehicle's `TelemetrySample` (planar pose from x/y + yaw for existing
   consumers; full estimate into `AvionicsState`). MAVLink `time_boot_ms` is
   retained for both groups. Independently advancing wrapping sequences reject
-  duplicate and reordered measurements before they enter the cache. A
-  confirmed boot-clock reset or clock wrap starts a new explicit source epoch.
+  duplicate and reordered measurements before they enter the cache. A 32-bit
+  boot-clock wrap starts a new explicit source epoch. Ordinary MAVLink has no
+  trustworthy boot UUID, so the default policy never infers a reboot from a
+  replayable clock regression. The simulator policy first requires accepted
+  measurement silence, then same-group source-time and receive-time dwell; a
+  different group cannot confirm the transition. Its 300 ms inter-group
+  high-water allowance is a simulator profile input, not an aircraft value.
   Group receive time controls withholding, while display freshness advances
   only with the source stamp, so cached publications age rather than freezing.
-- **Control**: the adapter is telemetry-only in this increment. Its
-  capabilities advertise no controllable scopes; control frames are rejected
-  at the boundary. Command uplink (arm/disarm via COMMAND_LONG through
-  Aviate's security gateway) is a later decision, not a hidden TODO in the
-  control path.
+- **Shared-memory mapping**: the simulator reader verifies the exact 216-byte
+  ABI and records the POSIX object's `(device, inode, size)` identity before
+  mapping. Reopening the same frozen object cannot change epoch or freshness.
+  A different object plus a coherent first sample authorizes an attachment
+  transition; sequence or acquisition-time rollback on the same object is
+  quarantined. The current Aviate SHM ABI has no writer incarnation field, so
+  inode identity remains simulator-only. An aircraft-capable producer must
+  provide a source-issued boot identity or persistent monotonic boot counter.
+- **Control**: when the command uplink is available, the adapter advertises the
+  flight-control scope and addresses setpoints to the same configured MAVLink
+  system and component used by telemetry. An unavailable uplink degrades to
+  telemetry-only capability rather than changing the measurement source.
 - **Video**: the Aviate SITL world is ordinary Gazebo, so camera frames reach
   the browser the same way the yard world's do — a camera sensor in the world
   SDF bridged by the existing gz sidecar. The adapter may spawn the sidecar
@@ -101,7 +123,7 @@ one-way.
 - The browser wire decoder and the host fill site each grow one arm; the
   instrument bridge (ADR-0017) is the only consumer that interprets it. The
   decoder preserves uint64 identities/timestamps without narrowing them to an
-  imprecise JavaScript number.
+  imprecise JavaScript number and preserves the 128-bit incarnation exactly.
 - Aviate's current wire gap becomes visible instead of papered over: no
   airspeed or barometric sensor message exists yet, so IAS renders `Missing`
   on the PFD — the honest display is the feature, and the gap is Aviate's to
@@ -110,4 +132,5 @@ one-way.
   messages (PX4 SITL does), which is a free conformance check against a
   second producer, but Aviate remains the contract we track.
 - On hardware, the same parser reads the same bytes over USB CDC; only the
-  transport binding differs.
+  transport binding differs. A hardware binding must inject its source-issued
+  incarnation rather than use the simulator operating-system entropy provider.

--- a/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
+++ b/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
@@ -56,6 +56,14 @@ when source identity, epoch, and clock domain match and acquisition-time skew
 meets the selected display profile. Publication in one `AvionicsState` does not
 by itself imply coherent acquisition.
 
+Group presence is structural throughout the adapter API. Missing attitude or
+kinematics is represented as `None`, never an identity quaternion, origin, or
+zero velocity. The planar `pose` and `velocity` messages are emitted only when
+both source groups share identity/clock and meet the selected skew bound; a
+single or incoherent group continues to flow independently through
+`AvionicsState`. Receivers treat absent message fields and group stamps as
+missing data.
+
 The wire stays raw because derivation is display policy: barometric-style
 altitude (−z), vertical speed (−vz), groundspeed (√(vx²+vy²)), and
 Euler attitude all derive in `pilotage-instrument-state`, where they are unit
@@ -76,9 +84,10 @@ A new adapter crate owns the Aviate vehicle end to end:
   first estimate. The parser is a plain `no_std`-style module with no I/O so
   the frame math is unit-testable byte-for-byte.
 - **Mapping**: ATTITUDE_QUATERNION + LOCAL_POSITION_NED fold into the
-  vehicle's `TelemetrySample` (planar pose from x/y + yaw for existing
-  consumers; full estimate into `AvionicsState`). MAVLink `time_boot_ms` is
-  retained for both groups. Independently advancing wrapping sequences reject
+  vehicle's `TelemetrySample` (a planar projection only when both groups are
+  available and coherent within the selected skew bound; each raw group
+  independently into `AvionicsState`). MAVLink `time_boot_ms` is retained for
+  both groups. Independently advancing wrapping sequences reject
   duplicate and reordered measurements before they enter the cache. A 32-bit
   boot-clock wrap starts a new explicit source epoch. Ordinary MAVLink has no
   trustworthy boot UUID, so the default policy never infers a reboot from a
@@ -100,6 +109,11 @@ A new adapter crate owns the Aviate vehicle end to end:
   flight-control scope and addresses setpoints to the same configured MAVLink
   system and component used by telemetry. An unavailable uplink degrades to
   telemetry-only capability rather than changing the measurement source.
+  Control requiring a current pose is rejected when either source group is
+  missing, stale, identity-incompatible, or outside the configured skew bound;
+  the adapter never seeds a setpoint with zero substitutes. Disarm is a
+  measurement-independent safety action and remains available when the
+  estimate is unavailable; a later arm still requires a coherent measured yaw.
 - **Video**: the Aviate SITL world is ordinary Gazebo, so camera frames reach
   the browser the same way the yard world's do — a camera sensor in the world
   SDF bridged by the existing gz sidecar. The adapter may spawn the sidecar

--- a/docs/adr/0019-pluggable-vehicle-link-shm-first.md
+++ b/docs/adr/0019-pluggable-vehicle-link-shm-first.md
@@ -32,15 +32,19 @@ the open one.
   selected by `PILOTAGE_AVIATE_LINK` with an `auto` default that prefers
   shared memory when present.
 - **Co-located SITL binds shared memory.** Aviate's gz-sim plugin
-  already publishes a versioned, seq-numbered latest-state block
+  publishes a seq-numbered latest-state block
   (`AviateSharedState` in its standalone-C `shared_state.h`) into POSIX
   shm every physics tick. The adapter attaches **read-only** as a second
   consumer, double-reads the sequence counter to reject torn snapshots,
   converts ENU/FLU → NED/FRD with math mirrored from Aviate's own
   conversion functions, and ages the block out (withholds telemetry)
-  when the counter stops advancing. No ports, no peering, no
-  single-consumer contention; both sides are Rust and no C++ bridge is
-  involved.
+  when the counter stops advancing. The reader requires the exact 216-byte
+  layout and records `(device, inode, size)` before mapping. Reopening the
+  same frozen object cannot reset freshness; a different object plus a
+  coherent first sample advances the attachment epoch. Sequence or simulation
+  time rollback within one object is quarantined. No ports, no peering, no
+  single-consumer contention; the Pilotage reader remains Rust and adds no
+  intermediary bridge process.
 - **The RF-link protocol decision is deferred**, deliberately: it
   belongs to the vehicle's communication component (which owns the radio
   and may speak MAVLink, CCSDS, or a native framing), and designing it
@@ -73,3 +77,8 @@ the open one.
 - A frozen simulator ages into flagged instruments rather than replaying
   stale state as live (the same withholding discipline as the Gazebo
   adapter's dead-reader path).
+- The 216-byte SHM contract has no magic, version, size, writer incarnation,
+  or clock epoch fields. POSIX object identity is sufficient only for the
+  simulator boundary. Any producer seeking operational credit must expose an
+  additive, source-issued incarnation and explicit clock epoch rather than
+  infer either from shared-memory metadata.

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -183,7 +183,7 @@ async fn spawn_host_runtime(
             let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
                 HOST_VEHICLE,
                 mode,
-                pilotage_adapter_aviate::LinkConfig::default(),
+                pilotage_adapter_aviate::LinkConfig::simulator(),
             )
             .await
             .map_err(HostError::AviateAdapter)?;

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -6,7 +6,6 @@
 use std::time::Duration;
 
 use pilotage_adapter_api::{StepBudget, VehicleAdapter};
-use pilotage_protocol::wire;
 use pilotage_session::{ClientKey, DomainEnvelope, SessionAction, SessionEngine, SessionOutcome};
 use pilotage_timing::{BoundedLatencyLog, MonoTimestamp, Stage, StageLatency};
 use tokio::sync::mpsc::error::TrySendError;
@@ -19,6 +18,9 @@ use crate::runtime::registry::ClientRegistry;
 use crate::runtime::wire_codec::{
     encode_envelope_message, encode_pong_datagram, encode_telemetry_datagram,
 };
+
+mod telemetry;
+use telemetry::sample_to_wire;
 
 /// Capacity of the [`EngineActor`]'s inbound command queue.
 ///
@@ -211,45 +213,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
     fn broadcast_telemetry(&mut self, now: MonoTimestamp) {
         let batch = self.adapter.sample_telemetry();
         for sample in batch.samples {
-            let wire_sample = wire::TelemetrySample {
-                vehicle: Some(wire::VehicleId {
-                    value: sample.vehicle.as_u64(),
-                }),
-                tick: Some(wire::SimTick {
-                    value: sample.tick.as_u64(),
-                }),
-                observed_at: Some(wire::MonoTimestamp {
-                    nanos: now.as_nanos(),
-                }),
-                pose: Some(wire::Pose2d {
-                    x_m: sample.pose.x as f32,
-                    y_m: sample.pose.y as f32,
-                    heading_rad: sample.pose.heading as f32,
-                }),
-                velocity: Some(wire::Velocity2d {
-                    linear_x_mps: sample.speed as f32,
-                    linear_y_mps: 0.0,
-                    angular_rad_s: 0.0,
-                }),
-                avionics: sample.avionics.map(|a| wire::AvionicsState {
-                    quat_w: a.quat_wxyz[0],
-                    quat_x: a.quat_wxyz[1],
-                    quat_y: a.quat_wxyz[2],
-                    quat_z: a.quat_wxyz[3],
-                    rate_p_rad_s: a.rates_rps[0],
-                    rate_q_rad_s: a.rates_rps[1],
-                    rate_r_rad_s: a.rates_rps[2],
-                    pos_n_m: a.pos_ned_m[0],
-                    pos_e_m: a.pos_ned_m[1],
-                    pos_d_m: a.pos_ned_m[2],
-                    vel_n_mps: a.vel_ned_mps[0],
-                    vel_e_mps: a.vel_ned_mps[1],
-                    vel_d_mps: a.vel_ned_mps[2],
-                    valid_flags: a.valid_flags,
-                    quality: a.quality,
-                    arm_state: a.arm_state,
-                }),
-            };
+            let wire_sample = sample_to_wire(sample, now);
             let bytes = encode_telemetry_datagram(wire_sample);
             self.broadcast_datagram(bytes);
         }

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -1,0 +1,73 @@
+//! Lossless adapter-to-wire telemetry mapping.
+
+use pilotage_adapter_api::{AvionicsSample, MeasurementClock, MeasurementStamp, TelemetrySample};
+use pilotage_protocol::wire;
+use pilotage_timing::MonoTimestamp;
+
+pub(super) fn sample_to_wire(
+    sample: TelemetrySample,
+    published_at: MonoTimestamp,
+) -> wire::TelemetrySample {
+    wire::TelemetrySample {
+        vehicle: Some(wire::VehicleId {
+            value: sample.vehicle.as_u64(),
+        }),
+        tick: Some(wire::SimTick {
+            value: sample.tick.as_u64(),
+        }),
+        observed_at: Some(wire::MonoTimestamp {
+            nanos: published_at.as_nanos(),
+        }),
+        pose: Some(wire::Pose2d {
+            x_m: sample.pose.x as f32,
+            y_m: sample.pose.y as f32,
+            heading_rad: sample.pose.heading as f32,
+        }),
+        velocity: Some(wire::Velocity2d {
+            linear_x_mps: sample.speed as f32,
+            linear_y_mps: 0.0,
+            angular_rad_s: 0.0,
+        }),
+        avionics: sample.avionics.map(avionics_to_wire),
+    }
+}
+
+fn measurement_stamp_to_wire(stamp: MeasurementStamp) -> wire::MeasurementStamp {
+    let clock = match stamp.clock {
+        MeasurementClock::VehicleBoot => wire::MeasurementClock::VehicleBoot,
+        MeasurementClock::Simulation => wire::MeasurementClock::Simulation,
+    };
+    wire::MeasurementStamp {
+        source_id: stamp.source_id,
+        source_epoch: stamp.source_epoch,
+        sequence: stamp.sequence,
+        acquired_at_ns: stamp.acquired_at_ns,
+        clock: clock as i32,
+    }
+}
+
+fn avionics_to_wire(sample: AvionicsSample) -> wire::AvionicsState {
+    wire::AvionicsState {
+        quat_w: sample.quat_wxyz[0],
+        quat_x: sample.quat_wxyz[1],
+        quat_y: sample.quat_wxyz[2],
+        quat_z: sample.quat_wxyz[3],
+        rate_p_rad_s: sample.rates_rps[0],
+        rate_q_rad_s: sample.rates_rps[1],
+        rate_r_rad_s: sample.rates_rps[2],
+        pos_n_m: sample.pos_ned_m[0],
+        pos_e_m: sample.pos_ned_m[1],
+        pos_d_m: sample.pos_ned_m[2],
+        vel_n_mps: sample.vel_ned_mps[0],
+        vel_e_mps: sample.vel_ned_mps[1],
+        vel_d_mps: sample.vel_ned_mps[2],
+        valid_flags: sample.valid_flags,
+        quality: sample.quality,
+        arm_state: sample.arm_state,
+        attitude_stamp: sample.attitude_stamp.map(measurement_stamp_to_wire),
+        kinematics_stamp: sample.kinematics_stamp.map(measurement_stamp_to_wire),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -43,6 +43,7 @@ fn measurement_stamp_to_wire(stamp: MeasurementStamp) -> wire::MeasurementStamp 
         sequence: stamp.sequence,
         acquired_at_ns: stamp.acquired_at_ns,
         clock: clock as i32,
+        source_incarnation: stamp.source_incarnation.into_bytes().to_vec(),
     }
 }
 

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -18,13 +18,13 @@ pub(super) fn sample_to_wire(
         observed_at: Some(wire::MonoTimestamp {
             nanos: published_at.as_nanos(),
         }),
-        pose: Some(wire::Pose2d {
-            x_m: sample.pose.x as f32,
-            y_m: sample.pose.y as f32,
-            heading_rad: sample.pose.heading as f32,
+        pose: sample.pose.map(|pose| wire::Pose2d {
+            x_m: pose.x as f32,
+            y_m: pose.y as f32,
+            heading_rad: pose.heading as f32,
         }),
-        velocity: Some(wire::Velocity2d {
-            linear_x_mps: sample.speed as f32,
+        velocity: sample.speed.map(|speed| wire::Velocity2d {
+            linear_x_mps: speed as f32,
             linear_y_mps: 0.0,
             angular_rad_s: 0.0,
         }),
@@ -48,25 +48,27 @@ fn measurement_stamp_to_wire(stamp: MeasurementStamp) -> wire::MeasurementStamp 
 }
 
 fn avionics_to_wire(sample: AvionicsSample) -> wire::AvionicsState {
+    let attitude = sample.attitude;
+    let kinematics = sample.kinematics;
     wire::AvionicsState {
-        quat_w: sample.quat_wxyz[0],
-        quat_x: sample.quat_wxyz[1],
-        quat_y: sample.quat_wxyz[2],
-        quat_z: sample.quat_wxyz[3],
-        rate_p_rad_s: sample.rates_rps[0],
-        rate_q_rad_s: sample.rates_rps[1],
-        rate_r_rad_s: sample.rates_rps[2],
-        pos_n_m: sample.pos_ned_m[0],
-        pos_e_m: sample.pos_ned_m[1],
-        pos_d_m: sample.pos_ned_m[2],
-        vel_n_mps: sample.vel_ned_mps[0],
-        vel_e_mps: sample.vel_ned_mps[1],
-        vel_d_mps: sample.vel_ned_mps[2],
+        quat_w: attitude.map_or(0.0, |group| group.quat_wxyz[0]),
+        quat_x: attitude.map_or(0.0, |group| group.quat_wxyz[1]),
+        quat_y: attitude.map_or(0.0, |group| group.quat_wxyz[2]),
+        quat_z: attitude.map_or(0.0, |group| group.quat_wxyz[3]),
+        rate_p_rad_s: attitude.map_or(0.0, |group| group.rates_rps[0]),
+        rate_q_rad_s: attitude.map_or(0.0, |group| group.rates_rps[1]),
+        rate_r_rad_s: attitude.map_or(0.0, |group| group.rates_rps[2]),
+        pos_n_m: kinematics.map_or(0.0, |group| group.pos_ned_m[0]),
+        pos_e_m: kinematics.map_or(0.0, |group| group.pos_ned_m[1]),
+        pos_d_m: kinematics.map_or(0.0, |group| group.pos_ned_m[2]),
+        vel_n_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[0]),
+        vel_e_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[1]),
+        vel_d_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[2]),
         valid_flags: sample.valid_flags,
         quality: sample.quality,
         arm_state: sample.arm_state,
-        attitude_stamp: sample.attitude_stamp.map(measurement_stamp_to_wire),
-        kinematics_stamp: sample.kinematics_stamp.map(measurement_stamp_to_wire),
+        attitude_stamp: attitude.map(|group| measurement_stamp_to_wire(group.stamp)),
+        kinematics_stamp: kinematics.map(|group| measurement_stamp_to_wire(group.stamp)),
     }
 }
 

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use pilotage_adapter_api::{
-    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetrySample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, MeasurementClock,
+    MeasurementStamp, Pose2d, SourceIncarnation, TelemetrySample,
 };
 use pilotage_protocol::{VehicleId, wire};
 use pilotage_timing::{MonoTimestamp, SimTick};
@@ -26,22 +27,26 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     let sample = TelemetrySample {
         vehicle: VehicleId::new(9),
         tick: SimTick::new(42),
-        pose: Pose2d {
+        pose: Some(Pose2d {
             x: 1.0,
             y: 2.0,
             heading: 0.5,
-        },
-        speed: 3.0,
+        }),
+        speed: Some(3.0),
         avionics: Some(AvionicsSample {
-            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
-            rates_rps: [0.0; 3],
-            pos_ned_m: [0.0; 3],
-            vel_ned_mps: [0.0; 3],
+            attitude: Some(AvionicsAttitudeSample {
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                rates_rps: [0.0; 3],
+                stamp: attitude,
+            }),
+            kinematics: Some(AvionicsKinematicsSample {
+                pos_ned_m: [0.0; 3],
+                vel_ned_mps: [0.0; 3],
+                stamp: kinematics,
+            }),
             valid_flags: 0b1111,
             quality: 0,
             arm_state: 2,
-            attitude_stamp: Some(attitude),
-            kinematics_stamp: Some(kinematics),
         }),
     };
 
@@ -70,42 +75,76 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     assert_eq!(kinematics_wire.acquired_at_ns, kinematics.acquired_at_ns);
 }
 
+fn simulation_stamp(sequence: u32) -> MeasurementStamp {
+    MeasurementStamp {
+        source_id: 1,
+        source_incarnation: SourceIncarnation::new([0x5A; 16]),
+        source_epoch: 1,
+        sequence,
+        acquired_at_ns: 42,
+        clock: MeasurementClock::Simulation,
+    }
+}
+
 #[test]
-fn absent_group_stamp_stays_absent() {
+fn kinematics_only_omits_planar_projection_while_group_flows() {
     let sample = TelemetrySample {
         vehicle: VehicleId::new(1),
         tick: SimTick::new(0),
-        pose: Pose2d {
-            x: 0.0,
-            y: 0.0,
-            heading: 0.0,
-        },
-        speed: 0.0,
+        pose: None,
+        speed: None,
         avionics: Some(AvionicsSample {
-            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
-            rates_rps: [0.0; 3],
-            pos_ned_m: [0.0; 3],
-            vel_ned_mps: [0.0; 3],
+            attitude: None,
+            kinematics: Some(AvionicsKinematicsSample {
+                pos_ned_m: [12.0, 3.0, -40.0],
+                vel_ned_mps: [5.0, 2.0, -1.0],
+                stamp: simulation_stamp(8),
+            }),
             valid_flags: 0b1100,
             quality: 0,
             arm_state: 0,
-            attitude_stamp: None,
-            kinematics_stamp: Some(MeasurementStamp {
-                source_id: 1,
-                source_incarnation: SourceIncarnation::new([0x5A; 16]),
-                source_epoch: 1,
-                sequence: 0,
-                acquired_at_ns: 42,
-                clock: MeasurementClock::Simulation,
-            }),
         }),
     };
 
     let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(1));
+    assert!(wire_sample.pose.is_none());
+    assert!(wire_sample.velocity.is_none());
     let avionics = wire_sample.avionics.expect("avionics");
     assert!(avionics.attitude_stamp.is_none());
+    assert_eq!(avionics.pos_n_m, 12.0);
+    assert_eq!(avionics.vel_n_mps, 5.0);
     assert_eq!(
         avionics.kinematics_stamp.expect("kinematics").clock,
         wire::MeasurementClock::Simulation as i32
     );
+}
+
+#[test]
+fn attitude_only_omits_planar_projection_while_group_flows() {
+    let sample = TelemetrySample {
+        vehicle: VehicleId::new(1),
+        tick: SimTick::new(0),
+        pose: None,
+        speed: None,
+        avionics: Some(AvionicsSample {
+            attitude: Some(AvionicsAttitudeSample {
+                quat_wxyz: [0.7, 0.0, 0.0, 0.7],
+                rates_rps: [0.1, 0.2, 0.3],
+                stamp: simulation_stamp(9),
+            }),
+            kinematics: None,
+            valid_flags: 0b0011,
+            quality: 0,
+            arm_state: 2,
+        }),
+    };
+
+    let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(1));
+    assert!(wire_sample.pose.is_none());
+    assert!(wire_sample.velocity.is_none());
+    let avionics = wire_sample.avionics.expect("avionics");
+    assert_eq!(avionics.quat_w, 0.7);
+    assert_eq!(avionics.rate_r_rad_s, 0.3);
+    assert_eq!(avionics.attitude_stamp.expect("attitude").sequence, 9);
+    assert!(avionics.kinematics_stamp.is_none());
 }

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_adapter_api::{
+    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, TelemetrySample,
+};
+use pilotage_protocol::{VehicleId, wire};
+use pilotage_timing::{MonoTimestamp, SimTick};
+
+use super::sample_to_wire;
+
+#[test]
+fn publication_time_and_source_acquisition_stamps_stay_distinct() {
+    let attitude = MeasurementStamp {
+        source_id: 7,
+        source_epoch: 3,
+        sequence: u32::MAX,
+        acquired_at_ns: 1_234_567,
+        clock: MeasurementClock::VehicleBoot,
+    };
+    let kinematics = MeasurementStamp {
+        sequence: 19,
+        acquired_at_ns: 1_200_000,
+        ..attitude
+    };
+    let sample = TelemetrySample {
+        vehicle: VehicleId::new(9),
+        tick: SimTick::new(42),
+        pose: Pose2d {
+            x: 1.0,
+            y: 2.0,
+            heading: 0.5,
+        },
+        speed: 3.0,
+        avionics: Some(AvionicsSample {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            rates_rps: [0.0; 3],
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            valid_flags: 0b1111,
+            quality: 0,
+            arm_state: 2,
+            attitude_stamp: Some(attitude),
+            kinematics_stamp: Some(kinematics),
+        }),
+    };
+
+    let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(9_000_000));
+    assert_eq!(wire_sample.vehicle.expect("vehicle").value, 9);
+    assert_eq!(
+        wire_sample.observed_at.expect("publication").nanos,
+        9_000_000
+    );
+    let avionics = wire_sample.avionics.expect("avionics");
+    let attitude_wire = avionics.attitude_stamp.expect("attitude stamp");
+    assert_eq!(attitude_wire.source_id, attitude.source_id);
+    assert_eq!(attitude_wire.source_epoch, attitude.source_epoch);
+    assert_eq!(attitude_wire.sequence, attitude.sequence);
+    assert_eq!(attitude_wire.acquired_at_ns, attitude.acquired_at_ns);
+    assert_eq!(
+        attitude_wire.clock,
+        wire::MeasurementClock::VehicleBoot as i32
+    );
+    let kinematics_wire = avionics.kinematics_stamp.expect("kinematics stamp");
+    assert_eq!(kinematics_wire.sequence, kinematics.sequence);
+    assert_eq!(kinematics_wire.acquired_at_ns, kinematics.acquired_at_ns);
+}
+
+#[test]
+fn absent_group_stamp_stays_absent() {
+    let sample = TelemetrySample {
+        vehicle: VehicleId::new(1),
+        tick: SimTick::new(0),
+        pose: Pose2d {
+            x: 0.0,
+            y: 0.0,
+            heading: 0.0,
+        },
+        speed: 0.0,
+        avionics: Some(AvionicsSample {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            rates_rps: [0.0; 3],
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            valid_flags: 0b1100,
+            quality: 0,
+            arm_state: 0,
+            attitude_stamp: None,
+            kinematics_stamp: Some(MeasurementStamp {
+                source_id: 1,
+                source_epoch: 1,
+                sequence: 0,
+                acquired_at_ns: 42,
+                clock: MeasurementClock::Simulation,
+            }),
+        }),
+    };
+
+    let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(1));
+    let avionics = wire_sample.avionics.expect("avionics");
+    assert!(avionics.attitude_stamp.is_none());
+    assert_eq!(
+        avionics.kinematics_stamp.expect("kinematics").clock,
+        wire::MeasurementClock::Simulation as i32
+    );
+}

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use pilotage_adapter_api::{
-    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, TelemetrySample,
+    AvionicsSample, MeasurementClock, MeasurementStamp, Pose2d, SourceIncarnation, TelemetrySample,
 };
 use pilotage_protocol::{VehicleId, wire};
 use pilotage_timing::{MonoTimestamp, SimTick};
@@ -12,6 +12,7 @@ use super::sample_to_wire;
 fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     let attitude = MeasurementStamp {
         source_id: 7,
+        source_incarnation: SourceIncarnation::new([0xA5; 16]),
         source_epoch: 3,
         sequence: u32::MAX,
         acquired_at_ns: 1_234_567,
@@ -53,6 +54,10 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     let avionics = wire_sample.avionics.expect("avionics");
     let attitude_wire = avionics.attitude_stamp.expect("attitude stamp");
     assert_eq!(attitude_wire.source_id, attitude.source_id);
+    assert_eq!(
+        attitude_wire.source_incarnation,
+        attitude.source_incarnation.into_bytes()
+    );
     assert_eq!(attitude_wire.source_epoch, attitude.source_epoch);
     assert_eq!(attitude_wire.sequence, attitude.sequence);
     assert_eq!(attitude_wire.acquired_at_ns, attitude.acquired_at_ns);
@@ -87,6 +92,7 @@ fn absent_group_stamp_stays_absent() {
             attitude_stamp: None,
             kinematics_stamp: Some(MeasurementStamp {
                 source_id: 1,
+                source_incarnation: SourceIncarnation::new([0x5A; 16]),
                 source_epoch: 1,
                 sequence: 0,
                 acquired_at_ns: 42,

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -43,6 +43,9 @@ message MeasurementStamp {
   // Monotonic acquisition time in the declared clock domain.
   uint64 acquired_at_ns = 4;
   MeasurementClock clock = 5;
+  // Opaque 128-bit attachment/boot identity. Receivers compare this for
+  // equality and accept changes only at an authorized lifecycle boundary.
+  bytes source_incarnation = 6;
 }
 
 // Raw avionics state estimate for flight vehicles (ADR-0018): attitude

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -55,6 +55,8 @@ message MeasurementStamp {
 // Euler angles) happens in the instrument runtime (ADR-0017). Ground
 // vehicles never set this field.
 message AvionicsState {
+  // Fields 1–7 are meaningful only when attitude_stamp is present. Proto3
+  // scalar defaults are not measurements and must not be displayed as such.
   float quat_w = 1;
   float quat_x = 2;
   float quat_y = 3;
@@ -62,6 +64,7 @@ message AvionicsState {
   float rate_p_rad_s = 5;
   float rate_q_rad_s = 6;
   float rate_r_rad_s = 7;
+  // Fields 8–13 are meaningful only when kinematics_stamp is present.
   float pos_n_m = 8;
   float pos_e_m = 9;
   float pos_d_m = 10;
@@ -87,6 +90,8 @@ message TelemetrySample {
   // Host publication time. This is transport metadata, not source
   // acquisition time; group acquisition stamps live in AvionicsState.
   MonoTimestamp observed_at = 3;
+  // Absence means no coherent planar projection is available. Receivers must
+  // not substitute an origin pose or zero velocity.
   Pose2d pose = 4;
   Velocity2d velocity = 5;
   AvionicsState avionics = 6;

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -23,6 +23,28 @@ message Velocity2d {
   float angular_rad_s = 3;
 }
 
+// The monotonic clock domain used by a MeasurementStamp. Values in different
+// domains are not directly comparable without an explicit clock correlation.
+enum MeasurementClock {
+  MEASUREMENT_CLOCK_UNSPECIFIED = 0;
+  MEASUREMENT_CLOCK_VEHICLE_BOOT = 1;
+  MEASUREMENT_CLOCK_SIMULATION = 2;
+}
+
+// Identity and acquisition stamp for one independently advancing measurement
+// group. Re-publishing a cached group preserves every field unchanged.
+message MeasurementStamp {
+  // Adapter-defined source identity, stable within one vehicle.
+  uint64 source_id = 1;
+  // Source boot/attachment generation. A reset changes this value.
+  uint32 source_epoch = 2;
+  // Wrapping group sequence, advanced only for a new measurement.
+  uint32 sequence = 3;
+  // Monotonic acquisition time in the declared clock domain.
+  uint64 acquired_at_ns = 4;
+  MeasurementClock clock = 5;
+}
+
 // Raw avionics state estimate for flight vehicles (ADR-0018): attitude
 // quaternion (body FRD → world NED), body rates, NED position/velocity,
 // and the source's validity/quality. Values are the estimator's output,
@@ -49,12 +71,18 @@ message AvionicsState {
   uint32 quality = 15;
   // 0 unknown, 1 disarmed, 2 armed (from the vehicle's own report).
   uint32 arm_state = 16;
+  // Attitude/rates and position/velocity advance independently. Absence means
+  // that group was not supplied in this publication.
+  MeasurementStamp attitude_stamp = 17;
+  MeasurementStamp kinematics_stamp = 18;
 }
 
 // A single best-effort telemetry sample for one vehicle.
 message TelemetrySample {
   VehicleId vehicle = 1;
   SimTick tick = 2;
+  // Host publication time. This is transport metadata, not source
+  // acquisition time; group acquisition stamps live in AvionicsState.
   MonoTimestamp observed_at = 3;
   Pose2d pose = 4;
   Velocity2d velocity = 5;

--- a/tools/loopback-probe/src/run.rs
+++ b/tools/loopback-probe/src/run.rs
@@ -176,7 +176,9 @@ async fn wait_for_rejection(
             }
             Ok(Some(ReceiverEvent::Telemetry(observation))) => {
                 metrics.telemetry_received = metrics.telemetry_received.saturating_add(1);
-                metrics.last_pose = Some(observation.pose);
+                if observation.pose.is_some() {
+                    metrics.last_pose = observation.pose;
+                }
             }
             Ok(Some(ReceiverEvent::VideoFrame { source_id, jpeg })) => {
                 fold_video_frame(source_id, &jpeg, video, &mut last_video_at);
@@ -200,7 +202,9 @@ fn drain_pending_events(
         match event {
             ReceiverEvent::Telemetry(observation) => {
                 metrics.telemetry_received = metrics.telemetry_received.wrapping_add(1);
-                metrics.last_pose = Some(observation.pose);
+                if observation.pose.is_some() {
+                    metrics.last_pose = observation.pose;
+                }
             }
             ReceiverEvent::FrameRejected(_) => {
                 metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);

--- a/tools/loopback-probe/src/sender.rs
+++ b/tools/loopback-probe/src/sender.rs
@@ -291,6 +291,9 @@ fn fold_telemetry(
     state: &mut SendLoopState,
     metrics: &mut RunMetrics,
 ) {
+    let Some(pose) = observation.pose else {
+        return;
+    };
     if let Some(watermark) = state.last_telemetry_at {
         while state
             .pending
@@ -303,8 +306,8 @@ fn fold_telemetry(
                 .saturating_add(1);
         }
     }
-    let changed = state.last_pose.replace(observation.pose) != Some(observation.pose);
-    metrics.last_pose = Some(observation.pose);
+    let changed = state.last_pose.replace(pose) != Some(pose);
+    metrics.last_pose = Some(pose);
     if changed && let Some(frame) = state.pending.pop_front() {
         let age = estimated_age(observation.received_at, frame.sent_at, ZERO_OFFSET);
         metrics.control_to_telemetry.record(age);

--- a/tools/loopback-probe/src/telemetry.rs
+++ b/tools/loopback-probe/src/telemetry.rs
@@ -19,7 +19,7 @@ pub struct TelemetryObservation {
     /// Client-local monotonic timestamp at datagram receipt.
     pub received_at: MonoTimestamp,
     /// Reported planar pose, used to detect a change since the last sample.
-    pub pose: (f32, f32, f32),
+    pub pose: Option<(f32, f32, f32)>,
 }
 
 /// Extracts the pose fields this probe tracks from an already-decoded
@@ -32,10 +32,11 @@ pub fn observation_from_sample(
     sample: &wire::TelemetrySample,
     received_at: MonoTimestamp,
 ) -> TelemetryObservation {
-    let pose = sample.pose.unwrap_or_default();
     TelemetryObservation {
         received_at,
-        pose: (pose.x_m, pose.y_m, pose.heading_rad),
+        pose: sample
+            .pose
+            .map(|pose| (pose.x_m, pose.y_m, pose.heading_rad)),
     }
 }
 
@@ -61,12 +62,12 @@ mod tests {
             avionics: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(100));
-        assert_eq!(observation.pose, (1.5, 2.5, 0.25));
+        assert_eq!(observation.pose, Some((1.5, 2.5, 0.25)));
         assert_eq!(observation.received_at, MonoTimestamp::from_nanos(100));
     }
 
     #[test]
-    fn missing_pose_projects_to_origin() {
+    fn missing_pose_stays_missing() {
         let sample = wire::TelemetrySample {
             vehicle: None,
             tick: None,
@@ -76,6 +77,6 @@ mod tests {
             avionics: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(0));
-        assert_eq!(observation.pose, (0.0, 0.0, 0.0));
+        assert_eq!(observation.pose, None);
     }
 }


### PR DESCRIPTION
## Summary

- carry source identity end to end: source id, attachment incarnation (128-bit, CSPRNG for simulator attachments, trait-injectable for aircraft boot UUIDs), wrapping source epoch, per-group wrapping sequence, monotonic acquisition time, and clock-domain identity — for both the MAVLink and SHM producers
- keep publication/receive time strictly separate from acquisition time at every hop; preserve independent attitude and kinematics stamps and publish an explicit coherence verdict with the snapshot
- gate ingress at both ends: the adapter link quarantines boot-clock regressions behind a dwell-confirmed reset heuristic (or rejects them outright under the conservative policy), and the browser rejects wrong-vehicle, wrong-source, replayed-incarnation, old-epoch, duplicate, reordered, clock-domain-switching, and time-regressing data — every rejection counted
- preserve partial measurement absence (a missing group stays missing instead of fabricating zeros) and retire every replaced transport session so stale measurements cannot survive a reconnect

## Acceptance criteria — evidence

| Issue #18 criterion | Status | Evidence |
|---|---|---|
| Every avionics producer supplies source identity, epoch, sequence, and acquisition time | ✅ | MAVLink: `adapters/aviate/src/link/measurement.rs` (`next_attitude_stamp`/`next_kinematics_stamp` build `MeasurementStamp{source_id, source_incarnation, source_epoch, sequence, acquired_at_ns, clock}`); `time_boot_ms` retained for **both** groups (`mavlink.rs`). SHM: `adapter/shm_sampling.rs` with simulation-clock stamps. Ground/reference adapters carry no avionics field by contract |
| The host forwards stamps unchanged and never presents broadcast time as source time | ✅ | `hosts/session-host/src/runtime/engine_actor/telemetry.rs` copies stamps verbatim; `observed_at` is publish-tick transport metadata. Pinned by `telemetry/tests.rs` (publish time ≠ acquisition time asserted on the wire message) |
| The browser routes by vehicle and rejects duplicate, reordered, and old-epoch data | ✅ | `clients/web/telemetry-ingress.js`: vehicle, source, incarnation (with bounded seen-set replay quarantine), epoch, per-group sequence, clock-domain, and acquisition-time-regression gates; 15 diagnostic counters. Node suite `telemetry-ingress.test.mjs`, now executed in CI |
| A repeated cached sample never resets freshness | ✅ | Duplicate sequence leaves `acceptedAtMs` untouched so age keeps growing (`testDuplicateDoesNotRefreshAge`, 750→3000 ms boundary walk); SHM side only refreshes progress on an advancing read (`frozen_sample_never_revives`) |
| Source restart is accepted only through an explicit epoch transition | ✅ | Adapter: `begin_source_epoch` fires only on serial-wrap regression or the dwell-confirmed simulator reset heuristic (`RESET_SOURCE_DWELL_MS`+`RESET_RECEIVE_DWELL`, quarantining the stream meanwhile); conservative policy refuses heuristic resets entirely. Browser: `acceptEpoch` admits only serially newer epochs and clears both groups on transition; a *new attachment* requires an unseen incarnation under the sim-only `SIM_ACCEPT_UNSEEN` policy (`PIN_FIRST` for anything real) |
| Attitude and kinematics retain independent stamps; excessive skew cannot be reported coherent | ✅ | Independent stamps through proto/ABI; `coherenceOf` demands equal source/incarnation/epoch/clock then compares acquisition times against the configured budget (skew tested on both sides of the limit). **And the verdict is consumed**: `resolve()` folds it into every attitude/kinematics signal status, so an excessive-skew snapshot renders amber-degraded, never as one coherent state (`excessive_skew_degrades_both_stamped_groups`, `skew_degradation_never_upgrades_a_worse_status`) |
| Rendering consumes one atomic snapshot generation without tearing | ✅ | ABI v2 carries the wrapping ingress generation + coherence byte; the WASM decodes the whole block into one immutable copy per render; a duplicate publication cannot advance the generation (`testSnapshotsAreAtomicAndImmutable`) |
| Counters use wrapping_add(1) | ✅ | All new Rust counters wrap; the JS mirror wraps through `increment()` (`testCountersAndGenerationWrap`) |

Deterministic verification per the issue: duplicate N, N+1-then-late-N, sequence wrap, epoch reset, interleaved vehicles, packet gaps, Valid/Stale/Failed boundaries, skew both sides, and previous-or-next snapshot atomicity are all covered by injected-clock tests with no sleeps (`link/tests.rs`, `adapter/tests.rs`, `shm/tests.rs`, `telemetry-ingress.test.mjs`, `transport-session.test.mjs`, `telemetry-display.test.mjs` — the three browser suites are wired as CI steps in this PR).

## Review findings addressed in this PR

- **Write-only coherence** (medium): the published verdict now degrades the stamped pair in `resolve()` instead of rotting unread (see above).
- **Zero default skew budget** (medium): kept as the fail-safe default — admitting an Aviate-derived 300 ms by default would smuggle a simulator assumption into the generic profile — but it is now documented on the field and the link **warns at startup**, so an interleaved multi-rate stream rejecting its slower group is loud, never silent. `LinkConfig::simulator()` remains the rate-derived example.
- The three browser suites have dedicated CI steps instead of being hidden behind the wire suite; `wire.test.mjs` no longer imports them, so every contract runs exactly once with its own check name. Build-script portability (`dev_t` width) is fixed for Linux CI, and the exhaustiveness fail-safe arm in `next_group_stamp` documents why it is unreachable.

## Known limits (deliberate, documented)

- Without a source boot UUID, a conservative-policy MAVLink link cannot accept a real FC reboot until the boot clock re-crosses the high-water mark — fail-safe by design; aircraft integrations supply an `IncarnationProvider` instead (ADR-0018).
- One SHM read is one coherent snapshot, so both groups share a stamp there — a property of the source, stated in the sampling code.
- Simulator timing budgets (300 ms skew, reset dwells) are simulation-only; aircraft thresholds require the AIR-02 safety analysis.

Refs #18. Stacked after #25 in merge order.

