### PR TITLE
Viewer: auto-recover a dropped session and hold neutral control off-focus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,9 @@ jobs:
       - name: viewer video-diagnostics decision logic (log dedup + reader restart)
         run: node clients/web/video-diagnostics.test.mjs
 
+      - name: viewer connection auto-recovery decision logic (backoff + reconnect gating)
+        run: node clients/web/session-recovery.test.mjs
+
       - name: wasm wire-decode conformance (REN)
         # The wasm exports the viewer decodes with must agree with the JS
         # reference decoders on layout, numeric kinds, and the capture-identity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
       - name: browser video capture-identity tests (HUD-01)
         run: node clients/web/video-identity.test.mjs
 
+      - name: viewer video-diagnostics decision logic (log dedup + reader restart)
+        run: node clients/web/video-diagnostics.test.mjs
+
       - name: wasm wire-decode conformance (REN)
         # The wasm exports the viewer decodes with must agree with the JS
         # reference decoders on layout, numeric kinds, and the capture-identity

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -57,6 +57,7 @@ import {
   shouldLogReadFailure,
   restartVerdict,
 } from "./video-diagnostics.js";
+import { reconnectDelayMs, reconnectDecision } from "./session-recovery.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -261,6 +262,8 @@ async function connect() {
     state.leaseGranted = false;
     state.skippedVideoFrames = 0;
     resetVideoDiagnostics();
+    reconnectState.wanted = true;
+    clearReconnectTimer();
     retireSessionPresentation("connecting");
     log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
   });
@@ -273,6 +276,7 @@ async function connect() {
   try {
     await transport.ready;
     if (!transportSessions.isActive(token)) return;
+    reconnectState.attempts = 0; // a successful handshake clears the backoff.
     log("WebTransport session ready");
 
     const bidi = await transport.createBidirectionalStream();
@@ -317,6 +321,9 @@ async function connect() {
     retireSessionPresentation("failed");
     log(`connect failed: ${error}`);
     transportSessions.close(token);
+    // A failed attempt (host briefly unreachable while the browser froze)
+    // backs off and retries up to the budget rather than giving up here.
+    scheduleReconnect();
   }
 }
 
@@ -327,6 +334,57 @@ function handleTransportClosed(token, error) {
   retireSessionPresentation(error === null ? "disconnected" : "failed");
   log(error === null ? "WebTransport session closed" : `WebTransport session errored: ${error}`);
   transportSessions.retire(token);
+  // A drop the user did not ask for (an errored close, or a graceful close
+  // the host initiated while the viewer still wants to fly) leaves control,
+  // gamepad, and video dead with no way back. Recover the session rather than
+  // stranding the pilot; a hidden/frozen tab waits until the user returns.
+  scheduleReconnect();
+}
+
+// --- connection auto-recovery ----------------------------------------------
+// A backgrounded tab the browser freezes stops the control loop, so its
+// keepalive datagrams cease and the WebTransport session idle-drops; the pilot
+// returns to a dead session ("controller stopped, sim unresponsive"). These
+// bound the automatic reconnect so a genuinely unreachable host does not spin.
+const RECONNECT_MAX_ATTEMPTS = 6;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 15000;
+const reconnectState = { wanted: false, attempts: 0, timer: null };
+
+function clearReconnectTimer() {
+  if (reconnectState.timer !== null) {
+    clearTimeout(reconnectState.timer);
+    reconnectState.timer = null;
+  }
+}
+
+/** Schedules the next reconnect if one is warranted (session dropped, user
+ *  wants to stay connected, tab visible, budget left). Idempotent while a
+ *  reconnect is already pending. */
+function scheduleReconnect() {
+  if (reconnectState.timer !== null) return;
+  const decision = reconnectDecision({
+    wanted: reconnectState.wanted,
+    active: transportSessions.active !== null,
+    visible: document.visibilityState === "visible",
+    attempts: reconnectState.attempts,
+    maxAttempts: RECONNECT_MAX_ATTEMPTS,
+  });
+  if (decision.giveUp) {
+    log("auto-reconnect gave up after repeated failures; press Connect to retry");
+    return;
+  }
+  if (!decision.attempt) return; // not wanted / already active / hidden — wait.
+  const delayMs = reconnectDelayMs(reconnectState.attempts, {
+    baseMs: RECONNECT_BASE_MS,
+    maxMs: RECONNECT_MAX_MS,
+  });
+  reconnectState.timer = setTimeout(() => {
+    reconnectState.timer = null;
+    reconnectState.attempts += 1;
+    log(`connection lost — auto-reconnecting (attempt ${reconnectState.attempts})...`);
+    void connect();
+  }, delayMs);
 }
 
 /** Writes a length-delimited `ClientHello` envelope onto the bootstrap bidi stream. */
@@ -1070,6 +1128,23 @@ function updateFlightReadout(pad, f) {
     `climb=${f.throttle.toFixed(2)} yaw=${f.yaw.toFixed(2)} | arm: Options/Enter, disarm: Create/Backspace`;
 }
 
+/** Neutral (zeroed) control axes for a flight mode: rover carries only
+ *  throttle/yaw, the flight modes carry roll/pitch/throttle/yaw. Held while the
+ *  window is unfocused so a frozen stick cannot keep driving the vehicle. */
+function neutralAxesFor(mode) {
+  return mode === "rover"
+    ? [
+        [AXIS_THROTTLE, 0],
+        [AXIS_YAW, 0],
+      ]
+    : [
+        [AXIS_ROLL, 0],
+        [AXIS_PITCH, 0],
+        [AXIS_THROTTLE, 0],
+        [AXIS_YAW, 0],
+      ];
+}
+
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
 async function startControlLoop(transport, token) {
   if (!transportSessions.isActive(token)) return;
@@ -1096,7 +1171,16 @@ async function startControlLoop(transport, token) {
       const profile = pad ? profileFor(pad.id) : null;
       let axes;
       let edges = [];
-      if (mode === "rover") {
+      if (!document.hasFocus()) {
+        // Losing window focus FREEZES the Gamepad API (Chrome stops updating
+        // stick values) and stops keyboard events, so the last input would
+        // keep driving the vehicle — a runaway throttle. Hold NEUTRAL until
+        // the window is focused again, and say so, rather than fly on a stale
+        // stick. Arm/reset/fpv edges are suppressed too; nothing off-window
+        // should command the vehicle.
+        axes = neutralAxesFor(mode);
+        els.gamepad.textContent = "control paused — focus the window to fly (holding neutral)";
+      } else if (mode === "rover") {
         // Ground vehicles (the Gazebo yard world) accept only the
         // throttle/yaw pair; extra axes would be rejected as unknown.
         const [throttle, yaw] = pad ? axesFromGamepad(pad, profile) : axesFromKeys();
@@ -1282,5 +1366,16 @@ document.getElementById("resetBtn").addEventListener("click", () => {
   state.pendingReset = true;
 });
 els.connectBtn.addEventListener("click", () => {
+  // A manual Connect is a fresh start: clear any pending auto-reconnect and
+  // reset its backoff so the user's explicit action is not deferred.
+  clearReconnectTimer();
+  reconnectState.attempts = 0;
   void connect();
+});
+
+// Returning to a tab the browser had frozen is the moment to recover: the
+// session likely idle-dropped while away, and only now can a reconnect
+// succeed (a hidden tab would just drop again).
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") scheduleReconnect();
 });

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -52,6 +52,11 @@ import { AvionicsIngress, FcStateTracker, INCARNATION_POLICY } from "./telemetry
 import { TransportSessionLifecycle } from "./transport-session.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
+import {
+  readinessTransition,
+  shouldLogReadFailure,
+  restartVerdict,
+} from "./video-diagnostics.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -255,6 +260,7 @@ async function connect() {
     state.connected = false;
     state.leaseGranted = false;
     state.skippedVideoFrames = 0;
+    resetVideoDiagnostics();
     retireSessionPresentation("connecting");
     log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
   });
@@ -288,8 +294,8 @@ async function connect() {
     instruments.fcState = new FcStateTracker();
     setTelemetrySessionState(els, "awaiting");
     state.connected = true;
-    acceptIncomingUniStreams(transport, token).catch((error) => {
-      transportSessions.runIfActive(token, () => log(`uni stream accept failed: ${error}`));
+    superviseIncomingUniStreams(transport, token).catch((error) => {
+      transportSessions.runIfActive(token, () => log(`video reader supervisor stopped: ${error}`));
     });
     readTelemetryDatagrams(transport, token).catch((error) => {
       transportSessions.runIfActive(token, () => log(`telemetry reader stopped: ${error}`));
@@ -414,11 +420,82 @@ function appendBytes(existing, incoming) {
   return out;
 }
 
-/** Accepts every host-initiated uni stream and dispatches on its leading kind-tag byte. */
+// Video rides host-initiated uni streams; control and telemetry ride datagrams
+// on the same transport. So an interrupted uni-stream reader kills video while
+// the connection (and control/telemetry) stays live. These bound the reader's
+// supervised restart: a reader that runs at least MIN_UPTIME before exiting is
+// a transient interruption and resumes freely; one that exits immediately and
+// repeatedly means the incoming-streams side is gone, so stop after MAX rather
+// than spin, and point the user at Connect.
+const UNI_STREAM_RESTART_MIN_UPTIME_MS = 1000;
+const UNI_STREAM_MAX_IMMEDIATE_RESTARTS = 5;
+const UNI_STREAM_RESTART_BACKOFF_MS = 250;
+
+/** Coalesces uni-stream read failures into at most one log line per interval:
+ * a host that resets a stalled frame's stream (ADR video deadline) surfaces a
+ * WebTransportError here every frame, which is expected, not per-frame news. */
+function noteStreamReadFailure(error) {
+  streamReadFailures.count += 1;
+  const nowMs = performance.now();
+  if (
+    !shouldLogReadFailure(
+      nowMs,
+      streamReadFailures.lastLoggedMs,
+      STREAM_READ_FAILURE_LOG_INTERVAL_MS,
+    )
+  ) {
+    return;
+  }
+  streamReadFailures.lastLoggedMs = nowMs;
+  log(`uni stream read failed: ${error} (${streamReadFailures.count} total this session)`);
+}
+
+function releaseReaderLock(reader) {
+  try {
+    reader.releaseLock();
+  } catch {
+    // Already released, or the stream errored; the restart re-acquires.
+  }
+}
+
+/** Keeps the video uni-stream reader alive across transient interruptions so a
+ * single WebTransportError does not permanently kill video while control and
+ * telemetry keep flowing on the same transport. */
+async function superviseIncomingUniStreams(transport, token) {
+  let immediateExits = 0;
+  while (transportSessions.isActive(token)) {
+    const startedAt = performance.now();
+    try {
+      await acceptIncomingUniStreams(transport, token);
+    } catch (error) {
+      transportSessions.runIfActive(token, () => noteStreamReadFailure(error));
+    }
+    if (!transportSessions.isActive(token)) return;
+    const verdict = restartVerdict(performance.now() - startedAt, immediateExits, {
+      minUptimeMs: UNI_STREAM_RESTART_MIN_UPTIME_MS,
+      maxImmediate: UNI_STREAM_MAX_IMMEDIATE_RESTARTS,
+    });
+    immediateExits = verdict.immediateExits;
+    if (verdict.giveUp) {
+      transportSessions.runIfActive(token, () =>
+        log("video reader lost and could not resume; press Connect to restore video"),
+      );
+      return;
+    }
+    if (!verdict.ranBriefly) {
+      transportSessions.runIfActive(token, () => log("resuming video stream reader"));
+    }
+    await new Promise((resolve) => setTimeout(resolve, UNI_STREAM_RESTART_BACKOFF_MS));
+  }
+}
+
+/** Accepts every host-initiated uni stream and dispatches on its leading
+ * kind-tag byte. Returns on session end / stream close; throws the reader's
+ * error up to the supervisor so it can resume. Releases the reader lock on
+ * exit so a resume can re-acquire it. */
 async function acceptIncomingUniStreams(transport, token) {
   if (!transportSessions.isActive(token)) return;
-  const uniStreams = transport.incomingUnidirectionalStreams;
-  const streamReader = uniStreams.getReader();
+  const streamReader = transport.incomingUnidirectionalStreams.getReader();
   if (!transportSessions.trackReader(token, streamReader)) return;
   try {
     for (;;) {
@@ -426,11 +503,12 @@ async function acceptIncomingUniStreams(transport, token) {
       if (!transportSessions.isActive(token)) return;
       if (done) return;
       readOneUniStream(stream, token).catch((error) => {
-        transportSessions.runIfActive(token, () => log(`uni stream read failed: ${error}`));
+        transportSessions.runIfActive(token, () => noteStreamReadFailure(error));
       });
     }
   } finally {
     transportSessions.untrackReader(token, streamReader);
+    releaseReaderLock(streamReader);
   }
 }
 
@@ -597,6 +675,36 @@ async function renderVideoFrame(body, token) {
 // the verdict still stays not-ready because the Gazebo rover publishes planar
 // pose rather than an avionics snapshot to associate against, and Aviate's
 // video clock mapping is unavailable — honestly.
+// Per-source conformal-readiness, so a persistent state (e.g. Aviate's
+// mapping-unavailable) is logged once on transition instead of every frame.
+// `undefined` = never logged; `null` = last logged ready; a string = last
+// logged not-ready reason. Reset per session (resetVideoDiagnostics).
+const videoReadinessLog = new Map();
+
+// Coalesces uni-stream read failures: under the host's per-frame stall/reset
+// regime a reset surfaces as a WebTransportError on the frame's stream, which
+// is expected and must not spam one line per frame.
+const streamReadFailures = { count: 0, lastLoggedMs: 0 };
+const STREAM_READ_FAILURE_LOG_INTERVAL_MS = 2000;
+
+function resetVideoDiagnostics() {
+  videoReadinessLog.clear();
+  streamReadFailures.count = 0;
+  streamReadFailures.lastLoggedMs = 0;
+}
+
+/** Logs a per-source conformal-readiness change once, never per frame. */
+function logVideoReadiness(sourceId, association) {
+  const transition = readinessTransition(
+    videoReadinessLog.get(sourceId),
+    association.ready,
+    association.reason,
+  );
+  if (!transition) return;
+  videoReadinessLog.set(sourceId, transition.state);
+  log(`video source ${sourceId} ${transition.message}`);
+}
+
 async function renderVideoFrameV2(body, token) {
   if (!transportSessions.isActive(token)) return;
   // Decode + capture-identity contract validation happen in wasm, from the
@@ -644,9 +752,7 @@ async function renderVideoFrameV2(body, token) {
     h264Registry?.reset(meta.sourceId);
   }
   state.lastAssociation = association;
-  if (!association.ready) {
-    log(`video source ${meta.sourceId} not conformal-ready: ${association.reason}`);
-  }
+  logVideoReadiness(meta.sourceId, association);
   await paintByCodec(fourcc, payload, meta.sourceId, target, token);
 }
 

--- a/clients/web/session-recovery.js
+++ b/clients/web/session-recovery.js
@@ -1,0 +1,22 @@
+// Pure decision logic for the demo viewer's connection auto-recovery: when a
+// WebTransport session drops unexpectedly (a backgrounded tab that the browser
+// froze, an idle timeout, a network blip), decide whether and when to
+// reconnect. Kept side-effect-free so it is testable apart from the transport
+// plumbing in main.js.
+
+/// The backoff before the next reconnect attempt: exponential in `attempts`,
+/// capped at `maxMs`. `attempts` is the count already made (0 for the first).
+export function reconnectDelayMs(attempts, { baseMs, maxMs }) {
+  const scaled = baseMs * 2 ** attempts;
+  return Math.min(maxMs, scaled);
+}
+
+/// Whether to attempt a reconnect now, and whether to give up. Reconnect only
+/// when the user wants to stay connected, no session is currently active, the
+/// page is visible (a hidden/frozen tab would just drop again — wait until the
+/// user returns), and the attempt budget is not spent.
+export function reconnectDecision({ wanted, active, visible, attempts, maxAttempts }) {
+  if (attempts >= maxAttempts) return { attempt: false, giveUp: true };
+  const attempt = wanted && !active && visible;
+  return { attempt, giveUp: false };
+}

--- a/clients/web/session-recovery.test.mjs
+++ b/clients/web/session-recovery.test.mjs
@@ -1,0 +1,49 @@
+// Checks for the viewer's connection auto-recovery decisions: exponential
+// backoff capped at a ceiling, and reconnect only when the user wants it, no
+// session is active, the tab is visible, and the attempt budget is left.
+//
+// Run: node clients/web/session-recovery.test.mjs
+
+import { reconnectDelayMs, reconnectDecision } from "./session-recovery.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// ---- backoff is exponential and capped -------------------------------------
+{
+  const opts = { baseMs: 1000, maxMs: 15000 };
+  check("first attempt waits the base delay", reconnectDelayMs(0, opts) === 1000);
+  check("second attempt doubles", reconnectDelayMs(1, opts) === 2000);
+  check("third attempt doubles again", reconnectDelayMs(2, opts) === 4000);
+  check("delay is capped at maxMs", reconnectDelayMs(10, opts) === 15000);
+  check("the cap is never exceeded", reconnectDelayMs(100, opts) === 15000);
+}
+
+// ---- reconnect only under the right conditions -----------------------------
+{
+  const base = { wanted: true, active: false, visible: true, attempts: 0, maxAttempts: 6 };
+  const attempt = (o) => reconnectDecision({ ...base, ...o });
+
+  check("wanted + inactive + visible + budget => attempt", attempt({}).attempt === true);
+  check("no attempt when the user never connected", attempt({ wanted: false }).attempt === false);
+  check("no attempt while a session is already active", attempt({ active: true }).attempt === false);
+  check("no attempt while the tab is hidden (would just drop again)", attempt({ visible: false }).attempt === false);
+
+  // The budget is a hard stop.
+  check("attempts under the cap do not give up", attempt({ attempts: 5 }).giveUp === false);
+  const spent = attempt({ attempts: 6 });
+  check("attempts at the cap give up", spent.giveUp === true && spent.attempt === false);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall session recovery checks passed");

--- a/clients/web/video-diagnostics.js
+++ b/clients/web/video-diagnostics.js
@@ -1,0 +1,43 @@
+// Pure decision logic for the demo viewer's video diagnostics: log a
+// per-source conformal-readiness change once (not per frame), coalesce a
+// burst of uni-stream read failures, and decide whether a video-reader
+// exit should resume or give up. Kept side-effect-free so it is testable
+// apart from the WebTransport plumbing in main.js.
+
+// The per-source readiness state a caller remembers: `undefined` = never
+// logged, `null` = last logged ready, a string = last logged not-ready reason.
+
+/// Whether a readiness change is worth logging, and the new state to
+/// remember. Returns `null` when nothing changed (the common per-frame
+/// case), so a persistent state logs exactly once on each transition.
+export function readinessTransition(previousState, ready, reason) {
+  const nextState = ready ? null : reason;
+  if (previousState === nextState) return null;
+  return {
+    state: nextState,
+    message:
+      nextState === null ? "now conformal-ready" : `not conformal-ready: ${nextState}`,
+  };
+}
+
+/// Whether a read failure should be logged now: at most one line per
+/// `intervalMs`. A host that resets a stalled frame's stream surfaces a
+/// WebTransportError here every frame, which is expected, not per-frame news.
+export function shouldLogReadFailure(nowMs, lastLoggedMs, intervalMs) {
+  return nowMs - lastLoggedMs >= intervalMs;
+}
+
+/// The verdict for a supervised video-reader exit. A reader that ran at
+/// least `minUptimeMs` before exiting was a transient interruption and
+/// resumes with the exit counter cleared; one that exits in under that
+/// window increments the counter, and once it reaches `maxImmediate` the
+/// incoming-streams side is judged gone — give up rather than spin.
+export function restartVerdict(uptimeMs, immediateExits, { minUptimeMs, maxImmediate }) {
+  const ranBriefly = uptimeMs < minUptimeMs;
+  const nextImmediateExits = ranBriefly ? immediateExits + 1 : 0;
+  return {
+    ranBriefly,
+    immediateExits: nextImmediateExits,
+    giveUp: nextImmediateExits >= maxImmediate,
+  };
+}

--- a/clients/web/video-diagnostics.test.mjs
+++ b/clients/web/video-diagnostics.test.mjs
@@ -1,0 +1,93 @@
+// Checks for the viewer's video-diagnostics decision logic: readiness is
+// logged once per transition (not per frame), read failures coalesce, and a
+// supervised reader resumes on a transient exit but gives up after repeated
+// immediate failures.
+//
+// Run: node clients/web/video-diagnostics.test.mjs
+
+import {
+  readinessTransition,
+  shouldLogReadFailure,
+  restartVerdict,
+} from "./video-diagnostics.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// ---- readiness is a per-transition event, not a per-frame one --------------
+{
+  // First ever frame while not ready: log once, remember the reason.
+  const first = readinessTransition(undefined, false, "mapping-unavailable");
+  check("first not-ready frame logs", first !== null);
+  check(
+    "not-ready message names the reason",
+    first.message === "not conformal-ready: mapping-unavailable",
+  );
+  check("remembered state is the reason", first.state === "mapping-unavailable");
+
+  // Every subsequent frame in the same state: nothing to log (the spam fix).
+  check(
+    "an unchanged not-ready state does not re-log",
+    readinessTransition("mapping-unavailable", false, "mapping-unavailable") === null,
+  );
+
+  // Becoming ready is a transition worth one line.
+  const recovered = readinessTransition("mapping-unavailable", true, "mapping-unavailable");
+  check("recovery to ready logs once", recovered !== null && recovered.state === null);
+  check("recovery message is now-ready", recovered.message === "now conformal-ready");
+  check(
+    "staying ready does not re-log",
+    readinessTransition(null, true, "mapping-unavailable") === null,
+  );
+
+  // A different not-ready reason is a new transition.
+  const changed = readinessTransition("mapping-unavailable", false, "no-snapshot");
+  check("a changed reason logs again", changed !== null && changed.state === "no-snapshot");
+}
+
+// ---- read failures coalesce to one line per interval -----------------------
+{
+  check("the first failure logs (last-logged 0)", shouldLogReadFailure(1000, 0, 2000) === false);
+  check("a failure past the interval logs", shouldLogReadFailure(3000, 1000, 2000) === true);
+  check("a failure within the interval is suppressed", shouldLogReadFailure(1500, 1000, 2000) === false);
+  check("a failure exactly at the interval logs", shouldLogReadFailure(3000, 1000, 2000) === true);
+}
+
+// ---- supervised-reader restart verdict -------------------------------------
+{
+  const opts = { minUptimeMs: 1000, maxImmediate: 5 };
+
+  // A reader that ran a long time before exiting is a transient interruption:
+  // resume, and the immediate-exit counter resets.
+  const transient = restartVerdict(5000, 3, opts);
+  check("a long-lived reader resumes", !transient.giveUp && !transient.ranBriefly);
+  check("a transient exit clears the immediate counter", transient.immediateExits === 0);
+
+  // A reader that exits immediately increments the counter but keeps resuming
+  // until the cap.
+  let exits = 0;
+  let gaveUp = false;
+  for (let i = 0; i < 5; i += 1) {
+    const v = restartVerdict(10, exits, opts);
+    exits = v.immediateExits;
+    gaveUp = v.giveUp;
+  }
+  check("five immediate exits reach give-up", gaveUp && exits === 5);
+  check(
+    "the fourth immediate exit still resumes",
+    restartVerdict(10, 3, opts).giveUp === false,
+  );
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall video diagnostics checks passed");


### PR DESCRIPTION
## What broke

Reported as *"xbox controller stopped working and the sim lost responsiveness after a while."* Two coupled demo-viewer control defects, one behind the other:

1. **The session silently died and never came back.** When the browser backgrounds a tab it freezes the control loop, so its keepalive datagrams stop and the WebTransport session idle-drops (a host-initiated or errored close does the same). `handleTransportClosed` only retired the presentation — control, gamepad, and video went dead with no path back short of the user noticing and clicking **Connect**.
2. **A frozen stick kept flying.** Losing window focus *freezes* the Gamepad API (Chrome stops updating axis values) and stops keyboard events, but the control loop kept sending the **last** stick position — a runaway command with no live input behind it.

## The fix

**Auto-recovery.** `handleTransportClosed` and the `connect()` failure path now schedule a bounded, visibility-gated reconnect:
- exponential backoff, base 1 s, capped at 15 s, up to 6 attempts;
- only while the user still wants to be connected (they clicked Connect and never disconnected), no session is already active, and the tab is visible — a hidden/frozen tab would just drop again, so recovery waits and fires on `visibilitychange` when the user returns;
- a successful handshake and a manual **Connect** both reset the backoff.

**Neutral-on-blur.** While `document.hasFocus()` is false the control loop holds neutral axes (rover: throttle/yaw = 0; flight: roll/pitch/throttle/yaw = 0), suppresses arm/reset/fpv edges, and the readout says *"control paused — focus the window to fly (holding neutral)."*

## Guardrail

The reconnect **decision** logic — the backoff curve and the attempt/give-up gating — is extracted to a pure, side-effect-free `clients/web/session-recovery.js` and covered by `session-recovery.test.mjs` (wired into CI), so the policy is verified apart from the WebTransport plumbing in `main.js`.

## Verification

- `node clients/web/session-recovery.test.mjs` — 11/11 pass.
- Full non-browser web suite (15 suites) green; `node --check clients/web/main.js` clean.

The `#103` `createWritable` cross-engine hunk stays uncommitted, unchanged by this branch.

> Stacked on #136 (video log-spam dedup + uni-stream reader recovery); both touch `clients/web/main.js` and the viewer CI steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxQWtCBRABhA5v318WjY4b

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #137 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #136
<!-- GitButler Footer Boundary Bottom -->