### PR TITLE
MEDIA-02: stream-local stop/refusal must not retire the video source writer

### DIFF
--- a/hosts/session-host/src/runtime/media/frame_writer.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer.rs
@@ -9,6 +9,7 @@ use pilotage_session::ClientKey;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::{debug, error, warn};
+use wtransport::error::{StreamOpeningError, StreamWriteError};
 use wtransport::{Connection, SendStream, VarInt};
 
 use super::{EncodedFrame, now_ns};
@@ -29,6 +30,38 @@ const FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(2);
 /// partial frame regardless of the code.
 const STALL_RESET_CODE: u32 = 1;
 
+/// Why an open, write, or finish failed, classified so a peer's decision
+/// to abandon ONE stream does not retire the whole source writer.
+enum StreamError {
+    /// The peer stopped or refused this stream alone (`Stopped`,
+    /// `Refused`), or it was already closed locally. The connection and
+    /// every other source are unaffected — this is one-frame loss.
+    PeerLocal {
+        /// The phase that surfaced it (`open`, `write`, `finish`).
+        phase: &'static str,
+        /// The peer's application error code, when it carried one.
+        code: Option<u64>,
+    },
+    /// Connection-level loss or a protocol failure (`NotConnected`,
+    /// `QuicProto`, or an open-request `ConnectionError`): the writer must
+    /// retire — no further frame can be delivered on this connection.
+    ConnectionFatal(&'static str),
+}
+
+/// Classifies a wtransport write/finish error: only `NotConnected` and
+/// `QuicProto` are connection-fatal; `Stopped`/`Closed` are peer-local.
+fn classify_write(error: &StreamWriteError, phase: &'static str) -> StreamError {
+    match error {
+        StreamWriteError::Stopped(code) => StreamError::PeerLocal {
+            phase,
+            code: Some(code.into_inner()),
+        },
+        StreamWriteError::Closed => StreamError::PeerLocal { phase, code: None },
+        StreamWriteError::NotConnected => StreamError::ConnectionFatal("not connected"),
+        StreamWriteError::QuicProto => StreamError::ConnectionFatal("QUIC protocol error"),
+    }
+}
+
 /// One per-frame outbound stream. `write_all`/`finish` are the clean send
 /// path; `reset` is the explicit RESET_STREAM a deadline-exceeded frame
 /// needs. Dropping a wtransport/Quinn `SendStream` attempts a graceful
@@ -38,9 +71,9 @@ const STALL_RESET_CODE: u32 = 1;
 /// because the writer runs as a spawned task on a multi-threaded runtime.
 trait FrameStream {
     /// Writes the whole buffer, awaiting flow-control credit.
-    fn write_all(&mut self, buf: &[u8]) -> impl Future<Output = Result<(), &'static str>> + Send;
+    fn write_all(&mut self, buf: &[u8]) -> impl Future<Output = Result<(), StreamError>> + Send;
     /// Finishes the stream cleanly (graceful FIN).
-    fn finish(&mut self) -> impl Future<Output = Result<(), &'static str>> + Send;
+    fn finish(&mut self) -> impl Future<Output = Result<(), StreamError>> + Send;
     /// Resets the stream (RESET_STREAM); a no-op on an already-closed one.
     fn reset(&mut self);
 }
@@ -50,20 +83,20 @@ trait FrameChannel {
     /// The stream this channel opens.
     type Stream: FrameStream;
     /// Opens one host-initiated uni stream.
-    fn open(&self) -> impl Future<Output = Result<Self::Stream, &'static str>> + Send;
+    fn open(&self) -> impl Future<Output = Result<Self::Stream, StreamError>> + Send;
 }
 
 impl FrameStream for SendStream {
-    async fn write_all(&mut self, buf: &[u8]) -> Result<(), &'static str> {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), StreamError> {
         SendStream::write_all(self, buf)
             .await
-            .map_err(|_| "payload write failed")
+            .map_err(|e| classify_write(&e, "write"))
     }
 
-    async fn finish(&mut self) -> Result<(), &'static str> {
+    async fn finish(&mut self) -> Result<(), StreamError> {
         SendStream::finish(self)
             .await
-            .map_err(|_| "stream finish failed")
+            .map_err(|e| classify_write(&e, "finish"))
     }
 
     fn reset(&mut self) {
@@ -76,12 +109,20 @@ impl FrameStream for SendStream {
 impl FrameChannel for Connection {
     type Stream = SendStream;
 
-    async fn open(&self) -> Result<SendStream, &'static str> {
-        self.open_uni()
+    async fn open(&self) -> Result<SendStream, StreamError> {
+        // The open-request error is connection-level; the opening error can
+        // be a peer refusal of this stream alone.
+        let opening = self
+            .open_uni()
             .await
-            .map_err(|_| "uni stream request failed")?
-            .await
-            .map_err(|_| "uni stream failed to open")
+            .map_err(|_| StreamError::ConnectionFatal("uni stream request failed"))?;
+        opening.await.map_err(|e| match e {
+            StreamOpeningError::Refused => StreamError::PeerLocal {
+                phase: "open",
+                code: None,
+            },
+            StreamOpeningError::NotConnected => StreamError::ConnectionFatal("not connected"),
+        })
     }
 }
 
@@ -108,17 +149,23 @@ enum FrameOutcome {
     /// had opened and was explicitly reset, false when the open itself
     /// timed out (there was no stream to reset).
     Stalled { reset: bool },
-    /// The open or write failed outright; the connection is going away.
-    Failed(&'static str),
+    /// The peer stopped or refused this stream alone; the connection and
+    /// other sources are healthy — one-frame loss, keep writing.
+    PeerLocal {
+        /// The phase (`open`, `write`, `finish`) that surfaced it.
+        phase: &'static str,
+        /// The peer's application error code, when it carried one.
+        code: Option<u64>,
+    },
+    /// Connection-level loss or protocol failure; retire the writer.
+    ConnectionFatal(&'static str),
 }
 
 /// Drains the handoff channel, delivering one frame per stream under a
 /// single absolute per-frame deadline that covers BOTH opening the stream
-/// and writing it. A frame that exceeds its deadline costs one frame and
-/// the writer proceeds — a mid-write timeout resets the opened stream
-/// (RESET_STREAM), an open timeout simply skips (no stream exists). An
-/// outright open/write failure means the connection is going away and ends
-/// the writer.
+/// and writing it. A frame lost to a deadline or a peer-local stop/refusal
+/// costs one frame and the writer proceeds; only connection-level loss
+/// retires the writer.
 async fn drain_frames<C: FrameChannel>(
     client: ClientKey,
     source_id: u8,
@@ -127,6 +174,7 @@ async fn drain_frames<C: FrameChannel>(
     start: Instant,
 ) {
     let mut stalls: u64 = 0;
+    let mut peer_drops: u64 = 0;
     while let Some(frame) = frames.recv().await {
         // Stamp publication at the moment of write, distinct from the receive
         // stamp taken at dequeue, so a consumer can separate host queueing
@@ -158,10 +206,21 @@ async fn drain_frames<C: FrameChannel>(
                     "video frame exceeded its deadline; continuing with the next frame"
                 );
             }
-            FrameOutcome::Failed(reason) => {
-                // A failed open/write means the connection is going away; stop
-                // writing video to it. The connection task's own teardown
-                // deregisters this client.
+            FrameOutcome::PeerLocal { phase, code } => {
+                peer_drops = peer_drops.wrapping_add(1);
+                warn!(
+                    client = client.as_u64(),
+                    source_id,
+                    phase,
+                    peer_code = code,
+                    total_peer_drops = peer_drops,
+                    "peer stopped or refused this video stream; the connection is healthy, \
+                     continuing with the next frame"
+                );
+            }
+            FrameOutcome::ConnectionFatal(reason) => {
+                // Connection-level loss; stop writing video to it. The
+                // connection task's own teardown deregisters this client.
                 debug!(
                     client = client.as_u64(),
                     source_id, reason, "video writer stopping"
@@ -176,7 +235,9 @@ async fn drain_frames<C: FrameChannel>(
 /// absolute `deadline`. An open that exceeds the deadline yields a stall
 /// with no stream to reset; a write that exceeds it explicitly resets the
 /// opened stream (RESET_STREAM), retained across the timed region so the
-/// reset can fire rather than a dropped-future FIN.
+/// reset can fire rather than a dropped-future FIN. Typed open/write
+/// failures pass their peer-local vs connection-fatal classification
+/// through unchanged.
 async fn deliver_frame<C: FrameChannel>(
     channel: &C,
     deadline: Instant,
@@ -185,15 +246,26 @@ async fn deliver_frame<C: FrameChannel>(
 ) -> FrameOutcome {
     let mut stream = match tokio::time::timeout_at(deadline, channel.open()).await {
         Ok(Ok(stream)) => stream,
-        Ok(Err(reason)) => return FrameOutcome::Failed(reason),
+        Ok(Err(error)) => return error.into_outcome(),
         Err(_elapsed) => return FrameOutcome::Stalled { reset: false },
     };
     match tokio::time::timeout_at(deadline, write_body(&mut stream, tag, body)).await {
         Ok(Ok(())) => FrameOutcome::Sent,
-        Ok(Err(reason)) => FrameOutcome::Failed(reason),
+        Ok(Err(error)) => error.into_outcome(),
         Err(_elapsed) => {
             stream.reset();
             FrameOutcome::Stalled { reset: true }
+        }
+    }
+}
+
+impl StreamError {
+    /// Maps a stream error to its frame outcome, preserving the peer-local
+    /// vs connection-fatal classification.
+    fn into_outcome(self) -> FrameOutcome {
+        match self {
+            StreamError::PeerLocal { phase, code } => FrameOutcome::PeerLocal { phase, code },
+            StreamError::ConnectionFatal(reason) => FrameOutcome::ConnectionFatal(reason),
         }
     }
 }
@@ -203,232 +275,11 @@ async fn write_body<S: FrameStream>(
     stream: &mut S,
     tag: u8,
     body: &[u8],
-) -> Result<(), &'static str> {
+) -> Result<(), StreamError> {
     stream.write_all(&[tag]).await?;
     stream.write_all(body).await?;
     stream.finish().await
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::panic)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    use pilotage_adapter_api::{
-        CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, MeasurementStamp,
-        SourceIncarnation, SourceIntegrity, SourceRole, VideoCaptureStamp,
-    };
-    use pilotage_session::ClientKey;
-    use tokio::sync::mpsc;
-    use tokio::time::Instant;
-
-    use super::{EncodedFrame, FrameChannel, FrameStream, drain_frames};
-
-    fn capture_stamp() -> VideoCaptureStamp {
-        VideoCaptureStamp {
-            stamp: MeasurementStamp {
-                role: SourceRole::VideoCapture,
-                integrity: SourceIntegrity::Unprotected,
-                source_id: 1,
-                source_incarnation: SourceIncarnation::new([5; 16]),
-                source_epoch: 0,
-                sequence: 3,
-                acquired_at_ns: 999,
-                clock: MeasurementClock::Simulation,
-            },
-            camera_id: CameraId(1),
-            calibration_id: CalibrationId::NONE,
-            mapping: CaptureClockMapping::identity(MeasurementClock::Simulation),
-        }
-    }
-
-    fn encoded_frame() -> EncodedFrame {
-        EncodedFrame {
-            jpeg: Arc::new(vec![0xFF, 0xD8, 0xFF, 0xD9]),
-            capture: capture_stamp(),
-            received_at_ns: 0,
-        }
-    }
-
-    /// Shared call tallies a test asserts against.
-    #[derive(Default)]
-    struct Tally {
-        opened: AtomicU32,
-        finished: AtomicU32,
-        reset: AtomicU32,
-    }
-
-    /// How a mock stream behaves once opened.
-    #[derive(Clone, Copy)]
-    enum Write {
-        /// `write_all` never completes (a wedged consumer).
-        Stall,
-        /// `write_all` returns an error (connection going away).
-        Fail,
-        /// Writes and finishes normally.
-        Ok,
-    }
-
-    /// How a mock `open()` behaves.
-    #[derive(Clone, Copy)]
-    enum Open {
-        /// `open()` never completes (the peer's stream allowance is full).
-        Stall,
-        /// `open()` yields a stream with the given write behavior.
-        Ready(Write),
-    }
-
-    struct MockStream {
-        write: Write,
-        tally: Arc<Tally>,
-    }
-
-    impl FrameStream for MockStream {
-        async fn write_all(&mut self, _buf: &[u8]) -> Result<(), &'static str> {
-            match self.write {
-                Write::Stall => {
-                    std::future::pending::<()>().await;
-                    Ok(())
-                }
-                Write::Fail => Err("payload write failed"),
-                Write::Ok => Ok(()),
-            }
-        }
-
-        async fn finish(&mut self) -> Result<(), &'static str> {
-            self.tally.finished.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-
-        fn reset(&mut self) {
-            self.tally.reset.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-
-    /// Hands out opens from a per-open script; opens beyond the script are
-    /// `Ready(Write::Ok)`.
-    struct MockChannel {
-        script: Vec<Open>,
-        tally: Arc<Tally>,
-    }
-
-    impl FrameChannel for MockChannel {
-        type Stream = MockStream;
-
-        async fn open(&self) -> Result<MockStream, &'static str> {
-            let n = self.tally.opened.fetch_add(1, Ordering::SeqCst) as usize;
-            match self
-                .script
-                .get(n)
-                .copied()
-                .unwrap_or(Open::Ready(Write::Ok))
-            {
-                Open::Stall => {
-                    std::future::pending::<()>().await;
-                    unreachable!("a stalled open never resolves")
-                }
-                Open::Ready(write) => Ok(MockStream {
-                    write,
-                    tally: self.tally.clone(),
-                }),
-            }
-        }
-    }
-
-    async fn queue(frames: usize) -> mpsc::Receiver<EncodedFrame> {
-        let (tx, rx) = mpsc::channel(frames.max(1));
-        for _ in 0..frames {
-            tx.send(encoded_frame()).await.expect("frame queues");
-        }
-        drop(tx);
-        rx
-    }
-
-    /// A stalled write must reset its stream exactly once (RESET_STREAM,
-    /// not a dropped FIN) and the next frame must open its own stream and
-    /// finish cleanly. Virtual time fires the deadline without real waiting.
-    #[tokio::test(start_paused = true)]
-    async fn a_stalled_write_resets_once_and_the_next_frame_proceeds() {
-        let mut rx = queue(2).await;
-        let tally = Arc::new(Tally::default());
-        let channel = MockChannel {
-            script: vec![Open::Ready(Write::Stall), Open::Ready(Write::Ok)],
-            tally: tally.clone(),
-        };
-
-        drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
-
-        assert_eq!(
-            tally.reset.load(Ordering::SeqCst),
-            1,
-            "the stalled frame's stream is reset exactly once"
-        );
-        assert_eq!(
-            tally.opened.load(Ordering::SeqCst),
-            2,
-            "the next frame opens its own stream"
-        );
-        assert_eq!(
-            tally.finished.load(Ordering::SeqCst),
-            1,
-            "the second frame finishes cleanly and is not reset"
-        );
-    }
-
-    /// A stalled OPEN also costs one frame: the per-frame deadline covers
-    /// opening, so an open that never completes is skipped (nothing to
-    /// reset) and the next frame opens its own stream and finishes.
-    #[tokio::test(start_paused = true)]
-    async fn a_stalled_open_is_skipped_and_the_next_frame_proceeds() {
-        let mut rx = queue(2).await;
-        let tally = Arc::new(Tally::default());
-        let channel = MockChannel {
-            script: vec![Open::Stall, Open::Ready(Write::Ok)],
-            tally: tally.clone(),
-        };
-
-        drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
-
-        assert_eq!(
-            tally.opened.load(Ordering::SeqCst),
-            2,
-            "the next frame opens its own stream after the stalled open"
-        );
-        assert_eq!(
-            tally.finished.load(Ordering::SeqCst),
-            1,
-            "the second frame finishes cleanly"
-        );
-        assert_eq!(
-            tally.reset.load(Ordering::SeqCst),
-            0,
-            "a stalled open has no stream to reset"
-        );
-    }
-
-    /// An outright open/write error ends the writer: the connection is going
-    /// away, so the frame after the failed one is never opened.
-    #[tokio::test(start_paused = true)]
-    async fn a_write_error_ends_the_writer() {
-        let mut rx = queue(2).await;
-        let tally = Arc::new(Tally::default());
-        let channel = MockChannel {
-            script: vec![Open::Ready(Write::Fail), Open::Ready(Write::Ok)],
-            tally: tally.clone(),
-        };
-
-        drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
-
-        assert_eq!(
-            tally.opened.load(Ordering::SeqCst),
-            1,
-            "the writer stops after the failed frame; the next is never opened"
-        );
-        assert_eq!(
-            tally.reset.load(Ordering::SeqCst),
-            0,
-            "an outright failure is not a reset"
-        );
-    }
-}
+mod tests;

--- a/hosts/session-host/src/runtime/media/frame_writer.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use pilotage_session::ClientKey;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 use wtransport::error::{StreamOpeningError, StreamWriteError};
 use wtransport::{Connection, SendStream, VarInt};
 
@@ -30,35 +30,92 @@ const FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(2);
 /// partial frame regardless of the code.
 const STALL_RESET_CODE: u32 = 1;
 
-/// Why an open, write, or finish failed, classified so a peer's decision
-/// to abandon ONE stream does not retire the whole source writer.
+/// A connection-fatal error's kind, preserved rather than erased so the
+/// log names what actually failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FatalKind {
+    /// The connection has been dropped.
+    NotConnected,
+    /// A QUIC protocol error.
+    QuicProto,
+    /// The uni-stream open request itself failed (connection-level).
+    OpenRequest,
+}
+
+impl FatalKind {
+    /// A stable log string for the fatal kind.
+    fn as_str(self) -> &'static str {
+        match self {
+            FatalKind::NotConnected => "not connected",
+            FatalKind::QuicProto => "QUIC protocol error",
+            FatalKind::OpenRequest => "uni stream request failed",
+        }
+    }
+}
+
+/// Why an open, write, or finish failed, classified so neither a peer's
+/// decision to abandon ONE stream nor a local close retires the writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StreamError {
     /// The peer stopped or refused this stream alone (`Stopped`,
-    /// `Refused`), or it was already closed locally. The connection and
-    /// every other source are unaffected — this is one-frame loss.
-    PeerLocal {
+    /// `Refused`): a peer-attributed one-frame loss; the connection and
+    /// every other source are unaffected.
+    PeerStop {
         /// The phase that surfaced it (`open`, `write`, `finish`).
         phase: &'static str,
         /// The peer's application error code, when it carried one.
         code: Option<u64>,
     },
-    /// Connection-level loss or a protocol failure (`NotConnected`,
-    /// `QuicProto`, or an open-request `ConnectionError`): the writer must
+    /// The stream was already closed locally (`Closed`): a frame-local
+    /// anomaly, recoverable like a peer stop but NOT a peer stop/refusal.
+    LocalClose {
+        /// The phase that surfaced it.
+        phase: &'static str,
+    },
+    /// Connection-level loss or a protocol failure: the writer must
     /// retire — no further frame can be delivered on this connection.
-    ConnectionFatal(&'static str),
+    ConnectionFatal {
+        /// The phase that surfaced it.
+        phase: &'static str,
+        /// The preserved underlying kind, not erased to a string.
+        kind: FatalKind,
+    },
 }
 
-/// Classifies a wtransport write/finish error: only `NotConnected` and
-/// `QuicProto` are connection-fatal; `Stopped`/`Closed` are peer-local.
+/// Classifies a wtransport write/finish error: `Stopped` is a peer stop,
+/// `Closed` is a local close, `NotConnected`/`QuicProto` are
+/// connection-fatal. Pinned to wtransport 0.7.1's four variants.
 fn classify_write(error: &StreamWriteError, phase: &'static str) -> StreamError {
     match error {
-        StreamWriteError::Stopped(code) => StreamError::PeerLocal {
+        StreamWriteError::Stopped(code) => StreamError::PeerStop {
             phase,
             code: Some(code.into_inner()),
         },
-        StreamWriteError::Closed => StreamError::PeerLocal { phase, code: None },
-        StreamWriteError::NotConnected => StreamError::ConnectionFatal("not connected"),
-        StreamWriteError::QuicProto => StreamError::ConnectionFatal("QUIC protocol error"),
+        StreamWriteError::Closed => StreamError::LocalClose { phase },
+        StreamWriteError::NotConnected => StreamError::ConnectionFatal {
+            phase,
+            kind: FatalKind::NotConnected,
+        },
+        StreamWriteError::QuicProto => StreamError::ConnectionFatal {
+            phase,
+            kind: FatalKind::QuicProto,
+        },
+    }
+}
+
+/// Classifies a wtransport stream-opening error: `Refused` is a peer
+/// refusal of this stream alone, `NotConnected` is connection-fatal.
+/// Pinned to wtransport 0.7.1's two variants.
+fn classify_open(error: &StreamOpeningError) -> StreamError {
+    match error {
+        StreamOpeningError::Refused => StreamError::PeerStop {
+            phase: "open",
+            code: None,
+        },
+        StreamOpeningError::NotConnected => StreamError::ConnectionFatal {
+            phase: "open",
+            kind: FatalKind::NotConnected,
+        },
     }
 }
 
@@ -115,14 +172,11 @@ impl FrameChannel for Connection {
         let opening = self
             .open_uni()
             .await
-            .map_err(|_| StreamError::ConnectionFatal("uni stream request failed"))?;
-        opening.await.map_err(|e| match e {
-            StreamOpeningError::Refused => StreamError::PeerLocal {
+            .map_err(|_| StreamError::ConnectionFatal {
                 phase: "open",
-                code: None,
-            },
-            StreamOpeningError::NotConnected => StreamError::ConnectionFatal("not connected"),
-        })
+                kind: FatalKind::OpenRequest,
+            })?;
+        opening.await.map_err(|e| classify_open(&e))
     }
 }
 
@@ -151,21 +205,42 @@ enum FrameOutcome {
     Stalled { reset: bool },
     /// The peer stopped or refused this stream alone; the connection and
     /// other sources are healthy — one-frame loss, keep writing.
-    PeerLocal {
+    PeerStop {
         /// The phase (`open`, `write`, `finish`) that surfaced it.
         phase: &'static str,
         /// The peer's application error code, when it carried one.
         code: Option<u64>,
     },
+    /// The stream was already closed locally — a frame-local anomaly,
+    /// recoverable, but not a peer stop/refusal.
+    LocalClose {
+        /// The phase that surfaced it.
+        phase: &'static str,
+    },
     /// Connection-level loss or protocol failure; retire the writer.
-    ConnectionFatal(&'static str),
+    ConnectionFatal {
+        /// The phase that surfaced it.
+        phase: &'static str,
+        /// The preserved underlying kind.
+        kind: FatalKind,
+    },
+}
+
+/// The running per-writer loss counters, kept distinguishable so logs and
+/// metrics separate deadline stalls, peer-local stop/refusal, and
+/// local closes from the one connection-fatal event that ends the writer.
+#[derive(Default)]
+struct LossCounters {
+    stalls: u64,
+    peer_drops: u64,
+    local_closes: u64,
 }
 
 /// Drains the handoff channel, delivering one frame per stream under a
 /// single absolute per-frame deadline that covers BOTH opening the stream
-/// and writing it. A frame lost to a deadline or a peer-local stop/refusal
-/// costs one frame and the writer proceeds; only connection-level loss
-/// retires the writer.
+/// and writing it. A frame lost to a deadline, a peer stop/refusal, or a
+/// local close costs one frame and the writer proceeds; only
+/// connection-level loss retires the writer.
 async fn drain_frames<C: FrameChannel>(
     client: ClientKey,
     source_id: u8,
@@ -173,8 +248,7 @@ async fn drain_frames<C: FrameChannel>(
     frames: &mut mpsc::Receiver<EncodedFrame>,
     start: Instant,
 ) {
-    let mut stalls: u64 = 0;
-    let mut peer_drops: u64 = 0;
+    let mut counters = LossCounters::default();
     while let Some(frame) = frames.recv().await {
         // Stamp publication at the moment of write, distinct from the receive
         // stamp taken at dequeue, so a consumer can separate host queueing
@@ -194,41 +268,75 @@ async fn drain_frames<C: FrameChannel>(
             continue;
         };
         let deadline = Instant::now() + FRAME_WRITE_DEADLINE;
-        match deliver_frame(channel, deadline, VIDEO_FRAME_V2, &body).await {
-            FrameOutcome::Sent => {}
-            FrameOutcome::Stalled { reset } => {
-                stalls = stalls.wrapping_add(1);
-                warn!(
-                    client = client.as_u64(),
-                    source_id,
-                    total_stalls = stalls,
-                    stream_reset = reset,
-                    "video frame exceeded its deadline; continuing with the next frame"
-                );
-            }
-            FrameOutcome::PeerLocal { phase, code } => {
-                peer_drops = peer_drops.wrapping_add(1);
-                warn!(
-                    client = client.as_u64(),
-                    source_id,
-                    phase,
-                    peer_code = code,
-                    total_peer_drops = peer_drops,
-                    "peer stopped or refused this video stream; the connection is healthy, \
-                     continuing with the next frame"
-                );
-            }
-            FrameOutcome::ConnectionFatal(reason) => {
-                // Connection-level loss; stop writing video to it. The
-                // connection task's own teardown deregisters this client.
-                debug!(
-                    client = client.as_u64(),
-                    source_id, reason, "video writer stopping"
-                );
-                return;
-            }
+        let outcome = deliver_frame(channel, deadline, VIDEO_FRAME_V2, &body).await;
+        if !record_outcome(client, source_id, outcome, &mut counters) {
+            return;
         }
     }
+}
+
+/// Folds one frame's outcome into the counters and logs it, returning
+/// `false` when the outcome is connection-fatal and the writer must retire.
+fn record_outcome(
+    client: ClientKey,
+    source_id: u8,
+    outcome: FrameOutcome,
+    counters: &mut LossCounters,
+) -> bool {
+    match outcome {
+        FrameOutcome::Sent => {}
+        FrameOutcome::Stalled { reset } => {
+            counters.stalls = counters.stalls.wrapping_add(1);
+            warn!(
+                client = client.as_u64(),
+                source_id,
+                total_stalls = counters.stalls,
+                stream_reset = reset,
+                "video frame exceeded its deadline; continuing with the next frame"
+            );
+        }
+        FrameOutcome::PeerStop { phase, code } => {
+            counters.peer_drops = counters.peer_drops.wrapping_add(1);
+            warn!(
+                client = client.as_u64(),
+                source_id,
+                phase,
+                peer_code = code,
+                total_peer_drops = counters.peer_drops,
+                "peer stopped or refused this video stream; the connection is healthy, \
+                 continuing with the next frame"
+            );
+        }
+        FrameOutcome::LocalClose { phase } => {
+            counters.local_closes = counters.local_closes.wrapping_add(1);
+            warn!(
+                client = client.as_u64(),
+                source_id,
+                phase,
+                total_local_closes = counters.local_closes,
+                "video stream was already closed locally; frame-local loss, continuing \
+                 with the next frame"
+            );
+        }
+        FrameOutcome::ConnectionFatal { phase, kind } => {
+            // Connection-level loss retires the writer; a distinguishable
+            // fatal record, not a debug line. The connection task's own
+            // teardown deregisters this client.
+            warn!(
+                client = client.as_u64(),
+                source_id,
+                phase,
+                reason = kind.as_str(),
+                total_connection_failures = 1_u64,
+                total_stalls = counters.stalls,
+                total_peer_drops = counters.peer_drops,
+                total_local_closes = counters.local_closes,
+                "video writer stopping: connection-level failure"
+            );
+            return false;
+        }
+    }
+    true
 }
 
 /// Opens a stream and writes the tag then the framed body, all under one
@@ -260,12 +368,15 @@ async fn deliver_frame<C: FrameChannel>(
 }
 
 impl StreamError {
-    /// Maps a stream error to its frame outcome, preserving the peer-local
-    /// vs connection-fatal classification.
+    /// Maps a stream error to its frame outcome, preserving the peer-stop,
+    /// local-close, and connection-fatal classification.
     fn into_outcome(self) -> FrameOutcome {
         match self {
-            StreamError::PeerLocal { phase, code } => FrameOutcome::PeerLocal { phase, code },
-            StreamError::ConnectionFatal(reason) => FrameOutcome::ConnectionFatal(reason),
+            StreamError::PeerStop { phase, code } => FrameOutcome::PeerStop { phase, code },
+            StreamError::LocalClose { phase } => FrameOutcome::LocalClose { phase },
+            StreamError::ConnectionFatal { phase, kind } => {
+                FrameOutcome::ConnectionFatal { phase, kind }
+            }
         }
     }
 }

--- a/hosts/session-host/src/runtime/media/frame_writer.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer.rs
@@ -9,7 +9,7 @@ use pilotage_session::ClientKey;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::{error, warn};
-use wtransport::error::{StreamOpeningError, StreamWriteError};
+use wtransport::error::{ConnectionError, StreamOpeningError, StreamWriteError};
 use wtransport::{Connection, SendStream, VarInt};
 
 use super::{EncodedFrame, now_ns};
@@ -31,35 +31,31 @@ const FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(2);
 const STALL_RESET_CODE: u32 = 1;
 
 /// A connection-fatal error's kind, preserved rather than erased so the
-/// log names what actually failed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// log names — and the error chain carries — what actually failed. The
+/// open-request kind keeps the real [`ConnectionError`] as its `#[source]`
+/// (timeout, application-close reason/code, H3, QUIC details all survive).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 enum FatalKind {
     /// The connection has been dropped.
+    #[error("not connected")]
     NotConnected,
     /// A QUIC protocol error.
+    #[error("QUIC protocol error")]
     QuicProto,
-    /// The uni-stream open request itself failed (connection-level).
-    OpenRequest,
-}
-
-impl FatalKind {
-    /// A stable log string for the fatal kind.
-    fn as_str(self) -> &'static str {
-        match self {
-            FatalKind::NotConnected => "not connected",
-            FatalKind::QuicProto => "QUIC protocol error",
-            FatalKind::OpenRequest => "uni stream request failed",
-        }
-    }
+    /// The uni-stream open request itself failed (connection-level); the
+    /// concrete cause is preserved.
+    #[error("uni stream request failed: {0}")]
+    OpenRequest(#[source] ConnectionError),
 }
 
 /// Why an open, write, or finish failed, classified so neither a peer's
 /// decision to abandon ONE stream nor a local close retires the writer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 enum StreamError {
     /// The peer stopped or refused this stream alone (`Stopped`,
     /// `Refused`): a peer-attributed one-frame loss; the connection and
     /// every other source are unaffected.
+    #[error("peer stopped or refused the stream at {phase}")]
     PeerStop {
         /// The phase that surfaced it (`open`, `write`, `finish`).
         phase: &'static str,
@@ -68,16 +64,19 @@ enum StreamError {
     },
     /// The stream was already closed locally (`Closed`): a frame-local
     /// anomaly, recoverable like a peer stop but NOT a peer stop/refusal.
+    #[error("stream already closed locally at {phase}")]
     LocalClose {
         /// The phase that surfaced it.
         phase: &'static str,
     },
     /// Connection-level loss or a protocol failure: the writer must
     /// retire — no further frame can be delivered on this connection.
+    #[error("connection-fatal at {phase}: {kind}")]
     ConnectionFatal {
         /// The phase that surfaced it.
         phase: &'static str,
-        /// The preserved underlying kind, not erased to a string.
+        /// The preserved underlying kind (its own `#[source]` chain).
+        #[source]
         kind: FatalKind,
     },
 }
@@ -116,6 +115,16 @@ fn classify_open(error: &StreamOpeningError) -> StreamError {
             phase: "open",
             kind: FatalKind::NotConnected,
         },
+    }
+}
+
+/// Classifies an open-request [`ConnectionError`] (the first `open_uni`
+/// await): always connection-fatal, but the concrete cause is retained
+/// rather than discarded to a static string.
+fn classify_open_request(error: ConnectionError) -> StreamError {
+    StreamError::ConnectionFatal {
+        phase: "open",
+        kind: FatalKind::OpenRequest(error),
     }
 }
 
@@ -167,15 +176,9 @@ impl FrameChannel for Connection {
     type Stream = SendStream;
 
     async fn open(&self) -> Result<SendStream, StreamError> {
-        // The open-request error is connection-level; the opening error can
-        // be a peer refusal of this stream alone.
-        let opening = self
-            .open_uni()
-            .await
-            .map_err(|_| StreamError::ConnectionFatal {
-                phase: "open",
-                kind: FatalKind::OpenRequest,
-            })?;
+        // The open-request error is connection-level (its cause preserved);
+        // the opening error can be a peer refusal of this stream alone.
+        let opening = self.open_uni().await.map_err(classify_open_request)?;
         opening.await.map_err(|e| classify_open(&e))
     }
 }
@@ -320,13 +323,15 @@ fn record_outcome(
         }
         FrameOutcome::ConnectionFatal { phase, kind } => {
             // Connection-level loss retires the writer; a distinguishable
-            // fatal record, not a debug line. The connection task's own
-            // teardown deregisters this client.
+            // fatal record, not a debug line. `%source` logs the preserved
+            // cause (timeout, application-close reason/code, H3, QUIC), not a
+            // static string. The connection task's own teardown deregisters
+            // this client.
             warn!(
                 client = client.as_u64(),
                 source_id,
                 phase,
-                reason = kind.as_str(),
+                source = %kind,
                 total_connection_failures = 1_u64,
                 total_stalls = counters.stalls,
                 total_peer_drops = counters.peer_drops,

--- a/hosts/session-host/src/runtime/media/frame_writer/tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests.rs
@@ -1,0 +1,305 @@
+//! Frame-writer delivery tests: deadline stalls, peer-local
+//! stop/refusal (one-frame loss, writer survives), and
+//! connection-fatal loss (writer retires), all in virtual time.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use pilotage_adapter_api::{
+    CalibrationId, CameraId, CaptureClockMapping, MeasurementClock, MeasurementStamp,
+    SourceIncarnation, SourceIntegrity, SourceRole, VideoCaptureStamp,
+};
+use pilotage_session::ClientKey;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+
+use super::{EncodedFrame, FrameChannel, FrameStream, drain_frames};
+
+fn capture_stamp() -> VideoCaptureStamp {
+    VideoCaptureStamp {
+        stamp: MeasurementStamp {
+            role: SourceRole::VideoCapture,
+            integrity: SourceIntegrity::Unprotected,
+            source_id: 1,
+            source_incarnation: SourceIncarnation::new([5; 16]),
+            source_epoch: 0,
+            sequence: 3,
+            acquired_at_ns: 999,
+            clock: MeasurementClock::Simulation,
+        },
+        camera_id: CameraId(1),
+        calibration_id: CalibrationId::NONE,
+        mapping: CaptureClockMapping::identity(MeasurementClock::Simulation),
+    }
+}
+
+fn encoded_frame() -> EncodedFrame {
+    EncodedFrame {
+        jpeg: Arc::new(vec![0xFF, 0xD8, 0xFF, 0xD9]),
+        capture: capture_stamp(),
+        received_at_ns: 0,
+    }
+}
+
+/// Shared call tallies a test asserts against.
+#[derive(Default)]
+struct Tally {
+    opened: AtomicU32,
+    finished: AtomicU32,
+    reset: AtomicU32,
+}
+
+/// How a mock stream behaves once opened.
+#[derive(Clone, Copy)]
+enum Write {
+    /// `write_all` never completes (a wedged consumer).
+    Stall,
+    /// The peer stopped this stream alone (peer-local, one-frame loss).
+    PeerStopped(u64),
+    /// The connection is gone (connection-fatal).
+    ConnFatal,
+    /// Writes and finishes normally.
+    Ok,
+}
+
+/// How a mock `open()` behaves.
+#[derive(Clone, Copy)]
+enum Open {
+    /// `open()` never completes (the peer's stream allowance is full).
+    Stall,
+    /// The peer refused this stream alone (peer-local, one-frame loss).
+    Refused,
+    /// The connection is gone (connection-fatal).
+    ConnFatal,
+    /// `open()` yields a stream with the given write behavior.
+    Ready(Write),
+}
+
+struct MockStream {
+    write: Write,
+    tally: Arc<Tally>,
+}
+
+impl FrameStream for MockStream {
+    async fn write_all(&mut self, _buf: &[u8]) -> Result<(), super::StreamError> {
+        match self.write {
+            Write::Stall => {
+                std::future::pending::<()>().await;
+                Ok(())
+            }
+            Write::PeerStopped(code) => Err(super::StreamError::PeerLocal {
+                phase: "write",
+                code: Some(code),
+            }),
+            Write::ConnFatal => Err(super::StreamError::ConnectionFatal("not connected")),
+            Write::Ok => Ok(()),
+        }
+    }
+
+    async fn finish(&mut self) -> Result<(), super::StreamError> {
+        self.tally.finished.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        self.tally.reset.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// Hands out opens from a per-open script; opens beyond the script are
+/// `Ready(Write::Ok)`.
+struct MockChannel {
+    script: Vec<Open>,
+    tally: Arc<Tally>,
+}
+
+impl FrameChannel for MockChannel {
+    type Stream = MockStream;
+
+    async fn open(&self) -> Result<MockStream, super::StreamError> {
+        let n = self.tally.opened.fetch_add(1, Ordering::SeqCst) as usize;
+        match self
+            .script
+            .get(n)
+            .copied()
+            .unwrap_or(Open::Ready(Write::Ok))
+        {
+            Open::Stall => {
+                std::future::pending::<()>().await;
+                unreachable!("a stalled open never resolves")
+            }
+            Open::Refused => Err(super::StreamError::PeerLocal {
+                phase: "open",
+                code: None,
+            }),
+            Open::ConnFatal => Err(super::StreamError::ConnectionFatal("not connected")),
+            Open::Ready(write) => Ok(MockStream {
+                write,
+                tally: self.tally.clone(),
+            }),
+        }
+    }
+}
+
+async fn queue(frames: usize) -> mpsc::Receiver<EncodedFrame> {
+    let (tx, rx) = mpsc::channel(frames.max(1));
+    for _ in 0..frames {
+        tx.send(encoded_frame()).await.expect("frame queues");
+    }
+    drop(tx);
+    rx
+}
+
+/// A stalled write must reset its stream exactly once (RESET_STREAM,
+/// not a dropped FIN) and the next frame must open its own stream and
+/// finish cleanly. Virtual time fires the deadline without real waiting.
+#[tokio::test(start_paused = true)]
+async fn a_stalled_write_resets_once_and_the_next_frame_proceeds() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Ready(Write::Stall), Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.reset.load(Ordering::SeqCst),
+        1,
+        "the stalled frame's stream is reset exactly once"
+    );
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        2,
+        "the next frame opens its own stream"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the second frame finishes cleanly and is not reset"
+    );
+}
+
+/// A stalled OPEN also costs one frame: the per-frame deadline covers
+/// opening, so an open that never completes is skipped (nothing to
+/// reset) and the next frame opens its own stream and finishes.
+#[tokio::test(start_paused = true)]
+async fn a_stalled_open_is_skipped_and_the_next_frame_proceeds() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Stall, Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        2,
+        "the next frame opens its own stream after the stalled open"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the second frame finishes cleanly"
+    );
+    assert_eq!(
+        tally.reset.load(Ordering::SeqCst),
+        0,
+        "a stalled open has no stream to reset"
+    );
+}
+
+/// A peer that STOPS one stream costs one frame, not the source: the
+/// next frame opens its own stream and finishes, and the writer stays
+/// alive (it drains every queued frame rather than returning early).
+#[tokio::test(start_paused = true)]
+async fn a_peer_stopped_write_loses_one_frame_and_the_writer_survives() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Ready(Write::PeerStopped(7)), Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        2,
+        "the writer survives the peer stop and opens the next frame's stream"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the frame after the stopped one finishes cleanly"
+    );
+}
+
+/// A peer that REFUSES one stream open likewise costs one frame: the
+/// next frame proceeds and the writer stays alive.
+#[tokio::test(start_paused = true)]
+async fn a_refused_open_loses_one_frame_and_the_next_proceeds() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Refused, Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        2,
+        "a refused open costs one frame; the next frame opens its stream"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the frame after the refused open finishes cleanly"
+    );
+}
+
+/// Connection-level loss DOES retire the writer: after a connection-fatal
+/// write, the frame after it is never opened.
+#[tokio::test(start_paused = true)]
+async fn a_connection_fatal_write_retires_the_writer() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Ready(Write::ConnFatal), Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        1,
+        "the writer retires on connection loss; the next frame is never opened"
+    );
+}
+
+/// A connection-fatal OPEN also retires the writer.
+#[tokio::test(start_paused = true)]
+async fn a_connection_fatal_open_retires_the_writer() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::ConnFatal, Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        1,
+        "the writer retires on a connection-fatal open; the next frame is never opened"
+    );
+}

--- a/hosts/session-host/src/runtime/media/frame_writer/tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests.rs
@@ -16,11 +16,11 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use wtransport::VarInt;
-use wtransport::error::{StreamOpeningError, StreamWriteError};
+use wtransport::error::{ConnectionError, StreamOpeningError, StreamWriteError};
 
 use super::{
-    EncodedFrame, FatalKind, FrameChannel, FrameStream, StreamError, classify_open, classify_write,
-    drain_frames,
+    EncodedFrame, FatalKind, FrameChannel, FrameStream, StreamError, classify_open,
+    classify_open_request, classify_write, drain_frames,
 };
 
 fn capture_stamp() -> VideoCaptureStamp {
@@ -396,4 +396,26 @@ fn classify_open_maps_every_pinned_variant() {
             kind: FatalKind::NotConnected,
         },
     );
+}
+
+#[test]
+fn an_open_request_error_preserves_its_concrete_cause() {
+    // A concrete ConnectionError must survive classification, not be
+    // erased to a static string: it is retained in the OpenRequest kind
+    // and reachable through the error source chain and Display.
+    let classified = classify_open_request(ConnectionError::TimedOut);
+    assert_eq!(
+        classified,
+        StreamError::ConnectionFatal {
+            phase: "open",
+            kind: FatalKind::OpenRequest(ConnectionError::TimedOut),
+        },
+    );
+    // The source chain reaches the exact ConnectionError.
+    let via_source = std::error::Error::source(&classified)
+        .and_then(std::error::Error::source)
+        .and_then(|e| e.downcast_ref::<ConnectionError>());
+    assert_eq!(via_source, Some(&ConnectionError::TimedOut));
+    // ...and its Display carries the concrete cause for the log.
+    assert!(classified.to_string().contains("timed out"), "{classified}");
 }

--- a/hosts/session-host/src/runtime/media/frame_writer/tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests.rs
@@ -15,7 +15,13 @@ use pilotage_session::ClientKey;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
-use super::{EncodedFrame, FrameChannel, FrameStream, drain_frames};
+use wtransport::VarInt;
+use wtransport::error::{StreamOpeningError, StreamWriteError};
+
+use super::{
+    EncodedFrame, FatalKind, FrameChannel, FrameStream, StreamError, classify_open, classify_write,
+    drain_frames,
+};
 
 fn capture_stamp() -> VideoCaptureStamp {
     VideoCaptureStamp {
@@ -51,27 +57,33 @@ struct Tally {
     reset: AtomicU32,
 }
 
-/// How a mock stream behaves once opened.
+/// How a mock stream behaves once opened. The failure cases construct a
+/// real `StreamWriteError` and route it through the production
+/// `classify_write`, so the drain tests exercise the actual mapping — a
+/// reversed classifier would flip these outcomes too.
 #[derive(Clone, Copy)]
 enum Write {
     /// `write_all` never completes (a wedged consumer).
     Stall,
-    /// The peer stopped this stream alone (peer-local, one-frame loss).
-    PeerStopped(u64),
-    /// The connection is gone (connection-fatal).
+    /// The peer stopped this stream alone (`StreamWriteError::Stopped`).
+    PeerStopped(u32),
+    /// The stream was already closed locally (`StreamWriteError::Closed`).
+    Closed,
+    /// The connection is gone (`StreamWriteError::NotConnected`).
     ConnFatal,
     /// Writes and finishes normally.
     Ok,
 }
 
-/// How a mock `open()` behaves.
+/// How a mock `open()` behaves; the failure cases route real
+/// `StreamOpeningError`s through the production `classify_open`.
 #[derive(Clone, Copy)]
 enum Open {
     /// `open()` never completes (the peer's stream allowance is full).
     Stall,
-    /// The peer refused this stream alone (peer-local, one-frame loss).
+    /// The peer refused this stream alone (`StreamOpeningError::Refused`).
     Refused,
-    /// The connection is gone (connection-fatal).
+    /// The connection is gone (`StreamOpeningError::NotConnected`).
     ConnFatal,
     /// `open()` yields a stream with the given write behavior.
     Ready(Write),
@@ -83,22 +95,23 @@ struct MockStream {
 }
 
 impl FrameStream for MockStream {
-    async fn write_all(&mut self, _buf: &[u8]) -> Result<(), super::StreamError> {
+    async fn write_all(&mut self, _buf: &[u8]) -> Result<(), StreamError> {
         match self.write {
             Write::Stall => {
                 std::future::pending::<()>().await;
                 Ok(())
             }
-            Write::PeerStopped(code) => Err(super::StreamError::PeerLocal {
-                phase: "write",
-                code: Some(code),
-            }),
-            Write::ConnFatal => Err(super::StreamError::ConnectionFatal("not connected")),
+            Write::PeerStopped(code) => Err(classify_write(
+                &StreamWriteError::Stopped(VarInt::from_u32(code)),
+                "write",
+            )),
+            Write::Closed => Err(classify_write(&StreamWriteError::Closed, "write")),
+            Write::ConnFatal => Err(classify_write(&StreamWriteError::NotConnected, "write")),
             Write::Ok => Ok(()),
         }
     }
 
-    async fn finish(&mut self) -> Result<(), super::StreamError> {
+    async fn finish(&mut self) -> Result<(), StreamError> {
         self.tally.finished.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -118,7 +131,7 @@ struct MockChannel {
 impl FrameChannel for MockChannel {
     type Stream = MockStream;
 
-    async fn open(&self) -> Result<MockStream, super::StreamError> {
+    async fn open(&self) -> Result<MockStream, StreamError> {
         let n = self.tally.opened.fetch_add(1, Ordering::SeqCst) as usize;
         match self
             .script
@@ -130,11 +143,8 @@ impl FrameChannel for MockChannel {
                 std::future::pending::<()>().await;
                 unreachable!("a stalled open never resolves")
             }
-            Open::Refused => Err(super::StreamError::PeerLocal {
-                phase: "open",
-                code: None,
-            }),
-            Open::ConnFatal => Err(super::StreamError::ConnectionFatal("not connected")),
+            Open::Refused => Err(classify_open(&StreamOpeningError::Refused)),
+            Open::ConnFatal => Err(classify_open(&StreamOpeningError::NotConnected)),
             Open::Ready(write) => Ok(MockStream {
                 write,
                 tally: self.tally.clone(),
@@ -301,5 +311,89 @@ async fn a_connection_fatal_open_retires_the_writer() {
         tally.opened.load(Ordering::SeqCst),
         1,
         "the writer retires on a connection-fatal open; the next frame is never opened"
+    );
+}
+
+/// A local `Closed` is recoverable frame-local loss: the next frame opens
+/// and finishes, the writer survives, and no stream reset is issued (the
+/// stream was already closed, not deadline-abandoned).
+#[tokio::test(start_paused = true)]
+async fn a_local_close_loses_one_frame_and_the_writer_survives() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Ready(Write::Closed), Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+
+    drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+
+    assert_eq!(
+        tally.opened.load(Ordering::SeqCst),
+        2,
+        "the writer survives a local close and opens the next frame's stream"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the frame after the local close finishes cleanly"
+    );
+    assert_eq!(
+        tally.reset.load(Ordering::SeqCst),
+        0,
+        "a local close does not reset a stream"
+    );
+}
+
+// ---- direct classifier matrix: every pinned wtransport variant --------------
+//
+// The drain tests above route through `classify_write`/`classify_open`,
+// but these pin the mapping itself so a reversed production classifier
+// (peer-local vs connection-fatal swapped) fails outright.
+
+#[test]
+fn classify_write_maps_every_pinned_variant() {
+    assert_eq!(
+        classify_write(&StreamWriteError::Stopped(VarInt::from_u32(9)), "write"),
+        StreamError::PeerStop {
+            phase: "write",
+            code: Some(9),
+        },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::Closed, "finish"),
+        StreamError::LocalClose { phase: "finish" },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::NotConnected, "write"),
+        StreamError::ConnectionFatal {
+            phase: "write",
+            kind: FatalKind::NotConnected,
+        },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::QuicProto, "write"),
+        StreamError::ConnectionFatal {
+            phase: "write",
+            kind: FatalKind::QuicProto,
+        },
+    );
+}
+
+#[test]
+fn classify_open_maps_every_pinned_variant() {
+    assert_eq!(
+        classify_open(&StreamOpeningError::Refused),
+        StreamError::PeerStop {
+            phase: "open",
+            code: None,
+        },
+    );
+    assert_eq!(
+        classify_open(&StreamOpeningError::NotConnected),
+        StreamError::ConnectionFatal {
+            phase: "open",
+            kind: FatalKind::NotConnected,
+        },
     );
 }


### PR DESCRIPTION
MEDIA-02: stream-local stop/refusal must not retire the video source writer

Closes #132. Parallel-safe follow-up to #129; does not reopen #126.

## Problem
`FrameStream for SendStream` erased every `StreamWriteError`/`StreamOpeningError` into a static string, and every `Failed` outcome retired the per-(client, source) writer. On wtransport 0.7.1, `StreamWriteError::Stopped(code)` and `StreamOpeningError::Refused` mean the peer abandoned **one stream**, not the connection — so a single browser/relay decision to drop a late frame silenced that source until reconnect while the connection and other sources stayed healthy.

## Fix
Open/write failures carry a typed `StreamError` with three classes:
- **PeerStop { phase, code }** — `Stopped`/`Refused`: peer-attributed one-frame loss (count `total_peer_drops`, log phase + peer code, continue).
- **LocalClose { phase }** — `Closed`: a **frame-local** anomaly, recoverable one-frame loss, counted (`total_local_closes`) and logged as a local close — **not** a peer stop/refusal.
- **ConnectionFatal { phase, kind }** — `NotConnected`/`QuicProto`/open-request: retire the writer. The open-request kind preserves the real `ConnectionError` as its `#[source]` (timeout, application-close reason/code, H3, QUIC survive); the fatal log records `%source`.

The absolute per-frame deadline, explicit RESET_STREAM, and no-retry from #129 are unchanged; a failed frame is never retried. Counters/logs distinguish deadline stalls, peer stop/refusal, local closes, and the connection-fatal event (`total_connection_failures`).

## Tests (virtual time + direct classifier matrix)
- `classify_write`/`classify_open` are asserted for **every** pinned wtransport variant, and the mocks route failures through the real classifiers — a reversed mapping fails outright.
- `ConnectionError::TimedOut` survives classification (asserted by value, via the error source chain, and in Display).
- Peer-stopped write, refused open, and local close each lose one frame while the writer **survives**; connection-fatal write and open each **retire** it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxQWtCBRABhA5v318WjY4b
