### PR TITLE
Viewer: relinquish control authority on focus loss; no held-button edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,18 @@ jobs:
       - name: viewer connection auto-recovery lifecycle (backoff/jitter, classification, control-suspended)
         run: node clients/web/reconnect.test.mjs
 
+      - name: viewer control arm-edge detection (rising edges, hold-across-reconnect safety)
+        run: node clients/web/control-edges.test.mjs
+
+      - name: viewer input-loss gate (latched blur, no post-latch frames, held-button safety)
+        run: node clients/web/control-gate.test.mjs
+
+      - name: viewer explicit lease release (ack/timeout/abandon, reconnect awaits settlement)
+        run: node clients/web/lease-release.test.mjs
+
+      - name: viewer connect lifecycle under a racing blur (live lease probe, immediate release)
+        run: node clients/web/connect-lifecycle.test.mjs
+
       - name: wasm wire-decode conformance (REN)
         # The wasm exports the viewer decodes with must agree with the JS
         # reference decoders on layout, numeric kinds, and the capture-identity

--- a/clients/web/bootstrap.js
+++ b/clients/web/bootstrap.js
@@ -30,7 +30,12 @@
  *   length-delimited envelope decoder; null means "need more bytes"
  * @param {() => boolean} deps.isActive superseded sessions stop reading
  * @param {(decoded: object) => void} deps.onMessage decoded-frame sink
- * @param {boolean} deps.requestLease request motion authority (manual connect)
+ * @param {boolean | (() => boolean)} deps.requestLease whether to request
+ *   motion authority. Accepts a FUNCTION evaluated at the `ServerWelcome`
+ *   moment — the instant before the one `LeaseRequest` emission — so a
+ *   live condition (an input-loss latch set during an earlier await of
+ *   this very connect) is honored, not a stale flag captured when the
+ *   connect began.
  * @param {() => Promise<boolean>} deps.sendLeaseRequest writes the
  *   `LeaseRequest`; false means the session was superseded mid-send
  */
@@ -57,7 +62,9 @@ export async function runBootstrapReader({
       onMessage(decoded);
       if (decoded.kind === "ServerWelcome") {
         welcomed = true;
-        if (!requestLease) {
+        const wantsLease =
+          typeof requestLease === "function" ? requestLease() : requestLease;
+        if (!wantsLease) {
           // Telemetry/video only; control stays suspended.
           return { completed: true, welcomed };
         }

--- a/clients/web/connect-authority.js
+++ b/clients/web/connect-authority.js
@@ -1,0 +1,61 @@
+// The authority side of one connect, in the ORDER the safety argument
+// depends on (CTRL-04, #147) — owned here so main.js and the lifecycle
+// tests execute the same production orchestration, and a regression in
+// the ordering fails the test rather than only re-deriving it:
+//
+//   1. On a manual connect, re-arm the input-loss gate SYNCHRONOUSLY,
+//      before the first await: a blur landing during any later await of
+//      this connect latches and stays latched.
+//   2. Await any in-flight release before the transport work supersedes
+//      the old session — the old session's stream reader is what
+//      delivers the acknowledgement (bounded; a lost ack degrades to
+//      the host watchdog).
+//   3. Open the transport and run bootstrap with the lease decision as
+//      a LIVE probe, evaluated at the ServerWelcome moment immediately
+//      before the one LeaseRequest emission.
+//   4. After a grant, re-check the gate: a blur that raced the grant
+//      releases the lease immediately on the new reliable stream;
+//      otherwise control starts. No grant → telemetry-only.
+
+/**
+ * @param {object} deps
+ * @param {boolean} deps.manual explicit user connect (only path to control)
+ * @param {{ reset: () => void, mayPublish: () => boolean }} deps.gate
+ * @param {{ settled: () => Promise<any> }} deps.releases
+ * @param {(leaseProbe: () => boolean) => Promise<object>} deps.openAndBootstrap
+ *   transport construction + handshake + bootstrap; must pass `leaseProbe`
+ *   through as the reader's live `requestLease` and resolve to a session
+ *   object with `completed` (bootstrap finished) and `leaseGranted`;
+ *   anything not `completed` is returned to the caller untouched.
+ * @param {(session: object) => void} deps.startControl
+ * @param {(session: object) => void} deps.releaseLease
+ * @param {(session: object, manual: boolean) => void} deps.telemetryOnly
+ */
+export async function negotiateSessionAuthority({
+  manual,
+  gate,
+  releases,
+  openAndBootstrap,
+  startControl,
+  releaseLease,
+  telemetryOnly,
+}) {
+  if (manual) {
+    gate.reset(); // synchronous, BEFORE the first await
+    await releases.settled();
+  }
+  const session = await openAndBootstrap(() => manual && gate.mayPublish());
+  if (!session || !session.completed) return session;
+  if (session.leaseGranted) {
+    if (gate.mayPublish()) {
+      startControl(session);
+    } else {
+      // The blur raced the grant: input loss latched after the lease
+      // request was already emitted. Surrender immediately.
+      releaseLease(session);
+    }
+  } else {
+    telemetryOnly(session, manual);
+  }
+  return session;
+}

--- a/clients/web/connect-lifecycle.test.mjs
+++ b/clients/web/connect-lifecycle.test.mjs
@@ -1,0 +1,173 @@
+// The connect/transport lifecycle under a racing blur (CTRL-04, #147),
+// executing the PRODUCTION orchestration: `negotiateSessionAuthority` —
+// the exact module main.js runs — over the real bootstrap reader loop,
+// the real control gate, and the real release tracker. A regression in
+// the production ordering (gate reset timing, live lease probe,
+// post-grant recheck) fails HERE, not only in a re-derivation.
+//
+// Run: node clients/web/connect-lifecycle.test.mjs
+
+import { negotiateSessionAuthority } from "./connect-authority.js";
+import { runBootstrapReader } from "./bootstrap.js";
+import { createControlGate } from "./control-gate.js";
+import { createReleaseTracker } from "./lease-release.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const WELCOME = 1;
+const LEASE_RESPONSE = 2;
+const KIND = { [WELCOME]: "ServerWelcome", [LEASE_RESPONSE]: "LeaseResponse" };
+const decode = (bytes) => {
+  if (bytes.length === 0) return null;
+  const kind = KIND[bytes[0]];
+  return kind ? { kind, message: {}, consumed: 1 } : null;
+};
+
+// A reader whose chunks can run side effects as they are consumed — the
+// seam where a "blur during an await of the connect" is injected.
+function reader(steps) {
+  const queue = [...steps];
+  return {
+    read: async () => {
+      const step = queue.shift();
+      if (!step) return { done: true };
+      if (step.effect) step.effect();
+      return { value: Uint8Array.from(step.bytes), done: false };
+    },
+  };
+}
+
+// Drives the PRODUCTION orchestration over the real bootstrap loop, the
+// way main.js wires it: openAndBootstrap runs the reader with the
+// module's live probe and reports whether a lease was granted.
+async function drive({ gate, tracker, steps }) {
+  const events = [];
+  let leaseRequests = 0;
+  const session = await negotiateSessionAuthority({
+    manual: true,
+    gate,
+    releases: tracker,
+    openAndBootstrap: async (leaseProbe) => {
+      const result = await runBootstrapReader({
+        reader: reader(steps),
+        decode,
+        isActive: () => true,
+        onMessage: () => {},
+        requestLease: leaseProbe, // the module's live probe, unwrapped by nothing
+        sendLeaseRequest: async () => {
+          leaseRequests += 1;
+          return true;
+        },
+      });
+      return {
+        completed: result.completed,
+        leaseGranted: leaseRequests > 0,
+        result,
+      };
+    },
+    startControl: () => events.push("start-control"),
+    releaseLease: () => events.push("release-now"),
+    telemetryOnly: () => events.push("telemetry-only"),
+  });
+  return { session, events, leaseRequests };
+}
+
+// --- a blur during the release-settlement await stays latched ---------------
+{
+  let focused = true;
+  const gate = createControlGate({ isFocused: () => focused });
+  const tracker = createReleaseTracker();
+  // A pending release from the previous blur is still settling when the
+  // user clicks Connect; a NEW blur lands during that await. The
+  // production module resets the gate BEFORE this await, so the latch
+  // must survive into the lease decision.
+  const settling = tracker.begin();
+  queueMicrotask(() => {
+    focused = false;
+    gate.latchInputLoss(); // the racing blur
+    focused = true;
+    tracker.acknowledge();
+  });
+  const { events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    steps: [{ bytes: [WELCOME] }, { bytes: [LEASE_RESPONSE] }],
+  });
+  await settling;
+  check("a blur during the settlement await suppresses the lease request", leaseRequests === 0);
+  check("the session is telemetry-only", events.join(",") === "telemetry-only");
+}
+
+// --- a blur during the bootstrap read await suppresses the request ----------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  const tracker = createReleaseTracker();
+  const { session, events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    // The blur fires while the reader is between hello and welcome — an
+    // await inside the real loop, after the module froze nothing.
+    steps: [{ bytes: [WELCOME], effect: () => gate.latchInputLoss() }],
+  });
+  check("bootstrap completes telemetry-only", session.completed === true);
+  check("the live probe suppressed the lease request", leaseRequests === 0);
+  check("no control started", events.join(",") === "telemetry-only");
+}
+
+// --- a blur AFTER the request raced the grant: released immediately ---------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  const tracker = createReleaseTracker();
+  const { events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    steps: [
+      { bytes: [WELCOME] }, // probe passes; LeaseRequest emitted
+      { bytes: [LEASE_RESPONSE], effect: () => gate.latchInputLoss() },
+    ],
+  });
+  check("the request was emitted before the blur", leaseRequests === 1);
+  check("the granted lease is released immediately", events.join(",") === "release-now");
+}
+
+// --- the clean path starts control exactly once ------------------------------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  const tracker = createReleaseTracker();
+  const { session, events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    steps: [{ bytes: [WELCOME] }, { bytes: [LEASE_RESPONSE] }],
+  });
+  check("clean connect completes", session.completed === true);
+  check("clean connect requests exactly once", leaseRequests === 1);
+  check("clean connect starts control", events.join(",") === "start-control");
+}
+
+// --- a stale latch from a previous session re-arms on explicit connect ------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  gate.latchInputLoss(); // left over from the previous blur
+  const tracker = createReleaseTracker();
+  const { events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    steps: [{ bytes: [WELCOME] }, { bytes: [LEASE_RESPONSE] }],
+  });
+  check("an explicit connect re-arms a stale latch", leaseRequests === 1);
+  check("control starts after the re-arm", events.join(",") === "start-control");
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall connect-lifecycle checks passed");

--- a/clients/web/control-edges.js
+++ b/clients/web/control-edges.js
@@ -1,0 +1,31 @@
+// Pure arm/disarm edge detection for the demo viewer's control loop.
+//
+// Arm/disarm are one-shot RISING edges: a command is sent only when an input
+// that was NOT pressed last tick is pressed now. The subtlety this module
+// exists to make testable is priming — seeding the "previously pressed" set to
+// whatever is already held when control (re)starts. Without it, a button held
+// down across a reconnect (or across control being re-enabled) reads as a fresh
+// press and fires a spurious arm/disarm. Clearing the set on focus loss serves
+// the same end: a key still "held" only because its keyup was swallowed by the
+// blur must not edge when the window returns.
+
+/// The set of arm/disarm inputs currently held, from raw button/key booleans.
+export function pressedArmInputs({ padArm, padDisarm, keyArm, keyDisarm }) {
+  const pressed = new Set();
+  if (padArm) pressed.add("pad-arm");
+  if (padDisarm) pressed.add("pad-disarm");
+  if (keyArm) pressed.add("key-arm");
+  if (keyDisarm) pressed.add("key-disarm");
+  return pressed;
+}
+
+/// The inputs in `pressedNow` that were NOT in `prevPressed` — the rising edges.
+/// A still-held input (present in both) yields nothing, which is exactly why
+/// priming `prevPressed` to the held set suppresses a hold-across-reconnect edge.
+export function risingArmEdges(pressedNow, prevPressed) {
+  const edges = [];
+  for (const which of pressedNow) {
+    if (!prevPressed.has(which)) edges.push(which);
+  }
+  return edges;
+}

--- a/clients/web/control-edges.test.mjs
+++ b/clients/web/control-edges.test.mjs
@@ -1,0 +1,77 @@
+// Checks for arm/disarm edge detection: rising edges only, and — the safety
+// property — a button held across a (re)connect or through a focus loss does
+// not fire a fresh arm/disarm once the previous set is primed/cleared.
+//
+// Run: node clients/web/control-edges.test.mjs
+
+import { pressedArmInputs, risingArmEdges } from "./control-edges.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+const arr = (set) => [...set].sort();
+
+// ---- pressedArmInputs maps raw booleans to a stable set --------------------
+{
+  check("nothing held is an empty set", pressedArmInputs({}).size === 0);
+  const held = pressedArmInputs({ padArm: true, keyDisarm: true });
+  check(
+    "held pad-arm + key-disarm map through",
+    arr(held).join(",") === "key-disarm,pad-arm",
+  );
+}
+
+// ---- rising edges only ------------------------------------------------------
+{
+  const now = new Set(["pad-arm"]);
+  check("a newly pressed input is a rising edge", risingArmEdges(now, new Set()).join() === "pad-arm");
+  check(
+    "an input held since last tick is NOT an edge",
+    risingArmEdges(now, new Set(["pad-arm"])).length === 0,
+  );
+  const two = new Set(["pad-arm", "key-disarm"]);
+  check(
+    "only the newly-pressed input edges",
+    risingArmEdges(two, new Set(["pad-arm"])).join() === "key-disarm",
+  );
+}
+
+// ---- the hold-across-reconnect safety property ------------------------------
+{
+  // The arm button is held down the whole time. At (re)connect the previous set
+  // is PRIMED to the currently-held inputs, so the first tick sees no edge.
+  const heldNow = pressedArmInputs({ padArm: true });
+  const primed = pressedArmInputs({ padArm: true }); // priming reads the same held state
+  check(
+    "a button held across reconnect does not edge when primed",
+    risingArmEdges(heldNow, primed).length === 0,
+  );
+
+  // The wrong (old) behavior: priming to an empty set turns the held button
+  // into a spurious arm on the first tick. This is the bug the priming fixes.
+  check(
+    "priming to empty would (wrongly) edge — the bug this prevents",
+    risingArmEdges(heldNow, new Set()).join() === "pad-arm",
+  );
+
+  // After a genuine release and re-press, it edges again.
+  const afterRelease = new Set();
+  const rePressed = pressedArmInputs({ padArm: true });
+  check(
+    "releasing then pressing again edges",
+    risingArmEdges(rePressed, afterRelease).join() === "pad-arm",
+  );
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall control-edge checks passed");

--- a/clients/web/control-gate.js
+++ b/clients/web/control-gate.js
@@ -1,0 +1,39 @@
+// The input-loss gate for the control loop (CTRL-04, #147).
+//
+// Focus loss must be LATCHED by the blur event itself, not polled by the
+// 30 Hz loop: a blur/refocus that fits entirely between two ticks — or a
+// blur that fires while the loop is parked on an await — is invisible to a
+// poll, so the loop would keep publishing on the same lease with freshly
+// cleared arm-edge state (a still-held arm button would read as a new
+// rising edge). Once latched, no frame may be sent under that generation;
+// only an explicit new connect (a fresh lease) resets the gate.
+
+/**
+ * @param {{ isFocused: () => boolean }} deps live focus probe, kept as a
+ *   belt-and-braces check alongside the latch
+ */
+export function createControlGate({ isFocused }) {
+  let latched = false;
+  return {
+    /** Called synchronously from the blur event: latches input loss. */
+    latchInputLoss() {
+      latched = true;
+    },
+    /** Whether input loss has been latched since the last reset. */
+    isLatched() {
+      return latched;
+    },
+    /**
+     * Whether the loop may publish a control frame right now. False once
+     * latched — a later refocus does NOT clear it — and false while
+     * actually unfocused even if no blur event was delivered.
+     */
+    mayPublish() {
+      return !latched && isFocused();
+    },
+    /** A fresh explicit connect (new lease/generation) re-arms the gate. */
+    reset() {
+      latched = false;
+    },
+  };
+}

--- a/clients/web/control-gate.test.mjs
+++ b/clients/web/control-gate.test.mjs
@@ -1,0 +1,112 @@
+// The input-loss gate (CTRL-04, #147): blur latches synchronously, so the
+// polling failure modes — blur/refocus between ticks, blur during an await
+// (e.g. writer.ready), a held arm button edging after a missed blur — are
+// structurally impossible, and no frame is published under a latched
+// generation.
+//
+// Run: node clients/web/control-gate.test.mjs
+
+import { createControlGate } from "./control-gate.js";
+import { risingArmEdges } from "./control-edges.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// --- blur/refocus entirely between ticks cannot be missed -------------------
+{
+  let focused = true;
+  const gate = createControlGate({ isFocused: () => focused });
+  check("focused and unlatched publishes", gate.mayPublish() === true);
+
+  // Blur fires between ticks; focus returns before the next tick runs.
+  focused = false;
+  gate.latchInputLoss();
+  focused = true;
+  check(
+    "a blur/refocus between ticks still relinquishes (latched, not polled)",
+    gate.mayPublish() === false,
+  );
+  check("refocus alone never clears the latch", gate.isLatched() === true);
+}
+
+// --- blur during an await (writer.ready): no frame after the await ---------
+{
+  let focused = true;
+  const gate = createControlGate({ isFocused: () => focused });
+  const events = [];
+  // The loop checked the gate, parked on an await, and the blur landed
+  // while it was parked; the post-await re-check must refuse the write.
+  const tick = async () => {
+    if (!gate.mayPublish()) return events.push("relinquish-at-top");
+    await Promise.resolve().then(() => {
+      focused = false;
+      gate.latchInputLoss(); // blur event fires during the await
+      focused = true; // and focus even returns before the loop resumes
+    });
+    if (!gate.mayPublish()) return events.push("refused-post-await");
+    events.push("frame-sent");
+  };
+  await tick();
+  check("blur during an await refuses the write", events.join(",") === "refused-post-await");
+  await tick();
+  check("the following tick relinquishes at the top", events.join(",").endsWith("relinquish-at-top"));
+}
+
+// --- no post-latch frames, ever, under the same generation ------------------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  gate.latchInputLoss();
+  let framesSent = 0;
+  for (let tick = 0; tick < 100; tick += 1) {
+    if (gate.mayPublish()) framesSent += 1;
+  }
+  check("no frame is publishable after the latch", framesSent === 0);
+}
+
+// --- held arm button across a latch cannot edge -----------------------------
+{
+  // The blur handler clears the previous-pressed set. With a POLLED check
+  // a missed blur would leave the loop running, and the held button would
+  // read as a fresh rising edge against the cleared set. With the latch,
+  // the loop is guaranteed to stop; edges can only be computed again after
+  // an explicit reconnect, whose start re-primes the held set — under
+  // which a still-held button is NOT a rising edge.
+  const gate = createControlGate({ isFocused: () => true });
+  const held = new Set(["arm"]);
+  let prev = new Set(held); // primed at control start
+
+  gate.latchInputLoss();
+  prev = new Set(); // the blur handler clears edge state
+
+  const publishedEdges = [];
+  if (gate.mayPublish()) {
+    publishedEdges.push(...risingArmEdges(held, prev));
+  }
+  check("a held button cannot edge after the latch", publishedEdges.length === 0);
+
+  // Explicit reconnect: gate resets AND the held set is re-primed first.
+  gate.reset();
+  prev = new Set(held);
+  const edgesAfterReconnect = gate.mayPublish() ? [...risingArmEdges(held, prev)] : [];
+  check("a still-held button is not an edge after reconnect priming", edgesAfterReconnect.length === 0);
+}
+
+// --- unfocused-without-an-event still refuses (belt and braces) -------------
+{
+  let focused = false;
+  const gate = createControlGate({ isFocused: () => focused });
+  check("actually unfocused refuses even unlatched", gate.mayPublish() === false);
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all control-gate checks passed");

--- a/clients/web/lease-release.js
+++ b/clients/web/lease-release.js
@@ -1,0 +1,67 @@
+// Tracks one in-flight explicit lease release and its acknowledgement
+// (CTRL-04, #147): the client treats authority as relinquished when the
+// host's `LeaseReleased` arrives, and an immediate reconnect waits —
+// bounded — for that settlement so a fresh `LeaseRequest` cannot race the
+// release into an `AlreadyHeld` denial. The host's silence watchdog
+// remains the independent backup: the bounded wait means a lost
+// acknowledgement degrades to the watchdog path instead of hanging the
+// reconnect.
+
+/**
+ * @param {object} [deps]
+ * @param {number} [deps.timeoutMs] bound on waiting for the acknowledgement
+ * @param {(cb: () => void, ms: number) => any} [deps.schedule]
+ * @param {(handle: any) => void} [deps.cancel]
+ */
+export function createReleaseTracker({
+  timeoutMs = 1200,
+  schedule = (cb, ms) => setTimeout(cb, ms),
+  cancel = (handle) => clearTimeout(handle),
+} = {}) {
+  let pending = null;
+
+  function settle(outcome) {
+    if (!pending) return;
+    const { resolve, timer } = pending;
+    pending = null;
+    if (timer !== null) cancel(timer);
+    resolve(outcome);
+  }
+
+  return {
+    /**
+     * Records a release as sent; the returned promise settles with
+     * "acknowledged", "timeout", or "abandoned". Idempotent while one is
+     * already pending.
+     */
+    begin() {
+      if (pending) return pending.promise;
+      let resolve;
+      const promise = new Promise((r) => {
+        resolve = r;
+      });
+      const timer = schedule(() => settle("timeout"), timeoutMs);
+      pending = { promise, resolve, timer };
+      return promise;
+    },
+    /** The host acknowledged: authority is relinquished now. */
+    acknowledge() {
+      settle("acknowledged");
+    },
+    /** The transport died first; the watchdog will do the release. */
+    abandon() {
+      settle("abandoned");
+    },
+    /** Whether an acknowledgement is still outstanding. */
+    isPending() {
+      return pending !== null;
+    },
+    /**
+     * Resolves once any in-flight release settles ("idle" immediately when
+     * none is): the reconnect path awaits this before requesting a lease.
+     */
+    settled() {
+      return pending ? pending.promise : Promise.resolve("idle");
+    },
+  };
+}

--- a/clients/web/lease-release.test.mjs
+++ b/clients/web/lease-release.test.mjs
@@ -1,0 +1,112 @@
+// The explicit lease-release tracker (CTRL-04, #147) under fake time: the
+// acknowledgement settles the release, the bound settles a lost one (the
+// host watchdog covers from there), and an immediate reconnect awaits
+// settlement so a fresh LeaseRequest cannot race into AlreadyHeld.
+//
+// Run: node clients/web/lease-release.test.mjs
+
+import { createReleaseTracker } from "./lease-release.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+function fakeClock() {
+  let seq = 0;
+  const timers = new Map();
+  return {
+    schedule: (cb, ms) => {
+      seq += 1;
+      timers.set(seq, { cb, ms });
+      return seq;
+    },
+    cancel: (handle) => timers.delete(handle),
+    fire: () => {
+      for (const [handle, { cb }] of [...timers]) {
+        timers.delete(handle);
+        cb();
+      }
+    },
+    armed: () => timers.size,
+  };
+}
+
+// --- acknowledgement settles the release ------------------------------------
+{
+  const clock = fakeClock();
+  const tracker = createReleaseTracker({ timeoutMs: 1200, schedule: clock.schedule, cancel: clock.cancel });
+  const settled = tracker.begin();
+  check("release is pending after begin", tracker.isPending() === true);
+  tracker.acknowledge();
+  check("ack resolves the release", (await settled) === "acknowledged");
+  check("ack cancels the timeout", clock.armed() === 0);
+  check("nothing pending after ack", tracker.isPending() === false);
+}
+
+// --- a lost acknowledgement settles at the bound (watchdog covers) ----------
+{
+  const clock = fakeClock();
+  const tracker = createReleaseTracker({ timeoutMs: 1200, schedule: clock.schedule, cancel: clock.cancel });
+  const settled = tracker.begin();
+  clock.fire();
+  check("the bound settles a lost ack as timeout", (await settled) === "timeout");
+}
+
+// --- transport death abandons the release -----------------------------------
+{
+  const clock = fakeClock();
+  const tracker = createReleaseTracker({ schedule: clock.schedule, cancel: clock.cancel });
+  const settled = tracker.begin();
+  tracker.abandon();
+  check("transport death abandons", (await settled) === "abandoned");
+}
+
+// --- begin() is idempotent while pending -------------------------------------
+{
+  const clock = fakeClock();
+  const tracker = createReleaseTracker({ schedule: clock.schedule, cancel: clock.cancel });
+  const first = tracker.begin();
+  const second = tracker.begin();
+  check("a duplicate begin joins the pending release", first === second);
+  tracker.acknowledge();
+  await first;
+}
+
+// --- immediate reconnect awaits settlement (the AlreadyHeld race) ------------
+{
+  const clock = fakeClock();
+  const tracker = createReleaseTracker({ schedule: clock.schedule, cancel: clock.cancel });
+  const order = [];
+  tracker.begin();
+
+  // connect(manual) awaits settled() before requesting the lease.
+  const connect = (async () => {
+    await tracker.settled();
+    order.push("lease-request");
+  })();
+  order.push("release-in-flight");
+  tracker.acknowledge();
+  await connect;
+  check(
+    "the lease request waits for the release to settle",
+    order.join(",") === "release-in-flight,lease-request",
+  );
+}
+
+// --- settled() passes immediately when idle -----------------------------------
+{
+  const tracker = createReleaseTracker();
+  check("idle settles immediately", (await tracker.settled()) === "idle");
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all lease-release checks passed");

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -19,6 +19,7 @@
 import {
   encodeClientHelloEnvelope,
   encodeLeaseRequestEnvelope,
+  encodeLeaseReleaseEnvelope,
   encodeControlFrameEnvelope,
   decodeLengthDelimitedEnvelope,
   STREAM_KIND_AUTHORITY,
@@ -51,11 +52,15 @@ import { formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-di
 import { AvionicsIngress, FcStateTracker, INCARNATION_POLICY } from "./telemetry-ingress.js";
 import { TransportSessionLifecycle } from "./transport-session.js";
 import { runBootstrapReader } from "./bootstrap.js";
+import { createControlGate } from "./control-gate.js";
+import { createReleaseTracker } from "./lease-release.js";
+import { negotiateSessionAuthority } from "./connect-authority.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
 import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
 import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 import { createReconnectController } from "./reconnect.js";
+import { pressedArmInputs, risingArmEdges } from "./control-edges.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -255,6 +260,45 @@ async function connect({ manual } = { manual: true }) {
   const url = `https://${host}:${port}/pilotage`;
   const certHash = hexToBytes(certHashHex);
 
+  // The gate re-arm, release-settlement wait, live lease probe, and
+  // post-grant decision run inside the production orchestration module,
+  // which the lifecycle tests execute directly.
+  const session = await negotiateSessionAuthority({
+    manual,
+    gate: controlGate,
+    releases: releaseTracker,
+    openAndBootstrap: (leaseProbe) =>
+      openTransportSession({ url, certHash, certHashHex, manual, leaseProbe }),
+    startControl: ({ transport, token }) => {
+      startControlLoop(transport, token).catch((error) => {
+        transportSessions.runIfActive(token, () => log(`control loop stopped: ${error}`));
+      });
+    },
+    releaseLease: ({ token }) => {
+      sendLeaseRelease(token);
+      els.gamepad.textContent =
+        "control released — input lost during connect; press Connect to resume";
+      log("input lost during connect — lease released immediately");
+    },
+    telemetryOnly: (_session, wasManual) => {
+      if (wasManual) {
+        // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
+        // advertises no controllable scopes; sending control frames
+        // anyway would only generate a 30 Hz stream of rejections.
+        log("no control lease granted; viewer is telemetry/video only");
+      } else {
+        log("reconnected (telemetry/video); press Connect to resume control");
+      }
+    },
+  });
+  return session.result;
+}
+
+/** Transport construction, handshake, and bootstrap for one session
+ *  attempt. Resolves to `{ completed, leaseGranted, transport, token,
+ *  result }`; `result` is connect()'s return contract for the reconnect
+ *  controller (SUPERSEDED, ok, or a classified failure). */
+async function openTransportSession({ url, certHash, certHashHex, manual, leaseProbe }) {
   let transport;
   try {
     transport = new WebTransport(url, {
@@ -262,11 +306,12 @@ async function connect({ manual } = { manual: true }) {
     });
   } catch (error) {
     log(`WebTransport creation failed: ${error}`);
-    return { ok: false, failure: { phase: "construct" } };
+    return { completed: false, result: { ok: false, failure: { phase: "construct" } } };
   }
   const token = transportSessions.begin(transport);
   transportSessions.runIfActive(token, () => {
     state.transport = transport;
+    state.sessionWriter = null;
     state.sessionId = 0;
     state.generation = 0n;
     state.sequence = 0;
@@ -289,17 +334,17 @@ async function connect({ manual } = { manual: true }) {
 
   try {
     await transport.ready;
-    if (!transportSessions.isActive(token)) return SUPERSEDED;
+    if (!transportSessions.isActive(token)) return { completed: false, result: SUPERSEDED };
     log("WebTransport session ready");
 
     const bidi = await transport.createBidirectionalStream();
-    if (!transportSessions.isActive(token)) return SUPERSEDED;
+    if (!transportSessions.isActive(token)) return { completed: false, result: SUPERSEDED };
     const writer = bidi.writable.getWriter();
     const reader = bidi.readable.getReader();
-    if (!transportSessions.trackWriter(token, writer)) return SUPERSEDED;
-    if (!transportSessions.trackReader(token, reader)) return SUPERSEDED;
+    if (!transportSessions.trackWriter(token, writer)) return { completed: false, result: SUPERSEDED };
+    if (!transportSessions.trackReader(token, reader)) return { completed: false, result: SUPERSEDED };
 
-    if (!(await sendClientHello(writer, token))) return SUPERSEDED;
+    if (!(await sendClientHello(writer, token))) return { completed: false, result: SUPERSEDED };
     // Only a manual connect requests the motion lease; an auto-reconnect
     // completes bootstrap at ServerWelcome, leaving control suspended.
     const bootstrap = await runBootstrapReader({
@@ -307,10 +352,14 @@ async function connect({ manual } = { manual: true }) {
       decode: decodeLengthDelimitedEnvelope,
       isActive: () => transportSessions.isActive(token),
       onMessage: (decoded) => handleBootstrapMessage(decoded, token),
-      requestLease: manual,
+      // The orchestration module's live probe, evaluated at the
+      // ServerWelcome moment immediately before the one LeaseRequest
+      // emission: a blur latched during ANY await of this connect
+      // suppresses the request entirely.
+      requestLease: leaseProbe,
       sendLeaseRequest: () => sendLeaseRequest(writer, token),
     });
-    if (!transportSessions.isActive(token)) return SUPERSEDED;
+    if (!transportSessions.isActive(token)) return { completed: false, result: SUPERSEDED };
     if (!bootstrap.completed) {
       // An untyped stream end is RETRYABLE wherever it lands in the
       // handshake: the host's Close carries no wire payload today, so a
@@ -336,27 +385,25 @@ async function connect({ manual } = { manual: true }) {
     // Bootstrap is proven good only here — reset the reconnect backoff now, not
     // at transport.ready (which precedes bootstrap).
     reconnect.notifyBootstrapComplete();
+    state.sessionWriter = writer;
+    runSessionStreamReader(reader, token).catch((error) => {
+      transportSessions.runIfActive(token, () => log(`session stream reader stopped: ${error}`));
+    });
     acceptIncomingUniStreams(transport, token).catch((error) => {
       transportSessions.runIfActive(token, () => log(`incoming uni-stream accept loop error: ${error}`));
     });
     readTelemetryDatagrams(transport, token).catch((error) => {
       transportSessions.runIfActive(token, () => log(`telemetry reader stopped: ${error}`));
     });
-    if (state.leaseGranted) {
-      startControlLoop(transport, token).catch((error) => {
-        transportSessions.runIfActive(token, () => log(`control loop stopped: ${error}`));
-      });
-    } else if (manual) {
-      // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
-      // advertises no controllable scopes; sending control frames anyway
-      // would only generate a 30 Hz stream of rejections.
-      log("no control lease granted; viewer is telemetry/video only");
-    } else {
-      log("reconnected (telemetry/video); press Connect to resume control");
-    }
-    return { ok: true };
+    return {
+      completed: true,
+      leaseGranted: state.leaseGranted,
+      transport,
+      token,
+      result: { ok: true },
+    };
   } catch (error) {
-    if (!transportSessions.isActive(token)) return SUPERSEDED;
+    if (!transportSessions.isActive(token)) return { completed: false, result: SUPERSEDED };
     state.connected = false;
     state.transport = null;
     retireSessionPresentation("failed");
@@ -366,7 +413,7 @@ async function connect({ manual } = { manual: true }) {
     // rejection or authenticated close code; an untyped failure — EOF,
     // reset, timeout — is always a retryable transport drop.
     const phase = error && error.bootstrapRejected ? "rejected" : "transport";
-    return { ok: false, failure: { phase } };
+    return { completed: false, result: { ok: false, failure: { phase } } };
   }
 }
 
@@ -374,6 +421,10 @@ function handleTransportClosed(token, error) {
   if (!transportSessions.isActive(token)) return;
   state.connected = false;
   state.transport = null;
+  state.sessionWriter = null;
+  // An unacknowledged release rides down with the transport; the host
+  // watchdog covers it from here.
+  releaseTracker.abandon();
   retireSessionPresentation(error === null ? "disconnected" : "failed");
   log(error === null ? "WebTransport session closed" : `WebTransport session errored: ${error}`);
   transportSessions.retire(token);
@@ -383,6 +434,16 @@ function handleTransportClosed(token, error) {
   // backoff. Control is NOT resumed by the reconnect (see connect: manual).
   reconnect.notifyDropped({ phase: "transport" });
 }
+
+// Input-loss gate (CTRL-04): blur LATCHES loss synchronously so a
+// blur/refocus between control-loop ticks can never be missed; only an
+// explicit new connect re-arms it.
+const controlGate = createControlGate({ isFocused: () => document.hasFocus() });
+
+// One in-flight explicit lease release and its acknowledgement; an
+// immediate reconnect waits (bounded) for settlement so it cannot race
+// into an AlreadyHeld denial. The host watchdog stays the backup.
+const releaseTracker = createReleaseTracker();
 
 /** Auto-recovery for an unexpectedly dropped session: reconnects the transport
  *  (telemetry/video) with capped, jittered backoff, and never re-requests
@@ -419,6 +480,52 @@ async function sendLeaseRequest(writer, token) {
   if (!transportSessions.isActive(token)) return false;
   log(`sent LeaseRequest for ${MOTION_SCOPE}`);
   return true;
+}
+
+/** Sends a `LeaseRelease` for the motion scope on the reliable session
+ *  stream and starts the bounded wait for the host's acknowledgement. */
+function sendLeaseRelease(token) {
+  const writer = state.sessionWriter;
+  if (!writer || !transportSessions.isActive(token)) return;
+  if (releaseTracker.isPending()) return; // one release per loss; the ack settles it
+  const release = encodeLeaseReleaseEnvelope({ vehicleId: VEHICLE_ID, scope: MOTION_SCOPE });
+  const settled = releaseTracker.begin();
+  settled.then((outcome) => {
+    transportSessions.runIfActive(token, () => log(`lease release ${outcome}`));
+  });
+  writer.write(lengthDelimit(release)).catch(() => {
+    // The reliable stream refused the write: the transport is dying, and
+    // the host watchdog will do the release.
+    releaseTracker.abandon();
+  });
+  log("sent LeaseRelease for " + MOTION_SCOPE);
+}
+
+/** Reads the session (bootstrap) stream after the handshake completes:
+ *  the host's `LeaseReleased` acknowledgement arrives here. */
+async function runSessionStreamReader(reader, token) {
+  let pending = new Uint8Array(0);
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (!transportSessions.isActive(token) || done) return;
+    pending = appendBytes(pending, value);
+    for (;;) {
+      const decoded = decodeLengthDelimitedEnvelope(pending);
+      if (!decoded) break;
+      pending = pending.subarray(decoded.consumed);
+      if (decoded.kind === "LeaseReleased") {
+        // Validate the acknowledgement before it settles anything: an
+        // ack for another vehicle or scope proves nothing about ours.
+        const m = decoded.message;
+        if (Number(m.vehicleId) === VEHICLE_ID && m.scope === MOTION_SCOPE) {
+          releaseTracker.acknowledge();
+          log(`LeaseReleased: released=${m.released} generation=${m.generation}`);
+        } else {
+          log(`ignoring LeaseReleased for vehicle=${m.vehicleId} scope=${m.scope}`);
+        }
+      }
+    }
+  }
 }
 
 /** Prefixes an already-encoded `Envelope` with a protobuf varint byte-length, matching `encode_length_delimited` on the host. */
@@ -953,22 +1060,28 @@ function flightAxesFromGamepad(pad, profile, mode) {
   };
 }
 
-/** One-shot arm/disarm edges from gamepad buttons and keys: Enter arms,
- *  Backspace disarms; pad options (9) arms, create (8) disarms. */
+/** The arm/disarm inputs held right now, from gamepad buttons and keys: Enter
+ *  arms, Backspace disarms; pad options (9) arms, create (8) disarms. */
+function currentArmInputs(pad) {
+  return pressedArmInputs({
+    padArm: !!pad?.buttons?.[PAD_ARM_BUTTON]?.pressed,
+    padDisarm: !!pad?.buttons?.[PAD_DISARM_BUTTON]?.pressed,
+    keyArm: state.keys.has("Enter"),
+    keyDisarm: state.keys.has("Backspace"),
+  });
+}
+
+/** One-shot arm/disarm edges: only inputs newly pressed since last tick fire.
+ *  `state.prevArmInputs` is primed to the held set at control start, so a
+ *  button held across a reconnect does not read as a fresh command. */
 function collectArmEdges(pad) {
-  const pressedNow = new Set();
-  if (pad?.buttons?.[PAD_ARM_BUTTON]?.pressed) pressedNow.add("pad-arm");
-  if (pad?.buttons?.[PAD_DISARM_BUTTON]?.pressed) pressedNow.add("pad-disarm");
-  if (state.keys.has("Enter")) pressedNow.add("key-arm");
-  if (state.keys.has("Backspace")) pressedNow.add("key-disarm");
+  const pressedNow = currentArmInputs(pad);
   const edges = [];
-  for (const which of pressedNow) {
-    if (!state.prevArmInputs.has(which)) {
-      const arm = which.endsWith("-arm");
-      edges.push([arm ? BUTTON_ARM : BUTTON_DISARM, BUTTON_EDGE_PRESSED]);
-      els.overlay.textContent = arm ? "ARM sent" : "DISARM sent";
-      log(arm ? "arm command sent" : "disarm command sent");
-    }
+  for (const which of risingArmEdges(pressedNow, state.prevArmInputs)) {
+    const arm = which.endsWith("-arm");
+    edges.push([arm ? BUTTON_ARM : BUTTON_DISARM, BUTTON_EDGE_PRESSED]);
+    els.overlay.textContent = arm ? "ARM sent" : "DISARM sent";
+    log(arm ? "arm command sent" : "disarm command sent");
   }
   state.prevArmInputs = pressedNow;
   return edges;
@@ -1061,11 +1174,31 @@ function updateFlightReadout(pad, f) {
     `climb=${f.throttle.toFixed(2)} yaw=${f.yaw.toFixed(2)} | arm: Options/Enter, disarm: Create/Backspace`;
 }
 
+/** Neutral (zeroed) control axes for a flight mode: rover carries only
+ *  throttle/yaw, the flight modes carry roll/pitch/throttle/yaw. */
+function neutralAxesFor(mode) {
+  return mode === "rover"
+    ? [
+        [AXIS_THROTTLE, 0],
+        [AXIS_YAW, 0],
+      ]
+    : [
+        [AXIS_ROLL, 0],
+        [AXIS_PITCH, 0],
+        [AXIS_THROTTLE, 0],
+        [AXIS_YAW, 0],
+      ];
+}
+
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
 async function startControlLoop(transport, token) {
   if (!transportSessions.isActive(token)) return;
   const writer = transport.datagrams.writable.getWriter();
   if (!transportSessions.trackWriter(token, writer)) return;
+  // Prime the arm-edge baseline to whatever is held right now, so a button held
+  // down as control starts (e.g. across a reconnect) is not read as a fresh
+  // arm/disarm on the first tick.
+  state.prevArmInputs = currentArmInputs(activeGamepad());
   const intervalMs = 1000 / CONTROL_HZ;
   // Self-paced async loop rather than setInterval: it awaits the writer's
   // backpressure signal (`ready`) before each send, so datagrams never queue up
@@ -1083,6 +1216,23 @@ async function startControlLoop(transport, token) {
       // A connected gamepad drives under its profile; the keyboard is the
       // fallback when none is present. The readout shows the live mapping.
       const mode = els.flightMode ? els.flightMode.value : "rover";
+      if (!controlGate.mayPublish()) {
+        // Input loss RELINQUISHES control authority. The latch is
+        // absolute: NO frame — not even a neutral — is sent under this
+        // generation, because the explicit LeaseRelease (sent by the
+        // blur handler the instant the latch set; re-attempted here for
+        // the polled-unfocused fallback) makes the host fence the
+        // generation and drive the vehicle to its link-loss policy. A
+        // client-side neutral would both violate the latch invariant and
+        // refresh the very setpoint freshness the silence watchdog (the
+        // independent backup) is watching.
+        state.prevArmInputs = new Set();
+        sendLeaseRelease(token);
+        els.gamepad.textContent =
+          "control released — input lost; press Connect to resume control";
+        log("input lost — control authority released (host acknowledges or watchdog covers)");
+        return;
+      }
       const pad = activeGamepad();
       const profile = pad ? profileFor(pad.id) : null;
       let axes;
@@ -1116,6 +1266,10 @@ async function startControlLoop(transport, token) {
           [AXIS_YAW, f.yaw],
         ];
       }
+      // Re-check the latch immediately before the write: no frame may be
+      // sent under this generation once input loss latched, regardless of
+      // which await the latch interleaved with.
+      if (!controlGate.mayPublish()) continue;
       state.sequence = (state.sequence + 1) >>> 0; // wraps at u32, matching the wire SequenceNum width.
       const envelope = encodeControlFrameEnvelope({
         sessionId: state.sessionId,
@@ -1283,4 +1437,21 @@ els.connectBtn.addEventListener("click", () => {
 // (a hidden tab would just drop again).
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") reconnect.notifyVisible();
+});
+
+// Losing window focus can swallow keyup events, leaving keys "stuck". Clear the
+// keyboard and arm-edge state immediately on blur so input released off-window
+// does not linger and a button still held when focus returns cannot edge.
+window.addEventListener("blur", () => {
+  // Latch FIRST, synchronously: the control loop may be parked on an
+  // await, and a refocus before its next tick must not un-happen the
+  // loss. Frames under the current generation end here — and the
+  // explicit release starts HERE too, not at the loop's next tick, so a
+  // Connect click racing the blur always finds the release in flight.
+  controlGate.latchInputLoss();
+  if (state.leaseGranted && transportSessions.active !== null) {
+    sendLeaseRelease(transportSessions.active);
+  }
+  state.keys.clear();
+  state.prevArmInputs = new Set();
 });

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -249,7 +249,7 @@ function encodeLeaseRequest({ vehicleId, scope }) {
 // (envelope.proto): schema_version = 1; oneof payload: control_frame=2,
 // authority_event=3, telemetry_sample=4, host_capabilities=5, client_hello=6,
 // server_welcome=7, lease_request=8, lease_response=9, ping=10, pong=11,
-// frame_rejected=12.
+// frame_rejected=12, lease_release=13, lease_released=14.
 const ENVELOPE_FIELD = {
   schemaVersion: 1,
   controlFrame: 2,
@@ -263,6 +263,8 @@ const ENVELOPE_FIELD = {
   ping: 10,
   pong: 11,
   frameRejected: 12,
+  leaseRelease: 13,
+  leaseReleased: 14,
 };
 
 /** Wraps an already-encoded payload submessage bytes in an `Envelope`. */
@@ -281,6 +283,20 @@ export function encodeClientHelloEnvelope(hello) {
 /** Encodes a `LeaseRequest` as a bare `Envelope` (payload field 8). */
 export function encodeLeaseRequestEnvelope(request) {
   return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.leaseRequest, encodeLeaseRequest(request)));
+}
+
+// ---- session.proto: LeaseRelease (field numbers 1,2) -----------------------
+// message LeaseRelease { VehicleId vehicle = 1; ScopeId scope = 2; }
+function encodeLeaseRelease({ vehicleId, scope }) {
+  const bytes = [];
+  fieldBytes(bytes, 1, encodeVehicleId(vehicleId));
+  fieldBytes(bytes, 2, encodeScopeId(scope));
+  return bytes;
+}
+
+/** Encodes a `LeaseRelease` as a bare `Envelope` (payload field 13). */
+export function encodeLeaseReleaseEnvelope(release) {
+  return new Uint8Array(encodeEnvelope(ENVELOPE_FIELD.leaseRelease, encodeLeaseRelease(release)));
 }
 
 // ---- control.proto: ControlFrame (field numbers per schema) ----------------
@@ -503,6 +519,9 @@ function decodeEnvelopeBody(body) {
   if (fields.has(ENVELOPE_FIELD.frameRejected)) {
     return { kind: "FrameRejected", message: decodeFrameRejected(firstBytes(fields, ENVELOPE_FIELD.frameRejected)) };
   }
+  if (fields.has(ENVELOPE_FIELD.leaseReleased)) {
+    return { kind: "LeaseReleased", message: decodeLeaseReleased(firstBytes(fields, ENVELOPE_FIELD.leaseReleased)) };
+  }
   return { kind: "unknown", message: {} };
 }
 
@@ -524,6 +543,18 @@ function decodeLeaseResponse(bytes) {
     granted: !!firstVarint(fields, 3),
     generation: decodeUint64Message(firstBytes(fields, 4)),
     reason: firstVarint(fields, 5),
+  };
+}
+
+// session.proto LeaseReleased: vehicle=1, scope=2, released=3, generation=4
+function decodeLeaseReleased(bytes) {
+  if (!bytes) return {};
+  const fields = parseFields(bytes);
+  return {
+    vehicleId: decodeUint64Message(firstBytes(fields, 1)),
+    scope: decodeStringMessage(firstBytes(fields, 2)),
+    released: !!firstVarint(fields, 3),
+    generation: decodeUint64Message(firstBytes(fields, 4)),
   };
 }
 


### PR DESCRIPTION
Refs #147. Browser half of the input-loss-safety split; consumes #141's `LeaseRelease` protocol. **Merge after #141 and #142.**

## Latched, not polled — and the latch is absolute
The `blur` event latches the control gate **synchronously and initiates the explicit release right there** — not at the loop's next tick — so a blur/refocus fitting between 30 Hz ticks (or during an await) can never be missed, and a Connect click racing the blur always finds the release already in flight. Once latched, **no frame flows under that generation — not even a neutral**: the explicit release makes the host fence the generation and drive the vehicle to its link-loss policy, and a client-side neutral would both violate the latch invariant and refresh the very setpoint freshness the silence watchdog is monitoring. Gate checked at tick top and again immediately before the write; only an explicit new connect re-arms. A held arm button cannot edge across the latch (the loop is guaranteed to stop; reconnect re-primes the held set).

## Released with a validated acknowledgement
`LeaseRelease` rides the reliable session stream; the host fences, engages the policy, and acks. The acknowledgement is **validated** — only a `LeaseReleased` matching this vehicle and the motion scope settles the pending release; foreign acks are ignored. One release per loss (duplicate begins join it). A manual reconnect **awaits settlement before superseding the old session** (whose stream reader is what delivers the ack), closing the `AlreadyHeld` race; the wait is bounded so a lost ack degrades to the watchdog path.

## Round-7: the lifecycle test executes production orchestration

The connect ordering now lives in `connect-authority.js` (`negotiateSessionAuthority`): synchronous gate re-arm before the first await → bounded release-settlement wait → transport open + bootstrap with the module's live lease probe → post-grant recheck (start control / release immediately / telemetry-only). `main.js` calls it with its transport I/O injected, and `connect-lifecycle.test.mjs` executes the SAME module over the real bootstrap loop, gate, and tracker — a regression in the production ordering fails the test rather than a re-derivation of it. Close #147 on merge.

## Round-6: the blur-during-connect race is closed

- The gate resets **synchronously at the very start** of a manual connect, before the first await — a blur landing during the release-settlement wait latches and STAYS latched.
- The lease decision is a **live probe** evaluated by the real bootstrap loop at the ServerWelcome moment (`requestLease: () => manual && controlGate.mayPublish()`), immediately before the one LeaseRequest emission — a blur during any await of the connect suppresses the request entirely.
- If a blur **races an already-granted lease**, it is released immediately on the new reliable stream instead of waiting for a control-loop tick.
- `connect-lifecycle.test.mjs` drives the REAL bootstrap loop + gate + tracker in connect()'s exact ordering: blur during the settlement await, blur during the bootstrap read, blur racing the grant (immediate release), and the clean single-request path.

## Guardrails
`control-gate.test.mjs` / `lease-release.test.mjs` (fake time, fake streams): blur/refocus between ticks; blur during an await refuses the post-await write; zero post-latch frames; held-button safety across latch and reconnect priming; refocus never clears the latch; ack/timeout/abandon settlement; duplicate-begin idempotence; lease-request-after-settlement ordering. Plus the release-path engine tests in #141 (holder ack + fence + neutralize, non-holder no-op, release-then-regrant without AlreadyHeld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)