### PR TITLE
AIR-03: standards applicability matrix, lifecycle evidence plan, and certification-claim CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,16 @@ jobs:
       - name: instrument requirement references
         run: bash scripts/check-instrument-requirements.sh
 
+      - name: certification-claim guard (AIR-03)
+        # Fail on any tracked doc/UI artifact that asserts a certification,
+        # compliance, approval, or airworthiness claim about this SIM project.
+        run: bash scripts/check-certification-claims.sh
+
+      - name: instrument trace inventory (AIR-03)
+        # Emit a requirement/test/review/configuration inventory to the log.
+        # This is an inventory, not a compliance trace, and fabricates nothing.
+        run: bash scripts/trace-report.sh
+
       - name: instrument crates are no_std (ADR-0017)
         # Compiling the instrument family for a bare-metal target proves the
         # no_std/no-alloc claim instead of trusting a comment.

--- a/docs/instruments/README.md
+++ b/docs/instruments/README.md
@@ -36,6 +36,31 @@ All browser, WebAssembly, Canvas, WebTransport, Gazebo, and test-harness output
 is **SIM / NOT FOR FLIGHT**. A visual resemblance to an aircraft display does
 not make the output primary flight information or authorize operational credit.
 
+## Standards and lifecycle evidence planning
+
+Seeded from the intended-function and safety baselines, the standards-applicability
+matrix and lifecycle-evidence plan record which industry standards and authority
+guidance a future certification effort would draw on, and which repository
+artifacts are engineering input versus lifecycle evidence still to be established.
+Both are **SIM / NOT FOR FLIGHT** engineering planning inputs. They make no
+compliance finding and confer no certification credit, and they depend on the
+AIR-01 (#24) and AIR-02 (#27) baselines, which remain preliminary and pending
+independent review.
+
+- [Standards applicability matrix](standards-applicability.md) classifies each
+  standard as authority-accepted, latest engineering baseline, requiring authority
+  agreement, or not applicable, with rationale, gaps, and issue-paper needs.
+- [Lifecycle evidence plan](evidence-plan.md) indexes today's requirement, design,
+  code, test, review, and configuration baselines, and states which prototype
+  artifacts may be reused as engineering input versus which DO-178C lifecycle
+  evidence must be established anew. Structural-coverage objectives are deferred
+  until AIR-02 allocates assurance.
+
+`scripts/check-certification-claims.sh` fails CI on any artifact that asserts a
+certification, compliance, approval, or airworthiness claim about this project;
+`scripts/trace-report.sh` emits a requirement/test/review/configuration inventory
+to the CI log (an inventory, not a compliance trace).
+
 ## Change control
 
 Every new or changed display feature must cite at least one requirement from

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -1,0 +1,201 @@
+# Lifecycle evidence plan (AIR-03)
+
+**SIM / NOT FOR FLIGHT.** This document plans the lifecycle evidence a future
+Pilotage instrument certification effort would need, indexes the artifacts that
+exist in the repository today, and states plainly which of those artifacts are
+**engineering input** versus which certified lifecycle data must be established
+anew. It is **not** a compliance record, and it does not claim that any existing
+artifact satisfies a certification objective. Existing prototype history is never
+represented here as certified lifecycle data.
+
+## Purpose
+
+A credible certification effort is evidence-driven: each objective is satisfied
+by a named, configuration-controlled artifact. This plan does two honest things.
+First, it inventories the requirements, design, code, test, review, and
+configuration material that already exists, with pointers to the actual files.
+Second, it draws a hard line between that prototype material — usable as
+engineering input — and the DO-178C lifecycle data that must be produced under an
+allocated software level and cannot be back-claimed from prototype history.
+
+The software levels that scale most DO-178C objectives are **not yet allocated**.
+AIR-02 performs that allocation and is preliminary and pending review (issue #27,
+review record `PENDING`). Wherever an objective depends on an allocated level,
+this plan marks it **deferred**, not satisfied.
+
+## Baselines that exist today
+
+These are real, tracked artifacts. Their existence is a statement of engineering
+work performed, not of certification credit earned.
+
+### Requirements baseline
+
+- [`requirements.md`](requirements.md) — the stable `AIR-*` intended-function and
+  hazard-derived requirement registry, guarded for identifier integrity and link
+  correctness by `scripts/check-instrument-requirements.sh`.
+- [`intended-functions.md`](intended-functions.md) — per-function intended
+  behavior, modes, and source assumptions.
+- [`system-boundary.md`](system-boundary.md) — trusted/untrusted interfaces,
+  simulator-only components, and reversion paths.
+
+### Design baseline
+
+- `docs/adr/0001`–`0019` — the architecture decision record set, including
+  ADR-0015 (workspace quality gates), ADR-0017 (instrument display runtime),
+  ADR-0018 (avionics telemetry and Aviate adapter), and ADR-0019 (pluggable
+  vehicle link).
+- [`scene-layer-protocol.md`](scene-layer-protocol.md) and
+  [`glyph-pack.md`](glyph-pack.md) — the controlled display-content contracts.
+- `docs/architecture.md` — the system-level architecture description.
+
+### Code baseline
+
+- The `pilotage-instrument-*` crate family (`-state`, `-scene`, `-glyphs`,
+  `-panels`, `-raster`) plus `pilotage-frames` and `pilotage-alerts`, compiled
+  for a bare-metal target in CI to substantiate the `no_std` claim (ADR-0017).
+- `clients/web-instruments` — the WebAssembly instrument backend.
+- `clients/web` — the browser viewer and its wire/telemetry/transport paths.
+
+### Test baseline
+
+- The in-crate `tests.rs` and `tests/` modules across the workspace (unit and
+  property tests with direct access to internals or public-API integration
+  tests).
+- The reference-rasterizer frame-hash tests (`pilotage-instrument-raster`) that
+  pin PFD/HSI output to SHA-256 hashes for bit-reproducibility (REN-03).
+- The glyph-pack integrity tests (`pilotage-instrument-glyphs`) for vocabulary
+  completeness and fail-closed corruption detection (REN-02).
+- The browser conformance suites run in CI: `wire.test.mjs`,
+  `telemetry-ingress.test.mjs`, `telemetry-display.test.mjs`,
+  `transport-session.test.mjs`, `instruments.test.mjs`, and
+  `scene-conformance.test.mjs`.
+- [`renderer-verification.md`](renderer-verification.md) — the verification wall
+  defining what each rendering backend must prove, its budgets, and the shared
+  conformance corpus.
+
+### Review baseline
+
+- [`review-record.md`](review-record.md) — the AIR-01 closure gate. Every
+  reviewer field currently reads `PENDING`; the baseline is **not approved** and
+  issue #24 remains open ([`AIR-BAS-006`](requirements.md#air-bas-006)).
+- The AIR-02 review record embedded in [`pssa.md`](pssa.md) — likewise `PENDING`;
+  issue #27 remains open.
+
+### Configuration baseline
+
+- The git commit history and the pull-request record are the configuration record
+  of engineering work (for example the merged increment and flight-mode PRs
+  visible in history).
+- ADR-0015 workspace quality gates, `.github/workflows/ci.yml`,
+  `scripts/check-structure.sh`, `scripts/check-instrument-requirements.sh`, and
+  `scripts/structure-function-baseline.tsv` are the automated configuration and
+  structural controls in force today.
+
+## Evidence index
+
+Each row maps an objective family to the artifact(s) that would carry it and the
+honest current status. `deferred` means the objective depends on an allocation or
+selection not yet made. `engineering input` means an artifact exists but is not
+certified lifecycle data. Nothing here is marked satisfied.
+
+| ID | Objective family (standard) | Current artifact(s) | Status |
+| --- | --- | --- | --- |
+| EVP-01 | System/development-assurance planning (ARP4754A) | `requirements.md`, ADR set, `docs/architecture.md` | engineering input; process not exercised to closure |
+| EVP-02 | Safety assessment (ARP4761 / FHA/PSSA) | [`fha.md`](fha.md), [`pssa.md`](pssa.md) | engineering input; **preliminary**, issue #27 `PENDING` |
+| EVP-03 | Software planning (DO-178C plans: PSAC/SDP/SVP/SCMP/SQAP) | none yet | deferred until level allocation (AIR-02, #27) |
+| EVP-04 | Software requirements (DO-178C) | `requirements.md` (`AIR-*`), intended-functions | engineering input; not level-allocated certified requirements |
+| EVP-05 | Software design (DO-178C) | ADR-0017/0018/0019, scene-layer/glyph-pack contracts | engineering input |
+| EVP-06 | Software coding (DO-178C) | `pilotage-instrument-*`, `pilotage-frames`, `pilotage-alerts`, `clients/web-instruments` | engineering input; **not** certified source data |
+| EVP-07 | Verification — reviews and analyses (DO-178C) | code review in PR history, `renderer-verification.md` | engineering input; not DO-178C-conformant review records |
+| EVP-08 | Verification — testing (DO-178C) | workspace `tests.rs`/`tests/`, browser `*.test.mjs`, raster/glyph tests | engineering input; not requirements-based certified test evidence |
+| EVP-09 | Structural coverage (DO-178C) | none | **deferred** — see structural-coverage section |
+| EVP-10 | Configuration management (DO-178C SCM) | git/PR history, ADR-0015 gates, CI, structure checks | engineering configuration record; not certified SCM data |
+| EVP-11 | Quality assurance (DO-178C SQA) | CI quality gates | engineering practice; independent SQA function not established |
+| EVP-12 | Problem reporting (DO-178C) | GitHub issues and PRs | engineering record; not certified problem-report data |
+| EVP-13 | Tool qualification (DO-330) | none | deferred; per-tool TQL undetermined until level allocation |
+| EVP-14 | Complex hardware (DO-254) | none | not applicable (no custom complex AEH in scope) |
+| EVP-15 | Environmental qualification (DO-160G) | none | not applicable (no airborne equipment); DO-160H excluded |
+| EVP-16 | Aeronautical data (DO-200B / ED-76) | none (simulator/reference data only) | not applicable yet (no operational data chain) |
+| EVP-17 | Security (DO-326A / ED-202A family; issue "DO-407/ED-326") | [`system-boundary.md`](system-boundary.md) trust analysis | engineering input; not a security certification artifact — see [standards matrix](standards-applicability.md) STD-050..STD-053 |
+| EVP-18 | Display / alerting guidance (AC 25-11B; alert model) | PFD/HSI intended functions, `pilotage-alerts` crate | engineering input; no display submitted for approval |
+| EVP-19 | Installation and flight-test evidence | none | not applicable (no installation; [`AIR-OUT-008`](requirements.md#air-out-008)) |
+
+## Reuse as engineering input versus evidence established anew
+
+This section is the anti-back-claim boundary. It is deliberately explicit.
+
+**May be reused as engineering input** (informs the certified effort, cited as
+prior engineering, never relabeled as certified data):
+
+- The `AIR-*` requirement registry as a starting requirement set.
+- The FHA/PSSA analysis as a starting safety analysis (preliminary; #27 `PENDING`).
+- The architecture decision records and display-content contracts as design
+  rationale.
+- The prototype source and tests as reference implementations and as evidence
+  that a behavior is achievable.
+- The CI gates, structural checks, and conformance corpora as engineering
+  verification practice and as the seed for a certified verification environment.
+
+**Must be established anew under an allocated software level** (cannot be
+back-claimed from prototype history):
+
+- DO-178C plans (PSAC, SDP, SVP, SCMP, SQAP) and their authority agreement.
+- Requirements, design, and code baselined and traced **as certified lifecycle
+  data**, at the level AIR-02 allocates, with DO-178C-conformant review records.
+- Requirements-based test cases and procedures with traceability, plus the
+  structural coverage appropriate to the allocated level.
+- Tool-qualification data (DO-330) for any tool whose output is relied upon
+  without independent verification.
+- Configuration management and problem-reporting records under a
+  certification-conformant SCM/SQA process, distinct from the current git/PR/CI
+  record.
+
+**Explicit non-back-claim statements:**
+
+- Passing CI and passing tests are engineering signals; they are **not** DO-178C
+  verification credit and are not represented as such.
+- The git and pull-request history is a configuration record of **engineering
+  work**; it is **not** certified configuration data, and its existence does not
+  establish DO-178C SCM objective satisfaction.
+- Preliminary FHA/PSSA classifications remain conditional and unclosed
+  ([`AIR-HAZ-001`](requirements.md#air-haz-001)); they confer no assurance level.
+
+## Structural coverage — deferred
+
+DO-178C structural-coverage objectives (statement, decision, and modified
+condition/decision coverage) scale with software level. **No software level is
+allocated**: that allocation is AIR-02's responsibility and AIR-02 is preliminary
+and pending review (issue #27, review record `PENDING`). Consequently:
+
+- Structural coverage is **deferred**. It is not claimed, and it is not planned to
+  a specific coverage criterion, because the governing level does not exist yet.
+- The existing frame-hash and conformance tests demonstrate reproducibility and
+  behavior; they are **not** a structural-coverage measurement and are not
+  represented as one.
+- When AIR-02 allocates levels, this section is replaced by a coverage objective
+  and a measurement method appropriate to each allocated level, and the
+  latent-failure exposure intervals ([`AIR-HAZ-010`](requirements.md#air-haz-010))
+  are set against the selected certification basis.
+
+## Acceptance-criteria coverage
+
+The AIR-03 acceptance criteria require the evidence plan to cover a specific set
+of standards families. Each is addressed above:
+
+- ARP4754 / ARP4761 — EVP-01, EVP-02.
+- DO-178C — EVP-03 through EVP-12 and the structural-coverage section.
+- DO-254 — EVP-14 (not applicable, current scope).
+- DO-160 — EVP-15 (not applicable; DO-160G recorded, DO-160H excluded).
+- Aeronautical data — EVP-16.
+- Security, including the issue's "DO-407/ED-326" reference — EVP-17 and
+  [standards matrix](standards-applicability.md) STD-050..STD-053.
+- Display / alerting guidance — EVP-18.
+- Installation qualification — EVP-19.
+
+## Re-verification clause
+
+This plan records status as of 2026-07-12 and is provisional. The evidence index
+must be re-baselined once AIR-02 allocates software levels and a certification
+authority, aircraft, operation, installation, and certification basis are
+selected. Until then it is an engineering planning input and confers no
+certification credit.

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -116,9 +116,11 @@ certified lifecycle data. Nothing here is marked satisfied.
 | EVP-14 | Complex hardware (DO-254) | none | not applicable (no custom complex AEH in scope) |
 | EVP-15 | Environmental qualification (DO-160G) | none | not applicable (no airborne equipment); DO-160H excluded |
 | EVP-16 | Aeronautical data (DO-200B / ED-76) | none (simulator/reference data only) | not applicable yet (no operational data chain) |
-| EVP-17 | Security (DO-326A / ED-202A family; issue "DO-407/ED-326") | [`system-boundary.md`](system-boundary.md) trust analysis | engineering input; not a security certification artifact — see [standards matrix](standards-applicability.md) STD-050..STD-053 |
+| EVP-17 | Security (DO-326A / ED-202A airworthiness-security family) | [`system-boundary.md`](system-boundary.md) trust analysis | engineering input; not a security certification artifact — see [standards matrix](standards-applicability.md) STD-050..STD-052 |
 | EVP-18 | Display / alerting guidance (AC 25-11B; alert model) | PFD/HSI intended functions, `pilotage-alerts` crate | engineering input; no display submitted for approval |
 | EVP-19 | Installation and flight-test evidence | none | not applicable (no installation; [`AIR-OUT-008`](requirements.md#air-out-008)) |
+| EVP-20 | Synthetic-vision performance (DO-407 / ED-326 and earlier DO-315 / ED-179; AC 20-167A / AC 20-185) | SVS is supplemental only ([`AIR-OUT-005`](requirements.md#air-out-005)); no operational-credit artifact | engineering input; DO-407 / ED-326 released MASPS with authority acceptance unresolved — see [standards matrix](standards-applicability.md) STD-066 |
+| EVP-21 | Source equipment — attitude/heading (AC 20-181, AHRS / TSO-C201) | attitude and heading inputs ([`AIR-IN-001`](requirements.md#air-in-001), [`AIR-IN-005`](requirements.md#air-in-005)) | not applicable yet (no airborne AHRS source selected) — see [standards matrix](standards-applicability.md) STD-065 |
 
 ## Reuse as engineering input versus evidence established anew
 
@@ -187,9 +189,13 @@ of standards families. Each is addressed above:
 - DO-254 — EVP-14 (not applicable, current scope).
 - DO-160 — EVP-15 (not applicable; DO-160G recorded, DO-160H excluded).
 - Aeronautical data — EVP-16.
-- Security, including the issue's "DO-407/ED-326" reference — EVP-17 and
-  [standards matrix](standards-applicability.md) STD-050..STD-053.
-- Display / alerting guidance — EVP-18.
+- Security (DO-326A / ED-202A airworthiness-security family) — EVP-17 and
+  [standards matrix](standards-applicability.md) STD-050..STD-052.
+- Synthetic-vision performance, including DO-407 / ED-326 (the SVS/SVGS/CVS MASPS,
+  not a security standard) — EVP-20 and [standards matrix](standards-applicability.md)
+  STD-066.
+- Display / alerting guidance — EVP-18; attitude/heading source equipment
+  (AC 20-181, AHRS) — EVP-21 and STD-065.
 - Installation qualification — EVP-19.
 
 ## Re-verification clause

--- a/docs/instruments/standards-applicability.md
+++ b/docs/instruments/standards-applicability.md
@@ -28,6 +28,12 @@ certification basis.
   change over time; every row **must be re-verified with the selected
   certification authority at the point of authority engagement**. The matrix is a
   planning input, not a standing statement of current recognition.
+- **Standard identities were verified against publisher listings on 2026-07-12**
+  (RTCA, EUROCAE, and FAA advisory-circular listings; per-row source links in the
+  matrix). That verification fixes each document's identity, title, and released
+  status as of that date. It does **not** establish authority acceptance:
+  authority-acceptance status is recorded separately per row and must be
+  re-verified with the selected authority at authority engagement.
 - No target aircraft, operating rule, certification authority, certification
   basis, or installed equipment has been selected. Applicability that depends on
   those selections is recorded as conditional, not resolved.
@@ -102,18 +108,34 @@ not the newest document available.
 | STD-050 | Airworthiness security process (DO-326A / ED-202A) | DO-326A / ED-202A | `not applicable` (current scope) as certification obligation | The airworthiness security process applies to airborne/ground systems within a certification program. The SIM-only program has no airborne system and no certification basis, so it carries no airworthiness-security obligation. The process may be adopted **selectively as engineering practice** for the simulator's trust boundaries. | Threat conditions and security assurance levels are undetermined absent a selected system and basis; the untrusted-interface analysis in [system boundary](system-boundary.md) is engineering input, not a security certification artifact. | Determined at system and basis selection. |
 | STD-051 | Airworthiness security methods (DO-356A / ED-203A) | DO-356A / ED-203A | `not applicable` (current scope) | Methods standard supporting DO-326A; inherits STD-050's applicability. | As STD-050. | Determined with STD-050. |
 | STD-052 | Continuing airworthiness security (DO-355 / ED-204) | DO-355 / ED-204 | `not applicable` (current scope) | Continuing-airworthiness security applies to fielded certified systems; none exists. | As STD-050. | Determined with STD-050. |
-| STD-053 | "DO-407 / ED-326" (as named in issue #28 acceptance criteria) | Not verified in this plan | `requires authority agreement` (identity to confirm) | Issue #28 acceptance criteria name "DO-407/ED-326" in the security context. This plan records that reference **verbatim** but does **not** assert it as a released standard in the recognized DO-326A/ED-202A security family: its identity and status were not independently confirmed here, and the tasking instructed against a web refresh. It is carried as a to-verify item rather than represented as an applicable standard. | The document number could not be reconciled to a confirmed released standard within this plan. | Confirm the correct document identity and status with the selected authority before citing it as a basis. |
 
-### Display, vision, and human factors
+The security family here is the DO-326A / ED-202A airworthiness-security set.
+DO-407 / ED-326 is **not** a security standard; it is the synthetic-vision MASPS
+and is classified under [SVS / SVGS / CVS vision systems](#svs--svgs--cvs-vision-systems),
+STD-066.
+
+### Display and human factors
 
 | ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
 | --- | --- | --- | --- | --- | --- | --- |
 | STD-060 | FAA AC 25-11B — electronic flight deck displays | AC 25-11B (guidance) | `authority-accepted` (guidance) | Recognized FAA guidance for electronic flight deck displays; used as the human-factors and display-integrity design reference for the PFD/HSI functions ([`AIR-OUT-001`](requirements.md#air-out-001)). | Applied as engineering input; no display is submitted for approval. Compliance is not asserted. | Regulatory paragraph mapping follows aircraft class selection. |
-| STD-061 | FAA AC 20-167A — airworthiness approval of EVS/SVS/CVS/EFVS equipment | AC 20-167A (guidance) | `latest engineering baseline` / applicable when SVS credit sought | Recognized FAA guidance for synthetic/enhanced vision approval. SVS here is **supplemental** situation awareness only ([`AIR-OUT-005`](requirements.md#air-out-005)); no operational vision credit is sought, so it is an engineering input. | Operational SVS credit would require the full guidance set, a performance standard, and a safety case not in current scope. | Required if operational SVS/EFVS credit is ever pursued. |
-| STD-062 | FAA AC 20-185 — airworthiness approval of synthetic vision systems | AC 20-185 (guidance) | `latest engineering baseline` / applicable when SVS credit sought | Companion synthetic-vision guidance; same conditional applicability as STD-061. | As STD-061. | Required if operational SVS credit is pursued. |
-| STD-063 | RTCA DO-315 / EUROCAE ED-179 — MASPS for EVS/SVS/CVS/EFVS | DO-315 / ED-179 family | `latest engineering baseline` / applicable when SVS credit sought | Minimum aviation system performance standards for vision systems; an engineering reference for SVS content only while SVS remains supplemental. | No performance credit claimed; the applicable member of the family depends on the SVS function selected. | Required if operational SVS/EFVS performance credit is pursued. |
-| STD-064 | SVGS / low-visibility operational credit guidance | Not selected | `not applicable` (current scope) | The baseline supplies **no** Synthetic Vision Guidance System function or low-visibility operational credit ([`AIR-OUT-009`](requirements.md#air-out-009)); the governing SVGS guidance is therefore not applicable. | Adding SVGS requires a distinct intended function, safety assessment, performance standard, and approval basis. | Required only if an SVGS function is introduced. |
-| STD-065 | FAA AC 20-181 (cited by AIR-03 tasking) | As cited by tasking | `requires authority agreement` (identity to confirm) | Listed in the AIR-03 tasking for display human factors. Its title and current applicability were **not independently verified** in this plan (no web refresh per tasking), so it is carried as a to-verify reference rather than asserted with a title. | Reference identity to confirm. | Confirm identity and applicability at authority engagement. |
+| STD-065 | [FAA AC 20-181](https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1023886) — airworthiness approval of Attitude Heading Reference System (AHRS) equipment | AC 20-181 (issued 2014-04-07; active) | `authority-accepted` (active FAA guidance) | Active FAA advisory circular supplementing airworthiness approval of AHRS articles approved under TSO-C201. This is **source-equipment** guidance, not general display human factors: the instrument functions consume AHRS-class attitude and heading data ([`AIR-IN-001`](requirements.md#air-in-001), [`AIR-IN-005`](requirements.md#air-in-005)), so AC 20-181 governs the eventual attitude/heading source rather than the display itself. | The SIM program supplies no airborne AHRS; applicability attaches to the attitude/heading source of a selected installation, not to browser demonstrations. | None to adopt; applies to the selected AHRS source equipment and its TSO. |
+
+### SVS / SVGS / CVS vision systems
+
+Synthetic-vision content here is **supplemental** situation awareness only
+([`AIR-OUT-005`](requirements.md#air-out-005)); no operational vision credit is
+sought. These rows carry an explicit **Authority acceptance** column because a
+released MASPS and an authority-recognized means of compliance are not the same
+thing, and the two diverge most sharply for the vision standards.
+
+| ID | Standard / reference | Selected revision | Authority status | Authority acceptance (2026-07-12) | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| STD-061 | FAA AC 20-167A — airworthiness approval of EVS/SVS/CVS/EFVS equipment | AC 20-167A (guidance) | `authority-accepted` (guidance) | Accepted (active FAA AC) | Recognized FAA approval guidance for synthetic/enhanced vision; an engineering input while SVS is supplemental. | Operational SVS credit would need the full guidance set, a performance standard, and a safety case not in current scope. | Required if operational SVS/EFVS credit is ever pursued. |
+| STD-062 | FAA AC 20-185 — airworthiness approval of synthetic vision systems | AC 20-185 (guidance) | `authority-accepted` (guidance) | Accepted (active FAA AC) | Companion synthetic-vision approval guidance; same conditional applicability as STD-061. | As STD-061. | Required if operational SVS credit is pursued. |
+| STD-063 | RTCA DO-315 / EUROCAE ED-179 — earlier MASPS for EVS/SVS/CVS/EFVS | DO-315 / ED-179 family | `latest engineering baseline` (earlier MASPS) | Not an FAA-named means of compliance; earlier engineering baseline, refined by STD-066 | Earlier vision-systems MASPS, retained as engineering reference; the current harmonized MASPS is DO-407 / ED-326 (STD-066). | No performance credit claimed; the applicable member of the family depends on the SVS function selected. | Required if operational SVS/EFVS performance credit is pursued. |
+| STD-066 | [RTCA DO-407](https://www.rtca.org/news/new-rtca-technical-products-address-global-aviation-functions-and-performance/) / [EUROCAE ED-326](https://www.eurocae.net/product/ed-326-masps-for-svs-svgs-cvs/) — MASPS for SVS, SVGS, and CVS | DO-407 (RTCA-approved 2024-12-12) / ED-326 (published 2025-01) | `latest engineering baseline` (released MASPS) | Not accepted — no recognizing FAA AC identified as of 2026-07-12; recognition **to confirm** at authority engagement (STD-066 open action) | Current harmonized RTCA SC-213 / EUROCAE WG-79 MASPS refining SVS, ASA-SVS, SVGS, and CVS performance for head-down and head-up displays; an engineering reference while SVS remains supplemental. Released engineering standard, distinct from the DO-326A / ED-202A security family. | No operational SVS/SVGS/CVS credit is sought; the applicable performance section depends on the function selected. | Required if operational SVS/SVGS/CVS credit is pursued; authority recognition of DO-407 / ED-326 must be confirmed first. |
+| STD-064 | SVGS / low-visibility operational credit guidance | Not selected | `not applicable` (current scope) | n/a — no SVGS function present | The baseline supplies **no** Synthetic Vision Guidance System function or low-visibility operational credit ([`AIR-OUT-009`](requirements.md#air-out-009)); the governing SVGS guidance is therefore not applicable. | Adding SVGS requires a distinct intended function, safety assessment, performance standard, and approval basis. | Required only if an SVGS function is introduced. |
 
 ### Development-process areas
 
@@ -147,15 +169,42 @@ not the newest document available.
   but AC 20-153B recognizes the revision it names; the anchor is therefore the
   recognized revision, with the newer one tracked as `requires authority
   agreement`.
-- **Security for a SIM-only program.** The DO-326A / ED-202A family is classified
-  `not applicable` as a *certification obligation* because there is no airborne
-  system or certification basis — not because security is unimportant. It may be
-  adopted selectively as engineering practice. The issue's "DO-407 / ED-326"
-  reference is recorded verbatim as a to-verify item (STD-053) rather than
-  asserted as a released standard, because its identity was not confirmed here.
+- **Security for a SIM-only program.** The DO-326A / ED-202A family (STD-050..
+  STD-052) is classified `not applicable` as a *certification obligation* because
+  there is no airborne system or certification basis — not because security is
+  unimportant. It may be adopted selectively as engineering practice.
+- **DO-407 / ED-326 are synthetic-vision MASPS, not security.** DO-407 (RTCA,
+  approved 2024-12-12 by SC-213) and ED-326 (EUROCAE, published 2025-01 by WG-79)
+  are the current harmonized Minimum Aviation System Performance Standards for SVS,
+  SVGS, and CVS. They are classified under vision systems (STD-066) as a released
+  engineering standard. Their **authority acceptance is recorded separately**: no
+  recognizing FAA AC was identified as of 2026-07-12, so acceptance is *not
+  established* and is tracked as an open verification action.
+- **AC 20-181 is AHRS-equipment guidance.** FAA AC 20-181 (issued 2014-04-07,
+  active) governs airworthiness approval of AHRS equipment under TSO-C201. It is
+  reclassified (STD-065) as active source-equipment guidance for the attitude and
+  heading sources the display consumes ([`AIR-IN-001`](requirements.md#air-in-001),
+  [`AIR-IN-005`](requirements.md#air-in-005)), not as a general display
+  human-factors reference.
 - **DO-254, environmental, installation, SVGS.** These are `not applicable` under
   the current SIM-only scope and are retained so their exclusion is explicit and
   revisited when scope changes, rather than silently dropped.
+
+## Open verification actions
+
+Any matrix row whose status is left unverified, to-verify, or to-confirm must
+have a corresponding entry here, keyed by its STD identifier, with the concrete
+unresolved action. `scripts/check-certification-claims.sh` fails CI if a row is
+marked unverified/to-verify/to-confirm/TBD without a matching entry in this
+section, so an open question can never quietly satisfy a coverage row.
+
+- **STD-066 (DO-407 / ED-326 authority acceptance).** The document identities and
+  released status are verified (RTCA DO-407 approved 2024-12-12; EUROCAE ED-326
+  published 2025-01). What is unresolved is **authority acceptance**: no FAA
+  advisory circular recognizing DO-407 / ED-326 as a means of compliance was
+  identified as of 2026-07-12. Action: at authority engagement, confirm with the
+  selected authority whether DO-407 / ED-326 (or a later revision) is recognized
+  before it is cited as a certification basis for any SVS/SVGS/CVS credit.
 
 ## Re-verification clause
 

--- a/docs/instruments/standards-applicability.md
+++ b/docs/instruments/standards-applicability.md
@@ -1,0 +1,167 @@
+# Standards applicability matrix (AIR-03)
+
+**SIM / NOT FOR FLIGHT.** This document classifies the industry standards,
+consensus references, and authority guidance that a future Pilotage instrument
+certification effort would draw on. It is an engineering planning artifact. It
+is **not** a compliance finding, a declaration that Pilotage meets any standard,
+an FAA/EASA finding, a TSO authorization, or a TC/STC approval. Nothing in this
+matrix authorizes airborne use of any Pilotage output.
+
+## Purpose
+
+The matrix separates *what current engineering practice would use* from *what a
+selected certification authority has formally recognized*. Those two are not the
+same: the newest revision of an industry standard is frequently ahead of the
+revision named in the authority guidance that would credit it. Recording the gap
+honestly — rather than quietly adopting the newest revision and implying it is
+accepted — is the entire point of this artifact.
+
+For each standard the matrix records: the selected revision, an authority-status
+classification, the rationale, known gaps, and whether an issue paper or explicit
+authority agreement would be required before the revision could be used as a
+certification basis.
+
+## Status of this matrix
+
+- This matrix records status **as of the plan date, 2026-07-12**. Standard
+  revisions, advisory-circular recognitions, and RTCA/EUROCAE publication states
+  change over time; every row **must be re-verified with the selected
+  certification authority at the point of authority engagement**. The matrix is a
+  planning input, not a standing statement of current recognition.
+- No target aircraft, operating rule, certification authority, certification
+  basis, or installed equipment has been selected. Applicability that depends on
+  those selections is recorded as conditional, not resolved.
+- This matrix builds on the AIR-01 intended-function baseline and the AIR-02
+  preliminary safety assessment. **Both are preliminary and pending independent
+  human review**: AIR-01 review is tracked by issue #24 and AIR-02 review by
+  issue #27, and both review records currently read `PENDING`
+  ([`AIR-BAS-006`](requirements.md#air-bas-006)). Assurance-level-dependent
+  applicability in this matrix is therefore provisional until AIR-02 closes.
+
+## Authority-status vocabulary
+
+Each row is classified as exactly one of the following for its *selected*
+revision. Where a newer industry revision exists, its status is recorded in the
+rationale and gap columns rather than by silently selecting it.
+
+| Status | Meaning |
+| --- | --- |
+| `authority-accepted` | The selected revision is the one recognized by active guidance from the anticipated authority (e.g. an FAA Advisory Circular that names it), so it can anchor a certification basis without a separate agreement. |
+| `latest engineering baseline` | The selected revision is the current industry revision and is used as engineering practice, but it is newer than the revision named in active authority guidance. |
+| `requires authority agreement` | The revision cannot be used as a certification basis until the selected authority agrees, typically through an issue paper or means-of-compliance record. |
+| `not applicable` | The standard governs a product element that is out of the current SIM-only scope; it is recorded so its exclusion is explicit and revisited if scope changes. |
+
+When a standard has a recognized anchor revision *and* a newer industry revision,
+the row selects the **anchor** revision as the status-bearing choice and records
+the newer revision as a tracked `requires authority agreement` item. This keeps
+the "selected revision" column honest: it names what could anchor a basis today,
+not the newest document available.
+
+## Matrix
+
+### Systems and safety
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-001 | SAE ARP4754 — development of civil aircraft and systems | ARP4754A (anchor); ARP4754B tracked | `authority-accepted` (A) | Active FAA AC 20-174 explicitly recognizes ARP4754A, so ARP4754A anchors the development-assurance process. ARP4754B is the current industry revision (a `latest engineering baseline`) but is ahead of the AC 20-174 recognition. | No aircraft/system selected, so development-assurance planning is provisional. Crediting ARP4754B is not yet supported by recognized guidance. | Issue paper / authority agreement **required** to credit ARP4754B in place of the AC 20-174-recognized ARP4754A. |
+| STD-002 | SAE ARP4761 — safety assessment process | ARP4761 (anchor); ARP4761A tracked | `authority-accepted` (original) | The safety-assessment guidance recognized alongside ARP4754A is the original ARP4761. ARP4761A is the current industry revision (a `latest engineering baseline`) and is newer than the recognized revision. | The AIR-02 FHA/PSSA are preliminary (issue #27 `PENDING`); the safety process is not exercised to closure. | Issue paper / authority agreement **required** to credit ARP4761A. |
+| STD-003 | Aircraft-level system safety objectives (25.1309 practice) | AC 25.1309-1B (guidance) | `authority-accepted` (guidance) | AC 25.1309-1B is recognized FAA guidance for system design and analysis and is the design reference used by AIR-02. It is applied as an engineering input, not as a satisfied objective. | No selected aircraft class or certification basis; the 25.1309 objective set is not allocated ([`AIR-HAZ-001`](requirements.md#air-haz-001)). | Authority agreement on the applicable regulatory paragraph follows aircraft selection. |
+
+### Software
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-010 | RTCA DO-178C — software considerations in airborne systems | DO-178C | `authority-accepted` | Active FAA AC 20-115D recognizes DO-178C as an accepted means of compliance for airborne software. It is the software-assurance anchor. | No software level is allocated; the assurance objectives that DO-178C scales by level are **deferred** until AIR-02 allocates levels (issue #27 `PENDING`). Prototype code is engineering input, not DO-178C lifecycle data (see [evidence plan](evidence-plan.md)). | None to adopt DO-178C itself; objective applicability follows the AIR-02 level allocation. |
+| STD-011 | RTCA DO-330 — software tool qualification considerations | DO-330 | `authority-accepted` | DO-330 is the tool-qualification framework referenced by DO-178C and recognized through AC 20-115D. Applicable when a tool's output is relied on without independent verification. | The set of tools requiring qualification, and their Tool Qualification Levels, cannot be fixed until software levels and the verification approach are set (AIR-02, issue #27 `PENDING`). | None to adopt DO-330; per-tool TQL determinations follow level allocation. |
+| STD-012 | RTCA DO-331 — model-based development and verification supplement | DO-331 | `authority-accepted` when invoked | Recognized supplement to DO-178C; applicable **only if** model-based development or verification is used. | Applicability undetermined: the development method for a future certified build is not selected. | None beyond the DO-178C basis; applies only if MBD is adopted. |
+| STD-013 | RTCA DO-332 — object-oriented technology and related techniques supplement | DO-332 | `authority-accepted` when invoked | Recognized supplement to DO-178C; applicable **only if** object-oriented or related techniques are used in certified software. | Applicability undetermined; the current prototype is not the certified architecture. | None beyond the DO-178C basis; applies only if OOT is adopted. |
+| STD-014 | RTCA DO-333 — formal methods supplement | DO-333 | `authority-accepted` when invoked | Recognized supplement to DO-178C; applicable **only if** formal methods are credited toward objectives. | Applicability undetermined; no formal-methods credit is claimed. | None beyond the DO-178C basis; applies only if formal-methods credit is sought. |
+
+### Complex hardware
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-020 | RTCA DO-254 — design assurance for airborne electronic hardware | DO-254 (revision recognized by AC 20-152A) | `not applicable` (current scope) | No custom or complex airborne electronic hardware is developed in the SIM-only program; there is no airborne display computer, FPGA, or ASIC in scope. AC 20-152A recognizes DO-254 for when such hardware exists. | A future installation that develops complex custom AEH (e.g. a display processor) would make DO-254 applicable and require a hardware-assurance plan. | Determined at hardware selection; not applicable until custom complex AEH enters scope. |
+
+### Environmental qualification
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-030 | RTCA DO-160 — environmental conditions and test procedures | DO-160G (current released revision) | `not applicable` (current scope) | Environmental qualification applies to installed airborne equipment, of which the SIM-only program has none. RTCA currently lists DO-160G as the current released revision; it is recorded as the revision to use **when** equipment is selected. **DO-160H is in work and is not listed here as an applicable released standard** — it must not be cited as a basis until it is published and the authority has dispositioned it. | No hardware to qualify; environmental categories cannot be assigned without a selected installation. | Determined at equipment selection; DO-160H excluded until published and dispositioned. |
+
+### Aeronautical data
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-040 | RTCA DO-200 / EUROCAE ED-76 — processing of aeronautical data | DO-200B / ED-76 (anchor); DO-200C / ED-76B tracked | `authority-accepted` (anchor) | Active FAA AC 20-153B recognizes the aeronautical-data revision it names as the accepted process. DO-200C / ED-76B is a current engineering baseline (a `latest engineering baseline`) and is newer than the AC 20-153B recognition. The synthetic-vision data chain ([`AIR-IN-011`](requirements.md#air-in-011)) would invoke this standard once an operational data supplier is used. | The program processes only simulator/reference data today; there is no operational aeronautical-data supply chain, so applicability is conditional. | Issue paper / authority agreement **required** to credit DO-200C / ED-76B in place of the AC 20-153B-recognized revision. |
+
+### Security
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-050 | Airworthiness security process (DO-326A / ED-202A) | DO-326A / ED-202A | `not applicable` (current scope) as certification obligation | The airworthiness security process applies to airborne/ground systems within a certification program. The SIM-only program has no airborne system and no certification basis, so it carries no airworthiness-security obligation. The process may be adopted **selectively as engineering practice** for the simulator's trust boundaries. | Threat conditions and security assurance levels are undetermined absent a selected system and basis; the untrusted-interface analysis in [system boundary](system-boundary.md) is engineering input, not a security certification artifact. | Determined at system and basis selection. |
+| STD-051 | Airworthiness security methods (DO-356A / ED-203A) | DO-356A / ED-203A | `not applicable` (current scope) | Methods standard supporting DO-326A; inherits STD-050's applicability. | As STD-050. | Determined with STD-050. |
+| STD-052 | Continuing airworthiness security (DO-355 / ED-204) | DO-355 / ED-204 | `not applicable` (current scope) | Continuing-airworthiness security applies to fielded certified systems; none exists. | As STD-050. | Determined with STD-050. |
+| STD-053 | "DO-407 / ED-326" (as named in issue #28 acceptance criteria) | Not verified in this plan | `requires authority agreement` (identity to confirm) | Issue #28 acceptance criteria name "DO-407/ED-326" in the security context. This plan records that reference **verbatim** but does **not** assert it as a released standard in the recognized DO-326A/ED-202A security family: its identity and status were not independently confirmed here, and the tasking instructed against a web refresh. It is carried as a to-verify item rather than represented as an applicable standard. | The document number could not be reconciled to a confirmed released standard within this plan. | Confirm the correct document identity and status with the selected authority before citing it as a basis. |
+
+### Display, vision, and human factors
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-060 | FAA AC 25-11B — electronic flight deck displays | AC 25-11B (guidance) | `authority-accepted` (guidance) | Recognized FAA guidance for electronic flight deck displays; used as the human-factors and display-integrity design reference for the PFD/HSI functions ([`AIR-OUT-001`](requirements.md#air-out-001)). | Applied as engineering input; no display is submitted for approval. Compliance is not asserted. | Regulatory paragraph mapping follows aircraft class selection. |
+| STD-061 | FAA AC 20-167A — airworthiness approval of EVS/SVS/CVS/EFVS equipment | AC 20-167A (guidance) | `latest engineering baseline` / applicable when SVS credit sought | Recognized FAA guidance for synthetic/enhanced vision approval. SVS here is **supplemental** situation awareness only ([`AIR-OUT-005`](requirements.md#air-out-005)); no operational vision credit is sought, so it is an engineering input. | Operational SVS credit would require the full guidance set, a performance standard, and a safety case not in current scope. | Required if operational SVS/EFVS credit is ever pursued. |
+| STD-062 | FAA AC 20-185 — airworthiness approval of synthetic vision systems | AC 20-185 (guidance) | `latest engineering baseline` / applicable when SVS credit sought | Companion synthetic-vision guidance; same conditional applicability as STD-061. | As STD-061. | Required if operational SVS credit is pursued. |
+| STD-063 | RTCA DO-315 / EUROCAE ED-179 — MASPS for EVS/SVS/CVS/EFVS | DO-315 / ED-179 family | `latest engineering baseline` / applicable when SVS credit sought | Minimum aviation system performance standards for vision systems; an engineering reference for SVS content only while SVS remains supplemental. | No performance credit claimed; the applicable member of the family depends on the SVS function selected. | Required if operational SVS/EFVS performance credit is pursued. |
+| STD-064 | SVGS / low-visibility operational credit guidance | Not selected | `not applicable` (current scope) | The baseline supplies **no** Synthetic Vision Guidance System function or low-visibility operational credit ([`AIR-OUT-009`](requirements.md#air-out-009)); the governing SVGS guidance is therefore not applicable. | Adding SVGS requires a distinct intended function, safety assessment, performance standard, and approval basis. | Required only if an SVGS function is introduced. |
+| STD-065 | FAA AC 20-181 (cited by AIR-03 tasking) | As cited by tasking | `requires authority agreement` (identity to confirm) | Listed in the AIR-03 tasking for display human factors. Its title and current applicability were **not independently verified** in this plan (no web refresh per tasking), so it is carried as a to-verify reference rather than asserted with a title. | Reference identity to confirm. | Confirm identity and applicability at authority engagement. |
+
+### Development-process areas
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-070 | Configuration management | DO-178C SCM objectives; ADR-0015 process | `authority-accepted` (framework) | DO-178C software configuration management objectives are the framework. Today the git history, pull-request record, and the ADR-0015 workspace quality gates form the configuration record (see [evidence plan](evidence-plan.md)). | The DO-178C SCM objective set scales by software level and is **deferred** until AIR-02 allocation (issue #27 `PENDING`). Prototype history is a configuration record of engineering work, not certified lifecycle configuration data. | None to adopt the framework; objective applicability follows level allocation. |
+| STD-071 | Quality assurance | DO-178C SQA objectives | `authority-accepted` (framework) | DO-178C software quality assurance objectives are the framework; CI quality gates are the current engineering practice. | SQA objectives are **deferred** until level allocation (issue #27 `PENDING`); an independent SQA function is not established. | Follows level allocation. |
+| STD-072 | Problem reporting | DO-178C problem-reporting objectives | `authority-accepted` (framework) | Problem reporting is currently the GitHub issue and pull-request record. DO-178C problem-reporting objectives are the framework for a certified build. | Formal problem-report classification and closure discipline are **deferred** until level allocation (issue #27 `PENDING`). | Follows level allocation. |
+
+### Installation and flight test
+
+| ID | Standard / reference | Selected revision | Authority status | Rationale | Known gaps | Issue paper / authority agreement |
+| --- | --- | --- | --- | --- | --- | --- |
+| STD-080 | Installation approval and flight-test evidence | Not selected | `not applicable` (current scope) | Installation approval, ground test, and flight-test evidence require an installed system on a selected aircraft. The SIM-only program has none; the airborne optical HUD and installation are explicitly outside the boundary ([`AIR-OUT-008`](requirements.md#air-out-008)). | Entirely conditional on aircraft, installation, and certification-basis selection. | Determined at installation; not applicable until an installation exists. |
+
+## Classification decisions worth flagging
+
+- **ARP4754B vs ARP4754A, and ARP4761A vs ARP4761.** The current industry
+  revisions (ARP4754B, ARP4761A) are recorded as `latest engineering baseline`
+  items, but the **anchor** selected for a basis is the revision that active FAA
+  AC 20-174 recognizes (ARP4754A, and the original ARP4761 alongside it). Using
+  the newer revisions as a certification basis requires authority agreement. This
+  is deliberate: adopting the newest document and implying it is accepted would be
+  exactly the misleading move this matrix exists to prevent.
+- **DO-160H is not listed as applicable.** DO-160G is the current released
+  revision per RTCA and is recorded as the revision to use when equipment is
+  selected. DO-160H is in work; it is named here only to state that it is **not**
+  an applicable released standard and must not be cited as a basis until it is
+  published and the authority disposition it.
+- **Aeronautical data.** DO-200C / ED-76B is the current engineering baseline,
+  but AC 20-153B recognizes the revision it names; the anchor is therefore the
+  recognized revision, with the newer one tracked as `requires authority
+  agreement`.
+- **Security for a SIM-only program.** The DO-326A / ED-202A family is classified
+  `not applicable` as a *certification obligation* because there is no airborne
+  system or certification basis — not because security is unimportant. It may be
+  adopted selectively as engineering practice. The issue's "DO-407 / ED-326"
+  reference is recorded verbatim as a to-verify item (STD-053) rather than
+  asserted as a released standard, because its identity was not confirmed here.
+- **DO-254, environmental, installation, SVGS.** These are `not applicable` under
+  the current SIM-only scope and are retained so their exclusion is explicit and
+  revisited when scope changes, rather than silently dropped.
+
+## Re-verification clause
+
+Every status in this matrix is provisional. Before any of it is used to plan a
+certification effort, each row must be re-verified against: the current revision
+published by the standards body, the advisory material recognized by the
+**selected** authority at that time, and the aircraft, operation, installation,
+and certification basis chosen for the program. Until then this matrix is an
+engineering planning input and confers no compliance credit.

--- a/scripts/check-certification-claims.sh
+++ b/scripts/check-certification-claims.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Fails CI when a tracked documentation or UI artifact asserts a
+# certification, compliance, approval, or airworthiness claim about this
+# project. Pilotage is SIM / NOT FOR FLIGHT: no artifact may state or imply that
+# any Pilotage output is certified, DO-178C compliant, FAA/EASA approved, or
+# airworthy.
+#
+# The standards and safety documents legitimately discuss these words in a
+# classification or negation context (e.g. "not certified", or enumerating the
+# banned vocabulary itself). They are exempted by an explicit allowlist and, in
+# exchange, are required to carry the SIM / NOT FOR FLIGHT banner so the exempt
+# set stays honest. Every other scanned artifact fails on the assertive-claim
+# patterns and the offending file:line is printed.
+#
+# This is a guard against misleading claims, not a proof of their absence: the
+# patterns target assertive phrasing and can be evaded by unusual wording. Treat
+# an addition to the allowlist as a reviewed decision.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+banner="SIM / NOT FOR FLIGHT"
+
+# Documents permitted to contain the claim vocabulary in a classification or
+# negation context. Each must carry the banner (checked below).
+allowlist=(
+    "docs/instruments/standards-applicability.md"
+    "docs/instruments/evidence-plan.md"
+    "docs/instruments/fha.md"
+    "docs/instruments/pssa.md"
+)
+
+# Assertive claim patterns (extended regex, matched case-insensitively). Neutral
+# uses such as "certification basis", "certification authority", "the certified
+# world", "does not claim certification", "continued-airworthiness", and "not a
+# compliance model" are intentionally not matched.
+claim_pattern='certifiable|airworthy|faa[ -]approved|faa[ -]certified|easa[ -]approved|flight[ -]certified|do-178[abc]?[ -]compliant|compliant with do-178|do-178[abc]?[ -]certified|meets( all)? do-178|fully compliant|(^|[^[:alnum:]])(is|are|now|fully|hereby|been|being|shall be) certified'
+
+is_allowlisted() {
+    local candidate="$1" allowed
+    for allowed in "${allowlist[@]}"; do
+        [ "$candidate" = "$allowed" ] && return 0
+    done
+    return 1
+}
+
+# Tracked documentation and UI artifacts. Rust/source crates are out of scope:
+# this guard is about the words the project publishes to humans.
+collect_scanned_files() {
+    git ls-files \
+        'docs/**/*.md' \
+        'README.md' \
+        'clients/web/*.html' \
+        'clients/web/*.js' \
+        'clients/web/*.mjs' \
+        '.github/**/*.md' \
+        '.github/ISSUE_TEMPLATE/*' \
+        '.github/PULL_REQUEST_TEMPLATE*' \
+        'CHANGELOG*' 'RELEASE*' 'HISTORY*'
+}
+
+status=0
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    [ -f "$file" ] || continue
+    if is_allowlisted "$file"; then
+        if ! grep -qF "$banner" "$file"; then
+            echo "MISSING BANNER: $file (allowlisted standards doc must carry '$banner')" >&2
+            status=1
+        fi
+        continue
+    fi
+    if hits="$(grep -HnEi "$claim_pattern" "$file")"; then
+        while IFS= read -r hit; do
+            echo "CERTIFICATION CLAIM: $hit" >&2
+        done <<< "$hits"
+        status=1
+    fi
+done < <(collect_scanned_files | LC_ALL=C sort -u)
+
+if [ "$status" -ne 0 ]; then
+    echo "check-certification-claims: FAILED" >&2
+    exit 1
+fi
+
+echo "check-certification-claims: OK"

--- a/scripts/check-certification-claims.sh
+++ b/scripts/check-certification-claims.sh
@@ -80,6 +80,44 @@ while IFS= read -r file; do
     fi
 done < <(collect_scanned_files | LC_ALL=C sort -u)
 
+# An open question must never quietly satisfy a coverage row: any matrix row
+# left unverified/to-verify/to-confirm/TBD must be reconciled by a matching
+# STD-keyed entry in the matrix's "Open verification actions" section.
+check_open_verification_actions() {
+    local matrix="docs/instruments/standards-applicability.md"
+    [ -f "$matrix" ] || return 0
+    awk '
+        # First pass: collect STD ids listed under "Open verification actions".
+        FNR == NR {
+            if ($0 ~ /^#+[ \t]+Open verification actions[ \t]*$/) { in_actions = 1; next }
+            if (in_actions && $0 ~ /^#+[ \t]/) { in_actions = 0 }
+            if (in_actions) {
+                s = $0
+                while (match(s, /STD-[0-9]+/)) {
+                    actions[substr(s, RSTART, RLENGTH)] = 1
+                    s = substr(s, RSTART + RLENGTH)
+                }
+            }
+            next
+        }
+        # Second pass: every matrix row carrying an unresolved marker must be keyed.
+        /^\|/ && /STD-[0-9]+/ {
+            low = tolower($0)
+            if (low ~ /to-verify|to verify|unverified|to be verified|to be determined|to[ -]confirm|(^|[^a-z])tbd([^a-z]|$)/) {
+                match($0, /STD-[0-9]+/)
+                id = substr($0, RSTART, RLENGTH)
+                if (!(id in actions)) {
+                    printf "UNRESOLVED VERIFICATION: %s:%d %s is marked unverified/to-verify/to-confirm/TBD without a matching entry in the \"Open verification actions\" section\n", FILENAME, FNR, id > "/dev/stderr"
+                    bad = 1
+                }
+            }
+        }
+        END { exit bad }
+    ' "$matrix" "$matrix" || status=1
+}
+
+check_open_verification_actions
+
 if [ "$status" -ne 0 ]; then
     echo "check-certification-claims: FAILED" >&2
     exit 1

--- a/scripts/trace-report.sh
+++ b/scripts/trace-report.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Emits a requirement / test / review / configuration inventory to the CI log.
+#
+# This is an INVENTORY, not a compliance trace. It counts and lists artifacts
+# that exist in the tree and reports review closure status verbatim. It does not
+# assert that any requirement is verified, any objective satisfied, or any review
+# complete, and it fabricates nothing: missing or pending evidence is reported as
+# missing or pending. A real certification trace is future lifecycle work (see
+# docs/instruments/evidence-plan.md).
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+document_dir="${PILOTAGE_INSTRUMENT_DOCUMENT_DIR:-docs/instruments}"
+catalog="$document_dir/requirements.md"
+review_record="$document_dir/review-record.md"
+pssa="$document_dir/pssa.md"
+
+if [ ! -f "$catalog" ]; then
+    echo "trace-report: missing $catalog" >&2
+    exit 1
+fi
+
+echo "=== Pilotage instrument trace inventory (NOT a compliance trace) ==="
+echo "Nothing below asserts verification or approval; pending evidence is"
+echo "reported as pending. See docs/instruments/evidence-plan.md."
+echo
+
+echo "--- Requirements (docs/instruments/requirements.md) ---"
+defined="$(grep -cE '^### AIR-[A-Z0-9]+-[0-9]{3} — ' "$catalog" || true)"
+echo "Defined requirement identifiers: $defined"
+# Unique identifiers referenced anywhere in the instrument docs (references are
+# occurrences outside the catalog's own definition headers and anchors).
+referenced="$(
+    {
+        grep -REo 'AIR-[A-Z0-9]+-[0-9]{3}' "$document_dir" --include='*.md' \
+            | sed 's/^.*://'
+    } | LC_ALL=C sort -u | wc -l | tr -d ' '
+)"
+echo "Distinct identifiers appearing across the docs: $referenced"
+echo "Requirement families defined:"
+grep -oE '^### AIR-[A-Z0-9]+-[0-9]{3}' "$catalog" \
+    | sed -E 's/^### (AIR-[A-Z0-9]+)-[0-9]{3}/\1/' \
+    | LC_ALL=C sort | uniq -c \
+    | sed 's/^/    /'
+echo
+
+echo "--- Tests present in the tree (inventory of artifacts, not results) ---"
+rust_tests="$(git ls-files '**/tests.rs' '**/tests/*.rs' | wc -l | tr -d ' ')"
+browser_suites="$(git ls-files 'clients/web/*.test.mjs' | wc -l | tr -d ' ')"
+echo "Rust test modules (tests.rs + tests/*.rs): $rust_tests"
+echo "Browser conformance suites (clients/web/*.test.mjs): $browser_suites"
+echo "Named test artifacts referenced from the docs:"
+grep -rhoE '[A-Za-z0-9_-]+\.test\.mjs|pilotage-instrument-[a-z]+' \
+    "$document_dir" --include='*.md' \
+    | LC_ALL=C sort -u \
+    | sed 's/^/    /' || true
+echo
+
+echo "--- Reviews (closure status, reported verbatim) ---"
+for record in "$review_record" "$pssa"; do
+    [ -f "$record" ] || continue
+    pending="$(grep -cE 'PENDING' "$record" || true)"
+    echo "$record: PENDING fields = $pending"
+done
+if [ -f "$review_record" ]; then
+    echo "AIR-01 closure decision lines:"
+    grep -E 'Tracking issue may close:|All three reviews complete:' "$review_record" \
+        | sed 's/^/    /' || true
+fi
+echo
+
+echo "--- Configuration record (git as the engineering configuration log) ---"
+head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+adr_count="$(git ls-files 'docs/adr/0*.md' | wc -l | tr -d ' ')"
+echo "HEAD commit: $head_sha"
+echo "Architecture decision records: $adr_count"
+echo "Structural/requirement guards in force:"
+for guard in scripts/check-structure.sh scripts/check-instrument-requirements.sh scripts/check-certification-claims.sh; do
+    [ -f "$guard" ] && echo "    $guard"
+done
+echo
+
+echo "trace-report: inventory emitted (informational; not a compliance trace)"


### PR DESCRIPTION
## AIR-03 — standards applicability, lifecycle evidence plan, certification-claim CI guard

**SIM / NOT FOR FLIGHT.** This is an assurance *planning* lane. Nothing here
claims or implies certification, compliance, or airworthiness for any Pilotage
output. The point is honest classification: separating current engineering
practice from what a certification authority has actually recognized, and drawing
a hard line between prototype engineering input and certified lifecycle data.

Builds on the **preliminary** AIR-01 (#24) and AIR-02 (#27) baselines, both
pending independent human review; assurance-level-dependent items here are
provisional until AIR-02 closes.

### Acceptance-criteria evidence

| Acceptance criterion (issue #28) | Where satisfied |
| --- | --- |
| Applicability matrix records selected revision, authority status, rationale, gaps, and required issue paper / authority agreement | `docs/instruments/standards-applicability.md` — matrix sections STD-001..STD-080, four-value authority-status vocabulary, plus an explicit Authority-acceptance column on the vision rows |
| Evidence plan covers ARP4754/4761, DO-178C, DO-254, DO-160, aeronautical data, security, synthetic-vision performance, display/alerting guidance, installation qualification | `docs/instruments/evidence-plan.md` — evidence index EVP-01..EVP-21 and the acceptance-criteria coverage section |
| CI produces requirement/test/review/configuration trace reports without fabricating missing evidence | `scripts/trace-report.sh` in CI; labeled an inventory, not a compliance trace; pending/missing evidence reported verbatim |
| Prototype history not retroactively represented as certified lifecycle data | `evidence-plan.md` — "Reuse as engineering input versus evidence established anew", with explicit non-back-claim statements |
| No UI/README/release/issue artifact claims certification | `scripts/check-certification-claims.sh` in CI; fails on assertive claims across tracked docs/UI, allowlisting only the standards/safety docs (which must carry the SIM banner) |
| Structural coverage deferred until AIR-02 allocates assurance | `evidence-plan.md` — "Structural coverage — deferred" (EVP-09) |

### Standards classifications (identities verified against publisher listings on 2026-07-12)

- **ARP4754B / ARP4761A** are *latest engineering baseline*; the status-bearing
  anchor is the AC 20-174-recognized revision (ARP4754A / original ARP4761).
  Crediting the newer revisions needs authority agreement.
- **DO-160H is not listed as applicable.** DO-160G is the current released
  revision; DO-160H is in work and named only to state it is excluded until
  published and dispositioned.
- **Aeronautical data:** DO-200C/ED-76B is the engineering baseline; anchor is the
  AC 20-153B-recognized revision, newer one requires authority agreement.
- **Security (SIM-only):** the DO-326A/ED-202A family (STD-050..STD-052) is *not
  applicable* as a certification obligation (no airborne system/basis), adoptable
  as engineering practice.
- **DO-407 / ED-326 are the synthetic-vision MASPS, not security.** RTCA DO-407
  (approved 2024-12-12 by SC-213) and EUROCAE ED-326 ("MASPS for SVS SVGS CVS",
  published 2025-01 by WG-79) are the current harmonized MASPS for SVS/SVGS/CVS.
  Classified under vision systems (**STD-066**) as a released engineering standard;
  authority acceptance recorded **separately** as *not accepted — no recognizing
  FAA AC identified as of 2026-07-12*, tracked as an open verification action.
- **AC 20-181 is AHRS-equipment guidance, active.** "Airworthiness Approval of
  Attitude Heading Reference System (AHRS) Equipment" (issued 2014-04-07, active,
  supplements TSO-C201). Reclassified (**STD-065**) as source-equipment guidance
  for the attitude/heading sources the display consumes (AIR-IN-001, AIR-IN-005),
  not a general display human-factors reference.

### Review fixes applied on this branch (commit `d20df46`)

The initial revision mis-placed DO-407/ED-326 under security as an unverified
reference and left AC 20-181 unclassified. Corrected here, with authoritative
sources:

- RTCA DO-407 — MASPS refining SVS/ASA-SVS/SVGS/CVS performance, approved
  2024-12-12 (RTCA SC-213 / EUROCAE WG-79): https://www.rtca.org/news/new-rtca-technical-products-address-global-aviation-functions-and-performance/
- EUROCAE ED-326 — "MASPS for SVS SVGS CVS", January 2025: https://www.eurocae.net/product/ed-326-masps-for-svs-svgs-cvs/
- FAA AC 20-181 — "Airworthiness Approval of AHRS Equipment", 2014-04-07, active: https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1023886

The retired "no web refresh" narrative is removed. The matrix header now carries a
dated identity-verification note ("identities verified against publisher listings
on 2026-07-12; authority acceptance recorded separately and re-verified at
authority engagement").

### Guards proven red

1. **Certification-claim guard.** Injecting `The Pilotage PFD is certifiable and
   DO-178C compliant, and the display is FAA-approved.` into a scanned,
   non-allowlisted file fails with the offending `file:line`; removing it restores
   `OK`.
2. **Unverified-row guard (new).** Injecting a matrix row marked `to-verify`
   without a matching entry in the "Open verification actions" section fails:
   ```
   UNRESOLVED VERIFICATION: docs/instruments/standards-applicability.md:153 STD-999 is marked unverified/to-verify/to-confirm/TBD without a matching entry in the "Open verification actions" section
   check-certification-claims: FAILED  (exit 1)
   ```
   Removing it restores `OK`. STD-066 (DO-407/ED-326 authority acceptance) is the
   one genuine open item and is reconciled by its recorded action.

Current tree is green on `check-certification-claims.sh`, `trace-report.sh`, and
`check-instrument-requirements.sh`.

### Notes

- The two allowlisted new docs and `fha.md`/`pssa.md` each carry the SIM banner
  (enforced by the guard's banner check).
- This lane touched only `docs/instruments/**`, the two scripts, and appended
  steps to `.github/workflows/ci.yml`. No Rust changed.

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
