### PR TITLE
HUD-03: fail closed on kinematic integrity and epoch skew (#38)

### DIFF
--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -220,7 +220,7 @@ pub const fn health_from_integrity(level: IntegrityLevel) -> InputHealth {
 /// The worse of two healths (`Ok` < `Degraded` < `Failed`), so a reading is no
 /// healthier than its weakest attribute.
 #[must_use]
-const fn worse(a: InputHealth, b: InputHealth) -> InputHealth {
+pub(crate) const fn worse(a: InputHealth, b: InputHealth) -> InputHealth {
     if a.to_u8() >= b.to_u8() { a } else { b }
 }
 

--- a/crates/pilotage-geo/src/conformal.rs
+++ b/crates/pilotage-geo/src/conformal.rs
@@ -35,7 +35,10 @@
 
 use pilotage_frames::{AngularVelocity, Epoch, FrameId, ROTATION_NORM_TOLERANCE, Velocity};
 
-use crate::availability::{AvailabilityProfile, ExternalHealth, SvsAvailability, derive_inputs};
+use crate::availability::{
+    AvailabilityProfile, ExternalHealth, SvsAvailability, derive_inputs, health_from_integrity,
+    worse,
+};
 use crate::identity::{
     CoherentSnapshot, SourceIncarnation, SourceStamp, StatedAttitude, StatedPosition,
 };
@@ -77,7 +80,9 @@ pub struct VelocityQuality {
 /// snapshot) plus the velocity and body rate — each frame-, epoch-, and
 /// snapshot-tagged, not a bare array. The velocity is NED (the flight-path-marker
 /// reference) and the body rate is body-frame; [`assess_conformal`] enforces both
-/// frames and that the velocity and rate share the pose's coherent snapshot.
+/// frames, that the velocity and rate share the pose's coherent snapshot and
+/// clock, folds their integrity into the derived availability, and charges their
+/// epoch skew against the policy co-timing limit and the error budget.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct KinematicSample {
     /// Body → NED attitude, with its identity stamp and angular accuracy.
@@ -259,8 +264,9 @@ pub fn assess_conformal(
         return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
     }
     // Both endpoint attitudes must be unit rotations, and the velocity/rate must be
-    // in their expected frames and share the pose's coherent snapshot — a zero
-    // quaternion or a mis-framed/mis-provenanced kinematic input never registers.
+    // in their expected frames, share the pose's coherent snapshot, and carry value
+    // epochs on the pose clock — a zero quaternion or a mis-framed, mis-provenanced,
+    // or clock-incoherent kinematic input never registers.
     if let Some(reason) = kinematic_fault(bracket) {
         return ConformalFix::refused(ConformalState::NonConformal(reason), identity);
     }
@@ -305,7 +311,11 @@ pub fn assess_conformal(
 /// Derives the synthetic-vision availability from the ACTUAL bracket samples —
 /// each endpoint's integrity and accuracy against the profile — taking the worse
 /// of the two. An untrusted or low-accuracy sample yields Unavailable or Degraded
-/// no matter what a caller claims.
+/// no matter what a caller claims. The velocity and body rate steer the
+/// flight-path marker exactly as the pose steers the horizon, so their stated
+/// integrity participates too: it is folded into the navigation-integrity input,
+/// and an untrusted or unknown kinematic reading fails the scene rather than
+/// silently steering a registered cue.
 ///
 /// Freshness is judged against the later of the capture time and the newer
 /// endpoint, so that a bracketed capture time (which precedes the newer sample)
@@ -325,13 +335,21 @@ fn derive_availability(
         newer_at
     };
     let assess = |s: &KinematicSample| {
-        SvsAvailability::assess(&derive_inputs(
+        let mut inputs = derive_inputs(
             &s.position,
             &s.attitude,
             &availability.external,
             reference,
             &availability.profile,
-        ))
+        );
+        inputs.integrity = worse(
+            inputs.integrity,
+            worse(
+                health_from_integrity(s.velocity.meta.integrity),
+                health_from_integrity(s.body_rate.meta.integrity),
+            ),
+        );
+        SvsAvailability::assess(&inputs)
     };
     worst_availability(assess(&bracket.older), assess(&bracket.newer))
 }
@@ -351,8 +369,9 @@ fn worst_availability(a: SvsAvailability, b: SvsAvailability) -> SvsAvailability
 }
 
 /// The kinematic-validity fault of a bracket: a non-unit attitude quaternion at
-/// either endpoint, a velocity or body rate in the wrong frame, or a velocity/rate
-/// whose provenance is not the pose's coherent snapshot. `None` when both samples
+/// either endpoint, a velocity or body rate in the wrong frame, a velocity/rate
+/// whose provenance is not the pose's coherent snapshot, or a velocity/rate value
+/// epoch on a different clock or scale than the pose. `None` when both samples
 /// are well-formed.
 fn kinematic_fault(bracket: &Bracket) -> Option<ConformalReason> {
     for s in [&bracket.older, &bracket.newer] {
@@ -370,6 +389,16 @@ fn kinematic_fault(bracket: &Bracket) -> Option<ConformalReason> {
             || !s.attitude.stamp.coherent_with(&s.body_rate.meta)
         {
             return Some(ConformalReason::KinematicProvenance);
+        }
+        // Coherence binds the *acquisition* epochs' clock/scale; the value epochs
+        // (the instant each kinematic value is valid at) must be on the pose clock
+        // too, or the co-timing skew charged by the interpolation would compare
+        // nanoseconds from incomparable clocks.
+        let pose = s.attitude.stamp.acquired_at;
+        for value_epoch in [s.velocity.epoch, s.body_rate.epoch] {
+            if value_epoch.clock != pose.clock || value_epoch.scale != pose.scale {
+                return Some(ConformalReason::ClockIncoherent);
+            }
         }
     }
     None

--- a/crates/pilotage-geo/src/conformal/budget.rs
+++ b/crates/pilotage-geo/src/conformal/budget.rs
@@ -5,8 +5,8 @@
 //! formula and origin, and the total is a conservative worst-case linear sum (not
 //! root-sum-square) so a consumer never under-counts. In particular there is no
 //! baked-in latency offset: the latency contribution is the caller's *measured*
-//! pipeline latency plus the attitude/position co-timing skew computed from the
-//! stamps.
+//! pipeline latency plus the component co-timing skew computed from the sample
+//! epochs.
 //!
 //! Angular rate and speed are not standalone additive terms — they are the
 //! *sensitivities* that turn a timing error into an angular error: attitude smears
@@ -44,7 +44,7 @@ pub struct AlignmentErrorBound {
     /// mapping error bound × `(angular_rate + speed / reference_range)`.
     pub clock_rad: f64,
     /// Latency times the registration sensitivity: `(measured pipeline latency +
-    /// attitude/position skew)` × `(angular_rate + speed / reference_range)`.
+    /// component co-timing skew)` × `(angular_rate + speed / reference_range)`.
     pub latency_rad: f64,
     /// Extrapolation times the registration sensitivity: the distance the capture
     /// time falls outside the bracket × `(angular_rate + speed / reference_range)`;

--- a/crates/pilotage-geo/src/conformal/interp.rs
+++ b/crates/pilotage-geo/src/conformal/interp.rs
@@ -43,12 +43,12 @@ pub(crate) struct Interpolated {
 }
 
 /// The timing facts of one interpolation: how far the capture time sits outside
-/// the bracket (extrapolation), how badly attitude and position are co-timed
+/// the bracket (extrapolation), how badly each sample's components are co-timed
 /// (skew), and the bracket span.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Timing {
-    /// Attitude/position co-timing skew, the worst of the two samples,
-    /// nanoseconds.
+    /// Component co-timing skew — the widest epoch spread across a sample's
+    /// pose and kinematic epochs, the worst of the two samples, nanoseconds.
     pub skew_ns: u64,
     /// How far the capture time falls outside `[older, newer]`, nanoseconds; `0`
     /// when the capture time is bracketed (a true interpolation).
@@ -101,10 +101,24 @@ fn lerp3_f32(a: [f32; 3], b: [f32; 3], t: f32) -> [f32; 3] {
     ]
 }
 
+/// The co-timing spread of one sample: the widest gap among its component
+/// epochs — the pose's acquisition epochs plus each kinematic value's tagged
+/// epoch and acquisition epoch. A velocity or body rate timed away from the
+/// pose widens the spread exactly like an attitude/position skew, so it is
+/// charged to the policy skew limit and the latency budget term rather than
+/// silently bridged.
 fn skew_of(sample: &KinematicSample) -> u64 {
-    let att = sample.attitude.stamp.acquired_at.nanos;
-    let pos = sample.position.stamp.acquired_at.nanos;
-    att.abs_diff(pos)
+    let epochs = [
+        sample.attitude.stamp.acquired_at.nanos,
+        sample.position.stamp.acquired_at.nanos,
+        sample.velocity.epoch.nanos,
+        sample.velocity.meta.acquired_at.nanos,
+        sample.body_rate.epoch.nanos,
+        sample.body_rate.meta.acquired_at.nanos,
+    ];
+    let hi = epochs.into_iter().max().unwrap_or(0);
+    let lo = epochs.into_iter().min().unwrap_or(0);
+    hi.saturating_sub(lo)
 }
 
 /// Interpolates the coherent bracket at `capture_ns`. The caller has already

--- a/crates/pilotage-geo/src/conformal/policy.rs
+++ b/crates/pilotage-geo/src/conformal/policy.rs
@@ -91,8 +91,8 @@ impl ConformalPolicy {
     ///
     /// - beyond ~50 ms of extrapolation past the newest snapshot a maneuvering
     ///   aircraft's registration is no longer trustworthy;
-    /// - attitude and position must be co-timed to within ~10 ms to share one
-    ///   conformal fix;
+    /// - a sample's components (attitude, position, velocity, body rate) must be
+    ///   co-timed to within ~10 ms to share one conformal fix;
     /// - above ~1 rad/s (~57°/s) body rate the smear over any residual timing
     ///   error swamps the budget, so conformal cues are suppressed;
     /// - sub-degree (~0.57°) total registration error is drawn as fully
@@ -182,8 +182,8 @@ impl ConformalPolicy {
     pub const fn max_extrapolation_ns(&self) -> u64 {
         self.max_extrapolation_ns
     }
-    /// Maximum attitude/position co-timing skew for one conformal fix,
-    /// nanoseconds.
+    /// Maximum co-timing skew among one sample's component epochs (pose,
+    /// velocity, body rate) for one conformal fix, nanoseconds.
     #[must_use]
     pub const fn max_skew_ns(&self) -> u64 {
         self.max_skew_ns

--- a/crates/pilotage-geo/src/conformal/state.rs
+++ b/crates/pilotage-geo/src/conformal/state.rs
@@ -38,8 +38,9 @@ pub enum ConformalReason {
     /// the projection view references, so the projection would run through the
     /// wrong camera model.
     CalibrationMismatch,
-    /// The capture time is not on the same clock domain and time scale as the
-    /// aircraft state, so it cannot be aligned to it.
+    /// The capture time — or a kinematic value's epoch — is not on the same
+    /// clock domain and time scale as the aircraft state, so it cannot be
+    /// aligned to it.
     ClockIncoherent,
     /// A sample's attitude and position are not one declared coherent snapshot,
     /// so the pose is not a single trustworthy fix.
@@ -56,7 +57,8 @@ pub enum ConformalReason {
     /// A bracket endpoint's velocity or body rate does not share the pose's
     /// coherent snapshot, so the kinematics are not one trustworthy fix.
     KinematicProvenance,
-    /// Attitude and position are co-timed worse than the policy allows.
+    /// A sample's components (pose, velocity, body rate) are co-timed worse
+    /// than the policy allows.
     ExcessiveSkew,
     /// The capture time falls further outside the bracket than the policy allows.
     ExcessiveExtrapolation,

--- a/crates/pilotage-geo/src/conformal/tests/kinematics.rs
+++ b/crates/pilotage-geo/src/conformal/tests/kinematics.rs
@@ -1,7 +1,9 @@
 //! The kinematic-input validity gate: regressions for the invalid-input
 //! blockers. A non-unit attitude, a mis-framed velocity or body rate, a
-//! mis-provenanced kinematic input, an untrusted integrity, and a wildly
-//! inaccurate velocity must each fail closed rather than draw a conformal cue.
+//! mis-provenanced kinematic input, an untrusted integrity (pose, velocity, or
+//! body rate), a kinematic epoch off the pose clock or timed away from the
+//! pose, and a wildly inaccurate velocity must each fail closed rather than
+//! draw a conformal cue.
 //!
 //! Shares the parent module's fixtures via `use super::*`.
 
@@ -9,6 +11,7 @@ use super::*;
 
 use pilotage_frames::FrameId;
 
+use crate::availability::AvailabilityReason;
 use crate::identity::IntegrityLevel;
 use crate::{ConformalReason, ConformalState};
 
@@ -108,6 +111,157 @@ fn kinematics_from_a_different_snapshot_are_non_conformal() {
         ConformalState::NonConformal(ConformalReason::KinematicProvenance)
     );
     assert!(fix.cues.is_none());
+}
+
+#[test]
+fn an_unknown_integrity_velocity_alone_is_unavailable_never_drawable() {
+    // The velocity steers the flight-path marker; a velocity the producer cannot
+    // vouch for must fail the derived availability even when the pose is fully
+    // trusted — nothing else about the sample is perturbed.
+    let mut newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2);
+    newer.velocity.meta.integrity = IntegrityLevel::Unknown;
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer,
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::Availability(AvailabilityReason::Integrity))
+    );
+    assert!(fix.cues.is_none() && fix.error.is_none());
+}
+
+#[test]
+fn an_unknown_integrity_body_rate_alone_is_unavailable_never_drawable() {
+    // The body rate scales the timing sensitivity of the whole error budget; a
+    // rate the producer cannot vouch for must fail the derived availability.
+    let mut newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2);
+    newer.body_rate.meta.integrity = IntegrityLevel::Unknown;
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer,
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::Unavailable(ConformalReason::Availability(AvailabilityReason::Integrity))
+    );
+    assert!(fix.cues.is_none() && fix.error.is_none());
+}
+
+#[test]
+fn a_monitored_velocity_degrades_the_scene_to_limited() {
+    // A monitored (reduced-integrity) velocity degrades rather than fails: the
+    // cues stay drawable but must carry the reduced-confidence mark.
+    let mut b = steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]);
+    b.newer.velocity.meta.integrity = IntegrityLevel::Monitored;
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::Limited(ConformalReason::Availability(AvailabilityReason::Integrity))
+    );
+    assert!(fix.cues.expect("a limited fix draws cues").limited);
+}
+
+#[test]
+fn a_velocity_timed_seconds_from_the_pose_is_non_conformal() {
+    // A velocity tagged nine seconds away from the pose epoch is not the state
+    // at the pose's instant, however coherent its snapshot identity is — the
+    // spread is charged as co-timing skew and exceeds the policy limit.
+    let mut newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2);
+    newer.velocity.epoch = epoch(9_000_002_000);
+    newer.velocity.meta.acquired_at = epoch(9_000_002_000);
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer,
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveSkew)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn a_velocity_value_epoch_alone_timed_from_the_pose_is_non_conformal() {
+    // The value epoch (the instant the velocity is valid at) participates in the
+    // skew on its own, even when the acquisition stamp stays co-timed.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.velocity.epoch = epoch(9_000_001_000);
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveSkew)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn a_body_rate_acquired_seconds_from_the_pose_is_non_conformal() {
+    // The body rate's acquisition epoch participates in the skew exactly like
+    // the velocity's.
+    let mut newer = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2);
+    newer.body_rate.meta.acquired_at = epoch(9_000_002_000);
+    let b = Bracket {
+        older: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1),
+        newer,
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ExcessiveSkew)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn a_kinematic_value_epoch_on_a_different_clock_is_non_conformal() {
+    // A velocity value epoch on a different clock cannot be compared to the pose
+    // epoch at all, so it is refused as clock-incoherent rather than having its
+    // nanoseconds read as if they were on the pose clock.
+    let mut older = sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 1_000, 1);
+    older.velocity.epoch.clock = ClockDomain::Gnss;
+    let b = Bracket {
+        older,
+        newer: sample(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3], 2_000, 2),
+    };
+    let fix = run(&b, capture(1_500), &generous());
+    assert_eq!(
+        fix.state,
+        ConformalState::NonConformal(ConformalReason::ClockIncoherent)
+    );
+    assert!(fix.cues.is_none());
+}
+
+#[test]
+fn a_small_kinematic_skew_is_charged_to_the_budget_not_refused() {
+    // A 5 ms velocity skew is within the 10 ms policy limit: the fix stays
+    // drawable, and the skew lands in the latency term of the error budget
+    // rather than being silently bridged.
+    let nominal = run(
+        &steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]),
+        capture(1_500),
+        &generous(),
+    );
+    let mut skewed = steady(Quat::IDENTITY, [50.0, 0.0, 0.0], [0.0; 3]);
+    skewed.newer.velocity.epoch = epoch(5_002_000);
+    skewed.newer.velocity.meta.acquired_at = epoch(5_002_000);
+    let fix = run(&skewed, capture(1_500), &generous());
+    assert!(fix.state.draws_cues(), "a within-limit skew stays drawable");
+    let (e0, e1) = (
+        nominal.error.expect("ran"),
+        fix.error.expect("interpolation ran"),
+    );
+    assert!(
+        e1.latency_rad > e0.latency_rad && e1.total_rad > e0.total_rad,
+        "the kinematic skew is charged into the latency term"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #38.

Follow-up to #88 (ad61aa3), which left one fail-closed gap: kinematic validation checked velocity/body-rate **frames** and **snapshot provenance**, but their **integrity levels** never reached the derived availability (only position + attitude were assessed), and their **tagged epochs** were never compared to the pose epoch (`coherent_with` binds snapshot identity + clock/scale, not time). Three counterexamples produced drawable cues against the merged commit: an `IntegrityLevel::Unknown` velocity, an `Unknown` body rate, and a velocity tagged nine seconds from the pose epoch.

## What changed

- **Integrity joins the derived availability** — `derive_availability` folds `health_from_integrity` of the velocity and body-rate stamps into the navigation-integrity input, worst-of. An `Unknown`/`Untrusted` kinematic reading is `Unavailable(Integrity)`; a `Monitored` one degrades the scene to `Limited`.
- **Value epochs must share the pose clock** — `kinematic_fault` refuses a velocity/body-rate `Tagged.epoch` on a different clock domain or time scale as `ClockIncoherent` (coherence already bound the *acquisition* epochs' clock/scale; the value epochs were unchecked, and an incomparable clock would make nanosecond skew meaningless).
- **Kinematic epoch skew is charged, not bridged** — `skew_of` now takes the widest spread across a sample's component epochs (pose acquisition, plus each kinematic value's tagged epoch and acquisition epoch), so the existing `max_skew_ns` policy gate refuses a gross skew (`ExcessiveSkew`) and a within-limit skew is charged into the latency term of the error budget.

## Guardrails

Eight regression tests in `conformal/tests/kinematics.rs`, all verified to **fail against ad61aa3** and pass here: the three counterexamples above, plus value-epoch-only skew, body-rate acquisition skew, cross-clock value epoch, monitored-velocity degradation, and within-limit skew being budget-charged rather than refused.

## Verification

Isolated-worktree run of the full CI set: `fmt --check`, `clippy --all-targets -- -D warnings`, `test --all-targets` (33 suites, 0 failures), `doc` with CI RUSTDOCFLAGS, `build --release`, thumbv7em no_std check, `check-structure.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)