### PR TITLE
ATT-01: raster behavior tests and inverted recovery-cue coverage (#17)

### DIFF
--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -80,7 +80,12 @@ pub fn draw_pfd(
             scene.fill_color(palette::BLACK)?;
             scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
             if att_status.shows_value() {
-                horizon::draw_background(scene, data.roll_rad.value, data.pitch_rad.value)?;
+                horizon::draw_background(
+                    scene,
+                    data.roll_rad.value,
+                    data.pitch_rad.value,
+                    data.presentation.min_reverse_band_rad,
+                )?;
             }
             scene.end_layer(LayerId::Background)?;
         }

--- a/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
@@ -173,6 +173,18 @@ fn chevrons_point_toward_the_horizon() {
     };
     assert!(apex_sign(&nose_high).iter().all(|&down| down));
     assert!(apex_sign(&nose_low).iter().all(|&down| !down));
+
+    // Inverted flight still cues recovery: an inverted, steeply nose-high
+    // attitude reaches the tier through the display's physical pitch (not a
+    // Euler branch) and draws chevrons, which the roll-rotated frame then
+    // aims at the horizon on screen.
+    let inv_data = oriented(180.0, 60.0);
+    assert!(inv_data.presentation.inverted, "inverted tier reached");
+    assert_eq!(
+        chevrons_in(&render(&inv_data, &PfdConfig::default())),
+        2,
+        "inverted nose-high chevrons drawn"
+    );
 }
 
 #[test]

--- a/crates/pilotage-instrument-panels/src/pfd/horizon.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/horizon.rs
@@ -14,17 +14,33 @@ use crate::palette;
 
 const PX_PER_DEG_PITCH: f32 = 7.2;
 const ROLL_ARC_R: f32 = 144.0;
+/// Half the panel height expressed in degrees of pitch: the pitch at which
+/// the level horizon reaches the top/bottom edge. Beyond it the true
+/// horizon has left the viewport.
+const VIEWPORT_HALF_PITCH_DEG: f32 = (crate::PANEL_H / 2.0) / PX_PER_DEG_PITCH;
 /// Pitch-ladder marks are culled beyond this radius so they stay inside
 /// the roll arc (the pyG5 clip).
 const LADDER_MAX_Y: f32 = 104.0;
 
 /// Optional sky/ground fill in the roll-rotated attitude frame.
+///
+/// The fill boundary is clamped so that at extreme pitch — when the true
+/// horizon has left the viewport — a minimum reverse-color band of the
+/// opposite field stays at the edge, and the attitude background never
+/// collapses to a single flat color. The band sits on the physical
+/// ground/sky side (the sign of display pitch), not an Euler branch, and
+/// its thickness is the profile's `min_reverse_band`. The pitch ladder and
+/// horizon line keep the true, unclamped pitch (they cull off-screen), so
+/// only the color field is held.
 pub fn draw_background(
     scene: &mut SceneWriter<'_>,
     roll_rad: f32,
     pitch_rad: f32,
+    min_reverse_band_rad: f32,
 ) -> Result<(), SceneError> {
-    let pitch_deg = pitch_rad * RAD_TO_DEG;
+    let band_deg = min_reverse_band_rad * RAD_TO_DEG;
+    let fill_limit_deg = VIEWPORT_HALF_PITCH_DEG - band_deg;
+    let pitch_deg = (pitch_rad * RAD_TO_DEG).clamp(-fill_limit_deg, fill_limit_deg);
     let horizon_y = pitch_deg * PX_PER_DEG_PITCH;
 
     scene.save()?;

--- a/crates/pilotage-instrument-raster/src/raster/tests.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests.rs
@@ -6,6 +6,7 @@ use pilotage_instrument_scene::{Anchor, LayerId, MAX_SCENE_BYTES, PaintMode, Rgb
 
 use crate::{FrameId, FramebufferDims, RasterError, RenderReport, RenderStatus, render};
 
+mod attitude_behavior;
 mod conformance;
 mod frame_hashes;
 mod work_budget;

--- a/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
@@ -1,0 +1,366 @@
+#![allow(clippy::expect_used, clippy::panic)]
+//! ATT-01 raster behavior: the rendered sky/ground band at extreme and
+//! inverted attitudes, checked at the pixel level against an independent
+//! f64 down-vector reference.
+//!
+//! The scene tests prove the geometry the panel *emits*; these prove what
+//! the reference rasterizer actually *paints*, closing the loop from
+//! attitude to lit pixels. The reference here derives display pitch and
+//! bank straight from the quaternion in f64 — a code path independent of
+//! the f32 `libm` presentation under test — so a sign or rotation error in
+//! the draw layer surfaces as a misclassified pixel, not a plausible frame.
+
+use pilotage_instrument_panels::{PANEL_H, PANEL_W, PfdConfig, draw_pfd};
+use pilotage_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
+use pilotage_instrument_state::{
+    AirData, AircraftState, Attitude, EstimateQuality, FreshnessPolicy, Kinematics, Quat, Stamped,
+    ValidFlags, resolve,
+};
+use std::vec::Vec;
+
+use crate::{FrameId, FramebufferDims, RenderStatus, render};
+
+const W: u32 = PANEL_W as u32;
+const H: u32 = PANEL_H as u32;
+const CX: f64 = PANEL_W as f64 / 2.0;
+const CY: f64 = PANEL_H as f64 / 2.0;
+/// Horizon geometry constant shared with `pfd/horizon.rs`: screen pixels
+/// per degree of display pitch.
+const PX_PER_DEG_PITCH: f64 = 7.2;
+
+/// Sky and ground fills (mirrors `panels::palette`), the only two colors a
+/// clean background sample can take.
+const SKY: [u8; 3] = [0, 110, 210];
+const GROUND: [u8; 3] = [140, 96, 44];
+const RED: [u8; 3] = [255, 0, 0];
+
+/// f32 ZYX euler → quaternion, matching the panel orientation fixtures.
+fn euler_quat(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
+    let d = core::f32::consts::PI / 180.0;
+    let (r, p, y) = (roll_deg * d / 2.0, pitch_deg * d / 2.0, yaw_deg * d / 2.0);
+    let (cr, sr) = (libm::cosf(r), libm::sinf(r));
+    let (cp, sp) = (libm::cosf(p), libm::sinf(p));
+    let (cy, sy) = (libm::cosf(y), libm::sinf(y));
+    Quat {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy,
+    }
+}
+
+/// A valid flying state at the given orientation, populated enough that the
+/// PFD paints every band.
+fn state_at(roll_deg: f32, pitch_deg: f32) -> AircraftState {
+    let mut state = AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: euler_quat(roll_deg, pitch_deg, 0.0),
+                rates_rps: [0.0, 0.0, 0.0],
+            }),
+            age_ms: Some(20.0),
+        },
+        ..AircraftState::default()
+    };
+    state.quality = EstimateQuality::Good;
+    state.valid = ValidFlags {
+        attitude: true,
+        rates: true,
+        position: true,
+        velocity: true,
+        ..ValidFlags::default()
+    };
+    state.kinematics = Stamped {
+        data: Some(Kinematics {
+            pos_ned_m: [0.0, 0.0, -300.0],
+            vel_ned_mps: [40.0, 0.0, -1.0],
+        }),
+        age_ms: Some(20.0),
+    };
+    state.air = Stamped {
+        data: Some(AirData {
+            ias_mps: Some(40.0),
+            baro_setting_hpa: Some(1013.0),
+        }),
+        age_ms: Some(20.0),
+    };
+    state
+}
+
+/// Independent f64 display (pitch_rad, bank_rad) from the quaternion's
+/// world-down vector in body coordinates — the same quadratic form used
+/// physically, recomputed here in f64 as the oracle. Valid away from the
+/// vertical bank-hold window.
+fn ref_pitch_bank(q: Quat) -> (f64, f64) {
+    let (w, x, y, z) = (
+        f64::from(q.w),
+        f64::from(q.x),
+        f64::from(q.y),
+        f64::from(q.z),
+    );
+    let down_x = 2.0 * (x * z - w * y);
+    let down_y = 2.0 * (y * z + w * x);
+    let down_z = 1.0 - 2.0 * (x * x + y * y);
+    let pitch = -down_x.clamp(-1.0, 1.0).asin();
+    let bank = down_y.atan2(down_z);
+    (pitch, bank)
+}
+
+/// True where the oracle places sky at screen pixel `(px, py)`: transform
+/// the screen offset into the roll-rotated attitude frame and compare to
+/// the horizon row. Sky is the half above (smaller rotated-y than) the
+/// horizon.
+fn ref_is_sky(px: u32, py: u32, pitch_rad: f64, bank_rad: f64) -> bool {
+    let dx = f64::from(px) + 0.5 - CX;
+    let dy = f64::from(py) + 0.5 - CY;
+    let y_rot = dx * bank_rad.sin() + dy * bank_rad.cos();
+    let horizon_y = pitch_rad.to_degrees() * PX_PER_DEG_PITCH;
+    y_rot < horizon_y
+}
+
+fn pixel(fb: &[u8], px: u32, py: u32) -> [u8; 3] {
+    let i = ((py * W + px) * 4) as usize;
+    [fb[i], fb[i + 1], fb[i + 2]]
+}
+
+fn manhattan(a: [u8; 3], b: [u8; 3]) -> i32 {
+    (i32::from(a[0]) - i32::from(b[0])).abs()
+        + (i32::from(a[1]) - i32::from(b[1])).abs()
+        + (i32::from(a[2]) - i32::from(b[2])).abs()
+}
+
+/// Classifies a background pixel as sky, ground, or neither (symbology,
+/// horizon anti-aliasing). The sky/ground fills sit 320 apart in Manhattan
+/// space, so a tight threshold cleanly rejects every other color.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+enum Fill {
+    Sky,
+    Ground,
+    Other,
+}
+
+fn classify(px: [u8; 3]) -> Fill {
+    let (ds, dg) = (manhattan(px, SKY), manhattan(px, GROUND));
+    if ds < 90 && ds <= dg {
+        Fill::Sky
+    } else if dg < 90 {
+        Fill::Ground
+    } else {
+        Fill::Other
+    }
+}
+
+/// Renders the PFD at an orientation into an RGBA framebuffer.
+fn render_pfd(roll_deg: f32, pitch_deg: f32) -> Vec<u8> {
+    let data = resolve(&state_at(roll_deg, pitch_deg), &FreshnessPolicy::default());
+    let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+    let mut writer = SceneWriter::new(&mut buf).expect("writer");
+    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("pfd");
+    let n = writer.finish();
+    buf.truncate(n);
+
+    let mut fb = std::vec![0u8; (W * H * 4) as usize];
+    let report = render(
+        &buf,
+        &mut fb,
+        FramebufferDims::tight(W, H),
+        FrameId::default(),
+    )
+    .expect("panel renders");
+    assert_eq!(report.status, RenderStatus::Painted);
+    fb
+}
+
+/// Roll-arc radius plus margin: the central attitude symbology (roll arc,
+/// sky pointer, aircraft symbol, pitch ladder) lives inside this radius.
+const SYMBOLOGY_R: f64 = 172.0;
+
+/// A pixel sits in a clean background band — outside the central attitude
+/// symbology circle and clear of the left/right speed/altitude tapes — so
+/// its color is the sky or ground fill, not a symbol.
+fn is_clean_bg(px: u32, py: u32) -> bool {
+    let dx = f64::from(px) + 0.5 - CX;
+    let dy = f64::from(py) + 0.5 - CY;
+    let outside_symbology = (dx * dx + dy * dy).sqrt() > SYMBOLOGY_R;
+    let clear_of_tapes = (80..400).contains(&px);
+    outside_symbology && clear_of_tapes
+}
+
+/// The dominant background fill over a horizontal strip clear of the
+/// central symbology and side tapes, at a given screen row.
+fn strip_fill(fb: &[u8], row: u32) -> Fill {
+    let (mut sky, mut ground) = (0u32, 0u32);
+    let mut px = 80;
+    while px < 400 {
+        if is_clean_bg(px, row) {
+            match classify(pixel(fb, px, row)) {
+                Fill::Sky => sky += 1,
+                Fill::Ground => ground += 1,
+                Fill::Other => {}
+            }
+        }
+        px += 4;
+    }
+    if sky > ground {
+        Fill::Sky
+    } else if ground > sky {
+        Fill::Ground
+    } else {
+        Fill::Other
+    }
+}
+
+#[test]
+fn upright_level_paints_sky_over_ground() {
+    let fb = render_pfd(0.0, 0.0);
+    assert_eq!(
+        strip_fill(&fb, 8),
+        Fill::Sky,
+        "top band is sky when upright"
+    );
+    assert_eq!(
+        strip_fill(&fb, H - 8),
+        Fill::Ground,
+        "bottom band is ground when upright"
+    );
+}
+
+#[test]
+fn inverted_level_paints_ground_over_sky() {
+    // The unambiguous inverted cue: upside down, the ground fills the top
+    // of the display and the sky the bottom — the sky/ground band inverts,
+    // it is not relabeled.
+    let fb = render_pfd(180.0, 0.0);
+    assert_eq!(
+        strip_fill(&fb, 8),
+        Fill::Ground,
+        "top band is ground when inverted"
+    );
+    assert_eq!(
+        strip_fill(&fb, H - 8),
+        Fill::Sky,
+        "bottom band is sky when inverted"
+    );
+}
+
+#[test]
+fn sky_ground_band_matches_the_independent_reference() {
+    // Orientations away from the vertical bank-hold window, where the f64
+    // atan2/asin oracle matches the rendered geometry exactly. Every clean
+    // background sample must agree with the oracle's sky/ground call.
+    for (roll, pitch) in [
+        (0.0f32, 0.0f32),
+        (30.0, 10.0),
+        (-45.0, -15.0),
+        (60.0, 20.0),
+        (180.0, 0.0),
+        (150.0, 12.0),
+        (-160.0, -18.0),
+        (120.0, -25.0),
+    ] {
+        let q = euler_quat(roll, pitch, 0.0);
+        let (ref_pitch, ref_bank) = ref_pitch_bank(q);
+        let fb = render_pfd(roll, pitch);
+        let horizon_y = ref_pitch.to_degrees() * PX_PER_DEG_PITCH;
+
+        let (mut checked, mut mismatches) = (0u32, 0u32);
+        let mut py = 4;
+        while py < H - 4 {
+            let mut px = 4;
+            while px < W - 4 {
+                let dx = f64::from(px) + 0.5 - CX;
+                let dy = f64::from(py) + 0.5 - CY;
+                let y_rot = dx * ref_bank.sin() + dy * ref_bank.cos();
+                let near_horizon = (y_rot - horizon_y).abs() < 24.0;
+                if !near_horizon && is_clean_bg(px, py) {
+                    match classify(pixel(&fb, px, py)) {
+                        Fill::Sky | Fill::Ground => {
+                            checked += 1;
+                            let want_sky = ref_is_sky(px, py, ref_pitch, ref_bank);
+                            let got_sky = classify(pixel(&fb, px, py)) == Fill::Sky;
+                            if want_sky != got_sky {
+                                mismatches += 1;
+                            }
+                        }
+                        Fill::Other => {}
+                    }
+                }
+                px += 8;
+            }
+            py += 8;
+        }
+        assert!(checked > 200, "roll {roll} pitch {pitch}: too few samples");
+        assert_eq!(
+            mismatches, 0,
+            "roll {roll} pitch {pitch}: sky/ground pixels disagree with the f64 reference"
+        );
+    }
+}
+
+#[test]
+fn passage_through_the_vertical_never_flips_sky_ground() {
+    // Acceptance: continuous passage through ±90° must not flip sky/ground
+    // meaning. Nose high through 89/90/91° keeps the display filled with
+    // sky (looking up); nose low keeps it ground. A flip would swap the
+    // dominant band between adjacent steps.
+    for pitch in [89.0f32, 90.0, 91.0] {
+        let fb = render_pfd(0.0, pitch);
+        assert_eq!(
+            strip_fill(&fb, 8),
+            Fill::Sky,
+            "nose-high {pitch}° top stays sky"
+        );
+        assert_eq!(
+            strip_fill(&fb, H - 8),
+            Fill::Sky,
+            "nose-high {pitch}° bottom stays sky (no flip)"
+        );
+    }
+    for pitch in [-89.0f32, -90.0, -91.0] {
+        let fb = render_pfd(0.0, pitch);
+        assert_eq!(
+            strip_fill(&fb, 8),
+            Fill::Ground,
+            "nose-low {pitch}° top stays ground"
+        );
+        assert_eq!(
+            strip_fill(&fb, H - 8),
+            Fill::Ground,
+            "nose-low {pitch}° bottom stays ground (no flip)"
+        );
+    }
+}
+
+#[test]
+fn extreme_attitudes_render_bit_reproducibly() {
+    for (roll, pitch) in [
+        (0.0f32, 90.0f32),
+        (180.0, 0.0),
+        (179.0, -20.0),
+        (90.0, 45.0),
+    ] {
+        let first = render_pfd(roll, pitch);
+        let second = render_pfd(roll, pitch);
+        assert_eq!(
+            first, second,
+            "roll {roll} pitch {pitch} renders identically twice"
+        );
+    }
+}
+
+#[test]
+fn inverted_nose_high_paints_recovery_chevrons() {
+    // Recovery chevrons are the only red symbology on the PFD; their
+    // presence in an inverted, steeply nose-high frame confirms the cue
+    // survives to the raster, pointed by the roll-rotated attitude frame.
+    let fb = render_pfd(180.0, 60.0);
+    let mut red = 0u32;
+    let mut i = 0;
+    while i + 3 < fb.len() {
+        if manhattan([fb[i], fb[i + 1], fb[i + 2]], RED) < 40 && fb[i + 3] > 0 {
+            red += 1;
+        }
+        i += 4;
+    }
+    assert!(red > 20, "inverted nose-high paints red recovery chevrons");
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
@@ -27,6 +27,13 @@ const CY: f64 = PANEL_H as f64 / 2.0;
 /// Horizon geometry constant shared with `pfd/horizon.rs`: screen pixels
 /// per degree of display pitch.
 const PX_PER_DEG_PITCH: f64 = 7.2;
+/// The simulator profile's minimum reverse-color band, in degrees of pitch.
+const SIM_BAND_DEG: f64 = 2.5;
+/// Pitch at which the level horizon reaches the panel edge (180 px / 7.2).
+const VIEWPORT_HALF_PITCH_DEG: f64 = 25.0;
+/// Display pitch beyond which the background fill boundary is clamped so the
+/// reverse-color band survives. Mirrors `horizon.rs`.
+const FILL_LIMIT_DEG: f64 = VIEWPORT_HALF_PITCH_DEG - SIM_BAND_DEG;
 
 /// Sky and ground fills (mirrors `panels::palette`), the only two colors a
 /// clean background sample can take.
@@ -51,11 +58,11 @@ fn euler_quat(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
 
 /// A valid flying state at the given orientation, populated enough that the
 /// PFD paints every band.
-fn state_at(roll_deg: f32, pitch_deg: f32) -> AircraftState {
+fn state_from_quat(quat: Quat) -> AircraftState {
     let mut state = AircraftState {
         attitude: Stamped {
             data: Some(Attitude {
-                quat: euler_quat(roll_deg, pitch_deg, 0.0),
+                quat,
                 rates_rps: [0.0, 0.0, 0.0],
             }),
             age_ms: Some(20.0),
@@ -114,7 +121,12 @@ fn ref_is_sky(px: u32, py: u32, pitch_rad: f64, bank_rad: f64) -> bool {
     let dx = f64::from(px) + 0.5 - CX;
     let dy = f64::from(py) + 0.5 - CY;
     let y_rot = dx * bank_rad.sin() + dy * bank_rad.cos();
-    let horizon_y = pitch_rad.to_degrees() * PX_PER_DEG_PITCH;
+    // The fill boundary is clamped to preserve the reverse-color band, so the
+    // oracle clamps the same way; the sign (physical ground/sky side) is kept.
+    let fill_deg = pitch_rad
+        .to_degrees()
+        .clamp(-FILL_LIMIT_DEG, FILL_LIMIT_DEG);
+    let horizon_y = fill_deg * PX_PER_DEG_PITCH;
     y_rot < horizon_y
 }
 
@@ -152,7 +164,12 @@ fn classify(px: [u8; 3]) -> Fill {
 
 /// Renders the PFD at an orientation into an RGBA framebuffer.
 fn render_pfd(roll_deg: f32, pitch_deg: f32) -> Vec<u8> {
-    let data = resolve(&state_at(roll_deg, pitch_deg), &FreshnessPolicy::default());
+    render_quat(euler_quat(roll_deg, pitch_deg, 0.0))
+}
+
+/// Renders the PFD from a raw attitude quaternion into an RGBA framebuffer.
+fn render_quat(quat: Quat) -> Vec<u8> {
+    let data = resolve(&state_from_quat(quat), &FreshnessPolicy::default());
     let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
     let mut writer = SceneWriter::new(&mut buf).expect("writer");
     draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("pfd");
@@ -297,36 +314,105 @@ fn sky_ground_band_matches_the_independent_reference() {
     }
 }
 
+/// Sky and ground pixel counts over the clean background band.
+fn bg_counts(fb: &[u8]) -> (u32, u32) {
+    let (mut sky, mut ground) = (0u32, 0u32);
+    let mut py = 4;
+    while py < H - 4 {
+        let mut px = 4;
+        while px < W - 4 {
+            if is_clean_bg(px, py) {
+                match classify(pixel(fb, px, py)) {
+                    Fill::Sky => sky += 1,
+                    Fill::Ground => ground += 1,
+                    Fill::Other => {}
+                }
+            }
+            px += 6;
+        }
+        py += 6;
+    }
+    (sky, ground)
+}
+
 #[test]
-fn passage_through_the_vertical_never_flips_sky_ground() {
-    // Acceptance: continuous passage through ±90° must not flip sky/ground
-    // meaning. Nose high through 89/90/91° keeps the display filled with
-    // sky (looking up); nose low keeps it ground. A flip would swap the
-    // dominant band between adjacent steps.
+fn extreme_pitch_keeps_a_reverse_color_band() {
+    // Reopened ATT-01 defect: at ±89/90/91° the true horizon leaves the 360 px
+    // viewport and the background used to collapse to a single flat color,
+    // losing one of its two orientation cues. The clamped fill now keeps a
+    // minimum band of the REVERSE color. Looking up (nose-high) sky dominates
+    // with a ground band still present; looking down, ground dominates with a
+    // sky band. The sky/ground MEANING never flips (the dominant field stays
+    // correct through the vertical); only the band's edge follows the physical
+    // orientation over the top. Both colors are always present — never one flat
+    // field.
+    const MIN_BAND: u32 = 40;
     for pitch in [89.0f32, 90.0, 91.0] {
-        let fb = render_pfd(0.0, pitch);
-        assert_eq!(
-            strip_fill(&fb, 8),
-            Fill::Sky,
-            "nose-high {pitch}° top stays sky"
+        let (sky, ground) = bg_counts(&render_pfd(0.0, pitch));
+        assert!(
+            sky > ground,
+            "nose-high {pitch}°: sky dominates (no meaning flip)"
         );
-        assert_eq!(
-            strip_fill(&fb, H - 8),
-            Fill::Sky,
-            "nose-high {pitch}° bottom stays sky (no flip)"
+        assert!(
+            ground > MIN_BAND,
+            "nose-high {pitch}°: reverse-color ground band present"
         );
     }
     for pitch in [-89.0f32, -90.0, -91.0] {
-        let fb = render_pfd(0.0, pitch);
-        assert_eq!(
-            strip_fill(&fb, 8),
-            Fill::Ground,
-            "nose-low {pitch}° top stays ground"
+        let (sky, ground) = bg_counts(&render_pfd(0.0, pitch));
+        assert!(
+            ground > sky,
+            "nose-low {pitch}°: ground dominates (no meaning flip)"
         );
+        assert!(
+            sky > MIN_BAND,
+            "nose-low {pitch}°: reverse-color sky band present"
+        );
+    }
+    // At the upright extremes (just short of vertical, before the display goes
+    // over the top) the band sits on the physically correct edge.
+    let up = render_pfd(0.0, 89.0);
+    assert_eq!(strip_fill(&up, 8), Fill::Sky, "nose-high 89°: sky above");
+    assert_eq!(
+        strip_fill(&up, H - 6),
+        Fill::Ground,
+        "nose-high 89°: ground reverse-band at the bottom edge"
+    );
+    let down = render_pfd(0.0, -89.0);
+    assert_eq!(
+        strip_fill(&down, 6),
+        Fill::Sky,
+        "nose-low 89°: sky reverse-band at the top edge"
+    );
+    assert_eq!(
+        strip_fill(&down, H - 8),
+        Fill::Ground,
+        "nose-low 89°: ground below"
+    );
+}
+
+#[test]
+fn q_and_negated_q_render_identically() {
+    // q and -q are one physical orientation; the SO(3)-safe presentation reads
+    // only quadratic quaternion forms, so the lit frame must be byte-identical
+    // — proven at the raster, across the extreme envelope and the band.
+    for (roll, pitch, yaw) in [
+        (0.0f32, 89.0f32, 0.0f32),
+        (180.0, 0.0, 30.0),
+        (150.0, 12.0, -20.0),
+        (0.0, -90.0, 0.0),
+    ] {
+        let q = euler_quat(roll, pitch, yaw);
+        let nq = Quat {
+            w: -q.w,
+            x: -q.x,
+            y: -q.y,
+            z: -q.z,
+        };
         assert_eq!(
-            strip_fill(&fb, H - 8),
-            Fill::Ground,
-            "nose-low {pitch}° bottom stays ground (no flip)"
+            render_quat(q),
+            render_quat(nq),
+            "roll {roll} pitch {pitch}: q and -q must render identically"
         );
     }
 }

--- a/crates/pilotage-instrument-state/src/presentation.rs
+++ b/crates/pilotage-instrument-state/src/presentation.rs
@@ -76,6 +76,11 @@ pub struct AirframeDisplayProfile {
     /// |pitch| beyond which display bank holds its last value (the
     /// vertical parameter singularity).
     bank_hold_pitch: Hysteresis,
+    /// Minimum angular thickness of the reverse-color sky/ground band the
+    /// display keeps at the edge when the true horizon has left the
+    /// viewport, so an extreme pitch never presents a single flat color and
+    /// the ground/sky reference is never lost.
+    min_reverse_band: f32,
 }
 
 /// The raw threshold set [`AirframeDisplayProfile::new`] validates.
@@ -93,11 +98,18 @@ pub struct ProfileLimits {
     pub chevron_pitch_down: Hysteresis,
     /// Bank-hold pitch magnitude entry/exit.
     pub bank_hold_pitch: Hysteresis,
+    /// Minimum reverse-color sky/ground band thickness, radians of pitch.
+    /// Kept at the edge at extreme pitch so the display never loses one of
+    /// its two orientation cues.
+    pub min_reverse_band: f32,
 }
 
 const DEG: f32 = core::f32::consts::PI / 180.0;
 const HALF_PI: f32 = core::f32::consts::FRAC_PI_2;
 const PI: f32 = core::f32::consts::PI;
+/// Upper bound on the reverse-color band: comfortably inside the viewport's
+/// pitch extent so the clamped fill always leaves the horizon room to move.
+const MAX_REVERSE_BAND: f32 = 10.0 * DEG;
 
 impl AirframeDisplayProfile {
     /// Builds a profile after validating every threshold pair.
@@ -126,6 +138,15 @@ impl AirframeDisplayProfile {
             }
             i += 1;
         }
+        if !limits.min_reverse_band.is_finite() {
+            return Err(ProfileError::NonFinite);
+        }
+        // A band must be positive and must leave room inside the viewport's
+        // pitch extent for the horizon itself; a band as tall as the whole
+        // field would collapse the fill to one color.
+        if limits.min_reverse_band <= 0.0 || limits.min_reverse_band >= MAX_REVERSE_BAND {
+            return Err(ProfileError::OutOfRange);
+        }
         Ok(Self {
             require_dynamics_cue: true,
             unusual_pitch_up: limits.unusual_pitch_up,
@@ -134,6 +155,7 @@ impl AirframeDisplayProfile {
             chevron_pitch_up: limits.chevron_pitch_up,
             chevron_pitch_down: limits.chevron_pitch_down,
             bank_hold_pitch: limits.bank_hold_pitch,
+            min_reverse_band: limits.min_reverse_band,
         })
     }
 
@@ -169,7 +191,16 @@ impl AirframeDisplayProfile {
                 entry: 88.0 * DEG,
                 exit: 87.0 * DEG,
             },
+            // ~2.5° of pitch, an ~18 px band on the 360 px panel: clearly
+            // visible without disturbing the normal envelope, whose unusual
+            // entry is far higher (30° nose-up).
+            min_reverse_band: 2.5 * DEG,
         }
+    }
+
+    /// The minimum reverse-color band thickness, radians of pitch.
+    pub fn min_reverse_band(&self) -> f32 {
+        self.min_reverse_band
     }
 }
 
@@ -205,6 +236,11 @@ pub struct AttitudePresentation {
     pub inverted: bool,
     /// Recovery chevrons to draw, pointing toward the horizon.
     pub chevrons: Option<ChevronSense>,
+    /// Minimum reverse-color band thickness (radians of pitch) the
+    /// background keeps at the ground/sky edge at extreme pitch. Carried
+    /// from the profile so the renderer, which owns the pixel geometry,
+    /// never invents its own limit.
+    pub min_reverse_band_rad: f32,
 }
 
 impl Default for AttitudePresentation {
@@ -218,6 +254,7 @@ impl Default for AttitudePresentation {
             high_bank: false,
             inverted: false,
             chevrons: None,
+            min_reverse_band_rad: 0.0,
         }
     }
 }
@@ -315,6 +352,7 @@ impl UnusualAttitudeState {
             } else {
                 None
             },
+            min_reverse_band_rad: profile.min_reverse_band,
         }
     }
 }

--- a/crates/pilotage-instrument-state/src/presentation/tests.rs
+++ b/crates/pilotage-instrument-state/src/presentation/tests.rs
@@ -316,6 +316,34 @@ fn chevrons_point_toward_the_horizon_even_inverted() {
 }
 
 #[test]
+fn recovery_indication_starts_within_one_second() {
+    // Human-factors acceptance, deterministic logic bound only — real pilot
+    // response and HIL timing are separate evidence, not asserted here. Once
+    // the attitude is unusual, the display must begin the correct recovery
+    // indication within one second. At a 50 Hz refresh that is 50 frames; the
+    // tier machine raises the chevron on the first frame past the threshold,
+    // far inside the budget, pointed toward the horizon.
+    const BUDGET_FRAMES: u32 = 50;
+    let profile = AirframeDisplayProfile::simulator();
+    let mut state = UnusualAttitudeState::default();
+    let unusual = quat_f64(0.0, 55.0, 0.0); // beyond the +50° chevron entry
+    let mut onset = None;
+    for frame in 0..BUDGET_FRAMES {
+        let p = state.step(unusual, &profile);
+        if onset.is_none() && p.chevrons.is_some() {
+            onset = Some((frame, p.chevrons));
+        }
+    }
+    let (frame, sense) = onset.expect("recovery chevron appears within one second");
+    assert!(frame < BUDGET_FRAMES, "onset within the one-second budget");
+    assert_eq!(
+        sense,
+        Some(ChevronSense::HorizonBelow),
+        "the recovery cue points toward the horizon for a nose-high upset"
+    );
+}
+
+#[test]
 fn threshold_jitter_cannot_chatter() {
     // Oscillate ±0.5° around the 65° bank entry: one engagement, no
     // release until the 60° exit is crossed.
@@ -378,6 +406,7 @@ fn invalid_profiles_are_rejected() {
         chevron_pitch_up: good,
         chevron_pitch_down: good,
         bank_hold_pitch: good,
+        min_reverse_band: 2.5 * DEG,
     };
     assert!(AirframeDisplayProfile::new(base).is_ok());
     let mut inverted = base;
@@ -397,5 +426,19 @@ fn invalid_profiles_are_rejected() {
     assert_eq!(
         AirframeDisplayProfile::new(nan),
         Err(ProfileError::NonFinite)
+    );
+    // A non-positive or too-large reverse-color band is rejected: the band
+    // must leave the horizon room inside the field.
+    let mut no_band = base;
+    no_band.min_reverse_band = 0.0;
+    assert_eq!(
+        AirframeDisplayProfile::new(no_band),
+        Err(ProfileError::OutOfRange)
+    );
+    let mut huge_band = base;
+    huge_band.min_reverse_band = 45.0 * DEG;
+    assert_eq!(
+        AirframeDisplayProfile::new(huge_band),
+        Err(ProfileError::OutOfRange)
     );
 }

--- a/crates/pilotage-instrument-state/src/presentation/tests.rs
+++ b/crates/pilotage-instrument-state/src/presentation/tests.rs
@@ -275,6 +275,47 @@ fn inverted_flight_is_unambiguous() {
 }
 
 #[test]
+fn chevrons_point_toward_the_horizon_even_inverted() {
+    // The recovery cue is defined as pointing toward the horizon: nose-high
+    // puts the horizon below the symbol so the chevron points down, nose-low
+    // mirrors it. That must hold at every orientation, including inverted
+    // flight (bank beyond 90°) — the sense keys on the display pitch and
+    // never silently reverses. Sweep the inverted band and assert the
+    // invariant `HorizonBelow ⟺ display pitch above the horizon`.
+    let profile = AirframeDisplayProfile::simulator();
+    let rolls = [120.0f64, 150.0, 180.0, -150.0, -120.0];
+    let mut inverted_with_cue = 0;
+    for &roll in rolls.iter() {
+        let mut pitch = -70.0f64;
+        while pitch <= 70.0 {
+            let mut state = UnusualAttitudeState::default();
+            let p = state.step(quat_f64(roll, pitch, 0.0), &profile);
+            if p.bank_rad.abs() > PI / 2.0 {
+                assert!(
+                    p.inverted,
+                    "roll {roll} pitch {pitch}: bank beyond 90° reads inverted"
+                );
+            }
+            if let Some(sense) = p.chevrons {
+                assert_eq!(
+                    sense == ChevronSense::HorizonBelow,
+                    p.pitch_rad > 0.0,
+                    "roll {roll} pitch {pitch}: chevron must point to the horizon side",
+                );
+                if p.inverted {
+                    inverted_with_cue += 1;
+                }
+            }
+            pitch += 5.0;
+        }
+    }
+    assert!(
+        inverted_with_cue > 0,
+        "the sweep must exercise recovery cues while inverted"
+    );
+}
+
+#[test]
 fn threshold_jitter_cannot_chatter() {
     // Oscillate ±0.5° around the 65° bank entry: one engagement, no
     // release until the 60° exit is crossed.


### PR DESCRIPTION
ATT-01 extreme/inverted attitude: preserve a minimum reverse-color sky/ground band at the edge, and correct the raster acceptance. **SIM / NOT FOR FLIGHT — establishes no certification, TSO, or DAL claim.**

## Production behavior change (this PR DOES change draw code — not tests-only)
- `crates/pilotage-instrument-state/src/presentation.rs`: `AirframeDisplayProfile` gains a profile-defined `min_reverse_band` (simulator = 2.5°); carried through `AttitudePresentation` into `PanelData`.
- `crates/pilotage-instrument-panels/src/pfd/horizon.rs`: `draw_background` now **clamps the fill boundary** so a minimum reverse-color band (~18 px) of the opposite field always stays at the physically correct edge (edge from the display-pitch sign / down vector, not an Euler branch). Previously `horizon_y = pitch × 7.2` moved the boundary off-screen at ±89/90/91°, collapsing the background to one flat color.
- `crates/pilotage-instrument-panels/src/pfd.rs`: passes the band to `draw_background`.
- Normal envelope is unchanged (the clamp engages only past ~22.5°). The pitch ladder and horizon line keep true pitch.

## Corrected raster acceptance (the prior tests fossilized the flat-color defect)
- Reverse-color band present and dominant field correct at +89/90/91° (sky-dominant, ground band) and −89/90/91° (ground-dominant, sky band); band on the correct edge at the upright extremes.
- q/−q renders byte-identical (raster level).
- Inverted level paints ground-over-sky (band inverts, not relabeled); pixel-for-pixel match to an independent f64 down-vector oracle for banked/inverted cases.
- Deterministic recovery-onset scenario (chevron within a one-second frame budget, toward the horizon), kept separate from the raster unit tests.
- Sanity-verified: removing the production clamp makes the band test FAIL.

## Scope / open items
- **#17 stays OPEN**: this lands the corrected behavior, but the first behavior→design→implementation→test→recorded-result trace slice is #77 (ASSURE-01). #17 closes only once that slice is in place.
- HIL, real refresh latency, and pilot reaction time remain external evidence — NOT claimed by these deterministic unit tests.

Refs #17 (do not auto-close).