### PR TITLE
ASSURE-04: make declared evidence baselines reachable and re-record LINK-AUTHZ

### DIFF
--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -1,12 +1,17 @@
-# ADVISORY / NON-BLOCKING engineering trace gate (ASSURE-01, issue 77).
+# Engineering trace gate (ASSURE-01, issue 77; ASSURE-04, issue 133).
 #
-# This is a SEPARATE workflow, deliberately NOT part of the required
-# `quality-gates` job in ci.yml. Its check must never be added to the
-# branch-protection required set: a failing evidence trace must not block a
-# merge or fail the main required CI. It runs the scoped no-orphan gate so the
-# trace is observable, and is NOT a certification, compliance, or tool
+# The trace VERDICT is advisory: a review may honestly stay PENDING, and a
+# pending review must never block a merge, so the verdict steps stay
+# `continue-on-error`. It is NOT a certification, compliance, or tool
 # qualification result (SIM / NOT FOR FLIGHT).
-name: Evidence trace gate (advisory)
+#
+# Baseline RESOLVABILITY is NOT advisory. The "baselines MUST be reachable
+# and resolvable (HARD)" step and the negative-fixture must-fail loops carry
+# no `continue-on-error`, so a broken or orphaned baseline — a declared SCM
+# commit unreachable from HEAD, a missing selector, or a missing artifact —
+# reddens this job. Durable evidence resolution is enforced; the review
+# verdict is not.
+name: Evidence trace gate
 
 on:
   push:
@@ -63,6 +68,18 @@ jobs:
           cargo run -q -p pilotage-evidence --bin evidence-gate --
           --graph docs/link/evidence-graph.evg --repo-root .
           --resolve-selectors
+
+      - name: LINK-04 slice — baselines MUST be reachable and resolvable (HARD)
+        # NOT advisory (no continue-on-error). The review verdict may stay
+        # PENDING, but every recorded result must resolve: its declared SCM
+        # baseline reachable from HEAD (not a force-push orphan), and its
+        # selectors and artifacts present. A broken or orphaned baseline
+        # reddens this job (ASSURE-04, issue 133). Needs full history
+        # (fetch-depth: 0 above) so reachability is decidable.
+        run: >
+          cargo run -q -p pilotage-evidence --bin evidence-gate --
+          --graph docs/link/evidence-graph.evg --repo-root .
+          --require-resolvable
 
       - name: ATT-01 slice — resolve selectors against the tree
         # Informational: selector resolution reads the referenced test files.
@@ -134,7 +151,7 @@ jobs:
                    traversal-artifact symlink-escape-artifact \
                    stale-source-artifact selector-not-a-test \
                    source-as-artifact unresolved-review-entry \
-                   baseline-unverifiable; do
+                   baseline-unverifiable baseline-unreachable; do
             if "${bin[@]}" --graph "$FIXTURES/$f.evg" \
                 --repo-root crates/pilotage-evidence \
                 --resolve-selectors >/dev/null 2>&1; then

--- a/crates/pilotage-evidence/src/bin/evidence-gate.rs
+++ b/crates/pilotage-evidence/src/bin/evidence-gate.rs
@@ -2,8 +2,15 @@
 //!
 //! ```text
 //! evidence-gate [--graph PATH] [--repo-root PATH] [--resolve-selectors]
-//!               [--impact NODE_ID] [--trace]
+//!               [--require-resolvable] [--impact NODE_ID] [--trace]
 //! ```
+//!
+//! `--require-resolvable` is a hard check meant for a required (not
+//! advisory) CI job: every recorded result must resolve — its baseline
+//! reachable from HEAD, its selectors and artifacts present — and the
+//! process exits non-zero if any does not. A review that is honestly
+//! PENDING is tolerated, so the check enforces durable evidence
+//! resolution without asserting the review is complete.
 //!
 //! The gate is an engineering trace check. A clean run is **not** a DO-178C,
 //! ISO 26262, ECSS, TSO, or ASIL result and is not tool qualification. The
@@ -21,7 +28,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use pilotage_evidence::gate::{validate, validate_resolving};
+use pilotage_evidence::gate::{FindingCode, validate, validate_resolving};
 use pilotage_evidence::policy::Policy;
 use pilotage_evidence::{EvidenceError, NodeId, impact, parse, report, trace};
 
@@ -42,6 +49,7 @@ struct Options {
     graph: Option<PathBuf>,
     repo_root: Option<PathBuf>,
     resolve_selectors: bool,
+    require_resolvable: bool,
     impact: Option<String>,
     trace: bool,
     as_of: Option<String>,
@@ -74,7 +82,9 @@ fn run(args: Vec<String>) -> Result<ExitCode, EvidenceError> {
         ..Policy::engineering_trace()
     };
 
-    let gate_report = if options.resolve_selectors {
+    // Resolvability (baseline reachability, selector, artifact) is filesystem-
+    // and git-backed, so it needs the repo root; `--require-resolvable` implies it.
+    let gate_report = if options.resolve_selectors || options.require_resolvable {
         validate_resolving(&graph, &policy, &repo_root)
     } else {
         validate(&graph, &policy)
@@ -102,6 +112,10 @@ fn run(args: Vec<String>) -> Result<ExitCode, EvidenceError> {
         }
     }
 
+    if options.require_resolvable {
+        return Ok(resolvable_exit(&gate_report));
+    }
+
     Ok(if gate_report.verdict.passed() {
         ExitCode::SUCCESS
     } else {
@@ -109,14 +123,40 @@ fn run(args: Vec<String>) -> Result<ExitCode, EvidenceError> {
     })
 }
 
+/// The exit code for `--require-resolvable`: a hard, non-advisory check
+/// that every result resolves — its baseline reachable, its selectors and
+/// artifacts present. The review verdict may honestly stay PENDING, so a
+/// `ReviewIncomplete` finding is tolerated; every other non-excepted
+/// finding fails. Safe to wire as a required CI step that a broken or
+/// orphaned baseline can never leave green.
+fn resolvable_exit(gate_report: &pilotage_evidence::gate::GateReport) -> ExitCode {
+    let blocking = gate_report
+        .findings
+        .iter()
+        .filter(|f| !f.excepted && f.code != FindingCode::ReviewIncomplete)
+        .count();
+    if blocking > 0 {
+        writeln!(
+            io::stderr(),
+            "evidence-gate: {blocking} unresolved finding(s) fail --require-resolvable \
+             (review-pending is tolerated; broken baselines/selectors/artifacts are not)"
+        )
+        .ok();
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
 const USAGE: &str = "usage: evidence-gate [--graph PATH] [--repo-root PATH] \
-[--resolve-selectors] [--impact NODE_ID] [--trace] [--as-of YYYY-MM-DD]";
+[--resolve-selectors] [--require-resolvable] [--impact NODE_ID] [--trace] [--as-of YYYY-MM-DD]";
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
     let mut options = Options {
         graph: None,
         repo_root: None,
         resolve_selectors: false,
+        require_resolvable: false,
         impact: None,
         trace: false,
         as_of: None,
@@ -129,6 +169,7 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
                 options.repo_root = Some(PathBuf::from(next(&mut iter, "--repo-root")?))
             }
             "--resolve-selectors" => options.resolve_selectors = true,
+            "--require-resolvable" => options.require_resolvable = true,
             "--impact" => options.impact = Some(next(&mut iter, "--impact")?),
             "--trace" => options.trace = true,
             "--as-of" => options.as_of = Some(next(&mut iter, "--as-of")?),

--- a/crates/pilotage-evidence/src/gate/baseline.rs
+++ b/crates/pilotage-evidence/src/gate/baseline.rs
@@ -62,6 +62,38 @@ pub(super) fn resolve(
             );
             continue;
         };
+        // A blob that resolves at `commit` proves nothing if `commit`
+        // itself is not reachable from HEAD: a force-push leaves the old
+        // commit as a dangling object that `rev-parse` still answers, yet
+        // a fresh clone (which fetches only reachable history) can never
+        // retrieve it. Require reachability so the recorded baseline is
+        // durable, not a force-push artifact.
+        match commit_is_reachable(repo_root, commit) {
+            Ok(true) => {}
+            Ok(false) => {
+                push(
+                    findings,
+                    id,
+                    format!(
+                        "baseline {commit} is not reachable from HEAD: a non-ancestor commit is \
+                         a force-push artifact that a fresh clone cannot fetch; an unreachable \
+                         baseline fails closed"
+                    ),
+                );
+                continue;
+            }
+            Err(reason) => {
+                push(
+                    findings,
+                    id,
+                    format!(
+                        "baseline {commit} reachability cannot be determined: {reason}; an \
+                         unverifiable baseline fails closed"
+                    ),
+                );
+                continue;
+            }
+        }
         for locator in case_locators(graph, id) {
             let path = locator.split('#').next().unwrap_or(locator);
             check_locator(
@@ -135,6 +167,29 @@ fn git_toplevel(repo_root: &Path) -> Option<std::path::PathBuf> {
     let text = String::from_utf8(output.stdout).ok()?;
     let trimmed = text.trim();
     (!trimmed.is_empty()).then(|| std::path::PathBuf::from(trimmed))
+}
+
+/// Whether `commit` is reachable from HEAD (an ancestor of, or equal to,
+/// HEAD), or why git could not answer. Reachability — not mere presence
+/// in the object store — is what a fresh clone can rely on: `git
+/// merge-base --is-ancestor` exits 0 for an ancestor, 1 for a
+/// non-ancestor present in the store, and >1 on error (e.g. an unknown
+/// commit).
+fn commit_is_reachable(repo_root: &Path, commit: &str) -> Result<bool, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["merge-base", "--is-ancestor", commit, "HEAD"])
+        .output()
+        .map_err(|error| format!("git could not run ({error})"))?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => Err(format!(
+            "git merge-base --is-ancestor {commit} HEAD failed ({})",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )),
+    }
 }
 
 /// The blob object id `commit` records for `relative`, or why git could
@@ -267,6 +322,48 @@ mod tests {
                 .iter()
                 .any(|f| f.detail.contains("unverifiable baseline fails closed")),
             "missing commit: {findings:?}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_present_but_unreachable_baseline_fails_closed() {
+        // Simulate a force-push orphan: commit, note its id, then amend so
+        // the original commit is still in the object store (rev-parse and
+        // blob lookups answer) but is no longer an ancestor of HEAD — a
+        // fresh clone could never fetch it.
+        let dir = std::env::temp_dir().join(format!("plt_evg_reach_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        git(&dir, &["init", "-q"]);
+        std::fs::write(dir.join("sample_tests.rs"), "#[test]\nfn sample() {}\n")
+            .expect("write source");
+        git(&dir, &["add", "sample_tests.rs"]);
+        git(&dir, &["commit", "-qm", "baseline"]);
+        let orphan = git(&dir, &["rev-parse", "HEAD"]);
+        let blob = git(&dir, &["rev-parse", "HEAD:sample_tests.rs"]);
+        // Amend to rewrite HEAD; `orphan` is now a dangling object.
+        git(
+            &dir,
+            &["commit", "-q", "--amend", "-m", "baseline (amended)"],
+        );
+        let head = git(&dir, &["rev-parse", "HEAD"]);
+        assert_ne!(orphan, head, "amend rewrote the commit");
+        // The orphan's blob still resolves — presence is not reachability.
+        assert_eq!(
+            super::git_blob_at(&dir, &orphan, "sample_tests.rs").expect("blob resolves"),
+            blob,
+            "the orphan is still present in the object store"
+        );
+
+        let graph = parse_graph(&graph_text(&orphan, &blob)).expect("graph parses");
+        let mut findings = Vec::new();
+        resolve(&graph, &Policy::default(), &dir, &mut findings);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.detail.contains("not reachable from HEAD")),
+            "a present-but-unreachable baseline must fail closed: {findings:?}"
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/pilotage-evidence/src/lib.rs
+++ b/crates/pilotage-evidence/src/lib.rs
@@ -29,6 +29,19 @@
 //! or certification claim, and is not tool qualification (DO-330). It records
 //! that the declared engineering trace is internally complete and resolvable,
 //! nothing more.
+//!
+//! # Durable baselines (ASSURE-04)
+//!
+//! A recorded result's `config-digest` must name a commit **reachable from
+//! HEAD** — an ancestor of merged history, not a lane commit a rebase or
+//! squash will rewrite. A rewritten commit becomes a force-push orphan: it
+//! may linger locally as a dangling object that `git rev-parse` still
+//! answers, but a fresh clone fetches only reachable history and can never
+//! retrieve it, so the baseline is broken. `gate::baseline` enforces
+//! reachability, and the `--require-resolvable` mode of the `evidence-gate`
+//! binary turns any unreachable/unresolvable baseline into a hard failure.
+//! If a lane whose evidence names its own commit is rebased before merge,
+//! re-record against the rewritten commit first.
 
 #![forbid(unsafe_code)]
 

--- a/crates/pilotage-evidence/tests/fixtures/att01-run-output-unreachable.txt
+++ b/crates/pilotage-evidence/tests/fixtures/att01-run-output-unreachable.txt
@@ -1,0 +1,10 @@
+Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
+scope: ATT-01
+suite: instrument raster band matcher
+command: cargo test -p pilotage-instrument-raster
+config-digest: 337e9b8e616f71778681b7381f397ac9a7178087
+tool-version: rustc 1.95.0
+run-id: local:337e9b8e616f71778681b7381f397ac9a7178087
+outcome: pass
+summary:
+  1 passed; the declared baseline is a force-push orphan, unreachable from HEAD

--- a/crates/pilotage-evidence/tests/fixtures/baseline-unreachable.evg
+++ b/crates/pilotage-evidence/tests/fixtures/baseline-unreachable.evg
@@ -1,0 +1,50 @@
+# Negative fixture for baseline REACHABILITY (ASSURE-04, issue 133).
+# The declared configuration commit 337e9b8 is the pre-rebase lane commit
+# that PR #131 recorded against; rebasing before merge rewrote it, so it is
+# NOT an ancestor of merged main — a force-push artifact. Whether it lingers
+# as a dangling object (present but not reachable) or is absent from a fresh
+# clone, a baseline that HEAD cannot reach must fail closed: a fresh clone
+# fetches only reachable history and could never retrieve it.
+# Minimal valid attitude fixture otherwise; its selector resolves against
+# sample_tests.rs when the crate directory is the repo root.
+evidence-graph 1
+scope ATT-01
+scope-title minimal valid attitude fixture slice
+scope-requirement AIR-ENV-002
+
+node PFD intended-function
+node FC-ATT-06 hazard
+node AIR-ENV-002 safety-requirement
+node DESIGN-SO3 design
+node IMPL-STEP implementation
+
+node CASE-BAND verification-case
+locator tests/fixtures/sample_tests.rs
+attr test band_matches_reference
+
+node RESULT-BAND verification-result
+attr command cargo test -p pilotage-instrument-raster
+attr config-digest 337e9b8e616f71778681b7381f397ac9a7178087
+attr tool-version rustc 1.95.0
+attr source-digest git-blob:c86e9a44ffd131b9bc0e610985ff447628288ed6
+attr artifact tests/fixtures/att01-run-output-unreachable.txt
+attr output-digest sha256:429bad609e04c5f148021f1acb646526da712b376cfc55953f863bf59bc6bfc3
+attr run-id local:337e9b8e616f71778681b7381f397ac9a7178087
+attr outcome pass
+
+node CFG-BASE configuration-item
+attr scm git
+attr commit 337e9b8e616f71778681b7381f397ac9a7178087
+node TOOL-CARGO tool
+attr version rustc 1.95.0
+
+edge FC-ATT-06 derives-from PFD
+edge AIR-ENV-002 mitigates FC-ATT-06
+edge AIR-ENV-002 allocated-to DESIGN-SO3
+edge DESIGN-SO3 implemented-by IMPL-STEP
+edge AIR-ENV-002 verified-by CASE-BAND
+edge CASE-BAND covers AIR-ENV-002
+edge RESULT-BAND result-of CASE-BAND
+edge RESULT-BAND covers AIR-ENV-002
+edge RESULT-BAND justified-by CFG-BASE
+edge RESULT-BAND justified-by TOOL-CARGO

--- a/docs/link/evidence-artifacts/link05/authz-regime.run.txt
+++ b/docs/link/evidence-artifacts/link05/authz-regime.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: browser avionics-ingress authorization regime
 command: node clients/web/telemetry-ingress.test.mjs
-config-digest: 337e9b8e616f71778681b7381f397ac9a7178087
+config-digest: 211406836a102c64c0e0065a796e238a8af16f3a
 tool-version: node v26.5.0
-run-id: local:337e9b8e616f71778681b7381f397ac9a7178087
+run-id: local:211406836a102c64c0e0065a796e238a8af16f3a
 outcome: pass
 summary:
   27 browser ingress checks passed; LINK-AUTHZ-005 cases:

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -15,6 +15,15 @@
 # result (LINK-AUTHZ-005) against CFG-LINK-AUTHZ, the commit that lands it.
 # This file lives in a separate evidence-only commit so each baseline the
 # results claim exists independently of the record.
+#
+# MERGE/REBASE RULE (ASSURE-04): a declared config-digest must name a
+# commit REACHABLE from merged history, not a lane commit that a rebase
+# will rewrite. If a lane is rebased (or squashed) after recording, its
+# original commit becomes a force-push orphan a fresh clone cannot fetch,
+# and the baseline is broken. Re-record against the rewritten/durable
+# commit BEFORE merge. The `--require-resolvable` gate enforces this:
+# CFG-LINK-AUTHZ was moved from the orphaned pre-rebase lane commit
+# 337e9b8 to the reachable merged commit 2114068 for exactly this reason.
 
 evidence-graph 1
 scope LINK-04
@@ -232,12 +241,12 @@ attr outcome pass
 node RESULT-LINK-AUTHZ verification-result
 title browser authorization-regime suite — recorded pass
 attr command node clients/web/telemetry-ingress.test.mjs
-attr config-digest 337e9b8e616f71778681b7381f397ac9a7178087
+attr config-digest 211406836a102c64c0e0065a796e238a8af16f3a
 attr tool-version node v26.5.0
 attr source-digest git-blob:0a5eca31635fd49bca87459c43b7ac0439259bef
 attr artifact docs/link/evidence-artifacts/link05/authz-regime.run.txt
-attr output-digest sha256:58c5f895a2a5dd6fbc2a6aad61feb6cde484478d6333d2bf6bc55c228cbe8f4d
-attr run-id local:337e9b8e616f71778681b7381f397ac9a7178087
+attr output-digest sha256:064e32f9b8cc9b78472dcf7de91e20b35b76a7b4263208bfccc3bab45418ad67
+attr run-id local:211406836a102c64c0e0065a796e238a8af16f3a
 attr outcome pass
 
 node CFG-LINK-WORKTREE configuration-item
@@ -249,8 +258,8 @@ attr tree a000c09c465aeb5a3a3b1fa35d6f90276559895a
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)
 attr scm git
-attr commit 337e9b8e616f71778681b7381f397ac9a7178087
-attr tree c80a85d393d8559a5dadec251999b8878fabb0a9
+attr commit 211406836a102c64c0e0065a796e238a8af16f3a
+attr tree 9cf15bb9b43f4202e55c314aef7f495dd3c20082
 
 node TOOL-LINK-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
Closes #133.

## The defect
PR #131 was rebased before merge, so its evidence declared the pre-rebase lane commit `337e9b8`, which is **not an ancestor of merged main** — a force-push orphan. `git rev-parse` still answers for it locally (dangling object), so the old baseline check passed, but a fresh clone fetches only reachable history and can never retrieve it. The runtime fix (#130) is correct and closed; this repairs its assurance record.

## Guardrail (fix + guardrail, same PR)
- **Reachability check** in `gate/baseline`: a declared `config-digest` must be reachable from HEAD (`git merge-base --is-ancestor`). A present-but-non-ancestor commit fails closed — unit-tested by amending past a commit and showing its blob still resolves while reachability does not.
- **`--require-resolvable`** hard mode on the `evidence-gate` binary: fails on any unresolved finding (unreachable baseline, missing selector/artifact) while tolerating an honestly PENDING review.
- **CI**: a HARD step (no `continue-on-error`) runs `--require-resolvable` on the LINK graph, and `baseline-unreachable` joins the must-fail fixture loop. The review verdict stays advisory; baseline resolvability does not.
- **Merge/rebase rule** documented in the graph header and crate docs: evidence must name a commit reachable from merged history; a rebased lane must be re-recorded before merge.

## Re-record
`CFG-LINK-AUTHZ`/`RESULT-LINK-AUTHZ` moved from orphaned `337e9b8` to reachable **`2114068`** ("ceiling numeric authorization" in merged main, with all 27 ingress checks). Run re-captured from a worktree at that exact commit; review stays PENDING.

## Verified from a fresh clone
Cloned the branch fresh (dangling `337e9b8` genuinely absent, `2114068` reachable): `--require-resolvable` passes, trace resolves both ways, selectors resolve, and the `baseline-unreachable` fixture fails closed.

Per the issue, this lane is **not rebased after recording** and should **merge with a merge commit** to keep `2114068` reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxQWtCBRABhA5v318WjY4b