### PR TITLE
WEB-02: fail closed when control datagrams are unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
       - name: transport session identity contract
         run: node clients/web/transport-session.test.mjs
 
+      - name: control datagram capability contract
+        run: node clients/web/datagram-control.test.mjs
+
       - name: instrument display fail-visible contract
         run: node clients/web/instruments.test.mjs
 

--- a/clients/web/connect-authority.js
+++ b/clients/web/connect-authority.js
@@ -27,7 +27,8 @@
  *   through as the reader's live `requestLease` and resolve to a session
  *   object with `completed` (bootstrap finished) and `leaseGranted`;
  *   anything not `completed` is returned to the caller untouched.
- * @param {(session: object) => void} deps.startControl
+ * @param {(session: object) => boolean|void} deps.startControl
+ * @param {(session: object) => void} deps.controlUnavailable
  * @param {(session: object) => void} deps.releaseLease
  * @param {(session: object, manual: boolean) => void} deps.telemetryOnly
  */
@@ -37,6 +38,7 @@ export async function negotiateSessionAuthority({
   releases,
   openAndBootstrap,
   startControl,
+  controlUnavailable,
   releaseLease,
   telemetryOnly,
 }) {
@@ -48,7 +50,7 @@ export async function negotiateSessionAuthority({
   if (!session || !session.completed) return session;
   if (session.leaseGranted) {
     if (gate.mayPublish()) {
-      startControl(session);
+      if (startControl(session) === false) controlUnavailable(session);
     } else {
       // The blur raced the grant: input loss latched after the lease
       // request was already emitted. Surrender immediately.

--- a/clients/web/connect-lifecycle.test.mjs
+++ b/clients/web/connect-lifecycle.test.mjs
@@ -48,7 +48,7 @@ function reader(steps) {
 // Drives the PRODUCTION orchestration over the real bootstrap loop, the
 // way main.js wires it: openAndBootstrap runs the reader with the
 // module's live probe and reports whether a lease was granted.
-async function drive({ gate, tracker, steps }) {
+async function drive({ gate, tracker, steps, controlStarts = true }) {
   const events = [];
   let leaseRequests = 0;
   const session = await negotiateSessionAuthority({
@@ -73,11 +73,32 @@ async function drive({ gate, tracker, steps }) {
         result,
       };
     },
-    startControl: () => events.push("start-control"),
+    startControl: () => {
+      events.push("start-control");
+      return controlStarts;
+    },
+    controlUnavailable: () => events.push("control-unavailable"),
     releaseLease: () => events.push("release-now"),
     telemetryOnly: () => events.push("telemetry-only"),
   });
   return { session, events, leaseRequests };
+}
+
+// --- a granted lease with no datagram writer is surrendered -----------------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  const tracker = createReleaseTracker();
+  const { events, leaseRequests } = await drive({
+    gate,
+    tracker,
+    steps: [{ bytes: [WELCOME] }, { bytes: [LEASE_RESPONSE] }],
+    controlStarts: false,
+  });
+  check("writer refusal follows one granted request", leaseRequests === 1);
+  check(
+    "writer refusal makes control unavailable and surrenders authority",
+    events.join(",") === "start-control,control-unavailable",
+  );
 }
 
 // --- a blur during the release-settlement await stays latched ---------------

--- a/clients/web/datagram-control.js
+++ b/clients/web/datagram-control.js
@@ -1,0 +1,39 @@
+// Capability and lifecycle boundary for the browser's control-datagram writer.
+
+/** Acquires the available datagram send stream without assuming an engine. */
+export function acquireDatagramWriter(datagrams) {
+  let writable;
+  try {
+    writable =
+      typeof datagrams?.createWritable === "function"
+        ? datagrams.createWritable()
+        : datagrams?.writable;
+    if (!writable || typeof writable.getWriter !== "function") {
+      return { ok: false, reason: "send-stream-unavailable" };
+    }
+    return { ok: true, writer: writable.getWriter() };
+  } catch (cause) {
+    return { ok: false, reason: "writer-acquisition-failed", cause };
+  }
+}
+
+/**
+ * Acquires and registers one control writer, then runs it under the session
+ * lifecycle so replacement or teardown aborts the writer before authority can
+ * leak into a stale session.
+ */
+export function startDatagramControl({ datagrams, lifecycle, token, run, onError }) {
+  const acquired = acquireDatagramWriter(datagrams);
+  if (!acquired.ok) return acquired;
+  const { writer } = acquired;
+  if (!lifecycle.trackWriter(token, writer)) {
+    return { ok: false, reason: "inactive-session" };
+  }
+  const completion = Promise.resolve()
+    .then(() => (lifecycle.isActive(token) ? run(writer) : undefined))
+    .catch((error) => {
+      if (lifecycle.isActive(token)) onError(error);
+    })
+    .finally(() => lifecycle.untrackWriter(token, writer));
+  return { ok: true, completion };
+}

--- a/clients/web/datagram-control.test.mjs
+++ b/clients/web/datagram-control.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+
+import { acquireDatagramWriter, startDatagramControl } from "./datagram-control.js";
+import { TransportSessionLifecycle } from "./transport-session.js";
+
+function writer() {
+  return {
+    abortCount: 0,
+    abort() {
+      this.abortCount += 1;
+      return Promise.resolve();
+    },
+  };
+}
+
+function transport() {
+  return {
+    closeCount: 0,
+    close() {
+      this.closeCount += 1;
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function testPreferredSendStreamWins() {
+  const preferred = writer();
+  let legacyReads = 0;
+  const datagrams = {
+    createWritable: () => ({ getWriter: () => preferred }),
+    get writable() {
+      legacyReads += 1;
+      return { getWriter: () => writer() };
+    },
+  };
+  const result = acquireDatagramWriter(datagrams);
+  assert.equal(result.ok, true);
+  assert.equal(result.writer, preferred);
+  assert.equal(legacyReads, 0);
+}
+
+function testLegacySendStreamIsBoundedFallback() {
+  const legacy = writer();
+  const result = acquireDatagramWriter({ writable: { getWriter: () => legacy } });
+  assert.equal(result.ok, true);
+  assert.equal(result.writer, legacy);
+}
+
+function testMissingSendStreamFailsClosed() {
+  assert.deepEqual(acquireDatagramWriter({}), {
+    ok: false,
+    reason: "send-stream-unavailable",
+  });
+}
+
+function testWriterAcquisitionFailuresAreTyped() {
+  const createFailure = acquireDatagramWriter({
+    createWritable() {
+      throw new Error("create failed");
+    },
+    writable: { getWriter: () => writer() },
+  });
+  assert.equal(createFailure.ok, false);
+  assert.equal(createFailure.reason, "writer-acquisition-failed");
+
+  const lockFailure = acquireDatagramWriter({
+    createWritable: () => ({
+      getWriter() {
+        throw new Error("lock failed");
+      },
+    }),
+  });
+  assert.equal(lockFailure.ok, false);
+  assert.equal(lockFailure.reason, "writer-acquisition-failed");
+}
+
+async function testSessionTeardownAbortsTheTrackedWriter() {
+  const lifecycle = new TransportSessionLifecycle();
+  const activeTransport = transport();
+  const token = lifecycle.begin(activeTransport);
+  const activeWriter = writer();
+  const running = deferred();
+  let runCount = 0;
+  const started = startDatagramControl({
+    datagrams: { createWritable: () => ({ getWriter: () => activeWriter }) },
+    lifecycle,
+    token,
+    run: async () => {
+      runCount += 1;
+      await running.promise;
+    },
+    onError: () => assert.fail("the control loop must not fail"),
+  });
+  assert.equal(started.ok, true);
+  await Promise.resolve();
+  assert.equal(runCount, 1);
+
+  lifecycle.close(token);
+  assert.equal(activeWriter.abortCount, 1);
+  assert.equal(activeTransport.closeCount, 1);
+  running.resolve();
+  await started.completion;
+  assert.equal(lifecycle.isActive(token), false);
+}
+
+for (const test of [
+  testPreferredSendStreamWins,
+  testLegacySendStreamIsBoundedFallback,
+  testMissingSendStreamFailsClosed,
+  testWriterAcquisitionFailuresAreTyped,
+  testSessionTeardownAbortsTheTrackedWriter,
+]) {
+  await test();
+  console.log(`ok - ${test.name}`);
+}

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -61,6 +61,7 @@ import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.j
 import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 import { createReconnectController } from "./reconnect.js";
 import { pressedArmInputs, risingArmEdges } from "./control-edges.js";
+import { startDatagramControl } from "./datagram-control.js";
 
 const VEHICLE_ID = 1n; // demo fixture: the single Gazebo vehicle this host serves.
 const INSTRUMENT_SOURCE_ID = 1n; // explicit simulator adapter source; never first-packet selection.
@@ -269,16 +270,21 @@ async function connect({ manual } = { manual: true }) {
     releases: releaseTracker,
     openAndBootstrap: (leaseProbe) =>
       openTransportSession({ url, certHash, certHashHex, manual, leaseProbe }),
-    startControl: ({ transport, token }) => {
-      startControlLoop(transport, token).catch((error) => {
-        transportSessions.runIfActive(token, () => log(`control loop stopped: ${error}`));
+    startControl: ({ transport, token }) => startControlLoop(transport, token),
+    controlUnavailable: ({ token }) => {
+      transportSessions.runIfActive(token, () => {
+        state.leaseGranted = false;
+        sendLeaseRelease(token);
       });
     },
     releaseLease: ({ token }) => {
-      sendLeaseRelease(token);
-      els.gamepad.textContent =
-        "control released — input lost during connect; press Connect to resume";
-      log("input lost during connect — lease released immediately");
+      transportSessions.runIfActive(token, () => {
+        state.leaseGranted = false;
+        sendLeaseRelease(token);
+        els.gamepad.textContent =
+          "control released — input lost during connect; press Connect to resume";
+        log("input lost during connect — lease released immediately");
+      });
     },
     telemetryOnly: (_session, wasManual) => {
       if (wasManual) {
@@ -1191,10 +1197,28 @@ function neutralAxesFor(mode) {
 }
 
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
-async function startControlLoop(transport, token) {
-  if (!transportSessions.isActive(token)) return;
-  const writer = transport.datagrams.writable.getWriter();
-  if (!transportSessions.trackWriter(token, writer)) return;
+function startControlLoop(transport, token) {
+  const started = startDatagramControl({
+    datagrams: transport.datagrams,
+    lifecycle: transportSessions,
+    token,
+    run: (writer) => runControlLoop(writer, token),
+    onError: (error) => log(`control loop stopped: ${error}`),
+  });
+  if (!started.ok) {
+    const detail =
+      started.reason === "send-stream-unavailable"
+        ? "no datagram send stream"
+        : "datagram writer acquisition failed";
+    els.gamepad.textContent = `control unavailable — ${detail}`;
+    els.overlay.textContent = "control unavailable";
+    log(`control unavailable: ${detail}`);
+  }
+  return started.ok;
+}
+
+/** Runs the control-fast send loop with an acquired, session-owned writer. */
+async function runControlLoop(writer, token) {
   // Prime the arm-edge baseline to whatever is held right now, so a button held
   // down as control starts (e.g. across a reconnect) is not read as a fresh
   // arm/disarm on the first tick.
@@ -1205,8 +1229,7 @@ async function startControlLoop(transport, token) {
   // in the WritableStream and get flushed in a burst with stale `sampled_at`
   // (which the host rejects as too old, ADR-0009). `sampled_at` is stamped right
   // before the write, after `ready`, so it reflects the real send moment.
-  try {
-    while (transportSessions.isActive(token) && state.connected) {
+  while (transportSessions.isActive(token) && state.connected) {
       try {
         await writer.ready;
       } catch {
@@ -1286,9 +1309,6 @@ async function startControlLoop(transport, token) {
         transportSessions.runIfActive(token, () => log(`control datagram send failed: ${error}`));
       });
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-  } finally {
-    transportSessions.untrackWriter(token, writer);
   }
 }
 


### PR DESCRIPTION
Closes #103.

Prefer the standard WebTransport datagram writer factory with a bounded legacy fallback. Refuse control authority visibly when no send stream exists or writer acquisition fails, and preserve token-scoped teardown.

Regression coverage exercises the standard API, legacy fallback, missing capabilities, acquisition failures, lease refusal, and transport teardown. The broader transport-crate migration remains tracked in #164.