### PR TITLE
Report gated arm/disarm presses instead of silently consuming them

### DIFF
--- a/clients/web-control/golden-vectors.json
+++ b/clients/web-control/golden-vectors.json
@@ -660,6 +660,170 @@
           }
         }
       ]
+    },
+    {
+      "name": "a gated arm or disarm press reports suppression, never silence",
+      "steps": [
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": []
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "motionGated": true
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": [
+              9
+            ]
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "arm": false,
+            "armSuppressed": true,
+            "motionGated": true
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": [
+              9
+            ]
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "arm": false,
+            "armSuppressed": false
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": []
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "armSuppressed": false
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": [
+              9
+            ]
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": true
+          },
+          "expect": {
+            "arm": true,
+            "armSuppressed": false,
+            "motionLive": true
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": []
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": true
+          },
+          "expect": {}
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": [
+              8
+            ]
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "disarm": false,
+            "disarmSuppressed": true,
+            "motionGated": true
+          }
+        },
+        {
+          "pad": {
+            "axes": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pressed": [
+              8
+            ]
+          },
+          "session": {
+            "mode": "quad-pilot",
+            "motionGranted": false
+          },
+          "expect": {
+            "disarmSuppressed": false
+          }
+        }
+      ]
     }
   ]
 }

--- a/clients/web-control/src/golden.rs
+++ b/clients/web-control/src/golden.rs
@@ -103,6 +103,8 @@ struct Expect {
     capture: Option<bool>,
     arm: Option<bool>,
     disarm: Option<bool>,
+    arm_suppressed: Option<bool>,
+    disarm_suppressed: Option<bool>,
     select: Option<String>,
     label: Option<String>,
     motion_lease: Option<String>,
@@ -229,6 +231,12 @@ fn check_plan(expect: &Expect, plan: &ControlPlan, ctx: &str) {
     }
     if let Some(want) = expect.disarm {
         assert_eq!(plan.disarm, want, "{ctx}: disarm edge");
+    }
+    if let Some(want) = expect.arm_suppressed {
+        assert_eq!(plan.arm_suppressed, want, "{ctx}: arm suppressed");
+    }
+    if let Some(want) = expect.disarm_suppressed {
+        assert_eq!(plan.disarm_suppressed, want, "{ctx}: disarm suppressed");
     }
     if let Some(want) = &expect.motion_lease {
         let got = match plan.motion_lease {

--- a/clients/web-control/src/plan.rs
+++ b/clients/web-control/src/plan.rs
@@ -116,6 +116,14 @@ pub struct ControlPlan {
     pub arm: bool,
     /// A typed disarm edge fired this tick.
     pub disarm: bool,
+    /// An arm edge fired while motion output was gated (no live authority).
+    /// The press is consumed — its baseline advances — never deferred, so the
+    /// shell MUST surface it: a swallowed safety press that stays silent is
+    /// indistinguishable from a dead control.
+    pub arm_suppressed: bool,
+    /// A disarm edge fired while motion output was gated; same surfacing
+    /// obligation as [`Self::arm_suppressed`].
+    pub disarm_suppressed: bool,
     /// The gimbal quasimode is capturing the right stick right now (the
     /// modifier is held while the gimbal lease is active), so the HUD can show
     /// capture even at a centered stick — #167's LT-descend suppression stays

--- a/clients/web-control/src/runtime.rs
+++ b/clients/web-control/src/runtime.rs
@@ -256,6 +256,11 @@ impl ControlRuntime {
             label: None,
             arm: false,
             disarm: false,
+            // The handover computes no edges (baselines re-seed at install so a
+            // held control cannot fire on resume), so there is nothing to
+            // suppress-report either.
+            arm_suppressed: false,
+            disarm_suppressed: false,
             capture_active: false,
         }
     }
@@ -328,6 +333,11 @@ impl ControlRuntime {
             label: Some(outcome.label),
             arm: live && outcome.arm,
             disarm: live && outcome.disarm,
+            // A press while gated is consumed (the edge baseline advanced), so
+            // report it: the shell owes the operator an explanation for a
+            // safety press that fired nothing.
+            arm_suppressed: !live && outcome.arm,
+            disarm_suppressed: !live && outcome.disarm,
             capture_active: captured,
         }
     }

--- a/clients/web-control/src/runtime/tests/motion.rs
+++ b/clients/web-control/src/runtime/tests/motion.rs
@@ -191,3 +191,45 @@ fn a_dropped_motion_reacquire_request_is_retried() {
         "a dropped reacquire request is retried"
     );
 }
+
+#[test]
+fn a_gated_arm_press_is_reported_suppressed_not_silent() {
+    let mut runtime = with_default();
+    // Prime the generation's edge baselines with nothing held, ungranted.
+    runtime.evaluate(&neutral(), &session_motion(Mode::QuadPilot, false, false));
+    // A fresh arm press while gated: no arm action, but a suppression report —
+    // a swallowed safety press must never be indistinguishable from a dead key.
+    let press = runtime.evaluate(
+        &sample(&[0.0, 0.0, 0.0, 0.0], &[9]),
+        &session_motion(Mode::QuadPilot, false, false),
+    );
+    assert!(press.motion.is_none(), "motion stays gated");
+    assert!(!press.arm, "no arm action rides absent authority");
+    assert!(press.arm_suppressed, "the swallowed press is reported");
+    // Held: the baseline advanced, so neither an action nor a report re-fires.
+    let held = runtime.evaluate(
+        &sample(&[0.0, 0.0, 0.0, 0.0], &[9]),
+        &session_motion(Mode::QuadPilot, false, false),
+    );
+    assert!(
+        !held.arm && !held.arm_suppressed,
+        "a held press reports once"
+    );
+    // Release, regrant, press again: the arm fires live with no report.
+    runtime.evaluate(&neutral(), &session_motion(Mode::QuadPilot, false, true));
+    let live = runtime.evaluate(
+        &sample(&[0.0, 0.0, 0.0, 0.0], &[9]),
+        &session_motion(Mode::QuadPilot, false, true),
+    );
+    assert!(
+        live.arm && !live.arm_suppressed,
+        "a granted press arms live"
+    );
+    // Disarm mirrors the same contract.
+    runtime.evaluate(&neutral(), &session_motion(Mode::QuadPilot, false, false));
+    let disarm = runtime.evaluate(
+        &sample(&[0.0, 0.0, 0.0, 0.0], &[8]),
+        &session_motion(Mode::QuadPilot, false, false),
+    );
+    assert!(!disarm.disarm && disarm.disarm_suppressed);
+}

--- a/clients/web-control/src/wasm.rs
+++ b/clients/web-control/src/wasm.rs
@@ -49,6 +49,8 @@ const FLAG_RECENTER: u32 = 1 << 2;
 const FLAG_ARM: u32 = 1 << 3;
 const FLAG_DISARM: u32 = 1 << 4;
 const FLAG_CAPTURE: u32 = 1 << 5;
+const FLAG_ARM_SUPPRESSED: u32 = 1 << 6;
+const FLAG_DISARM_SUPPRESSED: u32 = 1 << 7;
 const LEASE_SHIFT: u32 = 8; // bits 8..9: gimbal lease 0 none, 1 request, 2 release.
 const MOTION_LEASE_SHIFT: u32 = 10; // bits 10..11: motion lease, same encoding.
 
@@ -304,6 +306,12 @@ impl WebControl {
         }
         if plan.disarm {
             flags |= FLAG_DISARM;
+        }
+        if plan.arm_suppressed {
+            flags |= FLAG_ARM_SUPPRESSED;
+        }
+        if plan.disarm_suppressed {
+            flags |= FLAG_DISARM_SUPPRESSED;
         }
         if plan.capture_active {
             flags |= FLAG_CAPTURE;

--- a/clients/web/control-runtime.test.mjs
+++ b/clients/web/control-runtime.test.mjs
@@ -93,6 +93,16 @@ function checkPlan(expect, plan, ctx) {
   if (expect.disarm !== undefined) {
     check(`${ctx}: disarm edge`, plan.disarm === expect.disarm, plan.disarm);
   }
+  if (expect.armSuppressed !== undefined) {
+    check(`${ctx}: arm suppressed`, plan.armSuppressed === expect.armSuppressed, plan.armSuppressed);
+  }
+  if (expect.disarmSuppressed !== undefined) {
+    check(
+      `${ctx}: disarm suppressed`,
+      plan.disarmSuppressed === expect.disarmSuppressed,
+      plan.disarmSuppressed,
+    );
+  }
   if (expect.motionLease !== undefined) {
     const got = plan.motionLease ?? "none";
     check(`${ctx}: motion lease action`, got === expect.motionLease, got);

--- a/clients/web/control-shell.js
+++ b/clients/web/control-shell.js
@@ -24,6 +24,8 @@ const FLAG_RECENTER = 1 << 2;
 const FLAG_ARM = 1 << 3;
 const FLAG_DISARM = 1 << 4;
 const FLAG_CAPTURE = 1 << 5;
+const FLAG_ARM_SUPPRESSED = 1 << 6;
+const FLAG_DISARM_SUPPRESSED = 1 << 7;
 const LEASE_SHIFT = 8; // bits 8..9: gimbal lease 0 none, 1 request, 2 release.
 const MOTION_LEASE_SHIFT = 10; // bits 10..11: motion lease, same encoding.
 
@@ -262,6 +264,10 @@ export class ControlShell {
       gimbal,
       arm: (flags & FLAG_ARM) !== 0,
       disarm: (flags & FLAG_DISARM) !== 0,
+      // A press the runtime consumed while motion output was gated: the
+      // caller owes the operator a visible explanation (never a silent drop).
+      armSuppressed: (flags & FLAG_ARM_SUPPRESSED) !== 0,
+      disarmSuppressed: (flags & FLAG_DISARM_SUPPRESSED) !== 0,
       captureActive: (flags & FLAG_CAPTURE) !== 0,
       lease: leaseName(leaseCode),
       motionLease: leaseName(motionLeaseCode),

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -374,12 +374,17 @@ async function connect({ manual } = { manual: true }) {
       });
     },
     telemetryOnly: (_session, wasManual) => {
+      // The overlay carries this state too: buried in the collapsed log,
+      // a lease-less session is indistinguishable from a healthy wait for
+      // telemetry, and every arm press would then vanish behind it (#180).
       if (wasManual) {
         // A telemetry-only vehicle (e.g. the Aviate adapter, ADR-0018)
         // advertises no controllable scopes; sending control frames
         // anyway would only generate a 30 Hz stream of rejections.
+        els.overlay.textContent = "no control lease — telemetry/video only; press Connect to take control";
         log("no control lease granted; viewer is telemetry/video only");
       } else {
+        els.overlay.textContent = "reconnected without control; press Connect to resume";
         log("reconnected (telemetry/video); press Connect to resume control");
       }
     },
@@ -1355,6 +1360,7 @@ async function runControlLoop(writer, token) {
         ? state.controlShell.tickFromPad(pad, sessionState)
         : state.controlShell.tickFromKeys(sessionState);
       updateControlReadout(pad, mode, plan);
+      reportSuppressedPresses(plan);
       reportExpiredActions();
       if (state.pendingReset) {
         state.pendingReset = false;
@@ -1722,9 +1728,42 @@ function updateControlReadout(pad, mode, plan) {
     return;
   }
   const m = plan.motion ?? { roll: 0, pitch: 0, throttle: 0, yaw: 0 };
+  // Three honest states: "gated" (no frames — presses are suppressed),
+  // "recovering" (neutral recovery frames flow but live authority has not
+  // been confirmed, so presses are still suppressed), "streaming" (live).
+  // The distinction keeps the pre-press indicator from overstating
+  // authority during the post-revocation neutral-activation burst.
+  const motionState = !plan.motion
+    ? "gated"
+    : state.motionRecovered
+      ? "streaming"
+      : "recovering";
   els.gamepad.textContent =
     `flight [${mode}]: ${src} | roll=${m.roll.toFixed(2)} pitch=${m.pitch.toFixed(2)} ` +
-    `climb=${m.throttle.toFixed(2)} yaw=${m.yaw.toFixed(2)} | arm: Options/Enter disarm: Create/Backspace`;
+    `climb=${m.throttle.toFixed(2)} yaw=${m.yaw.toFixed(2)} | motion: ${motionState} | ` +
+    "arm: Options/Enter disarm: Create/Backspace";
+}
+
+/** The reason a gated tick refuses arm/disarm presses, for the operator. */
+function motionGateReason() {
+  if (state.motionDenied) return "motion lease denied; reconnect to retry";
+  if (!state.leaseGranted) return "no motion lease; press Connect to take control";
+  return "motion authority recovering";
+}
+
+/** Surfaces every runtime-suppressed arm/disarm press (CTRL-01 feedback,
+ *  #180): the press was consumed while motion output was gated, and a
+ *  swallowed safety press must never look like a dead key. */
+function reportSuppressedPresses(plan) {
+  for (const [suppressed, press] of [
+    [plan.armSuppressed, "arm"],
+    [plan.disarmSuppressed, "disarm"],
+  ]) {
+    if (!suppressed) continue;
+    const reason = motionGateReason();
+    els.overlay.textContent = `${press} press suppressed — ${reason}`;
+    log(`${press} press suppressed: ${reason}`);
+  }
 }
 
 // ---- instrument panels (ADR-0017) -------------------------------------------


### PR DESCRIPTION
Fixes #180. An arm/disarm edge that fired while motion output was gated was consumed with zero feedback — indistinguishable from a dead key.

- Runtime: `ControlPlan.arm_suppressed` / `disarm_suppressed` report a consumed-but-gated edge; wasm flags bits 6/7; shell decodes them.
- Viewer: each suppressed press logs its gate reason and flashes the overlay; the persistent readout now shows `motion: streaming|gated`; a lease-less session states itself on the overlay, not only the collapsed log.
- The gate itself is unchanged: no action ever rides absent authority.

Guards: new shared golden-vector group executed by BOTH interpreters (native golden.rs and wasm control-runtime.test.mjs), a runtime unit test covering suppress-once → held-no-refire → regrant-arms-live, and both vector interpreters extended to assert the new fields.

Verified: cargo test -p pilotage-control-web (52 pass), fmt/clippy/doc clean, wasm rebuilt, control-runtime.test.mjs / control-runtime.browser.test.mjs / control-structure / control-edges / viewer-boot.browser.test.mjs all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #184
- <kbd>&nbsp;1&nbsp;</kbd> #183 👈 
<!-- GitButler Footer Boundary Bottom -->