### PR TITLE
Host: expire silent holders and neutralize the vehicle on link loss

### DIFF
--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -22,8 +22,6 @@ use std::sync::{Arc, Mutex};
 use crate::link::LatestAviate;
 
 use crate::error::AviateAdapterError;
-use crate::incarnation::{IncarnationProvider, OsIncarnationProvider};
-use crate::link::LinkConfig;
 use crate::uplink::FlightUplink;
 
 mod camera;
@@ -31,12 +29,13 @@ mod control;
 mod sampling;
 mod shm_sampling;
 mod sources;
+mod startup;
 use control::{flight_button_pressed, normalized_flight_sticks, rejected_control};
 use sampling::{
     mavlink_batch, measurement_pair_is_coherent, measurement_pair_supports_pose, yaw_of,
 };
 use shm_sampling::ShmSource;
-use sources::{ArmReport, EstimateSource, bind_sources, fc_state_sample};
+use sources::{ArmReport, EstimateSource, fc_state_sample};
 
 /// The control scope exposes four canonical flight axes as DJI-style
 /// velocity demands.
@@ -121,77 +120,6 @@ pub struct AviateAdapter {
 }
 
 impl AviateAdapter {
-    /// Binds the profile's source roles and returns a ready adapter.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AviateAdapterError`] when a link the profile requires
-    /// cannot be established (`Simulation` tolerates only a missing
-    /// truth oracle).
-    pub async fn start(
-        vehicle: VehicleId,
-        profile: AviateProfile,
-        config: LinkConfig,
-    ) -> Result<Self, AviateAdapterError> {
-        let mut provider = OsIncarnationProvider;
-        Self::start_with_incarnation_provider(vehicle, profile, config, &mut provider).await
-    }
-
-    /// Binds the vehicle link using a caller-owned attachment identity source.
-    ///
-    /// Aircraft integrations use this entry point to supply a persistent boot
-    /// counter or source-issued UUID instead of the simulator CSPRNG provider.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AviateAdapterError`] when identity creation or the selected
-    /// vehicle link fails.
-    pub async fn start_with_incarnation_provider<P: IncarnationProvider>(
-        vehicle: VehicleId,
-        profile: AviateProfile,
-        config: LinkConfig,
-        provider: &mut P,
-    ) -> Result<Self, AviateAdapterError> {
-        let arm_incarnation = provider.next_incarnation_blocking()?;
-        let (estimate, truth) = bind_sources(profile, config, provider).await?;
-        // Oracle-only sessions bind no uplink at all: with no motion
-        // scope advertised, operational control is structurally absent
-        // rather than rejected case by case. Elsewhere a failed uplink
-        // bind degrades to telemetry-only rather than failing the
-        // adapter: displaying a flight you cannot command beats
-        // displaying nothing.
-        let uplink = if profile == AviateProfile::OracleOnly {
-            None
-        } else {
-            match FlightUplink::new() {
-                Ok(mut uplink) => {
-                    uplink.set_expected_source(config.system_id, config.component_id);
-                    Some(uplink)
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "flight uplink unavailable; telemetry-only");
-                    None
-                }
-            }
-        };
-        let (frames, camera_bridge, frame_forwarder) = camera::spawn_camera_bridge().await;
-        Ok(Self {
-            vehicle,
-            estimate,
-            truth,
-            uplink,
-            frames,
-            _camera_bridge: camera_bridge,
-            _frame_forwarder: frame_forwarder,
-            arm: None,
-            arm_incarnation,
-            started_at: std::time::Instant::now(),
-            last_reset: None,
-            fpv_mode: false,
-            link_loss_policy: None,
-        })
-    }
-
     /// Takes the raw-frame receiver for the host media task, if cameras
     /// are up and it has not been taken.
     pub fn subscribe_frames(
@@ -227,6 +155,24 @@ impl AviateAdapter {
             fpv_mode: false,
             link_loss_policy: None,
         }
+    }
+
+    /// Expires the bound uplink's post-arm quiet window, so tests step
+    /// past it deterministically instead of sleeping wall-clock time.
+    #[cfg(test)]
+    pub(crate) fn expire_uplink_quiet_for_test(&mut self) {
+        if let Some(uplink) = self.uplink.as_mut() {
+            uplink.expire_quiet_for_test();
+        }
+    }
+
+    /// Whether the bound uplink currently holds a captured position-hold
+    /// point, for tests of the link-loss hold-invalidation contract.
+    #[cfg(test)]
+    pub(crate) fn uplink_hold_captured(&self) -> bool {
+        self.uplink
+            .as_ref()
+            .is_some_and(crate::uplink::FlightUplink::hold_captured)
     }
 
     /// Installs a test uplink, for tests.
@@ -325,6 +271,14 @@ impl VehicleAdapter for AviateAdapter {
         }
         if let Err(reason) = self.validate_flight_frame(frame) {
             return rejected_control(tick, reason);
+        }
+        // The link-loss latch: while a policy is engaged the FC holds its
+        // policy state (braked hover) and ordinary frames are suppressed,
+        // so a newly granted holder with deflected sticks cannot fly the
+        // vehicle out of it. The host clears the latch only after the
+        // holder demonstrates neutral input.
+        if self.link_loss_policy.is_some() {
+            return rejected_control(tick, RejectReason::LinkLossEngaged);
         }
         if flight_button_pressed(frame, RESET_BUTTON) {
             self.spawn_reset();
@@ -456,20 +410,45 @@ impl VehicleAdapter for AviateAdapter {
         ]
     }
 
-    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), pilotage_adapter_api::LinkLossEnactError> {
         if vehicle != self.vehicle {
-            return;
+            return Err(pilotage_adapter_api::LinkLossEnactError::UnknownVehicle { vehicle });
         }
+        // Latch first, fail after: even an unenactable engage suppresses
+        // ordinary control frames. Any link-loss transition also
+        // invalidates the captured position-hold context — a hold point
+        // captured under the lost lease is obsolete, and letting it
+        // survive would command recovery back toward it the instant
+        // control resumes.
         self.link_loss_policy = policy;
-        // Engaging any policy sends a zero-velocity setpoint: the FC's
-        // velocity mode brakes to a hover, which is the only safe action
-        // a camera drone has (`Neutralize`). Clearing (link recovery)
-        // leaves the FC hovering until the operator commands again.
-        if policy.is_some()
-            && let Some(uplink) = self.uplink.as_mut()
-        {
-            uplink.send_neutral();
+        if let Some(uplink) = self.uplink.as_mut() {
+            uplink.clear_hold_state();
         }
+        if policy.is_some() {
+            // Engaging any policy sends a zero-velocity setpoint: the FC's
+            // velocity mode brakes to a hover, which is the only safe action
+            // a camera drone has (`Neutralize`). Clearing (link recovery)
+            // leaves the FC hovering until the operator commands again.
+            let Some(uplink) = self.uplink.as_mut() else {
+                return Err(pilotage_adapter_api::LinkLossEnactError::NoActuationChannel);
+            };
+            // Success is only claimed for a datagram the socket accepted;
+            // a refused send must reach the host's fail-closed counter,
+            // not vanish into a log line. The uplink counts refused sends,
+            // so an increment across this send IS the refusal.
+            let failures_before = uplink.send_failures();
+            uplink.send_neutral();
+            if uplink.send_failures() != failures_before {
+                return Err(pilotage_adapter_api::LinkLossEnactError::ChannelRejected {
+                    detail: "the neutral setpoint datagram was not sent".to_owned(),
+                });
+            }
+        }
+        Ok(())
     }
 
     fn step(&mut self, _budget: StepBudget) -> StepOutcome {

--- a/adapters/aviate/src/adapter/startup.rs
+++ b/adapters/aviate/src/adapter/startup.rs
@@ -1,0 +1,83 @@
+//! Adapter construction: binding the profile's source roles, the flight
+//! uplink, and the camera bridge into a ready [`AviateAdapter`].
+
+use pilotage_protocol::VehicleId;
+
+use super::{AviateAdapter, AviateProfile, camera, sources::bind_sources};
+use crate::error::AviateAdapterError;
+use crate::incarnation::{IncarnationProvider, OsIncarnationProvider};
+use crate::link::LinkConfig;
+use crate::uplink::FlightUplink;
+
+impl AviateAdapter {
+    /// Binds the profile's source roles and returns a ready adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateAdapterError`] when a link the profile requires
+    /// cannot be established (`Simulation` tolerates only a missing
+    /// truth oracle).
+    pub async fn start(
+        vehicle: VehicleId,
+        profile: AviateProfile,
+        config: LinkConfig,
+    ) -> Result<Self, AviateAdapterError> {
+        let mut provider = OsIncarnationProvider;
+        Self::start_with_incarnation_provider(vehicle, profile, config, &mut provider).await
+    }
+
+    /// Binds the vehicle link using a caller-owned attachment identity source.
+    ///
+    /// Aircraft integrations use this entry point to supply a persistent boot
+    /// counter or source-issued UUID instead of the simulator CSPRNG provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateAdapterError`] when identity creation or the selected
+    /// vehicle link fails.
+    pub async fn start_with_incarnation_provider<P: IncarnationProvider>(
+        vehicle: VehicleId,
+        profile: AviateProfile,
+        config: LinkConfig,
+        provider: &mut P,
+    ) -> Result<Self, AviateAdapterError> {
+        let arm_incarnation = provider.next_incarnation_blocking()?;
+        let (estimate, truth) = bind_sources(profile, config, provider).await?;
+        // Oracle-only sessions bind no uplink at all: with no motion
+        // scope advertised, operational control is structurally absent
+        // rather than rejected case by case. Elsewhere a failed uplink
+        // bind degrades to telemetry-only rather than failing the
+        // adapter: displaying a flight you cannot command beats
+        // displaying nothing.
+        let uplink = if profile == AviateProfile::OracleOnly {
+            None
+        } else {
+            match FlightUplink::new() {
+                Ok(mut uplink) => {
+                    uplink.set_expected_source(config.system_id, config.component_id);
+                    Some(uplink)
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "flight uplink unavailable; telemetry-only");
+                    None
+                }
+            }
+        };
+        let (frames, camera_bridge, frame_forwarder) = camera::spawn_camera_bridge().await;
+        Ok(Self {
+            vehicle,
+            estimate,
+            truth,
+            uplink,
+            frames,
+            _camera_bridge: camera_bridge,
+            _frame_forwarder: frame_forwarder,
+            arm: None,
+            arm_incarnation,
+            started_at: std::time::Instant::now(),
+            last_reset: None,
+            fpv_mode: false,
+            link_loss_policy: None,
+        })
+    }
+}

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -408,3 +408,5 @@ fn control_frames_are_rejected_at_the_boundary() {
         Disposition::Rejected(RejectReason::UnknownScope)
     );
 }
+
+mod link_loss_enact;

--- a/adapters/aviate/src/adapter/tests/link_loss_enact.rs
+++ b/adapters/aviate/src/adapter/tests/link_loss_enact.rs
@@ -1,0 +1,207 @@
+//! Link-loss enactment truth and hold-state invalidation at the adapter
+//! boundary: a refused neutral send is a typed failure (never silent
+//! success), and any link-loss transition invalidates a captured
+//! position-hold point — a hold surviving the loss would command
+//! recovery back toward an obsolete point the instant control resumes.
+
+use std::time::Duration;
+
+use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+
+use super::super::AviateAdapter;
+use super::fixtures::{flight_frame, state_with};
+
+#[test]
+fn link_loss_enactment_reports_refused_sends_and_proves_sent_ones() {
+    // Port zero is unroutable for send_to: the neutral never leaves, so
+    // enactment must be a typed failure while the latch still engages.
+    let mut refused = crate::uplink::FlightUplink::new().expect("uplink");
+    refused.set_target("0.0.0.0:0".parse().expect("addr"));
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::ZERO, Duration::ZERO),
+    )
+    .with_uplink(refused);
+    let result = adapter.set_link_loss_policy(
+        VehicleId::new(1),
+        Some(pilotage_adapter_api::LinkLossPolicy::Neutralize),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(pilotage_adapter_api::LinkLossEnactError::ChannelRejected { .. })
+        ),
+        "refused send must be a typed failure, got {result:?}"
+    );
+    let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::LinkLossEngaged),
+        "the latch engages even when the send was refused"
+    );
+
+    // Accepted send: a reachable fake FC receives the zero-velocity
+    // setpoint and the enactment reports Ok.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let mut sent = crate::uplink::FlightUplink::new().expect("uplink");
+    sent.set_target(fc.local_addr().expect("addr"));
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::ZERO, Duration::ZERO),
+    )
+    .with_uplink(sent);
+    adapter
+        .set_link_loss_policy(
+            VehicleId::new(1),
+            Some(pilotage_adapter_api::LinkLossPolicy::Neutralize),
+        )
+        .expect("neutral datagram accepted by the socket");
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf).expect("neutral frame");
+    let mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(mask, 2503, "neutralize streams velocity mode");
+}
+
+#[test]
+fn link_loss_transitions_invalidate_the_captured_hold_point() {
+    // Contract level: seeding a hold and driving either transition must
+    // leave the uplink hold-free.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    uplink.seed_hold_for_test([10.0, 20.0, -30.0]);
+    let mut adapter = AviateAdapter::from_state(
+        VehicleId::new(1),
+        state_with(Duration::ZERO, Duration::ZERO),
+    )
+    .with_uplink(uplink);
+
+    adapter
+        .set_link_loss_policy(
+            VehicleId::new(1),
+            Some(pilotage_adapter_api::LinkLossPolicy::Neutralize),
+        )
+        .expect("engage");
+    assert!(
+        !adapter.uplink_hold_captured(),
+        "engaging link loss must invalidate the captured hold"
+    );
+
+    adapter
+        .set_link_loss_policy(VehicleId::new(1), None)
+        .expect("clear");
+    assert!(
+        !adapter.uplink_hold_captured(),
+        "clearing link loss must also start hold-free"
+    );
+}
+
+/// Stamps the fixture as (near-)still at `pos`, fresh as of now.
+fn set_still_at(
+    state: &std::sync::Arc<std::sync::Mutex<crate::link::LatestAviate>>,
+    pos: [f32; 3],
+) {
+    let mut latest = state.lock().expect("state lock");
+    let kin = latest.kinematics.as_mut().expect("kinematics fixture");
+    kin.pos_ned_m = pos;
+    kin.vel_ned_mps = [0.1, 0.0, 0.0];
+    kin.received_at = std::time::Instant::now();
+}
+
+/// Sends one centered frame, expects a position-hold setpoint back, and
+/// returns its north coordinate.
+fn centered_hold_north(
+    adapter: &mut AviateAdapter,
+    fc: &std::net::UdpSocket,
+    buf: &mut [u8; 128],
+) -> f32 {
+    adapter.apply_control(&flight_frame(
+        vec![(LogicalAxisId::new(super::super::PITCH_AXIS), 0.0)],
+        vec![],
+    ));
+    fc.recv_from(buf).expect("hold frame");
+    let mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(mask, 2552, "still vehicle captures a hold");
+    f32::from_le_bytes([buf[14], buf[15], buf[16], buf[17]])
+}
+
+#[test]
+fn a_hold_captured_before_link_loss_never_commands_recovery_to_it() {
+    // Behavior level: capture a hold in flight, lose and recover the
+    // link while the vehicle "drifts" (the fixture position moves), and
+    // prove the first post-recovery hold is at the NEW position — a
+    // stale hold would fly the vehicle back to the obsolete point.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    let mut adapter =
+        AviateAdapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink);
+
+    // Arm, expire the post-arm quiet window deterministically (no
+    // wall-clock sleep), then open the motors-idle gate with a climb
+    // frame.
+    adapter.apply_control(&flight_frame(
+        vec![],
+        vec![(
+            LogicalButtonId::new(super::super::ARM_BUTTON),
+            ButtonEdge::Pressed,
+        )],
+    ));
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf).expect("arm frame");
+    adapter.expire_uplink_quiet_for_test();
+    adapter.apply_control(&flight_frame(
+        vec![(LogicalAxisId::new(super::super::THROTTLE_AXIS), 0.5)],
+        vec![],
+    ));
+    fc.recv_from(&mut buf).expect("climb frame");
+
+    // Still (fixture velocity low) with sticks centered: hold captures
+    // at the fixture position (10, 20, -30).
+    {
+        let mut latest = state.lock().expect("state lock");
+        let kin = latest.kinematics.as_mut().expect("kinematics fixture");
+        kin.vel_ned_mps = [0.1, 0.0, 0.0];
+        kin.received_at = std::time::Instant::now();
+    }
+    adapter.apply_control(&flight_frame(
+        vec![(LogicalAxisId::new(super::super::PITCH_AXIS), 0.0)],
+        vec![],
+    ));
+    fc.recv_from(&mut buf).expect("hold frame");
+    let mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
+    assert_eq!(mask, 2552, "still vehicle captures a hold");
+    let north = f32::from_le_bytes([buf[14], buf[15], buf[16], buf[17]]);
+    assert!(
+        (north - 10.0).abs() < 1e-3,
+        "hold at the old point: {north}"
+    );
+
+    // Link loss engages (drain its neutral), the vehicle drifts while
+    // neutralized, and the host clears after the new holder's activation.
+    adapter
+        .set_link_loss_policy(
+            VehicleId::new(1),
+            Some(pilotage_adapter_api::LinkLossPolicy::Neutralize),
+        )
+        .expect("engage");
+    fc.recv_from(&mut buf).expect("link-loss neutral frame");
+    set_still_at(&state, [50.0, 60.0, -30.0]);
+    adapter
+        .set_link_loss_policy(VehicleId::new(1), None)
+        .expect("clear");
+
+    // First centered frame after recovery: the hold captures at the
+    // CURRENT position, never the pre-loss one.
+    let north = centered_hold_north(&mut adapter, &fc, &mut buf);
+    assert!(
+        (north - 50.0).abs() < 1e-3,
+        "hold north must be the drifted position, got {north}"
+    );
+}

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -20,6 +20,8 @@ use crate::mavlink::{
     encode_velocity_setpoint,
 };
 
+mod fc_replies;
+
 /// Full-stick horizontal velocity demand.
 const MAX_HORIZONTAL_MPS: f32 = 3.0;
 /// FPV mode: full-stick roll/pitch attitude demand (~35°).
@@ -315,45 +317,49 @@ impl FlightUplink {
         self.send(&frame);
     }
 
-    /// Drains FC replies off the uplink socket (COMMAND_ACK, heartbeats
-    /// the FC sends its learned commander), returning the latest
-    /// armed-state report if any heartbeat arrived. Non-blocking; call
-    /// from the sampling tick.
-    pub fn poll_fc(&mut self) -> Option<bool> {
-        let mut buf = [0u8; 512];
-        let mut messages: Vec<(crate::mavlink::FrameSource, crate::mavlink::AviateMessage)> =
-            Vec::new();
-        let mut armed: Option<bool> = None;
-        while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
-            messages.clear();
-            crate::mavlink::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
-            for (source, message) in &messages {
-                if source.system_id != self.expected_system_id
-                    || source.component_id != self.expected_component_id
-                {
-                    continue;
-                }
-                match *message {
-                    crate::mavlink::AviateMessage::Heartbeat { armed: a } => armed = Some(a),
-                    crate::mavlink::AviateMessage::CommandAck { command, result } => {
-                        if result == 0 {
-                            info!(command, "FC accepted command");
-                        } else {
-                            warn!(command, result, "FC rejected command");
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-        armed
-    }
-
     /// The socket's local address, for tests.
     /// The MAVLink (system, component) identity this uplink accepts FC
     /// reports from — the provenance identity for those reports.
     pub fn expected_source(&self) -> (u8, u8) {
         (self.expected_system_id, self.expected_component_id)
+    }
+
+    /// Wrapping count of datagrams the socket refused to send. A safety
+    /// enactment (link-loss neutralize) compares this across its send:
+    /// an increment means the FC never received the command, which must
+    /// surface as a typed enactment failure — never as silent success.
+    pub fn send_failures(&self) -> u64 {
+        self.send_failures
+    }
+
+    /// Invalidates any captured position-hold context. A link-loss
+    /// transition MUST call this: the hold point was captured under the
+    /// lost lease, and the vehicle may have drifted arbitrarily far while
+    /// neutralized, so a hold surviving the loss would command recovery
+    /// back toward an obsolete point the instant control resumes.
+    pub fn clear_hold_state(&mut self) {
+        self.hold_pos_ned = None;
+        self.last_vel_ned = [0.0; 3];
+    }
+
+    /// Whether a position-hold point is currently captured, for tests.
+    #[cfg(test)]
+    pub(crate) fn hold_captured(&self) -> bool {
+        self.hold_pos_ned.is_some()
+    }
+
+    /// Plants a captured hold point, for tests exercising the stale-hold
+    /// invalidation contract without flying a full trajectory.
+    #[cfg(test)]
+    pub(crate) fn seed_hold_for_test(&mut self, pos_ned_m: [f32; 3]) {
+        self.hold_pos_ned = Some(pos_ned_m);
+    }
+
+    /// Expires the post-arm quiet window immediately, so tests advance
+    /// past it deterministically instead of sleeping wall-clock time.
+    #[cfg(test)]
+    pub(crate) fn expire_quiet_for_test(&mut self) {
+        self.quiet_until = None;
     }
 
     /// The local socket address this uplink receives FC replies on.

--- a/adapters/aviate/src/uplink/fc_replies.rs
+++ b/adapters/aviate/src/uplink/fc_replies.rs
@@ -1,0 +1,43 @@
+//! FC reply drainage for the flight uplink: COMMAND_ACK results and the
+//! heartbeats the FC sends its learned commander, filtered to the
+//! expected MAVLink source identity.
+
+use tracing::{info, warn};
+
+use super::FlightUplink;
+
+impl FlightUplink {
+    /// Drains FC replies off the uplink socket (COMMAND_ACK, heartbeats
+    /// the FC sends its learned commander), returning the latest
+    /// armed-state report if any heartbeat arrived. Non-blocking; call
+    /// from the sampling tick.
+    pub fn poll_fc(&mut self) -> Option<bool> {
+        let mut buf = [0u8; 512];
+        let mut messages: Vec<(crate::mavlink::FrameSource, crate::mavlink::AviateMessage)> =
+            Vec::new();
+        let mut armed: Option<bool> = None;
+        while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
+            messages.clear();
+            crate::mavlink::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
+            for (source, message) in &messages {
+                if source.system_id != self.expected_system_id
+                    || source.component_id != self.expected_component_id
+                {
+                    continue;
+                }
+                match *message {
+                    crate::mavlink::AviateMessage::Heartbeat { armed: a } => armed = Some(a),
+                    crate::mavlink::AviateMessage::CommandAck { command, result } => {
+                        if result == 0 {
+                            info!(command, "FC accepted command");
+                        } else {
+                            warn!(command, result, "FC rejected command");
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        armed
+    }
+}

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -11,9 +11,10 @@ use std::collections::BTreeMap;
 
 use pilotage_adapter_api::{
     AdapterCapabilities, ApplyOutcome, CalibrationId, CaptureClockMapping, Disposition,
-    ExecutionMode, LinkLossPolicy, MeasurementClock, Pose2d, RejectReason, SIM_FPV_CALIBRATION_ID,
-    SIM_FPV_CAMERA_ID, ScopeDescriptor, SourceIncarnation, StepBudget, StepOutcome, TelemetryBatch,
-    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoCaptureStamp, VideoSource,
+    ExecutionMode, LinkLossEnactError, LinkLossPolicy, MeasurementClock, Pose2d, RejectReason,
+    SIM_FPV_CALIBRATION_ID, SIM_FPV_CAMERA_ID, ScopeDescriptor, SourceIncarnation, StepBudget,
+    StepOutcome, TelemetryBatch, TelemetrySample, VehicleAdapter, VehicleDescriptor,
+    VideoCaptureStamp, VideoSource,
 };
 use pilotage_protocol::{LogicalAxisId, ScopeId, ScopedControlFrame, VehicleId};
 use pilotage_timing::SimTick;
@@ -347,6 +348,16 @@ impl VehicleAdapter for GazeboAdapter {
                 disposition: Disposition::Rejected(reason),
             };
         }
+        // The link-loss latch: while a policy is engaged the wheels stay
+        // stopped and ordinary frames are suppressed, so a newly granted
+        // holder with deflected sticks cannot drive the vehicle out of its
+        // policy state before the host clears the latch.
+        if self.link_loss_policy.is_some() {
+            return ApplyOutcome {
+                tick: self.latest_tick(),
+                disposition: Disposition::Rejected(RejectReason::LinkLossEngaged),
+            };
+        }
         let (control, transformed) = control_from_frame(frame);
         if !self.bridge.try_send_control(control) {
             return ApplyOutcome {
@@ -395,24 +406,33 @@ impl VehicleAdapter for GazeboAdapter {
         ]
     }
 
-    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), LinkLossEnactError> {
         if vehicle != self.vehicle {
-            return;
+            return Err(LinkLossEnactError::UnknownVehicle { vehicle });
         }
         self.link_loss_policy = policy;
         // On link loss, halt the vehicle immediately. Only `Neutralize` is
         // advertised (a diff-drive without onboard automation has no richer
         // safe action), so any engaged policy stops the wheels; clearing the
         // policy (`None`, link recovery) leaves the last operator command in
-        // effect. A closed control link means the vehicle is already stopping
-        // on its own bridge-side timeout, so a failed send is not fatal here.
-        if policy.is_some() {
-            let stopped = self.bridge.try_send_control(BridgeControl {
+        // effect. The bridge also stops the vehicle on its own timeout when
+        // the control link is closed, but a refused stop is still a fault
+        // the caller must count — the latch is engaged either way.
+        if policy.is_some()
+            && !self.bridge.try_send_control(BridgeControl {
                 linear_x: 0.0,
                 angular_z: 0.0,
+            })
+        {
+            return Err(LinkLossEnactError::ChannelRejected {
+                detail: "bridge refused the neutral stop command".to_owned(),
             });
-            let _ = stopped;
         }
+        Ok(())
     }
 
     fn step(&mut self, _budget: StepBudget) -> StepOutcome {

--- a/adapters/gazebo/src/adapter/tests.rs
+++ b/adapters/gazebo/src/adapter/tests.rs
@@ -323,7 +323,9 @@ async fn set_link_loss_policy_sends_stop() {
     let mut adapter =
         GazeboAdapter::from_bridge(vehicle, BridgeClient::connect_stream_for_test(host_side));
 
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize))
+        .expect("policy enacted");
     let received = read_envelope(&mut bridge_side)
         .await
         .expect("stop is read")

--- a/adapters/reference-headless/src/adapter.rs
+++ b/adapters/reference-headless/src/adapter.rs
@@ -2,9 +2,9 @@
 //! vehicle (ADR-0008).
 
 use pilotage_adapter_api::{
-    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossPolicy, Pose2d,
-    RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch, TelemetrySample,
-    VehicleAdapter, VehicleDescriptor, VideoSource,
+    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossEnactError,
+    LinkLossPolicy, Pose2d, RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch,
+    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
 };
 use pilotage_protocol::{LogicalAxisId, ScopeId, ScopedControlFrame, VehicleId};
 use pilotage_timing::SimTick;
@@ -167,6 +167,16 @@ impl VehicleAdapter for ReferenceAdapter {
                 disposition: Disposition::Rejected(reason),
             };
         }
+        // The link-loss latch: `tick_link_loss` already forces the dynamics
+        // to the policy state, but accepting frames while engaged would
+        // store deflected controls that spring back the instant the policy
+        // clears. Suppress them typed instead.
+        if self.controls.policy_engaged() {
+            return ApplyOutcome {
+                tick: self.tick,
+                disposition: Disposition::Rejected(RejectReason::LinkLossEngaged),
+            };
+        }
         let mut throttle = self.controls.throttle;
         let mut steering = self.controls.steering;
         let mut transformed = false;
@@ -218,10 +228,16 @@ impl VehicleAdapter for ReferenceAdapter {
         Vec::new()
     }
 
-    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
-        if vehicle == self.vehicle {
-            self.controls.set_policy(policy);
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), LinkLossEnactError> {
+        if vehicle != self.vehicle {
+            return Err(LinkLossEnactError::UnknownVehicle { vehicle });
         }
+        self.controls.set_policy(policy);
+        Ok(())
     }
 
     fn step(&mut self, budget: StepBudget) -> StepOutcome {

--- a/adapters/reference-headless/src/controls.rs
+++ b/adapters/reference-headless/src/controls.rs
@@ -48,6 +48,13 @@ impl ControlState {
         self.steering = steering;
     }
 
+    /// Whether a link-loss policy is currently engaged (the control latch:
+    /// ordinary frames must be rejected while this holds).
+    #[must_use]
+    pub fn policy_engaged(&self) -> bool {
+        self.policy.is_some()
+    }
+
     /// Sets or clears the link-loss policy, arming a `HoldBrief` countdown
     /// if applicable.
     ///

--- a/adapters/reference-headless/tests/link_loss.rs
+++ b/adapters/reference-headless/tests/link_loss.rs
@@ -45,7 +45,9 @@ fn neutralize_zeroes_controls_and_speed_decays_via_drag() {
     let speed_before_loss = measured_speed(&mut adapter);
     assert!(speed_before_loss > 0.0);
 
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize))
+        .expect("policy enacted");
     adapter.step(StepBudget { ticks: 1 });
     let speed_after_one_tick = measured_speed(&mut adapter);
     assert!(speed_after_one_tick < speed_before_loss);
@@ -66,13 +68,17 @@ fn clearing_link_loss_policy_restores_normal_control() {
     let mut adapter = ReferenceAdapter::from_seed(vehicle, 1);
     adapter.apply_control(&full_throttle_frame(vehicle));
 
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::Neutralize))
+        .expect("policy enacted");
     adapter.step(StepBudget { ticks: 1 });
     let speed_while_neutralized = measured_speed(&mut adapter);
 
     // Link recovery: clearing the policy and re-applying full throttle must
     // resume acceleration rather than staying neutralized permanently.
-    adapter.set_link_loss_policy(vehicle, None);
+    adapter
+        .set_link_loss_policy(vehicle, None)
+        .expect("policy enacted");
     adapter.apply_control(&full_throttle_frame(vehicle));
     for _ in 0..50u32 {
         adapter.step(StepBudget { ticks: 1 });
@@ -87,7 +93,9 @@ fn hold_brief_holds_controls_then_neutralizes() {
     let mut adapter = ReferenceAdapter::from_seed(vehicle, 1);
     adapter.apply_control(&full_throttle_frame(vehicle));
 
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 3 }));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 3 }))
+        .expect("policy enacted");
 
     // While held, throttle keeps applying: speed should still be climbing
     // for the held ticks (comparable to no link loss at all).
@@ -118,7 +126,9 @@ fn hold_brief_expiry_is_not_undone_by_a_later_apply_control() {
     let vehicle = VehicleId::new(3);
     let mut adapter = ReferenceAdapter::from_seed(vehicle, 1);
     adapter.apply_control(&full_throttle_frame(vehicle));
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 1 }));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 1 }))
+        .expect("policy enacted");
 
     // Run past the hold window so the policy has neutralized.
     adapter.step(StepBudget { ticks: 2 });

--- a/adapters/reference-headless/tests/snapshot_restore.rs
+++ b/adapters/reference-headless/tests/snapshot_restore.rs
@@ -64,7 +64,9 @@ fn snapshot_round_trip_preserves_link_loss_hold_countdown() {
     let vehicle = VehicleId::new(3);
     let mut adapter = ReferenceAdapter::from_seed(vehicle, 5);
     adapter.apply_control(&control_frame(vehicle));
-    adapter.set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 3 }));
+    adapter
+        .set_link_loss_policy(vehicle, Some(LinkLossPolicy::HoldBrief { ticks: 3 }))
+        .expect("policy enacted");
     adapter.step(StepBudget { ticks: 1 });
 
     let snapshot = adapter.snapshot().expect("snapshot succeeds");

--- a/crates/pilotage-adapter-api/src/control.rs
+++ b/crates/pilotage-adapter-api/src/control.rs
@@ -16,6 +16,13 @@ pub enum RejectReason {
     Fenced,
     /// A measurement required to apply the frame is unavailable.
     MeasurementUnavailable,
+    /// A link-loss policy is engaged on the vehicle; control frames are
+    /// suppressed until the policy is cleared through the host's recovery
+    /// path (a fresh authority generation plus the scope's activation
+    /// condition, ADR-0008). Without this latch a newly granted holder
+    /// with deflected sticks would drive the vehicle straight out of its
+    /// neutralized state.
+    LinkLossEngaged,
     /// The adapter rejected the frame for a reason not covered above.
     Other(String),
 }
@@ -62,6 +69,32 @@ pub enum LinkLossPolicy {
     Pause,
     /// Hand control to an onboard automation system.
     EngageAutomation,
+}
+
+/// Why an adapter could not enact a link-loss policy change.
+///
+/// A failed enactment is a fail-closed fault the driver must count and
+/// surface (never a silent no-op): the host has already fenced authority,
+/// so an unenacted policy means the vehicle may still be executing its
+/// last command with nobody in control.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LinkLossEnactError {
+    /// The adapter does not expose the named vehicle.
+    #[error("vehicle {vehicle:?} is not exposed by this adapter")]
+    UnknownVehicle {
+        /// The vehicle the policy change targeted.
+        vehicle: pilotage_protocol::VehicleId,
+    },
+    /// No actuation channel is bound, so the adapter cannot drive the
+    /// vehicle to its policy state (e.g. a telemetry-only profile).
+    #[error("no actuation channel is bound; the policy cannot be enacted")]
+    NoActuationChannel,
+    /// The actuation channel refused or dropped the policy command.
+    #[error("the actuation channel rejected the policy command: {detail}")]
+    ChannelRejected {
+        /// Channel-specific failure detail.
+        detail: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -13,7 +13,7 @@ mod vehicle_adapter;
 mod video;
 
 pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, VehicleDescriptor};
-pub use control::{ApplyOutcome, Disposition, LinkLossPolicy, RejectReason};
+pub use control::{ApplyOutcome, Disposition, LinkLossEnactError, LinkLossPolicy, RejectReason};
 // CAL-01 (#90): the camera calibration contract moved to
 // `pilotage-camera-calibration`; re-export it so `pilotage_adapter_api::…` paths
 // for consumers are unchanged, and expose the new `VerifiedCameraModel`.

--- a/crates/pilotage-adapter-api/src/vehicle_adapter.rs
+++ b/crates/pilotage-adapter-api/src/vehicle_adapter.rs
@@ -3,7 +3,7 @@
 use pilotage_protocol::{ScopedControlFrame, VehicleId};
 
 use crate::capability::AdapterCapabilities;
-use crate::control::{ApplyOutcome, LinkLossPolicy};
+use crate::control::{ApplyOutcome, LinkLossEnactError, LinkLossPolicy};
 use crate::step::{StepBudget, StepOutcome};
 use crate::telemetry::{TelemetryBatch, VideoSource};
 
@@ -34,11 +34,29 @@ pub trait VehicleAdapter {
     /// control link is judged lost.
     ///
     /// `Some(policy)` engages that policy; `Some` replaces whatever policy
-    /// was previously engaged. `None` signals link recovery: it clears any
-    /// engaged policy and returns the vehicle to normal control, which is
-    /// the only API-level path back to normal control once a policy has
-    /// been engaged (ADR-0008).
-    fn set_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>);
+    /// was previously engaged. While a policy is engaged the adapter must
+    /// suppress ordinary control frames (rejecting them with
+    /// [`RejectReason::LinkLossEngaged`]) so a newly granted holder cannot
+    /// drive the vehicle out of its policy state before the host clears it.
+    /// `None` signals link recovery: it clears any engaged policy and
+    /// returns the vehicle to normal control, which is the only API-level
+    /// path back to normal control once a policy has been engaged
+    /// (ADR-0008).
+    ///
+    /// # Errors
+    ///
+    /// Returns the typed enactment failure when the policy change could not
+    /// be driven to the vehicle. The caller must treat any error as a
+    /// counted fail-closed fault — authority has already been fenced, so an
+    /// unenacted policy leaves the vehicle executing its last command with
+    /// nobody in control.
+    ///
+    /// [`RejectReason::LinkLossEngaged`]: crate::RejectReason::LinkLossEngaged
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), LinkLossEnactError>;
 
     /// Advances the adapter by up to `budget` ticks; the primary drive
     /// mechanism for stepped, deterministic, and accelerated execution

--- a/crates/pilotage-conformance/src/session.rs
+++ b/crates/pilotage-conformance/src/session.rs
@@ -171,10 +171,17 @@ impl ScriptedSession {
     }
 
     fn apply_link_loss_policy(&mut self, vehicle: VehicleId, policy: Option<LinkLossPolicy>) {
-        self.adapter.set_link_loss_policy(vehicle, policy);
+        // A refused enactment must be visible in the comparable event log —
+        // an adapter that cannot drive its declared policy is a conformance
+        // divergence, not a silent no-op.
+        let enacted = self.adapter.set_link_loss_policy(vehicle, policy);
         self.events.push(SessionEvent::LinkLossPolicyEngaged {
             vehicle,
-            policy: policy_label(policy),
+            policy: if enacted.is_ok() {
+                policy_label(policy)
+            } else {
+                "enact-failed"
+            },
         });
     }
 }

--- a/crates/pilotage-protocol/src/lib.rs
+++ b/crates/pilotage-protocol/src/lib.rs
@@ -21,8 +21,8 @@ pub use convert::{
 };
 pub use ids::{Generation, PrincipalId, ScopeId, SequenceNum, SessionId, VehicleId};
 pub use session::{
-    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRequest,
-    LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
+    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRelease,
+    LeaseReleased, LeaseRequest, LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
 };
 pub use video_frame::{
     CaptureHeader, ContractFault, DecodedFrame, Offsets, encode_v2 as encode_video_frame_v2,

--- a/crates/pilotage-protocol/src/session.rs
+++ b/crates/pilotage-protocol/src/session.rs
@@ -58,6 +58,33 @@ pub struct LeaseRequest {
     pub scope: ScopeId,
 }
 
+/// A holder voluntarily relinquishing a control scope (ADR-0006): routed
+/// through the authority engine's release path, so the generation advances
+/// (stragglers are fenced) and the vehicle's link-loss policy engages
+/// exactly as for an involuntary loss.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseRelease {
+    /// Vehicle the released scope belongs to.
+    pub vehicle: VehicleId,
+    /// Control scope being relinquished.
+    pub scope: ScopeId,
+}
+
+/// The host's acknowledgement of a [`LeaseRelease`]: authority is
+/// relinquished the moment this arrives (the host silence watchdog remains
+/// the independent backup if it never does).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseReleased {
+    /// Vehicle the released scope belongs to.
+    pub vehicle: VehicleId,
+    /// The scope the release targeted.
+    pub scope: ScopeId,
+    /// False when the sender did not hold the scope (nothing was released).
+    pub released: bool,
+    /// The fencing generation now in force.
+    pub generation: Generation,
+}
+
 /// Why a `LeaseRequest` was denied (ADR-0006, ADR-0010).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LeaseDenialReason {

--- a/crates/pilotage-protocol/src/session_convert.rs
+++ b/crates/pilotage-protocol/src/session_convert.rs
@@ -5,8 +5,8 @@
 use crate::convert::ConvertError;
 use crate::ids::{Generation, PrincipalId, ScopeId, SequenceNum, SessionId, VehicleId};
 use crate::session::{
-    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRequest,
-    LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
+    ClientHello, FrameRejected, FrameRejectionReason, LeaseDenialReason, LeaseRelease,
+    LeaseReleased, LeaseRequest, LeaseResponse, Ping, Pong, ScopeHolderSnapshot, ServerWelcome,
 };
 use crate::wire;
 use pilotage_timing::MonoTimestamp;
@@ -138,6 +138,73 @@ impl TryFrom<wire::LeaseRequest> for LeaseRequest {
         Ok(LeaseRequest {
             vehicle: VehicleId::new(vehicle.value),
             scope: ScopeId::new(scope.value),
+        })
+    }
+}
+
+impl TryFrom<wire::LeaseRelease> for LeaseRelease {
+    type Error = ConvertError;
+
+    fn try_from(release: wire::LeaseRelease) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.LeaseRelease",
+            field,
+        };
+        let vehicle = release.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = release.scope.ok_or_else(|| missing("scope"))?;
+        Ok(LeaseRelease {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+        })
+    }
+}
+
+impl From<&LeaseRelease> for wire::LeaseRelease {
+    fn from(release: &LeaseRelease) -> Self {
+        wire::LeaseRelease {
+            vehicle: Some(wire::VehicleId {
+                value: release.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: release.scope.as_str().to_owned(),
+            }),
+        }
+    }
+}
+
+impl From<&LeaseReleased> for wire::LeaseReleased {
+    fn from(released: &LeaseReleased) -> Self {
+        wire::LeaseReleased {
+            vehicle: Some(wire::VehicleId {
+                value: released.vehicle.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: released.scope.as_str().to_owned(),
+            }),
+            released: released.released,
+            generation: Some(wire::Generation {
+                value: released.generation.as_u64(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<wire::LeaseReleased> for LeaseReleased {
+    type Error = ConvertError;
+
+    fn try_from(released: wire::LeaseReleased) -> Result<Self, Self::Error> {
+        let missing = |field: &'static str| ConvertError::MissingField {
+            message: "pilotage.v1.LeaseReleased",
+            field,
+        };
+        let vehicle = released.vehicle.ok_or_else(|| missing("vehicle"))?;
+        let scope = released.scope.ok_or_else(|| missing("scope"))?;
+        let generation = released.generation.ok_or_else(|| missing("generation"))?;
+        Ok(LeaseReleased {
+            vehicle: VehicleId::new(vehicle.value),
+            scope: ScopeId::new(scope.value),
+            released: released.released,
+            generation: Generation::new(generation.value),
         })
     }
 }

--- a/crates/pilotage-session/src/action.rs
+++ b/crates/pilotage-session/src/action.rs
@@ -7,7 +7,8 @@
 //!
 //! [`SessionEngine`]: crate::SessionEngine
 
-use pilotage_protocol::{FrameRejected, ScopedControlFrame};
+use pilotage_adapter_api::LinkLossPolicy;
+use pilotage_protocol::{FrameRejected, Generation, ScopeId, ScopedControlFrame, VehicleId};
 
 use crate::message::ClientKey;
 use crate::outbound::OutboundMessage;
@@ -81,6 +82,55 @@ pub enum SessionAction {
         /// Why the connection is being closed.
         reason: CloseReason,
     },
+    /// Engage a vehicle's link-loss policy on the adapter because its holder was
+    /// lost (ADR-0008, ADR-0010). Emitted exactly once per loss, after the
+    /// fencing generation has already advanced, so the adapter drives its
+    /// declared policy state (stop / zero velocity / hover-brake) a single
+    /// time. The host does NOT re-transmit: a real flight controller ages
+    /// that final setpoint and enters its own offboard-loss terminal state
+    /// if the link stays absent. This action is emitted on the uncapped
+    /// safety lane — it is never dropped behind the per-call action cap.
+    EngageLinkLoss {
+        /// Vehicle whose control link was lost.
+        vehicle: VehicleId,
+        /// The scope whose holder was lost.
+        scope: ScopeId,
+        /// The fencing generation in force after the loss advanced it;
+        /// straggler frames from the lost holder are behind this value.
+        generation: Generation,
+        /// What judged the link lost.
+        trigger: LinkLossTrigger,
+        /// Policy the adapter should enact, selected and validated from the
+        /// vehicle's declared `link_loss_actions` profile at engine
+        /// construction ([`LinkLossPolicy::Neutralize`] when the profile
+        /// declares it or declares nothing — the fail-closed floor).
+        policy: LinkLossPolicy,
+    },
+    /// Clear a vehicle's engaged link-loss policy on the adapter — the only path
+    /// back to normal control (ADR-0008). Emitted only after BOTH recovery
+    /// conditions hold: a fresh lease generation installed a holder (grant,
+    /// handover, or override — never reconnection alone), and that holder
+    /// demonstrated the scope's activation condition with an accepted
+    /// neutral-axes frame, so a client reconnecting with deflected sticks
+    /// cannot revive motion.
+    ClearLinkLoss {
+        /// Vehicle returning to normal control under a new holder.
+        vehicle: VehicleId,
+    },
+}
+
+/// What judged a holder's control link lost (ADR-0010): typed provenance for
+/// the [`SessionAction::EngageLinkLoss`] it produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkLossTrigger {
+    /// The holder's transport disconnected.
+    HolderDisconnect,
+    /// The holder stayed transport-connected but sent no accepted
+    /// axis-bearing frame within the holder-silence window.
+    HolderSilence,
+    /// The holder's lease was revoked by an authority transition (an
+    /// explicit release or an override displacing it).
+    AuthorityRevoked,
 }
 
 /// Why the engine asked the driver to close a client connection.

--- a/crates/pilotage-session/src/config.rs
+++ b/crates/pilotage-session/src/config.rs
@@ -1,10 +1,16 @@
 //! Static configuration for a [`SessionEngine`] (ADR-0005, ADR-0009).
 //!
 //! Config is supplied once at construction and never mutated; it bundles the
-//! handshake floor, the host version string echoed in capabilities, and the
-//! per-call action cap that bounds the engine's output.
+//! handshake floor, the host version string echoed in capabilities, the
+//! per-call action cap that bounds the engine's output, and the holder-silence
+//! watchdog window.
 //!
 //! [`SessionEngine`]: crate::SessionEngine
+
+use std::time::Duration;
+
+use pilotage_adapter_api::LinkLossPolicy;
+use pilotage_protocol::VehicleId;
 
 /// Immutable knobs the engine reads while deciding actions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,6 +41,40 @@ pub struct SessionConfig {
     ///
     /// [`SessionAction`]: crate::SessionAction
     pub max_actions_per_call: usize,
+    /// How long a lease holder may go without a fresh, accepted control frame
+    /// before the engine judges its control link lost and releases the scope
+    /// (advancing the generation) — even though the WebTransport connection is
+    /// still open.
+    ///
+    /// The QUIC keepalive holds an idle-but-open connection up for seconds, so a
+    /// holder whose client froze (a backgrounded browser tab) would otherwise
+    /// keep the lease and leave the vehicle on its last command indefinitely.
+    /// This is that watchdog's window; RF/scheduling jitter tolerance belongs
+    /// here (a value comfortably above the control cadence and the single-frame
+    /// staleness bound), because once the deadline passes the holder is declared
+    /// lost and the vehicle is neutralized — a decision that must not be undone
+    /// by a late straggler frame.
+    pub holder_silence: Duration,
+    /// The recovery activation deadband, in thousandths of full axis
+    /// deflection (stored as an integer so the config stays `Eq`).
+    ///
+    /// After a link-loss policy engages, a newly installed holder returns
+    /// the vehicle to normal control only by demonstrating neutral input:
+    /// an accepted frame whose every reported axis magnitude is at or
+    /// below this deadband, with no pressed edges. Without the gate a
+    /// client reconnecting with deflected sticks would drive the vehicle
+    /// straight out of its neutralized state on the grant alone.
+    pub activation_deadband_milli: u32,
+    /// Explicitly configured link-loss policy per vehicle.
+    ///
+    /// A vehicle's `link_loss_actions` capability declares what the
+    /// adapter *supports* — it is a menu, not a selection, and its order
+    /// carries no meaning. The policy to *enact* is configured here and
+    /// validated against that menu at engine construction; a configured
+    /// policy the adapter never declared falls closed to
+    /// `LinkLossPolicy::Neutralize` (the only universally safe floor), as
+    /// does an unconfigured vehicle.
+    pub link_loss_overrides: Vec<(VehicleId, LinkLossPolicy)>,
 }
 
 impl SessionConfig {
@@ -46,14 +86,32 @@ impl SessionConfig {
     /// broadcast, stays comfortably under this bound.
     pub const DEFAULT_MAX_ACTIONS_PER_CALL: usize = 256;
 
+    /// The default holder-silence watchdog window.
+    ///
+    /// One second is many control frames at the ADR-0009 control cadence and
+    /// well above the 250 ms single-frame staleness bound, so ordinary jitter or
+    /// a few dropped frames never trip it, while a frozen or vanished client is
+    /// caught within a second — long before the multi-second QUIC keepalive
+    /// would (never, for a still-open connection) surface the loss.
+    pub const DEFAULT_HOLDER_SILENCE: Duration = Duration::from_millis(1000);
+
+    /// The default recovery activation deadband: 5% of full deflection,
+    /// comfortably above stick-center noise and far below any deliberate
+    /// command.
+    pub const DEFAULT_ACTIVATION_DEADBAND_MILLI: u32 = 50;
+
     /// Constructs a config with the given handshake floor and host version,
-    /// using [`SessionConfig::DEFAULT_MAX_ACTIONS_PER_CALL`].
+    /// using [`SessionConfig::DEFAULT_MAX_ACTIONS_PER_CALL`] and
+    /// [`SessionConfig::DEFAULT_HOLDER_SILENCE`].
     #[must_use]
     pub fn new(required_protocol_version: u32, host_version: impl Into<String>) -> Self {
         Self {
             required_protocol_version,
             host_version: host_version.into(),
             max_actions_per_call: Self::DEFAULT_MAX_ACTIONS_PER_CALL,
+            holder_silence: Self::DEFAULT_HOLDER_SILENCE,
+            activation_deadband_milli: Self::DEFAULT_ACTIVATION_DEADBAND_MILLI,
+            link_loss_overrides: Vec::new(),
         }
     }
 
@@ -61,6 +119,31 @@ impl SessionConfig {
     #[must_use]
     pub fn with_max_actions_per_call(mut self, cap: usize) -> Self {
         self.max_actions_per_call = cap;
+        self
+    }
+
+    /// Overrides the holder-silence watchdog window.
+    #[must_use]
+    pub fn with_holder_silence(mut self, holder_silence: Duration) -> Self {
+        self.holder_silence = holder_silence;
+        self
+    }
+
+    /// Overrides the recovery activation deadband (thousandths of full
+    /// deflection).
+    #[must_use]
+    pub fn with_activation_deadband_milli(mut self, deadband_milli: u32) -> Self {
+        self.activation_deadband_milli = deadband_milli;
+        self
+    }
+
+    /// Configures the link-loss policy to enact for `vehicle`. Validated
+    /// against the vehicle's declared `link_loss_actions` at engine
+    /// construction; an undeclared configuration falls closed to
+    /// `Neutralize`.
+    #[must_use]
+    pub fn with_link_loss_policy(mut self, vehicle: VehicleId, policy: LinkLossPolicy) -> Self {
+        self.link_loss_overrides.push((vehicle, policy));
         self
     }
 }

--- a/crates/pilotage-session/src/engine.rs
+++ b/crates/pilotage-session/src/engine.rs
@@ -12,17 +12,20 @@
 //! See [`SessionEngine`] for the full caveat and the RTT/offset follow-up.
 
 mod handlers;
+mod link_loss;
 
 use pilotage_adapter_api::AdapterCapabilities;
 use pilotage_authority::{AuthorityCommand, AuthorityEffect, AuthorityEngine, LinkState};
 use pilotage_timing::{MonoTimestamp, StalenessPolicy};
 
-use crate::action::{SessionAction, SessionOutcome};
+use crate::action::{LinkLossTrigger, SessionAction, SessionOutcome};
 use crate::capabilities::scope_pairs;
 use crate::clients::ClientRegistry;
 use crate::config::SessionConfig;
+use crate::liveness::{ExpiredHolder, HolderLiveness};
 use crate::message::{ClientKey, DomainEnvelope};
 use crate::outbound::OutboundMessage;
+use link_loss::LinkLossState;
 
 /// A pure host-side session state machine driven by decoded messages and an
 /// explicit clock.
@@ -54,6 +57,17 @@ pub struct SessionEngine {
     staleness: StalenessPolicy,
     config: SessionConfig,
     clients: ClientRegistry,
+    /// Frame-silence deadlines for every scope that has a holder; drives the
+    /// watchdog that releases a holder whose client stops sending while its
+    /// connection stays open.
+    liveness: HolderLiveness,
+    /// Per-vehicle declared link-loss policy selection and which vehicles
+    /// currently have a policy engaged (awaiting the recovery activation
+    /// condition).
+    link_loss: LinkLossState,
+    /// Reusable buffer for the watchdog's expiry pass, so the steady-state
+    /// tick allocates nothing.
+    expired_scratch: Vec<ExpiredHolder>,
 }
 
 impl SessionEngine {
@@ -71,17 +85,24 @@ impl SessionEngine {
         // Registration time is irrelevant (no command consults `now`); a zero
         // stamp keeps construction free of a clock, per ADR-0002.
         let now = MonoTimestamp::from_nanos(0);
+        let mut scope_count: usize = 0;
         for (vehicle, scope) in scope_pairs(&capabilities) {
             clients.register_scope((vehicle, scope.clone()));
             let effects = authority.handle(AuthorityCommand::RegisterScope { vehicle, scope }, now);
             drop(effects);
+            scope_count = scope_count.saturating_add(1);
         }
+        let link_loss =
+            LinkLossState::from_capabilities(&capabilities, &config.link_loss_overrides);
         Self {
             authority,
             capabilities,
             staleness,
             config,
             clients,
+            liveness: HolderLiveness::with_scope_capacity(scope_count),
+            link_loss,
+            expired_scratch: Vec::with_capacity(scope_count),
         }
     }
 
@@ -102,6 +123,9 @@ impl SessionEngine {
         match msg {
             DomainEnvelope::Hello(hello) => self.on_hello(client, hello, &mut actions),
             DomainEnvelope::Lease(request) => self.on_lease(client, request, now, &mut actions),
+            DomainEnvelope::Release(release) => {
+                self.on_release(client, release, now, &mut actions);
+            }
             DomainEnvelope::Frame(frame) => self.on_frame(client, frame, now, &mut actions),
             DomainEnvelope::Ping(ping) => self.on_ping(client, ping, now, &mut actions),
             DomainEnvelope::Disconnect => self.on_disconnect(client, &mut actions),
@@ -109,43 +133,108 @@ impl SessionEngine {
         actions.into_outcome()
     }
 
-    /// Advances time-driven state (offer expiry) to `now`.
+    /// Advances time-driven state to `now`: offer expiry, then the
+    /// holder-silence watchdog.
     ///
-    /// Delegates expiry entirely to the embedded [`AuthorityEngine`], turning
-    /// each expiry effect into an authority broadcast.
+    /// Offer expiry is delegated to the embedded [`AuthorityEngine`]. The
+    /// watchdog then releases every holder whose frame-silence deadline has
+    /// passed by routing a synthetic `HolderLinkChanged { Lost }` through the
+    /// same authority path a disconnect uses, so the generation advances (late
+    /// straggler frames are fenced) and the vehicle is neutralized exactly once.
     ///
     /// The returned [`SessionOutcome`] carries [`SessionOutcome::dropped`], the
-    /// count of broadcasts the per-call cap forced the engine to drop; a
-    /// non-zero value is a correctness signal the driver MUST count.
+    /// count of actions the per-call cap forced the engine to drop; a non-zero
+    /// value is a correctness signal the driver MUST count.
     #[must_use]
     pub fn handle_tick(&mut self, now: MonoTimestamp) -> SessionOutcome {
         let mut actions = Actions::new(self.config.max_actions_per_call);
         let effects = self.authority.expire_due(now);
-        self.fan_out_authority(effects, &mut actions);
+        self.fan_out_authority(
+            effects,
+            now,
+            LinkLossTrigger::AuthorityRevoked,
+            &mut actions,
+        );
+        // A holder that stopped sending frames while its connection stayed open
+        // (a frozen client the QUIC keepalive holds up) is released here. The
+        // expiry list reuses the engine's scratch buffer (taken and restored
+        // around the loop so the borrow does not pin `self`).
+        let mut expired = core::mem::take(&mut self.expired_scratch);
+        self.liveness.expire_into(now, &mut expired);
+        for holder in expired.drain(..) {
+            let effects = self.authority.handle(
+                AuthorityCommand::HolderLinkChanged {
+                    vehicle: holder.vehicle,
+                    scope: holder.scope,
+                    principal: holder.principal,
+                    state: LinkState::Lost,
+                },
+                now,
+            );
+            self.fan_out_authority(effects, now, LinkLossTrigger::HolderSilence, &mut actions);
+        }
+        self.expired_scratch = expired;
         actions.into_outcome()
     }
 
     /// Returns the next time the engine wants a [`SessionEngine::handle_tick`]
-    /// call, delegating to the authority engine's earliest offer expiry.
+    /// call: the earlier of the authority engine's next offer expiry and the
+    /// earliest holder-silence deadline.
     #[must_use]
     pub fn next_deadline(&self) -> Option<MonoTimestamp> {
-        self.authority.next_deadline()
+        min_option(
+            self.authority.next_deadline(),
+            self.liveness.next_deadline(),
+        )
     }
 
     /// Broadcasts each authority effect and keeps holder bookkeeping in sync.
     ///
     /// Every effect that installs or clears an effective holder updates the
-    /// registry so the disconnect path releases exactly the scopes the client
-    /// still holds.
+    /// registry (so the disconnect path releases exactly the scopes the client
+    /// still holds), refreshes or clears the holder-silence watchdog, and emits
+    /// the adapter link-loss engagement for the transition after the broadcast:
+    /// clients learn the fenced state first, then the vehicle is neutralized.
+    /// The engagement rides the uncapped safety lane — a burst of broadcasts
+    /// hitting the per-call cap must never swallow the neutralization
+    /// (fail-closed, never dropped).
     pub(crate) fn fan_out_authority(
         &mut self,
         effects: Vec<AuthorityEffect>,
+        now: MonoTimestamp,
+        trigger: LinkLossTrigger,
         actions: &mut Actions,
     ) {
         for effect in effects {
             self.record_holder_change(&effect);
+            let transition = self.holder_transition_action(&effect, now, trigger);
             actions.broadcast(OutboundMessage::Authority(effect));
+            if let Some(action) = transition {
+                match action {
+                    SessionAction::EngageLinkLoss { .. } => actions.push_safety(action),
+                    _ => actions.push(action),
+                }
+            }
         }
+    }
+
+    /// Refreshes a holder's frame-silence deadline after it sent an accepted
+    /// axis-bearing frame; called from the on-frame accept path. Refresh is
+    /// in place (no allocation) and only for the recorded holder — a frame
+    /// can never create or resurrect a watchdog entry.
+    pub(crate) fn note_frame_accepted(
+        &mut self,
+        vehicle: pilotage_protocol::VehicleId,
+        scope: &pilotage_protocol::ScopeId,
+        holder: pilotage_protocol::PrincipalId,
+        now: MonoTimestamp,
+    ) {
+        self.liveness.refresh(
+            vehicle,
+            scope,
+            holder,
+            now.saturating_add(self.config.holder_silence),
+        );
     }
 
     /// Updates the registry's holder bookkeeping from one authority effect.
@@ -208,6 +297,10 @@ impl SessionEngine {
         scopes: Vec<crate::clients::ScopePair>,
         actions: &mut Actions,
     ) {
+        // Link-loss release and its neutralization do not consult `now` (the
+        // clear path sets no new deadline); a zero stamp keeps disconnect
+        // independent of a clock.
+        let now = MonoTimestamp::from_nanos(0);
         for (vehicle, scope) in scopes {
             let effects = self.authority.handle(
                 AuthorityCommand::HolderLinkChanged {
@@ -216,12 +309,18 @@ impl SessionEngine {
                     principal,
                     state: LinkState::Lost,
                 },
-                // Link-loss handling does not consult `now`; a zero stamp is
-                // sound and keeps disconnect independent of a clock.
-                MonoTimestamp::from_nanos(0),
+                now,
             );
-            self.fan_out_authority(effects, actions);
+            self.fan_out_authority(effects, now, LinkLossTrigger::HolderDisconnect, actions);
         }
+    }
+}
+
+/// The lesser of two optional deadlines, or whichever is present.
+fn min_option(a: Option<MonoTimestamp>, b: Option<MonoTimestamp>) -> Option<MonoTimestamp> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (some, None) | (None, some) => some,
     }
 }
 
@@ -234,6 +333,9 @@ impl SessionEngine {
 #[derive(Debug)]
 pub(crate) struct Actions {
     items: Vec<SessionAction>,
+    /// Count of ordinary (cap-subject) actions in `items`; safety-lane
+    /// pushes are excluded so they never consume ordinary budget.
+    ordinary: usize,
     cap: usize,
     dropped: usize,
 }
@@ -242,6 +344,7 @@ impl Actions {
     fn new(cap: usize) -> Self {
         Self {
             items: Vec::new(),
+            ordinary: 0,
             cap,
             dropped: 0,
         }
@@ -249,10 +352,24 @@ impl Actions {
 
     /// Appends an action unless the per-call cap is already reached.
     pub(crate) fn push(&mut self, action: SessionAction) {
-        if self.items.len() >= self.cap {
+        if self.ordinary >= self.cap {
             self.dropped = self.dropped.wrapping_add(1);
             return;
         }
+        self.ordinary = self.ordinary.saturating_add(1);
+        self.items.push(action);
+    }
+
+    /// Appends a safety-critical action REGARDLESS of the per-call cap.
+    ///
+    /// The cap exists to bound amplification of untrusted client input;
+    /// safety enactments (link-loss engagement) are bounded by the number
+    /// of registered scopes, not by client traffic, and dropping one would
+    /// leave a vehicle executing its last command with authority already
+    /// fenced. A safety action is therefore never droppable behind the
+    /// broadcast cap — the vector may exceed the cap by at most the scope
+    /// count.
+    pub(crate) fn push_safety(&mut self, action: SessionAction) {
         self.items.push(action);
     }
 

--- a/crates/pilotage-session/src/engine/handlers.rs
+++ b/crates/pilotage-session/src/engine/handlers.rs
@@ -7,11 +7,11 @@
 use pilotage_authority::{AuthorityCommand, AuthorityEffect, FrameVerdict};
 use pilotage_protocol::{
     ClientHello, FrameRejected, FrameRejectionReason, Generation, LeaseDenialReason, LeaseRequest,
-    Ping, Pong, ScopedControlFrame, ServerWelcome,
+    Ping, Pong, PrincipalId, ScopedControlFrame, ServerWelcome,
 };
 use pilotage_timing::{Freshness, MonoTimestamp};
 
-use crate::action::{CloseReason, SessionAction};
+use crate::action::{CloseReason, LinkLossTrigger, SessionAction};
 use crate::capabilities::host_capabilities;
 use crate::clients::ScopePair;
 use crate::engine::{Actions, SessionEngine};
@@ -111,8 +111,10 @@ impl SessionEngine {
             .iter()
             .any(|effect| matches!(effect, AuthorityEffect::CommandRejected { .. }));
         // `fan_out_authority` updates the holder record from the grant effect,
-        // so the post-grant generation lookup reflects the advanced value.
-        self.fan_out_authority(effects, actions);
+        // so the post-grant generation lookup reflects the advanced value. A
+        // grant can also displace a prior holder (revoke effect), which is an
+        // authority-driven loss, not silence or a disconnect.
+        self.fan_out_authority(effects, now, LinkLossTrigger::AuthorityRevoked, actions);
         let current_generation = self
             .clients
             .generation_of(&pair)
@@ -123,6 +125,54 @@ impl SessionEngine {
             lease_granted(&request, current_generation)
         };
         actions.send(client, OutboundMessage::LeaseResponse(response));
+    }
+
+    /// Routes a voluntary scope release through the authority engine and
+    /// acknowledges it (ADR-0006). A successful release advances the
+    /// fencing generation and engages the vehicle's link-loss policy —
+    /// the same authoritative state an involuntary loss produces — so a
+    /// client that latched input loss relinquishes deterministically
+    /// instead of waiting out the silence watchdog (which remains the
+    /// independent backup). The acknowledgement is unicast on the
+    /// reliable bootstrap stream; `released` is false when the sender did
+    /// not hold the scope, so a stale or duplicate release is a no-op the
+    /// client can observe.
+    pub(super) fn on_release(
+        &mut self,
+        client: ClientKey,
+        release: pilotage_protocol::LeaseRelease,
+        now: MonoTimestamp,
+        actions: &mut Actions,
+    ) {
+        let Some(principal) = self.welcomed_principal(client, actions) else {
+            return;
+        };
+        let pair: ScopePair = (release.vehicle, release.scope.clone());
+        let effects = self.authority.handle(
+            AuthorityCommand::Release {
+                vehicle: release.vehicle,
+                scope: release.scope.clone(),
+                by: principal,
+            },
+            now,
+        );
+        let released = effects
+            .iter()
+            .any(|effect| matches!(effect, AuthorityEffect::ScopeLeaseRevoked { .. }));
+        self.fan_out_authority(effects, now, LinkLossTrigger::AuthorityRevoked, actions);
+        let generation = self
+            .clients
+            .generation_of(&pair)
+            .unwrap_or_else(|| Generation::new(0));
+        actions.send(
+            client,
+            OutboundMessage::LeaseReleased(pilotage_protocol::LeaseReleased {
+                vehicle: release.vehicle,
+                scope: release.scope,
+                released,
+                generation,
+            }),
+        );
     }
 
     /// Staleness-checks, fence-verifies, then forwards or rejects a control
@@ -172,9 +222,7 @@ impl SessionEngine {
             .authority
             .verify_frame(frame.vehicle, &frame.scope, frame.generation)
         {
-            FrameVerdict::Accepted => {
-                actions.push(SessionAction::ApplyToAdapter { frame });
-            }
+            FrameVerdict::Accepted => self.accept_frame(frame, sender, now, actions),
             FrameVerdict::RejectedStaleGeneration { current } => {
                 actions.push(reject_frame(
                     client,
@@ -201,6 +249,31 @@ impl SessionEngine {
                 ));
             }
         }
+    }
+
+    /// Books an accepted frame: refreshes setpoint freshness, runs the
+    /// recovery activation check, and forwards the frame to the adapter.
+    fn accept_frame(
+        &mut self,
+        frame: ScopedControlFrame,
+        sender: PrincipalId,
+        now: MonoTimestamp,
+        actions: &mut Actions,
+    ) {
+        // The holder is actively driving; push its frame-silence deadline
+        // forward so the watchdog only fires on real silence. Only an
+        // axis-bearing frame counts as setpoint freshness — discrete/
+        // edge-only traffic proves the client is alive, not that it is
+        // commanding the vehicle, and must not hold the lease of an
+        // axis-silent holder open.
+        if !frame.payload.axes.is_empty() {
+            self.note_frame_accepted(frame.vehicle, &frame.scope, sender, now);
+        }
+        // A demonstrated-neutral frame from the fenced new holder is the
+        // recovery activation condition; the clear (if any) is emitted
+        // before the apply so the adapter un-latches first.
+        self.maybe_activate_recovery(frame.vehicle, &frame.scope, &frame.payload, actions);
+        actions.push(SessionAction::ApplyToAdapter { frame });
     }
 
     /// Answers a `Ping` with a `Pong` echoing the sender sample and stamping

--- a/crates/pilotage-session/src/engine/link_loss.rs
+++ b/crates/pilotage-session/src/engine/link_loss.rs
@@ -1,0 +1,258 @@
+//! Link-loss policy selection, engagement, and recovery activation
+//! (ADR-0008, ADR-0010).
+//!
+//! The engine engages a vehicle's link-loss policy when a scope's holder is
+//! lost and clears it only after EVERY lost scope has recovered: for each,
+//! a fresh fenced authority generation installed a new holder AND that
+//! holder demonstrated the activation condition on THAT scope — an accepted
+//! frame reporting every axis the scope declares, all inside the neutral
+//! deadband, with no pressed edges. Scope-specificity matters twice over: a
+//! neutral frame on an unrelated scope proves nothing about the lost one,
+//! and a frame covering only a subset of the declared axes would let an
+//! adapter's retained latest-valid values (a previously deflected axis the
+//! frame omitted) drive the vehicle the instant the latch clears.
+//!
+//! The enacted policy is CONFIGURED, not inferred: a vehicle's declared
+//! `link_loss_actions` is the menu of supported actions (its order carries
+//! no meaning), the session config selects from it per vehicle, and a
+//! selection the adapter never declared falls closed to
+//! [`LinkLossPolicy::Neutralize`] — the only universally safe floor — as
+//! does an unconfigured vehicle.
+
+use pilotage_adapter_api::{AdapterCapabilities, LinkLossPolicy};
+use pilotage_authority::AuthorityEffect;
+use pilotage_protocol::{ControlPayload, LogicalAxisId, ScopeId, VehicleId};
+use pilotage_timing::MonoTimestamp;
+
+use super::{Actions, SessionEngine};
+use crate::action::{LinkLossTrigger, SessionAction};
+
+/// Per-vehicle configured policy plus which scopes currently have their
+/// vehicle's policy engaged. Both vectors are bounded by the capability
+/// declaration and sized at construction.
+#[derive(Debug)]
+pub(crate) struct LinkLossState {
+    /// The policy configured and validated for each vehicle.
+    selected: Vec<(VehicleId, LinkLossPolicy)>,
+    /// Scopes whose holder loss engaged (or would keep engaged) their
+    /// vehicle's policy, each awaiting scope-specific recovery activation.
+    engaged: Vec<(VehicleId, ScopeId)>,
+}
+
+impl LinkLossState {
+    /// Resolves each vehicle's policy: the configured override when the
+    /// vehicle's declared `link_loss_actions` menu contains it, otherwise
+    /// `Neutralize` (the fail-closed floor — also the answer for an
+    /// unconfigured vehicle or an empty menu). Declaration order is never
+    /// consulted: supported-actions is a menu, not a configuration.
+    pub(crate) fn from_capabilities(
+        capabilities: &AdapterCapabilities,
+        overrides: &[(VehicleId, LinkLossPolicy)],
+    ) -> Self {
+        let mut selected = Vec::with_capacity(capabilities.vehicles.len());
+        let mut scope_count: usize = 0;
+        for vehicle in &capabilities.vehicles {
+            let configured = overrides
+                .iter()
+                .find(|(id, _)| *id == vehicle.id)
+                .map(|(_, policy)| *policy);
+            let policy = match configured {
+                Some(policy) if vehicle.link_loss_actions.contains(&policy) => policy,
+                _ => LinkLossPolicy::Neutralize,
+            };
+            selected.push((vehicle.id, policy));
+            scope_count = scope_count.saturating_add(vehicle.scopes.len());
+        }
+        Self {
+            selected,
+            engaged: Vec::with_capacity(scope_count),
+        }
+    }
+
+    /// The policy configured for `vehicle`; `Neutralize` for a vehicle the
+    /// profile never declared (fail-closed).
+    fn policy_for(&self, vehicle: VehicleId) -> LinkLossPolicy {
+        self.selected
+            .iter()
+            .find(|(id, _)| *id == vehicle)
+            .map(|(_, policy)| *policy)
+            .unwrap_or(LinkLossPolicy::Neutralize)
+    }
+
+    /// Records the loss of `scope` on `vehicle`. Idempotent.
+    fn engage_scope(&mut self, vehicle: VehicleId, scope: &ScopeId) {
+        if !self.is_scope_engaged(vehicle, scope) {
+            self.engaged.push((vehicle, scope.clone()));
+        }
+    }
+
+    /// Whether this exact scope's loss is awaiting recovery activation.
+    fn is_scope_engaged(&self, vehicle: VehicleId, scope: &ScopeId) -> bool {
+        self.engaged
+            .iter()
+            .any(|(v, s)| *v == vehicle && s == scope)
+    }
+
+    /// Whether any scope keeps `vehicle`'s policy engaged.
+    fn vehicle_engaged(&self, vehicle: VehicleId) -> bool {
+        self.engaged.iter().any(|(v, _)| *v == vehicle)
+    }
+
+    /// Clears one scope's engagement marker. Idempotent.
+    fn clear_scope(&mut self, vehicle: VehicleId, scope: &ScopeId) {
+        self.engaged.retain(|(v, s)| !(*v == vehicle && s == scope));
+    }
+}
+
+impl SessionEngine {
+    /// Updates the frame-silence watchdog for one holder-changing effect and
+    /// returns the adapter link-loss action it warrants, if any.
+    ///
+    /// An effect that installs a holder (grant, committed handover, override)
+    /// starts that scope's silence deadline but does NOT clear an engaged
+    /// policy — recovery additionally requires the new holder's activation
+    /// frame on the lost scope (see
+    /// [`SessionEngine::maybe_activate_recovery`]). An effect that clears
+    /// the holder (release, revoke, link-lost) stops the watchdog, records
+    /// the scope as engaged, and — on the vehicle's FIRST engaged scope —
+    /// emits the engagement; the fencing generation has already advanced,
+    /// so this is neutralize-after-fence. Later scope losses on an
+    /// already-engaged vehicle record their scope without re-emitting (the
+    /// adapter is already in its policy state).
+    pub(super) fn holder_transition_action(
+        &mut self,
+        effect: &AuthorityEffect,
+        now: MonoTimestamp,
+        trigger: LinkLossTrigger,
+    ) -> Option<SessionAction> {
+        let silence_deadline = now.saturating_add(self.config.holder_silence);
+        match effect {
+            AuthorityEffect::ScopeLeaseGranted {
+                vehicle,
+                scope,
+                holder,
+                ..
+            }
+            | AuthorityEffect::EmergencyOverrideApplied {
+                vehicle,
+                scope,
+                holder,
+                ..
+            } => {
+                self.liveness
+                    .mark_active((*vehicle, scope.clone()), *holder, silence_deadline);
+                None
+            }
+            AuthorityEffect::ScopeTransferCommitted {
+                vehicle, scope, to, ..
+            } => {
+                self.liveness
+                    .mark_active((*vehicle, scope.clone()), *to, silence_deadline);
+                None
+            }
+            AuthorityEffect::ScopeLeaseRevoked {
+                vehicle,
+                scope,
+                generation,
+                ..
+            }
+            | AuthorityEffect::HolderLinkLost {
+                vehicle,
+                scope,
+                generation,
+                ..
+            } => {
+                self.liveness.clear(&(*vehicle, scope.clone()));
+                let first = !self.link_loss.vehicle_engaged(*vehicle);
+                self.link_loss.engage_scope(*vehicle, scope);
+                if !first {
+                    return None;
+                }
+                Some(SessionAction::EngageLinkLoss {
+                    vehicle: *vehicle,
+                    scope: scope.clone(),
+                    generation: *generation,
+                    trigger,
+                    policy: self.link_loss.policy_for(*vehicle),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Clears one scope's engagement when the accepted frame satisfies the
+    /// recovery activation condition ON THAT SCOPE; called from the
+    /// frame-accept path, so the fenced-generation and holder-identity
+    /// checks have already passed. The vehicle's `ClearLinkLoss` is emitted
+    /// only when its LAST engaged scope recovers, ordered before the
+    /// frame's `ApplyToAdapter` so the adapter un-latches first.
+    pub(super) fn maybe_activate_recovery(
+        &mut self,
+        vehicle: VehicleId,
+        scope: &ScopeId,
+        payload: &ControlPayload,
+        actions: &mut Actions,
+    ) {
+        if !self.link_loss.is_scope_engaged(vehicle, scope) {
+            return;
+        }
+        let Some(declared) = declared_axes(&self.capabilities, vehicle, scope) else {
+            // A scope the capabilities no longer describe cannot prove
+            // anything; stay engaged (fail closed).
+            return;
+        };
+        if !payload_is_neutral(payload, declared, self.config.activation_deadband_milli) {
+            return;
+        }
+        self.link_loss.clear_scope(vehicle, scope);
+        if !self.link_loss.vehicle_engaged(vehicle) {
+            actions.push(SessionAction::ClearLinkLoss { vehicle });
+        }
+    }
+}
+
+/// The axes `scope` declares on `vehicle`, from the adapter's capability
+/// report.
+fn declared_axes<'a>(
+    capabilities: &'a AdapterCapabilities,
+    vehicle: VehicleId,
+    scope: &ScopeId,
+) -> Option<&'a [LogicalAxisId]> {
+    capabilities
+        .vehicles
+        .iter()
+        .find(|descriptor| descriptor.id == vehicle)?
+        .scopes
+        .iter()
+        .find(|descriptor| descriptor.scope == *scope)
+        .map(|descriptor| descriptor.axes.as_slice())
+}
+
+/// The activation condition for one scope: EVERY axis the scope declares is
+/// reported inside the neutral deadband, every reported axis (declared or
+/// not) is inside it too, and no edge is pressed. Requiring full declared
+/// coverage matters because adapters retain latest-valid values per axis: a
+/// frame omitting a previously deflected axis would un-latch straight into
+/// that stale deflection.
+fn payload_is_neutral(
+    payload: &ControlPayload,
+    declared: &[LogicalAxisId],
+    deadband_milli: u32,
+) -> bool {
+    let deadband = deadband_milli as f32 / 1000.0;
+    let all_declared_reported_neutral = declared.iter().all(|axis| {
+        payload
+            .axes
+            .iter()
+            .any(|(reported, value)| reported == axis && value.abs() <= deadband)
+    });
+    let all_reported_neutral = payload
+        .axes
+        .iter()
+        .all(|(_, value)| value.abs() <= deadband);
+    let no_pressed_edge = payload
+        .edges
+        .iter()
+        .all(|(_, edge)| *edge != pilotage_protocol::ButtonEdge::Pressed);
+    all_declared_reported_neutral && all_reported_neutral && no_pressed_edge
+}

--- a/crates/pilotage-session/src/lib.rs
+++ b/crates/pilotage-session/src/lib.rs
@@ -21,13 +21,14 @@ mod capabilities;
 mod clients;
 mod config;
 mod engine;
+mod liveness;
 mod message;
 mod outbound;
 
 #[cfg(test)]
 mod tests;
 
-pub use action::{CloseReason, SessionAction, SessionOutcome};
+pub use action::{CloseReason, LinkLossTrigger, SessionAction, SessionOutcome};
 pub use config::SessionConfig;
 pub use engine::SessionEngine;
 pub use message::{ClientKey, DomainEnvelope};

--- a/crates/pilotage-session/src/liveness.rs
+++ b/crates/pilotage-session/src/liveness.rs
@@ -1,0 +1,152 @@
+//! Holder-liveness bookkeeping for the session engine's frame-silence watchdog
+//! (ADR-0006, ADR-0008, ADR-0010).
+//!
+//! For each scope with an effective holder, the engine records the deadline by
+//! which that holder must send a fresh, accepted control frame. A holder that
+//! goes silent past its deadline — while its WebTransport connection is still
+//! open, so no disconnect ever fires — is judged link-lost and released. This
+//! module only tracks deadlines; the engine issues the release and the
+//! neutralization, keeping every clock read explicit.
+//!
+//! The tracker is allocation-free after configuration: slots are
+//! pre-allocated for every registered scope (an entry can only exist for a
+//! registered scope, so the capacity is exact), the per-frame refresh
+//! updates a slot in place through borrowed keys, and expiry moves slots
+//! into a caller-provided reusable buffer.
+
+use pilotage_protocol::{PrincipalId, ScopeId, VehicleId};
+use pilotage_timing::MonoTimestamp;
+
+use crate::clients::ScopePair;
+
+/// One scope with an effective holder and the instant by which that holder
+/// must send another accepted frame to stay live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HeldSlot {
+    vehicle: VehicleId,
+    scope: ScopeId,
+    principal: PrincipalId,
+    deadline: MonoTimestamp,
+}
+
+/// A holder whose frame-silence deadline has passed, moved out of the
+/// tracker for the engine to release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExpiredHolder {
+    /// Vehicle of the silent scope.
+    pub(crate) vehicle: VehicleId,
+    /// The silent scope.
+    pub(crate) scope: ScopeId,
+    /// The holder that went silent.
+    pub(crate) principal: PrincipalId,
+}
+
+/// Per-scope frame-silence deadlines for every scope that has a holder.
+///
+/// An entry exists exactly while a scope has an effective holder: the engine
+/// marks it active on grant/handover/override, refreshes it on accepted
+/// axis-bearing frames, and clears it when the holder is released. No entry
+/// means no holder to watch.
+#[derive(Debug, Default)]
+pub(crate) struct HolderLiveness {
+    entries: Vec<HeldSlot>,
+}
+
+impl HolderLiveness {
+    /// Creates a tracker with capacity for `scope_count` watched scopes —
+    /// the number of registered scopes, so the entry vector never grows
+    /// after construction.
+    pub(crate) fn with_scope_capacity(scope_count: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(scope_count),
+        }
+    }
+
+    /// Records that `principal` holds `pair` and must send another accepted
+    /// frame before `deadline`. Replaces any prior entry for the scope, so a
+    /// handover to a new holder resets the clock under the new principal.
+    pub(crate) fn mark_active(
+        &mut self,
+        pair: ScopePair,
+        principal: PrincipalId,
+        deadline: MonoTimestamp,
+    ) {
+        let (vehicle, scope) = pair;
+        if let Some(slot) = self.slot_mut(vehicle, &scope) {
+            slot.principal = principal;
+            slot.deadline = deadline;
+            return;
+        }
+        self.entries.push(HeldSlot {
+            vehicle,
+            scope,
+            principal,
+            deadline,
+        });
+    }
+
+    /// Pushes the deadline of an existing entry forward, in place and
+    /// without cloning the scope key — the per-accepted-frame hot path.
+    /// Only the recorded holder refreshes its own deadline; an entry is
+    /// never created here, so a frame cannot resurrect a released scope.
+    pub(crate) fn refresh(
+        &mut self,
+        vehicle: VehicleId,
+        scope: &ScopeId,
+        principal: PrincipalId,
+        deadline: MonoTimestamp,
+    ) {
+        if let Some(slot) = self.slot_mut(vehicle, scope)
+            && slot.principal == principal
+        {
+            slot.deadline = deadline;
+        }
+    }
+
+    /// Stops watching `pair` (its holder was released). Idempotent.
+    pub(crate) fn clear(&mut self, pair: &ScopePair) {
+        let (vehicle, scope) = pair;
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|slot| slot.vehicle == *vehicle && slot.scope == *scope)
+        {
+            self.entries.swap_remove(index);
+        }
+    }
+
+    /// The earliest holder-silence deadline across all watched scopes, if any.
+    /// The engine folds this into its next-tick deadline so a tick lands when a
+    /// holder would time out.
+    pub(crate) fn next_deadline(&self) -> Option<MonoTimestamp> {
+        self.entries.iter().map(|slot| slot.deadline).min()
+    }
+
+    /// Moves every entry whose deadline is at or before `now` — the holders
+    /// that have gone silent and must be released — into `out`, sorted by
+    /// `(vehicle, scope)` for deterministic effect ordering. `out` is the
+    /// engine's reusable scratch buffer, so the steady state allocates
+    /// nothing.
+    pub(crate) fn expire_into(&mut self, now: MonoTimestamp, out: &mut Vec<ExpiredHolder>) {
+        let mut index = 0;
+        while index < self.entries.len() {
+            if self.entries[index].deadline <= now {
+                let slot = self.entries.swap_remove(index);
+                out.push(ExpiredHolder {
+                    vehicle: slot.vehicle,
+                    scope: slot.scope,
+                    principal: slot.principal,
+                });
+            } else {
+                index = index.saturating_add(1);
+            }
+        }
+        out.sort_by(|a, b| (a.vehicle, &a.scope).cmp(&(b.vehicle, &b.scope)));
+    }
+
+    fn slot_mut(&mut self, vehicle: VehicleId, scope: &ScopeId) -> Option<&mut HeldSlot> {
+        self.entries
+            .iter_mut()
+            .find(|slot| slot.vehicle == vehicle && slot.scope == *scope)
+    }
+}

--- a/crates/pilotage-session/src/message.rs
+++ b/crates/pilotage-session/src/message.rs
@@ -9,7 +9,7 @@
 //!
 //! [`SessionEngine`]: crate::SessionEngine
 
-use pilotage_protocol::{ClientHello, LeaseRequest, Ping, ScopedControlFrame};
+use pilotage_protocol::{ClientHello, LeaseRelease, LeaseRequest, Ping, ScopedControlFrame};
 
 /// Identifies one connected client (one WebTransport session) within a
 /// [`SessionEngine`].
@@ -54,6 +54,10 @@ pub enum DomainEnvelope {
     /// A request to lease a control scope, routed through the authority
     /// engine's grant path.
     Lease(LeaseRequest),
+    /// A holder voluntarily relinquishing a scope, routed through the
+    /// authority engine's release path (generation advances, link-loss
+    /// policy engages) and acknowledged with a `LeaseReleased`.
+    Release(LeaseRelease),
     /// A real-time control frame to be staleness-checked, fence-verified, and
     /// forwarded to the adapter or rejected.
     Frame(ScopedControlFrame),

--- a/crates/pilotage-session/src/outbound.rs
+++ b/crates/pilotage-session/src/outbound.rs
@@ -7,7 +7,7 @@
 //! in `pilotage-protocol` and `pilotage-authority`.
 
 use pilotage_authority::AuthorityEffect;
-use pilotage_protocol::{LeaseResponse, Pong, ServerWelcome};
+use pilotage_protocol::{LeaseReleased, LeaseResponse, Pong, ServerWelcome};
 
 /// A message the engine directs at one client or at all clients.
 ///
@@ -23,6 +23,9 @@ pub enum OutboundMessage {
     Welcome(ServerWelcome),
     /// The reply to a `LeaseRequest` (ADR-0006).
     LeaseResponse(LeaseResponse),
+    /// The acknowledgement of a `LeaseRelease` (ADR-0006): the sender may
+    /// treat its authority as relinquished on receipt.
+    LeaseReleased(LeaseReleased),
     /// The reply to a `Ping` (ADR-0009 RTT probe).
     Pong(Pong),
     /// An authority event to be serialized and observed on the ordered

--- a/crates/pilotage-session/src/tests.rs
+++ b/crates/pilotage-session/src/tests.rs
@@ -13,19 +13,26 @@ mod frame;
 mod handshake;
 mod lease;
 mod ping;
+mod recovery;
+mod release;
+mod watchdog;
 
 use core::time::Duration;
 
 use pilotage_adapter_api::{
     AdapterCapabilities, ExecutionMode, LinkLossPolicy, ScopeDescriptor, VehicleDescriptor,
 };
+use pilotage_authority::AuthorityEffect;
 use pilotage_protocol::{
-    ClientHello, ControlPayload, Generation, LogicalAxisId, ScopeId, ScopedControlFrame,
-    SequenceNum, SessionId, VehicleId,
+    ButtonEdge, ClientHello, ControlPayload, Generation, LeaseRequest, LogicalAxisId,
+    LogicalButtonId, ScopeId, ScopedControlFrame, SequenceNum, SessionId, VehicleId,
 };
 use pilotage_timing::{MonoTimestamp, StalenessPolicy};
 
-use crate::{ClientKey, SessionConfig, SessionEngine};
+use crate::{
+    ClientKey, DomainEnvelope, LinkLossTrigger, OutboundMessage, SessionAction, SessionConfig,
+    SessionEngine, SessionOutcome,
+};
 
 /// The single motion scope used across the tests.
 pub(crate) fn motion() -> ScopeId {
@@ -112,4 +119,115 @@ pub(crate) fn frame(
             edges: Vec::new(),
         },
     }
+}
+
+/// An engine whose holder-silence window is `silence`, so deadlines land at
+/// small, readable nanosecond values.
+pub(crate) fn engine_with_silence(silence: Duration) -> SessionEngine {
+    SessionEngine::new(
+        capabilities(),
+        staleness(),
+        SessionConfig::new(1, "host-test").with_holder_silence(silence),
+    )
+}
+
+/// Grants the motion lease to `client` at `now`, returning the granted
+/// generation the holder must fence its frames with.
+pub(crate) fn grant(engine: &mut SessionEngine, client: ClientKey, now: u64) -> Generation {
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(now),
+    );
+    match outcome.actions.last() {
+        Some(SessionAction::SendToClient {
+            envelope: OutboundMessage::LeaseResponse(response),
+            ..
+        }) if response.granted => response.generation,
+        other => panic!("expected a granted lease, got {other:?}"),
+    }
+}
+
+/// Count of `EngageLinkLoss { policy: Neutralize }` actions for [`VEHICLE`].
+pub(crate) fn engaged_neutralize(outcome: &SessionOutcome) -> usize {
+    outcome
+        .actions
+        .iter()
+        .filter(|action| {
+            matches!(
+                action,
+                SessionAction::EngageLinkLoss {
+                    vehicle,
+                    policy: LinkLossPolicy::Neutralize,
+                    ..
+                } if *vehicle == VEHICLE
+            )
+        })
+        .count()
+}
+
+/// The trigger of the first `EngageLinkLoss` in the outcome, if any.
+pub(crate) fn engage_trigger(outcome: &SessionOutcome) -> Option<LinkLossTrigger> {
+    outcome.actions.iter().find_map(|action| match action {
+        SessionAction::EngageLinkLoss { trigger, .. } => Some(*trigger),
+        _ => None,
+    })
+}
+
+/// Count of `ClearLinkLoss` actions for [`VEHICLE`].
+pub(crate) fn cleared(outcome: &SessionOutcome) -> usize {
+    outcome
+        .actions
+        .iter()
+        .filter(
+            |action| matches!(action, SessionAction::ClearLinkLoss { vehicle } if *vehicle == VEHICLE),
+        )
+        .count()
+}
+
+/// Whether the outcome broadcast a `HolderLinkLost` authority effect.
+pub(crate) fn link_lost(outcome: &SessionOutcome) -> bool {
+    outcome.actions.iter().any(|action| {
+        matches!(
+            action,
+            SessionAction::Broadcast {
+                envelope: OutboundMessage::Authority(AuthorityEffect::HolderLinkLost { .. }),
+            }
+        )
+    })
+}
+
+/// A control frame whose payload demonstrates neutral input (axis at
+/// center, no edges) — the recovery activation condition.
+pub(crate) fn neutral_frame(
+    session: SessionId,
+    generation: Generation,
+    sequence: SequenceNum,
+    sampled_at: MonoTimestamp,
+) -> ScopedControlFrame {
+    let mut f = frame(session, generation, sequence, sampled_at);
+    f.payload = ControlPayload {
+        axes: vec![(LogicalAxisId::new(0), 0.0)],
+        edges: Vec::new(),
+    };
+    f
+}
+
+/// A control frame carrying only a pressed button edge — alive traffic
+/// that is neither setpoint freshness nor a neutral demonstration.
+pub(crate) fn edge_only_frame(
+    session: SessionId,
+    generation: Generation,
+    sequence: SequenceNum,
+    sampled_at: MonoTimestamp,
+) -> ScopedControlFrame {
+    let mut f = frame(session, generation, sequence, sampled_at);
+    f.payload = ControlPayload {
+        axes: Vec::new(),
+        edges: vec![(LogicalButtonId::new(0), ButtonEdge::Pressed)],
+    };
+    f
 }

--- a/crates/pilotage-session/src/tests/deadline.rs
+++ b/crates/pilotage-session/src/tests/deadline.rs
@@ -1,27 +1,27 @@
-//! Deadline pass-through: `next_deadline` and `handle_tick` delegate to the
-//! embedded authority engine.
+//! Deadline scheduling: `next_deadline` folds the authority engine's offer
+//! expiry together with the holder-silence watchdog.
 //!
 //! The increment-0 [`DomainEnvelope`] set carries no offer/accept handover
 //! messages (ADR-0010 two-phase handover is a later increment), so no offer is
-//! ever pending here: `next_deadline` reflects the authority engine's own
-//! `None`, and a tick produces no actions. These tests pin the delegation so a
-//! future increment that adds offers inherits correct scheduling behavior.
+//! ever pending here; the only deadline a grant creates is the holder-silence
+//! window. These tests pin that scheduling so a future increment that adds
+//! offers inherits correct behavior.
 //!
 //! [`DomainEnvelope`]: crate::DomainEnvelope
 
 use pilotage_timing::MonoTimestamp;
 
 use super::{VEHICLE, engine, motion, welcome};
-use crate::{ClientKey, DomainEnvelope};
+use crate::{ClientKey, DomainEnvelope, SessionConfig};
 
 #[test]
-fn no_pending_offer_means_no_deadline() {
+fn no_holder_and_no_offer_means_no_deadline() {
     let engine = engine();
     assert_eq!(engine.next_deadline(), None);
 }
 
 #[test]
-fn deadline_stays_none_after_a_grant() {
+fn deadline_after_a_grant_is_the_holder_silence_window() {
     let mut engine = engine();
     let client = ClientKey::new(1);
     welcome(&mut engine, client);
@@ -33,8 +33,12 @@ fn deadline_stays_none_after_a_grant() {
         }),
         MonoTimestamp::from_nanos(1),
     );
-    // A direct grant does not open an offer, so there is nothing to expire.
-    assert_eq!(engine.next_deadline(), None);
+    // A direct grant opens no handover offer, but it starts the holder-silence
+    // watchdog, so the next deadline is the grant time plus the silence window.
+    assert_eq!(
+        engine.next_deadline(),
+        Some(MonoTimestamp::from_nanos(1).saturating_add(SessionConfig::DEFAULT_HOLDER_SILENCE)),
+    );
 }
 
 #[test]

--- a/crates/pilotage-session/src/tests/disconnect.rs
+++ b/crates/pilotage-session/src/tests/disconnect.rs
@@ -166,8 +166,22 @@ fn disconnect_dropping_link_lost_broadcasts_is_reported_not_silent() {
         DomainEnvelope::Disconnect,
         MonoTimestamp::from_nanos(5),
     );
-    // The cap truncated the emitted actions...
-    assert_eq!(outcome.actions.len(), cap);
+    // The cap truncated the ordinary actions (broadcasts), while the safety
+    // lane still delivered the vehicle's single link-loss engagement above
+    // the cap — a safety enactment is never droppable behind the broadcast
+    // cap.
+    let engagements = outcome
+        .actions
+        .iter()
+        .filter(|a| matches!(a, SessionAction::EngageLinkLoss { .. }))
+        .count();
+    assert_eq!(engagements, 1, "one engagement per vehicle loss");
+    assert_eq!(
+        outcome.actions.len(),
+        cap + engagements,
+        "ordinary actions stay capped: {:?}",
+        outcome.actions
+    );
     // ...and the truncation is reported, not silent (the finding's contract).
     assert!(
         outcome.dropped > 0,

--- a/crates/pilotage-session/src/tests/recovery.rs
+++ b/crates/pilotage-session/src/tests/recovery.rs
@@ -1,0 +1,394 @@
+//! Recovery activation gate (ADR-0008): after a link-loss policy engages,
+//! a fresh fenced generation alone must not clear it — the new holder must
+//! additionally demonstrate neutral input with an accepted frame, so a
+//! client reconnecting with deflected sticks cannot revive motion. The
+//! engaged policy itself is selected from the vehicle's declared profile.
+
+use core::time::Duration;
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ExecutionMode, LinkLossPolicy, ScopeDescriptor, VehicleDescriptor,
+};
+use pilotage_protocol::{
+    ControlPayload, Generation, LeaseRequest, LogicalAxisId, ScopeId, ScopedControlFrame,
+    SequenceNum, SessionId,
+};
+use pilotage_timing::MonoTimestamp;
+
+use super::{
+    VEHICLE, cleared, edge_only_frame, engaged_neutralize, engine_with_silence, frame, grant,
+    motion, neutral_frame, staleness, welcome,
+};
+use crate::{
+    ClientKey, DomainEnvelope, OutboundMessage, SessionAction, SessionConfig, SessionEngine,
+};
+
+/// An engine whose holder went silent (policy engaged), then re-granted the
+/// scope to the same client at a fresh generation.
+fn engaged_then_regranted() -> (SessionEngine, ClientKey, SessionId, Generation) {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    grant(&mut engine, client, 1); // deadline 101
+    let lost = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(engaged_neutralize(&lost), 1);
+    let generation = grant(&mut engine, client, 200);
+    (engine, client, session, generation)
+}
+
+#[test]
+fn a_grant_alone_does_not_clear_neutralization() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    grant(&mut engine, client, 1); // deadline 101
+    let lost = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(engaged_neutralize(&lost), 1);
+
+    let regrant = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(200),
+    );
+    assert_eq!(
+        cleared(&regrant),
+        0,
+        "a grant alone must not clear link-loss: {:?}",
+        regrant.actions
+    );
+}
+
+#[test]
+fn deflected_or_edge_frames_do_not_activate_recovery() {
+    let (mut engine, client, session, generation) = engaged_then_regranted();
+
+    // Deflected sticks (the shared fixture's 0.25 axis) do not activate.
+    let deflected = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(frame(
+            session,
+            generation,
+            SequenceNum::new(1),
+            MonoTimestamp::from_nanos(210),
+        )),
+        MonoTimestamp::from_nanos(210),
+    );
+    assert_eq!(
+        cleared(&deflected),
+        0,
+        "deflected sticks must not clear link-loss: {:?}",
+        deflected.actions
+    );
+
+    // An edge-only frame is not a neutral demonstration either.
+    let edged = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(edge_only_frame(
+            session,
+            generation,
+            SequenceNum::new(2),
+            MonoTimestamp::from_nanos(220),
+        )),
+        MonoTimestamp::from_nanos(220),
+    );
+    assert_eq!(cleared(&edged), 0, "edges cannot activate recovery");
+}
+
+#[test]
+fn a_neutral_frame_clears_once_and_orders_before_the_apply() {
+    let (mut engine, client, session, generation) = engaged_then_regranted();
+
+    // Demonstrated-neutral sticks clear it, exactly once, with the clear
+    // ordered before the frame's apply so the adapter un-latches first.
+    let neutral = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(neutral_frame(
+            session,
+            generation,
+            SequenceNum::new(3),
+            MonoTimestamp::from_nanos(230),
+        )),
+        MonoTimestamp::from_nanos(230),
+    );
+    assert_eq!(
+        cleared(&neutral),
+        1,
+        "neutral frame clears: {:?}",
+        neutral.actions
+    );
+    let clear_index = neutral
+        .actions
+        .iter()
+        .position(|a| matches!(a, SessionAction::ClearLinkLoss { .. }))
+        .expect("clear present");
+    let apply_index = neutral
+        .actions
+        .iter()
+        .position(|a| matches!(a, SessionAction::ApplyToAdapter { .. }))
+        .expect("apply present");
+    assert!(clear_index < apply_index, "clear must precede the apply");
+
+    // Recovery is complete; further neutral frames do not re-clear.
+    let again = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(neutral_frame(
+            session,
+            generation,
+            SequenceNum::new(4),
+            MonoTimestamp::from_nanos(240),
+        )),
+        MonoTimestamp::from_nanos(240),
+    );
+    assert_eq!(cleared(&again), 0, "recovery already complete");
+}
+
+/// A capability report for one vehicle with the given scopes (each with
+/// its axes) and declared link-loss menu.
+fn profile(
+    scopes: Vec<(&'static str, Vec<u16>)>,
+    actions: Vec<LinkLossPolicy>,
+) -> AdapterCapabilities {
+    AdapterCapabilities {
+        execution: ExecutionMode {
+            real_time: true,
+            deterministic: true,
+            ..ExecutionMode::default()
+        },
+        vehicles: vec![VehicleDescriptor {
+            id: VEHICLE,
+            scopes: scopes
+                .into_iter()
+                .map(|(scope, axes)| ScopeDescriptor {
+                    scope: ScopeId::new(scope),
+                    axes: axes.into_iter().map(LogicalAxisId::new).collect(),
+                })
+                .collect(),
+            link_loss_actions: actions,
+        }],
+        adapter_version: "test".to_owned(),
+    }
+}
+
+/// A control frame for an arbitrary scope with explicit axis values.
+fn scoped_frame(
+    session: SessionId,
+    scope: &str,
+    generation: Generation,
+    sequence: u32,
+    at: u64,
+    axes: Vec<(u16, f32)>,
+) -> ScopedControlFrame {
+    ScopedControlFrame {
+        session,
+        vehicle: VEHICLE,
+        scope: ScopeId::new(scope),
+        generation,
+        sequence: SequenceNum::new(sequence),
+        sampled_at: MonoTimestamp::from_nanos(at),
+        profile_revision: 1,
+        payload: ControlPayload {
+            axes: axes
+                .into_iter()
+                .map(|(axis, value)| (LogicalAxisId::new(axis), value))
+                .collect(),
+            edges: Vec::new(),
+        },
+    }
+}
+
+fn grant_scope(engine: &mut SessionEngine, client: ClientKey, scope: &str, now: u64) -> Generation {
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(LeaseRequest {
+            vehicle: VEHICLE,
+            scope: ScopeId::new(scope),
+        }),
+        MonoTimestamp::from_nanos(now),
+    );
+    match outcome.actions.last() {
+        Some(SessionAction::SendToClient {
+            envelope: OutboundMessage::LeaseResponse(response),
+            ..
+        }) if response.granted => response.generation,
+        other => panic!("expected a granted lease for {scope}, got {other:?}"),
+    }
+}
+
+#[test]
+fn recovery_is_scope_specific_not_vehicle_wide() {
+    // Two scopes on one vehicle, held by different clients. Losing scope
+    // m1 engages the vehicle policy; a neutral frame on the UNRELATED
+    // scope m2 proves nothing about m1 and must not clear it. Only a
+    // fresh grant + neutral demonstration on m1 itself recovers.
+    let mut engine = SessionEngine::new(
+        profile(
+            vec![("vehicle.m1", vec![0]), ("vehicle.m2", vec![0])],
+            vec![LinkLossPolicy::Neutralize],
+        ),
+        staleness(),
+        SessionConfig::new(1, "host-test").with_holder_silence(Duration::from_nanos(100)),
+    );
+    let (c1, c2) = (ClientKey::new(1), ClientKey::new(2));
+    let s1 = welcome(&mut engine, c1);
+    let s2 = welcome(&mut engine, c2);
+    grant_scope(&mut engine, c1, "vehicle.m1", 1); // deadline 101
+    let g2 = grant_scope(&mut engine, c2, "vehicle.m2", 2);
+
+    // m2's holder keeps driving; only m1 goes silent and is lost.
+    let refresh = engine.handle_client_message(
+        c2,
+        DomainEnvelope::Frame(scoped_frame(s2, "vehicle.m2", g2, 1, 95, vec![(0, 0.4)])),
+        MonoTimestamp::from_nanos(95),
+    );
+    assert!(
+        refresh
+            .actions
+            .iter()
+            .any(|a| matches!(a, SessionAction::ApplyToAdapter { .. })),
+        "m2 frame accepted: {:?}",
+        refresh.actions
+    );
+    let lost = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(engaged_neutralize(&lost), 1, "m1 loss engages the vehicle");
+
+    // A neutral frame on m2 must NOT clear the m1 engagement.
+    let unrelated = engine.handle_client_message(
+        c2,
+        DomainEnvelope::Frame(scoped_frame(s2, "vehicle.m2", g2, 2, 120, vec![(0, 0.0)])),
+        MonoTimestamp::from_nanos(120),
+    );
+    assert_eq!(
+        cleared(&unrelated),
+        0,
+        "an unrelated scope cannot activate recovery: {:?}",
+        unrelated.actions
+    );
+
+    // Recovery on m1 itself: fresh grant, then a neutral m1 frame.
+    let g1 = grant_scope(&mut engine, c1, "vehicle.m1", 200);
+    let neutral = engine.handle_client_message(
+        c1,
+        DomainEnvelope::Frame(scoped_frame(s1, "vehicle.m1", g1, 3, 210, vec![(0, 0.0)])),
+        MonoTimestamp::from_nanos(210),
+    );
+    assert_eq!(
+        cleared(&neutral),
+        1,
+        "m1 recovery clears: {:?}",
+        neutral.actions
+    );
+}
+
+#[test]
+fn partial_axis_coverage_cannot_activate_recovery() {
+    // The scope declares two axes; adapters retain latest-valid values per
+    // axis, so a frame omitting one axis could un-latch straight into a
+    // stale deflection. Activation requires EVERY declared axis reported
+    // neutral.
+    let mut engine = SessionEngine::new(
+        profile(
+            vec![("vehicle.m1", vec![0, 1])],
+            vec![LinkLossPolicy::Neutralize],
+        ),
+        staleness(),
+        SessionConfig::new(1, "host-test").with_holder_silence(Duration::from_nanos(100)),
+    );
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    grant_scope(&mut engine, client, "vehicle.m1", 1);
+    let lost = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(engaged_neutralize(&lost), 1);
+    let generation = grant_scope(&mut engine, client, "vehicle.m1", 200);
+
+    // Only axis 0 reported neutral: axis 1's stale value could revive.
+    let partial = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(scoped_frame(
+            session,
+            "vehicle.m1",
+            generation,
+            1,
+            210,
+            vec![(0, 0.0)],
+        )),
+        MonoTimestamp::from_nanos(210),
+    );
+    assert_eq!(
+        cleared(&partial),
+        0,
+        "partial axis coverage must not clear: {:?}",
+        partial.actions
+    );
+
+    // Full declared coverage, all neutral: recovery completes.
+    let full = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(scoped_frame(
+            session,
+            "vehicle.m1",
+            generation,
+            2,
+            220,
+            vec![(0, 0.0), (1, 0.0)],
+        )),
+        MonoTimestamp::from_nanos(220),
+    );
+    assert_eq!(
+        cleared(&full),
+        1,
+        "full coverage clears: {:?}",
+        full.actions
+    );
+}
+
+#[test]
+fn the_enacted_policy_is_configured_and_validated_never_order_based() {
+    let cases: [(Vec<LinkLossPolicy>, Option<LinkLossPolicy>, LinkLossPolicy); 3] = [
+        // Unconfigured: the floor, even when the menu declares only
+        // another action — declaration order is a menu, not a selection.
+        (
+            vec![LinkLossPolicy::HoldBrief { ticks: 7 }],
+            None,
+            LinkLossPolicy::Neutralize,
+        ),
+        // Configured and declared: the configured policy is enacted.
+        (
+            vec![
+                LinkLossPolicy::Neutralize,
+                LinkLossPolicy::HoldBrief { ticks: 7 },
+            ],
+            Some(LinkLossPolicy::HoldBrief { ticks: 7 }),
+            LinkLossPolicy::HoldBrief { ticks: 7 },
+        ),
+        // Configured but NOT declared: falls closed to the floor.
+        (
+            vec![LinkLossPolicy::Neutralize],
+            Some(LinkLossPolicy::Brake),
+            LinkLossPolicy::Neutralize,
+        ),
+    ];
+    for (declared, configured, expected) in cases {
+        let mut config =
+            SessionConfig::new(1, "host-test").with_holder_silence(Duration::from_nanos(100));
+        if let Some(policy) = configured {
+            config = config.with_link_loss_policy(VEHICLE, policy);
+        }
+        let mut engine = SessionEngine::new(
+            profile(vec![("vehicle.motion", vec![0])], declared),
+            staleness(),
+            config,
+        );
+        let client = ClientKey::new(1);
+        welcome(&mut engine, client);
+        grant(&mut engine, client, 1);
+        let fired = engine.handle_tick(MonoTimestamp::from_nanos(101));
+        let policy = fired.actions.iter().find_map(|action| match action {
+            SessionAction::EngageLinkLoss { policy, .. } => Some(*policy),
+            _ => None,
+        });
+        assert_eq!(policy, Some(expected), "configured {configured:?}");
+    }
+}

--- a/crates/pilotage-session/src/tests/release.rs
+++ b/crates/pilotage-session/src/tests/release.rs
@@ -1,0 +1,134 @@
+//! Voluntary lease release (ADR-0006): a holder relinquishes a scope
+//! explicitly — the generation advances (stragglers are fenced), the
+//! vehicle's link-loss policy engages exactly as for an involuntary loss,
+//! and the sender gets a typed acknowledgement, so an immediate re-grant
+//! never races the silence watchdog into `AlreadyHeld`.
+
+use core::time::Duration;
+
+use pilotage_protocol::{LeaseRelease, SequenceNum};
+use pilotage_timing::MonoTimestamp;
+
+use super::{
+    VEHICLE, cleared, engaged_neutralize, engine_with_silence, frame, grant, motion, neutral_frame,
+    welcome,
+};
+use crate::{ClientKey, DomainEnvelope, OutboundMessage, SessionAction, SessionOutcome};
+
+fn release_ack(outcome: &SessionOutcome) -> Option<(bool, u64)> {
+    outcome.actions.iter().find_map(|action| match action {
+        SessionAction::SendToClient {
+            envelope: OutboundMessage::LeaseReleased(ack),
+            ..
+        } => Some((ack.released, ack.generation.as_u64())),
+        _ => None,
+    })
+}
+
+fn release_envelope() -> DomainEnvelope {
+    DomainEnvelope::Release(LeaseRelease {
+        vehicle: VEHICLE,
+        scope: motion(),
+    })
+}
+
+#[test]
+fn a_holder_release_is_acknowledged_fenced_and_neutralized() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    let generation = grant(&mut engine, client, 1);
+
+    let outcome =
+        engine.handle_client_message(client, release_envelope(), MonoTimestamp::from_nanos(10));
+    let (released, ack_generation) = release_ack(&outcome).expect("acknowledgement sent");
+    assert!(released, "the holder's release succeeds");
+    assert!(
+        ack_generation > generation.as_u64(),
+        "the acknowledged generation is the advanced fence"
+    );
+    assert_eq!(
+        engaged_neutralize(&outcome),
+        1,
+        "a voluntary release still neutralizes: {:?}",
+        outcome.actions
+    );
+
+    // A straggler frame at the pre-release generation is fenced.
+    let late = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(frame(
+            session,
+            generation,
+            SequenceNum::new(5),
+            MonoTimestamp::from_nanos(20),
+        )),
+        MonoTimestamp::from_nanos(20),
+    );
+    assert!(
+        !late
+            .actions
+            .iter()
+            .any(|a| matches!(a, SessionAction::ApplyToAdapter { .. })),
+        "a straggler after release must be fenced: {:?}",
+        late.actions
+    );
+}
+
+#[test]
+fn a_non_holder_release_is_acknowledged_as_a_no_op() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let holder = ClientKey::new(1);
+    let bystander = ClientKey::new(2);
+    welcome(&mut engine, holder);
+    welcome(&mut engine, bystander);
+    grant(&mut engine, holder, 1);
+
+    let outcome =
+        engine.handle_client_message(bystander, release_envelope(), MonoTimestamp::from_nanos(10));
+    let (released, _) = release_ack(&outcome).expect("acknowledgement sent");
+    assert!(!released, "a bystander releases nothing");
+    assert_eq!(
+        engaged_neutralize(&outcome),
+        0,
+        "nothing was lost, nothing engages: {:?}",
+        outcome.actions
+    );
+}
+
+#[test]
+fn release_then_immediate_regrant_never_races_already_held() {
+    // The AlreadyHeld race the explicit release exists to close: with only
+    // the silence watchdog, a client reconnecting faster than the window
+    // finds its old self still holding the scope. After an acknowledged
+    // release the scope is free IMMEDIATELY.
+    let mut engine = engine_with_silence(Duration::from_secs(1));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    grant(&mut engine, client, 1);
+
+    let released =
+        engine.handle_client_message(client, release_envelope(), MonoTimestamp::from_nanos(10));
+    assert_eq!(release_ack(&released).map(|(ok, _)| ok), Some(true));
+
+    // Re-grant in the very next message — no watchdog wait, no AlreadyHeld.
+    let regrant_generation = grant(&mut engine, client, 20);
+
+    // The engaged policy still clears only through the activation frame.
+    let neutral = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(neutral_frame(
+            session,
+            regrant_generation,
+            SequenceNum::new(1),
+            MonoTimestamp::from_nanos(30),
+        )),
+        MonoTimestamp::from_nanos(30),
+    );
+    assert_eq!(
+        cleared(&neutral),
+        1,
+        "recovery completes under the fresh grant: {:?}",
+        neutral.actions
+    );
+}

--- a/crates/pilotage-session/src/tests/watchdog.rs
+++ b/crates/pilotage-session/src/tests/watchdog.rs
@@ -1,0 +1,245 @@
+//! Holder-liveness watchdog and link-loss neutralization (ADR-0006, ADR-0008,
+//! ADR-0010): a holder that stops sending axis-bearing frames while its
+//! connection stays open is released and the vehicle is neutralized, the
+//! engagement is never droppable behind the action cap, and straggler frames
+//! are fenced. Recovery/activation behavior lives in the `recovery` sibling.
+
+use core::time::Duration;
+
+use pilotage_protocol::{LeaseRequest, SequenceNum};
+use pilotage_timing::MonoTimestamp;
+
+use super::{
+    VEHICLE, edge_only_frame, engage_trigger, engaged_neutralize, engine_with_silence, frame,
+    grant, link_lost, motion, staleness, welcome,
+};
+use crate::{
+    ClientKey, DomainEnvelope, LinkLossTrigger, SessionAction, SessionConfig, SessionEngine,
+};
+
+#[test]
+fn a_silent_holder_is_released_and_neutralized_after_the_deadline() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    grant(&mut engine, client, 1); // deadline = 1 + 100 = 101
+
+    // A tick before the deadline neither releases nor neutralizes.
+    let early = engine.handle_tick(MonoTimestamp::from_nanos(50));
+    assert!(!link_lost(&early), "not silent yet: {:?}", early.actions);
+    assert_eq!(engaged_neutralize(&early), 0);
+
+    // A tick at the deadline releases the holder and neutralizes once.
+    let fired = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert!(
+        link_lost(&fired),
+        "expected HolderLinkLost: {:?}",
+        fired.actions
+    );
+    assert_eq!(
+        engaged_neutralize(&fired),
+        1,
+        "expected exactly one Neutralize: {:?}",
+        fired.actions
+    );
+    assert_eq!(engage_trigger(&fired), Some(LinkLossTrigger::HolderSilence));
+}
+
+#[test]
+fn an_active_holder_is_never_expired() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    let generation = grant(&mut engine, client, 1); // deadline 101
+
+    // A fresh, accepted frame at t=90 refreshes the deadline to 190.
+    let applied = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(frame(
+            session,
+            generation,
+            SequenceNum::new(1),
+            MonoTimestamp::from_nanos(90),
+        )),
+        MonoTimestamp::from_nanos(90),
+    );
+    assert!(
+        applied
+            .actions
+            .iter()
+            .any(|a| matches!(a, SessionAction::ApplyToAdapter { .. })),
+        "frame should be accepted: {:?}",
+        applied.actions
+    );
+
+    // A tick past the ORIGINAL deadline but before the refreshed one does not
+    // fire — the holder is actively driving.
+    let tick = engine.handle_tick(MonoTimestamp::from_nanos(150));
+    assert!(
+        !link_lost(&tick),
+        "active holder must survive: {:?}",
+        tick.actions
+    );
+    assert_eq!(engaged_neutralize(&tick), 0);
+}
+
+#[test]
+fn next_deadline_reflects_the_holder_silence_window() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    grant(&mut engine, client, 1);
+    assert_eq!(engine.next_deadline(), Some(MonoTimestamp::from_nanos(101)));
+}
+
+#[test]
+fn a_disconnect_neutralizes_the_vehicle() {
+    // Releasing the lease alone would leave the adapter holding its last
+    // command; a disconnect must engage Neutralize, with disconnect
+    // provenance on the action.
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    grant(&mut engine, client, 1);
+    let outcome = engine.handle_client_message(
+        client,
+        DomainEnvelope::Disconnect,
+        MonoTimestamp::from_nanos(5),
+    );
+    assert_eq!(
+        engaged_neutralize(&outcome),
+        1,
+        "disconnect must neutralize once: {:?}",
+        outcome.actions
+    );
+    assert_eq!(
+        engage_trigger(&outcome),
+        Some(LinkLossTrigger::HolderDisconnect)
+    );
+}
+
+#[test]
+fn neutralize_is_engaged_exactly_once_per_loss() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    grant(&mut engine, client, 1); // deadline 101
+
+    let first = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(engaged_neutralize(&first), 1);
+
+    // The holder is gone; a later tick must not re-engage (no re-transmit).
+    let second = engine.handle_tick(MonoTimestamp::from_nanos(500));
+    assert_eq!(
+        engaged_neutralize(&second),
+        0,
+        "a released holder must not neutralize again: {:?}",
+        second.actions
+    );
+}
+
+#[test]
+fn edge_only_frames_do_not_refresh_the_silence_deadline() {
+    // Discrete traffic proves the client is alive, not that it is
+    // commanding the vehicle: a holder sending only button edges past the
+    // silence window is still judged link-lost.
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    let generation = grant(&mut engine, client, 1); // deadline 101
+
+    let edged = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(edge_only_frame(
+            session,
+            generation,
+            SequenceNum::new(1),
+            MonoTimestamp::from_nanos(90),
+        )),
+        MonoTimestamp::from_nanos(90),
+    );
+    assert!(
+        edged
+            .actions
+            .iter()
+            .any(|a| matches!(a, SessionAction::ApplyToAdapter { .. })),
+        "the edge frame itself is accepted: {:?}",
+        edged.actions
+    );
+
+    // Past the original deadline the holder expires — the edge-only frame
+    // did not extend setpoint freshness.
+    let tick = engine.handle_tick(MonoTimestamp::from_nanos(150));
+    assert!(
+        link_lost(&tick),
+        "edge-only traffic must not hold the lease open: {:?}",
+        tick.actions
+    );
+    assert_eq!(engaged_neutralize(&tick), 1);
+}
+
+#[test]
+fn neutralization_is_never_dropped_at_the_action_cap() {
+    // A cap of one means the expiry tick's authority broadcast fills the
+    // whole per-call budget; the safety lane must still deliver the
+    // engagement (fail-closed, never dropped behind the cap).
+    let mut engine = SessionEngine::new(
+        super::capabilities(),
+        staleness(),
+        SessionConfig::new(1, "host-test")
+            .with_holder_silence(Duration::from_nanos(100))
+            .with_max_actions_per_call(1),
+    );
+    let client = ClientKey::new(1);
+    welcome(&mut engine, client);
+    // The lease response may be dropped at the cap; the grant itself is
+    // engine state, proven by the armed watchdog deadline.
+    let granted = engine.handle_client_message(
+        client,
+        DomainEnvelope::Lease(LeaseRequest {
+            vehicle: VEHICLE,
+            scope: motion(),
+        }),
+        MonoTimestamp::from_nanos(1),
+    );
+    assert!(granted.dropped > 0, "cap of one must drop the response");
+    assert_eq!(engine.next_deadline(), Some(MonoTimestamp::from_nanos(101)));
+
+    let fired = engine.handle_tick(MonoTimestamp::from_nanos(101));
+    assert_eq!(
+        engaged_neutralize(&fired),
+        1,
+        "the engagement must survive the cap: {:?}",
+        fired.actions
+    );
+}
+
+#[test]
+fn a_straggler_frame_after_expiry_is_fenced_not_applied() {
+    let mut engine = engine_with_silence(Duration::from_nanos(100));
+    let client = ClientKey::new(1);
+    let session = welcome(&mut engine, client);
+    let generation = grant(&mut engine, client, 1); // deadline 101
+
+    let _released = engine.handle_tick(MonoTimestamp::from_nanos(101)); // advances generation
+
+    // A late frame at the pre-loss generation cannot drive the vehicle.
+    let late = engine.handle_client_message(
+        client,
+        DomainEnvelope::Frame(frame(
+            session,
+            generation,
+            SequenceNum::new(9),
+            MonoTimestamp::from_nanos(120),
+        )),
+        MonoTimestamp::from_nanos(120),
+    );
+    assert!(
+        !late
+            .actions
+            .iter()
+            .any(|a| matches!(a, SessionAction::ApplyToAdapter { .. })),
+        "a straggler after link loss must be fenced: {:?}",
+        late.actions
+    );
+}

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -22,6 +22,11 @@ use crate::runtime::wire_codec::{
 mod telemetry;
 use telemetry::sample_to_wire;
 
+#[cfg(test)]
+mod tests;
+
+mod link_loss;
+
 /// Capacity of the [`EngineActor`]'s inbound command queue.
 ///
 /// Bounded per ADR-0009's discipline: a lagging engine actor is a
@@ -112,6 +117,11 @@ pub struct EngineActor<A: VehicleAdapter> {
     clients: ClientRegistry,
     latency: BoundedLatencyLog<LATENCY_LOG_CAPACITY>,
     drops: DropCounters,
+    /// Wrapping count of link-loss policy changes the adapter failed to
+    /// enact. A non-zero value is a fail-closed fault, not noise: authority
+    /// was already fenced, so an unenacted policy means the vehicle may
+    /// still be executing its last command with nobody in control.
+    link_loss_enact_failures: u64,
     /// The single monotonic origin shared with every connection task's
     /// client-message stamps (ADR-0009: one `host_time` reference domain).
     /// Passed in rather than sampled here so tick-driven timestamps and
@@ -135,6 +145,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
             clients: ClientRegistry::new(),
             latency: BoundedLatencyLog::new(),
             drops: DropCounters::default(),
+            link_loss_enact_failures: 0,
             start,
         }
     }
@@ -273,6 +284,10 @@ impl<A: VehicleAdapter> EngineActor<A> {
                 let outcome = self.adapter.apply_control(&frame);
                 self.record_stage(Stage::Apply, apply_start.elapsed());
                 debug!(?outcome, "control frame applied to adapter");
+            }
+            action @ (SessionAction::EngageLinkLoss { .. }
+            | SessionAction::ClearLinkLoss { .. }) => {
+                self.enact_link_loss(action);
             }
         }
     }
@@ -450,7 +465,8 @@ fn to_connection_message(envelope: &pilotage_session::OutboundMessage) -> ToConn
             ToConnection::AuthorityMessage(encode_envelope_message(envelope))
         }
         pilotage_session::OutboundMessage::Welcome(_)
-        | pilotage_session::OutboundMessage::LeaseResponse(_) => {
+        | pilotage_session::OutboundMessage::LeaseResponse(_)
+        | pilotage_session::OutboundMessage::LeaseReleased(_) => {
             ToConnection::BootstrapMessage(encode_envelope_message(envelope))
         }
     }

--- a/hosts/session-host/src/runtime/engine_actor/link_loss.rs
+++ b/hosts/session-host/src/runtime/engine_actor/link_loss.rs
@@ -1,0 +1,82 @@
+//! Link-loss policy enactment on the live adapter (ADR-0008, ADR-0010): the
+//! actor drives engage/clear to `VehicleAdapter::set_link_loss_policy` and
+//! counts a refused enactment as a typed fail-closed fault, never a silent
+//! no-op — authority is already fenced when these actions arrive, so an
+//! unenacted policy means the vehicle may still be executing its last
+//! command with nobody in control.
+
+use pilotage_adapter_api::{LinkLossPolicy, VehicleAdapter};
+use pilotage_protocol::VehicleId;
+use pilotage_session::SessionAction;
+use tracing::{debug, error, warn};
+
+use super::EngineActor;
+
+impl<A: VehicleAdapter> EngineActor<A> {
+    /// Enacts one `EngageLinkLoss` / `ClearLinkLoss` action on the adapter.
+    pub(super) fn enact_link_loss(&mut self, action: SessionAction) {
+        match action {
+            SessionAction::EngageLinkLoss {
+                vehicle,
+                scope,
+                generation,
+                trigger,
+                policy,
+            } => {
+                // The holder was lost; the generation already advanced, so
+                // this drives the vehicle to its declared policy state once.
+                // The host does not re-transmit.
+                warn!(
+                    vehicle = vehicle.as_u64(),
+                    scope = scope.as_str(),
+                    generation = generation.as_u64(),
+                    ?trigger,
+                    ?policy,
+                    "holder lost; engaging link-loss policy"
+                );
+                self.set_policy_counting_failure(
+                    vehicle,
+                    Some(policy),
+                    "FAIL-CLOSED FAULT: link-loss policy was not enacted; \
+                     the vehicle may still be executing its last command",
+                );
+            }
+            SessionAction::ClearLinkLoss { vehicle } => {
+                // The recovery conditions held (fresh generation + activation
+                // frame); return the vehicle to normal control (ADR-0008's
+                // only path back). A failed clear leaves the vehicle
+                // neutralized — safe but stuck; counted the same way.
+                debug!(
+                    vehicle = vehicle.as_u64(),
+                    "recovery conditions met; clearing link-loss policy"
+                );
+                self.set_policy_counting_failure(
+                    vehicle,
+                    None,
+                    "link-loss policy clear failed; vehicle remains neutralized",
+                );
+            }
+            _ => {}
+        }
+    }
+
+    /// Drives a link-loss policy change to the adapter, counting and
+    /// surfacing a refused enactment as a typed fault (never silent).
+    fn set_policy_counting_failure(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+        fault: &str,
+    ) {
+        if let Err(error) = self.adapter.set_link_loss_policy(vehicle, policy) {
+            self.link_loss_enact_failures = self.link_loss_enact_failures.wrapping_add(1);
+            error!(
+                vehicle = vehicle.as_u64(),
+                ?policy,
+                %error,
+                failures = self.link_loss_enact_failures,
+                fault,
+            );
+        }
+    }
+}

--- a/hosts/session-host/src/runtime/engine_actor/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests.rs
@@ -1,0 +1,153 @@
+//! The engine actor must actually enact link-loss actions on the adapter —
+//! releasing a lease without calling `set_link_loss_policy` would leave the
+//! vehicle on its last command (ADR-0008) — and a failed enactment is a
+//! counted fail-closed fault, never a silent no-op.
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossEnactError,
+    LinkLossPolicy, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch, VehicleAdapter,
+    VehicleDescriptor, VideoSource,
+};
+use pilotage_protocol::{Generation, LogicalAxisId, ScopeId, ScopedControlFrame, VehicleId};
+use pilotage_session::{
+    LinkLossTrigger, SessionAction, SessionConfig, SessionEngine, SessionOutcome,
+};
+use pilotage_timing::{SimTick, StalenessPolicy};
+use tokio::time::Instant;
+
+use super::EngineActor;
+
+const VEHICLE: VehicleId = VehicleId::new(1);
+
+fn capabilities() -> AdapterCapabilities {
+    AdapterCapabilities {
+        execution: ExecutionMode {
+            real_time: true,
+            deterministic: true,
+            ..ExecutionMode::default()
+        },
+        vehicles: vec![VehicleDescriptor {
+            id: VEHICLE,
+            scopes: vec![ScopeDescriptor {
+                scope: ScopeId::new("vehicle.motion"),
+                axes: vec![LogicalAxisId::new(0)],
+            }],
+            link_loss_actions: vec![LinkLossPolicy::Neutralize],
+        }],
+        adapter_version: "test".to_owned(),
+    }
+}
+
+/// A vehicle adapter that records only its `set_link_loss_policy` calls; every
+/// other trait method is an inert stub, since the enactment path under test
+/// touches only the link-loss policy. With `fail_enactment` set it refuses
+/// every policy change, exercising the fail-closed fault path.
+#[derive(Default)]
+struct RecordingAdapter {
+    link_loss_calls: Vec<(VehicleId, Option<LinkLossPolicy>)>,
+    fail_enactment: bool,
+}
+
+impl VehicleAdapter for RecordingAdapter {
+    fn capabilities(&self) -> AdapterCapabilities {
+        capabilities()
+    }
+
+    fn apply_control(&mut self, _frame: &ScopedControlFrame) -> ApplyOutcome {
+        ApplyOutcome {
+            tick: SimTick::new(0),
+            disposition: Disposition::Accepted,
+        }
+    }
+
+    fn sample_telemetry(&mut self) -> TelemetryBatch {
+        TelemetryBatch {
+            samples: Vec::new(),
+        }
+    }
+
+    fn video_sources(&self) -> Vec<VideoSource> {
+        Vec::new()
+    }
+
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), LinkLossEnactError> {
+        self.link_loss_calls.push((vehicle, policy));
+        if self.fail_enactment {
+            return Err(LinkLossEnactError::NoActuationChannel);
+        }
+        Ok(())
+    }
+
+    fn step(&mut self, _budget: StepBudget) -> StepOutcome {
+        StepOutcome {
+            advanced: 0,
+            now: SimTick::new(0),
+        }
+    }
+}
+
+fn actor() -> EngineActor<RecordingAdapter> {
+    let engine = SessionEngine::new(
+        capabilities(),
+        StalenessPolicy::new(std::time::Duration::from_millis(250)),
+        SessionConfig::new(1, "host-test"),
+    );
+    EngineActor::new(engine, RecordingAdapter::default(), Instant::now())
+}
+
+fn engage_action() -> SessionAction {
+    SessionAction::EngageLinkLoss {
+        vehicle: VEHICLE,
+        scope: ScopeId::new("vehicle.motion"),
+        generation: Generation::new(2),
+        trigger: LinkLossTrigger::HolderSilence,
+        policy: LinkLossPolicy::Neutralize,
+    }
+}
+
+#[test]
+fn engage_link_loss_neutralizes_the_adapter() {
+    let mut actor = actor();
+    actor.enact(SessionOutcome {
+        actions: vec![engage_action()],
+        dropped: 0,
+    });
+    assert_eq!(
+        actor.adapter.link_loss_calls,
+        vec![(VEHICLE, Some(LinkLossPolicy::Neutralize))],
+        "EngageLinkLoss must call set_link_loss_policy(Some(Neutralize))"
+    );
+    assert_eq!(actor.link_loss_enact_failures, 0);
+}
+
+#[test]
+fn a_failed_enactment_is_a_counted_fault() {
+    let mut actor = actor();
+    actor.adapter.fail_enactment = true;
+    actor.enact(SessionOutcome {
+        actions: vec![engage_action()],
+        dropped: 0,
+    });
+    assert_eq!(
+        actor.link_loss_enact_failures, 1,
+        "a refused policy change must be counted, never silent"
+    );
+}
+
+#[test]
+fn clear_link_loss_returns_the_adapter_to_normal_control() {
+    let mut actor = actor();
+    actor.enact(SessionOutcome {
+        actions: vec![SessionAction::ClearLinkLoss { vehicle: VEHICLE }],
+        dropped: 0,
+    });
+    assert_eq!(
+        actor.adapter.link_loss_calls,
+        vec![(VEHICLE, None)],
+        "ClearLinkLoss must call set_link_loss_policy(None)"
+    );
+}

--- a/hosts/session-host/src/runtime/wire_codec.rs
+++ b/hosts/session-host/src/runtime/wire_codec.rs
@@ -97,9 +97,9 @@ pub enum BootstrapDecodeError {
 /// Decodes one length-delimited envelope from the front of `bytes` into a
 /// client-origin [`DomainEnvelope`] plus the unconsumed remainder.
 ///
-/// Only `ClientHello` and `LeaseRequest` are legitimately received on the
-/// bootstrap stream (ADR-0005): control frames and `Ping` travel as
-/// datagrams instead.
+/// Only `ClientHello`, `LeaseRequest`, and `LeaseRelease` are legitimately
+/// received on the bootstrap stream (ADR-0005): control frames and `Ping`
+/// travel as datagrams instead.
 ///
 /// # Errors
 ///
@@ -123,6 +123,9 @@ pub fn decode_bootstrap_message(
         Some(wire::envelope::Payload::LeaseRequest(request)) => {
             DomainEnvelope::Lease(LeaseRequest::try_from(request).map_err(DecodeError::from)?)
         }
+        Some(wire::envelope::Payload::LeaseRelease(release)) => DomainEnvelope::Release(
+            pilotage_protocol::LeaseRelease::try_from(release).map_err(DecodeError::from)?,
+        ),
         _ => return Err(BootstrapDecodeError::UnexpectedPayload),
     };
     Ok((domain, rest))
@@ -176,6 +179,9 @@ pub fn encode_envelope_message(message: &OutboundMessage) -> Vec<u8> {
         OutboundMessage::Welcome(welcome) => wire::envelope::Payload::ServerWelcome(welcome.into()),
         OutboundMessage::LeaseResponse(response) => {
             wire::envelope::Payload::LeaseResponse(response.into())
+        }
+        OutboundMessage::LeaseReleased(released) => {
+            wire::envelope::Payload::LeaseReleased(released.into())
         }
         OutboundMessage::Pong(pong) => wire::envelope::Payload::Pong(pong.into()),
         OutboundMessage::Authority(effect) => {

--- a/schemas/pilotage/v1/envelope.proto
+++ b/schemas/pilotage/v1/envelope.proto
@@ -30,5 +30,7 @@ message Envelope {
     Ping ping = 10;
     Pong pong = 11;
     FrameRejected frame_rejected = 12;
+    LeaseRelease lease_release = 13;
+    LeaseReleased lease_released = 14;
   }
 }

--- a/schemas/pilotage/v1/session.proto
+++ b/schemas/pilotage/v1/session.proto
@@ -80,6 +80,29 @@ message LeaseResponse {
   LeaseDenialReason reason = 5;
 }
 
+// A holder voluntarily relinquishes a control scope — the viewer latched
+// input loss (window blur froze its input sources), or any client choosing
+// to stand down. Routed through the authority engine's release path: the
+// generation advances (stragglers are fenced) and the vehicle's link-loss
+// policy engages, exactly as for an involuntary loss. Sent on the reliable
+// bootstrap stream, never as a droppable datagram.
+message LeaseRelease {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+}
+
+// The host's acknowledgement of a `LeaseRelease`: the client may treat its
+// authority as relinquished the moment this arrives (the host silence
+// watchdog remains the independent backup if it never does).
+message LeaseReleased {
+  VehicleId vehicle = 1;
+  ScopeId scope = 2;
+  // False when the sender did not hold the scope (nothing was released).
+  bool released = 3;
+  // The fencing generation now in force.
+  Generation generation = 4;
+}
+
 // An RTT/offset probe carrying the sender's local transport-time sample.
 // `nonce` correlates a `Ping` with its `Pong`; it carries no ordering or
 // uniqueness guarantee beyond what the sender chooses.


### PR DESCRIPTION
Refs #138, #140 (both stay open — multi-vehicle deadline configuration, wraparound sweeps, and stable evidence-ID coverage remain there). Host-side half of the #137 split; provides the wire capability #143 consumes.

## Watchdog
Releases any holder whose frame-silence deadline passes while connected; only accepted **axis-bearing** frames refresh setpoint freshness. Slot-based tracker with exact capacity, in-place refresh via borrowed keys, reusable expiry scratch — allocation-free after configuration on the hot paths.

## Fail-closed enactment
- `EngageLinkLoss` rides an uncapped safety lane (never droppable behind the broadcast cap; once per vehicle loss) and carries scope, fencing generation, trigger provenance, and the enacted policy.
- **The policy is configured, not inferred**: `link_loss_actions` is a menu whose order carries no meaning; `SessionConfig::with_link_loss_policy` selects per vehicle, validated against the menu; undeclared or unconfigured falls closed to Neutralize.
- `set_link_loss_policy` returns a typed result the actor counts on refusal — and **Aviate claims success only for a datagram its socket accepted**: a refused neutral send surfaces as `ChannelRejected` via the uplink send-failure counter, with the control latch engaged either way.

## Scope-specific, axis-complete recovery
Each lost scope is tracked individually: a neutral frame on an **unrelated scope proves nothing**, and activation requires **every axis the scope declares** reported inside the deadband (adapters retain latest-valid values per axis, so a partial frame would un-latch straight into a stale deflection), no pressed edges. `ClearLinkLoss` fires only when the vehicle's **last** engaged scope recovers, ordered before the activating frame's apply. All three adapters latch (`LinkLossEngaged`) while engaged.

## Explicit release (host side of CTRL-04 / #147)
`LeaseRelease`/`LeaseReleased` on the wire; `on_release` routes through the authority engine's release path — generation advances, stragglers fence, policy engages exactly as involuntary loss — and acknowledges the sender, so an immediate re-grant never races `AlreadyHeld`. The watchdog stays the independent backup.

## Round-5 amendment: stale hold never survives link loss

`FlightUplink` retained its captured position-hold point across a link loss; after recovery, the first centered frame would stream a PositionHold at the **obsolete** point — commanding the vehicle back to wherever it was before the loss, however far it drifted while neutralized. Both link-loss transitions (engage AND clear) now invalidate the hold context (`clear_hold_state`). Guardrails in `adapter/tests/link_loss_enact.rs`: the invalidation contract on both transitions, and a full behavioral flight — hold captured at (10,20), link lost, vehicle drifts to (50,60), recovery — proving the post-recovery hold is at the drifted position, never the old one.

## Guardrails (sans-IO, fake time)
Watchdog windows + provenance; edge-only no-refresh; cap-of-one survival; grant-alone no-clear; **unrelated-scope and partial-axis activation refusals; last-scope-clears**; configured-policy validation (unconfigured floor / configured+declared / configured-undeclared floor); **holder release ack + fence + neutralize; non-holder release no-op ack; release-then-regrant without AlreadyHeld**; actor failure counting; **aviate refused-send / sent-ok enactment**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)