### PR TITLE
DEMO-01: cargo xtask sim — one-command SITL session launcher with a backend seam

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# `cargo xtask <command>` — the repo's orchestration entry point
+# (tools/xtask): launches SITL sessions, wraps the reset script.
+[alias]
+xtask = "run -q -p xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "yasna"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "adapters/aviate",
     "tools/hid-probe",
     "tools/loopback-probe",
+    "tools/xtask",
     "hosts/session-host",
     "adapters/gazebo",
     "clients/web-instruments",

--- a/scripts/reset-flight-sim.sh
+++ b/scripts/reset-flight-sim.sh
@@ -17,6 +17,17 @@ gz service -s "/world/${WORLD}/control" \
 
 echo "restarting FC..."
 pkill -9 -f sitl-gazebo-x500 2>/dev/null || true
+
+# When `cargo xtask sim` supervises the session, the supervisor restarts
+# the flight controller itself; a script-spawned second FC would fight it
+# over the shm writer lease.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPERVISOR_PID_FILE="${REPO_ROOT}/target/xtask-sim/supervisor.pid"
+if [[ -f "${SUPERVISOR_PID_FILE}" ]] && kill -0 "$(cat "${SUPERVISOR_PID_FILE}")" 2>/dev/null; then
+  echo "done — the xtask supervisor restarts the FC; re-arm from the browser once it logs ready"
+  exit 0
+fi
+
 sleep 1
 AVIATE_DIR="${AVIATE_DIR:-$HOME/Aviate}"
 nohup "${AVIATE_DIR}/target/debug/sitl-gazebo-x500" > /tmp/fc_manual.log 2>&1 &

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -10,6 +10,6 @@ workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "signal", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "signal", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+description = "Repository orchestration: one-command SITL session launch and reset (DEMO-01)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "signal", "time"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -1,0 +1,93 @@
+//! The FC-backend seam: each backend plans its simulator/FC stages and
+//! contributes the host's adapter and environment. The launcher itself
+//! stays backend-agnostic so future FC families (PX4, JSBSim) are new
+//! implementations, not new orchestration.
+
+use std::path::PathBuf;
+
+use crate::cli::Profile;
+use crate::error::XtaskError;
+use crate::process::ProcessSpec;
+use crate::readiness::Readiness;
+
+mod aviate_gz;
+
+/// Everything a backend may need to plan its stages.
+#[derive(Debug)]
+pub struct SessionContext {
+    /// Workspace root of this repository.
+    pub repo_root: PathBuf,
+    /// Host WebTransport port.
+    pub host_port: u16,
+    /// Static viewer port.
+    pub viewer_port: u16,
+    /// Session profile handed to the host.
+    pub profile: Profile,
+    /// Directory stage logs are written under.
+    pub log_dir: PathBuf,
+}
+
+/// One plannable launch step: a process and the signal proving it is up.
+#[derive(Debug)]
+pub struct Stage {
+    /// The process to run.
+    pub spec: ProcessSpec,
+    /// The readiness signal to wait for before the next stage.
+    pub readiness: Readiness,
+}
+
+/// A launchable FC/simulator family.
+pub trait SimBackend {
+    /// Backend name as selected by `--fc`.
+    fn name(&self) -> &'static str;
+    /// The session host `--adapter` this backend's telemetry plane uses.
+    fn host_adapter(&self) -> &'static str;
+    /// Extra environment the host needs for this backend.
+    fn host_env(&self, ctx: &SessionContext) -> Vec<(String, String)>;
+    /// Validates tools/artifacts and plans the simulator and FC stages,
+    /// in launch order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XtaskError::MissingArtifact`] with an actionable hint
+    /// when a required tool or build product is absent.
+    fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError>;
+    /// `pgrep -f` patterns that mark a stale session of this backend.
+    fn stale_process_patterns(&self) -> Vec<&'static str>;
+    /// Resets the running simulation world and FC.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XtaskError::CommandFailed`] when the reset reports
+    /// failure.
+    fn reset(&self, repo_root: &std::path::Path) -> Result<(), XtaskError>;
+}
+
+/// Resolves `--fc` to a backend, fail-closed on unknown names.
+///
+/// # Errors
+///
+/// Returns [`XtaskError::UnknownBackend`] for any name this launcher
+/// does not implement.
+pub fn backend_for(name: &str) -> Result<Box<dyn SimBackend>, XtaskError> {
+    match name {
+        "aviate" => Ok(Box::new(aviate_gz::AviateGz)),
+        _ => Err(XtaskError::UnknownBackend {
+            name: name.to_owned(),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::backend_for;
+    use crate::error::XtaskError;
+
+    #[test]
+    fn backend_selection_fails_closed() {
+        assert_eq!(backend_for("aviate").expect("known").name(), "aviate");
+        let refusal = backend_for("px4");
+        assert!(matches!(refusal, Err(XtaskError::UnknownBackend { .. })));
+    }
+}

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -1,0 +1,317 @@
+//! The Aviate + Gazebo SITL backend: the proven flight-deck runbook as
+//! code — headless gz with the Aviate plugin, then the SITL FC over the
+//! versioned shm block, each gated on its own readiness signal.
+
+use std::path::{Path, PathBuf};
+
+use super::{SessionContext, SimBackend, Stage};
+use crate::error::XtaskError;
+use crate::process::ProcessSpec;
+use crate::readiness::{Readiness, stage_log};
+
+/// The world this backend launches; its `<world name>` is `aviate_sitl`
+/// (also what the reset script targets).
+const WORLD: &str = "sim/worlds/x500_flightdeck.sdf";
+const WORLD_NAME: &str = "aviate_sitl";
+
+/// The Aviate + Gazebo SITL backend.
+#[derive(Debug)]
+pub struct AviateGz;
+
+impl SimBackend for AviateGz {
+    fn name(&self) -> &'static str {
+        "aviate"
+    }
+
+    fn host_adapter(&self) -> &'static str {
+        "aviate"
+    }
+
+    fn host_env(&self, _ctx: &SessionContext) -> Vec<(String, String)> {
+        // The camera sidecar discovers gz topics through this.
+        vec![("GZ_IP".to_owned(), "127.0.0.1".to_owned())]
+    }
+
+    fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {
+        plan_with_aviate_dir(ctx, &aviate_dir(&ctx.repo_root))
+    }
+
+    fn stale_process_patterns(&self) -> Vec<&'static str> {
+        vec!["gz sim", "sitl-gazebo-x500"]
+    }
+
+    fn reset(&self, repo_root: &Path) -> Result<(), XtaskError> {
+        let script = repo_root.join("scripts/reset-flight-sim.sh");
+        let status = std::process::Command::new("bash")
+            .arg(&script)
+            .arg(WORLD_NAME)
+            .env("PATH", search_path())
+            .status()
+            .map_err(|source| XtaskError::Io {
+                context: "running the reset script",
+                source,
+            })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(XtaskError::CommandFailed {
+                context: "reset script",
+                status: status.to_string(),
+            })
+        }
+    }
+}
+
+/// Where the sibling Aviate checkout lives: `AVIATE_DIR`, else
+/// `../Aviate` next to this repository. A directory convention, never a
+/// source dependency.
+fn aviate_dir(repo_root: &Path) -> PathBuf {
+    std::env::var_os("AVIATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root.join("../Aviate"))
+}
+
+/// `PATH` for spawned tools, with Homebrew's prefix appended when it
+/// exists (gz lives there on macOS; a login shell has it, a bare spawn
+/// may not).
+fn search_path() -> String {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    let brew = Path::new("/opt/homebrew/bin");
+    if brew.is_dir() && !inherited.split(':').any(|p| p == "/opt/homebrew/bin") {
+        format!("{inherited}:/opt/homebrew/bin")
+    } else {
+        inherited
+    }
+}
+
+/// The testable core of [`AviateGz::plan`]: validates every artifact
+/// with an actionable hint, then assembles the gz and FC stages.
+fn plan_with_aviate_dir(ctx: &SessionContext, aviate: &Path) -> Result<Vec<Stage>, XtaskError> {
+    if !aviate.is_dir() {
+        return Err(XtaskError::MissingArtifact {
+            what: "Aviate checkout",
+            path: aviate.to_path_buf(),
+            hint: "clone the sibling Aviate repository or set AVIATE_DIR",
+        });
+    }
+    let plugin_dir = aviate.join("aviate-hal/xil/backends/gz/plugin/build");
+    let plugin = plugin_dir.join("libAviateGzPlugin.dylib");
+    let plugin_linux = plugin_dir.join("libAviateGzPlugin.so");
+    if !plugin.is_file() && !plugin_linux.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "Aviate gz plugin",
+            path: plugin,
+            hint: "build it: cmake .. && make -j8 in aviate-hal/xil/backends/gz/plugin/build",
+        });
+    }
+    let fc = aviate.join("target/debug/sitl-gazebo-x500");
+    if !fc.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "Aviate SITL FC binary",
+            path: fc,
+            hint: "build it: cargo build --bin sitl-gazebo-x500 in the Aviate checkout",
+        });
+    }
+    let world = ctx.repo_root.join(WORLD);
+    if !world.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "flight-deck world",
+            path: world,
+            hint: "run from the Pilotage repository root",
+        });
+    }
+    Ok(vec![
+        gz_stage(ctx, aviate, &search_path(), &world),
+        fc_stage(ctx, aviate, &search_path(), &fc),
+    ])
+}
+
+fn gz_stage(ctx: &SessionContext, aviate: &Path, path: &str, world: &Path) -> Stage {
+    let models = aviate.join("external/PX4-gazebo-models/models");
+    let gz_env = vec![
+        ("PATH".to_owned(), path.to_owned()),
+        ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
+        (
+            "GZ_SIM_SYSTEM_PLUGIN_PATH".to_owned(),
+            aviate
+                .join("aviate-hal/xil/backends/gz/plugin/build")
+                .display()
+                .to_string(),
+        ),
+        (
+            "GZ_SIM_RESOURCE_PATH".to_owned(),
+            format!(
+                "{}:{}",
+                models.display(),
+                ctx.repo_root.join("sim/worlds").display()
+            ),
+        ),
+    ];
+    Stage {
+        spec: ProcessSpec {
+            name: "gazebo",
+            program: "gz".to_owned(),
+            args: vec![
+                "sim".to_owned(),
+                "-s".to_owned(),
+                "-r".to_owned(),
+                "--headless-rendering".to_owned(),
+                world.display().to_string(),
+            ],
+            cwd: None,
+            env: gz_env.clone(),
+            // Cleared so gz selects the EGL backend instead of an X
+            // display that is not there.
+            remove_env: vec!["DISPLAY"],
+            log_path: stage_log(&ctx.log_dir, "gazebo"),
+        },
+        readiness: Readiness::CommandOutput {
+            program: "gz".to_owned(),
+            args: vec!["topic".to_owned(), "-l".to_owned()],
+            env: gz_env,
+            needle: WORLD_NAME,
+            timeout_s: 60,
+        },
+    }
+}
+
+fn fc_stage(ctx: &SessionContext, aviate: &Path, path: &str, fc: &Path) -> Stage {
+    Stage {
+        spec: ProcessSpec {
+            name: "flight-controller",
+            program: fc.display().to_string(),
+            args: vec![],
+            cwd: Some(aviate.to_path_buf()),
+            env: vec![
+                ("PATH".to_owned(), path.to_owned()),
+                ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
+            ],
+            remove_env: vec![],
+            log_path: stage_log(&ctx.log_dir, "flight-controller"),
+        },
+        readiness: Readiness::LogContains {
+            needle: "-> Ready",
+            timeout_s: 30,
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::plan_with_aviate_dir;
+    use crate::backend::SessionContext;
+    use crate::cli::Profile;
+    use crate::error::XtaskError;
+
+    fn context(repo_root: PathBuf) -> SessionContext {
+        let log_dir = repo_root.join("target/xtask-sim");
+        SessionContext {
+            repo_root,
+            host_port: 4433,
+            viewer_port: 8080,
+            profile: Profile::Simulation,
+            log_dir,
+        }
+    }
+
+    fn scaffold(tag: &str) -> (PathBuf, PathBuf) {
+        let base = std::env::temp_dir().join(format!("plt_xtask_{tag}_{}", std::process::id()));
+        let repo = base.join("repo");
+        let aviate = base.join("Aviate");
+        std::fs::create_dir_all(repo.join("sim/worlds")).expect("repo dirs");
+        std::fs::create_dir_all(aviate.join("aviate-hal/xil/backends/gz/plugin/build"))
+            .expect("plugin dir");
+        std::fs::create_dir_all(aviate.join("target/debug")).expect("fc dir");
+        (repo, aviate)
+    }
+
+    #[test]
+    fn missing_artifacts_fail_with_actionable_hints() {
+        let (repo, aviate) = scaffold("hints");
+        let ctx = context(repo.clone());
+
+        let refusal = plan_with_aviate_dir(&ctx, &aviate.join("nowhere"));
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "Aviate checkout",
+                ..
+            })
+        ));
+
+        let refusal = plan_with_aviate_dir(&ctx, &aviate);
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "Aviate gz plugin",
+                ..
+            })
+        ));
+
+        std::fs::write(
+            aviate.join("aviate-hal/xil/backends/gz/plugin/build/libAviateGzPlugin.dylib"),
+            b"",
+        )
+        .expect("plugin");
+        let refusal = plan_with_aviate_dir(&ctx, &aviate);
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "Aviate SITL FC binary",
+                ..
+            })
+        ));
+
+        std::fs::write(aviate.join("target/debug/sitl-gazebo-x500"), b"").expect("fc");
+        let refusal = plan_with_aviate_dir(&ctx, &aviate);
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "flight-deck world",
+                ..
+            })
+        ));
+        std::fs::remove_dir_all(repo.parent().expect("base")).ok();
+    }
+
+    #[test]
+    fn a_complete_checkout_plans_gz_then_fc_with_the_runbook_environment() {
+        let (repo, aviate) = scaffold("plan");
+        std::fs::write(
+            aviate.join("aviate-hal/xil/backends/gz/plugin/build/libAviateGzPlugin.dylib"),
+            b"",
+        )
+        .expect("plugin");
+        std::fs::write(aviate.join("target/debug/sitl-gazebo-x500"), b"").expect("fc");
+        std::fs::write(repo.join("sim/worlds/x500_flightdeck.sdf"), b"<sdf/>").expect("world");
+
+        let ctx = context(repo.clone());
+        let stages = plan_with_aviate_dir(&ctx, &aviate).expect("plans");
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0].spec.name, "gazebo");
+        assert_eq!(stages[1].spec.name, "flight-controller");
+
+        let env = |stage: usize, key: &str| -> String {
+            stages[stage]
+                .spec
+                .env
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| panic!("{key} missing"))
+        };
+        assert!(env(0, "GZ_SIM_SYSTEM_PLUGIN_PATH").contains("plugin/build"));
+        assert!(env(0, "GZ_SIM_RESOURCE_PATH").contains("PX4-gazebo-models"));
+        assert!(env(0, "GZ_SIM_RESOURCE_PATH").contains("sim/worlds"));
+        assert_eq!(env(0, "GZ_IP"), "127.0.0.1");
+        assert!(
+            stages[0].spec.remove_env.contains(&"DISPLAY"),
+            "gz must run headless without an X display"
+        );
+        assert_eq!(env(1, "GZ_IP"), "127.0.0.1");
+        std::fs::remove_dir_all(repo.parent().expect("base")).ok();
+    }
+}

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -1,0 +1,206 @@
+//! Argument parsing for the xtask entry point: `sim`, `reset`, `help`.
+
+use crate::error::XtaskError;
+
+/// Which session profile the host runs (mirrors the host's fail-closed
+/// `PILOTAGE_AVIATE_PROFILE` vocabulary exactly).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profile {
+    /// FC estimate + FC state; no truth source.
+    Physical,
+    /// Estimate + FC state, plus the truth oracle when attachable.
+    Simulation,
+    /// Truth stream only; no uplink, no operational control.
+    OracleOnly,
+}
+
+impl Profile {
+    /// The value passed through to `PILOTAGE_AVIATE_PROFILE`.
+    pub fn as_env_value(self) -> &'static str {
+        match self {
+            Profile::Physical => "physical",
+            Profile::Simulation => "simulation",
+            Profile::OracleOnly => "oracle-only",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, XtaskError> {
+        match value {
+            "physical" => Ok(Profile::Physical),
+            "simulation" => Ok(Profile::Simulation),
+            "oracle-only" => Ok(Profile::OracleOnly),
+            _ => Err(XtaskError::UnknownProfile {
+                value: value.to_owned(),
+            }),
+        }
+    }
+}
+
+/// Options for `cargo xtask sim`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SimArgs {
+    /// Which FC backend to launch (`--fc`, default `aviate`).
+    pub fc: String,
+    /// Session profile handed to the host (`--profile`).
+    pub profile: Profile,
+    /// Host WebTransport port (`--port`).
+    pub host_port: u16,
+    /// Static viewer port (`--viewer-port`).
+    pub viewer_port: u16,
+    /// Open the ready URL in the default browser (`--open`).
+    pub open: bool,
+}
+
+/// A parsed xtask invocation.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Command {
+    /// Launch a full SITL session and supervise it.
+    Sim(SimArgs),
+    /// Reset the running simulation world and FC.
+    Reset,
+    /// Print usage.
+    Help,
+}
+
+/// Parses raw arguments (without the binary name).
+///
+/// # Errors
+///
+/// Returns [`XtaskError::Usage`], [`XtaskError::UnknownProfile`], or
+/// [`XtaskError::UnknownBackend`] on malformed input; backend existence
+/// is validated later by the backend registry.
+pub fn parse_args(args: &[String]) -> Result<Command, XtaskError> {
+    let Some((command, rest)) = args.split_first() else {
+        return Ok(Command::Help);
+    };
+    match command.as_str() {
+        "sim" => Ok(Command::Sim(parse_sim(rest)?)),
+        "reset" => {
+            if let Some(extra) = rest.first() {
+                return Err(XtaskError::Usage {
+                    message: format!("reset takes no arguments (got {extra:?})"),
+                });
+            }
+            Ok(Command::Reset)
+        }
+        "help" | "--help" | "-h" => Ok(Command::Help),
+        other => Err(XtaskError::Usage {
+            message: format!("unknown command {other:?} (expected sim, reset, or help)"),
+        }),
+    }
+}
+
+fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
+    let mut fc = "aviate".to_owned();
+    let mut profile = Profile::Simulation;
+    let mut host_port: u16 = 4433;
+    let mut viewer_port: u16 = 8080;
+    let mut open = false;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--fc" => fc = required_value(&mut iter, "--fc")?,
+            "--profile" => profile = Profile::parse(&required_value(&mut iter, "--profile")?)?,
+            "--port" => host_port = required_port(&mut iter, "--port")?,
+            "--viewer-port" => viewer_port = required_port(&mut iter, "--viewer-port")?,
+            "--open" => open = true,
+            other => {
+                return Err(XtaskError::Usage {
+                    message: format!("unknown sim flag {other:?}"),
+                });
+            }
+        }
+    }
+    Ok(SimArgs {
+        fc,
+        profile,
+        host_port,
+        viewer_port,
+        open,
+    })
+}
+
+fn required_value(
+    iter: &mut std::slice::Iter<'_, String>,
+    flag: &'static str,
+) -> Result<String, XtaskError> {
+    iter.next().cloned().ok_or_else(|| XtaskError::Usage {
+        message: format!("{flag} requires a value"),
+    })
+}
+
+fn required_port(
+    iter: &mut std::slice::Iter<'_, String>,
+    flag: &'static str,
+) -> Result<u16, XtaskError> {
+    let raw = required_value(iter, flag)?;
+    raw.parse().map_err(|_| XtaskError::Usage {
+        message: format!("{flag} expects a port number, got {raw:?}"),
+    })
+}
+
+/// The `help` text.
+pub const USAGE: &str = "\
+cargo xtask <command>
+
+commands:
+  sim    launch a full SITL session (simulator + FC + host + viewer),
+         print the ready URL, supervise, and tear down on ctrl-c
+         --fc <name>          FC backend (default: aviate)
+         --profile <p>        physical | simulation (default) | oracle-only
+         --port <n>           host WebTransport port (default: 4433)
+         --viewer-port <n>    static viewer port (default: 8080)
+         --open               open the ready URL in the default browser
+  reset  reset the running simulation world and restart the FC
+  help   print this text";
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{Command, Profile, parse_args};
+    use crate::error::XtaskError;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn sim_defaults_are_the_documented_ones() {
+        let Command::Sim(sim) = parse_args(&args(&["sim"])).expect("parses") else {
+            panic!("expected sim");
+        };
+        assert_eq!(sim.fc, "aviate");
+        assert_eq!(sim.profile, Profile::Simulation);
+        assert_eq!(sim.host_port, 4433);
+        assert_eq!(sim.viewer_port, 8080);
+        assert!(!sim.open);
+    }
+
+    #[test]
+    fn sim_flags_parse_and_unknown_values_fail_closed() {
+        let Command::Sim(sim) = parse_args(&args(&[
+            "sim",
+            "--profile",
+            "oracle-only",
+            "--port",
+            "5000",
+            "--viewer-port",
+            "9000",
+            "--open",
+        ]))
+        .expect("parses") else {
+            panic!("expected sim");
+        };
+        assert_eq!(sim.profile, Profile::OracleOnly);
+        assert_eq!(sim.host_port, 5000);
+        assert_eq!(sim.viewer_port, 9000);
+        assert!(sim.open);
+
+        let refusal = parse_args(&args(&["sim", "--profile", "simulaton"]));
+        assert!(matches!(refusal, Err(XtaskError::UnknownProfile { .. })));
+        let refusal = parse_args(&args(&["sim", "--port", "banana"]));
+        assert!(matches!(refusal, Err(XtaskError::Usage { .. })));
+        let refusal = parse_args(&args(&["fly"]));
+        assert!(matches!(refusal, Err(XtaskError::Usage { .. })));
+    }
+}

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -134,9 +134,19 @@ fn required_port(
     flag: &'static str,
 ) -> Result<u16, XtaskError> {
     let raw = required_value(iter, flag)?;
-    raw.parse().map_err(|_| XtaskError::Usage {
+    let port: u16 = raw.parse().map_err(|_| XtaskError::Usage {
         message: format!("{flag} expects a port number, got {raw:?}"),
-    })
+    })?;
+    // Port 0 asks the OS for an ephemeral port, but readiness checks and
+    // the printed viewer URL would keep using the literal 0 — nothing
+    // reports the allocated port back, so the session could never be
+    // reached. Reject it rather than print a URL that cannot work.
+    if port == 0 {
+        return Err(XtaskError::Usage {
+            message: format!("{flag} must be 1-65535: port 0 (ephemeral) cannot be advertised"),
+        });
+    }
+    Ok(port)
 }
 
 /// The `help` text.
@@ -202,5 +212,18 @@ mod tests {
         assert!(matches!(refusal, Err(XtaskError::Usage { .. })));
         let refusal = parse_args(&args(&["fly"]));
         assert!(matches!(refusal, Err(XtaskError::Usage { .. })));
+    }
+
+    #[test]
+    fn port_zero_is_rejected_on_both_port_flags() {
+        // Port 0 would bind an ephemeral port that readiness checks and
+        // the printed viewer URL never learn about.
+        for flag in ["--port", "--viewer-port"] {
+            let refusal = parse_args(&args(&["sim", flag, "0"]));
+            assert!(
+                matches!(refusal, Err(XtaskError::Usage { .. })),
+                "{flag} 0 must be refused"
+            );
+        }
     }
 }

--- a/tools/xtask/src/error.rs
+++ b/tools/xtask/src/error.rs
@@ -92,4 +92,18 @@ pub enum XtaskError {
         #[source]
         source: std::io::Error,
     },
+    /// The user pressed ctrl-c before the session was ready; every
+    /// started stage has been torn down. A requested stop, not a fault.
+    #[error("session stopped before it was ready")]
+    Cancelled,
+    /// The host proved it is listening on a different port than the one
+    /// requested: advertising the requested port would hand out a URL
+    /// that cannot connect.
+    #[error("host is listening on port {actual}, not the requested {requested}")]
+    PortMismatch {
+        /// The port the launcher asked for.
+        requested: u16,
+        /// The port the host's LISTENING line proved.
+        actual: u16,
+    },
 }

--- a/tools/xtask/src/error.rs
+++ b/tools/xtask/src/error.rs
@@ -1,0 +1,95 @@
+//! Typed errors for the xtask launcher.
+
+use std::path::PathBuf;
+
+/// Why an xtask command could not run or has stopped.
+#[derive(Debug, thiserror::Error)]
+pub enum XtaskError {
+    /// Argument parsing failed: an unknown flag or missing/malformed value.
+    #[error("usage error: {message}")]
+    Usage {
+        /// What was wrong with the arguments.
+        message: String,
+    },
+    /// `--fc` named a backend this launcher does not know. Unknown
+    /// backends fail closed instead of guessing.
+    #[error("unknown --fc backend {name:?} (expected: aviate)")]
+    UnknownBackend {
+        /// The rejected backend name.
+        name: String,
+    },
+    /// `--profile` named an unknown session profile. Mirrors the host's
+    /// own fail-closed parsing: a typo must never fail open.
+    #[error("unknown --profile {value:?} (expected physical, simulation, or oracle-only)")]
+    UnknownProfile {
+        /// The rejected profile value.
+        value: String,
+    },
+    /// A tool or artifact a backend needs is absent.
+    #[error("{what} not found at {}: {hint}", path.display())]
+    MissingArtifact {
+        /// What was being looked for.
+        what: &'static str,
+        /// Where it was expected.
+        path: PathBuf,
+        /// How to produce it.
+        hint: &'static str,
+    },
+    /// Session processes from a previous run are still alive. The
+    /// launcher never kills processes it did not start.
+    #[error(
+        "session processes are already running:\n{listing}\nstop them first: pkill -f \"gz sim\"; pkill -f sitl-gazebo-x500; pkill -f pilotage-session-host; pkill -f \"http.server\""
+    )]
+    StaleSession {
+        /// `pgrep` listing of the offending processes.
+        listing: String,
+    },
+    /// Spawning a managed process failed.
+    #[error("spawning {name} failed: {source}")]
+    Spawn {
+        /// The stage that failed to start.
+        name: &'static str,
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A stage did not become ready before its deadline.
+    #[error("{name} was not ready within {seconds} s ({detail}); log: {}", log.display())]
+    NotReady {
+        /// The stage that never became ready.
+        name: &'static str,
+        /// The deadline that elapsed.
+        seconds: u64,
+        /// What readiness was being waited for.
+        detail: String,
+        /// Where the stage's output was captured.
+        log: PathBuf,
+    },
+    /// A stage exited while the session was starting or running.
+    #[error("{name} exited ({status}); last log lines:\n{tail}")]
+    StageDied {
+        /// The stage that died.
+        name: &'static str,
+        /// Its exit status.
+        status: String,
+        /// The tail of its captured log.
+        tail: String,
+    },
+    /// A build or helper command reported failure.
+    #[error("{context} failed with {status}")]
+    CommandFailed {
+        /// What was being run.
+        context: &'static str,
+        /// The reported exit status.
+        status: String,
+    },
+    /// An I/O operation outside process management failed.
+    #[error("I/O failure during {context}: {source}")]
+    Io {
+        /// What was being done.
+        context: &'static str,
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -20,8 +20,11 @@ fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match run(&args) {
         Ok(()) => ExitCode::SUCCESS,
+        // A ctrl-c before the session was ready is a requested stop:
+        // everything started has been torn down, nothing failed.
+        Err(error::XtaskError::Cancelled) => ExitCode::SUCCESS,
         Err(error) => {
-            print_line(&format!("error: {error}"));
+            tracing::error!(%error, "xtask failed");
             ExitCode::FAILURE
         }
     }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -1,0 +1,48 @@
+//! Repository orchestration entry point (`cargo xtask ...`): launches a
+//! full SITL session behind one command with event-based readiness and
+//! ordered teardown, and wraps the simulation reset script.
+
+use std::process::ExitCode;
+
+mod backend;
+mod cli;
+mod error;
+mod output;
+mod process;
+mod readiness;
+mod session;
+
+use cli::Command;
+use output::print_line;
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            print_line(&format!("error: {error}"));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<(), error::XtaskError> {
+    match cli::parse_args(args)? {
+        Command::Help => {
+            print_line(cli::USAGE);
+            Ok(())
+        }
+        Command::Reset => session::run_reset("aviate"),
+        Command::Sim(sim) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|source| error::XtaskError::Io {
+                    context: "building the async runtime",
+                    source,
+                })?;
+            runtime.block_on(session::run_sim(&sim))
+        }
+    }
+}

--- a/tools/xtask/src/output.rs
+++ b/tools/xtask/src/output.rs
@@ -1,0 +1,16 @@
+//! The single sanctioned place this binary writes to stdout.
+//!
+//! `disallowed_macros` (ADR-0015) bans bare `println!` everywhere else in
+//! the workspace so library crates never grow CLI side effects; this
+//! module is the CLI-product-output exception the lint rule anticipates
+//! (launch progress and the ready URL are this tool's deliverable, not a
+//! debug trace). Diagnostics still go through `tracing`.
+
+/// Writes one line of user-facing CLI output to stdout.
+// WHY: launch progress and the session-ready URL are the product of this
+// tool, so the workspace-wide println ban is waived here and nowhere else
+// in this binary.
+#[allow(clippy::disallowed_macros)]
+pub fn print_line(line: &str) {
+    println!("{line}");
+}

--- a/tools/xtask/src/process.rs
+++ b/tools/xtask/src/process.rs
@@ -125,14 +125,17 @@ impl ManagedChild {
     }
 
     /// Terminates the stage's whole process group: TERM, a bounded
-    /// grace wait, then KILL, then reap.
+    /// grace wait, then an unconditional group KILL, then reap. The
+    /// leader exiting only ends the grace wait early — descendants
+    /// that ignored TERM outlive it in the same group, so the KILL is
+    /// sent regardless (killing an already-empty group is harmless).
     pub fn terminate_group(&mut self) {
         let pid = self.child.id();
         signal_group(pid, "-TERM");
         let deadline = Instant::now() + TERM_GRACE;
         while Instant::now() < deadline {
             if matches!(self.child.try_wait(), Ok(Some(_))) {
-                return;
+                break;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
@@ -152,4 +155,83 @@ fn signal_group(pid: u32, signal: &str) {
         .stderr(Stdio::null())
         .status()
         .ok();
+}
+
+/// Whether any member of `pid`'s process group is still alive (signal 0
+/// probes without delivering).
+#[cfg(test)]
+pub(crate) fn group_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg("--")
+        .arg(format!("-{pid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{ManagedChild, ProcessSpec, group_alive};
+
+    fn spec(name: &'static str, script: &str, log: &std::path::Path) -> ProcessSpec {
+        ProcessSpec {
+            name,
+            program: "sh".to_owned(),
+            args: vec!["-c".to_owned(), script.to_owned()],
+            cwd: None,
+            env: Vec::new(),
+            remove_env: Vec::new(),
+            log_path: log.to_path_buf(),
+        }
+    }
+
+    fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
+        let end = Instant::now() + deadline;
+        while Instant::now() < end {
+            if done() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        done()
+    }
+
+    /// The leader exiting must not spare its descendants: a grandchild
+    /// that ignores TERM still dies from the unconditional group KILL.
+    #[test]
+    fn group_kill_reaches_term_ignoring_descendants_after_the_leader_exits() {
+        let log = std::env::temp_dir().join(format!("plt_xtask_grp_{}.log", std::process::id()));
+        let mut child = ManagedChild::spawn(&spec(
+            "group-test",
+            // The grandchild ignores TERM and holds the group; the
+            // leader exits immediately.
+            "sh -c 'trap \"\" TERM; sleep 30' & exit 0",
+            &log,
+        ))
+        .expect("test stage spawns");
+        let pid = child.child.id();
+
+        assert!(
+            wait_until(Duration::from_secs(5), || child.check_running().is_err()),
+            "the leader must exit on its own"
+        );
+        assert!(
+            group_alive(pid),
+            "the TERM-ignoring grandchild must be holding the group"
+        );
+
+        child.terminate_group();
+
+        assert!(
+            wait_until(Duration::from_secs(5), || !group_alive(pid)),
+            "the group KILL must reach the grandchild even though the leader already exited"
+        );
+        std::fs::remove_file(&log).ok();
+    }
 }

--- a/tools/xtask/src/process.rs
+++ b/tools/xtask/src/process.rs
@@ -160,78 +160,75 @@ fn signal_group(pid: u32, signal: &str) {
 /// Whether any member of `pid`'s process group is still alive (signal 0
 /// probes without delivering).
 #[cfg(test)]
-pub(crate) fn group_alive(pid: u32) -> bool {
-    Command::new("kill")
-        .arg("-0")
-        .arg("--")
-        .arg(format!("-{pid}"))
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-#[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::io::Read;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
-    use super::{ManagedChild, ProcessSpec, group_alive};
+    use super::{ManagedChild, ProcessSpec};
 
-    fn spec(name: &'static str, script: &str, log: &std::path::Path) -> ProcessSpec {
-        ProcessSpec {
-            name,
-            program: "sh".to_owned(),
-            args: vec!["-c".to_owned(), script.to_owned()],
-            cwd: None,
-            env: Vec::new(),
-            remove_env: Vec::new(),
-            log_path: log.to_path_buf(),
-        }
-    }
-
-    fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
-        let end = Instant::now() + deadline;
-        while Instant::now() < end {
-            if done() {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        done()
-    }
+    const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// The leader exiting must not spare its descendants: a grandchild
     /// that ignores TERM still dies from the unconditional group KILL.
+    /// The fifo synchronizes on process events, not polling: its open is
+    /// the grandchild-started event, and EOF fires only when every
+    /// process holding the write end — the whole group — is gone.
     #[test]
     fn group_kill_reaches_term_ignoring_descendants_after_the_leader_exits() {
-        let log = std::env::temp_dir().join(format!("plt_xtask_grp_{}.log", std::process::id()));
-        let mut child = ManagedChild::spawn(&spec(
-            "group-test",
-            // The grandchild ignores TERM and holds the group; the
-            // leader exits immediately.
-            "sh -c 'trap \"\" TERM; sleep 30' & exit 0",
-            &log,
-        ))
-        .expect("test stage spawns");
-        let pid = child.child.id();
+        let tag = format!("plt_grp_{}", std::process::id());
+        let fifo = std::env::temp_dir().join(format!("{tag}.fifo"));
+        let log = std::env::temp_dir().join(format!("{tag}.log"));
+        std::fs::remove_file(&fifo).ok();
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo runs");
+        assert!(status.success(), "mkfifo creates the fifo");
 
-        assert!(
-            wait_until(Duration::from_secs(5), || child.check_running().is_err()),
-            "the leader must exit on its own"
-        );
-        assert!(
-            group_alive(pid),
-            "the TERM-ignoring grandchild must be holding the group"
-        );
+        let (tx, rx) = mpsc::channel();
+        let reader_path = fifo.clone();
+        std::thread::spawn(move || {
+            let mut file =
+                std::fs::File::open(&reader_path).expect("fifo opens once the grandchild starts");
+            tx.send("open").ok();
+            let mut sink = Vec::new();
+            file.read_to_end(&mut sink).ok();
+            tx.send("eof").ok();
+            std::fs::remove_file(&reader_path).ok();
+        });
+
+        // The grandchild ignores TERM and holds the fifo; the leader
+        // exits immediately.
+        let mut child = ManagedChild::spawn(&ProcessSpec {
+            name: "group-test",
+            program: "sh".to_owned(),
+            args: vec![
+                "-c".to_owned(),
+                format!(
+                    "sh -c 'trap \"\" TERM; exec 9>{}; sleep 30' & exit 0",
+                    fifo.display()
+                ),
+            ],
+            cwd: None,
+            env: Vec::new(),
+            remove_env: Vec::new(),
+            log_path: log.clone(),
+        })
+        .expect("test stage spawns");
+
+        let event = rx.recv_timeout(EVENT_TIMEOUT).expect("grandchild starts");
+        assert_eq!(event, "open", "the grandchild is holding the group");
+        // The leader exits on its own; reaped or not, the group must die.
+        child.child.wait().ok();
 
         child.terminate_group();
 
-        assert!(
-            wait_until(Duration::from_secs(5), || !group_alive(pid)),
-            "the group KILL must reach the grandchild even though the leader already exited"
-        );
+        let event = rx
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("the group KILL reaches the grandchild");
+        assert_eq!(event, "eof", "every group member is gone");
         std::fs::remove_file(&log).ok();
     }
 }

--- a/tools/xtask/src/process.rs
+++ b/tools/xtask/src/process.rs
@@ -1,0 +1,155 @@
+//! Managed child processes: spawn with captured logs and their own
+//! process group, health checks, and group teardown.
+//!
+//! Each stage runs in its OWN process group so a terminal ctrl-c (which
+//! signals the launcher's group) never kills stages out from under the
+//! ordered teardown, and so teardown can signal a stage's whole subtree
+//! (gz spawns helpers) without unsafe code — the group is signalled via
+//! the `kill` utility rather than `libc::killpg`.
+
+use std::fs::File;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::error::XtaskError;
+
+/// Grace period between TERM and KILL during teardown.
+const TERM_GRACE: Duration = Duration::from_secs(2);
+
+/// One process a session stage runs.
+#[derive(Debug)]
+pub struct ProcessSpec {
+    /// Stage name for progress and errors.
+    pub name: &'static str,
+    /// Program to execute.
+    pub program: String,
+    /// Arguments.
+    pub args: Vec<String>,
+    /// Working directory, when it matters.
+    pub cwd: Option<PathBuf>,
+    /// Environment entries set on top of the inherited environment.
+    pub env: Vec<(String, String)>,
+    /// Environment names removed (e.g. `DISPLAY` for headless gz).
+    pub remove_env: Vec<&'static str>,
+    /// File capturing the process's stdout+stderr.
+    pub log_path: PathBuf,
+}
+
+/// A spawned stage.
+#[derive(Debug)]
+pub struct ManagedChild {
+    /// Stage name.
+    pub name: &'static str,
+    /// Captured-output path.
+    pub log_path: PathBuf,
+    child: Child,
+}
+
+impl ManagedChild {
+    /// Spawns `spec` with stdout/stderr captured to its log file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XtaskError::Spawn`] (or [`XtaskError::Io`] for the log
+    /// file) when the process cannot start.
+    pub fn spawn(spec: &ProcessSpec) -> Result<Self, XtaskError> {
+        let log = File::create(&spec.log_path).map_err(|source| XtaskError::Io {
+            context: "creating a stage log file",
+            source,
+        })?;
+        let log_err = log.try_clone().map_err(|source| XtaskError::Io {
+            context: "cloning a stage log handle",
+            source,
+        })?;
+        let mut command = Command::new(&spec.program);
+        command
+            .args(&spec.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(log_err));
+        if let Some(cwd) = &spec.cwd {
+            command.current_dir(cwd);
+        }
+        for (key, value) in &spec.env {
+            command.env(key, value);
+        }
+        for key in &spec.remove_env {
+            command.env_remove(key);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        let child = command.spawn().map_err(|source| XtaskError::Spawn {
+            name: spec.name,
+            source,
+        })?;
+        Ok(Self {
+            name: spec.name,
+            log_path: spec.log_path.clone(),
+            child,
+        })
+    }
+
+    /// `Ok(())` while running; the stage's exit status once it stopped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XtaskError::StageDied`] with the log tail when the
+    /// process has exited.
+    pub fn check_running(&mut self) -> Result<(), XtaskError> {
+        match self.child.try_wait() {
+            Ok(None) => Ok(()),
+            Ok(Some(status)) => Err(XtaskError::StageDied {
+                name: self.name,
+                status: status.to_string(),
+                tail: self.log_tail(12),
+            }),
+            Err(source) => Err(XtaskError::Io {
+                context: "polling a stage",
+                source,
+            }),
+        }
+    }
+
+    /// The last `lines` of the stage's captured log.
+    pub fn log_tail(&self, lines: usize) -> String {
+        let Ok(content) = std::fs::read_to_string(&self.log_path) else {
+            return String::from("<log unreadable>");
+        };
+        let all: Vec<&str> = content.lines().collect();
+        let start = all.len().saturating_sub(lines);
+        all[start..].join("\n")
+    }
+
+    /// Terminates the stage's whole process group: TERM, a bounded
+    /// grace wait, then KILL, then reap.
+    pub fn terminate_group(&mut self) {
+        let pid = self.child.id();
+        signal_group(pid, "-TERM");
+        let deadline = Instant::now() + TERM_GRACE;
+        while Instant::now() < deadline {
+            if matches!(self.child.try_wait(), Ok(Some(_))) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        signal_group(pid, "-KILL");
+        self.child.kill().ok();
+        self.child.wait().ok();
+    }
+}
+
+/// Signals a process group via the `kill` utility (no unsafe `killpg`).
+fn signal_group(pid: u32, signal: &str) {
+    Command::new("kill")
+        .arg(signal)
+        .arg("--")
+        .arg(format!("-{pid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok();
+}

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -55,8 +55,16 @@ pub enum Readiness {
 pub enum ReadySignal {
     /// The stage is up.
     Up,
-    /// The host is listening with this certificate hash.
-    HostCertificate(String),
+    /// The host proved it is listening: the port from its LISTENING
+    /// line (the one it actually bound, carried so the caller can fail
+    /// closed on a mismatch instead of advertising a dead URL) and its
+    /// certificate hash.
+    HostListening {
+        /// The port the host proved.
+        port: u16,
+        /// The certificate hash the host printed.
+        certificate: String,
+    },
 }
 
 /// Waits until `readiness` holds for `child`, failing fast if the stage
@@ -143,7 +151,7 @@ fn probe(child: &ManagedChild, readiness: &Readiness) -> Option<ReadySignal> {
             content
                 .lines()
                 .find_map(parse_listening)
-                .map(|(_, cert)| ReadySignal::HostCertificate(cert))
+                .map(|(port, certificate)| ReadySignal::HostListening { port, certificate })
         }
     }
 }

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -1,0 +1,212 @@
+//! Event-based stage readiness: each stage declares the observable
+//! signal that proves it is up, and the session waits on that signal
+//! with a hard deadline — never on a fixed sleep.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::error::XtaskError;
+use crate::process::ManagedChild;
+
+/// How often probes re-check while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(300);
+
+/// The observable signal that proves a stage is ready.
+#[derive(Debug)]
+pub enum Readiness {
+    /// A probe command's stdout contains `needle`.
+    CommandOutput {
+        /// Probe program.
+        program: String,
+        /// Probe arguments.
+        args: Vec<String>,
+        /// Environment the probe needs.
+        env: Vec<(String, String)>,
+        /// Substring that proves readiness.
+        needle: &'static str,
+        /// Deadline in seconds.
+        timeout_s: u64,
+    },
+    /// The stage's own log contains `needle`.
+    LogContains {
+        /// Substring that proves readiness.
+        needle: &'static str,
+        /// Deadline in seconds.
+        timeout_s: u64,
+    },
+    /// A local TCP endpoint accepts connections.
+    TcpAccepts {
+        /// Port on 127.0.0.1.
+        port: u16,
+        /// Deadline in seconds.
+        timeout_s: u64,
+    },
+    /// The host's `LISTENING <port> <cert-hex>` line appears in its log;
+    /// readiness yields the certificate hash.
+    HostListening {
+        /// Deadline in seconds.
+        timeout_s: u64,
+    },
+}
+
+/// What a satisfied readiness proves, beyond "up".
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReadySignal {
+    /// The stage is up.
+    Up,
+    /// The host is listening with this certificate hash.
+    HostCertificate(String),
+}
+
+/// Waits until `readiness` holds for `child`, failing fast if the stage
+/// dies first and failing closed at the deadline.
+///
+/// # Errors
+///
+/// Returns [`XtaskError::StageDied`] when the process exits while
+/// waiting, or [`XtaskError::NotReady`] at the deadline.
+pub async fn await_ready(
+    child: &mut ManagedChild,
+    readiness: &Readiness,
+) -> Result<ReadySignal, XtaskError> {
+    let (timeout_s, detail) = describe(readiness);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_s);
+    loop {
+        child.check_running()?;
+        if let Some(signal) = probe(child, readiness) {
+            return Ok(signal);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(XtaskError::NotReady {
+                name: child.name,
+                seconds: timeout_s,
+                detail,
+                log: child.log_path.clone(),
+            });
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn describe(readiness: &Readiness) -> (u64, String) {
+    match readiness {
+        Readiness::CommandOutput {
+            program,
+            needle,
+            timeout_s,
+            ..
+        } => (*timeout_s, format!("waiting for {needle:?} from {program}")),
+        Readiness::LogContains { needle, timeout_s } => {
+            (*timeout_s, format!("waiting for {needle:?} in its log"))
+        }
+        Readiness::TcpAccepts { port, timeout_s } => (
+            *timeout_s,
+            format!("waiting for 127.0.0.1:{port} to accept"),
+        ),
+        Readiness::HostListening { timeout_s } => {
+            (*timeout_s, "waiting for the LISTENING line".to_owned())
+        }
+    }
+}
+
+fn probe(child: &ManagedChild, readiness: &Readiness) -> Option<ReadySignal> {
+    match readiness {
+        Readiness::CommandOutput {
+            program,
+            args,
+            env,
+            needle,
+            ..
+        } => {
+            let mut command = Command::new(program);
+            command.args(args);
+            for (key, value) in env {
+                command.env(key, value);
+            }
+            let output = command.output().ok()?;
+            let text = String::from_utf8_lossy(&output.stdout);
+            text.contains(needle).then_some(ReadySignal::Up)
+        }
+        Readiness::LogContains { needle, .. } => {
+            let content = std::fs::read_to_string(&child.log_path).ok()?;
+            content.contains(needle).then_some(ReadySignal::Up)
+        }
+        Readiness::TcpAccepts { port, .. } => std::net::TcpStream::connect_timeout(
+            &std::net::SocketAddr::from(([127, 0, 0, 1], *port)),
+            Duration::from_millis(200),
+        )
+        .is_ok()
+        .then_some(ReadySignal::Up),
+        Readiness::HostListening { .. } => {
+            let content = std::fs::read_to_string(&child.log_path).ok()?;
+            content
+                .lines()
+                .find_map(parse_listening)
+                .map(|(_, cert)| ReadySignal::HostCertificate(cert))
+        }
+    }
+}
+
+/// Parses the host's `LISTENING <port> <cert-hex>` line.
+pub fn parse_listening(line: &str) -> Option<(u16, String)> {
+    let mut parts = line.split_whitespace();
+    if parts.next()? != "LISTENING" {
+        return None;
+    }
+    let port: u16 = parts.next()?.parse().ok()?;
+    let cert = parts.next()?;
+    let hex_ok = cert.len() == 64 && cert.bytes().all(|b| b.is_ascii_hexdigit());
+    if !hex_ok || parts.next().is_some() {
+        return None;
+    }
+    Some((port, cert.to_owned()))
+}
+
+/// The pinned viewer URL for a ready session.
+pub fn viewer_url(viewer_port: u16, host_port: u16, cert: &str) -> String {
+    format!("http://127.0.0.1:{viewer_port}/index.html?host=127.0.0.1&port={host_port}&cert={cert}")
+}
+
+/// The log file a stage writes under `log_dir`.
+pub fn stage_log(log_dir: &std::path::Path, name: &str) -> PathBuf {
+    log_dir.join(format!("{name}.log"))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{parse_listening, viewer_url};
+
+    #[test]
+    fn listening_line_parses_exactly_and_rejects_lookalikes() {
+        let cert = "a".repeat(64);
+        let line = format!("LISTENING 4433 {cert}");
+        assert_eq!(parse_listening(&line), Some((4433, cert.clone())));
+
+        assert_eq!(parse_listening("LISTENING 4433"), None);
+        assert_eq!(parse_listening(&format!("listening 4433 {cert}")), None);
+        assert_eq!(parse_listening("LISTENING 4433 nothex"), None);
+        assert_eq!(
+            parse_listening(&format!("LISTENING 70000 {cert}")),
+            None,
+            "port must fit u16"
+        );
+        assert_eq!(
+            parse_listening(&format!("LISTENING 4433 {cert} extra")),
+            None,
+            "trailing tokens are not the host's line"
+        );
+        let short = "ab".repeat(16);
+        assert_eq!(parse_listening(&format!("LISTENING 4433 {short}")), None);
+    }
+
+    #[test]
+    fn viewer_url_pins_host_port_and_certificate() {
+        let cert = "0f".repeat(32);
+        assert_eq!(
+            viewer_url(8080, 4433, &cert),
+            format!("http://127.0.0.1:8080/index.html?host=127.0.0.1&port=4433&cert={cert}")
+        );
+    }
+}

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -1,0 +1,283 @@
+//! Session orchestration: build the host, launch the backend's stages,
+//! the host, and the viewer in order — each gated on its readiness
+//! signal — print the pinned URL, supervise, and tear everything down
+//! in reverse order on ctrl-c or when any stage dies.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::backend::{SessionContext, Stage, backend_for};
+use crate::cli::SimArgs;
+use crate::error::XtaskError;
+use crate::output::print_line;
+use crate::process::{ManagedChild, ProcessSpec};
+use crate::readiness::{Readiness, ReadySignal, await_ready, stage_log, viewer_url};
+
+/// How often the supervisor re-checks stage health.
+const SUPERVISE_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Runs one full SITL session until ctrl-c or a stage failure.
+///
+/// # Errors
+///
+/// Returns a typed [`XtaskError`] for unknown backends, stale sessions,
+/// missing artifacts, spawn/readiness failures, and stages that die
+/// while the session runs.
+pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
+    let backend = backend_for(&args.fc)?;
+    let repo_root = repo_root()?;
+    let log_dir = repo_root.join("target/xtask-sim");
+    std::fs::create_dir_all(&log_dir).map_err(|source| XtaskError::Io {
+        context: "creating the session log directory",
+        source,
+    })?;
+    let ctx = SessionContext {
+        repo_root: repo_root.clone(),
+        host_port: args.host_port,
+        viewer_port: args.viewer_port,
+        profile: args.profile,
+        log_dir: log_dir.clone(),
+    };
+
+    refuse_stale_session(backend.stale_process_patterns())?;
+
+    print_line(&format!(
+        "launching a {} session (profile: {})",
+        backend.name(),
+        args.profile.as_env_value()
+    ));
+    print_line("building session host (release)...");
+    build_host(&repo_root)?;
+
+    let mut stages = backend.plan(&ctx)?;
+    stages.push(host_stage(
+        &ctx,
+        backend.host_adapter(),
+        backend.host_env(&ctx),
+    ));
+    stages.push(viewer_stage(&ctx)?);
+
+    let mut children: Vec<ManagedChild> = Vec::new();
+    let mut certificate = String::new();
+    for stage in &stages {
+        print_line(&format!("starting {}...", stage.spec.name));
+        let mut child = match ManagedChild::spawn(&stage.spec) {
+            Ok(child) => child,
+            Err(error) => {
+                teardown(&mut children);
+                return Err(error);
+            }
+        };
+        match await_ready(&mut child, &stage.readiness).await {
+            Ok(ReadySignal::HostCertificate(cert)) => certificate = cert,
+            Ok(ReadySignal::Up) => {}
+            Err(error) => {
+                child.terminate_group();
+                teardown(&mut children);
+                return Err(error);
+            }
+        }
+        print_line(&format!(
+            "{} ready (log: {})",
+            stage.spec.name,
+            child.log_path.display()
+        ));
+        children.push(child);
+    }
+
+    let url = viewer_url(args.viewer_port, args.host_port, &certificate);
+    print_line("");
+    print_line(&format!("session ready: {url}"));
+    print_line("press ctrl-c to stop the session");
+    if args.open {
+        open_in_browser(&url);
+    }
+
+    let outcome = supervise(&mut children).await;
+    teardown(&mut children);
+    outcome
+}
+
+/// Resets the running simulation via the selected backend.
+///
+/// # Errors
+///
+/// Returns the backend's typed reset failure.
+pub fn run_reset(fc: &str) -> Result<(), XtaskError> {
+    let backend = backend_for(fc)?;
+    backend.reset(&repo_root()?)
+}
+
+/// This repository's root (the workspace this binary was built from).
+fn repo_root() -> Result<PathBuf, XtaskError> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .nth(2)
+        .map(std::path::Path::to_path_buf)
+        .ok_or_else(|| XtaskError::Io {
+            context: "resolving the repository root",
+            source: std::io::Error::other("tools/xtask has no grandparent"),
+        })
+}
+
+/// Refuses to start over another session's processes: the launcher only
+/// ever kills processes it started.
+fn refuse_stale_session(mut patterns: Vec<&'static str>) -> Result<(), XtaskError> {
+    patterns.push("pilotage-session-host");
+    let mut listing = String::new();
+    for pattern in patterns {
+        let Ok(output) = Command::new("pgrep").args(["-f", pattern]).output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        for pid in String::from_utf8_lossy(&output.stdout).split_whitespace() {
+            // `ps` prints the command line without the environment noise
+            // macOS `pgrep -fl` appends.
+            let Ok(line) = Command::new("ps")
+                .args(["-o", "pid=,command=", "-p", pid])
+                .output()
+            else {
+                continue;
+            };
+            listing.push_str(String::from_utf8_lossy(&line.stdout).trim_end());
+            listing.push('\n');
+        }
+    }
+    if listing.trim().is_empty() {
+        Ok(())
+    } else {
+        Err(XtaskError::StaleSession {
+            listing: listing.trim_end().to_owned(),
+        })
+    }
+}
+
+fn build_host(repo_root: &std::path::Path) -> Result<(), XtaskError> {
+    let status = Command::new("cargo")
+        .args(["build", "--release", "-p", "pilotage-session-host"])
+        .current_dir(repo_root)
+        .status()
+        .map_err(|source| XtaskError::Io {
+            context: "building the session host",
+            source,
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(XtaskError::CommandFailed {
+            context: "cargo build --release -p pilotage-session-host",
+            status: status.to_string(),
+        })
+    }
+}
+
+fn host_stage(ctx: &SessionContext, adapter: &str, mut env: Vec<(String, String)>) -> Stage {
+    env.push((
+        "PILOTAGE_AVIATE_PROFILE".to_owned(),
+        ctx.profile.as_env_value().to_owned(),
+    ));
+    if std::env::var_os("RUST_LOG").is_none() {
+        env.push(("RUST_LOG".to_owned(), "info".to_owned()));
+    }
+    Stage {
+        spec: ProcessSpec {
+            name: "session-host",
+            program: ctx
+                .repo_root
+                .join("target/release/pilotage-session-host")
+                .display()
+                .to_string(),
+            args: vec![
+                "--port".to_owned(),
+                ctx.host_port.to_string(),
+                "--adapter".to_owned(),
+                adapter.to_owned(),
+            ],
+            cwd: Some(ctx.repo_root.clone()),
+            env,
+            remove_env: vec![],
+            log_path: stage_log(&ctx.log_dir, "session-host"),
+        },
+        readiness: Readiness::HostListening { timeout_s: 60 },
+    }
+}
+
+/// The static viewer. The host learning `--serve-web` retires this
+/// stage; until then python3 serves `clients/web` exactly like the
+/// recorded runbook.
+fn viewer_stage(ctx: &SessionContext) -> Result<Stage, XtaskError> {
+    let viewer_dir = ctx.repo_root.join("clients/web");
+    if !viewer_dir.join("index.html").is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "viewer entrypoint",
+            path: viewer_dir.join("index.html"),
+            hint: "run from the Pilotage repository root",
+        });
+    }
+    Ok(Stage {
+        spec: ProcessSpec {
+            name: "viewer",
+            program: "python3".to_owned(),
+            args: vec![
+                "-m".to_owned(),
+                "http.server".to_owned(),
+                ctx.viewer_port.to_string(),
+                "--bind".to_owned(),
+                "127.0.0.1".to_owned(),
+            ],
+            cwd: Some(viewer_dir),
+            env: vec![],
+            remove_env: vec![],
+            log_path: stage_log(&ctx.log_dir, "viewer"),
+        },
+        readiness: Readiness::TcpAccepts {
+            port: ctx.viewer_port,
+            timeout_s: 15,
+        },
+    })
+}
+
+/// Waits for ctrl-c (clean stop) or any stage dying (error).
+async fn supervise(children: &mut [ManagedChild]) -> Result<(), XtaskError> {
+    loop {
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal.map_err(|source| XtaskError::Io {
+                    context: "waiting for ctrl-c",
+                    source,
+                })?;
+                print_line("");
+                print_line("stopping the session...");
+                return Ok(());
+            }
+            () = tokio::time::sleep(SUPERVISE_INTERVAL) => {
+                for child in children.iter_mut() {
+                    child.check_running()?;
+                }
+            }
+        }
+    }
+}
+
+/// Stops every started stage in reverse launch order.
+fn teardown(children: &mut Vec<ManagedChild>) {
+    while let Some(mut child) = children.pop() {
+        print_line(&format!("stopping {}...", child.name));
+        child.terminate_group();
+    }
+}
+
+fn open_in_browser(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    if let Err(error) = Command::new(opener).arg(url).spawn() {
+        tracing::warn!(%error, opener, "could not open the browser; use the printed URL");
+    }
+}

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -66,11 +66,16 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
 
     // The reset script consults this marker: while a supervisor owns
     // the flight controller, the script must not respawn its own.
+    // Every failure past this point owns the already-running children:
+    // returning without teardown would orphan the whole simulator stack.
     let pid_file = log_dir.join("supervisor.pid");
-    std::fs::write(&pid_file, std::process::id().to_string()).map_err(|source| XtaskError::Io {
-        context: "writing the supervisor pid marker",
-        source,
-    })?;
+    if let Err(source) = std::fs::write(&pid_file, std::process::id().to_string()) {
+        teardown(&mut children);
+        return Err(XtaskError::Io {
+            context: "writing the supervisor pid marker",
+            source,
+        });
+    }
 
     let url = viewer_url(args.viewer_port, args.host_port, &certificate);
     print_line("");
@@ -287,15 +292,21 @@ async fn supervise(children: &mut [ManagedChild], stages: &[Stage]) -> Result<()
                     if stage.spec.name != "flight-controller" {
                         return Err(death);
                     }
-                    fc_restarts += 1;
+                    fc_restarts = fc_restarts.wrapping_add(1);
                     if fc_restarts > MAX_STAGE_RESTARTS {
                         return Err(death);
                     }
                     print_line(&format!(
                         "flight-controller exited (reset or crash); restarting ({fc_restarts}/{MAX_STAGE_RESTARTS})..."
                     ));
+                    // A replacement that spawns but never reports ready
+                    // must not outlive the error return: it is not in
+                    // `children`, so the caller's teardown would miss it.
                     let mut replacement = ManagedChild::spawn(&stage.spec)?;
-                    await_ready(&mut replacement, &stage.readiness).await?;
+                    if let Err(error) = await_ready(&mut replacement, &stage.readiness).await {
+                        replacement.terminate_group();
+                        return Err(error);
+                    }
                     print_line("flight-controller ready");
                     children[index] = replacement;
                 }
@@ -320,5 +331,128 @@ fn open_in_browser(url: &str) {
     };
     if let Err(error) = Command::new(opener).arg(url).spawn() {
         tracing::warn!(%error, opener, "could not open the browser; use the printed URL");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{start_stages, supervise};
+    use crate::backend::Stage;
+    use crate::process::{ManagedChild, ProcessSpec};
+    use crate::readiness::Readiness;
+
+    /// Builds a stage running `script` under sh, with `marker` planted in
+    /// argv so liveness is observable from outside via pgrep.
+    fn stage(name: &'static str, script: &str, marker: &str, readiness: Readiness) -> Stage {
+        let log = std::env::temp_dir().join(format!("plt_xtask_{marker}.log"));
+        Stage {
+            spec: ProcessSpec {
+                name,
+                program: "sh".to_owned(),
+                args: vec!["-c".to_owned(), script.to_owned(), marker.to_owned()],
+                cwd: None,
+                env: Vec::new(),
+                remove_env: Vec::new(),
+                log_path: log,
+            },
+            readiness,
+        }
+    }
+
+    fn marker_alive(marker: &str) -> bool {
+        std::process::Command::new("pgrep")
+            .args(["-f", marker])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    }
+
+    fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
+        let end = Instant::now() + deadline;
+        while Instant::now() < end {
+            if done() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        done()
+    }
+
+    /// A stage that never reports ready must not leave the stages started
+    /// before it (or itself) running.
+    #[tokio::test]
+    async fn readiness_failure_tears_down_every_started_stage() {
+        let a = format!("plt_xt_rdy_a_{}", std::process::id());
+        let b = format!("plt_xt_rdy_b_{}", std::process::id());
+        let stages = vec![
+            stage(
+                "first",
+                "echo READY; sleep 30",
+                &a,
+                Readiness::LogContains {
+                    needle: "READY",
+                    timeout_s: 5,
+                },
+            ),
+            stage(
+                "second",
+                "sleep 30",
+                &b,
+                Readiness::LogContains {
+                    needle: "NEVER_APPEARS",
+                    timeout_s: 1,
+                },
+            ),
+        ];
+
+        let outcome = start_stages(&stages).await;
+
+        assert!(outcome.is_err(), "the second stage can never become ready");
+        assert!(
+            wait_until(Duration::from_secs(5), || !marker_alive(&a)
+                && !marker_alive(&b)),
+            "both stages must be torn down after the readiness failure"
+        );
+    }
+
+    /// A flight-controller replacement that spawns but never reports
+    /// ready is not in `children`, so the supervisor must kill it before
+    /// returning the error.
+    #[tokio::test]
+    async fn failed_restart_kills_the_unready_replacement() {
+        let marker = format!("plt_xt_fcr_{}", std::process::id());
+        let fc = stage(
+            "flight-controller",
+            "sleep 30",
+            &marker,
+            Readiness::LogContains {
+                needle: "NEVER_APPEARS",
+                timeout_s: 1,
+            },
+        );
+        // The supervised child exits immediately, triggering the restart.
+        let dying = stage(
+            "flight-controller",
+            "exit 7",
+            "plt_xt_dying",
+            Readiness::LogContains {
+                needle: "",
+                timeout_s: 1,
+            },
+        );
+        let child = ManagedChild::spawn(&dying.spec).expect("dying stage spawns");
+        let mut children = vec![child];
+        let stages = vec![fc];
+
+        let outcome = supervise(&mut children, &stages).await;
+
+        assert!(outcome.is_err(), "the replacement can never become ready");
+        assert!(
+            wait_until(Duration::from_secs(5), || !marker_alive(&marker)),
+            "the unready replacement must not outlive the error"
+        );
     }
 }

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -62,22 +62,34 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     ));
     stages.push(viewer_stage(&ctx)?);
 
-    let (mut children, certificate) = start_stages(&stages).await?;
+    // The cancellation source must exist before the first child spawns:
+    // each child lives in its own process group, so a terminal ctrl-c
+    // delivered under default SIGINT disposition would kill only this
+    // launcher and orphan every already-started stage.
+    let mut cancel = spawn_cancel_listener()?;
+
+    let (mut children, listening) = start_stages(&stages, &mut cancel).await?;
+
+    let Some((actual_port, certificate)) = listening else {
+        teardown(&mut children);
+        return Err(XtaskError::Io {
+            context: "the host never proved a listening port",
+            source: std::io::Error::other("no LISTENING line was captured"),
+        });
+    };
+    if let Err(error) = verify_listening_port(args.host_port, actual_port) {
+        teardown(&mut children);
+        return Err(error);
+    }
 
     // The reset script consults this marker: while a supervisor owns
     // the flight controller, the script must not respawn its own.
     // Every failure past this point owns the already-running children:
     // returning without teardown would orphan the whole simulator stack.
     let pid_file = log_dir.join("supervisor.pid");
-    if let Err(source) = std::fs::write(&pid_file, std::process::id().to_string()) {
-        teardown(&mut children);
-        return Err(XtaskError::Io {
-            context: "writing the supervisor pid marker",
-            source,
-        });
-    }
+    claim_supervisor(&pid_file, &mut children)?;
 
-    let url = viewer_url(args.viewer_port, args.host_port, &certificate);
+    let url = viewer_url(args.viewer_port, actual_port, &certificate);
     print_line("");
     print_line(&format!("session ready: {url}"));
     print_line("press ctrl-c to stop the session");
@@ -85,17 +97,69 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
         open_in_browser(&url);
     }
 
-    let outcome = supervise(&mut children, &stages).await;
+    let outcome = supervise(&mut children, &stages, &mut cancel).await;
     std::fs::remove_file(&pid_file).ok();
     teardown(&mut children);
     outcome
 }
 
-/// Spawns every stage in order, awaiting each one's readiness signal.
-/// Already-started children are torn down on any failure.
-async fn start_stages(stages: &[Stage]) -> Result<(Vec<ManagedChild>, String), XtaskError> {
+/// Registers the SIGINT handler and returns a receiver that flips to
+/// `true` on ctrl-c. Registration happens synchronously in this call so
+/// no child can be spawned while the default (kill-the-launcher-only)
+/// disposition is still active.
+fn spawn_cancel_listener() -> Result<tokio::sync::watch::Receiver<bool>, XtaskError> {
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+        .map_err(|source| XtaskError::Io {
+            context: "registering the ctrl-c handler",
+            source,
+        })?;
+    let (tx, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        if sigint.recv().await.is_some() {
+            tx.send(true).ok();
+        }
+    });
+    Ok(rx)
+}
+
+/// Fails closed when the host proves a different port than the one
+/// requested: the URL printed to the user must be a port the host
+/// actually bound.
+fn verify_listening_port(requested: u16, actual: u16) -> Result<(), XtaskError> {
+    if actual == requested {
+        Ok(())
+    } else {
+        Err(XtaskError::PortMismatch { requested, actual })
+    }
+}
+
+/// Writes the supervisor pid marker, tearing the session down when the
+/// write fails: a session the reset script cannot coordinate with must
+/// not keep running.
+fn claim_supervisor(
+    pid_file: &std::path::Path,
+    children: &mut Vec<ManagedChild>,
+) -> Result<(), XtaskError> {
+    if let Err(source) = std::fs::write(pid_file, std::process::id().to_string()) {
+        teardown(children);
+        return Err(XtaskError::Io {
+            context: "writing the supervisor pid marker",
+            source,
+        });
+    }
+    Ok(())
+}
+
+/// Spawns every stage in order, awaiting each one's readiness signal or
+/// a ctrl-c. Already-started children — including the child whose
+/// readiness wait a cancellation interrupts — are torn down on any exit
+/// but success.
+async fn start_stages(
+    stages: &[Stage],
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+) -> Result<(Vec<ManagedChild>, Option<(u16, String)>), XtaskError> {
     let mut children: Vec<ManagedChild> = Vec::new();
-    let mut certificate = String::new();
+    let mut listening = None;
     for stage in stages {
         print_line(&format!("starting {}...", stage.spec.name));
         let mut child = match ManagedChild::spawn(&stage.spec) {
@@ -105,8 +169,20 @@ async fn start_stages(stages: &[Stage]) -> Result<(Vec<ManagedChild>, String), X
                 return Err(error);
             }
         };
-        match await_ready(&mut child, &stage.readiness).await {
-            Ok(ReadySignal::HostCertificate(cert)) => certificate = cert,
+        let ready = tokio::select! {
+            ready = await_ready(&mut child, &stage.readiness) => ready,
+            _ = cancel.changed() => {
+                print_line("");
+                print_line("stopping the session...");
+                child.terminate_group();
+                teardown(&mut children);
+                return Err(XtaskError::Cancelled);
+            }
+        };
+        match ready {
+            Ok(ReadySignal::HostListening { port, certificate }) => {
+                listening = Some((port, certificate));
+            }
             Ok(ReadySignal::Up) => {}
             Err(error) => {
                 child.terminate_group();
@@ -121,7 +197,7 @@ async fn start_stages(stages: &[Stage]) -> Result<(Vec<ManagedChild>, String), X
         ));
         children.push(child);
     }
-    Ok((children, certificate))
+    Ok((children, listening))
 }
 
 /// Resets the running simulation via the selected backend.
@@ -270,15 +346,18 @@ fn viewer_stage(ctx: &SessionContext) -> Result<Stage, XtaskError> {
 /// flight-controller stage is RESTARTED in place (bounded): the reset
 /// flow kills the FC by design (world reset + FC restart), and the
 /// session must survive it. Every other stage's death ends the session.
-async fn supervise(children: &mut [ManagedChild], stages: &[Stage]) -> Result<(), XtaskError> {
+/// The restart's readiness wait races the cancellation source, so a
+/// ctrl-c during an FC restart stops the session promptly instead of
+/// waiting out the replacement's readiness deadline.
+async fn supervise(
+    children: &mut [ManagedChild],
+    stages: &[Stage],
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+) -> Result<(), XtaskError> {
     let mut fc_restarts: u32 = 0;
     loop {
         tokio::select! {
-            signal = tokio::signal::ctrl_c() => {
-                signal.map_err(|source| XtaskError::Io {
-                    context: "waiting for ctrl-c",
-                    source,
-                })?;
+            _ = cancel.changed() => {
                 print_line("");
                 print_line("stopping the session...");
                 return Ok(());
@@ -303,7 +382,16 @@ async fn supervise(children: &mut [ManagedChild], stages: &[Stage]) -> Result<()
                     // must not outlive the error return: it is not in
                     // `children`, so the caller's teardown would miss it.
                     let mut replacement = ManagedChild::spawn(&stage.spec)?;
-                    if let Err(error) = await_ready(&mut replacement, &stage.readiness).await {
+                    let ready = tokio::select! {
+                        ready = await_ready(&mut replacement, &stage.readiness) => ready,
+                        _ = cancel.changed() => {
+                            print_line("");
+                            print_line("stopping the session...");
+                            replacement.terminate_group();
+                            return Ok(());
+                        }
+                    };
+                    if let Err(error) = ready {
                         replacement.terminate_group();
                         return Err(error);
                     }
@@ -335,124 +423,4 @@ fn open_in_browser(url: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::panic)]
-mod tests {
-    use std::time::{Duration, Instant};
-
-    use super::{start_stages, supervise};
-    use crate::backend::Stage;
-    use crate::process::{ManagedChild, ProcessSpec};
-    use crate::readiness::Readiness;
-
-    /// Builds a stage running `script` under sh, with `marker` planted in
-    /// argv so liveness is observable from outside via pgrep.
-    fn stage(name: &'static str, script: &str, marker: &str, readiness: Readiness) -> Stage {
-        let log = std::env::temp_dir().join(format!("plt_xtask_{marker}.log"));
-        Stage {
-            spec: ProcessSpec {
-                name,
-                program: "sh".to_owned(),
-                args: vec!["-c".to_owned(), script.to_owned(), marker.to_owned()],
-                cwd: None,
-                env: Vec::new(),
-                remove_env: Vec::new(),
-                log_path: log,
-            },
-            readiness,
-        }
-    }
-
-    fn marker_alive(marker: &str) -> bool {
-        std::process::Command::new("pgrep")
-            .args(["-f", marker])
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-
-    fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
-        let end = Instant::now() + deadline;
-        while Instant::now() < end {
-            if done() {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        done()
-    }
-
-    /// A stage that never reports ready must not leave the stages started
-    /// before it (or itself) running.
-    #[tokio::test]
-    async fn readiness_failure_tears_down_every_started_stage() {
-        let a = format!("plt_xt_rdy_a_{}", std::process::id());
-        let b = format!("plt_xt_rdy_b_{}", std::process::id());
-        let stages = vec![
-            stage(
-                "first",
-                "echo READY; sleep 30",
-                &a,
-                Readiness::LogContains {
-                    needle: "READY",
-                    timeout_s: 5,
-                },
-            ),
-            stage(
-                "second",
-                "sleep 30",
-                &b,
-                Readiness::LogContains {
-                    needle: "NEVER_APPEARS",
-                    timeout_s: 1,
-                },
-            ),
-        ];
-
-        let outcome = start_stages(&stages).await;
-
-        assert!(outcome.is_err(), "the second stage can never become ready");
-        assert!(
-            wait_until(Duration::from_secs(5), || !marker_alive(&a)
-                && !marker_alive(&b)),
-            "both stages must be torn down after the readiness failure"
-        );
-    }
-
-    /// A flight-controller replacement that spawns but never reports
-    /// ready is not in `children`, so the supervisor must kill it before
-    /// returning the error.
-    #[tokio::test]
-    async fn failed_restart_kills_the_unready_replacement() {
-        let marker = format!("plt_xt_fcr_{}", std::process::id());
-        let fc = stage(
-            "flight-controller",
-            "sleep 30",
-            &marker,
-            Readiness::LogContains {
-                needle: "NEVER_APPEARS",
-                timeout_s: 1,
-            },
-        );
-        // The supervised child exits immediately, triggering the restart.
-        let dying = stage(
-            "flight-controller",
-            "exit 7",
-            "plt_xt_dying",
-            Readiness::LogContains {
-                needle: "",
-                timeout_s: 1,
-            },
-        );
-        let child = ManagedChild::spawn(&dying.spec).expect("dying stage spawns");
-        let mut children = vec![child];
-        let stages = vec![fc];
-
-        let outcome = supervise(&mut children, &stages).await;
-
-        assert!(outcome.is_err(), "the replacement can never become ready");
-        assert!(
-            wait_until(Duration::from_secs(5), || !marker_alive(&marker)),
-            "the unready replacement must not outlive the error"
-        );
-    }
-}
+mod tests;

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -17,6 +17,10 @@ use crate::readiness::{Readiness, ReadySignal, await_ready, stage_log, viewer_ur
 /// How often the supervisor re-checks stage health.
 const SUPERVISE_INTERVAL: Duration = Duration::from_millis(500);
 
+/// How many times a restartable stage may die and be relaunched before
+/// the session gives up (a crash loop is a failure, not a lifecycle).
+const MAX_STAGE_RESTARTS: u32 = 3;
+
 /// Runs one full SITL session until ctrl-c or a stage failure.
 ///
 /// # Errors
@@ -58,9 +62,36 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     ));
     stages.push(viewer_stage(&ctx)?);
 
+    let (mut children, certificate) = start_stages(&stages).await?;
+
+    // The reset script consults this marker: while a supervisor owns
+    // the flight controller, the script must not respawn its own.
+    let pid_file = log_dir.join("supervisor.pid");
+    std::fs::write(&pid_file, std::process::id().to_string()).map_err(|source| XtaskError::Io {
+        context: "writing the supervisor pid marker",
+        source,
+    })?;
+
+    let url = viewer_url(args.viewer_port, args.host_port, &certificate);
+    print_line("");
+    print_line(&format!("session ready: {url}"));
+    print_line("press ctrl-c to stop the session");
+    if args.open {
+        open_in_browser(&url);
+    }
+
+    let outcome = supervise(&mut children, &stages).await;
+    std::fs::remove_file(&pid_file).ok();
+    teardown(&mut children);
+    outcome
+}
+
+/// Spawns every stage in order, awaiting each one's readiness signal.
+/// Already-started children are torn down on any failure.
+async fn start_stages(stages: &[Stage]) -> Result<(Vec<ManagedChild>, String), XtaskError> {
     let mut children: Vec<ManagedChild> = Vec::new();
     let mut certificate = String::new();
-    for stage in &stages {
+    for stage in stages {
         print_line(&format!("starting {}...", stage.spec.name));
         let mut child = match ManagedChild::spawn(&stage.spec) {
             Ok(child) => child,
@@ -85,18 +116,7 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
         ));
         children.push(child);
     }
-
-    let url = viewer_url(args.viewer_port, args.host_port, &certificate);
-    print_line("");
-    print_line(&format!("session ready: {url}"));
-    print_line("press ctrl-c to stop the session");
-    if args.open {
-        open_in_browser(&url);
-    }
-
-    let outcome = supervise(&mut children).await;
-    teardown(&mut children);
-    outcome
+    Ok((children, certificate))
 }
 
 /// Resets the running simulation via the selected backend.
@@ -241,8 +261,12 @@ fn viewer_stage(ctx: &SessionContext) -> Result<Stage, XtaskError> {
     })
 }
 
-/// Waits for ctrl-c (clean stop) or any stage dying (error).
-async fn supervise(children: &mut [ManagedChild]) -> Result<(), XtaskError> {
+/// Waits for ctrl-c (clean stop) or a stage dying. A dead
+/// flight-controller stage is RESTARTED in place (bounded): the reset
+/// flow kills the FC by design (world reset + FC restart), and the
+/// session must survive it. Every other stage's death ends the session.
+async fn supervise(children: &mut [ManagedChild], stages: &[Stage]) -> Result<(), XtaskError> {
+    let mut fc_restarts: u32 = 0;
     loop {
         tokio::select! {
             signal = tokio::signal::ctrl_c() => {
@@ -255,8 +279,25 @@ async fn supervise(children: &mut [ManagedChild]) -> Result<(), XtaskError> {
                 return Ok(());
             }
             () = tokio::time::sleep(SUPERVISE_INTERVAL) => {
-                for child in children.iter_mut() {
-                    child.check_running()?;
+                for index in 0..children.len() {
+                    let Err(death) = children[index].check_running() else {
+                        continue;
+                    };
+                    let stage = &stages[index];
+                    if stage.spec.name != "flight-controller" {
+                        return Err(death);
+                    }
+                    fc_restarts += 1;
+                    if fc_restarts > MAX_STAGE_RESTARTS {
+                        return Err(death);
+                    }
+                    print_line(&format!(
+                        "flight-controller exited (reset or crash); restarting ({fc_restarts}/{MAX_STAGE_RESTARTS})..."
+                    ));
+                    let mut replacement = ManagedChild::spawn(&stage.spec)?;
+                    await_ready(&mut replacement, &stage.readiness).await?;
+                    print_line("flight-controller ready");
+                    children[index] = replacement;
                 }
             }
         }

--- a/tools/xtask/src/session/tests.rs
+++ b/tools/xtask/src/session/tests.rs
@@ -1,0 +1,250 @@
+//! Session lifecycle tests: every failure and cancellation path
+//! must leave zero surviving process groups, proven with fifo
+//! open/EOF process events rather than polling.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::io::Read;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use super::{claim_supervisor, start_stages, supervise, verify_listening_port};
+use crate::backend::Stage;
+use crate::error::XtaskError;
+use crate::process::{ManagedChild, ProcessSpec};
+use crate::readiness::Readiness;
+
+const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A stage that opens `fifo` for writing, prints READY, and parks.
+/// The fifo is the synchronization primitive: its open is the
+/// stage-started event, and EOF fires only when every process
+/// holding the write end — the whole group — is gone.
+fn fifo_stage(name: &'static str, fifo: &std::path::Path, readiness: Readiness) -> Stage {
+    Stage {
+        spec: ProcessSpec {
+            name,
+            program: "sh".to_owned(),
+            args: vec![
+                "-c".to_owned(),
+                format!("exec 9>{}; echo READY; sleep 30", fifo.display()),
+            ],
+            cwd: None,
+            env: Vec::new(),
+            remove_env: Vec::new(),
+            log_path: fifo.with_extension("log"),
+        },
+        readiness,
+    }
+}
+
+fn ready() -> Readiness {
+    Readiness::LogContains {
+        needle: "READY",
+        timeout_s: 10,
+    }
+}
+
+fn never(timeout_s: u64) -> Readiness {
+    Readiness::LogContains {
+        needle: "NEVER_APPEARS",
+        timeout_s,
+    }
+}
+
+fn make_fifo(tag: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!("plt_xt_{tag}_{}.fifo", std::process::id()));
+    std::fs::remove_file(&path).ok();
+    let status = std::process::Command::new("mkfifo")
+        .arg(&path)
+        .status()
+        .expect("mkfifo runs");
+    assert!(status.success(), "mkfifo creates the fifo");
+    path
+}
+
+/// Watches `fifo` from its own thread: sends "open" once the stage
+/// opens the write end and "eof" once every write end is closed.
+fn watch_fifo(fifo: std::path::PathBuf) -> mpsc::Receiver<&'static str> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut file = std::fs::File::open(&fifo).expect("fifo opens once its stage starts");
+        tx.send("open").ok();
+        let mut sink = Vec::new();
+        file.read_to_end(&mut sink).ok();
+        tx.send("eof").ok();
+        std::fs::remove_file(&fifo).ok();
+    });
+    rx
+}
+
+fn expect_event(rx: &mpsc::Receiver<&'static str>, expected: &str, what: &str) {
+    let event = rx
+        .recv_timeout(EVENT_TIMEOUT)
+        .unwrap_or_else(|_| panic!("timed out: {what}"));
+    assert_eq!(event, expected, "{what}");
+}
+
+/// A stage that never reports ready must not leave the stages started
+/// before it (or itself) running.
+#[tokio::test]
+async fn readiness_failure_tears_down_every_started_stage() {
+    let fifo_a = make_fifo("rdyf_a");
+    let fifo_b = make_fifo("rdyf_b");
+    let watch_a = watch_fifo(fifo_a.clone());
+    let watch_b = watch_fifo(fifo_b.clone());
+    let stages = vec![
+        fifo_stage("first", &fifo_a, ready()),
+        fifo_stage("second", &fifo_b, never(1)),
+    ];
+    let (_keep, mut cancel) = tokio::sync::watch::channel(false);
+
+    let outcome = start_stages(&stages, &mut cancel).await;
+
+    assert!(outcome.is_err(), "the second stage can never become ready");
+    expect_event(&watch_a, "open", "first stage starts");
+    expect_event(&watch_b, "open", "second stage starts");
+    expect_event(&watch_a, "eof", "first stage group dies");
+    expect_event(&watch_b, "eof", "second stage group dies");
+}
+
+/// A flight-controller replacement that spawns but never reports
+/// ready is not in `children`, so the supervisor must kill it before
+/// returning the error.
+#[tokio::test]
+async fn failed_restart_kills_the_unready_replacement() {
+    let fifo = make_fifo("fcr");
+    let watch = watch_fifo(fifo.clone());
+    let fc = fifo_stage("flight-controller", &fifo, never(1));
+    let dying = ProcessSpec {
+        name: "flight-controller",
+        program: "sh".to_owned(),
+        args: vec!["-c".to_owned(), "exit 7".to_owned()],
+        cwd: None,
+        env: Vec::new(),
+        remove_env: Vec::new(),
+        log_path: fifo.with_extension("dying.log"),
+    };
+    let child = ManagedChild::spawn(&dying).expect("dying stage spawns");
+    let mut children = vec![child];
+    let stages = vec![fc];
+    let (_keep, mut cancel) = tokio::sync::watch::channel(false);
+
+    let outcome = supervise(&mut children, &stages, &mut cancel).await;
+
+    assert!(outcome.is_err(), "the replacement can never become ready");
+    expect_event(&watch, "open", "replacement starts");
+    expect_event(&watch, "eof", "unready replacement dies with the error");
+}
+
+/// Ctrl-c while a stage's readiness is still pending must tear down
+/// the not-yet-recorded child and every stage started before it.
+#[tokio::test]
+async fn cancellation_during_startup_tears_down_everything() {
+    let fifo_a = make_fifo("cans_a");
+    let fifo_b = make_fifo("cans_b");
+    let watch_a = watch_fifo(fifo_a.clone());
+    let watch_b = watch_fifo(fifo_b.clone());
+    let stages = vec![
+        fifo_stage("first", &fifo_a, ready()),
+        // A long deadline: only the cancellation can end this wait.
+        fifo_stage("second", &fifo_b, never(30)),
+    ];
+    let (cancel_tx, mut cancel) = tokio::sync::watch::channel(false);
+    // The ctrl-c arrives once the second stage is provably running
+    // and its readiness wait is in progress.
+    let trigger = std::thread::spawn(move || {
+        let event = watch_b
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("second stage starts");
+        assert_eq!(event, "open");
+        cancel_tx.send(true).ok();
+        let event = watch_b
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("second stage group dies");
+        assert_eq!(event, "eof");
+    });
+
+    let outcome = start_stages(&stages, &mut cancel).await;
+
+    assert!(
+        matches!(outcome, Err(XtaskError::Cancelled)),
+        "cancellation is reported as the typed requested-stop"
+    );
+    expect_event(&watch_a, "open", "first stage starts");
+    expect_event(&watch_a, "eof", "first stage group dies");
+    trigger
+        .join()
+        .expect("second stage started, cancel fired, its group died");
+}
+
+/// Ctrl-c during a flight-controller restart must stop promptly and
+/// kill the not-yet-ready replacement.
+#[tokio::test]
+async fn cancellation_during_restart_kills_the_replacement() {
+    let fifo = make_fifo("canr");
+    let watch = watch_fifo(fifo.clone());
+    let fc = fifo_stage("flight-controller", &fifo, never(30));
+    let dying = ProcessSpec {
+        name: "flight-controller",
+        program: "sh".to_owned(),
+        args: vec!["-c".to_owned(), "exit 7".to_owned()],
+        cwd: None,
+        env: Vec::new(),
+        remove_env: Vec::new(),
+        log_path: fifo.with_extension("dying.log"),
+    };
+    let child = ManagedChild::spawn(&dying).expect("dying stage spawns");
+    let mut children = vec![child];
+    let stages = vec![fc];
+    let (cancel_tx, mut cancel) = tokio::sync::watch::channel(false);
+    let trigger = std::thread::spawn(move || {
+        let event = watch
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("replacement starts");
+        assert_eq!(event, "open");
+        cancel_tx.send(true).ok();
+        let event = watch
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("replacement group dies");
+        assert_eq!(event, "eof");
+    });
+
+    let outcome = supervise(&mut children, &stages, &mut cancel).await;
+
+    assert!(outcome.is_ok(), "a requested stop during restart is clean");
+    trigger.join().expect("replacement started, then died");
+}
+
+/// A pid-marker write failure must not leave the session running:
+/// nothing can coordinate with a supervisor that has no marker.
+#[test]
+fn marker_write_failure_tears_down_the_session() {
+    let fifo = make_fifo("marker");
+    let watch = watch_fifo(fifo.clone());
+    let stage = fifo_stage("holder", &fifo, ready());
+    let child = ManagedChild::spawn(&stage.spec).expect("holder spawns");
+    expect_event(&watch, "open", "holder starts");
+    let mut children = vec![child];
+    let unwritable = std::env::temp_dir()
+        .join(format!("plt_xt_absent_{}", std::process::id()))
+        .join("supervisor.pid");
+
+    let outcome = claim_supervisor(&unwritable, &mut children);
+
+    assert!(outcome.is_err(), "the marker path cannot be written");
+    assert!(children.is_empty(), "teardown drains every child");
+    expect_event(&watch, "eof", "holder group dies");
+}
+
+#[test]
+fn listening_port_must_match_the_requested_port() {
+    assert!(verify_listening_port(4433, 4433).is_ok());
+    assert!(matches!(
+        verify_listening_port(4433, 4434),
+        Err(XtaskError::PortMismatch {
+            requested: 4433,
+            actual: 4434,
+        })
+    ));
+}


### PR DESCRIPTION
Closes #124. Implements the orchestration row of #11.

## What this is

`cargo xtask sim` replaces the recorded four-process manual runbook (#11 comments) with one supervised command: it builds the session host, launches headless Gazebo with the Aviate plugin, the SITL FC, the host, and the static viewer **in order, each gated on an event-based readiness signal with a hard deadline** (gz world topics → FC `Ready` log line → host `LISTENING` line → viewer TCP accept), prints the pinned viewer URL (host port + certificate hash parsed from the `LISTENING` line — certificate-pinning semantics untouched, per #11's boundary), then supervises: ctrl-c or any stage dying tears everything down in reverse order via per-stage process groups (TERM, bounded grace, KILL) — no orphaned gz/FC/host processes, which this repo's sessions have repeatedly leaked by hand.

`cargo xtask reset` wraps `scripts/reset-flight-sim.sh`.

## Shape

- **Backend seam**: a `SimBackend` trait plans the simulator/FC stages and contributes the host adapter + environment; `--fc aviate` is the only implementation (PX4/JSBSim are future implementations of the same trait, per the issue — unknown names fail typed). Profile selection (`--profile physical|simulation|oracle-only`) mirrors the host's fail-closed vocabulary exactly.
- **No source dependency on Aviate**: the sibling checkout is located by `AVIATE_DIR` (default `../Aviate`) and every artifact is validated with an actionable hint (plugin dylib → the cmake line; FC binary → the cargo line). The macOS/Linux plugin-name difference is handled — the launcher does not inherit `launch_gazebo.sh`'s Linux-only `.so` check.
- **Refuses stale sessions**: running `gz sim`/FC/host processes are listed (via `ps`, not killed) with the exact cleanup command — the launcher only ever kills processes it started.
- Stage logs land under `target/xtask-sim/` and every readiness failure names the log it captured.
- `.cargo/config.toml` carries only the `cargo xtask` alias.

## Verified live (this machine)

- Stale-session refusal fired correctly against a real leftover session and listed it readably.
- Clean field: full launch → `session ready: http://127.0.0.1:8080/index.html?host=…&cert=…` (viewer answered 200), SIGINT → ordered reverse teardown, zero leftover processes.

## Guardrails

Unit tests: `LISTENING` parse (exact-format, rejects lookalikes/oversized ports/trailing tokens), viewer-URL pinning, backend and profile selection fail-closed, artifact validation hints, and the full planned gz/FC environment (plugin path, resource path, `GZ_IP`, headless `DISPLAY` removal) against a scaffolded checkout.

## Out of scope

PX4/JSBSim implementations, `cargo xtask ci`, host `--serve-web` (separate #11 row — it will retire the python viewer stage here), #117 provisioning/auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)