### PR TITLE
CI: remove deprecated Node.js 20 action runtimes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,15 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC_SHA256: a7be2928c0454f132c599e25b79b7ad1b57663f2337d7f7e468a1d59b98ec1b0
+  PROTOC_VERSION: "26.1"
 
 jobs:
   quality-gates:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # buf breaking compares the working tree against the base ref, so the
           # base commit must be present locally; a shallow clone would hide it.
@@ -30,9 +32,16 @@ jobs:
           targets: thumbv7em-none-eabihf, wasm32-unknown-unknown
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          archive="${RUNNER_TEMP}/protoc-${PROTOC_VERSION}.zip"
+          install_dir="${RUNNER_TEMP}/protoc"
+          curl --fail --location --retry 3 --silent --show-error \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+            --output "${archive}"
+          echo "${PROTOC_SHA256}  ${archive}" | sha256sum --check --strict
+          unzip -q "${archive}" -d "${install_dir}"
+          echo "${install_dir}/bin" >> "${GITHUB_PATH}"
+          "${install_dir}/bin/protoc" --version
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Baseline membership verification resolves declared configuration
           # commits against real history; a shallow clone would make every


### PR DESCRIPTION
CI: remove deprecated Node.js 20 action runtimes

Closes #194

## Summary

- upgrade both workflow checkout steps from `actions/checkout@v4` to the Node.js 24-compatible `v7` line
- replace `arduino/setup-protoc@v3` with a pinned protoc 26.1 download verified by SHA-256
- enable weekly Dependabot updates for GitHub Actions dependencies

## Root cause

The workflows referenced action releases whose manifests declare the deprecated Node.js 20 runtime. GitHub currently forces those actions onto Node.js 24 and annotates every run; `arduino/setup-protoc` has no compatible release to upgrade to.

## Impact

CI no longer depends on GitHub's temporary Node.js 20 compatibility behavior. Protoc stays on the same 26.x release line, and its downloaded bytes are integrity-checked before installation.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS='-D missing_docs -D rustdoc::broken_intra_doc_links' cargo doc --no-deps`
- `cargo build --release`
- `bash scripts/check-structure.sh`
- parsed both workflow files and the Dependabot configuration as YAML
