### PR TITLE
Adapter: PX4 over standard MAVLink — telemetry, offboard velocity control, gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ name = "pilotage-adapter-px4"
 version = "0.1.0"
 dependencies = [
  "pilotage-adapter-api",
+ "pilotage-adapter-gazebo",
  "pilotage-mavlink",
  "pilotage-protocol",
  "pilotage-timing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-adapter-px4"
+version = "0.1.0"
+dependencies = [
+ "pilotage-adapter-api",
+ "pilotage-mavlink",
+ "pilotage-protocol",
+ "pilotage-timing",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "pilotage-adapter-reference"
 version = "0.1.0"
 dependencies = [
@@ -1245,6 +1258,7 @@ dependencies = [
  "pilotage-adapter-api",
  "pilotage-adapter-aviate",
  "pilotage-adapter-gazebo",
+ "pilotage-adapter-px4",
  "pilotage-adapter-reference",
  "pilotage-authority",
  "pilotage-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/pilotage-evidence",
     "adapters/reference-headless",
     "adapters/aviate",
+    "adapters/px4",
     "tools/hid-probe",
     "tools/loopback-probe",
     "tools/xtask",
@@ -78,6 +79,7 @@ pilotage-instrument-raster = { path = "crates/pilotage-instrument-raster" }
 pilotage-adapter-reference = { path = "adapters/reference-headless" }
 pilotage-adapter-gazebo = { path = "adapters/gazebo" }
 pilotage-adapter-aviate = { path = "adapters/aviate" }
+pilotage-adapter-px4 = { path = "adapters/px4" }
 pilotage-session = { path = "crates/pilotage-session" }
 
 [workspace.lints.rust]

--- a/adapters/px4/Cargo.toml
+++ b/adapters/px4/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pilotage-adapter-px4"
+description = "VehicleAdapter for PX4 over standard MAVLink 2.0: telemetry, offboard velocity control, and arming"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-adapter-api = { workspace = true }
+pilotage-mavlink = { workspace = true }
+pilotage-protocol = { workspace = true }
+pilotage-timing = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "sync", "time", "macros"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["net", "rt", "sync", "time", "macros", "rt-multi-thread"] }

--- a/adapters/px4/Cargo.toml
+++ b/adapters/px4/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 pilotage-adapter-api = { workspace = true }
+pilotage-adapter-gazebo = { workspace = true }
 pilotage-mavlink = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -1,7 +1,7 @@
 //! The PX4 `VehicleAdapter`: telemetry sampling from the shared
 //! MAVLink link and offboard flight control with the same gate
-//! discipline as the Aviate adapter (link-loss latch, commanded-reset
-//! latch, disarm always allowed).
+//! discipline as the Aviate adapter (link-loss latch followed by the
+//! commanded-reset latch).
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -15,8 +15,9 @@ use pilotage_protocol::VehicleId;
 use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame};
 use pilotage_timing::SimTick;
 
-use pilotage_mavlink::{AuthorizationSource, LinkConfig, LinkState, MavlinkLink};
+use pilotage_mavlink::{LinkState, MavlinkLink};
 
+use crate::config::Px4Config;
 use crate::error::Px4AdapterError;
 use crate::uplink::Px4Uplink;
 
@@ -102,24 +103,22 @@ struct ArmReport {
 }
 
 impl Px4Adapter {
-    /// Binds the MAVLink receive link (`PILOTAGE_PX4_ADDR`, default
-    /// `127.0.0.1:14550` — PX4 streams attitude, local position, and
-    /// the estimator status on its GCS instance) and the offboard
-    /// command uplink. A failed uplink bind degrades to
-    /// telemetry-only rather than failing the adapter.
+    /// Binds the configured MAVLink receive link and offboard command
+    /// uplink. A failed uplink bind degrades to telemetry-only rather
+    /// than failing the adapter.
     ///
     /// # Errors
     ///
     /// Returns [`Px4AdapterError::Link`] when the receive link cannot
     /// bind any socket.
-    pub async fn start(vehicle: VehicleId) -> Result<Self, Px4AdapterError> {
-        let config = link_config();
+    pub async fn start(vehicle: VehicleId, config: Px4Config) -> Result<Self, Px4AdapterError> {
+        let link_config = config.link_config();
         let incarnation = pilotage_adapter_api::SourceIncarnation::new(rand_incarnation());
-        let link = MavlinkLink::start(config, incarnation).await?;
+        let link = MavlinkLink::start(link_config, incarnation).await?;
         let state = link.state();
-        let uplink = match Px4Uplink::new() {
+        let uplink = match Px4Uplink::new(config.command_endpoint) {
             Ok(mut uplink) => {
-                uplink.set_expected_source(config.system_id, config.component_id);
+                uplink.set_expected_source(link_config.system_id, link_config.component_id);
                 Some(uplink)
             }
             Err(error) => {
@@ -230,37 +229,6 @@ impl Px4Adapter {
             }
         }
         Ok(())
-    }
-}
-
-fn link_config() -> LinkConfig {
-    let endpoint = std::env::var("PILOTAGE_PX4_ADDR")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 14_550)));
-    // The GCS mavlink instance owns the telemetry stream this adapter
-    // consumes; interval requests must come from the link's own socket
-    // (the instance retargets its stream to the last peer that spoke).
-    let gcs_command = std::env::var("PILOTAGE_PX4_GCS_ADDR")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 18_570)));
-    LinkConfig {
-        endpoint,
-        authorization_source: AuthorizationSource::StandardEstimatorStatus,
-        // The status is requested at 10 Hz; a 300 ms lag ceiling covers
-        // that with margin and matches the display's pairing budget.
-        standard_status_max_lag_ms: 300,
-        // PX4 streams only ~15-20 s after boot (logger, EKF, and the
-        // message-interval negotiation), so its post-restart clock is
-        // far above the default reset-candidate ceiling.
-        reset_candidate_max_ms: 60_000,
-        stream_command_target: Some(gcs_command),
-        // Attitude and local position at ~30 Hz; the estimator status
-        // at 10 Hz so every numeric group finds a status inside the
-        // display's 300 ms pairing budget.
-        stream_interval_requests: &[(31, 33_333), (32, 33_333), (230, 100_000)],
-        ..LinkConfig::simulator()
     }
 }
 

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -248,6 +248,9 @@ fn link_config() -> LinkConfig {
     LinkConfig {
         endpoint,
         authorization_source: AuthorizationSource::StandardEstimatorStatus,
+        // The status is requested at 10 Hz; a 300 ms lag ceiling covers
+        // that with margin and matches the display's pairing budget.
+        standard_status_max_lag_ms: 300,
         // PX4 streams only ~15-20 s after boot (logger, EKF, and the
         // message-interval negotiation), so its post-restart clock is
         // far above the default reset-candidate ceiling.

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -20,6 +20,7 @@ use pilotage_mavlink::{AuthorizationSource, LinkConfig, LinkState, MavlinkLink};
 use crate::error::Px4AdapterError;
 use crate::uplink::Px4Uplink;
 
+mod camera;
 mod control;
 mod sampling;
 #[cfg(test)]
@@ -60,6 +61,17 @@ pub struct Px4Adapter {
     // basis for state-dependent control; there is no truth oracle).
     estimate: Option<EstimateSource>,
     uplink: Option<Px4Uplink>,
+    // Pilotage's gz sidecar bridges the flight-deck rig's camera topics;
+    // the adapter remains usable without video when it cannot spawn.
+    frames: Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
+    _camera_bridge: Option<pilotage_adapter_gazebo::BridgeClient>,
+    _frame_forwarder: Option<tokio::task::JoinHandle<()>>,
+    // Latest heartbeat-reported arm state; re-acquired per heartbeat so
+    // its freshness honestly tracks the FC's liveness.
+    arm: Option<ArmReport>,
+    last_seen_heartbeat: Option<std::time::Instant>,
+    arm_incarnation: pilotage_adapter_api::SourceIncarnation,
+    started_at: std::time::Instant,
     last_reset: Option<std::time::Instant>,
     // Commanded-reset latch: engaged when a sim reset is requested,
     // cleared only by a fresh estimate source epoch plus demonstrated
@@ -79,6 +91,14 @@ pub struct Px4Adapter {
 struct EstimateSource {
     state: Arc<Mutex<LinkState>>,
     _link: Option<MavlinkLink>,
+}
+
+/// The latest FC arm report derived from telemetry heartbeats.
+#[derive(Debug, Clone, Copy)]
+struct ArmReport {
+    armed: bool,
+    sequence: u32,
+    acquired_at: std::time::Instant,
 }
 
 impl Px4Adapter {
@@ -107,6 +127,7 @@ impl Px4Adapter {
                 None
             }
         };
+        let (frames, camera_bridge, frame_forwarder) = camera::spawn_camera_bridge().await;
         Ok(Self {
             vehicle,
             estimate: Some(EstimateSource {
@@ -114,6 +135,13 @@ impl Px4Adapter {
                 _link: Some(link),
             }),
             uplink,
+            frames,
+            _camera_bridge: camera_bridge,
+            _frame_forwarder: frame_forwarder,
+            arm: None,
+            last_seen_heartbeat: None,
+            arm_incarnation: pilotage_adapter_api::SourceIncarnation::new(rand_incarnation()),
+            started_at: std::time::Instant::now(),
             last_reset: None,
             reset_latch: None,
             #[cfg(test)]
@@ -129,6 +157,13 @@ impl Px4Adapter {
             vehicle,
             estimate: Some(EstimateSource { state, _link: None }),
             uplink: None,
+            frames: None,
+            _camera_bridge: None,
+            _frame_forwarder: None,
+            arm: None,
+            last_seen_heartbeat: None,
+            arm_incarnation: pilotage_adapter_api::SourceIncarnation::new([0; 16]),
+            started_at: std::time::Instant::now(),
             last_reset: None,
             reset_latch: None,
             reset_spawns: 0,
@@ -136,11 +171,44 @@ impl Px4Adapter {
         }
     }
 
+    /// Takes the raw-frame receiver for the host media task, if cameras
+    /// are up and it has not been taken.
+    pub fn subscribe_frames(
+        &mut self,
+    ) -> Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>> {
+        self.frames.take()
+    }
+
     /// Installs a test uplink, for tests.
     #[cfg(test)]
     pub(crate) fn with_uplink(mut self, uplink: Px4Uplink) -> Self {
         self.uplink = Some(uplink);
         self
+    }
+
+    /// Folds the latest heartbeat arm flag into the arm report. Each
+    /// newly received heartbeat re-acquires the report (fresh stamp,
+    /// advanced sequence), so a silent FC honestly ages into staleness
+    /// instead of replaying the last state forever.
+    fn observe_arm_report(&mut self) {
+        let observed = self
+            .estimate
+            .as_ref()
+            .and_then(|source| source.state.lock().ok())
+            .and_then(|latest| Some((latest.heartbeat_armed?, latest.last_heartbeat?)));
+        let Some((armed, heartbeat_at)) = observed else {
+            return;
+        };
+        if self.last_seen_heartbeat == Some(heartbeat_at) {
+            return;
+        }
+        self.last_seen_heartbeat = Some(heartbeat_at);
+        let sequence = self.arm.map_or(0, |report| report.sequence.wrapping_add(1));
+        self.arm = Some(ArmReport {
+            armed,
+            sequence,
+            acquired_at: std::time::Instant::now(),
+        });
     }
 
     fn validate_flight_frame(&self, frame: &ScopedControlFrame) -> Result<(), RejectReason> {
@@ -262,11 +330,16 @@ impl VehicleAdapter for Px4Adapter {
     }
 
     fn sample_telemetry(&mut self) -> TelemetryBatch {
-        let batch = self
+        self.observe_arm_report();
+        let fc_state = sampling::fc_state_sample(self.arm, self.arm_incarnation, self.started_at);
+        let mut batch = self
             .estimate
             .as_ref()
             .map(|source| sampling::mavlink_batch(self.vehicle, &source.state))
             .unwrap_or_default();
+        for sample in &mut batch.samples {
+            sample.fc_state = fc_state;
+        }
         let telemetry_flowing = batch
             .samples
             .first()
@@ -278,7 +351,19 @@ impl VehicleAdapter for Px4Adapter {
     }
 
     fn video_sources(&self) -> Vec<VideoSource> {
-        vec![]
+        if self._camera_bridge.is_none() {
+            return vec![];
+        }
+        vec![
+            VideoSource {
+                id: pilotage_adapter_gazebo::FPV_SOURCE_ID.to_owned(),
+                description: "onboard forward camera".to_owned(),
+            },
+            VideoSource {
+                id: pilotage_adapter_gazebo::CHASE_SOURCE_ID.to_owned(),
+                description: "chase camera".to_owned(),
+            },
+        ]
     }
 
     fn set_link_loss_policy(

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -1,0 +1,328 @@
+//! The PX4 `VehicleAdapter`: telemetry sampling from the shared
+//! MAVLink link and offboard flight control with the same gate
+//! discipline as the Aviate adapter (link-loss latch, commanded-reset
+//! latch, disarm always allowed).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use pilotage_adapter_api::{
+    AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossEnactError,
+    LinkLossPolicy, RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch,
+    VehicleAdapter, VehicleDescriptor, VideoSource,
+};
+use pilotage_protocol::VehicleId;
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame};
+use pilotage_timing::SimTick;
+
+use pilotage_mavlink::{AuthorizationSource, LinkConfig, LinkState, MavlinkLink};
+
+use crate::error::Px4AdapterError;
+use crate::uplink::Px4Uplink;
+
+mod control;
+mod sampling;
+#[cfg(test)]
+mod tests;
+
+use control::rejected_control;
+
+/// The control scope: four canonical flight axes as velocity demands.
+pub const FLIGHT_SCOPE: &str = "vehicle.motion";
+/// Canonical `roll` axis (0): lateral velocity, + = right.
+pub const ROLL_AXIS: u16 = 0;
+/// Canonical `pitch` axis (1): forward velocity, + = forward.
+pub const PITCH_AXIS: u16 = 1;
+/// Canonical `throttle` axis (2): climb rate, + = climb.
+pub const THROTTLE_AXIS: u16 = 2;
+/// Canonical `yaw` axis (3): yaw rate, + = clockwise.
+pub const YAW_AXIS: u16 = 3;
+/// Logical button whose press arms the vehicle.
+pub const ARM_BUTTON: u16 = 0;
+/// Logical button whose press disarms the vehicle.
+pub const DISARM_BUTTON: u16 = 1;
+/// Logical button whose press resets the simulation.
+pub const RESET_BUTTON: u16 = 2;
+
+/// Data older than this is withheld from telemetry entirely, so
+/// downstream freshness models see the group's age grow instead of a
+/// frozen value replaying forever.
+const WITHHOLD_AFTER: Duration = Duration::from_secs(3);
+
+/// Telemetry-only-until-armed adapter for PX4 (ADR-0018). Real-time
+/// (ADR-0013): PX4 advances on its own clock; `step` reports the
+/// latest observed source time as the simulation tick.
+#[derive(Debug)]
+pub struct Px4Adapter {
+    vehicle: VehicleId,
+    // The shared receive-link cache. PX4's standard ESTIMATOR_STATUS
+    // is the authorization source (LINK-04: the estimate is the only
+    // basis for state-dependent control; there is no truth oracle).
+    estimate: Option<EstimateSource>,
+    uplink: Option<Px4Uplink>,
+    last_reset: Option<std::time::Instant>,
+    // Commanded-reset latch: engaged when a sim reset is requested,
+    // cleared only by a fresh estimate source epoch plus demonstrated
+    // neutral input. While engaged, everything except disarm is
+    // rejected.
+    reset_latch: Option<control::ResetLatch>,
+    // Reset script spawns recorded instead of executed, so tests can
+    // press the reset button without touching a live simulator.
+    #[cfg(test)]
+    reset_spawns: u32,
+    link_loss_policy: Option<LinkLossPolicy>,
+}
+
+/// The MAVLink estimate source: the shared cache plus the link task
+/// keeping it fed (dropped together).
+#[derive(Debug)]
+struct EstimateSource {
+    state: Arc<Mutex<LinkState>>,
+    _link: Option<MavlinkLink>,
+}
+
+impl Px4Adapter {
+    /// Binds the MAVLink receive link (`PILOTAGE_PX4_ADDR`, default
+    /// `127.0.0.1:14550` — PX4 streams attitude, local position, and
+    /// the estimator status on its GCS instance) and the offboard
+    /// command uplink. A failed uplink bind degrades to
+    /// telemetry-only rather than failing the adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Px4AdapterError::Link`] when the receive link cannot
+    /// bind any socket.
+    pub async fn start(vehicle: VehicleId) -> Result<Self, Px4AdapterError> {
+        let config = link_config();
+        let incarnation = pilotage_adapter_api::SourceIncarnation::new(rand_incarnation());
+        let link = MavlinkLink::start(config, incarnation).await?;
+        let state = link.state();
+        let uplink = match Px4Uplink::new() {
+            Ok(mut uplink) => {
+                uplink.set_expected_source(config.system_id, config.component_id);
+                Some(uplink)
+            }
+            Err(error) => {
+                tracing::warn!(%error, "PX4 uplink unavailable; telemetry-only");
+                None
+            }
+        };
+        Ok(Self {
+            vehicle,
+            estimate: Some(EstimateSource {
+                state,
+                _link: Some(link),
+            }),
+            uplink,
+            last_reset: None,
+            reset_latch: None,
+            #[cfg(test)]
+            reset_spawns: 0,
+            link_loss_policy: None,
+        })
+    }
+
+    /// Wires an adapter around a caller-supplied state cache, for tests.
+    #[cfg(test)]
+    pub(crate) fn from_state(vehicle: VehicleId, state: Arc<Mutex<LinkState>>) -> Self {
+        Self {
+            vehicle,
+            estimate: Some(EstimateSource { state, _link: None }),
+            uplink: None,
+            last_reset: None,
+            reset_latch: None,
+            reset_spawns: 0,
+            link_loss_policy: None,
+        }
+    }
+
+    /// Installs a test uplink, for tests.
+    #[cfg(test)]
+    pub(crate) fn with_uplink(mut self, uplink: Px4Uplink) -> Self {
+        self.uplink = Some(uplink);
+        self
+    }
+
+    fn validate_flight_frame(&self, frame: &ScopedControlFrame) -> Result<(), RejectReason> {
+        if frame.vehicle != self.vehicle {
+            return Err(RejectReason::UnknownVehicle);
+        }
+        if frame.scope.as_str() != FLIGHT_SCOPE {
+            return Err(RejectReason::UnknownScope);
+        }
+        let known = [
+            LogicalAxisId::new(ROLL_AXIS),
+            LogicalAxisId::new(PITCH_AXIS),
+            LogicalAxisId::new(THROTTLE_AXIS),
+            LogicalAxisId::new(YAW_AXIS),
+        ];
+        for (axis, _) in &frame.payload.axes {
+            if !known.contains(axis) {
+                return Err(RejectReason::UnknownAxis);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn link_config() -> LinkConfig {
+    let endpoint = std::env::var("PILOTAGE_PX4_ADDR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 14_550)));
+    LinkConfig {
+        endpoint,
+        authorization_source: AuthorizationSource::StandardEstimatorStatus,
+        // PX4 streams only ~15-20 s after boot (logger, EKF, and the
+        // message-interval negotiation), so its post-restart clock is
+        // far above the default reset-candidate ceiling.
+        reset_candidate_max_ms: 60_000,
+        ..LinkConfig::simulator()
+    }
+}
+
+/// A random attachment identity; each adapter start is a distinct
+/// source incarnation.
+fn rand_incarnation() -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    bytes[..8].copy_from_slice(&now.as_nanos().to_le_bytes()[..8]);
+    bytes[8..12].copy_from_slice(&std::process::id().to_le_bytes());
+    bytes
+}
+
+impl VehicleAdapter for Px4Adapter {
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            execution: ExecutionMode {
+                real_time: true,
+                ..ExecutionMode::default()
+            },
+            vehicles: vec![VehicleDescriptor {
+                id: self.vehicle,
+                scopes: if self.uplink.is_some() {
+                    vec![ScopeDescriptor {
+                        scope: ScopeId::new(FLIGHT_SCOPE),
+                        axes: vec![
+                            LogicalAxisId::new(ROLL_AXIS),
+                            LogicalAxisId::new(PITCH_AXIS),
+                            LogicalAxisId::new(THROTTLE_AXIS),
+                            LogicalAxisId::new(YAW_AXIS),
+                        ],
+                    }]
+                } else {
+                    vec![]
+                },
+                link_loss_actions: if self.uplink.is_some() {
+                    vec![LinkLossPolicy::Neutralize]
+                } else {
+                    vec![]
+                },
+            }],
+            adapter_version: env!("CARGO_PKG_VERSION").to_owned(),
+        }
+    }
+
+    fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
+        let tick = self.step(StepBudget { ticks: 0 }).now;
+        if let Some(outcome) = self.gated_flight_outcome(frame, tick) {
+            return outcome;
+        }
+        let Some((current_yaw, _pos, _vel)) = self.current_pose() else {
+            return rejected_control(tick, RejectReason::MeasurementUnavailable);
+        };
+        let Some(uplink) = self.uplink.as_mut() else {
+            return rejected_control(tick, RejectReason::UnknownScope);
+        };
+        for (button, edge) in &frame.payload.edges {
+            if *edge != ButtonEdge::Pressed {
+                continue;
+            }
+            if *button == LogicalButtonId::new(ARM_BUTTON) {
+                uplink.begin_arm(current_yaw);
+            }
+        }
+        let (sticks, transformed) = control::normalized_flight_sticks(frame);
+        uplink.send_stick_frame(
+            sticks[usize::from(ROLL_AXIS)],
+            sticks[usize::from(PITCH_AXIS)],
+            sticks[usize::from(THROTTLE_AXIS)],
+            sticks[usize::from(YAW_AXIS)],
+        );
+        ApplyOutcome {
+            tick,
+            disposition: if transformed {
+                Disposition::Transformed
+            } else {
+                Disposition::Accepted
+            },
+        }
+    }
+
+    fn sample_telemetry(&mut self) -> TelemetryBatch {
+        let batch = self
+            .estimate
+            .as_ref()
+            .map(|source| sampling::mavlink_batch(self.vehicle, &source.state))
+            .unwrap_or_default();
+        let telemetry_flowing = batch
+            .samples
+            .first()
+            .is_some_and(|sample| sample.avionics.is_some());
+        if let Some(uplink) = self.uplink.as_mut() {
+            uplink.maintain(telemetry_flowing);
+        }
+        batch
+    }
+
+    fn video_sources(&self) -> Vec<VideoSource> {
+        vec![]
+    }
+
+    fn set_link_loss_policy(
+        &mut self,
+        vehicle: VehicleId,
+        policy: Option<LinkLossPolicy>,
+    ) -> Result<(), LinkLossEnactError> {
+        if vehicle != self.vehicle {
+            return Err(LinkLossEnactError::UnknownVehicle { vehicle });
+        }
+        match policy {
+            Some(_) => {
+                let Some(uplink) = self.uplink.as_mut() else {
+                    self.link_loss_policy = policy;
+                    return Err(LinkLossEnactError::NoActuationChannel);
+                };
+                let failures_before = uplink.send_failures();
+                uplink.neutralize();
+                let refused = uplink.send_failures() != failures_before;
+                self.link_loss_policy = policy;
+                if refused {
+                    return Err(LinkLossEnactError::ChannelRejected {
+                        detail: "the neutral setpoint send was refused".to_owned(),
+                    });
+                }
+                Ok(())
+            }
+            None => {
+                self.link_loss_policy = None;
+                Ok(())
+            }
+        }
+    }
+
+    fn step(&mut self, _budget: StepBudget) -> StepOutcome {
+        let tick = self
+            .estimate
+            .as_ref()
+            .and_then(|source| source.state.lock().ok())
+            .and_then(|latest| latest.kinematics)
+            .map_or(0, |kin| u64::from(kin.time_boot_ms).wrapping_mul(1_000_000));
+        StepOutcome {
+            advanced: 0,
+            now: SimTick::new(tick),
+        }
+    }
+}

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -238,6 +238,13 @@ fn link_config() -> LinkConfig {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 14_550)));
+    // The GCS mavlink instance owns the telemetry stream this adapter
+    // consumes; interval requests must come from the link's own socket
+    // (the instance retargets its stream to the last peer that spoke).
+    let gcs_command = std::env::var("PILOTAGE_PX4_GCS_ADDR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 18_570)));
     LinkConfig {
         endpoint,
         authorization_source: AuthorizationSource::StandardEstimatorStatus,
@@ -245,6 +252,11 @@ fn link_config() -> LinkConfig {
         // message-interval negotiation), so its post-restart clock is
         // far above the default reset-candidate ceiling.
         reset_candidate_max_ms: 60_000,
+        stream_command_target: Some(gcs_command),
+        // Attitude and local position at ~30 Hz; the estimator status
+        // at 10 Hz so every numeric group finds a status inside the
+        // display's 300 ms pairing budget.
+        stream_interval_requests: &[(31, 33_333), (32, 33_333), (230, 100_000)],
         ..LinkConfig::simulator()
     }
 }
@@ -340,12 +352,8 @@ impl VehicleAdapter for Px4Adapter {
         for sample in &mut batch.samples {
             sample.fc_state = fc_state;
         }
-        let telemetry_flowing = batch
-            .samples
-            .first()
-            .is_some_and(|sample| sample.avionics.is_some());
         if let Some(uplink) = self.uplink.as_mut() {
-            uplink.maintain(telemetry_flowing);
+            uplink.maintain();
         }
         batch
     }

--- a/adapters/px4/src/adapter/camera.rs
+++ b/adapters/px4/src/adapter/camera.rs
@@ -1,0 +1,60 @@
+//! The gz camera sidecar path for the px4-gz world: Pilotage's C++
+//! gz-transport bridge delivers the flight-deck rig's `/camera` and
+//! `/chase_camera` frames.
+//!
+//! Frames are captured on the sidecar's simulation clock while PX4's
+//! flight state runs on its own boot clock; no correlation between the
+//! two is available, so every frame carries an unavailable clock
+//! mapping (ADR-0020) — a consumer must gate conformal overlay off
+//! rather than draw against a state it cannot align to the image.
+
+use pilotage_adapter_api::SourceIncarnation;
+use pilotage_adapter_gazebo::FrameStamper;
+
+/// Spawns the gz camera sidecar for the rig's `/camera` and
+/// `/chase_camera` topics, degrading to no-video when it can't
+/// (`PILOTAGE_PX4_CAMERA=off` disables the attempt).
+#[allow(clippy::type_complexity)]
+pub(crate) async fn spawn_camera_bridge() -> (
+    Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
+    Option<pilotage_adapter_gazebo::BridgeClient>,
+    Option<tokio::task::JoinHandle<()>>,
+) {
+    if std::env::var("PILOTAGE_PX4_CAMERA").as_deref() == Ok("off") {
+        return (None, None, None);
+    }
+    let incarnation = SourceIncarnation::new(super::rand_incarnation());
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .map_or_else(|| std::path::PathBuf::from("."), std::path::PathBuf::from);
+    let bin = workspace_root.join("adapters/gazebo/bridge/build/pilotage-gz-bridge");
+    let config = pilotage_adapter_gazebo::BridgeConfig::new("x500", bin);
+    match pilotage_adapter_gazebo::BridgeClient::spawn_and_connect(config).await {
+        Ok(mut bridge) => {
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            // No correlation between the sim capture clock and PX4's
+            // clock; PX4 also publishes no camera calibration.
+            let mut stamper = FrameStamper::new(
+                incarnation,
+                pilotage_adapter_api::CaptureClockMapping::Unavailable,
+                std::collections::BTreeMap::new(),
+            );
+            let forwarder = bridge.take_frame_rx().map(|mut bridge_rx| {
+                tokio::spawn(async move {
+                    while let Some(frame) = bridge_rx.recv().await {
+                        if tx.send(stamper.stamp(frame)).await.is_err() {
+                            return;
+                        }
+                    }
+                })
+            });
+            tracing::info!("PX4 camera sidecar up (FPV + chase)");
+            (Some(rx), Some(bridge), forwarder)
+        }
+        Err(error) => {
+            tracing::warn!(%error, "camera sidecar unavailable; no video");
+            (None, None, None)
+        }
+    }
+}

--- a/adapters/px4/src/adapter/control.rs
+++ b/adapters/px4/src/adapter/control.rs
@@ -1,0 +1,187 @@
+//! Flight-control input helpers, control gating, and reset handling —
+//! the same gate discipline as the Aviate adapter: link-loss latch,
+//! reset/disarm buttons, then the commanded-reset latch, with disarm
+//! always allowed.
+
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{ApplyOutcome, Disposition, RejectReason};
+use pilotage_protocol::{ButtonEdge, LogicalButtonId, ScopedControlFrame};
+use pilotage_timing::SimTick;
+
+use super::{DISARM_BUTTON, Px4Adapter, RESET_BUTTON};
+
+/// Full-stick magnitude below which a frame counts as neutral for
+/// reset-latch clearance (the host's recovery-activation deadband scale).
+const RESET_CLEAR_DEADBAND: f32 = 0.05;
+
+/// The engaged commanded-reset latch: the estimate stream's source epoch
+/// observed at engagement. `engaged_epoch` is `None` when no estimate
+/// stream was observable at that moment; the epoch-advance clearance can
+/// then never be satisfied, which fails closed.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ResetLatch {
+    engaged_epoch: Option<u32>,
+}
+
+pub(super) fn flight_button_pressed(frame: &ScopedControlFrame, button: u16) -> bool {
+    frame.payload.edges.iter().any(|(candidate, edge)| {
+        *edge == ButtonEdge::Pressed && *candidate == LogicalButtonId::new(button)
+    })
+}
+
+pub(super) fn rejected_control(tick: SimTick, reason: RejectReason) -> ApplyOutcome {
+    ApplyOutcome {
+        tick,
+        disposition: Disposition::Rejected(reason),
+    }
+}
+
+pub(super) fn normalized_flight_sticks(frame: &ScopedControlFrame) -> ([f32; 4], bool) {
+    let mut sticks = [0.0_f32; 4];
+    let mut transformed = false;
+    for (axis, value) in &frame.payload.axes {
+        let clamped = if value.is_nan() {
+            0.0
+        } else {
+            value.clamp(-1.0, 1.0)
+        };
+        transformed |= clamped != *value;
+        sticks[usize::from(axis.as_u16().min(3))] = clamped;
+    }
+    (sticks, transformed)
+}
+
+/// A frame demonstrates neutral input: every axis inside the deadband
+/// (NaN is not neutral) and no pressed button edges.
+fn frame_is_neutral(frame: &ScopedControlFrame) -> bool {
+    frame
+        .payload
+        .axes
+        .iter()
+        .all(|(_, value)| value.abs() <= RESET_CLEAR_DEADBAND)
+        && frame
+            .payload
+            .edges
+            .iter()
+            .all(|(_, edge)| *edge != ButtonEdge::Pressed)
+}
+
+impl Px4Adapter {
+    /// Runs the SITL reset script (debounced to one per 5 s), engaging
+    /// the commanded-reset latch: the PX4 this adapter was talking to
+    /// is about to restart, so every cached measurement loses its
+    /// authority to validate control. `PILOTAGE_RESET_CMD` overrides
+    /// the script path.
+    pub(super) fn spawn_reset(&mut self) {
+        let now = Instant::now();
+        if self
+            .last_reset
+            .is_some_and(|last_reset| now.duration_since(last_reset) < Duration::from_secs(5))
+        {
+            return;
+        }
+        self.last_reset = Some(now);
+        let engaged_epoch = self.observed_source_epoch();
+        tracing::info!(
+            ?engaged_epoch,
+            "reset latch engaged; control suppressed until a fresh PX4 stream and neutral input"
+        );
+        self.reset_latch = Some(ResetLatch { engaged_epoch });
+        #[cfg(test)]
+        {
+            self.reset_spawns = self.reset_spawns.wrapping_add(1);
+        }
+        #[cfg(not(test))]
+        run_reset_command();
+    }
+
+    /// The pre-pose gate chain for one flight frame: structural checks,
+    /// the link-loss latch, reset/disarm button handling, and the
+    /// commanded-reset latch. `Some` is the early outcome; `None` lets
+    /// the caller proceed to measurement-dependent control.
+    pub(super) fn gated_flight_outcome(
+        &mut self,
+        frame: &ScopedControlFrame,
+        tick: SimTick,
+    ) -> Option<ApplyOutcome> {
+        if self.uplink.is_none() {
+            return Some(rejected_control(tick, RejectReason::UnknownScope));
+        }
+        if let Err(reason) = self.validate_flight_frame(frame) {
+            return Some(rejected_control(tick, reason));
+        }
+        // While a link-loss policy is engaged, ordinary frames are
+        // suppressed so a newly granted holder with deflected sticks
+        // cannot fly the vehicle out of its failsafe state.
+        if self.link_loss_policy.is_some() {
+            return Some(rejected_control(tick, RejectReason::LinkLossEngaged));
+        }
+        if flight_button_pressed(frame, RESET_BUTTON) {
+            self.spawn_reset();
+        }
+        // Disarm is checked BEFORE the reset latch: surrendering
+        // authority must never be blocked, and it needs no measurement.
+        if flight_button_pressed(frame, DISARM_BUTTON) {
+            let Some(uplink) = self.uplink.as_mut() else {
+                return Some(rejected_control(tick, RejectReason::UnknownScope));
+            };
+            uplink.send_disarm();
+            return Some(ApplyOutcome {
+                tick,
+                disposition: Disposition::Accepted,
+            });
+        }
+        // The commanded-reset latch: cached measurements inside the
+        // freshness budget are pre-reset data, and the rebooting FC
+        // may accept commands before its estimator converges.
+        if self.reset_latch_blocks(frame) {
+            return Some(rejected_control(tick, RejectReason::ResetInProgress));
+        }
+        None
+    }
+
+    /// Whether the commanded-reset latch suppresses this frame,
+    /// attempting clearance first: the estimate stream must have
+    /// entered a new source epoch, the frame must be neutral, and a
+    /// full pose must be recoverable from the fresh stream.
+    fn reset_latch_blocks(&mut self, frame: &ScopedControlFrame) -> bool {
+        let Some(latch) = self.reset_latch else {
+            return false;
+        };
+        let epoch_advanced = matches!(
+            (latch.engaged_epoch, self.observed_source_epoch()),
+            (Some(engaged), Some(current)) if current != engaged
+        );
+        if epoch_advanced && frame_is_neutral(frame) && self.current_pose().is_some() {
+            tracing::info!("reset latch cleared: fresh PX4 stream and neutral input");
+            self.reset_latch = None;
+            return false;
+        }
+        true
+    }
+
+    /// The estimate stream's current acquisition epoch, when observable.
+    fn observed_source_epoch(&self) -> Option<u32> {
+        let source = self.estimate.as_ref()?;
+        let latest = source.state.lock().ok()?;
+        Some(latest.source_epoch)
+    }
+}
+
+/// Spawns the reset script without waiting for it. Not compiled for
+/// tests: the script resets the live simulator and restarts PX4.
+#[cfg(not(test))]
+fn run_reset_command() {
+    let script = std::env::var("PILOTAGE_RESET_CMD").unwrap_or_else(|_| {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .map_or_else(|| ".".to_owned(), |path| path.display().to_string())
+            + "/scripts/reset-px4-sim.sh"
+    });
+    tracing::info!(%script, "simulation reset requested from the viewer");
+    if let Err(error) = std::process::Command::new(&script).spawn() {
+        tracing::warn!(%error, %script, "reset script failed to spawn");
+    }
+}

--- a/adapters/px4/src/adapter/control.rs
+++ b/adapters/px4/src/adapter/control.rs
@@ -1,7 +1,6 @@
 //! Flight-control input helpers, control gating, and reset handling —
 //! the same gate discipline as the Aviate adapter: link-loss latch,
-//! reset/disarm buttons, then the commanded-reset latch, with disarm
-//! always allowed.
+//! reset/disarm buttons, then the commanded-reset latch.
 
 use std::time::{Duration, Instant};
 
@@ -121,8 +120,8 @@ impl Px4Adapter {
         if flight_button_pressed(frame, RESET_BUTTON) {
             self.spawn_reset();
         }
-        // Disarm is checked BEFORE the reset latch: surrendering
-        // authority must never be blocked, and it needs no measurement.
+        // Disarm is checked before the commanded-reset latch, but only
+        // after the link-loss gate above has admitted the frame.
         if flight_button_pressed(frame, DISARM_BUTTON) {
             let Some(uplink) = self.uplink.as_mut() else {
                 return Some(rejected_control(tick, RejectReason::UnknownScope));

--- a/adapters/px4/src/adapter/control.rs
+++ b/adapters/px4/src/adapter/control.rs
@@ -5,15 +5,24 @@
 
 use std::time::{Duration, Instant};
 
-use pilotage_adapter_api::{ApplyOutcome, Disposition, RejectReason};
-use pilotage_protocol::{ButtonEdge, LogicalButtonId, ScopedControlFrame};
+use pilotage_adapter_api::{
+    ApplyOutcome, Disposition, RejectReason, payload_satisfies_neutral_activation,
+};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopedControlFrame};
 use pilotage_timing::SimTick;
 
-use super::{DISARM_BUTTON, Px4Adapter, RESET_BUTTON};
+use super::{
+    DISARM_BUTTON, PITCH_AXIS, Px4Adapter, RESET_BUTTON, ROLL_AXIS, THROTTLE_AXIS, YAW_AXIS,
+};
 
-/// Full-stick magnitude below which a frame counts as neutral for
-/// reset-latch clearance (the host's recovery-activation deadband scale).
-const RESET_CLEAR_DEADBAND: f32 = 0.05;
+/// Reset clearance uses the same 5%-of-full-stick scale as host recovery.
+const RESET_CLEAR_DEADBAND_MILLI: u32 = 50;
+const FLIGHT_AXES: [LogicalAxisId; 4] = [
+    LogicalAxisId::new(ROLL_AXIS),
+    LogicalAxisId::new(PITCH_AXIS),
+    LogicalAxisId::new(THROTTLE_AXIS),
+    LogicalAxisId::new(YAW_AXIS),
+];
 
 /// The engaged commanded-reset latch: the estimate stream's source epoch
 /// observed at engagement. `engaged_epoch` is `None` when no estimate
@@ -52,19 +61,11 @@ pub(super) fn normalized_flight_sticks(frame: &ScopedControlFrame) -> ([f32; 4],
     (sticks, transformed)
 }
 
-/// A frame demonstrates neutral input: every axis inside the deadband
-/// (NaN is not neutral) and no pressed button edges.
+/// Reset clearance uses the canonical full-coverage neutral activation:
+/// every declared axis must be REPORTED neutral — an empty payload
+/// demonstrates nothing.
 fn frame_is_neutral(frame: &ScopedControlFrame) -> bool {
-    frame
-        .payload
-        .axes
-        .iter()
-        .all(|(_, value)| value.abs() <= RESET_CLEAR_DEADBAND)
-        && frame
-            .payload
-            .edges
-            .iter()
-            .all(|(_, edge)| *edge != ButtonEdge::Pressed)
+    payload_satisfies_neutral_activation(&frame.payload, &FLIGHT_AXES, RESET_CLEAR_DEADBAND_MILLI)
 }
 
 impl Px4Adapter {

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -154,7 +154,7 @@ impl super::Px4Adapter {
     /// or any component is non-finite.
     pub(super) fn current_pose(&mut self) -> Option<(f32, [f32; 3], Option<[f32; 3]>)> {
         let latest = self.estimate.as_ref()?.state.lock().ok()?;
-        latest.estimator_status_stamp()?;
+        let status_stamp = latest.estimator_status_stamp()?;
         let attitude = latest
             .attitude
             .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
@@ -163,7 +163,15 @@ impl super::Px4Adapter {
             .kinematics
             .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
             .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
-        if !measurement_pair_is_coherent(attitude, kinematics, latest.maximum_inter_group_skew_ms)
+        let current_epoch = latest.source_epoch;
+        if status_stamp.source_epoch != current_epoch
+            || attitude.stamp.source_epoch != current_epoch
+            || kinematics.stamp.source_epoch != current_epoch
+            || !measurement_pair_is_coherent(
+                attitude,
+                kinematics,
+                latest.maximum_inter_group_skew_ms,
+            )
             || !measurement_pair_supports_pose(attitude, kinematics)
         {
             return None;

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -1,0 +1,184 @@
+//! Telemetry sampling from the shared MAVLink cache: freshness
+//! withholding, pair-coherence, authorization masking, and the planar
+//! projection — the same discipline as the Aviate adapter, over the
+//! standard-status authorization source.
+
+use std::sync::{Arc, Mutex};
+
+use pilotage_adapter_api::{
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, SourceRole, TelemetryBatch,
+    TelemetrySample,
+};
+use pilotage_protocol::VehicleId;
+use pilotage_timing::SimTick;
+
+use pilotage_mavlink::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
+use pilotage_mavlink::{AttitudeUpdate, KinematicsUpdate, LinkState};
+
+use super::WITHHOLD_AFTER;
+
+/// Both stamps must come from the same source identity, epoch, and
+/// clock, with acquisition times inside the configured skew budget.
+pub(super) fn measurement_pair_is_coherent(
+    attitude: AttitudeUpdate,
+    kinematics: KinematicsUpdate,
+    maximum_inter_group_skew_ms: u32,
+) -> bool {
+    let a = attitude.stamp;
+    let k = kinematics.stamp;
+    let identity = a.source_id == k.source_id
+        && a.source_incarnation == k.source_incarnation
+        && a.source_epoch == k.source_epoch
+        && a.clock == k.clock;
+    let skew_ns = a.acquired_at_ns.abs_diff(k.acquired_at_ns);
+    identity && skew_ns <= u64::from(maximum_inter_group_skew_ms).saturating_mul(1_000_000)
+}
+
+/// A pose requires an authorized attitude and an authorized position.
+fn measurement_pair_supports_pose(attitude: AttitudeUpdate, kinematics: KinematicsUpdate) -> bool {
+    attitude.quality <= QUALITY_DEGRADED
+        && kinematics.quality <= QUALITY_DEGRADED
+        && attitude.valid_flags & 0b0001 != 0
+        && kinematics.valid_flags & 0b0100 != 0
+}
+
+/// Yaw (radians clockwise from north) from a body-FRD→world-NED
+/// quaternion.
+pub(super) fn yaw_of(quat_wxyz: [f32; 4]) -> f64 {
+    let [w, x, y, z] = quat_wxyz.map(f64::from);
+    (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
+}
+
+fn effective_authorization(
+    attitude: Option<AttitudeUpdate>,
+    kinematics: Option<KinematicsUpdate>,
+) -> (u32, u32) {
+    let attitude_flags = attitude
+        .filter(|att| att.quality <= QUALITY_DEGRADED)
+        .map_or(0, |att| att.valid_flags & 0b0011);
+    let kinematics_flags = kinematics
+        .filter(|kin| kin.quality <= QUALITY_DEGRADED)
+        .map_or(0, |kin| kin.valid_flags & 0b1100);
+    let flags = attitude_flags | kinematics_flags;
+    let quality = attitude
+        .filter(|_| attitude_flags != 0)
+        .map(|att| att.quality)
+        .into_iter()
+        .chain(
+            kinematics
+                .filter(|_| kinematics_flags != 0)
+                .map(|kin| kin.quality),
+        )
+        .max()
+        .unwrap_or(QUALITY_UNUSABLE);
+    (flags, quality)
+}
+
+pub(super) fn mavlink_batch(vehicle: VehicleId, state: &Arc<Mutex<LinkState>>) -> TelemetryBatch {
+    let Ok(latest) = state.lock() else {
+        return TelemetryBatch::default();
+    };
+    let kinematics = latest
+        .kinematics
+        .filter(|kin| kin.received_at.elapsed() <= WITHHOLD_AFTER);
+    let attitude = latest
+        .attitude
+        .filter(|att| att.received_at.elapsed() <= WITHHOLD_AFTER);
+    if attitude.is_none() && kinematics.is_none() {
+        return TelemetryBatch::default();
+    }
+
+    let estimator_status_stamp = latest.estimator_status_stamp();
+    let (planar_pose, planar_speed) = match (attitude, kinematics) {
+        (Some(att), Some(kin))
+            if estimator_status_stamp.is_some()
+                && measurement_pair_is_coherent(att, kin, latest.maximum_inter_group_skew_ms)
+                && measurement_pair_supports_pose(att, kin) =>
+        {
+            let pose = pilotage_adapter_api::Pose2d {
+                x: f64::from(kin.pos_ned_m[0]),
+                y: f64::from(kin.pos_ned_m[1]),
+                heading: yaw_of(att.quat_wxyz),
+            };
+            let speed = f64::from(
+                (kin.vel_ned_mps[0] * kin.vel_ned_mps[0] + kin.vel_ned_mps[1] * kin.vel_ned_mps[1])
+                    .sqrt(),
+            );
+            (Some(pose), Some(speed))
+        }
+        _ => (None, None),
+    };
+    let (valid_flags, quality) = if estimator_status_stamp.is_some() {
+        effective_authorization(attitude, kinematics)
+    } else {
+        (0, QUALITY_UNUSABLE)
+    };
+    let avionics = Some(AvionicsSample {
+        attitude: attitude.map(|att| AvionicsAttitudeSample {
+            quat_wxyz: att.quat_wxyz,
+            rates_rps: att.rates_rps,
+            stamp: att.stamp,
+        }),
+        kinematics: kinematics.map(|kin| AvionicsKinematicsSample {
+            pos_ned_m: kin.pos_ned_m,
+            vel_ned_mps: kin.vel_ned_mps,
+            stamp: kin.stamp,
+        }),
+        estimator_status_stamp,
+        valid_flags,
+        quality,
+    });
+    let source_time_ms = kinematics
+        .map(|kin| kin.time_boot_ms)
+        .or_else(|| attitude.map(|att| att.time_boot_ms))
+        .unwrap_or_default();
+    TelemetryBatch {
+        samples: vec![TelemetrySample {
+            vehicle,
+            tick: SimTick::new(u64::from(source_time_ms).wrapping_mul(1_000_000)),
+            pose: planar_pose,
+            speed: planar_speed,
+            avionics,
+            sim_truth: None,
+            fc_state: None,
+        }],
+    }
+}
+
+impl super::Px4Adapter {
+    /// The vehicle's current measured yaw (radians clockwise from
+    /// north), NED position, and independently validated NED velocity,
+    /// from the FC operational estimate only. Velocity carries its own
+    /// validity: `None` when the velocity group is not declared valid
+    /// or any component is non-finite.
+    pub(super) fn current_pose(&mut self) -> Option<(f32, [f32; 3], Option<[f32; 3]>)> {
+        let latest = self.estimate.as_ref()?.state.lock().ok()?;
+        latest.estimator_status_stamp()?;
+        let attitude = latest
+            .attitude
+            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
+            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
+        let kinematics = latest
+            .kinematics
+            .filter(|update| update.received_at.elapsed() <= WITHHOLD_AFTER)
+            .filter(|update| update.stamp.role == SourceRole::OperationalEstimate)?;
+        if !measurement_pair_is_coherent(attitude, kinematics, latest.maximum_inter_group_skew_ms)
+            || !measurement_pair_supports_pose(attitude, kinematics)
+        {
+            return None;
+        }
+        Some((
+            yaw_of(attitude.quat_wxyz) as f32,
+            kinematics.pos_ned_m,
+            validated_velocity(kinematics),
+        ))
+    }
+}
+
+/// The kinematics velocity as independently validated data: present
+/// only when the velocity group is declared valid and finite.
+fn validated_velocity(kinematics: KinematicsUpdate) -> Option<[f32; 3]> {
+    let declared_valid = kinematics.valid_flags & 0b1000 != 0;
+    let finite = kinematics.vel_ned_mps.iter().all(|v| v.is_finite());
+    (declared_valid && finite).then_some(kinematics.vel_ned_mps)
+}

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -6,8 +6,9 @@
 use std::sync::{Arc, Mutex};
 
 use pilotage_adapter_api::{
-    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, SourceRole, TelemetryBatch,
-    TelemetrySample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, FcStateSample,
+    MeasurementClock, MeasurementStamp, SourceIncarnation, SourceIntegrity, SourceRole,
+    TelemetryBatch, TelemetrySample,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
@@ -173,6 +174,38 @@ impl super::Px4Adapter {
             validated_velocity(kinematics),
         ))
     }
+}
+
+/// The heartbeat-derived FC state sample: arm reported by the FC's own
+/// telemetry, stamped under the FC-state source role.
+pub(super) fn fc_state_sample(
+    report: Option<super::ArmReport>,
+    incarnation: SourceIncarnation,
+    started_at: std::time::Instant,
+) -> Option<FcStateSample> {
+    let report = report?;
+    let acquired = report
+        .acquired_at
+        .checked_duration_since(started_at)
+        .unwrap_or_default();
+    Some(FcStateSample {
+        arm_state: if report.armed { 2 } else { 1 },
+        stamp: MeasurementStamp {
+            role: SourceRole::FcState,
+            // MAVLink frames are CRC-checked but unsigned: checksummed,
+            // never authenticated.
+            integrity: SourceIntegrity::ChecksummedOnly,
+            source_id: 1,
+            source_incarnation: incarnation,
+            // A gateway-generated attachment identity cannot observe an
+            // FC restart; a source-issued boot identity replaces this
+            // constant once the FC publishes one.
+            source_epoch: 1,
+            sequence: report.sequence,
+            acquired_at_ns: u64::try_from(acquired.as_nanos()).unwrap_or(u64::MAX),
+            clock: MeasurementClock::HostMonotonic,
+        },
+    })
 }
 
 /// The kinematics velocity as independently validated data: present

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -1,0 +1,268 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! Adapter-boundary behavior: the offboard arm sequence ordering on
+//! the wire, sampling authorization from the standard status, and the
+//! same gate discipline the Aviate adapter carries (commanded-reset
+//! latch, disarm bypass).
+
+use std::net::UdpSocket;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+
+use pilotage_mavlink::codec::{FcMessage, FrameSource};
+use pilotage_mavlink::link::apply_messages_at;
+use pilotage_mavlink::{AuthorizationSource, LinkState};
+
+use super::{ARM_BUTTON, DISARM_BUTTON, Px4Adapter, RESET_BUTTON, THROTTLE_AXIS};
+use crate::uplink::Px4Uplink;
+
+const SOURCE: FrameSource = FrameSource {
+    system_id: 1,
+    component_id: 1,
+    frame_sequence: 0,
+};
+
+fn live_state() -> Arc<Mutex<LinkState>> {
+    let state = Arc::new(Mutex::new(LinkState {
+        authorization_source: AuthorizationSource::StandardEstimatorStatus,
+        maximum_inter_group_skew_ms: 300,
+        ..LinkState::default()
+    }));
+    feed(&state, 1_000);
+    state
+}
+
+/// Feeds an authorized status + attitude + kinematics trio at the
+/// given boot time, the way a live PX4 stream populates the cache.
+fn feed(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32) {
+    let messages = [
+        (
+            SOURCE,
+            FcMessage::EstimatorStatus {
+                time_usec: u64::from(time_boot_ms) * 1_000,
+                flags: 1 | 2 | 4 | 8 | 32,
+            },
+        ),
+        (
+            SOURCE,
+            FcMessage::AttitudeQuaternion {
+                time_boot_ms,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                rates_rps: [0.0; 3],
+            },
+        ),
+        (
+            SOURCE,
+            FcMessage::LocalPositionNed {
+                time_boot_ms,
+                pos_ned_m: [1.0, 2.0, -3.0],
+                vel_ned_mps: [0.0; 3],
+            },
+        ),
+    ];
+    apply_messages_at(state, &messages, 0, 0, Instant::now());
+}
+
+fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
+    let fc = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let addr = fc.local_addr().expect("addr");
+    (fc, addr)
+}
+
+fn uplink_to(addr: std::net::SocketAddr) -> Px4Uplink {
+    let mut uplink = Px4Uplink::new().expect("uplink");
+    uplink.set_target(addr);
+    uplink
+}
+
+fn press(button: u16) -> pilotage_protocol::ScopedControlFrame {
+    frame(
+        vec![],
+        vec![(LogicalButtonId::new(button), ButtonEdge::Pressed)],
+    )
+}
+
+fn neutral() -> pilotage_protocol::ScopedControlFrame {
+    frame(vec![], vec![])
+}
+
+fn frame(
+    axes: Vec<(LogicalAxisId, f32)>,
+    edges: Vec<(LogicalButtonId, ButtonEdge)>,
+) -> pilotage_protocol::ScopedControlFrame {
+    pilotage_protocol::ScopedControlFrame {
+        session: pilotage_protocol::SessionId::new(1),
+        vehicle: VehicleId::new(1),
+        scope: pilotage_protocol::ScopeId::new(super::FLIGHT_SCOPE),
+        generation: pilotage_protocol::Generation::new(1),
+        sequence: pilotage_protocol::SequenceNum::new(1),
+        sampled_at: pilotage_timing::MonoTimestamp::from_nanos(0),
+        profile_revision: 1,
+        payload: pilotage_protocol::ControlPayload { axes, edges },
+    }
+}
+
+/// Decodes a received frame into its message id, plus the MAV_CMD id
+/// when the frame is a COMMAND_LONG.
+fn received_kind(fc: &UdpSocket) -> (u32, Option<u16>) {
+    let mut buf = [0u8; 128];
+    let (len, _) = fc.recv_from(&mut buf).expect("datagram");
+    assert!(len > 10, "runt frame");
+    let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
+    let command = (msg_id == 76).then(|| u16::from_le_bytes([buf[10 + 28], buf[10 + 29]]));
+    (msg_id, command)
+}
+
+#[test]
+fn arm_sequence_streams_before_offboard_and_arm() {
+    let (fc, addr) = fake_fc();
+    let mut uplink = uplink_to(addr);
+    uplink.use_manual_clock();
+    uplink.begin_arm(0.0);
+    // The stream starts immediately with a zero-velocity setpoint.
+    let (msg_id, _) = received_kind(&fc);
+    assert_eq!(msg_id, 84, "setpoint stream precedes any command");
+    assert!(uplink.streaming());
+
+    // Before the warmup elapses, maintenance emits only heartbeat and
+    // keepalive setpoints — never DO_SET_MODE or arm.
+    uplink.advance_clock(Duration::from_millis(100));
+    uplink.maintain(true);
+    loop {
+        let (msg_id, command) = received_kind(&fc);
+        assert!(
+            command != Some(176) && command != Some(400),
+            "no mode/arm before warmup"
+        );
+        if msg_id == 84 {
+            break;
+        }
+    }
+
+    // After the warmup, DO_SET_MODE (OFFBOARD) then arm, in order.
+    uplink.advance_clock(Duration::from_millis(300));
+    uplink.maintain(true);
+    let mut commands = vec![];
+    while commands.len() < 2 {
+        let (_, command) = received_kind(&fc);
+        if let Some(command) = command {
+            commands.push(command);
+        }
+    }
+    assert_eq!(commands, vec![176, 400], "OFFBOARD precedes arm");
+}
+
+#[test]
+fn disarm_stops_the_stream() {
+    let (fc, addr) = fake_fc();
+    let mut uplink = uplink_to(addr);
+    uplink.begin_arm(0.0);
+    uplink.send_disarm();
+    assert!(!uplink.streaming(), "disarm stops the stream");
+    let mut disarmed = false;
+    for _ in 0..3 {
+        let (msg_id, command) = received_kind(&fc);
+        if msg_id == 76 && command == Some(400) {
+            disarmed = true;
+            break;
+        }
+    }
+    assert!(disarmed, "disarm command reached the FC");
+}
+
+#[test]
+fn sticks_are_ignored_until_an_arm_sequence_starts() {
+    let (fc, addr) = fake_fc();
+    let mut uplink = uplink_to(addr);
+    uplink.send_stick_frame(0.0, 0.5, 0.5, 0.0);
+    fc.set_read_timeout(Some(Duration::from_millis(200)))
+        .expect("timeout");
+    let mut buf = [0u8; 128];
+    assert!(
+        fc.recv_from(&mut buf).is_err(),
+        "no setpoint may leave before an explicit arm"
+    );
+}
+
+#[test]
+fn neutralize_sends_zero_velocity_and_stops() {
+    let (fc, addr) = fake_fc();
+    let mut uplink = uplink_to(addr);
+    uplink.begin_arm(0.0);
+    let _ = received_kind(&fc);
+    uplink.neutralize();
+    assert!(!uplink.streaming());
+    let (msg_id, _) = received_kind(&fc);
+    assert_eq!(msg_id, 84, "one final zero-velocity setpoint");
+}
+
+#[test]
+fn sampled_telemetry_authorizes_from_the_standard_status() {
+    let state = live_state();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state.clone());
+    let batch = adapter.sample_telemetry();
+    let sample = &batch.samples[0];
+    let avionics = sample.avionics.expect("avionics");
+    assert_eq!(avionics.valid_flags, 0b1111);
+    assert!(sample.pose.is_some(), "authorized pair projects a pose");
+    let pose = sample.pose.expect("pose");
+    assert!((pose.x - 1.0).abs() < 1e-9 && (pose.y - 2.0).abs() < 1e-9);
+}
+
+#[test]
+fn reset_press_latches_and_disarm_bypasses() {
+    let (fc, addr) = fake_fc();
+    let state = live_state();
+    let mut adapter =
+        Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink_to(addr));
+    let outcome = adapter.apply_control(&press(RESET_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress)
+    );
+    assert_eq!(adapter.reset_spawns, 1);
+
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "arm against pre-reset measurements is rejected"
+    );
+    let outcome = adapter.apply_control(&press(DISARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "disarm always passes"
+    );
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf).expect("disarm datagram");
+}
+
+#[test]
+fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
+    let (_fc, addr) = fake_fc();
+    let state = live_state();
+    let mut adapter =
+        Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink_to(addr));
+    adapter.apply_control(&press(RESET_BUTTON));
+
+    // The restarted PX4's stream begins a new acquisition epoch and
+    // repopulates the cleared cache.
+    state.lock().expect("state").source_epoch = 2;
+    let deflected = frame(vec![(LogicalAxisId::new(THROTTLE_AXIS), 0.6)], vec![]);
+    let outcome = adapter.apply_control(&deflected);
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "active input does not clear the latch"
+    );
+    let outcome = adapter.apply_control(&neutral());
+    assert_eq!(outcome.disposition, Disposition::Accepted, "neutral clears");
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(outcome.disposition, Disposition::Accepted, "arm proceeds");
+}

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -2,8 +2,7 @@
 
 //! Adapter-boundary behavior: the offboard arm sequence ordering on
 //! the wire, sampling authorization from the standard status, and the
-//! same gate discipline the Aviate adapter carries (commanded-reset
-//! latch, disarm bypass).
+//! same gate discipline the Aviate adapter carries.
 
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
@@ -80,9 +79,7 @@ fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
 }
 
 fn uplink_to(addr: std::net::SocketAddr) -> Px4Uplink {
-    let mut uplink = Px4Uplink::new().expect("uplink");
-    uplink.set_target(addr);
-    uplink
+    Px4Uplink::new(addr).expect("uplink")
 }
 
 fn press(button: u16) -> pilotage_protocol::ScopedControlFrame {
@@ -304,7 +301,7 @@ fn reset_press_latches_and_disarm_bypasses() {
     assert_eq!(
         outcome.disposition,
         Disposition::Accepted,
-        "disarm always passes"
+        "disarm bypasses the commanded-reset latch"
     );
     let mut buf = [0u8; 128];
     fc.recv_from(&mut buf).expect("disarm datagram");
@@ -317,8 +314,7 @@ fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
     let fc = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
     fc.set_read_timeout(Some(Duration::from_secs(2)))
         .expect("timeout");
-    let mut uplink = Px4Uplink::new().expect("uplink");
-    uplink.set_target(fc.local_addr().expect("addr"));
+    let uplink = Px4Uplink::new(fc.local_addr().expect("addr")).expect("uplink");
     let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink);
     adapter.apply_control(&press(RESET_BUTTON));
 

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -26,18 +26,23 @@ const SOURCE: FrameSource = FrameSource {
 };
 
 fn live_state() -> Arc<Mutex<LinkState>> {
+    live_state_at(Instant::now()).0
+}
+
+fn live_state_at(start: Instant) -> (Arc<Mutex<LinkState>>, Instant) {
     let state = Arc::new(Mutex::new(LinkState {
         authorization_source: AuthorizationSource::StandardEstimatorStatus,
+        reset_policy: pilotage_mavlink::ResetPolicy::SimulatorHeuristic,
         maximum_inter_group_skew_ms: 300,
         ..LinkState::default()
     }));
-    feed(&state, 1_000);
-    state
+    feed_at(&state, 60_000, start);
+    (state, start)
 }
 
 /// Feeds an authorized status + attitude + kinematics trio at the
 /// given boot time, the way a live PX4 stream populates the cache.
-fn feed(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32) {
+fn feed_at(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32, now: Instant) {
     let messages = [
         (
             SOURCE,
@@ -63,7 +68,7 @@ fn feed(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32) {
             },
         ),
     ];
-    apply_messages_at(state, &messages, 0, 0, Instant::now());
+    apply_messages_at(state, &messages, 0, 0, now);
 }
 
 fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
@@ -87,8 +92,70 @@ fn press(button: u16) -> pilotage_protocol::ScopedControlFrame {
     )
 }
 
+/// Neutral demonstration: every declared axis REPORTED at center — an
+/// empty payload demonstrates nothing and must not clear a latch.
 fn neutral() -> pilotage_protocol::ScopedControlFrame {
-    frame(vec![], vec![])
+    frame(
+        vec![
+            (LogicalAxisId::new(super::ROLL_AXIS), 0.0),
+            (LogicalAxisId::new(super::PITCH_AXIS), 0.0),
+            (LogicalAxisId::new(THROTTLE_AXIS), 0.0),
+            (LogicalAxisId::new(super::YAW_AXIS), 0.0),
+        ],
+        vec![],
+    )
+}
+
+/// Drives a REAL source-epoch advance through the production message
+/// path: the old stream goes silent, a low boot clock is quarantined,
+/// dwells, and confirms — exactly what a restarted PX4 looks like.
+fn drive_epoch_advance(state: &Arc<Mutex<LinkState>>, start: Instant) {
+    let status = |tbm: u32| FcMessage::EstimatorStatus {
+        time_usec: u64::from(tbm) * 1_000,
+        flags: 1 | 2 | 4 | 8 | 32,
+    };
+    // Quarantined candidate after the silence budget, then source and
+    // receive dwell, then confirmation.
+    apply_messages_at(
+        state,
+        &[(SOURCE, status(1_000))],
+        0,
+        0,
+        start + Duration::from_secs(4),
+    );
+    apply_messages_at(
+        state,
+        &[(SOURCE, status(1_400))],
+        0,
+        0,
+        start + Duration::from_millis(4_400),
+    );
+    assert_eq!(
+        state.lock().expect("state").source_epoch,
+        2,
+        "the reset heuristic must confirm a fresh epoch"
+    );
+    // The restarted stream repopulates the cleared cache.
+    let trio = [
+        (SOURCE, status(1_500)),
+        (
+            SOURCE,
+            FcMessage::AttitudeQuaternion {
+                time_boot_ms: 1_500,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                rates_rps: [0.0; 3],
+            },
+        ),
+        (
+            SOURCE,
+            FcMessage::LocalPositionNed {
+                time_boot_ms: 1_500,
+                pos_ned_m: [1.0, 2.0, -3.0],
+                vel_ned_mps: [0.0; 3],
+            },
+        ),
+    ];
+    apply_messages_at(state, &trio, 0, 0, start + Duration::from_millis(4_500));
 }
 
 fn frame(
@@ -245,24 +312,57 @@ fn reset_press_latches_and_disarm_bypasses() {
 
 #[test]
 fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
-    let (_fc, addr) = fake_fc();
-    let state = live_state();
-    let mut adapter =
-        Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink_to(addr));
+    let start = Instant::now();
+    let (state, start) = live_state_at(start);
+    let fc = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    fc.set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("timeout");
+    let mut uplink = Px4Uplink::new().expect("uplink");
+    uplink.set_target(fc.local_addr().expect("addr"));
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_uplink(uplink);
     adapter.apply_control(&press(RESET_BUTTON));
 
-    // The restarted PX4's stream begins a new acquisition epoch and
-    // repopulates the cleared cache.
-    state.lock().expect("state").source_epoch = 2;
+    // The restarted PX4's stream is what advances the epoch — driven
+    // through the production message path, never by poking counters.
+    drive_epoch_advance(&state, start);
+
+    // An arm edge is not neutral: clearing on it would let the very
+    // frame that re-arms ride in before sticks were ever released.
+    let outcome = adapter.apply_control(&press(ARM_BUTTON));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "an arm edge does not clear the latch"
+    );
+    // A deflected stick is not neutral, and neither is a payload that
+    // omits declared axes — partial coverage demonstrates nothing.
     let deflected = frame(vec![(LogicalAxisId::new(THROTTLE_AXIS), 0.6)], vec![]);
     let outcome = adapter.apply_control(&deflected);
     assert_eq!(
         outcome.disposition,
         Disposition::Rejected(RejectReason::ResetInProgress),
-        "active input does not clear the latch"
+        "deflected sticks do not clear the latch"
     );
+    let empty = frame(vec![], vec![]);
+    let outcome = adapter.apply_control(&empty);
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::ResetInProgress),
+        "an EMPTY payload must not count as a neutral demonstration"
+    );
+
     let outcome = adapter.apply_control(&neutral());
-    assert_eq!(outcome.disposition, Disposition::Accepted, "neutral clears");
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "a full-axis neutral frame over the fresh stream clears the latch"
+    );
     let outcome = adapter.apply_control(&press(ARM_BUTTON));
-    assert_eq!(outcome.disposition, Disposition::Accepted, "arm proceeds");
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "arm proceeds once the latch has cleared"
+    );
+    let mut buf = [0u8; 128];
+    fc.recv_from(&mut buf).expect("arm datagram reaches the FC");
 }

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -132,7 +132,7 @@ fn arm_sequence_streams_before_offboard_and_arm() {
     // Before the warmup elapses, maintenance emits only heartbeat and
     // keepalive setpoints — never DO_SET_MODE or arm.
     uplink.advance_clock(Duration::from_millis(100));
-    uplink.maintain(true);
+    uplink.maintain();
     loop {
         let (msg_id, command) = received_kind(&fc);
         assert!(
@@ -146,7 +146,7 @@ fn arm_sequence_streams_before_offboard_and_arm() {
 
     // After the warmup, DO_SET_MODE (OFFBOARD) then arm, in order.
     uplink.advance_clock(Duration::from_millis(300));
-    uplink.maintain(true);
+    uplink.maintain();
     let mut commands = vec![];
     while commands.len() < 2 {
         let (_, command) = received_kind(&fc);

--- a/adapters/px4/src/config.rs
+++ b/adapters/px4/src/config.rs
@@ -1,0 +1,63 @@
+//! Typed PX4 adapter configuration.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use pilotage_mavlink::{AuthorizationSource, LinkConfig};
+
+/// PX4 operating profiles supported by this adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Px4Profile {
+    /// PX4 SITL with the bounded simulator reset heuristic enabled.
+    Simulation,
+}
+
+/// All policy and network configuration required to start the PX4 adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Px4Config {
+    profile: Px4Profile,
+    /// Local endpoint receiving PX4 telemetry.
+    pub telemetry_endpoint: SocketAddr,
+    /// PX4 GCS endpoint receiving stream-interval commands.
+    pub stream_command_endpoint: SocketAddr,
+    /// PX4 onboard endpoint receiving offboard commands.
+    pub command_endpoint: SocketAddr,
+}
+
+impl Px4Config {
+    /// Builds the default endpoint set for an explicit PX4 profile.
+    #[must_use]
+    pub fn new(profile: Px4Profile) -> Self {
+        Self {
+            profile,
+            telemetry_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 14_550)),
+            stream_command_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 18_570)),
+            command_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 14_580)),
+        }
+    }
+
+    pub(crate) fn link_config(self) -> LinkConfig {
+        let mut config = match self.profile {
+            Px4Profile::Simulation => LinkConfig::simulator(),
+        };
+        config.endpoint = self.telemetry_endpoint;
+        config.authorization_source = AuthorizationSource::StandardEstimatorStatus;
+        config.standard_status_max_lag_ms = 300;
+        config.reset_candidate_max_ms = 60_000;
+        config.stream_command_target = Some(self.stream_command_endpoint);
+        config.stream_interval_requests = &[(31, 33_333), (32, 33_333), (230, 100_000)];
+        config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pilotage_mavlink::ResetPolicy;
+
+    use super::{Px4Config, Px4Profile};
+
+    #[test]
+    fn simulation_profile_enables_only_the_simulator_reset_policy() {
+        let config = Px4Config::new(Px4Profile::Simulation).link_config();
+        assert_eq!(config.reset_policy, ResetPolicy::SimulatorHeuristic);
+    }
+}

--- a/adapters/px4/src/error.rs
+++ b/adapters/px4/src/error.rs
@@ -1,0 +1,16 @@
+//! Error type for the PX4 adapter.
+
+/// Why the PX4 adapter could not start.
+#[derive(Debug, thiserror::Error)]
+pub enum Px4AdapterError {
+    /// The MAVLink receive link could not start.
+    #[error(transparent)]
+    Link(#[from] pilotage_mavlink::LinkError),
+    /// The command uplink socket could not be bound.
+    #[error("binding the PX4 command uplink socket failed: {source}")]
+    UplinkBind {
+        /// The underlying socket error.
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/adapters/px4/src/lib.rs
+++ b/adapters/px4/src/lib.rs
@@ -15,6 +15,7 @@
 //! ADR-0002); all MAVLink byte work lives in `pilotage_mavlink`.
 
 mod adapter;
+mod config;
 mod error;
 mod uplink;
 
@@ -22,5 +23,6 @@ pub use adapter::{
     ARM_BUTTON, DISARM_BUTTON, FLIGHT_SCOPE, PITCH_AXIS, Px4Adapter, RESET_BUTTON, ROLL_AXIS,
     THROTTLE_AXIS, YAW_AXIS,
 };
+pub use config::{Px4Config, Px4Profile};
 pub use error::Px4AdapterError;
 pub use uplink::Px4Uplink;

--- a/adapters/px4/src/lib.rs
+++ b/adapters/px4/src/lib.rs
@@ -1,0 +1,26 @@
+//! `VehicleAdapter` for the PX4 autopilot over standard MAVLink 2.0
+//! (ADR-0018).
+//!
+//! PX4 exposes the same wire face regardless of which simulator (or
+//! airframe) sits behind it, so this adapter is FDM-agnostic: Gazebo,
+//! JSBSim, or FlightGear all look identical from here. Telemetry rides
+//! the shared [`pilotage_mavlink`] receive link (attitude, local
+//! position, and the standard ESTIMATOR_STATUS as the authorization
+//! source); control is the offboard contract — a continuous velocity
+//! setpoint stream that must precede and accompany OFFBOARD mode, with
+//! PX4's own offboard-loss failsafe as the FC-side twin of the host's
+//! link-loss policy.
+//!
+//! This crate owns I/O (`adapters/` is exempt from the sans-IO rule,
+//! ADR-0002); all MAVLink byte work lives in `pilotage_mavlink`.
+
+mod adapter;
+mod error;
+mod uplink;
+
+pub use adapter::{
+    ARM_BUTTON, DISARM_BUTTON, FLIGHT_SCOPE, PITCH_AXIS, Px4Adapter, RESET_BUTTON, ROLL_AXIS,
+    THROTTLE_AXIS, YAW_AXIS,
+};
+pub use error::Px4AdapterError;
+pub use uplink::Px4Uplink;

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -43,8 +43,10 @@ const OFFBOARD_WARMUP: Duration = Duration::from_millis(300);
 /// emitted at this period so PX4's offboard-loss failsafe does not
 /// trip between control frames.
 const STREAM_KEEPALIVE: Duration = Duration::from_millis(50);
-/// Message-interval requests are re-sent at this period until the
-/// telemetry actually flows.
+/// Message-interval requests are re-sent at this period for the whole
+/// session: they are idempotent, and a request lost during PX4's boot
+/// would otherwise leave the estimator status at its sparse default
+/// rate — too sparse for the display's status-to-numeric pairing.
 const INTERVAL_RETRY: Duration = Duration::from_secs(2);
 
 /// MAV_CMD_DO_SET_MODE.
@@ -57,8 +59,9 @@ const BASE_MODE_CUSTOM: f32 = 1.0;
 const PX4_MAIN_MODE_OFFBOARD: f32 = 6.0;
 /// Message ids whose intervals are requested, with the interval in
 /// microseconds: attitude quaternion and local position at ~30 Hz,
-/// the estimator status at 5 Hz.
-const STREAMS: [(u32, f32); 3] = [(31, 33_333.0), (32, 33_333.0), (230, 200_000.0)];
+/// the estimator status at 10 Hz — every numeric group must find a
+/// status within the display's 300 ms pairing budget.
+const STREAMS: [(u32, f32); 3] = [(31, 33_333.0), (32, 33_333.0), (230, 100_000.0)];
 
 /// The uplink's time source; tests substitute a manually advanced
 /// instant so sequencing is exercised without real-time sleeps.
@@ -183,10 +186,10 @@ impl Px4Uplink {
     }
 
     /// Periodic presence and stream upkeep: the 1 Hz GCS heartbeat,
-    /// message-interval requests until telemetry flows, keepalive
-    /// setpoints between control frames, and the warmup step of the
-    /// offboard arm sequence. Call at telemetry-sampling cadence.
-    pub fn maintain(&mut self, telemetry_flowing: bool) {
+    /// periodic message-interval requests, keepalive setpoints between
+    /// control frames, and the warmup step of the offboard arm
+    /// sequence. Call at telemetry-sampling cadence.
+    pub fn maintain(&mut self) {
         let now = self.clock.now();
         if self
             .last_heartbeat
@@ -196,10 +199,9 @@ impl Px4Uplink {
             let frame = encode_gcs_heartbeat(self.seq);
             self.send(&frame);
         }
-        if !telemetry_flowing
-            && self
-                .last_interval_request
-                .is_none_or(|at| now.duration_since(at) >= INTERVAL_RETRY)
+        if self
+            .last_interval_request
+            .is_none_or(|at| now.duration_since(at) >= INTERVAL_RETRY)
         {
             self.last_interval_request = Some(now);
             self.request_streams();

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -1,0 +1,384 @@
+//! PX4 offboard command uplink: GCS heartbeats, telemetry stream
+//! negotiation, the offboard arm sequence, and velocity setpoints.
+//!
+//! The offboard contract drives the shape of this module: PX4 accepts
+//! OFFBOARD mode only while a setpoint stream is already flowing, and
+//! it runs its own offboard-loss failsafe the moment the stream stops.
+//! Arming therefore is a sequence (stream → warmup → mode → arm), and
+//! "neutralize" is deliberately "stop the stream": PX4's failsafe
+//! (Hold) is the FC-side guarantee, mirroring how the host treats a
+//! silent control holder.
+
+use std::net::{SocketAddr, UdpSocket};
+use std::time::{Duration, Instant};
+
+use tracing::{info, warn};
+
+use pilotage_mavlink::codec::{
+    encode_arm_command, encode_command_long, encode_gcs_heartbeat, encode_velocity_setpoint,
+};
+
+/// Full-stick horizontal velocity demand. Demand scaling is operator
+/// policy destined for per-vehicle profile configuration; these values
+/// match the Aviate adapter's so the two SITL vehicles feel identical.
+const MAX_HORIZONTAL_MPS: f32 = 3.0;
+/// Full-stick climb/descend rate demand.
+const MAX_VERTICAL_MPS: f32 = 1.5;
+/// Full-stick yaw rate demand (~52°/s).
+const MAX_YAW_RATE_RPS: f32 = 0.9;
+/// Acceleration limit shaping stick steps into velocity ramps. The
+/// PX4 velocity-only offboard path applies no acceleration shaping of
+/// its own, so this slew is the only one in the chain.
+const MAX_ACCEL_MPS2: f32 = 5.0;
+/// Longest believable gap between control frames when integrating the
+/// yaw-rate stick; anything longer is a stall, not a dt.
+const MAX_DT_S: f32 = 0.1;
+/// GCS heartbeat period: presence for PX4's GCS-connection pre-arm
+/// check and its datalink-loss failsafe.
+const HEARTBEAT_PERIOD: Duration = Duration::from_secs(1);
+/// How long the zero-velocity stream must flow before OFFBOARD mode
+/// and arming are commanded (PX4 rejects OFFBOARD without a stream).
+const OFFBOARD_WARMUP: Duration = Duration::from_millis(300);
+/// While streaming with no fresh stick frame, a keepalive setpoint is
+/// emitted at this period so PX4's offboard-loss failsafe does not
+/// trip between control frames.
+const STREAM_KEEPALIVE: Duration = Duration::from_millis(50);
+/// Message-interval requests are re-sent at this period until the
+/// telemetry actually flows.
+const INTERVAL_RETRY: Duration = Duration::from_secs(2);
+
+/// MAV_CMD_DO_SET_MODE.
+const CMD_DO_SET_MODE: u16 = 176;
+/// MAV_CMD_SET_MESSAGE_INTERVAL.
+const CMD_SET_MESSAGE_INTERVAL: u16 = 511;
+/// MAV_MODE_FLAG_CUSTOM_MODE_ENABLED.
+const BASE_MODE_CUSTOM: f32 = 1.0;
+/// PX4 custom main mode OFFBOARD.
+const PX4_MAIN_MODE_OFFBOARD: f32 = 6.0;
+/// Message ids whose intervals are requested, with the interval in
+/// microseconds: attitude quaternion and local position at ~30 Hz,
+/// the estimator status at 5 Hz.
+const STREAMS: [(u32, f32); 3] = [(31, 33_333.0), (32, 33_333.0), (230, 200_000.0)];
+
+/// The uplink's time source; tests substitute a manually advanced
+/// instant so sequencing is exercised without real-time sleeps.
+#[derive(Debug)]
+enum UplinkClock {
+    System,
+    #[cfg(test)]
+    Manual(Instant),
+}
+
+impl UplinkClock {
+    fn now(&self) -> Instant {
+        match self {
+            Self::System => Instant::now(),
+            #[cfg(test)]
+            Self::Manual(at) => *at,
+        }
+    }
+}
+
+/// Where the offboard arm sequence stands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArmPhase {
+    /// No arm requested; no stream.
+    Idle,
+    /// Zero-velocity stream flowing; OFFBOARD + arm pending warmup.
+    Warmup,
+    /// OFFBOARD and arm have been commanded; stream continues.
+    Commanded,
+}
+
+/// The UDP MAVLink command uplink to PX4's onboard instance.
+#[derive(Debug)]
+pub struct Px4Uplink {
+    socket: UdpSocket,
+    target: SocketAddr,
+    seq: u8,
+    heading_sp_rad: f32,
+    last_frame: Option<Instant>,
+    last_vel_ned: [f32; 3],
+    arm_phase: ArmPhase,
+    warmup_since: Option<Instant>,
+    last_heartbeat: Option<Instant>,
+    last_interval_request: Option<Instant>,
+    started: Instant,
+    clock: UplinkClock,
+    send_failures: u64,
+    expected_system_id: u8,
+    expected_component_id: u8,
+}
+
+impl Px4Uplink {
+    /// Binds an ephemeral socket toward PX4's onboard command port
+    /// (`PILOTAGE_PX4_FC_ADDR`, default `127.0.0.1:14580`).
+    ///
+    /// # Errors
+    ///
+    /// Returns the socket bind error.
+    pub fn new() -> std::io::Result<Self> {
+        let target = std::env::var("PILOTAGE_PX4_FC_ADDR")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 14_580)));
+        let socket = UdpSocket::bind("127.0.0.1:0")?;
+        socket.set_nonblocking(true)?;
+        info!(%target, "PX4 offboard uplink ready");
+        Ok(Self {
+            socket,
+            target,
+            seq: 0,
+            heading_sp_rad: 0.0,
+            last_frame: None,
+            last_vel_ned: [0.0; 3],
+            arm_phase: ArmPhase::Idle,
+            warmup_since: None,
+            last_heartbeat: None,
+            last_interval_request: None,
+            started: Instant::now(),
+            clock: UplinkClock::System,
+            send_failures: 0,
+            expected_system_id: 1,
+            expected_component_id: 1,
+        })
+    }
+
+    /// Selects the MAVLink system/component commands are addressed to.
+    pub fn set_expected_source(&mut self, system_id: u8, component_id: u8) {
+        self.expected_system_id = system_id;
+        self.expected_component_id = component_id;
+    }
+
+    /// Retargets the uplink socket, for tests against a fake FC.
+    pub fn set_target(&mut self, target: SocketAddr) {
+        self.target = target;
+    }
+
+    /// Total refused sends, for enactment-truth counter deltas.
+    #[must_use]
+    pub fn send_failures(&self) -> u64 {
+        self.send_failures
+    }
+
+    fn send(&mut self, frame: &[u8]) {
+        if self.socket.send_to(frame, self.target).is_err() {
+            self.send_failures = self.send_failures.wrapping_add(1);
+            if self.send_failures == 1 || self.send_failures.is_multiple_of(100) {
+                warn!(
+                    failures = self.send_failures,
+                    target = %self.target,
+                    "PX4 uplink send failed"
+                );
+            }
+        }
+        self.seq = self.seq.wrapping_add(1);
+    }
+
+    fn time_boot_ms(&self) -> u32 {
+        self.clock
+            .now()
+            .saturating_duration_since(self.started)
+            .as_millis() as u32
+    }
+
+    /// Periodic presence and stream upkeep: the 1 Hz GCS heartbeat,
+    /// message-interval requests until telemetry flows, keepalive
+    /// setpoints between control frames, and the warmup step of the
+    /// offboard arm sequence. Call at telemetry-sampling cadence.
+    pub fn maintain(&mut self, telemetry_flowing: bool) {
+        let now = self.clock.now();
+        if self
+            .last_heartbeat
+            .is_none_or(|at| now.duration_since(at) >= HEARTBEAT_PERIOD)
+        {
+            self.last_heartbeat = Some(now);
+            let frame = encode_gcs_heartbeat(self.seq);
+            self.send(&frame);
+        }
+        if !telemetry_flowing
+            && self
+                .last_interval_request
+                .is_none_or(|at| now.duration_since(at) >= INTERVAL_RETRY)
+        {
+            self.last_interval_request = Some(now);
+            self.request_streams();
+        }
+        if self.arm_phase != ArmPhase::Idle
+            && self
+                .last_frame
+                .is_none_or(|at| now.duration_since(at) >= STREAM_KEEPALIVE)
+        {
+            let velocity = self.last_vel_ned;
+            self.send_velocity(velocity);
+        }
+        if self.arm_phase == ArmPhase::Warmup
+            && self
+                .warmup_since
+                .is_some_and(|since| now.duration_since(since) >= OFFBOARD_WARMUP)
+        {
+            self.command_offboard_and_arm();
+        }
+    }
+
+    fn request_streams(&mut self) {
+        for (message_id, interval_us) in STREAMS {
+            let frame = encode_command_long(
+                self.seq,
+                CMD_SET_MESSAGE_INTERVAL,
+                [message_id as f32, interval_us, 0.0, 0.0, 0.0, 0.0, 0.0],
+                self.expected_system_id,
+                self.expected_component_id,
+            );
+            self.send(&frame);
+        }
+    }
+
+    /// Starts the offboard arm sequence: seed the heading from the
+    /// measured yaw and begin the zero-velocity stream; OFFBOARD mode
+    /// and the arm command follow after the warmup.
+    pub fn begin_arm(&mut self, current_yaw_rad: f32) {
+        self.heading_sp_rad = current_yaw_rad;
+        self.last_vel_ned = [0.0; 3];
+        self.arm_phase = ArmPhase::Warmup;
+        self.warmup_since = Some(self.clock.now());
+        info!("offboard arm sequence: zero-velocity stream started");
+        self.send_velocity([0.0; 3]);
+    }
+
+    fn command_offboard_and_arm(&mut self) {
+        let mode = encode_command_long(
+            self.seq,
+            CMD_DO_SET_MODE,
+            [
+                BASE_MODE_CUSTOM,
+                PX4_MAIN_MODE_OFFBOARD,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            self.expected_system_id,
+            self.expected_component_id,
+        );
+        self.send(&mode);
+        let arm = encode_arm_command(
+            self.seq,
+            true,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
+        self.send(&arm);
+        self.arm_phase = ArmPhase::Commanded;
+        info!("offboard arm sequence: OFFBOARD and arm commanded");
+    }
+
+    /// Disarms and stops the setpoint stream.
+    pub fn send_disarm(&mut self) {
+        let frame = encode_arm_command(
+            self.seq,
+            false,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
+        self.send(&frame);
+        self.arm_phase = ArmPhase::Idle;
+        self.warmup_since = None;
+        self.last_vel_ned = [0.0; 3];
+        info!("disarm sent; setpoint stream stopped");
+    }
+
+    /// Converts one canonical stick frame (`[-1, 1]` roll/pitch/
+    /// throttle/yaw; pitch + = forward, roll + = right, throttle + =
+    /// climb, yaw + = clockwise) into a slew-limited velocity setpoint.
+    /// Ignored while no arm sequence is active: PX4 rejects setpoints
+    /// disarmed, and streaming before an explicit arm would mask the
+    /// arm sequencing.
+    pub fn send_stick_frame(&mut self, roll: f32, pitch: f32, throttle: f32, yaw: f32) {
+        if self.arm_phase == ArmPhase::Idle {
+            return;
+        }
+        let now = self.clock.now();
+        let dt = self
+            .last_frame
+            .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
+            .clamp(0.0, MAX_DT_S);
+        self.heading_sp_rad = wrap_pi(self.heading_sp_rad + yaw * MAX_YAW_RATE_RPS * dt);
+        let heading = self.heading_sp_rad;
+        let (sin, cos) = (heading.sin(), heading.cos());
+        let fwd = pitch * MAX_HORIZONTAL_MPS;
+        let lat = roll * MAX_HORIZONTAL_MPS;
+        let demand = [
+            fwd * cos - lat * sin,
+            fwd * sin + lat * cos,
+            -throttle * MAX_VERTICAL_MPS,
+        ];
+        let dv_max = MAX_ACCEL_MPS2 * dt.max(1.0 / 60.0);
+        let mut slewed = [0.0_f32; 3];
+        for (out, (target, current)) in slewed
+            .iter_mut()
+            .zip(demand.iter().zip(self.last_vel_ned.iter()))
+        {
+            *out = current + (target - current).clamp(-dv_max, dv_max);
+        }
+        self.send_velocity(slewed);
+    }
+
+    fn send_velocity(&mut self, vel_ned_mps: [f32; 3]) {
+        self.last_vel_ned = vel_ned_mps;
+        self.last_frame = Some(self.clock.now());
+        let frame = encode_velocity_setpoint(
+            self.seq,
+            self.time_boot_ms(),
+            vel_ned_mps,
+            self.heading_sp_rad,
+            self.expected_system_id,
+            self.expected_component_id,
+        );
+        self.send(&frame);
+    }
+
+    /// Enacts link-loss neutralization: one final zero-velocity
+    /// setpoint, then the stream stops so PX4's own offboard-loss
+    /// failsafe takes the vehicle (Hold). Stopping the stream — not
+    /// streaming neutral forever — is the honest enactment: a silent
+    /// pilot must look silent to the FC too.
+    pub fn neutralize(&mut self) {
+        self.send_velocity([0.0; 3]);
+        self.arm_phase = ArmPhase::Idle;
+        self.warmup_since = None;
+        info!("neutralized: stream stopped; PX4 offboard-loss failsafe takes over");
+    }
+
+    /// Whether an arm sequence is active (stream flowing), for tests.
+    #[cfg(test)]
+    pub(crate) fn streaming(&self) -> bool {
+        self.arm_phase != ArmPhase::Idle
+    }
+
+    /// Switches to the manual clock, for tests.
+    #[cfg(test)]
+    pub(crate) fn use_manual_clock(&mut self) {
+        self.clock = UplinkClock::Manual(Instant::now());
+    }
+
+    /// Advances the manual clock, for tests.
+    #[cfg(test)]
+    pub(crate) fn advance_clock(&mut self, by: Duration) {
+        if let UplinkClock::Manual(at) = &mut self.clock {
+            *at += by;
+        }
+    }
+}
+
+fn wrap_pi(angle: f32) -> f32 {
+    let mut wrapped = angle;
+    while wrapped > core::f32::consts::PI {
+        wrapped -= 2.0 * core::f32::consts::PI;
+    }
+    while wrapped < -core::f32::consts::PI {
+        wrapped += 2.0 * core::f32::consts::PI;
+    }
+    wrapped
+}

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -101,17 +101,13 @@ pub struct Px4Uplink {
 }
 
 impl Px4Uplink {
-    /// Binds an ephemeral socket toward PX4's onboard command port
-    /// (`PILOTAGE_PX4_FC_ADDR`, default `127.0.0.1:14580`).
+    /// Binds an ephemeral socket toward the configured PX4 onboard
+    /// command endpoint.
     ///
     /// # Errors
     ///
     /// Returns the socket bind error.
-    pub fn new() -> std::io::Result<Self> {
-        let target = std::env::var("PILOTAGE_PX4_FC_ADDR")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 14_580)));
+    pub fn new(target: SocketAddr) -> std::io::Result<Self> {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.set_nonblocking(true)?;
         info!(%target, "PX4 offboard uplink ready");

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -43,25 +43,13 @@ const OFFBOARD_WARMUP: Duration = Duration::from_millis(300);
 /// emitted at this period so PX4's offboard-loss failsafe does not
 /// trip between control frames.
 const STREAM_KEEPALIVE: Duration = Duration::from_millis(50);
-/// Message-interval requests are re-sent at this period for the whole
-/// session: they are idempotent, and a request lost during PX4's boot
-/// would otherwise leave the estimator status at its sparse default
-/// rate — too sparse for the display's status-to-numeric pairing.
-const INTERVAL_RETRY: Duration = Duration::from_secs(2);
 
 /// MAV_CMD_DO_SET_MODE.
 const CMD_DO_SET_MODE: u16 = 176;
-/// MAV_CMD_SET_MESSAGE_INTERVAL.
-const CMD_SET_MESSAGE_INTERVAL: u16 = 511;
 /// MAV_MODE_FLAG_CUSTOM_MODE_ENABLED.
 const BASE_MODE_CUSTOM: f32 = 1.0;
 /// PX4 custom main mode OFFBOARD.
 const PX4_MAIN_MODE_OFFBOARD: f32 = 6.0;
-/// Message ids whose intervals are requested, with the interval in
-/// microseconds: attitude quaternion and local position at ~30 Hz,
-/// the estimator status at 10 Hz — every numeric group must find a
-/// status within the display's 300 ms pairing budget.
-const STREAMS: [(u32, f32); 3] = [(31, 33_333.0), (32, 33_333.0), (230, 100_000.0)];
 
 /// The uplink's time source; tests substitute a manually advanced
 /// instant so sequencing is exercised without real-time sleeps.
@@ -105,7 +93,6 @@ pub struct Px4Uplink {
     arm_phase: ArmPhase,
     warmup_since: Option<Instant>,
     last_heartbeat: Option<Instant>,
-    last_interval_request: Option<Instant>,
     started: Instant,
     clock: UplinkClock,
     send_failures: u64,
@@ -138,7 +125,6 @@ impl Px4Uplink {
             arm_phase: ArmPhase::Idle,
             warmup_since: None,
             last_heartbeat: None,
-            last_interval_request: None,
             started: Instant::now(),
             clock: UplinkClock::System,
             send_failures: 0,
@@ -186,9 +172,11 @@ impl Px4Uplink {
     }
 
     /// Periodic presence and stream upkeep: the 1 Hz GCS heartbeat,
-    /// periodic message-interval requests, keepalive setpoints between
-    /// control frames, and the warmup step of the offboard arm
-    /// sequence. Call at telemetry-sampling cadence.
+    /// keepalive setpoints between control frames, and the warmup step
+    /// of the offboard arm sequence. Stream-interval negotiation is NOT
+    /// here: it must originate from the receive link's own socket (the
+    /// FC retargets a stream to the last peer that spoke on that link).
+    /// Call at telemetry-sampling cadence.
     pub fn maintain(&mut self) {
         let now = self.clock.now();
         if self
@@ -198,13 +186,6 @@ impl Px4Uplink {
             self.last_heartbeat = Some(now);
             let frame = encode_gcs_heartbeat(self.seq);
             self.send(&frame);
-        }
-        if self
-            .last_interval_request
-            .is_none_or(|at| now.duration_since(at) >= INTERVAL_RETRY)
-        {
-            self.last_interval_request = Some(now);
-            self.request_streams();
         }
         if self.arm_phase != ArmPhase::Idle
             && self
@@ -220,19 +201,6 @@ impl Px4Uplink {
                 .is_some_and(|since| now.duration_since(since) >= OFFBOARD_WARMUP)
         {
             self.command_offboard_and_arm();
-        }
-    }
-
-    fn request_streams(&mut self) {
-        for (message_id, interval_us) in STREAMS {
-            let frame = encode_command_long(
-                self.seq,
-                CMD_SET_MESSAGE_INTERVAL,
-                [message_id as f32, interval_us, 0.0, 0.0, 0.0, 0.0, 0.0],
-                self.expected_system_id,
-                self.expected_component_id,
-            );
-            self.send(&frame);
         }
     }
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -318,7 +318,13 @@ function encodeAxisSample(axisId, value) {
 function encodeControlPayload(axes, edges) {
   const bytes = [];
   for (const [axisId, value] of axes) {
-    fieldBytes(bytes, 1, encodeAxisSample(axisId, value));
+    // Every reported axis must appear on the wire even when fully
+    // neutral (axis 0 at value 0 encodes to an EMPTY submessage): the
+    // host's full-coverage neutral checks — link-loss recovery and
+    // reset-latch clearance — require every declared axis REPORTED,
+    // and a sample omitted by proto3 default-skipping reads as "this
+    // axis was never demonstrated".
+    fieldMessage(bytes, 1, encodeAxisSample(axisId, value));
   }
   for (const [buttonId, edge] of edges ?? []) {
     fieldBytes(bytes, 2, encodeButtonEdgeSample(buttonId, edge));

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -497,8 +497,9 @@ check(
     ],
     edges: [],
   });
-  // Walk the raw envelope: frame field 8 (payload) must contain four
-  // field-1 (axis sample) entries even though every value is neutral.
+  // Walk envelope field 2 (control frame) directly: frame field 8
+  // (payload) must contain four field-1 (axis sample) entries even
+  // though every value is neutral.
   function fieldsOf(bytes) {
     const out = [];
     let i = 0;
@@ -526,8 +527,7 @@ check(
     return out;
   }
   const envelopeFields = fieldsOf(Array.from(neutral));
-  const frame = envelopeFields.find(([f, v]) => f === 7 && v)?.[1]
-    ?? envelopeFields.find(([f, v]) => v && v.length > 8)?.[1];
+  const frame = envelopeFields.find(([f, v]) => f === 2 && v)?.[1] ?? [];
   const frameFields = fieldsOf(frame);
   const payload = frameFields.find(([f]) => f === 8)?.[1] ?? [];
   const axisEntries = fieldsOf(payload).filter(([f]) => f === 1);

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -476,6 +476,67 @@ check(
   check("an fc lane with a non-FC role decodes to null", wrongMessage.fcState === null);
 }
 
+// --- a fully neutral frame reports EVERY axis on the wire ---------------
+// The host's full-coverage neutral checks (link-loss recovery, reset-latch
+// clearance) require every declared axis REPORTED; proto3 default-skipping
+// of a neutral axis sample would silently make recovery unsatisfiable.
+{
+  const neutral = encodeControlFrameEnvelope({
+    sessionId: 1,
+    vehicleId: 1,
+    scope: "vehicle.motion",
+    generation: 1,
+    sequence: 1,
+    sampledAtNanos: 0n,
+    profileRevision: 1,
+    axes: [
+      [0, 0.0],
+      [1, 0.0],
+      [2, 0.0],
+      [3, 0.0],
+    ],
+    edges: [],
+  });
+  // Walk the raw envelope: frame field 8 (payload) must contain four
+  // field-1 (axis sample) entries even though every value is neutral.
+  function fieldsOf(bytes) {
+    const out = [];
+    let i = 0;
+    while (i < bytes.length) {
+      const tag = bytes[i++];
+      const field = tag >> 3;
+      const wire = tag & 7;
+      if (wire === 0) {
+        while (bytes[i] & 0x80) i++;
+        i++;
+        out.push([field, null]);
+      } else if (wire === 2) {
+        let len = 0, shift = 0;
+        while (bytes[i] & 0x80) { len |= (bytes[i] & 0x7f) << shift; shift += 7; i++; }
+        len |= bytes[i] << shift; i++;
+        out.push([field, bytes.slice(i, i + len)]);
+        i += len;
+      } else if (wire === 5) {
+        out.push([field, bytes.slice(i, i + 4)]);
+        i += 4;
+      } else {
+        break;
+      }
+    }
+    return out;
+  }
+  const envelopeFields = fieldsOf(Array.from(neutral));
+  const frame = envelopeFields.find(([f, v]) => f === 7 && v)?.[1]
+    ?? envelopeFields.find(([f, v]) => v && v.length > 8)?.[1];
+  const frameFields = fieldsOf(frame);
+  const payload = frameFields.find(([f]) => f === 8)?.[1] ?? [];
+  const axisEntries = fieldsOf(payload).filter(([f]) => f === 1);
+  check(
+    "a fully neutral frame reports all four axes on the wire",
+    axisEntries.length === 4,
+  );
+}
+
 if (failures > 0) {
   console.error(`\n${failures} check(s) failed`);
   process.exit(1);

--- a/hosts/session-host/Cargo.toml
+++ b/hosts/session-host/Cargo.toml
@@ -19,6 +19,7 @@ pilotage-adapter-api = { workspace = true }
 pilotage-adapter-reference = { workspace = true }
 pilotage-adapter-gazebo = { workspace = true }
 pilotage-adapter-aviate = { workspace = true }
+pilotage-adapter-px4 = { workspace = true }
 pilotage-timing = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "time", "sync", "net"] }

--- a/hosts/session-host/src/cli.rs
+++ b/hosts/session-host/src/cli.rs
@@ -128,6 +128,13 @@ mod tests {
     }
 
     #[test]
+    fn px4_adapter_parses() {
+        let args = vec!["--adapter".to_owned(), "px4".to_owned()];
+        let parsed = parse_args(&args).expect("PX4 adapter parses");
+        assert_eq!(parsed.adapter, AdapterKind::Px4);
+    }
+
+    #[test]
     fn unknown_adapter_is_an_error() {
         let args = vec!["--adapter".to_owned(), "unreal".to_owned()];
         assert_eq!(

--- a/hosts/session-host/src/cli.rs
+++ b/hosts/session-host/src/cli.rs
@@ -1,6 +1,6 @@
 //! Minimal argument parsing for the session-host binary: `--port <PORT>` and
-//! `--adapter reference|gazebo|aviate`, defaulting to port `0` (ephemeral,
-//! loopback-only bind) and the reference adapter.
+//! `--adapter reference|gazebo|aviate|px4`, defaulting to port `0`
+//! (ephemeral, loopback-only bind) and the reference adapter.
 
 /// Which vehicle adapter the host embeds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -13,6 +13,9 @@ pub enum AdapterKind {
     /// The telemetry-only Aviate flight-controller adapter over MAVLink
     /// (ADR-0018).
     Aviate,
+    /// The PX4 adapter over standard MAVLink: telemetry plus offboard
+    /// velocity control (ADR-0018).
+    Px4,
 }
 
 /// Parsed command-line configuration.
@@ -42,9 +45,8 @@ pub enum CliError {
     /// `--adapter` was given with no following value.
     #[error("--adapter requires a value")]
     MissingAdapterValue,
-    /// `--adapter` was given a value other than `reference`, `gazebo`,
-    /// or `aviate`.
-    #[error("invalid --adapter value {0:?} (expected reference, gazebo, or aviate)")]
+    /// `--adapter` was given a value outside the known adapter set.
+    #[error("invalid --adapter value {0:?} (expected reference, gazebo, aviate, or px4)")]
     InvalidAdapter(String),
     /// An argument was not recognized.
     #[error("unrecognized argument: {0}")]
@@ -75,6 +77,7 @@ pub fn parse_args(args: &[String]) -> Result<CliArgs, CliError> {
                     "reference" => AdapterKind::Reference,
                     "gazebo" => AdapterKind::Gazebo,
                     "aviate" => AdapterKind::Aviate,
+                    "px4" => AdapterKind::Px4,
                     other => return Err(CliError::InvalidAdapter(other.to_owned())),
                 };
             }

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -38,4 +38,7 @@ pub enum HostError {
     /// Starting the Aviate MAVLink telemetry link failed.
     #[error("failed to start the Aviate adapter: {0}")]
     AviateAdapter(#[source] pilotage_adapter_aviate::AviateAdapterError),
+    /// Starting the PX4 MAVLink link failed.
+    #[error("failed to start the PX4 adapter: {0}")]
+    Px4Adapter(#[source] pilotage_adapter_px4::Px4AdapterError),
 }

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -32,6 +32,42 @@ pub enum HostError {
         /// The rejected value, lossily decoded for this message.
         value: String,
     },
+    /// The PX4 adapter requires an explicit simulation profile.
+    #[error("PILOTAGE_PX4_PROFILE is required and must be set to simulation")]
+    Px4ProfileMissing,
+    /// A present PX4 profile did not name the only supported policy.
+    #[error("invalid PILOTAGE_PX4_PROFILE value {value:?} (expected simulation)")]
+    Px4Profile {
+        /// The rejected value.
+        value: String,
+    },
+    /// The PX4 profile could not be decoded as UTF-8.
+    #[error("PILOTAGE_PX4_PROFILE is not valid UTF-8: {source}")]
+    Px4ProfileEncoding {
+        /// The environment decoding failure.
+        #[source]
+        source: std::env::VarError,
+    },
+    /// A present PX4 endpoint was not a socket address.
+    #[error("invalid {variable} value {value:?}: {source}")]
+    Px4Endpoint {
+        /// The environment variable being parsed.
+        variable: &'static str,
+        /// The rejected value.
+        value: String,
+        /// The socket-address parse failure.
+        #[source]
+        source: std::net::AddrParseError,
+    },
+    /// A PX4 endpoint could not be decoded as UTF-8.
+    #[error("{variable} is not valid UTF-8: {source}")]
+    Px4EndpointEncoding {
+        /// The environment variable being parsed.
+        variable: &'static str,
+        /// The environment decoding failure.
+        #[source]
+        source: std::env::VarError,
+    },
     /// Spawning or connecting the Gazebo sidecar bridge failed.
     #[error("failed to start the Gazebo adapter: {0}")]
     GazeboAdapter(#[source] pilotage_adapter_gazebo::GazeboAdapterError),

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -9,6 +9,7 @@ mod connection;
 mod engine_actor;
 mod gazebo_launch;
 mod media;
+mod px4_config;
 mod registry;
 mod shutdown;
 mod stream_tag;
@@ -183,7 +184,8 @@ async fn spawn_host_runtime(
             spawn_aviate_runtime(endpoint, engine_tx, engine_rx, shutdown_rx, start).await
         }
         AdapterKind::Px4 => {
-            let mut adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE)
+            let config = px4_config::from_env()?;
+            let mut adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE, config)
                 .await
                 .map_err(HostError::Px4Adapter)?;
             let engine = build_engine(&adapter);

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -182,6 +182,22 @@ async fn spawn_host_runtime(
         AdapterKind::Aviate => {
             spawn_aviate_runtime(endpoint, engine_tx, engine_rx, shutdown_rx, start).await
         }
+        AdapterKind::Px4 => {
+            let adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE)
+                .await
+                .map_err(HostError::Px4Adapter)?;
+            let engine = build_engine(&adapter);
+            Ok(tokio::spawn(run_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                None,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
     }
 }
 

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -183,20 +183,36 @@ async fn spawn_host_runtime(
             spawn_aviate_runtime(endpoint, engine_tx, engine_rx, shutdown_rx, start).await
         }
         AdapterKind::Px4 => {
-            let adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE)
+            let mut adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE)
                 .await
                 .map_err(HostError::Px4Adapter)?;
             let engine = build_engine(&adapter);
-            Ok(tokio::spawn(run_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                None,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-                start,
-            )))
+            match adapter.subscribe_frames() {
+                Some(frames) => {
+                    let (media, media_task) = media::spawn_media_task(frames, start);
+                    Ok(tokio::spawn(run_with_media_until_shutdown(
+                        endpoint,
+                        engine,
+                        adapter,
+                        media,
+                        media_task,
+                        engine_tx,
+                        engine_rx,
+                        shutdown_rx,
+                        start,
+                    )))
+                }
+                None => Ok(tokio::spawn(run_until_shutdown(
+                    endpoint,
+                    engine,
+                    adapter,
+                    None,
+                    engine_tx,
+                    engine_rx,
+                    shutdown_rx,
+                    start,
+                ))),
+            }
         }
     }
 }

--- a/hosts/session-host/src/runtime/px4_config.rs
+++ b/hosts/session-host/src/runtime/px4_config.rs
@@ -1,0 +1,168 @@
+//! Fail-closed PX4 profile and endpoint configuration.
+
+use std::env::VarError;
+use std::net::SocketAddr;
+
+use pilotage_adapter_px4::{Px4Config, Px4Profile};
+
+use crate::error::HostError;
+
+const PROFILE: &str = "PILOTAGE_PX4_PROFILE";
+const TELEMETRY_ENDPOINT: &str = "PILOTAGE_PX4_ADDR";
+const STREAM_COMMAND_ENDPOINT: &str = "PILOTAGE_PX4_GCS_ADDR";
+const COMMAND_ENDPOINT: &str = "PILOTAGE_PX4_FC_ADDR";
+
+pub(crate) fn from_env() -> Result<Px4Config, HostError> {
+    config_from_values(
+        std::env::var(PROFILE),
+        std::env::var(TELEMETRY_ENDPOINT),
+        std::env::var(STREAM_COMMAND_ENDPOINT),
+        std::env::var(COMMAND_ENDPOINT),
+    )
+}
+
+fn config_from_values(
+    profile: Result<String, VarError>,
+    telemetry_endpoint: Result<String, VarError>,
+    stream_command_endpoint: Result<String, VarError>,
+    command_endpoint: Result<String, VarError>,
+) -> Result<Px4Config, HostError> {
+    let profile = parse_profile(profile)?;
+    let mut config = Px4Config::new(profile);
+    config.telemetry_endpoint = parse_endpoint(
+        TELEMETRY_ENDPOINT,
+        telemetry_endpoint,
+        config.telemetry_endpoint,
+    )?;
+    config.stream_command_endpoint = parse_endpoint(
+        STREAM_COMMAND_ENDPOINT,
+        stream_command_endpoint,
+        config.stream_command_endpoint,
+    )?;
+    config.command_endpoint =
+        parse_endpoint(COMMAND_ENDPOINT, command_endpoint, config.command_endpoint)?;
+    Ok(config)
+}
+
+fn parse_profile(value: Result<String, VarError>) -> Result<Px4Profile, HostError> {
+    match value {
+        Ok(value) if value == "simulation" => Ok(Px4Profile::Simulation),
+        Ok(value) => Err(HostError::Px4Profile { value }),
+        Err(VarError::NotPresent) => Err(HostError::Px4ProfileMissing),
+        Err(source @ VarError::NotUnicode(_)) => Err(HostError::Px4ProfileEncoding { source }),
+    }
+}
+
+fn parse_endpoint(
+    variable: &'static str,
+    value: Result<String, VarError>,
+    default: SocketAddr,
+) -> Result<SocketAddr, HostError> {
+    match value {
+        Ok(value) => value.parse().map_err(|source| HostError::Px4Endpoint {
+            variable,
+            value,
+            source,
+        }),
+        Err(VarError::NotPresent) => Ok(default),
+        Err(source @ VarError::NotUnicode(_)) => {
+            Err(HostError::Px4EndpointEncoding { variable, source })
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::env::VarError;
+    use std::ffi::OsString;
+    use std::net::SocketAddr;
+
+    use super::config_from_values;
+    use crate::error::HostError;
+
+    fn absent() -> Result<String, VarError> {
+        Err(VarError::NotPresent)
+    }
+
+    fn config(
+        profile: Result<String, VarError>,
+    ) -> Result<pilotage_adapter_px4::Px4Config, HostError> {
+        config_from_values(profile, absent(), absent(), absent())
+    }
+
+    #[test]
+    fn direct_px4_start_requires_an_explicit_simulation_profile() {
+        assert!(matches!(
+            config(absent()),
+            Err(HostError::Px4ProfileMissing)
+        ));
+        let accepted = config(Ok("simulation".to_owned())).expect("simulation profile");
+        assert_eq!(
+            accepted.telemetry_endpoint,
+            SocketAddr::from(([127, 0, 0, 1], 14_550))
+        );
+    }
+
+    #[test]
+    fn direct_px4_start_refuses_every_non_simulation_profile() {
+        for value in ["physical", "oracle-only", "simulaton", "Simulation", ""] {
+            let refusal = config(Ok(value.to_owned()));
+            assert!(
+                matches!(refusal, Err(HostError::Px4Profile { value: ref rejected }) if rejected == value),
+                "{value:?} must be refused, got {refusal:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_px4_start_refuses_non_unicode_profile_values() {
+        #[cfg(unix)]
+        let raw = {
+            use std::os::unix::ffi::OsStringExt;
+            OsString::from_vec(vec![0x66, 0xFF, 0x6F])
+        };
+        #[cfg(not(unix))]
+        let raw = OsString::from("\u{FFFD}garbage");
+        let refusal = config(Err(VarError::NotUnicode(raw)));
+        assert!(matches!(refusal, Err(HostError::Px4ProfileEncoding { .. })));
+    }
+
+    #[test]
+    fn present_invalid_endpoints_fail_instead_of_using_defaults() {
+        for (variable, refusal) in [
+            (
+                "PILOTAGE_PX4_ADDR",
+                config_from_values(
+                    Ok("simulation".to_owned()),
+                    Ok("not-an-address".to_owned()),
+                    absent(),
+                    absent(),
+                ),
+            ),
+            (
+                "PILOTAGE_PX4_GCS_ADDR",
+                config_from_values(
+                    Ok("simulation".to_owned()),
+                    absent(),
+                    Ok("127.0.0.1:not-a-port".to_owned()),
+                    absent(),
+                ),
+            ),
+            (
+                "PILOTAGE_PX4_FC_ADDR",
+                config_from_values(
+                    Ok("simulation".to_owned()),
+                    absent(),
+                    absent(),
+                    Ok("missing-port".to_owned()),
+                ),
+            ),
+        ] {
+            assert!(
+                matches!(refusal, Err(HostError::Px4Endpoint { variable: rejected, .. }) if rejected == variable),
+                "{variable} must fail closed, got {refusal:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #158 (child of #96). Adds a `VehicleAdapter` for PX4 over standard MAVLink, independent of the flight-dynamics backend: offboard velocity control, estimator-authorized telemetry, camera-sidecar media, heartbeat-derived FC state, and the same link-loss/reset-latch discipline as the Aviate adapter.

Safety amendment:
- Direct `pilotage-session-host --adapter px4` startup now requires `PILOTAGE_PX4_PROFILE=simulation`; missing, physical, oracle-only, unknown, and invalid-UTF-8 profiles fail with typed errors.
- A typed `Px4Config` is constructed once at the host boundary and passed into `Px4Adapter::start`.
- Present-but-invalid PX4 telemetry, stream-command, and command endpoints fail closed; defaults apply only when the variables are absent.
- Regression tests cover direct-host profile enforcement, every invalid endpoint, `--adapter px4` parsing, and exact envelope-field-2 neutral-axis encoding.

Reset clearance uses the canonical full-coverage neutral activation; `current_pose` requires status, attitude, and kinematics stamps from the current source epoch; reset tests drive a real reboot through the production message path; stream negotiation lives on one socket.

Built on merged #161 and merged #152's `RejectReason::ResetInProgress`.