### PR TITLE
HUD-03: bounded capture-time conformal projection (#38)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,7 @@ version = "0.1.0"
 dependencies = [
  "libm",
  "pilotage-calibration-id",
+ "pilotage-camera-calibration",
  "pilotage-frames",
  "thiserror",
 ]

--- a/crates/pilotage-geo/Cargo.toml
+++ b/crates/pilotage-geo/Cargo.toml
@@ -10,5 +10,9 @@ workspace = true
 [dependencies]
 pilotage-frames = { workspace = true }
 pilotage-calibration-id = { workspace = true }
+# HUD-03 (#38): the conformal projector consumes the unforgeable VerifiedCameraModel
+# minted only by CAL-01's verified path. Acyclic: camera-calibration does not
+# depend on geo. Both stay no_std.
+pilotage-camera-calibration = { workspace = true }
 libm = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pilotage-geo/src/conformal.rs
+++ b/crates/pilotage-geo/src/conformal.rs
@@ -33,9 +33,9 @@
 //!
 //! SIM / NOT FOR FLIGHT.
 
-use pilotage_frames::Epoch;
+use pilotage_frames::{AngularVelocity, Epoch, FrameId, ROTATION_NORM_TOLERANCE, Velocity};
 
-use crate::availability::SvsAvailability;
+use crate::availability::{AvailabilityProfile, ExternalHealth, SvsAvailability, derive_inputs};
 use crate::identity::{
     CoherentSnapshot, SourceIncarnation, SourceStamp, StatedAttitude, StatedPosition,
 };
@@ -64,20 +64,34 @@ pub use state::{ConformalReason, ConformalState};
 /// cap keeps the result allocation-free and `Copy` in this `no_std` contract.
 pub const MAX_PATH_CUES: usize = 8;
 
+/// A 1-sigma accuracy estimate for a velocity, in millimeters/second — the
+/// velocity-error input to the alignment budget. A distinct type so a velocity
+/// accuracy is never read as a position or attitude accuracy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VelocityQuality {
+    /// 1-sigma speed accuracy, millimeters/second.
+    pub sigma_mmps: u32,
+}
+
 /// One coherent kinematic sample: a pose (attitude + position, one coherent
-/// snapshot) plus the velocity and body rate the conformal path needs. The
-/// velocity is NED, meters/second (the flight-path-marker reference); the body
-/// rate is body FRD, radians/second.
+/// snapshot) plus the velocity and body rate — each frame-, epoch-, and
+/// snapshot-tagged, not a bare array. The velocity is NED (the flight-path-marker
+/// reference) and the body rate is body-frame; [`assess_conformal`] enforces both
+/// frames and that the velocity and rate share the pose's coherent snapshot.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KinematicSample {
     /// Body → NED attitude, with its identity stamp and angular accuracy.
     pub attitude: StatedAttitude,
     /// Geodetic position, with its identity stamp and position accuracy.
     pub position: StatedPosition,
-    /// NED velocity, meters/second.
-    pub velocity_ned_mps: [f64; 3],
-    /// Body-frame angular rate, radians/second.
-    pub body_rate_rps: [f32; 3],
+    /// NED velocity, meters/second — frame must be [`FrameId::Ned`]; carries its
+    /// own frame, epoch, and [`SourceStamp`] provenance.
+    pub velocity: Velocity<SourceStamp>,
+    /// Body-frame angular rate, radians/second — frame must be [`FrameId::Body`];
+    /// carries its own frame, epoch, and [`SourceStamp`] provenance.
+    pub body_rate: AngularVelocity<SourceStamp>,
+    /// The velocity's 1-sigma speed accuracy (the velocity-error budget input).
+    pub velocity_quality: VelocityQuality,
 }
 
 /// Two coherent samples that bracket the capture time. The capture time is
@@ -109,26 +123,44 @@ pub struct CaptureContext {
     pub pipeline_latency_ns: u64,
 }
 
+/// The synthetic-vision availability inputs the conformal path derives its scene
+/// verdict from: the producer-stated external subsystem health and the intended
+/// availability profile. The verdict is **derived** from the actual bracket
+/// samples against these — never taken as a caller-asserted value — so a low
+/// integrity or accuracy in the samples cannot be masked by an optimistic claim.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AvailabilityInputs {
+    /// Producer-stated health of the inputs the contract cannot check itself
+    /// (integrity monitor, calibration, database, coverage, renderer).
+    pub external: ExternalHealth,
+    /// The intended-function availability profile (freshness/accuracy limits).
+    pub profile: AvailabilityProfile,
+}
+
 /// The traceable identity a conformal fix carries, tying the **video** (the
-/// capture time it was aligned to) and the **overlay** (the coherent snapshot and
-/// source incarnation of the state) to one frame/snapshot identity — reusing
-/// [`CoherentSnapshot`] and [`SourceIncarnation`], not a new identity type.
+/// capture time it was aligned to) and the **overlay** (the coherent snapshots and
+/// source incarnation of the interpolated state) to a traceable identity — reusing
+/// [`CoherentSnapshot`] and [`SourceIncarnation`], not a new identity type. The
+/// interpolation reads **both** bracket endpoints, so both snapshot identities are
+/// retained (an interpolated fix belongs to no single snapshot).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FixIdentity {
-    /// The coherent snapshot the aligned state belongs to.
-    pub snapshot: CoherentSnapshot,
-    /// The source incarnation the aligned state belongs to.
+    /// The coherent snapshot of the older bracket endpoint.
+    pub older_snapshot: CoherentSnapshot,
+    /// The coherent snapshot of the newer bracket endpoint.
+    pub newer_snapshot: CoherentSnapshot,
+    /// The source incarnation both endpoints belong to (one continuous stream).
     pub source_incarnation: SourceIncarnation,
-    /// The capture time the state was aligned to.
+    /// The capture time the interpolated state was aligned to.
     pub capture_epoch: Epoch,
 }
 
 impl FixIdentity {
     fn at_capture(bracket: &Bracket, capture_epoch: Epoch) -> Self {
-        let stamp = bracket.newer.attitude.stamp;
         Self {
-            snapshot: stamp.snapshot,
-            source_incarnation: stamp.incarnation,
+            older_snapshot: bracket.older.attitude.stamp.snapshot,
+            newer_snapshot: bracket.newer.attitude.stamp.snapshot,
+            source_incarnation: bracket.newer.attitude.stamp.incarnation,
             capture_epoch,
         }
     }
@@ -199,7 +231,7 @@ pub fn assess_conformal(
     capture: CaptureContext,
     view: &ProjectionView,
     geom: &ViewGeometry,
-    availability: SvsAvailability,
+    availability: AvailabilityInputs,
     policy: &ConformalPolicy,
     path_ned_m: &[[f64; 3]],
 ) -> ConformalFix {
@@ -223,14 +255,24 @@ pub fn assess_conformal(
             identity,
         );
     }
-    if let SvsAvailability::Unavailable(reason) = availability {
+    if let Some(reason) = identity_fault(bracket, capture.capture_epoch) {
+        return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
+    }
+    // Both endpoint attitudes must be unit rotations, and the velocity/rate must be
+    // in their expected frames and share the pose's coherent snapshot — a zero
+    // quaternion or a mis-framed/mis-provenanced kinematic input never registers.
+    if let Some(reason) = kinematic_fault(bracket) {
+        return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
+    }
+    // Availability is DERIVED from the actual samples (integrity + accuracy)
+    // against the profile — never taken as a caller-asserted verdict — so a low
+    // integrity or accuracy in the samples cannot be masked by an optimistic claim.
+    let scene = derive_availability(bracket, availability, capture.capture_epoch);
+    if let SvsAvailability::Unavailable(reason) = scene {
         return ConformalFix::refused(
             ConformalState::Unavailable(ConformalReason::Availability(reason)),
             identity,
         );
-    }
-    if let Some(reason) = identity_fault(bracket, capture.capture_epoch) {
-        return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
     }
 
     let interp = interp::interpolate(&bracket.older, &bracket.newer, capture.capture_epoch.nanos);
@@ -246,7 +288,7 @@ pub fn assess_conformal(
         interp.timing.extrapolation_ns,
         rate_magnitude(interp.body_rate_rps),
         &error,
-        availability,
+        scene,
         policy,
     );
     let cues = state
@@ -258,6 +300,79 @@ pub fn assess_conformal(
         cues,
         identity,
     }
+}
+
+/// Derives the synthetic-vision availability from the ACTUAL bracket samples —
+/// each endpoint's integrity and accuracy against the profile — taking the worse
+/// of the two. An untrusted or low-accuracy sample yields Unavailable or Degraded
+/// no matter what a caller claims.
+///
+/// Freshness is judged against the later of the capture time and the newer
+/// endpoint, so that a bracketed capture time (which precedes the newer sample)
+/// never flags that sample as a future reading; the conformal path bounds how far
+/// the capture may sit outside the bracket separately, through the extrapolation
+/// limit. By this point [`identity_fault`] has already established that both
+/// samples and the capture share one clock and scale.
+fn derive_availability(
+    bracket: &Bracket,
+    availability: AvailabilityInputs,
+    capture: Epoch,
+) -> SvsAvailability {
+    let newer_at = bracket.newer.attitude.stamp.acquired_at;
+    let reference = if capture.nanos >= newer_at.nanos {
+        capture
+    } else {
+        newer_at
+    };
+    let assess = |s: &KinematicSample| {
+        SvsAvailability::assess(&derive_inputs(
+            &s.position,
+            &s.attitude,
+            &availability.external,
+            reference,
+            &availability.profile,
+        ))
+    };
+    worst_availability(assess(&bracket.older), assess(&bracket.newer))
+}
+
+/// The worse of two availability verdicts (Unavailable worse than Degraded worse
+/// than Available).
+fn worst_availability(a: SvsAvailability, b: SvsAvailability) -> SvsAvailability {
+    match (a, b) {
+        (SvsAvailability::Unavailable(r), _) | (_, SvsAvailability::Unavailable(r)) => {
+            SvsAvailability::Unavailable(r)
+        }
+        (SvsAvailability::Degraded(r), _) | (_, SvsAvailability::Degraded(r)) => {
+            SvsAvailability::Degraded(r)
+        }
+        _ => SvsAvailability::Available,
+    }
+}
+
+/// The kinematic-validity fault of a bracket: a non-unit attitude quaternion at
+/// either endpoint, a velocity or body rate in the wrong frame, or a velocity/rate
+/// whose provenance is not the pose's coherent snapshot. `None` when both samples
+/// are well-formed.
+fn kinematic_fault(bracket: &Bracket) -> Option<ConformalReason> {
+    for s in [&bracket.older, &bracket.newer] {
+        if s.attitude
+            .attitude
+            .renormalized(ROTATION_NORM_TOLERANCE)
+            .is_err()
+        {
+            return Some(ConformalReason::AttitudeNotARotation);
+        }
+        if s.velocity.frame != FrameId::Ned || s.body_rate.frame != FrameId::Body {
+            return Some(ConformalReason::KinematicFrame);
+        }
+        if !s.attitude.stamp.coherent_with(&s.velocity.meta)
+            || !s.attitude.stamp.coherent_with(&s.body_rate.meta)
+        {
+            return Some(ConformalReason::KinematicProvenance);
+        }
+    }
+    None
 }
 
 /// Projects every cue for a drawable fix: the horizon, the flight-path marker,

--- a/crates/pilotage-geo/src/conformal.rs
+++ b/crates/pilotage-geo/src/conformal.rs
@@ -1,0 +1,338 @@
+//! Bounded conformal projection (HUD-03): align the coherent aircraft state to
+//! video capture time and project registered symbology **only** while a bounded
+//! total-error budget holds.
+//!
+//! This module consumes the crate's existing contracts and adds no parallel
+//! ones. It interpolates the [`crate::CoherentSnapshot`]-identified state at
+//! capture time (attitude by normalized quaternion interpolation), combines a
+//! dynamic [`AlignmentErrorBound`] from named, individually sourced terms,
+//! projects the horizon, flight-path marker, and runway/path cues through the
+//! referenced camera model of a [`crate::ProjectionView`], and emits a
+//! four-valued [`ConformalState`] (`Valid` / `Limited` / `NonConformal` /
+//! `Unavailable`) that carries a typed [`ConformalReason`]. When the budget or a
+//! registration limit is exceeded the registered cues are **removed**
+//! ([`ConformalFix::cues`] is `None`), never left as plausible stale alignment.
+//!
+//! The resolved camera geometry ([`ViewGeometry`]) embeds the calibration it was
+//! resolved from, and the assessment refuses a geometry whose calibration does
+//! not match the projection view's — so a geometry or alignment bound resolved
+//! from the wrong calibration can never yield a registered scene.
+//!
+//! # What it reuses (no parallel types)
+//!
+//! - camera model / projection: [`crate::ProjectionView`], [`crate::Projection`],
+//!   [`crate::CalibrationRef`];
+//! - availability: [`crate::SvsAvailability`] and its [`crate::AvailabilityReason`]
+//!   are delegated into [`ConformalReason::Availability`];
+//! - capture-time coherent state and identity: [`crate::StatedAttitude`],
+//!   [`crate::StatedPosition`], [`crate::SourceStamp`], [`crate::CoherentSnapshot`],
+//!   [`crate::SourceIncarnation`]. The capture-clock mapping itself is the
+//!   caller's (the adapter's `CaptureClockMapping`): the caller maps the capture
+//!   time into the flight-state clock and supplies it as [`CaptureContext`], so
+//!   this crate does not re-mint a capture-time type.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use pilotage_frames::Epoch;
+
+use crate::availability::SvsAvailability;
+use crate::identity::{
+    CoherentSnapshot, SourceIncarnation, SourceStamp, StatedAttitude, StatedPosition,
+};
+use crate::view::{Projection, ProjectionView};
+
+mod budget;
+mod interp;
+mod policy;
+mod project;
+mod state;
+
+pub use budget::AlignmentErrorBound;
+pub use policy::{
+    ConformalError, ConformalPolicy, ConformalPolicyId, SIMULATOR_CONFORMAL_POLICY_ID,
+};
+pub use project::{
+    HorizonLine, ScreenMark, ViewGeometry, down_in_camera, project_flight_path, project_horizon,
+    project_path_cue,
+};
+pub use state::{ConformalReason, ConformalState};
+
+/// The maximum number of runway/path cue points one [`ConformalCues`] carries
+/// inline. It covers a runway outline (four threshold/corner points) plus a few
+/// approach-path or flight-path tunnel gates; a caller with more points projects
+/// the remainder itself through [`project_path_cue`] under the same verdict. The
+/// cap keeps the result allocation-free and `Copy` in this `no_std` contract.
+pub const MAX_PATH_CUES: usize = 8;
+
+/// One coherent kinematic sample: a pose (attitude + position, one coherent
+/// snapshot) plus the velocity and body rate the conformal path needs. The
+/// velocity is NED, meters/second (the flight-path-marker reference); the body
+/// rate is body FRD, radians/second.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KinematicSample {
+    /// Body → NED attitude, with its identity stamp and angular accuracy.
+    pub attitude: StatedAttitude,
+    /// Geodetic position, with its identity stamp and position accuracy.
+    pub position: StatedPosition,
+    /// NED velocity, meters/second.
+    pub velocity_ned_mps: [f64; 3],
+    /// Body-frame angular rate, radians/second.
+    pub body_rate_rps: [f32; 3],
+}
+
+/// Two coherent samples that bracket the capture time. The capture time is
+/// interpolated between them; outside `[older, newer]` the nearest endpoint is
+/// used and the extrapolation distance is charged to the error budget and the
+/// policy limit.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Bracket {
+    /// The earlier sample.
+    pub older: KinematicSample,
+    /// The later sample.
+    pub newer: KinematicSample,
+}
+
+/// The timing facts of the capture the caller has already resolved: the capture
+/// time expressed in the **flight-state clock** (the caller applied the adapter's
+/// `CaptureClockMapping`), the clock-mapping error bound, and the measured
+/// pipeline latency. Neither is a hidden constant; each is sourced by the caller.
+/// The calibration's static alignment bound is **not** here — it is carried by
+/// the derived [`ViewGeometry`], so it stays bound to the calibration it was
+/// resolved from.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CaptureContext {
+    /// Capture time, mapped into the aircraft state's clock domain and scale.
+    pub capture_epoch: Epoch,
+    /// Symmetric bound on the capture-clock mapping error, nanoseconds.
+    pub clock_error_ns: u64,
+    /// Measured glass-to-glass pipeline latency, nanoseconds.
+    pub pipeline_latency_ns: u64,
+}
+
+/// The traceable identity a conformal fix carries, tying the **video** (the
+/// capture time it was aligned to) and the **overlay** (the coherent snapshot and
+/// source incarnation of the state) to one frame/snapshot identity — reusing
+/// [`CoherentSnapshot`] and [`SourceIncarnation`], not a new identity type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixIdentity {
+    /// The coherent snapshot the aligned state belongs to.
+    pub snapshot: CoherentSnapshot,
+    /// The source incarnation the aligned state belongs to.
+    pub source_incarnation: SourceIncarnation,
+    /// The capture time the state was aligned to.
+    pub capture_epoch: Epoch,
+}
+
+impl FixIdentity {
+    fn at_capture(bracket: &Bracket, capture_epoch: Epoch) -> Self {
+        let stamp = bracket.newer.attitude.stamp;
+        Self {
+            snapshot: stamp.snapshot,
+            source_incarnation: stamp.incarnation,
+            capture_epoch,
+        }
+    }
+}
+
+/// The registered conformal cues for one frame. Present only when the state
+/// [`ConformalState::draws_cues`]; a [`ConformalState::NonConformal`] or
+/// [`ConformalState::Unavailable`] fix carries no cues at all, so an exceeded
+/// budget removes every cue — horizon, flight-path marker, and runway/path.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConformalCues {
+    /// The horizon line in normalized image coordinates.
+    pub horizon: HorizonLine,
+    /// The flight-path marker, or `None` when the velocity has no in-front
+    /// direction to draw.
+    pub flight_path: Option<ScreenMark>,
+    /// The projected runway/path cues, one slot per supplied point in order.
+    /// Slots `[0, path_count)` are the supplied points — each `Some` when it
+    /// projects in front of the camera and within the near/far clip, or `None`
+    /// when it is behind or clipped; slots `[path_count, MAX_PATH_CUES)` are
+    /// unused. An off-scale point is `Some` with `within_fov = false`.
+    pub path: [Option<ScreenMark>; MAX_PATH_CUES],
+    /// How many supplied runway/path points were considered (`≤ MAX_PATH_CUES`).
+    pub path_count: usize,
+    /// Whether the cues must be marked reduced-confidence
+    /// ([`ConformalState::Limited`]).
+    pub limited: bool,
+}
+
+/// The result of a conformal assessment: the verdict, the error breakdown (once
+/// interpolation ran), the cues (only when drawable), and the traceable identity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConformalFix {
+    /// The registration verdict.
+    pub state: ConformalState,
+    /// The dynamic alignment-error breakdown, or `None` when the fix was refused
+    /// structurally before any interpolation (invalid view, unavailable scene, or
+    /// a broken identity).
+    pub error: Option<AlignmentErrorBound>,
+    /// The registered cues, present only when [`ConformalState::draws_cues`].
+    pub cues: Option<ConformalCues>,
+    /// The traceable frame/snapshot identity.
+    pub identity: FixIdentity,
+}
+
+impl ConformalFix {
+    fn refused(state: ConformalState, identity: FixIdentity) -> Self {
+        Self {
+            state,
+            error: None,
+            cues: None,
+            identity,
+        }
+    }
+}
+
+/// Assesses whether the coherent state may be projected conformally at the
+/// capture time, and projects the cues when it may.
+///
+/// Precedence (fail-closed): an invalid view or an unavailable scene is
+/// `Unavailable`; a broken capture/identity relationship is `NonConformal`; then
+/// the interpolation, the dynamic error budget, and the policy limits decide
+/// `NonConformal` / `Limited` / `Valid` by fixed precedence. Cues are drawn only
+/// for a drawable verdict, so an exceeded budget removes them.
+#[must_use]
+pub fn assess_conformal(
+    bracket: &Bracket,
+    capture: CaptureContext,
+    view: &ProjectionView,
+    geom: &ViewGeometry,
+    availability: SvsAvailability,
+    policy: &ConformalPolicy,
+    path_ned_m: &[[f64; 3]],
+) -> ConformalFix {
+    let identity = FixIdentity::at_capture(bracket, capture.capture_epoch);
+
+    if view.validate().is_err()
+        || !matches!(view.projection, Projection::Perspective)
+        || geom.validate().is_err()
+    {
+        return ConformalFix::refused(
+            ConformalState::Unavailable(ConformalReason::ViewInvalid),
+            identity,
+        );
+    }
+    // The resolved geometry (extrinsics, field of view, alignment bound) must come
+    // from the same calibration the view references, or the projection would run
+    // through the wrong camera model and still register.
+    if geom.calibration != view.calibration {
+        return ConformalFix::refused(
+            ConformalState::Unavailable(ConformalReason::CalibrationMismatch),
+            identity,
+        );
+    }
+    if let SvsAvailability::Unavailable(reason) = availability {
+        return ConformalFix::refused(
+            ConformalState::Unavailable(ConformalReason::Availability(reason)),
+            identity,
+        );
+    }
+    if let Some(reason) = identity_fault(bracket, capture.capture_epoch) {
+        return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
+    }
+
+    let interp = interp::interpolate(&bracket.older, &bracket.newer, capture.capture_epoch.nanos);
+    let error = budget::compute(
+        geom.alignment_bound_rad,
+        capture.clock_error_ns,
+        capture.pipeline_latency_ns,
+        &interp,
+        policy,
+    );
+    let state = state::classify(
+        interp.timing.skew_ns,
+        interp.timing.extrapolation_ns,
+        rate_magnitude(interp.body_rate_rps),
+        &error,
+        availability,
+        policy,
+    );
+    let cues = state
+        .draws_cues()
+        .then(|| build_cues(&interp, view, geom, path_ned_m, !state.is_valid()));
+    ConformalFix {
+        state,
+        error: Some(error),
+        cues,
+        identity,
+    }
+}
+
+/// Projects every cue for a drawable fix: the horizon, the flight-path marker,
+/// and the runway/path points (up to [`MAX_PATH_CUES`], each clipped to the
+/// view's near/far policy). Only called for a drawable verdict, so a non-drawable
+/// fix carries no cues at all.
+fn build_cues(
+    interp: &interp::Interpolated,
+    view: &ProjectionView,
+    geom: &ViewGeometry,
+    path_ned_m: &[[f64; 3]],
+    limited: bool,
+) -> ConformalCues {
+    let mut path = [None; MAX_PATH_CUES];
+    let path_count = path_ned_m.len().min(MAX_PATH_CUES);
+    for (slot, point) in path.iter_mut().zip(path_ned_m.iter()).take(path_count) {
+        *slot = project::project_path_cue(interp.attitude, *point, view.near_far, geom);
+    }
+    ConformalCues {
+        horizon: project::project_horizon(interp.attitude, geom),
+        flight_path: project::project_flight_path(interp.attitude, interp.velocity_ned_mps, geom),
+        path,
+        path_count,
+        limited,
+    }
+}
+
+/// The structural fault that makes the capture/state relationship untrustworthy,
+/// or `None` when the bracket is a single coherent, in-order stream the capture
+/// time is expressed against.
+fn identity_fault(bracket: &Bracket, capture: Epoch) -> Option<ConformalReason> {
+    let older = bracket.older.attitude.stamp;
+    let newer = bracket.newer.attitude.stamp;
+    if !bracket
+        .older
+        .attitude
+        .stamp
+        .coherent_with(&bracket.older.position.stamp)
+        || !bracket
+            .newer
+            .attitude
+            .stamp
+            .coherent_with(&bracket.newer.position.stamp)
+    {
+        return Some(ConformalReason::SnapshotIncoherent);
+    }
+    if !same_stream(&older, &newer) || older.acquired_at.nanos > newer.acquired_at.nanos {
+        return Some(ConformalReason::StreamDiscontinuity);
+    }
+    if capture.clock != newer.acquired_at.clock || capture.scale != newer.acquired_at.scale {
+        return Some(ConformalReason::ClockIncoherent);
+    }
+    None
+}
+
+/// Whether two stamps are one continuous source stream: same source, incarnation,
+/// boot/attachment generation, and sampling clock and scale. Distinct from
+/// coherence, which additionally binds a single snapshot instance and so never
+/// holds across two different-time samples.
+fn same_stream(a: &SourceStamp, b: &SourceStamp) -> bool {
+    a.source_id == b.source_id
+        && a.incarnation == b.incarnation
+        && a.generation == b.generation
+        && a.acquired_at.clock == b.acquired_at.clock
+        && a.acquired_at.scale == b.acquired_at.scale
+}
+
+fn rate_magnitude(rate_rps: [f32; 3]) -> f64 {
+    let (x, y, z) = (
+        f64::from(rate_rps[0]),
+        f64::from(rate_rps[1]),
+        f64::from(rate_rps[2]),
+    );
+    libm::sqrt(x * x + y * y + z * z)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-geo/src/conformal/budget.rs
+++ b/crates/pilotage-geo/src/conformal/budget.rs
@@ -1,0 +1,116 @@
+//! The dynamic alignment-error bound: the total angular registration error of a
+//! conformal fix, combined from named, individually sourced contributors.
+//!
+//! Nothing here is a hidden constant. Every contributor is a field with a stated
+//! formula and origin, and the total is a conservative worst-case linear sum (not
+//! root-sum-square) so a consumer never under-counts. In particular there is no
+//! baked-in latency offset: the latency contribution is the caller's *measured*
+//! pipeline latency plus the attitude/position co-timing skew computed from the
+//! stamps.
+//!
+//! Angular rate and speed are not standalone additive terms — they are the
+//! *sensitivities* that turn a timing error into an angular error: attitude smears
+//! at the body angular rate, and a near-field feature's parallax smears at
+//! `speed / reference_range`. Each timing error (clock, latency, extrapolation) is
+//! multiplied by that combined sensitivity, so a fast maneuver or a fast closure
+//! inflates exactly the timing terms it should.
+
+use super::interp::Interpolated;
+use super::policy::ConformalPolicy;
+
+/// The named contributors to a conformal fix's total angular alignment error,
+/// radians. The total is the worst-case (linear) sum.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AlignmentErrorBound {
+    /// Calibration residual: the referenced calibration artifact's published
+    /// static angular alignment bound, resolved and supplied by the caller. This
+    /// crate references the calibration; it does not re-derive its budget.
+    pub calibration_rad: f64,
+    /// The interpolated attitude estimate's own 1-sigma angular accuracy (from
+    /// the coherent snapshots' attitude quality).
+    pub attitude_quality_rad: f64,
+    /// Position error as an angular parallax bound at the policy reference range:
+    /// `position_sigma / reference_range`.
+    pub position_rad: f64,
+    /// Clock uncertainty times the registration sensitivity: the capture-clock
+    /// mapping error bound × `(angular_rate + speed / reference_range)`.
+    pub clock_rad: f64,
+    /// Latency times the registration sensitivity: `(measured pipeline latency +
+    /// attitude/position skew)` × `(angular_rate + speed / reference_range)`.
+    pub latency_rad: f64,
+    /// Extrapolation times the registration sensitivity: the distance the capture
+    /// time falls outside the bracket × `(angular_rate + speed / reference_range)`;
+    /// zero for a true interpolation.
+    pub extrapolation_rad: f64,
+    /// The worst-case linear sum of the contributors — the single number the
+    /// state machine compares against the policy thresholds.
+    pub total_rad: f64,
+}
+
+impl AlignmentErrorBound {
+    /// Whether the total is within `limit_rad`, failing closed: a non-finite
+    /// total (from a non-finite input) is never within any limit, so it can never
+    /// be drawn as a plausible registered scene.
+    #[must_use]
+    pub fn within(&self, limit_rad: f64) -> bool {
+        self.total_rad.is_finite() && self.total_rad <= limit_rad
+    }
+}
+
+fn ns_to_s(ns: u64) -> f64 {
+    ns as f64 / 1e9
+}
+
+fn norm3_f64(v: [f64; 3]) -> f64 {
+    libm::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+}
+
+fn norm3_f32(v: [f32; 3]) -> f64 {
+    let (x, y, z) = (f64::from(v[0]), f64::from(v[1]), f64::from(v[2]));
+    libm::sqrt(x * x + y * y + z * z)
+}
+
+/// Combines the calibration residual, clock uncertainty, measured latency,
+/// angular rate, position/velocity error, and extrapolation of `interp` into the
+/// total alignment-error bound under `policy`.
+pub(crate) fn compute(
+    calibration_bound_rad: f64,
+    clock_error_ns: u64,
+    pipeline_latency_ns: u64,
+    interp: &Interpolated,
+    policy: &ConformalPolicy,
+) -> AlignmentErrorBound {
+    let range = policy.reference_range_m();
+    let omega = norm3_f32(interp.body_rate_rps);
+    let speed = norm3_f64(interp.velocity_ned_mps);
+    // Radians of registration error per second of timing error: the attitude
+    // channel smears at the body rate, the near-field parallax channel at
+    // speed/range.
+    let sensitivity = omega + speed / range;
+
+    let clock_s = ns_to_s(clock_error_ns);
+    let latency_s = ns_to_s(pipeline_latency_ns.saturating_add(interp.timing.skew_ns));
+    let extrap_s = ns_to_s(interp.timing.extrapolation_ns);
+
+    let calibration_rad = calibration_bound_rad;
+    let attitude_quality_rad = interp.attitude_sigma_rad;
+    let position_rad = interp.position_sigma_m / range;
+    let clock_rad = clock_s * sensitivity;
+    let latency_rad = latency_s * sensitivity;
+    let extrapolation_rad = extrap_s * sensitivity;
+
+    AlignmentErrorBound {
+        calibration_rad,
+        attitude_quality_rad,
+        position_rad,
+        clock_rad,
+        latency_rad,
+        extrapolation_rad,
+        total_rad: calibration_rad
+            + attitude_quality_rad
+            + position_rad
+            + clock_rad
+            + latency_rad
+            + extrapolation_rad,
+    }
+}

--- a/crates/pilotage-geo/src/conformal/budget.rs
+++ b/crates/pilotage-geo/src/conformal/budget.rs
@@ -32,6 +32,14 @@ pub struct AlignmentErrorBound {
     /// Position error as an angular parallax bound at the policy reference range:
     /// `position_sigma / reference_range`.
     pub position_rad: f64,
+    /// Velocity error as an angular parallax bound: the velocity 1-sigma
+    /// propagated over the total timing uncertainty into a position error, then
+    /// divided by the reference range — `velocity_sigma × (clock + latency +
+    /// extrapolation) / reference_range`. The state is bridged across those timing
+    /// gaps by the velocity, so an uncertain velocity leaves the extrapolated
+    /// position (and thus the near-field registration) uncertain. This is the
+    /// velocity-accuracy analog of [`Self::position_rad`].
+    pub velocity_rad: f64,
     /// Clock uncertainty times the registration sensitivity: the capture-clock
     /// mapping error bound × `(angular_rate + speed / reference_range)`.
     pub clock_rad: f64,
@@ -95,6 +103,11 @@ pub(crate) fn compute(
     let calibration_rad = calibration_bound_rad;
     let attitude_quality_rad = interp.attitude_sigma_rad;
     let position_rad = interp.position_sigma_m / range;
+    // The velocity bridges the state across the timing gaps (clock, latency,
+    // extrapolation), so a velocity 1-sigma leaves the extrapolated position
+    // uncertain by `velocity_sigma × timing`; as a parallax angle at the
+    // reference range that is the velocity-accuracy contribution.
+    let velocity_rad = interp.velocity_sigma_mps * (clock_s + latency_s + extrap_s) / range;
     let clock_rad = clock_s * sensitivity;
     let latency_rad = latency_s * sensitivity;
     let extrapolation_rad = extrap_s * sensitivity;
@@ -103,12 +116,14 @@ pub(crate) fn compute(
         calibration_rad,
         attitude_quality_rad,
         position_rad,
+        velocity_rad,
         clock_rad,
         latency_rad,
         extrapolation_rad,
         total_rad: calibration_rad
             + attitude_quality_rad
             + position_rad
+            + velocity_rad
             + clock_rad
             + latency_rad
             + extrapolation_rad,

--- a/crates/pilotage-geo/src/conformal/interp.rs
+++ b/crates/pilotage-geo/src/conformal/interp.rs
@@ -1,0 +1,159 @@
+//! Bounded capture-time interpolation of the coherent aircraft state.
+//!
+//! The safety-load-bearing quantity is attitude: the horizon and flight-path
+//! marker are registered against where the world's down vector and the velocity
+//! vector fall in the camera image, so attitude is interpolated with
+//! **normalized quaternion interpolation** (nlerp) in the short hemisphere. The
+//! blend reads `q` and `-q` as the same rotation — it flips the far sample into
+//! the near hemisphere before blending — so a producer's quaternion-sign choice
+//! never swings the interpolated attitude the long way round. Velocity and body
+//! rate are linear-blended.
+//!
+//! The geodetic position *value* is deliberately not re-derived here: no
+//! conformal cue consumes it (the horizon is at infinity, the flight-path marker
+//! is a direction), so it enters only through its accuracy (the parallax term of
+//! the error budget) and its coherent identity. Re-deriving a value nothing reads
+//! would add antimeridian and datum-realization edge cases for no consumer.
+
+use pilotage_frames::Quat;
+
+use super::KinematicSample;
+
+/// The aircraft state resolved at capture time, plus the timing facts the error
+/// budget and the state machine need.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Interpolated {
+    /// Body → local-navigation (NED) attitude at capture time.
+    pub attitude: Quat,
+    /// NED velocity at capture time, meters/second (the flight-path-marker
+    /// velocity reference).
+    pub velocity_ned_mps: [f64; 3],
+    /// Body-frame angular rate at capture time, radians/second.
+    pub body_rate_rps: [f32; 3],
+    /// The conservative (worst-of-bracket) attitude 1-sigma accuracy, radians.
+    pub attitude_sigma_rad: f64,
+    /// The conservative (worst-of-bracket) horizontal position 1-sigma accuracy,
+    /// meters.
+    pub position_sigma_m: f64,
+    /// Timing facts of the interpolation.
+    pub timing: Timing,
+}
+
+/// The timing facts of one interpolation: how far the capture time sits outside
+/// the bracket (extrapolation), how badly attitude and position are co-timed
+/// (skew), and the bracket span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Timing {
+    /// Attitude/position co-timing skew, the worst of the two samples,
+    /// nanoseconds.
+    pub skew_ns: u64,
+    /// How far the capture time falls outside `[older, newer]`, nanoseconds; `0`
+    /// when the capture time is bracketed (a true interpolation).
+    pub extrapolation_ns: u64,
+    /// The bracket span (newer − older), nanoseconds.
+    pub span_ns: u64,
+}
+
+/// Blends two unit quaternions on the short hemisphere and renormalizes, so the
+/// result is a unit rotation and `q`/`-q` inputs are equivalent. The antipodal
+/// degenerate case (a zero-norm blend) fails safe to `a`.
+fn nlerp(a: Quat, b: Quat, t: f32) -> Quat {
+    let dot = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+    let s = if dot < 0.0 { -1.0 } else { 1.0 };
+    let u = 1.0 - t;
+    let (w, x, y, z) = (
+        u * a.w + t * s * b.w,
+        u * a.x + t * s * b.x,
+        u * a.y + t * s * b.y,
+        u * a.z + t * s * b.z,
+    );
+    let n = libm::sqrtf(w * w + x * x + y * y + z * z);
+    if n > f32::EPSILON {
+        Quat {
+            w: w / n,
+            x: x / n,
+            y: y / n,
+            z: z / n,
+        }
+    } else {
+        a
+    }
+}
+
+fn lerp3_f64(a: [f64; 3], b: [f64; 3], t: f64) -> [f64; 3] {
+    let u = 1.0 - t;
+    [
+        u * a[0] + t * b[0],
+        u * a[1] + t * b[1],
+        u * a[2] + t * b[2],
+    ]
+}
+
+fn lerp3_f32(a: [f32; 3], b: [f32; 3], t: f32) -> [f32; 3] {
+    let u = 1.0 - t;
+    [
+        u * a[0] + t * b[0],
+        u * a[1] + t * b[1],
+        u * a[2] + t * b[2],
+    ]
+}
+
+fn skew_of(sample: &KinematicSample) -> u64 {
+    let att = sample.attitude.stamp.acquired_at.nanos;
+    let pos = sample.position.stamp.acquired_at.nanos;
+    att.abs_diff(pos)
+}
+
+/// Interpolates the coherent bracket at `capture_ns`. The caller has already
+/// validated that both samples and the capture time share one clock and scale,
+/// that the samples are one continuous stream, and that `older` is not after
+/// `newer`; this function is the pure numeric blend over that validated bracket.
+pub(crate) fn interpolate(
+    older: &KinematicSample,
+    newer: &KinematicSample,
+    capture_ns: u64,
+) -> Interpolated {
+    let older_ns = older.attitude.stamp.acquired_at.nanos;
+    let newer_ns = newer.attitude.stamp.acquired_at.nanos;
+    let span_ns = newer_ns.saturating_sub(older_ns);
+
+    // The blend fraction is clamped into `[0, 1]`: past either end the nearest
+    // endpoint is used and the extrapolation distance is charged to the budget
+    // rather than propagated forward into a fabricated pose.
+    let raw = if span_ns == 0 {
+        0.0
+    } else {
+        (capture_ns as f64 - older_ns as f64) / span_ns as f64
+    };
+    let t = raw.clamp(0.0, 1.0);
+
+    // Distance the capture time falls outside `[older, newer]`; one of the two
+    // saturating differences is zero whenever the capture time is bracketed.
+    let extrapolation_ns = older_ns
+        .saturating_sub(capture_ns)
+        .max(capture_ns.saturating_sub(newer_ns));
+
+    let attitude_sigma_rad = sigma_att(older).max(sigma_att(newer));
+    let position_sigma_m = sigma_pos(older).max(sigma_pos(newer));
+
+    Interpolated {
+        attitude: nlerp(older.attitude.attitude, newer.attitude.attitude, t as f32),
+        velocity_ned_mps: lerp3_f64(older.velocity_ned_mps, newer.velocity_ned_mps, t),
+        body_rate_rps: lerp3_f32(older.body_rate_rps, newer.body_rate_rps, t as f32),
+        attitude_sigma_rad,
+        position_sigma_m,
+        timing: Timing {
+            skew_ns: skew_of(older).max(skew_of(newer)),
+            extrapolation_ns,
+            span_ns,
+        },
+    }
+}
+
+fn sigma_att(sample: &KinematicSample) -> f64 {
+    f64::from(sample.attitude.quality.angular_mrad) * 1e-3
+}
+
+fn sigma_pos(sample: &KinematicSample) -> f64 {
+    f64::from(sample.position.quality.horizontal_mm) * 1e-3
+}

--- a/crates/pilotage-geo/src/conformal/interp.rs
+++ b/crates/pilotage-geo/src/conformal/interp.rs
@@ -35,6 +35,9 @@ pub(crate) struct Interpolated {
     /// The conservative (worst-of-bracket) horizontal position 1-sigma accuracy,
     /// meters.
     pub position_sigma_m: f64,
+    /// The conservative (worst-of-bracket) velocity 1-sigma accuracy,
+    /// meters/second — the velocity-error input to the alignment budget.
+    pub velocity_sigma_mps: f64,
     /// Timing facts of the interpolation.
     pub timing: Timing,
 }
@@ -135,13 +138,15 @@ pub(crate) fn interpolate(
 
     let attitude_sigma_rad = sigma_att(older).max(sigma_att(newer));
     let position_sigma_m = sigma_pos(older).max(sigma_pos(newer));
+    let velocity_sigma_mps = sigma_vel(older).max(sigma_vel(newer));
 
     Interpolated {
         attitude: nlerp(older.attitude.attitude, newer.attitude.attitude, t as f32),
-        velocity_ned_mps: lerp3_f64(older.velocity_ned_mps, newer.velocity_ned_mps, t),
-        body_rate_rps: lerp3_f32(older.body_rate_rps, newer.body_rate_rps, t as f32),
+        velocity_ned_mps: lerp3_f64(older.velocity.value, newer.velocity.value, t),
+        body_rate_rps: lerp3_f32(older.body_rate.value, newer.body_rate.value, t as f32),
         attitude_sigma_rad,
         position_sigma_m,
+        velocity_sigma_mps,
         timing: Timing {
             skew_ns: skew_of(older).max(skew_of(newer)),
             extrapolation_ns,
@@ -156,4 +161,8 @@ fn sigma_att(sample: &KinematicSample) -> f64 {
 
 fn sigma_pos(sample: &KinematicSample) -> f64 {
     f64::from(sample.position.quality.horizontal_mm) * 1e-3
+}
+
+fn sigma_vel(sample: &KinematicSample) -> f64 {
+    f64::from(sample.velocity_quality.sigma_mmps) * 1e-3
 }

--- a/crates/pilotage-geo/src/conformal/policy.rs
+++ b/crates/pilotage-geo/src/conformal/policy.rs
@@ -1,0 +1,215 @@
+//! The intended-function policy that bounds conformal projection: the
+//! extrapolation, skew, angular-rate, and total-error allocations a conformal
+//! HUD function is willing to draw registered symbology under.
+//!
+//! This is the conformal sibling of [`crate::AvailabilityProfile`]: availability
+//! allocates the freshness and accuracy limits that decide whether a synthetic
+//! scene may be drawn at all; this allocates the *registration* limits that
+//! decide whether that scene may be drawn **conformally** (locked to the outside
+//! world through the camera). The two are layered, not duplicated — a conformal
+//! verdict first consumes the [`crate::SvsAvailability`] verdict and only then
+//! applies these registration limits.
+//!
+//! There is deliberately no `Default` and no free function that picks a policy,
+//! so SIM limits are never presented as operational limits by omission. The one
+//! named policy shipped here is [`ConformalPolicy::simulator`]; its numbers are
+//! SIM benchmark data implying no aircraft or display approval. The checked
+//! [`ConformalPolicy::new`] refuses a zero, non-finite, or non-monotonic limit so
+//! a policy can never admit a registration it should reject, and the fields are
+//! private so a struct literal cannot skip the check.
+
+/// Why a conformal input could not be validated. A limit or a resolved geometry
+/// value that is zero, non-finite, non-monotonic, or otherwise malformed is
+/// refused, never clamped into range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ConformalError {
+    /// A policy limit was zero, non-finite, or its `valid` bound was not strictly
+    /// tighter than its `limited` bound (a non-monotonic error allocation could
+    /// admit a registration it should mark or drop).
+    #[error("conformal policy limit {field} is invalid (zero, non-finite, or non-monotonic)")]
+    InvalidPolicy {
+        /// The offending limit.
+        field: &'static str,
+    },
+    /// A resolved [`crate::ViewGeometry`] field was malformed: an incomplete
+    /// calibration reference, a non-unit body→camera rotation, a non-positive or
+    /// non-finite field of view, or a negative/non-finite alignment bound.
+    #[error("conformal view geometry field {field} is invalid")]
+    InvalidGeometry {
+        /// The offending geometry field.
+        field: &'static str,
+    },
+}
+
+/// Identity of a conformal policy — an intended-function allocation of the
+/// registration limits. Compared for equality; a verdict carries it so the
+/// limits it was judged against are traceable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConformalPolicyId(pub u32);
+
+/// The id of the simulator conformal policy.
+pub const SIMULATOR_CONFORMAL_POLICY_ID: ConformalPolicyId = ConformalPolicyId(1);
+
+/// The registration limits an intended conformal function allocates, selected at
+/// the evaluation boundary. There is deliberately **no** `Default`: a caller must
+/// choose a policy explicitly, so SIM limits are never presented as operational
+/// limits by omission.
+///
+/// The fields are private and the only ways to obtain a value are the checked
+/// [`ConformalPolicy::new`] and the controlled [`ConformalPolicy::simulator`]. A
+/// struct literal that skips the monotonicity check does not compile:
+///
+/// ```compile_fail
+/// use pilotage_geo::{ConformalPolicy, ConformalPolicyId};
+/// let _ = ConformalPolicy {
+///     id: ConformalPolicyId(9),
+///     version: 1,
+///     max_extrapolation_ns: 1,
+///     max_skew_ns: 1,
+///     max_conformal_rate_rps: 1.0,
+///     valid_error_rad: 9.0,
+///     limited_error_rad: 1.0,
+///     reference_range_m: 50.0,
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConformalPolicy {
+    id: ConformalPolicyId,
+    version: u16,
+    max_extrapolation_ns: u64,
+    max_skew_ns: u64,
+    max_conformal_rate_rps: f32,
+    valid_error_rad: f64,
+    limited_error_rad: f64,
+    reference_range_m: f64,
+}
+
+impl ConformalPolicy {
+    /// The published simulator policy. Its numbers are SIM benchmark data — a
+    /// placeholder intended-function allocation, not an operational or display
+    /// approval:
+    ///
+    /// - beyond ~50 ms of extrapolation past the newest snapshot a maneuvering
+    ///   aircraft's registration is no longer trustworthy;
+    /// - attitude and position must be co-timed to within ~10 ms to share one
+    ///   conformal fix;
+    /// - above ~1 rad/s (~57°/s) body rate the smear over any residual timing
+    ///   error swamps the budget, so conformal cues are suppressed;
+    /// - sub-degree (~0.57°) total registration error is drawn as fully
+    ///   registered; up to ~1.7° is drawn but marked reduced; beyond that the
+    ///   cues are removed;
+    /// - 50 m is the representative near-field conformal-feature range at which a
+    ///   positional error is converted to an angular parallax bound (the same
+    ///   reference range the calibration design-eye allowance uses).
+    #[must_use]
+    pub const fn simulator() -> Self {
+        Self {
+            id: SIMULATOR_CONFORMAL_POLICY_ID,
+            version: 1,
+            max_extrapolation_ns: 50_000_000,
+            max_skew_ns: 10_000_000,
+            max_conformal_rate_rps: 1.0,
+            valid_error_rad: 0.010,
+            limited_error_rad: 0.030,
+            reference_range_m: 50.0,
+        }
+    }
+
+    /// Builds a policy, failing closed on a zero, non-finite, or non-monotonic
+    /// limit: every duration and angle must be strictly positive and finite, and
+    /// the `valid` error bound must be strictly tighter than the `limited` bound,
+    /// so the policy cannot admit a registration it should mark or drop.
+    ///
+    /// # Errors
+    ///
+    /// [`ConformalError::InvalidPolicy`] naming the offending limit.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: ConformalPolicyId,
+        version: u16,
+        max_extrapolation_ns: u64,
+        max_skew_ns: u64,
+        max_conformal_rate_rps: f32,
+        valid_error_rad: f64,
+        limited_error_rad: f64,
+        reference_range_m: f64,
+    ) -> Result<Self, ConformalError> {
+        let bad = |field| Err(ConformalError::InvalidPolicy { field });
+        if max_extrapolation_ns == 0 {
+            return bad("max_extrapolation_ns");
+        }
+        if max_skew_ns == 0 {
+            return bad("max_skew_ns");
+        }
+        if !(max_conformal_rate_rps.is_finite() && max_conformal_rate_rps > 0.0) {
+            return bad("max_conformal_rate_rps");
+        }
+        if !(reference_range_m.is_finite() && reference_range_m > 0.0) {
+            return bad("reference_range_m");
+        }
+        let monotonic = valid_error_rad.is_finite()
+            && limited_error_rad.is_finite()
+            && valid_error_rad > 0.0
+            && limited_error_rad > valid_error_rad;
+        if !monotonic {
+            return bad("error_bound");
+        }
+        Ok(Self {
+            id,
+            version,
+            max_extrapolation_ns,
+            max_skew_ns,
+            max_conformal_rate_rps,
+            valid_error_rad,
+            limited_error_rad,
+            reference_range_m,
+        })
+    }
+
+    /// Policy identity.
+    #[must_use]
+    pub const fn id(&self) -> ConformalPolicyId {
+        self.id
+    }
+    /// Policy content version.
+    #[must_use]
+    pub const fn version(&self) -> u16 {
+        self.version
+    }
+    /// Extrapolation horizon (past the newest snapshot, or before the oldest)
+    /// beyond which conformal registration is refused, nanoseconds.
+    #[must_use]
+    pub const fn max_extrapolation_ns(&self) -> u64 {
+        self.max_extrapolation_ns
+    }
+    /// Maximum attitude/position co-timing skew for one conformal fix,
+    /// nanoseconds.
+    #[must_use]
+    pub const fn max_skew_ns(&self) -> u64 {
+        self.max_skew_ns
+    }
+    /// Body angular rate above which conformal cues are suppressed, rad/s.
+    #[must_use]
+    pub const fn max_conformal_rate_rps(&self) -> f32 {
+        self.max_conformal_rate_rps
+    }
+    /// Total alignment error at/under which a fix is fully registered
+    /// ([`crate::ConformalState::Valid`]), radians.
+    #[must_use]
+    pub const fn valid_error_rad(&self) -> f64 {
+        self.valid_error_rad
+    }
+    /// Total alignment error at/under which a fix is drawn but marked reduced
+    /// ([`crate::ConformalState::Limited`]); beyond it the cues are removed,
+    /// radians.
+    #[must_use]
+    pub const fn limited_error_rad(&self) -> f64 {
+        self.limited_error_rad
+    }
+    /// Reference range at which a positional error is converted to an angular
+    /// parallax bound, meters.
+    #[must_use]
+    pub const fn reference_range_m(&self) -> f64 {
+        self.reference_range_m
+    }
+}

--- a/crates/pilotage-geo/src/conformal/project.rs
+++ b/crates/pilotage-geo/src/conformal/project.rs
@@ -1,0 +1,306 @@
+//! Projecting the conformal cues — horizon, flight-path marker, and runway/path
+//! cues — through the referenced camera model, in an explicit coordinate
+//! reference.
+//!
+//! # Coordinate and velocity references (explicit)
+//!
+//! The camera optical frame follows the calibration's OpenCV convention: `+Z`
+//! along the optical axis into the scene, `+X` right, `+Y` **down**, origin at
+//! the principal point (the boresight). A direction `(X, Y, Z)` in that frame
+//! with `Z > 0` projects to the **normalized image coordinate**
+//! `(x, y) = (X/Z, Y/Z)` — the tangent of the angle off boresight, independent
+//! of focal length. A consumer maps it to pixels with the resolved intrinsics:
+//! `u = principal_x + focal_x · x`, `v = principal_y + focal_y · y`. Keeping the
+//! projection focal-independent is deliberate: this crate references the
+//! calibration but does not re-mint its intrinsics.
+//!
+//! The **horizon** is the locus of viewing rays perpendicular to the local
+//! vertical (NED down). Its image is the line `a·x + b·y + c = 0` whose
+//! coefficients are exactly the NED-down direction expressed in the camera frame;
+//! the ground half-plane is the side where `a·x + b·y + c > 0` (the side the down
+//! vector points).
+//!
+//! The **flight-path marker** sits at the direction of the aircraft's
+//! **ground-referenced NED velocity** (not air-mass, not heading), so under a
+//! crosswind it sits off the nose by the drift angle. It is drawn only when the
+//! velocity direction is in front of the camera; behind or grazing the optical
+//! axis it is removed.
+//!
+//! The **runway/path cues** are finite ground features (a runway outline, an
+//! approach path, or a flight-path tunnel gate) supplied as offsets in the local
+//! NED frame relative to the ownship, meters. Each is projected through the same
+//! camera and clipped to the projection view's near/far policy: a point behind
+//! the camera or outside the clip range is removed, and a point in front but
+//! outside the field is marked off-scale.
+//!
+//! # Binding to one calibration
+//!
+//! [`ViewGeometry`] can only be **derived** from a [`VerifiedCameraModel`]
+//! ([`ViewGeometry::derive`]) — the unforgeable verified model minted by
+//! `pilotage-camera-calibration` only after a genuine content-hash verification.
+//! [`ViewGeometry`]'s fields are crate-private, so a caller cannot hand-build one
+//! that pairs a copied calibration identity with forged geometry; the derived
+//! value embeds the [`CalibrationRef`] rebuilt from the verified model's identity
+//! and content hash, so the extrinsics, field of view, and alignment bound it
+//! carries provably belong to that one authenticated calibration.
+//! [`crate::assess_conformal`] additionally refuses (fail-closed) a geometry
+//! whose calibration does not match the [`crate::ProjectionView`]'s, so there is
+//! no path to a registered scene without a genuinely verified calibration.
+
+use pilotage_camera_calibration::VerifiedCameraModel;
+use pilotage_frames::{Quat, ROTATION_NORM_TOLERANCE};
+
+use super::policy::ConformalError;
+use crate::view::{CalibrationRef, NearFarPolicy};
+
+/// Speed below which the ground-referenced velocity has no well-defined
+/// direction, so the flight-path marker is not drawn, meters/second.
+const MIN_SPEED_MPS: f64 = 0.1;
+
+/// Minimum camera-axis component for a direction to be treated as in front of
+/// the camera; at or below it the projection is grazing/behind and is removed.
+const FORWARD_EPS: f64 = 1e-6;
+
+/// The horizon line in normalized image coordinates: the set of points `(x, y)`
+/// with `a·x + b·y + c = 0`. The coefficients are the NED-down direction in the
+/// camera optical frame, so the ground half-plane is `a·x + b·y + c > 0`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HorizonLine {
+    /// Coefficient of the normalized image `x`.
+    pub a: f64,
+    /// Coefficient of the normalized image `y`.
+    pub b: f64,
+    /// Constant term.
+    pub c: f64,
+}
+
+/// A cue marked at a normalized image coordinate, with whether it falls inside
+/// the referenced camera's field of view. A mark outside the field is the
+/// off-scale indication: the consumer clamps it to the frame edge rather than
+/// drawing it as if registered off-screen.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScreenMark {
+    /// Normalized image `x` = `X_cam / Z_cam` (tangent of the horizontal angle
+    /// off boresight).
+    pub x: f64,
+    /// Normalized image `y` = `Y_cam / Z_cam` (tangent of the vertical angle off
+    /// boresight; positive is down).
+    pub y: f64,
+    /// Whether the mark lies within the field of view.
+    pub within_fov: bool,
+}
+
+/// Validates resolved geometry components, failing closed: the calibration
+/// reference must be well-formed, the body→camera quaternion must be a unit
+/// rotation, each half-FOV tangent must be finite and strictly positive (a
+/// half-angle in `(0, 90°)`, a full field under 180°), and the alignment bound
+/// must be finite and non-negative.
+fn validate_components(
+    calibration: CalibrationRef,
+    body_to_camera: Quat,
+    half_fov_x_tan: f64,
+    half_fov_y_tan: f64,
+    alignment_bound_rad: f64,
+) -> Result<(), ConformalError> {
+    let bad = |field| Err(ConformalError::InvalidGeometry { field });
+    if calibration.validate().is_err() {
+        return bad("calibration");
+    }
+    if body_to_camera
+        .renormalized(ROTATION_NORM_TOLERANCE)
+        .is_err()
+    {
+        return bad("body_to_camera");
+    }
+    if !(half_fov_x_tan.is_finite() && half_fov_x_tan > 0.0) {
+        return bad("half_fov_x_tan");
+    }
+    if !(half_fov_y_tan.is_finite() && half_fov_y_tan > 0.0) {
+        return bad("half_fov_y_tan");
+    }
+    if !(alignment_bound_rad.is_finite() && alignment_bound_rad >= 0.0) {
+        return bad("alignment_bound_rad");
+    }
+    Ok(())
+}
+
+/// The resolved render-time viewing geometry for one projection call: the
+/// calibration it was derived from, the body→camera rotation, the field-of-view
+/// half-extents, and the calibration's published alignment bound.
+///
+/// This is **not** a second camera model: it embeds the existing
+/// [`CalibrationRef`] (identity and content hash only) and carries no intrinsics,
+/// distortion, or lifecycle — those live in the calibration contract.
+///
+/// Its fields are crate-private and there is no public field-wise constructor:
+/// the only way to obtain one is [`ViewGeometry::derive`] from a
+/// [`VerifiedCameraModel`]. A calibration binding therefore cannot be forged by
+/// copying a valid identity into hand-built geometry — that does not compile:
+///
+/// ```compile_fail
+/// use pilotage_geo::ViewGeometry;
+/// // The fields are private; a copied calibration identity cannot be paired with
+/// // arbitrary geometry. Only `ViewGeometry::derive` from a verified calibration
+/// // produces a value.
+/// let _ = ViewGeometry {
+///     calibration: todo!(),
+///     body_to_camera: todo!(),
+///     half_fov_x_tan: todo!(),
+///     half_fov_y_tan: todo!(),
+///     alignment_bound_rad: todo!(),
+/// };
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ViewGeometry {
+    /// The calibration this geometry was derived from (must equal the
+    /// projection view's calibration).
+    pub(crate) calibration: CalibrationRef,
+    /// Rotation taking body-frame directions into the camera optical frame.
+    pub(crate) body_to_camera: Quat,
+    /// Tangent of the half horizontal field of view.
+    pub(crate) half_fov_x_tan: f64,
+    /// Tangent of the half vertical field of view.
+    pub(crate) half_fov_y_tan: f64,
+    /// The calibration's published static angular alignment bound, radians.
+    pub(crate) alignment_bound_rad: f64,
+}
+
+impl ViewGeometry {
+    /// Derives the resolved geometry from a [`VerifiedCameraModel`] — the only way
+    /// to obtain a [`ViewGeometry`]. The `model` can itself only be minted by a
+    /// genuine content-hash verification in `pilotage-camera-calibration`, so a
+    /// derived geometry is authenticated by construction. Every field is read from
+    /// the one model — the [`CalibrationRef`] is rebuilt from its identity and
+    /// content hash — so the binding is a product of derivation, not a copyable
+    /// claim, and the derived value is validated before it is returned.
+    ///
+    /// # Errors
+    ///
+    /// [`ConformalError::InvalidGeometry`] when the derived values are malformed
+    /// (an incomplete reference, a non-unit rotation, a non-positive field of
+    /// view, or a negative/non-finite bound).
+    pub fn derive(model: &VerifiedCameraModel) -> Result<Self, ConformalError> {
+        let (half_fov_x_tan, half_fov_y_tan) = model.half_fov_tangents();
+        let geometry = Self {
+            calibration: CalibrationRef {
+                calibration_id: model.calibration_id(),
+                content_hash: model.content_hash(),
+            },
+            body_to_camera: model.body_to_camera(),
+            half_fov_x_tan,
+            half_fov_y_tan,
+            alignment_bound_rad: model.alignment_bound_rad(),
+        };
+        geometry.validate()?;
+        Ok(geometry)
+    }
+
+    /// Validates the resolved geometry, failing closed: the calibration reference
+    /// must be well-formed, the body→camera quaternion must be a unit rotation,
+    /// each half-FOV tangent must be finite and strictly positive (a half-angle in
+    /// `(0, 90°)`, a full field under 180°), and the alignment bound must be finite
+    /// and non-negative.
+    ///
+    /// # Errors
+    ///
+    /// [`ConformalError::InvalidGeometry`] naming the offending field.
+    pub fn validate(&self) -> Result<(), ConformalError> {
+        validate_components(
+            self.calibration,
+            self.body_to_camera,
+            self.half_fov_x_tan,
+            self.half_fov_y_tan,
+            self.alignment_bound_rad,
+        )
+    }
+
+    /// Whether a normalized image mark lies within this geometry's field of view.
+    fn within_fov(&self, x: f64, y: f64) -> bool {
+        x.abs() <= self.half_fov_x_tan && y.abs() <= self.half_fov_y_tan
+    }
+}
+
+/// The world's NED-down unit direction expressed in the camera optical frame:
+/// rotate NED down into the body frame (the inverse aircraft attitude), then
+/// body into camera (the extrinsics). All arithmetic is f64 — [`Quat::rotate`]
+/// promotes — so the horizon coefficients do not lose precision to the f32
+/// quaternion storage.
+#[must_use]
+pub fn down_in_camera(attitude_body_to_ned: Quat, body_to_camera: Quat) -> [f64; 3] {
+    let down_body = attitude_body_to_ned.inverse().rotate([0.0, 0.0, 1.0]);
+    body_to_camera.rotate(down_body)
+}
+
+/// Projects the horizon line for the given aircraft attitude and camera mount.
+/// The coefficients are the NED-down direction in the camera frame.
+#[must_use]
+pub fn project_horizon(attitude_body_to_ned: Quat, geom: &ViewGeometry) -> HorizonLine {
+    let [a, b, c] = down_in_camera(attitude_body_to_ned, geom.body_to_camera);
+    HorizonLine { a, b, c }
+}
+
+/// Projects the flight-path marker at the ground-referenced NED velocity
+/// direction. Returns `None` when the speed is below `MIN_SPEED_MPS` (no defined
+/// direction) or the velocity direction is not in front of the camera (removed
+/// rather than drawn behind the eye).
+#[must_use]
+pub fn project_flight_path(
+    attitude_body_to_ned: Quat,
+    velocity_ned_mps: [f64; 3],
+    geom: &ViewGeometry,
+) -> Option<ScreenMark> {
+    let speed = norm3(velocity_ned_mps);
+    if speed < MIN_SPEED_MPS {
+        return None;
+    }
+    let dir_ned = [
+        velocity_ned_mps[0] / speed,
+        velocity_ned_mps[1] / speed,
+        velocity_ned_mps[2] / speed,
+    ];
+    let dir_body = attitude_body_to_ned.inverse().rotate(dir_ned);
+    let f = geom.body_to_camera.rotate(dir_body);
+    if f[2] <= FORWARD_EPS {
+        return None;
+    }
+    let x = f[0] / f[2];
+    let y = f[1] / f[2];
+    Some(ScreenMark {
+        x,
+        y,
+        within_fov: geom.within_fov(x, y),
+    })
+}
+
+/// Projects one runway/path cue point — a finite ground feature given as an
+/// offset in the local NED frame relative to the ownship, meters — through the
+/// camera and the projection view's near/far clip policy.
+///
+/// Returns `None` when the point is behind the camera or outside the near/far
+/// clip range (removed rather than drawn); a point in front but outside the field
+/// is `Some` with `within_fov = false` (the off-scale indication).
+#[must_use]
+pub fn project_path_cue(
+    attitude_body_to_ned: Quat,
+    offset_ned_m: [f64; 3],
+    near_far: NearFarPolicy,
+    geom: &ViewGeometry,
+) -> Option<ScreenMark> {
+    let off_body = attitude_body_to_ned.inverse().rotate(offset_ned_m);
+    let c = geom.body_to_camera.rotate(off_body);
+    let depth = c[2];
+    if depth <= FORWARD_EPS || !near_far.contains_depth(depth) {
+        return None;
+    }
+    let x = c[0] / depth;
+    let y = c[1] / depth;
+    Some(ScreenMark {
+        x,
+        y,
+        within_fov: geom.within_fov(x, y),
+    })
+}
+
+fn norm3(v: [f64; 3]) -> f64 {
+    libm::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+}

--- a/crates/pilotage-geo/src/conformal/state.rs
+++ b/crates/pilotage-geo/src/conformal/state.rs
@@ -1,0 +1,132 @@
+//! The conformal-registration verdict and its fixed precedence.
+//!
+//! This is the conformal sibling of [`crate::SvsAvailability`]: like that
+//! verdict, every non-nominal outcome carries a typed reason, and the precedence
+//! is fixed so the same inputs always yield the same verdict. The verdict decides
+//! whether registered symbology may be drawn:
+//!
+//! - [`ConformalState::Valid`] — draw the cues registered to the world;
+//! - [`ConformalState::Limited`] — draw them, but marked as reduced confidence;
+//! - [`ConformalState::NonConformal`] — **remove** the registered cues (the
+//!   budget or a registration limit was exceeded); a consumer may show a
+//!   non-conformal fallback but must never leave plausible stale alignment;
+//! - [`ConformalState::Unavailable`] — no usable state or camera at all.
+//!
+//! Only [`ConformalState::Valid`] and [`ConformalState::Limited`] draw cues, so a
+//! consumer that honors [`ConformalState::draws_cues`] can never paint a stale
+//! horizon or flight-path marker after the error budget is exceeded.
+
+use crate::availability::{AvailabilityReason, SvsAvailability};
+
+use super::budget::AlignmentErrorBound;
+use super::policy::ConformalPolicy;
+
+/// Why a conformal fix is not fully registered. Each verdict below `Valid` names
+/// the specific condition that decided it, so the outcome is traceable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConformalReason {
+    /// No fault; the fix is fully registered.
+    Nominal,
+    /// The underlying synthetic-vision state is degraded or unavailable; carries
+    /// the delegated [`AvailabilityReason`] rather than re-deriving it.
+    Availability(AvailabilityReason),
+    /// The projection view failed validation or is not a perspective conformal
+    /// view, or the resolved view geometry failed validation, so no trustworthy
+    /// camera model resolves.
+    ViewInvalid,
+    /// The resolved view geometry was resolved from a different calibration than
+    /// the projection view references, so the projection would run through the
+    /// wrong camera model.
+    CalibrationMismatch,
+    /// The capture time is not on the same clock domain and time scale as the
+    /// aircraft state, so it cannot be aligned to it.
+    ClockIncoherent,
+    /// A sample's attitude and position are not one declared coherent snapshot,
+    /// so the pose is not a single trustworthy fix.
+    SnapshotIncoherent,
+    /// The two bracket samples are not one continuous source stream, or the
+    /// bracket is out of time order (a reordered or restarted timeline).
+    StreamDiscontinuity,
+    /// Attitude and position are co-timed worse than the policy allows.
+    ExcessiveSkew,
+    /// The capture time falls further outside the bracket than the policy allows.
+    ExcessiveExtrapolation,
+    /// The body angular rate exceeds the policy's conformal limit.
+    ExcessiveRate,
+    /// The dynamic alignment-error bound exceeds the policy's limit.
+    ErrorBudgetExceeded,
+}
+
+/// The conformal-registration verdict. Every outcome below `Valid` carries the
+/// [`ConformalReason`] that decided it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConformalState {
+    /// Fully registered; draw the cues locked to the world.
+    Valid,
+    /// Registered but reduced; draw the cues marked as lower confidence.
+    Limited(ConformalReason),
+    /// Not registered; remove the conformal cues for the given reason.
+    NonConformal(ConformalReason),
+    /// No usable aircraft state or camera model, for the given reason.
+    Unavailable(ConformalReason),
+}
+
+impl ConformalState {
+    /// The reason behind this verdict ([`ConformalReason::Nominal`] when valid).
+    #[must_use]
+    pub const fn reason(self) -> ConformalReason {
+        match self {
+            Self::Valid => ConformalReason::Nominal,
+            Self::Limited(r) | Self::NonConformal(r) | Self::Unavailable(r) => r,
+        }
+    }
+
+    /// Whether registered conformal cues may be drawn (valid or limited only).
+    /// A consumer that gates drawing on this can never paint a stale registration
+    /// after the budget is exceeded.
+    #[must_use]
+    pub const fn draws_cues(self) -> bool {
+        matches!(self, Self::Valid | Self::Limited(_))
+    }
+
+    /// Whether the fix is fully registered (valid only).
+    #[must_use]
+    pub const fn is_valid(self) -> bool {
+        matches!(self, Self::Valid)
+    }
+}
+
+/// Classifies a fix from its post-interpolation facts by fixed precedence: a
+/// registration limit (skew, extrapolation, rate) removes the cues first; then an
+/// exceeded error budget removes them; then a within-`limited`-but-not-`valid`
+/// budget or a degraded underlying scene marks them reduced; otherwise the fix is
+/// valid. Deterministic and traceable.
+pub(crate) fn classify(
+    skew_ns: u64,
+    extrapolation_ns: u64,
+    rate_rps: f64,
+    error: &AlignmentErrorBound,
+    availability: SvsAvailability,
+    policy: &ConformalPolicy,
+) -> ConformalState {
+    if skew_ns > policy.max_skew_ns() {
+        return ConformalState::NonConformal(ConformalReason::ExcessiveSkew);
+    }
+    if extrapolation_ns > policy.max_extrapolation_ns() {
+        return ConformalState::NonConformal(ConformalReason::ExcessiveExtrapolation);
+    }
+    // A non-finite rate fails closed alongside an over-limit one.
+    if rate_rps > f64::from(policy.max_conformal_rate_rps()) || !rate_rps.is_finite() {
+        return ConformalState::NonConformal(ConformalReason::ExcessiveRate);
+    }
+    if !error.within(policy.limited_error_rad()) {
+        return ConformalState::NonConformal(ConformalReason::ErrorBudgetExceeded);
+    }
+    if !error.within(policy.valid_error_rad()) {
+        return ConformalState::Limited(ConformalReason::ErrorBudgetExceeded);
+    }
+    if let SvsAvailability::Degraded(r) = availability {
+        return ConformalState::Limited(ConformalReason::Availability(r));
+    }
+    ConformalState::Valid
+}

--- a/crates/pilotage-geo/src/conformal/state.rs
+++ b/crates/pilotage-geo/src/conformal/state.rs
@@ -47,6 +47,15 @@ pub enum ConformalReason {
     /// The two bracket samples are not one continuous source stream, or the
     /// bracket is out of time order (a reordered or restarted timeline).
     StreamDiscontinuity,
+    /// A bracket endpoint's attitude quaternion is not a unit rotation (e.g. a
+    /// zero or denormalized quaternion), so it cannot orient the projection.
+    AttitudeNotARotation,
+    /// A bracket endpoint's velocity or body rate is not in its required frame
+    /// (velocity must be NED, body rate body-frame), so it cannot be projected.
+    KinematicFrame,
+    /// A bracket endpoint's velocity or body rate does not share the pose's
+    /// coherent snapshot, so the kinematics are not one trustworthy fix.
+    KinematicProvenance,
     /// Attitude and position are co-timed worse than the policy allows.
     ExcessiveSkew,
     /// The capture time falls further outside the bracket than the policy allows.

--- a/crates/pilotage-geo/src/conformal/tests.rs
+++ b/crates/pilotage-geo/src/conformal/tests.rs
@@ -1,24 +1,31 @@
-//! Ground-truth tests for bounded conformal projection (HUD-03): the projection
-//! and interpolation half. The verdict/state-machine half is in [`verdict`].
+//! Ground-truth tests for bounded conformal projection (HUD-03). This module
+//! holds the shared deterministic fixtures; the tests live in its submodules:
 //!
-//! Every test is deterministic and synchronizes on values, never on time. The
-//! projection is cross-checked against an independent f64 rotation-matrix oracle
-//! (a different arithmetic path than the production quaternion sandwich).
+//! - [`projection`] — the projection/interpolation geometry, cross-checked
+//!   against an independent f64 rotation-matrix oracle;
+//! - [`verdict`] — the four-valued state machine and its structural, budget, and
+//!   identity gates;
+//! - [`kinematics`] — the kinematic-input validity gate (attitude, frame,
+//!   provenance, and velocity-accuracy regressions).
+//!
+//! Every test is deterministic and synchronizes on values, never on time.
 #![allow(clippy::expect_used, clippy::panic)]
 
+mod kinematics;
+mod projection;
 mod verdict;
 
-use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, Tagged, TimeScale};
 
 use pilotage_camera_calibration::{
     SIM_FPV_CALIBRATION_HASH, SIM_FPV_CALIBRATION_ID, VerifiedCameraModel, sim_fpv_calibration,
 };
 
 use super::{
-    Bracket, CaptureContext, ConformalFix, ConformalPolicy, KinematicSample, ViewGeometry,
-    assess_conformal, down_in_camera, project_path_cue,
+    AvailabilityInputs, Bracket, CaptureContext, ConformalFix, ConformalPolicy, KinematicSample,
+    VelocityQuality, ViewGeometry, assess_conformal,
 };
-use crate::SvsAvailability;
+use crate::availability::{AvailabilityProfile, ExternalHealth, InputHealth};
 use crate::datum::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
     LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
@@ -80,7 +87,9 @@ fn geopos() -> GeodeticPosition {
 }
 
 /// A sample whose attitude and position share one coherent snapshot stamp (zero
-/// skew), with small, conformal-grade accuracies.
+/// skew), with small, conformal-grade accuracies. The velocity is NED and the
+/// body rate body-frame, each carrying the same coherent snapshot stamp as the
+/// pose so the kinematic provenance is coherent.
 fn sample(att: Quat, vel: [f64; 3], rate: [f32; 3], nanos: u64, snap_id: u64) -> KinematicSample {
     let s = stamp(nanos, snap_id);
     KinematicSample {
@@ -97,8 +106,19 @@ fn sample(att: Quat, vel: [f64; 3], rate: [f32; 3], nanos: u64, snap_id: u64) ->
                 vertical_mm: 100,
             },
         },
-        velocity_ned_mps: vel,
-        body_rate_rps: rate,
+        velocity: Tagged {
+            frame: FrameId::Ned,
+            epoch: epoch(nanos),
+            meta: s,
+            value: vel,
+        },
+        body_rate: Tagged {
+            frame: FrameId::Body,
+            epoch: epoch(nanos),
+            meta: s,
+            value: rate,
+        },
+        velocity_quality: VelocityQuality { sigma_mmps: 50 },
     }
 }
 
@@ -197,295 +217,33 @@ pub(super) fn generous() -> ConformalPolicy {
     .expect("a monotonic policy is valid")
 }
 
-/// Assess with the nominal view/camera, an available scene, and no path cues.
+/// External health with every producer-stated input nominal, so the derived
+/// availability is decided by the samples' own integrity and accuracy.
+pub(super) fn healthy_external() -> ExternalHealth {
+    ExternalHealth {
+        integrity: InputHealth::Ok,
+        calibration: InputHealth::Ok,
+        database: InputHealth::Ok,
+        coverage: InputHealth::Ok,
+        renderer: InputHealth::Ok,
+    }
+}
+
+/// Availability inputs that let the samples decide: nominal external health and
+/// the simulator profile.
+pub(super) fn availability() -> AvailabilityInputs {
+    AvailabilityInputs {
+        external: healthy_external(),
+        profile: AvailabilityProfile::simulator(),
+    }
+}
+
+/// Assess with the nominal view/camera, sample-decided availability, and no path
+/// cues.
 fn run(bracket: &Bracket, cap: CaptureContext, policy: &ConformalPolicy) -> ConformalFix {
-    assess_conformal(
-        bracket,
-        cap,
-        &view(),
-        &geom(),
-        SvsAvailability::Available,
-        policy,
-        &[],
-    )
+    assess_conformal(bracket, cap, &view(), &geom(), availability(), policy, &[])
 }
 
 fn approx(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() <= tol
-}
-
-#[test]
-fn forward_camera_mount_maps_body_axes_to_opencv_axes() {
-    let bc = geom().body_to_camera;
-    let near = |v: [f64; 3], e: [f64; 3]| (0..3).all(|i| approx(v[i], e[i], 1e-6));
-    assert!(
-        near(bc.rotate([1.0, 0.0, 0.0]), [0.0, 0.0, 1.0]),
-        "fwd -> optical axis"
-    );
-    assert!(
-        near(bc.rotate([0.0, 1.0, 0.0]), [1.0, 0.0, 0.0]),
-        "right -> image +x"
-    );
-    assert!(
-        near(bc.rotate([0.0, 0.0, 1.0]), [0.0, 1.0, 0.0]),
-        "down -> image +y"
-    );
-}
-
-// --- projection: horizon ----------------------------------------------------
-
-#[test]
-fn level_horizon_is_centered_and_horizontal() {
-    let cues = run(
-        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("level flight is conformal");
-    // 0*x + 1*y + 0 = 0 -> y = 0, horizontal through the image center.
-    assert!(approx(cues.horizon.a, 0.0, 1e-6) && approx(cues.horizon.c, 0.0, 1e-6));
-    assert!(
-        cues.horizon.b.abs() > 0.5,
-        "a horizontal line has a nonzero y-coefficient"
-    );
-}
-
-#[test]
-fn nose_up_drops_the_horizon_below_center() {
-    let q = euler_quat(0.0, 10.0, 0.0);
-    let cues = run(
-        &steady(q, [50.0, 0.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("10 deg nose-up is conformal");
-    // Line a*x + b*y + c = 0 at x=0 gives y = -c/b; nose-up puts the horizon
-    // below center (+y is down), at tan(pitch).
-    let y_at_center = -cues.horizon.c / cues.horizon.b;
-    assert!(
-        approx(y_at_center, libm::tan(10.0 * DEG), 1e-4),
-        "horizon y {y_at_center} should be tan(10 deg)"
-    );
-}
-
-#[test]
-fn high_pitch_and_bank_stay_finite_and_rotate_the_horizon() {
-    let q = euler_quat(30.0, 80.0, 0.0);
-    let cues = run(
-        &steady(q, [40.0, 0.0, 10.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("high pitch/bank is still conformal at zero rate");
-    let h = cues.horizon;
-    assert!(h.a.is_finite() && h.b.is_finite() && h.c.is_finite());
-    assert!(
-        h.a.abs() > 1e-3,
-        "bank rotates the horizon (nonzero x-coefficient)"
-    );
-}
-
-#[test]
-fn straight_ahead_flight_path_marker_sits_on_boresight() {
-    let fpm = run(
-        &steady(Quat::IDENTITY, [60.0, 0.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("conformal")
-    .flight_path
-    .expect("a forward velocity has a drawable marker");
-    assert!(approx(fpm.x, 0.0, 1e-6) && approx(fpm.y, 0.0, 1e-6));
-    assert!(fpm.within_fov);
-}
-
-#[test]
-fn crosswind_offsets_the_flight_path_marker_sideways() {
-    // Heading north, level, but drifting east: the marker shifts right by the
-    // drift angle, off the nose.
-    let fpm = run(
-        &steady(Quat::IDENTITY, [50.0, 10.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("conformal")
-    .flight_path
-    .expect("drawable");
-    assert!(
-        approx(fpm.x, 10.0 / 50.0, 1e-6),
-        "x = east/north drift tangent"
-    );
-    assert!(approx(fpm.y, 0.0, 1e-6), "no vertical drift");
-    assert!(fpm.within_fov);
-}
-
-#[test]
-fn flight_path_marker_off_scale_past_the_field_boundary() {
-    let inside = run(
-        &steady(Quat::IDENTITY, [50.0, 40.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("conformal")
-    .flight_path
-    .expect("drawable");
-    assert!(inside.within_fov, "tan ~0.8 is inside the 40 deg half-FOV");
-
-    let outside = run(
-        &steady(Quat::IDENTITY, [50.0, 60.0, 0.0], [0.0; 3]),
-        capture(1_500),
-        &sim(),
-    )
-    .cues
-    .expect("conformal")
-    .flight_path
-    .expect("drawable");
-    assert!(!outside.within_fov, "tan 1.2 is the off-scale indication");
-}
-
-#[test]
-fn runway_path_cue_projects_clips_and_flags_off_scale() {
-    let g = geom();
-    let nf = view().near_far; // near 0.5 m, far 5000 m
-    let att = Quat::IDENTITY; // level, forward-looking camera
-
-    // A runway point 300 m ahead and 50 m below the ownship projects below center
-    // (positive y is down) and on-scale.
-    let ahead = project_path_cue(att, [300.0, 0.0, 50.0], nf, &g).expect("in front, in range");
-    assert!(approx(ahead.x, 0.0, 1e-9) && approx(ahead.y, 50.0 / 300.0, 1e-9));
-    assert!(ahead.within_fov);
-
-    // A point in front but far to the right is off-scale (marked, not dropped).
-    let side = project_path_cue(att, [100.0, 200.0, 0.0], nf, &g).expect("in front");
-    assert!(!side.within_fov, "tan 2.0 is beyond the 40 deg half-FOV");
-
-    // Behind the camera: removed, never drawn behind the eye.
-    assert!(
-        project_path_cue(att, [-300.0, 0.0, 50.0], nf, &g).is_none(),
-        "a point behind the camera is removed"
-    );
-    // Beyond the far clip: removed by the projection view's near/far policy.
-    assert!(
-        project_path_cue(att, [6000.0, 0.0, 0.0], nf, &g).is_none(),
-        "a point past the far plane is clipped"
-    );
-    // Inside the near clip: also removed.
-    assert!(
-        project_path_cue(att, [0.2, 0.0, 0.0], nf, &g).is_none(),
-        "a point inside the near plane is clipped"
-    );
-}
-
-// --- independent f64 oracle -------------------------------------------------
-
-/// Rotation matrix from a quaternion — the standard closed form, an arithmetic
-/// path independent of the production `Quat::rotate` cross-product sandwich.
-fn rot(q: Quat) -> [[f64; 3]; 3] {
-    let (w, x, y, z) = (
-        f64::from(q.w),
-        f64::from(q.x),
-        f64::from(q.y),
-        f64::from(q.z),
-    );
-    [
-        [
-            1.0 - 2.0 * (y * y + z * z),
-            2.0 * (x * y - w * z),
-            2.0 * (x * z + w * y),
-        ],
-        [
-            2.0 * (x * y + w * z),
-            1.0 - 2.0 * (x * x + z * z),
-            2.0 * (y * z - w * x),
-        ],
-        [
-            2.0 * (x * z - w * y),
-            2.0 * (y * z + w * x),
-            1.0 - 2.0 * (x * x + y * y),
-        ],
-    ]
-}
-
-fn matvec(m: [[f64; 3]; 3], v: [f64; 3]) -> [f64; 3] {
-    let row = |r: [f64; 3]| r[0] * v[0] + r[1] * v[1] + r[2] * v[2];
-    [row(m[0]), row(m[1]), row(m[2])]
-}
-
-fn transpose(m: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
-    [
-        [m[0][0], m[1][0], m[2][0]],
-        [m[0][1], m[1][1], m[2][1]],
-        [m[0][2], m[1][2], m[2][2]],
-    ]
-}
-
-#[test]
-fn horizon_matches_the_independent_f64_reference() {
-    let bc = geom().body_to_camera;
-    for &(r, p, yaw) in &[
-        (0.0, 0.0, 0.0),
-        (0.0, 10.0, 0.0),
-        (30.0, 80.0, 0.0),
-        (-45.0, -20.0, 33.0),
-        (170.0, 5.0, -95.0),
-    ] {
-        let att = euler_quat(r, p, yaw);
-        let got = down_in_camera(att, bc);
-        // Oracle: NED down into body via R(att)^T, then body into camera via R(bc).
-        let down_body = matvec(transpose(rot(att)), [0.0, 0.0, 1.0]);
-        let want = matvec(rot(bc), down_body);
-        for i in 0..3 {
-            assert!(
-                approx(got[i], want[i], 1e-6),
-                "comp {i}: got {} want {} at r{r} p{p} y{yaw}",
-                got[i],
-                want[i]
-            );
-        }
-    }
-}
-
-#[test]
-fn static_pose_interpolates_to_the_same_attitude() {
-    let b = steady(euler_quat(5.0, -8.0, 42.0), [50.0, 0.0, 0.0], [0.0; 3]);
-    let a = run(&b, capture(1_000), &sim()).cues.expect("valid").horizon;
-    let c = run(&b, capture(1_900), &sim()).cues.expect("valid").horizon;
-    // A static pose yields the same horizon regardless of capture time (nlerp of
-    // two equal quaternions is that quaternion, up to renormalization rounding).
-    assert!(approx(a.a, c.a, 1e-6) && approx(a.b, c.b, 1e-6) && approx(a.c, c.c, 1e-6));
-}
-
-#[test]
-fn constant_rate_interpolates_the_midpoint_attitude() {
-    let b = Bracket {
-        older: sample(
-            euler_quat(0.0, 0.0, 0.0),
-            [50.0, 0.0, 0.0],
-            [0.0, 0.0, 0.17],
-            1_000_000,
-            1,
-        ),
-        newer: sample(
-            euler_quat(0.0, 0.0, 20.0),
-            [50.0, 0.0, 0.0],
-            [0.0, 0.0, 0.17],
-            3_000_000,
-            2,
-        ),
-    };
-    let fix = run(&b, capture(2_000_000), &sim());
-    // At the midpoint the interpolated attitude is ~10 deg yaw. A north-pointing
-    // velocity then projects to a marker at x = -tan(yaw): recover the yaw from it.
-    let fpm = fix.cues.expect("conformal").flight_path.expect("drawable");
-    assert!(
-        approx(fpm.x, -libm::tan(10.0 * DEG), 2e-3),
-        "midpoint yaw ~10 deg puts a north-velocity marker at -tan(10 deg), got x={}",
-        fpm.x
-    );
 }

--- a/crates/pilotage-geo/src/conformal/tests.rs
+++ b/crates/pilotage-geo/src/conformal/tests.rs
@@ -1,0 +1,491 @@
+//! Ground-truth tests for bounded conformal projection (HUD-03): the projection
+//! and interpolation half. The verdict/state-machine half is in [`verdict`].
+//!
+//! Every test is deterministic and synchronizes on values, never on time. The
+//! projection is cross-checked against an independent f64 rotation-matrix oracle
+//! (a different arithmetic path than the production quaternion sandwich).
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod verdict;
+
+use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+
+use pilotage_camera_calibration::{
+    SIM_FPV_CALIBRATION_HASH, SIM_FPV_CALIBRATION_ID, VerifiedCameraModel, sim_fpv_calibration,
+};
+
+use super::{
+    Bracket, CaptureContext, ConformalFix, ConformalPolicy, KinematicSample, ViewGeometry,
+    assess_conformal, down_in_camera, project_path_cue,
+};
+use crate::SvsAvailability;
+use crate::datum::{
+    BaroSettingId, DatumRealizationId, GeodeticPosition, GeoidModelId, HorizontalDatum,
+    LocalOriginId, TerrainRefId, VerticalDatum, VerticalPosition,
+};
+use crate::identity::{
+    AttitudeQuality, CoherentSnapshot, IntegrityLevel, PositionQuality, SourceIncarnation,
+    SourceStamp, StatedAttitude, StatedPosition,
+};
+use crate::view::{
+    CalibrationId, CalibrationRef, MinificationPolicy, NearFarPolicy, Projection, ProjectionView,
+};
+
+const DEG: f64 = core::f64::consts::PI / 180.0;
+
+// --- fixtures (shared with the `verdict` submodule via `use super::*`) ------
+
+fn epoch(nanos: u64) -> Epoch {
+    Epoch {
+        clock: ClockDomain::Simulation,
+        scale: TimeScale::Monotonic,
+        nanos,
+    }
+}
+
+fn stamp(nanos: u64, snap_id: u64) -> SourceStamp {
+    SourceStamp {
+        source_id: 7,
+        incarnation: SourceIncarnation([9; 16]),
+        generation: 1,
+        sequence: (nanos & 0xffff_ffff) as u32,
+        acquired_at: epoch(nanos),
+        integrity: IntegrityLevel::Trusted,
+        snapshot: CoherentSnapshot {
+            producer: SourceIncarnation([5; 16]),
+            generation: 1,
+            id: snap_id,
+        },
+    }
+}
+
+fn geopos() -> GeodeticPosition {
+    let vertical = VerticalPosition::new(
+        300.0,
+        VerticalDatum::Ellipsoid,
+        GeoidModelId::UNDECLARED,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .expect("ellipsoidal height needs no extra identity");
+    GeodeticPosition::new(
+        37.0,
+        -122.0,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        vertical,
+    )
+    .expect("a WGS-84 position is well-formed")
+}
+
+/// A sample whose attitude and position share one coherent snapshot stamp (zero
+/// skew), with small, conformal-grade accuracies.
+fn sample(att: Quat, vel: [f64; 3], rate: [f32; 3], nanos: u64, snap_id: u64) -> KinematicSample {
+    let s = stamp(nanos, snap_id);
+    KinematicSample {
+        attitude: StatedAttitude {
+            attitude: att,
+            stamp: s,
+            quality: AttitudeQuality { angular_mrad: 2 },
+        },
+        position: StatedPosition {
+            position: geopos(),
+            stamp: s,
+            quality: PositionQuality {
+                horizontal_mm: 100,
+                vertical_mm: 100,
+            },
+        },
+        velocity_ned_mps: vel,
+        body_rate_rps: rate,
+    }
+}
+
+/// A steady two-sample bracket 1 ms apart at the same pose/velocity/rate, ids
+/// declared and in order.
+fn steady(att: Quat, vel: [f64; 3], rate: [f32; 3]) -> Bracket {
+    Bracket {
+        older: sample(att, vel, rate, 1_000, 1),
+        newer: sample(att, vel, rate, 2_000, 2),
+    }
+}
+
+/// Aerospace ZYX (roll, pitch, yaw) body→NED quaternion, matching the presentation
+/// convention used across the workspace.
+fn euler_quat(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
+    let d = core::f32::consts::PI / 180.0;
+    let (r, p, y) = (roll_deg * d / 2.0, pitch_deg * d / 2.0, yaw_deg * d / 2.0);
+    let (cr, sr) = (libm::cosf(r), libm::sinf(r));
+    let (cp, sp) = (libm::cosf(p), libm::sinf(p));
+    let (cy, sy) = (libm::cosf(y), libm::sinf(y));
+    Quat {
+        w: cr * cp * cy + sr * sp * sy,
+        x: sr * cp * cy - cr * sp * sy,
+        y: cr * sp * cy + sr * cp * sy,
+        z: cr * cp * sy - sr * sp * cy,
+    }
+}
+
+/// A time inside the published sim FPV calibration's effective window.
+pub(super) const NOW_IN_WINDOW_NS: u64 = 1_600_000_000_000_000_000;
+
+/// The calibration reference the sim model — and therefore the projection view —
+/// is bound to (the published sim FPV identity and its content hash).
+pub(super) fn calibration() -> CalibrationRef {
+    CalibrationRef {
+        calibration_id: CalibrationId(SIM_FPV_CALIBRATION_ID),
+        content_hash: SIM_FPV_CALIBRATION_HASH,
+    }
+}
+
+/// A genuinely hash-verified camera model, minted the only way one can be — from
+/// the published sim calibration through its verify-and-mint path. The sim camera
+/// is forward-looking (body FRD → OpenCV optical).
+pub(super) fn verified_model() -> VerifiedCameraModel {
+    sim_fpv_calibration()
+        .verified_camera_model(SIM_FPV_CALIBRATION_HASH, NOW_IN_WINDOW_NS)
+        .expect("the published sim calibration verifies and mints")
+}
+
+/// The resolved geometry, obtained the only way it can be — by deriving it from a
+/// genuinely verified camera model.
+fn geom() -> ViewGeometry {
+    ViewGeometry::derive(&verified_model()).expect("the verified model derives geometry")
+}
+
+fn view() -> ProjectionView {
+    ProjectionView {
+        calibration: calibration(),
+        projection: Projection::Perspective,
+        near_far: NearFarPolicy {
+            near_m: 0.5,
+            far_m: 5000.0,
+        },
+        minification: MinificationPolicy::Trilinear,
+    }
+}
+
+fn capture(nanos: u64) -> CaptureContext {
+    CaptureContext {
+        capture_epoch: epoch(nanos),
+        clock_error_ns: 100_000,
+        pipeline_latency_ns: 2_000_000,
+    }
+}
+
+fn sim() -> ConformalPolicy {
+    ConformalPolicy::simulator()
+}
+
+/// A policy whose valid/limited budget comfortably covers the published sim
+/// calibration's static alignment bound (~0.0117 rad, which itself exceeds the
+/// tight simulator valid threshold). Used where a test isolates the "genuine
+/// verified calibration → Valid" or the availability-decides path from the
+/// error budget.
+pub(super) fn generous() -> ConformalPolicy {
+    ConformalPolicy::new(
+        crate::ConformalPolicyId(7),
+        1,
+        50_000_000,
+        10_000_000,
+        1.0,
+        0.050,
+        0.100,
+        50.0,
+    )
+    .expect("a monotonic policy is valid")
+}
+
+/// Assess with the nominal view/camera, an available scene, and no path cues.
+fn run(bracket: &Bracket, cap: CaptureContext, policy: &ConformalPolicy) -> ConformalFix {
+    assess_conformal(
+        bracket,
+        cap,
+        &view(),
+        &geom(),
+        SvsAvailability::Available,
+        policy,
+        &[],
+    )
+}
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    (a - b).abs() <= tol
+}
+
+#[test]
+fn forward_camera_mount_maps_body_axes_to_opencv_axes() {
+    let bc = geom().body_to_camera;
+    let near = |v: [f64; 3], e: [f64; 3]| (0..3).all(|i| approx(v[i], e[i], 1e-6));
+    assert!(
+        near(bc.rotate([1.0, 0.0, 0.0]), [0.0, 0.0, 1.0]),
+        "fwd -> optical axis"
+    );
+    assert!(
+        near(bc.rotate([0.0, 1.0, 0.0]), [1.0, 0.0, 0.0]),
+        "right -> image +x"
+    );
+    assert!(
+        near(bc.rotate([0.0, 0.0, 1.0]), [0.0, 1.0, 0.0]),
+        "down -> image +y"
+    );
+}
+
+// --- projection: horizon ----------------------------------------------------
+
+#[test]
+fn level_horizon_is_centered_and_horizontal() {
+    let cues = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("level flight is conformal");
+    // 0*x + 1*y + 0 = 0 -> y = 0, horizontal through the image center.
+    assert!(approx(cues.horizon.a, 0.0, 1e-6) && approx(cues.horizon.c, 0.0, 1e-6));
+    assert!(
+        cues.horizon.b.abs() > 0.5,
+        "a horizontal line has a nonzero y-coefficient"
+    );
+}
+
+#[test]
+fn nose_up_drops_the_horizon_below_center() {
+    let q = euler_quat(0.0, 10.0, 0.0);
+    let cues = run(
+        &steady(q, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("10 deg nose-up is conformal");
+    // Line a*x + b*y + c = 0 at x=0 gives y = -c/b; nose-up puts the horizon
+    // below center (+y is down), at tan(pitch).
+    let y_at_center = -cues.horizon.c / cues.horizon.b;
+    assert!(
+        approx(y_at_center, libm::tan(10.0 * DEG), 1e-4),
+        "horizon y {y_at_center} should be tan(10 deg)"
+    );
+}
+
+#[test]
+fn high_pitch_and_bank_stay_finite_and_rotate_the_horizon() {
+    let q = euler_quat(30.0, 80.0, 0.0);
+    let cues = run(
+        &steady(q, [40.0, 0.0, 10.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("high pitch/bank is still conformal at zero rate");
+    let h = cues.horizon;
+    assert!(h.a.is_finite() && h.b.is_finite() && h.c.is_finite());
+    assert!(
+        h.a.abs() > 1e-3,
+        "bank rotates the horizon (nonzero x-coefficient)"
+    );
+}
+
+#[test]
+fn straight_ahead_flight_path_marker_sits_on_boresight() {
+    let fpm = run(
+        &steady(Quat::IDENTITY, [60.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("a forward velocity has a drawable marker");
+    assert!(approx(fpm.x, 0.0, 1e-6) && approx(fpm.y, 0.0, 1e-6));
+    assert!(fpm.within_fov);
+}
+
+#[test]
+fn crosswind_offsets_the_flight_path_marker_sideways() {
+    // Heading north, level, but drifting east: the marker shifts right by the
+    // drift angle, off the nose.
+    let fpm = run(
+        &steady(Quat::IDENTITY, [50.0, 10.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(
+        approx(fpm.x, 10.0 / 50.0, 1e-6),
+        "x = east/north drift tangent"
+    );
+    assert!(approx(fpm.y, 0.0, 1e-6), "no vertical drift");
+    assert!(fpm.within_fov);
+}
+
+#[test]
+fn flight_path_marker_off_scale_past_the_field_boundary() {
+    let inside = run(
+        &steady(Quat::IDENTITY, [50.0, 40.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(inside.within_fov, "tan ~0.8 is inside the 40 deg half-FOV");
+
+    let outside = run(
+        &steady(Quat::IDENTITY, [50.0, 60.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(!outside.within_fov, "tan 1.2 is the off-scale indication");
+}
+
+#[test]
+fn runway_path_cue_projects_clips_and_flags_off_scale() {
+    let g = geom();
+    let nf = view().near_far; // near 0.5 m, far 5000 m
+    let att = Quat::IDENTITY; // level, forward-looking camera
+
+    // A runway point 300 m ahead and 50 m below the ownship projects below center
+    // (positive y is down) and on-scale.
+    let ahead = project_path_cue(att, [300.0, 0.0, 50.0], nf, &g).expect("in front, in range");
+    assert!(approx(ahead.x, 0.0, 1e-9) && approx(ahead.y, 50.0 / 300.0, 1e-9));
+    assert!(ahead.within_fov);
+
+    // A point in front but far to the right is off-scale (marked, not dropped).
+    let side = project_path_cue(att, [100.0, 200.0, 0.0], nf, &g).expect("in front");
+    assert!(!side.within_fov, "tan 2.0 is beyond the 40 deg half-FOV");
+
+    // Behind the camera: removed, never drawn behind the eye.
+    assert!(
+        project_path_cue(att, [-300.0, 0.0, 50.0], nf, &g).is_none(),
+        "a point behind the camera is removed"
+    );
+    // Beyond the far clip: removed by the projection view's near/far policy.
+    assert!(
+        project_path_cue(att, [6000.0, 0.0, 0.0], nf, &g).is_none(),
+        "a point past the far plane is clipped"
+    );
+    // Inside the near clip: also removed.
+    assert!(
+        project_path_cue(att, [0.2, 0.0, 0.0], nf, &g).is_none(),
+        "a point inside the near plane is clipped"
+    );
+}
+
+// --- independent f64 oracle -------------------------------------------------
+
+/// Rotation matrix from a quaternion — the standard closed form, an arithmetic
+/// path independent of the production `Quat::rotate` cross-product sandwich.
+fn rot(q: Quat) -> [[f64; 3]; 3] {
+    let (w, x, y, z) = (
+        f64::from(q.w),
+        f64::from(q.x),
+        f64::from(q.y),
+        f64::from(q.z),
+    );
+    [
+        [
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - w * z),
+            2.0 * (x * z + w * y),
+        ],
+        [
+            2.0 * (x * y + w * z),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - w * x),
+        ],
+        [
+            2.0 * (x * z - w * y),
+            2.0 * (y * z + w * x),
+            1.0 - 2.0 * (x * x + y * y),
+        ],
+    ]
+}
+
+fn matvec(m: [[f64; 3]; 3], v: [f64; 3]) -> [f64; 3] {
+    let row = |r: [f64; 3]| r[0] * v[0] + r[1] * v[1] + r[2] * v[2];
+    [row(m[0]), row(m[1]), row(m[2])]
+}
+
+fn transpose(m: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    [
+        [m[0][0], m[1][0], m[2][0]],
+        [m[0][1], m[1][1], m[2][1]],
+        [m[0][2], m[1][2], m[2][2]],
+    ]
+}
+
+#[test]
+fn horizon_matches_the_independent_f64_reference() {
+    let bc = geom().body_to_camera;
+    for &(r, p, yaw) in &[
+        (0.0, 0.0, 0.0),
+        (0.0, 10.0, 0.0),
+        (30.0, 80.0, 0.0),
+        (-45.0, -20.0, 33.0),
+        (170.0, 5.0, -95.0),
+    ] {
+        let att = euler_quat(r, p, yaw);
+        let got = down_in_camera(att, bc);
+        // Oracle: NED down into body via R(att)^T, then body into camera via R(bc).
+        let down_body = matvec(transpose(rot(att)), [0.0, 0.0, 1.0]);
+        let want = matvec(rot(bc), down_body);
+        for i in 0..3 {
+            assert!(
+                approx(got[i], want[i], 1e-6),
+                "comp {i}: got {} want {} at r{r} p{p} y{yaw}",
+                got[i],
+                want[i]
+            );
+        }
+    }
+}
+
+#[test]
+fn static_pose_interpolates_to_the_same_attitude() {
+    let b = steady(euler_quat(5.0, -8.0, 42.0), [50.0, 0.0, 0.0], [0.0; 3]);
+    let a = run(&b, capture(1_000), &sim()).cues.expect("valid").horizon;
+    let c = run(&b, capture(1_900), &sim()).cues.expect("valid").horizon;
+    // A static pose yields the same horizon regardless of capture time (nlerp of
+    // two equal quaternions is that quaternion, up to renormalization rounding).
+    assert!(approx(a.a, c.a, 1e-6) && approx(a.b, c.b, 1e-6) && approx(a.c, c.c, 1e-6));
+}
+
+#[test]
+fn constant_rate_interpolates_the_midpoint_attitude() {
+    let b = Bracket {
+        older: sample(
+            euler_quat(0.0, 0.0, 0.0),
+            [50.0, 0.0, 0.0],
+            [0.0, 0.0, 0.17],
+            1_000_000,
+            1,
+        ),
+        newer: sample(
+            euler_quat(0.0, 0.0, 20.0),
+            [50.0, 0.0, 0.0],
+            [0.0, 0.0, 0.17],
+            3_000_000,
+            2,
+        ),
+    };
+    let fix = run(&b, capture(2_000_000), &sim());
+    // At the midpoint the interpolated attitude is ~10 deg yaw. A north-pointing
+    // velocity then projects to a marker at x = -tan(yaw): recover the yaw from it.
+    let fpm = fix.cues.expect("conformal").flight_path.expect("drawable");
+    assert!(
+        approx(fpm.x, -libm::tan(10.0 * DEG), 2e-3),
+        "midpoint yaw ~10 deg puts a north-velocity marker at -tan(10 deg), got x={}",
+        fpm.x
+    );
+}

--- a/crates/pilotage-geo/src/conformal/tests/kinematics.rs
+++ b/crates/pilotage-geo/src/conformal/tests/kinematics.rs
@@ -1,0 +1,170 @@
+//! The kinematic-input validity gate: regressions for the invalid-input
+//! blockers. A non-unit attitude, a mis-framed velocity or body rate, a
+//! mis-provenanced kinematic input, an untrusted integrity, and a wildly
+//! inaccurate velocity must each fail closed rather than draw a conformal cue.
+//!
+//! Shares the parent module's fixtures via `use super::*`.
+
+use super::*;
+
+use pilotage_frames::FrameId;
+
+use crate::identity::IntegrityLevel;
+use crate::{ConformalReason, ConformalState};
+
+#[test]
+fn a_zero_quaternion_attitude_is_non_conformal_and_draws_nothing() {
+    // A zero (non-unit) quaternion cannot orient the projection. It must not yield
+    // a drawable verdict — it is refused before interpolation.
+    let zero = Quat {
+        w: 0.0,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    let b = Bracket {
+        older: sample(zero, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::AttitudeNotARotation)
+    );
+    assert!(fix.cues.is_none() && fix.error.is_none());
+}
+
+#[test]
+fn unknown_integrity_is_unavailable_never_drawable() {
+    // An `Unknown` integrity level fails closed through the derived availability:
+    // it must never produce a drawable conformal cue.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.attitude.stamp.integrity = IntegrityLevel::Unknown;
+    older.position.stamp.integrity = IntegrityLevel::Unknown;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert!(
+        matches!(
+            fix.state,
+            ConformalState::Unavailable(ConformalReason::Availability(_))
+        ),
+        "unknown integrity must be unavailable, got {:?}",
+        fix.state
+    );
+    assert!(fix.cues.is_none(), "an unknown-integrity fix draws no cues");
+}
+
+#[test]
+fn velocity_in_the_wrong_frame_is_non_conformal() {
+    // The velocity must be NED; a body-frame velocity is refused rather than
+    // projected as if it were NED.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.velocity.frame = FrameId::Body;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::KinematicFrame)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn body_rate_in_the_wrong_frame_is_non_conformal() {
+    // The body rate must be body-frame; an NED-tagged rate is refused.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.body_rate.frame = FrameId::Ned;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::KinematicFrame)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn kinematics_from_a_different_snapshot_are_non_conformal() {
+    // The velocity's provenance must be the pose's coherent snapshot; a velocity
+    // stamped with a different snapshot is not one trustworthy fix.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.velocity.meta.snapshot.id = 999;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::KinematicProvenance)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn velocity_error_is_a_named_budget_term_that_scales_with_the_accuracy() {
+    // A nominal fix carries a finite, positive, named velocity-error term.
+    let nominal = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    );
+    let e0 = nominal.error.expect("interpolation ran");
+    assert!(
+        e0.velocity_rad.is_finite() && e0.velocity_rad > 0.0,
+        "velocity error is a named, present term"
+    );
+
+    // A tenfold-worse velocity 1-sigma over the same timing yields ~tenfold the
+    // velocity term and a larger total — the term genuinely consumes the accuracy.
+    let mut worse = steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]);
+    worse.older.velocity_quality.sigma_mmps *= 10;
+    worse.newer.velocity_quality.sigma_mmps *= 10;
+    let e1 = run(&worse, capture(1_500), &sim())
+        .error
+        .expect("interpolation ran");
+    assert!(
+        e1.velocity_rad > 5.0 * e0.velocity_rad && e1.total_rad > e0.total_rad,
+        "the velocity term scales with the velocity accuracy and moves the total"
+    );
+}
+
+#[test]
+fn a_wildly_inaccurate_velocity_alone_removes_the_cues() {
+    // Low speed keeps the timing sensitivity small, so a 44 ms extrapolation is
+    // within both the limit and the budget when the velocity is accurate...
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [5.0, 0.0, 0.0], [0.0; 3], 1_000_000, 1),
+        newer: sample(Quat::IDENTITY, [5.0, 0.0, 0.0], [0.0; 3], 2_000_000, 2),
+    };
+    assert!(
+        run(&b, capture(46_000_000), &sim()).state.draws_cues(),
+        "an accurate slow state is drawable at 44 ms extrapolation"
+    );
+
+    // ...but a wildly inaccurate velocity (40 m/s 1-sigma), propagated over that
+    // extrapolation, pushes the parallax bound past the budget and removes every
+    // cue — the velocity accuracy alone decides, nothing else changed.
+    let mut broken = b;
+    broken.older.velocity_quality.sigma_mmps = 40_000;
+    broken.newer.velocity_quality.sigma_mmps = 40_000;
+    let fix = run(&broken, capture(46_000_000), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ErrorBudgetExceeded)
+    );
+    assert!(fix.cues.is_none());
+    assert!(
+        fix.error.expect("ran").velocity_rad > sim().valid_error_rad(),
+        "the velocity term dominates the budget"
+    );
+}

--- a/crates/pilotage-geo/src/conformal/tests/projection.rs
+++ b/crates/pilotage-geo/src/conformal/tests/projection.rs
@@ -1,0 +1,284 @@
+//! Projection and interpolation geometry: the horizon line, flight-path marker,
+//! and runway/path cues, cross-checked against an independent f64 rotation-matrix
+//! oracle (a different arithmetic path than the production quaternion sandwich).
+//!
+//! Shares the parent module's fixtures via `use super::*`.
+
+use super::super::{down_in_camera, project_path_cue};
+use super::*;
+
+#[test]
+fn forward_camera_mount_maps_body_axes_to_opencv_axes() {
+    let bc = geom().body_to_camera;
+    let near = |v: [f64; 3], e: [f64; 3]| (0..3).all(|i| approx(v[i], e[i], 1e-6));
+    assert!(
+        near(bc.rotate([1.0, 0.0, 0.0]), [0.0, 0.0, 1.0]),
+        "fwd -> optical axis"
+    );
+    assert!(
+        near(bc.rotate([0.0, 1.0, 0.0]), [1.0, 0.0, 0.0]),
+        "right -> image +x"
+    );
+    assert!(
+        near(bc.rotate([0.0, 0.0, 1.0]), [0.0, 1.0, 0.0]),
+        "down -> image +y"
+    );
+}
+
+// --- projection: horizon ----------------------------------------------------
+
+#[test]
+fn level_horizon_is_centered_and_horizontal() {
+    let cues = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("level flight is conformal");
+    // 0*x + 1*y + 0 = 0 -> y = 0, horizontal through the image center.
+    assert!(approx(cues.horizon.a, 0.0, 1e-6) && approx(cues.horizon.c, 0.0, 1e-6));
+    assert!(
+        cues.horizon.b.abs() > 0.5,
+        "a horizontal line has a nonzero y-coefficient"
+    );
+}
+
+#[test]
+fn nose_up_drops_the_horizon_below_center() {
+    let q = euler_quat(0.0, 10.0, 0.0);
+    let cues = run(
+        &steady(q, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("10 deg nose-up is conformal");
+    // Line a*x + b*y + c = 0 at x=0 gives y = -c/b; nose-up puts the horizon
+    // below center (+y is down), at tan(pitch).
+    let y_at_center = -cues.horizon.c / cues.horizon.b;
+    assert!(
+        approx(y_at_center, libm::tan(10.0 * DEG), 1e-4),
+        "horizon y {y_at_center} should be tan(10 deg)"
+    );
+}
+
+#[test]
+fn high_pitch_and_bank_stay_finite_and_rotate_the_horizon() {
+    let q = euler_quat(30.0, 80.0, 0.0);
+    let cues = run(
+        &steady(q, [40.0, 0.0, 10.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("high pitch/bank is still conformal at zero rate");
+    let h = cues.horizon;
+    assert!(h.a.is_finite() && h.b.is_finite() && h.c.is_finite());
+    assert!(
+        h.a.abs() > 1e-3,
+        "bank rotates the horizon (nonzero x-coefficient)"
+    );
+}
+
+#[test]
+fn straight_ahead_flight_path_marker_sits_on_boresight() {
+    let fpm = run(
+        &steady(Quat::IDENTITY, [60.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("a forward velocity has a drawable marker");
+    assert!(approx(fpm.x, 0.0, 1e-6) && approx(fpm.y, 0.0, 1e-6));
+    assert!(fpm.within_fov);
+}
+
+#[test]
+fn crosswind_offsets_the_flight_path_marker_sideways() {
+    // Heading north, level, but drifting east: the marker shifts right by the
+    // drift angle, off the nose.
+    let fpm = run(
+        &steady(Quat::IDENTITY, [50.0, 10.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(
+        approx(fpm.x, 10.0 / 50.0, 1e-6),
+        "x = east/north drift tangent"
+    );
+    assert!(approx(fpm.y, 0.0, 1e-6), "no vertical drift");
+    assert!(fpm.within_fov);
+}
+
+#[test]
+fn flight_path_marker_off_scale_past_the_field_boundary() {
+    let inside = run(
+        &steady(Quat::IDENTITY, [50.0, 40.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(inside.within_fov, "tan ~0.8 is inside the 40 deg half-FOV");
+
+    let outside = run(
+        &steady(Quat::IDENTITY, [50.0, 60.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+    )
+    .cues
+    .expect("conformal")
+    .flight_path
+    .expect("drawable");
+    assert!(!outside.within_fov, "tan 1.2 is the off-scale indication");
+}
+
+#[test]
+fn runway_path_cue_projects_clips_and_flags_off_scale() {
+    let g = geom();
+    let nf = view().near_far; // near 0.5 m, far 5000 m
+    let att = Quat::IDENTITY; // level, forward-looking camera
+
+    // A runway point 300 m ahead and 50 m below the ownship projects below center
+    // (positive y is down) and on-scale.
+    let ahead = project_path_cue(att, [300.0, 0.0, 50.0], nf, &g).expect("in front, in range");
+    assert!(approx(ahead.x, 0.0, 1e-9) && approx(ahead.y, 50.0 / 300.0, 1e-9));
+    assert!(ahead.within_fov);
+
+    // A point in front but far to the right is off-scale (marked, not dropped).
+    let side = project_path_cue(att, [100.0, 200.0, 0.0], nf, &g).expect("in front");
+    assert!(!side.within_fov, "tan 2.0 is beyond the 40 deg half-FOV");
+
+    // Behind the camera: removed, never drawn behind the eye.
+    assert!(
+        project_path_cue(att, [-300.0, 0.0, 50.0], nf, &g).is_none(),
+        "a point behind the camera is removed"
+    );
+    // Beyond the far clip: removed by the projection view's near/far policy.
+    assert!(
+        project_path_cue(att, [6000.0, 0.0, 0.0], nf, &g).is_none(),
+        "a point past the far plane is clipped"
+    );
+    // Inside the near clip: also removed.
+    assert!(
+        project_path_cue(att, [0.2, 0.0, 0.0], nf, &g).is_none(),
+        "a point inside the near plane is clipped"
+    );
+}
+
+// --- independent f64 oracle -------------------------------------------------
+
+/// Rotation matrix from a quaternion — the standard closed form, an arithmetic
+/// path independent of the production `Quat::rotate` cross-product sandwich.
+fn rot(q: Quat) -> [[f64; 3]; 3] {
+    let (w, x, y, z) = (
+        f64::from(q.w),
+        f64::from(q.x),
+        f64::from(q.y),
+        f64::from(q.z),
+    );
+    [
+        [
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - w * z),
+            2.0 * (x * z + w * y),
+        ],
+        [
+            2.0 * (x * y + w * z),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - w * x),
+        ],
+        [
+            2.0 * (x * z - w * y),
+            2.0 * (y * z + w * x),
+            1.0 - 2.0 * (x * x + y * y),
+        ],
+    ]
+}
+
+fn matvec(m: [[f64; 3]; 3], v: [f64; 3]) -> [f64; 3] {
+    let row = |r: [f64; 3]| r[0] * v[0] + r[1] * v[1] + r[2] * v[2];
+    [row(m[0]), row(m[1]), row(m[2])]
+}
+
+fn transpose(m: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    [
+        [m[0][0], m[1][0], m[2][0]],
+        [m[0][1], m[1][1], m[2][1]],
+        [m[0][2], m[1][2], m[2][2]],
+    ]
+}
+
+#[test]
+fn horizon_matches_the_independent_f64_reference() {
+    let bc = geom().body_to_camera;
+    for &(r, p, yaw) in &[
+        (0.0, 0.0, 0.0),
+        (0.0, 10.0, 0.0),
+        (30.0, 80.0, 0.0),
+        (-45.0, -20.0, 33.0),
+        (170.0, 5.0, -95.0),
+    ] {
+        let att = euler_quat(r, p, yaw);
+        let got = down_in_camera(att, bc);
+        // Oracle: NED down into body via R(att)^T, then body into camera via R(bc).
+        let down_body = matvec(transpose(rot(att)), [0.0, 0.0, 1.0]);
+        let want = matvec(rot(bc), down_body);
+        for i in 0..3 {
+            assert!(
+                approx(got[i], want[i], 1e-6),
+                "comp {i}: got {} want {} at r{r} p{p} y{yaw}",
+                got[i],
+                want[i]
+            );
+        }
+    }
+}
+
+#[test]
+fn static_pose_interpolates_to_the_same_attitude() {
+    let b = steady(euler_quat(5.0, -8.0, 42.0), [50.0, 0.0, 0.0], [0.0; 3]);
+    let a = run(&b, capture(1_000), &sim()).cues.expect("valid").horizon;
+    let c = run(&b, capture(1_900), &sim()).cues.expect("valid").horizon;
+    // A static pose yields the same horizon regardless of capture time (nlerp of
+    // two equal quaternions is that quaternion, up to renormalization rounding).
+    assert!(approx(a.a, c.a, 1e-6) && approx(a.b, c.b, 1e-6) && approx(a.c, c.c, 1e-6));
+}
+
+#[test]
+fn constant_rate_interpolates_the_midpoint_attitude() {
+    let b = Bracket {
+        older: sample(
+            euler_quat(0.0, 0.0, 0.0),
+            [50.0, 0.0, 0.0],
+            [0.0, 0.0, 0.17],
+            1_000_000,
+            1,
+        ),
+        newer: sample(
+            euler_quat(0.0, 0.0, 20.0),
+            [50.0, 0.0, 0.0],
+            [0.0, 0.0, 0.17],
+            3_000_000,
+            2,
+        ),
+    };
+    let fix = run(&b, capture(2_000_000), &sim());
+    // At the midpoint the interpolated attitude is ~10 deg yaw. A north-pointing
+    // velocity then projects to a marker at x = -tan(yaw): recover the yaw from it.
+    let fpm = fix.cues.expect("conformal").flight_path.expect("drawable");
+    assert!(
+        approx(fpm.x, -libm::tan(10.0 * DEG), 2e-3),
+        "midpoint yaw ~10 deg puts a north-velocity marker at -tan(10 deg), got x={}",
+        fpm.x
+    );
+}

--- a/crates/pilotage-geo/src/conformal/tests/verdict.rs
+++ b/crates/pilotage-geo/src/conformal/tests/verdict.rs
@@ -6,13 +6,14 @@
 
 use super::*;
 
+use crate::identity::IntegrityLevel;
 use crate::view::{CalibrationId, CalibrationRef, Projection, ProjectionView};
 use crate::{AvailabilityReason, ConformalPolicyId, ConformalReason, ConformalState, ViewGeometry};
 
-/// Assess with an overridden view and availability (for the structural gates). A
-/// generous policy keeps the sim calibration's static bound within the valid
-/// budget, so the availability verdict — not the error budget — decides.
-fn run_full(bracket: &Bracket, v: &ProjectionView, avail: SvsAvailability) -> ConformalFix {
+/// Assess with an overridden view and availability inputs (for the structural
+/// gates). A generous policy keeps the sim calibration's static bound within the
+/// valid budget, so the derived availability — not the error budget — decides.
+fn run_full(bracket: &Bracket, v: &ProjectionView, avail: AvailabilityInputs) -> ConformalFix {
     assess_conformal(bracket, capture(1_500), v, &geom(), avail, &generous(), &[])
 }
 
@@ -24,7 +25,7 @@ fn run_geom(bracket: &Bracket, g: &ViewGeometry) -> ConformalFix {
         capture(1_500),
         &view(),
         g,
-        SvsAvailability::Available,
+        availability(),
         &sim(),
         &[],
     )
@@ -37,15 +38,7 @@ fn run_path(
     policy: &ConformalPolicy,
     path: &[[f64; 3]],
 ) -> ConformalFix {
-    assess_conformal(
-        bracket,
-        cap,
-        &view(),
-        &geom(),
-        SvsAvailability::Available,
-        policy,
-        path,
-    )
+    assess_conformal(bracket, cap, &view(), &geom(), availability(), policy, path)
 }
 
 #[test]
@@ -223,7 +216,7 @@ fn unreferenced_calibration_is_unavailable() {
     let fix = run_full(
         &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
         &v,
-        SvsAvailability::Available,
+        availability(),
     );
     assert_eq!(
         fix.state,
@@ -242,7 +235,7 @@ fn orthographic_view_is_not_a_conformal_view() {
     let fix = run_full(
         &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
         &v,
-        SvsAvailability::Available,
+        availability(),
     );
     assert_eq!(
         fix.state,
@@ -251,13 +244,17 @@ fn orthographic_view_is_not_a_conformal_view() {
 }
 
 #[test]
-fn unavailable_scene_delegates_the_availability_reason() {
-    let avail = SvsAvailability::Unavailable(AvailabilityReason::Position);
-    let fix = run_full(
-        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
-        &view(),
-        avail,
-    );
+fn unavailable_scene_derived_from_a_sample_delegates_the_availability_reason() {
+    // The availability is DERIVED from the samples, not asserted: an untrusted
+    // position integrity in an endpoint makes the derived scene Unavailable, and
+    // the conformal verdict delegates that reason.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.position.stamp.integrity = IntegrityLevel::Untrusted;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run_full(&b, &view(), availability());
     assert_eq!(
         fix.state,
         ConformalState::Unavailable(ConformalReason::Availability(AvailabilityReason::Position))
@@ -267,7 +264,15 @@ fn unavailable_scene_delegates_the_availability_reason() {
 
 #[test]
 fn degraded_scene_marks_the_cues_limited() {
-    let avail = SvsAvailability::Degraded(AvailabilityReason::Database);
+    // A producer-stated external input degrades: the derived scene is Degraded and
+    // the cues are drawn but marked reduced.
+    let avail = AvailabilityInputs {
+        external: ExternalHealth {
+            database: InputHealth::Degraded,
+            ..healthy_external()
+        },
+        profile: AvailabilityProfile::simulator(),
+    };
     let fix = run_full(
         &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
         &view(),
@@ -284,17 +289,21 @@ fn degraded_scene_marks_the_cues_limited() {
 }
 
 #[test]
-fn fix_identity_ties_video_capture_time_to_the_overlay_snapshot() {
+fn fix_identity_retains_both_bracket_endpoints_and_the_capture_time() {
+    let older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 11);
     let newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 77);
-    let b = Bracket {
-        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
-        newer,
-    };
+    let b = Bracket { older, newer };
     let cap = capture(1_800);
     let fix = run(&b, cap, &sim());
-    // Overlay identity = the newest coherent snapshot's; video identity = the
-    // capture epoch. They are one FixIdentity, reusing the existing types.
-    assert_eq!(fix.identity.snapshot, newer.attitude.stamp.snapshot);
+    // The interpolation reads BOTH endpoints, so both snapshot identities are
+    // retained — an interpolated fix belongs to no single snapshot. Video identity
+    // is the capture epoch; overlay identity is the pair of coherent snapshots.
+    assert_eq!(fix.identity.older_snapshot, older.attitude.stamp.snapshot);
+    assert_eq!(fix.identity.newer_snapshot, newer.attitude.stamp.snapshot);
+    assert_ne!(
+        fix.identity.older_snapshot, fix.identity.newer_snapshot,
+        "the two endpoints are distinct snapshots, both kept"
+    );
     assert_eq!(
         fix.identity.source_incarnation,
         newer.attitude.stamp.incarnation
@@ -403,7 +412,7 @@ fn geometry_from_a_mismatched_calibration_is_not_valid() {
         calibration_id: CalibrationId(0x9999_0000),
         content_hash: calibration().content_hash,
     };
-    let fix = run_full(&bracket, &wrong_id, SvsAvailability::Available);
+    let fix = run_full(&bracket, &wrong_id, availability());
     assert_ne!(fix.state, ConformalState::Valid);
     assert_eq!(
         fix.state,
@@ -416,7 +425,7 @@ fn geometry_from_a_mismatched_calibration_is_not_valid() {
     let mut wrong_hash = view();
     wrong_hash.calibration.content_hash = [9; 32];
     assert_eq!(
-        run_full(&bracket, &wrong_hash, SvsAvailability::Available).state,
+        run_full(&bracket, &wrong_hash, availability()).state,
         ConformalState::Unavailable(ConformalReason::CalibrationMismatch)
     );
 }

--- a/crates/pilotage-geo/src/conformal/tests/verdict.rs
+++ b/crates/pilotage-geo/src/conformal/tests/verdict.rs
@@ -1,0 +1,435 @@
+//! Ground-truth tests for the conformal verdict: the four-valued state machine,
+//! the structural view/availability/identity gates, the dynamic error budget,
+//! policy-sourced limits, and the traceable video/overlay identity.
+//!
+//! Shares the parent module's fixtures via `use super::*`.
+
+use super::*;
+
+use crate::view::{CalibrationId, CalibrationRef, Projection, ProjectionView};
+use crate::{AvailabilityReason, ConformalPolicyId, ConformalReason, ConformalState, ViewGeometry};
+
+/// Assess with an overridden view and availability (for the structural gates). A
+/// generous policy keeps the sim calibration's static bound within the valid
+/// budget, so the availability verdict — not the error budget — decides.
+fn run_full(bracket: &Bracket, v: &ProjectionView, avail: SvsAvailability) -> ConformalFix {
+    assess_conformal(bracket, capture(1_500), v, &geom(), avail, &generous(), &[])
+}
+
+/// Assess with an overridden resolved geometry (for the calibration-binding and
+/// geometry-validation gates).
+fn run_geom(bracket: &Bracket, g: &ViewGeometry) -> ConformalFix {
+    assess_conformal(
+        bracket,
+        capture(1_500),
+        &view(),
+        g,
+        SvsAvailability::Available,
+        &sim(),
+        &[],
+    )
+}
+
+/// Assess the nominal view/camera/scene with a supplied set of runway/path cues.
+fn run_path(
+    bracket: &Bracket,
+    cap: CaptureContext,
+    policy: &ConformalPolicy,
+    path: &[[f64; 3]],
+) -> ConformalFix {
+    assess_conformal(
+        bracket,
+        cap,
+        &view(),
+        &geom(),
+        SvsAvailability::Available,
+        policy,
+        path,
+    )
+}
+
+#[test]
+fn nominal_low_dynamics_is_valid_with_a_bounded_budget() {
+    // A genuinely verified sim calibration + low dynamics reaches Valid under a
+    // policy whose valid budget covers the sim calibration's static bound.
+    let policy = generous();
+    let fix = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &policy,
+    );
+    assert_eq!(fix.state, ConformalState::Valid);
+    let err = fix.error.expect("interpolation ran");
+    assert!(err.total_rad.is_finite() && err.total_rad < policy.valid_error_rad());
+    // Every contributor is present and finite (named, sourced terms); the
+    // calibration term is the verified artifact's published bound.
+    assert!(err.calibration_rad > 0.0 && err.latency_rad > 0.0 && err.clock_rad > 0.0);
+}
+
+#[test]
+fn clock_domain_mismatch_is_non_conformal_and_removes_cues() {
+    let mut cap = capture(1_500);
+    cap.capture_epoch = Epoch {
+        clock: ClockDomain::VehicleBoot,
+        scale: TimeScale::Monotonic,
+        nanos: 1_500,
+    };
+    let fix = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        cap,
+        &sim(),
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ClockIncoherent)
+    );
+    assert!(
+        fix.cues.is_none(),
+        "a mismatched clock leaves no stale alignment"
+    );
+}
+
+#[test]
+fn reordered_bracket_is_a_stream_discontinuity() {
+    // newer stamped before older: the timeline is not monotonic.
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 3_000, 2),
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+    };
+    let fix = run(&b, capture(2_000), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::StreamDiscontinuity)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn dropped_frames_extrapolate_past_the_policy_limit() {
+    // Low dynamics so the budget stays small: the extrapolation *limit* is what
+    // trips, proving it comes from the policy, not the error budget.
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [1.0, 0.0, 0.0], [0.0; 3], 1_000_000, 1),
+        newer: sample(Quat::IDENTITY, [1.0, 0.0, 0.0], [0.0; 3], 2_000_000, 2),
+    };
+    // Capture 60 ms past the newest sample; simulator limit is 50 ms.
+    let past = run(&b, capture(62_000_000), &sim());
+    assert_eq!(
+        past.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveExtrapolation)
+    );
+    assert!(past.cues.is_none());
+    // 40 ms past is within both the limit and the budget: drawable.
+    let within = run(&b, capture(42_000_000), &sim());
+    assert!(
+        within.state.draws_cues(),
+        "40 ms extrapolation is inside 50 ms"
+    );
+}
+
+#[test]
+fn extrapolation_limit_is_sourced_from_the_policy() {
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [1.0, 0.0, 0.0], [0.0; 3], 1_000_000, 1),
+        newer: sample(Quat::IDENTITY, [1.0, 0.0, 0.0], [0.0; 3], 2_000_000, 2),
+    };
+    // A tighter policy (30 ms) flips a 40 ms extrapolation from drawable to
+    // non-conformal — the same inputs, only the policy differs.
+    let tight = ConformalPolicy::new(
+        ConformalPolicyId(9),
+        1,
+        30_000_000,
+        10_000_000,
+        1.0,
+        0.010,
+        0.030,
+        50.0,
+    )
+    .expect("valid policy");
+    let fix = run(&b, capture(42_000_000), &tight);
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveExtrapolation)
+    );
+}
+
+#[test]
+fn excessive_angular_rate_suppresses_conformal_cues() {
+    let b = steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [2.0, 0.0, 0.0]);
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveRate)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn exceeded_error_budget_removes_the_cues() {
+    // A large clock-mapping error at speed blows the angular budget.
+    let mut cap = capture(1_500);
+    cap.clock_error_ns = 100_000_000; // 100 ms
+    let fix = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        cap,
+        &sim(),
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ErrorBudgetExceeded)
+    );
+    assert!(
+        fix.cues.is_none(),
+        "exceeded budget must not leave stale alignment"
+    );
+    assert!(fix.error.expect("ran").total_rad > sim().limited_error_rad());
+}
+
+#[test]
+fn snapshot_incoherent_pose_is_refused() {
+    let mut s = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    // Break coherence: give the position a different snapshot id than attitude.
+    s.position.stamp.snapshot.id = 999;
+    let b = Bracket {
+        older: s,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::SnapshotIncoherent)
+    );
+}
+
+#[test]
+fn excessive_skew_between_attitude_and_position_is_refused() {
+    let mut s = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000_000, 1);
+    // Same snapshot (still coherent) but sampled 20 ms apart — over the 10 ms
+    // policy skew limit.
+    s.attitude.stamp.acquired_at = epoch(1_000_000);
+    s.position.stamp.acquired_at = epoch(21_000_000);
+    let newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 30_000_000, 2);
+    let fix = run(&Bracket { older: s, newer }, capture(20_000_000), &sim());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveSkew)
+    );
+}
+
+#[test]
+fn unreferenced_calibration_is_unavailable() {
+    let mut v = view();
+    v.calibration.calibration_id = CalibrationId::NONE;
+    let fix = run_full(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        &v,
+        SvsAvailability::Available,
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::ViewInvalid)
+    );
+    assert!(fix.cues.is_none() && fix.error.is_none());
+}
+
+#[test]
+fn orthographic_view_is_not_a_conformal_view() {
+    let mut v = view();
+    v.projection = Projection::Orthographic {
+        extent_x_m: 100.0,
+        extent_y_m: 75.0,
+    };
+    let fix = run_full(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        &v,
+        SvsAvailability::Available,
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::ViewInvalid)
+    );
+}
+
+#[test]
+fn unavailable_scene_delegates_the_availability_reason() {
+    let avail = SvsAvailability::Unavailable(AvailabilityReason::Position);
+    let fix = run_full(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        &view(),
+        avail,
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::Availability(AvailabilityReason::Position))
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn degraded_scene_marks_the_cues_limited() {
+    let avail = SvsAvailability::Degraded(AvailabilityReason::Database);
+    let fix = run_full(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        &view(),
+        avail,
+    );
+    assert_eq!(
+        fix.state,
+        ConformalState::Limited(ConformalReason::Availability(AvailabilityReason::Database))
+    );
+    assert!(
+        fix.cues.expect("limited still draws").limited,
+        "cues marked reduced"
+    );
+}
+
+#[test]
+fn fix_identity_ties_video_capture_time_to_the_overlay_snapshot() {
+    let newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 77);
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer,
+    };
+    let cap = capture(1_800);
+    let fix = run(&b, cap, &sim());
+    // Overlay identity = the newest coherent snapshot's; video identity = the
+    // capture epoch. They are one FixIdentity, reusing the existing types.
+    assert_eq!(fix.identity.snapshot, newer.attitude.stamp.snapshot);
+    assert_eq!(
+        fix.identity.source_incarnation,
+        newer.attitude.stamp.incarnation
+    );
+    assert_eq!(fix.identity.capture_epoch, cap.capture_epoch);
+}
+
+#[test]
+fn policy_rejects_non_monotonic_error_bounds() {
+    // valid > limited: non-monotonic.
+    let bad = ConformalPolicy::new(
+        ConformalPolicyId(2),
+        1,
+        50_000_000,
+        10_000_000,
+        1.0,
+        0.030,
+        0.010,
+        50.0,
+    );
+    assert!(matches!(
+        bad,
+        Err(super::super::ConformalError::InvalidPolicy {
+            field: "error_bound"
+        })
+    ));
+}
+
+#[test]
+fn policy_rejects_zero_and_non_finite_limits() {
+    let zero = ConformalPolicy::new(
+        ConformalPolicyId(3),
+        1,
+        0,
+        10_000_000,
+        1.0,
+        0.010,
+        0.030,
+        50.0,
+    );
+    assert!(matches!(
+        zero,
+        Err(super::super::ConformalError::InvalidPolicy {
+            field: "max_extrapolation_ns"
+        })
+    ));
+    let nan_range = ConformalPolicy::new(
+        ConformalPolicyId(4),
+        1,
+        50_000_000,
+        10_000_000,
+        1.0,
+        0.010,
+        0.030,
+        f64::NAN,
+    );
+    assert!(matches!(
+        nan_range,
+        Err(super::super::ConformalError::InvalidPolicy {
+            field: "reference_range_m"
+        })
+    ));
+}
+
+#[test]
+fn path_cues_ride_the_verdict_and_are_removed_when_budget_exceeded() {
+    let path = [[300.0, 0.0, 50.0], [400.0, 20.0, 60.0]];
+    // Drawable: the runway/path cues are projected and counted alongside the
+    // horizon and flight-path marker.
+    let ok = run_path(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &sim(),
+        &path,
+    );
+    let cues = ok.cues.expect("valid draws cues");
+    assert_eq!(cues.path_count, 2);
+    assert!(cues.path[0].is_some(), "the first runway point projects");
+    // Exceeded budget removes every cue, including the runway/path cues.
+    let mut cap = capture(1_500);
+    cap.clock_error_ns = 100_000_000;
+    let gone = run_path(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        cap,
+        &sim(),
+        &path,
+    );
+    assert_eq!(
+        gone.state,
+        ConformalState::NonConformal(ConformalReason::ErrorBudgetExceeded)
+    );
+    assert!(
+        gone.cues.is_none(),
+        "exceeded budget removes runway/path cues too"
+    );
+}
+
+#[test]
+fn geometry_from_a_mismatched_calibration_is_not_valid() {
+    let bracket = steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]);
+    // The geometry is derived from the genuine verified model, but the projection
+    // view references a DIFFERENT calibration id — the projection would run through
+    // the wrong camera model, so it is refused fail-closed.
+    let mut wrong_id = view();
+    wrong_id.calibration = CalibrationRef {
+        calibration_id: CalibrationId(0x9999_0000),
+        content_hash: calibration().content_hash,
+    };
+    let fix = run_full(&bracket, &wrong_id, SvsAvailability::Available);
+    assert_ne!(fix.state, ConformalState::Valid);
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::CalibrationMismatch)
+    );
+    assert!(fix.cues.is_none());
+
+    // Same id but a different content hash is also a mismatch: the artifact behind
+    // the id changed.
+    let mut wrong_hash = view();
+    wrong_hash.calibration.content_hash = [9; 32];
+    assert_eq!(
+        run_full(&bracket, &wrong_hash, SvsAvailability::Available).state,
+        ConformalState::Unavailable(ConformalReason::CalibrationMismatch)
+    );
+}
+
+#[test]
+fn assess_conformal_rejects_an_unvalidated_geometry() {
+    // Defense in depth: even if a malformed geometry is fabricated in-crate
+    // (external callers cannot — the fields are private and derive validates),
+    // assess_conformal re-validates and refuses it.
+    let mut g = geom();
+    g.half_fov_x_tan = f64::NAN;
+    assert_eq!(
+        run_geom(&steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]), &g).state,
+        ConformalState::Unavailable(ConformalReason::ViewInvalid)
+    );
+}

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -42,6 +42,7 @@ extern crate std;
 
 mod abi;
 mod availability;
+mod conformal;
 mod datum;
 mod error;
 mod identity;
@@ -54,6 +55,12 @@ pub use abi::{
 pub use availability::{
     AvailabilityProfile, AvailabilityProfileId, AvailabilityReason, ExternalHealth, InputHealth,
     SIMULATOR_PROFILE_ID, SvsAvailability, SvsInputs, derive_inputs, health_from_integrity,
+};
+pub use conformal::{
+    AlignmentErrorBound, Bracket, CaptureContext, ConformalCues, ConformalError, ConformalFix,
+    ConformalPolicy, ConformalPolicyId, ConformalReason, ConformalState, FixIdentity, HorizonLine,
+    KinematicSample, MAX_PATH_CUES, SIMULATOR_CONFORMAL_POLICY_ID, ScreenMark, ViewGeometry,
+    assess_conformal, down_in_camera, project_flight_path, project_horizon, project_path_cue,
 };
 pub use datum::{
     BaroSettingId, DatumRealizationId, GeoTile, GeodeticPosition, GeoidModelId, HorizontalDatum,


### PR DESCRIPTION
Implements #38 (HUD-03). New `conformal` module in `pilotage-geo` that **consumes existing contracts and creates no parallel policy or identity types** (verified):

- Camera/projection: `ProjectionView`/`Projection`/`CalibrationRef`/`NearFarPolicy`. Capture-time state + identity: `CoherentSnapshot`/`SourceStamp`/`SourceIncarnation`/`StatedAttitude`. Availability: `SvsAvailability`/`AvailabilityReason` delegated into the conformal reason. `FixIdentity` composes the existing capture-Epoch + snapshot identity (not a new identity type).
- Attitude interpolated at capture time via **normalized quaternion interpolation** (q/−q invariant).
- **Dynamic alignment-error bound** = worst-case sum of named, sourced terms (calibration residual, attitude 1σ, position→parallax, clock, latency, extrapolation), each scaled by angular-rate/velocity sensitivity — **no hard-coded latency offset**; non-finite → fail closed.
- **Four-state verdict** Valid / Limited / NonConformal / Unavailable (each with reason); cues emitted only for Valid/Limited, removed immediately when the budget is exceeded (never stale alignment).
- Projection **independently checked against an f64 reference** (`horizon_matches_the_independent_f64_reference`). ABI v2 unchanged; pilotage-geo stays no_std.

Ground-truth tests cover static pose, constant angular rate, crosswind, high pitch/bank, clock skew, drop/reorder, FOV boundaries, budget-exceeded cue removal, policy-sourced limits, and shared frame/snapshot identity. Independently verified: no parallel types, f64-reference test present, CI green on the rebased base. SIM / NOT FOR FLIGHT. Draft for review.