### PR TITLE
DISP-02: fit tape readouts to their boxes across the value range

### DIFF
--- a/clients/web/scene-conformance-corpus.json
+++ b/clients/web/scene-conformance-corpus.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 2,
-  "corpusVersion": 2,
+  "corpusVersion": 3,
   "generatedBy": "pilotage-instrument-raster REN-04 conformance reference",
   "simOnly": "Canvas/browser backend is SIM / NOT FOR FLIGHT",
   "canonicalization": "trace args are Q8.8 floor(v*256); non-finite as nan/inf/-inf",
   "review": {
-    "reason": "Add interpreterRejects: the browser interpreter now enforces raw-argument guards (finite floats, |coordinate| <= coordLimitPx, path vertex budget) and the golden pins where it must throw; new paint-fault cases cover the rotate/translate/arc/stroke-width guard paths.",
+    "reason": "Add text-centered-multichar: a center-anchored multi-digit run at a readout-like size, pinning that both backends place centered readout values from the same nominal advance (DISP-02's width-aware readout fitting relies on that agreement).",
     "approvedBy": "REN-04 owner; regenerated goldens require human review and are never rewritten by CI."
   },
   "budgets": {
@@ -19,7 +19,7 @@
     "coordLimitPx": 32767,
     "worstCaseFrameBytes": 67108864
   },
-  "corpusSha256": "52d0c09cec4c8b73aea1bda4d9adbb6597a86fe184881e75d777520af4b576f3",
+  "corpusSha256": "7130efd29b19c2f0fb4622cefd7357dd4e6c038f70efa27e0adbebc4d03cdc6f",
   "entries": [
     {
       "name": "empty-background-canonical",
@@ -185,6 +185,20 @@
       "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 2, "layerCommands": [0, 4, 0, 0, 0, 0] },
       "render": { "ok": true, "error": null },
       "commandTrace": ["50:1", "01", "10:255,255,255,255", "30:3584,0,10240,10240,31", "02", "51:1"],
+      "interpreterRejects": null,
+      "canvasMethods": null,
+      "framingBoundaries": null
+    },
+    {
+      "name": "text-centered-multichar",
+      "category": "text",
+      "notes": "Center-anchored multi-digit run at a readout-like size: both backends place the run from the same nominal advance, so a centered readout value lands identically.",
+      "bytesHex": "0150010002010000100400ffffffff3012000000a841050000704300003443313033303002000051010002",
+      "framingValid": true,
+      "decode": { "ok": true, "error": null },
+      "gate": { "verdict": "accept", "error": null, "unknownOpcodes": 0, "layersPresent": 4, "layerCommands": [0, 0, 4, 0, 0, 0] },
+      "render": { "ok": true, "error": null },
+      "commandTrace": ["50:2", "01", "10:255,255,255,255", "30:5376,5,61440,46080,3130333030", "02", "51:2"],
       "interpreterRejects": null,
       "canvasMethods": null,
       "framingBoundaries": null

--- a/crates/pilotage-instrument-panels/src/pfd/tapes.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tapes.rs
@@ -4,7 +4,9 @@
 //! height (7.2 px/kt), altitude ±150 ft (1.2 px/ft), VSI ±1500 fpm full
 //! scale.
 
-use pilotage_instrument_scene::{Anchor, PaintMode, Rgba8, SceneError, SceneWriter};
+use pilotage_instrument_scene::{
+    Anchor, PaintMode, Rgba8, SceneError, SceneWriter, nominal_text_ink_width, nominal_text_width,
+};
 use pilotage_instrument_state::AltitudeClass;
 use pilotage_instrument_state::{PanelData, Sig};
 
@@ -55,7 +57,7 @@ pub fn speed_tape(
 
     // Pointed readout box, always drawn so `Missing` shows dashes.
     let text = fmt_label!(8, "{:03}", libm::roundf(ias.value) as i32);
-    pointed_box_right(scene, ias, text.as_str())?;
+    pointed_readout(scene, ias, text.as_str(), &IAS_READOUT)?;
 
     // Groundspeed box under the tape.
     let gs = data.gs_kt;
@@ -105,10 +107,47 @@ fn band_rect(
     Ok(())
 }
 
-fn pointed_box_right(
+/// Geometry of a pointed tape readout: the rectangular body spans
+/// `far_x`..`near_x`, the tip at `tip_x` points toward the tape, and
+/// the value is anchored at `text_x`, no larger than `preferred_size`.
+struct PointedBox {
+    far_x: f32,
+    near_x: f32,
+    tip_x: f32,
+    text_x: f32,
+    preferred_size: f32,
+}
+
+/// Airspeed readout: body at the panel's left edge, tip pointing right.
+const IAS_READOUT: PointedBox = PointedBox {
+    far_x: 2.0,
+    near_x: 75.0,
+    tip_x: 90.0,
+    text_x: 40.0,
+    preferred_size: 28.0,
+};
+
+/// Altitude readout: body at the panel's right edge, tip pointing left.
+const ALT_READOUT: PointedBox = PointedBox {
+    far_x: 478.0,
+    near_x: 405.0,
+    tip_x: 390.0,
+    text_x: 442.0,
+    preferred_size: 26.0,
+};
+
+/// Pointed value readout beside a tape. The run size shrinks
+/// deterministically from `preferred_size` until the run's nominal ink
+/// (the scene text-metrics contract every backend honors) fits the box
+/// body, so a wide value — "10300", "-1030" — renders smaller, never
+/// outside the box: an overflowing readout is silent display
+/// corruption (DISP-02), which the box must make impossible for the
+/// signal's whole representable range.
+fn pointed_readout(
     scene: &mut SceneWriter<'_>,
     sig: Sig<f32>,
     text: &str,
+    geo: &PointedBox,
 ) -> Result<(), SceneError> {
     scene.fill_color(palette::BOX_BG)?;
     let border = status_paint::status_accent(sig.status).unwrap_or(palette::WHITE);
@@ -116,13 +155,13 @@ fn pointed_box_right(
     scene.polygon(
         PaintMode::FillStroke,
         &[
-            [2.0, 155.0],
-            [75.0, 155.0],
-            [75.0, 168.0],
-            [90.0, 180.0],
-            [75.0, 192.0],
-            [75.0, 205.0],
-            [2.0, 205.0],
+            [geo.far_x, 155.0],
+            [geo.near_x, 155.0],
+            [geo.near_x, 168.0],
+            [geo.tip_x, 180.0],
+            [geo.near_x, 192.0],
+            [geo.near_x, 205.0],
+            [geo.far_x, 205.0],
         ],
     )?;
     scene.fill_color(if sig.status.shows_value() {
@@ -135,8 +174,31 @@ fn pointed_box_right(
     } else {
         "---"
     };
-    scene.text(40.0, 180.0, 28.0, Anchor::CENTER, shown)?;
+    let size = fitted_text_size(geo, shown.chars().count());
+    scene.text(geo.text_x, 180.0, size, Anchor::CENTER, shown)?;
     Ok(())
+}
+
+/// Largest run size, capped at the box's preferred size, whose nominal
+/// extents stay inside the box body from the box's text anchor: a
+/// center anchor overhangs half the anchor width leftward and the ink
+/// width minus that half rightward, and both extents scale linearly
+/// with size, so the cap is a pure ratio.
+fn fitted_text_size(geo: &PointedBox, chars: usize) -> f32 {
+    let body_left = geo.far_x.min(geo.near_x);
+    let body_right = geo.far_x.max(geo.near_x);
+    let width = nominal_text_width(geo.preferred_size, chars);
+    let ink = nominal_text_ink_width(geo.preferred_size, chars);
+    let left_need = width / 2.0;
+    let right_need = ink - width / 2.0;
+    let mut scale = 1.0f32;
+    if left_need > geo.text_x - body_left {
+        scale = scale.min((geo.text_x - body_left) / left_need);
+    }
+    if right_need > body_right - geo.text_x {
+        scale = scale.min((body_right - geo.text_x) / right_need);
+    }
+    geo.preferred_size * scale.max(0.0)
 }
 
 /// Right-edge altitude tape with selected-altitude bug and baro box.
@@ -190,7 +252,7 @@ pub fn altitude_tape(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<()
     }
 
     let text = fmt_label!(12, "{}", libm::roundf(alt.value / 10.0) as i64 * 10);
-    pointed_box_left(scene, alt, text.as_str())?;
+    pointed_readout(scene, alt, text.as_str(), &ALT_READOUT)?;
     reference_label(scene, data)?;
     baro_and_sel_boxes(scene, data)?;
     Ok(())
@@ -207,40 +269,6 @@ fn reference_label(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), 
         _ => palette::WHITE,
     })?;
     scene.text(442.0, 222.0, 12.0, Anchor::CENTER, class.label())?;
-    Ok(())
-}
-
-fn pointed_box_left(
-    scene: &mut SceneWriter<'_>,
-    sig: Sig<f32>,
-    text: &str,
-) -> Result<(), SceneError> {
-    scene.fill_color(palette::BOX_BG)?;
-    let border = status_paint::status_accent(sig.status).unwrap_or(palette::WHITE);
-    scene.stroke(border, 2.0)?;
-    scene.polygon(
-        PaintMode::FillStroke,
-        &[
-            [478.0, 155.0],
-            [405.0, 155.0],
-            [405.0, 168.0],
-            [390.0, 180.0],
-            [405.0, 192.0],
-            [405.0, 205.0],
-            [478.0, 205.0],
-        ],
-    )?;
-    scene.fill_color(if sig.status.shows_value() {
-        palette::WHITE
-    } else {
-        palette::RED
-    })?;
-    let shown = if sig.status.shows_value() {
-        text
-    } else {
-        "---"
-    };
-    scene.text(442.0, 180.0, 26.0, Anchor::CENTER, shown)?;
     Ok(())
 }
 

--- a/crates/pilotage-instrument-raster/src/raster/tests.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests.rs
@@ -9,6 +9,7 @@ use crate::{FrameId, FramebufferDims, RasterError, RenderReport, RenderStatus, r
 mod attitude_behavior;
 mod conformance;
 mod frame_hashes;
+mod readout_bounds;
 mod work_budget;
 
 const BLACK: Rgba8 = Rgba8::rgb(0, 0, 0);

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 mod builders;
+mod layer_builders;
 
 use std::vec::Vec;
 
@@ -195,7 +196,7 @@ pub(super) fn corpus() -> Vec<CorpusEntry> {
     builders::text_entries(&mut out);
     builders::paint_fault_entries(&mut out);
     builders::malformed_entries(&mut out);
-    builders::layer_entries(&mut out);
-    builders::budget_entries(&mut out);
+    layer_builders::layer_entries(&mut out);
+    layer_builders::budget_entries(&mut out);
     out
 }

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/builders.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/builders.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 
 use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, Rgba8};
 
-use super::{CorpusEntry, Generator, f32le, gen_entry, in_layer, push_cmd, raw};
+use super::{CorpusEntry, in_layer, push_cmd, raw};
 
 const WHITE: Rgba8 = Rgba8::rgb(255, 255, 255);
 const RED: Rgba8 = Rgba8::rgb(200, 0, 0);
@@ -202,6 +202,21 @@ pub(super) fn text_entries(out: &mut Vec<CorpusEntry>) {
         true,
     ));
     out.push(raw(
+        "text-centered-multichar",
+        "text",
+        Some(
+            "Center-anchored multi-digit run at a readout-like size: both \
+             backends place the run from the same nominal advance, so a \
+             centered readout value lands identically.",
+        ),
+        in_layer(LayerId::Tapes, |w| {
+            w.fill_color(WHITE).expect("fill");
+            w.text(240.0, 180.0, 21.0, Anchor::CENTER, "10300")
+                .expect("text");
+        }),
+        true,
+    ));
+    out.push(raw(
         "text-uncovered",
         "text",
         Some("Character absent from the pack: both backends fail the run, neither substitutes a font."),
@@ -349,149 +364,4 @@ fn malformed_line() -> Vec<u8> {
     push_cmd(&mut b, 0x02, &[]);
     push_cmd(&mut b, 0x51, &[LayerId::Attitude.to_u8()]);
     b
-}
-
-/// Builds a scene from a compact token DSL: `s` save, `r` restore, `x`
-/// fill-rect body, `b<id>`/`e<id>` begin/end layer. Whitespace separates
-/// tokens. This keeps each layer-structure case on one line.
-fn layer_scene(spec: &str) -> Vec<u8> {
-    let mut b = std::vec![1u8];
-    for tok in spec.split_whitespace() {
-        match tok.as_bytes() {
-            b"s" => push_cmd(&mut b, 0x01, &[]),
-            b"r" => push_cmd(&mut b, 0x02, &[]),
-            b"x" => push_rect(&mut b),
-            [b'b', id] => push_cmd(&mut b, 0x50, &[id - b'0']),
-            [b'e', id] => push_cmd(&mut b, 0x51, &[id - b'0']),
-            _ => panic!("bad layer token {tok}"),
-        }
-    }
-    b
-}
-
-fn push_rect(b: &mut Vec<u8>) {
-    let mut rect = std::vec![PaintMode::Fill.to_u8()];
-    for v in [0.0f32, 0.0, 4.0, 4.0] {
-        rect.extend_from_slice(&f32le(v));
-    }
-    push_cmd(b, 0x23, &rect);
-}
-
-fn layer_case(name: &'static str, notes: &'static str, spec: &str) -> CorpusEntry {
-    raw(
-        name,
-        "layer-structure",
-        Some(notes),
-        layer_scene(spec),
-        true,
-    )
-}
-
-pub(super) fn layer_entries(out: &mut Vec<CorpusEntry>) {
-    out.push(layer_case(
-        "duplicate-layer",
-        "Attitude opened twice.",
-        "b1 s r e1 b1 s r e1",
-    ));
-    out.push(layer_case(
-        "out-of-order-layer",
-        "Tapes then Attitude descends the z-order.",
-        "b2 s r e2 b1 s r e1",
-    ));
-    out.push(layer_case(
-        "nested-layer",
-        "Tapes opened while Attitude is open.",
-        "b1 s b2 s r e2 r e1",
-    ));
-    out.push(layer_case("end-without-begin", "A stray end marker.", "e1"));
-    out.push(layer_case(
-        "end-mismatch",
-        "Attitude closed by a Tapes end marker.",
-        "b1 s r e2",
-    ));
-    out.push(layer_case(
-        "unclosed-layer",
-        "The scene ends with Attitude still open.",
-        "b1 s r",
-    ));
-    out.push(layer_case(
-        "unisolated-state",
-        "A command before the isolation save.",
-        "b1 x s r e1",
-    ));
-    out.push(layer_case(
-        "unbalanced-state",
-        "The isolation save is left open at layer end.",
-        "b1 s e1",
-    ));
-    out.push(layer_case(
-        "command-outside-layer",
-        "A drawing command before any layer opens.",
-        "x",
-    ));
-    out.push(raw(
-        "unknown-opcode-outside-layer",
-        "layer-structure",
-        Some("An unknown opcode decodes but sits outside any layer."),
-        std::vec![1, 0x7f, 0, 0],
-        true,
-    ));
-}
-
-pub(super) fn budget_entries(out: &mut Vec<CorpusEntry>) {
-    let a = LayerId::Attitude.to_u8();
-    out.push(gen_entry(
-        "stack-depth-at-limit",
-        "budget",
-        Some("Peak graphics-state depth equals the 32 budget."),
-        Generator::NestSaves {
-            layer: a,
-            extra_saves: 31,
-        },
-    ));
-    out.push(gen_entry(
-        "stack-depth-over-limit",
-        "budget",
-        Some("One save past the depth budget."),
-        Generator::NestSaves {
-            layer: a,
-            extra_saves: 32,
-        },
-    ));
-    out.push(gen_entry(
-        "layer-commands-at-limit",
-        "budget",
-        Some("Layer command count equals the 4096 budget."),
-        Generator::RepeatUnknown {
-            layer: a,
-            count: 4094,
-        },
-    ));
-    out.push(gen_entry(
-        "layer-commands-over-limit",
-        "budget",
-        Some("One command past the per-layer budget."),
-        Generator::RepeatUnknown {
-            layer: a,
-            count: 4095,
-        },
-    ));
-    out.push(gen_entry(
-        "scene-bytes-at-limit",
-        "budget",
-        Some("Encoded scene equals the 65536-byte budget."),
-        Generator::FillBytes {
-            layer: a,
-            total_len: 65536,
-        },
-    ));
-    out.push(gen_entry(
-        "scene-bytes-over-limit",
-        "budget",
-        Some("One byte past the scene budget."),
-        Generator::FillBytes {
-            layer: a,
-            total_len: 65537,
-        },
-    ));
 }

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/layer_builders.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/corpus/layer_builders.rs
@@ -1,0 +1,156 @@
+//! Layer-discipline corpus cases: a compact token DSL builds each
+//! begin/end/save/restore structure on one line, covering the band
+//! ordering and state-isolation-envelope rules both backends enforce.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec::Vec;
+
+use pilotage_instrument_scene::{LayerId, PaintMode};
+
+use super::{CorpusEntry, Generator, f32le, gen_entry, push_cmd, raw};
+
+/// Builds a scene from a compact token DSL: `s` save, `r` restore, `x`
+/// fill-rect body, `b<id>`/`e<id>` begin/end layer. Whitespace separates
+/// tokens. This keeps each layer-structure case on one line.
+fn layer_scene(spec: &str) -> Vec<u8> {
+    let mut b = std::vec![1u8];
+    for tok in spec.split_whitespace() {
+        match tok.as_bytes() {
+            b"s" => push_cmd(&mut b, 0x01, &[]),
+            b"r" => push_cmd(&mut b, 0x02, &[]),
+            b"x" => push_rect(&mut b),
+            [b'b', id] => push_cmd(&mut b, 0x50, &[id - b'0']),
+            [b'e', id] => push_cmd(&mut b, 0x51, &[id - b'0']),
+            _ => panic!("bad layer token {tok}"),
+        }
+    }
+    b
+}
+
+fn push_rect(b: &mut Vec<u8>) {
+    let mut rect = std::vec![PaintMode::Fill.to_u8()];
+    for v in [0.0f32, 0.0, 4.0, 4.0] {
+        rect.extend_from_slice(&f32le(v));
+    }
+    push_cmd(b, 0x23, &rect);
+}
+
+fn layer_case(name: &'static str, notes: &'static str, spec: &str) -> CorpusEntry {
+    raw(
+        name,
+        "layer-structure",
+        Some(notes),
+        layer_scene(spec),
+        true,
+    )
+}
+
+pub(super) fn layer_entries(out: &mut Vec<CorpusEntry>) {
+    out.push(layer_case(
+        "duplicate-layer",
+        "Attitude opened twice.",
+        "b1 s r e1 b1 s r e1",
+    ));
+    out.push(layer_case(
+        "out-of-order-layer",
+        "Tapes then Attitude descends the z-order.",
+        "b2 s r e2 b1 s r e1",
+    ));
+    out.push(layer_case(
+        "nested-layer",
+        "Tapes opened while Attitude is open.",
+        "b1 s b2 s r e2 r e1",
+    ));
+    out.push(layer_case("end-without-begin", "A stray end marker.", "e1"));
+    out.push(layer_case(
+        "end-mismatch",
+        "Attitude closed by a Tapes end marker.",
+        "b1 s r e2",
+    ));
+    out.push(layer_case(
+        "unclosed-layer",
+        "The scene ends with Attitude still open.",
+        "b1 s r",
+    ));
+    out.push(layer_case(
+        "unisolated-state",
+        "A command before the isolation save.",
+        "b1 x s r e1",
+    ));
+    out.push(layer_case(
+        "unbalanced-state",
+        "The isolation save is left open at layer end.",
+        "b1 s e1",
+    ));
+    out.push(layer_case(
+        "command-outside-layer",
+        "A drawing command before any layer opens.",
+        "x",
+    ));
+    out.push(raw(
+        "unknown-opcode-outside-layer",
+        "layer-structure",
+        Some("An unknown opcode decodes but sits outside any layer."),
+        std::vec![1, 0x7f, 0, 0],
+        true,
+    ));
+}
+
+pub(super) fn budget_entries(out: &mut Vec<CorpusEntry>) {
+    let a = LayerId::Attitude.to_u8();
+    out.push(gen_entry(
+        "stack-depth-at-limit",
+        "budget",
+        Some("Peak graphics-state depth equals the 32 budget."),
+        Generator::NestSaves {
+            layer: a,
+            extra_saves: 31,
+        },
+    ));
+    out.push(gen_entry(
+        "stack-depth-over-limit",
+        "budget",
+        Some("One save past the depth budget."),
+        Generator::NestSaves {
+            layer: a,
+            extra_saves: 32,
+        },
+    ));
+    out.push(gen_entry(
+        "layer-commands-at-limit",
+        "budget",
+        Some("Layer command count equals the 4096 budget."),
+        Generator::RepeatUnknown {
+            layer: a,
+            count: 4094,
+        },
+    ));
+    out.push(gen_entry(
+        "layer-commands-over-limit",
+        "budget",
+        Some("One command past the per-layer budget."),
+        Generator::RepeatUnknown {
+            layer: a,
+            count: 4095,
+        },
+    ));
+    out.push(gen_entry(
+        "scene-bytes-at-limit",
+        "budget",
+        Some("Encoded scene equals the 65536-byte budget."),
+        Generator::FillBytes {
+            layer: a,
+            total_len: 65536,
+        },
+    ));
+    out.push(gen_entry(
+        "scene-bytes-over-limit",
+        "budget",
+        Some("One byte past the scene budget."),
+        Generator::FillBytes {
+            layer: a,
+            total_len: 65537,
+        },
+    ));
+}

--- a/crates/pilotage-instrument-raster/src/raster/tests/conformance/manifest.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/conformance/manifest.rs
@@ -22,10 +22,10 @@ use super::outcomes::{Outcome, outcome_of};
 use crate::{MAX_DIMENSION, MAX_POLYGON_VERTICES, WORST_CASE_FRAME_BYTES};
 
 const SCHEMA_VERSION: u32 = 2;
-const CORPUS_VERSION: u32 = 2;
-const REVIEW_REASON: &str = "Add interpreterRejects: the browser interpreter now enforces raw-argument \
-guards (finite floats, |coordinate| <= coordLimitPx, path vertex budget) and the golden pins where it \
-must throw; new paint-fault cases cover the rotate/translate/arc/stroke-width guard paths.";
+const CORPUS_VERSION: u32 = 3;
+const REVIEW_REASON: &str = "Add text-centered-multichar: a center-anchored multi-digit run at a \
+readout-like size, pinning that both backends place centered readout values from the same nominal \
+advance (DISP-02's width-aware readout fitting relies on that agreement).";
 const REVIEW_APPROVED_BY: &str =
     "REN-04 owner; regenerated goldens require human review and are never rewritten by CI.";
 

--- a/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -21,7 +21,7 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // covers the reference-typed heading: the rose turns with the fixture's
 // explicit SIM-declared independent sample — never quaternion yaw — and
 // paints the amber SIM reference label (NAV-01).
-const PFD_SHA256: &str = "3148b8e9d5c3d9cc5c1ac812c3f5674615649c65d4966ad3f1a85d1ce1f1d952";
+const PFD_SHA256: &str = "43b49bde6bbf7372d704d54214d4a3d0b9cd3ad09e86862a8ffc20fd6ae05ef1";
 const HSI_SHA256: &str = "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c";
 
 /// A fixed, richly populated state so every panel band paints content.

--- a/crates/pilotage-instrument-raster/src/raster/tests/readout_bounds.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/readout_bounds.rs
@@ -1,0 +1,298 @@
+#![allow(clippy::expect_used, clippy::panic)]
+//! DISP-02 guardrail: across the representable value range, the tape
+//! readouts' glyph runs stay inside their pointed boxes.
+//!
+//! The check is semantic, not pixel inspection: the PFD scene is
+//! decoded, each pointed readout box is located from its own polygon,
+//! and the following text run's extents are recomputed from the glyph
+//! manifest — the reference backend's actual metrics. A run whose ink
+//! would leave the box body fails here for the value that overflows,
+//! not as an unexplained pixel diff. A drift guard binds the scene
+//! text-metrics contract to those manifest metrics, so the panel-side
+//! fitting and the backend-side painting cannot diverge silently.
+
+use pilotage_instrument_glyphs::{ADVANCE, CELL_H, CELL_W};
+use pilotage_instrument_panels::{PANEL_W, PfdConfig, draw_pfd};
+use pilotage_instrument_scene::{
+    Anchor, Cmd, MAX_SCENE_BYTES, SceneCmds, SceneWriter, nominal_text_ink_width,
+    nominal_text_width,
+};
+use pilotage_instrument_state::{
+    AirData, AircraftState, Attitude, EstimateQuality, FreshnessPolicy, Kinematics, Quat, Stamped,
+    ValidFlags, resolve,
+};
+use std::string::{String, ToString};
+use std::vec::Vec;
+
+const FT_PER_M: f32 = 3.280_84;
+const MPS_PER_KT: f32 = 0.514_444;
+
+/// A level, valid flying state at the given altitude and airspeed.
+fn state_at(alt_ft: f32, ias_kt: f32) -> AircraftState {
+    let mut state = AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: Quat {
+                    w: 1.0,
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                rates_rps: [0.0, 0.0, 0.0],
+            }),
+            age_ms: Some(20.0),
+        },
+        ..AircraftState::default()
+    };
+    state.quality = EstimateQuality::Good;
+    state.valid = ValidFlags {
+        attitude: true,
+        rates: true,
+        position: true,
+        velocity: true,
+        ..ValidFlags::default()
+    };
+    state.kinematics = Stamped {
+        data: Some(Kinematics {
+            pos_ned_m: [0.0, 0.0, -alt_ft / FT_PER_M],
+            vel_ned_mps: [40.0, 0.0, 0.0],
+        }),
+        age_ms: Some(20.0),
+    };
+    state.air = Stamped {
+        data: Some(AirData {
+            ias_mps: Some(ias_kt * MPS_PER_KT),
+            baro_setting_hpa: Some(1013.0),
+        }),
+        age_ms: Some(20.0),
+    };
+    state
+}
+
+fn pfd_scene(alt_ft: f32, ias_kt: f32) -> Vec<u8> {
+    let data = resolve(&state_at(alt_ft, ias_kt), &FreshnessPolicy::default());
+    let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+    let mut writer = SceneWriter::new(&mut buf).expect("writer");
+    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("pfd");
+    let n = writer.finish();
+    buf.truncate(n);
+    buf
+}
+
+/// One located readout: its box body span and the run that followed it.
+struct ReadoutRun {
+    body_left: f32,
+    body_right: f32,
+    x: f32,
+    size: f32,
+    text: String,
+}
+
+/// The pointed-readout y profile: body corners at 155/205, shoulders at
+/// 168/192, tip vertex at 180.
+fn is_pointed_box(points: &[[f32; 2]]) -> bool {
+    points.len() == 7
+        && points
+            .iter()
+            .all(|p| [155.0, 168.0, 180.0, 192.0, 205.0].contains(&p[1]))
+        && points.iter().filter(|p| p[1] == 180.0).count() == 1
+}
+
+/// Decodes the scene and pairs every pointed readout box with the text
+/// run drawn after it (the readout value is the next text command the
+/// panel emits).
+fn readout_runs(bytes: &[u8]) -> Vec<ReadoutRun> {
+    let mut runs = Vec::new();
+    let mut pending: Option<(f32, f32)> = None;
+    for cmd in SceneCmds::new(bytes).expect("decode") {
+        match cmd.expect("cmd") {
+            Cmd::Polygon { points, .. } => {
+                let pts: Vec<[f32; 2]> = points.iter().collect();
+                if is_pointed_box(&pts) {
+                    let tip_y = 180.0;
+                    let body: Vec<f32> =
+                        pts.iter().filter(|p| p[1] != tip_y).map(|p| p[0]).collect();
+                    let left = body.iter().copied().fold(f32::INFINITY, f32::min);
+                    let right = body.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                    pending = Some((left, right));
+                }
+            }
+            Cmd::Text {
+                x,
+                size,
+                anchor,
+                text,
+                ..
+            } => {
+                if let Some((body_left, body_right)) = pending.take() {
+                    assert_eq!(anchor, Anchor::CENTER, "readout anchor");
+                    runs.push(ReadoutRun {
+                        body_left,
+                        body_right,
+                        x,
+                        size,
+                        text: text.to_string(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    runs
+}
+
+/// Ink extents of a run exactly as the reference backend paints it
+/// (`raster::text::draw_run`): pen advances `ADVANCE`-scaled per char,
+/// glyph ink spans `CELL_W`-scaled from the pen.
+fn ink_extents(run: &ReadoutRun) -> (f32, f32) {
+    let scale = run.size / CELL_H as f32;
+    let advance = f32::from(ADVANCE) * scale;
+    let chars = run.text.chars().count() as f32;
+    let width = chars * advance;
+    let left = run.x - width / 2.0;
+    let ink_right = left + width - (f32::from(ADVANCE) - CELL_W as f32) * scale;
+    (left, ink_right)
+}
+
+/// Altitude sweep: the full sign + five digit envelope after the 10-ft
+/// rounding — including the widest negative ("-99990"), both sides of
+/// every digit-count transition (±9,990 → ±10,000), and the live-defect
+/// value 1,030 ft that painted outside its box.
+const ALT_SWEEP_FT: [f32; 15] = [
+    -99_990.0, -10_000.0, -9_990.0, -1_030.0, -150.0, -10.0, 0.0, 990.0, 1_030.0, 2_450.0, 9_990.0,
+    10_000.0, 12_340.0, 45_670.0, 99_990.0,
+];
+/// Airspeed sweep: the `{:03}` format floor up through four digits.
+const IAS_SWEEP_KT: [f32; 6] = [0.0, 78.0, 145.0, 460.0, 999.0, 1_043.0];
+
+#[test]
+fn readout_runs_stay_inside_their_boxes_across_the_value_range() {
+    const TOLERANCE: f32 = 1e-3;
+    for alt_ft in ALT_SWEEP_FT {
+        for ias_kt in IAS_SWEEP_KT {
+            let scene = pfd_scene(alt_ft, ias_kt);
+            let runs = readout_runs(&scene);
+            assert_eq!(runs.len(), 2, "both tape readouts at {alt_ft}/{ias_kt}");
+            for run in &runs {
+                assert!(!run.text.is_empty(), "readout shows a value");
+                let (left, ink_right) = ink_extents(run);
+                assert!(
+                    left >= run.body_left - TOLERANCE && ink_right <= run.body_right + TOLERANCE,
+                    "run '{}' ink [{left}, {ink_right}] leaves box body \
+                     [{}, {}] at alt {alt_ft} ft / ias {ias_kt} kt",
+                    run.text,
+                    run.body_left,
+                    run.body_right,
+                );
+                assert!(
+                    left >= 0.0 && ink_right <= PANEL_W,
+                    "run '{}' leaves the panel at alt {alt_ft} ft / ias {ias_kt} kt",
+                    run.text,
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_defect_value_renders_all_its_digits() {
+    // 1,030 ft rounds to "1030": the readout must carry every digit —
+    // shrinking is legal, truncating or clipping is not.
+    let scene = pfd_scene(1_030.0, 78.0);
+    let runs = readout_runs(&scene);
+    let alt = runs
+        .iter()
+        .find(|r| r.body_left > 300.0)
+        .expect("altitude readout");
+    assert_eq!(alt.text, "1030");
+}
+
+#[test]
+fn scene_text_metrics_contract_matches_the_glyph_manifest() {
+    for (size, chars) in [(26.0f32, 1usize), (28.0, 3), (21.0, 4), (14.0, 6)] {
+        let scale = size / CELL_H as f32;
+        let manifest_width = chars as f32 * f32::from(ADVANCE) * scale;
+        let manifest_ink = manifest_width - (f32::from(ADVANCE) - CELL_W as f32) * scale;
+        assert!(
+            (nominal_text_width(size, chars) - manifest_width).abs() < 1e-4,
+            "advance contract drifted from the glyph manifest",
+        );
+        assert!(
+            (nominal_text_ink_width(size, chars) - manifest_ink).abs() < 1e-4,
+            "ink contract drifted from the glyph manifest",
+        );
+    }
+}
+
+/// The worst-width corners of the sweep, re-checked at the PIXEL level:
+/// each readout run is re-drawn in isolation and rasterized by the real
+/// reference backend, and every painted glyph pixel must land inside the
+/// box body (one pixel of quantization slack) and the panel. The
+/// semantic extent test above cannot catch a regression in raster
+/// anchoring, quantization, or glyph painting; this one does.
+const PIXEL_CASES: [(f32, f32); 3] = [(-99_990.0, 1_043.0), (1_030.0, 78.0), (99_990.0, 999.0)];
+
+#[test]
+fn readout_glyphs_paint_only_inside_their_boxes() {
+    let (w, h) = (PANEL_W as u32, 360u32);
+    for (alt_ft, ias_kt) in PIXEL_CASES {
+        let runs = readout_runs(&pfd_scene(alt_ft, ias_kt));
+        assert_eq!(runs.len(), 2, "both readouts at {alt_ft}/{ias_kt}");
+        for run in &runs {
+            // The run in isolation: any lit pixel is glyph ink.
+            let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
+            let mut writer = SceneWriter::new(&mut buf).expect("writer");
+            writer
+                .begin_layer(pilotage_instrument_scene::LayerId::Tapes)
+                .expect("begin layer");
+            writer
+                .fill_color(pilotage_instrument_scene::Rgba8 {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                })
+                .expect("fill");
+            writer
+                .text(run.x, 180.0, run.size, Anchor::CENTER, &run.text)
+                .expect("text");
+            writer
+                .end_layer(pilotage_instrument_scene::LayerId::Tapes)
+                .expect("end layer");
+            let n = writer.finish();
+            buf.truncate(n);
+
+            let mut fb = std::vec![0u8; (w * h * 4) as usize];
+            let report = crate::render(
+                &buf,
+                &mut fb,
+                crate::FramebufferDims::tight(w, h),
+                crate::FrameId::default(),
+            )
+            .expect("isolated run renders");
+            assert_eq!(report.status, crate::RenderStatus::Painted);
+
+            let mut lit = 0usize;
+            for py in 0..h {
+                for px in 0..w {
+                    let i = ((py * w + px) * 4) as usize;
+                    if fb[i] == 0 && fb[i + 1] == 0 && fb[i + 2] == 0 {
+                        continue;
+                    }
+                    lit += 1;
+                    let x = px as f32;
+                    assert!(
+                        x >= run.body_left - 1.0 && x + 1.0 <= run.body_right + 1.0,
+                        "glyph pixel ({px},{py}) of '{}' outside box body [{}, {}] \
+                         at alt {alt_ft} ft / ias {ias_kt} kt",
+                        run.text,
+                        run.body_left,
+                        run.body_right,
+                    );
+                    assert!(x + 1.0 <= PANEL_W, "glyph pixel outside the panel");
+                }
+            }
+            assert!(lit > 0, "run '{}' painted no pixels", run.text);
+        }
+    }
+}

--- a/crates/pilotage-instrument-scene/src/lib.rs
+++ b/crates/pilotage-instrument-scene/src/lib.rs
@@ -23,6 +23,7 @@ mod decode;
 mod encode;
 mod layer;
 mod opcode;
+mod text_metrics;
 
 pub use cmd::{Anchor, Cmd, HAlign, MAX_TEXT_BYTES, PaintMode, PointsRef, VAlign};
 pub use color::Rgba8;
@@ -31,6 +32,9 @@ pub use encode::{SceneError, SceneWriter};
 pub use layer::{
     LAYER_COUNT, LayerError, LayerId, LayerReport, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES,
     MAX_STACK_DEPTH, validate_layers,
+};
+pub use text_metrics::{
+    NOMINAL_ADVANCE_RATIO, NOMINAL_GLYPH_RATIO, nominal_text_ink_width, nominal_text_width,
 };
 
 /// Format version written as the first byte of every encoded scene.

--- a/crates/pilotage-instrument-scene/src/text_metrics.rs
+++ b/crates/pilotage-instrument-scene/src/text_metrics.rs
@@ -1,0 +1,35 @@
+//! Nominal text extents — the layout half of the text contract.
+//!
+//! Exact glyph ink stays backend-owned (ADR-0017): anchors describe
+//! intent, and no panel positions individual glyphs. But a layout that
+//! must CONTAIN text — a readout box whose digits may never paint
+//! outside it (DISP-01/DISP-02) — needs extents every backend agrees
+//! on. These functions are that agreement: a conforming backend
+//! advances the pen [`NOMINAL_ADVANCE_RATIO`] of the run size per
+//! character and paints no ink past [`nominal_text_ink_width`]. The
+//! ratios are the glyph manifest's cell advance and cell width over its
+//! cell height; REN-04 conformance holds the shipped backends to them.
+
+/// Per-character pen advance as a fraction of the run size.
+pub const NOMINAL_ADVANCE_RATIO: f32 = 6.0 / 7.0;
+
+/// Painted glyph width as a fraction of the run size; the difference
+/// from [`NOMINAL_ADVANCE_RATIO`] is the inter-character gap.
+pub const NOMINAL_GLYPH_RATIO: f32 = 5.0 / 7.0;
+
+/// Anchor width of a run: `chars` advances at `size`. This is the
+/// width backends use to place `Center` and `Right` anchors.
+#[must_use]
+pub fn nominal_text_width(size: f32, chars: usize) -> f32 {
+    chars as f32 * size * NOMINAL_ADVANCE_RATIO
+}
+
+/// Painted (ink) width of a run: the anchor width minus the trailing
+/// inter-character gap after the last glyph. Zero for an empty run.
+#[must_use]
+pub fn nominal_text_ink_width(size: f32, chars: usize) -> f32 {
+    if chars == 0 {
+        return 0.0;
+    }
+    nominal_text_width(size, chars) - size * (NOMINAL_ADVANCE_RATIO - NOMINAL_GLYPH_RATIO)
+}


### PR DESCRIPTION
Closes #116.

## Defect

The altitude readout painted four-digit values ("1030") wider than its pointed box — glyphs spilled past the border and clipped at the panel edge; the airspeed readout carried the identical fixed-width assumption one digit later.

## Fix — contract level, per the issue's required shape

- **`pilotage-instrument-scene` gains nominal text extents** (`nominal_text_width` / `nominal_text_ink_width`): the glyph-manifest advance/ink ratios REN-04 already pins both backends to. Exact glyph geometry stays backend-owned; what becomes contractual is the extent a *containing* layout may rely on.
- **One shared width-aware `pointed_readout`** replaces both duplicated boxes: the run shrinks deterministically until its nominal ink fits the box body. Sign + five digits ("−99990") renders smaller; nothing ever paints outside the box or the panel. In-range values render **byte-identically** (51 panel tests untouched).

## Guardrails — three independent layers

1. **Semantic value-range sweep** (15 altitudes × 6 airspeeds): the full sign+five-digit envelope — including the widest negative **−99,990** and both sides of every digit-count transition (±9,990 → ±10,000 → 99,990) — decoded from the real PFD scene, each readout run's extents recomputed from the glyph manifest and asserted inside its own box polygon. Failures name the offending value.
2. **True pixel-raster guard**: for the worst-width corners, each readout run is re-drawn in isolation and rasterized by the **real reference backend**; every painted glyph pixel must land inside the box body (1 px quantization slack) and the panel, and the run must actually paint. This catches raster anchoring / quantization / glyph-painting regressions the semantic test cannot.
3. **Cross-backend conformance case**: the REN-04 corpus (bumped to v3) gains `text-centered-multichar` — a center-anchored multi-digit run at a readout-like size — so the browser Canvas interpreter is pinned to the same centered placement the fitting math relies on (`scene-conformance.test.mjs` passes against the regenerated golden).

Plus a drift test binding the scene text-metrics contract to the glyph manifest, and a deliberate PFD frame-hash re-pin (the old golden, rendered at the fixture's 1,000.7 ft, contained the clipped "1000" defect).

## Verification

`cargo test -p pilotage-instrument-{scene,panels,raster}` (26/51/84), workspace clippy `-D warnings`, `check-structure.sh`, and the node conformance suite all pass — re-verified in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)