### PR TITLE
ATT-01: SO(3)-safe unusual-attitude presentation and airframe display profiles

### DIFF
--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -6,8 +6,8 @@
 
 use pilotage_instrument_panels::{PfdConfig, VSpeeds, draw_hsi, draw_pfd};
 use pilotage_instrument_scene::{LayerError, LayerId, SceneError, SceneWriter, validate_layers};
+use pilotage_instrument_state::FreshnessPolicy;
 use pilotage_instrument_state::abi::{AbiError, STATE_ABI_SIZE, STATE_ABI_VERSION, decode_state};
-use pilotage_instrument_state::{FreshnessPolicy, resolve};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::render_status::RenderStatus;
@@ -34,6 +34,14 @@ pub(crate) struct Runtime {
     pub(crate) scene: Vec<u8>,
     pub(crate) generation: [u32; PANEL_COUNT],
     pub(crate) pfd_cfg: PfdConfig,
+    /// Unusual-attitude hysteresis latches, carried across frames so
+    /// tier entry/exit cannot chatter (ATT-01). Stepping twice per frame
+    /// (PFD then HSI) is idempotent: the latches depend on the input
+    /// magnitudes, not on step count.
+    pub(crate) unusual: pilotage_instrument_state::UnusualAttitudeState,
+    /// Display thresholds; the simulator profile's numbers are benchmark
+    /// data, not an aircraft approval.
+    pub(crate) profile: pilotage_instrument_state::AirframeDisplayProfile,
 }
 
 impl Runtime {
@@ -43,6 +51,8 @@ impl Runtime {
             scene: vec![0u8; SCENE_CAPACITY],
             generation: [0; PANEL_COUNT],
             pfd_cfg: PfdConfig::default(),
+            unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+            profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
         }
     }
 }
@@ -146,7 +156,12 @@ pub(crate) fn render_into(runtime: &mut Runtime, panel: u32) -> RenderAttempt {
             return RenderAttempt::failure(RenderStatus::StateBadVersion, generation);
         }
     };
-    let data = resolve(&state, &FreshnessPolicy::default());
+    let data = pilotage_instrument_state::resolve_stateful(
+        &state,
+        &FreshnessPolicy::default(),
+        &runtime.profile,
+        &mut runtime.unusual,
+    );
     let mut writer = match SceneWriter::new(&mut runtime.scene) {
         Ok(writer) => writer,
         Err(error) => return RenderAttempt::failure(scene_error_status(error), generation),

--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -96,6 +96,8 @@ fn scene_runtime(scene: &[u8]) -> Runtime {
         scene: buffer,
         generation: [7, 11],
         pfd_cfg: PfdConfig::default(),
+        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
     }
 }
 
@@ -227,6 +229,8 @@ fn render_into_reports_buffer_and_truncation_failures() {
         scene: vec![0u8; 4],
         generation: [0; 2],
         pfd_cfg: PfdConfig::default(),
+        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
     };
     assert_attempt(
         render_into(&mut tiny, 0),
@@ -241,6 +245,8 @@ fn render_into_reports_buffer_and_truncation_failures() {
         scene: vec![0u8; SCENE_CAPACITY],
         generation: [4, 8],
         pfd_cfg: PfdConfig::default(),
+        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
     };
     assert_attempt(
         render_into(&mut truncated, 0),
@@ -254,6 +260,8 @@ fn render_into_reports_buffer_and_truncation_failures() {
         scene: vec![0u8; SCENE_CAPACITY],
         generation: [0; 2],
         pfd_cfg: PfdConfig::default(),
+        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
     };
     assert_attempt(render_into(&mut valid, 2), RenderStatus::InvalidPanel, 0, 0);
     let rendered = render_into(&mut valid, 0);
@@ -270,6 +278,8 @@ fn malformed_scene_never_advances_or_commits_length() {
         scene: vec![1, 0],
         generation: [7, 11],
         pfd_cfg: PfdConfig::default(),
+        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
+        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
     };
     assert_attempt(
         validate_and_commit_scene(&mut runtime, 0, 2),

--- a/clients/web/instruments.html
+++ b/clients/web/instruments.html
@@ -139,8 +139,8 @@ writes packed state and interprets abstract scene commands onto Canvas2D.</div>
 
   const DEG = Math.PI / 180;
   const defs = [
-    ["roll", "roll °", -80, 80, 12, 1],
-    ["pitch", "pitch °", -30, 30, 6, 0.5],
+    ["roll", "roll °", -180, 180, 12, 1],
+    ["pitch", "pitch °", -180, 180, 6, 0.5],
     ["heading", "heading °", 0, 360, 9, 1],
     ["alt", "altitude m", -50, 3000, 950, 1],
     ["vsi", "climb m/s", -8, 8, 1.2, 0.1],

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -3,7 +3,7 @@
 //! tapes → symbology → annunciation, ADR-0017).
 
 use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
-use pilotage_instrument_state::{PanelData, SignalStatus};
+use pilotage_instrument_state::{ChevronSense, PanelData, SignalStatus};
 
 use crate::palette;
 use crate::status_paint;
@@ -56,12 +56,21 @@ pub struct PfdConfig {
 /// annunciations, in ascending z-order. The layers above `Background`
 /// never depend on the background mode, so the critical overlay stays
 /// complete — byte-identical — when the background is absent.
+/// The one declutter priority table (ATT-01): entering the unusual tier
+/// removes exactly these elements. Primary attitude, the airspeed and
+/// altitude tapes, VSI, and every failure flag/annunciation are never on
+/// this list — declutter can only ever *add* attention to the horizon.
+///
+/// - minor (2.5° and 5°) pitch-ladder rows — major 10° bars remain
+/// - speed-tape color bands
+/// - the turn-rate cue
 pub fn draw_pfd(
     data: &PanelData,
     cfg: &PfdConfig,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
     let att_status = data.roll_rad.status.worst(data.pitch_rad.status);
+    let declutter = att_status.shows_value() && data.presentation.unusual;
 
     match cfg.background {
         BackgroundMode::Horizon => {
@@ -78,17 +87,30 @@ pub fn draw_pfd(
 
     scene.begin_layer(LayerId::Attitude)?;
     if att_status.shows_value() {
-        horizon::draw_horizon_cues(scene, data.roll_rad.value, data.pitch_rad.value)?;
+        horizon::draw_horizon_cues(scene, data.roll_rad.value, data.pitch_rad.value, declutter)?;
         horizon::draw_roll_scale(scene, data.roll_rad.value)?;
         horizon::draw_aircraft_symbol(scene)?;
+        if let Some(sense) = data.presentation.chevrons {
+            draw_recovery_chevrons(scene, data.roll_rad.value, sense)?;
+        }
     }
     scene.end_layer(LayerId::Attitude)?;
 
     scene.begin_layer(LayerId::Tapes)?;
-    tapes::speed_tape(scene, data, cfg.v_speeds.as_ref())?;
+    tapes::speed_tape(
+        scene,
+        data,
+        if declutter {
+            None
+        } else {
+            cfg.v_speeds.as_ref()
+        },
+    )?;
     tapes::altitude_tape(scene, data)?;
     tapes::vsi(scene, data)?;
-    draw_turn_rate(scene, data)?;
+    if !declutter {
+        draw_turn_rate(scene, data)?;
+    }
     scene.end_layer(LayerId::Tapes)?;
 
     scene.begin_layer(LayerId::Annunciation)?;
@@ -106,6 +128,32 @@ pub fn draw_pfd(
         status_paint::draw_red_x(scene, 398.0, 60.0, 74.0, 200.0, "ALT")?;
     }
     scene.end_layer(LayerId::Annunciation)?;
+    Ok(())
+}
+
+/// Recovery chevrons in the roll-rotated attitude frame, pointing toward
+/// the horizon (an orientation cue, never a flight-director command).
+/// Nose high puts the horizon below the aircraft symbol, so the chevrons
+/// sit above center with their apexes downward; nose low mirrors it.
+fn draw_recovery_chevrons(
+    scene: &mut SceneWriter<'_>,
+    roll_rad: f32,
+    sense: ChevronSense,
+) -> Result<(), SceneError> {
+    scene.save()?;
+    scene.translate(240.0, 180.0)?;
+    scene.rotate(-roll_rad)?;
+    scene.stroke(palette::RED, 6.0)?;
+    let toward: f32 = match sense {
+        ChevronSense::HorizonBelow => 1.0,
+        ChevronSense::HorizonAbove => -1.0,
+    };
+    for offset in [56.0f32, 84.0] {
+        let base_y = -toward * offset;
+        let apex_y = base_y + toward * 22.0;
+        scene.polyline(&[[-42.0, base_y], [0.0, apex_y], [42.0, base_y]])?;
+    }
+    scene.restore()?;
     Ok(())
 }
 

--- a/crates/pilotage-instrument-panels/src/pfd/horizon.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/horizon.rs
@@ -45,6 +45,7 @@ pub fn draw_horizon_cues(
     scene: &mut SceneWriter<'_>,
     roll_rad: f32,
     pitch_rad: f32,
+    declutter: bool,
 ) -> Result<(), SceneError> {
     let horizon_y = pitch_rad * RAD_TO_DEG * PX_PER_DEG_PITCH;
     scene.save()?;
@@ -52,18 +53,27 @@ pub fn draw_horizon_cues(
     scene.rotate(-roll_rad)?;
     scene.stroke(palette::WHITE, 2.0)?;
     scene.line(-600.0, horizon_y, 600.0, horizon_y)?;
-    draw_pitch_ladder(scene, horizon_y)?;
+    draw_pitch_ladder(scene, horizon_y, declutter)?;
     scene.restore()?;
     Ok(())
 }
 
 /// Ladder marks every 2.5°, wide labeled bars every 10° (pyG5's
 /// half-width cycle 10/20/10/30).
-fn draw_pitch_ladder(scene: &mut SceneWriter<'_>, horizon_y: f32) -> Result<(), SceneError> {
+fn draw_pitch_ladder(
+    scene: &mut SceneWriter<'_>,
+    horizon_y: f32,
+    declutter: bool,
+) -> Result<(), SceneError> {
     scene.stroke(palette::WHITE, 2.0)?;
     scene.fill_color(palette::WHITE)?;
     for i in -36..=36i32 {
         if i == 0 {
+            continue;
+        }
+        // Declutter keeps only the labeled 10° bars: fewer, larger cues
+        // when orientation is the problem being solved.
+        if declutter && i.rem_euclid(4) != 0 {
             continue;
         }
         let deg = i as f32 * 2.5;

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -260,3 +260,197 @@ fn air_data_failure_cues_are_annunciations() {
         );
     }
 }
+
+// ---- ATT-01 unusual-attitude presentation --------------------------------------
+
+/// f32 ZYX euler → quaternion for orientation fixtures.
+fn quat_euler(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
+    let d = core::f32::consts::PI / 180.0;
+    let (r, p, y) = (roll_deg * d / 2.0, pitch_deg * d / 2.0, yaw_deg * d / 2.0);
+    let (cr, sr) = (libm::cosf(r), libm::sinf(r));
+    let (cp, sp) = (libm::cosf(p), libm::sinf(p));
+    let (cy, sy) = (libm::cosf(y), libm::sinf(y));
+    Quat {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy,
+    }
+}
+
+fn oriented(roll_deg: f32, pitch_deg: f32) -> PanelData {
+    let mut state = AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: quat_euler(roll_deg, pitch_deg, 0.0),
+                rates_rps: [0.0, 0.0, 0.02],
+            }),
+            age_ms: Some(20.0),
+        },
+        ..AircraftState::default()
+    };
+    state.quality = pilotage_instrument_state::EstimateQuality::Good;
+    state.valid = pilotage_instrument_state::ValidFlags {
+        attitude: true,
+        rates: true,
+        position: true,
+        velocity: true,
+    };
+    state.kinematics = flying_state_kinematics();
+    state.air = flying_state_air();
+    resolve(&state, &FreshnessPolicy::default())
+}
+
+fn flying_state_kinematics() -> Stamped<Kinematics> {
+    Stamped {
+        data: Some(Kinematics {
+            pos_ned_m: [0.0, 0.0, -300.0],
+            vel_ned_mps: [20.0, 0.0, -1.0],
+        }),
+        age_ms: Some(20.0),
+    }
+}
+
+fn flying_state_air() -> Stamped<AirData> {
+    Stamped {
+        data: Some(AirData {
+            ias_mps: Some(40.0),
+            baro_setting_hpa: Some(1013.0),
+        }),
+        age_ms: Some(20.0),
+    }
+}
+
+fn banded_cfg() -> PfdConfig {
+    PfdConfig {
+        v_speeds: Some(VSpeeds {
+            vs0_kt: 40.0,
+            vs_kt: 48.0,
+            vfe_kt: 85.0,
+            vno_kt: 129.0,
+            vne_kt: 163.0,
+        }),
+        ..PfdConfig::default()
+    }
+}
+
+fn count_cmds(scene: &[u8], mut hit: impl FnMut(&Cmd<'_>) -> bool) -> usize {
+    SceneCmds::new(scene)
+        .expect("valid scene")
+        .map(|c| c.expect("valid command"))
+        .filter(|c| hit(c))
+        .count()
+}
+
+fn chevrons_in(scene: &[u8]) -> usize {
+    count_cmds(scene, |c| matches!(c, Cmd::Polyline { .. }))
+}
+
+fn turn_rate_cue_in(scene: &[u8]) -> bool {
+    count_cmds(
+        scene,
+        |c| matches!(c, Cmd::Line { x1, y1, .. } if *x1 == 178.0 && *y1 == 334.0),
+    ) > 0
+}
+
+fn bands_in(scene: &[u8]) -> bool {
+    count_cmds(
+        scene,
+        |c| matches!(c, Cmd::FillColor { color } if *color == pilotage_instrument_scene::Rgba8::rgb(0, 160, 0)),
+    ) > 0
+}
+
+#[test]
+fn normal_envelope_has_no_unusual_artifacts() {
+    let scene = render(&oriented(10.0, 5.0), &banded_cfg());
+    assert_eq!(chevrons_in(&scene), 0);
+    assert!(turn_rate_cue_in(&scene));
+    assert!(bands_in(&scene));
+}
+
+#[test]
+fn declutter_follows_the_one_priority_table() {
+    let normal = render(&oriented(10.0, 5.0), &banded_cfg());
+    let decluttered = render(&oriented(70.0, 5.0), &banded_cfg());
+
+    // Removed: turn-rate cue, speed bands, minor ladder rows.
+    assert!(!turn_rate_cue_in(&decluttered));
+    assert!(!bands_in(&decluttered));
+    let lines = |scene: &[u8]| count_cmds(scene, |c| matches!(c, Cmd::Line { .. }));
+    assert!(
+        lines(&decluttered) < lines(&normal),
+        "minor ladder rows removed"
+    );
+
+    // Preserved: primary attitude, airspeed, altitude readouts.
+    let labels = texts(&decluttered);
+    assert!(labels.iter().any(|t| t == "078"), "IAS kept: {labels:?}");
+    assert!(labels.iter().any(|t| t == "980"), "ALT kept: {labels:?}");
+}
+
+#[test]
+fn declutter_never_removes_alerts_or_failures() {
+    let mut data = oriented(70.0, 5.0);
+    data.ias_kt.status = pilotage_instrument_state::SignalStatus::Failed;
+    data.roll_rad.status = pilotage_instrument_state::SignalStatus::Degraded;
+    data.pitch_rad.status = pilotage_instrument_state::SignalStatus::Degraded;
+    let scene = render(&data, &banded_cfg());
+    let labels = texts(&scene);
+    assert!(labels.iter().any(|t| t == "IAS"), "IAS failure flag kept");
+    assert!(labels.iter().any(|t| t == "ATT"), "ATT caution kept");
+}
+
+#[test]
+fn chevrons_point_toward_the_horizon() {
+    let nose_high = render(&oriented(0.0, 55.0), &PfdConfig::default());
+    assert_eq!(chevrons_in(&nose_high), 2, "nose-high chevrons drawn");
+    let nose_low = render(&oriented(0.0, -35.0), &PfdConfig::default());
+    assert_eq!(chevrons_in(&nose_low), 2, "nose-low chevrons drawn");
+    let normal = render(&oriented(0.0, 20.0), &PfdConfig::default());
+    assert_eq!(chevrons_in(&normal), 0);
+
+    // Sense: nose-high apexes sit below their bases (+y toward the
+    // horizon), nose-low mirrors.
+    let apex_sign = |scene: &[u8]| {
+        let mut signs = std::vec::Vec::new();
+        for c in SceneCmds::new(scene).expect("scene") {
+            if let Cmd::Polyline { points } = c.expect("cmd") {
+                let base = points.get(0).expect("base")[1];
+                let apex = points.get(1).expect("apex")[1];
+                signs.push(apex > base);
+            }
+        }
+        signs
+    };
+    assert!(apex_sign(&nose_high).iter().all(|&down| down));
+    assert!(apex_sign(&nose_low).iter().all(|&down| !down));
+}
+
+#[test]
+fn every_extreme_orientation_emits_finite_layered_scenes() {
+    for (roll, pitch) in [
+        (0.0f32, 89.0f32),
+        (0.0, 90.0),
+        (0.0, 91.0),
+        (10.0, 90.0),
+        (180.0, 0.0),
+        (179.0, -20.0),
+        (90.0, 45.0),
+        (-90.0, -45.0),
+        (65.0, 30.0),
+        (-66.0, -50.0),
+    ] {
+        let scene = render(&oriented(roll, pitch), &banded_cfg());
+        let report =
+            pilotage_instrument_scene::validate_layers(&scene).expect("layered at extremes");
+        assert!(report.contains(pilotage_instrument_scene::LayerId::Attitude));
+        for c in SceneCmds::new(&scene).expect("scene") {
+            if let Cmd::Line { x1, y1, x2, y2 } = c.expect("cmd") {
+                assert!(
+                    x1.is_finite() && y1.is_finite() && x2.is_finite() && y2.is_finite(),
+                    "non-finite line at roll {roll} pitch {pitch}"
+                );
+            }
+        }
+    }
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -16,7 +16,7 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // rasterizer. `libm` plus IEEE-754 f32 make these identical across the
 // supported CI architectures; a mismatch is a determinism regression, not a
 // value to re-pin casually.
-const PFD_SHA256: &str = "26ba92ba4250c6573fed08b5f42c22becbe8ec8fa521ab0dde7e8167c0349598";
+const PFD_SHA256: &str = "433e22df2c535b3792af5458b54e632db14ee1b61dea99d6b66f9dba427cb63d";
 const HSI_SHA256: &str = "6edcbc92d936a690a68f0632d2ec20b158d54e59cc9fde6640feefa077b258e3";
 
 /// A fixed, richly populated state so every panel band paints content.

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod abi;
 mod aircraft;
+mod presentation;
 mod quat;
 mod resolve;
 mod signal;
@@ -35,8 +36,12 @@ pub use aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
+pub use presentation::{
+    AirframeDisplayProfile, AttitudePresentation, ChevronSense, Hysteresis, ProfileError,
+    ProfileLimits, UnusualAttitudeState, down_in_body,
+};
 pub use quat::Quat;
-pub use resolve::{NavResolved, PanelData, resolve};
+pub use resolve::{NavResolved, PanelData, resolve, resolve_stateful};
 pub use signal::{FreshnessPolicy, PolicyError, Sig, SignalStatus};
 pub use validate::{
     GroupFault, QUAT_NORM_TOLERANCE, StateIntegrity, validate_quat, validate_state,

--- a/crates/pilotage-instrument-state/src/presentation.rs
+++ b/crates/pilotage-instrument-state/src/presentation.rs
@@ -1,0 +1,341 @@
+//! SO(3)-safe attitude presentation: geometry from the physical down
+//! vector, and the unusual-attitude tier machine (ATT-01).
+//!
+//! The canonical display attitude is the validated unit quaternion; the
+//! horizon geometry derives from where the world's down vector points in
+//! the body frame, using only quadratic quaternion forms so `q` and `-q`
+//! produce bit-identical output. Display pitch is the nose's angle to
+//! the horizontal; display bank rotates the horizon and stays continuous
+//! through the vertical, where it is *held* (the parameter chart is
+//! singular there, the rendered geometry is not). Sky stays above the
+//! horizon line whenever `|bank| < 90°`; inverted flight reads as bank
+//! beyond 90°, never as a relabeled sky/ground.
+//!
+//! Tier decisions (unusual entry/exit, chevrons, declutter) come from an
+//! [`AirframeDisplayProfile`] with explicit entry/exit hysteresis. The
+//! simulator profile carries fixed-wing benchmark numbers as data; it
+//! implies no aircraft approval.
+
+use libm::{asinf, atan2f};
+
+use crate::quat::Quat;
+
+/// Why an airframe display profile could not be constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileError {
+    /// A threshold is NaN or infinite.
+    NonFinite,
+    /// An exit threshold does not sit strictly inside its entry
+    /// threshold, so the tier could chatter.
+    NoHysteresis,
+    /// A threshold is outside its physical range.
+    OutOfRange,
+}
+
+/// Entry/exit angle thresholds (radians) for one hysteresis pair.
+///
+/// Entry fires at or beyond `entry`; exit requires coming back inside
+/// `exit`. `exit` must sit strictly inside `entry`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Hysteresis {
+    /// Magnitude at which the condition engages.
+    pub entry: f32,
+    /// Magnitude below which the condition releases.
+    pub exit: f32,
+}
+
+impl Hysteresis {
+    fn valid(&self, max: f32) -> bool {
+        self.entry.is_finite()
+            && self.exit.is_finite()
+            && self.exit > 0.0
+            && self.exit < self.entry
+            && self.entry <= max
+    }
+}
+
+/// Display thresholds for one airframe (ATT-01).
+///
+/// All values are profile *data*: the simulator profile's numbers are
+/// fixed-wing benchmark inputs (G5000-class), not an approval for any
+/// aircraft. Constructed only through [`AirframeDisplayProfile::new`] or
+/// [`AirframeDisplayProfile::simulator`], so inverted or non-finite
+/// thresholds cannot exist.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AirframeDisplayProfile {
+    unusual_pitch_up: Hysteresis,
+    unusual_pitch_down: Hysteresis,
+    unusual_bank: Hysteresis,
+    chevron_pitch_up: Hysteresis,
+    chevron_pitch_down: Hysteresis,
+    /// |pitch| beyond which display bank holds its last value (the
+    /// vertical parameter singularity).
+    bank_hold_pitch: Hysteresis,
+}
+
+/// The raw threshold set [`AirframeDisplayProfile::new`] validates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProfileLimits {
+    /// Nose-high unusual-attitude entry/exit.
+    pub unusual_pitch_up: Hysteresis,
+    /// Nose-low unusual-attitude entry/exit (magnitudes).
+    pub unusual_pitch_down: Hysteresis,
+    /// Bank unusual-attitude entry/exit (magnitudes).
+    pub unusual_bank: Hysteresis,
+    /// Nose-high recovery-chevron entry/exit.
+    pub chevron_pitch_up: Hysteresis,
+    /// Nose-low recovery-chevron entry/exit (magnitudes).
+    pub chevron_pitch_down: Hysteresis,
+    /// Bank-hold pitch magnitude entry/exit.
+    pub bank_hold_pitch: Hysteresis,
+}
+
+const DEG: f32 = core::f32::consts::PI / 180.0;
+const HALF_PI: f32 = core::f32::consts::FRAC_PI_2;
+const PI: f32 = core::f32::consts::PI;
+
+impl AirframeDisplayProfile {
+    /// Builds a profile after validating every threshold pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProfileError`] when a threshold is non-finite, outside
+    /// its physical range, or lacks hysteresis.
+    pub fn new(limits: ProfileLimits) -> Result<Self, ProfileError> {
+        let pairs = [
+            (limits.unusual_pitch_up, HALF_PI),
+            (limits.unusual_pitch_down, HALF_PI),
+            (limits.unusual_bank, PI),
+            (limits.chevron_pitch_up, HALF_PI),
+            (limits.chevron_pitch_down, HALF_PI),
+            (limits.bank_hold_pitch, HALF_PI),
+        ];
+        let mut i = 0;
+        while i < pairs.len() {
+            let (pair, max) = pairs[i];
+            if !(pair.entry.is_finite() && pair.exit.is_finite()) {
+                return Err(ProfileError::NonFinite);
+            }
+            if !pair.valid(max) {
+                return Err(ProfileError::NoHysteresis);
+            }
+            i += 1;
+        }
+        Ok(Self {
+            unusual_pitch_up: limits.unusual_pitch_up,
+            unusual_pitch_down: limits.unusual_pitch_down,
+            unusual_bank: limits.unusual_bank,
+            chevron_pitch_up: limits.chevron_pitch_up,
+            chevron_pitch_down: limits.chevron_pitch_down,
+            bank_hold_pitch: limits.bank_hold_pitch,
+        })
+    }
+
+    /// The simulator profile. Its numbers are fixed-wing *benchmark
+    /// inputs* (declutter at +30/-20° pitch or 65° bank; chevrons at
+    /// +50/-30° pitch, each with a 5° exit margin; bank hold beyond 88°
+    /// pitch). They are profile data for the simulator display only and
+    /// imply no aircraft approval.
+    pub fn simulator() -> Self {
+        Self {
+            unusual_pitch_up: Hysteresis {
+                entry: 30.0 * DEG,
+                exit: 25.0 * DEG,
+            },
+            unusual_pitch_down: Hysteresis {
+                entry: 20.0 * DEG,
+                exit: 15.0 * DEG,
+            },
+            unusual_bank: Hysteresis {
+                entry: 65.0 * DEG,
+                exit: 60.0 * DEG,
+            },
+            chevron_pitch_up: Hysteresis {
+                entry: 50.0 * DEG,
+                exit: 45.0 * DEG,
+            },
+            chevron_pitch_down: Hysteresis {
+                entry: 30.0 * DEG,
+                exit: 25.0 * DEG,
+            },
+            bank_hold_pitch: Hysteresis {
+                entry: 88.0 * DEG,
+                exit: 87.0 * DEG,
+            },
+        }
+    }
+}
+
+/// Which way recovery chevrons point: always toward the horizon, never
+/// a flight-director command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChevronSense {
+    /// Nose high: the horizon is below; chevrons point down.
+    HorizonBelow,
+    /// Nose low: the horizon is above; chevrons point up.
+    HorizonAbove,
+}
+
+/// The attitude presentation one frame renders from.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AttitudePresentation {
+    /// Display bank, radians, continuous through the vertical (held at
+    /// the singularity); positive right wing down. `|bank| > 90°` is
+    /// inverted flight.
+    pub bank_rad: f32,
+    /// Display pitch, radians, the nose's angle above the horizontal in
+    /// `[-90°, +90°]`.
+    pub pitch_rad: f32,
+    /// Unusual-attitude tier is engaged (drives declutter).
+    pub unusual: bool,
+    /// The nose-high condition is latched.
+    pub nose_high: bool,
+    /// The nose-low condition is latched.
+    pub nose_low: bool,
+    /// The high-bank condition is latched.
+    pub high_bank: bool,
+    /// The display reads inverted (`|bank| > 90°`).
+    pub inverted: bool,
+    /// Recovery chevrons to draw, pointing toward the horizon.
+    pub chevrons: Option<ChevronSense>,
+}
+
+impl Default for AttitudePresentation {
+    fn default() -> Self {
+        Self {
+            bank_rad: 0.0,
+            pitch_rad: 0.0,
+            unusual: false,
+            nose_high: false,
+            nose_low: false,
+            high_bank: false,
+            inverted: false,
+            chevrons: None,
+        }
+    }
+}
+
+/// Hysteresis latches carried across frames. Allocation-free; the
+/// display backend owns one per attitude source and resets it whenever
+/// the attitude is invalid, so recovery re-enters from a clean tier.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct UnusualAttitudeState {
+    nose_high: bool,
+    nose_low: bool,
+    high_bank: bool,
+    chevron_up: bool,
+    chevron_down: bool,
+    bank_hold: bool,
+    held_bank_rad: f32,
+    has_held_bank: bool,
+}
+
+impl UnusualAttitudeState {
+    /// Clears every latch (invalid attitude, source change, reinit).
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Advances the tier machine with a validated unit quaternion and
+    /// returns the frame's presentation. Deterministic: same state and
+    /// input produce the same output, and `q`/`-q` are identical because
+    /// only quadratic forms are read.
+    pub fn step(&mut self, quat: Quat, profile: &AirframeDisplayProfile) -> AttitudePresentation {
+        let (down_x, down_y, down_z) = down_in_body(quat);
+        let pitch = -asinf(down_x.clamp(-1.0, 1.0));
+
+        // Through the vertical the bank parameter is singular; hold the
+        // last well-defined value so the ball cannot spin (the rendered
+        // sky vector stays continuous either way).
+        let vertical = latch(
+            &mut self.bank_hold,
+            pitch.abs(),
+            profile.bank_hold_pitch.entry,
+            profile.bank_hold_pitch.exit,
+        );
+        let bank = if vertical && self.has_held_bank {
+            self.held_bank_rad
+        } else {
+            let raw = atan2f(down_y, down_z);
+            self.held_bank_rad = raw;
+            self.has_held_bank = true;
+            raw
+        };
+
+        let nose_high = latch(
+            &mut self.nose_high,
+            pitch,
+            profile.unusual_pitch_up.entry,
+            profile.unusual_pitch_up.exit,
+        );
+        let nose_low = latch(
+            &mut self.nose_low,
+            -pitch,
+            profile.unusual_pitch_down.entry,
+            profile.unusual_pitch_down.exit,
+        );
+        let high_bank = latch(
+            &mut self.high_bank,
+            bank.abs(),
+            profile.unusual_bank.entry,
+            profile.unusual_bank.exit,
+        );
+        let chevron_up = latch(
+            &mut self.chevron_up,
+            pitch,
+            profile.chevron_pitch_up.entry,
+            profile.chevron_pitch_up.exit,
+        );
+        let chevron_down = latch(
+            &mut self.chevron_down,
+            -pitch,
+            profile.chevron_pitch_down.entry,
+            profile.chevron_pitch_down.exit,
+        );
+
+        AttitudePresentation {
+            bank_rad: bank,
+            pitch_rad: pitch,
+            unusual: nose_high || nose_low || high_bank,
+            nose_high,
+            nose_low,
+            high_bank,
+            inverted: bank.abs() > HALF_PI,
+            chevrons: if chevron_up {
+                Some(ChevronSense::HorizonBelow)
+            } else if chevron_down {
+                Some(ChevronSense::HorizonAbove)
+            } else {
+                None
+            },
+        }
+    }
+}
+
+/// One hysteresis latch: engages at or beyond `entry`, releases only
+/// inside `exit`.
+fn latch(state: &mut bool, magnitude: f32, entry: f32, exit: f32) -> bool {
+    if *state {
+        if magnitude < exit {
+            *state = false;
+        }
+    } else if magnitude >= entry {
+        *state = true;
+    }
+    *state
+}
+
+/// The world down vector expressed in body coordinates, from quadratic
+/// quaternion forms only (the third row of the body→NED rotation), so
+/// `q` and `-q` are bit-identical. Level flight reads `(0, 0, 1)`.
+pub fn down_in_body(quat: Quat) -> (f32, f32, f32) {
+    let Quat { w, x, y, z } = quat;
+    (
+        2.0 * (x * z - w * y),
+        2.0 * (y * z + w * x),
+        1.0 - 2.0 * (x * x + y * y),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-state/src/presentation/tests.rs
+++ b/crates/pilotage-instrument-state/src/presentation/tests.rs
@@ -1,0 +1,360 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::f32::consts::PI;
+
+use super::{
+    AirframeDisplayProfile, ChevronSense, Hysteresis, ProfileError, ProfileLimits,
+    UnusualAttitudeState, down_in_body,
+};
+use crate::quat::Quat;
+
+const DEG: f32 = PI / 180.0;
+
+/// f64 reference quaternion from ZYX Euler angles, normalized.
+fn quat_f64(roll_deg: f64, pitch_deg: f64, yaw_deg: f64) -> Quat {
+    let (r, p, y) = (
+        roll_deg.to_radians() / 2.0,
+        pitch_deg.to_radians() / 2.0,
+        yaw_deg.to_radians() / 2.0,
+    );
+    let (cr, sr) = (r.cos(), r.sin());
+    let (cp, sp) = (p.cos(), p.sin());
+    let (cy, sy) = (y.cos(), y.sin());
+    let w = cr * cp * cy + sr * sp * sy;
+    let x = sr * cp * cy - cr * sp * sy;
+    let yq = cr * sp * cy + sr * cp * sy;
+    let z = cr * cp * sy - sr * sp * cy;
+    let n = (w * w + x * x + yq * yq + z * z).sqrt();
+    Quat {
+        w: (w / n) as f32,
+        x: (x / n) as f32,
+        y: (yq / n) as f32,
+        z: (z / n) as f32,
+    }
+}
+
+/// Independent f64 down-vector projection for the same quaternion.
+fn down_f64(q: Quat) -> (f64, f64, f64) {
+    let (w, x, y, z) = (
+        f64::from(q.w),
+        f64::from(q.x),
+        f64::from(q.y),
+        f64::from(q.z),
+    );
+    (
+        2.0 * (x * z - w * y),
+        2.0 * (y * z + w * x),
+        1.0 - 2.0 * (x * x + y * y),
+    )
+}
+
+fn neg(q: Quat) -> Quat {
+    Quat {
+        w: -q.w,
+        x: -q.x,
+        y: -q.y,
+        z: -q.z,
+    }
+}
+
+fn step_fresh(q: Quat) -> super::AttitudePresentation {
+    let mut state = UnusualAttitudeState::default();
+    state.step(q, &AirframeDisplayProfile::simulator())
+}
+
+/// The sky direction the rendered (pitch, bank) pair implies, as a unit
+/// down-vector reconstruction; comparing it against the true down vector
+/// proves the rendered geometry tracks physical orientation.
+fn down_from_display(pitch: f32, bank: f32) -> (f64, f64, f64) {
+    let (p, b) = (f64::from(pitch), f64::from(bank));
+    (-p.sin(), b.sin() * p.cos(), b.cos() * p.cos())
+}
+
+#[test]
+fn all_24_cube_rotations_match_the_f64_reference() {
+    // Every proper rotation with axis-aligned columns: signed
+    // permutation matrices with determinant +1.
+    let perms = [
+        [0, 1, 2],
+        [1, 2, 0],
+        [2, 0, 1],
+        [0, 2, 1],
+        [2, 1, 0],
+        [1, 0, 2],
+    ];
+    let mut checked = 0;
+    for (pi, perm) in perms.iter().enumerate() {
+        let perm_sign: f64 = if pi < 3 { 1.0 } else { -1.0 };
+        for signs in 0..8u8 {
+            let s = [
+                if signs & 1 != 0 { -1.0 } else { 1.0 },
+                if signs & 2 != 0 { -1.0 } else { 1.0 },
+                if signs & 4 != 0 { -1.0 } else { 1.0 },
+            ];
+            let det: f64 = perm_sign * s[0] * s[1] * s[2];
+            if det < 0.0 {
+                continue;
+            }
+            // Rotation matrix R with R[i][perm[i]] = s[i]; quaternion via
+            // the robust f64 Shepperd branch.
+            let mut m = [[0.0f64; 3]; 3];
+            for i in 0..3 {
+                m[i][perm[i]] = s[i];
+            }
+            let q = quat_from_matrix_f64(&m);
+            let (dx, dy, dz) = down_in_body(q);
+            // The true down vector in body coordinates is the matrix's
+            // third row.
+            for (got, want) in [(dx, m[2][0]), (dy, m[2][1]), (dz, m[2][2])] {
+                assert!(
+                    (f64::from(got) - want).abs() < 1e-6,
+                    "rotation {perm:?}/{signs:#05b}: {got} vs {want}"
+                );
+            }
+            let p = step_fresh(q);
+            assert!(p.bank_rad.is_finite() && p.pitch_rad.is_finite());
+            checked += 1;
+        }
+    }
+    assert_eq!(checked, 24, "the full proper cube-rotation group");
+}
+
+/// Robust f64 rotation-matrix→quaternion (largest-component branch).
+fn quat_from_matrix_f64(m: &[[f64; 3]; 3]) -> Quat {
+    let trace = m[0][0] + m[1][1] + m[2][2];
+    let (w, x, y, z) = if trace > 0.0 {
+        let s = (trace + 1.0).sqrt() * 2.0;
+        (
+            s / 4.0,
+            (m[2][1] - m[1][2]) / s,
+            (m[0][2] - m[2][0]) / s,
+            (m[1][0] - m[0][1]) / s,
+        )
+    } else if m[0][0] > m[1][1] && m[0][0] > m[2][2] {
+        let s = (1.0 + m[0][0] - m[1][1] - m[2][2]).sqrt() * 2.0;
+        (
+            (m[2][1] - m[1][2]) / s,
+            s / 4.0,
+            (m[0][1] + m[1][0]) / s,
+            (m[0][2] + m[2][0]) / s,
+        )
+    } else if m[1][1] > m[2][2] {
+        let s = (1.0 + m[1][1] - m[0][0] - m[2][2]).sqrt() * 2.0;
+        (
+            (m[0][2] - m[2][0]) / s,
+            (m[0][1] + m[1][0]) / s,
+            s / 4.0,
+            (m[1][2] + m[2][1]) / s,
+        )
+    } else {
+        let s = (1.0 + m[2][2] - m[0][0] - m[1][1]).sqrt() * 2.0;
+        (
+            (m[1][0] - m[0][1]) / s,
+            (m[0][2] + m[2][0]) / s,
+            (m[1][2] + m[2][1]) / s,
+            s / 4.0,
+        )
+    };
+    Quat {
+        w: w as f32,
+        x: x as f32,
+        y: y as f32,
+        z: z as f32,
+    }
+}
+
+#[test]
+fn q_and_negated_q_are_bit_identical() {
+    for &(roll, pitch, yaw) in DENSE_GRID {
+        let q = quat_f64(roll, pitch, yaw);
+        let a = step_fresh(q);
+        let b = step_fresh(neg(q));
+        assert_eq!(a, b, "roll {roll} pitch {pitch} yaw {yaw}");
+        assert_eq!(a.bank_rad.to_bits(), b.bank_rad.to_bits());
+        assert_eq!(a.pitch_rad.to_bits(), b.pitch_rad.to_bits());
+    }
+}
+
+/// The issue's dense bounded grid: every listed pitch and bank magnitude,
+/// both signs, with off-axis yaw so no case degenerates by construction.
+const DENSE_GRID: &[(f64, f64, f64)] = &{
+    const PITCHES: [f64; 9] = [0.0, 20.0, 30.0, 50.0, 89.0, 90.0, 91.0, 179.0, 180.0];
+    const BANKS: [f64; 8] = [0.0, 64.0, 65.0, 66.0, 89.0, 90.0, 179.0, 180.0];
+    let mut grid = [(0.0, 0.0, 0.0); PITCHES.len() * BANKS.len() * 4];
+    let mut i = 0;
+    let mut pi = 0;
+    while pi < PITCHES.len() {
+        let mut bi = 0;
+        while bi < BANKS.len() {
+            grid[i] = (BANKS[bi], PITCHES[pi], 33.0);
+            grid[i + 1] = (-BANKS[bi], PITCHES[pi], 213.0);
+            grid[i + 2] = (BANKS[bi], -PITCHES[pi], 33.0);
+            grid[i + 3] = (-BANKS[bi], -PITCHES[pi], 213.0);
+            i += 4;
+            bi += 1;
+        }
+        pi += 1;
+    }
+    grid
+};
+
+#[test]
+fn dense_so3_grid_is_finite_bounded_and_tracks_the_f64_reference() {
+    for &(roll, pitch, yaw) in DENSE_GRID {
+        let q = quat_f64(roll, pitch, yaw);
+        let p = step_fresh(q);
+        assert!(p.bank_rad.is_finite() && p.pitch_rad.is_finite());
+        assert!(p.pitch_rad.abs() <= PI / 2.0 + 1e-6, "pitch bounded");
+        assert!(p.bank_rad.abs() <= PI + 1e-6, "bank bounded");
+
+        // Independent f64 projection reference: the rendered pair must
+        // reconstruct the physical down vector (outside the held zone).
+        let (rx, ry, rz) = down_f64(q);
+        if f64::from(p.pitch_rad).cos() > 0.05 {
+            let (gx, gy, gz) = down_from_display(p.pitch_rad, p.bank_rad);
+            let dot = gx * rx + gy * ry + gz * rz;
+            assert!(
+                dot > 0.9999,
+                "display geometry diverges at roll {roll} pitch {pitch}: dot {dot}"
+            );
+        }
+    }
+}
+
+#[test]
+fn continuous_pole_passage_keeps_the_sky_vector_continuous() {
+    // Fly straight through the vertical: pitch 80°..100° in 0.25° steps
+    // at fixed bank/yaw. The (pitch, bank) chart is singular at 90°, but
+    // the reconstructed sky vector must track the true one closely on
+    // both sides and never invert its meaning.
+    let mut state = UnusualAttitudeState::default();
+    let profile = AirframeDisplayProfile::simulator();
+    // Inside the hold window the rendered bank is frozen, so the
+    // rendered sky vector may deviate from truth by up to the window
+    // width and snap back by about twice that at release. The bound is
+    // that geometric limit (8° covers the 3° window, the release snap,
+    // and one 0.25° step) — far from any sky/ground flip (180°).
+    let bound = (8.0f64).to_radians().cos();
+    let mut prev: Option<(f64, f64, f64)> = None;
+    let mut step_deg = 80.0;
+    while step_deg <= 100.0 {
+        let q = quat_f64(10.0, step_deg, 40.0);
+        let p = state.step(q, &profile);
+        assert!(p.bank_rad.is_finite() && p.pitch_rad.is_finite());
+        let (gx, gy, gz) = down_from_display(p.pitch_rad, p.bank_rad);
+        let (tx, ty, tz) = down_f64(q);
+        let truth = gx * tx + gy * ty + gz * tz;
+        assert!(
+            truth > bound,
+            "rendered geometry left the hold-window bound at pitch {step_deg}: dot {truth}"
+        );
+        if let Some((px, py, pz)) = prev {
+            let dot = gx * px + gy * py + gz * pz;
+            assert!(
+                dot > bound,
+                "sky vector jumped at pitch {step_deg}: dot {dot}"
+            );
+        }
+        prev = Some((gx, gy, gz));
+        step_deg += 0.25;
+    }
+    // Past the pole the display must read inverted (bank beyond 90°),
+    // not a relabeled sky.
+    let past = state.step(quat_f64(10.0, 100.0, 40.0), &profile);
+    assert!(past.inverted, "beyond the vertical reads inverted");
+}
+
+#[test]
+fn inverted_flight_is_unambiguous() {
+    let level_inverted = step_fresh(quat_f64(180.0, 0.0, 0.0));
+    assert!(level_inverted.inverted);
+    assert!((level_inverted.bank_rad.abs() - PI).abs() < 1e-3);
+    assert!(level_inverted.pitch_rad.abs() < 1e-3);
+    let upright = step_fresh(quat_f64(0.0, 0.0, 137.0));
+    assert!(!upright.inverted);
+}
+
+#[test]
+fn threshold_jitter_cannot_chatter() {
+    // Oscillate ±0.5° around the 65° bank entry: one engagement, no
+    // release until the 60° exit is crossed.
+    let profile = AirframeDisplayProfile::simulator();
+    let mut state = UnusualAttitudeState::default();
+    let mut transitions = 0;
+    let mut last = false;
+    for i in 0..100 {
+        let bank = if i % 2 == 0 { 65.4 } else { 64.6 };
+        let p = state.step(quat_f64(bank, 5.0, 0.0), &profile);
+        if p.high_bank != last {
+            transitions += 1;
+            last = p.high_bank;
+        }
+    }
+    assert_eq!(transitions, 1, "one entry, no chatter");
+    assert!(last, "still latched inside the hysteresis band");
+    let released = state.step(quat_f64(59.0, 5.0, 0.0), &profile);
+    assert!(!released.high_bank, "released below the exit threshold");
+}
+
+#[test]
+fn tier_thresholds_follow_the_simulator_profile() {
+    let at = |roll: f64, pitch: f64| step_fresh(quat_f64(roll, pitch, 0.0));
+    assert!(!at(0.0, 29.0).unusual);
+    assert!(at(0.0, 31.0).unusual && at(0.0, 31.0).nose_high);
+    assert!(!at(0.0, -19.0).unusual);
+    assert!(at(0.0, -21.0).unusual && at(0.0, -21.0).nose_low);
+    assert!(!at(64.0, 0.0).unusual);
+    assert!(at(66.0, 0.0).unusual && at(66.0, 0.0).high_bank);
+    assert_eq!(at(0.0, 51.0).chevrons, Some(ChevronSense::HorizonBelow));
+    assert_eq!(at(0.0, -31.0).chevrons, Some(ChevronSense::HorizonAbove));
+    assert_eq!(at(0.0, 45.0).chevrons, None);
+}
+
+#[test]
+fn bank_holds_through_the_vertical_and_resumes() {
+    let profile = AirframeDisplayProfile::simulator();
+    let mut state = UnusualAttitudeState::default();
+    let before = state.step(quat_f64(15.0, 85.0, 0.0), &profile);
+    let held = state.step(quat_f64(15.0, 89.5, 0.0), &profile);
+    assert!(
+        (held.bank_rad - before.bank_rad).abs() < 2.0 * DEG,
+        "bank held near the pole"
+    );
+    let resumed = state.step(quat_f64(15.0, 30.0, 0.0), &profile);
+    assert!((resumed.bank_rad - 15.0 * DEG).abs() < 0.5 * DEG);
+}
+
+#[test]
+fn invalid_profiles_are_rejected() {
+    let good = Hysteresis {
+        entry: 30.0 * DEG,
+        exit: 25.0 * DEG,
+    };
+    let base = ProfileLimits {
+        unusual_pitch_up: good,
+        unusual_pitch_down: good,
+        unusual_bank: good,
+        chevron_pitch_up: good,
+        chevron_pitch_down: good,
+        bank_hold_pitch: good,
+    };
+    assert!(AirframeDisplayProfile::new(base).is_ok());
+    let mut inverted = base;
+    inverted.unusual_bank = Hysteresis {
+        entry: 25.0 * DEG,
+        exit: 30.0 * DEG,
+    };
+    assert_eq!(
+        AirframeDisplayProfile::new(inverted),
+        Err(ProfileError::NoHysteresis)
+    );
+    let mut nan = base;
+    nan.chevron_pitch_up = Hysteresis {
+        entry: f32::NAN,
+        exit: 25.0 * DEG,
+    };
+    assert_eq!(
+        AirframeDisplayProfile::new(nan),
+        Err(ProfileError::NonFinite)
+    );
+}

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -5,6 +5,7 @@ use libm::{atan2f, sqrtf};
 use crate::aircraft::{
     AircraftState, EstimateQuality, NavData, NavSource, Selections, SnapshotCoherence, Wind,
 };
+use crate::presentation::{AirframeDisplayProfile, AttitudePresentation, UnusualAttitudeState};
 use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
 use crate::units::{M_TO_FT, MPS_TO_FPM, MPS_TO_KT};
 use crate::validate::{StateIntegrity, validate_quat, validate_state};
@@ -55,6 +56,10 @@ pub struct PanelData {
     /// Per-group typed fault reasons behind any validation-driven
     /// status downgrade, for annunciation and diagnostics.
     pub integrity: StateIntegrity,
+    /// SO(3)-safe attitude presentation (tier, chevrons, declutter,
+    /// continuous bank). Meaningful only while the attitude signals'
+    /// status shows a value; an invalid attitude resets it to default.
+    pub presentation: AttitudePresentation,
 }
 
 fn quality_status(q: EstimateQuality) -> SignalStatus {
@@ -127,75 +132,137 @@ fn sanitized_selections(selections: Selections) -> Selections {
 /// `Missing`. Values behind `Missing`/`Failed` are quiet zeros a panel
 /// never paints, and every showable value is finite.
 pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
-    let integrity = validate_state(state);
-    let quality = quality_status(state.quality).worst(fault_status(integrity.quality));
-    let coherence = coherence_status(state.snapshot.coherence);
+    let mut fresh = UnusualAttitudeState::default();
+    resolve_stateful(
+        state,
+        policy,
+        &AirframeDisplayProfile::simulator(),
+        &mut fresh,
+    )
+}
 
-    let att_fresh = if state.attitude.data.is_none() {
+/// [`resolve`] with a caller-held unusual-attitude latch state, so tier
+/// entry/exit hysteresis works across frames. [`resolve`] itself uses a
+/// fresh state per call (entry thresholds only), which is sufficient for
+/// single-frame consumers and tests.
+pub fn resolve_stateful(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    profile: &AirframeDisplayProfile,
+    unusual: &mut UnusualAttitudeState,
+) -> PanelData {
+    let integrity = validate_state(state);
+    let trust = Trust {
+        quality: quality_status(state.quality).worst(fault_status(integrity.quality)),
+        coherence: coherence_status(state.snapshot.coherence),
+    };
+
+    let (presentation, yaw, turn_rate) = attitude_geometry(state, profile, unusual);
+    let has_att = state.attitude.data.is_some();
+    let att_fresh = group_freshness(policy, has_att, state.attitude.age_ms);
+    let att_status = trust.fold(has_att, att_fresh, integrity.attitude, state.valid.attitude);
+    let rate_status = trust.fold(has_att, att_fresh, integrity.rates, state.valid.rates);
+
+    let has_kin = state.kinematics.data.is_some();
+    let kin_fresh = group_freshness(policy, has_kin, state.kinematics.age_ms);
+    let pos_status = trust.fold(has_kin, kin_fresh, integrity.position, state.valid.position);
+    let vel_status = trust.fold(has_kin, kin_fresh, integrity.velocity, state.valid.velocity);
+    let (alt_ft, vsi_fpm, gs_kt, track_rad, gs_mps) = kinematics_geometry(state);
+    let track_status = if !(gs_mps.is_finite() && gs_mps >= TRACK_MIN_GS_MPS) {
         SignalStatus::Missing
     } else {
-        policy.status_for_age(state.attitude.age_ms)
+        vel_status
     };
-    // Trust metadata (quality, coherence, flags, validation) applies
-    // only to groups that have data: absence stays Missing — dashes,
-    // not a red X — because nothing was received to distrust.
-    let has_attitude = state.attitude.data.is_some();
-    let att_status = if has_attitude {
-        att_fresh
-            .worst(quality)
-            .worst(coherence)
-            .worst(fault_status(integrity.attitude))
-            .worst(flag_status(state.valid.attitude))
+
+    let (ias, baro) = air_signals(state, policy, trust.quality, &integrity);
+
+    PanelData {
+        roll_rad: finite(Sig::with_status(presentation.bank_rad, att_status)),
+        pitch_rad: finite(Sig::with_status(presentation.pitch_rad, att_status)),
+        heading_rad: finite(Sig::with_status(yaw, att_status)),
+        turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
+        ias_kt: finite(ias),
+        gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
+        alt_ft: finite(Sig::with_status(alt_ft, pos_status)),
+        vsi_fpm: finite(Sig::with_status(vsi_fpm, vel_status)),
+        track_rad: finite(Sig::with_status(track_rad, track_status)),
+        baro_hpa: finite(baro),
+        wind: wind_signal(state, policy, &integrity),
+        nav: nav_resolved(state, policy, &integrity),
+        selections: sanitized_selections(state.selections),
+        integrity,
+        presentation,
+    }
+}
+
+/// Source-level trust shared by every estimate group this frame.
+#[derive(Clone, Copy)]
+struct Trust {
+    quality: SignalStatus,
+    coherence: SignalStatus,
+}
+
+impl Trust {
+    /// The deterministic worst-of for one group. Trust metadata applies
+    /// only to groups that have data: absence stays Missing — dashes,
+    /// not a red X — because nothing was received to distrust. A group
+    /// *with* data still folds even when its freshness reads Missing
+    /// (a bogus age), so declared distrust cannot be masked.
+    fn fold(
+        &self,
+        has_data: bool,
+        freshness: SignalStatus,
+        fault: Option<crate::validate::GroupFault>,
+        declared_valid: bool,
+    ) -> SignalStatus {
+        if !has_data {
+            return SignalStatus::Missing;
+        }
+        freshness
+            .worst(self.quality)
+            .worst(self.coherence)
+            .worst(fault_status(fault))
+            .worst(flag_status(declared_valid))
+    }
+}
+
+fn group_freshness(policy: &FreshnessPolicy, has_data: bool, age_ms: Option<f32>) -> SignalStatus {
+    if has_data {
+        policy.status_for_age(age_ms)
     } else {
         SignalStatus::Missing
-    };
-    let rate_status = if has_attitude {
-        att_fresh
-            .worst(quality)
-            .worst(coherence)
-            .worst(fault_status(integrity.rates))
-            .worst(flag_status(state.valid.rates))
-    } else {
-        SignalStatus::Missing
-    };
-    let (roll, pitch, yaw, turn_rate) = match state.attitude.data {
-        // Geometry only ever sees a validated, renormalized quaternion;
-        // a rejected one leaves quiet zeros behind a Failed status.
+    }
+}
+
+/// Geometry only ever sees a validated, renormalized quaternion; a
+/// rejected one resets the tier latches and leaves quiet zeros behind a
+/// Failed status — never a plausible horizon.
+fn attitude_geometry(
+    state: &AircraftState,
+    profile: &AirframeDisplayProfile,
+    unusual: &mut UnusualAttitudeState,
+) -> (AttitudePresentation, f32, f32) {
+    match state.attitude.data {
         Some(att) => match validate_quat(att.quat) {
             Ok(quat) => {
-                let (r, p, y) = quat.to_euler();
-                (r, p, y, att.rates_rps[2])
+                let presentation = unusual.step(quat, profile);
+                let (_, _, yaw) = quat.to_euler();
+                (presentation, yaw, att.rates_rps[2])
             }
-            Err(_) => (0.0, 0.0, 0.0, att.rates_rps[2]),
+            Err(_) => {
+                unusual.reset();
+                (AttitudePresentation::default(), 0.0, att.rates_rps[2])
+            }
         },
-        None => (0.0, 0.0, 0.0, 0.0),
-    };
+        None => {
+            unusual.reset();
+            (AttitudePresentation::default(), 0.0, 0.0)
+        }
+    }
+}
 
-    let kin_fresh = if state.kinematics.data.is_none() {
-        SignalStatus::Missing
-    } else {
-        policy.status_for_age(state.kinematics.age_ms)
-    };
-    let has_kinematics = state.kinematics.data.is_some();
-    let pos_status = if has_kinematics {
-        kin_fresh
-            .worst(quality)
-            .worst(coherence)
-            .worst(fault_status(integrity.position))
-            .worst(flag_status(state.valid.position))
-    } else {
-        SignalStatus::Missing
-    };
-    let vel_status = if has_kinematics {
-        kin_fresh
-            .worst(quality)
-            .worst(coherence)
-            .worst(fault_status(integrity.velocity))
-            .worst(flag_status(state.valid.velocity))
-    } else {
-        SignalStatus::Missing
-    };
-    let (alt_ft, vsi_fpm, gs_kt, track_rad, gs_mps) = match state.kinematics.data {
+fn kinematics_geometry(state: &AircraftState) -> (f32, f32, f32, f32, f32) {
+    match state.kinematics.data {
         Some(kin) => {
             let alt = -kin.pos_ned_m[2] * M_TO_FT;
             let vsi = -kin.vel_ned_mps[2] * MPS_TO_FPM;
@@ -206,13 +273,15 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
             (alt, vsi, gs_mps * MPS_TO_KT, track, gs_mps)
         }
         None => (0.0, 0.0, 0.0, 0.0, 0.0),
-    };
-    let track_status = if !(gs_mps.is_finite() && gs_mps >= TRACK_MIN_GS_MPS) {
-        SignalStatus::Missing
-    } else {
-        vel_status
-    };
+    }
+}
 
+fn air_signals(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    quality: SignalStatus,
+    integrity: &StateIntegrity,
+) -> (Sig<f32>, Sig<f32>) {
     let air_fresh = policy.status_for_age(state.air.age_ms);
     let air_fault = fault_status(integrity.air);
     let air = state.air.data.unwrap_or_default();
@@ -224,9 +293,16 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
         Some(v) => Sig::with_status(v, air_fresh.worst(air_fault)),
         None => Sig::missing(),
     };
+    (ias, baro)
+}
 
+fn nav_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    integrity: &StateIntegrity,
+) -> NavResolved {
     let nav_fresh = policy.status_for_age(state.nav.age_ms);
-    let nav = match state.nav.data {
+    match state.nav.data {
         Some(data) => {
             let status = nav_fresh.worst(fault_status(integrity.nav));
             // Guidance from an unidentifiable source must not draw a
@@ -242,12 +318,18 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
             NavResolved { data, status }
         }
         None => NavResolved::default(),
-    };
+    }
+}
 
+fn wind_signal(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    integrity: &StateIntegrity,
+) -> Sig<Wind> {
     let wind_status = policy
         .status_for_age(state.wind.age_ms)
         .worst(fault_status(integrity.wind));
-    let wind = match (state.wind.data, wind_status) {
+    match (state.wind.data, wind_status) {
         (Some(w), s) if s.shows_value() => Sig::with_status(w, s),
         _ => Sig::with_status(
             Wind {
@@ -260,23 +342,6 @@ pub fn resolve(state: &AircraftState, policy: &FreshnessPolicy) -> PanelData {
                 SignalStatus::Missing
             },
         ),
-    };
-
-    PanelData {
-        roll_rad: finite(Sig::with_status(roll, att_status)),
-        pitch_rad: finite(Sig::with_status(pitch, att_status)),
-        heading_rad: finite(Sig::with_status(yaw, att_status)),
-        turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
-        ias_kt: finite(ias),
-        gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
-        alt_ft: finite(Sig::with_status(alt_ft, pos_status)),
-        vsi_fpm: finite(Sig::with_status(vsi_fpm, vel_status)),
-        track_rad: finite(Sig::with_status(track_rad, track_status)),
-        baro_hpa: finite(baro),
-        wind,
-        nav,
-        selections: sanitized_selections(state.selections),
-        integrity,
     }
 }
 

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -3,7 +3,6 @@
 ./crates/pilotage-instrument-scene/src/decode.rs	decode_payload	94
 ./crates/pilotage-instrument-glyphs/src/sha256.rs	sha256	90
 ./crates/pilotage-conformance/src/fixture.rs	increment_zero_script	89
-./crates/pilotage-instrument-state/src/resolve.rs	resolve	153
 ./crates/pilotage-instrument-state/src/abi.rs	decode_state	134
 ./crates/pilotage-instrument-state/src/abi.rs	encode_state	108
 ./crates/pilotage-authority/src/wire.rs	from	88


### PR DESCRIPTION
## Summary

- display geometry now derives from the **physical down vector in body coordinates**, using quadratic quaternion forms only: `q` and `-q` are bit-identical, display pitch is bounded in ±90°, and display bank stays continuous through the vertical — where it is *held* inside a profile-defined window, because the parameter chart is singular there while the rendered sky vector is not
- an allocation-free `UnusualAttitudeState` carries entry/exit hysteresis latches (nose-high/low, high-bank, chevrons, bank-hold) driven by a **validated `AirframeDisplayProfile`**; the simulator profile's numbers (declutter +30/−20° pitch, 65° bank; chevrons +50/−30°; 5° exit margins) are fixed-wing benchmark *data*, not aircraft approval
- the PFD declutters from **one priority table** — minor ladder rows, speed-tape bands, turn-rate cue — which can never remove primary attitude, airspeed, altitude, VSI, or any failure flag; recovery chevrons draw in the critical Attitude layer pointing toward the horizon, explicitly not flight-director commands
- inverted flight reads as bank beyond 90°, never a relabeled sky/ground; invalid attitude resets the latches and paints the red X, never a plausible horizon
- the harness sliders cover the full orientation envelope (roll/pitch ±180°)

## Acceptance criteria — evidence

| Issue #17 criterion | Status | Evidence |
|---|---|---|
| Every valid orientation emits finite bounded scene commands | ✅ | `dense_so3_grid_is_finite_bounded_and_tracks_the_f64_reference` (pitch/bank bounded, all finite) + `every_extreme_orientation_emits_finite_layered_scenes` (panel level: layered + finite at 90°/inverted/knife-edge corners) |
| Continuous passage through ±90° does not flip sky/ground meaning | ✅ | `continuous_pole_passage_keeps_the_sky_vector_continuous`: 80°→100° in 0.25° steps; the reconstructed sky vector tracks truth within the hold-window bound (8°, vs 180° for a flip) at every step, and reads inverted past the pole |
| Inverted flight is unambiguous | ✅ | `inverted_flight_is_unambiguous` (bank ≈180° at inverted-level, pitch ≈0, upright never flagged); geometry keeps sky above the horizon line iff |bank| < 90° |
| Hysteresis prevents chatter | ✅ | `threshold_jitter_cannot_chatter` (±0.5° oscillation around the 65° entry: exactly one transition; release only below the 60° exit); profile construction rejects hysteresis-free thresholds (`invalid_profiles_are_rejected`) |
| Declutter follows one priority table and never removes required alerts/failures | ✅ | The table is a single documented list at `draw_pfd`; `declutter_follows_the_one_priority_table` (removed items gone, IAS/ALT readouts kept) + `declutter_never_removes_alerts_or_failures` (IAS red-X and ATT caution survive declutter) |
| Normal-envelope behavior changes only where the typed attitude model requires it | ✅ | All pre-existing panel tests pass unchanged; `normal_envelope_has_no_unusual_artifacts`; in the normal range the down-vector derivation equals the previous Euler roll/pitch identically |

Deterministic verification per the issue: **all 24 proper cube rotations** against an f64 Shepperd-branch reference (`all_24_cube_rotations_match_the_f64_reference`, count asserted = 24); **q vs −q bit-identical** across the whole grid; an **independent f64 projection reference** (display-implied sky vector vs true down vector, dot > 0.9999 outside the hold window); the issue's **dense grid** (pitch 0/±20/30/50/89/90/91/179/180 × bank 0/±64/65/66/89/90/179/180, both signs, off-axis yaw); threshold jitter; and semantic scene tests for normal / declutter / chevrons (both senses, apex direction asserted) / vertical / inverted / failed attitude. No sleeps anywhere.

## Cross-cutting effects (deliberate)

- The reference rasterizer's PFD frame hash moves once: its fixture flies 90° bank, which now legitimately renders the decluttered unusual tier. Re-pinned and stability-asserted.
- `resolve`'s 153-line function-length debt is retired from the structure baseline after decomposition into per-group helpers (the AV-02 gate enforced this — working as intended).
- The wasm runtime holds one latch state per resource; stepping twice per frame (PFD then HSI) is idempotent because latches depend on input magnitudes, not step count.

53 instrument-state tests, 20 panel tests, 10 renderer tests, full workspace gates green (fmt / clippy `-D warnings` / strict rustdoc / thumbv7em no_std / structure / requirements / release / all five browser suites against the rebuilt wasm).

SIM / NOT FOR FLIGHT: engineering objective per AC 20-185A App. C.6 / AC 25-11B as design inputs — no certification, TSO, DAL, or aircraft-suitability claim. Refs #17.
