### PR TITLE
SVS-01: transport-independent geospatial, projection, coherence, and availability contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         run: >
           cargo check
           -p pilotage-frames
+          -p pilotage-geo
           -p pilotage-alerts
           -p pilotage-instrument-state
           -p pilotage-instrument-scene
@@ -86,6 +87,11 @@ jobs:
           -p pilotage-instrument-panels
           -p pilotage-instrument-raster
           --target thumbv7em-none-eabihf
+
+      - name: geospatial contract (SVS-01)
+        # Datum discipline, coherence, view/projection, availability, and the
+        # fail-closed versioned ABI for synthetic vision and conformal HUD.
+        run: cargo test -p pilotage-geo
 
       - name: reference rasterizer frame hashes (REN-03)
         # Re-render the PFD and HSI panels and assert their pinned SHA-256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-geo"
+version = "0.1.0"
+dependencies = [
+ "libm",
+ "pilotage-frames",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-input"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/pilotage-adapter-api",
     "crates/pilotage-conformance",
     "crates/pilotage-frames",
+    "crates/pilotage-geo",
     "crates/pilotage-alerts",
     "crates/pilotage-instrument-scene",
     "crates/pilotage-instrument-state",
@@ -48,6 +49,7 @@ pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-frames = { path = "crates/pilotage-frames" }
+pilotage-geo = { path = "crates/pilotage-geo" }
 pilotage-alerts = { path = "crates/pilotage-alerts" }
 pilotage-instrument-scene = { path = "crates/pilotage-instrument-scene" }
 pilotage-instrument-state = { path = "crates/pilotage-instrument-state" }

--- a/crates/pilotage-geo/Cargo.toml
+++ b/crates/pilotage-geo/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pilotage-geo"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-frames = { workspace = true }
+libm = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-geo/src/abi.rs
+++ b/crates/pilotage-geo/src/abi.rs
@@ -1,396 +1,194 @@
 //! The versioned, fixed-size, little-endian wire ABI for one synthetic-vision
 //! contract frame, independent of any transport or renderer.
 //!
-//! The layout is versioned by a leading `u32` and has a fixed length
-//! ([`SVS_FRAME_LEN`]); [`decode_frame`] fails closed on a truncated buffer, a
-//! version it does not read, an enumerated field outside its known set, a
-//! non-finite coordinate, or values that violate a semantic invariant (an MSL
-//! height without a geoid, an invalid view). Encoding is allocation-free: it
-//! writes into a fixed array.
+//! The wire carries only *raw inputs*: the stated position and attitude, the
+//! projection view, the producer-stated health of the inputs the contract
+//! cannot itself check, and the frame reference time. It carries **no
+//! availability**: availability is *derived* from validating those inputs, so a
+//! wire producer can never self-report an `Available` scene over untrusted
+//! inputs.
+//!
+//! [`decode_frame`] fails closed on a wrong-length buffer (a fixed block must
+//! match exactly — trailing bytes are as suspect as truncation), a version it
+//! does not read, an enumerated field outside its known set, a non-finite
+//! coordinate, a non-unit aircraft attitude, or any semantic invariant
+//! violation (an MSL height with no geoid, an incomplete calibration reference).
+//! It returns a [`ValidatedSvsFrame`] whose availability is computed here, not
+//! read. [`encode_frame`] serializes only a [`ValidatedSvsFrame`], so an invalid
+//! frame cannot be encoded, and it is allocation-free.
 
-use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, TimeScale};
+use pilotage_frames::Epoch;
 
-use crate::availability::{AvailabilityReason, SvsAvailability};
-use crate::datum::{
-    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
-};
-use crate::error::AbiError;
-use crate::identity::{
-    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
-    StatedPosition,
-};
-use crate::view::{
-    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
-    ProjectionView, Viewport,
-};
+use crate::availability::{ExternalHealth, SvsAvailability, SvsInputs, derive_inputs};
+use crate::error::{AbiError, GeoError};
+use crate::identity::{StatedAttitude, StatedPosition};
+use crate::view::ProjectionView;
+
+mod codec;
 
 /// The ABI version. Bumped when the layout changes; decode refuses any other.
-pub const ABI_VERSION: u32 = 1;
+pub const ABI_VERSION: u32 = 2;
 
-const STAMP_LEN: usize = 8 + 16 + 4 + 4 + (1 + 1 + 8) + 1 + (4 + 4) + 8;
-const GEODETIC_LEN: usize = 8 + 8 + 1 + 8 + 1 + 2 + 8;
-const POSITION_LEN: usize = GEODETIC_LEN + STAMP_LEN;
+/// Largest quaternion norm error tolerated before an attitude is refused as not
+/// a rotation.
+pub(crate) const ATTITUDE_NORM_TOLERANCE: f32 = 1e-4;
+
+const STAMP_LEN: usize = 8 + 16 + 4 + 4 + (1 + 1 + 8) + 1 + (16 + 4 + 8);
+const GEODETIC_LEN: usize = 8 + 8 + 1 + 2 + 8 + 1 + 2 + 4 + 4 + 8;
+const POSITION_LEN: usize = GEODETIC_LEN + STAMP_LEN + (4 + 4);
 const QUAT_LEN: usize = 4 * 4;
-const ATTITUDE_LEN: usize = QUAT_LEN + STAMP_LEN;
-const VIEW_LEN: usize = (4 + 4) + (8 + 8) + 3 + (8 + 8) + (24 + QUAT_LEN + 1 + 1);
+const ATTITUDE_LEN: usize = QUAT_LEN + STAMP_LEN + 4;
+const VIEW_LEN: usize = 8 + 32 + 8 + 1 + 8 + 8 + 8 + 8 + 1;
+const EXTERNAL_LEN: usize = 5;
+const EPOCH_LEN: usize = 1 + 1 + 8;
 
-/// The fixed byte length of one encoded [`SvsFrame`].
-pub const SVS_FRAME_LEN: usize = 4 + POSITION_LEN + ATTITUDE_LEN + VIEW_LEN + 2;
+/// The fixed byte length of one encoded frame.
+pub const SVS_FRAME_LEN: usize =
+    4 + POSITION_LEN + ATTITUDE_LEN + VIEW_LEN + EXTERNAL_LEN + EPOCH_LEN;
 
-/// One complete synthetic-vision contract frame: a stated position, a stated
-/// attitude, the projection view, and the availability verdict. TAWS is a
-/// separate input and is deliberately not part of this frame.
+/// A raw, unvalidated synthetic-vision frame: the inputs a producer states,
+/// before the contract derives availability. Build one and call
+/// [`RawSvsFrame::validate`] (or round-trip through the wire) to obtain a
+/// [`ValidatedSvsFrame`]; availability is never part of a raw frame.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SvsFrame {
+pub struct RawSvsFrame {
     /// The stated aircraft position (datum-explicit, stamped).
     pub position: StatedPosition,
     /// The stated aircraft attitude (stamped).
     pub attitude: StatedAttitude,
-    /// The projection view a renderer must honor.
+    /// The projection view (references the one validated calibration).
     pub view: ProjectionView,
-    /// The availability verdict.
-    pub availability: SvsAvailability,
+    /// Producer-stated health of the inputs the contract cannot itself check.
+    pub external: ExternalHealth,
+    /// The producer's reference ("as of") time; position/attitude ages and the
+    /// future-sample check are computed against it.
+    pub reference_time: Epoch,
 }
 
-// ---- little-endian writer / reader (bounds-checked, no panic) --------------
-
-struct Writer<'a> {
-    buf: &'a mut [u8],
-    off: usize,
-}
-
-impl Writer<'_> {
-    fn bytes(&mut self, b: &[u8]) {
-        if let Some(slot) = self.buf.get_mut(self.off..self.off + b.len()) {
-            slot.copy_from_slice(b);
+impl RawSvsFrame {
+    /// Validates the raw inputs and derives availability, failing closed on any
+    /// structural violation: a non-finite or out-of-range position, an
+    /// incomplete datum identity, a non-unit aircraft attitude, or an invalid
+    /// view. Availability (including time/coherence) is *derived*, never stated.
+    ///
+    /// # Errors
+    ///
+    /// A [`GeoError`] describing the first structural violation.
+    pub fn validate(&self) -> Result<ValidatedSvsFrame, GeoError> {
+        self.position.position.validate()?;
+        if self
+            .attitude
+            .attitude
+            .renormalized(ATTITUDE_NORM_TOLERANCE)
+            .is_err()
+        {
+            return Err(GeoError::AttitudeNotARotation);
         }
-        self.off += b.len();
-    }
-    fn u8(&mut self, v: u8) {
-        self.bytes(&[v]);
-    }
-    fn u16(&mut self, v: u16) {
-        self.bytes(&v.to_le_bytes());
-    }
-    fn u32(&mut self, v: u32) {
-        self.bytes(&v.to_le_bytes());
-    }
-    fn u64(&mut self, v: u64) {
-        self.bytes(&v.to_le_bytes());
-    }
-    fn f32(&mut self, v: f32) {
-        self.bytes(&v.to_le_bytes());
-    }
-    fn f64(&mut self, v: f64) {
-        self.bytes(&v.to_le_bytes());
+        self.view.validate()?;
+        Ok(ValidatedSvsFrame::assemble(
+            self.position,
+            self.attitude,
+            self.view,
+            self.external,
+            self.reference_time,
+        ))
     }
 }
 
-struct Reader<'a> {
-    buf: &'a [u8],
-    off: usize,
+/// A validated synthetic-vision frame. Its availability and derived input health
+/// are computed from the inputs and cannot be set independently: the fields are
+/// private and the only ways to obtain one are [`RawSvsFrame::validate`] and
+/// [`decode_frame`]. There is no path by which an untrusted input yields an
+/// [`SvsAvailability::Available`] frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ValidatedSvsFrame {
+    position: StatedPosition,
+    attitude: StatedAttitude,
+    view: ProjectionView,
+    external: ExternalHealth,
+    reference_time: Epoch,
+    inputs: SvsInputs,
+    availability: SvsAvailability,
 }
 
-impl Reader<'_> {
-    fn take(&mut self, n: usize) -> Result<&[u8], AbiError> {
-        let end = self.off + n;
-        let slot = self.buf.get(self.off..end).ok_or(AbiError::Truncated {
-            needed: end,
-            got: self.buf.len(),
-        })?;
-        self.off = end;
-        Ok(slot)
-    }
-    fn u8(&mut self) -> Result<u8, AbiError> {
-        Ok(self.take(1)?[0])
-    }
-    fn u16(&mut self) -> Result<u16, AbiError> {
-        let b = self.take(2)?;
-        Ok(u16::from_le_bytes([b[0], b[1]]))
-    }
-    fn u32(&mut self) -> Result<u32, AbiError> {
-        let b = self.take(4)?;
-        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-    }
-    fn u64(&mut self) -> Result<u64, AbiError> {
-        let b = self.take(8)?;
-        Ok(u64::from_le_bytes([
-            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
-        ]))
-    }
-    fn f32(&mut self) -> Result<f32, AbiError> {
-        let b = self.take(4)?;
-        Ok(f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-    }
-    fn f64(&mut self) -> Result<f64, AbiError> {
-        let b = self.take(8)?;
-        Ok(f64::from_le_bytes([
-            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
-        ]))
-    }
-    fn finite_f64(&mut self, field: &'static str) -> Result<f64, AbiError> {
-        let v = self.f64()?;
-        if v.is_finite() {
-            Ok(v)
-        } else {
-            Err(AbiError::NonFinite { field })
-        }
-    }
-    /// Reads one enumerated byte and maps it, failing closed with the actual
-    /// unknown value.
-    fn enum_u8<T>(&mut self, field: &'static str, map: fn(u8) -> Option<T>) -> Result<T, AbiError> {
-        let code = self.u8()?;
-        map(code).ok_or(AbiError::UnknownEnum { field, value: code })
-    }
-}
-
-const fn frame_from_u8(code: u8) -> Option<FrameId> {
-    match FrameId::from_u8(code) {
-        Ok(frame) => Some(frame),
-        Err(_) => None,
-    }
-}
-
-const fn clock_from_u8(code: u8) -> Option<ClockDomain> {
-    match code {
-        0 => Some(ClockDomain::VehicleBoot),
-        1 => Some(ClockDomain::Simulation),
-        2 => Some(ClockDomain::Gnss),
-        3 => Some(ClockDomain::Ground),
-        _ => None,
-    }
-}
-
-const fn scale_from_u8(code: u8) -> Option<TimeScale> {
-    match code {
-        0 => Some(TimeScale::Monotonic),
-        1 => Some(TimeScale::Gps),
-        2 => Some(TimeScale::Tai),
-        3 => Some(TimeScale::Utc),
-        _ => None,
-    }
-}
-
-// ---- encoders --------------------------------------------------------------
-
-fn put_stamp(w: &mut Writer, s: &SourceStamp) {
-    w.u64(s.source_id);
-    w.bytes(&s.incarnation.0);
-    w.u32(s.generation);
-    w.u32(s.sequence);
-    w.u8(s.acquired_at.clock as u8);
-    w.u8(s.acquired_at.scale as u8);
-    w.u64(s.acquired_at.nanos);
-    w.u8(s.integrity.to_u8());
-    w.u32(s.accuracy.horizontal_mm);
-    w.u32(s.accuracy.vertical_mm);
-    w.u64(s.snapshot.0);
-}
-
-fn put_quat(w: &mut Writer, q: &Quat) {
-    w.f32(q.w);
-    w.f32(q.x);
-    w.f32(q.y);
-    w.f32(q.z);
-}
-
-fn put_position(w: &mut Writer, p: &StatedPosition) {
-    let g = &p.position;
-    w.f64(g.latitude_deg);
-    w.f64(g.longitude_deg);
-    w.u8(g.horizontal_datum.to_u8());
-    w.f64(g.vertical.height_m);
-    w.u8(g.vertical.datum.to_u8());
-    w.u16(g.vertical.geoid.0);
-    w.u64(g.vertical.origin.0);
-    put_stamp(w, &p.stamp);
-}
-
-fn put_view(w: &mut Writer, v: &ProjectionView) {
-    w.u32(v.viewport.width_px);
-    w.u32(v.viewport.height_px);
-    w.f64(v.focal_x_px);
-    w.f64(v.focal_y_px);
-    w.u8(v.projection.to_u8());
-    w.u8(v.minification.to_u8());
-    w.u8(v.convention.to_u8());
-    w.f64(v.near_far.near_m);
-    w.f64(v.near_far.far_m);
-    for c in v.camera.translation_m {
-        w.f64(c);
-    }
-    put_quat(w, &v.camera.attitude);
-    w.u8(v.camera.from_frame.to_u8());
-    w.u8(v.camera.to_frame.to_u8());
-}
-
-fn put_availability(w: &mut Writer, a: SvsAvailability) {
-    let (kind, reason) = match a {
-        SvsAvailability::Available => (0, AvailabilityReason::Nominal),
-        SvsAvailability::Degraded(r) => (1, r),
-        SvsAvailability::Unavailable(r) => (2, r),
-    };
-    w.u8(kind);
-    w.u8(reason.to_u8());
-}
-
-/// Serializes one frame into its fixed-size canonical byte form.
-#[must_use]
-pub fn encode_frame(frame: &SvsFrame) -> [u8; SVS_FRAME_LEN] {
-    let mut buf = [0u8; SVS_FRAME_LEN];
-    let mut w = Writer {
-        buf: &mut buf,
-        off: 0,
-    };
-    w.u32(ABI_VERSION);
-    put_position(&mut w, &frame.position);
-    put_quat(&mut w, &frame.attitude.attitude);
-    put_stamp(&mut w, &frame.attitude.stamp);
-    put_view(&mut w, &frame.view);
-    put_availability(&mut w, frame.availability);
-    buf
-}
-
-// ---- decoders --------------------------------------------------------------
-
-fn get_stamp(r: &mut Reader) -> Result<SourceStamp, AbiError> {
-    let source_id = r.u64()?;
-    let inc = r.take(16)?;
-    let mut incarnation = [0u8; 16];
-    incarnation.copy_from_slice(inc);
-    let generation = r.u32()?;
-    let sequence = r.u32()?;
-    let clock = r.enum_u8("clock", clock_from_u8)?;
-    let scale = r.enum_u8("time_scale", scale_from_u8)?;
-    let nanos = r.u64()?;
-    let integrity = r.enum_u8("integrity", IntegrityLevel::from_u8)?;
-    let horizontal_mm = r.u32()?;
-    let vertical_mm = r.u32()?;
-    let snapshot = SnapshotId(r.u64()?);
-    Ok(SourceStamp {
-        source_id,
-        incarnation: SourceIncarnation(incarnation),
-        generation,
-        sequence,
-        acquired_at: Epoch {
-            clock,
-            scale,
-            nanos,
-        },
-        integrity,
-        accuracy: Accuracy {
-            horizontal_mm,
-            vertical_mm,
-        },
-        snapshot,
-    })
-}
-
-fn get_quat(r: &mut Reader) -> Result<Quat, AbiError> {
-    Ok(Quat {
-        w: r.f32()?,
-        x: r.f32()?,
-        y: r.f32()?,
-        z: r.f32()?,
-    })
-}
-
-fn get_position(r: &mut Reader) -> Result<StatedPosition, AbiError> {
-    let latitude_deg = r.finite_f64("latitude_deg")?;
-    let longitude_deg = r.finite_f64("longitude_deg")?;
-    let hdatum = r.enum_u8("horizontal_datum", HorizontalDatum::from_u8)?;
-    let height_m = r.finite_f64("height_m")?;
-    let vdatum = r.enum_u8("vertical_datum", VerticalDatum::from_u8)?;
-    let geoid = GeoidModelId(r.u16()?);
-    let origin = LocalOriginId(r.u64()?);
-    let stamp = get_stamp(r)?;
-    let vertical = VerticalPosition::new(height_m, vdatum, geoid, origin)
-        .map_err(|_| AbiError::Malformed { field: "vertical" })?;
-    let position = GeodeticPosition::new(latitude_deg, longitude_deg, hdatum, vertical)
-        .map_err(|_| AbiError::Malformed { field: "position" })?;
-    Ok(StatedPosition { position, stamp })
-}
-
-fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
-    let width_px = r.u32()?;
-    let height_px = r.u32()?;
-    let focal_x_px = r.finite_f64("focal_x_px")?;
-    let focal_y_px = r.finite_f64("focal_y_px")?;
-    let projection = r.enum_u8("projection", ProjectionKind::from_u8)?;
-    let minification = r.enum_u8("minification", MinificationPolicy::from_u8)?;
-    let convention = r.enum_u8("convention", OpticalConvention::from_u8)?;
-    let near_m = r.finite_f64("near_m")?;
-    let far_m = r.finite_f64("far_m")?;
-    let translation_m = [
-        r.finite_f64("cam_x")?,
-        r.finite_f64("cam_y")?,
-        r.finite_f64("cam_z")?,
-    ];
-    let attitude = get_quat(r)?;
-    let from_frame = r.enum_u8("camera_from_frame", frame_from_u8)?;
-    let to_frame = r.enum_u8("camera_to_frame", frame_from_u8)?;
-    let view = ProjectionView {
-        viewport: Viewport {
-            width_px,
-            height_px,
-        },
-        focal_x_px,
-        focal_y_px,
-        projection,
-        near_far: NearFarPolicy { near_m, far_m },
-        minification,
-        convention,
-        camera: CameraPose {
-            translation_m,
+impl ValidatedSvsFrame {
+    /// Derives the input health and availability and assembles the frame. The
+    /// caller must have already validated the structural invariants.
+    fn assemble(
+        position: StatedPosition,
+        attitude: StatedAttitude,
+        view: ProjectionView,
+        external: ExternalHealth,
+        reference_time: Epoch,
+    ) -> Self {
+        let inputs = derive_inputs(&position, &attitude, &external, reference_time);
+        let availability = SvsAvailability::assess(&inputs);
+        Self {
+            position,
             attitude,
-            from_frame,
-            to_frame,
-        },
-    };
-    view.validate()
-        .map_err(|_| AbiError::Malformed { field: "view" })?;
-    Ok(view)
-}
+            view,
+            external,
+            reference_time,
+            inputs,
+            availability,
+        }
+    }
 
-fn get_availability(r: &mut Reader) -> Result<SvsAvailability, AbiError> {
-    let kind = r.u8()?;
-    let reason = r.enum_u8("availability_reason", AvailabilityReason::from_u8)?;
-    match kind {
-        0 => Ok(SvsAvailability::Available),
-        1 => Ok(SvsAvailability::Degraded(reason)),
-        2 => Ok(SvsAvailability::Unavailable(reason)),
-        other => Err(AbiError::UnknownEnum {
-            field: "availability_kind",
-            value: other,
-        }),
+    /// The stated aircraft position.
+    #[must_use]
+    pub fn position(&self) -> &StatedPosition {
+        &self.position
+    }
+    /// The stated aircraft attitude.
+    #[must_use]
+    pub fn attitude(&self) -> &StatedAttitude {
+        &self.attitude
+    }
+    /// The projection view.
+    #[must_use]
+    pub fn view(&self) -> &ProjectionView {
+        &self.view
+    }
+    /// The producer-stated external input health.
+    #[must_use]
+    pub fn external_health(&self) -> ExternalHealth {
+        self.external
+    }
+    /// The producer's reference time.
+    #[must_use]
+    pub fn reference_time(&self) -> Epoch {
+        self.reference_time
+    }
+    /// The full derived input health.
+    #[must_use]
+    pub fn inputs(&self) -> SvsInputs {
+        self.inputs
+    }
+    /// The derived availability verdict.
+    #[must_use]
+    pub fn availability(&self) -> SvsAvailability {
+        self.availability
     }
 }
 
-/// Decodes one frame from its canonical byte form, failing closed.
+/// Serializes one validated frame into its fixed-size canonical byte form. Only
+/// a [`ValidatedSvsFrame`] can be encoded, so an invalid frame cannot be
+/// serialized. Availability is not encoded — it is derived on decode.
+#[must_use]
+pub fn encode_frame(frame: &ValidatedSvsFrame) -> [u8; SVS_FRAME_LEN] {
+    codec::encode(frame)
+}
+
+/// Decodes one frame from its canonical byte form, failing closed, and derives
+/// availability from the decoded inputs.
 ///
 /// # Errors
 ///
-/// [`AbiError`] on truncation, an unsupported version, an unknown enumerated
-/// value, a non-finite coordinate, or a semantically malformed block.
-pub fn decode_frame(buf: &[u8]) -> Result<SvsFrame, AbiError> {
-    let mut r = Reader { buf, off: 0 };
-    let version = r.u32()?;
-    if version != ABI_VERSION {
-        return Err(AbiError::BadVersion { found: version });
-    }
-    let position = get_position(&mut r)?;
-    let attitude = StatedAttitude {
-        attitude: get_quat(&mut r)?,
-        stamp: get_stamp(&mut r)?,
-    };
-    let view = get_view(&mut r)?;
-    let availability = get_availability(&mut r)?;
-    Ok(SvsFrame {
-        position,
-        attitude,
-        view,
-        availability,
-    })
+/// [`AbiError`] on a wrong-length buffer, an unsupported version, an unknown
+/// enumerated value, a non-finite coordinate, a non-unit attitude, or a
+/// semantically malformed block.
+pub fn decode_frame(buf: &[u8]) -> Result<ValidatedSvsFrame, AbiError> {
+    codec::decode(buf)
 }
 
 #[cfg(test)]

--- a/crates/pilotage-geo/src/abi.rs
+++ b/crates/pilotage-geo/src/abi.rs
@@ -38,7 +38,7 @@ const GEODETIC_LEN: usize = 8 + 8 + 1 + 2 + 8 + 1 + 2 + 4 + 4 + 8;
 const POSITION_LEN: usize = GEODETIC_LEN + STAMP_LEN + (4 + 4);
 const QUAT_LEN: usize = 4 * 4;
 const ATTITUDE_LEN: usize = QUAT_LEN + STAMP_LEN + 4;
-const VIEW_LEN: usize = 8 + 32 + 8 + 1 + 8 + 8 + 8 + 8 + 1;
+const VIEW_LEN: usize = 4 + 32 + 1 + 8 + 8 + 8 + 8 + 1;
 const EXTERNAL_LEN: usize = 5;
 const EPOCH_LEN: usize = 1 + 1 + 8;
 

--- a/crates/pilotage-geo/src/abi.rs
+++ b/crates/pilotage-geo/src/abi.rs
@@ -1,0 +1,397 @@
+//! The versioned, fixed-size, little-endian wire ABI for one synthetic-vision
+//! contract frame, independent of any transport or renderer.
+//!
+//! The layout is versioned by a leading `u32` and has a fixed length
+//! ([`SVS_FRAME_LEN`]); [`decode_frame`] fails closed on a truncated buffer, a
+//! version it does not read, an enumerated field outside its known set, a
+//! non-finite coordinate, or values that violate a semantic invariant (an MSL
+//! height without a geoid, an invalid view). Encoding is allocation-free: it
+//! writes into a fixed array.
+
+use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, TimeScale};
+
+use crate::availability::{AvailabilityReason, SvsAvailability};
+use crate::datum::{
+    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
+};
+use crate::error::AbiError;
+use crate::identity::{
+    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
+    StatedPosition,
+};
+use crate::view::{
+    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
+    ProjectionView, Viewport,
+};
+
+/// The ABI version. Bumped when the layout changes; decode refuses any other.
+pub const ABI_VERSION: u32 = 1;
+
+const STAMP_LEN: usize = 8 + 16 + 4 + 4 + (1 + 1 + 8) + 1 + (4 + 4) + 8;
+const GEODETIC_LEN: usize = 8 + 8 + 1 + 8 + 1 + 2 + 8;
+const POSITION_LEN: usize = GEODETIC_LEN + STAMP_LEN;
+const QUAT_LEN: usize = 4 * 4;
+const ATTITUDE_LEN: usize = QUAT_LEN + STAMP_LEN;
+const VIEW_LEN: usize = (4 + 4) + (8 + 8) + 3 + (8 + 8) + (24 + QUAT_LEN + 1 + 1);
+
+/// The fixed byte length of one encoded [`SvsFrame`].
+pub const SVS_FRAME_LEN: usize = 4 + POSITION_LEN + ATTITUDE_LEN + VIEW_LEN + 2;
+
+/// One complete synthetic-vision contract frame: a stated position, a stated
+/// attitude, the projection view, and the availability verdict. TAWS is a
+/// separate input and is deliberately not part of this frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SvsFrame {
+    /// The stated aircraft position (datum-explicit, stamped).
+    pub position: StatedPosition,
+    /// The stated aircraft attitude (stamped).
+    pub attitude: StatedAttitude,
+    /// The projection view a renderer must honor.
+    pub view: ProjectionView,
+    /// The availability verdict.
+    pub availability: SvsAvailability,
+}
+
+// ---- little-endian writer / reader (bounds-checked, no panic) --------------
+
+struct Writer<'a> {
+    buf: &'a mut [u8],
+    off: usize,
+}
+
+impl Writer<'_> {
+    fn bytes(&mut self, b: &[u8]) {
+        if let Some(slot) = self.buf.get_mut(self.off..self.off + b.len()) {
+            slot.copy_from_slice(b);
+        }
+        self.off += b.len();
+    }
+    fn u8(&mut self, v: u8) {
+        self.bytes(&[v]);
+    }
+    fn u16(&mut self, v: u16) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn u32(&mut self, v: u32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn f32(&mut self, v: f32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn f64(&mut self, v: f64) {
+        self.bytes(&v.to_le_bytes());
+    }
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    off: usize,
+}
+
+impl Reader<'_> {
+    fn take(&mut self, n: usize) -> Result<&[u8], AbiError> {
+        let end = self.off + n;
+        let slot = self.buf.get(self.off..end).ok_or(AbiError::Truncated {
+            needed: end,
+            got: self.buf.len(),
+        })?;
+        self.off = end;
+        Ok(slot)
+    }
+    fn u8(&mut self) -> Result<u8, AbiError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, AbiError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+    fn u32(&mut self) -> Result<u32, AbiError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, AbiError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+    fn f32(&mut self) -> Result<f32, AbiError> {
+        let b = self.take(4)?;
+        Ok(f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn f64(&mut self) -> Result<f64, AbiError> {
+        let b = self.take(8)?;
+        Ok(f64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+    fn finite_f64(&mut self, field: &'static str) -> Result<f64, AbiError> {
+        let v = self.f64()?;
+        if v.is_finite() {
+            Ok(v)
+        } else {
+            Err(AbiError::NonFinite { field })
+        }
+    }
+    /// Reads one enumerated byte and maps it, failing closed with the actual
+    /// unknown value.
+    fn enum_u8<T>(&mut self, field: &'static str, map: fn(u8) -> Option<T>) -> Result<T, AbiError> {
+        let code = self.u8()?;
+        map(code).ok_or(AbiError::UnknownEnum { field, value: code })
+    }
+}
+
+const fn frame_from_u8(code: u8) -> Option<FrameId> {
+    match FrameId::from_u8(code) {
+        Ok(frame) => Some(frame),
+        Err(_) => None,
+    }
+}
+
+const fn clock_from_u8(code: u8) -> Option<ClockDomain> {
+    match code {
+        0 => Some(ClockDomain::VehicleBoot),
+        1 => Some(ClockDomain::Simulation),
+        2 => Some(ClockDomain::Gnss),
+        3 => Some(ClockDomain::Ground),
+        _ => None,
+    }
+}
+
+const fn scale_from_u8(code: u8) -> Option<TimeScale> {
+    match code {
+        0 => Some(TimeScale::Monotonic),
+        1 => Some(TimeScale::Gps),
+        2 => Some(TimeScale::Tai),
+        3 => Some(TimeScale::Utc),
+        _ => None,
+    }
+}
+
+// ---- encoders --------------------------------------------------------------
+
+fn put_stamp(w: &mut Writer, s: &SourceStamp) {
+    w.u64(s.source_id);
+    w.bytes(&s.incarnation.0);
+    w.u32(s.generation);
+    w.u32(s.sequence);
+    w.u8(s.acquired_at.clock as u8);
+    w.u8(s.acquired_at.scale as u8);
+    w.u64(s.acquired_at.nanos);
+    w.u8(s.integrity.to_u8());
+    w.u32(s.accuracy.horizontal_mm);
+    w.u32(s.accuracy.vertical_mm);
+    w.u64(s.snapshot.0);
+}
+
+fn put_quat(w: &mut Writer, q: &Quat) {
+    w.f32(q.w);
+    w.f32(q.x);
+    w.f32(q.y);
+    w.f32(q.z);
+}
+
+fn put_position(w: &mut Writer, p: &StatedPosition) {
+    let g = &p.position;
+    w.f64(g.latitude_deg);
+    w.f64(g.longitude_deg);
+    w.u8(g.horizontal_datum.to_u8());
+    w.f64(g.vertical.height_m);
+    w.u8(g.vertical.datum.to_u8());
+    w.u16(g.vertical.geoid.0);
+    w.u64(g.vertical.origin.0);
+    put_stamp(w, &p.stamp);
+}
+
+fn put_view(w: &mut Writer, v: &ProjectionView) {
+    w.u32(v.viewport.width_px);
+    w.u32(v.viewport.height_px);
+    w.f64(v.focal_x_px);
+    w.f64(v.focal_y_px);
+    w.u8(v.projection.to_u8());
+    w.u8(v.minification.to_u8());
+    w.u8(v.convention.to_u8());
+    w.f64(v.near_far.near_m);
+    w.f64(v.near_far.far_m);
+    for c in v.camera.translation_m {
+        w.f64(c);
+    }
+    put_quat(w, &v.camera.attitude);
+    w.u8(v.camera.from_frame.to_u8());
+    w.u8(v.camera.to_frame.to_u8());
+}
+
+fn put_availability(w: &mut Writer, a: SvsAvailability) {
+    let (kind, reason) = match a {
+        SvsAvailability::Available => (0, AvailabilityReason::Nominal),
+        SvsAvailability::Degraded(r) => (1, r),
+        SvsAvailability::Unavailable(r) => (2, r),
+    };
+    w.u8(kind);
+    w.u8(reason.to_u8());
+}
+
+/// Serializes one frame into its fixed-size canonical byte form.
+#[must_use]
+pub fn encode_frame(frame: &SvsFrame) -> [u8; SVS_FRAME_LEN] {
+    let mut buf = [0u8; SVS_FRAME_LEN];
+    let mut w = Writer {
+        buf: &mut buf,
+        off: 0,
+    };
+    w.u32(ABI_VERSION);
+    put_position(&mut w, &frame.position);
+    put_quat(&mut w, &frame.attitude.attitude);
+    put_stamp(&mut w, &frame.attitude.stamp);
+    put_view(&mut w, &frame.view);
+    put_availability(&mut w, frame.availability);
+    buf
+}
+
+// ---- decoders --------------------------------------------------------------
+
+fn get_stamp(r: &mut Reader) -> Result<SourceStamp, AbiError> {
+    let source_id = r.u64()?;
+    let inc = r.take(16)?;
+    let mut incarnation = [0u8; 16];
+    incarnation.copy_from_slice(inc);
+    let generation = r.u32()?;
+    let sequence = r.u32()?;
+    let clock = r.enum_u8("clock", clock_from_u8)?;
+    let scale = r.enum_u8("time_scale", scale_from_u8)?;
+    let nanos = r.u64()?;
+    let integrity = r.enum_u8("integrity", IntegrityLevel::from_u8)?;
+    let horizontal_mm = r.u32()?;
+    let vertical_mm = r.u32()?;
+    let snapshot = SnapshotId(r.u64()?);
+    Ok(SourceStamp {
+        source_id,
+        incarnation: SourceIncarnation(incarnation),
+        generation,
+        sequence,
+        acquired_at: Epoch {
+            clock,
+            scale,
+            nanos,
+        },
+        integrity,
+        accuracy: Accuracy {
+            horizontal_mm,
+            vertical_mm,
+        },
+        snapshot,
+    })
+}
+
+fn get_quat(r: &mut Reader) -> Result<Quat, AbiError> {
+    Ok(Quat {
+        w: r.f32()?,
+        x: r.f32()?,
+        y: r.f32()?,
+        z: r.f32()?,
+    })
+}
+
+fn get_position(r: &mut Reader) -> Result<StatedPosition, AbiError> {
+    let latitude_deg = r.finite_f64("latitude_deg")?;
+    let longitude_deg = r.finite_f64("longitude_deg")?;
+    let hdatum = r.enum_u8("horizontal_datum", HorizontalDatum::from_u8)?;
+    let height_m = r.finite_f64("height_m")?;
+    let vdatum = r.enum_u8("vertical_datum", VerticalDatum::from_u8)?;
+    let geoid = GeoidModelId(r.u16()?);
+    let origin = LocalOriginId(r.u64()?);
+    let stamp = get_stamp(r)?;
+    let vertical = VerticalPosition::new(height_m, vdatum, geoid, origin)
+        .map_err(|_| AbiError::Malformed { field: "vertical" })?;
+    let position = GeodeticPosition::new(latitude_deg, longitude_deg, hdatum, vertical)
+        .map_err(|_| AbiError::Malformed { field: "position" })?;
+    Ok(StatedPosition { position, stamp })
+}
+
+fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
+    let width_px = r.u32()?;
+    let height_px = r.u32()?;
+    let focal_x_px = r.finite_f64("focal_x_px")?;
+    let focal_y_px = r.finite_f64("focal_y_px")?;
+    let projection = r.enum_u8("projection", ProjectionKind::from_u8)?;
+    let minification = r.enum_u8("minification", MinificationPolicy::from_u8)?;
+    let convention = r.enum_u8("convention", OpticalConvention::from_u8)?;
+    let near_m = r.finite_f64("near_m")?;
+    let far_m = r.finite_f64("far_m")?;
+    let translation_m = [
+        r.finite_f64("cam_x")?,
+        r.finite_f64("cam_y")?,
+        r.finite_f64("cam_z")?,
+    ];
+    let attitude = get_quat(r)?;
+    let from_frame = r.enum_u8("camera_from_frame", frame_from_u8)?;
+    let to_frame = r.enum_u8("camera_to_frame", frame_from_u8)?;
+    let view = ProjectionView {
+        viewport: Viewport {
+            width_px,
+            height_px,
+        },
+        focal_x_px,
+        focal_y_px,
+        projection,
+        near_far: NearFarPolicy { near_m, far_m },
+        minification,
+        convention,
+        camera: CameraPose {
+            translation_m,
+            attitude,
+            from_frame,
+            to_frame,
+        },
+    };
+    view.validate()
+        .map_err(|_| AbiError::Malformed { field: "view" })?;
+    Ok(view)
+}
+
+fn get_availability(r: &mut Reader) -> Result<SvsAvailability, AbiError> {
+    let kind = r.u8()?;
+    let reason = r.enum_u8("availability_reason", AvailabilityReason::from_u8)?;
+    match kind {
+        0 => Ok(SvsAvailability::Available),
+        1 => Ok(SvsAvailability::Degraded(reason)),
+        2 => Ok(SvsAvailability::Unavailable(reason)),
+        other => Err(AbiError::UnknownEnum {
+            field: "availability_kind",
+            value: other,
+        }),
+    }
+}
+
+/// Decodes one frame from its canonical byte form, failing closed.
+///
+/// # Errors
+///
+/// [`AbiError`] on truncation, an unsupported version, an unknown enumerated
+/// value, a non-finite coordinate, or a semantically malformed block.
+pub fn decode_frame(buf: &[u8]) -> Result<SvsFrame, AbiError> {
+    let mut r = Reader { buf, off: 0 };
+    let version = r.u32()?;
+    if version != ABI_VERSION {
+        return Err(AbiError::BadVersion { found: version });
+    }
+    let position = get_position(&mut r)?;
+    let attitude = StatedAttitude {
+        attitude: get_quat(&mut r)?,
+        stamp: get_stamp(&mut r)?,
+    };
+    let view = get_view(&mut r)?;
+    let availability = get_availability(&mut r)?;
+    Ok(SvsFrame {
+        position,
+        attitude,
+        view,
+        availability,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/abi/codec.rs
+++ b/crates/pilotage-geo/src/abi/codec.rs
@@ -14,7 +14,9 @@ use crate::identity::{
     AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
     SourceStamp, StatedAttitude, StatedPosition,
 };
-use crate::view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
+use crate::view::{
+    CalibrationId, CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView,
+};
 
 use super::{ABI_VERSION, ATTITUDE_NORM_TOLERANCE, SVS_FRAME_LEN, ValidatedSvsFrame};
 
@@ -111,8 +113,8 @@ impl Reader<'_> {
         let code = self.u8()?;
         map(code).ok_or(AbiError::UnknownEnum { field, value: code })
     }
-    fn health(&mut self) -> Result<InputHealth, AbiError> {
-        Ok(InputHealth::from_u8_fail_closed(self.u8()?))
+    fn health(&mut self, field: &'static str) -> Result<InputHealth, AbiError> {
+        self.enum_u8(field, InputHealth::from_u8)
     }
     fn epoch(&mut self) -> Result<Epoch, AbiError> {
         let clock = self.enum_u8("clock", clock_from_u8)?;
@@ -188,9 +190,8 @@ fn put_position(w: &mut Writer, p: &StatedPosition) {
 }
 
 fn put_view(w: &mut Writer, v: &ProjectionView) {
-    w.u64(v.calibration.calibration_id);
+    w.u32(v.calibration.calibration_id.0);
     w.bytes(&v.calibration.content_hash);
-    w.f64(v.calibration.alignment_bound_rad);
     w.u8(v.projection.kind_u8());
     let (ex, ey) = match v.projection {
         Projection::Perspective => (0.0, 0.0),
@@ -330,10 +331,9 @@ fn get_attitude(r: &mut Reader) -> Result<StatedAttitude, AbiError> {
 }
 
 fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
-    let calibration_id = r.u64()?;
+    let calibration_id = CalibrationId(r.u32()?);
     let mut content_hash = [0u8; 32];
     content_hash.copy_from_slice(r.take(32)?);
-    let alignment_bound_rad = r.finite_f64("alignment_bound_rad")?;
     let projection_kind = r.u8()?;
     let extent_x_m = r.f64()?;
     let extent_y_m = r.f64()?;
@@ -357,7 +357,6 @@ fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
         calibration: CalibrationRef {
             calibration_id,
             content_hash,
-            alignment_bound_rad,
         },
         projection,
         near_far: NearFarPolicy { near_m, far_m },
@@ -372,11 +371,11 @@ fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
 
 fn get_external(r: &mut Reader) -> Result<ExternalHealth, AbiError> {
     Ok(ExternalHealth {
-        integrity: r.health()?,
-        calibration: r.health()?,
-        database: r.health()?,
-        coverage: r.health()?,
-        renderer: r.health()?,
+        integrity: r.health("external_integrity")?,
+        calibration: r.health("external_calibration")?,
+        database: r.health("external_database")?,
+        coverage: r.health("external_coverage")?,
+        renderer: r.health("external_renderer")?,
     })
 }
 

--- a/crates/pilotage-geo/src/abi/codec.rs
+++ b/crates/pilotage-geo/src/abi/codec.rs
@@ -1,0 +1,408 @@
+//! Little-endian encode/decode for the SVS frame ABI, bounds-checked and
+//! panic-free. This is the byte layer only; the frame types and the public
+//! [`encode`]/[`decode`] entry points live in the parent module.
+
+use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+
+use crate::availability::{ExternalHealth, InputHealth};
+use crate::datum::{
+    BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
+};
+use crate::error::{AbiError, GeoError};
+use crate::identity::{
+    AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
+    SourceStamp, StatedAttitude, StatedPosition,
+};
+use crate::view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
+
+use super::{ABI_VERSION, ATTITUDE_NORM_TOLERANCE, SVS_FRAME_LEN, ValidatedSvsFrame};
+
+// ---- little-endian writer / reader (bounds-checked, no panic) --------------
+
+struct Writer<'a> {
+    buf: &'a mut [u8],
+    off: usize,
+}
+
+impl Writer<'_> {
+    fn bytes(&mut self, b: &[u8]) {
+        if let Some(slot) = self.buf.get_mut(self.off..self.off + b.len()) {
+            slot.copy_from_slice(b);
+        }
+        self.off += b.len();
+    }
+    fn u8(&mut self, v: u8) {
+        self.bytes(&[v]);
+    }
+    fn u16(&mut self, v: u16) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn u32(&mut self, v: u32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn f32(&mut self, v: f32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn f64(&mut self, v: f64) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn epoch(&mut self, e: Epoch) {
+        self.u8(e.clock as u8);
+        self.u8(e.scale as u8);
+        self.u64(e.nanos);
+    }
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    off: usize,
+}
+
+impl Reader<'_> {
+    fn take(&mut self, n: usize) -> Result<&[u8], AbiError> {
+        let end = self.off + n;
+        let slot = self.buf.get(self.off..end).ok_or(AbiError::WrongLength {
+            needed: SVS_FRAME_LEN,
+            got: self.buf.len(),
+        })?;
+        self.off = end;
+        Ok(slot)
+    }
+    fn u8(&mut self) -> Result<u8, AbiError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, AbiError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+    fn u32(&mut self) -> Result<u32, AbiError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, AbiError> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+    fn f32(&mut self) -> Result<f32, AbiError> {
+        let b = self.take(4)?;
+        Ok(f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn f64(&mut self) -> Result<f64, AbiError> {
+        let b = self.take(8)?;
+        Ok(f64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+    fn finite_f64(&mut self, field: &'static str) -> Result<f64, AbiError> {
+        let v = self.f64()?;
+        if v.is_finite() {
+            Ok(v)
+        } else {
+            Err(AbiError::NonFinite { field })
+        }
+    }
+    fn enum_u8<T>(&mut self, field: &'static str, map: fn(u8) -> Option<T>) -> Result<T, AbiError> {
+        let code = self.u8()?;
+        map(code).ok_or(AbiError::UnknownEnum { field, value: code })
+    }
+    fn health(&mut self) -> Result<InputHealth, AbiError> {
+        Ok(InputHealth::from_u8_fail_closed(self.u8()?))
+    }
+    fn epoch(&mut self) -> Result<Epoch, AbiError> {
+        let clock = self.enum_u8("clock", clock_from_u8)?;
+        let scale = self.enum_u8("time_scale", scale_from_u8)?;
+        let nanos = self.u64()?;
+        Ok(Epoch {
+            clock,
+            scale,
+            nanos,
+        })
+    }
+}
+
+const fn clock_from_u8(code: u8) -> Option<ClockDomain> {
+    match code {
+        0 => Some(ClockDomain::VehicleBoot),
+        1 => Some(ClockDomain::Simulation),
+        2 => Some(ClockDomain::Gnss),
+        3 => Some(ClockDomain::Ground),
+        _ => None,
+    }
+}
+
+const fn scale_from_u8(code: u8) -> Option<TimeScale> {
+    match code {
+        0 => Some(TimeScale::Monotonic),
+        1 => Some(TimeScale::Gps),
+        2 => Some(TimeScale::Tai),
+        3 => Some(TimeScale::Utc),
+        _ => None,
+    }
+}
+
+// ---- encoders --------------------------------------------------------------
+
+fn put_stamp(w: &mut Writer, s: &SourceStamp) {
+    w.u64(s.source_id);
+    w.bytes(&s.incarnation.0);
+    w.u32(s.generation);
+    w.u32(s.sequence);
+    w.epoch(s.acquired_at);
+    w.u8(s.integrity.to_u8());
+    w.bytes(&s.snapshot.producer.0);
+    w.u32(s.snapshot.generation);
+    w.u64(s.snapshot.id);
+}
+
+fn put_quat(w: &mut Writer, q: &Quat) {
+    w.f32(q.w);
+    w.f32(q.x);
+    w.f32(q.y);
+    w.f32(q.z);
+}
+
+fn put_geodetic(w: &mut Writer, g: &GeodeticPosition) {
+    w.f64(g.latitude_deg);
+    w.f64(g.longitude_deg);
+    w.u8(g.horizontal_datum.to_u8());
+    w.u16(g.realization.0);
+    w.f64(g.vertical.height_m);
+    w.u8(g.vertical.datum.to_u8());
+    w.u16(g.vertical.geoid.0);
+    w.u32(g.vertical.terrain_ref.0);
+    w.u32(g.vertical.baro_setting.0);
+    w.u64(g.vertical.origin.0);
+}
+
+fn put_position(w: &mut Writer, p: &StatedPosition) {
+    put_geodetic(w, &p.position);
+    put_stamp(w, &p.stamp);
+    w.u32(p.quality.horizontal_mm);
+    w.u32(p.quality.vertical_mm);
+}
+
+fn put_view(w: &mut Writer, v: &ProjectionView) {
+    w.u64(v.calibration.calibration_id);
+    w.bytes(&v.calibration.content_hash);
+    w.f64(v.calibration.alignment_bound_rad);
+    w.u8(v.projection.kind_u8());
+    let (ex, ey) = match v.projection {
+        Projection::Perspective => (0.0, 0.0),
+        Projection::Orthographic {
+            extent_x_m,
+            extent_y_m,
+        } => (extent_x_m, extent_y_m),
+    };
+    w.f64(ex);
+    w.f64(ey);
+    w.f64(v.near_far.near_m);
+    w.f64(v.near_far.far_m);
+    w.u8(v.minification.to_u8());
+}
+
+fn put_external(w: &mut Writer, e: &ExternalHealth) {
+    w.u8(e.integrity.to_u8());
+    w.u8(e.calibration.to_u8());
+    w.u8(e.database.to_u8());
+    w.u8(e.coverage.to_u8());
+    w.u8(e.renderer.to_u8());
+}
+
+/// Serializes one validated frame into its fixed-size canonical byte form.
+pub(super) fn encode(frame: &ValidatedSvsFrame) -> [u8; SVS_FRAME_LEN] {
+    let mut buf = [0u8; SVS_FRAME_LEN];
+    let mut w = Writer {
+        buf: &mut buf,
+        off: 0,
+    };
+    w.u32(ABI_VERSION);
+    put_position(&mut w, frame.position());
+    put_quat(&mut w, &frame.attitude().attitude);
+    put_stamp(&mut w, &frame.attitude().stamp);
+    w.u32(frame.attitude().quality.angular_mrad);
+    put_view(&mut w, frame.view());
+    put_external(&mut w, &frame.external_health());
+    w.epoch(frame.reference_time());
+    buf
+}
+
+// ---- decoders --------------------------------------------------------------
+
+fn get_stamp(r: &mut Reader) -> Result<SourceStamp, AbiError> {
+    let source_id = r.u64()?;
+    let mut incarnation = [0u8; 16];
+    incarnation.copy_from_slice(r.take(16)?);
+    let generation = r.u32()?;
+    let sequence = r.u32()?;
+    let acquired_at = r.epoch()?;
+    let integrity = r.enum_u8("integrity", IntegrityLevel::from_u8)?;
+    let mut producer = [0u8; 16];
+    producer.copy_from_slice(r.take(16)?);
+    let snap_generation = r.u32()?;
+    let snap_id = r.u64()?;
+    Ok(SourceStamp {
+        source_id,
+        incarnation: SourceIncarnation(incarnation),
+        generation,
+        sequence,
+        acquired_at,
+        integrity,
+        snapshot: CoherentSnapshot {
+            producer: SourceIncarnation(producer),
+            generation: snap_generation,
+            id: snap_id,
+        },
+    })
+}
+
+fn get_quat(r: &mut Reader) -> Result<Quat, AbiError> {
+    Ok(Quat {
+        w: r.f32()?,
+        x: r.f32()?,
+        y: r.f32()?,
+        z: r.f32()?,
+    })
+}
+
+fn get_geodetic(r: &mut Reader) -> Result<GeodeticPosition, AbiError> {
+    let latitude_deg = r.finite_f64("latitude_deg")?;
+    let longitude_deg = r.finite_f64("longitude_deg")?;
+    let hdatum = r.enum_u8("horizontal_datum", HorizontalDatum::from_u8)?;
+    let realization = DatumRealizationId(r.u16()?);
+    let height_m = r.finite_f64("height_m")?;
+    let vdatum = r.enum_u8("vertical_datum", VerticalDatum::from_u8)?;
+    let geoid = GeoidModelId(r.u16()?);
+    let terrain_ref = TerrainRefId(r.u32()?);
+    let baro_setting = BaroSettingId(r.u32()?);
+    let origin = LocalOriginId(r.u64()?);
+    let vertical =
+        VerticalPosition::new(height_m, vdatum, geoid, terrain_ref, baro_setting, origin).map_err(
+            |reason| AbiError::Malformed {
+                field: "vertical",
+                reason,
+            },
+        )?;
+    GeodeticPosition::new(latitude_deg, longitude_deg, hdatum, realization, vertical).map_err(
+        |reason| AbiError::Malformed {
+            field: "position",
+            reason,
+        },
+    )
+}
+
+fn get_position(r: &mut Reader) -> Result<StatedPosition, AbiError> {
+    let position = get_geodetic(r)?;
+    let stamp = get_stamp(r)?;
+    let quality = PositionQuality {
+        horizontal_mm: r.u32()?,
+        vertical_mm: r.u32()?,
+    };
+    Ok(StatedPosition {
+        position,
+        stamp,
+        quality,
+    })
+}
+
+fn get_attitude(r: &mut Reader) -> Result<StatedAttitude, AbiError> {
+    let attitude = get_quat(r)?;
+    if attitude.renormalized(ATTITUDE_NORM_TOLERANCE).is_err() {
+        return Err(AbiError::Malformed {
+            field: "attitude",
+            reason: GeoError::AttitudeNotARotation,
+        });
+    }
+    let stamp = get_stamp(r)?;
+    let quality = AttitudeQuality {
+        angular_mrad: r.u32()?,
+    };
+    Ok(StatedAttitude {
+        attitude,
+        stamp,
+        quality,
+    })
+}
+
+fn get_view(r: &mut Reader) -> Result<ProjectionView, AbiError> {
+    let calibration_id = r.u64()?;
+    let mut content_hash = [0u8; 32];
+    content_hash.copy_from_slice(r.take(32)?);
+    let alignment_bound_rad = r.finite_f64("alignment_bound_rad")?;
+    let projection_kind = r.u8()?;
+    let extent_x_m = r.f64()?;
+    let extent_y_m = r.f64()?;
+    let near_m = r.finite_f64("near_m")?;
+    let far_m = r.finite_f64("far_m")?;
+    let minification = r.enum_u8("minification", MinificationPolicy::from_u8)?;
+    let projection = match projection_kind {
+        0 => Projection::Perspective,
+        1 => Projection::Orthographic {
+            extent_x_m,
+            extent_y_m,
+        },
+        other => {
+            return Err(AbiError::UnknownEnum {
+                field: "projection",
+                value: other,
+            });
+        }
+    };
+    let view = ProjectionView {
+        calibration: CalibrationRef {
+            calibration_id,
+            content_hash,
+            alignment_bound_rad,
+        },
+        projection,
+        near_far: NearFarPolicy { near_m, far_m },
+        minification,
+    };
+    view.validate().map_err(|reason| AbiError::Malformed {
+        field: "view",
+        reason,
+    })?;
+    Ok(view)
+}
+
+fn get_external(r: &mut Reader) -> Result<ExternalHealth, AbiError> {
+    Ok(ExternalHealth {
+        integrity: r.health()?,
+        calibration: r.health()?,
+        database: r.health()?,
+        coverage: r.health()?,
+        renderer: r.health()?,
+    })
+}
+
+/// Decodes one frame from its canonical byte form, failing closed.
+pub(super) fn decode(buf: &[u8]) -> Result<ValidatedSvsFrame, AbiError> {
+    if buf.len() != SVS_FRAME_LEN {
+        return Err(AbiError::WrongLength {
+            needed: SVS_FRAME_LEN,
+            got: buf.len(),
+        });
+    }
+    let mut r = Reader { buf, off: 0 };
+    let version = r.u32()?;
+    if version != ABI_VERSION {
+        return Err(AbiError::BadVersion { found: version });
+    }
+    let position = get_position(&mut r)?;
+    let attitude = get_attitude(&mut r)?;
+    let view = get_view(&mut r)?;
+    let external = get_external(&mut r)?;
+    let reference_time = r.epoch()?;
+    Ok(ValidatedSvsFrame::assemble(
+        position,
+        attitude,
+        view,
+        external,
+        reference_time,
+    ))
+}

--- a/crates/pilotage-geo/src/abi/tests.rs
+++ b/crates/pilotage-geo/src/abi/tests.rs
@@ -1,0 +1,163 @@
+//! Round-trip and fail-closed decode tests for the SVS frame ABI.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, TimeScale};
+
+use super::{ABI_VERSION, SVS_FRAME_LEN, SvsFrame, decode_frame, encode_frame};
+use crate::availability::{AvailabilityReason, SvsAvailability};
+use crate::datum::{
+    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
+};
+use crate::error::AbiError;
+use crate::identity::{
+    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
+    StatedPosition,
+};
+use crate::view::{
+    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
+    ProjectionView, Viewport,
+};
+
+fn stamp() -> SourceStamp {
+    SourceStamp {
+        source_id: 42,
+        incarnation: SourceIncarnation([3; 16]),
+        generation: 1,
+        sequence: 7,
+        acquired_at: Epoch {
+            clock: ClockDomain::Gnss,
+            scale: TimeScale::Gps,
+            nanos: 1_700_000_000_000_000_000,
+        },
+        integrity: IntegrityLevel::Trusted,
+        accuracy: Accuracy {
+            horizontal_mm: 1500,
+            vertical_mm: 3000,
+        },
+        snapshot: SnapshotId(99),
+    }
+}
+
+fn frame() -> SvsFrame {
+    let vertical = VerticalPosition::new(
+        250.0,
+        VerticalDatum::Msl,
+        GeoidModelId(1),
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("well-formed vertical");
+    let position = GeodeticPosition::new(37.62, -122.38, HorizontalDatum::Wgs84, vertical)
+        .expect("well-formed position");
+    SvsFrame {
+        position: StatedPosition {
+            position,
+            stamp: stamp(),
+        },
+        attitude: StatedAttitude {
+            attitude: Quat::IDENTITY,
+            stamp: stamp(),
+        },
+        view: ProjectionView {
+            viewport: Viewport {
+                width_px: 320,
+                height_px: 240,
+            },
+            focal_x_px: 190.0,
+            focal_y_px: 190.0,
+            projection: ProjectionKind::Perspective,
+            near_far: NearFarPolicy {
+                near_m: 0.1,
+                far_m: 20_000.0,
+            },
+            minification: MinificationPolicy::Trilinear,
+            convention: OpticalConvention::OpenCv,
+            camera: CameraPose {
+                translation_m: [1.1, 0.0, 0.3],
+                attitude: Quat::IDENTITY,
+                from_frame: FrameId::Body,
+                to_frame: FrameId::Installation,
+            },
+        },
+        availability: SvsAvailability::Degraded(AvailabilityReason::Coverage),
+    }
+}
+
+#[test]
+fn frame_round_trips_through_the_abi() {
+    let original = frame();
+    let bytes = encode_frame(&original);
+    assert_eq!(bytes.len(), SVS_FRAME_LEN);
+    let decoded = decode_frame(&bytes).expect("round-trips");
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn wrong_version_fails_closed() {
+    let mut bytes = encode_frame(&frame());
+    bytes[0] = bytes[0].wrapping_add(1);
+    assert!(matches!(
+        decode_frame(&bytes),
+        Err(AbiError::BadVersion { .. })
+    ));
+    assert_eq!(u32::from_le_bytes([1, 0, 0, 0]), ABI_VERSION);
+}
+
+#[test]
+fn truncated_buffer_fails_closed() {
+    let bytes = encode_frame(&frame());
+    assert!(matches!(
+        decode_frame(&bytes[..SVS_FRAME_LEN - 1]),
+        Err(AbiError::Truncated { .. })
+    ));
+    assert!(matches!(decode_frame(&[]), Err(AbiError::Truncated { .. })));
+}
+
+#[test]
+fn unknown_enum_value_fails_closed() {
+    // The horizontal-datum byte sits right after version(4) + lat(8) + lon(8).
+    let mut bytes = encode_frame(&frame());
+    bytes[20] = 200;
+    match decode_frame(&bytes) {
+        Err(AbiError::UnknownEnum { field, value }) => {
+            assert_eq!(field, "horizontal_datum");
+            assert_eq!(value, 200, "the actual unknown value is reported");
+        }
+        other => panic!("expected UnknownEnum, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_finite_coordinate_fails_closed() {
+    let mut bytes = encode_frame(&frame());
+    // Overwrite the latitude (offset 4..12) with a NaN bit pattern.
+    bytes[4..12].copy_from_slice(&f64::NAN.to_le_bytes());
+    assert!(matches!(
+        decode_frame(&bytes),
+        Err(AbiError::NonFinite {
+            field: "latitude_deg"
+        })
+    ));
+}
+
+#[test]
+fn semantically_malformed_block_fails_closed() {
+    // Change the vertical datum byte to MSL(2) while the geoid stays undeclared
+    // for a frame whose vertical was built as Ellipsoid — decode must refuse.
+    let vertical = VerticalPosition::new(
+        250.0,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("ellipsoid");
+    let position = GeodeticPosition::new(1.0, 2.0, HorizontalDatum::Wgs84, vertical).expect("pos");
+    let mut f = frame();
+    f.position.position = position;
+    let mut bytes = encode_frame(&f);
+    // vertical-datum byte: version(4)+lat(8)+lon(8)+hdatum(1)+height(8) = 29.
+    bytes[29] = VerticalDatum::Msl.to_u8();
+    assert!(matches!(
+        decode_frame(&bytes),
+        Err(AbiError::Malformed { field: "vertical" })
+    ));
+}

--- a/crates/pilotage-geo/src/abi/tests.rs
+++ b/crates/pilotage-geo/src/abi/tests.rs
@@ -18,7 +18,9 @@ use crate::identity::{
     AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
     SourceStamp, StatedAttitude, StatedPosition,
 };
-use crate::view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
+use crate::view::{
+    CalibrationId, CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView,
+};
 
 const ACQ_NS: u64 = 1_700_000_000_000_000_000;
 const REF_NS: u64 = ACQ_NS + 10_000_000; // 10 ms after acquisition: fresh.
@@ -89,9 +91,8 @@ fn attitude(integrity: IntegrityLevel) -> StatedAttitude {
 fn view() -> ProjectionView {
     ProjectionView {
         calibration: CalibrationRef {
-            calibration_id: 0x0FED_CBA9,
+            calibration_id: CalibrationId(0x0FED_CBA9),
             content_hash: [7u8; 32],
-            alignment_bound_rad: 0.0117,
         },
         projection: Projection::Perspective,
         near_far: NearFarPolicy {
@@ -319,15 +320,15 @@ fn an_incomplete_datum_identity_fails_closed() {
 #[test]
 fn an_incomplete_calibration_reference_fails_closed() {
     let mut r = raw();
-    r.view.calibration.calibration_id = 0;
+    r.view.calibration.calibration_id = CalibrationId::NONE;
     assert!(matches!(
         r.validate(),
         Err(crate::error::GeoError::IncompleteCalibrationReference)
     ));
-    // Decode refuses a zero calibration id on the wire (id at view offset:
+    // Decode refuses a zero calibration id on the wire (u32 id at view offset:
     // version(4)+position(125)+attitude(91) = 220).
     let mut bytes = encode_frame(&validated());
-    bytes[220..228].copy_from_slice(&0u64.to_le_bytes());
+    bytes[220..224].copy_from_slice(&0u32.to_le_bytes());
     assert!(matches!(
         decode_frame(&bytes),
         Err(AbiError::Malformed { field: "view", .. })
@@ -364,6 +365,24 @@ fn an_orthographic_frame_is_not_read_as_perspective() {
         },
         "the projection kind byte selects the payload; it is not silently perspective",
     );
+}
+
+#[test]
+fn an_unknown_external_health_byte_is_refused_not_coerced() {
+    // External health sits just before the 10-byte reference time; the first of
+    // its five bytes is the navigation-integrity monitor. An unknown value must
+    // be refused with UnknownEnum, not silently coerced to Failed — otherwise
+    // decode-then-encode would change the bytes.
+    let mut bytes = encode_frame(&validated());
+    let external_off = SVS_FRAME_LEN - 5 - 10;
+    bytes[external_off] = 200;
+    match decode_frame(&bytes) {
+        Err(AbiError::UnknownEnum { field, value }) => {
+            assert_eq!(field, "external_integrity");
+            assert_eq!(value, 200);
+        }
+        other => panic!("expected UnknownEnum, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/pilotage-geo/src/abi/tests.rs
+++ b/crates/pilotage-geo/src/abi/tests.rs
@@ -1,121 +1,282 @@
-//! Round-trip and fail-closed decode tests for the SVS frame ABI.
+//! Round-trip, fail-closed, and hostile cross-field tests for the SVS frame
+//! ABI. Availability is derived, never decoded: the central hostile case is
+//! that an untrusted or incoherent input can never yield an available scene.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, TimeScale};
+use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
-use super::{ABI_VERSION, SVS_FRAME_LEN, SvsFrame, decode_frame, encode_frame};
-use crate::availability::{AvailabilityReason, SvsAvailability};
+use super::{
+    ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,
+};
+use crate::availability::{AvailabilityReason, ExternalHealth, InputHealth, SvsAvailability};
 use crate::datum::{
-    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
+    BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
 };
 use crate::error::AbiError;
 use crate::identity::{
-    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
-    StatedPosition,
+    AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
+    SourceStamp, StatedAttitude, StatedPosition,
 };
-use crate::view::{
-    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
-    ProjectionView, Viewport,
-};
+use crate::view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
 
-fn stamp() -> SourceStamp {
+const ACQ_NS: u64 = 1_700_000_000_000_000_000;
+const REF_NS: u64 = ACQ_NS + 10_000_000; // 10 ms after acquisition: fresh.
+
+fn epoch(nanos: u64) -> Epoch {
+    Epoch {
+        clock: ClockDomain::Gnss,
+        scale: TimeScale::Gps,
+        nanos,
+    }
+}
+
+fn snapshot() -> CoherentSnapshot {
+    CoherentSnapshot {
+        producer: SourceIncarnation([9; 16]),
+        generation: 4,
+        id: 99,
+    }
+}
+
+fn stamp(integrity: IntegrityLevel) -> SourceStamp {
     SourceStamp {
         source_id: 42,
         incarnation: SourceIncarnation([3; 16]),
         generation: 1,
         sequence: 7,
-        acquired_at: Epoch {
-            clock: ClockDomain::Gnss,
-            scale: TimeScale::Gps,
-            nanos: 1_700_000_000_000_000_000,
-        },
-        integrity: IntegrityLevel::Trusted,
-        accuracy: Accuracy {
-            horizontal_mm: 1500,
-            vertical_mm: 3000,
-        },
-        snapshot: SnapshotId(99),
+        acquired_at: epoch(ACQ_NS),
+        integrity,
+        snapshot: snapshot(),
     }
 }
 
-fn frame() -> SvsFrame {
+fn position(integrity: IntegrityLevel) -> StatedPosition {
     let vertical = VerticalPosition::new(
         250.0,
         VerticalDatum::Msl,
         GeoidModelId(1),
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
     .expect("well-formed vertical");
-    let position = GeodeticPosition::new(37.62, -122.38, HorizontalDatum::Wgs84, vertical)
-        .expect("well-formed position");
-    SvsFrame {
-        position: StatedPosition {
-            position,
-            stamp: stamp(),
+    StatedPosition {
+        position: GeodeticPosition::new(
+            37.62,
+            -122.38,
+            HorizontalDatum::Wgs84,
+            DatumRealizationId::UNDECLARED,
+            vertical,
+        )
+        .expect("well-formed position"),
+        stamp: stamp(integrity),
+        quality: PositionQuality {
+            horizontal_mm: 1500,
+            vertical_mm: 3000,
         },
-        attitude: StatedAttitude {
-            attitude: Quat::IDENTITY,
-            stamp: stamp(),
-        },
-        view: ProjectionView {
-            viewport: Viewport {
-                width_px: 320,
-                height_px: 240,
-            },
-            focal_x_px: 190.0,
-            focal_y_px: 190.0,
-            projection: ProjectionKind::Perspective,
-            near_far: NearFarPolicy {
-                near_m: 0.1,
-                far_m: 20_000.0,
-            },
-            minification: MinificationPolicy::Trilinear,
-            convention: OpticalConvention::OpenCv,
-            camera: CameraPose {
-                translation_m: [1.1, 0.0, 0.3],
-                attitude: Quat::IDENTITY,
-                from_frame: FrameId::Body,
-                to_frame: FrameId::Installation,
-            },
-        },
-        availability: SvsAvailability::Degraded(AvailabilityReason::Coverage),
     }
 }
 
+fn attitude(integrity: IntegrityLevel) -> StatedAttitude {
+    StatedAttitude {
+        attitude: Quat::IDENTITY,
+        stamp: stamp(integrity),
+        quality: AttitudeQuality { angular_mrad: 5 },
+    }
+}
+
+fn view() -> ProjectionView {
+    ProjectionView {
+        calibration: CalibrationRef {
+            calibration_id: 0x0FED_CBA9,
+            content_hash: [7u8; 32],
+            alignment_bound_rad: 0.0117,
+        },
+        projection: Projection::Perspective,
+        near_far: NearFarPolicy {
+            near_m: 0.1,
+            far_m: 20_000.0,
+        },
+        minification: MinificationPolicy::Trilinear,
+    }
+}
+
+fn external_ok() -> ExternalHealth {
+    let ok = InputHealth::Ok;
+    ExternalHealth {
+        integrity: ok,
+        calibration: ok,
+        database: ok,
+        coverage: ok,
+        renderer: ok,
+    }
+}
+
+/// A fully trusted, fresh, coherent raw frame — the only shape that derives an
+/// available scene.
+fn raw() -> RawSvsFrame {
+    RawSvsFrame {
+        position: position(IntegrityLevel::Trusted),
+        attitude: attitude(IntegrityLevel::Trusted),
+        view: view(),
+        external: external_ok(),
+        reference_time: epoch(REF_NS),
+    }
+}
+
+fn validated() -> ValidatedSvsFrame {
+    raw().validate().expect("the nominal frame validates")
+}
+
 #[test]
-fn frame_round_trips_through_the_abi() {
-    let original = frame();
+fn frame_round_trips_through_the_abi_and_derives_availability() {
+    let original = validated();
+    assert_eq!(original.availability(), SvsAvailability::Available);
     let bytes = encode_frame(&original);
     assert_eq!(bytes.len(), SVS_FRAME_LEN);
     let decoded = decode_frame(&bytes).expect("round-trips");
     assert_eq!(decoded, original);
+    assert_eq!(
+        decoded.availability(),
+        SvsAvailability::Available,
+        "availability is recomputed identically on decode"
+    );
+}
+
+#[test]
+fn availability_is_never_read_from_the_wire() {
+    // Untrusted position integrity: the derived verdict is Unavailable no matter
+    // what a producer might wish. There is no wire byte a producer could set to
+    // claim Available over this input.
+    let mut r = raw();
+    r.position = position(IntegrityLevel::Untrusted);
+    let f = r.validate().expect("structurally valid, just untrusted");
+    assert_eq!(
+        f.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+    // Round-trips as still Unavailable — the wire carried no availability.
+    let decoded = decode_frame(&encode_frame(&f)).expect("round-trips");
+    assert_eq!(
+        decoded.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+}
+
+#[test]
+fn unknown_integrity_input_is_never_available() {
+    let mut r = raw();
+    r.attitude = attitude(IntegrityLevel::Unknown);
+    let f = r.validate().expect("structurally valid");
+    assert_eq!(
+        f.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::Attitude),
+    );
+}
+
+#[test]
+fn a_non_unit_aircraft_attitude_is_refused() {
+    // validate() refuses it structurally.
+    let mut r = raw();
+    r.attitude.attitude = Quat {
+        w: 2.0,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    assert!(matches!(
+        r.validate(),
+        Err(crate::error::GeoError::AttitudeNotARotation)
+    ));
+    // And decode refuses a wire frame whose attitude quaternion is not unit.
+    let mut bytes = encode_frame(&validated());
+    // Aircraft quaternion w is the first f32 of the attitude block at offset
+    // version(4) + position(125) = 129.
+    bytes[129..133].copy_from_slice(&2.0f32.to_le_bytes());
+    assert!(matches!(
+        decode_frame(&bytes),
+        Err(AbiError::Malformed {
+            field: "attitude",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_future_acquisition_fails_time_coherence() {
+    let mut r = raw();
+    r.reference_time = epoch(ACQ_NS - 1); // before acquisition: a future sample.
+    let f = r.validate().expect("structurally valid");
+    assert_eq!(
+        f.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}
+
+#[test]
+fn a_snapshot_id_collision_across_streams_is_not_coherent() {
+    // Position and attitude share the numeric snapshot id but from different
+    // producers: not one coherent snapshot, so the scene is unavailable.
+    let mut r = raw();
+    r.attitude.stamp.snapshot.producer = SourceIncarnation([1; 16]);
+    let f = r.validate().expect("structurally valid");
+    assert_eq!(
+        f.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}
+
+#[test]
+fn a_clock_or_scale_mismatch_fails_time_coherence() {
+    let mut r = raw();
+    r.attitude.stamp.acquired_at = Epoch {
+        clock: ClockDomain::Simulation,
+        scale: TimeScale::Monotonic,
+        nanos: ACQ_NS,
+    };
+    let f = r.validate().expect("structurally valid");
+    assert_eq!(
+        f.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}
+
+#[test]
+fn wrong_length_fails_closed_including_trailing_bytes() {
+    let bytes = encode_frame(&validated());
+    assert!(matches!(
+        decode_frame(&bytes[..SVS_FRAME_LEN - 1]),
+        Err(AbiError::WrongLength { .. })
+    ));
+    assert!(matches!(
+        decode_frame(&[]),
+        Err(AbiError::WrongLength { .. })
+    ));
+    // Trailing bytes are as suspect as truncation for a fixed-size block.
+    let mut too_long = bytes.to_vec();
+    too_long.push(0);
+    assert!(
+        matches!(decode_frame(&too_long), Err(AbiError::WrongLength { .. })),
+        "a fixed block must match its length exactly"
+    );
 }
 
 #[test]
 fn wrong_version_fails_closed() {
-    let mut bytes = encode_frame(&frame());
+    let mut bytes = encode_frame(&validated());
     bytes[0] = bytes[0].wrapping_add(1);
     assert!(matches!(
         decode_frame(&bytes),
         Err(AbiError::BadVersion { .. })
     ));
-    assert_eq!(u32::from_le_bytes([1, 0, 0, 0]), ABI_VERSION);
-}
-
-#[test]
-fn truncated_buffer_fails_closed() {
-    let bytes = encode_frame(&frame());
-    assert!(matches!(
-        decode_frame(&bytes[..SVS_FRAME_LEN - 1]),
-        Err(AbiError::Truncated { .. })
-    ));
-    assert!(matches!(decode_frame(&[]), Err(AbiError::Truncated { .. })));
+    assert_eq!(u32::from_le_bytes([2, 0, 0, 0]), ABI_VERSION);
 }
 
 #[test]
 fn unknown_enum_value_fails_closed() {
     // The horizontal-datum byte sits right after version(4) + lat(8) + lon(8).
-    let mut bytes = encode_frame(&frame());
+    let mut bytes = encode_frame(&validated());
     bytes[20] = 200;
     match decode_frame(&bytes) {
         Err(AbiError::UnknownEnum { field, value }) => {
@@ -128,7 +289,7 @@ fn unknown_enum_value_fails_closed() {
 
 #[test]
 fn non_finite_coordinate_fails_closed() {
-    let mut bytes = encode_frame(&frame());
+    let mut bytes = encode_frame(&validated());
     // Overwrite the latitude (offset 4..12) with a NaN bit pattern.
     bytes[4..12].copy_from_slice(&f64::NAN.to_le_bytes());
     assert!(matches!(
@@ -140,24 +301,79 @@ fn non_finite_coordinate_fails_closed() {
 }
 
 #[test]
-fn semantically_malformed_block_fails_closed() {
-    // Change the vertical datum byte to MSL(2) while the geoid stays undeclared
-    // for a frame whose vertical was built as Ellipsoid — decode must refuse.
-    let vertical = VerticalPosition::new(
-        250.0,
-        VerticalDatum::Ellipsoid,
-        GeoidModelId::UNDECLARED,
-        LocalOriginId::UNDECLARED,
-    )
-    .expect("ellipsoid");
-    let position = GeodeticPosition::new(1.0, 2.0, HorizontalDatum::Wgs84, vertical).expect("pos");
-    let mut f = frame();
-    f.position.position = position;
-    let mut bytes = encode_frame(&f);
-    // vertical-datum byte: version(4)+lat(8)+lon(8)+hdatum(1)+height(8) = 29.
-    bytes[29] = VerticalDatum::Msl.to_u8();
+fn an_incomplete_datum_identity_fails_closed() {
+    // Flip the vertical datum to AGL while the terrain reference stays
+    // undeclared (the nominal frame is MSL with a geoid); decode must refuse.
+    let mut bytes = encode_frame(&validated());
+    // vdatum byte: version(4)+lat(8)+lon(8)+hdatum(1)+realization(2)+height(8) = 31.
+    bytes[31] = VerticalDatum::Agl.to_u8();
     assert!(matches!(
         decode_frame(&bytes),
-        Err(AbiError::Malformed { field: "vertical" })
+        Err(AbiError::Malformed {
+            field: "vertical",
+            ..
+        })
     ));
+}
+
+#[test]
+fn an_incomplete_calibration_reference_fails_closed() {
+    let mut r = raw();
+    r.view.calibration.calibration_id = 0;
+    assert!(matches!(
+        r.validate(),
+        Err(crate::error::GeoError::IncompleteCalibrationReference)
+    ));
+    // Decode refuses a zero calibration id on the wire (id at view offset:
+    // version(4)+position(125)+attitude(91) = 220).
+    let mut bytes = encode_frame(&validated());
+    bytes[220..228].copy_from_slice(&0u64.to_le_bytes());
+    assert!(matches!(
+        decode_frame(&bytes),
+        Err(AbiError::Malformed { field: "view", .. })
+    ));
+}
+
+#[test]
+fn an_orthographic_view_without_extents_fails_closed() {
+    let mut r = raw();
+    r.view.projection = Projection::Orthographic {
+        extent_x_m: 0.0,
+        extent_y_m: 375.0,
+    };
+    assert!(matches!(
+        r.validate(),
+        Err(crate::error::GeoError::InvalidOrthographicExtent { .. })
+    ));
+}
+
+#[test]
+fn an_orthographic_frame_is_not_read_as_perspective() {
+    let mut r = raw();
+    r.view.projection = Projection::Orthographic {
+        extent_x_m: 500.0,
+        extent_y_m: 375.0,
+    };
+    let f = r.validate().expect("valid orthographic frame");
+    let decoded = decode_frame(&encode_frame(&f)).expect("round-trips");
+    assert_eq!(
+        decoded.view().projection,
+        Projection::Orthographic {
+            extent_x_m: 500.0,
+            extent_y_m: 375.0,
+        },
+        "the projection kind byte selects the payload; it is not silently perspective",
+    );
+}
+
+#[test]
+fn an_encoded_frame_can_only_come_from_a_validated_one() {
+    // encode_frame's signature takes &ValidatedSvsFrame, and the only ways to
+    // obtain one are validate()/decode() — both of which enforce every
+    // structural invariant. This test documents the guarantee and pins that a
+    // decoded frame re-encodes byte-identically.
+    let f = validated();
+    let once = encode_frame(&f);
+    let twice = encode_frame(&decode_frame(&once).expect("round-trips"));
+    assert_eq!(once, twice);
 }

--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -1,11 +1,30 @@
-//! Synthetic-vision availability: a finite, deterministic, traceable verdict.
+//! Synthetic-vision availability: a finite, deterministic, traceable verdict
+//! **derived** from validated inputs, never self-reported by a wire producer.
 //!
-//! A missing, inconsistent, or untrusted input never yields a plausible normal
-//! scene. [`SvsAvailability::assess`] maps the typed health of each input to a
-//! verdict by a **fixed precedence**, so the same inputs always yield the same
-//! verdict and the reason names the specific input that decided it. Health is
-//! stated, never defaulted: an unknown input is [`InputHealth::Failed`], not
-//! silently `Ok`.
+//! [`SvsAvailability::assess`] maps the typed health of each input to a verdict
+//! by a **fixed precedence**, so the same inputs always yield the same verdict
+//! and the reason names the specific input that decided it. The health of the
+//! inputs the contract can check for itself — position, attitude, and
+//! time/coherence — is *derived* ([`derive_inputs`]) from the actual position
+//! and attitude stamps and the frame reference time; only the inputs the
+//! contract cannot check (navigation-integrity monitor, calibration, database,
+//! coverage, renderer) are producer-stated ([`ExternalHealth`]). An untrusted
+//! reading can never produce an [`SvsAvailability::Available`] scene.
+
+use pilotage_frames::Epoch;
+
+use crate::identity::{IntegrityLevel, StatedAttitude, StatedPosition};
+
+/// Position/attitude older than this is stale and degrades the scene. A
+/// conformal scene at typical closing speeds is visibly wrong within a few
+/// hundred milliseconds of latency, so freshness beyond this bound is not
+/// trustworthy at full assurance.
+pub const MAX_FRESH_AGE_NS: u64 = 200_000_000;
+
+/// Position/attitude older than this is unusable for a scene: at this age the
+/// registration error is unbounded for any useful motion, so the input fails
+/// rather than degrades.
+pub const MAX_USABLE_AGE_NS: u64 = 1_000_000_000;
 
 /// The finite set of reasons synthetic vision can be degraded or unavailable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,7 +107,43 @@ impl InputHealth {
     }
 }
 
-/// The stated health of every synthetic-vision input.
+/// The producer-stated health of the inputs this contract cannot verify for
+/// itself: the navigation-integrity monitor and the calibration, database,
+/// coverage, and renderer subsystems. Position, attitude, and time/coherence
+/// health are never stated here — they are derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExternalHealth {
+    /// Navigation-integrity monitor health (e.g. RAIM/SBAS protection level
+    /// versus alert limit) — an external monitor the contract cannot recompute.
+    pub integrity: InputHealth,
+    /// Camera/eye calibration health.
+    pub calibration: InputHealth,
+    /// Terrain/obstacle database health.
+    pub database: InputHealth,
+    /// Database coverage health at the current position.
+    pub coverage: InputHealth,
+    /// Renderer health.
+    pub renderer: InputHealth,
+}
+
+impl ExternalHealth {
+    /// All external inputs failed — the fail-closed default when nothing is
+    /// stated.
+    #[must_use]
+    pub const fn all_failed() -> Self {
+        let f = InputHealth::Failed;
+        Self {
+            integrity: f,
+            calibration: f,
+            database: f,
+            coverage: f,
+            renderer: f,
+        }
+    }
+}
+
+/// The health of every synthetic-vision input, position/attitude/time-coherence
+/// derived and the rest producer-stated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SvsInputs {
     /// Position source health.
@@ -140,6 +195,73 @@ impl SvsInputs {
             (AvailabilityReason::Coverage, self.coverage),
             (AvailabilityReason::Renderer, self.renderer),
         ]
+    }
+}
+
+/// Maps an integrity level to the health a reading at that level contributes:
+/// only `Trusted` is fully usable, `Monitored` degrades, and an untrusted or
+/// unmonitored reading fails closed.
+#[must_use]
+pub const fn health_from_integrity(level: IntegrityLevel) -> InputHealth {
+    match level {
+        IntegrityLevel::Trusted => InputHealth::Ok,
+        IntegrityLevel::Monitored => InputHealth::Degraded,
+        IntegrityLevel::Untrusted | IntegrityLevel::Unknown => InputHealth::Failed,
+    }
+}
+
+/// Derives time/coherence health from the position and attitude stamps and the
+/// frame reference time, failing closed: incompatible clocks/scales, a future
+/// sample, no declared coherent snapshot, or an unusable age all fail; a merely
+/// stale but usable pair degrades.
+#[must_use]
+fn derive_time_coherence(
+    position: &StatedPosition,
+    attitude: &StatedAttitude,
+    reference_time: Epoch,
+) -> InputHealth {
+    // A coherent scene requires the position and attitude to be one declared
+    // coherent snapshot on one time base.
+    if !position.stamp.coherent_with(&attitude.stamp) {
+        return InputHealth::Failed;
+    }
+    // Both ages must be physical durations relative to the reference time; a
+    // future sample or an incompatible clock/scale fails closed.
+    let (Ok(pos_age), Ok(att_age)) = (
+        position.stamp.age_ns(reference_time),
+        attitude.stamp.age_ns(reference_time),
+    ) else {
+        return InputHealth::Failed;
+    };
+    let age = pos_age.max(att_age);
+    if age > MAX_USABLE_AGE_NS {
+        InputHealth::Failed
+    } else if age > MAX_FRESH_AGE_NS {
+        InputHealth::Degraded
+    } else {
+        InputHealth::Ok
+    }
+}
+
+/// Derives the full input health from the validated position and attitude, the
+/// producer-stated external health, and the frame reference time. Position,
+/// attitude, and time/coherence are computed here; the rest are taken as stated.
+#[must_use]
+pub fn derive_inputs(
+    position: &StatedPosition,
+    attitude: &StatedAttitude,
+    external: &ExternalHealth,
+    reference_time: Epoch,
+) -> SvsInputs {
+    SvsInputs {
+        position: health_from_integrity(position.stamp.integrity),
+        attitude: health_from_integrity(attitude.stamp.integrity),
+        integrity: external.integrity,
+        time_coherence: derive_time_coherence(position, attitude, reference_time),
+        calibration: external.calibration,
+        database: external.database,
+        coverage: external.coverage,
+        renderer: external.renderer,
     }
 }
 

--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -1,0 +1,197 @@
+//! Synthetic-vision availability: a finite, deterministic, traceable verdict.
+//!
+//! A missing, inconsistent, or untrusted input never yields a plausible normal
+//! scene. [`SvsAvailability::assess`] maps the typed health of each input to a
+//! verdict by a **fixed precedence**, so the same inputs always yield the same
+//! verdict and the reason names the specific input that decided it. Health is
+//! stated, never defaulted: an unknown input is [`InputHealth::Failed`], not
+//! silently `Ok`.
+
+/// The finite set of reasons synthetic vision can be degraded or unavailable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AvailabilityReason {
+    /// No fault; the scene is fully available.
+    Nominal = 0,
+    /// Position source missing, out of range, or untrusted.
+    Position = 1,
+    /// Attitude source missing or untrusted.
+    Attitude = 2,
+    /// Navigation integrity insufficient.
+    Integrity = 3,
+    /// Time base or cross-source coherence broken.
+    TimeCoherence = 4,
+    /// Camera/eye calibration missing or invalid.
+    Calibration = 5,
+    /// Terrain/obstacle database missing or stale.
+    Database = 6,
+    /// The database does not cover the current position.
+    Coverage = 7,
+    /// The renderer cannot produce a trustworthy frame.
+    Renderer = 8,
+}
+
+impl AvailabilityReason {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Nominal),
+            1 => Some(Self::Position),
+            2 => Some(Self::Attitude),
+            3 => Some(Self::Integrity),
+            4 => Some(Self::TimeCoherence),
+            5 => Some(Self::Calibration),
+            6 => Some(Self::Database),
+            7 => Some(Self::Coverage),
+            8 => Some(Self::Renderer),
+            _ => None,
+        }
+    }
+}
+
+/// The stated health of one synthetic-vision input. There is no default: a
+/// caller that does not know an input's health states [`Self::Failed`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum InputHealth {
+    /// Contributing normally.
+    Ok = 0,
+    /// Usable but reduced; contributes a degraded scene.
+    Degraded = 1,
+    /// Missing, inconsistent, or untrusted; contributes no scene.
+    Failed = 2,
+}
+
+impl InputHealth {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, failing closed: an unknown value is
+    /// [`Self::Failed`], never `Ok`.
+    #[must_use]
+    pub const fn from_u8_fail_closed(code: u8) -> Self {
+        match code {
+            0 => Self::Ok,
+            1 => Self::Degraded,
+            _ => Self::Failed,
+        }
+    }
+}
+
+/// The stated health of every synthetic-vision input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SvsInputs {
+    /// Position source health.
+    pub position: InputHealth,
+    /// Attitude source health.
+    pub attitude: InputHealth,
+    /// Navigation integrity health.
+    pub integrity: InputHealth,
+    /// Time base / cross-source coherence health.
+    pub time_coherence: InputHealth,
+    /// Camera/eye calibration health.
+    pub calibration: InputHealth,
+    /// Terrain/obstacle database health.
+    pub database: InputHealth,
+    /// Database coverage health at the current position.
+    pub coverage: InputHealth,
+    /// Renderer health.
+    pub renderer: InputHealth,
+}
+
+impl SvsInputs {
+    /// All inputs failed — the fail-closed default when nothing is known.
+    #[must_use]
+    pub const fn all_failed() -> Self {
+        let f = InputHealth::Failed;
+        Self {
+            position: f,
+            attitude: f,
+            integrity: f,
+            time_coherence: f,
+            calibration: f,
+            database: f,
+            coverage: f,
+            renderer: f,
+        }
+    }
+
+    /// The inputs in fixed precedence order (safety-load-bearing first), paired
+    /// with the reason each maps to. The order is the contract: it decides which
+    /// reason wins when several inputs fault.
+    const fn in_precedence(&self) -> [(AvailabilityReason, InputHealth); 8] {
+        [
+            (AvailabilityReason::Position, self.position),
+            (AvailabilityReason::Attitude, self.attitude),
+            (AvailabilityReason::Integrity, self.integrity),
+            (AvailabilityReason::TimeCoherence, self.time_coherence),
+            (AvailabilityReason::Calibration, self.calibration),
+            (AvailabilityReason::Database, self.database),
+            (AvailabilityReason::Coverage, self.coverage),
+            (AvailabilityReason::Renderer, self.renderer),
+        ]
+    }
+}
+
+/// The synthetic-vision availability verdict. A degraded or unavailable verdict
+/// always carries the specific [`AvailabilityReason`] that decided it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SvsAvailability {
+    /// Fully available.
+    Available,
+    /// Reduced but usable, for the given reason.
+    Degraded(AvailabilityReason),
+    /// Not usable, for the given reason.
+    Unavailable(AvailabilityReason),
+}
+
+impl SvsAvailability {
+    /// Assesses availability from the inputs by fixed precedence: the first
+    /// failed input (in order) makes the scene unavailable for its reason; else
+    /// the first degraded input degrades it; else it is available. Deterministic
+    /// and traceable — the reason names the deciding input.
+    #[must_use]
+    pub fn assess(inputs: &SvsInputs) -> Self {
+        let ordered = inputs.in_precedence();
+        for (reason, health) in ordered {
+            if health == InputHealth::Failed {
+                return Self::Unavailable(reason);
+            }
+        }
+        for (reason, health) in ordered {
+            if health == InputHealth::Degraded {
+                return Self::Degraded(reason);
+            }
+        }
+        Self::Available
+    }
+
+    /// The reason behind this verdict ([`AvailabilityReason::Nominal`] when
+    /// available).
+    #[must_use]
+    pub const fn reason(self) -> AvailabilityReason {
+        match self {
+            Self::Available => AvailabilityReason::Nominal,
+            Self::Degraded(r) | Self::Unavailable(r) => r,
+        }
+    }
+
+    /// Whether a normal scene may be drawn (available only).
+    #[must_use]
+    pub const fn is_available(self) -> bool {
+        matches!(self, Self::Available)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -13,7 +13,9 @@
 
 use pilotage_frames::Epoch;
 
-use crate::identity::{IntegrityLevel, StatedAttitude, StatedPosition};
+use crate::identity::{
+    AttitudeQuality, IntegrityLevel, PositionQuality, StatedAttitude, StatedPosition,
+};
 
 /// Position/attitude older than this is stale and degrades the scene. A
 /// conformal scene at typical closing speeds is visibly wrong within a few
@@ -25,6 +27,24 @@ pub const MAX_FRESH_AGE_NS: u64 = 200_000_000;
 /// registration error is unbounded for any useful motion, so the input fails
 /// rather than degrades.
 pub const MAX_USABLE_AGE_NS: u64 = 1_000_000_000;
+
+/// Position 1-sigma accuracy (per axis) beyond this degrades the scene: a few
+/// meters of registration error is visible but a conformal overlay can still
+/// aid orientation. A conservative SIM placeholder; a flight profile derives
+/// its own from the assurance allocation.
+pub const MAX_FRESH_POS_MM: u32 = 5_000;
+
+/// Position 1-sigma accuracy (per axis) beyond this is unusable for a scene:
+/// tens of meters places symbology on the wrong feature, so the input fails.
+pub const MAX_USABLE_POS_MM: u32 = 50_000;
+
+/// Attitude 1-sigma accuracy beyond this degrades the scene: about half a
+/// degree of angular error is visible at range but still orienting.
+pub const MAX_FRESH_ATT_MRAD: u32 = 10;
+
+/// Attitude 1-sigma accuracy beyond this is unusable: several degrees of
+/// angular error swings the horizon off the true one, so the input fails.
+pub const MAX_USABLE_ATT_MRAD: u32 = 50;
 
 /// The finite set of reasons synthetic vision can be degraded or unavailable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,8 +115,22 @@ impl InputHealth {
         self as u8
     }
 
-    /// Decodes the wire byte, failing closed: an unknown value is
-    /// [`Self::Failed`], never `Ok`.
+    /// Decodes a wire byte strictly: an unknown value is `None`, so the ABI can
+    /// refuse non-canonical data rather than silently coercing it (which would
+    /// also make decode-then-encode change the bytes).
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Ok),
+            1 => Some(Self::Degraded),
+            2 => Some(Self::Failed),
+            _ => None,
+        }
+    }
+
+    /// Decodes a wire byte defensively: an unknown value is [`Self::Failed`],
+    /// never `Ok`. Used where a non-strict, fail-safe interpretation is wanted;
+    /// the ABI itself decodes strictly via [`Self::from_u8`].
     #[must_use]
     pub const fn from_u8_fail_closed(code: u8) -> Self {
         match code {
@@ -210,6 +244,44 @@ pub const fn health_from_integrity(level: IntegrityLevel) -> InputHealth {
     }
 }
 
+/// The worse of two healths (`Ok` < `Degraded` < `Failed`), so a reading is no
+/// healthier than its weakest attribute.
+#[must_use]
+const fn worse(a: InputHealth, b: InputHealth) -> InputHealth {
+    if a.to_u8() >= b.to_u8() { a } else { b }
+}
+
+/// Maps a position accuracy to the health it contributes: within the fresh
+/// bound is usable, beyond the usable bound fails, and in between degrades. The
+/// worse of the horizontal and vertical axes decides.
+#[must_use]
+const fn health_from_position_quality(q: PositionQuality) -> InputHealth {
+    worse(mm_health(q.horizontal_mm), mm_health(q.vertical_mm))
+}
+
+#[must_use]
+const fn mm_health(mm: u32) -> InputHealth {
+    if mm > MAX_USABLE_POS_MM {
+        InputHealth::Failed
+    } else if mm > MAX_FRESH_POS_MM {
+        InputHealth::Degraded
+    } else {
+        InputHealth::Ok
+    }
+}
+
+/// Maps an attitude accuracy to the health it contributes.
+#[must_use]
+const fn health_from_attitude_quality(q: AttitudeQuality) -> InputHealth {
+    if q.angular_mrad > MAX_USABLE_ATT_MRAD {
+        InputHealth::Failed
+    } else if q.angular_mrad > MAX_FRESH_ATT_MRAD {
+        InputHealth::Degraded
+    } else {
+        InputHealth::Ok
+    }
+}
+
 /// Derives time/coherence health from the position and attitude stamps and the
 /// frame reference time, failing closed: incompatible clocks/scales, a future
 /// sample, no declared coherent snapshot, or an unusable age all fail; a merely
@@ -254,8 +326,14 @@ pub fn derive_inputs(
     reference_time: Epoch,
 ) -> SvsInputs {
     SvsInputs {
-        position: health_from_integrity(position.stamp.integrity),
-        attitude: health_from_integrity(attitude.stamp.integrity),
+        position: worse(
+            health_from_integrity(position.stamp.integrity),
+            health_from_position_quality(position.quality),
+        ),
+        attitude: worse(
+            health_from_integrity(attitude.stamp.integrity),
+            health_from_attitude_quality(attitude.quality),
+        ),
         integrity: external.integrity,
         time_coherence: derive_time_coherence(position, attitude, reference_time),
         calibration: external.calibration,

--- a/crates/pilotage-geo/src/availability/tests.rs
+++ b/crates/pilotage-geo/src/availability/tests.rs
@@ -1,0 +1,120 @@
+//! Tests for the deterministic, traceable availability verdict.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{AvailabilityReason, InputHealth, SvsAvailability, SvsInputs};
+
+fn all_ok() -> SvsInputs {
+    let ok = InputHealth::Ok;
+    SvsInputs {
+        position: ok,
+        attitude: ok,
+        integrity: ok,
+        time_coherence: ok,
+        calibration: ok,
+        database: ok,
+        coverage: ok,
+        renderer: ok,
+    }
+}
+
+#[test]
+fn all_ok_is_available() {
+    let v = SvsAvailability::assess(&all_ok());
+    assert_eq!(v, SvsAvailability::Available);
+    assert!(v.is_available());
+    assert_eq!(v.reason(), AvailabilityReason::Nominal);
+}
+
+#[test]
+fn nothing_known_is_unavailable_not_a_normal_scene() {
+    let v = SvsAvailability::assess(&SvsInputs::all_failed());
+    assert!(!v.is_available());
+    assert!(matches!(v, SvsAvailability::Unavailable(_)));
+}
+
+#[test]
+fn a_single_failed_input_makes_it_unavailable_for_that_reason() {
+    let mut inputs = all_ok();
+    inputs.calibration = InputHealth::Failed;
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::Calibration),
+    );
+}
+
+#[test]
+fn a_single_degraded_input_degrades_for_that_reason() {
+    let mut inputs = all_ok();
+    inputs.coverage = InputHealth::Degraded;
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Degraded(AvailabilityReason::Coverage),
+    );
+}
+
+#[test]
+fn failed_dominates_degraded_and_precedence_is_fixed() {
+    let mut inputs = all_ok();
+    // Renderer failed but position also degraded: a failure (unavailable)
+    // dominates a degrade, and among the two the failed reason wins.
+    inputs.position = InputHealth::Degraded;
+    inputs.renderer = InputHealth::Failed;
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::Renderer),
+    );
+
+    // Two failures: the higher-precedence one (position before integrity) wins,
+    // deterministically.
+    let mut two = all_ok();
+    two.integrity = InputHealth::Failed;
+    two.position = InputHealth::Failed;
+    assert_eq!(
+        SvsAvailability::assess(&two),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+}
+
+#[test]
+fn assessment_is_deterministic() {
+    let mut inputs = all_ok();
+    inputs.time_coherence = InputHealth::Degraded;
+    inputs.database = InputHealth::Failed;
+    let first = SvsAvailability::assess(&inputs);
+    let second = SvsAvailability::assess(&inputs);
+    assert_eq!(first, second);
+    assert_eq!(
+        first,
+        SvsAvailability::Unavailable(AvailabilityReason::Database)
+    );
+}
+
+#[test]
+fn input_health_decodes_fail_closed() {
+    assert_eq!(InputHealth::from_u8_fail_closed(0), InputHealth::Ok);
+    assert_eq!(InputHealth::from_u8_fail_closed(1), InputHealth::Degraded);
+    assert_eq!(InputHealth::from_u8_fail_closed(2), InputHealth::Failed);
+    assert_eq!(
+        InputHealth::from_u8_fail_closed(200),
+        InputHealth::Failed,
+        "an unknown health is failed, never ok"
+    );
+}
+
+#[test]
+fn availability_reason_wire_codes_round_trip_and_reject_unknown() {
+    for r in [
+        AvailabilityReason::Nominal,
+        AvailabilityReason::Position,
+        AvailabilityReason::Attitude,
+        AvailabilityReason::Integrity,
+        AvailabilityReason::TimeCoherence,
+        AvailabilityReason::Calibration,
+        AvailabilityReason::Database,
+        AvailabilityReason::Coverage,
+        AvailabilityReason::Renderer,
+    ] {
+        assert_eq!(AvailabilityReason::from_u8(r.to_u8()), Some(r));
+    }
+    assert_eq!(AvailabilityReason::from_u8(200), None);
+}

--- a/crates/pilotage-geo/src/availability/tests.rs
+++ b/crates/pilotage-geo/src/availability/tests.rs
@@ -118,3 +118,207 @@ fn availability_reason_wire_codes_round_trip_and_reject_unknown() {
     }
     assert_eq!(AvailabilityReason::from_u8(200), None);
 }
+
+// ---- derivation from validated inputs --------------------------------------
+
+use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+
+use super::{
+    ExternalHealth, MAX_FRESH_AGE_NS, MAX_USABLE_AGE_NS, derive_inputs, health_from_integrity,
+};
+use crate::datum::{
+    BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
+};
+use crate::identity::{
+    AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
+    SourceStamp, StatedAttitude, StatedPosition,
+};
+
+fn epoch(nanos: u64) -> Epoch {
+    Epoch {
+        clock: ClockDomain::Simulation,
+        scale: TimeScale::Monotonic,
+        nanos,
+    }
+}
+
+fn stamp(integrity: IntegrityLevel, nanos: u64) -> SourceStamp {
+    SourceStamp {
+        source_id: 1,
+        incarnation: SourceIncarnation([1; 16]),
+        generation: 0,
+        sequence: 0,
+        acquired_at: epoch(nanos),
+        integrity,
+        snapshot: CoherentSnapshot {
+            producer: SourceIncarnation([9; 16]),
+            generation: 3,
+            id: 77,
+        },
+    }
+}
+
+fn position(integrity: IntegrityLevel, nanos: u64) -> StatedPosition {
+    let vertical = VerticalPosition::new(
+        100.0,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("ellipsoid");
+    StatedPosition {
+        position: GeodeticPosition::new(
+            10.0,
+            20.0,
+            HorizontalDatum::Wgs84,
+            DatumRealizationId::UNDECLARED,
+            vertical,
+        )
+        .expect("position"),
+        stamp: stamp(integrity, nanos),
+        quality: PositionQuality {
+            horizontal_mm: 1000,
+            vertical_mm: 2000,
+        },
+    }
+}
+
+fn attitude(integrity: IntegrityLevel, nanos: u64) -> StatedAttitude {
+    StatedAttitude {
+        attitude: Quat::IDENTITY,
+        stamp: stamp(integrity, nanos),
+        quality: AttitudeQuality { angular_mrad: 5 },
+    }
+}
+
+fn external_ok() -> ExternalHealth {
+    let ok = InputHealth::Ok;
+    ExternalHealth {
+        integrity: ok,
+        calibration: ok,
+        database: ok,
+        coverage: ok,
+        renderer: ok,
+    }
+}
+
+#[test]
+fn health_from_integrity_only_trusts_the_top_level() {
+    assert_eq!(
+        health_from_integrity(IntegrityLevel::Trusted),
+        InputHealth::Ok
+    );
+    assert_eq!(
+        health_from_integrity(IntegrityLevel::Monitored),
+        InputHealth::Degraded
+    );
+    assert_eq!(
+        health_from_integrity(IntegrityLevel::Untrusted),
+        InputHealth::Failed
+    );
+    assert_eq!(
+        health_from_integrity(IntegrityLevel::Unknown),
+        InputHealth::Failed,
+        "an unmonitored reading is not trusted for a scene"
+    );
+}
+
+#[test]
+fn fresh_trusted_coherent_inputs_are_available() {
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+    );
+    assert_eq!(SvsAvailability::assess(&inputs), SvsAvailability::Available);
+}
+
+#[test]
+fn untrusted_position_can_never_be_available() {
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Untrusted, 0),
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+}
+
+#[test]
+fn monitored_attitude_degrades_the_scene() {
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &attitude(IntegrityLevel::Monitored, 0),
+        &external_ok(),
+        now,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Degraded(AvailabilityReason::Attitude),
+    );
+}
+
+#[test]
+fn a_future_sample_fails_time_coherence() {
+    // Reference time earlier than acquisition → future sample → failed.
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 1_000_000),
+        &attitude(IntegrityLevel::Trusted, 1_000_000),
+        &external_ok(),
+        epoch(0),
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}
+
+#[test]
+fn a_stale_pair_degrades_and_an_unusable_pair_fails() {
+    let stale = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        epoch(MAX_FRESH_AGE_NS + 1),
+    );
+    assert_eq!(
+        SvsAvailability::assess(&stale),
+        SvsAvailability::Degraded(AvailabilityReason::TimeCoherence),
+    );
+    let unusable = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        epoch(MAX_USABLE_AGE_NS + 1),
+    );
+    assert_eq!(
+        SvsAvailability::assess(&unusable),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}
+
+#[test]
+fn incoherent_position_and_attitude_fail_time_coherence() {
+    let mut att = attitude(IntegrityLevel::Trusted, 0);
+    att.stamp.snapshot.id = 78; // a different snapshot instance
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &att,
+        &external_ok(),
+        epoch(MAX_FRESH_AGE_NS / 2),
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
+}

--- a/crates/pilotage-geo/src/availability/tests.rs
+++ b/crates/pilotage-geo/src/availability/tests.rs
@@ -124,7 +124,8 @@ fn availability_reason_wire_codes_round_trip_and_reject_unknown() {
 use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
 use super::{
-    ExternalHealth, MAX_FRESH_AGE_NS, MAX_USABLE_AGE_NS, derive_inputs, health_from_integrity,
+    ExternalHealth, MAX_FRESH_AGE_NS, MAX_FRESH_ATT_MRAD, MAX_FRESH_POS_MM, MAX_USABLE_AGE_NS,
+    MAX_USABLE_ATT_MRAD, derive_inputs, health_from_integrity,
 };
 use crate::datum::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
@@ -321,4 +322,76 @@ fn incoherent_position_and_attitude_fail_time_coherence() {
         SvsAvailability::assess(&inputs),
         SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
     );
+}
+
+#[test]
+fn a_trusted_but_grossly_inaccurate_position_is_never_available() {
+    // Trusted integrity, fresh, coherent — but the position 1-sigma is
+    // u32::MAX mm. Accuracy participates: the scene is unavailable.
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let mut pos = position(IntegrityLevel::Trusted, 0);
+    pos.quality = PositionQuality {
+        horizontal_mm: u32::MAX,
+        vertical_mm: 0,
+    };
+    let inputs = derive_inputs(
+        &pos,
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+}
+
+#[test]
+fn a_trusted_but_imprecise_attitude_degrades_or_fails() {
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let mut att = attitude(IntegrityLevel::Trusted, 0);
+    att.quality = AttitudeQuality {
+        angular_mrad: MAX_FRESH_ATT_MRAD + 1,
+    };
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &att,
+        &external_ok(),
+        now,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Degraded(AvailabilityReason::Attitude),
+    );
+
+    att.quality = AttitudeQuality {
+        angular_mrad: MAX_USABLE_ATT_MRAD + 1,
+    };
+    let inputs = derive_inputs(
+        &position(IntegrityLevel::Trusted, 0),
+        &att,
+        &external_ok(),
+        now,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&inputs),
+        SvsAvailability::Unavailable(AvailabilityReason::Attitude),
+    );
+}
+
+#[test]
+fn position_quality_at_the_fresh_bound_is_still_available() {
+    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let mut pos = position(IntegrityLevel::Trusted, 0);
+    pos.quality = PositionQuality {
+        horizontal_mm: MAX_FRESH_POS_MM,
+        vertical_mm: MAX_FRESH_POS_MM,
+    };
+    let inputs = derive_inputs(
+        &pos,
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+    );
+    assert_eq!(SvsAvailability::assess(&inputs), SvsAvailability::Available);
 }

--- a/crates/pilotage-geo/src/datum.rs
+++ b/crates/pilotage-geo/src/datum.rs
@@ -1,0 +1,302 @@
+//! Datum discipline: WGS-84 and every horizontal/vertical reference typed, with
+//! no bare altitude anywhere.
+//!
+//! A height is meaningless without its reference, so [`VerticalPosition`] always
+//! carries a [`VerticalDatum`] (and, for geometric MSL, a declared
+//! [`GeoidModelId`]; for a local-relative height, a [`LocalOriginId`]). A
+//! horizontal position always carries a [`HorizontalDatum`]. Unknown datums are
+//! refused, never guessed.
+//!
+//! # Mapping to instrument-state `AltitudeClass`
+//!
+//! This crate is foundational and `pilotage-instrument-state` is a consumer, so
+//! it cannot depend on this crate's inverse; the vertical vocabulary is minted
+//! here with an explicit mapping instead of a dependency:
+//!
+//! | [`VerticalDatum`] | `AltitudeClass` |
+//! |---|---|
+//! | `Ellipsoid` | (geo-only; no instrument-state class) |
+//! | `Msl` | `GeometricMsl` |
+//! | `Agl` | `Agl` |
+//! | `BaroIndicated` | `BaroIndicated` |
+//! | `Pressure` | `Pressure` |
+//! | `LocalRelative` | `LocalRelative` |
+//! | `Unknown` | `Unknown` |
+
+use crate::error::GeoError;
+
+/// A horizontal geodetic datum. `Unknown` is the fail-closed wire default: a
+/// position on an unknown datum has no interpretable frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HorizontalDatum {
+    /// Unknown to this build; refused rather than guessed.
+    Unknown = 0,
+    /// World Geodetic System 1984.
+    Wgs84 = 1,
+    /// North American Datum 1983.
+    Nad83 = 2,
+    /// International Terrestrial Reference Frame 2014.
+    Itrf2014 = 3,
+}
+
+impl HorizontalDatum {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, failing closed on an unknown value.
+    ///
+    /// # Errors
+    ///
+    /// [`GeoError`] is not returned here; the caller maps `None` to a
+    /// fail-closed decode error with the field name.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Unknown),
+            1 => Some(Self::Wgs84),
+            2 => Some(Self::Nad83),
+            3 => Some(Self::Itrf2014),
+            _ => None,
+        }
+    }
+}
+
+/// A vertical datum: the reference a height is measured against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum VerticalDatum {
+    /// Unknown to this build; refused rather than guessed.
+    Unknown = 0,
+    /// Height above the reference ellipsoid (WGS-84 ellipsoidal height).
+    Ellipsoid = 1,
+    /// Geometric height above mean sea level, requiring a declared geoid model.
+    Msl = 2,
+    /// Height above ground level.
+    Agl = 3,
+    /// Barometric indicated altitude (against a set altimeter datum).
+    BaroIndicated = 4,
+    /// Pressure altitude (against the standard 1013.25 hPa datum).
+    Pressure = 5,
+    /// Simulator-local relative height, tied to a declared local origin.
+    LocalRelative = 6,
+}
+
+impl VerticalDatum {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Unknown),
+            1 => Some(Self::Ellipsoid),
+            2 => Some(Self::Msl),
+            3 => Some(Self::Agl),
+            4 => Some(Self::BaroIndicated),
+            5 => Some(Self::Pressure),
+            6 => Some(Self::LocalRelative),
+            _ => None,
+        }
+    }
+}
+
+/// Identity of the geoid model behind an MSL separation. `UNDECLARED` (0) means
+/// no model was declared, which makes a geometric-MSL height uninterpretable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GeoidModelId(pub u16);
+
+impl GeoidModelId {
+    /// The sentinel meaning no geoid model was declared.
+    pub const UNDECLARED: Self = Self(0);
+
+    /// Whether a geoid model was actually declared.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// Identity of the local origin behind a local-relative height, so an origin
+/// rebase is a visible identity change rather than a silent value jump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalOriginId(pub u64);
+
+impl LocalOriginId {
+    /// The sentinel meaning no origin was declared.
+    pub const UNDECLARED: Self = Self(0);
+
+    /// Whether a local origin was actually declared.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// A height with its vertical reference fully declared. There is no way to
+/// construct one without stating the datum (and the geoid or origin it needs).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VerticalPosition {
+    /// Height in meters, meaningful only against [`Self::datum`].
+    pub height_m: f64,
+    /// The vertical datum this height is measured against.
+    pub datum: VerticalDatum,
+    /// Geoid model for an MSL separation; `UNDECLARED` otherwise.
+    pub geoid: GeoidModelId,
+    /// Local origin for a relative height; `UNDECLARED` otherwise.
+    pub origin: LocalOriginId,
+}
+
+impl VerticalPosition {
+    /// Builds a vertical position, failing closed: the height must be finite,
+    /// the datum must be known, a geometric-MSL height needs a declared geoid,
+    /// and a local-relative height needs a declared origin.
+    ///
+    /// # Errors
+    ///
+    /// A [`GeoError`] describing the missing declaration.
+    pub fn new(
+        height_m: f64,
+        datum: VerticalDatum,
+        geoid: GeoidModelId,
+        origin: LocalOriginId,
+    ) -> Result<Self, GeoError> {
+        if !height_m.is_finite() {
+            return Err(GeoError::NonFinite { field: "height_m" });
+        }
+        match datum {
+            VerticalDatum::Unknown => return Err(GeoError::UnknownVerticalDatum),
+            VerticalDatum::Msl if !geoid.is_declared() => {
+                return Err(GeoError::UndeclaredGeoidModel);
+            }
+            VerticalDatum::LocalRelative if !origin.is_declared() => {
+                return Err(GeoError::NonFinite {
+                    field: "local_origin_undeclared",
+                });
+            }
+            _ => {}
+        }
+        Ok(Self {
+            height_m,
+            datum,
+            geoid,
+            origin,
+        })
+    }
+}
+
+/// A geodetic position: latitude, longitude, horizontal datum, and a fully
+/// declared vertical position. Longitude is normalized to `[-180, 180)`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeodeticPosition {
+    /// Latitude in degrees, in `[-90, 90]`.
+    pub latitude_deg: f64,
+    /// Longitude in degrees, normalized to `[-180, 180)`.
+    pub longitude_deg: f64,
+    /// The horizontal datum.
+    pub horizontal_datum: HorizontalDatum,
+    /// The vertical position.
+    pub vertical: VerticalPosition,
+}
+
+/// A discrete geospatial tile index at a fixed tile size, computed by flooring,
+/// so a position on a seam maps deterministically to a single tile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GeoTile {
+    /// Tile index along latitude.
+    pub lat_index: i32,
+    /// Tile index along longitude.
+    pub lon_index: i32,
+}
+
+/// Normalizes a longitude to `[-180, 180)` by wrapping whole turns, so the
+/// anti-meridian has one canonical representation (`+180` wraps to `-180`).
+#[must_use]
+pub fn wrap_longitude_deg(lon_deg: f64) -> f64 {
+    lon_deg - 360.0 * libm::floor((lon_deg + 180.0) / 360.0)
+}
+
+impl GeodeticPosition {
+    /// Builds a geodetic position, failing closed: coordinates must be finite,
+    /// latitude must be in `[-90, 90]`, the horizontal datum must be known, and
+    /// the longitude is normalized to `[-180, 180)` so the anti-meridian is
+    /// unambiguous.
+    ///
+    /// # Errors
+    ///
+    /// A [`GeoError`] for a non-finite coordinate, an out-of-range latitude, or
+    /// an unknown horizontal datum.
+    pub fn new(
+        latitude_deg: f64,
+        longitude_deg: f64,
+        horizontal_datum: HorizontalDatum,
+        vertical: VerticalPosition,
+    ) -> Result<Self, GeoError> {
+        if !latitude_deg.is_finite() {
+            return Err(GeoError::NonFinite {
+                field: "latitude_deg",
+            });
+        }
+        if !longitude_deg.is_finite() {
+            return Err(GeoError::NonFinite {
+                field: "longitude_deg",
+            });
+        }
+        if !(-90.0..=90.0).contains(&latitude_deg) {
+            return Err(GeoError::LatitudeOutOfRange {
+                lat_deg: latitude_deg,
+            });
+        }
+        if horizontal_datum == HorizontalDatum::Unknown {
+            return Err(GeoError::UnknownVerticalDatum);
+        }
+        Ok(Self {
+            latitude_deg,
+            longitude_deg: wrap_longitude_deg(longitude_deg),
+            horizontal_datum,
+            vertical,
+        })
+    }
+
+    /// Whether this position lies on the anti-meridian (±180°), where longitude
+    /// has two spellings for one place.
+    #[must_use]
+    pub fn on_antimeridian(&self) -> bool {
+        // After normalization the anti-meridian is exactly -180.
+        self.longitude_deg == -180.0
+    }
+
+    /// Whether this position is at a geographic pole, where longitude is
+    /// degenerate.
+    #[must_use]
+    pub fn at_pole(&self) -> bool {
+        self.latitude_deg == 90.0 || self.latitude_deg == -90.0
+    }
+
+    /// The tile this position falls in at `tile_deg`-degree tiles, computed by
+    /// flooring so a seam belongs to exactly one tile. `tile_deg` must be
+    /// positive and finite; a non-positive value yields the zero tile.
+    #[must_use]
+    pub fn tile(&self, tile_deg: f64) -> GeoTile {
+        if !(tile_deg.is_finite() && tile_deg > 0.0) {
+            return GeoTile {
+                lat_index: 0,
+                lon_index: 0,
+            };
+        }
+        GeoTile {
+            lat_index: libm::floor(self.latitude_deg / tile_deg) as i32,
+            lon_index: libm::floor(self.longitude_deg / tile_deg) as i32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/datum.rs
+++ b/crates/pilotage-geo/src/datum.rs
@@ -1,10 +1,13 @@
 //! Datum discipline: WGS-84 and every horizontal/vertical reference typed, with
-//! no bare altitude anywhere.
+//! no bare altitude and no implicit realization anywhere.
 //!
 //! A height is meaningless without its reference, so [`VerticalPosition`] always
-//! carries a [`VerticalDatum`] (and, for geometric MSL, a declared
-//! [`GeoidModelId`]; for a local-relative height, a [`LocalOriginId`]). A
-//! horizontal position always carries a [`HorizontalDatum`]. Unknown datums are
+//! carries a [`VerticalDatum`] and the identity that datum needs: a declared
+//! [`GeoidModelId`] for geometric MSL, a [`TerrainRefId`] for AGL, a
+//! [`BaroSettingId`] for barometric-indicated altitude, or a [`LocalOriginId`]
+//! for a local-relative height. A horizontal position always carries a
+//! [`HorizontalDatum`] and, for a realization-bearing datum (NAD83, ITRF), a
+//! declared [`DatumRealizationId`]. Unknown datums and missing realizations are
 //! refused, never guessed.
 //!
 //! # Mapping to instrument-state `AltitudeClass`
@@ -34,9 +37,10 @@ pub enum HorizontalDatum {
     Unknown = 0,
     /// World Geodetic System 1984.
     Wgs84 = 1,
-    /// North American Datum 1983.
+    /// North American Datum 1983 (realization must be declared).
     Nad83 = 2,
-    /// International Terrestrial Reference Frame 2014.
+    /// International Terrestrial Reference Frame 2014 (realization/reference
+    /// epoch must be declared).
     Itrf2014 = 3,
 }
 
@@ -47,12 +51,7 @@ impl HorizontalDatum {
         self as u8
     }
 
-    /// Decodes the wire byte, failing closed on an unknown value.
-    ///
-    /// # Errors
-    ///
-    /// [`GeoError`] is not returned here; the caller maps `None` to a
-    /// fail-closed decode error with the field name.
+    /// Decodes the wire byte, or `None` for an unknown value.
     #[must_use]
     pub const fn from_u8(code: u8) -> Option<Self> {
         match code {
@@ -62,6 +61,30 @@ impl HorizontalDatum {
             3 => Some(Self::Itrf2014),
             _ => None,
         }
+    }
+
+    /// Whether this datum needs a declared realization / reference epoch to be
+    /// unambiguous (NAD83 and ITRF have several realizations meters apart).
+    #[must_use]
+    pub const fn needs_realization(self) -> bool {
+        matches!(self, Self::Nad83 | Self::Itrf2014)
+    }
+}
+
+/// Identity of a horizontal-datum realization / reference epoch (e.g. a
+/// specific NAD83 or ITRF2014 realization). `UNDECLARED` (0) leaves the frame
+/// ambiguous and is refused for a realization-bearing datum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DatumRealizationId(pub u16);
+
+impl DatumRealizationId {
+    /// The sentinel meaning no realization was declared.
+    pub const UNDECLARED: Self = Self(0);
+
+    /// Whether a realization was actually declared.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
     }
 }
 
@@ -75,9 +98,10 @@ pub enum VerticalDatum {
     Ellipsoid = 1,
     /// Geometric height above mean sea level, requiring a declared geoid model.
     Msl = 2,
-    /// Height above ground level.
+    /// Height above ground level, requiring a declared terrain/ground reference.
     Agl = 3,
-    /// Barometric indicated altitude (against a set altimeter datum).
+    /// Barometric indicated altitude, requiring a declared applied-setting
+    /// identity (the altimeter setting its datum surface is referenced to).
     BaroIndicated = 4,
     /// Pressure altitude (against the standard 1013.25 hPa datum).
     Pressure = 5,
@@ -124,6 +148,40 @@ impl GeoidModelId {
     }
 }
 
+/// Identity of the terrain/ground reference an AGL height is measured above (a
+/// specific terrain database or ground-plane reference). `UNDECLARED` (0) means
+/// the ground is unidentified and an AGL height is refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerrainRefId(pub u32);
+
+impl TerrainRefId {
+    /// The sentinel meaning no terrain reference was declared.
+    pub const UNDECLARED: Self = Self(0);
+
+    /// Whether a terrain reference was actually declared.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// Identity of the applied altimeter setting a barometric-indicated height is
+/// referenced to. `UNDECLARED` (0) means the setting is unidentified and a
+/// barometric-indicated height is refused as a geospatial height.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BaroSettingId(pub u32);
+
+impl BaroSettingId {
+    /// The sentinel meaning no applied setting was declared.
+    pub const UNDECLARED: Self = Self(0);
+
+    /// Whether an applied setting was actually declared.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
+    }
+}
+
 /// Identity of the local origin behind a local-relative height, so an origin
 /// rebase is a visible identity change rather than a silent value jump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -140,8 +198,9 @@ impl LocalOriginId {
     }
 }
 
-/// A height with its vertical reference fully declared. There is no way to
-/// construct one without stating the datum (and the geoid or origin it needs).
+/// A height with its vertical reference and the identity that reference needs,
+/// all fully declared. There is no way to construct one without stating the
+/// datum and its required identity.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VerticalPosition {
     /// Height in meters, meaningful only against [`Self::datum`].
@@ -150,14 +209,20 @@ pub struct VerticalPosition {
     pub datum: VerticalDatum,
     /// Geoid model for an MSL separation; `UNDECLARED` otherwise.
     pub geoid: GeoidModelId,
+    /// Terrain/ground reference for an AGL height; `UNDECLARED` otherwise.
+    pub terrain_ref: TerrainRefId,
+    /// Applied altimeter-setting identity for barometric-indicated; `UNDECLARED`
+    /// otherwise.
+    pub baro_setting: BaroSettingId,
     /// Local origin for a relative height; `UNDECLARED` otherwise.
     pub origin: LocalOriginId,
 }
 
 impl VerticalPosition {
     /// Builds a vertical position, failing closed: the height must be finite,
-    /// the datum must be known, a geometric-MSL height needs a declared geoid,
-    /// and a local-relative height needs a declared origin.
+    /// the datum must be known, and the datum's required identity must be
+    /// declared — a geoid for MSL, a terrain reference for AGL, an applied
+    /// setting for barometric-indicated, an origin for local-relative.
     ///
     /// # Errors
     ///
@@ -166,6 +231,8 @@ impl VerticalPosition {
         height_m: f64,
         datum: VerticalDatum,
         geoid: GeoidModelId,
+        terrain_ref: TerrainRefId,
+        baro_setting: BaroSettingId,
         origin: LocalOriginId,
     ) -> Result<Self, GeoError> {
         if !height_m.is_finite() {
@@ -176,10 +243,14 @@ impl VerticalPosition {
             VerticalDatum::Msl if !geoid.is_declared() => {
                 return Err(GeoError::UndeclaredGeoidModel);
             }
+            VerticalDatum::Agl if !terrain_ref.is_declared() => {
+                return Err(GeoError::UndeclaredTerrainReference);
+            }
+            VerticalDatum::BaroIndicated if !baro_setting.is_declared() => {
+                return Err(GeoError::UndeclaredBaroSetting);
+            }
             VerticalDatum::LocalRelative if !origin.is_declared() => {
-                return Err(GeoError::NonFinite {
-                    field: "local_origin_undeclared",
-                });
+                return Err(GeoError::UndeclaredLocalOrigin);
             }
             _ => {}
         }
@@ -187,13 +258,34 @@ impl VerticalPosition {
             height_m,
             datum,
             geoid,
+            terrain_ref,
+            baro_setting,
             origin,
         })
     }
+
+    /// Re-checks the invariants a constructed value must uphold, so a value
+    /// built by directly setting fields is still refused when inconsistent.
+    ///
+    /// # Errors
+    ///
+    /// The same [`GeoError`] variants [`Self::new`] raises.
+    pub fn validate(&self) -> Result<(), GeoError> {
+        Self::new(
+            self.height_m,
+            self.datum,
+            self.geoid,
+            self.terrain_ref,
+            self.baro_setting,
+            self.origin,
+        )
+        .map(|_| ())
+    }
 }
 
-/// A geodetic position: latitude, longitude, horizontal datum, and a fully
-/// declared vertical position. Longitude is normalized to `[-180, 180)`.
+/// A geodetic position: latitude, longitude, horizontal datum, its realization,
+/// and a fully declared vertical position. Longitude is normalized to
+/// `[-180, 180)`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GeodeticPosition {
     /// Latitude in degrees, in `[-90, 90]`.
@@ -202,6 +294,9 @@ pub struct GeodeticPosition {
     pub longitude_deg: f64,
     /// The horizontal datum.
     pub horizontal_datum: HorizontalDatum,
+    /// The horizontal-datum realization / reference epoch; `UNDECLARED` for a
+    /// datum that does not need one.
+    pub realization: DatumRealizationId,
     /// The vertical position.
     pub vertical: VerticalPosition,
 }
@@ -225,18 +320,20 @@ pub fn wrap_longitude_deg(lon_deg: f64) -> f64 {
 
 impl GeodeticPosition {
     /// Builds a geodetic position, failing closed: coordinates must be finite,
-    /// latitude must be in `[-90, 90]`, the horizontal datum must be known, and
-    /// the longitude is normalized to `[-180, 180)` so the anti-meridian is
+    /// latitude must be in `[-90, 90]`, the horizontal datum must be known, a
+    /// realization-bearing datum must declare its realization, and the
+    /// longitude is normalized to `[-180, 180)` so the anti-meridian is
     /// unambiguous.
     ///
     /// # Errors
     ///
-    /// A [`GeoError`] for a non-finite coordinate, an out-of-range latitude, or
-    /// an unknown horizontal datum.
+    /// A [`GeoError`] for a non-finite coordinate, an out-of-range latitude, an
+    /// unknown horizontal datum, or an undeclared realization.
     pub fn new(
         latitude_deg: f64,
         longitude_deg: f64,
         horizontal_datum: HorizontalDatum,
+        realization: DatumRealizationId,
         vertical: VerticalPosition,
     ) -> Result<Self, GeoError> {
         if !latitude_deg.is_finite() {
@@ -255,14 +352,37 @@ impl GeodeticPosition {
             });
         }
         if horizontal_datum == HorizontalDatum::Unknown {
-            return Err(GeoError::UnknownVerticalDatum);
+            return Err(GeoError::UnknownHorizontalDatum);
+        }
+        if horizontal_datum.needs_realization() && !realization.is_declared() {
+            return Err(GeoError::UndeclaredDatumRealization);
         }
         Ok(Self {
             latitude_deg,
             longitude_deg: wrap_longitude_deg(longitude_deg),
             horizontal_datum,
+            realization,
             vertical,
         })
+    }
+
+    /// Re-checks the invariants a constructed value must uphold (finiteness,
+    /// latitude range, known datum, declared realization, and the vertical
+    /// invariants), so a value built by directly setting fields is still
+    /// refused when inconsistent.
+    ///
+    /// # Errors
+    ///
+    /// The same [`GeoError`] variants [`Self::new`] raises.
+    pub fn validate(&self) -> Result<(), GeoError> {
+        Self::new(
+            self.latitude_deg,
+            self.longitude_deg,
+            self.horizontal_datum,
+            self.realization,
+            self.vertical,
+        )
+        .and_then(|_| self.vertical.validate())
     }
 
     /// Whether this position lies on the anti-meridian (±180°), where longitude
@@ -281,20 +401,20 @@ impl GeodeticPosition {
     }
 
     /// The tile this position falls in at `tile_deg`-degree tiles, computed by
-    /// flooring so a seam belongs to exactly one tile. `tile_deg` must be
-    /// positive and finite; a non-positive value yields the zero tile.
-    #[must_use]
-    pub fn tile(&self, tile_deg: f64) -> GeoTile {
+    /// flooring so a seam belongs to exactly one tile.
+    ///
+    /// # Errors
+    ///
+    /// [`GeoError::InvalidTileSize`] when `tile_deg` is not positive and finite
+    /// — there is no plausible zero tile to fall back to.
+    pub fn tile(&self, tile_deg: f64) -> Result<GeoTile, GeoError> {
         if !(tile_deg.is_finite() && tile_deg > 0.0) {
-            return GeoTile {
-                lat_index: 0,
-                lon_index: 0,
-            };
+            return Err(GeoError::InvalidTileSize { tile_deg });
         }
-        GeoTile {
+        Ok(GeoTile {
             lat_index: libm::floor(self.latitude_deg / tile_deg) as i32,
             lon_index: libm::floor(self.longitude_deg / tile_deg) as i32,
-        }
+        })
     }
 }
 

--- a/crates/pilotage-geo/src/datum/tests.rs
+++ b/crates/pilotage-geo/src/datum/tests.rs
@@ -1,0 +1,173 @@
+//! Edge-case tests for datum discipline (anti-meridian, polar, tile-seam,
+//! vertical datum).
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{
+    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum,
+    VerticalPosition, wrap_longitude_deg,
+};
+use crate::error::GeoError;
+
+fn ellipsoid(height_m: f64) -> VerticalPosition {
+    VerticalPosition::new(
+        height_m,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("ellipsoid height is well-formed")
+}
+
+fn pos(lat: f64, lon: f64) -> GeodeticPosition {
+    GeodeticPosition::new(lat, lon, HorizontalDatum::Wgs84, ellipsoid(100.0))
+        .expect("well-formed geodetic position")
+}
+
+#[test]
+fn longitude_wraps_to_canonical_half_open_range() {
+    assert_eq!(wrap_longitude_deg(180.0), -180.0);
+    assert_eq!(wrap_longitude_deg(-180.0), -180.0);
+    assert_eq!(wrap_longitude_deg(181.0), -179.0);
+    assert_eq!(wrap_longitude_deg(-181.0), 179.0);
+    assert_eq!(wrap_longitude_deg(540.0), -180.0);
+    assert_eq!(wrap_longitude_deg(0.0), 0.0);
+}
+
+#[test]
+fn antimeridian_has_one_canonical_spelling() {
+    let east = pos(0.0, 180.0);
+    let west = pos(0.0, -180.0);
+    assert_eq!(
+        east.longitude_deg, west.longitude_deg,
+        "±180 collapse to one"
+    );
+    assert!(east.on_antimeridian() && west.on_antimeridian());
+    assert_eq!(east, west, "the two spellings are the same position");
+}
+
+#[test]
+fn poles_are_valid_and_flagged() {
+    let north = pos(90.0, 45.0);
+    let south = pos(-90.0, -73.0);
+    assert!(north.at_pole() && south.at_pole());
+    // Longitude is retained deterministically even though it is degenerate.
+    assert_eq!(north.longitude_deg, 45.0);
+}
+
+#[test]
+fn latitude_out_of_range_is_refused() {
+    let err = GeodeticPosition::new(90.001, 0.0, HorizontalDatum::Wgs84, ellipsoid(0.0))
+        .expect_err("beyond the pole is refused");
+    assert!(matches!(err, GeoError::LatitudeOutOfRange { .. }));
+}
+
+#[test]
+fn tile_seam_belongs_to_exactly_one_tile() {
+    // A position exactly on a 1-degree seam floors into the higher tile, and a
+    // hair below floors into the lower one — deterministic, never oscillating.
+    assert_eq!(pos(0.5, 1.0).tile(1.0).lon_index, 1);
+    assert_eq!(pos(0.5, 0.999_999).tile(1.0).lon_index, 0);
+    // The anti-meridian seam maps consistently (normalized to -180).
+    assert_eq!(pos(0.5, 180.0).tile(1.0).lon_index, -180);
+    assert_eq!(pos(0.5, -180.0).tile(1.0).lon_index, -180);
+}
+
+#[test]
+fn unknown_vertical_datum_is_refused() {
+    let err = VerticalPosition::new(
+        10.0,
+        VerticalDatum::Unknown,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect_err("an unknown datum has no interpretable reference");
+    assert!(matches!(err, GeoError::UnknownVerticalDatum));
+}
+
+#[test]
+fn geometric_msl_requires_a_declared_geoid() {
+    let missing = VerticalPosition::new(
+        10.0,
+        VerticalDatum::Msl,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect_err("MSL without a geoid model is undefined");
+    assert!(matches!(missing, GeoError::UndeclaredGeoidModel));
+
+    VerticalPosition::new(
+        10.0,
+        VerticalDatum::Msl,
+        GeoidModelId(12),
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("MSL with a declared geoid model is well-formed");
+}
+
+#[test]
+fn local_relative_requires_a_declared_origin() {
+    let missing = VerticalPosition::new(
+        10.0,
+        VerticalDatum::LocalRelative,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect_err("a relative height without an origin is a silent rebase risk");
+    assert!(matches!(missing, GeoError::NonFinite { .. }));
+
+    VerticalPosition::new(
+        10.0,
+        VerticalDatum::LocalRelative,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId(7),
+    )
+    .expect("local-relative with a declared origin is well-formed");
+}
+
+#[test]
+fn non_finite_coordinates_are_refused() {
+    assert!(matches!(
+        GeodeticPosition::new(f64::NAN, 0.0, HorizontalDatum::Wgs84, ellipsoid(0.0)),
+        Err(GeoError::NonFinite { .. })
+    ));
+    assert!(matches!(
+        ellipsoid_result(f64::INFINITY),
+        Err(GeoError::NonFinite { .. })
+    ));
+}
+
+fn ellipsoid_result(height_m: f64) -> Result<VerticalPosition, GeoError> {
+    VerticalPosition::new(
+        height_m,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+}
+
+#[test]
+fn unknown_horizontal_datum_is_refused() {
+    let err = GeodeticPosition::new(0.0, 0.0, HorizontalDatum::Unknown, ellipsoid(0.0))
+        .expect_err("an unknown horizontal datum has no interpretable frame");
+    assert!(matches!(err, GeoError::UnknownVerticalDatum));
+}
+
+#[test]
+fn datum_wire_codes_round_trip_and_reject_unknown() {
+    for d in [
+        VerticalDatum::Ellipsoid,
+        VerticalDatum::Msl,
+        VerticalDatum::Agl,
+        VerticalDatum::BaroIndicated,
+        VerticalDatum::Pressure,
+        VerticalDatum::LocalRelative,
+    ] {
+        assert_eq!(VerticalDatum::from_u8(d.to_u8()), Some(d));
+    }
+    assert_eq!(
+        VerticalDatum::from_u8(200),
+        None,
+        "unknown wire value fails closed"
+    );
+    assert_eq!(HorizontalDatum::from_u8(9), None);
+}

--- a/crates/pilotage-geo/src/datum/tests.rs
+++ b/crates/pilotage-geo/src/datum/tests.rs
@@ -1,26 +1,37 @@
 //! Edge-case tests for datum discipline (anti-meridian, polar, tile-seam,
-//! vertical datum).
+//! vertical datum, and the datum-identity completeness the contract requires).
 #![allow(clippy::expect_used, clippy::panic)]
 
 use super::{
-    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum,
-    VerticalPosition, wrap_longitude_deg,
+    BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition, wrap_longitude_deg,
 };
 use crate::error::GeoError;
 
 fn ellipsoid(height_m: f64) -> VerticalPosition {
+    ellipsoid_result(height_m).expect("ellipsoid height is well-formed")
+}
+
+fn ellipsoid_result(height_m: f64) -> Result<VerticalPosition, GeoError> {
     VerticalPosition::new(
         height_m,
         VerticalDatum::Ellipsoid,
         GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
-    .expect("ellipsoid height is well-formed")
 }
 
 fn pos(lat: f64, lon: f64) -> GeodeticPosition {
-    GeodeticPosition::new(lat, lon, HorizontalDatum::Wgs84, ellipsoid(100.0))
-        .expect("well-formed geodetic position")
+    GeodeticPosition::new(
+        lat,
+        lon,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        ellipsoid(100.0),
+    )
+    .expect("well-formed geodetic position")
 }
 
 #[test]
@@ -56,8 +67,14 @@ fn poles_are_valid_and_flagged() {
 
 #[test]
 fn latitude_out_of_range_is_refused() {
-    let err = GeodeticPosition::new(90.001, 0.0, HorizontalDatum::Wgs84, ellipsoid(0.0))
-        .expect_err("beyond the pole is refused");
+    let err = GeodeticPosition::new(
+        90.001,
+        0.0,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        ellipsoid(0.0),
+    )
+    .expect_err("beyond the pole is refused");
     assert!(matches!(err, GeoError::LatitudeOutOfRange { .. }));
 }
 
@@ -65,11 +82,24 @@ fn latitude_out_of_range_is_refused() {
 fn tile_seam_belongs_to_exactly_one_tile() {
     // A position exactly on a 1-degree seam floors into the higher tile, and a
     // hair below floors into the lower one — deterministic, never oscillating.
-    assert_eq!(pos(0.5, 1.0).tile(1.0).lon_index, 1);
-    assert_eq!(pos(0.5, 0.999_999).tile(1.0).lon_index, 0);
+    assert_eq!(pos(0.5, 1.0).tile(1.0).expect("tile").lon_index, 1);
+    assert_eq!(pos(0.5, 0.999_999).tile(1.0).expect("tile").lon_index, 0);
     // The anti-meridian seam maps consistently (normalized to -180).
-    assert_eq!(pos(0.5, 180.0).tile(1.0).lon_index, -180);
-    assert_eq!(pos(0.5, -180.0).tile(1.0).lon_index, -180);
+    assert_eq!(pos(0.5, 180.0).tile(1.0).expect("tile").lon_index, -180);
+    assert_eq!(pos(0.5, -180.0).tile(1.0).expect("tile").lon_index, -180);
+}
+
+#[test]
+fn invalid_tile_size_is_refused_not_a_zero_tile() {
+    for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        assert!(
+            matches!(
+                pos(0.5, 1.0).tile(bad),
+                Err(GeoError::InvalidTileSize { .. })
+            ),
+            "tile size {bad} must be refused, never a plausible zero tile"
+        );
+    }
 }
 
 #[test]
@@ -78,6 +108,8 @@ fn unknown_vertical_datum_is_refused() {
         10.0,
         VerticalDatum::Unknown,
         GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
     .expect_err("an unknown datum has no interpretable reference");
@@ -90,6 +122,8 @@ fn geometric_msl_requires_a_declared_geoid() {
         10.0,
         VerticalDatum::Msl,
         GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
     .expect_err("MSL without a geoid model is undefined");
@@ -99,9 +133,59 @@ fn geometric_msl_requires_a_declared_geoid() {
         10.0,
         VerticalDatum::Msl,
         GeoidModelId(12),
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
     .expect("MSL with a declared geoid model is well-formed");
+}
+
+#[test]
+fn agl_requires_a_declared_terrain_reference() {
+    let missing = VerticalPosition::new(
+        50.0,
+        VerticalDatum::Agl,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect_err("AGL without a ground reference is unidentified");
+    assert!(matches!(missing, GeoError::UndeclaredTerrainReference));
+
+    VerticalPosition::new(
+        50.0,
+        VerticalDatum::Agl,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId(3),
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("AGL with a declared terrain reference is well-formed");
+}
+
+#[test]
+fn barometric_indicated_requires_an_applied_setting_identity() {
+    let missing = VerticalPosition::new(
+        3000.0,
+        VerticalDatum::BaroIndicated,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect_err("barometric-indicated without an applied setting is unidentified");
+    assert!(matches!(missing, GeoError::UndeclaredBaroSetting));
+
+    VerticalPosition::new(
+        3000.0,
+        VerticalDatum::BaroIndicated,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId(101_325),
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("barometric-indicated with a declared applied setting is well-formed");
 }
 
 #[test]
@@ -110,24 +194,64 @@ fn local_relative_requires_a_declared_origin() {
         10.0,
         VerticalDatum::LocalRelative,
         GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
     .expect_err("a relative height without an origin is a silent rebase risk");
-    assert!(matches!(missing, GeoError::NonFinite { .. }));
+    assert!(
+        matches!(missing, GeoError::UndeclaredLocalOrigin),
+        "the reason is a local-origin refusal, not a disguised NonFinite"
+    );
 
     VerticalPosition::new(
         10.0,
         VerticalDatum::LocalRelative,
         GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
         LocalOriginId(7),
     )
     .expect("local-relative with a declared origin is well-formed");
 }
 
 #[test]
+fn realization_bearing_datums_require_a_declared_realization() {
+    for datum in [HorizontalDatum::Nad83, HorizontalDatum::Itrf2014] {
+        let missing = GeodeticPosition::new(
+            10.0,
+            20.0,
+            datum,
+            DatumRealizationId::UNDECLARED,
+            ellipsoid(0.0),
+        )
+        .expect_err("realization-bearing datum without a realization is ambiguous");
+        assert!(matches!(missing, GeoError::UndeclaredDatumRealization));
+
+        GeodeticPosition::new(10.0, 20.0, datum, DatumRealizationId(2011), ellipsoid(0.0))
+            .expect("a declared realization is well-formed");
+    }
+    // WGS-84 does not require a realization id in this contract.
+    GeodeticPosition::new(
+        10.0,
+        20.0,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        ellipsoid(0.0),
+    )
+    .expect("WGS-84 needs no explicit realization here");
+}
+
+#[test]
 fn non_finite_coordinates_are_refused() {
     assert!(matches!(
-        GeodeticPosition::new(f64::NAN, 0.0, HorizontalDatum::Wgs84, ellipsoid(0.0)),
+        GeodeticPosition::new(
+            f64::NAN,
+            0.0,
+            HorizontalDatum::Wgs84,
+            DatumRealizationId::UNDECLARED,
+            ellipsoid(0.0)
+        ),
         Err(GeoError::NonFinite { .. })
     ));
     assert!(matches!(
@@ -136,20 +260,20 @@ fn non_finite_coordinates_are_refused() {
     ));
 }
 
-fn ellipsoid_result(height_m: f64) -> Result<VerticalPosition, GeoError> {
-    VerticalPosition::new(
-        height_m,
-        VerticalDatum::Ellipsoid,
-        GeoidModelId::UNDECLARED,
-        LocalOriginId::UNDECLARED,
-    )
-}
-
 #[test]
-fn unknown_horizontal_datum_is_refused() {
-    let err = GeodeticPosition::new(0.0, 0.0, HorizontalDatum::Unknown, ellipsoid(0.0))
-        .expect_err("an unknown horizontal datum has no interpretable frame");
-    assert!(matches!(err, GeoError::UnknownVerticalDatum));
+fn unknown_horizontal_datum_is_refused_with_the_right_reason() {
+    let err = GeodeticPosition::new(
+        0.0,
+        0.0,
+        HorizontalDatum::Unknown,
+        DatumRealizationId::UNDECLARED,
+        ellipsoid(0.0),
+    )
+    .expect_err("an unknown horizontal datum has no interpretable frame");
+    assert!(
+        matches!(err, GeoError::UnknownHorizontalDatum),
+        "a horizontal fault must not report a vertical-datum reason"
+    );
 }
 
 #[test]

--- a/crates/pilotage-geo/src/error.rs
+++ b/crates/pilotage-geo/src/error.rs
@@ -1,0 +1,101 @@
+//! Typed, fail-closed failure model for the geospatial contract.
+//!
+//! Every variant is a refusal, not a repair: a construction or decode that
+//! cannot be trusted returns an error instead of guessing a datum, a unit, a
+//! frame, or a clock.
+
+/// Why constructing or validating a geospatial value failed.
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
+pub enum GeoError {
+    /// A field that must be finite is NaN or infinite.
+    #[error("geospatial field {field} is not finite")]
+    NonFinite {
+        /// The offending field.
+        field: &'static str,
+    },
+    /// Latitude is outside `[-90, 90]` degrees.
+    #[error("latitude {lat_deg} deg is outside [-90, 90]")]
+    LatitudeOutOfRange {
+        /// The offending latitude, degrees.
+        lat_deg: f64,
+    },
+    /// Longitude is outside `[-180, 180]` degrees (before normalization).
+    #[error("longitude {lon_deg} deg is outside [-180, 180]")]
+    LongitudeOutOfRange {
+        /// The offending longitude, degrees.
+        lon_deg: f64,
+    },
+    /// The vertical datum is unknown to this build; the height has no
+    /// interpretable reference and is refused rather than guessed.
+    #[error("vertical datum is unknown; height has no interpretable reference")]
+    UnknownVerticalDatum,
+    /// A geometric-MSL height was supplied without a declared geoid model, so
+    /// the ellipsoid↔MSL separation is undefined.
+    #[error("geometric-MSL height requires a declared geoid model")]
+    UndeclaredGeoidModel,
+    /// A viewport has a zero (or otherwise degenerate) dimension.
+    #[error("viewport {width_px}x{height_px} is degenerate")]
+    InvalidViewport {
+        /// Viewport width, pixels.
+        width_px: u32,
+        /// Viewport height, pixels.
+        height_px: u32,
+    },
+    /// A focal length is not strictly positive.
+    #[error("focal lengths ({focal_x_px}, {focal_y_px} px) are not positive")]
+    NonPositiveFocal {
+        /// Focal length x, pixels.
+        focal_x_px: f64,
+        /// Focal length y, pixels.
+        focal_y_px: f64,
+    },
+    /// The near/far clip policy is invalid (`near <= 0` or `far <= near`).
+    #[error("near/far policy (near={near_m}, far={far_m} m) is invalid")]
+    InvalidNearFar {
+        /// Near clip distance, meters.
+        near_m: f64,
+        /// Far clip distance, meters.
+        far_m: f64,
+    },
+}
+
+/// Why decoding a wire ABI block failed. Decode fails closed on any value this
+/// build cannot interpret, never masquerading as a benign default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AbiError {
+    /// The buffer is shorter than the fixed block length.
+    #[error("ABI block truncated: need {needed} bytes, got {got}")]
+    Truncated {
+        /// Bytes the block requires.
+        needed: usize,
+        /// Bytes supplied.
+        got: usize,
+    },
+    /// The leading version field is one this decoder does not read.
+    #[error("ABI version {found} is not supported")]
+    BadVersion {
+        /// The version found.
+        found: u32,
+    },
+    /// An enumerated field carried a value outside the known set.
+    #[error("ABI field {field} carried unknown value {value}")]
+    UnknownEnum {
+        /// The field that was unknown.
+        field: &'static str,
+        /// The unrecognized wire value.
+        value: u8,
+    },
+    /// A decoded floating-point field that must be finite is NaN or infinite.
+    #[error("ABI field {field} decoded a non-finite value")]
+    NonFinite {
+        /// The offending field.
+        field: &'static str,
+    },
+    /// The decoded values violate a semantic invariant (e.g. an MSL height with
+    /// no declared geoid), so the block is refused rather than trusted.
+    #[error("ABI block is semantically malformed: {field}")]
+    Malformed {
+        /// What made the block malformed.
+        field: &'static str,
+    },
+}

--- a/crates/pilotage-geo/src/error.rs
+++ b/crates/pilotage-geo/src/error.rs
@@ -25,6 +25,15 @@ pub enum GeoError {
         /// The offending longitude, degrees.
         lon_deg: f64,
     },
+    /// The horizontal datum is unknown to this build; the position has no
+    /// interpretable frame and is refused rather than guessed.
+    #[error("horizontal datum is unknown; position has no interpretable frame")]
+    UnknownHorizontalDatum,
+    /// A realization-bearing horizontal datum (NAD83, ITRF) was supplied
+    /// without a declared realization/reference-epoch identity, so the frame
+    /// is ambiguous by centimeters-to-meters and is refused.
+    #[error("horizontal datum realization/reference epoch was not declared")]
+    UndeclaredDatumRealization,
     /// The vertical datum is unknown to this build; the height has no
     /// interpretable reference and is refused rather than guessed.
     #[error("vertical datum is unknown; height has no interpretable reference")]
@@ -33,6 +42,23 @@ pub enum GeoError {
     /// the ellipsoid↔MSL separation is undefined.
     #[error("geometric-MSL height requires a declared geoid model")]
     UndeclaredGeoidModel,
+    /// An AGL height was supplied without a declared terrain/ground reference,
+    /// so the ground it is measured above is unidentified.
+    #[error("AGL height requires a declared terrain/ground reference")]
+    UndeclaredTerrainReference,
+    /// A barometric-indicated height was supplied without a declared applied
+    /// altimeter-setting identity, so its datum surface is unidentified.
+    #[error("barometric-indicated height requires a declared applied-setting identity")]
+    UndeclaredBaroSetting,
+    /// A local-relative height was supplied without a declared local origin.
+    #[error("local-relative height requires a declared local origin")]
+    UndeclaredLocalOrigin,
+    /// A tile size was non-positive or non-finite, so no tile index is defined.
+    #[error("tile size {tile_deg} deg is not a positive finite value")]
+    InvalidTileSize {
+        /// The offending tile size, degrees.
+        tile_deg: f64,
+    },
     /// A viewport has a zero (or otherwise degenerate) dimension.
     #[error("viewport {width_px}x{height_px} is degenerate")]
     InvalidViewport {
@@ -57,15 +83,63 @@ pub enum GeoError {
         /// Far clip distance, meters.
         far_m: f64,
     },
+    /// The accepted-calibration reference is incomplete: a zero id, an
+    /// all-zero content hash, or a non-positive/non-finite alignment bound.
+    /// The view must reference exactly one validated calibration artifact.
+    #[error("calibration reference is incomplete or unbounded")]
+    IncompleteCalibrationReference,
+    /// An orthographic projection was declared without positive, finite metric
+    /// extents; a focal-derived field of view is not an orthographic invariant.
+    #[error("orthographic extents ({extent_x_m}, {extent_y_m} m) are not positive finite")]
+    InvalidOrthographicExtent {
+        /// Metric extent across the viewport width, meters.
+        extent_x_m: f64,
+        /// Metric extent across the viewport height, meters.
+        extent_y_m: f64,
+    },
+    /// The camera attitude is not a unit rotation.
+    #[error("camera attitude is not a unit rotation")]
+    CameraAttitudeNotARotation,
+    /// The camera pose does not map Body → Installation.
+    #[error("camera pose must map Body -> Installation")]
+    WrongCameraPoseFrames,
+    /// The aircraft attitude quaternion is not a unit rotation.
+    #[error("aircraft attitude is not a unit rotation")]
+    AttitudeNotARotation,
+}
+
+/// Why an age could not be computed between two epochs. There is no
+/// silently-inferred age: a future sample or an incompatible clock/scale is a
+/// typed refusal, never a saturated zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AgeError {
+    /// The two epochs are on different clock domains, so their difference is
+    /// not a physical duration.
+    #[error("age spans two clock domains")]
+    ClockMismatch,
+    /// The two epochs use different time scales, so their difference is not a
+    /// physical duration.
+    #[error("age spans two time scales")]
+    ScaleMismatch,
+    /// The sample was acquired after the reference time (a future sample); its
+    /// age is undefined and it must not be treated as fresh.
+    #[error("sample acquired {acquired_nanos} ns is after reference {now_nanos} ns")]
+    FutureSample {
+        /// The sample acquisition time, nanoseconds.
+        acquired_nanos: u64,
+        /// The reference (now) time, nanoseconds.
+        now_nanos: u64,
+    },
 }
 
 /// Why decoding a wire ABI block failed. Decode fails closed on any value this
 /// build cannot interpret, never masquerading as a benign default.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
 pub enum AbiError {
-    /// The buffer is shorter than the fixed block length.
-    #[error("ABI block truncated: need {needed} bytes, got {got}")]
-    Truncated {
+    /// The buffer length does not equal the fixed block length. A fixed-size
+    /// block must match exactly: trailing bytes are as suspect as truncation.
+    #[error("ABI block length wrong: need exactly {needed} bytes, got {got}")]
+    WrongLength {
         /// Bytes the block requires.
         needed: usize,
         /// Bytes supplied.
@@ -92,10 +166,13 @@ pub enum AbiError {
         field: &'static str,
     },
     /// The decoded values violate a semantic invariant (e.g. an MSL height with
-    /// no declared geoid), so the block is refused rather than trusted.
-    #[error("ABI block is semantically malformed: {field}")]
+    /// no declared geoid, a non-unit attitude), so the block is refused rather
+    /// than trusted. Carries the geospatial reason that rejected it.
+    #[error("ABI block is semantically malformed in {field}: {reason}")]
     Malformed {
-        /// What made the block malformed.
+        /// The block region that was malformed.
         field: &'static str,
+        /// The geospatial validation reason.
+        reason: GeoError,
     },
 }

--- a/crates/pilotage-geo/src/identity.rs
+++ b/crates/pilotage-geo/src/identity.rs
@@ -1,11 +1,17 @@
-//! Source identity, integrity, accuracy, age, and coherent-snapshot identity
-//! for a stated position or attitude.
+//! Source identity, integrity, coherent-snapshot identity, and the
+//! function-specific accuracy of a stated position or attitude.
+//!
+//! Identity and quality are separate concerns. [`SourceStamp`] carries only
+//! identity, integrity, and coherent-snapshot membership — never a
+//! domain-specific accuracy. Position accuracy is a length ([`PositionQuality`],
+//! millimeters); attitude accuracy is an angle ([`AttitudeQuality`],
+//! milliradians). A position's accuracy can never be read as an attitude's, and
+//! vice versa, because they are different types.
 //!
 //! # Reuse of the AV-01 `MeasurementStamp` shape
 //!
 //! [`SourceStamp`] carries the same identity semantics as AV-01's
-//! `MeasurementStamp`, mapped field for field, plus the integrity, accuracy, and
-//! coherent-snapshot identity a synthetic-vision consumer needs:
+//! `MeasurementStamp`, mapped field for field:
 //!
 //! | [`SourceStamp`] | AV-01 `MeasurementStamp` |
 //! |---|---|
@@ -16,12 +22,15 @@
 //! | `acquired_at` ([`Epoch`]) | `acquired_at_ns` + `clock`, enriched with a time scale |
 //!
 //! The acquisition time is an [`Epoch`] (clock **and** scale **and** nanos), so
-//! an age is only computed between two readings on the same clock and scale;
-//! across clock domains the age is `None`, never a silently-inferred difference.
+//! an age is only a physical duration between two readings on the same clock and
+//! scale; across clock domains or scales the age is a typed refusal, never a
+//! silently-inferred difference, and a future sample is a typed refusal, never a
+//! saturated zero.
 
 use pilotage_frames::{Epoch, Quat};
 
 use crate::datum::GeodeticPosition;
+use crate::error::AgeError;
 
 /// An opaque 128-bit source attachment/boot identity, compared only for
 /// equality (a new incarnation is authorized at a lifecycle boundary, never
@@ -70,34 +79,60 @@ impl IntegrityLevel {
     }
 }
 
-/// A 1-sigma accuracy estimate, in millimeters, for the horizontal and vertical
-/// components of a position.
+/// A 1-sigma accuracy estimate for a position, in millimeters — a length. It is
+/// a distinct type from [`AttitudeQuality`] so a position's accuracy can never
+/// be read as an attitude's.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Accuracy {
+pub struct PositionQuality {
     /// Horizontal 1-sigma estimate, millimeters.
     pub horizontal_mm: u32,
     /// Vertical 1-sigma estimate, millimeters.
     pub vertical_mm: u32,
 }
 
-/// Identity of a coherent multi-source snapshot: two stamps sharing a
-/// non-zero [`SnapshotId`] were sampled as one coherent set. `0` means the
-/// reading is not part of a declared coherent snapshot.
+/// A 1-sigma accuracy estimate for an attitude, in milliradians — an angle. It
+/// is a distinct type from [`PositionQuality`]: an attitude accuracy is never
+/// measured in millimeters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SnapshotId(pub u64);
+pub struct AttitudeQuality {
+    /// 1-sigma angular estimate, milliradians.
+    pub angular_mrad: u32,
+}
 
-impl SnapshotId {
+/// Identity of a coherent multi-source snapshot: the coherence producer that
+/// assembled it (by incarnation and generation) plus the snapshot instance id.
+/// Two readings are coherent only when this full identity matches — an equal
+/// numeric `id` from a different producer or generation is a different snapshot,
+/// never coherent. `id == 0` means the reading is not part of a declared
+/// coherent snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoherentSnapshot {
+    /// The coherence producer's attachment/boot identity.
+    pub producer: SourceIncarnation,
+    /// The coherence producer's generation.
+    pub generation: u32,
+    /// The snapshot instance id within that producer/generation; `0` = none.
+    pub id: u64,
+}
+
+impl CoherentSnapshot {
     /// The sentinel meaning the reading is not part of a coherent snapshot.
-    pub const NONE: Self = Self(0);
+    pub const NONE: Self = Self {
+        producer: SourceIncarnation([0; 16]),
+        generation: 0,
+        id: 0,
+    };
 
     /// Whether this reading belongs to a declared coherent snapshot.
     #[must_use]
     pub const fn is_declared(self) -> bool {
-        self.0 != 0
+        self.id != 0
     }
 }
 
-/// The full identity and quality stamp of one reading.
+/// The identity stamp of one reading: who produced it, when, how trusted, and
+/// which coherent snapshot it belongs to. It carries no domain-specific
+/// accuracy — position and attitude carry their own typed quality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SourceStamp {
     /// Adapter-defined source identity, stable within one vehicle.
@@ -112,51 +147,72 @@ pub struct SourceStamp {
     pub acquired_at: Epoch,
     /// Integrity trust level.
     pub integrity: IntegrityLevel,
-    /// Accuracy estimate.
-    pub accuracy: Accuracy,
     /// Coherent-snapshot identity.
-    pub snapshot: SnapshotId,
+    pub snapshot: CoherentSnapshot,
 }
 
 impl SourceStamp {
-    /// Age in nanoseconds relative to `now`, or `None` when `now` is on a
-    /// different clock domain or time scale than the acquisition epoch — an age
-    /// across clocks would be a silently-inferred difference, which this
-    /// contract forbids. Saturates at zero for a `now` earlier than acquisition.
-    #[must_use]
-    pub fn age_ns(&self, now: Epoch) -> Option<u64> {
-        if now.clock != self.acquired_at.clock || now.scale != self.acquired_at.scale {
-            return None;
+    /// Age in nanoseconds relative to `now`, failing closed rather than
+    /// inferring: a `now` on a different clock domain or time scale, or a
+    /// sample acquired after `now`, is a typed [`AgeError`], never a saturated
+    /// zero.
+    ///
+    /// # Errors
+    ///
+    /// [`AgeError::ClockMismatch`], [`AgeError::ScaleMismatch`], or
+    /// [`AgeError::FutureSample`].
+    pub fn age_ns(&self, now: Epoch) -> Result<u64, AgeError> {
+        if now.clock != self.acquired_at.clock {
+            return Err(AgeError::ClockMismatch);
         }
-        Some(now.nanos.saturating_sub(self.acquired_at.nanos))
+        if now.scale != self.acquired_at.scale {
+            return Err(AgeError::ScaleMismatch);
+        }
+        if self.acquired_at.nanos > now.nanos {
+            return Err(AgeError::FutureSample {
+                acquired_nanos: self.acquired_at.nanos,
+                now_nanos: now.nanos,
+            });
+        }
+        Ok(now.nanos - self.acquired_at.nanos)
     }
 
-    /// Whether this stamp and `other` belong to the same coherent snapshot: both
-    /// declare a snapshot id and the ids match.
+    /// Whether this stamp and `other` belong to the same coherent snapshot.
+    /// Coherence binds the full snapshot identity (producer incarnation,
+    /// generation, and instance id) **and** the sampling time base (clock and
+    /// scale): two readings with the same numeric snapshot id from different
+    /// producers, generations, or time bases are not coherent.
     #[must_use]
     pub fn coherent_with(&self, other: &Self) -> bool {
-        self.snapshot.is_declared() && self.snapshot == other.snapshot
+        self.snapshot.is_declared()
+            && self.snapshot == other.snapshot
+            && self.acquired_at.clock == other.acquired_at.clock
+            && self.acquired_at.scale == other.acquired_at.scale
     }
 }
 
-/// A geodetic position with its full identity and quality stamp.
+/// A geodetic position with its identity stamp and position accuracy.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StatedPosition {
     /// The stated position (datum-explicit).
     pub position: GeodeticPosition,
-    /// Identity, epoch, integrity, accuracy, and snapshot of the reading.
+    /// Identity, epoch, integrity, and snapshot of the reading.
     pub stamp: SourceStamp,
+    /// Position accuracy (a length).
+    pub quality: PositionQuality,
 }
 
-/// A vehicle attitude with its full identity and quality stamp. The attitude
+/// A vehicle attitude with its identity stamp and angular accuracy. The attitude
 /// rotates body directions to the local navigation frame; the frame pairing is
 /// a `pilotage-frames` concern the consumer applies, never implied here.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StatedAttitude {
     /// Body → local-navigation rotation.
     pub attitude: Quat,
-    /// Identity, epoch, integrity, accuracy, and snapshot of the reading.
+    /// Identity, epoch, integrity, and snapshot of the reading.
     pub stamp: SourceStamp,
+    /// Attitude accuracy (an angle).
+    pub quality: AttitudeQuality,
 }
 
 #[cfg(test)]

--- a/crates/pilotage-geo/src/identity.rs
+++ b/crates/pilotage-geo/src/identity.rs
@@ -1,0 +1,163 @@
+//! Source identity, integrity, accuracy, age, and coherent-snapshot identity
+//! for a stated position or attitude.
+//!
+//! # Reuse of the AV-01 `MeasurementStamp` shape
+//!
+//! [`SourceStamp`] carries the same identity semantics as AV-01's
+//! `MeasurementStamp`, mapped field for field, plus the integrity, accuracy, and
+//! coherent-snapshot identity a synthetic-vision consumer needs:
+//!
+//! | [`SourceStamp`] | AV-01 `MeasurementStamp` |
+//! |---|---|
+//! | `source_id` | `source_id` |
+//! | `incarnation` | `source_incarnation` |
+//! | `generation` | `source_epoch` (boot/attachment generation) |
+//! | `sequence` | `sequence` |
+//! | `acquired_at` ([`Epoch`]) | `acquired_at_ns` + `clock`, enriched with a time scale |
+//!
+//! The acquisition time is an [`Epoch`] (clock **and** scale **and** nanos), so
+//! an age is only computed between two readings on the same clock and scale;
+//! across clock domains the age is `None`, never a silently-inferred difference.
+
+use pilotage_frames::{Epoch, Quat};
+
+use crate::datum::GeodeticPosition;
+
+/// An opaque 128-bit source attachment/boot identity, compared only for
+/// equality (a new incarnation is authorized at a lifecycle boundary, never
+/// ordered against an old one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceIncarnation(pub [u8; 16]);
+
+/// The trust an integrity monitor places in a reading. `Unknown` is the
+/// fail-closed default: an unmonitored reading is not trusted for a scene.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum IntegrityLevel {
+    /// No integrity information; treat as untrusted.
+    Unknown = 0,
+    /// Monitored and found untrustworthy.
+    Untrusted = 1,
+    /// Monitored, within bounds, but not to the highest assurance.
+    Monitored = 2,
+    /// Monitored and trusted to the stated accuracy bound.
+    Trusted = 3,
+}
+
+impl IntegrityLevel {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Unknown),
+            1 => Some(Self::Untrusted),
+            2 => Some(Self::Monitored),
+            3 => Some(Self::Trusted),
+            _ => None,
+        }
+    }
+
+    /// Whether a reading at this level may contribute to a normal scene.
+    #[must_use]
+    pub const fn is_trusted(self) -> bool {
+        matches!(self, Self::Trusted)
+    }
+}
+
+/// A 1-sigma accuracy estimate, in millimeters, for the horizontal and vertical
+/// components of a position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Accuracy {
+    /// Horizontal 1-sigma estimate, millimeters.
+    pub horizontal_mm: u32,
+    /// Vertical 1-sigma estimate, millimeters.
+    pub vertical_mm: u32,
+}
+
+/// Identity of a coherent multi-source snapshot: two stamps sharing a
+/// non-zero [`SnapshotId`] were sampled as one coherent set. `0` means the
+/// reading is not part of a declared coherent snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotId(pub u64);
+
+impl SnapshotId {
+    /// The sentinel meaning the reading is not part of a coherent snapshot.
+    pub const NONE: Self = Self(0);
+
+    /// Whether this reading belongs to a declared coherent snapshot.
+    #[must_use]
+    pub const fn is_declared(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// The full identity and quality stamp of one reading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceStamp {
+    /// Adapter-defined source identity, stable within one vehicle.
+    pub source_id: u64,
+    /// Opaque attachment/boot identity.
+    pub incarnation: SourceIncarnation,
+    /// Source boot/attachment generation (AV-01 `source_epoch`).
+    pub generation: u32,
+    /// Wrapping group sequence.
+    pub sequence: u32,
+    /// Acquisition epoch: clock domain, time scale, and nanoseconds.
+    pub acquired_at: Epoch,
+    /// Integrity trust level.
+    pub integrity: IntegrityLevel,
+    /// Accuracy estimate.
+    pub accuracy: Accuracy,
+    /// Coherent-snapshot identity.
+    pub snapshot: SnapshotId,
+}
+
+impl SourceStamp {
+    /// Age in nanoseconds relative to `now`, or `None` when `now` is on a
+    /// different clock domain or time scale than the acquisition epoch — an age
+    /// across clocks would be a silently-inferred difference, which this
+    /// contract forbids. Saturates at zero for a `now` earlier than acquisition.
+    #[must_use]
+    pub fn age_ns(&self, now: Epoch) -> Option<u64> {
+        if now.clock != self.acquired_at.clock || now.scale != self.acquired_at.scale {
+            return None;
+        }
+        Some(now.nanos.saturating_sub(self.acquired_at.nanos))
+    }
+
+    /// Whether this stamp and `other` belong to the same coherent snapshot: both
+    /// declare a snapshot id and the ids match.
+    #[must_use]
+    pub fn coherent_with(&self, other: &Self) -> bool {
+        self.snapshot.is_declared() && self.snapshot == other.snapshot
+    }
+}
+
+/// A geodetic position with its full identity and quality stamp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StatedPosition {
+    /// The stated position (datum-explicit).
+    pub position: GeodeticPosition,
+    /// Identity, epoch, integrity, accuracy, and snapshot of the reading.
+    pub stamp: SourceStamp,
+}
+
+/// A vehicle attitude with its full identity and quality stamp. The attitude
+/// rotates body directions to the local navigation frame; the frame pairing is
+/// a `pilotage-frames` concern the consumer applies, never implied here.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StatedAttitude {
+    /// Body → local-navigation rotation.
+    pub attitude: Quat,
+    /// Identity, epoch, integrity, accuracy, and snapshot of the reading.
+    pub stamp: SourceStamp,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/identity/tests.rs
+++ b/crates/pilotage-geo/src/identity/tests.rs
@@ -1,9 +1,10 @@
-//! Tests for source identity, age, and coherence.
+//! Tests for source identity, typed age, and coherent-snapshot binding.
 #![allow(clippy::expect_used, clippy::panic)]
 
 use pilotage_frames::{ClockDomain, Epoch, TimeScale};
 
-use super::{Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp};
+use super::{CoherentSnapshot, IntegrityLevel, SourceIncarnation, SourceStamp};
+use crate::error::AgeError;
 
 fn epoch(clock: ClockDomain, scale: TimeScale, nanos: u64) -> Epoch {
     Epoch {
@@ -13,7 +14,15 @@ fn epoch(clock: ClockDomain, scale: TimeScale, nanos: u64) -> Epoch {
     }
 }
 
-fn stamp(acquired_at: Epoch, snapshot: SnapshotId) -> SourceStamp {
+fn snap(producer: u8, generation: u32, id: u64) -> CoherentSnapshot {
+    CoherentSnapshot {
+        producer: SourceIncarnation([producer; 16]),
+        generation,
+        id,
+    }
+}
+
+fn stamp(acquired_at: Epoch, snapshot: CoherentSnapshot) -> SourceStamp {
     SourceStamp {
         source_id: 1,
         incarnation: SourceIncarnation([7; 16]),
@@ -21,10 +30,6 @@ fn stamp(acquired_at: Epoch, snapshot: SnapshotId) -> SourceStamp {
         sequence: 0,
         acquired_at,
         integrity: IntegrityLevel::Trusted,
-        accuracy: Accuracy {
-            horizontal_mm: 1000,
-            vertical_mm: 2000,
-        },
         snapshot,
     }
 }
@@ -32,13 +37,25 @@ fn stamp(acquired_at: Epoch, snapshot: SnapshotId) -> SourceStamp {
 #[test]
 fn age_is_computed_only_within_one_clock_and_scale() {
     let acq = epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000);
-    let s = stamp(acq, SnapshotId::NONE);
+    let s = stamp(acq, CoherentSnapshot::NONE);
     let same = epoch(ClockDomain::Gnss, TimeScale::Gps, 3_000);
-    assert_eq!(s.age_ns(same), Some(2_000));
-    // Earlier `now` saturates at zero rather than underflowing.
+    assert_eq!(s.age_ns(same), Ok(2_000));
+}
+
+#[test]
+fn a_future_sample_is_a_typed_error_never_a_saturated_zero() {
+    let s = stamp(
+        epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000),
+        CoherentSnapshot::NONE,
+    );
+    let earlier = epoch(ClockDomain::Gnss, TimeScale::Gps, 500);
     assert_eq!(
-        s.age_ns(epoch(ClockDomain::Gnss, TimeScale::Gps, 500)),
-        Some(0)
+        s.age_ns(earlier),
+        Err(AgeError::FutureSample {
+            acquired_nanos: 1_000,
+            now_nanos: 500,
+        }),
+        "a sample from the future must not read as age zero"
     );
 }
 
@@ -46,32 +63,52 @@ fn age_is_computed_only_within_one_clock_and_scale() {
 fn age_across_clock_domains_is_never_inferred() {
     let s = stamp(
         epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000),
-        SnapshotId::NONE,
+        CoherentSnapshot::NONE,
     );
     assert_eq!(
         s.age_ns(epoch(ClockDomain::VehicleBoot, TimeScale::Gps, 3_000)),
-        None,
+        Err(AgeError::ClockMismatch),
         "different clock domain: no age"
     );
     assert_eq!(
         s.age_ns(epoch(ClockDomain::Gnss, TimeScale::Utc, 3_000)),
-        None,
+        Err(AgeError::ScaleMismatch),
         "different time scale: no age"
     );
 }
 
 #[test]
-fn coherence_requires_a_declared_matching_snapshot() {
+fn coherence_binds_the_full_snapshot_identity_and_time_base() {
     let acq = epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000);
-    let a = stamp(acq, SnapshotId(42));
-    let b = stamp(acq, SnapshotId(42));
-    let c = stamp(acq, SnapshotId(43));
-    let undeclared = stamp(acq, SnapshotId::NONE);
+    let a = stamp(acq, snap(1, 5, 42));
+    let b = stamp(acq, snap(1, 5, 42));
     assert!(
         a.coherent_with(&b),
-        "matching declared snapshot is coherent"
+        "same producer/generation/id is coherent"
     );
-    assert!(!a.coherent_with(&c), "different snapshot is not coherent");
+
+    // Same numeric id but a different producer is a different snapshot.
+    assert!(
+        !a.coherent_with(&stamp(acq, snap(2, 5, 42))),
+        "equal id from a different producer is not coherent"
+    );
+    // Same numeric id but a different generation is a different snapshot.
+    assert!(
+        !a.coherent_with(&stamp(acq, snap(1, 6, 42))),
+        "equal id from a different generation is not coherent"
+    );
+    // Same snapshot identity but a different time base is not coherent.
+    let other_clock = epoch(ClockDomain::Simulation, TimeScale::Monotonic, 1_000);
+    assert!(
+        !a.coherent_with(&stamp(other_clock, snap(1, 5, 42))),
+        "a different clock/scale is not one coherent sampling"
+    );
+}
+
+#[test]
+fn an_undeclared_snapshot_is_never_coherent() {
+    let acq = epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000);
+    let undeclared = stamp(acq, CoherentSnapshot::NONE);
     assert!(
         !undeclared.coherent_with(&undeclared),
         "an undeclared snapshot is never coherent, even with itself"

--- a/crates/pilotage-geo/src/identity/tests.rs
+++ b/crates/pilotage-geo/src/identity/tests.rs
@@ -1,0 +1,94 @@
+//! Tests for source identity, age, and coherence.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_frames::{ClockDomain, Epoch, TimeScale};
+
+use super::{Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp};
+
+fn epoch(clock: ClockDomain, scale: TimeScale, nanos: u64) -> Epoch {
+    Epoch {
+        clock,
+        scale,
+        nanos,
+    }
+}
+
+fn stamp(acquired_at: Epoch, snapshot: SnapshotId) -> SourceStamp {
+    SourceStamp {
+        source_id: 1,
+        incarnation: SourceIncarnation([7; 16]),
+        generation: 0,
+        sequence: 0,
+        acquired_at,
+        integrity: IntegrityLevel::Trusted,
+        accuracy: Accuracy {
+            horizontal_mm: 1000,
+            vertical_mm: 2000,
+        },
+        snapshot,
+    }
+}
+
+#[test]
+fn age_is_computed_only_within_one_clock_and_scale() {
+    let acq = epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000);
+    let s = stamp(acq, SnapshotId::NONE);
+    let same = epoch(ClockDomain::Gnss, TimeScale::Gps, 3_000);
+    assert_eq!(s.age_ns(same), Some(2_000));
+    // Earlier `now` saturates at zero rather than underflowing.
+    assert_eq!(
+        s.age_ns(epoch(ClockDomain::Gnss, TimeScale::Gps, 500)),
+        Some(0)
+    );
+}
+
+#[test]
+fn age_across_clock_domains_is_never_inferred() {
+    let s = stamp(
+        epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000),
+        SnapshotId::NONE,
+    );
+    assert_eq!(
+        s.age_ns(epoch(ClockDomain::VehicleBoot, TimeScale::Gps, 3_000)),
+        None,
+        "different clock domain: no age"
+    );
+    assert_eq!(
+        s.age_ns(epoch(ClockDomain::Gnss, TimeScale::Utc, 3_000)),
+        None,
+        "different time scale: no age"
+    );
+}
+
+#[test]
+fn coherence_requires_a_declared_matching_snapshot() {
+    let acq = epoch(ClockDomain::Gnss, TimeScale::Gps, 1_000);
+    let a = stamp(acq, SnapshotId(42));
+    let b = stamp(acq, SnapshotId(42));
+    let c = stamp(acq, SnapshotId(43));
+    let undeclared = stamp(acq, SnapshotId::NONE);
+    assert!(
+        a.coherent_with(&b),
+        "matching declared snapshot is coherent"
+    );
+    assert!(!a.coherent_with(&c), "different snapshot is not coherent");
+    assert!(
+        !undeclared.coherent_with(&undeclared),
+        "an undeclared snapshot is never coherent, even with itself"
+    );
+}
+
+#[test]
+fn integrity_wire_codes_round_trip_and_reject_unknown() {
+    for level in [
+        IntegrityLevel::Unknown,
+        IntegrityLevel::Untrusted,
+        IntegrityLevel::Monitored,
+        IntegrityLevel::Trusted,
+    ] {
+        assert_eq!(IntegrityLevel::from_u8(level.to_u8()), Some(level));
+    }
+    assert_eq!(IntegrityLevel::from_u8(9), None);
+    assert!(IntegrityLevel::Trusted.is_trusted());
+    assert!(!IntegrityLevel::Monitored.is_trusted());
+}

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -48,18 +48,21 @@ mod identity;
 mod taws;
 mod view;
 
-pub use abi::{ABI_VERSION, SvsFrame, decode_frame, encode_frame};
-pub use availability::{AvailabilityReason, InputHealth, SvsAvailability, SvsInputs};
-pub use datum::{
-    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
+pub use abi::{
+    ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,
 };
-pub use error::{AbiError, GeoError};
+pub use availability::{
+    AvailabilityReason, ExternalHealth, InputHealth, MAX_FRESH_AGE_NS, MAX_USABLE_AGE_NS,
+    SvsAvailability, SvsInputs, derive_inputs, health_from_integrity,
+};
+pub use datum::{
+    BaroSettingId, DatumRealizationId, GeoTile, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition, wrap_longitude_deg,
+};
+pub use error::{AbiError, AgeError, GeoError};
 pub use identity::{
-    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
-    StatedPosition,
+    AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
+    SourceStamp, StatedAttitude, StatedPosition,
 };
 pub use taws::{TawsAlert, TawsHazard};
-pub use view::{
-    CameraPose, FieldOfView, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
-    ProjectionView, Viewport,
-};
+pub use view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -52,8 +52,9 @@ pub use abi::{
     ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,
 };
 pub use availability::{
-    AvailabilityReason, ExternalHealth, InputHealth, MAX_FRESH_AGE_NS, MAX_USABLE_AGE_NS,
-    SvsAvailability, SvsInputs, derive_inputs, health_from_integrity,
+    AvailabilityReason, ExternalHealth, InputHealth, MAX_FRESH_AGE_NS, MAX_FRESH_ATT_MRAD,
+    MAX_FRESH_POS_MM, MAX_USABLE_AGE_NS, MAX_USABLE_ATT_MRAD, MAX_USABLE_POS_MM, SvsAvailability,
+    SvsInputs, derive_inputs, health_from_integrity,
 };
 pub use datum::{
     BaroSettingId, DatumRealizationId, GeoTile, GeodeticPosition, GeoidModelId, HorizontalDatum,
@@ -65,4 +66,6 @@ pub use identity::{
     SourceStamp, StatedAttitude, StatedPosition,
 };
 pub use taws::{TawsAlert, TawsHazard};
-pub use view::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
+pub use view::{
+    CalibrationId, CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView,
+};

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -1,0 +1,65 @@
+//! Transport-independent geospatial, projection, coherence, and availability
+//! contract for synthetic vision and conformal HUD (SVS-01).
+//!
+//! This crate is the typed contract that a synthetic-vision system and a
+//! head-up display both consume; it is **not** a synthetic-vision
+//! implementation, a renderer, or a terrain database, and completion defines a
+//! simulator/engineering contract, **not** SVS/SVGS approval. SIM / NOT FOR
+//! FLIGHT.
+//!
+//! Everything here fails closed. Datum, units, reference, and clock domain are
+//! explicit at the type level and can never be silently inferred: there is no
+//! bare altitude, no untagged position, no implicit frame or clock. A missing,
+//! inconsistent, or untrusted input resolves to [`SvsAvailability::Degraded`] or
+//! [`SvsAvailability::Unavailable`] with a finite, traceable
+//! [`AvailabilityReason`] — never a plausible-looking normal scene. The wire
+//! ABI ([`abi`]) is versioned, fixed-size, little-endian, and decode fails
+//! closed on any unknown value.
+//!
+//! # Consumed vocabularies
+//!
+//! Reference frames, clock domains, time scales, epochs, and rotations come
+//! from `pilotage-frames` ([`pilotage_frames::FrameId`],
+//! [`pilotage_frames::Epoch`], [`pilotage_frames::Quat`]); source identity
+//! reuses the AV-01 `MeasurementStamp` shape ([`identity`] documents the
+//! mapping). The vertical-datum vocabulary parallels instrument-state's
+//! `AltitudeClass` with a documented mapping ([`datum`]) rather than a
+//! dependency, because this crate is foundational and instrument-state is a
+//! consumer.
+//!
+//! # TAWS independence
+//!
+//! A terrain-awareness alert is an independent [`taws::TawsAlert`] input. No
+//! type or path here lets synthetic vision become an implicit TAWS: the SVS
+//! availability verdict and a TAWS alert are separate values with separate
+//! failure behavior.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+#[cfg(test)]
+extern crate std;
+
+mod abi;
+mod availability;
+mod datum;
+mod error;
+mod identity;
+mod taws;
+mod view;
+
+pub use abi::{ABI_VERSION, SvsFrame, decode_frame, encode_frame};
+pub use availability::{AvailabilityReason, InputHealth, SvsAvailability, SvsInputs};
+pub use datum::{
+    GeodeticPosition, GeoidModelId, HorizontalDatum, LocalOriginId, VerticalDatum, VerticalPosition,
+};
+pub use error::{AbiError, GeoError};
+pub use identity::{
+    Accuracy, IntegrityLevel, SnapshotId, SourceIncarnation, SourceStamp, StatedAttitude,
+    StatedPosition,
+};
+pub use taws::{TawsAlert, TawsHazard};
+pub use view::{
+    CameraPose, FieldOfView, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
+    ProjectionView, Viewport,
+};

--- a/crates/pilotage-geo/src/taws.rs
+++ b/crates/pilotage-geo/src/taws.rs
@@ -1,0 +1,59 @@
+//! Terrain-awareness alerts as an INDEPENDENT input.
+//!
+//! Synthetic vision must never become an implicit terrain-awareness-and-warning
+//! system. A [`TawsAlert`] is a separate input with its own source identity and
+//! epoch; nothing in this crate derives a TAWS alert from the SVS scene or
+//! folds SVS availability into a terrain hazard. The two are independent values
+//! with independent failure behavior: an available scene asserts nothing about
+//! terrain clearance, and a TAWS warning is not suppressed by a degraded scene.
+//! A real display composes them side by side; it does not let one stand in for
+//! the other.
+
+use crate::identity::SourceStamp;
+
+/// The terrain hazard an independent TAWS reports. `None` is not an assurance of
+/// clearance — it is the absence of an alert from the TAWS input, distinct from
+/// anything the SVS scene shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TawsHazard {
+    /// No active terrain alert from the TAWS input.
+    None = 0,
+    /// Terrain caution.
+    Caution = 1,
+    /// Terrain warning (e.g. pull-up).
+    Warning = 2,
+}
+
+impl TawsHazard {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::None),
+            1 => Some(Self::Caution),
+            2 => Some(Self::Warning),
+            _ => None,
+        }
+    }
+}
+
+/// An independent terrain-awareness alert, carrying its own source stamp. It is
+/// an input to a display, never an output of synthetic vision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TawsAlert {
+    /// The reported terrain hazard.
+    pub hazard: TawsHazard,
+    /// Identity, epoch, and integrity of the TAWS source (separate from any
+    /// SVS position/attitude source).
+    pub stamp: SourceStamp,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/taws/tests.rs
+++ b/crates/pilotage-geo/src/taws/tests.rs
@@ -1,0 +1,36 @@
+//! Tests pinning TAWS independence in the type surface.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::TawsHazard;
+use crate::availability::{AvailabilityReason, InputHealth, SvsAvailability, SvsInputs};
+
+#[test]
+fn taws_hazard_wire_codes_round_trip_and_reject_unknown() {
+    for h in [TawsHazard::None, TawsHazard::Caution, TawsHazard::Warning] {
+        assert_eq!(TawsHazard::from_u8(h.to_u8()), Some(h));
+    }
+    assert_eq!(TawsHazard::from_u8(9), None);
+}
+
+// A structural guarantee: the availability API takes only SvsInputs and yields
+// only an SvsAvailability, with no TawsHazard anywhere in its signature — so a
+// TAWS alert can neither influence the SVS verdict nor be produced by it.
+#[test]
+fn svs_availability_is_computed_without_any_taws_input() {
+    let ok = InputHealth::Ok;
+    let inputs = SvsInputs {
+        position: ok,
+        attitude: ok,
+        integrity: ok,
+        time_coherence: ok,
+        calibration: ok,
+        database: ok,
+        coverage: ok,
+        renderer: ok,
+    };
+    // An available scene says nothing about terrain; a caller must consult the
+    // independent TAWS input separately.
+    let verdict = SvsAvailability::assess(&inputs);
+    assert_eq!(verdict, SvsAvailability::Available);
+    assert_eq!(verdict.reason(), AvailabilityReason::Nominal);
+}

--- a/crates/pilotage-geo/src/view.rs
+++ b/crates/pilotage-geo/src/view.rs
@@ -1,0 +1,235 @@
+//! Viewport, projection, camera pose, and the derived field of view.
+//!
+//! Aligned with the SVS-01 sibling calibration contract (ADR-0021): the field
+//! of view is **derived** from the viewport and focal lengths, never stored;
+//! the optical convention is OpenCV; and the camera pose names its frames with
+//! the `pilotage-frames` vocabulary (`Body` → `Installation`). Nothing here
+//! renders — it declares the view a renderer must honor.
+
+use pilotage_frames::{FrameId, Quat};
+
+use crate::error::GeoError;
+
+/// The optical coordinate convention intrinsics and the boresight are expressed
+/// in. Explicit so a projection is never read against a guessed axis layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum OpticalConvention {
+    /// OpenCV: `+Z` along the optical axis, `+X` right, `+Y` down.
+    OpenCv = 0,
+}
+
+impl OpticalConvention {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::OpenCv),
+            _ => None,
+        }
+    }
+}
+
+/// The image sensor viewport, in pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Viewport {
+    /// Image width, pixels.
+    pub width_px: u32,
+    /// Image height, pixels.
+    pub height_px: u32,
+}
+
+/// Angular field of view, in radians. Always a **derived** result, never a
+/// stored field.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FieldOfView {
+    /// Horizontal field of view, radians.
+    pub horizontal_rad: f64,
+    /// Vertical field of view, radians.
+    pub vertical_rad: f64,
+}
+
+/// The projection a renderer must apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProjectionKind {
+    /// Perspective projection.
+    Perspective = 0,
+    /// Orthographic projection.
+    Orthographic = 1,
+}
+
+impl ProjectionKind {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Perspective),
+            1 => Some(Self::Orthographic),
+            _ => None,
+        }
+    }
+}
+
+/// How a renderer samples terrain/tiles under minification (distant detail).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MinificationPolicy {
+    /// Nearest-sample (no filtering).
+    Nearest = 0,
+    /// Bilinear within one level.
+    Bilinear = 1,
+    /// Trilinear across mip levels.
+    Trilinear = 2,
+}
+
+impl MinificationPolicy {
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+    /// Decodes the wire byte, or `None` for an unknown value.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Nearest),
+            1 => Some(Self::Bilinear),
+            2 => Some(Self::Trilinear),
+            _ => None,
+        }
+    }
+}
+
+/// The near/far clip policy, in meters.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NearFarPolicy {
+    /// Near clip distance, meters (must be `> 0`).
+    pub near_m: f64,
+    /// Far clip distance, meters (must be `> near`).
+    pub far_m: f64,
+}
+
+impl NearFarPolicy {
+    /// Whether a depth (meters along the optical axis) is within the clip
+    /// range, inclusive of both planes — the projection-boundary predicate.
+    #[must_use]
+    pub fn contains_depth(&self, depth_m: f64) -> bool {
+        depth_m >= self.near_m && depth_m <= self.far_m
+    }
+}
+
+/// The camera pose: where the camera sits and how it is oriented, with both
+/// frames named (`Body` → `Installation`, the sensor mount).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CameraPose {
+    /// Camera optical-frame origin in the `from_frame`, meters.
+    pub translation_m: [f64; 3],
+    /// Rotation from `from_frame` directions to the camera optical frame.
+    pub attitude: Quat,
+    /// The frame the translation is in and the rotation maps from.
+    pub from_frame: FrameId,
+    /// The frame the rotation maps into (the sensor/installation mount).
+    pub to_frame: FrameId,
+}
+
+/// The complete projection view: viewport, focal lengths, projection, clip
+/// policy, minification, convention, and camera pose. The field of view is
+/// derived from the viewport and focal lengths, never stored.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProjectionView {
+    /// Image viewport.
+    pub viewport: Viewport,
+    /// Focal length x, pixels (`> 0`).
+    pub focal_x_px: f64,
+    /// Focal length y, pixels (`> 0`).
+    pub focal_y_px: f64,
+    /// Projection kind.
+    pub projection: ProjectionKind,
+    /// Near/far clip policy.
+    pub near_far: NearFarPolicy,
+    /// Minification sampling policy.
+    pub minification: MinificationPolicy,
+    /// Optical convention.
+    pub convention: OpticalConvention,
+    /// Camera pose.
+    pub camera: CameraPose,
+}
+
+impl ProjectionView {
+    /// Derives the angular field of view from the viewport and focal lengths:
+    /// `fov = 2·atan((size/2)/focal)` per axis.
+    #[must_use]
+    pub fn field_of_view(&self) -> FieldOfView {
+        let half_w = f64::from(self.viewport.width_px) / 2.0;
+        let half_h = f64::from(self.viewport.height_px) / 2.0;
+        FieldOfView {
+            horizontal_rad: 2.0 * libm::atan(half_w / self.focal_x_px),
+            vertical_rad: 2.0 * libm::atan(half_h / self.focal_y_px),
+        }
+    }
+
+    /// Validates the view, failing closed on a degenerate viewport, a
+    /// non-positive focal, an invalid clip policy, a non-finite camera
+    /// translation, a non-unit camera attitude, or wrong pose frames.
+    ///
+    /// # Errors
+    ///
+    /// A [`GeoError`] describing the first violation.
+    pub fn validate(&self) -> Result<(), GeoError> {
+        if self.viewport.width_px == 0 || self.viewport.height_px == 0 {
+            return Err(GeoError::InvalidViewport {
+                width_px: self.viewport.width_px,
+                height_px: self.viewport.height_px,
+            });
+        }
+        if !(self.focal_x_px.is_finite() && self.focal_y_px.is_finite())
+            || self.focal_x_px <= 0.0
+            || self.focal_y_px <= 0.0
+        {
+            return Err(GeoError::NonPositiveFocal {
+                focal_x_px: self.focal_x_px,
+                focal_y_px: self.focal_y_px,
+            });
+        }
+        if !(self.near_far.near_m.is_finite() && self.near_far.far_m.is_finite())
+            || self.near_far.near_m <= 0.0
+            || self.near_far.far_m <= self.near_far.near_m
+        {
+            return Err(GeoError::InvalidNearFar {
+                near_m: self.near_far.near_m,
+                far_m: self.near_far.far_m,
+            });
+        }
+        if !self.camera.translation_m.iter().all(|v| v.is_finite()) {
+            return Err(GeoError::NonFinite {
+                field: "camera_translation_m",
+            });
+        }
+        if self.camera.attitude.renormalized(1e-4).is_err() {
+            return Err(GeoError::NonFinite {
+                field: "camera_attitude_not_a_rotation",
+            });
+        }
+        if self.camera.from_frame != FrameId::Body || self.camera.to_frame != FrameId::Installation
+        {
+            return Err(GeoError::NonFinite {
+                field: "camera_pose_frames",
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/view.rs
+++ b/crates/pilotage-geo/src/view.rs
@@ -15,35 +15,57 @@
 
 use crate::error::GeoError;
 
-/// A reference to one accepted, validated calibration artifact. The view is
-/// meaningless without it: id and content hash identify the exact artifact, and
-/// the alignment bound is the artifact's published conservative angular bound
-/// that a conformal consumer composes into its total error budget.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// Accepted-calibration identity. Mirrors the authoritative
+/// `pilotage-adapter-api` `CalibrationId(u32)` field for field — same width,
+/// same `0 = none` sentinel — so a geo reference and the calibration artifact
+/// it points at share one identity space with no truncation. This crate is
+/// `no_std` and adapter-api is `std`, so the type is documented-mapped here
+/// (like the datum ↔ `AltitudeClass` mapping) rather than depended on across
+/// the direction boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalibrationId(pub u32);
+
+impl CalibrationId {
+    /// The sentinel meaning no calibration identity is referenced.
+    pub const NONE: Self = Self(0);
+
+    /// Whether a calibration identity is actually referenced.
+    #[must_use]
+    pub const fn is_referenced(self) -> bool {
+        self.0 != 0
+    }
+}
+
+/// A reference to one accepted, validated calibration artifact — identity and
+/// content hash only. The view is meaningless without it, and it deliberately
+/// carries **no** geometry or error bound: the alignment bound, principal
+/// point, distortion, boresight, design eye, and lifecycle all belong to the
+/// artifact and are obtained by *resolving* this reference against a verified
+/// artifact (in the `std` calibration contract). A producer cannot write an
+/// alignment bound onto the wire here, so it cannot understate one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CalibrationRef {
-    /// Accepted-calibration identity (must be non-zero).
-    pub calibration_id: u64,
-    /// The artifact's recorded content hash (must not be all-zero).
+    /// Accepted-calibration identity (must be referenced).
+    pub calibration_id: CalibrationId,
+    /// The artifact's recorded content hash (must not be all-zero); a resolver
+    /// admits the reference only if a verified artifact with this id hashes to
+    /// exactly this value.
     pub content_hash: [u8; 32],
-    /// The artifact's published conservative alignment bound, radians
-    /// (must be finite and `> 0`).
-    pub alignment_bound_rad: f64,
 }
 
 impl CalibrationRef {
-    /// Validates the reference: a non-zero id, a non-zero content hash, and a
-    /// finite positive alignment bound.
+    /// Validates the reference is well-formed: a referenced id and a non-zero
+    /// content hash. Whether the referenced artifact exists, is unexpired, and
+    /// matches the camera is a *resolution* concern the consumer settles
+    /// against a verified artifact — this contract only guarantees the
+    /// reference names something.
     ///
     /// # Errors
     ///
-    /// [`GeoError::IncompleteCalibrationReference`] when any part is missing.
+    /// [`GeoError::IncompleteCalibrationReference`] when id or hash is missing.
     pub fn validate(&self) -> Result<(), GeoError> {
         let hash_declared = self.content_hash.iter().any(|&b| b != 0);
-        if self.calibration_id == 0
-            || !hash_declared
-            || !self.alignment_bound_rad.is_finite()
-            || self.alignment_bound_rad <= 0.0
-        {
+        if !self.calibration_id.is_referenced() || !hash_declared {
             return Err(GeoError::IncompleteCalibrationReference);
         }
         Ok(())

--- a/crates/pilotage-geo/src/view.rs
+++ b/crates/pilotage-geo/src/view.rs
@@ -1,82 +1,82 @@
-//! Viewport, projection, camera pose, and the derived field of view.
+//! The projection view: a reference to one validated calibration plus the
+//! render-time projection and clip policy.
 //!
-//! Aligned with the SVS-01 sibling calibration contract (ADR-0021): the field
-//! of view is **derived** from the viewport and focal lengths, never stored;
-//! the optical convention is OpenCV; and the camera pose names its frames with
-//! the `pilotage-frames` vocabulary (`Body` → `Installation`). Nothing here
-//! renders — it declares the view a renderer must honor.
-
-use pilotage_frames::{FrameId, Quat};
+//! There is exactly one authoritative camera model in the program — the
+//! versioned, hashed calibration artifact (the SVS-01 sibling calibration
+//! contract, ADR-0021). This crate does **not** re-mint a second camera model:
+//! intrinsics, distortion, principal point, viewport, extrinsics, boresight,
+//! design eye, and the alignment-error bound all live in that artifact. A
+//! [`ProjectionView`] only *references* the accepted calibration by identity and
+//! content hash, carries its published alignment bound, and adds the render-time
+//! policy (projection kind and payload, near/far, minification). A consumer
+//! resolves the reference against a validated artifact to obtain the geometry;
+//! the field of view is a property of that resolved calibration, never stored
+//! here.
 
 use crate::error::GeoError;
 
-/// The optical coordinate convention intrinsics and the boresight are expressed
-/// in. Explicit so a projection is never read against a guessed axis layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum OpticalConvention {
-    /// OpenCV: `+Z` along the optical axis, `+X` right, `+Y` down.
-    OpenCv = 0,
-}
-
-impl OpticalConvention {
-    /// Wire encoding.
-    #[must_use]
-    pub const fn to_u8(self) -> u8 {
-        self as u8
-    }
-    /// Decodes the wire byte, or `None` for an unknown value.
-    #[must_use]
-    pub const fn from_u8(code: u8) -> Option<Self> {
-        match code {
-            0 => Some(Self::OpenCv),
-            _ => None,
-        }
-    }
-}
-
-/// The image sensor viewport, in pixels.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Viewport {
-    /// Image width, pixels.
-    pub width_px: u32,
-    /// Image height, pixels.
-    pub height_px: u32,
-}
-
-/// Angular field of view, in radians. Always a **derived** result, never a
-/// stored field.
+/// A reference to one accepted, validated calibration artifact. The view is
+/// meaningless without it: id and content hash identify the exact artifact, and
+/// the alignment bound is the artifact's published conservative angular bound
+/// that a conformal consumer composes into its total error budget.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FieldOfView {
-    /// Horizontal field of view, radians.
-    pub horizontal_rad: f64,
-    /// Vertical field of view, radians.
-    pub vertical_rad: f64,
+pub struct CalibrationRef {
+    /// Accepted-calibration identity (must be non-zero).
+    pub calibration_id: u64,
+    /// The artifact's recorded content hash (must not be all-zero).
+    pub content_hash: [u8; 32],
+    /// The artifact's published conservative alignment bound, radians
+    /// (must be finite and `> 0`).
+    pub alignment_bound_rad: f64,
 }
 
-/// The projection a renderer must apply.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum ProjectionKind {
-    /// Perspective projection.
-    Perspective = 0,
-    /// Orthographic projection.
-    Orthographic = 1,
-}
-
-impl ProjectionKind {
-    /// Wire encoding.
-    #[must_use]
-    pub const fn to_u8(self) -> u8 {
-        self as u8
+impl CalibrationRef {
+    /// Validates the reference: a non-zero id, a non-zero content hash, and a
+    /// finite positive alignment bound.
+    ///
+    /// # Errors
+    ///
+    /// [`GeoError::IncompleteCalibrationReference`] when any part is missing.
+    pub fn validate(&self) -> Result<(), GeoError> {
+        let hash_declared = self.content_hash.iter().any(|&b| b != 0);
+        if self.calibration_id == 0
+            || !hash_declared
+            || !self.alignment_bound_rad.is_finite()
+            || self.alignment_bound_rad <= 0.0
+        {
+            return Err(GeoError::IncompleteCalibrationReference);
+        }
+        Ok(())
     }
-    /// Decodes the wire byte, or `None` for an unknown value.
+}
+
+/// The projection a renderer must apply, with the payload each kind needs. A
+/// perspective view derives its field of view from the referenced calibration's
+/// focal lengths and viewport; an orthographic view is defined by metric
+/// extents, because a focal-derived field of view is not an orthographic
+/// invariant.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Projection {
+    /// Perspective projection; the field of view derives from the referenced
+    /// calibration (focal lengths + viewport), never stored here.
+    Perspective,
+    /// Orthographic projection defined by its metric extents across the
+    /// viewport, meters. Both extents must be finite and positive.
+    Orthographic {
+        /// Metric extent across the viewport width, meters.
+        extent_x_m: f64,
+        /// Metric extent across the viewport height, meters.
+        extent_y_m: f64,
+    },
+}
+
+impl Projection {
+    /// The wire discriminant for the projection kind.
     #[must_use]
-    pub const fn from_u8(code: u8) -> Option<Self> {
-        match code {
-            0 => Some(Self::Perspective),
-            1 => Some(Self::Orthographic),
-            _ => None,
+    pub const fn kind_u8(self) -> u8 {
+        match self {
+            Self::Perspective => 0,
+            Self::Orthographic { .. } => 1,
         }
     }
 }
@@ -129,79 +129,30 @@ impl NearFarPolicy {
     }
 }
 
-/// The camera pose: where the camera sits and how it is oriented, with both
-/// frames named (`Body` → `Installation`, the sensor mount).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct CameraPose {
-    /// Camera optical-frame origin in the `from_frame`, meters.
-    pub translation_m: [f64; 3],
-    /// Rotation from `from_frame` directions to the camera optical frame.
-    pub attitude: Quat,
-    /// The frame the translation is in and the rotation maps from.
-    pub from_frame: FrameId,
-    /// The frame the rotation maps into (the sensor/installation mount).
-    pub to_frame: FrameId,
-}
-
-/// The complete projection view: viewport, focal lengths, projection, clip
-/// policy, minification, convention, and camera pose. The field of view is
-/// derived from the viewport and focal lengths, never stored.
+/// The projection view: a reference to the one validated calibration plus the
+/// render-time projection and clip policy. It holds no camera model of its own.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ProjectionView {
-    /// Image viewport.
-    pub viewport: Viewport,
-    /// Focal length x, pixels (`> 0`).
-    pub focal_x_px: f64,
-    /// Focal length y, pixels (`> 0`).
-    pub focal_y_px: f64,
-    /// Projection kind.
-    pub projection: ProjectionKind,
+    /// Reference to the accepted, validated calibration artifact.
+    pub calibration: CalibrationRef,
+    /// Projection kind and payload.
+    pub projection: Projection,
     /// Near/far clip policy.
     pub near_far: NearFarPolicy,
     /// Minification sampling policy.
     pub minification: MinificationPolicy,
-    /// Optical convention.
-    pub convention: OpticalConvention,
-    /// Camera pose.
-    pub camera: CameraPose,
 }
 
 impl ProjectionView {
-    /// Derives the angular field of view from the viewport and focal lengths:
-    /// `fov = 2·atan((size/2)/focal)` per axis.
-    #[must_use]
-    pub fn field_of_view(&self) -> FieldOfView {
-        let half_w = f64::from(self.viewport.width_px) / 2.0;
-        let half_h = f64::from(self.viewport.height_px) / 2.0;
-        FieldOfView {
-            horizontal_rad: 2.0 * libm::atan(half_w / self.focal_x_px),
-            vertical_rad: 2.0 * libm::atan(half_h / self.focal_y_px),
-        }
-    }
-
-    /// Validates the view, failing closed on a degenerate viewport, a
-    /// non-positive focal, an invalid clip policy, a non-finite camera
-    /// translation, a non-unit camera attitude, or wrong pose frames.
+    /// Validates the view, failing closed on an incomplete calibration
+    /// reference, an invalid clip policy, or an orthographic projection without
+    /// positive finite extents.
     ///
     /// # Errors
     ///
     /// A [`GeoError`] describing the first violation.
     pub fn validate(&self) -> Result<(), GeoError> {
-        if self.viewport.width_px == 0 || self.viewport.height_px == 0 {
-            return Err(GeoError::InvalidViewport {
-                width_px: self.viewport.width_px,
-                height_px: self.viewport.height_px,
-            });
-        }
-        if !(self.focal_x_px.is_finite() && self.focal_y_px.is_finite())
-            || self.focal_x_px <= 0.0
-            || self.focal_y_px <= 0.0
-        {
-            return Err(GeoError::NonPositiveFocal {
-                focal_x_px: self.focal_x_px,
-                focal_y_px: self.focal_y_px,
-            });
-        }
+        self.calibration.validate()?;
         if !(self.near_far.near_m.is_finite() && self.near_far.far_m.is_finite())
             || self.near_far.near_m <= 0.0
             || self.near_far.far_m <= self.near_far.near_m
@@ -211,20 +162,17 @@ impl ProjectionView {
                 far_m: self.near_far.far_m,
             });
         }
-        if !self.camera.translation_m.iter().all(|v| v.is_finite()) {
-            return Err(GeoError::NonFinite {
-                field: "camera_translation_m",
-            });
-        }
-        if self.camera.attitude.renormalized(1e-4).is_err() {
-            return Err(GeoError::NonFinite {
-                field: "camera_attitude_not_a_rotation",
-            });
-        }
-        if self.camera.from_frame != FrameId::Body || self.camera.to_frame != FrameId::Installation
+        if let Projection::Orthographic {
+            extent_x_m,
+            extent_y_m,
+        } = self.projection
+            && (!(extent_x_m.is_finite() && extent_y_m.is_finite())
+                || extent_x_m <= 0.0
+                || extent_y_m <= 0.0)
         {
-            return Err(GeoError::NonFinite {
-                field: "camera_pose_frames",
+            return Err(GeoError::InvalidOrthographicExtent {
+                extent_x_m,
+                extent_y_m,
             });
         }
         Ok(())

--- a/crates/pilotage-geo/src/view/tests.rs
+++ b/crates/pilotage-geo/src/view/tests.rs
@@ -2,14 +2,15 @@
 //! payloads, projection boundary, and fail-closed validation.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use super::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
+use super::{
+    CalibrationId, CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView,
+};
 use crate::error::GeoError;
 
 fn calibration() -> CalibrationRef {
     CalibrationRef {
-        calibration_id: 0x0FED_CBA9,
+        calibration_id: CalibrationId(0x0FED_CBA9),
         content_hash: [7u8; 32],
-        alignment_bound_rad: 0.0117,
     }
 }
 
@@ -62,7 +63,7 @@ fn valid_orthographic_view_passes() {
 #[test]
 fn an_incomplete_calibration_reference_is_refused() {
     let mut v = view();
-    v.calibration.calibration_id = 0;
+    v.calibration.calibration_id = CalibrationId::NONE;
     assert!(matches!(
         v.validate(),
         Err(GeoError::IncompleteCalibrationReference)
@@ -74,20 +75,6 @@ fn an_incomplete_calibration_reference_is_refused() {
         matches!(v.validate(), Err(GeoError::IncompleteCalibrationReference)),
         "an all-zero content hash does not identify an artifact"
     );
-
-    let mut v = view();
-    v.calibration.alignment_bound_rad = 0.0;
-    assert!(
-        matches!(v.validate(), Err(GeoError::IncompleteCalibrationReference)),
-        "a zero alignment bound is an unbounded claim"
-    );
-
-    let mut v = view();
-    v.calibration.alignment_bound_rad = f64::NAN;
-    assert!(matches!(
-        v.validate(),
-        Err(GeoError::IncompleteCalibrationReference)
-    ));
 }
 
 #[test]

--- a/crates/pilotage-geo/src/view/tests.rs
+++ b/crates/pilotage-geo/src/view/tests.rs
@@ -1,46 +1,28 @@
-//! Tests for the projection view: derived FOV, projection boundary, and
-//! fail-closed validation.
+//! Tests for the projection view: the calibration reference, projection
+//! payloads, projection boundary, and fail-closed validation.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_frames::{FrameId, Quat};
-
-use super::{
-    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
-    ProjectionView, Viewport,
-};
+use super::{CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView};
 use crate::error::GeoError;
+
+fn calibration() -> CalibrationRef {
+    CalibrationRef {
+        calibration_id: 0x0FED_CBA9,
+        content_hash: [7u8; 32],
+        alignment_bound_rad: 0.0117,
+    }
+}
 
 fn view() -> ProjectionView {
     ProjectionView {
-        viewport: Viewport {
-            width_px: 320,
-            height_px: 240,
-        },
-        focal_x_px: 190.0,
-        focal_y_px: 190.0,
-        projection: ProjectionKind::Perspective,
+        calibration: calibration(),
+        projection: Projection::Perspective,
         near_far: NearFarPolicy {
             near_m: 0.1,
             far_m: 100.0,
         },
         minification: MinificationPolicy::Trilinear,
-        convention: OpticalConvention::OpenCv,
-        camera: CameraPose {
-            translation_m: [1.1, 0.0, 0.3],
-            attitude: Quat::IDENTITY,
-            from_frame: FrameId::Body,
-            to_frame: FrameId::Installation,
-        },
     }
-}
-
-#[test]
-fn field_of_view_is_derived_from_viewport_and_focal() {
-    let fov = view().field_of_view();
-    let expected_h = 2.0 * libm::atan(160.0 / 190.0);
-    let expected_v = 2.0 * libm::atan(120.0 / 190.0);
-    assert!((fov.horizontal_rad - expected_h).abs() < 1e-12);
-    assert!((fov.vertical_rad - expected_v).abs() < 1e-12);
 }
 
 #[test]
@@ -60,28 +42,70 @@ fn projection_boundary_is_inclusive_and_deterministic() {
 }
 
 #[test]
-fn valid_view_passes() {
-    view().validate().expect("the nominal view is valid");
+fn valid_perspective_view_passes() {
+    view()
+        .validate()
+        .expect("the nominal perspective view is valid");
 }
 
 #[test]
-fn degenerate_viewport_is_refused() {
+fn valid_orthographic_view_passes() {
     let mut v = view();
-    v.viewport.width_px = 0;
+    v.projection = Projection::Orthographic {
+        extent_x_m: 500.0,
+        extent_y_m: 375.0,
+    };
+    v.validate()
+        .expect("a well-formed orthographic view is valid");
+}
+
+#[test]
+fn an_incomplete_calibration_reference_is_refused() {
+    let mut v = view();
+    v.calibration.calibration_id = 0;
     assert!(matches!(
         v.validate(),
-        Err(GeoError::InvalidViewport { .. })
+        Err(GeoError::IncompleteCalibrationReference)
+    ));
+
+    let mut v = view();
+    v.calibration.content_hash = [0u8; 32];
+    assert!(
+        matches!(v.validate(), Err(GeoError::IncompleteCalibrationReference)),
+        "an all-zero content hash does not identify an artifact"
+    );
+
+    let mut v = view();
+    v.calibration.alignment_bound_rad = 0.0;
+    assert!(
+        matches!(v.validate(), Err(GeoError::IncompleteCalibrationReference)),
+        "a zero alignment bound is an unbounded claim"
+    );
+
+    let mut v = view();
+    v.calibration.alignment_bound_rad = f64::NAN;
+    assert!(matches!(
+        v.validate(),
+        Err(GeoError::IncompleteCalibrationReference)
     ));
 }
 
 #[test]
-fn non_positive_focal_is_refused() {
-    let mut v = view();
-    v.focal_x_px = 0.0;
-    assert!(matches!(
-        v.validate(),
-        Err(GeoError::NonPositiveFocal { .. })
-    ));
+fn orthographic_needs_positive_finite_extents() {
+    for (x, y) in [(0.0, 375.0), (500.0, -1.0), (f64::NAN, 375.0)] {
+        let mut v = view();
+        v.projection = Projection::Orthographic {
+            extent_x_m: x,
+            extent_y_m: y,
+        };
+        assert!(
+            matches!(
+                v.validate(),
+                Err(GeoError::InvalidOrthographicExtent { .. })
+            ),
+            "orthographic extents ({x}, {y}) must be positive finite"
+        );
+    }
 }
 
 #[test]
@@ -100,27 +124,19 @@ fn invalid_near_far_is_refused() {
 }
 
 #[test]
-fn wrong_camera_frames_are_refused() {
-    let mut v = view();
-    v.camera.from_frame = FrameId::Ned;
-    assert!(v.validate().is_err());
-}
-
-#[test]
-fn view_enums_round_trip_and_reject_unknown() {
+fn projection_kind_discriminants_match_the_wire() {
+    assert_eq!(Projection::Perspective.kind_u8(), 0);
     assert_eq!(
-        ProjectionKind::from_u8(1),
-        Some(ProjectionKind::Orthographic)
+        Projection::Orthographic {
+            extent_x_m: 1.0,
+            extent_y_m: 1.0,
+        }
+        .kind_u8(),
+        1
     );
-    assert_eq!(ProjectionKind::from_u8(9), None);
     assert_eq!(
         MinificationPolicy::from_u8(2),
         Some(MinificationPolicy::Trilinear)
     );
     assert_eq!(MinificationPolicy::from_u8(9), None);
-    assert_eq!(
-        OpticalConvention::from_u8(0),
-        Some(OpticalConvention::OpenCv)
-    );
-    assert_eq!(OpticalConvention::from_u8(9), None);
 }

--- a/crates/pilotage-geo/src/view/tests.rs
+++ b/crates/pilotage-geo/src/view/tests.rs
@@ -1,0 +1,126 @@
+//! Tests for the projection view: derived FOV, projection boundary, and
+//! fail-closed validation.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_frames::{FrameId, Quat};
+
+use super::{
+    CameraPose, MinificationPolicy, NearFarPolicy, OpticalConvention, ProjectionKind,
+    ProjectionView, Viewport,
+};
+use crate::error::GeoError;
+
+fn view() -> ProjectionView {
+    ProjectionView {
+        viewport: Viewport {
+            width_px: 320,
+            height_px: 240,
+        },
+        focal_x_px: 190.0,
+        focal_y_px: 190.0,
+        projection: ProjectionKind::Perspective,
+        near_far: NearFarPolicy {
+            near_m: 0.1,
+            far_m: 100.0,
+        },
+        minification: MinificationPolicy::Trilinear,
+        convention: OpticalConvention::OpenCv,
+        camera: CameraPose {
+            translation_m: [1.1, 0.0, 0.3],
+            attitude: Quat::IDENTITY,
+            from_frame: FrameId::Body,
+            to_frame: FrameId::Installation,
+        },
+    }
+}
+
+#[test]
+fn field_of_view_is_derived_from_viewport_and_focal() {
+    let fov = view().field_of_view();
+    let expected_h = 2.0 * libm::atan(160.0 / 190.0);
+    let expected_v = 2.0 * libm::atan(120.0 / 190.0);
+    assert!((fov.horizontal_rad - expected_h).abs() < 1e-12);
+    assert!((fov.vertical_rad - expected_v).abs() < 1e-12);
+}
+
+#[test]
+fn projection_boundary_is_inclusive_and_deterministic() {
+    let policy = view().near_far;
+    assert!(policy.contains_depth(0.1), "on the near plane is inside");
+    assert!(policy.contains_depth(100.0), "on the far plane is inside");
+    assert!(
+        !policy.contains_depth(0.099_999),
+        "just inside the near plane is out"
+    );
+    assert!(
+        !policy.contains_depth(100.000_001),
+        "just beyond the far plane is out"
+    );
+    assert!(policy.contains_depth(50.0));
+}
+
+#[test]
+fn valid_view_passes() {
+    view().validate().expect("the nominal view is valid");
+}
+
+#[test]
+fn degenerate_viewport_is_refused() {
+    let mut v = view();
+    v.viewport.width_px = 0;
+    assert!(matches!(
+        v.validate(),
+        Err(GeoError::InvalidViewport { .. })
+    ));
+}
+
+#[test]
+fn non_positive_focal_is_refused() {
+    let mut v = view();
+    v.focal_x_px = 0.0;
+    assert!(matches!(
+        v.validate(),
+        Err(GeoError::NonPositiveFocal { .. })
+    ));
+}
+
+#[test]
+fn invalid_near_far_is_refused() {
+    let mut v = view();
+    v.near_far = NearFarPolicy {
+        near_m: 10.0,
+        far_m: 5.0,
+    };
+    assert!(matches!(v.validate(), Err(GeoError::InvalidNearFar { .. })));
+    v.near_far = NearFarPolicy {
+        near_m: 0.0,
+        far_m: 5.0,
+    };
+    assert!(matches!(v.validate(), Err(GeoError::InvalidNearFar { .. })));
+}
+
+#[test]
+fn wrong_camera_frames_are_refused() {
+    let mut v = view();
+    v.camera.from_frame = FrameId::Ned;
+    assert!(v.validate().is_err());
+}
+
+#[test]
+fn view_enums_round_trip_and_reject_unknown() {
+    assert_eq!(
+        ProjectionKind::from_u8(1),
+        Some(ProjectionKind::Orthographic)
+    );
+    assert_eq!(ProjectionKind::from_u8(9), None);
+    assert_eq!(
+        MinificationPolicy::from_u8(2),
+        Some(MinificationPolicy::Trilinear)
+    );
+    assert_eq!(MinificationPolicy::from_u8(9), None);
+    assert_eq!(
+        OpticalConvention::from_u8(0),
+        Some(OpticalConvention::OpenCv)
+    );
+    assert_eq!(OpticalConvention::from_u8(9), None);
+}

--- a/docs/adr/0022-geospatial-projection-availability-contract.md
+++ b/docs/adr/0022-geospatial-projection-availability-contract.md
@@ -64,24 +64,32 @@ SIM / NOT FOR FLIGHT.
 - **The view references the one validated calibration.** There is exactly one
   authoritative camera model — the versioned, hashed calibration artifact
   (ADR-0021). [`ProjectionView`] does not re-mint intrinsics, distortion,
-  viewport, pose, or field of view; it *references* the accepted calibration by
-  id and content hash, carries its published alignment bound, and adds only the
-  render-time policy (projection kind, near/far, minification). Perspective and
-  orthographic are typed payloads — a focal-derived field of view is not an
-  orthographic invariant — and the field of view is a property of the resolved
-  calibration, never stored here.
+  viewport, pose, field of view, or the alignment bound; it *references* the
+  accepted calibration by id and content hash **only**, and adds only the
+  render-time policy (projection kind, near/far, minification). The alignment
+  bound and geometry come from *resolving* that reference against a verified
+  artifact (in the `std` calibration contract), so a producer cannot write an
+  understated bound onto the wire — there is no bound field to write. The
+  reference id is [`CalibrationId`], a `u32` mirroring the authoritative
+  adapter-api `CalibrationId(u32)` field for field (documented mapping across
+  the no_std/std boundary, like the datum ↔ `AltitudeClass` mapping), so the two
+  share one identity space with no truncation. Perspective and orthographic are
+  typed payloads — a focal-derived field of view is not an orthographic
+  invariant.
 
 - **Availability is derived, never self-reported.** The wire carries **no**
   availability. A frame decodes to a [`ValidatedSvsFrame`] whose
   [`SvsAvailability`] is *computed* from the validated inputs: position and
-  attitude health from their integrity, time/coherence from the age, future-
-  sample check, and coherent-snapshot binding against the frame reference time;
-  only the inputs the contract cannot check (navigation-integrity monitor,
-  calibration, database, coverage, renderer) are producer-stated. `assess` maps
-  input health to `Available`, `Degraded(reason)`, or `Unavailable(reason)` over
-  a finite [`AvailabilityReason`] set by a **fixed precedence**. An untrusted or
-  incoherent input can never yield an available scene, and there is no wire byte
-  a producer could set to claim otherwise.
+  attitude health from the **worse** of their integrity and their accuracy
+  (position 1-sigma in millimeters, attitude 1-sigma in milliradians, against
+  degrade/fail thresholds), time/coherence from the age, future-sample check,
+  and coherent-snapshot binding against the frame reference time; only the
+  inputs the contract cannot check (navigation-integrity monitor, calibration,
+  database, coverage, renderer) are producer-stated. `assess` maps input health
+  to `Available`, `Degraded(reason)`, or `Unavailable(reason)` over a finite
+  [`AvailabilityReason`] set by a **fixed precedence**. An untrusted, grossly
+  inaccurate, or incoherent input can never yield an available scene, and there
+  is no wire byte a producer could set to claim otherwise.
 
 - **TAWS is an independent input.** A [`TawsAlert`] is a separate type with its
   own source stamp; nothing derives a TAWS alert from the SVS scene or folds SVS

--- a/docs/adr/0022-geospatial-projection-availability-contract.md
+++ b/docs/adr/0022-geospatial-projection-availability-contract.md
@@ -1,0 +1,90 @@
+# ADR-0022: Transport-independent geospatial, projection, and availability contract
+
+- Status: Accepted
+- Date: 2026-07-13
+
+## Context
+
+Synthetic vision (SVS) and a conformal head-up display both need to place world
+geometry in an image: a runway where the runway is, terrain where the terrain
+is. Getting that right depends on agreeing, before any pixels, on what a
+position *means* (which datum, which vertical reference), which clock a reading
+came from, how trustworthy it is, how the camera projects, and — crucially —
+when the scene must **not** be drawn because an input is missing or untrusted.
+Those agreements are a contract, and they must be independent of the transport
+(WebTransport today, something else tomorrow) and of any particular renderer.
+
+The failure mode this contract exists to prevent is a *plausible wrong scene*: a
+height read against the wrong datum, an age computed across two clocks, a
+longitude that means two places at the anti-meridian, or a terrain database gap
+papered over as normal terrain. Each of those is a silent inference, and each
+would put symbology in the wrong place while looking correct.
+
+This is a SIM/engineering contract; completion is **not** SVS or SVGS approval.
+SIM / NOT FOR FLIGHT.
+
+## Decision
+
+- **A new foundational crate, `pilotage-geo`**, holds the typed contract. It is
+  `#![no_std]`, allocation-free, and `forbid(unsafe_code)`, so it compiles for a
+  bare-metal target and can sit beneath both consumers.
+
+- **Datum discipline; no bare altitude.** A height is a [`VerticalPosition`] that
+  always carries a [`VerticalDatum`] (ellipsoid, MSL, AGL, barometric-indicated,
+  pressure, or local-relative), a geoid model for MSL, and a local origin for a
+  relative height. A [`GeodeticPosition`] always carries a [`HorizontalDatum`].
+  Unknown datums are refused. The vertical vocabulary is minted here — not taken
+  from instrument-state's `AltitudeClass` — because this crate is foundational
+  and instrument-state is a consumer; the module documents the field-for-field
+  mapping so the two never drift.
+
+- **Longitude is normalized; poles and seams are explicit.** `new` wraps
+  longitude to `[-180, 180)`, so the anti-meridian has one canonical spelling;
+  `at_pole` and `on_antimeridian` flag the degenerate cases; and `tile` floors
+  into exactly one tile so a seam never oscillates.
+
+- **Identity and coherence reuse the AV-01 `MeasurementStamp` shape.** A
+  [`SourceStamp`] carries source id, incarnation, generation, sequence,
+  acquisition [`Epoch`] (clock **and** scale **and** nanos), integrity,
+  accuracy, and a coherent-snapshot id. Age is only computed between readings on
+  the same clock and scale — across clocks it is `None`, never a silently
+  inferred difference — and coherence requires a declared, matching snapshot id.
+
+- **The view derives its field of view.** [`ProjectionView`] stores the
+  viewport, focal lengths, projection, near/far policy, minification,
+  convention, and camera pose (frames named `Body` → `Installation`); the field
+  of view is **derived** from viewport and focal (aligning with the ADR-0021
+  calibration contract), never stored.
+
+- **Availability is finite, deterministic, and traceable.** [`SvsAvailability`]
+  is `Available`, `Degraded(reason)`, or `Unavailable(reason)` over a finite
+  [`AvailabilityReason`] set (position, attitude, integrity, time/coherence,
+  calibration, database, coverage, renderer). `assess` maps the stated health of
+  each input to a verdict by a **fixed precedence**, so the same inputs always
+  yield the same verdict and reason. Health is stated, never defaulted: an
+  unknown input is `Failed`, and "nothing known" is `Unavailable`, never a
+  normal scene.
+
+- **TAWS is an independent input.** A [`TawsAlert`] is a separate type with its
+  own source stamp; nothing derives a TAWS alert from the SVS scene or folds SVS
+  availability into a terrain hazard. The availability API's signature contains
+  no TAWS type, so the two cannot leak into one another.
+
+- **The ABI is versioned, fixed-size, and fail-closed.** One [`SvsFrame`]
+  encodes to a fixed little-endian byte block led by a version `u32`;
+  [`decode_frame`] refuses a truncated buffer, an unsupported version, an
+  enumerated value outside its known set (reporting the actual value), a
+  non-finite coordinate, and a semantically malformed block (e.g. an MSL height
+  with no geoid). Encoding is allocation-free (it writes a fixed array).
+
+## Consequences
+
+- Datum, units, reference, and clock domain cannot be silently inferred: they
+  are type-level, and decode fails closed on anything unknown.
+- A missing, inconsistent, or untrusted input resolves to degraded/unavailable
+  with a traceable reason, never a plausible normal scene.
+- A renderer and a transport can be swapped without touching the contract; the
+  frame ABI is their only coupling and it is versioned.
+- The vertical-datum vocabulary duplicates instrument-state's `AltitudeClass`
+  intentionally (dependency direction), pinned by the documented mapping table;
+  if either changes, the mapping is the place they are reconciled.

--- a/docs/adr/0022-geospatial-projection-availability-contract.md
+++ b/docs/adr/0022-geospatial-projection-availability-contract.md
@@ -29,53 +29,76 @@ SIM / NOT FOR FLIGHT.
   `#![no_std]`, allocation-free, and `forbid(unsafe_code)`, so it compiles for a
   bare-metal target and can sit beneath both consumers.
 
-- **Datum discipline; no bare altitude.** A height is a [`VerticalPosition`] that
-  always carries a [`VerticalDatum`] (ellipsoid, MSL, AGL, barometric-indicated,
-  pressure, or local-relative), a geoid model for MSL, and a local origin for a
-  relative height. A [`GeodeticPosition`] always carries a [`HorizontalDatum`].
-  Unknown datums are refused. The vertical vocabulary is minted here — not taken
-  from instrument-state's `AltitudeClass` — because this crate is foundational
-  and instrument-state is a consumer; the module documents the field-for-field
-  mapping so the two never drift.
+- **Datum discipline; no bare altitude, no implicit realization.** A height is a
+  [`VerticalPosition`] that always carries a [`VerticalDatum`] (ellipsoid, MSL,
+  AGL, barometric-indicated, pressure, or local-relative) **and the identity that
+  datum needs**: a declared geoid model for MSL, a terrain/ground reference for
+  AGL, an applied altimeter-setting identity for barometric-indicated, and a
+  local origin for a relative height. A [`GeodeticPosition`] always carries a
+  [`HorizontalDatum`] and, for a realization-bearing datum (NAD83, ITRF), a
+  declared realization/reference-epoch id. Unknown datums, undeclared
+  realizations, and missing identities are refused with a specific typed reason
+  (a horizontal fault never reports a vertical-datum reason), and an invalid tile
+  size is a `Result`, never a plausible zero tile. The vertical vocabulary is
+  minted here — not taken from instrument-state's `AltitudeClass` — because this
+  crate is foundational and instrument-state is a consumer; the module documents
+  the field-for-field mapping so the two never drift.
 
 - **Longitude is normalized; poles and seams are explicit.** `new` wraps
   longitude to `[-180, 180)`, so the anti-meridian has one canonical spelling;
   `at_pole` and `on_antimeridian` flag the degenerate cases; and `tile` floors
   into exactly one tile so a seam never oscillates.
 
-- **Identity and coherence reuse the AV-01 `MeasurementStamp` shape.** A
-  [`SourceStamp`] carries source id, incarnation, generation, sequence,
-  acquisition [`Epoch`] (clock **and** scale **and** nanos), integrity,
-  accuracy, and a coherent-snapshot id. Age is only computed between readings on
-  the same clock and scale — across clocks it is `None`, never a silently
-  inferred difference — and coherence requires a declared, matching snapshot id.
+- **Identity is separate from function-specific quality.** A [`SourceStamp`]
+  carries only source id, incarnation, generation, sequence, acquisition
+  [`Epoch`] (clock **and** scale **and** nanos), integrity, and a
+  coherent-snapshot identity — never an accuracy. Position accuracy is a length
+  (`PositionQuality`, millimeters) and attitude accuracy is an angle
+  (`AttitudeQuality`, milliradians): distinct types, so a position accuracy can
+  never be read as an attitude's. Age fails closed — a different clock, a
+  different scale, or a future sample is a typed `AgeError`, never a saturated
+  zero — and coherence binds the full snapshot identity (producer incarnation,
+  generation, instance id) and time base, so an equal numeric id from a
+  different stream is not coherent.
 
-- **The view derives its field of view.** [`ProjectionView`] stores the
-  viewport, focal lengths, projection, near/far policy, minification,
-  convention, and camera pose (frames named `Body` → `Installation`); the field
-  of view is **derived** from viewport and focal (aligning with the ADR-0021
-  calibration contract), never stored.
+- **The view references the one validated calibration.** There is exactly one
+  authoritative camera model — the versioned, hashed calibration artifact
+  (ADR-0021). [`ProjectionView`] does not re-mint intrinsics, distortion,
+  viewport, pose, or field of view; it *references* the accepted calibration by
+  id and content hash, carries its published alignment bound, and adds only the
+  render-time policy (projection kind, near/far, minification). Perspective and
+  orthographic are typed payloads — a focal-derived field of view is not an
+  orthographic invariant — and the field of view is a property of the resolved
+  calibration, never stored here.
 
-- **Availability is finite, deterministic, and traceable.** [`SvsAvailability`]
-  is `Available`, `Degraded(reason)`, or `Unavailable(reason)` over a finite
-  [`AvailabilityReason`] set (position, attitude, integrity, time/coherence,
-  calibration, database, coverage, renderer). `assess` maps the stated health of
-  each input to a verdict by a **fixed precedence**, so the same inputs always
-  yield the same verdict and reason. Health is stated, never defaulted: an
-  unknown input is `Failed`, and "nothing known" is `Unavailable`, never a
-  normal scene.
+- **Availability is derived, never self-reported.** The wire carries **no**
+  availability. A frame decodes to a [`ValidatedSvsFrame`] whose
+  [`SvsAvailability`] is *computed* from the validated inputs: position and
+  attitude health from their integrity, time/coherence from the age, future-
+  sample check, and coherent-snapshot binding against the frame reference time;
+  only the inputs the contract cannot check (navigation-integrity monitor,
+  calibration, database, coverage, renderer) are producer-stated. `assess` maps
+  input health to `Available`, `Degraded(reason)`, or `Unavailable(reason)` over
+  a finite [`AvailabilityReason`] set by a **fixed precedence**. An untrusted or
+  incoherent input can never yield an available scene, and there is no wire byte
+  a producer could set to claim otherwise.
 
 - **TAWS is an independent input.** A [`TawsAlert`] is a separate type with its
   own source stamp; nothing derives a TAWS alert from the SVS scene or folds SVS
   availability into a terrain hazard. The availability API's signature contains
   no TAWS type, so the two cannot leak into one another.
 
-- **The ABI is versioned, fixed-size, and fail-closed.** One [`SvsFrame`]
-  encodes to a fixed little-endian byte block led by a version `u32`;
-  [`decode_frame`] refuses a truncated buffer, an unsupported version, an
-  enumerated value outside its known set (reporting the actual value), a
-  non-finite coordinate, and a semantically malformed block (e.g. an MSL height
-  with no geoid). Encoding is allocation-free (it writes a fixed array).
+- **The ABI is versioned, fixed-size, and fail-closed.** One frame encodes to a
+  fixed little-endian byte block led by a version `u32`; the length must match
+  exactly (trailing bytes are as suspect as truncation). [`decode_frame`]
+  refuses a wrong length, an unsupported version, an enumerated value outside
+  its known set (reporting the actual value), a non-finite coordinate, a
+  non-unit aircraft attitude, an incomplete datum identity (an MSL height with
+  no geoid, an AGL height with no terrain reference, a barometric-indicated
+  height with no applied setting, a NAD83/ITRF datum with no realization), and
+  an incomplete calibration reference. Only a [`ValidatedSvsFrame`] can be
+  encoded, so an invalid frame cannot be serialized; encoding is
+  allocation-free.
 
 ## Consequences
 


### PR DESCRIPTION
Implements #34: the transport-independent geospatial, projection, coherence, and availability contract that a HUD (#38) and SVS both consume, as a new no_std `pilotage-geo` crate. **SIM / NOT FOR FLIGHT** — this defines an engineering contract, not SVS/SVGS approval; nothing here is a terrain database, a renderer, or optical HUD qualification.

Revised through two review rounds. The design principle throughout: an untrusted, inaccurate, incoherent, or unidentified input can never yield an `Available` scene, and there is no wire field a producer could set to claim otherwise.

## Contract shape

- **Datum discipline, no bare altitude, no implicit realization.** `VerticalPosition` always carries its `VerticalDatum` **and the identity that datum needs**: a geoid for MSL, a terrain reference for AGL, an applied-setting identity for barometric-indicated, a local origin for local-relative. `GeodeticPosition` carries its `HorizontalDatum` and, for NAD83/ITRF, a declared realization. Unknown datums, undeclared realizations, and missing identities are refused with specific typed reasons (a horizontal fault never reports a vertical reason); `tile()` returns a `Result`, never a plausible zero tile. Longitude normalizes to `[-180, 180)`; anti-meridian, poles, and tile seams are explicit.
- **Identity is separate from function-specific quality.** `SourceStamp` carries only identity, integrity, and coherent-snapshot membership. Position accuracy is a length (`PositionQuality`, mm); attitude accuracy is an angle (`AttitudeQuality`, mrad) — distinct types. `age_ns` returns `Result<u64, AgeError>` (clock/scale mismatch, future sample) — never a saturated zero. `coherent_with` binds the full snapshot identity (`CoherentSnapshot { producer, generation, id }`) plus time base, so an equal numeric id from a different stream is not coherent.
- **The view references the one calibration, identity + hash only.** `ProjectionView` does not re-mint a second camera model or store an alignment bound; it references the accepted calibration by `CalibrationId` (a `u32` mirroring the authoritative adapter-api `CalibrationId(u32)`) and content hash. The alignment bound and geometry come from resolving that reference against a verified artifact, so a producer cannot write — and thus cannot understate — a bound. `Projection` is a typed enum: `Perspective` (FOV derives from the resolved calibration) vs `Orthographic { extent_x_m, extent_y_m }`.
- **Availability is derived, never self-reported.** The wire carries **no** availability. A frame decodes to a `ValidatedSvsFrame` (private fields, checked constructor) whose `SvsAvailability` is computed: position/attitude health from the **worse** of integrity and accuracy (against named degrade/fail thresholds); time/coherence from age, future-sample, and coherent-snapshot binding vs the frame reference time; only the inputs the contract can't check (nav-integrity monitor, calibration, database, coverage, renderer) are producer-stated, and they decode strictly (unknown byte → `UnknownEnum`, never coerced).
- **TAWS is an independent input.** `TawsAlert` is a separate type; the availability API's signature contains no TAWS type, so neither can leak into the other.
- **ABI v2, fixed 305-byte little-endian, fail-closed.** Exact-length required (trailing bytes refused as suspect as truncation); decode refuses a wrong version, unknown enum (reporting the value), non-finite coordinate, non-unit aircraft attitude, incomplete datum identity, and incomplete calibration reference. Only a `ValidatedSvsFrame` can be encoded, so an invalid frame cannot be serialized; encoding is allocation-free.

## Hostile regression tests (each named)

Untrusted/unknown integrity → Unavailable; **trusted-but-grossly-inaccurate position/attitude → Unavailable/Degraded**; future acquisition; snapshot-id collision across streams; clock/scale mismatch; non-unit attitude; incomplete AGL/baro/realization identity; incomplete calibration reference; **unknown external-health byte → UnknownEnum (not coerced)**; orthographic-not-read-as-perspective; wrong length / trailing bytes; anti-meridian/pole/tile-seam; invalid tile size.

## Consumed vocabularies

`pilotage-frames` (FrameId, Epoch, ClockDomain, TimeScale, Quat) consumed directly. Vertical datum ↔ instrument-state `AltitudeClass`, source identity ↔ AV-01 `MeasurementStamp`, and `CalibrationId` ↔ adapter-api `CalibrationId` are documented field-for-field mappings (dependency-direction / no_std-vs-std boundary), pinned in ADR-0022.

## Verification

fmt, clippy `-D warnings`, `cargo test --all-targets` (30 suites; 65 in `pilotage-geo`), doc `-D missing_docs`, `build --release`, structure gate (`abi` split into `abi/codec.rs`), no_std `thumbv7em-none-eabihf` — all green. Registered in the workspace + CI (no_std check line + `cargo test -p pilotage-geo` step). ADR-0022 documents the contract.

Refs #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
