### PR TITLE
LINK-02: accept a page-rounded Aviate shm capacity (#99)

### DIFF
--- a/adapters/aviate/src/error.rs
+++ b/adapters/aviate/src/error.rs
@@ -38,14 +38,17 @@ pub enum AviateAdapterError {
         #[source]
         source: std::io::Error,
     },
-    /// The shared-memory object's ABI size does not match the reader.
-    #[error("Aviate state shm {name} has {actual} bytes; expected {expected}")]
-    ShmSizeMismatch {
+    /// The shared-memory object is too small to back the reader's mapping.
+    /// This is a capacity check, not a layout/version check: it proves only
+    /// that at least `required` bytes are present, never that the block's
+    /// fields match (that gate is Aviate#262).
+    #[error("Aviate state shm {name} reports {observed} bytes; needs at least {required}")]
+    ShmCapacityTooSmall {
         /// The POSIX shm object name.
         name: String,
-        /// Required byte size.
-        expected: usize,
-        /// Observed byte size.
-        actual: u64,
+        /// Byte count the reader must be able to map.
+        required: usize,
+        /// The kernel-reported object size (`st_size`), which may be negative.
+        observed: i64,
     },
 }

--- a/adapters/aviate/src/error.rs
+++ b/adapters/aviate/src/error.rs
@@ -39,9 +39,9 @@ pub enum AviateAdapterError {
         source: std::io::Error,
     },
     /// The shared-memory object is too small to back the reader's mapping.
-    /// This is a capacity check, not a layout/version check: it proves only
-    /// that at least `required` bytes are present, never that the block's
-    /// fields match (that gate is Aviate#262).
+    /// This is a capacity check, not a layout/version check: capacity does
+    /// not establish layout compatibility — it proves only that at least
+    /// `required` bytes are present, never that the block's fields match.
     #[error("Aviate state shm {name} reports {observed} bytes; needs at least {required}")]
     ShmCapacityTooSmall {
         /// The POSIX shm object name.

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -24,11 +24,29 @@ const fn device_identity(device: libc::dev_t) -> u64 {
     device as u64
 }
 
-/// Byte size of `AviateSharedState` (natural C alignment, all fields
-/// 8-byte aligned or packed tail).
+/// Byte count the reader maps and reads from `AviateSharedState`. This size and
+/// the `OFF_*` offsets below are a PROVISIONAL hand-mirror of the producer's
+/// `shared_state.h`; they are not validated against a magic/version/declared
+/// size, so a producer layout change is not detected here (that gate is
+/// Aviate#262). The capacity check only proves the object is large enough to
+/// map, never that these offsets are still correct.
 const SHM_SIZE: usize = 216;
 
-// Field offsets in `AviateSharedState` (shared_state.h).
+/// Whether a POSIX shm object whose kernel-reported `st_size` is `st_size`
+/// bytes can back a `required`-byte read-only mapping, returning the admitted
+/// capacity. This is a CAPACITY decision only: the kernel may page-round the
+/// object up (a 216-byte `ftruncate` reports `st_size = 16384` on a 16 KiB
+/// page), so any capacity at least `required` is admitted and only `required`
+/// bytes are ever mapped. A negative `st_size` (which must never be coerced to
+/// a huge unsigned value) or one smaller than `required` is refused. It makes
+/// no claim about field layout or version.
+fn admissible_capacity(st_size: i64, required: usize) -> Option<u64> {
+    let capacity = u64::try_from(st_size).ok()?;
+    (capacity >= required as u64).then_some(capacity)
+}
+
+// Field offsets in `AviateSharedState` (shared_state.h) — provisional, see
+// `SHM_SIZE`.
 const OFF_POS: usize = 0; // double[3]
 const OFF_QUAT: usize = 24; // double[4] (w, x, y, z), ENU/FLU
 const OFF_VEL: usize = 56; // double[3], ENU world
@@ -94,7 +112,7 @@ impl GzStateShm {
     /// # Errors
     ///
     /// Returns a typed [`AviateAdapterError`] when the region does not
-    /// exist, its ABI size differs, or it cannot be mapped.
+    /// exist, is too small to back the mapping, or cannot be mapped.
     pub fn open(instance: u8) -> Result<Self, AviateAdapterError> {
         let name = if instance == 0 {
             "/aviate_gz_bridge".to_owned()
@@ -130,15 +148,14 @@ impl GzStateShm {
                 });
             }
             let metadata = metadata.assume_init();
-            let size = u64::try_from(metadata.st_size).unwrap_or(u64::MAX);
-            if size != SHM_SIZE as u64 {
+            let Some(capacity) = admissible_capacity(metadata.st_size, SHM_SIZE) else {
                 libc::close(fd);
-                return Err(AviateAdapterError::ShmSizeMismatch {
+                return Err(AviateAdapterError::ShmCapacityTooSmall {
                     name,
-                    expected: SHM_SIZE,
-                    actual: size,
+                    required: SHM_SIZE,
+                    observed: metadata.st_size,
                 });
-            }
+            };
             let ptr = libc::mmap(
                 std::ptr::null_mut(),
                 SHM_SIZE,
@@ -160,7 +177,7 @@ impl GzStateShm {
                 ShmIdentity {
                     device: device_identity(metadata.st_dev),
                     inode: metadata.st_ino,
-                    size,
+                    size: capacity,
                 },
             )
         };

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -24,12 +24,12 @@ const fn device_identity(device: libc::dev_t) -> u64 {
     device as u64
 }
 
-/// Byte count the reader maps and reads from `AviateSharedState`. This size and
-/// the `OFF_*` offsets below are a PROVISIONAL hand-mirror of the producer's
-/// `shared_state.h`; they are not validated against a magic/version/declared
-/// size, so a producer layout change is not detected here (that gate is
-/// Aviate#262). The capacity check only proves the object is large enough to
-/// map, never that these offsets are still correct.
+/// Byte count the reader maps and reads from `AviateSharedState`. This size
+/// and the `OFF_*` offsets below hand-mirror the producer's `shared_state.h`
+/// and are not validated against a magic/version/declared-size header, so a
+/// producer layout change is not detected here. Capacity does not establish
+/// layout compatibility: the check below only proves the object is large
+/// enough to map, never that these offsets are still correct.
 const SHM_SIZE: usize = 216;
 
 /// Whether a POSIX shm object whose kernel-reported `st_size` is `st_size`

--- a/adapters/aviate/src/shm/tests.rs
+++ b/adapters/aviate/src/shm/tests.rs
@@ -2,7 +2,27 @@
 
 use std::time::{Duration, Instant};
 
-use super::{SHM_SIZE, ShmFreshness, ShmObservation, decode_sample, enu_quat_to_ned, enu_to_ned};
+use super::{
+    SHM_SIZE, ShmFreshness, ShmObservation, admissible_capacity, decode_sample, enu_quat_to_ned,
+    enu_to_ned,
+};
+
+#[test]
+fn capacity_rejects_negative_and_short_admits_exact_and_page_rounded() {
+    // A negative st_size must never be coerced to a huge unsigned capacity.
+    assert_eq!(admissible_capacity(-1, SHM_SIZE), None);
+    assert_eq!(admissible_capacity(i64::MIN, SHM_SIZE), None);
+    // One byte short of the required block is refused.
+    assert_eq!(admissible_capacity(SHM_SIZE as i64 - 1, SHM_SIZE), None);
+    // Exactly the required size is admitted.
+    assert_eq!(
+        admissible_capacity(SHM_SIZE as i64, SHM_SIZE),
+        Some(SHM_SIZE as u64)
+    );
+    // A page-rounded object (16 KiB page on Apple Silicon for a 216-byte
+    // ftruncate) is admitted; the mapping still reads only SHM_SIZE bytes.
+    assert_eq!(admissible_capacity(16384, SHM_SIZE), Some(16384));
+}
 
 fn put_f64(buf: &mut [u8; SHM_SIZE], off: usize, v: f64) {
     buf[off..off + 8].copy_from_slice(&v.to_ne_bytes());


### PR DESCRIPTION
Split out of #97 per the review verdict. Narrow `adapters/aviate/src/shm.rs` change (LINK-02).

## Problem
The aviate adapter opened `/aviate_gz_bridge`, then rejected it on an exact `st_size == 216` check. macOS page-rounds a shm object (a 216-byte `ftruncate` reports `st_size = 16384` on a 16 KiB page), so the check always failed and the adapter silently fell back to MAVLink, where no telemetry flows. The old code also coerced a negative `st_size` to `u64::MAX` (which would be accepted), and its comment called `actual >= 216` a layout check.

## Fix
- Extract a testable `admissible_capacity(st_size: i64, required) -> Option<u64>`: refuses a negative or too-small size, accepts an exact or page-rounded one, and maps only the required byte count.
- Rename the error to `ShmCapacityTooSmall { required, observed: i64 }` so a negative size reports honestly.
- Mark the 216-byte size and the `OFF_*` offsets explicitly provisional: `actual >= required` proves only "big enough to map", never that the fields still match. The magic/version/declared-size gate remains Aviate#262.

## Tests
`admissible_capacity` counterexamples: negative, one-byte-short (215), exact (216), and page-rounded (16384). Verified live against the running host — the fixed adapter attaches to the shm state block and telemetry flows.

Does not wait for Aviate#262. Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
