### PR TITLE
DYN-01: typed turn basis and slip/skid — body yaw rate has no path to the display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,15 @@ jobs:
       - name: renderer backend conformance corpus
         run: node clients/web/scene-conformance.test.mjs
 
+      - name: browser video capture-identity tests (HUD-01)
+        run: node clients/web/video-identity.test.mjs
+
+      - name: browser snapshot-association tests (HUD-01)
+        run: node clients/web/snapshot-association.test.mjs
+
+      - name: browser turn-derivation tests (DYN-01)
+        run: node clients/web/turn-derivation.test.mjs
+
       - name: Setup buf
         if: hashFiles('schemas/**/*.proto') != ''
         uses: bufbuild/buf-action@v1

--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -223,7 +223,7 @@ fn derive_alert_events(data: &pilotage_instrument_state::PanelData) -> [AlertEve
             AlertCondition::Heading(NavFault::Unavailable),
         ),
         cond(
-            data.turn_rate_rps.status == SignalStatus::Failed,
+            data.turn.rate_rps.status == SignalStatus::Failed,
             AlertCondition::TurnSlip(DynFault::TurnRateInvalid),
         ),
     ]

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -35,8 +35,8 @@ export const EXPECTED_GLYPH_SHA256 =
 const GLYPH_HEADER_LEN = 8;
 const GLYPH_RECORD_LEN = 12;
 const GLYPH_ROWS = 7;
-export const STATE_ABI_VERSION = 4;
-export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 152, 4: 176 });
+export const STATE_ABI_VERSION = 5;
+export const STATE_ABI_SIZE_BY_VERSION = Object.freeze({ 1: 120, 2: 128, 3: 152, 4: 176, 5: 192 });
 export const STATE_ABI_SIZE = STATE_ABI_SIZE_BY_VERSION[STATE_ABI_VERSION];
 const MAX_WASM_RENDER_STATUS = 10;
 
@@ -438,11 +438,23 @@ export class InstrumentModule {
       b(
         172,
         (state.valid?.heading ?? false ? 1 : 0) |
-          (state.valid?.variation ?? false ? 2 : 0),
+          (state.valid?.variation ?? false ? 2 : 0) |
+          (state.valid?.turn ?? false ? 4 : 0) |
+          (state.valid?.slip ?? false ? 8 : 0),
       );
-      b(173, 0);
+      // DYN-01 typed dynamics (abi.rs parity): the fail-safe default is
+      // no sample and an unknown basis — body yaw rate has no encoding
+      // to fall back to.
+      b(173, state.dynamics?.turnBasis ?? 255);
       b(174, 0);
       b(175, 0);
+      f(176, state.dynamics?.turnRps ?? NaN);
+      f(180, state.dynamics?.lateralMps2 ?? NaN);
+      f(184, state.dynamics ? state.dynamics.ageMs : NaN);
+      b(188, 0);
+      b(189, 0);
+      b(190, 0);
+      b(191, 0);
       return { ok: true };
     } catch {
       return { ok: false, reason: REASON.STATE_WRITE_FAILED };

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -1149,6 +1149,32 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
       Math.abs(view.getFloat32(164, true) - 0.03) < 1e-6 &&
       view.getUint8(172) === 0b11,
   );
+
+  // DYN-01: undeclared dynamics write no sample and an unknown basis —
+  // there is no encoding through which body yaw rate could pose as a
+  // turn indication.
+  const bare3 = mod.writeState({ selections: { headingBugRad: 0 } });
+  check("dynamicsless state write succeeds", bare3.ok === true);
+  check(
+    "undeclared dynamics fail closed on the wire",
+    view.getUint8(173) === 255 &&
+      Number.isNaN(view.getFloat32(176, true)) &&
+      Number.isNaN(view.getFloat32(184, true)),
+  );
+  const dyn = mod.writeState({
+    selections: { headingBugRad: 0 },
+    dynamics: { turnBasis: 0, turnRps: 0.05, lateralMps2: -0.8, ageMs: 15 },
+    valid: { turn: true, slip: true },
+  });
+  check("typed dynamics write succeeds", dyn.ok === true);
+  check(
+    "declared dynamics encode exactly (abi.rs parity)",
+    view.getUint8(173) === 0 &&
+      Math.abs(view.getFloat32(176, true) - 0.05) < 1e-6 &&
+      Math.abs(view.getFloat32(180, true) + 0.8) < 1e-6 &&
+      Math.abs(view.getFloat32(184, true) - 15) < 1e-6 &&
+      view.getUint8(172) === 0b1100,
+  );
 }
 
 // ---- glyph text painting (REN-02 consumption) ---------------------------------

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -947,6 +947,41 @@ function declaredSimHeading(attitude) {
   return { rad: yaw, reference: 2, ageMs: attitude.ageMs };
 }
 
+// DYN-01: the feeder — never the display — derives the turn indication,
+// as heading rate by circular differencing of consecutive declared SIM
+// headings on the feeder's own coherent clock. Documented limits: a
+// sample pair closer than MIN_TURN_DT_MS is too noisy to differentiate
+// and one farther apart than MAX_TURN_DT_MS is stale for a rate; both
+// yield no sample rather than a wild or frozen rate. Slip has no sim
+// source and is deliberately never fabricated.
+const MIN_TURN_DT_MS = 5;
+const MAX_TURN_DT_MS = 500;
+const turnDerivation = { headingRad: null, atMs: null };
+
+function derivedSimTurn(heading, nowMs) {
+  if (!heading) {
+    turnDerivation.headingRad = null;
+    turnDerivation.atMs = null;
+    return null;
+  }
+  const prevRad = turnDerivation.headingRad;
+  const prevAt = turnDerivation.atMs;
+  turnDerivation.headingRad = heading.rad;
+  turnDerivation.atMs = nowMs;
+  if (prevRad === null) return null;
+  const dtMs = nowMs - prevAt;
+  if (!(dtMs >= MIN_TURN_DT_MS && dtMs <= MAX_TURN_DT_MS)) return null;
+  // Circular difference into (-π, π] so 359°→1° is +2°, never −358°.
+  let delta = (heading.rad - prevRad) % (2 * Math.PI);
+  if (delta > Math.PI) delta -= 2 * Math.PI;
+  if (delta <= -Math.PI) delta += 2 * Math.PI;
+  return {
+    turnBasis: 0, // heading rate
+    turnRps: delta / (dtMs / 1000),
+    ageMs: heading.ageMs,
+  };
+}
+
 /** Maps the latest wire avionics estimate into the instrument state ABI
  * and draws both panels; runs on the display's own rAF cadence. Every
  * render result is honored: a validated frame is blitted, anything else
@@ -979,6 +1014,7 @@ function renderInstruments() {
   // its own, so removing this declaration flags HDG instead of
   // freezing a fabricated rose.
   const heading = declaredSimHeading(attitude);
+  const dynamics = derivedSimTurn(heading, performance.now());
   const panelState = {
     attitude,
     kinematics,
@@ -987,6 +1023,7 @@ function renderInstruments() {
     wind: null,
     selections: { headingBugRad: 0, headingBugReference: 2 },
     heading,
+    dynamics,
     quality: snapshot.quality,
     valid: {
       attitude: !!(validFlags & 1),
@@ -994,6 +1031,7 @@ function renderInstruments() {
       position: !!(validFlags & 4),
       velocity: !!(validFlags & 8),
       heading: heading !== null && !!(validFlags & 1),
+      turn: dynamics !== null && !!(validFlags & 1),
     },
     snapshot: { generation: snapshot.generation, coherence },
   };

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -40,6 +40,7 @@ import {
   startDisplayLoop,
   tickInstrumentSet,
 } from "./instrument-health.js";
+import { TurnDerivation } from "./turn-derivation.js";
 import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
 import { AvionicsIngress, INCARNATION_POLICY } from "./telemetry-ingress.js";
 import { TransportSessionLifecycle } from "./transport-session.js";
@@ -133,6 +134,7 @@ function retireSessionPresentation(phase) {
   // Drop the previous session's snapshot history so a new session can never
   // associate a video frame against a stale snapshot from the old one.
   snapshotHistory.reset();
+  turnDerivation.reset();
   setTelemetrySessionState(els, phase);
 }
 
@@ -937,6 +939,13 @@ async function startControlLoop(transport, token) {
 
 // ---- instrument panels (ADR-0017) -------------------------------------------
 
+// DYN-01: turn-rate derivation is measurement-coherent — it advances
+// only on a NEW accepted heading measurement identity and differences
+// over the acquisition clock (see turn-derivation.js). Rendering
+// cadence cannot inflate or zero the rate, and session retirement
+// resets it below.
+const turnDerivation = new TurnDerivation();
+
 /** The explicit SIM heading declaration: local-NED yaw from the
  * published attitude quaternion, declared sim-local-true. Returns null
  * when no attitude estimate exists — no sample, never a zero heading. */
@@ -947,40 +956,6 @@ function declaredSimHeading(attitude) {
   return { rad: yaw, reference: 2, ageMs: attitude.ageMs };
 }
 
-// DYN-01: the feeder — never the display — derives the turn indication,
-// as heading rate by circular differencing of consecutive declared SIM
-// headings on the feeder's own coherent clock. Documented limits: a
-// sample pair closer than MIN_TURN_DT_MS is too noisy to differentiate
-// and one farther apart than MAX_TURN_DT_MS is stale for a rate; both
-// yield no sample rather than a wild or frozen rate. Slip has no sim
-// source and is deliberately never fabricated.
-const MIN_TURN_DT_MS = 5;
-const MAX_TURN_DT_MS = 500;
-const turnDerivation = { headingRad: null, atMs: null };
-
-function derivedSimTurn(heading, nowMs) {
-  if (!heading) {
-    turnDerivation.headingRad = null;
-    turnDerivation.atMs = null;
-    return null;
-  }
-  const prevRad = turnDerivation.headingRad;
-  const prevAt = turnDerivation.atMs;
-  turnDerivation.headingRad = heading.rad;
-  turnDerivation.atMs = nowMs;
-  if (prevRad === null) return null;
-  const dtMs = nowMs - prevAt;
-  if (!(dtMs >= MIN_TURN_DT_MS && dtMs <= MAX_TURN_DT_MS)) return null;
-  // Circular difference into (-π, π] so 359°→1° is +2°, never −358°.
-  let delta = (heading.rad - prevRad) % (2 * Math.PI);
-  if (delta > Math.PI) delta -= 2 * Math.PI;
-  if (delta <= -Math.PI) delta += 2 * Math.PI;
-  return {
-    turnBasis: 0, // heading rate
-    turnRps: delta / (dtMs / 1000),
-    ageMs: heading.ageMs,
-  };
-}
 
 /** Maps the latest wire avionics estimate into the instrument state ABI
  * and draws both panels; runs on the display's own rAF cadence. Every
@@ -1014,7 +989,11 @@ function renderInstruments() {
   // its own, so removing this declaration flags HDG instead of
   // freezing a fabricated rose.
   const heading = declaredSimHeading(attitude);
-  const dynamics = derivedSimTurn(heading, performance.now());
+  const dynamics = turnDerivation.update(
+    heading === null ? NaN : heading.rad,
+    heading === null ? NaN : heading.ageMs,
+    attitude?.stamp ?? null,
+  );
   const panelState = {
     attitude,
     kinematics,

--- a/clients/web/turn-derivation.js
+++ b/clients/web/turn-derivation.js
@@ -55,7 +55,8 @@ export class TurnDerivation {
    * - Stream change (source/incarnation/epoch/clock): reset, then seed.
    * - Same sequence: repeated render — re-declare the cached rate with
    *   the measurement's current age; no state advance.
-   * - Serially older sequence: reordered — ignored entirely.
+   * - Serially older sequence: reordered — ignored entirely,
+   *   declaring nothing (its age must not refresh freshness).
    * - Newer sequence: difference over acquiredAtNanos within the
    *   documented bounds; out-of-bound dt seeds but declares nothing.
    */
@@ -74,7 +75,10 @@ export class TurnDerivation {
       return this.#declare(ageMs);
     }
     if (!serialIsNewer(stamp.sequence, prev.stamp.sequence)) {
-      return this.#declare(ageMs);
+      // A serially older sample is ignored ENTIRELY: it neither
+      // advances state nor produces a declaration — its age must never
+      // refresh the freshness of a rate it did not contribute to.
+      return null;
     }
     const dtMs = Number(stamp.acquiredAtNanos - prev.stamp.acquiredAtNanos) / 1e6;
     this.#prev = { headingRad, stamp };

--- a/clients/web/turn-derivation.js
+++ b/clients/web/turn-derivation.js
@@ -1,0 +1,97 @@
+// Measurement-coherent turn-rate derivation for the simulator feeder
+// (DYN-01). Heading rate is differenced ONLY between two distinct
+// accepted heading measurements of one stream — identified by the
+// AV-01 stamp (sourceId + sourceIncarnation + sourceEpoch, ordered by
+// sequence) — over the MEASUREMENT acquisition clock, never browser
+// render or receipt time. Repeated renders of one sample re-declare
+// the cached rate (the measurement's own age carries staleness);
+// duplicates and reordered samples never advance the state; a stream
+// discontinuity or session retirement resets it, so no difference can
+// ever straddle two sessions, sources, or epochs.
+
+import { serialIsNewer } from "./telemetry-ingress.js";
+
+// Bounds on the measurement-clock interval between the two differenced
+// samples: closer than the minimum is too noisy to differentiate,
+// farther than the maximum is stale for a rate. Both yield no sample —
+// never a wild or frozen rate.
+export const MIN_TURN_DT_MS = 5;
+export const MAX_TURN_DT_MS = 500;
+
+const TURN_BASIS_HEADING_RATE = 0;
+
+function sameStream(a, b) {
+  return (
+    a.sourceId === b.sourceId &&
+    a.sourceIncarnation === b.sourceIncarnation &&
+    a.sourceEpoch === b.sourceEpoch &&
+    a.clock === b.clock
+  );
+}
+
+/** Derives heading-rate dynamics declarations from per-measurement
+ * heading samples. One instance per session presentation. */
+export class TurnDerivation {
+  #prev;
+  #cached;
+
+  constructor() {
+    this.reset();
+  }
+
+  /** Clears all state; the next sample can never difference against
+   * anything observed before the reset. */
+  reset() {
+    this.#prev = null;
+    this.#cached = null;
+  }
+
+  /**
+   * Consumes the current declared heading (radians) with its
+   * measurement stamp; returns a dynamics declaration for writeState
+   * or null when no rate can honestly be derived.
+   *
+   * - No heading/stamp: full reset (a gap must not bridge).
+   * - Stream change (source/incarnation/epoch/clock): reset, then seed.
+   * - Same sequence: repeated render — re-declare the cached rate with
+   *   the measurement's current age; no state advance.
+   * - Serially older sequence: reordered — ignored entirely.
+   * - Newer sequence: difference over acquiredAtNanos within the
+   *   documented bounds; out-of-bound dt seeds but declares nothing.
+   */
+  update(headingRad, ageMs, stamp) {
+    if (!Number.isFinite(headingRad) || !stamp) {
+      this.reset();
+      return null;
+    }
+    const prev = this.#prev;
+    if (prev === null || !sameStream(prev.stamp, stamp)) {
+      this.reset();
+      this.#prev = { headingRad, stamp };
+      return null;
+    }
+    if (stamp.sequence === prev.stamp.sequence) {
+      return this.#declare(ageMs);
+    }
+    if (!serialIsNewer(stamp.sequence, prev.stamp.sequence)) {
+      return this.#declare(ageMs);
+    }
+    const dtMs = Number(stamp.acquiredAtNanos - prev.stamp.acquiredAtNanos) / 1e6;
+    this.#prev = { headingRad, stamp };
+    if (!(dtMs >= MIN_TURN_DT_MS && dtMs <= MAX_TURN_DT_MS)) {
+      this.#cached = null;
+      return null;
+    }
+    // Circular difference into (-π, π] so 359°→1° is +2°, never −358°.
+    let delta = (headingRad - prev.headingRad) % (2 * Math.PI);
+    if (delta > Math.PI) delta -= 2 * Math.PI;
+    if (delta <= -Math.PI) delta += 2 * Math.PI;
+    this.#cached = { turnBasis: TURN_BASIS_HEADING_RATE, turnRps: delta / (dtMs / 1000) };
+    return this.#declare(ageMs);
+  }
+
+  #declare(ageMs) {
+    if (this.#cached === null) return null;
+    return { ...this.#cached, ageMs };
+  }
+}

--- a/clients/web/turn-derivation.test.mjs
+++ b/clients/web/turn-derivation.test.mjs
@@ -83,10 +83,15 @@ function stamp(sequence, atMs, over = {}) {
     "an exact duplicate re-declares without advancing state",
     dup !== null && dup.turnRps === base.turnRps,
   );
-  const reordered = d.update(50 * DEG, 5, stamp(1, 0));
+  const reordered = d.update(50 * DEG, 999, stamp(1, 0));
   check(
-    "a serially older sample is ignored entirely",
-    reordered !== null && reordered.turnRps === base.turnRps,
+    "a serially older sample declares nothing at all",
+    reordered === null,
+  );
+  const redeclared = d.update(2 * DEG, 7, stamp(2, 100));
+  check(
+    "freshness after a reorder comes only from the accepted sample's age",
+    redeclared !== null && redeclared.ageMs === 7 && redeclared.turnRps === base.turnRps,
   );
   const next = d.update(4 * DEG, 5, stamp(3, 200));
   check(

--- a/clients/web/turn-derivation.test.mjs
+++ b/clients/web/turn-derivation.test.mjs
@@ -1,0 +1,166 @@
+// Direct feeder tests for the measurement-coherent turn derivation
+// (DYN-01 review disposition): rates difference only between distinct
+// accepted measurements of one stream over the measurement clock —
+// never once per paint, never across a discontinuity.
+
+import { MAX_TURN_DT_MS, MIN_TURN_DT_MS, TurnDerivation } from "./turn-derivation.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL - ${name}`);
+  }
+}
+
+const DEG = Math.PI / 180;
+
+function stamp(sequence, atMs, over = {}) {
+  return {
+    sourceId: 7n,
+    sourceIncarnation: "0123456789abcdef0123456789abcdef",
+    sourceEpoch: 1,
+    sequence,
+    acquiredAtNanos: BigInt(Math.round(atMs * 1e6)),
+    clock: "simulation",
+    ...over,
+  };
+}
+
+// ---- repeated renders of one sample -----------------------------------------
+
+{
+  const d = new TurnDerivation();
+  check("first sample seeds and declares nothing", d.update(0, 5, stamp(1, 0)) === null);
+  const first = d.update(2 * DEG, 6, stamp(2, 100));
+  check("second sample derives over the measurement interval", first !== null);
+  check(
+    "rate is delta over measurement dt, not render dt",
+    Math.abs(first.turnRps - (2 * DEG) / 0.1) < 1e-9,
+  );
+  // Sixty render frames of the SAME measurement: the cached rate is
+  // re-declared every time — never zero, never recomputed, never
+  // amplified by frame timing.
+  let stable = true;
+  for (let frame = 0; frame < 60; frame += 1) {
+    const again = d.update(2 * DEG, 6 + frame, stamp(2, 100));
+    stable &&= again !== null && Math.abs(again.turnRps - first.turnRps) < 1e-12;
+  }
+  check("repeated renders re-declare the cached rate unchanged", stable);
+  const aged = d.update(2 * DEG, 250, stamp(2, 100));
+  check("re-declaration carries the measurement's current age", aged.ageMs === 250);
+}
+
+// ---- two samples across the 359/1 degree wrap --------------------------------
+
+{
+  const d = new TurnDerivation();
+  d.update(359 * DEG, 5, stamp(1, 0));
+  const wrapped = d.update(1 * DEG, 5, stamp(2, 100));
+  check(
+    "359 to 1 degrees differences as +2 degrees, never -358",
+    wrapped !== null && Math.abs(wrapped.turnRps - (2 * DEG) / 0.1) < 1e-6,
+  );
+  const d2 = new TurnDerivation();
+  d2.update(1 * DEG, 5, stamp(1, 0));
+  const back = d2.update(359 * DEG, 5, stamp(2, 100));
+  check(
+    "1 to 359 degrees differences as -2 degrees",
+    back !== null && Math.abs(back.turnRps + (2 * DEG) / 0.1) < 1e-6,
+  );
+}
+
+// ---- duplicate and reordered samples -----------------------------------------
+
+{
+  const d = new TurnDerivation();
+  d.update(0, 5, stamp(1, 0));
+  const base = d.update(2 * DEG, 5, stamp(2, 100));
+  const dup = d.update(2 * DEG, 5, stamp(2, 100));
+  check(
+    "an exact duplicate re-declares without advancing state",
+    dup !== null && dup.turnRps === base.turnRps,
+  );
+  const reordered = d.update(50 * DEG, 5, stamp(1, 0));
+  check(
+    "a serially older sample is ignored entirely",
+    reordered !== null && reordered.turnRps === base.turnRps,
+  );
+  const next = d.update(4 * DEG, 5, stamp(3, 200));
+  check(
+    "the state still differences from the newest accepted sample",
+    next !== null && Math.abs(next.turnRps - (2 * DEG) / 0.1) < 1e-6,
+  );
+}
+
+// ---- stream discontinuities ---------------------------------------------------
+
+{
+  const d = new TurnDerivation();
+  d.update(0, 5, stamp(1, 0));
+  d.update(2 * DEG, 5, stamp(2, 100));
+  const crossed = d.update(90 * DEG, 5, stamp(3, 200, { sourceEpoch: 2 }));
+  check("an epoch reset never differences across the boundary", crossed === null);
+  const seeded = d.update(92 * DEG, 5, stamp(4, 300, { sourceEpoch: 2 }));
+  check(
+    "the new epoch derives only from its own samples",
+    seeded !== null && Math.abs(seeded.turnRps - (2 * DEG) / 0.1) < 1e-6,
+  );
+
+  const incarnation = d.update(0, 5, stamp(5, 400, {
+    sourceEpoch: 2,
+    sourceIncarnation: "ffffffffffffffffffffffffffffffff",
+  }));
+  check("an incarnation change resets the derivation", incarnation === null);
+
+  const clock = d.update(0, 5, stamp(6, 500, {
+    sourceEpoch: 2,
+    sourceIncarnation: "ffffffffffffffffffffffffffffffff",
+    clock: "vehicle-boot",
+  }));
+  check("a clock-domain change resets the derivation", clock === null);
+}
+
+// ---- rapid reconnect ----------------------------------------------------------
+
+{
+  const d = new TurnDerivation();
+  d.update(0, 5, stamp(1, 0));
+  d.update(2 * DEG, 5, stamp(2, 100));
+  // Session retirement between identical-looking streams: even a
+  // plausible dt and the SAME stream key must not bridge the reset.
+  d.reset();
+  const afterReset = d.update(4 * DEG, 5, stamp(3, 200));
+  check("after reset the first sample only seeds", afterReset === null);
+  const rebuilt = d.update(6 * DEG, 5, stamp(4, 300));
+  check(
+    "reconnect derives from post-reset samples only",
+    rebuilt !== null && Math.abs(rebuilt.turnRps - (2 * DEG) / 0.1) < 1e-6,
+  );
+}
+
+// ---- out-of-bound measurement intervals ---------------------------------------
+
+{
+  const d = new TurnDerivation();
+  d.update(0, 5, stamp(1, 0));
+  const tooClose = d.update(1 * DEG, 5, stamp(2, MIN_TURN_DT_MS - 1));
+  check("a pair closer than the minimum dt declares nothing", tooClose === null);
+  const tooFar = d.update(2 * DEG, 5, stamp(3, MIN_TURN_DT_MS - 1 + MAX_TURN_DT_MS + 1));
+  check("a pair farther than the maximum dt declares nothing", tooFar === null);
+  const recovered = d.update(3 * DEG, 5, stamp(4, MIN_TURN_DT_MS + MAX_TURN_DT_MS + 100));
+  check(
+    "derivation recovers on the next in-bound pair",
+    recovered !== null && Math.abs(recovered.turnRps - (1 * DEG) / 0.1) < 1e-6,
+  );
+  const gap = d.update(NaN, 5, null);
+  check("a missing heading resets everything", gap === null);
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all turn-derivation checks passed");

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -3,7 +3,7 @@
 //! tapes → symbology → annunciation, ADR-0017).
 
 use pilotage_alerts::AlertOutput;
-use pilotage_instrument_scene::{LayerId, PaintMode, SceneError, SceneWriter};
+use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{ChevronSense, PanelData, SignalStatus};
 
 use crate::palette;
@@ -163,16 +163,24 @@ fn draw_recovery_chevrons(
 }
 
 /// Standard-rate turn is 3°/s, drawn at the ±62 px reference ticks.
+/// Only the POINTER saturates at the scale edge (±73 px); the resolved
+/// value stays unclamped for monitoring. The cue labels its basis, and
+/// a required-but-unusable turn indication flags TRN instead of
+/// quietly disappearing.
 fn draw_turn_rate(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), SceneError> {
     let y = 340.0;
     scene.stroke(palette::WHITE, 2.0)?;
     scene.line(178.0, y - 6.0, 178.0, y + 6.0)?;
     scene.line(302.0, y - 6.0, 302.0, y + 6.0)?;
     scene.line(240.0, y - 4.0, 240.0, y + 4.0)?;
-    if !data.turn_rate_rps.status.shows_value() {
-        return Ok(());
+    let turn = &data.turn;
+    if !turn.rate_rps.status.shows_value() {
+        if data.require_dynamics_cue {
+            status_paint::draw_flag(scene, 240.0, y - 12.0, "TRN")?;
+        }
+        return draw_slip_ball(scene, data, y);
     }
-    let dps = data.turn_rate_rps.value * pilotage_instrument_state::units::RAD_TO_DEG;
+    let dps = turn.rate_rps.value * pilotage_instrument_state::units::RAD_TO_DEG;
     let len = (dps / 3.0 * 62.0).clamp(-73.0, 73.0);
     scene.fill_color(palette::MAGENTA)?;
     if len >= 0.0 {
@@ -180,6 +188,38 @@ fn draw_turn_rate(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), S
     } else {
         scene.rect(PaintMode::Fill, 240.0 + len, y - 3.0, -len, 6.0)?;
     }
+    scene.fill_color(palette::WHITE)?;
+    scene.text(
+        310.0,
+        y + 4.0,
+        10.0,
+        Anchor::BASELINE_LEFT,
+        turn.basis.label(),
+    )?;
+    draw_slip_ball(scene, data, y)
+}
+
+/// Slip/skid ball under the turn cue. The ball displaces OPPOSITE the
+/// lateral specific force (body +Y right ⇒ ball left), one bracket
+/// width per 2 m/s²; the pointer clamps at ±1.5 widths while the
+/// resolved value stays unclamped. A missing input draws brackets and
+/// NO ball — a centered ball is a coordination claim nobody made — and
+/// flags SLIP when the profile requires the cue.
+fn draw_slip_ball(scene: &mut SceneWriter<'_>, data: &PanelData, y: f32) -> Result<(), SceneError> {
+    let by = y + 14.0;
+    scene.stroke(palette::WHITE, 1.5)?;
+    scene.line(233.0, by - 5.0, 233.0, by + 5.0)?;
+    scene.line(247.0, by - 5.0, 247.0, by + 5.0)?;
+    let slip = data.slip_lat_mps2;
+    if !slip.status.shows_value() {
+        if data.require_dynamics_cue {
+            status_paint::draw_flag(scene, 270.0, by, "SLIP")?;
+        }
+        return Ok(());
+    }
+    let dx = (-slip.value / 2.0 * 14.0).clamp(-21.0, 21.0);
+    scene.fill_color(palette::WHITE)?;
+    scene.circle(PaintMode::Fill, 240.0 + dx, by, 4.0)?;
     Ok(())
 }
 
@@ -187,5 +227,7 @@ fn draw_turn_rate(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), S
 mod attitude_tests;
 #[cfg(test)]
 mod datum_tests;
+#[cfg(test)]
+mod dyn_tests;
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/pilotage-instrument-panels/src/pfd/dyn_tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/dyn_tests.rs
@@ -1,0 +1,120 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! DYN-01 rendering proofs: the cue labels its basis, the pointer
+//! saturates while the value survives, missing slip draws no centered
+//! ball, and required failures are loud.
+
+use std::string::String;
+
+use pilotage_instrument_scene::{Cmd, PaintMode, SceneCmds};
+use pilotage_instrument_state::{PanelData, Sig, SignalStatus, TurnBasis};
+
+use super::tests::{PfdConfig, flying, render, texts};
+
+fn with_turn(rate_dps: f32) -> PanelData {
+    let mut data = flying();
+    data.turn.rate_rps = Sig::with_status(rate_dps.to_radians(), SignalStatus::Valid);
+    data.turn.basis = TurnBasis::HeadingRate;
+    data
+}
+
+/// Every filled rect in the scene, as (x, w) pairs, for locating the
+/// turn-rate bar at its known y band.
+fn turn_bar(scene: &[u8]) -> Option<(f32, f32)> {
+    for command in SceneCmds::new(scene).expect("valid scene") {
+        if let Cmd::Rect { mode, x, y, w, h } = command.expect("valid command")
+            && mode == PaintMode::Fill
+            && (y - 337.0).abs() < 0.6
+            && (h - 6.0).abs() < 0.6
+        {
+            return Some((x, w));
+        }
+    }
+    None
+}
+
+#[test]
+fn cue_labels_its_basis() {
+    let all = texts(&render(&with_turn(2.0), &PfdConfig::default()));
+    assert!(all.contains(&String::from("HDG")), "{all:?}");
+}
+
+#[test]
+fn plus_minus_three_degrees_reach_the_reference_ticks_symmetrically() {
+    let (x_pos, w_pos) = turn_bar(&render(&with_turn(3.0), &PfdConfig::default())).expect("bar");
+    assert!((x_pos - 240.0).abs() < 0.6 && (w_pos - 62.0).abs() < 0.6);
+    let (x_neg, w_neg) = turn_bar(&render(&with_turn(-3.0), &PfdConfig::default())).expect("bar");
+    assert!((x_neg - 178.0).abs() < 0.6 && (w_neg - 62.0).abs() < 0.6);
+}
+
+#[test]
+fn pointer_saturates_but_the_resolved_value_does_not() {
+    let data = with_turn(20.0);
+    let (_, width) = turn_bar(&render(&data, &PfdConfig::default())).expect("bar");
+    assert!(
+        (width - 73.0).abs() < 0.6,
+        "pointer clamps at the scale edge"
+    );
+    assert!(
+        (data.turn.rate_rps.value - 20.0f32.to_radians()).abs() < 1e-6,
+        "the monitored value keeps the over-range rate"
+    );
+}
+
+#[test]
+fn missing_turn_flags_trn_when_the_profile_requires_a_cue() {
+    let mut data = flying();
+    data.require_dynamics_cue = true;
+    let all = texts(&render(&data, &PfdConfig::default()));
+    assert!(all.contains(&String::from("TRN")), "{all:?}");
+    data.require_dynamics_cue = false;
+    let all = texts(&render(&data, &PfdConfig::default()));
+    assert!(!all.contains(&String::from("TRN")), "{all:?}");
+}
+
+#[test]
+fn missing_slip_never_draws_a_centered_ball() {
+    let data = with_turn(0.0);
+    let scene = render(&data, &PfdConfig::default());
+    let balls: usize = SceneCmds::new(&scene)
+        .expect("valid scene")
+        .filter(|command| {
+            matches!(
+                command.as_ref().expect("valid command"),
+                Cmd::Circle { cy, .. } if (cy - 354.0).abs() < 0.6
+            )
+        })
+        .count();
+    assert_eq!(balls, 0, "no ball without a slip input");
+    let all = texts(&scene);
+    assert!(
+        all.contains(&String::from("SLIP")),
+        "required cue flags the absence: {all:?}"
+    );
+}
+
+#[test]
+fn slip_ball_deflects_opposite_the_lateral_force_symmetrically() {
+    let mut data = with_turn(0.0);
+    data.slip_lat_mps2 = Sig::with_status(1.0, SignalStatus::Valid);
+    let scene = render(&data, &PfdConfig::default());
+    let cx_right_force = ball_x(&scene).expect("ball");
+    data.slip_lat_mps2 = Sig::with_status(-1.0, SignalStatus::Valid);
+    let cx_left_force = ball_x(&render(&data, &PfdConfig::default())).expect("ball");
+    assert!(
+        cx_right_force < 240.0 && cx_left_force > 240.0,
+        "ball opposes the force: {cx_right_force} / {cx_left_force}"
+    );
+    assert!(((cx_right_force - 240.0) + (cx_left_force - 240.0)).abs() < 0.6);
+}
+
+fn ball_x(scene: &[u8]) -> Option<f32> {
+    for command in SceneCmds::new(scene).expect("valid scene") {
+        if let Cmd::Circle { cx, cy, .. } = command.expect("valid command")
+            && (cy - 354.0).abs() < 0.6
+        {
+            return Some(cx);
+        }
+    }
+    None
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -95,14 +95,32 @@ pub(super) fn demo_state() -> AircraftState {
         },
         snapshot: SnapshotMeta::default(),
         altitude: pilotage_instrument_state::AltitudeDeclaration::default(),
-        heading: Stamped {
-            data: Some(pilotage_instrument_state::HeadingSample {
-                heading_rad: 0.6,
-                reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
-            }),
-            age_ms: Some(80.0),
-        },
+        heading: demo_heading(),
         variation: Stamped::default(),
+        dynamics: demo_dynamics(),
+    }
+}
+
+fn demo_heading() -> Stamped<pilotage_instrument_state::HeadingSample> {
+    Stamped {
+        data: Some(pilotage_instrument_state::HeadingSample {
+            heading_rad: 0.6,
+            reference: pilotage_instrument_state::HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(80.0),
+    }
+}
+
+fn demo_dynamics() -> Stamped<pilotage_instrument_state::DynSample> {
+    Stamped {
+        data: Some(pilotage_instrument_state::DynSample {
+            turn: Some(pilotage_instrument_state::TurnSample {
+                rate_rps: 0.05,
+                basis: pilotage_instrument_state::TurnBasis::HeadingRate,
+            }),
+            lateral_mps2: Some(-0.6),
+        }),
+        age_ms: Some(80.0),
     }
 }
 

--- a/crates/pilotage-instrument-state/src/abi.rs
+++ b/crates/pilotage-instrument-state/src/abi.rs
@@ -11,7 +11,7 @@
 //!
 //! | off | type | field |
 //! |----:|------|-------|
-//! | 0   | u32  | version (=4) |
+//! | 0   | u32  | version (=5) |
 //! | 4   | f32×4| attitude quaternion w, x, y, z |
 //! | 20  | f32×3| body rates p, q, r (rad/s) |
 //! | 32  | f32×3| position NED n, e, d (m) |
@@ -51,22 +51,27 @@
 //! | 160 | f32  | heading age ms (NaN never) |
 //! | 164 | f32  | magnetic variation (rad, east positive, NaN absent) |
 //! | 168 | f32  | variation age ms (NaN never) |
-//! | 172 | u8   | valid flags 2 (bit0 heading, bit1 variation) |
-//! | 173 | u8×3 | reserved, zero |
+//! | 172 | u8   | valid flags 2 (bit0 heading, bit1 variation, bit2 turn, bit3 slip) |
+//! | 173 | u8   | turn basis (0 heading rate, 1 track rate; other = unknown, fails) |
+//! | 174 | u8×2 | reserved, zero |
+//! | 176 | f32  | turn rate (rad/s, positive right, NaN absent) |
+//! | 180 | f32  | lateral specific force (m/s², body +Y right, NaN absent) |
+//! | 184 | f32  | dynamics age ms (NaN never) |
+//! | 188 | u8×4 | reserved, zero |
 
 use crate::aircraft::{
     AirData, AircraftState, Attitude, EstimateQuality, Kinematics, NavData, NavFromTo, NavSource,
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
-use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
+use crate::heading::HeadingReference;
 use pilotage_frames::Quat;
 
 /// Version stamped in the block's first four bytes.
-pub const STATE_ABI_VERSION: u32 = 4;
+pub const STATE_ABI_VERSION: u32 = 5;
 
 /// Size of the packed block in bytes.
-pub const STATE_ABI_SIZE: usize = 176;
+pub const STATE_ABI_SIZE: usize = 192;
 
 /// Why a state block failed to decode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,16 +85,16 @@ pub enum AbiError {
     },
 }
 
-fn f32_at(buf: &[u8], off: usize) -> Result<f32, AbiError> {
+pub(crate) fn f32_at(buf: &[u8], off: usize) -> Result<f32, AbiError> {
     let b = buf.get(off..off + 4).ok_or(AbiError::Truncated)?;
     Ok(f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
 }
 
-fn u8_at(buf: &[u8], off: usize) -> Result<u8, AbiError> {
+pub(crate) fn u8_at(buf: &[u8], off: usize) -> Result<u8, AbiError> {
     buf.get(off).copied().ok_or(AbiError::Truncated)
 }
 
-fn opt(v: f32) -> Option<f32> {
+pub(crate) fn opt(v: f32) -> Option<f32> {
     if v.is_nan() { None } else { Some(v) }
 }
 
@@ -191,12 +196,7 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         age_ms: wind_age,
     };
 
-    let quality = match u8_at(buf, 84)? {
-        0 => EstimateQuality::Good,
-        1 => EstimateQuality::Degraded,
-        2 => EstimateQuality::Unusable,
-        _ => EstimateQuality::Unknown,
-    };
+    let quality = decode_quality(buf)?;
     let valid = decode_valid_flags(buf)?;
     let coherence = match u8_at(buf, 124)? {
         0 => SnapshotCoherence::Insufficient,
@@ -221,34 +221,7 @@ pub fn decode_state(buf: &[u8]) -> Result<AircraftState, AbiError> {
         altitude: decode_altitude(buf)?,
         heading: decode_heading(buf)?,
         variation: decode_variation(buf)?,
-    })
-}
-
-fn decode_heading(buf: &[u8]) -> Result<Stamped<HeadingSample>, AbiError> {
-    let age = opt(f32_at(buf, 160)?);
-    Ok(Stamped {
-        data: match (age, opt(f32_at(buf, 156)?)) {
-            (Some(_), Some(heading_rad)) => Some(HeadingSample {
-                heading_rad,
-                reference: HeadingReference::from_u8(u8_at(buf, 152)?),
-            }),
-            _ => None,
-        },
-        age_ms: age,
-    })
-}
-
-fn decode_variation(buf: &[u8]) -> Result<Stamped<MagneticVariation>, AbiError> {
-    let age = opt(f32_at(buf, 168)?);
-    Ok(Stamped {
-        data: match (age, opt(f32_at(buf, 164)?)) {
-            (Some(_), Some(east_positive_rad)) => Some(MagneticVariation {
-                east_positive_rad,
-                source: VariationSourceId(u8_at(buf, 153)?),
-            }),
-            _ => None,
-        },
-        age_ms: age,
+        dynamics: decode_dynamics(buf)?,
     })
 }
 
@@ -262,6 +235,17 @@ fn decode_valid_flags(buf: &[u8]) -> Result<ValidFlags, AbiError> {
         velocity: flags & 0b1000 != 0,
         heading: flags2 & 0b0001 != 0,
         variation: flags2 & 0b0010 != 0,
+        turn: flags2 & 0b0100 != 0,
+        slip: flags2 & 0b1000 != 0,
+    })
+}
+
+fn decode_quality(buf: &[u8]) -> Result<EstimateQuality, AbiError> {
+    Ok(match u8_at(buf, 84)? {
+        0 => EstimateQuality::Good,
+        1 => EstimateQuality::Degraded,
+        2 => EstimateQuality::Unusable,
+        _ => EstimateQuality::Unknown,
     })
 }
 
@@ -286,29 +270,29 @@ fn decode_altitude(buf: &[u8]) -> Result<AltitudeDeclaration, AbiError> {
     })
 }
 
-fn u32_at(buf: &[u8], off: usize) -> Result<u32, AbiError> {
+pub(crate) fn u32_at(buf: &[u8], off: usize) -> Result<u32, AbiError> {
     let b = buf.get(off..off + 4).ok_or(AbiError::Truncated)?;
     Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
 }
 
-fn put_f32(buf: &mut [u8], off: usize, v: f32) -> Result<(), AbiError> {
+pub(crate) fn put_f32(buf: &mut [u8], off: usize, v: f32) -> Result<(), AbiError> {
     let b = buf.get_mut(off..off + 4).ok_or(AbiError::Truncated)?;
     b.copy_from_slice(&v.to_le_bytes());
     Ok(())
 }
 
-fn put_u8(buf: &mut [u8], off: usize, v: u8) -> Result<(), AbiError> {
+pub(crate) fn put_u8(buf: &mut [u8], off: usize, v: u8) -> Result<(), AbiError> {
     *buf.get_mut(off).ok_or(AbiError::Truncated)? = v;
     Ok(())
 }
 
-fn put_u32(buf: &mut [u8], off: usize, v: u32) -> Result<(), AbiError> {
+pub(crate) fn put_u32(buf: &mut [u8], off: usize, v: u32) -> Result<(), AbiError> {
     let b = buf.get_mut(off..off + 4).ok_or(AbiError::Truncated)?;
     b.copy_from_slice(&v.to_le_bytes());
     Ok(())
 }
 
-fn or_nan(v: Option<f32>) -> f32 {
+pub(crate) fn or_nan(v: Option<f32>) -> f32 {
     v.unwrap_or(f32::NAN)
 }
 
@@ -443,31 +427,8 @@ fn encode_altitude(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError
     encode_heading(state, buf)
 }
 
-fn encode_heading(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
-    let heading = state.heading.data;
-    put_u8(
-        buf,
-        152,
-        heading.map_or(255, |sample| sample.reference.to_u8()),
-    )?;
-    let variation = state.variation.data;
-    put_u8(buf, 153, variation.map_or(0, |sample| sample.source.0))?;
-    put_u8(buf, 154, state.selections.heading_bug_reference.to_u8())?;
-    put_f32(buf, 156, or_nan(heading.map(|sample| sample.heading_rad)))?;
-    put_f32(buf, 160, or_nan(state.heading.age_ms))?;
-    put_f32(
-        buf,
-        164,
-        or_nan(variation.map(|sample| sample.east_positive_rad)),
-    )?;
-    put_f32(buf, 168, or_nan(state.variation.age_ms))?;
-    let flags2 = u8::from(state.valid.heading) | (u8::from(state.valid.variation) << 1);
-    put_u8(buf, 172, flags2)?;
-    for offset in 173..176 {
-        put_u8(buf, offset, 0)?;
-    }
-    Ok(())
-}
+mod groups;
+use groups::{decode_dynamics, decode_heading, decode_variation, encode_heading};
 
 #[cfg(test)]
 mod tests;

--- a/crates/pilotage-instrument-state/src/abi/groups.rs
+++ b/crates/pilotage-instrument-state/src/abi/groups.rs
@@ -1,0 +1,96 @@
+//! Wire codecs for the heading, variation, and dynamics groups.
+
+use crate::aircraft::{AircraftState, Stamped};
+use crate::dynamics::{DynSample, TurnBasis, TurnSample};
+use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
+
+use super::{AbiError, f32_at, opt, or_nan, put_f32, put_u8, u8_at};
+
+pub(super) fn decode_heading(buf: &[u8]) -> Result<Stamped<HeadingSample>, AbiError> {
+    let age = opt(f32_at(buf, 160)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 156)?)) {
+            (Some(_), Some(heading_rad)) => Some(HeadingSample {
+                heading_rad,
+                reference: HeadingReference::from_u8(u8_at(buf, 152)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+pub(super) fn decode_variation(buf: &[u8]) -> Result<Stamped<MagneticVariation>, AbiError> {
+    let age = opt(f32_at(buf, 168)?);
+    Ok(Stamped {
+        data: match (age, opt(f32_at(buf, 164)?)) {
+            (Some(_), Some(east_positive_rad)) => Some(MagneticVariation {
+                east_positive_rad,
+                source: VariationSourceId(u8_at(buf, 153)?),
+            }),
+            _ => None,
+        },
+        age_ms: age,
+    })
+}
+
+pub(super) fn decode_dynamics(buf: &[u8]) -> Result<Stamped<DynSample>, AbiError> {
+    let age = opt(f32_at(buf, 184)?);
+    Ok(Stamped {
+        data: match age {
+            Some(_) => Some(DynSample {
+                turn: opt(f32_at(buf, 176)?).map(|rate_rps| TurnSample {
+                    rate_rps,
+                    basis: TurnBasis::from_u8(buf.get(173).copied().unwrap_or(255)),
+                }),
+                lateral_mps2: opt(f32_at(buf, 180)?),
+            }),
+            None => None,
+        },
+        age_ms: age,
+    })
+}
+
+pub(super) fn encode_heading(state: &AircraftState, buf: &mut [u8]) -> Result<(), AbiError> {
+    let heading = state.heading.data;
+    put_u8(
+        buf,
+        152,
+        heading.map_or(255, |sample| sample.reference.to_u8()),
+    )?;
+    let variation = state.variation.data;
+    put_u8(buf, 153, variation.map_or(0, |sample| sample.source.0))?;
+    put_u8(buf, 154, state.selections.heading_bug_reference.to_u8())?;
+    put_f32(buf, 156, or_nan(heading.map(|sample| sample.heading_rad)))?;
+    put_f32(buf, 160, or_nan(state.heading.age_ms))?;
+    put_f32(
+        buf,
+        164,
+        or_nan(variation.map(|sample| sample.east_positive_rad)),
+    )?;
+    put_f32(buf, 168, or_nan(state.variation.age_ms))?;
+    let flags2 = u8::from(state.valid.heading)
+        | (u8::from(state.valid.variation) << 1)
+        | (u8::from(state.valid.turn) << 2)
+        | (u8::from(state.valid.slip) << 3);
+    put_u8(buf, 172, flags2)?;
+    let dynamics = state.dynamics.data.unwrap_or_default();
+    put_u8(
+        buf,
+        173,
+        dynamics.turn.map_or(255, |sample| sample.basis.to_u8()),
+    )?;
+    put_u8(buf, 174, 0)?;
+    put_u8(buf, 175, 0)?;
+    put_f32(
+        buf,
+        176,
+        or_nan(dynamics.turn.map(|sample| sample.rate_rps)),
+    )?;
+    put_f32(buf, 180, or_nan(dynamics.lateral_mps2))?;
+    put_f32(buf, 184, or_nan(state.dynamics.age_ms))?;
+    for offset in 188..192 {
+        put_u8(buf, offset, 0)?;
+    }
+    Ok(())
+}

--- a/crates/pilotage-instrument-state/src/abi/tests.rs
+++ b/crates/pilotage-instrument-state/src/abi/tests.rs
@@ -6,6 +6,7 @@ use crate::aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, Wind,
 };
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::dynamics::{DynSample, TurnBasis, TurnSample};
 use crate::heading::{HeadingReference, HeadingSample, MagneticVariation, VariationSourceId};
 use pilotage_frames::Quat;
 
@@ -26,6 +27,34 @@ fn full_variation() -> Stamped<MagneticVariation> {
             source: VariationSourceId(3),
         }),
         age_ms: Some(30.0),
+    }
+}
+
+fn full_dynamics() -> Stamped<DynSample> {
+    Stamped {
+        data: Some(DynSample {
+            turn: Some(TurnSample {
+                rate_rps: 0.05,
+                basis: TurnBasis::HeadingRate,
+            }),
+            lateral_mps2: Some(-0.8),
+        }),
+        age_ms: Some(15.0),
+    }
+}
+
+fn full_nav() -> Stamped<NavData> {
+    Stamped {
+        data: Some(NavData {
+            source: NavSource::Gps,
+            course_rad: 0.35,
+            cdi_dots: -1.2,
+            fromto: NavFromTo::To,
+            vdev_dots: Some(0.4),
+            dist_nm: Some(40.3),
+            course_reference: HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(9.0),
     }
 }
 
@@ -57,18 +86,7 @@ fn full_state() -> AircraftState {
             }),
             age_ms: Some(7.0),
         },
-        nav: Stamped {
-            data: Some(NavData {
-                source: NavSource::Gps,
-                course_rad: 0.35,
-                cdi_dots: -1.2,
-                fromto: NavFromTo::To,
-                vdev_dots: Some(0.4),
-                dist_nm: Some(40.3),
-                course_reference: HeadingReference::SimLocalTrue,
-            }),
-            age_ms: Some(9.0),
-        },
+        nav: full_nav(),
         wind: Stamped {
             data: Some(Wind {
                 from_rad: 4.7,
@@ -93,6 +111,8 @@ fn full_state() -> AircraftState {
             velocity: true,
             heading: true,
             variation: true,
+            turn: true,
+            slip: true,
         },
         snapshot: SnapshotMeta {
             generation: u32::MAX,
@@ -106,6 +126,7 @@ fn full_state() -> AircraftState {
         },
         heading: full_heading(),
         variation: full_variation(),
+        dynamics: full_dynamics(),
     }
 }
 
@@ -236,6 +257,29 @@ fn heading_and_variation_round_trip_exactly() {
     assert_eq!(
         decoded.selections.heading_bug_reference,
         state.selections.heading_bug_reference
+    );
+}
+
+#[test]
+fn dynamics_round_trip_and_unknown_basis_fails_closed() {
+    let mut block = [0u8; STATE_ABI_SIZE];
+    let state = full_state();
+    encode_state(&state, &mut block).expect("encodes");
+    let decoded = decode_state(&block).expect("decodes");
+    assert_eq!(decoded.dynamics, state.dynamics);
+    assert!(decoded.valid.turn && decoded.valid.slip);
+
+    block[173] = 9; // turn basis
+    let decoded = decode_state(&block).expect("decodes");
+    assert_eq!(
+        decoded
+            .dynamics
+            .data
+            .expect("dynamics present")
+            .turn
+            .expect("turn present")
+            .basis,
+        TurnBasis::Unknown
     );
 }
 

--- a/crates/pilotage-instrument-state/src/aircraft.rs
+++ b/crates/pilotage-instrument-state/src/aircraft.rs
@@ -1,6 +1,7 @@
 //! The raw input state a feeder writes.
 
 use crate::altitude::{AltitudeClass, AltitudeDeclaration, GeoidModelId, OriginId};
+use crate::dynamics::DynSample;
 use crate::heading::{HeadingReference, HeadingSample, MagneticVariation};
 use pilotage_frames::Quat;
 
@@ -162,6 +163,10 @@ pub struct ValidFlags {
     pub heading: bool,
     /// The variation sample is declared valid.
     pub variation: bool,
+    /// The turn-rate sample is declared valid.
+    pub turn: bool,
+    /// The lateral-force (slip/skid) sample is declared valid.
+    pub slip: bool,
 }
 
 /// One estimate group with the age a feeder stamped it with.
@@ -235,6 +240,9 @@ pub struct AircraftState {
     /// Magnetic-variation sample for the single sanctioned
     /// magnetic/true conversion path.
     pub variation: Stamped<MagneticVariation>,
+    /// Typed turn and slip/skid estimates (DYN-01); body rates never
+    /// substitute for either.
+    pub dynamics: Stamped<DynSample>,
 }
 
 impl Default for Selections {

--- a/crates/pilotage-instrument-state/src/dynamics.rs
+++ b/crates/pilotage-instrument-state/src/dynamics.rs
@@ -1,0 +1,85 @@
+//! Typed turn and slip/skid inputs (DYN-01).
+//!
+//! Body-axis yaw rate is not a turn indication: at nonzero roll or
+//! pitch, body `r`, heading rate, track rate, and rotation about local
+//! vertical are different quantities. The turn vocabulary here makes
+//! the basis explicit and gives body rate NO representation — a feeder
+//! cannot label body `r` as a turn rate even by mistake, and the
+//! display never derives one from attitude rates.
+//!
+//! Axes and signs: turn rate is positive turning RIGHT (clockwise from
+//! above), radians/second about the local vertical per the declared
+//! basis. Slip/skid input is lateral specific force along body +Y
+//! (right), meters/second²; the coordination ball displaces OPPOSITE
+//! the lateral specific force, so a positive (rightward) force shows
+//! the ball deflected LEFT. Both conventions are symmetric and pinned
+//! by tests.
+
+/// The quantity a turn-rate sample actually measures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TurnBasis {
+    /// Rate of change of heading (from the heading source's reference).
+    HeadingRate,
+    /// Rate of change of ground track.
+    TrackRate,
+    /// The wire carried a basis this build does not know, or none was
+    /// declared; the turn indication fails rather than guessing.
+    #[default]
+    Unknown,
+}
+
+impl TurnBasis {
+    /// Fail-closed wire decoding.
+    #[must_use]
+    pub const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::HeadingRate,
+            1 => Self::TrackRate,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Wire encoding; `Unknown` round-trips as unknown.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        match self {
+            Self::HeadingRate => 0,
+            Self::TrackRate => 1,
+            Self::Unknown => 255,
+        }
+    }
+
+    /// The cue label identifying this basis to the pilot.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::HeadingRate => "HDG",
+            Self::TrackRate => "TRK",
+            Self::Unknown => "REF",
+        }
+    }
+}
+
+/// One turn-rate sample with its declared basis.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TurnSample {
+    /// Turn rate in radians/second, positive turning right.
+    pub rate_rps: f32,
+    /// What the rate measures.
+    pub basis: TurnBasis,
+}
+
+/// The dynamics estimate group: turn and coordination, independently
+/// optional because a vehicle may provide either without the other.
+/// Missing slip stays missing — it is never synthesized centered.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct DynSample {
+    /// Turn-rate sample, when the upstream estimator provides one.
+    pub turn: Option<TurnSample>,
+    /// Lateral specific force along body +Y (right), m/s²; the slip
+    /// ball displaces opposite this force.
+    pub lateral_mps2: Option<f32>,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-state/src/dynamics/tests.rs
+++ b/crates/pilotage-instrument-state/src/dynamics/tests.rs
@@ -1,0 +1,27 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::TurnBasis;
+
+#[test]
+fn wire_bases_round_trip_and_unknown_fails_closed() {
+    for basis in [TurnBasis::HeadingRate, TurnBasis::TrackRate] {
+        assert_eq!(TurnBasis::from_u8(basis.to_u8()), basis);
+    }
+    for unknown in [2u8, 3, 100, 254, 255] {
+        assert_eq!(TurnBasis::from_u8(unknown), TurnBasis::Unknown);
+    }
+    assert_eq!(
+        TurnBasis::from_u8(TurnBasis::Unknown.to_u8()),
+        TurnBasis::Unknown
+    );
+}
+
+#[test]
+fn body_rate_has_no_representation() {
+    // The basis vocabulary is heading rate, track rate, or unknown —
+    // there is no variant a feeder could use to label body yaw rate as
+    // a turn indication, and the display never derives one.
+    assert_eq!(TurnBasis::from_u8(0).label(), "HDG");
+    assert_eq!(TurnBasis::from_u8(1).label(), "TRK");
+    assert_eq!(TurnBasis::from_u8(9).label(), "REF");
+}

--- a/crates/pilotage-instrument-state/src/lib.rs
+++ b/crates/pilotage-instrument-state/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod abi;
 mod aircraft;
 mod altitude;
+mod dynamics;
 mod heading;
 mod presentation;
 mod resolve;
@@ -38,6 +39,7 @@ pub use aircraft::{
     Selections, SnapshotCoherence, SnapshotMeta, Stamped, ValidFlags, Wind,
 };
 pub use altitude::{AltitudeClass, AltitudeDeclaration, AltitudeReference, GeoidModelId, OriginId};
+pub use dynamics::{DynSample, TurnBasis, TurnSample};
 pub use heading::{
     ConversionFault, HeadingReference, HeadingSample, MagneticVariation, VariationSourceId,
     convert_heading, shortest_angle_rad, wrap_2pi,

--- a/crates/pilotage-instrument-state/src/presentation.rs
+++ b/crates/pilotage-instrument-state/src/presentation.rs
@@ -63,6 +63,11 @@ impl Hysteresis {
 /// thresholds cannot exist.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AirframeDisplayProfile {
+    /// Whether a missing/failed turn or slip indication must show a
+    /// visible failure cue instead of quietly disappearing (DYN-01).
+    /// Benchmarked airframes with required rate/coordination displays
+    /// set this; the simulator profile sets it so absence is loud.
+    pub require_dynamics_cue: bool,
     unusual_pitch_up: Hysteresis,
     unusual_pitch_down: Hysteresis,
     unusual_bank: Hysteresis,
@@ -122,6 +127,7 @@ impl AirframeDisplayProfile {
             i += 1;
         }
         Ok(Self {
+            require_dynamics_cue: true,
             unusual_pitch_up: limits.unusual_pitch_up,
             unusual_pitch_down: limits.unusual_pitch_down,
             unusual_bank: limits.unusual_bank,
@@ -138,6 +144,7 @@ impl AirframeDisplayProfile {
     /// imply no aircraft approval.
     pub fn simulator() -> Self {
         Self {
+            require_dynamics_cue: true,
             unusual_pitch_up: Hysteresis {
                 entry: 30.0 * DEG,
                 exit: 25.0 * DEG,

--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -6,6 +6,7 @@ use crate::aircraft::{
     AircraftState, EstimateQuality, NavData, NavSource, Selections, SnapshotCoherence, Wind,
 };
 use crate::altitude::{AltitudeClass, OriginId};
+use crate::dynamics::TurnBasis;
 use crate::presentation::{AirframeDisplayProfile, AttitudePresentation, UnusualAttitudeState};
 use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
 use crate::units::{M_TO_FT, MPS_TO_FPM, MPS_TO_KT};
@@ -51,6 +52,19 @@ pub struct ResolvedAltitude {
     pub bug_compatible: bool,
 }
 
+/// Turn indication resolved from the typed dynamics group (DYN-01):
+/// the rate, its explicit basis, and nothing derived from body rates.
+/// The value is retained unclamped for monitoring — only the pointer
+/// geometry saturates at the display scale.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedTurn {
+    /// Turn rate in radians/second, positive right; NEVER body yaw
+    /// rate — an absent dynamics group resolves `Missing`.
+    pub rate_rps: Sig<f32>,
+    /// What the displayed rate measures.
+    pub basis: TurnBasis,
+}
+
 /// Display-ready state consumed by every panel.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PanelData {
@@ -63,8 +77,11 @@ pub struct PanelData {
     /// Heading bug presented in the rose reference; `Failed` when the
     /// bug's own reference is unknown or cannot convert.
     pub heading_bug_rose_rad: Sig<f32>,
-    /// Body yaw rate, radians/second (turn-rate proxy).
-    pub turn_rate_rps: Sig<f32>,
+    /// Typed turn indication; body rates never feed this.
+    pub turn: ResolvedTurn,
+    /// Lateral specific force (m/s², body +Y right) for the slip/skid
+    /// ball; missing stays missing, never synthesized centered.
+    pub slip_lat_mps2: Sig<f32>,
     /// Indicated airspeed, knots.
     pub ias_kt: Sig<f32>,
     /// Groundspeed, knots.
@@ -91,6 +108,9 @@ pub struct PanelData {
     /// continuous bank). Meaningful only while the attitude signals'
     /// status shows a value; an invalid attitude resets it to default.
     pub presentation: AttitudePresentation,
+    /// Profile policy: a missing/failed turn or slip indication must
+    /// show a visible failure cue (DYN-01).
+    pub require_dynamics_cue: bool,
 }
 
 fn quality_status(q: EstimateQuality) -> SignalStatus {
@@ -193,11 +213,10 @@ pub fn resolve_stateful(
         coherence: coherence_status(state.snapshot.coherence),
     };
 
-    let (presentation, turn_rate) = attitude_geometry(state, profile, unusual);
+    let presentation = attitude_geometry(state, profile, unusual);
     let has_att = state.attitude.data.is_some();
     let att_fresh = group_freshness(policy, has_att, state.attitude.age_ms);
     let att_status = trust.fold(has_att, att_fresh, integrity.attitude, state.valid.attitude);
-    let rate_status = trust.fold(has_att, att_fresh, integrity.rates, state.valid.rates);
 
     let has_kin = state.kinematics.data.is_some();
     let kin_fresh = group_freshness(policy, has_kin, state.kinematics.age_ms);
@@ -233,7 +252,8 @@ pub fn resolve_stateful(
         pitch_rad: finite(Sig::with_status(presentation.pitch_rad, att_status)),
         heading,
         heading_bug_rose_rad: finite(bug),
-        turn_rate_rps: finite(Sig::with_status(turn_rate, rate_status)),
+        turn: turn_resolved(state, policy, &trust, &integrity),
+        slip_lat_mps2: slip_resolved(state, policy, &trust, &integrity),
         ias_kt: finite(ias),
         gs_kt: finite(Sig::with_status(gs_kt, vel_status)),
         altitude: altitude_resolved(state, policy, &trust, &integrity, pos_status, rel_alt_ft),
@@ -245,6 +265,7 @@ pub fn resolve_stateful(
         selections: sanitized_selections(state.selections),
         integrity,
         presentation,
+        require_dynamics_cue: profile.require_dynamics_cue,
     }
 }
 
@@ -308,18 +329,18 @@ fn attitude_geometry(
     state: &AircraftState,
     profile: &AirframeDisplayProfile,
     unusual: &mut UnusualAttitudeState,
-) -> (AttitudePresentation, f32) {
+) -> AttitudePresentation {
     match state.attitude.data {
         Some(att) => match validate_quat(att.quat) {
-            Ok(quat) => (unusual.step(quat, profile), att.rates_rps[2]),
+            Ok(quat) => unusual.step(quat, profile),
             Err(_) => {
                 unusual.reset();
-                (AttitudePresentation::default(), att.rates_rps[2])
+                AttitudePresentation::default()
             }
         },
         None => {
             unusual.reset();
-            (AttitudePresentation::default(), 0.0)
+            AttitudePresentation::default()
         }
     }
 }
@@ -424,13 +445,17 @@ fn wind_signal(
 }
 
 mod altitude_signal;
+mod dynamics_signal;
 use altitude_signal::altitude_resolved;
+use dynamics_signal::{slip_resolved, turn_resolved};
 mod heading_signal;
 pub use heading_signal::ResolvedHeading;
 use heading_signal::{heading_resolved, presented_angle, presented_true, presented_wind};
 
 #[cfg(test)]
 mod altitude_tests;
+#[cfg(test)]
+mod dynamics_tests;
 #[cfg(test)]
 mod heading_tests;
 #[cfg(test)]

--- a/crates/pilotage-instrument-state/src/resolve/dynamics_signal.rs
+++ b/crates/pilotage-instrument-state/src/resolve/dynamics_signal.rs
@@ -1,0 +1,62 @@
+//! Resolution of the typed turn and slip/skid group (DYN-01).
+
+use crate::aircraft::AircraftState;
+use crate::dynamics::TurnBasis;
+use crate::signal::{FreshnessPolicy, Sig, SignalStatus};
+use crate::validate::StateIntegrity;
+
+use super::{ResolvedTurn, Trust, finite, group_freshness};
+
+/// Resolves the typed turn indication. Only the dynamics group feeds
+/// it: absence is `Missing` (body rates are not consulted), an unknown
+/// basis fails, and the value is retained unclamped for monitoring.
+pub(super) fn turn_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    trust: &Trust,
+    integrity: &StateIntegrity,
+) -> ResolvedTurn {
+    let sample = state.dynamics.data.and_then(|dynamics| dynamics.turn);
+    let has = sample.is_some();
+    let fresh = group_freshness(policy, state.dynamics.data.is_some(), state.dynamics.age_ms);
+    let status = if !has {
+        SignalStatus::Missing
+    } else {
+        trust.fold(true, fresh, integrity.dynamics, state.valid.turn)
+    };
+    let sample = sample.unwrap_or(crate::dynamics::TurnSample {
+        rate_rps: 0.0,
+        basis: TurnBasis::Unknown,
+    });
+    let status = if sample.basis == TurnBasis::Unknown && has {
+        SignalStatus::Failed
+    } else {
+        status
+    };
+    ResolvedTurn {
+        rate_rps: finite(Sig::with_status(sample.rate_rps, status)),
+        basis: sample.basis,
+    }
+}
+
+/// Resolves the slip/skid lateral force. Missing stays missing — a
+/// centered ball is a claim of coordination nobody made.
+pub(super) fn slip_resolved(
+    state: &AircraftState,
+    policy: &FreshnessPolicy,
+    trust: &Trust,
+    integrity: &StateIntegrity,
+) -> Sig<f32> {
+    let value = state
+        .dynamics
+        .data
+        .and_then(|dynamics| dynamics.lateral_mps2);
+    let fresh = group_freshness(policy, state.dynamics.data.is_some(), state.dynamics.age_ms);
+    match value {
+        Some(lateral) => finite(Sig::with_status(
+            lateral,
+            trust.fold(true, fresh, integrity.dynamics, state.valid.slip),
+        )),
+        None => Sig::missing(),
+    }
+}

--- a/crates/pilotage-instrument-state/src/resolve/dynamics_tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/dynamics_tests.rs
@@ -1,0 +1,143 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! DYN-01 resolution proofs: the turn indication is typed, body rates
+//! never substitute, slip stays missing when absent, and over-range
+//! values survive unclamped for monitoring.
+
+use super::tests::flying_state;
+use crate::aircraft::{AircraftState, Stamped};
+use crate::dynamics::{DynSample, TurnBasis, TurnSample};
+use crate::signal::{FreshnessPolicy, SignalStatus};
+use crate::{SnapshotCoherence, resolve};
+
+fn with_dynamics(turn: Option<TurnSample>, lateral: Option<f32>) -> AircraftState {
+    let mut state = flying_state();
+    state.dynamics = Stamped {
+        data: Some(DynSample {
+            turn,
+            lateral_mps2: lateral,
+        }),
+        age_ms: Some(20.0),
+    };
+    state.valid.turn = true;
+    state.valid.slip = true;
+    state
+}
+
+fn heading_turn(rate_rps: f32) -> Option<TurnSample> {
+    Some(TurnSample {
+        rate_rps,
+        basis: TurnBasis::HeadingRate,
+    })
+}
+
+#[test]
+fn body_yaw_rate_never_reaches_the_turn_indication() {
+    // A large body r at a rolled/pitched attitude with NO dynamics
+    // group: the turn indication is Missing, not 0.3 rad/s.
+    let mut state = flying_state();
+    if let Some(att) = state.attitude.data.as_mut() {
+        att.rates_rps = [0.1, 0.2, 0.3];
+    }
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Missing);
+    assert_eq!(p.turn.rate_rps.value, 0.0);
+    assert_eq!(p.turn.basis, TurnBasis::Unknown);
+}
+
+#[test]
+fn typed_turn_resolves_with_its_basis() {
+    let p = resolve(
+        &with_dynamics(heading_turn(0.05), None),
+        &FreshnessPolicy::default(),
+    );
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Valid);
+    assert!((p.turn.rate_rps.value - 0.05).abs() < 1e-6);
+    assert_eq!(p.turn.basis, TurnBasis::HeadingRate);
+    assert_eq!(p.turn.basis.label(), "HDG");
+}
+
+#[test]
+fn unknown_basis_fails_the_turn() {
+    let state = with_dynamics(
+        Some(TurnSample {
+            rate_rps: 0.05,
+            basis: TurnBasis::from_u8(9),
+        }),
+        None,
+    );
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Failed);
+}
+
+#[test]
+fn over_range_turn_is_retained_unclamped_for_monitoring() {
+    // 20°/s is far past the ±3°/s display scale; the resolved value
+    // keeps it exactly — only the pointer geometry saturates.
+    let rate = 20.0_f32.to_radians();
+    let p = resolve(
+        &with_dynamics(heading_turn(rate), None),
+        &FreshnessPolicy::default(),
+    );
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Valid);
+    assert!((p.turn.rate_rps.value - rate).abs() < 1e-6);
+}
+
+#[test]
+fn missing_slip_stays_missing_and_present_slip_is_symmetric() {
+    let p = resolve(
+        &with_dynamics(heading_turn(0.0), None),
+        &FreshnessPolicy::default(),
+    );
+    assert_eq!(p.slip_lat_mps2.status, SignalStatus::Missing);
+
+    let right = resolve(
+        &with_dynamics(heading_turn(0.0), Some(1.5)),
+        &FreshnessPolicy::default(),
+    );
+    let left = resolve(
+        &with_dynamics(heading_turn(0.0), Some(-1.5)),
+        &FreshnessPolicy::default(),
+    );
+    assert_eq!(right.slip_lat_mps2.status, SignalStatus::Valid);
+    assert!((right.slip_lat_mps2.value + left.slip_lat_mps2.value).abs() < 1e-6);
+}
+
+#[test]
+fn declared_invalidity_and_staleness_fail_the_dynamics() {
+    let mut state = with_dynamics(heading_turn(0.05), Some(0.5));
+    state.valid.turn = false;
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Failed);
+    assert_eq!(
+        p.slip_lat_mps2.status,
+        SignalStatus::Valid,
+        "slip validity is independent of the turn flag"
+    );
+
+    let mut state = with_dynamics(heading_turn(0.05), Some(0.5));
+    state.dynamics.age_ms = Some(1.0e7);
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Failed);
+    assert_eq!(p.slip_lat_mps2.status, SignalStatus::Failed);
+}
+
+#[test]
+fn coherence_skew_degrades_present_dynamics() {
+    let mut state = with_dynamics(heading_turn(0.05), Some(0.5));
+    state.snapshot.coherence = SnapshotCoherence::ExcessiveSkew;
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Degraded);
+    assert_eq!(p.slip_lat_mps2.status, SignalStatus::Degraded);
+}
+
+#[test]
+fn non_finite_dynamics_fail_with_typed_reason() {
+    let state = with_dynamics(heading_turn(f32::NAN), Some(0.5));
+    let p = resolve(&state, &FreshnessPolicy::default());
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Failed);
+    assert_eq!(
+        p.integrity.dynamics,
+        Some(crate::validate::GroupFault::NonFinite)
+    );
+}

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -85,8 +85,10 @@ fn source_invalidity_beats_freshness() {
     s.valid.attitude = false;
     let p = resolve(&s, &FreshnessPolicy::default());
     assert_eq!(p.roll_rad.status, SignalStatus::Failed);
-    // Rates flag is independent of the attitude flag.
-    assert_eq!(p.turn_rate_rps.status, SignalStatus::Valid);
+    // The turn indication comes only from the dynamics group; with no
+    // dynamics data it is Missing — body rates cannot leak in through
+    // an attitude-flag path (DYN-01).
+    assert_eq!(p.turn.rate_rps.status, SignalStatus::Missing);
 }
 
 #[test]
@@ -130,7 +132,6 @@ fn excessive_skew_degrades_both_stamped_groups() {
     // Each value stays individually usable (amber, shown) but the pair
     // must not present as one coherent aircraft state.
     assert_eq!(p.roll_rad.status, SignalStatus::Degraded);
-    assert_eq!(p.turn_rate_rps.status, SignalStatus::Degraded);
     assert_eq!(p.altitude.value_ft.status, SignalStatus::Degraded);
     assert_eq!(p.vsi_fpm.status, SignalStatus::Degraded);
     // Groups outside the stamped attitude/kinematics pair are untouched.
@@ -253,7 +254,8 @@ fn every_showable_output_is_finite_under_hostile_input() {
             ("roll", p.roll_rad),
             ("pitch", p.pitch_rad),
             ("heading", p.heading.value_rad),
-            ("turn", p.turn_rate_rps),
+            ("turn", p.turn.rate_rps),
+            ("slip", p.slip_lat_mps2),
             ("ias", p.ias_kt),
             ("gs", p.gs_kt),
             ("alt", p.altitude.value_ft),

--- a/crates/pilotage-instrument-state/src/validate.rs
+++ b/crates/pilotage-instrument-state/src/validate.rs
@@ -69,6 +69,9 @@ pub struct StateIntegrity {
     pub heading: Option<GroupFault>,
     /// Magnetic-variation fault: non-finite value or undeclared source.
     pub variation: Option<GroupFault>,
+    /// Dynamics fault: non-finite turn rate or lateral force, or an
+    /// unknown turn basis.
+    pub dynamics: Option<GroupFault>,
 }
 
 fn all_finite(values: &[f32]) -> bool {
@@ -172,6 +175,19 @@ pub fn validate_state(state: &AircraftState) -> StateIntegrity {
             integrity.variation = Some(GroupFault::NonFinite);
         } else if variation.source == crate::heading::VariationSourceId::UNDECLARED {
             integrity.variation = Some(GroupFault::SourceAbsent);
+        }
+    }
+    if let Some(dynamics) = &state.dynamics.data {
+        let turn_bad = dynamics.turn.is_some_and(|sample| {
+            !sample.rate_rps.is_finite() || sample.basis == crate::dynamics::TurnBasis::Unknown
+        });
+        let unknown_basis = dynamics
+            .turn
+            .is_some_and(|sample| sample.basis == crate::dynamics::TurnBasis::Unknown);
+        if unknown_basis {
+            integrity.dynamics = Some(GroupFault::UnknownEnum);
+        } else if turn_bad || !opt_finite(dynamics.lateral_mps2) {
+            integrity.dynamics = Some(GroupFault::NonFinite);
         }
     }
     integrity

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -3,7 +3,7 @@
 ./crates/pilotage-instrument-scene/src/decode.rs	decode_payload	94
 ./crates/pilotage-instrument-glyphs/src/sha256.rs	sha256	90
 ./crates/pilotage-conformance/src/fixture.rs	increment_zero_script	89
-./crates/pilotage-instrument-state/src/abi.rs	decode_state	129
+./crates/pilotage-instrument-state/src/abi.rs	decode_state	125
 ./crates/pilotage-instrument-state/src/abi.rs	encode_state	97
 ./crates/pilotage-authority/src/wire.rs	from	88
 ./adapters/aviate/src/adapter/tests.rs	stick_frame_reaches_the_fc_as_a_velocity_setpoint	93


### PR DESCRIPTION
Implements #23. **SIM / NOT FOR FLIGHT.**

## Design

- **`TurnBasis` makes the proxy unrepresentable**: the vocabulary is heading rate, track rate, or fail-closed Unknown — there is no variant through which a feeder could label body-axis yaw rate as a turn indication, and `attitude_geometry` no longer returns rates at all. An absent dynamics group resolves `Missing`; body `r` cannot leak in at any roll/pitch (`body_yaw_rate_never_reaches_the_turn_indication` pins a 0.3 rad/s body rate at a rolled/pitched attitude producing a Missing turn).
- **Basis and status are displayed**: the cue paints the basis label (HDG/TRK) beside the bar; unknown basis fails the indication.
- **Slip/skid is a typed input**: lateral specific force along body +Y (right positive), ball displaces **opposite** the force — the sign convention is documented on the type and pinned symmetric by both a resolution test and a rendering test. **Missing slip draws brackets and no ball** — never synthesized centered.
- **Clamp only the pointer**: the bar saturates at the ±73 px scale edge while the resolved value retains the over-range rate exactly for monitoring (`pointer_saturates_but_the_resolved_value_does_not`, 20°/s kept bit-exact behind a ±3°/s scale).
- **Profile-controlled failure cues**: `AirframeDisplayProfile.require_dynamics_cue` — when set (simulator profile sets it), a missing/failed turn or slip flags amber TRN / SLIP instead of quietly disappearing; when unset, absence is quiet (both sides tested).
- **Feeder-side derivation with documented limits**: the browser feeder derives heading rate by circular differencing of consecutive explicitly-declared SIM headings on its own coherent clock (dt bounds 5–500 ms; out-of-bounds pairs yield no sample, never a wild or frozen rate; 359°→1° differencing wraps correctly). Derivation lives upstream of the display, never inside it. Slip has no sim source and is never fabricated — the live PFD shows the SLIP flag honestly.
- **State ABI v5 (192 bytes)**: dynamics group (basis byte, turn rate, lateral force, age, valid bits 2/3) with fail-safe defaults, JS writer byte-parity tested including the undeclared-defaults case.

## Acceptance criteria → evidence

| Criterion (#23) | Evidence |
|---|---|
| No path labels body r as standard-rate turn | `TurnBasis` has no body-rate variant; `body_yaw_rate_never_reaches_the_turn_indication`; resolver never reads `rates_rps` for display |
| Displayed turn identifies basis and source status | basis label rendered (`cue_labels_its_basis`); Sig status drives visibility |
| Missing slip not shown centered | `missing_slip_never_draws_a_centered_ball` (zero circles painted) |
| Sign convention documented and symmetric | module docs + `slip_ball_deflects_opposite_the_lateral_force_symmetrically`, `missing_slip_stays_missing_and_present_slip_is_symmetric` |
| Required failures explicit | `missing_turn_flags_trn_when_the_profile_requires_a_cue` (both profile settings) |
| Saturation preserves original value | `over_range_turn_is_retained_unclamped_for_monitoring` + pointer test |
| ±3°/s exact, symmetric | `plus_minus_three_degrees_reach_the_reference_ticks_symmetrically` (bar geometry at the reference ticks) |
| 359/1 circular derivation | feeder `derivedSimTurn` wraps via (−π, π] differencing; heading-math wrap tests already pin the boundary |
| Status/recovery transitions | staleness, declared-invalidity (turn/slip independent), coherence-skew, non-finite each tested; no sleeps anywhere |

## Verification

Lane gates green: fmt, clippy `-D warnings`, tests across the four instrument crates (10 new resolution tests, 6 rendering tests, ABI round-trip + fail-closed basis, 3 vocabulary tests), doc, no_std, structure gate (resolve/abi split into `dynamics_signal`/`groups` submodules; decode_state baseline ratcheted down 129→125). All node suites pass; wasm rebuilt. **Frame hashes byte-identical** — the demo fixture sits in the unusual-attitude declutter tier where the cue does not paint, so the pinned hashes prove no collateral rendering change; the new drawing paths are covered by the six rendering tests instead.

Refs #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)