### PR TITLE
Worlds: shared 500 m scenery model for every FC family

### DIFF
--- a/sim/models/flightdeck_scenery/model.config
+++ b/sim/models/flightdeck_scenery/model.config
@@ -6,7 +6,7 @@
   <description>
     The shared Pilotage flight-deck scenery: one green field for every
     FC family's world, so the cameras see the same place regardless of
-    which flight controller is flying. Future shared props (pads,
-    markers, moving objects) belong here, never in a per-FC world.
+    which flight controller is flying. Future shared static props
+    (pads and markers) belong here, never in a per-FC world.
   </description>
 </model>

--- a/sim/models/flightdeck_scenery/model.config
+++ b/sim/models/flightdeck_scenery/model.config
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<model>
+  <name>flightdeck_scenery</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+  <description>
+    The shared Pilotage flight-deck scenery: one green field for every
+    FC family's world, so the cameras see the same place regardless of
+    which flight controller is flying. Future shared props (pads,
+    markers, moving objects) belong here, never in a per-FC world.
+  </description>
+</model>

--- a/sim/models/flightdeck_scenery/model.sdf
+++ b/sim/models/flightdeck_scenery/model.sdf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+  <model name="flightdeck_scenery">
+    <static>true</static>
+    <link name="ground">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>500 500</size>
+          </plane>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>500 500</size>
+          </plane>
+        </geometry>
+        <material>
+          <ambient>0.3 0.5 0.3 1</ambient>
+          <diffuse>0.3 0.5 0.3 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/sim/worlds/px4_flightdeck.sdf
+++ b/sim/worlds/px4_flightdeck.sdf
@@ -12,55 +12,12 @@
     <gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     <atmosphere type="adiabatic"/>
-    <model name="ground_plane">
-      <static>true</static>
-      <link name="link">
-        <collision name="collision">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-          <surface>
-            <friction>
-              <ode/>
-            </friction>
-            <bounce/>
-            <contact/>
-          </surface>
-        </collision>
-        <visual name="visual">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-          <material>
-            <ambient>0.3 0.5 0.3 1</ambient>
-            <diffuse>0.3 0.5 0.3 1</diffuse>
-            <specular>0.1 0.1 0.1 1</specular>
-          </material>
-        </visual>
-        <pose>0 0 0 0 -0 0</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>1</mass>
-          <inertia>
-            <ixx>1</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>1</iyy>
-            <iyz>0</iyz>
-            <izz>1</izz>
-          </inertia>
-        </inertial>
-        <enable_wind>false</enable_wind>
-      </link>
-      <pose>0 0 0 0 -0 0</pose>
-      <self_collide>false</self_collide>
-    </model>
+    <!-- Shared Pilotage scenery: the same field for every FC family
+         (sim/models/flightdeck_scenery). Per-FC worlds carry only
+         physics, environment, the vehicle, and FC glue. -->
+    <include>
+      <uri>model://flightdeck_scenery</uri>
+    </include>
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>

--- a/sim/worlds/x500_flightdeck.sdf
+++ b/sim/worlds/x500_flightdeck.sdf
@@ -74,33 +74,12 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
-    <!-- Ground plane -->
-    <model name="ground_plane">
-      <static>true</static>
-      <link name="link">
-        <collision name="collision">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-        </collision>
-        <visual name="visual">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-          <material>
-            <ambient>0.3 0.5 0.3 1</ambient>
-            <diffuse>0.3 0.5 0.3 1</diffuse>
-            <specular>0.1 0.1 0.1 1</specular>
-          </material>
-        </visual>
-      </link>
-    </model>
+    <!-- Shared Pilotage scenery: the same field for every FC family
+         (sim/models/flightdeck_scenery). Per-FC worlds carry only
+         physics, environment, the vehicle, and FC glue. -->
+    <include>
+      <uri>model://flightdeck_scenery</uri>
+    </include>
 
     <!-- Vehicle: x500 (instance 0) -->
     <include>

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -141,9 +141,10 @@ fn gz_stage(ctx: &SessionContext, aviate: &Path, path: &str, world: &Path) -> St
         (
             "GZ_SIM_RESOURCE_PATH".to_owned(),
             format!(
-                "{}:{}",
+                "{}:{}:{}",
                 models.display(),
-                ctx.repo_root.join("sim/worlds").display()
+                ctx.repo_root.join("sim/worlds").display(),
+                ctx.repo_root.join("sim/models").display()
             ),
         ),
     ];

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -160,8 +160,9 @@ fn gz_stage(
         (
             "GZ_SIM_RESOURCE_PATH".to_owned(),
             format!(
-                "{}:{}:{}",
+                "{}:{}:{}:{}",
                 ctx.repo_root.join("sim/worlds").display(),
+                ctx.repo_root.join("sim/models").display(),
                 px4.join("Tools/simulation/gz/worlds").display(),
                 px4.join("Tools/simulation/gz/models").display()
             ),
@@ -337,8 +338,7 @@ mod tests {
         let px4 = std::fs::read_to_string(repo_root.join("sim/worlds/px4_flightdeck.sdf"))
             .expect("px4 world");
         for invariant in [
-            "<ambient>0.3 0.5 0.3 1</ambient>",
-            "<size>100 100</size>",
+            "<uri>model://flightdeck_scenery</uri>",
             "<direction>-0.5 0.1 -0.9</direction>",
             "<magnetic_field>",
             "<model name=\"x500_camera_rig\">",
@@ -348,6 +348,15 @@ mod tests {
             assert!(aviate.contains(invariant), "aviate world lost {invariant}");
             assert!(px4.contains(invariant), "px4 world lost {invariant}");
         }
+        // Neither world may carry its own ground: the field lives in
+        // the ONE shared scenery model (green, 500 m) so future props
+        // appear for every FC family at once.
+        assert!(!aviate.contains("ground_plane") && !px4.contains("ground_plane"));
+        let scenery =
+            std::fs::read_to_string(repo_root.join("sim/models/flightdeck_scenery/model.sdf"))
+                .expect("scenery model");
+        assert!(scenery.contains("<ambient>0.3 0.5 0.3 1</ambient>"));
+        assert!(scenery.contains("<size>500 500</size>"));
         // The default sky is part of the look: neither world may
         // override the scene with a gray background.
         assert!(!aviate.contains("<scene>") && !px4.contains("<scene>"));


### PR DESCRIPTION
Scenery-only; disarm redesign remains split into #160. The field moves out of the per-FC world files into one shared static model, `sim/models/flightdeck_scenery`: a 500 m green plane included by both worlds, where future static props such as pads and markers appear for every FC family at once. Moving actors remain outside this static model and require their own dynamic models.

Per-FC worlds retain only what genuinely differs: physics, environment, vehicle, and FC glue. Both backends add the repository model path to Gazebo's resource path, and the look-parity test pins the shared include plus the scenery field so the two decks cannot silently diverge.

Rebased onto the merged #154/#155 stack.