### PR TITLE
AIR-05: certification-claim guard accepts explicit NOT FOR FLIGHT denials (#83)

### DIFF
--- a/scripts/check-certification-claims.sh
+++ b/scripts/check-certification-claims.sh
@@ -5,12 +5,20 @@
 # any Pilotage output is certified, DO-178C compliant, FAA/EASA approved, or
 # airworthy.
 #
-# The standards and safety documents legitimately discuss these words in a
-# classification or negation context (e.g. "not certified", or enumerating the
-# banned vocabulary itself). They are exempted by an explicit allowlist and, in
-# exchange, are required to carry the SIM / NOT FOR FLIGHT banner so the exempt
-# set stays honest. Every other scanned artifact fails on the assertive-claim
-# patterns and the offending file:line is printed.
+# The banned vocabulary is legitimately used to DENY such status — the required
+# safety wording "Nothing here is certified, approved, or airworthy" is the
+# opposite of a claim. An assertive claim is distinguished from a denial per
+# sentence: a claim keyword is a violation unless a negation (no/not/nothing/
+# never/neither/none/cannot/without) precedes it within the same sentence AND
+# the file carries the SIM / NOT FOR FLIGHT banner. Splitting on sentence
+# boundaries means a banner sentence cannot license a separate assertive
+# sentence sharing the line, and an affirmative "Pilotage is airworthy" still
+# fails. The `airworthy`/`certified` vocabulary is never removed and no file is
+# broadly exempted; the check stays fail-closed.
+#
+# Standards/safety documents that ENUMERATE the vocabulary in classification
+# context are exempted by an explicit allowlist and, in exchange, must carry the
+# banner so the exempt set stays honest.
 #
 # This is a guard against misleading claims, not a proof of their absence: the
 # patterns target assertive phrasing and can be evaded by unusual wording. Treat
@@ -22,8 +30,8 @@ cd "$root_dir"
 
 banner="SIM / NOT FOR FLIGHT"
 
-# Documents permitted to contain the claim vocabulary in a classification or
-# negation context. Each must carry the banner (checked below).
+# Documents permitted to enumerate the claim vocabulary in classification
+# context. Each must carry the banner (checked below).
 allowlist=(
     "docs/instruments/standards-applicability.md"
     "docs/instruments/evidence-plan.md"
@@ -31,11 +39,12 @@ allowlist=(
     "docs/instruments/pssa.md"
 )
 
-# Assertive claim patterns (extended regex, matched case-insensitively). Neutral
-# uses such as "certification basis", "certification authority", "the certified
-# world", "does not claim certification", "continued-airworthiness", and "not a
-# compliance model" are intentionally not matched.
-claim_pattern='certifiable|airworthy|faa[ -]approved|faa[ -]certified|easa[ -]approved|flight[ -]certified|do-178[abc]?[ -]compliant|compliant with do-178|do-178[abc]?[ -]certified|meets( all)? do-178|fully compliant|(^|[^[:alnum:]])(is|are|now|fully|hereby|been|being|shall be) certified'
+# Assertive claim patterns (extended regex, matched case-insensitively over
+# lowercased text, so `[a-z0-9]` also covers upper case and stays portable to
+# awk's dynamic regex). Neutral uses such as "certification basis",
+# "certification authority", "does not claim certification", and
+# "continued-airworthiness" are intentionally not matched.
+claim_pattern='certifiable|airworthy|faa[ -]approved|faa[ -]certified|easa[ -]approved|flight[ -]certified|do-178[abc]?[ -]compliant|compliant with do-178|do-178[abc]?[ -]certified|meets( all)? do-178|fully compliant|(^|[^a-z0-9])(is|are|now|fully|hereby|been|being|shall be) certified'
 
 is_allowlisted() {
     local candidate="$1" allowed
@@ -43,6 +52,58 @@ is_allowlisted() {
         [ "$candidate" = "$allowed" ] && return 0
     done
     return 1
+}
+
+# True (exit 0) when every claim keyword on the line is DENIED: a negation
+# precedes it within its sentence, so the line disclaims rather than asserts.
+# Exit 1 as soon as one claim keyword stands un-negated in its sentence.
+line_is_negated_disclaimer() {
+    printf '%s\n' "$1" | awk -v claim="$claim_pattern" '
+    {
+        lc = tolower($0)
+        n = split(lc, sent, /[.!?]/)
+        for (i = 1; i <= n; i++) {
+            seg = sent[i]
+            off = 0
+            while (match(substr(seg, off + 1), claim)) {
+                abs = off + RSTART
+                pre = substr(seg, 1, abs - 1)
+                if (pre !~ /(^|[^a-z])(no|not|nothing|never|neither|none|cannot|without)([^a-z]|$)/) {
+                    exit 1
+                }
+                off = abs + RLENGTH - 1
+            }
+        }
+        exit 0
+    }'
+}
+
+# Regression fixtures, executed on every run so CI exercises them (AIR-05).
+selftest() {
+    local f=0 c
+    for c in \
+        "SIM / NOT FOR FLIGHT. Nothing here is certified, approved, or airworthy." \
+        "It is not certified, not approved, and is not airworthy." \
+        "Pilotage is not airworthy and makes no compliance credit."
+    do
+        line_is_negated_disclaimer "$c" || {
+            echo "SELFTEST FAILED: negated disclaimer wrongly flagged: $c" >&2
+            f=1
+        }
+    done
+    for c in \
+        "Pilotage is airworthy." \
+        "Pilotage is certified." \
+        "SIM / NOT FOR FLIGHT. Pilotage is airworthy." \
+        "The system is now fully compliant." \
+        "This build is FAA approved."
+    do
+        if line_is_negated_disclaimer "$c"; then
+            echo "SELFTEST FAILED: assertive claim wrongly exempted: $c" >&2
+            f=1
+        fi
+    done
+    return $f
 }
 
 # Tracked documentation and UI artifacts. Rust/source crates are out of scope:
@@ -62,6 +123,11 @@ collect_scanned_files() {
 
 status=0
 
+if ! selftest; then
+    echo "check-certification-claims: self-test regression — the negation/claim discrimination is broken" >&2
+    status=1
+fi
+
 while IFS= read -r file; do
     [ -z "$file" ] && continue
     [ -f "$file" ] || continue
@@ -72,11 +138,18 @@ while IFS= read -r file; do
         fi
         continue
     fi
+    file_has_banner=0
+    grep -qF "$banner" "$file" && file_has_banner=1
     if hits="$(grep -HnEi "$claim_pattern" "$file")"; then
         while IFS= read -r hit; do
+            content="${hit#*:}"
+            content="${content#*:}"
+            if [ "$file_has_banner" -eq 1 ] && line_is_negated_disclaimer "$content"; then
+                continue
+            fi
             echo "CERTIFICATION CLAIM: $hit" >&2
+            status=1
         done <<< "$hits"
-        status=1
     fi
 done < <(collect_scanned_files | LC_ALL=C sort -u)
 


### PR DESCRIPTION
Fixes #83: the AIR-03 certification-claim guard rejected the required safety wording "Nothing here is certified, approved, or airworthy" (added by #82), reddening main.

## Change (scripts/check-certification-claims.sh only)
- Per-sentence discrimination: a claim keyword is a violation **unless** a negation (no/not/nothing/never/neither/none/cannot/without) precedes it **within the same sentence** AND the file carries the `SIM / NOT FOR FLIGHT` banner.
- Sentence splitting (`. ! ?`) stops a banner sentence from licensing a separate assertive sentence on the same line — "SIM / NOT FOR FLIGHT. Pilotage is airworthy." still **fails**.
- No file broadly exempted; the `airworthy`/`certified` vocabulary is retained → **fail-closed**.
- Embedded **self-test** runs on every invocation (so CI exercises the fixtures):
  - the exact README disclaimer and other negated denials **pass**;
  - `Pilotage is airworthy`, `is certified`, `FAA approved`, `fully compliant` **fail**;
  - allowlisted standards docs still require the banner.

## Verified locally
- Guard OK on the full working tree (README = main's disclaimer, unchanged).
- Injecting `Pilotage is airworthy and FAA approved.` into README → guard FAILS with file:line.
- shellcheck clean.

README is unchanged from main (the disclaimer wording stays, per #83). Corrective child of #28; regression exposed by #82.