### PR TITLE
GEO-01: explicit availability profiles and one canonical CalibrationId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
 name = "pilotage-adapter-api"
 version = "0.1.0"
 dependencies = [
+ "pilotage-calibration-id",
  "pilotage-frames",
  "pilotage-protocol",
  "pilotage-timing",
@@ -978,6 +979,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-calibration-id"
+version = "0.1.0"
+
+[[package]]
 name = "pilotage-conformance"
 version = "0.1.0"
 dependencies = [
@@ -1003,6 +1008,7 @@ name = "pilotage-geo"
 version = "0.1.0"
 dependencies = [
  "libm",
+ "pilotage-calibration-id",
  "pilotage-frames",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/pilotage-adapter-api",
     "crates/pilotage-conformance",
     "crates/pilotage-frames",
+    "crates/pilotage-calibration-id",
     "crates/pilotage-geo",
     "crates/pilotage-alerts",
     "crates/pilotage-instrument-scene",
@@ -49,6 +50,7 @@ pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-frames = { path = "crates/pilotage-frames" }
+pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-geo = { path = "crates/pilotage-geo" }
 pilotage-alerts = { path = "crates/pilotage-alerts" }
 pilotage-instrument-scene = { path = "crates/pilotage-instrument-scene" }

--- a/crates/pilotage-adapter-api/Cargo.toml
+++ b/crates/pilotage-adapter-api/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
 pilotage-frames = { workspace = true }
+pilotage-calibration-id = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 sha2 = "0.10.9"

--- a/crates/pilotage-adapter-api/src/video.rs
+++ b/crates/pilotage-adapter-api/src/video.rs
@@ -16,30 +16,28 @@
 
 use crate::telemetry::{MeasurementClock, MeasurementStamp};
 
+/// The one canonical calibration identity, owned by the dependency-free `no_std`
+/// `pilotage-calibration-id` leaf and re-exported here. A published camera
+/// calibration and a synthetic-vision projection reference name the *same* type,
+/// so there is no second `CalibrationId` and no lossy `u32` bridge between them.
+/// `0` (its `NONE` sentinel, `!is_referenced()`) means no calibration identity
+/// was published; a conformal consumer must treat that as "calibration
+/// unavailable" and never assume a default. This crate depends only on the leaf,
+/// not the whole geospatial contract, to name the id.
+pub use pilotage_calibration_id::CalibrationId;
+
+/// Compile-time proof that this crate's public `CalibrationId` *is* the leaf's,
+/// not a second definition or a lossy `u32` mirror: a leaf value must be usable
+/// as ours with no conversion. If anyone re-mints a local `CalibrationId`, this
+/// identity coercion stops type-checking and the build fails here.
+const _: fn(CalibrationId) -> pilotage_calibration_id::CalibrationId = |id| id;
+
 /// Stable identity of the physical camera a frame came from, distinct from the
 /// routing `source_id`: two attachments can reuse a routing slot over a
 /// session's life, but a conformal overlay needs the camera whose intrinsics
 /// and mounting produced this image.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CameraId(pub u32);
-
-/// Identity of the calibration (intrinsics/extrinsics) that applies to a
-/// frame's camera. `0` means no calibration identity was published; a
-/// conformal consumer must treat that as "calibration unavailable" and never
-/// assume a default.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CalibrationId(pub u32);
-
-impl CalibrationId {
-    /// The sentinel meaning no calibration identity was published.
-    pub const NONE: Self = Self(0);
-
-    /// Whether a calibration identity was actually published for this frame.
-    #[must_use]
-    pub const fn is_published(self) -> bool {
-        self.0 != 0
-    }
-}
 
 /// Whether a frame's capture clock can be related to the flight-state clock,
 /// and with what error.
@@ -247,9 +245,9 @@ mod tests {
     }
 
     #[test]
-    fn calibration_none_is_unpublished() {
-        assert!(!CalibrationId::NONE.is_published());
-        assert!(CalibrationId(1).is_published());
+    fn calibration_none_is_not_referenced() {
+        assert!(!CalibrationId::NONE.is_referenced());
+        assert!(CalibrationId(1).is_referenced());
     }
 
     #[test]
@@ -261,7 +259,7 @@ mod tests {
             mapping: CaptureClockMapping::Unavailable,
         };
         assert_eq!(capture.camera_id, CameraId(1));
-        assert!(!capture.calibration_id.is_published());
+        assert!(!capture.calibration_id.is_referenced());
         assert!(!capture.mapping.is_available());
     }
 }

--- a/crates/pilotage-calibration-id/Cargo.toml
+++ b/crates/pilotage-calibration-id/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pilotage-calibration-id"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/pilotage-calibration-id/src/lib.rs
+++ b/crates/pilotage-calibration-id/src/lib.rs
@@ -1,0 +1,48 @@
+//! The one canonical calibration identity for the program.
+//!
+//! A camera calibration artifact and a synthetic-vision projection reference
+//! both need to name *which* calibration applies, and they must agree on one
+//! identity space — a reference that points at an artifact by a different-width
+//! or separately-defined id could silently drift. This crate is that single
+//! definition: a `no_std`, dependency-free leaf both the `std` calibration
+//! contract (`pilotage-adapter-api`) and the geospatial contract
+//! (`pilotage-geo`) depend on and re-export, so neither owns the id relative to
+//! the other and neither pulls the other's whole contract to name a `u32`.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+/// The identity of one camera calibration (intrinsics/extrinsics) artifact.
+///
+/// `0` is the [`CalibrationId::NONE`] sentinel: no calibration identity is
+/// referenced, and a consumer must treat that as "calibration unavailable"
+/// rather than assume a default. Every other value names one artifact; the
+/// artifact's geometry, lifecycle, content hash, and error budget live in the
+/// calibration contract, never here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CalibrationId(pub u32);
+
+impl CalibrationId {
+    /// The sentinel meaning no calibration identity is referenced.
+    pub const NONE: Self = Self(0);
+
+    /// Whether a calibration identity is actually referenced (not [`Self::NONE`]).
+    #[must_use]
+    pub const fn is_referenced(self) -> bool {
+        self.0 != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CalibrationId;
+
+    #[test]
+    fn none_is_the_zero_sentinel_and_is_not_referenced() {
+        assert_eq!(CalibrationId::NONE, CalibrationId(0));
+        assert!(!CalibrationId::NONE.is_referenced());
+        assert!(CalibrationId(1).is_referenced());
+    }
+}

--- a/crates/pilotage-geo/Cargo.toml
+++ b/crates/pilotage-geo/Cargo.toml
@@ -9,5 +9,6 @@ workspace = true
 
 [dependencies]
 pilotage-frames = { workspace = true }
+pilotage-calibration-id = { workspace = true }
 libm = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pilotage-geo/src/abi.rs
+++ b/crates/pilotage-geo/src/abi.rs
@@ -19,7 +19,9 @@
 
 use pilotage_frames::Epoch;
 
-use crate::availability::{ExternalHealth, SvsAvailability, SvsInputs, derive_inputs};
+use crate::availability::{
+    AvailabilityProfile, ExternalHealth, SvsAvailability, SvsInputs, derive_inputs,
+};
 use crate::error::{AbiError, GeoError};
 use crate::identity::{StatedAttitude, StatedPosition};
 use crate::view::ProjectionView;
@@ -66,15 +68,20 @@ pub struct RawSvsFrame {
 }
 
 impl RawSvsFrame {
-    /// Validates the raw inputs and derives availability, failing closed on any
-    /// structural violation: a non-finite or out-of-range position, an
-    /// incomplete datum identity, a non-unit aircraft attitude, or an invalid
-    /// view. Availability (including time/coherence) is *derived*, never stated.
+    /// Validates the raw inputs and derives availability against `profile`,
+    /// failing closed on any structural violation: a non-finite or out-of-range
+    /// position, an incomplete datum identity, a non-unit aircraft attitude, or
+    /// an invalid view. Availability (including time/coherence) is *derived*,
+    /// never stated; the caller supplies the profile whose freshness and accuracy
+    /// limits the derivation is judged against, and its identity is bound into the
+    /// result. The wire carries no profile — it is receiver-side evaluation
+    /// context, so the same bytes can be judged under different intended
+    /// functions.
     ///
     /// # Errors
     ///
     /// A [`GeoError`] describing the first structural violation.
-    pub fn validate(&self) -> Result<ValidatedSvsFrame, GeoError> {
+    pub fn validate(&self, profile: &AvailabilityProfile) -> Result<ValidatedSvsFrame, GeoError> {
         self.position.position.validate()?;
         if self
             .attitude
@@ -91,6 +98,7 @@ impl RawSvsFrame {
             self.view,
             self.external,
             self.reference_time,
+            profile,
         ))
     }
 }
@@ -99,7 +107,9 @@ impl RawSvsFrame {
 /// are computed from the inputs and cannot be set independently: the fields are
 /// private and the only ways to obtain one are [`RawSvsFrame::validate`] and
 /// [`decode_frame`]. There is no path by which an untrusted input yields an
-/// [`SvsAvailability::Available`] frame.
+/// [`SvsAvailability::Available`] frame. The evaluation [`AvailabilityProfile`]
+/// the verdict was judged against is bound in, so a verdict is traceable to the
+/// exact freshness and accuracy limits that produced it.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ValidatedSvsFrame {
     position: StatedPosition,
@@ -107,21 +117,24 @@ pub struct ValidatedSvsFrame {
     view: ProjectionView,
     external: ExternalHealth,
     reference_time: Epoch,
+    profile: AvailabilityProfile,
     inputs: SvsInputs,
     availability: SvsAvailability,
 }
 
 impl ValidatedSvsFrame {
-    /// Derives the input health and availability and assembles the frame. The
-    /// caller must have already validated the structural invariants.
+    /// Derives the input health and availability against `profile` and assembles
+    /// the frame. The caller must have already validated the structural
+    /// invariants.
     fn assemble(
         position: StatedPosition,
         attitude: StatedAttitude,
         view: ProjectionView,
         external: ExternalHealth,
         reference_time: Epoch,
+        profile: &AvailabilityProfile,
     ) -> Self {
-        let inputs = derive_inputs(&position, &attitude, &external, reference_time);
+        let inputs = derive_inputs(&position, &attitude, &external, reference_time, profile);
         let availability = SvsAvailability::assess(&inputs);
         Self {
             position,
@@ -129,6 +142,7 @@ impl ValidatedSvsFrame {
             view,
             external,
             reference_time,
+            profile: *profile,
             inputs,
             availability,
         }
@@ -169,6 +183,12 @@ impl ValidatedSvsFrame {
     pub fn availability(&self) -> SvsAvailability {
         self.availability
     }
+    /// The evaluation profile the availability verdict was judged against, so the
+    /// verdict is traceable to its freshness and accuracy limits.
+    #[must_use]
+    pub fn profile(&self) -> AvailabilityProfile {
+        self.profile
+    }
 }
 
 /// Serializes one validated frame into its fixed-size canonical byte form. Only
@@ -180,15 +200,21 @@ pub fn encode_frame(frame: &ValidatedSvsFrame) -> [u8; SVS_FRAME_LEN] {
 }
 
 /// Decodes one frame from its canonical byte form, failing closed, and derives
-/// availability from the decoded inputs.
+/// availability from the decoded inputs against `profile`. The wire bytes carry
+/// no profile: the same block decodes identically regardless of `profile`, and
+/// only the derived availability differs, so the profile is receiver-controlled
+/// evaluation context rather than producer data.
 ///
 /// # Errors
 ///
 /// [`AbiError`] on a wrong-length buffer, an unsupported version, an unknown
 /// enumerated value, a non-finite coordinate, a non-unit attitude, or a
 /// semantically malformed block.
-pub fn decode_frame(buf: &[u8]) -> Result<ValidatedSvsFrame, AbiError> {
-    codec::decode(buf)
+pub fn decode_frame(
+    buf: &[u8],
+    profile: &AvailabilityProfile,
+) -> Result<ValidatedSvsFrame, AbiError> {
+    codec::decode(buf, profile)
 }
 
 #[cfg(test)]

--- a/crates/pilotage-geo/src/abi/codec.rs
+++ b/crates/pilotage-geo/src/abi/codec.rs
@@ -4,7 +4,7 @@
 
 use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
-use crate::availability::{ExternalHealth, InputHealth};
+use crate::availability::{AvailabilityProfile, ExternalHealth, InputHealth};
 use crate::datum::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
     LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
@@ -379,8 +379,13 @@ fn get_external(r: &mut Reader) -> Result<ExternalHealth, AbiError> {
     })
 }
 
-/// Decodes one frame from its canonical byte form, failing closed.
-pub(super) fn decode(buf: &[u8]) -> Result<ValidatedSvsFrame, AbiError> {
+/// Decodes one frame from its canonical byte form, failing closed, deriving
+/// availability against `profile`. The profile influences only the derived
+/// verdict, never how the bytes are parsed.
+pub(super) fn decode(
+    buf: &[u8],
+    profile: &AvailabilityProfile,
+) -> Result<ValidatedSvsFrame, AbiError> {
     if buf.len() != SVS_FRAME_LEN {
         return Err(AbiError::WrongLength {
             needed: SVS_FRAME_LEN,
@@ -403,5 +408,6 @@ pub(super) fn decode(buf: &[u8]) -> Result<ValidatedSvsFrame, AbiError> {
         view,
         external,
         reference_time,
+        profile,
     ))
 }

--- a/crates/pilotage-geo/src/abi/tests.rs
+++ b/crates/pilotage-geo/src/abi/tests.rs
@@ -8,7 +8,10 @@ use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
 use super::{
     ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,
 };
-use crate::availability::{AvailabilityReason, ExternalHealth, InputHealth, SvsAvailability};
+use crate::availability::{
+    AvailabilityProfile, AvailabilityProfileId, AvailabilityReason, ExternalHealth, InputHealth,
+    SvsAvailability,
+};
 use crate::datum::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
     LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
@@ -24,6 +27,10 @@ use crate::view::{
 
 const ACQ_NS: u64 = 1_700_000_000_000_000_000;
 const REF_NS: u64 = ACQ_NS + 10_000_000; // 10 ms after acquisition: fresh.
+
+/// The evaluation profile every round-trip test judges against. Availability is
+/// receiver-derived under this profile; the wire carries none.
+const SIM: AvailabilityProfile = AvailabilityProfile::simulator();
 
 fn epoch(nanos: u64) -> Epoch {
     Epoch {
@@ -127,7 +134,7 @@ fn raw() -> RawSvsFrame {
 }
 
 fn validated() -> ValidatedSvsFrame {
-    raw().validate().expect("the nominal frame validates")
+    raw().validate(&SIM).expect("the nominal frame validates")
 }
 
 #[test]
@@ -136,7 +143,7 @@ fn frame_round_trips_through_the_abi_and_derives_availability() {
     assert_eq!(original.availability(), SvsAvailability::Available);
     let bytes = encode_frame(&original);
     assert_eq!(bytes.len(), SVS_FRAME_LEN);
-    let decoded = decode_frame(&bytes).expect("round-trips");
+    let decoded = decode_frame(&bytes, &SIM).expect("round-trips");
     assert_eq!(decoded, original);
     assert_eq!(
         decoded.availability(),
@@ -152,13 +159,15 @@ fn availability_is_never_read_from_the_wire() {
     // claim Available over this input.
     let mut r = raw();
     r.position = position(IntegrityLevel::Untrusted);
-    let f = r.validate().expect("structurally valid, just untrusted");
+    let f = r
+        .validate(&SIM)
+        .expect("structurally valid, just untrusted");
     assert_eq!(
         f.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::Position),
     );
     // Round-trips as still Unavailable — the wire carried no availability.
-    let decoded = decode_frame(&encode_frame(&f)).expect("round-trips");
+    let decoded = decode_frame(&encode_frame(&f), &SIM).expect("round-trips");
     assert_eq!(
         decoded.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::Position),
@@ -169,7 +178,7 @@ fn availability_is_never_read_from_the_wire() {
 fn unknown_integrity_input_is_never_available() {
     let mut r = raw();
     r.attitude = attitude(IntegrityLevel::Unknown);
-    let f = r.validate().expect("structurally valid");
+    let f = r.validate(&SIM).expect("structurally valid");
     assert_eq!(
         f.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::Attitude),
@@ -187,7 +196,7 @@ fn a_non_unit_aircraft_attitude_is_refused() {
         z: 0.0,
     };
     assert!(matches!(
-        r.validate(),
+        r.validate(&SIM),
         Err(crate::error::GeoError::AttitudeNotARotation)
     ));
     // And decode refuses a wire frame whose attitude quaternion is not unit.
@@ -196,7 +205,7 @@ fn a_non_unit_aircraft_attitude_is_refused() {
     // version(4) + position(125) = 129.
     bytes[129..133].copy_from_slice(&2.0f32.to_le_bytes());
     assert!(matches!(
-        decode_frame(&bytes),
+        decode_frame(&bytes, &SIM),
         Err(AbiError::Malformed {
             field: "attitude",
             ..
@@ -208,7 +217,7 @@ fn a_non_unit_aircraft_attitude_is_refused() {
 fn a_future_acquisition_fails_time_coherence() {
     let mut r = raw();
     r.reference_time = epoch(ACQ_NS - 1); // before acquisition: a future sample.
-    let f = r.validate().expect("structurally valid");
+    let f = r.validate(&SIM).expect("structurally valid");
     assert_eq!(
         f.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
@@ -221,7 +230,7 @@ fn a_snapshot_id_collision_across_streams_is_not_coherent() {
     // producers: not one coherent snapshot, so the scene is unavailable.
     let mut r = raw();
     r.attitude.stamp.snapshot.producer = SourceIncarnation([1; 16]);
-    let f = r.validate().expect("structurally valid");
+    let f = r.validate(&SIM).expect("structurally valid");
     assert_eq!(
         f.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
@@ -236,7 +245,7 @@ fn a_clock_or_scale_mismatch_fails_time_coherence() {
         scale: TimeScale::Monotonic,
         nanos: ACQ_NS,
     };
-    let f = r.validate().expect("structurally valid");
+    let f = r.validate(&SIM).expect("structurally valid");
     assert_eq!(
         f.availability(),
         SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
@@ -247,18 +256,21 @@ fn a_clock_or_scale_mismatch_fails_time_coherence() {
 fn wrong_length_fails_closed_including_trailing_bytes() {
     let bytes = encode_frame(&validated());
     assert!(matches!(
-        decode_frame(&bytes[..SVS_FRAME_LEN - 1]),
+        decode_frame(&bytes[..SVS_FRAME_LEN - 1], &SIM),
         Err(AbiError::WrongLength { .. })
     ));
     assert!(matches!(
-        decode_frame(&[]),
+        decode_frame(&[], &SIM),
         Err(AbiError::WrongLength { .. })
     ));
     // Trailing bytes are as suspect as truncation for a fixed-size block.
     let mut too_long = bytes.to_vec();
     too_long.push(0);
     assert!(
-        matches!(decode_frame(&too_long), Err(AbiError::WrongLength { .. })),
+        matches!(
+            decode_frame(&too_long, &SIM),
+            Err(AbiError::WrongLength { .. })
+        ),
         "a fixed block must match its length exactly"
     );
 }
@@ -268,7 +280,7 @@ fn wrong_version_fails_closed() {
     let mut bytes = encode_frame(&validated());
     bytes[0] = bytes[0].wrapping_add(1);
     assert!(matches!(
-        decode_frame(&bytes),
+        decode_frame(&bytes, &SIM),
         Err(AbiError::BadVersion { .. })
     ));
     assert_eq!(u32::from_le_bytes([2, 0, 0, 0]), ABI_VERSION);
@@ -279,7 +291,7 @@ fn unknown_enum_value_fails_closed() {
     // The horizontal-datum byte sits right after version(4) + lat(8) + lon(8).
     let mut bytes = encode_frame(&validated());
     bytes[20] = 200;
-    match decode_frame(&bytes) {
+    match decode_frame(&bytes, &SIM) {
         Err(AbiError::UnknownEnum { field, value }) => {
             assert_eq!(field, "horizontal_datum");
             assert_eq!(value, 200, "the actual unknown value is reported");
@@ -294,7 +306,7 @@ fn non_finite_coordinate_fails_closed() {
     // Overwrite the latitude (offset 4..12) with a NaN bit pattern.
     bytes[4..12].copy_from_slice(&f64::NAN.to_le_bytes());
     assert!(matches!(
-        decode_frame(&bytes),
+        decode_frame(&bytes, &SIM),
         Err(AbiError::NonFinite {
             field: "latitude_deg"
         })
@@ -309,7 +321,7 @@ fn an_incomplete_datum_identity_fails_closed() {
     // vdatum byte: version(4)+lat(8)+lon(8)+hdatum(1)+realization(2)+height(8) = 31.
     bytes[31] = VerticalDatum::Agl.to_u8();
     assert!(matches!(
-        decode_frame(&bytes),
+        decode_frame(&bytes, &SIM),
         Err(AbiError::Malformed {
             field: "vertical",
             ..
@@ -322,7 +334,7 @@ fn an_incomplete_calibration_reference_fails_closed() {
     let mut r = raw();
     r.view.calibration.calibration_id = CalibrationId::NONE;
     assert!(matches!(
-        r.validate(),
+        r.validate(&SIM),
         Err(crate::error::GeoError::IncompleteCalibrationReference)
     ));
     // Decode refuses a zero calibration id on the wire (u32 id at view offset:
@@ -330,7 +342,7 @@ fn an_incomplete_calibration_reference_fails_closed() {
     let mut bytes = encode_frame(&validated());
     bytes[220..224].copy_from_slice(&0u32.to_le_bytes());
     assert!(matches!(
-        decode_frame(&bytes),
+        decode_frame(&bytes, &SIM),
         Err(AbiError::Malformed { field: "view", .. })
     ));
 }
@@ -343,7 +355,7 @@ fn an_orthographic_view_without_extents_fails_closed() {
         extent_y_m: 375.0,
     };
     assert!(matches!(
-        r.validate(),
+        r.validate(&SIM),
         Err(crate::error::GeoError::InvalidOrthographicExtent { .. })
     ));
 }
@@ -355,8 +367,8 @@ fn an_orthographic_frame_is_not_read_as_perspective() {
         extent_x_m: 500.0,
         extent_y_m: 375.0,
     };
-    let f = r.validate().expect("valid orthographic frame");
-    let decoded = decode_frame(&encode_frame(&f)).expect("round-trips");
+    let f = r.validate(&SIM).expect("valid orthographic frame");
+    let decoded = decode_frame(&encode_frame(&f), &SIM).expect("round-trips");
     assert_eq!(
         decoded.view().projection,
         Projection::Orthographic {
@@ -376,7 +388,7 @@ fn an_unknown_external_health_byte_is_refused_not_coerced() {
     let mut bytes = encode_frame(&validated());
     let external_off = SVS_FRAME_LEN - 5 - 10;
     bytes[external_off] = 200;
-    match decode_frame(&bytes) {
+    match decode_frame(&bytes, &SIM) {
         Err(AbiError::UnknownEnum { field, value }) => {
             assert_eq!(field, "external_integrity");
             assert_eq!(value, 200);
@@ -393,6 +405,58 @@ fn an_encoded_frame_can_only_come_from_a_validated_one() {
     // decoded frame re-encodes byte-identically.
     let f = validated();
     let once = encode_frame(&f);
-    let twice = encode_frame(&decode_frame(&once).expect("round-trips"));
+    let twice = encode_frame(&decode_frame(&once, &SIM).expect("round-trips"));
     assert_eq!(once, twice);
+}
+
+#[test]
+fn the_evaluation_profile_is_bound_in_and_survives_round_trip() {
+    let f = validated();
+    assert_eq!(f.profile(), SIM);
+    let decoded = decode_frame(&encode_frame(&f), &SIM).expect("round-trips");
+    assert_eq!(decoded.profile(), SIM);
+    assert_eq!(decoded, f);
+}
+
+#[test]
+fn the_same_wire_bytes_are_judged_by_the_receivers_profile() {
+    // One producer frame, fresh and trusted, encodes once. A receiver that
+    // evaluates the identical bytes under a stricter position-accuracy profile
+    // gets a different, traceable verdict: the profile is receiver-controlled
+    // evaluation context, not wire data, so ABI v2 is unchanged.
+    let bytes = encode_frame(&validated());
+
+    let strict = AvailabilityProfile::new(
+        AvailabilityProfileId(2),
+        1,
+        SIM.fresh_age_ns(),
+        SIM.usable_age_ns(),
+        1_000,
+        2_000,
+        SIM.fresh_att_mrad(),
+        SIM.usable_att_mrad(),
+    )
+    .expect("a monotonic profile");
+
+    let under_sim = decode_frame(&bytes, &SIM).expect("decodes under sim");
+    let under_strict = decode_frame(&bytes, &strict).expect("decodes under strict");
+
+    // Identical bytes decode to identical position, attitude, and view...
+    assert_eq!(under_sim.position(), under_strict.position());
+    assert_eq!(under_sim.attitude(), under_strict.attitude());
+    assert_eq!(under_sim.view(), under_strict.view());
+    // ...but a different, profile-traceable availability verdict.
+    assert_eq!(under_sim.availability(), SvsAvailability::Available);
+    assert_eq!(under_sim.profile(), SIM);
+    assert_eq!(
+        under_strict.availability(),
+        SvsAvailability::Unavailable(AvailabilityReason::Position),
+    );
+    assert_eq!(under_strict.profile(), strict);
+
+    // The wire bytes are profile-independent: re-encoding either verdict yields
+    // exactly the original block, so no profile or availability ever reaches the
+    // wire and ABI v2 bytes are untouched by the profile.
+    assert_eq!(encode_frame(&under_sim), bytes);
+    assert_eq!(encode_frame(&under_strict), bytes);
 }

--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -13,38 +13,11 @@
 
 use pilotage_frames::Epoch;
 
-use crate::identity::{
-    AttitudeQuality, IntegrityLevel, PositionQuality, StatedAttitude, StatedPosition,
-};
+use crate::identity::{IntegrityLevel, PositionQuality, StatedAttitude, StatedPosition};
 
-/// Position/attitude older than this is stale and degrades the scene. A
-/// conformal scene at typical closing speeds is visibly wrong within a few
-/// hundred milliseconds of latency, so freshness beyond this bound is not
-/// trustworthy at full assurance.
-pub const MAX_FRESH_AGE_NS: u64 = 200_000_000;
+mod profile;
 
-/// Position/attitude older than this is unusable for a scene: at this age the
-/// registration error is unbounded for any useful motion, so the input fails
-/// rather than degrades.
-pub const MAX_USABLE_AGE_NS: u64 = 1_000_000_000;
-
-/// Position 1-sigma accuracy (per axis) beyond this degrades the scene: a few
-/// meters of registration error is visible but a conformal overlay can still
-/// aid orientation. A conservative SIM placeholder; a flight profile derives
-/// its own from the assurance allocation.
-pub const MAX_FRESH_POS_MM: u32 = 5_000;
-
-/// Position 1-sigma accuracy (per axis) beyond this is unusable for a scene:
-/// tens of meters places symbology on the wrong feature, so the input fails.
-pub const MAX_USABLE_POS_MM: u32 = 50_000;
-
-/// Attitude 1-sigma accuracy beyond this degrades the scene: about half a
-/// degree of angular error is visible at range but still orienting.
-pub const MAX_FRESH_ATT_MRAD: u32 = 10;
-
-/// Attitude 1-sigma accuracy beyond this is unusable: several degrees of
-/// angular error swings the horizon off the true one, so the input fails.
-pub const MAX_USABLE_ATT_MRAD: u32 = 50;
+pub use profile::{AvailabilityProfile, AvailabilityProfileId, SIMULATOR_PROFILE_ID};
 
 /// The finite set of reasons synthetic vision can be degraded or unavailable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -251,46 +224,29 @@ const fn worse(a: InputHealth, b: InputHealth) -> InputHealth {
     if a.to_u8() >= b.to_u8() { a } else { b }
 }
 
-/// Maps a position accuracy to the health it contributes: within the fresh
-/// bound is usable, beyond the usable bound fails, and in between degrades. The
+/// Maps a position accuracy to the health it contributes under `profile`: the
 /// worse of the horizontal and vertical axes decides.
 #[must_use]
-const fn health_from_position_quality(q: PositionQuality) -> InputHealth {
-    worse(mm_health(q.horizontal_mm), mm_health(q.vertical_mm))
-}
-
-#[must_use]
-const fn mm_health(mm: u32) -> InputHealth {
-    if mm > MAX_USABLE_POS_MM {
-        InputHealth::Failed
-    } else if mm > MAX_FRESH_POS_MM {
-        InputHealth::Degraded
-    } else {
-        InputHealth::Ok
-    }
-}
-
-/// Maps an attitude accuracy to the health it contributes.
-#[must_use]
-const fn health_from_attitude_quality(q: AttitudeQuality) -> InputHealth {
-    if q.angular_mrad > MAX_USABLE_ATT_MRAD {
-        InputHealth::Failed
-    } else if q.angular_mrad > MAX_FRESH_ATT_MRAD {
-        InputHealth::Degraded
-    } else {
-        InputHealth::Ok
-    }
+const fn health_from_position_quality(
+    q: PositionQuality,
+    profile: &AvailabilityProfile,
+) -> InputHealth {
+    worse(
+        profile.position_mm_health(q.horizontal_mm),
+        profile.position_mm_health(q.vertical_mm),
+    )
 }
 
 /// Derives time/coherence health from the position and attitude stamps and the
-/// frame reference time, failing closed: incompatible clocks/scales, a future
-/// sample, no declared coherent snapshot, or an unusable age all fail; a merely
-/// stale but usable pair degrades.
+/// frame reference time under `profile`, failing closed: incompatible
+/// clocks/scales, a future sample, no declared coherent snapshot, or an unusable
+/// age all fail; a merely stale but usable pair degrades.
 #[must_use]
 fn derive_time_coherence(
     position: &StatedPosition,
     attitude: &StatedAttitude,
     reference_time: Epoch,
+    profile: &AvailabilityProfile,
 ) -> InputHealth {
     // A coherent scene requires the position and attitude to be one declared
     // coherent snapshot on one time base.
@@ -305,37 +261,32 @@ fn derive_time_coherence(
     ) else {
         return InputHealth::Failed;
     };
-    let age = pos_age.max(att_age);
-    if age > MAX_USABLE_AGE_NS {
-        InputHealth::Failed
-    } else if age > MAX_FRESH_AGE_NS {
-        InputHealth::Degraded
-    } else {
-        InputHealth::Ok
-    }
+    profile.age_health(pos_age.max(att_age))
 }
 
 /// Derives the full input health from the validated position and attitude, the
-/// producer-stated external health, and the frame reference time. Position,
-/// attitude, and time/coherence are computed here; the rest are taken as stated.
+/// producer-stated external health, the frame reference time, and the selected
+/// availability `profile`. Position, attitude, and time/coherence are computed
+/// here against the profile's limits; the rest are taken as stated.
 #[must_use]
 pub fn derive_inputs(
     position: &StatedPosition,
     attitude: &StatedAttitude,
     external: &ExternalHealth,
     reference_time: Epoch,
+    profile: &AvailabilityProfile,
 ) -> SvsInputs {
     SvsInputs {
         position: worse(
             health_from_integrity(position.stamp.integrity),
-            health_from_position_quality(position.quality),
+            health_from_position_quality(position.quality, profile),
         ),
         attitude: worse(
             health_from_integrity(attitude.stamp.integrity),
-            health_from_attitude_quality(attitude.quality),
+            profile.attitude_mrad_health(attitude.quality.angular_mrad),
         ),
         integrity: external.integrity,
-        time_coherence: derive_time_coherence(position, attitude, reference_time),
+        time_coherence: derive_time_coherence(position, attitude, reference_time, profile),
         calibration: external.calibration,
         database: external.database,
         coverage: external.coverage,

--- a/crates/pilotage-geo/src/availability/profile.rs
+++ b/crates/pilotage-geo/src/availability/profile.rs
@@ -1,0 +1,212 @@
+//! The explicit availability profile: the freshness and accuracy limits an
+//! intended function allocates, chosen by the receiver at the validation/decode
+//! boundary rather than baked into the derivation.
+//!
+//! There is deliberately no default and no free function that picks a profile,
+//! so SIM limits are never presented as operational limits by omission. The one
+//! named profile shipped here is [`AvailabilityProfile::simulator`]; its checked
+//! constructor refuses a zero or non-monotonic limit so a profile can never admit
+//! a reading it should reject. The fields are private: a profile can only come
+//! from the checked constructor or the controlled `simulator`, never a struct
+//! literal that skips the check. The limits never travel on the wire — they are
+//! receiver-controlled evaluation context, so the same frame can be judged under
+//! different intended functions and the wire ABI is unchanged.
+
+use crate::error::GeoError;
+
+use super::InputHealth;
+
+/// Identity of an availability profile — an intended-function allocation of the
+/// freshness and accuracy limits. Compared for equality; a verdict carries it so
+/// the limits it was judged against are traceable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AvailabilityProfileId(pub u32);
+
+/// The id of the simulator profile.
+pub const SIMULATOR_PROFILE_ID: AvailabilityProfileId = AvailabilityProfileId(1);
+
+/// The freshness and accuracy limits an intended function allocates, selected at
+/// the validation/decode boundary. There is deliberately **no** `Default` and no
+/// free function that picks one: a caller must choose a profile explicitly, so
+/// SIM limits are never presented as operational limits by omission.
+///
+/// The fields are private and the only ways to obtain a value are the checked
+/// [`AvailabilityProfile::new`] and the controlled [`AvailabilityProfile::simulator`].
+/// Within each pair the *fresh* limit must be strictly tighter than the *usable*
+/// limit and both must be non-zero, and `new` enforces that — so a struct literal
+/// that skips the check does not compile:
+///
+/// ```compile_fail
+/// use pilotage_geo::{AvailabilityProfile, AvailabilityProfileId};
+/// // Non-monotonic (fresh age 999 > usable age 1) AND unconstructable: the
+/// // fields are private, so this cannot bypass `new`'s monotonicity check.
+/// let _ = AvailabilityProfile {
+///     id: AvailabilityProfileId(9),
+///     version: 1,
+///     fresh_age_ns: 999,
+///     usable_age_ns: 1,
+///     fresh_pos_mm: 1,
+///     usable_pos_mm: 2,
+///     fresh_att_mrad: 1,
+///     usable_att_mrad: 2,
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AvailabilityProfile {
+    id: AvailabilityProfileId,
+    version: u16,
+    fresh_age_ns: u64,
+    usable_age_ns: u64,
+    fresh_pos_mm: u32,
+    usable_pos_mm: u32,
+    fresh_att_mrad: u32,
+    usable_att_mrad: u32,
+}
+
+impl AvailabilityProfile {
+    /// The published simulator profile: the SIM freshness and accuracy
+    /// allocation. This is a placeholder for an intended-function allocation, not
+    /// an operational limit.
+    #[must_use]
+    pub const fn simulator() -> Self {
+        Self {
+            id: SIMULATOR_PROFILE_ID,
+            version: 1,
+            // A conformal scene at typical closing speeds is visibly wrong within
+            // a few hundred milliseconds of latency; beyond ~1 s the registration
+            // error is unbounded for any useful motion.
+            fresh_age_ns: 200_000_000,
+            usable_age_ns: 1_000_000_000,
+            // A few meters of registration error is visible but still orienting;
+            // tens of meters place symbology on the wrong feature.
+            fresh_pos_mm: 5_000,
+            usable_pos_mm: 50_000,
+            // About half a degree is visible at range but orienting; several
+            // degrees swing the horizon off the true one.
+            fresh_att_mrad: 10,
+            usable_att_mrad: 50,
+        }
+    }
+
+    /// Builds a profile, failing closed on a zero or non-monotonic limit: within
+    /// each pair the fresh limit must be strictly less than the usable limit and
+    /// both must be non-zero, so the profile cannot admit a reading it should
+    /// reject.
+    ///
+    /// # Errors
+    ///
+    /// [`GeoError::InvalidAvailabilityProfile`] naming the offending pair.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: AvailabilityProfileId,
+        version: u16,
+        fresh_age_ns: u64,
+        usable_age_ns: u64,
+        fresh_pos_mm: u32,
+        usable_pos_mm: u32,
+        fresh_att_mrad: u32,
+        usable_att_mrad: u32,
+    ) -> Result<Self, GeoError> {
+        let monotonic_u64 = |fresh: u64, usable: u64| fresh > 0 && usable > fresh;
+        let monotonic_u32 = |fresh: u32, usable: u32| fresh > 0 && usable > fresh;
+        if !monotonic_u64(fresh_age_ns, usable_age_ns) {
+            return Err(GeoError::InvalidAvailabilityProfile { field: "age" });
+        }
+        if !monotonic_u32(fresh_pos_mm, usable_pos_mm) {
+            return Err(GeoError::InvalidAvailabilityProfile { field: "position" });
+        }
+        if !monotonic_u32(fresh_att_mrad, usable_att_mrad) {
+            return Err(GeoError::InvalidAvailabilityProfile { field: "attitude" });
+        }
+        Ok(Self {
+            id,
+            version,
+            fresh_age_ns,
+            usable_age_ns,
+            fresh_pos_mm,
+            usable_pos_mm,
+            fresh_att_mrad,
+            usable_att_mrad,
+        })
+    }
+
+    /// Profile identity.
+    #[must_use]
+    pub const fn id(&self) -> AvailabilityProfileId {
+        self.id
+    }
+    /// Profile content version.
+    #[must_use]
+    pub const fn version(&self) -> u16 {
+        self.version
+    }
+    /// Age at/under which a reading is fully fresh, nanoseconds.
+    #[must_use]
+    pub const fn fresh_age_ns(&self) -> u64 {
+        self.fresh_age_ns
+    }
+    /// Age beyond which a reading is unusable, nanoseconds.
+    #[must_use]
+    pub const fn usable_age_ns(&self) -> u64 {
+        self.usable_age_ns
+    }
+    /// Position 1-sigma accuracy (per axis) at/under which it is fresh, mm.
+    #[must_use]
+    pub const fn fresh_pos_mm(&self) -> u32 {
+        self.fresh_pos_mm
+    }
+    /// Position 1-sigma accuracy beyond which it is unusable, mm.
+    #[must_use]
+    pub const fn usable_pos_mm(&self) -> u32 {
+        self.usable_pos_mm
+    }
+    /// Attitude 1-sigma accuracy at/under which it is fresh, milliradians.
+    #[must_use]
+    pub const fn fresh_att_mrad(&self) -> u32 {
+        self.fresh_att_mrad
+    }
+    /// Attitude 1-sigma accuracy beyond which it is unusable, milliradians.
+    #[must_use]
+    pub const fn usable_att_mrad(&self) -> u32 {
+        self.usable_att_mrad
+    }
+
+    /// The health a position accuracy (mm) contributes under this profile.
+    #[must_use]
+    pub(super) const fn position_mm_health(&self, mm: u32) -> InputHealth {
+        if mm > self.usable_pos_mm {
+            InputHealth::Failed
+        } else if mm > self.fresh_pos_mm {
+            InputHealth::Degraded
+        } else {
+            InputHealth::Ok
+        }
+    }
+
+    /// The health an attitude accuracy (milliradians) contributes.
+    #[must_use]
+    pub(super) const fn attitude_mrad_health(&self, mrad: u32) -> InputHealth {
+        if mrad > self.usable_att_mrad {
+            InputHealth::Failed
+        } else if mrad > self.fresh_att_mrad {
+            InputHealth::Degraded
+        } else {
+            InputHealth::Ok
+        }
+    }
+
+    /// The health an age (nanoseconds) contributes.
+    #[must_use]
+    pub(super) const fn age_health(&self, age_ns: u64) -> InputHealth {
+        if age_ns > self.usable_age_ns {
+            InputHealth::Failed
+        } else if age_ns > self.fresh_age_ns {
+            InputHealth::Degraded
+        } else {
+            InputHealth::Ok
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/availability/profile/tests.rs
+++ b/crates/pilotage-geo/src/availability/profile/tests.rs
@@ -1,0 +1,67 @@
+//! Tests for the explicit, checked availability profile.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{AvailabilityProfile, AvailabilityProfileId, SIMULATOR_PROFILE_ID};
+use crate::availability::InputHealth;
+use crate::error::GeoError;
+
+#[test]
+fn the_simulator_profile_matches_its_golden_limits() {
+    // Independent golden literals, NOT the numbers simulator() is built from, so
+    // a change to the profile is caught here instead of drifting undetected.
+    let sim = AvailabilityProfile::simulator();
+    assert_eq!(sim.id(), SIMULATOR_PROFILE_ID);
+    assert_eq!(sim.version(), 1);
+    assert_eq!(sim.fresh_age_ns(), 200_000_000);
+    assert_eq!(sim.usable_age_ns(), 1_000_000_000);
+    assert_eq!(sim.fresh_pos_mm(), 5_000);
+    assert_eq!(sim.usable_pos_mm(), 50_000);
+    assert_eq!(sim.fresh_att_mrad(), 10);
+    assert_eq!(sim.usable_att_mrad(), 50);
+}
+
+#[test]
+fn simulator_health_boundaries_are_pinned_to_golden_limits() {
+    let sim = AvailabilityProfile::simulator();
+    // Age: 200_000_000 ns fresh / 1_000_000_000 ns usable.
+    assert_eq!(sim.age_health(200_000_000), InputHealth::Ok);
+    assert_eq!(sim.age_health(200_000_001), InputHealth::Degraded);
+    assert_eq!(sim.age_health(1_000_000_000), InputHealth::Degraded);
+    assert_eq!(sim.age_health(1_000_000_001), InputHealth::Failed);
+    // Position: 5_000 mm fresh / 50_000 mm usable.
+    assert_eq!(sim.position_mm_health(5_000), InputHealth::Ok);
+    assert_eq!(sim.position_mm_health(5_001), InputHealth::Degraded);
+    assert_eq!(sim.position_mm_health(50_000), InputHealth::Degraded);
+    assert_eq!(sim.position_mm_health(50_001), InputHealth::Failed);
+    // Attitude: 10 mrad fresh / 50 mrad usable.
+    assert_eq!(sim.attitude_mrad_health(10), InputHealth::Ok);
+    assert_eq!(sim.attitude_mrad_health(11), InputHealth::Degraded);
+    assert_eq!(sim.attitude_mrad_health(50), InputHealth::Degraded);
+    assert_eq!(sim.attitude_mrad_health(51), InputHealth::Failed);
+}
+
+#[test]
+fn profile_new_rejects_zero_and_non_monotonic_limits() {
+    let id = AvailabilityProfileId(7);
+    // A fresh age not strictly tighter than the usable age.
+    assert_eq!(
+        AvailabilityProfile::new(id, 1, 1_000, 1_000, 1, 2, 1, 2),
+        Err(GeoError::InvalidAvailabilityProfile { field: "age" }),
+    );
+    // A zero fresh position limit.
+    assert_eq!(
+        AvailabilityProfile::new(id, 1, 1, 2, 0, 2, 1, 2),
+        Err(GeoError::InvalidAvailabilityProfile { field: "position" }),
+    );
+    // A fresh attitude limit wider than the usable one.
+    assert_eq!(
+        AvailabilityProfile::new(id, 1, 1, 2, 1, 2, 9, 3),
+        Err(GeoError::InvalidAvailabilityProfile { field: "attitude" }),
+    );
+    // A fully monotonic, non-zero set is accepted; its accessors reflect it.
+    let ok = AvailabilityProfile::new(id, 4, 1, 2, 1, 2, 1, 2).expect("monotonic");
+    assert_eq!(ok.id(), id);
+    assert_eq!(ok.version(), 4);
+    assert_eq!(ok.fresh_age_ns(), 1);
+    assert_eq!(ok.usable_att_mrad(), 2);
+}

--- a/crates/pilotage-geo/src/availability/tests.rs
+++ b/crates/pilotage-geo/src/availability/tests.rs
@@ -124,8 +124,8 @@ fn availability_reason_wire_codes_round_trip_and_reject_unknown() {
 use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
 use super::{
-    ExternalHealth, MAX_FRESH_AGE_NS, MAX_FRESH_ATT_MRAD, MAX_FRESH_POS_MM, MAX_USABLE_AGE_NS,
-    MAX_USABLE_ATT_MRAD, derive_inputs, health_from_integrity,
+    AvailabilityProfile, AvailabilityProfileId, ExternalHealth, derive_inputs,
+    health_from_integrity,
 };
 use crate::datum::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
@@ -135,6 +135,31 @@ use crate::identity::{
     AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
     SourceStamp, StatedAttitude, StatedPosition,
 };
+
+// The simulator profile's limits, read through its public accessors — the SIM
+// values these derivation tests build fresh/stale/inaccurate inputs around.
+const SIM_FRESH_AGE_NS: u64 = AvailabilityProfile::simulator().fresh_age_ns();
+const SIM_USABLE_AGE_NS: u64 = AvailabilityProfile::simulator().usable_age_ns();
+const SIM_FRESH_POS_MM: u32 = AvailabilityProfile::simulator().fresh_pos_mm();
+const SIM_FRESH_ATT_MRAD: u32 = AvailabilityProfile::simulator().fresh_att_mrad();
+const SIM_USABLE_ATT_MRAD: u32 = AvailabilityProfile::simulator().usable_att_mrad();
+
+/// Derives inputs under the simulator profile, whose limits are the SIM
+/// allocation the derivation tests exercise.
+fn derive_sim(
+    position: &StatedPosition,
+    attitude: &StatedAttitude,
+    external: &ExternalHealth,
+    reference_time: Epoch,
+) -> SvsInputs {
+    derive_inputs(
+        position,
+        attitude,
+        external,
+        reference_time,
+        &AvailabilityProfile::simulator(),
+    )
+}
 
 fn epoch(nanos: u64) -> Epoch {
     Epoch {
@@ -229,8 +254,8 @@ fn health_from_integrity_only_trusts_the_top_level() {
 
 #[test]
 fn fresh_trusted_coherent_inputs_are_available() {
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
-    let inputs = derive_inputs(
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
@@ -241,8 +266,8 @@ fn fresh_trusted_coherent_inputs_are_available() {
 
 #[test]
 fn untrusted_position_can_never_be_available() {
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
-    let inputs = derive_inputs(
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
+    let inputs = derive_sim(
         &position(IntegrityLevel::Untrusted, 0),
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
@@ -256,8 +281,8 @@ fn untrusted_position_can_never_be_available() {
 
 #[test]
 fn monitored_attitude_degrades_the_scene() {
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
-    let inputs = derive_inputs(
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &attitude(IntegrityLevel::Monitored, 0),
         &external_ok(),
@@ -272,7 +297,7 @@ fn monitored_attitude_degrades_the_scene() {
 #[test]
 fn a_future_sample_fails_time_coherence() {
     // Reference time earlier than acquisition → future sample → failed.
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 1_000_000),
         &attitude(IntegrityLevel::Trusted, 1_000_000),
         &external_ok(),
@@ -286,21 +311,21 @@ fn a_future_sample_fails_time_coherence() {
 
 #[test]
 fn a_stale_pair_degrades_and_an_unusable_pair_fails() {
-    let stale = derive_inputs(
+    let stale = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
-        epoch(MAX_FRESH_AGE_NS + 1),
+        epoch(SIM_FRESH_AGE_NS + 1),
     );
     assert_eq!(
         SvsAvailability::assess(&stale),
         SvsAvailability::Degraded(AvailabilityReason::TimeCoherence),
     );
-    let unusable = derive_inputs(
+    let unusable = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
-        epoch(MAX_USABLE_AGE_NS + 1),
+        epoch(SIM_USABLE_AGE_NS + 1),
     );
     assert_eq!(
         SvsAvailability::assess(&unusable),
@@ -312,11 +337,11 @@ fn a_stale_pair_degrades_and_an_unusable_pair_fails() {
 fn incoherent_position_and_attitude_fail_time_coherence() {
     let mut att = attitude(IntegrityLevel::Trusted, 0);
     att.stamp.snapshot.id = 78; // a different snapshot instance
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &att,
         &external_ok(),
-        epoch(MAX_FRESH_AGE_NS / 2),
+        epoch(SIM_FRESH_AGE_NS / 2),
     );
     assert_eq!(
         SvsAvailability::assess(&inputs),
@@ -328,13 +353,13 @@ fn incoherent_position_and_attitude_fail_time_coherence() {
 fn a_trusted_but_grossly_inaccurate_position_is_never_available() {
     // Trusted integrity, fresh, coherent — but the position 1-sigma is
     // u32::MAX mm. Accuracy participates: the scene is unavailable.
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
     let mut pos = position(IntegrityLevel::Trusted, 0);
     pos.quality = PositionQuality {
         horizontal_mm: u32::MAX,
         vertical_mm: 0,
     };
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &pos,
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
@@ -348,12 +373,12 @@ fn a_trusted_but_grossly_inaccurate_position_is_never_available() {
 
 #[test]
 fn a_trusted_but_imprecise_attitude_degrades_or_fails() {
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
     let mut att = attitude(IntegrityLevel::Trusted, 0);
     att.quality = AttitudeQuality {
-        angular_mrad: MAX_FRESH_ATT_MRAD + 1,
+        angular_mrad: SIM_FRESH_ATT_MRAD + 1,
     };
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &att,
         &external_ok(),
@@ -365,9 +390,9 @@ fn a_trusted_but_imprecise_attitude_degrades_or_fails() {
     );
 
     att.quality = AttitudeQuality {
-        angular_mrad: MAX_USABLE_ATT_MRAD + 1,
+        angular_mrad: SIM_USABLE_ATT_MRAD + 1,
     };
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &position(IntegrityLevel::Trusted, 0),
         &att,
         &external_ok(),
@@ -381,17 +406,93 @@ fn a_trusted_but_imprecise_attitude_degrades_or_fails() {
 
 #[test]
 fn position_quality_at_the_fresh_bound_is_still_available() {
-    let now = epoch(MAX_FRESH_AGE_NS / 2);
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
     let mut pos = position(IntegrityLevel::Trusted, 0);
     pos.quality = PositionQuality {
-        horizontal_mm: MAX_FRESH_POS_MM,
-        vertical_mm: MAX_FRESH_POS_MM,
+        horizontal_mm: SIM_FRESH_POS_MM,
+        vertical_mm: SIM_FRESH_POS_MM,
     };
-    let inputs = derive_inputs(
+    let inputs = derive_sim(
         &pos,
         &attitude(IntegrityLevel::Trusted, 0),
         &external_ok(),
         now,
     );
     assert_eq!(SvsAvailability::assess(&inputs), SvsAvailability::Available);
+}
+
+// ---- derivation under an explicit, traceable profile -----------------------
+
+#[test]
+fn the_same_reading_is_judged_by_the_selected_profile() {
+    // A position 1-sigma that is fully fresh under the simulator profile but only
+    // degraded under a stricter one: the verdict tracks the profile, not the
+    // wire, so the same input yields different, deterministic results.
+    let now = epoch(SIM_FRESH_AGE_NS / 2);
+    let mut pos = position(IntegrityLevel::Trusted, 0);
+    pos.quality = PositionQuality {
+        horizontal_mm: 1_000,
+        vertical_mm: 1_000,
+    };
+
+    let stricter = AvailabilityProfile::new(
+        AvailabilityProfileId(2),
+        1,
+        SIM_FRESH_AGE_NS,
+        SIM_USABLE_AGE_NS,
+        500,
+        2_000,
+        SIM_FRESH_ATT_MRAD,
+        SIM_USABLE_ATT_MRAD,
+    )
+    .expect("a monotonic profile");
+
+    let under_sim = derive_sim(
+        &pos,
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+    );
+    let under_strict = derive_inputs(
+        &pos,
+        &attitude(IntegrityLevel::Trusted, 0),
+        &external_ok(),
+        now,
+        &stricter,
+    );
+
+    assert_eq!(
+        SvsAvailability::assess(&under_sim),
+        SvsAvailability::Available,
+    );
+    assert_eq!(
+        SvsAvailability::assess(&under_strict),
+        SvsAvailability::Degraded(AvailabilityReason::Position),
+    );
+}
+
+#[test]
+fn the_age_boundary_is_pinned_under_the_simulator_profile() {
+    let att = attitude(IntegrityLevel::Trusted, 0);
+    let pos = position(IntegrityLevel::Trusted, 0);
+    let assess = |reference: Epoch| {
+        SvsAvailability::assess(&derive_sim(&pos, &att, &external_ok(), reference))
+    };
+    // Exactly at the fresh age: still available.
+    assert_eq!(assess(epoch(SIM_FRESH_AGE_NS)), SvsAvailability::Available);
+    // One nanosecond older: degraded on time/coherence.
+    assert_eq!(
+        assess(epoch(SIM_FRESH_AGE_NS + 1)),
+        SvsAvailability::Degraded(AvailabilityReason::TimeCoherence),
+    );
+    // Exactly at the usable age: still only degraded.
+    assert_eq!(
+        assess(epoch(SIM_USABLE_AGE_NS)),
+        SvsAvailability::Degraded(AvailabilityReason::TimeCoherence),
+    );
+    // One nanosecond beyond usable: unavailable.
+    assert_eq!(
+        assess(epoch(SIM_USABLE_AGE_NS + 1)),
+        SvsAvailability::Unavailable(AvailabilityReason::TimeCoherence),
+    );
 }

--- a/crates/pilotage-geo/src/error.rs
+++ b/crates/pilotage-geo/src/error.rs
@@ -106,6 +106,14 @@ pub enum GeoError {
     /// The aircraft attitude quaternion is not a unit rotation.
     #[error("aircraft attitude is not a unit rotation")]
     AttitudeNotARotation,
+    /// An availability profile limit is zero or non-monotonic (a fresh limit is
+    /// not strictly tighter than its usable limit), so the profile could admit a
+    /// reading it should reject.
+    #[error("availability profile limit {field} is invalid (zero or non-monotonic)")]
+    InvalidAvailabilityProfile {
+        /// The offending limit pair.
+        field: &'static str,
+    },
 }
 
 /// Why an age could not be computed between two epochs. There is no

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -52,9 +52,8 @@ pub use abi::{
     ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,
 };
 pub use availability::{
-    AvailabilityReason, ExternalHealth, InputHealth, MAX_FRESH_AGE_NS, MAX_FRESH_ATT_MRAD,
-    MAX_FRESH_POS_MM, MAX_USABLE_AGE_NS, MAX_USABLE_ATT_MRAD, MAX_USABLE_POS_MM, SvsAvailability,
-    SvsInputs, derive_inputs, health_from_integrity,
+    AvailabilityProfile, AvailabilityProfileId, AvailabilityReason, ExternalHealth, InputHealth,
+    SIMULATOR_PROFILE_ID, SvsAvailability, SvsInputs, derive_inputs, health_from_integrity,
 };
 pub use datum::{
     BaroSettingId, DatumRealizationId, GeoTile, GeodeticPosition, GeoidModelId, HorizontalDatum,

--- a/crates/pilotage-geo/src/view.rs
+++ b/crates/pilotage-geo/src/view.rs
@@ -15,26 +15,17 @@
 
 use crate::error::GeoError;
 
-/// Accepted-calibration identity. Mirrors the authoritative
-/// `pilotage-adapter-api` `CalibrationId(u32)` field for field — same width,
-/// same `0 = none` sentinel — so a geo reference and the calibration artifact
-/// it points at share one identity space with no truncation. This crate is
-/// `no_std` and adapter-api is `std`, so the type is documented-mapped here
-/// (like the datum ↔ `AltitudeClass` mapping) rather than depended on across
-/// the direction boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CalibrationId(pub u32);
+/// The one canonical calibration identity, owned by the dependency-free `no_std`
+/// `pilotage-calibration-id` leaf and re-exported here. A geo projection
+/// reference and the `std` calibration artifact it points at are the *same*
+/// type over one identity space, not two mirrored `u32`s a lossy conversion
+/// could drift apart.
+pub use pilotage_calibration_id::CalibrationId;
 
-impl CalibrationId {
-    /// The sentinel meaning no calibration identity is referenced.
-    pub const NONE: Self = Self(0);
-
-    /// Whether a calibration identity is actually referenced.
-    #[must_use]
-    pub const fn is_referenced(self) -> bool {
-        self.0 != 0
-    }
-}
+/// Compile-time proof that geo's `CalibrationId` *is* the leaf's, not a second
+/// definition: a leaf value must be usable here with no conversion. If this
+/// re-export is ever replaced by a local type, the coercion fails the build.
+const _: fn(CalibrationId) -> pilotage_calibration_id::CalibrationId = |id| id;
 
 /// A reference to one accepted, validated calibration artifact — identity and
 /// content hash only. The view is meaningless without it, and it deliberately

--- a/docs/adr/0022-geospatial-projection-availability-contract.md
+++ b/docs/adr/0022-geospatial-projection-availability-contract.md
@@ -69,20 +69,35 @@ SIM / NOT FOR FLIGHT.
   render-time policy (projection kind, near/far, minification). The alignment
   bound and geometry come from *resolving* that reference against a verified
   artifact (in the `std` calibration contract), so a producer cannot write an
-  understated bound onto the wire — there is no bound field to write. The
-  reference id is [`CalibrationId`], a `u32` mirroring the authoritative
-  adapter-api `CalibrationId(u32)` field for field (documented mapping across
-  the no_std/std boundary, like the datum ↔ `AltitudeClass` mapping), so the two
-  share one identity space with no truncation. Perspective and orthographic are
-  typed payloads — a focal-derived field of view is not an orthographic
-  invariant.
+  understated bound onto the wire — there is no bound field to write. Perspective
+  and orthographic are typed payloads — a focal-derived field of view is not an
+  orthographic invariant.
+
+- **One canonical `CalibrationId` in a shared leaf.** The calibration identity is
+  a single type, [`CalibrationId`], owned by a dependency-free `no_std` leaf crate
+  (`pilotage-calibration-id`) that both `pilotage-geo` and the `std` calibration
+  contract (`pilotage-adapter-api`) depend on and re-export. Neither owns the id
+  relative to the other, and adapter-api pulls only the one-`u32` leaf — not the
+  whole geospatial/ABI contract — to name it. A synthetic-vision projection
+  reference and the calibration artifact it points at are therefore the **same**
+  type over one identity space, not two mirrored `u32`s a lossy conversion could
+  drift apart. Uniqueness is enforced two ways: a compile-time coercion in each
+  re-exporting crate proves its `CalibrationId` is the leaf's, and a repository
+  guard (in `check-structure.sh`, run in CI) fails the build if a second
+  `struct CalibrationId` is defined anywhere in the tree. Geometry, lifecycle,
+  content hash, and the alignment budget stay authoritative in the calibration
+  artifact; geo's [`CalibrationRef`] carries only the shared id plus the
+  artifact's content hash. (The vertical-datum vocabulary is still *mirror*ed
+  rather than shared — that mirror exists to avoid a dependency on a consumer,
+  `instrument-state`; the calibration id has no such direction problem, so it is
+  shared outright.)
 
 - **Availability is derived, never self-reported.** The wire carries **no**
   availability. A frame decodes to a [`ValidatedSvsFrame`] whose
   [`SvsAvailability`] is *computed* from the validated inputs: position and
   attitude health from the **worse** of their integrity and their accuracy
   (position 1-sigma in millimeters, attitude 1-sigma in milliradians, against
-  degrade/fail thresholds), time/coherence from the age, future-sample check,
+  degrade/fail limits), time/coherence from the age, future-sample check,
   and coherent-snapshot binding against the frame reference time; only the
   inputs the contract cannot check (navigation-integrity monitor, calibration,
   database, coverage, renderer) are producer-stated. `assess` maps input health
@@ -91,6 +106,40 @@ SIM / NOT FOR FLIGHT.
   inaccurate, or incoherent input can never yield an available scene, and there
   is no wire byte a producer could set to claim otherwise.
 
+- **The freshness and accuracy limits are an explicit [`AvailabilityProfile`],
+  chosen by the receiver, off the wire.** The degrade/fail limits are not baked
+  into the derivation: they live in an [`AvailabilityProfile`] (identity, version,
+  and four validated limit pairs — freshness age, usable age, position accuracy,
+  attitude accuracy) that the caller passes at the validation/decode boundary
+  (`RawSvsFrame::validate(&profile)`, `decode_frame(buf, &profile)`). The fields
+  are **private**: the only ways to obtain a profile are the checked
+  [`AvailabilityProfile::new`] and the controlled [`AvailabilityProfile::simulator`],
+  so a struct literal cannot skip the check (a `compile_fail` doctest pins that a
+  direct construction does not compile). `new` rejects a zero or non-monotonic
+  pair (a *fresh* limit must be strictly tighter than its *usable* limit) with a
+  typed [`GeoError::InvalidAvailabilityProfile`], so a profile can never admit a
+  reading it should reject. There is deliberately **no** `Default` and no free
+  function that picks a profile: SIM limits are never presented as operational
+  limits by omission, and the SIM constants are not a public surface — the profile
+  and its accessors are. The current SIM allocation is one named profile,
+  [`AvailabilityProfile::simulator`] (its limits pinned by independent golden
+  literals, not by the numbers it is built from); a flight or orbital function
+  would be a different named profile with its own limits. The selected profile's identity is
+  bound into the [`ValidatedSvsFrame`] (`profile()`), so a verdict is traceable to
+  the exact limits that produced it.
+
+  **The profile is receiver-controlled evaluation context, not producer data, so
+  it stays off the wire and ABI v2 is unchanged.** The bytes are what the producer
+  measured; the limits are the receiver's intended-function policy, and the same
+  block can legitimately be judged available under one function and unavailable
+  under a stricter one. Encoding never serialized availability and still does not
+  serialize the profile: `encode_frame` takes no profile, the byte layout and
+  `ABI_VERSION` are untouched, and decoding one block under two profiles yields
+  the identical parsed position/attitude/view with only the derived verdict (and
+  the bound profile identity) differing. The alternative — stamping a profile id
+  onto the wire — was rejected: it would let a producer's declared policy override
+  a receiver's, which inverts who is allowed to decide a scene is safe to draw.
+
 - **TAWS is an independent input.** A [`TawsAlert`] is a separate type with its
   own source stamp; nothing derives a TAWS alert from the SVS scene or folds SVS
   availability into a terrain hazard. The availability API's signature contains
@@ -98,15 +147,16 @@ SIM / NOT FOR FLIGHT.
 
 - **The ABI is versioned, fixed-size, and fail-closed.** One frame encodes to a
   fixed little-endian byte block led by a version `u32`; the length must match
-  exactly (trailing bytes are as suspect as truncation). [`decode_frame`]
-  refuses a wrong length, an unsupported version, an enumerated value outside
-  its known set (reporting the actual value), a non-finite coordinate, a
-  non-unit aircraft attitude, an incomplete datum identity (an MSL height with
-  no geoid, an AGL height with no terrain reference, a barometric-indicated
-  height with no applied setting, a NAD83/ITRF datum with no realization), and
-  an incomplete calibration reference. Only a [`ValidatedSvsFrame`] can be
-  encoded, so an invalid frame cannot be serialized; encoding is
-  allocation-free.
+  exactly (trailing bytes are as suspect as truncation). [`decode_frame`] takes
+  the receiver's evaluation profile (which drives only the derived verdict, never
+  how the bytes are parsed) and refuses a wrong length, an unsupported version,
+  an enumerated value outside its known set (reporting the actual value), a
+  non-finite coordinate, a non-unit aircraft attitude, an incomplete datum
+  identity (an MSL height with no geoid, an AGL height with no terrain reference,
+  a barometric-indicated height with no applied setting, a NAD83/ITRF datum with
+  no realization), and an incomplete calibration reference. Only a
+  [`ValidatedSvsFrame`] can be encoded, so an invalid frame cannot be serialized;
+  encoding is allocation-free.
 
 ## Consequences
 
@@ -116,6 +166,16 @@ SIM / NOT FOR FLIGHT.
   with a traceable reason, never a plausible normal scene.
 - A renderer and a transport can be swapped without touching the contract; the
   frame ABI is their only coupling and it is versioned.
+- The same wire frame can be evaluated under different intended-function limits
+  by choosing a different [`AvailabilityProfile`] at the receiver; SIM limits are
+  one named profile, never a silent default, and the profile the verdict was
+  judged against travels with the verdict. Because the profile is off the wire,
+  ABI v2 bytes are unchanged.
+- There is one `CalibrationId` in the program, owned by a shared `no_std` leaf
+  crate and re-exported by both geo and adapter-api, so a projection reference and
+  a calibration artifact cannot drift into two identity spaces and adapter-api does
+  not pull the geospatial contract to name a `u32`; per-crate compile-time
+  coercions and a repository guard fail the build if a second definition appears.
 - The vertical-datum vocabulary duplicates instrument-state's `AltitudeClass`
   intentionally (dependency direction), pinned by the documented mapping table;
   if either changes, the mapping is the place they are reconciled.

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -148,9 +148,38 @@ check_function_length() {
     done < <(collect_rs_files)
 }
 
+# There must be exactly one `CalibrationId` type in the program, in the
+# dependency-free leaf; every other crate re-exports it. A second public or
+# private definition would fork the identity space a projection reference and a
+# calibration artifact must share, so it is forbidden here (the `\b` stops the
+# pattern from matching `CalibrationIdentity`).
+check_calibration_id_uniqueness() {
+    local canonical="./crates/pilotage-calibration-id/src/lib.rs"
+    local matches unexpected file
+    matches=""
+    while IFS= read -r file; do
+        is_excluded_path "$file" && continue
+        if grep -Eq 'struct[[:space:]]+CalibrationId\b' "$file"; then
+            matches="$matches$file"$'\n'
+        fi
+    done < <(collect_rs_files)
+
+    if ! printf '%s' "$matches" | grep -qxF "$canonical"; then
+        echo "FORBIDDEN: canonical CalibrationId not found at $canonical" >&2
+        status=1
+    fi
+    unexpected="$(printf '%s' "$matches" | grep -vxF "$canonical" || true)"
+    while IFS= read -r file; do
+        [ -z "$file" ] && continue
+        echo "FORBIDDEN: $file defines a second CalibrationId; the only definition belongs in $canonical" >&2
+        status=1
+    done <<< "$unexpected"
+}
+
 check_forbidden_filenames
 check_file_length
 check_function_length
+check_calibration_id_uniqueness
 
 if [ "$status" -ne 0 ]; then
     echo "check-structure: FAILED" >&2


### PR DESCRIPTION
GEO-01: explicit availability profiles and one canonical CalibrationId

Refs #72. **SIM / NOT FOR FLIGHT** — this is an engineering contract, not SVS/SVGS approval.

Deliverables in `pilotage-geo` and the new `pilotage-calibration-id` leaf crate, plus the `pilotage-adapter-api` CalibrationId consolidation and an ADR-0022 update. This revision applies the PR #74 review.

## 1. Availability limits are an explicit, receiver-chosen profile

The baked-in SIM threshold constants are now an explicit `AvailabilityProfile` (new `availability/profile.rs`):

- Identity (`AvailabilityProfileId`) + content `version` + four validated limit pairs: freshness age, usable age, position accuracy, attitude accuracy.
- **Fields are private.** The only ways to obtain a profile are the checked `AvailabilityProfile::new(...)` and the controlled `AvailabilityProfile::simulator()`, so a struct literal cannot bypass the monotonicity check. A `compile_fail` doctest pins that a direct construction does not compile. Read access is via accessor methods (`id()`, `version()`, `fresh_age_ns()`, `usable_age_ns()`, `fresh_pos_mm()`, `usable_pos_mm()`, `fresh_att_mrad()`, `usable_att_mrad()`).
- `new` rejects a zero or non-monotonic pair (a *fresh* limit must be strictly tighter than its *usable* limit) with a typed `GeoError::InvalidAvailabilityProfile { field }`.
- **No `Default`, no free function that picks one** — SIM limits are never presented as operational limits by omission. The SIM numbers are no longer public constants (removed `MAX_*` exports); the public surface is the profile + accessors. The current SIM allocation is the one named `AvailabilityProfile::simulator()`.
- Selected at the validation/decode boundary: `RawSvsFrame::validate(&profile)` and `decode_frame(buf, &profile)`; bound into `ValidatedSvsFrame::profile()` for traceability.

**SIM regression tests use independent golden literals** (not the numbers `simulator()` is built from), so both sides can't drift together: `the_simulator_profile_matches_its_golden_limits` asserts the actual values (200_000_000 ns / 1_000_000_000 ns / 5_000 mm / 50_000 mm / 10 mrad / 50 mrad), and `simulator_health_boundaries_are_pinned_to_golden_limits` covers fresh / fresh+1 / usable / usable+1 for age, position, and attitude.

### Wire vs. receiver-context decision — ABI v2 is unchanged

The profile is **receiver-controlled evaluation context, not producer data**, so it stays **off the wire**. Stamping a producer profile id onto the wire was rejected because it would let a producer's policy override a receiver's — inverting who decides a scene is safe to draw.

**ABI-v2-unchanged proof (pinned by test):** `encode_frame` takes no profile; the byte layout and `ABI_VERSION` (still `2`) are untouched; `the_same_wire_bytes_are_judged_by_the_receivers_profile` decodes one identical block under `simulator()` and under a stricter named profile, asserting identical parsed position/attitude/view, different traceable availability, different bound `profile()`, and `encode(under_sim) == encode(under_strict) == original_bytes`.

## 2. One canonical `CalibrationId` in a shared leaf crate

A new dependency-free `no_std` leaf crate, **`pilotage-calibration-id`**, owns the single `CalibrationId`. Both `pilotage-geo` and `pilotage-adapter-api` depend on the leaf and re-export it. adapter-api **no longer depends on the whole `pilotage-geo` crate** — it pulls only the one-`u32` leaf, so the std calibration contract doesn't drag in the geospatial/ABI/TAWS surface to name an id. adapter-api's duplicate `CalibrationId` is deleted; the three `.is_published()` sites became `.is_referenced()`.

**Duplicate guard (two layers):**
- A compile-time coercion in each re-exporting crate (`const _: fn(CalibrationId) -> pilotage_calibration_id::CalibrationId = |id| id;`) proves its `CalibrationId` is the leaf's.
- A repository guard in `scripts/check-structure.sh` (already run in CI) fails the build if a second `struct CalibrationId` is defined anywhere in the tree. Verified it fails on an injected second definition and passes with only the canonical one.

## Gate evidence (all local, on the applied workspace)

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace` | 899 passed, 0 failed |
| `cargo doc -D missing_docs -D rustdoc::broken_intra_doc_links` (leaf, geo, adapter-api) | clean; `compile_fail` doctest passes |
| `cargo build --workspace --release` | ok |
| `scripts/check-structure.sh` | OK (incl. new CalibrationId-uniqueness guard; all files ≤ 500 lines) |
| `cargo build --target thumbv7em-none-eabihf` (leaf + geo) | ok (no_std) |

## Scope notes

- New crate `pilotage-calibration-id` is registered in the root `Cargo.toml` (members + workspace deps). **ci.yml follow-up needed** (owned by another agent this wave): add `pilotage-calibration-id` to the no_std matrix (`.github/workflows/ci.yml` lines ~81-89) and optionally a per-crate test line. Flagging rather than editing per lane ownership; `cargo test --workspace` already covers it and I verified the no_std build locally.
- Did not touch `clients/web` or `ci.yml`. My commit carries only my files plus the specific `Cargo.lock` / root-`Cargo.toml` hunks for the leaf crate and the adapter-api dependency swap; the concurrent svs-db crypto/lock hunks are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
