### PR TITLE
Adapter: latch control across a commanded sim reset until a fresh FC stream

### DIFF
--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -30,7 +30,7 @@ mod sampling;
 mod shm_sampling;
 mod sources;
 mod startup;
-use control::{flight_button_pressed, normalized_flight_sticks, rejected_control};
+use control::{normalized_flight_sticks, rejected_control};
 use sampling::mavlink_batch;
 use shm_sampling::ShmSource;
 use sources::{ArmReport, EstimateSource, fc_state_sample};
@@ -112,6 +112,16 @@ pub struct AviateAdapter {
     started_at: std::time::Instant,
     last_reset: Option<std::time::Instant>,
     link_loss_policy: Option<LinkLossPolicy>,
+    // Commanded-reset latch: engaged when a sim reset is requested,
+    // cleared only by a fresh estimate source epoch plus demonstrated
+    // neutral input (control::ResetLatch). While engaged, everything
+    // except disarm is rejected.
+    reset_latch: Option<control::ResetLatch>,
+    // Reset script spawns recorded instead of executed, so tests can
+    // press the reset button without running the real script (which
+    // kills any live SITL FC on the machine).
+    #[cfg(test)]
+    reset_spawns: u32,
     // FPV mode latch (FPV_TOGGLE_BUTTON): attitude sticks + direct
     // thrust instead of velocity sticks + brake-to-hold.
     fpv_mode: bool,
@@ -150,6 +160,8 @@ impl AviateAdapter {
             arm_incarnation: SourceIncarnation::new([0; 16]),
             started_at: std::time::Instant::now(),
             last_reset: None,
+            reset_latch: None,
+            reset_spawns: 0,
             fpv_mode: false,
             link_loss_policy: None,
         }
@@ -245,32 +257,8 @@ impl VehicleAdapter for AviateAdapter {
 
     fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
         let tick = self.step(StepBudget { ticks: 0 }).now;
-        if self.uplink.is_none() {
-            return rejected_control(tick, RejectReason::UnknownScope);
-        }
-        if let Err(reason) = self.validate_flight_frame(frame) {
-            return rejected_control(tick, reason);
-        }
-        // The link-loss latch: while a policy is engaged the FC holds its
-        // policy state (braked hover) and ordinary frames are suppressed,
-        // so a newly granted holder with deflected sticks cannot fly the
-        // vehicle out of it. The host clears the latch only after the
-        // holder demonstrates neutral input.
-        if self.link_loss_policy.is_some() {
-            return rejected_control(tick, RejectReason::LinkLossEngaged);
-        }
-        if flight_button_pressed(frame, RESET_BUTTON) {
-            self.spawn_reset();
-        }
-        if flight_button_pressed(frame, DISARM_BUTTON) {
-            let Some(uplink) = self.uplink.as_mut() else {
-                return rejected_control(tick, RejectReason::UnknownScope);
-            };
-            uplink.send_disarm();
-            return ApplyOutcome {
-                tick,
-                disposition: Disposition::Accepted,
-            };
+        if let Some(outcome) = self.gated_flight_outcome(frame, tick) {
+            return outcome;
         }
         let Some((current_yaw, current_pos, current_vel)) = self.current_pose() else {
             return rejected_control(tick, RejectReason::MeasurementUnavailable);

--- a/adapters/aviate/src/adapter/control.rs
+++ b/adapters/aviate/src/adapter/control.rs
@@ -1,12 +1,40 @@
-//! Flight-control input helpers and reset handling.
+//! Flight-control input helpers, control gating, and reset handling.
 
 use std::time::{Duration, Instant};
 
-use pilotage_adapter_api::{ApplyOutcome, Disposition, RejectReason};
-use pilotage_protocol::{ButtonEdge, LogicalButtonId, ScopedControlFrame};
+use pilotage_adapter_api::{
+    ApplyOutcome, Disposition, RejectReason, payload_satisfies_neutral_activation,
+};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopedControlFrame};
 use pilotage_timing::SimTick;
 
-use super::AviateAdapter;
+use super::{
+    AviateAdapter, DISARM_BUTTON, PITCH_AXIS, RESET_BUTTON, ROLL_AXIS, THROTTLE_AXIS, YAW_AXIS,
+};
+
+/// Reset clearance uses the same 5%-of-full-stick scale as host recovery.
+const RESET_CLEAR_DEADBAND_MILLI: u32 = 50;
+const FLIGHT_AXES: [LogicalAxisId; 4] = [
+    LogicalAxisId::new(ROLL_AXIS),
+    LogicalAxisId::new(PITCH_AXIS),
+    LogicalAxisId::new(THROTTLE_AXIS),
+    LogicalAxisId::new(YAW_AXIS),
+];
+
+/// The engaged commanded-reset latch: the estimate stream's source epoch
+/// observed at engagement. `engaged_epoch` is `None` when no estimate
+/// stream was observable at that moment; the epoch-advance clearance can
+/// then never be satisfied, which fails closed (a profile without an
+/// estimate stream cannot arm anyway).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ResetLatch {
+    engaged_epoch: Option<u32>,
+}
+
+/// Reset clearance uses the canonical full-coverage neutral activation.
+fn frame_is_neutral(frame: &ScopedControlFrame) -> bool {
+    payload_satisfies_neutral_activation(&frame.payload, &FLIGHT_AXES, RESET_CLEAR_DEADBAND_MILLI)
+}
 
 pub(super) fn flight_button_pressed(frame: &ScopedControlFrame, button: u16) -> bool {
     frame.payload.edges.iter().any(|(candidate, edge)| {
@@ -39,7 +67,9 @@ pub(super) fn normalized_flight_sticks(frame: &ScopedControlFrame) -> ([f32; 4],
 impl AviateAdapter {
     /// Runs the SITL reset script (debounced to one per 5 s): world
     /// reset + FC restart, fire-and-forget. `PILOTAGE_RESET_CMD`
-    /// overrides the script path.
+    /// overrides the script path. Engages the commanded-reset latch:
+    /// the FC this adapter was talking to is about to die, so every
+    /// cached measurement loses its authority to validate control.
     pub(super) fn spawn_reset(&mut self) {
         let now = Instant::now();
         if self
@@ -52,19 +82,116 @@ impl AviateAdapter {
         // The restarted FC re-reports arm state under fresh heartbeats;
         // the pre-reset report must not survive as current.
         self.arm = None;
-        let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .and_then(std::path::Path::parent)
-                .map_or_else(|| ".".to_owned(), |path| path.display().to_string())
-                + "/scripts/reset-flight-sim.sh"
-        });
-        tracing::info!(%script, "simulation reset requested from the viewer");
-        if let Err(error) = std::process::Command::new(&script)
-            .arg("aviate_sitl")
-            .spawn()
+        let engaged_epoch = self.observed_source_epoch();
+        tracing::info!(
+            ?engaged_epoch,
+            "reset latch engaged; control suppressed until a fresh FC stream and neutral input"
+        );
+        self.reset_latch = Some(ResetLatch { engaged_epoch });
+        #[cfg(test)]
         {
-            tracing::warn!(%error, %script, "reset script failed to spawn");
+            self.reset_spawns = self.reset_spawns.wrapping_add(1);
         }
+        #[cfg(not(test))]
+        run_reset_command();
+    }
+
+    /// The pre-pose gate chain for one flight frame: structural checks,
+    /// the link-loss latch, reset/disarm button handling, and the
+    /// commanded-reset latch. `Some` is the early outcome; `None` lets
+    /// the caller proceed to measurement-dependent control.
+    pub(super) fn gated_flight_outcome(
+        &mut self,
+        frame: &ScopedControlFrame,
+        tick: SimTick,
+    ) -> Option<ApplyOutcome> {
+        if self.uplink.is_none() {
+            return Some(rejected_control(tick, RejectReason::UnknownScope));
+        }
+        if let Err(reason) = self.validate_flight_frame(frame) {
+            return Some(rejected_control(tick, reason));
+        }
+        // The link-loss latch: while a policy is engaged the FC holds its
+        // policy state (braked hover) and ordinary frames are suppressed,
+        // so a newly granted holder with deflected sticks cannot fly the
+        // vehicle out of it. The host clears the latch only after the
+        // holder demonstrates neutral input.
+        if self.link_loss_policy.is_some() {
+            return Some(rejected_control(tick, RejectReason::LinkLossEngaged));
+        }
+        if flight_button_pressed(frame, RESET_BUTTON) {
+            self.spawn_reset();
+        }
+        // Disarm is checked BEFORE the reset latch: surrendering
+        // authority must never be blocked, and it needs no measurement.
+        if flight_button_pressed(frame, DISARM_BUTTON) {
+            let Some(uplink) = self.uplink.as_mut() else {
+                return Some(rejected_control(tick, RejectReason::UnknownScope));
+            };
+            uplink.send_disarm();
+            return Some(ApplyOutcome {
+                tick,
+                disposition: Disposition::Accepted,
+            });
+        }
+        // The commanded-reset latch: cached measurements inside the
+        // freshness budget are pre-reset data, and the rebooting FC
+        // accepts arm before its estimator converges. Suppress control
+        // until the estimate stream enters a fresh source epoch and the
+        // holder demonstrates neutral input.
+        if self.reset_latch_blocks(frame) {
+            return Some(rejected_control(tick, RejectReason::ResetInProgress));
+        }
+        None
+    }
+
+    /// Whether the commanded-reset latch suppresses this frame,
+    /// attempting clearance first: the estimate stream must have entered
+    /// a new source epoch (only the restarted FC's own measurements can
+    /// do that — a stale cache keeps the engaged epoch), the frame must
+    /// be neutral, and a full pose must be recoverable from the fresh
+    /// stream.
+    fn reset_latch_blocks(&mut self, frame: &ScopedControlFrame) -> bool {
+        let Some(latch) = self.reset_latch else {
+            return false;
+        };
+        let epoch_advanced = matches!(
+            (latch.engaged_epoch, self.observed_source_epoch()),
+            (Some(engaged), Some(current)) if current != engaged
+        );
+        if epoch_advanced && frame_is_neutral(frame) && self.current_pose().is_some() {
+            tracing::info!("reset latch cleared: fresh FC stream and neutral input");
+            self.reset_latch = None;
+            return false;
+        }
+        true
+    }
+
+    /// The estimate stream's current acquisition epoch, when observable.
+    fn observed_source_epoch(&self) -> Option<u32> {
+        let source = self.estimate.as_ref()?;
+        let latest = source.state.lock().ok()?;
+        Some(latest.source_epoch)
+    }
+}
+
+/// Spawns the reset script without waiting for it. Not compiled for
+/// tests: the script resets the live simulator and kills any running
+/// SITL FC on the machine.
+#[cfg(not(test))]
+fn run_reset_command() {
+    let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .map_or_else(|| ".".to_owned(), |path| path.display().to_string())
+            + "/scripts/reset-flight-sim.sh"
+    });
+    tracing::info!(%script, "simulation reset requested from the viewer");
+    if let Err(error) = std::process::Command::new(&script)
+        .arg("aviate_sitl")
+        .spawn()
+    {
+        tracing::warn!(%error, %script, "reset script failed to spawn");
     }
 }

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -184,7 +184,7 @@ impl super::AviateAdapter {
     /// infer "stopped" from a missing velocity.
     pub(super) fn current_pose(&mut self) -> Option<(f32, [f32; 3], Option<[f32; 3]>)> {
         let latest = self.estimate.as_ref()?.state.lock().ok()?;
-        latest.estimator_status_stamp()?;
+        let status_stamp = latest.estimator_status_stamp()?;
         let attitude = latest
             .attitude
             .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
@@ -193,7 +193,15 @@ impl super::AviateAdapter {
             .kinematics
             .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
             .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
-        if !measurement_pair_is_coherent(attitude, kinematics, latest.maximum_inter_group_skew_ms)
+        let current_epoch = latest.source_epoch;
+        if status_stamp.source_epoch != current_epoch
+            || attitude.stamp.source_epoch != current_epoch
+            || kinematics.stamp.source_epoch != current_epoch
+            || !measurement_pair_is_coherent(
+                attitude,
+                kinematics,
+                latest.maximum_inter_group_skew_ms,
+            )
             || !measurement_pair_supports_pose(attitude, kinematics)
         {
             return None;

--- a/adapters/aviate/src/adapter/startup.rs
+++ b/adapters/aviate/src/adapter/startup.rs
@@ -76,6 +76,9 @@ impl AviateAdapter {
             arm_incarnation,
             started_at: std::time::Instant::now(),
             last_reset: None,
+            reset_latch: None,
+            #[cfg(test)]
+            reset_spawns: 0,
             fpv_mode: false,
             link_loss_policy: None,
         })

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -316,3 +316,4 @@ fn control_frames_are_rejected_at_the_boundary() {
 }
 
 mod link_loss_enact;
+mod reset_latch;

--- a/adapters/aviate/src/adapter/tests/reset_latch.rs
+++ b/adapters/aviate/src/adapter/tests/reset_latch.rs
@@ -1,0 +1,285 @@
+//! The commanded-reset latch at the adapter boundary: a reset request
+//! invalidates every cached measurement's authority to validate control.
+//! Until the estimate stream provably restarts (a fresh source epoch)
+//! AND the holder demonstrates neutral input, everything except disarm
+//! is rejected with a typed reason — an arm validated against pre-reset
+//! data can reach the rebooting FC while its estimator is unconverged
+//! and bank the vehicle on the ground.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+
+use crate::link::{LatestAviate, ResetPolicy, apply_messages_at};
+use crate::mavlink::{AviateMessage, FrameSource};
+
+use super::super::{
+    ARM_BUTTON, AviateAdapter, DISARM_BUTTON, PITCH_AXIS, RESET_BUTTON, ROLL_AXIS, THROTTLE_AXIS,
+    YAW_AXIS,
+};
+use super::fixtures::{flight_frame, state_with};
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 0,
+};
+
+fn adapter_with_fake_fc() -> (AviateAdapter, std::net::UdpSocket, Arc<Mutex<LatestAviate>>) {
+    let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    let adapter = AviateAdapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink);
+    (adapter, fc, state)
+}
+
+fn press(button: u16) -> pilotage_protocol::ScopedControlFrame {
+    flight_frame(
+        vec![],
+        vec![(LogicalButtonId::new(button), ButtonEdge::Pressed)],
+    )
+}
+
+fn neutral() -> pilotage_protocol::ScopedControlFrame {
+    flight_frame(
+        vec![
+            (LogicalAxisId::new(ROLL_AXIS), 0.0),
+            (LogicalAxisId::new(PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.0),
+            (LogicalAxisId::new(YAW_AXIS), 0.0),
+        ],
+        vec![],
+    )
+}
+
+fn status(time_boot_ms: u32) -> AviateMessage {
+    AviateMessage::AviateEstimatorStatus {
+        time_usec: u64::from(time_boot_ms).saturating_mul(1_000),
+        valid_flags: 0x0f,
+        quality: 2,
+    }
+}
+
+fn attitude(time_boot_ms: u32) -> AviateMessage {
+    AviateMessage::AttitudeQuaternion {
+        time_boot_ms,
+        quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+        rates_rps: [0.0; 3],
+    }
+}
+
+fn kinematics(time_boot_ms: u32) -> AviateMessage {
+    AviateMessage::LocalPositionNed {
+        time_boot_ms,
+        pos_ned_m: [0.0; 3],
+        vel_ned_mps: [0.0; 3],
+    }
+}
+
+fn apply_at(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage], now: Instant) {
+    let sourced = messages
+        .iter()
+        .copied()
+        .map(|message| (SOURCE, message))
+        .collect::<Vec<_>>();
+    apply_messages_at(state, &sourced, 0, 0, now);
+}
+
+fn drive_fresh_epoch(state: &Arc<Mutex<LatestAviate>>) {
+    let start = Instant::now();
+    {
+        let mut latest = state.lock().expect("state");
+        latest.reset_policy = ResetPolicy::SimulatorHeuristic;
+        latest.last_source_time_ms = Some(5_000);
+        latest.last_accepted_at = start.checked_sub(Duration::from_secs(4));
+    }
+    apply_at(state, &[status(100)], start);
+    apply_at(state, &[status(200)], start + Duration::from_millis(100));
+    apply_at(
+        state,
+        &[status(400), attitude(400), kinematics(400)],
+        start + Duration::from_millis(400),
+    );
+
+    let latest = state.lock().expect("state");
+    assert_eq!(latest.source_epoch, 2, "link starts a fresh epoch");
+    assert_eq!(
+        latest.attitude.expect("attitude").stamp.source_epoch,
+        2,
+        "attitude is repopulated in the fresh epoch"
+    );
+    assert_eq!(
+        latest.kinematics.expect("kinematics").stamp.source_epoch,
+        2,
+        "kinematics is repopulated in the fresh epoch"
+    );
+    assert_eq!(
+        latest
+            .estimator_status_stamp()
+            .expect("status")
+            .source_epoch,
+        2,
+        "authorization is repopulated in the fresh epoch"
+    );
+}
+
+#[test]
+fn reset_press_engages_the_latch_and_debounces_the_script() {
+    let (mut adapter, _fc, _state) = adapter_with_fake_fc();
+    let outcome = adapter.apply_control(&press(RESET_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "the reset press itself carries no control authority"
+    );
+    assert_eq!(adapter.reset_spawns, 1, "one script spawn recorded");
+    let outcome = adapter.apply_control(&press(RESET_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress)
+    );
+    assert_eq!(
+        adapter.reset_spawns, 1,
+        "a second press inside the debounce window does not respawn"
+    );
+}
+
+#[test]
+fn stale_epoch_measurements_cannot_revalidate_arm_or_motion() {
+    // The core hazard: the cached estimate is FRESH by age (received
+    // moments ago) but belongs to the pre-reset FC — the source epoch
+    // has not advanced. Arm and motion must stay rejected.
+    let (mut adapter, _fc, _state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "arm against pre-reset measurements is rejected"
+    );
+    let motion = flight_frame(vec![(LogicalAxisId::new(PITCH_AXIS), 0.8)], vec![]);
+    let outcome = adapter.apply_control(&motion);
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "motion against pre-reset measurements is rejected"
+    );
+}
+
+#[test]
+fn disarm_bypasses_the_latch() {
+    let (mut adapter, fc, _state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    let outcome = adapter.apply_control(&press(DISARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "surrendering authority is never blocked by the reset latch"
+    );
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf)
+        .expect("disarm datagram reaches the FC");
+}
+
+#[test]
+fn fresh_epoch_plus_neutral_input_clears_the_latch() {
+    let (mut adapter, fc, state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    drive_fresh_epoch(&state);
+
+    let outcome = adapter.apply_control(&neutral());
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "a neutral frame over the fresh stream clears the latch"
+    );
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "arm proceeds once the latch has cleared"
+    );
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf).expect("arm datagram reaches the FC");
+}
+
+#[test]
+fn source_epoch_counter_alone_cannot_clear_the_latch() {
+    let (mut adapter, _fc, state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    state.lock().expect("state").source_epoch = 2;
+
+    let outcome = adapter.apply_control(&neutral());
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "epoch-1 measurements cannot clear a latch whose counter says epoch 2"
+    );
+}
+
+#[test]
+fn fresh_epoch_requires_every_flight_axis() {
+    let (mut adapter, _fc, state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    drive_fresh_epoch(&state);
+
+    let missing_yaw = flight_frame(
+        vec![
+            (LogicalAxisId::new(ROLL_AXIS), 0.0),
+            (LogicalAxisId::new(PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.0),
+        ],
+        vec![],
+    );
+    let outcome = adapter.apply_control(&missing_yaw);
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "a missing declared axis cannot clear the latch"
+    );
+    let outcome = adapter.apply_control(&flight_frame(vec![], vec![]));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "an empty control payload cannot clear the latch"
+    );
+}
+
+#[test]
+fn fresh_epoch_with_active_input_stays_latched() {
+    let (mut adapter, _fc, state) = adapter_with_fake_fc();
+    adapter.apply_control(&press(RESET_BUTTON));
+    drive_fresh_epoch(&state);
+
+    // An arm edge is not neutral: clearing on it would let the very
+    // frame that re-arms ride in before sticks were ever released.
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "an arm edge does not clear the latch"
+    );
+    // Deflected sticks are not neutral either.
+    let deflected = flight_frame(
+        vec![
+            (LogicalAxisId::new(ROLL_AXIS), 0.0),
+            (LogicalAxisId::new(PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.5),
+            (LogicalAxisId::new(YAW_AXIS), 0.0),
+        ],
+        vec![],
+    );
+    let outcome = adapter.apply_control(&deflected);
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "deflected sticks do not clear the latch"
+    );
+    let outcome = adapter.apply_control(&neutral());
+    assert_eq!(outcome.disposition, Disposition::Accepted, "neutral clears");
+}

--- a/adapters/aviate/src/link.rs
+++ b/adapters/aviate/src/link.rs
@@ -368,7 +368,7 @@ fn apply_messages(
     apply_messages_at(state, messages, crc_failures, unknown_ids, Instant::now());
 }
 
-fn apply_messages_at(
+pub(crate) fn apply_messages_at(
     state: &Arc<Mutex<LatestAviate>>,
     messages: &[(FrameSource, AviateMessage)],
     crc_failures: u32,

--- a/crates/pilotage-adapter-api/src/control.rs
+++ b/crates/pilotage-adapter-api/src/control.rs
@@ -1,7 +1,39 @@
 //! Control-application outcomes and link-loss policy vocabulary (ADR-0008).
 
+use pilotage_protocol::{ButtonEdge, ControlPayload, LogicalAxisId};
 use pilotage_timing::SimTick;
 use serde::{Deserialize, Serialize};
+
+/// Whether a control payload proves neutral activation for every axis a
+/// scope declares.
+///
+/// Every declared axis must be reported inside the deadband, every reported
+/// axis must be finite and inside it, and no pressed button edge is allowed.
+/// Full coverage prevents a retained value for an omitted axis from becoming
+/// active when a safety latch clears.
+#[must_use]
+pub fn payload_satisfies_neutral_activation(
+    payload: &ControlPayload,
+    declared_axes: &[LogicalAxisId],
+    deadband_milli: u32,
+) -> bool {
+    let deadband = deadband_milli as f32 / 1000.0;
+    let all_declared_reported_neutral = declared_axes.iter().all(|axis| {
+        payload
+            .axes
+            .iter()
+            .any(|(reported, value)| reported == axis && value.abs() <= deadband)
+    });
+    let all_reported_neutral = payload
+        .axes
+        .iter()
+        .all(|(_, value)| value.abs() <= deadband);
+    let no_pressed_edge = payload
+        .edges
+        .iter()
+        .all(|(_, edge)| *edge != ButtonEdge::Pressed);
+    all_declared_reported_neutral && all_reported_neutral && no_pressed_edge
+}
 
 /// Why an adapter did not accept a control frame as-is.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,6 +55,15 @@ pub enum RejectReason {
     /// with deflected sticks would drive the vehicle straight out of its
     /// neutralized state.
     LinkLossEngaged,
+    /// A commanded simulation reset is in progress on the vehicle:
+    /// control frames are suppressed until the estimate stream provably
+    /// restarts (a fresh source epoch) and the holder demonstrates
+    /// neutral input. Without this latch, an arm pressed inside the
+    /// restart window would be validated against pre-reset measurements
+    /// still within the freshness budget, and could reach the rebooting
+    /// FC while its estimator is unconverged. Disarm is exempt:
+    /// surrendering authority is never blocked.
+    ResetInProgress,
     /// The adapter rejected the frame for a reason not covered above.
     Other(String),
 }

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -13,7 +13,10 @@ mod vehicle_adapter;
 mod video;
 
 pub use capability::{AdapterCapabilities, ExecutionMode, ScopeDescriptor, VehicleDescriptor};
-pub use control::{ApplyOutcome, Disposition, LinkLossEnactError, LinkLossPolicy, RejectReason};
+pub use control::{
+    ApplyOutcome, Disposition, LinkLossEnactError, LinkLossPolicy, RejectReason,
+    payload_satisfies_neutral_activation,
+};
 // CAL-01 (#90): the camera calibration contract moved to
 // `pilotage-camera-calibration`; re-export it so `pilotage_adapter_api::…` paths
 // for consumers are unchanged, and expose the new `VerifiedCameraModel`.

--- a/crates/pilotage-session/src/engine/link_loss.rs
+++ b/crates/pilotage-session/src/engine/link_loss.rs
@@ -19,7 +19,9 @@
 //! [`LinkLossPolicy::Neutralize`] — the only universally safe floor — as
 //! does an unconfigured vehicle.
 
-use pilotage_adapter_api::{AdapterCapabilities, LinkLossPolicy};
+use pilotage_adapter_api::{
+    AdapterCapabilities, LinkLossPolicy, payload_satisfies_neutral_activation,
+};
 use pilotage_authority::AuthorityEffect;
 use pilotage_protocol::{ControlPayload, LogicalAxisId, ScopeId, VehicleId};
 use pilotage_timing::MonoTimestamp;
@@ -201,7 +203,11 @@ impl SessionEngine {
             // anything; stay engaged (fail closed).
             return;
         };
-        if !payload_is_neutral(payload, declared, self.config.activation_deadband_milli) {
+        if !payload_satisfies_neutral_activation(
+            payload,
+            declared,
+            self.config.activation_deadband_milli,
+        ) {
             return;
         }
         self.link_loss.clear_scope(vehicle, scope);
@@ -226,33 +232,4 @@ fn declared_axes<'a>(
         .iter()
         .find(|descriptor| descriptor.scope == *scope)
         .map(|descriptor| descriptor.axes.as_slice())
-}
-
-/// The activation condition for one scope: EVERY axis the scope declares is
-/// reported inside the neutral deadband, every reported axis (declared or
-/// not) is inside it too, and no edge is pressed. Requiring full declared
-/// coverage matters because adapters retain latest-valid values per axis: a
-/// frame omitting a previously deflected axis would un-latch straight into
-/// that stale deflection.
-fn payload_is_neutral(
-    payload: &ControlPayload,
-    declared: &[LogicalAxisId],
-    deadband_milli: u32,
-) -> bool {
-    let deadband = deadband_milli as f32 / 1000.0;
-    let all_declared_reported_neutral = declared.iter().all(|axis| {
-        payload
-            .axes
-            .iter()
-            .any(|(reported, value)| reported == axis && value.abs() <= deadband)
-    });
-    let all_reported_neutral = payload
-        .axes
-        .iter()
-        .all(|(_, value)| value.abs() <= deadband);
-    let no_pressed_edge = payload
-        .edges
-        .iter()
-        .all(|(_, edge)| *edge != pilotage_protocol::ButtonEdge::Pressed);
-    all_declared_reported_neutral && all_reported_neutral && no_pressed_edge
 }


### PR DESCRIPTION
Closes #151. The reset button kills the FC, but control kept flowing throughout the restart window: cached pre-reset measurements (still inside the 3 s freshness budget, validity flags cached from the dead FC) could validate an arm, and the rebooting FC accepts arm ~100 ms after boot while its estimator is unconverged (Aviate #287) — an immediate re-arm banks the vehicle on the pad.

The fix is a commanded-reset latch engaged in `spawn_reset`:

- Everything except **disarm** is rejected with the new typed `RejectReason::ResetInProgress`. Disarm bypasses the latch entirely — surrendering authority is never blocked, and it needs no measurement.
- Clearance requires ALL of: the estimate stream entering a **fresh MAVLink source epoch** (only the restarted FC's own measurements advance it, and `begin_source_epoch` clears every cached group, so stale data structurally cannot satisfy it), a **neutral frame** with explicit finite roll, pitch, throttle, and yaw values inside the canonical deadband and no pressed edges, and a full pose recoverable from the fresh stream. The frame that re-arms can never be the frame that clears.
- The gate chain (link-loss latch → reset/disarm buttons → reset latch) moved to `adapter/control.rs` as `gated_flight_outcome`, keeping `apply_control` and both files inside the structure limits.

Guardrail in the same PR: seven behavioral tests in `adapter/tests/reset_latch.rs` — stale-epoch rejection, disarm bypass, fresh-epoch neutral clearance, counter-only epoch rejection, missing/empty-axis rejection, active-input refusal, and script-spawn debounce. The reset script spawn is stubbed under `cfg(test)` so the suite cannot kill a live SITL FC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)