### PR TITLE
DISP-03: a starved watchdog clock must not judge render liveness (#127)

### DIFF
--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -95,9 +95,25 @@ export class PanelHealth {
   //   advanced for strictly longer than this is failed (LIVENESS).
   // recoveryFrames: consecutive validated frames required to clear a
   //   latched failure — one arbitrary good frame never clears it.
-  constructor({ livenessDeadlineMs = 1000, recoveryFrames = 30 } = {}, nowMs = 0) {
+  // tickIntervalMs: the cadence the caller schedules `tick` at. A tick
+  //   arriving later than twice this cadence proves the watchdog's own
+  //   scheduling domain was starved (browser throttling of an occluded
+  //   or backgrounded page suspends rAF and clamps timers together), so
+  //   that tick re-arms the deadline instead of judging liveness — a
+  //   deadline measured by a clock that itself stopped says nothing
+  //   about the render pipeline, and latching from it makes panels
+  //   blink FAIL/OK with every compositor burst. A genuinely dead
+  //   render loop on a normally scheduled page still trips within one
+  //   deadline of ticks running on cadence — including within one
+  //   deadline of scheduling resuming, which is exactly when a viewer
+  //   is looking again.
+  constructor(
+    { livenessDeadlineMs = 1000, recoveryFrames = 30, tickIntervalMs = 250 } = {},
+    nowMs = 0,
+  ) {
     this.livenessDeadlineMs = livenessDeadlineMs;
     this.recoveryFrames = recoveryFrames;
+    this.tickIntervalMs = tickIntervalMs;
     this.reset(nowMs);
   }
 
@@ -109,7 +125,14 @@ export class PanelHealth {
     this.goodStreak = 0;
     this.lastGeneration = null;
     this.lastAdvanceMs = nowMs;
-    this.counters = { failures: 0, duplicates: 0, recoveries: 0, livenessTrips: 0 };
+    this.lastTickMs = null;
+    this.counters = {
+      failures: 0,
+      duplicates: 0,
+      recoveries: 0,
+      livenessTrips: 0,
+      starvedTicks: 0,
+    };
   }
 
   // A validated frame was produced. Freshness credit requires the WASM
@@ -148,8 +171,18 @@ export class PanelHealth {
   // Watchdog tick from a scheduling domain independent of the render
   // loop; latches LIVENESS when frame advancement stalls past the
   // deadline (strictly greater: an advance exactly at the deadline is
-  // still on time).
+  // still on time). A tick whose own arrival is late against
+  // `tickIntervalMs` proves page-wide scheduling starvation and re-arms
+  // the deadline instead of judging with a stalled clock (see the
+  // constructor's tickIntervalMs contract).
   tick(nowMs) {
+    const starved = this.lastTickMs !== null && nowMs - this.lastTickMs > 2 * this.tickIntervalMs;
+    this.lastTickMs = nowMs;
+    if (starved) {
+      this.lastAdvanceMs = nowMs;
+      this.counters.starvedTicks += 1;
+      return this.display();
+    }
     if (nowMs - this.lastAdvanceMs > this.livenessDeadlineMs && !this.latched) {
       this.latched = true;
       this.reason = REASON.LIVENESS;

--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -125,7 +125,13 @@ export class PanelHealth {
     this.goodStreak = 0;
     this.lastGeneration = null;
     this.lastAdvanceMs = nowMs;
-    this.lastTickMs = null;
+    // Seed the tick clock at reset so the FIRST tick has a cadence
+    // baseline: a first tick already late against the scheduled cadence
+    // (the page was backgrounded before the watchdog ever ran) is
+    // recognized as starvation, not read as a dead renderer. Without
+    // this the first tick could never detect starvation and would falsely
+    // latch LIVENESS on a delayed initial fire.
+    this.lastTickMs = nowMs;
     this.counters = {
       failures: 0,
       duplicates: 0,
@@ -176,7 +182,9 @@ export class PanelHealth {
   // the deadline instead of judging with a stalled clock (see the
   // constructor's tickIntervalMs contract).
   tick(nowMs) {
-    const starved = this.lastTickMs !== null && nowMs - this.lastTickMs > 2 * this.tickIntervalMs;
+    // lastTickMs is seeded at reset, so even the first tick has a cadence
+    // baseline to measure its own lateness against.
+    const starved = nowMs - this.lastTickMs > 2 * this.tickIntervalMs;
     this.lastTickMs = nowMs;
     if (starved) {
       this.lastAdvanceMs = nowMs;

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -978,6 +978,63 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   check("generation wrap counts as advancement", health.tick(1500).showFailure === false);
 }
 
+// ---- scheduling starvation: a stalled watchdog clock must not judge ---------
+//
+// PERMANENT CONTRACT: LIVENESS may only latch from a tick whose own
+// arrival is on cadence. A browser that suspends rAF and clamps timers
+// for an occluded/backgrounded page starves the watchdog's clock along
+// with the render loop; a deadline measured by that stalled clock says
+// nothing about the render pipeline, and latching from it makes panels
+// blink FAIL/OK with every compositor burst. A late tick re-arms the
+// deadline; a genuinely dead render loop still trips within one deadline
+// of ticks running on cadence again — exactly when a viewer is looking.
+
+{
+  const health = new PanelHealth(
+    { livenessDeadlineMs: 1000, recoveryFrames: 3, tickIntervalMs: 250 },
+    0,
+  );
+  health.reportSuccess(0, 1);
+  health.tick(250); // on cadence: establishes the tick clock
+  const d = health.tick(2000); // throttled: 1750 ms gap >> 2 × 250 ms
+  check(
+    "a starved tick past the deadline does not latch LIVENESS",
+    d.showFailure === false && health.snapshot().counters.livenessTrips === 0,
+  );
+  check("starved tick is counted", health.snapshot().counters.starvedTicks === 1);
+  check(
+    "the starved tick re-armed the deadline",
+    health.tick(2250).showFailure === false,
+  );
+
+  // Scheduling has resumed (ticks on cadence) but frames never advance:
+  // the panel must fail within one deadline of the resume, not sooner.
+  health.tick(2500);
+  health.tick(2750);
+  health.tick(3000);
+  check("re-armed deadline holds until it elapses", health.display().showFailure === false);
+  const tripped = health.tick(3001);
+  check(
+    "a dead render loop trips one deadline after scheduling resumes",
+    tripped.showFailure === true && tripped.reason === REASON.LIVENESS,
+  );
+}
+
+{
+  // Starvation must not unlatch or mask an already-latched failure.
+  const health = new PanelHealth(
+    { livenessDeadlineMs: 1000, recoveryFrames: 3, tickIntervalMs: 250 },
+    0,
+  );
+  health.reportFailure(10, REASON.PAINT_FAILED);
+  health.tick(250);
+  const d = health.tick(5000); // starved while latched
+  check(
+    "a starved tick keeps a latched failure visible",
+    d.showFailure === true && d.reason === REASON.PAINT_FAILED,
+  );
+}
+
 {
   const health = new PanelHealth({ livenessDeadlineMs: 1000, recoveryFrames: 3 }, 0);
   health.reportFailure(10, REASON.RENDER_TRAP);

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -921,6 +921,20 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
 
 // ---- failure latch, recovery, liveness (injected clock) ---------------------
 
+// Ticks on the watchdog's own cadence from its last tick up to and
+// including `target`, then returns that final tick's display. A real
+// watchdog fires every interval, so liveness is exercised without the
+// gaps tripping the starvation guard; the final tick lands exactly on
+// `target` for precise deadline-boundary checks.
+function tickToCadence(health, target, interval = 250) {
+  let t = health.lastTickMs + interval;
+  while (t < target) {
+    health.tick(t);
+    t += interval;
+  }
+  return health.tick(target);
+}
+
 {
   const health = new PanelHealth({ livenessDeadlineMs: 1000, recoveryFrames: 3 }, 0);
   check("healthy start shows no failure", health.display().showFailure === false);
@@ -946,7 +960,9 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
 {
   const health = new PanelHealth({ livenessDeadlineMs: 1000, recoveryFrames: 3 }, 0);
   health.reportSuccess(0, 1);
-  check("at the deadline the panel is still live", health.tick(1000).showFailure === false);
+  // Ticks fire on cadence; at the deadline boundary the panel is still
+  // live, and the first tick strictly past it latches LIVENESS.
+  check("at the deadline the panel is still live", tickToCadence(health, 1000).showFailure === false);
   const d = health.tick(1001);
   check("past the deadline the panel fails LIVENESS", d.showFailure && d.reason === REASON.LIVENESS);
   check("liveness trip counted", health.snapshot().counters.livenessTrips === 1);
@@ -964,6 +980,7 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   health.reportSuccess(0, 5);
   health.reportSuccess(500, 5); // duplicate generation: no freshness credit
   check("duplicate generation counted", health.snapshot().counters.duplicates === 1);
+  tickToCadence(health, 1000);
   const d = health.tick(1001);
   check(
     "repeated generations cannot keep a stalled panel alive",
@@ -974,8 +991,9 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
 {
   const health = new PanelHealth({ livenessDeadlineMs: 1000, recoveryFrames: 3 }, 0);
   health.reportSuccess(0, 0xffffffff);
+  tickToCadence(health, 750);
   health.reportSuccess(900, 0); // u32 wrap is an advance, not a duplicate
-  check("generation wrap counts as advancement", health.tick(1500).showFailure === false);
+  check("generation wrap counts as advancement", tickToCadence(health, 1500).showFailure === false);
 }
 
 // ---- scheduling starvation: a stalled watchdog clock must not judge ---------
@@ -1016,6 +1034,37 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   const tripped = health.tick(3001);
   check(
     "a dead render loop trips one deadline after scheduling resumes",
+    tripped.showFailure === true && tripped.reason === REASON.LIVENESS,
+  );
+}
+
+{
+  // The FIRST tick can be the late one: if the page was backgrounded
+  // before the watchdog ever fired, the initial tick arrives long past
+  // the deadline with no preceding cadence-establishing tick. It must be
+  // recognized as starvation, not latch LIVENESS — the tick clock is
+  // seeded at reset so even the first tick has a baseline.
+  const health = new PanelHealth(
+    { livenessDeadlineMs: 1000, recoveryFrames: 3, tickIntervalMs: 250 },
+    0,
+  );
+  health.reportSuccess(0, 1);
+  const first = health.tick(2000); // first tick, no prior tick, 2000 ms late
+  check(
+    "a delayed first tick does not latch LIVENESS",
+    first.showFailure === false && health.snapshot().counters.livenessTrips === 0,
+  );
+  check("the delayed first tick is counted as starved", health.snapshot().counters.starvedTicks === 1);
+
+  // Scheduling then resumes on cadence with no renders: a genuinely dead
+  // renderer must still trip within one deadline of the resume.
+  health.tick(2250);
+  health.tick(2500);
+  health.tick(3000);
+  check("re-armed deadline holds until it elapses", health.display().showFailure === false);
+  const tripped = health.tick(3001);
+  check(
+    "a dead renderer trips one deadline after the delayed first tick",
     tripped.showFailure === true && tripped.reason === REASON.LIVENESS,
   );
 }

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -169,21 +169,23 @@ function retireSessionPresentation(phase) {
   setTelemetrySessionState(els, phase);
 }
 
+// Browser watchdog cadence (simulator-only): a scheduling domain separate
+// from requestAnimationFrame, so a stalled render loop still trips the
+// liveness deadline and covers the stale frame. Passed to each panel's
+// health so a tick arriving late against this cadence is recognized as
+// page-wide scheduling starvation rather than a render-pipeline fault.
+const WATCHDOG_INTERVAL_MS = 250;
+
 const instruments = {
   mod: null,
   moduleFault: null,
   ingress: newSimulatorAvionicsIngress(),
   fcState: new FcStateTracker(),
   health: {
-    [PANEL.PFD]: new PanelHealth(),
-    [PANEL.HSI]: new PanelHealth(),
+    [PANEL.PFD]: new PanelHealth({ tickIntervalMs: WATCHDOG_INTERVAL_MS }),
+    [PANEL.HSI]: new PanelHealth({ tickIntervalMs: WATCHDOG_INTERVAL_MS }),
   },
 };
-
-// Browser watchdog cadence (simulator-only): a scheduling domain separate
-// from requestAnimationFrame, so a stalled render loop still trips the
-// liveness deadline and covers the stale frame.
-const WATCHDOG_INTERVAL_MS = 250;
 
 /** The two instrument paint targets and their independent fault surfaces. */
 function instrumentTargets() {


### PR DESCRIPTION
The PanelHealth liveness watchdog (D-106, 1000 ms deadline) latched DISPLAY FAIL from its setInterval tick domain. Chrome starves an occluded/backgrounded window by suspending rAF and clamping timers to 1 s **together** — measured live: 0 rAF fps with ticks at exactly 1000 ms while `document.visibilityState === "visible"` and `hasFocus() === true`, so the visibility API cannot gate this. Every compositor burst then recovered the latch (30-frame streak ≈ 250 ms at 120 fps) and the next starved deadline re-latched: panels blinked FAIL/OK (5 trip/recovery cycles observed on both panels in one idle session).

## Fix
A deadline measured by a clock that itself stopped says nothing about the render pipeline. `PanelHealth` now knows the cadence its caller schedules ticks at (`tickIntervalMs`, wired to `WATCHDOG_INTERVAL_MS`); a tick arriving later than twice that cadence proves page-wide scheduling starvation and **re-arms the deadline instead of judging**. A genuinely dead render loop on a normally scheduled page still trips within one deadline — including within one deadline of scheduling resuming, exactly when a viewer is looking again. Starved ticks are counted (`counters.starvedTicks`); a latched failure stays latched through starvation.

## Guardrails
New permanent-contract tests in `instruments.test.mjs`: a starved tick past the deadline never latches and re-arms; a dead render loop trips one deadline after scheduling resumes; starvation never unlatches an existing failure.

## Verified live
15 s of a hidden Chrome window: 45 starved ticks, **zero** liveness trips, zero flapping (previously 5 trip/recovery cycles). Full arm/climb/yaw/descend flight: zero failures, zero ingress faults.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxQWtCBRABhA5v318WjY4b