### PR TITLE
AIR-02: preliminary FHA/PSSA and hazard-derived assurance allocation

### DIFF
--- a/docs/instruments/README.md
+++ b/docs/instruments/README.md
@@ -17,6 +17,21 @@ The baseline is split into four controlled artifacts:
 - [Review record](review-record.md) records the approvals required before the
   baseline can be treated as reviewed.
 
+## Preliminary safety assessment
+
+Seeded from the intended-function baseline, the preliminary functional hazard
+assessment and system safety assessment analyse the display functions for loss,
+misleading, frozen, stale, wrong-reference, and failed-reversion conditions,
+derive safety requirements, and allocate assurance by function and architecture.
+They are preliminary and not closable: classifications stay conditional on a
+selected vehicle, operation, installation, and certification basis, and closure
+requires a qualified independent safety review.
+
+- [Functional hazard assessment](fha.md) is the failure-condition hazard log with
+  conditional severities and derived requirements.
+- [System safety assessment](pssa.md) is the common-cause and independence
+  analysis, assurance allocation, traceability, and AIR-02 review record.
+
 All browser, WebAssembly, Canvas, WebTransport, Gazebo, and test-harness output
 is **SIM / NOT FOR FLIGHT**. A visual resemblance to an aircraft display does
 not make the output primary flight information or authorize operational credit.

--- a/docs/instruments/fha.md
+++ b/docs/instruments/fha.md
@@ -1,0 +1,233 @@
+# Preliminary functional hazard assessment (AIR-02)
+
+**SIM / NOT FOR FLIGHT.** This is a preliminary functional hazard assessment
+(FHA) of the Pilotage instrument display functions. It is an engineering input
+to a future safety assessment, not an FAA/EASA finding, TSO authorization, or
+TC/STC approval. Every browser, WebAssembly, Canvas, WebTransport, Gazebo, and
+test-harness surface analysed here is **SIM / NOT FOR FLIGHT** under
+[`AIR-BAS-001`](requirements.md#air-bas-001).
+
+This assessment is **preliminary** and is not closable. Its classifications
+remain conditional on decisions this project has not made — the target vehicle,
+operation, installation, credited function, and certification basis — per
+[`AIR-HAZ-001`](requirements.md#air-haz-001). Closure requires the qualified
+independent safety review recorded in the [PSSA](pssa.md); the review fields
+there remain `PENDING`.
+
+## Scope and inputs
+
+The analysed functions and their boundary are the merged AIR-01 baseline:
+[intended functions](intended-functions.md), [system boundary](system-boundary.md),
+and the [requirements registry](requirements.md). The architecture context is
+[ADR-0017](../adr/0017-instrument-display-runtime.md) (no_std sans-IO runtime,
+scene-command IR, six criticality-banded compositor layers, first-class
+validity) and [ADR-0018](../adr/0018-avionics-telemetry-and-aviate-adapter.md)
+(measurement-identity ingress gate, coherence result, fail-closed authorization).
+
+The hazard set additionally covers the vehicle-neutral six-degree-of-freedom
+frame contract introduced by FRAME-01 (issue #52), whose frame, epoch, clock,
+and time-scale identities create hazards an aircraft-only display does not have.
+
+The [PSSA](pssa.md) carries the common-cause and independence analysis, the
+assurance allocation, the simulator-versus-airborne mitigation split, and the
+full bidirectional traceability from these failure conditions to implementation
+and verification issues.
+
+## Method and conventions
+
+Failure conditions are analysed at the **display level** — the effect on what
+the crew sees and does — because the sensors, estimators, alerting logic, and
+installation that would set aircraft-level effects are outside this boundary
+(see [system boundary](system-boundary.md)). Aircraft-level classification is a
+downstream activity performed against a selected certification basis.
+
+Each failure condition records the flight phase where it is most critical (the
+phases are those of [`AIR-ENV-001`](requirements.md#air-env-001)), the
+display-level and crew effect, the detection means and any independence
+assumption, a preliminary conditional severity, and the derived safety
+requirement(s).
+
+### Failure-condition classes analysed
+
+Per issue #27 and the intended-function baseline, every function is analysed for
+**loss** (missing), **misleading** (hazardously incorrect but plausible),
+**frozen** (retained last-good), **stale/latent** (aged or lagging), **reordered
+or replayed** data, **wrong reference** (datum, polarity, heading, or frame),
+and **failed reversion**, plus the cross-cutting **compositor**, **renderer or
+output**, **monitor**, **timebase**, **source-selection**, and **common-cause**
+failure conditions.
+
+### Conditional severity notation
+
+Severity vocabulary is the qualitative ARP4761A / AC 25.1309-1B set —
+Catastrophic, Hazardous, Major, Minor, No Safety Effect. Unconditional severities
+are impossible before a vehicle and operation are selected
+([`AIR-HAZ-001`](requirements.md#air-haz-001)), so each entry gives two explicitly
+conditional anchors:
+
+- **WCC (worst-credible-if-credited):** the plausible worst severity *if* this
+  function were credited primary flight information on the conservative
+  dual-pilot Part 25 IFR reference of
+  [`AIR-BAS-002`](requirements.md#air-bas-002), in instrument meteorological
+  conditions, at the most exposed phase. It ranks analysis and assurance
+  priority only.
+- **ABT (as-built-today):** the effect in the only configuration that exists —
+  supplemental **SIM / NOT FOR FLIGHT** awareness with no operational credit —
+  which is **No Safety Effect** on any real operation.
+
+Both anchors are conditional. A spacecraft, rotorcraft, Part 23, or
+uncrewed-operation basis would move them, and only a selected basis with an
+aircraft-level assessment produces a real classification. Where an FRAME-01
+spacecraft operation changes the analysis, it is stated in the entry.
+
+## Failure-condition hazard log
+
+### Attitude and primary flight display
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-ATT-01 | Loss of attitude | **All phases.** Attitude guidance removed; attitude-failure flag shown; independent data retained | Per-signal validity and range checks; fails to a flag, not a value | Hazardous–Catastrophic / No Safety Effect | [`AIR-UNAV-001`](requirements.md#air-unav-001), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+| FC-ATT-02 | Misleading attitude (plausible wrong pitch/bank accepted) | **Takeoff, approach, unusual-attitude.** Crew flies to a false horizon; control input in wrong sense; unrecognised | Requires cross-source comparison; single-source attitude has no on-display detection | Catastrophic / No Safety Effect | [`AIR-IN-001`](requirements.md#air-in-001), [`AIR-FLAG-006`](requirements.md#air-flag-006), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+| FC-ATT-03 | Frozen horizon (last-good retained through maneuver) | **All phases.** False steady attitude while vehicle rotates; delayed recognition | Independent renderer-progress and source-time evidence; frozen frame must be replaced | Catastrophic / No Safety Effect | [`AIR-UNAV-007`](requirements.md#air-unav-007), [`AIR-IN-013`](requirements.md#air-in-013), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-ATT-04 | Stale / latent attitude (aged, not flagged) | **Unusual-attitude, high-rate.** Lagged horizon; overcontrol or late recovery | Freshness derived from source time; staleness thresholds allocated per function | Hazardous / No Safety Effect | [`AIR-FLAG-003`](requirements.md#air-flag-003), [`AIR-TIM-001`](requirements.md#air-tim-001), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-ATT-05 | Wrong reference frame / absent frame metadata | **All phases.** Horizon referenced to the wrong body/navigation frame or an assumed local vertical; tilt or datum wrong | Explicit declared frames; missing metadata must drive unavailable | Catastrophic / No Safety Effect | [`AIR-BAS-004`](requirements.md#air-bas-004), [`AIR-IN-001`](requirements.md#air-in-001), [`AIR-HAZ-006`](requirements.md#air-haz-006), [`AIR-HAZ-007`](requirements.md#air-haz-007) |
+| FC-ATT-06 | Polarity / singularity ambiguity | **Unusual-attitude, inverted, vertical, heading wrap.** Wrong recovery direction or ambiguous sky/ground at representation singularities | Full-orientation-domain determinism; SO(3)-safe presentation | Catastrophic / No Safety Effect | [`AIR-ENV-002`](requirements.md#air-env-002), [`AIR-MODE-003`](requirements.md#air-mode-003), [`AIR-HAZ-012`](requirements.md#air-haz-012) |
+| FC-ATT-07 | Failed reversion / declutter (SVS bleeds into unusual-attitude) | **Unusual-attitude, high-workload.** Cluttered or ambiguous recovery picture; background not shed | Deterministic reversion; unusual-attitude independent of SVS | Catastrophic / No Safety Effect | [`AIR-MODE-003`](requirements.md#air-mode-003), [`AIR-MODE-004`](requirements.md#air-mode-004), [`AIR-HAZ-005`](requirements.md#air-haz-005) |
+
+### Air data and altitude
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-AD-01 | Loss of airspeed / altitude | **All phases.** Affected tape flagged; honest `Missing`; no fabricated value | Presence is structural; a never-supplied signal reads `Missing` | Major–Hazardous / No Safety Effect | [`AIR-UNAV-002`](requirements.md#air-unav-002), [`AIR-FLAG-004`](requirements.md#air-flag-004) |
+| FC-AD-02 | Misleading airspeed / altitude value | **Takeoff, approach, landing.** Unrecognised over/underspeed or altitude error | Requires comparison or integrity; single-source air data has no on-display detection | Catastrophic / No Safety Effect | [`AIR-IN-004`](requirements.md#air-in-004), [`AIR-FLAG-006`](requirements.md#air-flag-006), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+| FC-AD-03 | Wrong datum / barometric setting (or NED height labelled pressure altitude) | **Approach, landing.** Altitude reads against wrong datum; terrain-clearance error | Declared altitude type/datum; missing datum drives unavailable | Catastrophic / No Safety Effect | [`AIR-IN-002`](requirements.md#air-in-002), [`AIR-UNAV-002`](requirements.md#air-unav-002), [`AIR-HAZ-007`](requirements.md#air-haz-007) |
+| FC-AD-04 | Frozen airspeed / altitude tape | **All phases.** False steady value while state changes | Renderer-progress and source-time evidence | Hazardous–Catastrophic / No Safety Effect | [`AIR-UNAV-007`](requirements.md#air-unav-007), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-AD-05 | Vertical-speed polarity inverted | **Climb, descent, approach.** Climb shown as descent or vice versa | Sign integrity through derivation and reversion | Hazardous / No Safety Effect | [`AIR-HAZ-012`](requirements.md#air-haz-012), [`AIR-IN-004`](requirements.md#air-in-004) |
+| FC-AD-06 | Substitution (groundspeed relabelled as indicated airspeed on air-data loss) | **Takeoff, approach.** Ground-relative speed read as air-relative; stall/overspeed margin wrong | Never relabel across quantities; loss flags the affected indication only | Catastrophic / No Safety Effect | [`AIR-UNAV-002`](requirements.md#air-unav-002), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+
+### Heading, navigation, and horizontal situation
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-HDG-01 | Loss of heading / navigation | **Taxi, approach.** Dependent cues removed or flagged; independent track/position kept | Per-signal validity; independent data retains its own label | Major–Hazardous / No Safety Effect | [`AIR-UNAV-003`](requirements.md#air-unav-003), [`AIR-OUT-002`](requirements.md#air-out-002) |
+| FC-HDG-02 | Wrong heading reference (magnetic/true confusion, or body yaw shown as heading) | **All phases.** Heading off by variation or by sideslip; wrong track flown | Declared true/magnetic reference and variation source; heading separate from attitude yaw | Hazardous / No Safety Effect | [`AIR-IN-005`](requirements.md#air-in-005), [`AIR-BAS-004`](requirements.md#air-bas-004), [`AIR-HAZ-007`](requirements.md#air-haz-007) |
+| FC-HDG-03 | Misleading deviation (wrong polarity or scale) | **Approach.** Crew flies to the wrong side of course/glidepath | Sign and scale integrity; declared navigation mode | Catastrophic / No Safety Effect | [`AIR-IN-005`](requirements.md#air-in-005), [`AIR-HAZ-012`](requirements.md#air-haz-012) |
+| FC-HDG-04 | Frozen / stale navigation | **Approach, taxi.** False position, track, or distance | Source-time freshness and renderer progress | Hazardous / No Safety Effect | [`AIR-HAZ-011`](requirements.md#air-haz-011), [`AIR-FLAG-003`](requirements.md#air-flag-003) |
+| FC-HDG-05 | Undeclared navigation mode / source | **Approach.** Crew credits guidance from the wrong or an invalid source | Declared navigation source and mode; reversion identifies the source | Hazardous / No Safety Effect | [`AIR-IN-005`](requirements.md#air-in-005), [`AIR-MODE-004`](requirements.md#air-mode-004) |
+
+### Conventional instruments (comparison / reversion surface)
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-INST-01 | False standby independence (six-pack drawn from same state treated as independent) | **Source or display failure.** A common-cause fault takes the "standby" down with the primary; unwarranted redundancy credit | Independence is not established by drawing a second instrument; requires common-cause analysis | Catastrophic / No Safety Effect | [`AIR-OUT-003`](requirements.md#air-out-003), [`AIR-HAZ-009`](requirements.md#air-haz-009) |
+| FC-INST-02 | Conventional instrument fabricates a missing source | **All phases.** A dial shows a plausible value with no valid source | Missing/failed source flags the instrument; no last-good substitution | Catastrophic / No Safety Effect | [`AIR-OUT-003`](requirements.md#air-out-003), [`AIR-OUT-004`](requirements.md#air-out-004), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+
+### Synthetic vision
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-SVS-01 | False terrain / runway (database corruption or coverage gap) | **Approach, taxi, low-level.** Wrong terrain or runway painted; false clearance impression | Database integrity, coverage, and provenance evidence; SVS is supplemental, not TAWS | Hazardous–Catastrophic / No Safety Effect | [`AIR-IN-011`](requirements.md#air-in-011), [`AIR-OUT-005`](requirements.md#air-out-005), [`AIR-UNAV-005`](requirements.md#air-unav-005) |
+| FC-SVS-02 | Lost position integrity (scene registered to wrong position) | **Approach.** Terrain/runway misregistered under symbology; misleading conformal impression | Position integrity and coherence with attitude/time; fails to remove SVS | Hazardous / No Safety Effect | [`AIR-IN-011`](requirements.md#air-in-011), [`AIR-UNAV-005`](requirements.md#air-unav-005), [`AIR-HAZ-006`](requirements.md#air-haz-006) |
+| FC-SVS-03 | SVS obscures primary symbology (compositor priority error) | **All phases.** Background covers attitude/tapes/alerts | Compositor enforces `background < symbology < warning`; fails toward exposing critical bands | Catastrophic / No Safety Effect | [`AIR-OUT-005`](requirements.md#air-out-005), [`AIR-HAZ-004`](requirements.md#air-haz-004) |
+| FC-SVS-04 | SVS mistaken for or suppressing terrain alerting | **Approach, low-level.** Crew reads terrain shading as a terrain-clear/alert function | SVS and TAWS remain visually and functionally distinct; alert loss is not hidden by graphics | Catastrophic / No Safety Effect | [`AIR-OUT-010`](requirements.md#air-out-010), [`AIR-IN-012`](requirements.md#air-in-012) |
+| FC-SVS-05 | Failed reversion (SVS fault does not return to conventional horizon) | **All phases.** Frozen or black background instead of sky/ground | Deterministic reversion to horizon; primary alerts preserved | Hazardous–Catastrophic / No Safety Effect | [`AIR-UNAV-005`](requirements.md#air-unav-005), [`AIR-MODE-002`](requirements.md#air-mode-002), [`AIR-HAZ-005`](requirements.md#air-haz-005) |
+| FC-SVS-06 | Frozen last-good imagery (raster renderer retains last terrain frame) | **All phases.** Stale terrain shown as current | Independent raster-renderer progress evidence; fault-contained SVS renderer | Hazardous / No Safety Effect | [`AIR-HAZ-011`](requirements.md#air-haz-011), [`AIR-UNAV-007`](requirements.md#air-unav-007) |
+
+### HUD-SIM and non-conformal repeater
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-HUD-01 | Conformal misregistration (calibration / extrinsics error) | **Approach, takeoff.** Conformal cue points to the wrong world position; misleading guidance impression | Calibration revision, design eye, intrinsics/extrinsics validated; invalid removes conformal claim | Hazardous–Catastrophic / No Safety Effect | [`AIR-IN-010`](requirements.md#air-in-010), [`AIR-OUT-006`](requirements.md#air-out-006), [`AIR-UNAV-006`](requirements.md#air-unav-006) |
+| FC-HUD-02 | Video / state time skew (overlay lags imagery) | **Approach.** Symbology misregisters against video under motion | Capture-time and state-time alignment within a latency budget | Hazardous / No Safety Effect | [`AIR-IN-010`](requirements.md#air-in-010), [`AIR-TIM-002`](requirements.md#air-tim-002), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-HUD-03 | Repeater mistaken for conformal HUD (missing NON-CONFORMAL identity) | **All phases.** Non-conformal repeater read as registered outside-world guidance | Persistent **NON-CONFORMAL / NOT A HUD** identity rendered by the surface itself | Hazardous / No Safety Effect | [`AIR-OUT-007`](requirements.md#air-out-007), [`AIR-MODE-006`](requirements.md#air-mode-006), [`AIR-FLAG-007`](requirements.md#air-flag-007) |
+| FC-HUD-04 | Failed conformal reversion (calibration invalid, conformal cues retained) | **Approach.** Stale or invalid conformal cues persist after calibration loss | Loss of calibration removes cues or enters non-conformal mode with annunciation | Hazardous–Catastrophic / No Safety Effect | [`AIR-UNAV-006`](requirements.md#air-unav-006), [`AIR-MODE-005`](requirements.md#air-mode-005), [`AIR-HAZ-005`](requirements.md#air-haz-005) |
+
+### Vehicle frame and six-degree-of-freedom state (FRAME-01)
+
+These failure conditions come from the vehicle-neutral frame contract of issue
+#52. Their aircraft severities use the NED/local-vertical adapter; the spacecraft
+column is stated where the operation changes the effect. All remain conditional
+on a selected vehicle and operation
+([`AIR-HAZ-001`](requirements.md#air-haz-001)).
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-FRM-01 | Wrong inertial / local frame selected | **All phases.** Attitude or velocity presented in the wrong frame; horizon or vector points wrong | Typed frame identity on every quantity; composition is a checked operation | Catastrophic / No Safety Effect | [`AIR-HAZ-006`](requirements.md#air-haz-006), [`AIR-HAZ-007`](requirements.md#air-haz-007) |
+| FC-FRM-02 | Stale transform epoch (outdated frame relationship composed) | **Maneuver, orbital ops.** Transform uses an expired frame relationship; misregistered presentation | Epoch carried and checked; mismatched epoch fails closed | Hazardous–Catastrophic / No Safety Effect | [`AIR-HAZ-006`](requirements.md#air-haz-006), [`AIR-UNAV-004`](requirements.md#air-unav-004) |
+| FC-FRM-03 | Clock / time-scale mismatch across groups | **All phases.** Values from different time scales blended and shown as one observation | Declared clock domain and time-scale; incoherent snapshot drives unavailable | Catastrophic / No Safety Effect | [`AIR-UNAV-004`](requirements.md#air-unav-004), [`AIR-IN-008`](requirements.md#air-in-008), [`AIR-HAZ-006`](requirements.md#air-haz-006) |
+| FC-FRM-04 | LVLH / inertial confusion | **Orbital ops.** Orbital attitude read in the wrong basis; wrong pointing understanding | Distinct, labelled, visually distinguishable projections; basis change is annunciated | Hazardous–Catastrophic (op-dependent) / No Safety Effect | [`AIR-HAZ-008`](requirements.md#air-haz-008), [`AIR-HAZ-007`](requirements.md#air-haz-007) |
+| FC-FRM-05 | Invalid local-vertical assumption (horizon fabricated where none defined) | **Orbital / zero-g, high-altitude.** A horizon is invented where the frame defines no local vertical | Attitude remains meaningful with no gravity/horizon; no fabricated horizon | Hazardous / No Safety Effect | [`AIR-HAZ-007`](requirements.md#air-haz-007), [`AIR-ENV-002`](requirements.md#air-env-002) |
+
+### Timebase, source selection, compositor, renderer, and monitor
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-TIME-01 | Clock reset / skew undetected | **All phases.** Stale data shown as fresh; replay accepted | Source epoch, monotonic sequence, and time-domain mapping detect reset/replay/age | Catastrophic / No Safety Effect | [`AIR-IN-008`](requirements.md#air-in-008), [`AIR-UNAV-004`](requirements.md#air-unav-004), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-TIME-02 | Reordering / replay accepted into display state | **All phases.** Out-of-order or replayed values presented | Wrap-safe sequence and epoch ordering reject duplicates and reorderings | Hazardous / No Safety Effect | [`AIR-IN-008`](requirements.md#air-in-008), [`AIR-UNAV-004`](requirements.md#air-unav-004) |
+| FC-SRC-01 | Miscompare hidden by source selection | **All phases.** One lying source presented as valid; disagreement suppressed | Miscompare exposed when threshold/persistence exceeded; selection cannot hide it | Catastrophic / No Safety Effect | [`AIR-FLAG-006`](requirements.md#air-flag-006), [`AIR-HAZ-002`](requirements.md#air-haz-002) |
+| FC-SRC-02 | Cross-channel common-cause defeats comparison | **All phases.** Both channels fail the same way; comparison passes while both are wrong | Requires documented common-cause boundary; monitors must not share the fault | Catastrophic / No Safety Effect | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-HAZ-003`](requirements.md#air-haz-003) |
+| FC-CMP-01 | Compositor priority-table error | **All phases.** Background painted above primary/warning bands | Encoding order is z-order; unknown layer id fails the frame; fault favors exposing critical | Catastrophic / No Safety Effect | [`AIR-HAZ-004`](requirements.md#air-haz-004), [`AIR-BAS-007`](requirements.md#air-bas-007) |
+| FC-CMP-02 | Compositor resource exhaustion drops a critical layer | **All phases.** Primary symbology or warnings missing from the composed frame | Per-layer/frame budgets; missing critical band fails toward display-failure | Catastrophic / No Safety Effect | [`AIR-HAZ-004`](requirements.md#air-haz-004), [`AIR-UNAV-007`](requirements.md#air-unav-007) |
+| FC-CMP-03 | Layer misattribution (content in wrong criticality band) | **All phases.** Content painted at the wrong z-order or criticality | Every command inside exactly one layer; validated ascending, unnested layers | Hazardous–Catastrophic / No Safety Effect | [`AIR-HAZ-004`](requirements.md#air-haz-004), [`AIR-BAS-007`](requirements.md#air-bas-007) |
+| FC-RND-01 | Renderer stall retains last-good image | **All phases.** Whole display frozen; no indication | Independent progress/output monitor replaces the retained frame within allocated time | Catastrophic / No Safety Effect | [`AIR-UNAV-007`](requirements.md#air-unav-007), [`AIR-IN-013`](requirements.md#air-in-013), [`AIR-HAZ-011`](requirements.md#air-haz-011) |
+| FC-RND-02 | Corrupt command / output buffer | **All phases.** Garbled or partial symbology | Buffer integrity and backend status; corrupt output drives display-failure | Hazardous–Catastrophic / No Safety Effect | [`AIR-UNAV-007`](requirements.md#air-unav-007), [`AIR-OUT-004`](requirements.md#air-out-004) |
+| FC-RND-03 | Nondeterministic backend (same state renders differently) | **All phases.** Layout/glyph/raster drift between platforms; unrepeatable presentation | Reproducible glyph pack and reference rasterizer; deterministic presentation | Major–Hazardous / No Safety Effect | [`AIR-BAS-007`](requirements.md#air-bas-007), [`AIR-FLAG-007`](requirements.md#air-flag-007) |
+| FC-MON-01 | Monitor coverage gap (stall not detected) | **All phases.** Frozen/failed display not caught | Monitor coverage sized to the failure conditions it must detect; bounded exposure | Catastrophic / No Safety Effect | [`AIR-IN-013`](requirements.md#air-in-013), [`AIR-HAZ-003`](requirements.md#air-haz-003), [`AIR-HAZ-010`](requirements.md#air-haz-010) |
+| FC-MON-02 | Monitor shares fault with the path it monitors | **All phases.** Monitor and renderer fail together; no detection | Monitor independence from monitored computation, timebase, power | Catastrophic / No Safety Effect | [`AIR-HAZ-003`](requirements.md#air-haz-003), [`AIR-HAZ-009`](requirements.md#air-haz-009) |
+| FC-MON-03 | Latent monitor failure (undetected until demanded) | **Source or display failure.** No coverage when a fault finally occurs | Power-up test, continuous monitor, or periodic self-test bounding exposure | Catastrophic / No Safety Effect | [`AIR-HAZ-010`](requirements.md#air-haz-010), [`AIR-TIM-003`](requirements.md#air-tim-003) |
+
+### Common-cause and combination failure conditions
+
+These combinations are the reason assurance is allocated by architecture, not by
+crate. The [PSSA](pssa.md) develops the common-cause boundaries.
+
+| ID | Failure condition | Display-level & crew effect | Detection / independence assumption | Conditional severity (WCC / ABT) | Derived requirement(s) |
+|---|---|---|---|---|---|
+| FC-CC-01 | Shared timebase fault | **All phases.** All time-dependent functions stale together; coherence and comparison both defeated | Timebase is a declared common-cause boundary; coherence uses independent evidence | Catastrophic / No Safety Effect | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-UNAV-004`](requirements.md#air-unav-004) |
+| FC-CC-02 | Shared validated state copy | **Source or display failure.** "Independent" instruments and standby all wrong together | The same state copy establishes no independence | Catastrophic / No Safety Effect | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-OUT-003`](requirements.md#air-out-003) |
+| FC-CC-03 | Shared power / renderer / compositor | **All phases.** Total display loss including the reversion surface | Independence of the reversion path from the primary path | Catastrophic / No Safety Effect | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-HAZ-003`](requirements.md#air-haz-003) |
+| FC-CC-04 | Shared database / position source | **Approach, low-level.** SVS and every position-derived cue wrong together | Database and position provenance treated as a common-cause boundary | Hazardous–Catastrophic / No Safety Effect | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-IN-011`](requirements.md#air-in-011) |
+
+## Hazard count by category
+
+| Category | Failure conditions |
+|---|---|
+| Attitude / PFD | 7 |
+| Air data / altitude | 6 |
+| Heading / navigation / HSI | 5 |
+| Conventional instruments | 2 |
+| Synthetic vision | 6 |
+| HUD-SIM / repeater | 4 |
+| Vehicle frame / six-DoF (FRAME-01) | 5 |
+| Timebase | 2 |
+| Source selection | 2 |
+| Compositor | 3 |
+| Renderer / output | 3 |
+| Monitor | 3 |
+| Common-cause combinations | 4 |
+| **Total** | **52** |
+
+## Derived safety requirements
+
+The hazard log derives safety requirements of two kinds:
+
+- **Existing intended-function requirements** (`AIR-BAS`, `AIR-IN`, `AIR-OUT`,
+  `AIR-MODE`, `AIR-FLAG`, `AIR-UNAV`, `AIR-ENV`, `AIR-TIM`) that already discharge
+  a failure condition; the FHA confirms their safety role and the [PSSA](pssa.md)
+  allocates them to implementation and verification issues.
+- **New hazard-derived requirements** minted by this assessment,
+  [`AIR-HAZ-001`](requirements.md#air-haz-001) through
+  [`AIR-HAZ-012`](requirements.md#air-haz-012), which close gaps the
+  intended-function baseline did not state as normative requirements —
+  misleading-information detection, monitor independence, compositor fail-safe
+  priority, fail-safe self-annunciating reversion, frame/epoch/time-scale
+  coherence, explicit reference basis, reference-frame confusion barrier,
+  common-cause declaration, latent-failure exposure, frozen/stale detection at
+  source time, and polarity/ordering integrity.
+
+The bidirectional traceability from every failure condition and derived
+requirement to an implementation or verification issue — and the explicit
+**unallocated** table for derived requirements with no existing issue — is in the
+[PSSA](pssa.md). This FHA is not closable; classification and closure depend on a
+selected certification basis and the qualified independent safety review recorded
+there.

--- a/docs/instruments/pssa.md
+++ b/docs/instruments/pssa.md
@@ -1,0 +1,275 @@
+# Preliminary system safety assessment (AIR-02)
+
+**SIM / NOT FOR FLIGHT.** This is a preliminary system safety assessment (PSSA)
+of the Pilotage instrument display architecture. It develops the common-cause and
+independence analysis, the assurance allocation, the simulator-versus-airborne
+mitigation split, and the bidirectional traceability for the failure conditions
+identified in the [FHA](fha.md). It is an engineering input to a future safety
+assessment, not an FAA/EASA finding, TSO authorization, or TC/STC approval. Every
+surface analysed remains **SIM / NOT FOR FLIGHT** under
+[`AIR-BAS-001`](requirements.md#air-bas-001).
+
+This assessment is **preliminary and not closable**. No development assurance
+level, integrity level, or quantitative probability objective is assigned, and
+none may be, until the target vehicle, operation, installation, credited function,
+and certification basis are selected and an aircraft-level assessment is performed
+([`AIR-BAS-003`](requirements.md#air-bas-003),
+[`AIR-HAZ-001`](requirements.md#air-haz-001)). Closure requires the qualified
+independent safety review recorded at the end of this document; those fields
+remain `PENDING`.
+
+## Architecture under assessment
+
+The assessed architecture is the AIR-01 [system boundary](system-boundary.md)
+realized by [ADR-0017](../adr/0017-instrument-display-runtime.md) and
+[ADR-0018](../adr/0018-avionics-telemetry-and-aviate-adapter.md):
+
+- Untrusted adapters and transports deliver data to an **input validation and
+  time/integrity gate**, which produces one atomic `DisplaySnapshot` with a
+  coherence result and a wrapping generation. Transport delivery is not evidence
+  of freshness or trust.
+- A **no_std sans-IO core** derives display quantities and per-signal validity,
+  emitting a versioned scene-command IR.
+- The IR is partitioned into six ascending, unnested **criticality bands**
+  (`Background < Attitude < Tapes < Guidance < Annunciation < Failure`); a
+  **compositor** enforces that ordering so optional background can never cover,
+  suppress, or replace primary symbology, warnings, or failure indications.
+- A **deterministic output backend** renders the composed frame, and an
+  **independent progress/output monitor** detects a renderer or output path that
+  retains a last-good image and forces a display-failure presentation within an
+  allocated time.
+
+The FRAME-01 contract (issue #52) adds typed frame, epoch, clock-domain, and
+time-scale identities to every presented spatial quantity, with checked
+composition and fail-closed unknown/mismatch handling. This PSSA treats that
+contract as a common resource whose integrity is that of the most critical
+spatial presentation it feeds.
+
+## Common-cause boundaries
+
+Assurance is allocated by architecture rather than by crate because the failure
+conditions in the [FHA](fha.md) — especially FC-CC-01 through FC-CC-04, FC-SRC-02,
+and FC-MON-02 — are dominated by shared resources. Each boundary below is a
+candidate common-cause group. Independence across a boundary is **assumed nowhere
+today**; it must be established by a selected installation and its own analysis
+([`AIR-HAZ-009`](requirements.md#air-haz-009)).
+
+| Common-cause boundary | What is shared today | Independence required before credit | Simulator-only limitation |
+|---|---|---|---|
+| Sensors / source estimators | Single upstream estimate (e.g. one Aviate estimator) feeds all functions | Independent sensing/estimation channels for any comparison or redundancy credit | Simulated truth carries no sensor-error, installation, or integrity claim |
+| Buses / transports | One WebTransport/shared-memory/USB CDC path | Physically and electrically independent buses for redundant channels | Receipt time is not source time; a transport cannot refresh age or integrity |
+| Timebase | One acquisition/clock domain drives freshness and coherence (FC-CC-01) | Independent timebase for any function credited to survive a clock fault | Browser/simulator clocks are not a qualified time source |
+| Source selection | One selection/authorization policy gates all groups | Selection logic independent from the sources it arbitrates | Simulator profile admits unseen incarnations and resets on session renegotiation; explicitly ineligible for credit |
+| Databases | Shared terrain/obstacle/aerodrome data and one position source (FC-CC-04) | Independent provenance and position integrity for SVS versus primary cues | Database graphics are not sensor observations, TAWS, or assurance evidence |
+| Renderer | One rasterizer/backend for every band | A reversion path whose renderer is independent of the primary path | Canvas/browser rendering is nondeterministic across platforms |
+| Compositor / window manager | One compositor orders every criticality band (FC-CMP-01–03) | Compositor integrity at least that of the most critical band it can affect | Browser window manager and lifecycle are not a qualified compositor |
+| Display hardware | One surface presents all functions (FC-CC-03) | Independent surfaces for any dual-display or standby credit | Browser display is not a qualified display platform |
+| Power | One power domain for core, renderer, compositor, monitor (FC-CC-03) | Independent power for any independently-credited path | Not modelled by the simulator |
+| Monitoring | One progress/output monitor (FC-MON-01–03) | Monitor independent of the computation, timebase, and power it checks | Simulator monitors demonstrate mechanism, not airborne coverage |
+
+The single largest common-cause item is the **shared validated state copy**: the
+no_std panels are pure functions of one immutable `DisplaySnapshot`, so drawing a
+second instrument, a six-pack, or a "standby" from that same copy establishes no
+independence (FC-CC-02, FC-INST-01). This is stated normatively by
+[`AIR-HAZ-009`](requirements.md#air-haz-009).
+
+## Independence assumptions (explicit)
+
+Recorded so the [FHA](fha.md) classifications are not read as assuming redundancy
+that does not exist:
+
+- **No source independence.** A single upstream estimate feeds every function;
+  misleading-source failure conditions (FC-ATT-02, FC-AD-02, FC-SRC-01) have no
+  on-display detection without an independent comparison source.
+- **No renderer, compositor, display, or power independence.** One process, one
+  backend, one surface, one power domain; the reversion surface is not independent
+  of the primary path (FC-CC-03).
+- **No monitor independence yet.** The progress/output monitor shares the process
+  and timebase of the path it monitors; it demonstrates the mechanism, not
+  airborne coverage (FC-MON-02), pending
+  [`AIR-HAZ-003`](requirements.md#air-haz-003).
+- **Ingress identity is simulator-grade.** Per ADR-0018, the shared-memory reader
+  uses POSIX `(device, inode, size)` identity and the browser profile uses
+  operating-system entropy for incarnation; both are explicitly ineligible for
+  operational credit and an aircraft producer must supply a source-issued boot
+  identity.
+- **Coherence is not redundancy.** The coherence result confirms that groups share
+  identity, epoch, and clock within a skew bound; it is not a cross-source
+  comparison and grants no miscompare detection.
+
+## Assurance allocation rationale
+
+No DAL/IDAL is assigned ([`AIR-BAS-003`](requirements.md#air-bas-003),
+[`AIR-HAZ-001`](requirements.md#air-haz-001)). The allocation below is a
+**relative, conditional** rationale: it says where integrity and independence
+must concentrate *if* a basis credits these functions, and recommends independence
+only where the intended function and architecture support it. Quantitative
+objectives are deliberately absent because there is no defined certification basis
+(that basis is the subject of AIR-03, issue #28).
+
+| Function / element | Worst-credible-if-credited | Allocation rationale (conditional) |
+|---|---|---|
+| Attitude / PFD primary symbology | Catastrophic | Highest integrity; a credited basis would drive attitude-source independence, cross-comparison, and a genuinely independent reversion path. Misleading and frozen attitude (FC-ATT-02, FC-ATT-03) are the design drivers |
+| Air data / altitude | Catastrophic | High integrity on value correctness, datum, and polarity; wrong-datum and substitution (FC-AD-03, FC-AD-06) require independent detection or unavailability |
+| Heading / navigation / HSI | Hazardous | Integrity on reference typing (magnetic/true), deviation polarity, and navigation-mode declaration (FC-HDG-02, FC-HDG-03) |
+| Conventional instruments | Inherits the quantity shown | No independent standby credit; integrity is that of the shared state and the honest-missing rule (FC-INST-01, FC-INST-02) |
+| SVS background | Hazardous (via misleading terrain) or contained | Imagery fidelity is a lower tier, but **containment** — compositor priority and reversion — inherits the primary-path integrity, because an SVS fault must never touch symbology (FC-SVS-03, FC-SVS-05) |
+| HUD-SIM / repeater | Hazardous | Integrity concentrated on calibration/time validation and on the fail-down to non-conformal (FC-HUD-01, FC-HUD-04); the conformal claim is the hazard |
+| Frame / six-DoF contract (FRAME-01) | Catastrophic | A shared spatial resource; its integrity equals that of the most critical spatial presentation. Fail-closed on frame/epoch/clock/time-scale mismatch is mandatory (FC-FRM-01–05) |
+| Compositor / window manager | Catastrophic | Inherits the highest criticality band it can affect; must fail toward exposing critical bands (FC-CMP-01–03) |
+| Timebase | Catastrophic | Common-cause to every time-dependent function; independence and self-test bound its latent failure (FC-CC-01, FC-MON-03) |
+| Progress / output monitor | Catastrophic | Must be independent of and bound the latency of the path it protects (FC-MON-01–03) |
+
+The recurring PSSA conclusion is that **shared resources — the timebase, source
+selection, compositor, renderer, monitor, and frame contract — inherit the
+integrity of the most critical function they can affect**, and are therefore the
+primary targets for independence and latent-failure control, not the individual
+panels.
+
+## Simulator versus airborne mitigations
+
+Per the [FHA](fha.md) and issue #27, the analysis distinguishes what the simulator
+demonstrates from what an airborne installation must provide.
+
+| Failure condition family | Simulator mechanism (demonstrated) | Airborne mitigation (required, not provided here) |
+|---|---|---|
+| Misleading value (FC-ATT-02, FC-AD-02, FC-SRC-01) | Per-signal validation, range/coherence checks, miscompare when a second source exists | Independent sensing channels and a comparison/voting architecture |
+| Frozen / stalled display (FC-ATT-03, FC-RND-01, FC-MON-01) | Progress/output monitor forces display-failure in the same process | An independent hardware monitor and independent power |
+| Wrong datum / reference / frame (FC-AD-03, FC-HDG-02, FC-FRM-01–05) | Declared metadata, fail-closed on missing/unknown, typed frames | Qualified source metadata and installation-verified references |
+| Compositor priority error (FC-CMP-01–03) | Validated ascending layer encoding, unknown-layer-id frame failure, budgets | Qualified compositor/window manager with resource guarantees |
+| Timebase / replay (FC-TIME-01–02, FC-CC-01) | Epoch, sequence, time-domain mapping, coherence result | Independent qualified timebase; source-issued boot identity |
+| Common-cause (FC-CC-01–04, FC-SRC-02, FC-MON-02) | Boundary declaration and containment rules | Physical/electrical/power separation and a documented common-cause analysis |
+
+## Traceability
+
+Traceability is bidirectional through the requirement registry: implementation and
+verification issues cite intended-function requirements under change control
+([`AIR-BAS-005`](requirements.md#air-bas-005)), and this assessment cites those
+issues back from each failure condition and derived requirement. All identifiers
+in the tables below link into the registry; issue references are GitHub issues in
+`luofang34/Pilotage`.
+
+### Failure-condition family → derived requirement → issue
+
+| Failure-condition family | Primary derived requirement(s) | Implementation / verification issue(s) |
+|---|---|---|
+| Attitude (FC-ATT-01–07) | [`AIR-UNAV-001`](requirements.md#air-unav-001), [`AIR-HAZ-002`](requirements.md#air-haz-002), [`AIR-HAZ-011`](requirements.md#air-haz-011), [`AIR-HAZ-012`](requirements.md#air-haz-012) | [#17](https://github.com/luofang34/Pilotage/issues/17), [#19](https://github.com/luofang34/Pilotage/issues/19), [#20](https://github.com/luofang34/Pilotage/issues/20), [#15](https://github.com/luofang34/Pilotage/issues/15) |
+| Air data (FC-AD-01–06) | [`AIR-UNAV-002`](requirements.md#air-unav-002), [`AIR-HAZ-002`](requirements.md#air-haz-002), [`AIR-HAZ-007`](requirements.md#air-haz-007), [`AIR-HAZ-012`](requirements.md#air-haz-012) | [#16](https://github.com/luofang34/Pilotage/issues/16), [#19](https://github.com/luofang34/Pilotage/issues/19), [#20](https://github.com/luofang34/Pilotage/issues/20) |
+| Heading / navigation (FC-HDG-01–05) | [`AIR-UNAV-003`](requirements.md#air-unav-003), [`AIR-HAZ-007`](requirements.md#air-haz-007), [`AIR-HAZ-012`](requirements.md#air-haz-012) | [#21](https://github.com/luofang34/Pilotage/issues/21), [#20](https://github.com/luofang34/Pilotage/issues/20), [#23](https://github.com/luofang34/Pilotage/issues/23) |
+| Conventional instruments (FC-INST-01–02) | [`AIR-OUT-003`](requirements.md#air-out-003), [`AIR-HAZ-002`](requirements.md#air-haz-002), [`AIR-HAZ-009`](requirements.md#air-haz-009) | [#20](https://github.com/luofang34/Pilotage/issues/20) |
+| Synthetic vision (FC-SVS-01–06) | [`AIR-OUT-005`](requirements.md#air-out-005), [`AIR-OUT-010`](requirements.md#air-out-010), [`AIR-UNAV-005`](requirements.md#air-unav-005), [`AIR-HAZ-004`](requirements.md#air-haz-004), [`AIR-HAZ-006`](requirements.md#air-haz-006) | [#34](https://github.com/luofang34/Pilotage/issues/34), [#33](https://github.com/luofang34/Pilotage/issues/33), [#31](https://github.com/luofang34/Pilotage/issues/31), [#32](https://github.com/luofang34/Pilotage/issues/32), [#35](https://github.com/luofang34/Pilotage/issues/35) |
+| HUD-SIM / repeater (FC-HUD-01–04) | [`AIR-OUT-006`](requirements.md#air-out-006), [`AIR-OUT-007`](requirements.md#air-out-007), [`AIR-UNAV-006`](requirements.md#air-unav-006), [`AIR-HAZ-005`](requirements.md#air-haz-005), [`AIR-HAZ-011`](requirements.md#air-haz-011) | [#36](https://github.com/luofang34/Pilotage/issues/36), [#37](https://github.com/luofang34/Pilotage/issues/37), [#38](https://github.com/luofang34/Pilotage/issues/38), [#39](https://github.com/luofang34/Pilotage/issues/39) |
+| Frame / six-DoF (FC-FRM-01–05) | [`AIR-HAZ-006`](requirements.md#air-haz-006), [`AIR-HAZ-007`](requirements.md#air-haz-007), [`AIR-HAZ-008`](requirements.md#air-haz-008), [`AIR-UNAV-004`](requirements.md#air-unav-004) | [#52](https://github.com/luofang34/Pilotage/issues/52), [#18](https://github.com/luofang34/Pilotage/issues/18), [#46](https://github.com/luofang34/Pilotage/issues/46) |
+| Timebase (FC-TIME-01–02) | [`AIR-IN-008`](requirements.md#air-in-008), [`AIR-UNAV-004`](requirements.md#air-unav-004), [`AIR-HAZ-011`](requirements.md#air-haz-011) | [#18](https://github.com/luofang34/Pilotage/issues/18), [#46](https://github.com/luofang34/Pilotage/issues/46) |
+| Source selection (FC-SRC-01–02) | [`AIR-FLAG-006`](requirements.md#air-flag-006), [`AIR-HAZ-002`](requirements.md#air-haz-002), [`AIR-HAZ-009`](requirements.md#air-haz-009) | [#20](https://github.com/luofang34/Pilotage/issues/20) |
+| Compositor (FC-CMP-01–03) | [`AIR-HAZ-004`](requirements.md#air-haz-004), [`AIR-BAS-007`](requirements.md#air-bas-007) | [#25](https://github.com/luofang34/Pilotage/issues/25), [#30](https://github.com/luofang34/Pilotage/issues/30) |
+| Renderer / output (FC-RND-01–03) | [`AIR-UNAV-007`](requirements.md#air-unav-007), [`AIR-BAS-007`](requirements.md#air-bas-007), [`AIR-HAZ-011`](requirements.md#air-haz-011) | [#15](https://github.com/luofang34/Pilotage/issues/15), [#26](https://github.com/luofang34/Pilotage/issues/26), [#29](https://github.com/luofang34/Pilotage/issues/29), [#30](https://github.com/luofang34/Pilotage/issues/30) |
+| Monitor (FC-MON-01–03) | [`AIR-IN-013`](requirements.md#air-in-013), [`AIR-HAZ-003`](requirements.md#air-haz-003), [`AIR-HAZ-010`](requirements.md#air-haz-010) | [#15](https://github.com/luofang34/Pilotage/issues/15), [#30](https://github.com/luofang34/Pilotage/issues/30) |
+| Common-cause (FC-CC-01–04) | [`AIR-HAZ-009`](requirements.md#air-haz-009), [`AIR-HAZ-003`](requirements.md#air-haz-003), [`AIR-UNAV-004`](requirements.md#air-unav-004) | *see unallocated table* |
+
+### Derived requirement → issue allocation
+
+| Derived requirement | Allocated issue(s) | Verification intent |
+|---|---|---|
+| [`AIR-HAZ-001`](requirements.md#air-haz-001) | [#28](https://github.com/luofang34/Pilotage/issues/28) | Certification-basis and lifecycle plan keeps classifications conditional; review confirms no unconditional severity appears |
+| [`AIR-HAZ-002`](requirements.md#air-haz-002) | [#19](https://github.com/luofang34/Pilotage/issues/19), [#20](https://github.com/luofang34/Pilotage/issues/20), [#15](https://github.com/luofang34/Pilotage/issues/15) | Per-signal validation + comparison/reversion; a quantity that cannot be shown correct is unavailable |
+| [`AIR-HAZ-003`](requirements.md#air-haz-003) | [#15](https://github.com/luofang34/Pilotage/issues/15), [#30](https://github.com/luofang34/Pilotage/issues/30) | Monitor coverage and fault-injection; installation-level independence remains an aircraft-architecture gap |
+| [`AIR-HAZ-004`](requirements.md#air-haz-004) | [#25](https://github.com/luofang34/Pilotage/issues/25), [#30](https://github.com/luofang34/Pilotage/issues/30) | Layer-contract validation and conformance/fault-injection gates |
+| [`AIR-HAZ-005`](requirements.md#air-haz-005) | [#20](https://github.com/luofang34/Pilotage/issues/20), [#35](https://github.com/luofang34/Pilotage/issues/35), [#15](https://github.com/luofang34/Pilotage/issues/15) | Deterministic reversion, SVS fallback, and display-failure on reversion-mechanism fault |
+| [`AIR-HAZ-006`](requirements.md#air-haz-006) | [#52](https://github.com/luofang34/Pilotage/issues/52), [#18](https://github.com/luofang34/Pilotage/issues/18), [#46](https://github.com/luofang34/Pilotage/issues/46) | Typed-frame checked composition; fail-closed on mismatch/unknown |
+| [`AIR-HAZ-007`](requirements.md#air-haz-007) | [#52](https://github.com/luofang34/Pilotage/issues/52), [#16](https://github.com/luofang34/Pilotage/issues/16), [#21](https://github.com/luofang34/Pilotage/issues/21) | Explicit reference/datum/local-vertical basis; no fabricated horizon |
+| [`AIR-HAZ-008`](requirements.md#air-haz-008) | [#52](https://github.com/luofang34/Pilotage/issues/52), [#34](https://github.com/luofang34/Pilotage/issues/34) | Distinct labelled projections; annunciated basis change |
+| [`AIR-HAZ-009`](requirements.md#air-haz-009) | *unallocated* | Analysis obligation; see unallocated table |
+| [`AIR-HAZ-010`](requirements.md#air-haz-010) | *unallocated* | Exposure intervals need a certification basis; see unallocated table |
+| [`AIR-HAZ-011`](requirements.md#air-haz-011) | [#15](https://github.com/luofang34/Pilotage/issues/15), [#18](https://github.com/luofang34/Pilotage/issues/18) | Source-time freshness + renderer-progress liveness |
+| [`AIR-HAZ-012`](requirements.md#air-haz-012) | [#17](https://github.com/luofang34/Pilotage/issues/17), [#23](https://github.com/luofang34/Pilotage/issues/23), [#18](https://github.com/luofang34/Pilotage/issues/18) | Polarity/ordering integrity through the orientation domain and reversion |
+
+### Unallocated derived requirements
+
+Requirements with no existing implementation or verification issue. Per issue #27
+these are listed explicitly rather than assigned invented issue numbers; each
+needs a new issue or a certification-basis decision.
+
+| Derived requirement | Why unallocated | What is needed |
+|---|---|---|
+| [`AIR-HAZ-009`](requirements.md#air-haz-009) | Common-cause boundary declaration is an ongoing analysis obligation against a selected architecture; no implementation issue owns the power, bus, and display-hardware separation it demands | A dedicated common-cause / independence analysis issue tied to a selected installation, plus the aircraft power and separation architecture |
+| [`AIR-HAZ-010`](requirements.md#air-haz-010) | Latent-failure exposure intervals cannot be set without a certification basis and its quantitative objectives; the monitor and reversion self-test cadence is undefined pre-basis | Exposure-interval derivation under the AIR-03 basis ([#28](https://github.com/luofang34/Pilotage/issues/28)) and a self-test/BIT implementation issue |
+
+Additional unallocated safety gaps identified by the analysis, each requiring a
+future issue: **independent power and physical separation** for the reversion path
+(FC-CC-03); an **independent hardware monitor** for airborne coverage (FC-MON-02,
+partially served by [#30](https://github.com/luofang34/Pilotage/issues/30) in
+simulation only); and **independent sensing/comparison sources** for
+misleading-value detection (FC-ATT-02, FC-AD-02), which are outside this boundary
+and belong to an aircraft sensor architecture.
+
+## Analysis snapshot (informative, non-normative)
+
+The GitHub issue tracker is the authoritative source for the current state of
+every referenced issue. As of this analysis revision, the implementation baseline
+that already exists in the merged registry covers input validation, measurement
+identity and coherence, fail-closed authorization, the scene-layer/compositor
+contract, the reproducible glyph pack, the reference rasterizer, display-liveness
+failure, and SO(3) unusual-attitude presentation. The synthetic-vision, HUD-SIM,
+alerting, source-comparison, frame-contract, and certification-basis work is
+tracked by open issues. This paragraph is informative context only; nothing in the
+FHA/PSSA classifications depends on an issue's open/closed state.
+
+## Independent safety review record (AIR-02)
+
+This record is the closure gate for AIR-02, mirroring
+[`AIR-BAS-006`](requirements.md#air-bas-006) and the AIR-01
+[review record](review-record.md). Empty or `PENDING` fields mean this assessment
+is not approved and issue #27 remains open. A pull-request approval without the
+qualifications and disposition below is not a substitute.
+
+### Assessment under review
+
+- Tracking issue: AIR-02 / GitHub issue 27
+- Artifacts: `fha.md`, `pssa.md`, and the `AIR-HAZ` requirements in
+  `requirements.md` in this directory
+- Baseline analysed: the AIR-01 intended-function baseline and the FRAME-01
+  (issue 52) frame contract
+- Certification or operational approval: not asserted by this review
+
+### Safety review
+
+- Reviewer: PENDING
+- Qualification and relevant experience: PENDING
+- Independence from the author: PENDING
+- Review revision/commit: PENDING
+- Date: PENDING
+- Disposition (`APPROVED`, `APPROVED WITH ACTIONS`, or `REJECTED`): PENDING
+- Open actions and linked issues: PENDING
+- Recorded rationale: PENDING
+
+The safety reviewer confirms that the failure-condition set is adequately
+complete for the analysed functions, that severities are stated conditionally with
+no unconditional classification or DAL, that common-cause boundaries and
+independence assumptions are explicit, that simulator mechanisms are distinguished
+from airborne mitigations, and that every derived requirement is either allocated
+to an issue or listed as unallocated.
+
+### Human-factors review
+
+- Reviewer: PENDING
+- Qualification and relevant experience: PENDING
+- Independence from the author: PENDING
+- Review revision/commit: PENDING
+- Date: PENDING
+- Disposition (`APPROVED`, `APPROVED WITH ACTIONS`, or `REJECTED`): PENDING
+- Open actions and linked issues: PENDING
+- Recorded rationale: PENDING
+
+The human-factors reviewer confirms that the crew-effect descriptions, detection
+assumptions, reversion behavior, and mode/annunciation failure conditions are
+suitable inputs to subsequent aircraft-specific validation.
+
+### Closure decision
+
+- All required reviews complete: NO
+- Certification basis selected and classifications made unconditional under it: NO
+- All blocking actions resolved or accepted by the responsible authority: NO
+- Tracking issue may close: NO
+- Decision revision/commit: PENDING
+- Decision owner and date: PENDING

--- a/docs/instruments/requirements.md
+++ b/docs/instruments/requirements.md
@@ -448,3 +448,118 @@ and jitter, including worst-case load and failure/recovery behavior.
 Every unavailable condition shall define a bounded detection, annunciation, and
 reversion time derived from its safety assessment; a browser demonstration
 threshold shall not be treated as an aircraft allocation.
+
+## Hazard-derived safety requirements
+
+These requirements are derived by the preliminary functional hazard assessment
+and preliminary system safety assessment ([FHA](fha.md), [PSSA](pssa.md)). Each
+is additive to the intended-function baseline and is referenced from the failure
+conditions and allocation tables that derive it.
+
+<a id="air-haz-001"></a>
+### AIR-HAZ-001 — Conditional failure-condition classification
+
+No failure condition identified by the instrument hazard assessment shall be
+assigned an unconditional severity, development assurance level, integrity level,
+or quantitative probability objective; every classification shall remain
+explicitly conditional on the selected vehicle, operation, installation, credited
+function, and certification basis, none of which this baseline selects.
+
+<a id="air-haz-002"></a>
+### AIR-HAZ-002 — Misleading-information detection means
+
+Each credited display quantity shall carry a detection means — range, coherence,
+source-time, cross-source comparison, integrity, or annunciation — sufficient to
+reveal an incorrect value; a quantity that cannot be shown correct for its
+intended use shall be presented as unavailable rather than displayed silently.
+
+<a id="air-haz-003"></a>
+### AIR-HAZ-003 — Monitor independence
+
+A monitor credited with detecting a renderer, output-path, or data fault shall
+not depend on the same computation, timebase, power, or resource whose failure it
+must detect, to the extent required by the failure condition it mitigates; a
+monitor that shares those resources shall claim no independence credit until an
+installation provides the required separation.
+
+<a id="air-haz-004"></a>
+### AIR-HAZ-004 — Compositor fail-safe priority
+
+A compositor, window-manager, or layer-composition fault — corrupt layer state,
+priority-table error, or resource exhaustion — shall resolve toward exposing
+higher-criticality bands and toward an explicit display-failure presentation, and
+shall never resolve toward suppressing primary symbology, warnings, or failure
+indications or toward promoting background content above them.
+
+<a id="air-haz-005"></a>
+### AIR-HAZ-005 — Fail-safe self-annunciating reversion
+
+A reversion or degraded-mode transition shall never select, restore, or upgrade
+an unvalidated, stale, or failed source; failure of the reversion mechanism
+itself shall drive an explicit display-failure presentation within the allocated
+monitor time and shall remain crew-visible, and no transition shall hide its
+cause or resulting source.
+
+<a id="air-haz-006"></a>
+### AIR-HAZ-006 — Frame, epoch, and time-scale coherence fail closed
+
+Every presented pose, attitude, position, velocity, angular rate, or derived
+reference shall carry an explicit frame identity, epoch, clock domain, and
+time-scale identity; composition or presentation across a mismatched or unknown
+frame, epoch, clock domain, or time-scale shall fail closed to a declared
+unavailable condition and shall never silently reproject, assume a default frame,
+or blend across time scales.
+
+<a id="air-haz-007"></a>
+### AIR-HAZ-007 — Explicit reference and local-vertical basis
+
+Any horizon, up/down, local-vertical, attitude datum, altitude datum, or heading
+reference shall be presented only against an explicitly selected reference basis;
+the display shall not assume a local vertical, gravity direction, or horizon where
+the selected frame defines none, and shall present attitude unambiguously or
+unavailable rather than fabricate a horizon.
+
+<a id="air-haz-008"></a>
+### AIR-HAZ-008 — Reference-frame confusion barrier
+
+Distinct reference projections — inertial, local-navigation, local-vertical or
+orbital, and target-relative — shall be labelled and visually distinguishable so a
+value expressed in one basis cannot be read as another; a change of reference
+basis shall be an explicit, annunciated display state and never an implicit
+substitution.
+
+<a id="air-haz-009"></a>
+### AIR-HAZ-009 — Common-cause boundary declaration
+
+Each independence or redundancy claim shall be accompanied by a documented
+common-cause analysis spanning shared sources, buses, timebase, source selection,
+databases, renderer, compositor, display hardware, power, and monitoring; drawing
+an additional instrument, panel, or surface from the same validated state copy
+shall establish no independence.
+
+<a id="air-haz-010"></a>
+### AIR-HAZ-010 — Latent-failure exposure bound
+
+Every credited monitor, comparator, reversion path, and fail-safe default shall
+have a defined detection means and a bounded exposure interval — power-up test,
+continuous monitor, or periodic self-test — established from the applicable safety
+assessment before any availability or independence credit is taken for it.
+
+<a id="air-haz-011"></a>
+### AIR-HAZ-011 — Frozen and stale detection at source time
+
+Staleness and frozen-image detection shall derive from original source or capture
+time together with independent renderer-progress evidence, so that a repeated,
+replayed, cached, or last-good value cannot present as current; forwarding,
+retransmission, re-rendering, or compositor recomposition shall not reset age or
+liveness.
+
+<a id="air-haz-012"></a>
+### AIR-HAZ-012 — Polarity and ordering integrity
+
+Signed and ordered quantities — vertical speed, deviations, turn and slip/skid
+direction, unusual-attitude recovery direction, tape and ladder motion, and
+sequence — shall preserve correct polarity and monotonic ordering through the full
+orientation domain, reversion, wrap, and representation-singularity transitions; a
+sign, wrap, or reordering fault shall flag the affected quantity rather than
+present a plausible incorrect value.


### PR DESCRIPTION
## Summary — preliminary FHA/PSSA; does NOT close #27

Seeds the functional hazard assessment and preliminary system safety assessment from the merged AIR-01 baseline: **52 failure conditions** across 13 categories (attitude/PFD, air data, heading/nav, conventional instruments, SVS, HUD-SIM, vehicle frame/six-DoF, timebase, source selection, compositor, renderer, monitor, common-cause combinations), **12 hazard-derived requirements** (`AIR-HAZ-001..012`) minted into the CI-gated registry (now 71 requirements), and a PSSA with explicit independence/common-cause assumptions and assurance-allocation rationale — deliberately assigning **no DAL** pre-vehicle-selection.

Like AIR-01, closure requires a qualified independent safety review: the review record ships with all fields `PENDING`, and this PR stays non-closing.

## Acceptance criteria — evidence

| Issue #27 criterion | Status | Evidence |
|---|---|---|
| Each intended function has loss/misleading/latent/frozen and combination hazards | ✅ | `fha.md` hazard log covers every AIR-01 intended function incl. roadmap-only ones (SVS/HUD-SIM), with misleading/missing/frozen/reordered/wrong-reference/failed-reversion/compositor/monitor conditions plus 4 explicit common-cause combinations; FRAME-01's spacecraft hazards land as `FC-FRM-01..05` (wrong frame, stale epoch, clock/scale mismatch, LVLH/inertial confusion, fabricated local-vertical) |
| FHA → safety requirement → implementation/test traceability is bidirectional | ✅ | Every failure condition links its requirements; `pssa.md` carries both directions (condition→requirement→issue and requirement→conditions), against real issues only — the 2 requirements with no owning issue (`AIR-HAZ-009` common-cause declaration, `AIR-HAZ-010` latent-exposure bound pending AIR-03) sit in an explicit **unallocated** table instead of invented issue numbers |
| PSSA records common-cause and independence assumptions explicitly | ✅ | Dedicated sections: shared-runtime/compositor/clock common-cause boundaries, stated independence assumptions, plus named gaps (independent power/separation, hardware monitor, independent sensing) |
| Simulator mechanisms distinguished from airborne mitigations | ✅ | Split mitigation columns/sections throughout; every severity written as the conditional pair "worst-credible-if-credited / as-built supplemental SIM", with `AIR-HAZ-001` making unconditional classification impossible pre-vehicle-selection |
| Derived thresholds and monitor deadlines have rationale, not vendor-copy constants | ✅ | Existing simulator constants are cited as benchmark data with their derivation context; `AIR-HAZ-010`/AIR-03 own interval-setting; no new naked constants introduced |
| Qualified independent safety review recorded before closure | ✅ (open by design) | `pssa.md` review record: reviewer identity/qualification/independence/revision/disposition/rationale all `PENDING`; issue stays open |

Registry gate green post-mint: 71 unique requirements, 6-case self-test OK; structure gate OK. Docs only — no code touched.

SIM / NOT FOR FLIGHT. Refs #27 (deliberately non-closing).
