### PR TITLE
REN-04 follow-up: deterministic work budgets and browser interpreter guards

### DIFF
--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -508,6 +508,31 @@ export function drawGlyphRun(ctx, glyphs, text, x, y, size, anchorByte) {
   }
 }
 
+// Fail-closed argument envelope mirroring the reference rasterizer's
+// limits (Q8.8 representable range, shared path-vertex buffer). The
+// rasterizer range-checks coordinates in device space after applying
+// the transform; Canvas2D has no such boundary, so the interpreter
+// rejects at the raw-argument level instead — a different (raw, not
+// device-space) rule with the same fail-closed outcome for the scenes
+// the encoder can produce, which never rely on a transform to bring an
+// out-of-range raw coordinate back in range. A violation throws;
+// renderPanel converts the throw to PAINT_FAILED and the back buffer
+// is discarded, so nothing partial reaches the visible frame.
+export const COORD_LIMIT_PX = 32767;
+export const MAX_PATH_VERTICES = 512;
+
+function coordGuard(v) {
+  if (!Number.isFinite(v) || Math.abs(v) > COORD_LIMIT_PX) {
+    throw new Error(`scene coordinate rejected: ${v}`);
+  }
+  return v;
+}
+
+function finiteGuard(v) {
+  if (!Number.isFinite(v)) throw new Error(`scene angle rejected: ${v}`);
+  return v;
+}
+
 // Interprets one encoded scene onto a Canvas2D context; returns the
 // number of skipped unknown opcodes. Text paints exclusively from the
 // verified glyph atlas — a scene with text and no atlas throws (the
@@ -531,22 +556,22 @@ export function interpretScene(view, ctx, glyphs = null) {
         ctx.restore();
         break;
       case 0x03:
-        ctx.translate(f(0), f(1));
+        ctx.translate(coordGuard(f(0)), coordGuard(f(1)));
         break;
       case 0x04:
-        ctx.rotate(f(0));
+        ctx.rotate(finiteGuard(f(0)));
         break;
       case 0x10:
         ctx.fillStyle = color(view, p);
         break;
       case 0x11:
         ctx.strokeStyle = color(view, p);
-        ctx.lineWidth = view.getFloat32(p + 4, true);
+        ctx.lineWidth = coordGuard(view.getFloat32(p + 4, true));
         break;
       case 0x20:
         ctx.beginPath();
-        ctx.moveTo(f(0), f(1));
-        ctx.lineTo(f(2), f(3));
+        ctx.moveTo(coordGuard(f(0)), coordGuard(f(1)));
+        ctx.lineTo(coordGuard(f(2)), coordGuard(f(3)));
         ctx.stroke();
         break;
       case 0x21:
@@ -564,15 +589,15 @@ export function interpretScene(view, ctx, glyphs = null) {
       case 0x23: {
         const mode = view.getUint8(p);
         const g = (i) => view.getFloat32(p + 1 + i * 4, true);
-        if (mode & 1) ctx.fillRect(g(0), g(1), g(2), g(3));
-        if (mode & 2) ctx.strokeRect(g(0), g(1), g(2), g(3));
+        if (mode & 1) ctx.fillRect(coordGuard(g(0)), coordGuard(g(1)), coordGuard(g(2)), coordGuard(g(3)));
+        if (mode & 2) ctx.strokeRect(coordGuard(g(0)), coordGuard(g(1)), coordGuard(g(2)), coordGuard(g(3)));
         break;
       }
       case 0x24: {
         const mode = view.getUint8(p);
         const g = (i) => view.getFloat32(p + 1 + i * 4, true);
         ctx.beginPath();
-        ctx.arc(g(0), g(1), g(2), 0, Math.PI * 2);
+        ctx.arc(coordGuard(g(0)), coordGuard(g(1)), coordGuard(g(2)), 0, Math.PI * 2);
         if (mode & 1) ctx.fill();
         if (mode & 2) ctx.stroke();
         break;
@@ -581,7 +606,7 @@ export function interpretScene(view, ctx, glyphs = null) {
         // Scene arc angles match Canvas2D: 0 at +x, positive clockwise
         // in y-down space.
         ctx.beginPath();
-        ctx.arc(f(0), f(1), f(2), f(3), f(3) + f(4), f(4) < 0);
+        ctx.arc(coordGuard(f(0)), coordGuard(f(1)), coordGuard(f(2)), finiteGuard(f(3)), finiteGuard(f(3) + f(4)), f(4) < 0);
         ctx.stroke();
         break;
       case 0x30: {
@@ -592,12 +617,12 @@ export function interpretScene(view, ctx, glyphs = null) {
         const text = new TextDecoder().decode(
           new Uint8Array(view.buffer, view.byteOffset + p + 13, plen - 13),
         );
-        drawGlyphRun(ctx, glyphs, text, x, y, size, anchor);
+        drawGlyphRun(ctx, glyphs, text, coordGuard(x), coordGuard(y), coordGuard(size), anchor);
         break;
       }
       case 0x40:
         ctx.beginPath();
-        ctx.rect(f(0), f(1), f(2), f(3));
+        ctx.rect(coordGuard(f(0)), coordGuard(f(1)), coordGuard(f(2)), coordGuard(f(3)));
         ctx.clip();
         break;
       case 0x50:
@@ -620,9 +645,12 @@ export function interpretScene(view, ctx, glyphs = null) {
 function pointsPath(view, p, plen, headBytes, ctx) {
   ctx.beginPath();
   const n = (plen - headBytes) / 8;
+  if (n > MAX_PATH_VERTICES) {
+    throw new Error(`scene path rejected: ${n} vertices exceeds ${MAX_PATH_VERTICES}`);
+  }
   for (let i = 0; i < n; i++) {
-    const x = view.getFloat32(p + headBytes + i * 8, true);
-    const y = view.getFloat32(p + headBytes + i * 8 + 4, true);
+    const x = coordGuard(view.getFloat32(p + headBytes + i * 8, true));
+    const y = coordGuard(view.getFloat32(p + headBytes + i * 8 + 4, true));
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -15,6 +15,8 @@ import {
   LOGICAL_H,
   LOGICAL_W,
   PANEL,
+  COORD_LIMIT_PX,
+  MAX_PATH_VERTICES,
   STATE_ABI_SIZE,
   STATE_ABI_SIZE_BY_VERSION,
   STATE_ABI_VERSION,
@@ -248,6 +250,47 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   check(
     "a genuinely unknown opcode still counts",
     interpretScene(view(trulyUnknown), new RecordingCtx()) === 1,
+  );
+}
+
+// ---- raw-argument guards (REN-04: fail-closed parity with the rasterizer) ---
+
+{
+  const throws = (bytes) => {
+    try {
+      interpretScene(view(Uint8Array.from(bytes)), new RecordingCtx());
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  const rect = (x) => [1, ...cmd(0x23, [1, ...f32(x), ...f32(0), ...f32(4), ...f32(4)])];
+  check("a non-finite coordinate throws before Canvas sees it", throws(rect(NaN)));
+  check(
+    "a coordinate beyond COORD_LIMIT_PX throws",
+    throws(rect(COORD_LIMIT_PX + 1)) && !throws(rect(COORD_LIMIT_PX)),
+  );
+  check("a non-finite rotation angle throws", throws([1, ...cmd(0x04, f32(NaN))]));
+  check(
+    "an out-of-range translation throws",
+    throws([1, ...cmd(0x03, [...f32(40000), ...f32(0)])]),
+  );
+  check(
+    "an out-of-range stroke width throws",
+    throws([1, ...cmd(0x11, [255, 255, 255, 255, ...f32(40000)])]),
+  );
+  check(
+    "a non-finite arc angle throws",
+    throws([1, ...cmd(0x25, [...f32(10), ...f32(10), ...f32(5), ...f32(NaN), ...f32(1)])]),
+  );
+  const path = (n) => {
+    const pts = [];
+    for (let i = 0; i < n; i += 1) pts.push(...f32(i % 100), ...f32(i % 7));
+    return [1, ...cmd(0x21, pts)];
+  };
+  check(
+    "a path beyond the vertex budget throws, one at the budget paints",
+    throws(path(MAX_PATH_VERTICES + 1)) && !throws(path(MAX_PATH_VERTICES)),
   );
 }
 

--- a/clients/web/scene-conformance-corpus.json
+++ b/clients/web/scene-conformance-corpus.json
@@ -1,11 +1,11 @@
 {
-  "schemaVersion": 1,
-  "corpusVersion": 1,
+  "schemaVersion": 2,
+  "corpusVersion": 2,
   "generatedBy": "pilotage-instrument-raster REN-04 conformance reference",
   "simOnly": "Canvas/browser backend is SIM / NOT FOR FLIGHT",
   "canonicalization": "trace args are Q8.8 floor(v*256); non-finite as nan/inf/-inf",
   "review": {
-    "reason": "Initial REN-04 backend-conformance corpus.",
+    "reason": "Add interpreterRejects: the browser interpreter now enforces raw-argument guards (finite floats, |coordinate| <= coordLimitPx, path vertex budget) and the golden pins where it must throw; new paint-fault cases cover the rotate/translate/arc/stroke-width guard paths.",
     "approvedBy": "REN-04 owner; regenerated goldens require human review and are never rewritten by CI."
   },
   "budgets": {
@@ -16,9 +16,10 @@
     "maxTextBytes": 250,
     "maxDimension": 4096,
     "maxPolygonVertices": 512,
+    "coordLimitPx": 32767,
     "worstCaseFrameBytes": 67108864
   },
-  "corpusSha256": "b96d3bd30cfe27ac40e1bbea5a3750da8b7d5c1f6105fa4590f5af86a5143621",
+  "corpusSha256": "52d0c09cec4c8b73aea1bda4d9adbb6597a86fe184881e75d777520af4b576f3",
   "entries": [
     {
       "name": "empty-background-canonical",
@@ -30,6 +31,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 1, "layerCommands": [2, 0, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:0", "01", "02", "51:0"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "restore"],
       "framingBoundaries": null
     },
@@ -43,6 +45,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 17, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "23:F,512,512,5120,5120", "11:200,0,0,255,512", "20:0,0,7680,7680", "21:1280,10240,3840,15360,6400,10240", "22:FS:10240,10240,15360,10240,12800,15360", "24:F,17920,7680,2560", "24:S,17920,17920,2560", "25:7680,20480,3072,0,768", "01", "03:20480,20480", "04:128", "40:0,0,3840,3840", "23:F,0,0,7680,7680", "02", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "fillRect:512,512,5120,5120", "beginPath", "moveTo:0,0", "lineTo:7680,7680", "stroke", "beginPath", "moveTo:1280,10240", "lineTo:3840,15360", "lineTo:6400,10240", "stroke", "beginPath", "moveTo:10240,10240", "lineTo:15360,10240", "lineTo:12800,15360", "closePath", "fill", "stroke", "beginPath", "arc:17920,7680,2560,0,1608", "fill", "beginPath", "arc:17920,17920,2560,0,1608", "stroke", "beginPath", "arc:7680,20480,3072,0,768,0", "stroke", "save", "translate:20480,20480", "rotate:128", "beginPath", "rect:0,0,3840,3840", "clip", "fillRect:0,0,7680,7680", "restore", "restore"],
       "framingBoundaries": null
     },
@@ -56,6 +59,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 22, "layerCommands": [0, 4, 4, 0, 4, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "11:255,255,255,255,512", "20:0,46080,122880,46080", "02", "51:1", "50:2", "01", "10:255,255,255,255", "23:S,5120,30720,10240,30720", "02", "51:2", "50:4", "01", "10:255,176,0,255", "23:F,53760,5120,15360,5120", "02", "51:4"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "beginPath", "moveTo:0,46080", "lineTo:122880,46080", "stroke", "restore", "save", "strokeRect:5120,30720,10240,30720", "restore", "save", "fillRect:53760,5120,15360,5120", "restore"],
       "framingBoundaries": null
     },
@@ -69,6 +73,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 7, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "01", "03:30720,23040", "04:128", "20:-10240,0,10240,0", "02", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "save", "translate:30720,23040", "rotate:128", "beginPath", "moveTo:-10240,0", "lineTo:10240,0", "stroke", "restore", "restore"],
       "framingBoundaries": null
     },
@@ -82,6 +87,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 5, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "40:0,0,7680,7680", "10:255,255,255,255", "23:F,0,0,15360,15360", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "beginPath", "rect:0,0,7680,7680", "clip", "fillRect:0,0,15360,15360", "restore"],
       "framingBoundaries": null
     },
@@ -95,6 +101,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 7, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "01", "03:61440,46080", "04:716", "20:-153600,0,153600,0", "02", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "save", "translate:61440,46080", "rotate:716", "beginPath", "moveTo:-153600,0", "lineTo:153600,0", "stroke", "restore", "restore"],
       "framingBoundaries": null
     },
@@ -108,6 +115,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "23:F,7680000,0,2560,2560", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "fillRect:7680000,0,2560,2560", "restore"],
       "framingBoundaries": null
     },
@@ -121,6 +129,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 1, "layerCommands": [6, 0, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:0", "01", "10:20,40,60,255", "23:F,0,0,122880,46080", "10:60,40,20,255", "22:F:0,46080,122880,46080,122880,92160,0,92160", "02", "51:0"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "fillRect:0,0,122880,46080", "beginPath", "moveTo:0,46080", "lineTo:122880,46080", "lineTo:122880,92160", "lineTo:0,92160", "closePath", "fill", "restore"],
       "framingBoundaries": null
     },
@@ -134,6 +143,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 8, "layerCommands": [0, 0, 0, 5, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:3", "01", "11:255,255,255,255,512", "20:61440,15360,61440,76800", "20:51200,46080,71680,46080", "02", "51:3"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "beginPath", "moveTo:61440,15360", "lineTo:61440,76800", "stroke", "beginPath", "moveTo:51200,46080", "lineTo:71680,46080", "stroke", "restore"],
       "framingBoundaries": null
     },
@@ -147,6 +157,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 32, "layerCommands": [0, 0, 0, 0, 0, 4] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:5", "01", "10:200,0,0,255", "23:F,0,0,122880,92160", "02", "51:5"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "fillRect:0,0,122880,92160", "restore"],
       "framingBoundaries": null
     },
@@ -160,6 +171,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 1, "layersPresent": 2, "layerCommands": [0, 3, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "unknown:127", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": ["save", "restore"],
       "framingBoundaries": null
     },
@@ -173,6 +185,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "30:3584,0,10240,10240,31", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -186,45 +199,105 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": false, "error": "Glyph" },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "30:3584,0,10240,10240,23", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
     {
       "name": "paint-non-finite",
       "category": "paint-fault",
-      "notes": "Gate accepts; the software rasterizer spoils on a non-finite coordinate while Canvas2D would paint it (SIM/NOT FOR FLIGHT).",
+      "notes": "Gate accepts; the software rasterizer spoils on a non-finite coordinate and the browser interpreter's raw-argument guard throws before Canvas2D sees it.",
       "bytesHex": "0150010001010000100400ffffffff231100010000c07f00000000000020410000204102000051010001",
       "framingValid": true,
       "decode": { "ok": true, "error": null },
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": false, "error": "NonFinite" },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "23:F,nan,0,2560,2560", "02", "51:1"],
-      "canvasMethods": ["save", "fillRect:nan,0,2560,2560", "restore"],
+      "interpreterRejects": "coordinate",
+      "canvasMethods": null,
       "framingBoundaries": null
     },
     {
       "name": "paint-out-of-range",
       "category": "paint-fault",
-      "notes": "Gate accepts; the software rasterizer spoils on an out-of-range device coordinate while Canvas2D would paint it.",
+      "notes": "Gate accepts; the software rasterizer spoils on an out-of-range device coordinate and the interpreter's raw-argument guard rejects the same value.",
       "bytesHex": "0150010001010000100400ffffffff2311000100401c4700000000000020410000204102000051010001",
       "framingValid": true,
       "decode": { "ok": true, "error": null },
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": false, "error": "CoordinateOutOfRange" },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "23:F,10240000,0,2560,2560", "02", "51:1"],
-      "canvasMethods": ["save", "fillRect:10240000,0,2560,2560", "restore"],
+      "interpreterRejects": "coordinate",
+      "canvasMethods": null,
       "framingBoundaries": null
     },
     {
       "name": "paint-too-many-vertices",
       "category": "paint-fault",
-      "notes": "Gate accepts; the software rasterizer enforces its per-shape vertex budget while Canvas2D has none.",
+      "notes": "Gate accepts; both backends enforce the shared per-shape vertex budget — the rasterizer via its fixed buffer, the interpreter via its path guard.",
       "bytesHex": "0150010001010000110800ffffffff0000803f21081000000000000000000000803f0000803f0000004000000040000040400000404000008040000080400000a0400000a0400000c0400000c0400000e04000000000000000410000803f000010410000004000002041000040400000304100008040000040410000a040000050410000c0400000604100000000000070410000803f000080410000004000008841000040400000904100008040000098410000a0400000a0410000c0400000a841000000000000b0410000803f0000b841000000400000c041000040400000c841000080400000d0410000a0400000d8410000c0400000e041000000000000e8410000803f0000f041000000400000f841000040400000004200008040000004420000a040000008420000c04000000c4200000000000010420000803f0000144200000040000018420000404000001c4200008040000020420000a040000024420000c040000028420000000000002c420000803f00003042000000400000344200004040000038420000804000003c420000a040000040420000c0400000444200000000000048420000803f00004c420000004000005042000040400000544200008040000058420000a04000005c420000c0400000604200000000000064420000803f000068420000004000006c42000040400000704200008040000074420000a040000078420000c04000007c4200000000000080420000803f000082420000004000008442000040400000864200008040000088420000a04000008a420000c04000008c420000000000008e420000803f000090420000004000009242000040400000944200008040000096420000a040000098420000c04000009a420000000000009c420000803f00009e42000000400000a042000040400000a242000080400000a4420000a0400000a6420000c0400000a842000000000000aa420000803f0000ac42000000400000ae42000040400000b042000080400000b2420000a0400000b4420000c0400000b642000000000000b8420000803f0000ba42000000400000bc42000040400000be42000080400000c0420000a0400000c2420000c0400000c442000000000000c6420000803f0000c842000000400000ca42000040400000cc42000080400000ce420000a0400000d0420000c0400000d242000000000000d4420000803f0000d642000000400000d842000040400000da42000080400000dc420000a0400000de420000c0400000e042000000000000e2420000803f0000e442000000400000e642000040400000e842000080400000ea420000a0400000ec420000c0400000ee42000000000000f0420000803f0000f242000000400000f442000040400000f642000080400000f8420000a0400000fa420000c0400000fc42000000000000fe420000803f000000430000004000000143000040400000024300008040000003430000a040000004430000c0400000054300000000000006430000803f00000743000000400000084300004040000009430000804000000a430000a04000000b430000c04000000c430000000000000d430000803f00000e430000004000000f43000040400000104300008040000011430000a040000012430000c0400000134300000000000014430000803f000015430000004000001643000040400000174300008040000018430000a040000019430000c04000001a430000000000001b430000803f00001c430000004000001d430000404000001e430000804000001f430000a040000020430000c0400000214300000000000022430000803f000023430000004000002443000040400000254300008040000026430000a040000027430000c0400000284300000000000029430000803f00002a430000004000002b430000404000002c430000804000002d430000a04000002e430000c04000002f4300000000000030430000803f000031430000004000003243000040400000334300008040000034430000a040000035430000c0400000364300000000000037430000803f0000384300000040000039430000404000003a430000804000003b430000a04000003c430000c04000003d430000000000003e430000803f00003f430000004000004043000040400000414300008040000042430000a040000043430000c0400000444300000000000045430000803f000046430000004000004743000040400000484300008040000049430000a04000004a430000c04000004b430000000000004c430000803f00004d430000004000004e430000404000004f4300008040000050430000a040000051430000c0400000524300000000000053430000803f000054430000004000005543000040400000564300008040000057430000a040000058430000c040000059430000000000005a430000803f00005b430000004000005c430000404000005d430000804000005e430000a04000005f430000c0400000604300000000000061430000803f000062430000004000006343000040400000644300008040000065430000a040000066430000c0400000674300000000000068430000803f000069430000004000006a430000404000006b430000804000006c430000a04000006d430000c04000006e430000000000006f430000803f000070430000004000007143000040400000724300008040000073430000a040000074430000c0400000754300000000000076430000803f00007743000000400000784300004040000079430000804000007a430000a04000007b430000c04000007c430000000000007d430000803f00007e430000004000007f43000040400000804300008040008080430000a040000081430000c0400080814300000000000082430000803f008082430000004000008343000040400080834300008040000084430000a040008084430000c0400000854300000000008085430000803f000086430000004000808643000040400000874300008040008087430000a040000088430000c0400080884300000000000089430000803f008089430000004000008a430000404000808a430000804000008b430000a04000808b430000c04000008c430000000000808c430000803f00008d430000004000808d430000404000008e430000804000808e430000a04000008f430000c04000808f4300000000000090430000803f008090430000004000009143000040400080914300008040000092430000a040008092430000c0400000934300000000008093430000803f000094430000004000809443000040400000954300008040008095430000a040000096430000c0400080964300000000000097430000803f008097430000004000009843000040400080984300008040000099430000a040008099430000c04000009a430000000000809a430000803f00009b430000004000809b430000404000009c430000804000809c430000a04000009d430000c04000809d430000000000009e430000803f00809e430000004000009f430000404000809f43000080400000a0430000a0400080a0430000c0400000a143000000000080a1430000803f0000a243000000400080a243000040400000a343000080400080a3430000a0400000a4430000c0400080a443000000000000a5430000803f0080a543000000400000a643000040400080a643000080400000a7430000a0400080a7430000c0400000a843000000000080a8430000803f0000a943000000400080a943000040400000aa43000080400080aa430000a0400000ab430000c0400080ab43000000000000ac430000803f0080ac43000000400000ad43000040400080ad43000080400000ae430000a0400080ae430000c0400000af43000000000080af430000803f0000b043000000400080b043000040400000b143000080400080b1430000a0400000b2430000c0400080b243000000000000b3430000803f0080b343000000400000b443000040400080b443000080400000b5430000a0400080b5430000c0400000b643000000000080b6430000803f0000b743000000400080b743000040400000b843000080400080b8430000a0400000b9430000c0400080b943000000000000ba430000803f0080ba43000000400000bb43000040400080bb43000080400000bc430000a0400080bc430000c0400000bd43000000000080bd430000803f0000be43000000400080be43000040400000bf43000080400080bf430000a0400000c0430000c0400080c043000000000000c1430000803f0080c143000000400000c243000040400080c243000080400000c3430000a0400080c3430000c0400000c443000000000080c4430000803f0000c543000000400080c543000040400000c643000080400080c6430000a0400000c7430000c0400080c743000000000000c8430000803f0080c843000000400000c943000040400080c943000080400000ca430000a0400080ca430000c0400000cb43000000000080cb430000803f0000cc43000000400080cc43000040400000cd43000080400080cd430000a0400000ce430000c0400080ce43000000000000cf430000803f0080cf43000000400000d043000040400080d043000080400000d1430000a0400080d1430000c0400000d243000000000080d2430000803f0000d343000000400080d343000040400000d443000080400080d4430000a0400000d5430000c0400080d543000000000000d6430000803f0080d643000000400000d743000040400080d743000080400000d8430000a0400080d8430000c0400000d943000000000080d9430000803f0000da43000000400080da43000040400000db43000080400080db430000a0400000dc430000c0400080dc43000000000000dd430000803f0080dd43000000400000de43000040400080de43000080400000df430000a0400080df430000c0400000e043000000000080e0430000803f0000e143000000400080e143000040400000e243000080400080e2430000a0400000e3430000c0400080e343000000000000e4430000803f0080e443000000400000e543000040400080e543000080400000e6430000a0400080e6430000c0400000e743000000000080e7430000803f0000e843000000400080e843000040400000e943000080400080e9430000a0400000ea430000c0400080ea43000000000000eb430000803f0080eb43000000400000ec43000040400080ec43000080400000ed430000a0400080ed430000c0400000ee43000000000080ee430000803f0000ef43000000400080ef43000040400000f043000080400080f0430000a0400000f1430000c0400080f143000000000000f2430000803f0080f243000000400000f343000040400080f343000080400000f4430000a0400080f4430000c0400000f543000000000080f5430000803f0000f643000000400080f643000040400000f743000080400080f7430000a0400000f8430000c0400080f843000000000000f9430000803f0080f943000000400000fa43000040400080fa43000080400000fb430000a0400080fb430000c0400000fc43000000000080fc430000803f0000fd43000000400080fd43000040400000fe43000080400080fe430000a0400000ff430000c0400080ff4300000000000000440000803f02000051010001",
       "framingValid": true,
       "decode": { "ok": true, "error": null },
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": false, "error": "TooManyVertices" },
       "commandTrace": null,
+      "interpreterRejects": "vertex-count",
+      "canvasMethods": null,
+      "framingBoundaries": null
+    },
+    {
+      "name": "paint-non-finite-rotate",
+      "category": "paint-fault",
+      "notes": "A NaN rotation poisons the transform: the rasterizer spoils on the first mapped point, the interpreter's angle guard throws at the rotate itself.",
+      "bytesHex": "01500100010100000404000000c07f100400ffffffff2311000100002041000020410000a0400000a04002000051010001",
+      "framingValid": true,
+      "decode": { "ok": true, "error": null },
+      "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 5, 0, 0, 0, 0] },
+      "render": { "ok": false, "error": "NonFinite" },
+      "commandTrace": ["50:1", "01", "04:nan", "10:255,255,255,255", "23:F,2560,2560,1280,1280", "02", "51:1"],
+      "interpreterRejects": "angle",
+      "canvasMethods": null,
+      "framingBoundaries": null
+    },
+    {
+      "name": "paint-out-of-range-translate",
+      "category": "paint-fault",
+      "notes": "An out-of-range translation: the rasterizer rejects in device space, the interpreter rejects the raw argument.",
+      "bytesHex": "015001000101000003080000401c4700000000100400ffffffff2311000100000000000000000000a0400000a04002000051010001",
+      "framingValid": true,
+      "decode": { "ok": true, "error": null },
+      "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 5, 0, 0, 0, 0] },
+      "render": { "ok": false, "error": "CoordinateOutOfRange" },
+      "commandTrace": ["50:1", "01", "03:10240000,0", "10:255,255,255,255", "23:F,0,0,1280,1280", "02", "51:1"],
+      "interpreterRejects": "coordinate",
+      "canvasMethods": null,
+      "framingBoundaries": null
+    },
+    {
+      "name": "paint-non-finite-arc-angle",
+      "category": "paint-fault",
+      "notes": "A non-finite arc start angle: the rasterizer spoils computing the sweep, the interpreter's angle guard throws.",
+      "bytesHex": "0150010001010000110800ffffffff0000803f2514000000f0410000f041000020410000c07f0000803f02000051010001",
+      "framingValid": true,
+      "decode": { "ok": true, "error": null },
+      "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
+      "render": { "ok": false, "error": "NonFinite" },
+      "commandTrace": ["50:1", "01", "11:255,255,255,255,256", "25:7680,7680,2560,nan,256", "02", "51:1"],
+      "interpreterRejects": "angle",
+      "canvasMethods": null,
+      "framingBoundaries": null
+    },
+    {
+      "name": "paint-out-of-range-stroke-width",
+      "category": "paint-fault",
+      "notes": "A stroke width beyond the coordinate limit: the interpreter rejects the raw argument; the reference outcome pins whatever the rasterizer does with it.",
+      "bytesHex": "0150010001010000110800ffffffff00401c4720100000002041000020410000a0410000a04102000051010001",
+      "framingValid": true,
+      "decode": { "ok": true, "error": null },
+      "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
+      "render": { "ok": true, "error": null },
+      "commandTrace": ["50:1", "01", "11:255,255,255,255,10240000", "20:2560,2560,5120,5120", "02", "51:1"],
+      "interpreterRejects": "coordinate",
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -238,6 +311,7 @@
       "gate": { "verdict": "reject", "error": "Decode:BadVersion", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:Decode:BadVersion" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -251,6 +325,7 @@
       "gate": { "verdict": "reject", "error": "Decode:Truncated", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:Decode:Truncated" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -264,6 +339,7 @@
       "gate": { "verdict": "reject", "error": "Decode:BadPayload", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:Decode:BadPayload" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -277,6 +353,7 @@
       "gate": { "verdict": "reject", "error": "Decode:BadPayload", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:Decode:BadPayload" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -290,6 +367,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 5, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": [1, 5, 8, 15, 35, 54, 57, 61]
     },
@@ -303,6 +381,7 @@
       "gate": { "verdict": "reject", "error": "DuplicateLayer", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:DuplicateLayer" },
       "commandTrace": ["50:1", "01", "02", "51:1", "50:1", "01", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -316,6 +395,7 @@
       "gate": { "verdict": "reject", "error": "OutOfOrder", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:OutOfOrder" },
       "commandTrace": ["50:2", "01", "02", "51:2", "50:1", "01", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -329,6 +409,7 @@
       "gate": { "verdict": "reject", "error": "NestedLayer", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:NestedLayer" },
       "commandTrace": ["50:1", "01", "50:2", "01", "02", "51:2", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -342,6 +423,7 @@
       "gate": { "verdict": "reject", "error": "EndWithoutBegin", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:EndWithoutBegin" },
       "commandTrace": ["51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -355,6 +437,7 @@
       "gate": { "verdict": "reject", "error": "EndMismatch", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:EndMismatch" },
       "commandTrace": ["50:1", "01", "02", "51:2"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -368,6 +451,7 @@
       "gate": { "verdict": "reject", "error": "UnclosedLayer", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:UnclosedLayer" },
       "commandTrace": ["50:1", "01", "02"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -381,6 +465,7 @@
       "gate": { "verdict": "reject", "error": "UnisolatedState", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:UnisolatedState" },
       "commandTrace": ["50:1", "23:F,0,0,1024,1024", "01", "02", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -394,6 +479,7 @@
       "gate": { "verdict": "reject", "error": "UnbalancedState", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:UnbalancedState" },
       "commandTrace": ["50:1", "01", "51:1"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -407,6 +493,7 @@
       "gate": { "verdict": "reject", "error": "CommandOutsideLayer", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:CommandOutsideLayer" },
       "commandTrace": ["23:F,0,0,1024,1024"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -420,6 +507,7 @@
       "gate": { "verdict": "reject", "error": "CommandOutsideLayer", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:CommandOutsideLayer" },
       "commandTrace": ["unknown:127"],
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -433,6 +521,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 65, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -446,6 +535,7 @@
       "gate": { "verdict": "reject", "error": "StackOverCapacity", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:StackOverCapacity" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -459,6 +549,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 4094, "layersPresent": 2, "layerCommands": [0, 4096, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -472,6 +563,7 @@
       "gate": { "verdict": "reject", "error": "OverCapacity", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:OverCapacity" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -485,6 +577,7 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 1, "layersPresent": 2, "layerCommands": [0, 3, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     },
@@ -498,6 +591,7 @@
       "gate": { "verdict": "reject", "error": "SceneTooLarge", "unknownOpcodes": null, "layersPresent": null, "layerCommands": null },
       "render": { "ok": false, "error": "Layer:SceneTooLarge" },
       "commandTrace": null,
+      "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null
     }

--- a/clients/web/scene-conformance.test.mjs
+++ b/clients/web/scene-conformance.test.mjs
@@ -25,7 +25,9 @@
 import { readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import {
+  COORD_LIMIT_PX,
   InstrumentModule,
+  MAX_PATH_VERTICES,
   PANEL,
   STATE_ABI_SIZE,
   STATE_ABI_VERSION,
@@ -286,17 +288,25 @@ function conform(entry, bytes) {
     const d = traceDivergence("CommandTrace", entry.name, entry.commandTrace, decoded.trace ?? []);
     if (d) out.push(d);
   }
-  if (entry.canvasMethods) conformCanvas(entry, v, out);
+  if (entry.canvasMethods || entry.interpreterRejects) conformCanvas(entry, v, out);
   return out;
 }
 
+// When the golden predicts a raw-argument rejection (interpreterRejects), the
+// interpreter MUST throw before completing the scene — a clean pass means the
+// browser-side guard is missing and malformed geometry would reach Canvas.
 function conformCanvas(entry, v, out) {
   const ctx = new RecordingCtx();
   let unknown;
   try {
     unknown = interpretScene(v, ctx, null);
   } catch (error) {
+    if (entry.interpreterRejects) return;
     out.push(DIVERGENCE("InterpretThrew", entry.name, String(error)));
+    return;
+  }
+  if (entry.interpreterRejects) {
+    out.push(DIVERGENCE("GuardMissing", entry.name, `expected ${entry.interpreterRejects} rejection, scene painted`));
     return;
   }
   if (unknown !== entry.gate.unknownOpcodes) {
@@ -311,7 +321,7 @@ function conformCanvas(entry, v, out) {
 const golden = JSON.parse(
   readFileSync(new URL("./scene-conformance-corpus.json", import.meta.url), "utf8"),
 );
-check("golden schema version is understood", golden.schemaVersion === 1);
+check("golden schema version is understood", golden.schemaVersion === 2);
 check("browser backend is declared SIM / NOT FOR FLIGHT", /SIM \/ NOT FOR FLIGHT/.test(golden.simOnly));
 check(
   "budgets are the pinned resource bounds",
@@ -319,7 +329,9 @@ check(
     golden.budgets.maxLayerCommands === 4096 &&
     golden.budgets.maxStackDepth === 32 &&
     golden.budgets.maxPolygonVertices === 512 &&
-    golden.budgets.maxDimension === 4096,
+    golden.budgets.maxDimension === 4096 &&
+    golden.budgets.maxPolygonVertices === MAX_PATH_VERTICES &&
+    golden.budgets.coordLimitPx === COORD_LIMIT_PX,
 );
 
 const entries = golden.entries.map((e) => ({ entry: e, bytes: entryBytes(e) }));

--- a/crates/pilotage-instrument-raster/src/curve.rs
+++ b/crates/pilotage-instrument-raster/src/curve.rs
@@ -82,6 +82,7 @@ fn paint(
     for py in region.top..region.bottom {
         let dy = (py as f32 + 0.5) - disc.cy;
         for px in region.left..region.right {
+            surface.count_sample();
             let dx = (px as f32 + 0.5) - disc.cx;
             let dist = libm::sqrtf(dx * dx + dy * dy);
             if covered(dist, dx, dy) {

--- a/crates/pilotage-instrument-raster/src/lib.rs
+++ b/crates/pilotage-instrument-raster/src/lib.rs
@@ -83,7 +83,7 @@ mod transform;
 
 pub use error::RasterError;
 pub use raster::render;
-pub use report::{FrameId, FramebufferDims, RenderReport, RenderStatus};
+pub use report::{FrameId, FramebufferDims, RenderReport, RenderStatus, RenderWork};
 
 /// Largest framebuffer dimension accepted per axis, in pixels.
 pub const MAX_DIMENSION: u32 = 4096;

--- a/crates/pilotage-instrument-raster/src/paint.rs
+++ b/crates/pilotage-instrument-raster/src/paint.rs
@@ -27,6 +27,7 @@ pub(crate) fn fill_polygon(
     for py in region.top..region.bottom {
         let cy = Fx::pixel_center(py).raw();
         for px in region.left..region.right {
+            surface.count_sample();
             let cx = Fx::pixel_center(px).raw();
             if winding_nonzero(verts, cx, cy) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/raster.rs
+++ b/crates/pilotage-instrument-raster/src/raster.rs
@@ -42,6 +42,7 @@ pub fn render(
             frame,
             unknown_opcodes,
             layers_present,
+            work: surface.work(),
         }),
         Err(error) => {
             surface.spoil();

--- a/crates/pilotage-instrument-raster/src/raster/tests.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests.rs
@@ -8,6 +8,7 @@ use crate::{FrameId, FramebufferDims, RasterError, RenderReport, RenderStatus, r
 
 mod conformance;
 mod frame_hashes;
+mod work_budget;
 
 const BLACK: Rgba8 = Rgba8::rgb(0, 0, 0);
 const WHITE: Rgba8 = Rgba8::rgb(255, 255, 255);

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance.rs
@@ -19,6 +19,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 mod corpus;
+mod guards;
 mod manifest;
 mod outcomes;
 

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/builders.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/builders.rs
@@ -217,7 +217,7 @@ pub(super) fn paint_fault_entries(out: &mut Vec<CorpusEntry>) {
     out.push(raw(
         "paint-non-finite",
         "paint-fault",
-        Some("Gate accepts; the software rasterizer spoils on a non-finite coordinate while Canvas2D would paint it (SIM/NOT FOR FLIGHT)."),
+        Some("Gate accepts; the software rasterizer spoils on a non-finite coordinate and the browser interpreter's raw-argument guard throws before Canvas2D sees it."),
         in_layer(LayerId::Attitude, |w| {
             w.fill_color(WHITE).expect("fill");
             w.rect(PaintMode::Fill, f32::NAN, 0.0, 10.0, 10.0).expect("rect");
@@ -227,7 +227,7 @@ pub(super) fn paint_fault_entries(out: &mut Vec<CorpusEntry>) {
     out.push(raw(
         "paint-out-of-range",
         "paint-fault",
-        Some("Gate accepts; the software rasterizer spoils on an out-of-range device coordinate while Canvas2D would paint it."),
+        Some("Gate accepts; the software rasterizer spoils on an out-of-range device coordinate and the interpreter's raw-argument guard rejects the same value."),
         in_layer(LayerId::Attitude, |w| {
             w.fill_color(WHITE).expect("fill");
             w.rect(PaintMode::Fill, 40000.0, 0.0, 10.0, 10.0).expect("rect");
@@ -237,13 +237,55 @@ pub(super) fn paint_fault_entries(out: &mut Vec<CorpusEntry>) {
     out.push(raw(
         "paint-too-many-vertices",
         "paint-fault",
-        Some("Gate accepts; the software rasterizer enforces its per-shape vertex budget while Canvas2D has none."),
+        Some("Gate accepts; both backends enforce the shared per-shape vertex budget — the rasterizer via its fixed buffer, the interpreter via its path guard."),
         in_layer(LayerId::Attitude, |w| {
             w.stroke(WHITE, 1.0).expect("stroke");
             let pts: Vec<[f32; 2]> = (0..513).map(|i| [i as f32, (i % 7) as f32]).collect();
             w.polyline(&pts).expect("polyline");
         }),
         false,
+    ));
+    out.push(raw(
+        "paint-non-finite-rotate",
+        "paint-fault",
+        Some("A NaN rotation poisons the transform: the rasterizer spoils on the first mapped point, the interpreter's angle guard throws at the rotate itself."),
+        in_layer(LayerId::Attitude, |w| {
+            w.rotate(f32::NAN).expect("rotate");
+            w.fill_color(WHITE).expect("fill");
+            w.rect(PaintMode::Fill, 10.0, 10.0, 5.0, 5.0).expect("rect");
+        }),
+        true,
+    ));
+    out.push(raw(
+        "paint-out-of-range-translate",
+        "paint-fault",
+        Some("An out-of-range translation: the rasterizer rejects in device space, the interpreter rejects the raw argument."),
+        in_layer(LayerId::Attitude, |w| {
+            w.translate(40000.0, 0.0).expect("translate");
+            w.fill_color(WHITE).expect("fill");
+            w.rect(PaintMode::Fill, 0.0, 0.0, 5.0, 5.0).expect("rect");
+        }),
+        true,
+    ));
+    out.push(raw(
+        "paint-non-finite-arc-angle",
+        "paint-fault",
+        Some("A non-finite arc start angle: the rasterizer spoils computing the sweep, the interpreter's angle guard throws."),
+        in_layer(LayerId::Attitude, |w| {
+            w.stroke(WHITE, 1.0).expect("stroke");
+            w.arc(30.0, 30.0, 10.0, f32::NAN, 1.0).expect("arc");
+        }),
+        true,
+    ));
+    out.push(raw(
+        "paint-out-of-range-stroke-width",
+        "paint-fault",
+        Some("A stroke width beyond the coordinate limit: the interpreter rejects the raw argument; the reference outcome pins whatever the rasterizer does with it."),
+        in_layer(LayerId::Attitude, |w| {
+            w.stroke(WHITE, 40000.0).expect("stroke");
+            w.line(10.0, 10.0, 20.0, 20.0).expect("line");
+        }),
+        true,
     ));
 }
 

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/guards.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/guards.rs
@@ -1,0 +1,88 @@
+//! Prediction of the browser interpreter's raw-argument guards.
+//!
+//! `instruments.js` refuses to hand Canvas2D non-finite or out-of-range
+//! geometry: `interpretScene` guards every float that would become Canvas
+//! geometry and every path against the shared vertex budget, throwing before
+//! the drawing call. This module mirrors that rule command for command so the
+//! golden pins exactly where the browser must throw (`interpreterRejects`),
+//! and the browser test fails with `GuardMissing` if a predicted rejection
+//! paints instead.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::string::{String, ToString};
+
+use pilotage_instrument_scene::{Cmd, SceneCmds};
+
+/// Mirrors the browser interpreter's raw-argument guards: every float that
+/// would reach Canvas geometry must be finite, coordinates and sizes must
+/// satisfy |v| <= COORD_LIMIT_PX, arc angles need only be finite, and a path
+/// may carry at most the shared vertex budget. Evaluation order matches
+/// `interpretScene` so the first rejection reason is the one the browser
+/// reports. This is deliberately a RAW-argument rule: the reference
+/// rasterizer range-checks in device space after the transform, which the
+/// interpreter cannot reproduce without becoming a rasterizer itself.
+pub(super) fn interpreter_rejects(bytes: &[u8]) -> Option<String> {
+    let cmds = SceneCmds::new(bytes).ok()?;
+    for item in cmds {
+        let reason = command_rejection(&item.ok()?);
+        if reason.is_some() {
+            return reason;
+        }
+    }
+    None
+}
+
+fn coord_ok(v: f32) -> bool {
+    let d = v as f64;
+    d.is_finite() && d.abs() <= crate::fixed::COORD_LIMIT_PX as f64
+}
+
+fn coords_ok(vs: &[f32]) -> bool {
+    vs.iter().all(|&v| coord_ok(v))
+}
+
+fn command_rejection(cmd: &Cmd<'_>) -> Option<String> {
+    let coordinate = || Some("coordinate".to_string());
+    match cmd {
+        Cmd::Translate { x, y } if !coords_ok(&[*x, *y]) => coordinate(),
+        Cmd::Rotate { radians } if !(*radians as f64).is_finite() => Some("angle".to_string()),
+        Cmd::Stroke { width, .. } if !coord_ok(*width) => coordinate(),
+        Cmd::Line { x1, y1, x2, y2 } if !coords_ok(&[*x1, *y1, *x2, *y2]) => coordinate(),
+        Cmd::Polyline { points } | Cmd::Polygon { points, .. } => {
+            if points.iter().count() > crate::MAX_POLYGON_VERTICES {
+                return Some("vertex-count".to_string());
+            }
+            for [x, y] in points.iter() {
+                if !coords_ok(&[x, y]) {
+                    return coordinate();
+                }
+            }
+            None
+        }
+        Cmd::Rect { x, y, w, h, .. } | Cmd::ClipRect { x, y, w, h }
+            if !coords_ok(&[*x, *y, *w, *h]) =>
+        {
+            coordinate()
+        }
+        Cmd::Circle { cx, cy, r, .. } if !coords_ok(&[*cx, *cy, *r]) => coordinate(),
+        Cmd::Arc {
+            cx,
+            cy,
+            r,
+            start,
+            sweep,
+        } => {
+            if !coords_ok(&[*cx, *cy, *r]) {
+                return coordinate();
+            }
+            let (s, e) = (*start as f64, *start as f64 + *sweep as f64);
+            if !s.is_finite() || !e.is_finite() {
+                return Some("angle".to_string());
+            }
+            None
+        }
+        Cmd::Text { x, y, size, .. } if !coords_ok(&[*x, *y, *size]) => coordinate(),
+        _ => None,
+    }
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/manifest.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/manifest.rs
@@ -21,9 +21,11 @@ use super::corpus::CorpusEntry;
 use super::outcomes::{Outcome, outcome_of};
 use crate::{MAX_DIMENSION, MAX_POLYGON_VERTICES, WORST_CASE_FRAME_BYTES};
 
-const SCHEMA_VERSION: u32 = 1;
-const CORPUS_VERSION: u32 = 1;
-const REVIEW_REASON: &str = "Initial REN-04 backend-conformance corpus.";
+const SCHEMA_VERSION: u32 = 2;
+const CORPUS_VERSION: u32 = 2;
+const REVIEW_REASON: &str = "Add interpreterRejects: the browser interpreter now enforces raw-argument \
+guards (finite floats, |coordinate| <= coordLimitPx, path vertex budget) and the golden pins where it \
+must throw; new paint-fault cases cover the rotate/translate/arc/stroke-width guard paths.";
 const REVIEW_APPROVED_BY: &str =
     "REN-04 owner; regenerated goldens require human review and are never rewritten by CI.";
 
@@ -94,6 +96,10 @@ fn budget_lines(lines: &mut Vec<String>) {
         "    \"maxPolygonVertices\": {MAX_POLYGON_VERTICES},"
     ));
     lines.push(std::format!(
+        "    \"coordLimitPx\": {},",
+        crate::fixed::COORD_LIMIT_PX as i64
+    ));
+    lines.push(std::format!(
         "    \"worstCaseFrameBytes\": {WORST_CASE_FRAME_BYTES}"
     ));
     lines.push("  },".to_string());
@@ -124,6 +130,10 @@ fn entry_block(entry: &CorpusEntry, o: &Outcome) -> String {
     lines.push(std::format!(
         "      \"commandTrace\": {},",
         opt_str_array(&o.command_trace)
+    ));
+    lines.push(std::format!(
+        "      \"interpreterRejects\": {},",
+        opt_owned(&o.interpreter_rejects)
     ));
     lines.push(std::format!(
         "      \"canvasMethods\": {},",

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/outcomes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/outcomes.rs
@@ -17,6 +17,7 @@ use pilotage_instrument_scene::{
 };
 
 use super::corpus::CorpusEntry;
+use super::guards::interpreter_rejects;
 use crate::{FrameId, FramebufferDims, RasterError, render};
 
 pub(super) struct Outcome {
@@ -31,6 +32,7 @@ pub(super) struct Outcome {
     pub(super) layer_commands: Option<[u16; 6]>,
     pub(super) render_ok: bool,
     pub(super) render_error: Option<String>,
+    pub(super) interpreter_rejects: Option<String>,
     pub(super) canvas_methods: Option<Vec<String>>,
     pub(super) framing_boundaries: Option<Vec<usize>>,
 }
@@ -49,7 +51,16 @@ pub(super) fn outcome_of(entry: &CorpusEntry) -> Outcome {
     let (decode_ok, decode_error, full_trace) = decode(bytes);
     let g = gate(bytes);
     let (render_ok, render_error) = render_outcome(bytes);
-    let canvas = entry.trace && g.verdict == "accept" && decode_ok && entry.category != "text";
+    let rejects = if g.verdict == "accept" && decode_ok && entry.category != "text" {
+        interpreter_rejects(bytes)
+    } else {
+        None
+    };
+    let canvas = entry.trace
+        && g.verdict == "accept"
+        && decode_ok
+        && entry.category != "text"
+        && rejects.is_none();
     Outcome {
         framing_valid: framing_valid(bytes),
         decode_ok,
@@ -67,6 +78,7 @@ pub(super) fn outcome_of(entry: &CorpusEntry) -> Outcome {
         } else {
             None
         },
+        interpreter_rejects: rejects,
         framing_boundaries: if entry.sweep {
             Some(boundaries(bytes))
         } else {

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -26,7 +26,7 @@ const HSI_SHA256: &str = "6edcbc92d936a690a68f0632d2ec20b158d54e59cc9fde6640feef
 /// (defaults must not be relied on), and the quaternion's squared
 /// component sum is exactly 1.0 in f32, so a validating resolver's
 /// renormalization divides by exactly 1.0 and changes nothing.
-fn demo_state() -> AircraftState {
+pub(super) fn demo_state() -> AircraftState {
     AircraftState {
         attitude: Stamped {
             data: Some(Attitude {
@@ -87,7 +87,7 @@ fn demo_state() -> AircraftState {
     }
 }
 
-fn encode(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
+pub(super) fn encode(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
     let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
     let mut w = SceneWriter::new(&mut buf).expect("writer");
     build(&mut w);

--- a/crates/pilotage-instrument-raster/src/raster/tests/work_budget.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/work_budget.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! CI gate on the deterministic work counters: the demo panel fixtures must
+//! fit inside [`RenderWork::BUDGET`], and the counters must be a pure
+//! function of scene bytes and dimensions.
+
+use pilotage_instrument_panels::{PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+use pilotage_instrument_state::{FreshnessPolicy, resolve};
+use std::vec::Vec;
+
+use super::frame_hashes::{demo_state, encode};
+use crate::{FrameId, FramebufferDims, RenderWork, render};
+
+fn work_for(scene: &[u8]) -> RenderWork {
+    let (w, h) = (PANEL_W as u32, PANEL_H as u32);
+    let mut fb = std::vec![0u8; (w * h * 4) as usize];
+    let report = render(
+        scene,
+        &mut fb,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect("panel scene renders");
+    report.work
+}
+
+fn panel_scenes() -> Vec<(&'static str, Vec<u8>)> {
+    let data = resolve(&demo_state(), &FreshnessPolicy::default());
+    std::vec![
+        (
+            "PFD",
+            encode(|w| draw_pfd(&data, &PfdConfig::default(), w).expect("pfd")),
+        ),
+        ("HSI", encode(|w| draw_hsi(&data, w).expect("hsi"))),
+    ]
+}
+
+#[test]
+fn panel_fixtures_fit_within_work_budget() {
+    for (name, scene) in panel_scenes() {
+        let work = work_for(&scene);
+        assert!(
+            work.within(&RenderWork::BUDGET),
+            "{name} exceeds the engineering work budget: \
+             {work:?} vs {:?} — either the scene grew pathologically or a \
+             primitive's bounded region loop regressed; investigate before \
+             raising the budget",
+            RenderWork::BUDGET,
+        );
+    }
+}
+
+#[test]
+fn work_counters_are_deterministic_and_nonzero() {
+    for (name, scene) in panel_scenes() {
+        let first = work_for(&scene);
+        let second = work_for(&scene);
+        assert_eq!(first, second, "{name} work counters are reproducible");
+        assert!(
+            first.coverage_samples > 0 && first.composites > 0,
+            "{name} paints content, so both counters must advance"
+        );
+        assert!(
+            first.composites <= first.coverage_samples,
+            "{name}: every composite follows a coverage sample"
+        );
+    }
+}

--- a/crates/pilotage-instrument-raster/src/report.rs
+++ b/crates/pilotage-instrument-raster/src/report.rs
@@ -63,4 +63,43 @@ pub struct RenderReport {
     pub unknown_opcodes: u32,
     /// Bitset of layers present, bit `i` for the layer with discriminant `i`.
     pub layers_present: u8,
+    /// Deterministic work performed producing this frame.
+    pub work: RenderWork,
+}
+
+/// The target-independent work metric for one render: a pure function
+/// of scene bytes and framebuffer dimensions, identical on every
+/// platform, so engineering budgets can gate it in CI long before any
+/// display hardware exists to time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RenderWork {
+    /// Pixel-center coverage evaluations across all primitives.
+    pub coverage_samples: u64,
+    /// Source-over composites applied.
+    pub composites: u64,
+}
+
+impl RenderWork {
+    /// Engineering work budget for one panel frame.
+    ///
+    /// The fully populated PFD demo fixture — every band painting content —
+    /// measures ~547k coverage samples and ~434k composites on the 480x360
+    /// panel (~3.2 samples and ~2.5 composites per output pixel). The budget
+    /// grants 2x headroom over that worst measured fixture, rounded up, so
+    /// scenes can grow denser without churning the constant while per-frame
+    /// work stays bounded at ~6.4 samples per pixel. Because the counters
+    /// are a pure function of scene bytes and dimensions, exceeding this
+    /// budget is a deterministic CI failure on every platform, not a timing
+    /// flake. Wall-clock budgets are added when display hardware is
+    /// selected; until then this operation count is the portable proxy.
+    pub const BUDGET: RenderWork = RenderWork {
+        coverage_samples: 1_100_000,
+        composites: 900_000,
+    };
+
+    /// Whether this work fits inside `budget` on both axes.
+    #[must_use]
+    pub const fn within(&self, budget: &RenderWork) -> bool {
+        self.coverage_samples <= budget.coverage_samples && self.composites <= budget.composites
+    }
 }

--- a/crates/pilotage-instrument-raster/src/stroke.rs
+++ b/crates/pilotage-instrument-raster/src/stroke.rs
@@ -38,6 +38,7 @@ pub(crate) fn stroke_path(
     for py in region.top..region.bottom {
         let cy = py as f32 + 0.5;
         for px in region.left..region.right {
+            surface.count_sample();
             let cx = px as f32 + 0.5;
             if covered(verts, seg_count, cx, cy, hw) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/surface.rs
+++ b/crates/pilotage-instrument-raster/src/surface.rs
@@ -46,6 +46,12 @@ pub(crate) struct Surface<'a> {
     width: i32,
     height: i32,
     stride: usize,
+    /// Coverage evaluations performed (one per pixel-center test in a
+    /// primitive's bounded region loop). A pure function of scene and
+    /// dimensions, so it doubles as the target-independent work metric.
+    coverage_samples: u64,
+    /// Source-over composites actually applied.
+    composites: u64,
 }
 
 impl<'a> Surface<'a> {
@@ -82,6 +88,8 @@ impl<'a> Surface<'a> {
             width: dims.width as i32,
             height: dims.height as i32,
             stride,
+            coverage_samples: 0,
+            composites: 0,
         })
     }
 
@@ -114,8 +122,22 @@ impl<'a> Surface<'a> {
         }
     }
 
+    /// Counts one pixel-center coverage evaluation.
+    pub(crate) fn count_sample(&mut self) {
+        self.coverage_samples = self.coverage_samples.wrapping_add(1);
+    }
+
+    /// The work performed so far: coverage evaluations and composites.
+    pub(crate) fn work(&self) -> crate::report::RenderWork {
+        crate::report::RenderWork {
+            coverage_samples: self.coverage_samples,
+            composites: self.composites,
+        }
+    }
+
     /// Composites one straight-alpha sRGB pixel with source-over.
     pub(crate) fn composite(&mut self, x: i32, y: i32, color: [u8; 4]) {
+        self.composites = self.composites.wrapping_add(1);
         let sa = color[3] as u32;
         if sa == 0 {
             return;

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -39,7 +39,10 @@ the whole frame before anything becomes visible.
 | UTF-8 bytes per text run | 250 | `MAX_TEXT_BYTES` |
 | Framebuffer dimension (per axis) | 4096 px | `MAX_DIMENSION` |
 | Vertices per polyline/polygon command | 512 | `MAX_POLYGON_VERTICES` |
+| Representable coordinate magnitude | 32767 px | `COORD_LIMIT_PX` (Rust + JS) |
 | Worst-case frame size | 67108864 bytes | `WORST_CASE_FRAME_BYTES` |
+| Coverage samples per frame | 1100000 | `RenderWork::BUDGET` |
+| Composites per frame | 900000 | `RenderWork::BUDGET` |
 
 The corpus exercises the scene-byte, per-layer-command, and stack-depth budgets
 at and one past their limits (`resource_budgets_flip_verdict_at_their_limits`),
@@ -55,19 +58,32 @@ constant.
 
 The reference rasterizer is straight-line over the scene and framebuffer with no
 I/O and only documented-bounded loops (see the crate docs on
-`pilotage-instrument-raster::render`), so a target-independent worst-case
-execution time is a sum of bounded step counts:
+`pilotage-instrument-raster::render`), so its work is a pure function of scene
+bytes and framebuffer dimensions. That work is now *counted*, not just bounded:
+every `RenderReport` carries a `RenderWork` record with
 
-- command dispatches: at most `MAX_LAYER_COMMANDS` times the layer count;
-- per-pixel coverage tests: at most framebuffer pixels times a shape's edges.
+- `coverage_samples` — pixel-center coverage evaluations across all primitives
+  (each bounded region loop counts one evaluation per pixel it visits);
+- `composites` — source-over composites actually applied.
 
-A step-counting harness can wrap the coverage predicate and command dispatch
-without changing output. The WCET for a specific target is that step-count sum
-multiplied by the selected target's per-step cycle bound; measured cycle costs
-and the final WCET wait for hardware selection and are out of scope here. Frame
-time is one of the gated budgets: a target that cannot meet its frame deadline
-fails, and the browser watchdog (`PanelHealth`, simulator-only) latches a stalled
-panel as `LIVENESS` past its deadline.
+Because the counters are deterministic and platform-independent, an engineering
+work budget gates them in CI today, before any display hardware exists to time.
+`RenderWork::BUDGET` (1.1M coverage samples, 900k composites per frame) is
+pinned at 2x the worst measured panel fixture — the fully populated PFD demo
+scene measures ~547k samples / ~434k composites on the 480x360 panel, about 3.2
+samples per output pixel — so scenes can grow denser without churning the
+constant while per-frame work stays bounded at ~6.4 samples per pixel. The gate
+is `panel_fixtures_fit_within_work_budget` (with
+`work_counters_are_deterministic_and_nonzero` pinning purity), and exceeding the
+budget is a hard CI failure with instructions to investigate the scene or the
+region loops before raising the constant.
+
+The WCET for a specific target is the counted work multiplied by the selected
+target's per-operation cycle bound; measured cycle costs and the final WCET wait
+for hardware selection and are out of scope here. Frame time is one of the gated
+budgets: a target that cannot meet its frame deadline fails, and the browser
+watchdog (`PanelHealth`, simulator-only) latches a stalled panel as `LIVENESS`
+past its deadline.
 
 ## The conformance corpus
 
@@ -90,7 +106,7 @@ drift on both sides.
 | Malformed / truncated | bad version, truncated tail, malformed known payload, unknown layer id, full truncation sweep |
 | Layer structure | duplicate, out-of-order, nested, end-without-begin, end-mismatch, unclosed, command-outside-layer, unisolated state, unbalanced state |
 | Resource exhaustion | scene bytes, per-layer commands, and stack depth — each at and one past the limit |
-| Paint fail-safe | non-finite coordinate, out-of-range coordinate, over-vertex-budget shape |
+| Paint fail-safe | non-finite coordinate, out-of-range coordinate, over-vertex-budget shape, non-finite rotation, out-of-range translation, non-finite arc angle, out-of-range stroke width |
 
 Budget-boundary streams that would be megabytes of hex are carried as a compact
 `generator` descriptor (`fill_bytes`, `repeat_unknown`, `nest_saves`) that both
@@ -111,9 +127,13 @@ only runs on wasm-generated scenes. So the golden pins, per case:
   per-layer command counts) — the reference layer-gate result, cross-checked on
   the Rust side and used as the reference verdict;
 - `render` (ok + typed error class) — the reference rasterizer outcome;
+- `interpreterRejects` — where the browser interpreter's raw-argument guards
+  must throw (`coordinate`, `angle`, or `vertex-count`), predicted by the
+  reference generator with the same rule and evaluation order;
 - `canvasMethods` — the sequence of Canvas draw calls the interpreter must issue,
   captured from a command-recording canvas and compared as opcode + quantized
-  args.
+  args (omitted when `interpreterRejects` is set: the interpreter never reaches
+  those calls).
 
 Canonicalization is Q8.8: `floor(v * 256)`, with `nan`/`inf`/`-inf` sentinels.
 Comparisons are exact — never tolerance-fudged.
@@ -124,23 +144,42 @@ Differences surface as typed conformance failures, never numeric tolerances:
 `FramingMismatch`, `DecodeVerdictMismatch`, `DecodeClassMismatch`,
 `CommandTraceDivergence{index}`, `CommandTraceLengthMismatch`,
 `UnknownOpcodeCountMismatch`, `CanvasDivergence{index}`, `CanvasLengthMismatch`,
-`InterpretThrew`. Any divergence fails the browser test with the case name and
-the differing index.
+`InterpretThrew`, `GuardMissing`. Any divergence fails the browser test with the
+case name and the differing index. `GuardMissing` is the fail-closed direction:
+a case the golden marks `interpreterRejects` that the interpreter paints anyway
+means a browser-side guard has been weakened or removed.
 
-### Documented intentional divergences
+### Fail-closed geometry guards on both backends
 
-Where the two backends legitimately differ, the golden records both outcomes and
-each side checks its own — these are not bugs:
+Canvas2D itself has no fail-safe for non-finite or absurd geometry — it will
+happily accept a NaN rectangle or a ten-million-pixel translation. The browser
+interpreter therefore does not let such arguments reach Canvas: `interpretScene`
+guards every float that would become Canvas geometry (finite, and
+`|v| <= COORD_LIMIT_PX` = 32767 for coordinates, sizes, radii, and stroke
+widths; finite for rotation and arc angles) and every path against the shared
+vertex budget (`MAX_PATH_VERTICES` = 512, the rasterizer's
+`MAX_POLYGON_VERTICES`). A violation throws; `renderPanel` converts the throw to
+`PAINT_FAILED` and discards the back buffer, so nothing partial reaches the
+visible frame — the same commit-or-spoil outcome as the rasterizer.
 
-- **Non-finite and out-of-range coordinates**, and **shapes past the vertex
-  budget**: the software rasterizer spoils the frame (typed `NonFinite`,
-  `CoordinateOutOfRange`, `TooManyVertices`); Canvas2D has no equivalent
-  fail-safe and paints them. The browser is SIM / NOT FOR FLIGHT; a flight-class
-  backend must add these guards.
+One asymmetry remains, and it is a *rule* difference, not a missing guard: the
+software rasterizer range-checks coordinates in **device space after the
+transform** (that is where Q8.8 quantization happens), while the interpreter
+rejects at the **raw-argument level** before Canvas applies the transform. The
+raw rule cannot be transform-exact without reimplementing the rasterizer's
+transform pipeline. For every scene the project encoder can produce this makes
+no difference — panel geometry never relies on a transform to bring an
+out-of-range raw coordinate back into range — and the corpus generator predicts
+`interpreterRejects` with exactly the raw rule, so the golden pins the
+interpreter's actual behavior, not an aspiration. A scene that deliberately
+paired out-of-range raw arguments with a compensating transform would be
+rejected by the interpreter and painted by the rasterizer; the conformance claim
+for the browser backend is accordingly scoped to encoder-producible scenes, and
+the browser remains SIM / NOT FOR FLIGHT.
 
 No unexpected divergence was found between the backends at the levels they can be
-compared: framing, decode, unknown-opcode counting, and the interpreter's
-opcode-to-Canvas mapping all agree across the corpus.
+compared: framing, decode, unknown-opcode counting, guard placement, and the
+interpreter's opcode-to-Canvas mapping all agree across the corpus.
 
 ### Golden review policy
 


### PR DESCRIPTION
Delivers the two remaining engineering follow-ups recorded on #30 after the conformance foundation merged in #57. **SIM / NOT FOR FLIGHT** — the browser backend remains simulator-only; this PR narrows, not closes, the gap to a flight-class backend.

## 1. Deterministic operation counter + CI-gated work budget

The reference rasterizer's work is now *counted*, not just bounded:

- `Surface` counts **pixel-center coverage evaluations** (one per pixel visited by any primitive's bounded region loop — `paint.rs` fill, `stroke.rs` capsule, `curve.rs` disc/ring) and **source-over composites** (`surface.rs::composite`). Counters use `wrapping_add` per workspace convention.
- Every `RenderReport` carries the `RenderWork` record; it is a pure function of scene bytes and framebuffer dimensions — identical on every platform, so it gates in CI today without display hardware.
- **Budget with rationale** (`RenderWork::BUDGET`, doc comment on the constant): the fully populated PFD demo fixture measures **546,846 samples / 433,412 composites** on the 480x360 panel (~3.2 samples per output pixel); the budget pins **1.1M samples / 900k composites** — 2x the worst measured fixture, ~6.4 samples per pixel — so scenes can grow denser without churning the constant while per-frame work stays bounded.
- **CI gate**: `panel_fixtures_fit_within_work_budget` fails the build when either axis is exceeded, with instructions to investigate the scene or region loops before raising the budget; `work_counters_are_deterministic_and_nonzero` pins reproducibility, non-triviality, and the composites ≤ samples invariant.
- **Target timing artifacts stay deferred to hardware selection**, as agreed on #30: WCET = counted work x the selected target's per-operation cycle bound. The counter is the portable factor; the cycle bound is the hardware factor.

## 2. Canvas asymmetry reconciled: equivalent interpreter guards

#57 documented that malformed/non-finite geometry reaching `interpretScene` would be handed to Canvas2D, which has no fail-safe. Both remedies the review offered are now in place — guards added *and* the residual claim explicitly scoped:

- **Guards** (`clients/web/instruments.js`): every float that would become Canvas geometry must be finite with `|v| <= COORD_LIMIT_PX` (32767 — the rasterizer's Q8.8 representable limit) — coordinates, sizes, radii, stroke widths; rotation and arc angles must be finite; paths respect `MAX_PATH_VERTICES` (512 — the rasterizer's `MAX_POLYGON_VERTICES`). A violation **throws**; `renderPanel` converts it to `PAINT_FAILED` and discards the back buffer — the same commit-or-spoil outcome as the rasterizer's `spoil()`.
- **The golden pins the guards** (corpus schema v2): the Rust generator predicts rejections with the same rule and evaluation order (`conformance/guards.rs` → `interpreterRejects: coordinate|angle|vertex-count`), and the browser suite adds the **`GuardMissing`** divergence — a case the golden marks as rejected that paints anyway fails CI. All three pre-existing paint-fault cases plus **four new cases** (non-finite rotate, out-of-range translate, non-finite arc angle, out-of-range stroke width) verify the throw on the JS side; `budgets.coordLimitPx` in the golden binds the Rust and JS constants together.
- **Honest residual, documented**: the rasterizer range-checks in *device space after the transform* (where Q8.8 quantization lives); the interpreter rejects at the *raw-argument level*. For every encoder-producible scene the two agree — panel geometry never relies on a transform to bring an out-of-range raw value back in range — and `docs/instruments/renderer-verification.md` now states the rule difference and scopes the browser conformance claim to encoder-producible scenes.

## Evidence map

| Criterion (#30 follow-up list) | Evidence |
|---|---|
| Deterministic operation/work counter | `RenderWork` on every `RenderReport`; `work_counters_are_deterministic_and_nonzero` |
| Conservative budgets with rationale | `RenderWork::BUDGET` doc comment (measured 547k/434k → 2x headroom) |
| CI fails on budget exceedance | `panel_fixtures_fit_within_work_budget` (runs in the existing `cargo test` gate) |
| Target timing artifacts | Deferred to hardware selection (documented in renderer-verification.md) |
| Canvas asymmetry reconciled | Raw-argument guards + `interpreterRejects`/`GuardMissing` in corpus v2 + scoped claim in docs |

## Verification

- `cargo fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test --all-targets` (29 suites), `cargo doc -D missing_docs -D broken_intra_doc_links`, `cargo build --release`, structure gate: all pass locally.
- no_std proof: `cargo check --target thumbv7em-none-eabihf` across the instrument family passes.
- All six node suites pass, including the regenerated 41-case corpus (7 guard cases throw exactly where predicted; 0 divergences) and 7 new direct guard unit tests with at-limit/past-limit boundary pairs.
- Golden regenerated via the reviewed protocol: `schemaVersion` 2, `corpusVersion` 2, new `review.reason`; CI still only compares, never rewrites.

Refs #30 (stays open per review disposition until hardware timing artifacts exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)