### PR TITLE
VID-04: initialize H.264 ownership after wasm startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,13 @@ jobs:
         # output, at the recorded dimensions, and closed by the adapter.
         run: node clients/web/video-h264.browser.test.mjs
 
+      - name: viewer entrypoint boot contract (VID-04)
+        # A real browser loads the unmodified index.html + main.js: module
+        # evaluation must complete with no wasm-backed object constructed
+        # before wasm init, a good wasm load ends in live panels, and a
+        # failed wasm load degrades visibly without killing the viewer.
+        run: node clients/web/viewer-boot.browser.test.mjs
+
       - name: browser snapshot-association tests (HUD-01)
         run: node clients/web/snapshot-association.test.mjs
 

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -106,6 +106,10 @@ const state = {
   connected: false,
   leaseGranted: false,
   skippedVideoFrames: 0,
+  // Page-lifetime latch: wasm absence never heals without a reload (the
+  // instrument module loads once at boot), so the H.264-unavailable notice
+  // is worth one line, not one line per frame at stream rate.
+  h264UnavailableLogged: false,
   droppedIdentityFrames: 0,
   // Latest capture-to-snapshot association verdict for an accepted frame
   // (ADR-0020), a diagnostic surface only — no conformal overlay is drawn yet.
@@ -158,7 +162,7 @@ function retireSessionPresentation(phase) {
   turnDerivation.reset();
   // Close every H.264 decoder so none outlives the session that owned it; a
   // reconnect rebuilds them bound to the new session token.
-  h264Registry.closeAll();
+  h264Registry?.closeAll();
   setTelemetrySessionState(els, phase);
 }
 
@@ -483,13 +487,21 @@ const VIDEO_TARGETS = {
 // (H264DecoderRegistry owns that lifetime — see video-h264.js). A source that
 // only ever carries MJPEG never constructs one. The decoder's output callback
 // tests its own session's liveness, so a reconnect's fresh decoder supersedes
-// any retired one.
-const h264Registry = new H264DecoderRegistry((target, token) =>
-  new H264CanvasDecoder(target, {
-    log: (message) => log(message),
-    isActive: () => transportSessions.isActive(token),
-  }),
-);
+// any retired one. The registry's ownership table lives in the instrument
+// wasm, so construction must wait for that module to initialize — constructing
+// it here would trap on the uninitialized wasm binding and take the whole
+// viewer module down with it. Until the wasm is ready (or if it fails to
+// load), the H.264 path skips frames visibly; MJPEG is unaffected.
+let h264Registry = null;
+
+function buildH264Registry() {
+  return new H264DecoderRegistry((target, token) =>
+    new H264CanvasDecoder(target, {
+      log: (message) => log(message),
+      isActive: () => transportSessions.isActive(token),
+    }),
+  );
+}
 
 /** Decodes one MJPEG payload and blits it to `target`, resizing its canvas to
  *  the frame. Session-token checked around the async decode so a frame decoded
@@ -519,6 +531,14 @@ async function paintByCodec(fourcc, payload, sourceId, target, token) {
     return;
   }
   if (fourcc === FOURCC_H264) {
+    if (!h264Registry) {
+      state.skippedVideoFrames += 1;
+      if (!state.h264UnavailableLogged) {
+        state.h264UnavailableLogged = true;
+        log("H.264 decode unavailable (instrument wasm not loaded); skipping H.264 frames silently");
+      }
+      return;
+    }
     h264Registry.for(sourceId, target, token).decode(payload);
     return;
   }
@@ -613,7 +633,7 @@ async function renderVideoFrameV2(body, token) {
     log(`video source ${meta.sourceId} capture discontinuity: fresh epoch/incarnation/calibration`);
     // A discontinuity is a GOP boundary an H.264 decoder cannot span; drop this
     // source's decoder so the next keyframe reconfigures a fresh one (MJPEG: no-op).
-    h264Registry.reset(meta.sourceId);
+    h264Registry?.reset(meta.sourceId);
   }
   state.lastAssociation = association;
   if (!association.ready) {
@@ -1118,6 +1138,7 @@ async function startInstruments() {
     // cached copy (a 304 keeps it cheap when unchanged).
     const wasmSource = await fetch("./instrument-runtime_bg.wasm", { cache: "no-cache" });
     instruments.mod = await loadInstruments(wasmSource);
+    h264Registry = buildH264Registry();
     const nowMs = performance.now();
     for (const health of Object.values(instruments.health)) health.reset(nowMs);
     setInterval(watchdogTick, WATCHDOG_INTERVAL_MS);

--- a/clients/web/viewer-boot.browser.test.mjs
+++ b/clients/web/viewer-boot.browser.test.mjs
@@ -1,0 +1,249 @@
+// Boundary test for viewer startup: a real Chromium loads the REAL
+// entrypoint (index.html + main.js, unmodified) and this driver asserts the
+// boot contract that unit tests cannot see — module evaluation must complete
+// (no wasm-backed object may be constructed before the instrument wasm
+// initializes), a successful wasm load must end in live panels, and a failed
+// wasm load must degrade visibly without killing the rest of the viewer.
+// The server injects only observation scaffolding around the untouched page:
+// an error-capture prelude ahead of the entrypoint and a result-reporting
+// probe behind it.
+//
+// Fail closed: no usable Chromium (set CHROME to override discovery) is a
+// test failure, not a skip — CI must actually boot the viewer.
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const webRoot = dirname(fileURLToPath(import.meta.url));
+const TEST_PORT_PARAM = "4433";
+const TEST_CERT_PARAM = "a".repeat(64);
+
+let failures = 0;
+function check(name, ok) {
+  if (ok) {
+    console.log(`ok - ${name}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL - ${name}`);
+  }
+}
+
+function chromeBinary() {
+  const candidates = [
+    process.env.CHROME,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium-browser",
+    "/usr/bin/chromium",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  console.error(
+    `FAIL - no Chromium found (set CHROME to a binary; searched ${candidates.join(", ")})`,
+  );
+  process.exit(1);
+}
+
+const contentTypes = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".wasm": "application/wasm",
+  ".json": "application/json",
+};
+
+// Runs before the entrypoint module: uncaught exceptions and unhandled
+// rejections during boot are the exact failure class this test exists for.
+const errorCapturePrelude = `<script>
+window.__bootErrors = [];
+addEventListener("error", (e) => window.__bootErrors.push(String(e.error ?? e.message)));
+addEventListener("unhandledrejection", (e) => window.__bootErrors.push("unhandledrejection: " + String(e.reason)));
+</script>`;
+
+// Runs after the entrypoint module graph: waits for the instrument boot to
+// settle either way, then reports what the page actually reached.
+const resultProbe = `<script type="module">
+const deadline = Date.now() + 20000;
+const statusText = () => document.getElementById("status")?.textContent ?? "";
+const settled = () =>
+  statusText().includes("instrument panels ready") ||
+  statusText().includes("instrument panels unavailable");
+while (!settled() && Date.now() < deadline) {
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+let canvasUsable = false;
+try {
+  canvasUsable = Boolean(document.getElementById("video")?.getContext("2d"));
+} catch {}
+await fetch("/boot-result", {
+  method: "POST",
+  body: JSON.stringify({
+    bootErrors: window.__bootErrors,
+    port: document.getElementById("port")?.value ?? null,
+    cert: document.getElementById("certHash")?.value ?? null,
+    ready: statusText().includes("instrument panels ready (wasm loaded)"),
+    unavailable: statusText().includes("instrument panels unavailable"),
+    canvasUsable,
+  }),
+});
+</script>`;
+
+const ENTRYPOINT_TAG = '<script type="module" src="./main.js"></script>';
+
+function instrumentedIndex() {
+  const raw = readFileSync(join(webRoot, "index.html"), "utf8");
+  if (!raw.includes(ENTRYPOINT_TAG)) {
+    console.error(`FAIL - index.html no longer contains ${ENTRYPOINT_TAG}; update this test's anchor`);
+    process.exit(1);
+  }
+  return raw.replace(
+    ENTRYPOINT_TAG,
+    `${errorCapturePrelude}\n${ENTRYPOINT_TAG}\n${resultProbe}`,
+  );
+}
+
+/** Boots the real viewer against a static server and reports the probe's
+ *  observation. `serveWasm: false` answers the wasm fetch with 404 to drive
+ *  the wasm-load-failure path. */
+async function bootScenario({ label, serveWasm }) {
+  let resolveResult;
+  const result = new Promise((resolve) => {
+    resolveResult = resolve;
+  });
+
+  const page = instrumentedIndex();
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/boot-result") {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.writeHead(204).end();
+        resolveResult(JSON.parse(body));
+      });
+      return;
+    }
+    const path = (req.url ?? "/").split("?")[0];
+    if (path === "/" || path === "/index.html") {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(page);
+      return;
+    }
+    if (!serveWasm && path === "/instrument-runtime_bg.wasm") {
+      res.writeHead(404).end();
+      return;
+    }
+    // Serve the real clients/web tree, jailed to webRoot; anything the page
+    // asks for beyond it (favicon and the like) is a plain 404.
+    const resolved = normalize(join(webRoot, path));
+    const dot = resolved.lastIndexOf(".");
+    const contentType = dot >= 0 ? contentTypes[resolved.slice(dot)] : undefined;
+    if (!resolved.startsWith(webRoot) || !contentType || !existsSync(resolved)) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200, { "content-type": contentType });
+    res.end(readFileSync(resolved));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const url = `${origin}/index.html?host=127.0.0.1&port=${TEST_PORT_PARAM}&cert=${TEST_CERT_PARAM}`;
+
+  const profile = mkdtempSync(join(tmpdir(), "pilotage-boot-chrome-"));
+  const chrome = spawn(
+    chromeBinary(),
+    [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--no-first-run",
+      "--disable-extensions",
+      "--mute-audio",
+      `--user-data-dir=${profile}`,
+      url,
+    ],
+    // Chrome is a process tree (browser, renderers, crashpad); detach it into
+    // its own process group so teardown can kill the whole tree at once.
+    { stdio: "ignore", detached: true },
+  );
+
+  const timeout = setTimeout(() => {
+    console.error(`FAIL - ${label}: probe reported nothing within 60s`);
+    try {
+      process.kill(-chrome.pid, "SIGKILL");
+    } catch {
+      chrome.kill("SIGKILL");
+    }
+    process.exit(1);
+  }, 60_000);
+
+  const observed = await result;
+  clearTimeout(timeout);
+  const exited = new Promise((resolve) => chrome.once("exit", resolve));
+  try {
+    process.kill(-chrome.pid, "SIGKILL");
+  } catch {
+    chrome.kill("SIGKILL");
+  }
+  await exited;
+  server.close();
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      rmSync(profile, { recursive: true, force: true });
+      break;
+    } catch (error) {
+      if (attempt >= 20) {
+        console.warn(`leaving temp profile ${profile}: ${error}`);
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  return observed;
+}
+
+// Scenario 1: normal boot. Module evaluation must complete (URL params
+// applied proves everything after the H.264 registry site ran) with zero
+// uncaught errors, and the wasm init path must end in live panels — which
+// also proves the registry construction that follows wasm load succeeded.
+{
+  const observed = await bootScenario({ label: "normal boot", serveWasm: true });
+  check("normal boot: no uncaught boot errors", observed.bootErrors.length === 0);
+  if (observed.bootErrors.length > 0) console.error(observed.bootErrors.join("\n"));
+  check(
+    "normal boot: module evaluation completed (URL params applied)",
+    observed.port === TEST_PORT_PARAM && observed.cert === TEST_CERT_PARAM,
+  );
+  check("normal boot: instrument panels ready (wasm loaded)", observed.ready === true);
+}
+
+// Scenario 2: the wasm fetch fails. The viewer must degrade visibly — panels
+// report unavailable — while the rest of the page stays alive: module fully
+// evaluated, MJPEG paint surface still usable. No uncaught errors allowed;
+// the failure must travel the fail-visible path, not the exception path.
+{
+  const observed = await bootScenario({ label: "wasm-load failure", serveWasm: false });
+  check("wasm failure: no uncaught boot errors", observed.bootErrors.length === 0);
+  if (observed.bootErrors.length > 0) console.error(observed.bootErrors.join("\n"));
+  check(
+    "wasm failure: module evaluation completed (URL params applied)",
+    observed.port === TEST_PORT_PARAM && observed.cert === TEST_CERT_PARAM,
+  );
+  check("wasm failure: panels report unavailable", observed.unavailable === true);
+  check("wasm failure: panels did not claim ready", observed.ready !== true);
+  check("wasm failure: MJPEG canvas still usable", observed.canvasUsable === true);
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("viewer boot contract passed");


### PR DESCRIPTION
## Bug

The VID-02 wiring constructs `H264DecoderRegistry` during `main.js` module evaluation. Its constructor default — `ownership = new H264SourceOwnership()` — calls the wasm-bindgen glue before `loadInstruments()` initializes the instrument module, so every page load dies with:

```
TypeError: Cannot read properties of undefined (reading 'h264sourceownership_new')
```

The uncaught throw kills the entire viewer module: no URL-param application, no Connect handler, no instrument boot, no wasm fetch — while all existing CI stays green, because no test loads the actual entrypoint. Closes #112.

## Fix

- `h264Registry` is `null` at module scope and is built immediately after `loadInstruments()` resolves.
- Until then — or permanently, if the wasm load fails — the H.264 paint path skips frames fail-visible behind a **page-lifetime one-shot log** (wasm absence never heals without a reload, so one line, not one per frame at stream rate). MJPEG is unaffected.
- Session teardown (`closeAll`) and capture-discontinuity reset take `?.` since the registry may legitimately be absent.

## Guardrail (same PR, wired into CI)

`clients/web/viewer-boot.browser.test.mjs`: a real Chromium loads the **unmodified** `index.html` + `main.js` (the server injects only an error-capture prelude and a result probe around the untouched page) and asserts:

- **Normal boot** — zero uncaught errors, module evaluation completed (URL params applied), status reaches "instrument panels ready (wasm loaded)" (registry construction precedes that line).
- **Wasm 404** — zero uncaught errors, module still fully evaluated, panels report "unavailable", MJPEG canvas still usable.

Verified the guardrail catches the bug: reintroducing the eager construction fails 6/8 checks with the exact TypeError above, exit code 1.

## Out of scope

- `datagrams.createWritable` hunk (#103) — left uncommitted, needs its own tests.
- Aviate SHM v3 adapter rework — deferred until Aviate #272 merges (per review, will consume `aviate-xil-shm` `ConsumerSession` instead of hand-mirrored offsets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S5Ug5FMbCeneXnGyuv4jn