### PR TITLE
HUD-01 follow-up: capture-to-aircraft-snapshot association

### DIFF
--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -130,6 +130,9 @@ function newSimulatorAvionicsIngress() {
 
 function retireSessionPresentation(phase) {
   instruments.ingress = newSimulatorAvionicsIngress();
+  // Drop the previous session's snapshot history so a new session can never
+  // associate a video frame against a stale snapshot from the old one.
+  snapshotHistory.reset();
   setTelemetrySessionState(els, phase);
 }
 

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -43,6 +43,7 @@ import {
 import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
 import { AvionicsIngress, INCARNATION_POLICY } from "./telemetry-ingress.js";
 import { TransportSessionLifecycle } from "./transport-session.js";
+import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -98,12 +99,18 @@ const state = {
   leaseGranted: false,
   skippedVideoFrames: 0,
   droppedIdentityFrames: 0,
+  // Latest capture-to-snapshot association verdict for an accepted frame
+  // (ADR-0020), a diagnostic surface only — no conformal overlay is drawn yet.
+  lastAssociation: null,
 };
 const transportSessions = new TransportSessionLifecycle();
 // Capture-identity guard for the video downlink: drops duplicate/reordered/
 // stale frames so a replayed frame never displaces a newer one or refreshes
 // its age (ADR-0020).
 const videoIdentity = new VideoIdentityTracker();
+// Bounded history of accepted aircraft snapshots, fed from the telemetry path,
+// against which an accepted video frame's capture time is associated (ADR-0020).
+const snapshotHistory = new SnapshotAssociator();
 
 // Ingestion accepts only source advancement for the selected vehicle. Drawing
 // remains on requestAnimationFrame, decoupled from telemetry publication.
@@ -500,12 +507,13 @@ async function renderVideoFrame(body, token) {
 // (ADR-0020). The capture identity gates the frame through `videoIdentity`: a
 // duplicate, reordered, stale-epoch, or wrong-camera frame is dropped and never
 // blitted, so a replayed frame cannot displace a newer one or refresh its age.
-// Conformal readiness is deliberately NOT evaluated here: the gate must judge a
-// frame against the specific aircraft snapshot it is associated with, and that
-// association (picking the snapshot for a frame at render time) is deferred
-// (#36). Evaluating conformalReady against the latest snapshot would reintroduce
-// the receipt-time conflation this whole change exists to remove, so the render
-// path only enforces capture-identity ordering.
+// Association runs ONLY on a frame the tracker accepted (via
+// `associateIfAccepted`), so a replay can never associate fresh. It finds the
+// aircraft snapshot corresponding to the frame's CAPTURE time; the verdict is a
+// diagnostic surface only, since no conformal overlay is drawn yet. Live, the
+// simulator publishes no recognized calibration and its adapters never pair an
+// available video mapping with an in-domain avionics snapshot, so the verdict
+// stays not-ready — honestly.
 async function renderVideoFrameV2(body, token) {
   if (!transportSessions.isActive(token)) return;
   const parsed = parseVideoFrameV2(body);
@@ -517,17 +525,21 @@ async function renderVideoFrameV2(body, token) {
   const { meta, fourcc, payload } = parsed;
   const target = videoTargetFor(meta.sourceId, fourcc);
   if (!target) return;
-  const verdict = videoIdentity.admit(meta);
-  if (!verdict.accepted) {
+  const { admit, association } = associateIfAccepted(videoIdentity, snapshotHistory, meta);
+  if (!admit.accepted) {
     state.droppedIdentityFrames += 1;
     log(
-      `video frame not admitted (${verdict.reason}) for source ${meta.sourceId} ` +
+      `video frame not admitted (${admit.reason}) for source ${meta.sourceId} ` +
         `seq ${meta.sequence}; dropped (${state.droppedIdentityFrames} identity drops total)`,
     );
     return;
   }
-  if (verdict.discontinuity) {
+  if (admit.discontinuity) {
     log(`video source ${meta.sourceId} capture discontinuity: fresh epoch/incarnation/calibration`);
+  }
+  state.lastAssociation = association;
+  if (!association.ready) {
+    log(`video source ${meta.sourceId} not conformal-ready: ${association.reason}`);
   }
   await paintJpeg(payload, target, token);
 }
@@ -547,6 +559,15 @@ async function readTelemetryDatagrams(transport, token) {
         const t = decoded.message;
         if (t.avionics) {
           instruments.ingress.ingest(t, performance.now());
+          // Feed the association ring from the ACCEPTED snapshot the ingress
+          // exposes (not the raw wire sample), anchored on the kinematics group:
+          // position is what registers world features for a conformal overlay.
+          // A snapshot without kinematics supplies no spatial anchor and is not
+          // observed, so association stays fail-closed for it.
+          const accepted = instruments.ingress.snapshot(performance.now());
+          if (accepted.kinematics) {
+            snapshotHistory.observe(accepted.kinematics.stamp);
+          }
         }
         if (t.vehicleId !== VEHICLE_ID) continue;
         els.telemetry.textContent = formatTelemetrySummary(t);

--- a/clients/web/snapshot-association.js
+++ b/clients/web/snapshot-association.js
@@ -1,0 +1,206 @@
+// Capture-to-aircraft-snapshot association for the viewer (ADR-0020).
+//
+// Given a v2 video frame with a valid clock mapping, this finds the aircraft
+// snapshot that corresponds to the frame's CAPTURE time — never browser receipt
+// time — with a traceable identity and a quantified total error. It OBSERVES
+// the aircraft snapshots main.js has already accepted (it does not gate them;
+// AV-01's ingestion contract in telemetry-ingress.js owns that) and keeps a
+// bounded history ring. Association maps the capture time through the frame's
+// CaptureClockMapping into the snapshot clock domain and selects the nearest
+// snapshot by acquisition time.
+//
+// Everything fails closed: an empty history, a clock-domain mismatch, a nearest
+// snapshot that crosses a source-incarnation discontinuity, or a total error
+// (mapping error bound + association delta) over budget all yield "not ready".
+// The result is finally passed through conformalGate, so the #62 checks
+// (mapping validity, target-clock match, published/recognized calibration,
+// overflow-safe mapped time, error budget) can never be bypassed.
+
+import { conformalGate, mapCaptureTime, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
+
+const CLOCK_VEHICLE_BOOT = 1;
+const CLOCK_SIMULATION = 2;
+const INCARNATION_HEX = /^[0-9a-f]{32}$/;
+
+// History ring size. The mapped capture time of a displayed frame is at most a
+// glass-to-glass latency old (transport + host queue + decode, well under a
+// second in this demo), so a few seconds of snapshots is ample slack. At the
+// simulator's telemetry rate (tens of hertz) 256 entries covers several
+// seconds; overflow drops the oldest (counted), never silently. A power of two
+// keeps the intent obvious rather than implying a tuned value.
+export const DEFAULT_HISTORY_CAPACITY = 256;
+
+/** Reason an association was or was not produced, for logging and diagnostics. */
+export const ASSOCIATION = Object.freeze({
+  READY: "ready",
+  MAPPING_UNAVAILABLE: "mapping-unavailable",
+  MAPPED_TIME_OVERFLOW: "mapped-time-overflow",
+  EMPTY_HISTORY: "empty-history",
+  CLOCK_MISMATCH: "clock-mismatch",
+  INCARNATION_DISCONTINUITY: "incarnation-discontinuity",
+  TOTAL_ERROR_EXCEEDS_BUDGET: "total-error-exceeds-budget",
+  NOT_ADMITTED: "not-admitted",
+});
+
+function isSnapshotIdentityValid(id) {
+  return (
+    id !== null &&
+    typeof id === "object" &&
+    typeof id.sourceIncarnation === "string" &&
+    INCARNATION_HEX.test(id.sourceIncarnation) &&
+    Number.isInteger(id.sourceEpoch) &&
+    Number.isInteger(id.sequence) &&
+    typeof id.acquiredAtNanos === "bigint" &&
+    id.acquiredAtNanos >= 0n &&
+    (id.clock === CLOCK_VEHICLE_BOOT || id.clock === CLOCK_SIMULATION)
+  );
+}
+
+function identityOf(id) {
+  return Object.freeze({
+    sourceId: id.sourceId,
+    sourceIncarnation: id.sourceIncarnation,
+    sourceEpoch: id.sourceEpoch,
+    sequence: id.sequence,
+    acquiredAtNanos: id.acquiredAtNanos,
+    clock: id.clock,
+  });
+}
+
+function sameIdentity(a, b) {
+  return (
+    a.sourceIncarnation === b.sourceIncarnation &&
+    a.sourceEpoch === b.sourceEpoch &&
+    a.sequence === b.sequence &&
+    a.acquiredAtNanos === b.acquiredAtNanos &&
+    a.clock === b.clock
+  );
+}
+
+function absDiff(a, b) {
+  return a >= b ? a - b : b - a;
+}
+
+function closed(reason) {
+  return Object.freeze({
+    ready: false,
+    snapshotIdentity: null,
+    mappedCaptureNanos: null,
+    totalErrorNanos: null,
+    reason,
+  });
+}
+
+/**
+ * Bounded history of accepted aircraft snapshots and the association logic over
+ * it. `observe` records one accepted snapshot's AV-01 identity; `associate`
+ * finds the snapshot corresponding to a frame's capture time.
+ */
+export class SnapshotAssociator {
+  constructor({ capacity = DEFAULT_HISTORY_CAPACITY } = {}) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new TypeError("capacity must be a positive integer");
+    }
+    this.capacity = capacity;
+    this.entries = [];
+    this.currentIncarnation = null;
+    this.counters = { observed: 0, deduped: 0, dropped: 0, invalid: 0 };
+  }
+
+  /** Records one accepted snapshot identity, oldest-first. Consecutive
+   *  duplicates are ignored (main.js re-reads the accepted snapshot each
+   *  telemetry frame); overflow drops the oldest entry and is counted. */
+  observe(identity) {
+    if (!isSnapshotIdentityValid(identity)) {
+      this.bump("invalid");
+      return false;
+    }
+    const entry = identityOf(identity);
+    const newest = this.entries[this.entries.length - 1];
+    if (newest && sameIdentity(newest, entry)) {
+      this.bump("deduped");
+      return false;
+    }
+    this.entries.push(entry);
+    this.currentIncarnation = entry.sourceIncarnation;
+    this.bump("observed");
+    if (this.entries.length > this.capacity) {
+      this.entries.shift();
+      this.bump("dropped");
+    }
+    return true;
+  }
+
+  /**
+   * Associates a frame's capture time with the nearest accepted snapshot.
+   * Returns a verdict `{ ready, snapshotIdentity, mappedCaptureNanos,
+   * totalErrorNanos, reason }`. Fails closed; the `reason` is one of
+   * [`ASSOCIATION`]. The budget boundary is inclusive: a total error exactly
+   * equal to the budget is within budget.
+   */
+  associate(meta, options = {}) {
+    const budget = options.maxClockErrorNanos ?? DEFAULT_MAX_CLOCK_ERROR_NANOS;
+    if (!meta || meta.mappingAvailable !== true) return closed(ASSOCIATION.MAPPING_UNAVAILABLE);
+    const mapped = mapCaptureTime(meta.captureTimeNanos, meta.mappingOffsetNanos);
+    if (mapped === null) return closed(ASSOCIATION.MAPPED_TIME_OVERFLOW);
+    if (this.entries.length === 0) return closed(ASSOCIATION.EMPTY_HISTORY);
+    const candidates = this.entries.filter((e) => e.clock === meta.mappingTargetClock);
+    if (candidates.length === 0) return closed(ASSOCIATION.CLOCK_MISMATCH);
+
+    let nearest = null;
+    let bestDelta = null;
+    for (const entry of candidates) {
+      const delta = absDiff(entry.acquiredAtNanos, mapped);
+      if (bestDelta === null || delta < bestDelta) {
+        bestDelta = delta;
+        nearest = entry;
+      }
+    }
+    // A snapshot from a superseded source incarnation cannot anchor a conformal
+    // association: the estimator restarted between that snapshot and now.
+    if (nearest.sourceIncarnation !== this.currentIncarnation) {
+      return closed(ASSOCIATION.INCARNATION_DISCONTINUITY);
+    }
+
+    const totalError = meta.clockErrorBoundNanos + bestDelta;
+    const snapshotIdentity = identityOf(nearest);
+    if (totalError > budget) {
+      return this.verdict(false, snapshotIdentity, mapped, totalError, ASSOCIATION.TOTAL_ERROR_EXCEEDS_BUDGET);
+    }
+    // The #62 gate is the final authority: it re-checks mapping validity, the
+    // target-clock match against the associated snapshot, the calibration, and
+    // the mapping's own error bound. Association never bypasses it.
+    const gate = conformalGate(meta, snapshotIdentity, options);
+    if (!gate.conformalReady) {
+      return this.verdict(false, snapshotIdentity, mapped, totalError, `gate-closed:${gate.reason}`);
+    }
+    return this.verdict(true, snapshotIdentity, mapped, totalError, ASSOCIATION.READY);
+  }
+
+  verdict(ready, snapshotIdentity, mappedCaptureNanos, totalErrorNanos, reason) {
+    return Object.freeze({ ready, snapshotIdentity, mappedCaptureNanos, totalErrorNanos, reason });
+  }
+
+  diagnostics() {
+    return Object.freeze({ ...this.counters, size: this.entries.length });
+  }
+
+  bump(name, amount = 1) {
+    this.counters[name] = (this.counters[name] + amount) >>> 0;
+  }
+}
+
+/**
+ * The single admission-then-association path. Association runs ONLY on a frame
+ * the identity tracker accepted, so a duplicate, reordered, or stale-epoch frame
+ * (which the tracker rejects) can never produce a fresh association. Returns
+ * `{ accepted, admit, association }`; `association` is `null` when the frame was
+ * not admitted, else the associator's verdict.
+ */
+export function associateIfAccepted(tracker, associator, meta, options = {}) {
+  const admit = tracker.admit(meta);
+  if (!admit.accepted) {
+    return Object.freeze({ accepted: false, admit, association: closed(ASSOCIATION.NOT_ADMITTED) });
+  }
+  return Object.freeze({ accepted: true, admit, association: associator.associate(meta, options) });
+}

--- a/clients/web/snapshot-association.js
+++ b/clients/web/snapshot-association.js
@@ -9,12 +9,19 @@
 // CaptureClockMapping into the snapshot clock domain and selects the nearest
 // snapshot by acquisition time.
 //
-// Everything fails closed: an empty history, a clock-domain mismatch, a nearest
-// snapshot that crosses a source-incarnation discontinuity, or a total error
-// (mapping error bound + association delta) over budget all yield "not ready".
-// The result is finally passed through conformalGate, so the #62 checks
-// (mapping validity, target-clock match, published/recognized calibration,
-// overflow-safe mapped time, error budget) can never be bypassed.
+// The current aircraft stream is identified by the full AV-01 tuple
+// (sourceId + sourceIncarnation + sourceEpoch). Only snapshots from that stream
+// are eligible: if the nearest snapshot by time belongs to a superseded source,
+// incarnation, or epoch, the association is an explicit discontinuity, never a
+// ready verdict — a snapshot from before a source switch or an epoch reset can
+// never anchor a conformal overlay even when it is closest in time.
+//
+// Everything fails closed: an empty history, a clock-domain mismatch, a
+// stream-identity discontinuity, or a total error (mapping error bound +
+// association delta) over budget all yield "not ready". The result is finally
+// passed through conformalGate, so its checks (mapping validity, target-clock
+// match, published/recognized calibration, overflow-safe mapped time, error
+// budget) can never be bypassed.
 
 import { conformalGate, mapCaptureTime, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
 
@@ -37,7 +44,7 @@ export const ASSOCIATION = Object.freeze({
   MAPPED_TIME_OVERFLOW: "mapped-time-overflow",
   EMPTY_HISTORY: "empty-history",
   CLOCK_MISMATCH: "clock-mismatch",
-  INCARNATION_DISCONTINUITY: "incarnation-discontinuity",
+  STREAM_DISCONTINUITY: "stream-discontinuity",
   TOTAL_ERROR_EXCEEDS_BUDGET: "total-error-exceeds-budget",
   NOT_ADMITTED: "not-admitted",
 });
@@ -46,6 +53,7 @@ function isSnapshotIdentityValid(id) {
   return (
     id !== null &&
     typeof id === "object" &&
+    (typeof id.sourceId === "bigint" || Number.isInteger(id.sourceId)) &&
     typeof id.sourceIncarnation === "string" &&
     INCARNATION_HEX.test(id.sourceIncarnation) &&
     Number.isInteger(id.sourceEpoch) &&
@@ -67,8 +75,30 @@ function identityOf(id) {
   });
 }
 
+// The stream identity: the AV-01 tuple that must be continuous for a snapshot
+// to anchor the same conformal timeline. A change in any of sourceId (a
+// different source), sourceIncarnation (a source restart), or sourceEpoch (an
+// epoch reset) begins a new stream.
+function streamOf(id) {
+  return Object.freeze({
+    sourceId: id.sourceId,
+    sourceIncarnation: id.sourceIncarnation,
+    sourceEpoch: id.sourceEpoch,
+  });
+}
+
+function sameStream(id, stream) {
+  return (
+    stream !== null &&
+    id.sourceId === stream.sourceId &&
+    id.sourceIncarnation === stream.sourceIncarnation &&
+    id.sourceEpoch === stream.sourceEpoch
+  );
+}
+
 function sameIdentity(a, b) {
   return (
+    a.sourceId === b.sourceId &&
     a.sourceIncarnation === b.sourceIncarnation &&
     a.sourceEpoch === b.sourceEpoch &&
     a.sequence === b.sequence &&
@@ -103,13 +133,14 @@ export class SnapshotAssociator {
     }
     this.capacity = capacity;
     this.entries = [];
-    this.currentIncarnation = null;
+    this.currentStream = null;
     this.counters = { observed: 0, deduped: 0, dropped: 0, invalid: 0 };
   }
 
-  /** Records one accepted snapshot identity, oldest-first. Consecutive
-   *  duplicates are ignored (main.js re-reads the accepted snapshot each
-   *  telemetry frame); overflow drops the oldest entry and is counted. */
+  /** Records one accepted snapshot identity, oldest-first, and adopts its
+   *  stream as the current one. Consecutive duplicates are ignored (main.js
+   *  re-reads the accepted snapshot each telemetry frame); overflow drops the
+   *  oldest entry and is counted. */
   observe(identity) {
     if (!isSnapshotIdentityValid(identity)) {
       this.bump("invalid");
@@ -122,13 +153,21 @@ export class SnapshotAssociator {
       return false;
     }
     this.entries.push(entry);
-    this.currentIncarnation = entry.sourceIncarnation;
+    this.currentStream = streamOf(entry);
     this.bump("observed");
     if (this.entries.length > this.capacity) {
       this.entries.shift();
       this.bump("dropped");
     }
     return true;
+  }
+
+  /** Clears the history and current stream. main.js calls this on a
+   *  transport/session reset so a new session can never associate a frame
+   *  against a snapshot the previous session left in the ring. */
+  reset() {
+    this.entries = [];
+    this.currentStream = null;
   }
 
   /**
@@ -156,10 +195,12 @@ export class SnapshotAssociator {
         nearest = entry;
       }
     }
-    // A snapshot from a superseded source incarnation cannot anchor a conformal
-    // association: the estimator restarted between that snapshot and now.
-    if (nearest.sourceIncarnation !== this.currentIncarnation) {
-      return closed(ASSOCIATION.INCARNATION_DISCONTINUITY);
+    // The nearest snapshot by time must belong to the current stream. If it is
+    // from a superseded source, incarnation, or epoch, the aircraft identity
+    // changed between that snapshot and now, so no ready association is
+    // possible — even though it is closest in time.
+    if (!sameStream(nearest, this.currentStream)) {
+      return closed(ASSOCIATION.STREAM_DISCONTINUITY);
     }
 
     const totalError = meta.clockErrorBoundNanos + bestDelta;
@@ -167,7 +208,7 @@ export class SnapshotAssociator {
     if (totalError > budget) {
       return this.verdict(false, snapshotIdentity, mapped, totalError, ASSOCIATION.TOTAL_ERROR_EXCEEDS_BUDGET);
     }
-    // The #62 gate is the final authority: it re-checks mapping validity, the
+    // conformalGate is the final authority: it re-checks mapping validity, the
     // target-clock match against the associated snapshot, the calibration, and
     // the mapping's own error bound. Association never bypasses it.
     const gate = conformalGate(meta, snapshotIdentity, options);

--- a/clients/web/snapshot-association.test.mjs
+++ b/clients/web/snapshot-association.test.mjs
@@ -130,7 +130,50 @@ function frameMeta(overrides = {}) {
   a.observe(snapId({ sourceIncarnation: INC_B, acquiredAtNanos: 5000n }));
   const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
   check("incarnation discontinuity is not ready", v.ready === false);
-  check("incarnation discontinuity reason is reported", v.reason === ASSOCIATION.INCARNATION_DISCONTINUITY);
+  check("incarnation discontinuity reason is reported", v.reason === ASSOCIATION.STREAM_DISCONTINUITY);
+}
+
+// (a) Same source and incarnation, epoch increments (a reset within one
+// attachment): a snapshot from the OLD epoch that is closer in time is not
+// selected — the stream is identified by sourceId + incarnation + epoch.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sourceEpoch: 0, acquiredAtNanos: 1000n }));
+  a.observe(snapId({ sourceEpoch: 1, acquiredAtNanos: 5000n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("epoch reset: old-epoch nearest snapshot is not selected", v.ready === false && v.reason === ASSOCIATION.STREAM_DISCONTINUITY);
+  check("epoch reset: no old-epoch snapshot identity is returned", v.snapshotIdentity === null);
+}
+
+// (b) After a source switch, the old source is never selected even when nearest.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sourceId: 10n, acquiredAtNanos: 1000n }));
+  a.observe(snapId({ sourceId: 20n, acquiredAtNanos: 5000n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("source switch: old source is never selected", v.ready === false && v.reason === ASSOCIATION.STREAM_DISCONTINUITY);
+  check("source switch: no old-source snapshot identity is returned", v.snapshotIdentity === null);
+}
+
+// (c) Two identities differing ONLY in sourceId must not be deduped.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sourceId: 10n, acquiredAtNanos: 1000n }));
+  const second = a.observe(snapId({ sourceId: 20n, acquiredAtNanos: 1000n }));
+  check("differing sourceId is not deduped", second === true);
+  check("both distinct-source snapshots are retained", a.diagnostics().size === 2 && a.diagnostics().deduped === 0);
+}
+
+// (d) After a transport/session reset, the old session's history cannot produce
+// a ready verdict.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 1000n }));
+  const before = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("pre-reset frame would be ready", before.ready === true);
+  a.reset();
+  const after = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("after session reset the old session yields no ready verdict", after.ready === false && after.reason === ASSOCIATION.EMPTY_HISTORY);
 }
 
 // Budget boundary is inclusive: a total error exactly at the budget is ready,

--- a/clients/web/snapshot-association.test.mjs
+++ b/clients/web/snapshot-association.test.mjs
@@ -1,0 +1,229 @@
+// Behavioral checks for capture-to-aircraft-snapshot association (ADR-0020).
+//
+// Run: node clients/web/snapshot-association.test.mjs
+
+import {
+  SnapshotAssociator,
+  associateIfAccepted,
+  ASSOCIATION,
+  DEFAULT_HISTORY_CAPACITY,
+} from "./snapshot-association.js";
+import { VideoIdentityTracker, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const INC_A = "aa".repeat(16);
+const INC_B = "bb".repeat(16);
+const CLOCK_VEHICLE_BOOT = 1;
+const CLOCK_SIMULATION = 2;
+const RECOGNIZED = { recognizedCalibrations: new Set([7]) };
+
+// One accepted aircraft snapshot's AV-01 identity (kinematics-anchored). The
+// snapshot clock is the flight-state clock (vehicle-boot) the video mapping
+// targets.
+function snapId(overrides = {}) {
+  return {
+    sourceId: 10n,
+    sourceIncarnation: INC_A,
+    sourceEpoch: 0,
+    sequence: 0,
+    acquiredAtNanos: 1000n,
+    clock: CLOCK_VEHICLE_BOOT,
+    ...overrides,
+  };
+}
+
+// A parsed v2 video frame: capture on the sim clock, mapped into the vehicle-
+// boot flight clock. Carries both the tracker-identity fields and the mapping
+// fields, so it works with associate() and associateIfAccepted().
+function frameMeta(overrides = {}) {
+  return {
+    sourceId: 0,
+    sourceEpoch: 0,
+    sourceIncarnation: INC_B,
+    sequence: 0,
+    captureTimeNanos: 1000n,
+    captureClock: CLOCK_SIMULATION,
+    cameraId: 0,
+    calibrationId: 7,
+    mappingAvailable: true,
+    mappingTargetClock: CLOCK_VEHICLE_BOOT,
+    mappingOffsetNanos: 0n,
+    clockErrorBoundNanos: 0n,
+    ...overrides,
+  };
+}
+
+// Exact-match association: capture time maps onto a snapshot's acquisition time.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("exact match is ready", v.ready === true && v.reason === ASSOCIATION.READY);
+  check("exact match selects the snapshot", v.snapshotIdentity.acquiredAtNanos === 1000n);
+  check("exact match maps the capture time", v.mappedCaptureNanos === 1000n);
+  check("exact match has zero total error", v.totalErrorNanos === 0n);
+}
+
+// Nearest-selection among several snapshots.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+  a.observe(snapId({ sequence: 2, acquiredAtNanos: 2000n }));
+  a.observe(snapId({ sequence: 3, acquiredAtNanos: 3000n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: 2100n }), RECOGNIZED);
+  check("nearest selection picks the closest snapshot", v.snapshotIdentity.sequence === 2);
+  check("nearest selection reports the association delta as total error", v.totalErrorNanos === 100n);
+  check("nearest selection is ready within budget", v.ready === true);
+}
+
+// Fail-closed: empty history.
+{
+  const v = new SnapshotAssociator().associate(frameMeta(), RECOGNIZED);
+  check("empty history is not ready", v.ready === false && v.reason === ASSOCIATION.EMPTY_HISTORY);
+}
+
+// Fail-closed: no snapshot in the mapping's target clock domain.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ clock: CLOCK_VEHICLE_BOOT, acquiredAtNanos: 1000n }));
+  const v = a.associate(frameMeta({ mappingTargetClock: CLOCK_SIMULATION }), RECOGNIZED);
+  check("clock-domain mismatch is not ready", v.ready === false && v.reason === ASSOCIATION.CLOCK_MISMATCH);
+}
+
+// Fail-closed: nearest snapshot outside budget (total error = bound + delta).
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 0n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: DEFAULT_MAX_CLOCK_ERROR_NANOS + 1000n }), RECOGNIZED);
+  check("nearest outside budget is not ready", v.ready === false);
+  check("over-budget reason is reported", v.reason === ASSOCIATION.TOTAL_ERROR_EXCEEDS_BUDGET);
+  check("over-budget still reports the mapped time and total error", v.mappedCaptureNanos !== null && v.totalErrorNanos !== null);
+}
+
+// Total error combines the mapping's error bound with the association delta:
+// each alone is within budget, together they exceed it.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 1000n }));
+  const bound = DEFAULT_MAX_CLOCK_ERROR_NANOS - 100n;
+  const v = a.associate(
+    frameMeta({ captureTimeNanos: 1200n, clockErrorBoundNanos: bound }),
+    RECOGNIZED,
+  );
+  check("total error sums bound and delta", v.totalErrorNanos === bound + 200n);
+  check("summed error over budget is not ready", v.ready === false && v.reason === ASSOCIATION.TOTAL_ERROR_EXCEEDS_BUDGET);
+}
+
+// Fail-closed: the nearest snapshot is from a superseded source incarnation.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sourceIncarnation: INC_A, acquiredAtNanos: 1000n }));
+  a.observe(snapId({ sourceIncarnation: INC_B, acquiredAtNanos: 5000n }));
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("incarnation discontinuity is not ready", v.ready === false);
+  check("incarnation discontinuity reason is reported", v.reason === ASSOCIATION.INCARNATION_DISCONTINUITY);
+}
+
+// Budget boundary is inclusive: a total error exactly at the budget is ready,
+// one nanosecond over is not.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 0n }));
+  const atBudget = a.associate(
+    frameMeta({ captureTimeNanos: DEFAULT_MAX_CLOCK_ERROR_NANOS }),
+    RECOGNIZED,
+  );
+  check("total error exactly at budget is ready (inclusive)", atBudget.ready === true);
+  check("at-budget total error is the budget", atBudget.totalErrorNanos === DEFAULT_MAX_CLOCK_ERROR_NANOS);
+
+  const overBudget = a.associate(
+    frameMeta({ captureTimeNanos: DEFAULT_MAX_CLOCK_ERROR_NANOS + 1n }),
+    RECOGNIZED,
+  );
+  check("one nanosecond over budget is not ready", overBudget.ready === false);
+}
+
+// The ring is bounded: overflow drops the oldest entry and counts it.
+{
+  const a = new SnapshotAssociator({ capacity: 2 });
+  a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+  a.observe(snapId({ sequence: 2, acquiredAtNanos: 2000n }));
+  a.observe(snapId({ sequence: 3, acquiredAtNanos: 3000n }));
+  check("overflow drops the oldest, counted", a.diagnostics().dropped === 1);
+  check("ring holds only the capacity", a.diagnostics().size === 2);
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n }), RECOGNIZED);
+  check("the dropped oldest snapshot is gone", v.snapshotIdentity.sequence !== 1);
+}
+
+// Consecutive identical snapshots are deduped (main.js re-reads the accepted
+// snapshot each telemetry frame).
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+  const second = a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+  check("consecutive identical snapshot is deduped", second === false && a.diagnostics().deduped === 1);
+  check("dedup keeps one entry", a.diagnostics().size === 1);
+}
+
+// The association is finally passed through conformalGate: an unrecognized
+// calibration closes the gate even when the snapshot distance and clock are fine.
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 1000n }));
+  // No recognized-calibration option: the sim's default fail-closed set.
+  const v = a.associate(frameMeta({ captureTimeNanos: 1000n, calibrationId: 7 }));
+  check("unrecognized calibration closes the wrapped gate", v.ready === false);
+  check("gate-closed reason is surfaced", v.reason === "gate-closed:calibration-unavailable");
+  check("gate-closed still reports the associated snapshot", v.snapshotIdentity.acquiredAtNanos === 1000n);
+}
+
+// A malformed snapshot identity is rejected without entering the ring.
+{
+  const a = new SnapshotAssociator();
+  check("malformed snapshot is not observed", a.observe(snapId({ sourceIncarnation: "nothex" })) === false);
+  check("malformed snapshot is counted", a.diagnostics().invalid === 1 && a.diagnostics().size === 0);
+}
+
+// End-to-end: a tracker-accepted frame associates to the correct snapshot with a
+// quantified total error.
+{
+  const tracker = new VideoIdentityTracker();
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sequence: 4, acquiredAtNanos: 1000n }));
+  const meta = frameMeta({ sequence: 1, captureTimeNanos: 1000n, clockErrorBoundNanos: 100n });
+  const res = associateIfAccepted(tracker, a, meta, RECOGNIZED);
+  check("end-to-end: frame is admitted", res.accepted === true);
+  check("end-to-end: association is ready", res.association.ready === true);
+  check("end-to-end: correct snapshot identity", res.association.snapshotIdentity.acquiredAtNanos === 1000n);
+  check("end-to-end: quantified total error (bound + delta)", res.association.totalErrorNanos === 100n);
+}
+
+// A replayed (duplicate) frame is rejected by the tracker, so it never produces
+// a fresh association.
+{
+  const tracker = new VideoIdentityTracker();
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ acquiredAtNanos: 1000n }));
+  const first = associateIfAccepted(tracker, a, frameMeta({ sequence: 5, captureTimeNanos: 1000n }), RECOGNIZED);
+  check("first frame is admitted and associated", first.accepted === true && first.association.ready === true);
+  const replay = associateIfAccepted(tracker, a, frameMeta({ sequence: 5, captureTimeNanos: 1000n }), RECOGNIZED);
+  check("replayed frame is not admitted", replay.accepted === false);
+  check("replayed frame produces no fresh association", replay.association.ready === false && replay.association.reason === ASSOCIATION.NOT_ADMITTED);
+}
+
+check("default history capacity is documented and positive", Number.isInteger(DEFAULT_HISTORY_CAPACITY) && DEFAULT_HISTORY_CAPACITY > 0);
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall snapshot association checks passed");

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -32,7 +32,7 @@ export const DEFAULT_RECOGNIZED_CALIBRATIONS = Object.freeze(new Set());
 /** Applies a mapping offset to a capture time, refusing (returns `null`) when
  *  the signed offset would carry the result outside the u64 nanosecond range,
  *  rather than wrapping into a plausible-looking but wrong time. */
-function mapCaptureTime(captureTimeNanos, offsetNanos) {
+export function mapCaptureTime(captureTimeNanos, offsetNanos) {
   if (typeof captureTimeNanos !== "bigint" || typeof offsetNanos !== "bigint") return null;
   const mapped = captureTimeNanos + offsetNanos;
   if (mapped < 0n || mapped > U64_MAX) return null;

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -9,6 +9,11 @@ import {
   ADMIT,
   DEFAULT_MAX_CLOCK_ERROR_NANOS,
 } from "./video-identity.js";
+import {
+  SnapshotAssociator,
+  associateIfAccepted,
+  ASSOCIATION,
+} from "./snapshot-association.js";
 
 let failures = 0;
 function check(name, cond) {
@@ -293,6 +298,30 @@ check(
   "gate with no candidate snapshot is closed",
   conformalGate(meta({ mappingAvailable: true, calibrationId: 7 }), null, RECOGNIZED).conformalReady === false,
 );
+
+// The tracker verdict gates association: a frame the tracker rejects (here a
+// stale epoch) never reaches the associator, so it cannot associate fresh.
+{
+  const tracker = new VideoIdentityTracker();
+  const associator = new SnapshotAssociator();
+  associator.observe({
+    sourceId: 10n,
+    sourceIncarnation: "aa".repeat(16),
+    sourceEpoch: 0,
+    sequence: 0,
+    acquiredAtNanos: 1000n,
+    clock: CLOCK_SIMULATION,
+  });
+  tracker.admit(meta({ sourceEpoch: 5, sequence: 0 }));
+  const stale = associateIfAccepted(
+    tracker,
+    associator,
+    meta({ sourceEpoch: 4, sequence: 9, mappingTargetClock: CLOCK_SIMULATION }),
+    RECOGNIZED,
+  );
+  check("tracker-rejected frame is not admitted", stale.accepted === false);
+  check("tracker-rejected frame does not associate", stale.association.reason === ASSOCIATION.NOT_ADMITTED);
+}
 
 if (failures > 0) {
   console.error(`\n${failures} check(s) failed`);

--- a/docs/adr/0020-video-capture-identity-and-clock-mapping.md
+++ b/docs/adr/0020-video-capture-identity-and-clock-mapping.md
@@ -90,12 +90,22 @@ property of the integration, not something a consumer may assume.
   prerequisite for a HUD-SIM overlay, NOT an airborne HUD capability, and is NOT
   FOR FLIGHT.
 
-- **Deferred:** actual capture-to-snapshot *association* — selecting, at render
-  time, the specific aircraft snapshot a given frame corresponds to — is not
-  implemented in this change. The gate is the mechanism that association will
-  use; the browser deliberately does not evaluate conformal readiness against
-  the latest snapshot, which would reintroduce the receipt-time conflation this
-  ADR exists to remove.
+- The browser performs **capture-to-snapshot association**
+  (`snapshot-association.js`). It observes the aircraft snapshots the AV-01
+  ingestion has already accepted — it does not gate them — into a bounded
+  history ring, each entry carrying the snapshot's `MeasurementStamp` identity.
+  Given an accepted video frame, it maps the capture time through the frame's
+  mapping into the snapshot clock domain and selects the **nearest snapshot by
+  acquisition time**. The result is a typed verdict carrying the associated
+  snapshot identity, the mapped capture time, and a **total error** (the
+  mapping's error bound plus the association delta). It fails closed: an empty
+  history, a clock-domain mismatch, a nearest snapshot from a superseded source
+  incarnation, or a total error over budget all yield "not ready". Association
+  runs only on frames the identity tracker accepted (so a replay never
+  associates fresh), and the verdict is finally passed through `conformalGate`,
+  so the calibration/clock/mapping checks can never be bypassed. The browser
+  never associates against the *latest* snapshot by receipt — only by capture
+  time — which is the whole point of this ADR.
 
 ## Consequences
 

--- a/docs/adr/0020-video-capture-identity-and-clock-mapping.md
+++ b/docs/adr/0020-video-capture-identity-and-clock-mapping.md
@@ -96,16 +96,23 @@ property of the integration, not something a consumer may assume.
   history ring, each entry carrying the snapshot's `MeasurementStamp` identity.
   Given an accepted video frame, it maps the capture time through the frame's
   mapping into the snapshot clock domain and selects the **nearest snapshot by
-  acquisition time**. The result is a typed verdict carrying the associated
-  snapshot identity, the mapped capture time, and a **total error** (the
-  mapping's error bound plus the association delta). It fails closed: an empty
-  history, a clock-domain mismatch, a nearest snapshot from a superseded source
-  incarnation, or a total error over budget all yield "not ready". Association
-  runs only on frames the identity tracker accepted (so a replay never
-  associates fresh), and the verdict is finally passed through `conformalGate`,
-  so the calibration/clock/mapping checks can never be bypassed. The browser
-  never associates against the *latest* snapshot by receipt — only by capture
-  time — which is the whole point of this ADR.
+  acquisition time**. The current aircraft stream is identified by the full
+  AV-01 tuple `source_id + source_incarnation + source_epoch`; only snapshots
+  from that stream are eligible, so a nearest snapshot from a different source,
+  a superseded incarnation, or an old epoch (e.g. one that survives in the ring
+  after an epoch reset) yields an explicit stream discontinuity, never a ready
+  association — even when it is closest in time. The result is a typed verdict
+  carrying the associated snapshot identity, the mapped capture time, and a
+  **total error** (the mapping's error bound plus the association delta). It
+  fails closed: an empty history, a clock-domain mismatch, a stream-identity
+  discontinuity, or a total error over budget all yield "not ready".
+  Association runs only on frames the identity tracker accepted (so a replay
+  never associates fresh), the history is dropped on a transport/session reset
+  so a new session cannot associate against the old one, and the verdict is
+  finally passed through `conformalGate`, so the calibration/clock/mapping
+  checks can never be bypassed. The browser never associates against the
+  *latest* snapshot by receipt — only by capture time — which is the whole
+  point of this ADR.
 
 ## Consequences
 


### PR DESCRIPTION
## HUD-01 follow-up: capture-to-aircraft-snapshot association

**SIM / NOT FOR FLIGHT.** This is the remaining #36 / HUD-01 association scope — the piece PR #62 deferred. Given an accepted v2 video frame with a valid clock mapping, it finds the aircraft snapshot corresponding to the frame's **capture** time (never browser receipt time), with a traceable identity and a quantified total error. No conformal overlay is drawn — the verdict is a diagnostic surface. Makes no certification claim.

Refs #36 (does not close the issue).

### Stream continuity (this revision's fix)

The associator now keys continuity on the **full AV-01 stream tuple `source_id + source_incarnation + source_epoch`**, not just the incarnation. Before nearest-selection produces a ready verdict, the nearest snapshot must belong to the current stream; a nearest snapshot from a different source, a superseded incarnation, or an **old epoch** (e.g. one still in the ring after an epoch reset) returns an explicit `STREAM_DISCONTINUITY` verdict — never a ready association — even when it is closest in time. `sameIdentity()` now compares `sourceId`, so snapshots from different sources are never misjudged as duplicates. `SnapshotAssociator.reset()` drops the history on a transport/session retire (wired into `main.js`) so a new session cannot associate against the previous one's snapshots.

### Design decisions

- **History ring size: `DEFAULT_HISTORY_CAPACITY = 256`** — a few seconds of snapshots at the simulator's telemetry rate; overflow drops the oldest, counted.
- **Budget boundary: inclusive** — a total error exactly at the budget is ready; one nanosecond over is not.
- **Association anchor: the kinematics group** — position registers world features; a snapshot without kinematics supplies no spatial anchor and is not observed.

### How it works

`SnapshotAssociator` observes the AV-01-accepted snapshots (it does not gate them) into a bounded ring keyed on the stream tuple. `associate(meta)` maps the frame's capture time through its mapping into the snapshot clock domain, selects the nearest snapshot by acquisition time, requires it to be in the current stream, computes **total error = mapping error bound + association delta**, and passes the result through `conformalGate` so the calibration/clock/mapping checks are never bypassed. `associateIfAccepted` is the single admission-then-association path: association runs only on frames the identity tracker accepted, so a replay never associates fresh.

### Acceptance criteria → evidence

| Criterion | Evidence (test in `snapshot-association.test.mjs` unless noted) |
|---|---|
| Bounded ring; overflow drops oldest, counted; dedup | "overflow drops the oldest, counted", "ring holds only the capacity", "consecutive identical snapshot is deduped" |
| Entry carries AV-01 identity; nearest-by-acquisition selection | "exact match selects the snapshot", "nearest selection picks the closest snapshot" |
| Total error = mapping bound + association delta, within budget | "nearest selection reports the association delta as total error", "total error sums bound and delta" |
| Fail-closed: empty history / clock mismatch / over budget | "empty history is not ready", "clock-domain mismatch is not ready", "nearest outside budget is not ready" |
| **Full stream continuity — epoch reset: old-epoch nearest not selected** | **"epoch reset: old-epoch nearest snapshot is not selected", "epoch reset: no old-epoch snapshot identity is returned"** |
| **Full stream continuity — source switch: old source never selected** | **"source switch: old source is never selected", "source switch: no old-source snapshot identity is returned"** |
| **Dedup uses `sourceId` — identities differing only in sourceId not deduped** | **"differing sourceId is not deduped", "both distinct-source snapshots are retained"** |
| **Session reset — old session yields no ready verdict** | **"after session reset the old session yields no ready verdict"** |
| Budget boundary decided & documented (inclusive) | "total error exactly at budget is ready (inclusive)", "one nanosecond over budget is not ready" |
| Replayed/duplicate frame must not associate fresh | "replayed frame produces no fresh association"; `video-identity.test.mjs` "tracker-rejected frame does not associate" |
| conformalGate consumed; its checks not bypassed | "unrecognized calibration closes the wrapped gate", "gate-closed reason is surfaced" |
| End-to-end: accepted frame + populated ring + valid mapping + recognized calibration → ready with correct snapshot identity and quantified total error | "end-to-end: association is ready", "end-to-end: correct snapshot identity", "end-to-end: quantified total error (bound + delta)" |

### Live status (for #36 closure)

The mechanism is complete and wired into `main.js` (fed from the telemetry path, verdict exposed as a diagnostic), but live it stays not-ready: the simulator publishes no recognized calibration, and its adapters never pair an available video mapping with an in-domain avionics snapshot (Gazebo has the sim mapping but no avionics; Aviate has avionics on the vehicle-boot clock but an `Unavailable` video mapping). No overlay is drawn; the path is exercised end-to-end by tests with synthetic data.

### Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets`, `cargo doc` (`-D missing_docs`, `-D rustdoc::broken_intra_doc_links`), `cargo build --release`, and `scripts/check-structure.sh` all pass. `node clients/web/snapshot-association.test.mjs`, `video-identity.test.mjs`, and `wire.test.mjs` pass, as do the untouched suites (instruments, telemetry-display, telemetry-ingress, transport-session, scene-conformance). Browser-side + ADR only; no Rust source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
