### PR TITLE
Instruments: fail visibly on unknown scene opcodes

### DIFF
--- a/clients/web/instrument-health.js
+++ b/clients/web/instrument-health.js
@@ -38,6 +38,11 @@ export const REASON = Object.freeze({
   LIVENESS: 106,
   STATE_WRITE_FAILED: 107,
   GLYPH_ASSET: 108,
+  // A scene opcode this interpreter does not know: presenting the frame
+  // anyway would silently skip draw commands (a clip or tape backdrop
+  // dropping out bleeds layers that must never show through), so the
+  // frame fails visibly instead.
+  UNKNOWN_OPCODE: 109,
 });
 
 // A typed module-level fault raised by loadInstruments so callers can show

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -521,8 +521,8 @@ export class InstrumentModule {
       if (unknownThisFrame > 0) {
         // A skipped opcode means draw commands silently dropped out of
         // the frame — a lost clip or tape backdrop bleeds layers that
-        // must never show through (stale interpreter vs newer scene
-        // stream). Never present such a frame.
+        // must never show through. This is a scene/interpreter
+        // opcode-set mismatch; never present such a frame.
         return { ok: false, reason: REASON.UNKNOWN_OPCODE };
       }
     } catch {

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -516,7 +516,15 @@ export class InstrumentModule {
       const bctx = back.getContext("2d");
       bctx.fillStyle = "#000";
       bctx.fillRect(0, 0, LOGICAL_W, LOGICAL_H);
-      this.unknownOpcodes += interpretScene(view, bctx, this.#glyphs);
+      const unknownThisFrame = interpretScene(view, bctx, this.#glyphs);
+      this.unknownOpcodes += unknownThisFrame;
+      if (unknownThisFrame > 0) {
+        // A skipped opcode means draw commands silently dropped out of
+        // the frame — a lost clip or tape backdrop bleeds layers that
+        // must never show through (stale interpreter vs newer scene
+        // stream). Never present such a frame.
+        return { ok: false, reason: REASON.UNKNOWN_OPCODE };
+      }
     } catch {
       return { ok: false, reason: REASON.PAINT_FAILED };
     }

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -562,7 +562,7 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
 
 // A scene carrying an opcode this interpreter does not know must fail the
 // frame, never present it: a silently skipped clip or backdrop command
-// bleeds layers that may never show through (the stale-interpreter class).
+// bleeds layers that may never show through (a scene/interpreter opcode-set mismatch).
 {
   const withUnknown = Uint8Array.from([
     1,

--- a/clients/web/instruments.test.mjs
+++ b/clients/web/instruments.test.mjs
@@ -560,6 +560,30 @@ const view = (bytes) => new DataView(bytes.buffer, bytes.byteOffset, bytes.byteL
   check("command-limit failure leaves visible target untouched", visible.log.length === 0);
 }
 
+// A scene carrying an opcode this interpreter does not know must fail the
+// frame, never present it: a silently skipped clip or backdrop command
+// bleeds layers that may never show through (the stale-interpreter class).
+{
+  const withUnknown = Uint8Array.from([
+    1,
+    ...cmd(0x23, [1, ...f32(0), ...f32(0), ...f32(10), ...f32(10)]),
+    ...cmd(0x7f, []),
+  ]);
+  const mod = new InstrumentModule(fakeExports({ sceneBytes: withUnknown }), {
+    createCanvas: recordingCanvas,
+  });
+  const visible = new RecordingCtx();
+  const result = mod.renderPanel(PANEL.PFD, visible, 480, 360);
+  check(
+    "an unknown scene opcode fails the frame as UNKNOWN_OPCODE",
+    !result.ok && result.reason === REASON.UNKNOWN_OPCODE,
+  );
+  check(
+    "the partially-interpreted frame never reaches the visible target",
+    visible.log.length === 0,
+  );
+}
+
 {
   for (const reason of [
     REASON.SCENE_BUFFER_FULL,

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -341,17 +341,25 @@ fn viewer_stage(ctx: &SessionContext) -> Result<Stage, XtaskError> {
             hint: "run from the Pilotage repository root",
         });
     }
+    // Cache-Control: no-store on every response: the served client must
+    // always equal the working-tree source. The viewer is served straight
+    // from the tree, so any heuristic caching of main.js would let the
+    // browser run a client that has diverged from the source on disk;
+    // no-store holds the served client and the on-disk source identical.
+    let server = format!(
+        "import http.server\n\
+         class H(http.server.SimpleHTTPRequestHandler):\n\
+         \tdef end_headers(self):\n\
+         \t\tself.send_header('Cache-Control', 'no-store')\n\
+         \t\tsuper().end_headers()\n\
+         http.server.test(HandlerClass=H, port={port}, bind='127.0.0.1')\n",
+        port = ctx.viewer_port
+    );
     Ok(Stage {
         spec: ProcessSpec {
             name: "viewer",
             program: "python3".to_owned(),
-            args: vec![
-                "-m".to_owned(),
-                "http.server".to_owned(),
-                ctx.viewer_port.to_string(),
-                "--bind".to_owned(),
-                "127.0.0.1".to_owned(),
-            ],
+            args: vec!["-c".to_owned(), server],
             cwd: Some(viewer_dir),
             env: vec![],
             remove_env: vec![],

--- a/tools/xtask/src/session/tests.rs
+++ b/tools/xtask/src/session/tests.rs
@@ -9,11 +9,15 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use super::{claim_supervisor, resolve_manifest, start_stages, supervise, verify_listening_port};
-use crate::backend::Stage;
+use super::{
+    claim_supervisor, resolve_manifest, start_stages, supervise, verify_listening_port,
+    viewer_stage,
+};
+use crate::backend::{SessionContext, Stage};
+use crate::cli::Profile;
 use crate::error::XtaskError;
 use crate::process::{ManagedChild, ProcessSpec};
-use crate::readiness::Readiness;
+use crate::readiness::{Readiness, await_ready};
 
 const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -263,4 +267,76 @@ fn listening_port_must_match_the_requested_port() {
             actual: 4434,
         })
     ));
+}
+
+/// Reserves an ephemeral port by binding then releasing it, so the
+/// spawned server can claim it. The reserve→claim window is tiny and
+/// loopback-local; a collision only reruns the test.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("an ephemeral port binds")
+        .local_addr()
+        .expect("the bound address is readable")
+        .port()
+}
+
+/// Minimal HTTP/1.0 GET returning the raw response. HTTP/1.0 makes the
+/// server close the connection at end-of-body, so the read completes on
+/// EOF without content-length parsing.
+fn http_get(port: u16, path: &str) -> String {
+    use std::io::Write;
+    let mut stream = std::net::TcpStream::connect(("127.0.0.1", port))
+        .expect("the viewer server accepts the request connection");
+    stream
+        .write_all(format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n").as_bytes())
+        .expect("the request is written");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("the response is read to EOF");
+    response
+}
+
+/// Every viewer response must carry `Cache-Control: no-store` so the
+/// browser can never present a cached client that has diverged from the
+/// working-tree source. Spawns the real `viewer_stage` process on an
+/// ephemeral port and reads the header off the wire.
+#[tokio::test]
+async fn viewer_server_sets_cache_control_no_store() {
+    let repo_root = std::env::temp_dir().join(format!("plt_xt_viewer_{}", std::process::id()));
+    let web = repo_root.join("clients/web");
+    std::fs::create_dir_all(&web).expect("temp clients/web is created");
+    std::fs::write(web.join("index.html"), "<title>viewer</title>")
+        .expect("the viewer entrypoint is written");
+
+    let ctx = SessionContext {
+        repo_root: repo_root.clone(),
+        host_port: 0,
+        viewer_port: free_port(),
+        profile: Profile::Simulation,
+        log_dir: repo_root.clone(),
+    };
+    let stage = viewer_stage(&ctx).expect("the viewer stage plans");
+    let mut child = ManagedChild::spawn(&stage.spec).expect("the viewer server spawns");
+    let ready = await_ready(&mut child, &stage.readiness).await;
+
+    // Read the header off the wire only once the server accepts, but
+    // always tear the process group down before asserting.
+    let response = ready.is_ok().then(|| http_get(ctx.viewer_port, "/"));
+    child.terminate_group();
+    std::fs::remove_dir_all(&repo_root).ok();
+
+    ready.expect("the viewer server accepts connections");
+    let headers = response
+        .unwrap_or_default()
+        .split("\r\n\r\n")
+        .next()
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        headers
+            .to_ascii_lowercase()
+            .contains("cache-control: no-store"),
+        "every viewer response must carry Cache-Control: no-store; got headers:\n{headers}"
+    );
 }


### PR DESCRIPTION
Closes the instrument-bleed the owner reported (sky/ground showing behind the PFD tapes). Refs #30 (hardware timing work stays open).

## Fix

An unknown scene opcode meant `interpretScene` silently skipped draw commands — a lost clip or tape backdrop bleeds layers that must never show through (a scene/interpreter opcode-set mismatch). The frame now **fails visibly** with the typed `D-109` cover before the back buffer reaches the visible canvas, and a regression test pins that a partially-interpreted frame never reaches the visible target.

## Staleness defense (moved here from #173)

The `Cache-Control: no-store` viewer server is co-located here: it removes the staleness source (a browser caching an old `main.js` after an edit) that lets a stale scene interpreter meet a newer scene stream. Together the header + the opcode gate close the hole and guarantee no partial frame is presented.

Independent of the gimbal PRs; recommended to merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)