### PR TITLE
SVS-02: signed, provenance-preserving aeronautical database packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
         # fail-closed versioned ABI for synthetic vision and conformal HUD.
         run: cargo test -p pilotage-geo
 
+      - name: database package integrity (SVS-02)
+        # Signed, provenance-preserving, atomically activated aeronautical
+        # database packages: one-byte mutation fails tile/package verification,
+        # interrupted update yields the prior package or none, and trust-root,
+        # rollback, expiry, coverage, and datum rules fail closed.
+        run: cargo test -p pilotage-svs-db
+
       - name: reference rasterizer frame hashes (REN-03)
         # Re-render the PFD and HSI panels and assert their pinned SHA-256
         # frame hashes, proving the software rasterizer is bit-reproducible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +187,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -248,10 +260,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -290,7 +339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -303,6 +352,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -341,6 +414,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1127,6 +1206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-svs-db"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "pilotage-geo",
+ "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-timing"
 version = "0.1.0"
 
@@ -1135,6 +1224,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1390,6 +1489,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -1482,6 +1590,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -1603,6 +1720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1850,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/pilotage-frames",
     "crates/pilotage-calibration-id",
     "crates/pilotage-geo",
+    "crates/pilotage-svs-db",
     "crates/pilotage-alerts",
     "crates/pilotage-instrument-scene",
     "crates/pilotage-instrument-state",
@@ -44,6 +45,8 @@ tokio = "1.48.0"
 wtransport = "0.7.1"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
+sha2 = "0.10.9"
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 pilotage-timing = { path = "crates/pilotage-timing" }
 pilotage-protocol = { path = "crates/pilotage-protocol" }
 pilotage-authority = { path = "crates/pilotage-authority" }
@@ -52,6 +55,7 @@ pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-frames = { path = "crates/pilotage-frames" }
 pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-geo = { path = "crates/pilotage-geo" }
+pilotage-svs-db = { path = "crates/pilotage-svs-db" }
 pilotage-alerts = { path = "crates/pilotage-alerts" }
 pilotage-instrument-scene = { path = "crates/pilotage-instrument-scene" }
 pilotage-instrument-state = { path = "crates/pilotage-instrument-state" }

--- a/crates/pilotage-svs-db/Cargo.toml
+++ b/crates/pilotage-svs-db/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pilotage-svs-db"
+description = "Signed, provenance-preserving, atomically activated aeronautical database packages for synthetic vision (SVS-02, SIM / NOT FOR FLIGHT)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-geo = { workspace = true }
+thiserror = { workspace = true }
+sha2 = { workspace = true }
+ed25519-dalek = { workspace = true }

--- a/crates/pilotage-svs-db/src/activation.rs
+++ b/crates/pilotage-svs-db/src/activation.rs
@@ -19,16 +19,18 @@ use crate::error::{DbError, DbUnavailable};
 use crate::identity::ActiveDbId;
 use crate::identity::DayNumber;
 use crate::manifest::PackageManifest;
-use crate::tile::CandidatePackage;
+use crate::tile::{CandidatePackage, Tile};
 use crate::trust::TrustRoot;
 use crate::verify::{UsePolicy, VerifiedPackage, verify_package};
 
-/// The currently active, fully verified package. Minted only from a
-/// [`VerifiedPackage`] token, so an active package is always one that passed
-/// verification.
+/// The currently active, fully verified package: its manifest and its verified
+/// tiles as one unit. Minted only from a [`VerifiedPackage`] token, so an active
+/// package is always one that passed verification and whose tiles are exactly
+/// the verified ones — never a mix across versions.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActivePackage {
     manifest: PackageManifest,
+    tiles: Vec<Tile>,
 }
 
 impl ActivePackage {
@@ -38,20 +40,41 @@ impl ActivePackage {
         &self.manifest
     }
 
+    /// The active tile content.
+    #[must_use]
+    pub fn tiles(&self) -> &[Tile] {
+        &self.tiles
+    }
+
     /// The active-database id, for output and diagnostics.
     #[must_use]
     pub fn id(&self) -> ActiveDbId {
         self.manifest.active_id()
     }
 
-    /// Whether the active package covers a position, mapping a coverage exit to
-    /// the typed reason a consumer surfaces.
+    /// Whether the package is within its effectivity/expiry window at `now`.
+    #[must_use]
+    pub fn is_current(&self, now: DayNumber) -> bool {
+        !self.manifest.effectivity.is_before_effective(now)
+            && !self.manifest.effectivity.is_after_expiry(now)
+    }
+
+    /// The availability of this package at a time and a position, failing closed
+    /// on a currency lapse (not yet effective, or expired) **before** any
+    /// coverage check, then on a coverage exit.
     ///
     /// # Errors
     ///
-    /// [`DbUnavailable::Coverage`] when the position lies outside the covered
-    /// region.
-    pub fn availability_for_position(&self, pos: &GeodeticPosition) -> Result<(), DbUnavailable> {
+    /// [`DbUnavailable::Currency`] when outside the effectivity/expiry window,
+    /// or [`DbUnavailable::Coverage`] when the position is outside coverage.
+    pub fn availability(
+        &self,
+        now: DayNumber,
+        pos: &GeodeticPosition,
+    ) -> Result<(), DbUnavailable> {
+        if !self.is_current(now) {
+            return Err(DbUnavailable::Currency);
+        }
         if self.manifest.coverage.region.contains(pos) {
             Ok(())
         } else {
@@ -96,12 +119,14 @@ impl PackageStore {
         }
     }
 
-    /// Installs an already-verified package, replacing any prior one with a
-    /// single assignment (the atomic swap). Returns the new active id.
+    /// Installs an already-verified package — its manifest and verified tiles
+    /// together — replacing any prior one with a single assignment (the atomic
+    /// swap). The manifest and tiles move as one unit, so a torn update can only
+    /// ever leave the complete prior package or the complete new one. Returns
+    /// the new active id.
     pub fn activate(&mut self, verified: VerifiedPackage) -> ActiveDbId {
-        let active = ActivePackage {
-            manifest: verified.into_manifest(),
-        };
+        let (manifest, tiles) = verified.into_parts();
+        let active = ActivePackage { manifest, tiles };
         let id = active.id();
         self.active = Some(active);
         id
@@ -126,21 +151,26 @@ impl PackageStore {
         Ok(self.activate(verified))
     }
 
-    /// The availability of the active database at a position: the active id on
-    /// success, or the typed reason a consumer maps onto
-    /// [`pilotage_geo::AvailabilityReason`] (no package, or a coverage exit).
+    /// The availability of the active database at the current day and a
+    /// position: the active id on success, or the typed reason a consumer maps
+    /// onto [`pilotage_geo::AvailabilityReason`]. Currency is re-checked here at
+    /// use time, so a package that was current at activation but has since
+    /// expired fails closed rather than being served indefinitely.
     ///
     /// # Errors
     ///
-    /// [`DbUnavailable::NoPackage`] when nothing is active, or
-    /// [`DbUnavailable::Coverage`] when the position is outside coverage.
-    pub fn availability_for_position(
+    /// [`DbUnavailable::NoPackage`] when nothing is active,
+    /// [`DbUnavailable::Currency`] when the active package is outside its
+    /// effectivity/expiry window, or [`DbUnavailable::Coverage`] when the
+    /// position is outside coverage.
+    pub fn availability(
         &self,
+        now: DayNumber,
         pos: &GeodeticPosition,
     ) -> Result<ActiveDbId, DbUnavailable> {
         match &self.active {
             None => Err(DbUnavailable::NoPackage),
-            Some(active) => active.availability_for_position(pos).map(|()| active.id()),
+            Some(active) => active.availability(now, pos).map(|()| active.id()),
         }
     }
 }

--- a/crates/pilotage-svs-db/src/activation.rs
+++ b/crates/pilotage-svs-db/src/activation.rs
@@ -1,0 +1,149 @@
+//! Atomic activation: a pure validate-then-swap over an in-memory store.
+//!
+//! Activation is two phases. [`verify_package`] validates a candidate in full
+//! and returns a [`VerifiedPackage`] token without touching the store;
+//! [`PackageStore::activate`] takes that token and installs it with a single
+//! assignment. The store therefore only ever holds a complete, verified package
+//! or the complete prior one — an interruption between the phases leaves the
+//! prior package intact, and a failed verification never reaches the swap. There
+//! is no observable partial or mixed-version state.
+//!
+//! The store is pure state: no file or network I/O lives here, so the whole
+//! transition is exercised with in-memory fixtures. The airborne/runtime path
+//! reads the active id and answers coverage queries; it does not download or
+//! mutate the database.
+
+use pilotage_geo::GeodeticPosition;
+
+use crate::error::{DbError, DbUnavailable};
+use crate::identity::ActiveDbId;
+use crate::identity::DayNumber;
+use crate::manifest::PackageManifest;
+use crate::tile::CandidatePackage;
+use crate::trust::TrustRoot;
+use crate::verify::{UsePolicy, VerifiedPackage, verify_package};
+
+/// The currently active, fully verified package. Minted only from a
+/// [`VerifiedPackage`] token, so an active package is always one that passed
+/// verification.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActivePackage {
+    manifest: PackageManifest,
+}
+
+impl ActivePackage {
+    /// The active manifest.
+    #[must_use]
+    pub fn manifest(&self) -> &PackageManifest {
+        &self.manifest
+    }
+
+    /// The active-database id, for output and diagnostics.
+    #[must_use]
+    pub fn id(&self) -> ActiveDbId {
+        self.manifest.active_id()
+    }
+
+    /// Whether the active package covers a position, mapping a coverage exit to
+    /// the typed reason a consumer surfaces.
+    ///
+    /// # Errors
+    ///
+    /// [`DbUnavailable::Coverage`] when the position lies outside the covered
+    /// region.
+    pub fn availability_for_position(&self, pos: &GeodeticPosition) -> Result<(), DbUnavailable> {
+        if self.manifest.coverage.region.contains(pos) {
+            Ok(())
+        } else {
+            Err(DbUnavailable::Coverage)
+        }
+    }
+}
+
+/// The in-memory active-package store. Holds at most one active package;
+/// activation replaces it atomically.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PackageStore {
+    active: Option<ActivePackage>,
+}
+
+impl PackageStore {
+    /// An empty store with no active package.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { active: None }
+    }
+
+    /// The active package, if any.
+    #[must_use]
+    pub fn active(&self) -> Option<&ActivePackage> {
+        self.active.as_ref()
+    }
+
+    /// The active-database id, if any, to carry into rendered output and
+    /// diagnostics.
+    #[must_use]
+    pub fn active_id(&self) -> Option<ActiveDbId> {
+        self.active.as_ref().map(ActivePackage::id)
+    }
+
+    /// A one-line diagnostic naming the active database, or its absence.
+    #[must_use]
+    pub fn diagnostic_line(&self) -> String {
+        match self.active_id() {
+            Some(id) => format!("active database {id}"),
+            None => "no active database".to_string(),
+        }
+    }
+
+    /// Installs an already-verified package, replacing any prior one with a
+    /// single assignment (the atomic swap). Returns the new active id.
+    pub fn activate(&mut self, verified: VerifiedPackage) -> ActiveDbId {
+        let active = ActivePackage {
+            manifest: verified.into_manifest(),
+        };
+        let id = active.id();
+        self.active = Some(active);
+        id
+    }
+
+    /// Verifies a candidate against the trust root, the current day, and the
+    /// active id (for rollback), then activates it. On any failure the store is
+    /// left holding the prior package (or nothing) unchanged — the swap is
+    /// reached only after full verification succeeds.
+    ///
+    /// # Errors
+    ///
+    /// The [`DbError`] from verification; the store is untouched in that case.
+    pub fn stage_and_activate(
+        &mut self,
+        candidate: &CandidatePackage,
+        trust: &TrustRoot,
+        now: DayNumber,
+        policy: UsePolicy,
+    ) -> Result<ActiveDbId, DbError> {
+        let verified = verify_package(candidate, trust, now, self.active_id(), policy)?;
+        Ok(self.activate(verified))
+    }
+
+    /// The availability of the active database at a position: the active id on
+    /// success, or the typed reason a consumer maps onto
+    /// [`pilotage_geo::AvailabilityReason`] (no package, or a coverage exit).
+    ///
+    /// # Errors
+    ///
+    /// [`DbUnavailable::NoPackage`] when nothing is active, or
+    /// [`DbUnavailable::Coverage`] when the position is outside coverage.
+    pub fn availability_for_position(
+        &self,
+        pos: &GeodeticPosition,
+    ) -> Result<ActiveDbId, DbUnavailable> {
+        match &self.active {
+            None => Err(DbUnavailable::NoPackage),
+            Some(active) => active.availability_for_position(pos).map(|()| active.id()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/activation.rs
+++ b/crates/pilotage-svs-db/src/activation.rs
@@ -84,17 +84,23 @@ impl ActivePackage {
 }
 
 /// The in-memory active-package store. Holds at most one active package;
-/// activation replaces it atomically.
+/// activation replaces it atomically. A monotonic `generation` counter advances
+/// on every successful activation, so a verification token minted against an
+/// earlier state can be detected and refused.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PackageStore {
     active: Option<ActivePackage>,
+    generation: u64,
 }
 
 impl PackageStore {
     /// An empty store with no active package.
     #[must_use]
     pub fn new() -> Self {
-        Self { active: None }
+        Self {
+            active: None,
+            generation: 0,
+        }
     }
 
     /// The active package, if any.
@@ -119,23 +125,58 @@ impl PackageStore {
         }
     }
 
+    /// Verifies a candidate against the trust root, the current day, and the
+    /// store's current state, minting a token stamped with the state it was
+    /// verified against. The token is only installable while the store is still
+    /// in that state.
+    ///
+    /// # Errors
+    ///
+    /// The [`DbError`] from verification.
+    pub(crate) fn verify(
+        &self,
+        candidate: &CandidatePackage,
+        trust: &TrustRoot,
+        now: DayNumber,
+        policy: UsePolicy,
+    ) -> Result<VerifiedPackage, DbError> {
+        verify_package(candidate, trust, now, self.active_id(), policy)
+            .map(|token| token.stamp_generation(self.generation))
+    }
+
     /// Installs an already-verified package — its manifest and verified tiles
     /// together — replacing any prior one with a single assignment (the atomic
-    /// swap). The manifest and tiles move as one unit, so a torn update can only
-    /// ever leave the complete prior package or the complete new one. Returns
-    /// the new active id.
-    pub fn activate(&mut self, verified: VerifiedPackage) -> ActiveDbId {
+    /// swap) and advancing the generation. The token is refused with
+    /// [`DbError::StaleActivation`] if the store has changed since it was
+    /// verified, so a replayed token cannot roll the active package backward;
+    /// the existing active package is then left unchanged.
+    ///
+    /// # Errors
+    ///
+    /// [`DbError::StaleActivation`] when the token's expected state no longer
+    /// matches the store.
+    pub(crate) fn activate(&mut self, verified: VerifiedPackage) -> Result<ActiveDbId, DbError> {
+        if verified.expected_generation() != self.generation
+            || verified.expected_active() != self.active_id()
+        {
+            return Err(DbError::StaleActivation {
+                expected_generation: verified.expected_generation(),
+                actual_generation: self.generation,
+            });
+        }
         let (manifest, tiles) = verified.into_parts();
         let active = ActivePackage { manifest, tiles };
         let id = active.id();
         self.active = Some(active);
-        id
+        self.generation = self.generation.wrapping_add(1);
+        Ok(id)
     }
 
     /// Verifies a candidate against the trust root, the current day, and the
-    /// active id (for rollback), then activates it. On any failure the store is
-    /// left holding the prior package (or nothing) unchanged — the swap is
-    /// reached only after full verification succeeds.
+    /// active id (for rollback), then activates it — atomically, in one call, so
+    /// there is no reusable token to replay. On any failure the store is left
+    /// holding the prior package (or nothing) unchanged; the swap is reached
+    /// only after full verification succeeds.
     ///
     /// # Errors
     ///
@@ -147,8 +188,8 @@ impl PackageStore {
         now: DayNumber,
         policy: UsePolicy,
     ) -> Result<ActiveDbId, DbError> {
-        let verified = verify_package(candidate, trust, now, self.active_id(), policy)?;
-        Ok(self.activate(verified))
+        let verified = self.verify(candidate, trust, now, policy)?;
+        self.activate(verified)
     }
 
     /// The availability of the active database at the current day and a

--- a/crates/pilotage-svs-db/src/activation/tests.rs
+++ b/crates/pilotage-svs-db/src/activation/tests.rs
@@ -4,23 +4,45 @@
 
 use pilotage_geo::AvailabilityReason;
 
-use super::PackageStore;
+use super::{ActivePackage, PackageStore};
 use crate::error::DbUnavailable;
 use crate::fixtures;
-use crate::identity::{DatasetId, PackageVersion};
+use crate::identity::{DatasetId, DayNumber, PackageVersion};
+use crate::tile::CandidatePackage;
 use crate::verify::{UsePolicy, verify_package};
 
-fn v1() -> crate::tile::CandidatePackage {
+/// Uniform tile-payload tag for version 1, so v1 and v2 content is disjoint.
+const TAG_V1: u8 = 0x11;
+/// Uniform tile-payload tag for version 2.
+const TAG_V2: u8 = 0x22;
+
+fn v1() -> CandidatePackage {
     fixtures::candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), true)
 }
 
-fn v2() -> crate::tile::CandidatePackage {
+fn v2() -> CandidatePackage {
     fixtures::candidate_with(DatasetId(1), PackageVersion::new(2, 0, 0), true)
 }
 
-fn tampered(mut candidate: crate::tile::CandidatePackage) -> crate::tile::CandidatePackage {
+fn v1_tagged() -> CandidatePackage {
+    fixtures::candidate_tagged(DatasetId(1), PackageVersion::new(1, 0, 0), TAG_V1)
+}
+
+fn v2_tagged() -> CandidatePackage {
+    fixtures::candidate_tagged(DatasetId(1), PackageVersion::new(2, 0, 0), TAG_V2)
+}
+
+fn tampered(mut candidate: CandidatePackage) -> CandidatePackage {
     candidate.tiles[0].bytes[0] ^= 0x01;
     candidate
+}
+
+fn all_tiles_have_tag(active: &ActivePackage, tag: u8) -> bool {
+    !active.tiles().is_empty()
+        && active
+            .tiles()
+            .iter()
+            .all(|t| t.bytes.iter().all(|&b| b == tag))
 }
 
 /// Acceptance: an interrupted update yields the complete prior package or no
@@ -121,7 +143,7 @@ fn a_position_inside_coverage_returns_the_active_id() {
         )
         .expect("v1 activates");
     let inside = fixtures::position(40.5, -74.5);
-    assert_eq!(store.availability_for_position(&inside), Ok(id));
+    assert_eq!(store.availability(fixtures::NOW, &inside), Ok(id));
 }
 
 #[test]
@@ -137,7 +159,7 @@ fn a_position_outside_coverage_is_a_coverage_exit() {
         .expect("v1 activates");
     let outside = fixtures::position(0.0, 0.0);
     let reason = store
-        .availability_for_position(&outside)
+        .availability(fixtures::NOW, &outside)
         .expect_err("outside coverage");
     assert_eq!(reason, DbUnavailable::Coverage);
     assert_eq!(
@@ -150,12 +172,107 @@ fn a_position_outside_coverage_is_a_coverage_exit() {
 fn no_active_package_is_a_database_fault() {
     let store = PackageStore::new();
     let reason = store
-        .availability_for_position(&fixtures::position(40.5, -74.5))
+        .availability(fixtures::NOW, &fixtures::position(40.5, -74.5))
         .expect_err("no package");
     assert_eq!(reason, DbUnavailable::NoPackage);
     assert_eq!(
         reason.to_availability_reason(),
         AvailabilityReason::Database
+    );
+}
+
+/// Acceptance (data level): a torn/interrupted update yields the complete prior
+/// tile content or the complete new tile content, never a mix. v1 and v2 carry
+/// disjoint tile payloads, so any residual bytes from the other version would be
+/// visible.
+#[test]
+fn interrupted_update_preserves_complete_content_never_a_mix() {
+    let trust = fixtures::trust_root();
+    let mut store = PackageStore::new();
+    store
+        .stage_and_activate(
+            &v1_tagged(),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    assert!(all_tiles_have_tag(store.active().expect("active"), TAG_V1));
+
+    // A torn update (tampered v2) fails; the complete v1 content stays, with no
+    // v2 bytes bleeding in.
+    store
+        .stage_and_activate(
+            &tampered(v2_tagged()),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect_err("tampered v2 fails");
+    let active = store.active().expect("active");
+    assert!(all_tiles_have_tag(active, TAG_V1), "prior content intact");
+    assert!(
+        !active.tiles().iter().any(|t| t.bytes.contains(&TAG_V2)),
+        "no torn v2 content mixed in"
+    );
+
+    // A verified token held but not yet installed leaves the complete v1 content
+    // in place; the swap then installs the complete v2 content with no v1 bytes.
+    let token = verify_package(
+        &v2_tagged(),
+        &trust,
+        fixtures::NOW,
+        store.active_id(),
+        UsePolicy::SimulatorPermitted,
+    )
+    .expect("v2 verifies");
+    assert!(
+        all_tiles_have_tag(store.active().expect("active"), TAG_V1),
+        "still complete v1 before the swap"
+    );
+    store.activate(token);
+    let active = store.active().expect("active");
+    assert!(
+        all_tiles_have_tag(active, TAG_V2),
+        "complete v2 content after swap"
+    );
+    assert!(
+        !active.tiles().iter().any(|t| t.bytes.contains(&TAG_V1)),
+        "no residual v1 content"
+    );
+}
+
+/// Acceptance: currency is re-checked at use time. A package current at
+/// activation fails closed once the query time is outside its effectivity/expiry
+/// window, rather than being served indefinitely.
+#[test]
+fn currency_is_rechecked_at_use_time() {
+    let mut store = PackageStore::new();
+    let id = store
+        .stage_and_activate(
+            &v1(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    let inside = fixtures::position(40.5, -74.5);
+
+    assert_eq!(store.availability(fixtures::NOW, &inside), Ok(id));
+
+    let expired = store
+        .availability(DayNumber(250), &inside)
+        .expect_err("expired at use time");
+    assert_eq!(expired, DbUnavailable::Currency);
+    assert_eq!(
+        expired.to_availability_reason(),
+        AvailabilityReason::Database
+    );
+
+    assert_eq!(
+        store.availability(DayNumber(50), &inside),
+        Err(DbUnavailable::Currency),
+        "not yet effective also fails closed"
     );
 }
 

--- a/crates/pilotage-svs-db/src/activation/tests.rs
+++ b/crates/pilotage-svs-db/src/activation/tests.rs
@@ -1,0 +1,184 @@
+//! Tests for atomic activation, diagnostics, and coverage availability.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pilotage_geo::AvailabilityReason;
+
+use super::PackageStore;
+use crate::error::DbUnavailable;
+use crate::fixtures;
+use crate::identity::{DatasetId, PackageVersion};
+use crate::verify::{UsePolicy, verify_package};
+
+fn v1() -> crate::tile::CandidatePackage {
+    fixtures::candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), true)
+}
+
+fn v2() -> crate::tile::CandidatePackage {
+    fixtures::candidate_with(DatasetId(1), PackageVersion::new(2, 0, 0), true)
+}
+
+fn tampered(mut candidate: crate::tile::CandidatePackage) -> crate::tile::CandidatePackage {
+    candidate.tiles[0].bytes[0] ^= 0x01;
+    candidate
+}
+
+/// Acceptance: an interrupted update yields the complete prior package or no
+/// package, never a partial or mixed-version mix. Verification is pure and the
+/// swap is a single assignment, so a failure never reaches the swap and a
+/// verified-but-not-yet-installed token leaves the prior package intact.
+#[test]
+fn interrupted_update_yields_prior_or_no_package() {
+    let trust = fixtures::trust_root();
+
+    // A failed update leaves the prior complete package active.
+    let mut store = PackageStore::new();
+    let id1 = store
+        .stage_and_activate(&v1(), &trust, fixtures::NOW, UsePolicy::SimulatorPermitted)
+        .expect("v1 activates");
+    let err = store
+        .stage_and_activate(
+            &tampered(v2()),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect_err("tampered update fails");
+    assert_eq!(err.to_availability_reason(), AvailabilityReason::Database);
+    assert_eq!(store.active_id(), Some(id1), "prior package must be intact");
+
+    // A failed first update leaves no package, never a partial one.
+    let mut empty = PackageStore::new();
+    assert!(
+        empty
+            .stage_and_activate(
+                &tampered(v1()),
+                &trust,
+                fixtures::NOW,
+                UsePolicy::SimulatorPermitted,
+            )
+            .is_err()
+    );
+    assert_eq!(empty.active_id(), None, "no partial package on failure");
+
+    // Two-phase: a verified token is held but not yet installed — the swap is
+    // the only mutation, so the prior package remains active until it happens.
+    let token = verify_package(
+        &v2(),
+        &trust,
+        fixtures::NOW,
+        store.active_id(),
+        UsePolicy::SimulatorPermitted,
+    )
+    .expect("v2 verifies");
+    assert_eq!(store.active_id(), Some(id1), "prior intact before the swap");
+    let id2 = store.activate(token);
+    assert_eq!(
+        store.active_id(),
+        Some(id2),
+        "swap installed the new package"
+    );
+    assert_ne!(id1, id2);
+}
+
+/// Acceptance: the active-database id is carried into diagnostics and is
+/// available as an accessor for rendered output.
+#[test]
+fn active_database_id_carried_into_diagnostics() {
+    let mut store = PackageStore::new();
+    assert_eq!(store.active_id(), None);
+    assert_eq!(store.diagnostic_line(), "no active database");
+
+    let id = store
+        .stage_and_activate(
+            &v1(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    assert_eq!(store.active_id(), Some(id));
+    assert_eq!(store.active().expect("active").id(), id);
+
+    let line = store.diagnostic_line();
+    assert!(
+        line.contains(&format!("{id}")),
+        "diagnostic names the id: {line}"
+    );
+    // A simulator package renders its marker so it can never pass as operational.
+    assert!(format!("{id}").ends_with("SIM"));
+}
+
+#[test]
+fn a_position_inside_coverage_returns_the_active_id() {
+    let mut store = PackageStore::new();
+    let id = store
+        .stage_and_activate(
+            &v1(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    let inside = fixtures::position(40.5, -74.5);
+    assert_eq!(store.availability_for_position(&inside), Ok(id));
+}
+
+#[test]
+fn a_position_outside_coverage_is_a_coverage_exit() {
+    let mut store = PackageStore::new();
+    store
+        .stage_and_activate(
+            &v1(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    let outside = fixtures::position(0.0, 0.0);
+    let reason = store
+        .availability_for_position(&outside)
+        .expect_err("outside coverage");
+    assert_eq!(reason, DbUnavailable::Coverage);
+    assert_eq!(
+        reason.to_availability_reason(),
+        AvailabilityReason::Coverage
+    );
+}
+
+#[test]
+fn no_active_package_is_a_database_fault() {
+    let store = PackageStore::new();
+    let reason = store
+        .availability_for_position(&fixtures::position(40.5, -74.5))
+        .expect_err("no package");
+    assert_eq!(reason, DbUnavailable::NoPackage);
+    assert_eq!(
+        reason.to_availability_reason(),
+        AvailabilityReason::Database
+    );
+}
+
+#[test]
+fn activation_replaces_the_prior_package() {
+    let mut store = PackageStore::new();
+    let id1 = store
+        .stage_and_activate(
+            &v1(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+    let id2 = store
+        .stage_and_activate(
+            &v2(),
+            &fixtures::trust_root(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v2 activates");
+    assert_ne!(id1, id2);
+    assert_eq!(store.active_id(), Some(id2));
+    assert_eq!(id2.version, PackageVersion::new(2, 0, 0));
+}

--- a/crates/pilotage-svs-db/src/activation/tests.rs
+++ b/crates/pilotage-svs-db/src/activation/tests.rs
@@ -5,11 +5,11 @@
 use pilotage_geo::AvailabilityReason;
 
 use super::{ActivePackage, PackageStore};
-use crate::error::DbUnavailable;
+use crate::error::{DbError, DbUnavailable};
 use crate::fixtures;
 use crate::identity::{DatasetId, DayNumber, PackageVersion};
 use crate::tile::CandidatePackage;
-use crate::verify::{UsePolicy, verify_package};
+use crate::verify::UsePolicy;
 
 /// Uniform tile-payload tag for version 1, so v1 and v2 content is disjoint.
 const TAG_V1: u8 = 0x11;
@@ -85,16 +85,13 @@ fn interrupted_update_yields_prior_or_no_package() {
 
     // Two-phase: a verified token is held but not yet installed — the swap is
     // the only mutation, so the prior package remains active until it happens.
-    let token = verify_package(
-        &v2(),
-        &trust,
-        fixtures::NOW,
-        store.active_id(),
-        UsePolicy::SimulatorPermitted,
-    )
-    .expect("v2 verifies");
+    let token = store
+        .verify(&v2(), &trust, fixtures::NOW, UsePolicy::SimulatorPermitted)
+        .expect("v2 verifies");
     assert_eq!(store.active_id(), Some(id1), "prior intact before the swap");
-    let id2 = store.activate(token);
+    let id2 = store
+        .activate(token)
+        .expect("swap installs the new package");
     assert_eq!(
         store.active_id(),
         Some(id2),
@@ -218,19 +215,19 @@ fn interrupted_update_preserves_complete_content_never_a_mix() {
 
     // A verified token held but not yet installed leaves the complete v1 content
     // in place; the swap then installs the complete v2 content with no v1 bytes.
-    let token = verify_package(
-        &v2_tagged(),
-        &trust,
-        fixtures::NOW,
-        store.active_id(),
-        UsePolicy::SimulatorPermitted,
-    )
-    .expect("v2 verifies");
+    let token = store
+        .verify(
+            &v2_tagged(),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v2 verifies");
     assert!(
         all_tiles_have_tag(store.active().expect("active"), TAG_V1),
         "still complete v1 before the swap"
     );
-    store.activate(token);
+    store.activate(token).expect("swap installs v2");
     let active = store.active().expect("active");
     assert!(
         all_tiles_have_tag(active, TAG_V2),
@@ -273,6 +270,49 @@ fn currency_is_rechecked_at_use_time() {
         store.availability(DayNumber(50), &inside),
         Err(DbUnavailable::Currency),
         "not yet effective also fails closed"
+    );
+}
+
+/// Acceptance (fail-closed): a stale verification token cannot roll the active
+/// package backward. A token verified against the empty store is refused once a
+/// different package has been activated, and the active package (id and content)
+/// is left unchanged. The only public activation path is the atomic
+/// `stage_and_activate`; the raw token swap is crate-internal and CAS-guarded.
+#[test]
+fn stale_verification_token_cannot_roll_back_the_active_package() {
+    let trust = fixtures::trust_root();
+    let mut store = PackageStore::new();
+
+    // Verify v1 against the empty store and hold the token.
+    let v1_token = store
+        .verify(
+            &v1_tagged(),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 verifies");
+
+    // Activate v2 normally.
+    let id2 = store
+        .stage_and_activate(
+            &v2_tagged(),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v2 activates");
+
+    // Replaying the stale v1 token is refused; v2 stays fully active.
+    let err = store
+        .activate(v1_token)
+        .expect_err("stale token must be refused");
+    assert!(matches!(err, DbError::StaleActivation { .. }));
+    assert_eq!(err.to_availability_reason(), AvailabilityReason::Database);
+    assert_eq!(store.active_id(), Some(id2), "v2 id remains");
+    assert!(
+        all_tiles_have_tag(store.active().expect("active"), TAG_V2),
+        "v2 content remains; not rolled back to v1"
     );
 }
 

--- a/crates/pilotage-svs-db/src/canonical.rs
+++ b/crates/pilotage-svs-db/src/canonical.rs
@@ -1,0 +1,114 @@
+//! The canonical byte layout the manifest signature and content hash are taken
+//! over, and the canonical bytes of a tile.
+//!
+//! The layout is fixed, little-endian, and free of timestamps, padding, or
+//! platform-dependent ordering, so the same package always produces the same
+//! bytes and therefore the same hash and the same signature verdict. Following
+//! the controlled-artifact pattern used elsewhere in the tree (a canonical
+//! serialization, a hash the build records, and a verifier that recomputes),
+//! [`manifest_content_hash`] lets a test pin the encoding: any change to the
+//! byte layout changes the recorded hash and fails that test.
+//!
+//! The manifest's signature *bytes* are deliberately excluded from the canonical
+//! form (they are the signature *over* it); the signing key id is included, so
+//! the intended signer is bound into what is signed.
+
+use sha2::{Digest, Sha256};
+
+use crate::manifest::{ContentSpec, Coverage, Effectivity, PackageManifest, Provenance};
+use crate::tile::Tile;
+
+/// Domain-separating magic for a manifest's canonical bytes.
+const MANIFEST_MAGIC: &[u8; 8] = b"SVSDBPKG";
+/// Domain-separating magic for a tile's canonical bytes.
+const TILE_MAGIC: &[u8; 8] = b"SVSDBTIL";
+
+/// The canonical bytes of a manifest, excluding the signature bytes.
+#[must_use]
+pub fn manifest_canonical_bytes(manifest: &PackageManifest) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(MANIFEST_MAGIC);
+    out.extend_from_slice(&manifest.schema_version.to_le_bytes());
+    append_provenance(&mut out, &manifest.provenance);
+    append_effectivity(&mut out, &manifest.effectivity);
+    append_coverage(&mut out, &manifest.coverage);
+    append_content(&mut out, &manifest.content);
+    out.extend_from_slice(&manifest.tile_count.to_le_bytes());
+    out.extend_from_slice(&manifest.tile_root.0);
+    out.push(u8::from(manifest.simulation_only));
+    out.extend_from_slice(&manifest.signature.key_id.0.to_le_bytes());
+    out
+}
+
+/// Appends provenance: dataset, provider, version, the ordered processing
+/// chain, and the use restrictions.
+fn append_provenance(out: &mut Vec<u8>, provenance: &Provenance) {
+    out.extend_from_slice(&provenance.dataset.0.to_le_bytes());
+    out.extend_from_slice(&provenance.provider.0.to_le_bytes());
+    out.extend_from_slice(&provenance.version.major.to_le_bytes());
+    out.extend_from_slice(&provenance.version.minor.to_le_bytes());
+    out.extend_from_slice(&provenance.version.patch.to_le_bytes());
+    let steps = provenance.processing.steps();
+    out.extend_from_slice(&(steps.len() as u64).to_le_bytes());
+    for step in steps {
+        out.extend_from_slice(&step.code.to_le_bytes());
+        out.extend_from_slice(&step.tool_id.to_le_bytes());
+    }
+    out.extend_from_slice(&provenance.restrictions.bits().to_le_bytes());
+}
+
+/// Appends the three effectivity day numbers.
+fn append_effectivity(out: &mut Vec<u8>, effectivity: &Effectivity) {
+    out.extend_from_slice(&effectivity.release.0.to_le_bytes());
+    out.extend_from_slice(&effectivity.effective.0.to_le_bytes());
+    out.extend_from_slice(&effectivity.expiry.0.to_le_bytes());
+}
+
+/// Appends coverage: the bounding box (as IEEE-754 bit patterns), the datum and
+/// its declared identities, and the resolution.
+fn append_coverage(out: &mut Vec<u8>, coverage: &Coverage) {
+    out.extend_from_slice(&coverage.region.min_lat_deg.to_bits().to_le_bytes());
+    out.extend_from_slice(&coverage.region.max_lat_deg.to_bits().to_le_bytes());
+    out.extend_from_slice(&coverage.region.min_lon_deg.to_bits().to_le_bytes());
+    out.extend_from_slice(&coverage.region.max_lon_deg.to_bits().to_le_bytes());
+    out.push(coverage.horizontal_datum.to_u8());
+    out.extend_from_slice(&coverage.realization.0.to_le_bytes());
+    out.push(coverage.vertical_datum.to_u8());
+    out.extend_from_slice(&coverage.geoid.0.to_le_bytes());
+    out.extend_from_slice(&coverage.resolution.post_spacing_mm.to_le_bytes());
+}
+
+/// Appends content: the feature set, accuracy, and integrity level.
+fn append_content(out: &mut Vec<u8>, content: &ContentSpec) {
+    out.extend_from_slice(&content.features.bits().to_le_bytes());
+    out.extend_from_slice(&content.accuracy.horizontal_mm.to_le_bytes());
+    out.extend_from_slice(&content.accuracy.vertical_mm.to_le_bytes());
+    out.push(content.integrity.to_u8());
+}
+
+/// The canonical bytes of a tile: its key bound in front of its payload, so a
+/// tile cannot be relabelled to another key without changing its leaf hash.
+#[must_use]
+pub fn tile_canonical_bytes(tile: &Tile) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(TILE_MAGIC);
+    out.push(tile.key.class.to_u8());
+    out.push(tile.key.level);
+    out.extend_from_slice(&tile.key.tile.lat_index.to_le_bytes());
+    out.extend_from_slice(&tile.key.tile.lon_index.to_le_bytes());
+    out.extend_from_slice(&(tile.bytes.len() as u64).to_le_bytes());
+    out.extend_from_slice(&tile.bytes);
+    out
+}
+
+/// The SHA-256 of a manifest's canonical bytes — the recorded content hash a
+/// test can pin the encoding against.
+#[must_use]
+pub fn manifest_content_hash(manifest: &PackageManifest) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(manifest_canonical_bytes(manifest));
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/canonical/tests.rs
+++ b/crates/pilotage-svs-db/src/canonical/tests.rs
@@ -1,0 +1,70 @@
+//! Tests for the canonical byte layout and the recorded content hash.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use super::{manifest_canonical_bytes, manifest_content_hash, tile_canonical_bytes};
+use crate::fixtures;
+
+fn to_hex(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Pins the canonical encoding: the SHA-256 of the fixture manifest's canonical
+/// bytes is a recorded constant. Any change to the byte layout (field order,
+/// widths, endianness, or which fields are covered) changes this hash and fails
+/// here — the encoding cannot drift silently.
+#[test]
+fn manifest_content_hash_is_stable() {
+    let candidate = fixtures::candidate();
+    let got = to_hex(&manifest_content_hash(&candidate.manifest));
+    let recorded = "253f25080ddce18c905526d61a4e4624e222102dd1a1425f60afeb98ee981815";
+    assert_eq!(got, recorded, "canonical manifest encoding changed");
+}
+
+#[test]
+fn canonical_bytes_are_deterministic() {
+    let candidate = fixtures::candidate();
+    assert_eq!(
+        manifest_canonical_bytes(&candidate.manifest),
+        manifest_canonical_bytes(&candidate.manifest)
+    );
+}
+
+#[test]
+fn mutating_a_manifest_field_changes_the_canonical_bytes() {
+    let candidate = fixtures::candidate();
+    let mut mutated = candidate.manifest.clone();
+    mutated.coverage.region.max_lat_deg += 0.5;
+    assert_ne!(
+        manifest_canonical_bytes(&candidate.manifest),
+        manifest_canonical_bytes(&mutated)
+    );
+}
+
+#[test]
+fn signature_bytes_are_excluded_from_the_canonical_form() {
+    // Changing only the signature bytes must not change what is signed.
+    let candidate = fixtures::candidate();
+    let mut other = candidate.manifest.clone();
+    other.signature.bytes = [0xEE; 64];
+    assert_eq!(
+        manifest_canonical_bytes(&candidate.manifest),
+        manifest_canonical_bytes(&other)
+    );
+}
+
+#[test]
+fn tile_canonical_bytes_bind_the_key() {
+    let tiles = fixtures::tiles();
+    let mut relabelled = tiles[0].clone();
+    relabelled.key = tiles[1].key;
+    // Same payload, different key -> different canonical bytes.
+    assert_ne!(
+        tile_canonical_bytes(&tiles[0]),
+        tile_canonical_bytes(&relabelled)
+    );
+}

--- a/crates/pilotage-svs-db/src/error.rs
+++ b/crates/pilotage-svs-db/src/error.rs
@@ -1,0 +1,194 @@
+//! Typed, fail-closed failure model for database packages.
+//!
+//! Every [`DbError`] variant is a refusal to activate or to serve, never a
+//! repair: a package that cannot be trusted, does not cover the position, is
+//! expired, or is an out-of-policy rollback makes synthetic vision unavailable
+//! rather than drawing a plausible-looking scene. Each error collapses to a
+//! coarse [`DbUnavailable`] category, which a consumer maps onto
+//! [`pilotage_geo::AvailabilityReason`] — `Coverage` when the position simply
+//! left the covered region, `Database` for every integrity, provenance,
+//! currency, and policy failure.
+
+use pilotage_geo::AvailabilityReason;
+
+use crate::feature::FeatureClass;
+use crate::identity::{DayNumber, PackageVersion};
+use crate::trust::TrustKeyId;
+
+/// Why a database package was refused for activation or for a query. A refusal
+/// carries the context its message needs; there is no silent fallback to a
+/// partial or stale package.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DbError {
+    /// The manifest schema version is outside the range this build reads, so
+    /// the package is refused rather than partially parsed.
+    #[error("manifest schema version {version} is outside supported [{min}, {max}]")]
+    IncompatibleManifest {
+        /// The schema version the manifest declared.
+        version: u16,
+        /// Lowest schema version this build reads.
+        min: u16,
+        /// Highest schema version this build reads.
+        max: u16,
+    },
+    /// The package declares no feature class, so it covers nothing.
+    #[error("package declares an empty feature set")]
+    EmptyFeatureSet,
+    /// The horizontal datum is unknown to this build.
+    #[error("manifest horizontal datum is unknown; coverage has no interpretable frame")]
+    UnknownHorizontalDatum,
+    /// The vertical datum is unknown to this build.
+    #[error("manifest vertical datum is unknown; heights have no interpretable reference")]
+    UnknownVerticalDatum,
+    /// A realization-bearing horizontal datum declared no realization.
+    #[error("manifest horizontal datum requires a declared realization/reference epoch")]
+    UndeclaredRealization,
+    /// A geometric-MSL vertical datum declared no geoid model.
+    #[error("manifest geometric-MSL datum requires a declared geoid model")]
+    UndeclaredGeoid,
+    /// The coverage bounding box is non-finite or degenerate.
+    #[error("coverage box is invalid: {reason}")]
+    InvalidCoverage {
+        /// What was wrong with the box.
+        reason: &'static str,
+    },
+    /// The effectivity dates are not ordered `release <= effective <= expiry`.
+    #[error("effectivity dates are not ordered release<=effective<=expiry")]
+    BadEffectivity,
+    /// The current day is before the package becomes effective.
+    #[error("package not yet effective: day {now} is before effective day {effective}")]
+    NotYetEffective {
+        /// The current day number.
+        now: DayNumber,
+        /// The day the package becomes effective.
+        effective: DayNumber,
+    },
+    /// The current day is after the package expires.
+    #[error("package expired: day {now} is after expiry day {expiry}")]
+    Expired {
+        /// The current day number.
+        now: DayNumber,
+        /// The day the package expires.
+        expiry: DayNumber,
+    },
+    /// The number of tiles supplied does not match the manifest.
+    #[error("tile count mismatch: manifest declares {declared}, package supplies {supplied}")]
+    TileCountMismatch {
+        /// Tiles the manifest declares.
+        declared: u32,
+        /// Tiles the package actually supplied.
+        supplied: u32,
+    },
+    /// Two tiles share one key, so the package is ambiguous.
+    #[error("duplicate tile {class:?} at ({lat_index}, {lon_index})")]
+    DuplicateTile {
+        /// The feature class of the duplicated tile.
+        class: FeatureClass,
+        /// Tile latitude index.
+        lat_index: i32,
+        /// Tile longitude index.
+        lon_index: i32,
+    },
+    /// The recomputed tile-root hash does not match the manifest, so at least
+    /// one tile or the declared root was mutated.
+    #[error("tile-root hash mismatch; a tile or the manifest root was mutated")]
+    TileRootMismatch,
+    /// The signing key id is not in the configured trust root.
+    #[error("signing key {key_id} is not a configured trust root")]
+    UntrustedRoot {
+        /// The key id the manifest named.
+        key_id: TrustKeyId,
+    },
+    /// The manifest signature did not verify against the trust root's key.
+    #[error("manifest signature failed verification against the trust root")]
+    SignatureInvalid,
+    /// The candidate is an older version of the active dataset (out-of-policy
+    /// rollback).
+    #[error("rollback blocked: candidate {candidate} is older than active {active}")]
+    RollbackBlocked {
+        /// The active package version.
+        active: PackageVersion,
+        /// The (older) candidate version.
+        candidate: PackageVersion,
+    },
+    /// The package is a permanently-marked simulator fixture and operational
+    /// use was required.
+    #[error("package is simulation_only and cannot be accepted as operational")]
+    SimulationOnlyForbidden,
+}
+
+impl DbError {
+    /// The coarse availability category this refusal collapses to.
+    #[must_use]
+    pub const fn category(&self) -> DbUnavailable {
+        match self {
+            Self::TileCountMismatch { .. } | Self::DuplicateTile { .. } => {
+                DbUnavailable::MissingData
+            }
+            Self::TileRootMismatch => DbUnavailable::Corrupt,
+            Self::UntrustedRoot { .. } | Self::SignatureInvalid => DbUnavailable::Signature,
+            Self::NotYetEffective { .. } | Self::Expired { .. } => DbUnavailable::Currency,
+            Self::IncompatibleManifest { .. } => DbUnavailable::Incompatible,
+            Self::UnknownHorizontalDatum
+            | Self::UnknownVerticalDatum
+            | Self::UndeclaredRealization
+            | Self::UndeclaredGeoid => DbUnavailable::Datum,
+            Self::RollbackBlocked { .. } => DbUnavailable::Rollback,
+            Self::SimulationOnlyForbidden => DbUnavailable::SimulationOnly,
+            Self::EmptyFeatureSet | Self::InvalidCoverage { .. } | Self::BadEffectivity => {
+                DbUnavailable::Malformed
+            }
+        }
+    }
+
+    /// The [`pilotage_geo::AvailabilityReason`] a consumer surfaces for this
+    /// refusal.
+    #[must_use]
+    pub const fn to_availability_reason(&self) -> AvailabilityReason {
+        self.category().to_availability_reason()
+    }
+}
+
+/// The coarse reason synthetic vision is unavailable from the database's point
+/// of view — the typed value a consumer maps onto
+/// [`pilotage_geo::AvailabilityReason`]. Everything but a plain coverage exit
+/// resolves to `Database`, because it is the database (its integrity,
+/// provenance, currency, policy, or presence) that is at fault, not the
+/// aircraft's position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DbUnavailable {
+    /// No package is active.
+    NoPackage,
+    /// A required tile is missing, duplicated, or miscounted.
+    MissingData,
+    /// A tile's content did not match its hash (corruption or tampering).
+    Corrupt,
+    /// The signature or trust root failed.
+    Signature,
+    /// The package is not yet effective or has expired.
+    Currency,
+    /// The manifest schema is incompatible with this build.
+    Incompatible,
+    /// The datum discipline was violated (unknown or undeclared datum).
+    Datum,
+    /// The activation would be an out-of-policy rollback.
+    Rollback,
+    /// The package is a simulator fixture and cannot be used operationally.
+    SimulationOnly,
+    /// The manifest is structurally malformed (empty, degenerate, misordered).
+    Malformed,
+    /// The query position lies outside the package's covered region.
+    Coverage,
+}
+
+impl DbUnavailable {
+    /// Maps to the geospatial availability reason a consumer reports. Only a
+    /// coverage exit is `Coverage`; every other cause is a `Database` fault.
+    #[must_use]
+    pub const fn to_availability_reason(self) -> AvailabilityReason {
+        match self {
+            Self::Coverage => AvailabilityReason::Coverage,
+            _ => AvailabilityReason::Database,
+        }
+    }
+}

--- a/crates/pilotage-svs-db/src/error.rs
+++ b/crates/pilotage-svs-db/src/error.rs
@@ -115,6 +115,13 @@ pub enum DbError {
     /// use was required.
     #[error("package is simulation_only and cannot be accepted as operational")]
     SimulationOnlyForbidden,
+    /// The manifest's signed use restrictions forbid operational use, and
+    /// operational use was required.
+    #[error("signed use restrictions {restrictions:#x} forbid operational use")]
+    OperationalUseRestricted {
+        /// The restriction bits that forbade operational use.
+        restrictions: u32,
+    },
 }
 
 impl DbError {
@@ -135,6 +142,7 @@ impl DbError {
             | Self::UndeclaredGeoid => DbUnavailable::Datum,
             Self::RollbackBlocked { .. } => DbUnavailable::Rollback,
             Self::SimulationOnlyForbidden => DbUnavailable::SimulationOnly,
+            Self::OperationalUseRestricted { .. } => DbUnavailable::Restricted,
             Self::EmptyFeatureSet | Self::InvalidCoverage { .. } | Self::BadEffectivity => {
                 DbUnavailable::Malformed
             }
@@ -175,10 +183,15 @@ pub enum DbUnavailable {
     Rollback,
     /// The package is a simulator fixture and cannot be used operationally.
     SimulationOnly,
+    /// The manifest's signed use restrictions forbid the requested use.
+    Restricted,
     /// The manifest is structurally malformed (empty, degenerate, misordered).
     Malformed,
     /// The query position lies outside the package's covered region.
     Coverage,
+    /// An emitted output was stamped against a database that is no longer the
+    /// active one, so its provenance cannot be trusted.
+    ProvenanceMismatch,
 }
 
 impl DbUnavailable {

--- a/crates/pilotage-svs-db/src/error.rs
+++ b/crates/pilotage-svs-db/src/error.rs
@@ -122,6 +122,14 @@ pub enum DbError {
         /// The restriction bits that forbade operational use.
         restrictions: u32,
     },
+    /// The manifest carries an unrecognized signed use-restriction bit. Such a
+    /// bit could be a forbid-operational flag this build does not understand, so
+    /// the package is refused rather than assumed permissive.
+    #[error("manifest carries unknown use-restriction bits {restrictions:#x}")]
+    UnknownUseRestriction {
+        /// The full restriction bits, including the unrecognized ones.
+        restrictions: u32,
+    },
 }
 
 impl DbError {
@@ -143,9 +151,10 @@ impl DbError {
             Self::RollbackBlocked { .. } => DbUnavailable::Rollback,
             Self::SimulationOnlyForbidden => DbUnavailable::SimulationOnly,
             Self::OperationalUseRestricted { .. } => DbUnavailable::Restricted,
-            Self::EmptyFeatureSet | Self::InvalidCoverage { .. } | Self::BadEffectivity => {
-                DbUnavailable::Malformed
-            }
+            Self::EmptyFeatureSet
+            | Self::InvalidCoverage { .. }
+            | Self::BadEffectivity
+            | Self::UnknownUseRestriction { .. } => DbUnavailable::Malformed,
         }
     }
 

--- a/crates/pilotage-svs-db/src/error.rs
+++ b/crates/pilotage-svs-db/src/error.rs
@@ -130,6 +130,20 @@ pub enum DbError {
         /// The full restriction bits, including the unrecognized ones.
         restrictions: u32,
     },
+    /// A verification token was submitted for activation after the store changed
+    /// since it was verified. Installing it would replay a stale decision (for
+    /// example rolling the active package backward), so it is refused and the
+    /// current active package is left unchanged.
+    #[error(
+        "stale activation: token verified against generation {expected_generation}, \
+         store is at {actual_generation}"
+    )]
+    StaleActivation {
+        /// The activation generation the token was verified against.
+        expected_generation: u64,
+        /// The store's current activation generation.
+        actual_generation: u64,
+    },
 }
 
 impl DbError {
@@ -148,7 +162,7 @@ impl DbError {
             | Self::UnknownVerticalDatum
             | Self::UndeclaredRealization
             | Self::UndeclaredGeoid => DbUnavailable::Datum,
-            Self::RollbackBlocked { .. } => DbUnavailable::Rollback,
+            Self::RollbackBlocked { .. } | Self::StaleActivation { .. } => DbUnavailable::Rollback,
             Self::SimulationOnlyForbidden => DbUnavailable::SimulationOnly,
             Self::OperationalUseRestricted { .. } => DbUnavailable::Restricted,
             Self::EmptyFeatureSet

--- a/crates/pilotage-svs-db/src/feature.rs
+++ b/crates/pilotage-svs-db/src/feature.rs
@@ -1,0 +1,117 @@
+//! The aeronautical feature classes a database package can carry, and a set of
+//! them.
+//!
+//! A package declares which classes it covers ([`FeatureSet`]); a tile belongs
+//! to exactly one class ([`FeatureClass`]). The class is part of a tile's
+//! identity, so a terrain tile and an obstacle tile at the same geographic index
+//! are distinct leaves under the tile-root hash and can never be substituted for
+//! one another.
+
+/// One aeronautical feature class. The discriminant is the wire encoding and
+/// also the canonical ordering key, so tiles sort deterministically by class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum FeatureClass {
+    /// Terrain elevation posts.
+    Terrain = 1,
+    /// Vertical obstacles (towers, masts, buildings).
+    Obstacles = 2,
+    /// Aerodrome reference points and layouts.
+    Aerodromes = 3,
+    /// Runway geometry.
+    Runways = 4,
+    /// Taxiway geometry.
+    Taxiways = 5,
+}
+
+impl FeatureClass {
+    /// Every class, in canonical order.
+    pub const ALL: [Self; 5] = [
+        Self::Terrain,
+        Self::Obstacles,
+        Self::Aerodromes,
+        Self::Runways,
+        Self::Taxiways,
+    ];
+
+    /// Wire encoding.
+    #[must_use]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes the wire byte, or `None` for a value outside the known set.
+    #[must_use]
+    pub const fn from_u8(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Terrain),
+            2 => Some(Self::Obstacles),
+            3 => Some(Self::Aerodromes),
+            4 => Some(Self::Runways),
+            5 => Some(Self::Taxiways),
+            _ => None,
+        }
+    }
+
+    /// The single-bit mask this class occupies in a [`FeatureSet`].
+    #[must_use]
+    const fn mask(self) -> u32 {
+        1u32 << (self as u32)
+    }
+}
+
+/// A set of feature classes a package declares it covers, as a bitset. The bit
+/// for a class is its [`FeatureClass::to_u8`] position, so the encoding is
+/// stable and independent of insertion order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeatureSet(u32);
+
+impl FeatureSet {
+    /// The empty set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// This set with `class` added.
+    #[must_use]
+    pub const fn with(self, class: FeatureClass) -> Self {
+        Self(self.0 | class.mask())
+    }
+
+    /// Whether `class` is present.
+    #[must_use]
+    pub const fn contains(self, class: FeatureClass) -> bool {
+        self.0 & class.mask() != 0
+    }
+
+    /// Whether the set is empty — a package covering no class is refused.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// The raw bits, for the canonical serialization.
+    #[must_use]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Rebuilds a set from raw bits that carry no unknown class positions, or
+    /// `None` when a bit outside the known classes is set (fail closed rather
+    /// than silently accepting an unrecognized class).
+    #[must_use]
+    pub const fn from_bits(bits: u32) -> Option<Self> {
+        let mut known = 0u32;
+        let mut i = 0;
+        while i < FeatureClass::ALL.len() {
+            known |= FeatureClass::ALL[i].mask();
+            i += 1;
+        }
+        if bits & !known != 0 {
+            None
+        } else {
+            Some(Self(bits))
+        }
+    }
+}

--- a/crates/pilotage-svs-db/src/fixtures.rs
+++ b/crates/pilotage-svs-db/src/fixtures.rs
@@ -93,6 +93,24 @@ pub(crate) fn tiles() -> Vec<Tile> {
         .collect()
 }
 
+/// Three terrain tiles whose payloads are uniformly `tag`, so two versions built
+/// with different tags have completely disjoint content and any mix is visible.
+pub(crate) fn tiles_tagged(tag: u8) -> Vec<Tile> {
+    (0..3)
+        .map(|i| Tile {
+            key: TileKey {
+                class: FeatureClass::Terrain,
+                level: 0,
+                tile: GeoTile {
+                    lat_index: i,
+                    lon_index: 0,
+                },
+            },
+            bytes: vec![tag; 16],
+        })
+        .collect()
+}
+
 /// The tile-root over `tiles`, computed the same way verification recomputes it.
 pub(crate) fn tile_root(tiles: &[Tile]) -> TileRoot {
     let mut entries: Vec<(TileKey, [u8; 32])> = tiles
@@ -111,6 +129,7 @@ pub(crate) fn base_manifest(
     dataset: DatasetId,
     version: PackageVersion,
     simulation_only: bool,
+    restrictions: UseRestrictions,
 ) -> PackageManifest {
     PackageManifest {
         schema_version: MANIFEST_SCHEMA_VERSION,
@@ -122,7 +141,7 @@ pub(crate) fn base_manifest(
                 code: 1,
                 tool_id: 42,
             }]),
-            restrictions: UseRestrictions::NO_OPERATIONAL_USE,
+            restrictions,
         },
         effectivity: Effectivity {
             release: DayNumber(100),
@@ -170,20 +189,70 @@ pub(crate) fn sign(manifest: &mut PackageManifest) {
 }
 
 /// A default valid, signed candidate package: dataset `1`, version `1.0.0`,
-/// three terrain tiles, `simulation_only = true`.
+/// three terrain tiles, `simulation_only = true`, `NO_OPERATIONAL_USE`.
 pub(crate) fn candidate() -> CandidatePackage {
     candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), true)
 }
 
 /// A valid, signed candidate package with the given dataset, version, and
-/// simulation flag.
+/// simulation flag, carrying the `NO_OPERATIONAL_USE` restriction (the SIM
+/// default).
 pub(crate) fn candidate_with(
     dataset: DatasetId,
     version: PackageVersion,
     simulation_only: bool,
 ) -> CandidatePackage {
     let tiles = tiles();
-    let mut manifest = base_manifest(&tiles, dataset, version, simulation_only);
+    let mut manifest = base_manifest(
+        &tiles,
+        dataset,
+        version,
+        simulation_only,
+        UseRestrictions::NO_OPERATIONAL_USE,
+    );
+    sign(&mut manifest);
+    CandidatePackage { manifest, tiles }
+}
+
+/// A valid, signed candidate package with `tag`-uniform tiles, so distinct tags
+/// give content-disjoint versions for the no-mixing test.
+pub(crate) fn candidate_tagged(
+    dataset: DatasetId,
+    version: PackageVersion,
+    tag: u8,
+) -> CandidatePackage {
+    let tiles = tiles_tagged(tag);
+    let mut manifest = base_manifest(&tiles, dataset, version, false, UseRestrictions::NONE);
+    sign(&mut manifest);
+    CandidatePackage { manifest, tiles }
+}
+
+/// A signed package that is genuinely operational: not `simulation_only` and
+/// with no use restrictions.
+pub(crate) fn operational_candidate() -> CandidatePackage {
+    let tiles = tiles();
+    let mut manifest = base_manifest(
+        &tiles,
+        DatasetId(1),
+        PackageVersion::new(1, 0, 0),
+        false,
+        UseRestrictions::NONE,
+    );
+    sign(&mut manifest);
+    CandidatePackage { manifest, tiles }
+}
+
+/// A signed package that is not `simulation_only` but carries the
+/// `NO_OPERATIONAL_USE` restriction, so operational use must still be refused.
+pub(crate) fn restricted_candidate() -> CandidatePackage {
+    let tiles = tiles();
+    let mut manifest = base_manifest(
+        &tiles,
+        DatasetId(1),
+        PackageVersion::new(1, 0, 0),
+        false,
+        UseRestrictions::NO_OPERATIONAL_USE,
+    );
     sign(&mut manifest);
     CandidatePackage { manifest, tiles }
 }

--- a/crates/pilotage-svs-db/src/fixtures.rs
+++ b/crates/pilotage-svs-db/src/fixtures.rs
@@ -1,0 +1,189 @@
+//! Deterministic in-memory fixtures for the tests.
+//!
+//! Signing lives here, not in the library: these fixtures play the offline
+//! publisher that produces a signed package, while the crate under test only
+//! verifies. Keys are derived from fixed seeds, so every signature and hash is
+//! reproducible with no randomness and no I/O.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use ed25519_dalek::{Signer, SigningKey};
+use pilotage_geo::{
+    BaroSettingId, DatumRealizationId, GeoTile, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    IntegrityLevel, LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
+};
+
+use crate::canonical::{manifest_canonical_bytes, tile_canonical_bytes};
+use crate::feature::{FeatureClass, FeatureSet};
+use crate::identity::{DatasetId, DayNumber, PackageVersion, ProviderId};
+use crate::manifest::{
+    Accuracy, ContentSpec, Coverage, CoverageBox, Effectivity, MANIFEST_SCHEMA_VERSION,
+    PackageManifest, ProcessingChain, ProcessingStep, Provenance, Resolution, UseRestrictions,
+};
+use crate::merkle::{TileRoot, merkle_root, tile_leaf_hash};
+use crate::tile::{CandidatePackage, Tile, TileKey};
+use crate::trust::{PackageSignature, TrustAnchor, TrustKeyId, TrustRoot};
+
+/// The current day the valid fixtures are effective on.
+pub(crate) const NOW: DayNumber = DayNumber(150);
+
+/// The trust key id the fixtures sign under.
+pub(crate) const KEY_ID: TrustKeyId = TrustKeyId(0xA1);
+
+/// The publisher's signing key, from a fixed seed.
+pub(crate) fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[7u8; 32])
+}
+
+/// A trust root that trusts the fixture publisher's key under [`KEY_ID`].
+pub(crate) fn trust_root() -> TrustRoot {
+    TrustRoot::new(vec![TrustAnchor {
+        key_id: KEY_ID,
+        public_key: signing_key().verifying_key().to_bytes(),
+    }])
+}
+
+/// A trust root that binds [`KEY_ID`] to a *different* public key, so a
+/// correctly-signed fixture fails signature verification against it.
+pub(crate) fn wrong_key_trust_root() -> TrustRoot {
+    TrustRoot::new(vec![TrustAnchor {
+        key_id: KEY_ID,
+        public_key: SigningKey::from_bytes(&[9u8; 32])
+            .verifying_key()
+            .to_bytes(),
+    }])
+}
+
+/// A geodetic position at `lat`/`lon` on WGS-84 with an ellipsoidal height, for
+/// coverage queries.
+pub(crate) fn position(lat_deg: f64, lon_deg: f64) -> GeodeticPosition {
+    let vertical = VerticalPosition::new(
+        0.0,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("ellipsoidal vertical position is valid");
+    GeodeticPosition::new(
+        lat_deg,
+        lon_deg,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        vertical,
+    )
+    .expect("wgs84 position is valid")
+}
+
+/// Three terrain tiles with distinct keys and payloads.
+pub(crate) fn tiles() -> Vec<Tile> {
+    (0..3)
+        .map(|i| Tile {
+            key: TileKey {
+                class: FeatureClass::Terrain,
+                level: 0,
+                tile: GeoTile {
+                    lat_index: i,
+                    lon_index: 0,
+                },
+            },
+            bytes: vec![i as u8; 16],
+        })
+        .collect()
+}
+
+/// The tile-root over `tiles`, computed the same way verification recomputes it.
+pub(crate) fn tile_root(tiles: &[Tile]) -> TileRoot {
+    let mut entries: Vec<(TileKey, [u8; 32])> = tiles
+        .iter()
+        .map(|t| (t.key, tile_leaf_hash(&tile_canonical_bytes(t))))
+        .collect();
+    entries.sort_by_key(|entry| entry.0);
+    let leaves: Vec<[u8; 32]> = entries.into_iter().map(|(_, leaf)| leaf).collect();
+    merkle_root(&leaves)
+}
+
+/// An unsigned manifest over `tiles` with the given dataset, version, and
+/// simulation flag. Coverage is a small WGS-84 box; effectivity is `[100, 200]`.
+pub(crate) fn base_manifest(
+    tiles: &[Tile],
+    dataset: DatasetId,
+    version: PackageVersion,
+    simulation_only: bool,
+) -> PackageManifest {
+    PackageManifest {
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        provenance: Provenance {
+            dataset,
+            provider: ProviderId(0xB2),
+            version,
+            processing: ProcessingChain(vec![ProcessingStep {
+                code: 1,
+                tool_id: 42,
+            }]),
+            restrictions: UseRestrictions::NO_OPERATIONAL_USE,
+        },
+        effectivity: Effectivity {
+            release: DayNumber(100),
+            effective: DayNumber(100),
+            expiry: DayNumber(200),
+        },
+        coverage: Coverage {
+            region: CoverageBox {
+                min_lat_deg: 40.0,
+                max_lat_deg: 41.0,
+                min_lon_deg: -75.0,
+                max_lon_deg: -74.0,
+            },
+            horizontal_datum: HorizontalDatum::Wgs84,
+            realization: DatumRealizationId::UNDECLARED,
+            vertical_datum: VerticalDatum::Ellipsoid,
+            geoid: GeoidModelId::UNDECLARED,
+            resolution: Resolution {
+                post_spacing_mm: 30_000,
+            },
+        },
+        content: ContentSpec {
+            features: FeatureSet::empty().with(FeatureClass::Terrain),
+            accuracy: Accuracy {
+                horizontal_mm: 3_000,
+                vertical_mm: 5_000,
+            },
+            integrity: IntegrityLevel::Monitored,
+        },
+        tile_count: tiles.len() as u32,
+        tile_root: tile_root(tiles),
+        simulation_only,
+        signature: PackageSignature {
+            key_id: KEY_ID,
+            bytes: [0u8; 64],
+        },
+    }
+}
+
+/// Signs (or re-signs) a manifest in place with the fixture key, over its
+/// current canonical bytes.
+pub(crate) fn sign(manifest: &mut PackageManifest) {
+    let bytes = manifest_canonical_bytes(manifest);
+    manifest.signature.bytes = signing_key().sign(&bytes).to_bytes();
+}
+
+/// A default valid, signed candidate package: dataset `1`, version `1.0.0`,
+/// three terrain tiles, `simulation_only = true`.
+pub(crate) fn candidate() -> CandidatePackage {
+    candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), true)
+}
+
+/// A valid, signed candidate package with the given dataset, version, and
+/// simulation flag.
+pub(crate) fn candidate_with(
+    dataset: DatasetId,
+    version: PackageVersion,
+    simulation_only: bool,
+) -> CandidatePackage {
+    let tiles = tiles();
+    let mut manifest = base_manifest(&tiles, dataset, version, simulation_only);
+    sign(&mut manifest);
+    CandidatePackage { manifest, tiles }
+}

--- a/crates/pilotage-svs-db/src/fixtures.rs
+++ b/crates/pilotage-svs-db/src/fixtures.rs
@@ -256,3 +256,19 @@ pub(crate) fn restricted_candidate() -> CandidatePackage {
     sign(&mut manifest);
     CandidatePackage { manifest, tiles }
 }
+
+/// A signed package carrying an unknown use-restriction bit (outside
+/// `KNOWN_MASK`), which must be refused at validation rather than assumed
+/// permissive.
+pub(crate) fn unknown_restriction_candidate() -> CandidatePackage {
+    let tiles = tiles();
+    let mut manifest = base_manifest(
+        &tiles,
+        DatasetId(1),
+        PackageVersion::new(1, 0, 0),
+        false,
+        UseRestrictions(1 << 31),
+    );
+    sign(&mut manifest);
+    CandidatePackage { manifest, tiles }
+}

--- a/crates/pilotage-svs-db/src/identity.rs
+++ b/crates/pilotage-svs-db/src/identity.rs
@@ -1,0 +1,92 @@
+//! Stable identities for a database package: the dataset and provider it comes
+//! from, its version, effectivity day numbers, and the active-database id that
+//! is carried into rendered output and diagnostics.
+//!
+//! Versions are ordered ([`PackageVersion`] is `Ord`) so an out-of-policy
+//! rollback is a comparison, not a guess. Day numbers ([`DayNumber`]) are a
+//! bare count of days from a fixed simulator epoch, ordered the same way, so
+//! effectivity and expiry are decided without any calendar arithmetic.
+
+use core::fmt;
+
+/// Identity of an aeronautical dataset (the logical database this package is a
+/// release of). Compared for equality; a different dataset is a different
+/// database, never a rollback of this one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DatasetId(pub u64);
+
+/// Identity of the data provider that produced a dataset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderId(pub u64);
+
+/// A package version, ordered major-then-minor-then-patch. Ordering is the
+/// rollback policy's only input: a candidate older than the active package of
+/// the same dataset is refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PackageVersion {
+    /// Major version.
+    pub major: u16,
+    /// Minor version.
+    pub minor: u16,
+    /// Patch version.
+    pub patch: u16,
+}
+
+impl PackageVersion {
+    /// Builds a version.
+    #[must_use]
+    pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl fmt::Display for PackageVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// A day number: whole days since a fixed simulator epoch. Ordered, so
+/// effectivity (`effective <= now`) and expiry (`now <= expiry`) are plain
+/// comparisons with no calendar math and no clock domain to confuse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DayNumber(pub u32);
+
+impl fmt::Display for DayNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The identity of the currently active database, carried into rendered output
+/// and diagnostics so every produced frame can name the exact package it was
+/// drawn against. The `simulation_only` flag travels with the id so a simulator
+/// package can never be presented as an operational one downstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveDbId {
+    /// The dataset this package is a release of.
+    pub dataset: DatasetId,
+    /// The provider that produced it.
+    pub provider: ProviderId,
+    /// The package version.
+    pub version: PackageVersion,
+    /// Whether the package is a permanently-marked simulator fixture.
+    pub simulation_only: bool,
+}
+
+impl fmt::Display for ActiveDbId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "svsdb:{:016x}/{:016x}@{}{}",
+            self.dataset.0,
+            self.provider.0,
+            self.version,
+            if self.simulation_only { " SIM" } else { "" }
+        )
+    }
+}

--- a/crates/pilotage-svs-db/src/identity.rs
+++ b/crates/pilotage-svs-db/src/identity.rs
@@ -64,8 +64,11 @@ impl fmt::Display for DayNumber {
 
 /// The identity of the currently active database, carried into rendered output
 /// and diagnostics so every produced frame can name the exact package it was
-/// drawn against. The `simulation_only` flag travels with the id so a simulator
-/// package can never be presented as an operational one downstream.
+/// drawn against. Identity is content-addressed: [`Self::content_hash`] is the
+/// hash of the signed manifest bytes (which cover the tile-root), so two
+/// different databases can never share an id even when re-signed under the same
+/// dataset and version. The `simulation_only` flag travels with the id so a
+/// simulator package can never be presented as an operational one downstream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ActiveDbId {
     /// The dataset this package is a release of.
@@ -76,16 +79,24 @@ pub struct ActiveDbId {
     pub version: PackageVersion,
     /// Whether the package is a permanently-marked simulator fixture.
     pub simulation_only: bool,
+    /// The content hash of the signed manifest, binding this id to the exact
+    /// package content. Distinct content yields a distinct id even at the same
+    /// version.
+    pub content_hash: [u8; 32],
 }
 
 impl fmt::Display for ActiveDbId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "svsdb:{:016x}/{:016x}@{}{}",
+            "svsdb:{:016x}/{:016x}@{}#{:02x}{:02x}{:02x}{:02x}{}",
             self.dataset.0,
             self.provider.0,
             self.version,
+            self.content_hash[0],
+            self.content_hash[1],
+            self.content_hash[2],
+            self.content_hash[3],
             if self.simulation_only { " SIM" } else { "" }
         )
     }

--- a/crates/pilotage-svs-db/src/lib.rs
+++ b/crates/pilotage-svs-db/src/lib.rs
@@ -36,6 +36,7 @@ mod feature;
 mod identity;
 mod manifest;
 mod merkle;
+mod output;
 mod tile;
 mod trust;
 mod verify;
@@ -54,6 +55,7 @@ pub use manifest::{
     UseRestrictions, schema_is_compatible,
 };
 pub use merkle::{TileRoot, merkle_root, tile_leaf_hash};
+pub use output::RenderStamp;
 pub use tile::{CandidatePackage, Tile, TileKey};
 pub use trust::{PackageSignature, TrustAnchor, TrustKeyId, TrustRoot, verify_signature};
 pub use verify::{UsePolicy, VerifiedPackage, verify_package};

--- a/crates/pilotage-svs-db/src/lib.rs
+++ b/crates/pilotage-svs-db/src/lib.rs
@@ -1,0 +1,59 @@
+//! Signed, provenance-preserving, atomically activated aeronautical database
+//! packages for synthetic vision (SVS-02).
+//!
+//! A [`PackageManifest`] pins a database of terrain, obstacles, aerodromes,
+//! runways, and taxiways: where it came from, when it is valid, the region and
+//! datum it covers, a [`TileRoot`] hash over every tile, and an Ed25519
+//! signature binding all of it to a configured [`TrustRoot`]. [`verify_package`]
+//! checks every tile and the whole manifest before a package may become active;
+//! [`PackageStore`] activates it as a pure validate-then-swap, so an interrupted
+//! update yields the complete prior package or none, never a partial or
+//! mixed-version mix. Every failure — missing tile, corruption, signature or
+//! trust failure, expiry, coverage exit, incompatible schema, or wrong datum —
+//! is a typed refusal that a consumer maps onto
+//! [`pilotage_geo::SvsAvailability::Unavailable`], never a plausible-looking
+//! scene.
+//!
+//! The datum vocabulary is consumed from `pilotage-geo`
+//! ([`pilotage_geo::HorizontalDatum`], [`pilotage_geo::VerticalDatum`], and
+//! their identities), never re-minted here. The airborne/runtime path verifies
+//! an already-present package and reads the active id; it never downloads or
+//! mutates a database online.
+//!
+//! # SIM / NOT FOR FLIGHT
+//!
+//! This is a simulator/engineering contract. Passing these tests does not
+//! qualify a data supplier or an aeronautical database, and fixtures marked
+//! [`PackageManifest::simulation_only`] are permanently simulation-only and are
+//! never accepted as operational databases.
+
+#![forbid(unsafe_code)]
+
+mod activation;
+mod canonical;
+mod error;
+mod feature;
+mod identity;
+mod manifest;
+mod merkle;
+mod tile;
+mod trust;
+mod verify;
+
+#[cfg(test)]
+mod fixtures;
+
+pub use activation::{ActivePackage, PackageStore};
+pub use canonical::{manifest_canonical_bytes, manifest_content_hash, tile_canonical_bytes};
+pub use error::{DbError, DbUnavailable};
+pub use feature::{FeatureClass, FeatureSet};
+pub use identity::{ActiveDbId, DatasetId, DayNumber, PackageVersion, ProviderId};
+pub use manifest::{
+    Accuracy, ContentSpec, Coverage, CoverageBox, Effectivity, MANIFEST_SCHEMA_VERSION,
+    MIN_SUPPORTED_SCHEMA, PackageManifest, ProcessingChain, ProcessingStep, Provenance, Resolution,
+    UseRestrictions, schema_is_compatible,
+};
+pub use merkle::{TileRoot, merkle_root, tile_leaf_hash};
+pub use tile::{CandidatePackage, Tile, TileKey};
+pub use trust::{PackageSignature, TrustAnchor, TrustKeyId, TrustRoot, verify_signature};
+pub use verify::{UsePolicy, VerifiedPackage, verify_package};

--- a/crates/pilotage-svs-db/src/manifest.rs
+++ b/crates/pilotage-svs-db/src/manifest.rs
@@ -78,7 +78,8 @@ pub struct PackageManifest {
 
 impl PackageManifest {
     /// The active-database id this manifest describes, for output and
-    /// diagnostics.
+    /// diagnostics. The id is content-addressed: it carries the hash of the
+    /// signed manifest bytes, so distinct content never shares an id.
     #[must_use]
     pub fn active_id(&self) -> ActiveDbId {
         ActiveDbId {
@@ -86,6 +87,7 @@ impl PackageManifest {
             provider: self.provenance.provider,
             version: self.provenance.version,
             simulation_only: self.simulation_only,
+            content_hash: crate::canonical::manifest_content_hash(self),
         }
     }
 
@@ -115,6 +117,11 @@ impl PackageManifest {
         }
         if !self.effectivity.is_ordered() {
             return Err(DbError::BadEffectivity);
+        }
+        if self.provenance.restrictions.has_unknown_bits() {
+            return Err(DbError::UnknownUseRestriction {
+                restrictions: self.provenance.restrictions.bits(),
+            });
         }
         self.validate_datum()
     }

--- a/crates/pilotage-svs-db/src/manifest.rs
+++ b/crates/pilotage-svs-db/src/manifest.rs
@@ -1,0 +1,141 @@
+//! The versioned package manifest and its compatibility policy.
+//!
+//! A [`PackageManifest`] is the signed description of a database package:
+//! provenance, effectivity, coverage and datum, content, the tile-root hash
+//! over every tile, a permanent `simulation_only` flag, and the signature that
+//! binds all of it to a trust root. Everything except the signature is part of
+//! the canonical bytes the signature is computed over (see [`crate::canonical`]),
+//! so no field can be altered without breaking either the signature (for
+//! manifest fields) or the tile-root check (for tile bytes).
+//!
+//! # Schema compatibility policy
+//!
+//! The schema is versioned by [`MANIFEST_SCHEMA_VERSION`]. This build reads a
+//! manifest only when its `schema_version` lies in
+//! `[MIN_SUPPORTED_SCHEMA, MANIFEST_SCHEMA_VERSION]`. A **newer** schema is
+//! refused rather than partially parsed — an unknown field layout could carry
+//! meaning this build would silently drop — and a schema **older** than the
+//! minimum is refused rather than upgraded by guesswork. The policy is
+//! deliberately closed at both ends: widening it is an explicit code change,
+//! never an implicit acceptance.
+
+mod content;
+mod coverage;
+mod effectivity;
+mod provenance;
+
+#[cfg(test)]
+mod tests;
+
+pub use content::{Accuracy, ContentSpec};
+pub use coverage::{Coverage, CoverageBox, Resolution};
+pub use effectivity::Effectivity;
+pub use provenance::{ProcessingChain, ProcessingStep, Provenance, UseRestrictions};
+
+use pilotage_geo::{HorizontalDatum, VerticalDatum};
+
+use crate::error::DbError;
+use crate::identity::ActiveDbId;
+use crate::merkle::TileRoot;
+use crate::trust::PackageSignature;
+
+/// The highest manifest schema version this build produces and reads.
+pub const MANIFEST_SCHEMA_VERSION: u16 = 1;
+
+/// The lowest manifest schema version this build still reads.
+pub const MIN_SUPPORTED_SCHEMA: u16 = 1;
+
+/// Whether `version` is within the compatibility window this build reads.
+#[must_use]
+pub const fn schema_is_compatible(version: u16) -> bool {
+    MIN_SUPPORTED_SCHEMA <= version && version <= MANIFEST_SCHEMA_VERSION
+}
+
+/// The signed description of a database package. Construct it directly; it is
+/// validated by [`Self::validate_structure`] and, in full, by the verification
+/// pipeline before any activation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PackageManifest {
+    /// The manifest schema version.
+    pub schema_version: u16,
+    /// Where the package comes from and how it may be used.
+    pub provenance: Provenance,
+    /// When the package is valid.
+    pub effectivity: Effectivity,
+    /// The region and datum it covers.
+    pub coverage: Coverage,
+    /// What it carries and the quality it claims.
+    pub content: ContentSpec,
+    /// The number of tiles the package must supply.
+    pub tile_count: u32,
+    /// The Merkle-style root over every tile.
+    pub tile_root: TileRoot,
+    /// Whether this is a permanently-marked simulator fixture.
+    pub simulation_only: bool,
+    /// The signature binding the canonical manifest bytes to a trust root.
+    pub signature: PackageSignature,
+}
+
+impl PackageManifest {
+    /// The active-database id this manifest describes, for output and
+    /// diagnostics.
+    #[must_use]
+    pub fn active_id(&self) -> ActiveDbId {
+        ActiveDbId {
+            dataset: self.provenance.dataset,
+            provider: self.provenance.provider,
+            version: self.provenance.version,
+            simulation_only: self.simulation_only,
+        }
+    }
+
+    /// Checks the manifest-intrinsic invariants: schema compatibility, a
+    /// non-empty feature set, a valid coverage box, ordered effectivity dates,
+    /// and datum discipline. Currency, tiles, signature, and rollback are
+    /// checked by the full pipeline, not here.
+    ///
+    /// # Errors
+    ///
+    /// The [`DbError`] naming the first violated invariant.
+    pub fn validate_structure(&self) -> Result<(), DbError> {
+        if !schema_is_compatible(self.schema_version) {
+            return Err(DbError::IncompatibleManifest {
+                version: self.schema_version,
+                min: MIN_SUPPORTED_SCHEMA,
+                max: MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        if self.content.features.is_empty() {
+            return Err(DbError::EmptyFeatureSet);
+        }
+        if !self.coverage.region.is_valid() {
+            return Err(DbError::InvalidCoverage {
+                reason: "non-finite or degenerate bounds",
+            });
+        }
+        if !self.effectivity.is_ordered() {
+            return Err(DbError::BadEffectivity);
+        }
+        self.validate_datum()
+    }
+
+    /// Enforces datum discipline on the coverage: the datum must be known and
+    /// carry the identity it requires (a realization for NAD83/ITRF, a geoid
+    /// for geometric MSL). A wrong or under-declared datum is refused.
+    fn validate_datum(&self) -> Result<(), DbError> {
+        let c = &self.coverage;
+        if c.horizontal_datum == HorizontalDatum::Unknown {
+            return Err(DbError::UnknownHorizontalDatum);
+        }
+        if c.horizontal_datum.needs_realization() && !c.realization.is_declared() {
+            return Err(DbError::UndeclaredRealization);
+        }
+        if c.vertical_datum == VerticalDatum::Unknown {
+            return Err(DbError::UnknownVerticalDatum);
+        }
+        if c.vertical_datum == VerticalDatum::Msl && !c.geoid.is_declared() {
+            return Err(DbError::UndeclaredGeoid);
+        }
+        Ok(())
+    }
+}

--- a/crates/pilotage-svs-db/src/manifest/content.rs
+++ b/crates/pilotage-svs-db/src/manifest/content.rs
@@ -1,0 +1,32 @@
+//! Content specification: which feature classes a package carries and the
+//! accuracy and integrity it claims for them.
+//!
+//! The integrity level is consumed from `pilotage-geo`
+//! ([`pilotage_geo::IntegrityLevel`]) rather than re-minted, so a package's
+//! declared assurance is expressed in the same vocabulary the availability
+//! contract judges an input by.
+
+use pilotage_geo::IntegrityLevel;
+
+use crate::feature::FeatureSet;
+
+/// The declared 1-sigma accuracy of a package's data, split by axis so a
+/// horizontal accuracy can never be read as a vertical one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Accuracy {
+    /// Horizontal 1-sigma accuracy, millimeters.
+    pub horizontal_mm: u32,
+    /// Vertical 1-sigma accuracy, millimeters.
+    pub vertical_mm: u32,
+}
+
+/// What a package carries and the quality it claims.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContentSpec {
+    /// The feature classes present.
+    pub features: FeatureSet,
+    /// The declared accuracy.
+    pub accuracy: Accuracy,
+    /// The declared integrity/assurance level.
+    pub integrity: IntegrityLevel,
+}

--- a/crates/pilotage-svs-db/src/manifest/coverage.rs
+++ b/crates/pilotage-svs-db/src/manifest/coverage.rs
@@ -1,0 +1,84 @@
+//! Coverage: the geographic region a package spans and the datum that region's
+//! coordinates and heights are expressed in.
+//!
+//! The datum vocabulary is consumed from `pilotage-geo`
+//! ([`pilotage_geo::HorizontalDatum`], [`pilotage_geo::VerticalDatum`], and
+//! their realization/geoid identities) rather than re-minted here, so a package
+//! and the synthetic-vision contract that consumes it can never disagree about
+//! what a datum means. A query outside the box is a coverage exit, distinct
+//! from a database fault.
+
+use pilotage_geo::{
+    DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum, VerticalDatum,
+};
+
+/// The horizontal ground resolution a terrain-bearing package is sampled at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Resolution {
+    /// Terrain post spacing, millimeters. Zero means unspecified.
+    pub post_spacing_mm: u32,
+}
+
+/// A geographic bounding box in degrees, half-open on the upper edges so
+/// adjacent boxes tile without overlap. Validated to be finite with
+/// `min < max` on both axes.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CoverageBox {
+    /// Southern latitude bound, degrees (inclusive).
+    pub min_lat_deg: f64,
+    /// Northern latitude bound, degrees (exclusive).
+    pub max_lat_deg: f64,
+    /// Western longitude bound, degrees (inclusive).
+    pub min_lon_deg: f64,
+    /// Eastern longitude bound, degrees (exclusive).
+    pub max_lon_deg: f64,
+}
+
+impl CoverageBox {
+    /// Whether every bound is finite and the box is non-degenerate.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.min_lat_deg.is_finite()
+            && self.max_lat_deg.is_finite()
+            && self.min_lon_deg.is_finite()
+            && self.max_lon_deg.is_finite()
+            && self.min_lat_deg < self.max_lat_deg
+            && self.min_lon_deg < self.max_lon_deg
+    }
+
+    /// Whether `lat_deg`/`lon_deg` fall inside the box (inclusive lower,
+    /// exclusive upper).
+    #[must_use]
+    pub fn contains_lat_lon(&self, lat_deg: f64, lon_deg: f64) -> bool {
+        lat_deg >= self.min_lat_deg
+            && lat_deg < self.max_lat_deg
+            && lon_deg >= self.min_lon_deg
+            && lon_deg < self.max_lon_deg
+    }
+
+    /// Whether a geodetic position lies inside the box.
+    #[must_use]
+    pub fn contains(&self, pos: &GeodeticPosition) -> bool {
+        self.contains_lat_lon(pos.latitude_deg, pos.longitude_deg)
+    }
+}
+
+/// The covered region together with the datum its coordinates and heights are
+/// referenced to.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Coverage {
+    /// The bounding region.
+    pub region: CoverageBox,
+    /// The horizontal datum of the region's coordinates.
+    pub horizontal_datum: HorizontalDatum,
+    /// The horizontal-datum realization; `UNDECLARED` for a datum that needs
+    /// none.
+    pub realization: DatumRealizationId,
+    /// The vertical datum of the package's heights.
+    pub vertical_datum: VerticalDatum,
+    /// The geoid model behind a geometric-MSL vertical datum; `UNDECLARED`
+    /// otherwise.
+    pub geoid: GeoidModelId,
+    /// The horizontal ground resolution.
+    pub resolution: Resolution,
+}

--- a/crates/pilotage-svs-db/src/manifest/effectivity.rs
+++ b/crates/pilotage-svs-db/src/manifest/effectivity.rs
@@ -1,0 +1,41 @@
+//! Effectivity: the release, effective, and expiry day numbers that bound when
+//! a package may be used.
+//!
+//! Currency is a pure comparison against a supplied day number, never a wall
+//! clock read inside this crate: the airborne/runtime path is handed the
+//! current day and decides. A package is usable only on `[effective, expiry]`;
+//! outside that window it fails closed.
+
+use crate::identity::DayNumber;
+
+/// The day numbers that bound a package's validity, ordered
+/// `release <= effective <= expiry`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Effectivity {
+    /// The day the package was released.
+    pub release: DayNumber,
+    /// The first day the package may be used.
+    pub effective: DayNumber,
+    /// The last day the package may be used.
+    pub expiry: DayNumber,
+}
+
+impl Effectivity {
+    /// Whether the three dates are ordered `release <= effective <= expiry`.
+    #[must_use]
+    pub const fn is_ordered(&self) -> bool {
+        self.release.0 <= self.effective.0 && self.effective.0 <= self.expiry.0
+    }
+
+    /// Whether `now` is before the effective day.
+    #[must_use]
+    pub const fn is_before_effective(&self, now: DayNumber) -> bool {
+        now.0 < self.effective.0
+    }
+
+    /// Whether `now` is after the expiry day.
+    #[must_use]
+    pub const fn is_after_expiry(&self, now: DayNumber) -> bool {
+        now.0 > self.expiry.0
+    }
+}

--- a/crates/pilotage-svs-db/src/manifest/provenance.rs
+++ b/crates/pilotage-svs-db/src/manifest/provenance.rs
@@ -58,6 +58,14 @@ impl UseRestrictions {
         self.0 & other.0 == other.0
     }
 
+    /// Whether these restrictions forbid operational use. Both
+    /// [`Self::NO_OPERATIONAL_USE`] and [`Self::TRAINING_ONLY`] confine a
+    /// package to non-operational use.
+    #[must_use]
+    pub const fn forbids_operational(self) -> bool {
+        self.contains(Self::NO_OPERATIONAL_USE) || self.contains(Self::TRAINING_ONLY)
+    }
+
     /// The raw bits, for the canonical serialization.
     #[must_use]
     pub const fn bits(self) -> u32 {

--- a/crates/pilotage-svs-db/src/manifest/provenance.rs
+++ b/crates/pilotage-svs-db/src/manifest/provenance.rs
@@ -1,0 +1,81 @@
+//! Provenance: which dataset and provider a package comes from, its version,
+//! the processing lineage that produced it, and the use restrictions that
+//! travel with it.
+//!
+//! The processing chain is an ordered lineage of operations from the source
+//! data to this package — a simulator stand-in for the recorded data process a
+//! quality standard such as DO-200C requires. It is authenticated like the rest
+//! of the manifest: it is part of the signed canonical bytes, so a package
+//! cannot silently drop or rewrite its own history.
+
+use crate::identity::{DatasetId, PackageVersion, ProviderId};
+
+/// One step of the processing lineage: an operation code and the identity of the
+/// tool that performed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessingStep {
+    /// The operation performed (provider-defined code).
+    pub code: u16,
+    /// Identity of the tool that performed it.
+    pub tool_id: u32,
+}
+
+/// The ordered processing lineage from source data to this package. Order is
+/// significant and preserved in the canonical bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessingChain(pub Vec<ProcessingStep>);
+
+impl ProcessingChain {
+    /// The steps, source-first.
+    #[must_use]
+    pub fn steps(&self) -> &[ProcessingStep] {
+        &self.0
+    }
+
+    /// Whether the lineage is empty — a package with no recorded processing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Restrictions on how a package may be used, as a bitset of restriction codes.
+/// Restrictions are additive: a set bit is a constraint that applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UseRestrictions(pub u32);
+
+impl UseRestrictions {
+    /// No declared restrictions.
+    pub const NONE: Self = Self(0);
+    /// The package must not be used for operational purposes.
+    pub const NO_OPERATIONAL_USE: Self = Self(1 << 0);
+    /// The package is limited to training use.
+    pub const TRAINING_ONLY: Self = Self(1 << 1);
+
+    /// Whether every restriction bit in `other` is set here.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// The raw bits, for the canonical serialization.
+    #[must_use]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+/// Where a package comes from and under what constraints it may be used.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Provenance {
+    /// The dataset this package is a release of.
+    pub dataset: DatasetId,
+    /// The provider that produced it.
+    pub provider: ProviderId,
+    /// The package version.
+    pub version: PackageVersion,
+    /// The processing lineage.
+    pub processing: ProcessingChain,
+    /// Restrictions on use.
+    pub restrictions: UseRestrictions,
+}

--- a/crates/pilotage-svs-db/src/manifest/provenance.rs
+++ b/crates/pilotage-svs-db/src/manifest/provenance.rs
@@ -51,6 +51,10 @@ impl UseRestrictions {
     pub const NO_OPERATIONAL_USE: Self = Self(1 << 0);
     /// The package is limited to training use.
     pub const TRAINING_ONLY: Self = Self(1 << 1);
+    /// Every restriction bit this build understands. A bit outside this mask is
+    /// an unknown restriction and is refused at validation rather than assumed
+    /// harmless.
+    pub const KNOWN_MASK: Self = Self(Self::NO_OPERATIONAL_USE.0 | Self::TRAINING_ONLY.0);
 
     /// Whether every restriction bit in `other` is set here.
     #[must_use]
@@ -64,6 +68,14 @@ impl UseRestrictions {
     #[must_use]
     pub const fn forbids_operational(self) -> bool {
         self.contains(Self::NO_OPERATIONAL_USE) || self.contains(Self::TRAINING_ONLY)
+    }
+
+    /// Whether any bit outside [`Self::KNOWN_MASK`] is set. An unknown
+    /// restriction could be a forbid-operational flag this build does not
+    /// understand, so it must be refused rather than assumed permissive.
+    #[must_use]
+    pub const fn has_unknown_bits(self) -> bool {
+        self.0 & !Self::KNOWN_MASK.0 != 0
     }
 
     /// The raw bits, for the canonical serialization.

--- a/crates/pilotage-svs-db/src/manifest/tests.rs
+++ b/crates/pilotage-svs-db/src/manifest/tests.rs
@@ -1,0 +1,116 @@
+//! Tests for the manifest schema, its compatibility policy, and datum
+//! discipline.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pilotage_geo::{DatumRealizationId, HorizontalDatum, VerticalDatum};
+
+use super::{MANIFEST_SCHEMA_VERSION, MIN_SUPPORTED_SCHEMA, schema_is_compatible};
+use crate::error::DbError;
+use crate::fixtures;
+
+/// Acceptance: the manifest schema is versioned with an explicit compatibility
+/// policy closed at both ends — the current version is accepted, and both a
+/// newer and an older-than-minimum version are refused rather than guessed.
+#[test]
+fn manifest_schema_versioned_with_compatibility_policy() {
+    assert!(schema_is_compatible(MANIFEST_SCHEMA_VERSION));
+    assert!(!schema_is_compatible(MANIFEST_SCHEMA_VERSION + 1));
+    assert!(!schema_is_compatible(MIN_SUPPORTED_SCHEMA - 1));
+
+    let candidate = fixtures::candidate();
+    let mut newer = candidate.manifest.clone();
+    newer.schema_version = MANIFEST_SCHEMA_VERSION + 1;
+    assert_eq!(
+        newer.validate_structure(),
+        Err(DbError::IncompatibleManifest {
+            version: MANIFEST_SCHEMA_VERSION + 1,
+            min: MIN_SUPPORTED_SCHEMA,
+            max: MANIFEST_SCHEMA_VERSION,
+        })
+    );
+}
+
+#[test]
+fn default_fixture_manifest_is_structurally_valid() {
+    let candidate = fixtures::candidate();
+    assert_eq!(candidate.manifest.validate_structure(), Ok(()));
+}
+
+#[test]
+fn empty_feature_set_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.content.features = crate::feature::FeatureSet::empty();
+    assert_eq!(manifest.validate_structure(), Err(DbError::EmptyFeatureSet));
+}
+
+#[test]
+fn degenerate_coverage_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.coverage.region.max_lat_deg = manifest.coverage.region.min_lat_deg;
+    assert!(matches!(
+        manifest.validate_structure(),
+        Err(DbError::InvalidCoverage { .. })
+    ));
+}
+
+#[test]
+fn misordered_effectivity_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.effectivity.expiry = crate::identity::DayNumber(50);
+    assert_eq!(manifest.validate_structure(), Err(DbError::BadEffectivity));
+}
+
+#[test]
+fn unknown_horizontal_datum_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.coverage.horizontal_datum = HorizontalDatum::Unknown;
+    assert_eq!(
+        manifest.validate_structure(),
+        Err(DbError::UnknownHorizontalDatum)
+    );
+}
+
+#[test]
+fn realization_bearing_datum_without_realization_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.coverage.horizontal_datum = HorizontalDatum::Nad83;
+    manifest.coverage.realization = DatumRealizationId::UNDECLARED;
+    assert_eq!(
+        manifest.validate_structure(),
+        Err(DbError::UndeclaredRealization)
+    );
+}
+
+#[test]
+fn unknown_vertical_datum_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.coverage.vertical_datum = VerticalDatum::Unknown;
+    assert_eq!(
+        manifest.validate_structure(),
+        Err(DbError::UnknownVerticalDatum)
+    );
+}
+
+#[test]
+fn geometric_msl_without_geoid_is_refused() {
+    let candidate = fixtures::candidate();
+    let mut manifest = candidate.manifest.clone();
+    manifest.coverage.vertical_datum = VerticalDatum::Msl;
+    assert_eq!(manifest.validate_structure(), Err(DbError::UndeclaredGeoid));
+}
+
+#[test]
+fn active_id_reflects_the_manifest() {
+    let candidate = fixtures::candidate();
+    let id = candidate.manifest.active_id();
+    assert_eq!(id.dataset, candidate.manifest.provenance.dataset);
+    assert_eq!(id.version, candidate.manifest.provenance.version);
+    assert_eq!(id.simulation_only, candidate.manifest.simulation_only);
+}

--- a/crates/pilotage-svs-db/src/merkle.rs
+++ b/crates/pilotage-svs-db/src/merkle.rs
@@ -1,0 +1,74 @@
+//! The tile-root hash: a domain-separated Merkle tree over the package's tiles.
+//!
+//! Each tile hashes to a leaf; leaves combine pairwise into a single
+//! [`TileRoot`] that the manifest declares and the signature covers. Because the
+//! root depends on every leaf, a one-byte change to any tile changes its leaf,
+//! propagates up the tree, and makes the recomputed root disagree with the
+//! declared one.
+//!
+//! Leaves and interior nodes carry distinct one-byte domain tags, so a leaf
+//! hash can never be reinterpreted as an interior node (the classic Merkle
+//! second-preimage confusion). A lone node at an odd level is promoted
+//! unchanged rather than hashed against a duplicate of itself.
+
+use sha2::{Digest, Sha256};
+
+/// A 32-byte Merkle-style root over a package's tiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TileRoot(pub [u8; 32]);
+
+/// Domain tag for a leaf hash.
+const LEAF_DOMAIN: u8 = 0x00;
+/// Domain tag for an interior-node hash.
+const NODE_DOMAIN: u8 = 0x01;
+/// Domain tag for the root of an empty tree (a package with no tiles).
+const EMPTY_DOMAIN: u8 = 0x02;
+
+/// The leaf hash of a tile's canonical bytes.
+#[must_use]
+pub fn tile_leaf_hash(canonical_tile_bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update([LEAF_DOMAIN]);
+    hasher.update(canonical_tile_bytes);
+    hasher.finalize().into()
+}
+
+/// The interior-node hash of two child hashes.
+#[must_use]
+fn node_hash(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update([NODE_DOMAIN]);
+    hasher.update(left);
+    hasher.update(right);
+    hasher.finalize().into()
+}
+
+/// The Merkle root over `leaves`, in the given order. Callers pass leaves in a
+/// deterministic order (tiles sorted by key), so the root is a pure function of
+/// the tile set.
+#[must_use]
+pub fn merkle_root(leaves: &[[u8; 32]]) -> TileRoot {
+    if leaves.is_empty() {
+        let mut hasher = Sha256::new();
+        hasher.update([EMPTY_DOMAIN]);
+        return TileRoot(hasher.finalize().into());
+    }
+    let mut level: Vec<[u8; 32]> = leaves.to_vec();
+    while level.len() > 1 {
+        let mut next: Vec<[u8; 32]> = Vec::with_capacity(level.len().div_ceil(2));
+        let mut i = 0;
+        while i < level.len() {
+            if i + 1 < level.len() {
+                next.push(node_hash(&level[i], &level[i + 1]));
+            } else {
+                next.push(level[i]);
+            }
+            i += 2;
+        }
+        level = next;
+    }
+    TileRoot(level[0])
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/merkle/tests.rs
+++ b/crates/pilotage-svs-db/src/merkle/tests.rs
@@ -1,0 +1,46 @@
+//! Tests for the domain-separated Merkle tile-root.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use super::{merkle_root, tile_leaf_hash};
+
+fn leaf(byte: u8) -> [u8; 32] {
+    tile_leaf_hash(&[byte; 8])
+}
+
+#[test]
+fn changing_one_leaf_changes_the_root() {
+    let base = [leaf(1), leaf(2), leaf(3)];
+    let mutated = [leaf(1), leaf(2), leaf(4)];
+    assert_ne!(merkle_root(&base), merkle_root(&mutated));
+}
+
+#[test]
+fn distinct_leaf_sets_have_distinct_roots() {
+    let a = [leaf(1), leaf(2)];
+    let b = [leaf(3), leaf(4)];
+    assert_ne!(merkle_root(&a), merkle_root(&b));
+}
+
+#[test]
+fn empty_tree_root_is_fixed_and_distinct_from_any_leaf() {
+    let empty = merkle_root(&[]);
+    assert_eq!(empty, merkle_root(&[]));
+    assert_ne!(empty.0, leaf(0));
+    assert_ne!(empty.0, leaf(1));
+}
+
+#[test]
+fn leaf_and_interior_node_domains_do_not_collide() {
+    // A single-leaf tree yields the leaf; a two-leaf tree yields an interior
+    // node hash. Distinct domains keep them apart even for related inputs.
+    let single = merkle_root(&[leaf(5)]);
+    let paired = merkle_root(&[leaf(5), leaf(5)]);
+    assert_ne!(single, paired);
+}
+
+#[test]
+fn root_is_a_pure_function_of_leaf_order() {
+    let leaves = [leaf(1), leaf(2), leaf(3)];
+    assert_eq!(merkle_root(&leaves), merkle_root(&leaves));
+}

--- a/crates/pilotage-svs-db/src/output.rs
+++ b/crates/pilotage-svs-db/src/output.rs
@@ -1,0 +1,73 @@
+//! Output provenance: binding the active-database id into emitted output and
+//! checking it back.
+//!
+//! A [`RenderStamp`] is the provenance an output frame carries: the exact
+//! active-database id it was produced against. [`PackageStore::render_stamp`]
+//! mints one only when the database is actually available at the time and
+//! position (currency + coverage), so an unavailable database yields no stamp
+//! rather than an unattributed frame. [`PackageStore::verify_output_provenance`]
+//! checks a stamp back against the currently active database, so a frame drawn
+//! against a since-retired package is caught instead of trusted.
+
+use pilotage_geo::GeodeticPosition;
+
+use crate::activation::PackageStore;
+use crate::error::DbUnavailable;
+use crate::identity::{ActiveDbId, DayNumber};
+
+/// The provenance stamp an emitted output carries: the active-database id it was
+/// produced against. There is no public constructor; a stamp is minted only by
+/// [`PackageStore::render_stamp`], so it always names a database that was
+/// available when the output was produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenderStamp {
+    active_db: ActiveDbId,
+}
+
+impl RenderStamp {
+    /// The active-database id this output was produced against.
+    #[must_use]
+    pub fn active_db(&self) -> ActiveDbId {
+        self.active_db
+    }
+}
+
+impl PackageStore {
+    /// Mints a provenance stamp for output produced at `now` and `pos`, only
+    /// when the active database is available there. The stamp binds the exact
+    /// active id into the output so downstream can attribute and re-check it.
+    ///
+    /// # Errors
+    ///
+    /// The [`DbUnavailable`] reason the database is not available (no package,
+    /// currency lapse, or coverage exit) — in which case no output is stamped.
+    pub fn render_stamp(
+        &self,
+        now: DayNumber,
+        pos: &GeodeticPosition,
+    ) -> Result<RenderStamp, DbUnavailable> {
+        let active_db = self.availability(now, pos)?;
+        Ok(RenderStamp { active_db })
+    }
+
+    /// Checks an output's provenance stamp against the currently active
+    /// database. A stamp naming a database that is no longer active is refused,
+    /// so output produced against a retired package cannot be presented as
+    /// current.
+    ///
+    /// # Errors
+    ///
+    /// [`DbUnavailable::NoPackage`] when nothing is active, or
+    /// [`DbUnavailable::ProvenanceMismatch`] when the stamp names a different
+    /// database than the active one.
+    pub fn verify_output_provenance(&self, stamp: &RenderStamp) -> Result<(), DbUnavailable> {
+        match self.active_id() {
+            None => Err(DbUnavailable::NoPackage),
+            Some(id) if id == stamp.active_db => Ok(()),
+            Some(_) => Err(DbUnavailable::ProvenanceMismatch),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/output/tests.rs
+++ b/crates/pilotage-svs-db/src/output/tests.rs
@@ -65,3 +65,43 @@ fn rendered_output_provenance_bound_and_checked() {
         Err(DbUnavailable::ProvenanceMismatch)
     );
 }
+
+/// Acceptance (fail-closed): output provenance is content-addressed, not merely
+/// version-keyed. Re-signing DIFFERENT content under the SAME dataset and
+/// version produces a DIFFERENT active id, so a stamp minted against the earlier
+/// content is rejected once the new content is active.
+#[test]
+fn output_provenance_is_content_addressed_across_same_version() {
+    let trust = fixtures::trust_root();
+    let inside = fixtures::position(40.5, -74.5);
+    let mut store = PackageStore::new();
+
+    let id_a = store
+        .stage_and_activate(
+            &fixtures::candidate_tagged(DatasetId(1), PackageVersion::new(1, 0, 0), 0x11),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("content A activates");
+    let stamp_a = store.render_stamp(fixtures::NOW, &inside).expect("stamp A");
+    assert_eq!(stamp_a.active_db(), id_a);
+
+    // Different content, same dataset and version.
+    let id_b = store
+        .stage_and_activate(
+            &fixtures::candidate_tagged(DatasetId(1), PackageVersion::new(1, 0, 0), 0x22),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("content B activates");
+    assert_eq!(id_a.version, id_b.version, "same version");
+    assert_ne!(id_a, id_b, "different content must yield a different id");
+
+    // The earlier stamp is refused now that different content is active.
+    assert_eq!(
+        store.verify_output_provenance(&stamp_a),
+        Err(DbUnavailable::ProvenanceMismatch)
+    );
+}

--- a/crates/pilotage-svs-db/src/output/tests.rs
+++ b/crates/pilotage-svs-db/src/output/tests.rs
@@ -1,0 +1,67 @@
+//! Tests for output-provenance binding and checking.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use crate::activation::PackageStore;
+use crate::error::DbUnavailable;
+use crate::fixtures;
+use crate::identity::{DatasetId, PackageVersion};
+use crate::verify::UsePolicy;
+
+fn candidate(version: PackageVersion) -> crate::tile::CandidatePackage {
+    fixtures::candidate_with(DatasetId(1), version, true)
+}
+
+/// Acceptance: the active-database id is bound into emitted output and checked
+/// against the active package. Output is stamped only when the database is
+/// available, the stamp carries the exact active id, and a stamp from a retired
+/// package is rejected.
+#[test]
+fn rendered_output_provenance_bound_and_checked() {
+    let trust = fixtures::trust_root();
+    let inside = fixtures::position(40.5, -74.5);
+    let mut store = PackageStore::new();
+
+    // With no active package there is no output to attribute.
+    assert_eq!(
+        store.render_stamp(fixtures::NOW, &inside),
+        Err(DbUnavailable::NoPackage)
+    );
+
+    let id1 = store
+        .stage_and_activate(
+            &candidate(PackageVersion::new(1, 0, 0)),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v1 activates");
+
+    // The stamp carries the active id and verifies against the active package.
+    let stamp = store.render_stamp(fixtures::NOW, &inside).expect("stamp");
+    assert_eq!(stamp.active_db(), id1);
+    assert_eq!(store.verify_output_provenance(&stamp), Ok(()));
+
+    // Output outside coverage is not stamped (never attributed to an
+    // unavailable database).
+    assert_eq!(
+        store.render_stamp(fixtures::NOW, &fixtures::position(0.0, 0.0)),
+        Err(DbUnavailable::Coverage)
+    );
+
+    // After activating a new package, the earlier stamp no longer matches the
+    // active database and is refused.
+    let id2 = store
+        .stage_and_activate(
+            &candidate(PackageVersion::new(2, 0, 0)),
+            &trust,
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("v2 activates");
+    assert_ne!(id1, id2);
+    assert_eq!(
+        store.verify_output_provenance(&stamp),
+        Err(DbUnavailable::ProvenanceMismatch)
+    );
+}

--- a/crates/pilotage-svs-db/src/tile.rs
+++ b/crates/pilotage-svs-db/src/tile.rs
@@ -1,0 +1,70 @@
+//! Tiles and the candidate package that carries them.
+//!
+//! A tile is identified by its feature class, level, and geographic index
+//! ([`TileKey`]); the key is part of the tile's canonical bytes, so a tile
+//! cannot be relabelled to a different key without changing its leaf hash. A
+//! [`CandidatePackage`] is a manifest plus the tile bytes already present on the
+//! device — the airborne/runtime path verifies it, it never downloads it.
+
+use pilotage_geo::GeoTile;
+
+use crate::feature::FeatureClass;
+use crate::manifest::PackageManifest;
+
+/// The identity of a tile: its feature class, level of detail, and geographic
+/// index. Ordered class-then-level-then-index, giving tiles one canonical order
+/// for the tile-root hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TileKey {
+    /// The feature class this tile belongs to.
+    pub class: FeatureClass,
+    /// The level of detail.
+    pub level: u8,
+    /// The geographic tile index.
+    pub tile: GeoTile,
+}
+
+impl TileKey {
+    /// The total-order sort key: class, level, then geographic index.
+    #[must_use]
+    fn order(&self) -> (u8, u8, i32, i32) {
+        (
+            self.class.to_u8(),
+            self.level,
+            self.tile.lat_index,
+            self.tile.lon_index,
+        )
+    }
+}
+
+impl PartialOrd for TileKey {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TileKey {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.order().cmp(&other.order())
+    }
+}
+
+/// A tile: its key and its opaque payload bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tile {
+    /// The tile's identity.
+    pub key: TileKey,
+    /// The tile's opaque payload.
+    pub bytes: Vec<u8>,
+}
+
+/// A manifest together with the tile bytes already present on the device. This
+/// is the input to verification; the runtime path consumes it and never fetches
+/// or mutates it online.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CandidatePackage {
+    /// The package manifest.
+    pub manifest: PackageManifest,
+    /// The tiles the package supplies.
+    pub tiles: Vec<Tile>,
+}

--- a/crates/pilotage-svs-db/src/trust.rs
+++ b/crates/pilotage-svs-db/src/trust.rs
@@ -1,0 +1,98 @@
+//! The trust root and signature block, and verify-only signature checking.
+//!
+//! A package carries a [`PackageSignature`]: which trust key signed it and the
+//! 64-byte Ed25519 signature over the canonical manifest bytes. A [`TrustRoot`]
+//! is the set of public keys this device is configured to trust. Verification
+//! is one-way: this crate can *check* a signature against a configured key, but
+//! holds no private key and cannot *produce* one. Signing lives with the
+//! offline publisher (and, in this crate, only in test fixtures), so the
+//! airborne/runtime path can authenticate a package but never forge one.
+
+use core::fmt;
+
+use ed25519_dalek::{Signature, VerifyingKey};
+
+use crate::error::DbError;
+
+/// Identity of a trust key (the key a package claims to be signed by).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrustKeyId(pub u64);
+
+impl fmt::Display for TrustKeyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "key:{:016x}", self.0)
+    }
+}
+
+/// A package's signature: the trust key that signed it and the Ed25519
+/// signature bytes over the canonical manifest bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PackageSignature {
+    /// The trust key the package claims to be signed by.
+    pub key_id: TrustKeyId,
+    /// The 64-byte Ed25519 signature.
+    pub bytes: [u8; 64],
+}
+
+/// One configured trust anchor: a key id and its Ed25519 public key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrustAnchor {
+    /// The key id.
+    pub key_id: TrustKeyId,
+    /// The 32-byte Ed25519 public key.
+    pub public_key: [u8; 32],
+}
+
+/// The set of trust anchors this device is configured to accept. A package
+/// signed by a key absent from this set is refused, however well-formed its
+/// signature is.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TrustRoot {
+    anchors: Vec<TrustAnchor>,
+}
+
+impl TrustRoot {
+    /// A trust root over the given anchors.
+    #[must_use]
+    pub fn new(anchors: Vec<TrustAnchor>) -> Self {
+        Self { anchors }
+    }
+
+    /// The public key configured for `key_id`, if any.
+    #[must_use]
+    pub fn public_key(&self, key_id: TrustKeyId) -> Option<[u8; 32]> {
+        self.anchors
+            .iter()
+            .find(|a| a.key_id == key_id)
+            .map(|a| a.public_key)
+    }
+}
+
+/// Verifies `signature` over `message` against `trust`, failing closed: an
+/// untrusted key id is [`DbError::UntrustedRoot`], and a malformed key or a
+/// signature that does not verify is [`DbError::SignatureInvalid`]. Uses strict
+/// verification, which rejects the malleable non-canonical signature forms.
+///
+/// # Errors
+///
+/// [`DbError::UntrustedRoot`] or [`DbError::SignatureInvalid`].
+pub fn verify_signature(
+    trust: &TrustRoot,
+    signature: &PackageSignature,
+    message: &[u8],
+) -> Result<(), DbError> {
+    let public_key = trust
+        .public_key(signature.key_id)
+        .ok_or(DbError::UntrustedRoot {
+            key_id: signature.key_id,
+        })?;
+    let verifying_key =
+        VerifyingKey::from_bytes(&public_key).map_err(|_| DbError::SignatureInvalid)?;
+    let sig = Signature::from_bytes(&signature.bytes);
+    verifying_key
+        .verify_strict(message, &sig)
+        .map_err(|_| DbError::SignatureInvalid)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/trust/tests.rs
+++ b/crates/pilotage-svs-db/src/trust/tests.rs
@@ -1,0 +1,64 @@
+//! Tests for trust-root signature verification.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use super::{TrustRoot, verify_signature};
+use crate::canonical::manifest_canonical_bytes;
+use crate::error::DbError;
+use crate::fixtures;
+
+#[test]
+fn a_valid_signature_verifies_against_the_trust_root() {
+    let candidate = fixtures::candidate();
+    let bytes = manifest_canonical_bytes(&candidate.manifest);
+    assert_eq!(
+        verify_signature(
+            &fixtures::trust_root(),
+            &candidate.manifest.signature,
+            &bytes
+        ),
+        Ok(())
+    );
+}
+
+#[test]
+fn a_key_id_absent_from_the_trust_root_is_refused() {
+    let candidate = fixtures::candidate();
+    let bytes = manifest_canonical_bytes(&candidate.manifest);
+    let empty = TrustRoot::new(vec![]);
+    assert_eq!(
+        verify_signature(&empty, &candidate.manifest.signature, &bytes),
+        Err(DbError::UntrustedRoot {
+            key_id: candidate.manifest.signature.key_id,
+        })
+    );
+}
+
+#[test]
+fn a_trusted_id_bound_to_the_wrong_key_fails_signature() {
+    let candidate = fixtures::candidate();
+    let bytes = manifest_canonical_bytes(&candidate.manifest);
+    assert_eq!(
+        verify_signature(
+            &fixtures::wrong_key_trust_root(),
+            &candidate.manifest.signature,
+            &bytes,
+        ),
+        Err(DbError::SignatureInvalid)
+    );
+}
+
+#[test]
+fn a_mutated_message_fails_signature() {
+    let candidate = fixtures::candidate();
+    let mut bytes = manifest_canonical_bytes(&candidate.manifest);
+    bytes[0] ^= 0x01;
+    assert_eq!(
+        verify_signature(
+            &fixtures::trust_root(),
+            &candidate.manifest.signature,
+            &bytes
+        ),
+        Err(DbError::SignatureInvalid)
+    );
+}

--- a/crates/pilotage-svs-db/src/verify.rs
+++ b/crates/pilotage-svs-db/src/verify.rs
@@ -27,12 +27,16 @@ pub enum UsePolicy {
     OperationalRequired,
 }
 
-/// A package that passed every verification check. The inner manifest is
-/// private and there is no public constructor, so a value of this type is proof
-/// that [`verify_package`] accepted the package it describes.
+/// A package that passed every verification check, carrying both the verified
+/// manifest and the verified tile content. The fields are private and there is
+/// no public constructor, so a value of this type is proof that
+/// [`verify_package`] accepted exactly the manifest **and** tiles it holds —
+/// activation installs the two together, so content can never mix across
+/// versions.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VerifiedPackage {
     manifest: PackageManifest,
+    tiles: Vec<Tile>,
 }
 
 impl VerifiedPackage {
@@ -42,16 +46,23 @@ impl VerifiedPackage {
         &self.manifest
     }
 
+    /// The verified tile content.
+    #[must_use]
+    pub fn tiles(&self) -> &[Tile] {
+        &self.tiles
+    }
+
     /// The active-database id this package would install.
     #[must_use]
     pub fn active_id(&self) -> ActiveDbId {
         self.manifest.active_id()
     }
 
-    /// Consumes the token, yielding the verified manifest.
+    /// Consumes the token, yielding the verified manifest and tiles as one unit
+    /// so activation swaps them together.
     #[must_use]
-    pub(crate) fn into_manifest(self) -> PackageManifest {
-        self.manifest
+    pub(crate) fn into_parts(self) -> (PackageManifest, Vec<Tile>) {
+        (self.manifest, self.tiles)
     }
 }
 
@@ -76,10 +87,11 @@ pub fn verify_package(
     verify_tiles(candidate)?;
     let signed_bytes = manifest_canonical_bytes(manifest);
     verify_signature(trust, &manifest.signature, &signed_bytes)?;
-    check_use_policy(manifest.simulation_only, policy)?;
+    check_use_policy(manifest, policy)?;
     check_rollback(manifest, active)?;
     Ok(VerifiedPackage {
         manifest: manifest.clone(),
+        tiles: candidate.tiles.clone(),
     })
 }
 
@@ -144,10 +156,21 @@ fn tile_leaves_sorted(tiles: &[Tile]) -> Result<Vec<[u8; 32]>, DbError> {
     Ok(entries.into_iter().map(|(_, leaf)| leaf).collect())
 }
 
-/// Enforces the simulator-use policy.
-fn check_use_policy(simulation_only: bool, policy: UsePolicy) -> Result<(), DbError> {
-    if simulation_only && policy == UsePolicy::OperationalRequired {
+/// Enforces the use policy against every signed use marker: under an
+/// operational policy a `simulation_only` package is refused, and so is any
+/// package whose signed use restrictions forbid operational use. A simulator
+/// policy accepts both, still carrying the markers downstream.
+fn check_use_policy(manifest: &PackageManifest, policy: UsePolicy) -> Result<(), DbError> {
+    if policy != UsePolicy::OperationalRequired {
+        return Ok(());
+    }
+    if manifest.simulation_only {
         return Err(DbError::SimulationOnlyForbidden);
+    }
+    if manifest.provenance.restrictions.forbids_operational() {
+        return Err(DbError::OperationalUseRestricted {
+            restrictions: manifest.provenance.restrictions.bits(),
+        });
     }
     Ok(())
 }

--- a/crates/pilotage-svs-db/src/verify.rs
+++ b/crates/pilotage-svs-db/src/verify.rs
@@ -1,0 +1,172 @@
+//! The full verification pipeline: the only way to mint a [`VerifiedPackage`].
+//!
+//! [`verify_package`] runs every check a package must pass before it may become
+//! active — structure and datum discipline, currency, tile integrity against
+//! the Merkle root, signature against the trust root, the simulator-use policy,
+//! and the rollback policy — and returns a [`VerifiedPackage`] proof token only
+//! when all pass. The function is pure: it reads the candidate, the trust root,
+//! the current day, and the active id, and returns a value; it performs no I/O
+//! and mutates nothing, so activation can build the new state fully before any
+//! swap (see [`crate::activation`]).
+
+use crate::canonical::{manifest_canonical_bytes, tile_canonical_bytes};
+use crate::error::DbError;
+use crate::identity::{ActiveDbId, DayNumber};
+use crate::manifest::{Effectivity, PackageManifest};
+use crate::merkle::merkle_root;
+use crate::tile::{CandidatePackage, Tile};
+use crate::trust::{TrustRoot, verify_signature};
+
+/// Whether a simulator-only package may be activated in this context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsePolicy {
+    /// Simulator fixtures are permitted (the SIM default). They still activate
+    /// carrying their `simulation_only` marker downstream.
+    SimulatorPermitted,
+    /// Operational use is required: a `simulation_only` package is refused.
+    OperationalRequired,
+}
+
+/// A package that passed every verification check. The inner manifest is
+/// private and there is no public constructor, so a value of this type is proof
+/// that [`verify_package`] accepted the package it describes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerifiedPackage {
+    manifest: PackageManifest,
+}
+
+impl VerifiedPackage {
+    /// The verified manifest.
+    #[must_use]
+    pub fn manifest(&self) -> &PackageManifest {
+        &self.manifest
+    }
+
+    /// The active-database id this package would install.
+    #[must_use]
+    pub fn active_id(&self) -> ActiveDbId {
+        self.manifest.active_id()
+    }
+
+    /// Consumes the token, yielding the verified manifest.
+    #[must_use]
+    pub(crate) fn into_manifest(self) -> PackageManifest {
+        self.manifest
+    }
+}
+
+/// Verifies a candidate package in full, failing closed on the first violated
+/// rule. Pure: no I/O, no mutation. `active` is the id of the currently active
+/// package (for the rollback policy), `now` the current day (for currency), and
+/// `policy` whether a simulator fixture is acceptable here.
+///
+/// # Errors
+///
+/// The [`DbError`] naming the first failed check.
+pub fn verify_package(
+    candidate: &CandidatePackage,
+    trust: &TrustRoot,
+    now: DayNumber,
+    active: Option<ActiveDbId>,
+    policy: UsePolicy,
+) -> Result<VerifiedPackage, DbError> {
+    let manifest = &candidate.manifest;
+    manifest.validate_structure()?;
+    check_currency(&manifest.effectivity, now)?;
+    verify_tiles(candidate)?;
+    let signed_bytes = manifest_canonical_bytes(manifest);
+    verify_signature(trust, &manifest.signature, &signed_bytes)?;
+    check_use_policy(manifest.simulation_only, policy)?;
+    check_rollback(manifest, active)?;
+    Ok(VerifiedPackage {
+        manifest: manifest.clone(),
+    })
+}
+
+/// Rejects a package that is not yet effective or has expired.
+fn check_currency(effectivity: &Effectivity, now: DayNumber) -> Result<(), DbError> {
+    if effectivity.is_before_effective(now) {
+        return Err(DbError::NotYetEffective {
+            now,
+            effective: effectivity.effective,
+        });
+    }
+    if effectivity.is_after_expiry(now) {
+        return Err(DbError::Expired {
+            now,
+            expiry: effectivity.expiry,
+        });
+    }
+    Ok(())
+}
+
+/// Verifies the tiles supplied match the manifest: exact count, no duplicate
+/// keys, and a recomputed tile-root that equals the declared one.
+fn verify_tiles(candidate: &CandidatePackage) -> Result<(), DbError> {
+    let manifest = &candidate.manifest;
+    let supplied = candidate.tiles.len();
+    if supplied as u64 != u64::from(manifest.tile_count) {
+        return Err(DbError::TileCountMismatch {
+            declared: manifest.tile_count,
+            supplied: supplied as u32,
+        });
+    }
+    let leaves = tile_leaves_sorted(&candidate.tiles)?;
+    if merkle_root(&leaves) != manifest.tile_root {
+        return Err(DbError::TileRootMismatch);
+    }
+    Ok(())
+}
+
+/// The tiles' leaf hashes in canonical (key-sorted) order, rejecting a
+/// duplicate key so the tile set is unambiguous.
+fn tile_leaves_sorted(tiles: &[Tile]) -> Result<Vec<[u8; 32]>, DbError> {
+    let mut entries: Vec<(crate::tile::TileKey, [u8; 32])> = tiles
+        .iter()
+        .map(|tile| {
+            (
+                tile.key,
+                crate::merkle::tile_leaf_hash(&tile_canonical_bytes(tile)),
+            )
+        })
+        .collect();
+    entries.sort_by_key(|entry| entry.0);
+    for pair in entries.windows(2) {
+        if pair[0].0 == pair[1].0 {
+            let key = pair[0].0;
+            return Err(DbError::DuplicateTile {
+                class: key.class,
+                lat_index: key.tile.lat_index,
+                lon_index: key.tile.lon_index,
+            });
+        }
+    }
+    Ok(entries.into_iter().map(|(_, leaf)| leaf).collect())
+}
+
+/// Enforces the simulator-use policy.
+fn check_use_policy(simulation_only: bool, policy: UsePolicy) -> Result<(), DbError> {
+    if simulation_only && policy == UsePolicy::OperationalRequired {
+        return Err(DbError::SimulationOnlyForbidden);
+    }
+    Ok(())
+}
+
+/// Rejects an out-of-policy rollback: a candidate older than the active package
+/// of the same dataset. A different dataset is a different database, not a
+/// rollback of this one.
+fn check_rollback(manifest: &PackageManifest, active: Option<ActiveDbId>) -> Result<(), DbError> {
+    if let Some(active) = active
+        && active.dataset == manifest.provenance.dataset
+        && manifest.provenance.version < active.version
+    {
+        return Err(DbError::RollbackBlocked {
+            active: active.version,
+            candidate: manifest.provenance.version,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-svs-db/src/verify.rs
+++ b/crates/pilotage-svs-db/src/verify.rs
@@ -33,10 +33,19 @@ pub enum UsePolicy {
 /// [`verify_package`] accepted exactly the manifest **and** tiles it holds —
 /// activation installs the two together, so content can never mix across
 /// versions.
+///
+/// A token also records the store state it was verified against — the active id
+/// and the activation generation observed at verify time. Activation refuses a
+/// token whose recorded state no longer matches the store, so a stale token
+/// cannot be replayed to roll the active package backward. The token is inert
+/// outside its crate: only [`crate::PackageStore`] can install it, and only when
+/// the store is still in the state the token expects.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VerifiedPackage {
     manifest: PackageManifest,
     tiles: Vec<Tile>,
+    expected_active: Option<ActiveDbId>,
+    expected_generation: u64,
 }
 
 impl VerifiedPackage {
@@ -56,6 +65,26 @@ impl VerifiedPackage {
     #[must_use]
     pub fn active_id(&self) -> ActiveDbId {
         self.manifest.active_id()
+    }
+
+    /// The active id the token was verified against.
+    #[must_use]
+    pub(crate) fn expected_active(&self) -> Option<ActiveDbId> {
+        self.expected_active
+    }
+
+    /// The activation generation the token was verified against.
+    #[must_use]
+    pub(crate) fn expected_generation(&self) -> u64 {
+        self.expected_generation
+    }
+
+    /// Records the activation generation this token was verified against, so
+    /// activation can detect an intervening activation.
+    #[must_use]
+    pub(crate) fn stamp_generation(mut self, generation: u64) -> Self {
+        self.expected_generation = generation;
+        self
     }
 
     /// Consumes the token, yielding the verified manifest and tiles as one unit
@@ -92,6 +121,8 @@ pub fn verify_package(
     Ok(VerifiedPackage {
         manifest: manifest.clone(),
         tiles: candidate.tiles.clone(),
+        expected_active: active,
+        expected_generation: 0,
     })
 }
 

--- a/crates/pilotage-svs-db/src/verify/tests.rs
+++ b/crates/pilotage-svs-db/src/verify/tests.rs
@@ -1,0 +1,270 @@
+//! Tests for the verification pipeline and the fail-closed rules.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pilotage_geo::AvailabilityReason;
+
+use super::{UsePolicy, verify_package};
+use crate::activation::PackageStore;
+use crate::error::DbError;
+use crate::fixtures;
+use crate::identity::{ActiveDbId, DatasetId, DayNumber, PackageVersion, ProviderId};
+
+fn trusted() -> crate::trust::TrustRoot {
+    fixtures::trust_root()
+}
+
+#[test]
+fn a_valid_package_verifies_and_reports_its_id() {
+    let candidate = fixtures::candidate();
+    let verified = verify_package(
+        &candidate,
+        &trusted(),
+        fixtures::NOW,
+        None,
+        UsePolicy::SimulatorPermitted,
+    )
+    .expect("valid package verifies");
+    assert_eq!(verified.active_id(), candidate.manifest.active_id());
+}
+
+/// Acceptance: a one-byte mutation of any tile fails the tile-root check, and a
+/// one-byte mutation of the manifest fails the signature check. Neither is
+/// re-signed — a tamperer cannot produce a fresh signature.
+#[test]
+fn one_byte_mutation_fails_verification() {
+    // Tile mutation -> recomputed tile-root disagrees with the declared root.
+    let mut tampered_tile = fixtures::candidate();
+    tampered_tile.tiles[0].bytes[0] ^= 0x01;
+    assert_eq!(
+        verify_package(
+            &tampered_tile,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::TileRootMismatch)
+    );
+
+    // Manifest mutation -> signature no longer verifies.
+    let mut tampered_manifest = fixtures::candidate();
+    tampered_manifest.manifest.coverage.region.max_lat_deg += 0.001;
+    assert_eq!(
+        verify_package(
+            &tampered_manifest,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::SignatureInvalid)
+    );
+}
+
+/// Acceptance: the trust-root, rollback, expiry, coverage, and datum rules each
+/// fail closed with a deterministic, typed reason. Each rule is asserted by a
+/// helper so this anchor stays readable.
+#[test]
+fn trust_rollback_expiry_coverage_datum_rules_fail_closed() {
+    assert_untrusted_root_refused();
+    assert_expiry_refused();
+    assert_not_yet_effective_refused();
+    assert_rollback_blocked();
+    assert_wrong_datum_refused();
+    assert_coverage_exit_is_coverage_reason();
+}
+
+fn assert_untrusted_root_refused() {
+    let candidate = fixtures::candidate();
+    assert_eq!(
+        verify_package(
+            &candidate,
+            &crate::trust::TrustRoot::new(vec![]),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::UntrustedRoot {
+            key_id: candidate.manifest.signature.key_id,
+        })
+    );
+}
+
+fn assert_expiry_refused() {
+    assert!(matches!(
+        verify_package(
+            &fixtures::candidate(),
+            &trusted(),
+            DayNumber(250),
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::Expired { .. })
+    ));
+}
+
+fn assert_not_yet_effective_refused() {
+    assert!(matches!(
+        verify_package(
+            &fixtures::candidate(),
+            &trusted(),
+            DayNumber(50),
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::NotYetEffective { .. })
+    ));
+}
+
+fn assert_rollback_blocked() {
+    let active = ActiveDbId {
+        dataset: DatasetId(1),
+        provider: ProviderId(0xB2),
+        version: PackageVersion::new(2, 0, 0),
+        simulation_only: true,
+    };
+    assert_eq!(
+        verify_package(
+            &fixtures::candidate(),
+            &trusted(),
+            fixtures::NOW,
+            Some(active),
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::RollbackBlocked {
+            active: PackageVersion::new(2, 0, 0),
+            candidate: PackageVersion::new(1, 0, 0),
+        })
+    );
+}
+
+fn assert_wrong_datum_refused() {
+    let mut wrong = fixtures::candidate();
+    wrong.manifest.coverage.horizontal_datum = pilotage_geo::HorizontalDatum::Unknown;
+    assert_eq!(
+        verify_package(
+            &wrong,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::UnknownHorizontalDatum)
+    );
+}
+
+fn assert_coverage_exit_is_coverage_reason() {
+    let mut store = PackageStore::new();
+    store
+        .stage_and_activate(
+            &fixtures::candidate(),
+            &trusted(),
+            fixtures::NOW,
+            UsePolicy::SimulatorPermitted,
+        )
+        .expect("valid package activates");
+    let reason = store
+        .availability_for_position(&fixtures::position(0.0, 0.0))
+        .expect_err("position is outside coverage");
+    assert_eq!(
+        reason.to_availability_reason(),
+        AvailabilityReason::Coverage
+    );
+}
+
+/// Acceptance: a `simulation_only` package is never accepted under an
+/// operational-use policy, while a non-simulator package is.
+#[test]
+fn simulation_only_never_accepted_as_operational() {
+    let sim = fixtures::candidate();
+    assert!(sim.manifest.simulation_only);
+    assert_eq!(
+        verify_package(
+            &sim,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::OperationalRequired,
+        ),
+        Err(DbError::SimulationOnlyForbidden)
+    );
+
+    // The same package is usable in the simulator, still carrying its marker.
+    let verified = verify_package(
+        &sim,
+        &trusted(),
+        fixtures::NOW,
+        None,
+        UsePolicy::SimulatorPermitted,
+    )
+    .expect("simulator package is usable in the simulator");
+    assert!(verified.active_id().simulation_only);
+
+    // A non-simulator package passes the operational policy.
+    let operational = fixtures::candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), false);
+    assert!(
+        verify_package(
+            &operational,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::OperationalRequired,
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn tile_count_mismatch_is_refused() {
+    let mut candidate = fixtures::candidate();
+    candidate.tiles.pop();
+    assert_eq!(
+        verify_package(
+            &candidate,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::TileCountMismatch {
+            declared: 3,
+            supplied: 2,
+        })
+    );
+}
+
+#[test]
+fn a_duplicate_tile_key_is_refused() {
+    let mut candidate = fixtures::candidate();
+    let dup = candidate.tiles[0].clone();
+    candidate.tiles.push(dup);
+    candidate.manifest.tile_count = 4;
+    assert!(matches!(
+        verify_package(
+            &candidate,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        Err(DbError::DuplicateTile { .. })
+    ));
+}
+
+#[test]
+fn a_legitimately_resigned_change_verifies() {
+    let mut candidate = fixtures::candidate();
+    candidate.manifest.coverage.region.max_lat_deg += 0.5;
+    fixtures::sign(&mut candidate.manifest);
+    assert!(
+        verify_package(
+            &candidate,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        )
+        .is_ok()
+    );
+}

--- a/crates/pilotage-svs-db/src/verify/tests.rs
+++ b/crates/pilotage-svs-db/src/verify/tests.rs
@@ -123,6 +123,7 @@ fn assert_rollback_blocked() {
         provider: ProviderId(0xB2),
         version: PackageVersion::new(2, 0, 0),
         simulation_only: true,
+        content_hash: [0; 32],
     };
     assert_eq!(
         verify_package(
@@ -259,6 +260,38 @@ fn signed_use_restrictions_refuse_operational_use() {
             UsePolicy::OperationalRequired,
         )
         .is_ok()
+    );
+}
+
+/// Acceptance (fail-closed): a manifest carrying an unknown use-restriction bit
+/// is refused at validation — an unrecognized restriction is never assumed to
+/// permit operational use — and it is refused under every policy, not only the
+/// operational one.
+#[test]
+fn unknown_use_restriction_bit_is_refused() {
+    let unknown = fixtures::unknown_restriction_candidate();
+    let expected = Err(DbError::UnknownUseRestriction {
+        restrictions: unknown.manifest.provenance.restrictions.bits(),
+    });
+    assert_eq!(
+        verify_package(
+            &unknown,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::OperationalRequired,
+        ),
+        expected
+    );
+    assert_eq!(
+        verify_package(
+            &unknown,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        ),
+        expected
     );
 }
 

--- a/crates/pilotage-svs-db/src/verify/tests.rs
+++ b/crates/pilotage-svs-db/src/verify/tests.rs
@@ -165,7 +165,7 @@ fn assert_coverage_exit_is_coverage_reason() {
         )
         .expect("valid package activates");
     let reason = store
-        .availability_for_position(&fixtures::position(0.0, 0.0))
+        .availability(fixtures::NOW, &fixtures::position(0.0, 0.0))
         .expect_err("position is outside coverage");
     assert_eq!(
         reason.to_availability_reason(),
@@ -201,11 +201,58 @@ fn simulation_only_never_accepted_as_operational() {
     .expect("simulator package is usable in the simulator");
     assert!(verified.active_id().simulation_only);
 
-    // A non-simulator package passes the operational policy.
-    let operational = fixtures::candidate_with(DatasetId(1), PackageVersion::new(1, 0, 0), false);
+    // A genuinely operational package (not simulation_only, no restrictions)
+    // passes the operational policy.
+    let operational = fixtures::operational_candidate();
     assert!(
         verify_package(
             &operational,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::OperationalRequired,
+        )
+        .is_ok()
+    );
+}
+
+/// Acceptance: the manifest's signed use restrictions are enforced. A package
+/// that is not `simulation_only` but carries `NO_OPERATIONAL_USE` is still
+/// refused for operational use; only a package with no operational restriction
+/// is accepted.
+#[test]
+fn signed_use_restrictions_refuse_operational_use() {
+    let restricted = fixtures::restricted_candidate();
+    assert!(!restricted.manifest.simulation_only);
+    assert_eq!(
+        verify_package(
+            &restricted,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::OperationalRequired,
+        ),
+        Err(DbError::OperationalUseRestricted {
+            restrictions: restricted.manifest.provenance.restrictions.bits(),
+        })
+    );
+
+    // Under the simulator policy the same restricted package is usable.
+    assert!(
+        verify_package(
+            &restricted,
+            &trusted(),
+            fixtures::NOW,
+            None,
+            UsePolicy::SimulatorPermitted,
+        )
+        .is_ok()
+    );
+
+    // A package with no operational restriction is accepted operationally.
+    assert!(
+        verify_package(
+            &fixtures::operational_candidate(),
             &trusted(),
             fixtures::NOW,
             None,


### PR DESCRIPTION
## SVS-02: signed, provenance-preserving aeronautical database packages

**SIM / NOT FOR FLIGHT.** This is a simulator/engineering contract. Passing these tests does **not** qualify a data supplier or an aeronautical database. Fixtures are permanently marked `simulation_only` and are never accepted as operational databases. Authority acceptance and provider approval are tracked by AIR-03, not here.

Refs #33 (does not close).

### What this adds

A new crate, **`pilotage-svs-db`**, defining a versioned, integrity-checked, atomically activated database package for terrain, obstacles, aerodromes, runways, and taxiways.

- A **versioned manifest** pins provenance, effectivity, coverage + datum, content, a Merkle **tile-root** hash, a permanent `simulation_only` flag, and an Ed25519 **signature** bound to a configured trust root.
- **Verification** checks every tile and the whole manifest before activation, failing closed with a typed reason.
- **Activation** is a pure validate-then-swap: an interrupted update yields the complete prior package or none, never a partial/mixed mix.
- Every failure maps onto `pilotage_geo::AvailabilityReason::{Database, Coverage}` for a consumer.

### Design decisions

**std + real asymmetric crypto.** The crate is `std`. Hashing uses **`sha2` 0.10.9** (already resolved in the workspace lock — no new hash version). The trust-root signature uses **`ed25519-dalek` v2**, a real, vetted asymmetric primitive, because a symmetric MAC would let the verify-only airborne side *forge* a package, contradicting "the airborne/runtime path does not mutate databases." The library is **verify-only**; signing lives entirely in test fixtures with fixed-seed keys, modelling the offline publisher. Both deps are workspace-pinned. Following the REN-02 glyph-pack / #37 calibration pattern, the canonical bytes are a fixed little-endian layout, and a recorded SHA-256 of the fixture manifest is pinned in a test so the encoding cannot drift silently.

**Datum vocabulary is consumed, not re-minted.** The manifest's coverage carries `pilotage_geo::HorizontalDatum` / `VerticalDatum` and their realization/geoid identities directly; there are no parallel datum types.

**Atomicity model.** `verify_package(...)` is a pure function (candidate, trust root, current day, active id, use policy) → `Result<VerifiedPackage, DbError>` with no I/O and no mutation. `PackageStore::activate(token)` performs the only mutation: a single assignment swapping in the new `ActivePackage`. A failed verification never reaches the swap (prior package or none stays intact); a verified-but-not-yet-installed token leaves the prior package active until the swap. This is exercised without any real I/O or sleeps.

### Crate module map

`error` (typed `DbError` + `DbUnavailable` → geo availability), `identity` (dataset/provider/version/day/`ActiveDbId`), `feature` (classes + set), `manifest` (+ `provenance`, `coverage`, `content`, `effectivity`; `MANIFEST_SCHEMA_VERSION` + compatibility policy), `canonical` (byte layout + content hash), `merkle` (domain-separated tile-root), `tile` (keys + candidate package), `trust` (trust root + Ed25519 verify), `verify` (pipeline + `VerifiedPackage` proof token), `activation` (`PackageStore` validate-then-swap).

### Acceptance criteria → evidence

| Acceptance criterion | Test (`cargo test -p pilotage-svs-db`) |
|---|---|
| Manifest schema versioned with an explicit compatibility policy | `manifest::tests::manifest_schema_versioned_with_compatibility_policy` |
| A one-byte mutation fails package/tile verification | `verify::tests::one_byte_mutation_fails_verification` |
| Interrupted update yields the complete prior package or no package, never a partial mix | `activation::tests::interrupted_update_yields_prior_or_no_package` |
| Trust-root, rollback, expiry, coverage, and datum rules have deterministic tests | `verify::tests::trust_rollback_expiry_coverage_datum_rules_fail_closed` |
| Active database id carried into rendered output and diagnostics | `activation::tests::active_database_id_carried_into_diagnostics` |
| `simulation_only` fixtures marked and never accepted as operational | `verify::tests::simulation_only_never_accepted_as_operational` |

37 tests pass. Additional tests cover the Merkle construction, canonical byte stability (pinned recorded hash), tile-count/duplicate-key refusal, wrong-key vs untrusted-key signature failures, and coverage/no-package availability mapping.

### Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p pilotage-svs-db` (37 passing), `cargo doc` with `-D missing_docs -D rustdoc::broken_intra_doc_links`, and `cargo build --release` are green for this crate; `scripts/check-structure.sh` reports no violation in `crates/pilotage-svs-db`. Added a `database package integrity (SVS-02)` CI step (owned this wave). The crate is `std`, so no bare-metal `thumbv7em` check is added.

**Cargo.lock:** the crypto dependency tree (`ed25519-dalek`, `curve25519-dalek`, `sha2`, and transitive crates) is committed on this lane. `cargo test --locked -p pilotage-svs-db` passes against an isolated checkout of this branch (41 tests). Only this lane's crypto hunks were committed; concurrent lanes' lockfile hunks were left untouched.

### Review response

Five follow-up gaps were addressed on this same lane, each with a test:

| Gap | Fix | Test |
|---|---|---|
| Signed use restrictions ignored (only `simulation_only` checked) | Operational policy now refuses any package whose signed `NO_OPERATIONAL_USE`/`TRAINING_ONLY` restriction forbids operational use | `verify::tests::signed_use_restrictions_refuse_operational_use` |
| "Atomic activation" swapped only the manifest, not tile data | `VerifiedPackage`/`ActivePackage` carry the verified tiles and swap them with the manifest as one unit | `activation::tests::interrupted_update_preserves_complete_content_never_a_mix` |
| No currency check at use | The availability query takes the current day and fails closed once the active package is outside its effectivity/expiry window | `activation::tests::currency_is_rechecked_at_use_time` |
| Output provenance not bound | `PackageStore::render_stamp` binds the active id into a `RenderStamp` minted only when available; `verify_output_provenance` rejects a stamp from a retired package | `output::tests::rendered_output_provenance_bound_and_checked` |
| Cargo.lock stale under `--locked` | Crypto lock entries committed on this lane | verified via isolated `cargo test --locked` |

### Re-review response (two fail-open defects)

| Defect | Fix | Counter-test |
|---|---|---|
| Different content could share an `ActiveDbId` (same dataset/version, re-signed), so a retired-package `RenderStamp` still verified `Ok` | `ActiveDbId` (and the `RenderStamp` it stamps) now carries the signed manifest's content hash, so distinct content yields a distinct id and a stale stamp is a `ProvenanceMismatch` | `output::tests::output_provenance_is_content_addressed_across_same_version` |
| An unknown signed use-restriction bit was treated as harmless (fail-open) | `UseRestrictions::KNOWN_MASK` defined; manifest validation refuses any bit outside it (`DbError::UnknownUseRestriction`), under every policy | `verify::tests::unknown_use_restriction_bit_is_refused` |
| A replayed stale verification token could roll the active DB backward, bypassing rollback policy | `PackageStore::activate` demoted to crate-internal (public activation is only the atomic `stage_and_activate`); each token carries the active id + a monotonic generation observed at verify time, and the swap refuses a mismatched token (`DbError::StaleActivation`), leaving the active package unchanged | `activation::tests::stale_verification_token_cannot_roll_back_the_active_package` |

Full local CI (fmt `--all --check`, clippy `--all-targets --locked -D warnings`, `test --locked -p pilotage-svs-db`, doc `-D missing_docs`, build --release, check-structure, and the thumbv7em no_std check) is green on an **isolated** `git worktree` checkout of this branch. 44 tests pass.

**Not yet closing #33:** `RenderStamp` provenance lives inside `pilotage-svs-db` and is not yet carried/enforced by an actual rendered frame/scene; that render-path enforcement is a separate later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
