### PR TITLE
xtask sim: open the connected viewer by default; follow the invoking checkout

### DIFF
--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -47,7 +47,8 @@ pub struct SimArgs {
     pub host_port: u16,
     /// Static viewer port (`--viewer-port`).
     pub viewer_port: u16,
-    /// Open the ready URL in the default browser (`--open`).
+    /// Open the ready URL in the default browser (default on;
+    /// `--no-open` suppresses it, `--open` states it explicitly).
     pub open: bool,
 }
 
@@ -95,7 +96,7 @@ fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
     let mut profile = Profile::Simulation;
     let mut host_port: u16 = 4433;
     let mut viewer_port: u16 = 8080;
-    let mut open = false;
+    let mut open = true;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
@@ -104,6 +105,7 @@ fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
             "--port" => host_port = required_port(&mut iter, "--port")?,
             "--viewer-port" => viewer_port = required_port(&mut iter, "--viewer-port")?,
             "--open" => open = true,
+            "--no-open" => open = false,
             other => {
                 return Err(XtaskError::Usage {
                     message: format!("unknown sim flag {other:?}"),
@@ -160,7 +162,7 @@ commands:
          --profile <p>        physical | simulation (default) | oracle-only
          --port <n>           host WebTransport port (default: 4433)
          --viewer-port <n>    static viewer port (default: 8080)
-         --open               open the ready URL in the default browser
+         --no-open            do not open the ready URL in the default browser
   reset  reset the running simulation world and restart the FC
   help   print this text";
 
@@ -183,6 +185,14 @@ mod tests {
         assert_eq!(sim.profile, Profile::Simulation);
         assert_eq!(sim.host_port, 4433);
         assert_eq!(sim.viewer_port, 8080);
+        assert!(sim.open, "the browser opens by default");
+    }
+
+    #[test]
+    fn no_open_suppresses_the_browser() {
+        let Command::Sim(sim) = parse_args(&args(&["sim", "--no-open"])).expect("parses") else {
+            panic!("expected sim");
+        };
         assert!(!sim.open);
     }
 

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -171,9 +171,13 @@ pub fn parse_listening(line: &str) -> Option<(u16, String)> {
     Some((port, cert.to_owned()))
 }
 
-/// The pinned viewer URL for a ready session.
+/// The pinned viewer URL for a ready session. `autoconnect=1` tells the
+/// viewer to connect on load — the URL already pins host, port, and
+/// certificate, so a Connect click would add nothing.
 pub fn viewer_url(viewer_port: u16, host_port: u16, cert: &str) -> String {
-    format!("http://127.0.0.1:{viewer_port}/index.html?host=127.0.0.1&port={host_port}&cert={cert}")
+    format!(
+        "http://127.0.0.1:{viewer_port}/index.html?host=127.0.0.1&port={host_port}&cert={cert}&autoconnect=1"
+    )
 }
 
 /// The log file a stage writes under `log_dir`.
@@ -210,11 +214,13 @@ mod tests {
     }
 
     #[test]
-    fn viewer_url_pins_host_port_and_certificate() {
+    fn viewer_url_pins_host_port_certificate_and_autoconnect() {
         let cert = "0f".repeat(32);
         assert_eq!(
             viewer_url(8080, 4433, &cert),
-            format!("http://127.0.0.1:8080/index.html?host=127.0.0.1&port=4433&cert={cert}")
+            format!(
+                "http://127.0.0.1:8080/index.html?host=127.0.0.1&port=4433&cert={cert}&autoconnect=1"
+            )
         );
     }
 }

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -3,7 +3,7 @@
 //! signal — print the pinned URL, supervise, and tear everything down
 //! in reverse order on ctrl-c or when any stage dies.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -218,10 +218,19 @@ pub fn run_reset(fc: &str) -> Result<(), XtaskError> {
 /// operates on the repository the user is standing in. The compile-time
 /// path is only the fallback for running the binary outside cargo.
 fn repo_root() -> Result<PathBuf, XtaskError> {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")));
-    root_from(&manifest)
+    let runtime_manifest = std::env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
+    let manifest = resolve_manifest(
+        runtime_manifest.as_deref(),
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    );
+    root_from(manifest)
+}
+
+fn resolve_manifest<'a>(
+    runtime_manifest: Option<&'a Path>,
+    compiled_manifest: &'a Path,
+) -> &'a Path {
+    runtime_manifest.unwrap_or(compiled_manifest)
 }
 
 /// The workspace root two levels above `tools/xtask`.

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -210,9 +210,22 @@ pub fn run_reset(fc: &str) -> Result<(), XtaskError> {
     backend.reset(&repo_root()?)
 }
 
-/// This repository's root (the workspace this binary was built from).
+/// This repository's root: the checkout `cargo xtask` was INVOKED from.
+///
+/// `cargo run` exports `CARGO_MANIFEST_DIR` into the child's runtime
+/// environment, pointing at the invoking workspace's `tools/xtask` — so a
+/// binary cached from another checkout (a worktree, a moved clone) still
+/// operates on the repository the user is standing in. The compile-time
+/// path is only the fallback for running the binary outside cargo.
 fn repo_root() -> Result<PathBuf, XtaskError> {
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    root_from(&manifest)
+}
+
+/// The workspace root two levels above `tools/xtask`.
+fn root_from(manifest: &std::path::Path) -> Result<PathBuf, XtaskError> {
     manifest
         .ancestors()
         .nth(2)

--- a/tools/xtask/src/session/tests.rs
+++ b/tools/xtask/src/session/tests.rs
@@ -5,16 +5,32 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use std::io::Read;
+use std::path::Path;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use super::{claim_supervisor, start_stages, supervise, verify_listening_port};
+use super::{claim_supervisor, resolve_manifest, start_stages, supervise, verify_listening_port};
 use crate::backend::Stage;
 use crate::error::XtaskError;
 use crate::process::{ManagedChild, ProcessSpec};
 use crate::readiness::Readiness;
 
 const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[test]
+fn runtime_manifest_wins_over_deleted_compiled_checkout() {
+    let runtime = Path::new("/active/Pilotage/tools/xtask");
+    let deleted_compiled = Path::new("/deleted/worktree/tools/xtask");
+
+    assert_eq!(resolve_manifest(Some(runtime), deleted_compiled), runtime);
+}
+
+#[test]
+fn compiled_manifest_is_the_outside_cargo_fallback() {
+    let compiled = Path::new("/compiled/Pilotage/tools/xtask");
+
+    assert_eq!(resolve_manifest(None, compiled), compiled);
+}
 
 /// A stage that opens `fifo` for writing, prints READY, and parks.
 /// The fifo is the synchronization primitive: its open is the


### PR DESCRIPTION
Follow-up to the DEMO-01 launcher (#124/#125), prompted by two things found while running the #144 SITL acceptance:

**One command, zero clicks.** `cargo xtask sim` now opens the ready URL in the default browser by default (`--no-open` suppresses it), and the pinned URL carries `autoconnect=1`. The matching viewer change (stacked separately as the viewer-autoconnect PR, since it touches `main.js` above the #142/#143 stack) connects on load when the URL fully pins host, port, and certificate. Until that lands, the extra parameter is inert.

**A cached xtask binary now follows the checkout you invoke it from.** `repo_root()` was compile-time (`env!("CARGO_MANIFEST_DIR")`): a binary cached into a shared target dir from another checkout (a git worktree, a moved clone) permanently launched against that baked-in - possibly deleted - path, failing with `could not find Cargo.toml in <dead worktree>`. It now prefers the runtime `CARGO_MANIFEST_DIR` that `cargo run` exports, which always names the invoking workspace; the compile-time path remains only as the outside-cargo fallback.

Guardrails: `viewer_url` pins `autoconnect=1`; sim defaults open the browser; `--no-open` suppresses; the pure manifest resolver proves runtime precedence over a different/deleted compiled checkout and the compile-time fallback when no runtime path is supplied. Verified live: plain `cargo xtask sim` from the repo root brings up gazebo + FC + host + viewer, opens the browser, and the viewer connects hands-free (ServerWelcome -> LeaseRequest -> granted, generation 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)