### PR TITLE
REN-04: price counted render work into a provisional cost envelope (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,12 @@ jobs:
 
       - name: target timing gate (REN-04)
         # No display hardware is selected: the USB CDC scan documents that no
-        # target is connected, and the WCET gate prices the counted work
-        # budget with the conservative model against the recorded frame
-        # deadline. The artifact drift guard keeps the committed timing
-        # record equal to the shipped model.
+        # target is connected, and the envelope gate prices the per-class
+        # work budget with the conservative model against the frame deadline
+        # derived from the SIM display liveness requirement. The artifact
+        # drift guard keeps the committed timing record equal to the shipped
+        # model. The envelope is provisional — not a WCET claim — until a
+        # measured target binds firmware, clock, memory, and compiler state.
         run: |
           bash scripts/detect-target.sh
           cargo test -p pilotage-instrument-raster timing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,16 @@ jobs:
           -p pilotage-instrument-raster
           --target thumbv7em-none-eabihf
 
+      - name: target timing gate (REN-04)
+        # No display hardware is selected: the USB CDC scan documents that no
+        # target is connected, and the WCET gate prices the counted work
+        # budget with the conservative model against the recorded frame
+        # deadline. The artifact drift guard keeps the committed timing
+        # record equal to the shipped model.
+        run: |
+          bash scripts/detect-target.sh
+          cargo test -p pilotage-instrument-raster timing
+
       - name: geospatial contract (SVS-01)
         # Datum discipline, coherence, view/projection, availability, and the
         # fail-closed versioned ABI for synthetic vision and conformal HUD.

--- a/crates/pilotage-instrument-raster/src/curve.rs
+++ b/crates/pilotage-instrument-raster/src/curve.rs
@@ -83,6 +83,8 @@ fn paint(
         let dy = (py as f32 + 0.5) - disc.cy;
         for px in region.left..region.right {
             surface.count_sample();
+            // One disc-distance test per sample, priced like an edge test.
+            surface.count_edge_tests(1);
             let dx = (px as f32 + 0.5) - disc.cx;
             let dist = libm::sqrtf(dx * dx + dy * dy);
             if covered(dist, dx, dy) {

--- a/crates/pilotage-instrument-raster/src/curve.rs
+++ b/crates/pilotage-instrument-raster/src/curve.rs
@@ -25,7 +25,7 @@ pub(crate) struct Disc {
 
 /// Fills the disc with `color`.
 pub(crate) fn fill_circle(surface: &mut Surface<'_>, clip: PixelRect, disc: Disc, color: [u8; 4]) {
-    paint(surface, clip, disc, disc.r, color, |dist, _, _| {
+    paint(surface, clip, disc, disc.r, color, 0, |dist, _, _| {
         dist <= disc.r
     });
 }
@@ -38,7 +38,7 @@ pub(crate) fn stroke_circle(
     hw: f32,
     color: [u8; 4],
 ) {
-    paint(surface, clip, disc, disc.r + hw, color, |dist, _, _| {
+    paint(surface, clip, disc, disc.r + hw, color, 0, |dist, _, _| {
         libm::fabsf(dist - disc.r) <= hw
     });
 }
@@ -56,12 +56,22 @@ pub(crate) fn stroke_arc(
 ) {
     let cap0 = end_point(disc, start);
     let cap1 = end_point(disc, start + sweep);
-    paint(surface, clip, disc, disc.r + hw, color, |dist, dx, dy| {
-        if near(dx, dy, cap0, hw) || near(dx, dy, cap1, hw) {
-            return true;
-        }
-        libm::fabsf(dist - disc.r) <= hw && arc_contains(libm::atan2f(dy, dx), start, sweep)
-    });
+    // Each arc sample may evaluate two cap distances, `atan2f`, and `fmodf`
+    // beyond its disc test — priced as one arc test per sample.
+    paint(
+        surface,
+        clip,
+        disc,
+        disc.r + hw,
+        color,
+        1,
+        |dist, dx, dy| {
+            if near(dx, dy, cap0, hw) || near(dx, dy, cap1, hw) {
+                return true;
+            }
+            libm::fabsf(dist - disc.r) <= hw && arc_contains(libm::atan2f(dy, dx), start, sweep)
+        },
+    );
 }
 
 /// Iterates the pixel box of radius `reach` around the center, compositing
@@ -73,6 +83,7 @@ fn paint(
     disc: Disc,
     reach: f32,
     color: [u8; 4],
+    arc_tests_per_sample: u64,
     covered: impl Fn(f32, f32, f32) -> bool,
 ) {
     if reach < 0.0 || clip.is_empty() {
@@ -83,8 +94,8 @@ fn paint(
         let dy = (py as f32 + 0.5) - disc.cy;
         for px in region.left..region.right {
             surface.count_sample();
-            // One disc-distance test per sample, priced like an edge test.
-            surface.count_edge_tests(1);
+            surface.count_disc_tests(1);
+            surface.count_arc_tests(arc_tests_per_sample);
             let dx = (px as f32 + 0.5) - disc.cx;
             let dist = libm::sqrtf(dx * dx + dy * dy);
             if covered(dist, dx, dy) {

--- a/crates/pilotage-instrument-raster/src/lib.rs
+++ b/crates/pilotage-instrument-raster/src/lib.rs
@@ -53,16 +53,17 @@
 //!   [`MAX_POLYGON_VERTICES`] per shape, and the scene crate's stack, command,
 //!   and byte budgets. The worst-case frame size is [`WORST_CASE_FRAME_BYTES`].
 //!
-//! # Execution-time measurement
+//! # Execution-time pricing
 //! The renderer is straight-line over the scene and framebuffer with no I/O
-//! and only documented-bounded loops, so a target-independent worst-case
-//! execution time is a sum of bounded step counts. [`RenderWork`] counts
-//! them per frame — coverage samples, worst-case per-edge/segment/disc tests
-//! inside those samples, and composites — and [`timing::TargetTimingModel`]
-//! prices the counts into a WCET gated against a recorded frame deadline.
-//! Until display hardware is selected and measured over USB CDC, the shipped
-//! model is a named conservative bound; the timing artifact records the
-//! bounds, their rationale, and the derived WCET.
+//! and only documented-bounded loops, so its per-frame cost is a sum of
+//! bounded step counts. [`RenderWork`] counts them per cost class — polygon
+//! edge tests, stroke segment tests, disc tests, arc angular extras, and
+//! composites — and [`timing::TargetTimingModel`] prices the counts into a
+//! provisional cost envelope gated against the display-derived frame
+//! deadline. Until a target is detected over USB CDC and measured, the
+//! shipped model is a named conservative bound and the envelope is not a
+//! WCET claim; the timing artifact records the bounds, assumptions, and
+//! derivation.
 
 #![no_std]
 

--- a/crates/pilotage-instrument-raster/src/lib.rs
+++ b/crates/pilotage-instrument-raster/src/lib.rs
@@ -56,13 +56,13 @@
 //! # Execution-time measurement
 //! The renderer is straight-line over the scene and framebuffer with no I/O
 //! and only documented-bounded loops, so a target-independent worst-case
-//! execution time is a sum of bounded step counts — command dispatches (at
-//! most [`pilotage_instrument_scene::MAX_LAYER_COMMANDS`] times the layer
-//! count) and per-pixel coverage tests (at most framebuffer pixels times a
-//! shape's edges) — multiplied by the selected target's per-step cycle bound.
-//! A step-counting harness can wrap the coverage predicate and command
-//! dispatch without changing output; measured cycle costs and the final WCET
-//! wait for hardware selection and are out of scope here.
+//! execution time is a sum of bounded step counts. [`RenderWork`] counts
+//! them per frame — coverage samples, worst-case per-edge/segment/disc tests
+//! inside those samples, and composites — and [`timing::TargetTimingModel`]
+//! prices the counts into a WCET gated against a recorded frame deadline.
+//! Until display hardware is selected and measured over USB CDC, the shipped
+//! model is a named conservative bound; the timing artifact records the
+//! bounds, their rationale, and the derived WCET.
 
 #![no_std]
 
@@ -79,6 +79,7 @@ mod state;
 mod stroke;
 mod surface;
 mod text;
+pub mod timing;
 mod transform;
 
 pub use error::RasterError;

--- a/crates/pilotage-instrument-raster/src/paint.rs
+++ b/crates/pilotage-instrument-raster/src/paint.rs
@@ -30,7 +30,7 @@ pub(crate) fn fill_polygon(
             surface.count_sample();
             // The winding test always walks every edge, so the priced count
             // is exact, not an upper bound.
-            surface.count_edge_tests(verts.len() as u64);
+            surface.count_polygon_edge_tests(verts.len() as u64);
             let cx = Fx::pixel_center(px).raw();
             if winding_nonzero(verts, cx, cy) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/paint.rs
+++ b/crates/pilotage-instrument-raster/src/paint.rs
@@ -28,6 +28,9 @@ pub(crate) fn fill_polygon(
         let cy = Fx::pixel_center(py).raw();
         for px in region.left..region.right {
             surface.count_sample();
+            // The winding test always walks every edge, so the priced count
+            // is exact, not an upper bound.
+            surface.count_edge_tests(verts.len() as u64);
             let cx = Fx::pixel_center(px).raw();
             if winding_nonzero(verts, cx, cy) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/report.rs
+++ b/crates/pilotage-instrument-raster/src/report.rs
@@ -75,31 +75,41 @@ pub struct RenderReport {
 pub struct RenderWork {
     /// Pixel-center coverage evaluations across all primitives.
     pub coverage_samples: u64,
-    /// Worst-case per-edge/segment/disc tests inside those coverage
-    /// evaluations — the unit a target timing model prices, since a
-    /// polygon sample walks every edge while an arc sample tests one disc.
-    pub edge_tests: u64,
+    /// Integer winding edge tests inside polygon coverage samples (a sample
+    /// walks every edge of its polygon).
+    pub polygon_edge_tests: u64,
+    /// f32 capsule segment-distance tests inside stroke coverage samples
+    /// (worst case: every segment, so an early exit never under-counts).
+    pub stroke_segment_tests: u64,
+    /// Center-distance (`sqrtf`) tests inside circle/arc coverage samples,
+    /// one per sample.
+    pub disc_tests: u64,
+    /// Arc angular-membership evaluations — the transcendental extras an arc
+    /// sample may perform beyond its disc test (two cap distances, `atan2f`,
+    /// `fmodf`) — one per arc coverage sample, priced as their own class.
+    pub arc_tests: u64,
     /// Source-over composites applied.
     pub composites: u64,
 }
 
 impl RenderWork {
-    /// Engineering work budget for one panel frame.
+    /// Engineering work budget for one panel frame, per cost class.
     ///
     /// The fully populated PFD demo fixture — every band painting content —
-    /// measures ~547k coverage samples, ~2.0M edge tests, and ~434k
-    /// composites on the 480x360 panel (~3.2 samples and ~2.5 composites per
-    /// output pixel). The budget grants 2x headroom over that worst measured
-    /// fixture, rounded up, so scenes can grow denser without churning the
-    /// constant while per-frame work stays bounded at ~6.4 samples per
-    /// pixel. Because the counters are a pure function of scene bytes and
-    /// dimensions, exceeding this budget is a deterministic CI failure on
-    /// every platform, not a timing flake. The [`crate::timing`] model
-    /// prices this budget into a worst-case execution time and gates it
-    /// against the recorded frame deadline.
+    /// is the worst measured panel scene on the 480x360 panel; each class
+    /// budget grants 2x headroom over the worse of the PFD/HSI fixtures,
+    /// rounded up, so scenes can grow denser without churning the constants.
+    /// Because the counters are a pure function of scene bytes and
+    /// dimensions, exceeding any class budget is a deterministic CI failure
+    /// on every platform, not a timing flake. The [`crate::timing`] model
+    /// prices this budget into a provisional cost envelope and gates it
+    /// against the display-derived frame deadline.
     pub const BUDGET: RenderWork = RenderWork {
         coverage_samples: 1_100_000,
-        edge_tests: 4_000_000,
+        polygon_edge_tests: 3_600_000,
+        stroke_segment_tests: 250_000,
+        disc_tests: 175_000,
+        arc_tests: 175_000,
         composites: 900_000,
     };
 
@@ -107,7 +117,10 @@ impl RenderWork {
     #[must_use]
     pub const fn within(&self, budget: &RenderWork) -> bool {
         self.coverage_samples <= budget.coverage_samples
-            && self.edge_tests <= budget.edge_tests
+            && self.polygon_edge_tests <= budget.polygon_edge_tests
+            && self.stroke_segment_tests <= budget.stroke_segment_tests
+            && self.disc_tests <= budget.disc_tests
+            && self.arc_tests <= budget.arc_tests
             && self.composites <= budget.composites
     }
 }

--- a/crates/pilotage-instrument-raster/src/report.rs
+++ b/crates/pilotage-instrument-raster/src/report.rs
@@ -75,6 +75,10 @@ pub struct RenderReport {
 pub struct RenderWork {
     /// Pixel-center coverage evaluations across all primitives.
     pub coverage_samples: u64,
+    /// Worst-case per-edge/segment/disc tests inside those coverage
+    /// evaluations — the unit a target timing model prices, since a
+    /// polygon sample walks every edge while an arc sample tests one disc.
+    pub edge_tests: u64,
     /// Source-over composites applied.
     pub composites: u64,
 }
@@ -83,23 +87,27 @@ impl RenderWork {
     /// Engineering work budget for one panel frame.
     ///
     /// The fully populated PFD demo fixture — every band painting content —
-    /// measures ~547k coverage samples and ~434k composites on the 480x360
-    /// panel (~3.2 samples and ~2.5 composites per output pixel). The budget
-    /// grants 2x headroom over that worst measured fixture, rounded up, so
-    /// scenes can grow denser without churning the constant while per-frame
-    /// work stays bounded at ~6.4 samples per pixel. Because the counters
-    /// are a pure function of scene bytes and dimensions, exceeding this
-    /// budget is a deterministic CI failure on every platform, not a timing
-    /// flake. Wall-clock budgets are added when display hardware is
-    /// selected; until then this operation count is the portable proxy.
+    /// measures ~547k coverage samples, ~2.0M edge tests, and ~434k
+    /// composites on the 480x360 panel (~3.2 samples and ~2.5 composites per
+    /// output pixel). The budget grants 2x headroom over that worst measured
+    /// fixture, rounded up, so scenes can grow denser without churning the
+    /// constant while per-frame work stays bounded at ~6.4 samples per
+    /// pixel. Because the counters are a pure function of scene bytes and
+    /// dimensions, exceeding this budget is a deterministic CI failure on
+    /// every platform, not a timing flake. The [`crate::timing`] model
+    /// prices this budget into a worst-case execution time and gates it
+    /// against the recorded frame deadline.
     pub const BUDGET: RenderWork = RenderWork {
         coverage_samples: 1_100_000,
+        edge_tests: 4_000_000,
         composites: 900_000,
     };
 
-    /// Whether this work fits inside `budget` on both axes.
+    /// Whether this work fits inside `budget` on every axis.
     #[must_use]
     pub const fn within(&self, budget: &RenderWork) -> bool {
-        self.coverage_samples <= budget.coverage_samples && self.composites <= budget.composites
+        self.coverage_samples <= budget.coverage_samples
+            && self.edge_tests <= budget.edge_tests
+            && self.composites <= budget.composites
     }
 }

--- a/crates/pilotage-instrument-raster/src/stroke.rs
+++ b/crates/pilotage-instrument-raster/src/stroke.rs
@@ -39,6 +39,10 @@ pub(crate) fn stroke_path(
         let cy = py as f32 + 0.5;
         for px in region.left..region.right {
             surface.count_sample();
+            // The coverage test early-exits on a hit; the priced count is the
+            // worst case (every segment, or the single point) so the timing
+            // model never under-counts.
+            surface.count_edge_tests(seg_count.max(1) as u64);
             let cx = px as f32 + 0.5;
             if covered(verts, seg_count, cx, cy, hw) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/stroke.rs
+++ b/crates/pilotage-instrument-raster/src/stroke.rs
@@ -42,7 +42,7 @@ pub(crate) fn stroke_path(
             // The coverage test early-exits on a hit; the priced count is the
             // worst case (every segment, or the single point) so the timing
             // model never under-counts.
-            surface.count_edge_tests(seg_count.max(1) as u64);
+            surface.count_stroke_segment_tests(seg_count.max(1) as u64);
             let cx = px as f32 + 0.5;
             if covered(verts, seg_count, cx, cy, hw) {
                 surface.composite(px, py, color);

--- a/crates/pilotage-instrument-raster/src/surface.rs
+++ b/crates/pilotage-instrument-raster/src/surface.rs
@@ -50,6 +50,9 @@ pub(crate) struct Surface<'a> {
     /// primitive's bounded region loop). A pure function of scene and
     /// dimensions, so it doubles as the target-independent work metric.
     coverage_samples: u64,
+    /// Worst-case per-edge/segment/disc tests inside coverage evaluations —
+    /// the priced unit of the target timing model.
+    edge_tests: u64,
     /// Source-over composites actually applied.
     composites: u64,
 }
@@ -89,6 +92,7 @@ impl<'a> Surface<'a> {
             height: dims.height as i32,
             stride,
             coverage_samples: 0,
+            edge_tests: 0,
             composites: 0,
         })
     }
@@ -127,10 +131,19 @@ impl<'a> Surface<'a> {
         self.coverage_samples = self.coverage_samples.wrapping_add(1);
     }
 
-    /// The work performed so far: coverage evaluations and composites.
+    /// Counts the bounded per-edge/segment/disc tests one coverage
+    /// evaluation performs — the unit the target timing model prices, so the
+    /// count is the caller's worst case (every edge), not an early-exit path.
+    pub(crate) fn count_edge_tests(&mut self, n: u64) {
+        self.edge_tests = self.edge_tests.wrapping_add(n);
+    }
+
+    /// The work performed so far: coverage evaluations, edge tests, and
+    /// composites.
     pub(crate) fn work(&self) -> crate::report::RenderWork {
         crate::report::RenderWork {
             coverage_samples: self.coverage_samples,
+            edge_tests: self.edge_tests,
             composites: self.composites,
         }
     }

--- a/crates/pilotage-instrument-raster/src/surface.rs
+++ b/crates/pilotage-instrument-raster/src/surface.rs
@@ -50,9 +50,14 @@ pub(crate) struct Surface<'a> {
     /// primitive's bounded region loop). A pure function of scene and
     /// dimensions, so it doubles as the target-independent work metric.
     coverage_samples: u64,
-    /// Worst-case per-edge/segment/disc tests inside coverage evaluations —
-    /// the priced unit of the target timing model.
-    edge_tests: u64,
+    /// Integer winding edge tests inside polygon coverage samples.
+    polygon_edge_tests: u64,
+    /// f32 segment-distance tests inside stroke samples (worst case).
+    stroke_segment_tests: u64,
+    /// Center-distance tests inside circle/arc samples.
+    disc_tests: u64,
+    /// Arc angular-membership extras beyond the disc test.
+    arc_tests: u64,
     /// Source-over composites actually applied.
     composites: u64,
 }
@@ -92,7 +97,10 @@ impl<'a> Surface<'a> {
             height: dims.height as i32,
             stride,
             coverage_samples: 0,
-            edge_tests: 0,
+            polygon_edge_tests: 0,
+            stroke_segment_tests: 0,
+            disc_tests: 0,
+            arc_tests: 0,
             composites: 0,
         })
     }
@@ -131,19 +139,37 @@ impl<'a> Surface<'a> {
         self.coverage_samples = self.coverage_samples.wrapping_add(1);
     }
 
-    /// Counts the bounded per-edge/segment/disc tests one coverage
-    /// evaluation performs — the unit the target timing model prices, so the
-    /// count is the caller's worst case (every edge), not an early-exit path.
-    pub(crate) fn count_edge_tests(&mut self, n: u64) {
-        self.edge_tests = self.edge_tests.wrapping_add(n);
+    /// Counts the integer winding edge tests of one polygon coverage sample
+    /// (every edge — the count is the worst case the timing model prices).
+    pub(crate) fn count_polygon_edge_tests(&mut self, n: u64) {
+        self.polygon_edge_tests = self.polygon_edge_tests.wrapping_add(n);
     }
 
-    /// The work performed so far: coverage evaluations, edge tests, and
-    /// composites.
+    /// Counts the f32 segment-distance tests of one stroke coverage sample
+    /// (every segment, never an early-exit path).
+    pub(crate) fn count_stroke_segment_tests(&mut self, n: u64) {
+        self.stroke_segment_tests = self.stroke_segment_tests.wrapping_add(n);
+    }
+
+    /// Counts one circle/arc center-distance test.
+    pub(crate) fn count_disc_tests(&mut self, n: u64) {
+        self.disc_tests = self.disc_tests.wrapping_add(n);
+    }
+
+    /// Counts one arc angular-membership evaluation (cap distances, `atan2f`,
+    /// `fmodf`) beyond the sample's disc test.
+    pub(crate) fn count_arc_tests(&mut self, n: u64) {
+        self.arc_tests = self.arc_tests.wrapping_add(n);
+    }
+
+    /// The work performed so far, by cost class.
     pub(crate) fn work(&self) -> crate::report::RenderWork {
         crate::report::RenderWork {
             coverage_samples: self.coverage_samples,
-            edge_tests: self.edge_tests,
+            polygon_edge_tests: self.polygon_edge_tests,
+            stroke_segment_tests: self.stroke_segment_tests,
+            disc_tests: self.disc_tests,
+            arc_tests: self.arc_tests,
             composites: self.composites,
         }
     }

--- a/crates/pilotage-instrument-raster/src/timing.rs
+++ b/crates/pilotage-instrument-raster/src/timing.rs
@@ -1,0 +1,115 @@
+//! Target timing model: prices the counted render work into a worst-case
+//! execution time and gates it against a recorded frame deadline.
+//!
+//! The renderer's work is counted in target-independent units
+//! ([`crate::RenderWork`]): worst-case per-edge/segment/disc tests inside
+//! coverage evaluations, and source-over composites. A [`TargetTimingModel`]
+//! multiplies those counts by per-operation cycle bounds and adds a fixed
+//! per-frame overhead (clear + command dispatch), yielding a WCET that is a
+//! pure function of the counted work — no wall-clock measurement in CI, so
+//! the gate can never flake.
+//!
+//! There is deliberately no `Default`: a caller must name a model, so a
+//! conservative placeholder is never mistaken for a measured target. The one
+//! model shipped here is [`CONSERVATIVE_CORTEX_M7_CLASS`], whose provenance
+//! is [`CycleProvenance::ConservativeBound`]: no display hardware is
+//! selected, and the USB CDC scan (`scripts/detect-target.sh`) found no
+//! connected target to measure, so every cycle count is an instruction-level
+//! upper bound with the rationale recorded in the timing artifact
+//! (`docs/instruments/evidence-artifacts/timing/target-timing.txt`). When a
+//! target is measured, a `MeasuredUsbCdc` model replaces the bounds and the
+//! deadline tightens to the display requirement; the machinery stays as is.
+//!
+//! SIM / NOT FOR FLIGHT: the recorded deadline is an anti-regression
+//! envelope for the conservative model, not a display-suitability or
+//! airworthiness claim.
+
+use crate::report::RenderWork;
+
+/// How a model's cycle counts were obtained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleProvenance {
+    /// Instruction-level upper bounds; no hardware measurement exists.
+    ConservativeBound,
+    /// Measured on a connected target detected over USB CDC; carries the
+    /// reported firmware identity string.
+    MeasuredUsbCdc(&'static str),
+}
+
+/// Per-target cycle pricing for the counted render work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TargetTimingModel {
+    /// The model's stable name (recorded in the timing artifact).
+    pub name: &'static str,
+    /// Where the cycle counts came from.
+    pub provenance: CycleProvenance,
+    /// Core clock the deadline is priced against, hertz.
+    pub cpu_hz: u64,
+    /// Upper bound on cycles for one edge/segment/disc test, including its
+    /// share of the sample-loop overhead.
+    pub cycles_per_edge_test: u64,
+    /// Upper bound on cycles for one source-over composite, including the
+    /// framebuffer read-modify-write.
+    pub cycles_per_composite: u64,
+    /// Fixed per-frame cycles: the frame clear plus worst-case command
+    /// dispatch, independent of scene density.
+    pub frame_overhead_cycles: u64,
+    /// The frame deadline the WCET is gated against, microseconds.
+    pub frame_deadline_us: u64,
+}
+
+/// The conservative Cortex-M7-class placeholder model, pending hardware
+/// selection and USB CDC measurement.
+///
+/// Bounds and rationale (recorded in the timing artifact): a winding edge
+/// test is integer compares plus two widening multiplies (~20 cycles), a
+/// stroke segment distance is short f32 arithmetic with one divide
+/// (~40 cycles), and an arc disc test is one `sqrtf` plus compares
+/// (~35 cycles) — 48 covers the worst of them plus loop overhead on a
+/// zero-wait-state core. A composite is a 4-byte read-modify-write with
+/// `div255` blend chains, bounded by 48. The overhead covers the 480x360
+/// clear and maximal command dispatch. 480 MHz is the Cortex-M7 class
+/// ceiling. All values assume code and framebuffer in zero-wait RAM; flash
+/// wait states and cache effects must be re-validated at measurement.
+pub const CONSERVATIVE_CORTEX_M7_CLASS: TargetTimingModel = TargetTimingModel {
+    name: "conservative-cortex-m7-class",
+    provenance: CycleProvenance::ConservativeBound,
+    cpu_hz: 480_000_000,
+    cycles_per_edge_test: 48,
+    cycles_per_composite: 48,
+    frame_overhead_cycles: 2_000_000,
+    frame_deadline_us: 600_000,
+};
+
+impl TargetTimingModel {
+    /// Worst-case cycles for one frame of `work`, saturating so an absurd
+    /// count can never wrap into a small (plausible) figure.
+    #[must_use]
+    pub const fn wcet_cycles(&self, work: &RenderWork) -> u64 {
+        work.edge_tests
+            .saturating_mul(self.cycles_per_edge_test)
+            .saturating_add(work.composites.saturating_mul(self.cycles_per_composite))
+            .saturating_add(self.frame_overhead_cycles)
+    }
+
+    /// Worst-case execution time for one frame of `work`, microseconds,
+    /// rounded up so pricing never flatters the work.
+    #[must_use]
+    pub const fn wcet_us(&self, work: &RenderWork) -> u64 {
+        let cycles = self.wcet_cycles(work);
+        let per_us = self.cpu_hz / 1_000_000;
+        if per_us == 0 {
+            return u64::MAX;
+        }
+        cycles.div_ceil(per_us)
+    }
+
+    /// Whether one frame of `work` meets the recorded frame deadline.
+    #[must_use]
+    pub const fn meets_deadline(&self, work: &RenderWork) -> bool {
+        self.wcet_us(work) <= self.frame_deadline_us
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-raster/src/timing.rs
+++ b/crates/pilotage-instrument-raster/src/timing.rs
@@ -1,27 +1,41 @@
-//! Target timing model: prices the counted render work into a worst-case
-//! execution time and gates it against a recorded frame deadline.
+//! Target timing model: prices the counted render work, per cost class, into
+//! a provisional cost envelope gated against the display-derived frame
+//! deadline.
 //!
 //! The renderer's work is counted in target-independent units
-//! ([`crate::RenderWork`]): worst-case per-edge/segment/disc tests inside
-//! coverage evaluations, and source-over composites. A [`TargetTimingModel`]
-//! multiplies those counts by per-operation cycle bounds and adds a fixed
-//! per-frame overhead (clear + command dispatch), yielding a WCET that is a
-//! pure function of the counted work — no wall-clock measurement in CI, so
-//! the gate can never flake.
+//! ([`crate::RenderWork`]): integer polygon edge tests, f32 stroke segment
+//! tests, circle/arc disc tests, arc angular-membership extras, and
+//! source-over composites. A [`TargetTimingModel`] multiplies each class by
+//! its per-operation cycle bound and adds a fixed per-frame overhead (clear +
+//! command dispatch), yielding a cost that is a pure function of the counted
+//! work — no wall-clock measurement in CI, so the gate can never flake.
+//!
+//! **Provisional, not WCET.** Until per-operation cycles are measured on the
+//! selected hardware, the derived figure is a *provisional cost envelope*
+//! under recorded assumptions (instruction-level bounds with a stated
+//! memory-system allowance, an assumed core clock, zero-wait code/framebuffer
+//! placement) — never a worst-case-execution-time claim. The provenance is
+//! typed: only a [`CycleProvenance::MeasuredUsbCdc`] model, carrying the
+//! firmware/build identity, MCU, clock and memory configuration, compiler
+//! flags, and the committed raw measurement output, can ground a WCET claim.
+//!
+//! The frame deadline is not chosen here: it derives from the one recorded
+//! display requirement that exists today — the SIM display liveness deadline
+//! (`PanelHealth` `livenessDeadlineMs`, 1000 ms, in
+//! `clients/web/instrument-health.js`): a panel whose frame generation has
+//! not advanced within that deadline fails `LIVENESS`, so producing one frame
+//! must fit inside it. When display hardware is selected, the deadline
+//! tightens to that display's refresh requirement.
 //!
 //! There is deliberately no `Default`: a caller must name a model, so a
 //! conservative placeholder is never mistaken for a measured target. The one
-//! model shipped here is [`CONSERVATIVE_CORTEX_M7_CLASS`], whose provenance
-//! is [`CycleProvenance::ConservativeBound`]: no display hardware is
-//! selected, and the USB CDC scan (`scripts/detect-target.sh`) found no
-//! connected target to measure, so every cycle count is an instruction-level
-//! upper bound with the rationale recorded in the timing artifact
-//! (`docs/instruments/evidence-artifacts/timing/target-timing.txt`). When a
-//! target is measured, a `MeasuredUsbCdc` model replaces the bounds and the
-//! deadline tightens to the display requirement; the machinery stays as is.
+//! model shipped here is [`CONSERVATIVE_CORTEX_M7_CLASS`]; its bounds,
+//! rationale, and derived envelope are recorded in the timing artifact
+//! (`docs/instruments/evidence-artifacts/timing/target-timing.txt`), and the
+//! USB CDC scan (`scripts/detect-target.sh`) detects a connected target
+//! rather than asking.
 //!
-//! SIM / NOT FOR FLIGHT: the recorded deadline is an anti-regression
-//! envelope for the conservative model, not a display-suitability or
+//! SIM / NOT FOR FLIGHT: nothing here is a display-suitability or
 //! airworthiness claim.
 
 use crate::report::RenderWork;
@@ -29,74 +43,113 @@ use crate::report::RenderWork;
 /// How a model's cycle counts were obtained.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CycleProvenance {
-    /// Instruction-level upper bounds; no hardware measurement exists.
+    /// Instruction-level upper bounds with a stated memory-system allowance;
+    /// no hardware measurement exists, so derived figures are provisional
+    /// envelopes, never WCET claims.
     ConservativeBound,
-    /// Measured on a connected target detected over USB CDC; carries the
-    /// reported firmware identity string.
-    MeasuredUsbCdc(&'static str),
+    /// Measured on a connected target detected over USB CDC. Every field is
+    /// required so the measurement is reproducible and auditable; a
+    /// measurement that cannot state its configuration is not a measurement.
+    MeasuredUsbCdc {
+        /// Firmware identity and build hash reported over the CDC handshake.
+        firmware: &'static str,
+        /// MCU part number.
+        mcu: &'static str,
+        /// Measured core clock configuration, hertz.
+        clock_hz: u64,
+        /// Compiler and flags the measured binary was built with.
+        compiler: &'static str,
+        /// Cache/flash wait-state and memory-placement state during the run.
+        memory_state: &'static str,
+        /// Repo-relative path of the committed raw measurement output.
+        raw_output: &'static str,
+    },
 }
 
-/// Per-target cycle pricing for the counted render work.
+/// Per-target cycle pricing for the counted render work, one bound per cost
+/// class.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TargetTimingModel {
     /// The model's stable name (recorded in the timing artifact).
     pub name: &'static str,
     /// Where the cycle counts came from.
     pub provenance: CycleProvenance,
-    /// Core clock the deadline is priced against, hertz.
+    /// Core clock the deadline is priced against, hertz. For a
+    /// conservative-bound model this is an assumption recorded in the
+    /// artifact, not a measured fact.
     pub cpu_hz: u64,
-    /// Upper bound on cycles for one edge/segment/disc test, including its
-    /// share of the sample-loop overhead.
-    pub cycles_per_edge_test: u64,
+    /// Upper bound on cycles for one integer winding edge test.
+    pub cycles_per_polygon_edge_test: u64,
+    /// Upper bound on cycles for one f32 capsule segment-distance test.
+    pub cycles_per_stroke_segment_test: u64,
+    /// Upper bound on cycles for one circle/arc center-distance test.
+    pub cycles_per_disc_test: u64,
+    /// Upper bound on cycles for one arc angular-membership evaluation (two
+    /// cap distances, `atan2f`, `fmodf`).
+    pub cycles_per_arc_test: u64,
     /// Upper bound on cycles for one source-over composite, including the
     /// framebuffer read-modify-write.
     pub cycles_per_composite: u64,
     /// Fixed per-frame cycles: the frame clear plus worst-case command
     /// dispatch, independent of scene density.
     pub frame_overhead_cycles: u64,
-    /// The frame deadline the WCET is gated against, microseconds.
+    /// The frame deadline the envelope is gated against, microseconds —
+    /// derived from a recorded display requirement, never invented here.
     pub frame_deadline_us: u64,
 }
 
 /// The conservative Cortex-M7-class placeholder model, pending hardware
 /// selection and USB CDC measurement.
 ///
-/// Bounds and rationale (recorded in the timing artifact): a winding edge
-/// test is integer compares plus two widening multiplies (~20 cycles), a
-/// stroke segment distance is short f32 arithmetic with one divide
-/// (~40 cycles), and an arc disc test is one `sqrtf` plus compares
-/// (~35 cycles) — 48 covers the worst of them plus loop overhead on a
-/// zero-wait-state core. A composite is a 4-byte read-modify-write with
-/// `div255` blend chains, bounded by 48. The overhead covers the 480x360
-/// clear and maximal command dispatch. 480 MHz is the Cortex-M7 class
-/// ceiling. All values assume code and framebuffer in zero-wait RAM; flash
-/// wait states and cache effects must be re-validated at measurement.
+/// Bounds and rationale (recorded in the timing artifact): each bound is a
+/// zero-wait instruction-level estimate doubled as a memory-system allowance
+/// (flash wait states, cache misses, framebuffer traffic). A winding edge
+/// test is integer compares plus two widening multiplies (~20 cycles → 40);
+/// a stroke segment distance is short f32 arithmetic with one divide
+/// (~40 → 80); a disc test is one `sqrtf` plus compares (~30 → 60); an arc
+/// test may add two cap `sqrtf`s, a software `atan2f`, and `fmodf`
+/// (~120 → 240); a composite is a 4-byte read-modify-write with `div255`
+/// blend chains (~40 → 80). The overhead covers the 480x360 clear and
+/// maximal command dispatch. The 480 MHz clock is an assumption (the class
+/// ceiling); the envelope scales inversely with the real clock and binds
+/// only after measurement. The deadline is the SIM display liveness
+/// requirement (`PanelHealth` `livenessDeadlineMs` = 1000 ms).
 pub const CONSERVATIVE_CORTEX_M7_CLASS: TargetTimingModel = TargetTimingModel {
     name: "conservative-cortex-m7-class",
     provenance: CycleProvenance::ConservativeBound,
     cpu_hz: 480_000_000,
-    cycles_per_edge_test: 48,
-    cycles_per_composite: 48,
+    cycles_per_polygon_edge_test: 40,
+    cycles_per_stroke_segment_test: 80,
+    cycles_per_disc_test: 60,
+    cycles_per_arc_test: 240,
+    cycles_per_composite: 80,
     frame_overhead_cycles: 2_000_000,
-    frame_deadline_us: 600_000,
+    frame_deadline_us: 1_000_000,
 };
 
 impl TargetTimingModel {
-    /// Worst-case cycles for one frame of `work`, saturating so an absurd
-    /// count can never wrap into a small (plausible) figure.
+    /// Provisional cost envelope for one frame of `work`, cycles — the
+    /// per-class worst-case sum, saturating so an absurd count can never
+    /// wrap into a small (plausible) figure.
     #[must_use]
-    pub const fn wcet_cycles(&self, work: &RenderWork) -> u64 {
-        work.edge_tests
-            .saturating_mul(self.cycles_per_edge_test)
+    pub const fn envelope_cycles(&self, work: &RenderWork) -> u64 {
+        work.polygon_edge_tests
+            .saturating_mul(self.cycles_per_polygon_edge_test)
+            .saturating_add(
+                work.stroke_segment_tests
+                    .saturating_mul(self.cycles_per_stroke_segment_test),
+            )
+            .saturating_add(work.disc_tests.saturating_mul(self.cycles_per_disc_test))
+            .saturating_add(work.arc_tests.saturating_mul(self.cycles_per_arc_test))
             .saturating_add(work.composites.saturating_mul(self.cycles_per_composite))
             .saturating_add(self.frame_overhead_cycles)
     }
 
-    /// Worst-case execution time for one frame of `work`, microseconds,
+    /// Provisional cost envelope for one frame of `work`, microseconds,
     /// rounded up so pricing never flatters the work.
     #[must_use]
-    pub const fn wcet_us(&self, work: &RenderWork) -> u64 {
-        let cycles = self.wcet_cycles(work);
+    pub const fn envelope_us(&self, work: &RenderWork) -> u64 {
+        let cycles = self.envelope_cycles(work);
         let per_us = self.cpu_hz / 1_000_000;
         if per_us == 0 {
             return u64::MAX;
@@ -104,10 +157,11 @@ impl TargetTimingModel {
         cycles.div_ceil(per_us)
     }
 
-    /// Whether one frame of `work` meets the recorded frame deadline.
+    /// Whether one frame of `work` fits the display-derived frame deadline
+    /// under this model's assumptions.
     #[must_use]
-    pub const fn meets_deadline(&self, work: &RenderWork) -> bool {
-        self.wcet_us(work) <= self.frame_deadline_us
+    pub const fn within_deadline(&self, work: &RenderWork) -> bool {
+        self.envelope_us(work) <= self.frame_deadline_us
     }
 }
 

--- a/crates/pilotage-instrument-raster/src/timing/tests.rs
+++ b/crates/pilotage-instrument-raster/src/timing/tests.rs
@@ -1,0 +1,119 @@
+//! The CI timing gate and the WCET pricing invariants.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{CONSERVATIVE_CORTEX_M7_CLASS, CycleProvenance, TargetTimingModel};
+use crate::report::RenderWork;
+
+#[test]
+fn budget_wcet_meets_the_frame_deadline() {
+    // THE timing gate: the engineering work budget, priced by the recorded
+    // model, must fit the recorded frame deadline. Growing the budget or the
+    // cycle bounds past the deadline is a deterministic CI failure that
+    // forces a reasoned artifact update, never a silent regression.
+    let model = CONSERVATIVE_CORTEX_M7_CLASS;
+    assert!(
+        model.meets_deadline(&RenderWork::BUDGET),
+        "budget WCET {} us exceeds the {} us frame deadline",
+        model.wcet_us(&RenderWork::BUDGET),
+        model.frame_deadline_us,
+    );
+}
+
+#[test]
+fn wcet_is_monotonic_in_the_counted_work() {
+    let model = CONSERVATIVE_CORTEX_M7_CLASS;
+    let base = RenderWork {
+        coverage_samples: 10,
+        edge_tests: 100,
+        composites: 50,
+    };
+    let more_edges = RenderWork {
+        edge_tests: 101,
+        ..base
+    };
+    let more_composites = RenderWork {
+        composites: 51,
+        ..base
+    };
+    assert!(model.wcet_cycles(&more_edges) > model.wcet_cycles(&base));
+    assert!(model.wcet_cycles(&more_composites) > model.wcet_cycles(&base));
+}
+
+#[test]
+fn wcet_saturates_instead_of_wrapping() {
+    // An absurd count must never wrap into a small, plausible-looking WCET.
+    let model = CONSERVATIVE_CORTEX_M7_CLASS;
+    let absurd = RenderWork {
+        coverage_samples: u64::MAX,
+        edge_tests: u64::MAX,
+        composites: u64::MAX,
+    };
+    assert_eq!(model.wcet_cycles(&absurd), u64::MAX);
+    assert!(!model.meets_deadline(&absurd));
+}
+
+#[test]
+fn a_sub_megahertz_clock_prices_to_the_failing_extreme() {
+    // cpu_hz below 1 MHz has no whole cycles-per-microsecond figure; the
+    // pricing fails closed to u64::MAX rather than dividing by zero.
+    let model = TargetTimingModel {
+        cpu_hz: 999_999,
+        ..CONSERVATIVE_CORTEX_M7_CLASS
+    };
+    assert_eq!(model.wcet_us(&RenderWork::BUDGET), u64::MAX);
+    assert!(!model.meets_deadline(&RenderWork::BUDGET));
+}
+
+#[test]
+fn the_shipped_model_is_a_conservative_bound_not_a_measurement() {
+    // Until a target is detected over USB CDC and measured, the shipped
+    // model must say so; a measured model carries the firmware identity.
+    assert_eq!(
+        CONSERVATIVE_CORTEX_M7_CLASS.provenance,
+        CycleProvenance::ConservativeBound
+    );
+}
+
+/// The value of a `<field>: <value>` line in the timing artifact.
+fn artifact_field(text: &str, field: &str) -> std::string::String {
+    let key = std::format!("{field}:");
+    text.lines()
+        .find_map(|line| line.trim().strip_prefix(&key))
+        .unwrap_or_else(|| panic!("timing artifact has no {field} field"))
+        .trim()
+        .into()
+}
+
+#[test]
+fn the_timing_artifact_matches_the_shipped_model() {
+    // The committed timing artifact is the reviewable record of the model;
+    // this guard fails CI when either side drifts, so the recorded bounds,
+    // budget, WCET, and deadline can never disagree with the shipped code.
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../docs/instruments/evidence-artifacts/timing/target-timing.txt");
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let model = CONSERVATIVE_CORTEX_M7_CLASS;
+    let budget = RenderWork::BUDGET;
+    assert_eq!(artifact_field(&text, "target"), model.name);
+    assert_eq!(artifact_field(&text, "provenance"), "conservative-bound");
+    let numbers = [
+        ("cpu-hz", model.cpu_hz),
+        ("cycles-per-edge-test", model.cycles_per_edge_test),
+        ("cycles-per-composite", model.cycles_per_composite),
+        ("frame-overhead-cycles", model.frame_overhead_cycles),
+        ("budget-coverage-samples", budget.coverage_samples),
+        ("budget-edge-tests", budget.edge_tests),
+        ("budget-composites", budget.composites),
+        ("wcet-cycles", model.wcet_cycles(&budget)),
+        ("wcet-us", model.wcet_us(&budget)),
+        ("frame-deadline-us", model.frame_deadline_us),
+    ];
+    for (field, expected) in numbers {
+        assert_eq!(
+            artifact_field(&text, field),
+            std::format!("{expected}"),
+            "timing artifact field {field} disagrees with the shipped model"
+        );
+    }
+}

--- a/crates/pilotage-instrument-raster/src/timing/tests.rs
+++ b/crates/pilotage-instrument-raster/src/timing/tests.rs
@@ -1,55 +1,96 @@
-//! The CI timing gate and the WCET pricing invariants.
+//! The CI envelope gate and the pricing invariants.
 #![allow(clippy::expect_used, clippy::panic)]
 
 use super::{CONSERVATIVE_CORTEX_M7_CLASS, CycleProvenance, TargetTimingModel};
 use crate::report::RenderWork;
 
 #[test]
-fn budget_wcet_meets_the_frame_deadline() {
-    // THE timing gate: the engineering work budget, priced by the recorded
-    // model, must fit the recorded frame deadline. Growing the budget or the
-    // cycle bounds past the deadline is a deterministic CI failure that
-    // forces a reasoned artifact update, never a silent regression.
+fn budget_envelope_fits_the_display_derived_deadline() {
+    // THE timing gate: the per-class work budget, priced by the recorded
+    // model, must fit the frame deadline derived from the SIM display
+    // liveness requirement. Growing a budget or a cycle bound past it is a
+    // deterministic CI failure that forces a reasoned artifact update,
+    // never a silent regression.
     let model = CONSERVATIVE_CORTEX_M7_CLASS;
     assert!(
-        model.meets_deadline(&RenderWork::BUDGET),
-        "budget WCET {} us exceeds the {} us frame deadline",
-        model.wcet_us(&RenderWork::BUDGET),
+        model.within_deadline(&RenderWork::BUDGET),
+        "budget envelope {} us exceeds the {} us frame deadline",
+        model.envelope_us(&RenderWork::BUDGET),
         model.frame_deadline_us,
     );
 }
 
 #[test]
-fn wcet_is_monotonic_in_the_counted_work() {
+fn the_envelope_is_monotonic_in_every_cost_class() {
     let model = CONSERVATIVE_CORTEX_M7_CLASS;
     let base = RenderWork {
         coverage_samples: 10,
-        edge_tests: 100,
+        polygon_edge_tests: 100,
+        stroke_segment_tests: 100,
+        disc_tests: 100,
+        arc_tests: 100,
         composites: 50,
     };
-    let more_edges = RenderWork {
-        edge_tests: 101,
-        ..base
-    };
-    let more_composites = RenderWork {
-        composites: 51,
-        ..base
-    };
-    assert!(model.wcet_cycles(&more_edges) > model.wcet_cycles(&base));
-    assert!(model.wcet_cycles(&more_composites) > model.wcet_cycles(&base));
+    let bumped = [
+        RenderWork {
+            polygon_edge_tests: 101,
+            ..base
+        },
+        RenderWork {
+            stroke_segment_tests: 101,
+            ..base
+        },
+        RenderWork {
+            disc_tests: 101,
+            ..base
+        },
+        RenderWork {
+            arc_tests: 101,
+            ..base
+        },
+        RenderWork {
+            composites: 51,
+            ..base
+        },
+    ];
+    for work in bumped {
+        assert!(model.envelope_cycles(&work) > model.envelope_cycles(&base));
+    }
 }
 
 #[test]
-fn wcet_saturates_instead_of_wrapping() {
-    // An absurd count must never wrap into a small, plausible-looking WCET.
+fn an_arc_test_is_priced_dearer_than_a_disc_test() {
+    // The review counterexample: an arc sample performs cap distances,
+    // atan2f, and fmodf beyond its disc test, so pricing an arc like a bare
+    // disc under-counts. The model must keep the arc class strictly dearer.
+    let model = CONSERVATIVE_CORTEX_M7_CLASS;
+    assert!(model.cycles_per_arc_test > model.cycles_per_disc_test);
+    let disc_only = RenderWork {
+        disc_tests: 1_000,
+        ..RenderWork::default()
+    };
+    let arc_heavy = RenderWork {
+        disc_tests: 1_000,
+        arc_tests: 1_000,
+        ..RenderWork::default()
+    };
+    assert!(model.envelope_cycles(&arc_heavy) > model.envelope_cycles(&disc_only));
+}
+
+#[test]
+fn the_envelope_saturates_instead_of_wrapping() {
+    // An absurd count must never wrap into a small, plausible-looking figure.
     let model = CONSERVATIVE_CORTEX_M7_CLASS;
     let absurd = RenderWork {
         coverage_samples: u64::MAX,
-        edge_tests: u64::MAX,
+        polygon_edge_tests: u64::MAX,
+        stroke_segment_tests: u64::MAX,
+        disc_tests: u64::MAX,
+        arc_tests: u64::MAX,
         composites: u64::MAX,
     };
-    assert_eq!(model.wcet_cycles(&absurd), u64::MAX);
-    assert!(!model.meets_deadline(&absurd));
+    assert_eq!(model.envelope_cycles(&absurd), u64::MAX);
+    assert!(!model.within_deadline(&absurd));
 }
 
 #[test]
@@ -60,14 +101,15 @@ fn a_sub_megahertz_clock_prices_to_the_failing_extreme() {
         cpu_hz: 999_999,
         ..CONSERVATIVE_CORTEX_M7_CLASS
     };
-    assert_eq!(model.wcet_us(&RenderWork::BUDGET), u64::MAX);
-    assert!(!model.meets_deadline(&RenderWork::BUDGET));
+    assert_eq!(model.envelope_us(&RenderWork::BUDGET), u64::MAX);
+    assert!(!model.within_deadline(&RenderWork::BUDGET));
 }
 
 #[test]
 fn the_shipped_model_is_a_conservative_bound_not_a_measurement() {
-    // Until a target is detected over USB CDC and measured, the shipped
-    // model must say so; a measured model carries the firmware identity.
+    // Until a target is detected over USB CDC and measured — with its
+    // firmware/build identity, MCU, clock and memory configuration, compiler
+    // flags, and raw output recorded — the shipped model must say so.
     assert_eq!(
         CONSERVATIVE_CORTEX_M7_CLASS.provenance,
         CycleProvenance::ConservativeBound
@@ -88,7 +130,8 @@ fn artifact_field(text: &str, field: &str) -> std::string::String {
 fn the_timing_artifact_matches_the_shipped_model() {
     // The committed timing artifact is the reviewable record of the model;
     // this guard fails CI when either side drifts, so the recorded bounds,
-    // budget, WCET, and deadline can never disagree with the shipped code.
+    // budgets, envelope, and deadline can never disagree with the shipped
+    // code.
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../docs/instruments/evidence-artifacts/timing/target-timing.txt");
     let text =
@@ -98,15 +141,27 @@ fn the_timing_artifact_matches_the_shipped_model() {
     assert_eq!(artifact_field(&text, "target"), model.name);
     assert_eq!(artifact_field(&text, "provenance"), "conservative-bound");
     let numbers = [
-        ("cpu-hz", model.cpu_hz),
-        ("cycles-per-edge-test", model.cycles_per_edge_test),
+        ("assumed-cpu-hz", model.cpu_hz),
+        (
+            "cycles-per-polygon-edge-test",
+            model.cycles_per_polygon_edge_test,
+        ),
+        (
+            "cycles-per-stroke-segment-test",
+            model.cycles_per_stroke_segment_test,
+        ),
+        ("cycles-per-disc-test", model.cycles_per_disc_test),
+        ("cycles-per-arc-test", model.cycles_per_arc_test),
         ("cycles-per-composite", model.cycles_per_composite),
         ("frame-overhead-cycles", model.frame_overhead_cycles),
         ("budget-coverage-samples", budget.coverage_samples),
-        ("budget-edge-tests", budget.edge_tests),
+        ("budget-polygon-edge-tests", budget.polygon_edge_tests),
+        ("budget-stroke-segment-tests", budget.stroke_segment_tests),
+        ("budget-disc-tests", budget.disc_tests),
+        ("budget-arc-tests", budget.arc_tests),
         ("budget-composites", budget.composites),
-        ("wcet-cycles", model.wcet_cycles(&budget)),
-        ("wcet-us", model.wcet_us(&budget)),
+        ("envelope-cycles", model.envelope_cycles(&budget)),
+        ("envelope-us", model.envelope_us(&budget)),
         ("frame-deadline-us", model.frame_deadline_us),
     ];
     for (field, expected) in numbers {

--- a/docs/instruments/evidence-artifacts/timing/target-timing.txt
+++ b/docs/instruments/evidence-artifacts/timing/target-timing.txt
@@ -1,46 +1,62 @@
 Pilotage evidence — target render timing model (SIM / NOT FOR FLIGHT)
 scope: REN-04
-artifact: conservative per-operation cycle bounds, frame deadline, derived WCET
-detection: usb-cdc scan (scripts/detect-target.sh) found no connected target, 2026-07-15
+artifact: per-class conservative cycle bounds, display-derived frame deadline,
+  and the resulting PROVISIONAL COST ENVELOPE (not a WCET claim)
+detection: usb-cdc scan (scripts/detect-target.sh) found no connected target,
+  2026-07-15; no identity handshake was therefore possible
 target: conservative-cortex-m7-class
 provenance: conservative-bound
-cpu-hz: 480000000
-cycles-per-edge-test: 48
-cycles-per-composite: 48
+assumed-cpu-hz: 480000000
+cycles-per-polygon-edge-test: 40
+cycles-per-stroke-segment-test: 80
+cycles-per-disc-test: 60
+cycles-per-arc-test: 240
+cycles-per-composite: 80
 frame-overhead-cycles: 2000000
 budget-coverage-samples: 1100000
-budget-edge-tests: 4000000
+budget-polygon-edge-tests: 3600000
+budget-stroke-segment-tests: 250000
+budget-disc-tests: 175000
+budget-arc-tests: 175000
 budget-composites: 900000
-wcet-cycles: 237200000
-wcet-us: 494167
-frame-deadline-us: 600000
+envelope-cycles: 290500000
+envelope-us: 605209
+frame-deadline-us: 1000000
+deadline-source: SIM display liveness requirement — PanelHealth
+  livenessDeadlineMs = 1000 ms (clients/web/instrument-health.js); a panel
+  whose frame generation has not advanced within it fails LIVENESS, so
+  producing one frame must fit inside it. The deadline is not derived from
+  this envelope and predates it; a selected display's refresh requirement
+  will replace it.
 rationale:
-- The counted operation is the per-edge/segment/disc test inside a coverage
-  evaluation (RenderWork::edge_tests), not the coverage sample: a polygon
-  sample walks every edge while an arc sample tests one disc, so only the
-  edge test has a bounded per-operation cost.
-- cycles-per-edge-test 48 bounds the worst predicate on a zero-wait-state
-  Cortex-M7-class core: a winding edge test is integer compares plus two
-  widening multiplies (~20 cycles), a stroke segment distance is short f32
-  arithmetic with one divide (~40), an arc disc test is one sqrtf plus
-  compares (~35), each plus its share of the sample-loop overhead.
-- cycles-per-composite 48 bounds the 4-byte source-over read-modify-write
-  with div255 blend chains.
-- frame-overhead-cycles 2000000 covers the 480x360 frame clear and maximal
-  command dispatch, independent of scene density.
-- All bounds assume code and framebuffer in zero-wait RAM; flash wait states
-  and cache effects must be re-validated when a target is measured.
-- Derived: WCET(budget) = 4000000*48 + 900000*48 + 2000000 = 237200000
-  cycles = 494167 us at 480 MHz, an implied full-redraw ceiling of ~2 Hz for
-  the 2x-headroom work budget on this conservative model. The recorded
-  600000 us deadline is therefore an ANTI-REGRESSION envelope for the
-  conservative model only — not a display-suitability, refresh-rate, or
-  airworthiness claim. Hardware selection follows measurement: a measured
-  model (provenance measured-usb-cdc, carrying the firmware identity) is
-  expected to price substantially tighter, and the display deadline then
-  becomes the real requirement together with a partial-redraw or
-  hardware-acceleration decision.
-gate: timing::tests::budget_wcet_meets_the_frame_deadline and the artifact
-  drift guard timing::tests::the_timing_artifact_matches_the_shipped_model
-  (crates/pilotage-instrument-raster) fail CI when the model, the work
-  budget, or this record disagree.
+- The work is counted per cost class (RenderWork): integer polygon winding
+  edge tests, f32 stroke segment-distance tests, circle/arc disc tests, arc
+  angular-membership extras (two cap sqrtf, atan2f, fmodf — priced as their
+  own class so an arc sample is never billed as a bare disc test), and
+  source-over composites. Counting is worst-case per sample so predicate
+  early exits never under-count, and the counters are a pure function of
+  scene bytes and dimensions.
+- Each cycle bound is a zero-wait instruction-level estimate DOUBLED as a
+  memory-system allowance (flash wait states, cache misses, framebuffer
+  traffic): winding edge ~20 -> 40; stroke segment ~40 -> 80; disc ~30 -> 60;
+  arc extras ~120 -> 240; composite ~40 -> 80. These are engineering bounds
+  with rationale, not measurements.
+- assumed-cpu-hz 480000000 is the Cortex-M7 class ceiling and is an
+  ASSUMPTION: a slower configured clock lengthens the envelope
+  proportionally. It binds only after measurement on the selected target.
+- Class budgets are 2x the worse of the PFD/HSI demo fixtures at 480x360
+  (PFD measures 547549 samples / 1780493 polygon edge tests / 115506 stroke
+  segment tests / 84681 disc tests / 84681 arc tests / 433729 composites).
+- Derived: envelope(budget) = 3600000*40 + 250000*80 + 175000*60 +
+  175000*240 + 900000*80 + 2000000 = 290500000 cycles = 605209 us at the
+  assumed clock — inside the 1000000 us liveness deadline, with the margin
+  consumed as the deadline tightens to a real display refresh requirement.
+- A measured model (provenance measured-usb-cdc) must record the firmware
+  identity and build hash reported over the CDC handshake, the MCU part, the
+  measured clock and cache/flash/memory configuration, the compiler and
+  flags, and the committed raw measurement output; only then does the priced
+  figure become a WCET claim and the deadline a display requirement.
+gate: timing::tests::budget_envelope_fits_the_display_derived_deadline and
+  the drift guard timing::tests::the_timing_artifact_matches_the_shipped_model
+  (crates/pilotage-instrument-raster) fail CI when the model, the budgets, or
+  this record disagree.

--- a/docs/instruments/evidence-artifacts/timing/target-timing.txt
+++ b/docs/instruments/evidence-artifacts/timing/target-timing.txt
@@ -1,0 +1,46 @@
+Pilotage evidence — target render timing model (SIM / NOT FOR FLIGHT)
+scope: REN-04
+artifact: conservative per-operation cycle bounds, frame deadline, derived WCET
+detection: usb-cdc scan (scripts/detect-target.sh) found no connected target, 2026-07-15
+target: conservative-cortex-m7-class
+provenance: conservative-bound
+cpu-hz: 480000000
+cycles-per-edge-test: 48
+cycles-per-composite: 48
+frame-overhead-cycles: 2000000
+budget-coverage-samples: 1100000
+budget-edge-tests: 4000000
+budget-composites: 900000
+wcet-cycles: 237200000
+wcet-us: 494167
+frame-deadline-us: 600000
+rationale:
+- The counted operation is the per-edge/segment/disc test inside a coverage
+  evaluation (RenderWork::edge_tests), not the coverage sample: a polygon
+  sample walks every edge while an arc sample tests one disc, so only the
+  edge test has a bounded per-operation cost.
+- cycles-per-edge-test 48 bounds the worst predicate on a zero-wait-state
+  Cortex-M7-class core: a winding edge test is integer compares plus two
+  widening multiplies (~20 cycles), a stroke segment distance is short f32
+  arithmetic with one divide (~40), an arc disc test is one sqrtf plus
+  compares (~35), each plus its share of the sample-loop overhead.
+- cycles-per-composite 48 bounds the 4-byte source-over read-modify-write
+  with div255 blend chains.
+- frame-overhead-cycles 2000000 covers the 480x360 frame clear and maximal
+  command dispatch, independent of scene density.
+- All bounds assume code and framebuffer in zero-wait RAM; flash wait states
+  and cache effects must be re-validated when a target is measured.
+- Derived: WCET(budget) = 4000000*48 + 900000*48 + 2000000 = 237200000
+  cycles = 494167 us at 480 MHz, an implied full-redraw ceiling of ~2 Hz for
+  the 2x-headroom work budget on this conservative model. The recorded
+  600000 us deadline is therefore an ANTI-REGRESSION envelope for the
+  conservative model only — not a display-suitability, refresh-rate, or
+  airworthiness claim. Hardware selection follows measurement: a measured
+  model (provenance measured-usb-cdc, carrying the firmware identity) is
+  expected to price substantially tighter, and the display deadline then
+  becomes the real requirement together with a partial-redraw or
+  hardware-acceleration decision.
+gate: timing::tests::budget_wcet_meets_the_frame_deadline and the artifact
+  drift guard timing::tests::the_timing_artifact_matches_the_shipped_model
+  (crates/pilotage-instrument-raster) fail CI when the model, the work
+  budget, or this record disagree.

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -78,12 +78,20 @@ is `panel_fixtures_fit_within_work_budget` (with
 budget is a hard CI failure with instructions to investigate the scene or the
 region loops before raising the constant.
 
-The WCET for a specific target is the counted work multiplied by the selected
-target's per-operation cycle bound; measured cycle costs and the final WCET wait
-for hardware selection and are out of scope here. Frame time is one of the gated
-budgets: a target that cannot meet its frame deadline fails, and the browser
-watchdog (`PanelHealth`, simulator-only) latches a stalled panel as `LIVENESS`
-past its deadline.
+The WCET for a specific target is the counted work multiplied by the target's
+per-operation cycle bound. `RenderWork::edge_tests` counts the priced unit (a
+polygon sample walks every edge; an arc sample tests one disc), and
+`timing::TargetTimingModel` derives the WCET and gates it against a recorded
+frame deadline (`budget_wcet_meets_the_frame_deadline`). No display hardware is
+selected yet — the USB CDC scan (`scripts/detect-target.sh`) detects a
+connected target rather than asking — so the shipped model is the named
+conservative bound recorded, with its rationale and derived WCET, in
+`docs/instruments/evidence-artifacts/timing/target-timing.txt`; a drift guard
+keeps that artifact equal to the shipped constants. The recorded deadline is an
+anti-regression envelope for the conservative model, not a display-suitability
+claim; a measured target replaces the bounds and tightens the deadline to the
+display requirement. The browser watchdog (`PanelHealth`, simulator-only)
+latches a stalled panel as `LIVENESS` past its deadline.
 
 ## The conformance corpus
 

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -78,20 +78,25 @@ is `panel_fixtures_fit_within_work_budget` (with
 budget is a hard CI failure with instructions to investigate the scene or the
 region loops before raising the constant.
 
-The WCET for a specific target is the counted work multiplied by the target's
-per-operation cycle bound. `RenderWork::edge_tests` counts the priced unit (a
-polygon sample walks every edge; an arc sample tests one disc), and
-`timing::TargetTimingModel` derives the WCET and gates it against a recorded
-frame deadline (`budget_wcet_meets_the_frame_deadline`). No display hardware is
+The per-frame cost for a specific target is the counted work priced per cost
+class. `RenderWork` counts polygon edge tests, stroke segment tests, disc
+tests, arc angular extras (cap distances, `atan2f`, `fmodf` — their own class,
+so an arc sample is never billed as a bare disc test), and composites;
+`timing::TargetTimingModel` derives a **provisional cost envelope** — not a
+WCET claim until per-operation cycles are measured on selected hardware — and
+gates it against the frame deadline derived from the SIM display liveness
+requirement (`PanelHealth` `livenessDeadlineMs` = 1000 ms:
+`budget_envelope_fits_the_display_derived_deadline`). No display hardware is
 selected yet — the USB CDC scan (`scripts/detect-target.sh`) detects a
-connected target rather than asking — so the shipped model is the named
-conservative bound recorded, with its rationale and derived WCET, in
+connected target and attempts an identity handshake rather than asking — so
+the shipped model is the named conservative bound recorded, with its
+assumptions and derivation, in
 `docs/instruments/evidence-artifacts/timing/target-timing.txt`; a drift guard
-keeps that artifact equal to the shipped constants. The recorded deadline is an
-anti-regression envelope for the conservative model, not a display-suitability
-claim; a measured target replaces the bounds and tightens the deadline to the
-display requirement. The browser watchdog (`PanelHealth`, simulator-only)
-latches a stalled panel as `LIVENESS` past its deadline.
+keeps that artifact equal to the shipped constants. A measured model must bind
+the firmware/build identity, MCU, clock and memory configuration, compiler
+flags, and raw output; only then does the envelope become a WCET and the
+deadline a display refresh requirement. The browser watchdog (`PanelHealth`,
+simulator-only) latches a stalled panel as `LIVENESS` past its deadline.
 
 ## The conformance corpus
 

--- a/scripts/detect-target.sh
+++ b/scripts/detect-target.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # Detect a connected render target over USB CDC — detect, never ask.
 #
-# Prints any CDC serial devices present (macOS and Linux names). Detection is
-# informational: the timing gate itself is the deterministic cargo test
-# `timing::tests::budget_wcet_meets_the_frame_deadline`, and the detection
-# outcome is recorded in
-# docs/instruments/evidence-artifacts/timing/target-timing.txt. When a target
-# IS connected, measure per-operation cycles on it and replace the
-# conservative-bound model with a measured-usb-cdc one.
+# Scans the CDC serial device names (macOS and Linux) and, for each device,
+# attempts an identity handshake: the port is configured raw at 115200 and any
+# identity banner the firmware emits is read with a short timeout. Detection
+# is informational: the envelope gate itself is the deterministic cargo test
+# `timing::tests::budget_envelope_fits_the_display_derived_deadline`, and the
+# detection outcome is recorded in
+# docs/instruments/evidence-artifacts/timing/target-timing.txt.
+#
+# A measured timing model (provenance measured-usb-cdc) requires the firmware
+# to report, and the artifact to record: firmware identity + build hash, MCU
+# part, configured core clock, compiler and flags, cache/flash/memory state,
+# and the committed raw measurement output.
 set -u
 
 found=0
@@ -15,13 +20,25 @@ for dev in /dev/ttyACM* /dev/ttyUSB* /dev/cu.usbmodem* /dev/cu.usbserial*; do
   [ -e "$dev" ] || continue
   found=1
   echo "usb-cdc: $dev"
+  # Configure the port (either stty dialect) and read an identity banner.
+  stty -f "$dev" 115200 raw -echo 2>/dev/null \
+    || stty -F "$dev" 115200 raw -echo 2>/dev/null \
+    || true
+  banner=""
+  if IFS= read -r -t 2 banner < "$dev" 2>/dev/null && [ -n "$banner" ]; then
+    echo "  identity banner: $banner"
+    echo "  -> measure per-operation cycles on this target and record a"
+    echo "     measured-usb-cdc model (firmware/build hash, MCU, clock,"
+    echo "     compiler flags, memory state, raw output) in the timing artifact"
+  else
+    echo "  no identity banner within 2s — unidentified device; it cannot"
+    echo "  ground a measured timing model until its firmware reports an"
+    echo "  identity over CDC"
+  fi
 done
 
 if [ "$found" -eq 0 ]; then
-  echo "usb-cdc: no target connected; the conservative-bound timing model applies"
-else
-  echo "usb-cdc: target present — measure per-operation cycles on it and update"
-  echo "         docs/instruments/evidence-artifacts/timing/target-timing.txt"
-  echo "         (provenance: measured-usb-cdc, with the firmware identity)"
+  echo "usb-cdc: no target connected; the conservative-bound model and its"
+  echo "         provisional cost envelope apply (not a WCET claim)"
 fi
 exit 0

--- a/scripts/detect-target.sh
+++ b/scripts/detect-target.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Detect a connected render target over USB CDC — detect, never ask.
+#
+# Prints any CDC serial devices present (macOS and Linux names). Detection is
+# informational: the timing gate itself is the deterministic cargo test
+# `timing::tests::budget_wcet_meets_the_frame_deadline`, and the detection
+# outcome is recorded in
+# docs/instruments/evidence-artifacts/timing/target-timing.txt. When a target
+# IS connected, measure per-operation cycles on it and replace the
+# conservative-bound model with a measured-usb-cdc one.
+set -u
+
+found=0
+for dev in /dev/ttyACM* /dev/ttyUSB* /dev/cu.usbmodem* /dev/cu.usbserial*; do
+  [ -e "$dev" ] || continue
+  found=1
+  echo "usb-cdc: $dev"
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "usb-cdc: no target connected; the conservative-bound timing model applies"
+else
+  echo "usb-cdc: target present — measure per-operation cycles on it and update"
+  echo "         docs/instruments/evidence-artifacts/timing/target-timing.txt"
+  echo "         (provenance: measured-usb-cdc, with the firmware identity)"
+fi
+exit 0


### PR DESCRIPTION
Begins the target timing work for #30 (**refs #30, does not close it** — #30 stays open pending a real USB CDC target identity, a bound measurement artifact, a real display deadline, and a possible hardware-acceleration decision).

## What changed

- **Per-class counted work** — `RenderWork` counts each cost class separately: integer polygon winding edge tests, f32 stroke segment-distance tests, circle/arc disc tests, **arc angular extras** (two cap `sqrtf`s, `atan2f`, `fmodf` — their own class, so an arc sample is never billed as a bare disc test), and source-over composites. Counting is worst-case per sample (early exits never under-count) and stays a pure function of scene bytes and dimensions — the gate cannot flake. Measured fixture split (PFD @480×360): 1,780,493 polygon-edge / 115,506 stroke-segment / 84,681 disc / 84,681 arc / 433,729 composites; each class budget is 2× the worse of the PFD/HSI fixtures.
- **Provisional cost envelope, not WCET** — `timing::TargetTimingModel` prices each class with its own conservative bound, stated as a zero-wait instruction estimate **doubled** as a memory-system allowance (polygon edge 40, stroke segment 80, disc 60, arc 240, composite 80 cycles), plus a fixed frame overhead. The API says what it is: `envelope_cycles` / `envelope_us` / `within_deadline`. The 480 MHz clock is recorded as an **assumption** the envelope scales against, not a fact. A WCET claim requires measured provenance.
- **Typed measurement binding** — `CycleProvenance::MeasuredUsbCdc` is a struct requiring the firmware identity + build hash reported over the CDC handshake, the MCU part, the measured clock, the compiler and flags, the cache/flash/memory state, and the committed raw measurement output path. A measurement that cannot state its configuration is not a measurement.
- **Deadline derived from a requirement, never from the envelope** — the frame deadline is the pre-existing SIM display liveness requirement (`PanelHealth livenessDeadlineMs = 1000 ms`, `clients/web/instrument-health.js`): a panel that cannot produce a frame inside it fails LIVENESS. The envelope prices at 605,209 µs against that 1,000,000 µs deadline — non-circular, with the margin consumed as the deadline tightens to a selected display's refresh requirement.
- **Detection, not asking** — `scripts/detect-target.sh` scans CDC device names and attempts an identity handshake (raw 115200, 2 s banner read); an unidentified device is reported as unable to ground a measured model. No target is currently connected, and the artifact records that.
- **Artifact + drift guard + CI gate** — `docs/instruments/evidence-artifacts/timing/target-timing.txt` records the detection outcome, per-class bounds with rationale, assumptions, budgets, the derived envelope, and the deadline source; `the_timing_artifact_matches_the_shipped_model` fails CI on any drift, and the `target timing gate (REN-04)` CI step runs the detection plus the envelope gate (`budget_envelope_fits_the_display_derived_deadline`).

## Verification

Isolated-worktree full CI: `cargo check --locked`, fmt, clippy `-D warnings`, all test suites 0 failures, doc gates, `check-structure.sh`, thumbv7em no_std check (the timing module is `no_std`), release build. Conformance goldens unaffected — the counters change no painted bytes. A regression test pins that an arc test is priced strictly dearer than a disc test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)