### PR TITLE
ALR-01 integration: every panel consumes the one alert manager output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,9 @@ name = "pilotage-instrument-panels"
 version = "0.1.0"
 dependencies = [
  "libm",
+ "pilotage-alerts",
  "pilotage-frames",
+ "pilotage-instrument-glyphs",
  "pilotage-instrument-scene",
  "pilotage-instrument-state",
 ]
@@ -1056,6 +1058,7 @@ dependencies = [
 name = "pilotage-instruments-web"
 version = "0.1.0"
 dependencies = [
+ "pilotage-alerts",
  "pilotage-instrument-glyphs",
  "pilotage-instrument-panels",
  "pilotage-instrument-scene",

--- a/clients/web-instruments/Cargo.toml
+++ b/clients/web-instruments/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
+pilotage-alerts = { workspace = true }
 pilotage-instrument-glyphs = { workspace = true }
 pilotage-instrument-panels = { workspace = true }
 pilotage-instrument-scene = { workspace = true }

--- a/clients/web-instruments/src/alert_tests.rs
+++ b/clients/web-instruments/src/alert_tests.rs
@@ -1,0 +1,119 @@
+//! ALR-01 integration proofs: one manager output feeds every panel, and
+//! primary-data flags never depend on the alerting path.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_instrument_scene::SceneCmds;
+use pilotage_instrument_state::{AircraftState, Stamped};
+
+use crate::exports::InstrumentRuntime;
+use crate::render_status::RenderStatus;
+use crate::tests::{attitude_state, encoded_state_block, unpack};
+
+fn failed_alt_state() -> AircraftState {
+    let mut state = attitude_state();
+    state.kinematics = Stamped {
+        data: Some(pilotage_instrument_state::Kinematics {
+            pos_ned_m: [0.0, 0.0, -300.0],
+            vel_ned_mps: [0.0; 3],
+        }),
+        age_ms: Some(10.0),
+    };
+    state.valid.position = false;
+    state.valid.velocity = false;
+    state
+}
+
+fn committed_scene_texts(rt: &InstrumentRuntime, len: usize) -> Vec<String> {
+    let runtime = rt.runtime.as_ref().expect("initialized");
+    let scene = &runtime.scene[..len];
+    SceneCmds::new(scene)
+        .expect("valid scene")
+        .map(|c| c.expect("valid command"))
+        .filter_map(|c| match c {
+            pilotage_instrument_scene::Cmd::Text { text, .. } => Some(String::from(text)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn stack_only(texts: &[String]) -> Vec<String> {
+    const STACK: &[&str] = &["ALT SRC", "NAV SRC", "TRN RATE", "ALRT FAIL", "MORE"];
+    texts
+        .iter()
+        .filter(|t| STACK.contains(&t.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn render_texts(rt: &mut InstrumentRuntime, panel: u32) -> Vec<String> {
+    let packed = unpack(rt.render_result(panel));
+    assert_eq!(packed.status, RenderStatus::Ok as u32);
+    committed_scene_texts(rt, packed.scene_len as usize)
+}
+
+#[test]
+fn one_alert_step_feeds_every_panel_the_same_semantic_state() {
+    let mut rt = InstrumentRuntime::new();
+    rt.init();
+    let block = encoded_state_block(&failed_alt_state());
+    rt.runtime
+        .as_mut()
+        .expect("initialized")
+        .state
+        .copy_from_slice(&block);
+
+    let summary = rt.step_alerts(1_000, 1);
+    assert_eq!(summary & 0xff, RenderStatus::Ok as u64);
+    assert!((summary >> 8) & 0xff >= 1, "alt loss must assert an alert");
+    assert_eq!((summary >> 16) & 1, 0, "healthy path is not faulted");
+
+    let pfd = stack_only(&render_texts(&mut rt, 0));
+    let hsi = stack_only(&render_texts(&mut rt, 1));
+    assert!(pfd.contains(&String::from("ALT SRC")), "{pfd:?}");
+    assert_eq!(pfd, hsi, "both panels consume the one cached AlertOutput");
+}
+
+#[test]
+fn primary_flags_render_when_alerts_were_never_stepped() {
+    let mut rt = InstrumentRuntime::new();
+    rt.init();
+    let block = encoded_state_block(&failed_alt_state());
+    rt.runtime
+        .as_mut()
+        .expect("initialized")
+        .state
+        .copy_from_slice(&block);
+
+    let texts = render_texts(&mut rt, 0);
+    assert!(
+        texts.contains(&String::from("ALT")),
+        "ALT red X comes from resolved state, not the manager: {texts:?}"
+    );
+    assert!(
+        stack_only(&texts).is_empty(),
+        "no manager step, no alert stack: {texts:?}"
+    );
+}
+
+#[test]
+fn faulted_alerting_path_is_annunciated_and_flags_survive() {
+    let mut rt = InstrumentRuntime::new();
+    rt.init();
+    let block = encoded_state_block(&failed_alt_state());
+    rt.runtime
+        .as_mut()
+        .expect("initialized")
+        .state
+        .copy_from_slice(&block);
+
+    let summary = rt.step_alerts(1_000, 0);
+    assert_eq!((summary >> 16) & 1, 1, "monitor fault must mark the output");
+
+    let texts = render_texts(&mut rt, 0);
+    assert!(texts.contains(&String::from("ALRT FAIL")), "{texts:?}");
+    assert!(
+        texts.contains(&String::from("ALT")),
+        "primary flag independent of the faulted alerting path: {texts:?}"
+    );
+}

--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -4,10 +4,15 @@
 //! resource owns its buffers, configuration, and generations; this module has
 //! no process-global or thread-local mutable state.
 
+use pilotage_alerts::{
+    AlertCondition, AlertContext, AlertEvent, AlertManager, AlertOutput, AlertProfile, AltFault,
+    DynFault, ManagerHealth, NavFault,
+};
 use pilotage_instrument_panels::{PfdConfig, VSpeeds, draw_hsi, draw_pfd};
 use pilotage_instrument_scene::{LayerError, LayerId, SceneError, SceneWriter, validate_layers};
 use pilotage_instrument_state::FreshnessPolicy;
 use pilotage_instrument_state::abi::{AbiError, STATE_ABI_SIZE, STATE_ABI_VERSION, decode_state};
+use pilotage_instrument_state::{NavSource, SignalStatus};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::render_status::RenderStatus;
@@ -42,6 +47,17 @@ pub(crate) struct Runtime {
     /// Display thresholds; the simulator profile's numbers are benchmark
     /// data, not an aircraft approval.
     pub(crate) profile: pilotage_instrument_state::AirframeDisplayProfile,
+    /// The single alert state machine (ALR-01). Stepped once per
+    /// [`InstrumentRuntime::step_alerts`] call; every panel render then
+    /// consumes the one cached [`AlertOutput`], so the PFD and HSI can
+    /// never disagree on the semantic alert state within a frame.
+    pub(crate) alerts: AlertManager,
+    /// Alerting profile; simulator benchmark data, not an approval.
+    pub(crate) alert_profile: AlertProfile,
+    /// The last stepped output. `None` until the backend steps alerts —
+    /// panels then draw no alert stack, while primary-data flags render
+    /// unconditionally from resolved state.
+    pub(crate) alert_output: Option<AlertOutput>,
 }
 
 impl Runtime {
@@ -53,6 +69,9 @@ impl Runtime {
             pfd_cfg: PfdConfig::default(),
             unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
             profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+            alerts: AlertManager::new(),
+            alert_profile: AlertProfile::simulator(),
+            alert_output: None,
         }
     }
 }
@@ -166,16 +185,48 @@ pub(crate) fn render_into(runtime: &mut Runtime, panel: u32) -> RenderAttempt {
         Ok(writer) => writer,
         Err(error) => return RenderAttempt::failure(scene_error_status(error), generation),
     };
+    let alerts = runtime.alert_output.as_ref();
     let drawn = if panel == PANEL_PFD {
-        draw_pfd(&data, &runtime.pfd_cfg, &mut writer)
+        draw_pfd(&data, &runtime.pfd_cfg, alerts, &mut writer)
     } else {
-        draw_hsi(&data, &mut writer)
+        draw_hsi(&data, alerts, &mut writer)
     };
     let len = match drawn {
         Ok(()) => writer.finish(),
         Err(error) => return RenderAttempt::failure(scene_error_status(error), generation),
     };
     validate_and_commit_scene(runtime, panel_idx, len)
+}
+
+/// Maps resolved panel signals to the typed alert conditions this
+/// runtime can honestly assert today: altitude, navigation, and
+/// turn-rate source loss. Attitude and airspeed loss stay primary-data
+/// flags only (red X), deliberately outside the alerting path, so the
+/// display of a lost primary never depends on the manager. Every
+/// condition is asserted or cleared each step; both operations are
+/// idempotent in the manager.
+fn derive_alert_events(data: &pilotage_instrument_state::PanelData) -> [AlertEvent; 3] {
+    let cond = |active: bool, c: AlertCondition| {
+        if active {
+            AlertEvent::Assert(c)
+        } else {
+            AlertEvent::Clear(c)
+        }
+    };
+    [
+        cond(
+            data.alt_ft.status == SignalStatus::Failed,
+            AlertCondition::Altitude(AltFault::Unavailable),
+        ),
+        cond(
+            data.nav.data.source != NavSource::None && data.nav.status == SignalStatus::Failed,
+            AlertCondition::Heading(NavFault::Unavailable),
+        ),
+        cond(
+            data.turn_rate_rps.status == SignalStatus::Failed,
+            AlertCondition::TurnSlip(DynFault::TurnRateInvalid),
+        ),
+    ]
 }
 
 /// The state-block ABI version this module was built against.
@@ -259,6 +310,50 @@ impl InstrumentRuntime {
             || RenderAttempt::failure(RenderStatus::NotInitialized, 0).packed(),
             |runtime| render_into(runtime, panel).packed(),
         )
+    }
+
+    /// Steps the alert manager once against the current state block and
+    /// caches the output every subsequent panel render consumes, so all
+    /// panels in a frame share one semantic alert state. `now_ms` is the
+    /// caller's monotonic clock (the manager never reads an interior
+    /// clock); `path_healthy == 0` marks the independent display/alerting
+    /// path monitor faulted, which flags the output untrusted without
+    /// suppressing it.
+    ///
+    /// Returns status in bits 0..7, active-alert count in bits 8..15,
+    /// faulted health in bit 16, overflow in bit 17, and the manager
+    /// generation in bits 32..63.
+    pub fn step_alerts(&mut self, now_ms: u64, path_healthy: u32) -> u64 {
+        let Some(runtime) = self.runtime.as_mut() else {
+            return RenderStatus::NotInitialized as u64;
+        };
+        let state = match decode_state(&runtime.state) {
+            Ok(state) => state,
+            Err(AbiError::Truncated) => return RenderStatus::StateTruncated as u64,
+            Err(AbiError::BadVersion { .. }) => return RenderStatus::StateBadVersion as u64,
+        };
+        let data = pilotage_instrument_state::resolve_stateful(
+            &state,
+            &FreshnessPolicy::default(),
+            &runtime.profile,
+            &mut runtime.unusual,
+        );
+        let events = derive_alert_events(&data);
+        let ctx = AlertContext {
+            declutter: data.presentation.unusual,
+            alerting_path_healthy: path_healthy != 0,
+            ..AlertContext::default()
+        };
+        let out = runtime
+            .alerts
+            .step(&runtime.alert_profile, &events, ctx, now_ms);
+        let summary = (RenderStatus::Ok as u64)
+            | ((out.active().len() as u64 & 0xff) << 8)
+            | (u64::from(out.health() == ManagerHealth::Faulted) << 16)
+            | (u64::from(out.overflow()) << 17)
+            | ((out.generation() as u64) << 32);
+        runtime.alert_output = Some(out);
+        summary
     }
 
     /// The controlled glyph pack's canonical serialization (REN-02), for

--- a/clients/web-instruments/src/lib.rs
+++ b/clients/web-instruments/src/lib.rs
@@ -27,4 +27,6 @@ pub use exports::{InstrumentRuntime, abi_version};
 pub use render_status::RenderStatus;
 
 #[cfg(test)]
+mod alert_tests;
+#[cfg(test)]
 mod tests;

--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -13,13 +13,13 @@ use crate::exports::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PackedResult {
-    status: u32,
-    scene_len: u32,
-    generation: u32,
+pub(crate) struct PackedResult {
+    pub(crate) status: u32,
+    pub(crate) scene_len: u32,
+    pub(crate) generation: u32,
 }
 
-fn unpack(result: u64) -> PackedResult {
+pub(crate) fn unpack(result: u64) -> PackedResult {
     PackedResult {
         status: (result & 0xff) as u32,
         scene_len: ((result >> 8) & 0x00ff_ffff) as u32,
@@ -33,7 +33,7 @@ fn write_state(runtime: &mut Runtime, state: &AircraftState) {
     runtime.state.copy_from_slice(&block);
 }
 
-fn attitude_state() -> AircraftState {
+pub(crate) fn attitude_state() -> AircraftState {
     AircraftState {
         attitude: Stamped {
             data: Some(Attitude {
@@ -53,7 +53,7 @@ fn attitude_state() -> AircraftState {
     }
 }
 
-fn encoded_state_block(state: &AircraftState) -> Vec<u8> {
+pub(crate) fn encoded_state_block(state: &AircraftState) -> Vec<u8> {
     let mut block = vec![0u8; STATE_ABI_SIZE];
     encode_state(state, &mut block).expect("encodes");
     block
@@ -98,6 +98,9 @@ fn scene_runtime(scene: &[u8]) -> Runtime {
         pfd_cfg: PfdConfig::default(),
         unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
         profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: pilotage_alerts::AlertManager::new(),
+        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        alert_output: None,
     }
 }
 
@@ -231,6 +234,9 @@ fn render_into_reports_buffer_and_truncation_failures() {
         pfd_cfg: PfdConfig::default(),
         unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
         profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: pilotage_alerts::AlertManager::new(),
+        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        alert_output: None,
     };
     assert_attempt(
         render_into(&mut tiny, 0),
@@ -247,6 +253,9 @@ fn render_into_reports_buffer_and_truncation_failures() {
         pfd_cfg: PfdConfig::default(),
         unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
         profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: pilotage_alerts::AlertManager::new(),
+        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        alert_output: None,
     };
     assert_attempt(
         render_into(&mut truncated, 0),
@@ -262,6 +271,9 @@ fn render_into_reports_buffer_and_truncation_failures() {
         pfd_cfg: PfdConfig::default(),
         unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
         profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: pilotage_alerts::AlertManager::new(),
+        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        alert_output: None,
     };
     assert_attempt(render_into(&mut valid, 2), RenderStatus::InvalidPanel, 0, 0);
     let rendered = render_into(&mut valid, 0);
@@ -280,6 +292,9 @@ fn malformed_scene_never_advances_or_commits_length() {
         pfd_cfg: PfdConfig::default(),
         unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
         profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: pilotage_alerts::AlertManager::new(),
+        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        alert_output: None,
     };
     assert_attempt(
         validate_and_commit_scene(&mut runtime, 0, 2),

--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -274,6 +274,22 @@ export function renderInstrumentSet(module, health, targets, state, nowMs) {
     );
   }
 
+  // One alert step per frame, before any panel renders: every panel in
+  // this set then draws from the same manager output. The independent
+  // watchdog verdict (any panel currently latched failed) feeds the
+  // manager's path-health input. A step failure fails the whole set —
+  // a wasm anomaly here is as disqualifying as a state-write failure.
+  let alertResult;
+  try {
+    const pathHealthy = targets.every(([panel]) => !health[panel].display().showFailure);
+    alertResult = module.stepAlerts(nowMs, pathHealthy);
+  } catch {
+    alertResult = { ok: false, reason: REASON.RENDER_TRAP };
+  }
+  if (alertResult?.ok !== true) {
+    return failInstrumentSet(health, targets, nowMs, alertResult?.reason ?? REASON.RENDER_TRAP);
+  }
+
   const outcomes = [];
   for (const target of targets) {
     const [panel, ctx, canvas, presenter] = target;

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -50,6 +50,7 @@ const REQUIRED_RUNTIME_METHODS = [
   "scene_ptr",
   "render_result",
   "set_v_speeds",
+  "step_alerts",
   "glyph_manifest",
   "glyph_recorded_hash",
 ];
@@ -311,6 +312,35 @@ export class InstrumentModule {
         return { ok: false, reason: REASON.RENDER_TRAP };
       }
       return status === 0 ? { ok: true } : { ok: false, reason: status };
+    } catch {
+      return { ok: false, reason: REASON.RENDER_TRAP };
+    }
+  }
+
+  // Steps the alert manager once for this frame; every panel rendered
+  // afterward consumes the one cached output, so the panels can never
+  // disagree on the semantic alert state. pathHealthy carries the
+  // independent display-watchdog verdict into the manager (false marks
+  // the output untrusted without suppressing it).
+  stepAlerts(nowMs, pathHealthy) {
+    if (this.#disposed) return { ok: false, reason: REASON.RENDER_TRAP };
+    try {
+      const packed = this.#runtime.step_alerts(
+        BigInt(Math.max(0, Math.round(nowMs))),
+        pathHealthy ? 1 : 0,
+      );
+      if (typeof packed !== "bigint") return { ok: false, reason: REASON.RENDER_TRAP };
+      const status = Number(packed & 0xffn);
+      if (status < 0 || status > MAX_WASM_RENDER_STATUS) {
+        return { ok: false, reason: REASON.RENDER_TRAP };
+      }
+      if (status !== 0) return { ok: false, reason: status };
+      return {
+        ok: true,
+        active: Number((packed >> 8n) & 0xffn),
+        faulted: ((packed >> 16n) & 1n) === 1n,
+        overflow: ((packed >> 17n) & 1n) === 1n,
+      };
     } catch {
       return { ok: false, reason: REASON.RENDER_TRAP };
     }

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -152,6 +152,7 @@ function fakeExports({
       return packRenderResult(resultStatus, resultLen, renderGeneration(panel));
     },
     set_v_speeds: () => 0,
+    step_alerts: () => 0n,
     glyph_manifest: () => new Uint8Array(0),
     glyph_recorded_hash: () => new Uint8Array(0),
     memory: { buffer },
@@ -700,6 +701,70 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   );
 }
 
+// ---- ALR-01: one alert step per frame, fail-visible on step failure ----
+
+{
+  const { bytes } = buildScene();
+  let steps = 0;
+  let stepArgs = null;
+  const mod = new InstrumentModule(
+    fakeExports({
+      sceneBytes: bytes,
+      generation: (panel) => panel + 1,
+      overrides: {
+        step_alerts: (nowMs, healthy) => {
+          steps += 1;
+          stepArgs = [nowMs, healthy];
+          return 0n;
+        },
+      },
+    }),
+    { createCanvas: recordingCanvas },
+  );
+  const pfd = recordingCanvas(480, 360);
+  const hsi = recordingCanvas(480, 360);
+  const health = {
+    [PANEL.PFD]: new PanelHealth({}, 0),
+    [PANEL.HSI]: new PanelHealth({}, 0),
+  };
+  renderInstrumentSet(
+    mod,
+    health,
+    [
+      [PANEL.PFD, pfd.ctx, pfd, recordingPresenter()],
+      [PANEL.HSI, hsi.ctx, hsi, recordingPresenter()],
+    ],
+    {},
+    5,
+  );
+  check(
+    "alerts step exactly once per frame for the whole panel set",
+    steps === 1 && stepArgs[0] === 5n && stepArgs[1] === 1,
+  );
+
+  const failing = new InstrumentModule(
+    fakeExports({
+      sceneBytes: bytes,
+      overrides: { step_alerts: () => { throw new Error("trap"); } },
+    }),
+    { createCanvas: recordingCanvas },
+  );
+  const canvas2 = recordingCanvas(480, 360);
+  const presenter2 = recordingPresenter();
+  const health2 = { [PANEL.PFD]: new PanelHealth({}, 0) };
+  const [failed] = renderInstrumentSet(
+    failing,
+    health2,
+    [[PANEL.PFD, canvas2.ctx, canvas2, presenter2]],
+    {},
+    6,
+  );
+  check(
+    "an alert-step trap fails the frame set fail-visibly",
+    failed.ok === false && failed.reason === REASON.RENDER_TRAP && failed.covered,
+  );
+}
+
 {
   const { bytes } = buildScene();
   let generation = 0;
@@ -1112,6 +1177,7 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
         scene_ptr: () => rt.scene_ptr(),
         render_result: (panel) => rt.render_result(panel),
         set_v_speeds: (...a) => rt.set_v_speeds(...a),
+        step_alerts: (...a) => rt.step_alerts(...a),
         glyph_manifest: () => rt.glyph_manifest(),
         glyph_recorded_hash: () => rt.glyph_recorded_hash(),
         ...over,

--- a/crates/pilotage-instrument-panels/Cargo.toml
+++ b/crates/pilotage-instrument-panels/Cargo.toml
@@ -10,8 +10,10 @@ workspace = true
 
 [dependencies]
 libm = { workspace = true }
+pilotage-alerts = { workspace = true }
 pilotage-instrument-scene = { workspace = true }
 pilotage-instrument-state = { workspace = true }
 
 [dev-dependencies]
 pilotage-frames = { workspace = true }
+pilotage-instrument-glyphs = { workspace = true }

--- a/crates/pilotage-instrument-panels/src/annunciation.rs
+++ b/crates/pilotage-instrument-panels/src/annunciation.rs
@@ -1,0 +1,138 @@
+//! Manager-driven alert annunciation shared by every panel.
+//!
+//! Each panel passes the SAME [`AlertOutput`] snapshot into
+//! [`draw_alert_stack`], so a semantic alert difference between panels is
+//! structurally impossible: the stack is a pure function of the manager
+//! output, and the caller supplies one snapshot per frame. Primary-data
+//! failure flags (the red X and ATT/IAS/ALT/HDG flags) are drawn by each
+//! panel directly from `PanelData` and never pass through here — the
+//! alerting path can be absent, saturated, or faulted without touching
+//! them.
+
+use pilotage_alerts::{
+    AlertClass, AlertCondition, AlertId, AlertOutput, AltFault, DisplayFault, DynFault,
+    ManagerHealth, MiscompareFault, NavFault, SystemNote,
+};
+use pilotage_instrument_scene::{Anchor, Rgba8, SceneError, SceneWriter};
+
+use crate::palette;
+
+const STACK_X: f32 = 100.0;
+const STACK_BASE_Y: f32 = 352.0;
+const ROW_STEP: f32 = 16.0;
+/// Visible rows; anything beyond collapses into the MORE marker so the
+/// stack can never crowd primary symbology.
+const STACK_ROWS: usize = 3;
+
+fn class_color(class: AlertClass) -> Rgba8 {
+    match class {
+        AlertClass::Warning => palette::RED,
+        AlertClass::Caution => palette::AMBER,
+        AlertClass::Advisory | AlertClass::Status | AlertClass::Maintenance => palette::WHITE,
+    }
+}
+
+/// Short, glyph-pack-covered label for a stable alert identity. An
+/// identity outside the known vocabulary still shows — as the generic
+/// ALERT token — because an unknown fault must never be invisible.
+fn alert_label(id: AlertId) -> &'static str {
+    use AlertCondition as C;
+    let table: [(AlertId, &'static str); 20] = [
+        (C::Altitude(AltFault::ReferenceLost).id(), "ALT REF"),
+        (C::Altitude(AltFault::DatumMiscompare).id(), "BARO CMP"),
+        (C::Altitude(AltFault::Unavailable).id(), "ALT SRC"),
+        (C::Heading(NavFault::HeadingReferenceLost).id(), "HDG REF"),
+        (C::Heading(NavFault::CourseSourceInvalid).id(), "CRS SRC"),
+        (C::Heading(NavFault::Unavailable).id(), "NAV SRC"),
+        (C::TurnSlip(DynFault::TurnRateInvalid).id(), "TRN RATE"),
+        (C::TurnSlip(DynFault::SlipInvalid).id(), "SLIP"),
+        (C::TurnSlip(DynFault::Unavailable).id(), "TRN SRC"),
+        (C::Miscompare(MiscompareFault::Attitude).id(), "ATT CMP"),
+        (C::Miscompare(MiscompareFault::Airspeed).id(), "IAS CMP"),
+        (C::Miscompare(MiscompareFault::Altitude).id(), "ALT CMP"),
+        (C::Miscompare(MiscompareFault::Heading).id(), "HDG CMP"),
+        (C::Display(DisplayFault::RendererStalled).id(), "DSP STALL"),
+        (
+            C::Display(DisplayFault::FrameGenerationLost).id(),
+            "DSP GEN",
+        ),
+        (
+            C::Display(DisplayFault::CommandBufferCorrupt).id(),
+            "DSP BUF",
+        ),
+        (C::Display(DisplayFault::BackendLost).id(), "DSP LOST"),
+        (C::Display(DisplayFault::RetainedImage).id(), "DSP HOLD"),
+        (C::System(SystemNote::DatabaseStale).id(), "DB OLD"),
+        (C::System(SystemNote::MaintenanceRequired).id(), "MAINT"),
+    ];
+    for (known, label) in table {
+        if known == id {
+            return label;
+        }
+    }
+    if (C::System(SystemNote::ConfigMismatch).id()) == id {
+        return "CONFIG";
+    }
+    let code = (id.0 & 0xff) as u8;
+    if (C::FrameMismatch { code }).id() == id {
+        return "FRAME";
+    }
+    "ALERT"
+}
+
+/// Draws the manager's alert stack in the annunciation layer:
+/// priority-ordered rows (the manager's own ordering), warning red,
+/// caution amber, everything lower white. Inhibited and decluttered
+/// alerts are hidden here exactly as the manager flagged them; a
+/// truncated or overflowed list shows the amber MORE marker, and a
+/// faulted alerting path shows ALRT FAIL — the degradation itself is
+/// annunciated from the primary render path.
+pub(crate) fn draw_alert_stack(
+    scene: &mut SceneWriter<'_>,
+    alerts: &AlertOutput,
+) -> Result<(), SceneError> {
+    if alerts.health() == ManagerHealth::Faulted {
+        scene.fill_color(palette::AMBER)?;
+        scene.text(
+            STACK_X,
+            STACK_BASE_Y - 4.0 * ROW_STEP,
+            12.0,
+            Anchor::BASELINE_LEFT,
+            "ALRT FAIL",
+        )?;
+    }
+    let mut row = 0usize;
+    let mut truncated = alerts.overflow();
+    for alert in alerts.active() {
+        if alert.inhibited || alert.decluttered {
+            continue;
+        }
+        if row >= STACK_ROWS {
+            truncated = true;
+            break;
+        }
+        scene.fill_color(class_color(alert.class))?;
+        scene.text(
+            STACK_X,
+            STACK_BASE_Y - row as f32 * ROW_STEP,
+            12.0,
+            Anchor::BASELINE_LEFT,
+            alert_label(alert.id),
+        )?;
+        row = row.wrapping_add(1);
+    }
+    if truncated {
+        scene.fill_color(palette::AMBER)?;
+        scene.text(
+            STACK_X,
+            STACK_BASE_Y - (row as f32) * ROW_STEP,
+            12.0,
+            Anchor::BASELINE_LEFT,
+            "MORE",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-panels/src/annunciation/tests.rs
+++ b/crates/pilotage-instrument-panels/src/annunciation/tests.rs
@@ -1,0 +1,192 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::string::String;
+use std::vec::Vec;
+
+use pilotage_alerts::{
+    AlertCondition, AlertContext, AlertEvent, AlertManager, AlertOutput, AlertProfile, AltFault,
+    DynFault, ManagerHealth, NavFault,
+};
+use pilotage_instrument_scene::SceneWriter;
+use pilotage_instrument_state::{PanelData, SignalStatus};
+
+use crate::pfd::tests::{flying, texts};
+use crate::{PfdConfig, draw_hsi, draw_pfd};
+
+fn stepped(events: &[AlertEvent], healthy: bool) -> AlertOutput {
+    let mut manager = AlertManager::new();
+    manager.step(
+        &AlertProfile::simulator(),
+        events,
+        AlertContext {
+            alerting_path_healthy: healthy,
+            ..AlertContext::default()
+        },
+        1_000,
+    )
+}
+
+fn saturated() -> AlertOutput {
+    let events: Vec<AlertEvent> = (0..30)
+        .map(|code| AlertEvent::Assert(AlertCondition::FrameMismatch { code }))
+        .collect();
+    stepped(&events, true)
+}
+
+fn pfd_scene(data: &PanelData, alerts: Option<&AlertOutput>) -> Vec<u8> {
+    let mut buf = std::vec![0u8; 32 * 1024];
+    let mut w = SceneWriter::new(&mut buf).expect("fits");
+    draw_pfd(data, &PfdConfig::default(), alerts, &mut w).expect("pfd fits");
+    let len = w.finish();
+    buf.truncate(len);
+    buf
+}
+
+fn hsi_scene(data: &PanelData, alerts: Option<&AlertOutput>) -> Vec<u8> {
+    let mut buf = std::vec![0u8; 32 * 1024];
+    let mut w = SceneWriter::new(&mut buf).expect("fits");
+    draw_hsi(data, alerts, &mut w).expect("hsi fits");
+    let len = w.finish();
+    buf.truncate(len);
+    buf
+}
+
+/// The stack tokens of a scene: every text run that is a known alert
+/// label or stack marker. Primary flags (ATT/IAS/ALT/HDG/NAV) are
+/// two-to-three-character runs that never collide with these.
+fn stack_tokens(scene: &[u8]) -> Vec<String> {
+    const STACK: &[&str] = &[
+        "ALT SRC",
+        "NAV SRC",
+        "TRN RATE",
+        "FRAME",
+        "ALRT FAIL",
+        "MORE",
+        "ALERT",
+    ];
+    texts(scene)
+        .into_iter()
+        .filter(|t| STACK.contains(&t.as_str()))
+        .collect()
+}
+
+fn failed_primaries() -> PanelData {
+    let mut data = flying();
+    data.roll_rad.status = SignalStatus::Failed;
+    data.pitch_rad.status = SignalStatus::Failed;
+    data.alt_ft.status = SignalStatus::Failed;
+    data
+}
+
+#[test]
+fn widgets_consume_manager_output() {
+    let out = stepped(
+        &[
+            AlertEvent::Assert(AlertCondition::Altitude(AltFault::Unavailable)),
+            AlertEvent::Assert(AlertCondition::TurnSlip(DynFault::TurnRateInvalid)),
+        ],
+        true,
+    );
+    let with = stack_tokens(&pfd_scene(&flying(), Some(&out)));
+    assert!(with.contains(&String::from("ALT SRC")), "{with:?}");
+    assert!(with.contains(&String::from("TRN RATE")), "{with:?}");
+    let without = stack_tokens(&pfd_scene(&flying(), None));
+    assert!(
+        without.is_empty(),
+        "no manager output, no stack: {without:?}"
+    );
+}
+
+#[test]
+fn pfd_and_hsi_present_the_same_semantic_alert_state() {
+    let out = stepped(
+        &[
+            AlertEvent::Assert(AlertCondition::Altitude(AltFault::Unavailable)),
+            AlertEvent::Assert(AlertCondition::Heading(NavFault::Unavailable)),
+        ],
+        true,
+    );
+    let data = flying();
+    let pfd = stack_tokens(&pfd_scene(&data, Some(&out)));
+    let hsi = stack_tokens(&hsi_scene(&data, Some(&out)));
+    assert_eq!(pfd, hsi, "one AlertOutput, one semantic stack, both panels");
+    assert!(!pfd.is_empty());
+}
+
+#[test]
+fn primary_flags_survive_every_manager_failure_mode() {
+    let data = failed_primaries();
+    let cases: [(&str, Option<AlertOutput>); 4] = [
+        ("manager never stepped", None),
+        ("manager empty", Some(stepped(&[], true))),
+        ("alerting path faulted", Some(stepped(&[], false))),
+        ("manager saturated", Some(saturated())),
+    ];
+    for (name, alerts) in &cases {
+        let scene = pfd_scene(&data, alerts.as_ref());
+        let all = texts(&scene);
+        assert!(
+            all.contains(&String::from("ATT")) && all.contains(&String::from("ALT")),
+            "{name}: primary-data flags must render regardless of the manager: {all:?}"
+        );
+    }
+}
+
+#[test]
+fn degraded_alerting_is_itself_annunciated() {
+    let out = stepped(&[], false);
+    assert_eq!(out.health(), ManagerHealth::Faulted);
+    let tokens = stack_tokens(&pfd_scene(&flying(), Some(&out)));
+    assert!(tokens.contains(&String::from("ALRT FAIL")), "{tokens:?}");
+}
+
+#[test]
+fn saturation_shows_rows_and_the_more_marker() {
+    let out = saturated();
+    assert!(out.overflow(), "30 asserts past 24 slots must overflow");
+    let tokens = stack_tokens(&pfd_scene(&flying(), Some(&out)));
+    let frames = tokens.iter().filter(|t| t.as_str() == "FRAME").count();
+    assert_eq!(frames, 3, "visible rows cap at the stack limit: {tokens:?}");
+    assert!(tokens.contains(&String::from("MORE")), "{tokens:?}");
+}
+
+#[test]
+fn every_label_is_covered_by_the_glyph_pack() {
+    let labels = [
+        "ALT REF",
+        "BARO CMP",
+        "ALT SRC",
+        "HDG REF",
+        "CRS SRC",
+        "NAV SRC",
+        "TRN RATE",
+        "SLIP",
+        "TRN SRC",
+        "ATT CMP",
+        "IAS CMP",
+        "ALT CMP",
+        "HDG CMP",
+        "DSP STALL",
+        "DSP GEN",
+        "DSP BUF",
+        "DSP LOST",
+        "DSP HOLD",
+        "DB OLD",
+        "MAINT",
+        "CONFIG",
+        "FRAME",
+        "ALERT",
+        "ALRT FAIL",
+        "MORE",
+    ];
+    for label in labels {
+        for ch in label.chars() {
+            assert!(
+                pilotage_instrument_glyphs::PANEL_GLYPHS
+                    .lookup(ch)
+                    .is_some(),
+                "glyph pack must cover {ch:?} in {label:?}"
+            );
+        }
+    }
+}

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -1,6 +1,7 @@
 //! The Horizontal Situation Indicator: rotating compass rose, heading
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
+use pilotage_alerts::AlertOutput;
 use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{NavSource, PanelData, SignalStatus};
 
@@ -23,7 +24,11 @@ pub(crate) const ROSE_R: f32 = 160.0;
 /// black backdrop, the rotating orientation symbology, the readout
 /// boxes, course guidance, and — above everything it annunciates — the
 /// heading failure flag.
-pub fn draw_hsi(data: &PanelData, scene: &mut SceneWriter<'_>) -> Result<(), SceneError> {
+pub fn draw_hsi(
+    data: &PanelData,
+    alerts: Option<&AlertOutput>,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), SceneError> {
     scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
     scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
@@ -67,6 +72,9 @@ pub fn draw_hsi(data: &PanelData, scene: &mut SceneWriter<'_>) -> Result<(), Sce
     }
     if !hdg.status.shows_value() {
         status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
+    }
+    if let Some(alerts) = alerts {
+        crate::annunciation::draw_alert_stack(scene, alerts)?;
     }
     scene.end_layer(LayerId::Annunciation)?;
     Ok(())

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -47,7 +47,7 @@ fn quat_yaw(yaw: f32) -> pilotage_instrument_state::Quat {
 fn render(data: &PanelData) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_hsi(data, &mut w).expect("panel fits buffer");
+    draw_hsi(data, None, &mut w).expect("panel fits buffer");
     let len = w.finish();
     buf.truncate(len);
     buf

--- a/crates/pilotage-instrument-panels/src/lib.rs
+++ b/crates/pilotage-instrument-panels/src/lib.rs
@@ -17,6 +17,7 @@
 #[cfg(test)]
 extern crate std;
 
+mod annunciation;
 mod fixed_str;
 mod hsi;
 mod palette;

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -2,6 +2,7 @@
 //! and turn-rate cue, composed in fixed layers (background → attitude →
 //! tapes → symbology → annunciation, ADR-0017).
 
+use pilotage_alerts::AlertOutput;
 use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{ChevronSense, PanelData, SignalStatus};
 
@@ -67,6 +68,7 @@ pub struct PfdConfig {
 pub fn draw_pfd(
     data: &PanelData,
     cfg: &PfdConfig,
+    alerts: Option<&AlertOutput>,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
     let att_status = data.roll_rad.status.worst(data.pitch_rad.status);
@@ -127,6 +129,9 @@ pub fn draw_pfd(
     if data.alt_ft.status == SignalStatus::Failed {
         status_paint::draw_red_x(scene, 398.0, 60.0, 74.0, 200.0, "ALT")?;
     }
+    if let Some(alerts) = alerts {
+        crate::annunciation::draw_alert_stack(scene, alerts)?;
+    }
     scene.end_layer(LayerId::Annunciation)?;
     Ok(())
 }
@@ -181,4 +186,4 @@ fn draw_turn_rate(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), S
 #[cfg(test)]
 mod attitude_tests;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -11,7 +11,7 @@ use pilotage_instrument_state::{
 
 use super::{PfdConfig, VSpeeds, draw_pfd};
 
-fn flying() -> PanelData {
+pub(crate) fn flying() -> PanelData {
     let state = AircraftState {
         attitude: Stamped {
             data: Some(Attitude {
@@ -49,7 +49,7 @@ fn flying() -> PanelData {
 pub(crate) fn render(data: &PanelData, cfg: &PfdConfig) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_pfd(data, cfg, &mut w).expect("panel fits buffer");
+    draw_pfd(data, cfg, None, &mut w).expect("panel fits buffer");
     let len = w.finish();
     buf.truncate(len);
     buf

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -124,7 +124,7 @@ fn sha_hex(bytes: &[u8]) -> std::string::String {
 #[test]
 fn pfd_frame_hash_is_reproducible_and_pinned() {
     let data = resolve(&demo_state(), &FreshnessPolicy::default());
-    let scene = encode(|w| draw_pfd(&data, &PfdConfig::default(), w).expect("pfd"));
+    let scene = encode(|w| draw_pfd(&data, &PfdConfig::default(), None, w).expect("pfd"));
     let first = frame(&scene);
     let second = frame(&scene);
     assert_eq!(
@@ -137,7 +137,7 @@ fn pfd_frame_hash_is_reproducible_and_pinned() {
 #[test]
 fn hsi_frame_hash_is_reproducible_and_pinned() {
     let data = resolve(&demo_state(), &FreshnessPolicy::default());
-    let scene = encode(|w| draw_hsi(&data, w).expect("hsi"));
+    let scene = encode(|w| draw_hsi(&data, None, w).expect("hsi"));
     let first = frame(&scene);
     let second = frame(&scene);
     assert_eq!(

--- a/crates/pilotage-instrument-raster/src/raster/tests/work_budget.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/work_budget.rs
@@ -29,9 +29,9 @@ fn panel_scenes() -> Vec<(&'static str, Vec<u8>)> {
     std::vec![
         (
             "PFD",
-            encode(|w| draw_pfd(&data, &PfdConfig::default(), w).expect("pfd")),
+            encode(|w| draw_pfd(&data, &PfdConfig::default(), None, w).expect("pfd")),
         ),
-        ("HSI", encode(|w| draw_hsi(&data, w).expect("hsi"))),
+        ("HSI", encode(|w| draw_hsi(&data, None, w).expect("hsi"))),
     ]
 }
 


### PR DESCRIPTION
Delivers the integration follow-up recorded on #22: the review disposition was to close ALR-01 only after the paths from the pure manager crate to the visible panels are proven. **Stacked on #58** (it edits files that PR touches) — merge #58 first, then retarget or let GitHub cascade this onto `main`. **SIM / NOT FOR FLIGHT** throughout.

## What the review asked for, and where it is proven

| Closing criterion (#22) | Proof |
|---|---|
| Widgets consume manager output, not ad-hoc flags | `draw_pfd`/`draw_hsi` take `Option<&AlertOutput>`; the stack renders only from manager output (`widgets_consume_manager_output`: with output → `ALT SRC`/`TRN RATE` rows; without → no stack) |
| PFD and HUD receive the same semantic alert state | One `AlertManager` in the wasm runtime, stepped once per `step_alerts` call; every subsequent panel render consumes the one cached `AlertOutput` (`one_alert_step_feeds_every_panel_the_same_semantic_state` — PFD and HSI token sequences are equal; `pfd_and_hsi_present_the_same_semantic_alert_state` at the panels layer; `alerts step exactly once per frame for the whole panel set` in the JS pipeline). A future HUD panel plugs into the same cached snapshot — disagreement is structural, not procedural, impossible within a frame |
| Primary-data flags independent under real manager failure | `primary_flags_survive_every_manager_failure_mode`: the ATT/ALT red X renders through the real draw path with the manager **never stepped**, **empty**, **path-faulted**, and **saturated past its 24-slot capacity with overflow**; `primary_flags_render_when_alerts_were_never_stepped` and `faulted_alerting_path_is_annunciated_and_flags_survive` prove the same end-to-end through the wasm runtime |

## Design decisions worth reviewing

- **Attitude and airspeed loss are deliberately NOT alert conditions.** They remain primary-data flags (red X) drawn directly from resolved state, so the display of a lost primary never depends on the alerting path. The runtime derives only what it can honestly assert today: altitude, navigation, and turn-rate source loss (`derive_alert_events`, assert/clear both idempotent).
- **Degraded alerting is itself annunciated from the primary render path**: the browser feeds the independent display-watchdog verdict into `AlertContext::alerting_path_healthy`; a faulted path renders the amber `ALRT FAIL` token while the alert list continues (per the manager's contract that health never suppresses output).
- **The stack is bounded fail-visible**: three rows, priority order from the manager, anything beyond (or a capacity overflow) collapses into the amber `MORE` marker — saturation can never crowd primary symbology (`saturation_shows_rows_and_the_more_marker`).
- **Every label is glyph-pack covered**, gated by `every_label_is_covered_by_the_glyph_pack` — an uncovered character would otherwise fail the whole frame at paint time (REN-02 no-fallback rule).
- **A step failure fails the frame set fail-visibly** through the existing failure page (`an alert-step trap fails the frame set fail-visibly`); `step_alerts` joins `REQUIRED_RUNTIME_METHODS` so a stale wasm build cannot pass load validation.
- Panels called with `None` draw byte-identical scenes to before — the pinned PFD/HSI frame hashes are untouched.

## Verification

- Full local battery green: `fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test --all-targets` (29 suites, incl. 8 new panels tests + 3 new runtime tests), `doc -D missing_docs -D broken_intra_doc_links`, `build --release`, structure gate, no_std check (`thumbv7em-none-eabihf`) across the instrument family incl. `pilotage-alerts`.
- All six node suites green, including the two new pipeline proofs; the wasm artifact rebuilt via `scripts/build-web-instruments.sh`.

Refs #22 — with this integration merged, the closing criteria recorded there are all evidenced; closing remains the reviewer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)