### PR TITLE
Link: PX4-dialect capabilities for the shared MAVLink crate

### DIFF
--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -308,6 +308,32 @@ pub fn encode_arm_command(seq: u8, arm: bool, target_system: u8, target_componen
     frame
 }
 
+/// Serializes an arbitrary COMMAND_LONG frame (mode changes, message
+/// interval requests, and any other MAV_CMD the arm helper does not
+/// cover) for the selected MAVLink system and component.
+///
+/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
+/// target_system @30, target_component @31, confirmation @32.
+pub fn encode_command_long(
+    seq: u8,
+    command: u16,
+    params: [f32; 7],
+    target_system: u8,
+    target_component: u8,
+) -> [u8; 45] {
+    let mut payload = [0u8; 33];
+    for (index, param) in params.iter().enumerate() {
+        let at = index * 4;
+        payload[at..at + 4].copy_from_slice(&param.to_le_bytes());
+    }
+    payload[28..30].copy_from_slice(&command.to_le_bytes());
+    payload[30] = target_system;
+    payload[31] = target_component;
+    let mut frame = [0u8; 45];
+    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
+    frame
+}
+
 /// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
 /// velocity plus absolute yaw, everything else masked out
 /// (`type_mask` ignores position, acceleration, and yaw rate — the

--- a/crates/pilotage-mavlink/src/lib.rs
+++ b/crates/pilotage-mavlink/src/lib.rs
@@ -15,5 +15,6 @@ pub mod link;
 
 pub use codec::{FcMessage, FrameSource, ParseStats, parse_datagram};
 pub use link::{
-    AttitudeUpdate, KinematicsUpdate, LinkConfig, LinkError, LinkState, MavlinkLink, ResetPolicy,
+    AttitudeUpdate, AuthorizationSource, KinematicsUpdate, LinkConfig, LinkError, LinkState,
+    MavlinkLink, ResetPolicy,
 };

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -38,6 +38,9 @@ pub enum AuthorizationSource {
     StandardEstimatorStatus,
 }
 
+/// MAV_CMD_SET_MESSAGE_INTERVAL.
+const SET_MESSAGE_INTERVAL: u16 = 511;
+
 /// Whether an unstamped MAVLink boot-clock regression may use the simulator
 /// reset heuristic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -72,6 +75,14 @@ pub struct LinkConfig {
     /// time: a rebooted FC whose clock is already above this ceiling is
     /// rejected as reordered forever instead of starting a new epoch.
     pub reset_candidate_max_ms: u32,
+    /// Where periodic message-interval requests are sent, when the
+    /// source needs them (PX4's GCS instance streams sparse defaults).
+    /// They MUST originate from the link's own socket: the instance
+    /// retargets its stream to whichever peer last spoke to it, so a
+    /// request from any other socket steals the stream.
+    pub stream_command_target: Option<SocketAddr>,
+    /// (message id, interval µs) pairs requested at the heartbeat tick.
+    pub stream_interval_requests: &'static [(u32, u32)],
     /// Largest source-clock lag admitted when a second measurement group
     /// first joins or advances behind the epoch high-water mark.
     ///
@@ -95,6 +106,8 @@ impl Default for LinkConfig {
             reset_policy: ResetPolicy::Conservative,
             authorization_source: AuthorizationSource::AviatePrivate,
             reset_candidate_max_ms: measurement::DEFAULT_RESET_CANDIDATE_MAX_MS,
+            stream_command_target: None,
+            stream_interval_requests: &[],
             maximum_inter_group_skew_ms: 0,
         }
     }
@@ -321,12 +334,7 @@ impl MavlinkLink {
             config,
             source_incarnation,
         )));
-        let task = tokio::spawn(run_link(
-            socket,
-            config.endpoint,
-            router_mode,
-            state.clone(),
-        ));
+        let task = tokio::spawn(run_link(socket, config, router_mode, state.clone()));
         Ok(Self { state, task })
     }
 
@@ -344,10 +352,11 @@ impl Drop for MavlinkLink {
 
 async fn run_link(
     socket: UdpSocket,
-    endpoint: SocketAddr,
+    config: LinkConfig,
     router_mode: bool,
     state: Arc<Mutex<LinkState>>,
 ) {
+    let endpoint = config.endpoint;
     let mut buf = vec![0u8; 2048];
     let mut messages = Vec::with_capacity(8);
     let mut heartbeat = tokio::time::interval(Duration::from_secs(1));
@@ -360,6 +369,21 @@ async fn run_link(
                     seq = seq.wrapping_add(1);
                     if let Err(error) = socket.send_to(&frame, endpoint).await {
                         warn!(%error, "GCS heartbeat send failed");
+                    }
+                }
+                if let Some(target) = config.stream_command_target {
+                    for &(message_id, interval_us) in config.stream_interval_requests {
+                        let frame = crate::codec::encode_command_long(
+                            seq,
+                            SET_MESSAGE_INTERVAL,
+                            [message_id as f32, interval_us as f32, 0.0, 0.0, 0.0, 0.0, 0.0],
+                            config.system_id,
+                            config.component_id,
+                        );
+                        seq = seq.wrapping_add(1);
+                        if let Err(error) = socket.send_to(&frame, target).await {
+                            warn!(%error, "stream interval request send failed");
+                        }
                     }
                 }
             }

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -70,6 +70,12 @@ pub struct LinkConfig {
     pub reset_policy: ResetPolicy,
     /// Which message carries estimator authorization for this source.
     pub authorization_source: AuthorizationSource,
+    /// Longest a standard-status authorization stays current for later
+    /// numeric groups (StandardEstimatorStatus only). Must cover the
+    /// configured status interval with margin, and must not exceed the
+    /// display's status-to-numeric pairing budget or the panels flag
+    /// samples this link still authorizes.
+    pub standard_status_max_lag_ms: u32,
     /// Ceiling on a low boot clock that may seed a simulator reset
     /// candidate. Must exceed the FC's worst-case boot-to-streaming
     /// time: a rebooted FC whose clock is already above this ceiling is
@@ -105,6 +111,7 @@ impl Default for LinkConfig {
             source_id: 1,
             reset_policy: ResetPolicy::Conservative,
             authorization_source: AuthorizationSource::AviatePrivate,
+            standard_status_max_lag_ms: estimator::DEFAULT_STANDARD_STATUS_MAX_LAG_MS,
             reset_candidate_max_ms: measurement::DEFAULT_RESET_CANDIDATE_MAX_MS,
             stream_command_target: None,
             stream_interval_requests: &[],
@@ -151,6 +158,8 @@ pub struct LinkState {
     pub reset_policy: ResetPolicy,
     /// Which message carries estimator authorization for this source.
     pub authorization_source: AuthorizationSource,
+    /// Configured standard-status authorization lag ceiling.
+    pub standard_status_max_lag_ms: u32,
     /// Configured ceiling on a reset-candidate boot clock.
     pub reset_candidate_max_ms: u32,
     /// Configured epoch-wide inter-group source-clock lag bound.
@@ -205,6 +214,7 @@ impl Default for LinkState {
             source_incarnation: SourceIncarnation::new([0; 16]),
             reset_policy: ResetPolicy::Conservative,
             authorization_source: AuthorizationSource::AviatePrivate,
+            standard_status_max_lag_ms: estimator::DEFAULT_STANDARD_STATUS_MAX_LAG_MS,
             reset_candidate_max_ms: measurement::DEFAULT_RESET_CANDIDATE_MAX_MS,
             maximum_inter_group_skew_ms: 0,
             attitude: None,
@@ -238,6 +248,7 @@ impl LinkState {
             source_incarnation,
             reset_policy: config.reset_policy,
             authorization_source: config.authorization_source,
+            standard_status_max_lag_ms: config.standard_status_max_lag_ms,
             reset_candidate_max_ms: config.reset_candidate_max_ms,
             maximum_inter_group_skew_ms: config.maximum_inter_group_skew_ms,
             source_epoch: 1,

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -14,21 +14,10 @@ use pilotage_adapter_api::{MeasurementStamp, SourceIncarnation};
 
 use crate::codec::{FcMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
 
-/// Why the MAVLink link could not start.
-#[derive(Debug, thiserror::Error)]
-pub enum LinkError {
-    /// Neither the direct MAVLink port nor an ephemeral fallback socket
-    /// could be bound.
-    #[error("binding a UDP socket for MAVLink telemetry failed: {source}")]
-    Bind {
-        /// The underlying socket error.
-        #[source]
-        source: std::io::Error,
-    },
-}
-
+mod error;
 pub mod estimator;
 pub mod measurement;
+pub use error::LinkError;
 use estimator::{
     EstimatorStatusUpdate, accept_status, authorization_at, invalidate_cached_authorization,
 };
@@ -78,6 +67,11 @@ pub struct LinkConfig {
     pub reset_policy: ResetPolicy,
     /// Which message carries estimator authorization for this source.
     pub authorization_source: AuthorizationSource,
+    /// Ceiling on a low boot clock that may seed a simulator reset
+    /// candidate. Must exceed the FC's worst-case boot-to-streaming
+    /// time: a rebooted FC whose clock is already above this ceiling is
+    /// rejected as reordered forever instead of starting a new epoch.
+    pub reset_candidate_max_ms: u32,
     /// Largest source-clock lag admitted when a second measurement group
     /// first joins or advances behind the epoch high-water mark.
     ///
@@ -100,6 +94,7 @@ impl Default for LinkConfig {
             source_id: 1,
             reset_policy: ResetPolicy::Conservative,
             authorization_source: AuthorizationSource::AviatePrivate,
+            reset_candidate_max_ms: measurement::DEFAULT_RESET_CANDIDATE_MAX_MS,
             maximum_inter_group_skew_ms: 0,
         }
     }
@@ -143,6 +138,8 @@ pub struct LinkState {
     pub reset_policy: ResetPolicy,
     /// Which message carries estimator authorization for this source.
     pub authorization_source: AuthorizationSource,
+    /// Configured ceiling on a reset-candidate boot clock.
+    pub reset_candidate_max_ms: u32,
     /// Configured epoch-wide inter-group source-clock lag bound.
     pub maximum_inter_group_skew_ms: u32,
     /// Latest attitude estimate: quaternion (w,x,y,z), body rates,
@@ -193,6 +190,7 @@ impl Default for LinkState {
             source_incarnation: SourceIncarnation::new([0; 16]),
             reset_policy: ResetPolicy::Conservative,
             authorization_source: AuthorizationSource::AviatePrivate,
+            reset_candidate_max_ms: measurement::DEFAULT_RESET_CANDIDATE_MAX_MS,
             maximum_inter_group_skew_ms: 0,
             attitude: None,
             kinematics: None,
@@ -224,6 +222,7 @@ impl LinkState {
             source_incarnation,
             reset_policy: config.reset_policy,
             authorization_source: config.authorization_source,
+            reset_candidate_max_ms: config.reset_candidate_max_ms,
             maximum_inter_group_skew_ms: config.maximum_inter_group_skew_ms,
             source_epoch: 1,
             ..Self::default()

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -12,16 +12,16 @@ use tracing::{debug, error, info, warn};
 
 use pilotage_adapter_api::{MeasurementStamp, SourceIncarnation};
 
-use crate::codec::{FcMessage, FrameSource, encode_gcs_heartbeat, parse_datagram};
+use crate::codec::{encode_gcs_heartbeat, parse_datagram};
 
+mod apply;
 mod error;
 pub mod estimator;
 pub mod measurement;
+use apply::apply_messages;
+pub use apply::apply_messages_at;
 pub use error::LinkError;
-use estimator::{
-    EstimatorStatusUpdate, accept_status, authorization_at, invalidate_cached_authorization,
-};
-use measurement::{next_attitude_stamp, next_kinematics_stamp};
+use estimator::EstimatorStatusUpdate;
 
 /// Which message carries the estimator authorization for cached numeric
 /// groups.
@@ -152,6 +152,8 @@ pub struct LinkState {
     pub estimator_status: Option<EstimatorStatusUpdate>,
     /// Receive stamp of the last FC heartbeat.
     pub last_heartbeat: Option<Instant>,
+    /// Whether the last FC heartbeat reported the vehicle armed.
+    pub heartbeat_armed: Option<bool>,
     /// Total decoded frames.
     pub decoded: u64,
     /// Total CRC failures (a correctness signal, logged).
@@ -196,6 +198,7 @@ impl Default for LinkState {
             kinematics: None,
             estimator_status: None,
             last_heartbeat: None,
+            heartbeat_armed: None,
             decoded: 0,
             crc_failures: 0,
             unknown_ids: 0,
@@ -385,101 +388,6 @@ async fn run_link(
                         warn!(%error, "MAVLink socket receive failed");
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
-                }
-            }
-        }
-    }
-}
-
-/// Folds decoded messages into the shared cache. Kept synchronous and
-/// lock-scoped: the lock is never held across an await.
-fn apply_messages(
-    state: &Arc<Mutex<LinkState>>,
-    messages: &[(FrameSource, FcMessage)],
-    crc_failures: u32,
-    unknown_ids: u32,
-) {
-    apply_messages_at(state, messages, crc_failures, unknown_ids, Instant::now());
-}
-
-/// Folds decoded messages into the shared cache at an explicit receive
-/// instant. Public so adapter crates can drive the cache in tests
-/// without a socket; production traffic arrives via the link task.
-pub fn apply_messages_at(
-    state: &Arc<Mutex<LinkState>>,
-    messages: &[(FrameSource, FcMessage)],
-    crc_failures: u32,
-    unknown_ids: u32,
-    now: Instant,
-) {
-    let Ok(mut latest) = state.lock() else {
-        return;
-    };
-    latest.crc_failures = latest.crc_failures.wrapping_add(u64::from(crc_failures));
-    latest.unknown_ids = latest.unknown_ids.wrapping_add(u64::from(unknown_ids));
-    for &(source, message) in messages {
-        if source.system_id != latest.system_id || source.component_id != latest.component_id {
-            latest.wrong_sources = latest.wrong_sources.wrapping_add(1);
-            continue;
-        }
-        if message == FcMessage::InvalidAviateEstimatorStatus {
-            latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
-            invalidate_cached_authorization(&mut latest);
-            continue;
-        }
-        latest.decoded = latest.decoded.wrapping_add(1);
-        match message {
-            FcMessage::InvalidAviateEstimatorStatus => {}
-            FcMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
-            FcMessage::CommandAck { .. } => {}
-            FcMessage::EstimatorStatus { time_usec, flags } => {
-                // Standard-status dialects authorize from msg 230; the
-                // Aviate dialect treats it as diagnostic only.
-                if latest.authorization_source == AuthorizationSource::StandardEstimatorStatus {
-                    let (valid_flags, quality) = estimator::standard_authorization(flags);
-                    let aligned_usec = (time_usec / 1_000) * 1_000;
-                    accept_status(&mut latest, aligned_usec, valid_flags, quality, now);
-                }
-            }
-            FcMessage::AviateEstimatorStatus {
-                time_usec,
-                valid_flags,
-                quality,
-            } => accept_status(&mut latest, time_usec, valid_flags, quality, now),
-            FcMessage::AttitudeQuaternion {
-                time_boot_ms,
-                quat_wxyz,
-                rates_rps,
-            } => {
-                if let Some(stamp) = next_attitude_stamp(&mut latest, time_boot_ms, now) {
-                    let authorization = authorization_at(&latest, time_boot_ms);
-                    latest.attitude = Some(AttitudeUpdate {
-                        quat_wxyz,
-                        rates_rps,
-                        time_boot_ms,
-                        stamp,
-                        valid_flags: authorization.valid_flags,
-                        quality: authorization.quality,
-                        received_at: now,
-                    });
-                }
-            }
-            FcMessage::LocalPositionNed {
-                time_boot_ms,
-                pos_ned_m,
-                vel_ned_mps,
-            } => {
-                if let Some(stamp) = next_kinematics_stamp(&mut latest, time_boot_ms, now) {
-                    let authorization = authorization_at(&latest, time_boot_ms);
-                    latest.kinematics = Some(KinematicsUpdate {
-                        pos_ned_m,
-                        vel_ned_mps,
-                        time_boot_ms,
-                        stamp,
-                        valid_flags: authorization.valid_flags,
-                        quality: authorization.quality,
-                        received_at: now,
-                    });
                 }
             }
         }

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -34,6 +34,21 @@ use estimator::{
 };
 use measurement::{next_attitude_stamp, next_kinematics_stamp};
 
+/// Which message carries the estimator authorization for cached numeric
+/// groups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AuthorizationSource {
+    /// Aviate's private lossless estimator status (msg 20000): the FC
+    /// emits a status for every numeric millisecond, so authorization
+    /// requires an exact source-time match.
+    #[default]
+    AviatePrivate,
+    /// The standard ESTIMATOR_STATUS (msg 230), as PX4 streams it: the
+    /// status arrives at its own (slower) rate, so a numeric group is
+    /// authorized by the most recent status within a bounded lag.
+    StandardEstimatorStatus,
+}
+
 /// Whether an unstamped MAVLink boot-clock regression may use the simulator
 /// reset heuristic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -61,6 +76,8 @@ pub struct LinkConfig {
     pub source_id: u64,
     /// Policy for a boot-clock regression without a source boot UUID.
     pub reset_policy: ResetPolicy,
+    /// Which message carries estimator authorization for this source.
+    pub authorization_source: AuthorizationSource,
     /// Largest source-clock lag admitted when a second measurement group
     /// first joins or advances behind the epoch high-water mark.
     ///
@@ -82,6 +99,7 @@ impl Default for LinkConfig {
             component_id: 1,
             source_id: 1,
             reset_policy: ResetPolicy::Conservative,
+            authorization_source: AuthorizationSource::AviatePrivate,
             maximum_inter_group_skew_ms: 0,
         }
     }
@@ -123,6 +141,8 @@ pub struct LinkState {
     pub source_incarnation: SourceIncarnation,
     /// Reset inference policy for this source.
     pub reset_policy: ResetPolicy,
+    /// Which message carries estimator authorization for this source.
+    pub authorization_source: AuthorizationSource,
     /// Configured epoch-wide inter-group source-clock lag bound.
     pub maximum_inter_group_skew_ms: u32,
     /// Latest attitude estimate: quaternion (w,x,y,z), body rates,
@@ -172,6 +192,7 @@ impl Default for LinkState {
             source_id: 1,
             source_incarnation: SourceIncarnation::new([0; 16]),
             reset_policy: ResetPolicy::Conservative,
+            authorization_source: AuthorizationSource::AviatePrivate,
             maximum_inter_group_skew_ms: 0,
             attitude: None,
             kinematics: None,
@@ -202,6 +223,7 @@ impl LinkState {
             source_id: config.source_id,
             source_incarnation,
             reset_policy: config.reset_policy,
+            authorization_source: config.authorization_source,
             maximum_inter_group_skew_ms: config.maximum_inter_group_skew_ms,
             source_epoch: 1,
             ..Self::default()
@@ -411,7 +433,15 @@ pub fn apply_messages_at(
             FcMessage::InvalidAviateEstimatorStatus => {}
             FcMessage::Heartbeat { .. } => latest.last_heartbeat = Some(now),
             FcMessage::CommandAck { .. } => {}
-            FcMessage::EstimatorStatus { .. } => {}
+            FcMessage::EstimatorStatus { time_usec, flags } => {
+                // Standard-status dialects authorize from msg 230; the
+                // Aviate dialect treats it as diagnostic only.
+                if latest.authorization_source == AuthorizationSource::StandardEstimatorStatus {
+                    let (valid_flags, quality) = estimator::standard_authorization(flags);
+                    let aligned_usec = (time_usec / 1_000) * 1_000;
+                    accept_status(&mut latest, aligned_usec, valid_flags, quality, now);
+                }
+            }
             FcMessage::AviateEstimatorStatus {
                 time_usec,
                 valid_flags,

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -1,0 +1,114 @@
+//! Folding decoded MAVLink messages into the shared link cache:
+//! source filtering, liveness, estimator authorization, and the
+//! measurement-group acquisition discipline.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use super::estimator::{accept_status, authorization_at, invalidate_cached_authorization};
+use super::measurement::{next_attitude_stamp, next_kinematics_stamp};
+use super::{AttitudeUpdate, AuthorizationSource, KinematicsUpdate, LinkState, estimator};
+use crate::codec::{FcMessage, FrameSource};
+
+/// Folds decoded messages into the shared cache. Kept synchronous and
+/// lock-scoped: the lock is never held across an await.
+pub(super) fn apply_messages(
+    state: &Arc<Mutex<LinkState>>,
+    messages: &[(FrameSource, FcMessage)],
+    crc_failures: u32,
+    unknown_ids: u32,
+) {
+    apply_messages_at(state, messages, crc_failures, unknown_ids, Instant::now());
+}
+
+/// Applies a standard ESTIMATOR_STATUS (msg 230): standard-status
+/// dialects authorize from it; the Aviate dialect treats it as
+/// diagnostic only.
+fn apply_standard_status(latest: &mut LinkState, time_usec: u64, flags: u16, now: Instant) {
+    if latest.authorization_source == AuthorizationSource::StandardEstimatorStatus {
+        let (valid_flags, quality) = estimator::standard_authorization(flags);
+        let aligned_usec = (time_usec / 1_000) * 1_000;
+        accept_status(latest, aligned_usec, valid_flags, quality, now);
+    }
+}
+
+/// Folds decoded messages into the shared cache at an explicit receive
+/// instant. Public so adapter crates can drive the cache in tests
+/// without a socket; production traffic arrives via the link task.
+pub fn apply_messages_at(
+    state: &Arc<Mutex<LinkState>>,
+    messages: &[(FrameSource, FcMessage)],
+    crc_failures: u32,
+    unknown_ids: u32,
+    now: Instant,
+) {
+    let Ok(mut latest) = state.lock() else {
+        return;
+    };
+    latest.crc_failures = latest.crc_failures.wrapping_add(u64::from(crc_failures));
+    latest.unknown_ids = latest.unknown_ids.wrapping_add(u64::from(unknown_ids));
+    for &(source, message) in messages {
+        if source.system_id != latest.system_id || source.component_id != latest.component_id {
+            latest.wrong_sources = latest.wrong_sources.wrapping_add(1);
+            continue;
+        }
+        if message == FcMessage::InvalidAviateEstimatorStatus {
+            latest.invalid_estimator_statuses = latest.invalid_estimator_statuses.wrapping_add(1);
+            invalidate_cached_authorization(&mut latest);
+            continue;
+        }
+        latest.decoded = latest.decoded.wrapping_add(1);
+        match message {
+            FcMessage::InvalidAviateEstimatorStatus => {}
+            FcMessage::Heartbeat { armed } => {
+                latest.last_heartbeat = Some(now);
+                latest.heartbeat_armed = Some(armed);
+            }
+            FcMessage::CommandAck { .. } => {}
+            FcMessage::EstimatorStatus { time_usec, flags } => {
+                apply_standard_status(&mut latest, time_usec, flags, now);
+            }
+            FcMessage::AviateEstimatorStatus {
+                time_usec,
+                valid_flags,
+                quality,
+            } => accept_status(&mut latest, time_usec, valid_flags, quality, now),
+            FcMessage::AttitudeQuaternion {
+                time_boot_ms,
+                quat_wxyz,
+                rates_rps,
+            } => {
+                if let Some(stamp) = next_attitude_stamp(&mut latest, time_boot_ms, now) {
+                    let authorization = authorization_at(&latest, time_boot_ms);
+                    latest.attitude = Some(AttitudeUpdate {
+                        quat_wxyz,
+                        rates_rps,
+                        time_boot_ms,
+                        stamp,
+                        valid_flags: authorization.valid_flags,
+                        quality: authorization.quality,
+                        received_at: now,
+                    });
+                }
+            }
+            FcMessage::LocalPositionNed {
+                time_boot_ms,
+                pos_ned_m,
+                vel_ned_mps,
+            } => {
+                if let Some(stamp) = next_kinematics_stamp(&mut latest, time_boot_ms, now) {
+                    let authorization = authorization_at(&latest, time_boot_ms);
+                    latest.kinematics = Some(KinematicsUpdate {
+                        pos_ned_m,
+                        vel_ned_mps,
+                        time_boot_ms,
+                        stamp,
+                        valid_flags: authorization.valid_flags,
+                        quality: authorization.quality,
+                        received_at: now,
+                    });
+                }
+            }
+        }
+    }
+}

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -32,6 +32,15 @@ fn apply_standard_status(latest: &mut LinkState, time_usec: u64, flags: u16, now
     }
 }
 
+/// MAV_RESULT_ACCEPTED = 0. A refused command must be loud: a denied
+/// disarm or mode change looks exactly like an unresponsive vehicle
+/// otherwise.
+fn note_command_ack(command: u16, result: u8) {
+    if result != 0 {
+        tracing::warn!(command, result, "FC refused a command");
+    }
+}
+
 /// Folds decoded messages into the shared cache at an explicit receive
 /// instant. Public so adapter crates can drive the cache in tests
 /// without a socket; production traffic arrives via the link task.
@@ -64,7 +73,7 @@ pub fn apply_messages_at(
                 latest.last_heartbeat = Some(now);
                 latest.heartbeat_armed = Some(armed);
             }
-            FcMessage::CommandAck { .. } => {}
+            FcMessage::CommandAck { command, result } => note_command_ack(command, result),
             FcMessage::EstimatorStatus { time_usec, flags } => {
                 apply_standard_status(&mut latest, time_usec, flags, now);
             }

--- a/crates/pilotage-mavlink/src/link/error.rs
+++ b/crates/pilotage-mavlink/src/link/error.rs
@@ -1,0 +1,14 @@
+//! Why the MAVLink link could not start.
+
+/// Why the MAVLink link could not start.
+#[derive(Debug, thiserror::Error)]
+pub enum LinkError {
+    /// Neither the direct MAVLink port nor an ephemeral fallback socket
+    /// could be bound.
+    #[error("binding a UDP socket for MAVLink telemetry failed: {source}")]
+    Bind {
+        /// The underlying socket error.
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/crates/pilotage-mavlink/src/link/estimator.rs
+++ b/crates/pilotage-mavlink/src/link/estimator.rs
@@ -115,17 +115,76 @@ fn fail_closed_out_of_range_status(latest: &mut LinkState) {
     invalidate_cached_authorization(latest);
 }
 
+/// Longest a standard-status authorization stays current for later
+/// numeric groups. PX4 streams ESTIMATOR_STATUS at its own (slower)
+/// rate; beyond this lag the numeric group flies unauthorized and
+/// fails closed.
+const MAX_STANDARD_STATUS_LAG_MS: u32 = 2_000;
+
 pub(super) fn authorization_at(latest: &LinkState, time_boot_ms: u32) -> EstimatorAuthorization {
-    let time_usec = u64::from(time_boot_ms).saturating_mul(1_000);
-    latest
-        .estimator_status
-        .map_or_else(EstimatorAuthorization::fail_closed, |status| {
+    let Some(status) = latest.estimator_status else {
+        return EstimatorAuthorization::fail_closed();
+    };
+    match latest.authorization_source {
+        // Aviate emits a status for every numeric millisecond:
+        // authorization requires the exact pair.
+        super::AuthorizationSource::AviatePrivate => {
+            let time_usec = u64::from(time_boot_ms).saturating_mul(1_000);
             if status.time_usec == time_usec {
                 status.authorization
             } else {
                 EstimatorAuthorization::fail_closed()
             }
-        })
+        }
+        // Standard-status dialects authorize from the most recent
+        // report within a bounded lag. The wrapping distance keeps the
+        // comparison correct across a boot-clock wrap: a status AHEAD
+        // of the numeric (distance in the upper half) is also current.
+        super::AuthorizationSource::StandardEstimatorStatus => {
+            let distance = time_boot_ms.wrapping_sub(status.time_boot_ms);
+            if distance <= MAX_STANDARD_STATUS_LAG_MS || distance > u32::MAX / 2 {
+                status.authorization
+            } else {
+                EstimatorAuthorization::fail_closed()
+            }
+        }
+    }
+}
+
+/// Maps standard ESTIMATOR_STATUS (msg 230) flags onto this crate's
+/// wire authorization vocabulary: bit 0 (attitude) grants attitude and
+/// rates, horizontal+vertical position bits grant position, and
+/// horizontal+vertical velocity bits grant velocity. Wire quality is
+/// GOOD (2) with attitude, position, and velocity all present,
+/// DEGRADED (1) with attitude alone, otherwise UNUSABLE (0).
+pub(super) fn standard_authorization(flags: u16) -> (u8, u8) {
+    const ATTITUDE: u16 = 1;
+    const VELOCITY_HORIZ: u16 = 2;
+    const VELOCITY_VERT: u16 = 4;
+    const POS_HORIZ_REL: u16 = 8;
+    const POS_HORIZ_ABS: u16 = 16;
+    const POS_VERT_ABS: u16 = 32;
+    let attitude = flags & ATTITUDE != 0;
+    let position = flags & (POS_HORIZ_REL | POS_HORIZ_ABS) != 0 && flags & POS_VERT_ABS != 0;
+    let velocity = flags & VELOCITY_HORIZ != 0 && flags & VELOCITY_VERT != 0;
+    let mut valid: u8 = 0;
+    if attitude {
+        valid |= 0b0011;
+    }
+    if position {
+        valid |= 0b0100;
+    }
+    if velocity {
+        valid |= 0b1000;
+    }
+    let quality = if attitude && position && velocity {
+        2
+    } else if attitude {
+        1
+    } else {
+        0
+    };
+    (valid, quality)
 }
 
 fn degrade_cached_groups(latest: &mut LinkState, status: EstimatorAuthorization) {

--- a/crates/pilotage-mavlink/src/link/estimator.rs
+++ b/crates/pilotage-mavlink/src/link/estimator.rs
@@ -115,11 +115,10 @@ fn fail_closed_out_of_range_status(latest: &mut LinkState) {
     invalidate_cached_authorization(latest);
 }
 
-/// Longest a standard-status authorization stays current for later
-/// numeric groups. PX4 streams ESTIMATOR_STATUS at its own (slower)
-/// rate; beyond this lag the numeric group flies unauthorized and
-/// fails closed.
-const MAX_STANDARD_STATUS_LAG_MS: u32 = 2_000;
+/// Default ceiling on how long a standard-status authorization stays
+/// current for later numeric groups; a deployment must configure a
+/// budget derived from its actual status rate.
+pub const DEFAULT_STANDARD_STATUS_MAX_LAG_MS: u32 = 2_000;
 
 pub(super) fn authorization_at(latest: &LinkState, time_boot_ms: u32) -> EstimatorAuthorization {
     let Some(status) = latest.estimator_status else {
@@ -142,7 +141,7 @@ pub(super) fn authorization_at(latest: &LinkState, time_boot_ms: u32) -> Estimat
         // of the numeric (distance in the upper half) is also current.
         super::AuthorizationSource::StandardEstimatorStatus => {
             let distance = time_boot_ms.wrapping_sub(status.time_boot_ms);
-            if distance <= MAX_STANDARD_STATUS_LAG_MS || distance > u32::MAX / 2 {
+            if distance <= latest.standard_status_max_lag_ms || distance > u32::MAX / 2 {
                 status.authorization
             } else {
                 EstimatorAuthorization::fail_closed()

--- a/crates/pilotage-mavlink/src/link/estimator/tests.rs
+++ b/crates/pilotage-mavlink/src/link/estimator/tests.rs
@@ -429,3 +429,5 @@ fn same_timestamp_unknown_quality_revokes_the_cached_pair() {
     );
     assert_eq!(latest.invalid_estimator_statuses, 1);
 }
+
+mod standard_status;

--- a/crates/pilotage-mavlink/src/link/estimator/tests/standard_status.rs
+++ b/crates/pilotage-mavlink/src/link/estimator/tests/standard_status.rs
@@ -84,3 +84,63 @@ fn aviate_dialect_never_authorizes_from_the_standard_status() {
     assert_eq!((att.valid_flags, att.quality), (0, QUALITY_UNUSABLE));
     assert!(latest.estimator_status.is_none());
 }
+
+#[test]
+fn standard_status_lag_is_authorized_exactly_at_the_configured_ceiling() {
+    let state = standard_state();
+    apply(&state, &[standard_status(1_000_000, 1 | 2 | 4 | 8 | 32)]);
+    // Default ceiling: authorized at exactly the limit...
+    apply(
+        &state,
+        &[attitude(
+            1_000 + super::super::DEFAULT_STANDARD_STATUS_MAX_LAG_MS,
+        )],
+    );
+    {
+        let latest = state.lock().expect("lock");
+        let att = latest.attitude.expect("attitude");
+        assert_eq!(att.quality, QUALITY_GOOD, "lag == ceiling authorizes");
+    }
+    // ...and fails closed one millisecond past it.
+    apply(
+        &state,
+        &[attitude(
+            1_001 + super::super::DEFAULT_STANDARD_STATUS_MAX_LAG_MS,
+        )],
+    );
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("attitude");
+    assert_eq!(
+        (att.valid_flags, att.quality),
+        (0, QUALITY_UNUSABLE),
+        "lag == ceiling + 1 fails closed"
+    );
+}
+
+#[test]
+fn a_deployment_configured_ceiling_governs_authorization() {
+    let state = Arc::new(Mutex::new(LinkState {
+        authorization_source: crate::AuthorizationSource::StandardEstimatorStatus,
+        standard_status_max_lag_ms: 300,
+        maximum_inter_group_skew_ms: 300,
+        ..LinkState::default()
+    }));
+    apply(&state, &[standard_status(1_000_000, 1 | 2 | 4 | 8 | 32)]);
+    apply(&state, &[attitude(1_300)]);
+    {
+        let latest = state.lock().expect("lock");
+        assert_eq!(
+            latest.attitude.expect("attitude").quality,
+            QUALITY_GOOD,
+            "within the configured 300 ms ceiling"
+        );
+    }
+    apply(&state, &[attitude(1_301)]);
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("attitude");
+    assert_eq!(
+        (att.valid_flags, att.quality),
+        (0, QUALITY_UNUSABLE),
+        "past the configured ceiling fails closed"
+    );
+}

--- a/crates/pilotage-mavlink/src/link/estimator/tests/standard_status.rs
+++ b/crates/pilotage-mavlink/src/link/estimator/tests/standard_status.rs
@@ -1,0 +1,86 @@
+//! Authorization from the standard ESTIMATOR_STATUS (msg 230): the
+//! bounded-lag grant, the degraded attitude-only case, and the Aviate
+//! dialect's refusal to authorize from it.
+
+use std::sync::{Arc, Mutex};
+
+use crate::codec::FcMessage;
+use crate::link::LinkState;
+
+use super::{QUALITY_DEGRADED, QUALITY_GOOD, QUALITY_UNUSABLE, apply, attitude, kinematics, state};
+
+fn standard_state() -> Arc<Mutex<LinkState>> {
+    Arc::new(Mutex::new(LinkState {
+        authorization_source: crate::AuthorizationSource::StandardEstimatorStatus,
+        maximum_inter_group_skew_ms: 300,
+        ..LinkState::default()
+    }))
+}
+
+fn standard_status(time_usec: u64, flags: u16) -> FcMessage {
+    FcMessage::EstimatorStatus { time_usec, flags }
+}
+
+#[test]
+fn standard_status_authorizes_numerics_within_bounded_lag() {
+    let state = standard_state();
+    // Attitude + both velocity bits + relative-horizontal and vertical
+    // position: full authorization.
+    apply(&state, &[standard_status(1_000_000, 1 | 2 | 4 | 8 | 32)]);
+    apply(&state, &[attitude(2_500), kinematics(2_500)]);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(
+        (
+            latest.attitude.expect("attitude").valid_flags,
+            latest.attitude.expect("attitude").quality
+        ),
+        (0b1111, QUALITY_GOOD)
+    );
+    assert_eq!(
+        (
+            latest.kinematics.expect("kinematics").valid_flags,
+            latest.kinematics.expect("kinematics").quality
+        ),
+        (0b1111, QUALITY_GOOD)
+    );
+}
+
+#[test]
+fn standard_status_beyond_the_lag_bound_fails_closed() {
+    let state = standard_state();
+    apply(&state, &[standard_status(1_000_000, 1 | 2 | 4 | 8 | 32)]);
+    apply(&state, &[attitude(3_500)]);
+
+    let latest = state.lock().expect("lock");
+    assert_eq!(
+        (
+            latest.attitude.expect("attitude").valid_flags,
+            latest.attitude.expect("attitude").quality
+        ),
+        (0, QUALITY_UNUSABLE)
+    );
+}
+
+#[test]
+fn standard_status_attitude_only_is_degraded() {
+    let state = standard_state();
+    apply(&state, &[standard_status(1_000_000, 1)]);
+    apply(&state, &[attitude(1_200)]);
+
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("attitude");
+    assert_eq!((att.valid_flags, att.quality), (0b0011, QUALITY_DEGRADED));
+}
+
+#[test]
+fn aviate_dialect_never_authorizes_from_the_standard_status() {
+    let state = state();
+    apply(&state, &[standard_status(1_000_000, 0xff)]);
+    apply(&state, &[attitude(1_000)]);
+
+    let latest = state.lock().expect("lock");
+    let att = latest.attitude.expect("attitude");
+    assert_eq!((att.valid_flags, att.quality), (0, QUALITY_UNUSABLE));
+    assert!(latest.estimator_status.is_none());
+}

--- a/crates/pilotage-mavlink/src/link/measurement.rs
+++ b/crates/pilotage-mavlink/src/link/measurement.rs
@@ -7,7 +7,8 @@ use tracing::warn;
 
 use super::{LinkState, ResetPolicy};
 
-const RESET_CANDIDATE_MAX_MS: u32 = 5_000;
+/// Default ceiling on a low boot clock that may seed a reset candidate.
+pub(super) const DEFAULT_RESET_CANDIDATE_MAX_MS: u32 = 5_000;
 pub(super) const RESET_SILENCE: Duration = Duration::from_secs(3);
 pub(super) const RESET_RECEIVE_DWELL: Duration = Duration::from_millis(250);
 pub(super) const RESET_SOURCE_DWELL_MS: u32 = 250;
@@ -76,7 +77,7 @@ fn reset_candidate_or_reject(
     time_boot_ms: u32,
     now: Instant,
 ) -> TimeObservation {
-    if time_boot_ms > RESET_CANDIDATE_MAX_MS
+    if time_boot_ms > latest.reset_candidate_max_ms
         || latest.reset_policy == ResetPolicy::Conservative
         || !accepted_stream_is_silent(latest, now)
     {


### PR DESCRIPTION
Closes #157 (child of #96). The PX4 prerequisite split out of #153 so the extraction stays pure: a configured `AuthorizationSource` (standard ESTIMATOR_STATUS with a **configured** bounded lag — a `LinkConfig` parameter with exact-boundary tests, PX4 uses 300 ms — vs Aviate's exact-pair private status), a general COMMAND_LONG encoder, heartbeat arm-state retention, a configurable reset-candidate boot-clock ceiling (PX4 streams ~15–20 s after boot; the 5 s default would reject a rebooted stream forever), link-socket-originated stream-interval negotiation (the FC retargets a stream to the last peer that spoke on that link), and loud refused COMMAND_ACKs.

Stacked between #153 and #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)