### PR TITLE
Viewer: auto-reconnect the transport without resuming control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,12 @@ jobs:
       - name: viewer incoming-uni-stream accept-loop lifecycle (stream isolation + terminal collection)
         run: node clients/web/uni-stream-accept.test.mjs
 
+      - name: viewer bootstrap reader (no LeaseRequest on auto-reconnect, pre-welcome rejection signal)
+        run: node clients/web/bootstrap.test.mjs
+
+      - name: viewer connection auto-recovery lifecycle (backoff/jitter, classification, control-suspended)
+        run: node clients/web/reconnect.test.mjs
+
       - name: wasm wire-decode conformance (REN)
         # The wasm exports the viewer decodes with must agree with the JS
         # reference decoders on layout, numeric kinds, and the capture-identity

--- a/clients/web/bootstrap.js
+++ b/clients/web/bootstrap.js
@@ -1,0 +1,81 @@
+// The bootstrap reader: consumes the length-delimited handshake stream until
+// the session is established, with the lease decision made HERE — the one
+// place a LeaseRequest can be emitted — so "an auto-reconnect never
+// re-requests motion authority" is a property of the real reader loop, not
+// of a flag some caller promises to pass.
+//
+// Side-effect free by construction: the stream, the envelope decoder, the
+// liveness check, and the lease send are all injected, so the loop is
+// testable against fakes while main.js runs it against the real transport.
+
+/** Reads bootstrap frames until the session is established.
+ *
+ * With `requestLease` it sends a `LeaseRequest` on `ServerWelcome` and
+ * completes on `LeaseResponse` (the control path); without it, bootstrap
+ * completes at `ServerWelcome` and no lease is requested, so the session is
+ * telemetry/video only.
+ *
+ * Returns `{ completed, welcomed }`. `welcomed` distinguishes where an
+ * incomplete bootstrap ended (before or after `ServerWelcome`) — useful
+ * telemetry, but NOT a rejection signal: an untyped stream end is
+ * retryable wherever it lands, because the host's close carries no wire
+ * payload and a pre-welcome EOF is indistinguishable from an early
+ * network blip. Only a future typed protocol rejection may classify as
+ * non-retryable (#146).
+ *
+ * @param {object} deps
+ * @param {{ read: () => Promise<{value?: Uint8Array, done: boolean}> }} deps.reader
+ *   the bootstrap stream reader
+ * @param {(bytes: Uint8Array) => ({kind: string, consumed: number} | null)} deps.decode
+ *   length-delimited envelope decoder; null means "need more bytes"
+ * @param {() => boolean} deps.isActive superseded sessions stop reading
+ * @param {(decoded: object) => void} deps.onMessage decoded-frame sink
+ * @param {boolean} deps.requestLease request motion authority (manual connect)
+ * @param {() => Promise<boolean>} deps.sendLeaseRequest writes the
+ *   `LeaseRequest`; false means the session was superseded mid-send
+ */
+export async function runBootstrapReader({
+  reader,
+  decode,
+  isActive,
+  onMessage,
+  requestLease,
+  sendLeaseRequest,
+}) {
+  let pending = new Uint8Array(0);
+  let welcomed = false;
+  let sentLease = false;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (!isActive()) return { completed: false, welcomed };
+    if (done) return { completed: false, welcomed };
+    pending = appendBytes(pending, value);
+    for (;;) {
+      const decoded = decode(pending);
+      if (!decoded) break;
+      pending = pending.subarray(decoded.consumed);
+      onMessage(decoded);
+      if (decoded.kind === "ServerWelcome") {
+        welcomed = true;
+        if (!requestLease) {
+          // Telemetry/video only; control stays suspended.
+          return { completed: true, welcomed };
+        }
+        if (!sentLease) {
+          sentLease = true;
+          if (!(await sendLeaseRequest())) return { completed: false, welcomed };
+        }
+      }
+      if (decoded.kind === "LeaseResponse") {
+        return { completed: true, welcomed };
+      }
+    }
+  }
+}
+
+function appendBytes(existing, incoming) {
+  const out = new Uint8Array(existing.length + incoming.length);
+  out.set(existing, 0);
+  out.set(incoming, existing.length);
+  return out;
+}

--- a/clients/web/bootstrap.test.mjs
+++ b/clients/web/bootstrap.test.mjs
@@ -1,0 +1,144 @@
+// The REAL bootstrap reader loop under fakes: proves an auto-reconnect
+// (requestLease: false) emits no LeaseRequest from the loop that actually
+// runs in main.js — not merely that a controller passes a flag — and that
+// a stream that ends before ServerWelcome is distinguishable (a
+// retryable untyped end whose position is still visible telemetry) from a post-welcome drop.
+//
+// Run: node clients/web/bootstrap.test.mjs
+
+import { runBootstrapReader } from "./bootstrap.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// One-byte-tag framing for the fake wire: [tag] per message, delivered in
+// arbitrary chunk boundaries to exercise the buffering/consumed path.
+const WELCOME = 1;
+const LEASE_RESPONSE = 2;
+const KIND = { [WELCOME]: "ServerWelcome", [LEASE_RESPONSE]: "LeaseResponse" };
+
+function fakeDecode(bytes) {
+  if (bytes.length === 0) return null;
+  const kind = KIND[bytes[0]];
+  return kind ? { kind, message: {}, consumed: 1 } : null;
+}
+
+function fakeReader(chunks) {
+  const queue = [...chunks];
+  return {
+    read: async () =>
+      queue.length > 0 ? { value: Uint8Array.from(queue.shift()), done: false } : { done: true },
+  };
+}
+
+function harness({ chunks, requestLease, active = () => true, leaseOk = true }) {
+  const seen = [];
+  let leaseRequests = 0;
+  const run = runBootstrapReader({
+    reader: fakeReader(chunks),
+    decode: fakeDecode,
+    isActive: active,
+    onMessage: (decoded) => seen.push(decoded.kind),
+    requestLease,
+    sendLeaseRequest: async () => {
+      leaseRequests += 1;
+      return leaseOk;
+    },
+  });
+  return run.then((result) => ({ result, seen, leaseRequests: () => leaseRequests }));
+}
+
+// --- auto-reconnect: the real loop must emit no LeaseRequest ---------------
+{
+  const { result, seen, leaseRequests } = await harness({
+    chunks: [[WELCOME]],
+    requestLease: false,
+  });
+  check("auto-reconnect completes at ServerWelcome", result.completed === true);
+  check("auto-reconnect is marked welcomed", result.welcomed === true);
+  check("auto-reconnect emits ZERO LeaseRequests", leaseRequests() === 0);
+  check("the welcome was delivered to the message sink", seen.includes("ServerWelcome"));
+}
+
+// --- manual connect: exactly one LeaseRequest, completes on the response ---
+{
+  const { result, seen, leaseRequests } = await harness({
+    // Welcome split across chunk boundaries with the response following.
+    chunks: [[], [WELCOME], [LEASE_RESPONSE]],
+    requestLease: true,
+  });
+  check("manual connect completes on LeaseResponse", result.completed === true);
+  check("manual connect emits exactly one LeaseRequest", leaseRequests() === 1);
+  check("both messages delivered in order", seen.join(",") === "ServerWelcome,LeaseResponse");
+}
+
+// --- a duplicate welcome must not double-send the lease request ------------
+{
+  const { result, leaseRequests } = await harness({
+    chunks: [[WELCOME, WELCOME], [LEASE_RESPONSE]],
+    requestLease: true,
+  });
+  check("duplicate welcome still completes", result.completed === true);
+  check("duplicate welcome sends one LeaseRequest", leaseRequests() === 1);
+}
+
+// --- close BEFORE welcome: distinguishable, but still retryable -------------
+{
+  const { result, leaseRequests } = await harness({
+    chunks: [],
+    requestLease: true,
+  });
+  check("pre-welcome close is incomplete", result.completed === false);
+  check("pre-welcome close is NOT welcomed (telemetry only, still retryable)", result.welcomed === false);
+  check("pre-welcome close never sent a lease", leaseRequests() === 0);
+}
+
+// --- close AFTER welcome: an ordinary transport drop ------------------------
+{
+  const { result } = await harness({
+    chunks: [[WELCOME]],
+    requestLease: true,
+  });
+  check("post-welcome close is incomplete", result.completed === false);
+  check("post-welcome close IS welcomed (transport drop, retryable)", result.welcomed === true);
+}
+
+// --- a superseded session stops without completing --------------------------
+{
+  let reads = 0;
+  const { result, leaseRequests } = await harness({
+    chunks: [[WELCOME], [LEASE_RESPONSE]],
+    requestLease: true,
+    active: () => {
+      reads += 1;
+      return false;
+    },
+  });
+  check("superseded session is incomplete", result.completed === false);
+  check("superseded session stops at the first liveness check", reads === 1);
+  check("superseded session never sent a lease", leaseRequests() === 0);
+}
+
+// --- a lease send superseded mid-write ends the bootstrap -------------------
+{
+  const { result, leaseRequests } = await harness({
+    chunks: [[WELCOME], [LEASE_RESPONSE]],
+    requestLease: true,
+    leaseOk: false,
+  });
+  check("superseded lease send is incomplete", result.completed === false);
+  check("superseded lease send happened once", leaseRequests() === 1);
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all bootstrap reader checks passed");

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -50,10 +50,12 @@ import { TurnDerivation } from "./turn-derivation.js";
 import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
 import { AvionicsIngress, FcStateTracker, INCARNATION_POLICY } from "./telemetry-ingress.js";
 import { TransportSessionLifecycle } from "./transport-session.js";
+import { runBootstrapReader } from "./bootstrap.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
 import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
 import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
+import { createReconnectController } from "./reconnect.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -225,13 +227,30 @@ function hexToBytes(hex) {
   return out;
 }
 
-async function connect() {
+// A superseded attempt (a newer session token began) returns this so the
+// reconnect controller does not treat it as a failure and reschedule — the
+// newer flow owns recovery.
+const SUPERSEDED = { ok: true };
+
+// Opening one session. `manual` is true only for a user-initiated Connect:
+// only then is the motion lease requested and control resumed. An automatic
+// reconnect (`manual: false`) restores transport, telemetry, and video but
+// NEVER re-requests motion authority — control stays suspended until the user
+// explicitly reconnects. Returns `{ ok }` / `{ ok: false, failure }` for the
+// reconnect controller.
+async function connect({ manual } = { manual: true }) {
   const host = els.host.value.trim();
   const port = els.port.value.trim();
   const certHashHex = els.certHash.value.trim();
   if (!host || !port || !certHashHex) {
     log("host, port, and cert hash are all required");
-    return;
+    return { ok: false, failure: { phase: "construct" } };
+  }
+  // A SHA-256 hash is exactly 32 bytes; anything else is a configuration
+  // error (non-retryable), not something WebTransport should be handed.
+  if (!/^[0-9a-fA-F]{64}$/.test(certHashHex)) {
+    log("certificate hash must be exactly 64 hexadecimal characters (SHA-256)");
+    return { ok: false, failure: { phase: "construct" } };
   }
   const url = `https://${host}:${port}/pilotage`;
   const certHash = hexToBytes(certHashHex);
@@ -243,7 +262,7 @@ async function connect() {
     });
   } catch (error) {
     log(`WebTransport creation failed: ${error}`);
-    return;
+    return { ok: false, failure: { phase: "construct" } };
   }
   const token = transportSessions.begin(transport);
   transportSessions.runIfActive(token, () => {
@@ -259,7 +278,8 @@ async function connect() {
     state.skippedVideoFrames = 0;
     resetVideoDiagnostics();
     retireSessionPresentation("connecting");
-    log(`connecting to ${url} pinned to cert hash ${certHashHex.slice(0, 16)}...`);
+    const mode = manual ? "requesting control" : "auto-reconnect, telemetry/video only";
+    log(`connecting to ${url} (${mode}) pinned to cert hash ${certHashHex.slice(0, 16)}...`);
   });
 
   transport.closed.then(
@@ -269,20 +289,42 @@ async function connect() {
 
   try {
     await transport.ready;
-    if (!transportSessions.isActive(token)) return;
+    if (!transportSessions.isActive(token)) return SUPERSEDED;
     log("WebTransport session ready");
 
     const bidi = await transport.createBidirectionalStream();
-    if (!transportSessions.isActive(token)) return;
+    if (!transportSessions.isActive(token)) return SUPERSEDED;
     const writer = bidi.writable.getWriter();
     const reader = bidi.readable.getReader();
-    if (!transportSessions.trackWriter(token, writer)) return;
-    if (!transportSessions.trackReader(token, reader)) return;
+    if (!transportSessions.trackWriter(token, writer)) return SUPERSEDED;
+    if (!transportSessions.trackReader(token, reader)) return SUPERSEDED;
 
-    if (!(await sendClientHello(writer, token))) return;
-    const negotiated = await runBootstrapReader(reader, writer, token);
-    if (!transportSessions.isActive(token)) return;
-    if (!negotiated) throw new Error("bootstrap stream closed before LeaseResponse");
+    if (!(await sendClientHello(writer, token))) return SUPERSEDED;
+    // Only a manual connect requests the motion lease; an auto-reconnect
+    // completes bootstrap at ServerWelcome, leaving control suspended.
+    const bootstrap = await runBootstrapReader({
+      reader,
+      decode: decodeLengthDelimitedEnvelope,
+      isActive: () => transportSessions.isActive(token),
+      onMessage: (decoded) => handleBootstrapMessage(decoded, token),
+      requestLease: manual,
+      sendLeaseRequest: () => sendLeaseRequest(writer, token),
+    });
+    if (!transportSessions.isActive(token)) return SUPERSEDED;
+    if (!bootstrap.completed) {
+      // An untyped stream end is RETRYABLE wherever it lands in the
+      // handshake: the host's Close carries no wire payload today, so a
+      // pre-welcome EOF is indistinguishable from an ordinary early
+      // transport drop, and classifying it as a rejection would
+      // permanently stop recovery after a network blip. Only a TYPED
+      // protocol rejection may set `bootstrapRejected` (none exists on
+      // the wire yet — tracked in the reconnection issue).
+      throw new Error(
+        bootstrap.welcomed
+          ? "bootstrap stream closed after welcome, before it completed"
+          : "bootstrap stream closed before ServerWelcome",
+      );
+    }
 
     // Negotiation is the lifecycle boundary for measurement ordering. The
     // token prevents readers from the replaced transport from reaching this
@@ -291,6 +333,9 @@ async function connect() {
     instruments.fcState = new FcStateTracker();
     setTelemetrySessionState(els, "awaiting");
     state.connected = true;
+    // Bootstrap is proven good only here — reset the reconnect backoff now, not
+    // at transport.ready (which precedes bootstrap).
+    reconnect.notifyBootstrapComplete();
     acceptIncomingUniStreams(transport, token).catch((error) => {
       transportSessions.runIfActive(token, () => log(`incoming uni-stream accept loop error: ${error}`));
     });
@@ -301,19 +346,27 @@ async function connect() {
       startControlLoop(transport, token).catch((error) => {
         transportSessions.runIfActive(token, () => log(`control loop stopped: ${error}`));
       });
-    } else {
+    } else if (manual) {
       // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
       // advertises no controllable scopes; sending control frames anyway
       // would only generate a 30 Hz stream of rejections.
       log("no control lease granted; viewer is telemetry/video only");
+    } else {
+      log("reconnected (telemetry/video); press Connect to resume control");
     }
+    return { ok: true };
   } catch (error) {
-    if (!transportSessions.isActive(token)) return;
+    if (!transportSessions.isActive(token)) return SUPERSEDED;
     state.connected = false;
     state.transport = null;
     retireSessionPresentation("failed");
     log(`connect failed: ${error}`);
     transportSessions.close(token);
+    // "rejected" (non-retryable) is reserved for a TYPED protocol
+    // rejection or authenticated close code; an untyped failure — EOF,
+    // reset, timeout — is always a retryable transport drop.
+    const phase = error && error.bootstrapRejected ? "rejected" : "transport";
+    return { ok: false, failure: { phase } };
   }
 }
 
@@ -324,7 +377,25 @@ function handleTransportClosed(token, error) {
   retireSessionPresentation(error === null ? "disconnected" : "failed");
   log(error === null ? "WebTransport session closed" : `WebTransport session errored: ${error}`);
   transportSessions.retire(token);
+  // The drop was not user-initiated (there is no disconnect control); recover
+  // the transport if the user still wants a session. A clean or errored close
+  // is treated as a transient transport drop — retried with capped, jittered
+  // backoff. Control is NOT resumed by the reconnect (see connect: manual).
+  reconnect.notifyDropped({ phase: "transport" });
 }
+
+/** Auto-recovery for an unexpectedly dropped session: reconnects the transport
+ *  (telemetry/video) with capped, jittered backoff, and never re-requests
+ *  motion authority. Uses real timers, page visibility, and session state. */
+const reconnect = createReconnectController({
+  connect,
+  schedule: (delayMs, cb) => setTimeout(cb, delayMs),
+  cancel: (handle) => clearTimeout(handle),
+  isVisible: () => document.visibilityState === "visible",
+  isActive: () => transportSessions.active !== null,
+  random: () => Math.random(),
+  log,
+});
 
 /** Writes a length-delimited `ClientHello` envelope onto the bootstrap bidi stream. */
 async function sendClientHello(writer, token) {
@@ -370,30 +441,6 @@ function lengthDelimit(envelopeBytes) {
   return out;
 }
 
-/** Reads bootstrap frames until ServerWelcome and LeaseResponse establish the session. */
-async function runBootstrapReader(reader, writer, token) {
-  let pending = new Uint8Array(0);
-  let sentLease = false;
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (!transportSessions.isActive(token)) return false;
-    if (done) return false;
-    pending = appendBytes(pending, value);
-    for (;;) {
-      const decoded = decodeLengthDelimitedEnvelope(pending);
-      if (!decoded) break;
-      pending = pending.subarray(decoded.consumed);
-      handleBootstrapMessage(decoded, token);
-      if (decoded.kind === "ServerWelcome" && !sentLease) {
-        sentLease = true;
-        if (!(await sendLeaseRequest(writer, token))) return false;
-      }
-      if (decoded.kind === "LeaseResponse") {
-        return true;
-      }
-    }
-  }
-}
 
 function handleBootstrapMessage(decoded, token) {
   if (!transportSessions.isActive(token)) return;
@@ -1226,5 +1273,14 @@ document.getElementById("resetBtn").addEventListener("click", () => {
   state.pendingReset = true;
 });
 els.connectBtn.addEventListener("click", () => {
-  void connect();
+  // An explicit, user-initiated start: resets the reconnect backoff and is the
+  // only path that requests control.
+  reconnect.requestConnect();
+});
+
+// Returning to a tab the browser had frozen is the moment to recover: the
+// session likely idle-dropped while away, and only now can a reconnect succeed
+// (a hidden tab would just drop again).
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") reconnect.notifyVisible();
 });

--- a/clients/web/reconnect.js
+++ b/clients/web/reconnect.js
@@ -1,0 +1,150 @@
+// Connection auto-recovery for the demo viewer.
+//
+// When a WebTransport session drops unexpectedly (a backgrounded tab the
+// browser froze, an idle timeout, a network blip), reconnect the TRANSPORT so
+// telemetry and video come back — but never automatically re-request motion
+// authority. Control stays suspended until the user explicitly re-enables it;
+// that gate lives in the control loop, not here.
+//
+// The controller is side-effect-free except through its injected `connect`,
+// `schedule`, and `cancel`, so its whole lifecycle runs under fake time and a
+// fake WebTransport in tests.
+
+/// The backoff before the next reconnect attempt: exponential in `attempts`,
+/// capped at `maxMs`, with symmetric bounded jitter so a fleet of viewers that
+/// dropped together does not resynchronize into a thundering herd. `attempts`
+/// is the count already made (0 for the first); `jitter` in [0,1) is the
+/// caller's random fraction (0 yields the un-jittered value). Once the
+/// exponential reaches the cap the delay stays at the cap — a slow, capped
+/// retry that continues indefinitely rather than a hard stop or a busy loop.
+export function reconnectDelayMs(attempts, { baseMs, maxMs, jitterRatio = 0.25 }, jitter = 0) {
+  const exponential = Math.min(maxMs, baseMs * 2 ** attempts);
+  const spread = exponential * jitterRatio;
+  const offset = (jitter * 2 - 1) * spread; // [0,1) -> [-spread, +spread)
+  return Math.max(0, Math.round(exponential + offset));
+}
+
+/// Classifies a connect failure as retryable or not. A construction failure
+/// (a bad URL or certificate hash) and an explicit host rejection
+/// (authentication, protocol, or lease policy) cannot succeed on retry — they
+/// need the user to act — so they stop auto-recovery. Anything else is treated
+/// as a transient transport drop and retried. `failure.phase` is a structured
+/// tag from the connect flow, never a matched error string.
+export function classifyConnectFailure(failure) {
+  if (!failure) return { retryable: true, kind: "unknown" };
+  if (failure.phase === "construct") return { retryable: false, kind: "config" };
+  if (failure.phase === "rejected") {
+    return { retryable: false, kind: failure.kind || "rejected" };
+  }
+  return { retryable: true, kind: failure.kind || "transport" };
+}
+
+/// Creates a reconnect controller.
+///
+/// Dependencies:
+///   - `connect({ manual })` — performs one connect attempt and resolves to
+///     `{ ok }` or `{ ok: false, failure }`. `manual` is true only for a
+///     user-initiated Connect; an auto-reconnect passes false so `connect`
+///     restores transport/telemetry/video WITHOUT requesting motion authority.
+///   - `schedule(delayMs, cb) -> handle` / `cancel(handle)` — the timer.
+///   - `isVisible()` / `isActive()` — page visibility and whether a session is
+///     already up.
+///   - `random()` — jitter source in [0,1).
+///   - `log(message)` — user-facing status line.
+export function createReconnectController({
+  connect,
+  schedule,
+  cancel,
+  isVisible,
+  isActive,
+  random = () => 0,
+  log = () => {},
+  baseMs = 1000,
+  maxMs = 15000,
+  jitterRatio = 0.25,
+}) {
+  const state = { wanted: false, attempts: 0, timer: null, stopped: false, halted: false };
+
+  function clearTimer() {
+    if (state.timer !== null) {
+      cancel(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function scheduleNext(rawFailure) {
+    if (state.stopped || state.halted || state.timer !== null) return;
+    if (!state.wanted) return; // the user never asked to be connected
+    const failure = classifyConnectFailure(rawFailure);
+    if (rawFailure && !failure.retryable) {
+      // LATCH the halt: a non-retryable failure ends auto-recovery until
+      // an explicit Connect. Without the latch, any later trigger with no
+      // failure attached — a visibilitychange, a stray drop notification —
+      // would classify as retryable and silently restart the loop.
+      state.halted = true;
+      log(`connection cannot be auto-recovered (${failure.kind}); press Connect to retry`);
+      return;
+    }
+    if (isActive()) return; // already connected
+    if (!isVisible()) return; // hidden/frozen tab would just drop again — wait for visibility
+    const delay = reconnectDelayMs(state.attempts, { baseMs, maxMs, jitterRatio }, random());
+    state.timer = schedule(delay, () => {
+      state.timer = null;
+      state.attempts += 1;
+      log(`connection lost — auto-reconnecting (attempt ${state.attempts})...`);
+      void attempt(false);
+    });
+  }
+
+  async function attempt(manual) {
+    if (state.stopped || !state.wanted) return;
+    const outcome = await connect({ manual });
+    if (state.stopped) return;
+    if (outcome && outcome.ok) return; // success: notifyBootstrapComplete resets the backoff
+    scheduleNext(outcome && outcome.failure);
+  }
+
+  return {
+    /// The user clicked Connect: an explicit, fresh start that resets the
+    /// backoff and requests control.
+    requestConnect() {
+      state.wanted = true;
+      state.stopped = false;
+      state.halted = false;
+      state.attempts = 0;
+      clearTimer();
+      void attempt(true);
+    },
+    /// The transport dropped while we still want a session; schedule recovery.
+    notifyDropped(failure) {
+      scheduleNext(failure);
+    },
+    /// Application bootstrap finished (ServerWelcome + LeaseResponse). Only now
+    /// is the connection proven good, so the backoff resets HERE — never at
+    /// transport.ready, which precedes bootstrap and would retry a
+    /// bootstrap/protocol failure forever at the base interval.
+    notifyBootstrapComplete() {
+      state.attempts = 0;
+    },
+    /// The tab became visible again — retry a reconnect that was deferred while
+    /// it was hidden.
+    notifyVisible() {
+      scheduleNext();
+    },
+    /// The user asked to disconnect, or teardown: stop trying.
+    stop() {
+      state.stopped = true;
+      state.wanted = false;
+      clearTimer();
+    },
+    /// Inspection for tests.
+    snapshot() {
+      return {
+        wanted: state.wanted,
+        attempts: state.attempts,
+        pending: state.timer !== null,
+        halted: state.halted,
+      };
+    },
+  };
+}

--- a/clients/web/reconnect.test.mjs
+++ b/clients/web/reconnect.test.mjs
@@ -1,0 +1,241 @@
+// Lifecycle checks for the viewer's connection auto-recovery, driven by FAKE
+// time (an injected scheduler) and a FAKE WebTransport (an injected `connect`
+// returning programmed outcomes) — not only the pure decision helpers.
+//
+// Run: node clients/web/reconnect.test.mjs
+
+import {
+  reconnectDelayMs,
+  classifyConnectFailure,
+  createReconnectController,
+} from "./reconnect.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// A fake scheduler: records scheduled callbacks and lets the test fire the
+// earliest one, so "time" advances only when the test says so.
+function fakeScheduler() {
+  let seq = 0;
+  const timers = new Map();
+  return {
+    schedule(delayMs, cb) {
+      seq += 1;
+      timers.set(seq, { delayMs, cb });
+      return seq;
+    },
+    cancel(id) {
+      timers.delete(id);
+    },
+    pendingDelays() {
+      return [...timers.values()].map((t) => t.delayMs);
+    },
+    count() {
+      return timers.size;
+    },
+    async fireNext() {
+      const entry = [...timers.entries()][0];
+      if (!entry) return false;
+      const [id, timer] = entry;
+      timers.delete(id);
+      timer.cb();
+      await flush();
+      return true;
+    },
+  };
+}
+
+// A fake WebTransport connect: returns programmed outcomes and records the
+// `manual` flag of every attempt (the proof control is never auto-requested).
+function fakeConnect(script) {
+  const calls = [];
+  let i = 0;
+  return {
+    calls,
+    fn: async ({ manual }) => {
+      calls.push(manual);
+      const outcome = script[Math.min(i, script.length - 1)];
+      i += 1;
+      return outcome;
+    },
+  };
+}
+
+// ---- pure backoff -----------------------------------------------------------
+{
+  const opts = { baseMs: 1000, maxMs: 15000, jitterRatio: 0 };
+  check("first attempt waits the base delay", reconnectDelayMs(0, opts) === 1000);
+  check("the delay doubles each attempt", reconnectDelayMs(2, opts) === 4000);
+  check("the delay is capped", reconnectDelayMs(20, opts) === 15000);
+  // With jitter, the value stays within the symmetric band around the base.
+  const jittered = reconnectDelayMs(0, { baseMs: 1000, maxMs: 15000, jitterRatio: 0.25 }, 0.0);
+  check("jitter=0 pulls to the low edge of the band", jittered === 750);
+  const high = reconnectDelayMs(0, { baseMs: 1000, maxMs: 15000, jitterRatio: 0.25 }, 0.999);
+  check("jitter≈1 pulls to the high edge of the band", high > 1000 && high <= 1250);
+}
+
+// ---- classification ---------------------------------------------------------
+{
+  check("a construct failure is non-retryable", classifyConnectFailure({ phase: "construct" }).retryable === false);
+  check("an explicit rejection is non-retryable", classifyConnectFailure({ phase: "rejected", kind: "protocol" }).retryable === false);
+  check("a transport drop is retryable", classifyConnectFailure({ phase: "transport" }).retryable === true);
+  check("an unknown failure is retryable (do not strand the user)", classifyConnectFailure(undefined).retryable === true);
+}
+
+// A controller wired to fakes; `random: () => 0.5` yields the un-jittered value.
+function harness(script, { visible = true, active = false } = {}) {
+  const sched = fakeScheduler();
+  const connect = fakeConnect(script);
+  const logs = [];
+  const controller = createReconnectController({
+    connect: connect.fn,
+    schedule: sched.schedule,
+    cancel: sched.cancel,
+    isVisible: () => visible,
+    isActive: () => active,
+    random: () => 0.5,
+    log: (m) => logs.push(m),
+    baseMs: 1000,
+    maxMs: 15000,
+  });
+  return { sched, connect, logs, controller, setVisible: (v) => (visible = v) };
+}
+
+// ---- auto-reconnect restores the transport but never requests control -------
+{
+  const h = harness([{ ok: true }, { ok: true }]);
+  h.controller.requestConnect();
+  await flush();
+  h.controller.notifyBootstrapComplete();
+  h.controller.notifyDropped(); // unexpected drop
+
+  check("a drop schedules exactly one reconnect", h.sched.count() === 1);
+  await h.sched.fireNext();
+
+  check("the reconnect ran", h.connect.calls.length === 2);
+  check("the manual Connect requested control", h.connect.calls[0] === true);
+  check(
+    "the auto-reconnect did NOT request control (manual === false)",
+    h.connect.calls[1] === false,
+  );
+}
+
+// ---- backoff grows across failures, then resets on bootstrap ----------------
+{
+  const h = harness([
+    { ok: false, failure: { phase: "transport" } },
+    { ok: false, failure: { phase: "transport" } },
+    { ok: false, failure: { phase: "transport" } },
+    { ok: true },
+  ]);
+  h.controller.requestConnect();
+  await flush(); // attempt #1 fails -> schedules with attempts=0 -> 1000
+  check("first backoff is the base", h.sched.pendingDelays()[0] === 1000);
+  await h.sched.fireNext(); // attempts=1, fails -> schedules 2000
+  check("second backoff doubled", h.sched.pendingDelays()[0] === 2000);
+  await h.sched.fireNext(); // attempts=2, fails -> schedules 4000
+  check("third backoff doubled again", h.sched.pendingDelays()[0] === 4000);
+  await h.sched.fireNext(); // attempts=3, this one SUCCEEDS -> no new timer
+  check("a successful reconnect schedules nothing further", h.sched.count() === 0);
+
+  // Bootstrap-complete (only reached on success) resets the backoff, so the
+  // next unexpected drop starts again at the base delay.
+  h.controller.notifyBootstrapComplete();
+  h.controller.notifyDropped();
+  check("bootstrap-complete reset the backoff to base", h.sched.pendingDelays()[0] === 1000);
+}
+
+// ---- a non-retryable failure stops auto-recovery ----------------------------
+{
+  const h = harness([{ ok: false, failure: { phase: "construct" } }]);
+  h.controller.requestConnect();
+  await flush();
+  check("a non-retryable failure schedules no retry", h.sched.count() === 0);
+  check(
+    "the user is told to reconnect manually",
+    h.logs.some((m) => m.includes("press Connect")),
+  );
+}
+
+// ---- a hidden tab defers; becoming visible retries --------------------------
+{
+  const h = harness([{ ok: false, failure: { phase: "transport" } }, { ok: true }], {
+    visible: false,
+  });
+  h.controller.requestConnect();
+  await flush();
+  check("a hidden tab schedules no reconnect", h.sched.count() === 0);
+  h.setVisible(true);
+  h.controller.notifyVisible();
+  check("becoming visible schedules the deferred reconnect", h.sched.count() === 1);
+}
+
+// ---- stop() halts recovery --------------------------------------------------
+{
+  const h = harness([{ ok: false, failure: { phase: "transport" } }]);
+  h.controller.requestConnect();
+  await flush();
+  check("a retry is pending before stop", h.sched.count() === 1);
+  h.controller.stop();
+  check("stop cancels the pending retry", h.sched.count() === 0);
+  h.controller.notifyDropped();
+  check("stop makes later drops inert", h.sched.count() === 0);
+}
+
+
+// --- a non-retryable failure LATCHES: nothing restarts auto-recovery --------
+{
+  const clock = fakeScheduler();
+  const attempts = [];
+  const controller = createReconnectController({
+    connect: async ({ manual }) => {
+      attempts.push(manual);
+      return { ok: false, failure: { phase: "construct" } };
+    },
+    schedule: clock.schedule,
+    cancel: clock.cancel,
+    isVisible: () => true,
+    isActive: () => false,
+    random: () => 0,
+    log: () => {},
+  });
+  controller.requestConnect();
+  await flush();
+  check("the construct failure halts auto-recovery", controller.snapshot().halted === true);
+  const before = attempts.length;
+
+  // A visibility change must NOT restart retries after the halt.
+  controller.notifyVisible();
+  await flush();
+  check("visibilitychange cannot restart a halted recovery", controller.snapshot().pending === false);
+
+  // Neither can a stray drop notification without a failure.
+  controller.notifyDropped();
+  await flush();
+  check("a stray drop cannot restart a halted recovery", controller.snapshot().pending === false);
+  check("no attempt ran after the halt", attempts.length === before);
+
+  // Only an explicit Connect clears the halt — it attempts again, and a
+  // repeat of the same non-retryable failure re-latches rather than
+  // looping.
+  controller.requestConnect();
+  await flush();
+  check("the explicit Connect attempted", attempts.length === before + 1);
+  check("the repeated construct failure re-latches", controller.snapshot().halted === true);
+  check("still nothing scheduled", controller.snapshot().pending === false);
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall reconnect lifecycle checks passed");


### PR DESCRIPTION
Refs #146. The session-reconnection half of the #137 split: auto-reconnect restores transport/telemetry/video and NEVER re-requests motion authority.

- **The real reader proves the lease property**: `bootstrap.js` owns the loop and the one `LeaseRequest` emission point; its tests drive the actual loop and prove auto-reconnect emits zero LeaseRequests.
- **Untyped EOF is retryable, wherever it lands**: the host's `Close` carries no wire payload, so a pre-welcome EOF is indistinguishable from an early network blip and no longer stops recovery. The non-retryable `rejected` branch is reserved for a future typed protocol rejection / authenticated close code (#146).
- **Certificate hash validated as exactly 64 hex chars (SHA-256)** before construction — a malformed hash is a non-retryable configuration failure, giving the non-retryable path its real trigger.
- **Non-retryable failures LATCH**: a construct/config failure halts auto-recovery until an explicit Connect — a `visibilitychange` or a stray drop notification can no longer silently restart the retry loop (tested: halted → visibility/drop triggers schedule nothing; explicit Connect attempts once and re-latches on the same config error).
- Backoff resets only after application bootstrap completes; capped + jittered with a slow steady state; hidden tabs defer and retry on `visibilitychange`.

Rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)