### PR TITLE
HUD-01: preserve video capture identity and clock mapping end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
 name = "pilotage-adapter-gazebo"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "pilotage-adapter-api",
  "pilotage-protocol",
  "pilotage-timing",

--- a/adapters/aviate/src/adapter/camera.rs
+++ b/adapters/aviate/src/adapter/camera.rs
@@ -1,5 +1,17 @@
 //! The gz camera sidecar path: Pilotage's own C++ gz-transport bridge
 //! delivers the flight world's `/camera` and `/chase_camera` frames.
+//!
+//! The frames are captured on the sidecar's simulation clock, but Aviate's
+//! flight state is estimated on the flight controller's vehicle-boot clock.
+//! No correlation between those two clocks is available, so every frame is
+//! stamped with an unavailable clock mapping (ADR-0020): a consumer must gate
+//! conformal overlay off rather than draw against a state it cannot align to
+//! the image. The capture identity itself (source, epoch, sequence, sim
+//! capture time) is still preserved honestly.
+
+use pilotage_adapter_gazebo::FrameStamper;
+
+use crate::incarnation::{IncarnationProvider, OsIncarnationProvider};
 
 /// Spawns the gz camera sidecar for the flight world's `/camera` and
 /// `/chase_camera` topics, degrading to no-video when it can't
@@ -13,6 +25,13 @@ pub(crate) async fn spawn_camera_bridge() -> (
     if std::env::var("PILOTAGE_AVIATE_CAMERA").as_deref() == Ok("off") {
         return (None, None, None);
     }
+    let incarnation = match OsIncarnationProvider.next_incarnation_blocking() {
+        Ok(incarnation) => incarnation,
+        Err(error) => {
+            tracing::warn!(%error, "no capture incarnation available; no video");
+            return (None, None, None);
+        }
+    };
     let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)
@@ -22,11 +41,16 @@ pub(crate) async fn spawn_camera_bridge() -> (
     match pilotage_adapter_gazebo::BridgeClient::spawn_and_connect(config).await {
         Ok(mut bridge) => {
             let (tx, rx) = tokio::sync::mpsc::channel(4);
+            // Aviate has no correlation between the sim capture clock and the
+            // flight controller's clock, so the mapping is unavailable.
+            let mut stamper = FrameStamper::new(
+                incarnation,
+                pilotage_adapter_api::CaptureClockMapping::Unavailable,
+            );
             let forwarder = bridge.take_frame_rx().map(|mut bridge_rx| {
                 tokio::spawn(async move {
                     while let Some(frame) = bridge_rx.recv().await {
-                        let raw = pilotage_adapter_gazebo::RawVideoFrame::from(frame);
-                        if tx.send(raw).await.is_err() {
+                        if tx.send(stamper.stamp(frame)).await.is_err() {
                             return;
                         }
                     }

--- a/adapters/gazebo/Cargo.toml
+++ b/adapters/gazebo/Cargo.toml
@@ -13,6 +13,7 @@ pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sync", "io-util", "time", "process"] }
 prost = { workspace = true }
+getrandom = { version = "0.3.4", features = ["std"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -8,9 +8,10 @@
 //! because streaming video does not fit the pull-based `sample_telemetry` shape.
 
 use pilotage_adapter_api::{
-    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossPolicy, Pose2d,
-    RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch, TelemetrySample,
-    VehicleAdapter, VehicleDescriptor, VideoSource,
+    AdapterCapabilities, ApplyOutcome, CaptureClockMapping, Disposition, ExecutionMode,
+    LinkLossPolicy, MeasurementClock, Pose2d, RejectReason, ScopeDescriptor, SourceIncarnation,
+    StepBudget, StepOutcome, TelemetryBatch, TelemetrySample, VehicleAdapter, VehicleDescriptor,
+    VideoCaptureStamp, VideoSource,
 };
 use pilotage_protocol::{LogicalAxisId, ScopeId, ScopedControlFrame, VehicleId};
 use pilotage_timing::SimTick;
@@ -19,6 +20,7 @@ use tokio::task::JoinHandle;
 
 use crate::bridge_client::{BridgeClient, BridgeConfig};
 use crate::error::GazeboAdapterError;
+use crate::video::FrameStamper;
 use crate::wire::{BridgeControl, BridgeFrame, BridgeOdometry};
 
 /// The control scope this adapter exposes for the diff-drive vehicle.
@@ -36,13 +38,15 @@ pub const FPV_CAMERA: u8 = 0;
 /// Wire source id of the chase camera.
 pub const CHASE_CAMERA: u8 = 1;
 
-/// A decoded raw camera frame from the sidecar bridge, paired with the
-/// simulation tick it was captured at.
+/// A decoded raw camera frame from the sidecar bridge, carrying the capture
+/// identity and clock mapping needed to trace it back to the aircraft state
+/// (ADR-0020).
 ///
 /// Exposed via [`GazeboAdapter::subscribe_frames`] alongside the
 /// `VehicleAdapter` trait rather than through it: frame delivery is a
 /// streaming, backpressure-sensitive concern that does not fit the pull-based
-/// `sample_telemetry` shape (ADR-0008).
+/// `sample_telemetry` shape (ADR-0008). A frame is only ever built by a
+/// [`FrameStamper`], so its [`capture`](Self::capture) is always fully formed.
 #[derive(Debug, Clone)]
 pub struct RawVideoFrame {
     /// Video source this frame came from: 0 = onboard FPV, 1 = chase. Carried
@@ -55,27 +59,13 @@ pub struct RawVideoFrame {
     pub height: u32,
     /// Sidecar-reported pixel format (e.g. `"RGB_INT8"`).
     pub pixel_format: String,
-    /// Simulation tick this frame was captured at (sidecar sim time, ns).
+    /// Simulation tick this frame was captured at (sidecar sim time, ns). Also
+    /// carried in [`Self::capture`] as the capture stamp's acquisition time.
     pub tick: SimTick,
     /// Raw pixel bytes, row-major, no padding.
     pub rgb: Vec<u8>,
-}
-
-impl From<BridgeFrame> for RawVideoFrame {
-    fn from(frame: BridgeFrame) -> Self {
-        Self {
-            // Bridge `camera_id` is a u32 for wire headroom, but only ids 0
-            // (FPV) / 1 (chase) are assigned; an out-of-range id saturates to
-            // u8::MAX so the reader routes it to no known source rather than
-            // aliasing onto a valid one.
-            source_id: u8::try_from(frame.camera_id).unwrap_or(u8::MAX),
-            width: frame.width,
-            height: frame.height,
-            pixel_format: frame.pixel_format,
-            tick: SimTick::new(frame.sim_time_ns),
-            rgb: frame.rgb,
-        }
-    }
+    /// Capture identity and clock mapping for this frame (ADR-0020).
+    pub capture: VideoCaptureStamp,
 }
 
 /// `VehicleAdapter` implementation that drives a real Gazebo diff-drive
@@ -110,9 +100,10 @@ impl GazeboAdapter {
         let mut bridge = BridgeClient::spawn_and_connect(config).await?;
 
         let (raw_tx, raw_rx) = mpsc::channel::<RawVideoFrame>(depth);
+        let stamper = FrameStamper::new(new_incarnation()?, sim_capture_mapping());
         let frame_forwarder = bridge
             .take_frame_rx()
-            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx)));
+            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx, stamper)));
 
         Ok(Self {
             vehicle,
@@ -128,9 +119,10 @@ impl GazeboAdapter {
     #[cfg(test)]
     fn from_bridge(vehicle: VehicleId, mut bridge: BridgeClient) -> Self {
         let (raw_tx, raw_rx) = mpsc::channel::<RawVideoFrame>(4);
+        let stamper = FrameStamper::new(SourceIncarnation::new([0; 16]), sim_capture_mapping());
         let frame_forwarder = bridge
             .take_frame_rx()
-            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx)));
+            .map(|bridge_rx| tokio::spawn(forward_frames(bridge_rx, raw_tx, stamper)));
         Self {
             vehicle,
             bridge,
@@ -259,14 +251,36 @@ fn telemetry_from_odometry(vehicle: VehicleId, odom: &BridgeOdometry) -> Telemet
     }
 }
 
-/// Forwards `BridgeFrame`s to the adapter's `RawVideoFrame` channel until
-/// either end closes.
+/// Draws an opaque 128-bit attachment incarnation for this adapter's camera
+/// capture identity from the operating-system CSPRNG.
+///
+/// # Errors
+///
+/// Returns [`GazeboAdapterError::IncarnationUnavailable`] if the OS entropy
+/// source is unavailable.
+fn new_incarnation() -> Result<SourceIncarnation, GazeboAdapterError> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|source| GazeboAdapterError::IncarnationUnavailable { source })?;
+    Ok(SourceIncarnation::new(bytes))
+}
+
+/// The capture-clock mapping for the Gazebo sidecar: the sim clock that stamps
+/// the frames is the same clock that stamps this adapter's telemetry, so the
+/// mapping is the identity with zero residual error (ADR-0020).
+fn sim_capture_mapping() -> CaptureClockMapping {
+    CaptureClockMapping::identity(MeasurementClock::Simulation)
+}
+
+/// Forwards `BridgeFrame`s to the adapter's `RawVideoFrame` channel, stamping
+/// each with capture identity via `stamper`, until either end closes.
 async fn forward_frames(
     mut bridge_rx: mpsc::Receiver<BridgeFrame>,
     raw_tx: mpsc::Sender<RawVideoFrame>,
+    mut stamper: FrameStamper,
 ) {
     while let Some(frame) = bridge_rx.recv().await {
-        if raw_tx.send(RawVideoFrame::from(frame)).await.is_err() {
+        if raw_tx.send(stamper.stamp(frame)).await.is_err() {
             return;
         }
     }

--- a/adapters/gazebo/src/adapter/tests.rs
+++ b/adapters/gazebo/src/adapter/tests.rs
@@ -218,6 +218,17 @@ async fn camera_frame_reaches_the_subscriber() {
     assert_eq!(frame.height, 2);
     assert_eq!(frame.tick.as_u64(), 77);
     assert_eq!(frame.rgb.len(), 24);
+    // The adapter stamps a capture identity: the sidecar sim time becomes the
+    // capture acquisition time, and the sim clock maps to itself (ADR-0020).
+    assert_eq!(frame.capture.stamp.acquired_at_ns, 77);
+    assert_eq!(
+        frame.capture.stamp.sequence, 0,
+        "first FPV frame is sequence 0"
+    );
+    assert!(
+        frame.capture.mapping.is_available(),
+        "sim capture clock maps to sim telemetry clock"
+    );
 }
 
 #[tokio::test]

--- a/adapters/gazebo/src/error.rs
+++ b/adapters/gazebo/src/error.rs
@@ -76,4 +76,12 @@ pub enum GazeboAdapterError {
         /// Human-readable description of why the task ended.
         reason: String,
     },
+    /// Drawing an opaque attachment incarnation for the camera capture
+    /// identity from the operating-system CSPRNG failed.
+    #[error("failed to obtain a capture incarnation from the OS CSPRNG: {source}")]
+    IncarnationUnavailable {
+        /// Underlying `getrandom` error.
+        #[source]
+        source: getrandom::Error,
+    },
 }

--- a/adapters/gazebo/src/lib.rs
+++ b/adapters/gazebo/src/lib.rs
@@ -8,6 +8,7 @@ mod adapter;
 mod bridge_client;
 mod error;
 mod framing;
+mod video;
 pub mod wire;
 
 pub use adapter::{
@@ -16,3 +17,4 @@ pub use adapter::{
 };
 pub use bridge_client::{BRIDGE_BIN_ENV, BridgeClient, BridgeConfig, LatestBridgeState};
 pub use error::GazeboAdapterError;
+pub use video::FrameStamper;

--- a/adapters/gazebo/src/video.rs
+++ b/adapters/gazebo/src/video.rs
@@ -1,0 +1,204 @@
+//! Stamping raw sidecar camera frames with capture identity and a clock
+//! mapping to the flight-state clock (ADR-0020).
+//!
+//! The sidecar reports each frame with a sim-time capture stamp but no
+//! source identity or sequence; this module supplies both. One
+//! [`FrameStamper`] is bound to a single adapter attachment: it holds that
+//! attachment's opaque incarnation, advances a wrapping per-source sequence,
+//! and attaches the caller-declared mapping from the sim capture clock to the
+//! flight-state clock. Stamping is the sole constructor of a
+//! [`RawVideoFrame`]'s [`VideoCaptureStamp`], so a frame can never reach a
+//! reader without a fully-formed capture identity.
+
+use std::collections::BTreeMap;
+
+use pilotage_adapter_api::{
+    CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, MeasurementStamp,
+    SourceIncarnation, VideoCaptureStamp,
+};
+use pilotage_timing::SimTick;
+
+use crate::adapter::RawVideoFrame;
+use crate::wire::BridgeFrame;
+
+/// Assigns capture identity to every frame of one adapter attachment.
+///
+/// Bound to a single incarnation for its lifetime; a new attachment
+/// constructs a new stamper with a fresh incarnation. The wrapping sequence
+/// is tracked independently per routing source so the FPV and chase streams
+/// order separately.
+#[derive(Debug)]
+pub struct FrameStamper {
+    incarnation: SourceIncarnation,
+    epoch: u32,
+    mapping: CaptureClockMapping,
+    next_sequence: BTreeMap<u8, u32>,
+}
+
+impl FrameStamper {
+    /// Builds a stamper for one attachment identified by `incarnation`, whose
+    /// frames map to the flight-state clock via `mapping`.
+    #[must_use]
+    pub fn new(incarnation: SourceIncarnation, mapping: CaptureClockMapping) -> Self {
+        Self {
+            incarnation,
+            epoch: 0,
+            mapping,
+            next_sequence: BTreeMap::new(),
+        }
+    }
+
+    /// Advances the attachment's epoch to mark a capture discontinuity (e.g. a
+    /// sidecar reconnect), resetting every source's sequence so a receiver
+    /// treats subsequent frames as a fresh, unordered start. Uses
+    /// `wrapping_add(1)`, never `+= 1`, so a debug build cannot panic at the
+    /// `u32` boundary.
+    pub fn reset_epoch(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+        self.next_sequence.clear();
+    }
+
+    /// Consumes one sidecar frame and returns it stamped with a complete
+    /// capture identity: the attachment incarnation and epoch, a wrapping
+    /// per-source sequence, the sim capture time, the camera identity, and the
+    /// clock mapping.
+    #[must_use]
+    pub fn stamp(&mut self, frame: BridgeFrame) -> RawVideoFrame {
+        // The sidecar camera_id is a u32 for wire headroom, but only ids 0
+        // (FPV) / 1 (chase) are assigned; an out-of-range id saturates to
+        // u8::MAX so a reader routes it to no known source rather than
+        // aliasing onto a valid one.
+        let source_id = u8::try_from(frame.camera_id).unwrap_or(u8::MAX);
+        let sequence = self.take_sequence(source_id);
+        let stamp = MeasurementStamp {
+            source_id: u64::from(source_id),
+            source_incarnation: self.incarnation,
+            source_epoch: self.epoch,
+            sequence,
+            acquired_at_ns: frame.sim_time_ns,
+            clock: MeasurementClock::Simulation,
+        };
+        RawVideoFrame {
+            source_id,
+            width: frame.width,
+            height: frame.height,
+            pixel_format: frame.pixel_format,
+            tick: SimTick::new(frame.sim_time_ns),
+            rgb: frame.rgb,
+            capture: VideoCaptureStamp {
+                stamp,
+                camera_id: CameraId(frame.camera_id),
+                // The Gazebo sidecar publishes no calibration identity.
+                calibration_id: CalibrationId::NONE,
+                mapping: self.mapping,
+            },
+        }
+    }
+
+    /// Returns the next sequence for `source_id` and advances the stored value
+    /// with `wrapping_add(1)`, so the counter cycles at the `u32` boundary
+    /// instead of panicking in a debug build.
+    fn take_sequence(&mut self, source_id: u8) -> u32 {
+        let slot = self.next_sequence.entry(source_id).or_insert(0);
+        let sequence = *slot;
+        *slot = slot.wrapping_add(1);
+        sequence
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::FrameStamper;
+    use pilotage_adapter_api::{
+        CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, SourceIncarnation,
+    };
+
+    use crate::wire::BridgeFrame;
+
+    fn bridge_frame(camera_id: u32, sim_time_ns: u64) -> BridgeFrame {
+        BridgeFrame {
+            width: 4,
+            height: 4,
+            pixel_format: "RGB_INT8".to_owned(),
+            sim_time_ns,
+            rgb: vec![0; 48],
+            camera_id,
+        }
+    }
+
+    fn stamper() -> FrameStamper {
+        FrameStamper::new(
+            SourceIncarnation::new([9; 16]),
+            CaptureClockMapping::identity(MeasurementClock::Simulation),
+        )
+    }
+
+    #[test]
+    fn sequences_advance_per_source_from_zero() {
+        let mut stamper = stamper();
+        let fpv0 = stamper.stamp(bridge_frame(0, 100));
+        let chase0 = stamper.stamp(bridge_frame(1, 110));
+        let fpv1 = stamper.stamp(bridge_frame(0, 120));
+        assert_eq!(fpv0.capture.stamp.sequence, 0);
+        assert_eq!(fpv1.capture.stamp.sequence, 1, "FPV advances independently");
+        assert_eq!(
+            chase0.capture.stamp.sequence, 0,
+            "chase starts its own count"
+        );
+        assert_eq!(fpv0.source_id, 0);
+        assert_eq!(chase0.source_id, 1);
+    }
+
+    #[test]
+    fn stamp_carries_capture_time_camera_and_mapping() {
+        let mut stamper = stamper();
+        let frame = stamper.stamp(bridge_frame(1, 4_242));
+        assert_eq!(frame.capture.stamp.acquired_at_ns, 4_242);
+        assert_eq!(frame.capture.stamp.clock, MeasurementClock::Simulation);
+        assert_eq!(frame.capture.camera_id, CameraId(1));
+        assert_eq!(frame.capture.calibration_id, CalibrationId::NONE);
+        assert!(frame.capture.mapping.is_available());
+        assert_eq!(frame.capture.mapping.error_bound_ns(), Some(0));
+        assert_eq!(
+            frame.capture.stamp.source_incarnation,
+            SourceIncarnation::new([9; 16])
+        );
+    }
+
+    #[test]
+    fn reset_epoch_bumps_generation_and_restarts_sequences() {
+        let mut stamper = stamper();
+        let before = stamper.stamp(bridge_frame(0, 100));
+        assert_eq!(before.capture.stamp.source_epoch, 0);
+        assert_eq!(before.capture.stamp.sequence, 0);
+        stamper.reset_epoch();
+        let after = stamper.stamp(bridge_frame(0, 200));
+        assert_eq!(after.capture.stamp.source_epoch, 1, "epoch advanced");
+        assert_eq!(
+            after.capture.stamp.sequence, 0,
+            "sequence restarted after reset"
+        );
+    }
+
+    #[test]
+    fn sequence_wraps_at_the_u32_boundary() {
+        let mut stamper = stamper();
+        stamper.next_sequence.insert(0, u32::MAX);
+        let wrap = stamper.stamp(bridge_frame(0, 1));
+        let after = stamper.stamp(bridge_frame(0, 2));
+        assert_eq!(wrap.capture.stamp.sequence, u32::MAX);
+        assert_eq!(after.capture.stamp.sequence, 0, "wraps to 0, never panics");
+    }
+
+    #[test]
+    fn unavailable_mapping_is_carried_verbatim() {
+        let mut stamper = FrameStamper::new(
+            SourceIncarnation::new([1; 16]),
+            CaptureClockMapping::Unavailable,
+        );
+        let frame = stamper.stamp(bridge_frame(0, 1));
+        assert!(!frame.capture.mapping.is_available());
+        assert_eq!(frame.capture.mapping.error_bound_ns(), None);
+    }
+}

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -11,9 +11,10 @@
 // host's dev cert hash, open a bidi stream, send ClientHello, read
 // ServerWelcome, send a LeaseRequest for vehicle.motion, read LeaseResponse.
 // Then: accept host-initiated uni streams and dispatch on their leading
-// kind-tag byte (0x01 authority-events, 0x02 one video frame); read
-// telemetry-fast datagrams for live pose; send control-fast datagrams
-// (bare Envelope, ControlFrame arm) from arrow/WASD key state.
+// kind-tag byte (0x01 authority-events, 0x03 one video frame with a capture
+// identity header, 0x02 the legacy video frame); read telemetry-fast datagrams
+// for live pose; send control-fast datagrams (bare Envelope, ControlFrame arm)
+// from arrow/WASD key state.
 
 import {
   encodeClientHelloEnvelope,
@@ -21,10 +22,13 @@ import {
   encodeControlFrameEnvelope,
   decodeLengthDelimitedEnvelope,
   decodeBareEnvelope,
+  parseVideoFrameV2,
   STREAM_KIND_AUTHORITY,
   STREAM_KIND_VIDEO,
+  STREAM_KIND_VIDEO_V2,
   BUTTON_EDGE_PRESSED,
 } from "./wire.js";
+import { VideoIdentityTracker } from "./video-identity.js";
 import { loadInstruments, PANEL } from "./instruments.js";
 import {
   coverInstrumentFailures,
@@ -93,8 +97,17 @@ const state = {
   connected: false,
   leaseGranted: false,
   skippedVideoFrames: 0,
+  droppedIdentityFrames: 0,
+  // Latest conformal-overlay verdict per source. Defaults unavailable: a
+  // conformal overlay is only admissible once a source presents a bounded
+  // clock mapping (ADR-0020). Conformal drawing itself does not exist yet.
+  conformalReady: false,
 };
 const transportSessions = new TransportSessionLifecycle();
+// Capture-identity guard for the video downlink: drops duplicate/reordered/
+// stale frames so a replayed frame never displaces a newer one or refreshes
+// its age (ADR-0020).
+const videoIdentity = new VideoIdentityTracker();
 
 // Ingestion accepts only source advancement for the selected vehicle. Drawing
 // remains on requestAnimationFrame, decoupled from telemetry publication.
@@ -395,6 +408,8 @@ async function readOneUniStream(stream, token) {
     const body = buf.subarray(1);
     if (kind === STREAM_KIND_AUTHORITY) {
       dispatchAuthorityStream(body, token);
+    } else if (kind === STREAM_KIND_VIDEO_V2) {
+      await renderVideoFrameV2(body, token);
     } else if (kind === STREAM_KIND_VIDEO) {
       await renderVideoFrame(body, token);
     } else {
@@ -420,9 +435,7 @@ function dispatchAuthorityStream(body, token) {
   }
 }
 
-// Video body is `[source_id: u8][fourcc: 4 bytes][u32 LE len][payload]` after
-// the kind tag (ADR-0016; host stream_tag.rs `frame_video_payload`). The
-// source_id (0 = onboard FPV, 1 = chase) routes the frame to its canvas. An
+// The source_id (0 = onboard FPV, 1 = chase) routes a frame to its canvas. An
 // unknown source_id or unknown FourCC is counted and logged, never a hard
 // failure, so a host streaming a source or codec this viewer lacks degrades
 // gracefully. Only "MJPG" is decoded here.
@@ -434,29 +447,10 @@ const VIDEO_TARGETS = {
   [SOURCE_CHASE]: { canvas: els.chaseCanvas, ctx: chaseCtx },
 };
 
-async function renderVideoFrame(body, token) {
-  if (!transportSessions.isActive(token)) return;
-  if (body.length < 9) return;
-  const sourceId = body[0];
-  const fourcc = String.fromCharCode(body[1], body[2], body[3], body[4]);
-  const view = new DataView(body.buffer, body.byteOffset + 5, 4);
-  const len = view.getUint32(0, true);
-  const payload = body.subarray(9, 9 + len);
-  if (payload.length !== len) {
-    log(`video frame length mismatch: declared ${len}, got ${payload.length}`);
-    return;
-  }
-  const target = VIDEO_TARGETS[sourceId];
-  if (!target) {
-    state.skippedVideoFrames += 1;
-    log(`unknown video source_id ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
-    return;
-  }
-  if (fourcc !== FOURCC_MJPEG) {
-    state.skippedVideoFrames += 1;
-    log(`unknown video codec FourCC "${fourcc}" for source ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
-    return;
-  }
+/** Decodes one MJPEG payload and blits it to `target`, resizing its canvas to
+ *  the frame. Session-token checked around the async decode so a frame decoded
+ *  after teardown is dropped. */
+async function paintJpeg(payload, target, token) {
   const bitmap = await createImageBitmap(new Blob([payload], { type: "image/jpeg" }));
   if (!transportSessions.isActive(token)) {
     bitmap.close();
@@ -469,6 +463,74 @@ async function renderVideoFrame(body, token) {
   }
   targetCtx.drawImage(bitmap, 0, 0);
   bitmap.close();
+}
+
+/** Resolves a frame's routing target and codec, counting/logging a skip for an
+ *  unknown source or FourCC. Returns the target, or `null` to skip. */
+function videoTargetFor(sourceId, fourcc) {
+  const target = VIDEO_TARGETS[sourceId];
+  if (!target) {
+    state.skippedVideoFrames += 1;
+    log(`unknown video source_id ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
+    return null;
+  }
+  if (fourcc !== FOURCC_MJPEG) {
+    state.skippedVideoFrames += 1;
+    log(`unknown video codec FourCC "${fourcc}" for source ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
+    return null;
+  }
+  return target;
+}
+
+// v1 video body `[source_id][fourcc][u32 LE len][payload]` (ADR-0016), retained
+// so a host that has not adopted the v2 capture-identity framing still renders.
+async function renderVideoFrame(body, token) {
+  if (!transportSessions.isActive(token)) return;
+  if (body.length < 9) return;
+  const sourceId = body[0];
+  const fourcc = String.fromCharCode(body[1], body[2], body[3], body[4]);
+  const view = new DataView(body.buffer, body.byteOffset + 5, 4);
+  const len = view.getUint32(0, true);
+  const payload = body.subarray(9, 9 + len);
+  if (payload.length !== len) {
+    log(`video frame length mismatch: declared ${len}, got ${payload.length}`);
+    return;
+  }
+  const target = videoTargetFor(sourceId, fourcc);
+  if (target) await paintJpeg(payload, target, token);
+}
+
+// v2 video body: a capture-identity header, then `[fourcc][u32 LE len][payload]`
+// (ADR-0020). The capture identity gates the frame through `videoIdentity`: a
+// duplicate, reordered, stale-epoch, or wrong-camera frame is dropped and never
+// blitted, so a replayed frame cannot displace a newer one or refresh its age.
+// The clock-mapping verdict decides whether a conformal overlay is admissible;
+// it defaults unavailable and conformal drawing does not exist yet.
+async function renderVideoFrameV2(body, token) {
+  if (!transportSessions.isActive(token)) return;
+  const parsed = parseVideoFrameV2(body);
+  if (!parsed) {
+    state.skippedVideoFrames += 1;
+    log(`malformed v2 video frame; skipping (${state.skippedVideoFrames} skipped total)`);
+    return;
+  }
+  const { meta, fourcc, payload } = parsed;
+  const target = videoTargetFor(meta.sourceId, fourcc);
+  if (!target) return;
+  const verdict = videoIdentity.admit(meta);
+  state.conformalReady = verdict.gate.conformalReady;
+  if (!verdict.accepted) {
+    state.droppedIdentityFrames += 1;
+    log(
+      `video frame not admitted (${verdict.reason}) for source ${meta.sourceId} ` +
+        `seq ${meta.sequence}; dropped (${state.droppedIdentityFrames} identity drops total)`,
+    );
+    return;
+  }
+  if (verdict.discontinuity) {
+    log(`video source ${meta.sourceId} capture discontinuity: fresh epoch/incarnation`);
+  }
+  await paintJpeg(payload, target, token);
 }
 
 /** Reads telemetry-fast datagrams (bare Envelope, TelemetrySample arm) forever, updating the pose overlay. */

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -98,10 +98,6 @@ const state = {
   leaseGranted: false,
   skippedVideoFrames: 0,
   droppedIdentityFrames: 0,
-  // Latest conformal-overlay verdict per source. Defaults unavailable: a
-  // conformal overlay is only admissible once a source presents a bounded
-  // clock mapping (ADR-0020). Conformal drawing itself does not exist yet.
-  conformalReady: false,
 };
 const transportSessions = new TransportSessionLifecycle();
 // Capture-identity guard for the video downlink: drops duplicate/reordered/
@@ -504,8 +500,12 @@ async function renderVideoFrame(body, token) {
 // (ADR-0020). The capture identity gates the frame through `videoIdentity`: a
 // duplicate, reordered, stale-epoch, or wrong-camera frame is dropped and never
 // blitted, so a replayed frame cannot displace a newer one or refresh its age.
-// The clock-mapping verdict decides whether a conformal overlay is admissible;
-// it defaults unavailable and conformal drawing does not exist yet.
+// Conformal readiness is deliberately NOT evaluated here: the gate must judge a
+// frame against the specific aircraft snapshot it is associated with, and that
+// association (picking the snapshot for a frame at render time) is deferred
+// (#36). Evaluating conformalReady against the latest snapshot would reintroduce
+// the receipt-time conflation this whole change exists to remove, so the render
+// path only enforces capture-identity ordering.
 async function renderVideoFrameV2(body, token) {
   if (!transportSessions.isActive(token)) return;
   const parsed = parseVideoFrameV2(body);
@@ -518,7 +518,6 @@ async function renderVideoFrameV2(body, token) {
   const target = videoTargetFor(meta.sourceId, fourcc);
   if (!target) return;
   const verdict = videoIdentity.admit(meta);
-  state.conformalReady = verdict.gate.conformalReady;
   if (!verdict.accepted) {
     state.droppedIdentityFrames += 1;
     log(
@@ -528,7 +527,7 @@ async function renderVideoFrameV2(body, token) {
     return;
   }
   if (verdict.discontinuity) {
-    log(`video source ${meta.sourceId} capture discontinuity: fresh epoch/incarnation`);
+    log(`video source ${meta.sourceId} capture discontinuity: fresh epoch/incarnation/calibration`);
   }
   await paintJpeg(payload, target, token);
 }

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -1,0 +1,187 @@
+// Per-source video capture identity tracking for the viewer (ADR-0020).
+//
+// A displayed frame must correspond to the aircraft state at capture, so a
+// stale, duplicated, or reordered frame must never masquerade as fresh. This
+// mirrors the avionics ingestion discipline in telemetry-ingress.js: freshness
+// advances only when a source presents a strictly newer epoch/sequence, and a
+// replayed frame leaves the accepted state — and therefore the displayed age —
+// untouched. The serial-number comparison is reused from that module rather
+// than reimplemented, so both paths share one definition of "newer".
+
+import { serialIsNewer } from "./telemetry-ingress.js";
+
+const CLOCK_VEHICLE_BOOT = 1;
+const CLOCK_SIMULATION = 2;
+const INCARNATION_HEX = /^[0-9a-f]{32}$/;
+
+/** Why a frame was or was not admitted, for logging and diagnostics. */
+export const ADMIT = Object.freeze({
+  ACCEPTED: "accepted",
+  DUPLICATE: "duplicate",
+  REORDERED: "reordered",
+  STALE_EPOCH: "stale-epoch",
+  WRONG_CAMERA: "wrong-camera",
+  MALFORMED: "malformed",
+});
+
+/**
+ * Verdict on whether a frame's capture clock can anchor a conformal overlay.
+ *
+ * Defaults to unavailable: only an explicitly available, bounded clock mapping
+ * yields `conformalReady === true`, and it carries the quantified error bound a
+ * consumer would budget against. Conformal drawing itself does not exist yet;
+ * this states only admissibility, so an absent or unavailable mapping keeps the
+ * gate closed.
+ */
+export function conformalGate(meta) {
+  if (!meta || meta.mappingAvailable !== true) {
+    return Object.freeze({
+      mappingValid: false,
+      conformalReady: false,
+      clockErrorBoundNanos: null,
+    });
+  }
+  return Object.freeze({
+    mappingValid: true,
+    conformalReady: true,
+    clockErrorBoundNanos: meta.clockErrorBoundNanos,
+  });
+}
+
+function isMetaValid(meta) {
+  return (
+    meta !== null &&
+    typeof meta === "object" &&
+    Number.isInteger(meta.sourceId) &&
+    typeof meta.sourceIncarnation === "string" &&
+    INCARNATION_HEX.test(meta.sourceIncarnation) &&
+    Number.isInteger(meta.sourceEpoch) &&
+    meta.sourceEpoch >= 0 &&
+    meta.sourceEpoch <= 0xffff_ffff &&
+    Number.isInteger(meta.sequence) &&
+    meta.sequence >= 0 &&
+    meta.sequence <= 0xffff_ffff &&
+    typeof meta.captureTimeNanos === "bigint" &&
+    meta.captureTimeNanos >= 0n &&
+    Number.isInteger(meta.cameraId) &&
+    (meta.captureClock === CLOCK_VEHICLE_BOOT || meta.captureClock === CLOCK_SIMULATION)
+  );
+}
+
+function result(reason, discontinuity, meta) {
+  return Object.freeze({
+    accepted: reason === ADMIT.ACCEPTED,
+    reason,
+    discontinuity,
+    gate: conformalGate(meta),
+  });
+}
+
+/**
+ * Tracks capture identity independently per routing source. `admit` returns
+ * whether a frame advances that source's timeline; only an advancing frame
+ * updates the accepted state (last sequence, capture time, receive time), so a
+ * rejected replay cannot refresh the frame's age.
+ */
+export class VideoIdentityTracker {
+  constructor() {
+    this.sources = new Map();
+    this.counters = {
+      accepted: 0,
+      duplicates: 0,
+      reordered: 0,
+      staleEpochs: 0,
+      wrongCamera: 0,
+      malformed: 0,
+      epochResets: 0,
+      incarnationResets: 0,
+    };
+  }
+
+  admit(meta) {
+    if (!isMetaValid(meta)) {
+      this.bump("malformed");
+      return result(ADMIT.MALFORMED, false, meta);
+    }
+    const state = this.sources.get(meta.sourceId);
+    if (!state) {
+      this.establish(meta);
+      this.bump("accepted");
+      return result(ADMIT.ACCEPTED, true, meta);
+    }
+    if (meta.cameraId !== state.cameraId) {
+      this.bump("wrongCamera");
+      return result(ADMIT.WRONG_CAMERA, false, meta);
+    }
+    if (meta.sourceIncarnation !== state.incarnation) {
+      this.establish(meta);
+      this.bump("incarnationResets");
+      this.bump("accepted");
+      return result(ADMIT.ACCEPTED, true, meta);
+    }
+    return this.admitWithinIncarnation(state, meta);
+  }
+
+  admitWithinIncarnation(state, meta) {
+    if (meta.sourceEpoch !== state.epoch) {
+      if (!serialIsNewer(meta.sourceEpoch, state.epoch)) {
+        this.bump("staleEpochs");
+        return result(ADMIT.STALE_EPOCH, false, meta);
+      }
+      this.establish(meta);
+      this.bump("epochResets");
+      this.bump("accepted");
+      return result(ADMIT.ACCEPTED, true, meta);
+    }
+    if (meta.sequence === state.lastSequence) {
+      this.bump("duplicates");
+      return result(ADMIT.DUPLICATE, false, meta);
+    }
+    if (!serialIsNewer(meta.sequence, state.lastSequence)) {
+      this.bump("reordered");
+      return result(ADMIT.REORDERED, false, meta);
+    }
+    this.advance(state, meta);
+    this.bump("accepted");
+    return result(ADMIT.ACCEPTED, false, meta);
+  }
+
+  establish(meta) {
+    this.sources.set(meta.sourceId, {
+      cameraId: meta.cameraId,
+      incarnation: meta.sourceIncarnation,
+      epoch: meta.sourceEpoch,
+      lastSequence: meta.sequence,
+      lastCaptureTimeNanos: meta.captureTimeNanos,
+      lastReceiveTimeNanos: meta.receiveTimeNanos,
+    });
+  }
+
+  advance(state, meta) {
+    state.lastSequence = meta.sequence;
+    state.lastCaptureTimeNanos = meta.captureTimeNanos;
+    state.lastReceiveTimeNanos = meta.receiveTimeNanos;
+  }
+
+  /** The last accepted frame's identity for a source, or `null` if none yet. */
+  lastAccepted(sourceId) {
+    const state = this.sources.get(sourceId);
+    if (!state) return null;
+    return Object.freeze({
+      cameraId: state.cameraId,
+      incarnation: state.incarnation,
+      epoch: state.epoch,
+      sequence: state.lastSequence,
+      captureTimeNanos: state.lastCaptureTimeNanos,
+      receiveTimeNanos: state.lastReceiveTimeNanos,
+    });
+  }
+
+  diagnostics() {
+    return Object.freeze({ ...this.counters });
+  }
+
+  bump(name, amount = 1) {
+    this.counters[name] = (this.counters[name] + amount) >>> 0;
+  }
+}

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -13,6 +13,31 @@ import { serialIsNewer } from "./telemetry-ingress.js";
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
 const INCARNATION_HEX = /^[0-9a-f]{32}$/;
+const U64_MAX = (1n << 64n) - 1n;
+
+// Maximum clock-mapping error a conformal overlay tolerates. A bounded mapping
+// alone is not sufficient: at a representative approach speed (~80 m/s) a 1 ms
+// clock error is ~8 cm of along-track registration error, so the clock's
+// contribution is budgeted to a small fraction of that. This is a SIM default;
+// an airborne profile must derive its own budget from the intended display
+// function and the platform's actual clock discipline.
+export const DEFAULT_MAX_CLOCK_ERROR_NANOS = 2_000_000n;
+
+// Calibration identities this consumer recognizes. Empty by default and
+// fail-closed: a conformal overlay needs a known calibration, and the simulator
+// publishes none (CalibrationId::NONE == 0), so the gate stays closed until a
+// real calibration registry is supplied.
+export const DEFAULT_RECOGNIZED_CALIBRATIONS = Object.freeze(new Set());
+
+/** Applies a mapping offset to a capture time, refusing (returns `null`) when
+ *  the signed offset would carry the result outside the u64 nanosecond range,
+ *  rather than wrapping into a plausible-looking but wrong time. */
+function mapCaptureTime(captureTimeNanos, offsetNanos) {
+  if (typeof captureTimeNanos !== "bigint" || typeof offsetNanos !== "bigint") return null;
+  const mapped = captureTimeNanos + offsetNanos;
+  if (mapped < 0n || mapped > U64_MAX) return null;
+  return mapped;
+}
 
 /** Why a frame was or was not admitted, for logging and diagnostics. */
 export const ADMIT = Object.freeze({
@@ -25,26 +50,56 @@ export const ADMIT = Object.freeze({
 });
 
 /**
- * Verdict on whether a frame's capture clock can anchor a conformal overlay.
+ * Verdict on whether a frame may anchor a conformal overlay against a specific
+ * candidate aircraft snapshot. Consumes BOTH the frame metadata and the
+ * candidate snapshot identity (an AV-01 `MeasurementStamp`, of which only the
+ * `clock` is read here); a mapping is only usable if it targets the same clock
+ * the snapshot is expressed in.
  *
- * Defaults to unavailable: only an explicitly available, bounded clock mapping
- * yields `conformalReady === true`, and it carries the quantified error bound a
- * consumer would budget against. Conformal drawing itself does not exist yet;
- * this states only admissibility, so an absent or unavailable mapping keeps the
- * gate closed.
+ * Fails closed. `mappingValid` requires the mapping to be available, to target
+ * the candidate snapshot's clock, to be within the configured error budget, and
+ * to map the capture time without overflow. `conformalReady` additionally
+ * requires a published, recognized calibration. A bounded mapping alone is not
+ * sufficient, and conformal drawing itself does not exist yet; this states only
+ * admissibility.
+ *
+ * `options.recognizedCalibrations` (a `Set` of calibration ids) and
+ * `options.maxClockErrorNanos` (a `bigint`) override the fail-closed defaults.
  */
-export function conformalGate(meta) {
-  if (!meta || meta.mappingAvailable !== true) {
-    return Object.freeze({
+export function conformalGate(meta, snapshotIdentity, options = {}) {
+  const recognized = options.recognizedCalibrations ?? DEFAULT_RECOGNIZED_CALIBRATIONS;
+  const budget = options.maxClockErrorNanos ?? DEFAULT_MAX_CLOCK_ERROR_NANOS;
+  const closed = (reason) =>
+    Object.freeze({
       mappingValid: false,
       conformalReady: false,
       clockErrorBoundNanos: null,
+      mappedCaptureTimeNanos: null,
+      reason,
     });
+  if (!meta || meta.mappingAvailable !== true) return closed("mapping-unavailable");
+  if (!snapshotIdentity || snapshotIdentity.clock !== meta.mappingTargetClock) {
+    return closed("clock-mismatch");
   }
+  const bound = meta.clockErrorBoundNanos;
+  if (typeof bound !== "bigint" || bound < 0n || bound > budget) {
+    return closed("error-exceeds-budget");
+  }
+  const mapped = mapCaptureTime(meta.captureTimeNanos, meta.mappingOffsetNanos);
+  if (mapped === null) return closed("mapped-time-overflow");
+  // The clock side is valid: available, targets the snapshot's clock, within
+  // budget, and maps without overflow. Conformal readiness additionally demands
+  // a published, recognized calibration.
+  const calibrationReady =
+    Number.isInteger(meta.calibrationId) &&
+    meta.calibrationId !== 0 &&
+    recognized.has(meta.calibrationId);
   return Object.freeze({
     mappingValid: true,
-    conformalReady: true,
-    clockErrorBoundNanos: meta.clockErrorBoundNanos,
+    conformalReady: calibrationReady,
+    clockErrorBoundNanos: bound,
+    mappedCaptureTimeNanos: mapped,
+    reason: calibrationReady ? "ready" : "calibration-unavailable",
   });
 }
 
@@ -64,16 +119,16 @@ function isMetaValid(meta) {
     typeof meta.captureTimeNanos === "bigint" &&
     meta.captureTimeNanos >= 0n &&
     Number.isInteger(meta.cameraId) &&
+    Number.isInteger(meta.calibrationId) &&
     (meta.captureClock === CLOCK_VEHICLE_BOOT || meta.captureClock === CLOCK_SIMULATION)
   );
 }
 
-function result(reason, discontinuity, meta) {
+function result(reason, discontinuity) {
   return Object.freeze({
     accepted: reason === ADMIT.ACCEPTED,
     reason,
     discontinuity,
-    gate: conformalGate(meta),
   });
 }
 
@@ -95,29 +150,39 @@ export class VideoIdentityTracker {
       malformed: 0,
       epochResets: 0,
       incarnationResets: 0,
+      calibrationResets: 0,
     };
   }
 
   admit(meta) {
     if (!isMetaValid(meta)) {
       this.bump("malformed");
-      return result(ADMIT.MALFORMED, false, meta);
+      return result(ADMIT.MALFORMED, false);
     }
     const state = this.sources.get(meta.sourceId);
     if (!state) {
       this.establish(meta);
       this.bump("accepted");
-      return result(ADMIT.ACCEPTED, true, meta);
+      return result(ADMIT.ACCEPTED, true);
     }
     if (meta.cameraId !== state.cameraId) {
       this.bump("wrongCamera");
-      return result(ADMIT.WRONG_CAMERA, false, meta);
+      return result(ADMIT.WRONG_CAMERA, false);
     }
     if (meta.sourceIncarnation !== state.incarnation) {
       this.establish(meta);
       this.bump("incarnationResets");
       this.bump("accepted");
-      return result(ADMIT.ACCEPTED, true, meta);
+      return result(ADMIT.ACCEPTED, true);
+    }
+    // A calibration change re-bases the camera model, so the conformal timeline
+    // must not silently continue across it: re-establish and flag a
+    // discontinuity, exactly as for a fresh incarnation.
+    if (meta.calibrationId !== state.calibrationId) {
+      this.establish(meta);
+      this.bump("calibrationResets");
+      this.bump("accepted");
+      return result(ADMIT.ACCEPTED, true);
     }
     return this.admitWithinIncarnation(state, meta);
   }
@@ -126,29 +191,30 @@ export class VideoIdentityTracker {
     if (meta.sourceEpoch !== state.epoch) {
       if (!serialIsNewer(meta.sourceEpoch, state.epoch)) {
         this.bump("staleEpochs");
-        return result(ADMIT.STALE_EPOCH, false, meta);
+        return result(ADMIT.STALE_EPOCH, false);
       }
       this.establish(meta);
       this.bump("epochResets");
       this.bump("accepted");
-      return result(ADMIT.ACCEPTED, true, meta);
+      return result(ADMIT.ACCEPTED, true);
     }
     if (meta.sequence === state.lastSequence) {
       this.bump("duplicates");
-      return result(ADMIT.DUPLICATE, false, meta);
+      return result(ADMIT.DUPLICATE, false);
     }
     if (!serialIsNewer(meta.sequence, state.lastSequence)) {
       this.bump("reordered");
-      return result(ADMIT.REORDERED, false, meta);
+      return result(ADMIT.REORDERED, false);
     }
     this.advance(state, meta);
     this.bump("accepted");
-    return result(ADMIT.ACCEPTED, false, meta);
+    return result(ADMIT.ACCEPTED, false);
   }
 
   establish(meta) {
     this.sources.set(meta.sourceId, {
       cameraId: meta.cameraId,
+      calibrationId: meta.calibrationId,
       incarnation: meta.sourceIncarnation,
       epoch: meta.sourceEpoch,
       lastSequence: meta.sequence,
@@ -169,6 +235,7 @@ export class VideoIdentityTracker {
     if (!state) return null;
     return Object.freeze({
       cameraId: state.cameraId,
+      calibrationId: state.calibrationId,
       incarnation: state.incarnation,
       epoch: state.epoch,
       sequence: state.lastSequence,

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -3,7 +3,12 @@
 //
 // Run: node clients/web/video-identity.test.mjs
 
-import { VideoIdentityTracker, conformalGate, ADMIT } from "./video-identity.js";
+import {
+  VideoIdentityTracker,
+  conformalGate,
+  ADMIT,
+  DEFAULT_MAX_CLOCK_ERROR_NANOS,
+} from "./video-identity.js";
 
 let failures = 0;
 function check(name, cond) {
@@ -163,24 +168,131 @@ function meta(overrides = {}) {
   check("malformed reason is reported", bad.reason === ADMIT.MALFORMED);
 }
 
-// The conformal gate defaults unavailable and only opens for a bounded mapping.
+// A calibration-ID change re-bases the camera model, so it must be an explicit
+// discontinuity rather than silently continuing the conformal timeline.
 {
   const t = new VideoIdentityTracker();
-  const available = t.admit(meta({ mappingAvailable: true, clockErrorBoundNanos: 250n }));
-  check("available mapping yields a valid gate", available.gate.mappingValid === true);
-  check("available mapping is conformal-ready", available.gate.conformalReady === true);
-  check("available mapping carries its error bound", available.gate.clockErrorBoundNanos === 250n);
-
-  const t2 = new VideoIdentityTracker();
-  const unavailable = t2.admit(meta({ mappingAvailable: false }));
-  check("unavailable mapping gate is invalid", unavailable.gate.mappingValid === false);
-  check("unavailable mapping is not conformal-ready", unavailable.gate.conformalReady === false);
-  check("unavailable mapping has no error bound", unavailable.gate.clockErrorBoundNanos === null);
+  t.admit(meta({ calibrationId: 5, sequence: 9 }));
+  const recal = t.admit(meta({ calibrationId: 6, sequence: 0 }));
+  check("calibration change is accepted", recal.accepted === true);
+  check("calibration change marks a discontinuity", recal.discontinuity === true);
+  check("calibration reset is counted", t.diagnostics().calibrationResets === 1);
+  check("calibration change re-bases the tracked calibration", t.lastAccepted(0).calibrationId === 6);
 }
 
-// The standalone gate defaults closed for absent metadata.
-check("gate on null meta is closed", conformalGate(null).conformalReady === false);
-check("gate on null meta is not valid", conformalGate(null).mappingValid === false);
+// ---- conformal gate --------------------------------------------------------
+// The gate consumes BOTH the frame metadata and the candidate aircraft snapshot
+// identity (an AV-01 MeasurementStamp; only its clock is read here). It fails
+// closed and demands: available mapping, a target clock matching the snapshot,
+// error within budget, an overflow-free mapped time, and a published/recognized
+// calibration.
+const snap = (clock) => Object.freeze({ clock });
+const RECOGNIZED = { recognizedCalibrations: new Set([7]) };
+const CLOCK_SIMULATION = 2;
+const CLOCK_VEHICLE_BOOT = 1;
+
+// A calibration ID of zero (unpublished / CalibrationId::NONE) keeps the gate
+// closed even when the clock side is fully valid.
+{
+  const g = conformalGate(
+    meta({ mappingAvailable: true, mappingTargetClock: CLOCK_SIMULATION, calibrationId: 0 }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("calibration id zero: clock side is valid", g.mappingValid === true);
+  check("calibration id zero keeps the gate closed", g.conformalReady === false);
+}
+
+// A published but unrecognized (wrong/stale) calibration keeps the gate closed.
+{
+  const g = conformalGate(
+    meta({ mappingAvailable: true, mappingTargetClock: CLOCK_SIMULATION, calibrationId: 99 }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("unrecognized calibration keeps the gate closed", g.conformalReady === false);
+}
+
+// A mapping targeting a clock other than the candidate snapshot's is not usable.
+{
+  const g = conformalGate(
+    meta({ mappingAvailable: true, mappingTargetClock: CLOCK_VEHICLE_BOOT, calibrationId: 7 }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("target-clock mismatch keeps the gate closed", g.conformalReady === false);
+  check("target-clock mismatch is not mapping-valid", g.mappingValid === false);
+}
+
+// An available mapping whose quantified error exceeds the budget keeps the gate
+// closed: "bounded" alone is not sufficient.
+{
+  const overBudget = DEFAULT_MAX_CLOCK_ERROR_NANOS + 1n;
+  const g = conformalGate(
+    meta({
+      mappingAvailable: true,
+      mappingTargetClock: CLOCK_SIMULATION,
+      calibrationId: 7,
+      clockErrorBoundNanos: overBudget,
+    }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("excessive error bound keeps the gate closed", g.conformalReady === false);
+  check("excessive error bound is not mapping-valid", g.mappingValid === false);
+}
+
+// A mapping whose signed offset would carry the capture time outside the u64
+// range refuses rather than wrapping into a plausible time.
+{
+  const g = conformalGate(
+    meta({
+      mappingAvailable: true,
+      mappingTargetClock: CLOCK_SIMULATION,
+      calibrationId: 7,
+      captureTimeNanos: 5n,
+      mappingOffsetNanos: -6n,
+    }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("mapped-time underflow refuses", g.conformalReady === false && g.reason === "mapped-time-overflow");
+}
+
+// Only a fully compatible snapshot / calibration / mapping combination is ready.
+{
+  const g = conformalGate(
+    meta({
+      mappingAvailable: true,
+      mappingTargetClock: CLOCK_SIMULATION,
+      calibrationId: 7,
+      captureTimeNanos: 1000n,
+      mappingOffsetNanos: 50n,
+      clockErrorBoundNanos: 250n,
+    }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check("compatible combination is conformal-ready", g.conformalReady === true);
+  check("ready verdict is mapping-valid", g.mappingValid === true);
+  check("ready verdict carries the error bound", g.clockErrorBoundNanos === 250n);
+  check("ready verdict exposes the mapped capture time", g.mappedCaptureTimeNanos === 1050n);
+}
+
+// An unavailable mapping is not mapping-valid regardless of the snapshot.
+{
+  const g = conformalGate(meta({ mappingAvailable: false }), snap(CLOCK_SIMULATION), RECOGNIZED);
+  check("unavailable mapping is not mapping-valid", g.mappingValid === false);
+  check("unavailable mapping is not conformal-ready", g.conformalReady === false);
+  check("unavailable mapping has no error bound", g.clockErrorBoundNanos === null);
+}
+
+// The gate fails closed for absent metadata or an absent candidate snapshot.
+check("gate on null meta is closed", conformalGate(null, snap(CLOCK_SIMULATION)).conformalReady === false);
+check(
+  "gate with no candidate snapshot is closed",
+  conformalGate(meta({ mappingAvailable: true, calibrationId: 7 }), null, RECOGNIZED).conformalReady === false,
+);
 
 if (failures > 0) {
   console.error(`\n${failures} check(s) failed`);

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -1,0 +1,189 @@
+// Behavioral checks for the video capture-identity tracker and conformal gate
+// (ADR-0020).
+//
+// Run: node clients/web/video-identity.test.mjs
+
+import { VideoIdentityTracker, conformalGate, ADMIT } from "./video-identity.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const INCARNATION_A = "ab".repeat(16);
+const INCARNATION_B = "cd".repeat(16);
+
+function meta(overrides = {}) {
+  return {
+    sourceId: 0,
+    sourceEpoch: 0,
+    sourceIncarnation: INCARNATION_A,
+    sequence: 0,
+    captureTimeNanos: 1000n,
+    captureClock: 2,
+    mappingAvailable: true,
+    mappingTargetClock: 2,
+    mappingOffsetNanos: 0n,
+    clockErrorBoundNanos: 0n,
+    receiveTimeNanos: 0n,
+    publicationTimeNanos: 0n,
+    cameraId: 0,
+    calibrationId: 0,
+    ...overrides,
+  };
+}
+
+// First frame establishes the source and is a discontinuity (fresh start).
+{
+  const t = new VideoIdentityTracker();
+  const first = t.admit(meta({ sequence: 5, captureTimeNanos: 5000n }));
+  check("first frame is accepted", first.accepted && first.reason === ADMIT.ACCEPTED);
+  check("first frame marks a discontinuity", first.discontinuity === true);
+}
+
+// A strictly newer sequence advances; the accepted capture time follows it.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sequence: 5, captureTimeNanos: 5000n }));
+  const next = t.admit(meta({ sequence: 6, captureTimeNanos: 6000n }));
+  check("newer sequence is accepted", next.accepted && next.discontinuity === false);
+  check(
+    "accepted state tracks the newest frame's capture time",
+    t.lastAccepted(0).captureTimeNanos === 6000n,
+  );
+}
+
+// A duplicate sequence is dropped and does NOT refresh the frame's age: the
+// last accepted capture time stays the earlier value even though the replay
+// carried a later one.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sequence: 5, captureTimeNanos: 5000n }));
+  const replay = t.admit(meta({ sequence: 5, captureTimeNanos: 9999n }));
+  check("duplicate sequence is not accepted", replay.accepted === false);
+  check("duplicate reason is reported", replay.reason === ADMIT.DUPLICATE);
+  check(
+    "duplicate does not refresh the accepted capture time",
+    t.lastAccepted(0).captureTimeNanos === 5000n,
+  );
+  check("duplicate is counted", t.diagnostics().duplicates === 1);
+}
+
+// A reordered (older) sequence is dropped and leaves state untouched.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sequence: 5, captureTimeNanos: 5000n }));
+  const older = t.admit(meta({ sequence: 3, captureTimeNanos: 3000n }));
+  check("older sequence is not accepted", older.accepted === false);
+  check("older sequence reason is reordered", older.reason === ADMIT.REORDERED);
+  check(
+    "reordered frame does not move the accepted sequence",
+    t.lastAccepted(0).sequence === 5,
+  );
+}
+
+// The wrapping sequence is compared with serial arithmetic: 0 is newer than
+// 0xFFFFFFFF, so a frame straddling the u32 boundary advances rather than being
+// mistaken for an ancient reorder.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sequence: 0xffffffff, captureTimeNanos: 5000n }));
+  const wrapped = t.admit(meta({ sequence: 0, captureTimeNanos: 6000n }));
+  check("sequence wrap (MAX -> 0) is accepted as newer", wrapped.accepted === true);
+  check("wrapped frame advances the accepted sequence", t.lastAccepted(0).sequence === 0);
+  // A backward wrap of the same magnitude is still a reorder.
+  const back = t.admit(meta({ sequence: 0xffffffff, captureTimeNanos: 7000n }));
+  check("wrapping backward is still rejected", back.accepted === false);
+}
+
+// A newer epoch resets the timeline: it is accepted, flagged as a
+// discontinuity, and lets a lower sequence through under the new epoch.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sourceEpoch: 0, sequence: 9, captureTimeNanos: 5000n }));
+  const reset = t.admit(meta({ sourceEpoch: 1, sequence: 0, captureTimeNanos: 6000n }));
+  check("newer epoch is accepted", reset.accepted === true);
+  check("newer epoch marks a discontinuity", reset.discontinuity === true);
+  check("epoch reset is counted", t.diagnostics().epochResets === 1);
+  check("epoch reset re-bases the sequence", t.lastAccepted(0).epoch === 1 && t.lastAccepted(0).sequence === 0);
+}
+
+// An older epoch is stale and dropped.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sourceEpoch: 5, sequence: 0 }));
+  const stale = t.admit(meta({ sourceEpoch: 4, sequence: 100 }));
+  check("older epoch is not accepted", stale.accepted === false);
+  check("older epoch reason is stale-epoch", stale.reason === ADMIT.STALE_EPOCH);
+  check("stale epoch is counted", t.diagnostics().staleEpochs === 1);
+}
+
+// A frame whose camera id differs from the source's established camera is
+// rejected rather than mixed into the same stream.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ cameraId: 0, sequence: 0 }));
+  const wrong = t.admit(meta({ cameraId: 1, sequence: 1 }));
+  check("wrong camera id is not accepted", wrong.accepted === false);
+  check("wrong camera reason is reported", wrong.reason === ADMIT.WRONG_CAMERA);
+  check("wrong camera is counted", t.diagnostics().wrongCamera === 1);
+}
+
+// A new incarnation (a fresh attachment) is a discontinuity that re-establishes
+// the source.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sourceIncarnation: INCARNATION_A, sequence: 9 }));
+  const reattach = t.admit(meta({ sourceIncarnation: INCARNATION_B, sequence: 0 }));
+  check("new incarnation is accepted", reattach.accepted === true);
+  check("new incarnation marks a discontinuity", reattach.discontinuity === true);
+  check("incarnation reset is counted", t.diagnostics().incarnationResets === 1);
+}
+
+// Sources are tracked independently: chase frames never affect FPV state.
+{
+  const t = new VideoIdentityTracker();
+  t.admit(meta({ sourceId: 0, sequence: 5 }));
+  const chase = t.admit(meta({ sourceId: 1, sequence: 0 }));
+  check("a second source starts its own timeline", chase.accepted === true);
+  check("first source keeps its own sequence", t.lastAccepted(0).sequence === 5);
+  check("second source has its own sequence", t.lastAccepted(1).sequence === 0);
+}
+
+// A malformed stamp is rejected without disturbing state.
+{
+  const t = new VideoIdentityTracker();
+  const bad = t.admit(meta({ sourceIncarnation: "nothex" }));
+  check("malformed stamp is not accepted", bad.accepted === false);
+  check("malformed reason is reported", bad.reason === ADMIT.MALFORMED);
+}
+
+// The conformal gate defaults unavailable and only opens for a bounded mapping.
+{
+  const t = new VideoIdentityTracker();
+  const available = t.admit(meta({ mappingAvailable: true, clockErrorBoundNanos: 250n }));
+  check("available mapping yields a valid gate", available.gate.mappingValid === true);
+  check("available mapping is conformal-ready", available.gate.conformalReady === true);
+  check("available mapping carries its error bound", available.gate.clockErrorBoundNanos === 250n);
+
+  const t2 = new VideoIdentityTracker();
+  const unavailable = t2.admit(meta({ mappingAvailable: false }));
+  check("unavailable mapping gate is invalid", unavailable.gate.mappingValid === false);
+  check("unavailable mapping is not conformal-ready", unavailable.gate.conformalReady === false);
+  check("unavailable mapping has no error bound", unavailable.gate.clockErrorBoundNanos === null);
+}
+
+// The standalone gate defaults closed for absent metadata.
+check("gate on null meta is closed", conformalGate(null).conformalReady === false);
+check("gate on null meta is not valid", conformalGate(null).mappingValid === false);
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall video identity checks passed");

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -20,10 +20,82 @@
 
 export const STREAM_KIND_AUTHORITY = 0x01;
 export const STREAM_KIND_VIDEO = 0x02;
+// 0x03 = one video frame that leads with a capture-identity header before the
+// codec-tagged, length-prefixed payload (ADR-0020;
+// hosts/session-host/src/runtime/stream_tag.rs `frame_video_payload_v2`).
+export const STREAM_KIND_VIDEO_V2 = 0x03;
 
 // The `pilotage.v1` schema version this build produces and accepts
 // (pilotage_protocol::convert::SCHEMA_VERSION mirrors this constant).
 export const SCHEMA_VERSION = 1;
+
+// Byte offsets of the fixed v2 capture-identity header (little-endian), a
+// by-hand mirror of `frame_video_payload_v2` in
+// hosts/session-host/src/runtime/stream_tag.rs. `PAYLOAD` is also the header
+// length (source_id .. calibration_id) plus the 4-byte FourCC and 4-byte u32
+// length prefix.
+const V2_OFFSET = Object.freeze({
+  sourceId: 0,
+  sourceEpoch: 1,
+  sourceIncarnation: 5,
+  sequence: 21,
+  captureTime: 25,
+  captureClock: 33,
+  mappingAvailable: 34,
+  mappingTargetClock: 35,
+  mappingOffset: 36,
+  clockErrorBound: 44,
+  receiveTime: 52,
+  publicationTime: 60,
+  cameraId: 68,
+  calibrationId: 72,
+  fourcc: 76,
+  length: 80,
+  payload: 84,
+});
+
+/**
+ * Parses a v2 video-frame body: the bytes after the `STREAM_KIND_VIDEO_V2`
+ * (0x03) kind tag. Returns `{ meta, fourcc, payload }`, where `meta` is the
+ * capture identity and clock mapping (source identity/epoch/incarnation,
+ * wrapping sequence, sim capture time and clock, the mapping to the
+ * flight-state clock with its quantified error bound, host receive/publication
+ * times, and camera/calibration identities), `fourcc` is the 4-char codec tag,
+ * and `payload` is the encoded frame. Returns `null` if the body is shorter
+ * than the fixed header or the declared payload length does not match.
+ */
+export function parseVideoFrameV2(body) {
+  if (body.length < V2_OFFSET.payload) return null;
+  const view = new DataView(body.buffer, body.byteOffset, body.length);
+  const len = view.getUint32(V2_OFFSET.length, true);
+  const payload = body.subarray(V2_OFFSET.payload, V2_OFFSET.payload + len);
+  if (payload.length !== len) return null;
+  const fourcc = String.fromCharCode(
+    body[V2_OFFSET.fourcc],
+    body[V2_OFFSET.fourcc + 1],
+    body[V2_OFFSET.fourcc + 2],
+    body[V2_OFFSET.fourcc + 3],
+  );
+  const meta = {
+    sourceId: body[V2_OFFSET.sourceId],
+    sourceEpoch: view.getUint32(V2_OFFSET.sourceEpoch, true),
+    sourceIncarnation: decodeIncarnation(
+      body.subarray(V2_OFFSET.sourceIncarnation, V2_OFFSET.sourceIncarnation + 16),
+    ),
+    sequence: view.getUint32(V2_OFFSET.sequence, true),
+    captureTimeNanos: view.getBigUint64(V2_OFFSET.captureTime, true),
+    captureClock: body[V2_OFFSET.captureClock],
+    mappingAvailable: body[V2_OFFSET.mappingAvailable] === 1,
+    mappingTargetClock: body[V2_OFFSET.mappingTargetClock],
+    mappingOffsetNanos: view.getBigInt64(V2_OFFSET.mappingOffset, true),
+    clockErrorBoundNanos: view.getBigUint64(V2_OFFSET.clockErrorBound, true),
+    receiveTimeNanos: view.getBigUint64(V2_OFFSET.receiveTime, true),
+    publicationTimeNanos: view.getBigUint64(V2_OFFSET.publicationTime, true),
+    cameraId: view.getUint32(V2_OFFSET.cameraId, true),
+    calibrationId: view.getUint32(V2_OFFSET.calibrationId, true),
+  };
+  return { meta, fourcc, payload };
+}
 
 // ---- varint + protobuf tag primitives -------------------------------------
 

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -9,7 +9,12 @@
 // rejects the datagram as unrecognized. These checks pin the invariant that the
 // required fields are emitted even when their ids are zero.
 
-import { encodeControlFrameEnvelope, decodeBareEnvelope, SCHEMA_VERSION } from "./wire.js";
+import {
+  encodeControlFrameEnvelope,
+  decodeBareEnvelope,
+  parseVideoFrameV2,
+  SCHEMA_VERSION,
+} from "./wire.js";
 
 let failures = 0;
 function check(name, cond) {
@@ -269,6 +274,104 @@ check("a sample without avionics decodes to null", (() => {
   bytesField(bareNoAv, 4, []);
   return decodeBareEnvelope(new Uint8Array(bareNoAv)).message.avionics === null;
 })());
+
+// ---- v2 video capture-identity frame parsing (ADR-0020) --------------------
+// Builds a v2 body exactly as hosts/session-host stream_tag.rs
+// `frame_video_payload_v2` does, so parseVideoFrameV2 is checked against the
+// real byte layout, not against itself.
+function buildV2Body(fields, fourcc, payload) {
+  const header = new Uint8Array(76);
+  const view = new DataView(header.buffer);
+  header[0] = fields.sourceId;
+  view.setUint32(1, fields.sourceEpoch, true);
+  header.set(fields.incarnation, 5);
+  view.setUint32(21, fields.sequence, true);
+  view.setBigUint64(25, fields.captureTimeNanos, true);
+  header[33] = fields.captureClock;
+  header[34] = fields.mappingAvailable;
+  header[35] = fields.mappingTargetClock;
+  view.setBigInt64(36, fields.mappingOffsetNanos, true);
+  view.setBigUint64(44, fields.clockErrorBoundNanos, true);
+  view.setBigUint64(52, fields.receiveTimeNanos, true);
+  view.setBigUint64(60, fields.publicationTimeNanos, true);
+  view.setUint32(68, fields.cameraId, true);
+  view.setUint32(72, fields.calibrationId, true);
+  const tail = new Uint8Array(8 + payload.length);
+  const tailView = new DataView(tail.buffer);
+  for (let i = 0; i < 4; i += 1) tail[i] = fourcc.charCodeAt(i);
+  tailView.setUint32(4, payload.length, true);
+  tail.set(payload, 8);
+  const body = new Uint8Array(header.length + tail.length);
+  body.set(header, 0);
+  body.set(tail, header.length);
+  return body;
+}
+
+const v2Fields = {
+  sourceId: 1,
+  sourceEpoch: 7,
+  incarnation: new Uint8Array(16).fill(0xab),
+  sequence: 42,
+  captureTimeNanos: 123456n,
+  captureClock: 2,
+  mappingAvailable: 1,
+  mappingTargetClock: 1,
+  mappingOffsetNanos: -1000n,
+  clockErrorBoundNanos: 250n,
+  receiveTimeNanos: 5000n,
+  publicationTimeNanos: 6000n,
+  cameraId: 9,
+  calibrationId: 3,
+};
+
+const v2Payload = new Uint8Array([0xff, 0xd8, 1, 2, 3, 0xff, 0xd9]);
+const v2Body = buildV2Body(v2Fields, "MJPG", v2Payload);
+const v2Parsed = parseVideoFrameV2(v2Body);
+check("v2 frame parses to a full capture identity", (() => {
+  if (!v2Parsed) return false;
+  const m = v2Parsed.meta;
+  return (
+    m.sourceId === 1 &&
+    m.sourceEpoch === 7 &&
+    m.sourceIncarnation === "ab".repeat(16) &&
+    m.sequence === 42 &&
+    m.captureTimeNanos === 123456n &&
+    m.captureClock === 2 &&
+    m.mappingAvailable === true &&
+    m.mappingTargetClock === 1 &&
+    m.mappingOffsetNanos === -1000n &&
+    m.clockErrorBoundNanos === 250n &&
+    m.receiveTimeNanos === 5000n &&
+    m.publicationTimeNanos === 6000n &&
+    m.cameraId === 9 &&
+    m.calibrationId === 3 &&
+    v2Parsed.fourcc === "MJPG"
+  );
+})());
+check(
+  "v2 frame preserves the exact payload bytes",
+  v2Parsed !== null &&
+    v2Parsed.payload.length === v2Payload.length &&
+    v2Parsed.payload.every((b, i) => b === v2Payload[i]),
+);
+check(
+  "v2 unavailable mapping parses with a false flag",
+  (() => {
+    const body = buildV2Body({ ...v2Fields, mappingAvailable: 0 }, "MJPG", v2Payload);
+    const parsed = parseVideoFrameV2(body);
+    return parsed !== null && parsed.meta.mappingAvailable === false;
+  })(),
+);
+check("v2 body shorter than the header is rejected", parseVideoFrameV2(new Uint8Array(80)) === null);
+check(
+  "v2 declared length mismatch is rejected",
+  (() => {
+    const body = buildV2Body(v2Fields, "MJPG", v2Payload);
+    // Corrupt the u32 length prefix (offset 80) to over-declare the payload.
+    new DataView(body.buffer).setUint32(80, 999, true);
+    return parseVideoFrameV2(body) === null;
+  })(),
+);
 
 if (failures > 0) {
   console.error(`\n${failures} check(s) failed`);

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -10,6 +10,7 @@ mod control;
 mod step;
 mod telemetry;
 mod vehicle_adapter;
+mod video;
 
 pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, VehicleDescriptor};
 pub use control::{ApplyOutcome, Disposition, LinkLossPolicy, RejectReason};
@@ -19,3 +20,4 @@ pub use telemetry::{
     MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch, TelemetrySample, VideoSource,
 };
 pub use vehicle_adapter::VehicleAdapter;
+pub use video::{CalibrationId, CameraId, CaptureClockMapping, VideoCaptureStamp};

--- a/crates/pilotage-adapter-api/src/video.rs
+++ b/crates/pilotage-adapter-api/src/video.rs
@@ -1,0 +1,198 @@
+//! Capture identity and clock mapping for streamed video frames (ADR-0020).
+//!
+//! A displayed camera frame is only useful for a conformal overlay if the
+//! consumer can recover the aircraft state that corresponds to the *captured*
+//! image, not to the moment the browser happened to receive it. That demands
+//! two things travel with every frame: a traceable capture identity (which
+//! source, which attachment, which frame) and an explicit statement of whether
+//! the capture clock can be related to the flight-state clock at all, with a
+//! quantified error when it can.
+//!
+//! The capture identity reuses the AV-01 [`MeasurementStamp`] vocabulary
+//! wholesale rather than inventing a parallel one: a captured frame is just a
+//! measurement group whose acquisition clock is the camera's. Only the
+//! correlation to the flight-state clock is new, expressed by
+//! [`CaptureClockMapping`].
+
+use crate::telemetry::{MeasurementClock, MeasurementStamp};
+
+/// Stable identity of the physical camera a frame came from, distinct from the
+/// routing `source_id`: two attachments can reuse a routing slot over a
+/// session's life, but a conformal overlay needs the camera whose intrinsics
+/// and mounting produced this image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CameraId(pub u32);
+
+/// Identity of the calibration (intrinsics/extrinsics) that applies to a
+/// frame's camera. `0` means no calibration identity was published; a
+/// conformal consumer must treat that as "calibration unavailable" and never
+/// assume a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CalibrationId(pub u32);
+
+impl CalibrationId {
+    /// The sentinel meaning no calibration identity was published.
+    pub const NONE: Self = Self(0);
+
+    /// Whether a calibration identity was actually published for this frame.
+    #[must_use]
+    pub const fn is_published(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// Whether a frame's capture clock can be related to the flight-state clock,
+/// and with what error.
+///
+/// This is the gate that decides whether a conformal overlay is even
+/// admissible: absent a bounded mapping, the aircraft state that corresponds
+/// to a captured image cannot be recovered, and a consumer must fall back to a
+/// non-conformal presentation rather than draw the overlay against the wrong
+/// state. The default is [`CaptureClockMapping::Unavailable`]: a mapping is
+/// asserted only when an adapter can actually establish one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CaptureClockMapping {
+    /// No correlation between the capture clock and the flight-state clock is
+    /// available. Conformal output must be gated off.
+    #[default]
+    Unavailable,
+    /// A correlation with a bounded residual error is available.
+    Bounded {
+        /// Flight-state clock domain the capture time maps into.
+        target: MeasurementClock,
+        /// Nanoseconds added to the capture acquisition time to express it in
+        /// `target`. Signed because the flight clock's origin may precede or
+        /// follow the capture clock's.
+        offset_ns: i64,
+        /// Symmetric bound, in nanoseconds, on the residual error of the
+        /// mapped time. This is the quantified clock error a consumer budgets
+        /// against; it is meaningful only for this variant.
+        error_bound_ns: u64,
+    },
+}
+
+impl CaptureClockMapping {
+    /// The identity mapping: the capture clock *is* the flight-state clock, so
+    /// the capture time needs no offset and carries no residual error. Used
+    /// when a single simulation clock stamps both the video frames and the
+    /// telemetry (the Gazebo sidecar's sim time).
+    #[must_use]
+    pub const fn identity(clock: MeasurementClock) -> Self {
+        Self::Bounded {
+            target: clock,
+            offset_ns: 0,
+            error_bound_ns: 0,
+        }
+    }
+
+    /// Whether a bounded mapping is present. A consumer gates conformal output
+    /// on this being `true`.
+    #[must_use]
+    pub const fn is_available(self) -> bool {
+        matches!(self, Self::Bounded { .. })
+    }
+
+    /// The quantified error bound in nanoseconds when a mapping is available,
+    /// or `None` when it is not.
+    #[must_use]
+    pub const fn error_bound_ns(self) -> Option<u64> {
+        match self {
+            Self::Bounded { error_bound_ns, .. } => Some(error_bound_ns),
+            Self::Unavailable => None,
+        }
+    }
+}
+
+/// Everything needed to trace one captured video frame back to the aircraft
+/// state: the capture identity (an AV-01 [`MeasurementStamp`]), the camera and
+/// calibration identities, and the mapping from the capture clock to the
+/// flight-state clock.
+///
+/// The stamp's `source_id`, `source_epoch`, `sequence`, `acquired_at_ns` and
+/// `clock` carry, respectively, the routing source, the attachment/reset
+/// generation, the wrapping frame sequence, the capture time, and the capture
+/// clock domain — the identity a receiver deduplicates and orders on.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VideoCaptureStamp {
+    /// Capture identity of this frame, in the AV-01 measurement vocabulary.
+    pub stamp: MeasurementStamp,
+    /// Physical camera this frame came from.
+    pub camera_id: CameraId,
+    /// Calibration that applies to the camera, or [`CalibrationId::NONE`].
+    pub calibration_id: CalibrationId,
+    /// Whether and how the capture clock relates to the flight-state clock.
+    pub mapping: CaptureClockMapping,
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{CalibrationId, CameraId, CaptureClockMapping, VideoCaptureStamp};
+    use crate::telemetry::{MeasurementClock, MeasurementStamp, SourceIncarnation};
+
+    fn stamp() -> MeasurementStamp {
+        MeasurementStamp {
+            source_id: 0,
+            source_incarnation: SourceIncarnation::new([7; 16]),
+            source_epoch: 0,
+            sequence: 0,
+            acquired_at_ns: 1_000,
+            clock: MeasurementClock::Simulation,
+        }
+    }
+
+    #[test]
+    fn mapping_defaults_to_unavailable() {
+        assert_eq!(
+            CaptureClockMapping::default(),
+            CaptureClockMapping::Unavailable
+        );
+        assert!(!CaptureClockMapping::default().is_available());
+        assert_eq!(CaptureClockMapping::default().error_bound_ns(), None);
+    }
+
+    #[test]
+    fn identity_mapping_is_available_with_zero_error() {
+        let mapping = CaptureClockMapping::identity(MeasurementClock::Simulation);
+        assert!(mapping.is_available());
+        assert_eq!(mapping.error_bound_ns(), Some(0));
+        assert_eq!(
+            mapping,
+            CaptureClockMapping::Bounded {
+                target: MeasurementClock::Simulation,
+                offset_ns: 0,
+                error_bound_ns: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn bounded_mapping_reports_its_error_bound() {
+        let mapping = CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: -42,
+            error_bound_ns: 5_000,
+        };
+        assert!(mapping.is_available());
+        assert_eq!(mapping.error_bound_ns(), Some(5_000));
+    }
+
+    #[test]
+    fn calibration_none_is_unpublished() {
+        assert!(!CalibrationId::NONE.is_published());
+        assert!(CalibrationId(1).is_published());
+    }
+
+    #[test]
+    fn capture_stamp_holds_identity_and_mapping() {
+        let capture = VideoCaptureStamp {
+            stamp: stamp(),
+            camera_id: CameraId(1),
+            calibration_id: CalibrationId::NONE,
+            mapping: CaptureClockMapping::Unavailable,
+        };
+        assert_eq!(capture.camera_id, CameraId(1));
+        assert!(!capture.calibration_id.is_published());
+        assert!(!capture.mapping.is_available());
+    }
+}

--- a/crates/pilotage-adapter-api/src/video.rs
+++ b/crates/pilotage-adapter-api/src/video.rs
@@ -101,6 +101,37 @@ impl CaptureClockMapping {
             Self::Unavailable => None,
         }
     }
+
+    /// The target flight-state clock a bounded mapping expresses times in, or
+    /// `None` when no mapping is available.
+    #[must_use]
+    pub const fn target_clock(self) -> Option<MeasurementClock> {
+        match self {
+            Self::Bounded { target, .. } => Some(target),
+            Self::Unavailable => None,
+        }
+    }
+
+    /// Applies the mapping to a capture time, returning that instant expressed
+    /// in the target clock.
+    ///
+    /// Returns `None` when the mapping is unavailable, or when the signed offset
+    /// would carry the result outside the `u64` nanosecond range: a mapping
+    /// that would overflow or underflow refuses rather than wrapping into a
+    /// plausible-looking but wrong time.
+    #[must_use]
+    pub const fn map_capture_ns(self, capture_ns: u64) -> Option<u64> {
+        match self {
+            Self::Unavailable => None,
+            Self::Bounded { offset_ns, .. } => {
+                if offset_ns >= 0 {
+                    capture_ns.checked_add(offset_ns.unsigned_abs())
+                } else {
+                    capture_ns.checked_sub(offset_ns.unsigned_abs())
+                }
+            }
+        }
+    }
 }
 
 /// Everything needed to trace one captured video frame back to the aircraft
@@ -175,6 +206,44 @@ mod tests {
         };
         assert!(mapping.is_available());
         assert_eq!(mapping.error_bound_ns(), Some(5_000));
+        assert_eq!(mapping.target_clock(), Some(MeasurementClock::VehicleBoot));
+    }
+
+    #[test]
+    fn map_capture_ns_applies_the_signed_offset() {
+        let forward = CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: 100,
+            error_bound_ns: 0,
+        };
+        assert_eq!(forward.map_capture_ns(1_000), Some(1_100));
+        let backward = CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: -100,
+            error_bound_ns: 0,
+        };
+        assert_eq!(backward.map_capture_ns(1_000), Some(900));
+        assert_eq!(
+            CaptureClockMapping::identity(MeasurementClock::Simulation).map_capture_ns(42),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn map_capture_ns_refuses_to_wrap_at_the_u64_edges() {
+        let overflow = CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: 1,
+            error_bound_ns: 0,
+        };
+        assert_eq!(overflow.map_capture_ns(u64::MAX), None, "overflow refuses");
+        let underflow = CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: -1,
+            error_bound_ns: 0,
+        };
+        assert_eq!(underflow.map_capture_ns(0), None, "underflow refuses");
+        assert_eq!(CaptureClockMapping::Unavailable.map_capture_ns(1_000), None);
     }
 
     #[test]

--- a/docs/adr/0020-video-capture-identity-and-clock-mapping.md
+++ b/docs/adr/0020-video-capture-identity-and-clock-mapping.md
@@ -67,14 +67,35 @@ property of the integration, not something a consumer may assume.
   comparison: freshness advances only on a strictly newer epoch/sequence. A
   duplicate, reordered, stale-epoch, or wrong-camera frame is dropped and leaves
   the accepted state untouched, so a replayed frame can neither displace a newer
-  frame nor refresh its age. An epoch reset or a new incarnation is accepted as
-  an explicit discontinuity.
+  frame nor refresh its age. An epoch reset, a new incarnation, or a
+  **calibration-ID change** is accepted as an explicit discontinuity — the
+  conformal timeline never silently continues across a change of camera model.
 
-- The browser exposes a **conformal gate** (`mappingValid` / `conformalReady` /
-  `clockErrorBoundNanos`) that defaults closed. Conformal drawing does not exist
-  yet; the gate states only whether an overlay would be admissible, and an absent
-  or unavailable mapping keeps it closed. This is a SIM prerequisite for a
-  HUD-SIM overlay, NOT an airborne HUD capability, and is NOT FOR FLIGHT.
+- The browser exposes a **conformal gate**, `conformalGate(meta,
+  candidateSnapshotIdentity)`, that **fails closed** and consumes BOTH the frame
+  metadata AND the candidate aircraft snapshot's identity (an AV-01
+  `MeasurementStamp`; its `clock` is read here). "Bounded" is not sufficient. A
+  frame is conformal-ready only when all hold:
+  - the clock mapping is available, and its **target clock matches** the clock
+    the candidate snapshot is expressed in;
+  - the mapping's quantified error is within a **configured budget**
+    (`DEFAULT_MAX_CLOCK_ERROR_NANOS`, a named constant with a stated rationale);
+  - applying the mapping's signed offset to the capture time does **not overflow
+    or underflow** the `u64` nanosecond range (it refuses rather than wrapping);
+  - the frame's **calibration ID is published and recognized**
+    (`CalibrationId::NONE` / zero, or an unrecognized id, keeps the gate closed).
+
+  The gate reports `mappingValid` (the clock side) separately from
+  `conformalReady` (which additionally requires calibration). This is a SIM
+  prerequisite for a HUD-SIM overlay, NOT an airborne HUD capability, and is NOT
+  FOR FLIGHT.
+
+- **Deferred:** actual capture-to-snapshot *association* — selecting, at render
+  time, the specific aircraft snapshot a given frame corresponds to — is not
+  implemented in this change. The gate is the mechanism that association will
+  use; the browser deliberately does not evaluate conformal readiness against
+  the latest snapshot, which would reintroduce the receipt-time conflation this
+  ADR exists to remove.
 
 ## Consequences
 

--- a/docs/adr/0020-video-capture-identity-and-clock-mapping.md
+++ b/docs/adr/0020-video-capture-identity-and-clock-mapping.md
@@ -1,0 +1,89 @@
+# ADR-0020: Video frames carry a capture identity and an explicit clock mapping
+
+- Status: Accepted
+- Date: 2026-07-12
+
+## Context
+
+A conformal overlay draws symbology registered to the world as seen in a camera
+image: a runway outline on the runway, a flight-path marker where the aircraft
+is actually going. That registration is only correct if the overlay is computed
+from the aircraft state **at the instant the image was captured**, not the
+instant the browser happened to receive and decode the frame. Network jitter,
+host queueing, and JPEG decode latency put tens to hundreds of milliseconds
+between capture and display; at approach speeds that is meters of registration
+error.
+
+The media plane as it stood could not support this even in principle. A video
+frame on the wire (ADR-0016) was `[0x02][source_id][fourcc][u32 len][payload]`:
+it carried no capture time, no source identity beyond the routing byte, and no
+sequence. The Gazebo adapter's `RawVideoFrame` did carry a sidecar sim-time
+capture tick, but the host discarded it at the encode step. So a consumer had
+nothing to correlate a frame against a telemetry sample, and nothing to detect a
+duplicated or reordered frame — a replayed frame would blit over a newer one and
+its age would silently reset.
+
+Two distinct clocks are also in play and must not be conflated. A frame is
+captured on the camera/sim clock; the aircraft state is estimated on the flight
+controller's clock (ADR-0009's domain discipline, ADR-0018's `MeasurementStamp`).
+Whether those two clocks can be related at all — and with what error — is a
+property of the integration, not something a consumer may assume.
+
+## Decision
+
+- Every video frame carries a **capture identity** and an explicit
+  **clock mapping**, defined once in `pilotage-adapter-api` and preserved
+  unchanged from the adapter to the browser.
+
+- The capture identity **reuses the AV-01 `MeasurementStamp` vocabulary**
+  (ADR-0018) rather than inventing a parallel one: a captured frame is a
+  measurement group whose acquisition clock is the camera's. It carries the
+  routing source id, an opaque per-attachment incarnation, a source epoch, a
+  wrapping `u32` frame sequence, the capture time in nanoseconds, and the
+  capture clock domain. Alongside it travel a camera id and a calibration id
+  (`0` = no calibration published), and the clock mapping.
+
+- The clock mapping is `CaptureClockMapping`, whose **default is `Unavailable`**.
+  A mapping is asserted only when an adapter can actually establish one, as
+  `Bounded { target, offset_ns, error_bound_ns }`: the flight-state clock the
+  capture time maps into, the signed offset, and the **quantified error bound** a
+  consumer budgets against. The Gazebo sidecar stamps both its frames and its
+  telemetry from one sim clock, so it declares the identity mapping (offset 0,
+  error 0). Aviate captures on the sim sidecar clock but estimates flight state
+  on the vehicle-boot clock with no correlation between them, so it declares
+  `Unavailable` — honestly, rather than fabricating a stamp.
+
+- The wire format is **explicitly versioned**. A new stream-kind byte `0x03`
+  precedes a v2 body: a fixed capture-identity header, then the existing
+  `[fourcc][u32 len][payload]`. `0x02` keeps its exact prior meaning; a reader
+  that does not recognize `0x03` skips the stream, exactly as it skips an unknown
+  FourCC, so a v2 host degrades gracefully against an older client. The host
+  additionally stamps host **receive** and **publication** times into the header,
+  kept distinct from the capture time so a consumer never conflates host receipt
+  with acquisition — the receipt time this whole ADR exists to stop relying on.
+
+- The browser runs a **per-source identity tracker** mirroring the avionics
+  ingestion discipline (`telemetry-ingress.js`) and reusing its serial-number
+  comparison: freshness advances only on a strictly newer epoch/sequence. A
+  duplicate, reordered, stale-epoch, or wrong-camera frame is dropped and leaves
+  the accepted state untouched, so a replayed frame can neither displace a newer
+  frame nor refresh its age. An epoch reset or a new incarnation is accepted as
+  an explicit discontinuity.
+
+- The browser exposes a **conformal gate** (`mappingValid` / `conformalReady` /
+  `clockErrorBoundNanos`) that defaults closed. Conformal drawing does not exist
+  yet; the gate states only whether an overlay would be admissible, and an absent
+  or unavailable mapping keeps it closed. This is a SIM prerequisite for a
+  HUD-SIM overlay, NOT an airborne HUD capability, and is NOT FOR FLIGHT.
+
+## Consequences
+
+- A future conformal overlay can select the aircraft state corresponding to a
+  frame's capture time and know the residual clock error, or refuse to draw when
+  no mapping is available — the decision is data-driven, not implicit.
+- Adapters that genuinely lack a capture-clock correlation report that fact; the
+  system never invents a mapping to make an overlay appear admissible.
+- Adding the header costs a fixed number of bytes per frame and one serial
+  comparison per frame in the browser; both are negligible against the JPEG.
+- The v1 `0x02` framing remains defined for compatibility and is exercised only
+  by the framing round-trip tests; the host emits `0x03`.

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -143,6 +143,11 @@ async fn spawn_host_runtime(
     engine_rx: mpsc::Receiver<ToEngine>,
     shutdown_rx: oneshot::Receiver<()>,
 ) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    // A single monotonic origin feeds every `host_time` stamp across the host
+    // (ADR-0009): the engine actor, each connection task, and — so a video
+    // frame's receive/publication stamps stay comparable with them — the media
+    // task all derive from this `Instant`.
+    let start = tokio::time::Instant::now();
     match adapter {
         AdapterKind::Reference => {
             let (engine, adapter) = build_reference();
@@ -154,12 +159,13 @@ async fn spawn_host_runtime(
                 engine_tx,
                 engine_rx,
                 shutdown_rx,
+                start,
             )))
         }
         AdapterKind::Gazebo => {
             let (engine, adapter, frames) =
                 gazebo_launch::build_gazebo(HOST_VEHICLE, MAX_CONTROL_AGE).await?;
-            let (media, media_task) = media::spawn_media_task(frames);
+            let (media, media_task) = media::spawn_media_task(frames, start);
             Ok(tokio::spawn(run_with_media_until_shutdown(
                 endpoint,
                 engine,
@@ -169,50 +175,65 @@ async fn spawn_host_runtime(
                 engine_tx,
                 engine_rx,
                 shutdown_rx,
+                start,
             )))
         }
         AdapterKind::Aviate => {
-            // PILOTAGE_AVIATE_LINK selects the vehicle link (ADR-0019):
-            // "shm" (co-located SITL), "mavlink" (routed/remote), or the
-            // default "auto" (shm when present, else MAVLink).
-            let mode = match std::env::var("PILOTAGE_AVIATE_LINK").as_deref() {
-                Ok("shm") => pilotage_adapter_aviate::AviateLinkMode::Shm,
-                Ok("mavlink") => pilotage_adapter_aviate::AviateLinkMode::Mavlink,
-                _ => pilotage_adapter_aviate::AviateLinkMode::Auto,
-            };
-            let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
-                HOST_VEHICLE,
-                mode,
-                pilotage_adapter_aviate::LinkConfig::simulator(),
-            )
-            .await
-            .map_err(HostError::AviateAdapter)?;
-            let engine = build_engine(&adapter);
-            match adapter.subscribe_frames() {
-                Some(frames) => {
-                    let (media, media_task) = media::spawn_media_task(frames);
-                    Ok(tokio::spawn(run_with_media_until_shutdown(
-                        endpoint,
-                        engine,
-                        adapter,
-                        media,
-                        media_task,
-                        engine_tx,
-                        engine_rx,
-                        shutdown_rx,
-                    )))
-                }
-                None => Ok(tokio::spawn(run_until_shutdown(
-                    endpoint,
-                    engine,
-                    adapter,
-                    None,
-                    engine_tx,
-                    engine_rx,
-                    shutdown_rx,
-                ))),
-            }
+            spawn_aviate_runtime(endpoint, engine_tx, engine_rx, shutdown_rx, start).await
         }
+    }
+}
+
+/// Builds the Aviate adapter and spawns its runtime, wiring the media task only
+/// when the adapter exposes a video frame source.
+async fn spawn_aviate_runtime(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
+) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    // PILOTAGE_AVIATE_LINK selects the vehicle link (ADR-0019): "shm"
+    // (co-located SITL), "mavlink" (routed/remote), or the default "auto" (shm
+    // when present, else MAVLink).
+    let mode = match std::env::var("PILOTAGE_AVIATE_LINK").as_deref() {
+        Ok("shm") => pilotage_adapter_aviate::AviateLinkMode::Shm,
+        Ok("mavlink") => pilotage_adapter_aviate::AviateLinkMode::Mavlink,
+        _ => pilotage_adapter_aviate::AviateLinkMode::Auto,
+    };
+    let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
+        HOST_VEHICLE,
+        mode,
+        pilotage_adapter_aviate::LinkConfig::simulator(),
+    )
+    .await
+    .map_err(HostError::AviateAdapter)?;
+    let engine = build_engine(&adapter);
+    match adapter.subscribe_frames() {
+        Some(frames) => {
+            let (media, media_task) = media::spawn_media_task(frames, start);
+            Ok(tokio::spawn(run_with_media_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                media,
+                media_task,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
+        None => Ok(tokio::spawn(run_until_shutdown(
+            endpoint,
+            engine,
+            adapter,
+            None,
+            engine_tx,
+            engine_rx,
+            shutdown_rx,
+            start,
+        ))),
     }
 }
 
@@ -220,6 +241,7 @@ async fn spawn_host_runtime(
 /// tears down every spawned task (engine actor, accept loop, and every
 /// per-connection task) within the shutdown timeout. `media` is `Some` only
 /// for the Gazebo path, wiring each connection into the video downlink.
+#[allow(clippy::too_many_arguments)]
 async fn run_until_shutdown<A>(
     endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
     engine: SessionEngine,
@@ -228,15 +250,15 @@ async fn run_until_shutdown<A>(
     engine_tx: mpsc::Sender<ToEngine>,
     engine_rx: mpsc::Receiver<ToEngine>,
     shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
 ) where
     A: VehicleAdapter + Send + 'static,
 {
-    // A single monotonic origin feeds every `host_time` comparison across
-    // the host (ADR-0009): client-message receive stamps (via `accept_loop`
-    // and each connection task) and the engine actor's tick/offer-expiry
-    // stamps must derive from the same `Instant`, or the two streams of
-    // timestamps drift apart and skew staleness/expiry comparisons.
-    let start = tokio::time::Instant::now();
+    // `start` is the single monotonic origin every `host_time` stamp across
+    // the host derives from (ADR-0009): client-message receive stamps (via
+    // `accept_loop` and each connection task), the engine actor's
+    // tick/offer-expiry stamps, and the media task's frame stamps. Sharing one
+    // origin keeps those timestamp streams comparable rather than drifting.
 
     let mut tasks = JoinSet::new();
     tasks.spawn(named_task(
@@ -278,6 +300,7 @@ async fn run_with_media_until_shutdown<A>(
     engine_tx: mpsc::Sender<ToEngine>,
     engine_rx: mpsc::Receiver<ToEngine>,
     shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
 ) where
     A: VehicleAdapter + Send + 'static,
 {
@@ -289,6 +312,7 @@ async fn run_with_media_until_shutdown<A>(
         engine_tx,
         engine_rx,
         shutdown_rx,
+        start,
     )
     .await;
     // The engine actor (owner of the adapter and its frame sender) has now

--- a/hosts/session-host/src/runtime/media.rs
+++ b/hosts/session-host/src/runtime/media.rs
@@ -14,15 +14,17 @@
 use std::sync::Arc;
 
 use jpeg_encoder::{ColorType, Encoder};
+use pilotage_adapter_api::VideoCaptureStamp;
 use pilotage_adapter_gazebo::RawVideoFrame;
 use pilotage_session::ClientKey;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::task::JoinSet;
+use tokio::time::Instant;
 use tracing::{debug, error, warn};
 use wtransport::Connection;
 
-use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME, frame_video_payload};
+use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME_V2, frame_video_payload_v2};
 
 /// JPEG quality (1-100) for encoded camera frames. 75 balances size against
 /// visible quality for a teleop preview (ADR-0005: owned, tunable pipeline).
@@ -81,9 +83,10 @@ const COMMAND_QUEUE_CAPACITY: usize = 256;
 /// exits after its per-client writers finish.
 pub fn spawn_media_task(
     frames: mpsc::Receiver<RawVideoFrame>,
+    start: Instant,
 ) -> (MediaHandle, tokio::task::JoinHandle<()>) {
     let (commands_tx, commands_rx) = mpsc::channel(COMMAND_QUEUE_CAPACITY);
-    let handle = tokio::spawn(media_loop(frames, commands_rx));
+    let handle = tokio::spawn(media_loop(frames, commands_rx, start));
     (
         MediaHandle {
             commands: commands_tx,
@@ -92,12 +95,30 @@ pub fn spawn_media_task(
     )
 }
 
-/// Per-(client, source) outbound handoff of the latest encoded JPEG. Capacity
+/// Host monotonic nanoseconds since `start`, saturating rather than
+/// overflowing, in the same `host_time` domain the engine and connection tasks
+/// stamp with (ADR-0009). Used for the receive/publication stamps that a
+/// consumer must never confuse with a frame's capture time.
+fn now_ns(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+/// One encoded frame handed to a client's writer: the shared JPEG, the capture
+/// identity to serialize alongside it, and the host receive time stamped when
+/// the media task dequeued the raw frame (kept distinct from the capture time).
+#[derive(Clone)]
+struct EncodedFrame {
+    jpeg: Arc<Vec<u8>>,
+    capture: VideoCaptureStamp,
+    received_at_ns: u64,
+}
+
+/// Per-(client, source) outbound handoff of the latest encoded frame. Capacity
 /// 1 bounds in-flight frames to one per source per client: `try_send` on a
 /// full channel means that source's writer is still busy with its previous
 /// frame, so the new frame is dropped-to-latest and counted (ADR-0011
 /// best-effort media).
-type FrameTx = mpsc::Sender<Arc<Vec<u8>>>;
+type FrameTx = mpsc::Sender<EncodedFrame>;
 
 /// The media task's own view of one video source of a connected client: the
 /// handoff channel to that source's writer task, plus the running drop count
@@ -121,6 +142,7 @@ struct ClientEntry {
 async fn media_loop(
     mut frames: mpsc::Receiver<RawVideoFrame>,
     mut commands: mpsc::Receiver<MediaCommand>,
+    start: Instant,
 ) {
     let mut clients: std::collections::BTreeMap<ClientKey, ClientEntry> =
         std::collections::BTreeMap::new();
@@ -147,7 +169,10 @@ async fn media_loop(
             }
             frame = frames.recv() => {
                 match frame {
-                    Some(frame) => fan_out_frame(frame, &mut clients, &mut writers),
+                    // Stamp host receipt the moment the frame leaves the adapter
+                    // channel, before the encode cost, so the receive time
+                    // reflects arrival rather than processing.
+                    Some(frame) => fan_out_frame(frame, now_ns(start), &mut clients, &mut writers, start),
                     None => break,
                 }
             }
@@ -191,33 +216,41 @@ fn apply_command(
 /// consumer), and evicting any client whose connection has gone away.
 fn fan_out_frame(
     frame: RawVideoFrame,
+    received_at_ns: u64,
     clients: &mut std::collections::BTreeMap<ClientKey, ClientEntry>,
     writers: &mut JoinSet<()>,
+    start: Instant,
 ) {
     if clients.is_empty() {
         return;
     }
     let source_id = frame.source_id;
+    let capture = frame.capture;
     let Some(jpeg) = encode_jpeg(&frame) else {
         return;
     };
-    let jpeg = Arc::new(jpeg);
+    let encoded = EncodedFrame {
+        jpeg: Arc::new(jpeg),
+        capture,
+        received_at_ns,
+    };
     let mut closed = Vec::new();
     for (client, entry) in clients.iter_mut() {
         let sink = entry.sources.entry(source_id).or_insert_with(|| {
-            let (frame_tx, frame_rx) = mpsc::channel::<Arc<Vec<u8>>>(1);
+            let (frame_tx, frame_rx) = mpsc::channel::<EncodedFrame>(1);
             writers.spawn(client_writer(
                 *client,
                 source_id,
                 entry.connection.clone(),
                 frame_rx,
+                start,
             ));
             ClientSink {
                 frames: frame_tx,
                 dropped: 0,
             }
         });
-        match sink.frames.try_send(Arc::clone(&jpeg)) {
+        match sink.frames.try_send(encoded.clone()) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 sink.dropped = sink.dropped.wrapping_add(1);
@@ -267,18 +300,25 @@ fn encode_jpeg(frame: &RawVideoFrame) -> Option<Vec<u8>> {
     Some(jpeg)
 }
 
-/// Per-(client, source) writer: receives the latest encoded JPEG and writes it
-/// as one host-initiated uni stream tagged [`VIDEO_FRAME`], one stream per
-/// frame (ADR-0005), stamped with `source_id`. Exits when the handoff channel
-/// closes (client deregistered or media task shutting down).
+/// Per-(client, source) writer: receives the latest encoded frame and writes
+/// it as one host-initiated uni stream tagged [`VIDEO_FRAME_V2`], one stream
+/// per frame (ADR-0005, ADR-0020), leading with the frame's capture identity.
+/// Exits when the handoff channel closes (client deregistered or media task
+/// shutting down).
 async fn client_writer(
     client: ClientKey,
     source_id: u8,
     connection: Connection,
-    mut frames: mpsc::Receiver<Arc<Vec<u8>>>,
+    mut frames: mpsc::Receiver<EncodedFrame>,
+    start: Instant,
 ) {
-    while let Some(jpeg) = frames.recv().await {
-        if let Err(reason) = write_one_frame(&connection, source_id, &jpeg).await {
+    while let Some(frame) = frames.recv().await {
+        // Stamp publication at the moment of write, distinct from the receive
+        // stamp taken at dequeue, so a consumer can separate host queueing
+        // latency from the capture-to-receipt gap.
+        let published_at_ns = now_ns(start);
+        if let Err(reason) = write_one_frame(&connection, source_id, &frame, published_at_ns).await
+        {
             // A failed uni-stream open/write means the connection is going
             // away; stop writing video to it. The connection task's own
             // teardown deregisters this client.
@@ -291,15 +331,24 @@ async fn client_writer(
     }
 }
 
-/// Opens one host-initiated uni stream, writes the [`VIDEO_FRAME`] tag then
-/// the source-tagged, codec-tagged, length-prefixed JPEG, and finishes the
-/// stream (ADR-0005 media unit; ADR-0016 FourCC codec tag).
+/// Opens one host-initiated uni stream, writes the [`VIDEO_FRAME_V2`] tag then
+/// the capture-identity header and codec-tagged, length-prefixed JPEG, and
+/// finishes the stream (ADR-0005 media unit; ADR-0016 FourCC codec tag;
+/// ADR-0020 capture identity).
 async fn write_one_frame(
     connection: &Connection,
     source_id: u8,
-    jpeg: &[u8],
+    frame: &EncodedFrame,
+    published_at_ns: u64,
 ) -> Result<(), &'static str> {
-    let Some(body) = frame_video_payload(source_id, FOURCC_MJPEG, jpeg) else {
+    let Some(body) = frame_video_payload_v2(
+        source_id,
+        &frame.capture,
+        frame.received_at_ns,
+        published_at_ns,
+        FOURCC_MJPEG,
+        &frame.jpeg,
+    ) else {
         // A frame larger than u32::MAX cannot be length-prefixed; skip it
         // without failing the writer (no real camera frame reaches this).
         error!("video frame exceeds u32 length prefix; skipping");
@@ -312,7 +361,7 @@ async fn write_one_frame(
         .await
         .map_err(|_| "uni stream failed to open")?;
     stream
-        .write_all(&[VIDEO_FRAME])
+        .write_all(&[VIDEO_FRAME_V2])
         .await
         .map_err(|_| "tag write failed")?;
     stream
@@ -327,11 +376,29 @@ async fn write_one_frame(
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
     use super::encode_jpeg;
-    use crate::runtime::stream_tag::{
-        FOURCC_MJPEG, VIDEO_FRAME, frame_video_payload, parse_video_payload,
+    use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME_V2, frame_video_payload_v2};
+    use pilotage_adapter_api::{
+        CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, MeasurementStamp,
+        SourceIncarnation, VideoCaptureStamp,
     };
     use pilotage_adapter_gazebo::RawVideoFrame;
     use pilotage_timing::SimTick;
+
+    fn capture_stamp() -> VideoCaptureStamp {
+        VideoCaptureStamp {
+            stamp: MeasurementStamp {
+                source_id: 1,
+                source_incarnation: SourceIncarnation::new([5; 16]),
+                source_epoch: 0,
+                sequence: 3,
+                acquired_at_ns: 999,
+                clock: MeasurementClock::Simulation,
+            },
+            camera_id: CameraId(1),
+            calibration_id: CalibrationId::NONE,
+            mapping: CaptureClockMapping::identity(MeasurementClock::Simulation),
+        }
+    }
 
     /// Builds a synthetic RGB frame with a simple gradient so the encoder has
     /// real (non-constant) pixel data to work with.
@@ -351,11 +418,12 @@ mod tests {
             pixel_format: "RGB_INT8".to_owned(),
             tick: SimTick::new(0),
             rgb,
+            capture: capture_stamp(),
         }
     }
 
     #[test]
-    fn encodes_frames_and_wire_frames_round_trip() {
+    fn encodes_frame_and_v2_body_carries_the_jpeg() {
         let frame = synthetic_rgb(16, 12);
         let jpeg = encode_jpeg(&frame).expect("synthetic RGB frame encodes to JPEG");
         // A JPEG stream begins with the SOI marker 0xFFD8 and ends with EOI
@@ -363,26 +431,21 @@ mod tests {
         assert_eq!(&jpeg[..2], &[0xFF, 0xD8], "JPEG starts with SOI");
         assert_eq!(&jpeg[jpeg.len() - 2..], &[0xFF, 0xD9], "JPEG ends with EOI");
 
-        // Frame the JPEG exactly as the media task writes it after the tag,
-        // then parse the source-tagged, codec-tagged length-prefixed body back
-        // (ADR-0016).
-        let body = frame_video_payload(1, FOURCC_MJPEG, &jpeg).expect("JPEG frames");
-        let (source_id, codec, parsed) =
-            parse_video_payload(&body).expect("framed body parses back");
-        assert_eq!(source_id, 1, "carries the chase source id");
-        assert_eq!(codec, FOURCC_MJPEG, "carries the MJPG FourCC");
-        assert_eq!(parsed, jpeg.as_slice(), "round-trips the exact JPEG bytes");
+        // Frame the JPEG exactly as the media task writes it after the tag: a
+        // v2 capture-identity body (ADR-0020). The full on-wire unit leads with
+        // the v2 kind tag, then the header, codec, length prefix, and payload.
+        let body = frame_video_payload_v2(1, &frame.capture, 10, 20, FOURCC_MJPEG, &jpeg)
+            .expect("JPEG frames into a v2 body");
+        assert_eq!(body[0], 1, "leads with the chase source id");
+        assert_eq!(
+            &body[body.len() - jpeg.len()..],
+            jpeg.as_slice(),
+            "JPEG trails intact"
+        );
 
-        // The full on-wire unit is [tag][source_id][fourcc][u32 len][jpeg];
-        // assemble and dissect it the way a client reader would.
-        let mut wire = vec![VIDEO_FRAME];
+        let mut wire = vec![VIDEO_FRAME_V2];
         wire.extend_from_slice(&body);
-        assert_eq!(wire[0], VIDEO_FRAME, "leads with the video kind tag");
-        let (source_id, codec, parsed) =
-            parse_video_payload(&wire[1..]).expect("payload after tag parses");
-        assert_eq!(source_id, 1);
-        assert_eq!(codec, FOURCC_MJPEG);
-        assert_eq!(parsed, jpeg.as_slice());
+        assert_eq!(wire[0], VIDEO_FRAME_V2, "leads with the v2 video kind tag");
     }
 
     #[test]

--- a/hosts/session-host/src/runtime/stream_tag.rs
+++ b/hosts/session-host/src/runtime/stream_tag.rs
@@ -7,6 +7,8 @@
 //! begins with a single kind-tag byte before its payload; the reader consumes
 //! that byte first and routes on it.
 
+use pilotage_adapter_api::{CaptureClockMapping, MeasurementClock, VideoCaptureStamp};
+
 /// Tag prefixing the dedicated authority-events stream: the reliable, ordered
 /// stream of lease/handover/override events (ADR-0005) carries
 /// length-delimited envelopes after this byte.
@@ -17,7 +19,103 @@ pub const AUTHORITY_EVENTS: u8 = 0x01;
 /// this byte (ADR-0005 media = one uni stream per frame; ADR-0016 codec tag).
 /// `source_id` names the video source (0 = onboard FPV, 1 = chase) so a client
 /// with several sources routes each frame to the right one.
+///
+/// This framing carries no capture identity; [`VIDEO_FRAME_V2`] supersedes it
+/// as the emitted format. The tag and its builder are kept only to pin the
+/// stable meaning of `0x02` in the compat tests.
+#[cfg(test)]
 pub const VIDEO_FRAME: u8 = 0x02;
+
+/// Tag prefixing a per-frame video stream that leads with a capture-identity
+/// header before the codec-tagged, length-prefixed payload (ADR-0020).
+///
+/// A reader that does not recognize this tag skips the stream, exactly as it
+/// would an unknown FourCC, so a host emitting v2 frames degrades gracefully
+/// against an older client. The body layout is built by
+/// [`frame_video_payload_v2`].
+pub const VIDEO_FRAME_V2: u8 = 0x03;
+
+/// Byte length of the fixed capture-identity header a [`VIDEO_FRAME_V2`] body
+/// carries before its FourCC, `u32` length prefix, and payload. Keep this in
+/// sync with [`frame_video_payload_v2`] and the browser parser in
+/// `clients/web/wire.js`.
+const V2_META_LEN: usize = 1  // source_id
+    + 4   // source_epoch
+    + 16  // source_incarnation
+    + 4   // sequence
+    + 8   // capture_time_ns
+    + 1   // capture_clock
+    + 1   // mapping_available
+    + 1   // mapping_target_clock
+    + 8   // mapping_offset_ns
+    + 8   // clock_error_bound_ns
+    + 8   // receive_time_ns
+    + 8   // publication_time_ns
+    + 4   // camera_id
+    + 4; // calibration_id
+
+/// Wire code for a [`MeasurementClock`], matching the `pilotage.v1`
+/// `MeasurementClock` enum the browser already decodes: 1 vehicle-boot, 2
+/// simulation. `0` (unspecified) is reserved for an absent target clock.
+fn measurement_clock_code(clock: MeasurementClock) -> u8 {
+    match clock {
+        MeasurementClock::VehicleBoot => 1,
+        MeasurementClock::Simulation => 2,
+    }
+}
+
+/// Serializes one encoded frame as the on-wire body that follows the
+/// [`VIDEO_FRAME_V2`] tag: the fixed capture-identity header (source identity,
+/// attachment epoch and incarnation, wrapping sequence, sim capture time and
+/// clock, the clock mapping to the flight-state clock, host receive and
+/// publication times, and camera/calibration identities), then the codec
+/// FourCC, a little-endian `u32` length prefix, and the encoded bytes.
+///
+/// `source_id` is the routing byte (0 = onboard FPV, 1 = chase) and is the
+/// same identity carried in `capture.stamp.source_id`. `receive_time_ns` and
+/// `publication_time_ns` are host monotonic stamps, kept distinct from the
+/// capture time so a consumer never conflates host receipt with acquisition.
+///
+/// Returns the framed bytes, or `None` if `payload` is larger than `u32::MAX`.
+#[must_use]
+pub fn frame_video_payload_v2(
+    source_id: u8,
+    capture: &VideoCaptureStamp,
+    receive_time_ns: u64,
+    publication_time_ns: u64,
+    codec: [u8; 4],
+    payload: &[u8],
+) -> Option<Vec<u8>> {
+    let len = u32::try_from(payload.len()).ok()?;
+    let (available, target, offset_ns, error_bound_ns) = match capture.mapping {
+        CaptureClockMapping::Unavailable => (0_u8, 0_u8, 0_i64, 0_u64),
+        CaptureClockMapping::Bounded {
+            target,
+            offset_ns,
+            error_bound_ns,
+        } => (1, measurement_clock_code(target), offset_ns, error_bound_ns),
+    };
+    let stamp = &capture.stamp;
+    let mut out = Vec::with_capacity(V2_META_LEN + 4 + payload.len());
+    out.push(source_id);
+    out.extend_from_slice(&stamp.source_epoch.to_le_bytes());
+    out.extend_from_slice(&stamp.source_incarnation.into_bytes());
+    out.extend_from_slice(&stamp.sequence.to_le_bytes());
+    out.extend_from_slice(&stamp.acquired_at_ns.to_le_bytes());
+    out.push(measurement_clock_code(stamp.clock));
+    out.push(available);
+    out.push(target);
+    out.extend_from_slice(&offset_ns.to_le_bytes());
+    out.extend_from_slice(&error_bound_ns.to_le_bytes());
+    out.extend_from_slice(&receive_time_ns.to_le_bytes());
+    out.extend_from_slice(&publication_time_ns.to_le_bytes());
+    out.extend_from_slice(&capture.camera_id.0.to_le_bytes());
+    out.extend_from_slice(&capture.calibration_id.0.to_le_bytes());
+    out.extend_from_slice(&codec);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(payload);
+    Some(out)
+}
 
 /// FourCC codec tag for Motion JPEG frames (ADR-0016).
 ///
@@ -39,6 +137,7 @@ pub const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
 /// Returns the framed bytes, or `None` if `payload` is larger than `u32::MAX`
 /// (far beyond any real camera frame; a length that cannot be expressed in
 /// the 4-byte prefix must not be silently truncated).
+#[cfg(test)]
 #[must_use]
 pub fn frame_video_payload(source_id: u8, codec: [u8; 4], payload: &[u8]) -> Option<Vec<u8>> {
     let len = u32::try_from(payload.len()).ok()?;
@@ -74,7 +173,19 @@ pub fn parse_video_payload(body: &[u8]) -> Option<(u8, [u8; 4], &[u8])> {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{FOURCC_MJPEG, frame_video_payload, parse_video_payload};
+    use super::{
+        FOURCC_MJPEG, VIDEO_FRAME, VIDEO_FRAME_V2, frame_video_payload, parse_video_payload,
+    };
+
+    #[test]
+    fn v1_and_v2_kind_tags_are_distinct_and_stable() {
+        assert_eq!(VIDEO_FRAME, 0x02, "v1 video kind byte keeps its meaning");
+        assert_eq!(VIDEO_FRAME_V2, 0x03, "v2 video kind byte");
+        assert_ne!(
+            VIDEO_FRAME, VIDEO_FRAME_V2,
+            "a reader can tell v1 and v2 apart"
+        );
+    }
 
     #[test]
     fn framing_round_trips() {
@@ -110,5 +221,91 @@ mod tests {
         // Declares 5 bytes but only 2 follow.
         let body = vec![0, b'M', b'J', b'P', b'G', 5, 0, 0, 0, 1, 2];
         assert_eq!(parse_video_payload(&body), None);
+    }
+
+    use super::{V2_META_LEN, VideoCaptureStamp, frame_video_payload_v2};
+    use pilotage_adapter_api::{
+        CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, MeasurementStamp,
+        SourceIncarnation,
+    };
+
+    fn le_u32(bytes: &[u8], at: usize) -> u32 {
+        u32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]])
+    }
+
+    fn le_u64(bytes: &[u8], at: usize) -> u64 {
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(&bytes[at..at + 8]);
+        u64::from_le_bytes(buf)
+    }
+
+    fn le_i64(bytes: &[u8], at: usize) -> i64 {
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(&bytes[at..at + 8]);
+        i64::from_le_bytes(buf)
+    }
+
+    fn sample_capture(mapping: CaptureClockMapping) -> VideoCaptureStamp {
+        VideoCaptureStamp {
+            stamp: MeasurementStamp {
+                source_id: 1,
+                source_incarnation: SourceIncarnation::new([0xAB; 16]),
+                source_epoch: 7,
+                sequence: 42,
+                acquired_at_ns: 123_456,
+                clock: MeasurementClock::Simulation,
+            },
+            camera_id: CameraId(9),
+            calibration_id: CalibrationId(3),
+            mapping,
+        }
+    }
+
+    #[test]
+    fn v2_header_places_every_field_at_its_offset() {
+        let capture = sample_capture(CaptureClockMapping::Bounded {
+            target: MeasurementClock::VehicleBoot,
+            offset_ns: -1_000,
+            error_bound_ns: 250,
+        });
+        let jpeg = vec![0xFF, 0xD8, 1, 2, 3, 0xFF, 0xD9];
+        let body =
+            frame_video_payload_v2(1, &capture, 5_000, 6_000, FOURCC_MJPEG, &jpeg).expect("frames");
+
+        assert_eq!(body[0], 1, "source_id routing byte");
+        assert_eq!(le_u32(&body, 1), 7, "source_epoch");
+        assert_eq!(&body[5..21], &[0xAB; 16], "source_incarnation");
+        assert_eq!(le_u32(&body, 21), 42, "sequence");
+        assert_eq!(le_u64(&body, 25), 123_456, "capture_time_ns");
+        assert_eq!(body[33], 2, "capture clock = simulation");
+        assert_eq!(body[34], 1, "mapping available");
+        assert_eq!(body[35], 1, "mapping target = vehicle boot");
+        assert_eq!(le_i64(&body, 36), -1_000, "mapping offset");
+        assert_eq!(le_u64(&body, 44), 250, "clock error bound");
+        assert_eq!(le_u64(&body, 52), 5_000, "receive time");
+        assert_eq!(le_u64(&body, 60), 6_000, "publication time");
+        assert_eq!(le_u32(&body, 68), 9, "camera id");
+        assert_eq!(le_u32(&body, 72), 3, "calibration id");
+        assert_eq!(&body[76..80], b"MJPG", "codec fourcc after the header");
+        assert_eq!(le_u32(&body, 80), jpeg.len() as u32, "length prefix");
+        // Header (V2_META_LEN) + 4-byte FourCC + 4-byte length prefix.
+        assert_eq!(
+            &body[V2_META_LEN + 8..],
+            jpeg.as_slice(),
+            "payload trails intact"
+        );
+    }
+
+    #[test]
+    fn v2_unavailable_mapping_zeroes_the_mapping_fields() {
+        let capture = sample_capture(CaptureClockMapping::Unavailable);
+        let body =
+            frame_video_payload_v2(0, &capture, 1, 2, FOURCC_MJPEG, &[9, 9]).expect("frames");
+        assert_eq!(body[34], 0, "mapping unavailable flag");
+        assert_eq!(body[35], 0, "no target clock");
+        assert_eq!(le_i64(&body, 36), 0, "no offset");
+        assert_eq!(le_u64(&body, 44), 0, "no error bound");
+        // The capture stamp itself is still preserved.
+        assert_eq!(le_u64(&body, 25), 123_456, "capture time survives");
     }
 }


### PR DESCRIPTION
## HUD-01: preserve video capture identity and clock mapping end to end

**SIM / NOT FOR FLIGHT.** This is a HUD-SIM prerequisite — it lets a *future* conformal overlay use the aircraft state that corresponds to a captured image rather than browser receipt time. It is **not** an airborne HUD capability and makes **no** certification claim. Conformal drawing itself does not exist yet; this PR makes it possible and gates it off by default.

Refs #36 (does not close the issue).

### Association status — DEFERRED (read before deciding #36 closure)

Actual capture-to-aircraft-snapshot **association** — selecting, at render time, the specific aircraft snapshot a given frame corresponds to — is **not implemented** in this PR. What is implemented is everything that makes association possible and safe: the per-frame capture identity, the clock mapping with a quantified error, and the `conformalGate` that association will consume. The browser deliberately does **not** evaluate conformal readiness against the latest snapshot, because that would reintroduce the receipt-time conflation this change exists to remove.

### What changed

Every video frame carries a traceable capture identity and an explicit clock mapping, preserved unchanged from the adapter to the browser (ADR-0020).

- **`pilotage-adapter-api`** — `VideoCaptureStamp` reuses the AV-01 `MeasurementStamp` vocabulary plus `CameraId`/`CalibrationId` and `CaptureClockMapping` (defaults `Unavailable`; only asserts a `Bounded { target, offset_ns, error_bound_ns }` correlation). `CaptureClockMapping::map_capture_ns` applies the signed offset with checked `u64` arithmetic, refusing at the edges instead of wrapping.
- **Gazebo** — a `FrameStamper` assigns each frame its incarnation, a wrapping `u32` sequence (`wrapping_add(1)`), and the sim **identity** mapping; the sidecar capture tick becomes the capture time.
- **Aviate** — reuses the stamper but declares the mapping **`Unavailable`** (flight state on the vehicle-boot clock, no correlation to sim capture time); never fabricates a stamp.
- **Host** — versioned framing: new stream-kind `0x03` leads with the capture-identity header; `0x02` keeps its meaning for the compat tests. Host receive/publication times are stamped distinct from capture time on the shared monotonic origin (ADR-0009).
- **Browser** — `parseVideoFrameV2` parses the header; `VideoIdentityTracker` drops duplicate/reordered/stale-epoch/wrong-camera frames (a replay never displaces a newer frame or refreshes its age), and treats an epoch reset, a new incarnation, or a **calibration-ID change** as an explicit discontinuity.

### Conformal gate (hardened per review)

`conformalGate(meta, candidateSnapshotIdentity, options)` **fails closed** and consumes BOTH the frame metadata and the candidate aircraft snapshot's identity (an AV-01 `MeasurementStamp`; its `clock` is read). `conformalReady` is true only when: the mapping is available; its **target clock matches** the snapshot's clock; its error is within a **configured budget** (`DEFAULT_MAX_CLOCK_ERROR_NANOS`, a named constant with rationale); the mapped capture time does **not overflow/underflow** `u64`; and the frame's **calibration ID is published and recognized** (zero/`NONE` or unrecognized keeps it closed). `mappingValid` (the clock side) is reported separately from `conformalReady` (which adds calibration).

### Acceptance criteria → evidence

| # | Criterion | Evidence (test) |
|---|-----------|-----------------|
| 1 | Capture metadata reaches the browser unchanged | Rust `stream_tag::tests::v2_header_places_every_field_at_its_offset`, `v2_unavailable_mapping_zeroes_the_mapping_fields`; Gazebo `video::tests::stamp_carries_capture_time_camera_and_mapping`, `adapter::tests::camera_frame_reaches_the_subscriber`; JS `wire.test.mjs` "v2 frame parses to a full capture identity", "v2 frame preserves the exact payload bytes" |
| 2 | Duplicate/reordered frames cannot become fresh or replace newer frames | JS `video-identity.test.mjs` "duplicate sequence is not accepted", "duplicate does not refresh the accepted capture time", "older sequence is not accepted", "reordered frame does not move the accepted sequence" |
| 3 | Epoch reset and wrapping sequence have explicit tested semantics using `wrapping_add(1)` | Rust `video::tests::sequence_wraps_at_the_u32_boundary`, `reset_epoch_bumps_generation_and_restarts_sequences`; JS `video-identity.test.mjs` "sequence wrap (MAX -> 0) is accepted as newer", "wrapping backward is still rejected", "newer epoch is accepted", "older epoch is not accepted" |
| 4 | Video and aircraft snapshots associated with traceable identities and a quantified clock error; mapping targets the snapshot's clock | Capture identity **is** the AV-01 `MeasurementStamp`; Rust `video::tests::map_capture_ns_applies_the_signed_offset`, `map_capture_ns_refuses_to_wrap_at_the_u64_edges`; **JS `video-identity.test.mjs` "target-clock mismatch keeps the gate closed", "mapped-time underflow refuses", "compatible combination is conformal-ready"** |
| 5 | Unavailable / insufficient mapping prevents conformal output (gate fails closed) | Rust `video::tests::mapping_defaults_to_unavailable`, Gazebo `video::tests::unavailable_mapping_is_carried_verbatim` (Aviate path); **JS `video-identity.test.mjs` "calibration id zero keeps the gate closed", "unrecognized calibration keeps the gate closed", "excessive error bound keeps the gate closed", "gate with no candidate snapshot is closed"**, "unavailable mapping is not mapping-valid" |

**Six new gate tests added this revision (review fixes):** `calibration id zero keeps the gate closed`, `unrecognized calibration keeps the gate closed`, `calibration change marks a discontinuity`, `target-clock mismatch keeps the gate closed`, `excessive error bound keeps the gate closed`, `compatible combination is conformal-ready` — plus `mapped-time underflow refuses` for the u64-edge arithmetic (mirrored in Rust by `map_capture_ns_refuses_to_wrap_at_the_u64_edges`).

Other guards: wrong-camera rejection, incarnation discontinuity, per-source independence, malformed-frame rejection at both the parser (`wire.test.mjs` "v2 declared length mismatch is rejected") and the tracker.

### Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets`, `cargo doc` (`-D missing_docs`, `-D rustdoc::broken_intra_doc_links`), and `cargo build --release` are green for every crate in this change and its consumers. `node clients/web/wire.test.mjs` and `node clients/web/video-identity.test.mjs` pass, as do the untouched suites (instruments, telemetry-display, telemetry-ingress, transport-session, scene-conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
