### PR TITLE
Device swaps retain control authority; scope transfers keep the fence

### DIFF
--- a/clients/web-control/golden-vectors.json
+++ b/clients/web-control/golden-vectors.json
@@ -343,8 +343,8 @@
             "mode": "quad-pilot"
           },
           "expect": {
-            "motionThrottle": 0.0,
-            "motionLease": "release",
+            "motionGated": true,
+            "motionLease": "none",
             "activationRevision": 2,
             "label": "Sony DualSense"
           }
@@ -362,12 +362,11 @@
             ]
           },
           "session": {
-            "mode": "quad-pilot",
-            "motionGranted": false
+            "mode": "quad-pilot"
           },
           "expect": {
             "motionGated": true,
-            "motionLease": "request",
+            "motionLease": "none",
             "arm": false
           }
         },
@@ -513,7 +512,7 @@
             "mode": "quad-pilot"
           },
           "expect": {
-            "motionLease": "release",
+            "motionLease": "none",
             "activationRevision": 2,
             "label": "Generic Gamepad (standard mapping)"
           }
@@ -567,7 +566,8 @@
           },
           "expect": {
             "activationRevision": 3,
-            "label": "Session Override"
+            "label": "Session Override",
+            "motionLease": "none"
           }
         },
         {
@@ -581,11 +581,11 @@
             "pressed": []
           },
           "session": {
-            "mode": "quad-pilot",
-            "motionGranted": false
+            "mode": "quad-pilot"
           },
           "expect": {
-            "motionLease": "request"
+            "motionThrottle": 0.0,
+            "motionLease": "none"
           }
         },
         {
@@ -603,7 +603,7 @@
             "motionRecovered": false
           },
           "expect": {
-            "motionGated": true
+            "motionThrottle": 0.0
           }
         },
         {

--- a/clients/web-control/src/coordinator.rs
+++ b/clients/web-control/src/coordinator.rs
@@ -1,9 +1,10 @@
 //! Coordinates the device stage and the control runtime as ONE activation
 //! authority (INPUT-01): any effective-mapping change — new scheme bytes OR
 //! a device selection that changes what physical input means — takes the
-//! same transactional path: neutral output, gimbal + motion lease cycle,
+//! same transactional path: neutral output, retained same-scope authority,
 //! and an advanced activation revision that the announcement and every
-//! subsequent frame carry. The wasm shell and the native golden harness
+//! subsequent frame carry. Real scope-member transfers use the runtime's
+//! separate authority-cycle path. The wasm shell and native golden harness
 //! both drive this type, so their transaction semantics cannot drift.
 
 use pilotage_input::ProfileLayer;
@@ -80,20 +81,19 @@ impl ControlCoordinator {
 
     /// Re-opens the activation transaction for the CURRENT mapping without
     /// changing it — the seam a scope handover (e.g. entering direct
-    /// flight) uses to get the same neutral fencing, lease cycle, and
-    /// revision advance a mapping change gets. Returns false before the
-    /// first activation.
+    /// flight) uses to get neutral fencing, a fresh motion generation, and a
+    /// revision advance. Returns false before the first activation.
     pub fn reactivate(&mut self) -> bool {
         self.runtime.reactivate()
     }
 
     /// Resolves a `Gamepad.id` through the layered registry and, when the
     /// EFFECTIVE mapping changes, swaps it transactionally: the runtime
-    /// re-opens its activation handover (neutral output, lease cycle,
+    /// re-opens its activation handover (neutral output, retained leases,
     /// revision advance) and the new map installs only when that handover
-    /// completes — a deflected input on the new pad cannot drive the
-    /// existing lease for even one tick. An unchanged resolution only
-    /// re-seeds the discrete edge baselines.
+    /// completes — a deflected input on the new pad cannot drive live output
+    /// until the installed map itself reads neutral. An unchanged resolution
+    /// only re-seeds the discrete edge baselines.
     pub fn select_device(&mut self, gamepad_id: &str) -> SelectOutcome {
         self.last_pad_id = gamepad_id.to_owned();
         let (candidate, outcome) = self.stage.resolve_pad(gamepad_id);
@@ -115,8 +115,8 @@ impl ControlCoordinator {
     /// The selected pad is gone (disconnect, or a physical replacement's
     /// disconnect half): control returns to the keyboard TRANSACTIONALLY —
     /// the switch changes what physical input means, so it takes the same
-    /// neutral handover, lease cycle, revision advance, and re-announcement
-    /// a pad selection takes.
+    /// neutral handover, retained authority, revision advance, and
+    /// re-announcement a pad selection takes.
     pub fn deselect_device(&mut self) {
         self.last_pad_id = String::new();
         if self.active_source == InputSource::Keyboard && self.stage.pad_digest().is_none() {
@@ -132,7 +132,7 @@ impl ControlCoordinator {
     /// Opens the swap transaction (or applies it immediately before the
     /// first scheme activation, when there is no authority to fence).
     fn swap(&mut self, incoming: PendingSwap) {
-        if self.runtime.reactivate() {
+        if self.runtime.reactivate_mapping() {
             // A second swap opening before the first installs merges into
             // it: the transaction boundary applies the LATEST resolution of
             // every part.
@@ -189,9 +189,9 @@ impl ControlCoordinator {
 
     /// Evaluates one control tick, and lands any pending device swap the
     /// moment the runtime's handover completes (the activation revision
-    /// advances): motion output is still gated behind the motion-lease
-    /// reacquisition at that point, so the remapped pad never publishes on
-    /// the old authority.
+    /// advances): motion output remains gated until the newly installed map
+    /// itself reads neutral, so an incoming-map deflection that the outgoing
+    /// map could not see never publishes.
     pub fn evaluate(&mut self, sample: &RawSample, session: &SessionState) -> ControlPlan {
         let plan = self.runtime.evaluate(sample, session);
         if self.runtime.activation_revision() != self.seen_revision {

--- a/clients/web-control/src/coordinator/tests.rs
+++ b/clients/web-control/src/coordinator/tests.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 //! The transactional device-swap discipline (INPUT-01): a selection that
-//! changes the effective mapping cycles authority through the runtime's
+//! changes the effective mapping retains authority through the runtime's
 //! neutral handover and installs only at the boundary, so a deflected input
-//! on the new pad can never drive the old lease.
+//! on the new pad can never drive the live session.
 
 use super::ControlCoordinator;
 use pilotage_input::ProfileLayer;
@@ -72,10 +72,8 @@ fn a_device_change_swaps_transactionally_and_gates_the_deflection() {
     let deflected = pad_sample(&coordinator, &[0.0, -1.0, 0.0, 0.0], &[]);
     let plan = coordinator.evaluate(&deflected, &session(true, true));
     assert_eq!(throttle(&plan), Some(0.0), "the handover emits neutral");
-    assert!(
-        plan.motion_lease.is_some(),
-        "the handover cycles the motion lease"
-    );
+    assert_eq!(plan.motion_lease, None, "the motion lease stays held");
+    assert_eq!(plan.lease, None, "the gimbal lease stays held");
     assert_eq!(
         coordinator.activation_revision(),
         1,
@@ -83,19 +81,24 @@ fn a_device_change_swaps_transactionally_and_gates_the_deflection() {
     );
 
     // Only a genuine neutral completes the handover; the new map installs
-    // and the activation revision advances, while motion output is still
-    // gated behind the lease reacquisition.
+    // and the activation revision advances. The installed mapping must then
+    // supply its own neutral proof before live output resumes.
     let neutral = pad_sample(&coordinator, &[0.0; 4], &[]);
     coordinator.evaluate(&neutral, &session(true, true));
     assert_eq!(coordinator.activation_revision(), 2, "install advances");
     assert_eq!(coordinator.device_label(), "Sony DualSense");
     let deflected = pad_sample(&coordinator, &[0.0, -1.0, 0.0, 0.0], &[]);
-    let plan = coordinator.evaluate(&deflected, &session(false, false));
+    let plan = coordinator.evaluate(&deflected, &session(true, true));
     assert_eq!(
         throttle(&plan),
         None,
-        "the new map cannot drive until the lease is regranted"
+        "the installed map cannot drive before its neutral proof"
     );
+    assert_eq!(plan.motion_lease, None, "authority remains held");
+    let proof = coordinator.evaluate(&neutral, &session(true, true));
+    assert_eq!(throttle(&proof), Some(0.0));
+    let resumed = coordinator.evaluate(&deflected, &session(true, true));
+    assert_eq!(throttle(&resumed), Some(1.0), "live resumes in place");
 }
 
 #[test]
@@ -189,6 +192,55 @@ fn a_layer_override_takes_the_transactional_path() {
         coordinator.stage().keyboard_digest(),
         keyboard_digest_before
     );
+}
+
+#[test]
+fn an_incoming_map_deflection_must_center_before_it_can_publish() {
+    let mut coordinator = with_scheme();
+    coordinator.select_device("");
+    let neutral = pad_sample(&coordinator, &[0.0; 5], &[]);
+    coordinator.evaluate(&neutral, &session(true, true));
+    coordinator.evaluate(&neutral, &session(true, true));
+
+    // Physical axis 4 is irrelevant under the outgoing map, but the incoming
+    // map routes it to the scheme's throttle slot.
+    let override_json = br#"{
+      "schema_version": 1,
+      "revision": 6,
+      "device": { "vendor_id": 0, "product_id": 0, "product": "Shifted Throttle" },
+      "axes": [
+        { "source_index": 4, "logical": "slot1", "invert": false, "deadzone": 0.0, "expo": 0.0,
+          "calibration": { "min": -1.0, "center": 0.0, "max": 1.0 } }
+      ],
+      "buttons": [],
+      "keys": []
+    }"#;
+    assert!(coordinator.add_device_profile(ProfileLayer::Session, override_json));
+
+    let hidden_deflection = pad_sample(&coordinator, &[0.0, 0.0, 0.0, 0.0, -1.0], &[]);
+    let installed = coordinator.evaluate(&hidden_deflection, &session(true, true));
+    assert_eq!(
+        throttle(&installed),
+        None,
+        "the install tick emits no frames (announcement head start)"
+    );
+    assert_eq!(coordinator.activation_revision(), 3);
+    assert_eq!(installed.motion_lease, None);
+
+    let visible_deflection = pad_sample(&coordinator, &[0.0, 0.0, 0.0, 0.0, -1.0], &[]);
+    let gated = coordinator.evaluate(&visible_deflection, &session(true, true));
+    assert_eq!(
+        throttle(&gated),
+        None,
+        "the incoming map exposes deflection"
+    );
+    assert_eq!(gated.motion_lease, None, "the lease was never cycled");
+
+    let centered = pad_sample(&coordinator, &[0.0; 5], &[]);
+    let proof = coordinator.evaluate(&centered, &session(true, true));
+    assert_eq!(throttle(&proof), Some(0.0));
+    let resumed = coordinator.evaluate(&visible_deflection, &session(true, true));
+    assert!(throttle(&resumed).is_some(), "live resumes after neutral");
 }
 
 #[test]

--- a/clients/web-control/src/plan.rs
+++ b/clients/web-control/src/plan.rs
@@ -102,11 +102,8 @@ pub struct ControlPlan {
     pub gimbal: Option<Frame>,
     /// A gimbal-lease request or release, when the plan calls for one.
     pub lease: Option<LeaseAction>,
-    /// A motion-lease request or release from the post-handover reacquisition.
-    /// A live scheme swap fences the motion generation, so the runtime releases
-    /// the lease, waits for the release to register, then re-requests — and
-    /// gates all motion output (`motion` stays `None`) until the host regrants
-    /// on a fresh generation, so the new mapping never rides the old authority.
+    /// A motion-lease request or release from a scope-member transfer. A
+    /// same-scope mapping activation retains the lease and emits no action.
     pub motion_lease: Option<LeaseAction>,
     /// A human-readable scheme label for the DOM readout (never control).
     pub label: Option<&'static str>,
@@ -148,9 +145,9 @@ pub struct ActivationPlan {
     /// part of the handover.
     pub emit_neutral: bool,
     /// Whether the shell must release the gimbal lease as part of the
-    /// handover (it is reacquired through normal lease planning on resume).
+    /// handover. Same-scope activations leave this false.
     pub release_gimbal_lease: bool,
-    /// Whether the shell must also release the motion lease for the handover,
-    /// because the candidate remaps flight (reacquired on resume).
+    /// Whether the shell must release motion for a real scope-member transfer.
+    /// Same-scope mapping changes leave this false.
     pub release_motion_lease: bool,
 }

--- a/clients/web-control/src/runtime.rs
+++ b/clients/web-control/src/runtime.rs
@@ -9,19 +9,20 @@
 //! itself only accepts a [`CompiledProfile`]; invalid bytes never get here.
 
 use crate::flight::{Capture, flight_axes, shaped_stick};
-use crate::plan::{ActivationPlan, ControlPlan, Frame, LeaseAction};
+use crate::plan::{ControlPlan, Frame, LeaseAction};
 use crate::profile::CompiledProfile;
 use crate::quasimode::{
     LeasePlan, frame_plan, gimbal_demand, lease_plan, modifier_held, reset_edge, reset_held,
 };
 use crate::sample::{RawSample, SessionState};
 
+mod activation;
 mod authority;
-use authority::{MOTION_LEASE_RETRY_MS, MotionOutput, MotionPhase};
+use authority::{MotionOutput, MotionPhase};
 
 /// Sentinel making the first lease request fire immediately (before any real
 /// `now_ms`), rather than waiting out a debounce window from time zero.
-const NEVER_REQUESTED_MS: f64 = f64::NEG_INFINITY;
+pub(super) const NEVER_REQUESTED_MS: f64 = f64::NEG_INFINITY;
 
 /// The stateful web-control runtime. Construct it, then activate a compiled
 /// profile before evaluating ticks.
@@ -35,11 +36,9 @@ pub struct ControlRuntime {
     last_request_ms: f64,
     prev_arm: bool,
     prev_disarm: bool,
-    // Where the motion lease sits after a profile switch. A live scheme swap
-    // remaps flight, so the handover fences the motion generation and the
-    // runtime reacquires it — gating all motion output until the host regrants
-    // on a fresh generation, so the new mapping never publishes on the old
-    // authority.
+    // Where the motion lease sits during a real scope-member transfer. A
+    // same-scope mapping activation retains authority and uses
+    // `mapping_neutral_pending` instead.
     motion_phase: MotionPhase,
     // When the last motion release/request was emitted, so a dropped lease
     // write is retried rather than wedging the reacquisition.
@@ -55,6 +54,14 @@ pub struct ControlRuntime {
     // fresh arm/disarm/recenter. Unlike a generation change this does NOT
     // touch the motion-authority phase — a terminal denial stays terminal.
     reseed_edges: bool,
+    // A same-scope activation retains its lease, but live output stays gated
+    // until one neutral tick has been evaluated through the installed mapping.
+    // This covers a non-standard incoming device map whose deflection is not
+    // visible through the outgoing map used to decide the install boundary.
+    mapping_neutral_pending: bool,
+    // A pending activation releases motion only for a real scope-member
+    // transfer. Mapping and scheme changes remain on the held generation.
+    handover_releases_motion: bool,
 }
 
 impl ControlRuntime {
@@ -111,67 +118,6 @@ impl ControlRuntime {
             .map_or([0u8; 32], CompiledProfile::digest)
     }
 
-    /// Begins activating a compiled profile. With no profile yet, installs it
-    /// immediately. Otherwise opens a transaction: the current profile stays
-    /// active while the shell emits neutral and releases the gimbal lease, and
-    /// the candidate installs on the first tick that finds the captured
-    /// controls neutral. Edge and quasimode state is cleared now, so a control
-    /// held across the handover cannot fire a fresh edge on resume.
-    pub fn activate(&mut self, candidate: CompiledProfile) -> ActivationPlan {
-        self.streaming = false;
-        if self.active.is_none() {
-            self.install(candidate);
-            return ActivationPlan {
-                installed: true,
-                activation_revision: self.activation_revision,
-                emit_neutral: true,
-                release_gimbal_lease: false,
-                release_motion_lease: false,
-            };
-        }
-        self.pending = Some(candidate);
-        // A fresh handover has emitted no motion release yet: reset the retry
-        // clock so the first handover tick releases immediately instead of
-        // waiting out a window left over from earlier lease traffic.
-        self.motion_action_ms = NEVER_REQUESTED_MS;
-        ActivationPlan {
-            installed: false,
-            activation_revision: self.activation_revision,
-            emit_neutral: true,
-            release_gimbal_lease: true,
-            release_motion_lease: true,
-        }
-    }
-
-    /// Re-opens the activation transaction for the ALREADY-active scheme: a
-    /// device selection changed the effective physical mapping, and any
-    /// mapping change is a new activation (INPUT-01) — the same neutral
-    /// handover, lease cycle, and activation-revision advance a scheme
-    /// change takes. Returns false (a no-op) before the first activation:
-    /// there is no authority to fence and no revision to advance yet.
-    pub fn reactivate(&mut self) -> bool {
-        match self.active.clone() {
-            Some(active) => {
-                self.activate(active);
-                true
-            }
-            None => false,
-        }
-    }
-
-    /// Installs a candidate as the active profile and advances the activation
-    /// revision, re-seeding every edge baseline so nothing held fires.
-    fn install(&mut self, candidate: CompiledProfile) {
-        self.active = Some(candidate);
-        self.pending = None;
-        self.activation_revision = self.activation_revision.wrapping_add(1);
-        self.reset_baseline = false;
-        self.streaming = false;
-        self.last_request_ms = NEVER_REQUESTED_MS;
-        self.prev_arm = false;
-        self.prev_disarm = false;
-    }
-
     /// Evaluates one control tick. A dead session emits nothing; a pending
     /// activation emits the neutral handover until captured controls are
     /// neutral; otherwise the active profile drives flight and the gimbal
@@ -216,6 +162,10 @@ impl ControlRuntime {
         if self.last_generation == Some(session.generation) {
             return;
         }
+        // Only a generation CHANGE is a reconnect; the first observation is
+        // ordinary startup and must not void a transfer opened before the
+        // first tick.
+        let reconnect = self.last_generation.is_some();
         self.last_generation = Some(session.generation);
         self.reset_baseline = reset_held(sample, &active.gimbal);
         self.prev_arm = sample.pressed(usize::from(active.flight.arm_button));
@@ -223,83 +173,15 @@ impl ControlRuntime {
         self.streaming = false;
         // A fresh session re-establishes motion authority through bootstrap, so
         // any mid-handover or terminal-denied motion phase from the previous
-        // connection is void.
+        // connection is void. A scope transfer interrupted by the reconnect is
+        // moot too (bootstrap re-leases the boot scope), so a still-pending
+        // install completes as a mapping change on the held bootstrap
+        // authority instead of releasing the fresh session's lease.
         self.motion_phase = MotionPhase::Held;
-    }
-
-    /// Emits the neutral handover, and installs the pending profile once the
-    /// captured controls (the modifier and the gimbal sticks) read neutral, so
-    /// behavior changes only after a genuine neutral transition.
-    ///
-    /// Each scope's release — and its neutral frame — is emitted only while
-    /// the session still shows that lease granted. Once the release is
-    /// reflected the scope has no holder: another release would draw a
-    /// `released: false` acknowledgement and any frame a NoHolder rejection,
-    /// each raising a host warning, at tick rate for as long as the operator
-    /// stays deflected. The motion release re-emits after
-    /// [`MOTION_LEASE_RETRY_MS`] without the session reflecting it (a lost
-    /// write must not wedge the handover); the shell drops the gimbal grant
-    /// the moment it executes that release, which bounds it to one emission,
-    /// and the host's holder-silence watchdog covers a lost gimbal release.
-    fn evaluate_handover(
-        &mut self,
-        sample: &RawSample,
-        session: &SessionState,
-        active: &CompiledProfile,
-    ) -> ControlPlan {
-        let release_motion = session.motion_granted
-            && session.now_ms - self.motion_action_ms >= MOTION_LEASE_RETRY_MS;
-        if release_motion {
-            self.motion_action_ms = session.now_ms;
+        if reconnect {
+            self.handover_releases_motion = false;
+            self.mapping_neutral_pending = false;
         }
-        // Neutral must hold across the UNION of the active AND candidate
-        // controls: a profile swap remaps flight and gimbal inputs, so any
-        // input deflected under EITHER profile could jump meaning at install.
-        let union_neutral = controls_neutral(sample, active)
-            && self
-                .pending
-                .as_ref()
-                .is_some_and(|candidate| controls_neutral(sample, candidate));
-        if let Some(candidate) = union_neutral.then(|| self.pending.take()).flatten() {
-            self.reset_baseline = reset_held(sample, &candidate.gimbal);
-            self.prev_arm = sample.pressed(usize::from(candidate.flight.arm_button));
-            self.prev_disarm = sample.pressed(usize::from(candidate.flight.disarm_button));
-            self.install_after_seed(candidate, session.now_ms);
-        }
-        ControlPlan {
-            // The neutrals keep each still-held scope's liveness until its
-            // release lands, then stop: no frame rides a released lease.
-            motion: session.motion_granted.then(neutral_motion),
-            gimbal: session.lease_granted.then(neutral_gimbal),
-            lease: session.lease_granted.then_some(LeaseAction::Release),
-            // The scheme remaps flight too, so the motion lease is cycled with
-            // the gimbal lease and reacquired on resume.
-            motion_lease: release_motion.then_some(LeaseAction::Release),
-            label: None,
-            arm: false,
-            disarm: false,
-            // The handover computes no edges (baselines re-seed at install so a
-            // held control cannot fire on resume), so there is nothing to
-            // suppress-report either.
-            arm_suppressed: false,
-            disarm_suppressed: false,
-            capture_active: false,
-        }
-    }
-
-    /// Installs after the edge baselines have been seeded to the current held
-    /// state (so a held control does not fire), without re-clearing them. Opens
-    /// the motion-lease reacquisition: the handover released the motion lease,
-    /// so the runtime gates motion output until it is regranted on a fresh
-    /// generation.
-    fn install_after_seed(&mut self, candidate: CompiledProfile, now_ms: f64) {
-        self.active = Some(candidate);
-        self.pending = None;
-        self.activation_revision = self.activation_revision.wrapping_add(1);
-        self.streaming = false;
-        self.last_request_ms = NEVER_REQUESTED_MS;
-        self.motion_phase = MotionPhase::Releasing;
-        self.motion_action_ms = now_ms;
     }
 
     /// The normal tick: flight motion (masked while LT is held), the gimbal
@@ -336,7 +218,9 @@ impl ControlRuntime {
 
         let outcome = self.motion_frame(sample, session, active, captured);
         let lease = self.lease_action(session);
-        let (motion_lease, output) = self.advance_motion_authority(sample, session, active);
+        let (motion_lease, authority_output) =
+            self.advance_motion_authority(sample, session, active);
+        let output = self.apply_mapping_neutral_gate(sample, active, authority_output);
         // Live output only under a held, granted lease; the recovery path emits
         // explicit neutral activation frames instead, and everything else gates.
         // Arm/disarm fire only when live (their baselines still advance while
@@ -361,6 +245,39 @@ impl ControlRuntime {
             arm_suppressed: !live && outcome.arm,
             disarm_suppressed: !live && outcome.disarm,
             capture_active: captured,
+        }
+    }
+
+    /// Holds a same-scope activation behind the installed mapping's own
+    /// neutral sample: a deflection visible only through the incoming map
+    /// must center once before anything publishes. Authority is never
+    /// released on this path, so this is client-side hygiene, not host
+    /// recovery — the single neutral emitted on satisfaction is a
+    /// conservative first frame under the advanced revision, not a recovery
+    /// proof. A gated authority cannot satisfy the gate: its tick publishes
+    /// nothing, so nothing has demonstrated the centered state downstream.
+    fn apply_mapping_neutral_gate(
+        &mut self,
+        sample: &RawSample,
+        active: &CompiledProfile,
+        authority_output: MotionOutput,
+    ) -> MotionOutput {
+        if !self.mapping_neutral_pending {
+            return authority_output;
+        }
+        if !controls_neutral(sample, active) {
+            return MotionOutput::Gated;
+        }
+        match authority_output {
+            MotionOutput::Gated => MotionOutput::Gated,
+            MotionOutput::Neutral => {
+                self.mapping_neutral_pending = false;
+                MotionOutput::Neutral
+            }
+            MotionOutput::Live => {
+                self.mapping_neutral_pending = false;
+                MotionOutput::Neutral
+            }
         }
     }
 

--- a/clients/web-control/src/runtime/activation.rs
+++ b/clients/web-control/src/runtime/activation.rs
@@ -1,0 +1,165 @@
+//! Profile activation and neutral handover transactions.
+
+use super::authority::{MOTION_LEASE_RETRY_MS, MotionPhase};
+use super::{ControlRuntime, NEVER_REQUESTED_MS, controls_neutral, neutral_gimbal, neutral_motion};
+use crate::plan::{ActivationPlan, ControlPlan, LeaseAction};
+use crate::profile::CompiledProfile;
+use crate::quasimode::reset_held;
+use crate::sample::{RawSample, SessionState};
+
+impl ControlRuntime {
+    /// Begins a same-scope profile activation. Existing authority stays held.
+    pub fn activate(&mut self, candidate: CompiledProfile) -> ActivationPlan {
+        self.begin_activation(candidate, false)
+    }
+
+    /// Re-opens activation for a device map while retaining both leases.
+    pub fn reactivate_mapping(&mut self) -> bool {
+        self.reactivate_active(false)
+    }
+
+    /// Re-opens activation for a motion scope-member transfer.
+    pub fn reactivate(&mut self) -> bool {
+        self.reactivate_active(true)
+    }
+
+    fn reactivate_active(&mut self, releases_motion: bool) -> bool {
+        match self.active.clone() {
+            Some(active) => {
+                self.begin_activation(active, releases_motion);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn begin_activation(
+        &mut self,
+        candidate: CompiledProfile,
+        releases_motion: bool,
+    ) -> ActivationPlan {
+        self.streaming = false;
+        if self.active.is_none() {
+            self.install(candidate);
+            return ActivationPlan {
+                installed: true,
+                activation_revision: self.activation_revision,
+                emit_neutral: true,
+                release_gimbal_lease: false,
+                release_motion_lease: false,
+            };
+        }
+        let transaction_open = self.pending.is_some();
+        self.pending = Some(candidate);
+        self.handover_releases_motion = if transaction_open {
+            self.handover_releases_motion || releases_motion
+        } else {
+            releases_motion
+        };
+        if releases_motion {
+            // A scope transfer has emitted no motion release yet.
+            self.motion_action_ms = NEVER_REQUESTED_MS;
+        }
+        ActivationPlan {
+            installed: false,
+            activation_revision: self.activation_revision,
+            emit_neutral: true,
+            release_gimbal_lease: false,
+            release_motion_lease: releases_motion,
+        }
+    }
+
+    /// Installs the first profile and initializes its edge baselines.
+    fn install(&mut self, candidate: CompiledProfile) {
+        self.active = Some(candidate);
+        self.pending = None;
+        self.activation_revision = self.activation_revision.wrapping_add(1);
+        self.reset_baseline = false;
+        self.streaming = false;
+        self.last_request_ms = NEVER_REQUESTED_MS;
+        self.prev_arm = false;
+        self.prev_disarm = false;
+        self.mapping_neutral_pending = false;
+        self.handover_releases_motion = false;
+    }
+
+    /// Emits neutral until every control used by either profile is centered:
+    /// a swap remaps flight and gimbal inputs, so any input deflected under
+    /// EITHER profile could jump meaning at install. On the transfer path the
+    /// motion release is emitted only while the session still shows the lease
+    /// granted, and re-emitted on [`MOTION_LEASE_RETRY_MS`] — a lost write
+    /// must not wedge the handover, while a release per tick would draw a
+    /// `released: false` acknowledgement (a host warning) for as long as the
+    /// operator stays deflected.
+    pub(super) fn evaluate_handover(
+        &mut self,
+        sample: &RawSample,
+        session: &SessionState,
+        active: &CompiledProfile,
+    ) -> ControlPlan {
+        let releases_motion = self.handover_releases_motion;
+        let release_motion = releases_motion
+            && session.motion_granted
+            && session.now_ms - self.motion_action_ms >= MOTION_LEASE_RETRY_MS;
+        if release_motion {
+            self.motion_action_ms = session.now_ms;
+        }
+        let union_neutral = controls_neutral(sample, active)
+            && self
+                .pending
+                .as_ref()
+                .is_some_and(|candidate| controls_neutral(sample, candidate));
+        let installed = match union_neutral.then(|| self.pending.take()).flatten() {
+            Some(candidate) => {
+                self.reset_baseline = reset_held(sample, &candidate.gimbal);
+                self.prev_arm = sample.pressed(usize::from(candidate.flight.arm_button));
+                self.prev_disarm = sample.pressed(usize::from(candidate.flight.disarm_button));
+                self.install_after_seed(candidate, session.now_ms, releases_motion);
+                true
+            }
+            None => false,
+        };
+        ControlPlan {
+            // The install tick emits NO frames: the activation revision just
+            // advanced, frames are datagrams, and a datagram under the new
+            // revision could beat the shell's reliable-stream re-announcement
+            // to the host (a ProfileMismatch rejection). One silent tick gives
+            // the announcement a head start the liveness watchdog comfortably
+            // tolerates. On the transfer path everything after this tick is
+            // gated behind the regrant, which the ordered stream necessarily
+            // delivers after the announcement.
+            motion: (!installed && session.motion_granted).then(neutral_motion),
+            gimbal: (!installed && session.lease_granted).then(neutral_gimbal),
+            lease: None,
+            motion_lease: release_motion.then_some(LeaseAction::Release),
+            label: None,
+            arm: false,
+            disarm: false,
+            arm_suppressed: false,
+            disarm_suppressed: false,
+            capture_active: false,
+        }
+    }
+
+    fn install_after_seed(
+        &mut self,
+        candidate: CompiledProfile,
+        now_ms: f64,
+        releases_motion: bool,
+    ) {
+        self.active = Some(candidate);
+        self.pending = None;
+        self.activation_revision = self.activation_revision.wrapping_add(1);
+        self.streaming = false;
+        self.last_request_ms = NEVER_REQUESTED_MS;
+        self.handover_releases_motion = false;
+        if releases_motion {
+            self.motion_phase = MotionPhase::Releasing;
+            self.motion_action_ms = now_ms;
+        } else {
+            // The incoming physical map may expose deflection the outgoing map
+            // could not observe at the installation boundary.
+            self.mapping_neutral_pending = true;
+        }
+    }
+}

--- a/clients/web-control/src/runtime/authority.rs
+++ b/clients/web-control/src/runtime/authority.rs
@@ -1,4 +1,4 @@
-//! The motion-lease reacquisition state machine. On a live profile switch the
+//! The motion-lease reacquisition state machine. On a scope-member transfer the
 //! runtime fences the motion generation and recovers only through a neutral
 //! activation burst, so the host clears its link-loss brake before a live
 //! command resumes and nothing publishes on the released generation.
@@ -9,8 +9,8 @@ use crate::sample::{RawSample, SessionState};
 
 use super::{ControlRuntime, controls_neutral};
 
-/// The motion lease's position in the reacquisition handshake after a profile
-/// switch. Steady flight sits in [`MotionPhase::Held`]; a handover walks
+/// The motion lease's position in the reacquisition handshake after a scope
+/// transfer. Steady flight sits in [`MotionPhase::Held`]; a handover walks
 /// `Held → Releasing → Reacquiring → Neutralizing → Held`, gating live motion
 /// output the whole way and recovering only through a neutral activation burst
 /// so the host clears its link-loss brake before a live command resumes.
@@ -55,7 +55,7 @@ pub(super) enum MotionOutput {
 pub(super) const MOTION_LEASE_RETRY_MS: f64 = 250.0;
 
 impl ControlRuntime {
-    /// Advances the motion-lease reacquisition after a profile handover and
+    /// Advances motion-lease reacquisition after a scope-member transfer and
     /// returns any lease action to emit plus what to do with motion output. The
     /// full handshake is
     /// `release → (session reflects release) → request → (fresh grant) →

--- a/clients/web-control/src/runtime/tests.rs
+++ b/clients/web-control/src/runtime/tests.rs
@@ -169,7 +169,8 @@ fn a_second_profile_takes_effect_only_after_a_neutral_transaction() {
         !activation.installed,
         "handover deferred while controls held"
     );
-    assert!(activation.release_gimbal_lease);
+    assert!(!activation.release_gimbal_lease);
+    assert!(!activation.release_motion_lease);
 
     // While controls stay held the runtime emits ONLY the neutral handover —
     // neither the old rates nor the new binding takes effect.
@@ -179,7 +180,11 @@ fn a_second_profile_takes_effect_only_after_a_neutral_transaction() {
         0.0,
         "output is neutral mid-handover"
     );
-    assert_eq!(during.lease, Some(LeaseAction::Release));
+    assert_eq!(during.lease, None, "same-scope activation retains gimbal");
+    assert_eq!(
+        during.motion_lease, None,
+        "same-scope activation retains motion"
+    );
     assert_eq!(runtime.activation_revision(), 1, "not installed yet");
 
     // Release everything: the captured controls are neutral, so the candidate
@@ -335,9 +340,8 @@ fn a_profile_swap_waits_for_the_candidate_controls_to_be_neutral_too() {
         "the candidate's own control held blocks install"
     );
     assert_eq!(
-        during.motion_lease,
-        Some(LeaseAction::Release),
-        "the motion lease is cycled too"
+        during.motion_lease, None,
+        "same-scope activation retains the motion lease"
     );
 
     // Release: the union of both profiles' controls is neutral, so it installs.

--- a/clients/web-control/src/runtime/tests/motion.rs
+++ b/clients/web-control/src/runtime/tests/motion.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-//! Motion-lease reacquisition after a live profile switch. The runtime fences
+//! Motion-lease reacquisition after a live scope-member transfer. The runtime fences
 //! the motion generation, gates live output through the whole handshake, and
 //! recovers ONLY once the operator's controls read neutral AND the host
 //! confirms it cleared the vehicle's link-loss latch — so a remapped scheme
 //! never publishes on the released generation and never resumes on the hope a
 //! best-effort datagram arrived. A denied reacquire is terminal.
 
-use super::{SECOND_PROFILE, sample, session, with_default};
+use super::{SECOND_PROFILE, sample, session, session_gen, with_default};
 use crate::plan::LeaseAction;
 use crate::profile::ProfileRuntime;
 use crate::sample::{Mode, RawSample, SessionState};
@@ -63,6 +63,78 @@ fn is_neutral_motion(plan: &crate::plan::ControlPlan) -> bool {
 }
 
 #[test]
+fn a_same_scope_activation_retains_authority_and_requires_installed_neutral() {
+    let mut runtime = with_default();
+    let candidate = ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles");
+    let activation = runtime.activate(candidate);
+    assert!(!activation.release_motion_lease);
+    assert!(!activation.release_gimbal_lease);
+
+    let pending = runtime.evaluate(&deflected(), &session(Mode::QuadPilot, true));
+    assert!(is_neutral_motion(&pending));
+    assert_eq!(pending.motion_lease, None);
+    assert_eq!(pending.lease, None);
+    assert_eq!(runtime.activation_revision(), 1);
+
+    let installed = runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
+    assert!(
+        installed.motion.is_none() && installed.gimbal.is_none(),
+        "the install tick emits no frames: the re-announcement must reach \
+         the host before any datagram carries the advanced revision"
+    );
+    assert_eq!(runtime.activation_revision(), 2);
+    assert_eq!(installed.motion_lease, None);
+    assert_eq!(installed.lease, None);
+
+    let gated = runtime.evaluate(&deflected(), &session(Mode::QuadPilot, true));
+    assert!(
+        gated.motion.is_none(),
+        "the installed mapping must read neutral"
+    );
+    assert_eq!(gated.motion_lease, None, "authority remains held");
+
+    let proof = runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
+    assert!(is_neutral_motion(&proof), "neutral proof reaches the host");
+    let resumed = runtime.evaluate(&deflected(), &session(Mode::QuadPilot, true));
+    assert!(resumed.motion.is_some());
+    assert!(!is_neutral_motion(&resumed));
+}
+
+#[test]
+fn a_fresh_session_voids_a_pending_transfer_release() {
+    let mut runtime = with_default();
+    // Steady flight on generation 1, then a scope transfer opens — but the
+    // transport dies before its release lands. Bootstrap re-leases the boot
+    // scope, so the transfer is moot: the reconnect must not release the
+    // fresh session's lease on its behalf.
+    runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
+    assert!(runtime.reactivate());
+
+    let installed = runtime.evaluate(&neutral(), &session_gen(2, Mode::QuadPilot, true));
+    assert_eq!(
+        installed.motion_lease, None,
+        "no release rides the fresh session"
+    );
+    assert_eq!(
+        runtime.activation_revision(),
+        2,
+        "the pending install completes as a mapping change"
+    );
+
+    let proof = runtime.evaluate(&neutral(), &session_gen(2, Mode::QuadPilot, true));
+    assert!(
+        is_neutral_motion(&proof),
+        "one conservative neutral follows the install"
+    );
+    let live = runtime.evaluate(&deflected(), &session_gen(2, Mode::QuadPilot, true));
+    assert!(
+        live.motion.is_some() && !is_neutral_motion(&live),
+        "live resumes on the held bootstrap authority"
+    );
+    assert_eq!(live.motion_lease, None, "the lease was never cycled");
+}
+
+#[test]
 fn a_live_switch_recovers_only_when_the_host_confirms() {
     let mut runtime = with_default();
     // Steady flight publishes the live stick.
@@ -75,7 +147,7 @@ fn a_live_switch_recovers_only_when_the_host_confirms() {
     );
 
     // Handover installs with controls neutral, releasing the motion lease.
-    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    assert!(runtime.reactivate());
     let install = runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
     assert_eq!(runtime.activation_revision(), 2, "neutral controls install");
     assert_eq!(install.motion_lease, Some(LeaseAction::Release));
@@ -135,7 +207,7 @@ fn a_live_switch_recovers_only_when_the_host_confirms() {
 #[test]
 fn a_denied_motion_reacquire_is_terminal() {
     let mut runtime = with_default();
-    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    assert!(runtime.reactivate());
     // Install (Releasing) at t=1000, then the release lands → request at t=1010.
     runtime.evaluate(&neutral(), &session_at(1000.0, Mode::QuadPilot, true, true));
     let req = runtime.evaluate(
@@ -161,7 +233,7 @@ fn a_denied_motion_reacquire_is_terminal() {
 #[test]
 fn a_dropped_motion_reacquire_request_is_retried() {
     let mut runtime = with_default();
-    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    assert!(runtime.reactivate());
     // Install at t=1000 (motion still granted): the runtime enters Releasing.
     runtime.evaluate(&neutral(), &session_at(1000.0, Mode::QuadPilot, true, true));
     // Release lands at t=1010: the request is emitted and the clock recorded.
@@ -193,18 +265,18 @@ fn a_dropped_motion_reacquire_request_is_retried() {
 }
 
 #[test]
-fn a_deflected_handover_waits_in_silence_once_the_releases_land() {
+fn a_deflected_scope_transfer_waits_after_the_motion_release_lands() {
     let mut runtime = with_default();
-    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    assert!(runtime.reactivate());
 
-    // First handover tick, both leases still granted: one release per scope,
-    // with the neutrals still streaming liveness under the held generation.
+    // A motion member transfer releases only that scope. Gimbal authority is
+    // independent and keeps its neutral liveness stream.
     let first = runtime.evaluate(
         &deflected(),
         &session_at(1000.0, Mode::QuadPilot, true, true),
     );
     assert_eq!(first.motion_lease, Some(LeaseAction::Release));
-    assert_eq!(first.lease, Some(LeaseAction::Release));
+    assert_eq!(first.lease, None);
     assert!(first.motion.is_some() && first.gimbal.is_some());
 
     // Next tick, acknowledgements still in flight (grants unchanged): the
@@ -215,18 +287,17 @@ fn a_deflected_handover_waits_in_silence_once_the_releases_land() {
     );
     assert_eq!(inflight.motion_lease, None, "no duplicate release per tick");
 
-    // Both releases reflected, operator still deflected: the handover waits
-    // in SILENCE — a release now would draw `released: false` and a frame a
-    // NoHolder rejection, each a host warning, every tick until neutral.
+    // Once the motion release is reflected, motion waits silently while the
+    // independent gimbal scope continues its neutral stream.
     for now_ms in [1066.0, 1100.0, 2000.0, 30_000.0] {
         let waiting = runtime.evaluate(
             &deflected(),
-            &session_at(now_ms, Mode::QuadPilot, false, false),
+            &session_at(now_ms, Mode::QuadPilot, true, false),
         );
         assert_eq!(waiting.motion_lease, None, "no release without a grant");
-        assert_eq!(waiting.lease, None, "no gimbal release without a grant");
+        assert_eq!(waiting.lease, None, "gimbal authority is retained");
         assert!(waiting.motion.is_none(), "no frame rides a released lease");
-        assert!(waiting.gimbal.is_none(), "no frame rides a released lease");
+        assert!(waiting.gimbal.is_some(), "gimbal liveness remains neutral");
     }
     assert_eq!(
         runtime.activation_revision(),
@@ -238,7 +309,7 @@ fn a_deflected_handover_waits_in_silence_once_the_releases_land() {
 #[test]
 fn a_lost_handover_release_is_retried_on_the_window_not_per_tick() {
     let mut runtime = with_default();
-    runtime.activate(ProfileRuntime::compile(SECOND_PROFILE.as_bytes()).expect("compiles"));
+    assert!(runtime.reactivate());
     let first = runtime.evaluate(
         &deflected(),
         &session_at(1000.0, Mode::QuadPilot, true, true),

--- a/clients/web-control/src/wasm.rs
+++ b/clients/web-control/src/wasm.rs
@@ -106,8 +106,8 @@ impl WebControl {
     }
 
     /// Re-opens the activation transaction for the current mapping (neutral
-    /// handover, gimbal + motion lease cycle, revision advance on install)
-    /// without changing it — the shell's seam for a motion-scope handover.
+    /// handover, motion authority cycle, revision advance on install) without
+    /// changing it — the shell's seam for a motion-scope-member handover.
     /// Returns false before the first activation.
     pub fn reactivate(&mut self) -> bool {
         self.coordinator.reactivate()
@@ -173,10 +173,9 @@ impl WebControl {
     /// fallback, `0` when refused (an ambiguous layer fails closed:
     /// subsequent pad ticks read an empty sample and drive nothing). A
     /// selection that changes the effective mapping swaps TRANSACTIONALLY:
-    /// the runtime cycles the gimbal + motion leases through a neutral
-    /// handover, the map installs only when the handover completes, and the
-    /// activation revision advances — so the shell re-announces and a
-    /// deflected input on the new pad can never drive the old authority.
+    /// the runtime retains both leases through a neutral handover, the map
+    /// installs only when the handover completes, and the activation revision
+    /// advances. Live output resumes only after the installed map reads neutral.
     pub fn select_device(&mut self, gamepad_id: &str) -> u32 {
         match self.coordinator.select_device(gamepad_id) {
             SelectOutcome::Refused => 0,

--- a/clients/web/control-shell.js
+++ b/clients/web/control-shell.js
@@ -114,8 +114,8 @@ export class ControlShell {
   }
 
   /** Re-opens the activation transaction for the CURRENT mapping — neutral
-   *  handover, gimbal + motion lease cycle, revision advance on install —
-   *  without changing it. The seam a motion-scope handover (entering or
+   *  handover, motion authority cycle, revision advance on install — without
+   *  changing it. The seam a motion-scope-member handover (entering or
    *  leaving direct flight) uses so sticks are neutral-fenced across the
    *  switch. Returns false before the first activation. */
   reactivate() {

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -1447,10 +1447,12 @@ async function runControlLoop(writer, token) {
         state.pendingReset = false;
         requestSimReset();
       }
-      // A completed device-swap handover advances the activation revision;
-      // the re-announcement must ride the reliable stream before the swap's
-      // lease reacquisition (queued below via plan.motionLease) so frames
-      // never carry an unannounced revision.
+      // A completed activation handover advances the revision; the
+      // re-announcement must reach the host before any frame carries it.
+      // The runtime emits no frames on the install tick (frames are
+      // datagrams and could beat this ordered-stream write), and a
+      // transfer's lease reacquisition is queued below, after this write,
+      // on the same ordered stream.
       maybeAnnounceProfileActivation();
       // Re-check the latch immediately before the write: no frame may be
       // sent under this generation once input loss latched, regardless of
@@ -1466,10 +1468,11 @@ async function runControlLoop(writer, token) {
         executeLeaseAction(token, plan.lease, GIMBAL_SCOPE);
       }
       if (plan.motionLease) {
-        // A profile switch (or scope handover) cycles the motion lease so
-        // the host fences the old flight generation before the remapped
-        // scheme runs (distinct from the input-loss release, which drives
-        // the link-loss policy).
+        // Only a scope-member transfer cycles the motion lease (the host
+        // fences the old flight generation before the new member runs);
+        // a same-scope mapping swap retains authority and emits no
+        // action. Distinct from the input-loss release, which drives the
+        // vehicle's link-loss policy.
         executeLeaseAction(token, plan.motionLease, state.motionScope);
       }
       await new Promise((resolve) => setTimeout(resolve, intervalMs));

--- a/docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
+++ b/docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: CTRL-01
 suite: input-source coordinator suite
 command: cargo test -p pilotage-control-web --lib coordinator
-config-digest: 967ed8a16d39148eeb7ea6dda426664e9404c9be
+config-digest: 8e6db14bab5ebc73fd42caea0b557cecb5878bed
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+run-id: local:8e6db14bab5ebc73fd42caea0b557cecb5878bed
 outcome: pass
 summary:
-test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out; finished in 0.00s
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s

--- a/docs/control/evidence-graph.evg
+++ b/docs/control/evidence-graph.evg
@@ -370,12 +370,12 @@ attr outcome pass
 node RESULT-CTRL-SOURCE verification-result
 title input-source coordinator suite — recorded pass
 attr command cargo test -p pilotage-control-web --lib coordinator
-attr config-digest 967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr config-digest 8e6db14bab5ebc73fd42caea0b557cecb5878bed
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:b2fb617c8e28ca4df0fd7131dae863d0680fdf8e
+attr source-digest git-blob:facd0179360009f4ef2ec926c786f8463268b5bd
 attr artifact docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
-attr output-digest sha256:acebed7c3c10d24fab98473fd97adc6ff767656b5a8efd47f671d1e14dba99a3
-attr run-id local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr output-digest sha256:1129fa37c471196c4971f6617fcf2e4699f60d187a778756d2d0b7afa6160796
+attr run-id local:8e6db14bab5ebc73fd42caea0b557cecb5878bed
 attr outcome pass
 node RESULT-CTRL-FIXTURE verification-result
 title browser-encoded wire fixture suite — recorded pass
@@ -428,6 +428,12 @@ title committed code baseline the recorded results were produced against (engine
 attr scm git
 attr commit 967ed8a16d39148eeb7ea6dda426664e9404c9be
 attr tree a5d55f59813d313df367c12e3d3fdedeffe18f4d
+
+node CFG-CTRL-SOURCE configuration-item
+title committed input-source coordinator verification baseline
+attr scm git
+attr commit 8e6db14bab5ebc73fd42caea0b557cecb5878bed
+attr tree 922a0e83b812d83912d75d217ba5f03121c1d928
 
 node TOOL-CTRL-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified
@@ -586,7 +592,7 @@ edge RESULT-CTRL-WIRE justified-by TOOL-CTRL-CARGO
 edge RESULT-CTRL-SOURCE result-of CASE-CTRL-SOURCE-BOOT
 edge RESULT-CTRL-SOURCE result-of CASE-CTRL-SWAP-GATED
 edge RESULT-CTRL-SOURCE covers INPUT-SRC-004
-edge RESULT-CTRL-SOURCE justified-by CFG-CTRL01
+edge RESULT-CTRL-SOURCE justified-by CFG-CTRL-SOURCE
 edge RESULT-CTRL-SOURCE justified-by TOOL-CTRL-CARGO
 
 edge RESULT-CTRL-FIXTURE result-of CASE-CTRL-BROWSER-FRAME


### PR DESCRIPTION
## Context

Closes #188.

Selecting a gamepad mid-session — including the first button press that exposes a connected pad to the page — cycled the `vehicle.motion` lease through the transactional activation handover. The host routes a voluntary release through the same path as involuntary link loss, so touching the pad while armed enacted the PX4 adapter's `neutralize()`: offboard stream torn down, arm sequence reset, vehicle dropped into its offboard-loss failsafe. Observed live 2026-07-22: arm accepted, pad touched ~1.1 s later, takeoff impossible for the rest of the session.

## What changed

- **Same-scope activations retain authority.** A device swap, layer override, or scheme install keeps both the motion and gimbal leases (`ControlRuntime::reactivate_mapping`, `activation.rs`). The safety property the lease cycle provided is preserved client-side: the handover still installs only at union-neutral, and a new `mapping_neutral_pending` gate holds output after install until the *installed* map itself reads neutral — a deflection visible only through the incoming map cannot publish, ever.
- **Scope-member transfers keep the full fence.** Entering/leaving direct flight still walks `Held → Releasing → Reacquiring → Neutralizing → Held` (`ControlRuntime::reactivate`), releasing and reacquiring on a fresh generation with host-confirmed link-loss recovery.
- **The install tick emits no frames.** The activation revision advances at install, frames are datagrams, and a datagram under the new revision could beat the reliable-stream re-announcement to the host (a `ProfileMismatch` rejection). One silent tick gives the announcement a head start; on the transfer path everything later is gated behind the regrant, which the ordered stream necessarily delivers after the announcement.
- **A reconnect voids a pending transfer's release.** A generation change already voided the motion phase; it now also clears the pending-transfer release flag and the mapping-neutral gate, so a transfer interrupted by a transport drop completes as a mapping change on the fresh session's bootstrap lease instead of releasing it.

## Guardrails

- `a_same_scope_activation_retains_authority_and_requires_installed_neutral` — no lease action on a same-scope activation; output gated until the installed map's own neutral.
- `an_incoming_map_deflection_must_center_before_it_can_publish` — a deflection invisible to the outgoing map cannot drive after install.
- `a_fresh_session_voids_a_pending_transfer_release` — no release rides a fresh session for a transfer the reconnect mooted.
- Install-tick silence asserted in both the unit tests and the shared golden vectors (`golden-vectors.json`), executed by the native harness and the wasm twin so the two cannot drift.
- Transfer-path release/retry/denial/recovery tests preserved and re-pointed at `reactivate()`.

Local gates on the branch in an isolated worktree: `fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test -p pilotage-control-web --all-targets` (57 passed), wasm rebuild + `control-runtime.test.mjs` + `control-structure.test.mjs`.

Live px4-gz acceptance (arm via keyboard → pick up pad → take off, no re-arm) still to be flown before merge.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)