### PR TITLE
REN-03: implement a deterministic software reference rasterizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,13 @@ jobs:
           -p pilotage-instrument-scene
           -p pilotage-instrument-glyphs
           -p pilotage-instrument-panels
+          -p pilotage-instrument-raster
           --target thumbv7em-none-eabihf
+
+      - name: reference rasterizer frame hashes (REN-03)
+        # Re-render the PFD and HSI panels and assert their pinned SHA-256
+        # frame hashes, proving the software rasterizer is bit-reproducible.
+        run: cargo test -p pilotage-instrument-raster
 
       - name: instrument wasm backend builds
         # Generating the resource binding here makes the fail-visible test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ name = "pilotage-instrument-raster"
 version = "0.1.0"
 dependencies = [
  "libm",
+ "pilotage-instrument-glyphs",
  "pilotage-instrument-panels",
  "pilotage-instrument-scene",
  "pilotage-instrument-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -166,7 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -194,6 +203,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -208,6 +226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -247,13 +275,23 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -369,6 +407,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -961,6 +1009,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-instrument-raster"
+version = "0.1.0"
+dependencies = [
+ "libm",
+ "pilotage-instrument-panels",
+ "pilotage-instrument-scene",
+ "pilotage-instrument-state",
+ "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-instrument-scene"
 version = "0.1.0"
 dependencies = [
@@ -1548,13 +1608,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1878,6 +1949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2146,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "sha2",
+ "sha2 0.11.0",
  "socket2",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/pilotage-instrument-state",
     "crates/pilotage-instrument-glyphs",
     "crates/pilotage-instrument-panels",
+    "crates/pilotage-instrument-raster",
     "adapters/reference-headless",
     "adapters/aviate",
     "tools/hid-probe",
@@ -48,6 +49,7 @@ pilotage-instrument-scene = { path = "crates/pilotage-instrument-scene" }
 pilotage-instrument-state = { path = "crates/pilotage-instrument-state" }
 pilotage-instrument-glyphs = { path = "crates/pilotage-instrument-glyphs" }
 pilotage-instrument-panels = { path = "crates/pilotage-instrument-panels" }
+pilotage-instrument-raster = { path = "crates/pilotage-instrument-raster" }
 pilotage-adapter-reference = { path = "adapters/reference-headless" }
 pilotage-adapter-gazebo = { path = "adapters/gazebo" }
 pilotage-adapter-aviate = { path = "adapters/aviate" }

--- a/crates/pilotage-instrument-raster/Cargo.toml
+++ b/crates/pilotage-instrument-raster/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pilotage-instrument-raster"
+description = "Deterministic software reference rasterizer for the scene IR (ADR-0017, REN-03)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+libm = { workspace = true }
+thiserror = { workspace = true }
+pilotage-instrument-scene = { workspace = true }
+
+[dev-dependencies]
+pilotage-instrument-panels = { workspace = true }
+pilotage-instrument-state = { workspace = true }
+sha2 = "0.10.9"

--- a/crates/pilotage-instrument-raster/Cargo.toml
+++ b/crates/pilotage-instrument-raster/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 libm = { workspace = true }
+pilotage-instrument-glyphs = { workspace = true }
 thiserror = { workspace = true }
 pilotage-instrument-scene = { workspace = true }
 

--- a/crates/pilotage-instrument-raster/src/curve.rs
+++ b/crates/pilotage-instrument-raster/src/curve.rs
@@ -1,0 +1,131 @@
+//! Circle and arc coverage by exact distance to the center.
+//!
+//! A circle is rotation-invariant, so under this rigid transform its
+//! transformed center plus unchanged radius reproduce it exactly. Coverage
+//! samples the pixel center once with no anti-aliasing: a fill covers pixels
+//! within the radius; a circle or arc stroke covers pixels within the
+//! half-width of the ideal ring. An arc additionally tests angular
+//! membership and paints round caps at its two endpoints, matching the
+//! stroke module's round-cap semantics.
+
+use core::f32::consts::TAU;
+
+use crate::surface::{PixelRect, Surface};
+
+/// A device-space center and radius after transform and snapping.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Disc {
+    /// Center x in device pixels.
+    pub(crate) cx: f32,
+    /// Center y in device pixels.
+    pub(crate) cy: f32,
+    /// Radius in device pixels (never negative).
+    pub(crate) r: f32,
+}
+
+/// Fills the disc with `color`.
+pub(crate) fn fill_circle(surface: &mut Surface<'_>, clip: PixelRect, disc: Disc, color: [u8; 4]) {
+    paint(surface, clip, disc, disc.r, color, |dist, _, _| {
+        dist <= disc.r
+    });
+}
+
+/// Strokes the circle outline centered on the ideal ring at half-width `hw`.
+pub(crate) fn stroke_circle(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    disc: Disc,
+    hw: f32,
+    color: [u8; 4],
+) {
+    paint(surface, clip, disc, disc.r + hw, color, |dist, _, _| {
+        libm::fabsf(dist - disc.r) <= hw
+    });
+}
+
+/// Strokes an arc from `start` sweeping `sweep` radians (device angles),
+/// with round caps at both ends.
+pub(crate) fn stroke_arc(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    disc: Disc,
+    start: f32,
+    sweep: f32,
+    hw: f32,
+    color: [u8; 4],
+) {
+    let cap0 = end_point(disc, start);
+    let cap1 = end_point(disc, start + sweep);
+    paint(surface, clip, disc, disc.r + hw, color, |dist, dx, dy| {
+        if near(dx, dy, cap0, hw) || near(dx, dy, cap1, hw) {
+            return true;
+        }
+        libm::fabsf(dist - disc.r) <= hw && arc_contains(libm::atan2f(dy, dx), start, sweep)
+    });
+}
+
+/// Iterates the pixel box of radius `reach` around the center, compositing
+/// where `covered` accepts the pixel. `covered` receives the center distance
+/// and the offset `(dx, dy)` from the center.
+fn paint(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    disc: Disc,
+    reach: f32,
+    color: [u8; 4],
+    covered: impl Fn(f32, f32, f32) -> bool,
+) {
+    if reach < 0.0 || clip.is_empty() {
+        return;
+    }
+    let region = bounds(disc.cx, disc.cy, reach).intersect(clip);
+    for py in region.top..region.bottom {
+        let dy = (py as f32 + 0.5) - disc.cy;
+        for px in region.left..region.right {
+            let dx = (px as f32 + 0.5) - disc.cx;
+            let dist = libm::sqrtf(dx * dx + dy * dy);
+            if covered(dist, dx, dy) {
+                surface.composite(px, py, color);
+            }
+        }
+    }
+}
+
+fn end_point(disc: Disc, angle: f32) -> (f32, f32) {
+    (disc.r * libm::cosf(angle), disc.r * libm::sinf(angle))
+}
+
+fn near(dx: f32, dy: f32, cap: (f32, f32), hw: f32) -> bool {
+    let ex = dx - cap.0;
+    let ey = dy - cap.1;
+    libm::sqrtf(ex * ex + ey * ey) <= hw
+}
+
+/// Whether device angle `ang` lies on the arc `[start, start + sweep]`,
+/// handling either sweep sign and a full turn.
+fn arc_contains(ang: f32, start: f32, sweep: f32) -> bool {
+    if libm::fabsf(sweep) >= TAU {
+        return true;
+    }
+    let mut d = libm::fmodf(ang - start, TAU);
+    if d < 0.0 {
+        d += TAU;
+    }
+    if sweep >= 0.0 {
+        d <= sweep
+    } else {
+        d >= TAU + sweep
+    }
+}
+
+fn bounds(cx: f32, cy: f32, reach: f32) -> PixelRect {
+    PixelRect {
+        left: libm::floorf(cx - reach) as i32,
+        top: libm::floorf(cy - reach) as i32,
+        right: libm::ceilf(cx + reach) as i32 + 1,
+        bottom: libm::ceilf(cy + reach) as i32 + 1,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/curve/tests.rs
+++ b/crates/pilotage-instrument-raster/src/curve/tests.rs
@@ -1,0 +1,72 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::f32::consts::FRAC_PI_2;
+use std::vec::Vec;
+
+use super::*;
+use crate::report::FramebufferDims;
+use crate::surface::Surface;
+
+const RED: [u8; 4] = [255, 0, 0, 255];
+
+fn disc() -> Disc {
+    Disc {
+        cx: 10.0,
+        cy: 10.0,
+        r: 5.0,
+    }
+}
+
+fn painted(draw: impl FnOnce(&mut Surface<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; 20 * 20 * 4];
+    {
+        let mut s = Surface::new(&mut buf, FramebufferDims::tight(20, 20)).expect("surface");
+        draw(&mut s);
+    }
+    buf
+}
+
+fn covered(buf: &[u8], x: u32, y: u32) -> bool {
+    buf[((y * 20 + x) * 4 + 3) as usize] != 0
+}
+
+#[test]
+fn filled_circle_covers_the_interior_not_beyond_the_radius() {
+    let buf = painted(|s| fill_circle(s, s.bounds(), disc(), RED));
+    assert!(covered(&buf, 10, 10));
+    assert!(covered(&buf, 10, 14));
+    assert!(!covered(&buf, 10, 16));
+}
+
+#[test]
+fn stroked_circle_is_hollow() {
+    let buf = painted(|s| stroke_circle(s, s.bounds(), disc(), 1.0, RED));
+    assert!(!covered(&buf, 10, 10), "center is empty");
+    assert!(covered(&buf, 15, 10), "ring at the radius is painted");
+}
+
+#[test]
+fn arc_paints_only_its_angular_span() {
+    // Quarter arc from +x sweeping clockwise to +y.
+    let buf = painted(|s| stroke_arc(s, s.bounds(), disc(), 0.0, FRAC_PI_2, 1.0, RED));
+    assert!(covered(&buf, 15, 10), "east end is on the arc");
+    assert!(!covered(&buf, 5, 10), "west is outside the sweep");
+}
+
+#[test]
+fn full_turn_sweep_paints_the_whole_ring() {
+    let buf = painted(|s| stroke_arc(s, s.bounds(), disc(), 0.0, 7.0, 1.0, RED));
+    assert!(covered(&buf, 15, 10));
+    assert!(covered(&buf, 5, 10));
+}
+
+#[test]
+fn negative_reach_paints_nothing() {
+    let empty = Disc {
+        cx: 10.0,
+        cy: 10.0,
+        r: 0.0,
+    };
+    let buf = painted(|s| stroke_circle(s, s.bounds(), empty, -1.0, RED));
+    assert!(buf.iter().all(|&b| b == 0));
+}

--- a/crates/pilotage-instrument-raster/src/error.rs
+++ b/crates/pilotage-instrument-raster/src/error.rs
@@ -7,11 +7,16 @@
 //! spoils the whole frame (see [`crate::render`]) so no plausible old frame
 //! survives a failure.
 
+use pilotage_instrument_glyphs::GlyphError;
 use pilotage_instrument_scene::{DecodeError, LayerError};
 
 /// Why a render did not produce a valid frame.
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq)]
 pub enum RasterError {
+    /// The controlled glyph pack failed verification, or a text run used
+    /// a character the pack does not cover; nothing substitutes.
+    #[error(transparent)]
+    Glyph(#[from] GlyphError),
     /// The framebuffer has a zero width or height.
     #[error("framebuffer width and height must be non-zero")]
     ZeroFramebuffer,

--- a/crates/pilotage-instrument-raster/src/error.rs
+++ b/crates/pilotage-instrument-raster/src/error.rs
@@ -1,0 +1,75 @@
+//! Typed rasterizer failures.
+//!
+//! Geometry errors ([`RasterError::ZeroFramebuffer`] and the other
+//! framebuffer-shape variants) are reported before the framebuffer is
+//! touched, so the caller's buffer is left untouched. Every other error is
+//! raised only after the framebuffer shape is accepted; the renderer then
+//! spoils the whole frame (see [`crate::render`]) so no plausible old frame
+//! survives a failure.
+
+use pilotage_instrument_scene::{DecodeError, LayerError};
+
+/// Why a render did not produce a valid frame.
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq)]
+pub enum RasterError {
+    /// The framebuffer has a zero width or height.
+    #[error("framebuffer width and height must be non-zero")]
+    ZeroFramebuffer,
+    /// A framebuffer dimension exceeds [`crate::MAX_DIMENSION`].
+    #[error("framebuffer {width}x{height} exceeds the {limit}px dimension limit")]
+    FramebufferTooLarge {
+        /// Requested width in pixels.
+        width: u32,
+        /// Requested height in pixels.
+        height: u32,
+        /// The per-axis pixel limit.
+        limit: u32,
+    },
+    /// The row stride is narrower than one packed RGBA8 row.
+    #[error("row stride {stride_bytes} is below the {min_bytes}-byte minimum")]
+    StrideTooSmall {
+        /// The stride the caller supplied.
+        stride_bytes: usize,
+        /// Bytes one packed row needs (`width * 4`).
+        min_bytes: usize,
+    },
+    /// The pixel slice is shorter than `height * stride`.
+    #[error("framebuffer slice has {have} bytes but needs {need}")]
+    FramebufferTooSmall {
+        /// Bytes the geometry needs.
+        need: usize,
+        /// Bytes the slice holds.
+        have: usize,
+    },
+    /// The scene failed the layered-scene contract before painting.
+    #[error("scene layer contract violated: {0}")]
+    Layer(#[from] LayerError),
+    /// A command stream decode failed during painting.
+    #[error("scene decode failed during paint: {0}")]
+    Decode(#[from] DecodeError),
+    /// A coordinate, transform component, or size was NaN or infinite.
+    #[error("a coordinate or transform value was not finite")]
+    NonFinite,
+    /// A device coordinate fell outside the representable range.
+    #[error("a device coordinate exceeded the +/-{limit_px}px range")]
+    CoordinateOutOfRange {
+        /// The per-axis device-coordinate limit in pixels.
+        limit_px: f32,
+    },
+    /// A polyline or polygon carried more vertices than one command may
+    /// paint.
+    #[error("a shape has more than {limit} vertices")]
+    TooManyVertices {
+        /// The per-command vertex limit.
+        limit: usize,
+    },
+    /// The graphics-state save stack exceeded its depth budget.
+    #[error("graphics-state stack exceeded depth {limit}")]
+    StackOverflow {
+        /// The maximum save depth.
+        limit: usize,
+    },
+    /// A restore was issued with no matching save.
+    #[error("restore with no matching save")]
+    UnbalancedRestore,
+}

--- a/crates/pilotage-instrument-raster/src/fixed.rs
+++ b/crates/pilotage-instrument-raster/src/fixed.rs
@@ -1,0 +1,70 @@
+//! The single subpixel quantization boundary: Q8.8 fixed point.
+//!
+//! Every device-space coordinate the affine transform produces is snapped
+//! to this grid, once, at the moment it is produced (see [`Fx::snap`]).
+//! All later edge and distance tests read the snapped value, so a frame is
+//! independent of how the platform rounds the `f32` transform arithmetic
+//! beyond this one point. The unit is 1/256 of a device pixel.
+
+use crate::error::RasterError;
+
+/// Fixed-point fractional bits: 1 unit is `1 / 256` device pixels.
+pub(crate) const FRAC_BITS: u32 = 8;
+
+/// Fixed-point scale (`2^FRAC_BITS`).
+pub(crate) const ONE: i32 = 1 << FRAC_BITS;
+
+/// Half a pixel in fixed point; a pixel center offset from its top-left.
+pub(crate) const HALF: i32 = ONE / 2;
+
+/// Largest absolute device coordinate accepted, in pixels. A snapped
+/// coordinate past this fails rather than wrapping the fixed-point range;
+/// `32767 * 256` stays well inside `i32` and cross products stay inside
+/// `i64`.
+pub(crate) const COORD_LIMIT_PX: f32 = 32767.0;
+
+const COORD_LIMIT_RAW: i32 = 32767 * ONE;
+
+/// A device coordinate on the Q8.8 grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Fx(i32);
+
+impl Fx {
+    /// The grid origin, a filler for fixed-size vertex buffers.
+    pub(crate) const ZERO: Self = Self(0);
+
+    /// Snaps a device-space `f32` to the grid, the crate's one quantization
+    /// point. Rejects non-finite inputs and coordinates outside
+    /// [`COORD_LIMIT_PX`] with a typed error instead of wrapping.
+    pub(crate) fn snap(v: f32) -> Result<Self, RasterError> {
+        if !v.is_finite() {
+            return Err(RasterError::NonFinite);
+        }
+        let raw = libm::roundf(v * ONE as f32);
+        if !(-(COORD_LIMIT_RAW as f32)..=COORD_LIMIT_RAW as f32).contains(&raw) {
+            return Err(RasterError::CoordinateOutOfRange {
+                limit_px: COORD_LIMIT_PX,
+            });
+        }
+        Ok(Self(raw as i32))
+    }
+
+    /// The pixel center of column/row `p`, exactly on the grid.
+    pub(crate) const fn pixel_center(p: i32) -> Self {
+        Self(p * ONE + HALF)
+    }
+
+    /// Raw fixed-point units (1/256 px), widened for cross products.
+    pub(crate) const fn raw(self) -> i64 {
+        self.0 as i64
+    }
+
+    /// The exact `f32` value; snapped grid values are representable without
+    /// loss for the accepted coordinate range.
+    pub(crate) fn to_f32(self) -> f32 {
+        self.0 as f32 / ONE as f32
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/fixed/tests.rs
+++ b/crates/pilotage-instrument-raster/src/fixed/tests.rs
@@ -1,0 +1,53 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::error::RasterError;
+
+#[test]
+fn snaps_zero_and_unit_and_subpixel() {
+    assert_eq!(Fx::snap(0.0).expect("finite").raw(), 0);
+    assert_eq!(Fx::snap(1.0).expect("finite").raw(), i64::from(ONE));
+    // A half pixel snaps to 128 (1/256 units), the subpixel boundary.
+    assert_eq!(Fx::snap(0.5).expect("finite").raw(), i64::from(HALF));
+    // One quantization step is exactly 1/256 px.
+    assert_eq!(Fx::snap(1.0 / 256.0).expect("finite").raw(), 1);
+}
+
+#[test]
+fn snaps_negative_symmetrically() {
+    assert_eq!(Fx::snap(-1.0).expect("finite").raw(), -i64::from(ONE));
+    assert_eq!(Fx::snap(-0.5).expect("finite").raw(), -i64::from(HALF));
+}
+
+#[test]
+fn round_trips_exactly_within_range() {
+    for v in [0.0f32, 0.5, -0.5, 123.25, -400.75, 32000.0] {
+        assert_eq!(Fx::snap(v).expect("finite").to_f32(), v);
+    }
+}
+
+#[test]
+fn pixel_center_is_half_past_the_index() {
+    assert_eq!(Fx::pixel_center(0).to_f32(), 0.5);
+    assert_eq!(Fx::pixel_center(10).to_f32(), 10.5);
+    assert_eq!(Fx::pixel_center(-1).to_f32(), -0.5);
+}
+
+#[test]
+fn rejects_out_of_range() {
+    assert!(matches!(
+        Fx::snap(COORD_LIMIT_PX + 1.0),
+        Err(RasterError::CoordinateOutOfRange { .. })
+    ));
+    assert!(matches!(
+        Fx::snap(-(COORD_LIMIT_PX + 1.0)),
+        Err(RasterError::CoordinateOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn rejects_non_finite() {
+    assert_eq!(Fx::snap(f32::NAN), Err(RasterError::NonFinite));
+    assert_eq!(Fx::snap(f32::INFINITY), Err(RasterError::NonFinite));
+    assert_eq!(Fx::snap(f32::NEG_INFINITY), Err(RasterError::NonFinite));
+}

--- a/crates/pilotage-instrument-raster/src/lib.rs
+++ b/crates/pilotage-instrument-raster/src/lib.rs
@@ -1,0 +1,95 @@
+//! Deterministic software reference rasterizer for the instrument scene IR
+//! (ADR-0017, REN-03).
+//!
+//! [`render`] paints an encoded [`pilotage_instrument_scene`] scene into a
+//! caller-provided RGBA8 framebuffer with no GPU, OS, clock, random source,
+//! allocation, or platform font dependency, producing bit-identical frames
+//! across targets. The crate is `no_std` and allocation-free; every `f32`
+//! operation goes through `libm` so results do not vary with the platform
+//! math library, and IEEE-754 `f32` arithmetic makes them identical across
+//! CI architectures.
+//!
+//! # Framebuffer contract
+//! - Pixels are RGBA8 — four bytes per pixel in R, G, B, A order, straight
+//!   (non-premultiplied) alpha, sRGB, row-major, top-left origin, with
+//!   `stride_bytes` between row starts (see [`FramebufferDims`]).
+//! - The frame is cleared to transparent black before the first command; a
+//!   scene's own background layer paints any opaque backdrop.
+//! - Compositing is source-over evaluated directly on the sRGB-encoded 8-bit
+//!   channels (a defined, colorimetrically simplified rule for exact
+//!   reproducibility), with all division rounded to nearest by integer math.
+//!   Each pixel is covered at most once per primitive, so a translucent shape
+//!   never composites against itself.
+//!
+//! # Rasterization contract
+//! - Coverage is sampled at pixel centers `(x + 0.5, y + 0.5)` with no
+//!   anti-aliasing: a pixel is wholly inside or wholly outside a shape.
+//! - Every device coordinate is snapped once to Q8.8 fixed point (1/256 px)
+//!   as it leaves the affine transform; that is the single quantization
+//!   boundary, so a frame does not depend on transform rounding beyond it.
+//! - Transforms translate/rotate post-multiply in command order (Canvas2D
+//!   semantics) from an identity, 1:1 initial transform (one logical unit is
+//!   one device pixel). The IR has no scale op, so this stays a rigid motion:
+//!   stroke widths and radii are unscaled and a circle stays a circle.
+//! - Clipping is rectangle intersection only; each clip is the device-space
+//!   axis-aligned bound of the transformed rectangle (conservative under
+//!   rotation).
+//! - Filled polygons use the non-zero winding rule, computed in integer
+//!   arithmetic. Strokes are centered with round joins and caps, evaluated as
+//!   capsule distance to the path; circles and arcs use exact center
+//!   distance. Text renders as a deterministic placeholder box derived only
+//!   from the run's size, anchor, and byte length until REN-02's glyph pack
+//!   replaces it.
+//!
+//! # Fail-safe behavior and bounds
+//! - Non-finite coordinates or transforms, out-of-range coordinates,
+//!   over-budget shapes, and stack overflow are typed [`RasterError`]s; a
+//!   NaN or infinity is never painted.
+//! - Any error raised after the framebuffer geometry is accepted spoils the
+//!   whole frame — opaque black plus a red diagonal cross drawn by direct
+//!   writes that cannot fail — so no plausible old frame survives a failure.
+//!   Framebuffer-geometry errors leave the buffer untouched.
+//! - Resource bounds are explicit: [`MAX_DIMENSION`] per axis,
+//!   [`MAX_POLYGON_VERTICES`] per shape, and the scene crate's stack, command,
+//!   and byte budgets. The worst-case frame size is [`WORST_CASE_FRAME_BYTES`].
+//!
+//! # Execution-time measurement
+//! The renderer is straight-line over the scene and framebuffer with no I/O
+//! and only documented-bounded loops, so a target-independent worst-case
+//! execution time is a sum of bounded step counts — command dispatches (at
+//! most [`pilotage_instrument_scene::MAX_LAYER_COMMANDS`] times the layer
+//! count) and per-pixel coverage tests (at most framebuffer pixels times a
+//! shape's edges) — multiplied by the selected target's per-step cycle bound.
+//! A step-counting harness can wrap the coverage predicate and command
+//! dispatch without changing output; measured cycle costs and the final WCET
+//! wait for hardware selection and are out of scope here.
+
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+mod curve;
+mod error;
+mod fixed;
+mod paint;
+mod raster;
+mod report;
+mod state;
+mod stroke;
+mod surface;
+mod text;
+mod transform;
+
+pub use error::RasterError;
+pub use raster::render;
+pub use report::{FrameId, FramebufferDims, RenderReport, RenderStatus};
+
+/// Largest framebuffer dimension accepted per axis, in pixels.
+pub const MAX_DIMENSION: u32 = 4096;
+
+/// Largest vertex count a single polyline or polygon command may paint.
+pub const MAX_POLYGON_VERTICES: usize = 512;
+
+/// Worst-case frame size in bytes: a [`MAX_DIMENSION`]-square RGBA8 frame.
+pub const WORST_CASE_FRAME_BYTES: usize = MAX_DIMENSION as usize * MAX_DIMENSION as usize * 4;

--- a/crates/pilotage-instrument-raster/src/paint.rs
+++ b/crates/pilotage-instrument-raster/src/paint.rs
@@ -1,0 +1,85 @@
+//! Polygon and rectangle fills by the non-zero winding rule.
+//!
+//! Fill rule: a pixel belongs to a polygon when the winding number of the
+//! polygon's edges around the pixel center is non-zero. Coverage is sampled
+//! once, at the pixel center `(px + 0.5, py + 0.5)`, with no anti-aliasing,
+//! so a pixel is wholly inside or wholly outside and the frame is exactly
+//! reproducible. Winding is computed in Q8.8 integer arithmetic widened to
+//! `i64`, independent of floating point.
+
+use crate::fixed::{FRAC_BITS, Fx};
+use crate::surface::{PixelRect, Surface};
+
+/// Fills the closed polygon through `verts` with `color`, clipped to `clip`.
+pub(crate) fn fill_polygon(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    verts: &[[Fx; 2]],
+    color: [u8; 4],
+) {
+    if verts.len() < 3 || clip.is_empty() {
+        return;
+    }
+    let region = bounds(verts).intersect(clip);
+    if region.is_empty() {
+        return;
+    }
+    for py in region.top..region.bottom {
+        let cy = Fx::pixel_center(py).raw();
+        for px in region.left..region.right {
+            let cx = Fx::pixel_center(px).raw();
+            if winding_nonzero(verts, cx, cy) {
+                surface.composite(px, py, color);
+            }
+        }
+    }
+}
+
+/// The half-open pixel bounding box covering every pixel whose center could
+/// fall inside the vertices.
+fn bounds(verts: &[[Fx; 2]]) -> PixelRect {
+    let mut min_x = verts[0][0].raw();
+    let mut max_x = min_x;
+    let mut min_y = verts[0][1].raw();
+    let mut max_y = min_y;
+    for v in &verts[1..] {
+        min_x = min_x.min(v[0].raw());
+        max_x = max_x.max(v[0].raw());
+        min_y = min_y.min(v[1].raw());
+        max_y = max_y.max(v[1].raw());
+    }
+    PixelRect {
+        left: (min_x >> FRAC_BITS) as i32,
+        top: (min_y >> FRAC_BITS) as i32,
+        right: ((max_x >> FRAC_BITS) + 1) as i32,
+        bottom: ((max_y >> FRAC_BITS) + 1) as i32,
+    }
+}
+
+/// Non-zero winding test for a pixel center against the polygon edges.
+fn winding_nonzero(verts: &[[Fx; 2]], px: i64, py: i64) -> bool {
+    let n = verts.len();
+    let mut wn: i32 = 0;
+    for i in 0..n {
+        let a = verts[i];
+        let b = verts[(i + 1) % n];
+        let ay = a[1].raw();
+        let by = b[1].raw();
+        if ay <= py {
+            if by > py && is_left(a, b, px, py) > 0 {
+                wn = wn.wrapping_add(1);
+            }
+        } else if by <= py && is_left(a, b, px, py) < 0 {
+            wn = wn.wrapping_sub(1);
+        }
+    }
+    wn != 0
+}
+
+/// Signed area of the triangle (a, b, p); positive when p is left of a→b.
+fn is_left(a: [Fx; 2], b: [Fx; 2], px: i64, py: i64) -> i64 {
+    (b[0].raw() - a[0].raw()) * (py - a[1].raw()) - (px - a[0].raw()) * (b[1].raw() - a[1].raw())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/paint/tests.rs
+++ b/crates/pilotage-instrument-raster/src/paint/tests.rs
@@ -1,0 +1,92 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec::Vec;
+
+use super::*;
+use crate::report::FramebufferDims;
+use crate::surface::Surface;
+
+const RED: [u8; 4] = [255, 0, 0, 255];
+
+fn verts(coords: &[(f32, f32)]) -> Vec<[Fx; 2]> {
+    coords
+        .iter()
+        .map(|&(x, y)| [Fx::snap(x).expect("finite"), Fx::snap(y).expect("finite")])
+        .collect()
+}
+
+fn painted(w: u32, h: u32, draw: impl FnOnce(&mut Surface<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; (w * h * 4) as usize];
+    {
+        let mut s = Surface::new(&mut buf, FramebufferDims::tight(w, h)).expect("surface");
+        draw(&mut s);
+    }
+    buf
+}
+
+fn pix(buf: &[u8], w: u32, x: u32, y: u32) -> [u8; 4] {
+    let at = ((y * w + x) * 4) as usize;
+    [buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]
+}
+
+#[test]
+fn axis_aligned_rectangle_fills_pixel_centers_inside() {
+    let quad = verts(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]);
+    let buf = painted(8, 8, |s| fill_polygon(s, s.bounds(), &quad, RED));
+    assert_eq!(pix(&buf, 8, 0, 0), RED);
+    assert_eq!(pix(&buf, 8, 3, 3), RED);
+    // Centers at 4.5 fall outside the half-open [0,4) span.
+    assert_eq!(pix(&buf, 8, 4, 0), [0, 0, 0, 0]);
+    assert_eq!(pix(&buf, 8, 0, 4), [0, 0, 0, 0]);
+}
+
+#[test]
+fn triangle_fills_its_interior_only() {
+    let tri = verts(&[(1.0, 1.0), (7.0, 1.0), (1.0, 7.0)]);
+    let buf = painted(8, 8, |s| fill_polygon(s, s.bounds(), &tri, RED));
+    assert_eq!(pix(&buf, 8, 2, 2), RED);
+    // The opposite corner is outside the hypotenuse.
+    assert_eq!(pix(&buf, 8, 6, 6), [0, 0, 0, 0]);
+}
+
+#[test]
+fn non_zero_rule_fills_a_self_intersecting_star_center() {
+    // A pentagram traced by connecting every second point winds the center
+    // twice: non-zero fills it, even-odd would leave it hollow.
+    let star = verts(&[
+        (10.0, 2.0),
+        (14.70, 16.47),
+        (2.39, 7.53),
+        (17.61, 7.53),
+        (5.30, 16.47),
+    ]);
+    let buf = painted(20, 20, |s| fill_polygon(s, s.bounds(), &star, RED));
+    assert_eq!(
+        pix(&buf, 20, 10, 10),
+        RED,
+        "star center is filled (non-zero)"
+    );
+    assert_eq!(pix(&buf, 20, 0, 0), [0, 0, 0, 0], "outside stays empty");
+}
+
+#[test]
+fn clip_confines_the_fill() {
+    let quad = verts(&[(0.0, 0.0), (8.0, 0.0), (8.0, 8.0), (0.0, 8.0)]);
+    let clip = PixelRect {
+        left: 2,
+        top: 2,
+        right: 5,
+        bottom: 5,
+    };
+    let buf = painted(8, 8, |s| fill_polygon(s, clip, &quad, RED));
+    assert_eq!(pix(&buf, 8, 3, 3), RED);
+    assert_eq!(pix(&buf, 8, 1, 1), [0, 0, 0, 0]);
+    assert_eq!(pix(&buf, 8, 5, 5), [0, 0, 0, 0]);
+}
+
+#[test]
+fn degenerate_polygons_paint_nothing() {
+    let line = verts(&[(0.0, 0.0), (8.0, 8.0)]);
+    let buf = painted(8, 8, |s| fill_polygon(s, s.bounds(), &line, RED));
+    assert!(buf.iter().all(|&b| b == 0));
+}

--- a/crates/pilotage-instrument-raster/src/raster.rs
+++ b/crates/pilotage-instrument-raster/src/raster.rs
@@ -1,0 +1,328 @@
+//! The render entry point: validate, clear, paint, and fail visibly.
+//!
+//! [`render`] gates the frame on
+//! [`validate_layers`](pilotage_instrument_scene::validate_layers) exactly as
+//! the WASM backend does, clears to the defined initial state, then walks the
+//! command stream. Layer markers are no-ops for painting; the save/restore
+//! they wrap are honored as ordinary commands. Any failure once the
+//! framebuffer geometry is accepted spoils the whole frame before returning,
+//! so a caller can never mistake stale contents for a fresh render.
+
+use pilotage_instrument_scene::{Anchor, Cmd, PaintMode, PointsRef, SceneCmds, validate_layers};
+
+use crate::curve::{self, Disc};
+use crate::error::RasterError;
+use crate::fixed::Fx;
+use crate::paint::fill_polygon;
+use crate::report::{FrameId, FramebufferDims, RenderReport, RenderStatus};
+use crate::state::RenderState;
+use crate::stroke::stroke_path;
+use crate::surface::Surface;
+use crate::text::{self, Run};
+use crate::transform::Affine;
+
+/// Renders an encoded scene into a caller-provided RGBA8 framebuffer.
+///
+/// `frame` is echoed into the report unchanged (the rasterizer is stateless).
+/// On success the framebuffer holds the painted frame; on any error after the
+/// framebuffer geometry is accepted, it holds the spoil pattern and the error
+/// is returned. Geometry errors leave the buffer untouched. See the crate
+/// docs for the full pixel-format, compositing, and coverage contract.
+pub fn render(
+    scene: &[u8],
+    pixels: &mut [u8],
+    dims: FramebufferDims,
+    frame: FrameId,
+) -> Result<RenderReport, RasterError> {
+    let mut surface = Surface::new(pixels, dims)?;
+    match paint(scene, &mut surface) {
+        Ok((unknown_opcodes, layers_present)) => Ok(RenderReport {
+            scene_version: scene.first().copied().unwrap_or(0),
+            status: RenderStatus::Painted,
+            frame,
+            unknown_opcodes,
+            layers_present,
+        }),
+        Err(error) => {
+            surface.spoil();
+            Err(error)
+        }
+    }
+}
+
+/// Validates, clears, and paints; returns the unknown-opcode count and the
+/// present-layer bitset for the report.
+fn paint(scene: &[u8], surface: &mut Surface<'_>) -> Result<(u32, u8), RasterError> {
+    let report = validate_layers(scene)?;
+    surface.clear();
+    let mut state = RenderState::new(surface.bounds());
+    let mut unknown: u32 = 0;
+    for item in SceneCmds::new(scene)? {
+        run(&item?, &mut state, surface, &mut unknown)?;
+    }
+    Ok((unknown, report.present))
+}
+
+fn run(
+    cmd: &Cmd<'_>,
+    state: &mut RenderState,
+    surface: &mut Surface<'_>,
+    unknown: &mut u32,
+) -> Result<(), RasterError> {
+    match cmd {
+        Cmd::Save => state.save(),
+        Cmd::Restore => state.restore(),
+        Cmd::Translate { x, y } => translate(state, *x, *y),
+        Cmd::Rotate { radians } => rotate(state, *radians),
+        Cmd::FillColor { color } => {
+            state.set_fill(*color);
+            Ok(())
+        }
+        Cmd::Stroke { color, width } => state.set_stroke(*color, *width),
+        Cmd::ClipRect { x, y, w, h } => clip(state, *x, *y, *w, *h),
+        Cmd::Line { x1, y1, x2, y2 } => line(state, surface, [*x1, *y1, *x2, *y2]),
+        Cmd::Polyline { points } => polyline(state, surface, points),
+        Cmd::Polygon { mode, points } => polygon(state, surface, *mode, points),
+        Cmd::Rect { mode, x, y, w, h } => rect(state, surface, *mode, [*x, *y, *w, *h]),
+        Cmd::Circle { mode, cx, cy, r } => circle(state, surface, *mode, [*cx, *cy, *r]),
+        Cmd::Arc {
+            cx,
+            cy,
+            r,
+            start,
+            sweep,
+        } => arc(state, surface, [*cx, *cy, *r], *start, *sweep),
+        Cmd::Text {
+            x,
+            y,
+            size,
+            anchor,
+            text: run_text,
+        } => draw_text(state, surface, [*x, *y, *size], *anchor, run_text.len()),
+        Cmd::BeginLayer { .. } | Cmd::EndLayer { .. } => Ok(()),
+        Cmd::Unknown { .. } => {
+            *unknown = unknown.wrapping_add(1);
+            Ok(())
+        }
+    }
+}
+
+fn finite(v: f32) -> Result<f32, RasterError> {
+    if v.is_finite() {
+        Ok(v)
+    } else {
+        Err(RasterError::NonFinite)
+    }
+}
+
+fn fills(mode: PaintMode) -> bool {
+    matches!(mode, PaintMode::Fill | PaintMode::FillStroke)
+}
+
+fn strokes(mode: PaintMode) -> bool {
+    matches!(mode, PaintMode::Stroke | PaintMode::FillStroke)
+}
+
+fn translate(state: &mut RenderState, x: f32, y: f32) -> Result<(), RasterError> {
+    state.ctm_mut().translate(finite(x)?, finite(y)?);
+    Ok(())
+}
+
+fn rotate(state: &mut RenderState, radians: f32) -> Result<(), RasterError> {
+    state.ctm_mut().rotate(finite(radians)?);
+    Ok(())
+}
+
+fn clip(state: &mut RenderState, x: f32, y: f32, w: f32, h: f32) -> Result<(), RasterError> {
+    let ctm = state.current().ctm;
+    let corners = rect_corners(&ctm, x, y, w, h)?;
+    state.clip_rect(&corners);
+    Ok(())
+}
+
+fn line(state: &RenderState, surface: &mut Surface<'_>, v: [f32; 4]) -> Result<(), RasterError> {
+    let gs = state.current();
+    let verts = [gs.ctm.map(v[0], v[1])?, gs.ctm.map(v[2], v[3])?];
+    stroke_path(
+        surface,
+        gs.clip,
+        &verts,
+        false,
+        gs.stroke_width,
+        gs.stroke_color,
+    );
+    Ok(())
+}
+
+fn polyline(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    points: &PointsRef<'_>,
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let mut buf = [[Fx::ZERO; 2]; crate::MAX_POLYGON_VERTICES];
+    let n = map_points(&gs.ctm, points, &mut buf)?;
+    stroke_path(
+        surface,
+        gs.clip,
+        &buf[..n],
+        false,
+        gs.stroke_width,
+        gs.stroke_color,
+    );
+    Ok(())
+}
+
+fn polygon(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    mode: PaintMode,
+    points: &PointsRef<'_>,
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let mut buf = [[Fx::ZERO; 2]; crate::MAX_POLYGON_VERTICES];
+    let n = map_points(&gs.ctm, points, &mut buf)?;
+    if fills(mode) {
+        fill_polygon(surface, gs.clip, &buf[..n], gs.fill);
+    }
+    if strokes(mode) {
+        stroke_path(
+            surface,
+            gs.clip,
+            &buf[..n],
+            true,
+            gs.stroke_width,
+            gs.stroke_color,
+        );
+    }
+    Ok(())
+}
+
+fn rect(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    mode: PaintMode,
+    v: [f32; 4],
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let corners = rect_corners(&gs.ctm, v[0], v[1], v[2], v[3])?;
+    if fills(mode) {
+        fill_polygon(surface, gs.clip, &corners, gs.fill);
+    }
+    if strokes(mode) {
+        stroke_path(
+            surface,
+            gs.clip,
+            &corners,
+            true,
+            gs.stroke_width,
+            gs.stroke_color,
+        );
+    }
+    Ok(())
+}
+
+fn circle(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    mode: PaintMode,
+    v: [f32; 3],
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let disc = disc(&gs.ctm, v[0], v[1], v[2])?;
+    if fills(mode) {
+        curve::fill_circle(surface, gs.clip, disc, gs.fill);
+    }
+    if strokes(mode) {
+        curve::stroke_circle(
+            surface,
+            gs.clip,
+            disc,
+            gs.stroke_width / 2.0,
+            gs.stroke_color,
+        );
+    }
+    Ok(())
+}
+
+fn arc(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    v: [f32; 3],
+    start: f32,
+    sweep: f32,
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let disc = disc(&gs.ctm, v[0], v[1], v[2])?;
+    let device_start = finite(start)? + gs.ctm.rotation();
+    curve::stroke_arc(
+        surface,
+        gs.clip,
+        disc,
+        device_start,
+        finite(sweep)?,
+        gs.stroke_width / 2.0,
+        gs.stroke_color,
+    );
+    Ok(())
+}
+
+fn draw_text(
+    state: &RenderState,
+    surface: &mut Surface<'_>,
+    v: [f32; 3],
+    anchor: Anchor,
+    byte_len: usize,
+) -> Result<(), RasterError> {
+    let gs = state.current();
+    let run = Run {
+        x: v[0],
+        y: v[1],
+        size: finite(v[2])?,
+        anchor,
+        byte_len,
+    };
+    text::draw_placeholder(surface, gs.clip, &gs.ctm, run, gs.fill)
+}
+
+/// Transforms the four corners of a logical rectangle to snapped device
+/// coordinates in clockwise order.
+fn rect_corners(ctm: &Affine, x: f32, y: f32, w: f32, h: f32) -> Result<[[Fx; 2]; 4], RasterError> {
+    Ok([
+        ctm.map(x, y)?,
+        ctm.map(x + w, y)?,
+        ctm.map(x + w, y + h)?,
+        ctm.map(x, y + h)?,
+    ])
+}
+
+/// Maps a circle/arc center and radius into device space; a non-positive or
+/// non-finite radius paints nothing (radius zero).
+fn disc(ctm: &Affine, cx: f32, cy: f32, r: f32) -> Result<Disc, RasterError> {
+    let center = ctm.map(cx, cy)?;
+    let radius = Fx::snap(finite(r)?.max(0.0))?;
+    Ok(Disc {
+        cx: center[0].to_f32(),
+        cy: center[1].to_f32(),
+        r: radius.to_f32(),
+    })
+}
+
+fn map_points(
+    ctm: &Affine,
+    points: &PointsRef<'_>,
+    buf: &mut [[Fx; 2]; crate::MAX_POLYGON_VERTICES],
+) -> Result<usize, RasterError> {
+    let mut n = 0;
+    for [x, y] in points.iter() {
+        let slot = buf.get_mut(n).ok_or(RasterError::TooManyVertices {
+            limit: crate::MAX_POLYGON_VERTICES,
+        })?;
+        *slot = ctm.map(x, y)?;
+        n = n.wrapping_add(1);
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/raster.rs
+++ b/crates/pilotage-instrument-raster/src/raster.rs
@@ -54,6 +54,10 @@ pub fn render(
 /// present-layer bitset for the report.
 fn paint(scene: &[u8], surface: &mut Surface<'_>) -> Result<(u32, u8), RasterError> {
     let report = validate_layers(scene)?;
+    // The controlled glyph pack is part of the display's integrity
+    // envelope: a corrupt pack fails the frame before any text could
+    // paint from it (REN-02's no-fallback rule).
+    pilotage_instrument_glyphs::PANEL_GLYPHS.verify()?;
     surface.clear();
     let mut state = RenderState::new(surface.bounds());
     let mut unknown: u32 = 0;
@@ -98,7 +102,7 @@ fn run(
             size,
             anchor,
             text: run_text,
-        } => draw_text(state, surface, [*x, *y, *size], *anchor, run_text.len()),
+        } => draw_text(state, surface, [*x, *y, *size], *anchor, run_text),
         Cmd::BeginLayer { .. } | Cmd::EndLayer { .. } => Ok(()),
         Cmd::Unknown { .. } => {
             *unknown = unknown.wrapping_add(1);
@@ -272,7 +276,7 @@ fn draw_text(
     surface: &mut Surface<'_>,
     v: [f32; 3],
     anchor: Anchor,
-    byte_len: usize,
+    run_text: &str,
 ) -> Result<(), RasterError> {
     let gs = state.current();
     let run = Run {
@@ -280,9 +284,9 @@ fn draw_text(
         y: v[1],
         size: finite(v[2])?,
         anchor,
-        byte_len,
+        text: run_text,
     };
-    text::draw_placeholder(surface, gs.clip, &gs.ctm, run, gs.fill)
+    text::draw_run(surface, gs.clip, &gs.ctm, run, gs.fill)
 }
 
 /// Transforms the four corners of a logical rectangle to snapped device

--- a/crates/pilotage-instrument-raster/src/raster/tests.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests.rs
@@ -1,0 +1,329 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec::Vec;
+
+use pilotage_instrument_scene::{Anchor, LayerId, MAX_SCENE_BYTES, PaintMode, Rgba8, SceneWriter};
+
+use crate::{FrameId, FramebufferDims, RasterError, RenderReport, RenderStatus, render};
+
+mod frame_hashes;
+
+const BLACK: Rgba8 = Rgba8::rgb(0, 0, 0);
+const WHITE: Rgba8 = Rgba8::rgb(255, 255, 255);
+
+/// Wraps `build` in one valid Attitude layer so the scene passes the layer
+/// contract, isolating tests from the layered-scene rules.
+fn scene(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+    let mut w = SceneWriter::new(&mut buf).expect("writer");
+    w.begin_layer(LayerId::Attitude).expect("begin layer");
+    build(&mut w);
+    w.end_layer(LayerId::Attitude).expect("end layer");
+    let n = w.finish();
+    buf.truncate(n);
+    buf
+}
+
+fn render_scene(bytes: &[u8], w: u32, h: u32) -> (Result<RenderReport, RasterError>, Vec<u8>) {
+    let mut fb = std::vec![0u8; (w * h * 4) as usize];
+    let res = render(
+        bytes,
+        &mut fb,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    );
+    (res, fb)
+}
+
+fn is_black_opaque(px: &[u8]) -> bool {
+    px[0] == 0 && px[1] == 0 && px[2] == 0 && px[3] == 255
+}
+
+fn assert_spoiled(fb: &[u8]) {
+    assert!(
+        fb.chunks_exact(4).all(|px| px[3] == 255),
+        "a spoiled frame is fully opaque"
+    );
+    assert!(
+        fb[0] == 255 && fb[1] == 0 && fb[2] == 0 && fb[3] == 255,
+        "the spoil cross reaches the top-left corner"
+    );
+    assert!(
+        fb.chunks_exact(4).any(is_black_opaque),
+        "the spoil pattern has a black field"
+    );
+}
+
+fn painted_any(fb: &[u8]) -> bool {
+    fb.chunks_exact(4).any(|px| px[3] != 0)
+}
+
+#[test]
+fn renders_every_primitive_in_one_frame() {
+    let bytes = scene(|w| {
+        w.fill_color(WHITE).expect("fill");
+        w.rect(PaintMode::Fill, 2.0, 2.0, 20.0, 20.0).expect("rect");
+        w.stroke(Rgba8::rgb(200, 0, 0), 2.0).expect("stroke");
+        w.line(0.0, 0.0, 30.0, 30.0).expect("line");
+        w.polyline(&[[5.0, 40.0], [15.0, 60.0], [25.0, 40.0]])
+            .expect("polyline");
+        w.polygon(
+            PaintMode::FillStroke,
+            &[[40.0, 40.0], [60.0, 40.0], [50.0, 60.0]],
+        )
+        .expect("polygon");
+        w.circle(PaintMode::Fill, 70.0, 30.0, 10.0)
+            .expect("circle fill");
+        w.circle(PaintMode::Stroke, 70.0, 70.0, 10.0)
+            .expect("circle stroke");
+        w.arc(30.0, 80.0, 12.0, 0.0, 3.0).expect("arc");
+        w.text(50.0, 90.0, 10.0, Anchor::CENTER, "OK")
+            .expect("text");
+        w.save().expect("save");
+        w.translate(80.0, 80.0).expect("translate");
+        w.rotate(0.5).expect("rotate");
+        w.clip_rect(0.0, 0.0, 15.0, 15.0).expect("clip");
+        w.rect(PaintMode::Fill, 0.0, 0.0, 30.0, 30.0)
+            .expect("clipped rect");
+        w.restore().expect("restore");
+    });
+    let (res, fb) = render_scene(&bytes, 100, 100);
+    let report = res.expect("renders");
+    assert_eq!(report.status, RenderStatus::Painted);
+    assert_eq!(report.scene_version, 1);
+    assert_eq!(report.unknown_opcodes, 0);
+    assert!(report.layers_present & (1 << LayerId::Attitude.to_u8()) != 0);
+    assert!(painted_any(&fb));
+}
+
+#[test]
+fn boundary_coordinates_render_without_error() {
+    for (x, y, w, h) in [
+        (0.0f32, 0.0f32, 10.0f32, 10.0f32), // origin corner
+        (-5.0, -5.0, 12.0, 12.0),           // negative, partly off-screen
+        (0.25, 0.25, 5.5, 5.5),             // subpixel offsets
+        (30000.0, 0.0, 10.0, 10.0),         // large but in range, fully clipped
+    ] {
+        let bytes = scene(|writer| {
+            writer.fill_color(WHITE).expect("fill");
+            writer.rect(PaintMode::Fill, x, y, w, h).expect("rect");
+        });
+        let (res, _) = render_scene(&bytes, 50, 50);
+        assert!(res.is_ok(), "coords ({x},{y},{w},{h}) should render");
+    }
+}
+
+#[test]
+fn out_of_range_coordinate_fails_and_spoils() {
+    let bytes = scene(|w| {
+        w.fill_color(WHITE).expect("fill");
+        w.rect(PaintMode::Fill, 40000.0, 0.0, 10.0, 10.0)
+            .expect("rect");
+    });
+    let (res, fb) = render_scene(&bytes, 32, 32);
+    assert!(matches!(res, Err(RasterError::CoordinateOutOfRange { .. })));
+    assert_spoiled(&fb);
+}
+
+type Emit = fn(&mut SceneWriter<'_>, f32);
+
+/// One command builder per non-finite-sensitive slot; each places `bad` in a
+/// different coordinate, transform, or size field.
+fn non_finite_slots() -> Vec<Emit> {
+    std::vec![
+        |w, b| w.translate(b, 0.0).expect("enc"),
+        |w, b| w.translate(0.0, b).expect("enc"),
+        |w, b| w.rotate(b).expect("enc"),
+        |w, b| w.stroke(BLACK, b).expect("enc"),
+        |w, b| w.line(b, 0.0, 1.0, 1.0).expect("enc"),
+        |w, b| w.line(0.0, b, 1.0, 1.0).expect("enc"),
+        |w, b| w.line(0.0, 0.0, b, 1.0).expect("enc"),
+        |w, b| w.line(0.0, 0.0, 1.0, b).expect("enc"),
+        |w, b| w.polyline(&[[b, 0.0], [1.0, 1.0]]).expect("enc"),
+        |w, b| w
+            .polygon(PaintMode::Fill, &[[0.0, 0.0], [b, 1.0], [2.0, 2.0]])
+            .expect("enc"),
+        |w, b| w.rect(PaintMode::Fill, b, 0.0, 1.0, 1.0).expect("enc"),
+        |w, b| w.rect(PaintMode::Fill, 0.0, b, 1.0, 1.0).expect("enc"),
+        |w, b| w.rect(PaintMode::Fill, 0.0, 0.0, b, 1.0).expect("enc"),
+        |w, b| w.rect(PaintMode::Fill, 0.0, 0.0, 1.0, b).expect("enc"),
+        |w, b| w.circle(PaintMode::Fill, b, 0.0, 1.0).expect("enc"),
+        |w, b| w.circle(PaintMode::Fill, 0.0, b, 1.0).expect("enc"),
+        |w, b| w.circle(PaintMode::Fill, 0.0, 0.0, b).expect("enc"),
+        |w, b| w.arc(b, 0.0, 1.0, 0.0, 1.0).expect("enc"),
+        |w, b| w.arc(0.0, b, 1.0, 0.0, 1.0).expect("enc"),
+        |w, b| w.arc(0.0, 0.0, b, 0.0, 1.0).expect("enc"),
+        |w, b| w.arc(0.0, 0.0, 1.0, b, 1.0).expect("enc"),
+        |w, b| w.arc(0.0, 0.0, 1.0, 0.0, b).expect("enc"),
+        |w, b| w.text(b, 0.0, 10.0, Anchor::CENTER, "x").expect("enc"),
+        |w, b| w.text(0.0, b, 10.0, Anchor::CENTER, "x").expect("enc"),
+        |w, b| w.text(0.0, 0.0, b, Anchor::CENTER, "x").expect("enc"),
+        |w, b| w.clip_rect(b, 0.0, 1.0, 1.0).expect("enc"),
+        |w, b| w.clip_rect(0.0, b, 1.0, 1.0).expect("enc"),
+        |w, b| w.clip_rect(0.0, 0.0, b, 1.0).expect("enc"),
+        |w, b| w.clip_rect(0.0, 0.0, 1.0, b).expect("enc"),
+    ]
+}
+
+#[test]
+fn non_finite_in_any_slot_fails_and_spoils() {
+    for (i, emit) in non_finite_slots().iter().enumerate() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let bytes = scene(|w| emit(w, bad));
+            let (res, fb) = render_scene(&bytes, 32, 32);
+            assert_eq!(res, Err(RasterError::NonFinite), "slot {i}, value {bad}");
+            assert_spoiled(&fb);
+        }
+    }
+}
+
+#[test]
+fn malformed_payload_fails_and_spoils() {
+    // A LINE opcode (0x20) inside a valid layer but with a 4-byte payload
+    // where 16 are required: the layer decoder rejects it.
+    let mut bytes = std::vec![1u8]; // version
+    push_cmd(&mut bytes, 0x50, &[LayerId::Attitude.to_u8()]); // begin layer
+    push_cmd(&mut bytes, 0x01, &[]); // save (isolation)
+    push_cmd(&mut bytes, 0x20, &[0, 0, 0, 0]); // malformed line
+    push_cmd(&mut bytes, 0x02, &[]); // restore
+    push_cmd(&mut bytes, 0x51, &[LayerId::Attitude.to_u8()]); // end layer
+    let (res, fb) = render_scene(&bytes, 32, 32);
+    assert!(matches!(res, Err(RasterError::Layer(_))));
+    assert_spoiled(&fb);
+}
+
+fn push_cmd(bytes: &mut Vec<u8>, op: u8, payload: &[u8]) {
+    bytes.push(op);
+    bytes.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    bytes.extend_from_slice(payload);
+}
+
+#[test]
+fn unknown_opcode_is_counted_not_fatal() {
+    let mut bytes = std::vec![1u8];
+    push_cmd(&mut bytes, 0x50, &[LayerId::Attitude.to_u8()]);
+    push_cmd(&mut bytes, 0x01, &[]);
+    push_cmd(&mut bytes, 0x7f, &[9, 9]); // unknown opcode, skipped by length
+    push_cmd(&mut bytes, 0x02, &[]);
+    push_cmd(&mut bytes, 0x51, &[LayerId::Attitude.to_u8()]);
+    let (res, _) = render_scene(&bytes, 16, 16);
+    assert_eq!(res.expect("renders").unknown_opcodes, 1);
+}
+
+#[test]
+fn zero_and_oversized_dimensions_are_rejected_before_painting() {
+    let bytes = scene(|w| {
+        w.fill_color(WHITE).expect("fill");
+        w.rect(PaintMode::Fill, 0.0, 0.0, 4.0, 4.0).expect("rect");
+    });
+    let mut fb = std::vec![7u8; 64];
+    assert_eq!(
+        render(
+            &bytes,
+            &mut fb,
+            FramebufferDims::tight(0, 4),
+            FrameId::default()
+        ),
+        Err(RasterError::ZeroFramebuffer)
+    );
+    assert!(
+        fb.iter().all(|&b| b == 7),
+        "geometry error leaves the buffer"
+    );
+    let over = crate::MAX_DIMENSION + 1;
+    assert!(matches!(
+        render(
+            &bytes,
+            &mut fb,
+            FramebufferDims::tight(over, 1),
+            FrameId::default()
+        ),
+        Err(RasterError::FramebufferTooLarge { .. })
+    ));
+}
+
+#[test]
+fn undersized_buffer_is_rejected_before_painting() {
+    let bytes = scene(|w| {
+        w.rect(PaintMode::Fill, 0.0, 0.0, 4.0, 4.0).expect("rect");
+    });
+    let mut fb = std::vec![3u8; 10];
+    assert!(matches!(
+        render(
+            &bytes,
+            &mut fb,
+            FramebufferDims::tight(8, 8),
+            FrameId::default()
+        ),
+        Err(RasterError::FramebufferTooSmall { .. })
+    ));
+    assert!(fb.iter().all(|&b| b == 3));
+}
+
+#[test]
+fn oversized_scene_fails_and_spoils() {
+    let huge = std::vec![0u8; MAX_SCENE_BYTES + 1];
+    let (res, fb) = render_scene(&huge, 32, 32);
+    assert!(matches!(res, Err(RasterError::Layer(_))));
+    assert_spoiled(&fb);
+}
+
+#[test]
+fn maximum_stack_depth_renders() {
+    let bytes = scene(|w| {
+        // The layer isolation save is depth 1; nest 31 more to reach the
+        // budget of 32 without overflowing.
+        for _ in 0..(pilotage_instrument_scene::MAX_STACK_DEPTH - 1) {
+            w.save().expect("save");
+        }
+        w.fill_color(WHITE).expect("fill");
+        w.rect(PaintMode::Fill, 0.0, 0.0, 4.0, 4.0).expect("rect");
+        for _ in 0..(pilotage_instrument_scene::MAX_STACK_DEPTH - 1) {
+            w.restore().expect("restore");
+        }
+    });
+    let (res, fb) = render_scene(&bytes, 16, 16);
+    assert!(res.is_ok());
+    assert!(painted_any(&fb));
+}
+
+#[test]
+fn frame_identifiers_are_echoed() {
+    let bytes = scene(|w| {
+        w.fill_color(WHITE).expect("fill");
+        w.rect(PaintMode::Fill, 0.0, 0.0, 4.0, 4.0).expect("rect");
+    });
+    let mut fb = std::vec![0u8; 16 * 16 * 4];
+    let frame = FrameId {
+        frame_generation: 7,
+        render_generation: 42,
+    };
+    let report = render(&bytes, &mut fb, FramebufferDims::tight(16, 16), frame).expect("renders");
+    assert_eq!(report.frame, frame);
+}
+
+#[test]
+fn failure_overwrites_a_previously_plausible_frame() {
+    // Pre-fill with a believable opaque frame, then fail: nothing of it
+    // may survive.
+    let mut fb = std::vec![0u8; 32 * 32 * 4];
+    for px in fb.chunks_exact_mut(4) {
+        px.copy_from_slice(&[20, 40, 60, 255]);
+    }
+    let bytes = scene(|w| {
+        w.rect(PaintMode::Fill, 40000.0, 0.0, 10.0, 10.0)
+            .expect("rect");
+    });
+    let res = render(
+        &bytes,
+        &mut fb,
+        FramebufferDims::tight(32, 32),
+        FrameId::default(),
+    );
+    assert!(res.is_err());
+    assert_spoiled(&fb);
+    assert!(
+        !fb.chunks_exact(4).any(|px| px == [20, 40, 60, 255]),
+        "no pixel of the stale frame remains"
+    );
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -1,0 +1,148 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_instrument_panels::{PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+use pilotage_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
+use pilotage_instrument_state::{
+    AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
+    Quat, Selections, SnapshotMeta, Stamped, ValidFlags, Wind,
+};
+use pilotage_instrument_state::{FreshnessPolicy, resolve};
+use sha2::{Digest, Sha256};
+use std::vec::Vec;
+
+use crate::{FrameId, FramebufferDims, RenderStatus, render};
+
+// Frame hashes pinned from a byte-reproducible render on the reference
+// rasterizer. `libm` plus IEEE-754 f32 make these identical across the
+// supported CI architectures; a mismatch is a determinism regression, not a
+// value to re-pin casually.
+const PFD_SHA256: &str = "2e54b6332dd9799c71dc550079b8e7b444629d3f6dc45f88533801350a07f0a2";
+const HSI_SHA256: &str = "9fc035d4ae8d7a5467d991bf6ed322ad38a6b0171f5853c05803fbca03db7896";
+
+/// A fixed, richly populated state so every panel band paints content.
+///
+/// The fixture must resolve bit-identically whether or not fail-safe
+/// validation is in the resolution path: trust is declared explicitly
+/// (defaults must not be relied on), and the quaternion's squared
+/// component sum is exactly 1.0 in f32, so a validating resolver's
+/// renormalization divides by exactly 1.0 and changes nothing.
+fn demo_state() -> AircraftState {
+    AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: Quat {
+                    w: 0.5,
+                    x: 0.5,
+                    y: 0.5,
+                    z: 0.5,
+                },
+                rates_rps: [0.02, -0.01, 0.05],
+            }),
+            age_ms: Some(80.0),
+        },
+        kinematics: Stamped {
+            data: Some(Kinematics {
+                pos_ned_m: [1200.0, 340.0, -305.0],
+                vel_ned_mps: [52.0, 9.0, -2.0],
+            }),
+            age_ms: Some(80.0),
+        },
+        air: Stamped {
+            data: Some(AirData {
+                ias_mps: Some(53.0),
+                baro_setting_hpa: Some(1013.2),
+            }),
+            age_ms: Some(80.0),
+        },
+        nav: Stamped {
+            data: Some(NavData {
+                source: NavSource::Gps,
+                course_rad: 0.6,
+                cdi_dots: 0.7,
+                fromto: NavFromTo::To,
+                vdev_dots: Some(-0.4),
+                dist_nm: Some(12.4),
+            }),
+            age_ms: Some(80.0),
+        },
+        wind: Stamped {
+            data: Some(Wind {
+                from_rad: 2.1,
+                speed_mps: 7.5,
+            }),
+            age_ms: Some(80.0),
+        },
+        selections: Selections {
+            heading_bug_rad: 0.5,
+            altitude_sel_m: Some(915.0),
+        },
+        quality: EstimateQuality::Good,
+        valid: ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity: true,
+        },
+        snapshot: SnapshotMeta::default(),
+    }
+}
+
+fn encode(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+    let mut w = SceneWriter::new(&mut buf).expect("writer");
+    build(&mut w);
+    let n = w.finish();
+    buf.truncate(n);
+    buf
+}
+
+fn frame(scene: &[u8]) -> Vec<u8> {
+    let (w, h) = (PANEL_W as u32, PANEL_H as u32);
+    let mut fb = std::vec![0u8; (w * h * 4) as usize];
+    let report = render(
+        scene,
+        &mut fb,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect("panel scene renders");
+    assert_eq!(report.status, RenderStatus::Painted);
+    fb
+}
+
+fn sha_hex(bytes: &[u8]) -> std::string::String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut out = std::string::String::with_capacity(64);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[test]
+fn pfd_frame_hash_is_reproducible_and_pinned() {
+    let data = resolve(&demo_state(), &FreshnessPolicy::default());
+    let scene = encode(|w| draw_pfd(&data, &PfdConfig::default(), w).expect("pfd"));
+    let first = frame(&scene);
+    let second = frame(&scene);
+    assert_eq!(
+        first, second,
+        "PFD frame is bit-reproducible across renders"
+    );
+    assert_eq!(sha_hex(&first), PFD_SHA256);
+}
+
+#[test]
+fn hsi_frame_hash_is_reproducible_and_pinned() {
+    let data = resolve(&demo_state(), &FreshnessPolicy::default());
+    let scene = encode(|w| draw_hsi(&data, w).expect("hsi"));
+    let first = frame(&scene);
+    let second = frame(&scene);
+    assert_eq!(
+        first, second,
+        "HSI frame is bit-reproducible across renders"
+    );
+    assert_eq!(sha_hex(&first), HSI_SHA256);
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -16,8 +16,8 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // rasterizer. `libm` plus IEEE-754 f32 make these identical across the
 // supported CI architectures; a mismatch is a determinism regression, not a
 // value to re-pin casually.
-const PFD_SHA256: &str = "2e54b6332dd9799c71dc550079b8e7b444629d3f6dc45f88533801350a07f0a2";
-const HSI_SHA256: &str = "9fc035d4ae8d7a5467d991bf6ed322ad38a6b0171f5853c05803fbca03db7896";
+const PFD_SHA256: &str = "26ba92ba4250c6573fed08b5f42c22becbe8ec8fa521ab0dde7e8167c0349598";
+const HSI_SHA256: &str = "6edcbc92d936a690a68f0632d2ec20b158d54e59cc9fde6640feefa077b258e3";
 
 /// A fixed, richly populated state so every panel band paints content.
 ///

--- a/crates/pilotage-instrument-raster/src/report.rs
+++ b/crates/pilotage-instrument-raster/src/report.rs
@@ -1,0 +1,66 @@
+//! Framebuffer description and the stateless render report.
+
+/// Pixel geometry of a caller-provided RGBA8 framebuffer.
+///
+/// Pixels are row-major, top-left origin, four bytes each (R, G, B, A),
+/// with `stride_bytes` between the starts of consecutive rows so callers
+/// can render into a sub-window of a larger buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FramebufferDims {
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+    /// Bytes between the starts of consecutive rows (`>= width * 4`).
+    pub stride_bytes: u32,
+}
+
+impl FramebufferDims {
+    /// Dimensions for a tightly packed buffer (`stride = width * 4`).
+    pub const fn tight(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            stride_bytes: width.saturating_mul(4),
+        }
+    }
+}
+
+/// Opaque generation counters echoed back so a caller can correlate a
+/// frame with the render that produced it.
+///
+/// The rasterizer is stateless: it neither reads nor advances these, it
+/// only carries them from input to [`RenderReport`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FrameId {
+    /// The snapshot/frame generation the scene was built from.
+    pub frame_generation: u32,
+    /// The render generation of this paint attempt.
+    pub render_generation: u32,
+}
+
+/// Outcome discriminant of a completed render.
+///
+/// One success variant today; kept an enum so later outcomes (for example
+/// a partial-content status) append without changing the success path's
+/// meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderStatus {
+    /// The full scene painted and self-validated.
+    Painted,
+}
+
+/// What a successful render produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenderReport {
+    /// The scene format version byte that was honored.
+    pub scene_version: u8,
+    /// The completion status.
+    pub status: RenderStatus,
+    /// The echoed frame/render correlation identifiers.
+    pub frame: FrameId,
+    /// Unknown opcodes skipped during painting (version policy).
+    pub unknown_opcodes: u32,
+    /// Bitset of layers present, bit `i` for the layer with discriminant `i`.
+    pub layers_present: u8,
+}

--- a/crates/pilotage-instrument-raster/src/state.rs
+++ b/crates/pilotage-instrument-raster/src/state.rs
@@ -1,0 +1,138 @@
+//! The graphics-state stack: transform, clip, and paints under save/restore.
+
+use pilotage_instrument_scene::{MAX_STACK_DEPTH, Rgba8};
+
+use crate::error::RasterError;
+use crate::fixed::{FRAC_BITS, Fx, HALF};
+use crate::surface::PixelRect;
+use crate::transform::Affine;
+
+/// One saved graphics state: transform, clip, and the active paints.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GraphicsState {
+    /// Current transform matrix.
+    pub(crate) ctm: Affine,
+    /// Current clip rectangle in device pixels.
+    pub(crate) clip: PixelRect,
+    /// Fill color as straight-alpha RGBA8.
+    pub(crate) fill: [u8; 4],
+    /// Stroke color as straight-alpha RGBA8.
+    pub(crate) stroke_color: [u8; 4],
+    /// Stroke width in device pixels (never negative).
+    pub(crate) stroke_width: f32,
+}
+
+fn rgba(color: Rgba8) -> [u8; 4] {
+    [color.r, color.g, color.b, color.a]
+}
+
+/// Rounds a Q8.8 device coordinate to the nearest pixel boundary, matching
+/// the pixel-center coverage rule so clips align with fills.
+fn round_px(raw: i64) -> i32 {
+    ((raw + HALF as i64) >> FRAC_BITS) as i32
+}
+
+/// The transform/clip/paint state and its bounded save stack.
+pub(crate) struct RenderState {
+    current: GraphicsState,
+    stack: [GraphicsState; MAX_STACK_DEPTH],
+    depth: usize,
+}
+
+impl RenderState {
+    /// Starts at identity transform, the surface-bounds clip, and the
+    /// Canvas defaults (opaque black paints, unit stroke width).
+    pub(crate) fn new(clip: PixelRect) -> Self {
+        let current = GraphicsState {
+            ctm: Affine::IDENTITY,
+            clip,
+            fill: [0, 0, 0, 255],
+            stroke_color: [0, 0, 0, 255],
+            stroke_width: 1.0,
+        };
+        Self {
+            current,
+            stack: [current; MAX_STACK_DEPTH],
+            depth: 0,
+        }
+    }
+
+    /// The active graphics state.
+    pub(crate) fn current(&self) -> &GraphicsState {
+        &self.current
+    }
+
+    /// The active transform, mutable for translate/rotate composition.
+    pub(crate) fn ctm_mut(&mut self) -> &mut Affine {
+        &mut self.current.ctm
+    }
+
+    /// Sets the fill paint.
+    pub(crate) fn set_fill(&mut self, color: Rgba8) {
+        self.current.fill = rgba(color);
+    }
+
+    /// Sets the stroke paint; a negative width clamps to zero (paints
+    /// nothing) rather than inverting the offset.
+    pub(crate) fn set_stroke(&mut self, color: Rgba8, width: f32) -> Result<(), RasterError> {
+        if !width.is_finite() {
+            return Err(RasterError::NonFinite);
+        }
+        self.current.stroke_color = rgba(color);
+        self.current.stroke_width = width.max(0.0);
+        Ok(())
+    }
+
+    /// Pushes a copy of the active state.
+    pub(crate) fn save(&mut self) -> Result<(), RasterError> {
+        let slot = self
+            .stack
+            .get_mut(self.depth)
+            .ok_or(RasterError::StackOverflow {
+                limit: MAX_STACK_DEPTH,
+            })?;
+        *slot = self.current;
+        self.depth = self.depth.wrapping_add(1);
+        Ok(())
+    }
+
+    /// Pops to the most recently saved state.
+    pub(crate) fn restore(&mut self) -> Result<(), RasterError> {
+        let depth = self
+            .depth
+            .checked_sub(1)
+            .ok_or(RasterError::UnbalancedRestore)?;
+        self.current = *self
+            .stack
+            .get(depth)
+            .ok_or(RasterError::UnbalancedRestore)?;
+        self.depth = depth;
+        Ok(())
+    }
+
+    /// Intersects the clip with the device-space bounding box of a logical
+    /// rectangle's transformed corners (rect-intersection clipping only;
+    /// under rotation this is the conservative axis-aligned bound).
+    pub(crate) fn clip_rect(&mut self, corners: &[[Fx; 2]; 4]) {
+        let mut min_x = corners[0][0].raw();
+        let mut max_x = min_x;
+        let mut min_y = corners[0][1].raw();
+        let mut max_y = min_y;
+        for corner in &corners[1..] {
+            min_x = min_x.min(corner[0].raw());
+            max_x = max_x.max(corner[0].raw());
+            min_y = min_y.min(corner[1].raw());
+            max_y = max_y.max(corner[1].raw());
+        }
+        let rect = PixelRect {
+            left: round_px(min_x),
+            top: round_px(min_y),
+            right: round_px(max_x),
+            bottom: round_px(max_y),
+        };
+        self.current.clip = self.current.clip.intersect(rect);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/state/tests.rs
+++ b/crates/pilotage-instrument-raster/src/state/tests.rs
@@ -1,0 +1,94 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_instrument_scene::{MAX_STACK_DEPTH, Rgba8};
+
+use super::*;
+use crate::error::RasterError;
+use crate::fixed::Fx;
+use crate::surface::PixelRect;
+
+fn full() -> PixelRect {
+    PixelRect {
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+    }
+}
+
+fn corners(x: f32, y: f32, w: f32, h: f32) -> [[Fx; 2]; 4] {
+    let s = |a: f32, b: f32| [Fx::snap(a).expect("finite"), Fx::snap(b).expect("finite")];
+    [s(x, y), s(x + w, y), s(x + w, y + h), s(x, y + h)]
+}
+
+#[test]
+fn save_restore_round_trips_paints() {
+    let mut st = RenderState::new(full());
+    st.set_fill(Rgba8::rgb(1, 2, 3));
+    st.save().expect("save");
+    st.set_fill(Rgba8::rgb(9, 9, 9));
+    assert_eq!(st.current().fill, [9, 9, 9, 255]);
+    st.restore().expect("restore");
+    assert_eq!(st.current().fill, [1, 2, 3, 255]);
+}
+
+#[test]
+fn stack_overflows_exactly_at_the_budget() {
+    let mut st = RenderState::new(full());
+    for _ in 0..MAX_STACK_DEPTH {
+        st.save().expect("within budget");
+    }
+    assert_eq!(
+        st.save(),
+        Err(RasterError::StackOverflow {
+            limit: MAX_STACK_DEPTH
+        })
+    );
+}
+
+#[test]
+fn restore_without_save_is_unbalanced() {
+    let mut st = RenderState::new(full());
+    assert_eq!(st.restore(), Err(RasterError::UnbalancedRestore));
+}
+
+#[test]
+fn clip_rect_intersects_successive_rectangles() {
+    let mut st = RenderState::new(full());
+    st.clip_rect(&corners(10.0, 10.0, 20.0, 30.0));
+    assert_eq!(
+        st.current().clip,
+        PixelRect {
+            left: 10,
+            top: 10,
+            right: 30,
+            bottom: 40,
+        }
+    );
+    st.clip_rect(&corners(0.0, 0.0, 20.0, 20.0));
+    assert_eq!(
+        st.current().clip,
+        PixelRect {
+            left: 10,
+            top: 10,
+            right: 20,
+            bottom: 20,
+        }
+    );
+}
+
+#[test]
+fn negative_stroke_width_clamps_to_zero() {
+    let mut st = RenderState::new(full());
+    st.set_stroke(Rgba8::rgb(0, 0, 0), -4.0).expect("finite");
+    assert_eq!(st.current().stroke_width, 0.0);
+}
+
+#[test]
+fn non_finite_stroke_width_is_rejected() {
+    let mut st = RenderState::new(full());
+    assert_eq!(
+        st.set_stroke(Rgba8::rgb(0, 0, 0), f32::NAN),
+        Err(RasterError::NonFinite)
+    );
+}

--- a/crates/pilotage-instrument-raster/src/stroke.rs
+++ b/crates/pilotage-instrument-raster/src/stroke.rs
@@ -1,0 +1,107 @@
+//! Stroking as a union of capsules (round joins and caps).
+//!
+//! Stroke semantics: a stroke is centered on its path, half its width to
+//! each side. A pixel is painted when its center lies within `width / 2` of
+//! the path, treating the path as the union of round-ended capsules over its
+//! segments. Round joins and round caps therefore fall out of the distance
+//! test rather than needing a separate construction, and each pixel is
+//! tested once so overlapping segments never composite a pixel twice. Width
+//! is in device pixels (equal to logical width under this rigid transform).
+
+use crate::fixed::Fx;
+use crate::surface::{PixelRect, Surface};
+
+/// Strokes the path through `verts` (closed when `closed`) at `width`.
+pub(crate) fn stroke_path(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    verts: &[[Fx; 2]],
+    closed: bool,
+    width: f32,
+    color: [u8; 4],
+) {
+    if width <= 0.0 || verts.is_empty() || clip.is_empty() {
+        return;
+    }
+    let hw = width / 2.0;
+    let region = bounds(verts, hw).intersect(clip);
+    if region.is_empty() {
+        return;
+    }
+    let seg_count = if verts.len() == 1 {
+        0
+    } else if closed {
+        verts.len()
+    } else {
+        verts.len() - 1
+    };
+    for py in region.top..region.bottom {
+        let cy = py as f32 + 0.5;
+        for px in region.left..region.right {
+            let cx = px as f32 + 0.5;
+            if covered(verts, seg_count, cx, cy, hw) {
+                surface.composite(px, py, color);
+            }
+        }
+    }
+}
+
+/// Whether the pixel center is within `hw` of any segment (or the single
+/// vertex, for a one-point path).
+fn covered(verts: &[[Fx; 2]], seg_count: usize, cx: f32, cy: f32, hw: f32) -> bool {
+    if seg_count == 0 {
+        return point_dist(verts[0], cx, cy) <= hw;
+    }
+    let n = verts.len();
+    for i in 0..seg_count {
+        if seg_dist(verts[i], verts[(i + 1) % n], cx, cy) <= hw {
+            return true;
+        }
+    }
+    false
+}
+
+fn point_dist(p: [Fx; 2], cx: f32, cy: f32) -> f32 {
+    let dx = cx - p[0].to_f32();
+    let dy = cy - p[1].to_f32();
+    libm::sqrtf(dx * dx + dy * dy)
+}
+
+/// Distance from `(cx, cy)` to the segment `a`–`b`.
+fn seg_dist(a: [Fx; 2], b: [Fx; 2], cx: f32, cy: f32) -> f32 {
+    let (ax, ay) = (a[0].to_f32(), a[1].to_f32());
+    let ex = b[0].to_f32() - ax;
+    let ey = b[1].to_f32() - ay;
+    let len2 = ex * ex + ey * ey;
+    let t = if len2 <= 0.0 {
+        0.0
+    } else {
+        (((cx - ax) * ex + (cy - ay) * ey) / len2).clamp(0.0, 1.0)
+    };
+    let qx = ax + t * ex;
+    let qy = ay + t * ey;
+    libm::sqrtf((cx - qx) * (cx - qx) + (cy - qy) * (cy - qy))
+}
+
+/// Pixel bounding box of the path expanded by the half-width.
+fn bounds(verts: &[[Fx; 2]], hw: f32) -> PixelRect {
+    let mut min_x = verts[0][0].to_f32();
+    let mut max_x = min_x;
+    let mut min_y = verts[0][1].to_f32();
+    let mut max_y = min_y;
+    for v in &verts[1..] {
+        min_x = min_x.min(v[0].to_f32());
+        max_x = max_x.max(v[0].to_f32());
+        min_y = min_y.min(v[1].to_f32());
+        max_y = max_y.max(v[1].to_f32());
+    }
+    PixelRect {
+        left: libm::floorf(min_x - hw) as i32,
+        top: libm::floorf(min_y - hw) as i32,
+        right: libm::ceilf(max_x + hw) as i32 + 1,
+        bottom: libm::ceilf(max_y + hw) as i32 + 1,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/stroke/tests.rs
+++ b/crates/pilotage-instrument-raster/src/stroke/tests.rs
@@ -1,0 +1,76 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec::Vec;
+
+use super::*;
+use crate::report::FramebufferDims;
+use crate::surface::Surface;
+
+const RED: [u8; 4] = [255, 0, 0, 255];
+
+fn verts(coords: &[(f32, f32)]) -> Vec<[Fx; 2]> {
+    coords
+        .iter()
+        .map(|&(x, y)| [Fx::snap(x).expect("finite"), Fx::snap(y).expect("finite")])
+        .collect()
+}
+
+fn painted(w: u32, h: u32, draw: impl FnOnce(&mut Surface<'_>)) -> Vec<u8> {
+    let mut buf = std::vec![0u8; (w * h * 4) as usize];
+    {
+        let mut s = Surface::new(&mut buf, FramebufferDims::tight(w, h)).expect("surface");
+        draw(&mut s);
+    }
+    buf
+}
+
+fn covered_px(buf: &[u8], w: u32, x: u32, y: u32) -> bool {
+    let at = ((y * w + x) * 4) as usize;
+    buf[at + 3] != 0
+}
+
+#[test]
+fn horizontal_line_has_the_requested_width() {
+    let line = verts(&[(2.0, 4.0), (6.0, 4.0)]);
+    let buf = painted(8, 8, |s| stroke_path(s, s.bounds(), &line, false, 2.0, RED));
+    // A width-2 centered stroke covers the two rows within half a pixel.
+    assert!(covered_px(&buf, 8, 4, 3));
+    assert!(covered_px(&buf, 8, 4, 4));
+    assert!(!covered_px(&buf, 8, 4, 2));
+    assert!(!covered_px(&buf, 8, 4, 5));
+}
+
+#[test]
+fn round_caps_extend_past_the_endpoints() {
+    let line = verts(&[(2.0, 4.0), (6.0, 4.0)]);
+    let buf = painted(8, 8, |s| stroke_path(s, s.bounds(), &line, false, 2.0, RED));
+    assert!(covered_px(&buf, 8, 6, 4), "cap reaches just past the end");
+    assert!(!covered_px(&buf, 8, 7, 4), "but not a full pixel beyond");
+}
+
+#[test]
+fn zero_width_paints_nothing() {
+    let line = verts(&[(0.0, 0.0), (8.0, 8.0)]);
+    let buf = painted(8, 8, |s| stroke_path(s, s.bounds(), &line, false, 0.0, RED));
+    assert!(buf.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn single_point_path_draws_a_round_dot() {
+    let dot = verts(&[(4.0, 4.0)]);
+    let buf = painted(8, 8, |s| stroke_path(s, s.bounds(), &dot, false, 3.0, RED));
+    assert!(covered_px(&buf, 8, 4, 4));
+    assert!(!covered_px(&buf, 8, 0, 0));
+}
+
+#[test]
+fn closed_path_strokes_the_closing_edge() {
+    // The open path draws the top and hypotenuse edges; the closing edge is
+    // the left vertical from (1,6) back to (1,1).
+    let tri = verts(&[(1.0, 1.0), (6.0, 1.0), (1.0, 6.0)]);
+    let open = painted(8, 8, |s| stroke_path(s, s.bounds(), &tri, false, 1.0, RED));
+    let closed = painted(8, 8, |s| stroke_path(s, s.bounds(), &tri, true, 1.0, RED));
+    // A point on the left edge is covered only once the path is closed.
+    assert!(!covered_px(&open, 8, 1, 3));
+    assert!(covered_px(&closed, 8, 1, 3));
+}

--- a/crates/pilotage-instrument-raster/src/surface.rs
+++ b/crates/pilotage-instrument-raster/src/surface.rs
@@ -1,0 +1,178 @@
+//! The RGBA8 device surface: geometry, clipping, compositing, and spoiling.
+//!
+//! Pixels are straight-alpha sRGB (R, G, B, A), row-major, top-left origin.
+//! Compositing is source-over performed directly on the sRGB-encoded 8-bit
+//! channels — a defined, colorimetrically simplified rule chosen so a frame
+//! is bit-reproducible on every target, with all division rounded to nearest
+//! by integer arithmetic. Coverage is sampled once per pixel per primitive,
+//! so a translucent shape never composites a pixel against itself.
+
+use crate::error::RasterError;
+use crate::report::FramebufferDims;
+
+/// A half-open pixel rectangle used for clip regions and shape bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PixelRect {
+    /// Inclusive left column.
+    pub(crate) left: i32,
+    /// Inclusive top row.
+    pub(crate) top: i32,
+    /// Exclusive right column.
+    pub(crate) right: i32,
+    /// Exclusive bottom row.
+    pub(crate) bottom: i32,
+}
+
+impl PixelRect {
+    /// The intersection of two rectangles, possibly empty.
+    pub(crate) fn intersect(self, other: Self) -> Self {
+        Self {
+            left: self.left.max(other.left),
+            top: self.top.max(other.top),
+            right: self.right.min(other.right),
+            bottom: self.bottom.min(other.bottom),
+        }
+    }
+
+    /// Whether the rectangle covers no pixels.
+    pub(crate) fn is_empty(self) -> bool {
+        self.right <= self.left || self.bottom <= self.top
+    }
+}
+
+/// An sRGB straight-alpha RGBA8 render target borrowed from the caller.
+pub(crate) struct Surface<'a> {
+    pixels: &'a mut [u8],
+    width: i32,
+    height: i32,
+    stride: usize,
+}
+
+impl<'a> Surface<'a> {
+    /// Validates framebuffer geometry and borrows the pixel slice. All
+    /// failures here are raised before any pixel is touched.
+    pub(crate) fn new(pixels: &'a mut [u8], dims: FramebufferDims) -> Result<Self, RasterError> {
+        if dims.width == 0 || dims.height == 0 {
+            return Err(RasterError::ZeroFramebuffer);
+        }
+        if dims.width > crate::MAX_DIMENSION || dims.height > crate::MAX_DIMENSION {
+            return Err(RasterError::FramebufferTooLarge {
+                width: dims.width,
+                height: dims.height,
+                limit: crate::MAX_DIMENSION,
+            });
+        }
+        let min_row = dims.width as usize * 4;
+        let stride = dims.stride_bytes as usize;
+        if stride < min_row {
+            return Err(RasterError::StrideTooSmall {
+                stride_bytes: stride,
+                min_bytes: min_row,
+            });
+        }
+        let need = (dims.height as usize - 1) * stride + min_row;
+        if pixels.len() < need {
+            return Err(RasterError::FramebufferTooSmall {
+                need,
+                have: pixels.len(),
+            });
+        }
+        Ok(Self {
+            pixels,
+            width: dims.width as i32,
+            height: dims.height as i32,
+            stride,
+        })
+    }
+
+    /// The full-surface clip rectangle.
+    pub(crate) fn bounds(&self) -> PixelRect {
+        PixelRect {
+            left: 0,
+            top: 0,
+            right: self.width,
+            bottom: self.height,
+        }
+    }
+
+    fn index(&self, x: i32, y: i32) -> Option<usize> {
+        if x < 0 || y < 0 || x >= self.width || y >= self.height {
+            return None;
+        }
+        Some(y as usize * self.stride + x as usize * 4)
+    }
+
+    /// Clears the frame region to transparent black, the defined initial
+    /// state before any command paints.
+    pub(crate) fn clear(&mut self) {
+        let row_bytes = self.width as usize * 4;
+        for y in 0..self.height {
+            let start = y as usize * self.stride;
+            if let Some(row) = self.pixels.get_mut(start..start + row_bytes) {
+                row.fill(0);
+            }
+        }
+    }
+
+    /// Composites one straight-alpha sRGB pixel with source-over.
+    pub(crate) fn composite(&mut self, x: i32, y: i32, color: [u8; 4]) {
+        let sa = color[3] as u32;
+        if sa == 0 {
+            return;
+        }
+        let Some(idx) = self.index(x, y) else {
+            return;
+        };
+        let Some(px) = self.pixels.get_mut(idx..idx + 4) else {
+            return;
+        };
+        if sa == 255 {
+            px.copy_from_slice(&color);
+            return;
+        }
+        let inv = 255 - sa;
+        let da = px[3] as u32;
+        let out_a = sa + div255(da * inv);
+        let denom = out_a * 255;
+        for c in 0..3 {
+            let num = color[c] as u32 * sa * 255 + px[c] as u32 * da * inv;
+            px[c] = ((num + denom / 2) / denom) as u8;
+        }
+        px[3] = out_a as u8;
+    }
+
+    /// Overwrites the entire frame with the unmistakable failure pattern:
+    /// opaque black plus a red diagonal cross, by direct writes that cannot
+    /// fail, so no plausible frame survives an error.
+    pub(crate) fn spoil(&mut self) {
+        for y in 0..self.height {
+            for x in 0..self.width {
+                self.put(x, y, [0, 0, 0, 255]);
+            }
+        }
+        let thickness = 1 + self.width.min(self.height) / 128;
+        for x in 0..self.width {
+            let y = (x as i64 * (self.height - 1) as i64 / (self.width.max(2) - 1) as i64) as i32;
+            for t in -thickness..=thickness {
+                self.put(x, y + t, [255, 0, 0, 255]);
+                self.put(x, self.height - 1 - y + t, [255, 0, 0, 255]);
+            }
+        }
+    }
+
+    fn put(&mut self, x: i32, y: i32, color: [u8; 4]) {
+        if let Some(idx) = self.index(x, y)
+            && let Some(px) = self.pixels.get_mut(idx..idx + 4)
+        {
+            px.copy_from_slice(&color);
+        }
+    }
+}
+
+/// Round-to-nearest division by 255 for a channel product.
+fn div255(v: u32) -> u32 {
+    ((v + 128) * 257) >> 16
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/surface/tests.rs
+++ b/crates/pilotage-instrument-raster/src/surface/tests.rs
@@ -1,0 +1,120 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::error::RasterError;
+
+fn dims(w: u32, h: u32) -> FramebufferDims {
+    FramebufferDims::tight(w, h)
+}
+
+#[test]
+fn rejects_zero_dimensions() {
+    let mut buf = [0u8; 16];
+    assert_eq!(
+        Surface::new(&mut buf, dims(0, 4)).err(),
+        Some(RasterError::ZeroFramebuffer)
+    );
+    assert_eq!(
+        Surface::new(&mut buf, dims(4, 0)).err(),
+        Some(RasterError::ZeroFramebuffer)
+    );
+}
+
+#[test]
+fn rejects_oversized_dimensions() {
+    let mut buf = [0u8; 16];
+    let over = crate::MAX_DIMENSION + 1;
+    assert!(matches!(
+        Surface::new(&mut buf, dims(over, 1)),
+        Err(RasterError::FramebufferTooLarge { .. })
+    ));
+}
+
+#[test]
+fn rejects_short_stride_and_slice() {
+    let mut buf = [0u8; 64];
+    assert!(matches!(
+        Surface::new(
+            &mut buf,
+            FramebufferDims {
+                width: 4,
+                height: 4,
+                stride_bytes: 8,
+            }
+        ),
+        Err(RasterError::StrideTooSmall { .. })
+    ));
+    let mut small = [0u8; 15];
+    assert!(matches!(
+        Surface::new(&mut small, dims(2, 2)),
+        Err(RasterError::FramebufferTooSmall { .. })
+    ));
+}
+
+#[test]
+fn opaque_source_overwrites() {
+    let mut buf = [9u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.composite(0, 0, [10, 20, 30, 255]);
+    assert_eq!(&buf[0..4], &[10, 20, 30, 255]);
+}
+
+#[test]
+fn transparent_source_is_a_no_op() {
+    let mut buf = [7u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.composite(1, 1, [1, 2, 3, 0]);
+    assert_eq!(&buf[12..16], &[7, 7, 7, 7]);
+}
+
+#[test]
+fn half_alpha_over_transparent_recovers_the_source_color() {
+    let mut buf = [0u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.composite(0, 0, [200, 100, 50, 128]);
+    assert_eq!(&buf[0..4], &[200, 100, 50, 128]);
+}
+
+#[test]
+fn half_alpha_over_opaque_rounds_to_nearest() {
+    let mut buf = [0u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.composite(0, 0, [100, 100, 100, 255]);
+    s.composite(0, 0, [0, 0, 0, 128]);
+    assert_eq!(&buf[0..4], &[50, 50, 50, 255]);
+}
+
+#[test]
+fn clear_zeroes_the_frame_region() {
+    let mut buf = [5u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.clear();
+    assert!(buf.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn out_of_bounds_composite_is_ignored() {
+    let mut buf = [0u8; 16];
+    let mut s = Surface::new(&mut buf, dims(2, 2)).expect("surface");
+    s.composite(-1, 0, [1, 1, 1, 255]);
+    s.composite(2, 0, [1, 1, 1, 255]);
+    s.composite(0, 2, [1, 1, 1, 255]);
+    assert!(buf.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn spoil_paints_opaque_black_with_a_red_cross() {
+    let mut buf = std::vec![0u8; 16 * 16 * 4];
+    let mut s = Surface::new(&mut buf, dims(16, 16)).expect("surface");
+    s.spoil();
+    // Every pixel is opaque: a spoiled frame can never read as transparent.
+    assert!(buf.chunks_exact(4).all(|px| px[3] == 255));
+    // The top-left corner is on the main diagonal and painted red.
+    assert_eq!(&buf[0..4], &[255, 0, 0, 255]);
+    // A pixel off both diagonals stays black.
+    let off = (10 * 16 + 2) * 4;
+    assert_eq!(&buf[off..off + 4], &[0, 0, 0, 255]);
+    // The cross is visibly present.
+    let red = buf.chunks_exact(4).filter(|px| px[0] == 255).count();
+    assert!(red >= 16);
+}

--- a/crates/pilotage-instrument-raster/src/text.rs
+++ b/crates/pilotage-instrument-raster/src/text.rs
@@ -1,82 +1,87 @@
-//! The pre-glyph-pack text contract: a deterministic placeholder box.
+//! Text through the controlled glyph pack (REN-02's contract).
 //!
-//! Until REN-02's glyph pack lands, a [`Cmd::Text`](pilotage_instrument_scene::Cmd::Text)
-//! run renders as a stroked bounding box whose extent is a pure function of
-//! the run's `size`, `anchor`, and UTF-8 byte length — never of any platform
-//! font metrics — so frame hashes stay stable and swap cleanly for real
-//! glyphs later. The box is stroked in the current fill color (text paints
-//! with the fill color) at a fixed width; an empty run or a non-positive
-//! size paints nothing.
+//! Each character renders from the verified bitmap manifest in
+//! `pilotage-instrument-glyphs`: every set cell pixel becomes a logical
+//! quad scaled by the run size and transformed like any other geometry,
+//! so text obeys the same quantization boundary, clipping, and
+//! compositing rules as primitives, with no platform font API anywhere.
+//! A character without a glyph is a typed failure — nothing substitutes.
+//! An empty run or a non-positive size paints nothing.
+//!
+//! Metrics are the manifest's: the run `size` maps to the cell height,
+//! the pen advances by the manifest advance, and the bitmap sits
+//! entirely above its baseline (descent zero), so `Bottom` anchors
+//! coincide with `Baseline`.
 
+use pilotage_instrument_glyphs::{ADVANCE, CELL_H, CELL_W, PANEL_GLYPHS};
 use pilotage_instrument_scene::{Anchor, HAlign, VAlign};
 
 use crate::error::RasterError;
-use crate::stroke::stroke_path;
+use crate::paint::fill_polygon;
 use crate::surface::{PixelRect, Surface};
 use crate::transform::Affine;
 
-/// Logical advance width per UTF-8 byte, as a fraction of the run size.
-const ADVANCE_RATIO: f32 = 0.6;
-
-/// Logical box height above the anchored baseline, as a fraction of size.
-const ASCENT_RATIO: f32 = 0.75;
-
-/// Logical box height below the baseline, as a fraction of size.
-const DESCENT_RATIO: f32 = 0.25;
-
-/// Stroke width of the placeholder box, in device pixels.
-const BOX_STROKE: f32 = 1.0;
-
-/// Renders the placeholder box for a text run using the current fill color.
-pub(crate) fn draw_placeholder(
+/// Renders a text run from the glyph pack using the current fill color.
+pub(crate) fn draw_run(
     surface: &mut Surface<'_>,
     clip: PixelRect,
     ctm: &Affine,
-    run: Run,
+    run: Run<'_>,
     color: [u8; 4],
 ) -> Result<(), RasterError> {
-    if run.byte_len == 0 || run.size <= 0.0 {
+    if run.text.is_empty() || run.size <= 0.0 {
         return Ok(());
     }
-    let w = run.byte_len as f32 * ADVANCE_RATIO * run.size;
+    let scale = run.size / CELL_H as f32;
+    let advance = f32::from(ADVANCE) * scale;
+    let width = run.text.chars().count() as f32 * advance;
     let left = match run.anchor.h {
         HAlign::Left => run.x,
-        HAlign::Center => run.x - w / 2.0,
-        HAlign::Right => run.x - w,
+        HAlign::Center => run.x - width / 2.0,
+        HAlign::Right => run.x - width,
     };
-    let (top, bottom) = match run.anchor.v {
-        VAlign::Baseline => (
-            run.y - ASCENT_RATIO * run.size,
-            run.y + DESCENT_RATIO * run.size,
-        ),
-        VAlign::Top => (run.y, run.y + run.size),
-        VAlign::Bottom => (run.y - run.size, run.y),
-        VAlign::Middle => (run.y - run.size / 2.0, run.y + run.size / 2.0),
+    let top = match run.anchor.v {
+        VAlign::Baseline | VAlign::Bottom => run.y - run.size,
+        VAlign::Top => run.y,
+        VAlign::Middle => run.y - run.size / 2.0,
     };
-    let right = left + w;
-    let corners = [
-        ctm.map(left, top)?,
-        ctm.map(right, top)?,
-        ctm.map(right, bottom)?,
-        ctm.map(left, bottom)?,
-    ];
-    stroke_path(surface, clip, &corners, true, BOX_STROKE, color);
+    let mut pen = left;
+    for ch in run.text.chars() {
+        let glyph = PANEL_GLYPHS.glyph(ch)?.glyph;
+        for row in 0..CELL_H {
+            for col in 0..CELL_W {
+                if !glyph.pixel(col, row) {
+                    continue;
+                }
+                let x0 = pen + col as f32 * scale;
+                let y0 = top + row as f32 * scale;
+                let quad = [
+                    ctm.map(x0, y0)?,
+                    ctm.map(x0 + scale, y0)?,
+                    ctm.map(x0 + scale, y0 + scale)?,
+                    ctm.map(x0, y0 + scale)?,
+                ];
+                fill_polygon(surface, clip, &quad, color);
+            }
+        }
+        pen += advance;
+    }
     Ok(())
 }
 
-/// A text run's placeholder-relevant fields.
+/// A text run.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Run {
+pub(crate) struct Run<'a> {
     /// Anchor point x in logical units.
     pub(crate) x: f32,
     /// Anchor point y in logical units.
     pub(crate) y: f32,
-    /// Run size in logical units.
+    /// Run size in logical units (maps to the glyph cell height).
     pub(crate) size: f32,
     /// Text positioning.
     pub(crate) anchor: Anchor,
-    /// UTF-8 byte length of the run.
-    pub(crate) byte_len: usize,
+    /// The UTF-8 text.
+    pub(crate) text: &'a str,
 }
 
 #[cfg(test)]

--- a/crates/pilotage-instrument-raster/src/text.rs
+++ b/crates/pilotage-instrument-raster/src/text.rs
@@ -1,0 +1,83 @@
+//! The pre-glyph-pack text contract: a deterministic placeholder box.
+//!
+//! Until REN-02's glyph pack lands, a [`Cmd::Text`](pilotage_instrument_scene::Cmd::Text)
+//! run renders as a stroked bounding box whose extent is a pure function of
+//! the run's `size`, `anchor`, and UTF-8 byte length — never of any platform
+//! font metrics — so frame hashes stay stable and swap cleanly for real
+//! glyphs later. The box is stroked in the current fill color (text paints
+//! with the fill color) at a fixed width; an empty run or a non-positive
+//! size paints nothing.
+
+use pilotage_instrument_scene::{Anchor, HAlign, VAlign};
+
+use crate::error::RasterError;
+use crate::stroke::stroke_path;
+use crate::surface::{PixelRect, Surface};
+use crate::transform::Affine;
+
+/// Logical advance width per UTF-8 byte, as a fraction of the run size.
+const ADVANCE_RATIO: f32 = 0.6;
+
+/// Logical box height above the anchored baseline, as a fraction of size.
+const ASCENT_RATIO: f32 = 0.75;
+
+/// Logical box height below the baseline, as a fraction of size.
+const DESCENT_RATIO: f32 = 0.25;
+
+/// Stroke width of the placeholder box, in device pixels.
+const BOX_STROKE: f32 = 1.0;
+
+/// Renders the placeholder box for a text run using the current fill color.
+pub(crate) fn draw_placeholder(
+    surface: &mut Surface<'_>,
+    clip: PixelRect,
+    ctm: &Affine,
+    run: Run,
+    color: [u8; 4],
+) -> Result<(), RasterError> {
+    if run.byte_len == 0 || run.size <= 0.0 {
+        return Ok(());
+    }
+    let w = run.byte_len as f32 * ADVANCE_RATIO * run.size;
+    let left = match run.anchor.h {
+        HAlign::Left => run.x,
+        HAlign::Center => run.x - w / 2.0,
+        HAlign::Right => run.x - w,
+    };
+    let (top, bottom) = match run.anchor.v {
+        VAlign::Baseline => (
+            run.y - ASCENT_RATIO * run.size,
+            run.y + DESCENT_RATIO * run.size,
+        ),
+        VAlign::Top => (run.y, run.y + run.size),
+        VAlign::Bottom => (run.y - run.size, run.y),
+        VAlign::Middle => (run.y - run.size / 2.0, run.y + run.size / 2.0),
+    };
+    let right = left + w;
+    let corners = [
+        ctm.map(left, top)?,
+        ctm.map(right, top)?,
+        ctm.map(right, bottom)?,
+        ctm.map(left, bottom)?,
+    ];
+    stroke_path(surface, clip, &corners, true, BOX_STROKE, color);
+    Ok(())
+}
+
+/// A text run's placeholder-relevant fields.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Run {
+    /// Anchor point x in logical units.
+    pub(crate) x: f32,
+    /// Anchor point y in logical units.
+    pub(crate) y: f32,
+    /// Run size in logical units.
+    pub(crate) size: f32,
+    /// Text positioning.
+    pub(crate) anchor: Anchor,
+    /// UTF-8 byte length of the run.
+    pub(crate) byte_len: usize,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/text/tests.rs
+++ b/crates/pilotage-instrument-raster/src/text/tests.rs
@@ -2,61 +2,90 @@
 
 use std::vec::Vec;
 
+use pilotage_instrument_glyphs::GlyphError;
 use pilotage_instrument_scene::{Anchor, HAlign, VAlign};
 
 use super::*;
+use crate::error::RasterError;
 use crate::report::FramebufferDims;
 use crate::surface::Surface;
 use crate::transform::Affine;
 
 const WHITE: [u8; 4] = [255, 255, 255, 255];
 
-fn painted(run: Run) -> Vec<u8> {
-    let mut buf = std::vec![0u8; 40 * 40 * 4];
+fn painted(run: Run<'_>) -> Result<Vec<u8>, RasterError> {
+    let mut buf = std::vec![0u8; 64 * 64 * 4];
     {
-        let mut s = Surface::new(&mut buf, FramebufferDims::tight(40, 40)).expect("surface");
+        let mut s = Surface::new(&mut buf, FramebufferDims::tight(64, 64)).expect("surface");
         let clip = s.bounds();
-        draw_placeholder(&mut s, clip, &Affine::IDENTITY, run, WHITE).expect("finite run");
+        draw_run(&mut s, clip, &Affine::IDENTITY, run, WHITE)?;
     }
-    buf
+    Ok(buf)
 }
 
 fn covered(buf: &[u8], x: u32, y: u32) -> bool {
-    buf[((y * 40 + x) * 4 + 3) as usize] != 0
+    buf[((y * 64 + x) * 4 + 3) as usize] != 0
 }
 
-fn run(x: f32, y: f32, size: f32, anchor: Anchor, byte_len: usize) -> Run {
+fn run(x: f32, y: f32, size: f32, anchor: Anchor, text: &str) -> Run<'_> {
     Run {
         x,
         y,
         size,
         anchor,
-        byte_len,
+        text,
     }
 }
 
 #[test]
 fn empty_run_paints_nothing() {
-    let buf = painted(run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, 0));
+    let buf = painted(run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, "")).expect("empty ok");
     assert!(buf.iter().all(|&b| b == 0));
 }
 
 #[test]
 fn non_positive_size_paints_nothing() {
-    let buf = painted(run(5.0, 20.0, 0.0, Anchor::BASELINE_LEFT, 3));
+    let buf = painted(run(5.0, 20.0, 0.0, Anchor::BASELINE_LEFT, "123")).expect("zero size ok");
     assert!(buf.iter().all(|&b| b == 0));
 }
 
 #[test]
-fn placeholder_draws_a_hollow_box() {
-    let buf = painted(run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, 3));
-    // Left edge of the box is painted; its interior is hollow.
-    assert!(covered(&buf, 5, 17), "left edge painted");
-    assert!(!covered(&buf, 14, 17), "interior hollow");
+fn glyph_pixels_paint_above_the_baseline() {
+    // "1" at cell-native scale (size == cell height * 2 = 14): pixels land
+    // strictly within [x, x+advance) x [y-size, y).
+    let buf = painted(run(8.0, 40.0, 14.0, Anchor::BASELINE_LEFT, "1")).expect("renders");
+    assert!(!buf.iter().all(|&b| b == 0), "glyph painted something");
+    for y in 0..64 {
+        for x in 0..64 {
+            if covered(&buf, x, y) {
+                assert!((8..20).contains(&x), "x {x} inside the advance box");
+                assert!((26..40).contains(&y), "y {y} above the baseline");
+            }
+        }
+    }
 }
 
 #[test]
-fn horizontal_anchor_shifts_the_box() {
+fn uncovered_character_is_a_typed_failure_never_a_substitute() {
+    let mut buf = std::vec![0u8; 64 * 64 * 4];
+    let mut s = Surface::new(&mut buf, FramebufferDims::tight(64, 64)).expect("surface");
+    let clip = s.bounds();
+    let err = draw_run(
+        &mut s,
+        clip,
+        &Affine::IDENTITY,
+        run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, "\u{00e9}"),
+        WHITE,
+    )
+    .expect_err("no glyph for e-acute");
+    assert!(matches!(
+        err,
+        RasterError::Glyph(GlyphError::MissingGlyph { .. })
+    ));
+}
+
+#[test]
+fn horizontal_anchor_shifts_the_run() {
     let top = Anchor {
         h: HAlign::Left,
         v: VAlign::Top,
@@ -65,14 +94,14 @@ fn horizontal_anchor_shifts_the_box() {
         h: HAlign::Center,
         v: VAlign::Top,
     };
-    let left = painted(run(20.0, 5.0, 10.0, top, 3));
-    let center = painted(run(20.0, 5.0, 10.0, centered, 3));
-    assert_ne!(left, center, "anchor changes the box position");
+    let left = painted(run(30.0, 5.0, 10.0, top, "88")).expect("renders");
+    let center = painted(run(30.0, 5.0, 10.0, centered, "88")).expect("renders");
+    assert_ne!(left, center, "anchor changes the run position");
 }
 
 #[test]
-fn placeholder_is_deterministic() {
-    let a = painted(run(5.0, 20.0, 10.0, Anchor::CENTER, 4));
-    let b = painted(run(5.0, 20.0, 10.0, Anchor::CENTER, 4));
+fn glyph_text_is_deterministic() {
+    let a = painted(run(5.0, 30.0, 12.0, Anchor::CENTER, "360\u{00b0}")).expect("renders");
+    let b = painted(run(5.0, 30.0, 12.0, Anchor::CENTER, "360\u{00b0}")).expect("renders");
     assert_eq!(a, b);
 }

--- a/crates/pilotage-instrument-raster/src/text/tests.rs
+++ b/crates/pilotage-instrument-raster/src/text/tests.rs
@@ -1,0 +1,78 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec::Vec;
+
+use pilotage_instrument_scene::{Anchor, HAlign, VAlign};
+
+use super::*;
+use crate::report::FramebufferDims;
+use crate::surface::Surface;
+use crate::transform::Affine;
+
+const WHITE: [u8; 4] = [255, 255, 255, 255];
+
+fn painted(run: Run) -> Vec<u8> {
+    let mut buf = std::vec![0u8; 40 * 40 * 4];
+    {
+        let mut s = Surface::new(&mut buf, FramebufferDims::tight(40, 40)).expect("surface");
+        let clip = s.bounds();
+        draw_placeholder(&mut s, clip, &Affine::IDENTITY, run, WHITE).expect("finite run");
+    }
+    buf
+}
+
+fn covered(buf: &[u8], x: u32, y: u32) -> bool {
+    buf[((y * 40 + x) * 4 + 3) as usize] != 0
+}
+
+fn run(x: f32, y: f32, size: f32, anchor: Anchor, byte_len: usize) -> Run {
+    Run {
+        x,
+        y,
+        size,
+        anchor,
+        byte_len,
+    }
+}
+
+#[test]
+fn empty_run_paints_nothing() {
+    let buf = painted(run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, 0));
+    assert!(buf.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn non_positive_size_paints_nothing() {
+    let buf = painted(run(5.0, 20.0, 0.0, Anchor::BASELINE_LEFT, 3));
+    assert!(buf.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn placeholder_draws_a_hollow_box() {
+    let buf = painted(run(5.0, 20.0, 10.0, Anchor::BASELINE_LEFT, 3));
+    // Left edge of the box is painted; its interior is hollow.
+    assert!(covered(&buf, 5, 17), "left edge painted");
+    assert!(!covered(&buf, 14, 17), "interior hollow");
+}
+
+#[test]
+fn horizontal_anchor_shifts_the_box() {
+    let top = Anchor {
+        h: HAlign::Left,
+        v: VAlign::Top,
+    };
+    let centered = Anchor {
+        h: HAlign::Center,
+        v: VAlign::Top,
+    };
+    let left = painted(run(20.0, 5.0, 10.0, top, 3));
+    let center = painted(run(20.0, 5.0, 10.0, centered, 3));
+    assert_ne!(left, center, "anchor changes the box position");
+}
+
+#[test]
+fn placeholder_is_deterministic() {
+    let a = painted(run(5.0, 20.0, 10.0, Anchor::CENTER, 4));
+    let b = painted(run(5.0, 20.0, 10.0, Anchor::CENTER, 4));
+    assert_eq!(a, b);
+}

--- a/crates/pilotage-instrument-raster/src/transform.rs
+++ b/crates/pilotage-instrument-raster/src/transform.rs
@@ -1,0 +1,68 @@
+//! The current transform matrix and its Canvas2D-order composition.
+//!
+//! An [`Affine`] maps a logical point to device pixels. The initial
+//! transform is the identity: one logical unit is one device pixel, top-left
+//! origin. [`Cmd::Translate`](pilotage_instrument_scene::Cmd::Translate) and
+//! [`Cmd::Rotate`](pilotage_instrument_scene::Cmd::Rotate) post-multiply, so
+//! they act in the current local frame exactly as `CanvasRenderingContext2D`
+//! `translate`/`rotate` do, composing in command order. The IR has no scale
+//! operation and the initial transform is unit-scale, so this family stays a
+//! rigid motion: a stroke width in logical units equals its device pixel
+//! width, and a circle stays a circle.
+
+use crate::error::RasterError;
+use crate::fixed::Fx;
+
+/// A 2x3 affine map `x' = a*x + c*y + e`, `y' = b*x + d*y + f`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Affine {
+    a: f32,
+    b: f32,
+    c: f32,
+    d: f32,
+    e: f32,
+    f: f32,
+}
+
+impl Affine {
+    /// The identity map (logical units are device pixels).
+    pub(crate) const IDENTITY: Self = Self {
+        a: 1.0,
+        b: 0.0,
+        c: 0.0,
+        d: 1.0,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Post-multiplies a translation, as `ctx.translate(tx, ty)` does.
+    pub(crate) fn translate(&mut self, tx: f32, ty: f32) {
+        self.e += self.a * tx + self.c * ty;
+        self.f += self.b * tx + self.d * ty;
+    }
+
+    /// Post-multiplies a rotation; positive is clockwise in the y-down
+    /// device space, matching the IR.
+    pub(crate) fn rotate(&mut self, radians: f32) {
+        let (s, k) = (libm::sinf(radians), libm::cosf(radians));
+        let (a, b, c, d) = (self.a, self.b, self.c, self.d);
+        self.a = a * k + c * s;
+        self.b = b * k + d * s;
+        self.c = -a * s + c * k;
+        self.d = -b * s + d * k;
+    }
+
+    /// Maps a logical point to a snapped device coordinate (the single
+    /// quantization point), or fails on non-finite / out-of-range results.
+    pub(crate) fn map(&self, x: f32, y: f32) -> Result<[Fx; 2], RasterError> {
+        let dx = self.a * x + self.c * y + self.e;
+        let dy = self.b * x + self.d * y + self.f;
+        Ok([Fx::snap(dx)?, Fx::snap(dy)?])
+    }
+
+    /// The accumulated rotation angle, used to place an arc's angular span
+    /// in device space. Exact for this rigid-motion family.
+    pub(crate) fn rotation(&self) -> f32 {
+        libm::atan2f(self.b, self.a)
+    }
+}


### PR DESCRIPTION
## Summary

- a deterministic, `no_std`, allocation-free software reference rasterizer for the versioned scene IR: renders into a caller-provided RGBA8 framebuffer with a fully specified contract, no platform font APIs, no GPU, no OS dependence
- the contract is written down and pinned: RGBA8 straight-alpha sRGB top-left row-major; source-over with integer round-to-nearest; pixel-center sampling, no AA; a **single Q8.8 quantization boundary** where device coordinates leave the affine transform; Canvas2D-order transforms; rect-intersection clipping; non-zero winding fill; centered strokes with round caps/joins via capsule distance
- layer-contract enforcement before painting (`validate_layers`, mirroring the WASM renderer's gate); typed errors for malformed scenes, non-finite input, geometry/vertex/stack/dimension bounds; any post-acceptance failure overwrites the whole frame with an unmistakable spoil pattern via infallible direct writes — a plausible stale frame cannot survive an error
- reproducible frame hashes in CI: the real PFD and HSI scenes (fixed state → `resolve` → `draw_pfd`/`draw_hsi`) rasterize to pinned SHA-256 digests

## Acceptance criteria — evidence

| Issue #29 criterion | Status | Evidence |
|---|---|---|
| Supported CI architectures produce the specified reproducible frame hashes | ✅ | `reference rasterizer frame hashes (REN-03)` CI step; PFD `26ba92ba…349598`, HSI `6edcbc92…b258e3` at 480×360, asserted stable across renders (sha2 as dev-dependency only) |
| Every opcode and boundary coordinate has a test | ✅ | 56 tests: every opcode (layer markers as paint no-ops included), boundary and out-of-range coordinates, unknown-opcode counting, frame-id echo |
| NaN/Inf, invalid transforms, malformed payloads, extreme dimensions, buffer exhaustion fail deterministically | ✅ | Typed `RasterError` per class; NaN/Inf injected per coordinate slot → typed error **and** spoiled frame; framebuffer geometry and dimension limits tested at their edges |
| Resource bounds explicit and enforced | ✅ | `MAX_DIMENSION`, `MAX_POLYGON_VERTICES`, graphics-state stack depth, `WORST_CASE_FRAME_BYTES` — public consts enforced with boundary tests; execution-time measurement method documented (target WCET deferred to hardware selection, per the issue) |
| Renderer independent of browser/Canvas/GPU APIs | ✅ | `no_std` proven by the thumbv7em CI cross-compile; pure integer/libm math; stateless `render()` echoing scene version + frame/render generations for caller correlation |

## Text: integrated with the controlled glyph pack

The pre-glyph-pack placeholder is gone: text paints from the verified REN-02 bitmap manifest — each set cell pixel is a logical quad through the same quantization/clipping/compositing rules as every primitive, metrics come from the manifest, an uncovered character is a typed `MissingGlyph` failure that spoils the frame, and the pack content hash is verified before any painting (a corrupt asset fails the frame; no fallback). Frame hashes re-pinned for real text; 57 tests.

Module map: `fixed` (the quantization boundary) / `transform` / `surface` (compositing, clip, spoil) / `state` (bounded stack) / `paint`·`stroke`·`curve`·`text` (primitives) / `raster` (validate → clear → paint → spoil-on-error) / `error` / `report`. Largest file 329 lines; 57 tests; fmt/clippy `-D warnings`/strict rustdoc/thumbv7em/release all clean.

SIM / NOT FOR FLIGHT: a verification reference, not a certified airborne renderer. Refs #29. Coordinates with #26 for text; parallel with #45.


## Review finding fixed before merge

The original frame-hash fixture relied on default validity flags and a slightly denormalized quaternion, so its pixels depended on whether fail-safe validation (#45) sat in the resolution path — the pinned hashes matched one semantic regime but not the branch's own CI. The fixture now declares trust explicitly and uses a quaternion whose f32 squared-component sum is exactly 1.0 (renormalization divides by exactly 1.0), making the render bit-identical under both regimes; hashes re-pinned and verified stable.


