### PR TITLE
ALR-01: deterministic central flightcrew alert manager and aural contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: >
           cargo check
           -p pilotage-frames
+          -p pilotage-alerts
           -p pilotage-instrument-state
           -p pilotage-instrument-scene
           -p pilotage-instrument-glyphs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-alerts"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-authority"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/pilotage-adapter-api",
     "crates/pilotage-conformance",
     "crates/pilotage-frames",
+    "crates/pilotage-alerts",
     "crates/pilotage-instrument-scene",
     "crates/pilotage-instrument-state",
     "crates/pilotage-instrument-glyphs",
@@ -47,6 +48,7 @@ pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-frames = { path = "crates/pilotage-frames" }
+pilotage-alerts = { path = "crates/pilotage-alerts" }
 pilotage-instrument-scene = { path = "crates/pilotage-instrument-scene" }
 pilotage-instrument-state = { path = "crates/pilotage-instrument-state" }
 pilotage-instrument-glyphs = { path = "crates/pilotage-instrument-glyphs" }

--- a/crates/pilotage-alerts/Cargo.toml
+++ b/crates/pilotage-alerts/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pilotage-alerts"
+description = "Deterministic central flightcrew alert manager and aural contract (ALR-01)"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "deny"
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+let_underscore_must_use = "deny"
+let_underscore_future = "deny"
+await_holding_lock = "deny"
+disallowed_types = "deny"
+disallowed_macros = "deny"
+
+[dependencies]
+thiserror = { version = "2.0.18", default-features = false }
+
+# Standalone workspace so the crate builds via `--manifest-path` before the
+# root workspace registers it as a member. Central registration removes this
+# table (and the generated Cargo.lock) and switches to `[lints] workspace`.
+[workspace]

--- a/crates/pilotage-alerts/Cargo.toml
+++ b/crates/pilotage-alerts/Cargo.toml
@@ -25,4 +25,3 @@ thiserror = { version = "2.0.18", default-features = false }
 # Standalone workspace so the crate builds via `--manifest-path` before the
 # root workspace registers it as a member. Central registration removes this
 # table (and the generated Cargo.lock) and switches to `[lints] workspace`.
-[workspace]

--- a/crates/pilotage-alerts/src/class.rs
+++ b/crates/pilotage-alerts/src/class.rs
@@ -1,0 +1,97 @@
+//! Static alert taxonomy: severity classes, their latching and declutter
+//! behavior, the aural token each class owns, and the acknowledgement
+//! lifecycle a managed alert occupies.
+//!
+//! Everything here is fixed content, the part AC 25.1322-1 separates from
+//! live state: a class's severity, whether it latches, and which tone it
+//! carries do not change at runtime. The live transition state lives in the
+//! manager.
+
+/// Severity class of an alert, ordered least to most urgent so [`Ord`]
+/// yields the priority ranking directly ([`AlertClass::Warning`] is
+/// greatest).
+///
+/// Warning outranks caution outranks advisory; status and maintenance sit
+/// below and carry no aural.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AlertClass {
+    /// Maintenance information for ground crews; silent, and decluttered
+    /// under unusual attitude.
+    Maintenance,
+    /// System status with no required flightcrew action; silent, and
+    /// decluttered under unusual attitude.
+    Status,
+    /// Crew awareness, lowest aural tier (single chime).
+    Advisory,
+    /// Immediate crew awareness and likely subsequent action (triple
+    /// chime).
+    Caution,
+    /// Immediate crew action; highest priority, continuous aural.
+    Warning,
+}
+
+impl AlertClass {
+    /// The static aural token this class owns. Status and maintenance are
+    /// silent.
+    pub const fn aural_token(self) -> AuralToken {
+        match self {
+            Self::Warning => AuralToken::ContinuousTone,
+            Self::Caution => AuralToken::TripleChime,
+            Self::Advisory => AuralToken::SingleChime,
+            Self::Status | Self::Maintenance => AuralToken::Silent,
+        }
+    }
+
+    /// Whether an alert of this class persists after its condition clears,
+    /// until the crew acknowledges it. Warnings and cautions latch;
+    /// advisories, status, and maintenance self-clear.
+    pub const fn latches(self) -> bool {
+        matches!(self, Self::Warning | Self::Caution)
+    }
+
+    /// Whether unusual-attitude declutter may hide this class. Warnings and
+    /// cautions are always retained; everything below them declutters.
+    pub const fn declutters_under_unusual(self) -> bool {
+        matches!(self, Self::Advisory | Self::Status | Self::Maintenance)
+    }
+}
+
+/// One-at-a-time aural command. The manager emits at most one token per
+/// step; the audio backend (out of scope here) plays it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AuralToken {
+    /// No tone this step.
+    #[default]
+    Silent,
+    /// One chime: advisory onset.
+    SingleChime,
+    /// Three chimes: caution onset.
+    TripleChime,
+    /// Continuous tone that sounds every step until acknowledged: warning.
+    ContinuousTone,
+}
+
+impl AuralToken {
+    /// Whether the token sounds continuously — re-emitted every step while
+    /// the alert stays active and unacknowledged — rather than as a
+    /// one-shot at onset.
+    pub const fn is_continuous(self) -> bool {
+        matches!(self, Self::ContinuousTone)
+    }
+}
+
+/// Where a managed alert sits in the acknowledgement lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertState {
+    /// Condition present, not yet acknowledged: full visual and aural.
+    Active,
+    /// Condition present, crew acknowledged: visual persists, aural
+    /// silenced.
+    Acknowledged,
+    /// Condition cleared but latched unacknowledged: visual persists,
+    /// silent.
+    LatchedCleared,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-alerts/src/class/tests.rs
+++ b/crates/pilotage-alerts/src/class/tests.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+
+#[test]
+fn priority_order_is_warning_highest() {
+    assert!(AlertClass::Warning > AlertClass::Caution);
+    assert!(AlertClass::Caution > AlertClass::Advisory);
+    assert!(AlertClass::Advisory > AlertClass::Status);
+    assert!(AlertClass::Status > AlertClass::Maintenance);
+}
+
+#[test]
+fn aural_tokens_match_classes() {
+    assert_eq!(
+        AlertClass::Warning.aural_token(),
+        AuralToken::ContinuousTone
+    );
+    assert_eq!(AlertClass::Caution.aural_token(), AuralToken::TripleChime);
+    assert_eq!(AlertClass::Advisory.aural_token(), AuralToken::SingleChime);
+    assert_eq!(AlertClass::Status.aural_token(), AuralToken::Silent);
+    assert_eq!(AlertClass::Maintenance.aural_token(), AuralToken::Silent);
+}
+
+#[test]
+fn only_warning_is_continuous() {
+    assert!(AuralToken::ContinuousTone.is_continuous());
+    assert!(!AuralToken::TripleChime.is_continuous());
+    assert!(!AuralToken::SingleChime.is_continuous());
+    assert!(!AuralToken::Silent.is_continuous());
+}
+
+#[test]
+fn warning_and_caution_latch() {
+    assert!(AlertClass::Warning.latches());
+    assert!(AlertClass::Caution.latches());
+    assert!(!AlertClass::Advisory.latches());
+    assert!(!AlertClass::Status.latches());
+    assert!(!AlertClass::Maintenance.latches());
+}
+
+#[test]
+fn declutter_retains_warning_and_caution() {
+    assert!(!AlertClass::Warning.declutters_under_unusual());
+    assert!(!AlertClass::Caution.declutters_under_unusual());
+    assert!(AlertClass::Advisory.declutters_under_unusual());
+    assert!(AlertClass::Status.declutters_under_unusual());
+    assert!(AlertClass::Maintenance.declutters_under_unusual());
+}

--- a/crates/pilotage-alerts/src/condition.rs
+++ b/crates/pilotage-alerts/src/condition.rs
@@ -1,0 +1,358 @@
+//! The typed alert-condition vocabulary and the stable identities alerts
+//! carry.
+//!
+//! Producers hand the manager typed conditions, never raw telemetry. Each
+//! future monitor owns a fault sub-vocabulary here: altitude reference,
+//! heading/navigation reference, turn/slip, source miscompare, display and
+//! renderer health, frame identity, and non-flight system notes. Every
+//! condition maps deterministically to a stable [`AlertId`] and a fixed
+//! [`AlertClass`], so a fault's identity and severity are properties of the
+//! fault, not of the frame or the airframe.
+//!
+//! Identities pack a one-byte family selector and a one-byte fault code:
+//! `id = (family << 8) | code`. [`class_of`] reverses an id back to its
+//! class, which the profile uses to reject inhibiting an uninhibitable
+//! alert.
+
+use crate::class::AlertClass;
+
+/// Stable, machine-readable alert identity. Ordering is defined so ties in
+/// severity break by ascending id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AlertId(pub u16);
+
+const FAMILY_ALTITUDE: u8 = 0x01;
+const FAMILY_NAV: u8 = 0x02;
+const FAMILY_TURN_SLIP: u8 = 0x03;
+const FAMILY_MISCOMPARE: u8 = 0x04;
+const FAMILY_DISPLAY: u8 = 0x05;
+const FAMILY_FRAME: u8 = 0x06;
+const FAMILY_SYSTEM: u8 = 0x07;
+
+const fn id(family: u8, code: u8) -> AlertId {
+    AlertId(((family as u16) << 8) | code as u16)
+}
+
+/// Altitude reference/datum faults (from the altitude monitor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AltFault {
+    /// Barometric reference or datum lost; the altitude datum is untrusted.
+    ReferenceLost,
+    /// Two altitude datums disagree beyond tolerance.
+    DatumMiscompare,
+    /// No usable altitude source.
+    Unavailable,
+}
+
+impl AltFault {
+    const fn code(self) -> u8 {
+        match self {
+            Self::ReferenceLost => 1,
+            Self::DatumMiscompare => 2,
+            Self::Unavailable => 3,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::ReferenceLost),
+            2 => Some(Self::DatumMiscompare),
+            3 => Some(Self::Unavailable),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        AlertClass::Caution
+    }
+}
+
+/// Heading and navigation reference faults (from the navigation monitor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavFault {
+    /// Heading reference lost; the directional datum is untrusted.
+    HeadingReferenceLost,
+    /// The selected course source is invalid or unidentifiable.
+    CourseSourceInvalid,
+    /// No usable navigation source.
+    Unavailable,
+}
+
+impl NavFault {
+    const fn code(self) -> u8 {
+        match self {
+            Self::HeadingReferenceLost => 1,
+            Self::CourseSourceInvalid => 2,
+            Self::Unavailable => 3,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::HeadingReferenceLost),
+            2 => Some(Self::CourseSourceInvalid),
+            3 => Some(Self::Unavailable),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        match self {
+            Self::HeadingReferenceLost | Self::CourseSourceInvalid => AlertClass::Caution,
+            Self::Unavailable => AlertClass::Advisory,
+        }
+    }
+}
+
+/// Turn and slip indication faults (from the turn/slip monitor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynFault {
+    /// Turn-rate estimate invalid.
+    TurnRateInvalid,
+    /// Slip/skid estimate invalid.
+    SlipInvalid,
+    /// No usable turn/slip source.
+    Unavailable,
+}
+
+impl DynFault {
+    const fn code(self) -> u8 {
+        match self {
+            Self::TurnRateInvalid => 1,
+            Self::SlipInvalid => 2,
+            Self::Unavailable => 3,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::TurnRateInvalid),
+            2 => Some(Self::SlipInvalid),
+            3 => Some(Self::Unavailable),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        AlertClass::Advisory
+    }
+}
+
+/// Source-miscompare faults (from the miscompare monitor). The miscompare
+/// algorithm itself is out of scope; this is only its declared result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MiscompareFault {
+    /// Attitude sources disagree — loss of a trustworthy attitude.
+    Attitude,
+    /// Airspeed sources disagree.
+    Airspeed,
+    /// Altitude sources disagree.
+    Altitude,
+    /// Heading sources disagree.
+    Heading,
+}
+
+impl MiscompareFault {
+    const fn code(self) -> u8 {
+        match self {
+            Self::Attitude => 1,
+            Self::Airspeed => 2,
+            Self::Altitude => 3,
+            Self::Heading => 4,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Attitude),
+            2 => Some(Self::Airspeed),
+            3 => Some(Self::Altitude),
+            4 => Some(Self::Heading),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        match self {
+            Self::Attitude => AlertClass::Warning,
+            Self::Airspeed | Self::Altitude | Self::Heading => AlertClass::Caution,
+        }
+    }
+}
+
+/// Display and renderer health faults (DISP-01-style reason codes, from the
+/// renderer-health monitor, AIR-IN-013).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplayFault {
+    /// The renderer stopped making progress.
+    RendererStalled,
+    /// Frame generation stopped advancing.
+    FrameGenerationLost,
+    /// The draw-command buffer failed its integrity check.
+    CommandBufferCorrupt,
+    /// The rendering backend was lost.
+    BackendLost,
+    /// A retained last-good image is suspected on the output path.
+    RetainedImage,
+}
+
+impl DisplayFault {
+    const fn code(self) -> u8 {
+        match self {
+            Self::RendererStalled => 1,
+            Self::FrameGenerationLost => 2,
+            Self::CommandBufferCorrupt => 3,
+            Self::BackendLost => 4,
+            Self::RetainedImage => 5,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::RendererStalled),
+            2 => Some(Self::FrameGenerationLost),
+            3 => Some(Self::CommandBufferCorrupt),
+            4 => Some(Self::BackendLost),
+            5 => Some(Self::RetainedImage),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        match self {
+            Self::RendererStalled
+            | Self::FrameGenerationLost
+            | Self::CommandBufferCorrupt
+            | Self::RetainedImage => AlertClass::Warning,
+            Self::BackendLost => AlertClass::Caution,
+        }
+    }
+}
+
+/// Non-flight system notes: status and maintenance information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemNote {
+    /// A navigation or terrain database is out of date.
+    DatabaseStale,
+    /// Maintenance action is required (ground-crew information).
+    MaintenanceRequired,
+    /// A configuration mismatch was detected.
+    ConfigMismatch,
+}
+
+impl SystemNote {
+    const fn code(self) -> u8 {
+        match self {
+            Self::DatabaseStale => 1,
+            Self::MaintenanceRequired => 2,
+            Self::ConfigMismatch => 3,
+        }
+    }
+
+    const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::DatabaseStale),
+            2 => Some(Self::MaintenanceRequired),
+            3 => Some(Self::ConfigMismatch),
+            _ => None,
+        }
+    }
+
+    const fn class(self) -> AlertClass {
+        match self {
+            Self::DatabaseStale | Self::ConfigMismatch => AlertClass::Status,
+            Self::MaintenanceRequired => AlertClass::Maintenance,
+        }
+    }
+}
+
+/// A typed fault condition a producer asserts or clears. The manager reads
+/// only its stable identity and fixed class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertCondition {
+    /// Altitude reference/datum fault.
+    Altitude(AltFault),
+    /// Heading/navigation reference fault.
+    Heading(NavFault),
+    /// Turn/slip indication fault.
+    TurnSlip(DynFault),
+    /// Declared source miscompare.
+    Miscompare(MiscompareFault),
+    /// Display/renderer health fault.
+    Display(DisplayFault),
+    /// Frame-identity mismatch. Frame types are owned elsewhere
+    /// (FRAME-01); this seam carries only an opaque fault code so the
+    /// manager can raise the alert before those types land.
+    FrameMismatch {
+        /// Opaque frame-mismatch reason code.
+        code: u8,
+    },
+    /// Non-flight status or maintenance note.
+    System(SystemNote),
+}
+
+impl AlertCondition {
+    /// The stable identity this condition raises.
+    pub const fn id(self) -> AlertId {
+        match self {
+            Self::Altitude(f) => id(FAMILY_ALTITUDE, f.code()),
+            Self::Heading(f) => id(FAMILY_NAV, f.code()),
+            Self::TurnSlip(f) => id(FAMILY_TURN_SLIP, f.code()),
+            Self::Miscompare(f) => id(FAMILY_MISCOMPARE, f.code()),
+            Self::Display(f) => id(FAMILY_DISPLAY, f.code()),
+            Self::FrameMismatch { code } => id(FAMILY_FRAME, code),
+            Self::System(f) => id(FAMILY_SYSTEM, f.code()),
+        }
+    }
+
+    /// The fixed severity class this condition carries.
+    pub const fn class(self) -> AlertClass {
+        match self {
+            Self::Altitude(f) => f.class(),
+            Self::Heading(f) => f.class(),
+            Self::TurnSlip(f) => f.class(),
+            Self::Miscompare(f) => f.class(),
+            Self::Display(f) => f.class(),
+            Self::FrameMismatch { .. } => AlertClass::Caution,
+            Self::System(f) => f.class(),
+        }
+    }
+}
+
+/// The class an identity carries, or `None` if this build does not know the
+/// identity. Every frame-mismatch code resolves to caution.
+pub const fn class_of(id: AlertId) -> Option<AlertClass> {
+    let family = (id.0 >> 8) as u8;
+    let code = (id.0 & 0x00ff) as u8;
+    match family {
+        FAMILY_ALTITUDE => match AltFault::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        FAMILY_NAV => match NavFault::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        FAMILY_TURN_SLIP => match DynFault::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        FAMILY_MISCOMPARE => match MiscompareFault::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        FAMILY_DISPLAY => match DisplayFault::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        FAMILY_FRAME => Some(AlertClass::Caution),
+        FAMILY_SYSTEM => match SystemNote::from_code(code) {
+            Some(f) => Some(f.class()),
+            None => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-alerts/src/condition/tests.rs
+++ b/crates/pilotage-alerts/src/condition/tests.rs
@@ -1,0 +1,73 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+
+/// A representative condition for every known identity.
+const CATALOG: &[AlertCondition] = &[
+    AlertCondition::Altitude(AltFault::ReferenceLost),
+    AlertCondition::Altitude(AltFault::DatumMiscompare),
+    AlertCondition::Altitude(AltFault::Unavailable),
+    AlertCondition::Heading(NavFault::HeadingReferenceLost),
+    AlertCondition::Heading(NavFault::CourseSourceInvalid),
+    AlertCondition::Heading(NavFault::Unavailable),
+    AlertCondition::TurnSlip(DynFault::TurnRateInvalid),
+    AlertCondition::TurnSlip(DynFault::SlipInvalid),
+    AlertCondition::TurnSlip(DynFault::Unavailable),
+    AlertCondition::Miscompare(MiscompareFault::Attitude),
+    AlertCondition::Miscompare(MiscompareFault::Airspeed),
+    AlertCondition::Miscompare(MiscompareFault::Altitude),
+    AlertCondition::Miscompare(MiscompareFault::Heading),
+    AlertCondition::Display(DisplayFault::RendererStalled),
+    AlertCondition::Display(DisplayFault::FrameGenerationLost),
+    AlertCondition::Display(DisplayFault::CommandBufferCorrupt),
+    AlertCondition::Display(DisplayFault::BackendLost),
+    AlertCondition::Display(DisplayFault::RetainedImage),
+    AlertCondition::FrameMismatch { code: 7 },
+    AlertCondition::System(SystemNote::DatabaseStale),
+    AlertCondition::System(SystemNote::MaintenanceRequired),
+    AlertCondition::System(SystemNote::ConfigMismatch),
+];
+
+#[test]
+fn identities_are_unique() {
+    for (i, a) in CATALOG.iter().enumerate() {
+        for b in &CATALOG[i + 1..] {
+            assert_ne!(a.id(), b.id(), "collision between {a:?} and {b:?}");
+        }
+    }
+}
+
+#[test]
+fn class_of_agrees_with_condition_class() {
+    for cond in CATALOG {
+        assert_eq!(
+            class_of(cond.id()),
+            Some(cond.class()),
+            "class mismatch for {cond:?}"
+        );
+    }
+}
+
+#[test]
+fn every_frame_code_resolves_to_caution() {
+    for code in 0..=u8::MAX {
+        let cond = AlertCondition::FrameMismatch { code };
+        assert_eq!(cond.class(), AlertClass::Caution);
+        assert_eq!(class_of(cond.id()), Some(AlertClass::Caution));
+    }
+}
+
+#[test]
+fn unknown_identities_resolve_to_none() {
+    // Unused code inside a known family, and an unknown family.
+    assert_eq!(class_of(AlertId(0x0109)), None);
+    assert_eq!(class_of(AlertId(0x0900)), None);
+}
+
+#[test]
+fn attitude_miscompare_is_a_warning() {
+    assert_eq!(
+        AlertCondition::Miscompare(MiscompareFault::Attitude).class(),
+        AlertClass::Warning
+    );
+}

--- a/crates/pilotage-alerts/src/event.rs
+++ b/crates/pilotage-alerts/src/event.rs
@@ -1,0 +1,65 @@
+//! Inputs to one manager step: crew and condition events, and the flight
+//! context that scopes inhibition and declutter.
+
+use crate::condition::{AlertCondition, AlertId};
+
+/// A single input to [`AlertManager::step`](crate::AlertManager::step).
+///
+/// Assert and clear carry a typed condition; acknowledgement carries an
+/// identity or acknowledges everything asserted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertEvent {
+    /// The condition is active as of this step.
+    Assert(AlertCondition),
+    /// The condition is no longer active.
+    Clear(AlertCondition),
+    /// The crew acknowledged one alert by identity: silence its aural, keep
+    /// its visual per class.
+    Acknowledge(AlertId),
+    /// The crew acknowledged every currently asserted alert (master
+    /// caution/warning press).
+    AcknowledgeAll,
+}
+
+/// Flight phase, the scope an [`InhibitRule`](crate::InhibitRule) keys on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FlightPhase {
+    /// On the ground, not taking off.
+    #[default]
+    Ground,
+    /// Takeoff roll and initial climb (the classic inhibit window).
+    Takeoff,
+    /// Climb.
+    Climb,
+    /// Cruise.
+    Cruise,
+    /// Approach.
+    Approach,
+    /// Landing rollout.
+    Landing,
+}
+
+/// Caller-supplied context for one step. It scopes inhibition and
+/// declutter and reports the independent health of the alerting path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlertContext {
+    /// Current flight phase; an inhibit rule fires only in its phase.
+    pub phase: FlightPhase,
+    /// Unusual-attitude declutter is active: hide advisory, status, and
+    /// maintenance; retain warnings and cautions.
+    pub declutter: bool,
+    /// The independent display/alerting-path health input (AIR-IN-013):
+    /// `false` marks the output untrusted so the consumer also honors
+    /// primary-data flags. It never suppresses the alert list.
+    pub alerting_path_healthy: bool,
+}
+
+impl Default for AlertContext {
+    fn default() -> Self {
+        Self {
+            phase: FlightPhase::Ground,
+            declutter: false,
+            alerting_path_healthy: true,
+        }
+    }
+}

--- a/crates/pilotage-alerts/src/lib.rs
+++ b/crates/pilotage-alerts/src/lib.rs
@@ -1,0 +1,47 @@
+//! Deterministic central flightcrew alert manager and aural contract
+//! (ALR-01).
+//!
+//! Alert meaning belongs in one place, not scattered across widget colors
+//! and flags. This crate is that place: a pure, bounded, `no_std`,
+//! allocation-free, I/O-free state machine that turns typed fault
+//! conditions into a priority-ordered visual alert list and a single aural
+//! command. It generates alerts; it does not render them. Panels consume
+//! [`AlertOutput`] and decide layout, never severity or inhibition.
+//!
+//! The core guarantee is determinism: [`AlertManager::step`] reads no
+//! interior clock and holds no hidden state, so the same
+//! `(policy, events, context, time)` applied to the same manager state
+//! produces byte-identical output and ordering. Time and flight/mode
+//! context are caller inputs.
+//!
+//! Priority follows AC 25.1322-1 concepts: warning outranks caution
+//! outranks advisory, with status and maintenance below and silent; ties
+//! break by ascending stable [`AlertId`]. Warnings and cautions latch until
+//! acknowledged or cleared; lower classes self-clear. Acknowledgement
+//! silences the aural but never clears an active condition. Capacity is
+//! bounded and overflow is fail-visible: a full table drops the
+//! lowest-priority alert, counted with a wrapping counter, and never
+//! silently displaces a higher-priority one. Completion demonstrates no
+//! regulatory compliance.
+
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+mod class;
+mod condition;
+mod event;
+mod manager;
+mod output;
+mod profile;
+
+pub use class::{AlertClass, AlertState, AuralToken};
+pub use condition::{
+    AlertCondition, AlertId, AltFault, DisplayFault, DynFault, MiscompareFault, NavFault,
+    SystemNote, class_of,
+};
+pub use event::{AlertContext, AlertEvent, FlightPhase};
+pub use manager::AlertManager;
+pub use output::{ActiveAlert, AlertOutput, MAX_ACTIVE_ALERTS, ManagerHealth};
+pub use profile::{AlertProfile, InhibitRule, MAX_INHIBIT_RULES, ProfileError};

--- a/crates/pilotage-alerts/src/manager.rs
+++ b/crates/pilotage-alerts/src/manager.rs
@@ -1,0 +1,331 @@
+//! The deterministic alert state machine.
+//!
+//! [`AlertManager::step`] is pure over its inputs and the manager's stored
+//! state: it reads no clock, allocates nothing, and never panics. One step
+//! applies the events, re-arms escalations whose deadline has passed,
+//! arbitrates the single aural command, and produces a sorted
+//! [`AlertOutput`]. Each managed alert is one slot in a fixed array keyed
+//! by identity, so duplicates collapse and ordering is total.
+
+use crate::class::{AlertClass, AlertState, AuralToken};
+use crate::condition::{AlertCondition, AlertId};
+use crate::event::{AlertContext, AlertEvent};
+use crate::output::{ActiveAlert, AlertOutput, MAX_ACTIVE_ALERTS, ManagerHealth};
+use crate::profile::AlertProfile;
+
+/// One tracked alert. Present-but-unacknowledged is [`AlertState::Active`];
+/// present-and-acknowledged is [`AlertState::Acknowledged`]; a slot that is
+/// not present exists only for a latched, unacknowledged, cleared alert.
+#[derive(Debug, Clone, Copy)]
+struct Alert {
+    id: AlertId,
+    class: AlertClass,
+    present: bool,
+    acknowledged: bool,
+    aural_armed: bool,
+    last_aural_ms: u64,
+    generation: u32,
+}
+
+impl Alert {
+    fn new(id: AlertId, class: AlertClass, now_ms: u64, generation: u32) -> Self {
+        Self {
+            id,
+            class,
+            present: true,
+            acknowledged: false,
+            aural_armed: true,
+            last_aural_ms: now_ms,
+            generation,
+        }
+    }
+}
+
+/// The central alert manager. Bounded, deterministic, and clock-free.
+#[derive(Debug, Clone)]
+pub struct AlertManager {
+    slots: [Option<Alert>; MAX_ACTIVE_ALERTS],
+    generation: u32,
+    overflow_dropped: u32,
+}
+
+impl Default for AlertManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AlertManager {
+    /// A manager with no active alerts.
+    pub const fn new() -> Self {
+        Self {
+            slots: [None; MAX_ACTIVE_ALERTS],
+            generation: 0,
+            overflow_dropped: 0,
+        }
+    }
+
+    /// Advances the machine by one step and returns the resulting output.
+    ///
+    /// The same `(profile, events, ctx, now_ms)` applied to the same
+    /// manager state produces byte-identical output and ordering; nothing
+    /// here reads an interior clock.
+    pub fn step(
+        &mut self,
+        profile: &AlertProfile,
+        events: &[AlertEvent],
+        ctx: AlertContext,
+        now_ms: u64,
+    ) -> AlertOutput {
+        let mut overflowed = false;
+        for &event in events {
+            overflowed |= self.apply_event(event, now_ms);
+        }
+        self.apply_escalation(profile, now_ms);
+        let aural = self.arbitrate(profile, ctx, now_ms);
+        self.build_output(profile, ctx, aural, overflowed)
+    }
+
+    fn apply_event(&mut self, event: AlertEvent, now_ms: u64) -> bool {
+        match event {
+            AlertEvent::Assert(cond) => self.assert(cond, now_ms),
+            AlertEvent::Clear(cond) => {
+                self.clear(cond.id());
+                false
+            }
+            AlertEvent::Acknowledge(id) => {
+                self.acknowledge(id);
+                false
+            }
+            AlertEvent::AcknowledgeAll => {
+                self.acknowledge_all();
+                false
+            }
+        }
+    }
+
+    fn assert(&mut self, cond: AlertCondition, now_ms: u64) -> bool {
+        let id = cond.id();
+        if let Some(i) = self.index_of(id) {
+            if self.slots[i].is_some_and(|a| !a.present) {
+                let generation = self.next_generation();
+                if let Some(a) = self.slots[i].as_mut() {
+                    a.present = true;
+                    a.acknowledged = false;
+                    a.aural_armed = true;
+                    a.last_aural_ms = now_ms;
+                    a.generation = generation;
+                }
+            }
+            return false;
+        }
+        self.insert(id, cond.class(), now_ms)
+    }
+
+    /// Inserts a new alert. Returns `true` when capacity forced a drop: a
+    /// higher-priority newcomer evicts the lowest-priority slot, otherwise
+    /// the newcomer itself is dropped. Either way the wrapping drop counter
+    /// advances and the drop is never silent.
+    fn insert(&mut self, id: AlertId, class: AlertClass, now_ms: u64) -> bool {
+        if let Some(i) = self.free_slot() {
+            let generation = self.next_generation();
+            self.slots[i] = Some(Alert::new(id, class, now_ms, generation));
+            return false;
+        }
+        if let Some(i) = self.lowest_priority_index()
+            && let Some(loser) = self.slots[i]
+            && ranks_above(class, id, loser.class, loser.id)
+        {
+            let generation = self.next_generation();
+            self.slots[i] = Some(Alert::new(id, class, now_ms, generation));
+        }
+        self.overflow_dropped = self.overflow_dropped.wrapping_add(1);
+        true
+    }
+
+    fn clear(&mut self, id: AlertId) {
+        let Some(i) = self.index_of(id) else { return };
+        let Some(alert) = self.slots[i] else { return };
+        if alert.class.latches() && !alert.acknowledged {
+            if let Some(a) = self.slots[i].as_mut() {
+                a.present = false;
+                a.aural_armed = false;
+            }
+        } else {
+            self.slots[i] = None;
+        }
+    }
+
+    fn acknowledge(&mut self, id: AlertId) {
+        if let Some(i) = self.index_of(id) {
+            self.ack_index(i);
+        }
+    }
+
+    fn acknowledge_all(&mut self) {
+        let mut i = 0;
+        while i < MAX_ACTIVE_ALERTS {
+            if self.slots[i].is_some() {
+                self.ack_index(i);
+            }
+            i += 1;
+        }
+    }
+
+    fn ack_index(&mut self, i: usize) {
+        let Some(alert) = self.slots[i] else { return };
+        if alert.class.latches() && !alert.present {
+            self.slots[i] = None;
+        } else if let Some(a) = self.slots[i].as_mut() {
+            a.acknowledged = true;
+            a.aural_armed = false;
+        }
+    }
+
+    /// Re-arms a one-shot aural whose escalation deadline has elapsed while
+    /// the alert stays active and unacknowledged. Continuous and silent
+    /// classes never re-arm this way.
+    fn apply_escalation(&mut self, profile: &AlertProfile, now_ms: u64) {
+        for slot in self.slots.iter_mut() {
+            let Some(a) = slot else { continue };
+            if !a.present || a.acknowledged || a.aural_armed {
+                continue;
+            }
+            let token = a.class.aural_token();
+            if token.is_continuous() || matches!(token, AuralToken::Silent) {
+                continue;
+            }
+            if now_ms.saturating_sub(a.last_aural_ms) >= profile.escalation_ms(a.class) {
+                a.aural_armed = true;
+            }
+        }
+    }
+
+    /// Picks the single highest-priority alert that wants to sound and
+    /// returns its token, consuming its one-shot arming. Lower-priority
+    /// pending one-shots stay armed and resume in a later step.
+    fn arbitrate(&mut self, profile: &AlertProfile, ctx: AlertContext, now_ms: u64) -> AuralToken {
+        let best = self
+            .slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &slot)| slot.map(|a| (i, a)))
+            .filter(|(_, a)| sounds(a, profile, ctx))
+            .fold(
+                None,
+                |best: Option<(usize, AlertClass, AlertId)>, (i, a)| match best {
+                    Some((_, bc, bid)) if !ranks_above(a.class, a.id, bc, bid) => best,
+                    _ => Some((i, a.class, a.id)),
+                },
+            );
+        let Some((i, class, _)) = best else {
+            return AuralToken::Silent;
+        };
+        if let Some(a) = self.slots[i].as_mut() {
+            a.aural_armed = false;
+            a.last_aural_ms = now_ms;
+        }
+        class.aural_token()
+    }
+
+    fn build_output(
+        &self,
+        profile: &AlertProfile,
+        ctx: AlertContext,
+        aural: AuralToken,
+        overflowed: bool,
+    ) -> AlertOutput {
+        let mut out = AlertOutput::empty(self.generation, self.overflow_dropped);
+        out.set_aural(aural);
+        out.set_overflow(overflowed);
+        out.set_health(if ctx.alerting_path_healthy {
+            ManagerHealth::Nominal
+        } else {
+            ManagerHealth::Faulted
+        });
+        for a in self.slots.iter().flatten() {
+            out.push(view(a, profile, ctx));
+        }
+        out.sort_active();
+        out
+    }
+
+    fn index_of(&self, id: AlertId) -> Option<usize> {
+        self.slots
+            .iter()
+            .position(|&slot| slot.is_some_and(|a| a.id == id))
+    }
+
+    fn free_slot(&self) -> Option<usize> {
+        self.slots.iter().position(Option::is_none)
+    }
+
+    fn lowest_priority_index(&self) -> Option<usize> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &slot)| slot.map(|a| (i, a)))
+            .fold(
+                None,
+                |worst: Option<(usize, AlertClass, AlertId)>, (i, a)| match worst {
+                    Some((_, wc, wid)) if !ranks_above(wc, wid, a.class, a.id) => worst,
+                    _ => Some((i, a.class, a.id)),
+                },
+            )
+            .map(|(i, _, _)| i)
+    }
+
+    fn next_generation(&mut self) -> u32 {
+        self.generation = self.generation.wrapping_add(1);
+        self.generation
+    }
+}
+
+/// Whether `(a_class, a_id)` outranks `(b_class, b_id)`: higher class wins;
+/// within a class, the lower identity wins.
+fn ranks_above(a_class: AlertClass, a_id: AlertId, b_class: AlertClass, b_id: AlertId) -> bool {
+    a_class > b_class || (a_class == b_class && a_id < b_id)
+}
+
+/// Whether an alert would sound this step: present, unacknowledged, not
+/// inhibited, not decluttered, and either continuous or armed.
+fn sounds(a: &Alert, profile: &AlertProfile, ctx: AlertContext) -> bool {
+    if !a.present || a.acknowledged {
+        return false;
+    }
+    let token = a.class.aural_token();
+    if matches!(token, AuralToken::Silent) {
+        return false;
+    }
+    if a.class != AlertClass::Warning && profile.is_inhibited(a.id, ctx.phase) {
+        return false;
+    }
+    if ctx.declutter && a.class.declutters_under_unusual() {
+        return false;
+    }
+    token.is_continuous() || a.aural_armed
+}
+
+fn view(a: &Alert, profile: &AlertProfile, ctx: AlertContext) -> ActiveAlert {
+    let inhibited = a.class != AlertClass::Warning && profile.is_inhibited(a.id, ctx.phase);
+    let decluttered = ctx.declutter && a.class.declutters_under_unusual();
+    let state = if a.present && !a.acknowledged {
+        AlertState::Active
+    } else if a.present {
+        AlertState::Acknowledged
+    } else {
+        AlertState::LatchedCleared
+    };
+    ActiveAlert {
+        id: a.id,
+        class: a.class,
+        state,
+        aural: a.class.aural_token(),
+        inhibited,
+        decluttered,
+        generation: a.generation,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-alerts/src/manager/tests.rs
+++ b/crates/pilotage-alerts/src/manager/tests.rs
@@ -1,0 +1,432 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::condition::{AltFault, DisplayFault, DynFault, MiscompareFault, SystemNote};
+use crate::event::FlightPhase;
+use crate::profile::InhibitRule;
+
+fn warn() -> AlertCondition {
+    AlertCondition::Display(DisplayFault::RendererStalled)
+}
+
+fn attitude_warn() -> AlertCondition {
+    AlertCondition::Miscompare(MiscompareFault::Attitude)
+}
+
+fn caution() -> AlertCondition {
+    AlertCondition::Altitude(AltFault::ReferenceLost)
+}
+
+fn caution2() -> AlertCondition {
+    AlertCondition::Miscompare(MiscompareFault::Airspeed)
+}
+
+fn advisory() -> AlertCondition {
+    AlertCondition::TurnSlip(DynFault::TurnRateInvalid)
+}
+
+fn status() -> AlertCondition {
+    AlertCondition::System(SystemNote::DatabaseStale)
+}
+
+fn maintenance() -> AlertCondition {
+    AlertCondition::System(SystemNote::MaintenanceRequired)
+}
+
+/// Deadlines long enough that escalation never fires inside a test that
+/// does not want it.
+fn perm_profile() -> AlertProfile {
+    AlertProfile::new(1_000_000, 1_000_000, 1_000_000, &[]).expect("valid profile")
+}
+
+fn ctx() -> AlertContext {
+    AlertContext::default()
+}
+
+fn find(out: &AlertOutput, id: AlertId) -> Option<&ActiveAlert> {
+    out.active().iter().find(|a| a.id == id)
+}
+
+fn state_of(out: &AlertOutput, id: AlertId) -> Option<AlertState> {
+    find(out, id).map(|a| a.state)
+}
+
+#[test]
+fn determinism_is_byte_identical() {
+    let profile = perm_profile();
+    let script: &[(&[AlertEvent], u64)] = &[
+        (
+            &[AlertEvent::Assert(caution()), AlertEvent::Assert(warn())],
+            0,
+        ),
+        (&[AlertEvent::Acknowledge(warn().id())], 50),
+        (&[AlertEvent::Clear(caution())], 100),
+        (&[AlertEvent::Assert(advisory())], 150),
+    ];
+    let mut a = AlertManager::new();
+    let mut b = AlertManager::new();
+    for &(events, now) in script {
+        let out_a = a.step(&profile, events, ctx(), now);
+        let out_b = b.step(&profile, events, ctx(), now);
+        assert_eq!(out_a, out_b);
+    }
+}
+
+#[test]
+fn simultaneous_severities_order_and_aural() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let out = m.step(
+        &profile,
+        &[
+            AlertEvent::Assert(advisory()),
+            AlertEvent::Assert(warn()),
+            AlertEvent::Assert(status()),
+            AlertEvent::Assert(caution()),
+            AlertEvent::Assert(maintenance()),
+        ],
+        ctx(),
+        0,
+    );
+    let order = [
+        out.active()[0].class,
+        out.active()[1].class,
+        out.active()[2].class,
+        out.active()[3].class,
+        out.active()[4].class,
+    ];
+    assert_eq!(
+        order,
+        [
+            AlertClass::Warning,
+            AlertClass::Caution,
+            AlertClass::Advisory,
+            AlertClass::Status,
+            AlertClass::Maintenance,
+        ]
+    );
+    assert_eq!(out.aural(), AuralToken::ContinuousTone);
+}
+
+#[test]
+fn tie_break_by_ascending_id() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    // Two cautions; caution() is 0x0101, caution2() is 0x0402.
+    let out = m.step(
+        &profile,
+        &[
+            AlertEvent::Assert(caution2()),
+            AlertEvent::Assert(caution()),
+        ],
+        ctx(),
+        0,
+    );
+    assert_eq!(out.active()[0].id, caution().id());
+    assert_eq!(out.active()[1].id, caution2().id());
+}
+
+#[test]
+fn duplicate_assert_collapses() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let out = m.step(
+        &profile,
+        &[
+            AlertEvent::Assert(caution()),
+            AlertEvent::Assert(caution()),
+            AlertEvent::Assert(caution()),
+        ],
+        ctx(),
+        0,
+    );
+    assert_eq!(out.active().len(), 1);
+}
+
+#[test]
+fn acknowledge_keeps_condition_and_silences() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.step(&profile, &[AlertEvent::Assert(warn())], ctx(), 0);
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(warn().id())], ctx(), 10);
+    assert_eq!(state_of(&out, warn().id()), Some(AlertState::Acknowledged));
+    assert_eq!(out.aural(), AuralToken::Silent);
+    // The condition is still present: not cleared by acknowledgement.
+    assert_eq!(out.active().len(), 1);
+}
+
+#[test]
+fn latched_warning_persists_until_ack() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.step(&profile, &[AlertEvent::Assert(warn())], ctx(), 0);
+    // Condition clears while unacknowledged: warning latches, aural stops.
+    let out = m.step(&profile, &[AlertEvent::Clear(warn())], ctx(), 10);
+    assert_eq!(
+        state_of(&out, warn().id()),
+        Some(AlertState::LatchedCleared)
+    );
+    assert_eq!(out.aural(), AuralToken::Silent);
+    // Acknowledgement of a cleared latched alert removes it.
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(warn().id())], ctx(), 20);
+    assert!(find(&out, warn().id()).is_none());
+}
+
+#[test]
+fn non_latching_advisory_self_clears() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.step(&profile, &[AlertEvent::Assert(advisory())], ctx(), 0);
+    let out = m.step(&profile, &[AlertEvent::Clear(advisory())], ctx(), 10);
+    assert!(find(&out, advisory().id()).is_none());
+}
+
+#[test]
+fn recovery_re_alerts_after_clear() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 0);
+    let cleared = m.step(&profile, &[AlertEvent::Clear(caution())], ctx(), 10);
+    assert_eq!(
+        state_of(&cleared, caution().id()),
+        Some(AlertState::LatchedCleared)
+    );
+    // Condition returns: re-alert, aural sounds again, not stuck.
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 20);
+    assert_eq!(state_of(&out, caution().id()), Some(AlertState::Active));
+    assert_eq!(out.aural(), AuralToken::TripleChime);
+}
+
+#[test]
+fn inhibit_entry_and_exit() {
+    let rule = InhibitRule {
+        id: caution().id(),
+        phase: FlightPhase::Approach,
+    };
+    let profile = AlertProfile::new(1_000_000, 1_000_000, 1_000_000, &[rule]).expect("valid");
+    let cruise = AlertContext {
+        phase: FlightPhase::Cruise,
+        ..AlertContext::default()
+    };
+    let approach = AlertContext {
+        phase: FlightPhase::Approach,
+        ..AlertContext::default()
+    };
+    let mut m = AlertManager::new();
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], cruise, 0);
+    assert!(!find(&out, caution().id()).expect("present").inhibited);
+    assert_eq!(out.aural(), AuralToken::TripleChime);
+
+    // Enter the inhibiting phase: flagged inhibited, silenced.
+    let out = m.step(&profile, &[], approach, 10);
+    assert!(find(&out, caution().id()).expect("present").inhibited);
+    assert_eq!(out.aural(), AuralToken::Silent);
+
+    // Exit the inhibiting phase: no longer inhibited.
+    let out = m.step(&profile, &[], cruise, 20);
+    assert!(!find(&out, caution().id()).expect("present").inhibited);
+}
+
+#[test]
+fn escalation_boundary_at_and_before_deadline() {
+    let profile = AlertProfile::new(1_000_000, 1_000, 1_000_000, &[]).expect("valid");
+    let mut m = AlertManager::new();
+    // Onset chimes once.
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 0);
+    assert_eq!(out.aural(), AuralToken::TripleChime);
+    // One millisecond before the deadline: still silent.
+    let out = m.step(&profile, &[], ctx(), 999);
+    assert_eq!(out.aural(), AuralToken::Silent);
+    // At the deadline: re-chimes.
+    let out = m.step(&profile, &[], ctx(), 1_000);
+    assert_eq!(out.aural(), AuralToken::TripleChime);
+}
+
+#[test]
+fn aural_preemption_then_resume() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    // Caution and warning onset together: warning preempts, caution stays
+    // pending.
+    let out = m.step(
+        &profile,
+        &[AlertEvent::Assert(caution()), AlertEvent::Assert(warn())],
+        ctx(),
+        0,
+    );
+    assert_eq!(out.aural(), AuralToken::ContinuousTone);
+    // Acknowledge the warning: the queued caution chime resumes.
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(warn().id())], ctx(), 10);
+    assert_eq!(out.aural(), AuralToken::TripleChime);
+}
+
+fn fill_with_cautions(m: &mut AlertManager, profile: &AlertProfile) {
+    let mut events = [AlertEvent::AcknowledgeAll; MAX_ACTIVE_ALERTS];
+    for (i, e) in events.iter_mut().enumerate() {
+        *e = AlertEvent::Assert(AlertCondition::FrameMismatch {
+            code: (i as u8) + 1,
+        });
+    }
+    let out = m.step(profile, &events, ctx(), 0);
+    assert_eq!(out.active().len(), MAX_ACTIVE_ALERTS);
+}
+
+#[test]
+fn overflow_evicts_lowest_for_warning() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    fill_with_cautions(&mut m, &profile);
+    let out = m.step(&profile, &[AlertEvent::Assert(warn())], ctx(), 10);
+    assert!(out.overflow());
+    assert_eq!(out.overflow_dropped(), 1);
+    assert_eq!(out.active().len(), MAX_ACTIVE_ALERTS);
+    // The warning is present; the highest-id (lowest-priority) caution went.
+    assert!(find(&out, warn().id()).is_some());
+    let dropped = AlertCondition::FrameMismatch {
+        code: MAX_ACTIVE_ALERTS as u8,
+    };
+    assert!(find(&out, dropped.id()).is_none());
+}
+
+#[test]
+fn overflow_rejects_lower_priority_newcomer() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    fill_with_cautions(&mut m, &profile);
+    let out = m.step(&profile, &[AlertEvent::Assert(advisory())], ctx(), 10);
+    assert!(out.overflow());
+    assert_eq!(out.overflow_dropped(), 1);
+    // A lower-priority newcomer is dropped; no caution is displaced.
+    assert!(find(&out, advisory().id()).is_none());
+    assert_eq!(out.active().len(), MAX_ACTIVE_ALERTS);
+    let first = AlertCondition::FrameMismatch { code: 1 };
+    assert!(find(&out, first.id()).is_some());
+}
+
+#[test]
+fn generation_wraps() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.generation = u32::MAX;
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 0);
+    assert_eq!(out.generation(), 0);
+    assert_eq!(out.active()[0].generation, 0);
+}
+
+#[test]
+fn manager_fault_preserves_primary_data_alert() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let faulted = AlertContext {
+        alerting_path_healthy: false,
+        ..AlertContext::default()
+    };
+    let out = m.step(&profile, &[AlertEvent::Assert(attitude_warn())], faulted, 0);
+    assert_eq!(out.health(), ManagerHealth::Faulted);
+    // The primary-data warning is still present alongside the fault flag.
+    assert_eq!(
+        state_of(&out, attitude_warn().id()),
+        Some(AlertState::Active)
+    );
+}
+
+#[test]
+fn unusual_attitude_declutter_retains_warning_and_caution() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let declutter = AlertContext {
+        declutter: true,
+        ..AlertContext::default()
+    };
+    let out = m.step(
+        &profile,
+        &[
+            AlertEvent::Assert(warn()),
+            AlertEvent::Assert(caution()),
+            AlertEvent::Assert(advisory()),
+        ],
+        declutter,
+        0,
+    );
+    assert!(!find(&out, warn().id()).expect("present").decluttered);
+    assert!(!find(&out, caution().id()).expect("present").decluttered);
+    assert!(find(&out, advisory().id()).expect("present").decluttered);
+    // The decluttered advisory does not sound; the warning still does.
+    assert_eq!(out.aural(), AuralToken::ContinuousTone);
+}
+
+#[test]
+fn acknowledge_all_silences_everything() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    m.step(
+        &profile,
+        &[AlertEvent::Assert(warn()), AlertEvent::Assert(caution())],
+        ctx(),
+        0,
+    );
+    let out = m.step(&profile, &[AlertEvent::AcknowledgeAll], ctx(), 10);
+    assert_eq!(out.aural(), AuralToken::Silent);
+    assert_eq!(state_of(&out, warn().id()), Some(AlertState::Acknowledged));
+    assert_eq!(
+        state_of(&out, caution().id()),
+        Some(AlertState::Acknowledged)
+    );
+}
+
+#[test]
+fn transition_table_latching() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let id = caution().id();
+
+    // none -> Active
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 0);
+    assert_eq!(state_of(&out, id), Some(AlertState::Active));
+
+    // Active -> Acknowledged
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(id)], ctx(), 1);
+    assert_eq!(state_of(&out, id), Some(AlertState::Acknowledged));
+
+    // Acknowledged + Clear -> removed (acknowledged and cleared)
+    let out = m.step(&profile, &[AlertEvent::Clear(caution())], ctx(), 2);
+    assert!(find(&out, id).is_none());
+
+    // none -> Active -> LatchedCleared (clear while unacknowledged)
+    m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 3);
+    let out = m.step(&profile, &[AlertEvent::Clear(caution())], ctx(), 4);
+    assert_eq!(state_of(&out, id), Some(AlertState::LatchedCleared));
+
+    // LatchedCleared -> Active (recovery)
+    let out = m.step(&profile, &[AlertEvent::Assert(caution())], ctx(), 5);
+    assert_eq!(state_of(&out, id), Some(AlertState::Active));
+
+    // Active -> LatchedCleared -> removed via acknowledgement
+    m.step(&profile, &[AlertEvent::Clear(caution())], ctx(), 6);
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(id)], ctx(), 7);
+    assert!(find(&out, id).is_none());
+}
+
+#[test]
+fn transition_table_non_latching() {
+    let profile = perm_profile();
+    let mut m = AlertManager::new();
+    let id = advisory().id();
+
+    // none -> Active
+    let out = m.step(&profile, &[AlertEvent::Assert(advisory())], ctx(), 0);
+    assert_eq!(state_of(&out, id), Some(AlertState::Active));
+
+    // Active -> Acknowledged (still present)
+    let out = m.step(&profile, &[AlertEvent::Acknowledge(id)], ctx(), 1);
+    assert_eq!(state_of(&out, id), Some(AlertState::Acknowledged));
+
+    // Acknowledged + Clear -> removed
+    let out = m.step(&profile, &[AlertEvent::Clear(advisory())], ctx(), 2);
+    assert!(find(&out, id).is_none());
+
+    // Active + Clear -> removed directly (self-clearing)
+    m.step(&profile, &[AlertEvent::Assert(advisory())], ctx(), 3);
+    let out = m.step(&profile, &[AlertEvent::Clear(advisory())], ctx(), 4);
+    assert!(find(&out, id).is_none());
+}

--- a/crates/pilotage-alerts/src/output.rs
+++ b/crates/pilotage-alerts/src/output.rs
@@ -1,0 +1,143 @@
+//! The frozen output contract a manager step produces: a bounded,
+//! priority-ordered snapshot of active alerts, the single arbitrated aural
+//! command, overflow accounting, and manager health.
+//!
+//! The alert list is stored in a fixed array and exposed only as a sorted
+//! slice, so a consumer can never observe filler entries or an unsorted
+//! order. Later visual integration depends on this shape staying stable.
+
+use crate::class::{AlertClass, AlertState, AuralToken};
+use crate::condition::AlertId;
+
+/// Most alerts the manager tracks and reports at once. Beyond this,
+/// overflow drops the lowest-priority alert, fail-visible.
+pub const MAX_ACTIVE_ALERTS: usize = 24;
+
+/// Manager self-health for a step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ManagerHealth {
+    /// The alerting path is healthy; the output is trustworthy.
+    #[default]
+    Nominal,
+    /// The independent monitor reports the alerting path degraded; the
+    /// consumer must also honor primary-data flags directly. The alert list
+    /// is still produced and unchanged by this flag.
+    Faulted,
+}
+
+/// One alert in the manager's output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveAlert {
+    /// Stable identity.
+    pub id: AlertId,
+    /// Severity class.
+    pub class: AlertClass,
+    /// Acknowledgement-lifecycle state.
+    pub state: AlertState,
+    /// The static aural token this alert's class owns; the *sounded*
+    /// command for the step is [`AlertOutput::aural`], chosen by
+    /// arbitration.
+    pub aural: AuralToken,
+    /// Suppressed by profile inhibition in the current phase. Never true
+    /// for a warning.
+    pub inhibited: bool,
+    /// Hidden by unusual-attitude declutter. Never true for a warning or a
+    /// caution.
+    pub decluttered: bool,
+    /// Generation stamp (wrapping) at the alert's last state change.
+    pub generation: u32,
+}
+
+impl ActiveAlert {
+    const PLACEHOLDER: Self = Self {
+        id: AlertId(0),
+        class: AlertClass::Status,
+        state: AlertState::Acknowledged,
+        aural: AuralToken::Silent,
+        inhibited: false,
+        decluttered: false,
+        generation: 0,
+    };
+}
+
+/// The result of one [`AlertManager::step`](crate::AlertManager::step).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlertOutput {
+    alerts: [ActiveAlert; MAX_ACTIVE_ALERTS],
+    len: usize,
+    aural: AuralToken,
+    overflow: bool,
+    overflow_dropped: u32,
+    health: ManagerHealth,
+    generation: u32,
+}
+
+impl AlertOutput {
+    pub(crate) fn empty(generation: u32, overflow_dropped: u32) -> Self {
+        Self {
+            alerts: [ActiveAlert::PLACEHOLDER; MAX_ACTIVE_ALERTS],
+            len: 0,
+            aural: AuralToken::Silent,
+            overflow: false,
+            overflow_dropped,
+            health: ManagerHealth::Nominal,
+            generation,
+        }
+    }
+
+    pub(crate) fn set_aural(&mut self, aural: AuralToken) {
+        self.aural = aural;
+    }
+
+    pub(crate) fn set_overflow(&mut self, overflow: bool) {
+        self.overflow = overflow;
+    }
+
+    pub(crate) fn set_health(&mut self, health: ManagerHealth) {
+        self.health = health;
+    }
+
+    pub(crate) fn push(&mut self, alert: ActiveAlert) {
+        if self.len < MAX_ACTIVE_ALERTS {
+            self.alerts[self.len] = alert;
+            self.len += 1;
+        }
+    }
+
+    pub(crate) fn sort_active(&mut self) {
+        self.alerts[..self.len]
+            .sort_unstable_by(|a, b| b.class.cmp(&a.class).then(a.id.cmp(&b.id)));
+    }
+
+    /// The active alerts, priority-ordered: warning first, ties by
+    /// ascending id.
+    pub fn active(&self) -> &[ActiveAlert] {
+        &self.alerts[..self.len]
+    }
+
+    /// The single arbitrated aural command for this step.
+    pub fn aural(&self) -> AuralToken {
+        self.aural
+    }
+
+    /// Whether at least one alert was dropped for capacity this step
+    /// (fail-visible).
+    pub fn overflow(&self) -> bool {
+        self.overflow
+    }
+
+    /// Cumulative, wrapping count of alerts ever dropped for capacity.
+    pub fn overflow_dropped(&self) -> u32 {
+        self.overflow_dropped
+    }
+
+    /// Manager self-health for this step.
+    pub fn health(&self) -> ManagerHealth {
+        self.health
+    }
+
+    /// The manager generation (wrapping) after this step.
+    pub fn generation(&self) -> u32 {
+        self.generation
+    }
+}

--- a/crates/pilotage-alerts/src/profile.rs
+++ b/crates/pilotage-alerts/src/profile.rs
@@ -1,0 +1,166 @@
+//! The alert policy: per-class escalation deadlines and inhibit wiring.
+//!
+//! Aircraft-specific inhibit schedules never live in the manager; they live
+//! in a validated [`AlertProfile`], constructed like the display profiles
+//! in `pilotage-instrument-state` — through a constructor that rejects an
+//! ill-formed policy up front. Validation refuses a zero escalation
+//! deadline, more inhibit rules than the fixed budget, a rule that would
+//! inhibit a warning, and a rule naming an identity this build does not
+//! know. [`AlertProfile::simulator`] is benchmark data only and implies no
+//! aircraft approval.
+
+use crate::class::AlertClass;
+use crate::condition::{AlertCondition, AlertId, DynFault, SystemNote, class_of};
+use crate::event::FlightPhase;
+
+/// Most inhibit rules a profile may carry.
+pub const MAX_INHIBIT_RULES: usize = 16;
+
+/// One inhibit rule: `id` is suppressed while the aircraft is in `phase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InhibitRule {
+    /// The identity to inhibit. Must be a known, non-warning identity.
+    pub id: AlertId,
+    /// The phase the rule applies in.
+    pub phase: FlightPhase,
+}
+
+/// Why an [`AlertProfile`] could not be constructed.
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileError {
+    /// An escalation deadline is zero, which would re-trigger the aural
+    /// every step.
+    #[error("escalation deadline for {class:?} must be positive")]
+    NonPositiveEscalation {
+        /// The class whose deadline was zero.
+        class: AlertClass,
+    },
+    /// More inhibit rules were supplied than the fixed budget holds.
+    #[error("profile carries {count} inhibit rules, over the fixed budget")]
+    TooManyInhibits {
+        /// The number of rules supplied.
+        count: usize,
+    },
+    /// A rule targets a warning-class identity; warnings may not be
+    /// inhibited.
+    #[error("inhibit rule targets warning alert {id:?}, which may not be inhibited")]
+    UninhibitableAlert {
+        /// The offending identity.
+        id: AlertId,
+    },
+    /// A rule targets an identity this build does not know.
+    #[error("inhibit rule targets unknown alert {id:?}")]
+    UnknownInhibitAlert {
+        /// The unknown identity.
+        id: AlertId,
+    },
+}
+
+/// Escalation deadlines and inhibit wiring for the alert manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlertProfile {
+    warning_escalation_ms: u64,
+    caution_escalation_ms: u64,
+    advisory_escalation_ms: u64,
+    inhibits: [Option<InhibitRule>; MAX_INHIBIT_RULES],
+}
+
+impl AlertProfile {
+    /// Builds a profile after validating deadlines and inhibit wiring.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProfileError`] when an escalation deadline is zero, when
+    /// there are more inhibit rules than the fixed budget, when a rule
+    /// targets a warning, or when a rule names an unknown identity.
+    pub fn new(
+        warning_escalation_ms: u64,
+        caution_escalation_ms: u64,
+        advisory_escalation_ms: u64,
+        inhibits: &[InhibitRule],
+    ) -> Result<Self, ProfileError> {
+        if warning_escalation_ms == 0 {
+            return Err(ProfileError::NonPositiveEscalation {
+                class: AlertClass::Warning,
+            });
+        }
+        if caution_escalation_ms == 0 {
+            return Err(ProfileError::NonPositiveEscalation {
+                class: AlertClass::Caution,
+            });
+        }
+        if advisory_escalation_ms == 0 {
+            return Err(ProfileError::NonPositiveEscalation {
+                class: AlertClass::Advisory,
+            });
+        }
+        if inhibits.len() > MAX_INHIBIT_RULES {
+            return Err(ProfileError::TooManyInhibits {
+                count: inhibits.len(),
+            });
+        }
+        let mut wiring = [None; MAX_INHIBIT_RULES];
+        let mut i = 0;
+        while i < inhibits.len() {
+            let rule = inhibits[i];
+            match class_of(rule.id) {
+                None => return Err(ProfileError::UnknownInhibitAlert { id: rule.id }),
+                Some(AlertClass::Warning) => {
+                    return Err(ProfileError::UninhibitableAlert { id: rule.id });
+                }
+                Some(_) => {}
+            }
+            wiring[i] = Some(rule);
+            i += 1;
+        }
+        Ok(Self {
+            warning_escalation_ms,
+            caution_escalation_ms,
+            advisory_escalation_ms,
+            inhibits: wiring,
+        })
+    }
+
+    /// A benchmark-data-only profile. Its deadlines (warning 5 s, caution
+    /// 10 s, advisory 20 s) and its two inhibit rules — turn-rate advisory
+    /// during takeoff, database-stale status on approach — are simulator
+    /// inputs, not an approval for any aircraft.
+    pub fn simulator() -> Self {
+        let mut inhibits = [None; MAX_INHIBIT_RULES];
+        inhibits[0] = Some(InhibitRule {
+            id: AlertCondition::TurnSlip(DynFault::TurnRateInvalid).id(),
+            phase: FlightPhase::Takeoff,
+        });
+        inhibits[1] = Some(InhibitRule {
+            id: AlertCondition::System(SystemNote::DatabaseStale).id(),
+            phase: FlightPhase::Approach,
+        });
+        Self {
+            warning_escalation_ms: 5_000,
+            caution_escalation_ms: 10_000,
+            advisory_escalation_ms: 20_000,
+            inhibits,
+        }
+    }
+
+    /// The escalation deadline for a class. Silent classes never escalate.
+    pub fn escalation_ms(&self, class: AlertClass) -> u64 {
+        match class {
+            AlertClass::Warning => self.warning_escalation_ms,
+            AlertClass::Caution => self.caution_escalation_ms,
+            AlertClass::Advisory => self.advisory_escalation_ms,
+            AlertClass::Status | AlertClass::Maintenance => u64::MAX,
+        }
+    }
+
+    /// Whether `id` is inhibited in `phase` by any rule.
+    pub fn is_inhibited(&self, id: AlertId, phase: FlightPhase) -> bool {
+        self.inhibits
+            .iter()
+            .flatten()
+            .any(|rule| rule.id == id && rule.phase == phase)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-alerts/src/profile/tests.rs
+++ b/crates/pilotage-alerts/src/profile/tests.rs
@@ -1,0 +1,104 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::condition::{AlertCondition, DisplayFault, MiscompareFault};
+
+fn caution_id() -> AlertId {
+    AlertCondition::Altitude(crate::condition::AltFault::ReferenceLost).id()
+}
+
+#[test]
+fn simulator_profile_is_valid_and_wired() {
+    let profile = AlertProfile::simulator();
+    let turn = AlertCondition::TurnSlip(DynFault::TurnRateInvalid).id();
+    let db = AlertCondition::System(SystemNote::DatabaseStale).id();
+    assert!(profile.is_inhibited(turn, FlightPhase::Takeoff));
+    assert!(!profile.is_inhibited(turn, FlightPhase::Cruise));
+    assert!(profile.is_inhibited(db, FlightPhase::Approach));
+    assert_eq!(profile.escalation_ms(AlertClass::Warning), 5_000);
+    assert_eq!(profile.escalation_ms(AlertClass::Caution), 10_000);
+    assert_eq!(profile.escalation_ms(AlertClass::Advisory), 20_000);
+    assert_eq!(profile.escalation_ms(AlertClass::Status), u64::MAX);
+}
+
+#[test]
+fn zero_escalation_is_rejected() {
+    assert_eq!(
+        AlertProfile::new(0, 10, 10, &[]),
+        Err(ProfileError::NonPositiveEscalation {
+            class: AlertClass::Warning
+        })
+    );
+    assert_eq!(
+        AlertProfile::new(10, 0, 10, &[]),
+        Err(ProfileError::NonPositiveEscalation {
+            class: AlertClass::Caution
+        })
+    );
+    assert_eq!(
+        AlertProfile::new(10, 10, 0, &[]),
+        Err(ProfileError::NonPositiveEscalation {
+            class: AlertClass::Advisory
+        })
+    );
+}
+
+#[test]
+fn too_many_inhibits_is_rejected() {
+    let rule = InhibitRule {
+        id: caution_id(),
+        phase: FlightPhase::Cruise,
+    };
+    let rules = [rule; MAX_INHIBIT_RULES + 1];
+    assert_eq!(
+        AlertProfile::new(1, 1, 1, &rules),
+        Err(ProfileError::TooManyInhibits {
+            count: MAX_INHIBIT_RULES + 1
+        })
+    );
+}
+
+#[test]
+fn exactly_the_budget_is_accepted() {
+    let rule = InhibitRule {
+        id: caution_id(),
+        phase: FlightPhase::Cruise,
+    };
+    let rules = [rule; MAX_INHIBIT_RULES];
+    assert!(AlertProfile::new(1, 1, 1, &rules).is_ok());
+}
+
+#[test]
+fn inhibiting_a_warning_is_rejected() {
+    let warning = AlertCondition::Display(DisplayFault::RendererStalled).id();
+    let attitude = AlertCondition::Miscompare(MiscompareFault::Attitude).id();
+    let rules = [InhibitRule {
+        id: warning,
+        phase: FlightPhase::Cruise,
+    }];
+    assert_eq!(
+        AlertProfile::new(1, 1, 1, &rules),
+        Err(ProfileError::UninhibitableAlert { id: warning })
+    );
+    let rules = [InhibitRule {
+        id: attitude,
+        phase: FlightPhase::Cruise,
+    }];
+    assert_eq!(
+        AlertProfile::new(1, 1, 1, &rules),
+        Err(ProfileError::UninhibitableAlert { id: attitude })
+    );
+}
+
+#[test]
+fn inhibiting_an_unknown_identity_is_rejected() {
+    let unknown = AlertId(0x0099);
+    let rules = [InhibitRule {
+        id: unknown,
+        phase: FlightPhase::Cruise,
+    }];
+    assert_eq!(
+        AlertProfile::new(1, 1, 1, &rules),
+        Err(ProfileError::UnknownInhibitAlert { id: unknown })
+    );
+}


### PR DESCRIPTION
## Summary

- `pilotage-alerts`: a pure, bounded, deterministic, `no_std`/allocation-free flightcrew alert manager — `AlertManager::step(events, now) → AlertOutput`, no interior time reads, same state + input → same output
- full per-alert state machine: **Active → Acknowledged / LatchedCleared → removed**, with assert/duplicate/re-assert (recovery re-alerts, never sticks), acknowledge (silences aural, visual persists per class), clear (self-clearing vs latched classes), one-shot escalation on a profile deadline, and single-token aural arbitration (highest priority sounds; preempted one-shots resume later)
- **typed conditions, never raw telemetry**: input seams for ALT (#16), NAV (#21), turn/slip (#23), source miscompare (#20), renderer/display failure (DISP-01 reason family), and an opaque `FrameMismatch { code }` seam that deliberately invents no frame types while FRAME-01 (#52) owns that contract
- alert **generation** stays separate from display **rendering**: output is a priority-ordered bounded list (id, class, state, aural token, inhibited) — no drawing, no layout
- `AlertProfile` with validated construction (`ProfileError` for zero deadlines, over-capacity rule sets, inhibits targeting warnings or unknown ids); warnings are structurally uninhibitable at validation AND runtime; `simulator()` is benchmark data only

## Acceptance criteria — evidence (issue #22)

| Criterion | Status | Evidence |
|---|---|---|
| Pure, bounded, deterministic state machine | ✅ | Clock/event injection only; `MAX_ACTIVE_ALERTS = 24` fixed table; overflow evicts lowest-priority (never a higher one), counted with `wrapping_add`, surfaced via `output.overflow()` — never silent |
| Priority / inhibit / latch / acknowledge / clear / escalation / recovery | ✅ | Full transition table pinned by tests: class-then-id priority with deterministic tie-break, phase-scoped inhibits with entry/exit, latch persistence past clear, ack semantics per class, escalation boundary at exactly the deadline (999 ms silent / 1000 ms re-chime), cleared-then-reasserted re-alerts |
| Typed conditions, not telemetry inspection | ✅ | `AlertId` family vocabulary with fixed class mapping (`class_of` reversal used by profile validation); producers translate their own faults |
| Generation separate from rendering | ✅ | Output is data (`ActiveAlert` list + `ManagerHealth`); a manager-path fault degrades health while still producing the primary-data alert list |
| Input seams for ALT/NAV/DYN/miscompare/renderer/frame | ✅ | One typed family each; frame seam kept opaque per the FRAME-01 coordination rule |
| Injected sequences and clocks, no sleeps | ✅ | 35 deterministic tests incl. generation wrap (`u32::MAX → 0`) and aural preempt/resume |
| No aircraft-specific inhibit schedules without a profile | ✅ | Inhibits live only in validated `AlertProfile`; the simulator profile is labeled benchmark-data-only |

Gates: fmt / clippy `-D warnings` / 35 tests / strict rustdoc / release / **standalone thumbv7em `no_std` proof** all green (sole dependency: `thiserror` without default features).

## Workspace registration

Landed on this branch after #54 merged, per the sequencing stated when this PR opened: root manifest member + workspace dependency + the thumbv7em bare-metal CI gate now include `pilotage-alerts`, and the crate builds under the normal workspace gates.

SIM / NOT FOR FLIGHT — AC 25.1322-1 as design input, no certification claim. Refs #22.

