### PR TITLE
Autolaunch lifecycle: truthful readiness, session discovery, visibility-deferred autoconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
       - name: viewer connection auto-recovery lifecycle (backoff/jitter, classification, control-suspended)
         run: node clients/web/reconnect.test.mjs
 
+      - name: viewer session discovery (manifest validation, stale-tab convergence, visibility-deferred autoconnect)
+        run: node clients/web/session-discovery.test.mjs
+
       - name: viewer control arm-edge detection (rising edges, hold-across-reconnect safety)
         run: node clients/web/control-edges.test.mjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ adapters/**/bridge/build/
 * 2.*
 *.bak
 *.orig
+clients/web/session.json

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -72,6 +72,11 @@ import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.j
 import { bindVideoTargets, resolveVideoTarget } from "./video-routing.js";
 import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 import { createReconnectController } from "./reconnect.js";
+import {
+  applySessionConfig,
+  validSessionConfig,
+  whenVisible,
+} from "./session-discovery.js";
 import { startDatagramControl } from "./datagram-control.js";
 import { loadControlShell } from "./control-shell.js";
 import { advanceMotionLease, applyMotionRecovery } from "./motion-lease.js";
@@ -313,6 +318,30 @@ function applyUrlParams() {
   if (params.has("cert")) els.certHash.value = params.get("cert");
 }
 
+/** Re-reads the launcher-served session manifest and updates the connect
+ *  inputs, so a stale tab (its URL pins an older session's certificate)
+ *  converges on the CURRENT session at its next attempt instead of
+ *  retrying a dead hash forever. A missing manifest (viewer served
+ *  without the launcher) is silent — there is nothing to converge to. */
+async function refreshSessionConfig() {
+  let fetched;
+  try {
+    const response = await fetch("./session.json", { cache: "no-cache" });
+    if (!response.ok) return;
+    fetched = await response.json();
+  } catch {
+    return;
+  }
+  const config = validSessionConfig(fetched);
+  if (!config) return;
+  if (applySessionConfig(els, config)) {
+    log(
+      `session discovery: connect target updated to ${config.host}:${config.port} ` +
+        `(cert ${config.certHash.slice(0, 16)}...)`,
+    );
+  }
+}
+
 /** Decodes a lowercase-hex cert hash string into a Uint8Array digest. */
 function hexToBytes(hex) {
   const clean = hex.trim().toLowerCase();
@@ -392,6 +421,13 @@ async function connect({ manual } = { manual: true }) {
       }
     },
   });
+  // A failed attempt may mean this tab belongs to an older session (its
+  // pinned certificate no longer matches the host on this port): re-read
+  // the launcher manifest so the NEXT attempt targets the live session.
+  // Config errors are excluded — they need the user, not a retry target.
+  if (!session.result.ok && session.result.failure?.phase !== "construct") {
+    void refreshSessionConfig();
+  }
   return session.result;
 }
 
@@ -550,6 +586,11 @@ function handleTransportClosed(token, error) {
   retireSessionPresentation(error === null ? "disconnected" : "failed");
   log(error === null ? "WebTransport session closed" : `WebTransport session errored: ${error}`);
   transportSessions.retire(token);
+  // Every transport death funnels through here — including a handshake
+  // failure, whose `closed` rejection retires the token BEFORE connect()'s
+  // own catch can see a live session. Re-read the launcher manifest so the
+  // scheduled retry targets the CURRENT session, not a dead certificate.
+  void refreshSessionConfig();
   // The drop was not user-initiated (there is no disconnect control); recover
   // the transport if the user still wants a session. A clean or errored close
   // is treated as a transient transport drop — retried with capped, jittered
@@ -1925,7 +1966,7 @@ async function startControl() {
 
 window.addEventListener("pagehide", () => instruments.mod?.dispose(), { once: true });
 applyUrlParams();
-startInstruments();
+const instrumentsStarted = startInstruments();
 startControl();
 document.getElementById("fpvBtn").addEventListener("click", () => {
   state.pendingFpvToggle = true;
@@ -1939,10 +1980,17 @@ els.connectBtn.addEventListener("click", () => {
   reconnect.requestConnect();
 });
 // A launcher-pinned URL (host + port + cert all present, autoconnect=1)
-// connects on load through the SAME explicit path as the button — the URL
-// already states everything the click would add. Anything less than a
-// fully pinned URL still requires the click. Runs after all wiring so the
-// full connect stack (control gate, reconnect controller) is in place.
+// connects through the SAME explicit path as the button — the URL already
+// states everything the click would add. Anything less than a fully
+// pinned URL still requires the click. Runs after all wiring so the full
+// connect stack (control gate, reconnect controller) is in place.
+//
+// Deferred to VISIBILITY: a launcher-opened tab can load hidden behind
+// other windows, where throttled timers starve the 30 Hz control loop
+// into watchdog revoke/regrant churn and an unfocused lease probe would
+// silently skip motion authority. The instrument wasm is awaited first
+// so the panels are ready when the first telemetry arrives (a failed
+// wasm load still connects — telemetry and video degrade visibly).
 {
   const params = new URLSearchParams(window.location.search);
   if (
@@ -1951,7 +1999,9 @@ els.connectBtn.addEventListener("click", () => {
     els.port.value &&
     els.certHash.value
   ) {
-    reconnect.requestConnect();
+    whenVisible(document, () => {
+      instrumentsStarted.finally(() => reconnect.requestConnect());
+    });
   }
 }
 

--- a/clients/web/session-discovery.js
+++ b/clients/web/session-discovery.js
@@ -1,0 +1,56 @@
+// Session discovery for launcher-driven viewers (#182).
+//
+// Every launcher run mints a fresh certificate and pins it in the opened
+// URL, so a tab left over from an earlier session retries forever against
+// a host whose certificate no longer matches — and a refresh of that tab
+// cannot converge, because its URL still carries the dead hash. The
+// launcher therefore serves the CURRENT session's connect parameters next
+// to the page (`session.json`), and the viewer re-reads them after a
+// failed connect so any tab converges on the live session.
+//
+// Pure DOM-free helpers, unit tested off the page; main.js wires them to
+// the real inputs, fetch, and document.
+
+/** Validates a fetched session manifest. Returns the normalized
+ *  `{ host, port, certHash }` (port as the input-box string), or null
+ *  unless every field is present and usable — a partial manifest must
+ *  never half-update the connect inputs. */
+export function validSessionConfig(config) {
+  if (!config || typeof config !== "object") return null;
+  const { host, port, certHash } = config;
+  if (typeof host !== "string" || host.trim().length === 0) return null;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  if (typeof certHash !== "string" || !/^[0-9a-fA-F]{64}$/.test(certHash)) return null;
+  return { host: host.trim(), port: String(port), certHash };
+}
+
+/** Applies a validated config to the connect inputs, reporting whether
+ *  anything actually changed (the caller logs only real updates). */
+export function applySessionConfig(els, config) {
+  const changed =
+    els.host.value !== config.host ||
+    els.port.value !== config.port ||
+    els.certHash.value !== config.certHash;
+  els.host.value = config.host;
+  els.port.value = config.port;
+  els.certHash.value = config.certHash;
+  return changed;
+}
+
+/** Runs `begin` once `doc` is visible — immediately when it already is,
+ *  otherwise on the first visibilitychange that lands visible. A hidden
+ *  launcher-opened tab must not autoconnect: its throttled timers starve
+ *  the 30 Hz control loop into watchdog churn, and an unfocused connect
+ *  silently skips motion authority. */
+export function whenVisible(doc, begin) {
+  if (doc.visibilityState === "visible") {
+    begin();
+    return;
+  }
+  const onChange = () => {
+    if (doc.visibilityState !== "visible") return;
+    doc.removeEventListener("visibilitychange", onChange);
+    begin();
+  };
+  doc.addEventListener("visibilitychange", onChange);
+}

--- a/clients/web/session-discovery.test.mjs
+++ b/clients/web/session-discovery.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+
+import {
+  applySessionConfig,
+  validSessionConfig,
+  whenVisible,
+} from "./session-discovery.js";
+
+const CERT = "ab".repeat(32);
+
+function testManifestValidationFailsClosed() {
+  assert.deepEqual(validSessionConfig({ host: "127.0.0.1", port: 4433, certHash: CERT }), {
+    host: "127.0.0.1",
+    port: "4433",
+    certHash: CERT,
+  });
+  // Every rejection is total: a partial manifest never half-applies.
+  assert.equal(validSessionConfig(null), null);
+  assert.equal(validSessionConfig({ port: 4433, certHash: CERT }), null);
+  assert.equal(validSessionConfig({ host: " ", port: 4433, certHash: CERT }), null);
+  assert.equal(validSessionConfig({ host: "127.0.0.1", port: 0, certHash: CERT }), null);
+  assert.equal(validSessionConfig({ host: "127.0.0.1", port: 70000, certHash: CERT }), null);
+  assert.equal(validSessionConfig({ host: "127.0.0.1", port: "4433", certHash: CERT }), null);
+  assert.equal(validSessionConfig({ host: "127.0.0.1", port: 4433, certHash: "nothex" }), null);
+  assert.equal(
+    validSessionConfig({ host: "127.0.0.1", port: 4433, certHash: CERT.slice(2) }),
+    null,
+  );
+}
+testManifestValidationFailsClosed();
+console.log("ok - testManifestValidationFailsClosed");
+
+function testApplyReportsOnlyRealChanges() {
+  const els = {
+    host: { value: "127.0.0.1" },
+    port: { value: "4433" },
+    certHash: { value: CERT },
+  };
+  const same = { host: "127.0.0.1", port: "4433", certHash: CERT };
+  assert.equal(applySessionConfig(els, same), false, "identical config is not a change");
+  const fresh = { host: "127.0.0.1", port: "4433", certHash: "cd".repeat(32) };
+  assert.equal(applySessionConfig(els, fresh), true, "a new cert is a change");
+  assert.equal(els.certHash.value, "cd".repeat(32));
+}
+testApplyReportsOnlyRealChanges();
+console.log("ok - testApplyReportsOnlyRealChanges");
+
+function testAutoconnectWaitsForVisibility() {
+  // Already visible: begin runs synchronously.
+  let began = 0;
+  whenVisible({ visibilityState: "visible" }, () => {
+    began += 1;
+  });
+  assert.equal(began, 1);
+
+  // Hidden: begin waits for the first visible transition, then detaches.
+  const listeners = [];
+  const doc = {
+    visibilityState: "hidden",
+    addEventListener: (kind, fn) => listeners.push([kind, fn]),
+    removeEventListener: (kind, fn) => {
+      const at = listeners.findIndex(([k, f]) => k === kind && f === fn);
+      if (at >= 0) listeners.splice(at, 1);
+    },
+  };
+  whenVisible(doc, () => {
+    began += 1;
+  });
+  assert.equal(began, 1, "no connect while hidden");
+  assert.equal(listeners.length, 1);
+  // A change that lands still-hidden must not begin.
+  listeners[0][1]();
+  assert.equal(began, 1);
+  doc.visibilityState = "visible";
+  listeners[0][1]();
+  assert.equal(began, 2, "begins on the first visible transition");
+  assert.equal(listeners.length, 0, "the listener detaches after beginning");
+}
+testAutoconnectWaitsForVisibility();
+console.log("ok - testAutoconnectWaitsForVisibility");

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -103,8 +103,8 @@ fn build_engine<A: VehicleAdapter>(adapter: &A, options: RuntimeOptions) -> Sess
 }
 
 /// Starts the session host bound to `127.0.0.1:port` (`0` for an OS-assigned
-/// ephemeral port), prints the `LISTENING` line, and returns a handle for
-/// shutdown.
+/// ephemeral port), prints the `LISTENING` line once the runtime is accepting
+/// connections, and returns a handle for shutdown.
 ///
 /// `adapter` selects the embedded vehicle adapter: [`AdapterKind::Reference`]
 /// (default, 1a behavior, no video) or [`AdapterKind::Gazebo`] (real Gazebo
@@ -141,12 +141,6 @@ pub async fn start_with_options(
     let endpoint = Endpoint::server(config).map_err(HostError::Endpoint)?;
     let local_addr = endpoint.local_addr().map_err(HostError::LocalAddr)?;
 
-    print_line(&format!(
-        "LISTENING {} {}",
-        local_addr.port(),
-        cert_hash_hex
-    ));
-
     let (engine_tx, engine_rx) = mpsc::channel::<ToEngine>(ENGINE_QUEUE_CAPACITY);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -159,6 +153,16 @@ pub async fn start_with_options(
         shutdown_rx,
     )
     .await?;
+
+    // The LISTENING line is the startup contract launchers gate on (the
+    // browser opens against it), so it must not print until the adapter is
+    // built and the accept loop is spawned: a bound-but-not-accepting
+    // window would hand an autoconnecting page a dead session.
+    print_line(&format!(
+        "LISTENING {} {}",
+        local_addr.port(),
+        cert_hash_hex
+    ));
 
     Ok(RunningHost {
         local_addr,

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -180,6 +180,14 @@ pub fn viewer_url(viewer_port: u16, host_port: u16, cert: &str) -> String {
     )
 }
 
+/// The session manifest the static viewer serves at `/session.json`: the
+/// CURRENT session's connect parameters. A viewer tab whose URL pins an
+/// older session's certificate re-reads this after a failed connect and
+/// converges on the live session instead of retrying a dead hash forever.
+pub fn session_manifest(host_port: u16, cert: &str) -> String {
+    format!("{{\"host\":\"127.0.0.1\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n")
+}
+
 /// The log file a stage writes under `log_dir`.
 pub fn stage_log(log_dir: &std::path::Path, name: &str) -> PathBuf {
     log_dir.join(format!("{name}.log"))
@@ -221,6 +229,17 @@ mod tests {
             format!(
                 "http://127.0.0.1:8080/index.html?host=127.0.0.1&port=4433&cert={cert}&autoconnect=1"
             )
+        );
+    }
+
+    #[test]
+    fn session_manifest_carries_exactly_the_listening_values() {
+        let cert = "0f".repeat(32);
+        // The viewer's validator requires this exact shape (host string,
+        // integer port, 64-hex certHash); a drift here strands stale tabs.
+        assert_eq!(
+            super::session_manifest(4433, &cert),
+            format!("{{\"host\":\"127.0.0.1\",\"port\":4433,\"certHash\":\"{cert}\"}}\n")
         );
     }
 }

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -12,7 +12,9 @@ use crate::cli::SimArgs;
 use crate::error::XtaskError;
 use crate::output::print_line;
 use crate::process::{ManagedChild, ProcessSpec};
-use crate::readiness::{Readiness, ReadySignal, await_ready, stage_log, viewer_url};
+use crate::readiness::{
+    Readiness, ReadySignal, await_ready, session_manifest, stage_log, viewer_url,
+};
 use preflight::{build_host, prepare_web_assets};
 
 pub(crate) mod preflight;
@@ -98,18 +100,43 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     let pid_file = log_dir.join("supervisor.pid");
     claim_supervisor(&pid_file, &mut children)?;
 
-    let url = viewer_url(args.viewer_port, actual_port, &certificate);
+    write_session_manifest(&ctx, actual_port, &certificate);
+    announce_ready(args, actual_port, &certificate);
+
+    let outcome = supervise(&mut children, &stages, &mut cancel).await;
+    std::fs::remove_file(&pid_file).ok();
+    // The manifest describes a session that no longer exists past this
+    // point; leaving it behind would let a later failed connect clobber
+    // hand-typed connect inputs with a dead target.
+    std::fs::remove_file(ctx.repo_root.join("clients/web/session.json")).ok();
+    teardown(&mut children);
+    outcome
+}
+
+/// Prints the ready URL and opens it in the default browser when asked.
+fn announce_ready(args: &SimArgs, actual_port: u16, certificate: &str) {
+    let url = viewer_url(args.viewer_port, actual_port, certificate);
     print_line("");
     print_line(&format!("session ready: {url}"));
     print_line("press ctrl-c to stop the session");
     if args.open {
         open_in_browser(&url);
     }
+}
 
-    let outcome = supervise(&mut children, &stages, &mut cancel).await;
-    std::fs::remove_file(&pid_file).ok();
-    teardown(&mut children);
-    outcome
+/// Writes the served session manifest (`clients/web/session.json`): any
+/// viewer tab — including one whose URL pins an older session's
+/// certificate — re-reads it after a failed connect and converges on
+/// THIS session. Best-effort: a failed write only loses stale-tab
+/// convergence, never the session.
+fn write_session_manifest(ctx: &SessionContext, port: u16, certificate: &str) {
+    let path = ctx.repo_root.join("clients/web/session.json");
+    if let Err(error) = std::fs::write(&path, session_manifest(port, certificate)) {
+        print_line(&format!(
+            "warning: could not write {}: {error}",
+            path.display()
+        ));
+    }
 }
 
 /// Registers the SIGINT handler and returns a receiver that flips to


### PR DESCRIPTION
Fixes #182. Three cooperating defects left the auto-opened tab dead until a refresh:

1. **Host readiness lied by a window**: `LISTENING` printed at endpoint-bind, before `spawn_host_runtime` built the adapter and spawned the accept loop — the launcher's browser-open gate could land an autoconnecting page on a bound-but-dead host. The line now prints only after the runtime is accepting.
2. **Stale tabs stormed forever**: every run mints a fresh cert pinned in the URL; old tabs retried the dead hash indefinitely (live-observed CERTIFICATE_VERIFY_FAILED every ~25 s in the host log). xtask now serves the CURRENT session's parameters as `clients/web/session.json` (gitignored), and the viewer re-reads it after any non-config connect failure — any stale tab converges on the live session at its next attempt.
3. **Hidden-tab connect degraded silently**: an occluded tab clamps 33 ms timers to ~1000 ms (measured), starving the 30 Hz loop into watchdog revoke/regrant churn, and an unfocused lease probe skips motion authority. Autoconnect now defers to `document.visibilityState === "visible"` and awaits the instrument wasm so first paint has panels.

Guards: `session-discovery.test.mjs` (fail-closed manifest validation, change detection, visibility deferral incl. hidden→hidden transitions and listener detach), an xtask test pinning the manifest shape to the viewer validator's exact contract, and a new CI step.

Verified: fmt/clippy -D warnings, xtask + session-host tests (104 pass), release build, session-discovery/reconnect JS suites, viewer-boot browser test (35 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)