### PR TITLE
NAV-01: typed magnetic/true heading — the rose turns on an independent sample

### DIFF
--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -48,6 +48,7 @@ pub(crate) fn attitude_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -35,8 +35,8 @@ export const EXPECTED_GLYPH_SHA256 =
 const GLYPH_HEADER_LEN = 8;
 const GLYPH_RECORD_LEN = 12;
 const GLYPH_ROWS = 7;
-export const STATE_ABI_VERSION = 3;
-export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 144 });
+export const STATE_ABI_VERSION = 4;
+export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 144, 4: 168 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
 const MAX_WASM_RENDER_STATUS = 10;
 
@@ -411,10 +411,24 @@ export class InstrumentModule {
       f(128, state.altitude?.sampleM ?? NaN);
       f(132, state.selections?.baroSelHpa ?? NaN);
       view.setUint32(136, state.altitude?.originId ?? 0, true);
-      b(140, 0);
-      b(141, 0);
+      // NAV-01 independent heading (abi.rs parity): operational heading
+      // is never derived implicitly from the attitude quaternion. The
+      // fail-safe default is no sample at all — the rose flags HDG
+      // rather than freezing on a fabricated heading.
+      b(140, state.heading?.reference ?? 255);
+      b(141, state.variation?.sourceId ?? 0);
       b(142, 0);
       b(143, 0);
+      f(144, state.heading?.rad ?? NaN);
+      f(148, state.heading ? state.heading.ageMs : NaN);
+      f(152, state.variation?.eastRad ?? NaN);
+      f(156, state.variation ? state.variation.ageMs : NaN);
+      b(
+        160,
+        (state.valid?.heading ?? false ? 1 : 0) |
+          (state.valid?.variation ?? false ? 2 : 0),
+      );
+      for (let off = 161; off < 168; off += 1) b(off, 0);
       return { ok: true };
     } catch {
       return { ok: false, reason: REASON.STATE_WRITE_FAILED };

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -1108,6 +1108,35 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
       Math.abs(view.getFloat32(132, true) - 1020.5) < 1e-3 &&
       view.getUint32(136, true) === 7,
   );
+
+  // NAV-01: no heading declared means NO sample — reference byte 255,
+  // NaN value/age, no validity bit. A fabricated default heading of
+  // zero would be a plausible frozen rose.
+  const bare = mod.writeState({ selections: { headingBugRad: 0 } });
+  check("headingless state write succeeds", bare.ok === true);
+  check(
+    "undeclared heading writes an absent, fail-closed sample",
+    view.getUint8(140) === 255 &&
+      Number.isNaN(view.getFloat32(144, true)) &&
+      Number.isNaN(view.getFloat32(148, true)) &&
+      view.getUint8(160) === 0,
+  );
+  const headed = mod.writeState({
+    selections: { headingBugRad: 0 },
+    heading: { rad: 1.25, reference: 2, ageMs: 12 },
+    variation: { eastRad: 0.03, sourceId: 3, ageMs: 40 },
+    valid: { heading: true, variation: true },
+  });
+  check("declared heading write succeeds", headed.ok === true);
+  check(
+    "declared heading and variation encode exactly (abi.rs parity)",
+    view.getUint8(140) === 2 &&
+      Math.abs(view.getFloat32(144, true) - 1.25) < 1e-6 &&
+      Math.abs(view.getFloat32(148, true) - 12) < 1e-6 &&
+      view.getUint8(141) === 3 &&
+      Math.abs(view.getFloat32(152, true) - 0.03) < 1e-6 &&
+      view.getUint8(160) === 0b11,
+  );
 }
 
 // ---- glyph text painting (REN-02 consumption) ---------------------------------

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -2,7 +2,8 @@
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
 use pilotage_alerts::AlertOutput;
-use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_state::HeadingReference;
 use pilotage_instrument_state::{NavSource, PanelData, SignalStatus};
 
 use crate::palette;
@@ -34,7 +35,7 @@ pub fn draw_hsi(
     scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
     scene.end_layer(LayerId::Background)?;
 
-    let hdg = data.heading_rad;
+    let hdg = data.heading.value_rad;
     scene.begin_layer(LayerId::Attitude)?;
     if hdg.status.shows_value() {
         rose::draw_rose(scene, hdg.value)?;
@@ -70,7 +71,19 @@ pub fn draw_hsi(
     {
         status_paint::draw_flag(scene, CX, CY + 60.0, "NAV")?;
     }
-    if !hdg.status.shows_value() {
+    if hdg.status.shows_value() {
+        scene.fill_color(match data.heading.reference {
+            HeadingReference::SimLocalTrue => palette::AMBER,
+            _ => palette::WHITE,
+        })?;
+        scene.text(
+            CX,
+            CY - 118.0,
+            12.0,
+            Anchor::CENTER,
+            data.heading.reference.label(),
+        )?;
+    } else {
         status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
     }
     if let Some(alerts) = alerts {

--- a/crates/pilotage-instrument-panels/src/hsi/boxes.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/boxes.rs
@@ -22,7 +22,7 @@ pub fn wind_box(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), Sce
         scene.text(58.0, 26.0, 14.0, Anchor::CENTER, "WIND ---")?;
         return Ok(());
     }
-    let hdg = data.heading_rad.value;
+    let hdg = data.heading.value_rad.value;
     // Arrow points where the wind blows toward, in the aircraft's frame.
     scene.save()?;
     scene.translate(28.0, 26.0)?;

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -10,6 +10,9 @@ use pilotage_instrument_state::{
 
 use super::draw_hsi;
 
+/// Heading comes from the explicit SIM-declared independent sample —
+/// the attitude quaternion still describes the same yaw, but nothing
+/// derives heading from it (NAV-01).
 fn heading_only(heading_rad: f32) -> PanelData {
     let state = pilotage_instrument_state::AircraftState {
         attitude: pilotage_instrument_state::Stamped {
@@ -19,12 +22,21 @@ fn heading_only(heading_rad: f32) -> PanelData {
             }),
             age_ms: Some(10.0),
         },
+        heading: pilotage_instrument_state::Stamped {
+            data: Some(pilotage_instrument_state::HeadingSample {
+                heading_rad,
+                reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
+            }),
+            age_ms: Some(10.0),
+        },
         quality: pilotage_instrument_state::EstimateQuality::Good,
         valid: pilotage_instrument_state::ValidFlags {
             attitude: true,
             rates: true,
             position: true,
             velocity: true,
+            heading: true,
+            ..Default::default()
         },
         ..Default::default()
     };
@@ -139,7 +151,7 @@ fn no_nav_source_shows_dashes_and_no_cdi() {
 #[test]
 fn failed_heading_renders_red_x() {
     let mut data = heading_only(0.0);
-    data.heading_rad = Sig::with_status(0.0, SignalStatus::Failed);
+    data.heading.value_rad = Sig::with_status(0.0, SignalStatus::Failed);
     let scene = render(&data);
     let labels = texts(&scene);
     assert!(labels.iter().any(|t| t == "HDG"), "HDG flag: {labels:?}");
@@ -168,7 +180,7 @@ fn scenes_are_layered_for_every_heading_status() {
         SignalStatus::Failed,
     ] {
         let mut data = heading_only(0.0);
-        data.heading_rad = Sig::with_status(0.0, status);
+        data.heading.value_rad = Sig::with_status(0.0, status);
         let scene = render(&data);
         let report = validate_layers(&scene).expect("layered scene validates");
         for layer in [
@@ -207,4 +219,39 @@ fn degraded_navigation_cue_is_an_annunciation() {
         !layer_texts(&scene, LayerId::Guidance).contains(&expected),
         "NAV cue must not share the guidance band"
     );
+}
+
+// ---- NAV-01: reference labelling and no fabricated rose -----------------
+
+#[test]
+fn sim_declared_heading_is_labelled_sim() {
+    let labels = texts(&render(&heading_only(0.0)));
+    assert!(labels.iter().any(|t| t == "SIM"), "{labels:?}");
+}
+
+#[test]
+fn magnetic_heading_is_labelled_mag() {
+    let mut data = heading_only(0.0);
+    data.heading.reference = pilotage_instrument_state::HeadingReference::Magnetic;
+    let labels = texts(&render(&data));
+    assert!(labels.iter().any(|t| t == "MAG"), "{labels:?}");
+}
+
+#[test]
+fn missing_heading_leaves_no_plausible_rose() {
+    let mut data = heading_only(0.0);
+    data.heading.value_rad =
+        Sig::with_status(0.0, pilotage_instrument_state::SignalStatus::Missing);
+    let labels = texts(&render(&data));
+    assert!(
+        labels.iter().any(|t| t == "HDG"),
+        "missing heading must flag, not freeze: {labels:?}"
+    );
+    for cardinal in ["N", "E", "S", "W"] {
+        assert!(
+            !labels.iter().any(|t| t == cardinal),
+            "{cardinal} must not paint on a dead rose: {labels:?}"
+        );
+    }
+    assert!(!labels.iter().any(|t| t == "SIM"), "{labels:?}");
 }

--- a/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
@@ -43,6 +43,7 @@ fn oriented(roll_deg: f32, pitch_deg: f32) -> PanelData {
         rates: true,
         position: true,
         velocity: true,
+        ..Default::default()
     };
     state.kinematics = flying_state_kinematics();
     state.air = flying_state_air();
@@ -244,6 +245,7 @@ fn ned_adapter_output_is_byte_identical_to_the_direct_path() {
         rates: true,
         position: true,
         velocity: true,
+        ..Default::default()
     };
     via_adapter_state.kinematics = flying_state_kinematics();
     via_adapter_state.air = flying_state_air();

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -41,6 +41,7 @@ pub(crate) fn flying() -> PanelData {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     };

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -17,9 +17,12 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // supported CI architectures; a mismatch is a determinism regression, not a
 // value to re-pin casually. The PFD hash covers the datum-qualified
 // altitude tape: the fixture's local-relative reference paints the amber
-// REL label and the not-applied SET setting box (ALT-01).
+// REL label and the not-applied SET setting box (ALT-01). The HSI hash
+// covers the reference-typed heading: the rose turns with the fixture's
+// explicit SIM-declared independent sample — never quaternion yaw — and
+// paints the amber SIM reference label (NAV-01).
 const PFD_SHA256: &str = "3148b8e9d5c3d9cc5c1ac812c3f5674615649c65d4966ad3f1a85d1ce1f1d952";
-const HSI_SHA256: &str = "6edcbc92d936a690a68f0632d2ec20b158d54e59cc9fde6640feefa077b258e3";
+const HSI_SHA256: &str = "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c";
 
 /// A fixed, richly populated state so every panel band paints content.
 ///
@@ -85,9 +88,19 @@ pub(super) fn demo_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            heading: true,
+            ..Default::default()
         },
         snapshot: SnapshotMeta::default(),
         altitude: pilotage_instrument_state::AltitudeDeclaration::default(),
+        heading: Stamped {
+            data: Some(pilotage_instrument_state::HeadingSample {
+                heading_rad: 0.6,
+                reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
+            }),
+            age_ms: Some(80.0),
+        },
+        variation: Stamped::default(),
     }
 }
 

--- a/crates/pilotage-instrument-state/src/abi.rs
+++ b/crates/pilotage-instrument-state/src/abi.rs
@@ -11,7 +11,7 @@
 //!
 //! | off | type | field |
 //! |----:|------|-------|
-//! | 0   | u32  | version (=3) |
+//! | 0   | u32  | version (=4) |
 //! | 4   | f32×4| attitude quaternion w, x, y, z |
 //! | 20  | f32×3| body rates p, q, r (rad/s) |
 //! | 32  | f32×3| position NED n, e, d (m) |
@@ -39,20 +39,29 @@
 //! | 128 | f32  | altitude sample (m, NaN absent; classes 1-4) |
 //! | 132 | f32  | pilot-selected baro setting (hPa, NaN absent) |
 //! | 136 | u32  | local-origin identity |
-//! | 140 | u8×4 | reserved, zero |
+//! | 140 | u8   | heading reference (0 magnetic, 1 true, 2 sim-local-true; other = unknown, fails) |
+//! | 141 | u8   | variation source id (0 = undeclared; conversion refuses) |
+//! | 142 | u8×2 | reserved, zero |
+//! | 144 | f32  | heading (rad from the declared north, NaN absent) |
+//! | 148 | f32  | heading age ms (NaN never) |
+//! | 152 | f32  | magnetic variation (rad, east positive, NaN absent) |
+//! | 156 | f32  | variation age ms (NaN never) |
+//! | 160 | u8   | valid flags 2 (bit0 heading, bit1 variation) |
+//! | 161 | u8×7 | reserved, zero |
 
 use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
 use pilotage_frames::Quat;
 
 /// Version stamped in the block's first four bytes.
-pub const STATE_ABI_VERSION: u32 = 3;
+pub const STATE_ABI_VERSION: u32 = 4;
 
 /// Size of the packed block in bytes.
-pub const STATE_ABI_SIZE: usize = 144;
+pub const STATE_ABI_SIZE: usize = 168;
 
 /// Why a state block failed to decode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,13 +191,7 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         2 => EstimateQuality::Unusable,
         _ => EstimateQuality::Unknown,
     };
-    let flags = u8_at(buf, 85)?;
-    let valid = ValidFlags {
-        attitude: flags & 0b0001 != 0,
-        rates: flags & 0b0010 != 0,
-        position: flags & 0b0100 != 0,
-        velocity: flags & 0b1000 != 0,
-    };
+    let valid = decode_valid_flags(buf)?;
     let coherence = match u8_at(buf, 124)? {
         0 => SnapshotCoherence::Insufficient,
         1 => SnapshotCoherence::Coherent,
@@ -210,6 +213,49 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
             coherence,
         },
         altitude: decode_altitude(buf)?,
+        heading: decode_heading(buf)?,
+        variation: decode_variation(buf)?,
+    })
+}
+
+fn decode_heading(buf: &[u8]) -> Result<Stamped<HeadingSample>, AbiError> {
+    let age = opt(f32_at(buf, 148)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 144)?)) {
+            (Some(_), Some(heading_rad)) => Some(HeadingSample {
+                heading_rad,
+                reference: HeadingReference::from_u8(u8_at(buf, 140)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+fn decode_variation(buf: &[u8]) -> Result<Stamped<MagneticVariation>, AbiError> {
+    let age = opt(f32_at(buf, 156)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 152)?)) {
+            (Some(_), Some(east_positive_rad)) => Some(MagneticVariation {
+                east_positive_rad,
+                source: VariationSourceId(u8_at(buf, 141)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+fn decode_valid_flags(buf: &[u8]) -> Result<ValidFlags, AbiError> {
+    let flags = u8_at(buf, 85)?;
+    let flags2 = u8_at(buf, 160)?;
+    Ok(ValidFlags {
+        attitude: flags & 0b0001 != 0,
+        rates: flags & 0b0010 != 0,
+        position: flags & 0b0100 != 0,
+        velocity: flags & 0b1000 != 0,
+        heading: flags2 & 0b0001 != 0,
+        variation: flags2 & 0b0010 != 0,
     })
 }
 
@@ -299,16 +345,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
     put_f32(buf, 76, or_nan(state.nav.age_ms))?;
     put_f32(buf, 80, or_nan(state.wind.age_ms))?;
 
-    put_u8(
-        buf,
-        84,
-        match state.quality {
-            EstimateQuality::Good => 0,
-            EstimateQuality::Degraded => 1,
-            EstimateQuality::Unusable => 2,
-            EstimateQuality::Unknown => 255,
-        },
-    )?;
+    encode_quality(state, buf)?;
     let flags = u8::from(state.valid.attitude)
         | (u8::from(state.valid.rates) << 1)
         | (u8::from(state.valid.position) << 2)
@@ -362,7 +399,48 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
             SnapshotCoherence::Unknown => 255,
         },
     )?;
-    encode_altitude(state, buf)
+    encode_altitude(state, buf)?;
+    encode_heading(state, buf)
+}
+
+fn encode_heading(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
+    let heading = state.heading.data;
+    put_u8(
+        buf,
+        140,
+        heading.map_or(255, |sample| sample.reference.to_u8()),
+    )?;
+    let variation = state.variation.data;
+    put_u8(buf, 141, variation.map_or(0, |sample| sample.source.0))?;
+    put_u8(buf, 142, 0)?;
+    put_u8(buf, 143, 0)?;
+    put_f32(buf, 144, or_nan(heading.map(|sample| sample.heading_rad)))?;
+    put_f32(buf, 148, or_nan(state.heading.age_ms))?;
+    put_f32(
+        buf,
+        152,
+        or_nan(variation.map(|sample| sample.east_positive_rad)),
+    )?;
+    put_f32(buf, 156, or_nan(state.variation.age_ms))?;
+    let flags2 = u8::from(state.valid.heading) | (u8::from(state.valid.variation) << 1);
+    put_u8(buf, 160, flags2)?;
+    for offset in 161..168 {
+        put_u8(buf, offset, 0)?;
+    }
+    Ok(())
+}
+
+fn encode_quality(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
+    put_u8(
+        buf,
+        84,
+        match state.quality {
+            EstimateQuality::Good => 0,
+            EstimateQuality::Degraded => 1,
+            EstimateQuality::Unusable => 2,
+            EstimateQuality::Unknown => 255,
+        },
+    )
 }
 
 fn encode_altitude(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
@@ -372,9 +450,6 @@ fn encode_altitude(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError
     put_f32(buf, 128, or_nan(state.altitude.sample_m))?;
     put_f32(buf, 132, or_nan(state.selections.baro_sel_hpa))?;
     put_u32(buf, 136, state.altitude.origin.0)?;
-    for offset in 140..144 {
-        put_u8(buf, offset, 0)?;
-    }
     Ok(())
 }
 

--- a/crates/pilotage-instrument-state/src/abi/tests.rs
+++ b/crates/pilotage-instrument-state/src/abi/tests.rs
@@ -6,7 +6,28 @@ use crate::aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
 use pilotage_frames::Quat;
+
+fn full_heading() -> Stamped<HeadingSample> {
+    Stamped {
+        data: Some(HeadingSample {
+            heading_rad: 1.25,
+            reference: HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(9.0),
+    }
+}
+
+fn full_variation() -> Stamped<MagneticVariation> {
+    Stamped {
+        data: Some(MagneticVariation {
+            east_positive_rad: 0.04,
+            source: VariationSourceId(3),
+        }),
+        age_ms: Some(30.0),
+    }
+}
 
 fn full_state() -> AircraftState {
     AircraftState {
@@ -66,6 +87,8 @@ fn full_state() -> AircraftState {
             rates: false,
             position: true,
             velocity: true,
+            heading: true,
+            variation: true,
         },
         snapshot: SnapshotMeta {
             generation: u32::MAX,
@@ -77,6 +100,8 @@ fn full_state() -> AircraftState {
             geoid_model: GeoidModelId(1),
             origin: OriginId(42),
         },
+        heading: full_heading(),
+        variation: full_variation(),
     }
 }
 
@@ -155,6 +180,29 @@ fn unknown_altitude_reference_bytes_decode_fail_closed() {
     let state = decode_state(&block).expect("decodes");
     assert_eq!(state.altitude.reference_class, AltitudeClass::Unknown);
     assert_eq!(state.selections.altitude_sel_class, AltitudeClass::Unknown);
+}
+
+#[test]
+fn unknown_heading_reference_byte_decodes_fail_closed() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    encode_state(&full_state(), &mut block).expect("encodes");
+    block[140] = 9;
+    let state = decode_state(&block).expect("decodes");
+    assert_eq!(
+        state.heading.data.expect("heading present").reference,
+        HeadingReference::Unknown
+    );
+}
+
+#[test]
+fn heading_and_variation_round_trip_exactly() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    let state = full_state();
+    encode_state(&state, &mut block).expect("encodes");
+    let decoded = decode_state(&block).expect("decodes");
+    assert_eq!(decoded.heading, state.heading);
+    assert_eq!(decoded.variation, state.variation);
+    assert!(decoded.valid.heading && decoded.valid.variation);
 }
 
 #[test]

--- a/crates/pilotage-instrument-state/src/aircraft.rs
+++ b/crates/pilotage-instrument-state/src/aircraft.rs
@@ -1,6 +1,7 @@
 //! The raw input state a feeder writes.
 
 use crate::altitude::{AltitudeClass, AltitudeDeclaration};
+use crate::heading::{HeadingSample, MagneticVariation};
 use pilotage_frames::Quat;
 
 /// Attitude estimate: orientation and body rotation rates.
@@ -143,6 +144,10 @@ pub struct ValidFlags {
     pub position: bool,
     /// NED velocity is valid.
     pub velocity: bool,
+    /// The heading sample is declared valid.
+    pub heading: bool,
+    /// The variation sample is declared valid.
+    pub variation: bool,
 }
 
 /// One estimate group with the age a feeder stamped it with.
@@ -210,6 +215,12 @@ pub struct AircraftState {
     pub snapshot: SnapshotMeta,
     /// Datum declaration for the primary altitude (ALT-01).
     pub altitude: AltitudeDeclaration,
+    /// Independent heading sample with an explicit reference (NAV-01).
+    /// Operational heading never derives implicitly from attitude yaw.
+    pub heading: Stamped<HeadingSample>,
+    /// Magnetic-variation sample for the single sanctioned
+    /// magnetic/true conversion path.
+    pub variation: Stamped<MagneticVariation>,
 }
 
 impl Default for Selections {

--- a/crates/pilotage-instrument-state/src/heading.rs
+++ b/crates/pilotage-instrument-state/src/heading.rs
@@ -1,0 +1,170 @@
+//! Typed heading references and the single sanctioned conversion path.
+//!
+//! Operational heading is an independent sample with an explicit
+//! magnetic/true reference — never implicit quaternion yaw, which is
+//! local-NED orientation, ill-conditioned near vertical pitch, and
+//! carries no reference. Magnetic/true conversion happens in exactly
+//! one place, [`convert_heading`], and only with a valid magnetic
+//! variation sample whose sign convention (east positive), source, and
+//! freshness are explicit. Nothing here ever fabricates or substitutes
+//! a reference.
+
+use core::f32::consts::{PI, TAU};
+
+/// The north reference a horizontal angle is measured from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeadingReference {
+    /// Magnetic north.
+    Magnetic,
+    /// True north.
+    True,
+    /// The simulator's local-NED north, explicitly declared by the
+    /// feeder. Numerically a true-north convention for the local scene;
+    /// labelled SIM so it can never pass for a navigation-grade source.
+    SimLocalTrue,
+    /// The wire carried a reference this build does not know; heading
+    /// fails rather than guessing.
+    Unknown,
+}
+
+impl HeadingReference {
+    /// Fail-closed wire decoding.
+    #[must_use]
+    pub const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Magnetic,
+            1 => Self::True,
+            2 => Self::SimLocalTrue,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Wire encoding; `Unknown` round-trips as unknown.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        match self {
+            Self::Magnetic => 0,
+            Self::True => 1,
+            Self::SimLocalTrue => 2,
+            Self::Unknown => 255,
+        }
+    }
+
+    /// The HSI label identifying this reference.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Magnetic => "MAG",
+            Self::True => "TRU",
+            Self::SimLocalTrue => "SIM",
+            Self::Unknown => "REF",
+        }
+    }
+
+    /// Whether both references measure from (a) true north, so values
+    /// carry across without a variation sample.
+    #[must_use]
+    const fn true_north(self) -> bool {
+        matches!(self, Self::True | Self::SimLocalTrue)
+    }
+}
+
+/// An independent heading sample with its declared reference.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HeadingSample {
+    /// Heading in radians clockwise from the declared north.
+    pub heading_rad: f32,
+    /// Which north the heading is measured from.
+    pub reference: HeadingReference,
+}
+
+/// Identity of the magnetic-variation source. Zero is "undeclared": an
+/// unattributed variation must not silently rotate the compass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VariationSourceId(pub u8);
+
+impl VariationSourceId {
+    /// No source declared.
+    pub const UNDECLARED: Self = Self(0);
+}
+
+/// A magnetic-variation sample. Sign convention: east variation is
+/// positive, so `true = magnetic + variation`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MagneticVariation {
+    /// Variation in radians, east positive.
+    pub east_positive_rad: f32,
+    /// Which model/source produced it.
+    pub source: VariationSourceId,
+}
+
+/// Why a reference conversion is not available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionFault {
+    /// Either side's reference is unknown.
+    UnknownReference,
+    /// Magnetic/true conversion was required but no usable variation
+    /// sample exists (absent, stale, undeclared source, or non-finite).
+    VariationUnavailable,
+}
+
+/// Normalizes an angle to `[0, 2π)`.
+#[must_use]
+pub fn wrap_2pi(angle_rad: f32) -> f32 {
+    let wrapped = angle_rad % TAU;
+    if wrapped < 0.0 {
+        wrapped + TAU
+    } else {
+        wrapped
+    }
+}
+
+/// The signed minimal rotation from `from_rad` to `to_rad`, in
+/// `(-π, π]`; correct across the 359°/1° wrap in both directions.
+#[must_use]
+pub fn shortest_angle_rad(from_rad: f32, to_rad: f32) -> f32 {
+    let delta = wrap_2pi(to_rad - from_rad);
+    if delta > PI { delta - TAU } else { delta }
+}
+
+/// Converts a horizontal angle between references. This is the single
+/// sanctioned conversion path: same-true-north pairs carry across
+/// unchanged, magnetic/true crossings require a usable variation sample
+/// (east positive: `true = magnetic + variation`), and an unknown
+/// reference on either side refuses. The result is wrapped to
+/// `[0, 2π)`.
+pub fn convert_heading(
+    value_rad: f32,
+    from: HeadingReference,
+    to: HeadingReference,
+    variation: Option<&MagneticVariation>,
+) -> Result<f32, ConversionFault> {
+    if from == HeadingReference::Unknown || to == HeadingReference::Unknown {
+        return Err(ConversionFault::UnknownReference);
+    }
+    if from == to || (from.true_north() && to.true_north()) {
+        return Ok(wrap_2pi(value_rad));
+    }
+    let variation = usable_variation(variation)?;
+    let converted = if from == HeadingReference::Magnetic {
+        value_rad + variation
+    } else {
+        value_rad - variation
+    };
+    Ok(wrap_2pi(converted))
+}
+
+fn usable_variation(variation: Option<&MagneticVariation>) -> Result<f32, ConversionFault> {
+    match variation {
+        Some(sample)
+            if sample.east_positive_rad.is_finite()
+                && sample.source != VariationSourceId::UNDECLARED =>
+        {
+            Ok(sample.east_positive_rad)
+        }
+        _ => Err(ConversionFault::VariationUnavailable),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-state/src/heading/tests.rs
+++ b/crates/pilotage-instrument-state/src/heading/tests.rs
@@ -1,0 +1,137 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::f32::consts::PI;
+
+use super::{
+    ConversionFault, HeadingReference, MagneticVariation, VariationSourceId, convert_heading,
+    shortest_angle_rad, wrap_2pi,
+};
+
+const DEG: f32 = PI / 180.0;
+
+fn var(east_deg: f32) -> MagneticVariation {
+    MagneticVariation {
+        east_positive_rad: east_deg * DEG,
+        source: VariationSourceId(1),
+    }
+}
+
+#[test]
+fn wrap_covers_the_359_to_1_degree_boundary_both_ways() {
+    let delta = shortest_angle_rad(359.0 * DEG, 1.0 * DEG);
+    assert!((delta - 2.0 * DEG).abs() < 1e-6, "359→1 is +2°, not −358°");
+    let delta = shortest_angle_rad(1.0 * DEG, 359.0 * DEG);
+    assert!((delta + 2.0 * DEG).abs() < 1e-6, "1→359 is −2°");
+    assert!((wrap_2pi(-DEG) - 359.0 * DEG).abs() < 1e-5);
+}
+
+#[test]
+fn variation_converts_across_north_in_both_signs() {
+    // Magnetic 359° with 2°E variation is true 1°.
+    let true_rad = convert_heading(
+        359.0 * DEG,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        Some(&var(2.0)),
+    )
+    .expect("converts");
+    assert!((true_rad - 1.0 * DEG).abs() < 1e-5);
+
+    // Magnetic 1° with 2°W variation is true 359°.
+    let true_rad = convert_heading(
+        1.0 * DEG,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        Some(&var(-2.0)),
+    )
+    .expect("converts");
+    assert!((true_rad - 359.0 * DEG).abs() < 1e-5);
+
+    // The inverse subtracts: true 1° with 2°E variation is magnetic 359°.
+    let mag_rad = convert_heading(
+        1.0 * DEG,
+        HeadingReference::True,
+        HeadingReference::Magnetic,
+        Some(&var(2.0)),
+    )
+    .expect("converts");
+    assert!((mag_rad - 359.0 * DEG).abs() < 1e-5);
+}
+
+#[test]
+fn true_north_pair_needs_no_variation_and_magnetic_crossing_requires_it() {
+    let same = convert_heading(
+        0.5,
+        HeadingReference::SimLocalTrue,
+        HeadingReference::True,
+        None,
+    );
+    assert!((same.expect("true-north pair") - 0.5).abs() < 1e-6);
+
+    let refused = convert_heading(
+        0.5,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        None,
+    );
+    assert_eq!(refused, Err(ConversionFault::VariationUnavailable));
+}
+
+#[test]
+fn stale_or_unattributed_variation_never_rotates_the_compass() {
+    let undeclared = MagneticVariation {
+        east_positive_rad: 0.1,
+        source: VariationSourceId::UNDECLARED,
+    };
+    assert_eq!(
+        convert_heading(
+            0.5,
+            HeadingReference::Magnetic,
+            HeadingReference::True,
+            Some(&undeclared),
+        ),
+        Err(ConversionFault::VariationUnavailable)
+    );
+    let non_finite = MagneticVariation {
+        east_positive_rad: f32::NAN,
+        source: VariationSourceId(1),
+    };
+    assert_eq!(
+        convert_heading(
+            0.5,
+            HeadingReference::Magnetic,
+            HeadingReference::True,
+            Some(&non_finite),
+        ),
+        Err(ConversionFault::VariationUnavailable)
+    );
+}
+
+#[test]
+fn unknown_reference_refuses_conversion_and_round_trips_on_the_wire() {
+    assert_eq!(
+        convert_heading(0.5, HeadingReference::Unknown, HeadingReference::True, None),
+        Err(ConversionFault::UnknownReference)
+    );
+    for reference in [
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        HeadingReference::SimLocalTrue,
+    ] {
+        assert_eq!(HeadingReference::from_u8(reference.to_u8()), reference);
+    }
+    for unknown in [3u8, 9, 254, 255] {
+        assert_eq!(
+            HeadingReference::from_u8(unknown),
+            HeadingReference::Unknown
+        );
+    }
+}
+
+#[test]
+fn labels_identify_every_reference() {
+    assert_eq!(HeadingReference::Magnetic.label(), "MAG");
+    assert_eq!(HeadingReference::True.label(), "TRU");
+    assert_eq!(HeadingReference::SimLocalTrue.label(), "SIM");
+    assert_eq!(HeadingReference::Unknown.label(), "REF");
+}

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod abi;
 mod aircraft;
 mod altitude;
+mod heading;
 mod presentation;
 mod resolve;
 mod signal;
@@ -37,13 +38,18 @@ pub use aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 pub use altitude::{AltitudeClass, AltitudeDeclaration, AltitudeReference, GeoidModelId, OriginId};
+pub use heading::{
+    ConversionFault, HeadingReference, HeadingSample, MagneticVariation, VariationSourceId,
+    convert_heading, shortest_angle_rad, wrap_2pi,
+};
 pub use pilotage_frames::Quat;
 pub use presentation::{
     AirframeDisplayProfile, AttitudePresentation, ChevronSense, Hysteresis, ProfileError,
     ProfileLimits, UnusualAttitudeState, down_in_body,
 };
 pub use resolve::{
-    BARO_SETTING_TOLERANCE_HPA, NavResolved, PanelData, ResolvedAltitude, resolve, resolve_stateful,
+    BARO_SETTING_TOLERANCE_HPA, NavResolved, PanelData, ResolvedAltitude, ResolvedHeading, resolve,
+    resolve_stateful,
 };
 pub use signal::{FreshnessPolicy, PolicyError, Sig, SignalStatus};
 pub use validate::{

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -54,8 +54,8 @@ pub struct PanelData {
     pub roll_rad: Sig<f32>,
     /// Pitch angle, radians, positive nose-up.
     pub pitch_rad: Sig<f32>,
-    /// Heading, radians clockwise from north.
-    pub heading_rad: Sig<f32>,
+    /// Independent, reference-typed heading.
+    pub heading: ResolvedHeading,
     /// Body yaw rate, radians/second (turn-rate proxy).
     pub turn_rate_rps: Sig<f32>,
     /// Indicated airspeed, knots.
@@ -127,7 +127,7 @@ fn coherence_status(coherence: SnapshotCoherence) -> SignalStatus {
 /// A signal that would show a non-finite value fails instead: no
 /// non-finite number may reach scene generation, and no value is
 /// silently repaired.
-fn finite(sig: Sig<f32>) -> Sig<f32> {
+pub(crate) fn finite(sig: Sig<f32>) -> Sig<f32> {
     if sig.status.shows_value() && !sig.value.is_finite() {
         Sig::with_status(0.0, SignalStatus::Failed)
     } else {
@@ -183,7 +183,7 @@ pub fn resolve_stateful(
         coherence: coherence_status(state.snapshot.coherence),
     };
 
-    let (presentation, yaw, turn_rate) = attitude_geometry(state, profile, unusual);
+    let (presentation, turn_rate) = attitude_geometry(state, profile, unusual);
     let has_att = state.attitude.data.is_some();
     let att_fresh = group_freshness(policy, has_att, state.attitude.age_ms);
     let att_status = trust.fold(has_att, att_fresh, integrity.attitude, state.valid.attitude);
@@ -201,19 +201,30 @@ pub fn resolve_stateful(
     };
 
     let (ias, baro) = air_signals(state, policy, trust.quality, &integrity);
+    let heading = heading_resolved(state, policy, &trust, &integrity);
+    let track = presented_true(
+        Sig::with_status(track_rad, track_status),
+        heading.reference,
+        state,
+    );
+    let wind = presented_wind(
+        wind_signal(state, policy, &integrity),
+        heading.reference,
+        state,
+    );
 
     PanelData {
         roll_rad: finite(Sig::with_status(presentation.bank_rad, att_status)),
         pitch_rad: finite(Sig::with_status(presentation.pitch_rad, att_status)),
-        heading_rad: finite(Sig::with_status(yaw, att_status)),
+        heading,
         turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
         ias_kt: finite(ias),
         gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
         altitude: altitude_resolved(state, policy, &trust, &integrity, pos_status, rel_alt_ft),
         vsi_fpm: finite(Sig::with_status(vsi_fpm, vel_status)),
-        track_rad: finite(Sig::with_status(track_rad, track_status)),
+        track_rad: finite(track),
         baro_hpa: finite(baro),
-        wind: wind_signal(state, policy, &integrity),
+        wind,
         nav: nav_resolved(state, policy, &integrity),
         selections: sanitized_selections(state.selections),
         integrity,
@@ -223,9 +234,9 @@ pub fn resolve_stateful(
 
 /// Source-level trust shared by every estimate group this frame.
 #[derive(Clone, Copy)]
-struct Trust {
-    quality: SignalStatus,
-    coherence: SignalStatus,
+pub(crate) struct Trust {
+    pub(crate) quality: SignalStatus,
+    pub(crate) coherence: SignalStatus,
 }
 
 impl Trust {
@@ -234,7 +245,7 @@ impl Trust {
     /// not a red X — because nothing was received to distrust. A group
     /// *with* data still folds even when its freshness reads Missing
     /// (a bogus age), so declared distrust cannot be masked.
-    fn fold(
+    pub(crate) fn fold(
         &self,
         has_data: bool,
         freshness: SignalStatus,
@@ -252,7 +263,11 @@ impl Trust {
     }
 }
 
-fn group_freshness(policy: &FreshnessPolicy, has_data: bool, age_ms: Option<f32>) -> SignalStatus {
+pub(crate) fn group_freshness(
+    policy: &FreshnessPolicy,
+    has_data: bool,
+    age_ms: Option<f32>,
+) -> SignalStatus {
     if has_data {
         policy.status_for_age(age_ms)
     } else {
@@ -267,22 +282,21 @@ fn attitude_geometry(
     state: &AircraftState,
     profile: &AirframeDisplayProfile,
     unusual: &mut UnusualAttitudeState,
-) -> (AttitudePresentation, f32, f32) {
+) -> (AttitudePresentation, f32) {
     match state.attitude.data {
         Some(att) => match validate_quat(att.quat) {
             Ok(quat) => {
                 let presentation = unusual.step(quat, profile);
-                let (_, _, yaw) = quat.to_euler();
-                (presentation, yaw, att.rates_rps[2])
+                (presentation, att.rates_rps[2])
             }
             Err(_) => {
                 unusual.reset();
-                (AttitudePresentation::default(), 0.0, att.rates_rps[2])
+                (AttitudePresentation::default(), att.rates_rps[2])
             }
         },
         None => {
             unusual.reset();
-            (AttitudePresentation::default(), 0.0, 0.0)
+            (AttitudePresentation::default(), 0.0)
         }
     }
 }
@@ -421,5 +435,11 @@ fn wind_signal(
     }
 }
 
+mod heading_signal;
+pub use heading_signal::ResolvedHeading;
+use heading_signal::{heading_resolved, presented_true, presented_wind};
+
+#[cfg(test)]
+mod heading_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
@@ -1,0 +1,119 @@
+//! Presentation of the independent heading sample and of true-north
+//! quantities in the display reference (NAV-01).
+
+use crate::aircraft::AircraftState;
+use crate::heading::{HeadingReference, convert_heading, wrap_2pi};
+use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
+use crate::validate::StateIntegrity;
+
+use super::{Trust, Wind, finite, group_freshness};
+
+/// Heading resolved from the independent sample (NAV-01): the value,
+/// its declared reference, and nothing else — attitude yaw never feeds
+/// this. A missing sample resolves `Missing` and the compass rose fails
+/// visibly instead of freezing on a fabricated heading.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedHeading {
+    /// Heading in radians clockwise from the declared north; quiet zero
+    /// behind a hidden status.
+    pub value_rad: Sig<f32>,
+    /// The reference every HSI angular quantity is presented in.
+    pub reference: HeadingReference,
+}
+
+/// Resolves the independent heading sample. Its status folds the same
+/// trust chain as every estimate group; the reference passes through
+/// typed. An unknown reference fails; absence is `Missing` — the rose
+/// fails visibly, never a frozen plausible heading, and attitude yaw is
+/// not consulted at any pitch.
+pub(super) fn heading_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    trust: &Trust,
+    integrity: &StateIntegrity,
+) -> ResolvedHeading {
+    let has = state.heading.data.is_some();
+    let fresh = group_freshness(policy, has, state.heading.age_ms);
+    let status = trust.fold(has, fresh, integrity.heading, state.valid.heading);
+    let sample = state.heading.data.unwrap_or(crate::heading::HeadingSample {
+        heading_rad: 0.0,
+        reference: HeadingReference::Unknown,
+    });
+    let reference = if has {
+        sample.reference
+    } else {
+        HeadingReference::Unknown
+    };
+    ResolvedHeading {
+        value_rad: finite(Sig::with_status(wrap_2pi(sample.heading_rad), status)),
+        reference,
+    }
+}
+
+/// A usable variation sample, or `None` when absent, stale, faulted, or
+/// undeclared — the caller then degrades instead of converting.
+fn usable_variation(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+) -> Option<crate::heading::MagneticVariation> {
+    let fresh = policy.status_for_age(state.variation.age_ms);
+    match (state.variation.data, state.valid.variation) {
+        (Some(sample), true) if fresh.shows_value() => Some(sample),
+        _ => None,
+    }
+}
+
+/// Presents a NED-derived (true-north) angle in the display reference.
+/// A magnetic display without a usable variation degrades the quantity
+/// to `Failed` rather than mixing references on one rose.
+pub(super) fn presented_true(
+    sig: Sig<f32>,
+    display: HeadingReference,
+    state: &AircraftState,
+) -> Sig<f32> {
+    if !sig.status.shows_value() || display == HeadingReference::Unknown {
+        return sig;
+    }
+    let variation = usable_variation(state, &FreshnessPolicy::default());
+    match convert_heading(
+        sig.value,
+        HeadingReference::True,
+        display,
+        variation.as_ref(),
+    ) {
+        Ok(value) => Sig::with_status(value, sig.status),
+        Err(_) => Sig::with_status(0.0, SignalStatus::Failed),
+    }
+}
+
+pub(super) fn presented_wind(
+    wind: Sig<Wind>,
+    display: HeadingReference,
+    state: &AircraftState,
+) -> Sig<Wind> {
+    if !wind.status.shows_value() || display == HeadingReference::Unknown {
+        return wind;
+    }
+    let converted = presented_true(
+        Sig::with_status(wind.value.from_rad, wind.status),
+        display,
+        state,
+    );
+    if converted.status.shows_value() {
+        Sig::with_status(
+            Wind {
+                from_rad: converted.value,
+                speed_mps: wind.value.speed_mps,
+            },
+            wind.status,
+        )
+    } else {
+        Sig::with_status(
+            Wind {
+                from_rad: 0.0,
+                speed_mps: 0.0,
+            },
+            SignalStatus::Failed,
+        )
+    }
+}

--- a/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
@@ -1,0 +1,144 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! NAV-01 resolution proofs: heading is the independent sample, never
+//! quaternion yaw; every HSI angle presents in one reference or
+//! visibly degrades; conversion happens only through a usable
+//! variation sample.
+
+use core::f32::consts::PI;
+
+use super::resolve;
+use super::tests::flying_state;
+use crate::aircraft::{AircraftState, Stamped};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
+use crate::signal::{FreshnessPolicy, SignalStatus};
+use pilotage_frames::Quat;
+
+const DEG: f32 = PI / 180.0;
+
+fn with_heading(reference: HeadingReference, heading_rad: f32) -> AircraftState {
+    let mut state = flying_state();
+    state.heading = Stamped {
+        data: Some(HeadingSample {
+            heading_rad,
+            reference,
+        }),
+        age_ms: Some(20.0),
+    };
+    state.valid.heading = true;
+    state
+}
+
+fn with_variation(mut state: AircraftState, east_deg: f32) -> AircraftState {
+    state.variation = Stamped {
+        data: Some(MagneticVariation {
+            east_positive_rad: east_deg * DEG,
+            source: VariationSourceId(1),
+        }),
+        age_ms: Some(50.0),
+    };
+    state.valid.variation = true;
+    state
+}
+
+#[test]
+fn missing_heading_resolves_missing_even_with_a_valid_attitude() {
+    let p = resolve(&flying_state(), &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Missing);
+    assert_eq!(p.heading.reference, HeadingReference::Unknown);
+    assert_eq!(
+        p.heading.value_rad.value, 0.0,
+        "no plausible frozen heading may remain"
+    );
+}
+
+#[test]
+fn heading_is_independent_of_attitude_through_the_vertical() {
+    for pitch_deg in [89.0f32, 90.0, 91.0, 180.0] {
+        let mut state = with_heading(HeadingReference::SimLocalTrue, 1.0);
+        let half = pitch_deg * DEG / 2.0;
+        // Pure pitch rotation: ill-conditioned yaw at/beyond vertical.
+        state.attitude.data = state.attitude.data.map(|mut att| {
+            att.quat = Quat {
+                w: libm::cosf(half),
+                x: 0.0,
+                y: libm::sinf(half),
+                z: 0.0,
+            };
+            att
+        });
+        let p = resolve(&state, &FreshnessPolicy::default());
+        assert_eq!(p.heading.value_rad.status, SignalStatus::Valid);
+        assert!(
+            (p.heading.value_rad.value - 1.0).abs() < 1e-6,
+            "independent heading must not bend at pitch {pitch_deg}"
+        );
+    }
+}
+
+#[test]
+fn unknown_reference_fails_the_heading() {
+    let state = with_heading(HeadingReference::from_u8(9), 1.0);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Failed);
+    assert_eq!(p.heading.reference, HeadingReference::Unknown);
+}
+
+#[test]
+fn undeclared_validity_fails_the_heading() {
+    let mut state = with_heading(HeadingReference::True, 1.0);
+    state.valid.heading = false;
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn heading_value_wraps_into_one_turn() {
+    let state = with_heading(HeadingReference::SimLocalTrue, 370.0 * DEG);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert!((p.heading.value_rad.value - 10.0 * DEG).abs() < 1e-4);
+}
+
+#[test]
+fn magnetic_display_without_variation_degrades_true_quantities() {
+    // Track and wind are NED-derived (true); a magnetic rose must not
+    // mix them in unconverted.
+    let state = with_heading(HeadingReference::Magnetic, 1.0);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn magnetic_display_with_variation_converts_the_track() {
+    let mut state = with_variation(with_heading(HeadingReference::Magnetic, 1.0), 2.0);
+    // Velocity due north: true track 0° reads magnetic 358° under 2°E.
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [20.0, 0.0, 0.0];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Valid);
+    assert!(
+        (p.track_rad.value - 358.0 * DEG).abs() < 1e-4,
+        "got {}",
+        p.track_rad.value
+    );
+}
+
+#[test]
+fn stale_variation_refuses_conversion() {
+    let mut state = with_variation(with_heading(HeadingReference::Magnetic, 1.0), 2.0);
+    state.variation.age_ms = Some(1.0e9);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn sim_true_display_presents_true_quantities_unchanged() {
+    let mut state = with_heading(HeadingReference::SimLocalTrue, 1.0);
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [0.0, 20.0, 0.0];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Valid);
+    assert!((p.track_rad.value - 90.0 * DEG).abs() < 1e-4);
+}

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -5,7 +5,7 @@ use crate::aircraft::{AirData, AircraftState, Attitude, EstimateQuality, Kinemat
 use crate::signal::{FreshnessPolicy, SignalStatus};
 use pilotage_frames::Quat;
 
-fn flying_state() -> AircraftState {
+pub(crate) fn flying_state() -> AircraftState {
     AircraftState {
         attitude: Stamped {
             data: Some(Attitude {
@@ -34,6 +34,7 @@ fn flying_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }
@@ -251,7 +252,7 @@ fn every_showable_output_is_finite_under_hostile_input() {
         for (name, sig) in [
             ("roll", p.roll_rad),
             ("pitch", p.pitch_rad),
-            ("heading", p.heading_rad),
+            ("heading", p.heading.value_rad),
             ("turn", p.turn_rate_rps),
             ("ias", p.ias_kt),
             ("gs", p.gs_kt),

--- a/crates/pilotage-instrument-state/src/validate.rs
+++ b/crates/pilotage-instrument-state/src/validate.rs
@@ -65,6 +65,10 @@ pub struct StateIntegrity {
     /// Datum-qualified altitude fault: unknown reference class, missing
     /// required source, undeclared model, or non-finite sample.
     pub altitude: Option<GroupFault>,
+    /// Heading-sample fault: non-finite value or unknown reference.
+    pub heading: Option<GroupFault>,
+    /// Magnetic-variation fault: non-finite value or undeclared source.
+    pub variation: Option<GroupFault>,
 }
 
 fn all_finite(values: &[f32]) -> bool {
@@ -156,6 +160,20 @@ pub fn validate_state(state: &AircraftState) -> StateIntegrity {
         integrity.coherence = Some(GroupFault::UnknownEnum);
     }
     integrity.altitude = altitude_fault(state);
+    if let Some(heading) = &state.heading.data {
+        if heading.reference == crate::heading::HeadingReference::Unknown {
+            integrity.heading = Some(GroupFault::UnknownEnum);
+        } else if !heading.heading_rad.is_finite() {
+            integrity.heading = Some(GroupFault::NonFinite);
+        }
+    }
+    if let Some(variation) = &state.variation.data {
+        if !variation.east_positive_rad.is_finite() {
+            integrity.variation = Some(GroupFault::NonFinite);
+        } else if variation.source == crate::heading::VariationSourceId::UNDECLARED {
+            integrity.variation = Some(GroupFault::SourceAbsent);
+        }
+    }
     integrity
 }
 

--- a/crates/pilotage-instrument-state/src/validate/tests.rs
+++ b/crates/pilotage-instrument-state/src/validate/tests.rs
@@ -57,6 +57,7 @@ fn trusted_full_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -3,8 +3,8 @@
 ./crates/pilotage-instrument-scene/src/decode.rs	decode_payload	94
 ./crates/pilotage-instrument-glyphs/src/sha256.rs	sha256	90
 ./crates/pilotage-conformance/src/fixture.rs	increment_zero_script	89
-./crates/pilotage-instrument-state/src/abi.rs	decode_state	132
-./crates/pilotage-instrument-state/src/abi.rs	encode_state	105
+./crates/pilotage-instrument-state/src/abi.rs	decode_state	128
+./crates/pilotage-instrument-state/src/abi.rs	encode_state	97
 ./crates/pilotage-authority/src/wire.rs	from	88
 ./adapters/aviate/src/adapter/tests.rs	stick_frame_reaches_the_fc_as_a_velocity_setpoint	93
 ./adapters/aviate/src/uplink.rs	send_stick_frame	90


### PR DESCRIPTION
Implements #21. **Stacked on #61 (ALT-01)** — both revise the state ABI; merge #61 first. **SIM / NOT FOR FLIGHT.**

## Design

- **Quaternion yaw is out of the heading path entirely.** `attitude_geometry` no longer produces yaw; `PanelData.heading_rad` is gone. Heading is `ResolvedHeading { value_rad, reference }` from an independent `HeadingSample` group with its own age and declared-valid bit (acceptance: "PanelData exposes no unreferenced heading", "Quaternion yaw is not the implicit operational heading").
- **References are typed** (`HeadingReference`): Magnetic, True, and `SimLocalTrue` — the sanctioned, *explicitly declared* admission of simulator local-NED yaw, labelled amber `SIM` on the rose so it can never pass for a navigation-grade source. Unknown wire bytes fail closed.
- **One conversion path** (`convert_heading` in the new `heading` module): magnetic/true crossings require a usable `MagneticVariation` sample — east-positive sign convention fixed in the type, source identity mandatory (`VariationSourceId::UNDECLARED` refuses), freshness enforced at the call site. Stale, undeclared, or non-finite variation never rotates the compass. Wrap arithmetic (`wrap_2pi`, `shortest_angle_rad`) is centralized beside it.
- **One reference per rose**: NED-derived true quantities (track, wind) present in the heading sample's reference. On a magnetic rose without usable variation they *fail visibly* rather than mixing references (`magnetic_display_without_variation_degrades_true_quantities`); with variation they convert exactly (`358°` for a true-north track under 2°E).
- **No fabricated rose**: a missing sample resolves `Missing` → HDG red-X, and the cardinal letters do not paint (`missing_heading_leaves_no_plausible_rose`). At pitch 89°/90°/91° and inverted, the independent sample passes through bit-unchanged (`heading_is_independent_of_attitude_through_the_vertical`).
- **State ABI v4 (168 bytes)**: heading value/age/reference and variation value/age/source appended with a second valid-flags byte; the JS writer's fail-safe default writes *no* sample (reference 255, NaN value) — a default heading of zero would be exactly the plausible frozen rose the issue bans.

## Acceptance criteria → evidence

| Criterion (#21) | Evidence |
|---|---|
| PanelData exposes no unreferenced heading | `ResolvedHeading` is the only heading; field `heading_rad` removed repo-wide |
| HSI quantities share one resolved reference or visibly fail | `presented_true`/`presented_wind` + degrade tests; SIM/MAG/TRU label on the rose |
| Quaternion yaw not the implicit operational heading | yaw dropped from `attitude_geometry`; `missing_heading_resolves_missing_even_with_a_valid_attitude` |
| True/magnetic conversion centralized | `convert_heading` is the single path; callers cannot add/subtract variation themselves |
| 359/0 wrap correct | `wrap_covers_the_359_to_1_degree_boundary_both_ways`, conversions across north both signs |
| Missing heading cannot leave a plausible frozen rose | `missing_heading_leaves_no_plausible_rose` (no cardinals, HDG flag) |
| Independent heading at 89/90/91 and inverted | `heading_is_independent_of_attitude_through_the_vertical` |
| Unknown-reference fail-closed ABI | `unknown_heading_reference_byte_decodes_fail_closed`, `unknown_reference_fails_the_heading` |

## Feeder follow-up (deliberate)

The live browser feeder (`main.js`) does not yet declare the explicit SIM heading — that file is owned by the in-flight HUD-01 lane this wave, and editing it now would tangle the lanes. Until the one-line declaration lands as a follow-up commit, the live HSI honestly flags HDG (fail-safe, not a regression of information: the previous rose was an unlabelled implicit-yaw fabrication). The wasm/state/HSI path is fully proven by the fixture and runtime tests.

## Verification

Lane-scoped gates green: fmt, clippy `-D warnings`, tests (9 new resolution tests, 6 heading-math tests, 3 HSI rendering tests, ABI round-trip/fail-closed), doc, no_std, structure gate (resolve split into `heading_signal` submodule; decode/encode baselines ratcheted down again 132→128 / 105→97). HSI frame hash re-pinned with rationale (rose now driven by the explicit SIM sample); PFD hash byte-identical. JS parity + all touched node suites green; wasm rebuilt.

Refs #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)