### PR TITLE
Extract the MAVLink codec and receive link into pilotage-mavlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "getrandom 0.3.4",
  "pilotage-adapter-api",
  "pilotage-adapter-gazebo",
+ "pilotage-mavlink",
  "pilotage-protocol",
  "pilotage-timing",
  "thiserror",
@@ -1202,6 +1203,16 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "pilotage-mavlink"
+version = "0.1.0"
+dependencies = [
+ "pilotage-adapter-api",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/pilotage-input",
     "crates/pilotage-timing",
     "crates/pilotage-adapter-api",
+    "crates/pilotage-mavlink",
     "crates/pilotage-conformance",
     "crates/pilotage-frames",
     "crates/pilotage-calibration-id",
@@ -62,6 +63,7 @@ pilotage-protocol = { path = "crates/pilotage-protocol" }
 pilotage-authority = { path = "crates/pilotage-authority" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
+pilotage-mavlink = { path = "crates/pilotage-mavlink" }
 pilotage-frames = { path = "crates/pilotage-frames" }
 pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-camera-calibration = { path = "crates/pilotage-camera-calibration" }

--- a/adapters/aviate/Cargo.toml
+++ b/adapters/aviate/Cargo.toml
@@ -13,6 +13,7 @@ aviate-xil-contract = { workspace = true }
 aviate-xil-shm = { workspace = true }
 getrandom = { version = "0.3.4", features = ["std"] }
 pilotage-adapter-api = { workspace = true }
+pilotage-mavlink = { workspace = true }
 pilotage-adapter-gazebo = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }

--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -19,7 +19,7 @@ use pilotage_timing::SimTick;
 use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
-use crate::link::LatestAviate;
+use pilotage_mavlink::link::LinkState;
 
 use crate::error::AviateAdapterError;
 use crate::uplink::FlightUplink;
@@ -147,7 +147,7 @@ impl AviateAdapter {
 
     /// Wires an adapter around a caller-supplied state cache, for tests.
     #[cfg(test)]
-    pub(crate) fn from_state(vehicle: VehicleId, state: Arc<Mutex<LatestAviate>>) -> Self {
+    pub(crate) fn from_state(vehicle: VehicleId, state: Arc<Mutex<LinkState>>) -> Self {
         Self {
             vehicle,
             estimate: Some(EstimateSource { state, _link: None }),

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -10,8 +10,8 @@ use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
 use super::WITHHOLD_AFTER;
-use crate::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
-use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
+use pilotage_mavlink::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
+use pilotage_mavlink::link::{AttitudeUpdate, KinematicsUpdate, LinkState};
 
 /// Yaw extracted from the body→NED quaternion (heading, radians
 /// clockwise from north).
@@ -112,10 +112,7 @@ fn effective_authorization(
     (flags, quality)
 }
 
-pub(crate) fn mavlink_batch(
-    vehicle: VehicleId,
-    state: &Arc<Mutex<LatestAviate>>,
-) -> TelemetryBatch {
+pub(crate) fn mavlink_batch(vehicle: VehicleId, state: &Arc<Mutex<LinkState>>) -> TelemetryBatch {
     let Ok(latest) = state.lock() else {
         return TelemetryBatch::default();
     };

--- a/adapters/aviate/src/adapter/sources.rs
+++ b/adapters/aviate/src/adapter/sources.rs
@@ -13,16 +13,16 @@ use super::AviateProfile;
 use super::shm_sampling::ShmSource;
 use crate::error::AviateAdapterError;
 use crate::incarnation::IncarnationProvider;
-use crate::link::{AviateLink, LatestAviate, LinkConfig};
+use pilotage_mavlink::link::{LinkConfig, LinkState, MavlinkLink};
 
 /// The MAVLink estimate link: the latest-value cache plus the receive
 /// task that feeds it. This link only ever produces the FC operational
 /// estimate role.
 #[derive(Debug)]
 pub(super) struct EstimateSource {
-    pub(super) state: Arc<Mutex<LatestAviate>>,
+    pub(super) state: Arc<Mutex<LinkState>>,
     // Kept alive for its receive task; dropped with the adapter.
-    pub(super) _link: Option<AviateLink>,
+    pub(super) _link: Option<MavlinkLink>,
 }
 
 /// One FC arm report received on the uplink socket, with receive-side
@@ -81,7 +81,7 @@ async fn estimate_source(
     config: LinkConfig,
     incarnation: SourceIncarnation,
 ) -> Result<EstimateSource, AviateAdapterError> {
-    let link = AviateLink::start(config, incarnation).await?;
+    let link = MavlinkLink::start(config, incarnation).await?;
     Ok(EstimateSource {
         state: link.state(),
         _link: Some(link),

--- a/adapters/aviate/src/adapter/startup.rs
+++ b/adapters/aviate/src/adapter/startup.rs
@@ -6,8 +6,8 @@ use pilotage_protocol::VehicleId;
 use super::{AviateAdapter, AviateProfile, camera, sources::bind_sources};
 use crate::error::AviateAdapterError;
 use crate::incarnation::{IncarnationProvider, OsIncarnationProvider};
-use crate::link::LinkConfig;
 use crate::uplink::FlightUplink;
+use pilotage_mavlink::link::LinkConfig;
 
 impl AviateAdapter {
     /// Binds the profile's source roles and returns a ready adapter.

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -8,7 +8,7 @@ use pilotage_adapter_api::{
 };
 use pilotage_protocol::{ButtonEdge, LogicalButtonId, VehicleId};
 
-use crate::link::KinematicsUpdate;
+use pilotage_mavlink::link::KinematicsUpdate;
 
 mod fixtures;
 mod flight_control;
@@ -276,7 +276,7 @@ fn disarm_does_not_require_a_current_measurement_pair() {
     let mut buf = [0_u8; 128];
     let len = fc.recv(&mut buf).expect("receive disarm");
     assert!(len >= 45);
-    assert_eq!(buf[7], crate::mavlink::COMMAND_LONG_ID as u8);
+    assert_eq!(buf[7], pilotage_mavlink::codec::COMMAND_LONG_ID as u8);
     assert_eq!(
         f32::from_le_bytes(buf[10..14].try_into().expect("param1")),
         0.0
@@ -315,5 +315,6 @@ fn control_frames_are_rejected_at_the_boundary() {
     );
 }
 
+mod estimator_authorization;
 mod link_loss_enact;
 mod reset_latch;

--- a/adapters/aviate/src/adapter/tests/estimator_authorization.rs
+++ b/adapters/aviate/src/adapter/tests/estimator_authorization.rs
@@ -1,0 +1,110 @@
+//! The adapter half of estimator-status authorization: sampled telemetry
+//! tracks a status-only revocation and never re-grants cached numerics.
+//! The link-layer half of this contract lives with `pilotage_mavlink`.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use pilotage_adapter_api::VehicleAdapter;
+use pilotage_mavlink::LinkState;
+use pilotage_mavlink::codec::{FcMessage, FrameSource};
+use pilotage_mavlink::link::apply_messages_at;
+use pilotage_mavlink::link::estimator::{QUALITY_GOOD, QUALITY_UNUSABLE};
+use pilotage_protocol::VehicleId;
+
+use super::super::AviateAdapter;
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 0,
+};
+
+fn apply(state: &Arc<Mutex<LinkState>>, messages: &[FcMessage]) {
+    let messages = messages
+        .iter()
+        .copied()
+        .map(|message| (SOURCE, message))
+        .collect::<Vec<_>>();
+    apply_messages_at(state, &messages, 0, 0, Instant::now());
+}
+
+fn private_status(time_usec: u64, valid_flags: u8, quality: u8) -> FcMessage {
+    FcMessage::AviateEstimatorStatus {
+        time_usec,
+        valid_flags,
+        quality,
+    }
+}
+
+fn attitude(time_boot_ms: u32) -> FcMessage {
+    FcMessage::AttitudeQuaternion {
+        time_boot_ms,
+        quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+        rates_rps: [0.0; 3],
+    }
+}
+
+fn kinematics(time_boot_ms: u32) -> FcMessage {
+    FcMessage::LocalPositionNed {
+        time_boot_ms,
+        pos_ned_m: [0.0; 3],
+        vel_ned_mps: [0.0; 3],
+    }
+}
+
+#[test]
+fn sampled_telemetry_tracks_status_only_revocation_without_regrant() {
+    let state = Arc::new(Mutex::new(LinkState::default()));
+    apply(&state, &[attitude(100), kinematics(100)]);
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state.clone());
+
+    let initial = adapter.sample_telemetry();
+    let sample = &initial.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert!(avionics.estimator_status_stamp.is_none());
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+
+    apply(
+        &state,
+        &[
+            private_status(200_000, 0x0f, 2),
+            attitude(200),
+            kinematics(200),
+        ],
+    );
+    let authorized = adapter.sample_telemetry();
+    let sample = &authorized.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0x0f, QUALITY_GOOD)
+    );
+    assert_eq!(
+        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
+        Some(0)
+    );
+    assert!(sample.pose.is_some());
+    assert!(sample.speed.is_some());
+
+    apply(&state, &[private_status(300_000, 0, 0)]);
+    apply(&state, &[private_status(400_000, 0x0f, 2)]);
+    let revoked = adapter.sample_telemetry();
+    let sample = &revoked.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(
+        (avionics.valid_flags, avionics.quality),
+        (0, QUALITY_UNUSABLE)
+    );
+    assert_eq!(
+        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
+        Some(2)
+    );
+    assert!(sample.pose.is_none());
+    assert!(sample.speed.is_none());
+}

--- a/adapters/aviate/src/adapter/tests/fixtures.rs
+++ b/adapters/aviate/src/adapter/tests/fixtures.rs
@@ -9,10 +9,10 @@ use pilotage_adapter_api::{
 };
 use pilotage_protocol::VehicleId;
 
-use crate::link::estimator::{EstimatorAuthorization, EstimatorStatusUpdate};
-use crate::link::{AttitudeUpdate, KinematicsUpdate, LatestAviate};
+use pilotage_mavlink::link::estimator::{EstimatorAuthorization, EstimatorStatusUpdate};
+use pilotage_mavlink::link::{AttitudeUpdate, KinematicsUpdate, LinkState};
 
-pub(super) fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LatestAviate>> {
+pub(super) fn state_with(att_age: Duration, kin_age: Duration) -> Arc<Mutex<LinkState>> {
     state_with_acquisition_skew(att_age, kin_age, 0)
 }
 
@@ -20,7 +20,7 @@ pub(super) fn state_with_acquisition_skew(
     att_age: Duration,
     kin_age: Duration,
     acquisition_skew_ns: u64,
-) -> Arc<Mutex<LatestAviate>> {
+) -> Arc<Mutex<LinkState>> {
     let now = Instant::now();
     let attitude_stamp = MeasurementStamp {
         role: SourceRole::OperationalEstimate,
@@ -56,7 +56,7 @@ pub(super) fn state_with_acquisition_skew(
             ..attitude_stamp
         },
     };
-    let state = LatestAviate {
+    let state = LinkState {
         attitude: Some(AttitudeUpdate {
             // 90° yaw: heading east.
             quat_wxyz: [
@@ -83,7 +83,7 @@ pub(super) fn state_with_acquisition_skew(
         }),
         estimator_status: Some(estimator_status),
         maximum_inter_group_skew_ms: 300,
-        ..LatestAviate::default()
+        ..LinkState::default()
     };
     Arc::new(Mutex::new(state))
 }

--- a/adapters/aviate/src/adapter/tests/flight_control.rs
+++ b/adapters/aviate/src/adapter/tests/flight_control.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use pilotage_adapter_api::{Disposition, VehicleAdapter};
 use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
 
-use crate::link::{KinematicsUpdate, LatestAviate};
+use pilotage_mavlink::link::{KinematicsUpdate, LinkState};
 
 use super::super::{ARM_BUTTON, AviateAdapter, PITCH_AXIS, THROTTLE_AXIS};
 use super::fixtures::{flight_frame, state_with};
@@ -36,7 +36,7 @@ fn centered_frame() -> pilotage_protocol::ScopedControlFrame {
 }
 
 /// Rewrites the fixture's kinematics group, fresh as of now.
-fn set_kinematics(state: &Arc<Mutex<LatestAviate>>, mutate: impl FnOnce(&mut KinematicsUpdate)) {
+fn set_kinematics(state: &Arc<Mutex<LinkState>>, mutate: impl FnOnce(&mut KinematicsUpdate)) {
     let mut latest = state.lock().expect("state lock");
     let kin = latest.kinematics.as_mut().expect("kinematics fixture");
     mutate(kin);
@@ -44,7 +44,7 @@ fn set_kinematics(state: &Arc<Mutex<LatestAviate>>, mutate: impl FnOnce(&mut Kin
 }
 
 /// Rewrites the fixture's measured velocity, fresh as of now.
-fn set_velocity(state: &Arc<Mutex<LatestAviate>>, vel: [f32; 3]) {
+fn set_velocity(state: &Arc<Mutex<LinkState>>, vel: [f32; 3]) {
     set_kinematics(state, |kin| kin.vel_ned_mps = vel);
 }
 
@@ -52,7 +52,7 @@ fn set_velocity(state: &Arc<Mutex<LatestAviate>>, vel: [f32; 3]) {
 /// can be read from), heading east (yaw 90°) so body-frame rotation is
 /// observable. The state handle steers the fixture's measurements; the
 /// uplink runs on its manual clock so no test sleeps against real time.
-fn flying_adapter(fc: &std::net::UdpSocket) -> (AviateAdapter, Arc<Mutex<LatestAviate>>) {
+fn flying_adapter(fc: &std::net::UdpSocket) -> (AviateAdapter, Arc<Mutex<LinkState>>) {
     let mut uplink = crate::uplink::FlightUplink::new().expect("uplink");
     uplink.set_target(fc.local_addr().expect("addr"));
     uplink.use_manual_clock();

--- a/adapters/aviate/src/adapter/tests/link_loss_enact.rs
+++ b/adapters/aviate/src/adapter/tests/link_loss_enact.rs
@@ -101,7 +101,7 @@ fn link_loss_transitions_invalidate_the_captured_hold_point() {
 
 /// Stamps the fixture as (near-)still at `pos`, fresh as of now.
 fn set_still_at(
-    state: &std::sync::Arc<std::sync::Mutex<crate::link::LatestAviate>>,
+    state: &std::sync::Arc<std::sync::Mutex<pilotage_mavlink::link::LinkState>>,
     pos: [f32; 3],
 ) {
     let mut latest = state.lock().expect("state lock");

--- a/adapters/aviate/src/adapter/tests/reset_latch.rs
+++ b/adapters/aviate/src/adapter/tests/reset_latch.rs
@@ -12,8 +12,9 @@ use std::time::{Duration, Instant};
 use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
 use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
 
-use crate::link::{LatestAviate, ResetPolicy, apply_messages_at};
-use crate::mavlink::{AviateMessage, FrameSource};
+use pilotage_mavlink::codec::{FcMessage, FrameSource};
+use pilotage_mavlink::link::apply_messages_at;
+use pilotage_mavlink::{LinkState, ResetPolicy};
 
 use super::super::{
     ARM_BUTTON, AviateAdapter, DISARM_BUTTON, PITCH_AXIS, RESET_BUTTON, ROLL_AXIS, THROTTLE_AXIS,
@@ -27,7 +28,7 @@ const SOURCE: FrameSource = FrameSource {
     frame_sequence: 0,
 };
 
-fn adapter_with_fake_fc() -> (AviateAdapter, std::net::UdpSocket, Arc<Mutex<LatestAviate>>) {
+fn adapter_with_fake_fc() -> (AviateAdapter, std::net::UdpSocket, Arc<Mutex<LinkState>>) {
     let fc = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
     fc.set_read_timeout(Some(Duration::from_secs(2)))
         .expect("timeout");
@@ -57,31 +58,31 @@ fn neutral() -> pilotage_protocol::ScopedControlFrame {
     )
 }
 
-fn status(time_boot_ms: u32) -> AviateMessage {
-    AviateMessage::AviateEstimatorStatus {
+fn status(time_boot_ms: u32) -> FcMessage {
+    FcMessage::AviateEstimatorStatus {
         time_usec: u64::from(time_boot_ms).saturating_mul(1_000),
         valid_flags: 0x0f,
         quality: 2,
     }
 }
 
-fn attitude(time_boot_ms: u32) -> AviateMessage {
-    AviateMessage::AttitudeQuaternion {
+fn attitude(time_boot_ms: u32) -> FcMessage {
+    FcMessage::AttitudeQuaternion {
         time_boot_ms,
         quat_wxyz: [1.0, 0.0, 0.0, 0.0],
         rates_rps: [0.0; 3],
     }
 }
 
-fn kinematics(time_boot_ms: u32) -> AviateMessage {
-    AviateMessage::LocalPositionNed {
+fn kinematics(time_boot_ms: u32) -> FcMessage {
+    FcMessage::LocalPositionNed {
         time_boot_ms,
         pos_ned_m: [0.0; 3],
         vel_ned_mps: [0.0; 3],
     }
 }
 
-fn apply_at(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage], now: Instant) {
+fn apply_at(state: &Arc<Mutex<LinkState>>, messages: &[FcMessage], now: Instant) {
     let sourced = messages
         .iter()
         .copied()
@@ -90,7 +91,7 @@ fn apply_at(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage], now: I
     apply_messages_at(state, &sourced, 0, 0, now);
 }
 
-fn drive_fresh_epoch(state: &Arc<Mutex<LatestAviate>>) {
+fn drive_fresh_epoch(state: &Arc<Mutex<LinkState>>) {
     let start = Instant::now();
     {
         let mut latest = state.lock().expect("state");

--- a/adapters/aviate/src/adapter/tests/source_roles.rs
+++ b/adapters/aviate/src/adapter/tests/source_roles.rs
@@ -14,7 +14,7 @@ use pilotage_protocol::VehicleId;
 use super::{flight_frame, state_with};
 use crate::adapter::AviateAdapter;
 use crate::adapter::shm_sampling::ShmSource;
-use crate::link::LatestAviate;
+use pilotage_mavlink::link::LinkState;
 
 fn truth_writer(tag: &str) -> (String, aviate_xil_shm::SimWriterSession) {
     // macOS caps shm names at 31 chars; keep the unique suffix short.
@@ -74,7 +74,7 @@ fn healthy_truth_cannot_seed_a_control_setpoint() {
     let uplink = crate::uplink::FlightUplink::new().expect("uplink");
     let mut adapter = AviateAdapter::from_state(
         VehicleId::new(1),
-        Arc::new(Mutex::new(LatestAviate::default())),
+        Arc::new(Mutex::new(LinkState::default())),
     )
     .with_uplink(uplink);
     adapter.estimate = None;
@@ -124,13 +124,16 @@ fn fc_state_publishes_standalone_with_host_receive_provenance() {
     let uplink_addr = uplink.local_addr().expect("uplink addr");
     let mut adapter = AviateAdapter::from_state(
         VehicleId::new(1),
-        Arc::new(Mutex::new(LatestAviate::default())),
+        Arc::new(Mutex::new(LinkState::default())),
     )
     .with_uplink(uplink);
     adapter.estimate = None;
 
-    fc.send_to(&crate::mavlink::encode_gcs_heartbeat(0), uplink_addr)
-        .expect("send heartbeat");
+    fc.send_to(
+        &pilotage_mavlink::codec::encode_gcs_heartbeat(0),
+        uplink_addr,
+    )
+    .expect("send heartbeat");
     // The receive is a kernel handoff on loopback; poll until the
     // datagram lands rather than sleeping.
     let mut batch = TelemetryBatch::default();
@@ -169,7 +172,7 @@ fn oracle_only_shape_advertises_no_control_and_streams_truth() {
     let (name, _writer) = truth_writer("orc");
     let mut adapter = AviateAdapter::from_state(
         VehicleId::new(1),
-        Arc::new(Mutex::new(LatestAviate::default())),
+        Arc::new(Mutex::new(LinkState::default())),
     );
     adapter.estimate = None;
     attach_truth(&mut adapter, &name);

--- a/adapters/aviate/src/error.rs
+++ b/adapters/aviate/src/error.rs
@@ -10,14 +10,9 @@ pub enum AviateAdapterError {
         #[source]
         source: getrandom::Error,
     },
-    /// Neither the direct MAVLink port nor an ephemeral fallback socket
-    /// could be bound.
-    #[error("binding a UDP socket for MAVLink telemetry failed: {source}")]
-    Bind {
-        /// The underlying socket error.
-        #[source]
-        source: std::io::Error,
-    },
+    /// The MAVLink receive link could not start.
+    #[error(transparent)]
+    Link(#[from] pilotage_mavlink::LinkError),
     /// Attaching to the XIL shm object failed at the operating-system
     /// level: the object does not exist (no simulation writer is up) or
     /// the kernel refused the read-only mapping.

--- a/adapters/aviate/src/lib.rs
+++ b/adapters/aviate/src/lib.rs
@@ -16,10 +16,10 @@
 mod adapter;
 mod error;
 mod incarnation;
-mod link;
-pub mod mavlink;
 pub mod shm;
 mod uplink;
+
+pub use pilotage_mavlink::codec as mavlink;
 
 pub use adapter::{
     ARM_BUTTON, AviateAdapter, AviateProfile, DISARM_BUTTON, FLIGHT_SCOPE, PITCH_AXIS, ROLL_AXIS,
@@ -27,5 +27,5 @@ pub use adapter::{
 };
 pub use error::AviateAdapterError;
 pub use incarnation::{IncarnationProvider, OsIncarnationProvider};
-pub use link::{LinkConfig, ResetPolicy};
+pub use pilotage_mavlink::link::{LinkConfig, ResetPolicy};
 pub use uplink::FlightUplink;

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use tracing::{info, warn};
 
-use crate::mavlink::{
+use pilotage_mavlink::codec::{
     encode_arm_command, encode_attitude_setpoint, encode_position_setpoint,
     encode_velocity_setpoint,
 };
@@ -242,7 +242,7 @@ impl FlightUplink {
                 .now()
                 .saturating_duration_since(self.started)
                 .as_millis() as u32,
-            crate::mavlink::AttitudeTarget {
+            pilotage_mavlink::codec::AttitudeTarget {
                 roll_rad: roll * FPV_MAX_TILT_RAD,
                 pitch_rad: pitch * FPV_MAX_TILT_RAD,
                 yaw_rad: self.heading_sp_rad,

--- a/adapters/aviate/src/uplink/fc_replies.rs
+++ b/adapters/aviate/src/uplink/fc_replies.rs
@@ -13,12 +13,14 @@ impl FlightUplink {
     /// from the sampling tick.
     pub fn poll_fc(&mut self) -> Option<bool> {
         let mut buf = [0u8; 512];
-        let mut messages: Vec<(crate::mavlink::FrameSource, crate::mavlink::AviateMessage)> =
-            Vec::new();
+        let mut messages: Vec<(
+            pilotage_mavlink::codec::FrameSource,
+            pilotage_mavlink::codec::FcMessage,
+        )> = Vec::new();
         let mut armed: Option<bool> = None;
         while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
             messages.clear();
-            crate::mavlink::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
+            pilotage_mavlink::codec::parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
             for (source, message) in &messages {
                 if source.system_id != self.expected_system_id
                     || source.component_id != self.expected_component_id
@@ -26,8 +28,8 @@ impl FlightUplink {
                     continue;
                 }
                 match *message {
-                    crate::mavlink::AviateMessage::Heartbeat { armed: a } => armed = Some(a),
-                    crate::mavlink::AviateMessage::CommandAck { command, result } => {
+                    pilotage_mavlink::codec::FcMessage::Heartbeat { armed: a } => armed = Some(a),
+                    pilotage_mavlink::codec::FcMessage::CommandAck { command, result } => {
                         if result == 0 {
                             info!(command, "FC accepted command");
                         } else {

--- a/crates/pilotage-evidence/src/gate/baseline.rs
+++ b/crates/pilotage-evidence/src/gate/baseline.rs
@@ -19,6 +19,7 @@ use crate::graph::Graph;
 use crate::id::NodeId;
 use crate::node::NodeKind;
 use crate::policy::Policy;
+use crate::relation::RelationKind;
 
 /// The digest scheme naming a git blob object id.
 const GIT_BLOB_SCHEME: &str = "git-blob:";
@@ -100,6 +101,39 @@ pub(super) fn resolve(
                 graph, repo_root, toplevel, commit, path, expected, findings, id,
             );
         }
+        check_configuration_identity(graph, id, commit, findings);
+    }
+}
+
+/// The result's declared `config-digest` must equal the commit of a
+/// configuration-item that justifies it: a result vouched for by a
+/// configuration node recording a DIFFERENT commit carries two
+/// contradictory identities, and the trace silently stops meaning
+/// anything.
+fn check_configuration_identity(
+    graph: &Graph,
+    id: &NodeId,
+    commit: &str,
+    findings: &mut Vec<Finding>,
+) {
+    let mut configuration_commits = graph
+        .edges()
+        .filter(|edge| edge.from == *id && edge.relation == RelationKind::JustifiedBy)
+        .filter_map(|edge| graph.node(&edge.to))
+        .filter(|node| node.kind == NodeKind::ConfigurationItem)
+        .filter_map(|node| node.attr("commit").map(str::trim))
+        .peekable();
+    if configuration_commits.peek().is_none() {
+        return; // structural completeness is judged elsewhere
+    }
+    if !configuration_commits.any(|declared| declared == commit) {
+        push(
+            findings,
+            id,
+            format!(
+                "config-digest {commit} does not match any justifying configuration-item's                  recorded commit; the result claims one baseline while its configuration                  record names another"
+            ),
+        );
     }
 }
 
@@ -278,6 +312,51 @@ mod tests {
              edge RESULT result-of CASE\n\
              edge RESULT covers R1\n"
         )
+    }
+
+    fn graph_text_with_configuration(commit: &str, blob: &str, cfg_commit: &str) -> String {
+        format!(
+            "{}node CFG configuration-item\n\
+             attr scm git\n\
+             attr commit {cfg_commit}\n\
+             edge RESULT justified-by CFG\n",
+            graph_text(commit, blob)
+        )
+    }
+
+    #[test]
+    fn a_configuration_item_recording_a_different_commit_is_a_finding() {
+        let dir = std::env::temp_dir().join(format!("plt_evg_cfgid_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        git(&dir, &["init", "-q"]);
+        std::fs::write(dir.join("sample_tests.rs"), "#[test]\nfn sample() {}\n")
+            .expect("write source");
+        git(&dir, &["add", "sample_tests.rs"]);
+        git(&dir, &["commit", "-qm", "baseline"]);
+        let commit = git(&dir, &["rev-parse", "HEAD"]);
+        let blob = git(&dir, &["rev-parse", "HEAD:sample_tests.rs"]);
+        let policy = Policy::default();
+
+        // Matching identities: no finding.
+        let graph = parse_graph(&graph_text_with_configuration(&commit, &blob, &commit))
+            .expect("graph parses");
+        let mut findings = Vec::new();
+        resolve(&graph, &policy, &dir, &mut findings);
+        assert!(findings.is_empty(), "matching identity: {findings:?}");
+
+        // The configuration node recording a DIFFERENT commit is the
+        // two-baselines lie and must fail closed.
+        let mismatched = graph_text_with_configuration(&commit, &blob, &"1".repeat(40));
+        let graph = parse_graph(&mismatched).expect("graph parses");
+        let mut findings = Vec::new();
+        resolve(&graph, &policy, &dir, &mut findings);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.detail.contains("does not match any justifying")),
+            "mismatched configuration identity must be a finding: {findings:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/pilotage-mavlink/Cargo.toml
+++ b/crates/pilotage-mavlink/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pilotage-mavlink"
+description = "MAVLink 2.0 subset codec and receive-link machinery shared by flight-controller adapters"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-adapter-api = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "sync", "time", "macros"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["net", "rt", "sync", "time", "macros", "rt-multi-thread"] }

--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -3,7 +3,7 @@
 //! path beyond the caller's message vector.
 //!
 //! The decoded telemetry set includes liveness, estimator values, and both
-//! standard and Aviate-specific estimator status. Anything else is counted
+//! standard and Aviate-private estimator status. Anything else is counted
 //! and skipped. CRC is the MAVLink X.25 accumulator seeded with
 //! each message's CRC_EXTRA (values cross-checked against Aviate's
 //! `aviate-link` implementation, the peer this parser must interoperate
@@ -29,7 +29,7 @@ pub const AVIATE_ESTIMATOR_STATUS_ID: u32 = 20_000;
 
 /// One parsed frame event from the Aviate subset.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum AviateMessage {
+pub enum FcMessage {
     /// A private estimator-status frame whose integrity or framing could not
     /// be validated. This event can only revoke authorization.
     InvalidAviateEstimatorStatus,
@@ -166,7 +166,7 @@ fn record_invalid_private_status(
     bytes: &[u8],
     at: usize,
     stats: &mut ParseStats,
-    out: &mut Vec<(FrameSource, AviateMessage)>,
+    out: &mut Vec<(FrameSource, FcMessage)>,
 ) {
     let Some((source, message_id)) = frame_header(bytes, at) else {
         return;
@@ -174,7 +174,7 @@ fn record_invalid_private_status(
     if message_id == AVIATE_ESTIMATOR_STATUS_ID {
         stats.invalid_estimator_status_frames =
             stats.invalid_estimator_status_frames.wrapping_add(1);
-        out.push((source, AviateMessage::InvalidAviateEstimatorStatus));
+        out.push((source, FcMessage::InvalidAviateEstimatorStatus));
     }
 }
 
@@ -185,7 +185,7 @@ fn record_invalid_private_status(
 /// Unknown ids and ordinary CRC failures skip the frame. A private-status
 /// integrity failure appends a source-tagged revocation event. Stray bytes
 /// before a frame start are discarded byte-by-byte.
-pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>) -> ParseStats {
+pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, FcMessage)>) -> ParseStats {
     let mut stats = ParseStats::default();
     let mut at = 0usize;
     while at < bytes.len() {
@@ -237,7 +237,7 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, AviateMessage)>)
                     if msg_id == AVIATE_ESTIMATOR_STATUS_ID {
                         stats.invalid_estimator_status_frames =
                             stats.invalid_estimator_status_frames.wrapping_add(1);
-                        out.push((source, AviateMessage::InvalidAviateEstimatorStatus));
+                        out.push((source, FcMessage::InvalidAviateEstimatorStatus));
                     }
                 }
             }
@@ -384,7 +384,7 @@ pub fn encode_velocity_setpoint(
 /// Body-rate demand is intentionally absent because the FC attitude loop
 /// derives rate commands from this target.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct AttitudeTarget {
+pub struct AttitudeTarget {
     /// Roll demand in radians.
     pub roll_rad: f32,
     /// Pitch demand in radians.
@@ -400,11 +400,7 @@ pub(crate) struct AttitudeTarget {
 }
 
 /// Encodes one absolute attitude target for the selected component.
-pub(crate) fn encode_attitude_setpoint(
-    seq: u8,
-    time_boot_ms: u32,
-    target: AttitudeTarget,
-) -> [u8; 51] {
+pub fn encode_attitude_setpoint(seq: u8, time_boot_ms: u32, target: AttitudeTarget) -> [u8; 51] {
     const SET_ATTITUDE_TARGET_ID: u32 = 82;
     let (sr, cr) = (target.roll_rad * 0.5).sin_cos();
     let (sp, cp) = (target.pitch_rad * 0.5).sin_cos();

--- a/crates/pilotage-mavlink/src/codec/decoding.rs
+++ b/crates/pilotage-mavlink/src/codec/decoding.rs
@@ -1,0 +1,86 @@
+//! Payload decoding with MAVLink 2 trailing-zero extension.
+
+use super::{
+    ATTITUDE_QUATERNION_ID, AVIATE_ESTIMATOR_STATUS_ID, COMMAND_ACK_ID, ESTIMATOR_STATUS_ID,
+    FcMessage, HEARTBEAT_ID, LOCAL_POSITION_NED_ID,
+};
+
+fn f32_at(payload: &[u8], off: usize) -> f32 {
+    let mut bytes = [0_u8; 4];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    f32::from_le_bytes(bytes)
+}
+
+fn u32_at(payload: &[u8], off: usize) -> u32 {
+    let mut bytes = [0_u8; 4];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u32::from_le_bytes(bytes)
+}
+
+fn u64_at(payload: &[u8], off: usize) -> u64 {
+    let mut bytes = [0_u8; 8];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u64::from_le_bytes(bytes)
+}
+
+fn u16_at(payload: &[u8], off: usize) -> u16 {
+    let mut bytes = [0_u8; 2];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        *slot = payload.get(off + index).copied().unwrap_or(0);
+    }
+    u16::from_le_bytes(bytes)
+}
+
+pub(super) fn decode_known(msg_id: u32, payload: &[u8]) -> Option<FcMessage> {
+    match msg_id {
+        HEARTBEAT_ID => Some(FcMessage::Heartbeat {
+            // Payload: custom_mode u32 @0, type @4, autopilot @5,
+            // base_mode @6 (bit 0x80 = SAFETY_ARMED).
+            armed: payload.get(6).is_some_and(|b| b & 0x80 != 0),
+        }),
+        COMMAND_ACK_ID => Some(FcMessage::CommandAck {
+            command: u16::from(payload.first().copied().unwrap_or(0))
+                | (u16::from(payload.get(1).copied().unwrap_or(0)) << 8),
+            result: payload.get(2).copied().unwrap_or(0),
+        }),
+        ATTITUDE_QUATERNION_ID => Some(FcMessage::AttitudeQuaternion {
+            time_boot_ms: u32_at(payload, 0),
+            quat_wxyz: [
+                f32_at(payload, 4),
+                f32_at(payload, 8),
+                f32_at(payload, 12),
+                f32_at(payload, 16),
+            ],
+            rates_rps: [
+                f32_at(payload, 20),
+                f32_at(payload, 24),
+                f32_at(payload, 28),
+            ],
+        }),
+        LOCAL_POSITION_NED_ID => Some(FcMessage::LocalPositionNed {
+            time_boot_ms: u32_at(payload, 0),
+            pos_ned_m: [f32_at(payload, 4), f32_at(payload, 8), f32_at(payload, 12)],
+            vel_ned_mps: [
+                f32_at(payload, 16),
+                f32_at(payload, 20),
+                f32_at(payload, 24),
+            ],
+        }),
+        ESTIMATOR_STATUS_ID => Some(FcMessage::EstimatorStatus {
+            time_usec: u64_at(payload, 0),
+            flags: u16_at(payload, 40),
+        }),
+        AVIATE_ESTIMATOR_STATUS_ID => Some(FcMessage::AviateEstimatorStatus {
+            time_usec: u64_at(payload, 0),
+            valid_flags: payload.get(8).copied().unwrap_or(0),
+            quality: payload.get(9).copied().unwrap_or(0),
+        }),
+        _ => None,
+    }
+}

--- a/crates/pilotage-mavlink/src/codec/tests.rs
+++ b/crates/pilotage-mavlink/src/codec/tests.rs
@@ -1,0 +1,338 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{
+    ATTITUDE_QUATERNION_ID, AVIATE_ESTIMATOR_STATUS_ID, ESTIMATOR_STATUS_ID, FcMessage,
+    FrameSource, LOCAL_POSITION_NED_ID, MAGIC_V2, encode_gcs_heartbeat, parse_datagram,
+};
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 7,
+};
+
+/// Test-side serializer: builds a MAVLink 2.0 frame the way Aviate's
+/// `aviate-link` does, optionally truncating trailing zero payload bytes
+/// (the v2 wire optimization the parser must zero-extend back).
+fn encode_frame(msg_id: u32, payload: &[u8], truncate: bool) -> Vec<u8> {
+    let mut p = payload.to_vec();
+    if truncate {
+        while p.len() > 1 && p.last() == Some(&0) {
+            p.pop();
+        }
+    }
+    let mut frame = vec![
+        MAGIC_V2,
+        p.len() as u8,
+        0,
+        0,
+        7, // seq
+        1, // sysid
+        1, // compid
+        (msg_id & 0xff) as u8,
+        ((msg_id >> 8) & 0xff) as u8,
+        ((msg_id >> 16) & 0xff) as u8,
+    ];
+    frame.extend_from_slice(&p);
+    let extra = match msg_id {
+        0 => 50,
+        31 => 246,
+        32 => 185,
+        230 => 163,
+        20_000 => 171,
+        other => (other & 0xff) as u8,
+    };
+    let crc = super::compute_crc(&frame[1..], extra);
+    frame.push((crc & 0xff) as u8);
+    frame.push((crc >> 8) as u8);
+    frame
+}
+
+fn attitude_payload(q: [f32; 4], rates: [f32; 3], t: u32) -> Vec<u8> {
+    let mut p = t.to_le_bytes().to_vec();
+    for v in q.iter().chain(rates.iter()) {
+        p.extend_from_slice(&v.to_le_bytes());
+    }
+    // MAVLink2 extension repr_offset_q[4] as zeros (full 48-byte layout).
+    p.extend_from_slice(&[0u8; 16]);
+    p
+}
+
+fn local_position_payload(pos: [f32; 3], vel: [f32; 3], t: u32) -> Vec<u8> {
+    let mut p = t.to_le_bytes().to_vec();
+    for v in pos.iter().chain(vel.iter()) {
+        p.extend_from_slice(&v.to_le_bytes());
+    }
+    p
+}
+
+#[test]
+fn decodes_attitude_and_position_from_one_datagram() {
+    let q = [0.9f32, 0.1, 0.2, 0.3];
+    let rates = [0.01f32, 0.02, 0.03];
+    let pos = [1.0f32, 2.0, -30.0];
+    let vel = [4.0f32, 0.0, -1.5];
+    let mut datagram = encode_frame(
+        ATTITUDE_QUATERNION_ID,
+        &attitude_payload(q, rates, 1234),
+        false,
+    );
+    datagram.extend_from_slice(&encode_frame(
+        LOCAL_POSITION_NED_ID,
+        &local_position_payload(pos, vel, 1250),
+        false,
+    ));
+
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.decoded, 2);
+    assert_eq!(stats.crc_failures, 0);
+    assert_eq!(
+        out[0],
+        (
+            SOURCE,
+            FcMessage::AttitudeQuaternion {
+                time_boot_ms: 1234,
+                quat_wxyz: q,
+                rates_rps: rates,
+            }
+        )
+    );
+    assert_eq!(
+        out[1],
+        (
+            SOURCE,
+            FcMessage::LocalPositionNed {
+                time_boot_ms: 1250,
+                pos_ned_m: pos,
+                vel_ned_mps: vel,
+            }
+        )
+    );
+}
+
+#[test]
+fn v2_truncated_payload_zero_extends() {
+    // Attitude with zero rates: trailing zeros truncate on the wire.
+    let q = [1.0f32, 0.0, 0.0, 0.0];
+    let frame = encode_frame(
+        ATTITUDE_QUATERNION_ID,
+        &attitude_payload(q, [0.0; 3], 99),
+        true,
+    );
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    assert_eq!(
+        out[0],
+        (
+            SOURCE,
+            FcMessage::AttitudeQuaternion {
+                time_boot_ms: 99,
+                quat_wxyz: q,
+                rates_rps: [0.0; 3],
+            }
+        )
+    );
+}
+
+#[test]
+fn decodes_aviate_estimator_status_golden_vectors() {
+    let cases = [
+        (
+            vec![
+                253, 10, 0, 0, 7, 1, 1, 32, 78, 0, 184, 130, 1, 0, 0, 0, 0, 0, 15, 2, 238, 73,
+            ],
+            FcMessage::AviateEstimatorStatus {
+                time_usec: 99_000,
+                valid_flags: 0x0f,
+                quality: 2,
+            },
+            7,
+        ),
+        (
+            vec![
+                253, 10, 0, 0, 4, 1, 1, 32, 78, 0, 144, 208, 3, 0, 0, 0, 0, 0, 3, 1, 137, 232,
+            ],
+            FcMessage::AviateEstimatorStatus {
+                time_usec: 250_000,
+                valid_flags: 0x03,
+                quality: 1,
+            },
+            4,
+        ),
+        (
+            vec![253, 2, 0, 0, 7, 1, 1, 32, 78, 0, 104, 66, 104, 226],
+            FcMessage::AviateEstimatorStatus {
+                time_usec: 17_000,
+                valid_flags: 0,
+                quality: 0,
+            },
+            7,
+        ),
+    ];
+
+    for (frame, expected, frame_sequence) in cases {
+        let mut out = Vec::new();
+        let stats = parse_datagram(&frame, &mut out);
+        assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+        assert_eq!(
+            out,
+            vec![(
+                FrameSource {
+                    frame_sequence,
+                    ..SOURCE
+                },
+                expected
+            )]
+        );
+    }
+}
+
+#[test]
+fn standard_estimator_status_is_known_but_distinct() {
+    let frame = [253, 2, 0, 0, 7, 1, 1, 230, 0, 0, 104, 66, 51, 209];
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    assert_eq!(
+        out,
+        vec![(
+            SOURCE,
+            FcMessage::EstimatorStatus {
+                time_usec: 17_000,
+                flags: 0,
+            }
+        )]
+    );
+}
+
+#[test]
+fn status_test_serializer_uses_the_canonical_crc_extras() {
+    let private = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let standard = encode_frame(ESTIMATOR_STATUS_ID, &[0; 42], false);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&private, &mut out);
+    assert_eq!(stats.decoded, 1);
+    let stats = parse_datagram(&standard, &mut out);
+    assert_eq!(stats.decoded, 1);
+}
+
+#[test]
+fn corrupted_frame_fails_crc_and_is_skipped() {
+    let mut frame = encode_frame(
+        LOCAL_POSITION_NED_ID,
+        &local_position_payload([1.0; 3], [0.5; 3], 7),
+        false,
+    );
+    frame[12] ^= 0xff;
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.crc_failures, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 0);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn corrupted_private_status_is_an_explicit_revocation_signal() {
+    let mut frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    frame[10] ^= 0xff;
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.crc_failures, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert_eq!(out, vec![(SOURCE, FcMessage::InvalidAviateEstimatorStatus)]);
+}
+
+#[test]
+fn truncated_private_status_is_an_explicit_revocation_signal() {
+    let frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame[..frame.len() - 1], &mut out);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(stats.garbage_bytes > 0);
+    assert_eq!(out, vec![(SOURCE, FcMessage::InvalidAviateEstimatorStatus)]);
+}
+
+#[test]
+fn unsupported_incompatibility_flags_never_authorize_private_status() {
+    let mut frame = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    frame[2] = 0x02;
+    let mut out = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(stats.garbage_bytes > 0);
+    assert_eq!(out, vec![(SOURCE, FcMessage::InvalidAviateEstimatorStatus)]);
+}
+
+#[test]
+fn invalid_private_status_event_preserves_datagram_order() {
+    let mut datagram = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    let mut invalid = encode_frame(AVIATE_ESTIMATOR_STATUS_ID, &[0; 10], false);
+    invalid[10] ^= 0xff;
+    datagram.extend_from_slice(&invalid);
+    let mut out = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.decoded, 1);
+    assert_eq!(stats.invalid_estimator_status_frames, 1);
+    assert!(matches!(
+        out.as_slice(),
+        [
+            (_, FcMessage::AviateEstimatorStatus { .. }),
+            (_, FcMessage::InvalidAviateEstimatorStatus)
+        ]
+    ));
+}
+
+#[test]
+fn unknown_message_id_is_counted_and_skipped_whole() {
+    let unknown = encode_frame(99, &[1, 2, 3, 4], false);
+    let mut datagram = unknown;
+    datagram.extend_from_slice(&encode_frame(
+        LOCAL_POSITION_NED_ID,
+        &local_position_payload([0.0; 3], [1.0; 3], 1),
+        false,
+    ));
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.unknown_ids, 1);
+    assert_eq!(stats.decoded, 1, "the frame after the unknown id decodes");
+}
+
+#[test]
+fn garbage_prefix_resyncs_to_the_next_frame() {
+    let mut datagram = vec![0x00, 0x42, 0x13];
+    datagram.extend_from_slice(&encode_frame(0, &[0u8; 9], false));
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.garbage_bytes, 3);
+    assert_eq!(out, vec![(SOURCE, FcMessage::Heartbeat { armed: false })]);
+}
+
+#[test]
+fn gcs_heartbeat_parses_back_as_heartbeat() {
+    let frame = encode_gcs_heartbeat(4);
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    assert_eq!(
+        out,
+        vec![(
+            FrameSource {
+                system_id: 255,
+                component_id: 190,
+                frame_sequence: 4,
+            },
+            FcMessage::Heartbeat { armed: false }
+        )]
+    );
+}
+
+#[test]
+fn truncated_tail_is_garbage_not_panic() {
+    let frame = encode_frame(0, &[0u8; 9], false);
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame[..frame.len() - 3], &mut out);
+    assert!(out.is_empty());
+    assert!(stats.garbage_bytes > 0);
+}

--- a/crates/pilotage-mavlink/src/lib.rs
+++ b/crates/pilotage-mavlink/src/lib.rs
@@ -1,0 +1,19 @@
+//! MAVLink 2.0 subset codec and receive-link machinery shared by
+//! flight-controller adapters (ADR-0018).
+//!
+//! The [`codec`] module is pure byte functions — framing, CRC-EXTRA,
+//! decoding of the standard message subset (heartbeat, attitude,
+//! local position, command ack, estimator status) plus the Aviate
+//! private estimator-status extension — unit-testable byte-for-byte.
+//! The [`link`] module owns the UDP receive task and the shared
+//! latest-state cache with the acquisition-clock discipline: source
+//! epochs, reboot detection, inter-group skew budgets, and staleness
+//! stamps. Adapters sample the cache; they never touch the socket.
+
+pub mod codec;
+pub mod link;
+
+pub use codec::{FcMessage, FrameSource, ParseStats, parse_datagram};
+pub use link::{
+    AttitudeUpdate, KinematicsUpdate, LinkConfig, LinkError, LinkState, MavlinkLink, ResetPolicy,
+};

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -1,4 +1,4 @@
-//! The UDP MAVLink link task: receives Aviate telemetry, caches the
+//! The UDP MAVLink link task: receives FC telemetry, caches the
 //! latest estimate, and (in router mode) keeps this endpoint registered
 //! with GCS heartbeats.
 
@@ -12,11 +12,23 @@ use tracing::{debug, error, info, warn};
 
 use pilotage_adapter_api::{MeasurementStamp, SourceIncarnation};
 
-use crate::error::AviateAdapterError;
-use crate::mavlink::{AviateMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
+use crate::codec::{FcMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
 
-pub(crate) mod estimator;
-mod measurement;
+/// Why the MAVLink link could not start.
+#[derive(Debug, thiserror::Error)]
+pub enum LinkError {
+    /// Neither the direct MAVLink port nor an ephemeral fallback socket
+    /// could be bound.
+    #[error("binding a UDP socket for MAVLink telemetry failed: {source}")]
+    Bind {
+        /// The underlying socket error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+pub mod estimator;
+pub mod measurement;
 use estimator::{
     EstimatorStatusUpdate, accept_status, authorization_at, invalidate_cached_authorization,
 };
@@ -33,7 +45,7 @@ pub enum ResetPolicy {
     SimulatorHeuristic,
 }
 
-/// Where the Aviate MAVLink telemetry is reachable.
+/// Where the FC MAVLink telemetry is reachable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LinkConfig {
     /// The MAVLink GCS endpoint. If this port is free the adapter binds
@@ -100,7 +112,7 @@ impl LinkConfig {
 /// can propagate to consumers (ADR-0018: loss of data marks groups
 /// stale rather than freezing them).
 #[derive(Debug)]
-pub struct LatestAviate {
+pub struct LinkState {
     /// Configured MAVLink vehicle system id.
     pub system_id: u8,
     /// Configured MAVLink producer component id.
@@ -120,7 +132,7 @@ pub struct LatestAviate {
     /// stamp.
     pub kinematics: Option<KinematicsUpdate>,
     /// Latest accepted lossless estimator authorization report.
-    pub(crate) estimator_status: Option<EstimatorStatusUpdate>,
+    pub estimator_status: Option<EstimatorStatusUpdate>,
     /// Receive stamp of the last FC heartbeat.
     pub last_heartbeat: Option<Instant>,
     /// Total decoded frames.
@@ -136,7 +148,7 @@ pub struct LatestAviate {
     /// Receive time of the last accepted new group measurement.
     pub last_accepted_at: Option<Instant>,
     /// Candidate low timestamps awaiting simulator-only confirmation.
-    pub(crate) pending_reset: Option<measurement::ResetCandidate>,
+    pub pending_reset: Option<measurement::ResetCandidate>,
     /// Duplicate group measurements rejected before entering the cache.
     pub duplicate_measurements: u64,
     /// Older group measurements rejected before entering the cache.
@@ -152,7 +164,7 @@ pub struct LatestAviate {
     pub wrong_sources: u64,
 }
 
-impl Default for LatestAviate {
+impl Default for LinkState {
     fn default() -> Self {
         Self {
             system_id: 1,
@@ -182,7 +194,7 @@ impl Default for LatestAviate {
     }
 }
 
-impl LatestAviate {
+impl LinkState {
     fn for_source(config: LinkConfig, source_incarnation: SourceIncarnation) -> Self {
         Self {
             system_id: config.system_id,
@@ -196,7 +208,8 @@ impl LatestAviate {
         }
     }
 
-    pub(crate) fn estimator_status_stamp(&self) -> Option<MeasurementStamp> {
+    /// Stamp of the last accepted estimator authorization report, if any.
+    pub fn estimator_status_stamp(&self) -> Option<MeasurementStamp> {
         self.estimator_status.map(|status| status.stamp)
     }
 }
@@ -242,22 +255,22 @@ pub struct KinematicsUpdate {
 /// A running MAVLink link: the receive task plus the shared latest-state
 /// cache the adapter samples from.
 #[derive(Debug)]
-pub struct AviateLink {
-    state: Arc<Mutex<LatestAviate>>,
+pub struct MavlinkLink {
+    state: Arc<Mutex<LinkState>>,
     task: JoinHandle<()>,
 }
 
-impl AviateLink {
+impl MavlinkLink {
     /// Binds the socket (direct or router mode) and spawns the receive
     /// task.
     ///
     /// # Errors
     ///
-    /// Returns [`AviateAdapterError::Bind`] when no socket can be bound.
+    /// Returns [`LinkError::Bind`] when no socket can be bound.
     pub async fn start(
         config: LinkConfig,
         source_incarnation: SourceIncarnation,
-    ) -> Result<Self, AviateAdapterError> {
+    ) -> Result<Self, LinkError> {
         if config.maximum_inter_group_skew_ms == 0 {
             warn!(
                 "inter-group skew budget is zero: the slower of any \
@@ -271,16 +284,16 @@ impl AviateLink {
                 debug!(%direct_err, "MAVLink endpoint taken; assuming a router owns it");
                 let socket = UdpSocket::bind((config.endpoint.ip(), 0))
                     .await
-                    .map_err(|source| AviateAdapterError::Bind { source })?;
+                    .map_err(|source| LinkError::Bind { source })?;
                 (socket, true)
             }
         };
         info!(
             mode = if router_mode { "router" } else { "direct" },
             endpoint = %config.endpoint,
-            "Aviate MAVLink link listening"
+            "MAVLink link listening"
         );
-        let state = Arc::new(Mutex::new(LatestAviate::for_source(
+        let state = Arc::new(Mutex::new(LinkState::for_source(
             config,
             source_incarnation,
         )));
@@ -294,12 +307,12 @@ impl AviateLink {
     }
 
     /// The shared latest-state cache.
-    pub fn state(&self) -> Arc<Mutex<LatestAviate>> {
+    pub fn state(&self) -> Arc<Mutex<LinkState>> {
         self.state.clone()
     }
 }
 
-impl Drop for AviateLink {
+impl Drop for MavlinkLink {
     fn drop(&mut self) {
         self.task.abort();
     }
@@ -309,7 +322,7 @@ async fn run_link(
     socket: UdpSocket,
     endpoint: SocketAddr,
     router_mode: bool,
-    state: Arc<Mutex<LatestAviate>>,
+    state: Arc<Mutex<LinkState>>,
 ) {
     let mut buf = vec![0u8; 2048];
     let mut messages = Vec::with_capacity(8);
@@ -360,17 +373,20 @@ async fn run_link(
 /// Folds decoded messages into the shared cache. Kept synchronous and
 /// lock-scoped: the lock is never held across an await.
 fn apply_messages(
-    state: &Arc<Mutex<LatestAviate>>,
-    messages: &[(FrameSource, AviateMessage)],
+    state: &Arc<Mutex<LinkState>>,
+    messages: &[(FrameSource, FcMessage)],
     crc_failures: u32,
     unknown_ids: u32,
 ) {
     apply_messages_at(state, messages, crc_failures, unknown_ids, Instant::now());
 }
 
-pub(crate) fn apply_messages_at(
-    state: &Arc<Mutex<LatestAviate>>,
-    messages: &[(FrameSource, AviateMessage)],
+/// Folds decoded messages into the shared cache at an explicit receive
+/// instant. Public so adapter crates can drive the cache in tests
+/// without a socket; production traffic arrives via the link task.
+pub fn apply_messages_at(
+    state: &Arc<Mutex<LinkState>>,
+    messages: &[(FrameSource, FcMessage)],
     crc_failures: u32,
     unknown_ids: u32,
     now: Instant,
@@ -385,23 +401,23 @@ pub(crate) fn apply_messages_at(
             latest.wrong_sources = latest.wrong_sources.wrapping_add(1);
             continue;
         }
-        if message == AviateMessage::InvalidAviateEstimatorStatus {
+        if message == FcMessage::InvalidAviateEstimatorStatus {
             latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
             invalidate_cached_authorization(&mut latest);
             continue;
         }
         latest.decoded = latest.decoded.wrapping_add(1);
         match message {
-            AviateMessage::InvalidAviateEstimatorStatus => {}
-            AviateMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
-            AviateMessage::CommandAck { .. } => {}
-            AviateMessage::EstimatorStatus { .. } => {}
-            AviateMessage::AviateEstimatorStatus {
+            FcMessage::InvalidAviateEstimatorStatus => {}
+            FcMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
+            FcMessage::CommandAck { .. } => {}
+            FcMessage::EstimatorStatus { .. } => {}
+            FcMessage::AviateEstimatorStatus {
                 time_usec,
                 valid_flags,
                 quality,
             } => accept_status(&mut latest, time_usec, valid_flags, quality, now),
-            AviateMessage::AttitudeQuaternion {
+            FcMessage::AttitudeQuaternion {
                 time_boot_ms,
                 quat_wxyz,
                 rates_rps,
@@ -419,7 +435,7 @@ pub(crate) fn apply_messages_at(
                     });
                 }
             }
-            AviateMessage::LocalPositionNed {
+            FcMessage::LocalPositionNed {
                 time_boot_ms,
                 pos_ned_m,
                 vel_ned_mps,

--- a/crates/pilotage-mavlink/src/link/estimator.rs
+++ b/crates/pilotage-mavlink/src/link/estimator.rs
@@ -4,18 +4,26 @@ use std::time::Instant;
 
 use pilotage_adapter_api::MeasurementStamp;
 
-use super::LatestAviate;
+use super::LinkState;
 use super::measurement::next_estimator_status_stamp;
 
-pub(crate) const KNOWN_VALID_FLAGS: u32 = 0x0f;
-pub(crate) const QUALITY_GOOD: u32 = 0;
-pub(crate) const QUALITY_DEGRADED: u32 = 1;
-pub(crate) const QUALITY_UNUSABLE: u32 = 2;
+/// The validity bits this dialect defines; unknown bits are masked off.
+pub const KNOWN_VALID_FLAGS: u32 = 0x0f;
+/// Canonical quality: fully usable.
+pub const QUALITY_GOOD: u32 = 0;
+/// Canonical quality: degraded but present.
+pub const QUALITY_DEGRADED: u32 = 1;
+/// Canonical quality: unusable; consumers must not act on the values.
+pub const QUALITY_UNUSABLE: u32 = 2;
 
+/// The authorization an estimator-status report grants to cached
+/// numeric groups: masked validity bits plus a canonical quality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct EstimatorAuthorization {
-    pub(crate) valid_flags: u32,
-    pub(crate) quality: u32,
+pub struct EstimatorAuthorization {
+    /// Validity bits, masked to [`KNOWN_VALID_FLAGS`].
+    pub valid_flags: u32,
+    /// Canonical quality (`QUALITY_GOOD` / `_DEGRADED` / `_UNUSABLE`).
+    pub quality: u32,
 }
 
 impl EstimatorAuthorization {
@@ -46,16 +54,21 @@ impl EstimatorAuthorization {
     }
 }
 
+/// One accepted estimator-status report with its acquisition stamp.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct EstimatorStatusUpdate {
-    pub(crate) time_usec: u64,
-    pub(crate) time_boot_ms: u32,
-    pub(crate) authorization: EstimatorAuthorization,
-    pub(crate) stamp: MeasurementStamp,
+pub struct EstimatorStatusUpdate {
+    /// Source-reported time, microseconds.
+    pub time_usec: u64,
+    /// Milliseconds since FC boot derived from `time_usec`.
+    pub time_boot_ms: u32,
+    /// The authorization this report grants.
+    pub authorization: EstimatorAuthorization,
+    /// Identity and acquisition stamp for this report.
+    pub stamp: MeasurementStamp,
 }
 
 pub(super) fn accept_status(
-    latest: &mut LatestAviate,
+    latest: &mut LinkState,
     time_usec: u64,
     valid_flags: u8,
     quality: u8,
@@ -97,12 +110,12 @@ fn status_time_boot_ms(time_usec: u64) -> Option<u32> {
     u32::try_from(time_usec / 1_000).ok()
 }
 
-fn fail_closed_out_of_range_status(latest: &mut LatestAviate) {
+fn fail_closed_out_of_range_status(latest: &mut LinkState) {
     latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
     invalidate_cached_authorization(latest);
 }
 
-pub(super) fn authorization_at(latest: &LatestAviate, time_boot_ms: u32) -> EstimatorAuthorization {
+pub(super) fn authorization_at(latest: &LinkState, time_boot_ms: u32) -> EstimatorAuthorization {
     let time_usec = u64::from(time_boot_ms).saturating_mul(1_000);
     latest
         .estimator_status
@@ -115,7 +128,7 @@ pub(super) fn authorization_at(latest: &LatestAviate, time_boot_ms: u32) -> Esti
         })
 }
 
-fn degrade_cached_groups(latest: &mut LatestAviate, status: EstimatorAuthorization) {
+fn degrade_cached_groups(latest: &mut LinkState, status: EstimatorAuthorization) {
     if let Some(attitude) = latest.attitude.as_mut() {
         attitude.valid_flags &= status.valid_flags;
         attitude.quality = attitude.quality.max(status.quality);
@@ -126,7 +139,7 @@ fn degrade_cached_groups(latest: &mut LatestAviate, status: EstimatorAuthorizati
     }
 }
 
-pub(super) fn invalidate_cached_authorization(latest: &mut LatestAviate) {
+pub(super) fn invalidate_cached_authorization(latest: &mut LinkState) {
     let fail_closed = EstimatorAuthorization::fail_closed();
     if let Some(status) = latest.estimator_status.as_mut() {
         status.authorization = fail_closed;

--- a/crates/pilotage-mavlink/src/link/estimator/tests.rs
+++ b/crates/pilotage-mavlink/src/link/estimator/tests.rs
@@ -3,12 +3,8 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use pilotage_adapter_api::VehicleAdapter;
-use pilotage_protocol::VehicleId;
-
-use crate::AviateAdapter;
-use crate::link::{LatestAviate, ResetPolicy, apply_messages_at};
-use crate::mavlink::{AviateMessage, FrameSource};
+use crate::codec::{FcMessage, FrameSource};
+use crate::link::{LinkState, ResetPolicy, apply_messages_at};
 
 use super::{EstimatorAuthorization, QUALITY_DEGRADED, QUALITY_GOOD, QUALITY_UNUSABLE};
 
@@ -18,47 +14,47 @@ const SOURCE: FrameSource = FrameSource {
     frame_sequence: 0,
 };
 
-fn state() -> Arc<Mutex<LatestAviate>> {
-    Arc::new(Mutex::new(LatestAviate::default()))
+fn state() -> Arc<Mutex<LinkState>> {
+    Arc::new(Mutex::new(LinkState::default()))
 }
 
-fn simulator_state() -> Arc<Mutex<LatestAviate>> {
-    Arc::new(Mutex::new(LatestAviate {
+fn simulator_state() -> Arc<Mutex<LinkState>> {
+    Arc::new(Mutex::new(LinkState {
         reset_policy: ResetPolicy::SimulatorHeuristic,
         maximum_inter_group_skew_ms: 300,
-        ..LatestAviate::default()
+        ..LinkState::default()
     }))
 }
 
-fn private_status(time_usec: u64, valid_flags: u8, quality: u8) -> AviateMessage {
-    AviateMessage::AviateEstimatorStatus {
+fn private_status(time_usec: u64, valid_flags: u8, quality: u8) -> FcMessage {
+    FcMessage::AviateEstimatorStatus {
         time_usec,
         valid_flags,
         quality,
     }
 }
 
-fn attitude(time_boot_ms: u32) -> AviateMessage {
-    AviateMessage::AttitudeQuaternion {
+fn attitude(time_boot_ms: u32) -> FcMessage {
+    FcMessage::AttitudeQuaternion {
         time_boot_ms,
         quat_wxyz: [1.0, 0.0, 0.0, 0.0],
         rates_rps: [0.0; 3],
     }
 }
 
-fn kinematics(time_boot_ms: u32) -> AviateMessage {
-    AviateMessage::LocalPositionNed {
+fn kinematics(time_boot_ms: u32) -> FcMessage {
+    FcMessage::LocalPositionNed {
         time_boot_ms,
         pos_ned_m: [0.0; 3],
         vel_ned_mps: [0.0; 3],
     }
 }
 
-fn apply(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage]) {
+fn apply(state: &Arc<Mutex<LinkState>>, messages: &[FcMessage]) {
     apply_at(state, messages, Instant::now());
 }
 
-fn apply_at(state: &Arc<Mutex<LatestAviate>>, messages: &[AviateMessage], now: Instant) {
+fn apply_at(state: &Arc<Mutex<LinkState>>, messages: &[FcMessage], now: Instant) {
     let messages = messages
         .iter()
         .copied()
@@ -98,7 +94,7 @@ fn missing_mismatched_and_standard_status_fail_closed() {
     apply(
         &state,
         &[
-            AviateMessage::EstimatorStatus {
+            FcMessage::EstimatorStatus {
                 time_usec: 202_000,
                 flags: u16::MAX,
             },
@@ -432,60 +428,4 @@ fn same_timestamp_unknown_quality_revokes_the_cached_pair() {
         QUALITY_UNUSABLE
     );
     assert_eq!(latest.invalid_estimator_statuses, 1);
-}
-
-#[test]
-fn sampled_telemetry_tracks_status_only_revocation_without_regrant() {
-    let state = state();
-    apply(&state, &[attitude(100), kinematics(100)]);
-    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state.clone());
-
-    let initial = adapter.sample_telemetry();
-    let sample = &initial.samples[0];
-    let avionics = sample.avionics.expect("avionics");
-    assert_eq!(
-        (avionics.valid_flags, avionics.quality),
-        (0, QUALITY_UNUSABLE)
-    );
-    assert!(avionics.estimator_status_stamp.is_none());
-    assert!(sample.pose.is_none());
-    assert!(sample.speed.is_none());
-
-    apply(
-        &state,
-        &[
-            private_status(200_000, 0x0f, 2),
-            attitude(200),
-            kinematics(200),
-        ],
-    );
-    let authorized = adapter.sample_telemetry();
-    let sample = &authorized.samples[0];
-    let avionics = sample.avionics.expect("avionics");
-    assert_eq!(
-        (avionics.valid_flags, avionics.quality),
-        (0x0f, QUALITY_GOOD)
-    );
-    assert_eq!(
-        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
-        Some(0)
-    );
-    assert!(sample.pose.is_some());
-    assert!(sample.speed.is_some());
-
-    apply(&state, &[private_status(300_000, 0, 0)]);
-    apply(&state, &[private_status(400_000, 0x0f, 2)]);
-    let revoked = adapter.sample_telemetry();
-    let sample = &revoked.samples[0];
-    let avionics = sample.avionics.expect("avionics");
-    assert_eq!(
-        (avionics.valid_flags, avionics.quality),
-        (0, QUALITY_UNUSABLE)
-    );
-    assert_eq!(
-        avionics.estimator_status_stamp.map(|stamp| stamp.sequence),
-        Some(2)
-    );
-    assert!(sample.pose.is_none());
-    assert!(sample.speed.is_none());
 }

--- a/crates/pilotage-mavlink/src/link/measurement.rs
+++ b/crates/pilotage-mavlink/src/link/measurement.rs
@@ -1,0 +1,284 @@
+//! Measurement ordering and simulator reset quarantine.
+
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{MeasurementClock, MeasurementStamp, SourceIntegrity, SourceRole};
+use tracing::warn;
+
+use super::{LinkState, ResetPolicy};
+
+const RESET_CANDIDATE_MAX_MS: u32 = 5_000;
+pub(super) const RESET_SILENCE: Duration = Duration::from_secs(3);
+pub(super) const RESET_RECEIVE_DWELL: Duration = Duration::from_millis(250);
+pub(super) const RESET_SOURCE_DWELL_MS: u32 = 250;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MeasurementGroup {
+    Attitude,
+    Kinematics,
+    EstimatorStatus,
+}
+
+/// A quarantined low-boot-clock candidate awaiting simulator-only
+/// reset confirmation (source progress + silence + receive dwell).
+#[derive(Debug, Clone, Copy)]
+pub struct ResetCandidate {
+    group: MeasurementGroup,
+    first_time_ms: u32,
+    latest_time_ms: u32,
+    started_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeObservation {
+    CurrentEpoch,
+    PendingReset,
+    NewEpoch,
+    Rejected,
+}
+
+pub(super) fn serial_is_newer(candidate: u32, current: u32) -> bool {
+    let distance = candidate.wrapping_sub(current);
+    distance != 0 && distance < (1_u32 << 31)
+}
+
+fn begin_source_epoch(latest: &mut LinkState, time_boot_ms: u32) {
+    latest.source_epoch = latest.source_epoch.wrapping_add(1);
+    latest.last_source_time_ms = Some(time_boot_ms);
+    latest.last_accepted_at = None;
+    latest.pending_reset = None;
+    latest.attitude = None;
+    latest.kinematics = None;
+    latest.estimator_status = None;
+    latest.source_resets = latest.source_resets.wrapping_add(1);
+    warn!(
+        source_epoch = latest.source_epoch,
+        time_boot_ms, "MAVLink acquisition clock entered a new epoch"
+    );
+}
+
+fn accepted_stream_is_silent(latest: &LinkState, now: Instant) -> bool {
+    latest.last_accepted_at.is_none_or(|accepted| {
+        now.checked_duration_since(accepted)
+            .unwrap_or(Duration::ZERO)
+            >= RESET_SILENCE
+    })
+}
+
+fn reject_reordered(latest: &mut LinkState) -> TimeObservation {
+    latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
+    TimeObservation::Rejected
+}
+
+fn reset_candidate_or_reject(
+    latest: &mut LinkState,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    if time_boot_ms > RESET_CANDIDATE_MAX_MS
+        || latest.reset_policy == ResetPolicy::Conservative
+        || !accepted_stream_is_silent(latest, now)
+    {
+        reject_reordered(latest)
+    } else {
+        advance_reset_candidate(latest, group, time_boot_ms, now)
+    }
+}
+
+fn advance_reset_candidate(
+    latest: &mut LinkState,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    let Some(mut candidate) = latest.pending_reset else {
+        latest.pending_reset = Some(ResetCandidate {
+            group,
+            first_time_ms: time_boot_ms,
+            latest_time_ms: time_boot_ms,
+            started_at: now,
+        });
+        latest.suspected_resets = latest.suspected_resets.wrapping_add(1);
+        return TimeObservation::PendingReset;
+    };
+    if candidate.group != group || !serial_is_newer(time_boot_ms, candidate.latest_time_ms) {
+        return reject_reordered(latest);
+    }
+    candidate.latest_time_ms = time_boot_ms;
+    latest.pending_reset = Some(candidate);
+    let source_dwell = time_boot_ms.wrapping_sub(candidate.first_time_ms);
+    let receive_dwell = now
+        .checked_duration_since(candidate.started_at)
+        .unwrap_or(Duration::ZERO);
+    if source_dwell < RESET_SOURCE_DWELL_MS || receive_dwell < RESET_RECEIVE_DWELL {
+        return TimeObservation::PendingReset;
+    }
+    begin_source_epoch(latest, time_boot_ms);
+    TimeObservation::NewEpoch
+}
+
+fn observe_source_time(
+    latest: &mut LinkState,
+    group: MeasurementGroup,
+    current_time_ms: Option<u32>,
+    time_boot_ms: u32,
+    now: Instant,
+) -> TimeObservation {
+    if let Some(high_water) = latest.last_source_time_ms
+        && time_boot_ms < high_water
+        && serial_is_newer(time_boot_ms, high_water)
+    {
+        begin_source_epoch(latest, time_boot_ms);
+        return TimeObservation::NewEpoch;
+    }
+    if let Some(high_water) = latest.last_source_time_ms
+        && time_boot_ms < high_water
+        && high_water.wrapping_sub(time_boot_ms) > latest.maximum_inter_group_skew_ms
+    {
+        return reset_candidate_or_reject(latest, group, time_boot_ms, now);
+    }
+    let Some(current) = current_time_ms else {
+        latest.pending_reset = None;
+        return observe_initial_group(latest, time_boot_ms);
+    };
+    if time_boot_ms == current {
+        return TimeObservation::CurrentEpoch;
+    }
+    if time_boot_ms > current && serial_is_newer(time_boot_ms, current) {
+        latest.pending_reset = None;
+        return TimeObservation::CurrentEpoch;
+    }
+    reset_candidate_or_reject(latest, group, time_boot_ms, now)
+}
+
+fn observe_initial_group(latest: &mut LinkState, time_boot_ms: u32) -> TimeObservation {
+    let Some(high_water) = latest.last_source_time_ms else {
+        return TimeObservation::CurrentEpoch;
+    };
+    if time_boot_ms == high_water
+        || (time_boot_ms > high_water && serial_is_newer(time_boot_ms, high_water))
+    {
+        return TimeObservation::CurrentEpoch;
+    }
+    if time_boot_ms < high_water
+        && high_water.wrapping_sub(time_boot_ms) <= latest.maximum_inter_group_skew_ms
+    {
+        return TimeObservation::CurrentEpoch;
+    }
+    reject_reordered(latest)
+}
+
+pub(super) fn next_attitude_stamp(
+    latest: &mut LinkState,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .attitude
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::Attitude,
+        time_boot_ms,
+        now,
+    )
+}
+
+pub(super) fn next_kinematics_stamp(
+    latest: &mut LinkState,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .kinematics
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::Kinematics,
+        time_boot_ms,
+        now,
+    )
+}
+
+pub(super) fn next_estimator_status_stamp(
+    latest: &mut LinkState,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let current = latest
+        .estimator_status
+        .map(|update| (update.time_boot_ms, update.stamp));
+    next_group_stamp(
+        current,
+        latest,
+        MeasurementGroup::EstimatorStatus,
+        time_boot_ms,
+        now,
+    )
+}
+
+fn next_group_stamp(
+    current: Option<(u32, MeasurementStamp)>,
+    latest: &mut LinkState,
+    group: MeasurementGroup,
+    time_boot_ms: u32,
+    now: Instant,
+) -> Option<MeasurementStamp> {
+    let observation = observe_source_time(
+        latest,
+        group,
+        current.map(|(time, _)| time),
+        time_boot_ms,
+        now,
+    );
+    let current = match observation {
+        TimeObservation::CurrentEpoch => current,
+        TimeObservation::NewEpoch => None,
+        TimeObservation::PendingReset | TimeObservation::Rejected => return None,
+    };
+    let sequence = match current {
+        None => 0,
+        Some((current_time, _)) if current_time == time_boot_ms => {
+            latest.duplicate_measurements = latest.duplicate_measurements.wrapping_add(1);
+            return None;
+        }
+        Some((current_time, stamp)) if serial_is_newer(time_boot_ms, current_time) => {
+            stamp.sequence.wrapping_add(1)
+        }
+        // observe_source_time admits only equal or serially newer times
+        // for a group that already has a measurement, so this arm is the
+        // exhaustiveness fail-safe: an older time that ever slipped
+        // through would still reject rather than regress the sequence.
+        Some(_) => return reject_group(latest),
+    };
+    update_high_water(latest, time_boot_ms);
+    latest.last_accepted_at = Some(now);
+    Some(MeasurementStamp {
+        role: SourceRole::OperationalEstimate,
+        // MAVLink frames are CRC-checked but unsigned.
+        integrity: SourceIntegrity::ChecksummedOnly,
+        source_id: latest.source_id,
+        source_incarnation: latest.source_incarnation,
+        source_epoch: latest.source_epoch,
+        sequence,
+        acquired_at_ns: u64::from(time_boot_ms).wrapping_mul(1_000_000),
+        clock: MeasurementClock::VehicleBoot,
+    })
+}
+
+fn update_high_water(latest: &mut LinkState, time_boot_ms: u32) {
+    if latest
+        .last_source_time_ms
+        .is_none_or(|current| serial_is_newer(time_boot_ms, current))
+    {
+        latest.last_source_time_ms = Some(time_boot_ms);
+    }
+}
+
+fn reject_group(latest: &mut LinkState) -> Option<MeasurementStamp> {
+    latest.reordered_measurements = latest.reordered_measurements.wrapping_add(1);
+    None
+}

--- a/crates/pilotage-mavlink/src/link/tests.rs
+++ b/crates/pilotage-mavlink/src/link/tests.rs
@@ -5,9 +5,9 @@ use std::time::{Duration, Instant};
 
 use pilotage_adapter_api::SourceIncarnation;
 
-use crate::mavlink::{AviateMessage, FrameSource};
+use crate::codec::{FcMessage, FrameSource};
 
-use super::{LatestAviate, ResetPolicy, apply_messages_at};
+use super::{LinkState, ResetPolicy, apply_messages_at};
 
 const SELECTED: FrameSource = FrameSource {
     system_id: 1,
@@ -15,7 +15,7 @@ const SELECTED: FrameSource = FrameSource {
     frame_sequence: 0,
 };
 
-fn state(policy: ResetPolicy) -> Arc<Mutex<LatestAviate>> {
+fn state(policy: ResetPolicy) -> Arc<Mutex<LinkState>> {
     let maximum_inter_group_skew_ms = if policy == ResetPolicy::SimulatorHeuristic {
         300
     } else {
@@ -24,22 +24,19 @@ fn state(policy: ResetPolicy) -> Arc<Mutex<LatestAviate>> {
     state_with_skew(policy, maximum_inter_group_skew_ms)
 }
 
-fn state_with_skew(
-    policy: ResetPolicy,
-    maximum_inter_group_skew_ms: u32,
-) -> Arc<Mutex<LatestAviate>> {
-    Arc::new(Mutex::new(LatestAviate {
+fn state_with_skew(policy: ResetPolicy, maximum_inter_group_skew_ms: u32) -> Arc<Mutex<LinkState>> {
+    Arc::new(Mutex::new(LinkState {
         reset_policy: policy,
         maximum_inter_group_skew_ms,
         source_incarnation: SourceIncarnation::new([0xA5; 16]),
-        ..LatestAviate::default()
+        ..LinkState::default()
     }))
 }
 
-fn attitude_at(time_boot_ms: u32, qw: f32) -> (FrameSource, AviateMessage) {
+fn attitude_at(time_boot_ms: u32, qw: f32) -> (FrameSource, FcMessage) {
     (
         SELECTED,
-        AviateMessage::AttitudeQuaternion {
+        FcMessage::AttitudeQuaternion {
             time_boot_ms,
             quat_wxyz: [qw, 0.0, 0.0, 0.0],
             rates_rps: [0.0; 3],
@@ -47,10 +44,10 @@ fn attitude_at(time_boot_ms: u32, qw: f32) -> (FrameSource, AviateMessage) {
     )
 }
 
-fn kinematics_at(time_boot_ms: u32, north: f32) -> (FrameSource, AviateMessage) {
+fn kinematics_at(time_boot_ms: u32, north: f32) -> (FrameSource, FcMessage) {
     (
         SELECTED,
-        AviateMessage::LocalPositionNed {
+        FcMessage::LocalPositionNed {
             time_boot_ms,
             pos_ned_m: [north, 0.0, 0.0],
             vel_ned_mps: [0.0; 3],
@@ -58,10 +55,10 @@ fn kinematics_at(time_boot_ms: u32, north: f32) -> (FrameSource, AviateMessage) 
     )
 }
 
-fn status_at(time_boot_ms: u32, valid_flags: u8, quality: u8) -> (FrameSource, AviateMessage) {
+fn status_at(time_boot_ms: u32, valid_flags: u8, quality: u8) -> (FrameSource, FcMessage) {
     (
         SELECTED,
-        AviateMessage::AviateEstimatorStatus {
+        FcMessage::AviateEstimatorStatus {
             time_usec: u64::from(time_boot_ms).saturating_mul(1_000),
             valid_flags,
             quality,
@@ -69,11 +66,7 @@ fn status_at(time_boot_ms: u32, valid_flags: u8, quality: u8) -> (FrameSource, A
     )
 }
 
-fn apply_at(
-    state: &Arc<Mutex<LatestAviate>>,
-    messages: &[(FrameSource, AviateMessage)],
-    now: Instant,
-) {
+fn apply_at(state: &Arc<Mutex<LinkState>>, messages: &[(FrameSource, FcMessage)], now: Instant) {
     apply_messages_at(state, messages, 0, 0, now);
 }
 
@@ -160,7 +153,7 @@ fn invalid_status_frame_revokes_without_fabricating_source_time() {
         .expect("status");
     apply_messages_at(
         &state,
-        &[(SELECTED, AviateMessage::InvalidAviateEstimatorStatus)],
+        &[(SELECTED, FcMessage::InvalidAviateEstimatorStatus)],
         1,
         0,
         now,
@@ -180,7 +173,7 @@ fn invalid_status_poisons_authorization_for_delayed_exact_numeric() {
     apply_at(&state, &[status_at(100, 0x0f, 2)], now);
     apply_at(
         &state,
-        &[(SELECTED, AviateMessage::InvalidAviateEstimatorStatus)],
+        &[(SELECTED, FcMessage::InvalidAviateEstimatorStatus)],
         now,
     );
     apply_at(&state, &[kinematics_at(100, 1.0)], now);
@@ -200,7 +193,7 @@ fn trailing_invalid_status_wins_within_a_multi_frame_datagram() {
             status_at(100, 0x0f, 2),
             attitude_at(100, 0.5),
             kinematics_at(100, 1.0),
-            (SELECTED, AviateMessage::InvalidAviateEstimatorStatus),
+            (SELECTED, FcMessage::InvalidAviateEstimatorStatus),
         ],
         now,
     );
@@ -231,7 +224,7 @@ fn wrong_source_invalid_status_cannot_revoke_selected_source() {
     wrong.system_id = 2;
     apply_at(
         &state,
-        &[(wrong, AviateMessage::InvalidAviateEstimatorStatus)],
+        &[(wrong, FcMessage::InvalidAviateEstimatorStatus)],
         now,
     );
 
@@ -259,7 +252,7 @@ fn out_of_range_status_revokes_without_fabricating_source_time() {
         &state,
         &[(
             SELECTED,
-            AviateMessage::AviateEstimatorStatus {
+            FcMessage::AviateEstimatorStatus {
                 time_usec: (u64::from(u32::MAX) + 1).saturating_mul(1_000),
                 valid_flags: 0x0f,
                 quality: 2,
@@ -336,7 +329,7 @@ fn same_datagram_cross_group_replay_cannot_confirm_reset() {
     assert_eq!(latest.source_resets, 0);
 }
 
-fn confirm_attitude_reset(state: &Arc<Mutex<LatestAviate>>, start: Instant, first_low_ms: u32) {
+fn confirm_attitude_reset(state: &Arc<Mutex<LinkState>>, start: Instant, first_low_ms: u32) {
     apply_at(
         state,
         &[attitude_at(first_low_ms, 0.6)],

--- a/docs/link/evidence-artifacts/link04/adapter.run.txt
+++ b/docs/link/evidence-artifacts/link04/adapter.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: adapter source-role acceptance
 command: cargo test -p pilotage-adapter-aviate source_roles
-config-digest: 5dfedb440a562919894be17e1ff199bcaae4e25c
+config-digest: a06be9513007911cd726e2a76416b4389b036c15
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5dfedb440a562919894be17e1ff199bcaae4e25c
+run-id: local:a06be9513007911cd726e2a76416b4389b036c15
 outcome: pass
 summary:
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 79 filtered out; finished in 0.00s
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out; finished in 0.00s

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -249,6 +249,12 @@ attr output-digest sha256:064e32f9b8cc9b78472dcf7de91e20b35b76a7b4263208bfccc3ba
 attr run-id local:211406836a102c64c0e0065a796e238a8af16f3a
 attr outcome pass
 
+node CFG-LINK-EXTRACTION configuration-item
+title committed code baseline of the re-recorded adapter suite (the MAVLink extraction commit)
+attr scm git
+attr commit a06be9513007911cd726e2a76416b4389b036c15
+attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
+
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
@@ -344,7 +350,7 @@ edge RESULT-LINK-ADAPTER result-of CASE-LINK-ORACLE
 edge RESULT-LINK-ADAPTER result-of CASE-LINK-MISLABEL
 edge RESULT-LINK-ADAPTER covers LINK-ROLE-001
 edge RESULT-LINK-ADAPTER covers LINK-CTRL-002
-edge RESULT-LINK-ADAPTER justified-by CFG-LINK-WORKTREE
+edge RESULT-LINK-ADAPTER justified-by CFG-LINK-EXTRACTION
 edge RESULT-LINK-ADAPTER justified-by TOOL-LINK-CARGO
 
 edge RESULT-LINK-WIRE result-of CASE-LINK-WIRE

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -184,12 +184,12 @@ attr test testDuplicateStatusDowngradeIsNotReversibleByANewerNumeric
 node RESULT-LINK-ADAPTER verification-result
 title adapter source-role acceptance suite — recorded pass
 attr command cargo test -p pilotage-adapter-aviate source_roles
-attr config-digest 5dfedb440a562919894be17e1ff199bcaae4e25c
+attr config-digest a06be9513007911cd726e2a76416b4389b036c15
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:df97524b1f96016992494b6a0cb78bd9445cca0f
+attr source-digest git-blob:aab8e146252f94229733a7d22f49481dd5d23470
 attr artifact docs/link/evidence-artifacts/link04/adapter.run.txt
-attr output-digest sha256:beff03b0157c24fe78d165d819d31d2b22cabd9e87a8f38abc8044be2afa1542
-attr run-id local:5dfedb440a562919894be17e1ff199bcaae4e25c
+attr output-digest sha256:67b753585fb73f0dc60582e0460e7b686aa349a5df04c3f5ca4c271e6a07be52
+attr run-id local:a06be9513007911cd726e2a76416b4389b036c15
 attr outcome pass
 
 node RESULT-LINK-WIRE verification-result


### PR DESCRIPTION
Refs #96. A **behavior-preserving move** of the MAVLink codec (framing, CRC-EXTRA, the standard message subset + the Aviate private estimator-status extension) and the receive-link machinery (latest-state cache, source epochs, reboot detection, skew budgets, estimator authorization) from the Aviate adapter into a shared `pilotage-mavlink` crate, so the PX4 adapter (#158) reuses them instead of copying.

Honest API note: this is NOT API-invisible to `pilotage-adapter-aviate` consumers — the moved types are renamed at the boundary (`AviateMessage` → `FcMessage`, `LatestAviate` → `LinkState`, `AviateLink` → `MavlinkLink`; bind failure becomes typed `LinkError`). The aviate crate re-exports the codec as its public `mavlink` module, so module *paths* survive but type *names* change. The moved link/codec suites pass unmodified.

Also carries the LINK-04 evidence for the move: the adapter-suite result re-recorded against the extraction baseline, a matching configuration-item, and a new gate check (with regression tests) that fails closed when a result's `config-digest` matches none of its justifying configuration-items — the two-baselines inconsistency this PR's first draft demonstrated.

PX4-specific link capabilities live in #161, stacked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)