### PR TITLE
NAV-01: every HSI angle reference-typed and rose-coherent (supersedes #63)

### DIFF
--- a/clients/web-instruments/src/tests.rs
+++ b/clients/web-instruments/src/tests.rs
@@ -48,6 +48,7 @@ pub(crate) fn attitude_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -35,8 +35,8 @@ export const EXPECTED_GLYPH_SHA256 =
 const GLYPH_HEADER_LEN = 8;
 const GLYPH_RECORD_LEN = 12;
 const GLYPH_ROWS = 7;
-export const STATE_ABI_VERSION = 3;
-export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 152 });
+export const STATE_ABI_VERSION = 4;
+export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 152, 4: 176 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
 const MAX_WASM_RENDER_STATUS = 10;
 
@@ -423,6 +423,26 @@ export class InstrumentModule {
       b(149, 0);
       b(150, 0);
       b(151, 0);
+      // NAV-01 typed angles (abi.rs parity): operational heading is an
+      // independent declared sample — the fail-safe default is NO
+      // sample and Unknown references, so nothing renders on a north
+      // nobody declared.
+      b(152, state.heading?.reference ?? 255);
+      b(153, state.variation?.sourceId ?? 0);
+      b(154, state.selections?.headingBugReference ?? 255);
+      b(155, state.nav?.courseReference ?? 255);
+      f(156, state.heading?.rad ?? NaN);
+      f(160, state.heading ? state.heading.ageMs : NaN);
+      f(164, state.variation?.eastRad ?? NaN);
+      f(168, state.variation ? state.variation.ageMs : NaN);
+      b(
+        172,
+        (state.valid?.heading ?? false ? 1 : 0) |
+          (state.valid?.variation ?? false ? 2 : 0),
+      );
+      b(173, 0);
+      b(174, 0);
+      b(175, 0);
       return { ok: true };
     } catch {
       return { ok: false, reason: REASON.STATE_WRITE_FAILED };

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -1118,6 +1118,37 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
     "selection datum identity encodes exactly (abi.rs parity)",
     view.getUint8(140) === 4 && view.getUint32(144, true) === 9,
   );
+
+  // NAV-01: undeclared heading/bug/course write Unknown references and
+  // no sample — a zero-default heading would be a plausible frozen rose.
+  const bare2 = mod.writeState({ selections: { headingBugRad: 0 } });
+  check("headingless state write succeeds", bare2.ok === true);
+  check(
+    "undeclared heading and angle references fail closed on the wire",
+    view.getUint8(152) === 255 &&
+      view.getUint8(154) === 255 &&
+      view.getUint8(155) === 255 &&
+      Number.isNaN(view.getFloat32(156, true)) &&
+      view.getUint8(172) === 0,
+  );
+  const headed = mod.writeState({
+    selections: { headingBugRad: 0.5, headingBugReference: 2 },
+    heading: { rad: 1.25, reference: 2, ageMs: 12 },
+    variation: { eastRad: 0.03, sourceId: 3, ageMs: 40 },
+    nav: { source: 1, courseRad: 0.3, courseReference: 2 },
+    valid: { heading: true, variation: true },
+  });
+  check("declared heading write succeeds", headed.ok === true);
+  check(
+    "declared heading, bug, course, and variation encode exactly",
+    view.getUint8(152) === 2 &&
+      view.getUint8(153) === 3 &&
+      view.getUint8(154) === 2 &&
+      view.getUint8(155) === 2 &&
+      Math.abs(view.getFloat32(156, true) - 1.25) < 1e-6 &&
+      Math.abs(view.getFloat32(164, true) - 0.03) < 1e-6 &&
+      view.getUint8(172) === 0b11,
+  );
 }
 
 // ---- glyph text painting (REN-02 consumption) ---------------------------------

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -913,6 +913,16 @@ async function startControlLoop(transport, token) {
 
 // ---- instrument panels (ADR-0017) -------------------------------------------
 
+/** The explicit SIM heading declaration: local-NED yaw from the
+ * published attitude quaternion, declared sim-local-true. Returns null
+ * when no attitude estimate exists — no sample, never a zero heading. */
+function declaredSimHeading(attitude) {
+  const q = attitude?.quat;
+  if (!q || ![q.w, q.x, q.y, q.z].every(Number.isFinite)) return null;
+  const yaw = Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z));
+  return { rad: yaw, reference: 2, ageMs: attitude.ageMs };
+}
+
 /** Maps the latest wire avionics estimate into the instrument state ABI
  * and draws both panels; runs on the display's own rAF cadence. Every
  * render result is honored: a validated frame is blitted, anything else
@@ -938,19 +948,28 @@ function renderInstruments() {
     coherent: 1,
     "excessive-skew": 2,
   }[snapshot.coherence.status];
+  // NAV-01: the feeder — not the display — declares the simulator's
+  // heading explicitly. Local-NED yaw is computed HERE from the same
+  // estimate the vehicle published and declared as sim-local-true
+  // (reference 2); the display never derives heading from attitude on
+  // its own, so removing this declaration flags HDG instead of
+  // freezing a fabricated rose.
+  const heading = declaredSimHeading(attitude);
   const panelState = {
     attitude,
     kinematics,
     air: null, // no airspeed/baro sensor on Aviate's wire yet (ADR-0018): honest Missing.
     nav: null,
     wind: null,
-    selections: { headingBugRad: 0 },
+    selections: { headingBugRad: 0, headingBugReference: 2 },
+    heading,
     quality: snapshot.quality,
     valid: {
       attitude: !!(validFlags & 1),
       rates: !!(validFlags & 2),
       position: !!(validFlags & 4),
       velocity: !!(validFlags & 8),
+      heading: heading !== null && !!(validFlags & 1),
     },
     snapshot: { generation: snapshot.generation, coherence },
   };

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -2,7 +2,8 @@
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
 use pilotage_alerts::AlertOutput;
-use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_state::HeadingReference;
 use pilotage_instrument_state::{NavSource, PanelData, SignalStatus};
 
 use crate::palette;
@@ -34,11 +35,13 @@ pub fn draw_hsi(
     scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
     scene.end_layer(LayerId::Background)?;
 
-    let hdg = data.heading_rad;
+    let hdg = data.heading.value_rad;
     scene.begin_layer(LayerId::Attitude)?;
     if hdg.status.shows_value() {
         rose::draw_rose(scene, hdg.value)?;
-        rose::draw_heading_bug(scene, hdg.value, data.selections.heading_bug_rad)?;
+        if data.heading_bug_rose_rad.status.shows_value() {
+            rose::draw_heading_bug(scene, hdg.value, data.heading_bug_rose_rad.value)?;
+        }
         if data.track_rad.status.shows_value() {
             rose::draw_track_diamond(scene, hdg.value, data.track_rad.value)?;
         }
@@ -57,6 +60,7 @@ pub fn draw_hsi(
     if hdg.status.shows_value()
         && data.nav.data.source != NavSource::None
         && data.nav.status.shows_value()
+        && data.nav.course_rose_rad.status.shows_value()
     {
         cdi::draw_cdi(scene, &data.nav, hdg.value)?;
     }
@@ -70,7 +74,19 @@ pub fn draw_hsi(
     {
         status_paint::draw_flag(scene, CX, CY + 60.0, "NAV")?;
     }
-    if !hdg.status.shows_value() {
+    if hdg.status.shows_value() {
+        scene.fill_color(match data.heading.reference {
+            HeadingReference::SimLocalTrue => palette::AMBER,
+            _ => palette::WHITE,
+        })?;
+        scene.text(
+            CX,
+            CY - 118.0,
+            12.0,
+            Anchor::CENTER,
+            data.heading.reference.label(),
+        )?;
+    } else {
         status_paint::draw_red_x(scene, CX - 140.0, CY - 140.0, 280.0, 280.0, "HDG")?;
     }
     if let Some(alerts) = alerts {

--- a/crates/pilotage-instrument-panels/src/hsi/boxes.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/boxes.rs
@@ -22,7 +22,7 @@ pub fn wind_box(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), Sce
         scene.text(58.0, 26.0, 14.0, Anchor::CENTER, "WIND ---")?;
         return Ok(());
     }
-    let hdg = data.heading_rad.value;
+    let hdg = data.heading.value_rad.value;
     // Arrow points where the wind blows toward, in the aircraft's frame.
     scene.save()?;
     scene.translate(28.0, 26.0)?;
@@ -70,12 +70,18 @@ pub fn course_box(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), S
     scene.rect(PaintMode::FillStroke, 2.0, 322.0, 112.0, 36.0)?;
     scene.fill_color(palette::WHITE)?;
     scene.text(30.0, 340.0, 15.0, Anchor::CENTER, "CRS")?;
-    if data.nav.data.source == NavSource::None || !data.nav.status.shows_value() {
+    if data.nav.data.source == NavSource::None
+        || !data.nav.status.shows_value()
+        || !data.nav.course_rose_rad.status.shows_value()
+    {
+        // A course whose reference is unknown or cannot convert into
+        // the rose reference is suppressed here exactly like an absent
+        // source — dashes, never a number on the wrong north.
         scene.fill_color(palette::GREY)?;
         scene.text(78.0, 340.0, 18.0, Anchor::CENTER, "---°")?;
         return Ok(());
     }
-    let deg = libm::roundf(wrap_deg_360(data.nav.data.course_rad * RAD_TO_DEG)) as i32;
+    let deg = libm::roundf(wrap_deg_360(data.nav.course_rose_rad.value * RAD_TO_DEG)) as i32;
     let shown = if deg == 0 { 360 } else { deg };
     let text = fmt_label!(8, "{shown:03}°");
     scene.fill_color(source_color(data.nav.data.source))?;
@@ -88,7 +94,12 @@ pub fn heading_sel_box(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<
     scene.fill_color(palette::BOX_BG)?;
     scene.stroke(palette::GREY, 1.5)?;
     scene.rect(PaintMode::FillStroke, 366.0, 322.0, 112.0, 36.0)?;
-    let deg = libm::roundf(wrap_deg_360(data.selections.heading_bug_rad * RAD_TO_DEG)) as i32;
+    if !data.heading_bug_rose_rad.status.shows_value() {
+        scene.fill_color(palette::AMBER)?;
+        scene.text(422.0, 340.0, 15.0, Anchor::CENTER, "HDG REF")?;
+        return Ok(());
+    }
+    let deg = libm::roundf(wrap_deg_360(data.heading_bug_rose_rad.value * RAD_TO_DEG)) as i32;
     let shown = if deg == 0 { 360 } else { deg };
     let text = fmt_label!(8, "{shown:03}°");
     scene.fill_color(palette::CYAN)?;

--- a/crates/pilotage-instrument-panels/src/hsi/cdi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/cdi.rs
@@ -25,7 +25,7 @@ pub fn draw_cdi(
     let color = source_color(nav.data.source);
     scene.save()?;
     scene.translate(super::CX, super::CY)?;
-    scene.rotate(nav.data.course_rad - heading_rad)?;
+    scene.rotate(nav.course_rose_rad.value - heading_rad)?;
 
     // Course arrow: head, fore shaft, aft shaft.
     scene.fill_color(color)?;

--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -10,6 +10,9 @@ use pilotage_instrument_state::{
 
 use super::draw_hsi;
 
+/// Heading comes from the explicit SIM-declared independent sample —
+/// the attitude quaternion still describes the same yaw, but nothing
+/// derives heading from it (NAV-01).
 fn heading_only(heading_rad: f32) -> PanelData {
     let state = pilotage_instrument_state::AircraftState {
         attitude: pilotage_instrument_state::Stamped {
@@ -19,12 +22,21 @@ fn heading_only(heading_rad: f32) -> PanelData {
             }),
             age_ms: Some(10.0),
         },
+        heading: pilotage_instrument_state::Stamped {
+            data: Some(pilotage_instrument_state::HeadingSample {
+                heading_rad,
+                reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
+            }),
+            age_ms: Some(10.0),
+        },
         quality: pilotage_instrument_state::EstimateQuality::Good,
         valid: pilotage_instrument_state::ValidFlags {
             attitude: true,
             rates: true,
             position: true,
             velocity: true,
+            heading: true,
+            ..Default::default()
         },
         ..Default::default()
     };
@@ -115,8 +127,10 @@ fn gps_course_draws_cdi_and_course_box() {
             fromto: NavFromTo::To,
             vdev_dots: Some(0.4),
             dist_nm: Some(40.3),
+            course_reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
         },
         status: SignalStatus::Valid,
+        course_rose_rad: Sig::with_status(0.35, SignalStatus::Valid),
     };
     let scene = render(&data);
     let labels = texts(&scene);
@@ -139,7 +153,7 @@ fn no_nav_source_shows_dashes_and_no_cdi() {
 #[test]
 fn failed_heading_renders_red_x() {
     let mut data = heading_only(0.0);
-    data.heading_rad = Sig::with_status(0.0, SignalStatus::Failed);
+    data.heading.value_rad = Sig::with_status(0.0, SignalStatus::Failed);
     let scene = render(&data);
     let labels = texts(&scene);
     assert!(labels.iter().any(|t| t == "HDG"), "HDG flag: {labels:?}");
@@ -168,7 +182,7 @@ fn scenes_are_layered_for_every_heading_status() {
         SignalStatus::Failed,
     ] {
         let mut data = heading_only(0.0);
-        data.heading_rad = Sig::with_status(0.0, status);
+        data.heading.value_rad = Sig::with_status(0.0, status);
         let scene = render(&data);
         let report = validate_layers(&scene).expect("layered scene validates");
         for layer in [
@@ -194,8 +208,10 @@ fn degraded_navigation_cue_is_an_annunciation() {
             fromto: NavFromTo::To,
             vdev_dots: Some(0.4),
             dist_nm: Some(40.3),
+            course_reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
         },
         status: SignalStatus::Degraded,
+        course_rose_rad: Sig::with_status(0.35, SignalStatus::Degraded),
     };
     let scene = render(&data);
     let expected = (String::from("NAV"), [240.0, 250.0, 11.0]);
@@ -206,5 +222,83 @@ fn degraded_navigation_cue_is_an_annunciation() {
     assert!(
         !layer_texts(&scene, LayerId::Guidance).contains(&expected),
         "NAV cue must not share the guidance band"
+    );
+}
+
+// ---- NAV-01: reference labelling, no fabricated rose, typed angles ------
+
+#[test]
+fn sim_declared_heading_is_labelled_sim() {
+    let labels = texts(&render(&heading_only(0.0)));
+    assert!(labels.iter().any(|t| t == "SIM"), "{labels:?}");
+}
+
+#[test]
+fn magnetic_heading_is_labelled_mag() {
+    let mut data = heading_only(0.0);
+    data.heading.reference = pilotage_instrument_state::HeadingReference::Magnetic;
+    let labels = texts(&render(&data));
+    assert!(labels.iter().any(|t| t == "MAG"), "{labels:?}");
+}
+
+#[test]
+fn missing_heading_leaves_no_plausible_rose() {
+    let mut data = heading_only(0.0);
+    data.heading.value_rad =
+        Sig::with_status(0.0, pilotage_instrument_state::SignalStatus::Missing);
+    let labels = texts(&render(&data));
+    assert!(
+        labels.iter().any(|t| t == "HDG"),
+        "missing heading must flag, not freeze: {labels:?}"
+    );
+    for cardinal in ["N", "E", "S", "W"] {
+        assert!(
+            !labels.iter().any(|t| t == cardinal),
+            "{cardinal} must not paint on a dead rose: {labels:?}"
+        );
+    }
+}
+
+#[test]
+fn incompatible_bug_is_suppressed_with_its_flag() {
+    let mut data = heading_only(0.0);
+    data.selections.heading_bug_rad = 1.0;
+    data.heading_bug_rose_rad =
+        Sig::with_status(0.0, pilotage_instrument_state::SignalStatus::Failed);
+    let labels = texts(&render(&data));
+    assert!(
+        labels.iter().any(|t| t == "HDG REF"),
+        "suppressed bug must say why: {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|t| t == "057°"),
+        "raw bug number must not render: {labels:?}"
+    );
+}
+
+#[test]
+fn incompatible_course_shows_dashes_and_no_cdi() {
+    let mut data = heading_only(0.0);
+    data.nav = NavResolved {
+        data: NavData {
+            source: NavSource::Gps,
+            course_rad: 0.35,
+            cdi_dots: -1.2,
+            fromto: NavFromTo::To,
+            vdev_dots: Some(0.4),
+            dist_nm: Some(40.3),
+            course_reference: pilotage_instrument_state::HeadingReference::True,
+        },
+        status: SignalStatus::Valid,
+        course_rose_rad: Sig::with_status(0.0, SignalStatus::Failed),
+    };
+    let labels = texts(&render(&data));
+    assert!(
+        labels.iter().any(|t| t == "---°"),
+        "course box dashes: {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|t| t == "020°"),
+        "raw course must not render: {labels:?}"
     );
 }

--- a/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
@@ -43,6 +43,7 @@ fn oriented(roll_deg: f32, pitch_deg: f32) -> PanelData {
         rates: true,
         position: true,
         velocity: true,
+        ..Default::default()
     };
     state.kinematics = flying_state_kinematics();
     state.air = flying_state_air();
@@ -244,6 +245,7 @@ fn ned_adapter_output_is_byte_identical_to_the_direct_path() {
         rates: true,
         position: true,
         velocity: true,
+        ..Default::default()
     };
     via_adapter_state.kinematics = flying_state_kinematics();
     via_adapter_state.air = flying_state_air();

--- a/crates/pilotage-instrument-panels/src/pfd/tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tests.rs
@@ -41,6 +41,7 @@ pub(crate) fn flying() -> PanelData {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     };

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -17,9 +17,12 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // supported CI architectures; a mismatch is a determinism regression, not a
 // value to re-pin casually. The PFD hash covers the datum-qualified
 // altitude tape: the fixture's local-relative reference paints the amber
-// REL label and the not-applied SET setting box (ALT-01).
+// REL label and the not-applied SET setting box (ALT-01). The HSI hash
+// covers the reference-typed heading: the rose turns with the fixture's
+// explicit SIM-declared independent sample — never quaternion yaw — and
+// paints the amber SIM reference label (NAV-01).
 const PFD_SHA256: &str = "3148b8e9d5c3d9cc5c1ac812c3f5674615649c65d4966ad3f1a85d1ce1f1d952";
-const HSI_SHA256: &str = "6edcbc92d936a690a68f0632d2ec20b158d54e59cc9fde6640feefa077b258e3";
+const HSI_SHA256: &str = "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c";
 
 /// A fixed, richly populated state so every panel band paints content.
 ///
@@ -64,6 +67,7 @@ pub(super) fn demo_state() -> AircraftState {
                 fromto: NavFromTo::To,
                 vdev_dots: Some(-0.4),
                 dist_nm: Some(12.4),
+                course_reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
             }),
             age_ms: Some(80.0),
         },
@@ -76,6 +80,7 @@ pub(super) fn demo_state() -> AircraftState {
         },
         selections: Selections {
             heading_bug_rad: 0.5,
+            heading_bug_reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
             altitude_sel_m: Some(915.0),
             ..Selections::default()
         },
@@ -85,9 +90,19 @@ pub(super) fn demo_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            heading: true,
+            ..ValidFlags::default()
         },
         snapshot: SnapshotMeta::default(),
         altitude: pilotage_instrument_state::AltitudeDeclaration::default(),
+        heading: Stamped {
+            data: Some(pilotage_instrument_state::HeadingSample {
+                heading_rad: 0.6,
+                reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
+            }),
+            age_ms: Some(80.0),
+        },
+        variation: Stamped::default(),
     }
 }
 

--- a/crates/pilotage-instrument-state/src/abi.rs
+++ b/crates/pilotage-instrument-state/src/abi.rs
@@ -11,7 +11,7 @@
 //!
 //! | off | type | field |
 //! |----:|------|-------|
-//! | 0   | u32  | version (=3) |
+//! | 0   | u32  | version (=4) |
 //! | 4   | f32×4| attitude quaternion w, x, y, z |
 //! | 20  | f32×3| body rates p, q, r (rad/s) |
 //! | 32  | f32×3| position NED n, e, d (m) |
@@ -43,19 +43,30 @@
 //! | 141 | u8×3 | reserved, zero |
 //! | 144 | u32  | selected-altitude origin identity |
 //! | 148 | u8×4 | reserved, zero |
+//! | 152 | u8   | heading reference (0 magnetic, 1 true, 2 sim-local-true; other = unknown, fails) |
+//! | 153 | u8   | variation source id (0 = undeclared; conversion refuses) |
+//! | 154 | u8   | heading-bug reference (same coding; unknown suppresses the bug) |
+//! | 155 | u8   | course reference (same coding; unknown suppresses CDI/course) |
+//! | 156 | f32  | heading (rad from the declared north, NaN absent) |
+//! | 160 | f32  | heading age ms (NaN never) |
+//! | 164 | f32  | magnetic variation (rad, east positive, NaN absent) |
+//! | 168 | f32  | variation age ms (NaN never) |
+//! | 172 | u8   | valid flags 2 (bit0 heading, bit1 variation) |
+//! | 173 | u8×3 | reserved, zero |
 
 use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
 use pilotage_frames::Quat;
 
 /// Version stamped in the block's first four bytes.
-pub const STATE_ABI_VERSION: u32 = 3;
+pub const STATE_ABI_VERSION: u32 = 4;
 
 /// Size of the packed block in bytes.
-pub const STATE_ABI_SIZE: usize = 152;
+pub const STATE_ABI_SIZE: usize = 176;
 
 /// Why a state block failed to decode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,6 +173,7 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
                 fromto,
                 vdev_dots: opt(f32_at(buf, 96)?),
                 dist_nm: opt(f32_at(buf, 100)?),
+                course_reference: HeadingReference::from_u8(u8_at(buf, 155)?),
             }),
             None => None,
         },
@@ -185,13 +197,7 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         2 => EstimateQuality::Unusable,
         _ => EstimateQuality::Unknown,
     };
-    let flags = u8_at(buf, 85)?;
-    let valid = ValidFlags {
-        attitude: flags & 0b0001 != 0,
-        rates: flags & 0b0010 != 0,
-        position: flags & 0b0100 != 0,
-        velocity: flags & 0b1000 != 0,
-    };
+    let valid = decode_valid_flags(buf)?;
     let coherence = match u8_at(buf, 124)? {
         0 => SnapshotCoherence::Insufficient,
         1 => SnapshotCoherence::Coherent,
@@ -213,12 +219,56 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
             coherence,
         },
         altitude: decode_altitude(buf)?,
+        heading: decode_heading(buf)?,
+        variation: decode_variation(buf)?,
+    })
+}
+
+fn decode_heading(buf: &[u8]) -> Result<Stamped<HeadingSample>, AbiError> {
+    let age = opt(f32_at(buf, 160)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 156)?)) {
+            (Some(_), Some(heading_rad)) => Some(HeadingSample {
+                heading_rad,
+                reference: HeadingReference::from_u8(u8_at(buf, 152)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+fn decode_variation(buf: &[u8]) -> Result<Stamped<MagneticVariation>, AbiError> {
+    let age = opt(f32_at(buf, 168)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 164)?)) {
+            (Some(_), Some(east_positive_rad)) => Some(MagneticVariation {
+                east_positive_rad,
+                source: VariationSourceId(u8_at(buf, 153)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+fn decode_valid_flags(buf: &[u8]) -> Result<ValidFlags, AbiError> {
+    let flags = u8_at(buf, 85)?;
+    let flags2 = u8_at(buf, 172)?;
+    Ok(ValidFlags {
+        attitude: flags & 0b0001 != 0,
+        rates: flags & 0b0010 != 0,
+        position: flags & 0b0100 != 0,
+        velocity: flags & 0b1000 != 0,
+        heading: flags2 & 0b0001 != 0,
+        variation: flags2 & 0b0010 != 0,
     })
 }
 
 fn decode_selections(buf: &[u8]) -> Result<Selections, AbiError> {
     Ok(Selections {
         heading_bug_rad: f32_at(buf, 104)?,
+        heading_bug_reference: HeadingReference::from_u8(u8_at(buf, 154)?),
         altitude_sel_m: opt(f32_at(buf, 108)?),
         altitude_sel_class: AltitudeClass::from_u8(u8_at(buf, 126)?),
         altitude_sel_origin: OriginId(u32_at(buf, 144)?),
@@ -304,16 +354,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
     put_f32(buf, 76, or_nan(state.nav.age_ms))?;
     put_f32(buf, 80, or_nan(state.wind.age_ms))?;
 
-    put_u8(
-        buf,
-        84,
-        match state.quality {
-            EstimateQuality::Good => 0,
-            EstimateQuality::Degraded => 1,
-            EstimateQuality::Unusable => 2,
-            EstimateQuality::Unknown => 255,
-        },
-    )?;
+    encode_quality(state, buf)?;
     let flags = u8::from(state.valid.attitude)
         | (u8::from(state.valid.rates) << 1)
         | (u8::from(state.valid.position) << 2)
@@ -346,6 +387,7 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
     put_f32(buf, 92, nav.cdi_dots)?;
     put_f32(buf, 96, or_nan(nav.vdev_dots))?;
     put_f32(buf, 100, or_nan(nav.dist_nm))?;
+    put_u8(buf, 155, nav.course_reference.to_u8())?;
 
     put_f32(buf, 104, state.selections.heading_bug_rad)?;
     put_f32(buf, 108, or_nan(state.selections.altitude_sel_m))?;
@@ -370,6 +412,19 @@ pub fn encode_state(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiErro
     encode_altitude(state, buf)
 }
 
+fn encode_quality(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
+    put_u8(
+        buf,
+        84,
+        match state.quality {
+            EstimateQuality::Good => 0,
+            EstimateQuality::Degraded => 1,
+            EstimateQuality::Unusable => 2,
+            EstimateQuality::Unknown => 255,
+        },
+    )
+}
+
 fn encode_altitude(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
     put_u8(buf, 125, state.altitude.reference_class.to_u8())?;
     put_u8(buf, 126, state.selections.altitude_sel_class.to_u8())?;
@@ -383,6 +438,32 @@ fn encode_altitude(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError
     put_u8(buf, 143, 0)?;
     put_u32(buf, 144, state.selections.altitude_sel_origin.0)?;
     for offset in 148..152 {
+        put_u8(buf, offset, 0)?;
+    }
+    encode_heading(state, buf)
+}
+
+fn encode_heading(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
+    let heading = state.heading.data;
+    put_u8(
+        buf,
+        152,
+        heading.map_or(255, |sample| sample.reference.to_u8()),
+    )?;
+    let variation = state.variation.data;
+    put_u8(buf, 153, variation.map_or(0, |sample| sample.source.0))?;
+    put_u8(buf, 154, state.selections.heading_bug_reference.to_u8())?;
+    put_f32(buf, 156, or_nan(heading.map(|sample| sample.heading_rad)))?;
+    put_f32(buf, 160, or_nan(state.heading.age_ms))?;
+    put_f32(
+        buf,
+        164,
+        or_nan(variation.map(|sample| sample.east_positive_rad)),
+    )?;
+    put_f32(buf, 168, or_nan(state.variation.age_ms))?;
+    let flags2 = u8::from(state.valid.heading) | (u8::from(state.valid.variation) << 1);
+    put_u8(buf, 172, flags2)?;
+    for offset in 173..176 {
         put_u8(buf, offset, 0)?;
     }
     Ok(())

--- a/crates/pilotage-instrument-state/src/abi/tests.rs
+++ b/crates/pilotage-instrument-state/src/abi/tests.rs
@@ -6,7 +6,28 @@ use crate::aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
 use pilotage_frames::Quat;
+
+fn full_heading() -> Stamped<HeadingSample> {
+    Stamped {
+        data: Some(HeadingSample {
+            heading_rad: 1.25,
+            reference: HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(9.0),
+    }
+}
+
+fn full_variation() -> Stamped<MagneticVariation> {
+    Stamped {
+        data: Some(MagneticVariation {
+            east_positive_rad: 0.04,
+            source: VariationSourceId(3),
+        }),
+        age_ms: Some(30.0),
+    }
+}
 
 fn full_state() -> AircraftState {
     AircraftState {
@@ -44,6 +65,7 @@ fn full_state() -> AircraftState {
                 fromto: NavFromTo::To,
                 vdev_dots: Some(0.4),
                 dist_nm: Some(40.3),
+                course_reference: HeadingReference::SimLocalTrue,
             }),
             age_ms: Some(9.0),
         },
@@ -56,6 +78,7 @@ fn full_state() -> AircraftState {
         },
         selections: Selections {
             heading_bug_rad: 0.16,
+            heading_bug_reference: HeadingReference::SimLocalTrue,
             altitude_sel_m: Some(3048.0),
             altitude_sel_class: AltitudeClass::LocalRelative,
             altitude_sel_origin: OriginId(42),
@@ -68,6 +91,8 @@ fn full_state() -> AircraftState {
             rates: false,
             position: true,
             velocity: true,
+            heading: true,
+            variation: true,
         },
         snapshot: SnapshotMeta {
             generation: u32::MAX,
@@ -79,6 +104,8 @@ fn full_state() -> AircraftState {
             geoid_model: GeoidModelId(1),
             origin: OriginId(42),
         },
+        heading: full_heading(),
+        variation: full_variation(),
     }
 }
 
@@ -172,6 +199,43 @@ fn selection_identity_round_trips_exactly() {
     assert_eq!(
         decoded.selections.altitude_sel_model,
         state.selections.altitude_sel_model
+    );
+}
+
+#[test]
+fn unknown_heading_and_angle_reference_bytes_decode_fail_closed() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    encode_state(&full_state(), &mut block).expect("encodes");
+    block[152] = 9; // heading reference
+    block[154] = 9; // bug reference
+    block[155] = 9; // course reference
+    let state = decode_state(&block).expect("decodes");
+    assert_eq!(
+        state.heading.data.expect("heading present").reference,
+        HeadingReference::Unknown
+    );
+    assert_eq!(
+        state.selections.heading_bug_reference,
+        HeadingReference::Unknown
+    );
+    assert_eq!(
+        state.nav.data.expect("nav present").course_reference,
+        HeadingReference::Unknown
+    );
+}
+
+#[test]
+fn heading_and_variation_round_trip_exactly() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    let state = full_state();
+    encode_state(&state, &mut block).expect("encodes");
+    let decoded = decode_state(&block).expect("decodes");
+    assert_eq!(decoded.heading, state.heading);
+    assert_eq!(decoded.variation, state.variation);
+    assert!(decoded.valid.heading && decoded.valid.variation);
+    assert_eq!(
+        decoded.selections.heading_bug_reference,
+        state.selections.heading_bug_reference
     );
 }
 

--- a/crates/pilotage-instrument-state/src/aircraft.rs
+++ b/crates/pilotage-instrument-state/src/aircraft.rs
@@ -1,6 +1,7 @@
 //! The raw input state a feeder writes.
 
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation};
 use pilotage_frames::Quat;
 
 /// Attitude estimate: orientation and body rotation rates.
@@ -69,8 +70,11 @@ pub enum NavFromTo {
 pub struct NavData {
     /// Which source drives the deviation bar.
     pub source: NavSource,
-    /// Selected course in radians.
+    /// Selected course in radians from ITS OWN declared north.
     pub course_rad: f32,
+    /// The north the course is expressed against. The CDI and course
+    /// box render only after conversion into the rose reference.
+    pub course_reference: HeadingReference,
     /// Lateral deviation in dots (full scale ±2).
     pub cdi_dots: f32,
     /// TO/FROM flag.
@@ -85,8 +89,11 @@ pub struct NavData {
 /// so they carry no freshness.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Selections {
-    /// Heading bug in radians.
+    /// Heading bug in radians from ITS OWN declared north.
     pub heading_bug_rad: f32,
+    /// The north the heading bug is expressed against. The bug renders
+    /// only after conversion into the rose reference; unknown fails.
+    pub heading_bug_reference: HeadingReference,
     /// Selected altitude in meters, when set.
     pub altitude_sel_m: Option<f32>,
     /// Reference class the selected altitude is expressed in. The bug
@@ -151,6 +158,10 @@ pub struct ValidFlags {
     pub position: bool,
     /// NED velocity is valid.
     pub velocity: bool,
+    /// The heading sample is declared valid.
+    pub heading: bool,
+    /// The variation sample is declared valid.
+    pub variation: bool,
 }
 
 /// One estimate group with the age a feeder stamped it with.
@@ -218,12 +229,19 @@ pub struct AircraftState {
     pub snapshot: SnapshotMeta,
     /// Datum declaration for the primary altitude (ALT-01).
     pub altitude: AltitudeDeclaration,
+    /// Independent heading sample with an explicit reference (NAV-01).
+    /// Operational heading never derives implicitly from attitude yaw.
+    pub heading: Stamped<HeadingSample>,
+    /// Magnetic-variation sample for the single sanctioned
+    /// magnetic/true conversion path.
+    pub variation: Stamped<MagneticVariation>,
 }
 
 impl Default for Selections {
     fn default() -> Self {
         Self {
             heading_bug_rad: 0.0,
+            heading_bug_reference: HeadingReference::Unknown,
             altitude_sel_m: None,
             altitude_sel_class: AltitudeClass::LocalRelative,
             altitude_sel_origin: OriginId(0),

--- a/crates/pilotage-instrument-state/src/heading.rs
+++ b/crates/pilotage-instrument-state/src/heading.rs
@@ -1,0 +1,173 @@
+//! Typed heading references and the single sanctioned conversion path.
+//!
+//! Operational heading is an independent sample with an explicit
+//! magnetic/true reference — never implicit quaternion yaw, which is
+//! local-NED orientation, ill-conditioned near vertical pitch, and
+//! carries no reference. Magnetic/true conversion happens in exactly
+//! one place, [`convert_heading`], and only with a valid magnetic
+//! variation sample whose sign convention (east positive), source, and
+//! freshness are explicit. Nothing here ever fabricates or substitutes
+//! a reference.
+
+use core::f32::consts::{PI, TAU};
+
+/// The north reference a horizontal angle is measured from. The
+/// default is [`Self::Unknown`]: an undeclared reference fails closed,
+/// never masquerading as any particular north.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HeadingReference {
+    /// Magnetic north.
+    Magnetic,
+    /// True north.
+    True,
+    /// The simulator's local-NED north, explicitly declared by the
+    /// feeder. Numerically a true-north convention for the local scene;
+    /// labelled SIM so it can never pass for a navigation-grade source.
+    SimLocalTrue,
+    /// The wire carried a reference this build does not know, or none
+    /// was declared; the quantity fails rather than guessing.
+    #[default]
+    Unknown,
+}
+
+impl HeadingReference {
+    /// Fail-closed wire decoding.
+    #[must_use]
+    pub const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Magnetic,
+            1 => Self::True,
+            2 => Self::SimLocalTrue,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Wire encoding; `Unknown` round-trips as unknown.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        match self {
+            Self::Magnetic => 0,
+            Self::True => 1,
+            Self::SimLocalTrue => 2,
+            Self::Unknown => 255,
+        }
+    }
+
+    /// The HSI label identifying this reference.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Magnetic => "MAG",
+            Self::True => "TRU",
+            Self::SimLocalTrue => "SIM",
+            Self::Unknown => "REF",
+        }
+    }
+
+    /// Whether both references measure from (a) true north, so values
+    /// carry across without a variation sample.
+    #[must_use]
+    const fn true_north(self) -> bool {
+        matches!(self, Self::True | Self::SimLocalTrue)
+    }
+}
+
+/// An independent heading sample with its declared reference.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HeadingSample {
+    /// Heading in radians clockwise from the declared north.
+    pub heading_rad: f32,
+    /// Which north the heading is measured from.
+    pub reference: HeadingReference,
+}
+
+/// Identity of the magnetic-variation source. Zero is "undeclared": an
+/// unattributed variation must not silently rotate the compass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VariationSourceId(pub u8);
+
+impl VariationSourceId {
+    /// No source declared.
+    pub const UNDECLARED: Self = Self(0);
+}
+
+/// A magnetic-variation sample. Sign convention: east variation is
+/// positive, so `true = magnetic + variation`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MagneticVariation {
+    /// Variation in radians, east positive.
+    pub east_positive_rad: f32,
+    /// Which model/source produced it.
+    pub source: VariationSourceId,
+}
+
+/// Why a reference conversion is not available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionFault {
+    /// Either side's reference is unknown.
+    UnknownReference,
+    /// Magnetic/true conversion was required but no usable variation
+    /// sample exists (absent, stale, undeclared source, or non-finite).
+    VariationUnavailable,
+}
+
+/// Normalizes an angle to `[0, 2π)`.
+#[must_use]
+pub fn wrap_2pi(angle_rad: f32) -> f32 {
+    let wrapped = angle_rad % TAU;
+    if wrapped < 0.0 {
+        wrapped + TAU
+    } else {
+        wrapped
+    }
+}
+
+/// The signed minimal rotation from `from_rad` to `to_rad`, in
+/// `(-π, π]`; correct across the 359°/1° wrap in both directions.
+#[must_use]
+pub fn shortest_angle_rad(from_rad: f32, to_rad: f32) -> f32 {
+    let delta = wrap_2pi(to_rad - from_rad);
+    if delta > PI { delta - TAU } else { delta }
+}
+
+/// Converts a horizontal angle between references. This is the single
+/// sanctioned conversion path: same-true-north pairs carry across
+/// unchanged, magnetic/true crossings require a usable variation sample
+/// (east positive: `true = magnetic + variation`), and an unknown
+/// reference on either side refuses. The result is wrapped to
+/// `[0, 2π)`.
+pub fn convert_heading(
+    value_rad: f32,
+    from: HeadingReference,
+    to: HeadingReference,
+    variation: Option<&MagneticVariation>,
+) -> Result<f32, ConversionFault> {
+    if from == HeadingReference::Unknown || to == HeadingReference::Unknown {
+        return Err(ConversionFault::UnknownReference);
+    }
+    if from == to || (from.true_north() && to.true_north()) {
+        return Ok(wrap_2pi(value_rad));
+    }
+    let variation = usable_variation(variation)?;
+    let converted = if from == HeadingReference::Magnetic {
+        value_rad + variation
+    } else {
+        value_rad - variation
+    };
+    Ok(wrap_2pi(converted))
+}
+
+fn usable_variation(variation: Option<&MagneticVariation>) -> Result<f32, ConversionFault> {
+    match variation {
+        Some(sample)
+            if sample.east_positive_rad.is_finite()
+                && sample.source != VariationSourceId::UNDECLARED =>
+        {
+            Ok(sample.east_positive_rad)
+        }
+        _ => Err(ConversionFault::VariationUnavailable),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-state/src/heading/tests.rs
+++ b/crates/pilotage-instrument-state/src/heading/tests.rs
@@ -1,0 +1,137 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::f32::consts::PI;
+
+use super::{
+    ConversionFault, HeadingReference, MagneticVariation, VariationSourceId, convert_heading,
+    shortest_angle_rad, wrap_2pi,
+};
+
+const DEG: f32 = PI / 180.0;
+
+fn var(east_deg: f32) -> MagneticVariation {
+    MagneticVariation {
+        east_positive_rad: east_deg * DEG,
+        source: VariationSourceId(1),
+    }
+}
+
+#[test]
+fn wrap_covers_the_359_to_1_degree_boundary_both_ways() {
+    let delta = shortest_angle_rad(359.0 * DEG, 1.0 * DEG);
+    assert!((delta - 2.0 * DEG).abs() < 1e-6, "359→1 is +2°, not −358°");
+    let delta = shortest_angle_rad(1.0 * DEG, 359.0 * DEG);
+    assert!((delta + 2.0 * DEG).abs() < 1e-6, "1→359 is −2°");
+    assert!((wrap_2pi(-DEG) - 359.0 * DEG).abs() < 1e-5);
+}
+
+#[test]
+fn variation_converts_across_north_in_both_signs() {
+    // Magnetic 359° with 2°E variation is true 1°.
+    let true_rad = convert_heading(
+        359.0 * DEG,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        Some(&var(2.0)),
+    )
+    .expect("converts");
+    assert!((true_rad - 1.0 * DEG).abs() < 1e-5);
+
+    // Magnetic 1° with 2°W variation is true 359°.
+    let true_rad = convert_heading(
+        1.0 * DEG,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        Some(&var(-2.0)),
+    )
+    .expect("converts");
+    assert!((true_rad - 359.0 * DEG).abs() < 1e-5);
+
+    // The inverse subtracts: true 1° with 2°E variation is magnetic 359°.
+    let mag_rad = convert_heading(
+        1.0 * DEG,
+        HeadingReference::True,
+        HeadingReference::Magnetic,
+        Some(&var(2.0)),
+    )
+    .expect("converts");
+    assert!((mag_rad - 359.0 * DEG).abs() < 1e-5);
+}
+
+#[test]
+fn true_north_pair_needs_no_variation_and_magnetic_crossing_requires_it() {
+    let same = convert_heading(
+        0.5,
+        HeadingReference::SimLocalTrue,
+        HeadingReference::True,
+        None,
+    );
+    assert!((same.expect("true-north pair") - 0.5).abs() < 1e-6);
+
+    let refused = convert_heading(
+        0.5,
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        None,
+    );
+    assert_eq!(refused, Err(ConversionFault::VariationUnavailable));
+}
+
+#[test]
+fn stale_or_unattributed_variation_never_rotates_the_compass() {
+    let undeclared = MagneticVariation {
+        east_positive_rad: 0.1,
+        source: VariationSourceId::UNDECLARED,
+    };
+    assert_eq!(
+        convert_heading(
+            0.5,
+            HeadingReference::Magnetic,
+            HeadingReference::True,
+            Some(&undeclared),
+        ),
+        Err(ConversionFault::VariationUnavailable)
+    );
+    let non_finite = MagneticVariation {
+        east_positive_rad: f32::NAN,
+        source: VariationSourceId(1),
+    };
+    assert_eq!(
+        convert_heading(
+            0.5,
+            HeadingReference::Magnetic,
+            HeadingReference::True,
+            Some(&non_finite),
+        ),
+        Err(ConversionFault::VariationUnavailable)
+    );
+}
+
+#[test]
+fn unknown_reference_refuses_conversion_and_round_trips_on_the_wire() {
+    assert_eq!(
+        convert_heading(0.5, HeadingReference::Unknown, HeadingReference::True, None),
+        Err(ConversionFault::UnknownReference)
+    );
+    for reference in [
+        HeadingReference::Magnetic,
+        HeadingReference::True,
+        HeadingReference::SimLocalTrue,
+    ] {
+        assert_eq!(HeadingReference::from_u8(reference.to_u8()), reference);
+    }
+    for unknown in [3u8, 9, 254, 255] {
+        assert_eq!(
+            HeadingReference::from_u8(unknown),
+            HeadingReference::Unknown
+        );
+    }
+}
+
+#[test]
+fn labels_identify_every_reference() {
+    assert_eq!(HeadingReference::Magnetic.label(), "MAG");
+    assert_eq!(HeadingReference::True.label(), "TRU");
+    assert_eq!(HeadingReference::SimLocalTrue.label(), "SIM");
+    assert_eq!(HeadingReference::Unknown.label(), "REF");
+}

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod abi;
 mod aircraft;
 mod altitude;
+mod heading;
 mod presentation;
 mod resolve;
 mod signal;
@@ -37,6 +38,10 @@ pub use aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 pub use altitude::{AltitudeClass, AltitudeDeclaration, AltitudeReference, GeoidModelId, OriginId};
+pub use heading::{
+    ConversionFault, HeadingReference, HeadingSample, MagneticVariation, VariationSourceId,
+    convert_heading, shortest_angle_rad, wrap_2pi,
+};
 pub use pilotage_frames::Quat;
 pub use presentation::{
     AirframeDisplayProfile, AttitudePresentation, ChevronSense, Hysteresis, ProfileError,

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -16,12 +16,16 @@ use crate::validate::{StateIntegrity, validate_quat, validate_state};
 const TRACK_MIN_GS_MPS: f32 = 0.5;
 
 /// Resolved navigation guidance for the HSI.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct NavResolved {
     /// Guidance data as provided; `source == None` removes the CDI.
     pub data: NavData,
     /// Status of the guidance group as a whole.
     pub status: SignalStatus,
+    /// Selected course presented in the rose reference; `Failed` when
+    /// the course's own reference is unknown or cannot convert. The CDI
+    /// and course box render only from this, never from the raw angle.
+    pub course_rose_rad: Sig<f32>,
 }
 
 /// The pilot-selected and source-applied altimeter settings disagree
@@ -54,8 +58,11 @@ pub struct PanelData {
     pub roll_rad: Sig<f32>,
     /// Pitch angle, radians, positive nose-up.
     pub pitch_rad: Sig<f32>,
-    /// Heading, radians clockwise from north.
-    pub heading_rad: Sig<f32>,
+    /// Independent, reference-typed heading.
+    pub heading: ResolvedHeading,
+    /// Heading bug presented in the rose reference; `Failed` when the
+    /// bug's own reference is unknown or cannot convert.
+    pub heading_bug_rose_rad: Sig<f32>,
     /// Body yaw rate, radians/second (turn-rate proxy).
     pub turn_rate_rps: Sig<f32>,
     /// Indicated airspeed, knots.
@@ -102,7 +109,7 @@ fn flag_status(valid: bool) -> SignalStatus {
     }
 }
 
-fn fault_status<T>(fault: Option<T>) -> SignalStatus {
+pub(crate) fn fault_status<T>(fault: Option<T>) -> SignalStatus {
     if fault.is_some() {
         SignalStatus::Failed
     } else {
@@ -127,7 +134,7 @@ fn coherence_status(coherence: SnapshotCoherence) -> SignalStatus {
 /// A signal that would show a non-finite value fails instead: no
 /// non-finite number may reach scene generation, and no value is
 /// silently repaired.
-fn finite(sig: Sig<f32>) -> Sig<f32> {
+pub(crate) fn finite(sig: Sig<f32>) -> Sig<f32> {
     if sig.status.shows_value() && !sig.value.is_finite() {
         Sig::with_status(0.0, SignalStatus::Failed)
     } else {
@@ -142,6 +149,7 @@ fn sanitized_selections(selections: Selections) -> Selections {
         } else {
             0.0
         },
+        heading_bug_reference: selections.heading_bug_reference,
         altitude_sel_m: selections.altitude_sel_m.filter(|value| value.is_finite()),
         altitude_sel_class: selections.altitude_sel_class,
         altitude_sel_origin: selections.altitude_sel_origin,
@@ -185,7 +193,7 @@ pub fn resolve_stateful(
         coherence: coherence_status(state.snapshot.coherence),
     };
 
-    let (presentation, yaw, turn_rate) = attitude_geometry(state, profile, unusual);
+    let (presentation, turn_rate) = attitude_geometry(state, profile, unusual);
     let has_att = state.attitude.data.is_some();
     let att_fresh = group_freshness(policy, has_att, state.attitude.age_ms);
     let att_status = trust.fold(has_att, att_fresh, integrity.attitude, state.valid.attitude);
@@ -203,31 +211,52 @@ pub fn resolve_stateful(
     };
 
     let (ias, baro) = air_signals(state, policy, trust.quality, &integrity);
+    let heading = heading_resolved(state, policy, &trust, &integrity);
+    let rose = heading.reference;
+    let track = presented_true(Sig::with_status(track_rad, track_status), rose, state);
+    let wind = presented_wind(wind_signal(state, policy, &integrity), rose, state);
+    let bug = presented_angle(
+        Sig::with_status(state.selections.heading_bug_rad, SignalStatus::Valid),
+        state.selections.heading_bug_reference,
+        rose,
+        state,
+    );
 
     PanelData {
         roll_rad: finite(Sig::with_status(presentation.bank_rad, att_status)),
         pitch_rad: finite(Sig::with_status(presentation.pitch_rad, att_status)),
-        heading_rad: finite(Sig::with_status(yaw, att_status)),
+        heading,
+        heading_bug_rose_rad: finite(bug),
         turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
         ias_kt: finite(ias),
         gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
         altitude: altitude_resolved(state, policy, &trust, &integrity, pos_status, rel_alt_ft),
         vsi_fpm: finite(Sig::with_status(vsi_fpm, vel_status)),
-        track_rad: finite(Sig::with_status(track_rad, track_status)),
+        track_rad: finite(track),
         baro_hpa: finite(baro),
-        wind: wind_signal(state, policy, &integrity),
-        nav: nav_resolved(state, policy, &integrity),
+        wind,
+        nav: nav_resolved(state, policy, &integrity, rose),
         selections: sanitized_selections(state.selections),
         integrity,
         presentation,
     }
 }
 
+impl Default for NavResolved {
+    fn default() -> Self {
+        Self {
+            data: NavData::default(),
+            status: SignalStatus::default(),
+            course_rose_rad: Sig::with_status(0.0, SignalStatus::Missing),
+        }
+    }
+}
+
 /// Source-level trust shared by every estimate group this frame.
 #[derive(Clone, Copy)]
-struct Trust {
-    quality: SignalStatus,
-    coherence: SignalStatus,
+pub(crate) struct Trust {
+    pub(crate) quality: SignalStatus,
+    pub(crate) coherence: SignalStatus,
 }
 
 impl Trust {
@@ -236,7 +265,7 @@ impl Trust {
     /// not a red X — because nothing was received to distrust. A group
     /// *with* data still folds even when its freshness reads Missing
     /// (a bogus age), so declared distrust cannot be masked.
-    fn fold(
+    pub(crate) fn fold(
         &self,
         has_data: bool,
         freshness: SignalStatus,
@@ -254,7 +283,11 @@ impl Trust {
     }
 }
 
-fn group_freshness(policy: &FreshnessPolicy, has_data: bool, age_ms: Option<f32>) -> SignalStatus {
+pub(crate) fn group_freshness(
+    policy: &FreshnessPolicy,
+    has_data: bool,
+    age_ms: Option<f32>,
+) -> SignalStatus {
     if has_data {
         policy.status_for_age(age_ms)
     } else {
@@ -269,103 +302,19 @@ fn attitude_geometry(
     state: &AircraftState,
     profile: &AirframeDisplayProfile,
     unusual: &mut UnusualAttitudeState,
-) -> (AttitudePresentation, f32, f32) {
+) -> (AttitudePresentation, f32) {
     match state.attitude.data {
         Some(att) => match validate_quat(att.quat) {
-            Ok(quat) => {
-                let presentation = unusual.step(quat, profile);
-                let (_, _, yaw) = quat.to_euler();
-                (presentation, yaw, att.rates_rps[2])
-            }
+            Ok(quat) => (unusual.step(quat, profile), att.rates_rps[2]),
             Err(_) => {
                 unusual.reset();
-                (AttitudePresentation::default(), 0.0, att.rates_rps[2])
+                (AttitudePresentation::default(), att.rates_rps[2])
             }
         },
         None => {
             unusual.reset();
-            (AttitudePresentation::default(), 0.0, 0.0)
+            (AttitudePresentation::default(), 0.0)
         }
-    }
-}
-
-/// Resolves the datum-qualified altitude for the declared class. The
-/// non-local classes ride the air-data group's stamp in ABI v3 (they
-/// arrive beside it); a dedicated source group would bring its own
-/// stamp. A required source that is absent fails the altitude — the
-/// value is a quiet zero and nothing substitutes.
-fn altitude_resolved(
-    state: &AircraftState,
-    policy: &FreshnessPolicy,
-    trust: &Trust,
-    integrity: &StateIntegrity,
-    pos_status: SignalStatus,
-    rel_alt_ft: f32,
-) -> ResolvedAltitude {
-    let decl = state.altitude;
-    let class = decl.reference_class;
-    let fault = fault_status(integrity.altitude);
-    let sample_ft = decl.sample_m.map(|m| m * M_TO_FT);
-    let sample_status = group_freshness(policy, state.air.data.is_some(), state.air.age_ms)
-        .worst(trust.quality)
-        .worst(trust.coherence)
-        .worst(fault);
-    let value = match class {
-        AltitudeClass::LocalRelative => Sig::with_status(rel_alt_ft, pos_status.worst(fault)),
-        AltitudeClass::BaroIndicated
-        | AltitudeClass::Pressure
-        | AltitudeClass::GeometricMsl
-        | AltitudeClass::Agl => match (sample_ft, integrity.altitude) {
-            (Some(v), None) => Sig::with_status(v, sample_status),
-            _ => Sig::with_status(0.0, SignalStatus::Failed),
-        },
-        AltitudeClass::Unknown => Sig::with_status(0.0, SignalStatus::Failed),
-    };
-    let applied = state.air.data.and_then(|air| air.baro_setting_hpa);
-    let setting_mismatch = class == AltitudeClass::BaroIndicated
-        && matches!(
-            (applied, state.selections.baro_sel_hpa),
-            (Some(a), Some(s)) if (a - s).abs() > BARO_SETTING_TOLERANCE_HPA
-        );
-    let bug_compatible = selection_compatible(state, class, setting_mismatch);
-    ResolvedAltitude {
-        value_ft: finite(value),
-        class,
-        origin: decl.origin,
-        setting_mismatch,
-        bug_compatible,
-    }
-}
-
-/// Whether the pilot's altitude selection shares the displayed datum's
-/// COMPLETE reference identity — class equality alone is never
-/// compatibility. Local-relative selections must name the same origin;
-/// geometric-MSL selections must name the same declared model; a
-/// barometric selection's datum is the applied setting, so a disputed
-/// setting suppresses the bug; pressure altitude's datum is fully
-/// identified by its class (standard atmosphere); AGL carries no source
-/// identity in this ABI revision, so class equality is its complete
-/// identity today. Anything unknown or incomplete fails closed.
-fn selection_compatible(
-    state: &AircraftState,
-    displayed: AltitudeClass,
-    setting_mismatch: bool,
-) -> bool {
-    if state.selections.altitude_sel_m.is_none() || state.selections.altitude_sel_class != displayed
-    {
-        return false;
-    }
-    let decl = state.altitude;
-    let selections = state.selections;
-    match displayed {
-        AltitudeClass::LocalRelative => selections.altitude_sel_origin == decl.origin,
-        AltitudeClass::GeometricMsl => {
-            selections.altitude_sel_model == decl.geoid_model
-                && selections.altitude_sel_model != crate::altitude::GeoidModelId::UNDECLARED
-        }
-        AltitudeClass::BaroIndicated => !setting_mismatch,
-        AltitudeClass::Pressure | AltitudeClass::Agl => true,
-        AltitudeClass::Unknown => false,
     }
 }
 
@@ -408,6 +357,7 @@ fn nav_resolved(
     state: &AircraftState,
     policy: &FreshnessPolicy,
     integrity: &StateIntegrity,
+    rose: crate::heading::HeadingReference,
 ) -> NavResolved {
     let nav_fresh = policy.status_for_age(state.nav.age_ms);
     match state.nav.data {
@@ -423,7 +373,20 @@ fn nav_resolved(
             } else {
                 data
             };
-            NavResolved { data, status }
+            // The course renders only in the rose reference; an
+            // unknown course reference or an impossible conversion
+            // fails this one quantity, not the whole nav group.
+            let course = presented_angle(
+                Sig::with_status(data.course_rad, status),
+                data.course_reference,
+                rose,
+                state,
+            );
+            NavResolved {
+                data,
+                status,
+                course_rose_rad: finite(course),
+            }
         }
         None => NavResolved::default(),
     }
@@ -453,7 +416,15 @@ fn wind_signal(
     }
 }
 
+mod altitude_signal;
+use altitude_signal::altitude_resolved;
+mod heading_signal;
+pub use heading_signal::ResolvedHeading;
+use heading_signal::{heading_resolved, presented_angle, presented_true, presented_wind};
+
 #[cfg(test)]
 mod altitude_tests;
+#[cfg(test)]
+mod heading_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/pilotage-instrument-state/src/resolve/altitude_signal.rs
+++ b/crates/pilotage-instrument-state/src/resolve/altitude_signal.rs
@@ -1,0 +1,92 @@
+//! Resolution of the datum-qualified altitude and the full-identity
+//! selection-compatibility rule (ALT-01).
+
+use crate::aircraft::AircraftState;
+use crate::altitude::AltitudeClass;
+use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
+use crate::units::M_TO_FT;
+use crate::validate::StateIntegrity;
+
+use super::{
+    BARO_SETTING_TOLERANCE_HPA, ResolvedAltitude, Trust, fault_status, finite, group_freshness,
+};
+
+/// Resolves the datum-qualified altitude for the declared class. The
+/// non-local classes ride the air-data group's stamp in ABI v3 (they
+/// arrive beside it); a dedicated source group would bring its own
+/// stamp. A required source that is absent fails the altitude — the
+/// value is a quiet zero and nothing substitutes.
+pub(super) fn altitude_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    trust: &Trust,
+    integrity: &StateIntegrity,
+    pos_status: SignalStatus,
+    rel_alt_ft: f32,
+) -> ResolvedAltitude {
+    let decl = state.altitude;
+    let class = decl.reference_class;
+    let fault = fault_status(integrity.altitude);
+    let sample_ft = decl.sample_m.map(|m| m * M_TO_FT);
+    let sample_status = group_freshness(policy, state.air.data.is_some(), state.air.age_ms)
+        .worst(trust.quality)
+        .worst(trust.coherence)
+        .worst(fault);
+    let value = match class {
+        AltitudeClass::LocalRelative => Sig::with_status(rel_alt_ft, pos_status.worst(fault)),
+        AltitudeClass::BaroIndicated
+        | AltitudeClass::Pressure
+        | AltitudeClass::GeometricMsl
+        | AltitudeClass::Agl => match (sample_ft, integrity.altitude) {
+            (Some(v), None) => Sig::with_status(v, sample_status),
+            _ => Sig::with_status(0.0, SignalStatus::Failed),
+        },
+        AltitudeClass::Unknown => Sig::with_status(0.0, SignalStatus::Failed),
+    };
+    let applied = state.air.data.and_then(|air| air.baro_setting_hpa);
+    let setting_mismatch = class == AltitudeClass::BaroIndicated
+        && matches!(
+            (applied, state.selections.baro_sel_hpa),
+            (Some(a), Some(s)) if (a - s).abs() > BARO_SETTING_TOLERANCE_HPA
+        );
+    let bug_compatible = selection_compatible(state, class, setting_mismatch);
+    ResolvedAltitude {
+        value_ft: finite(value),
+        class,
+        origin: decl.origin,
+        setting_mismatch,
+        bug_compatible,
+    }
+}
+
+/// Whether the pilot's altitude selection shares the displayed datum's
+/// COMPLETE reference identity — class equality alone is never
+/// compatibility. Local-relative selections must name the same origin;
+/// geometric-MSL selections must name the same declared model; a
+/// barometric selection's datum is the applied setting, so a disputed
+/// setting suppresses the bug; pressure altitude's datum is fully
+/// identified by its class (standard atmosphere); AGL carries no source
+/// identity in this ABI revision, so class equality is its complete
+/// identity today. Anything unknown or incomplete fails closed.
+fn selection_compatible(
+    state: &AircraftState,
+    displayed: AltitudeClass,
+    setting_mismatch: bool,
+) -> bool {
+    if state.selections.altitude_sel_m.is_none() || state.selections.altitude_sel_class != displayed
+    {
+        return false;
+    }
+    let decl = state.altitude;
+    let selections = state.selections;
+    match displayed {
+        AltitudeClass::LocalRelative => selections.altitude_sel_origin == decl.origin,
+        AltitudeClass::GeometricMsl => {
+            selections.altitude_sel_model == decl.geoid_model
+                && selections.altitude_sel_model != crate::altitude::GeoidModelId::UNDECLARED
+        }
+        AltitudeClass::BaroIndicated => !setting_mismatch,
+        AltitudeClass::Pressure | AltitudeClass::Agl => true,
+        AltitudeClass::Unknown => false,
+    }
+}

--- a/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
@@ -1,0 +1,131 @@
+//! Presentation of the independent heading sample and of true-north
+//! quantities in the display reference (NAV-01).
+
+use crate::aircraft::AircraftState;
+use crate::heading::{HeadingReference, convert_heading, wrap_2pi};
+use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
+use crate::validate::StateIntegrity;
+
+use super::{Trust, Wind, finite, group_freshness};
+
+/// Heading resolved from the independent sample (NAV-01): the value,
+/// its declared reference, and nothing else — attitude yaw never feeds
+/// this. A missing sample resolves `Missing` and the compass rose fails
+/// visibly instead of freezing on a fabricated heading.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedHeading {
+    /// Heading in radians clockwise from the declared north; quiet zero
+    /// behind a hidden status.
+    pub value_rad: Sig<f32>,
+    /// The reference every HSI angular quantity is presented in.
+    pub reference: HeadingReference,
+}
+
+/// Resolves the independent heading sample. Its status folds the same
+/// trust chain as every estimate group; the reference passes through
+/// typed. An unknown reference fails; absence is `Missing` — the rose
+/// fails visibly, never a frozen plausible heading, and attitude yaw is
+/// not consulted at any pitch.
+pub(super) fn heading_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    trust: &Trust,
+    integrity: &StateIntegrity,
+) -> ResolvedHeading {
+    let has = state.heading.data.is_some();
+    let fresh = group_freshness(policy, has, state.heading.age_ms);
+    let status = trust.fold(has, fresh, integrity.heading, state.valid.heading);
+    let sample = state.heading.data.unwrap_or(crate::heading::HeadingSample {
+        heading_rad: 0.0,
+        reference: HeadingReference::Unknown,
+    });
+    let reference = if has {
+        sample.reference
+    } else {
+        HeadingReference::Unknown
+    };
+    ResolvedHeading {
+        value_rad: finite(Sig::with_status(wrap_2pi(sample.heading_rad), status)),
+        reference,
+    }
+}
+
+/// A usable variation sample, or `None` when absent, stale, faulted, or
+/// undeclared — the caller then degrades instead of converting.
+fn usable_variation(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+) -> Option<crate::heading::MagneticVariation> {
+    let fresh = policy.status_for_age(state.variation.age_ms);
+    match (state.variation.data, state.valid.variation) {
+        (Some(sample), true) if fresh.shows_value() => Some(sample),
+        _ => None,
+    }
+}
+
+/// Presents an angle expressed against its OWN declared north in the
+/// rose (display) reference through the single conversion path. An
+/// unknown reference on either side, or a magnetic/true crossing with
+/// no usable variation, fails this one quantity — it is never drawn
+/// raw on a rose it does not match.
+pub(super) fn presented_angle(
+    sig: Sig<f32>,
+    own: HeadingReference,
+    display: HeadingReference,
+    state: &AircraftState,
+) -> Sig<f32> {
+    if !sig.status.shows_value() {
+        return sig;
+    }
+    let variation = usable_variation(state, &FreshnessPolicy::default());
+    match convert_heading(sig.value, own, display, variation.as_ref()) {
+        Ok(value) => Sig::with_status(value, sig.status),
+        Err(_) => Sig::with_status(0.0, SignalStatus::Failed),
+    }
+}
+
+/// Presents a NED-derived (true-north) angle in the display reference.
+/// A magnetic display without a usable variation degrades the quantity
+/// to `Failed` rather than mixing references on one rose.
+pub(super) fn presented_true(
+    sig: Sig<f32>,
+    display: HeadingReference,
+    state: &AircraftState,
+) -> Sig<f32> {
+    if !sig.status.shows_value() || display == HeadingReference::Unknown {
+        return sig;
+    }
+    presented_angle(sig, HeadingReference::True, display, state)
+}
+
+pub(super) fn presented_wind(
+    wind: Sig<Wind>,
+    display: HeadingReference,
+    state: &AircraftState,
+) -> Sig<Wind> {
+    if !wind.status.shows_value() || display == HeadingReference::Unknown {
+        return wind;
+    }
+    let converted = presented_true(
+        Sig::with_status(wind.value.from_rad, wind.status),
+        display,
+        state,
+    );
+    if converted.status.shows_value() {
+        Sig::with_status(
+            Wind {
+                from_rad: converted.value,
+                speed_mps: wind.value.speed_mps,
+            },
+            wind.status,
+        )
+    } else {
+        Sig::with_status(
+            Wind {
+                from_rad: 0.0,
+                speed_mps: 0.0,
+            },
+            SignalStatus::Failed,
+        )
+    }
+}

--- a/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
@@ -1,0 +1,290 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! NAV-01 resolution proofs: heading is the independent sample, never
+//! quaternion yaw; every HSI angle presents in one reference or
+//! visibly degrades; conversion happens only through a usable
+//! variation sample.
+
+use core::f32::consts::PI;
+
+use super::resolve;
+use super::tests::flying_state;
+use crate::aircraft::{AircraftState, Stamped};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
+use crate::signal::{FreshnessPolicy, SignalStatus};
+use pilotage_frames::Quat;
+
+const DEG: f32 = PI / 180.0;
+
+fn with_heading(reference: HeadingReference, heading_rad: f32) -> AircraftState {
+    let mut state = flying_state();
+    state.heading = Stamped {
+        data: Some(HeadingSample {
+            heading_rad,
+            reference,
+        }),
+        age_ms: Some(20.0),
+    };
+    state.valid.heading = true;
+    state
+}
+
+fn with_variation(mut state: AircraftState, east_deg: f32) -> AircraftState {
+    state.variation = Stamped {
+        data: Some(MagneticVariation {
+            east_positive_rad: east_deg * DEG,
+            source: VariationSourceId(1),
+        }),
+        age_ms: Some(50.0),
+    };
+    state.valid.variation = true;
+    state
+}
+
+#[test]
+fn missing_heading_resolves_missing_even_with_a_valid_attitude() {
+    let p = resolve(&flying_state(), &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Missing);
+    assert_eq!(p.heading.reference, HeadingReference::Unknown);
+    assert_eq!(
+        p.heading.value_rad.value, 0.0,
+        "no plausible frozen heading may remain"
+    );
+}
+
+#[test]
+fn heading_is_independent_of_attitude_through_the_vertical() {
+    for pitch_deg in [89.0f32, 90.0, 91.0, 180.0] {
+        let mut state = with_heading(HeadingReference::SimLocalTrue, 1.0);
+        let half = pitch_deg * DEG / 2.0;
+        // Pure pitch rotation: ill-conditioned yaw at/beyond vertical.
+        state.attitude.data = state.attitude.data.map(|mut att| {
+            att.quat = Quat {
+                w: libm::cosf(half),
+                x: 0.0,
+                y: libm::sinf(half),
+                z: 0.0,
+            };
+            att
+        });
+        let p = resolve(&state, &FreshnessPolicy::default());
+        assert_eq!(p.heading.value_rad.status, SignalStatus::Valid);
+        assert!(
+            (p.heading.value_rad.value - 1.0).abs() < 1e-6,
+            "independent heading must not bend at pitch {pitch_deg}"
+        );
+    }
+}
+
+#[test]
+fn unknown_reference_fails_the_heading() {
+    let state = with_heading(HeadingReference::from_u8(9), 1.0);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Failed);
+    assert_eq!(p.heading.reference, HeadingReference::Unknown);
+}
+
+#[test]
+fn undeclared_validity_fails_the_heading() {
+    let mut state = with_heading(HeadingReference::True, 1.0);
+    state.valid.heading = false;
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn heading_value_wraps_into_one_turn() {
+    let state = with_heading(HeadingReference::SimLocalTrue, 370.0 * DEG);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert!((p.heading.value_rad.value - 10.0 * DEG).abs() < 1e-4);
+}
+
+#[test]
+fn magnetic_display_without_variation_degrades_true_quantities() {
+    // Track and wind are NED-derived (true); a magnetic rose must not
+    // mix them in unconverted.
+    let state = with_heading(HeadingReference::Magnetic, 1.0);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn magnetic_display_with_variation_converts_the_track() {
+    let mut state = with_variation(with_heading(HeadingReference::Magnetic, 1.0), 2.0);
+    // Velocity due north: true track 0° reads magnetic 358° under 2°E.
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [20.0, 0.0, 0.0];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Valid);
+    assert!(
+        (p.track_rad.value - 358.0 * DEG).abs() < 1e-4,
+        "got {}",
+        p.track_rad.value
+    );
+}
+
+#[test]
+fn stale_variation_refuses_conversion() {
+    let mut state = with_variation(with_heading(HeadingReference::Magnetic, 1.0), 2.0);
+    state.variation.age_ms = Some(1.0e9);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn sim_true_display_presents_true_quantities_unchanged() {
+    let mut state = with_heading(HeadingReference::SimLocalTrue, 1.0);
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [0.0, 20.0, 0.0];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.track_rad.status, SignalStatus::Valid);
+    assert!((p.track_rad.value - 90.0 * DEG).abs() < 1e-4);
+}
+
+// ---- Review: every displayed angle is typed and rose-coherent -----------
+
+fn with_bug(mut state: AircraftState, bug_deg: f32, reference: HeadingReference) -> AircraftState {
+    state.selections.heading_bug_rad = bug_deg * DEG;
+    state.selections.heading_bug_reference = reference;
+    state
+}
+
+fn with_course(
+    mut state: AircraftState,
+    course_deg: f32,
+    reference: HeadingReference,
+) -> AircraftState {
+    state.nav = Stamped {
+        data: Some(crate::aircraft::NavData {
+            source: crate::aircraft::NavSource::Gps,
+            course_rad: course_deg * DEG,
+            cdi_dots: 0.5,
+            fromto: crate::aircraft::NavFromTo::To,
+            vdev_dots: None,
+            dist_nm: None,
+            course_reference: reference,
+        }),
+        age_ms: Some(20.0),
+    };
+    state
+}
+
+#[test]
+fn true_bug_on_a_magnetic_rose_fails_without_variation() {
+    let state = with_bug(
+        with_heading(HeadingReference::Magnetic, 1.0),
+        90.0,
+        HeadingReference::True,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading_bug_rose_rad.status, SignalStatus::Failed);
+    assert_eq!(p.heading_bug_rose_rad.value, 0.0);
+}
+
+#[test]
+fn true_course_on_a_magnetic_rose_fails_without_variation() {
+    let state = with_course(
+        with_heading(HeadingReference::Magnetic, 1.0),
+        90.0,
+        HeadingReference::True,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.nav.course_rose_rad.status, SignalStatus::Failed);
+    assert_eq!(
+        p.nav.status,
+        SignalStatus::Valid,
+        "one incompatible quantity fails alone, not the nav group"
+    );
+}
+
+#[test]
+fn valid_variation_converts_bug_and_course_onto_the_magnetic_rose() {
+    let state = with_variation(
+        with_course(
+            with_bug(
+                with_heading(HeadingReference::Magnetic, 1.0),
+                90.0,
+                HeadingReference::True,
+            ),
+            180.0,
+            HeadingReference::True,
+        ),
+        2.0,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading_bug_rose_rad.status, SignalStatus::Valid);
+    assert!((p.heading_bug_rose_rad.value - 88.0 * DEG).abs() < 1e-4);
+    assert_eq!(p.nav.course_rose_rad.status, SignalStatus::Valid);
+    assert!((p.nav.course_rose_rad.value - 178.0 * DEG).abs() < 1e-4);
+}
+
+#[test]
+fn numerically_identical_angles_in_incompatible_references_never_pass_raw() {
+    // Bug 090 TRUE on a 090-showing MAGNETIC rose under 2E variation:
+    // the drawn bug is 088, never the raw 090.
+    let state = with_variation(
+        with_bug(
+            with_heading(HeadingReference::Magnetic, 90.0 * DEG),
+            90.0,
+            HeadingReference::True,
+        ),
+        2.0,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert!((p.heading_bug_rose_rad.value - 88.0 * DEG).abs() < 1e-4);
+    assert!((p.heading_bug_rose_rad.value - p.selections.heading_bug_rad).abs() > 1e-3);
+}
+
+#[test]
+fn unknown_bug_or_course_reference_fails_that_quantity() {
+    let state = with_course(
+        with_bug(
+            with_heading(HeadingReference::SimLocalTrue, 1.0),
+            45.0,
+            HeadingReference::Unknown,
+        ),
+        60.0,
+        HeadingReference::Unknown,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading_bug_rose_rad.status, SignalStatus::Failed);
+    assert_eq!(p.nav.course_rose_rad.status, SignalStatus::Failed);
+}
+
+#[test]
+fn every_displayed_angle_agrees_on_the_rose_reference() {
+    // Magnetic rose, valid 2E variation, all true-north inputs: every
+    // presented angle is the true value minus variation — one coherent
+    // reference across heading, track, bug, and course.
+    let mut state = with_variation(
+        with_course(
+            with_bug(
+                with_heading(HeadingReference::Magnetic, 100.0 * DEG),
+                90.0,
+                HeadingReference::True,
+            ),
+            180.0,
+            HeadingReference::True,
+        ),
+        2.0,
+    );
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [0.0, 20.0, 0.0];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.reference, HeadingReference::Magnetic);
+    for (name, sig, true_deg) in [
+        ("track", p.track_rad, 90.0f32),
+        ("bug", p.heading_bug_rose_rad, 90.0),
+        ("course", p.nav.course_rose_rad, 180.0),
+    ] {
+        assert_eq!(sig.status, SignalStatus::Valid, "{name}");
+        assert!(
+            (sig.value - (true_deg - 2.0) * DEG).abs() < 1e-4,
+            "{name} must present magnetic: {}",
+            sig.value
+        );
+    }
+}

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -34,6 +34,7 @@ pub(crate) fn flying_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }
@@ -251,7 +252,7 @@ fn every_showable_output_is_finite_under_hostile_input() {
         for (name, sig) in [
             ("roll", p.roll_rad),
             ("pitch", p.pitch_rad),
-            ("heading", p.heading_rad),
+            ("heading", p.heading.value_rad),
             ("turn", p.turn_rate_rps),
             ("ias", p.ias_kt),
             ("gs", p.gs_kt),
@@ -291,6 +292,7 @@ fn pilotage_state_navdata_unknown() -> crate::aircraft::NavData {
         fromto: crate::aircraft::NavFromTo::To,
         vdev_dots: None,
         dist_nm: None,
+        course_reference: crate::heading::HeadingReference::SimLocalTrue,
     }
 }
 

--- a/crates/pilotage-instrument-state/src/validate.rs
+++ b/crates/pilotage-instrument-state/src/validate.rs
@@ -65,6 +65,10 @@ pub struct StateIntegrity {
     /// Datum-qualified altitude fault: unknown reference class, missing
     /// required source, undeclared model, or non-finite sample.
     pub altitude: Option<GroupFault>,
+    /// Heading-sample fault: non-finite value or unknown reference.
+    pub heading: Option<GroupFault>,
+    /// Magnetic-variation fault: non-finite value or undeclared source.
+    pub variation: Option<GroupFault>,
 }
 
 fn all_finite(values: &[f32]) -> bool {
@@ -156,6 +160,20 @@ pub fn validate_state(state: &AircraftState) -> StateIntegrity {
         integrity.coherence = Some(GroupFault::UnknownEnum);
     }
     integrity.altitude = altitude_fault(state);
+    if let Some(heading) = &state.heading.data {
+        if heading.reference == crate::heading::HeadingReference::Unknown {
+            integrity.heading = Some(GroupFault::UnknownEnum);
+        } else if !heading.heading_rad.is_finite() {
+            integrity.heading = Some(GroupFault::NonFinite);
+        }
+    }
+    if let Some(variation) = &state.variation.data {
+        if !variation.east_positive_rad.is_finite() {
+            integrity.variation = Some(GroupFault::NonFinite);
+        } else if variation.source == crate::heading::VariationSourceId::UNDECLARED {
+            integrity.variation = Some(GroupFault::SourceAbsent);
+        }
+    }
     integrity
 }
 

--- a/crates/pilotage-instrument-state/src/validate/tests.rs
+++ b/crates/pilotage-instrument-state/src/validate/tests.rs
@@ -5,6 +5,7 @@ use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
 };
+use crate::heading::HeadingReference;
 use pilotage_frames::Quat;
 
 const BAD: [f32; 3] = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
@@ -46,6 +47,7 @@ fn trusted_full_state() -> AircraftState {
             fromto: NavFromTo::To,
             vdev_dots: Some(0.2),
             dist_nm: Some(12.5),
+            course_reference: HeadingReference::SimLocalTrue,
         }),
         wind: stamped(Wind {
             from_rad: 1.0,
@@ -57,6 +59,7 @@ fn trusted_full_state() -> AircraftState {
             rates: true,
             position: true,
             velocity: true,
+            ..Default::default()
         },
         ..AircraftState::default()
     }

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -3,8 +3,8 @@
 ./crates/pilotage-instrument-scene/src/decode.rs	decode_payload	94
 ./crates/pilotage-instrument-glyphs/src/sha256.rs	sha256	90
 ./crates/pilotage-conformance/src/fixture.rs	increment_zero_script	89
-./crates/pilotage-instrument-state/src/abi.rs	decode_state	132
-./crates/pilotage-instrument-state/src/abi.rs	encode_state	105
+./crates/pilotage-instrument-state/src/abi.rs	decode_state	129
+./crates/pilotage-instrument-state/src/abi.rs	encode_state	97
 ./crates/pilotage-authority/src/wire.rs	from	88
 ./adapters/aviate/src/adapter/tests.rs	stick_frame_reaches_the_fc_as_a_velocity_setpoint	93
 ./adapters/aviate/src/uplink.rs	send_stick_frame	90


### PR DESCRIPTION
Implements #21, incorporating the full review of #63 — this branch supersedes `agent/nav-01-heading-ref` (the old stack was based on pre-review ALT-01 and could not rebase cleanly; rebuilt on merged main with #61's revised ABI). **SIM / NOT FOR FLIGHT.**

## What the review demanded, delivered

Everything from the first PR (independent reference-typed `HeadingSample`, quaternion yaw removed from the heading path, centralized `convert_heading` with attributed east-positive variation, track/wind conversion, no frozen rose, 359/1° wrap tests) **plus the previously missing angular quantities**:

- **`Selections.heading_bug_reference: HeadingReference`** — the bug is no longer an unreferenced scalar. `PanelData.heading_bug_rose_rad` is the bug presented in the rose reference through the one conversion path; the rose bug polygon and the selected-heading box render only from it. Incompatible/unknown → amber `HDG REF` marker, no number (`incompatible_bug_is_suppressed_with_its_flag`).
- **`NavData.course_reference: HeadingReference`** — `NavResolved.course_rose_rad` is the course presented in the rose reference; the CDI rotation and the course box consume only it (the raw `course_rad` no longer reaches Canvas geometry). Impossible conversion fails that single quantity, not the nav group: course box dashes, CDI removed, DME/deviation intact (`true_course_on_a_magnetic_rose_fails_without_variation`, `incompatible_course_shows_dashes_and_no_cdi`).
- **Live feeder declares SIM heading explicitly** (`declaredSimHeading` in main.js, now free after #62): local-NED yaw is computed feeder-side from the published estimate and declared `sim-local-true` with the attitude's age and validity; no attitude → no sample, never a zero heading. The display cannot fabricate heading — deleting the declaration flags HDG.

## Review test matrix → evidence

| Case (review) | Test |
|---|---|
| Magnetic rose + true bug, no variation | `true_bug_on_a_magnetic_rose_fails_without_variation` |
| Magnetic rose + true course, no variation | `true_course_on_a_magnetic_rose_fails_without_variation` |
| Both with valid variation | `valid_variation_converts_bug_and_course_onto_the_magnetic_rose` (88°/178° exact under 2°E) |
| Numerically identical, reference-incompatible | `numerically_identical_angles_in_incompatible_references_never_pass_raw` (090 TRUE ≠ 090 MAG; drawn 088) |
| Unknown course/bug reference | `unknown_bug_or_course_reference_fails_that_quantity` + ABI `unknown_heading_and_angle_reference_bytes_decode_fail_closed` |
| All displayed angles agree on the resolved reference | `every_displayed_angle_agrees_on_the_rose_reference` (heading/track/bug/course all magnetic under live variation) |
| Rendering suppression | `incompatible_bug_is_suppressed_with_its_flag`, `incompatible_course_shows_dashes_and_no_cdi` |

Carried over and still green: independence at pitch 89/90/91 and inverted, missing-heading-no-frozen-rose (cardinals do not paint), stale/undeclared/non-finite variation never rotates the compass, wrap both directions across north, SIM/MAG labels.

## Wire

State ABI v4 (176 bytes): heading value/age/reference, variation value/age/source, bug and course reference bytes, second valid-flags byte — all fail-safe (`Unknown`/no-sample defaults, proven byte-for-byte by the JS parity tests, including the undeclared-defaults case).

## Verification

Lane gates green: fmt, clippy `-D warnings`, tests across the four instrument crates (23 heading-resolution/math tests, 13 HSI rendering tests, ABI round-trip + fail-closed), doc, no_std, structure gate (resolve split into `altitude_signal`/`heading_signal` submodules; decode/encode baselines ratcheted down again 132→129 / 105→97). All seven node suites pass; wasm rebuilt; HSI frame hash re-pinned with rationale (byte-identical to the first implementation's SIM-driven rose — the rework changed contracts, not pixels); PFD hash untouched.

Refs #21. Closes nothing until review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)