### PR TITLE
REN-02: browser loads, verifies, and exclusively consumes the controlled glyph pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
 name = "pilotage-instruments-web"
 version = "0.1.0"
 dependencies = [
+ "pilotage-instrument-glyphs",
  "pilotage-instrument-panels",
  "pilotage-instrument-scene",
  "pilotage-instrument-state",

--- a/clients/web-instruments/Cargo.toml
+++ b/clients/web-instruments/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
+pilotage-instrument-glyphs = { workspace = true }
 pilotage-instrument-panels = { workspace = true }
 pilotage-instrument-scene = { workspace = true }
 pilotage-instrument-state = { workspace = true }

--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -245,4 +245,28 @@ impl InstrumentRuntime {
             |runtime| render_into(runtime, panel).packed(),
         )
     }
+
+    /// The controlled glyph pack's canonical serialization (REN-02), for
+    /// the backend's independent hash verification and atlas
+    /// construction. A serialization failure returns an empty buffer,
+    /// which no verifier accepts.
+    pub fn glyph_manifest(&self) -> Vec<u8> {
+        let manifest = pilotage_instrument_glyphs::PANEL_GLYPHS;
+        let mut out = vec![0u8; manifest.canonical_len()];
+        match manifest.write_canonical(&mut out) {
+            Ok(len) => {
+                out.truncate(len);
+                out
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// The compile-time-recorded glyph content hash the backend must
+    /// match against both the canonical bytes and its own pinned value.
+    pub fn glyph_recorded_hash(&self) -> Vec<u8> {
+        pilotage_instrument_glyphs::PANEL_GLYPHS
+            .recorded_hash()
+            .to_vec()
+    }
 }

--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -396,3 +396,24 @@ fn malformed_scene_framing_gates_visible_commit() {
     });
     assert_scene_rejected(0, &outside_layer, RenderStatus::SceneLayerContract);
 }
+
+#[test]
+fn glyph_exports_surface_the_verified_pack() {
+    use pilotage_instrument_glyphs::PANEL_GLYPHS;
+
+    use crate::exports::InstrumentRuntime;
+
+    assert!(PANEL_GLYPHS.verify().is_ok(), "shipped pack verifies");
+    let runtime = InstrumentRuntime::new();
+    let canonical = runtime.glyph_manifest();
+    assert_eq!(canonical.len(), PANEL_GLYPHS.canonical_len());
+    let mut expected = vec![0u8; PANEL_GLYPHS.canonical_len()];
+    let len = PANEL_GLYPHS
+        .write_canonical(&mut expected)
+        .expect("canonical fits");
+    assert_eq!(canonical, expected[..len]);
+    assert_eq!(
+        runtime.glyph_recorded_hash(),
+        PANEL_GLYPHS.recorded_hash().to_vec()
+    );
+}

--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -37,6 +37,7 @@ export const REASON = Object.freeze({
   PAINT_FAILED: 105,
   LIVENESS: 106,
   STATE_WRITE_FAILED: 107,
+  GLYPH_ASSET: 108,
 });
 
 // A typed module-level fault raised by loadInstruments so callers can show

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -24,6 +24,17 @@ export const LOGICAL_W = 480;
 export const LOGICAL_H = 360;
 
 const SCENE_FORMAT_VERSION = 1;
+
+// The controlled glyph pack's recorded content hash (REN-02). The backend
+// verifies the wasm-exported canonical bytes against BOTH the wasm's
+// recorded hash and this pinned value before declaring ready, so a stale
+// or corrupt asset — on either side — fails visibly instead of falling
+// back to a system font.
+export const EXPECTED_GLYPH_SHA256 =
+  "281eef6229feee417c7090d8c8ea79489c017cd1c02fc7234876b2a64a532158";
+const GLYPH_HEADER_LEN = 8;
+const GLYPH_RECORD_LEN = 12;
+const GLYPH_ROWS = 7;
 export const STATE_ABI_VERSION = 2;
 export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
@@ -39,6 +50,8 @@ const REQUIRED_RUNTIME_METHODS = [
   "scene_ptr",
   "render_result",
   "set_v_speeds",
+  "glyph_manifest",
+  "glyph_recorded_hash",
 ];
 
 export async function loadInstruments(wasmUrl, options = {}) {
@@ -144,12 +157,85 @@ export async function loadInstruments(wasmUrl, options = {}) {
       `instrument buffer layout invalid: state=${statePtr} scene=${scenePtr} memory=${memoryLen}`,
     );
   }
+  let glyphs;
+  try {
+    glyphs = options.glyphAtlas ?? (await loadVerifiedGlyphAtlas(runtime));
+  } catch (error) {
+    releaseRuntime(runtime);
+    throw error;
+  }
   return new InstrumentModule(runtime, {
     ...options,
     memory: wasm.memory,
     statePtr,
     scenePtr,
+    glyphs,
   });
+}
+
+/// Loads the wasm-exported glyph canonical bytes, verifies them against
+/// both the wasm-recorded hash and the pinned EXPECTED_GLYPH_SHA256, and
+/// parses the atlas. Any shortfall is a typed GLYPH_ASSET fault: the
+/// backend never becomes ready over a missing, corrupt, or wrong-hash
+/// asset, and never substitutes a system font.
+async function loadVerifiedGlyphAtlas(runtime) {
+  let canonical;
+  let recorded;
+  try {
+    canonical = runtime.glyph_manifest();
+    recorded = runtime.glyph_recorded_hash();
+  } catch (error) {
+    throw new InstrumentFault(REASON.GLYPH_ASSET, `glyph asset query failed: ${error}`);
+  }
+  if (!(canonical instanceof Uint8Array) || !(recorded instanceof Uint8Array)) {
+    throw new InstrumentFault(REASON.GLYPH_ASSET, "glyph asset export shape invalid");
+  }
+  const recordedHex = [...recorded].map((b) => b.toString(16).padStart(2, "0")).join("");
+  if (recordedHex !== EXPECTED_GLYPH_SHA256) {
+    throw new InstrumentFault(
+      REASON.GLYPH_ASSET,
+      `glyph recorded hash ${recordedHex} does not match the pinned pack`,
+    );
+  }
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", canonical));
+  const digestHex = [...digest].map((b) => b.toString(16).padStart(2, "0")).join("");
+  if (digestHex !== EXPECTED_GLYPH_SHA256) {
+    throw new InstrumentFault(
+      REASON.GLYPH_ASSET,
+      `glyph canonical bytes hash ${digestHex}, expected the pinned pack`,
+    );
+  }
+  return parseGlyphAtlas(canonical);
+}
+
+/// Parses the canonical glyph serialization (verified by hash above):
+/// 8-byte header (version u16 LE, cell w/h u8, advance u8, baseline u8,
+/// count u16 LE) then 12 bytes per glyph (char u32 LE, advance u8, seven
+/// row bitmaps, leftmost column = highest used bit).
+export function parseGlyphAtlas(canonical) {
+  if (canonical.length < GLYPH_HEADER_LEN) {
+    throw new InstrumentFault(REASON.GLYPH_ASSET, "glyph canonical too short");
+  }
+  const view = new DataView(canonical.buffer, canonical.byteOffset, canonical.byteLength);
+  const count = view.getUint16(6, true);
+  if (canonical.length !== GLYPH_HEADER_LEN + count * GLYPH_RECORD_LEN) {
+    throw new InstrumentFault(REASON.GLYPH_ASSET, "glyph canonical length mismatch");
+  }
+  const map = new Map();
+  for (let i = 0; i < count; i += 1) {
+    const at = GLYPH_HEADER_LEN + i * GLYPH_RECORD_LEN;
+    const rows = [];
+    for (let r = 0; r < GLYPH_ROWS; r += 1) rows.push(canonical[at + 5 + r]);
+    map.set(view.getUint32(at, true), { advance: canonical[at + 4], rows });
+  }
+  return {
+    version: view.getUint16(0, true),
+    cellW: canonical[2],
+    cellH: canonical[3],
+    advance: canonical[4],
+    baseline: canonical[5],
+    map,
+  };
 }
 
 function releaseRuntime(runtime) {
@@ -184,7 +270,10 @@ export class InstrumentModule {
 
   // options.createCanvas injects the back-buffer factory (tests pass a
   // recording double; the browser default is a plain offscreen element).
-  constructor(runtime, { createCanvas, memory, statePtr, scenePtr } = {}) {
+  #glyphs;
+
+  constructor(runtime, { createCanvas, memory, statePtr, scenePtr, glyphs } = {}) {
+    this.#glyphs = glyphs ?? null;
     this.#runtime = runtime;
     this.#memory = memory ?? runtime.memory;
     this.#statePtr = statePtr ?? runtime.state_ptr();
@@ -347,7 +436,7 @@ export class InstrumentModule {
       const bctx = back.getContext("2d");
       bctx.fillStyle = "#000";
       bctx.fillRect(0, 0, LOGICAL_W, LOGICAL_H);
-      this.unknownOpcodes += interpretScene(view, bctx);
+      this.unknownOpcodes += interpretScene(view, bctx, this.#glyphs);
     } catch {
       return { ok: false, reason: REASON.PAINT_FAILED };
     }
@@ -387,12 +476,43 @@ function color(view, at) {
   return `rgba(${r},${g},${b},${a / 255})`;
 }
 
-const H_ALIGN = ["left", "center", "right"];
-const V_ALIGN = ["alphabetic", "middle", "top", "bottom"];
+// Paints one text run from the glyph atlas with the reference
+// rasterizer's metrics: run size maps to the cell height, the pen
+// advances by the manifest advance, the bitmap sits entirely above the
+// baseline, and the leftmost column is the highest used row bit. An
+// uncovered character throws — nothing substitutes.
+export function drawGlyphRun(ctx, glyphs, text, x, y, size, anchorByte) {
+  if (text.length === 0 || !(size > 0)) return;
+  if (!glyphs) throw new Error("text requires the verified glyph atlas");
+  const scale = size / glyphs.cellH;
+  const advance = glyphs.advance * scale;
+  const chars = [...text];
+  const width = chars.length * advance;
+  const h = anchorByte & 3;
+  const v = (anchorByte >> 2) & 3;
+  const left = h === 1 ? x - width / 2 : h === 2 ? x - width : x;
+  // v: 0 baseline, 1 middle, 2 top, 3 bottom (descent is zero).
+  const top = v === 2 ? y : v === 1 ? y - size / 2 : y - size;
+  let pen = left;
+  for (const ch of chars) {
+    const glyph = glyphs.map.get(ch.codePointAt(0));
+    if (!glyph) throw new Error(`no glyph for character ${JSON.stringify(ch)}`);
+    for (let row = 0; row < glyph.rows.length; row += 1) {
+      for (let col = 0; col < glyphs.cellW; col += 1) {
+        if ((glyph.rows[row] >> (glyphs.cellW - 1 - col)) & 1) {
+          ctx.fillRect(pen + col * scale, top + row * scale, scale, scale);
+        }
+      }
+    }
+    pen += advance;
+  }
+}
 
 // Interprets one encoded scene onto a Canvas2D context; returns the
-// number of skipped unknown opcodes.
-export function interpretScene(view, ctx) {
+// number of skipped unknown opcodes. Text paints exclusively from the
+// verified glyph atlas — a scene with text and no atlas throws (the
+// renderer surfaces it as PAINT_FAILED), never a system-font fallback.
+export function interpretScene(view, ctx, glyphs = null) {
   if (view.getUint8(0) !== SCENE_FORMAT_VERSION) return 0;
   let at = 1;
   let unknown = 0;
@@ -472,10 +592,7 @@ export function interpretScene(view, ctx) {
         const text = new TextDecoder().decode(
           new Uint8Array(view.buffer, view.byteOffset + p + 13, plen - 13),
         );
-        ctx.font = `bold ${size}px system-ui, sans-serif`;
-        ctx.textAlign = H_ALIGN[anchor & 3] ?? "left";
-        ctx.textBaseline = V_ALIGN[(anchor >> 2) & 3] ?? "alphabetic";
-        ctx.fillText(text, x, y);
+        drawGlyphRun(ctx, glyphs, text, x, y, size, anchor);
         break;
       }
       case 0x40:

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -150,9 +150,27 @@ function fakeExports({
       return packRenderResult(resultStatus, resultLen, renderGeneration(panel));
     },
     set_v_speeds: () => 0,
+    glyph_manifest: () => new Uint8Array(0),
+    glyph_recorded_hash: () => new Uint8Array(0),
     memory: { buffer },
   };
   return Object.assign(exports, overrides);
+}
+
+// A minimal verified-shape atlas for unit paths that are not exercising
+// the real verification chain (the real-wasm section runs it in full).
+function fakeAtlas() {
+  return {
+    version: 1,
+    cellW: 5,
+    cellH: 7,
+    advance: 6,
+    baseline: 7,
+    map: new Map([
+      ["1".codePointAt(0), { advance: 6, rows: [0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110] }],
+      ["8".codePointAt(0), { advance: 6, rows: [0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110] }],
+    ]),
+  };
 }
 
 function injectedLoader(exports) {
@@ -162,6 +180,7 @@ function injectedLoader(exports) {
     createRuntime: () => exports,
     queryAbiVersion: () => exports.abi_version(),
     createCanvas: recordingCanvas,
+    glyphAtlas: fakeAtlas(),
   };
 }
 
@@ -957,14 +976,73 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   );
 }
 
+// ---- glyph text painting (REN-02 consumption) ---------------------------------
+
+{
+  const textScene = Uint8Array.from([
+    1,
+    ...cmd(0x50, [1]),
+    ...cmd(0x30, [...f32(14), 0, ...f32(8), ...f32(40), 0x31]),
+    ...cmd(0x51, [1]),
+  ]);
+  const ctx = new RecordingCtx();
+  const unknown = interpretScene(view(textScene), ctx, fakeAtlas());
+  check("text paints from the atlas as fillRect quads", ctx.calls("fillRect").length > 0);
+  check("text never calls fillText", ctx.calls("fillText").length === 0);
+  check("layer markers and glyph text are known vocabulary", unknown === 0);
+
+  let threw = null;
+  try {
+    interpretScene(view(textScene), new RecordingCtx(), null);
+  } catch (error) {
+    threw = error;
+  }
+  check("text without a verified atlas throws instead of falling back", threw !== null);
+
+  const uncovered = Uint8Array.from([
+    1,
+    ...cmd(0x30, [...f32(14), 0, ...f32(8), ...f32(40), 0x7a]),
+  ]);
+  let missing = null;
+  try {
+    interpretScene(view(uncovered), new RecordingCtx(), fakeAtlas());
+  } catch (error) {
+    missing = error;
+  }
+  check("an uncovered character throws, never substitutes", missing !== null);
+}
+
+{
+  // A text-bearing scene through renderPanel: an atlas miss surfaces as
+  // PAINT_FAILED and leaves the visible target untouched.
+  const textScene = Uint8Array.from([
+    1,
+    ...cmd(0x50, [1]),
+    ...cmd(0x30, [...f32(14), 0, ...f32(8), ...f32(40), 0x7a]),
+    ...cmd(0x51, [1]),
+  ]);
+  const mod = new InstrumentModule(fakeExports({ sceneBytes: textScene }), {
+    createCanvas: recordingCanvas,
+    glyphs: fakeAtlas(),
+  });
+  const visible = new RecordingCtx();
+  const result = mod.renderPanel(PANEL.PFD, visible, 480, 360);
+  check(
+    "atlas miss is PAINT_FAILED through the pipeline",
+    !result.ok && result.reason === REASON.PAINT_FAILED,
+  );
+  check("atlas miss leaves the visible target untouched", visible.log.length === 0);
+}
+
 // ---- the real WASM module, end to end ----------------------------------------
 
 {
   const wasmUrl = new URL("./instrument-runtime_bg.wasm", import.meta.url);
   let mod = null;
   let capturedWasm = null;
+  let bindings = null;
   try {
-    const bindings = await import("./instrument-runtime.js");
+    bindings = await import("./instrument-runtime.js");
     mod = await loadInstruments(readFileSync(wasmUrl), {
       createCanvas: recordingCanvas,
       loadBindings: async () => bindings,
@@ -978,6 +1056,68 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   }
   if (mod) {
     check("real wasm passes load, ABI, init, and exact-size validation", mod instanceof InstrumentModule);
+
+    // The verification chain fails closed on a corrupt, truncated, or
+    // wrong-hash glyph asset — the backend never becomes ready over one.
+    const wrapRuntime = (over) => {
+      const rt = new bindings.InstrumentRuntime();
+      return {
+        free: () => rt.free(),
+        init: () => rt.init(),
+        state_ptr: () => rt.state_ptr(),
+        state_len: () => rt.state_len(),
+        scene_ptr: () => rt.scene_ptr(),
+        render_result: (panel) => rt.render_result(panel),
+        set_v_speeds: (...a) => rt.set_v_speeds(...a),
+        glyph_manifest: () => rt.glyph_manifest(),
+        glyph_recorded_hash: () => rt.glyph_recorded_hash(),
+        ...over,
+      };
+    };
+    const assetFailure = async (over) => {
+      try {
+        await loadInstruments(readFileSync(wasmUrl), {
+          createCanvas: recordingCanvas,
+          loadBindings: async () => bindings,
+          initializeBindings: async () => capturedWasm,
+          createRuntime: () => wrapRuntime(over),
+        });
+        return null;
+      } catch (error) {
+        return error?.reason ?? null;
+      }
+    };
+    check(
+      "corrupt glyph canonical fails load as GLYPH_ASSET",
+      (await assetFailure({
+        glyph_manifest: () => {
+          const rt = new bindings.InstrumentRuntime();
+          const c = rt.glyph_manifest();
+          c[10] ^= 1;
+          return c;
+        },
+      })) === REASON.GLYPH_ASSET,
+    );
+    check(
+      "truncated glyph canonical fails load as GLYPH_ASSET",
+      (await assetFailure({
+        glyph_manifest: () => {
+          const rt = new bindings.InstrumentRuntime();
+          return rt.glyph_manifest().subarray(0, 40);
+        },
+      })) === REASON.GLYPH_ASSET,
+    );
+    check(
+      "wrong recorded glyph hash fails load as GLYPH_ASSET",
+      (await assetFailure({
+        glyph_recorded_hash: () => {
+          const rt = new bindings.InstrumentRuntime();
+          const h = rt.glyph_recorded_hash();
+          h[0] ^= 1;
+          return h;
+        },
+      })) === REASON.GLYPH_ASSET,
+    );
     check("raw WASM resource is encapsulated by the validated module", !("runtime" in mod));
 
     // The zeroed state block is a version-0 decode failure — a typed


### PR DESCRIPTION
## Summary — completes issue #26

With #47 (the controlled asset) and #48 (reference-renderer consumption) merged, this PR lands the remaining criterion: the **browser** backend loads, independently verifies, and exclusively consumes the glyph pack.

- the wasm runtime exports its canonical glyph bytes and compile-time-recorded hash; the browser SHA-256s the bytes itself (WebCrypto) and requires BOTH to match the pinned `EXPECTED_GLYPH_SHA256` before building the atlas — the backend cannot declare ready over a missing, truncated, corrupt, or wrong-hash asset (typed `GLYPH_ASSET` fault → DISPLAY FAIL page)
- text paints exclusively from the verified atlas using the reference rasterizer's metrics (size→cell height, manifest advance, zero descent, identical anchor mapping): `fillRect` quads per set cell pixel — **`fillText` and `system-ui` no longer exist in the paint path**
- an uncovered character fails the frame (`PAINT_FAILED`) rather than substituting; a text scene with no atlas throws rather than falling back

## Issue #26 criteria — final status

| Criterion | Status | Evidence |
|---|---|---|
| Instrument output no longer depends on installed system-ui fonts | ✅ | zero `fillText`/`font` usage in `instruments.js`; reference renderer already glyph-native (#48); pinned by tests asserting fillRect-only text and clean unknown-opcode diagnostics on real frames |
| Mandatory vocabulary completeness tests | ✅ (#47) | `PANEL_VOCABULARY`/`PANEL_STRINGS`/`FLAG_VOCABULARY` |
| Byte-identical artifacts and manifest | ✅ (#47) | canonical serialization + recorded hash pinned |
| Missing/corrupt/wrong-hash assets fail visibly | ✅ | real-wasm corruption suite: flipped canonical byte, truncated canonical, flipped recorded hash → each fails load as `GLYPH_ASSET` (D-108) and surfaces on the failure page; Rust test pins the export contract against the glyphs crate |
| Both renderers consume the same metrics contract | ✅ | reference rasterizer (#48) and this browser painter share the manifest's cell/advance/baseline semantics and the same anchor mapping |

118 browser checks green against the real generated WASM (three new asset-corruption paths + atlas-text paths); 10 Rust renderer tests; fmt/clippy/doc gates clean. Closing #26 upon merge is appropriate: every criterion now has a runtime implementation and a named test. SIM / NOT FOR FLIGHT.

Closes #26.
