### PR TITLE
GIM-04: PX4 Gimbal Protocol v2 backend + gz_x500_gimbal SITL rig

### DIFF
--- a/adapters/aviate/src/adapter.rs
+++ b/adapters/aviate/src/adapter.rs
@@ -356,6 +356,7 @@ impl VehicleAdapter for AviateAdapter {
                     avionics: None,
                     sim_truth: truth,
                     fc_state,
+                    gimbal: None,
                 }],
             };
         }

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -163,6 +163,7 @@ pub(crate) fn mavlink_batch(vehicle: VehicleId, state: &Arc<Mutex<LinkState>>) -
             avionics,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         }],
     }
 }

--- a/adapters/aviate/src/uplink/fc_replies.rs
+++ b/adapters/aviate/src/uplink/fc_replies.rs
@@ -29,7 +29,9 @@ impl FlightUplink {
                 }
                 match *message {
                     pilotage_mavlink::codec::FcMessage::Heartbeat { armed: a } => armed = Some(a),
-                    pilotage_mavlink::codec::FcMessage::CommandAck { command, result } => {
+                    pilotage_mavlink::codec::FcMessage::CommandAck {
+                        command, result, ..
+                    } => {
                         if result == 0 {
                             info!(command, "FC accepted command");
                         } else {

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -261,6 +261,7 @@ fn telemetry_from_odometry(vehicle: VehicleId, odom: &BridgeOdometry) -> Telemet
         avionics: None,
         sim_truth: None,
         fc_state: None,
+        gimbal: None,
     }
 }
 

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -23,6 +23,8 @@ use crate::uplink::Px4Uplink;
 
 mod camera;
 mod control;
+#[cfg(test)]
+mod gimbal_tests;
 mod pointing;
 mod sampling;
 #[cfg(test)]
@@ -124,13 +126,22 @@ impl Px4Adapter {
     pub async fn start(vehicle: VehicleId, config: Px4Config) -> Result<Self, Px4AdapterError> {
         let link_config = config.link_config();
         let incarnation = pilotage_adapter_api::SourceIncarnation::new(rand_incarnation());
-        let link = MavlinkLink::start(link_config, incarnation).await?;
+        let mut link = MavlinkLink::start(link_config, incarnation).await?;
         let state = link.state();
-        let gimbal = Some(crate::gimbal::Px4GimbalControl::new(
-            link.outbound(),
-            link_config.system_id,
-            link_config.component_id,
-        ));
+        // The gimbal path is wired only when the vehicle is declared to
+        // carry one: a bare airframe advertises no `vehicle.gimbal`
+        // scope, so a client cannot lease a payload it cannot point. The
+        // rate lane is taken exactly once here, so it is always present
+        // on this first (and only) take.
+        let gimbal = match (config.gimbal, link.take_gimbal_rate_sender()) {
+            (true, Some(rates)) => Some(crate::gimbal::Px4GimbalControl::new(
+                link.command_sender(),
+                rates,
+                link_config.system_id,
+                link_config.component_id,
+            )),
+            _ => None,
+        };
         let uplink = match Px4Uplink::new(config.command_endpoint) {
             Ok(mut uplink) => {
                 uplink.set_expected_source(link_config.system_id, link_config.component_id);
@@ -353,6 +364,11 @@ impl VehicleAdapter for Px4Adapter {
     fn sample_telemetry(&mut self) -> TelemetryBatch {
         self.observe_arm_report();
         let fc_state = sampling::fc_state_sample(self.arm, self.arm_incarnation, self.started_at);
+        let gimbal_attitude = self
+            .gimbal
+            .is_some()
+            .then(|| self.gimbal_attitude())
+            .flatten();
         let mut batch = self
             .estimate
             .as_ref()
@@ -360,6 +376,7 @@ impl VehicleAdapter for Px4Adapter {
             .unwrap_or_default();
         for sample in &mut batch.samples {
             sample.fc_state = fc_state;
+            sample.gimbal = gimbal_attitude;
         }
         if let Some(uplink) = self.uplink.as_mut() {
             uplink.maintain();

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -23,6 +23,7 @@ use crate::uplink::Px4Uplink;
 
 mod camera;
 mod control;
+mod pointing;
 mod sampling;
 #[cfg(test)]
 mod tests;
@@ -45,6 +46,11 @@ pub const ARM_BUTTON: u16 = 0;
 pub const DISARM_BUTTON: u16 = 1;
 /// Logical button whose press resets the simulation.
 pub const RESET_BUTTON: u16 = 2;
+/// The gimbal pointing scope (GIM-01, ADR-0006 vocabulary): pitch/yaw
+/// LOS rate demands, leased and fenced independently of flight.
+pub const GIMBAL_SCOPE: &str = "vehicle.gimbal";
+/// Gimbal-scope button whose press recenters the gimbal.
+pub const GIMBAL_NEUTRAL_BUTTON: u16 = 0;
 
 /// Data older than this is withheld from telemetry entirely, so
 /// downstream freshness models see the group's age grow instead of a
@@ -62,6 +68,10 @@ pub struct Px4Adapter {
     // basis for state-dependent control; there is no truth oracle).
     estimate: Option<EstimateSource>,
     uplink: Option<Px4Uplink>,
+    // Gimbal-manager command path; rides the receive link's socket
+    // because the FC's GCS instance retargets its telemetry stream to
+    // the last peer that spoke.
+    gimbal: Option<crate::gimbal::Px4GimbalControl>,
     // Pilotage's gz sidecar bridges the flight-deck rig's camera topics;
     // the adapter remains usable without video when it cannot spawn.
     frames: Option<tokio::sync::mpsc::Receiver<pilotage_adapter_gazebo::RawVideoFrame>>,
@@ -116,6 +126,11 @@ impl Px4Adapter {
         let incarnation = pilotage_adapter_api::SourceIncarnation::new(rand_incarnation());
         let link = MavlinkLink::start(link_config, incarnation).await?;
         let state = link.state();
+        let gimbal = Some(crate::gimbal::Px4GimbalControl::new(
+            link.outbound(),
+            link_config.system_id,
+            link_config.component_id,
+        ));
         let uplink = match Px4Uplink::new(config.command_endpoint) {
             Ok(mut uplink) => {
                 uplink.set_expected_source(link_config.system_id, link_config.component_id);
@@ -134,6 +149,7 @@ impl Px4Adapter {
                 _link: Some(link),
             }),
             uplink,
+            gimbal,
             frames,
             _camera_bridge: camera_bridge,
             _frame_forwarder: frame_forwarder,
@@ -156,6 +172,7 @@ impl Px4Adapter {
             vehicle,
             estimate: Some(EstimateSource { state, _link: None }),
             uplink: None,
+            gimbal: None,
             frames: None,
             _camera_bridge: None,
             _frame_forwarder: None,
@@ -182,6 +199,13 @@ impl Px4Adapter {
     #[cfg(test)]
     pub(crate) fn with_uplink(mut self, uplink: Px4Uplink) -> Self {
         self.uplink = Some(uplink);
+        self
+    }
+
+    /// Installs a test gimbal control path, for tests.
+    #[cfg(test)]
+    pub(crate) fn with_gimbal(mut self, gimbal: crate::gimbal::Px4GimbalControl) -> Self {
+        self.gimbal = Some(gimbal);
         self
     }
 
@@ -253,18 +277,29 @@ impl VehicleAdapter for Px4Adapter {
             },
             vehicles: vec![VehicleDescriptor {
                 id: self.vehicle,
-                scopes: if self.uplink.is_some() {
-                    vec![ScopeDescriptor {
-                        scope: ScopeId::new(FLIGHT_SCOPE),
-                        axes: vec![
-                            LogicalAxisId::new(ROLL_AXIS),
-                            LogicalAxisId::new(PITCH_AXIS),
-                            LogicalAxisId::new(THROTTLE_AXIS),
-                            LogicalAxisId::new(YAW_AXIS),
-                        ],
-                    }]
-                } else {
-                    vec![]
+                scopes: {
+                    let mut scopes = Vec::new();
+                    if self.uplink.is_some() {
+                        scopes.push(ScopeDescriptor {
+                            scope: ScopeId::new(FLIGHT_SCOPE),
+                            axes: vec![
+                                LogicalAxisId::new(ROLL_AXIS),
+                                LogicalAxisId::new(PITCH_AXIS),
+                                LogicalAxisId::new(THROTTLE_AXIS),
+                                LogicalAxisId::new(YAW_AXIS),
+                            ],
+                        });
+                    }
+                    if self.gimbal.is_some() {
+                        scopes.push(ScopeDescriptor {
+                            scope: ScopeId::new(GIMBAL_SCOPE),
+                            axes: vec![
+                                LogicalAxisId::new(PITCH_AXIS),
+                                LogicalAxisId::new(YAW_AXIS),
+                            ],
+                        });
+                    }
+                    scopes
                 },
                 link_loss_actions: if self.uplink.is_some() {
                     vec![LinkLossPolicy::Neutralize]
@@ -278,6 +313,9 @@ impl VehicleAdapter for Px4Adapter {
 
     fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
         let tick = self.step(StepBudget { ticks: 0 }).now;
+        if frame.scope.as_str() == GIMBAL_SCOPE {
+            return self.apply_gimbal(frame, tick);
+        }
         if let Some(outcome) = self.gated_flight_outcome(frame, tick) {
             return outcome;
         }
@@ -325,6 +363,9 @@ impl VehicleAdapter for Px4Adapter {
         }
         if let Some(uplink) = self.uplink.as_mut() {
             uplink.maintain();
+        }
+        if let Some(gimbal) = self.gimbal.as_mut() {
+            gimbal.maintain();
         }
         batch
     }

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -84,6 +84,11 @@ pub struct Px4Adapter {
     arm: Option<ArmReport>,
     last_seen_heartbeat: Option<std::time::Instant>,
     arm_incarnation: pilotage_adapter_api::SourceIncarnation,
+    // Payload-device stamp discipline for the gimbal lane: a stable
+    // gimbal identity plus a reboot-aware epoch, kept apart from the FC
+    // arm incarnation so a device reboot never regresses time under a
+    // fixed identity+epoch.
+    gimbal_stamp: sampling::GimbalStamp,
     started_at: std::time::Instant,
     last_reset: Option<std::time::Instant>,
     // Commanded-reset latch: engaged when a sim reset is requested,
@@ -167,6 +172,9 @@ impl Px4Adapter {
             arm: None,
             last_seen_heartbeat: None,
             arm_incarnation: pilotage_adapter_api::SourceIncarnation::new(rand_incarnation()),
+            gimbal_stamp: sampling::GimbalStamp::new(pilotage_adapter_api::SourceIncarnation::new(
+                rand_incarnation(),
+            )),
             started_at: std::time::Instant::now(),
             last_reset: None,
             reset_latch: None,
@@ -190,6 +198,9 @@ impl Px4Adapter {
             arm: None,
             last_seen_heartbeat: None,
             arm_incarnation: pilotage_adapter_api::SourceIncarnation::new([0; 16]),
+            gimbal_stamp: sampling::GimbalStamp::new(pilotage_adapter_api::SourceIncarnation::new(
+                [0x60; 16],
+            )),
             started_at: std::time::Instant::now(),
             last_reset: None,
             reset_latch: None,

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use pilotage_adapter_api::{
     AdapterCapabilities, ApplyOutcome, Disposition, ExecutionMode, LinkLossEnactError,
     LinkLossPolicy, RejectReason, ScopeDescriptor, StepBudget, StepOutcome, TelemetryBatch,
-    VehicleAdapter, VehicleDescriptor, VideoSource,
+    TelemetrySample, VehicleAdapter, VehicleDescriptor, VideoSource,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopeId, ScopedControlFrame};
@@ -374,6 +374,22 @@ impl VehicleAdapter for Px4Adapter {
             .as_ref()
             .map(|source| sampling::mavlink_batch(self.vehicle, &source.state))
             .unwrap_or_default();
+        // When no coherent avionics group is available the batch is
+        // empty, but FC-state and gimbal-device reports are independent
+        // sources that must still reach clients: carry them on a sample
+        // even with no pose. Their own stamps drive freshness.
+        if batch.samples.is_empty() && (fc_state.is_some() || gimbal_attitude.is_some()) {
+            batch.samples.push(TelemetrySample {
+                vehicle: self.vehicle,
+                tick: self.step(StepBudget { ticks: 0 }).now,
+                pose: None,
+                speed: None,
+                avionics: None,
+                sim_truth: None,
+                fc_state: None,
+                gimbal: None,
+            });
+        }
         for sample in &mut batch.samples {
             sample.fc_state = fc_state;
             sample.gimbal = gimbal_attitude;

--- a/adapters/px4/src/adapter/gimbal_tests.rs
+++ b/adapters/px4/src/adapter/gimbal_tests.rs
@@ -330,3 +330,57 @@ fn a_gimbal_failure_flag_reaches_telemetry() {
         "device failure is surfaced, not dropped"
     );
 }
+
+/// A gimbal (or FC) reboot regresses the device's `time_boot_ms`. The
+/// stamp must open a NEW epoch under a stable identity so acquisition
+/// time never runs backwards within one (identity, epoch) — otherwise a
+/// reboot is indistinguishable from a stale replay.
+#[test]
+fn a_gimbal_reboot_opens_a_new_epoch_instead_of_regressing_time() {
+    let state = live_state();
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state.clone()).with_gimbal(control);
+
+    let stamp_now = |adapter: &mut Px4Adapter| {
+        adapter.sample_telemetry().samples[0]
+            .gimbal
+            .expect("gimbal sample present")
+            .stamp
+    };
+
+    // One boot session: two reports with rising device boot time.
+    feed_gimbal(&state, 5_000, 0, Instant::now());
+    let first = stamp_now(&mut adapter);
+    feed_gimbal(&state, 6_000, 0, Instant::now());
+    let later = stamp_now(&mut adapter);
+    assert_eq!(
+        first.source_epoch, later.source_epoch,
+        "no reboot within one boot session"
+    );
+    assert!(
+        later.acquired_at_ns > first.acquired_at_ns,
+        "acquisition time advances within an epoch"
+    );
+
+    // Reboot: the device's boot time regresses 6000 -> 10 ms.
+    feed_gimbal(&state, 10, 0, Instant::now());
+    let after = stamp_now(&mut adapter);
+    assert_eq!(
+        after.source_epoch,
+        later.source_epoch.wrapping_add(1),
+        "a reboot opens the next epoch"
+    );
+    assert_eq!(
+        after.source_incarnation, later.source_incarnation,
+        "the same gimbal source identity spans the reboot; only the epoch turns over"
+    );
+    // The small post-reboot boot time lives under the NEW epoch, so no
+    // consumer ever sees time regress within one (identity, epoch).
+
+    // Re-sampling the same post-reboot report is not a second reboot.
+    let resample = stamp_now(&mut adapter);
+    assert_eq!(
+        resample.source_epoch, after.source_epoch,
+        "re-observing the same boot time keeps the epoch"
+    );
+}

--- a/adapters/px4/src/adapter/gimbal_tests.rs
+++ b/adapters/px4/src/adapter/gimbal_tests.rs
@@ -249,3 +249,84 @@ fn an_ack_addressed_to_another_endpoint_is_ignored() {
         "an ack for another endpoint must not reject our frames"
     );
 }
+
+/// Feeds a gimbal-device attitude status into the shared cache at the
+/// given receive instant, the way a live PX4 stream populates it.
+fn feed_gimbal(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32, failure_flags: u32, now: Instant) {
+    apply_messages_at(
+        state,
+        &[(
+            SOURCE,
+            FcMessage::GimbalDeviceAttitudeStatus {
+                time_boot_ms,
+                quat_wxyz: [0.98, 0.0, -0.19, 0.0],
+                rates_rps: [0.0, 0.05, -0.02],
+                flags: 12,
+                failure_flags,
+            },
+        )],
+        0,
+        0,
+        now,
+    );
+}
+
+#[test]
+fn gimbal_attitude_is_stamped_as_a_payload_device_on_the_device_clock() {
+    use pilotage_adapter_api::{MeasurementClock, SourceRole};
+    let state = live_state();
+    feed_gimbal(&state, 5_000, 0, Instant::now());
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let batch = adapter.sample_telemetry();
+    let gimbal = batch.samples[0].gimbal.expect("gimbal sample present");
+    assert_eq!(
+        gimbal.stamp.role,
+        SourceRole::PayloadDevice,
+        "not a camera frame"
+    );
+    assert_eq!(
+        gimbal.stamp.clock,
+        MeasurementClock::VehicleBoot,
+        "device boot clock"
+    );
+    // The device's own boot-relative time (ms) carried as ns, not host time.
+    assert_eq!(gimbal.stamp.acquired_at_ns, 5_000 * 1_000_000);
+    assert_eq!(gimbal.flags, 12);
+    assert_eq!(gimbal.failure_flags, 0);
+}
+
+#[test]
+fn gimbal_only_telemetry_survives_without_an_avionics_group() {
+    // A cache with a gimbal report but no attitude/kinematics: the batch
+    // would otherwise be empty and the gimbal would vanish.
+    let state = Arc::new(Mutex::new(LinkState::default()));
+    feed_gimbal(&state, 7_000, 0, Instant::now());
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let batch = adapter.sample_telemetry();
+    assert_eq!(
+        batch.samples.len(),
+        1,
+        "a carrier sample exists for gimbal-only"
+    );
+    assert!(batch.samples[0].avionics.is_none());
+    assert!(
+        batch.samples[0].gimbal.is_some(),
+        "gimbal-only telemetry must reach clients"
+    );
+}
+
+#[test]
+fn a_gimbal_failure_flag_reaches_telemetry() {
+    let state = live_state();
+    feed_gimbal(&state, 5_000, 0b10, Instant::now());
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let batch = adapter.sample_telemetry();
+    let gimbal = batch.samples[0].gimbal.expect("gimbal sample present");
+    assert_eq!(
+        gimbal.failure_flags, 0b10,
+        "device failure is surfaced, not dropped"
+    );
+}

--- a/adapters/px4/src/adapter/gimbal_tests.rs
+++ b/adapters/px4/src/adapter/gimbal_tests.rs
@@ -1,0 +1,251 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! Gimbal-scope (vehicle.gimbal) adapter behavior: capability
+//! advertisement, pointing that works where flight is rejected, the
+//! recenter command, axis validation, and the durable claim-denial
+//! state that a later unrelated ack must not bury.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use pilotage_adapter_api::{Disposition, RejectReason, VehicleAdapter};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, VehicleId};
+
+use pilotage_mavlink::LinkState;
+use pilotage_mavlink::codec::FcMessage;
+use pilotage_mavlink::link::apply_messages_at;
+
+use super::Px4Adapter;
+use super::tests::{SOURCE, fake_fc, frame, live_state, uplink_to};
+
+/// A gimbal-scope control frame (overrides the flight-scope default).
+fn gimbal_frame(
+    axes: Vec<(LogicalAxisId, f32)>,
+    edges: Vec<(LogicalButtonId, ButtonEdge)>,
+) -> pilotage_protocol::ScopedControlFrame {
+    let mut built = frame(axes, edges);
+    built.scope = pilotage_protocol::ScopeId::new(super::GIMBAL_SCOPE);
+    built
+}
+
+struct GimbalLanes {
+    commands: tokio::sync::mpsc::Receiver<pilotage_mavlink::OutboundCommand>,
+    rates: tokio::sync::watch::Receiver<Option<pilotage_mavlink::GimbalRateDemand>>,
+}
+
+fn gimbal_control() -> (crate::gimbal::Px4GimbalControl, GimbalLanes) {
+    let (command_tx, command_rx) = tokio::sync::mpsc::channel(16);
+    let (rate_tx, rate_rx) = tokio::sync::watch::channel(None);
+    (
+        crate::gimbal::Px4GimbalControl::new(command_tx, rate_tx, 1, 1),
+        GimbalLanes {
+            commands: command_rx,
+            rates: rate_rx,
+        },
+    )
+}
+
+fn next_command(lanes: &mut GimbalLanes) -> u16 {
+    lanes.commands.try_recv().expect("queued command").command
+}
+
+#[test]
+fn capabilities_advertise_the_gimbal_scope_alongside_flight() {
+    let (fc, addr) = fake_fc();
+    drop(fc);
+    let (control, _lanes) = gimbal_control();
+    let adapter = Px4Adapter::from_state(VehicleId::new(1), live_state())
+        .with_uplink(uplink_to(addr))
+        .with_gimbal(control);
+    let scopes: Vec<String> = adapter.capabilities().vehicles[0]
+        .scopes
+        .iter()
+        .map(|descriptor| descriptor.scope.as_str().to_owned())
+        .collect();
+    assert_eq!(scopes, vec![super::FLIGHT_SCOPE, super::GIMBAL_SCOPE]);
+}
+
+#[test]
+fn a_vehicle_without_a_gimbal_advertises_no_gimbal_scope() {
+    let (fc, addr) = fake_fc();
+    drop(fc);
+    let adapter =
+        Px4Adapter::from_state(VehicleId::new(1), live_state()).with_uplink(uplink_to(addr));
+    let scopes: Vec<String> = adapter.capabilities().vehicles[0]
+        .scopes
+        .iter()
+        .map(|descriptor| descriptor.scope.as_str().to_owned())
+        .collect();
+    assert_eq!(scopes, vec![super::FLIGHT_SCOPE], "no gimbal, no scope");
+}
+
+#[test]
+fn gimbal_demands_flow_even_where_flight_control_cannot() {
+    // A bare cache: no estimator authorization, so flight frames are
+    // rejected — but pointing is not flight, and must keep working.
+    let state = Arc::new(Mutex::new(LinkState::default()));
+    let (control, mut lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![
+            (LogicalAxisId::new(super::PITCH_AXIS), 0.5),
+            (LogicalAxisId::new(super::YAW_AXIS), -0.25),
+        ],
+        vec![],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    assert_eq!(
+        next_command(&mut lanes),
+        1001,
+        "primary-control claim first"
+    );
+    let rate = *lanes.rates.borrow_and_update();
+    assert!(
+        rate.is_some(),
+        "then the rate demand on the latest-value lane"
+    );
+}
+
+#[test]
+fn gimbal_neutral_button_recentres() {
+    let (control, mut lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![],
+        vec![(
+            LogicalButtonId::new(super::GIMBAL_NEUTRAL_BUTTON),
+            ButtonEdge::Pressed,
+        )],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    assert_eq!(
+        next_command(&mut lanes),
+        1001,
+        "primary-control claim first"
+    );
+    assert_eq!(
+        next_command(&mut lanes),
+        1000,
+        "DO_GIMBAL_MANAGER_PITCHYAW recenters"
+    );
+}
+
+#[test]
+fn gimbal_frame_with_flight_axes_is_rejected() {
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::ROLL_AXIS), 0.5)],
+        vec![],
+    ));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::UnknownAxis),
+        "the gimbal scope accepts pitch/yaw only"
+    );
+}
+
+#[test]
+fn fresh_claim_denial_rejects_pointing_frames_loudly() {
+    let state = live_state();
+    apply_messages_at(
+        &state,
+        &[(
+            SOURCE,
+            FcMessage::CommandAck {
+                command: 1001,
+                result: 4,
+                target_system: 255,
+                target_component: 190,
+            },
+        )],
+        0,
+        0,
+        Instant::now(),
+    );
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::PITCH_AXIS), 0.5)],
+        vec![],
+    ));
+    assert!(
+        matches!(
+            outcome.disposition,
+            Disposition::Rejected(RejectReason::Other(_))
+        ),
+        "PX4 ignores non-primary demands silently, so a cached denial \
+         must reject loudly instead: {:?}",
+        outcome.disposition
+    );
+}
+
+#[test]
+fn an_unrelated_ack_does_not_bury_a_gimbal_claim_denial() {
+    // A denied CONFIGURE (1001), then a later, unrelated
+    // SET_MESSAGE_INTERVAL (511) acceptance. The CONFIGURE verdict is
+    // tracked separately, so the denial must still reject pointing
+    // frames — otherwise ignored gimbal demands would report accepted.
+    let state = live_state();
+    let deny = |c: u16, r: u8| {
+        (
+            SOURCE,
+            FcMessage::CommandAck {
+                command: c,
+                result: r,
+                target_system: 255,
+                target_component: 190,
+            },
+        )
+    };
+    apply_messages_at(&state, &[deny(1001, 4)], 0, 0, Instant::now());
+    apply_messages_at(&state, &[deny(511, 0)], 0, 0, Instant::now());
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::PITCH_AXIS), 0.5)],
+        vec![],
+    ));
+    assert!(
+        matches!(
+            outcome.disposition,
+            Disposition::Rejected(RejectReason::Other(_))
+        ),
+        "the 511 ack must not bury the 1001 denial: {:?}",
+        outcome.disposition
+    );
+}
+
+#[test]
+fn an_ack_addressed_to_another_endpoint_is_ignored() {
+    // A CONFIGURE denial addressed to a different component proves
+    // nothing about our claim; it must not reject our pointing frames.
+    let state = live_state();
+    apply_messages_at(
+        &state,
+        &[(
+            SOURCE,
+            FcMessage::CommandAck {
+                command: 1001,
+                result: 4,
+                target_system: 42,
+                target_component: 200,
+            },
+        )],
+        0,
+        0,
+        Instant::now(),
+    );
+    let (control, _lanes) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::PITCH_AXIS), 0.5)],
+        vec![],
+    ));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Accepted,
+        "an ack for another endpoint must not reject our frames"
+    );
+}

--- a/adapters/px4/src/adapter/pointing.rs
+++ b/adapters/px4/src/adapter/pointing.rs
@@ -51,11 +51,15 @@ impl Px4Adapter {
                 )),
             );
         }
+        // A send that never reached the wire (a full or closed lane)
+        // must not report as applied. Track every command/demand this
+        // frame issued.
+        let mut delivered = true;
         for (button, edge) in &frame.payload.edges {
             if *edge == ButtonEdge::Pressed
                 && *button == LogicalButtonId::new(GIMBAL_NEUTRAL_BUTTON)
             {
-                gimbal.neutral();
+                delivered &= gimbal.neutral();
             }
         }
         let mut pitch = 0.0_f32;
@@ -75,7 +79,13 @@ impl Px4Adapter {
             }
         }
         if !frame.payload.axes.is_empty() {
-            gimbal.rate_demand(pitch, yaw);
+            delivered &= gimbal.rate_demand(pitch, yaw);
+        }
+        if !delivered {
+            return rejected_control(
+                tick,
+                RejectReason::Other("gimbal command lane full; demand not sent".to_owned()),
+            );
         }
         ApplyOutcome {
             tick,
@@ -88,11 +98,14 @@ impl Px4Adapter {
     }
 
     /// A recent CONFIGURE denial from the FC, if one is cached on the
-    /// receive link.
+    /// receive link. Reads the dedicated CONFIGURE ack slot so an
+    /// unrelated later ack (a periodic SET_MESSAGE_INTERVAL, MAV_CMD
+    /// 511) cannot bury a claim denial and let ignored gimbal demands
+    /// report as accepted.
     fn fresh_claim_denial(&self) -> Option<u8> {
         let source = self.estimate.as_ref()?;
         let latest = source.state.lock().ok()?;
-        let ack = latest.last_command_ack?;
+        let ack = latest.gimbal_configure_ack?;
         (ack.command == CMD_GIMBAL_CONFIGURE
             && ack.result != 0
             && ack.received_at.elapsed() < CLAIM_DENIAL_FRESHNESS)

--- a/adapters/px4/src/adapter/pointing.rs
+++ b/adapters/px4/src/adapter/pointing.rs
@@ -1,0 +1,101 @@
+//! Gimbal pointing-frame application for the `vehicle.gimbal` scope:
+//! structural validation, the typed claim-denial surface, and demand
+//! extraction into the gimbal-manager command path.
+
+use std::time::Duration;
+
+use pilotage_adapter_api::{ApplyOutcome, Disposition, RejectReason};
+use pilotage_protocol::{ButtonEdge, LogicalAxisId, LogicalButtonId, ScopedControlFrame};
+use pilotage_timing::SimTick;
+
+use super::control::rejected_control;
+use super::{GIMBAL_NEUTRAL_BUTTON, PITCH_AXIS, Px4Adapter, YAW_AXIS};
+use crate::gimbal::CMD_GIMBAL_CONFIGURE;
+
+/// How long a CONFIGURE denial keeps rejecting pointing frames. The
+/// claim is re-asserted every second while demands flow, so a live
+/// denial refreshes itself and a stale one ages out instead of
+/// blocking the scope forever.
+const CLAIM_DENIAL_FRESHNESS: Duration = Duration::from_secs(5);
+
+impl Px4Adapter {
+    /// Applies one `vehicle.gimbal` frame: neutral-reset edges and
+    /// pitch/yaw LOS rate demands. Pointing is deliberately outside
+    /// the flight gate chain — a gimbal cannot fly the vehicle, and
+    /// its scope is leased and fenced independently — but a fresh
+    /// primary-control denial from the FC rejects frames loudly
+    /// because PX4 ignores non-primary demands silently.
+    pub(super) fn apply_gimbal(
+        &mut self,
+        frame: &ScopedControlFrame,
+        tick: SimTick,
+    ) -> ApplyOutcome {
+        if frame.vehicle != self.vehicle {
+            return rejected_control(tick, RejectReason::UnknownVehicle);
+        }
+        let known = [LogicalAxisId::new(PITCH_AXIS), LogicalAxisId::new(YAW_AXIS)];
+        for (axis, _) in &frame.payload.axes {
+            if !known.contains(axis) {
+                return rejected_control(tick, RejectReason::UnknownAxis);
+            }
+        }
+        let denial = self.fresh_claim_denial();
+        let Some(gimbal) = self.gimbal.as_mut() else {
+            return rejected_control(tick, RejectReason::UnknownScope);
+        };
+        if let Some(result) = denial {
+            return rejected_control(
+                tick,
+                RejectReason::Other(format!(
+                    "gimbal primary-control claim denied by the FC (MAV_RESULT {result})"
+                )),
+            );
+        }
+        for (button, edge) in &frame.payload.edges {
+            if *edge == ButtonEdge::Pressed
+                && *button == LogicalButtonId::new(GIMBAL_NEUTRAL_BUTTON)
+            {
+                gimbal.neutral();
+            }
+        }
+        let mut pitch = 0.0_f32;
+        let mut yaw = 0.0_f32;
+        let mut transformed = false;
+        for (axis, value) in &frame.payload.axes {
+            let clamped = if value.is_nan() {
+                0.0
+            } else {
+                value.clamp(-1.0, 1.0)
+            };
+            transformed |= clamped != *value;
+            if *axis == LogicalAxisId::new(PITCH_AXIS) {
+                pitch = clamped;
+            } else {
+                yaw = clamped;
+            }
+        }
+        if !frame.payload.axes.is_empty() {
+            gimbal.rate_demand(pitch, yaw);
+        }
+        ApplyOutcome {
+            tick,
+            disposition: if transformed {
+                Disposition::Transformed
+            } else {
+                Disposition::Accepted
+            },
+        }
+    }
+
+    /// A recent CONFIGURE denial from the FC, if one is cached on the
+    /// receive link.
+    fn fresh_claim_denial(&self) -> Option<u8> {
+        let source = self.estimate.as_ref()?;
+        let latest = source.state.lock().ok()?;
+        let ack = latest.last_command_ack?;
+        (ack.command == CMD_GIMBAL_CONFIGURE
+            && ack.result != 0
+            && ack.received_at.elapsed() < CLAIM_DENIAL_FRESHNESS)
+            .then_some(ack.result)
+    }
+}

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -187,31 +187,34 @@ impl super::Px4Adapter {
 
 impl super::Px4Adapter {
     /// The latest gimbal-device orientation, withheld once stale so a
-    /// frozen value never replays as live. Stamped under the video-
-    /// capture role — payload-device state, never a vehicle estimate and
-    /// never eligible for control validation (LINK-04).
+    /// frozen value never replays as live. Stamped under the
+    /// payload-device role with the device's OWN boot clock
+    /// (`time_boot_ms`), not host receive time: it is payload-device
+    /// state, never a vehicle estimate and never eligible for control
+    /// validation (LINK-04).
     pub(super) fn gimbal_attitude(&mut self) -> Option<GimbalAttitudeSample> {
         let source = self.estimate.as_ref()?;
         let latest = source.state.lock().ok()?;
         let device = latest
             .gimbal_device
             .filter(|report| report.received_at.elapsed() <= WITHHOLD_AFTER)?;
-        let acquired = device
-            .received_at
-            .checked_duration_since(self.started_at)
-            .unwrap_or_default();
         Some(GimbalAttitudeSample {
             quat_wxyz: device.quat_wxyz,
             rates_rps: device.rates_rps,
+            flags: u32::from(device.flags),
+            failure_flags: device.failure_flags,
             stamp: MeasurementStamp {
-                role: SourceRole::VideoCapture,
+                role: SourceRole::PayloadDevice,
                 integrity: SourceIntegrity::ChecksummedOnly,
                 source_id: 2,
                 source_incarnation: self.arm_incarnation,
                 source_epoch: 1,
                 sequence: device.time_boot_ms,
-                acquired_at_ns: u64::try_from(acquired.as_nanos()).unwrap_or(u64::MAX),
-                clock: MeasurementClock::HostMonotonic,
+                // The device reports its own boot-relative time; carry it
+                // as the acquisition time under the vehicle-boot clock
+                // rather than substituting a host stamp.
+                acquired_at_ns: u64::from(device.time_boot_ms).saturating_mul(1_000_000),
+                clock: MeasurementClock::VehicleBoot,
             },
         })
     }

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -185,37 +185,87 @@ impl super::Px4Adapter {
     }
 }
 
+/// The payload-device stamp discipline for the gimbal lane. The device
+/// reports `time_boot_ms` relative to its OWN boot, so a gimbal (or FC)
+/// reboot regresses that value. Minting the stamp under a constant
+/// identity and epoch — borrowing the FC arm incarnation with a fixed
+/// epoch — would make the acquisition time and sequence run BACKWARDS
+/// within one epoch, which a consumer cannot tell apart from a stale
+/// replay. This carries a stable gimbal-source incarnation and opens a
+/// NEW epoch whenever the boot time fails to advance (a reboot, or a u32
+/// wrap), so within any one (incarnation, epoch) acquisition time is
+/// monotonic and a reboot surfaces as a visible epoch change.
+#[derive(Debug)]
+pub(super) struct GimbalStamp {
+    incarnation: SourceIncarnation,
+    last_time_boot_ms: Option<u32>,
+    epoch: u32,
+}
+
+impl GimbalStamp {
+    /// A fresh discipline for one gimbal source instance. The incarnation
+    /// is this adapter session's gimbal identity, distinct from the FC
+    /// arm incarnation so a re-arm never reads as a gimbal reboot.
+    pub(super) fn new(incarnation: SourceIncarnation) -> Self {
+        Self {
+            incarnation,
+            last_time_boot_ms: None,
+            epoch: 0,
+        }
+    }
+
+    /// Mints the payload-device stamp for a device report as it is
+    /// ingested into the provenance domain, advancing the epoch on a
+    /// detected reboot — the first report, or a `time_boot_ms` that does
+    /// not exceed the previous one. Re-observing the same boot time (the
+    /// same report sampled twice) is not a reboot and keeps the epoch.
+    pub(super) fn stamp_for(&mut self, time_boot_ms: u32) -> MeasurementStamp {
+        let reboot = self
+            .last_time_boot_ms
+            .is_none_or(|prev| time_boot_ms < prev);
+        if reboot {
+            self.epoch = self.epoch.wrapping_add(1);
+        }
+        self.last_time_boot_ms = Some(time_boot_ms);
+        MeasurementStamp {
+            role: SourceRole::PayloadDevice,
+            integrity: SourceIntegrity::ChecksummedOnly,
+            source_id: 2,
+            source_incarnation: self.incarnation,
+            source_epoch: self.epoch,
+            sequence: time_boot_ms,
+            // The device reports its own boot-relative time; carry it as
+            // the acquisition time under the vehicle-boot clock rather
+            // than substituting a host stamp.
+            acquired_at_ns: u64::from(time_boot_ms).saturating_mul(1_000_000),
+            clock: MeasurementClock::VehicleBoot,
+        }
+    }
+}
+
 impl super::Px4Adapter {
     /// The latest gimbal-device orientation, withheld once stale so a
     /// frozen value never replays as live. Stamped under the
     /// payload-device role with the device's OWN boot clock
     /// (`time_boot_ms`), not host receive time: it is payload-device
     /// state, never a vehicle estimate and never eligible for control
-    /// validation (LINK-04).
+    /// validation (LINK-04). The reset/epoch discipline lives in
+    /// [`GimbalStamp`], so a device reboot opens a new epoch instead of
+    /// regressing time under the old one.
     pub(super) fn gimbal_attitude(&mut self) -> Option<GimbalAttitudeSample> {
-        let source = self.estimate.as_ref()?;
-        let latest = source.state.lock().ok()?;
-        let device = latest
-            .gimbal_device
-            .filter(|report| report.received_at.elapsed() <= WITHHOLD_AFTER)?;
+        let device = {
+            let source = self.estimate.as_ref()?;
+            let latest = source.state.lock().ok()?;
+            latest
+                .gimbal_device
+                .filter(|report| report.received_at.elapsed() <= WITHHOLD_AFTER)?
+        };
         Some(GimbalAttitudeSample {
             quat_wxyz: device.quat_wxyz,
             rates_rps: device.rates_rps,
             flags: u32::from(device.flags),
             failure_flags: device.failure_flags,
-            stamp: MeasurementStamp {
-                role: SourceRole::PayloadDevice,
-                integrity: SourceIntegrity::ChecksummedOnly,
-                source_id: 2,
-                source_incarnation: self.arm_incarnation,
-                source_epoch: 1,
-                sequence: device.time_boot_ms,
-                // The device reports its own boot-relative time; carry it
-                // as the acquisition time under the vehicle-boot clock
-                // rather than substituting a host stamp.
-                acquired_at_ns: u64::from(device.time_boot_ms).saturating_mul(1_000_000),
-                clock: MeasurementClock::VehicleBoot,
-            },
+            stamp: self.gimbal_stamp.stamp_for(device.time_boot_ms),
         })
     }
 }

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 
 use pilotage_adapter_api::{
     AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, FcStateSample,
-    MeasurementClock, MeasurementStamp, SourceIncarnation, SourceIntegrity, SourceRole,
-    TelemetryBatch, TelemetrySample,
+    GimbalAttitudeSample, MeasurementClock, MeasurementStamp, SourceIncarnation, SourceIntegrity,
+    SourceRole, TelemetryBatch, TelemetrySample,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
@@ -142,6 +142,7 @@ pub(super) fn mavlink_batch(vehicle: VehicleId, state: &Arc<Mutex<LinkState>>) -
             avionics,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         }],
     }
 }
@@ -181,6 +182,38 @@ impl super::Px4Adapter {
             kinematics.pos_ned_m,
             validated_velocity(kinematics),
         ))
+    }
+}
+
+impl super::Px4Adapter {
+    /// The latest gimbal-device orientation, withheld once stale so a
+    /// frozen value never replays as live. Stamped under the video-
+    /// capture role — payload-device state, never a vehicle estimate and
+    /// never eligible for control validation (LINK-04).
+    pub(super) fn gimbal_attitude(&mut self) -> Option<GimbalAttitudeSample> {
+        let source = self.estimate.as_ref()?;
+        let latest = source.state.lock().ok()?;
+        let device = latest
+            .gimbal_device
+            .filter(|report| report.received_at.elapsed() <= WITHHOLD_AFTER)?;
+        let acquired = device
+            .received_at
+            .checked_duration_since(self.started_at)
+            .unwrap_or_default();
+        Some(GimbalAttitudeSample {
+            quat_wxyz: device.quat_wxyz,
+            rates_rps: device.rates_rps,
+            stamp: MeasurementStamp {
+                role: SourceRole::VideoCapture,
+                integrity: SourceIntegrity::ChecksummedOnly,
+                source_id: 2,
+                source_incarnation: self.arm_incarnation,
+                source_epoch: 1,
+                sequence: device.time_boot_ms,
+                acquired_at_ns: u64::try_from(acquired.as_nanos()).unwrap_or(u64::MAX),
+                clock: MeasurementClock::HostMonotonic,
+            },
+        })
     }
 }
 

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -362,3 +362,127 @@ fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
     let mut buf = [0u8; 128];
     fc.recv_from(&mut buf).expect("arm datagram reaches the FC");
 }
+
+fn gimbal_frame(
+    axes: Vec<(LogicalAxisId, f32)>,
+    edges: Vec<(LogicalButtonId, ButtonEdge)>,
+) -> pilotage_protocol::ScopedControlFrame {
+    let mut built = frame(axes, edges);
+    built.scope = pilotage_protocol::ScopeId::new(super::GIMBAL_SCOPE);
+    built
+}
+
+fn gimbal_control() -> (
+    crate::gimbal::Px4GimbalControl,
+    tokio::sync::mpsc::Receiver<Vec<u8>>,
+) {
+    let (tx, rx) = tokio::sync::mpsc::channel(64);
+    (crate::gimbal::Px4GimbalControl::new(tx, 1, 1), rx)
+}
+
+fn queued_msg_id(rx: &mut tokio::sync::mpsc::Receiver<Vec<u8>>) -> u32 {
+    let buf = rx.try_recv().expect("queued frame");
+    u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16)
+}
+
+#[test]
+fn capabilities_advertise_the_gimbal_scope_alongside_flight() {
+    let (fc, addr) = fake_fc();
+    drop(fc);
+    let (control, _rx) = gimbal_control();
+    let adapter = Px4Adapter::from_state(VehicleId::new(1), live_state())
+        .with_uplink(uplink_to(addr))
+        .with_gimbal(control);
+    let scopes: Vec<String> = adapter.capabilities().vehicles[0]
+        .scopes
+        .iter()
+        .map(|descriptor| descriptor.scope.as_str().to_owned())
+        .collect();
+    assert_eq!(scopes, vec![super::FLIGHT_SCOPE, super::GIMBAL_SCOPE]);
+}
+
+#[test]
+fn gimbal_demands_flow_even_where_flight_control_cannot() {
+    // A bare cache: no estimator authorization, so flight frames are
+    // rejected — but pointing is not flight, and must keep working.
+    let state = Arc::new(Mutex::new(LinkState::default()));
+    let (control, mut rx) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![
+            (LogicalAxisId::new(super::PITCH_AXIS), 0.5),
+            (LogicalAxisId::new(super::YAW_AXIS), -0.25),
+        ],
+        vec![],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    assert_eq!(queued_msg_id(&mut rx), 76, "primary-control claim first");
+    assert_eq!(queued_msg_id(&mut rx), 282, "then the rate demand");
+}
+
+#[test]
+fn gimbal_neutral_button_recentres() {
+    let (control, mut rx) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![],
+        vec![(
+            LogicalButtonId::new(super::GIMBAL_NEUTRAL_BUTTON),
+            ButtonEdge::Pressed,
+        )],
+    ));
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    assert_eq!(queued_msg_id(&mut rx), 76, "primary-control claim first");
+    let buf = rx.try_recv().expect("pitchyaw command");
+    let command = u16::from_le_bytes([buf[38], buf[39]]);
+    assert_eq!(command, 1000, "DO_GIMBAL_MANAGER_PITCHYAW recenters");
+}
+
+#[test]
+fn gimbal_frame_with_flight_axes_is_rejected() {
+    let (control, _rx) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::ROLL_AXIS), 0.5)],
+        vec![],
+    ));
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::UnknownAxis),
+        "the gimbal scope accepts pitch/yaw only"
+    );
+}
+
+#[test]
+fn fresh_claim_denial_rejects_pointing_frames_loudly() {
+    let state = live_state();
+    apply_messages_at(
+        &state,
+        &[(
+            SOURCE,
+            FcMessage::CommandAck {
+                command: 1001,
+                result: 4,
+            },
+        )],
+        0,
+        0,
+        Instant::now(),
+    );
+    let (control, _rx) = gimbal_control();
+    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
+    let outcome = adapter.apply_control(&gimbal_frame(
+        vec![(LogicalAxisId::new(super::PITCH_AXIS), 0.5)],
+        vec![],
+    ));
+    assert!(
+        matches!(
+            outcome.disposition,
+            Disposition::Rejected(RejectReason::Other(_))
+        ),
+        "PX4 ignores non-primary demands silently, so a cached denial \
+         must reject loudly instead: {:?}",
+        outcome.disposition
+    );
+}

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -18,13 +18,13 @@ use pilotage_mavlink::{AuthorizationSource, LinkState};
 use super::{ARM_BUTTON, DISARM_BUTTON, Px4Adapter, RESET_BUTTON, THROTTLE_AXIS};
 use crate::uplink::Px4Uplink;
 
-const SOURCE: FrameSource = FrameSource {
+pub(super) const SOURCE: FrameSource = FrameSource {
     system_id: 1,
     component_id: 1,
     frame_sequence: 0,
 };
 
-fn live_state() -> Arc<Mutex<LinkState>> {
+pub(super) fn live_state() -> Arc<Mutex<LinkState>> {
     live_state_at(Instant::now()).0
 }
 
@@ -70,7 +70,7 @@ fn feed_at(state: &Arc<Mutex<LinkState>>, time_boot_ms: u32, now: Instant) {
     apply_messages_at(state, &messages, 0, 0, now);
 }
 
-fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
+pub(super) fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
     let fc = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
     fc.set_read_timeout(Some(Duration::from_secs(2)))
         .expect("timeout");
@@ -78,7 +78,7 @@ fn fake_fc() -> (UdpSocket, std::net::SocketAddr) {
     (fc, addr)
 }
 
-fn uplink_to(addr: std::net::SocketAddr) -> Px4Uplink {
+pub(super) fn uplink_to(addr: std::net::SocketAddr) -> Px4Uplink {
     Px4Uplink::new(addr).expect("uplink")
 }
 
@@ -155,7 +155,7 @@ fn drive_epoch_advance(state: &Arc<Mutex<LinkState>>, start: Instant) {
     apply_messages_at(state, &trio, 0, 0, start + Duration::from_millis(4_500));
 }
 
-fn frame(
+pub(super) fn frame(
     axes: Vec<(LogicalAxisId, f32)>,
     edges: Vec<(LogicalButtonId, ButtonEdge)>,
 ) -> pilotage_protocol::ScopedControlFrame {
@@ -361,128 +361,4 @@ fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
     );
     let mut buf = [0u8; 128];
     fc.recv_from(&mut buf).expect("arm datagram reaches the FC");
-}
-
-fn gimbal_frame(
-    axes: Vec<(LogicalAxisId, f32)>,
-    edges: Vec<(LogicalButtonId, ButtonEdge)>,
-) -> pilotage_protocol::ScopedControlFrame {
-    let mut built = frame(axes, edges);
-    built.scope = pilotage_protocol::ScopeId::new(super::GIMBAL_SCOPE);
-    built
-}
-
-fn gimbal_control() -> (
-    crate::gimbal::Px4GimbalControl,
-    tokio::sync::mpsc::Receiver<Vec<u8>>,
-) {
-    let (tx, rx) = tokio::sync::mpsc::channel(64);
-    (crate::gimbal::Px4GimbalControl::new(tx, 1, 1), rx)
-}
-
-fn queued_msg_id(rx: &mut tokio::sync::mpsc::Receiver<Vec<u8>>) -> u32 {
-    let buf = rx.try_recv().expect("queued frame");
-    u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16)
-}
-
-#[test]
-fn capabilities_advertise_the_gimbal_scope_alongside_flight() {
-    let (fc, addr) = fake_fc();
-    drop(fc);
-    let (control, _rx) = gimbal_control();
-    let adapter = Px4Adapter::from_state(VehicleId::new(1), live_state())
-        .with_uplink(uplink_to(addr))
-        .with_gimbal(control);
-    let scopes: Vec<String> = adapter.capabilities().vehicles[0]
-        .scopes
-        .iter()
-        .map(|descriptor| descriptor.scope.as_str().to_owned())
-        .collect();
-    assert_eq!(scopes, vec![super::FLIGHT_SCOPE, super::GIMBAL_SCOPE]);
-}
-
-#[test]
-fn gimbal_demands_flow_even_where_flight_control_cannot() {
-    // A bare cache: no estimator authorization, so flight frames are
-    // rejected — but pointing is not flight, and must keep working.
-    let state = Arc::new(Mutex::new(LinkState::default()));
-    let (control, mut rx) = gimbal_control();
-    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
-
-    let outcome = adapter.apply_control(&gimbal_frame(
-        vec![
-            (LogicalAxisId::new(super::PITCH_AXIS), 0.5),
-            (LogicalAxisId::new(super::YAW_AXIS), -0.25),
-        ],
-        vec![],
-    ));
-    assert_eq!(outcome.disposition, Disposition::Accepted);
-    assert_eq!(queued_msg_id(&mut rx), 76, "primary-control claim first");
-    assert_eq!(queued_msg_id(&mut rx), 282, "then the rate demand");
-}
-
-#[test]
-fn gimbal_neutral_button_recentres() {
-    let (control, mut rx) = gimbal_control();
-    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
-    let outcome = adapter.apply_control(&gimbal_frame(
-        vec![],
-        vec![(
-            LogicalButtonId::new(super::GIMBAL_NEUTRAL_BUTTON),
-            ButtonEdge::Pressed,
-        )],
-    ));
-    assert_eq!(outcome.disposition, Disposition::Accepted);
-    assert_eq!(queued_msg_id(&mut rx), 76, "primary-control claim first");
-    let buf = rx.try_recv().expect("pitchyaw command");
-    let command = u16::from_le_bytes([buf[38], buf[39]]);
-    assert_eq!(command, 1000, "DO_GIMBAL_MANAGER_PITCHYAW recenters");
-}
-
-#[test]
-fn gimbal_frame_with_flight_axes_is_rejected() {
-    let (control, _rx) = gimbal_control();
-    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state()).with_gimbal(control);
-    let outcome = adapter.apply_control(&gimbal_frame(
-        vec![(LogicalAxisId::new(super::ROLL_AXIS), 0.5)],
-        vec![],
-    ));
-    assert_eq!(
-        outcome.disposition,
-        Disposition::Rejected(RejectReason::UnknownAxis),
-        "the gimbal scope accepts pitch/yaw only"
-    );
-}
-
-#[test]
-fn fresh_claim_denial_rejects_pointing_frames_loudly() {
-    let state = live_state();
-    apply_messages_at(
-        &state,
-        &[(
-            SOURCE,
-            FcMessage::CommandAck {
-                command: 1001,
-                result: 4,
-            },
-        )],
-        0,
-        0,
-        Instant::now(),
-    );
-    let (control, _rx) = gimbal_control();
-    let mut adapter = Px4Adapter::from_state(VehicleId::new(1), state).with_gimbal(control);
-    let outcome = adapter.apply_control(&gimbal_frame(
-        vec![(LogicalAxisId::new(super::PITCH_AXIS), 0.5)],
-        vec![],
-    ));
-    assert!(
-        matches!(
-            outcome.disposition,
-            Disposition::Rejected(RejectReason::Other(_))
-        ),
-        "PX4 ignores non-primary demands silently, so a cached denial \
-         must reject loudly instead: {:?}",
-        outcome.disposition
-    );
 }

--- a/adapters/px4/src/config.rs
+++ b/adapters/px4/src/config.rs
@@ -21,10 +21,17 @@ pub struct Px4Config {
     pub stream_command_endpoint: SocketAddr,
     /// PX4 onboard endpoint receiving offboard commands.
     pub command_endpoint: SocketAddr,
+    /// Whether this vehicle carries a MAVLink Gimbal Protocol v2 gimbal.
+    /// Off by default: a bare airframe has no gimbal, and advertising
+    /// the `vehicle.gimbal` scope on one would let a client lease a
+    /// payload the vehicle cannot point. `PILOTAGE_PX4_GIMBAL=1` (via
+    /// the launcher) or [`Px4Config::with_gimbal`] enables it.
+    pub gimbal: bool,
 }
 
 impl Px4Config {
-    /// Builds the default endpoint set for an explicit PX4 profile.
+    /// Builds the default endpoint set for an explicit PX4 profile. The
+    /// gimbal capability is off; enable it with [`Px4Config::with_gimbal`].
     #[must_use]
     pub fn new(profile: Px4Profile) -> Self {
         Self {
@@ -32,7 +39,16 @@ impl Px4Config {
             telemetry_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 14_550)),
             stream_command_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 18_570)),
             command_endpoint: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 14_580)),
+            gimbal: false,
         }
+    }
+
+    /// Declares that this vehicle carries a gimbal, so the adapter
+    /// advertises the `vehicle.gimbal` scope and wires its command path.
+    #[must_use]
+    pub fn with_gimbal(mut self, gimbal: bool) -> Self {
+        self.gimbal = gimbal;
+        self
     }
 
     pub(crate) fn link_config(self) -> LinkConfig {

--- a/adapters/px4/src/gimbal.rs
+++ b/adapters/px4/src/gimbal.rs
@@ -32,6 +32,12 @@ const CLAIM_PERIOD: Duration = Duration::from_secs(1);
 /// slower, so a stick release racing a dropped frame must be closed
 /// out from this side.
 const STALE_DEMAND_CUTOFF: Duration = Duration::from_millis(300);
+/// How long idle (zero-rate) demands stay suppressed after a neutral
+/// command: a rate setpoint replaces the manager's angle setpoint
+/// within one control tick, so a continuous zero-rate keepalive stream
+/// would race the one-shot recenter and usually win. Deliberate
+/// nonzero demand breaks through immediately.
+const NEUTRAL_SETTLE: Duration = Duration::from_millis(800);
 
 /// MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW.
 pub(crate) const CMD_GIMBAL_PITCHYAW: u16 = 1000;
@@ -68,6 +74,7 @@ pub struct Px4GimbalControl {
     last_claim: Option<Instant>,
     last_demand: Option<Instant>,
     streaming: bool,
+    neutral_settle_until: Option<Instant>,
     dropped_sends: u64,
     clock: GimbalClock,
 }
@@ -84,6 +91,7 @@ impl Px4GimbalControl {
             last_claim: None,
             last_demand: None,
             streaming: false,
+            neutral_settle_until: None,
             dropped_sends: 0,
             clock: GimbalClock::System,
         }
@@ -141,7 +149,17 @@ impl Px4GimbalControl {
 
     /// Converts one canonical gimbal stick frame (`[-1, 1]` pitch/yaw;
     /// pitch + = camera up, yaw + = camera right) into a rate demand.
+    /// Idle (zero) demands inside the neutral settle window are dropped
+    /// so the recenter's angle setpoint survives; real demand clears
+    /// the window and steers immediately.
     pub fn rate_demand(&mut self, pitch: f32, yaw: f32) {
+        let idle = pitch == 0.0 && yaw == 0.0;
+        if let Some(until) = self.neutral_settle_until {
+            if idle && self.clock.now() < until {
+                return;
+            }
+            self.neutral_settle_until = None;
+        }
         self.claim_if_due();
         let frame = encode_gimbal_rate_setpoint(
             self.seq,
@@ -179,6 +197,11 @@ impl Px4GimbalControl {
             self.target_component,
         );
         self.send(&frame);
+        self.neutral_settle_until = Some(self.clock.now() + NEUTRAL_SETTLE);
+        // The stale-demand cutoff would also emit a zero-rate setpoint
+        // into the settle window; the stream restarts with the next
+        // accepted demand instead.
+        self.streaming = false;
         info!("gimbal neutral commanded");
     }
 
@@ -323,5 +346,43 @@ mod tests {
             (76, Some(super::CMD_GIMBAL_CONFIGURE))
         );
         assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
+    }
+
+    #[test]
+    fn neutral_settle_window_holds_off_idle_keepalives() {
+        let (mut control, mut rx) = control();
+        control.neutral();
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
+        // Idle keepalives inside the window are dropped: a zero-rate
+        // setpoint would replace the angle target and cancel the recenter.
+        control.rate_demand(0.0, 0.0);
+        control.advance_clock(Duration::from_millis(400));
+        control.rate_demand(0.0, 0.0);
+        control.maintain();
+        assert!(rx.try_recv().is_err(), "the settle window must stay quiet");
+        // Past the window the keepalive stream resumes.
+        control.advance_clock(Duration::from_millis(500));
+        control.rate_demand(0.0, 0.0);
+        assert_eq!(queued_kind(&mut rx).0, 282);
+    }
+
+    #[test]
+    fn real_demand_breaks_through_the_settle_window() {
+        let (mut control, mut rx) = control();
+        control.neutral();
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
+        control.advance_clock(Duration::from_millis(100));
+        control.rate_demand(0.5, 0.0);
+        let buf = rx.try_recv().expect("deliberate demand steers immediately");
+        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
+        assert_eq!(msg_id, 282);
     }
 }

--- a/adapters/px4/src/gimbal.rs
+++ b/adapters/px4/src/gimbal.rs
@@ -2,22 +2,25 @@
 //! claim discipline, stick-rate streaming, the stale-demand cutoff,
 //! and the neutral reset.
 //!
-//! Frames leave through the telemetry link's own socket (the FC's GCS
-//! instance retargets its stream to the last peer that spoke, so a
-//! second socket would steal the telemetry stream). PX4 silently
-//! ignores GIMBAL_MANAGER_SET_ATTITUDE from a sender that does not
-//! hold primary control, so the claim is re-asserted periodically
-//! while demands flow instead of being trusted once.
+//! Two typed lanes reach the FC's GCS instance through the telemetry
+//! link's own socket (the instance retargets its stream to the last
+//! peer that spoke, so a second socket would steal the telemetry
+//! stream). The link task owns the socket's single MAVLink sequence and
+//! does all encoding: claims and recenters ride an ordered command
+//! queue, while rate demands ride a latest-value lane so a stalled link
+//! coalesces stale demands instead of queueing them. PX4 silently
+//! ignores GIMBAL_MANAGER_SET_ATTITUDE from a sender that does not hold
+//! primary control, so the claim is re-asserted periodically while
+//! demands flow.
 
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
 use tracing::{info, warn};
 
-use pilotage_mavlink::codec::{
-    GCS_COMPONENT_ID, GCS_SYSTEM_ID, GIMBAL_FLAGS_HORIZON_YAW_FOLLOW, encode_command_long,
-    encode_gimbal_rate_setpoint,
-};
+use pilotage_mavlink::codec::{GCS_COMPONENT_ID, GCS_SYSTEM_ID, GIMBAL_FLAGS_HORIZON_YAW_FOLLOW};
+use pilotage_mavlink::{GimbalRateDemand, OutboundCommand};
 
 /// Full-stick gimbal pitch rate (~46°/s).
 const MAX_PITCH_RATE_RPS: f32 = 0.8;
@@ -64,11 +67,11 @@ impl GimbalClock {
     }
 }
 
-/// The gimbal-manager command path riding the telemetry link's socket.
+/// The gimbal-manager command path over the link's typed lanes.
 #[derive(Debug)]
 pub struct Px4GimbalControl {
-    outbound: Sender<Vec<u8>>,
-    seq: u8,
+    commands: Sender<OutboundCommand>,
+    rates: watch::Sender<Option<GimbalRateDemand>>,
     target_system: u8,
     target_component: u8,
     last_claim: Option<Instant>,
@@ -80,12 +83,18 @@ pub struct Px4GimbalControl {
 }
 
 impl Px4GimbalControl {
-    /// Wires the control path onto a link's outbound sender.
-    pub fn new(outbound: Sender<Vec<u8>>, target_system: u8, target_component: u8) -> Self {
+    /// Wires the control path onto a link's ordered command lane and
+    /// latest-value rate lane.
+    pub fn new(
+        commands: Sender<OutboundCommand>,
+        rates: watch::Sender<Option<GimbalRateDemand>>,
+        target_system: u8,
+        target_component: u8,
+    ) -> Self {
         info!("PX4 gimbal-manager control path ready");
         Self {
-            outbound,
-            seq: 0,
+            commands,
+            rates,
             target_system,
             target_component,
             last_claim: None,
@@ -97,40 +106,53 @@ impl Px4GimbalControl {
         }
     }
 
-    /// Total frames refused by the outbound queue, for enactment-truth
-    /// counter deltas.
+    /// Total commands or demands refused by a full or closed lane, for
+    /// enactment-truth counter deltas.
     #[must_use]
     pub fn dropped_sends(&self) -> u64 {
         self.dropped_sends
     }
 
-    fn send(&mut self, frame: &[u8]) {
-        if self.outbound.try_send(frame.to_vec()).is_err() {
-            self.dropped_sends = self.dropped_sends.wrapping_add(1);
-            if self.dropped_sends == 1 || self.dropped_sends.is_multiple_of(100) {
-                warn!(
-                    dropped = self.dropped_sends,
-                    "gimbal uplink frame dropped: outbound queue unavailable"
-                );
-            }
+    /// Enqueues a reliable COMMAND_LONG. Returns false when the ordered
+    /// lane is full or closed — a claim or recenter that never reached
+    /// the wire must not be reported as applied.
+    fn send_command(&mut self, command: u16, params: [f32; 7]) -> bool {
+        let message = OutboundCommand {
+            command,
+            params,
+            target_system: self.target_system,
+            target_component: self.target_component,
+        };
+        if self.commands.try_send(message).is_err() {
+            self.record_drop();
+            return false;
         }
-        self.seq = self.seq.wrapping_add(1);
+        true
+    }
+
+    fn record_drop(&mut self) {
+        self.dropped_sends = self.dropped_sends.wrapping_add(1);
+        if self.dropped_sends == 1 || self.dropped_sends.is_multiple_of(100) {
+            warn!(
+                dropped = self.dropped_sends,
+                "gimbal uplink send dropped: lane full or closed"
+            );
+        }
     }
 
     /// Re-asserts the primary-control claim when due: CONFIGURE naming
     /// this codec's GCS identity as primary, leaving the secondary
-    /// holder unchanged (-1 per the command convention).
-    fn claim_if_due(&mut self) {
+    /// holder unchanged (-1 per the command convention). Returns false
+    /// when a due claim could not be enqueued.
+    fn claim_if_due(&mut self) -> bool {
         let now = self.clock.now();
         if self
             .last_claim
             .is_some_and(|at| now.duration_since(at) < CLAIM_PERIOD)
         {
-            return;
+            return true;
         }
-        self.last_claim = Some(now);
-        let frame = encode_command_long(
-            self.seq,
+        let sent = self.send_command(
             CMD_GIMBAL_CONFIGURE,
             [
                 f32::from(GCS_SYSTEM_ID),
@@ -141,45 +163,59 @@ impl Px4GimbalControl {
                 0.0,
                 0.0,
             ],
-            self.target_system,
-            self.target_component,
         );
-        self.send(&frame);
+        if sent {
+            self.last_claim = Some(now);
+        }
+        sent
+    }
+
+    /// Publishes the latest gimbal rate demand. Returns false when the
+    /// rate lane has no receiver (the link was torn down).
+    fn publish_rate(&mut self, pitch_rps: f32, yaw_rps: f32) -> bool {
+        let demand = GimbalRateDemand {
+            pitch_rps,
+            yaw_rps,
+            target_system: self.target_system,
+            target_component: self.target_component,
+        };
+        if self.rates.send(Some(demand)).is_err() {
+            self.record_drop();
+            return false;
+        }
+        true
     }
 
     /// Converts one canonical gimbal stick frame (`[-1, 1]` pitch/yaw;
     /// pitch + = camera up, yaw + = camera right) into a rate demand.
     /// Idle (zero) demands inside the neutral settle window are dropped
     /// so the recenter's angle setpoint survives; real demand clears
-    /// the window and steers immediately.
-    pub fn rate_demand(&mut self, pitch: f32, yaw: f32) {
+    /// the window and steers immediately. Returns false when the demand
+    /// could not be delivered.
+    pub fn rate_demand(&mut self, pitch: f32, yaw: f32) -> bool {
         let idle = pitch == 0.0 && yaw == 0.0;
         if let Some(until) = self.neutral_settle_until {
             if idle && self.clock.now() < until {
-                return;
+                return true;
             }
             self.neutral_settle_until = None;
         }
-        self.claim_if_due();
-        let frame = encode_gimbal_rate_setpoint(
-            self.seq,
-            pitch * MAX_PITCH_RATE_RPS,
-            yaw * MAX_YAW_RATE_RPS,
-            self.target_system,
-            self.target_component,
-        );
-        self.send(&frame);
+        let claimed = self.claim_if_due();
+        let published = self.publish_rate(pitch * MAX_PITCH_RATE_RPS, yaw * MAX_YAW_RATE_RPS);
         self.last_demand = Some(self.clock.now());
         self.streaming = true;
+        claimed && published
     }
 
     /// Recenters the gimbal: an absolute zero-pitch/zero-yaw angle
-    /// command under the horizon/yaw-follow flags, so the camera
-    /// returns level and forward.
-    pub fn neutral(&mut self) {
-        self.claim_if_due();
-        let frame = encode_command_long(
-            self.seq,
+    /// command under the horizon/yaw-follow flags, so the camera returns
+    /// level and forward. Clears the rate lane so no stale demand
+    /// overrides the angle setpoint, and opens a settle window against
+    /// idle keepalives. Returns false when the command could not be
+    /// enqueued.
+    pub fn neutral(&mut self) -> bool {
+        let claimed = self.claim_if_due();
+        let sent = self.send_command(
             CMD_GIMBAL_PITCHYAW,
             [
                 0.0,
@@ -193,20 +229,18 @@ impl Px4GimbalControl {
                 0.0,
                 0.0,
             ],
-            self.target_system,
-            self.target_component,
         );
-        self.send(&frame);
+        // Drop any lingering rate demand so the link stops emitting rate
+        // setpoints that would overwrite the recenter's angle target.
+        self.rates.send(None).ok();
         self.neutral_settle_until = Some(self.clock.now() + NEUTRAL_SETTLE);
-        // The stale-demand cutoff would also emit a zero-rate setpoint
-        // into the settle window; the stream restarts with the next
-        // accepted demand instead.
         self.streaming = false;
         info!("gimbal neutral commanded");
+        claimed && sent
     }
 
-    /// Closes out a silent demand stream: one zero-rate setpoint when
-    /// no demand has arrived within the cutoff, so a released stick or
+    /// Closes out a silent demand stream: one zero-rate setpoint when no
+    /// demand has arrived within the cutoff, so a released stick or
     /// dropped control frame cannot leave the gimbal slewing. Call at
     /// telemetry-sampling cadence.
     pub fn maintain(&mut self) {
@@ -218,14 +252,7 @@ impl Px4GimbalControl {
             .last_demand
             .is_none_or(|at| now.duration_since(at) >= STALE_DEMAND_CUTOFF)
         {
-            let frame = encode_gimbal_rate_setpoint(
-                self.seq,
-                0.0,
-                0.0,
-                self.target_system,
-                self.target_component,
-            );
-            self.send(&frame);
+            let _ = self.publish_rate(0.0, 0.0);
             self.streaming = false;
             info!("gimbal demand stream cut off with a zero-rate setpoint");
         }
@@ -257,132 +284,149 @@ impl Px4GimbalControl {
 mod tests {
     use std::time::Duration;
 
+    use pilotage_mavlink::{GimbalRateDemand, OutboundCommand};
+    use tokio::sync::{mpsc, watch};
+
     use super::Px4GimbalControl;
 
-    fn control() -> (Px4GimbalControl, tokio::sync::mpsc::Receiver<Vec<u8>>) {
-        let (tx, rx) = tokio::sync::mpsc::channel(64);
-        let mut control = Px4GimbalControl::new(tx, 1, 1);
-        control.use_manual_clock();
-        (control, rx)
+    struct Lanes {
+        commands: mpsc::Receiver<OutboundCommand>,
+        rates: watch::Receiver<Option<GimbalRateDemand>>,
     }
 
-    fn queued_kind(rx: &mut tokio::sync::mpsc::Receiver<Vec<u8>>) -> (u32, Option<u16>) {
-        let buf = rx.try_recv().expect("queued frame");
-        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
-        let command = (msg_id == 76).then(|| u16::from_le_bytes([buf[38], buf[39]]));
-        (msg_id, command)
+    fn control() -> (Px4GimbalControl, Lanes) {
+        let (command_tx, command_rx) = mpsc::channel(16);
+        let (rate_tx, rate_rx) = watch::channel(None);
+        let mut control = Px4GimbalControl::new(command_tx, rate_tx, 1, 1);
+        control.use_manual_clock();
+        (
+            control,
+            Lanes {
+                commands: command_rx,
+                rates: rate_rx,
+            },
+        )
+    }
+
+    fn next_command(lanes: &mut Lanes) -> u16 {
+        lanes.commands.try_recv().expect("queued command").command
+    }
+
+    fn latest_rate(lanes: &mut Lanes) -> Option<GimbalRateDemand> {
+        *lanes.rates.borrow_and_update()
     }
 
     #[test]
     fn first_demand_claims_before_streaming() {
-        let (mut control, mut rx) = control();
-        control.rate_demand(0.5, -0.25);
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx).0, 282);
+        let (mut control, mut lanes) = control();
+        assert!(control.rate_demand(0.5, -0.25));
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
+        let rate = latest_rate(&mut lanes).expect("rate published");
+        assert!(rate.pitch_rps > 0.0 && rate.yaw_rps < 0.0);
         assert!(control.streaming());
     }
 
     #[test]
     fn claim_reasserts_only_after_its_period() {
-        let (mut control, mut rx) = control();
+        let (mut control, mut lanes) = control();
         control.rate_demand(0.1, 0.0);
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx).0, 282);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
         // Within the period: demands stream without a fresh claim.
         control.advance_clock(Duration::from_millis(400));
         control.rate_demand(0.2, 0.0);
-        assert_eq!(queued_kind(&mut rx).0, 282);
-        // Past the period: the claim re-heals before the next demand.
+        assert!(
+            lanes.commands.try_recv().is_err(),
+            "no re-claim within period"
+        );
+        // Past the period: the claim re-heals with the next demand.
         control.advance_clock(Duration::from_millis(700));
         control.rate_demand(0.3, 0.0);
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx).0, 282);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
     }
 
     #[test]
     fn stale_demand_stream_cuts_off_with_one_zero_rate() {
-        let (mut control, mut rx) = control();
+        let (mut control, mut lanes) = control();
         control.rate_demand(1.0, 1.0);
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx).0, 282);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
+        latest_rate(&mut lanes);
         // Fresh demands keep the stream open.
         control.advance_clock(Duration::from_millis(100));
         control.maintain();
-        assert!(rx.try_recv().is_err(), "no cutoff while fresh");
+        assert!(
+            !lanes.rates.has_changed().unwrap_or(false),
+            "no cutoff while fresh"
+        );
         // Silence past the cutoff closes the stream with zero rates.
         control.advance_clock(Duration::from_millis(400));
         control.maintain();
-        let buf = rx.try_recv().expect("cutoff frame");
-        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
-        assert_eq!(msg_id, 282);
-        let pitch = f32::from_le_bytes([buf[34], buf[35], buf[36], buf[37]]);
-        let yaw = f32::from_le_bytes([buf[38], buf[39], buf[40], buf[41]]);
-        assert_eq!((pitch, yaw), (0.0, 0.0));
+        let rate = latest_rate(&mut lanes).expect("cutoff demand");
+        assert_eq!((rate.pitch_rps, rate.yaw_rps), (0.0, 0.0));
         assert!(!control.streaming());
-        // The cutoff fires once, not forever.
-        control.advance_clock(Duration::from_millis(400));
-        control.maintain();
-        assert!(rx.try_recv().is_err(), "cutoff is one-shot");
     }
 
     #[test]
-    fn neutral_sends_the_pitchyaw_command() {
-        let (mut control, mut rx) = control();
-        control.neutral();
+    fn neutral_sends_the_pitchyaw_command_and_clears_rates() {
+        let (mut control, mut lanes) = control();
+        control.rate_demand(0.5, 0.0);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
+        latest_rate(&mut lanes);
+        assert!(control.neutral());
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_PITCHYAW);
         assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+            latest_rate(&mut lanes),
+            None,
+            "rate lane cleared for the recenter"
         );
-        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
     }
 
     #[test]
     fn neutral_settle_window_holds_off_idle_keepalives() {
-        let (mut control, mut rx) = control();
+        let (mut control, mut lanes) = control();
         control.neutral();
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
-        // Idle keepalives inside the window are dropped: a zero-rate
-        // setpoint would replace the angle target and cancel the recenter.
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_PITCHYAW);
+        latest_rate(&mut lanes);
+        // Idle keepalives inside the window do not repopulate the lane.
         control.rate_demand(0.0, 0.0);
         control.advance_clock(Duration::from_millis(400));
         control.rate_demand(0.0, 0.0);
-        control.maintain();
-        assert!(rx.try_recv().is_err(), "the settle window must stay quiet");
+        assert!(
+            !lanes.rates.has_changed().unwrap_or(false),
+            "the settle window must keep the rate lane quiet"
+        );
         // Past the window the keepalive stream resumes.
         control.advance_clock(Duration::from_millis(500));
         control.rate_demand(0.0, 0.0);
-        assert_eq!(queued_kind(&mut rx).0, 282);
+        assert!(lanes.rates.has_changed().unwrap_or(false));
     }
 
     #[test]
     fn real_demand_breaks_through_the_settle_window() {
-        let (mut control, mut rx) = control();
+        let (mut control, mut lanes) = control();
         control.neutral();
-        assert_eq!(
-            queued_kind(&mut rx),
-            (76, Some(super::CMD_GIMBAL_CONFIGURE))
-        );
-        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_CONFIGURE);
+        assert_eq!(next_command(&mut lanes), super::CMD_GIMBAL_PITCHYAW);
+        latest_rate(&mut lanes);
         control.advance_clock(Duration::from_millis(100));
-        control.rate_demand(0.5, 0.0);
-        let buf = rx.try_recv().expect("deliberate demand steers immediately");
-        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
-        assert_eq!(msg_id, 282);
+        assert!(control.rate_demand(0.5, 0.0));
+        let rate = latest_rate(&mut lanes).expect("deliberate demand steers immediately");
+        assert!(rate.pitch_rps > 0.0);
+    }
+
+    #[test]
+    fn a_closed_command_lane_reports_a_dropped_send() {
+        let (command_tx, command_rx) = mpsc::channel(1);
+        let (rate_tx, _rate_rx) = watch::channel(None);
+        let mut control = Px4GimbalControl::new(command_tx, rate_tx, 1, 1);
+        control.use_manual_clock();
+        // Closing the lane (receiver dropped) makes the due claim's
+        // try_send fail, so the recenter cannot be reported as applied.
+        drop(command_rx);
+        assert!(
+            !control.neutral(),
+            "a command that never reached the wire is not applied"
+        );
+        assert!(control.dropped_sends() >= 1);
     }
 }

--- a/adapters/px4/src/gimbal.rs
+++ b/adapters/px4/src/gimbal.rs
@@ -1,0 +1,327 @@
+//! PX4 gimbal-manager uplink (Gimbal Protocol v2): the primary-control
+//! claim discipline, stick-rate streaming, the stale-demand cutoff,
+//! and the neutral reset.
+//!
+//! Frames leave through the telemetry link's own socket (the FC's GCS
+//! instance retargets its stream to the last peer that spoke, so a
+//! second socket would steal the telemetry stream). PX4 silently
+//! ignores GIMBAL_MANAGER_SET_ATTITUDE from a sender that does not
+//! hold primary control, so the claim is re-asserted periodically
+//! while demands flow instead of being trusted once.
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
+
+use pilotage_mavlink::codec::{
+    GCS_COMPONENT_ID, GCS_SYSTEM_ID, GIMBAL_FLAGS_HORIZON_YAW_FOLLOW, encode_command_long,
+    encode_gimbal_rate_setpoint,
+};
+
+/// Full-stick gimbal pitch rate (~46°/s).
+const MAX_PITCH_RATE_RPS: f32 = 0.8;
+/// Full-stick gimbal yaw rate (~46°/s).
+const MAX_YAW_RATE_RPS: f32 = 0.8;
+/// How often the primary-control claim is re-asserted while demands
+/// flow: a claim lost to an FC restart or a competing GCS re-heals
+/// within this bound.
+const CLAIM_PERIOD: Duration = Duration::from_secs(1);
+/// A demand stream silent longer than this is cut off with one
+/// zero-rate setpoint. The FC's own stale-setpoint fallback is far
+/// slower, so a stick release racing a dropped frame must be closed
+/// out from this side.
+const STALE_DEMAND_CUTOFF: Duration = Duration::from_millis(300);
+
+/// MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW.
+pub(crate) const CMD_GIMBAL_PITCHYAW: u16 = 1000;
+/// MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE.
+pub(crate) const CMD_GIMBAL_CONFIGURE: u16 = 1001;
+
+/// The gimbal control clock; tests substitute a manually advanced
+/// instant so the claim and cutoff cadences are exercised without
+/// real-time sleeps.
+#[derive(Debug)]
+enum GimbalClock {
+    System,
+    #[cfg(test)]
+    Manual(Instant),
+}
+
+impl GimbalClock {
+    fn now(&self) -> Instant {
+        match self {
+            Self::System => Instant::now(),
+            #[cfg(test)]
+            Self::Manual(at) => *at,
+        }
+    }
+}
+
+/// The gimbal-manager command path riding the telemetry link's socket.
+#[derive(Debug)]
+pub struct Px4GimbalControl {
+    outbound: Sender<Vec<u8>>,
+    seq: u8,
+    target_system: u8,
+    target_component: u8,
+    last_claim: Option<Instant>,
+    last_demand: Option<Instant>,
+    streaming: bool,
+    dropped_sends: u64,
+    clock: GimbalClock,
+}
+
+impl Px4GimbalControl {
+    /// Wires the control path onto a link's outbound sender.
+    pub fn new(outbound: Sender<Vec<u8>>, target_system: u8, target_component: u8) -> Self {
+        info!("PX4 gimbal-manager control path ready");
+        Self {
+            outbound,
+            seq: 0,
+            target_system,
+            target_component,
+            last_claim: None,
+            last_demand: None,
+            streaming: false,
+            dropped_sends: 0,
+            clock: GimbalClock::System,
+        }
+    }
+
+    /// Total frames refused by the outbound queue, for enactment-truth
+    /// counter deltas.
+    #[must_use]
+    pub fn dropped_sends(&self) -> u64 {
+        self.dropped_sends
+    }
+
+    fn send(&mut self, frame: &[u8]) {
+        if self.outbound.try_send(frame.to_vec()).is_err() {
+            self.dropped_sends = self.dropped_sends.wrapping_add(1);
+            if self.dropped_sends == 1 || self.dropped_sends.is_multiple_of(100) {
+                warn!(
+                    dropped = self.dropped_sends,
+                    "gimbal uplink frame dropped: outbound queue unavailable"
+                );
+            }
+        }
+        self.seq = self.seq.wrapping_add(1);
+    }
+
+    /// Re-asserts the primary-control claim when due: CONFIGURE naming
+    /// this codec's GCS identity as primary, leaving the secondary
+    /// holder unchanged (-1 per the command convention).
+    fn claim_if_due(&mut self) {
+        let now = self.clock.now();
+        if self
+            .last_claim
+            .is_some_and(|at| now.duration_since(at) < CLAIM_PERIOD)
+        {
+            return;
+        }
+        self.last_claim = Some(now);
+        let frame = encode_command_long(
+            self.seq,
+            CMD_GIMBAL_CONFIGURE,
+            [
+                f32::from(GCS_SYSTEM_ID),
+                f32::from(GCS_COMPONENT_ID),
+                -1.0,
+                -1.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            self.target_system,
+            self.target_component,
+        );
+        self.send(&frame);
+    }
+
+    /// Converts one canonical gimbal stick frame (`[-1, 1]` pitch/yaw;
+    /// pitch + = camera up, yaw + = camera right) into a rate demand.
+    pub fn rate_demand(&mut self, pitch: f32, yaw: f32) {
+        self.claim_if_due();
+        let frame = encode_gimbal_rate_setpoint(
+            self.seq,
+            pitch * MAX_PITCH_RATE_RPS,
+            yaw * MAX_YAW_RATE_RPS,
+            self.target_system,
+            self.target_component,
+        );
+        self.send(&frame);
+        self.last_demand = Some(self.clock.now());
+        self.streaming = true;
+    }
+
+    /// Recenters the gimbal: an absolute zero-pitch/zero-yaw angle
+    /// command under the horizon/yaw-follow flags, so the camera
+    /// returns level and forward.
+    pub fn neutral(&mut self) {
+        self.claim_if_due();
+        let frame = encode_command_long(
+            self.seq,
+            CMD_GIMBAL_PITCHYAW,
+            [
+                0.0,
+                0.0,
+                f32::NAN,
+                f32::NAN,
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    GIMBAL_FLAGS_HORIZON_YAW_FOLLOW as f32
+                },
+                0.0,
+                0.0,
+            ],
+            self.target_system,
+            self.target_component,
+        );
+        self.send(&frame);
+        info!("gimbal neutral commanded");
+    }
+
+    /// Closes out a silent demand stream: one zero-rate setpoint when
+    /// no demand has arrived within the cutoff, so a released stick or
+    /// dropped control frame cannot leave the gimbal slewing. Call at
+    /// telemetry-sampling cadence.
+    pub fn maintain(&mut self) {
+        if !self.streaming {
+            return;
+        }
+        let now = self.clock.now();
+        if self
+            .last_demand
+            .is_none_or(|at| now.duration_since(at) >= STALE_DEMAND_CUTOFF)
+        {
+            let frame = encode_gimbal_rate_setpoint(
+                self.seq,
+                0.0,
+                0.0,
+                self.target_system,
+                self.target_component,
+            );
+            self.send(&frame);
+            self.streaming = false;
+            info!("gimbal demand stream cut off with a zero-rate setpoint");
+        }
+    }
+
+    /// Whether a demand stream is active, for tests.
+    #[cfg(test)]
+    pub(crate) fn streaming(&self) -> bool {
+        self.streaming
+    }
+
+    /// Switches to the manual clock, for tests.
+    #[cfg(test)]
+    pub(crate) fn use_manual_clock(&mut self) {
+        self.clock = GimbalClock::Manual(Instant::now());
+    }
+
+    /// Advances the manual clock, for tests.
+    #[cfg(test)]
+    pub(crate) fn advance_clock(&mut self, by: Duration) {
+        if let GimbalClock::Manual(at) = &mut self.clock {
+            *at += by;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::time::Duration;
+
+    use super::Px4GimbalControl;
+
+    fn control() -> (Px4GimbalControl, tokio::sync::mpsc::Receiver<Vec<u8>>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let mut control = Px4GimbalControl::new(tx, 1, 1);
+        control.use_manual_clock();
+        (control, rx)
+    }
+
+    fn queued_kind(rx: &mut tokio::sync::mpsc::Receiver<Vec<u8>>) -> (u32, Option<u16>) {
+        let buf = rx.try_recv().expect("queued frame");
+        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
+        let command = (msg_id == 76).then(|| u16::from_le_bytes([buf[38], buf[39]]));
+        (msg_id, command)
+    }
+
+    #[test]
+    fn first_demand_claims_before_streaming() {
+        let (mut control, mut rx) = control();
+        control.rate_demand(0.5, -0.25);
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx).0, 282);
+        assert!(control.streaming());
+    }
+
+    #[test]
+    fn claim_reasserts_only_after_its_period() {
+        let (mut control, mut rx) = control();
+        control.rate_demand(0.1, 0.0);
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx).0, 282);
+        // Within the period: demands stream without a fresh claim.
+        control.advance_clock(Duration::from_millis(400));
+        control.rate_demand(0.2, 0.0);
+        assert_eq!(queued_kind(&mut rx).0, 282);
+        // Past the period: the claim re-heals before the next demand.
+        control.advance_clock(Duration::from_millis(700));
+        control.rate_demand(0.3, 0.0);
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx).0, 282);
+    }
+
+    #[test]
+    fn stale_demand_stream_cuts_off_with_one_zero_rate() {
+        let (mut control, mut rx) = control();
+        control.rate_demand(1.0, 1.0);
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx).0, 282);
+        // Fresh demands keep the stream open.
+        control.advance_clock(Duration::from_millis(100));
+        control.maintain();
+        assert!(rx.try_recv().is_err(), "no cutoff while fresh");
+        // Silence past the cutoff closes the stream with zero rates.
+        control.advance_clock(Duration::from_millis(400));
+        control.maintain();
+        let buf = rx.try_recv().expect("cutoff frame");
+        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
+        assert_eq!(msg_id, 282);
+        let pitch = f32::from_le_bytes([buf[34], buf[35], buf[36], buf[37]]);
+        let yaw = f32::from_le_bytes([buf[38], buf[39], buf[40], buf[41]]);
+        assert_eq!((pitch, yaw), (0.0, 0.0));
+        assert!(!control.streaming());
+        // The cutoff fires once, not forever.
+        control.advance_clock(Duration::from_millis(400));
+        control.maintain();
+        assert!(rx.try_recv().is_err(), "cutoff is one-shot");
+    }
+
+    #[test]
+    fn neutral_sends_the_pitchyaw_command() {
+        let (mut control, mut rx) = control();
+        control.neutral();
+        assert_eq!(
+            queued_kind(&mut rx),
+            (76, Some(super::CMD_GIMBAL_CONFIGURE))
+        );
+        assert_eq!(queued_kind(&mut rx), (76, Some(super::CMD_GIMBAL_PITCHYAW)));
+    }
+}

--- a/adapters/px4/src/gimbal.rs
+++ b/adapters/px4/src/gimbal.rs
@@ -200,11 +200,16 @@ impl Px4GimbalControl {
             }
             self.neutral_settle_until = None;
         }
-        let claimed = self.claim_if_due();
+        // Do not stream a rate the FC would drop: if a due claim could
+        // not be enqueued, the sender does not hold primary control, so
+        // report the demand rejected without publishing it.
+        if !self.claim_if_due() {
+            return false;
+        }
         let published = self.publish_rate(pitch * MAX_PITCH_RATE_RPS, yaw * MAX_YAW_RATE_RPS);
         self.last_demand = Some(self.clock.now());
         self.streaming = true;
-        claimed && published
+        published
     }
 
     /// Recenters the gimbal: an absolute zero-pitch/zero-yaw angle
@@ -252,9 +257,13 @@ impl Px4GimbalControl {
             .last_demand
             .is_none_or(|at| now.duration_since(at) >= STALE_DEMAND_CUTOFF)
         {
-            let _ = self.publish_rate(0.0, 0.0);
             self.streaming = false;
-            info!("gimbal demand stream cut off with a zero-rate setpoint");
+            // Only claim the cutoff succeeded if the zero-rate setpoint
+            // actually reached the lane; a closed lane means the link is
+            // gone and there is nothing left to cut off.
+            if self.publish_rate(0.0, 0.0) {
+                info!("gimbal demand stream cut off with a zero-rate setpoint");
+            }
         }
     }
 

--- a/adapters/px4/src/lib.rs
+++ b/adapters/px4/src/lib.rs
@@ -17,12 +17,14 @@
 mod adapter;
 mod config;
 mod error;
+mod gimbal;
 mod uplink;
 
 pub use adapter::{
-    ARM_BUTTON, DISARM_BUTTON, FLIGHT_SCOPE, PITCH_AXIS, Px4Adapter, RESET_BUTTON, ROLL_AXIS,
-    THROTTLE_AXIS, YAW_AXIS,
+    ARM_BUTTON, DISARM_BUTTON, FLIGHT_SCOPE, GIMBAL_NEUTRAL_BUTTON, GIMBAL_SCOPE, PITCH_AXIS,
+    Px4Adapter, RESET_BUTTON, ROLL_AXIS, THROTTLE_AXIS, YAW_AXIS,
 };
 pub use config::{Px4Config, Px4Profile};
 pub use error::Px4AdapterError;
+pub use gimbal::Px4GimbalControl;
 pub use uplink::Px4Uplink;

--- a/adapters/reference-headless/src/adapter.rs
+++ b/adapters/reference-headless/src/adapter.rs
@@ -220,6 +220,7 @@ impl VehicleAdapter for ReferenceAdapter {
                 avionics: None,
                 sim_truth: None,
                 fc_state: None,
+                gimbal: None,
             }],
         }
     }

--- a/clients/web-instruments/src/decode_envelope.rs
+++ b/clients/web-instruments/src/decode_envelope.rs
@@ -420,6 +420,7 @@ mod tests {
             avionics: None,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         };
         let message = telemetry_message(sample);
         assert_eq!(message.vehicle_id, 1);

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -565,7 +565,7 @@ function decodeLeaseReleased(bytes) {
 }
 
 // telemetry.proto TelemetrySample: vehicle=1, tick=2, observed_at=3, pose=4,
-// velocity=5, avionics=6, sim_truth=7, fc_state=8
+// velocity=5, avionics=6, sim_truth=7, fc_state=8, gimbal=9
 // Pose2d: x_m=1, y_m=2, heading_rad=3 (all float, wire type 5)
 function decodeTelemetrySample(bytes) {
   if (!bytes) return {};
@@ -586,6 +586,7 @@ function decodeTelemetrySample(bytes) {
     avionics: decodeAvionicsState(firstBytes(fields, 6)),
     simTruth: decodeSimTruthState(firstBytes(fields, 7)),
     fcState: decodeFcState(firstBytes(fields, 8)),
+    gimbal: decodeGimbalAttitude(firstBytes(fields, 9)),
   };
 }
 
@@ -632,6 +633,34 @@ function decodeFcState(bytes) {
   if (stamp === null || stamp.role !== 3) return null;
   return {
     armState: firstVarint(f, 1) ?? 0,
+    stamp,
+  };
+}
+
+// telemetry.proto GimbalAttitude: quat_w..z=1..4, rate_x/y/z_rad_s=5..7,
+// stamp=8, flags=9, failure_flags=10. Payload-device orientation under its
+// own provenance; unconsumable (null) without a payload-device stamp, so a
+// mislabeled lane can never point the camera view or be read as FC state.
+function decodeGimbalAttitude(bytes) {
+  if (!bytes) return null;
+  const f = parseFields(bytes);
+  const stamp = decodeMeasurementStamp(firstBytes(f, 8));
+  // Exact-role gate: the gimbal lane must carry the payload-device role.
+  if (stamp === null || stamp.role !== 5) return null;
+  return {
+    quat: {
+      w: decodeFloat32(firstBytes(f, 1)),
+      x: decodeFloat32(firstBytes(f, 2)),
+      y: decodeFloat32(firstBytes(f, 3)),
+      z: decodeFloat32(firstBytes(f, 4)),
+    },
+    ratesRadS: [
+      decodeFloat32(firstBytes(f, 5)),
+      decodeFloat32(firstBytes(f, 6)),
+      decodeFloat32(firstBytes(f, 7)),
+    ],
+    flags: firstVarint(f, 9) ?? 0,
+    failureFlags: firstVarint(f, 10) ?? 0,
     stamp,
   };
 }

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -476,6 +476,70 @@ check(
   check("an fc lane with a non-FC role decodes to null", wrongMessage.fcState === null);
 }
 
+// ---- LINK-04 payload-device lane: gimbal (9) --------------------------------
+// Gimbal attitude travels as its own payload-device-stamped message: it
+// surfaces orientation, rates, flags, and failure flags, and is unconsumable
+// (null) without a payload-device-role stamp, so a mislabeled lane can never
+// drive the camera view or be mistaken for FC state.
+{
+  const gimbal = [];
+  f32Field(gimbal, 1, 1.0); // quat_w
+  f32Field(gimbal, 5, 0.25); // rate_x
+  f32Field(gimbal, 6, -0.5); // rate_y
+  f32Field(gimbal, 7, 0.75); // rate_z
+  bytesField(gimbal, 8, measurementStamp(9, 2, 5000, 5_000_000, 4, 0x33, 5)); // payload-device role
+  varint(gimbal, (9 << 3) | 0); // flags
+  varint(gimbal, 0b101);
+  varint(gimbal, (10 << 3) | 0); // failure_flags
+  varint(gimbal, 0b10);
+
+  const telemetry = [];
+  bytesField(telemetry, 1, uint64Message(1));
+  bytesField(telemetry, 9, gimbal);
+  const envelope = [];
+  varint(envelope, (1 << 3) | 0);
+  varint(envelope, SCHEMA_VERSION);
+  bytesField(envelope, 4, telemetry);
+  const message = decodeBareEnvelope(new Uint8Array(envelope)).message;
+
+  check("gimbal lane decodes orientation and rates",
+    message.gimbal?.quat?.w === 1.0 && message.gimbal?.ratesRadS?.[1] === -0.5);
+  check("gimbal lane surfaces device flags and failure flags",
+    message.gimbal?.flags === 0b101 && message.gimbal?.failureFlags === 0b10);
+  check("gimbal stamp carries the payload-device role and vehicle-boot clock",
+    message.gimbal?.stamp?.role === 5 && message.gimbal?.stamp?.clock === 4);
+
+  // Provenance-free gimbal is unconsumable, not defaulted.
+  const bare = [];
+  f32Field(bare, 1, 1.0);
+  const telemetryBare = [];
+  bytesField(telemetryBare, 1, uint64Message(1));
+  bytesField(telemetryBare, 9, bare);
+  const envelopeBare = [];
+  varint(envelopeBare, (1 << 3) | 0);
+  varint(envelopeBare, SCHEMA_VERSION);
+  bytesField(envelopeBare, 4, telemetryBare);
+  const bareMessage = decodeBareEnvelope(new Uint8Array(envelopeBare)).message;
+  check("an unstamped gimbal decodes to null", bareMessage.gimbal === null);
+
+  // A gimbal lane wearing a non-payload-device role is unconsumable.
+  const wrong = [];
+  f32Field(wrong, 1, 1.0);
+  bytesField(wrong, 8, measurementStamp(9, 2, 6, 6_000_000, 4, 0x33, 3)); // FC role
+  varint(wrong, (9 << 3) | 0);
+  varint(wrong, 0b1);
+  const telemetryWrong = [];
+  bytesField(telemetryWrong, 1, uint64Message(1));
+  bytesField(telemetryWrong, 9, wrong);
+  const envelopeWrong = [];
+  varint(envelopeWrong, (1 << 3) | 0);
+  varint(envelopeWrong, SCHEMA_VERSION);
+  bytesField(envelopeWrong, 4, telemetryWrong);
+  const wrongMessage = decodeBareEnvelope(new Uint8Array(envelopeWrong)).message;
+  check("a gimbal lane with a non-payload-device role decodes to null",
+    wrongMessage.gimbal === null);
+}
+
 // --- a fully neutral frame reports EVERY axis on the wire ---------------
 // The host's full-coverage neutral checks (link-loss recovery, reset-latch
 // clearance) require every declared axis REPORTED; proto3 default-skipping

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -33,8 +33,8 @@ pub use pilotage_camera_calibration::{
 pub use step::{StepBudget, StepOutcome};
 pub use telemetry::{
     AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, FcStateSample,
-    MeasurementClock, MeasurementStamp, Pose2d, SimTruthSample, SourceIncarnation, SourceIntegrity,
-    SourceRole, TelemetryBatch, TelemetrySample, VideoSource,
+    GimbalAttitudeSample, MeasurementClock, MeasurementStamp, Pose2d, SimTruthSample,
+    SourceIncarnation, SourceIntegrity, SourceRole, TelemetryBatch, TelemetrySample, VideoSource,
 };
 pub use vehicle_adapter::VehicleAdapter;
 pub use video::{CalibrationId, CameraId, CaptureClockMapping, VideoCaptureStamp};

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -199,6 +199,21 @@ pub struct FcStateSample {
     pub stamp: MeasurementStamp,
 }
 
+/// Gimbal payload-device orientation (Gimbal Protocol v2 attitude
+/// status) with its own provenance: device state relayed over the FC
+/// link, never a vehicle estimate and never an input to control
+/// validation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GimbalAttitudeSample {
+    /// Orientation quaternion (w, x, y, z); vehicle-frame yaw unless
+    /// the device declares an earth-frame yaw mode.
+    pub quat_wxyz: [f32; 4],
+    /// Device angular velocity (rad/s); NaN encodes device-unknown.
+    pub rates_rps: [f32; 3],
+    /// Identity and acquisition time of the device report.
+    pub stamp: MeasurementStamp,
+}
+
 /// A single vehicle's telemetry at one simulation tick.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TelemetrySample {
@@ -221,6 +236,8 @@ pub struct TelemetrySample {
     pub sim_truth: Option<SimTruthSample>,
     /// FC-owned arm/mode state with its own provenance stamp.
     pub fc_state: Option<FcStateSample>,
+    /// Gimbal payload-device orientation with its own provenance stamp.
+    pub gimbal: Option<GimbalAttitudeSample>,
 }
 
 /// A batch of telemetry samples returned from a single `sample_telemetry`
@@ -268,6 +285,7 @@ mod tests {
             avionics: None,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         };
         assert_eq!(sample.pose.expect("pose").x, 1.0);
         assert_eq!(sample.speed, Some(3.0));

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -59,6 +59,10 @@ pub enum SourceRole {
     FcState,
     /// Video capture identity for camera frames.
     VideoCapture,
+    /// Payload-device orientation/state (gimbal attitude) relayed over
+    /// the FC link: never a vehicle estimate, never eligible for control
+    /// validation, carrying the device's own boot clock.
+    PayloadDevice,
 }
 
 /// Integrity classification of the path that delivered an observation.
@@ -210,6 +214,11 @@ pub struct GimbalAttitudeSample {
     pub quat_wxyz: [f32; 4],
     /// Device angular velocity (rad/s); NaN encodes device-unknown.
     pub rates_rps: [f32; 3],
+    /// GIMBAL_DEVICE_FLAGS in effect (mode/lock bits).
+    pub flags: u32,
+    /// Non-zero reports a device failure condition; carried so a
+    /// consumer can surface a degraded payload without re-deriving it.
+    pub failure_flags: u32,
     /// Identity and acquisition time of the device report.
     pub stamp: MeasurementStamp,
 }

--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -10,7 +10,13 @@
 //! with byte-for-byte).
 
 mod decoding;
+mod encoding;
 use decoding::decode_known;
+pub use encoding::{
+    AttitudeTarget, GCS_COMPONENT_ID, GCS_SYSTEM_ID, GIMBAL_FLAGS_HORIZON_YAW_FOLLOW,
+    encode_arm_command, encode_attitude_setpoint, encode_command_long, encode_gcs_heartbeat,
+    encode_gimbal_rate_setpoint, encode_position_setpoint, encode_velocity_setpoint,
+};
 
 /// MAVLink 2.0 start-of-frame marker.
 pub const MAGIC_V2: u8 = 0xFD;
@@ -82,6 +88,20 @@ pub enum FcMessage {
         /// Source quality enum: 0 unusable, 1 degraded, 2 good.
         quality: u8,
     },
+    /// Gimbal device orientation report (Gimbal Protocol v2).
+    GimbalDeviceAttitudeStatus {
+        /// Milliseconds since gimbal/FC boot.
+        time_boot_ms: u32,
+        /// Orientation quaternion (w, x, y, z); frame per the device
+        /// flags (vehicle-frame yaw unless YAW_LOCK).
+        quat_wxyz: [f32; 4],
+        /// Angular velocity (x, y, z) in rad/s; NaN when unknown.
+        rates_rps: [f32; 3],
+        /// GIMBAL_DEVICE_FLAGS in effect on the device.
+        flags: u16,
+        /// Non-zero reports a device failure condition.
+        failure_flags: u32,
+    },
 }
 
 /// Datagram parse accounting, for link diagnostics.
@@ -117,6 +137,10 @@ pub struct FrameSource {
 pub const COMMAND_LONG_ID: u32 = 76;
 /// SET_POSITION_TARGET_LOCAL_NED message id (uplink: velocity setpoints).
 pub const SET_POSITION_TARGET_ID: u32 = 84;
+/// GIMBAL_MANAGER_SET_ATTITUDE message id (uplink: gimbal rate demands).
+pub const GIMBAL_MANAGER_SET_ATTITUDE_ID: u32 = 282;
+/// GIMBAL_DEVICE_ATTITUDE_STATUS message id (downlink: gimbal orientation).
+pub const GIMBAL_DEVICE_ATTITUDE_STATUS_ID: u32 = 285;
 
 /// CRC_EXTRA per message id, from the MAVLink XML definitions (matching
 /// `aviate-link`); `None` for ids this parser cannot verify.
@@ -130,6 +154,8 @@ fn crc_extra(msg_id: u32) -> Option<u8> {
         AVIATE_ESTIMATOR_STATUS_ID => Some(171),
         COMMAND_LONG_ID => Some(152),
         SET_POSITION_TARGET_ID => Some(143),
+        GIMBAL_MANAGER_SET_ATTITUDE_ID => Some(123),
+        GIMBAL_DEVICE_ATTITUDE_STATUS_ID => Some(137),
         _ => None,
     }
 }
@@ -248,208 +274,6 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, FcMessage)>) -> 
         at = at.saturating_add(frame_len);
     }
     stats
-}
-
-/// Writes a MAVLink 2.0 frame (GCS sysid 255, compid 190) around
-/// `payload` into `out`, returning the frame length. `out` must hold
-/// `10 + payload.len() + 2` bytes; a too-small buffer returns 0.
-fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u8]) -> usize {
-    let total = 10 + payload.len() + 2;
-    if out.len() < total || payload.len() > 255 {
-        return 0;
-    }
-    out[0] = MAGIC_V2;
-    out[1] = payload.len() as u8;
-    out[2] = 0;
-    out[3] = 0;
-    out[4] = seq;
-    out[5] = 255;
-    out[6] = 190;
-    out[7] = (msg_id & 0xff) as u8;
-    out[8] = ((msg_id >> 8) & 0xff) as u8;
-    out[9] = ((msg_id >> 16) & 0xff) as u8;
-    out[10..10 + payload.len()].copy_from_slice(payload);
-    let crc = compute_crc(&out[1..10 + payload.len()], extra);
-    out[10 + payload.len()] = (crc & 0xff) as u8;
-    out[10 + payload.len() + 1] = (crc >> 8) as u8;
-    total
-}
-
-/// Serializes a GCS heartbeat frame, used to register this endpoint with
-/// a MAVLink router that only forwards to peers it has heard from.
-pub fn encode_gcs_heartbeat(seq: u8) -> [u8; 21] {
-    // Payload: custom_mode u32 (0), type MAV_TYPE_GCS=6, autopilot
-    // MAV_AUTOPILOT_INVALID=8, base_mode 0, system_status MAV_STATE_ACTIVE=4,
-    // mavlink_version 3.
-    let mut payload = [0u8; 9];
-    payload[4] = 6;
-    payload[5] = 8;
-    payload[7] = 4;
-    payload[8] = 3;
-    let mut frame = [0u8; 21];
-    encode_frame_v2(seq, HEARTBEAT_ID, &payload, 50, &mut frame);
-    frame
-}
-
-/// Serializes a COMMAND_LONG arm/disarm frame (MAV_CMD 400) for the selected
-/// MAVLink system and component.
-///
-/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
-/// target_system @30, target_component @31, confirmation @32.
-pub fn encode_arm_command(seq: u8, arm: bool, target_system: u8, target_component: u8) -> [u8; 45] {
-    let mut payload = [0u8; 33];
-    let param1: f32 = if arm { 1.0 } else { 0.0 };
-    payload[0..4].copy_from_slice(&param1.to_le_bytes());
-    payload[28..30].copy_from_slice(&400u16.to_le_bytes());
-    payload[30] = target_system;
-    payload[31] = target_component;
-    let mut frame = [0u8; 45];
-    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
-    frame
-}
-
-/// Serializes an arbitrary COMMAND_LONG frame (mode changes, message
-/// interval requests, and any other MAV_CMD the arm helper does not
-/// cover) for the selected MAVLink system and component.
-///
-/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
-/// target_system @30, target_component @31, confirmation @32.
-pub fn encode_command_long(
-    seq: u8,
-    command: u16,
-    params: [f32; 7],
-    target_system: u8,
-    target_component: u8,
-) -> [u8; 45] {
-    let mut payload = [0u8; 33];
-    for (index, param) in params.iter().enumerate() {
-        let at = index * 4;
-        payload[at..at + 4].copy_from_slice(&param.to_le_bytes());
-    }
-    payload[28..30].copy_from_slice(&command.to_le_bytes());
-    payload[30] = target_system;
-    payload[31] = target_component;
-    let mut frame = [0u8; 45];
-    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
-    frame
-}
-
-/// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
-/// velocity plus absolute yaw, everything else masked out
-/// (`type_mask` ignores position, acceleration, and yaw rate — the
-/// combination Aviate's bridge maps to `ControlMode::VelocityControl`).
-///
-/// Serializes a SET_POSITION_TARGET_LOCAL_NED **position-hold**
-/// setpoint: NED position plus absolute yaw, velocity/acceleration/yaw
-/// rate masked out (the combination Aviate's bridge maps to
-/// `ControlMode::PositionHold`) — DJI's brake-then-hold on centered
-/// sticks.
-pub fn encode_position_setpoint(
-    seq: u8,
-    time_boot_ms: u32,
-    pos_ned_m: [f32; 3],
-    yaw_rad: f32,
-    target_system: u8,
-    target_component: u8,
-) -> [u8; 65] {
-    // Ignore velocity (8|16|32), acceleration (64|128|256), yaw rate
-    // (2048): position + absolute yaw remain.
-    const TYPE_MASK: u16 = 8 | 16 | 32 | 64 | 128 | 256 | 2048;
-    let mut payload = [0u8; 53];
-    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
-    payload[4..8].copy_from_slice(&pos_ned_m[0].to_le_bytes());
-    payload[8..12].copy_from_slice(&pos_ned_m[1].to_le_bytes());
-    payload[12..16].copy_from_slice(&pos_ned_m[2].to_le_bytes());
-    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
-    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
-    payload[50] = target_system;
-    payload[51] = target_component;
-    payload[52] = 1; // MAV_FRAME_LOCAL_NED
-    let mut frame = [0u8; 65];
-    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
-    frame
-}
-
-/// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
-/// velocity plus absolute yaw, everything else masked out
-/// (`type_mask` ignores position, acceleration, and yaw rate — the
-/// combination Aviate's bridge maps to `ControlMode::VelocityControl`).
-///
-/// Wire order (53 bytes): time_boot_ms u32 @0, x/y/z @4..16,
-/// vx/vy/vz @16..28, afx/afy/afz @28..40, yaw @40, yaw_rate @44,
-/// type_mask u16 @48, target_system @50, target_component @51,
-/// coordinate_frame @52.
-pub fn encode_velocity_setpoint(
-    seq: u8,
-    time_boot_ms: u32,
-    vel_ned_mps: [f32; 3],
-    yaw_rad: f32,
-    target_system: u8,
-    target_component: u8,
-) -> [u8; 65] {
-    // Ignore position (1|2|4), acceleration (64|128|256), yaw rate (2048):
-    // velocity + absolute yaw remain.
-    const TYPE_MASK: u16 = 1 | 2 | 4 | 64 | 128 | 256 | 2048;
-    let mut payload = [0u8; 53];
-    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
-    payload[16..20].copy_from_slice(&vel_ned_mps[0].to_le_bytes());
-    payload[20..24].copy_from_slice(&vel_ned_mps[1].to_le_bytes());
-    payload[24..28].copy_from_slice(&vel_ned_mps[2].to_le_bytes());
-    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
-    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
-    payload[50] = target_system;
-    payload[51] = target_component;
-    payload[52] = 1; // MAV_FRAME_LOCAL_NED
-    let mut frame = [0u8; 65];
-    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
-    frame
-}
-
-/// Absolute FPV attitude demand and the component selected to receive it.
-///
-/// Body-rate demand is intentionally absent because the FC attitude loop
-/// derives rate commands from this target.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct AttitudeTarget {
-    /// Roll demand in radians.
-    pub roll_rad: f32,
-    /// Pitch demand in radians.
-    pub pitch_rad: f32,
-    /// Yaw demand in radians.
-    pub yaw_rad: f32,
-    /// Normalized collective thrust.
-    pub thrust: f32,
-    /// Selected MAVLink system id.
-    pub system_id: u8,
-    /// Selected MAVLink component id.
-    pub component_id: u8,
-}
-
-/// Encodes one absolute attitude target for the selected component.
-pub fn encode_attitude_setpoint(seq: u8, time_boot_ms: u32, target: AttitudeTarget) -> [u8; 51] {
-    const SET_ATTITUDE_TARGET_ID: u32 = 82;
-    let (sr, cr) = (target.roll_rad * 0.5).sin_cos();
-    let (sp, cp) = (target.pitch_rad * 0.5).sin_cos();
-    let (sy, cy) = (target.yaw_rad * 0.5).sin_cos();
-    let q = [
-        cr * cp * cy + sr * sp * sy,
-        sr * cp * cy - cr * sp * sy,
-        cr * sp * cy + sr * cp * sy,
-        cr * cp * sy - sr * sp * cy,
-    ];
-    let mut payload = [0u8; 39];
-    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
-    for (i, w) in q.iter().enumerate() {
-        payload[4 + i * 4..8 + i * 4].copy_from_slice(&w.to_le_bytes());
-    }
-    // body rates [20..32) stay zero (masked); thrust at [32..36).
-    payload[32..36].copy_from_slice(&target.thrust.clamp(0.0, 1.0).to_le_bytes());
-    payload[36] = target.system_id;
-    payload[37] = target.component_id;
-    payload[38] = 0b0000_0111; // ignore body roll/pitch/yaw rate
-    let mut frame = [0u8; 51];
-    encode_frame_v2(seq, SET_ATTITUDE_TARGET_ID, &payload, 49, &mut frame);
-    frame
 }
 
 #[cfg(test)]

--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -51,6 +51,10 @@ pub enum FcMessage {
         command: u16,
         /// MAV_RESULT (0 = accepted).
         result: u8,
+        /// Addressed system (v2 extension; 0 when the sender omitted it).
+        target_system: u8,
+        /// Addressed component (v2 extension; 0 when omitted).
+        target_component: u8,
     },
     /// Attitude estimate (10 Hz): quaternion is body FRD → world NED,
     /// MAVLink order q1=w, q2=x, q3=y, q4=z.
@@ -139,6 +143,10 @@ pub const COMMAND_LONG_ID: u32 = 76;
 pub const SET_POSITION_TARGET_ID: u32 = 84;
 /// GIMBAL_MANAGER_SET_ATTITUDE message id (uplink: gimbal rate demands).
 pub const GIMBAL_MANAGER_SET_ATTITUDE_ID: u32 = 282;
+/// MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW (COMMAND_LONG payload).
+pub const MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW: u16 = 1000;
+/// MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE (COMMAND_LONG payload).
+pub const MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE: u16 = 1001;
 /// GIMBAL_DEVICE_ATTITUDE_STATUS message id (downlink: gimbal orientation).
 pub const GIMBAL_DEVICE_ATTITUDE_STATUS_ID: u32 = 285;
 

--- a/crates/pilotage-mavlink/src/codec/decoding.rs
+++ b/crates/pilotage-mavlink/src/codec/decoding.rs
@@ -2,7 +2,7 @@
 
 use super::{
     ATTITUDE_QUATERNION_ID, AVIATE_ESTIMATOR_STATUS_ID, COMMAND_ACK_ID, ESTIMATOR_STATUS_ID,
-    FcMessage, HEARTBEAT_ID, LOCAL_POSITION_NED_ID,
+    FcMessage, GIMBAL_DEVICE_ATTITUDE_STATUS_ID, HEARTBEAT_ID, LOCAL_POSITION_NED_ID,
 };
 
 fn f32_at(payload: &[u8], off: usize) -> f32 {
@@ -80,6 +80,27 @@ pub(super) fn decode_known(msg_id: u32, payload: &[u8]) -> Option<FcMessage> {
             time_usec: u64_at(payload, 0),
             valid_flags: payload.get(8).copied().unwrap_or(0),
             quality: payload.get(9).copied().unwrap_or(0),
+        }),
+        // Wire order: time_boot_ms u32 @0, q[4] @4..20, angular
+        // velocity x/y/z @20..32, failure_flags u32 @32, flags u16
+        // @36, targets @38..40, then v2 extension fields this decoder
+        // ignores (zero-truncated payloads shorter than 40 still
+        // decode via the zero-extending accessors).
+        GIMBAL_DEVICE_ATTITUDE_STATUS_ID => Some(FcMessage::GimbalDeviceAttitudeStatus {
+            time_boot_ms: u32_at(payload, 0),
+            quat_wxyz: [
+                f32_at(payload, 4),
+                f32_at(payload, 8),
+                f32_at(payload, 12),
+                f32_at(payload, 16),
+            ],
+            rates_rps: [
+                f32_at(payload, 20),
+                f32_at(payload, 24),
+                f32_at(payload, 28),
+            ],
+            failure_flags: u32_at(payload, 32),
+            flags: u16_at(payload, 36),
         }),
         _ => None,
     }

--- a/crates/pilotage-mavlink/src/codec/decoding.rs
+++ b/crates/pilotage-mavlink/src/codec/decoding.rs
@@ -48,6 +48,10 @@ pub(super) fn decode_known(msg_id: u32, payload: &[u8]) -> Option<FcMessage> {
             command: u16::from(payload.first().copied().unwrap_or(0))
                 | (u16::from(payload.get(1).copied().unwrap_or(0)) << 8),
             result: payload.get(2).copied().unwrap_or(0),
+            // v2 extension fields: zero when the sender truncated them,
+            // which consumers treat as "unaddressed".
+            target_system: payload.get(8).copied().unwrap_or(0),
+            target_component: payload.get(9).copied().unwrap_or(0),
         }),
         ATTITUDE_QUATERNION_ID => Some(FcMessage::AttitudeQuaternion {
             time_boot_ms: u32_at(payload, 0),

--- a/crates/pilotage-mavlink/src/codec/encoding.rs
+++ b/crates/pilotage-mavlink/src/codec/encoding.rs
@@ -1,0 +1,259 @@
+//! Frame serialization for the uplink subset: GCS presence, commands,
+//! offboard setpoints, and gimbal-manager demands.
+
+use super::{
+    COMMAND_LONG_ID, GIMBAL_MANAGER_SET_ATTITUDE_ID, HEARTBEAT_ID, MAGIC_V2,
+    SET_POSITION_TARGET_ID, compute_crc,
+};
+
+/// MAVLink system id stamped on every frame this codec encodes (the
+/// conventional GCS identity). Gimbal primary-control claims must name
+/// this identity or PX4 silently ignores the subsequent demands.
+pub const GCS_SYSTEM_ID: u8 = 255;
+/// MAVLink component id stamped on every frame this codec encodes.
+pub const GCS_COMPONENT_ID: u8 = 190;
+
+/// Writes a MAVLink 2.0 frame ([`GCS_SYSTEM_ID`]/[`GCS_COMPONENT_ID`])
+/// around `payload` into `out`, returning the frame length. `out` must
+/// hold `10 + payload.len() + 2` bytes; a too-small buffer returns 0.
+fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u8]) -> usize {
+    let total = 10 + payload.len() + 2;
+    if out.len() < total || payload.len() > 255 {
+        return 0;
+    }
+    out[0] = MAGIC_V2;
+    out[1] = payload.len() as u8;
+    out[2] = 0;
+    out[3] = 0;
+    out[4] = seq;
+    out[5] = GCS_SYSTEM_ID;
+    out[6] = GCS_COMPONENT_ID;
+    out[7] = (msg_id & 0xff) as u8;
+    out[8] = ((msg_id >> 8) & 0xff) as u8;
+    out[9] = ((msg_id >> 16) & 0xff) as u8;
+    out[10..10 + payload.len()].copy_from_slice(payload);
+    let crc = compute_crc(&out[1..10 + payload.len()], extra);
+    out[10 + payload.len()] = (crc & 0xff) as u8;
+    out[10 + payload.len() + 1] = (crc >> 8) as u8;
+    total
+}
+
+/// Serializes a GCS heartbeat frame, used to register this endpoint with
+/// a MAVLink router that only forwards to peers it has heard from.
+pub fn encode_gcs_heartbeat(seq: u8) -> [u8; 21] {
+    // Payload: custom_mode u32 (0), type MAV_TYPE_GCS=6, autopilot
+    // MAV_AUTOPILOT_INVALID=8, base_mode 0, system_status MAV_STATE_ACTIVE=4,
+    // mavlink_version 3.
+    let mut payload = [0u8; 9];
+    payload[4] = 6;
+    payload[5] = 8;
+    payload[7] = 4;
+    payload[8] = 3;
+    let mut frame = [0u8; 21];
+    encode_frame_v2(seq, HEARTBEAT_ID, &payload, 50, &mut frame);
+    frame
+}
+
+/// Serializes a COMMAND_LONG arm/disarm frame (MAV_CMD 400) for the selected
+/// MAVLink system and component.
+///
+/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
+/// target_system @30, target_component @31, confirmation @32.
+pub fn encode_arm_command(seq: u8, arm: bool, target_system: u8, target_component: u8) -> [u8; 45] {
+    let mut payload = [0u8; 33];
+    let param1: f32 = if arm { 1.0 } else { 0.0 };
+    payload[0..4].copy_from_slice(&param1.to_le_bytes());
+    payload[28..30].copy_from_slice(&400u16.to_le_bytes());
+    payload[30] = target_system;
+    payload[31] = target_component;
+    let mut frame = [0u8; 45];
+    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
+    frame
+}
+
+/// Serializes an arbitrary COMMAND_LONG frame (mode changes, message
+/// interval requests, and any other MAV_CMD the arm helper does not
+/// cover) for the selected MAVLink system and component.
+///
+/// Wire order (33 bytes): param1..7 f32 @0..28, command u16 @28,
+/// target_system @30, target_component @31, confirmation @32.
+pub fn encode_command_long(
+    seq: u8,
+    command: u16,
+    params: [f32; 7],
+    target_system: u8,
+    target_component: u8,
+) -> [u8; 45] {
+    let mut payload = [0u8; 33];
+    for (index, param) in params.iter().enumerate() {
+        let at = index * 4;
+        payload[at..at + 4].copy_from_slice(&param.to_le_bytes());
+    }
+    payload[28..30].copy_from_slice(&command.to_le_bytes());
+    payload[30] = target_system;
+    payload[31] = target_component;
+    let mut frame = [0u8; 45];
+    encode_frame_v2(seq, COMMAND_LONG_ID, &payload, 152, &mut frame);
+    frame
+}
+
+/// Serializes a SET_POSITION_TARGET_LOCAL_NED **position-hold**
+/// setpoint: NED position plus absolute yaw, velocity/acceleration/yaw
+/// rate masked out (the combination Aviate's bridge maps to
+/// `ControlMode::PositionHold`) — DJI's brake-then-hold on centered
+/// sticks.
+pub fn encode_position_setpoint(
+    seq: u8,
+    time_boot_ms: u32,
+    pos_ned_m: [f32; 3],
+    yaw_rad: f32,
+    target_system: u8,
+    target_component: u8,
+) -> [u8; 65] {
+    // Ignore velocity (8|16|32), acceleration (64|128|256), yaw rate
+    // (2048): position + absolute yaw remain.
+    const TYPE_MASK: u16 = 8 | 16 | 32 | 64 | 128 | 256 | 2048;
+    let mut payload = [0u8; 53];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    payload[4..8].copy_from_slice(&pos_ned_m[0].to_le_bytes());
+    payload[8..12].copy_from_slice(&pos_ned_m[1].to_le_bytes());
+    payload[12..16].copy_from_slice(&pos_ned_m[2].to_le_bytes());
+    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
+    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
+    payload[50] = target_system;
+    payload[51] = target_component;
+    payload[52] = 1; // MAV_FRAME_LOCAL_NED
+    let mut frame = [0u8; 65];
+    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
+    frame
+}
+
+/// Serializes a SET_POSITION_TARGET_LOCAL_NED velocity setpoint: NED
+/// velocity plus absolute yaw, everything else masked out
+/// (`type_mask` ignores position, acceleration, and yaw rate — the
+/// combination Aviate's bridge maps to `ControlMode::VelocityControl`).
+///
+/// Wire order (53 bytes): time_boot_ms u32 @0, x/y/z @4..16,
+/// vx/vy/vz @16..28, afx/afy/afz @28..40, yaw @40, yaw_rate @44,
+/// type_mask u16 @48, target_system @50, target_component @51,
+/// coordinate_frame @52.
+pub fn encode_velocity_setpoint(
+    seq: u8,
+    time_boot_ms: u32,
+    vel_ned_mps: [f32; 3],
+    yaw_rad: f32,
+    target_system: u8,
+    target_component: u8,
+) -> [u8; 65] {
+    // Ignore position (1|2|4), acceleration (64|128|256), yaw rate (2048):
+    // velocity + absolute yaw remain.
+    const TYPE_MASK: u16 = 1 | 2 | 4 | 64 | 128 | 256 | 2048;
+    let mut payload = [0u8; 53];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    payload[16..20].copy_from_slice(&vel_ned_mps[0].to_le_bytes());
+    payload[20..24].copy_from_slice(&vel_ned_mps[1].to_le_bytes());
+    payload[24..28].copy_from_slice(&vel_ned_mps[2].to_le_bytes());
+    payload[40..44].copy_from_slice(&yaw_rad.to_le_bytes());
+    payload[48..50].copy_from_slice(&TYPE_MASK.to_le_bytes());
+    payload[50] = target_system;
+    payload[51] = target_component;
+    payload[52] = 1; // MAV_FRAME_LOCAL_NED
+    let mut frame = [0u8; 65];
+    encode_frame_v2(seq, SET_POSITION_TARGET_ID, &payload, 143, &mut frame);
+    frame
+}
+
+/// Absolute FPV attitude demand and the component selected to receive it.
+///
+/// Body-rate demand is intentionally absent because the FC attitude loop
+/// derives rate commands from this target.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AttitudeTarget {
+    /// Roll demand in radians.
+    pub roll_rad: f32,
+    /// Pitch demand in radians.
+    pub pitch_rad: f32,
+    /// Yaw demand in radians.
+    pub yaw_rad: f32,
+    /// Normalized collective thrust.
+    pub thrust: f32,
+    /// Selected MAVLink system id.
+    pub system_id: u8,
+    /// Selected MAVLink component id.
+    pub component_id: u8,
+}
+
+/// Encodes one absolute attitude target for the selected component.
+pub fn encode_attitude_setpoint(seq: u8, time_boot_ms: u32, target: AttitudeTarget) -> [u8; 51] {
+    const SET_ATTITUDE_TARGET_ID: u32 = 82;
+    let (sr, cr) = (target.roll_rad * 0.5).sin_cos();
+    let (sp, cp) = (target.pitch_rad * 0.5).sin_cos();
+    let (sy, cy) = (target.yaw_rad * 0.5).sin_cos();
+    let q = [
+        cr * cp * cy + sr * sp * sy,
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+    ];
+    let mut payload = [0u8; 39];
+    payload[0..4].copy_from_slice(&time_boot_ms.to_le_bytes());
+    for (i, w) in q.iter().enumerate() {
+        payload[4 + i * 4..8 + i * 4].copy_from_slice(&w.to_le_bytes());
+    }
+    // body rates [20..32) stay zero (masked); thrust at [32..36).
+    payload[32..36].copy_from_slice(&target.thrust.clamp(0.0, 1.0).to_le_bytes());
+    payload[36] = target.system_id;
+    payload[37] = target.component_id;
+    payload[38] = 0b0000_0111; // ignore body roll/pitch/yaw rate
+    let mut frame = [0u8; 51];
+    encode_frame_v2(seq, SET_ATTITUDE_TARGET_ID, &payload, 49, &mut frame);
+    frame
+}
+
+/// GIMBAL_MANAGER_FLAGS with roll and pitch locked to the horizon and
+/// yaw following the vehicle (no YAW_LOCK): the operator-camera
+/// default, so the view pans with the airframe and holds level through
+/// attitude changes.
+pub const GIMBAL_FLAGS_HORIZON_YAW_FOLLOW: u32 = 4 | 8;
+
+/// Serializes a GIMBAL_MANAGER_SET_ATTITUDE rate demand: the attitude
+/// quaternion and roll rate are NaN ("ignored" per the message spec;
+/// the device keeps its own horizon), leaving the pitch/yaw angular
+/// velocity demand in rad/s under [`GIMBAL_FLAGS_HORIZON_YAW_FOLLOW`].
+///
+/// PX4 silently drops this message unless the sender holds gimbal
+/// primary control, so a streaming caller must pair it with periodic
+/// DO_GIMBAL_MANAGER_CONFIGURE claims naming
+/// [`GCS_SYSTEM_ID`]/[`GCS_COMPONENT_ID`].
+///
+/// Wire order (35 bytes): flags u32 @0, q\[4\] @4..20, angular_velocity
+/// x/y/z @20..32, target_system @32, target_component @33,
+/// gimbal_device_id @34 (0 = all gimbal devices).
+pub fn encode_gimbal_rate_setpoint(
+    seq: u8,
+    pitch_rate_rps: f32,
+    yaw_rate_rps: f32,
+    target_system: u8,
+    target_component: u8,
+) -> [u8; 47] {
+    let mut payload = [0u8; 35];
+    payload[0..4].copy_from_slice(&GIMBAL_FLAGS_HORIZON_YAW_FOLLOW.to_le_bytes());
+    for slot in 0..5 {
+        // q[0..4] and angular_velocity_x: NaN = ignored.
+        let at = 4 + slot * 4;
+        payload[at..at + 4].copy_from_slice(&f32::NAN.to_le_bytes());
+    }
+    payload[24..28].copy_from_slice(&pitch_rate_rps.to_le_bytes());
+    payload[28..32].copy_from_slice(&yaw_rate_rps.to_le_bytes());
+    payload[32] = target_system;
+    payload[33] = target_component;
+    let mut frame = [0u8; 47];
+    encode_frame_v2(
+        seq,
+        GIMBAL_MANAGER_SET_ATTITUDE_ID,
+        &payload,
+        123,
+        &mut frame,
+    );
+    frame
+}

--- a/crates/pilotage-mavlink/src/codec/tests.rs
+++ b/crates/pilotage-mavlink/src/codec/tests.rs
@@ -39,6 +39,7 @@ fn encode_frame(msg_id: u32, payload: &[u8], truncate: bool) -> Vec<u8> {
         31 => 246,
         32 => 185,
         230 => 163,
+        285 => 137,
         20_000 => 171,
         other => (other & 0xff) as u8,
     };
@@ -335,4 +336,125 @@ fn truncated_tail_is_garbage_not_panic() {
     let stats = parse_datagram(&frame[..frame.len() - 3], &mut out);
     assert!(out.is_empty());
     assert!(stats.garbage_bytes > 0);
+}
+
+/// Full 49-byte GIMBAL_DEVICE_ATTITUDE_STATUS payload: base fields
+/// through the targets, then the v2 extension tail the decoder ignores.
+fn gimbal_status_payload(
+    q: [f32; 4],
+    rates: [f32; 3],
+    t: u32,
+    failure: u32,
+    flags: u16,
+) -> Vec<u8> {
+    let mut p = t.to_le_bytes().to_vec();
+    for v in q.iter().chain(rates.iter()) {
+        p.extend_from_slice(&v.to_le_bytes());
+    }
+    p.extend_from_slice(&failure.to_le_bytes());
+    p.extend_from_slice(&flags.to_le_bytes());
+    p.push(255); // target_system
+    p.push(190); // target_component
+    p.extend_from_slice(&0.25f32.to_le_bytes()); // ext: delta_yaw
+    p.extend_from_slice(&0.0f32.to_le_bytes()); // ext: delta_yaw_velocity
+    p.push(0); // ext: gimbal_device_id
+    p
+}
+
+#[test]
+fn decodes_gimbal_device_attitude_status() {
+    let q = [0.98f32, 0.0, -0.19, 0.0];
+    let rates = [0.0f32, 0.05, -0.02];
+    let frame = encode_frame(
+        super::GIMBAL_DEVICE_ATTITUDE_STATUS_ID,
+        &gimbal_status_payload(q, rates, 5_000, 0, 12),
+        false,
+    );
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    assert_eq!(
+        out,
+        vec![(
+            SOURCE,
+            FcMessage::GimbalDeviceAttitudeStatus {
+                time_boot_ms: 5_000,
+                quat_wxyz: q,
+                rates_rps: rates,
+                flags: 12,
+                failure_flags: 0,
+            }
+        )]
+    );
+}
+
+#[test]
+fn gimbal_status_v2_truncated_payload_zero_extends() {
+    // Zero failure flags and zero extension tail truncate on the wire;
+    // the decoder must recover flags at their full-layout offset.
+    let q = [1.0f32, 0.0, 0.0, 0.0];
+    let frame = encode_frame(
+        super::GIMBAL_DEVICE_ATTITUDE_STATUS_ID,
+        &gimbal_status_payload(q, [0.0; 3], 7, 0, 12),
+        true,
+    );
+    let mut out: Vec<(FrameSource, FcMessage)> = Vec::new();
+    let stats = parse_datagram(&frame, &mut out);
+    assert_eq!(stats.decoded, 1, "stats: {stats:?}");
+    match out[0].1 {
+        FcMessage::GimbalDeviceAttitudeStatus {
+            time_boot_ms,
+            quat_wxyz,
+            flags,
+            failure_flags,
+            ..
+        } => {
+            assert_eq!(time_boot_ms, 7);
+            assert_eq!(quat_wxyz, q);
+            assert_eq!(flags, 12);
+            assert_eq!(failure_flags, 0);
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+#[test]
+fn gimbal_rate_setpoint_locks_the_wire_layout() {
+    let frame = super::encode_gimbal_rate_setpoint(9, 0.4, -0.6, 1, 1);
+    // Header: v2 magic, 35-byte payload, GCS identity, msg id 282.
+    assert_eq!(frame[0], MAGIC_V2);
+    assert_eq!(frame[1], 35);
+    assert_eq!(frame[4], 9);
+    assert_eq!(frame[5], 255);
+    assert_eq!(frame[6], 190);
+    assert_eq!(
+        u32::from(frame[7]) | (u32::from(frame[8]) << 8) | (u32::from(frame[9]) << 16),
+        super::GIMBAL_MANAGER_SET_ATTITUDE_ID
+    );
+    let payload = &frame[10..45];
+    assert_eq!(
+        &payload[0..4],
+        &12u32.to_le_bytes(),
+        "horizon + yaw-follow flags"
+    );
+    // q[0..4] and angular_velocity_x are NaN ("ignored").
+    for slot in 0..5 {
+        let at = 4 + slot * 4;
+        let bytes: [u8; 4] = payload[at..at + 4].try_into().expect("slice length");
+        assert!(
+            f32::from_le_bytes(bytes).is_nan(),
+            "slot {slot} must be NaN"
+        );
+    }
+    let pitch: [u8; 4] = payload[24..28].try_into().expect("slice length");
+    let yaw: [u8; 4] = payload[28..32].try_into().expect("slice length");
+    assert_eq!(f32::from_le_bytes(pitch), 0.4);
+    assert_eq!(f32::from_le_bytes(yaw), -0.6);
+    assert_eq!(payload[32], 1, "target system");
+    assert_eq!(payload[33], 1, "target component");
+    assert_eq!(payload[34], 0, "all gimbal devices");
+    // The CRC must verify under CRC_EXTRA 123 (checked against PX4's
+    // generated common-dialect headers).
+    let wire_crc = u16::from(frame[45]) | (u16::from(frame[46]) << 8);
+    assert_eq!(super::compute_crc(&frame[1..45], 123), wire_crc);
 }

--- a/crates/pilotage-mavlink/src/lib.rs
+++ b/crates/pilotage-mavlink/src/lib.rs
@@ -15,6 +15,6 @@ pub mod link;
 
 pub use codec::{FcMessage, FrameSource, ParseStats, parse_datagram};
 pub use link::{
-    AttitudeUpdate, AuthorizationSource, CommandAckReport, GimbalDeviceAttitude, KinematicsUpdate,
-    LinkConfig, LinkError, LinkState, MavlinkLink, ResetPolicy,
+    AttitudeUpdate, AuthorizationSource, CommandAckReport, GimbalDeviceAttitude, GimbalRateDemand,
+    KinematicsUpdate, LinkConfig, LinkError, LinkState, MavlinkLink, OutboundCommand, ResetPolicy,
 };

--- a/crates/pilotage-mavlink/src/lib.rs
+++ b/crates/pilotage-mavlink/src/lib.rs
@@ -15,6 +15,6 @@ pub mod link;
 
 pub use codec::{FcMessage, FrameSource, ParseStats, parse_datagram};
 pub use link::{
-    AttitudeUpdate, AuthorizationSource, KinematicsUpdate, LinkConfig, LinkError, LinkState,
-    MavlinkLink, ResetPolicy,
+    AttitudeUpdate, AuthorizationSource, CommandAckReport, GimbalDeviceAttitude, KinematicsUpdate,
+    LinkConfig, LinkError, LinkState, MavlinkLink, ResetPolicy,
 };

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -475,4 +475,6 @@ fn fold_datagram(
 }
 
 #[cfg(test)]
+mod arbiter_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -18,10 +18,12 @@ mod apply;
 mod error;
 pub mod estimator;
 pub mod measurement;
+mod updates;
 use apply::apply_messages;
 pub use apply::apply_messages_at;
 pub use error::LinkError;
 use estimator::EstimatorStatusUpdate;
+pub use updates::{AttitudeUpdate, CommandAckReport, GimbalDeviceAttitude, KinematicsUpdate};
 
 /// Which message carries the estimator authorization for cached numeric
 /// groups.
@@ -172,6 +174,13 @@ pub struct LinkState {
     pub kinematics: Option<KinematicsUpdate>,
     /// Latest accepted lossless estimator authorization report.
     pub estimator_status: Option<EstimatorStatusUpdate>,
+    /// Latest gimbal-device orientation report. Cached outside the
+    /// estimate measurement discipline: it is payload-device status,
+    /// never an input to vehicle state or control validation.
+    pub gimbal_device: Option<GimbalDeviceAttitude>,
+    /// Latest command acknowledgement, kept so uplink senders can
+    /// surface a typed denial instead of a silently dead command path.
+    pub last_command_ack: Option<CommandAckReport>,
     /// Receive stamp of the last FC heartbeat.
     pub last_heartbeat: Option<Instant>,
     /// Whether the last FC heartbeat reported the vehicle armed.
@@ -220,6 +229,8 @@ impl Default for LinkState {
             attitude: None,
             kinematics: None,
             estimator_status: None,
+            gimbal_device: None,
+            last_command_ack: None,
             last_heartbeat: None,
             heartbeat_armed: None,
             decoded: 0,
@@ -262,50 +273,13 @@ impl LinkState {
     }
 }
 
-/// One attitude update with its receive stamp.
-#[derive(Debug, Clone, Copy)]
-pub struct AttitudeUpdate {
-    /// Quaternion (w, x, y, z), body FRD → world NED.
-    pub quat_wxyz: [f32; 4],
-    /// Body rates (p, q, r) rad/s.
-    pub rates_rps: [f32; 3],
-    /// Milliseconds since FC boot.
-    pub time_boot_ms: u32,
-    /// Identity and acquisition stamp for this group update.
-    pub stamp: MeasurementStamp,
-    /// Authorization bits retained for this numeric acquisition.
-    pub valid_flags: u32,
-    /// Canonical quality retained for this numeric acquisition.
-    pub quality: u32,
-    /// When this update was received.
-    pub received_at: Instant,
-}
-
-/// One kinematics update with its receive stamp.
-#[derive(Debug, Clone, Copy)]
-pub struct KinematicsUpdate {
-    /// Position NED, meters.
-    pub pos_ned_m: [f32; 3],
-    /// Velocity NED, m/s.
-    pub vel_ned_mps: [f32; 3],
-    /// Milliseconds since FC boot.
-    pub time_boot_ms: u32,
-    /// Identity and acquisition stamp for this group update.
-    pub stamp: MeasurementStamp,
-    /// Authorization bits retained for this numeric acquisition.
-    pub valid_flags: u32,
-    /// Canonical quality retained for this numeric acquisition.
-    pub quality: u32,
-    /// When this update was received.
-    pub received_at: Instant,
-}
-
 /// A running MAVLink link: the receive task plus the shared latest-state
 /// cache the adapter samples from.
 #[derive(Debug)]
 pub struct MavlinkLink {
     state: Arc<Mutex<LinkState>>,
     task: JoinHandle<()>,
+    outbound: tokio::sync::mpsc::Sender<Vec<u8>>,
 }
 
 impl MavlinkLink {
@@ -345,13 +319,35 @@ impl MavlinkLink {
             config,
             source_incarnation,
         )));
-        let task = tokio::spawn(run_link(socket, config, router_mode, state.clone()));
-        Ok(Self { state, task })
+        let (outbound, outbound_rx) = tokio::sync::mpsc::channel(64);
+        let task = tokio::spawn(run_link(
+            socket,
+            config,
+            router_mode,
+            state.clone(),
+            outbound_rx,
+        ));
+        Ok(Self {
+            state,
+            task,
+            outbound,
+        })
     }
 
     /// The shared latest-state cache.
     pub fn state(&self) -> Arc<Mutex<LinkState>> {
         self.state.clone()
+    }
+
+    /// A sender whose frames leave through the link's own socket
+    /// toward the stream-command target. The FC's GCS instance
+    /// retargets its stream to whichever peer last spoke, so uplink
+    /// traffic for that instance (gimbal-manager demands, claims) must
+    /// use this path — a second socket would steal the telemetry
+    /// stream. Frames are dropped with a warning when the link has no
+    /// stream-command target.
+    pub fn outbound(&self) -> tokio::sync::mpsc::Sender<Vec<u8>> {
+        self.outbound.clone()
     }
 }
 
@@ -366,6 +362,7 @@ async fn run_link(
     config: LinkConfig,
     router_mode: bool,
     state: Arc<Mutex<LinkState>>,
+    mut outbound_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
 ) {
     let endpoint = config.endpoint;
     let mut buf = vec![0u8; 2048];
@@ -374,6 +371,20 @@ async fn run_link(
     let mut seq: u8 = 0;
     loop {
         tokio::select! {
+            frame = outbound_rx.recv() => {
+                match (frame, config.stream_command_target) {
+                    (Some(frame), Some(target)) => {
+                        if let Err(error) = socket.send_to(&frame, target).await {
+                            warn!(%error, "outbound uplink frame send failed");
+                        }
+                    }
+                    (Some(_), None) => {
+                        warn!("outbound uplink frame dropped: link has no stream command target");
+                    }
+                    // All senders dropped; the link is being torn down.
+                    (None, _) => {}
+                }
+            }
             _ = heartbeat.tick() => {
                 if router_mode {
                     let frame = encode_gcs_heartbeat(seq);
@@ -401,23 +412,7 @@ async fn run_link(
             received = socket.recv_from(&mut buf) => {
                 match received {
                     Ok((len, _from)) => {
-                        messages.clear();
-                        let stats = parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
-                        apply_messages(
-                            &state,
-                            &messages,
-                            stats.crc_failures,
-                            stats.unknown_ids,
-                        );
-                        if stats.crc_failures > 0 {
-                            warn!(crc_failures = stats.crc_failures, "MAVLink CRC failures in datagram");
-                        }
-                        if stats.invalid_estimator_status_frames > 0 {
-                            error!(
-                                invalid_frames = stats.invalid_estimator_status_frames,
-                                "private estimator status frame failed validation"
-                            );
-                        }
+                        fold_datagram(buf.get(..len).unwrap_or(&[]), &state, &mut messages);
                     }
                     Err(error) => {
                         warn!(%error, "MAVLink socket receive failed");
@@ -426,6 +421,30 @@ async fn run_link(
                 }
             }
         }
+    }
+}
+
+/// Parses one datagram into the reusable message buffer, folds it into
+/// the shared cache, and surfaces integrity failures loudly.
+fn fold_datagram(
+    bytes: &[u8],
+    state: &Arc<Mutex<LinkState>>,
+    messages: &mut Vec<(crate::codec::FrameSource, crate::codec::FcMessage)>,
+) {
+    messages.clear();
+    let stats = parse_datagram(bytes, messages);
+    apply_messages(state, messages, stats.crc_failures, stats.unknown_ids);
+    if stats.crc_failures > 0 {
+        warn!(
+            crc_failures = stats.crc_failures,
+            "MAVLink CRC failures in datagram"
+        );
+    }
+    if stats.invalid_estimator_status_frames > 0 {
+        error!(
+            invalid_frames = stats.invalid_estimator_status_frames,
+            "private estimator status frame failed validation"
+        );
     }
 }
 

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -18,11 +18,14 @@ mod apply;
 mod error;
 pub mod estimator;
 pub mod measurement;
+mod outbound;
 mod updates;
 use apply::apply_messages;
 pub use apply::apply_messages_at;
 pub use error::LinkError;
 use estimator::EstimatorStatusUpdate;
+pub use outbound::{GimbalRateDemand, OutboundCommand};
+use outbound::{send_gimbal_rate, send_outbound_command};
 pub use updates::{AttitudeUpdate, CommandAckReport, GimbalDeviceAttitude, KinematicsUpdate};
 
 /// Which message carries the estimator authorization for cached numeric
@@ -181,6 +184,10 @@ pub struct LinkState {
     /// Latest command acknowledgement, kept so uplink senders can
     /// surface a typed denial instead of a silently dead command path.
     pub last_command_ack: Option<CommandAckReport>,
+    /// Latest gimbal CONFIGURE acknowledgement, tracked apart from
+    /// `last_command_ack` so unrelated acks cannot bury a claim denial
+    /// while the FC silently ignores gimbal demands.
+    pub gimbal_configure_ack: Option<CommandAckReport>,
     /// Receive stamp of the last FC heartbeat.
     pub last_heartbeat: Option<Instant>,
     /// Whether the last FC heartbeat reported the vehicle armed.
@@ -231,6 +238,7 @@ impl Default for LinkState {
             estimator_status: None,
             gimbal_device: None,
             last_command_ack: None,
+            gimbal_configure_ack: None,
             last_heartbeat: None,
             heartbeat_armed: None,
             decoded: 0,
@@ -279,7 +287,8 @@ impl LinkState {
 pub struct MavlinkLink {
     state: Arc<Mutex<LinkState>>,
     task: JoinHandle<()>,
-    outbound: tokio::sync::mpsc::Sender<Vec<u8>>,
+    commands: tokio::sync::mpsc::Sender<OutboundCommand>,
+    gimbal_rates: Option<tokio::sync::watch::Sender<Option<GimbalRateDemand>>>,
 }
 
 impl MavlinkLink {
@@ -319,18 +328,21 @@ impl MavlinkLink {
             config,
             source_incarnation,
         )));
-        let (outbound, outbound_rx) = tokio::sync::mpsc::channel(64);
+        let (commands, command_rx) = tokio::sync::mpsc::channel(16);
+        let (rate_tx, rate_rx) = tokio::sync::watch::channel(None);
         let task = tokio::spawn(run_link(
             socket,
             config,
             router_mode,
             state.clone(),
-            outbound_rx,
+            command_rx,
+            rate_rx,
         ));
         Ok(Self {
             state,
             task,
-            outbound,
+            commands,
+            gimbal_rates: Some(rate_tx),
         })
     }
 
@@ -339,15 +351,23 @@ impl MavlinkLink {
         self.state.clone()
     }
 
-    /// A sender whose frames leave through the link's own socket
-    /// toward the stream-command target. The FC's GCS instance
-    /// retargets its stream to whichever peer last spoke, so uplink
-    /// traffic for that instance (gimbal-manager demands, claims) must
-    /// use this path — a second socket would steal the telemetry
-    /// stream. Frames are dropped with a warning when the link has no
-    /// stream-command target.
-    pub fn outbound(&self) -> tokio::sync::mpsc::Sender<Vec<u8>> {
-        self.outbound.clone()
+    /// The ordered command lane toward the stream-command target. The
+    /// FC's GCS instance retargets its stream to whichever peer last
+    /// spoke, so uplink traffic for that instance must ride the link's
+    /// own socket — and the link task assigns the socket's single
+    /// MAVLink sequence, so callers never encode frames themselves.
+    pub fn command_sender(&self) -> tokio::sync::mpsc::Sender<OutboundCommand> {
+        self.commands.clone()
+    }
+
+    /// Takes the latest-value gimbal rate lane (single producer). Each
+    /// publication replaces the previous demand; the link task encodes
+    /// only the newest, so stale demands coalesce away under
+    /// backpressure instead of queueing behind fresh ones.
+    pub fn take_gimbal_rate_sender(
+        &mut self,
+    ) -> Option<tokio::sync::watch::Sender<Option<GimbalRateDemand>>> {
+        self.gimbal_rates.take()
     }
 }
 
@@ -362,27 +382,27 @@ async fn run_link(
     config: LinkConfig,
     router_mode: bool,
     state: Arc<Mutex<LinkState>>,
-    mut outbound_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    mut command_rx: tokio::sync::mpsc::Receiver<OutboundCommand>,
+    mut rate_rx: tokio::sync::watch::Receiver<Option<GimbalRateDemand>>,
 ) {
     let endpoint = config.endpoint;
     let mut buf = vec![0u8; 2048];
     let mut messages = Vec::with_capacity(8);
     let mut heartbeat = tokio::time::interval(Duration::from_secs(1));
     let mut seq: u8 = 0;
+    let mut rates_open = true;
     loop {
         tokio::select! {
-            frame = outbound_rx.recv() => {
-                match (frame, config.stream_command_target) {
-                    (Some(frame), Some(target)) => {
-                        if let Err(error) = socket.send_to(&frame, target).await {
-                            warn!(%error, "outbound uplink frame send failed");
-                        }
-                    }
-                    (Some(_), None) => {
-                        warn!("outbound uplink frame dropped: link has no stream command target");
-                    }
-                    // All senders dropped; the link is being torn down.
-                    (None, _) => {}
+            command = command_rx.recv() => {
+                send_outbound_command(&socket, &mut seq, config.stream_command_target, command).await;
+            }
+            changed = rate_rx.changed(), if rates_open => {
+                if changed.is_err() {
+                    // The demand producer dropped; stop polling the lane.
+                    rates_open = false;
+                } else {
+                    let demand = *rate_rx.borrow_and_update();
+                    send_gimbal_rate(&socket, &mut seq, config.stream_command_target, demand).await;
                 }
             }
             _ = heartbeat.tick() => {

--- a/crates/pilotage-mavlink/src/link.rs
+++ b/crates/pilotage-mavlink/src/link.rs
@@ -393,6 +393,12 @@ async fn run_link(
     let mut rates_open = true;
     loop {
         tokio::select! {
+            // Biased: the command lane is polled before the rate lane so a
+            // queued CONFIGURE always reaches the wire before the rate
+            // setpoint enqueued after it. Without this, an unbiased select
+            // could transmit the first rate demand ahead of the claim and
+            // PX4 would drop it as non-primary (claim-before-first-setpoint).
+            biased;
             command = command_rx.recv() => {
                 send_outbound_command(&socket, &mut seq, config.stream_command_target, command).await;
             }

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -44,6 +44,38 @@ fn note_command_ack(command: u16, result: u8) {
     }
 }
 
+/// Caches one command acknowledgement addressed to this GCS identity.
+/// Acks for another endpoint prove nothing about our commands; zero
+/// targets mean the sender omitted the v2 extension fields (accepted as
+/// unaddressed). The gimbal CONFIGURE verdict is tracked apart from the
+/// general slot so a later, unrelated ack (e.g. periodic
+/// SET_MESSAGE_INTERVAL) cannot bury a claim denial.
+fn apply_command_ack(
+    latest: &mut LinkState,
+    command: u16,
+    result: u8,
+    target_system: u8,
+    target_component: u8,
+    now: Instant,
+) {
+    let addressed_to_us = (target_system == 0 && target_component == 0)
+        || (target_system == crate::codec::GCS_SYSTEM_ID
+            && target_component == crate::codec::GCS_COMPONENT_ID);
+    if !addressed_to_us {
+        return;
+    }
+    note_command_ack(command, result);
+    let report = CommandAckReport {
+        command,
+        result,
+        received_at: now,
+    };
+    latest.last_command_ack = Some(report);
+    if command == crate::codec::MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE {
+        latest.gimbal_configure_ack = Some(report);
+    }
+}
+
 /// Folds decoded messages into the shared cache at an explicit receive
 /// instant. Public so adapter crates can drive the cache in tests
 /// without a socket; production traffic arrives via the link task.
@@ -74,6 +106,52 @@ pub fn apply_messages_at(
     }
 }
 
+/// Folds one attitude group into the cache, stamping it with the
+/// authorization current at its source time.
+fn apply_attitude(
+    latest: &mut LinkState,
+    time_boot_ms: u32,
+    quat_wxyz: [f32; 4],
+    rates_rps: [f32; 3],
+    now: Instant,
+) {
+    if let Some(stamp) = next_attitude_stamp(latest, time_boot_ms, now) {
+        let authorization = authorization_at(latest, time_boot_ms);
+        latest.attitude = Some(AttitudeUpdate {
+            quat_wxyz,
+            rates_rps,
+            time_boot_ms,
+            stamp,
+            valid_flags: authorization.valid_flags,
+            quality: authorization.quality,
+            received_at: now,
+        });
+    }
+}
+
+/// Folds one kinematics group into the cache, stamping it with the
+/// authorization current at its source time.
+fn apply_kinematics(
+    latest: &mut LinkState,
+    time_boot_ms: u32,
+    pos_ned_m: [f32; 3],
+    vel_ned_mps: [f32; 3],
+    now: Instant,
+) {
+    if let Some(stamp) = next_kinematics_stamp(latest, time_boot_ms, now) {
+        let authorization = authorization_at(latest, time_boot_ms);
+        latest.kinematics = Some(KinematicsUpdate {
+            pos_ned_m,
+            vel_ned_mps,
+            time_boot_ms,
+            stamp,
+            valid_flags: authorization.valid_flags,
+            quality: authorization.quality,
+            received_at: now,
+        });
+    }
+}
+
 /// Applies one source-matched decoded message to the cache.
 fn apply_message(latest: &mut LinkState, message: FcMessage, now: Instant) {
     match message {
@@ -82,14 +160,19 @@ fn apply_message(latest: &mut LinkState, message: FcMessage, now: Instant) {
             latest.last_heartbeat = Some(now);
             latest.heartbeat_armed = Some(armed);
         }
-        FcMessage::CommandAck { command, result } => {
-            note_command_ack(command, result);
-            latest.last_command_ack = Some(CommandAckReport {
-                command,
-                result,
-                received_at: now,
-            });
-        }
+        FcMessage::CommandAck {
+            command,
+            result,
+            target_system,
+            target_component,
+        } => apply_command_ack(
+            latest,
+            command,
+            result,
+            target_system,
+            target_component,
+            now,
+        ),
         FcMessage::EstimatorStatus { time_usec, flags } => {
             apply_standard_status(latest, time_usec, flags, now);
         }
@@ -102,38 +185,12 @@ fn apply_message(latest: &mut LinkState, message: FcMessage, now: Instant) {
             time_boot_ms,
             quat_wxyz,
             rates_rps,
-        } => {
-            if let Some(stamp) = next_attitude_stamp(latest, time_boot_ms, now) {
-                let authorization = authorization_at(latest, time_boot_ms);
-                latest.attitude = Some(AttitudeUpdate {
-                    quat_wxyz,
-                    rates_rps,
-                    time_boot_ms,
-                    stamp,
-                    valid_flags: authorization.valid_flags,
-                    quality: authorization.quality,
-                    received_at: now,
-                });
-            }
-        }
+        } => apply_attitude(latest, time_boot_ms, quat_wxyz, rates_rps, now),
         FcMessage::LocalPositionNed {
             time_boot_ms,
             pos_ned_m,
             vel_ned_mps,
-        } => {
-            if let Some(stamp) = next_kinematics_stamp(latest, time_boot_ms, now) {
-                let authorization = authorization_at(latest, time_boot_ms);
-                latest.kinematics = Some(KinematicsUpdate {
-                    pos_ned_m,
-                    vel_ned_mps,
-                    time_boot_ms,
-                    stamp,
-                    valid_flags: authorization.valid_flags,
-                    quality: authorization.quality,
-                    received_at: now,
-                });
-            }
-        }
+        } => apply_kinematics(latest, time_boot_ms, pos_ned_m, vel_ned_mps, now),
         FcMessage::GimbalDeviceAttitudeStatus {
             time_boot_ms,
             quat_wxyz,

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -7,7 +7,10 @@ use std::time::Instant;
 
 use super::estimator::{accept_status, authorization_at, invalidate_cached_authorization};
 use super::measurement::{next_attitude_stamp, next_kinematics_stamp};
-use super::{AttitudeUpdate, AuthorizationSource, KinematicsUpdate, LinkState, estimator};
+use super::{
+    AttitudeUpdate, AuthorizationSource, CommandAckReport, GimbalDeviceAttitude, KinematicsUpdate,
+    LinkState, estimator,
+};
 use crate::codec::{FcMessage, FrameSource};
 
 /// Folds decoded messages into the shared cache. Kept synchronous and
@@ -67,57 +70,88 @@ pub fn apply_messages_at(
             continue;
         }
         latest.decoded = latest.decoded.wrapping_add(1);
-        match message {
-            FcMessage::InvalidAviateEstimatorStatus => {}
-            FcMessage::Heartbeat { armed } => {
-                latest.last_heartbeat = Some(now);
-                latest.heartbeat_armed = Some(armed);
+        apply_message(&mut latest, message, now);
+    }
+}
+
+/// Applies one source-matched decoded message to the cache.
+fn apply_message(latest: &mut LinkState, message: FcMessage, now: Instant) {
+    match message {
+        FcMessage::InvalidAviateEstimatorStatus => {}
+        FcMessage::Heartbeat { armed } => {
+            latest.last_heartbeat = Some(now);
+            latest.heartbeat_armed = Some(armed);
+        }
+        FcMessage::CommandAck { command, result } => {
+            note_command_ack(command, result);
+            latest.last_command_ack = Some(CommandAckReport {
+                command,
+                result,
+                received_at: now,
+            });
+        }
+        FcMessage::EstimatorStatus { time_usec, flags } => {
+            apply_standard_status(latest, time_usec, flags, now);
+        }
+        FcMessage::AviateEstimatorStatus {
+            time_usec,
+            valid_flags,
+            quality,
+        } => accept_status(latest, time_usec, valid_flags, quality, now),
+        FcMessage::AttitudeQuaternion {
+            time_boot_ms,
+            quat_wxyz,
+            rates_rps,
+        } => {
+            if let Some(stamp) = next_attitude_stamp(latest, time_boot_ms, now) {
+                let authorization = authorization_at(latest, time_boot_ms);
+                latest.attitude = Some(AttitudeUpdate {
+                    quat_wxyz,
+                    rates_rps,
+                    time_boot_ms,
+                    stamp,
+                    valid_flags: authorization.valid_flags,
+                    quality: authorization.quality,
+                    received_at: now,
+                });
             }
-            FcMessage::CommandAck { command, result } => note_command_ack(command, result),
-            FcMessage::EstimatorStatus { time_usec, flags } => {
-                apply_standard_status(&mut latest, time_usec, flags, now);
+        }
+        FcMessage::LocalPositionNed {
+            time_boot_ms,
+            pos_ned_m,
+            vel_ned_mps,
+        } => {
+            if let Some(stamp) = next_kinematics_stamp(latest, time_boot_ms, now) {
+                let authorization = authorization_at(latest, time_boot_ms);
+                latest.kinematics = Some(KinematicsUpdate {
+                    pos_ned_m,
+                    vel_ned_mps,
+                    time_boot_ms,
+                    stamp,
+                    valid_flags: authorization.valid_flags,
+                    quality: authorization.quality,
+                    received_at: now,
+                });
             }
-            FcMessage::AviateEstimatorStatus {
-                time_usec,
-                valid_flags,
-                quality,
-            } => accept_status(&mut latest, time_usec, valid_flags, quality, now),
-            FcMessage::AttitudeQuaternion {
-                time_boot_ms,
+        }
+        FcMessage::GimbalDeviceAttitudeStatus {
+            time_boot_ms,
+            quat_wxyz,
+            rates_rps,
+            flags,
+            failure_flags,
+        } => {
+            if failure_flags != 0 {
+                tracing::warn!(failure_flags, "gimbal device reports a failure condition");
+            }
+            latest.gimbal_device = Some(GimbalDeviceAttitude {
                 quat_wxyz,
                 rates_rps,
-            } => {
-                if let Some(stamp) = next_attitude_stamp(&mut latest, time_boot_ms, now) {
-                    let authorization = authorization_at(&latest, time_boot_ms);
-                    latest.attitude = Some(AttitudeUpdate {
-                        quat_wxyz,
-                        rates_rps,
-                        time_boot_ms,
-                        stamp,
-                        valid_flags: authorization.valid_flags,
-                        quality: authorization.quality,
-                        received_at: now,
-                    });
-                }
-            }
-            FcMessage::LocalPositionNed {
                 time_boot_ms,
-                pos_ned_m,
-                vel_ned_mps,
-            } => {
-                if let Some(stamp) = next_kinematics_stamp(&mut latest, time_boot_ms, now) {
-                    let authorization = authorization_at(&latest, time_boot_ms);
-                    latest.kinematics = Some(KinematicsUpdate {
-                        pos_ned_m,
-                        vel_ned_mps,
-                        time_boot_ms,
-                        stamp,
-                        valid_flags: authorization.valid_flags,
-                        quality: authorization.quality,
-                        received_at: now,
-                    });
-                }
-            }
+                flags,
+                failure_flags,
+                received_at: now,
+            });
         }
     }
 }

--- a/crates/pilotage-mavlink/src/link/arbiter_tests.rs
+++ b/crates/pilotage-mavlink/src/link/arbiter_tests.rs
@@ -1,0 +1,115 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! Socket-level proof of the outbound arbiter's ordering guarantee: when
+//! a gimbal claim (CONFIGURE) and a rate setpoint are both pending, the
+//! `biased` select in [`run_link`] must transmit the claim FIRST. PX4
+//! drops a rate demand that arrives before the primary-control claim, so
+//! this is verified end-to-end over a real UDP socket — not by
+//! inspecting the command and rate lanes in isolation, which cannot see
+//! how the arbiter interleaves them onto the wire.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::UdpSocket;
+
+use crate::codec::{
+    COMMAND_LONG_ID, GIMBAL_MANAGER_SET_ATTITUDE_ID, MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE,
+};
+
+use super::{GimbalRateDemand, LinkConfig, LinkState, OutboundCommand, run_link};
+
+/// Receives one datagram and returns its MAVLink v2 message id, failing
+/// the test if nothing arrives promptly or the frame is not v2.
+async fn recv_frame(socket: &UdpSocket) -> ([u8; 64], usize) {
+    let mut buf = [0u8; 64];
+    let (len, _from) = tokio::time::timeout(Duration::from_secs(2), socket.recv_from(&mut buf))
+        .await
+        .expect("a datagram arrives within 2s")
+        .expect("the datagram is received");
+    (buf, len)
+}
+
+fn message_id(frame: &[u8]) -> u32 {
+    assert!(frame.len() >= 10 && frame[0] == 0xFD, "a MAVLink v2 frame");
+    u32::from(frame[7]) | (u32::from(frame[8]) << 8) | (u32::from(frame[9]) << 16)
+}
+
+/// The COMMAND_LONG `command` field: params 1..7 (28 bytes) then the u16
+/// command, at payload offset 28 — frame offset 38 after the 10-byte v2
+/// header.
+fn command_long_command(frame: &[u8]) -> u16 {
+    assert!(frame.len() >= 40, "a full COMMAND_LONG frame");
+    u16::from(frame[38]) | (u16::from(frame[39]) << 8)
+}
+
+#[tokio::test]
+async fn configure_reaches_the_wire_before_the_first_rate_frame() {
+    // The FC's socket receives whatever the link transmits.
+    let fc = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("the fc socket binds");
+    let fc_addr = fc.local_addr().expect("the fc address is readable");
+    let link_socket = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("the link socket binds");
+
+    // router_mode = false and no stream-interval requests, so the heartbeat
+    // tick emits nothing: the only datagrams are the two under test.
+    let config = LinkConfig {
+        stream_command_target: Some(fc_addr),
+        ..LinkConfig::default()
+    };
+    let state = Arc::new(Mutex::new(LinkState::default()));
+    let (command_tx, command_rx) = tokio::sync::mpsc::channel(8);
+    let (rate_tx, rate_rx) = tokio::sync::watch::channel(None);
+
+    // Enqueue the claim, THEN the rate — both are pending before the
+    // arbiter first runs, so only the biased ordering decides which wins.
+    command_tx
+        .send(OutboundCommand {
+            command: MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE,
+            params: [0.0; 7],
+            target_system: 1,
+            target_component: 1,
+        })
+        .await
+        .expect("the claim queues");
+    rate_tx
+        .send(Some(GimbalRateDemand {
+            pitch_rps: 0.2,
+            yaw_rps: -0.1,
+            target_system: 1,
+            target_component: 1,
+        }))
+        .expect("the rate publishes");
+
+    let link = tokio::spawn(run_link(
+        link_socket,
+        config,
+        false,
+        state,
+        command_rx,
+        rate_rx,
+    ));
+
+    let (first, first_len) = recv_frame(&fc).await;
+    let (second, second_len) = recv_frame(&fc).await;
+    link.abort();
+
+    assert_eq!(
+        message_id(&first[..first_len]),
+        COMMAND_LONG_ID,
+        "the claim (a COMMAND_LONG) reaches the wire first"
+    );
+    assert_eq!(
+        command_long_command(&first[..first_len]),
+        MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE,
+        "the first frame is specifically the gimbal-manager CONFIGURE claim"
+    );
+    assert_eq!(
+        message_id(&second[..second_len]),
+        GIMBAL_MANAGER_SET_ATTITUDE_ID,
+        "the rate setpoint follows the claim, never ahead of it"
+    );
+}

--- a/crates/pilotage-mavlink/src/link/outbound.rs
+++ b/crates/pilotage-mavlink/src/link/outbound.rs
@@ -1,0 +1,95 @@
+//! Typed outbound uplink lanes for the FC's GCS instance.
+//!
+//! The link task owns the socket's single MAVLink sequence counter and
+//! does all encoding: a second sender with its own counter on the same
+//! socket/identity would interleave duplicate and backward sequence
+//! numbers, corrupting the packet-loss accounting the field exists for.
+//! Reliable commands (claims, recenters) ride an ordered queue; gimbal
+//! rate demands ride a latest-value slot so a stalled link coalesces
+//! stale demands away instead of queueing them behind fresh ones.
+
+use std::net::SocketAddr;
+
+use tokio::net::UdpSocket;
+use tracing::warn;
+
+/// One reliably-ordered COMMAND_LONG for the FC's GCS instance.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OutboundCommand {
+    /// MAV_CMD id.
+    pub command: u16,
+    /// COMMAND_LONG params 1..7.
+    pub params: [f32; 7],
+    /// Target MAVLink system.
+    pub target_system: u8,
+    /// Target MAVLink component.
+    pub target_component: u8,
+}
+
+/// The latest-value gimbal rate demand (rad/s). Every publication
+/// replaces the previous one; the link task encodes only the newest.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GimbalRateDemand {
+    /// Pitch rate demand, + = camera up.
+    pub pitch_rps: f32,
+    /// Yaw rate demand, + = camera right.
+    pub yaw_rps: f32,
+    /// Target MAVLink system.
+    pub target_system: u8,
+    /// Target MAVLink component.
+    pub target_component: u8,
+}
+
+/// Encodes and sends one ordered command through the link socket,
+/// advancing the shared sequence. A missing stream-command target drops
+/// the command with a warning.
+pub(super) async fn send_outbound_command(
+    socket: &UdpSocket,
+    seq: &mut u8,
+    target: Option<SocketAddr>,
+    command: Option<OutboundCommand>,
+) {
+    match (command, target) {
+        (Some(command), Some(target)) => {
+            let frame = crate::codec::encode_command_long(
+                *seq,
+                command.command,
+                command.params,
+                command.target_system,
+                command.target_component,
+            );
+            *seq = seq.wrapping_add(1);
+            if let Err(error) = socket.send_to(&frame, target).await {
+                warn!(%error, "outbound command send failed");
+            }
+        }
+        (Some(_), None) => {
+            warn!("outbound command dropped: link has no stream command target");
+        }
+        // All senders dropped; the link is being torn down.
+        (None, _) => {}
+    }
+}
+
+/// Encodes and sends one gimbal rate setpoint, advancing the shared
+/// sequence. `None` demand (a cleared lane) sends nothing.
+pub(super) async fn send_gimbal_rate(
+    socket: &UdpSocket,
+    seq: &mut u8,
+    target: Option<SocketAddr>,
+    demand: Option<GimbalRateDemand>,
+) {
+    if let (Some(demand), Some(target)) = (demand, target) {
+        let frame = crate::codec::encode_gimbal_rate_setpoint(
+            *seq,
+            demand.pitch_rps,
+            demand.yaw_rps,
+            demand.target_system,
+            demand.target_component,
+        );
+        *seq = seq.wrapping_add(1);
+        if let Err(error) = socket.send_to(&frame, target).await {
+            warn!(%error, "gimbal rate setpoint send failed");
+        }
+    }
+}

--- a/crates/pilotage-mavlink/src/link/updates.rs
+++ b/crates/pilotage-mavlink/src/link/updates.rs
@@ -1,0 +1,77 @@
+//! Per-group cache entries the link task writes and adapters sample:
+//! each carries its receive stamp so staleness propagates to consumers
+//! (ADR-0018: loss of data marks groups stale rather than freezing
+//! them).
+
+use std::time::Instant;
+
+use pilotage_adapter_api::MeasurementStamp;
+
+/// One attitude update with its receive stamp.
+#[derive(Debug, Clone, Copy)]
+pub struct AttitudeUpdate {
+    /// Quaternion (w, x, y, z), body FRD → world NED.
+    pub quat_wxyz: [f32; 4],
+    /// Body rates (p, q, r) rad/s.
+    pub rates_rps: [f32; 3],
+    /// Milliseconds since FC boot.
+    pub time_boot_ms: u32,
+    /// Identity and acquisition stamp for this group update.
+    pub stamp: MeasurementStamp,
+    /// Authorization bits retained for this numeric acquisition.
+    pub valid_flags: u32,
+    /// Canonical quality retained for this numeric acquisition.
+    pub quality: u32,
+    /// When this update was received.
+    pub received_at: Instant,
+}
+
+/// One kinematics update with its receive stamp.
+#[derive(Debug, Clone, Copy)]
+pub struct KinematicsUpdate {
+    /// Position NED, meters.
+    pub pos_ned_m: [f32; 3],
+    /// Velocity NED, m/s.
+    pub vel_ned_mps: [f32; 3],
+    /// Milliseconds since FC boot.
+    pub time_boot_ms: u32,
+    /// Identity and acquisition stamp for this group update.
+    pub stamp: MeasurementStamp,
+    /// Authorization bits retained for this numeric acquisition.
+    pub valid_flags: u32,
+    /// Canonical quality retained for this numeric acquisition.
+    pub quality: u32,
+    /// When this update was received.
+    pub received_at: Instant,
+}
+
+/// Latest gimbal-device orientation (Gimbal Protocol v2 attitude
+/// status), with its receive stamp for staleness handling.
+#[derive(Debug, Clone, Copy)]
+pub struct GimbalDeviceAttitude {
+    /// Orientation quaternion (w, x, y, z); vehicle-frame yaw unless
+    /// the device flags say YAW_LOCK.
+    pub quat_wxyz: [f32; 4],
+    /// Angular velocity (x, y, z) rad/s; NaN when the device does not
+    /// report rates.
+    pub rates_rps: [f32; 3],
+    /// Milliseconds since gimbal/FC boot.
+    pub time_boot_ms: u32,
+    /// GIMBAL_DEVICE_FLAGS in effect.
+    pub flags: u16,
+    /// Non-zero reports a device failure condition.
+    pub failure_flags: u32,
+    /// When this report was received.
+    pub received_at: Instant,
+}
+
+/// One command acknowledgement with its receive stamp.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandAckReport {
+    /// The acknowledged MAV_CMD id.
+    pub command: u16,
+    /// MAV_RESULT (0 = accepted).
+    pub result: u8,
+    /// When the acknowledgement was received.
+    pub received_at: Instant,
+}

--- a/crates/pilotage-protocol/build.rs
+++ b/crates/pilotage-protocol/build.rs
@@ -44,6 +44,7 @@ fn main() -> ExitCode {
     match prost_build::Config::new()
         .boxed(".pilotage.v1.TelemetrySample.sim_truth")
         .boxed(".pilotage.v1.TelemetrySample.fc_state")
+        .boxed(".pilotage.v1.TelemetrySample.gimbal")
         .compile_protos(&protos, &[schema_root])
     {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -160,6 +160,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
         }),
         sim_truth: None,
         fc_state: None,
+        gimbal: None,
     };
     let envelope = wire::Envelope {
         schema_version: SCHEMA_VERSION,

--- a/crates/pilotage-protocol/src/wire.rs
+++ b/crates/pilotage-protocol/src/wire.rs
@@ -5,6 +5,13 @@
 //! because `prost` does not emit doc comments for every generated item, and
 //! the schema `.proto` files (the source of truth) already carry the
 //! documentation.
-#![allow(missing_docs)]
+//!
+//! `large_enum_variant` is allowed on the generated code: the `Envelope`
+//! payload is a message-routing union that only ever holds one variant at
+//! a time and is heap-owned in the transport, so boxing every large
+//! variant to equalize inline sizes is churn that fights prost's shape.
+//! The large per-group fields inside `TelemetrySample` are already boxed
+//! (`build.rs`).
+#![allow(missing_docs, clippy::large_enum_variant)]
 
 include!(concat!(env!("OUT_DIR"), "/pilotage.v1.rs"));

--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: 5dfedb440a562919894be17e1ff199bcaae4e25c
+config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5dfedb440a562919894be17e1ff199bcaae4e25c
+run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 outcome: pass
 summary:
 test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
+config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 outcome: pass
 summary:
 test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-sink.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-sink.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture sink round trip
 command: cargo test -p loopback-probe capture::
-config-digest: 5dfedb440a562919894be17e1ff199bcaae4e25c
+config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5dfedb440a562919894be17e1ff199bcaae4e25c
+run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-sink.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-sink.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture sink round trip
 command: cargo test -p loopback-probe capture::
-config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
+config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture projection
 command: cargo test -p loopback-probe telemetry::
-config-digest: 5dfedb440a562919894be17e1ff199bcaae4e25c
+config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5dfedb440a562919894be17e1ff199bcaae4e25c
+run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 outcome: pass
 summary:
 test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture projection
 command: cargo test -p loopback-probe telemetry::
-config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
+config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 outcome: pass
 summary:
 test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/host-wire.run.txt
+++ b/docs/link/evidence-artifacts/link04/host-wire.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: host wire-mapping
 command: cargo test -p pilotage-session-host --lib engine_actor::telemetry
-config-digest: 5dfedb440a562919894be17e1ff199bcaae4e25c
+config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5dfedb440a562919894be17e1ff199bcaae4e25c
+run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 outcome: pass
 summary:
-test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 0.00s
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/host-wire.run.txt
+++ b/docs/link/evidence-artifacts/link04/host-wire.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: host wire-mapping
 command: cargo test -p pilotage-session-host --lib engine_actor::telemetry
-config-digest: 5bd4a3bc6bdb242d1828ac7043117059530dca35
+config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 outcome: pass
 summary:
 test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 0.00s

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -195,45 +195,45 @@ attr outcome pass
 node RESULT-LINK-WIRE verification-result
 title host wire-mapping suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::telemetry
-attr config-digest 5dfedb440a562919894be17e1ff199bcaae4e25c
+attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:9475d75821336825f4aba67953ba544b20aa856e
+attr source-digest git-blob:889087b7df14f59dbd4d13f67f11ae3d86632b36
 attr artifact docs/link/evidence-artifacts/link04/host-wire.run.txt
-attr output-digest sha256:6c3699e4e04694149b4aebc4d274c83e9c1aff82abbed60ef10310079dcb8d2a
-attr run-id local:5dfedb440a562919894be17e1ff199bcaae4e25c
+attr output-digest sha256:5934fc287328f12271ebfe18e41d00ae11d57c003aaa9ca8f103c235280e7c0c
+attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr outcome pass
 
 node RESULT-LINK-CAPTURE verification-result
 title loopback-probe capture projection suite — recorded pass
 attr command cargo test -p loopback-probe telemetry::
-attr config-digest 5dfedb440a562919894be17e1ff199bcaae4e25c
+attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:d54d1f5f5ce4cd3d65d7723ccd089a5dee0bed20
+attr source-digest git-blob:65e0988d096f01778980b542d46f777541d8bfe2
 attr artifact docs/link/evidence-artifacts/link04/capture.run.txt
-attr output-digest sha256:ebc55085be041f1f5f5339c65201233870b81efb545d4dee378979d9f7df148c
-attr run-id local:5dfedb440a562919894be17e1ff199bcaae4e25c
+attr output-digest sha256:fadec4519c95623e812f270cdcae6956d31a1e1dd89f8293a3556e3ac534eae7
+attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest 5dfedb440a562919894be17e1ff199bcaae4e25c
+attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:fbc947454e43c051a94e4722cb639d317373767e
+attr source-digest git-blob:df0490b0fdcdc0cae08441c3d717cd1ff0764f57
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:62b2fdb06c63262726e288c1c7fc411eed594f484b283b0a997a5453ed07a1f0
-attr run-id local:5dfedb440a562919894be17e1ff199bcaae4e25c
+attr output-digest sha256:d097d92f65dc9cf5f6b67f1532ab0649f51389d1c0a0286fe6d8729d8c4a312f
+attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
 title loopback-probe capture sink suite — recorded pass
 attr command cargo test -p loopback-probe capture::
-attr config-digest 5dfedb440a562919894be17e1ff199bcaae4e25c
+attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:7442d11b6f3011d51a20fd807b655c16b1c42bc3
+attr source-digest git-blob:329779834423fffad82e5ed8270a33dd92c45fb6
 attr artifact docs/link/evidence-artifacts/link04/capture-sink.run.txt
-attr output-digest sha256:071adfde6ec1bfa2609a21a99482bfcff7113984de059dc77d68bba60f790f9b
-attr run-id local:5dfedb440a562919894be17e1ff199bcaae4e25c
+attr output-digest sha256:74a4939c6b9d71a4185c02f066718589616443a4b2e3b58c72b5db75d1f0ce2a
+attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -258,8 +258,8 @@ attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
-attr commit 5dfedb440a562919894be17e1ff199bcaae4e25c
-attr tree a000c09c465aeb5a3a3b1fa35d6f90276559895a
+attr commit 5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr tree 0e68ffddabc910a7e6bc41b20768a82804505a08
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -195,45 +195,45 @@ attr outcome pass
 node RESULT-LINK-WIRE verification-result
 title host wire-mapping suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::telemetry
-attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:889087b7df14f59dbd4d13f67f11ae3d86632b36
 attr artifact docs/link/evidence-artifacts/link04/host-wire.run.txt
-attr output-digest sha256:5934fc287328f12271ebfe18e41d00ae11d57c003aaa9ca8f103c235280e7c0c
-attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr output-digest sha256:7acbbfa35eaf2845a455364184a37e6e2b9b3b65d3c1bfb489cfdf0ad594d6c5
+attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr outcome pass
 
 node RESULT-LINK-CAPTURE verification-result
 title loopback-probe capture projection suite — recorded pass
 attr command cargo test -p loopback-probe telemetry::
-attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:65e0988d096f01778980b542d46f777541d8bfe2
 attr artifact docs/link/evidence-artifacts/link04/capture.run.txt
-attr output-digest sha256:fadec4519c95623e812f270cdcae6956d31a1e1dd89f8293a3556e3ac534eae7
-attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr output-digest sha256:2aed2db420bf9bf0c8ac51c622044cc4ab436f74a17f58033c053cb08fd75507
+attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:df0490b0fdcdc0cae08441c3d717cd1ff0764f57
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:d097d92f65dc9cf5f6b67f1532ab0649f51389d1c0a0286fe6d8729d8c4a312f
-attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr output-digest sha256:fab8e23b76f5b66c67c86398a0f5f3d2d50e2247e6c0af4a581114e205726b22
+attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
 title loopback-probe capture sink suite — recorded pass
 attr command cargo test -p loopback-probe capture::
-attr config-digest 5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:329779834423fffad82e5ed8270a33dd92c45fb6
 attr artifact docs/link/evidence-artifacts/link04/capture-sink.run.txt
-attr output-digest sha256:74a4939c6b9d71a4185c02f066718589616443a4b2e3b58c72b5db75d1f0ce2a
-attr run-id local:5bd4a3bc6bdb242d1828ac7043117059530dca35
+attr output-digest sha256:2fd6ac86f5dc0c4ab49ef46143e2c6169019b315c827fea0f167f6397e5fee64
+attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -258,8 +258,8 @@ attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
-attr commit 5bd4a3bc6bdb242d1828ac7043117059530dca35
-attr tree 0e68ffddabc910a7e6bc41b20768a82804505a08
+attr commit ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr tree fb15a5c8155c7dad37f772504025c1c529ba7f49
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -1,8 +1,8 @@
 //! Lossless adapter-to-wire telemetry mapping.
 
 use pilotage_adapter_api::{
-    AvionicsSample, FcStateSample, MeasurementClock, MeasurementStamp, SimTruthSample,
-    SourceIntegrity, SourceRole, TelemetrySample,
+    AvionicsSample, FcStateSample, GimbalAttitudeSample, MeasurementClock, MeasurementStamp,
+    SimTruthSample, SourceIntegrity, SourceRole, TelemetrySample,
 };
 use pilotage_protocol::wire;
 use pilotage_timing::MonoTimestamp;
@@ -41,6 +41,20 @@ pub(super) fn sample_to_wire(
         fc_state: sample
             .fc_state
             .map(|state| Box::new(fc_state_to_wire(state))),
+        gimbal: sample.gimbal.map(|gimbal| Box::new(gimbal_to_wire(gimbal))),
+    }
+}
+
+fn gimbal_to_wire(sample: GimbalAttitudeSample) -> wire::GimbalAttitude {
+    wire::GimbalAttitude {
+        quat_w: sample.quat_wxyz[0],
+        quat_x: sample.quat_wxyz[1],
+        quat_y: sample.quat_wxyz[2],
+        quat_z: sample.quat_wxyz[3],
+        rate_x_rad_s: sample.rates_rps[0],
+        rate_y_rad_s: sample.rates_rps[1],
+        rate_z_rad_s: sample.rates_rps[2],
+        stamp: Some(measurement_stamp_to_wire(sample.stamp)),
     }
 }
 

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -55,6 +55,8 @@ fn gimbal_to_wire(sample: GimbalAttitudeSample) -> wire::GimbalAttitude {
         rate_y_rad_s: sample.rates_rps[1],
         rate_z_rad_s: sample.rates_rps[2],
         stamp: Some(measurement_stamp_to_wire(sample.stamp)),
+        flags: sample.flags,
+        failure_flags: sample.failure_flags,
     }
 }
 
@@ -69,6 +71,7 @@ fn measurement_stamp_to_wire(stamp: MeasurementStamp) -> wire::MeasurementStamp 
         SourceRole::SimulationTruth => wire::SourceRole::SimulationTruth,
         SourceRole::FcState => wire::SourceRole::FcState,
         SourceRole::VideoCapture => wire::SourceRole::VideoCapture,
+        SourceRole::PayloadDevice => wire::SourceRole::PayloadDevice,
     };
     let integrity = match stamp.integrity {
         SourceIntegrity::Authenticated => wire::SourceIntegrity::Authenticated,

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -22,15 +22,27 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
         acquired_at_ns: 1_234_567,
         clock: MeasurementClock::VehicleBoot,
     };
-    let kinematics = MeasurementStamp {
-        sequence: 19,
-        acquired_at_ns: 1_200_000,
+    let with = |sequence, acquired_at_ns| MeasurementStamp {
+        sequence,
+        acquired_at_ns,
         ..attitude
     };
-    let estimator_status = MeasurementStamp {
-        sequence: 20,
-        acquired_at_ns: 1_234_567,
-        ..attitude
+    let kinematics = with(19, 1_200_000);
+    let estimator_status = with(20, 1_234_567);
+    let avionics = AvionicsSample {
+        attitude: Some(AvionicsAttitudeSample {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            rates_rps: [0.0; 3],
+            stamp: attitude,
+        }),
+        kinematics: Some(AvionicsKinematicsSample {
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            stamp: kinematics,
+        }),
+        estimator_status_stamp: Some(estimator_status),
+        valid_flags: 0b1111,
+        quality: 0,
     };
     let sample = TelemetrySample {
         vehicle: VehicleId::new(9),
@@ -41,23 +53,10 @@ fn publication_time_and_source_acquisition_stamps_stay_distinct() {
             heading: 0.5,
         }),
         speed: Some(3.0),
-        avionics: Some(AvionicsSample {
-            attitude: Some(AvionicsAttitudeSample {
-                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
-                rates_rps: [0.0; 3],
-                stamp: attitude,
-            }),
-            kinematics: Some(AvionicsKinematicsSample {
-                pos_ned_m: [0.0; 3],
-                vel_ned_mps: [0.0; 3],
-                stamp: kinematics,
-            }),
-            estimator_status_stamp: Some(estimator_status),
-            valid_flags: 0b1111,
-            quality: 0,
-        }),
+        avionics: Some(avionics),
         sim_truth: None,
         fc_state: None,
+        gimbal: None,
     };
 
     let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(9_000_000));
@@ -139,6 +138,7 @@ fn kinematics_only_omits_planar_projection_while_group_flows() {
         }),
         sim_truth: None,
         fc_state: None,
+        gimbal: None,
     };
 
     let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(1));
@@ -177,6 +177,7 @@ fn attitude_only_omits_planar_projection_while_group_flows() {
         }),
         sim_truth: None,
         fc_state: None,
+        gimbal: None,
     };
 
     let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(1));
@@ -229,6 +230,7 @@ fn truth_and_fc_state_survive_the_wire_under_their_own_identities() {
             arm_state: 2,
             stamp: fc_stamp,
         }),
+        gimbal: None,
     };
 
     let wire_sample = sample_to_wire(sample, MonoTimestamp::from_nanos(5));

--- a/hosts/session-host/src/runtime/px4_config.rs
+++ b/hosts/session-host/src/runtime/px4_config.rs
@@ -11,6 +11,7 @@ const PROFILE: &str = "PILOTAGE_PX4_PROFILE";
 const TELEMETRY_ENDPOINT: &str = "PILOTAGE_PX4_ADDR";
 const STREAM_COMMAND_ENDPOINT: &str = "PILOTAGE_PX4_GCS_ADDR";
 const COMMAND_ENDPOINT: &str = "PILOTAGE_PX4_FC_ADDR";
+const GIMBAL: &str = "PILOTAGE_PX4_GIMBAL";
 
 pub(crate) fn from_env() -> Result<Px4Config, HostError> {
     config_from_values(
@@ -18,6 +19,7 @@ pub(crate) fn from_env() -> Result<Px4Config, HostError> {
         std::env::var(TELEMETRY_ENDPOINT),
         std::env::var(STREAM_COMMAND_ENDPOINT),
         std::env::var(COMMAND_ENDPOINT),
+        std::env::var(GIMBAL),
     )
 }
 
@@ -26,9 +28,10 @@ fn config_from_values(
     telemetry_endpoint: Result<String, VarError>,
     stream_command_endpoint: Result<String, VarError>,
     command_endpoint: Result<String, VarError>,
+    gimbal: Result<String, VarError>,
 ) -> Result<Px4Config, HostError> {
     let profile = parse_profile(profile)?;
-    let mut config = Px4Config::new(profile);
+    let mut config = Px4Config::new(profile).with_gimbal(parse_flag(gimbal));
     config.telemetry_endpoint = parse_endpoint(
         TELEMETRY_ENDPOINT,
         telemetry_endpoint,
@@ -42,6 +45,12 @@ fn config_from_values(
     config.command_endpoint =
         parse_endpoint(COMMAND_ENDPOINT, command_endpoint, config.command_endpoint)?;
     Ok(config)
+}
+
+/// A capability flag: enabled only by an explicit truthy value, so a
+/// vehicle without a gimbal never advertises the scope by accident.
+fn parse_flag(value: Result<String, VarError>) -> bool {
+    matches!(value.as_deref(), Ok("1") | Ok("true"))
 }
 
 fn parse_profile(value: Result<String, VarError>) -> Result<Px4Profile, HostError> {
@@ -88,7 +97,7 @@ mod tests {
     fn config(
         profile: Result<String, VarError>,
     ) -> Result<pilotage_adapter_px4::Px4Config, HostError> {
-        config_from_values(profile, absent(), absent(), absent())
+        config_from_values(profile, absent(), absent(), absent(), absent())
     }
 
     #[test]
@@ -138,6 +147,7 @@ mod tests {
                     Ok("not-an-address".to_owned()),
                     absent(),
                     absent(),
+                    absent(),
                 ),
             ),
             (
@@ -146,6 +156,7 @@ mod tests {
                     Ok("simulation".to_owned()),
                     absent(),
                     Ok("127.0.0.1:not-a-port".to_owned()),
+                    absent(),
                     absent(),
                 ),
             ),
@@ -156,6 +167,7 @@ mod tests {
                     absent(),
                     absent(),
                     Ok("missing-port".to_owned()),
+                    absent(),
                 ),
             ),
         ] {

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -175,6 +175,25 @@ message FcState {
   MeasurementStamp stamp = 2;
 }
 
+// Gimbal device orientation (Gimbal Protocol v2 attitude status) under its
+// own provenance stamp: payload-device state, never a vehicle estimate and
+// never an input to control validation.
+message GimbalAttitude {
+  // Orientation quaternion (w, x, y, z); vehicle-frame yaw unless the
+  // device declares an earth-frame yaw mode.
+  float quat_w = 1;
+  float quat_x = 2;
+  float quat_y = 3;
+  float quat_z = 4;
+  // Device angular velocity (rad/s); NaN encodes device-unknown.
+  float rate_x_rad_s = 5;
+  float rate_y_rad_s = 6;
+  float rate_z_rad_s = 7;
+  // Identity and acquisition of the device report. Absence makes the
+  // sample unconsumable.
+  MeasurementStamp stamp = 8;
+}
+
 // A single best-effort telemetry sample for one vehicle.
 message TelemetrySample {
   VehicleId vehicle = 1;
@@ -192,4 +211,6 @@ message TelemetrySample {
   SimTruthState sim_truth = 7;
   // FC-owned arm/mode state with its own provenance stamp.
   FcState fc_state = 8;
+  // Gimbal payload-device orientation with its own provenance stamp.
+  GimbalAttitude gimbal = 9;
 }

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -51,6 +51,10 @@ enum SourceRole {
   SOURCE_ROLE_FC_STATE = 3;
   // Video capture identity for camera frames.
   SOURCE_ROLE_VIDEO_CAPTURE = 4;
+  // Payload-device orientation/state (gimbal attitude) relayed over the
+  // FC link: not a vehicle estimate and never eligible for control
+  // validation. Carries the device's own boot clock, not host time.
+  SOURCE_ROLE_PAYLOAD_DEVICE = 5;
 }
 
 // Integrity classification of the path that delivered an observation. The
@@ -192,6 +196,10 @@ message GimbalAttitude {
   // Identity and acquisition of the device report. Absence makes the
   // sample unconsumable.
   MeasurementStamp stamp = 8;
+  // GIMBAL_DEVICE_FLAGS in effect (mode/lock bits).
+  uint32 flags = 9;
+  // Non-zero reports a device failure condition.
+  uint32 failure_flags = 10;
 }
 
 // A single best-effort telemetry sample for one vehicle.

--- a/sim/worlds/px4_flightdeck.sdf
+++ b/sim/worlds/px4_flightdeck.sdf
@@ -39,12 +39,15 @@
       <elevation>0</elevation>
     </spherical_coordinates>
 
-    <!-- Pilotage: the PX4 x500 is included statically (PX4 attaches to
-         it via PX4_GZ_MODEL_NAME instead of spawning) so the Pilotage
+    <!-- Pilotage: the PX4 vehicle is included statically (PX4 attaches
+         to it via PX4_GZ_MODEL_NAME instead of spawning) so the Pilotage
          camera rig can be welded to it at world scope, publishing the
-         /camera and /chase_camera topics the gz sidecar bridges. -->
+         /camera and /chase_camera topics the gz sidecar bridges.
+         x500_gimbal merge-includes x500 plus the CGO3 3-axis gimbal
+         whose joints PX4's GZGimbal bridge drives (GIM-04), so
+         `x500_0::base_link` remains the rig attachment. -->
     <include>
-      <uri>model://x500</uri>
+      <uri>model://x500_gimbal</uri>
       <name>x500_0</name>
       <pose>0 0 0.24 0 0 0</pose>
     </include>

--- a/tools/loopback-probe/src/capture.rs
+++ b/tools/loopback-probe/src/capture.rs
@@ -158,6 +158,7 @@ mod tests {
                     )
                 }),
             })),
+            gimbal: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(9));
 

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -333,6 +333,7 @@ mod tests {
                 avionics: None,
                 sim_truth: None,
                 fc_state: None,
+                gimbal: None,
             },
         ));
         let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(5)).expect("telemetry");
@@ -381,6 +382,7 @@ mod tests {
                     arm_state: 2,
                     stamp: Some(fc_stamp),
                 })),
+                gimbal: None,
             },
         ));
         let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(9)).expect("telemetry");

--- a/tools/loopback-probe/src/telemetry.rs
+++ b/tools/loopback-probe/src/telemetry.rs
@@ -185,6 +185,7 @@ mod tests {
             avionics: None,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(100));
         assert_eq!(observation.pose, Some((1.5, 2.5, 0.25)));
@@ -204,6 +205,7 @@ mod tests {
             avionics: None,
             sim_truth: None,
             fc_state: None,
+            gimbal: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(0));
         assert_eq!(observation.pose, None);
@@ -237,6 +239,7 @@ mod tests {
                     wire::SourceIntegrity::ChecksummedOnly,
                 )),
             })),
+            gimbal: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(9));
         let truth = observation.sim_truth.expect("truth lane captured");
@@ -274,6 +277,7 @@ mod tests {
                 arm_state: 2,
                 stamp: None,
             })),
+            gimbal: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(1));
         assert_eq!(observation.sim_truth, None, "truth without provenance");

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -16,8 +16,12 @@ use crate::readiness::{Readiness, stage_log};
 /// The gz world PX4's x500 model spawns into (PX4 ships `default.sdf`;
 /// its `<world name>` is `default` — also what the reset script targets).
 const WORLD_NAME: &str = "default";
-/// PX4 airframe autostart id for the gz x500.
-const SYS_AUTOSTART: &str = "4001";
+/// PX4 airframe autostart id for the gz x500 with the CGO3 gimbal
+/// (4019_gz_x500_gimbal): MNT_MODE_IN/OUT = MAVLink Gimbal Protocol v2,
+/// which the PX4 adapter's `vehicle.gimbal` scope drives (GIM-04).
+const SYS_AUTOSTART: &str = "4019";
+/// The matching PX4 model selector for the airframe above.
+const SIM_MODEL: &str = "gz_x500_gimbal";
 
 /// The PX4 + Gazebo SITL backend.
 #[derive(Debug)]
@@ -227,7 +231,7 @@ fn px4_stage(
                 // Pilotage camera rig) instead of spawning its own.
                 ("PX4_GZ_STANDALONE".to_owned(), "1".to_owned()),
                 ("PX4_SYS_AUTOSTART".to_owned(), SYS_AUTOSTART.to_owned()),
-                ("PX4_SIM_MODEL".to_owned(), "gz_x500".to_owned()),
+                ("PX4_SIM_MODEL".to_owned(), SIM_MODEL.to_owned()),
                 ("PX4_GZ_MODEL_NAME".to_owned(), "x500_0".to_owned()),
                 ("PX4_GZ_WORLD".to_owned(), WORLD_NAME.to_owned()),
             ],
@@ -402,6 +406,38 @@ mod tests {
                 .any(|(k, _)| k == "GZ_SIM_SERVER_CONFIG_PATH"),
             "gz must load PX4's sensor systems via the server config"
         );
+        assert!(
+            fc_env
+                .iter()
+                .any(|(k, v)| k == "PX4_SYS_AUTOSTART" && v == "4019")
+                && fc_env
+                    .iter()
+                    .any(|(k, v)| k == "PX4_SIM_MODEL" && v == "gz_x500_gimbal"),
+            "the FC must boot the gimbal airframe (GIM-04): 4019/gz_x500_gimbal"
+        );
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    // The airframe env above and the statically included world model
+    // must agree: PX4's GZGimbal bridge publishes joint commands under
+    // `/model/<PX4_GZ_MODEL_NAME>/…`, so a world still carrying the
+    // plain x500 would boot cleanly and then ignore every gimbal
+    // demand silently.
+    #[test]
+    fn the_px4_world_carries_the_gimbal_model_the_airframe_expects() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("repo root");
+        let world = std::fs::read_to_string(repo_root.join("sim/worlds/px4_flightdeck.sdf"))
+            .expect("px4 world");
+        assert!(
+            world.contains("<uri>model://x500_gimbal</uri>"),
+            "the px4 world must include the gimbal-bearing vehicle"
+        );
+        assert!(
+            world.contains("<name>x500_0</name>"),
+            "the included vehicle must keep the name PX4_GZ_MODEL_NAME attaches to"
+        );
     }
 }

--- a/tools/xtask/src/backend/px4_gz.rs
+++ b/tools/xtask/src/backend/px4_gz.rs
@@ -40,6 +40,9 @@ impl SimBackend for Px4Gz {
         vec![
             ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
             ("PILOTAGE_PX4_PROFILE".to_owned(), "simulation".to_owned()),
+            // This backend boots the gz_x500_gimbal airframe (4019), so
+            // the adapter advertises the vehicle.gimbal scope.
+            ("PILOTAGE_PX4_GIMBAL".to_owned(), "1".to_owned()),
         ]
     }
 
@@ -298,6 +301,20 @@ mod tests {
                 .host_env(&ctx)
                 .iter()
                 .any(|(key, value)| { key == "PILOTAGE_PX4_PROFILE" && value == "simulation" })
+        );
+    }
+
+    #[test]
+    fn host_environment_enables_the_gimbal_capability() {
+        // The gz_x500_gimbal airframe carries a gimbal; the host must
+        // advertise the scope, and no other FC backend sets this flag.
+        let backend = Px4Gz;
+        let ctx = context(PathBuf::from("unused-for-host-environment"));
+        assert!(
+            backend
+                .host_env(&ctx)
+                .iter()
+                .any(|(key, value)| key == "PILOTAGE_PX4_GIMBAL" && value == "1")
         );
     }
 


### PR DESCRIPTION
Refs #168, part of #162 (GIM-01).

First gimbal backend: the PX4 adapter advertises a second, independently
leased control scope — `vehicle.gimbal` (ADR-0006 vocabulary; supersedes the
`payload.gimbal` working name in the issue) — and maps it to MAVLink Gimbal
Protocol v2, tested live against PX4 SITL `gz_x500_gimbal`.

## What

- **pilotage-mavlink**: GIMBAL_MANAGER_SET_ATTITUDE (282) rate-demand encoder
  (all-NaN attitude quaternion, horizon + yaw-follow flags),
  GIMBAL_DEVICE_ATTITUDE_STATUS (285) decode with MAVLink-v2 zero-extension,
  CRC_EXTRA values verified against PX4's generated common-dialect headers.
  Outbound frames ride the receive link's own socket via a new mpsc lane: the
  FC's GCS instance retargets its stream to the last peer that spoke, so a
  second socket would steal the telemetry stream. Command acks and gimbal
  device status are cached on LinkState.
- **PX4 adapter**: `vehicle.gimbal` scope (pitch/yaw LOS rate demands +
  recenter edge). Primary control is claimed for the codec's GCS identity and
  re-asserted at 1 Hz while demands flow — PX4 silently drops non-primary
  SET_ATTITUDE — and a fresh CONFIGURE denial rejects pointing frames with a
  typed reason. A demand stream silent past 300 ms is cut off with one
  zero-rate setpoint (the FC's own stale fallback is 2 s). Pointing is
  deliberately outside the flight gate chain and keeps working where flight
  control is rejected.
- **xtask px4-gz + world**: boots `PX4_SYS_AUTOSTART=4019` /
  `gz_x500_gimbal`; the flight-deck world statically includes
  `model://x500_gimbal` under the same `x500_0` name (merge-include keeps
  `x500_0::base_link` valid for the camera-rig weld).

## Guardrails

- Golden wire-layout lockdown for the 282 encoder; 285 decode incl. truncated
  payloads; claim-before-stream, claim re-assert cadence, one-shot stale
  cutoff, neutral command, typed claim-denial rejection; xtask planning test
  pins the airframe env and a world test pins the model include (a plain-x500
  world boots cleanly and then ignores every gimbal demand silently).

## Verification

- Full local CI: fmt, clippy `-D warnings`, workspace tests, doc gates,
  release build.
- Live SITL E2E against `gz_x500_gimbal` (standalone gz + PX4, probe using
  these exact codec functions): CONFIGURE accepted, pitch leg 0 to -1.271 rad
  on a -0.5 rad/s stream, yaw leg +1.49 rad, neutral recentered to
  level/vehicle-forward; acks `[(1001,0)x5, (1000,0)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
