### PR TITLE
LINK-XIL: consume aviate-xil-shm ConsumerSession and remove the local ABI mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aviate-xil-contract"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Aviate.git?rev=ac9bd248406a892fbe97a712d921326c96abd8b6#ac9bd248406a892fbe97a712d921326c96abd8b6"
+
+[[package]]
+name = "aviate-xil-shm"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Aviate.git?rev=ac9bd248406a892fbe97a712d921326c96abd8b6#ac9bd248406a892fbe97a712d921326c96abd8b6"
+dependencies = [
+ "aviate-xil-contract",
+ "libc",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,8 +1016,9 @@ dependencies = [
 name = "pilotage-adapter-aviate"
 version = "0.1.0"
 dependencies = [
+ "aviate-xil-contract",
+ "aviate-xil-shm",
  "getrandom 0.3.4",
- "libc",
  "pilotage-adapter-api",
  "pilotage-adapter-gazebo",
  "pilotage-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
+# The Aviate XIL contract crates are consumed only at one exact upstream
+# revision: both crates must always pin the identical rev so the layout
+# types, the transport, and the canonical object name cannot drift apart.
+aviate-xil-contract = { git = "https://github.com/luofang34/Aviate.git", rev = "ac9bd248406a892fbe97a712d921326c96abd8b6" }
+aviate-xil-shm = { git = "https://github.com/luofang34/Aviate.git", rev = "ac9bd248406a892fbe97a712d921326c96abd8b6" }
 thiserror = { version = "2.0.18", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/adapters/aviate/Cargo.toml
+++ b/adapters/aviate/Cargo.toml
@@ -5,28 +5,13 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
-# Not `workspace = true`: the workspace forbids unsafe_code outright,
-# but the shared-memory vehicle link (ADR-0019) needs shm_open/mmap.
-# This crate denies unsafe_code and allows it only at contained sites in
-# shm.rs, each with a SAFETY justification; everything else
-# matches the workspace wall.
-[lints.rust]
-unsafe_code = "deny"
-missing_docs = "deny"
-
-[lints.clippy]
-unwrap_used = "deny"
-expect_used = "deny"
-panic = "deny"
-let_underscore_must_use = "deny"
-let_underscore_future = "deny"
-await_holding_lock = "deny"
-disallowed_types = "deny"
-disallowed_macros = "deny"
+[lints]
+workspace = true
 
 [dependencies]
+aviate-xil-contract = { workspace = true }
+aviate-xil-shm = { workspace = true }
 getrandom = { version = "0.3.4", features = ["std"] }
-libc = { workspace = true }
 pilotage-adapter-api = { workspace = true }
 pilotage-adapter-gazebo = { workspace = true }
 pilotage-protocol = { workspace = true }

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -104,7 +104,9 @@ enum Source {
         // Kept alive for its receive task; dropped with the adapter.
         _link: Option<AviateLink>,
     },
-    Shm(ShmSource),
+    // Boxed: the session machine (attachment, fault, freshness, naming)
+    // dwarfs the MAVLink variant.
+    Shm(Box<ShmSource>),
 }
 
 /// Telemetry-only adapter for the Aviate flight controller (ADR-0018).
@@ -217,7 +219,21 @@ impl AviateAdapter {
         instance: u8,
         incarnation: SourceIncarnation,
     ) -> Result<Source, AviateAdapterError> {
-        Ok(Source::Shm(ShmSource::open(instance, incarnation)?))
+        Ok(Source::Shm(Box::new(ShmSource::open(
+            instance,
+            incarnation,
+        )?)))
+    }
+
+    /// The typed fault that has fail-closed the shared-memory source, if
+    /// any. A faulted source publishes no telemetry and does not
+    /// re-attach. Only the shared-memory source carries a fail-closed
+    /// fault state; the MAVLink source reports `None` here.
+    pub fn shm_fault(&self) -> Option<&AviateAdapterError> {
+        match &self.source {
+            Source::Shm(source) => source.fault(),
+            Source::Mavlink { .. } => None,
+        }
     }
 
     async fn mavlink_source(

--- a/adapters/aviate/src/adapter/shm_sampling.rs
+++ b/adapters/aviate/src/adapter/shm_sampling.rs
@@ -1,7 +1,23 @@
-//! Shared-memory source sampling and incarnation transitions.
+//! Shared-memory source sampling: the consumer-session state machine and
+//! source-epoch transitions.
+//!
+//! One explicit machine over the upstream `writer_state()`:
+//!
+//! * `Current` — the only state that publishes samples.
+//! * `Replaced` / `Gone` / `Initializing` — output stops immediately and
+//!   the source re-attaches on a bounded interval; a successful re-attach
+//!   starts a new Pilotage source epoch with fresh freshness state.
+//! * `ContractMismatch` — the source fails closed with a sticky typed
+//!   fault; no sample is ever read through a foreign layout.
+//!
+//! An unpublished snapshot (`read` returning `None`) publishes nothing:
+//! frozen data is never replayed. A `reset_generation` change on the same
+//! writer starts a new source epoch and accepts the simulation-time
+//! rewind.
 
 use std::time::{Duration, Instant};
 
+use aviate_xil_contract::WriterState;
 use pilotage_adapter_api::{
     AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, MeasurementClock,
     MeasurementStamp, Pose2d, SourceIncarnation, TelemetryBatch, TelemetrySample,
@@ -11,18 +27,34 @@ use pilotage_timing::SimTick;
 
 use super::{WITHHOLD_AFTER, yaw_of};
 use crate::error::AviateAdapterError;
-use crate::shm::{GzStateSample, GzStateShm, ShmFreshness, ShmObservation};
+use crate::shm::{GzStateSample, GzStateShm, ShmFreshness, ShmObservation, object_name};
 
 const REATTACH_INTERVAL: Duration = Duration::from_millis(250);
 
+/// Simulator-field availability, in the wire batch's flag positions:
+/// attitude (bit 0), position (bit 2), and velocity (bit 3) are present.
+/// The rates bit (1) stays CLEAR: the contract carries no body gyro — its
+/// angular-velocity lane is world-frame and advisory — so body rates are
+/// published unavailable. This says which simulator fields exist; it is
+/// NOT an FC-estimator authorization.
+const TRUTH_VALID_FLAGS: u32 = 0b1101;
+
 #[derive(Debug)]
 pub(super) struct ShmSource {
-    shm: GzStateShm,
+    /// The live consumer attachment; `None` while detached (writer gone,
+    /// replaced, or mid-initialization) and awaiting re-attachment.
+    session: Option<GzStateShm>,
+    /// Sticky fail-closed fault: set on a contract mismatch, never
+    /// cleared. While present, no sample is published and no
+    /// re-attachment is attempted.
+    fault: Option<AviateAdapterError>,
     freshness: ShmFreshness,
+    name: String,
     instance: u8,
     epoch: u32,
     incarnation: SourceIncarnation,
     last_reattach_attempt: Option<Instant>,
+    reset_generation: Option<u32>,
 }
 
 impl ShmSource {
@@ -30,13 +62,26 @@ impl ShmSource {
         instance: u8,
         incarnation: SourceIncarnation,
     ) -> Result<Self, AviateAdapterError> {
+        Self::open_named(&object_name(instance), instance, incarnation)
+    }
+
+    /// Attaches to an explicit object name. [`Self::open`] resolves the
+    /// canonical production name; tests attach to a private object.
+    fn open_named(
+        name: &str,
+        instance: u8,
+        incarnation: SourceIncarnation,
+    ) -> Result<Self, AviateAdapterError> {
         Ok(Self {
-            shm: GzStateShm::open(instance)?,
+            session: Some(GzStateShm::open_named(name)?),
+            fault: None,
             freshness: ShmFreshness::new(),
+            name: name.to_owned(),
             instance,
             epoch: 1,
             incarnation,
             last_reattach_attempt: None,
+            reset_generation: None,
         })
     }
 
@@ -46,9 +91,16 @@ impl ShmSource {
     }
 
     pub(super) fn tick(&self) -> u64 {
-        self.shm
-            .read()
+        self.session
+            .as_ref()
+            .filter(|session| session.writer_state() == WriterState::Current)
+            .and_then(GzStateShm::read)
             .map_or(0, |sample| sample.time_us.wrapping_mul(1_000))
+    }
+
+    /// The typed fault that has fail-closed this source, if any.
+    pub(super) fn fault(&self) -> Option<&AviateAdapterError> {
+        self.fault.as_ref()
     }
 
     pub(super) fn sample(&mut self, vehicle: VehicleId, arm_state: u32) -> TelemetryBatch {
@@ -67,27 +119,69 @@ impl ShmSource {
     }
 
     fn usable_sample(&mut self, now: Instant) -> Option<GzStateSample> {
-        let sample = self.shm.read();
-        let usable = match sample {
-            Some(sample) => match self.freshness.observe_at(sample.seq, sample.time_us, now) {
-                ShmObservation::Advancing => true,
-                ShmObservation::Unchanged(age) => age <= WITHHOLD_AFTER,
-                ShmObservation::Quarantined => false,
-            },
-            None => false,
-        };
-        if usable {
-            return sample;
+        if self.fault.is_some() {
+            return None;
         }
-        let absent_stale =
-            sample.is_none() && self.freshness.observe_absent_at(now) > WITHHOLD_AFTER;
-        let frozen_or_quarantined = sample.is_some();
-        if absent_stale || frozen_or_quarantined {
-            self.try_reattach(now);
+        match self.session.as_ref().map(GzStateShm::writer_state) {
+            Some(WriterState::Current) => return self.read_current(now),
+            Some(state) => {
+                // Replaced, Gone, Initializing, or ContractMismatch: this
+                // mapping serves a dead (or not-yet-born, or foreign)
+                // world. Output stops in this same call; the re-attach
+                // below decides between a new epoch and a fail-closed
+                // fault.
+                tracing::warn!(?state, "Aviate shm writer lost; output stopped");
+                self.session = None;
+                self.last_reattach_attempt = None;
+            }
+            None => {}
         }
-        None
+        self.try_reattach(now);
+        // A successful re-attach serves its first coherent sample in the
+        // same call, so the new epoch starts with data, not a blank tick.
+        if self.session.is_some() {
+            self.read_current(now)
+        } else {
+            None
+        }
     }
 
+    /// Reads through a `Current` writer. `None` from the upstream read —
+    /// writer mid-initialization, world mid-reset, or a retired epoch —
+    /// publishes nothing; frozen data is never replayed.
+    fn read_current(&mut self, now: Instant) -> Option<GzStateSample> {
+        let sample = self.session.as_ref().and_then(GzStateShm::read)?;
+        if self
+            .reset_generation
+            .is_some_and(|generation| generation != sample.reset_generation)
+        {
+            // A reset_generation change is a world reset on the SAME
+            // writer: sim time rewinds to zero by design. Re-baseline
+            // freshness in a fresh source epoch instead of quarantining,
+            // so telemetry survives a world reset without a host restart.
+            self.freshness = ShmFreshness::new_at(now);
+            self.epoch = self.epoch.wrapping_add(1);
+            tracing::info!(
+                reset_generation = sample.reset_generation,
+                source_epoch = self.epoch,
+                "Aviate world reset observed; shm freshness re-baselined"
+            );
+        }
+        self.reset_generation = Some(sample.reset_generation);
+        match self
+            .freshness
+            .observe_at(sample.sim_step, sample.time_us, now)
+        {
+            ShmObservation::Advancing => Some(sample),
+            ShmObservation::Unchanged(age) if age <= WITHHOLD_AFTER => Some(sample),
+            ShmObservation::Unchanged(_) | ShmObservation::Quarantined => None,
+        }
+    }
+
+    /// One bounded re-attachment attempt: rate-limited to
+    /// [`REATTACH_INTERVAL`], never spinning on an absent writer. A
+    /// contract mismatch fails the source closed with the upstream
+    /// refusal preserved verbatim.
     fn try_reattach(&mut self, now: Instant) {
         if self.last_reattach_attempt.is_some_and(|last| {
             now.checked_duration_since(last).unwrap_or_default() < REATTACH_INTERVAL
@@ -95,27 +189,41 @@ impl ShmSource {
             return;
         }
         self.last_reattach_attempt = Some(now);
-        let Ok(candidate) = GzStateShm::open(self.instance) else {
-            return;
-        };
-        if candidate.identity() == self.shm.identity() {
-            return;
+        self.absorb_reattach(GzStateShm::open_named(&self.name), now);
+    }
+
+    /// Applies one re-attachment outcome to the machine: a new session
+    /// starts a new source epoch; a contract mismatch is a sticky
+    /// fail-closed fault; any other refusal leaves the source detached
+    /// until the next bounded attempt.
+    fn absorb_reattach(&mut self, attach: Result<GzStateShm, AviateAdapterError>, now: Instant) {
+        match attach {
+            Ok(session) => {
+                self.session = Some(session);
+                self.freshness = ShmFreshness::new_at(now);
+                self.epoch = self.epoch.wrapping_add(1);
+                // A different object is a different writer; its generation
+                // counter starts a new numbering and must not be compared
+                // with the old one.
+                self.reset_generation = None;
+                self.last_reattach_attempt = None;
+                tracing::warn!(
+                    source_epoch = self.epoch,
+                    "Aviate SHM object entered a new attachment epoch"
+                );
+            }
+            Err(error @ AviateAdapterError::ShmContractMismatch { .. }) => {
+                // A foreign or stale layout stands behind the canonical
+                // name: reading it would be plausible garbage. Fail closed
+                // and stay closed.
+                tracing::error!(%error, "Aviate shm contract mismatch; source failed closed");
+                self.fault = Some(error);
+            }
+            Err(_) => {
+                // Absent or not-yet-ready writer: retry at the next
+                // interval without replaying anything meanwhile.
+            }
         }
-        let Some(first) = candidate.read() else {
-            return;
-        };
-        let mut freshness = ShmFreshness::new_at(now);
-        if freshness.observe_at(first.seq, first.time_us, now) != ShmObservation::Advancing {
-            return;
-        }
-        self.shm = candidate;
-        self.freshness = freshness;
-        self.epoch = self.epoch.wrapping_add(1);
-        self.last_reattach_attempt = None;
-        tracing::warn!(
-            source_epoch = self.epoch,
-            "Aviate SHM object entered a new attachment epoch"
-        );
     }
 }
 
@@ -132,7 +240,10 @@ fn batch_from_sample(
         source_id: u64::from(instance).wrapping_add(1),
         source_incarnation: incarnation,
         source_epoch: epoch,
-        sequence: sample.seq,
+        // The stamp carries a wrapping u32 group sequence; the physics
+        // step counter's low 32 bits preserve adjacency and wrap
+        // semantics.
+        sequence: sample.sim_step as u32,
         acquired_at_ns: sample.time_us.wrapping_mul(1_000),
         clock: MeasurementClock::Simulation,
     };
@@ -154,7 +265,10 @@ fn batch_from_sample(
             avionics: Some(AvionicsSample {
                 attitude: Some(AvionicsAttitudeSample {
                     quat_wxyz: sample.quat_wxyz,
-                    rates_rps: sample.rates_rps,
+                    // No body gyro exists on this source (see the
+                    // `crate::shm` docs): rates are neutral with their
+                    // validity bit clear in `TRUTH_VALID_FLAGS`.
+                    rates_rps: [0.0; 3],
                     stamp,
                 }),
                 kinematics: Some(AvionicsKinematicsSample {
@@ -162,10 +276,14 @@ fn batch_from_sample(
                     vel_ned_mps: sample.vel_ned_mps,
                     stamp,
                 }),
-                // The coherent simulator block is its own explicit
-                // ground-truth authorization source.
+                // COMPATIBILITY PROJECTION: the wire batch has one
+                // estimator-shaped avionics sample, so simulator truth
+                // rides it with the stamp marking simulator-field
+                // availability — not an FC estimator's authorization.
+                // The truth-versus-estimate source split is a separate
+                // concern, not solved by this projection.
                 estimator_status_stamp: Some(stamp),
-                valid_flags: 0b1111,
+                valid_flags: TRUTH_VALID_FLAGS,
                 quality: 0,
                 arm_state,
             }),

--- a/adapters/aviate/src/adapter/shm_sampling/tests.rs
+++ b/adapters/aviate/src/adapter/shm_sampling/tests.rs
@@ -1,34 +1,237 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+use std::time::{Duration, Instant};
+
+use aviate_xil_contract::AttachError;
+use aviate_xil_shm::{AttachFailure, ModelStateSnapshot, SimWriterSession};
 use pilotage_adapter_api::SourceIncarnation;
 use pilotage_protocol::VehicleId;
 
-use crate::shm::GzStateSample;
+use super::{REATTACH_INTERVAL, ShmSource, TRUTH_VALID_FLAGS, batch_from_sample};
+use crate::error::AviateAdapterError;
+use crate::shm::{GzStateSample, attach_error};
 
-use super::batch_from_sample;
+fn unique_name(tag: &str) -> String {
+    // macOS caps shm names at 31 chars; keep the unique suffix short.
+    format!("/plt_s_{tag}_{}", std::process::id())
+}
+
+fn incarnation() -> SourceIncarnation {
+    SourceIncarnation::new([0x5a; 16])
+}
+
+fn snapshot(generation: u32, sim_step: u64, time_us: u64) -> ModelStateSnapshot {
+    ModelStateSnapshot {
+        reset_generation: generation,
+        sim_step,
+        time_us,
+        pos: [1.0, 2.0, 3.0],
+        quat: [1.0, 0.0, 0.0, 0.0],
+        vel: [0.5, 0.0, -1.0],
+        // Advisory world-frame lane: deliberately non-zero in every test
+        // so any leak into published telemetry becomes visible.
+        ang_vel: [7.0, -3.0, 11.0],
+    }
+}
 
 #[test]
-fn simulator_sample_has_explicit_ground_truth_authorization() {
+fn coherent_snapshot_flows_with_truth_stamping_and_no_body_rates() {
+    let name = unique_name("flow");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 40, 1_000));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let batch = source.sample(VehicleId::new(1), 0);
+    let avionics = batch.samples[0].avionics.expect("avionics");
+    let attitude = avionics.attitude.expect("attitude");
+    let kinematics = avionics.kinematics.expect("kinematics");
+
+    assert_eq!(kinematics.pos_ned_m, [2.0, 1.0, -3.0]);
+    assert_eq!(kinematics.vel_ned_mps, [0.0, 0.5, 1.0]);
+    assert_eq!(attitude.stamp.sequence, 40, "sim_step is the sequence");
+    assert_eq!(attitude.stamp.source_epoch, 1);
+    assert_eq!(attitude.stamp.acquired_at_ns, 1_000_000);
+
+    // The producer publishes non-zero world-frame angular velocity; it
+    // must not surface as authoritative body rates.
+    assert_eq!(avionics.valid_flags & 0b10, 0, "rates bit must stay clear");
+    assert_eq!(avionics.valid_flags, TRUTH_VALID_FLAGS);
+    assert_eq!(attitude.rates_rps, [0.0; 3]);
+}
+
+#[test]
+fn world_reset_starts_a_new_epoch_and_accepts_the_time_rewind() {
+    let name = unique_name("rst");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 100, 5_000_000));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let now = Instant::now();
+    let first = source.usable_sample(now).expect("pre-reset sample");
+    assert_eq!(first.time_us, 5_000_000);
+    assert_eq!(source.epoch, 1);
+
+    // Between the reset and the new world's first published step there is
+    // nothing to serve — and nothing is replayed.
+    let new_generation = writer.bump_reset_generation();
+    assert_eq!(source.usable_sample(now + Duration::from_millis(1)), None);
+
+    // Sim time rewinds to zero by design; the step counter stays
+    // monotonic. The sampler re-keys on the new generation and accepts
+    // the rewind in a new source epoch.
+    writer.write_model_state(&snapshot(new_generation, 101, 1_000));
+    let resumed = source
+        .usable_sample(now + Duration::from_millis(2))
+        .expect("post-reset sample");
+    assert_eq!(resumed.reset_generation, new_generation);
+    assert_eq!(resumed.time_us, 1_000);
+    assert_eq!(source.epoch, 2);
+}
+
+#[test]
+fn writer_disappearance_stops_output_without_frozen_replay() {
+    let name = unique_name("gone");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 7, 1_000));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let now = Instant::now();
+    assert!(source.usable_sample(now).is_some());
+
+    // The dead mapping still holds the final snapshot; not one more
+    // sample may be published from it.
+    drop(writer);
+    assert_eq!(source.usable_sample(now + Duration::from_millis(1)), None);
+    assert!(source.session.is_none(), "detached from the dead world");
+    assert!(source.fault.is_none(), "a vanished writer is not a fault");
+}
+
+#[test]
+fn writer_replacement_reattaches_into_a_new_source_epoch() {
+    let name = unique_name("repl");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 10, 2_000));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let now = Instant::now();
+    assert_eq!(source.usable_sample(now).expect("live sample").sim_step, 10);
+    assert_eq!(source.epoch, 1);
+
+    drop(writer);
+    let replacement = SimWriterSession::create(&name).expect("replacement writer");
+    replacement.write_model_state(&snapshot(replacement.reset_generation(), 3, 500));
+
+    // One poll observes the replacement, detaches, re-attaches, and
+    // serves the new world's first coherent sample in a new source epoch.
+    let resumed = source
+        .usable_sample(now + Duration::from_millis(1))
+        .expect("post-replacement sample");
+    assert_eq!(resumed.sim_step, 3);
+    assert_eq!(source.epoch, 2);
+}
+
+#[test]
+fn reattachment_is_bounded_by_the_retry_interval() {
+    let name = unique_name("bnd");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 1, 100));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let now = Instant::now();
+    assert!(source.usable_sample(now).is_some());
+
+    // Detach and burn the immediate attempt while no writer exists.
+    drop(writer);
+    assert_eq!(source.usable_sample(now), None);
+
+    let replacement = SimWriterSession::create(&name).expect("replacement writer");
+    replacement.write_model_state(&snapshot(replacement.reset_generation(), 2, 200));
+
+    // Inside the interval no new attempt is made: still no output.
+    assert_eq!(source.usable_sample(now + REATTACH_INTERVAL / 2), None);
+    // At the interval the bounded retry lands and a new epoch begins.
+    assert!(source.usable_sample(now + REATTACH_INTERVAL).is_some());
+    assert_eq!(source.epoch, 2);
+}
+
+#[test]
+fn unavailable_attachment_fails_closed() {
+    let refusal = ShmSource::open_named(&unique_name("no"), 0, incarnation());
+    assert!(
+        matches!(refusal, Err(AviateAdapterError::ShmAttachIo { .. })),
+        "got {refusal:?}"
+    );
+}
+
+#[test]
+fn a_contract_mismatch_is_a_sticky_fail_closed_fault() {
+    let name = unique_name("flt");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    writer.write_model_state(&snapshot(writer.reset_generation(), 1, 100));
+
+    let mut source = ShmSource::open_named(&name, 0, incarnation()).expect("attach");
+    let now = Instant::now();
+    assert!(source.usable_sample(now).is_some());
+
+    // An incompatible-layout refusal (detected upstream on attach) fails
+    // the machine closed with the violation preserved verbatim.
+    source.session = None;
+    source.absorb_reattach(
+        Err(attach_error(
+            &name,
+            AttachFailure::Contract(AttachError::VersionMismatch { found: 2 }),
+        )),
+        now,
+    );
+    assert!(
+        matches!(
+            source.fault(),
+            Some(AviateAdapterError::ShmContractMismatch {
+                violation: AttachError::VersionMismatch { found: 2 },
+                ..
+            })
+        ),
+        "got {:?}",
+        source.fault()
+    );
+
+    // Even with a healthy, publishing writer behind the name, a
+    // fail-closed source publishes nothing and never re-attaches.
+    assert_eq!(source.usable_sample(now + Duration::from_millis(1)), None);
+    assert_eq!(
+        source.usable_sample(now + REATTACH_INTERVAL + Duration::from_millis(1)),
+        None
+    );
+    assert!(source.session.is_none(), "no session behind a fault");
+    assert!(source.fault.is_some(), "the fault is sticky");
+}
+
+#[test]
+fn simulator_batch_is_an_estimator_shaped_projection_with_shared_stamps() {
     let batch = batch_from_sample(
         VehicleId::new(1),
         0,
         GzStateSample {
             quat_wxyz: [1.0, 0.0, 0.0, 0.0],
-            rates_rps: [0.0; 3],
             pos_ned_m: [0.0; 3],
             vel_ned_mps: [0.0; 3],
             time_us: 42,
-            seq: 7,
+            // Verifies the u64 step truncates to the wrapping u32 wire
+            // sequence by its low bits.
+            sim_step: (1 << 32) | 7,
+            reset_generation: 1,
         },
         0,
         3,
-        SourceIncarnation::new([0x5a; 16]),
+        incarnation(),
     );
 
     let avionics = batch.samples[0].avionics.expect("avionics");
     let status = avionics.estimator_status_stamp.expect("status stamp");
     assert_eq!(status, avionics.attitude.expect("attitude").stamp);
     assert_eq!(status, avionics.kinematics.expect("kinematics").stamp);
-    assert_eq!(avionics.valid_flags, 0x0f);
+    assert_eq!(status.sequence, 7);
+    assert_eq!(status.source_epoch, 3);
+    assert_eq!(avionics.valid_flags, TRUTH_VALID_FLAGS);
     assert_eq!(avionics.quality, 0);
 }

--- a/adapters/aviate/src/error.rs
+++ b/adapters/aviate/src/error.rs
@@ -18,37 +18,34 @@ pub enum AviateAdapterError {
         #[source]
         source: std::io::Error,
     },
-    /// The generated POSIX shared-memory name was not a valid C string.
-    #[error("Aviate state shm name {name} is invalid: {source}")]
-    ShmName {
+    /// Attaching to the XIL shm object failed at the operating-system
+    /// level: the object does not exist (no simulation writer is up) or
+    /// the kernel refused the read-only mapping.
+    #[error("Aviate XIL shm {name} attach failed: {source}")]
+    ShmAttachIo {
         /// The POSIX shm object name.
         name: String,
-        /// The embedded-NUL error.
-        #[source]
-        source: std::ffi::NulError,
-    },
-    /// A POSIX shared-memory operation failed.
-    #[error("Aviate state shm {name} operation {operation} failed: {source}")]
-    ShmIo {
-        /// The POSIX shm object name.
-        name: String,
-        /// The operation that failed.
-        operation: &'static str,
-        /// The operating-system failure.
+        /// The operating-system failure reported by the upstream attach.
         #[source]
         source: std::io::Error,
     },
-    /// The shared-memory object is too small to back the reader's mapping.
-    /// This is a capacity check, not a layout/version check: capacity does
-    /// not establish layout compatibility — it proves only that at least
-    /// `required` bytes are present, never that the block's fields match.
-    #[error("Aviate state shm {name} reports {observed} bytes; needs at least {required}")]
-    ShmCapacityTooSmall {
+    /// The object exists but is not the contract block this build was
+    /// compiled against (foreign magic, layout version, declared size, or
+    /// a truncated mapping). Reading it would be plausible garbage, so the
+    /// attachment fails closed.
+    #[error("Aviate XIL shm {name} contract violation: {violation:?}")]
+    ShmContractMismatch {
         /// The POSIX shm object name.
         name: String,
-        /// Byte count the reader must be able to map.
-        required: usize,
-        /// The kernel-reported object size (`st_size`), which may be negative.
-        observed: i64,
+        /// The upstream attach-rule violation, verbatim.
+        violation: aviate_xil_contract::AttachError,
+    },
+    /// The block validates but the simulation writer has not published
+    /// readiness yet (writer mid-initialization). Retryable: attach again
+    /// once the writer is up; payload fields must not be read before then.
+    #[error("Aviate XIL shm {name} writer not ready")]
+    ShmWriterNotReady {
+        /// The POSIX shm object name.
+        name: String,
     },
 }

--- a/adapters/aviate/src/shm.rs
+++ b/adapters/aviate/src/shm.rs
@@ -1,288 +1,137 @@
-//! Pure-Rust reader for Aviate's Gazebo-bridge shared-memory state block
+//! Thin safe wrapper around the Aviate XIL shared-memory consumer endpoint
 //! (ADR-0019: the co-located SITL vehicle link binds shared memory).
 //!
-//! Aviate's gz-sim plugin publishes `AviateSharedState` (its
-//! `shared_state.h`, a standalone-C contract) into POSIX shm
-//! `/aviate_gz_bridge[_<instance>]` every physics tick: ENU pose,
-//! ENU/FLU quaternion, velocities, sim time, and a sequence counter.
-//! This module attaches read-only as a second consumer beside the FC and
-//! converts to the NED/FRD convention the telemetry plane carries,
-//! mirroring Aviate's own conversion math exactly.
+//! The contract layout, attach validation (magic / layout version /
+//! declared size / readiness), the seqlock read protocol, and writer
+//! liveness/replacement detection are owned by the upstream
+//! `aviate-xil-contract` + `aviate-xil-shm` crates, pinned to one exact
+//! revision — this module carries no layout knowledge of its own. It
+//! resolves the canonical object name from the upstream naming authority,
+//! converts each coherent snapshot at the boundary (world ENU → NED,
+//! ENU/FLU quaternion → NED/FRD), and tracks wall-clock freshness so a
+//! frozen block ages into withheld telemetry instead of replaying.
 //!
-//! The shared block is coherent simulator ground truth. Its sampler publishes
-//! an explicit synthetic authorization stamp so consumers can distinguish
-//! this source from FC estimator telemetry.
+//! The block is coherent simulator ground truth, not an FC operational
+//! estimate. The adapter currently exposes it through an estimator-shaped
+//! COMPATIBILITY PROJECTION (the stamps assert which simulator fields are
+//! present, not that an FC estimator authorized anything), selects it
+//! ahead of MAVLink in `Auto`, and uses its pose for SITL command
+//! construction. These behaviors are SIM-only; explicit truth/estimate
+//! separation remains required by #107 before flight-capable use.
+//!
+//! The contract's angular-velocity lane is world-frame and advisory
+//! (gz's `WorldAngularVelocity` verbatim; zero on the known setup). It is
+//! NOT a body gyro, so no body-rate field exists on [`GzStateSample`]:
+//! consumers needing body rates must derive them from successive
+//! attitudes and label them as derived.
 
-use std::ffi::CString;
 use std::time::Instant;
 
+use aviate_xil_contract::{ShmName, WriterState, shm_name};
+use aviate_xil_shm::{AttachFailure, ConsumerSession, ModelStateSnapshot};
+
 use crate::error::AviateAdapterError;
-
-// libc::dev_t differs in signedness and width across supported Unix targets.
-#[allow(clippy::unnecessary_cast)]
-const fn device_identity(device: libc::dev_t) -> u64 {
-    device as u64
-}
-
-/// Byte count the reader maps and reads from `AviateSharedState`. This size
-/// and the `OFF_*` offsets below hand-mirror the producer's `shared_state.h`
-/// and are not validated against a magic/version/declared-size header, so a
-/// producer layout change is not detected here. Capacity does not establish
-/// layout compatibility: the check below only proves the object is large
-/// enough to map, never that these offsets are still correct.
-const SHM_SIZE: usize = 216;
-
-/// Whether a POSIX shm object whose kernel-reported `st_size` is `st_size`
-/// bytes can back a `required`-byte read-only mapping, returning the admitted
-/// capacity. This is a CAPACITY decision only: the kernel may page-round the
-/// object up (a 216-byte `ftruncate` reports `st_size = 16384` on a 16 KiB
-/// page), so any capacity at least `required` is admitted and only `required`
-/// bytes are ever mapped. A negative `st_size` (which must never be coerced to
-/// a huge unsigned value) or one smaller than `required` is refused. It makes
-/// no claim about field layout or version.
-fn admissible_capacity(st_size: i64, required: usize) -> Option<u64> {
-    let capacity = u64::try_from(st_size).ok()?;
-    (capacity >= required as u64).then_some(capacity)
-}
-
-// Field offsets in `AviateSharedState` (shared_state.h) — provisional, see
-// `SHM_SIZE`.
-const OFF_POS: usize = 0; // double[3]
-const OFF_QUAT: usize = 24; // double[4] (w, x, y, z), ENU/FLU
-const OFF_VEL: usize = 56; // double[3], ENU world
-const OFF_ANG_VEL: usize = 80; // double[3], FLU body
-const OFF_TIME_US: usize = 104; // u64 sim time
-const OFF_SEQ: usize = 112; // u32 update counter
-const OFF_VALID: usize = 116; // u32 non-zero = valid
-const OFF_PLUGIN_READY: usize = 192; // u32 set once plugin is up
 
 /// One coherent ground-truth sample, already in NED/FRD.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GzStateSample {
     /// Attitude quaternion (w, x, y, z), body FRD → world NED.
     pub quat_wxyz: [f32; 4],
-    /// Body rates (p, q, r) rad/s, FRD.
-    pub rates_rps: [f32; 3],
     /// Position NED, meters.
     pub pos_ned_m: [f32; 3],
     /// Velocity NED, m/s.
     pub vel_ned_mps: [f32; 3],
-    /// Simulation time in microseconds.
+    /// Simulation time in microseconds. Rewinds to zero on a world reset;
+    /// pair with `reset_generation` before judging progress.
     pub time_us: u64,
-    /// The block's update counter.
-    pub seq: u32,
+    /// Physics step counter, the source sequence: monotonic across world
+    /// resets (epochs are told apart by `reset_generation`, not by this
+    /// counter restarting).
+    pub sim_step: u64,
+    /// The simulation-world epoch this snapshot belongs to, coherent with
+    /// the payload it stamps.
+    pub reset_generation: u32,
 }
 
-/// A read-only mapping of the Aviate gz-bridge block.
+/// A read-only attachment to the Aviate gz-bridge block.
 #[derive(Debug)]
 pub struct GzStateShm {
-    base: *const u8,
-    identity: ShmIdentity,
+    session: ConsumerSession,
 }
-
-/// Stable operating-system identity of one POSIX shared-memory object.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ShmIdentity {
-    device: u64,
-    inode: u64,
-    size: u64,
-}
-
-/// Progress classification for one coherent SHM observation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ShmObservation {
-    /// Sequence and acquisition time advanced in the same incarnation.
-    Advancing,
-    /// The same coherent sample remains mapped, with its frozen duration.
-    Unchanged(std::time::Duration),
-    /// Sequence or acquisition time rolled back on the same SHM object.
-    Quarantined,
-}
-
-// SAFETY: the mapping is process-private, read-only, and lives for the
-// adapter's lifetime; the raw pointer is only dereferenced through
-// volatile byte copies in `raw_snapshot`.
-#[allow(unsafe_code)]
-unsafe impl Send for GzStateShm {}
 
 impl GzStateShm {
-    /// Attaches read-only to instance `instance`'s block
-    /// (`/aviate_gz_bridge` for instance 0).
+    /// Attaches read-only to instance `instance`'s block, named by the
+    /// upstream naming authority ([`shm_name`]).
     ///
     /// # Errors
     ///
-    /// Returns a typed [`AviateAdapterError`] when the region does not
-    /// exist, is too small to back the mapping, or cannot be mapped.
+    /// Returns a typed [`AviateAdapterError`] when the object is absent or
+    /// unmappable ([`AviateAdapterError::ShmAttachIo`]), carries a foreign
+    /// or stale contract ([`AviateAdapterError::ShmContractMismatch`]), or
+    /// has no ready writer ([`AviateAdapterError::ShmWriterNotReady`]).
     pub fn open(instance: u8) -> Result<Self, AviateAdapterError> {
-        let name = if instance == 0 {
-            "/aviate_gz_bridge".to_owned()
-        } else {
-            format!("/aviate_gz_bridge_{instance}")
-        };
-        let c_name = CString::new(name.clone()).map_err(|source| AviateAdapterError::ShmName {
-            name: name.clone(),
-            source,
-        })?;
-        // SAFETY: shm_open/mmap with a valid, NUL-terminated name;
-        // read-only PROT_READ/O_RDONLY so no writer state can be
-        // corrupted; fd is closed after mapping (POSIX keeps the mapping
-        // alive); MAP_FAILED and negative fds are checked before use.
-        #[allow(unsafe_code)]
-        let (base, identity) = unsafe {
-            let fd = libc::shm_open(c_name.as_ptr(), libc::O_RDONLY, 0);
-            if fd < 0 {
-                return Err(AviateAdapterError::ShmIo {
-                    name,
-                    operation: "shm_open",
-                    source: std::io::Error::last_os_error(),
-                });
-            }
-            let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
-            if libc::fstat(fd, metadata.as_mut_ptr()) != 0 {
-                let source = std::io::Error::last_os_error();
-                libc::close(fd);
-                return Err(AviateAdapterError::ShmIo {
-                    name,
-                    operation: "fstat",
-                    source,
-                });
-            }
-            let metadata = metadata.assume_init();
-            let Some(capacity) = admissible_capacity(metadata.st_size, SHM_SIZE) else {
-                libc::close(fd);
-                return Err(AviateAdapterError::ShmCapacityTooSmall {
-                    name,
-                    required: SHM_SIZE,
-                    observed: metadata.st_size,
-                });
-            };
-            let ptr = libc::mmap(
-                std::ptr::null_mut(),
-                SHM_SIZE,
-                libc::PROT_READ,
-                libc::MAP_SHARED,
-                fd,
-                0,
-            );
-            libc::close(fd);
-            if ptr == libc::MAP_FAILED {
-                return Err(AviateAdapterError::ShmIo {
-                    name,
-                    operation: "mmap",
-                    source: std::io::Error::last_os_error(),
-                });
-            }
-            (
-                ptr.cast::<u8>().cast_const(),
-                ShmIdentity {
-                    device: device_identity(metadata.st_dev),
-                    inode: metadata.st_ino,
-                    size: capacity,
-                },
-            )
-        };
-        Ok(Self { base, identity })
+        Self::open_named(&object_name(instance))
     }
 
-    /// Returns the POSIX object identity captured before the mapping opened.
-    #[must_use]
-    pub const fn identity(&self) -> ShmIdentity {
-        self.identity
-    }
-
-    /// Copies the block byte-by-byte (volatile: the plugin writes
-    /// concurrently; the `seq` double-read in [`Self::read`] rejects
-    /// torn copies).
-    fn raw_snapshot(&self) -> [u8; SHM_SIZE] {
-        let mut out = [0u8; SHM_SIZE];
-        for (i, slot) in out.iter_mut().enumerate() {
-            // SAFETY: `base` is a live PROT_READ mapping of exactly
-            // SHM_SIZE bytes established in `open`; `i < SHM_SIZE`.
-            #[allow(unsafe_code)]
-            {
-                *slot = unsafe { self.base.add(i).read_volatile() };
-            }
+    /// Attaches read-only to the POSIX shm object `name`. [`Self::open`]
+    /// resolves the production name; tests attach to a private object.
+    pub(crate) fn open_named(name: &str) -> Result<Self, AviateAdapterError> {
+        match ConsumerSession::attach(name) {
+            Ok(session) => Ok(Self { session }),
+            Err(failure) => Err(attach_error(name, failure)),
         }
-        out
     }
 
-    /// Reads one coherent sample, or `None` when the plugin is not
-    /// ready, the block is flagged invalid, or two attempts kept
-    /// tearing.
+    /// What the object name behind this attachment resolves to right now.
+    /// [`WriterState::Current`] is the only state in which reads are
+    /// trustworthy; every other state is the sampler's signal to stop
+    /// output and re-attach or fail closed.
+    pub fn writer_state(&self) -> WriterState {
+        self.session.writer_state()
+    }
+
+    /// Reads one coherent sample, or `None` when no snapshot is published
+    /// (writer mid-initialization, world mid-reset, or a retired epoch).
+    /// `None` means publish nothing — never replay a cached sample.
     pub fn read(&self) -> Option<GzStateSample> {
-        for _ in 0..4 {
-            let first = self.raw_snapshot();
-            let seq = u32_at(&first, OFF_SEQ);
-            let second_seq = u32_at(&self.raw_snapshot(), OFF_SEQ);
-            if seq != second_seq {
-                continue; // torn mid-update; retry
-            }
-            if u32_at(&first, OFF_PLUGIN_READY) == 0 || u32_at(&first, OFF_VALID) == 0 {
-                return None;
-            }
-            return Some(decode_sample(&first, seq));
+        self.session
+            .read_model_state()
+            .map(|snapshot| sample_from_snapshot(&snapshot))
+    }
+}
+
+/// Canonical POSIX shm object name for one simulator instance, derived
+/// from the upstream naming authority — never assembled here, so the
+/// versioned namespace and its guardrails stay upstream's alone.
+pub(crate) fn object_name(instance: u8) -> ShmName {
+    shm_name(u32::from(instance))
+}
+
+/// Maps an upstream attach refusal into the adapter's typed error,
+/// preserving the original context (never collapsed or discarded).
+pub(crate) fn attach_error(name: &str, failure: AttachFailure) -> AviateAdapterError {
+    let name = name.to_owned();
+    match failure {
+        AttachFailure::Io(source) => AviateAdapterError::ShmAttachIo { name, source },
+        AttachFailure::Contract(violation) => {
+            AviateAdapterError::ShmContractMismatch { name, violation }
         }
-        None
+        AttachFailure::NotReady => AviateAdapterError::ShmWriterNotReady { name },
     }
 }
 
-impl Drop for GzStateShm {
-    fn drop(&mut self) {
-        // SAFETY: unmapping the exact region mapped in `open`; `base`
-        // is never used again (drop consumes the sole owner).
-        #[allow(unsafe_code)]
-        unsafe {
-            libc::munmap(self.base.cast_mut().cast(), SHM_SIZE);
-        }
-    }
-}
-
-fn f64_at(buf: &[u8; SHM_SIZE], off: usize) -> f64 {
-    let mut b = [0u8; 8];
-    if let Some(src) = buf.get(off..off + 8) {
-        b.copy_from_slice(src);
-    }
-    f64::from_ne_bytes(b)
-}
-
-fn u64_at(buf: &[u8; SHM_SIZE], off: usize) -> u64 {
-    let mut b = [0u8; 8];
-    if let Some(src) = buf.get(off..off + 8) {
-        b.copy_from_slice(src);
-    }
-    u64::from_ne_bytes(b)
-}
-
-fn u32_at(buf: &[u8; SHM_SIZE], off: usize) -> u32 {
-    let mut b = [0u8; 4];
-    if let Some(src) = buf.get(off..off + 4) {
-        b.copy_from_slice(src);
-    }
-    u32::from_ne_bytes(b)
-}
-
-fn vec3_at(buf: &[u8; SHM_SIZE], off: usize) -> [f64; 3] {
-    [
-        f64_at(buf, off),
-        f64_at(buf, off + 8),
-        f64_at(buf, off + 16),
-    ]
-}
-
-fn decode_sample(buf: &[u8; SHM_SIZE], seq: u32) -> GzStateSample {
-    let quat_enu_flu = [
-        f64_at(buf, OFF_QUAT),
-        f64_at(buf, OFF_QUAT + 8),
-        f64_at(buf, OFF_QUAT + 16),
-        f64_at(buf, OFF_QUAT + 24),
-    ];
+/// Converts one upstream snapshot at the adapter boundary: world ENU →
+/// NED, ENU/FLU quaternion → NED/FRD; `time_us`, `sim_step`, and
+/// `reset_generation` pass through unchanged. The advisory world-frame
+/// `ang_vel` lane is deliberately dropped (see the module docs).
+pub(crate) fn sample_from_snapshot(snapshot: &ModelStateSnapshot) -> GzStateSample {
     GzStateSample {
-        quat_wxyz: enu_quat_to_ned(quat_enu_flu),
-        rates_rps: flu_to_frd(vec3_at(buf, OFF_ANG_VEL)),
-        pos_ned_m: enu_to_ned(vec3_at(buf, OFF_POS)),
-        vel_ned_mps: enu_to_ned(vec3_at(buf, OFF_VEL)),
-        time_us: u64_at(buf, OFF_TIME_US),
-        seq,
+        quat_wxyz: enu_quat_to_ned(snapshot.quat),
+        pos_ned_m: enu_to_ned(snapshot.pos),
+        vel_ned_mps: enu_to_ned(snapshot.vel),
+        time_us: snapshot.time_us,
+        sim_step: snapshot.sim_step,
+        reset_generation: snapshot.reset_generation,
     }
 }
 
@@ -290,11 +139,6 @@ fn decode_sample(buf: &[u8; SHM_SIZE], seq: u32) -> GzStateSample {
 /// `enu_to_ned_f32`.
 fn enu_to_ned(enu: [f64; 3]) -> [f32; 3] {
     [enu[1] as f32, enu[0] as f32, -enu[2] as f32]
-}
-
-/// FLU body vector → FRD (negate y/z), matching Aviate's `flu_to_frd_f32`.
-fn flu_to_frd(flu: [f64; 3]) -> [f32; 3] {
-    [flu[0] as f32, -flu[1] as f32, -flu[2] as f32]
 }
 
 /// Body→world quaternion, ENU/FLU convention → NED/FRD, matching
@@ -306,11 +150,27 @@ fn enu_quat_to_ned(q: [f64; 4]) -> [f32; 4] {
     [s * (w + z), s * (x + y), s * (x - y), s * (w - z)]
 }
 
-/// Wall-clock progress tracking so a frozen block (paused sim, dead
+/// Progress classification for one coherent SHM observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShmObservation {
+    /// Step counter and simulation time advanced within the same epoch.
+    Advancing,
+    /// The same coherent sample remains published, with its frozen duration.
+    Unchanged(std::time::Duration),
+    /// Step counter or simulation time rolled back within the same epoch —
+    /// a protocol violation the writer-state machine did not announce.
+    Quarantined,
+}
+
+/// Wall-clock progress tracking so a frozen block (paused sim, stalled
 /// plugin) ages into withheld telemetry instead of replaying forever.
+/// Tracks progress WITHIN one world epoch of one attachment; a
+/// `reset_generation` change or a re-attachment is the caller's signal to
+/// re-baseline with a fresh tracker (sim time rewinds to zero by design
+/// on a world reset).
 #[derive(Debug)]
 pub struct ShmFreshness {
-    last_seq: Option<u32>,
+    last_step: Option<u64>,
     last_time_us: Option<u64>,
     last_progress: Instant,
     quarantined: bool,
@@ -324,34 +184,39 @@ impl ShmFreshness {
 
     pub(crate) fn new_at(now: Instant) -> Self {
         Self {
-            last_seq: None,
+            last_step: None,
             last_time_us: None,
             last_progress: now,
             quarantined: false,
         }
     }
 
-    /// Feeds the latest observed `seq`; returns how long the block has
-    /// been frozen (zero while it keeps advancing).
-    pub fn observe(&mut self, seq: u32, time_us: u64) -> ShmObservation {
-        self.observe_at(seq, time_us, Instant::now())
+    /// Feeds the latest observed `sim_step`/`time_us` pair and classifies
+    /// the block's progress.
+    pub fn observe(&mut self, sim_step: u64, time_us: u64) -> ShmObservation {
+        self.observe_at(sim_step, time_us, Instant::now())
     }
 
-    pub(crate) fn observe_at(&mut self, seq: u32, time_us: u64, now: Instant) -> ShmObservation {
+    pub(crate) fn observe_at(
+        &mut self,
+        sim_step: u64,
+        time_us: u64,
+        now: Instant,
+    ) -> ShmObservation {
         if self.quarantined {
             return ShmObservation::Quarantined;
         }
-        let observation = match (self.last_seq, self.last_time_us) {
-            (Some(previous_seq), Some(previous_time))
-                if seq == previous_seq && time_us == previous_time =>
+        let observation = match (self.last_step, self.last_time_us) {
+            (Some(previous_step), Some(previous_time))
+                if sim_step == previous_step && time_us == previous_time =>
             {
                 ShmObservation::Unchanged(
                     now.checked_duration_since(self.last_progress)
                         .unwrap_or_default(),
                 )
             }
-            (Some(previous_seq), Some(previous_time))
-                if serial_is_newer(seq, previous_seq) && time_us > previous_time =>
+            (Some(previous_step), Some(previous_time))
+                if serial_is_newer(sim_step, previous_step) && time_us > previous_time =>
             {
                 ShmObservation::Advancing
             }
@@ -362,28 +227,17 @@ impl ShmFreshness {
             }
         };
         if observation == ShmObservation::Advancing {
-            self.last_seq = Some(seq);
+            self.last_step = Some(sim_step);
             self.last_time_us = Some(time_us);
             self.last_progress = now;
         }
         observation
     }
-
-    /// Marks an unreadable/invalid block; returns how long since the
-    /// last good progress.
-    pub fn observe_absent(&mut self) -> std::time::Duration {
-        self.last_progress.elapsed()
-    }
-
-    pub(crate) fn observe_absent_at(&self, now: Instant) -> std::time::Duration {
-        now.checked_duration_since(self.last_progress)
-            .unwrap_or_default()
-    }
 }
 
-fn serial_is_newer(candidate: u32, current: u32) -> bool {
+fn serial_is_newer(candidate: u64, current: u64) -> bool {
     let distance = candidate.wrapping_sub(current);
-    distance != 0 && distance < (1_u32 << 31)
+    distance != 0 && distance < (1_u64 << 63)
 }
 
 impl Default for ShmFreshness {

--- a/adapters/aviate/src/shm/tests.rs
+++ b/adapters/aviate/src/shm/tests.rs
@@ -1,31 +1,20 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+use std::io;
 use std::time::{Duration, Instant};
 
+use aviate_xil_contract::{AttachError, WriterState};
+use aviate_xil_shm::{AttachFailure, ModelStateSnapshot, SimWriterSession};
+
 use super::{
-    SHM_SIZE, ShmFreshness, ShmObservation, admissible_capacity, decode_sample, enu_quat_to_ned,
-    enu_to_ned,
+    GzStateShm, ShmFreshness, ShmObservation, attach_error, enu_quat_to_ned, enu_to_ned,
+    sample_from_snapshot,
 };
+use crate::error::AviateAdapterError;
 
-#[test]
-fn capacity_rejects_negative_and_short_admits_exact_and_page_rounded() {
-    // A negative st_size must never be coerced to a huge unsigned capacity.
-    assert_eq!(admissible_capacity(-1, SHM_SIZE), None);
-    assert_eq!(admissible_capacity(i64::MIN, SHM_SIZE), None);
-    // One byte short of the required block is refused.
-    assert_eq!(admissible_capacity(SHM_SIZE as i64 - 1, SHM_SIZE), None);
-    // Exactly the required size is admitted.
-    assert_eq!(
-        admissible_capacity(SHM_SIZE as i64, SHM_SIZE),
-        Some(SHM_SIZE as u64)
-    );
-    // A page-rounded object (16 KiB page on Apple Silicon for a 216-byte
-    // ftruncate) is admitted; the mapping still reads only SHM_SIZE bytes.
-    assert_eq!(admissible_capacity(16384, SHM_SIZE), Some(16384));
-}
-
-fn put_f64(buf: &mut [u8; SHM_SIZE], off: usize, v: f64) {
-    buf[off..off + 8].copy_from_slice(&v.to_ne_bytes());
+fn unique_name(tag: &str) -> String {
+    // macOS caps shm names at 31 chars; keep the unique suffix short.
+    format!("/plt_t_{tag}_{}", std::process::id())
 }
 
 #[test]
@@ -54,50 +43,165 @@ fn identity_enu_flu_attitude_is_heading_east_in_ned() {
 }
 
 #[test]
-fn block_decodes_positions_velocities_and_time() {
-    let mut buf = [0u8; SHM_SIZE];
-    // pos ENU (east 1, north 2, up 3).
-    put_f64(&mut buf, super::OFF_POS, 1.0);
-    put_f64(&mut buf, super::OFF_POS + 8, 2.0);
-    put_f64(&mut buf, super::OFF_POS + 16, 3.0);
-    // identity quaternion.
-    put_f64(&mut buf, super::OFF_QUAT, 1.0);
-    // vel ENU (0.5 east, 0 north, -1 up = descending).
-    put_f64(&mut buf, super::OFF_VEL, 0.5);
-    put_f64(&mut buf, super::OFF_VEL + 16, -1.0);
-    buf[super::OFF_TIME_US..super::OFF_TIME_US + 8].copy_from_slice(&42_000_000u64.to_ne_bytes());
-
-    let s = decode_sample(&buf, 7);
-    assert_eq!(s.pos_ned_m, [2.0, 1.0, -3.0]);
-    assert_eq!(s.vel_ned_mps, [0.0, 0.5, 1.0]);
-    assert_eq!(s.time_us, 42_000_000);
-    assert_eq!(s.seq, 7);
+fn ninety_degree_enu_yaw_is_the_ned_identity() {
+    // A 90° yaw about ENU up points body forward at +y_ENU = north; in
+    // NED/FRD facing north is the identity attitude.
+    let half = core::f64::consts::FRAC_1_SQRT_2;
+    let q = enu_quat_to_ned([half, 0.0, 0.0, half]);
+    let expected = [1.0_f32, 0.0, 0.0, 0.0];
+    for (component, want) in q.iter().zip(expected) {
+        assert!((component - want).abs() < 1e-6, "quat {q:?}");
+    }
 }
 
 #[test]
-fn frozen_sample_never_revives_without_a_new_identity() {
+fn snapshot_conversion_translates_frames_and_preserves_identity_fields() {
+    let snapshot = ModelStateSnapshot {
+        reset_generation: 5,
+        sim_step: 777,
+        time_us: 42_000_000,
+        // pos ENU (east 1, north 2, up 3).
+        pos: [1.0, 2.0, 3.0],
+        quat: [1.0, 0.0, 0.0, 0.0],
+        // vel ENU (0.5 east, 0 north, -1 up = descending).
+        vel: [0.5, 0.0, -1.0],
+        ang_vel: [0.0; 3],
+    };
+    let sample = sample_from_snapshot(&snapshot);
+    assert_eq!(sample.pos_ned_m, [2.0, 1.0, -3.0]);
+    assert_eq!(sample.vel_ned_mps, [0.0, 0.5, 1.0]);
+    assert_eq!(sample.quat_wxyz, enu_quat_to_ned([1.0, 0.0, 0.0, 0.0]));
+    assert_eq!(sample.time_us, 42_000_000);
+    assert_eq!(sample.sim_step, 777);
+    assert_eq!(sample.reset_generation, 5);
+}
+
+#[test]
+fn world_angular_velocity_never_reaches_the_sample() {
+    // The contract's ang_vel lane is world-frame and advisory — NOT a
+    // body gyro. Two snapshots differing only in that lane must convert
+    // identically: no field of the sample may derive from it.
+    let still = ModelStateSnapshot {
+        reset_generation: 1,
+        sim_step: 10,
+        time_us: 1_000,
+        pos: [1.0, 2.0, 3.0],
+        quat: [1.0, 0.0, 0.0, 0.0],
+        vel: [0.5, 0.0, -1.0],
+        ang_vel: [0.0; 3],
+    };
+    let spinning = ModelStateSnapshot {
+        ang_vel: [7.0, -3.0, 11.0],
+        ..still
+    };
+    assert_eq!(
+        sample_from_snapshot(&still),
+        sample_from_snapshot(&spinning)
+    );
+}
+
+#[test]
+fn attach_failures_map_to_typed_errors_preserving_context() {
+    let io = attach_error(
+        "/t",
+        AttachFailure::Io(io::Error::from(io::ErrorKind::NotFound)),
+    );
+    assert!(
+        matches!(
+            io,
+            AviateAdapterError::ShmAttachIo { ref name, ref source }
+                if name == "/t" && source.kind() == io::ErrorKind::NotFound
+        ),
+        "got {io:?}"
+    );
+
+    let contract = attach_error(
+        "/t",
+        AttachFailure::Contract(AttachError::VersionMismatch { found: 2 }),
+    );
+    assert!(
+        matches!(
+            contract,
+            AviateAdapterError::ShmContractMismatch {
+                ref name,
+                violation: AttachError::VersionMismatch { found: 2 },
+            } if name == "/t"
+        ),
+        "got {contract:?}"
+    );
+
+    let not_ready = attach_error("/t", AttachFailure::NotReady);
+    assert!(
+        matches!(
+            not_ready,
+            AviateAdapterError::ShmWriterNotReady { ref name } if name == "/t"
+        ),
+        "got {not_ready:?}"
+    );
+}
+
+#[test]
+fn attach_to_an_absent_object_fails_closed_with_io_context() {
+    let refusal = GzStateShm::open_named(&unique_name("no"));
+    assert!(
+        matches!(refusal, Err(AviateAdapterError::ShmAttachIo { .. })),
+        "got {refusal:?}"
+    );
+}
+
+#[test]
+fn attach_reads_the_writers_published_snapshot_until_it_exits() {
+    let name = unique_name("att");
+    let writer = SimWriterSession::create(&name).expect("create writer");
+    let generation = writer.reset_generation();
+    writer.write_model_state(&ModelStateSnapshot {
+        reset_generation: generation,
+        sim_step: 2,
+        time_us: 1_000,
+        pos: [1.0, 2.0, 3.0],
+        quat: [1.0, 0.0, 0.0, 0.0],
+        vel: [0.0; 3],
+        ang_vel: [0.0; 3],
+    });
+
+    let reader = GzStateShm::open_named(&name).expect("attach accepts the block");
+    assert_eq!(reader.writer_state(), WriterState::Current);
+    let sample = reader.read().expect("coherent sample");
+    assert_eq!(sample.sim_step, 2);
+    assert_eq!(sample.reset_generation, generation);
+    assert_eq!(sample.time_us, 1_000);
+    assert_eq!(sample.pos_ned_m, [2.0, 1.0, -3.0]);
+
+    // The writer's exit is announced by the writer-state machine, not by
+    // the mapping (which still holds the dead world's final snapshot).
+    drop(writer);
+    assert_eq!(reader.writer_state(), WriterState::Gone);
+}
+
+#[test]
+fn frozen_sample_never_revives_without_new_progress() {
     let start = Instant::now();
     let mut freshness = ShmFreshness::new_at(start);
     assert_eq!(
-        freshness.observe_at(7, 42_000, start),
+        freshness.observe_at(8, 42_000, start),
         ShmObservation::Advancing
     );
     assert_eq!(
-        freshness.observe_at(7, 42_000, start + Duration::from_secs(4)),
+        freshness.observe_at(8, 42_000, start + Duration::from_secs(4)),
         ShmObservation::Unchanged(Duration::from_secs(4))
     );
     assert_eq!(
-        freshness.observe_at(7, 42_000, start + Duration::from_secs(8)),
+        freshness.observe_at(8, 42_000, start + Duration::from_secs(8)),
         ShmObservation::Unchanged(Duration::from_secs(8))
     );
 }
 
 #[test]
-fn same_object_rollback_is_quarantined_but_sequence_wrap_is_valid() {
+fn same_epoch_rollback_is_quarantined_but_step_wrap_is_valid() {
     let start = Instant::now();
     let mut wrapped = ShmFreshness::new_at(start);
     assert_eq!(
-        wrapped.observe_at(u32::MAX, 100, start),
+        wrapped.observe_at(u64::MAX, 100, start),
         ShmObservation::Advancing
     );
     assert_eq!(


### PR DESCRIPTION
Closes #114. Part of #96 (LINK-01 epic, XIL compatibility lane).

## Scope: ABI transport replacement only

**#115 replaces the shared-memory ABI transport only.** The telemetry it publishes remains an **estimator-shaped compatibility projection**: simulator truth rides `AvionicsSample`/`estimator_status_stamp` because the wire model has a single avionics sample shape, and `Auto` still models the shm and MAVLink links as alternatives. Those source-role defects predate this PR and are **#107's** to fix — #115 does not solve them, claims nothing about them, and adds **no new control use of SHM truth**. #107 is the immediate follow-up and remains required before any flight-like or operational source claim.

## Pinned upstream revision

`aviate-xil-shm` + `aviate-xil-contract` are git dependencies pinned to the identical exact revision **`ac9bd248406a892fbe97a712d921326c96abd8b6`** — the Aviate **#276 merge commit** (versioned shm namespace), which contains #272's Rust-owned contract. The Aviate repository is public; plain anonymous https fetch works locally and in CI.

## Source honesty

**This data is SIM ground truth, not an FC operational estimate.** The adapter currently exposes it through an estimator-shaped compatibility projection, selects it ahead of MAVLink in `Auto`, and uses its pose for SITL command construction. These behaviors are SIM-only; explicit truth/estimate separation remains required by #107 before flight-capable use. Stamps and `TRUTH_VALID_FLAGS` assert **simulator-field availability only** (rates bit clear — no body gyro exists on this source), not FC-estimator authorization.

## What changed

- `adapters/aviate/src/shm.rs` is a thin safe wrapper around the upstream read-only `ConsumerSession` (no `HostSession`/`FcSession`). The hand-mirrored ABI — offsets, magic/version/size validation, seqlock, mmap/munmap, CString, volatile reads, filesystem-identity logic — is deleted; layout knowledge lives only upstream. The adapter's direct `libc` dependency and its unsafe-code lint exception are gone (`[lints] workspace = true`, workspace `unsafe_code = "forbid"` applies).
- Every production attach and re-attach derives its object name from upstream **`shm_name()` / `ShmName`** — Pilotage contains no `/aviate_gz_bridge_v3` literal and never appends `_{instance}` itself; the reattachment machine stores a `String` copied from the returned `ShmName`. Naming and namespace-isolation guardrails are upstream's.
- Boundary conversion of `ModelStateSnapshot`: pos/vel world ENU → NED, quat `[w,x,y,z]` ENU/FLU → NED/FRD; `time_us`, `sim_step`, `reset_generation` preserved; `sim_step` is the source sequence. The advisory world-frame `ang_vel` lane is dropped: no body-rate field exists on the sample; published rates are neutral with their validity bit clear.
- `shm_sampling.rs` runs an explicit machine over upstream `writer_state()`:
  - `Current` → read; upstream `read() == None` publishes nothing (never replays frozen data).
  - `Replaced`/`Gone`/`Initializing` → output stops in the same poll; bounded (rate-limited) re-attachment; success starts a new Pilotage source epoch with fresh freshness state.
  - `ContractMismatch` → sticky typed fail-closed fault, exposed via `AviateAdapter::shm_fault()` and `error!`-logged; no re-attachment behind a fault.
  - A `reset_generation` change on the same writer starts a new source epoch and accepts the simulation-time rewind.
- `AttachFailure::{Io, Contract, NotReady}` map to typed `AviateAdapterError::{ShmAttachIo, ShmContractMismatch, ShmWriterNotReady}` preserving the original context (`#[source]` io error / upstream `AttachError` verbatim).

## Tests

- Golden vectors for ENU→NED position/velocity and ENU/FLU→NED/FRD quaternion (identity → east; 90° ENU yaw → NED identity).
- Proof world-frame angular velocity is never exposed as authoritative body rates (conversion invariance + rates validity bit clear against a producer publishing non-zero `ang_vel`).
- Integration with upstream `SimWriterSession` as the real producer, re-run against the `ac9bd248` pin: coherent reception; reset-generation change + sim-time rewind → new source epoch; writer disappearance stops output with no frozen replay; writer replacement → re-attach + new source epoch; bounded retry interval honored; absent attachment fails closed.
- Contract mismatch is covered by upstream's attach-validation tests plus Pilotage's typed-error mapping and sticky fail-closed state-machine tests — there is no real malformed-object integration fixture here (fabricating one would require the raw-memory access this PR removes).
- Synchronization is by process state and injected instants — no sleeps.
- All copied-ABI offset/header/capacity tests and the constant-based name test are removed; naming correctness relies on upstream's Rust/C++ guardrails.

## Out of scope

Command/actuator shm, lifecycle/time control, input/controller mapping, **#107's source-role redesign**, JavaScript changes.

## Gates (all green locally; branch verified in an isolated worktree with `--locked`)

`cargo fmt --check` · `clippy --all-targets -D warnings` · `test --all-targets` (0 failures) · `doc -D missing_docs -D broken_intra_doc_links` · `build --release` · `bash scripts/check-structure.sh` · no direct `libc`, `unsafe`, SHM offset, or hardcoded object-name mirror remains (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
