### PR TITLE
GEO-68: enforce exact unsigned wire ranges in browser identity validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
       - name: browser turn-derivation tests (DYN-01)
         run: node clients/web/turn-derivation.test.mjs
 
+      - name: browser wire-range identity bounds (GEO-68)
+        run: node clients/web/wire-bounds.test.mjs
+
       - name: Setup buf
         if: hashFiles('schemas/**/*.proto') != ''
         uses: bufbuild/buf-action@v1

--- a/clients/web/calibration.test.mjs
+++ b/clients/web/calibration.test.mjs
@@ -43,6 +43,8 @@ function fpvFrameMeta(overrides = {}) {
     mappingTargetClock: CLOCK_VEHICLE_BOOT,
     mappingOffsetNanos: 0n,
     clockErrorBoundNanos: 0n,
+    receiveTimeNanos: 0n,
+    publicationTimeNanos: 0n,
     ...overrides,
   };
 }

--- a/clients/web/snapshot-association.js
+++ b/clients/web/snapshot-association.js
@@ -23,7 +23,7 @@
 // match, published/recognized calibration, overflow-safe mapped time, error
 // budget) can never be bypassed.
 
-import { conformalGate, mapCaptureTime, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
+import { conformalGate, mapCaptureTime, metaFault, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
 import { firstFault } from "./wire-bounds.js";
 
 const CLOCK_VEHICLE_BOOT = 1;
@@ -47,6 +47,7 @@ export const ASSOCIATION = Object.freeze({
   STREAM_DISCONTINUITY: "stream-discontinuity",
   TOTAL_ERROR_EXCEEDS_BUDGET: "total-error-exceeds-budget",
   NOT_ADMITTED: "not-admitted",
+  MALFORMED_META: "malformed-meta",
 });
 
 // The first field of an AV-01 snapshot identity to violate its exact wire type
@@ -118,13 +119,14 @@ function absDiff(a, b) {
   return a >= b ? a - b : b - a;
 }
 
-function closed(reason) {
+function closed(reason, fault = null) {
   return Object.freeze({
     ready: false,
     snapshotIdentity: null,
     mappedCaptureNanos: null,
     totalErrorNanos: null,
     reason,
+    fault,
   });
 }
 
@@ -189,7 +191,14 @@ export class SnapshotAssociator {
    */
   associate(meta, options = {}) {
     const budget = options.maxClockErrorNanos ?? DEFAULT_MAX_CLOCK_ERROR_NANOS;
-    if (!meta || meta.mappingAvailable !== true) return closed(ASSOCIATION.MAPPING_UNAVAILABLE);
+    // Validate every wire field this path maps, sums, or compares BEFORE any
+    // BigInt arithmetic. A field of the wrong numeric kind (e.g. a Number
+    // clockErrorBoundNanos later added to a BigInt delta) would otherwise throw
+    // a TypeError mid-association instead of failing closed. Never throw; always
+    // return a closed verdict carrying the typed reason.
+    const fault = metaFault(meta);
+    if (fault !== null) return closed(ASSOCIATION.MALFORMED_META, fault);
+    if (meta.mappingAvailable !== true) return closed(ASSOCIATION.MAPPING_UNAVAILABLE);
     const mapped = mapCaptureTime(meta.captureTimeNanos, meta.mappingOffsetNanos);
     if (mapped === null) return closed(ASSOCIATION.MAPPED_TIME_OVERFLOW);
     if (this.entries.length === 0) return closed(ASSOCIATION.EMPTY_HISTORY);
@@ -229,7 +238,7 @@ export class SnapshotAssociator {
   }
 
   verdict(ready, snapshotIdentity, mappedCaptureNanos, totalErrorNanos, reason) {
-    return Object.freeze({ ready, snapshotIdentity, mappedCaptureNanos, totalErrorNanos, reason });
+    return Object.freeze({ ready, snapshotIdentity, mappedCaptureNanos, totalErrorNanos, reason, fault: null });
   }
 
   diagnostics() {

--- a/clients/web/snapshot-association.js
+++ b/clients/web/snapshot-association.js
@@ -24,7 +24,7 @@
 // budget) can never be bypassed.
 
 import { conformalGate, mapCaptureTime, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
-import { isIncarnation, isU32, isU64 } from "./wire-bounds.js";
+import { firstFault } from "./wire-bounds.js";
 
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
@@ -49,21 +49,26 @@ export const ASSOCIATION = Object.freeze({
   NOT_ADMITTED: "not-admitted",
 });
 
-function isSnapshotIdentityValid(id) {
-  // Each field is exactly its AV-01 wire type at its exact range: source id is
-  // a u64 (a BigInt, never a truncating Number), epoch and sequence are u32,
-  // and the acquisition time is a u64. Out-of-range, negative, fractional, or
-  // wrong-numeric-kind values are refused fail-closed, never clamped.
-  return (
-    id !== null &&
-    typeof id === "object" &&
-    isU64(id.sourceId) &&
-    isIncarnation(id.sourceIncarnation) &&
-    isU32(id.sourceEpoch) &&
-    isU32(id.sequence) &&
-    isU64(id.acquiredAtNanos) &&
-    (id.clock === CLOCK_VEHICLE_BOOT || id.clock === CLOCK_SIMULATION)
-  );
+// The first field of an AV-01 snapshot identity to violate its exact wire type
+// and range, as a typed `{ field, rule }` reason, or `null` when it is valid:
+// source id is a u64 (a BigInt, never a truncating Number), epoch and sequence
+// are u32, and the acquisition time is a u64. Out-of-range, negative,
+// fractional, or wrong-numeric-kind values are refused fail-closed, never
+// clamped.
+function snapshotIdentityFault(id) {
+  if (id === null || typeof id !== "object") return { field: "identity", rule: "malformed" };
+  const fault = firstFault([
+    ["sourceId", "u64", id.sourceId],
+    ["sourceIncarnation", "incarnation", id.sourceIncarnation],
+    ["sourceEpoch", "u32", id.sourceEpoch],
+    ["sequence", "u32", id.sequence],
+    ["acquiredAtNanos", "u64", id.acquiredAtNanos],
+  ]);
+  if (fault) return fault;
+  if (id.clock !== CLOCK_VEHICLE_BOOT && id.clock !== CLOCK_SIMULATION) {
+    return { field: "clock", rule: "malformed" };
+  }
+  return null;
 }
 
 function identityOf(id) {
@@ -137,6 +142,7 @@ export class SnapshotAssociator {
     this.entries = [];
     this.currentStream = null;
     this.counters = { observed: 0, deduped: 0, dropped: 0, invalid: 0 };
+    this.lastInvalidReason = null;
   }
 
   /** Records one accepted snapshot identity, oldest-first, and adopts its
@@ -144,8 +150,10 @@ export class SnapshotAssociator {
    *  re-reads the accepted snapshot each telemetry frame); overflow drops the
    *  oldest entry and is counted. */
   observe(identity) {
-    if (!isSnapshotIdentityValid(identity)) {
+    const fault = snapshotIdentityFault(identity);
+    if (fault !== null) {
       this.bump("invalid");
+      this.lastInvalidReason = fault;
       return false;
     }
     const entry = identityOf(identity);
@@ -225,7 +233,7 @@ export class SnapshotAssociator {
   }
 
   diagnostics() {
-    return Object.freeze({ ...this.counters, size: this.entries.length });
+    return Object.freeze({ ...this.counters, size: this.entries.length, lastInvalidReason: this.lastInvalidReason });
   }
 
   bump(name, amount = 1) {

--- a/clients/web/snapshot-association.js
+++ b/clients/web/snapshot-association.js
@@ -24,10 +24,10 @@
 // budget) can never be bypassed.
 
 import { conformalGate, mapCaptureTime, DEFAULT_MAX_CLOCK_ERROR_NANOS } from "./video-identity.js";
+import { isIncarnation, isU32, isU64 } from "./wire-bounds.js";
 
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
-const INCARNATION_HEX = /^[0-9a-f]{32}$/;
 
 // History ring size. The mapped capture time of a displayed frame is at most a
 // glass-to-glass latency old (transport + host queue + decode, well under a
@@ -50,16 +50,18 @@ export const ASSOCIATION = Object.freeze({
 });
 
 function isSnapshotIdentityValid(id) {
+  // Each field is exactly its AV-01 wire type at its exact range: source id is
+  // a u64 (a BigInt, never a truncating Number), epoch and sequence are u32,
+  // and the acquisition time is a u64. Out-of-range, negative, fractional, or
+  // wrong-numeric-kind values are refused fail-closed, never clamped.
   return (
     id !== null &&
     typeof id === "object" &&
-    (typeof id.sourceId === "bigint" || Number.isInteger(id.sourceId)) &&
-    typeof id.sourceIncarnation === "string" &&
-    INCARNATION_HEX.test(id.sourceIncarnation) &&
-    Number.isInteger(id.sourceEpoch) &&
-    Number.isInteger(id.sequence) &&
-    typeof id.acquiredAtNanos === "bigint" &&
-    id.acquiredAtNanos >= 0n &&
+    isU64(id.sourceId) &&
+    isIncarnation(id.sourceIncarnation) &&
+    isU32(id.sourceEpoch) &&
+    isU32(id.sequence) &&
+    isU64(id.acquiredAtNanos) &&
     (id.clock === CLOCK_VEHICLE_BOOT || id.clock === CLOCK_SIMULATION)
   );
 }

--- a/clients/web/snapshot-association.test.mjs
+++ b/clients/web/snapshot-association.test.mjs
@@ -265,11 +265,6 @@ function frameMeta(overrides = {}) {
 
 check("default history capacity is documented and positive", Number.isInteger(DEFAULT_HISTORY_CAPACITY) && DEFAULT_HISTORY_CAPACITY > 0);
 
-if (failures > 0) {
-  console.error(`\n${failures} check(s) failed`);
-  process.exit(1);
-}
-console.log("\nall snapshot association checks passed");
 
 // ---- GEO-68: hostile wire-range identities are refused, never observed ------
 
@@ -297,3 +292,28 @@ console.log("\nall snapshot association checks passed");
   ok.observe(snapId());
   check("a well-formed identity is observed", ok.diagnostics().size === 1);
 }
+
+// ---- GEO-68: the refusal records a typed { field, rule } reason -------------
+
+function assertReason(reason, field, rule) {
+  check(
+    `typed reason names the field and rule: ${field}/${rule}`,
+    reason !== null && reason.field === field && reason.rule === rule,
+  );
+}
+
+{
+  const a = new SnapshotAssociator();
+  a.observe(snapId({ sourceEpoch: 0x1_0000_0000 }));
+  assertReason(a.diagnostics().lastInvalidReason, "sourceEpoch", "out-of-range");
+  a.observe(snapId({ sourceId: 10 }));
+  assertReason(a.diagnostics().lastInvalidReason, "sourceId", "wrong-numeric-kind");
+  a.observe(snapId({ sourceIncarnation: "xyz" }));
+  assertReason(a.diagnostics().lastInvalidReason, "sourceIncarnation", "malformed");
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall snapshot association checks passed");

--- a/clients/web/snapshot-association.test.mjs
+++ b/clients/web/snapshot-association.test.mjs
@@ -270,3 +270,30 @@ if (failures > 0) {
   process.exit(1);
 }
 console.log("\nall snapshot association checks passed");
+
+// ---- GEO-68: hostile wire-range identities are refused, never observed ------
+
+{
+  const hostile = [
+    ["negative sourceEpoch", { sourceEpoch: -1 }],
+    ["overflowing sourceEpoch", { sourceEpoch: 0x1_0000_0000 }],
+    ["fractional sequence", { sequence: 1.5 }],
+    ["Number sourceId (u64 must be BigInt)", { sourceId: 10 }],
+    ["negative sourceId bigint", { sourceId: -1n }],
+    ["overflowing sourceId bigint", { sourceId: (1n << 64n) }],
+    ["negative acquiredAtNanos", { acquiredAtNanos: -1n }],
+    ["overflowing acquiredAtNanos", { acquiredAtNanos: (1n << 64n) }],
+    ["Number acquiredAtNanos", { acquiredAtNanos: 1000 }],
+    ["malformed incarnation", { sourceIncarnation: "xyz" }],
+  ];
+  for (const [name, override] of hostile) {
+    const a = new SnapshotAssociator();
+    a.observe(snapId(override));
+    const d = a.diagnostics();
+    check(`hostile identity refused, never observed: ${name}`, d.invalid === 1 && d.size === 0);
+  }
+  // The nominal identity is still accepted.
+  const ok = new SnapshotAssociator();
+  ok.observe(snapId());
+  check("a well-formed identity is observed", ok.diagnostics().size === 1);
+}

--- a/clients/web/snapshot-association.test.mjs
+++ b/clients/web/snapshot-association.test.mjs
@@ -58,6 +58,8 @@ function frameMeta(overrides = {}) {
     mappingTargetClock: CLOCK_VEHICLE_BOOT,
     mappingOffsetNanos: 0n,
     clockErrorBoundNanos: 0n,
+    receiveTimeNanos: 0n,
+    publicationTimeNanos: 0n,
     ...overrides,
   };
 }
@@ -310,6 +312,43 @@ function assertReason(reason, field, rule) {
   assertReason(a.diagnostics().lastInvalidReason, "sourceId", "wrong-numeric-kind");
   a.observe(snapId({ sourceIncarnation: "xyz" }));
   assertReason(a.diagnostics().lastInvalidReason, "sourceIncarnation", "malformed");
+}
+
+// ---- GEO-68: associate() fails closed on a hostile meta and never throws ----
+// The associator maps, sums, and compares BigInt times. A wire field of the
+// wrong numeric kind reaching that arithmetic throws a TypeError ("Cannot mix
+// BigInt and other types") instead of failing closed — the exact defect this
+// guards. Each hostile frame, set up so it would otherwise reach the
+// `clockErrorBoundNanos + bestDelta` sum, must yield a closed MALFORMED_META
+// verdict carrying a typed fault, and must never throw.
+{
+  const hostileMeta = [
+    ["Number clockErrorBoundNanos", { clockErrorBoundNanos: 100 }],
+    ["Number captureTimeNanos", { captureTimeNanos: 1000 }],
+    ["Number mappingOffsetNanos", { mappingOffsetNanos: 0 }],
+    ["negative clockErrorBoundNanos", { clockErrorBoundNanos: -1n }],
+    ["over-u64 clockErrorBoundNanos", { clockErrorBoundNanos: 1n << 64n }],
+    ["over-i64 mappingOffsetNanos", { mappingOffsetNanos: 1n << 63n }],
+    ["over-u8 sourceId", { sourceId: 256 }],
+    ["bigint sourceId (u8 must be Number)", { sourceId: 0n }],
+  ];
+  for (const [name, override] of hostileMeta) {
+    const a = new SnapshotAssociator();
+    a.observe(snapId({ sequence: 1, acquiredAtNanos: 1000n }));
+    let verdict = null;
+    let threw = null;
+    try {
+      verdict = a.associate(frameMeta({ captureTimeNanos: 1000n, ...override }), RECOGNIZED);
+    } catch (e) {
+      threw = e;
+    }
+    check(`associate never throws on ${name}`, threw === null);
+    check(
+      `associate fails closed on ${name}`,
+      verdict !== null && verdict.ready === false && verdict.reason === ASSOCIATION.MALFORMED_META,
+    );
+    check(`associate reports a typed fault on ${name}`, verdict !== null && verdict.fault !== null);
+  }
 }
 
 if (failures > 0) {

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -2,6 +2,8 @@
 // Publication/receipt time is transport metadata: freshness advances only
 // when a source group presents a new epoch/sequence.
 
+import { isIncarnation, isU32, isU64 } from "./wire-bounds.js";
+
 export const COHERENCE = Object.freeze({
   INSUFFICIENT: "insufficient",
   COHERENT: "coherent",
@@ -35,20 +37,19 @@ export function serialIsNewer(candidate, current) {
 }
 
 function isStampValid(stamp) {
+  // Identity fields are bounded to their exact wire ranges: source id and
+  // acquisition time are u64 (BigInt, upper-bounded — a decoded varint past
+  // 2^64 is refused, not accepted), epoch and sequence are u32. Fail-closed,
+  // never clamped; this tightens identity validation without changing the
+  // reorder/freshness gating below.
   return (
     stamp !== null &&
     typeof stamp === "object" &&
-    typeof stamp.sourceId === "bigint" &&
-    typeof stamp.sourceIncarnation === "string" &&
-    /^[0-9a-f]{32}$/.test(stamp.sourceIncarnation) &&
-    Number.isInteger(stamp.sourceEpoch) &&
-    stamp.sourceEpoch >= 0 &&
-    stamp.sourceEpoch <= 0xffff_ffff &&
-    Number.isInteger(stamp.sequence) &&
-    stamp.sequence >= 0 &&
-    stamp.sequence <= 0xffff_ffff &&
-    typeof stamp.acquiredAtNanos === "bigint" &&
-    stamp.acquiredAtNanos >= 0n &&
+    isU64(stamp.sourceId) &&
+    isIncarnation(stamp.sourceIncarnation) &&
+    isU32(stamp.sourceEpoch) &&
+    isU32(stamp.sequence) &&
+    isU64(stamp.acquiredAtNanos) &&
     (stamp.clock === CLOCK_VEHICLE_BOOT || stamp.clock === CLOCK_SIMULATION)
   );
 }

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -2,7 +2,7 @@
 // Publication/receipt time is transport metadata: freshness advances only
 // when a source group presents a new epoch/sequence.
 
-import { isIncarnation, isU32, isU64 } from "./wire-bounds.js";
+import { firstFault } from "./wire-bounds.js";
 
 export const COHERENCE = Object.freeze({
   INSUFFICIENT: "insufficient",
@@ -36,22 +36,26 @@ export function serialIsNewer(candidate, current) {
   return distance !== 0 && distance < SERIAL_HALF_RANGE;
 }
 
-function isStampValid(stamp) {
-  // Identity fields are bounded to their exact wire ranges: source id and
-  // acquisition time are u64 (BigInt, upper-bounded — a decoded varint past
-  // 2^64 is refused, not accepted), epoch and sequence are u32. Fail-closed,
-  // never clamped; this tightens identity validation without changing the
-  // reorder/freshness gating below.
-  return (
-    stamp !== null &&
-    typeof stamp === "object" &&
-    isU64(stamp.sourceId) &&
-    isIncarnation(stamp.sourceIncarnation) &&
-    isU32(stamp.sourceEpoch) &&
-    isU32(stamp.sequence) &&
-    isU64(stamp.acquiredAtNanos) &&
-    (stamp.clock === CLOCK_VEHICLE_BOOT || stamp.clock === CLOCK_SIMULATION)
-  );
+// The first stamp field to violate its exact wire type and range, as a typed
+// `{ field, rule }` reason, or `null` when the stamp is valid: source id and
+// acquisition time are u64 (BigInt, upper-bounded — a decoded varint past 2^64
+// is refused, not accepted), epoch and sequence are u32. Fail-closed, never
+// clamped; this tightens identity validation without changing the
+// reorder/freshness gating below.
+function stampFault(stamp) {
+  if (stamp === null || typeof stamp !== "object") return { field: "stamp", rule: "malformed" };
+  const fault = firstFault([
+    ["sourceId", "u64", stamp.sourceId],
+    ["sourceIncarnation", "incarnation", stamp.sourceIncarnation],
+    ["sourceEpoch", "u32", stamp.sourceEpoch],
+    ["sequence", "u32", stamp.sequence],
+    ["acquiredAtNanos", "u64", stamp.acquiredAtNanos],
+  ]);
+  if (fault) return fault;
+  if (stamp.clock !== CLOCK_VEHICLE_BOOT && stamp.clock !== CLOCK_SIMULATION) {
+    return { field: "clock", rule: "malformed" };
+  }
+  return null;
 }
 
 function copyAttitude(avionics) {
@@ -182,6 +186,7 @@ export class AvionicsIngress {
     this.quality = QUALITY_UNUSABLE;
     this.generation = 0;
     this.lastCoherence = COHERENCE.INSUFFICIENT;
+    this.lastRejectReason = null;
     this.counters = {
       duplicates: 0,
       reordered: 0,
@@ -317,8 +322,10 @@ export class AvionicsIngress {
 
   acceptGroup(name, stamp, copyData, avionics, nowMs) {
     if (stamp === null || stamp === undefined) return false;
-    if (!isStampValid(stamp)) {
+    const fault = stampFault(stamp);
+    if (fault !== null) {
       this.bump("invalidStamps");
+      this.lastRejectReason = fault;
       return false;
     }
     if (!this.acceptSource(stamp.sourceId)) return false;
@@ -445,7 +452,7 @@ export class AvionicsIngress {
   }
 
   diagnostics() {
-    return Object.freeze({ ...this.counters });
+    return Object.freeze({ ...this.counters, lastRejectReason: this.lastRejectReason });
   }
 
   bump(name, amount = 1) {

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -475,3 +475,35 @@ for (const test of [
   test();
   console.log(`ok - ${test.name}`);
 }
+
+// ---- GEO-68: out-of-range / wrong-kind stamp identity rejected, typed reason -
+
+{
+  const gate = ingress();
+  assert.equal(
+    gate.ingest(packet(stamp(1, 100n, 0x1_0000_0000), null), 0),
+    false,
+    "a source_epoch past u32 is refused, never clamped into range",
+  );
+  assert.deepEqual(gate.diagnostics().lastRejectReason, {
+    field: "sourceEpoch",
+    rule: "out-of-range",
+  });
+}
+{
+  const gate = ingress();
+  // sourceId is a u64: a Number is the wrong numeric kind (silent 2^53 truncation).
+  assert.equal(gate.ingest(packet(stamp(1, 100n, 1, 10), null), 0), false);
+  assert.deepEqual(gate.diagnostics().lastRejectReason, {
+    field: "sourceId",
+    rule: "wrong-numeric-kind",
+  });
+}
+{
+  const gate = ingress();
+  assert.equal(
+    gate.ingest(packet(stamp(1, 100n, 0xffff_ffff), null), 0),
+    true,
+    "the exact u32 max epoch is accepted",
+  );
+}

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -78,6 +78,11 @@ export function conformalGate(meta, snapshotIdentity, options = {}) {
       reason,
     });
   if (!meta || meta.mappingAvailable !== true) return closed("mapping-unavailable");
+  // The gate is the final authority: malformed identity fields (out-of-range,
+  // wrong numeric kind) can never produce a ready verdict, even when the
+  // mapping and calibration are otherwise valid. This also closes the direct
+  // associate() path, which does not run admit()'s validator.
+  if (!isMetaValid(meta)) return closed("malformed-meta");
   if (!snapshotIdentity || snapshotIdentity.clock !== meta.mappingTargetClock) {
     return closed("clock-mismatch");
   }

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -9,10 +9,10 @@
 // than reimplemented, so both paths share one definition of "newer".
 
 import { serialIsNewer } from "./telemetry-ingress.js";
+import { isIncarnation, isU32, isU64, isU8 } from "./wire-bounds.js";
 
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
-const INCARNATION_HEX = /^[0-9a-f]{32}$/;
 const U64_MAX = (1n << 64n) - 1n;
 
 // Maximum clock-mapping error a conformal overlay tolerates. A bounded mapping
@@ -91,7 +91,7 @@ export function conformalGate(meta, snapshotIdentity, options = {}) {
   // budget, and maps without overflow. Conformal readiness additionally demands
   // a published, recognized calibration.
   const calibrationReady =
-    Number.isInteger(meta.calibrationId) &&
+    isU32(meta.calibrationId) &&
     meta.calibrationId !== 0 &&
     recognized.has(meta.calibrationId);
   return Object.freeze({
@@ -104,22 +104,20 @@ export function conformalGate(meta, snapshotIdentity, options = {}) {
 }
 
 function isMetaValid(meta) {
+  // Each field at its exact wire type and range: the video-frame source id is
+  // a u8, epoch/sequence/camera id/calibration id are u32, and the capture
+  // time is a u64 (a BigInt, never a truncating Number). Negative, fractional,
+  // over-range, or wrong-numeric-kind values are refused fail-closed.
   return (
     meta !== null &&
     typeof meta === "object" &&
-    Number.isInteger(meta.sourceId) &&
-    typeof meta.sourceIncarnation === "string" &&
-    INCARNATION_HEX.test(meta.sourceIncarnation) &&
-    Number.isInteger(meta.sourceEpoch) &&
-    meta.sourceEpoch >= 0 &&
-    meta.sourceEpoch <= 0xffff_ffff &&
-    Number.isInteger(meta.sequence) &&
-    meta.sequence >= 0 &&
-    meta.sequence <= 0xffff_ffff &&
-    typeof meta.captureTimeNanos === "bigint" &&
-    meta.captureTimeNanos >= 0n &&
-    Number.isInteger(meta.cameraId) &&
-    Number.isInteger(meta.calibrationId) &&
+    isU8(meta.sourceId) &&
+    isIncarnation(meta.sourceIncarnation) &&
+    isU32(meta.sourceEpoch) &&
+    isU32(meta.sequence) &&
+    isU64(meta.captureTimeNanos) &&
+    isU32(meta.cameraId) &&
+    isU32(meta.calibrationId) &&
     (meta.captureClock === CLOCK_VEHICLE_BOOT || meta.captureClock === CLOCK_SIMULATION)
   );
 }

--- a/clients/web/video-identity.js
+++ b/clients/web/video-identity.js
@@ -9,7 +9,7 @@
 // than reimplemented, so both paths share one definition of "newer".
 
 import { serialIsNewer } from "./telemetry-ingress.js";
-import { isIncarnation, isU32, isU64, isU8 } from "./wire-bounds.js";
+import { RULE, firstFault, isIncarnation, isU32 } from "./wire-bounds.js";
 
 const CLOCK_VEHICLE_BOOT = 1;
 const CLOCK_SIMULATION = 2;
@@ -77,12 +77,15 @@ export function conformalGate(meta, snapshotIdentity, options = {}) {
       mappedCaptureTimeNanos: null,
       reason,
     });
-  if (!meta || meta.mappingAvailable !== true) return closed("mapping-unavailable");
-  // The gate is the final authority: malformed identity fields (out-of-range,
-  // wrong numeric kind) can never produce a ready verdict, even when the
-  // mapping and calibration are otherwise valid. This also closes the direct
-  // associate() path, which does not run admit()'s validator.
-  if (!isMetaValid(meta)) return closed("malformed-meta");
+  // The gate is the final authority: any malformed wire field (out-of-range,
+  // wrong numeric kind) can never produce a ready verdict, even when the mapping
+  // and calibration are otherwise valid. Validate before reading mappingAvailable
+  // or any mapped/BigInt field, so a wrong-numeric-kind value fails closed with a
+  // typed reason rather than throwing. This also closes the direct associate()
+  // path, which does not run admit()'s validator.
+  const fault = metaFault(meta);
+  if (fault !== null) return closed(`malformed-meta:${fault.field}:${fault.rule}`);
+  if (meta.mappingAvailable !== true) return closed("mapping-unavailable");
   if (!snapshotIdentity || snapshotIdentity.clock !== meta.mappingTargetClock) {
     return closed("clock-mismatch");
   }
@@ -108,30 +111,46 @@ export function conformalGate(meta, snapshotIdentity, options = {}) {
   });
 }
 
-function isMetaValid(meta) {
-  // Each field at its exact wire type and range: the video-frame source id is
-  // a u8, epoch/sequence/camera id/calibration id are u32, and the capture
-  // time is a u64 (a BigInt, never a truncating Number). Negative, fractional,
-  // over-range, or wrong-numeric-kind values are refused fail-closed.
-  return (
-    meta !== null &&
-    typeof meta === "object" &&
-    isU8(meta.sourceId) &&
-    isIncarnation(meta.sourceIncarnation) &&
-    isU32(meta.sourceEpoch) &&
-    isU32(meta.sequence) &&
-    isU64(meta.captureTimeNanos) &&
-    isU32(meta.cameraId) &&
-    isU32(meta.calibrationId) &&
-    (meta.captureClock === CLOCK_VEHICLE_BOOT || meta.captureClock === CLOCK_SIMULATION)
-  );
+const KNOWN_CLOCKS = new Set([CLOCK_VEHICLE_BOOT, CLOCK_SIMULATION]);
+
+/**
+ * The first frame-metadata field to violate its exact wire type and range, as a
+ * typed `{ field, rule }` reason, or `null` when every field is valid. Covers
+ * EVERY wire field the video path reads, stores, or maps — not only the identity
+ * tuple but the clock-mapping offset (a signed i64) and the error-bound, receive,
+ * and publication times (u64). Callers must run this before any BigInt
+ * arithmetic on those fields, so a wrong-numeric-kind value fails closed with a
+ * reason instead of throwing a `TypeError` when mixed with a BigInt. Negative,
+ * fractional, over-range, or wrong-numeric-kind values are refused, never
+ * clamped.
+ */
+export function metaFault(meta) {
+  if (meta === null || typeof meta !== "object") return { field: "meta", rule: RULE.MALFORMED };
+  const fault = firstFault([
+    ["sourceId", "u8", meta.sourceId],
+    ["sourceEpoch", "u32", meta.sourceEpoch],
+    ["sequence", "u32", meta.sequence],
+    ["cameraId", "u32", meta.cameraId],
+    ["calibrationId", "u32", meta.calibrationId],
+    ["captureTimeNanos", "u64", meta.captureTimeNanos],
+    ["mappingOffsetNanos", "i64", meta.mappingOffsetNanos],
+    ["clockErrorBoundNanos", "u64", meta.clockErrorBoundNanos],
+    ["receiveTimeNanos", "u64", meta.receiveTimeNanos],
+    ["publicationTimeNanos", "u64", meta.publicationTimeNanos],
+  ]);
+  if (fault !== null) return fault;
+  if (!isIncarnation(meta.sourceIncarnation)) return { field: "sourceIncarnation", rule: RULE.MALFORMED };
+  if (!KNOWN_CLOCKS.has(meta.captureClock)) return { field: "captureClock", rule: RULE.MALFORMED };
+  if (!KNOWN_CLOCKS.has(meta.mappingTargetClock)) return { field: "mappingTargetClock", rule: RULE.MALFORMED };
+  return null;
 }
 
-function result(reason, discontinuity) {
+function result(reason, discontinuity, fault = null) {
   return Object.freeze({
     accepted: reason === ADMIT.ACCEPTED,
     reason,
     discontinuity,
+    fault,
   });
 }
 
@@ -155,12 +174,18 @@ export class VideoIdentityTracker {
       incarnationResets: 0,
       calibrationResets: 0,
     };
+    // The `{ field, rule }` of the most recent malformed frame, so diagnostics
+    // can report which wire field failed and why — not merely that a frame was
+    // malformed.
+    this.lastMalformedReason = null;
   }
 
   admit(meta) {
-    if (!isMetaValid(meta)) {
+    const fault = metaFault(meta);
+    if (fault !== null) {
       this.bump("malformed");
-      return result(ADMIT.MALFORMED, false);
+      this.lastMalformedReason = fault;
+      return result(ADMIT.MALFORMED, false, fault);
     }
     const state = this.sources.get(meta.sourceId);
     if (!state) {
@@ -248,7 +273,7 @@ export class VideoIdentityTracker {
   }
 
   diagnostics() {
-    return Object.freeze({ ...this.counters });
+    return Object.freeze({ ...this.counters, lastMalformedReason: this.lastMalformedReason });
   }
 
   bump(name, amount = 1) {

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -328,3 +328,29 @@ if (failures > 0) {
   process.exit(1);
 }
 console.log("\nall video identity checks passed");
+
+// ---- GEO-68: hostile wire-range meta is refused as malformed ----------------
+
+{
+  const hostile = [
+    ["negative sourceId (u8)", { sourceId: -1 }],
+    ["overflowing sourceId (u8)", { sourceId: 256 }],
+    ["bigint sourceId (u8 must be Number)", { sourceId: 0n }],
+    ["overflowing sourceEpoch", { sourceEpoch: 0x1_0000_0000 }],
+    ["fractional sequence", { sequence: 2.5 }],
+    ["Number captureTimeNanos (u64 must be BigInt)", { captureTimeNanos: 1000 }],
+    ["overflowing captureTimeNanos", { captureTimeNanos: (1n << 64n) }],
+    ["negative cameraId", { cameraId: -1 }],
+    ["overflowing calibrationId", { calibrationId: 0x1_0000_0000 }],
+    ["bigint calibrationId (u32 must be Number)", { calibrationId: 7n }],
+    ["malformed incarnation", { sourceIncarnation: "nope" }],
+  ];
+  for (const [name, override] of hostile) {
+    const t = new VideoIdentityTracker();
+    const verdict = t.admit(meta(override));
+    check(
+      `hostile meta refused as malformed: ${name}`,
+      verdict.accepted === false && verdict.reason === ADMIT.MALFORMED,
+    );
+  }
+}

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -323,11 +323,6 @@ check(
   check("tracker-rejected frame does not associate", stale.association.reason === ASSOCIATION.NOT_ADMITTED);
 }
 
-if (failures > 0) {
-  console.error(`\n${failures} check(s) failed`);
-  process.exit(1);
-}
-console.log("\nall video identity checks passed");
 
 // ---- GEO-68: hostile wire-range meta is refused as malformed ----------------
 
@@ -354,3 +349,34 @@ console.log("\nall video identity checks passed");
     );
   }
 }
+
+// ---- GEO-68: a malformed meta identity can never be conformal-ready ---------
+
+{
+  const g = conformalGate(
+    meta({ mappingAvailable: true, mappingTargetClock: CLOCK_SIMULATION, sourceId: 256, calibrationId: 7 }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check(
+    "a malformed meta (u8 sourceId=256) is refused by the gate, never ready",
+    g.conformalReady === false && g.reason === "malformed-meta",
+  );
+}
+{
+  const g = conformalGate(
+    meta({ mappingAvailable: true, mappingTargetClock: CLOCK_SIMULATION, calibrationId: 7n }),
+    snap(CLOCK_SIMULATION),
+    RECOGNIZED,
+  );
+  check(
+    "a bigint calibrationId (u32 must be Number) is refused by the gate",
+    g.conformalReady === false && g.reason === "malformed-meta",
+  );
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall video identity checks passed");

--- a/clients/web/video-identity.test.mjs
+++ b/clients/web/video-identity.test.mjs
@@ -350,6 +350,39 @@ check(
   }
 }
 
+// ---- GEO-68: admit() surfaces the typed { field, rule } reason --------------
+// The rejection is not merely "malformed": the verdict and the tracker's
+// diagnostics both name which wire field failed and why, across the identity
+// tuple, the signed mapping offset, and the u64 error/receive/publication times.
+{
+  const cases = [
+    [{ sourceId: 256 }, "sourceId", "out-of-range"],
+    [{ calibrationId: 7n }, "calibrationId", "wrong-numeric-kind"],
+    [{ captureTimeNanos: 1000 }, "captureTimeNanos", "wrong-numeric-kind"],
+    [{ clockErrorBoundNanos: -1n }, "clockErrorBoundNanos", "negative"],
+    [{ mappingOffsetNanos: 1n << 63n }, "mappingOffsetNanos", "out-of-range"],
+    [{ receiveTimeNanos: 5 }, "receiveTimeNanos", "wrong-numeric-kind"],
+    [{ sourceIncarnation: "nope" }, "sourceIncarnation", "malformed"],
+  ];
+  for (const [override, field, rule] of cases) {
+    const t = new VideoIdentityTracker();
+    const verdict = t.admit(meta(override));
+    check(
+      `admit reports the typed fault ${field}/${rule}`,
+      verdict.accepted === false &&
+        verdict.fault !== null &&
+        verdict.fault.field === field &&
+        verdict.fault.rule === rule,
+    );
+    check(
+      `diagnostics exposes the last malformed reason ${field}/${rule}`,
+      t.diagnostics().lastMalformedReason !== null &&
+        t.diagnostics().lastMalformedReason.field === field &&
+        t.diagnostics().lastMalformedReason.rule === rule,
+    );
+  }
+}
+
 // ---- GEO-68: a malformed meta identity can never be conformal-ready ---------
 
 {
@@ -359,8 +392,8 @@ check(
     RECOGNIZED,
   );
   check(
-    "a malformed meta (u8 sourceId=256) is refused by the gate, never ready",
-    g.conformalReady === false && g.reason === "malformed-meta",
+    "a malformed meta (u8 sourceId=256) is refused by the gate, never ready, with a typed reason",
+    g.conformalReady === false && g.reason === "malformed-meta:sourceId:out-of-range",
   );
 }
 {
@@ -370,8 +403,8 @@ check(
     RECOGNIZED,
   );
   check(
-    "a bigint calibrationId (u32 must be Number) is refused by the gate",
-    g.conformalReady === false && g.reason === "malformed-meta",
+    "a bigint calibrationId (u32 must be Number) is refused by the gate with a typed reason",
+    g.conformalReady === false && g.reason === "malformed-meta:calibrationId:wrong-numeric-kind",
   );
 }
 

--- a/clients/web/wire-bounds.js
+++ b/clients/web/wire-bounds.js
@@ -1,6 +1,7 @@
 // Exact unsigned wire-range predicates and typed rejection reasons for
-// browser-side identity validators (GEO-68). Every identity field decoded from
-// the wire has one exact unsigned type; these enforce that type and its range,
+// browser-side identity validators (GEO-68). Every field decoded from the wire
+// has one exact numeric type (unsigned for identities and times, signed i64 for
+// a clock-mapping offset); these enforce that type and its range,
 // fail-closed, with no clamping. A value that is negative, fractional, out of
 // range, or of the wrong numeric kind (a Number where a BigInt is required, or
 // a BigInt where a Number is required) is rejected — never coerced. `firstFault`
@@ -13,6 +14,10 @@ export const U8_MAX = 0xff;
 export const U32_MAX = 0xffff_ffff;
 /** Largest u64 wire value. */
 export const U64_MAX = 0xffff_ffff_ffff_ffffn;
+/** Most negative i64 wire value. */
+export const I64_MIN = -(1n << 63n);
+/** Largest i64 wire value. */
+export const I64_MAX = (1n << 63n) - 1n;
 
 /** Canonical 128-bit incarnation spelling: exactly 32 lowercase hex digits. */
 export const INCARNATION_HEX = /^[0-9a-f]{32}$/;
@@ -59,6 +64,15 @@ export function isU64(value) {
   return isBigUintInRange(value, U64_MAX);
 }
 
+/**
+ * A signed BigInt-typed i64 wire field (e.g. a clock-mapping offset, which may
+ * be negative). Rejects a Number (a truncating kind for a 64-bit field) and any
+ * BigInt outside `[I64_MIN, I64_MAX]`.
+ */
+export function isI64(value) {
+  return typeof value === "bigint" && value >= I64_MIN && value <= I64_MAX;
+}
+
 /** A 128-bit incarnation field: a string of exactly 32 lowercase hex digits. */
 export function isIncarnation(value) {
   return typeof value === "string" && INCARNATION_HEX.test(value);
@@ -79,6 +93,10 @@ export function fieldFault(kind, value) {
       if (typeof value !== "bigint") return RULE.WRONG_KIND;
       if (value < 0n) return RULE.NEGATIVE;
       return value > U64_MAX ? RULE.OUT_OF_RANGE : null;
+    }
+    case "i64": {
+      if (typeof value !== "bigint") return RULE.WRONG_KIND;
+      return value < I64_MIN || value > I64_MAX ? RULE.OUT_OF_RANGE : null;
     }
     case "incarnation":
       return isIncarnation(value) ? null : RULE.MALFORMED;

--- a/clients/web/wire-bounds.js
+++ b/clients/web/wire-bounds.js
@@ -1,0 +1,57 @@
+// Exact unsigned wire-range predicates for browser-side identity validators
+// (GEO-68). Every identity field decoded from the wire has one exact unsigned
+// type; these predicates enforce that type and its range, fail-closed, with no
+// clamping. A value that is negative, fractional, out of range, or of the wrong
+// numeric kind (a Number where a BigInt is required, or a BigInt where a Number
+// is required) is rejected — never coerced. Reason strings pair with the
+// predicates so a validator can report exactly which field and which rule
+// refused a value.
+
+/** Largest u8 wire value. */
+export const U8_MAX = 0xff;
+/** Largest u32 wire value. */
+export const U32_MAX = 0xffff_ffff;
+/** Largest u64 wire value. */
+export const U64_MAX = 0xffff_ffff_ffff_ffffn;
+
+/** Canonical 128-bit incarnation spelling: exactly 32 lowercase hex digits. */
+export const INCARNATION_HEX = /^[0-9a-f]{32}$/;
+
+/**
+ * A Number-typed unsigned wire integer within `[0, max]`. Rejects a BigInt
+ * (a Number field must not be given a BigInt), a fractional or non-finite
+ * value, a negative value, and anything above `max`. `Number.isInteger`
+ * already excludes BigInt, NaN, Infinity, and fractions.
+ */
+export function isUintInRange(value, max) {
+  return Number.isInteger(value) && value >= 0 && value <= max;
+}
+
+/** A u8 wire field (e.g. a video-frame source id). */
+export function isU8(value) {
+  return isUintInRange(value, U8_MAX);
+}
+
+/** A u32 wire field (epoch, sequence, camera id, calibration id). */
+export function isU32(value) {
+  return isUintInRange(value, U32_MAX);
+}
+
+/**
+ * A BigInt-typed unsigned wire integer within `[0n, max]`. Rejects a Number
+ * (a u64 field must not be given a Number — that silently truncates past
+ * 2^53), a negative BigInt, and anything above `max`.
+ */
+export function isBigUintInRange(value, max) {
+  return typeof value === "bigint" && value >= 0n && value <= max;
+}
+
+/** A u64 wire field (source id, acquisition/capture time nanoseconds). */
+export function isU64(value) {
+  return isBigUintInRange(value, U64_MAX);
+}
+
+/** A 128-bit incarnation field: a string of exactly 32 lowercase hex digits. */
+export function isIncarnation(value) {
+  return typeof value === "string" && INCARNATION_HEX.test(value);
+}

--- a/clients/web/wire-bounds.js
+++ b/clients/web/wire-bounds.js
@@ -1,11 +1,11 @@
-// Exact unsigned wire-range predicates for browser-side identity validators
-// (GEO-68). Every identity field decoded from the wire has one exact unsigned
-// type; these predicates enforce that type and its range, fail-closed, with no
-// clamping. A value that is negative, fractional, out of range, or of the wrong
-// numeric kind (a Number where a BigInt is required, or a BigInt where a Number
-// is required) is rejected — never coerced. Reason strings pair with the
-// predicates so a validator can report exactly which field and which rule
-// refused a value.
+// Exact unsigned wire-range predicates and typed rejection reasons for
+// browser-side identity validators (GEO-68). Every identity field decoded from
+// the wire has one exact unsigned type; these enforce that type and its range,
+// fail-closed, with no clamping. A value that is negative, fractional, out of
+// range, or of the wrong numeric kind (a Number where a BigInt is required, or
+// a BigInt where a Number is required) is rejected — never coerced. `firstFault`
+// pairs the rules with field names so a validator reports exactly which field
+// and which rule refused a value (a typed reason, not a bare boolean).
 
 /** Largest u8 wire value. */
 export const U8_MAX = 0xff;
@@ -17,11 +17,19 @@ export const U64_MAX = 0xffff_ffff_ffff_ffffn;
 /** Canonical 128-bit incarnation spelling: exactly 32 lowercase hex digits. */
 export const INCARNATION_HEX = /^[0-9a-f]{32}$/;
 
+/** The specific rule a field violated, for a typed rejection reason. */
+export const RULE = Object.freeze({
+  WRONG_KIND: "wrong-numeric-kind",
+  NEGATIVE: "negative",
+  FRACTIONAL: "fractional",
+  OUT_OF_RANGE: "out-of-range",
+  MALFORMED: "malformed",
+});
+
 /**
  * A Number-typed unsigned wire integer within `[0, max]`. Rejects a BigInt
  * (a Number field must not be given a BigInt), a fractional or non-finite
- * value, a negative value, and anything above `max`. `Number.isInteger`
- * already excludes BigInt, NaN, Infinity, and fractions.
+ * value, a negative value, and anything above `max`.
  */
 export function isUintInRange(value, max) {
   return Number.isInteger(value) && value >= 0 && value <= max;
@@ -54,4 +62,41 @@ export function isU64(value) {
 /** A 128-bit incarnation field: a string of exactly 32 lowercase hex digits. */
 export function isIncarnation(value) {
   return typeof value === "string" && INCARNATION_HEX.test(value);
+}
+
+/** The typed rule a value violates for its kind, or `null` when it is valid. */
+export function fieldFault(kind, value) {
+  switch (kind) {
+    case "u8":
+    case "u32": {
+      const max = kind === "u8" ? U8_MAX : U32_MAX;
+      if (typeof value !== "number") return RULE.WRONG_KIND;
+      if (!Number.isInteger(value)) return RULE.FRACTIONAL;
+      if (value < 0) return RULE.NEGATIVE;
+      return value > max ? RULE.OUT_OF_RANGE : null;
+    }
+    case "u64": {
+      if (typeof value !== "bigint") return RULE.WRONG_KIND;
+      if (value < 0n) return RULE.NEGATIVE;
+      return value > U64_MAX ? RULE.OUT_OF_RANGE : null;
+    }
+    case "incarnation":
+      return isIncarnation(value) ? null : RULE.MALFORMED;
+    default:
+      return RULE.MALFORMED;
+  }
+}
+
+/**
+ * The first field to violate its wire type/range in `spec`, as a typed
+ * `{ field, rule }` reason, or `null` when every field is valid. `spec` is an
+ * array of `[fieldName, kind, value]`. Evaluation order is the spec order, so
+ * the reported field is deterministic.
+ */
+export function firstFault(spec) {
+  for (const [field, kind, value] of spec) {
+    const rule = fieldFault(kind, value);
+    if (rule !== null) return { field, rule };
+  }
+  return null;
 }

--- a/clients/web/wire-bounds.test.mjs
+++ b/clients/web/wire-bounds.test.mjs
@@ -7,9 +7,12 @@ import {
   RULE,
   fieldFault,
   firstFault,
+  I64_MAX,
+  I64_MIN,
   U32_MAX,
   U64_MAX,
   U8_MAX,
+  isI64,
   isIncarnation,
   isU32,
   isU64,
@@ -54,6 +57,18 @@ check(
   !isU64(1000) && !isU64(0) && !isU64(Number.MAX_SAFE_INTEGER),
 );
 check("u64 rejects a fractional Number too", !isU64(1.5));
+
+// ---- i64 (signed clock-mapping offset) --------------------------------------
+
+check("i64 accepts 0n, its min, and its max", isI64(0n) && isI64(I64_MIN) && isI64(I64_MAX));
+check("i64 accepts a negative in range", isI64(-1n));
+check("i64 rejects one past the max", !isI64(I64_MAX + 1n));
+check("i64 rejects one below the min", !isI64(I64_MIN - 1n));
+check("i64 rejects a Number (would truncate past 2^53)", !isI64(0) && !isI64(-1) && !isI64(1000));
+check("fieldFault: a valid i64 (including negative) has no fault", fieldFault("i64", -5n) === null);
+check("fieldFault: a Number for i64 is wrong-kind", fieldFault("i64", -5) === RULE.WRONG_KIND);
+check("fieldFault: an i64 past the max is out-of-range", fieldFault("i64", I64_MAX + 1n) === RULE.OUT_OF_RANGE);
+check("fieldFault: an i64 below the min is out-of-range", fieldFault("i64", I64_MIN - 1n) === RULE.OUT_OF_RANGE);
 
 // ---- incarnation ------------------------------------------------------------
 

--- a/clients/web/wire-bounds.test.mjs
+++ b/clients/web/wire-bounds.test.mjs
@@ -4,6 +4,9 @@
 
 import {
   INCARNATION_HEX,
+  RULE,
+  fieldFault,
+  firstFault,
   U32_MAX,
   U64_MAX,
   U8_MAX,
@@ -63,6 +66,29 @@ check("the incarnation regex is anchored", INCARNATION_HEX.source.startsWith("^"
 // ---- generic range ----------------------------------------------------------
 
 check("isUintInRange respects an arbitrary max", isUintInRange(5, 5) && !isUintInRange(6, 5));
+
+// ---- typed rejection reasons ------------------------------------------------
+
+check("fieldFault: a valid u32 has no fault", fieldFault("u32", 5) === null);
+check("fieldFault: a bigint for u32 is wrong-kind", fieldFault("u32", 5n) === RULE.WRONG_KIND);
+check("fieldFault: a Number for u64 is wrong-kind", fieldFault("u64", 5) === RULE.WRONG_KIND);
+check("fieldFault: a negative is negative", fieldFault("u32", -1) === RULE.NEGATIVE);
+check("fieldFault: a fraction is fractional", fieldFault("u32", 1.5) === RULE.FRACTIONAL);
+check("fieldFault: over max is out-of-range", fieldFault("u32", U32_MAX + 1) === RULE.OUT_OF_RANGE);
+check("fieldFault: a bad incarnation is malformed", fieldFault("incarnation", "xyz") === RULE.MALFORMED);
+
+check(
+  "firstFault reports the first offending field and its rule",
+  (() => {
+    const r = firstFault([
+      ["sourceId", "u64", 10n],
+      ["sourceEpoch", "u32", 0x1_0000_0000],
+      ["sequence", "u32", -1],
+    ]);
+    return r !== null && r.field === "sourceEpoch" && r.rule === RULE.OUT_OF_RANGE;
+  })(),
+);
+check("firstFault returns null when every field is valid", firstFault([["a", "u32", 0], ["b", "u64", 0n]]) === null);
 
 if (failures > 0) {
   console.error(`${failures} check(s) failed`);

--- a/clients/web/wire-bounds.test.mjs
+++ b/clients/web/wire-bounds.test.mjs
@@ -1,0 +1,71 @@
+// Exhaustive tests for the exact unsigned wire-range predicates (GEO-68):
+// every width rejects negative, fractional, over-range, and wrong-numeric-kind
+// values, and never clamps.
+
+import {
+  INCARNATION_HEX,
+  U32_MAX,
+  U64_MAX,
+  U8_MAX,
+  isIncarnation,
+  isU32,
+  isU64,
+  isU8,
+  isUintInRange,
+} from "./wire-bounds.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL - ${name}`);
+  }
+}
+
+// ---- u8 ---------------------------------------------------------------------
+
+check("u8 accepts 0 and the max", isU8(0) && isU8(U8_MAX));
+check("u8 rejects one past the max", !isU8(U8_MAX + 1));
+check("u8 rejects a negative", !isU8(-1));
+check("u8 rejects a fraction", !isU8(1.5));
+check("u8 rejects a bigint (wrong numeric kind)", !isU8(1n));
+check("u8 rejects NaN and Infinity", !isU8(Number.NaN) && !isU8(Number.POSITIVE_INFINITY));
+
+// ---- u32 --------------------------------------------------------------------
+
+check("u32 accepts 0 and the max", isU32(0) && isU32(U32_MAX));
+check("u32 rejects one past the max", !isU32(U32_MAX + 1));
+check("u32 rejects a negative", !isU32(-1));
+check("u32 rejects a fraction", !isU32(3.14));
+check("u32 rejects a bigint", !isU32(5n));
+
+// ---- u64 --------------------------------------------------------------------
+
+check("u64 accepts 0n and the max", isU64(0n) && isU64(U64_MAX));
+check("u64 rejects one past the max", !isU64(U64_MAX + 1n));
+check("u64 rejects a negative bigint", !isU64(-1n));
+check(
+  "u64 rejects a Number (would truncate past 2^53)",
+  !isU64(1000) && !isU64(0) && !isU64(Number.MAX_SAFE_INTEGER),
+);
+check("u64 rejects a fractional Number too", !isU64(1.5));
+
+// ---- incarnation ------------------------------------------------------------
+
+check("incarnation accepts 32 lowercase hex", isIncarnation("0123456789abcdef0123456789abcdef"));
+check("incarnation rejects wrong length", !isIncarnation("abc"));
+check("incarnation rejects uppercase", !isIncarnation("0123456789ABCDEF0123456789ABCDEF"));
+check("incarnation rejects a non-string", !isIncarnation(0x123n) && !isIncarnation(null));
+check("the incarnation regex is anchored", INCARNATION_HEX.source.startsWith("^"));
+
+// ---- generic range ----------------------------------------------------------
+
+check("isUintInRange respects an arbitrary max", isUintInRange(5, 5) && !isUintInRange(6, 5));
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all wire-bounds checks passed");

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -624,8 +624,10 @@ function decodeMeasurementStamp(bytes) {
   return {
     sourceId: firstBigVarint(f, 1),
     sourceIncarnation: decodeIncarnation(firstBytes(f, 6)),
-    sourceEpoch: firstVarint(f, 2) >>> 0,
-    sequence: firstVarint(f, 3) >>> 0,
+    // No `>>> 0`: a wire value past u32 must be REJECTED by the identity
+    // validator downstream, never silently truncated into range.
+    sourceEpoch: firstVarint(f, 2),
+    sequence: firstVarint(f, 3),
     acquiredAtNanos: firstBigVarint(f, 4),
     clock: firstVarint(f, 5),
   };

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -373,6 +373,25 @@ check(
   })(),
 );
 
+
+// ---- GEO-68: the stamp decoder surfaces over-range values, never clamps -----
+
+{
+  const over = 0x1_0000_0000; // 2^32, one past u32 max
+  const av = [];
+  bytesField(av, 17, measurementStamp(5n, over, over, 100n, 1, 0xab));
+  const decoded = decodeAvionicsOnly(av).avionics.attitudeStamp;
+  check("a source_epoch past u32 is surfaced raw, not clamped to 0", decoded.sourceEpoch === over);
+  check("a sequence past u32 is surfaced raw, not clamped to 0", decoded.sequence === over);
+}
+{
+  const max = 0xffff_ffff;
+  const av = [];
+  bytesField(av, 17, measurementStamp(5n, max, max, 100n, 1, 0xab));
+  const decoded = decodeAvionicsOnly(av).avionics.attitudeStamp;
+  check("the exact u32 max round-trips through decode unchanged", decoded.sourceEpoch === max);
+}
+
 if (failures > 0) {
   console.error(`\n${failures} check(s) failed`);
   process.exit(1);


### PR DESCRIPTION
Implements #68. Hostile-input hardening of every browser-side snapshot, video, association, and ingress identity validator. **SIM / NOT FOR FLIGHT.**

## The gap

The identity validators accepted values outside their exact wire ranges: `snapshot-association.isSnapshotIdentityValid` took a source id as *either* a BigInt *or* a truncating Number and left epoch/sequence/acquisition-time unbounded; `video-identity.isMetaValid` left the camera/calibration ids and the u64 capture time unbounded; `telemetry-ingress.isStampValid` had no u64 upper bound (a decoded varint past 2^64 slipped through). A negative, fractional, over-range, or wrong-numeric-kind value could be admitted.

## The fix

- **One shared `wire-bounds.js`** with exact-unsigned-range predicates — `isU8`, `isU32`, `isU64`, `isIncarnation` — each rejecting negative, fractional, over-range, and **wrong-numeric-kind** values (a Number where a u64 BigInt is required, or a BigInt where a u32/u8 Number is required), fail-closed, never clamped.
- **Applied uniformly**: snapshot-association (source id = u64 BigInt strictly, epoch/sequence = u32, acquisition time = u64), video-identity (frame source id = u8, camera/calibration = u32, capture time = u64), telemetry-ingress (source id / acquisition time = u64 with the missing upper bound — reorder/freshness gating unchanged).
- **Hostile boundary tests** through the public `observe`/`admit` APIs: each width's negative, overflow (max+1), fractional, and Number/BigInt-confused case is refused (snapshot → `invalid` counter, never observed; video → `ADMIT.MALFORMED`). Plus an exhaustive `wire-bounds.test.mjs` unit suite, now registered in CI.

## Acceptance criteria → evidence

| Criterion (#68) | Evidence |
|---|---|
| Exact unsigned ranges across snapshot/video/association/ingress validators | shared `wire-bounds.js` applied in all three validators |
| Reject negative / overflowing / fractional / Number-BigInt-confused; never clamp | `wire-bounds.test.mjs` (per width) + hostile suites in snapshot-association / video-identity tests |
| Typed fail-closed reasons | snapshot `invalid` counter (never observed); video `ADMIT.MALFORMED` |
| Hostile boundary tests + full CI | new suites, `wire-bounds.test.mjs` wired into ci.yml |

## Note on ci.yml

This lane adds one browser-suite line (`wire-bounds.test.mjs`) to `.github/workflows/ci.yml` in the browser-suites section. The concurrent SVS-02 lane registers its new Rust crate in a different section; the two additions are non-adjacent and merge cleanly in either order.

## Verification

All nine (now ten) node suites green; the tightening rejects only out-of-range values that valid data never produces, so the existing telemetry-ingress / video-identity / snapshot-association / instruments / wire suites stay green. No Rust touched.

Refs #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)