### PR TITLE
Video: dedup readiness spam and isolate uni-stream failures from the session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
       - name: browser video capture-identity tests (HUD-01)
         run: node clients/web/video-identity.test.mjs
 
+      - name: viewer video-diagnostics decision logic (readiness dedup + read-failure coalescing)
+        run: node clients/web/video-diagnostics.test.mjs
+
+      - name: viewer incoming-uni-stream accept-loop lifecycle (stream isolation + terminal collection)
+        run: node clients/web/uni-stream-accept.test.mjs
+
       - name: wasm wire-decode conformance (REN)
         # The wasm exports the viewer decodes with must agree with the JS
         # reference decoders on layout, numeric kinds, and the capture-identity

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -52,6 +52,8 @@ import { AvionicsIngress, FcStateTracker, INCARNATION_POLICY } from "./telemetry
 import { TransportSessionLifecycle } from "./transport-session.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
+import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
+import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -255,6 +257,7 @@ async function connect() {
     state.connected = false;
     state.leaseGranted = false;
     state.skippedVideoFrames = 0;
+    resetVideoDiagnostics();
     retireSessionPresentation("connecting");
     log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
   });
@@ -289,7 +292,7 @@ async function connect() {
     setTelemetrySessionState(els, "awaiting");
     state.connected = true;
     acceptIncomingUniStreams(transport, token).catch((error) => {
-      transportSessions.runIfActive(token, () => log(`uni stream accept failed: ${error}`));
+      transportSessions.runIfActive(token, () => log(`incoming uni-stream accept loop error: ${error}`));
     });
     readTelemetryDatagrams(transport, token).catch((error) => {
       transportSessions.runIfActive(token, () => log(`telemetry reader stopped: ${error}`));
@@ -414,24 +417,42 @@ function appendBytes(existing, incoming) {
   return out;
 }
 
-/** Accepts every host-initiated uni stream and dispatches on its leading kind-tag byte. */
-async function acceptIncomingUniStreams(transport, token) {
-  if (!transportSessions.isActive(token)) return;
-  const uniStreams = transport.incomingUnidirectionalStreams;
-  const streamReader = uniStreams.getReader();
-  if (!transportSessions.trackReader(token, streamReader)) return;
-  try {
-    for (;;) {
-      const { value: stream, done } = await streamReader.read();
-      if (!transportSessions.isActive(token)) return;
-      if (done) return;
-      readOneUniStream(stream, token).catch((error) => {
-        transportSessions.runIfActive(token, () => log(`uni stream read failed: ${error}`));
-      });
-    }
-  } finally {
-    transportSessions.untrackReader(token, streamReader);
+/** Coalesces uni-stream read failures into at most one log line per interval
+ * (after the first, which logs immediately): a host that resets a stalled
+ * frame's stream (ADR video deadline) surfaces a WebTransportError here every
+ * frame, which after the first is expected, not per-frame news. */
+function noteStreamReadFailure(error) {
+  streamReadFailures.count += 1;
+  const nowMs = performance.now();
+  if (
+    !shouldLogReadFailure(
+      nowMs,
+      streamReadFailures.lastLoggedMs,
+      STREAM_READ_FAILURE_LOG_INTERVAL_MS,
+    )
+  ) {
+    return;
   }
+  streamReadFailures.lastLoggedMs = nowMs;
+  log(`uni stream read failed: ${error} (${streamReadFailures.count} total this session)`);
+}
+
+/** Runs the one incoming-uni-stream accept loop for this session. An individual
+ * received stream failing loses only that frame and the loop keeps accepting;
+ * the collection stream itself closing or erroring is terminal for the whole
+ * WebTransport session (a re-acquired reader is handed the same stored error),
+ * so it is surfaced once as a session failure and never reacquired. */
+async function acceptIncomingUniStreams(transport, token) {
+  await runIncomingStreamAcceptLoop(transport.incomingUnidirectionalStreams, {
+    isActive: () => transportSessions.isActive(token),
+    handleStream: (stream) => readOneUniStream(stream, token),
+    onStreamFailure: (error) =>
+      transportSessions.runIfActive(token, () => noteStreamReadFailure(error)),
+    onCollectionTerminal: (error) =>
+      transportSessions.runIfActive(token, () => handleTransportClosed(token, error)),
+    trackReader: (reader) => transportSessions.trackReader(token, reader),
+    untrackReader: (reader) => transportSessions.untrackReader(token, reader),
+  });
 }
 
 /** Drains one uni stream to completion, buffering bytes, reading the kind tag, then dispatching. */
@@ -597,6 +618,37 @@ async function renderVideoFrame(body, token) {
 // the verdict still stays not-ready because the Gazebo rover publishes planar
 // pose rather than an avionics snapshot to associate against, and Aviate's
 // video clock mapping is unavailable — honestly.
+// Per-source conformal-readiness, so a persistent state (e.g. Aviate's
+// mapping-unavailable) is logged once on transition instead of every frame.
+// `undefined` = never logged; `null` = last logged ready; a string = last
+// logged not-ready reason. Reset per session (resetVideoDiagnostics).
+const videoReadinessLog = new Map();
+
+// Coalesces uni-stream read failures: under the host's per-frame stall/reset
+// regime a reset surfaces as a WebTransportError on the frame's stream, which
+// after the first is expected and must not spam one line per frame.
+// `lastLoggedMs === null` means never logged, so the first failure logs at once.
+const streamReadFailures = { count: 0, lastLoggedMs: null };
+const STREAM_READ_FAILURE_LOG_INTERVAL_MS = 2000;
+
+function resetVideoDiagnostics() {
+  videoReadinessLog.clear();
+  streamReadFailures.count = 0;
+  streamReadFailures.lastLoggedMs = null;
+}
+
+/** Logs a per-source conformal-readiness change once, never per frame. */
+function logVideoReadiness(sourceId, association) {
+  const transition = readinessTransition(
+    videoReadinessLog.get(sourceId),
+    association.ready,
+    association.reason,
+  );
+  if (!transition) return;
+  videoReadinessLog.set(sourceId, transition.state);
+  log(`video source ${sourceId} ${transition.message}`);
+}
+
 async function renderVideoFrameV2(body, token) {
   if (!transportSessions.isActive(token)) return;
   // Decode + capture-identity contract validation happen in wasm, from the
@@ -644,9 +696,7 @@ async function renderVideoFrameV2(body, token) {
     h264Registry?.reset(meta.sourceId);
   }
   state.lastAssociation = association;
-  if (!association.ready) {
-    log(`video source ${meta.sourceId} not conformal-ready: ${association.reason}`);
-  }
+  logVideoReadiness(meta.sourceId, association);
   await paintByCodec(fourcc, payload, meta.sourceId, target, token);
 }
 

--- a/clients/web/uni-stream-accept.js
+++ b/clients/web/uni-stream-accept.js
@@ -1,0 +1,78 @@
+// The demo viewer's incoming-uni-stream accept loop, factored out so its
+// lifecycle can be tested against real ReadableStreams.
+//
+// `WebTransport.incomingUnidirectionalStreams` is a SINGLE ReadableStream for
+// the whole session. Two properties of the WHATWG Streams model drive this
+// design:
+//
+//   1. An individual receive stream (one video frame) failing is independent of
+//      the collection: it loses that one frame, and the loop keeps accepting
+//      later streams.
+//   2. The collection stream closing or erroring is TERMINAL for the session.
+//      Once it stores an error, every future reader — including one obtained by
+//      releasing the lock and calling getReader() again — is handed back the
+//      identical stored error. Reacquiring a reader therefore cannot recover;
+//      the only correct response is to surface one session failure and stop.
+//
+// So there is exactly one accept loop per WebTransport session, and a terminal
+// collection end is reported once via `onCollectionTerminal`, never retried.
+
+/**
+ * Runs one accept loop over an incoming-uni-stream collection.
+ *
+ * @param incomingStreams the session's `incomingUnidirectionalStreams`
+ * @param cb callbacks:
+ *   - `isActive()` — whether the session is still current; the loop stops
+ *     (without reporting a terminal) as soon as it returns false.
+ *   - `handleStream(stream)` — drains one received stream; may reject, which
+ *     loses only that frame and is reported through `onStreamFailure`.
+ *   - `onStreamFailure(error)` — a single stream's drain rejected.
+ *   - `onCollectionTerminal(errorOrNull)` — the collection closed (`null`) or
+ *     errored (the stored error). Terminal for the session; fired at most once.
+ *   - `trackReader(reader)` / `untrackReader(reader)` — optional session
+ *     bookkeeping so teardown can cancel a blocked read; `trackReader` may
+ *     return false to abort before the loop starts.
+ */
+export async function runIncomingStreamAcceptLoop(
+  incomingStreams,
+  { isActive, handleStream, onStreamFailure, onCollectionTerminal, trackReader, untrackReader },
+) {
+  if (!isActive()) return;
+  const reader = incomingStreams.getReader();
+  if (trackReader && !trackReader(reader)) {
+    releaseReaderLock(reader);
+    return;
+  }
+  try {
+    for (;;) {
+      const { value: stream, done } = await reader.read();
+      if (!isActive()) return;
+      if (done) {
+        // The collection closed gracefully — the session is ending. Terminal.
+        onCollectionTerminal(null);
+        return;
+      }
+      // An individual stream's drain rejecting loses only that frame; keep
+      // accepting. Never let it reach the collection-level terminal path.
+      Promise.resolve(handleStream(stream)).catch((error) => {
+        if (isActive()) onStreamFailure(error);
+      });
+    }
+  } catch (error) {
+    // The collection stream itself errored: terminal for the session. Do NOT
+    // reacquire a reader — it would return this same stored error.
+    if (isActive()) onCollectionTerminal(error);
+  } finally {
+    if (untrackReader) untrackReader(reader);
+    releaseReaderLock(reader);
+  }
+}
+
+function releaseReaderLock(reader) {
+  try {
+    reader.releaseLock();
+  } catch {
+    // Lock already released, or the stream errored with a pending read; there
+    // is nothing to release and no recovery to attempt.
+  }
+}

--- a/clients/web/uni-stream-accept.test.mjs
+++ b/clients/web/uni-stream-accept.test.mjs
@@ -1,0 +1,157 @@
+// Lifecycle checks for the incoming-uni-stream accept loop against REAL
+// ReadableStreams (Node's WHATWG implementation), proving the two properties
+// the loop depends on:
+//   1. An individual received stream failing loses only that frame; the loop
+//      keeps accepting later streams.
+//   2. The collection stream closing/erroring is terminal for the session and
+//      is reported exactly once — and a re-acquired reader is handed the SAME
+//      stored error, which is why reacquisition cannot recover.
+//
+// Run: node clients/web/uni-stream-accept.test.mjs
+
+import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// A pull-driven collection: each read() advances one scripted step, so a value
+// is genuinely delivered BEFORE a later close/error (unlike enqueue-then-error,
+// which discards the queue).
+function scriptedCollection(steps) {
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      const step = steps[i];
+      i += 1;
+      if (!step || step.close) {
+        controller.close();
+      } else if (step.error) {
+        controller.error(step.error);
+      } else {
+        controller.enqueue(step.value);
+      }
+    },
+  });
+}
+
+// ---- 1. individual-stream isolation, then a graceful terminal close --------
+{
+  const s1 = { id: 1 };
+  const s2 = { id: 2 };
+  const s3 = { id: 3 };
+  const collection = scriptedCollection([
+    { value: s1 },
+    { value: s2 },
+    { value: s3 },
+    { close: true },
+  ]);
+
+  const handled = [];
+  const failed = [];
+  const terminals = [];
+
+  await runIncomingStreamAcceptLoop(collection, {
+    isActive: () => true,
+    handleStream: (stream) => {
+      handled.push(stream.id);
+      // The middle frame's drain rejects; the other two succeed.
+      return stream.id === 2
+        ? Promise.reject(new Error("frame 2 drain failed"))
+        : Promise.resolve();
+    },
+    onStreamFailure: (error) => failed.push(error),
+    onCollectionTerminal: (error) => terminals.push(error),
+  });
+  await tick(); // let the fire-and-forget handleStream rejections settle
+
+  check("every received stream is handled", handled.join(",") === "1,2,3");
+  check("a single stream's drain failure is isolated to one report", failed.length === 1);
+  check("the failure carries the drain error", String(failed[0]).includes("frame 2 drain failed"));
+  check("the surviving streams were not disturbed", handled.includes(1) && handled.includes(3));
+  check("a graceful collection close reports one terminal (null)", terminals.length === 1 && terminals[0] === null);
+}
+
+// ---- 2. a collection error is terminal, reported once, and unrecoverable ----
+{
+  const storedError = new Error("collection errored (session gone)");
+  const collection = scriptedCollection([{ value: { id: 1 } }, { error: storedError }]);
+
+  const terminals = [];
+  await runIncomingStreamAcceptLoop(collection, {
+    isActive: () => true,
+    handleStream: () => Promise.resolve(),
+    onStreamFailure: () => {},
+    onCollectionTerminal: (error) => terminals.push(error),
+  });
+
+  check("a collection error reports exactly one terminal", terminals.length === 1);
+  check("the terminal carries the collection's stored error", terminals[0] === storedError);
+
+  // WHATWG Streams: once the collection stream is errored, releasing the lock
+  // and acquiring a NEW reader returns the identical stored error. This is the
+  // proof that reacquiring a reader (the removed "supervisor") cannot recover.
+  let reacquiredError = null;
+  try {
+    await collection.getReader().read();
+  } catch (error) {
+    reacquiredError = error;
+  }
+  check("a re-acquired reader is handed the SAME stored error", reacquiredError === storedError);
+}
+
+// ---- 3. going inactive stops the loop without a terminal report ------------
+{
+  let calls = 0;
+  const collection = scriptedCollection([{ value: { id: 1 } }, { value: { id: 2 } }]);
+  const terminals = [];
+
+  await runIncomingStreamAcceptLoop(collection, {
+    // true for the entry guard, false right after the first read.
+    isActive: () => {
+      calls += 1;
+      return calls < 2;
+    },
+    handleStream: () => Promise.resolve(),
+    onStreamFailure: () => {},
+    onCollectionTerminal: (error) => terminals.push(error),
+  });
+
+  check("an inactive session stops the loop", true);
+  check("stopping for inactivity is not a terminal session failure", terminals.length === 0);
+}
+
+// ---- 4. trackReader refusal aborts before dispatching any stream -----------
+{
+  const collection = scriptedCollection([{ value: { id: 1 } }, { value: { id: 2 } }]);
+  const handled = [];
+  const terminals = [];
+
+  await runIncomingStreamAcceptLoop(collection, {
+    isActive: () => true,
+    handleStream: (stream) => {
+      handled.push(stream.id);
+      return Promise.resolve();
+    },
+    onStreamFailure: () => {},
+    onCollectionTerminal: (error) => terminals.push(error),
+    trackReader: () => false, // session already gone when the reader was tracked
+  });
+
+  check("trackReader refusal dispatches no stream", handled.length === 0);
+  check("trackReader refusal reports no terminal", terminals.length === 0);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall uni-stream accept lifecycle checks passed");

--- a/clients/web/video-diagnostics.js
+++ b/clients/web/video-diagnostics.js
@@ -1,0 +1,29 @@
+// Pure decision logic for the demo viewer's video diagnostics: log a
+// per-source conformal-readiness change once (not per frame), and coalesce a
+// burst of uni-stream read failures. Kept side-effect-free so it is testable
+// apart from the WebTransport plumbing in main.js.
+
+// The per-source readiness state a caller remembers: `undefined` = never
+// logged, `null` = last logged ready, a string = last logged not-ready reason.
+
+/// Whether a readiness change is worth logging, and the new state to
+/// remember. Returns `null` when nothing changed (the common per-frame
+/// case), so a persistent state logs exactly once on each transition.
+export function readinessTransition(previousState, ready, reason) {
+  const nextState = ready ? null : reason;
+  if (previousState === nextState) return null;
+  return {
+    state: nextState,
+    message:
+      nextState === null ? "now conformal-ready" : `not conformal-ready: ${nextState}`,
+  };
+}
+
+/// Whether a read failure should be logged now. The first failure of a session
+/// (`lastLoggedMs === null`, never logged) logs immediately; after that, at
+/// most one line per `intervalMs`. A host that resets a stalled frame's stream
+/// surfaces a WebTransportError here every frame, which after the first is
+/// expected, not per-frame news.
+export function shouldLogReadFailure(nowMs, lastLoggedMs, intervalMs) {
+  return lastLoggedMs === null || nowMs - lastLoggedMs >= intervalMs;
+}

--- a/clients/web/video-diagnostics.test.mjs
+++ b/clients/web/video-diagnostics.test.mjs
@@ -1,0 +1,66 @@
+// Checks for the viewer's video-diagnostics decision logic: readiness is
+// logged once per transition (not per frame), and read failures log on the
+// first occurrence then coalesce to one line per interval.
+//
+// Run: node clients/web/video-diagnostics.test.mjs
+
+import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// ---- readiness is a per-transition event, not a per-frame one --------------
+{
+  // First ever frame while not ready: log once, remember the reason.
+  const first = readinessTransition(undefined, false, "mapping-unavailable");
+  check("first not-ready frame logs", first !== null);
+  check(
+    "not-ready message names the reason",
+    first.message === "not conformal-ready: mapping-unavailable",
+  );
+  check("remembered state is the reason", first.state === "mapping-unavailable");
+
+  // Every subsequent frame in the same state: nothing to log (the spam fix).
+  check(
+    "an unchanged not-ready state does not re-log",
+    readinessTransition("mapping-unavailable", false, "mapping-unavailable") === null,
+  );
+
+  // Becoming ready is a transition worth one line.
+  const recovered = readinessTransition("mapping-unavailable", true, "mapping-unavailable");
+  check("recovery to ready logs once", recovered !== null && recovered.state === null);
+  check("recovery message is now-ready", recovered.message === "now conformal-ready");
+  check(
+    "staying ready does not re-log",
+    readinessTransition(null, true, "mapping-unavailable") === null,
+  );
+
+  // A different not-ready reason is a new transition.
+  const changed = readinessTransition("mapping-unavailable", false, "no-snapshot");
+  check("a changed reason logs again", changed !== null && changed.state === "no-snapshot");
+}
+
+// ---- read failures log first, then coalesce to one line per interval -------
+{
+  // The first failure of a session (never logged before) logs immediately.
+  check("the first failure logs immediately", shouldLogReadFailure(1000, null, 2000) === true);
+  // After a log at t=1000, failures inside the interval are suppressed...
+  check("a failure within the interval is suppressed", shouldLogReadFailure(1500, 1000, 2000) === false);
+  check("a failure just before the interval is suppressed", shouldLogReadFailure(2999, 1000, 2000) === false);
+  // ...and one at or past the interval logs again.
+  check("a failure exactly at the interval logs", shouldLogReadFailure(3000, 1000, 2000) === true);
+  check("a failure past the interval logs", shouldLogReadFailure(5000, 1000, 2000) === true);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall video diagnostics checks passed");


### PR DESCRIPTION
Video: dedup readiness spam and isolate uni-stream failures from the session

Closes #139.

A small diagnostics + stream-isolation PR. The video path itself is unchanged.

## Readiness spam
`renderVideoFrameV2` logged "not conformal-ready" for **every** frame, so a persistent state (Aviate publishes no video clock mapping ⇒ every frame is `mapping-unavailable`) produced ~60 lines/second per source. Readiness is now logged once per transition (not-ready ⇄ ready).

## Read-failure spam
A host that resets a stalled frame's stream surfaces a `WebTransportError` on each frame's stream. These now **log the first failure immediately, then coalesce** to at most one line per 2 s. The prior helper asserted — and implemented — that the first failure did *not* log during the first interval; that's fixed, and its test was corrected (it previously asserted the opposite of its own name).

## Stream isolation vs terminal collection (the substantive fix)
`incomingUnidirectionalStreams` is a **single** `ReadableStream` for the whole session. Two properties of the WebTransport + WHATWG Streams model:

1. An **individual** received stream (one video frame) failing already loses only that frame — the accept loop keeps accepting later streams.
2. The **collection** stream closing or erroring is **terminal** for the session. The Streams Standard stores the error and hands it back to every future reader, so releasing the lock and acquiring another reader returns the **identical stored error** — reacquisition cannot recover.

The previous revision misread (2): it "supervised" the accept loop and, on the collection erroring, released and re-acquired the reader expecting to resume — which can only re-observe the stored error, and wrongly treats a terminal session failure as recoverable.

### This PR
- **Removes** `superviseIncomingUniStreams`, the `restartVerdict` decision, the reader reacquisition, and the recovery claim.
- Runs **exactly one** incoming-stream accept loop per WebTransport session.
- An individual receive-stream failure drops only that frame and the loop continues.
- A collection close/error is terminal → **one visible session failure** (routed through `handleTransportClosed`), never a reacquire.
- Factors the loop into `clients/web/uni-stream-accept.js`, tested against **real `ReadableStream`s** (`uni-stream-accept.test.mjs`), proving individual-stream isolation, terminal-collection reporting, and — directly — that a re-acquired reader on an errored collection is handed the **identical** stored error.

## Guardrails (CI)
- `viewer incoming-uni-stream accept-loop lifecycle (stream isolation + terminal collection)` → `uni-stream-accept.test.mjs`
- `viewer video-diagnostics decision logic (readiness dedup + read-failure coalescing)` → `video-diagnostics.test.mjs`

## Verification
- `node clients/web/uni-stream-accept.test.mjs` — 12/12 pass (incl. the identical-stored-error proof).
- `node clients/web/video-diagnostics.test.mjs` — pass.
- Full non-browser web suite (15 suites) green; `node --check clients/web/main.js` clean.

The `#103` `createWritable` hunk stays uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxQWtCBRABhA5v318WjY4b

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #143
- <kbd>&nbsp;2&nbsp;</kbd> #142
- <kbd>&nbsp;1&nbsp;</kbd> #136 👈 
<!-- GitButler Footer Boundary Bottom -->