### PR TITLE
AV-02: consume Aviate estimator authorization fail closed

### DIFF
--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -24,7 +24,9 @@ mod camera;
 mod control;
 mod sampling;
 mod shm_sampling;
-use sampling::{mavlink_batch, measurement_pair_is_coherent, yaw_of};
+use sampling::{
+    mavlink_batch, measurement_pair_is_coherent, measurement_pair_supports_pose, yaw_of,
+};
 use shm_sampling::ShmSource;
 
 /// The control scope exposes four canonical flight axes as DJI-style
@@ -260,6 +262,7 @@ impl AviateAdapter {
             Source::Shm(source) => source.current_pose(),
             Source::Mavlink { state, .. } => {
                 let latest = state.lock().ok()?;
+                latest.estimator_status_stamp()?;
                 let attitude = latest
                     .attitude
                     .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)?;
@@ -270,7 +273,8 @@ impl AviateAdapter {
                     attitude,
                     kinematics,
                     latest.maximum_inter_group_skew_ms,
-                ) {
+                ) || !measurement_pair_supports_pose(attitude, kinematics)
+                {
                     return None;
                 }
                 Some((yaw_of(attitude.quat_wxyz) as f32, kinematics.pos_ned_m))

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -10,6 +10,7 @@ use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
 use super::WITHHOLD_AFTER;
+use crate::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
 use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
 
 /// Yaw extracted from the body→NED quaternion (heading, radians
@@ -41,6 +42,76 @@ pub(super) fn measurement_pair_is_coherent(
             <= u64::from(maximum_skew_ms) * 1_000_000
 }
 
+pub(super) fn measurement_pair_supports_pose(
+    attitude: AttitudeUpdate,
+    kinematics: KinematicsUpdate,
+) -> bool {
+    attitude.quality <= QUALITY_DEGRADED
+        && kinematics.quality <= QUALITY_DEGRADED
+        && attitude.valid_flags & 0b0001 != 0
+        && kinematics.valid_flags & 0b0100 != 0
+}
+
+fn planar_projection(
+    attitude: Option<AttitudeUpdate>,
+    kinematics: Option<KinematicsUpdate>,
+    maximum_skew_ms: u32,
+    has_authorization: bool,
+) -> (Option<Pose2d>, Option<f64>) {
+    let coherent_pair = attitude.zip(kinematics).filter(|(att, kin)| {
+        has_authorization && measurement_pair_is_coherent(*att, *kin, maximum_skew_ms)
+    });
+    let pose = coherent_pair
+        .filter(|(att, kin)| measurement_pair_supports_pose(*att, *kin))
+        .map(|(att, kin)| Pose2d {
+            x: f64::from(kin.pos_ned_m[0]),
+            y: f64::from(kin.pos_ned_m[1]),
+            heading: yaw_of(att.quat_wxyz),
+        });
+    let speed = coherent_pair
+        .filter(|(att, kin)| {
+            att.quality <= QUALITY_DEGRADED
+                && kin.quality <= QUALITY_DEGRADED
+                && kin.valid_flags & 0b1000 != 0
+        })
+        .map(|(_, kin)| {
+            f64::from(
+                (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1])
+                    .sqrt(),
+            )
+        });
+    (pose, speed)
+}
+
+fn effective_authorization(
+    attitude: Option<AttitudeUpdate>,
+    kinematics: Option<KinematicsUpdate>,
+    has_authorization: bool,
+) -> (u32, u32) {
+    if !has_authorization {
+        return (0, QUALITY_UNUSABLE);
+    }
+    let attitude_flags = attitude
+        .filter(|att| att.quality <= QUALITY_DEGRADED)
+        .map_or(0, |att| att.valid_flags & 0b0011);
+    let kinematics_flags = kinematics
+        .filter(|kin| kin.quality <= QUALITY_DEGRADED)
+        .map_or(0, |kin| kin.valid_flags & 0b1100);
+    let flags = attitude_flags | kinematics_flags;
+    let quality = attitude
+        .filter(|_| attitude_flags != 0)
+        .map(|att| att.quality)
+        .into_iter()
+        .chain(
+            kinematics
+                .filter(|_| kinematics_flags != 0)
+                .map(|kin| kin.quality),
+        )
+        .max()
+        .unwrap_or(QUALITY_UNUSABLE);
+    (flags, quality)
+}
+
 pub(crate) fn mavlink_batch(
     vehicle: VehicleId,
     state: &Arc<Mutex<LatestAviate>>,
@@ -59,25 +130,15 @@ pub(crate) fn mavlink_batch(
         return TelemetryBatch::default();
     }
 
-    let planar = attitude
-        .zip(kinematics)
-        .filter(|(att, kin)| {
-            measurement_pair_is_coherent(*att, *kin, latest.maximum_inter_group_skew_ms)
-        })
-        .map(|(att, kin)| {
-            let speed = f64::from(
-                (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1])
-                    .sqrt(),
-            );
-            (
-                Pose2d {
-                    x: f64::from(kin.pos_ned_m[0]),
-                    y: f64::from(kin.pos_ned_m[1]),
-                    heading: yaw_of(att.quat_wxyz),
-                },
-                speed,
-            )
-        });
+    let estimator_status_stamp = latest.estimator_status_stamp();
+    let has_authorization = estimator_status_stamp.is_some();
+    let (planar_pose, planar_speed) = planar_projection(
+        attitude,
+        kinematics,
+        latest.maximum_inter_group_skew_ms,
+        has_authorization,
+    );
+    let (valid_flags, quality) = effective_authorization(attitude, kinematics, has_authorization);
     let avionics = Some(AvionicsSample {
         attitude: attitude.map(|att| AvionicsAttitudeSample {
             quat_wxyz: att.quat_wxyz,
@@ -89,11 +150,9 @@ pub(crate) fn mavlink_batch(
             vel_ned_mps: kin.vel_ned_mps,
             stamp: kin.stamp,
         }),
-        // The source messages do not carry estimator validity or quality;
-        // freshness is the only validity dimension this link can claim.
-        valid_flags: (u32::from(attitude.is_some()) * 0b0011)
-            | (u32::from(kinematics.is_some()) * 0b1100),
-        quality: 0,
+        estimator_status_stamp,
+        valid_flags,
+        quality,
         arm_state,
     });
     let source_time_ms = kinematics
@@ -104,8 +163,8 @@ pub(crate) fn mavlink_batch(
         samples: vec![TelemetrySample {
             vehicle,
             tick: SimTick::new(u64::from(source_time_ms).wrapping_mul(1_000_000)),
-            pose: planar.map(|(pose, _)| pose),
-            speed: planar.map(|(_, speed)| speed),
+            pose: planar_pose,
+            speed: planar_speed,
             avionics,
         }],
     }

--- a/adapters/aviate/src/adapter/shm_sampling.rs
+++ b/adapters/aviate/src/adapter/shm_sampling.rs
@@ -162,6 +162,9 @@ fn batch_from_sample(
                     vel_ned_mps: sample.vel_ned_mps,
                     stamp,
                 }),
+                // The coherent simulator block is its own explicit
+                // ground-truth authorization source.
+                estimator_status_stamp: Some(stamp),
                 valid_flags: 0b1111,
                 quality: 0,
                 arm_state,
@@ -169,3 +172,6 @@ fn batch_from_sample(
         }],
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/adapters/aviate/src/adapter/shm_sampling/tests.rs
+++ b/adapters/aviate/src/adapter/shm_sampling/tests.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_adapter_api::SourceIncarnation;
+use pilotage_protocol::VehicleId;
+
+use crate::shm::GzStateSample;
+
+use super::batch_from_sample;
+
+#[test]
+fn simulator_sample_has_explicit_ground_truth_authorization() {
+    let batch = batch_from_sample(
+        VehicleId::new(1),
+        0,
+        GzStateSample {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            rates_rps: [0.0; 3],
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            time_us: 42,
+            seq: 7,
+        },
+        0,
+        3,
+        SourceIncarnation::new([0x5a; 16]),
+    );
+
+    let avionics = batch.samples[0].avionics.expect("avionics");
+    let status = avionics.estimator_status_stamp.expect("status stamp");
+    assert_eq!(status, avionics.attitude.expect("attitude").stamp);
+    assert_eq!(status, avionics.kinematics.expect("kinematics").stamp);
+    assert_eq!(avionics.valid_flags, 0x0f);
+    assert_eq!(avionics.quality, 0);
+}

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -9,6 +9,7 @@ use pilotage_adapter_api::{
 };
 use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
 
+use crate::link::estimator::{EstimatorAuthorization, EstimatorStatusUpdate};
 use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
 
 use super::{AviateAdapter, sampling::measurement_pair_is_coherent};
@@ -39,6 +40,18 @@ fn state_with_acquisition_skew(
         ..attitude_stamp
     };
     let skew_ms = u32::try_from(acquisition_skew_ns / 1_000_000).unwrap_or(u32::MAX);
+    let estimator_status = EstimatorStatusUpdate {
+        time_usec: 5_000_000,
+        time_boot_ms: 5_000,
+        authorization: EstimatorAuthorization {
+            valid_flags: 0b1111,
+            quality: 0,
+        },
+        stamp: MeasurementStamp {
+            sequence: 7,
+            ..attitude_stamp
+        },
+    };
     let state = LatestAviate {
         attitude: Some(AttitudeUpdate {
             // 90° yaw: heading east.
@@ -51,6 +64,8 @@ fn state_with_acquisition_skew(
             rates_rps: [0.0, 0.0, 0.1],
             time_boot_ms: 5000,
             stamp: attitude_stamp,
+            valid_flags: 0b1111,
+            quality: 0,
             received_at: now.checked_sub(att_age).unwrap_or(now),
         }),
         kinematics: Some(KinematicsUpdate {
@@ -58,8 +73,11 @@ fn state_with_acquisition_skew(
             vel_ned_mps: [3.0, 4.0, -1.0],
             time_boot_ms: 5000_u32.saturating_sub(skew_ms),
             stamp: kinematics_stamp,
+            valid_flags: 0b1111,
+            quality: 0,
             received_at: now.checked_sub(kin_age).unwrap_or(now),
         }),
+        estimator_status: Some(estimator_status),
         maximum_inter_group_skew_ms: 300,
         ..LatestAviate::default()
     };
@@ -128,6 +146,10 @@ fn fresh_state_samples_pose_speed_and_avionics() {
     );
     assert_eq!(avionics.valid_flags, 0b1111);
     assert_eq!(
+        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
+        Some(7)
+    );
+    assert_eq!(
         avionics.attitude.map(|group| group.stamp.sequence),
         Some(10)
     );
@@ -135,6 +157,40 @@ fn fresh_state_samples_pose_speed_and_avionics() {
         avionics.kinematics.map(|group| group.stamp.sequence),
         Some(5)
     );
+}
+
+#[test]
+fn missing_status_normalizes_hand_built_numeric_groups_fail_closed() {
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    state.lock().expect("lock").estimator_status = None;
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state);
+    let batch = adapter.sample_telemetry();
+    let sample = &batch.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!((avionics.valid_flags, avionics.quality), (0, 2));
+    assert!(avionics.estimator_status_stamp.is_none());
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+}
+
+#[test]
+fn unusable_group_with_diagnostic_flags_does_not_taint_an_authorized_group() {
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    {
+        let mut latest = state.lock().expect("lock");
+        let attitude = latest.attitude.as_mut().expect("attitude");
+        attitude.valid_flags = 0b0011;
+        attitude.quality = 2;
+        let kinematics = latest.kinematics.as_mut().expect("kinematics");
+        kinematics.valid_flags = 0b1100;
+        kinematics.quality = 0;
+    }
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state);
+    let sample = adapter.sample_telemetry().samples.remove(0);
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!((avionics.valid_flags, avionics.quality), (0b1100, 0));
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
 }
 
 #[test]
@@ -235,6 +291,23 @@ fn over_skew_measurement_pair_cannot_seed_a_control_setpoint() {
         state_with_acquisition_skew(Duration::ZERO, Duration::ZERO, 301_000_000),
     )
     .with_uplink(uplink);
+    let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::MeasurementUnavailable)
+    );
+}
+
+#[test]
+fn estimator_revocation_cannot_seed_a_control_setpoint() {
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    {
+        let mut latest = state.lock().expect("lock");
+        latest.attitude.as_mut().expect("attitude").quality = 2;
+        latest.kinematics.as_mut().expect("kinematics").quality = 2;
+    }
+    let uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state).with_uplink(uplink);
     let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
     assert_eq!(
         outcome.disposition,

--- a/adapters/aviate/src/lib.rs
+++ b/adapters/aviate/src/lib.rs
@@ -1,14 +1,13 @@
-//! Telemetry-only `VehicleAdapter` for the Aviate flight controller
-//! (ADR-0018).
+//! `VehicleAdapter` for the Aviate flight controller (ADR-0018).
 //!
-//! Aviate's public contract is a deliberate MAVLink 2.0 subset —
-//! HEARTBEAT, ATTITUDE_QUATERNION, LOCAL_POSITION_NED — over UDP in SITL
-//! and USB CDC on hardware. This adapter consumes that subset and folds
-//! it into the telemetry plane: planar pose for existing consumers, the
-//! raw estimate into `AvionicsSample` for the instrument runtime
-//! (ADR-0017). Control is not implemented in this increment: the adapter
-//! advertises no controllable scopes and rejects every control frame at
-//! the boundary.
+//! Aviate's public contract is a deliberate MAVLink 2.0 subset covering
+//! liveness, estimator values, lossless estimator authorization, and flight
+//! commands. The FC exposes it over UDP in SITL and USB CDC on hardware.
+//! This adapter folds the estimate into the telemetry plane: planar pose for
+//! existing consumers and raw groups plus explicit validity/quality into
+//! `AvionicsSample` for the instrument runtime (ADR-0017). Aviate's private
+//! estimator-status message is the sole authorization source; the standard
+//! status projection remains diagnostic.
 //!
 //! This crate owns I/O (`adapters/` is exempt from the sans-IO rule,
 //! ADR-0002); the MAVLink frame math itself lives in [`mavlink`] as pure

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -8,14 +8,18 @@ use std::time::{Duration, Instant};
 
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use pilotage_adapter_api::{MeasurementStamp, SourceIncarnation};
 
 use crate::error::AviateAdapterError;
 use crate::mavlink::{AviateMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
 
+pub(crate) mod estimator;
 mod measurement;
+use estimator::{
+    EstimatorStatusUpdate, accept_status, authorization_at, invalidate_cached_authorization,
+};
 use measurement::{next_attitude_stamp, next_kinematics_stamp};
 
 /// Whether an unstamped MAVLink boot-clock regression may use the simulator
@@ -106,6 +110,8 @@ pub struct LatestAviate {
     /// Latest NED kinematics: position, velocity, FC boot time, receive
     /// stamp.
     pub kinematics: Option<KinematicsUpdate>,
+    /// Latest accepted lossless estimator authorization report.
+    pub(crate) estimator_status: Option<EstimatorStatusUpdate>,
     /// Receive stamp of the last FC heartbeat.
     pub last_heartbeat: Option<Instant>,
     /// Total decoded frames.
@@ -126,6 +132,9 @@ pub struct LatestAviate {
     pub duplicate_measurements: u64,
     /// Older group measurements rejected before entering the cache.
     pub reordered_measurements: u64,
+    /// Malformed or unparseable private estimator-status reports that forced
+    /// cached authorization closed.
+    pub invalid_estimator_statuses: u64,
     /// Confirmed reboot or acquisition-clock-wrap transitions.
     pub source_resets: u64,
     /// Low-clock reset candidates quarantined for confirmation.
@@ -145,6 +154,7 @@ impl Default for LatestAviate {
             maximum_inter_group_skew_ms: 0,
             attitude: None,
             kinematics: None,
+            estimator_status: None,
             last_heartbeat: None,
             decoded: 0,
             crc_failures: 0,
@@ -155,6 +165,7 @@ impl Default for LatestAviate {
             pending_reset: None,
             duplicate_measurements: 0,
             reordered_measurements: 0,
+            invalid_estimator_statuses: 0,
             source_resets: 0,
             suspected_resets: 0,
             wrong_sources: 0,
@@ -175,6 +186,10 @@ impl LatestAviate {
             ..Self::default()
         }
     }
+
+    pub(crate) fn estimator_status_stamp(&self) -> Option<MeasurementStamp> {
+        self.estimator_status.map(|status| status.stamp)
+    }
 }
 
 /// One attitude update with its receive stamp.
@@ -188,6 +203,10 @@ pub struct AttitudeUpdate {
     pub time_boot_ms: u32,
     /// Identity and acquisition stamp for this group update.
     pub stamp: MeasurementStamp,
+    /// Authorization bits retained for this numeric acquisition.
+    pub valid_flags: u32,
+    /// Canonical quality retained for this numeric acquisition.
+    pub quality: u32,
     /// When this update was received.
     pub received_at: Instant,
 }
@@ -203,6 +222,10 @@ pub struct KinematicsUpdate {
     pub time_boot_ms: u32,
     /// Identity and acquisition stamp for this group update.
     pub stamp: MeasurementStamp,
+    /// Authorization bits retained for this numeric acquisition.
+    pub valid_flags: u32,
+    /// Canonical quality retained for this numeric acquisition.
+    pub quality: u32,
     /// When this update was received.
     pub received_at: Instant,
 }
@@ -299,9 +322,20 @@ async fn run_link(
                     Ok((len, _from)) => {
                         messages.clear();
                         let stats = parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
-                        apply_messages(&state, &messages, stats.crc_failures, stats.unknown_ids);
+                        apply_messages(
+                            &state,
+                            &messages,
+                            stats.crc_failures,
+                            stats.unknown_ids,
+                        );
                         if stats.crc_failures > 0 {
                             warn!(crc_failures = stats.crc_failures, "MAVLink CRC failures in datagram");
+                        }
+                        if stats.invalid_estimator_status_frames > 0 {
+                            error!(
+                                invalid_frames = stats.invalid_estimator_status_frames,
+                                "private estimator status frame failed validation"
+                            );
                         }
                     }
                     Err(error) => {
@@ -338,25 +372,40 @@ fn apply_messages_at(
     latest.crc_failures = latest.crc_failures.wrapping_add(u64::from(crc_failures));
     latest.unknown_ids = latest.unknown_ids.wrapping_add(u64::from(unknown_ids));
     for &(source, message) in messages {
-        latest.decoded = latest.decoded.wrapping_add(1);
         if source.system_id != latest.system_id || source.component_id != latest.component_id {
             latest.wrong_sources = latest.wrong_sources.wrapping_add(1);
             continue;
         }
+        if message == AviateMessage::InvalidAviateEstimatorStatus {
+            latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
+            invalidate_cached_authorization(&mut latest);
+            continue;
+        }
+        latest.decoded = latest.decoded.wrapping_add(1);
         match message {
+            AviateMessage::InvalidAviateEstimatorStatus => {}
             AviateMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
             AviateMessage::CommandAck { .. } => {}
+            AviateMessage::EstimatorStatus { .. } => {}
+            AviateMessage::AviateEstimatorStatus {
+                time_usec,
+                valid_flags,
+                quality,
+            } => accept_status(&mut latest, time_usec, valid_flags, quality, now),
             AviateMessage::AttitudeQuaternion {
                 time_boot_ms,
                 quat_wxyz,
                 rates_rps,
             } => {
                 if let Some(stamp) = next_attitude_stamp(&mut latest, time_boot_ms, now) {
+                    let authorization = authorization_at(&latest, time_boot_ms);
                     latest.attitude = Some(AttitudeUpdate {
                         quat_wxyz,
                         rates_rps,
                         time_boot_ms,
                         stamp,
+                        valid_flags: authorization.valid_flags,
+                        quality: authorization.quality,
                         received_at: now,
                     });
                 }
@@ -367,11 +416,14 @@ fn apply_messages_at(
                 vel_ned_mps,
             } => {
                 if let Some(stamp) = next_kinematics_stamp(&mut latest, time_boot_ms, now) {
+                    let authorization = authorization_at(&latest, time_boot_ms);
                     latest.kinematics = Some(KinematicsUpdate {
                         pos_ned_m,
                         vel_ned_mps,
                         time_boot_ms,
                         stamp,
+                        valid_flags: authorization.valid_flags,
+                        quality: authorization.quality,
                         received_at: now,
                     });
                 }

--- a/adapters/aviate/src/link/estimator.rs
+++ b/adapters/aviate/src/link/estimator.rs
@@ -1,0 +1,138 @@
+//! Aviate estimator-status authorization for cached numeric groups.
+
+use std::time::Instant;
+
+use pilotage_adapter_api::MeasurementStamp;
+
+use super::LatestAviate;
+use super::measurement::next_estimator_status_stamp;
+
+pub(crate) const KNOWN_VALID_FLAGS: u32 = 0x0f;
+pub(crate) const QUALITY_GOOD: u32 = 0;
+pub(crate) const QUALITY_DEGRADED: u32 = 1;
+pub(crate) const QUALITY_UNUSABLE: u32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EstimatorAuthorization {
+    pub(crate) valid_flags: u32,
+    pub(crate) quality: u32,
+}
+
+impl EstimatorAuthorization {
+    fn from_fc(valid_flags: u8, quality: u8) -> Self {
+        let valid_flags = u32::from(valid_flags) & KNOWN_VALID_FLAGS;
+        match quality {
+            2 => Self {
+                valid_flags,
+                quality: QUALITY_GOOD,
+            },
+            1 => Self {
+                valid_flags,
+                quality: QUALITY_DEGRADED,
+            },
+            0 => Self {
+                valid_flags,
+                quality: QUALITY_UNUSABLE,
+            },
+            _ => Self::fail_closed(),
+        }
+    }
+
+    pub(super) const fn fail_closed() -> Self {
+        Self {
+            valid_flags: 0,
+            quality: QUALITY_UNUSABLE,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EstimatorStatusUpdate {
+    pub(crate) time_usec: u64,
+    pub(crate) time_boot_ms: u32,
+    pub(crate) authorization: EstimatorAuthorization,
+    pub(crate) stamp: MeasurementStamp,
+}
+
+pub(super) fn accept_status(
+    latest: &mut LatestAviate,
+    time_usec: u64,
+    valid_flags: u8,
+    quality: u8,
+    now: Instant,
+) {
+    let Some(time_boot_ms) = status_time_boot_ms(time_usec) else {
+        fail_closed_out_of_range_status(latest);
+        return;
+    };
+    let malformed = !time_usec.is_multiple_of(1_000) || quality > 2;
+    if malformed {
+        latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
+        if latest
+            .estimator_status
+            .is_none_or(|current| time_usec >= current.time_usec)
+        {
+            invalidate_cached_authorization(latest);
+        }
+    }
+    let Some(mut stamp) = next_estimator_status_stamp(latest, time_boot_ms, now) else {
+        return;
+    };
+    stamp.acquired_at_ns = time_usec.saturating_mul(1_000);
+    let authorization = if malformed {
+        EstimatorAuthorization::fail_closed()
+    } else {
+        EstimatorAuthorization::from_fc(valid_flags, quality)
+    };
+    degrade_cached_groups(latest, authorization);
+    latest.estimator_status = Some(EstimatorStatusUpdate {
+        time_usec,
+        time_boot_ms,
+        authorization,
+        stamp,
+    });
+}
+
+fn status_time_boot_ms(time_usec: u64) -> Option<u32> {
+    u32::try_from(time_usec / 1_000).ok()
+}
+
+fn fail_closed_out_of_range_status(latest: &mut LatestAviate) {
+    latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
+    invalidate_cached_authorization(latest);
+}
+
+pub(super) fn authorization_at(latest: &LatestAviate, time_boot_ms: u32) -> EstimatorAuthorization {
+    let time_usec = u64::from(time_boot_ms).saturating_mul(1_000);
+    latest
+        .estimator_status
+        .map_or_else(EstimatorAuthorization::fail_closed, |status| {
+            if status.time_usec == time_usec {
+                status.authorization
+            } else {
+                EstimatorAuthorization::fail_closed()
+            }
+        })
+}
+
+fn degrade_cached_groups(latest: &mut LatestAviate, status: EstimatorAuthorization) {
+    if let Some(attitude) = latest.attitude.as_mut() {
+        attitude.valid_flags &= status.valid_flags;
+        attitude.quality = attitude.quality.max(status.quality);
+    }
+    if let Some(kinematics) = latest.kinematics.as_mut() {
+        kinematics.valid_flags &= status.valid_flags;
+        kinematics.quality = kinematics.quality.max(status.quality);
+    }
+}
+
+pub(super) fn invalidate_cached_authorization(latest: &mut LatestAviate) {
+    let fail_closed = EstimatorAuthorization::fail_closed();
+    if let Some(status) = latest.estimator_status.as_mut() {
+        status.authorization = fail_closed;
+    }
+    degrade_cached_groups(latest, fail_closed);
+}
+
+#[cfg(test)]
+mod tests;

--- a/adapters/aviate/src/link/estimator/tests.rs
+++ b/adapters/aviate/src/link/estimator/tests.rs
@@ -1,0 +1,491 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::VehicleAdapter;
+use pilotage_protocol::VehicleId;
+
+use crate::AviateAdapter;
+use crate::link::{LatestAviate, ResetPolicy, apply_messages_at};
+use crate::mavlink::{AviateMessage, FrameSource};
+
+use super::{EstimatorAuthorization, QUALITY_DEGRADED, QUALITY_GOOD, QUALITY_UNUSABLE};
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 0,
+};
+
+fn state() -> Arc<Mutex<LatestAviate>> {
+    Arc::new(Mutex::new(LatestAviate::default()))
+}
+
+fn simulator_state() -> Arc<Mutex<LatestAviate>> {
+    Arc::new(Mutex::new(LatestAviate {
+        reset_policy: ResetPolicy::SimulatorHeuristic,
+        maximum_inter_group_skew_ms: 300,
+        ..LatestAviate::default()
+    }))
+}
+
+fn private_status(time_usec: u64, valid_flags: u8, quality: u8) -> AviateMessage {
+    AviateMessage::AviateEstimatorStatus {
+        time_usec,
+        valid_flags,
+        quality,
+    }
+}
+
+fn attitude(time_boot_ms: u32) -> AviateMessage {
+    AviateMessage::AttitudeQuaternion {
+        time_boot_ms,
+        quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+        rates_rps: [0.0; 3],
+    }
+}
+
+fn kinematics(time_boot_ms: u32) -> AviateMessage {
+    AviateMessage::LocalPositionNed {
+        time_boot_ms,
+        pos_ned_m: [0.0; 3],
+        vel_ned_mps: [0.0; 3],
+    }
+}
+
+fn apply(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage]) {
+    apply_at(state, messages, Instant::now());
+}
+
+fn apply_at(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage], now: Instant) {
+    let messages = messages
+        .iter()
+        .copied()
+        .map(|message| (SOURCE, message))
+        .collect::<Vec<_>>();
+    apply_messages_at(state, &messages, 0, 0, now);
+}
+
+#[test]
+fn maps_fc_quality_and_masks_unknown_validity_bits() {
+    assert_eq!(
+        EstimatorAuthorization::from_fc(0xff, 2),
+        EstimatorAuthorization {
+            valid_flags: 0x0f,
+            quality: QUALITY_GOOD,
+        }
+    );
+    assert_eq!(
+        EstimatorAuthorization::from_fc(0x03, 1).quality,
+        QUALITY_DEGRADED
+    );
+    assert_eq!(
+        EstimatorAuthorization::from_fc(0x0f, 0).quality,
+        QUALITY_UNUSABLE
+    );
+    assert_eq!(
+        EstimatorAuthorization::from_fc(0x0f, 7),
+        EstimatorAuthorization::fail_closed()
+    );
+}
+
+#[test]
+fn missing_mismatched_and_standard_status_fail_closed() {
+    let state = state();
+    apply(&state, &[attitude(100)]);
+    apply(&state, &[private_status(200_000, 0x0f, 2), kinematics(201)]);
+    apply(
+        &state,
+        &[
+            AviateMessage::EstimatorStatus {
+                time_usec: 202_000,
+                flags: u16::MAX,
+            },
+            attitude(202),
+        ],
+    );
+
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("attitude");
+    let kinematics = latest.kinematics.expect("kinematics");
+    assert_eq!(
+        (attitude.valid_flags, attitude.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        (kinematics.valid_flags, kinematics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+}
+
+#[test]
+fn status_arriving_after_numeric_does_not_regrant_it() {
+    let state = state();
+    apply(&state, &[attitude(100)]);
+    apply(&state, &[private_status(100_000, 0x0f, 2)]);
+
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("attitude");
+    assert_eq!(
+        (attitude.valid_flags, attitude.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        latest.estimator_status_stamp().map(|stamp| stamp.sequence),
+        Some(0)
+    );
+}
+
+#[test]
+fn later_status_can_revoke_but_not_restore_cached_numeric() {
+    let state = state();
+    apply(
+        &state,
+        &[
+            private_status(100_000, 0x0f, 2),
+            attitude(100),
+            kinematics(100),
+        ],
+    );
+    apply(&state, &[private_status(200_000, 0, 0)]);
+    apply(&state, &[private_status(300_000, 0x0f, 2)]);
+
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("attitude");
+    let kinematics = latest.kinematics.expect("kinematics");
+    assert_eq!(
+        (attitude.valid_flags, attitude.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        (kinematics.valid_flags, kinematics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        latest.estimator_status_stamp().map(|stamp| stamp.sequence),
+        Some(2)
+    );
+}
+
+#[test]
+fn new_exact_status_and_numeric_pair_restores_authorization() {
+    let state = state();
+    apply(
+        &state,
+        &[
+            private_status(100_000, 0, 0),
+            attitude(100),
+            kinematics(100),
+            private_status(200_000, 0x0f, 2),
+            attitude(200),
+            kinematics(200),
+        ],
+    );
+
+    let latest = state.lock().expect("lock");
+    let attitude = latest.attitude.expect("attitude");
+    let kinematics = latest.kinematics.expect("kinematics");
+    assert_eq!(
+        (attitude.valid_flags, attitude.quality),
+        (0x0f, QUALITY_GOOD)
+    );
+    assert_eq!(
+        (kinematics.valid_flags, kinematics.quality),
+        (0x0f, QUALITY_GOOD)
+    );
+}
+
+#[test]
+fn status_clock_wrap_starts_epoch_and_clears_numeric_groups() {
+    let state = state();
+    let high_ms = u32::MAX - 5;
+    apply(
+        &state,
+        &[
+            private_status(u64::from(high_ms) * 1_000, 0x0f, 2),
+            attitude(high_ms),
+            kinematics(high_ms),
+        ],
+    );
+    apply(&state, &[private_status(3_000, 0x0f, 2)]);
+
+    {
+        let latest = state.lock().expect("lock");
+        assert_eq!(latest.source_epoch, 2);
+        assert_eq!(
+            latest
+                .estimator_status_stamp()
+                .map(|stamp| (stamp.source_epoch, stamp.sequence)),
+            Some((2, 0))
+        );
+        assert!(latest.attitude.is_none());
+        assert!(latest.kinematics.is_none());
+    }
+
+    apply(
+        &state,
+        &[private_status(4_000, 0x0f, 2), attitude(4), kinematics(4)],
+    );
+    let latest = state.lock().expect("lock");
+    assert_eq!(
+        latest.estimator_status_stamp().map(|stamp| stamp.sequence),
+        Some(1)
+    );
+    assert_eq!(latest.attitude.expect("attitude").quality, QUALITY_GOOD);
+    assert_eq!(latest.kinematics.expect("kinematics").quality, QUALITY_GOOD);
+}
+
+#[test]
+fn duplicate_and_reordered_status_do_not_advance_its_sequence() {
+    let state = state();
+    apply(&state, &[private_status(100_000, 0x0f, 2)]);
+    apply(&state, &[private_status(100_000, 0, 0)]);
+    apply(&state, &[private_status(99_000, 0, 0)]);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(
+        latest.estimator_status_stamp().map(|stamp| stamp.sequence),
+        Some(0)
+    );
+    assert_eq!(latest.duplicate_measurements, 1);
+    assert_eq!(latest.reordered_measurements, 1);
+}
+
+#[test]
+fn active_low_status_clock_is_rejected() {
+    let state = simulator_state();
+    let start = Instant::now();
+    apply_at(&state, &[private_status(60_000_000, 0x0f, 2)], start);
+    apply_at(
+        &state,
+        &[private_status(100_000, 0, 0)],
+        start + Duration::from_millis(100),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert_eq!(
+        latest.estimator_status.expect("status").time_boot_ms,
+        60_000
+    );
+    assert_eq!(latest.reordered_measurements, 1);
+}
+
+#[test]
+fn status_only_reset_requires_silence_source_progress_and_receive_dwell() {
+    let state = simulator_state();
+    let start = Instant::now();
+    apply_at(&state, &[private_status(60_000_000, 0x0f, 2)], start);
+    apply_at(
+        &state,
+        &[private_status(100_000, 0x0f, 2)],
+        start + Duration::from_secs(4),
+    );
+    apply_at(
+        &state,
+        &[private_status(200_000, 0x0f, 2)],
+        start + Duration::from_millis(4_100),
+    );
+    assert_eq!(state.lock().expect("lock").source_epoch, 1);
+    apply_at(
+        &state,
+        &[private_status(400_000, 0x0f, 2)],
+        start + Duration::from_millis(4_400),
+    );
+
+    let latest = state.lock().expect("lock");
+    let stamp = latest.estimator_status_stamp().expect("new status");
+    assert_eq!((latest.source_epoch, stamp.source_epoch), (2, 2));
+    assert_eq!(stamp.sequence, 0);
+    assert_eq!(latest.source_resets, 1);
+}
+
+#[test]
+fn a_different_measurement_group_cannot_confirm_status_reset() {
+    let state = simulator_state();
+    let start = Instant::now();
+    apply_at(&state, &[private_status(60_000_000, 0x0f, 2)], start);
+    apply_at(
+        &state,
+        &[private_status(100_000, 0x0f, 2)],
+        start + Duration::from_secs(4),
+    );
+    apply_at(
+        &state,
+        &[attitude(400)],
+        start + Duration::from_millis(4_400),
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.source_epoch, 1);
+    assert!(latest.attitude.is_none());
+    assert_eq!(
+        latest.estimator_status.expect("old status").time_boot_ms,
+        60_000
+    );
+    assert_eq!(latest.source_resets, 0);
+}
+
+#[test]
+fn status_sequence_is_independent_gap_insensitive_and_wrapping() {
+    let state = state();
+    apply(&state, &[private_status(100_000, 0x0f, 2), attitude(100)]);
+    apply(&state, &[private_status(5_000_000, 0x0f, 2)]);
+    {
+        let mut latest = state.lock().expect("lock");
+        assert_eq!(latest.attitude.expect("attitude").stamp.sequence, 0);
+        assert_eq!(
+            latest.estimator_status_stamp().map(|stamp| stamp.sequence),
+            Some(1)
+        );
+        latest
+            .estimator_status
+            .as_mut()
+            .expect("status")
+            .stamp
+            .sequence = u32::MAX;
+    }
+    apply(&state, &[private_status(6_000_000, 0x0f, 2)]);
+
+    assert_eq!(
+        state
+            .lock()
+            .expect("lock")
+            .estimator_status_stamp()
+            .map(|stamp| stamp.sequence),
+        Some(0)
+    );
+}
+
+#[test]
+fn non_millisecond_status_propagates_fail_closed_without_authorizing() {
+    let state = state();
+    apply(
+        &state,
+        &[
+            private_status(100_000, 0x0f, 2),
+            attitude(100),
+            kinematics(100),
+        ],
+    );
+    apply(&state, &[private_status(200_001, 0x0f, 2)]);
+
+    let latest = state.lock().expect("lock");
+    let status = latest.estimator_status.expect("status");
+    assert_eq!(status.stamp.acquired_at_ns, 200_001_000);
+    assert_eq!(status.authorization, EstimatorAuthorization::fail_closed());
+    assert_eq!(latest.attitude.expect("attitude").quality, QUALITY_UNUSABLE);
+    assert_eq!(
+        latest.kinematics.expect("kinematics").quality,
+        QUALITY_UNUSABLE
+    );
+    assert_eq!(latest.invalid_estimator_statuses, 1);
+}
+
+#[test]
+fn same_millisecond_malformed_status_revokes_the_cached_pair() {
+    let state = state();
+    apply(
+        &state,
+        &[
+            private_status(100_000, 0x0f, 2),
+            attitude(100),
+            kinematics(100),
+        ],
+    );
+    apply(&state, &[private_status(100_001, 0x0f, 2)]);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(
+        latest
+            .estimator_status
+            .expect("last valid status")
+            .time_usec,
+        100_000
+    );
+    assert_eq!(latest.attitude.expect("attitude").quality, QUALITY_UNUSABLE);
+    assert_eq!(
+        latest.kinematics.expect("kinematics").quality,
+        QUALITY_UNUSABLE
+    );
+    assert_eq!(latest.invalid_estimator_statuses, 1);
+}
+
+#[test]
+fn same_timestamp_unknown_quality_revokes_the_cached_pair() {
+    let state = state();
+    apply(
+        &state,
+        &[
+            private_status(100_000, 0x0f, 2),
+            attitude(100),
+            kinematics(100),
+        ],
+    );
+    apply(&state, &[private_status(100_000, 0x0f, u8::MAX)]);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.attitude.expect("attitude").quality, QUALITY_UNUSABLE);
+    assert_eq!(
+        latest.kinematics.expect("kinematics").quality,
+        QUALITY_UNUSABLE
+    );
+    assert_eq!(latest.invalid_estimator_statuses, 1);
+}
+
+#[test]
+fn sampled_telemetry_tracks_status_only_revocation_without_regrant() {
+    let state = state();
+    apply(&state, &[attitude(100), kinematics(100)]);
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state.clone());
+
+    let initial = adapter.sample_telemetry();
+    let sample = &initial.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert!(avionics.estimator_status_stamp.is_none());
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+
+    apply(
+        &state,
+        &[
+            private_status(200_000, 0x0f, 2),
+            attitude(200),
+            kinematics(200),
+        ],
+    );
+    let authorized = adapter.sample_telemetry();
+    let sample = &authorized.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0x0f, QUALITY_GOOD)
+    );
+    assert_eq!(
+        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
+        Some(0)
+    );
+    assert!(sample.pose.is_some());
+    assert!(sample.speed.is_some());
+
+    apply(&state, &[private_status(300_000, 0, 0)]);
+    apply(&state, &[private_status(400_000, 0x0f, 2)]);
+    let revoked = adapter.sample_telemetry();
+    let sample = &revoked.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
+        Some(2)
+    );
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+}

--- a/adapters/aviate/src/link/measurement.rs
+++ b/adapters/aviate/src/link/measurement.rs
@@ -16,6 +16,7 @@ pub(super) const RESET_SOURCE_DWELL_MS: u32 = 250;
 pub(super) enum MeasurementGroup {
     Attitude,
     Kinematics,
+    EstimatorStatus,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -46,6 +47,7 @@ fn begin_source_epoch(latest: &mut LatestAviate, time_boot_ms: u32) {
     latest.pending_reset = None;
     latest.attitude = None;
     latest.kinematics = None;
+    latest.estimator_status = None;
     latest.source_resets = latest.source_resets.wrapping_add(1);
     warn!(
         source_epoch = latest.source_epoch,
@@ -194,6 +196,23 @@ pub(super) fn next_kinematics_stamp(
         current,
         latest,
         MeasurementGroup::Kinematics,
+        time_boot_ms,
+        now,
+    )
+}
+
+pub(super) fn next_estimator_status_stamp(
+    latest: &mut LatestAviate,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .estimator_status
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::EstimatorStatus,
         time_boot_ms,
         now,
     )

--- a/adapters/aviate/src/link/tests.rs
+++ b/adapters/aviate/src/link/tests.rs
@@ -58,6 +58,17 @@ fn kinematics_at(time_boot_ms: u32, north: f32) -> (FrameSource, AviateMessage) 
     )
 }
 
+fn status_at(time_boot_ms: u32, valid_flags: u8, quality: u8) -> (FrameSource, AviateMessage) {
+    (
+        SELECTED,
+        AviateMessage::AviateEstimatorStatus {
+            time_usec: u64::from(time_boot_ms).saturating_mul(1_000),
+            valid_flags,
+            quality,
+        },
+    )
+}
+
 fn apply_at(
     state: &Arc<Mutex<LatestAviate>>,
     messages: &[(FrameSource, AviateMessage)],
@@ -127,6 +138,141 @@ fn advancing_groups_keep_independent_sequences() {
     assert_eq!(latest.attitude.expect("attitude").stamp.sequence, 1);
     assert_eq!(latest.kinematics.expect("kinematics").stamp.sequence, 1);
     assert_eq!(latest.last_source_time_ms, Some(110));
+}
+
+#[test]
+fn invalid_status_frame_revokes_without_fabricating_source_time() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(
+        &state,
+        &[
+            status_at(100, 0x0f, 2),
+            attitude_at(100, 0.5),
+            kinematics_at(100, 1.0),
+        ],
+        now,
+    );
+    let status_before = state
+        .lock()
+        .expect("lock")
+        .estimator_status_stamp()
+        .expect("status");
+    apply_messages_at(
+        &state,
+        &[(SELECTED, AviateMessage::InvalidAviateEstimatorStatus)],
+        1,
+        0,
+        now,
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.estimator_status_stamp(), Some(status_before));
+    assert_eq!(latest.attitude.expect("attitude").quality, 2);
+    assert_eq!(latest.kinematics.expect("kinematics").quality, 2);
+    assert_eq!(latest.invalid_estimator_statuses, 1);
+}
+
+#[test]
+fn invalid_status_poisons_authorization_for_delayed_exact_numeric() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(&state, &[status_at(100, 0x0f, 2)], now);
+    apply_at(
+        &state,
+        &[(SELECTED, AviateMessage::InvalidAviateEstimatorStatus)],
+        now,
+    );
+    apply_at(&state, &[kinematics_at(100, 1.0)], now);
+
+    let latest = state.lock().expect("lock");
+    let kinematics = latest.kinematics.expect("kinematics");
+    assert_eq!((kinematics.valid_flags, kinematics.quality), (0, 2));
+}
+
+#[test]
+fn trailing_invalid_status_wins_within_a_multi_frame_datagram() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(
+        &state,
+        &[
+            status_at(100, 0x0f, 2),
+            attitude_at(100, 0.5),
+            kinematics_at(100, 1.0),
+            (SELECTED, AviateMessage::InvalidAviateEstimatorStatus),
+        ],
+        now,
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.attitude.expect("attitude").quality, 2);
+    assert_eq!(latest.kinematics.expect("kinematics").quality, 2);
+    assert_eq!(
+        latest
+            .estimator_status
+            .expect("status")
+            .authorization
+            .quality,
+        2
+    );
+}
+
+#[test]
+fn wrong_source_invalid_status_cannot_revoke_selected_source() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(
+        &state,
+        &[status_at(100, 0x0f, 2), attitude_at(100, 0.5)],
+        now,
+    );
+    let mut wrong = SELECTED;
+    wrong.system_id = 2;
+    apply_at(
+        &state,
+        &[(wrong, AviateMessage::InvalidAviateEstimatorStatus)],
+        now,
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.attitude.expect("attitude").quality, 0);
+    assert_eq!(latest.invalid_estimator_statuses, 0);
+    assert_eq!(latest.wrong_sources, 1);
+}
+
+#[test]
+fn out_of_range_status_revokes_without_fabricating_source_time() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    apply_at(
+        &state,
+        &[
+            status_at(100, 0x0f, 2),
+            attitude_at(100, 0.5),
+            kinematics_at(100, 1.0),
+        ],
+        now,
+    );
+    let status_before = state.lock().expect("lock").estimator_status_stamp();
+    apply_at(
+        &state,
+        &[(
+            SELECTED,
+            AviateMessage::AviateEstimatorStatus {
+                time_usec: (u64::from(u32::MAX) + 1).saturating_mul(1_000),
+                valid_flags: 0x0f,
+                quality: 2,
+            },
+        )],
+        now,
+    );
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(latest.estimator_status_stamp(), status_before);
+    assert_eq!(latest.attitude.expect("attitude").quality, 2);
+    assert_eq!(latest.kinematics.expect("kinematics").quality, 2);
+    assert_eq!(latest.invalid_estimator_statuses, 1);
 }
 
 #[test]

--- a/adapters/aviate/src/mavlink.rs
+++ b/adapters/aviate/src/mavlink.rs
@@ -2,11 +2,15 @@
 //! (ADR-0018): pure byte functions, no I/O, no allocation on the parse
 //! path beyond the caller's message vector.
 //!
-//! Only the three message ids Aviate emits are decoded; anything else is
-//! counted and skipped. CRC is the MAVLink X.25 accumulator seeded with
+//! The decoded telemetry set includes liveness, estimator values, and both
+//! standard and Aviate-specific estimator status. Anything else is counted
+//! and skipped. CRC is the MAVLink X.25 accumulator seeded with
 //! each message's CRC_EXTRA (values cross-checked against Aviate's
 //! `aviate-link` implementation, the peer this parser must interoperate
 //! with byte-for-byte).
+
+mod decoding;
+use decoding::decode_known;
 
 /// MAVLink 2.0 start-of-frame marker.
 pub const MAGIC_V2: u8 = 0xFD;
@@ -18,10 +22,17 @@ pub const ATTITUDE_QUATERNION_ID: u32 = 31;
 pub const LOCAL_POSITION_NED_ID: u32 = 32;
 /// COMMAND_ACK message id (arm/disarm feedback).
 pub const COMMAND_ACK_ID: u32 = 77;
+/// Standard ESTIMATOR_STATUS message id.
+pub const ESTIMATOR_STATUS_ID: u32 = 230;
+/// Aviate's lossless estimator authorization message id.
+pub const AVIATE_ESTIMATOR_STATUS_ID: u32 = 20_000;
 
-/// One decoded telemetry message from the Aviate subset.
+/// One parsed frame event from the Aviate subset.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AviateMessage {
+    /// A private estimator-status frame whose integrity or framing could not
+    /// be validated. This event can only revoke authorization.
+    InvalidAviateEstimatorStatus,
     /// Link liveness beacon (1 Hz); `armed` is base_mode's
     /// MAV_MODE_FLAG_SAFETY_ARMED bit.
     Heartbeat {
@@ -54,6 +65,23 @@ pub enum AviateMessage {
         /// Velocity (north, east, down) in meters/second.
         vel_ned_mps: [f32; 3],
     },
+    /// Standard estimator health projection. This message is diagnostic and
+    /// never authorizes Pilotage consumers to use an estimate.
+    EstimatorStatus {
+        /// Microseconds since FC boot.
+        time_usec: u64,
+        /// MAVLink ESTIMATOR_STATUS flags.
+        flags: u16,
+    },
+    /// Aviate's lossless estimator validity and quality report.
+    AviateEstimatorStatus {
+        /// Microseconds since FC boot.
+        time_usec: u64,
+        /// Source validity bits.
+        valid_flags: u8,
+        /// Source quality enum: 0 unusable, 1 degraded, 2 good.
+        quality: u8,
+    },
 }
 
 /// Datagram parse accounting, for link diagnostics.
@@ -63,6 +91,10 @@ pub struct ParseStats {
     pub decoded: u32,
     /// Frames with a valid layout but a CRC mismatch.
     pub crc_failures: u32,
+    /// Private estimator-status frames whose integrity, compatibility, or
+    /// declared frame extent could not be validated. Consumers use this as an
+    /// immediate revocation signal; it never authorizes numeric telemetry.
+    pub invalid_estimator_status_frames: u32,
     /// Structurally valid frames carrying a message id this parser does
     /// not know (skipped whole).
     pub unknown_ids: u32,
@@ -94,6 +126,8 @@ fn crc_extra(msg_id: u32) -> Option<u8> {
         ATTITUDE_QUATERNION_ID => Some(246),
         LOCAL_POSITION_NED_ID => Some(185),
         COMMAND_ACK_ID => Some(143),
+        ESTIMATOR_STATUS_ID => Some(163),
+        AVIATE_ESTIMATOR_STATUS_ID => Some(171),
         COMMAND_LONG_ID => Some(152),
         SET_POSITION_TARGET_ID => Some(143),
         _ => None,
@@ -116,61 +150,31 @@ fn compute_crc(data: &[u8], extra: u8) -> u16 {
     crc_accumulate(extra, crc)
 }
 
-/// Reads an `f32` at `off`, zero-extending past the payload end
-/// (MAVLink 2 truncates trailing zero bytes on the wire).
-fn f32_at(payload: &[u8], off: usize) -> f32 {
-    let mut b = [0u8; 4];
-    for (i, slot) in b.iter_mut().enumerate() {
-        *slot = payload.get(off + i).copied().unwrap_or(0);
-    }
-    f32::from_le_bytes(b)
+fn frame_header(bytes: &[u8], at: usize) -> Option<(FrameSource, u32)> {
+    let header = bytes.get(at..at + 10)?;
+    let source = FrameSource {
+        frame_sequence: header[4],
+        system_id: header[5],
+        component_id: header[6],
+    };
+    let message_id =
+        u32::from(header[7]) | (u32::from(header[8]) << 8) | (u32::from(header[9]) << 16);
+    Some((source, message_id))
 }
 
-/// Reads a `u32` at `off` with the same zero extension.
-fn u32_at(payload: &[u8], off: usize) -> u32 {
-    let mut b = [0u8; 4];
-    for (i, slot) in b.iter_mut().enumerate() {
-        *slot = payload.get(off + i).copied().unwrap_or(0);
-    }
-    u32::from_le_bytes(b)
-}
-
-fn decode_known(msg_id: u32, payload: &[u8]) -> Option<AviateMessage> {
-    match msg_id {
-        HEARTBEAT_ID => Some(AviateMessage::Heartbeat {
-            // Payload: custom_mode u32 @0, type @4, autopilot @5,
-            // base_mode @6 (bit 0x80 = SAFETY_ARMED).
-            armed: payload.get(6).is_some_and(|b| b & 0x80 != 0),
-        }),
-        COMMAND_ACK_ID => Some(AviateMessage::CommandAck {
-            command: u16::from(payload.first().copied().unwrap_or(0))
-                | (u16::from(payload.get(1).copied().unwrap_or(0)) << 8),
-            result: payload.get(2).copied().unwrap_or(0),
-        }),
-        ATTITUDE_QUATERNION_ID => Some(AviateMessage::AttitudeQuaternion {
-            time_boot_ms: u32_at(payload, 0),
-            quat_wxyz: [
-                f32_at(payload, 4),
-                f32_at(payload, 8),
-                f32_at(payload, 12),
-                f32_at(payload, 16),
-            ],
-            rates_rps: [
-                f32_at(payload, 20),
-                f32_at(payload, 24),
-                f32_at(payload, 28),
-            ],
-        }),
-        LOCAL_POSITION_NED_ID => Some(AviateMessage::LocalPositionNed {
-            time_boot_ms: u32_at(payload, 0),
-            pos_ned_m: [f32_at(payload, 4), f32_at(payload, 8), f32_at(payload, 12)],
-            vel_ned_mps: [
-                f32_at(payload, 16),
-                f32_at(payload, 20),
-                f32_at(payload, 24),
-            ],
-        }),
-        _ => None,
+fn record_invalid_private_status(
+    bytes: &[u8],
+    at: usize,
+    stats: &mut ParseStats,
+    out: &mut Vec<(FrameSource, AviateMessage)>,
+) {
+    let Some((source, message_id)) = frame_header(bytes, at) else {
+        return;
+    };
+    if message_id == AVIATE_ESTIMATOR_STATUS_ID {
+        stats.invalid_estimator_status_frames =
+            stats.invalid_estimator_status_frames.wrapping_add(1);
+        out.push((source, AviateMessage::InvalidAviateEstimatorStatus));
     }
 }
 
@@ -178,8 +182,9 @@ fn decode_known(msg_id: u32, payload: &[u8]) -> Option<AviateMessage> {
 /// several), appending `(sender identity, message)` pairs to `out` and
 /// returning parse accounting. Consumers match both system and component ids;
 /// first-packet source selection is not an identity policy.
-/// Unknown ids and CRC failures skip the frame; stray bytes before a
-/// frame start are discarded byte-by-byte.
+/// Unknown ids and ordinary CRC failures skip the frame. A private-status
+/// integrity failure appends a source-tagged revocation event. Stray bytes
+/// before a frame start are discarded byte-by-byte.
 pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>) -> ParseStats {
     let mut stats = ParseStats::default();
     let mut at = 0usize;
@@ -194,12 +199,20 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>)
         let Some(&incompat) = bytes.get(at + 2) else {
             break;
         };
+        if incompat & !0x01 != 0 {
+            record_invalid_private_status(bytes, at, &mut stats, out);
+            // Unknown incompatibility bits may change the frame layout, so
+            // no later byte boundary in this datagram is trustworthy.
+            stats.garbage_bytes = stats.garbage_bytes.wrapping_add((bytes.len() - at) as u32);
+            break;
+        }
         let payload_len = usize::from(len);
         let signed = incompat & 0x01 != 0;
         let sig_len = if signed { 13 } else { 0 };
         let frame_len = 10 + payload_len + 2 + sig_len;
         let Some(frame) = bytes.get(at..at + frame_len) else {
             // Truncated tail; nothing after it can parse either.
+            record_invalid_private_status(bytes, at, &mut stats, out);
             stats.garbage_bytes = stats.garbage_bytes.wrapping_add((bytes.len() - at) as u32);
             break;
         };
@@ -221,6 +234,11 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>)
                     }
                 } else {
                     stats.crc_failures = stats.crc_failures.wrapping_add(1);
+                    if msg_id == AVIATE_ESTIMATOR_STATUS_ID {
+                        stats.invalid_estimator_status_frames =
+                            stats.invalid_estimator_status_frames.wrapping_add(1);
+                        out.push((source, AviateMessage::InvalidAviateEstimatorStatus));
+                    }
                 }
             }
             None => {

--- a/adapters/aviate/src/mavlink/decoding.rs
+++ b/adapters/aviate/src/mavlink/decoding.rs
@@ -1,0 +1,86 @@
+//! Payload decoding with MAVLink 2 trailing-zero extension.
+
+use super::{
+    ATTITUDE_QUATERNION_ID, AVIATE_ESTIMATOR_STATUS_ID, AviateMessage, COMMAND_ACK_ID,
+    ESTIMATOR_STATUS_ID, HEARTBEAT_ID, LOCAL_POSITION_NED_ID,
+};
+
+fn f32_at(payload: &[u8], off: usize) -> f32 {
+    let mut bytes = [0_u8; 4];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    f32::from_le_bytes(bytes)
+}
+
+fn u32_at(payload: &[u8], off: usize) -> u32 {
+    let mut bytes = [0_u8; 4];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u32::from_le_bytes(bytes)
+}
+
+fn u64_at(payload: &[u8], off: usize) -> u64 {
+    let mut bytes = [0_u8; 8];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u64::from_le_bytes(bytes)
+}
+
+fn u16_at(payload: &[u8], off: usize) -> u16 {
+    let mut bytes = [0_u8; 2];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u16::from_le_bytes(bytes)
+}
+
+pub(super) fn decode_known(msg_id: u32, payload: &[u8]) -> Option<AviateMessage> {
+    match msg_id {
+        HEARTBEAT_ID => Some(AviateMessage::Heartbeat {
+            // Payload: custom_mode u32 @0, type @4, autopilot @5,
+            // base_mode @6 (bit 0x80 = SAFETY_ARMED).
+            armed: payload.get(6).is_some_and(|b| b & 0x80 != 0),
+        }),
+        COMMAND_ACK_ID => Some(AviateMessage::CommandAck {
+            command: u16::from(payload.first().copied().unwrap_or(0))
+                | (u16::from(payload.get(1).copied().unwrap_or(0)) << 8),
+            result: payload.get(2).copied().unwrap_or(0),
+        }),
+        ATTITUDE_QUATERNION_ID => Some(AviateMessage::AttitudeQuaternion {
+            time_boot_ms: u32_at(payload, 0),
+            quat_wxyz: [
+                f32_at(payload, 4),
+                f32_at(payload, 8),
+                f32_at(payload, 12),
+                f32_at(payload, 16),
+            ],
+            rates_rps: [
+                f32_at(payload, 20),
+                f32_at(payload, 24),
+                f32_at(payload, 28),
+            ],
+        }),
+        LOCAL_POSITION_NED_ID => Some(AviateMessage::LocalPositionNed {
+            time_boot_ms: u32_at(payload, 0),
+            pos_ned_m: [f32_at(payload, 4), f32_at(payload, 8), f32_at(payload, 12)],
+            vel_ned_mps: [
+                f32_at(payload, 16),
+                f32_at(payload, 20),
+                f32_at(payload, 24),
+            ],
+        }),
+        ESTIMATOR_STATUS_ID => Some(AviateMessage::EstimatorStatus {
+            time_usec: u64_at(payload, 0),
+            flags: u16_at(payload, 40),
+        }),
+        AVIATE_ESTIMATOR_STATUS_ID => Some(AviateMessage::AviateEstimatorStatus {
+            time_usec: u64_at(payload, 0),
+            valid_flags: payload.get(8).copied().unwrap_or(0),
+            quality: payload.get(9).copied().unwrap_or(0),
+        }),
+        _ => None,
+    }
+}

--- a/adapters/aviate/src/mavlink/tests.rs
+++ b/adapters/aviate/src/mavlink/tests.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use super::{
-    ATTITUDE_QUATERNION_ID, AviateMessage, FrameSource, LOCAL_POSITION_NED_ID, MAGIC_V2,
-    encode_gcs_heartbeat, parse_datagram,
+    ATTITUDE_QUATERNION_ID, AVIATE_ESTIMATOR_STATUS_ID, AviateMessage, ESTIMATOR_STATUS_ID,
+    FrameSource, LOCAL_POSITION_NED_ID, MAGIC_V2, encode_gcs_heartbeat, parse_datagram,
 };
 
 const SOURCE: FrameSource = FrameSource {
@@ -38,6 +38,8 @@ fn encode_frame(msg_id: u32, payload: &[u8], truncate: bool) -> Vec<u8> {
         0 => 50,
         31 => 246,
         32 => 185,
+        230 => 163,
+        20_000 => 171,
         other => (other & 0xff) as u8,
     };
     let crc = super::compute_crc(&frame[1..], extra);
@@ -135,6 +137,88 @@ fn v2_truncated_payload_zero_extends() {
 }
 
 #[test]
+fn decodes_aviate_estimator_status_golden_vectors() {
+    let cases = [
+        (
+            vec![
+                253, 10, 0, 0, 7, 1, 1, 32, 78, 0, 184, 130, 1, 0, 0, 0, 0, 0, 15, 2, 238, 73,
+            ],
+            AviateMessage::AviateEstimatorStatus {
+                time_usec: 99_000,
+                valid_flags: 0x0f,
+                quality: 2,
+            },
+            7,
+        ),
+        (
+            vec![
+                253, 10, 0, 0, 4, 1, 1, 32, 78, 0, 144, 208, 3, 0, 0, 0, 0, 0, 3, 1, 137, 232,
+            ],
+            AviateMessage::AviateEstimatorStatus {
+                time_usec: 250_000,
+                valid_flags: 0x03,
+                quality: 1,
+            },
+            4,
+        ),
+        (
+            vec![253, 2, 0, 0, 7, 1, 1, 32, 78, 0, 104, 66, 104, 226],
+            AviateMessage::AviateEstimatorStatus {
+                time_usec: 17_000,
+                valid_flags: 0,
+                quality: 0,
+            },
+            7,
+        ),
+    ];
+
+    for (frame, expected, frame_sequence) in cases {
+        let mut out = Vec::new();
+        let stats = parse_datagram(&frame, &mut out);
+        assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+        assert_eq!(
+            out,
+            vec![(
+                FrameSource {
+                    frame_sequence,
+                    ..SOURCE
+                },
+                expected
+            )]
+        );
+    }
+}
+
+#[test]
+fn standard_estimator_status_is_known_but_distinct() {
+    let frame = [253, 2, 0, 0, 7, 1, 1, 230, 0, 0, 104, 66, 51, 209];
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    assert_eq!(
+        out,
+        vec![(
+            SOURCE,
+            AviateMessage::EstimatorStatus {
+                time_usec: 17_000,
+                flags: 0,
+            }
+        )]
+    );
+}
+
+#[test]
+fn status_test_serializer_uses_the_canonical_crc_extras() {
+    let private = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let standard = encode_frame(ESTIMATOR_STATUS_ID, &[0; 42], false);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&private, &mut out);
+    assert_eq!(stats.decoded, 1);
+    let stats = parse_datagram(&standard, &mut out);
+    assert_eq!(stats.decoded, 1);
+}
+
+#[test]
 fn corrupted_frame_fails_crc_and_is_skipped() {
     let mut frame = encode_frame(
         LOCAL_POSITION_NED_ID,
@@ -145,7 +229,68 @@ fn corrupted_frame_fails_crc_and_is_skipped() {
     let mut out: Vec<(FrameSource, AviateMessage)> = Vec::new();
     let stats = parse_datagram(&frame, &mut out);
     assert_eq!(stats.crc_failures, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 0);
     assert!(out.is_empty());
+}
+
+#[test]
+fn corrupted_private_status_is_an_explicit_revocation_signal() {
+    let mut frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    frame[10] ^= 0xff;
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.crc_failures, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert_eq!(
+        out,
+        vec![(SOURCE, AviateMessage::InvalidAviateEstimatorStatus)]
+    );
+}
+
+#[test]
+fn truncated_private_status_is_an_explicit_revocation_signal() {
+    let frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame[..frame.len() - 1], &mut out);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(stats.garbage_bytes > 0);
+    assert_eq!(
+        out,
+        vec![(SOURCE, AviateMessage::InvalidAviateEstimatorStatus)]
+    );
+}
+
+#[test]
+fn unsupported_incompatibility_flags_never_authorize_private_status() {
+    let mut frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    frame[2] = 0x02;
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(stats.garbage_bytes > 0);
+    assert_eq!(
+        out,
+        vec![(SOURCE, AviateMessage::InvalidAviateEstimatorStatus)]
+    );
+}
+
+#[test]
+fn invalid_private_status_event_preserves_datagram_order() {
+    let mut datagram = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let mut invalid = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    invalid[10] ^= 0xff;
+    datagram.extend_from_slice(&invalid);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.decoded, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(matches!(
+        out.as_slice(),
+        [
+            (_, AviateMessage::AviateEstimatorStatus { .. }),
+            (_, AviateMessage::InvalidAviateEstimatorStatus)
+        ]
+    ));
 }
 
 #[test]

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -9,8 +9,9 @@
 //! converts to the NED/FRD convention the telemetry plane carries,
 //! mirroring Aviate's own conversion math exactly.
 //!
-//! v0 reads the simulator ground-truth block; the FC-estimate block with
-//! real validity flags is the deferred vehicle-link RFC's v1.
+//! The shared block is coherent simulator ground truth. Its sampler publishes
+//! an explicit synthetic authorization stamp so consumers can distinguish
+//! this source from FC estimator telemetry.
 
 use std::ffi::CString;
 use std::time::Instant;

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -871,7 +871,7 @@ function renderInstruments() {
   const snapshot = instruments.ingress.snapshot(performance.now());
   const attitude = snapshot.attitude;
   const kinematics = snapshot.kinematics;
-  const quality = Math.max(attitude?.quality ?? 0, kinematics?.quality ?? 0);
+  const validFlags = snapshot.validFlags;
   const coherence = {
     insufficient: 0,
     coherent: 1,
@@ -884,12 +884,12 @@ function renderInstruments() {
     nav: null,
     wind: null,
     selections: { headingBugRad: 0 },
-    quality,
+    quality: snapshot.quality,
     valid: {
-      attitude: !!(attitude?.validFlags & 1),
-      rates: !!(attitude?.validFlags & 2),
-      position: !!(kinematics?.validFlags & 4),
-      velocity: !!(kinematics?.validFlags & 8),
+      attitude: !!(validFlags & 1),
+      rates: !!(validFlags & 2),
+      position: !!(validFlags & 4),
+      velocity: !!(validFlags & 8),
     },
     snapshot: { generation: snapshot.generation, coherence },
   };

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -16,6 +16,10 @@ export const INCARNATION_POLICY = Object.freeze({
 const SERIAL_HALF_RANGE = 0x80000000;
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
+const QUALITY_UNUSABLE = 2;
+const ATTITUDE_VALID_FLAGS = 0b0011;
+const KINEMATICS_VALID_FLAGS = 0b1100;
+const KNOWN_VALID_FLAGS = ATTITUDE_VALID_FLAGS | KINEMATICS_VALID_FLAGS;
 
 function increment(value, amount = 1) {
   return (value + amount) >>> 0;
@@ -53,8 +57,6 @@ function copyAttitude(avionics) {
   return Object.freeze({
     quat: Object.freeze({ ...avionics.quat }),
     rates: Object.freeze([...avionics.rates]),
-    validFlags: avionics.validFlags >>> 0,
-    quality: avionics.quality >>> 0,
     armState: avionics.armState >>> 0,
   });
 }
@@ -63,14 +65,45 @@ function copyKinematics(avionics) {
   return Object.freeze({
     posNed: Object.freeze([...avionics.posNed]),
     velNed: Object.freeze([...avionics.velNed]),
-    validFlags: avionics.validFlags >>> 0,
-    quality: avionics.quality >>> 0,
     armState: avionics.armState >>> 0,
   });
 }
 
+function copyEstimatorStatus() {
+  return Object.freeze({});
+}
+
 function stampCopy(stamp) {
   return Object.freeze({ ...stamp });
+}
+
+function stampsEqual(left, right) {
+  return (
+    left !== null &&
+    left !== undefined &&
+    right !== null &&
+    right !== undefined &&
+    left.sourceId === right.sourceId &&
+    left.sourceIncarnation === right.sourceIncarnation &&
+    left.sourceEpoch === right.sourceEpoch &&
+    left.sequence === right.sequence &&
+    left.acquiredAtNanos === right.acquiredAtNanos &&
+    left.clock === right.clock
+  );
+}
+
+function sameAcquisition(left, right) {
+  return (
+    left !== null &&
+    left !== undefined &&
+    right !== null &&
+    right !== undefined &&
+    left.sourceId === right.sourceId &&
+    left.sourceIncarnation === right.sourceIncarnation &&
+    left.sourceEpoch === right.sourceEpoch &&
+    left.acquiredAtNanos === right.acquiredAtNanos &&
+    left.clock === right.clock
+  );
 }
 
 function groupSnapshot(group, nowMs) {
@@ -141,6 +174,11 @@ export class AvionicsIngress {
     this.sourceEpoch = null;
     this.attitude = null;
     this.kinematics = null;
+    this.estimatorStatus = null;
+    this.attitudeAuthorizationPaired = false;
+    this.kinematicsAuthorizationPaired = false;
+    this.validFlags = 0;
+    this.quality = QUALITY_UNUSABLE;
     this.generation = 0;
     this.lastCoherence = COHERENCE.INSUFFICIENT;
     this.counters = {
@@ -171,16 +209,34 @@ export class AvionicsIngress {
     const avionics = message.avionics;
     if (!avionics) return false;
 
-    let changed = false;
-    changed = this.acceptGroup("attitude", avionics.attitudeStamp, copyAttitude, avionics, nowMs)
-      || changed;
-    changed = this.acceptGroup(
+    const acceptedStatus = this.acceptGroup(
+      "estimatorStatus",
+      avionics.estimatorStatusStamp,
+      copyEstimatorStatus,
+      avionics,
+      nowMs,
+    );
+    const acceptedAttitude = this.acceptGroup(
+      "attitude",
+      avionics.attitudeStamp,
+      copyAttitude,
+      avionics,
+      nowMs,
+    );
+    const acceptedKinematics = this.acceptGroup(
       "kinematics",
       avionics.kinematicsStamp,
       copyKinematics,
       avionics,
       nowMs,
-    ) || changed;
+    );
+    const acceptedNumeric = acceptedAttitude || acceptedKinematics;
+    const previousValidFlags = this.validFlags;
+    const previousQuality = this.quality;
+    this.updateAuthorization(avionics, acceptedAttitude, acceptedKinematics);
+    const authorizationChanged =
+      this.validFlags !== previousValidFlags || this.quality !== previousQuality;
+    const changed = acceptedNumeric || acceptedStatus || authorizationChanged;
     if (changed) {
       this.generation = increment(this.generation);
       this.recordCoherenceTransition();
@@ -188,8 +244,78 @@ export class AvionicsIngress {
     return changed;
   }
 
+  updateAuthorization(avionics, acceptedAttitude, acceptedKinematics) {
+    // A transport validation fault cannot mint a source acquisition time, so
+    // a publication backed by the current stamp may change trust only in the
+    // fail-closed direction and never refreshes that stamp's age.
+    if (stampsEqual(avionics.estimatorStatusStamp, this.estimatorStatus?.stamp)) {
+      this.applyStatusDowngrade(avionics);
+    }
+    if (acceptedAttitude || acceptedKinematics) {
+      this.updateAuthorizationFromNumeric(avionics, acceptedAttitude, acceptedKinematics);
+    }
+  }
+
+  applyStatusDowngrade(avionics) {
+    if (!this.hasEstablishedAuthorization()) {
+      this.failClosedAuthorization();
+      return;
+    }
+    this.validFlags = (this.validFlags & (avionics.validFlags >>> 0)) >>> 0;
+    this.quality = Math.max(this.quality, avionics.quality >>> 0);
+  }
+
+  updateAuthorizationFromNumeric(avionics, acceptedAttitude, acceptedKinematics) {
+    const currentStatusStamp = this.estimatorStatus?.stamp;
+    const statusMatches = stampsEqual(avionics.estimatorStatusStamp, currentStatusStamp);
+    const incomingValidFlags = avionics.validFlags >>> 0;
+    let acceptedExactPair = false;
+    if (acceptedAttitude) {
+      this.attitudeAuthorizationPaired =
+        statusMatches && sameAcquisition(avionics.attitudeStamp, currentStatusStamp);
+      const attitudeFlags = this.attitudeAuthorizationPaired
+        ? incomingValidFlags & ATTITUDE_VALID_FLAGS
+        : 0;
+      this.validFlags = (
+        (this.validFlags & ~ATTITUDE_VALID_FLAGS) | attitudeFlags
+      ) >>> 0;
+      acceptedExactPair = this.attitudeAuthorizationPaired;
+    }
+    if (acceptedKinematics) {
+      this.kinematicsAuthorizationPaired =
+        statusMatches && sameAcquisition(avionics.kinematicsStamp, currentStatusStamp);
+      const kinematicsFlags = this.kinematicsAuthorizationPaired
+        ? incomingValidFlags & KINEMATICS_VALID_FLAGS
+        : 0;
+      this.validFlags = (
+        (this.validFlags & ~KINEMATICS_VALID_FLAGS) | kinematicsFlags
+      ) >>> 0;
+      acceptedExactPair = acceptedExactPair || this.kinematicsAuthorizationPaired;
+    }
+
+    if ((this.validFlags & KNOWN_VALID_FLAGS) === 0) {
+      this.quality = QUALITY_UNUSABLE;
+      return;
+    }
+    if (acceptedExactPair) this.quality = avionics.quality >>> 0;
+  }
+
+  hasEstablishedAuthorization() {
+    return (
+      (this.attitude !== null && this.attitudeAuthorizationPaired) ||
+      (this.kinematics !== null && this.kinematicsAuthorizationPaired)
+    );
+  }
+
+  failClosedAuthorization() {
+    this.attitudeAuthorizationPaired = false;
+    this.kinematicsAuthorizationPaired = false;
+    this.validFlags = 0;
+    this.quality = QUALITY_UNUSABLE;
+  }
+
   acceptGroup(name, stamp, copyData, avionics, nowMs) {
-    if (stamp === null) return false;
+    if (stamp === null || stamp === undefined) return false;
     if (!isStampValid(stamp)) {
       this.bump("invalidStamps");
       return false;
@@ -261,6 +387,8 @@ export class AvionicsIngress {
     this.sourceEpoch = null;
     this.attitude = null;
     this.kinematics = null;
+    this.estimatorStatus = null;
+    this.failClosedAuthorization();
     this.lastCoherence = COHERENCE.INSUFFICIENT;
     this.bump("incarnationTransitions");
     return true;
@@ -279,6 +407,8 @@ export class AvionicsIngress {
     this.sourceEpoch = candidate;
     this.attitude = null;
     this.kinematics = null;
+    this.estimatorStatus = null;
+    this.failClosedAuthorization();
     this.bump("sourceResets");
     return true;
   }
@@ -298,6 +428,7 @@ export class AvionicsIngress {
     if (!Number.isFinite(nowMs)) throw new TypeError("nowMs must be finite");
     const attitude = groupSnapshot(this.attitude, nowMs);
     const kinematics = groupSnapshot(this.kinematics, nowMs);
+    const estimatorStatus = groupSnapshot(this.estimatorStatus, nowMs);
     return Object.freeze({
       generation: this.generation,
       sourceId: this.sourceId,
@@ -305,6 +436,9 @@ export class AvionicsIngress {
       sourceEpoch: this.sourceEpoch,
       attitude,
       kinematics,
+      estimatorStatus,
+      validFlags: this.validFlags,
+      quality: this.quality,
       coherence: coherenceOf(this.attitude, this.kinematics, this.maximumSkewNanos),
     });
   }

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -35,11 +35,43 @@ function avionics(attitudeStamp, kinematicsStamp, value = 1) {
     armState: 2,
     attitudeStamp,
     kinematicsStamp,
+    estimatorStatusStamp: null,
   };
 }
 
 function packet(attitudeStamp, kinematicsStamp, value = 1, vehicleId = VEHICLE) {
   return { vehicleId, avionics: avionics(attitudeStamp, kinematicsStamp, value) };
+}
+
+function statusPacket(statusStamp, validFlags, quality, vehicleId = VEHICLE) {
+  return {
+    vehicleId,
+    avionics: {
+      ...avionics(null, null),
+      validFlags,
+      quality,
+      estimatorStatusStamp: statusStamp,
+    },
+  };
+}
+
+function pairedPacket(
+  attitudeStamp,
+  kinematicsStamp,
+  statusStamp,
+  value,
+  validFlags,
+  quality,
+) {
+  return {
+    vehicleId: VEHICLE,
+    avionics: {
+      ...avionics(attitudeStamp, kinematicsStamp, value),
+      validFlags,
+      quality,
+      estimatorStatusStamp: statusStamp,
+    },
+  };
 }
 
 function ingress(maximumSkewNanos = 100n) {
@@ -174,21 +206,224 @@ function testIndependentGroupsAndCoherenceBoundary() {
   assert.equal(snapshot.kinematics.posNed[0], 3);
 }
 
+function testStatusOnlyRevocationDoesNotRefreshMeasurements() {
+  const gate = ingress();
+  const initialStatus = stamp(10, 1_000n);
+  gate.ingest(statusPacket(initialStatus, 0b1111, 0), 10);
+  let snapshot = gate.snapshot(10);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+
+  gate.ingest(
+    pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), initialStatus, 1, 0b1111, 0),
+    15,
+  );
+  snapshot = gate.snapshot(20);
+  assert.equal(snapshot.generation, 2);
+  assert.equal(snapshot.validFlags, 0b1111);
+  assert.equal(snapshot.quality, 0);
+  assert.equal(snapshot.attitude.ageMs, 5);
+  assert.equal(snapshot.estimatorStatus.ageMs, 10);
+
+  assert.equal(gate.ingest(statusPacket(stamp(11, 1_100n), 0, 2), 30), true);
+  snapshot = gate.snapshot(40);
+  assert.equal(snapshot.generation, 3);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(snapshot.attitude.ageMs, 25);
+  assert.equal(snapshot.kinematics.ageMs, 25);
+  assert.equal(snapshot.estimatorStatus.ageMs, 10);
+}
+
+function testStatusPayloadAloneControlsAuthorization() {
+  const gate = ingress();
+  const unusableStatus = stamp(10, 1_000n);
+  gate.ingest(statusPacket(unusableStatus, 0, 2), 0);
+  gate.ingest(pairedPacket(stamp(1, 1_000n), null, unusableStatus, 1, 0, 2), 1);
+
+  const goodStatus = stamp(11, 1_100n);
+  gate.ingest(statusPacket(goodStatus, 0b1111, 0), 2);
+  let snapshot = gate.snapshot(2);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal("quality" in snapshot.estimatorStatus, false);
+  assert.equal("validFlags" in snapshot.estimatorStatus, false);
+
+  gate.ingest(pairedPacket(stamp(2, 1_050n), null, goodStatus, 2, 0b0011, 0), 3);
+  snapshot = gate.snapshot(3);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(snapshot.validFlags, 0);
+
+  gate.ingest(pairedPacket(stamp(3, 1_100n), null, goodStatus, 3, 0b0011, 0), 4);
+  snapshot = gate.snapshot(4);
+  assert.equal(snapshot.quality, 0);
+  assert.equal(snapshot.validFlags, 0b0011);
+
+  gate.ingest(statusPacket(stamp(12, 1_300n), 0b0001, 1), 5);
+  gate.ingest(statusPacket(stamp(13, 1_400n), 0b1111, 0), 6);
+  snapshot = gate.snapshot(6);
+  assert.equal(snapshot.quality, 1);
+  assert.equal(snapshot.validFlags, 0b0001);
+}
+
+function testMismatchedGroupCannotRegainThroughOtherNumeric() {
+  const gate = ingress();
+  const firstStatus = stamp(10, 1_000n);
+  gate.ingest(statusPacket(firstStatus, 0b1111, 0), 0);
+  gate.ingest(
+    pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), firstStatus, 1, 0b1111, 0),
+    1,
+  );
+
+  const nextStatus = stamp(11, 1_200n);
+  gate.ingest(statusPacket(nextStatus, 0b1111, 0), 2);
+  gate.ingest(pairedPacket(stamp(2, 1_100n), null, nextStatus, 2, 0b1111, 0), 3);
+  assert.equal(gate.snapshot(3).validFlags, 0b1100);
+
+  gate.ingest(pairedPacket(null, stamp(2, 1_200n), nextStatus, 3, 0b1111, 0), 4);
+  assert.equal(gate.snapshot(4).validFlags, 0b1100);
+
+  gate.ingest(pairedPacket(stamp(3, 1_200n), null, nextStatus, 4, 0b1111, 0), 5);
+  assert.equal(gate.snapshot(5).validFlags, 0b1111);
+}
+
+function testStatusGoodReauthorizesOnlyExactNumericGroup() {
+  const gate = ingress();
+  const firstStatus = stamp(10, 1_000n);
+  gate.ingest(statusPacket(firstStatus, 0b1111, 0), 0);
+  gate.ingest(
+    pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), firstStatus, 1, 0b1111, 0),
+    1,
+  );
+
+  gate.ingest(statusPacket(stamp(11, 1_100n), 0, 2), 2);
+  const goodStatus = stamp(12, 1_200n);
+  gate.ingest(statusPacket(goodStatus, 0b1111, 0), 3);
+  let snapshot = gate.snapshot(3);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+
+  gate.ingest(pairedPacket(null, stamp(2, 1_200n), goodStatus, 2, 0b1111, 0), 4);
+  snapshot = gate.snapshot(4);
+  assert.equal(snapshot.validFlags, 0b1100);
+  assert.equal(snapshot.quality, 0);
+
+  gate.ingest(pairedPacket(stamp(2, 1_200n), null, goodStatus, 3, 0b1111, 0), 5);
+  assert.equal(gate.snapshot(5).validFlags, 0b1111);
+}
+
+function testCombinedStatusRevokesBeforeOneNumericGroupRecovers() {
+  const gate = ingress();
+  const firstStatus = stamp(10, 1_000n);
+  gate.ingest(statusPacket(firstStatus, 0b1111, 0), 0);
+  gate.ingest(
+    pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), firstStatus, 1, 0b1111, 0),
+    1,
+  );
+
+  const nextStatus = stamp(11, 1_200n);
+  gate.ingest(
+    pairedPacket(stamp(2, 1_200n), stamp(1, 1_000n), nextStatus, 2, 0b0011, 0),
+    2,
+  );
+  let snapshot = gate.snapshot(2);
+  assert.equal(snapshot.validFlags, 0b0011);
+  assert.equal(snapshot.quality, 0);
+
+  const unusableStatus = stamp(12, 1_300n);
+  gate.ingest(
+    pairedPacket(stamp(3, 1_250n), stamp(1, 1_000n), unusableStatus, 3, 0, 2),
+    3,
+  );
+  snapshot = gate.snapshot(3);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+}
+
+function testDuplicateStatusStampCanOnlyPublishALocalDowngrade() {
+  const gate = ingress();
+  const status = stamp(10, 1_000n);
+  const good = pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), status, 1, 0b1111, 0);
+  gate.ingest(statusPacket(status, 0b1111, 0), 0);
+  gate.ingest(good, 1);
+  const generation = gate.snapshot(1).generation;
+
+  const revoked = pairedPacket(stamp(1, 1_000n), stamp(1, 1_000n), status, 1, 0, 2);
+  assert.equal(gate.ingest(revoked, 10), true);
+  let snapshot = gate.snapshot(11);
+  assert.equal(snapshot.generation, (generation + 1) >>> 0);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(snapshot.attitude.ageMs, 10);
+  assert.equal(snapshot.estimatorStatus.ageMs, 11);
+
+  assert.equal(gate.ingest(good, 20), false);
+  snapshot = gate.snapshot(21);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(snapshot.attitude.ageMs, 20);
+}
+
+function testStatusOrderingIsIndependent() {
+  const gate = ingress();
+  gate.ingest(statusPacket(stamp(10, 1_000n), 0, 2), 0);
+  assert.equal(gate.ingest(statusPacket(stamp(10, 1_000n), 0b1111, 0), 1), false);
+  assert.equal(gate.ingest(statusPacket(stamp(9, 900n), 0b1111, 0), 2), false);
+  assert.equal(gate.ingest(packet(stamp(1, 1_100n), null, 5), 3), true);
+
+  const snapshot = gate.snapshot(3);
+  assert.equal(snapshot.attitude.quat.w, 5);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+  assert.equal(gate.diagnostics().duplicates, 1);
+  assert.equal(gate.diagnostics().reordered, 1);
+}
+
+function testStatusResetsWithSourceIdentity() {
+  const gate = new AvionicsIngress({
+    vehicleId: VEHICLE,
+    maximumSkewNanos: 100n,
+    incarnationPolicy: INCARNATION_POLICY.SIM_ACCEPT_UNSEEN,
+  });
+  gate.ingest(statusPacket(stamp(1, 1_000n), 0b1111, 0), 0);
+  gate.ingest(packet(stamp(0, 1n, 2), null, 2), 1);
+  let snapshot = gate.snapshot(1);
+  assert.equal(snapshot.estimatorStatus, null);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+
+  gate.ingest(statusPacket(stamp(0, 2n, 2), 0b1111, 0), 2);
+  gate.ingest(packet(stamp(0, 1n, 2, SOURCE, INCARNATION_B), null, 3), 3);
+  snapshot = gate.snapshot(3);
+  assert.equal(snapshot.sourceIncarnation, INCARNATION_B);
+  assert.equal(snapshot.estimatorStatus, null);
+  assert.equal(snapshot.validFlags, 0);
+  assert.equal(snapshot.quality, 2);
+}
+
 function testSnapshotsAreAtomicAndImmutable() {
   const gate = ingress();
-  gate.ingest(packet(stamp(1, 10n), stamp(1, 10n), 1), 0);
+  const firstStatus = stamp(10, 10n);
+  gate.ingest(statusPacket(firstStatus, 0b1111, 0), 0);
+  gate.ingest(pairedPacket(stamp(1, 10n), stamp(1, 10n), firstStatus, 1, 0b1111, 0), 0);
   const before = gate.snapshot(0);
-  gate.ingest(packet(stamp(2, 20n), stamp(2, 20n), 2), 1);
+  gate.ingest(
+    pairedPacket(stamp(2, 20n), stamp(2, 20n), stamp(11, 20n), 2, 0, 2),
+    1,
+  );
   const after = gate.snapshot(1);
 
-  assert.equal(before.generation, 1);
+  assert.equal(before.generation, 2);
   assert.equal(before.attitude.quat.w, 1);
   assert.equal(before.kinematics.posNed[0], 1);
-  assert.equal(after.generation, 2);
+  assert.equal(after.generation, 3);
   assert.equal(after.attitude.quat.w, 2);
   assert.equal(after.kinematics.posNed[0], 2);
   assert.equal(Object.isFrozen(before), true);
   assert.equal(Object.isFrozen(before.attitude.quat), true);
+  assert.equal(Object.isFrozen(before.estimatorStatus), true);
+  assert.equal(before.validFlags, 0b1111);
+  assert.equal(after.validFlags, 0);
 }
 
 function testInvalidStampIsRejected() {
@@ -225,6 +460,14 @@ for (const test of [
   testSimulatorPolicyAcceptsUnseenAndRejectsSeenIncarnations,
   testAcquisitionTimeRegressionDoesNotRefreshAge,
   testIndependentGroupsAndCoherenceBoundary,
+  testStatusOnlyRevocationDoesNotRefreshMeasurements,
+  testStatusPayloadAloneControlsAuthorization,
+  testMismatchedGroupCannotRegainThroughOtherNumeric,
+  testStatusGoodReauthorizesOnlyExactNumericGroup,
+  testCombinedStatusRevokesBeforeOneNumericGroupRecovers,
+  testDuplicateStatusStampCanOnlyPublishALocalDowngrade,
+  testStatusOrderingIsIndependent,
+  testStatusResetsWithSourceIdentity,
   testSnapshotsAreAtomicAndImmutable,
   testInvalidStampIsRejected,
   testCountersAndGenerationWrap,

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -494,7 +494,8 @@ function decodeVelocity2d(bytes) {
 
 // telemetry.proto AvionicsState (ADR-0018): quat_w..z=1..4,
 // rate_p/q/r_rad_s=5..7, pos_n/e/d_m=8..10, vel_n/e/d_mps=11..13 (float),
-// valid_flags=14, quality=15, arm_state=16 (varint), group stamps=17/18.
+// valid_flags=14, quality=15, arm_state=16 (varint), attitude and kinematics
+// stamps=17/18, estimator authorization stamp=19.
 // Raw estimate; display derivation
 // happens in the instrument runtime (ADR-0017).
 function decodeAvionicsState(bytes) {
@@ -502,6 +503,7 @@ function decodeAvionicsState(bytes) {
   const f = parseFields(bytes);
   const attitudeStamp = decodeMeasurementStamp(firstBytes(f, 17));
   const kinematicsStamp = decodeMeasurementStamp(firstBytes(f, 18));
+  const estimatorStatusStamp = decodeMeasurementStamp(firstBytes(f, 19));
   const attitude = attitudeStamp === null ? null : {
     quat: {
       w: decodeFloat32(firstBytes(f, 1)),
@@ -540,6 +542,7 @@ function decodeAvionicsState(bytes) {
     armState: firstVarint(f, 16) ?? 0,
     attitudeStamp,
     kinematicsStamp,
+    estimatorStatusStamp,
   };
 }
 

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -177,6 +177,7 @@ const sourceId = 0xfedc_ba98_7654_3210n;
 const acquiredAt = 0xffff_ffff_ffff_fffen;
 bytesField(avionics, 17, measurementStamp(sourceId, 3, 10, acquiredAt, 1, 0xa5));
 bytesField(avionics, 18, measurementStamp(sourceId, 3, 5, acquiredAt - 100_000n, 1, 0xa5));
+bytesField(avionics, 19, measurementStamp(sourceId, 3, 12, acquiredAt, 1, 0xa5));
 
 const sample = [];
 bytesField(sample, 1, uint64Message(1));
@@ -197,7 +198,7 @@ check("telemetry source tick is preserved", decoded.message.tick === 42n);
 check("host publication time is preserved separately", decoded.message.publishedAtNanos === 2_000_000n);
 check("absent top-level pose remains null", decoded.message.pose === null && decoded.message.xM === null);
 check("absent top-level velocity remains null", decoded.message.velocity === null && decoded.message.linearXMps === null);
-check("both stamped avionics groups are present", av.attitude !== null && av.kinematics !== null);
+check("both stamped numeric groups are present", av.attitude !== null && av.kinematics !== null);
 check("avionics quat_w decodes", Math.abs(av.quat.w - 0.9) < 1e-6);
 check("omitted zero quat components decode as 0", av.quat.x === 0 && av.quat.y === 0 && av.quat.z === 0);
 check("avionics pos_d decodes", Math.abs(av.posNed[2] + 304.8) < 1e-3);
@@ -208,6 +209,7 @@ check("attitude incarnation decodes exactly", av.attitudeStamp.sourceIncarnation
 check("attitude epoch and sequence decode", av.attitudeStamp.sourceEpoch === 3 && av.attitudeStamp.sequence === 10);
 check("attitude uint64 acquisition time and clock decode", av.attitudeStamp.acquiredAtNanos === acquiredAt && av.attitudeStamp.clock === 1);
 check("kinematics sequence remains independent", av.kinematicsStamp.sequence === 5);
+check("estimator status stamp decodes independently", av.estimatorStatusStamp.sequence === 12);
 
 const attitudeOnly = [];
 f32Field(attitudeOnly, 1, 0.7);
@@ -223,6 +225,7 @@ check(
   "attitude-only publication preserves only the attitude group",
   decodedAttitudeOnly.avionics.attitude !== null
     && decodedAttitudeOnly.avionics.kinematics === null
+    && decodedAttitudeOnly.avionics.estimatorStatusStamp === null
     && decodedAttitudeOnly.avionics.quat !== null
     && decodedAttitudeOnly.avionics.posNed === null,
 );
@@ -241,8 +244,23 @@ check(
   "kinematics-only publication preserves only the kinematics group",
   decodedKinematicsOnly.avionics.attitude === null
     && decodedKinematicsOnly.avionics.kinematics !== null
+    && decodedKinematicsOnly.avionics.estimatorStatusStamp === null
     && decodedKinematicsOnly.avionics.quat === null
     && decodedKinematicsOnly.avionics.posNed[0] === 12,
+);
+
+const statusOnly = [];
+varint(statusOnly, (15 << 3) | 0);
+varint(statusOnly, 2); // canonical Unusable; valid_flags remains omitted/zero
+bytesField(statusOnly, 19, measurementStamp(sourceId, 3, 13, acquiredAt + 1n, 1, 0xa5));
+const decodedStatusOnly = decodeAvionicsOnly(statusOnly).avionics;
+check(
+  "status-only publication preserves authorization without numeric groups",
+  decodedStatusOnly.attitude === null
+    && decodedStatusOnly.kinematics === null
+    && decodedStatusOnly.validFlags === 0
+    && decodedStatusOnly.quality === 2
+    && decodedStatusOnly.estimatorStatusStamp.sequence === 13,
 );
 check("a sample without avionics decodes to null", (() => {
   const bareNoAv = [];

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -97,10 +97,19 @@ pub struct AvionicsSample {
     pub attitude: Option<AvionicsAttitudeSample>,
     /// Position/velocity group, or `None` when it was not supplied.
     pub kinematics: Option<AvionicsKinematicsSample>,
-    /// Validity bitmask: bit0 attitude, bit1 rates, bit2 position,
-    /// bit3 velocity.
+    /// Identity and acquisition time of the estimator status observation
+    /// backing the effective authorization, or `None` when no explicit
+    /// authorization was supplied.
+    pub estimator_status_stamp: Option<MeasurementStamp>,
+    /// Effective latched authorization bitmask: bit0 attitude, bit1 rates,
+    /// bit2 position, bit3 velocity. This can include fail-closed downgrades
+    /// relative to the raw status observation and is meaningful only when
+    /// [`Self::estimator_status_stamp`] is present.
     pub valid_flags: u32,
-    /// Estimate quality: 0 good, 1 degraded, 2 unusable.
+    /// Effective latched estimate quality: 0 good, 1 degraded, 2 unusable.
+    /// This can include fail-closed downgrades relative to the raw status
+    /// observation and is meaningful only when
+    /// [`Self::estimator_status_stamp`] is present.
     pub quality: u32,
     /// Arm state as the vehicle reports it: 0 unknown, 1 disarmed,
     /// 2 armed.

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -140,6 +140,14 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
                 acquired_at_ns: 900_000,
                 clock: wire::MeasurementClock::VehicleBoot as i32,
             }),
+            estimator_status_stamp: Some(wire::MeasurementStamp {
+                source_id: 7,
+                source_incarnation: vec![0xA5; 16],
+                source_epoch: 3,
+                sequence: 11,
+                acquired_at_ns: 1_000_000,
+                clock: wire::MeasurementClock::VehicleBoot as i32,
+            }),
         }),
     };
     let envelope = wire::Envelope {

--- a/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
+++ b/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
@@ -10,9 +10,10 @@ The telemetry plane today carries planar ground-vehicle state: `Pose2d`
 attitude, altitude, and vertical state, and the first vehicle that produces
 them for real is the Aviate flight controller: its Gazebo SITL flies an X500
 quadrotor and emits a deliberate MAVLink 2.0 subset — HEARTBEAT,
-ATTITUDE_QUATERNION, LOCAL_POSITION_NED — over UDP in SITL and USB CDC on
-hardware. Aviate's stated boundary is that it never does UI or GCS work, so
-the display side of that contract has to live here.
+ESTIMATOR_STATUS, AVIATE_ESTIMATOR_STATUS, ATTITUDE_QUATERNION, and
+LOCAL_POSITION_NED — over UDP in SITL and USB CDC on hardware. Aviate's stated
+boundary is that it never does UI or GCS work, so the display side of that
+contract has to live here.
 
 Two constraints from standing decisions: schema evolution must be additive
 (ADR-0014, enforced by `buf breaking`), and vehicles enter through the
@@ -27,8 +28,8 @@ the raw state estimate, not display-ready numbers: attitude quaternion
 (w, x, y, z), body angular rates, NED position, NED velocity, a validity
 bitmask and quality enum mirroring Aviate's `StateValidFlags` /
 `EstimateQuality`, plus independent attitude/rates and kinematics measurement
-stamps. Ground vehicles simply never set the field; nothing existing changes
-shape.
+stamps and an independent estimator-status stamp. Ground vehicles simply never
+set the field; nothing existing changes shape.
 
 Each group stamp carries a vehicle-scoped logical source identity, an opaque
 128-bit source incarnation, a source epoch, a wrapping group sequence, a
@@ -40,7 +41,7 @@ metadata and never relabels source acquisition time.
 
 The receiver accepts a group only when its incarnation is authorized and its
 epoch/sequence advances under wrap-safe serial arithmetic. Duplicates,
-reordering, previously seen incarnations, older epochs, acquisition-time
+reordering, already-seen incarnations, older epochs, acquisition-time
 regressions, other vehicles, and unselected sources are counted and cannot
 replace display state or refresh its age. A new incarnation or epoch clears
 every group from the earlier identity so one display generation cannot mix
@@ -50,11 +51,34 @@ accept a bounded number of unseen incarnations and resets all ingress history
 after each newly negotiated WebTransport session; that policy is explicitly
 ineligible for operational credit.
 
-Attitude and kinematics retain separate stamps. The ingress gate publishes an
-immutable display generation and an explicit coherence result derived only
-when source identity, epoch, and clock domain match and acquisition-time skew
-meets the selected display profile. Publication in one `AvionicsState` does not
-by itself imply coherent acquisition.
+Attitude, kinematics, and estimator status retain separate stamps. The ingress
+gate publishes an immutable display generation and an explicit coherence result
+derived only when source identity, epoch, and clock domain match and
+acquisition-time skew meets the selected display profile. Publication in one
+`AvionicsState` does not by itself imply coherent acquisition.
+
+`AVIATE_ESTIMATOR_STATUS` is the lossless authorization source. Its validity
+bits and quality authorize a numeric group only when the FC acquisition
+timestamps match exactly. Missing, malformed, reordered, timestamp-mismatched,
+or unknown authorization fails closed. Each accepted status can only retain or
+downgrade the authorization latched onto an already cached numeric group; a
+later Good status cannot restore data from another timestamp. A new exact-paired
+numeric group establishes a new authorization baseline. Aviate emits the
+status pair immediately before every numeric snapshot and also permits
+status-only cycles, so revocation never waits for another numeric message. The common
+`ESTIMATOR_STATUS` projection is decoded for diagnostics but never grants
+authorization because it cannot represent Aviate's per-signal contract without
+loss.
+
+A private-status CRC or structural parse failure immediately downgrades every
+cached numeric group to Unusable. Because an invalid frame cannot supply a
+trustworthy source acquisition time, this local downgrade retains the last
+valid status stamp. The parser preserves the failed frame's header source and
+position as a revoke-only event, so source selection still applies and a later
+failure in a multi-frame datagram wins. Receivers admit a duplicate-stamped
+effective authorization only when it monotonically removes validity or worsens
+quality; it advances the display generation without refreshing any source-group
+age. Duplicate-stamped authorization can never restore data.
 
 Group presence is structural throughout the adapter API. Missing attitude or
 kinematics is represented as `None`, never an identity quaternion, origin, or
@@ -77,17 +101,19 @@ A new adapter crate owns the Aviate vehicle end to end:
 - **Telemetry**: binds the MAVLink GCS UDP port (default 14550) and parses
   MAVLink v2 frames with a minimal hand-rolled parser — magic `0xFD`, header,
   24-bit message id, CRC-16/MCRF4XX seeded with each message's CRC_EXTRA,
-  and v2 payload-truncation zero-extension — for exactly the three message
-  ids Aviate emits. Frames that fail CRC or carry unknown ids are counted
-  and skipped. Every accepted frame must match the configured MAVLink system
-  and component; the logical source is configured rather than selected by the
-  first estimate. The parser is a plain `no_std`-style module with no I/O so
-  the frame math is unit-testable byte-for-byte.
-- **Mapping**: ATTITUDE_QUATERNION + LOCAL_POSITION_NED fold into the
+  and v2 payload-truncation zero-extension — for the focused Aviate message
+  contract. Frames that fail CRC or carry unknown ids are counted and skipped.
+  Every accepted frame must match the configured MAVLink system and component;
+  the logical source is configured rather than selected by the first estimate.
+  The parser is a plain `no_std`-style module with no I/O so the frame math is
+  unit-testable byte-for-byte against producer-owned golden vectors.
+- **Mapping**: AVIATE_ESTIMATOR_STATUS authorizes ATTITUDE_QUATERNION and
+  LOCAL_POSITION_NED only through the exact timestamp and monotonic-latching
+  rules above. The numeric messages fold into the
   vehicle's `TelemetrySample` (a planar projection only when both groups are
   available and coherent within the selected skew bound; each raw group
-  independently into `AvionicsState`). MAVLink `time_boot_ms` is retained for
-  both groups. Independently advancing wrapping sequences reject
+  independently into `AvionicsState`). MAVLink boot time is retained for all
+  three acquisition groups. Independently advancing wrapping sequences reject
   duplicate and reordered measurements before they enter the cache. A 32-bit
   boot-clock wrap starts a new explicit source epoch. Ordinary MAVLink has no
   trustworthy boot UUID, so the default policy never infers a reboot from a
@@ -120,11 +146,11 @@ A new adapter crate owns the Aviate vehicle end to end:
   for its cameras exactly as the Gazebo adapter does; no new media path.
 
 **Why not the `rust-mavlink` crate:** it generates the entire MAVLink common
-dialect (hundreds of messages) to use three, and its message structs would
-become a second vocabulary fighting the schema. The subset parser is a few
-hundred lines with exhaustive tests, matches Aviate's own
-minimal-subset ethos, and keeps the dependency wall around the telemetry
-plane. If the message set ever grows past a handful, revisit.
+dialect while Aviate also carries a small private status message, and its
+message structs would become a second vocabulary fighting the schema. The
+focused parser has exhaustive producer-vector tests, matches Aviate's own
+minimal-subset ethos, and keeps the dependency wall around the telemetry plane.
+If the message contract grows substantially, revisit.
 
 **Why not teach Aviate the Pilotage protocol:** MAVLink is Aviate's public
 contract and its hardware transport (USB CDC) already speaks it; coupling the
@@ -142,9 +168,13 @@ one-way.
   airspeed or barometric sensor message exists yet, so IAS renders `Missing`
   on the PFD — the honest display is the feature, and the gap is Aviate's to
   fill (its `TelemetryCycleFormatter` is the extension point).
-- The same adapter binds any MAVLink v2 source that emits the same three
-  messages (PX4 SITL does), which is a free conformance check against a
-  second producer, but Aviate remains the contract we track.
+- Numeric messages from another MAVLink source remain observable but fail
+  closed unless an explicit adapter mapping supplies equally lossless
+  authorization. A common ESTIMATOR_STATUS projection alone is insufficient.
+- AVIATE_ESTIMATOR_STATUS belongs to a private dialect whose producer contract
+  is not yet declared stable. Producer-owned golden vectors make any layout or
+  CRC drift fail tests, but an operational integration also requires a declared
+  stable dialect and an assigned message-id range.
 - On hardware, the same parser reads the same bytes over USB CDC; only the
   transport binding differs. A hardware binding must inject its source-issued
   incarnation rather than use the simulator operating-system entropy provider.

--- a/docs/adr/0019-pluggable-vehicle-link-shm-first.md
+++ b/docs/adr/0019-pluggable-vehicle-link-shm-first.md
@@ -50,9 +50,9 @@ the open one.
   and may speak MAVLink, CCSDS, or a native framing), and designing it
   before that component exists would be speculation. What this ADR fixes
   now is the *seam* those protocols plug into. The MAVLink binding
-  remains for ecosystem interop; a native Aviate link (subscribe/fan-out
-  semantics, validity flags on the wire, HMAC) is the expected v1 and
-  gets its own RFC with the Aviate side.
+  remains for ecosystem interop and carries Aviate's estimator authorization;
+  a native Aviate link (subscribe/fan-out semantics, source incarnation,
+  authenticated framing) still gets its own RFC with the Aviate side.
 - **Unsafe containment.** Mapping shared memory requires `shm_open`/
   `mmap`. The adapter crate drops the workspace-level
   `unsafe_code = "forbid"` to `deny` with per-site `allow` and SAFETY
@@ -65,10 +65,11 @@ the open one.
 - The instrument runtime and everything above the adapter never learns
   which link produced a sample — the thin-display/thick-display axis
   from the ADR-0017 survey stays open all the way down.
-- v0 reads the simulator ground-truth block, so `valid_flags`/`quality`
-  are trivially perfect; honest per-signal validity from the FC's own
-  estimator arrives with the v1 estimate block. The wire schema
-  (ADR-0018) already carries those fields either way.
+- Shared memory reads simulator ground truth, so the adapter explicitly marks
+  each atomic block Good with all represented signals valid. This authorization
+  is simulator-only. The MAVLink binding instead consumes the FC estimator's
+  lossless per-signal status and exact acquisition timestamp under ADR-0018's
+  fail-closed join rules.
 - Latency for co-located SITL drops to a memory read (the block is
   written at the 1 kHz physics rate), and the port-ownership races
   disappear — which, more than raw latency, is what shared memory buys;

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -4,6 +4,9 @@ use pilotage_adapter_api::{AvionicsSample, MeasurementClock, MeasurementStamp, T
 use pilotage_protocol::wire;
 use pilotage_timing::MonoTimestamp;
 
+const ESTIMATOR_VALID_FLAGS_MASK: u32 = 0x0f;
+const ESTIMATOR_QUALITY_UNUSABLE: u32 = 2;
+
 pub(super) fn sample_to_wire(
     sample: TelemetrySample,
     published_at: MonoTimestamp,
@@ -50,6 +53,14 @@ fn measurement_stamp_to_wire(stamp: MeasurementStamp) -> wire::MeasurementStamp 
 fn avionics_to_wire(sample: AvionicsSample) -> wire::AvionicsState {
     let attitude = sample.attitude;
     let kinematics = sample.kinematics;
+    let (valid_flags, quality) = if sample.estimator_status_stamp.is_some() {
+        (
+            sample.valid_flags & ESTIMATOR_VALID_FLAGS_MASK,
+            sample.quality.min(ESTIMATOR_QUALITY_UNUSABLE),
+        )
+    } else {
+        (0, ESTIMATOR_QUALITY_UNUSABLE)
+    };
     wire::AvionicsState {
         quat_w: attitude.map_or(0.0, |group| group.quat_wxyz[0]),
         quat_x: attitude.map_or(0.0, |group| group.quat_wxyz[1]),
@@ -64,11 +75,12 @@ fn avionics_to_wire(sample: AvionicsSample) -> wire::AvionicsState {
         vel_n_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[0]),
         vel_e_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[1]),
         vel_d_mps: kinematics.map_or(0.0, |group| group.vel_ned_mps[2]),
-        valid_flags: sample.valid_flags,
-        quality: sample.quality,
+        valid_flags,
+        quality,
         arm_state: sample.arm_state,
         attitude_stamp: attitude.map(|group| measurement_stamp_to_wire(group.stamp)),
         kinematics_stamp: kinematics.map(|group| measurement_stamp_to_wire(group.stamp)),
+        estimator_status_stamp: sample.estimator_status_stamp.map(measurement_stamp_to_wire),
     }
 }
 

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -7,7 +7,7 @@ use pilotage_adapter_api::{
 use pilotage_protocol::{VehicleId, wire};
 use pilotage_timing::{MonoTimestamp, SimTick};
 
-use super::sample_to_wire;
+use super::{avionics_to_wire, sample_to_wire};
 
 #[test]
 fn publication_time_and_source_acquisition_stamps_stay_distinct() {
@@ -22,6 +22,11 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     let kinematics = MeasurementStamp {
         sequence: 19,
         acquired_at_ns: 1_200_000,
+        ..attitude
+    };
+    let estimator_status = MeasurementStamp {
+        sequence: 20,
+        acquired_at_ns: 1_234_567,
         ..attitude
     };
     let sample = TelemetrySample {
@@ -44,6 +49,7 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
                 vel_ned_mps: [0.0; 3],
                 stamp: kinematics,
             }),
+            estimator_status_stamp: Some(estimator_status),
             valid_flags: 0b1111,
             quality: 0,
             arm_state: 2,
@@ -57,6 +63,8 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
         9_000_000
     );
     let avionics = wire_sample.avionics.expect("avionics");
+    assert_eq!(avionics.valid_flags, 0b1111);
+    assert_eq!(avionics.quality, 0);
     let attitude_wire = avionics.attitude_stamp.expect("attitude stamp");
     assert_eq!(attitude_wire.source_id, attitude.source_id);
     assert_eq!(
@@ -73,6 +81,11 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
     let kinematics_wire = avionics.kinematics_stamp.expect("kinematics stamp");
     assert_eq!(kinematics_wire.sequence, kinematics.sequence);
     assert_eq!(kinematics_wire.acquired_at_ns, kinematics.acquired_at_ns);
+    let status_wire = avionics
+        .estimator_status_stamp
+        .expect("estimator status stamp");
+    assert_eq!(status_wire.sequence, estimator_status.sequence);
+    assert_eq!(status_wire.acquired_at_ns, estimator_status.acquired_at_ns);
 }
 
 fn simulation_stamp(sequence: u32) -> MeasurementStamp {
@@ -84,6 +97,21 @@ fn simulation_stamp(sequence: u32) -> MeasurementStamp {
         acquired_at_ns: 42,
         clock: MeasurementClock::Simulation,
     }
+}
+
+#[test]
+fn estimator_authorization_is_normalized_at_wire_boundary() {
+    let avionics = avionics_to_wire(AvionicsSample {
+        attitude: None,
+        kinematics: None,
+        estimator_status_stamp: Some(simulation_stamp(1)),
+        valid_flags: u32::MAX,
+        quality: u32::MAX,
+        arm_state: 0,
+    });
+
+    assert_eq!(avionics.valid_flags, 0x0f);
+    assert_eq!(avionics.quality, 2);
 }
 
 #[test]
@@ -100,6 +128,7 @@ fn kinematics_only_omits_planar_projection_while_group_flows() {
                 vel_ned_mps: [5.0, 2.0, -1.0],
                 stamp: simulation_stamp(8),
             }),
+            estimator_status_stamp: None,
             valid_flags: 0b1100,
             quality: 0,
             arm_state: 0,
@@ -111,6 +140,9 @@ fn kinematics_only_omits_planar_projection_while_group_flows() {
     assert!(wire_sample.velocity.is_none());
     let avionics = wire_sample.avionics.expect("avionics");
     assert!(avionics.attitude_stamp.is_none());
+    assert!(avionics.estimator_status_stamp.is_none());
+    assert_eq!(avionics.valid_flags, 0);
+    assert_eq!(avionics.quality, 2);
     assert_eq!(avionics.pos_n_m, 12.0);
     assert_eq!(avionics.vel_n_mps, 5.0);
     assert_eq!(
@@ -133,6 +165,7 @@ fn attitude_only_omits_planar_projection_while_group_flows() {
                 stamp: simulation_stamp(9),
             }),
             kinematics: None,
+            estimator_status_stamp: None,
             valid_flags: 0b0011,
             quality: 0,
             arm_state: 2,

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -50,10 +50,10 @@ message MeasurementStamp {
 
 // Raw avionics state estimate for flight vehicles (ADR-0018): attitude
 // quaternion (body FRD → world NED), body rates, NED position/velocity,
-// and the source's validity/quality. Values are the estimator's output,
-// not display-ready numbers — display derivation (altitude, groundspeed,
-// Euler angles) happens in the instrument runtime (ADR-0017). Ground
-// vehicles never set this field.
+// and the adapter's effective latched validity/quality authorization. Numeric
+// values are the estimator's output, not display-ready numbers — display
+// derivation (altitude, groundspeed, Euler angles) happens in the instrument
+// runtime (ADR-0017). Ground vehicles never set this field.
 message AvionicsState {
   // Fields 1–7 are meaningful only when attitude_stamp is present. Proto3
   // scalar defaults are not measurements and must not be displayed as such.
@@ -71,9 +71,14 @@ message AvionicsState {
   float vel_n_mps = 11;
   float vel_e_mps = 12;
   float vel_d_mps = 13;
-  // bit0 attitude, bit1 rates, bit2 position, bit3 velocity.
+  // Effective latched authorization: bit0 attitude, bit1 rates, bit2 position,
+  // bit3 velocity. It can include fail-closed downgrades relative to the raw
+  // status observation and is meaningful only when estimator_status_stamp is
+  // present.
   uint32 valid_flags = 14;
-  // 0 good, 1 degraded, 2 unusable.
+  // Effective latched quality: 0 good, 1 degraded, 2 unusable. It can include
+  // fail-closed downgrades relative to the raw status observation and is
+  // meaningful only when estimator_status_stamp is present.
   uint32 quality = 15;
   // 0 unknown, 1 disarmed, 2 armed (from the vehicle's own report).
   uint32 arm_state = 16;
@@ -81,6 +86,10 @@ message AvionicsState {
   // that group was not supplied in this publication.
   MeasurementStamp attitude_stamp = 17;
   MeasurementStamp kinematics_stamp = 18;
+  // Acquisition identity of the status observation backing valid_flags and
+  // quality. Absence means no explicit estimator authorization was supplied
+  // and consumers fail closed.
+  MeasurementStamp estimator_status_stamp = 19;
 }
 
 // A single best-effort telemetry sample for one vehicle.

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -19,6 +19,7 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root_dir"
 
 status=0
+function_baseline="scripts/structure-function-baseline.tsv"
 
 is_excluded_path() {
     case "$1" in
@@ -73,17 +74,45 @@ check_function_length() {
     local file
     while IFS= read -r file; do
         is_excluded_path "$file" && continue
-        awk -v fname="$file" '
-            function report(len, start) {
-                if (len > 80) {
+        awk -v fname="$file" -v baseline="$function_baseline" '
+            function report(name, len, start, key, limit) {
+                key = fname SUBSEP name
+                seen[key] = 1
+                if (key in allowed) {
+                    limit = allowed[key]
+                    if (len != limit) {
+                        printf "FORBIDDEN: %s:%d function %s has %d lines; baseline requires exactly %d\n", fname, start, name, len, limit > "/dev/stderr"
+                        bad = 1
+                    }
+                } else if (len > 80) {
                     printf "FORBIDDEN: %s:%d function body has %d lines (limit 80)\n", fname, start, len > "/dev/stderr"
                     bad = 1
                 }
             }
-            BEGIN { depth = 0; in_fn = 0; fn_depth = 0; fn_start = 0; body_lines = 0; bad = 0 }
+            BEGIN {
+                while ((getline entry < baseline) > 0) {
+                    if (entry ~ /^[ \t]*#/ || entry ~ /^[ \t]*$/) {
+                        continue
+                    }
+                    split(entry, fields, "\t")
+                    key = fields[1] SUBSEP fields[2]
+                    allowed[key] = fields[3] + 0
+                    allowed_file[key] = fields[1]
+                }
+                close(baseline)
+                depth = 0
+                in_fn = 0
+                fn_depth = 0
+                fn_start = 0
+                body_lines = 0
+                bad = 0
+            }
             {
                 line = $0
-                if (!in_fn && line ~ /\bfn[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(<[^>]*>)?[ \t]*\(/) {
+                if (!in_fn && line ~ /(^|[^[:alnum:]_])fn[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(<[^>]*>)?[ \t]*\(/) {
+                    match(line, /fn[ \t]+[A-Za-z_][A-Za-z0-9_]*/)
+                    fn_name = substr(line, RSTART, RLENGTH)
+                    sub(/^fn[ \t]+/, "", fn_name)
                     in_fn = 1
                     fn_depth = depth
                     fn_start = NR
@@ -101,11 +130,20 @@ check_function_length() {
                 }
                 depth -= n_close
                 if (in_fn && has_opened && depth <= fn_depth) {
-                    report(body_lines, fn_start)
+                    report(fn_name, body_lines, fn_start)
                     in_fn = 0
                 }
             }
-            END { exit bad }
+            END {
+                for (key in allowed) {
+                    if (allowed_file[key] == fname && !(key in seen)) {
+                        split(key, parts, SUBSEP)
+                        printf "FORBIDDEN: baseline function %s in %s was not found\n", parts[2], fname > "/dev/stderr"
+                        bad = 1
+                    }
+                }
+                exit bad
+            }
         ' "$file" || status=1
     done < <(collect_rs_files)
 }

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -1,0 +1,12 @@
+# path	function	exact_body_lines
+./clients/web-instruments/src/tests.rs	exported_surface_packs_one_atomic_render_result	84
+./crates/pilotage-instrument-scene/src/decode.rs	decode_payload	94
+./crates/pilotage-instrument-glyphs/src/sha256.rs	sha256	90
+./crates/pilotage-conformance/src/fixture.rs	increment_zero_script	89
+./crates/pilotage-instrument-state/src/resolve.rs	resolve	153
+./crates/pilotage-instrument-state/src/abi.rs	decode_state	134
+./crates/pilotage-instrument-state/src/abi.rs	encode_state	108
+./crates/pilotage-authority/src/wire.rs	from	88
+./adapters/aviate/src/adapter/tests.rs	stick_frame_reaches_the_fc_as_a_velocity_setpoint	93
+./adapters/aviate/src/uplink.rs	send_stick_frame	90
+./hosts/session-host/tests/loopback.rs	hello_lease_frame_and_stale_generation_rejection	99


### PR DESCRIPTION
## Summary

- decode standard `ESTIMATOR_STATUS` and lossless private `AVIATE_ESTIMATOR_STATUS` with producer-owned golden vectors, MAVLink 2 trailing-zero handling, and explicit FC-to-Pilotage quality mapping
- authorize attitude and kinematics only through an exact acquisition-time join; malformed, missing, unknown, mismatched, wrong-source, or transport-invalid status fails closed
- preserve an independent status stamp through the adapter API, protobuf field 19, session host, browser decoder, and immutable ingress snapshot
- make status-only revocation immediate, prevent later Good status from restoring cached numeric data, and allow only a new exact-paired group to recover its own authorization
- gate planar projection and pose-dependent control on effective authorization while keeping disarm measurement-independent; give SHM simulation an explicit simulator-only ground-truth authorization
- repair the Rust function-length guard and pin exact mainline debt so new or growing functions above 80 lines fail CI

## Upstream contract

Verified against Aviate `main` at `6a519f1` and the telemetry contract from Aviate #150, #161, #162, and #163. The current open Aviate PR #176 is governance-only and does not alter telemetry.

## Failure behavior

Private-status CRC, framing, incompatibility, malformed-time, unknown-quality, reset, and ordering cases have explicit regression coverage. Revoke-only parse events retain header source and datagram order. `Unusable` may retain diagnostic flags from the FC, but those flags do not authorize display or prevent another exact-paired group from recovering.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (Aviate adapter 67/67)
- strict `cargo doc --no-deps` with missing-doc and broken-link denial
- `cargo build --release`
- structure, instrument requirements, bare-metal no_std, raster, glyph, WASM build, and five browser contract suites
- `buf lint schemas`
- `buf breaking schemas --against .git#ref=refs/remotes/origin/main,subdir=schemas`
- two independent blocking reviews: no remaining P1/P2 findings

## Operational limits

This is assurance-oriented engineering, not a certification claim. Aviate private message 20000 still needs a declared stable dialect and assigned message-id range for operational credit. Hardware also lacks a trustworthy boot UUID or source incarnation, so conservative reboot quarantine remains mandatory.

Closes #46