### PR TITLE
VAL-01: validate numeric inputs and propagate integrity fail-safe per signal group

### DIFF
--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -42,6 +42,13 @@ fn attitude_state() -> AircraftState {
             }),
             age_ms: Some(10.0),
         },
+        quality: pilotage_instrument_state::EstimateQuality::Good,
+        valid: pilotage_instrument_state::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
         ..AircraftState::default()
     }
 }

--- a/clients/web/instruments.html
+++ b/clients/web/instruments.html
@@ -236,6 +236,7 @@ writes packed state and interprets abstract scene commands onto Canvas2D.</div>
         wind: { fromRad: v("windDir") * DEG, speedMps: v("windSpd"), ageMs: 16 },
         selections: { headingBugRad: v("hdgBug") * DEG, altitudeSelM: v("altSel") },
         quality: Number(document.getElementById("quality").value),
+        valid: { attitude: true, rates: true, position: true, velocity: true },
       },
       now,
     );

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -259,14 +259,17 @@ export class InstrumentModule {
       f(72, state.air ? state.air.ageMs : NaN);
       f(76, state.nav ? state.nav.ageMs : NaN);
       f(80, state.wind ? state.wind.ageMs : NaN);
-      b(84, state.quality ?? 0);
+      // Fail-safe defaults mirror abi.rs exactly (VAL-01): undeclared
+      // quality is unknown (255, resolves Failed), and validity is
+      // never assumed — unset flags mean "not declared valid".
+      b(84, state.quality ?? 255);
       const valid = state.valid ?? {};
       b(
         85,
-        (valid.attitude ?? true ? 1 : 0) |
-          (valid.rates ?? true ? 2 : 0) |
-          (valid.position ?? true ? 4 : 0) |
-          (valid.velocity ?? true ? 8 : 0),
+        (valid.attitude ?? false ? 1 : 0) |
+          (valid.rates ?? false ? 2 : 0) |
+          (valid.position ?? false ? 4 : 0) |
+          (valid.velocity ?? false ? 8 : 0),
       );
       b(86, state.nav?.source ?? 0);
       b(87, state.nav?.fromto ?? 0);

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -920,6 +920,43 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   );
 }
 
+// ---- VAL-01: fail-safe write defaults mirror abi.rs ---------------------------
+
+{
+  const exportsFake = fakeExports({});
+  const mod = new InstrumentModule(exportsFake, { createCanvas: recordingCanvas });
+  const minimal = mod.writeState({ selections: { headingBugRad: 0 } });
+  check("minimal state write succeeds", minimal.ok === true);
+  const view = new DataView(exportsFake.memory.buffer, exportsFake.state_ptr(), STATE_ABI_SIZE);
+  check(
+    "undeclared quality writes the unknown code (abi.rs parity), never Good",
+    view.getUint8(84) === 255,
+  );
+  check("undeclared validity writes no flags (nothing declared valid)", view.getUint8(85) === 0);
+
+  const declared = mod.writeState({
+    selections: { headingBugRad: 0 },
+    quality: 1,
+    valid: { attitude: true, rates: true, position: true, velocity: true },
+  });
+  check("declared trust write succeeds", declared.ok === true);
+  check(
+    "declared quality and flags encode exactly",
+    view.getUint8(84) === 1 && view.getUint8(85) === 0b1111,
+  );
+
+  const partial = mod.writeState({
+    selections: { headingBugRad: 0 },
+    quality: 0,
+    valid: { attitude: true, velocity: true },
+  });
+  check("partial validity write succeeds", partial.ok === true);
+  check(
+    "undeclared flags stay unset within a partial declaration",
+    view.getUint8(85) === 0b1001,
+  );
+}
+
 // ---- the real WASM module, end to end ----------------------------------------
 
 {

--- a/crates/pilotage-instrument-panels/src/hsi/cdi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/cdi.rs
@@ -59,7 +59,10 @@ pub fn draw_cdi(
         NavFromTo::From => {
             scene.polygon(PaintMode::Fill, &[[0.0, 34.0], [-8.0, 18.0], [8.0, 18.0]])?;
         }
-        NavFromTo::Off => {}
+        // Unknown resolution never reaches here (the nav group fails
+        // before drawing); the arm is the exhaustiveness fail-safe and
+        // draws no flag rather than inventing one.
+        NavFromTo::Off | NavFromTo::Unknown => {}
     }
     scene.restore()?;
     Ok(())

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -19,6 +19,13 @@ fn heading_only(heading_rad: f32) -> PanelData {
             }),
             age_ms: Some(10.0),
         },
+        quality: pilotage_instrument_state::EstimateQuality::Good,
+        valid: pilotage_instrument_state::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
         ..Default::default()
     };
     pilotage_instrument_state::resolve(

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -34,6 +34,13 @@ fn flying() -> PanelData {
             }),
             age_ms: Some(20.0),
         },
+        quality: pilotage_instrument_state::EstimateQuality::Good,
+        valid: pilotage_instrument_state::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
         ..AircraftState::default()
     };
     resolve(&state, &FreshnessPolicy::default())

--- a/crates/pilotage-instrument-state/src/abi.rs
+++ b/crates/pilotage-instrument-state/src/abi.rs
@@ -19,10 +19,10 @@
 //! | 56  | f32  | IAS (m/s, NaN absent) |
 //! | 60  | f32  | baro setting (hPa, NaN absent) |
 //! | 64  | f32×5| ages ms: attitude, kinematics, air, nav, wind (NaN never) |
-//! | 84  | u8   | quality (0 good, 1 degraded, 2 unusable) |
-//! | 85  | u8   | valid flags (bit0 att, 1 rates, 2 pos, 3 vel) |
-//! | 86  | u8   | nav source (0 none, 1 gps, 2 nav1, 3 nav2) |
-//! | 87  | u8   | nav from/to (0 off, 1 to, 2 from) |
+//! | 84  | u8   | quality (0 good, 1 degraded, 2 unusable; other = unknown, fails) |
+//! | 85  | u8   | valid flags (bit0 att, 1 rates, 2 pos, 3 vel; unset = not declared valid) |
+//! | 86  | u8   | nav source (0 none, 1 gps, 2 nav1, 3 nav2; other = unknown, fails) |
+//! | 87  | u8   | nav from/to (0 off, 1 to, 2 from; other = unknown, fails) |
 //! | 88  | f32  | nav course (rad) |
 //! | 92  | f32  | nav lateral deviation (dots) |
 //! | 96  | f32  | nav vertical deviation (dots, NaN absent) |
@@ -32,7 +32,7 @@
 //! | 112 | f32  | wind from (rad) |
 //! | 116 | f32  | wind speed (m/s) |
 //! | 120 | u32  | snapshot generation (wrapping) |
-//! | 124 | u8   | coherence (0 insufficient, 1 coherent, 2 excessive skew) |
+//! | 124 | u8   | coherence (0 insufficient, 1 coherent, 2 excessive skew; other = unknown, degrades) |
 //! | 125 | u8×3 | reserved, zero |
 
 use crate::aircraft::{
@@ -127,16 +127,21 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         age_ms: air_age,
     };
 
+    // Unknown wire values are preserved as Unknown, never mapped to a
+    // benign known value: guidance from an unidentifiable source must
+    // fail, not masquerade as no-source (VAL-01 fail-safe decoding).
     let source = match u8_at(buf, 86)? {
+        0 => NavSource::None,
         1 => NavSource::Gps,
         2 => NavSource::Nav1,
         3 => NavSource::Nav2,
-        _ => NavSource::None,
+        _ => NavSource::Unknown,
     };
     let fromto = match u8_at(buf, 87)? {
+        0 => NavFromTo::Off,
         1 => NavFromTo::To,
         2 => NavFromTo::From,
-        _ => NavFromTo::Off,
+        _ => NavFromTo::Unknown,
     };
     let nav = Stamped {
         data: match nav_age {
@@ -165,9 +170,10 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
     };
 
     let quality = match u8_at(buf, 84)? {
+        0 => EstimateQuality::Good,
         1 => EstimateQuality::Degraded,
         2 => EstimateQuality::Unusable,
-        _ => EstimateQuality::Good,
+        _ => EstimateQuality::Unknown,
     };
     let flags = u8_at(buf, 85)?;
     let valid = ValidFlags {
@@ -177,9 +183,10 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         velocity: flags & 0b1000 != 0,
     };
     let coherence = match u8_at(buf, 124)? {
+        0 => SnapshotCoherence::Insufficient,
         1 => SnapshotCoherence::Coherent,
         2 => SnapshotCoherence::ExcessiveSkew,
-        _ => SnapshotCoherence::Insufficient,
+        _ => SnapshotCoherence::Unknown,
     };
 
     Ok(AircraftState {
@@ -276,6 +283,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
             EstimateQuality::Good => 0,
             EstimateQuality::Degraded => 1,
             EstimateQuality::Unusable => 2,
+            EstimateQuality::Unknown => 255,
         },
     )?;
     let flags = u8::from(state.valid.attitude)
@@ -293,6 +301,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
             NavSource::Gps => 1,
             NavSource::Nav1 => 2,
             NavSource::Nav2 => 3,
+            NavSource::Unknown => 255,
         },
     )?;
     put_u8(
@@ -302,6 +311,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
             NavFromTo::Off => 0,
             NavFromTo::To => 1,
             NavFromTo::From => 2,
+            NavFromTo::Unknown => 255,
         },
     )?;
     put_f32(buf, 88, nav.course_rad)?;
@@ -326,6 +336,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
             SnapshotCoherence::Insufficient => 0,
             SnapshotCoherence::Coherent => 1,
             SnapshotCoherence::ExcessiveSkew => 2,
+            SnapshotCoherence::Unknown => 255,
         },
     )?;
     for offset in 125..128 {

--- a/crates/pilotage-instrument-state/src/abi/tests.rs
+++ b/crates/pilotage-instrument-state/src/abi/tests.rs
@@ -112,3 +112,61 @@ fn wrong_version_is_rejected() {
         Some(AbiError::BadVersion { found: 99 })
     );
 }
+
+// ---- VAL-01 fail-safe wire decoding --------------------------------------------
+
+#[test]
+fn unknown_wire_values_decode_fail_safe_not_benign() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    encode_state(&full_state(), &mut block).expect("encodes");
+    // Poke values outside every known enum range.
+    block[84] = 7; // quality
+    block[86] = 9; // nav source
+    block[87] = 9; // nav from/to
+    block[124] = 9; // coherence
+    let state = decode_state(&block).expect("decodes");
+    assert_eq!(state.quality, EstimateQuality::Unknown);
+    assert_eq!(
+        state.nav.data.expect("nav present").source,
+        NavSource::Unknown
+    );
+    assert_eq!(
+        state.nav.data.expect("nav present").fromto,
+        NavFromTo::Unknown
+    );
+    assert_eq!(state.snapshot.coherence, SnapshotCoherence::Unknown);
+}
+
+#[test]
+fn unknown_variants_round_trip_as_explicit_unknown() {
+    let mut state = full_state();
+    state.quality = EstimateQuality::Unknown;
+    if let Some(nav) = state.nav.data.as_mut() {
+        nav.source = NavSource::Unknown;
+        nav.fromto = NavFromTo::Unknown;
+    }
+    state.snapshot.coherence = SnapshotCoherence::Unknown;
+    let mut block = [0u8; STATE_ABI_SIZE];
+    encode_state(&state, &mut block).expect("encodes");
+    assert_eq!(block[84], 255);
+    assert_eq!(block[86], 255);
+    assert_eq!(block[87], 255);
+    assert_eq!(block[124], 255);
+    let decoded = decode_state(&block).expect("decodes");
+    assert_eq!(decoded.quality, EstimateQuality::Unknown);
+    assert_eq!(decoded.snapshot.coherence, SnapshotCoherence::Unknown);
+}
+
+#[test]
+fn zeroed_metadata_never_decodes_as_trusted() {
+    // A block whose metadata bytes are all zero: quality 0 is an
+    // explicit Good declaration (the wire's zero value), but the valid
+    // flags are all unset — nothing is declared valid.
+    let mut block = [0u8; STATE_ABI_SIZE];
+    encode_state(&AircraftState::default(), &mut block).expect("encodes");
+    assert_eq!(block[85], 0, "default flags declare nothing valid");
+    assert_eq!(block[84], 255, "default quality encodes unknown");
+    let state = decode_state(&block).expect("decodes");
+    assert!(!state.valid.attitude);
+    assert_eq!(state.quality, EstimateQuality::Unknown);
+}

--- a/crates/pilotage-instrument-state/src/aircraft.rs
+++ b/crates/pilotage-instrument-state/src/aircraft.rs
@@ -42,6 +42,10 @@ pub enum NavSource {
     Nav1,
     /// NAV radio 2 (green).
     Nav2,
+    /// The wire carried a source this build does not know. Guidance from
+    /// an unidentifiable source must not display; the nav group fails
+    /// rather than quietly pretending no source is selected.
+    Unknown,
 }
 
 /// TO/FROM resolution of the selected course.
@@ -54,6 +58,9 @@ pub enum NavFromTo {
     To,
     /// Flying away from the station/waypoint.
     From,
+    /// The wire carried a resolution this build does not know; the nav
+    /// group fails rather than defaulting to a benign flag state.
+    Unknown,
 }
 
 /// Lateral/vertical course guidance from the selected source.
@@ -93,20 +100,31 @@ pub struct Wind {
 }
 
 /// Source-reported estimate quality (mirrors Aviate's `EstimateQuality`).
+///
+/// Trust must be declared, never assumed: the default is [`Self::Unknown`],
+/// and a wire value outside the known set decodes to `Unknown` rather than
+/// to a benign level. Unknown quality resolves `Failed`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EstimateQuality {
     /// Full confidence.
-    #[default]
     Good,
     /// Reduced confidence; signals show `Degraded`.
     Degraded,
     /// The source says do not trust; signals show `Failed`.
     Unusable,
+    /// No quality was declared, or the declared value is not one this
+    /// build knows; signals show `Failed`.
+    #[default]
+    Unknown,
 }
 
 /// Which estimate groups the source declares valid (mirrors Aviate's
 /// `StateValidFlags`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// The default declares nothing valid: a feeder that never sets the flags
+/// gets `Failed` groups, not silently trusted ones. Flags apply only to
+/// groups that have data — a group never received stays `Missing`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ValidFlags {
     /// Attitude quaternion is valid.
     pub attitude: bool,
@@ -116,17 +134,6 @@ pub struct ValidFlags {
     pub position: bool,
     /// NED velocity is valid.
     pub velocity: bool,
-}
-
-impl Default for ValidFlags {
-    fn default() -> Self {
-        Self {
-            attitude: true,
-            rates: true,
-            position: true,
-            velocity: true,
-        }
-    }
 }
 
 /// One estimate group with the age a feeder stamped it with.
@@ -157,6 +164,9 @@ pub enum SnapshotCoherence {
     Coherent,
     /// Required groups exceed the configured acquisition-time skew budget.
     ExcessiveSkew,
+    /// The wire carried a coherence value this build does not know; the
+    /// pairing cannot be trusted, so stamped groups degrade.
+    Unknown,
 }
 
 /// Metadata assigned by the ingress gate to one immutable state generation.

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -17,7 +17,9 @@
 //! The crate is `no_std`, allocation-free, and sans-IO: time enters only
 //! as ages the caller supplies. [`abi`] defines the packed little-endian
 //! input layout shared with non-Rust feeders (the browser writes it into
-//! WASM linear memory).
+//! WASM linear memory). Decoding and resolution are fail-safe (VAL-01):
+//! trust must be declared, unknown wire values fail rather than mapping
+//! to benign ones, and no non-finite value can reach scene generation.
 
 #![no_std]
 
@@ -27,6 +29,7 @@ mod quat;
 mod resolve;
 mod signal;
 pub mod units;
+mod validate;
 
 pub use aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
@@ -34,4 +37,7 @@ pub use aircraft::{
 };
 pub use quat::Quat;
 pub use resolve::{NavResolved, PanelData, resolve};
-pub use signal::{FreshnessPolicy, Sig, SignalStatus};
+pub use signal::{FreshnessPolicy, PolicyError, Sig, SignalStatus};
+pub use validate::{
+    GroupFault, QUAT_NORM_TOLERANCE, StateIntegrity, validate_quat, validate_state,
+};

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -3,10 +3,11 @@
 use libm::{atan2f, sqrtf};
 
 use crate::aircraft::{
-    AircraftState, EstimateQuality, NavData, Selections, SnapshotCoherence, Wind,
+    AircraftState, EstimateQuality, NavData, NavSource, Selections, SnapshotCoherence, Wind,
 };
 use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
 use crate::units::{M_TO_FT, MPS_TO_FPM, MPS_TO_KT};
+use crate::validate::{StateIntegrity, validate_quat, validate_state};
 
 /// Below this groundspeed the track angle is geometrically meaningless
 /// and resolves `Missing` instead of jittering.
@@ -48,15 +49,19 @@ pub struct PanelData {
     pub wind: Sig<Wind>,
     /// Navigation guidance.
     pub nav: NavResolved,
-    /// Pilot selections, passed through untouched.
+    /// Pilot selections, sanitized: a non-finite selection is dropped to
+    /// its neutral value and reported in `integrity`, never drawn raw.
     pub selections: Selections,
+    /// Per-group typed fault reasons behind any validation-driven
+    /// status downgrade, for annunciation and diagnostics.
+    pub integrity: StateIntegrity,
 }
 
 fn quality_status(q: EstimateQuality) -> SignalStatus {
     match q {
         EstimateQuality::Good => SignalStatus::Valid,
         EstimateQuality::Degraded => SignalStatus::Degraded,
-        EstimateQuality::Unusable => SignalStatus::Failed,
+        EstimateQuality::Unusable | EstimateQuality::Unknown => SignalStatus::Failed,
     }
 }
 
@@ -68,27 +73,62 @@ fn flag_status(valid: bool) -> SignalStatus {
     }
 }
 
+fn fault_status<T>(fault: Option<T>) -> SignalStatus {
+    if fault.is_some() {
+        SignalStatus::Failed
+    } else {
+        SignalStatus::Valid
+    }
+}
+
 /// Attitude and kinematics are stamped independently; when the ingress
 /// gate reports their acquisition times exceed the skew budget, each
 /// value is individually usable but the pair must not present as one
 /// coherent aircraft state, so both groups degrade (amber, value shown).
-/// `Insufficient` means too few stamped groups to judge — the ordinary
-/// missing/freshness handling already covers that case.
+/// An unknown coherence wire value degrades the same way — the pairing
+/// cannot be trusted. `Insufficient` means too few stamped groups to
+/// judge; the ordinary missing/freshness handling covers that case.
 fn coherence_status(coherence: SnapshotCoherence) -> SignalStatus {
     match coherence {
-        SnapshotCoherence::ExcessiveSkew => SignalStatus::Degraded,
+        SnapshotCoherence::ExcessiveSkew | SnapshotCoherence::Unknown => SignalStatus::Degraded,
         SnapshotCoherence::Insufficient | SnapshotCoherence::Coherent => SignalStatus::Valid,
+    }
+}
+
+/// A signal that would show a non-finite value fails instead: no
+/// non-finite number may reach scene generation, and no value is
+/// silently repaired.
+fn finite(sig: Sig<f32>) -> Sig<f32> {
+    if sig.status.shows_value() && !sig.value.is_finite() {
+        Sig::with_status(0.0, SignalStatus::Failed)
+    } else {
+        sig
+    }
+}
+
+fn sanitized_selections(selections: Selections) -> Selections {
+    Selections {
+        heading_bug_rad: if selections.heading_bug_rad.is_finite() {
+            selections.heading_bug_rad
+        } else {
+            0.0
+        },
+        altitude_sel_m: selections.altitude_sel_m.filter(|value| value.is_finite()),
     }
 }
 
 /// Resolves raw input state into display-ready signals.
 ///
-/// Each signal's status is the worst of: its group's freshness under
-/// `policy`, the source quality, the snapshot's group-coherence result,
-/// and the source's validity flag for that group. Values behind
-/// `Missing`/`Failed` are quiet zeros a panel never paints.
+/// Each signal's status is the deterministic worst of: its group's
+/// freshness under `policy`, the source quality, the snapshot's
+/// group-coherence result, the source's validity flag for that group,
+/// and numeric/integrity validation ([`validate_state`]). Validity
+/// flags apply only to groups with data — a group never received stays
+/// `Missing`. Values behind `Missing`/`Failed` are quiet zeros a panel
+/// never paints, and every showable value is finite.
 pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
-    let quality = quality_status(state.quality);
+    let integrity = validate_state(state);
+    let quality = quality_status(state.quality).worst(fault_status(integrity.quality));
     let coherence = coherence_status(state.snapshot.coherence);
 
     let att_fresh = if state.attitude.data.is_none() {
@@ -96,19 +136,38 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
     } else {
         policy.status_for_age(state.attitude.age_ms)
     };
-    let att_status = att_fresh
-        .worst(quality)
-        .worst(coherence)
-        .worst(flag_status(state.valid.attitude));
-    let rate_status = att_fresh
-        .worst(quality)
-        .worst(coherence)
-        .worst(flag_status(state.valid.rates));
+    // Trust metadata (quality, coherence, flags, validation) applies
+    // only to groups that have data: absence stays Missing — dashes,
+    // not a red X — because nothing was received to distrust.
+    let has_attitude = state.attitude.data.is_some();
+    let att_status = if has_attitude {
+        att_fresh
+            .worst(quality)
+            .worst(coherence)
+            .worst(fault_status(integrity.attitude))
+            .worst(flag_status(state.valid.attitude))
+    } else {
+        SignalStatus::Missing
+    };
+    let rate_status = if has_attitude {
+        att_fresh
+            .worst(quality)
+            .worst(coherence)
+            .worst(fault_status(integrity.rates))
+            .worst(flag_status(state.valid.rates))
+    } else {
+        SignalStatus::Missing
+    };
     let (roll, pitch, yaw, turn_rate) = match state.attitude.data {
-        Some(att) => {
-            let (r, p, y) = att.quat.to_euler();
-            (r, p, y, att.rates_rps[2])
-        }
+        // Geometry only ever sees a validated, renormalized quaternion;
+        // a rejected one leaves quiet zeros behind a Failed status.
+        Some(att) => match validate_quat(att.quat) {
+            Ok(quat) => {
+                let (r, p, y) = quat.to_euler();
+                (r, p, y, att.rates_rps[2])
+            }
+            Err(_) => (0.0, 0.0, 0.0, att.rates_rps[2]),
+        },
         None => (0.0, 0.0, 0.0, 0.0),
     };
 
@@ -117,14 +176,25 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
     } else {
         policy.status_for_age(state.kinematics.age_ms)
     };
-    let pos_status = kin_fresh
-        .worst(quality)
-        .worst(coherence)
-        .worst(flag_status(state.valid.position));
-    let vel_status = kin_fresh
-        .worst(quality)
-        .worst(coherence)
-        .worst(flag_status(state.valid.velocity));
+    let has_kinematics = state.kinematics.data.is_some();
+    let pos_status = if has_kinematics {
+        kin_fresh
+            .worst(quality)
+            .worst(coherence)
+            .worst(fault_status(integrity.position))
+            .worst(flag_status(state.valid.position))
+    } else {
+        SignalStatus::Missing
+    };
+    let vel_status = if has_kinematics {
+        kin_fresh
+            .worst(quality)
+            .worst(coherence)
+            .worst(fault_status(integrity.velocity))
+            .worst(flag_status(state.valid.velocity))
+    } else {
+        SignalStatus::Missing
+    };
     let (alt_ft, vsi_fpm, gs_kt, track_rad, gs_mps) = match state.kinematics.data {
         Some(kin) => {
             let alt = -kin.pos_ned_m[2] * M_TO_FT;
@@ -137,57 +207,76 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
         }
         None => (0.0, 0.0, 0.0, 0.0, 0.0),
     };
-    let track_status = if gs_mps < TRACK_MIN_GS_MPS {
+    let track_status = if !(gs_mps.is_finite() && gs_mps >= TRACK_MIN_GS_MPS) {
         SignalStatus::Missing
     } else {
         vel_status
     };
 
     let air_fresh = policy.status_for_age(state.air.age_ms);
+    let air_fault = fault_status(integrity.air);
     let air = state.air.data.unwrap_or_default();
     let ias = match air.ias_mps {
-        Some(v) => Sig::with_status(v * MPS_TO_KT, air_fresh.worst(quality)),
+        Some(v) => Sig::with_status(v * MPS_TO_KT, air_fresh.worst(quality).worst(air_fault)),
         None => Sig::missing(),
     };
     let baro = match air.baro_setting_hpa {
-        Some(v) => Sig::with_status(v, air_fresh),
+        Some(v) => Sig::with_status(v, air_fresh.worst(air_fault)),
         None => Sig::missing(),
     };
 
     let nav_fresh = policy.status_for_age(state.nav.age_ms);
     let nav = match state.nav.data {
-        Some(data) => NavResolved {
-            data,
-            status: nav_fresh,
-        },
+        Some(data) => {
+            let status = nav_fresh.worst(fault_status(integrity.nav));
+            // Guidance from an unidentifiable source must not draw a
+            // CDI at all; failing the group removes it.
+            let data = if matches!(data.source, NavSource::Unknown) {
+                NavData {
+                    source: NavSource::Unknown,
+                    ..NavData::default()
+                }
+            } else {
+                data
+            };
+            NavResolved { data, status }
+        }
         None => NavResolved::default(),
     };
 
-    let wind = match (state.wind.data, policy.status_for_age(state.wind.age_ms)) {
+    let wind_status = policy
+        .status_for_age(state.wind.age_ms)
+        .worst(fault_status(integrity.wind));
+    let wind = match (state.wind.data, wind_status) {
         (Some(w), s) if s.shows_value() => Sig::with_status(w, s),
         _ => Sig::with_status(
             Wind {
                 from_rad: 0.0,
                 speed_mps: 0.0,
             },
-            SignalStatus::Missing,
+            if state.wind.data.is_some() && wind_status == SignalStatus::Failed {
+                SignalStatus::Failed
+            } else {
+                SignalStatus::Missing
+            },
         ),
     };
 
     PanelData {
-        roll_rad: Sig::with_status(roll, att_status),
-        pitch_rad: Sig::with_status(pitch, att_status),
-        heading_rad: Sig::with_status(yaw, att_status),
-        turn_rate_rps: Sig::with_status(turn_rate, rate_status),
-        ias_kt: ias,
-        gs_kt: Sig::with_status(gs_kt, vel_status),
-        alt_ft: Sig::with_status(alt_ft, pos_status),
-        vsi_fpm: Sig::with_status(vsi_fpm, vel_status),
-        track_rad: Sig::with_status(track_rad, track_status),
-        baro_hpa: baro,
+        roll_rad: finite(Sig::with_status(roll, att_status)),
+        pitch_rad: finite(Sig::with_status(pitch, att_status)),
+        heading_rad: finite(Sig::with_status(yaw, att_status)),
+        turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
+        ias_kt: finite(ias),
+        gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
+        alt_ft: finite(Sig::with_status(alt_ft, pos_status)),
+        vsi_fpm: finite(Sig::with_status(vsi_fpm, vel_status)),
+        track_rad: finite(Sig::with_status(track_rad, track_status)),
+        baro_hpa: finite(baro),
         wind,
         nav,
-        selections: state.selections,
+        selections: sanitized_selections(state.selections),
+        integrity,
     }
 }
 

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -28,6 +28,13 @@ fn flying_state() -> AircraftState {
             }),
             age_ms: Some(100.0),
         },
+        quality: EstimateQuality::Good,
+        valid: crate::aircraft::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
         ..AircraftState::default()
     }
 }
@@ -155,4 +162,176 @@ fn skew_degradation_never_upgrades_a_worse_status() {
     };
     let p = resolve(&s, &FreshnessPolicy::default());
     assert_eq!(p.roll_rad.status, SignalStatus::Failed);
+}
+
+// ---- VAL-01 fail-safe resolution ---------------------------------------------
+
+#[test]
+fn undeclared_trust_never_resolves_valid() {
+    // Data present but neither quality nor validity declared: the
+    // fail-safe defaults resolve Failed, not Valid.
+    let s = AircraftState {
+        attitude: flying_state().attitude,
+        kinematics: flying_state().kinematics,
+        ..AircraftState::default()
+    };
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Failed);
+    assert_eq!(p.alt_ft.status, SignalStatus::Failed);
+}
+
+#[test]
+fn invalid_quaternion_never_reaches_attitude_geometry() {
+    let mut s = flying_state();
+    if let Some(att) = s.attitude.data.as_mut() {
+        att.quat = Quat {
+            w: f32::NAN,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+    }
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Failed);
+    assert_eq!(p.roll_rad.value, 0.0, "quiet zero, not quaternion output");
+    assert!(p.pitch_rad.value.is_finite());
+    // Isolation: kinematics-derived signals are untouched by the
+    // attitude fault.
+    assert_eq!(p.alt_ft.status, SignalStatus::Valid);
+}
+
+#[test]
+fn denormalized_quaternion_within_tolerance_still_displays() {
+    let mut s = flying_state();
+    if let Some(att) = s.attitude.data.as_mut() {
+        att.quat = Quat {
+            w: 1.01,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+    }
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Valid);
+    assert!(p.roll_rad.value.abs() < 1e-6);
+}
+
+#[test]
+fn derived_overflow_fails_instead_of_showing_infinity() {
+    let mut s = flying_state();
+    if let Some(kin) = s.kinematics.data.as_mut() {
+        // Finite input whose unit conversion overflows f32.
+        kin.pos_ned_m[2] = -f32::MAX;
+    }
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.alt_ft.status, SignalStatus::Failed);
+    assert_eq!(p.alt_ft.value, 0.0);
+}
+
+#[test]
+fn every_showable_output_is_finite_under_hostile_input() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut s = flying_state();
+        if let Some(att) = s.attitude.data.as_mut() {
+            att.rates_rps = [bad; 3];
+        }
+        if let Some(kin) = s.kinematics.data.as_mut() {
+            kin.vel_ned_mps = [bad; 3];
+        }
+        if let Some(air) = s.air.data.as_mut() {
+            air.baro_setting_hpa = Some(bad);
+        }
+        s.selections.heading_bug_rad = bad;
+        s.selections.altitude_sel_m = Some(bad);
+        let p = resolve(&s, &FreshnessPolicy::default());
+        for (name, sig) in [
+            ("roll", p.roll_rad),
+            ("pitch", p.pitch_rad),
+            ("heading", p.heading_rad),
+            ("turn", p.turn_rate_rps),
+            ("ias", p.ias_kt),
+            ("gs", p.gs_kt),
+            ("alt", p.alt_ft),
+            ("vsi", p.vsi_fpm),
+            ("track", p.track_rad),
+            ("baro", p.baro_hpa),
+        ] {
+            assert!(
+                !sig.status.shows_value() || sig.value.is_finite(),
+                "{name} shows non-finite {} for {bad}",
+                sig.value
+            );
+        }
+        assert!(p.selections.heading_bug_rad.is_finite());
+        assert_eq!(p.selections.altitude_sel_m, None);
+    }
+}
+
+#[test]
+fn unknown_nav_source_fails_the_group_and_clears_guidance() {
+    let mut s = flying_state();
+    s.nav = Stamped {
+        data: Some(pilotage_state_navdata_unknown()),
+        age_ms: Some(10.0),
+    };
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.nav.status, SignalStatus::Failed);
+    assert_eq!(p.nav.data.cdi_dots, 0.0, "guidance values cleared");
+}
+
+fn pilotage_state_navdata_unknown() -> crate::aircraft::NavData {
+    crate::aircraft::NavData {
+        source: crate::aircraft::NavSource::Unknown,
+        course_rad: 1.0,
+        cdi_dots: 1.5,
+        fromto: crate::aircraft::NavFromTo::To,
+        vdev_dots: None,
+        dist_nm: None,
+    }
+}
+
+#[test]
+fn multi_fault_priority_resolves_the_worst() {
+    // Degraded quality + excessive skew + a validity flag off: Failed
+    // (the flag) must win over both Degraded causes.
+    use crate::aircraft::{SnapshotCoherence, SnapshotMeta};
+    let mut s = flying_state();
+    s.quality = EstimateQuality::Degraded;
+    s.snapshot = SnapshotMeta {
+        generation: 1,
+        coherence: SnapshotCoherence::ExcessiveSkew,
+    };
+    s.valid.attitude = false;
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Failed);
+    // Without the flag the two Degraded causes stay Degraded.
+    s.valid.attitude = true;
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Degraded);
+}
+
+#[test]
+fn unknown_coherence_degrades_stamped_groups() {
+    use crate::aircraft::{SnapshotCoherence, SnapshotMeta};
+    let mut s = flying_state();
+    s.snapshot = SnapshotMeta {
+        generation: 1,
+        coherence: SnapshotCoherence::Unknown,
+    };
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.roll_rad.status, SignalStatus::Degraded);
+    assert_eq!(p.alt_ft.status, SignalStatus::Degraded);
+}
+
+#[test]
+fn faults_are_reported_for_diagnostics() {
+    let mut s = flying_state();
+    if let Some(att) = s.attitude.data.as_mut() {
+        att.quat.w = f32::NAN;
+    }
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(
+        p.integrity.attitude,
+        Some(crate::validate::GroupFault::NonFinite)
+    );
 }

--- a/crates/pilotage-instrument-state/src/signal.rs
+++ b/crates/pilotage-instrument-state/src/signal.rs
@@ -65,14 +65,25 @@ impl Sig<f32> {
     }
 }
 
+/// Why a freshness policy could not be constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyError {
+    /// A threshold is NaN, infinite, or not positive.
+    NonPositiveThreshold,
+    /// The stale threshold does not come before the fail threshold, so
+    /// no age could ever resolve `Stale`.
+    StaleNotBeforeFail,
+}
+
 /// Freshness thresholds resolving an age into a status (ADR-0009's
 /// staleness discipline applied to display data).
+///
+/// Only [`FreshnessPolicy::new`] and `Default` construct one, so an
+/// inverted, non-finite, or non-positive threshold pair cannot exist.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FreshnessPolicy {
-    /// Age at which data is flagged stale, in milliseconds.
-    pub stale_after_ms: f32,
-    /// Age at which data is no longer shown, in milliseconds.
-    pub fail_after_ms: f32,
+    stale_after_ms: f32,
+    fail_after_ms: f32,
 }
 
 impl Default for FreshnessPolicy {
@@ -85,6 +96,38 @@ impl Default for FreshnessPolicy {
 }
 
 impl FreshnessPolicy {
+    /// Builds a policy after validating both thresholds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyError`] when a threshold is non-finite or not
+    /// positive, or when `stale_after_ms >= fail_after_ms`.
+    pub fn new(stale_after_ms: f32, fail_after_ms: f32) -> Result<Self, PolicyError> {
+        if !(stale_after_ms.is_finite() && fail_after_ms.is_finite())
+            || stale_after_ms <= 0.0
+            || fail_after_ms <= 0.0
+        {
+            return Err(PolicyError::NonPositiveThreshold);
+        }
+        if stale_after_ms >= fail_after_ms {
+            return Err(PolicyError::StaleNotBeforeFail);
+        }
+        Ok(Self {
+            stale_after_ms,
+            fail_after_ms,
+        })
+    }
+
+    /// Age at which data is flagged stale, in milliseconds.
+    pub fn stale_after_ms(&self) -> f32 {
+        self.stale_after_ms
+    }
+
+    /// Age at which data is no longer shown, in milliseconds.
+    pub fn fail_after_ms(&self) -> f32 {
+        self.fail_after_ms
+    }
+
     /// Status from a group's age; `None` means never received.
     pub fn status_for_age(&self, age_ms: Option<f32>) -> SignalStatus {
         match age_ms {

--- a/crates/pilotage-instrument-state/src/signal/tests.rs
+++ b/crates/pilotage-instrument-state/src/signal/tests.rs
@@ -42,3 +42,36 @@ fn only_showable_statuses_show_values() {
     assert!(!SignalStatus::Missing.shows_value());
     assert!(!SignalStatus::Failed.shows_value());
 }
+
+// ---- VAL-01 policy construction -----------------------------------------------
+
+#[test]
+fn invalid_policy_construction_is_rejected() {
+    use super::PolicyError;
+    for (stale, fail) in [
+        (f32::NAN, 100.0),
+        (100.0, f32::NAN),
+        (f32::INFINITY, 200.0),
+        (100.0, f32::INFINITY),
+        (0.0, 100.0),
+        (-1.0, 100.0),
+        (100.0, 0.0),
+    ] {
+        assert_eq!(
+            super::FreshnessPolicy::new(stale, fail),
+            Err(PolicyError::NonPositiveThreshold),
+            "{stale}/{fail}"
+        );
+    }
+    assert_eq!(
+        super::FreshnessPolicy::new(100.0, 100.0),
+        Err(PolicyError::StaleNotBeforeFail)
+    );
+    assert_eq!(
+        super::FreshnessPolicy::new(200.0, 100.0),
+        Err(PolicyError::StaleNotBeforeFail)
+    );
+    let policy = super::FreshnessPolicy::new(100.0, 200.0).expect("valid thresholds");
+    assert_eq!(policy.stale_after_ms(), 100.0);
+    assert_eq!(policy.fail_after_ms(), 200.0);
+}

--- a/crates/pilotage-instrument-state/src/validate.rs
+++ b/crates/pilotage-instrument-state/src/validate.rs
@@ -1,0 +1,153 @@
+//! Pure numeric/integrity validators applied before display resolution.
+//!
+//! No non-finite, malformed, unknown-quality, invalid-quaternion, or
+//! otherwise untrusted value may resolve `Valid` or influence display
+//! geometry. Validators never repair silently: a fault fails its group
+//! with a typed reason, and independent group faults stay isolated.
+
+use libm::sqrtf;
+
+use crate::aircraft::{
+    AircraftState, EstimateQuality, NavFromTo, NavSource, Selections, SnapshotCoherence,
+};
+use crate::quat::Quat;
+
+/// Largest relative quaternion norm error normalized instead of failed.
+///
+/// Within the tolerance the quaternion is renormalized (accumulated
+/// rounding from an estimator is expected); at zero, gross, or
+/// non-finite norm the attitude is unusable and fails instead.
+pub const QUAT_NORM_TOLERANCE: f32 = 0.02;
+
+/// Why one group's data cannot be trusted this frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupFault {
+    /// A mandatory value is NaN or infinite.
+    NonFinite,
+    /// The attitude quaternion has zero, gross, or non-finite norm.
+    QuatNorm,
+    /// The source declared a quality level this build does not know.
+    UnknownQuality,
+    /// An enum field carried a value this build does not know.
+    UnknownEnum,
+}
+
+/// Per-group validation results; `None` means the group's received data
+/// passed. Groups without data are not validated (absence is `Missing`,
+/// not a fault).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StateIntegrity {
+    /// Attitude quaternion fault.
+    pub attitude: Option<GroupFault>,
+    /// Body-rates fault.
+    pub rates: Option<GroupFault>,
+    /// NED position fault.
+    pub position: Option<GroupFault>,
+    /// NED velocity fault.
+    pub velocity: Option<GroupFault>,
+    /// Air-data fault.
+    pub air: Option<GroupFault>,
+    /// Navigation-guidance fault.
+    pub nav: Option<GroupFault>,
+    /// Wind-estimate fault.
+    pub wind: Option<GroupFault>,
+    /// Pilot-selections fault.
+    pub selections: Option<GroupFault>,
+    /// Source quality was undeclared or unknown (taints every estimate
+    /// group, matching how quality itself combines).
+    pub quality: Option<GroupFault>,
+    /// Snapshot coherence carried an unknown wire value.
+    pub coherence: Option<GroupFault>,
+}
+
+fn all_finite(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+fn opt_finite(value: Option<f32>) -> bool {
+    value.is_none_or(f32::is_finite)
+}
+
+/// Validates the attitude quaternion: every component finite and the
+/// norm within [`QUAT_NORM_TOLERANCE`] of unity. Returns the normalized
+/// quaternion; never repairs a gross error.
+pub fn validate_quat(quat: Quat) -> Result<Quat, GroupFault> {
+    if !all_finite(&[quat.w, quat.x, quat.y, quat.z]) {
+        return Err(GroupFault::NonFinite);
+    }
+    let norm = sqrtf(quat.w * quat.w + quat.x * quat.x + quat.y * quat.y + quat.z * quat.z);
+    if !norm.is_finite() || (norm - 1.0).abs() > QUAT_NORM_TOLERANCE {
+        return Err(GroupFault::QuatNorm);
+    }
+    Ok(Quat {
+        w: quat.w / norm,
+        x: quat.x / norm,
+        y: quat.y / norm,
+        z: quat.z / norm,
+    })
+}
+
+fn selections_fault(selections: &Selections) -> Option<GroupFault> {
+    let finite = selections.heading_bug_rad.is_finite() && opt_finite(selections.altitude_sel_m);
+    if finite {
+        None
+    } else {
+        Some(GroupFault::NonFinite)
+    }
+}
+
+/// Validates every received group of `state` and reports per-group
+/// faults. Absent groups pass (their absence resolves `Missing`); the
+/// deterministic worst-of combination in `resolve` folds these faults
+/// into each signal's status.
+pub fn validate_state(state: &AircraftState) -> StateIntegrity {
+    let mut integrity = StateIntegrity::default();
+
+    if let Some(attitude) = &state.attitude.data {
+        if let Err(fault) = validate_quat(attitude.quat) {
+            integrity.attitude = Some(fault);
+        }
+        if !all_finite(&attitude.rates_rps) {
+            integrity.rates = Some(GroupFault::NonFinite);
+        }
+    }
+    if let Some(kinematics) = &state.kinematics.data {
+        if !all_finite(&kinematics.pos_ned_m) {
+            integrity.position = Some(GroupFault::NonFinite);
+        }
+        if !all_finite(&kinematics.vel_ned_mps) {
+            integrity.velocity = Some(GroupFault::NonFinite);
+        }
+    }
+    if let Some(air) = &state.air.data
+        && !(opt_finite(air.ias_mps) && opt_finite(air.baro_setting_hpa))
+    {
+        integrity.air = Some(GroupFault::NonFinite);
+    }
+    if let Some(nav) = &state.nav.data {
+        if matches!(nav.source, NavSource::Unknown) || matches!(nav.fromto, NavFromTo::Unknown) {
+            integrity.nav = Some(GroupFault::UnknownEnum);
+        } else if !(all_finite(&[nav.course_rad, nav.cdi_dots])
+            && opt_finite(nav.vdev_dots)
+            && opt_finite(nav.dist_nm))
+        {
+            integrity.nav = Some(GroupFault::NonFinite);
+        }
+    }
+    if let Some(wind) = &state.wind.data
+        && !all_finite(&[wind.from_rad, wind.speed_mps])
+    {
+        integrity.wind = Some(GroupFault::NonFinite);
+    }
+    integrity.selections = selections_fault(&state.selections);
+    if state.quality == EstimateQuality::Unknown {
+        integrity.quality = Some(GroupFault::UnknownQuality);
+    }
+    if state.snapshot.coherence == SnapshotCoherence::Unknown {
+        integrity.coherence = Some(GroupFault::UnknownEnum);
+    }
+    integrity
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-state/src/validate/tests.rs
+++ b/crates/pilotage-instrument-state/src/validate/tests.rs
@@ -1,0 +1,219 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{GroupFault, QUAT_NORM_TOLERANCE, validate_quat, validate_state};
+use crate::aircraft::{
+    AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
+    Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
+};
+use crate::quat::Quat;
+
+const BAD: [f32; 3] = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+
+fn quat_scaled(scale: f32) -> Quat {
+    Quat {
+        w: scale,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    }
+}
+
+fn stamped<T>(data: T) -> Stamped<T> {
+    Stamped {
+        data: Some(data),
+        age_ms: Some(10.0),
+    }
+}
+
+fn trusted_full_state() -> AircraftState {
+    AircraftState {
+        attitude: stamped(Attitude {
+            quat: Quat::IDENTITY,
+            rates_rps: [0.0; 3],
+        }),
+        kinematics: stamped(Kinematics {
+            pos_ned_m: [1.0, 2.0, -3.0],
+            vel_ned_mps: [4.0, 5.0, -0.5],
+        }),
+        air: stamped(AirData {
+            ias_mps: Some(40.0),
+            baro_setting_hpa: Some(1013.25),
+        }),
+        nav: stamped(NavData {
+            source: NavSource::Gps,
+            course_rad: 0.3,
+            cdi_dots: -1.0,
+            fromto: NavFromTo::To,
+            vdev_dots: Some(0.2),
+            dist_nm: Some(12.5),
+        }),
+        wind: stamped(Wind {
+            from_rad: 1.0,
+            speed_mps: 5.0,
+        }),
+        quality: EstimateQuality::Good,
+        valid: crate::aircraft::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
+        ..AircraftState::default()
+    }
+}
+
+#[test]
+fn trusted_state_reports_no_faults() {
+    assert_eq!(validate_state(&trusted_full_state()), Default::default());
+}
+
+#[test]
+fn quat_tolerance_boundaries_normalize_or_fail() {
+    // Inside the tolerance: normalized to unit length.
+    let inside = validate_quat(quat_scaled(1.0 + QUAT_NORM_TOLERANCE * 0.99)).expect("normalizes");
+    assert!((inside.w - 1.0).abs() < 1e-6);
+    let below = validate_quat(quat_scaled(1.0 - QUAT_NORM_TOLERANCE * 0.99)).expect("normalizes");
+    assert!((below.w - 1.0).abs() < 1e-6);
+
+    // Outside the tolerance in either direction: a gross error fails
+    // rather than being silently repaired.
+    for scale in [
+        1.0 + QUAT_NORM_TOLERANCE * 1.5,
+        1.0 - QUAT_NORM_TOLERANCE * 1.5,
+        0.0,
+        10.0,
+    ] {
+        assert_eq!(
+            validate_quat(quat_scaled(scale)),
+            Err(GroupFault::QuatNorm),
+            "scale {scale}"
+        );
+    }
+    for bad in BAD {
+        assert_eq!(
+            validate_quat(Quat {
+                w: bad,
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            }),
+            Err(GroupFault::NonFinite),
+            "component {bad}"
+        );
+    }
+}
+
+#[test]
+fn non_finite_values_fault_exactly_their_own_group() {
+    for bad in BAD {
+        let mut s = trusted_full_state();
+        if let Some(att) = s.attitude.data.as_mut() {
+            att.rates_rps[1] = bad;
+        }
+        let report = validate_state(&s);
+        assert_eq!(report.rates, Some(GroupFault::NonFinite), "{bad}");
+        // Isolation: no other group is tainted by the rates fault.
+        assert_eq!(report.attitude, None);
+        assert_eq!(report.position, None);
+        assert_eq!(report.air, None);
+        assert_eq!(report.nav, None);
+        assert_eq!(report.wind, None);
+
+        let mut s = trusted_full_state();
+        if let Some(kin) = s.kinematics.data.as_mut() {
+            kin.pos_ned_m[2] = bad;
+        }
+        let report = validate_state(&s);
+        assert_eq!(report.position, Some(GroupFault::NonFinite));
+        assert_eq!(report.velocity, None);
+
+        let mut s = trusted_full_state();
+        if let Some(air) = s.air.data.as_mut() {
+            air.baro_setting_hpa = Some(bad);
+        }
+        assert_eq!(validate_state(&s).air, Some(GroupFault::NonFinite));
+
+        let mut s = trusted_full_state();
+        if let Some(nav) = s.nav.data.as_mut() {
+            nav.cdi_dots = bad;
+        }
+        assert_eq!(validate_state(&s).nav, Some(GroupFault::NonFinite));
+
+        let mut s = trusted_full_state();
+        if let Some(wind) = s.wind.data.as_mut() {
+            wind.speed_mps = bad;
+        }
+        assert_eq!(validate_state(&s).wind, Some(GroupFault::NonFinite));
+
+        let mut s = trusted_full_state();
+        s.selections.heading_bug_rad = bad;
+        assert_eq!(validate_state(&s).selections, Some(GroupFault::NonFinite));
+    }
+}
+
+#[test]
+fn finite_extrema_are_not_faults() {
+    let mut s = trusted_full_state();
+    if let Some(kin) = s.kinematics.data.as_mut() {
+        kin.pos_ned_m = [f32::MAX, f32::MIN, -f32::MAX];
+    }
+    assert_eq!(validate_state(&s).position, None);
+}
+
+#[test]
+fn optional_absence_is_not_a_fault() {
+    let mut s = trusted_full_state();
+    if let Some(air) = s.air.data.as_mut() {
+        air.ias_mps = None;
+        air.baro_setting_hpa = None;
+    }
+    if let Some(nav) = s.nav.data.as_mut() {
+        nav.vdev_dots = None;
+        nav.dist_nm = None;
+    }
+    s.selections.altitude_sel_m = None;
+    let report = validate_state(&s);
+    assert_eq!(report.air, None);
+    assert_eq!(report.nav, None);
+    assert_eq!(report.selections, None);
+}
+
+#[test]
+fn unknown_enums_and_quality_are_typed_faults() {
+    let mut s = trusted_full_state();
+    if let Some(nav) = s.nav.data.as_mut() {
+        nav.source = NavSource::Unknown;
+    }
+    assert_eq!(validate_state(&s).nav, Some(GroupFault::UnknownEnum));
+
+    let mut s = trusted_full_state();
+    if let Some(nav) = s.nav.data.as_mut() {
+        nav.fromto = NavFromTo::Unknown;
+    }
+    assert_eq!(validate_state(&s).nav, Some(GroupFault::UnknownEnum));
+
+    let mut s = trusted_full_state();
+    s.quality = EstimateQuality::Unknown;
+    assert_eq!(validate_state(&s).quality, Some(GroupFault::UnknownQuality));
+
+    let mut s = trusted_full_state();
+    s.snapshot = SnapshotMeta {
+        generation: 1,
+        coherence: SnapshotCoherence::Unknown,
+    };
+    assert_eq!(validate_state(&s).coherence, Some(GroupFault::UnknownEnum));
+}
+
+#[test]
+fn absent_groups_are_not_validated() {
+    let empty = AircraftState {
+        selections: Selections::default(),
+        ..AircraftState::default()
+    };
+    let report = validate_state(&empty);
+    // Absence resolves Missing downstream; it is not an integrity fault
+    // (but the undeclared quality still is).
+    assert_eq!(report.attitude, None);
+    assert_eq!(report.nav, None);
+    assert_eq!(report.quality, Some(GroupFault::UnknownQuality));
+}


### PR DESCRIPTION
## Summary

- close every fail-open decode path: trust must be declared, never assumed — default quality is `Unknown` (resolves `Failed`), default validity flags declare nothing, and wire values outside the known sets decode to explicit `Unknown` variants (encoded 255) instead of mapping to benign ones
- add pure validators (`validate.rs`): per-field finiteness for every received group, quaternion norm validated within a documented ±2% tolerance (renormalized inside it, failed at zero/gross/non-finite norm), enum compatibility; typed `GroupFault` reasons ride `PanelData.integrity` for annunciation and diagnostics
- resolution folds the deterministic worst of freshness, quality, coherence, validity flags, and numeric validation into every signal; trust metadata applies only to groups with data, so absence stays `Missing` (dashes) instead of becoming `Failed` (red X)
- a `finite()` exit guard makes a non-finite showable `PanelData` value structurally impossible; pilot selections are sanitized with the fault reported, never drawn raw
- `FreshnessPolicy` construction is validated (`PolicyError`); the browser writer mirrors the fail-safe byte mappings exactly

## Acceptance criteria — evidence

| Issue #19 criterion | Status | Evidence |
|---|---|---|
| Default/absent/unknown metadata never produces Valid or Good | ✅ | `EstimateQuality`/`ValidFlags` fail-safe defaults; `undeclared_trust_never_resolves_valid`, `zeroed_metadata_never_decodes_as_trusted`, `unknown_wire_values_decode_fail_safe_not_benign`; empty state stays honest `Missing` (`empty_state_resolves_all_missing`) |
| Every displayed numeric value is finite | ✅ | `finite()` guard on every `Sig` at the resolve exit; `every_showable_output_is_finite_under_hostile_input` injects NaN/±Inf into every slot and asserts every `shows_value` output finite; `derived_overflow_fails_instead_of_showing_infinity` covers finite inputs whose unit conversion overflows |
| Optional NaN accepted only at explicitly documented fields | ✅ | The ABI doc table marks exactly which offsets use NaN-as-absent; decode maps them to `None`; `optional_absence_is_not_a_fault` |
| Invalid quaternion never reaches attitude geometry | ✅ | Geometry consumes only `validate_quat` output (renormalized or rejected); `invalid_quaternion_never_reaches_attitude_geometry` (quiet zeros + Failed, kinematics isolated), `quat_tolerance_boundaries_normalize_or_fail`, `denormalized_quaternion_within_tolerance_still_displays` |
| Baro, nav, and wind receive the same integrity treatment | ✅ | Air/nav/wind faults fold into their statuses; unknown nav source fails the group **and clears guidance values** so no CDI can draw from an unidentifiable source (`unknown_nav_source_fails_the_group_and_clears_guidance`) |
| Independent group failures remain isolated | ✅ | `non_finite_values_fault_exactly_their_own_group` asserts, per injected fault, that every other group reports none; resolve keeps attitude/kinematics statuses independent (`invalid_quaternion…` asserts alt stays Valid) |
| Invalid freshness policy construction is rejected | ✅ | Fields are private; `FreshnessPolicy::new` rejects NaN/∞/non-positive/inverted thresholds (`invalid_policy_construction_is_rejected` covers all seven bad shapes + both orderings) |
| Public errors are typed; no anyhow | ✅ | `GroupFault`, `PolicyError`, existing `AbiError` — plain typed enums in a `no_std` crate; anyhow is workspace-banned via `disallowed_types` |

Deterministic verification per the issue — NaN, both infinities, finite extrema, optional absence, quaternion tolerance boundaries/zero/gross, all known and unknown enums/qualities, missing/stale/degraded/failed metadata, derivation overflow, group isolation, multi-fault priority (`multi_fault_priority_resolves_the_worst`: Failed flag beats two Degraded causes; without it they stay Degraded) — all named table tests, no sleeps.

## Rust/JS parity

`writeState` mirrors `abi.rs` exactly: undeclared quality writes 255 (unknown), undeclared flags write 0, partial declarations leave undeclared bits unset — pinned by byte-level parity tests in `instruments.test.mjs` (108 checks green against the real WASM). The slider harness declares its validity explicitly, since nothing is assumed anymore.

## Semantics worth reviewing

- **Missing vs Failed:** trust metadata gates on data presence. Nothing received → `Missing` (dashes); data received without declared trust, or failing validation → `Failed` (red X). This keeps "no sensor" visually distinct from "lying sensor", per ADR-0017's honesty rule.
- **No silent repair:** the only value ever adjusted is a quaternion inside the documented ±2% norm tolerance (estimator rounding); everything else fails with its reason on `PanelData.integrity`.

SIM / NOT FOR FLIGHT: engineering objective, not a certification claim. Refs #19.
