### PR TITLE
Handover lease flood fix + honest end-of-session reporting

### DIFF
--- a/clients/web-control/src/runtime.rs
+++ b/clients/web-control/src/runtime.rs
@@ -17,7 +17,7 @@ use crate::quasimode::{
 use crate::sample::{RawSample, SessionState};
 
 mod authority;
-use authority::{MotionOutput, MotionPhase};
+use authority::{MOTION_LEASE_RETRY_MS, MotionOutput, MotionPhase};
 
 /// Sentinel making the first lease request fire immediately (before any real
 /// `now_ms`), rather than waiting out a debounce window from time zero.
@@ -130,6 +130,10 @@ impl ControlRuntime {
             };
         }
         self.pending = Some(candidate);
+        // A fresh handover has emitted no motion release yet: reset the retry
+        // clock so the first handover tick releases immediately instead of
+        // waiting out a window left over from earlier lease traffic.
+        self.motion_action_ms = NEVER_REQUESTED_MS;
         ActivationPlan {
             installed: false,
             activation_revision: self.activation_revision,
@@ -226,12 +230,28 @@ impl ControlRuntime {
     /// Emits the neutral handover, and installs the pending profile once the
     /// captured controls (the modifier and the gimbal sticks) read neutral, so
     /// behavior changes only after a genuine neutral transition.
+    ///
+    /// Each scope's release — and its neutral frame — is emitted only while
+    /// the session still shows that lease granted. Once the release is
+    /// reflected the scope has no holder: another release would draw a
+    /// `released: false` acknowledgement and any frame a NoHolder rejection,
+    /// each raising a host warning, at tick rate for as long as the operator
+    /// stays deflected. The motion release re-emits after
+    /// [`MOTION_LEASE_RETRY_MS`] without the session reflecting it (a lost
+    /// write must not wedge the handover); the shell drops the gimbal grant
+    /// the moment it executes that release, which bounds it to one emission,
+    /// and the host's holder-silence watchdog covers a lost gimbal release.
     fn evaluate_handover(
         &mut self,
         sample: &RawSample,
         session: &SessionState,
         active: &CompiledProfile,
     ) -> ControlPlan {
+        let release_motion = session.motion_granted
+            && session.now_ms - self.motion_action_ms >= MOTION_LEASE_RETRY_MS;
+        if release_motion {
+            self.motion_action_ms = session.now_ms;
+        }
         // Neutral must hold across the UNION of the active AND candidate
         // controls: a profile swap remaps flight and gimbal inputs, so any
         // input deflected under EITHER profile could jump meaning at install.
@@ -247,12 +267,14 @@ impl ControlRuntime {
             self.install_after_seed(candidate, session.now_ms);
         }
         ControlPlan {
-            motion: Some(neutral_motion()),
-            gimbal: Some(neutral_gimbal()),
-            lease: Some(LeaseAction::Release),
+            // The neutrals keep each still-held scope's liveness until its
+            // release lands, then stop: no frame rides a released lease.
+            motion: session.motion_granted.then(neutral_motion),
+            gimbal: session.lease_granted.then(neutral_gimbal),
+            lease: session.lease_granted.then_some(LeaseAction::Release),
             // The scheme remaps flight too, so the motion lease is cycled with
             // the gimbal lease and reacquired on resume.
-            motion_lease: Some(LeaseAction::Release),
+            motion_lease: release_motion.then_some(LeaseAction::Release),
             label: None,
             arm: false,
             disarm: false,

--- a/clients/web-control/src/runtime/authority.rs
+++ b/clients/web-control/src/runtime/authority.rs
@@ -52,7 +52,7 @@ pub(super) enum MotionOutput {
 
 /// A dropped motion release/request is re-emitted after this long without the
 /// session reflecting the expected transition.
-const MOTION_LEASE_RETRY_MS: f64 = 250.0;
+pub(super) const MOTION_LEASE_RETRY_MS: f64 = 250.0;
 
 impl ControlRuntime {
     /// Advances the motion-lease reacquisition after a profile handover and

--- a/clients/web-control/src/runtime/tests/motion.rs
+++ b/clients/web-control/src/runtime/tests/motion.rs
@@ -193,6 +193,77 @@ fn a_dropped_motion_reacquire_request_is_retried() {
 }
 
 #[test]
+fn a_deflected_handover_waits_in_silence_once_the_releases_land() {
+    let mut runtime = with_default();
+    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+
+    // First handover tick, both leases still granted: one release per scope,
+    // with the neutrals still streaming liveness under the held generation.
+    let first = runtime.evaluate(
+        &deflected(),
+        &session_at(1000.0, Mode::QuadPilot, true, true),
+    );
+    assert_eq!(first.motion_lease, Some(LeaseAction::Release));
+    assert_eq!(first.lease, Some(LeaseAction::Release));
+    assert!(first.motion.is_some() && first.gimbal.is_some());
+
+    // Next tick, acknowledgements still in flight (grants unchanged): the
+    // motion release is NOT re-sent at tick rate.
+    let inflight = runtime.evaluate(
+        &deflected(),
+        &session_at(1033.0, Mode::QuadPilot, true, true),
+    );
+    assert_eq!(inflight.motion_lease, None, "no duplicate release per tick");
+
+    // Both releases reflected, operator still deflected: the handover waits
+    // in SILENCE — a release now would draw `released: false` and a frame a
+    // NoHolder rejection, each a host warning, every tick until neutral.
+    for now_ms in [1066.0, 1100.0, 2000.0, 30_000.0] {
+        let waiting = runtime.evaluate(
+            &deflected(),
+            &session_at(now_ms, Mode::QuadPilot, false, false),
+        );
+        assert_eq!(waiting.motion_lease, None, "no release without a grant");
+        assert_eq!(waiting.lease, None, "no gimbal release without a grant");
+        assert!(waiting.motion.is_none(), "no frame rides a released lease");
+        assert!(waiting.gimbal.is_none(), "no frame rides a released lease");
+    }
+    assert_eq!(
+        runtime.activation_revision(),
+        1,
+        "still pending while deflected"
+    );
+}
+
+#[test]
+fn a_lost_handover_release_is_retried_on_the_window_not_per_tick() {
+    let mut runtime = with_default();
+    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    let first = runtime.evaluate(
+        &deflected(),
+        &session_at(1000.0, Mode::QuadPilot, true, true),
+    );
+    assert_eq!(first.motion_lease, Some(LeaseAction::Release));
+
+    // The session still shows the grant well past the retry window — the
+    // release write was lost. Quiet inside the window, one re-emit after it.
+    let quiet = runtime.evaluate(
+        &deflected(),
+        &session_at(1100.0, Mode::QuadPilot, true, true),
+    );
+    assert_eq!(quiet.motion_lease, None, "quiet inside the retry window");
+    let retry = runtime.evaluate(
+        &deflected(),
+        &session_at(1300.0, Mode::QuadPilot, true, true),
+    );
+    assert_eq!(
+        retry.motion_lease,
+        Some(LeaseAction::Release),
+        "a lost release is retried once the window elapses"
+    );
+}
+
+#[test]
 fn a_gated_arm_press_is_reported_suppressed_not_silent() {
     let mut runtime = with_default();
     // Prime the generation's edge baselines with nothing held, ungranted.

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -74,6 +74,7 @@ import { runIncomingStreamAcceptLoop } from "./uni-stream-accept.js";
 import { createReconnectController } from "./reconnect.js";
 import {
   applySessionConfig,
+  launcherSessionOver,
   validSessionConfig,
   whenVisible,
 } from "./session-discovery.js";
@@ -318,26 +319,62 @@ function applyUrlParams() {
   if (params.has("cert")) els.certHash.value = params.get("cert");
 }
 
+// The manifest-discovery context: whether this page came from the launcher
+// (a launcher-pinned URL, or a manifest served earlier), and whether the
+// session's end has already been reported (re-armed by the next manifest,
+// so a NEW session's later teardown reports again).
+const discovery = {
+  launcherPinned: new URLSearchParams(window.location.search).get("autoconnect") === "1",
+  manifestSeen: false,
+  endReported: false,
+};
+
 /** Re-reads the launcher-served session manifest and updates the connect
  *  inputs, so a stale tab (its URL pins an older session's certificate)
  *  converges on the CURRENT session at its next attempt instead of
- *  retrying a dead hash forever. A missing manifest (viewer served
- *  without the launcher) is silent — there is nothing to converge to. */
+ *  retrying a dead hash forever. A missing manifest on a page served
+ *  without the launcher is silent — there is nothing to converge to. In a
+ *  launcher context, a manifest that is now GONE means the launcher
+ *  session ended (it deletes `session.json` at teardown): that is said
+ *  once, so the retry loop — kept running, because it converges onto the
+ *  next session's manifest by itself — is never mistaken for a live host. */
 async function refreshSessionConfig() {
-  let fetched;
+  let response = null;
+  let outcome;
   try {
-    const response = await fetch("./session.json", { cache: "no-cache" });
-    if (!response.ok) return;
-    fetched = await response.json();
+    response = await fetch("./session.json", { cache: "no-cache" });
+    outcome = response.ok ? "fetched" : "missing";
   } catch {
+    outcome = "unreachable";
+  }
+  if (outcome === "fetched") {
+    // A served-but-malformed manifest is an invalid config, not a dead
+    // launcher: stay silent like any other unusable manifest.
+    let fetched = null;
+    try {
+      fetched = await response.json();
+    } catch {
+      return;
+    }
+    const config = validSessionConfig(fetched);
+    if (!config) return;
+    discovery.manifestSeen = true;
+    discovery.endReported = false;
+    if (applySessionConfig(els, config)) {
+      log(
+        `session discovery: connect target updated to ${config.host}:${config.port} ` +
+          `(cert ${config.certHash.slice(0, 16)}...)`,
+      );
+    }
     return;
   }
-  const config = validSessionConfig(fetched);
-  if (!config) return;
-  if (applySessionConfig(els, config)) {
+  const context = discovery.launcherPinned || discovery.manifestSeen;
+  if (launcherSessionOver(context, outcome) && !discovery.endReported) {
+    discovery.endReported = true;
     log(
-      `session discovery: connect target updated to ${config.host}:${config.port} ` +
-        `(cert ${config.certHash.slice(0, 16)}...)`,
+      "the launcher session is over (its manifest is gone) — reconnect attempts " +
+        "cannot succeed until a new session starts (cargo xtask sim); " +
+        "auto-reconnect keeps watching for one",
     );
   }
 }

--- a/clients/web/session-discovery.js
+++ b/clients/web/session-discovery.js
@@ -37,6 +37,18 @@ export function applySessionConfig(els, config) {
   return changed;
 }
 
+/** Whether a failed manifest re-read proves the LAUNCHER session is over,
+ *  rather than the manifest merely never having existed (a viewer served
+ *  without the launcher has none, and silence is correct there). The
+ *  launcher deletes `session.json` when its session ends and its static
+ *  server dies with it, so in a launcher context — the URL was
+ *  launcher-pinned, or a manifest WAS served earlier — a manifest that is
+ *  now absent (`"missing"`) or unfetchable (`"unreachable"`) means no
+ *  reconnect can succeed until a NEW session writes a fresh manifest. */
+export function launcherSessionOver(launcherContext, outcome) {
+  return launcherContext && (outcome === "missing" || outcome === "unreachable");
+}
+
 /** Runs `begin` once `doc` is visible — immediately when it already is,
  *  otherwise on the first visibilitychange that lands visible. A hidden
  *  launcher-opened tab must not autoconnect: its throttled timers starve

--- a/clients/web/session-discovery.test.mjs
+++ b/clients/web/session-discovery.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   applySessionConfig,
+  launcherSessionOver,
   validSessionConfig,
   whenVisible,
 } from "./session-discovery.js";
@@ -78,3 +79,17 @@ function testAutoconnectWaitsForVisibility() {
 }
 testAutoconnectWaitsForVisibility();
 console.log("ok - testAutoconnectWaitsForVisibility");
+
+function testSessionOverNeedsBothLauncherContextAndAGoneManifest() {
+  // A gone manifest proves the session ended ONLY in a launcher context;
+  // a viewer served without the launcher never had one, and silence is
+  // correct there.
+  assert.equal(launcherSessionOver(true, "missing"), true, "launcher deleted the manifest");
+  assert.equal(launcherSessionOver(true, "unreachable"), true, "the launcher's server is gone");
+  assert.equal(launcherSessionOver(false, "missing"), false, "no manifest was ever promised");
+  assert.equal(launcherSessionOver(false, "unreachable"), false);
+  // A fetched (or merely invalid) manifest is never "over".
+  assert.equal(launcherSessionOver(true, "fetched"), false);
+}
+testSessionOverNeedsBothLauncherContextAndAGoneManifest();
+console.log("ok - testSessionOverNeedsBothLauncherContextAndAGoneManifest");


### PR DESCRIPTION
## Problem

During a live profile handover (e.g. a gamepad becoming active mid-flight), the viewer log filled with a 30 Hz loop of `LeaseReleased: released=false`, `control frame rejected (reason 2)` (NoHolder), and paired `WarningRaised` authority events for both `vehicle.motion` and `vehicle.gimbal` — for as long as the operator's controls stayed deflected.

Separately, after the launcher stack tore down, the viewer retried forever with bare "connection lost — auto-reconnecting (attempt N)… Opening handshake failed" noise, with no indication the session was authoritatively gone (the launcher deletes `session.json` at teardown, so no retry could ever succeed).

## Root cause

`evaluate_handover` emitted a `LeaseRelease` for both scopes **plus** neutral motion/gimbal frames on **every tick** while waiting for neutral controls. The first release leaves the host with no holder; every subsequent tick then drew a `released: false` acknowledgement, two NoHolder frame rejections, and two host warnings.

## Fix

- **Commit 1 (runtime):** each scope releases only while the session still shows its lease granted. The motion release re-emits on the existing 250 ms `MOTION_LEASE_RETRY_MS` window (a lost write cannot wedge the handover); the gimbal release is bounded by the shell dropping the grant on execute, with the host's holder-silence watchdog as backstop. Neutral frames stream only while their lease is still held — no frame rides a released lease. Guardrail tests: a deflected handover emits one release per scope then waits in silence at any later tick; a lost release retries on the window, not per tick.
- **Commit 2 (viewer):** in a launcher context (autoconnect-pinned URL, or a manifest seen earlier), a `session.json` that is now missing/unreachable is reported once as "the launcher session is over"; the capped retry loop stays running because it converges onto the next session's manifest by itself. New pure helper `launcherSessionOver` with tests.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` (46 suites ok), doc gate, `cargo build --release` — all green.
- All non-browser `clients/web/*.test.mjs` suites pass, including the new `launcherSessionOver` cases.
- `scripts/build-web-instruments.sh` rebuilt the served wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)