### PR TITLE
Flight: brake to a stop before capturing the stick-release hold point

### DIFF
--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use pilotage_adapter_api::{
     AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossPolicy, RejectReason,
-    ScopeDescriptor, SourceIncarnation, SourceRole, StepBudget, StepOutcome, TelemetryBatch,
-    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
+    ScopeDescriptor, SourceIncarnation, StepBudget, StepOutcome, TelemetryBatch, TelemetrySample,
+    VehicleAdapter, VehicleDescriptor, VideoSource,
 };
 use pilotage_protocol::{
     ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame, VehicleId,
@@ -31,9 +31,7 @@ mod shm_sampling;
 mod sources;
 mod startup;
 use control::{flight_button_pressed, normalized_flight_sticks, rejected_control};
-use sampling::{
-    mavlink_batch, measurement_pair_is_coherent, measurement_pair_supports_pose, yaw_of,
-};
+use sampling::mavlink_batch;
 use shm_sampling::ShmSource;
 use sources::{ArmReport, EstimateSource, fc_state_sample};
 
@@ -182,29 +180,10 @@ impl AviateAdapter {
         self
     }
 
-    /// The vehicle's current measured yaw (radians clockwise from
-    /// north) and NED position, FROM THE FC OPERATIONAL ESTIMATE ONLY
-    /// (LINK-04): simulation truth is never eligible to seed command
-    /// construction, so without a live authorized estimate there is no
-    /// pose and state-dependent control is rejected instead of
-    /// borrowing truth.
-    fn current_pose(&mut self) -> Option<(f32, [f32; 3])> {
-        let latest = self.estimate.as_ref()?.state.lock().ok()?;
-        latest.estimator_status_stamp()?;
-        let attitude = latest
-            .attitude
-            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
-            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
-        let kinematics = latest
-            .kinematics
-            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
-            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
-        if !measurement_pair_is_coherent(attitude, kinematics, latest.maximum_inter_group_skew_ms)
-            || !measurement_pair_supports_pose(attitude, kinematics)
-        {
-            return None;
-        }
-        Some((yaw_of(attitude.quat_wxyz) as f32, kinematics.pos_ned_m))
+    /// The bound uplink, for tests that drive its manual clock.
+    #[cfg(test)]
+    pub(crate) fn uplink_mut(&mut self) -> Option<&mut FlightUplink> {
+        self.uplink.as_mut()
     }
 
     fn validate_flight_frame(&self, frame: &ScopedControlFrame) -> Result<(), RejectReason> {
@@ -293,7 +272,7 @@ impl VehicleAdapter for AviateAdapter {
                 disposition: Disposition::Accepted,
             };
         }
-        let Some((current_yaw, current_pos)) = self.current_pose() else {
+        let Some((current_yaw, current_pos, current_vel)) = self.current_pose() else {
             return rejected_control(tick, RejectReason::MeasurementUnavailable);
         };
         let Some(uplink) = self.uplink.as_mut() else {
@@ -328,6 +307,7 @@ impl VehicleAdapter for AviateAdapter {
                 sticks[usize::from(YAW_AXIS)],
                 current_yaw,
                 current_pos,
+                current_vel,
             );
         }
         ApplyOutcome {

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -3,8 +3,8 @@
 use std::sync::{Arc, Mutex};
 
 use pilotage_adapter_api::{
-    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, Pose2d, TelemetryBatch,
-    TelemetrySample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, Pose2d, SourceRole,
+    TelemetryBatch, TelemetrySample,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
@@ -168,4 +168,51 @@ pub(crate) fn mavlink_batch(
             fc_state: None,
         }],
     }
+}
+
+impl super::AviateAdapter {
+    /// The vehicle's current measured yaw (radians clockwise from
+    /// north), NED position, and independently validated NED velocity,
+    /// FROM THE FC OPERATIONAL ESTIMATE ONLY (LINK-04): simulation truth
+    /// is never eligible to seed command construction, so without a live
+    /// authorized estimate there is no pose and state-dependent control
+    /// is rejected instead of borrowing truth.
+    ///
+    /// Velocity carries its own validity: `None` when the FC did not
+    /// declare the velocity group valid or any component is non-finite.
+    /// A pose can be usable while velocity is not; a caller must never
+    /// infer "stopped" from a missing velocity.
+    pub(super) fn current_pose(&mut self) -> Option<(f32, [f32; 3], Option<[f32; 3]>)> {
+        let latest = self.estimate.as_ref()?.state.lock().ok()?;
+        latest.estimator_status_stamp()?;
+        let attitude = latest
+            .attitude
+            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
+            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
+        let kinematics = latest
+            .kinematics
+            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
+            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
+        if !measurement_pair_is_coherent(attitude, kinematics, latest.maximum_inter_group_skew_ms)
+            || !measurement_pair_supports_pose(attitude, kinematics)
+        {
+            return None;
+        }
+        Some((
+            yaw_of(attitude.quat_wxyz) as f32,
+            kinematics.pos_ned_m,
+            validated_velocity(kinematics),
+        ))
+    }
+}
+
+/// The kinematics velocity as independently validated data: present only
+/// when the FC declared the velocity group valid (bit 3, the same gate the
+/// planar speed projection uses) and every component is finite. NaN would
+/// otherwise poison downstream comparisons silently — `NaN > threshold` is
+/// false, which reads as "stopped".
+fn validated_velocity(kinematics: KinematicsUpdate) -> Option<[f32; 3]> {
+    let declared_valid = kinematics.valid_flags & 0b1000 != 0;
+    let finite = kinematics.vel_ned_mps.iter().all(|v| v.is_finite());
+    (declared_valid && finite).then_some(kinematics.vel_ned_mps)
 }

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -6,11 +6,12 @@ use pilotage_adapter_api::{
     Disposition, MeasurementClock, MeasurementStamp, RejectReason, SourceIncarnation, SourceRole,
     VehicleAdapter,
 };
-use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+use pilotage_protocol::{ButtonEdge, LogicalButtonId, VehicleId};
 
 use crate::link::KinematicsUpdate;
 
 mod fixtures;
+mod flight_control;
 mod source_roles;
 use fixtures::{flight_frame, state_with, state_with_acquisition_skew};
 
@@ -280,101 +281,6 @@ fn disarm_does_not_require_a_current_measurement_pair() {
         f32::from_le_bytes(buf[10..14].try_into().expect("param1")),
         0.0
     );
-}
-
-#[test]
-fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
-    // A fake FC: any UDP socket we can read the uplink's frames from.
-    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
-    fc.set_read_timeout(Some(Duration::from_secs(2)))
-        .expect("timeout");
-
-    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
-    uplink.set_target(fc.local_addr().expect("addr"));
-    // Heading east (yaw 90°) so body-frame rotation is observable.
-    let mut adapter = AviateAdapter::from_state(
-        VehicleId::new(1),
-        state_with(Duration::ZERO, Duration::ZERO),
-    )
-    .with_uplink(uplink);
-
-    let caps = adapter.capabilities();
-    assert_eq!(caps.vehicles[0].scopes.len(), 1, "flight scope advertised");
-    assert_eq!(caps.vehicles[0].scopes[0].axes.len(), 4);
-
-    // Arm edge (stick frames are suppressed for a beat afterward so the
-    // FC's single command slot is not overwritten before its loop runs).
-    let outcome = adapter.apply_control(&flight_frame(
-        vec![],
-        vec![(LogicalButtonId::new(super::ARM_BUTTON), ButtonEdge::Pressed)],
-    ));
-    assert_eq!(outcome.disposition, Disposition::Accepted);
-
-    let mut buf = [0u8; 128];
-    // First datagram: the arm command (COMMAND_LONG 400, param1=1).
-    let (n, _) = fc.recv_from(&mut buf).expect("arm frame");
-    assert_eq!(buf[7], 76, "COMMAND_LONG id");
-    assert_eq!(
-        f32::from_le_bytes([buf[10], buf[11], buf[12], buf[13]]),
-        1.0
-    );
-    assert!(n >= 45);
-
-    // Past the post-arm quiet window: full forward stick + half climb,
-    // streamed like the 30 Hz control loop. The slew limiter ramps the
-    // command from zero, so assert the ramp rather than an instant step.
-    std::thread::sleep(Duration::from_millis(200));
-    let f = |buf: &[u8; 128], off: usize| {
-        f32::from_le_bytes([buf[10 + off], buf[11 + off], buf[12 + off], buf[13 + off]])
-    };
-    let mut last_ve = 0.0f32;
-    for _ in 0..30 {
-        let outcome = adapter.apply_control(&flight_frame(
-            vec![
-                (LogicalAxisId::new(super::PITCH_AXIS), 1.0),
-                (LogicalAxisId::new(super::THROTTLE_AXIS), 0.5),
-            ],
-            vec![],
-        ));
-        assert_eq!(outcome.disposition, Disposition::Accepted);
-        fc.recv_from(&mut buf).expect("setpoint frame");
-        assert_eq!(buf[7], 84, "SET_POSITION_TARGET id");
-        let ve = f(&buf, 20);
-        assert!(
-            ve >= last_ve - 1e-4,
-            "ramp must not reverse: {ve} < {last_ve}"
-        );
-        last_ve = ve;
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    // Heading is east (yaw 90°), stick full-forward → velocity is +east:
-    // vn≈0, ve ramping toward 3.
-    let (vn, vz) = (f(&buf, 16), f(&buf, 24));
-    assert!(vn.abs() < 0.05, "vn {vn}");
-    assert!(last_ve > 1.0, "ramped east velocity, got {last_ve}");
-    assert!(vz < -0.2, "climb demand present, got {vz}");
-    let type_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
-    assert_eq!(type_mask, 2503);
-
-    // Centered sticks switch to position-hold (DJI brake-then-hold):
-    // the hold loop runs on the FC, so the ground streams a
-    // position-valid setpoint (mask 2552) at the captured hold point
-    // — the fake pose's NED position — with no ground-side gains.
-    let outcome = adapter.apply_control(&flight_frame(
-        vec![
-            (LogicalAxisId::new(super::PITCH_AXIS), 0.0),
-            (LogicalAxisId::new(super::THROTTLE_AXIS), 0.0),
-        ],
-        vec![],
-    ));
-    assert_eq!(outcome.disposition, Disposition::Accepted);
-    fc.recv_from(&mut buf).expect("hold frame");
-    let hold_mask = u16::from_le_bytes([buf[10 + 48], buf[11 + 48]]);
-    assert_eq!(hold_mask, 2552, "hold streams FC position mode");
-    // Position fields carry the captured point (fake pose 10, 20, -30).
-    assert!((f(&buf, 4) - 10.0).abs() < 1e-3, "hold north");
-    assert!((f(&buf, 8) - 20.0).abs() < 1e-3, "hold east");
-    assert!((f(&buf, 12) + 30.0).abs() < 1e-3, "hold down");
 }
 
 #[test]

--- a/adapters/aviate/src/adapter/tests/flight_control.rs
+++ b/adapters/aviate/src/adapter/tests/flight_control.rs
@@ -1,0 +1,293 @@
+//! Flight-control uplink behavior through the adapter boundary: the
+//! stick-to-setpoint path, the brake-then-hold state machine, and its
+//! velocity-evidence rules, all against a fake FC socket and the
+//! uplink's manual clock (no real-time sleeps).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use pilotage_adapter_api::{Disposition, VehicleAdapter};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+
+use crate::link::{KinematicsUpdate, LatestAviate};
+
+use super::super::{ARM_BUTTON, AviateAdapter, PITCH_AXIS, THROTTLE_AXIS};
+use super::fixtures::{flight_frame, state_with};
+
+/// A little-endian f32 payload field at `off` bytes into the frame body.
+fn field(buf: &[u8; 128], off: usize) -> f32 {
+    f32::from_le_bytes([buf[10 + off], buf[11 + off], buf[12 + off], buf[13 + off]])
+}
+
+/// The SET_POSITION_TARGET type mask (velocity mode 2503, position 2552).
+fn type_mask(buf: &[u8; 128]) -> u16 {
+    u16::from_le_bytes([buf[10 + 48], buf[11 + 48]])
+}
+
+/// An all-centered stick frame.
+fn centered_frame() -> pilotage_protocol::ScopedControlFrame {
+    flight_frame(
+        vec![
+            (LogicalAxisId::new(PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.0),
+        ],
+        vec![],
+    )
+}
+
+/// Rewrites the fixture's kinematics group, fresh as of now.
+fn set_kinematics(state: &Arc<Mutex<LatestAviate>>, mutate: impl FnOnce(&mut KinematicsUpdate)) {
+    let mut latest = state.lock().expect("state lock");
+    let kin = latest.kinematics.as_mut().expect("kinematics fixture");
+    mutate(kin);
+    kin.received_at = std::time::Instant::now();
+}
+
+/// Rewrites the fixture's measured velocity, fresh as of now.
+fn set_velocity(state: &Arc<Mutex<LatestAviate>>, vel: [f32; 3]) {
+    set_kinematics(state, |kin| kin.vel_ned_mps = vel);
+}
+
+/// An adapter wired to a fake FC (any UDP socket the uplink's frames
+/// can be read from), heading east (yaw 90°) so body-frame rotation is
+/// observable. The state handle steers the fixture's measurements; the
+/// uplink runs on its manual clock so no test sleeps against real time.
+fn flying_adapter(fc: &std::net::UdpSocket) -> (AviateAdapter, Arc<Mutex<LatestAviate>>) {
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    uplink.use_manual_clock();
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    let adapter = AviateAdapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink);
+    (adapter, state)
+}
+
+/// Advances the uplink's manual clock by `ms` milliseconds.
+fn tick_clock(adapter: &mut AviateAdapter, ms: u64) {
+    adapter
+        .uplink_mut()
+        .expect("uplink bound")
+        .advance_clock(Duration::from_millis(ms));
+}
+
+/// Arms, waits out the post-arm quiet window, then streams frames of
+/// full-forward stick with half climb like the 30 Hz control loop,
+/// asserting the slew limiter ramps the command from zero. Returns the
+/// last east-velocity command, leaving the vehicle flying east.
+fn arm_and_ramp_east(
+    adapter: &mut AviateAdapter,
+    fc: &std::net::UdpSocket,
+    buf: &mut [u8; 128],
+) -> f32 {
+    // Arm edge (stick frames are suppressed for a beat afterward so the
+    // FC's single command slot is not overwritten before its loop runs).
+    let outcome = adapter.apply_control(&flight_frame(
+        vec![],
+        vec![(LogicalButtonId::new(ARM_BUTTON), ButtonEdge::Pressed)],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+
+    // First datagram: the arm command (COMMAND_LONG 400, param1=1).
+    let (n, _) = fc.recv_from(buf).expect("arm frame");
+    assert_eq!(buf[7], 76, "COMMAND_LONG id");
+    assert_eq!(field(buf, 0), 1.0);
+    assert!(n >= 45);
+
+    // Step the manual clock past the post-arm quiet window, then 20 ms
+    // per frame like the 30 Hz control loop — no real-time sleeps.
+    tick_clock(adapter, 200);
+    let mut last_ve = 0.0f32;
+    for _ in 0..30 {
+        let outcome = adapter.apply_control(&flight_frame(
+            vec![
+                (LogicalAxisId::new(PITCH_AXIS), 1.0),
+                (LogicalAxisId::new(THROTTLE_AXIS), 0.5),
+            ],
+            vec![],
+        ));
+        assert_eq!(outcome.disposition, Disposition::Accepted);
+        fc.recv_from(buf).expect("setpoint frame");
+        assert_eq!(buf[7], 84, "SET_POSITION_TARGET id");
+        let ve = field(buf, 20);
+        assert!(
+            ve >= last_ve - 1e-4,
+            "ramp must not reverse: {ve} < {last_ve}"
+        );
+        last_ve = ve;
+        tick_clock(adapter, 20);
+    }
+    last_ve
+}
+
+#[test]
+fn stick_frame_reaches_the_fc_as_a_velocity_setpoint() {
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let (mut adapter, _state) = flying_adapter(&fc);
+
+    let caps = adapter.capabilities();
+    assert_eq!(caps.vehicles[0].scopes.len(), 1, "flight scope advertised");
+    assert_eq!(caps.vehicles[0].scopes[0].axes.len(), 4);
+
+    let mut buf = [0u8; 128];
+    let last_ve = arm_and_ramp_east(&mut adapter, &fc, &mut buf);
+
+    // Heading is east (yaw 90°), stick full-forward → velocity is +east:
+    // vn≈0, ve ramping toward 3.
+    let (vn, vz) = (field(&buf, 16), field(&buf, 24));
+    assert!(vn.abs() < 0.05, "vn {vn}");
+    assert!(last_ve > 1.0, "ramped east velocity, got {last_ve}");
+    assert!(vz < -0.2, "climb demand present, got {vz}");
+    assert_eq!(type_mask(&buf), 2503);
+}
+
+#[test]
+fn centered_sticks_brake_to_a_stop_before_capturing_the_hold() {
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let (mut adapter, state) = flying_adapter(&fc);
+    let mut buf = [0u8; 128];
+    arm_and_ramp_east(&mut adapter, &fc, &mut buf);
+
+    // Centered sticks while still moving (fake estimate: |vel| ≈ 5 m/s)
+    // brake first: zero-velocity setpoints (mask 2503), NOT a hold
+    // point captured at release — that point would be overrun and
+    // flown back to.
+    let outcome = adapter.apply_control(&centered_frame());
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    fc.recv_from(&mut buf).expect("brake frame");
+    assert_eq!(type_mask(&buf), 2503, "braking streams velocity mode");
+    for (off, axis) in [(16, "vn"), (20, "ve"), (24, "vz")] {
+        let v = field(&buf, off);
+        assert!(v.abs() < 1e-6, "brake demands zero {axis}, got {v}");
+    }
+
+    // A purely vertical residual (1 m/s climb) is still motion: the
+    // brake phase covers the vertical axis, not just horizontal.
+    set_velocity(&state, [0.0, 0.0, -1.0]);
+    adapter.apply_control(&centered_frame());
+    fc.recv_from(&mut buf).expect("vertical brake frame");
+    assert_eq!(type_mask(&buf), 2503, "vertical residual keeps braking");
+
+    // Braking finished (|vel| below the capture threshold): NOW the
+    // hold point is captured and streamed as a position-valid setpoint
+    // (mask 2552) — the fake pose's NED position, no ground-side gains.
+    set_velocity(&state, [0.1, 0.05, 0.0]);
+    let outcome = adapter.apply_control(&centered_frame());
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    fc.recv_from(&mut buf).expect("hold frame");
+    assert_eq!(type_mask(&buf), 2552, "hold streams FC position mode");
+    // Position fields carry the captured point (fake pose 10, 20, -30).
+    assert!((field(&buf, 4) - 10.0).abs() < 1e-3, "hold north");
+    assert!((field(&buf, 8) - 20.0).abs() < 1e-3, "hold east");
+    assert!((field(&buf, 12) + 30.0).abs() < 1e-3, "hold down");
+
+    // A gust (velocity back above threshold) must NOT drop the captured
+    // hold point — re-capturing on a blip would walk the vehicle
+    // downwind. The hold stays until a stick deflects.
+    set_velocity(&state, [3.0, 4.0, -1.0]);
+    adapter.apply_control(&centered_frame());
+    fc.recv_from(&mut buf).expect("sticky hold frame");
+    assert_eq!(
+        type_mask(&buf),
+        2552,
+        "captured hold survives a velocity blip"
+    );
+    assert!((field(&buf, 4) - 10.0).abs() < 1e-3, "sticky hold north");
+}
+
+/// Asserts the next frame the fake FC receives is a zero-demand
+/// velocity-mode setpoint (the braking frame).
+fn expect_brake_frame(fc: &std::net::UdpSocket, buf: &mut [u8; 128], why: &str) {
+    fc.recv_from(buf).expect(why);
+    assert_eq!(type_mask(buf), 2503, "{why}: braking streams velocity mode");
+    for off in [16, 20, 24] {
+        assert!(field(buf, off).abs() < 1e-6, "{why}: zero demand");
+    }
+}
+
+#[test]
+fn invalid_velocity_keeps_braking_and_never_captures_the_hold() {
+    // Position-valid but velocity-invalid: the estimate withholds the
+    // velocity group (bit 3 cleared), so stillness can never be
+    // demonstrated — the uplink must keep braking, not capture a hold
+    // from absent data.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let (mut adapter, state) = flying_adapter(&fc);
+    let mut buf = [0u8; 128];
+    arm_and_ramp_east(&mut adapter, &fc, &mut buf);
+
+    // Even a numerically tiny velocity is no evidence while undeclared.
+    set_kinematics(&state, |kin| {
+        kin.vel_ned_mps = [0.0, 0.0, 0.0];
+        kin.valid_flags = 0b0111;
+    });
+    for _ in 0..3 {
+        adapter.apply_control(&centered_frame());
+        expect_brake_frame(&fc, &mut buf, "velocity-invalid frame");
+    }
+
+    // Validity restored with demonstrated stillness: NOW the hold captures.
+    set_kinematics(&state, |kin| {
+        kin.vel_ned_mps = [0.1, 0.0, 0.0];
+        kin.valid_flags = 0b1111;
+    });
+    adapter.apply_control(&centered_frame());
+    fc.recv_from(&mut buf).expect("hold frame");
+    assert_eq!(
+        type_mask(&buf),
+        2552,
+        "validated stillness captures the hold"
+    );
+}
+
+#[test]
+fn non_finite_velocity_keeps_braking() {
+    // NaN compares false against any threshold; without independent
+    // validation that silently reads as "stopped" and captures the hold
+    // at full speed — the exact defect brake-then-hold exists to prevent.
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let (mut adapter, state) = flying_adapter(&fc);
+    let mut buf = [0u8; 128];
+    arm_and_ramp_east(&mut adapter, &fc, &mut buf);
+
+    for bad in [
+        [f32::NAN, 0.0, 0.0],
+        [0.0, f32::INFINITY, 0.0],
+        [0.0, 0.0, f32::NEG_INFINITY],
+    ] {
+        set_velocity(&state, bad);
+        adapter.apply_control(&centered_frame());
+        expect_brake_frame(&fc, &mut buf, "non-finite velocity frame");
+    }
+}
+
+#[test]
+fn hold_captures_only_at_or_below_the_speed_threshold() {
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let (mut adapter, state) = flying_adapter(&fc);
+    let mut buf = [0u8; 128];
+    arm_and_ramp_east(&mut adapter, &fc, &mut buf);
+
+    // Just above the 0.3 m/s capture threshold: still braking.
+    set_velocity(&state, [0.301, 0.0, 0.0]);
+    adapter.apply_control(&centered_frame());
+    expect_brake_frame(&fc, &mut buf, "above-threshold frame");
+
+    // Just below: stillness demonstrated, hold captured.
+    set_velocity(&state, [0.299, 0.0, 0.0]);
+    adapter.apply_control(&centered_frame());
+    fc.recv_from(&mut buf).expect("hold frame");
+    assert_eq!(
+        type_mask(&buf),
+        2552,
+        "below-threshold speed captures the hold"
+    );
+}

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -42,11 +42,40 @@ const MAX_YAW_RATE_RPS: f32 = 0.9;
 /// Longest believable gap between control frames when integrating the
 /// yaw-rate stick; anything longer is a stall, not a dt.
 const MAX_DT_S: f32 = 0.1;
+/// Measured speed below which the hold point may be captured after the
+/// sticks center. Capturing while still moving commands PositionHold on
+/// a point the vehicle is about to overrun — it brakes past it, then
+/// flies back (~1.5–2 m from a full-stick release). Above this speed
+/// the uplink streams zero-velocity setpoints and lets the FC's
+/// velocity mode brake; this is a threshold on a measurement, not a
+/// control gain — the hold loop itself stays on the FC.
+const HOLD_CAPTURE_MAX_MPS: f32 = 0.3;
 /// Stick frames are suppressed this long after an arm/disarm send: the
 /// FC stages inbound commands in a single slot, so a setpoint arriving
 /// in the same poll batch would overwrite the arm before the control
 /// loop consumes it.
 const ARM_QUIET: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// The uplink's time source. Production reads the system monotonic clock;
+/// tests substitute a manually advanced instant so timing behavior (the
+/// post-arm quiet window, the slew-limiter dt) is exercised without
+/// real-time sleeps.
+#[derive(Debug)]
+enum UplinkClock {
+    System,
+    #[cfg(test)]
+    Manual(Instant),
+}
+
+impl UplinkClock {
+    fn now(&self) -> Instant {
+        match self {
+            Self::System => Instant::now(),
+            #[cfg(test)]
+            Self::Manual(at) => *at,
+        }
+    }
+}
 
 /// The UDP MAVLink command uplink to the FC.
 #[derive(Debug)]
@@ -68,6 +97,7 @@ pub struct FlightUplink {
     hold_pos_ned: Option<[f32; 3]>,
     last_vel_ned: [f32; 3],
     started: Instant,
+    clock: UplinkClock,
     send_failures: u64,
     expected_system_id: u8,
     expected_component_id: u8,
@@ -105,10 +135,26 @@ impl FlightUplink {
             hold_pos_ned: None,
             last_vel_ned: [0.0; 3],
             started: Instant::now(),
+            clock: UplinkClock::System,
             send_failures: 0,
             expected_system_id: 1,
             expected_component_id: 1,
         })
+    }
+
+    /// Switches to the manually advanced clock, anchored at construction
+    /// time, so tests drive the quiet window and slew dt deterministically.
+    #[cfg(test)]
+    pub(crate) fn use_manual_clock(&mut self) {
+        self.clock = UplinkClock::Manual(self.started);
+    }
+
+    /// Advances the manual clock; a no-op on the system clock.
+    #[cfg(test)]
+    pub(crate) fn advance_clock(&mut self, dt: std::time::Duration) {
+        if let UplinkClock::Manual(at) = &mut self.clock {
+            *at += dt;
+        }
     }
 
     /// Selects the MAVLink system/component whose replies may affect state.
@@ -144,7 +190,7 @@ impl FlightUplink {
 
     fn send_arm_command(&mut self, arm: bool) {
         self.last_frame = None;
-        self.quiet_until = Some(Instant::now() + ARM_QUIET);
+        self.quiet_until = Some(self.clock.now() + ARM_QUIET);
         self.airborne = false;
         self.hold_pos_ned = None;
         self.last_vel_ned = [0.0; 3];
@@ -164,7 +210,7 @@ impl FlightUplink {
     /// to collective thrust around the hover point — altitude is the
     /// pilot's axis in FPV.
     pub fn send_fpv_frame(&mut self, roll: f32, pitch: f32, throttle: f32, yaw: f32) {
-        let now = Instant::now();
+        let now = self.clock.now();
         if let Some(quiet) = self.quiet_until {
             if now < quiet {
                 return;
@@ -192,7 +238,10 @@ impl FlightUplink {
         };
         let frame = encode_attitude_setpoint(
             self.seq,
-            self.started.elapsed().as_millis() as u32,
+            self.clock
+                .now()
+                .saturating_duration_since(self.started)
+                .as_millis() as u32,
             crate::mavlink::AttitudeTarget {
                 roll_rad: roll * FPV_MAX_TILT_RAD,
                 pitch_rad: pitch * FPV_MAX_TILT_RAD,
@@ -208,7 +257,11 @@ impl FlightUplink {
     /// Converts one canonical stick frame (`[-1, 1]` roll/pitch/
     /// throttle/yaw, stick conventions: pitch + = forward, roll + =
     /// right, throttle + = climb, yaw + = clockwise) into a velocity
-    /// setpoint and sends it.
+    /// setpoint and sends it. `current_vel_ned_mps` is the measured
+    /// (estimated) velocity as independently validated data — `None`
+    /// when the estimate did not declare it valid or it is non-finite —
+    /// used only to decide when braking has finished after the sticks
+    /// center.
     #[allow(clippy::too_many_arguments)]
     pub fn send_stick_frame(
         &mut self,
@@ -218,8 +271,9 @@ impl FlightUplink {
         yaw: f32,
         current_yaw_rad: f32,
         current_pos_ned_m: [f32; 3],
+        current_vel_ned_mps: Option<[f32; 3]>,
     ) {
-        let now = Instant::now();
+        let now = self.clock.now();
         if let Some(quiet) = self.quiet_until {
             if now < quiet {
                 return;
@@ -238,13 +292,12 @@ impl FlightUplink {
             .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
             .clamp(0.0, MAX_DT_S);
         self.last_frame = Some(now);
-        let time_boot_ms = self.started.elapsed().as_millis() as u32;
+        let time_boot_ms = self
+            .clock
+            .now()
+            .saturating_duration_since(self.started)
+            .as_millis() as u32;
 
-        // DJI brake-then-hold: with every stick centered, capture the
-        // current position once and stream a position setpoint. The
-        // hold loop itself runs on the FC (PositionHold cascade) —
-        // ground code carries no control gains, only the captured
-        // point. Any stick deflection returns to velocity mode.
         let sticks_active = roll
             .abs()
             .max(pitch.abs())
@@ -252,17 +305,7 @@ impl FlightUplink {
             .max(yaw.abs())
             > 0.02;
         if !sticks_active {
-            let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
-            self.last_vel_ned = [0.0; 3];
-            let frame = encode_position_setpoint(
-                self.seq,
-                time_boot_ms,
-                hold,
-                self.heading_sp_rad,
-                self.expected_system_id,
-                self.expected_component_id,
-            );
-            self.send(&frame);
+            self.send_brake_or_hold(current_pos_ned_m, current_vel_ned_mps, time_boot_ms);
             return;
         }
         self.hold_pos_ned = None;
@@ -301,11 +344,66 @@ impl FlightUplink {
         self.send(&frame);
     }
 
+    /// DJI brake-then-hold, entered while every stick is centered:
+    /// first brake — stream zero-velocity setpoints while the vehicle
+    /// still moves — then capture the position once braking finishes
+    /// and stream it as the hold point. Capturing at release instead
+    /// would command PositionHold on a point the momentum overruns,
+    /// and the FC would faithfully fly back to it. The hold loop
+    /// itself runs on the FC (PositionHold cascade) — ground code
+    /// carries no control gains, only the captured point. Once
+    /// captured, the hold point is sticky against gusts (re-capturing
+    /// on a velocity blip would let the vehicle drift downwind); any
+    /// stick deflection returns to velocity mode.
+    fn send_brake_or_hold(
+        &mut self,
+        current_pos_ned_m: [f32; 3],
+        current_vel_ned_mps: Option<[f32; 3]>,
+        time_boot_ms: u32,
+    ) {
+        self.last_vel_ned = [0.0; 3];
+        // The hold is captured only on POSITIVE evidence of stillness: a
+        // validated, finite velocity at or below the capture threshold.
+        // Missing or invalid velocity keeps braking — "stopped" is never
+        // inferred from absent data (a NaN comparison is silently false,
+        // which would otherwise capture the hold at full speed, the exact
+        // defect this state machine exists to prevent).
+        let demonstrated_still = current_vel_ned_mps.is_some_and(|vel| {
+            (vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]).sqrt() <= HOLD_CAPTURE_MAX_MPS
+        });
+        if self.hold_pos_ned.is_none() && !demonstrated_still {
+            let frame = encode_velocity_setpoint(
+                self.seq,
+                time_boot_ms,
+                [0.0; 3],
+                self.heading_sp_rad,
+                self.expected_system_id,
+                self.expected_component_id,
+            );
+            self.send(&frame);
+            return;
+        }
+        let hold = *self.hold_pos_ned.get_or_insert(current_pos_ned_m);
+        let frame = encode_position_setpoint(
+            self.seq,
+            time_boot_ms,
+            hold,
+            self.heading_sp_rad,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
+        self.send(&frame);
+    }
+
     /// Sends a zero-velocity setpoint holding the current heading — the
     /// link-loss neutralize action (the FC's velocity mode brakes to a
     /// hover on zero demand).
     pub fn send_neutral(&mut self) {
-        let time_boot_ms = self.started.elapsed().as_millis() as u32;
+        let time_boot_ms = self
+            .clock
+            .now()
+            .saturating_duration_since(self.started)
+            .as_millis() as u32;
         let frame = encode_velocity_setpoint(
             self.seq,
             time_boot_ms,

--- a/scripts/structure-function-baseline.tsv
+++ b/scripts/structure-function-baseline.tsv
@@ -6,6 +6,4 @@
 ./crates/pilotage-instrument-state/src/abi.rs	decode_state	125
 ./crates/pilotage-instrument-state/src/abi.rs	encode_state	97
 ./crates/pilotage-authority/src/wire.rs	from	88
-./adapters/aviate/src/adapter/tests.rs	stick_frame_reaches_the_fc_as_a_velocity_setpoint	93
-./adapters/aviate/src/uplink.rs	send_stick_frame	90
 ./hosts/session-host/tests/loopback.rs	hello_lease_frame_and_stale_generation_rejection	99


### PR DESCRIPTION
Fixes #123.

## Symptom / root cause

Release the yoke after a translation and the vehicle brakes, then flies **back** ~1.5–2 m: `send_stick_frame` captured the hold point on the first centered-stick frame while still moving at up to 3 m/s, so the FC was commanded PositionHold on a point the momentum overruns. (Full kinematic walkthrough in #123.)

## Fix — ground side only, no control gains

Centered sticks stream **zero-velocity setpoints** (the `send_neutral` frame), and the hold is captured only on **positive evidence of stillness**:

- Velocity is **independently validated data**: `current_pose()` returns it as `Option<[f32;3]>`, present only when the FC declared the velocity group valid (bit 3 — the same gate the planar speed projection uses) and every component is finite.
- Capture requires validated, finite velocity **at or below** 0.3 m/s. Missing, undeclared, or non-finite velocity keeps braking — "stopped" is never inferred from absent data (`NaN > 0.3` is false, which would otherwise capture the hold at full speed — the exact defect this PR prevents).
- The captured hold is sticky against velocity blips; any stick deflection returns to velocity mode. `send_neutral` (link-loss neutralize) untouched.

The threshold is on a measurement, not a control gain; the hold loop stays on the FC (LINK-04 gating: OperationalEstimate only, simulation truth ineligible).

## Deterministic timing

`FlightUplink` runs on an injectable clock (system in production, manually advanced in tests), so the post-arm quiet window and slew-limiter dt are exercised **without real-time sleeps** — the whole suite runs in ~10 ms.

## Guardrails (fake FC socket, manual clock)

- brake at |vel| ≈ 5 m/s (mask 2503, zero demand), purely vertical 1 m/s residual still brakes, capture below threshold (mask 2552 at the fixture pose), hold survives a velocity blip;
- **position-valid / velocity-invalid** (bit 3 cleared, even at numerically zero velocity) never captures — braking continues until validity plus stillness;
- **NaN, +∞, −∞** components each keep braking;
- **threshold boundary**: 0.301 m/s brakes, 0.299 m/s captures.

## Status / why draft

- [x] `cargo test -p pilotage-adapter-aviate` — 89 passed (no sleeps)
- [x] fmt, clippy `--all-targets -- -D warnings`, `check-structure.sh` clean; verified in an isolated worktree
- [x] SITL trajectory acceptance per #123 — **recorded** (see the results comment): vertical bounce-back 0.041 m (baseline ~0.4 m); horizontal worst backward excursion 0.49 m of damped hold-loop ringing with no directed return leg (baseline 1.5–2 m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)