### PR TITLE
xtask: the px4-gz backend — xtask-owned gz plus standalone PX4

### DIFF
--- a/scripts/reset-px4-sim.sh
+++ b/scripts/reset-px4-sim.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Resets the PX4 flight demo between test iterations: puts the Gazebo
+# world back to its initial pose and restarts the px4 binary (whose
+# estimator state must reset with the vehicle). Host and browser stay
+# up — the MAVLink link detects the restarted stream as a new source
+# epoch and the adapter's reset latch clears on fresh telemetry plus
+# neutral input.
+#
+# Usage: scripts/reset-px4-sim.sh [world-name]  (default: default)
+set -euo pipefail
+export PATH="/opt/homebrew/bin:$PATH"
+export GZ_IP="${GZ_IP:-127.0.0.1}"
+WORLD="${1:-default}"
+
+echo "resetting world '${WORLD}'..."
+gz service -s "/world/${WORLD}/control" \
+  --reqtype gz.msgs.WorldControl --reptype gz.msgs.Boolean \
+  --timeout 3000 --req 'reset: {all: true}'
+
+echo "restarting PX4..."
+pkill -9 -f "bin/px4" 2>/dev/null || true
+
+# When `cargo xtask sim` supervises the session, the supervisor restarts
+# the flight-controller stage itself; a script-spawned second px4 would
+# fight it over the model and the MAVLink ports.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPERVISOR_PID_FILE="${REPO_ROOT}/target/xtask-sim/supervisor.pid"
+if [[ -f "${SUPERVISOR_PID_FILE}" ]] && kill -0 "$(cat "${SUPERVISOR_PID_FILE}")" 2>/dev/null; then
+  echo "done — the xtask supervisor restarts PX4; re-arm from the browser once it logs ready"
+  exit 0
+fi
+
+PX4_DIR="${PX4_DIR:-$HOME/PX4-Autopilot}"
+ROOTFS="${PX4_DIR}/build/px4_sitl_default/rootfs"
+mkdir -p "${ROOTFS}"
+cd "${ROOTFS}"
+PX4_GZ_STANDALONE=1 PX4_SYS_AUTOSTART=4001 PX4_SIM_MODEL=gz_x500 PX4_GZ_WORLD="${WORLD}" \
+  nohup ../bin/px4 ../etc -s etc/init.d-posix/rcS -d > /tmp/px4_manual.log 2>&1 &
+echo "done — re-arm from the browser once PX4 logs ready (~10 s)"

--- a/scripts/reset-px4-sim.sh
+++ b/scripts/reset-px4-sim.sh
@@ -18,7 +18,10 @@ gz service -s "/world/${WORLD}/control" \
   --timeout 3000 --req 'reset: {all: true}'
 
 echo "restarting PX4..."
-pkill -9 -f "bin/px4" 2>/dev/null || true
+# Match ONLY this checkout's SITL binary: a bare "bin/px4" pattern
+# would kill unrelated PX4 sessions on the machine.
+PX4_DIR="${PX4_DIR:-$HOME/PX4-Autopilot}"
+pkill -9 -f "${PX4_DIR}/build/px4_sitl_default/bin/px4" 2>/dev/null || true
 
 # When `cargo xtask sim` supervises the session, the supervisor restarts
 # the flight-controller stage itself; a script-spawned second px4 would
@@ -30,10 +33,10 @@ if [[ -f "${SUPERVISOR_PID_FILE}" ]] && kill -0 "$(cat "${SUPERVISOR_PID_FILE}")
   exit 0
 fi
 
-PX4_DIR="${PX4_DIR:-$HOME/PX4-Autopilot}"
 ROOTFS="${PX4_DIR}/build/px4_sitl_default/rootfs"
 mkdir -p "${ROOTFS}"
 cd "${ROOTFS}"
-PX4_GZ_STANDALONE=1 PX4_SYS_AUTOSTART=4001 PX4_SIM_MODEL=gz_x500 PX4_GZ_WORLD="${WORLD}" \
+PX4_GZ_STANDALONE=1 PX4_SYS_AUTOSTART=4001 PX4_SIM_MODEL=gz_x500 \
+  PX4_GZ_MODEL_NAME=x500_0 PX4_GZ_WORLD="${WORLD}" \
   nohup ../bin/px4 ../etc -s etc/init.d-posix/rcS -d > /tmp/px4_manual.log 2>&1 &
 echo "done — re-arm from the browser once PX4 logs ready (~10 s)"

--- a/sim/worlds/px4_flightdeck.sdf
+++ b/sim/worlds/px4_flightdeck.sdf
@@ -93,7 +93,7 @@
     </include>
 
     <model name="x500_camera_rig">
-      <pose>0 0 0.24 0 0 0</pose>
+      <pose>0 0 0.48 0 0 0</pose>
       <link name="rig_link">
         <inertial>
           <mass>0.01</mass>

--- a/sim/worlds/px4_flightdeck.sdf
+++ b/sim/worlds/px4_flightdeck.sdf
@@ -12,12 +12,6 @@
     <gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     <atmosphere type="adiabatic"/>
-    <scene>
-      <grid>false</grid>
-      <ambient>0.4 0.4 0.4 1</ambient>
-      <background>0.7 0.7 0.7 1</background>
-      <shadows>true</shadows>
-    </scene>
     <model name="ground_plane">
       <static>true</static>
       <link name="link">
@@ -25,7 +19,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>100 100</size>
             </plane>
           </geometry>
           <surface>
@@ -40,13 +34,13 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>500 500</size>
+              <size>100 100</size>
             </plane>
           </geometry>
           <material>
-            <ambient>0.8 0.8 0.8 1</ambient>
-            <diffuse>0.8 0.8 0.8 1</diffuse>
-            <specular>0.8 0.8 0.8 1</specular>
+            <ambient>0.3 0.5 0.3 1</ambient>
+            <diffuse>0.3 0.5 0.3 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
           </material>
         </visual>
         <pose>0 0 0 0 -0 0</pose>
@@ -67,24 +61,18 @@
       <pose>0 0 0 0 -0 0</pose>
       <self_collide>false</self_collide>
     </model>
-    <light name="sunUTC" type="directional">
-      <pose>0 0 500 0 -0 0</pose>
+    <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
-      <intensity>1</intensity>
-      <direction>0.001 0.625 -0.78</direction>
-      <diffuse>0.904 0.904 0.904 1</diffuse>
-      <specular>0.271 0.271 0.271 1</specular>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
       <attenuation>
-        <range>2000</range>
-        <linear>0</linear>
-        <constant>1</constant>
-        <quadratic>0</quadratic>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
       </attenuation>
-      <spot>
-        <inner_angle>0</inner_angle>
-        <outer_angle>0</outer_angle>
-        <falloff>0</falloff>
-      </spot>
+      <direction>-0.5 0.1 -0.9</direction>
     </light>
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>

--- a/sim/worlds/px4_flightdeck.sdf
+++ b/sim/worlds/px4_flightdeck.sdf
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The Pilotage px4-gz flight-deck world: PX4's stock default world
+     plus a statically included x500 (PX4 attaches by model name) and
+     the Pilotage camera rig (FPV /camera + /chase_camera). -->
+<sdf version="1.9">
+  <world name="default">
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+    <scene>
+      <grid>false</grid>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <light name="sunUTC" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>47.397971057728974</latitude_deg>
+      <longitude_deg> 8.546163739800146</longitude_deg>
+      <elevation>0</elevation>
+    </spherical_coordinates>
+
+    <!-- Pilotage: the PX4 x500 is included statically (PX4 attaches to
+         it via PX4_GZ_MODEL_NAME instead of spawning) so the Pilotage
+         camera rig can be welded to it at world scope, publishing the
+         /camera and /chase_camera topics the gz sidecar bridges. -->
+    <include>
+      <uri>model://x500</uri>
+      <name>x500_0</name>
+      <pose>0 0 0.24 0 0 0</pose>
+    </include>
+
+    <model name="x500_camera_rig">
+      <pose>0 0 0.24 0 0 0</pose>
+      <link name="rig_link">
+        <inertial>
+          <mass>0.01</mass>
+          <inertia><ixx>1e-5</ixx><iyy>1e-5</iyy><izz>1e-5</izz></inertia>
+        </inertial>
+        <sensor name="camera" type="camera">
+          <pose>0.12 0 0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>1.396</horizontal_fov>
+            <image><width>320</width><height>240</height></image>
+            <clip><near>0.1</near><far>300</far></clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <topic>camera</topic>
+        </sensor>
+        <sensor name="chase_camera" type="camera">
+          <pose>-1.6 0 0.9 0 0.35 0</pose>
+          <camera>
+            <horizontal_fov>1.6</horizontal_fov>
+            <image><width>320</width><height>240</height></image>
+            <clip><near>0.1</near><far>300</far></clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <topic>chase_camera</topic>
+        </sensor>
+      </link>
+    </model>
+    <joint name="camera_rig_mount" type="fixed">
+      <parent>x500_0::base_link</parent>
+      <child>x500_camera_rig::rig_link</child>
+    </joint>
+
+  </world>
+</sdf>

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -10,7 +10,8 @@ use crate::error::XtaskError;
 use crate::process::ProcessSpec;
 use crate::readiness::Readiness;
 
-mod aviate_gz;
+pub(crate) mod aviate_gz;
+mod px4_gz;
 
 /// Everything a backend may need to plan its stages.
 #[derive(Debug)]
@@ -71,7 +72,10 @@ pub trait SimBackend {
 /// does not implement.
 pub fn backend_for(name: &str) -> Result<Box<dyn SimBackend>, XtaskError> {
     match name {
-        "aviate" => Ok(Box::new(aviate_gz::AviateGz)),
+        // Canonical names pair the FC family with the simulator behind
+        // it; the bare FC name stays accepted as the family's default.
+        "aviate-gz" | "aviate" => Ok(Box::new(aviate_gz::AviateGz)),
+        "px4-gz" | "px4" => Ok(Box::new(px4_gz::Px4Gz)),
         _ => Err(XtaskError::UnknownBackend {
             name: name.to_owned(),
         }),
@@ -86,8 +90,11 @@ mod tests {
 
     #[test]
     fn backend_selection_fails_closed() {
-        assert_eq!(backend_for("aviate").expect("known").name(), "aviate");
-        let refusal = backend_for("px4");
+        assert_eq!(backend_for("aviate").expect("known").name(), "aviate-gz");
+        assert_eq!(backend_for("aviate-gz").expect("known").name(), "aviate-gz");
+        assert_eq!(backend_for("px4").expect("known").name(), "px4-gz");
+        assert_eq!(backend_for("px4-gz").expect("known").name(), "px4-gz");
+        let refusal = backend_for("px4-jsbsim");
         assert!(matches!(refusal, Err(XtaskError::UnknownBackend { .. })));
     }
 }

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -20,7 +20,7 @@ pub struct AviateGz;
 
 impl SimBackend for AviateGz {
     fn name(&self) -> &'static str {
-        "aviate"
+        "aviate-gz"
     }
 
     fn host_adapter(&self) -> &'static str {
@@ -74,7 +74,7 @@ fn aviate_dir(repo_root: &Path) -> PathBuf {
 /// `PATH` for spawned tools, with Homebrew's prefix appended when it
 /// exists (gz lives there on macOS; a login shell has it, a bare spawn
 /// may not).
-fn search_path() -> String {
+pub(crate) fn search_path() -> String {
     let inherited = std::env::var("PATH").unwrap_or_default();
     let brew = Path::new("/opt/homebrew/bin");
     if brew.is_dir() && !inherited.split(':').any(|p| p == "/opt/homebrew/bin") {

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -8,6 +8,7 @@
 use std::path::{Path, PathBuf};
 
 use super::{SessionContext, SimBackend, Stage};
+use crate::cli::Profile;
 use crate::error::XtaskError;
 use crate::process::ProcessSpec;
 use crate::readiness::{Readiness, stage_log};
@@ -36,6 +37,18 @@ impl SimBackend for Px4Gz {
     }
 
     fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {
+        // The PX4 adapter implements only the simulation profile; the
+        // host would silently ignore any other selection, so refuse it
+        // here instead of launching a session that lies about its
+        // policy.
+        if ctx.profile != Profile::Simulation {
+            return Err(XtaskError::Usage {
+                message: format!(
+                    "the px4-gz backend supports only --profile simulation (got {:?})",
+                    ctx.profile
+                ),
+            });
+        }
         plan_with_px4_dir(ctx, &px4_dir(&ctx.repo_root))
     }
 
@@ -70,9 +83,12 @@ impl SimBackend for Px4Gz {
 /// `../PX4-Autopilot` next to this repository. A directory convention,
 /// never a source dependency.
 fn px4_dir(repo_root: &Path) -> PathBuf {
-    std::env::var_os("PX4_DIR")
+    let dir = std::env::var_os("PX4_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|| repo_root.join("../PX4-Autopilot"))
+        .unwrap_or_else(|| repo_root.join("../PX4-Autopilot"));
+    // Canonical, or the reset script's exact-path process match never
+    // sees the spawned binary (a literal `..` in the command line).
+    dir.canonicalize().unwrap_or(dir)
 }
 
 /// The testable core of [`Px4Gz::plan`]: validates every artifact with

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -1,0 +1,311 @@
+//! The PX4 + Gazebo SITL backend, orchestrated by this launcher rather
+//! than PX4's own scripts: xtask starts the gz server with PX4's world,
+//! sensor systems, and plugins, then runs the px4 binary in standalone
+//! mode so it attaches to that server and spawns the x500 model. The
+//! adapter side is FDM-agnostic — swapping gz for JSBSim or FlightGear
+//! is a new backend planning different stages, not a new adapter.
+
+use std::path::{Path, PathBuf};
+
+use super::{SessionContext, SimBackend, Stage};
+use crate::error::XtaskError;
+use crate::process::ProcessSpec;
+use crate::readiness::{Readiness, stage_log};
+
+/// The gz world PX4's x500 model spawns into (PX4 ships `default.sdf`;
+/// its `<world name>` is `default` — also what the reset script targets).
+const WORLD_NAME: &str = "default";
+/// PX4 airframe autostart id for the gz x500.
+const SYS_AUTOSTART: &str = "4001";
+
+/// The PX4 + Gazebo SITL backend.
+#[derive(Debug)]
+pub struct Px4Gz;
+
+impl SimBackend for Px4Gz {
+    fn name(&self) -> &'static str {
+        "px4-gz"
+    }
+
+    fn host_adapter(&self) -> &'static str {
+        "px4"
+    }
+
+    fn host_env(&self, _ctx: &SessionContext) -> Vec<(String, String)> {
+        vec![("GZ_IP".to_owned(), "127.0.0.1".to_owned())]
+    }
+
+    fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {
+        plan_with_px4_dir(ctx, &px4_dir(&ctx.repo_root))
+    }
+
+    fn stale_process_patterns(&self) -> Vec<&'static str> {
+        vec!["gz sim", "bin/px4"]
+    }
+
+    fn reset(&self, repo_root: &Path) -> Result<(), XtaskError> {
+        let script = repo_root.join("scripts/reset-px4-sim.sh");
+        let status = std::process::Command::new("bash")
+            .arg(&script)
+            .arg(WORLD_NAME)
+            .env("PATH", super::aviate_gz::search_path())
+            .env("PX4_DIR", px4_dir(repo_root))
+            .status()
+            .map_err(|source| XtaskError::Io {
+                context: "running the PX4 reset script",
+                source,
+            })?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(XtaskError::CommandFailed {
+                context: "PX4 reset script",
+                status: status.to_string(),
+            })
+        }
+    }
+}
+
+/// Where the PX4-Autopilot checkout lives: `PX4_DIR`, else
+/// `../PX4-Autopilot` next to this repository. A directory convention,
+/// never a source dependency.
+fn px4_dir(repo_root: &Path) -> PathBuf {
+    std::env::var_os("PX4_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root.join("../PX4-Autopilot"))
+}
+
+/// The testable core of [`Px4Gz::plan`]: validates every artifact with
+/// an actionable hint, then assembles the gz and PX4 stages.
+fn plan_with_px4_dir(ctx: &SessionContext, px4: &Path) -> Result<Vec<Stage>, XtaskError> {
+    if !px4.is_dir() {
+        return Err(XtaskError::MissingArtifact {
+            what: "PX4-Autopilot checkout",
+            path: px4.to_path_buf(),
+            hint: "clone PX4-Autopilot next to this repository or set PX4_DIR",
+        });
+    }
+    let binary = px4.join("build/px4_sitl_default/bin/px4");
+    if !binary.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "PX4 SITL binary",
+            path: binary,
+            hint: "build it: make px4_sitl in the PX4-Autopilot checkout",
+        });
+    }
+    let world = px4.join("Tools/simulation/gz/worlds/default.sdf");
+    if !world.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "PX4 gz world",
+            path: world,
+            hint: "the PX4 checkout is missing Tools/simulation/gz (update submodules)",
+        });
+    }
+    let server_config = px4.join("Tools/simulation/gz/server.config");
+    if !server_config.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "PX4 gz server config",
+            path: server_config,
+            hint: "the PX4 checkout is missing Tools/simulation/gz/server.config",
+        });
+    }
+    let path = super::aviate_gz::search_path();
+    Ok(vec![
+        gz_stage(ctx, px4, &path, &world, &server_config),
+        px4_stage(ctx, px4, &path, &binary)?,
+    ])
+}
+
+fn gz_stage(
+    ctx: &SessionContext,
+    px4: &Path,
+    path: &str,
+    world: &Path,
+    server_config: &Path,
+) -> Stage {
+    // PX4's worlds carry no inline system plugins; the sensor systems
+    // (imu, magnetometer, navsat, air pressure) come from the server
+    // config, and PX4's own gz plugins from the build tree.
+    let gz_env = vec![
+        ("PATH".to_owned(), path.to_owned()),
+        ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
+        (
+            "GZ_SIM_SERVER_CONFIG_PATH".to_owned(),
+            server_config.display().to_string(),
+        ),
+        (
+            "GZ_SIM_SYSTEM_PLUGIN_PATH".to_owned(),
+            px4.join("build/px4_sitl_default/src/modules/simulation/gz_plugins")
+                .display()
+                .to_string(),
+        ),
+        (
+            "GZ_SIM_RESOURCE_PATH".to_owned(),
+            format!(
+                "{}:{}",
+                px4.join("Tools/simulation/gz/worlds").display(),
+                px4.join("Tools/simulation/gz/models").display()
+            ),
+        ),
+    ];
+    Stage {
+        spec: ProcessSpec {
+            name: "gazebo",
+            program: "gz".to_owned(),
+            args: vec![
+                "sim".to_owned(),
+                "-s".to_owned(),
+                "-r".to_owned(),
+                "--headless-rendering".to_owned(),
+                world.display().to_string(),
+            ],
+            cwd: None,
+            env: gz_env.clone(),
+            remove_env: vec!["DISPLAY"],
+            log_path: stage_log(&ctx.log_dir, "gazebo"),
+        },
+        readiness: Readiness::CommandOutput {
+            program: "gz".to_owned(),
+            args: vec!["topic".to_owned(), "-l".to_owned()],
+            env: gz_env,
+            needle: WORLD_NAME,
+            timeout_s: 60,
+        },
+    }
+}
+
+fn px4_stage(
+    ctx: &SessionContext,
+    px4: &Path,
+    path: &str,
+    binary: &Path,
+) -> Result<Stage, XtaskError> {
+    // px4 resolves its startup script relative to the working directory
+    // and litters it with eeprom/dataman state; a dedicated rootfs dir
+    // inside the build tree keeps that contained.
+    let rootfs = px4.join("build/px4_sitl_default/rootfs");
+    std::fs::create_dir_all(&rootfs).map_err(|source| XtaskError::Io {
+        context: "creating the PX4 rootfs directory",
+        source,
+    })?;
+    Ok(Stage {
+        spec: ProcessSpec {
+            name: "flight-controller",
+            program: binary.display().to_string(),
+            args: vec![
+                px4.join("build/px4_sitl_default/etc").display().to_string(),
+                "-s".to_owned(),
+                "etc/init.d-posix/rcS".to_owned(),
+                "-d".to_owned(),
+            ],
+            cwd: Some(rootfs),
+            env: vec![
+                ("PATH".to_owned(), path.to_owned()),
+                ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
+                // Standalone: xtask owns the gz server; px4 attaches to
+                // it and spawns the model instead of forking its own.
+                ("PX4_GZ_STANDALONE".to_owned(), "1".to_owned()),
+                ("PX4_SYS_AUTOSTART".to_owned(), SYS_AUTOSTART.to_owned()),
+                ("PX4_SIM_MODEL".to_owned(), "gz_x500".to_owned()),
+                ("PX4_GZ_WORLD".to_owned(), WORLD_NAME.to_owned()),
+            ],
+            remove_env: vec![],
+            log_path: stage_log(&ctx.log_dir, "flight-controller"),
+        },
+        // "Ready for takeoff" waits on a GCS heartbeat, which only the
+        // session host provides — a later stage. Boot completion is the
+        // honest FC-stage signal.
+        readiness: Readiness::LogContains {
+            needle: "Startup script returned successfully",
+            timeout_s: 60,
+        },
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::plan_with_px4_dir;
+    use crate::backend::SessionContext;
+    use crate::cli::Profile;
+    use crate::error::XtaskError;
+
+    fn context(repo_root: PathBuf) -> SessionContext {
+        SessionContext {
+            repo_root,
+            host_port: 4433,
+            viewer_port: 8080,
+            profile: Profile::Simulation,
+            log_dir: std::env::temp_dir(),
+        }
+    }
+
+    fn scaffold(tag: &str) -> (PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!("px4-gz-plan-{tag}-{}", std::process::id()));
+        let px4 = root.join("PX4-Autopilot");
+        std::fs::create_dir_all(&px4).expect("scaffold");
+        (root, px4)
+    }
+
+    #[test]
+    fn missing_artifacts_fail_with_actionable_hints() {
+        let (root, px4) = scaffold("missing");
+        let ctx = context(root.clone());
+
+        let refusal = plan_with_px4_dir(&ctx, &root.join("absent"));
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "PX4-Autopilot checkout",
+                ..
+            })
+        ));
+
+        let refusal = plan_with_px4_dir(&ctx, &px4);
+        assert!(matches!(
+            refusal,
+            Err(XtaskError::MissingArtifact {
+                what: "PX4 SITL binary",
+                ..
+            })
+        ));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_complete_checkout_plans_gz_then_px4_standalone() {
+        let (root, px4) = scaffold("complete");
+        for file in [
+            "build/px4_sitl_default/bin/px4",
+            "Tools/simulation/gz/worlds/default.sdf",
+            "Tools/simulation/gz/server.config",
+        ] {
+            let path = px4.join(file);
+            std::fs::create_dir_all(path.parent().expect("parent")).expect("dirs");
+            std::fs::write(&path, b"x").expect("file");
+        }
+        let ctx = context(root.clone());
+        let stages = plan_with_px4_dir(&ctx, &px4).expect("plan");
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0].spec.name, "gazebo");
+        assert_eq!(stages[1].spec.name, "flight-controller");
+        let fc_env = &stages[1].spec.env;
+        assert!(
+            fc_env
+                .iter()
+                .any(|(k, v)| k == "PX4_GZ_STANDALONE" && v == "1"),
+            "px4 must attach to the xtask-owned gz server, not spawn its own"
+        );
+        assert!(
+            stages[0]
+                .spec
+                .env
+                .iter()
+                .any(|(k, _)| k == "GZ_SIM_SERVER_CONFIG_PATH"),
+            "gz must load PX4's sensor systems via the server config"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -93,12 +93,12 @@ fn plan_with_px4_dir(ctx: &SessionContext, px4: &Path) -> Result<Vec<Stage>, Xta
             hint: "build it: make px4_sitl in the PX4-Autopilot checkout",
         });
     }
-    let world = px4.join("Tools/simulation/gz/worlds/default.sdf");
+    let world = ctx.repo_root.join("sim/worlds/px4_flightdeck.sdf");
     if !world.is_file() {
         return Err(XtaskError::MissingArtifact {
-            what: "PX4 gz world",
+            what: "px4 flight-deck world",
             path: world,
-            hint: "the PX4 checkout is missing Tools/simulation/gz (update submodules)",
+            hint: "run from the Pilotage repository root",
         });
     }
     let server_config = px4.join("Tools/simulation/gz/server.config");
@@ -142,7 +142,8 @@ fn gz_stage(
         (
             "GZ_SIM_RESOURCE_PATH".to_owned(),
             format!(
-                "{}:{}",
+                "{}:{}:{}",
+                ctx.repo_root.join("sim/worlds").display(),
                 px4.join("Tools/simulation/gz/worlds").display(),
                 px4.join("Tools/simulation/gz/models").display()
             ),
@@ -203,10 +204,12 @@ fn px4_stage(
                 ("PATH".to_owned(), path.to_owned()),
                 ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
                 // Standalone: xtask owns the gz server; px4 attaches to
-                // it and spawns the model instead of forking its own.
+                // the statically included model (which carries the
+                // Pilotage camera rig) instead of spawning its own.
                 ("PX4_GZ_STANDALONE".to_owned(), "1".to_owned()),
                 ("PX4_SYS_AUTOSTART".to_owned(), SYS_AUTOSTART.to_owned()),
                 ("PX4_SIM_MODEL".to_owned(), "gz_x500".to_owned()),
+                ("PX4_GZ_MODEL_NAME".to_owned(), "x500_0".to_owned()),
                 ("PX4_GZ_WORLD".to_owned(), WORLD_NAME.to_owned()),
             ],
             remove_env: vec![],
@@ -279,13 +282,15 @@ mod tests {
         let (root, px4) = scaffold("complete");
         for file in [
             "build/px4_sitl_default/bin/px4",
-            "Tools/simulation/gz/worlds/default.sdf",
             "Tools/simulation/gz/server.config",
         ] {
             let path = px4.join(file);
             std::fs::create_dir_all(path.parent().expect("parent")).expect("dirs");
             std::fs::write(&path, b"x").expect("file");
         }
+        let world = root.join("sim/worlds/px4_flightdeck.sdf");
+        std::fs::create_dir_all(world.parent().expect("parent")).expect("dirs");
+        std::fs::write(&world, b"x").expect("world");
         let ctx = context(root.clone());
         let stages = plan_with_px4_dir(&ctx, &px4).expect("plan");
         assert_eq!(stages.len(), 2);
@@ -297,6 +302,12 @@ mod tests {
                 .iter()
                 .any(|(k, v)| k == "PX4_GZ_STANDALONE" && v == "1"),
             "px4 must attach to the xtask-owned gz server, not spawn its own"
+        );
+        assert!(
+            fc_env
+                .iter()
+                .any(|(k, v)| k == "PX4_GZ_MODEL_NAME" && v == "x500_0"),
+            "px4 must attach to the world's rig-bearing model, not spawn one"
         );
         assert!(
             stages[0]

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -33,14 +33,16 @@ impl SimBackend for Px4Gz {
     }
 
     fn host_env(&self, _ctx: &SessionContext) -> Vec<(String, String)> {
-        vec![("GZ_IP".to_owned(), "127.0.0.1".to_owned())]
+        vec![
+            ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
+            ("PILOTAGE_PX4_PROFILE".to_owned(), "simulation".to_owned()),
+        ]
     }
 
     fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {
-        // The PX4 adapter implements only the simulation profile; the
-        // host would silently ignore any other selection, so refuse it
-        // here instead of launching a session that lies about its
-        // policy.
+        // The PX4 adapter implements only the simulation profile. Keep
+        // the launcher boundary aligned with the host boundary so no
+        // unsupported session reaches process startup.
         if ctx.profile != Profile::Simulation {
             return Err(XtaskError::Usage {
                 message: format!(
@@ -246,8 +248,8 @@ fn px4_stage(
 mod tests {
     use std::path::PathBuf;
 
-    use super::plan_with_px4_dir;
-    use crate::backend::SessionContext;
+    use super::{Px4Gz, plan_with_px4_dir};
+    use crate::backend::{SessionContext, SimBackend};
     use crate::cli::Profile;
     use crate::error::XtaskError;
 
@@ -266,6 +268,32 @@ mod tests {
         let px4 = root.join("PX4-Autopilot");
         std::fs::create_dir_all(&px4).expect("scaffold");
         (root, px4)
+    }
+
+    #[test]
+    fn plan_refuses_physical_and_oracle_only_profiles() {
+        let backend = Px4Gz;
+        for profile in [Profile::Physical, Profile::OracleOnly] {
+            let mut ctx = context(PathBuf::from("unused-for-profile-refusal"));
+            ctx.profile = profile;
+            let refusal = backend.plan(&ctx);
+            assert!(
+                matches!(refusal, Err(XtaskError::Usage { .. })),
+                "{profile:?} must be refused, got {refusal:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn host_environment_declares_the_px4_simulation_profile() {
+        let backend = Px4Gz;
+        let ctx = context(PathBuf::from("unused-for-host-environment"));
+        assert!(
+            backend
+                .host_env(&ctx)
+                .iter()
+                .any(|(key, value)| { key == "PILOTAGE_PX4_PROFILE" && value == "simulation" })
+        );
     }
 
     #[test]

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -277,6 +277,38 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    // The two FC families keep separate worlds (their physics steps,
+    // vehicle models, and FC glue genuinely differ), but the flight
+    // deck must LOOK the same from the cameras: one green field, one
+    // sun, one rig. This pins the shared appearance so the two files
+    // cannot drift apart silently.
+    #[test]
+    fn both_flight_deck_worlds_share_the_same_look() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("repo root");
+        let aviate = std::fs::read_to_string(repo_root.join("sim/worlds/x500_flightdeck.sdf"))
+            .expect("aviate world");
+        let px4 = std::fs::read_to_string(repo_root.join("sim/worlds/px4_flightdeck.sdf"))
+            .expect("px4 world");
+        for invariant in [
+            "<ambient>0.3 0.5 0.3 1</ambient>",
+            "<size>100 100</size>",
+            "<direction>-0.5 0.1 -0.9</direction>",
+            "<magnetic_field>",
+            "<model name=\"x500_camera_rig\">",
+            "<topic>camera</topic>",
+            "<topic>chase_camera</topic>",
+        ] {
+            assert!(aviate.contains(invariant), "aviate world lost {invariant}");
+            assert!(px4.contains(invariant), "px4 world lost {invariant}");
+        }
+        // The default sky is part of the look: neither world may
+        // override the scene with a gray background.
+        assert!(!aviate.contains("<scene>") && !px4.contains("<scene>"));
+    }
+
     #[test]
     fn a_complete_checkout_plans_gz_then_px4_standalone() {
         let (root, px4) = scaffold("complete");

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -158,7 +158,7 @@ cargo xtask <command>
 commands:
   sim    launch a full SITL session (simulator + FC + host + viewer),
          print the ready URL, supervise, and tear down on ctrl-c
-         --fc <name>          FC backend (default: aviate)
+         --fc <name>          FC backend: aviate-gz (alias aviate), px4-gz (alias px4)
          --profile <p>        physical | simulation (default) | oracle-only
          --port <n>           host WebTransport port (default: 4433)
          --viewer-port <n>    static viewer port (default: 8080)

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -214,6 +214,27 @@ mod tests {
     }
 
     #[test]
+    fn reset_fc_selection_parses_and_malformed_flags_fail_closed() {
+        assert_eq!(
+            parse_args(&args(&["reset"])).expect("default reset parses"),
+            Command::Reset("aviate".to_owned())
+        );
+        assert_eq!(
+            parse_args(&args(&["reset", "--fc", "px4-gz"])).expect("explicit PX4 reset parses"),
+            Command::Reset("px4-gz".to_owned())
+        );
+        for malformed in [
+            args(&["reset", "--fc"]),
+            args(&["reset", "--backend", "px4-gz"]),
+        ] {
+            assert!(matches!(
+                parse_args(&malformed),
+                Err(XtaskError::Usage { .. })
+            ));
+        }
+    }
+
+    #[test]
     fn sim_flags_parse_and_unknown_values_fail_closed() {
         let Command::Sim(sim) = parse_args(&args(&[
             "sim",

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -57,8 +57,8 @@ pub struct SimArgs {
 pub enum Command {
     /// Launch a full SITL session and supervise it.
     Sim(SimArgs),
-    /// Reset the running simulation world and FC.
-    Reset,
+    /// Reset the running simulation world and FC of the named backend.
+    Reset(String),
     /// Print usage.
     Help,
 }
@@ -76,19 +76,35 @@ pub fn parse_args(args: &[String]) -> Result<Command, XtaskError> {
     };
     match command.as_str() {
         "sim" => Ok(Command::Sim(parse_sim(rest)?)),
-        "reset" => {
-            if let Some(extra) = rest.first() {
-                return Err(XtaskError::Usage {
-                    message: format!("reset takes no arguments (got {extra:?})"),
-                });
-            }
-            Ok(Command::Reset)
-        }
+        "reset" => Ok(Command::Reset(parse_reset(rest)?)),
         "help" | "--help" | "-h" => Ok(Command::Help),
         other => Err(XtaskError::Usage {
             message: format!("unknown command {other:?} (expected sim, reset, or help)"),
         }),
     }
+}
+
+fn parse_reset(args: &[String]) -> Result<String, XtaskError> {
+    let mut fc = "aviate".to_owned();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--fc" => {
+                fc = iter
+                    .next()
+                    .ok_or_else(|| XtaskError::Usage {
+                        message: "--fc requires a value".to_owned(),
+                    })?
+                    .clone();
+            }
+            other => {
+                return Err(XtaskError::Usage {
+                    message: format!("unknown reset argument {other:?} (expected --fc <name>)"),
+                });
+            }
+        }
+    }
+    Ok(fc)
 }
 
 fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
@@ -159,6 +175,7 @@ commands:
   sim    launch a full SITL session (simulator + FC + host + viewer),
          print the ready URL, supervise, and tear down on ctrl-c
          --fc <name>          FC backend: aviate-gz (alias aviate), px4-gz (alias px4)
+    reset [--fc <name>]      reset the named backend's world and FC (default aviate)
          --profile <p>        physical | simulation (default) | oracle-only
          --port <n>           host WebTransport port (default: 4433)
          --viewer-port <n>    static viewer port (default: 8080)

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -36,7 +36,7 @@ fn run(args: &[String]) -> Result<(), error::XtaskError> {
             print_line(cli::USAGE);
             Ok(())
         }
-        Command::Reset => session::run_reset("aviate"),
+        Command::Reset(fc) => session::run_reset(&fc),
         Command::Sim(sim) => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()


### PR DESCRIPTION
Closes #159 (child of #96). xtask owns PX4/Gazebo orchestration: it launches the gz server with the Pilotage flight-deck world, runs PX4 in standalone attach mode against the rig-bearing model, and keeps the FC under the same supervised stage lifecycle used by Aviate. Backend names pair FC and simulator (`aviate-gz` / `px4-gz`, with bare aliases) so additional PX4 dynamics backends remain separate.

Safety and regression guardrails:
- `Px4Gz::plan` refuses physical and oracle-only profiles before artifact or process startup, with direct tests for both refusals.
- The host stage explicitly supplies `PILOTAGE_PX4_PROFILE=simulation`, satisfying the typed boundary merged in #154.
- `cargo xtask reset [--fc <backend>]` is backend-aware and has success plus malformed-argument parsing tests.
- Reset process matching is scoped to this checkout's SITL binary; the unsupervised fallback retains the attach name.
- The FPV camera rig is positioned above the airframe.

The reset remains process-kill based for the current single-session SITL milestone. #110 remains open to replace that mechanism with typed, session-scoped simulator lifecycle control.