### PR TITLE
PX4 arm/disarm enactment truth: consume COMMAND_ACK and surface FC refusals

### DIFF
--- a/adapters/aviate/src/adapter/sources.rs
+++ b/adapters/aviate/src/adapter/sources.rs
@@ -103,6 +103,10 @@ pub(super) fn fc_state_sample(
         .unwrap_or_default();
     Some(FcStateSample {
         arm_state: if report.armed { 2 } else { 1 },
+        // The Aviate uplink logs COMMAND_ACKs but does not yet pair them
+        // with the command they answer; the enactment lane stays empty
+        // rather than carrying an unpaired verdict.
+        last_command: None,
         stamp: MeasurementStamp {
             // Role is the discriminator; the id carries the configured
             // FC identity: (system id << 8) | component id.

--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -405,7 +405,12 @@ impl VehicleAdapter for Px4Adapter {
 
     fn sample_telemetry(&mut self) -> TelemetryBatch {
         self.observe_arm_report();
-        let fc_state = sampling::fc_state_sample(self.arm, self.arm_incarnation, self.started_at);
+        let fc_state = sampling::fc_state_sample(
+            self.arm,
+            self.uplink.as_ref().and_then(Px4Uplink::last_arm_ack),
+            self.arm_incarnation,
+            self.started_at,
+        );
         let gimbal_attitude = self
             .gimbal
             .is_some()

--- a/adapters/px4/src/adapter/sampling.rs
+++ b/adapters/px4/src/adapter/sampling.rs
@@ -274,6 +274,7 @@ impl super::Px4Adapter {
 /// telemetry, stamped under the FC-state source role.
 pub(super) fn fc_state_sample(
     report: Option<super::ArmReport>,
+    last_command: Option<pilotage_adapter_api::FcCommandAck>,
     incarnation: SourceIncarnation,
     started_at: std::time::Instant,
 ) -> Option<FcStateSample> {
@@ -284,6 +285,10 @@ pub(super) fn fc_state_sample(
         .unwrap_or_default();
     Some(FcStateSample {
         arm_state: if report.armed { 2 } else { 1 },
+        // The FC's verdict on the most recent commanded arm/disarm rides
+        // the same report provenance: enactment truth the operator needs
+        // when "command accepted" and "vehicle armed" disagree.
+        last_command,
         stamp: MeasurementStamp {
             role: SourceRole::FcState,
             // MAVLink frames are CRC-checked but unsigned: checksummed,

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -4,6 +4,8 @@
 //! the wire, sampling authorization from the standard status, and the
 //! same gate discipline the Aviate adapter carries.
 
+mod uplink_ack;
+
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/adapters/px4/src/adapter/tests/uplink_ack.rs
+++ b/adapters/px4/src/adapter/tests/uplink_ack.rs
@@ -1,0 +1,95 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! COMMAND_ACK enactment truth: PX4 acknowledges a COMMAND_LONG to the
+//! endpoint that sent it, so the arm/disarm verdict pairs on the command
+//! socket and must survive to [`Px4Uplink::last_arm_ack`].
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use pilotage_adapter_api::FcCommandAck;
+use pilotage_mavlink::codec::encode_command_ack;
+
+use super::{fake_fc, uplink_to};
+use crate::uplink::Px4Uplink;
+
+/// Drains FC replies (one `maintain` per pass) until `condition` holds or
+/// a deadline lapses — loopback UDP delivery has no event to await.
+fn drain_until(uplink: &mut Px4Uplink, condition: impl Fn(&Px4Uplink) -> bool) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        uplink.maintain();
+        if condition(uplink) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    false
+}
+
+/// Receives frames at the fake FC until the arm/disarm COMMAND_LONG
+/// arrives, returning the uplink socket's address to acknowledge to.
+fn recv_until_arm_command(fc: &UdpSocket) -> std::net::SocketAddr {
+    let mut buf = [0u8; 128];
+    loop {
+        let (len, from) = fc.recv_from(&mut buf).expect("datagram");
+        assert!(len > 10, "runt frame");
+        let msg_id = u32::from(buf[7]) | (u32::from(buf[8]) << 8) | (u32::from(buf[9]) << 16);
+        if msg_id == 76 && u16::from_le_bytes([buf[10 + 28], buf[10 + 29]]) == 400 {
+            return from;
+        }
+    }
+}
+
+#[test]
+fn an_fc_command_ack_pairs_with_the_latest_arm_or_disarm() {
+    let (fc, addr) = fake_fc();
+    let mut uplink = uplink_to(addr);
+    uplink.use_manual_clock();
+    uplink.begin_arm(0.0);
+    uplink.advance_clock(Duration::from_millis(400));
+    uplink.maintain();
+    let uplink_addr = recv_until_arm_command(&fc);
+    assert_eq!(
+        uplink.last_arm_ack(),
+        None,
+        "no verdict before the FC answers"
+    );
+
+    // The FC refuses the arm (MAV_RESULT 4, TEMPORARILY_REJECTED): the
+    // refusal must surface, not vanish into a fire-and-forget socket.
+    let refused = encode_command_ack(0, 400, 4, 1, 1);
+    fc.send_to(&refused, uplink_addr).expect("ack send");
+    assert!(
+        drain_until(&mut uplink, |u| u.last_arm_ack().is_some()),
+        "the refusal reaches the uplink"
+    );
+    assert_eq!(
+        uplink.last_arm_ack(),
+        Some(FcCommandAck {
+            arm: true,
+            result: 4
+        })
+    );
+
+    // A new disarm opens a fresh verdict slot; the FC accepts this one.
+    uplink.send_disarm();
+    assert_eq!(
+        uplink.last_arm_ack(),
+        None,
+        "a fresh command clears the stale verdict"
+    );
+    let accepted = encode_command_ack(1, 400, 0, 1, 1);
+    fc.send_to(&accepted, uplink_addr).expect("ack send");
+    assert!(
+        drain_until(&mut uplink, |u| u.last_arm_ack().is_some()),
+        "the acceptance reaches the uplink"
+    );
+    assert_eq!(
+        uplink.last_arm_ack(),
+        Some(FcCommandAck {
+            arm: false,
+            result: 0
+        })
+    );
+}

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -12,10 +12,13 @@
 use std::net::{SocketAddr, UdpSocket};
 use std::time::{Duration, Instant};
 
+use pilotage_adapter_api::FcCommandAck;
 use tracing::{info, warn};
 
 use pilotage_mavlink::codec::{
-    encode_arm_command, encode_command_long, encode_gcs_heartbeat, encode_velocity_setpoint,
+    FcMessage, FrameSource, GCS_COMPONENT_ID, GCS_SYSTEM_ID, MAV_CMD_COMPONENT_ARM_DISARM,
+    MAV_CMD_DO_SET_MODE, encode_arm_command, encode_command_long, encode_gcs_heartbeat,
+    encode_velocity_setpoint, parse_datagram,
 };
 
 /// Full-stick horizontal velocity demand. Demand scaling is operator
@@ -44,8 +47,6 @@ const OFFBOARD_WARMUP: Duration = Duration::from_millis(300);
 /// trip between control frames.
 const STREAM_KEEPALIVE: Duration = Duration::from_millis(50);
 
-/// MAV_CMD_DO_SET_MODE.
-const CMD_DO_SET_MODE: u16 = 176;
 /// MAV_MODE_FLAG_CUSTOM_MODE_ENABLED.
 const BASE_MODE_CUSTOM: f32 = 1.0;
 /// PX4 custom main mode OFFBOARD.
@@ -92,6 +93,11 @@ pub struct Px4Uplink {
     last_vel_ned: [f32; 3],
     arm_phase: ArmPhase,
     warmup_since: Option<Instant>,
+    // Which command the next MAV_CMD_COMPONENT_ARM_DISARM ack answers
+    // (COMMAND_ACK carries only the command id, and arm and disarm share
+    // one), and the FC's verdict once it arrives on this socket.
+    last_sent_arm: Option<bool>,
+    last_arm_ack: Option<FcCommandAck>,
     last_heartbeat: Option<Instant>,
     started: Instant,
     clock: UplinkClock,
@@ -120,6 +126,8 @@ impl Px4Uplink {
             last_vel_ned: [0.0; 3],
             arm_phase: ArmPhase::Idle,
             warmup_since: None,
+            last_sent_arm: None,
+            last_arm_ack: None,
             last_heartbeat: None,
             started: Instant::now(),
             clock: UplinkClock::System,
@@ -174,6 +182,7 @@ impl Px4Uplink {
     /// FC retargets a stream to the last peer that spoke on that link).
     /// Call at telemetry-sampling cadence.
     pub fn maintain(&mut self) {
+        self.drain_fc_replies();
         let now = self.clock.now();
         if self
             .last_heartbeat
@@ -215,7 +224,7 @@ impl Px4Uplink {
     fn command_offboard_and_arm(&mut self) {
         let mode = encode_command_long(
             self.seq,
-            CMD_DO_SET_MODE,
+            MAV_CMD_DO_SET_MODE,
             [
                 BASE_MODE_CUSTOM,
                 PX4_MAIN_MODE_OFFBOARD,
@@ -237,7 +246,85 @@ impl Px4Uplink {
         );
         self.send(&arm);
         self.arm_phase = ArmPhase::Commanded;
+        // A fresh command opens a fresh verdict: the ack lane reports the
+        // LATEST arm/disarm, never a stale answer to an earlier one.
+        self.last_sent_arm = Some(true);
+        self.last_arm_ack = None;
         info!("offboard arm sequence: OFFBOARD and arm commanded");
+    }
+
+    /// The FC's answer to the most recent arm/disarm command, once its
+    /// COMMAND_ACK has arrived on this socket. `None` while unanswered.
+    #[must_use]
+    pub fn last_arm_ack(&self) -> Option<FcCommandAck> {
+        self.last_arm_ack
+    }
+
+    /// Drains FC replies off the command socket. PX4 acknowledges a
+    /// COMMAND_LONG to the endpoint that sent it, so the arm/disarm
+    /// verdict arrives HERE, not on the telemetry link. Non-blocking.
+    fn drain_fc_replies(&mut self) {
+        let mut buf = [0u8; 512];
+        let mut messages: Vec<(FrameSource, FcMessage)> = Vec::new();
+        while let Ok((len, _)) = self.socket.recv_from(&mut buf) {
+            messages.clear();
+            parse_datagram(buf.get(..len).unwrap_or(&[]), &mut messages);
+            for (source, message) in &messages {
+                if source.system_id != self.expected_system_id
+                    || source.component_id != self.expected_component_id
+                {
+                    continue;
+                }
+                self.apply_fc_reply(message);
+            }
+        }
+    }
+
+    /// Applies one FC reply: a MAV_CMD_COMPONENT_ARM_DISARM ack pairs
+    /// with the most recent arm or disarm this uplink sent (the ack
+    /// carries only the command id); a refused OFFBOARD mode command is
+    /// logged so a wedged arm sequence is diagnosable.
+    ///
+    /// Known limit: COMMAND_ACK has no per-instance correlation, so an
+    /// ack still in flight when the NEXT arm/disarm goes out is
+    /// attributed to that newer command, and with UDP reordering a stale
+    /// ack could mask a fresher verdict. Closing this needs a protocol
+    /// with correlated acks; the heartbeat-derived arm state remains the
+    /// ground truth either way.
+    fn apply_fc_reply(&mut self, message: &FcMessage) {
+        let FcMessage::CommandAck {
+            command,
+            result,
+            target_system,
+            target_component,
+        } = *message
+        else {
+            return;
+        };
+        let addressed_to_us = (target_system == 0 && target_component == 0)
+            || (target_system == GCS_SYSTEM_ID && target_component == GCS_COMPONENT_ID);
+        if !addressed_to_us {
+            return;
+        }
+        if command == MAV_CMD_DO_SET_MODE && result != 0 {
+            warn!(result, "PX4 refused the OFFBOARD mode command");
+        }
+        if command != MAV_CMD_COMPONENT_ARM_DISARM {
+            return;
+        }
+        // Unsolicited: no arm/disarm of ours awaits a verdict.
+        let Some(arm) = self.last_sent_arm else {
+            return;
+        };
+        if result == 0 {
+            info!(arm, "FC acknowledged the arm/disarm command");
+        } else {
+            warn!(arm, result, "FC REFUSED the arm/disarm command");
+        }
+        self.last_arm_ack = Some(FcCommandAck {
+            arm,
+            result: u32::from(result),
+        });
     }
 
     /// Disarms and stops the setpoint stream.
@@ -252,6 +339,8 @@ impl Px4Uplink {
         self.arm_phase = ArmPhase::Idle;
         self.warmup_since = None;
         self.last_vel_ned = [0.0; 3];
+        self.last_sent_arm = Some(false);
+        self.last_arm_ack = None;
         info!("disarm sent; setpoint stream stopped");
     }
 

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -145,6 +145,9 @@ const state = {
   selectedPadId: null,
   pendingReset: false,
   pendingFpvToggle: false,
+  // The FC arm/disarm verdict (kind:result) last logged, so each verdict
+  // is announced exactly once however many samples repeat it.
+  lastFcVerdictLogged: null,
   // Camera-velocity vs FPV/direct flight, tracked here so the DOM toggle
   // sends an explicit typed ModeRequest TARGET, never a stateless flip.
   // Flips ONLY on the host's accepted mode ack (reliable delivery), never
@@ -425,6 +428,7 @@ async function openTransportSession({ url, certHash, certHashHex, manual, leaseP
     state.controlGeneration = (state.controlGeneration + 1) >>> 0;
     state.pendingReset = false;
     state.pendingFpvToggle = false;
+    state.lastFcVerdictLogged = null;
     state.connected = false;
     state.leaseGranted = false;
     state.skippedVideoFrames = 0;
@@ -1151,10 +1155,9 @@ async function readTelemetryDatagrams(transport, token) {
           }
         }
         if (t.vehicleId !== VEHICLE_ID) continue;
-        els.telemetry.textContent = formatTelemetrySummary(
-          t,
-          instruments.fcState.observe(t.fcState ?? null, performance.now()),
-        );
+        const fcView = instruments.fcState.observe(t.fcState ?? null, performance.now());
+        logFcCommandVerdict(fcView);
+        els.telemetry.textContent = formatTelemetrySummary(t, fcView);
       } else if (decoded.kind === "Pong") {
         // RTT probing is out of scope for this demo viewer; ignored.
       } else if (decoded.kind === "FrameRejected") {
@@ -1742,6 +1745,21 @@ function updateControlReadout(pad, mode, plan) {
     `flight [${mode}]: ${src} | roll=${m.roll.toFixed(2)} pitch=${m.pitch.toFixed(2)} ` +
     `climb=${m.throttle.toFixed(2)} yaw=${m.yaw.toFixed(2)} | motion: ${motionState} | ` +
     "arm: Options/Enter disarm: Create/Backspace";
+}
+
+/** Logs each NEW FC arm/disarm verdict once (enactment truth): a refusal
+ *  is loud on the overlay and log; an acceptance just clears the memory,
+ *  since the arm-state readout already reflects success. */
+function logFcCommandVerdict(fcView) {
+  const verdict = fcView?.lastCommand ?? null;
+  const key = verdict ? `${verdict.arm ? "arm" : "disarm"}:${verdict.result}` : null;
+  if (key === state.lastFcVerdictLogged) return;
+  state.lastFcVerdictLogged = key;
+  if (verdict && verdict.result !== 0) {
+    const which = verdict.arm ? "arm" : "disarm";
+    els.overlay.textContent = `FC refused ${which} (result ${verdict.result})`;
+    log(`FC refused the ${which} command (MAV_RESULT ${verdict.result})`);
+  }
 }
 
 /** The reason a gated tick refuses arm/disarm presses, for the operator. */

--- a/clients/web/telemetry-display.js
+++ b/clients/web/telemetry-display.js
@@ -27,6 +27,13 @@ export function formatTelemetrySummary(sample, fcView = null) {
     arm = fcView.stale
       ? "arm: stale"
       : ({ 0: "arm: unknown", 1: "DISARMED", 2: "ARMED" }[fcView.armState] ?? "arm: invalid");
+    // Enactment truth: the FC refused the most recent commanded
+    // arm/disarm. Without this marker, "command accepted" and a stubborn
+    // DISARMED readout are indistinguishable from a dead control.
+    const verdict = fcView.lastCommand;
+    if (!fcView.stale && verdict && verdict.result !== 0) {
+      arm += ` (FC refused ${verdict.arm ? "arm" : "disarm"}: result ${verdict.result})`;
+    }
   }
   let pose = "pose Missing";
   if (sample.pose !== null && sample.pose !== undefined) {

--- a/clients/web/telemetry-display.test.mjs
+++ b/clients/web/telemetry-display.test.mjs
@@ -128,3 +128,33 @@ function testTruthGatesOnValidityIntegrityAndRole() {
 }
 testTruthGatesOnValidityIntegrityAndRole();
 console.log("ok - testTruthGatesOnValidityIntegrityAndRole");
+
+function testFcRefusalVerdictSurfacesInTheArmReadout() {
+  // A refused arm marks the readout: the enactment truth that separates
+  // "command accepted" from "the FC armed".
+  assert.equal(
+    formatTelemetrySummary(
+      { pose: null, velocity: null },
+      { armState: 1, ageMs: 100, stale: false, lastCommand: { arm: true, result: 4 } },
+    ),
+    "DISARMED (FC refused arm: result 4) | pose Missing | velocity Missing",
+  );
+  // An accepted verdict adds nothing: the arm state already shows it.
+  assert.equal(
+    formatTelemetrySummary(
+      { pose: null, velocity: null },
+      { armState: 2, ageMs: 100, stale: false, lastCommand: { arm: true, result: 0 } },
+    ),
+    "ARMED | pose Missing | velocity Missing",
+  );
+  // A stale report suppresses the verdict along with the arm state.
+  assert.equal(
+    formatTelemetrySummary(
+      { pose: null, velocity: null },
+      { armState: 1, ageMs: 9000, stale: true, lastCommand: { arm: true, result: 4 } },
+    ),
+    "arm: stale | pose Missing | velocity Missing",
+  );
+}
+testFcRefusalVerdictSurfacesInTheArmReadout();
+console.log("ok - testFcRefusalVerdictSurfacesInTheArmReadout");

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -629,6 +629,7 @@ export class FcStateTracker {
       const stamp = fcState.stamp;
       this.last = {
         armState: fcState.armState >>> 0,
+        lastCommand: sanitizeFcCommand(fcState.lastCommand),
         sourceId: stamp.sourceId,
         sourceIncarnation: stamp.sourceIncarnation,
         sourceEpoch: stamp.sourceEpoch,
@@ -670,8 +671,19 @@ export class FcStateTracker {
     const ageMs = nowMs - this.last.firstSeenMs;
     return {
       armState: this.last.armState,
+      lastCommand: this.last.lastCommand,
       ageMs,
       stale: ageMs > this.staleAfterMs,
     };
   }
+}
+
+// The FC's arm/disarm COMMAND_ACK verdict riding the fc-state lane. A
+// malformed verdict degrades to null (no verdict) rather than rejecting
+// the whole report: the arm state itself is still valid and fresh.
+function sanitizeFcCommand(lastCommand) {
+  if (!lastCommand || typeof lastCommand.arm !== "boolean") return null;
+  const result = lastCommand.result;
+  if (!Number.isInteger(result) || result < 0) return null;
+  return { arm: lastCommand.arm, result };
 }

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -738,3 +738,26 @@ function testEstimateStampsRequireKnownIntegrity() {
 }
 testEstimateStampsRequireKnownIntegrity();
 console.log("ok - testEstimateStampsRequireKnownIntegrity");
+
+function testFcVerdictLaneIsCarriedAndSanitized() {
+  const tracker = new FcStateTracker(3000);
+  // A well-formed COMMAND_ACK verdict rides the accepted report into the view.
+  let view = tracker.observe(
+    { ...fcReport(1, 1), lastCommand: { arm: true, result: 4 } },
+    1000,
+  );
+  assert.deepEqual(view.lastCommand, { arm: true, result: 4 });
+  // A malformed verdict degrades to null (no verdict) WITHOUT rejecting the
+  // report: the arm state itself is still valid and refreshes normally.
+  view = tracker.observe(
+    { ...fcReport(2, 2), lastCommand: { arm: "yes", result: -1 } },
+    1100,
+  );
+  assert.equal(view.armState, 2, "the malformed verdict does not reject the report");
+  assert.equal(view.lastCommand, null);
+  // A report without the lane clears the remembered verdict.
+  view = tracker.observe(fcReport(3, 2), 1200);
+  assert.equal(view.lastCommand, null);
+}
+testFcVerdictLaneIsCarriedAndSanitized();
+console.log("ok - testFcVerdictLaneIsCarriedAndSanitized");

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -952,16 +952,25 @@ function decodeSimTruthState(bytes) {
   };
 }
 
-// telemetry.proto FcState: arm_state=1 (varint), stamp=2. FC-owned arm
-// state under its own provenance; unconsumable (null) without the stamp.
+// telemetry.proto FcState: arm_state=1 (varint), stamp=2,
+// last_command_kind=3, last_command_result=4. FC-owned arm state under
+// its own provenance; unconsumable (null) without the stamp.
 function decodeFcState(bytes) {
   if (!bytes) return null;
   const f = parseFields(bytes);
   const stamp = decodeMeasurementStamp(firstBytes(f, 2));
   // Exact-role gate: FC state must carry the FC-state role.
   if (stamp === null || stamp.role !== 3) return null;
+  // The FC's COMMAND_ACK verdict for the most recent commanded arm or
+  // disarm (kind 1 arm, 2 disarm; result is the raw MAV_RESULT) — the
+  // enactment truth that distinguishes "command taken" from "FC did it".
+  const kind = firstVarint(f, 3) ?? 0;
   return {
     armState: firstVarint(f, 1) ?? 0,
+    lastCommand:
+      kind === 1 || kind === 2
+        ? { arm: kind === 1, result: firstVarint(f, 4) ?? 0 }
+        : null,
     stamp,
   };
 }

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -439,7 +439,32 @@ check(
   check("fc lane decodes arm state under the FC role and host clock",
     message.fcState?.armState === 2 && message.fcState?.stamp?.role === 3
     && message.fcState?.stamp?.clock === 3);
+  check("fc lane without a verdict decodes lastCommand null",
+    message.fcState?.lastCommand === null);
   check("no estimate lane is synthesized alongside truth", message.avionics === null);
+
+  // The FC's COMMAND_ACK verdict lane: kind (1 arm / 2 disarm) plus the
+  // raw MAV_RESULT survive decode — the enactment truth for a refusal.
+  const refused = [];
+  varint(refused, (1 << 3) | 0); // arm_state
+  varint(refused, 1); // DISARMED
+  bytesField(refused, 2, measurementStamp(1, 1, 4, 78, 3, 0x22, 3));
+  varint(refused, (3 << 3) | 0); // last_command_kind
+  varint(refused, 1); // the refused command was an ARM
+  varint(refused, (4 << 3) | 0); // last_command_result
+  varint(refused, 4); // MAV_RESULT_TEMPORARILY_REJECTED
+  const refusedTelemetry = [];
+  bytesField(refusedTelemetry, 1, uint64Message(1));
+  bytesField(refusedTelemetry, 2, uint64Message(43));
+  bytesField(refusedTelemetry, 8, refused);
+  const refusedEnvelope = [];
+  varint(refusedEnvelope, (1 << 3) | 0);
+  varint(refusedEnvelope, SCHEMA_VERSION);
+  bytesField(refusedEnvelope, 4, refusedTelemetry);
+  const refusedMessage = decodeBareEnvelope(new Uint8Array(refusedEnvelope)).message;
+  check("fc lane surfaces the FC's arm refusal verdict",
+    refusedMessage.fcState?.lastCommand?.arm === true
+    && refusedMessage.fcState?.lastCommand?.result === 4);
 
   // Provenance-free lanes are unconsumable, not defaulted.
   const bare = [];

--- a/crates/pilotage-adapter-api/src/lib.rs
+++ b/crates/pilotage-adapter-api/src/lib.rs
@@ -36,7 +36,7 @@ pub use pilotage_camera_calibration::{
 };
 pub use step::{StepBudget, StepOutcome};
 pub use telemetry::{
-    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, FcStateSample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, FcCommandAck, FcStateSample,
     GimbalAttitudeSample, MeasurementClock, MeasurementStamp, Pose2d, SimTruthSample,
     SourceIncarnation, SourceIntegrity, SourceRole, TelemetryBatch, TelemetrySample, VideoSource,
 };

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -191,6 +191,18 @@ pub struct SimTruthSample {
     pub stamp: MeasurementStamp,
 }
 
+/// The FC's acknowledgement of the most recent commanded arm or disarm
+/// (COMMAND_ACK) — enactment truth for the operator. It rides FC-state
+/// provenance, so the verdict ages with the report that carried it; the
+/// action-result path's command-acceptance semantics are unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FcCommandAck {
+    /// True when the acknowledged command was an arm, false for a disarm.
+    pub arm: bool,
+    /// The raw MAV_RESULT the FC returned (0 = accepted).
+    pub result: u32,
+}
+
 /// FC-owned vehicle state (arm today; mode/failsafe belong here as they
 /// arrive) with its own provenance: the FC is the only author, and the
 /// stamp records which link observation reported it — it is never merged
@@ -199,6 +211,10 @@ pub struct SimTruthSample {
 pub struct FcStateSample {
     /// Arm state as the FC reports it: 0 unknown, 1 disarmed, 2 armed.
     pub arm_state: u32,
+    /// The FC's answer to the most recent commanded arm/disarm, when one
+    /// has been observed. A refusal here is the only signal that turns
+    /// "the command was taken" into "the FC did not do it".
+    pub last_command: Option<FcCommandAck>,
     /// Identity and acquisition time of the FC report carrying this state.
     pub stamp: MeasurementStamp,
 }

--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -14,8 +14,9 @@ mod encoding;
 use decoding::decode_known;
 pub use encoding::{
     AttitudeTarget, GCS_COMPONENT_ID, GCS_SYSTEM_ID, GIMBAL_FLAGS_HORIZON_YAW_FOLLOW,
-    encode_arm_command, encode_attitude_setpoint, encode_command_long, encode_gcs_heartbeat,
-    encode_gimbal_rate_setpoint, encode_position_setpoint, encode_velocity_setpoint,
+    encode_arm_command, encode_attitude_setpoint, encode_command_ack, encode_command_long,
+    encode_gcs_heartbeat, encode_gimbal_rate_setpoint, encode_position_setpoint,
+    encode_velocity_setpoint,
 };
 
 /// MAVLink 2.0 start-of-frame marker.
@@ -143,6 +144,10 @@ pub const COMMAND_LONG_ID: u32 = 76;
 pub const SET_POSITION_TARGET_ID: u32 = 84;
 /// GIMBAL_MANAGER_SET_ATTITUDE message id (uplink: gimbal rate demands).
 pub const GIMBAL_MANAGER_SET_ATTITUDE_ID: u32 = 282;
+/// MAV_CMD_COMPONENT_ARM_DISARM (COMMAND_LONG payload).
+pub const MAV_CMD_COMPONENT_ARM_DISARM: u16 = 400;
+/// MAV_CMD_DO_SET_MODE (COMMAND_LONG payload).
+pub const MAV_CMD_DO_SET_MODE: u16 = 176;
 /// MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW (COMMAND_LONG payload).
 pub const MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW: u16 = 1000;
 /// MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE (COMMAND_LONG payload).

--- a/crates/pilotage-mavlink/src/codec/encoding.rs
+++ b/crates/pilotage-mavlink/src/codec/encoding.rs
@@ -2,7 +2,7 @@
 //! offboard setpoints, and gimbal-manager demands.
 
 use super::{
-    COMMAND_LONG_ID, GIMBAL_MANAGER_SET_ATTITUDE_ID, HEARTBEAT_ID, MAGIC_V2,
+    COMMAND_ACK_ID, COMMAND_LONG_ID, GIMBAL_MANAGER_SET_ATTITUDE_ID, HEARTBEAT_ID, MAGIC_V2,
     SET_POSITION_TARGET_ID, compute_crc,
 };
 
@@ -17,6 +17,30 @@ pub const GCS_COMPONENT_ID: u8 = 190;
 /// around `payload` into `out`, returning the frame length. `out` must
 /// hold `10 + payload.len() + 2` bytes; a too-small buffer returns 0.
 fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u8]) -> usize {
+    encode_frame_v2_from(
+        seq,
+        msg_id,
+        payload,
+        extra,
+        GCS_SYSTEM_ID,
+        GCS_COMPONENT_ID,
+        out,
+    )
+}
+
+/// Writes a MAVLink 2.0 frame under an explicit SOURCE identity — the
+/// FC-side encoder for messages an autopilot originates (a fake FC in a
+/// test, a gateway loopback).
+#[allow(clippy::too_many_arguments)]
+fn encode_frame_v2_from(
+    seq: u8,
+    msg_id: u32,
+    payload: &[u8],
+    extra: u8,
+    system_id: u8,
+    component_id: u8,
+    out: &mut [u8],
+) -> usize {
     let total = 10 + payload.len() + 2;
     if out.len() < total || payload.len() > 255 {
         return 0;
@@ -26,8 +50,8 @@ fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u
     out[2] = 0;
     out[3] = 0;
     out[4] = seq;
-    out[5] = GCS_SYSTEM_ID;
-    out[6] = GCS_COMPONENT_ID;
+    out[5] = system_id;
+    out[6] = component_id;
     out[7] = (msg_id & 0xff) as u8;
     out[8] = ((msg_id >> 8) & 0xff) as u8;
     out[9] = ((msg_id >> 16) & 0xff) as u8;
@@ -36,6 +60,37 @@ fn encode_frame_v2(seq: u8, msg_id: u32, payload: &[u8], extra: u8, out: &mut [u
     out[10 + payload.len()] = (crc & 0xff) as u8;
     out[10 + payload.len() + 1] = (crc >> 8) as u8;
     total
+}
+
+/// Serializes an FC-sourced COMMAND_ACK frame addressed to the GCS
+/// identity this codec commands under — the acknowledgement an autopilot
+/// returns for a COMMAND_LONG (fake FCs in tests, gateway loopback).
+///
+/// Wire order (10 bytes): command u16 @0, result u8 @2, progress u8 @3,
+/// result_param2 i32 @4, target_system @8, target_component @9.
+pub fn encode_command_ack(
+    seq: u8,
+    command: u16,
+    result: u8,
+    system_id: u8,
+    component_id: u8,
+) -> [u8; 22] {
+    let mut payload = [0u8; 10];
+    payload[0..2].copy_from_slice(&command.to_le_bytes());
+    payload[2] = result;
+    payload[8] = GCS_SYSTEM_ID;
+    payload[9] = GCS_COMPONENT_ID;
+    let mut frame = [0u8; 22];
+    encode_frame_v2_from(
+        seq,
+        COMMAND_ACK_ID,
+        &payload,
+        143,
+        system_id,
+        component_id,
+        &mut frame,
+    );
+    frame
 }
 
 /// Serializes a GCS heartbeat frame, used to register this endpoint with

--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 outcome: pass
 summary:
 test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-sink.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-sink.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture sink round trip
 command: cargo test -p loopback-probe capture::
-config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture projection
 command: cargo test -p loopback-probe telemetry::
-config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 outcome: pass
 summary:
 test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/host-wire.run.txt
+++ b/docs/link/evidence-artifacts/link04/host-wire.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: host wire-mapping
 command: cargo test -p pilotage-session-host --lib engine_actor::telemetry
-config-digest: ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 outcome: pass
 summary:
-test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 0.00s
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link05/authz-regime.run.txt
+++ b/docs/link/evidence-artifacts/link05/authz-regime.run.txt
@@ -2,12 +2,12 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: browser avionics-ingress authorization regime
 command: node clients/web/telemetry-ingress.test.mjs
-config-digest: 211406836a102c64c0e0065a796e238a8af16f3a
+config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
 tool-version: node v26.5.0
-run-id: local:211406836a102c64c0e0065a796e238a8af16f3a
+run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 outcome: pass
 summary:
-  27 browser ingress checks passed; LINK-AUTHZ-005 cases:
+  28 browser ingress checks passed; LINK-AUTHZ-005 cases:
   ok - testInterleavedLaneWithinBudgetKeepsItsAuthorization
   ok - testNumericBeyondSkewBudgetIsNotAuthorized
   ok - testDuplicateStatusDowngradeIsNotReversibleByANewerNumeric

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -195,45 +195,45 @@ attr outcome pass
 node RESULT-LINK-WIRE verification-result
 title host wire-mapping suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::telemetry
-attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:889087b7df14f59dbd4d13f67f11ae3d86632b36
+attr source-digest git-blob:f8de90fe18e5ed843e14f8819c039f6b1a01240a
 attr artifact docs/link/evidence-artifacts/link04/host-wire.run.txt
-attr output-digest sha256:7acbbfa35eaf2845a455364184a37e6e2b9b3b65d3c1bfb489cfdf0ad594d6c5
-attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr output-digest sha256:6a78076e7d8bb2d263dc2d5f3993ed248e13a70ef96288c671266be44f7895d7
+attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr outcome pass
 
 node RESULT-LINK-CAPTURE verification-result
 title loopback-probe capture projection suite — recorded pass
 attr command cargo test -p loopback-probe telemetry::
-attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:65e0988d096f01778980b542d46f777541d8bfe2
+attr source-digest git-blob:4cc1cc78aea89d713d4e7c12fd770e0cbc173267
 attr artifact docs/link/evidence-artifacts/link04/capture.run.txt
-attr output-digest sha256:2aed2db420bf9bf0c8ac51c622044cc4ab436f74a17f58033c053cb08fd75507
-attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr output-digest sha256:f08379106c9914561729e90c046d090cb7b9717f184c0f8e46961a6f0c049f90
+attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:df0490b0fdcdc0cae08441c3d717cd1ff0764f57
+attr source-digest git-blob:22c8f6e33ee12ecfa1075d017a73b5e77ebc0828
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:fab8e23b76f5b66c67c86398a0f5f3d2d50e2247e6c0af4a581114e205726b22
-attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr output-digest sha256:3c2b1962e64c629567607d5287764942711070b46cbe1083663dbc9005cc1afe
+attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
 title loopback-probe capture sink suite — recorded pass
 attr command cargo test -p loopback-probe capture::
-attr config-digest ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:329779834423fffad82e5ed8270a33dd92c45fb6
+attr source-digest git-blob:fab4a30681c88e02875c7892bec1d7c4f094facb
 attr artifact docs/link/evidence-artifacts/link04/capture-sink.run.txt
-attr output-digest sha256:2fd6ac86f5dc0c4ab49ef46143e2c6169019b315c827fea0f167f6397e5fee64
-attr run-id local:ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
+attr output-digest sha256:72db92aa7f96ca6e0b8f7d8dc6f42f10cc0a4617dec4459e25e86446971b655f
+attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -241,12 +241,12 @@ attr outcome pass
 node RESULT-LINK-AUTHZ verification-result
 title browser authorization-regime suite — recorded pass
 attr command node clients/web/telemetry-ingress.test.mjs
-attr config-digest 211406836a102c64c0e0065a796e238a8af16f3a
+attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tool-version node v26.5.0
-attr source-digest git-blob:0a5eca31635fd49bca87459c43b7ac0439259bef
+attr source-digest git-blob:5debe53552fbab04c08f9d8cff891541f3cf9c13
 attr artifact docs/link/evidence-artifacts/link05/authz-regime.run.txt
-attr output-digest sha256:064e32f9b8cc9b78472dcf7de91e20b35b76a7b4263208bfccc3bab45418ad67
-attr run-id local:211406836a102c64c0e0065a796e238a8af16f3a
+attr output-digest sha256:c41a448821b4654cabecc501fadb180266bc5a78156d299870ccbc55eee82567
+attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr outcome pass
 
 node CFG-LINK-EXTRACTION configuration-item
@@ -258,14 +258,14 @@ attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
-attr commit ccf58cb4a32642cbaaad7c5e4ee353382e9cc96a
-attr tree fb15a5c8155c7dad37f772504025c1c529ba7f49
+attr commit f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr tree 9b6e82ce4092a7fa8190e159d9626492462642e4
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)
 attr scm git
-attr commit 211406836a102c64c0e0065a796e238a8af16f3a
-attr tree 9cf15bb9b43f4202e55c314aef7f495dd3c20082
+attr commit f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr tree 9b6e82ce4092a7fa8190e159d9626492462642e4
 
 node TOOL-LINK-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -150,6 +150,12 @@ fn sim_truth_to_wire(sample: SimTruthSample) -> wire::SimTruthState {
 fn fc_state_to_wire(sample: FcStateSample) -> wire::FcState {
     wire::FcState {
         arm_state: sample.arm_state,
+        // 0 none observed, 1 arm, 2 disarm — the FC's COMMAND_ACK verdict
+        // for the most recent commanded arm/disarm (enactment truth).
+        last_command_kind: sample
+            .last_command
+            .map_or(0, |ack| if ack.arm { 1 } else { 2 }),
+        last_command_result: sample.last_command.map_or(0, |ack| ack.result),
         stamp: Some(measurement_stamp_to_wire(sample.stamp)),
     }
 }

--- a/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry/tests.rs
@@ -228,6 +228,7 @@ fn truth_and_fc_state_survive_the_wire_under_their_own_identities() {
         }),
         fc_state: Some(FcStateSample {
             arm_state: 2,
+            last_command: None,
             stamp: fc_stamp,
         }),
         gimbal: None,
@@ -267,4 +268,40 @@ fn truth_and_fc_state_survive_the_wire_under_their_own_identities() {
         truth_wire_stamp.source_incarnation, fc_wire_stamp.source_incarnation,
         "roles carry independent identities"
     );
+}
+
+#[test]
+fn the_fc_command_verdict_crosses_the_wire() {
+    let stamp = MeasurementStamp {
+        role: SourceRole::FcState,
+        integrity: SourceIntegrity::ChecksummedOnly,
+        source_id: 1,
+        source_incarnation: SourceIncarnation::new([0x22; 16]),
+        source_epoch: 1,
+        sequence: 3,
+        acquired_at_ns: 77,
+        clock: MeasurementClock::HostMonotonic,
+    };
+    // A refused arm: kind 1 with the raw MAV_RESULT.
+    let refused = super::fc_state_to_wire(FcStateSample {
+        arm_state: 1,
+        last_command: Some(pilotage_adapter_api::FcCommandAck {
+            arm: true,
+            result: 4,
+        }),
+        stamp,
+    });
+    assert_eq!(
+        refused.last_command_kind, 1,
+        "an arm verdict maps to kind 1"
+    );
+    assert_eq!(refused.last_command_result, 4, "the raw MAV_RESULT crosses");
+    // No verdict observed: the lane stays at kind 0.
+    let none = super::fc_state_to_wire(FcStateSample {
+        arm_state: 2,
+        last_command: None,
+        stamp,
+    });
+    assert_eq!(none.last_command_kind, 0);
+    assert_eq!(none.last_command_result, 0);
 }

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -177,6 +177,14 @@ message FcState {
   // Identity and acquisition of the FC report carrying this state.
   // Absence makes the sample unconsumable.
   MeasurementStamp stamp = 2;
+  // The FC's acknowledgement (COMMAND_ACK) of the most recent commanded
+  // arm or disarm: 0 none observed, 1 the command was an arm, 2 a disarm.
+  // Enactment truth for the operator — the action-result path's
+  // command-acceptance semantics are unchanged by this lane.
+  uint32 last_command_kind = 3;
+  // Raw MAV_RESULT for that command (0 = accepted); meaningful only when
+  // last_command_kind is non-zero.
+  uint32 last_command_result = 4;
 }
 
 // Gimbal device orientation (Gimbal Protocol v2 attitude status) under its

--- a/tools/loopback-probe/src/capture.rs
+++ b/tools/loopback-probe/src/capture.rs
@@ -157,6 +157,7 @@ mod tests {
                         wire::SourceIntegrity::ChecksummedOnly,
                     )
                 }),
+                ..Default::default()
             })),
             gimbal: None,
         };

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -381,6 +381,7 @@ mod tests {
                 fc_state: Some(Box::new(wire::FcState {
                     arm_state: 2,
                     stamp: Some(fc_stamp),
+                    ..Default::default()
                 })),
                 gimbal: None,
             },

--- a/tools/loopback-probe/src/telemetry.rs
+++ b/tools/loopback-probe/src/telemetry.rs
@@ -238,6 +238,7 @@ mod tests {
                     wire::SourceRole::FcState,
                     wire::SourceIntegrity::ChecksummedOnly,
                 )),
+                ..Default::default()
             })),
             gimbal: None,
         };
@@ -276,6 +277,7 @@ mod tests {
             fc_state: Some(Box::new(wire::FcState {
                 arm_state: 2,
                 stamp: None,
+                ..Default::default()
             })),
             gimbal: None,
         };


### PR DESCRIPTION
PX4 arm/disarm enactment truth: consume COMMAND_ACK and surface FC refusals

Fixes #181. Stacked on #183 (shares the main.js control-feedback region).

The PX4 uplink was fire-and-forget: arm/disarm went out as UDP, the adapter reported `accepted` unconditionally, and every FC refusal was invisible — live-captured during the investigation: viewer says "disarm … accepted" while PX4 logs `Disarming denied: not landed`, and `Disarmed by auto preflight disarming` silently un-arms ~10 s after an arm with no takeoff.

- Uplink: drains its command socket (PX4 acks a COMMAND_LONG to the endpoint that sent it), pairs MAV_CMD_COMPONENT_ARM_DISARM acks with the latest arm/disarm sent (the ack carries only the command id), logs refused OFFBOARD mode commands.
- Wire: `FcState.last_command_kind/result` carry the verdict on the fc-state lane; host maps it; adapter folds it beside the ArmReport.
- Viewer: each NEW refusal is logged + overlaid once; the arm readout shows `(FC refused arm: result N)` while fresh; malformed verdicts degrade to null without rejecting the report.
- ActionResult semantics (command taken by the adapter) are unchanged; aviate keeps logging acks and leaves the lane empty rather than carrying an unpaired verdict.

Guards: fake-FC ack-pairing test (refusal surfaces, fresh command clears the stale verdict), host wire-mapping assertions, JS decode/tracker/display tests.

Verified: workspace clippy -D warnings, fmt, doc gate (CI flags), targeted crate tests (385 pass), release build, wire/wire-wasm/telemetry JS suites, viewer-boot browser test (35 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Supersedes #184 (auto-closed by GitHub when its stacked base branch was deleted at #183's merge; review record and CI history live there). Includes the LINK-04 evidence re-record at baseline f75f99d4.
