### PR TITLE
NAV-02: one resolver freshness policy for heading-reference conversion

### DIFF
--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -213,13 +213,19 @@ pub fn resolve_stateful(
     let (ias, baro) = air_signals(state, policy, trust.quality, &integrity);
     let heading = heading_resolved(state, policy, &trust, &integrity);
     let rose = heading.reference;
-    let track = presented_true(Sig::with_status(track_rad, track_status), rose, state);
-    let wind = presented_wind(wind_signal(state, policy, &integrity), rose, state);
+    let track = presented_true(
+        Sig::with_status(track_rad, track_status),
+        rose,
+        state,
+        policy,
+    );
+    let wind = presented_wind(wind_signal(state, policy, &integrity), rose, state, policy);
     let bug = presented_angle(
         Sig::with_status(state.selections.heading_bug_rad, SignalStatus::Valid),
         state.selections.heading_bug_reference,
         rose,
         state,
+        policy,
     );
 
     PanelData {
@@ -381,6 +387,7 @@ fn nav_resolved(
                 data.course_reference,
                 rose,
                 state,
+                policy,
             );
             NavResolved {
                 data,

--- a/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_signal.rs
@@ -67,17 +67,21 @@ fn usable_variation(
 /// rose (display) reference through the single conversion path. An
 /// unknown reference on either side, or a magnetic/true crossing with
 /// no usable variation, fails this one quantity — it is never drawn
-/// raw on a rose it does not match.
+/// raw on a rose it does not match. Variation freshness is judged by
+/// the RESOLVER'S policy — the same one that judges the heading sample
+/// — so every quantity on the rose agrees on whether the variation is
+/// usable (NAV-02).
 pub(super) fn presented_angle(
     sig: Sig<f32>,
     own: HeadingReference,
     display: HeadingReference,
     state: &AircraftState,
+    policy: &FreshnessPolicy,
 ) -> Sig<f32> {
     if !sig.status.shows_value() {
         return sig;
     }
-    let variation = usable_variation(state, &FreshnessPolicy::default());
+    let variation = usable_variation(state, policy);
     match convert_heading(sig.value, own, display, variation.as_ref()) {
         Ok(value) => Sig::with_status(value, sig.status),
         Err(_) => Sig::with_status(0.0, SignalStatus::Failed),
@@ -91,17 +95,19 @@ pub(super) fn presented_true(
     sig: Sig<f32>,
     display: HeadingReference,
     state: &AircraftState,
+    policy: &FreshnessPolicy,
 ) -> Sig<f32> {
     if !sig.status.shows_value() || display == HeadingReference::Unknown {
         return sig;
     }
-    presented_angle(sig, HeadingReference::True, display, state)
+    presented_angle(sig, HeadingReference::True, display, state, policy)
 }
 
 pub(super) fn presented_wind(
     wind: Sig<Wind>,
     display: HeadingReference,
     state: &AircraftState,
+    policy: &FreshnessPolicy,
 ) -> Sig<Wind> {
     if !wind.status.shows_value() || display == HeadingReference::Unknown {
         return wind;
@@ -110,6 +116,7 @@ pub(super) fn presented_wind(
         Sig::with_status(wind.value.from_rad, wind.status),
         display,
         state,
+        policy,
     );
     if converted.status.shows_value() {
         Sig::with_status(

--- a/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/heading_tests.rs
@@ -288,3 +288,116 @@ fn every_displayed_angle_agrees_on_the_rose_reference() {
         );
     }
 }
+
+// ---- NAV-02 (#65): one freshness policy for every converted quantity ----
+
+/// The magnetic-rose fixture with every group freshly stamped (5 ms) so
+/// a strict policy isolates the VARIATION threshold: no other group's
+/// age can trip first and mask the quantity under test.
+fn magnetic_everything_fresh() -> AircraftState {
+    let mut state = with_variation(
+        with_course(
+            with_bug(
+                with_heading(HeadingReference::Magnetic, 1.0),
+                90.0,
+                HeadingReference::True,
+            ),
+            180.0,
+            HeadingReference::True,
+        ),
+        2.0,
+    );
+    if let Some(kin) = state.kinematics.data.as_mut() {
+        kin.vel_ned_mps = [0.0, 20.0, 0.0];
+    }
+    state.attitude.age_ms = Some(5.0);
+    state.kinematics.age_ms = Some(5.0);
+    state.air.age_ms = Some(5.0);
+    state.nav.age_ms = Some(5.0);
+    state.heading.age_ms = Some(5.0);
+    state.wind = Stamped {
+        data: Some(crate::aircraft::Wind {
+            from_rad: 0.5,
+            speed_mps: 4.0,
+        }),
+        age_ms: Some(5.0),
+    };
+    state
+}
+
+fn converted_statuses(p: &crate::resolve::PanelData) -> [(&'static str, SignalStatus); 4] {
+    [
+        ("track", p.track_rad.status),
+        ("bug", p.heading_bug_rose_rad.status),
+        ("course", p.nav.course_rose_rad.status),
+        ("wind", p.wind.status),
+    ]
+}
+
+#[test]
+fn conversion_freshness_follows_the_resolver_policy_not_the_default() {
+    let mut state = magnetic_everything_fresh();
+    state.variation.age_ms = Some(50.0);
+    // Default policy: a 50 ms variation is fresh — everything converts.
+    let p = resolve(&state, &FreshnessPolicy::default());
+    for (name, status) in converted_statuses(&p) {
+        assert_eq!(status, SignalStatus::Valid, "{name}");
+    }
+    // Strict policy: the SAME variation is failed — every quantity
+    // needing magnetic/true conversion fails with it. A conversion path
+    // still judging by the default thresholds would keep painting here.
+    let strict = FreshnessPolicy::new(10.0, 40.0).expect("valid policy");
+    let p = resolve(&state, &strict);
+    for (name, status) in converted_statuses(&p) {
+        assert_eq!(status, SignalStatus::Failed, "{name}");
+    }
+    assert_eq!(
+        p.heading.value_rad.status,
+        SignalStatus::Valid,
+        "the 5 ms heading sample is fresh under the same strict policy"
+    );
+}
+
+#[test]
+fn heading_and_converted_quantities_share_one_freshness_verdict() {
+    // Under a policy strict enough to fail the 5 ms heading sample,
+    // the heading and every converted quantity fail together — one
+    // policy judges them all, never configuration for one and default
+    // for the others.
+    let state = magnetic_everything_fresh();
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Valid);
+    let harsher = FreshnessPolicy::new(1.0, 4.0).expect("valid policy");
+    let p = resolve(&state, &harsher);
+    assert_eq!(p.heading.value_rad.status, SignalStatus::Failed);
+    for (name, status) in converted_statuses(&p) {
+        assert_eq!(status, SignalStatus::Failed, "{name}");
+    }
+}
+
+#[test]
+fn variation_astride_the_threshold_fails_every_converted_quantity_together() {
+    let policy = FreshnessPolicy::new(10.0, 40.0).expect("valid policy");
+    let mut state = magnetic_everything_fresh();
+
+    // One millisecond inside the fail threshold: stale variation still
+    // shows, so every quantity converts.
+    state.variation.age_ms = Some(39.0);
+    let p = resolve(&state, &policy);
+    for (name, status) in converted_statuses(&p) {
+        assert!(status.shows_value(), "{name}: {status:?}");
+    }
+
+    // One millisecond past it: every converted quantity fails at once —
+    // partial continued display across the same threshold is forbidden.
+    state.variation.age_ms = Some(41.0);
+    let p = resolve(&state, &policy);
+    for (name, status) in converted_statuses(&p) {
+        assert_eq!(status, SignalStatus::Failed, "{name}");
+    }
+    assert_eq!(
+        p.heading.value_rad.status,
+        SignalStatus::Valid,
+        "only conversion-dependent quantities follow the variation"
+    );
+}


### PR DESCRIPTION
Implements #65 (review follow-up from #64 — scoped fix, #21 stays closed). **SIM / NOT FOR FLIGHT.**

## The defect

`presented_angle()` judged magnetic-variation freshness with `FreshnessPolicy::default()` instead of the policy the resolver's caller supplied, so under any non-default policy the heading sample (judged by configuration) and the converted quantities (judged by the default) could disagree about the same variation sample.

## The fix

The resolver's `FreshnessPolicy` is now threaded through `presented_angle`, `presented_true`, and `presented_wind` into `usable_variation`; no conversion path can reach a default policy (grep-clean outside tests).

## Required tests → evidence

| Requirement (#65) | Test |
|---|---|
| Resolver policy, not default, judges conversion | `conversion_freshness_follows_the_resolver_policy_not_the_default` — a 50 ms variation converts under the default policy and fails every converted quantity under a strict custom policy, while the 5 ms heading sample stays valid under both |
| Heading/variation/bug/course/track/wind verdicts consistent under a custom policy | `heading_and_converted_quantities_share_one_freshness_verdict` — a policy harsh enough to fail the heading fails all of them together |
| Variation astride the threshold: all magnetic-conversion quantities fail together | `variation_astride_the_threshold_fails_every_converted_quantity_together` — 39 ms vs 41 ms against a 40 ms fail threshold flips track, bug, course, and wind as one; no partial continued display |

The fixture stamps every other group at 5 ms so the strict policies isolate the variation threshold — no other group's age can trip first and mask the quantity under test.

## Verification

fmt, clippy `-D warnings`, tests across the four instrument crates (26 heading tests), doc, no_std, structure gate, instruments node suite: all green. No ABI, rendering, or hash changes — pure resolution-path plumbing plus tests.

Refs #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)