### PR TITLE
Idle PX4 uplink becomes a typed enactment rejection, relayed reliably with needs-arm readout

### DIFF
--- a/adapters/px4/src/adapter.rs
+++ b/adapters/px4/src/adapter.rs
@@ -21,7 +21,7 @@ use pilotage_mavlink::{LinkState, MavlinkLink};
 
 use crate::config::Px4Config;
 use crate::error::Px4AdapterError;
-use crate::uplink::Px4Uplink;
+use crate::uplink::{Px4Uplink, StickFrameDisposition};
 
 mod advertisement;
 mod camera;
@@ -391,7 +391,15 @@ impl VehicleAdapter for Px4Adapter {
             };
         };
         let (sticks, constrained) = control::sticks_from_velocity(&velocity);
-        uplink.send_stick_frame(sticks[0], sticks[1], sticks[2], sticks[3]);
+        if uplink.send_stick_frame(sticks[0], sticks[1], sticks[2], sticks[3])
+            == StickFrameDisposition::UplinkIdle
+        {
+            return ApplyOutcome {
+                tick,
+                disposition: Disposition::Rejected(RejectReason::UplinkIdle),
+                action_results,
+            };
+        }
         ApplyOutcome {
             tick,
             disposition: if constrained {

--- a/adapters/px4/src/adapter/gimbal_link_loss_tests.rs
+++ b/adapters/px4/src/adapter/gimbal_link_loss_tests.rs
@@ -39,6 +39,9 @@ fn gimbal_link_loss_latches_gimbal_but_leaves_motion_flying() {
     let mut adapter = Px4Adapter::from_state(VehicleId::new(1), live_state())
         .with_uplink(uplink_to(addr))
         .with_gimbal(control);
+    adapter.uplink.as_mut().expect("uplink").begin_arm(0.0);
+    let mut initial = [0u8; 128];
+    fc.recv_from(&mut initial).expect("initial setpoint");
 
     adapter
         .set_link_loss_policy(
@@ -59,19 +62,19 @@ fn gimbal_link_loss_latches_gimbal_but_leaves_motion_flying() {
         "the gimbal latch suppresses gimbal frames"
     );
 
+    // Engaging the gimbal scope itself never sent a neutral to the FC.
+    let mut buf = [0u8; 128];
+    assert!(
+        fc.recv_from(&mut buf).is_err(),
+        "engaging the gimbal scope must not neutralize the FC"
+    );
+
     // ...but motion is untouched: a neutral flight frame still flies.
     let motion = adapter.apply_control(&neutral_flight_frame());
     assert_eq!(
         motion.disposition,
         Disposition::Accepted,
         "a gimbal failsafe must never suppress motion"
-    );
-
-    // And engaging the gimbal scope never sent a neutral to the FC.
-    let mut buf = [0u8; 128];
-    assert!(
-        fc.recv_from(&mut buf).is_err(),
-        "engaging the gimbal scope must not neutralize the FC"
     );
 }
 

--- a/adapters/px4/src/adapter/tests.rs
+++ b/adapters/px4/src/adapter/tests.rs
@@ -18,7 +18,7 @@ use pilotage_mavlink::link::apply_messages_at;
 use pilotage_mavlink::{AuthorizationSource, LinkState};
 
 use super::{ARM_BUTTON, DISARM_BUTTON, Px4Adapter, THROTTLE_AXIS};
-use crate::uplink::Px4Uplink;
+use crate::uplink::{Px4Uplink, StickFrameDisposition};
 
 pub(super) const SOURCE: FrameSource = FrameSource {
     system_id: 1,
@@ -277,16 +277,33 @@ fn disarm_stops_the_stream() {
 }
 
 #[test]
-fn sticks_are_ignored_until_an_arm_sequence_starts() {
+fn sticks_report_uplink_idle_until_an_arm_sequence_starts() {
     let (fc, addr) = fake_fc();
     let mut uplink = uplink_to(addr);
-    uplink.send_stick_frame(0.0, 0.5, 0.5, 0.0);
+    assert_eq!(
+        uplink.send_stick_frame(0.0, 0.5, 0.5, 0.0),
+        StickFrameDisposition::UplinkIdle
+    );
     fc.set_read_timeout(Some(Duration::from_millis(200)))
         .expect("timeout");
     let mut buf = [0u8; 128];
     assert!(
         fc.recv_from(&mut buf).is_err(),
         "no setpoint may leave before an explicit arm"
+    );
+}
+
+#[test]
+fn a_velocity_frame_after_neutralize_is_rejected_as_uplink_idle() {
+    let (_fc, addr) = fake_fc();
+    let mut adapter =
+        Px4Adapter::from_state(VehicleId::new(1), live_state()).with_uplink(uplink_to(addr));
+    adapter.uplink.as_mut().expect("uplink").neutralize();
+
+    let outcome = adapter.apply_control(&neutral());
+    assert_eq!(
+        outcome.disposition,
+        Disposition::Rejected(RejectReason::UplinkIdle)
     );
 }
 
@@ -411,8 +428,8 @@ fn fresh_epoch_and_neutral_input_clear_the_reset_latch() {
     let outcome = adapter.apply_control(&neutral());
     assert_eq!(
         outcome.disposition,
-        Disposition::Accepted,
-        "a full-axis neutral frame over the fresh stream clears the latch"
+        Disposition::Rejected(RejectReason::UplinkIdle),
+        "the neutral frame clears the reset latch but cannot revive an idle uplink"
     );
     let outcome = adapter.apply_control(&press(ARM_BUTTON));
     assert_eq!(

--- a/adapters/px4/src/uplink.rs
+++ b/adapters/px4/src/uplink.rs
@@ -82,6 +82,15 @@ enum ArmPhase {
     Commanded,
 }
 
+/// Whether a stick frame reached the PX4 setpoint queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StickFrameDisposition {
+    /// The frame was encoded and queued on the MAVLink uplink.
+    Queued,
+    /// No arm sequence is active, so no setpoint left the process.
+    UplinkIdle,
+}
+
 /// The UDP MAVLink command uplink to PX4's onboard instance.
 #[derive(Debug)]
 pub struct Px4Uplink {
@@ -347,12 +356,19 @@ impl Px4Uplink {
     /// Converts one canonical stick frame (`[-1, 1]` roll/pitch/
     /// throttle/yaw; pitch + = forward, roll + = right, throttle + =
     /// climb, yaw + = clockwise) into a slew-limited velocity setpoint.
-    /// Ignored while no arm sequence is active: PX4 rejects setpoints
-    /// disarmed, and streaming before an explicit arm would mask the
-    /// arm sequencing.
-    pub fn send_stick_frame(&mut self, roll: f32, pitch: f32, throttle: f32, yaw: f32) {
+    /// Reports [`StickFrameDisposition::UplinkIdle`] while no arm sequence is
+    /// active: PX4 rejects setpoints disarmed, and streaming before an
+    /// explicit arm would mask the arm sequencing.
+    #[must_use]
+    pub(crate) fn send_stick_frame(
+        &mut self,
+        roll: f32,
+        pitch: f32,
+        throttle: f32,
+        yaw: f32,
+    ) -> StickFrameDisposition {
         if self.arm_phase == ArmPhase::Idle {
-            return;
+            return StickFrameDisposition::UplinkIdle;
         }
         let now = self.clock.now();
         let dt = self
@@ -378,6 +394,7 @@ impl Px4Uplink {
             *out = current + (target - current).clamp(-dv_max, dv_max);
         }
         self.send_velocity(slewed);
+        StickFrameDisposition::Queued
     }
 
     fn send_velocity(&mut self, vel_ned_mps: [f32; 3]) {

--- a/clients/web/control-enactment.js
+++ b/clients/web/control-enactment.js
@@ -1,0 +1,33 @@
+import { CONTROL_ACTION } from "./wire.js";
+
+/** Wire reason assigned to an admitted frame refused by an idle uplink. */
+export const FRAME_REJECTION_UPLINK_IDLE = 18;
+
+/** Advances the client latch that distinguishes authority from enactment. */
+export function updateNeedsArm(current, event) {
+  if (event.kind === "FrameRejected" && event.reason === FRAME_REJECTION_UPLINK_IDLE) {
+    return true;
+  }
+  if (
+    event.kind === "ControlActionResult" &&
+    event.action === CONTROL_ACTION.arm &&
+    event.accepted
+  ) {
+    return false;
+  }
+  if (
+    event.kind === "ControlActionResult" &&
+    event.action === CONTROL_ACTION.disarm &&
+    event.accepted
+  ) {
+    return true;
+  }
+  return current;
+}
+
+/** Labels whether motion is gated, recovering, waiting for arm, or enacted. */
+export function motionReadoutState(plan, { motionRecovered, needsArm }) {
+  if (needsArm) return "needs arm";
+  if (!plan.motion) return "gated";
+  return motionRecovered ? "streaming" : "recovering";
+}

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -82,6 +82,11 @@ import { startDatagramControl } from "./datagram-control.js";
 import { loadControlShell } from "./control-shell.js";
 import { advanceMotionLease, applyMotionRecovery } from "./motion-lease.js";
 import {
+  FRAME_REJECTION_UPLINK_IDLE,
+  motionReadoutState,
+  updateNeedsArm,
+} from "./control-enactment.js";
+import {
   INTENT_FAMILY_VELOCITY,
   INTENT_FAMILY_ATTITUDE_THRUST,
   INTENT_FAMILY_GIMBAL_RATE,
@@ -199,6 +204,10 @@ const state = {
   // datagram. Irrelevant in steady flight; reset false when a release starts a
   // new recovery cycle.
   motionRecovered: true,
+  // Session authority is not enactment truth: an adapter rejection latches
+  // this until the reliable accepted Arm result proves the uplink restarted.
+  motionNeedsArm: false,
+  lastFrameRejectionLogged: null,
   // The gimbal scope's own lease/fencing state: independent generation and
   // sequence, granted (or not) without affecting flight control.
   gimbalGeneration: 0n,
@@ -492,6 +501,8 @@ async function openTransportSession({ url, certHash, certHashHex, manual, leaseP
     state.motionFence = 0n;
     state.motionDenied = false;
     state.motionRecovered = true;
+    state.motionNeedsArm = false;
+    state.lastFrameRejectionLogged = null;
     state.gimbalGeneration = 0n;
     state.gimbalSequence = 0;
     state.gimbalLeaseGranted = false;
@@ -752,6 +763,9 @@ async function runSessionStreamReader(reader, token) {
       pending = pending.subarray(decoded.consumed);
       if (decoded.kind === "ControlActionResult") {
         handleActionResult(decoded.message);
+      }
+      if (decoded.kind === "FrameRejected") {
+        handleFrameRejected(decoded.message);
       }
       if (decoded.kind === "LeaseReleased") {
         // Validate the acknowledgement before it settles anything: an
@@ -1207,6 +1221,65 @@ async function renderVideoFrameV2(body, token) {
   await paintByCodec(fourcc, payload, meta.sourceId, target, token);
 }
 
+/** Applies ingress or adapter rejection truth without repeating one latched
+ *  condition at control-frame cadence. */
+function handleFrameRejected(r) {
+  const key = `${r.reason}:${r.scope}:${r.currentGeneration}`;
+  const firstNotice = key !== state.lastFrameRejectionLogged;
+  if (firstNotice) {
+    state.lastFrameRejectionLogged = key;
+    log(
+      `control frame rejected (reason ${r.reason}) scope=${r.scope} ` +
+        `seq=${r.sequence} hostGen=${r.currentGeneration}`,
+    );
+  }
+  if (
+    r.reason === FRAME_REJECTION_UPLINK_IDLE &&
+    motionGroup(r.scope) === motionGroup(state.motionScope)
+  ) {
+    state.motionNeedsArm = updateNeedsArm(state.motionNeedsArm, {
+      kind: "FrameRejected",
+      reason: r.reason,
+    });
+    if (firstNotice) {
+      els.overlay.textContent = "motion uplink idle — press arm to start control";
+      log("motion authority is granted but the vehicle uplink needs arm");
+    }
+  }
+  if (
+    (r.reason === 1 || r.reason === 2) &&
+    r.scope === GIMBAL_SCOPE &&
+    state.gimbalLeaseGranted
+  ) {
+    state.gimbalLeaseGranted = false;
+    log("host fenced our gimbal authority; the lease planner will re-request");
+  }
+  if (
+    (r.reason === 1 || r.reason === 2) &&
+    motionGroup(r.scope) === motionGroup(state.motionScope) &&
+    state.leaseGranted
+  ) {
+    state.leaseGranted = false;
+    state.motionRecovered = false;
+    if (r.currentGeneration !== undefined) {
+      state.motionFence = BigInt(r.currentGeneration);
+    }
+    const nowMs = performance.now();
+    if (nowMs - (state.lastAuthorityReacquireMs ?? 0) > 500) {
+      state.lastAuthorityReacquireMs = nowMs;
+      const writer = state.sessionWriter;
+      if (writer) {
+        const request = encodeLeaseRequestEnvelope({
+          vehicleId: VEHICLE_ID,
+          scope: state.motionScope,
+        });
+        writer.write(lengthDelimit(request)).catch(() => {});
+        log("host fenced our motion authority; reacquiring the lease");
+      }
+    }
+  }
+}
+
 /** Reads telemetry-fast datagrams (bare Envelope, TelemetrySample arm) forever, updating the pose overlay. */
 async function readTelemetryDatagrams(transport, token) {
   if (!transportSessions.isActive(token)) return;
@@ -1239,52 +1312,7 @@ async function readTelemetryDatagrams(transport, token) {
       } else if (decoded.kind === "Pong") {
         // RTT probing is out of scope for this demo viewer; ignored.
       } else if (decoded.kind === "FrameRejected") {
-        const r = decoded.message;
-        log(
-          `control frame rejected (reason ${r.reason}) scope=${r.scope} ` +
-            `seq=${r.sequence} hostGen=${r.currentGeneration}`,
-        );
-        // A fenced rejection on the GIMBAL scope while we think we hold it:
-        // the host revoked (e.g. the silence watchdog during a stall). Drop
-        // the local grant so the quasimode's lease planner re-requests,
-        // instead of streaming rejected frames forever.
-        if (
-          (r.reason === 1 || r.reason === 2) &&
-          r.scope === GIMBAL_SCOPE &&
-          state.gimbalLeaseGranted
-        ) {
-          state.gimbalLeaseGranted = false;
-          log("host fenced our gimbal authority; the lease planner will re-request");
-        }
-        // Reasons 1 (stale generation) and 2 (no holder) on the motion
-        // group while we believe we hold it mean the host fenced us out —
-        // typically the silence watchdog revoked during a stall. Drop the
-        // local grant and re-request (debounced), instead of streaming
-        // rejected frames forever.
-        if (
-          (r.reason === 1 || r.reason === 2) &&
-          motionGroup(r.scope) === motionGroup(state.motionScope) &&
-          state.leaseGranted
-        ) {
-          state.leaseGranted = false;
-          state.motionRecovered = false;
-          if (r.currentGeneration !== undefined) {
-            state.motionFence = BigInt(r.currentGeneration);
-          }
-          const nowMs = performance.now();
-          if (nowMs - (state.lastAuthorityReacquireMs ?? 0) > 500) {
-            state.lastAuthorityReacquireMs = nowMs;
-            const writer = state.sessionWriter;
-            if (writer) {
-              const request = encodeLeaseRequestEnvelope({
-                vehicleId: VEHICLE_ID,
-                scope: state.motionScope,
-              });
-              writer.write(lengthDelimit(request)).catch(() => {});
-              log("host fenced our motion authority; reacquiring the lease");
-            }
-          }
-        }
+        handleFrameRejected(decoded.message);
       }
     }
   } finally {
@@ -1556,6 +1584,19 @@ function handleActionResult(m) {
   if (!m.actionId) return;
   const entry = resolveAction(state.actionTracker, m.actionId);
   if (!entry) return; // a replay of an already-settled press
+  if (motionGroup(entry.scope) === motionGroup(state.motionScope)) {
+    const wasNeedsArm = state.motionNeedsArm;
+    state.motionNeedsArm = updateNeedsArm(state.motionNeedsArm, {
+      kind: "ControlActionResult",
+      action: entry.action,
+      accepted: m.accepted,
+    });
+    if (wasNeedsArm && !state.motionNeedsArm) {
+      state.lastFrameRejectionLogged = null;
+      els.overlay.textContent = "arm sequence accepted — motion uplink active";
+      log("accepted arm result restored motion enactment");
+    }
+  }
   if (entry.scope === SIM_LIFECYCLE_SCOPE) {
     // The lifecycle lease exists only for this press: release it so the
     // silence watchdog never has a held-but-frameless scope to revoke.
@@ -1809,16 +1850,12 @@ function updateControlReadout(pad, mode, plan) {
     return;
   }
   const m = plan.motion ?? { roll: 0, pitch: 0, throttle: 0, yaw: 0 };
-  // Three honest states: "gated" (no frames — presses are suppressed),
-  // "recovering" (neutral recovery frames flow but live authority has not
-  // been confirmed, so presses are still suppressed), "streaming" (live).
-  // The distinction keeps the pre-press indicator from overstating
-  // authority during the post-revocation neutral-activation burst.
-  const motionState = !plan.motion
-    ? "gated"
-    : state.motionRecovered
-      ? "streaming"
-      : "recovering";
+  // Authority and enactment are separate: an idle adapter uplink stays
+  // "needs arm" even while the lease is held and frames leave the browser.
+  const motionState = motionReadoutState(plan, {
+    motionRecovered: state.motionRecovered,
+    needsArm: state.motionNeedsArm,
+  });
   els.gamepad.textContent =
     `flight [${mode}]: ${src} | roll=${m.roll.toFixed(2)} pitch=${m.pitch.toFixed(2)} ` +
     `climb=${m.throttle.toFixed(2)} yaw=${m.yaw.toFixed(2)} | motion: ${motionState} | ` +

--- a/clients/web/motion-lease.test.mjs
+++ b/clients/web/motion-lease.test.mjs
@@ -4,6 +4,12 @@
 // generation wraparound enforced off the wire.
 
 import { initialMotionLease, advanceMotionLease, isFreshGeneration } from "./motion-lease.js";
+import {
+  FRAME_REJECTION_UPLINK_IDLE,
+  motionReadoutState,
+  updateNeedsArm,
+} from "./control-enactment.js";
+import { CONTROL_ACTION } from "./wire.js";
 
 let failures = 0;
 function check(name, ok) {
@@ -69,6 +75,47 @@ check("denial persists through a later grant", grantAfterDenial.denied === true)
 // An unrelated message kind leaves the state unchanged.
 const unchanged = advanceMotionLease(afterGrant, { kind: "Pong", message: {} });
 check("an unrelated message is a no-op", unchanged === afterGrant);
+
+// Lease and recovery are authority truth, not adapter enactment truth. An
+// idle-uplink rejection latches the readout until an accepted ARM result.
+const livePlan = { motion: { roll: 0, pitch: 0, throttle: 0, yaw: 0 } };
+let needsArm = updateNeedsArm(false, {
+  kind: "FrameRejected",
+  reason: FRAME_REJECTION_UPLINK_IDLE,
+});
+check("uplink idle latches needs-arm", needsArm === true);
+check(
+  "lease plus recovery cannot overstate enactment",
+  motionReadoutState(livePlan, { motionRecovered: true, needsArm }) === "needs arm",
+);
+needsArm = updateNeedsArm(needsArm, {
+  kind: "ControlActionResult",
+  action: CONTROL_ACTION.arm,
+  accepted: false,
+});
+check("a refused arm cannot clear needs-arm", needsArm === true);
+needsArm = updateNeedsArm(needsArm, {
+  kind: "ControlActionResult",
+  action: CONTROL_ACTION.modeRequest,
+  accepted: true,
+});
+check("an unrelated result cannot clear needs-arm", needsArm === true);
+needsArm = updateNeedsArm(needsArm, {
+  kind: "ControlActionResult",
+  action: CONTROL_ACTION.arm,
+  accepted: true,
+});
+check("accepted arm restores enacted state", needsArm === false);
+check(
+  "the readout returns to streaming on the positive signal",
+  motionReadoutState(livePlan, { motionRecovered: true, needsArm }) === "streaming",
+);
+needsArm = updateNeedsArm(needsArm, {
+  kind: "ControlActionResult",
+  action: CONTROL_ACTION.disarm,
+  accepted: true,
+});
+check("accepted disarm retires enacted state", needsArm === true);
 
 if (failures > 0) {
   console.error(`${failures} failure(s)`);

--- a/crates/pilotage-adapter-api/src/control.rs
+++ b/crates/pilotage-adapter-api/src/control.rs
@@ -68,6 +68,10 @@ pub enum RejectReason {
     /// FC while its estimator is unconverged. Disarm is exempt:
     /// surrendering authority is never blocked.
     ResetInProgress,
+    /// The vehicle uplink has no active command sequence, so the frame could
+    /// not be queued even though session authority admitted it. The operator
+    /// must explicitly arm to begin the enacted stream.
+    UplinkIdle,
     /// The adapter rejected the frame for a reason not covered above.
     Other(String),
 }

--- a/crates/pilotage-protocol/src/session.rs
+++ b/crates/pilotage-protocol/src/session.rs
@@ -160,8 +160,8 @@ pub struct Pong {
     pub responder_sent_at: MonoTimestamp,
 }
 
-/// Why the host rejected an inbound control frame without applying it
-/// (ADR-0009 rejection rules, CTRL-01 typed-command validation).
+/// Why an admitted control frame was not enacted at ingress or at the
+/// vehicle-adapter boundary (ADR-0009, CTRL-01).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameRejectionReason {
     /// The frame's generation is older than the scope's current
@@ -215,10 +215,16 @@ pub enum FrameRejectionReason {
     /// the structurally total translation would turn "no update" into an
     /// explicit neutral, so partial legacy coverage is rejected.
     PartialCommand,
+    /// The adapter rejected the frame for a reason without a more specific
+    /// wire representation.
+    AdapterRejected,
+    /// The vehicle uplink has no active command sequence. Authority remains
+    /// held, but the operator must arm before frames enact.
+    UplinkIdle,
 }
 
-/// Sent back to a control frame's sender (never broadcast) when the frame
-/// is well-formed but not honored (ADR-0009, ADR-0012).
+/// Sent back to a control frame's sender (never broadcast) when the frame is
+/// well-formed but not honored at ingress or enactment (ADR-0009, ADR-0012).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrameRejected {
     /// Vehicle the rejected frame targeted.

--- a/crates/pilotage-protocol/src/session_convert/rejection.rs
+++ b/crates/pilotage-protocol/src/session_convert/rejection.rs
@@ -31,6 +31,8 @@ impl From<FrameRejectionReason> for wire::FrameRejectionReason {
             FrameRejectionReason::SessionMismatch => wire::FrameRejectionReason::SessionMismatch,
             FrameRejectionReason::StaleSequence => wire::FrameRejectionReason::StaleSequence,
             FrameRejectionReason::LegacyDisabled => wire::FrameRejectionReason::LegacyDisabled,
+            FrameRejectionReason::AdapterRejected => wire::FrameRejectionReason::AdapterRejected,
+            FrameRejectionReason::UplinkIdle => wire::FrameRejectionReason::UplinkIdle,
         }
     }
 }
@@ -70,6 +72,10 @@ impl TryFrom<wire::FrameRejectionReason> for FrameRejectionReason {
             }
             wire::FrameRejectionReason::StaleSequence => Ok(FrameRejectionReason::StaleSequence),
             wire::FrameRejectionReason::LegacyDisabled => Ok(FrameRejectionReason::LegacyDisabled),
+            wire::FrameRejectionReason::AdapterRejected => {
+                Ok(FrameRejectionReason::AdapterRejected)
+            }
+            wire::FrameRejectionReason::UplinkIdle => Ok(FrameRejectionReason::UplinkIdle),
             wire::FrameRejectionReason::Unspecified => Err(ConvertError::UnknownEnum {
                 enum_name: "pilotage.v1.FrameRejectionReason",
                 value: reason as i32,

--- a/crates/pilotage-protocol/src/session_convert/tests.rs
+++ b/crates/pilotage-protocol/src/session_convert/tests.rs
@@ -243,7 +243,7 @@ fn sample_frame_rejected() -> FrameRejected {
         vehicle: VehicleId::new(1),
         scope: ScopeId::new("vehicle.motion"),
         sequence: SequenceNum::new(7),
-        reason: FrameRejectionReason::StaleGeneration,
+        reason: FrameRejectionReason::UplinkIdle,
         current_generation: Generation::new(5),
     }
 }
@@ -403,6 +403,8 @@ mod proptests {
             Just(FrameRejectionReason::NoHolder),
             Just(FrameRejectionReason::UnknownScope),
             Just(FrameRejectionReason::TooOld),
+            Just(FrameRejectionReason::AdapterRejected),
+            Just(FrameRejectionReason::UplinkIdle),
         ]
     }
 

--- a/crates/pilotage-session/src/outbound.rs
+++ b/crates/pilotage-session/src/outbound.rs
@@ -8,7 +8,8 @@
 
 use pilotage_authority::AuthorityEffect;
 use pilotage_protocol::{
-    ControlActionResult, LeaseReleased, LeaseResponse, LinkLossCleared, Pong, ServerWelcome,
+    ControlActionResult, FrameRejected, LeaseReleased, LeaseResponse, LinkLossCleared, Pong,
+    ServerWelcome,
 };
 
 /// A message the engine directs at one client or at all clients.
@@ -38,6 +39,9 @@ pub enum OutboundMessage {
     /// the frame's sender on the reliable session stream after the adapter
     /// disposed of it.
     ControlActionResult(ControlActionResult),
+    /// A reliable adapter-boundary rejection returned after session ingress
+    /// admitted the frame but vehicle enactment refused it (CTRL-11).
+    FrameRejected(FrameRejected),
     /// An authority event to be serialized and observed on the ordered
     /// authority stream (ADR-0006, ADR-0012). Carried as the source
     /// [`AuthorityEffect`] so the driver performs the canonical wire mapping.

--- a/hosts/session-host/src/runtime/connection.rs
+++ b/hosts/session-host/src/runtime/connection.rs
@@ -56,9 +56,9 @@ impl DatagramClass {
 /// One message the engine actor asks a connection task to write out.
 #[derive(Debug, Clone)]
 pub enum ToConnection {
-    /// Bytes to write, length-delimited, on the bootstrap stream (unicast
-    /// handshake/lease/`Pong` replies only — never authority events,
-    /// ADR-0005's dedicated authority-events stream).
+    /// Bytes to write, length-delimited, on the reliable session stream
+    /// (handshake, lease, action, and adapter-enactment replies — never
+    /// authority events, which use ADR-0005's dedicated stream).
     BootstrapMessage(Vec<u8>),
     /// Bytes to write, length-delimited, on the dedicated authority-events
     /// stream (ADR-0005: reliable ordered, no head-of-line contention with

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -29,9 +29,11 @@ mod action_dedup;
 mod apply;
 mod drops;
 mod link_loss;
+mod rejection_dedup;
 use action_dedup::ActionDedup;
 use drops::{DropCounters, MessageClass};
 use pilotage_protocol::ScopedControlFrame;
+use rejection_dedup::RejectionDedup;
 
 /// Capacity of the [`EngineActor`]'s inbound command queue.
 ///
@@ -90,6 +92,7 @@ pub struct EngineActor<A: VehicleAdapter> {
     latency: BoundedLatencyLog<LATENCY_LOG_CAPACITY>,
     drops: DropCounters,
     action_dedup: ActionDedup,
+    adapter_rejection_dedup: RejectionDedup,
     /// Wrapping count of link-loss policy changes the adapter failed to
     /// enact. A non-zero value is a fail-closed fault, not noise: authority
     /// was already fenced, so an unenacted policy means the vehicle may
@@ -119,6 +122,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
             latency: BoundedLatencyLog::new(),
             drops: DropCounters::default(),
             action_dedup: ActionDedup::default(),
+            adapter_rejection_dedup: RejectionDedup::default(),
             link_loss_enact_failures: 0,
             start,
         }
@@ -195,6 +199,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
         if is_disconnect {
             self.clients.remove(client);
             self.action_dedup.forget(client);
+            self.adapter_rejection_dedup.forget(client);
         }
         self.enact(outcome);
     }
@@ -270,6 +275,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
                 self.send_to(client, ToConnection::Close, MessageClass::Unicast);
                 self.clients.remove(client);
                 self.action_dedup.forget(client);
+                self.adapter_rejection_dedup.forget(client);
             }
             SessionAction::ActivationAccepted { client, activation } => {
                 // The traceability record for control evidence (INPUT-01):
@@ -338,6 +344,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
             Err(TrySendError::Closed(_)) => {
                 self.clients.remove(client);
                 self.action_dedup.forget(client);
+                self.adapter_rejection_dedup.forget(client);
             }
         }
     }
@@ -352,6 +359,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
         }
         self.clients.remove(client);
         self.action_dedup.forget(client);
+        self.adapter_rejection_dedup.forget(client);
     }
 
     fn broadcast_datagram(&mut self, bytes: Vec<u8>) {
@@ -413,6 +421,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
         for client in closed {
             self.clients.remove(client);
             self.action_dedup.forget(client);
+            self.adapter_rejection_dedup.forget(client);
         }
     }
 
@@ -478,7 +487,8 @@ fn to_connection_message(envelope: &pilotage_session::OutboundMessage) -> ToConn
         pilotage_session::OutboundMessage::Welcome(_)
         | pilotage_session::OutboundMessage::LeaseResponse(_)
         | pilotage_session::OutboundMessage::LeaseReleased(_)
-        | pilotage_session::OutboundMessage::ControlActionResult(_) => {
+        | pilotage_session::OutboundMessage::ControlActionResult(_)
+        | pilotage_session::OutboundMessage::FrameRejected(_) => {
             ToConnection::BootstrapMessage(encode_envelope_message(envelope))
         }
     }

--- a/hosts/session-host/src/runtime/engine_actor/apply.rs
+++ b/hosts/session-host/src/runtime/engine_actor/apply.rs
@@ -1,7 +1,8 @@
 //! Adapter delivery for gated control frames: exactly-once execution of
 //! correlated discrete actions and the per-action result echo (CTRL-01).
 
-use pilotage_adapter_api::Disposition;
+use pilotage_adapter_api::{Disposition, RejectReason};
+use pilotage_protocol::{FrameRejected, FrameRejectionReason};
 
 use super::*;
 
@@ -15,7 +16,9 @@ impl<A: VehicleAdapter> EngineActor<A> {
     /// unavailable, reset in progress, unsupported scope) returns before
     /// per-action disposal — is answered HERE with the rejection's reason,
     /// so a press is never silently dropped and a valid command always
-    /// yields exactly one correlated result.
+    /// yields exactly one correlated result. A rejected intent-only frame
+    /// also returns a reliable frame-level notice, transition-deduplicated so
+    /// a steady refusal cannot flood the session stream.
     pub(super) fn apply_to_adapter(&mut self, client: ClientKey, mut frame: ScopedControlFrame) {
         for replay in self.action_dedup.strip_answered(client, &mut frame) {
             let envelope = pilotage_session::OutboundMessage::ControlActionResult(replay);
@@ -31,6 +34,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
         let outcome = self.adapter.apply_control(&frame);
         self.record_stage(Stage::Apply, apply_start.elapsed());
         debug!(?outcome, "control frame applied to adapter");
+        self.report_adapter_rejection(client, &frame, &outcome.disposition);
         let mut answered = vec![false; frame.actions.len()];
         for result in outcome.action_results {
             // Actions cannot repeat within a gated frame, so the action
@@ -70,6 +74,39 @@ impl<A: VehicleAdapter> EngineActor<A> {
         }
     }
 
+    fn report_adapter_rejection(
+        &mut self,
+        client: ClientKey,
+        frame: &ScopedControlFrame,
+        disposition: &Disposition,
+    ) {
+        let Disposition::Rejected(reason) = disposition else {
+            self.adapter_rejection_dedup
+                .observe_enacted(client, frame.vehicle, &frame.scope);
+            return;
+        };
+        let reason = adapter_rejection_reason(reason);
+        if !self.adapter_rejection_dedup.should_notify(
+            client,
+            frame.vehicle,
+            &frame.scope,
+            frame.generation,
+            reason,
+        ) {
+            return;
+        }
+        let rejection = FrameRejected {
+            vehicle: frame.vehicle,
+            scope: frame.scope.clone(),
+            sequence: frame.sequence,
+            reason,
+            current_generation: frame.generation,
+        };
+        let envelope = pilotage_session::OutboundMessage::FrameRejected(rejection);
+        let message = to_connection_message(&envelope);
+        self.send_to(client, message, MessageClass::Unicast);
+    }
+
     /// Sends one correlated result on the reliable stream and records it
     /// for replay dedup.
     fn answer_action(
@@ -95,5 +132,26 @@ impl<A: VehicleAdapter> EngineActor<A> {
         let envelope = pilotage_session::OutboundMessage::ControlActionResult(full);
         let message = to_connection_message(&envelope);
         self.send_to(client, message, MessageClass::Unicast);
+    }
+}
+
+/// Maps an adapter-boundary refusal to its wire reason. Exhaustive on
+/// purpose: a new [`RejectReason`] variant must decide its wire mapping here
+/// rather than silently degrading to the generic reason. `Fenced` and
+/// `LinkLossEngaged` deliberately stay generic — the wire's stale-generation
+/// and no-holder reasons make the client drop its grant and reacquire, a
+/// recovery that must only ever be driven by the SESSION's authority state,
+/// never by adapter-internal bookkeeping downstream of an admitted frame.
+fn adapter_rejection_reason(reason: &RejectReason) -> FrameRejectionReason {
+    match reason {
+        RejectReason::UnknownScope => FrameRejectionReason::UnknownScope,
+        RejectReason::UplinkIdle => FrameRejectionReason::UplinkIdle,
+        RejectReason::UnknownAxis
+        | RejectReason::UnknownVehicle
+        | RejectReason::Fenced
+        | RejectReason::MeasurementUnavailable
+        | RejectReason::LinkLossEngaged
+        | RejectReason::ResetInProgress
+        | RejectReason::Other(_) => FrameRejectionReason::AdapterRejected,
     }
 }

--- a/hosts/session-host/src/runtime/engine_actor/rejection_dedup.rs
+++ b/hosts/session-host/src/runtime/engine_actor/rejection_dedup.rs
@@ -1,0 +1,50 @@
+//! Transition deduplication for adapter-boundary frame rejections.
+
+use std::collections::BTreeMap;
+
+use pilotage_protocol::{FrameRejectionReason, Generation, ScopeId, VehicleId};
+use pilotage_session::ClientKey;
+
+type RejectionKey = (ClientKey, VehicleId, ScopeId);
+type RejectionState = (Generation, FrameRejectionReason);
+
+/// One reliable notice per adapter rejection transition and authority epoch.
+#[derive(Debug, Default)]
+pub(super) struct RejectionDedup {
+    active: BTreeMap<RejectionKey, RejectionState>,
+}
+
+impl RejectionDedup {
+    /// Records a rejection and reports whether its transition needs a notice.
+    pub(super) fn should_notify(
+        &mut self,
+        client: ClientKey,
+        vehicle: VehicleId,
+        scope: &ScopeId,
+        generation: Generation,
+        reason: FrameRejectionReason,
+    ) -> bool {
+        let key = (client, vehicle, scope.clone());
+        let state = (generation, reason);
+        if self.active.get(&key) == Some(&state) {
+            return false;
+        }
+        self.active.insert(key, state);
+        true
+    }
+
+    /// An enacted frame ends the active rejection transition for this scope.
+    pub(super) fn observe_enacted(
+        &mut self,
+        client: ClientKey,
+        vehicle: VehicleId,
+        scope: &ScopeId,
+    ) {
+        self.active.remove(&(client, vehicle, scope.clone()));
+    }
+
+    /// Drops every transition owned by a retired connection.
+    pub(super) fn forget(&mut self, client: ClientKey) {
+        self.active.retain(|(owner, _, _), _| *owner != client);
+    }
+}

--- a/hosts/session-host/src/runtime/engine_actor/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests.rs
@@ -30,6 +30,7 @@ const MOTION: &str = "vehicle.motion";
 
 // Shared fixtures live in a sibling submodule to stay under the file-size
 // gate; a child module reads this parent's imports via `use super::*`.
+mod adapter_rejections;
 mod fixtures;
 mod reliable_actions;
 use fixtures::*;

--- a/hosts/session-host/src/runtime/engine_actor/tests/adapter_rejections.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests/adapter_rejections.rs
@@ -1,0 +1,66 @@
+//! Reliable adapter-rejection delivery and transition deduplication.
+
+use super::fixtures::{actor, motion_control_frame, register_client};
+use super::*;
+
+fn drain_rejections(
+    receiver: &mut mpsc::Receiver<ToConnection>,
+) -> Vec<pilotage_protocol::FrameRejected> {
+    let mut rejections = Vec::new();
+    while let Ok(message) = receiver.try_recv() {
+        let ToConnection::BootstrapMessage(bytes) = message else {
+            continue;
+        };
+        let Ok(envelope) =
+            <pilotage_protocol::wire::Envelope as prost::Message>::decode_length_delimited(
+                bytes.as_slice(),
+            )
+        else {
+            continue;
+        };
+        if let Some(pilotage_protocol::wire::envelope::Payload::FrameRejected(rejected)) =
+            envelope.payload
+        {
+            rejections.push(
+                pilotage_protocol::FrameRejected::try_from(rejected)
+                    .expect("valid frame rejection"),
+            );
+        }
+    }
+    rejections
+}
+
+#[test]
+fn an_uplink_idle_rejection_reaches_the_sender_once_per_transition() {
+    let mut actor = actor();
+    let mut receiver = register_client(&mut actor);
+    let client = ClientKey::new(1);
+    actor.adapter.reject_control = Some(RejectReason::UplinkIdle);
+
+    actor.apply_to_adapter(client, motion_control_frame());
+    actor.apply_to_adapter(client, motion_control_frame());
+    let notices = drain_rejections(&mut receiver);
+    assert_eq!(
+        notices.len(),
+        1,
+        "a 30 Hz refusal is transition-deduplicated"
+    );
+    assert_eq!(notices[0].scope, ScopeId::new(MOTION));
+    assert_eq!(notices[0].current_generation, Generation::new(1));
+    assert_eq!(
+        notices[0].reason,
+        pilotage_protocol::FrameRejectionReason::UplinkIdle
+    );
+
+    actor.adapter.reject_control = None;
+    actor.apply_to_adapter(client, motion_control_frame());
+    actor.adapter.reject_control = Some(RejectReason::UplinkIdle);
+    let mut next = motion_control_frame();
+    next.sequence = SequenceNum::new(2);
+    actor.apply_to_adapter(client, next);
+    assert_eq!(
+        drain_rejections(&mut receiver).len(),
+        1,
+        "an enacted frame arms a fresh rejection transition"
+    );
+}

--- a/hosts/session-host/src/runtime/engine_actor/tests/fixtures.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests/fixtures.rs
@@ -51,6 +51,8 @@ pub(super) struct RecordingAdapter {
     /// Scopes whose latch is currently engaged (suppressing control).
     pub(super) latched: Vec<ScopeId>,
     pub(super) fail_enactment: bool,
+    /// Optional frame-level refusal injected before per-action disposal.
+    pub(super) reject_control: Option<RejectReason>,
     /// The discrete actions of every `apply_control` call, in call order —
     /// the exactly-once observable for the dedup tests.
     pub(super) applied_actions: Vec<Vec<pilotage_protocol::ControlAction>>,
@@ -63,7 +65,9 @@ impl VehicleAdapter for RecordingAdapter {
 
     fn apply_control(&mut self, frame: &ScopedControlFrame) -> ApplyOutcome {
         self.applied_actions.push(frame.actions.clone());
-        let disposition = if self.latched.contains(&frame.scope) {
+        let disposition = if let Some(reason) = self.reject_control.clone() {
+            Disposition::Rejected(reason)
+        } else if self.latched.contains(&frame.scope) {
             Disposition::Rejected(RejectReason::LinkLossEngaged)
         } else {
             Disposition::Accepted

--- a/hosts/session-host/src/runtime/wire_codec.rs
+++ b/hosts/session-host/src/runtime/wire_codec.rs
@@ -203,6 +203,9 @@ pub fn encode_envelope_message(message: &OutboundMessage) -> Vec<u8> {
         OutboundMessage::ControlActionResult(result) => {
             wire::envelope::Payload::ControlActionResult(result.into())
         }
+        OutboundMessage::FrameRejected(rejected) => {
+            wire::envelope::Payload::FrameRejected(rejected.into())
+        }
         OutboundMessage::Authority(effect) => {
             wire::envelope::Payload::AuthorityEvent(wire::AuthorityEvent::from(effect))
         }

--- a/schemas/pilotage/v1/session.proto
+++ b/schemas/pilotage/v1/session.proto
@@ -143,8 +143,8 @@ message Pong {
   MonoTimestamp responder_sent_at = 3;
 }
 
-// Why the host rejected an inbound `ControlFrame` without applying it
-// (ADR-0009 rejection rules).
+// Why an admitted `ControlFrame` was not enacted, either at host ingress or
+// at the vehicle-adapter boundary (ADR-0009 rejection rules).
 enum FrameRejectionReason {
   FRAME_REJECTION_REASON_UNSPECIFIED = 0;
   // The frame's `generation` is older than the scope's current generation.
@@ -197,11 +197,18 @@ enum FrameRejectionReason {
   // typed-only (the production default); legacy translation exists only
   // behind the explicit simulation compatibility mode.
   FRAME_REJECTION_REASON_LEGACY_DISABLED = 16;
+  // The adapter rejected the admitted frame for a reason without a more
+  // specific wire representation.
+  FRAME_REJECTION_REASON_ADAPTER_REJECTED = 17;
+  // The adapter's vehicle uplink has no active command sequence. Session
+  // authority remains held, but the operator must arm before frames enact.
+  FRAME_REJECTION_REASON_UPLINK_IDLE = 18;
 }
 
-// Sent back to the frame's sender (never broadcast) when a `ControlFrame`
-// is well-formed but not honored, so the client can distinguish "dropped in
-// transit" from "explicitly rejected" (ADR-0009, ADR-0012).
+// Sent back to the frame's sender (never broadcast) when a `ControlFrame` is
+// well-formed but not honored at ingress or enactment, so the client can
+// distinguish "dropped in transit" from "explicitly rejected" (ADR-0009,
+// ADR-0012).
 message FrameRejected {
   VehicleId vehicle = 1;
   ScopeId scope = 2;


### PR DESCRIPTION
## Context

Closes #189. Continuous-frame sibling of CTRL-09 (#178); composes with #193.

After any `neutralize()` (input-loss release, watchdog revocation, or — before #193 — a device swap), the PX4 uplink resets its arm sequence and `send_stick_frame` silently discarded every subsequent frame while `arm_phase` was idle. The session layer kept accepting those frames — holder valid, generation current, link-loss cleared — so the client readout reported `motion: streaming` while every stick command was thrown away in the adapter with no rejection, no log, no operator indication. Observed live 2026-07-22: ~37 s of dead sticks under a UI claiming live authority, with the FC heartbeat still reporting ARMED.

## What changed

- **Adapter: no silent-drop path.** `Px4Uplink::send_stick_frame` returns a typed `StickFrameDisposition`; an idle uplink yields `UplinkIdle` and the adapter rejects the frame (`RejectReason::UplinkIdle` → wire `FRAME_REJECTION_UPLINK_IDLE = 18`, with `ADAPTER_REJECTED = 17` as the generic adapter-boundary reason).
- **Host: reliable, deduplicated relay.** An adapter-boundary rejection is sent to the frame's sender as a `FrameRejected` on the reliable session stream — one notice per `(client, vehicle, scope)` × `(generation, reason)` transition (`rejection_dedup.rs`), re-armed by an enacted frame, forgotten on every client-removal path. A 30 Hz refusal never becomes a 30 Hz notice storm.
- **Wire-reason mapping is exhaustive** — a new `RejectReason` variant must decide its mapping at compile time. `Fenced` and `LinkLossEngaged` deliberately map to the generic reason: the stale-generation/no-holder reasons drive the client's drop-grant-and-reacquire recovery, which only the session's authority state may trigger.
- **Client: authority is not enactment.** A new `motionNeedsArm` latch (pure helpers in `control-enactment.js`) is set by an `UplinkIdle` rejection on the motion group, cleared only by an accepted Arm result, and re-latched by an accepted Disarm. The readout shows `needs arm` instead of `streaming`, with an overlay prompt on the first notice. `FrameRejected` handling is unified across the datagram and reliable paths (`handleFrameRejected`) with per-transition log dedup; frames keep streaming while needs-arm — that is what holds lease liveness.

## Guardrails

- Adapter: `sticks_report_uplink_idle_until_an_arm_sequence_starts`, `a_velocity_frame_after_neutralize_is_rejected_as_uplink_idle`; the gimbal link-loss suite additionally proves engaging the gimbal scope never neutralizes the FC with an active arm sequence.
- Host: `an_uplink_idle_rejection_reaches_the_sender_once_per_transition` — one reliable notice per transition, re-armed by an enacted frame.
- Client: needs-arm latch transitions and readout precedence in `motion-lease.test.mjs` (CI-wired).
- Protocol: round-trip conversion coverage for both new wire reasons.

No evidence-graph-bound source is modified (verified against every `locator`/`source-digest` in `docs/control/evidence-graph.evg`), so no baseline re-record is needed.

Local gates on the branch in an isolated worktree: workspace `fmt --check`; `clippy --all-targets -- -D warnings` and `cargo test --all-targets` for `pilotage-adapter-px4`, `pilotage-protocol`, `pilotage-session`, `pilotage-session-host`, `pilotage-adapter-api`; `cargo doc` clean; `motion-lease.test.mjs` + `control-structure.test.mjs`.

Live px4-gz acceptance (trigger a neutralize → observe `needs arm` → press arm → fly) still to be flown before merge.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)