### PR TITLE
Viewer: enforce gimbal source-2 routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: viewer video-diagnostics decision logic (readiness dedup + read-failure coalescing)
         run: node clients/web/video-diagnostics.test.mjs
 
+      - name: viewer video-source routing (FPV + chase + gimbal payload)
+        run: node clients/web/video-routing.test.mjs
+
       - name: viewer incoming-uni-stream accept-loop lifecycle (stream isolation + terminal collection)
         run: node clients/web/uni-stream-accept.test.mjs
 

--- a/adapters/gazebo/src/adapter.rs
+++ b/adapters/gazebo/src/adapter.rs
@@ -59,9 +59,10 @@ pub const GIMBAL_CAMERA: u8 = 2;
 /// [`FrameStamper`], so its [`capture`](Self::capture) is always fully formed.
 #[derive(Debug, Clone)]
 pub struct RawVideoFrame {
-    /// Video source this frame came from: 0 = onboard FPV, 1 = chase. Carried
-    /// end to end so the host media pipeline and every reader can route each
-    /// frame to the right video source (the wire `source_id` byte).
+    /// Video source this frame came from: 0 = onboard FPV, 1 = chase, 2 =
+    /// gimbal payload. Carried end to end so the host media pipeline and every
+    /// reader can route each frame to the right video source (the wire
+    /// `source_id` byte).
     pub source_id: u8,
     /// Frame width in pixels.
     pub width: u32,

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -69,6 +69,7 @@ import { negotiateSessionAuthority } from "./connect-authority.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
 import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
+import { bindVideoTargets, resolveVideoTarget } from "./video-routing.js";
 import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 import { createReconnectController } from "./reconnect.js";
 import { startDatagramControl } from "./datagram-control.js";
@@ -122,16 +123,10 @@ const els = {
   overlay: document.getElementById("overlay"),
   telemetry: document.getElementById("telemetry"),
   gamepad: document.getElementById("gamepad"),
-  canvas: document.getElementById("video"),
-  chaseCanvas: document.getElementById("chaseVideo"),
-  gimbalCanvas: document.getElementById("gimbalVideo"),
   pfd: document.getElementById("pfd"),
   hsi: document.getElementById("hsi"),
   flightMode: document.getElementById("flightMode"),
 };
-const ctx = els.canvas.getContext("2d");
-const chaseCtx = els.chaseCanvas.getContext("2d");
-const gimbalCtx = els.gimbalCanvas.getContext("2d");
 const pfdCtx = els.pfd.getContext("2d");
 const hsiCtx = els.hsi.getContext("2d");
 const pfdFaultPresenter = createDomFaultPresenter(els.pfd);
@@ -935,14 +930,7 @@ function dispatchAuthorityEnvelope(decoded, token) {
 // gracefully. Codec dispatch is
 // separate: "MJPG" paints via createImageBitmap; "H264" routes to WebCodecs.
 const FOURCC_MJPEG = "MJPG";
-const SOURCE_FPV = 0;
-const SOURCE_CHASE = 1;
-const SOURCE_GIMBAL = 2;
-const VIDEO_TARGETS = {
-  [SOURCE_FPV]: { canvas: els.canvas, ctx },
-  [SOURCE_CHASE]: { canvas: els.chaseCanvas, ctx: chaseCtx },
-  [SOURCE_GIMBAL]: { canvas: els.gimbalCanvas, ctx: gimbalCtx },
-};
+const VIDEO_TARGETS = bindVideoTargets(document);
 
 // Per-source H.264 decoders, each bound to the transport session that built it
 // (H264DecoderRegistry owns that lifetime — see video-h264.js). A source that
@@ -1010,13 +998,13 @@ async function paintByCodec(fourcc, payload, sourceId, target, token) {
 /** Resolves a frame's canvas target by source id, counting/logging a skip for
  *  an unknown source. Returns the target, or `null` to skip. */
 function videoTargetFor(sourceId) {
-  const target = VIDEO_TARGETS[sourceId];
-  if (!target) {
+  return resolveVideoTarget(VIDEO_TARGETS, sourceId, (unknownSourceId) => {
     state.skippedVideoFrames += 1;
-    log(`unknown video source_id ${sourceId}; skipping frame (${state.skippedVideoFrames} skipped total)`);
-    return null;
-  }
-  return target;
+    log(
+      `unknown video source_id ${unknownSourceId}; skipping frame ` +
+        `(${state.skippedVideoFrames} skipped total)`,
+    );
+  });
 }
 
 // v1 video body `[source_id][fourcc][u32 LE len][payload]` (ADR-0016), retained

--- a/clients/web/video-routing.js
+++ b/clients/web/video-routing.js
@@ -1,0 +1,37 @@
+// Video-source identity belongs in one binding table: a source must never be
+// silently redirected to another camera when the viewer grows a new feed.
+
+export const VIDEO_SOURCE_ID = Object.freeze({
+  FPV: 0,
+  CHASE: 1,
+  GIMBAL: 2,
+});
+
+const SOURCE_CANVASES = Object.freeze([
+  [VIDEO_SOURCE_ID.FPV, "video"],
+  [VIDEO_SOURCE_ID.CHASE, "chaseVideo"],
+  [VIDEO_SOURCE_ID.GIMBAL, "gimbalVideo"],
+]);
+
+/** Binds every assigned source id to its own live canvas and 2D context. */
+export function bindVideoTargets(documentRoot) {
+  const targets = Object.create(null);
+  for (const [sourceId, elementId] of SOURCE_CANVASES) {
+    const canvas = documentRoot.getElementById(elementId);
+    const context = canvas?.getContext("2d") ?? null;
+    if (!canvas || !context) {
+      throw new Error(`video source ${sourceId} canvas #${elementId} is unavailable`);
+    }
+    canvas.dataset.videoSourceId = String(sourceId);
+    targets[sourceId] = Object.freeze({ canvas, ctx: context });
+  }
+  return Object.freeze(targets);
+}
+
+/** Resolves an assigned source, reporting only genuinely unknown identities. */
+export function resolveVideoTarget(targets, sourceId, onUnknown) {
+  const target = targets[sourceId];
+  if (target) return target;
+  onUnknown(sourceId);
+  return null;
+}

--- a/clients/web/video-routing.test.mjs
+++ b/clients/web/video-routing.test.mjs
@@ -1,0 +1,75 @@
+// Browser video-source routing contract. Source identity is shared by the
+// legacy v1 frame byte and v2 decoded metadata; both must select the payload
+// canvas without taking the unknown-source diagnostic path.
+
+import {
+  VIDEO_SOURCE_ID,
+  bindVideoTargets,
+  resolveVideoTarget,
+} from "./video-routing.js";
+
+let failures = 0;
+function check(name, condition) {
+  if (condition) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+function canvas(id) {
+  const context = { id: `${id}-context` };
+  return {
+    id,
+    dataset: {},
+    getContext: (kind) => (kind === "2d" ? context : null),
+  };
+}
+
+const canvases = new Map([
+  ["video", canvas("video")],
+  ["chaseVideo", canvas("chaseVideo")],
+  ["gimbalVideo", canvas("gimbalVideo")],
+]);
+const documentRoot = { getElementById: (id) => canvases.get(id) ?? null };
+const targets = bindVideoTargets(documentRoot);
+
+check("FPV source 0 binds the onboard canvas", targets[VIDEO_SOURCE_ID.FPV].canvas.id === "video");
+check(
+  "chase source 1 binds a distinct canvas",
+  targets[VIDEO_SOURCE_ID.CHASE].canvas.id === "chaseVideo",
+);
+check(
+  "payload source 2 binds the gimbal canvas",
+  targets[VIDEO_SOURCE_ID.GIMBAL].canvas.id === "gimbalVideo",
+);
+check(
+  "runtime registration marks the payload canvas as source 2",
+  canvases.get("gimbalVideo").dataset.videoSourceId === "2",
+);
+
+const unknown = [];
+const v1Body = Uint8Array.of(VIDEO_SOURCE_ID.GIMBAL);
+const v2Meta = { sourceId: VIDEO_SOURCE_ID.GIMBAL };
+check(
+  "a v1 source-2 byte resolves to the payload canvas",
+  resolveVideoTarget(targets, v1Body[0], (sourceId) => unknown.push(sourceId)).canvas.id ===
+    "gimbalVideo",
+);
+check(
+  "v2 source-2 metadata resolves to the payload canvas",
+  resolveVideoTarget(targets, v2Meta.sourceId, (sourceId) => unknown.push(sourceId)).canvas.id ===
+    "gimbalVideo",
+);
+check("source 2 never takes the unknown-source path", unknown.length === 0);
+check(
+  "an unassigned source still takes the unknown-source path",
+  resolveVideoTarget(targets, 3, (sourceId) => unknown.push(sourceId)) === null && unknown[0] === 3,
+);
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall video routing checks passed");

--- a/clients/web/viewer-boot.browser.test.mjs
+++ b/clients/web/viewer-boot.browser.test.mjs
@@ -91,6 +91,8 @@ try {
 let framePositioned = false;
 let presenterIsFrameChild = false;
 let logInFlow = false;
+let gimbalRouteRegistered = false;
+let gimbalOptionPresent = false;
 try {
   const frame = document.getElementById("pfd")?.parentElement;
   const presenter = frame?.querySelector('div[role="alert"]');
@@ -98,6 +100,12 @@ try {
   presenterIsFrameChild = Boolean(presenter && presenter.parentElement === frame);
   const dock = document.querySelector(".log-dock");
   logInFlow = dock ? getComputedStyle(dock).position === "static" : false;
+  const gimbalCanvas = document.getElementById("gimbalVideo");
+  gimbalRouteRegistered =
+    Boolean(gimbalCanvas?.getContext("2d")) && gimbalCanvas?.dataset.videoSourceId === "2";
+  gimbalOptionPresent = Boolean(
+    document.querySelector('#mainView option[value="stage-gimbal"]'),
+  );
 } catch {}
 await fetch("/boot-result", {
   method: "POST",
@@ -111,6 +119,8 @@ await fetch("/boot-result", {
     framePositioned,
     presenterIsFrameChild,
     logInFlow,
+    gimbalRouteRegistered,
+    gimbalOptionPresent,
   }),
 });
 </script>`;
@@ -256,6 +266,10 @@ async function bootScenario({ label, serveWasm }) {
   check(
     "layout: the session log stays in normal flow (never overlays instrument pixels)",
     observed.logInFlow === true,
+  );
+  check(
+    "video: the payload option and registered source-2 canvas exist together",
+    observed.gimbalOptionPresent === true && observed.gimbalRouteRegistered === true,
   );
 }
 


### PR DESCRIPTION
Fixes #176

## Summary
- centralize FPV, chase, and gimbal source-to-canvas bindings in a runtime module
- route both v1 source bytes and v2 decoded source ids through the same source-2-aware resolver
- expose the live source registration to the real-browser boot probe
- keep unknown sources fail-visible without aliasing them onto another camera
- document source 2 on the Gazebo frame boundary

## Regression guards
- add a focused video-routing suite covering distinct sources 0/1/2, v1 and v2 source-2 lookup, and unknown source 3
- run that suite in CI
- require the real Chromium viewer boot to observe the payload selector and a live gimbal canvas registered as source 2

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps
- cargo build --release
- repository structure, instrument-requirement, certification-claim, standards-registry, trace, no_std, timing, and USB CDC target gates
- all 30 non-browser web suites and all 3 real Chromium suites
- buf lint and buf breaking against origin/main