### PR TITLE
Resume control on the live session after an input-loss latch

### DIFF
--- a/clients/web-control/src/runtime.rs
+++ b/clients/web-control/src/runtime.rs
@@ -177,7 +177,18 @@ impl ControlRuntime {
         // moot too (bootstrap re-leases the boot scope), so a still-pending
         // install completes as a mapping change on the held bootstrap
         // authority instead of releasing the fresh session's lease.
-        self.motion_phase = MotionPhase::Held;
+        //
+        // A generation that arrives UNRECOVERED — the host has not confirmed
+        // clearing the vehicle's link-loss latch — re-enters the
+        // neutral-activation recovery instead of publishing live: authority
+        // regained after an input-loss release must not publish a held
+        // deflection, and live output waits for the host's confirmation
+        // exactly as a scope transfer's reacquisition does.
+        self.motion_phase = if session.motion_recovered {
+            MotionPhase::Held
+        } else {
+            MotionPhase::Neutralizing
+        };
         if reconnect {
             self.handover_releases_motion = false;
             self.mapping_neutral_pending = false;

--- a/clients/web-control/src/runtime/tests/motion.rs
+++ b/clients/web-control/src/runtime/tests/motion.rs
@@ -101,6 +101,75 @@ fn a_same_scope_activation_retains_authority_and_requires_installed_neutral() {
 }
 
 #[test]
+fn an_unrecovered_fresh_generation_reenters_neutral_activation_recovery() {
+    let mut runtime = with_default();
+    runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
+    let unrecovered = SessionState {
+        motion_recovered: false,
+        ..session_gen(2, Mode::QuadPilot, true)
+    };
+
+    // The regrant after an input-loss suspension arrives on a fresh
+    // generation with the link-loss clearance still outstanding: a held
+    // deflection stays gated, never published.
+    let held = runtime.evaluate(&deflected(), &unrecovered);
+    assert!(held.motion.is_none(), "a held deflection cannot publish");
+    let centered = runtime.evaluate(&neutral(), &unrecovered);
+    assert!(
+        is_neutral_motion(&centered),
+        "centered controls retransmit the neutral activation"
+    );
+    let deflected_again = runtime.evaluate(&deflected(), &unrecovered);
+    assert!(
+        deflected_again.motion.is_none(),
+        "re-deflecting mid-recovery gates again"
+    );
+
+    // Host confirmation: one final neutral, then live publishes.
+    let confirmed = runtime.evaluate(&deflected(), &session_gen(2, Mode::QuadPilot, true));
+    assert!(
+        is_neutral_motion(&confirmed),
+        "confirmation completes with one final neutral"
+    );
+    let live = runtime.evaluate(&deflected(), &session_gen(2, Mode::QuadPilot, true));
+    assert!(
+        live.motion.is_some() && !is_neutral_motion(&live),
+        "live output resumes only after the host confirmed"
+    );
+}
+
+#[test]
+fn a_button_pressed_while_suspended_fires_no_edge_on_the_fresh_generation() {
+    let mut runtime = with_default();
+    runtime.evaluate(&neutral(), &session(Mode::QuadPilot, true));
+
+    // The arm button (9) went down while control was suspended (no ticks).
+    // The fresh generation's first tick seeds the baseline from the held
+    // state, so the press cannot fire; recovery gates it regardless.
+    let arm_held = sample(&[0.0; 4], &[9]);
+    let unrecovered = SessionState {
+        motion_recovered: false,
+        ..session_gen(2, Mode::QuadPilot, true)
+    };
+    let primed = runtime.evaluate(&arm_held, &unrecovered);
+    assert!(
+        !primed.arm,
+        "a press held across the suspension fires no edge"
+    );
+    assert!(
+        !primed.arm_suppressed,
+        "a seeded baseline is not a suppression"
+    );
+
+    // Released and pressed again after the host confirmed: a genuine edge.
+    runtime.evaluate(&neutral(), &unrecovered);
+    runtime.evaluate(&neutral(), &session_gen(2, Mode::QuadPilot, true));
+    runtime.evaluate(&neutral(), &session_gen(2, Mode::QuadPilot, true));
+    let fresh_press = runtime.evaluate(&arm_held, &session_gen(2, Mode::QuadPilot, true));
+    assert!(fresh_press.arm, "a fresh press after recovery arms");
+}
+
+#[test]
 fn a_fresh_session_voids_a_pending_transfer_release() {
     let mut runtime = with_default();
     // Steady flight on generation 1, then a scope transfer opens — but the

--- a/clients/web/connect-lifecycle.test.mjs
+++ b/clients/web/connect-lifecycle.test.mjs
@@ -1,4 +1,4 @@
-// The connect/transport lifecycle under a racing blur (CTRL-04, #147),
+// The connect/transport lifecycle under a racing blur (CTRL-04),
 // executing the PRODUCTION orchestration: `negotiateSessionAuthority` —
 // the exact module main.js runs — over the real bootstrap reader loop,
 // the real control gate, and the real release tracker. A regression in
@@ -11,6 +11,7 @@ import { negotiateSessionAuthority } from "./connect-authority.js";
 import { runBootstrapReader } from "./bootstrap.js";
 import { createControlGate } from "./control-gate.js";
 import { createReleaseTracker } from "./lease-release.js";
+import { resumeGrantDecision, resumeSessionControl } from "./resume-control.js";
 
 let failures = 0;
 function check(name, cond) {
@@ -43,6 +44,14 @@ function reader(steps) {
       return { value: Uint8Array.from(step.bytes), done: false };
     },
   };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }
 
 // Drives the PRODUCTION orchestration over the real bootstrap loop, the
@@ -185,6 +194,105 @@ async function drive({ gate, tracker, steps, controlStarts = true }) {
   });
   check("an explicit connect re-arms a stale latch", leaseRequests === 1);
   check("control starts after the re-arm", events.join(",") === "start-control");
+}
+
+// --- same-session resume waits for release and writer settlement ------------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  gate.latchInputLoss();
+  const tracker = createReleaseTracker();
+  const release = tracker.begin();
+  const stopped = deferred();
+  const liveTransport = Object.freeze({ id: "same-transport" });
+  let activeTransport = liveTransport;
+  let requests = 0;
+  let announcements = 0;
+  let surrenders = 0;
+  const resume = resumeSessionControl({
+    gate,
+    releases: tracker,
+    controlSettled: () => stopped.promise,
+    isSessionLive: () => activeTransport === liveTransport,
+    announceActivation: () => {
+      announcements += 1;
+    },
+    requestLeases: () => {
+      requests += 1;
+    },
+    surrender: () => {
+      surrenders += 1;
+    },
+  });
+  await Promise.resolve();
+  check("resume waits for the release acknowledgement", requests === 0);
+  tracker.acknowledge();
+  await release;
+  await Promise.resolve();
+  check("resume also waits for the prior datagram run", requests === 0);
+  stopped.resolve();
+  const result = await resume;
+  check("resume requests authority on the existing transport", result.requested && requests === 1);
+  check("resume re-announces before its request", announcements === 1);
+  check("clean same-session resume does not surrender", surrenders === 0);
+  check("the transport identity never changes", activeTransport === liveTransport);
+}
+
+// --- a blur during same-session release settlement aborts the request -------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  gate.latchInputLoss();
+  const tracker = createReleaseTracker();
+  const release = tracker.begin();
+  let requests = 0;
+  const resume = resumeSessionControl({
+    gate,
+    releases: tracker,
+    controlSettled: () => Promise.resolve(),
+    isSessionLive: () => true,
+    announceActivation: () => {},
+    requestLeases: () => {
+      requests += 1;
+    },
+    surrender: () => {},
+  });
+  queueMicrotask(() => {
+    gate.latchInputLoss();
+    tracker.acknowledge();
+  });
+  await release;
+  const result = await resume;
+  check("a blur during release settlement leaves the gate latched", gate.isLatched());
+  check("a raced blur sends no same-session request", !result.requested && requests === 0);
+}
+
+// --- a blur after the request surrenders any raced grant --------------------
+{
+  const gate = createControlGate({ isFocused: () => true });
+  gate.latchInputLoss();
+  const tracker = createReleaseTracker();
+  let surrenders = 0;
+  const result = await resumeSessionControl({
+    gate,
+    releases: tracker,
+    controlSettled: () => Promise.resolve(),
+    isSessionLive: () => true,
+    announceActivation: () => {},
+    requestLeases: () => gate.latchInputLoss(),
+    surrender: () => {
+      surrenders += 1;
+    },
+  });
+  check("a post-request blur is detected", result.requested && result.interrupted);
+  check("the interrupted request is surrendered", surrenders === 1);
+  check(
+    "a raced grant cannot start control",
+    resumeGrantDecision({
+      pending: true,
+      granted: true,
+      sessionLive: true,
+      mayPublish: gate.mayPublish(),
+    }) === "surrender",
+  );
 }
 
 if (failures > 0) {

--- a/clients/web/control-gate.js
+++ b/clients/web/control-gate.js
@@ -1,12 +1,12 @@
-// The input-loss gate for the control loop (CTRL-04, #147).
+// The input-loss gate for the control loop.
 //
 // Focus loss must be LATCHED by the blur event itself, not polled by the
 // 30 Hz loop: a blur/refocus that fits entirely between two ticks — or a
 // blur that fires while the loop is parked on an await — is invisible to a
 // poll, so the loop would keep publishing on the same lease with freshly
 // cleared arm-edge state (a still-held arm button would read as a new
-// rising edge). Once latched, no frame may be sent under that generation;
-// only an explicit new connect (a fresh lease) resets the gate.
+// rising edge). Once latched, no frame may be sent until an explicit connect
+// or same-session resume begins a fresh authority attempt.
 
 /**
  * @param {{ isFocused: () => boolean }} deps live focus probe, kept as a
@@ -31,7 +31,7 @@ export function createControlGate({ isFocused }) {
     mayPublish() {
       return !latched && isFocused();
     },
-    /** A fresh explicit connect (new lease/generation) re-arms the gate. */
+    /** An explicit connect or resume re-arms the gate before its first await. */
     reset() {
       latched = false;
     },

--- a/clients/web/control-runtime.test.mjs
+++ b/clients/web/control-runtime.test.mjs
@@ -163,6 +163,78 @@ for (const group of vectors.groups) {
   });
 }
 
+// Same-session resume rides the authority-recovery contract: the regrant's
+// fresh generation gates a held deflection, retransmits neutral once
+// centered, and goes live only after the host confirms link-loss clearance.
+// Every negative check has a positive control on the SAME key, so a dud key
+// name cannot make the suite pass vacuously.
+{
+  const shell = await loadControlShell(wasmBytes);
+  const deflects = (motion) =>
+    motion !== null && Object.values(motion).some((value) => value !== 0);
+  const isNeutral = (motion) =>
+    motion !== null && Object.values(motion).every((value) => value === 0);
+  const live = toSession({ mode: "quad-pilot", generation: 1, motionRecovered: true });
+  shell.tickFromKeys(live);
+  shell.keyEvent("ArrowUp", true);
+  check(
+    "same-session resume: the bound key deflects while live (positive control)",
+    deflects(shell.tickFromKeys(live).motion),
+  );
+
+  const suspended = toSession({
+    mode: "quad-pilot",
+    generation: 1,
+    motionGranted: false,
+    motionRecovered: false,
+  });
+  check("same-session resume: suspension gates motion", shell.tickFromKeys(suspended).motion === null);
+  // The arm key goes down while control is suspended (no ticks run).
+  shell.keyEvent("Enter", true);
+
+  const regranted = toSession({
+    mode: "quad-pilot",
+    generation: 2,
+    motionRecovered: false,
+  });
+  const primed = shell.tickFromKeys(regranted);
+  check(
+    "same-session resume: a held deflection cannot publish on regrant",
+    primed.motion === null,
+    primed.motion,
+  );
+  check(
+    "same-session resume: an arm pressed while suspended fires no edge",
+    primed.arm === false,
+  );
+  shell.clearKeys();
+  check(
+    "same-session resume: centered controls retransmit the neutral activation",
+    isNeutral(shell.tickFromKeys(regranted).motion),
+  );
+  shell.keyEvent("ArrowUp", true);
+  check(
+    "same-session resume: re-deflecting mid-recovery gates again",
+    shell.tickFromKeys(regranted).motion === null,
+  );
+
+  const confirmed = toSession({ mode: "quad-pilot", generation: 2, motionRecovered: true });
+  check(
+    "same-session resume: confirmation completes with one final neutral",
+    isNeutral(shell.tickFromKeys(confirmed).motion),
+  );
+  check(
+    "same-session resume: live resumes after confirmation (positive control)",
+    deflects(shell.tickFromKeys(confirmed).motion),
+  );
+  shell.keyEvent("Enter", false);
+  shell.keyEvent("Enter", true);
+  check(
+    "same-session resume: a fresh arm press after recovery arms (positive control)",
+    shell.tickFromKeys(confirmed).arm === true,
+  );
+}
+
 if (failures > 0) {
   console.error(`${failures} failure(s)`);
   process.exit(1);

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -65,6 +65,13 @@ require("imports the control shell", /from "\.\/control-shell\.js"/);
 require("evaluates one tick through the runtime", /tickFromPad|tickFromKeys/);
 require("resolves pad identity through the runtime selector", /selectDevice/);
 require("forwards key transitions to the runtime", /keyEvent/);
+// A same-session resume must hand the runtime a FRESH session generation
+// before its loop restarts: the generation prime is what re-seeds the
+// discrete edge baselines and re-enters neutral-activation recovery.
+require(
+  "advances the control generation before a resumed loop starts",
+  /function completePendingResume[\s\S]*?controlGeneration \+ 1[\s\S]*?startControlLoop/,
+);
 
 if (failures > 0) {
   console.error(`${failures} structural violation(s)`);

--- a/clients/web/datagram-control.js
+++ b/clients/web/datagram-control.js
@@ -17,6 +17,43 @@ export function acquireDatagramWriter(datagrams) {
   }
 }
 
+function releaseWriterLock(writer) {
+  try {
+    writer.releaseLock();
+  } catch {
+    // Session teardown may have invalidated the writer before the run ended.
+  }
+}
+
+/** Interrupts one pending backpressure wait without closing the send stream. */
+export function createDatagramRunStop() {
+  let stopped = false;
+  let wake = null;
+  return {
+    stop() {
+      stopped = true;
+      wake?.(false);
+    },
+    waitFor(writerReady) {
+      if (stopped) return Promise.resolve(false);
+      return new Promise((resolve) => {
+        let settled = false;
+        const finish = (ready) => {
+          if (settled) return;
+          settled = true;
+          wake = null;
+          resolve(ready);
+        };
+        wake = finish;
+        Promise.resolve(writerReady).then(
+          () => finish(true),
+          () => finish(false),
+        );
+      });
+    },
+  };
+}
+
 /**
  * Acquires and registers one control writer, then runs it under the session
  * lifecycle so replacement or teardown aborts the writer before authority can
@@ -27,6 +64,7 @@ export function startDatagramControl({ datagrams, lifecycle, token, run, onError
   if (!acquired.ok) return acquired;
   const { writer } = acquired;
   if (!lifecycle.trackWriter(token, writer)) {
+    releaseWriterLock(writer);
     return { ok: false, reason: "inactive-session" };
   }
   const completion = Promise.resolve()
@@ -34,6 +72,9 @@ export function startDatagramControl({ datagrams, lifecycle, token, run, onError
     .catch((error) => {
       if (lifecycle.isActive(token)) onError(error);
     })
-    .finally(() => lifecycle.untrackWriter(token, writer));
+    .finally(() => {
+      lifecycle.untrackWriter(token, writer);
+      releaseWriterLock(writer);
+    });
   return { ok: true, completion };
 }

--- a/clients/web/datagram-control.test.mjs
+++ b/clients/web/datagram-control.test.mjs
@@ -1,14 +1,22 @@
 import assert from "node:assert/strict";
 
-import { acquireDatagramWriter, startDatagramControl } from "./datagram-control.js";
+import {
+  acquireDatagramWriter,
+  createDatagramRunStop,
+  startDatagramControl,
+} from "./datagram-control.js";
 import { TransportSessionLifecycle } from "./transport-session.js";
 
 function writer() {
   return {
     abortCount: 0,
+    releaseCount: 0,
     abort() {
       this.abortCount += 1;
       return Promise.resolve();
+    },
+    releaseLock() {
+      this.releaseCount += 1;
     },
   };
 }
@@ -85,6 +93,7 @@ async function testSessionTeardownAbortsTheTrackedWriter() {
   const lifecycle = new TransportSessionLifecycle();
   const activeTransport = transport();
   const token = lifecycle.begin(activeTransport);
+  assert.equal(lifecycle.currentToken(), token);
   const activeWriter = writer();
   const running = deferred();
   let runCount = 0;
@@ -108,6 +117,82 @@ async function testSessionTeardownAbortsTheTrackedWriter() {
   running.resolve();
   await started.completion;
   assert.equal(lifecycle.isActive(token), false);
+  assert.equal(lifecycle.currentToken(), null);
+  assert.equal(activeWriter.releaseCount, 1);
+}
+
+function testInactiveSessionReleasesARefusedWriterLock() {
+  const lifecycle = new TransportSessionLifecycle();
+  const token = lifecycle.begin(transport());
+  lifecycle.close(token);
+  const refused = writer();
+  const started = startDatagramControl({
+    datagrams: { createWritable: () => ({ getWriter: () => refused }) },
+    lifecycle,
+    token,
+    run: () => assert.fail("an inactive run must not start"),
+    onError: () => assert.fail("an inactive run must not report a loop failure"),
+  });
+  assert.deepEqual(
+    { ok: started.ok, reason: started.reason },
+    { ok: false, reason: "inactive-session" },
+  );
+  assert.equal(refused.abortCount, 1);
+  assert.equal(refused.releaseCount, 1);
+}
+
+async function testCompletedRunReleasesTheWriterForSameTransportReuse() {
+  const lifecycle = new TransportSessionLifecycle();
+  const token = lifecycle.begin(transport());
+  let locked = false;
+  const writers = [];
+  const datagrams = {
+    createWritable: () => ({
+      getWriter() {
+        if (locked) throw new Error("locked");
+        locked = true;
+        const acquired = writer();
+        const releaseLock = acquired.releaseLock;
+        acquired.releaseLock = () => {
+          releaseLock.call(acquired);
+          locked = false;
+        };
+        writers.push(acquired);
+        return acquired;
+      },
+    }),
+  };
+  const first = startDatagramControl({
+    datagrams,
+    lifecycle,
+    token,
+    run: () => {},
+    onError: () => assert.fail("the first run must not fail"),
+  });
+  assert.equal(first.ok, true);
+  await first.completion;
+
+  const second = startDatagramControl({
+    datagrams,
+    lifecycle,
+    token,
+    run: () => {},
+    onError: () => assert.fail("the resumed run must not fail"),
+  });
+  assert.equal(second.ok, true);
+  await second.completion;
+  assert.equal(writers.length, 2);
+  assert.deepEqual(writers.map((item) => item.releaseCount), [1, 1]);
+}
+
+async function testInputLossInterruptsPendingBackpressureWithoutClosingStream() {
+  const stop = createDatagramRunStop();
+  const pending = deferred();
+  const ready = stop.waitFor(pending.promise);
+  stop.stop();
+  assert.equal(await ready, false);
+  assert.equal(await stop.waitFor(Promise.resolve()), false);
+  pending.resolve();
 }
 
 for (const test of [
@@ -116,6 +201,9 @@ for (const test of [
   testMissingSendStreamFailsClosed,
   testWriterAcquisitionFailuresAreTyped,
   testSessionTeardownAbortsTheTrackedWriter,
+  testInactiveSessionReleasesARefusedWriterLock,
+  testCompletedRunReleasesTheWriterForSameTransportReuse,
+  testInputLossInterruptsPendingBackpressureWithoutClosingStream,
 ]) {
   await test();
   console.log(`ok - ${test.name}`);

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -236,6 +236,7 @@
   <label>port <input id="port" placeholder="4433" /></label>
   <label>cert hash <input id="certHash" placeholder="hex from LISTENING line" /></label>
   <button id="connectBtn">Connect</button>
+  <button id="resumeBtn" hidden>Resume control</button>
   <label>controls
     <select id="flightMode">
       <option value="quad-pilot" selected>Quad — Pilot (Mode 2)</option>

--- a/clients/web/lease-release.js
+++ b/clients/web/lease-release.js
@@ -1,8 +1,8 @@
-// Tracks one in-flight explicit lease release and its acknowledgement
-// (CTRL-04, #147): the client treats authority as relinquished when the
-// host's `LeaseReleased` arrives, and an immediate reconnect waits —
-// bounded — for that settlement so a fresh `LeaseRequest` cannot race the
-// release into an `AlreadyHeld` denial. The host's silence watchdog
+// Tracks one in-flight explicit lease release and its acknowledgement: the
+// client treats authority as relinquished when the host's `LeaseReleased`
+// arrives, and the next authority attempt waits — bounded — for settlement so
+// a fresh `LeaseRequest` cannot race the release into an `AlreadyHeld` denial.
+// The host's silence watchdog
 // remains the independent backup: the bounded wait means a lost
 // acknowledgement degrades to the watchdog path instead of hanging the
 // reconnect.
@@ -58,7 +58,7 @@ export function createReleaseTracker({
     },
     /**
      * Resolves once any in-flight release settles ("idle" immediately when
-     * none is): the reconnect path awaits this before requesting a lease.
+     * none is): the next explicit authority attempt awaits this before a lease.
      */
     settled() {
       return pending ? pending.promise : Promise.resolve("idle");

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -78,7 +78,8 @@ import {
   validSessionConfig,
   whenVisible,
 } from "./session-discovery.js";
-import { startDatagramControl } from "./datagram-control.js";
+import { createDatagramRunStop, startDatagramControl } from "./datagram-control.js";
+import { resumeGrantDecision, resumeSessionControl } from "./resume-control.js";
 import { loadControlShell } from "./control-shell.js";
 import { advanceMotionLease, applyMotionRecovery } from "./motion-lease.js";
 import {
@@ -130,6 +131,7 @@ const els = {
   port: document.getElementById("port"),
   certHash: document.getElementById("certHash"),
   connectBtn: document.getElementById("connectBtn"),
+  resumeBtn: document.getElementById("resumeBtn"),
   status: document.getElementById("status"),
   overlay: document.getElementById("overlay"),
   telemetry: document.getElementById("telemetry"),
@@ -193,6 +195,15 @@ const state = {
   advertisedScopes: [],
   connected: false,
   leaseGranted: false,
+  // The current datagram run must finish and release its writer lock before a
+  // same-session resume can acquire the stream again.
+  controlCompletion: null,
+  stopControlRun: null,
+  // A live session token while a resume LeaseRequest awaits its response.
+  resumePendingToken: null,
+  // Input loss remembers whether the independent gimbal lease was held so the
+  // explicit resume restores the same authority set.
+  resumeGimbalLease: false,
   // The generation the motion lease held when last released: a post-handover
   // regrant must be strictly newer than this fence to be accepted.
   motionFence: 0n,
@@ -515,6 +526,11 @@ async function openTransportSession({ url, certHash, certHashHex, manual, leaseP
     state.lastFcVerdictLogged = null;
     state.connected = false;
     state.leaseGranted = false;
+    state.controlCompletion = null;
+    state.stopControlRun = null;
+    state.resumePendingToken = null;
+    state.resumeGimbalLease = false;
+    els.resumeBtn.hidden = true;
     state.skippedVideoFrames = 0;
     resetVideoDiagnostics();
     retireSessionPresentation("connecting");
@@ -628,6 +644,9 @@ function handleTransportClosed(token, error) {
   state.connected = false;
   state.transport = null;
   state.sessionWriter = null;
+  state.resumePendingToken = null;
+  state.resumeGimbalLease = false;
+  els.resumeBtn.hidden = true;
   // An unacknowledged release rides down with the transport; the host
   // watchdog covers it from here.
   releaseTracker.abandon();
@@ -726,6 +745,84 @@ function sendLeaseRelease(token) {
   log("sent LeaseRelease for " + scope);
 }
 
+/** Relinquishes local authority synchronously with the input-loss latch. */
+function suspendControlForInputLoss(token) {
+  state.stopControlRun?.stop();
+  const releaseNeeded = state.leaseGranted || state.resumePendingToken === token;
+  state.resumeGimbalLease ||= state.gimbalLeaseGranted;
+  if (releaseNeeded) sendLeaseRelease(token);
+  state.motionFence = state.generation;
+  state.leaseGranted = false;
+  state.motionRecovered = false;
+}
+
+function showResumeAffordance() {
+  const token = transportSessions.currentToken();
+  const available =
+    token !== null &&
+    state.connected &&
+    controlGate.isLatched() &&
+    motionCapabilityFor(state.motionScope);
+  els.resumeBtn.hidden = !available;
+  if (available) {
+    els.overlay.textContent = "control suspended — press Resume control";
+  }
+}
+
+async function requestResumeLeases(token) {
+  const writer = state.sessionWriter;
+  if (!writer || !transportSessions.isActive(token)) {
+    throw new Error("the live session stream is unavailable");
+  }
+  const motion = encodeLeaseRequestEnvelope({ vehicleId: VEHICLE_ID, scope: state.motionScope });
+  await writer.write(lengthDelimit(motion));
+  log(`sent same-session LeaseRequest for ${state.motionScope}`);
+  if (state.resumeGimbalLease) {
+    const gimbal = encodeLeaseRequestEnvelope({ vehicleId: VEHICLE_ID, scope: GIMBAL_SCOPE });
+    await writer.write(lengthDelimit(gimbal));
+    log(`sent same-session LeaseRequest for ${GIMBAL_SCOPE}`);
+  }
+}
+
+/** Explicitly resumes authority and the datagram run on the current session. */
+async function resumeControlInPlace() {
+  const token = transportSessions.currentToken();
+  if (!token || !state.connected) {
+    els.resumeBtn.hidden = true;
+    reconnect.requestConnect();
+    return;
+  }
+  els.resumeBtn.disabled = true;
+  try {
+    const result = await resumeSessionControl({
+      gate: controlGate,
+      releases: releaseTracker,
+      controlSettled: () => state.controlCompletion ?? Promise.resolve(),
+      isSessionLive: () => transportSessions.isActive(token) && state.connected,
+      announceActivation: () => maybeAnnounceProfileActivation(),
+      requestLeases: async () => {
+        state.resumePendingToken = token;
+        await requestResumeLeases(token);
+      },
+      surrender: () => sendLeaseRelease(token),
+    });
+    if (!result.requested) {
+      showResumeAffordance();
+      return;
+    }
+    els.overlay.textContent = result.interrupted
+      ? "resume interrupted by input loss"
+      : "resume requested — waiting for fresh motion authority";
+  } catch (error) {
+    state.resumePendingToken = null;
+    controlGate.latchInputLoss();
+    log(`same-session resume failed: ${error}`);
+    showResumeAffordance();
+  } finally {
+    els.resumeBtn.disabled = false;
+  }
+}
+
 /** Applies a motion-scope reliable-stream message to the flat authority state
  *  through the pure {@link advanceMotionLease} transition: it enforces the
  *  generation fence and terminal denial, and installs a fresh generation
@@ -747,6 +844,44 @@ function applyMotionLease(decoded) {
     state.sequence = 0;
   }
   return after;
+}
+
+function completePendingResume(token, granted) {
+  const decision = resumeGrantDecision({
+    pending: state.resumePendingToken === token,
+    granted,
+    sessionLive: transportSessions.isActive(token) && state.connected,
+    mayPublish: controlGate.mayPublish(),
+  });
+  if (decision === "unrelated") return;
+  if (decision === "surrender") {
+    suspendControlForInputLoss(token);
+    state.resumePendingToken = null;
+    showResumeAffordance();
+    return;
+  }
+  state.resumePendingToken = null;
+  if (decision === "denied") {
+    state.motionDenied = true;
+    if (state.gimbalLeaseGranted) executeLeaseAction(token, "release", GIMBAL_SCOPE);
+    els.overlay.textContent = "same-session resume denied — press Connect to retry";
+    return;
+  }
+  state.resumeGimbalLease = false;
+  // A fresh wasm session generation: the runtime re-seeds every discrete
+  // edge baseline (a button pressed while control was suspended cannot fire
+  // on resume) and, arriving unrecovered, re-enters the neutral-activation
+  // recovery before any live output.
+  state.controlGeneration = (state.controlGeneration + 1) >>> 0;
+  if (startControlLoop(state.transport, token)) {
+    els.resumeBtn.hidden = true;
+    els.overlay.textContent = "control resumed — center inputs for neutral recovery";
+    log("same-session control resumed on fresh authority");
+  } else {
+    controlGate.latchInputLoss();
+    suspendControlForInputLoss(token);
+    showResumeAffordance();
+  }
 }
 
 /** Reads the session (bootstrap) stream after the handshake completes:
@@ -817,7 +952,13 @@ async function runSessionStreamReader(reader, token) {
         state.gimbalLeaseGranted = !!m.granted;
         state.gimbalLeaseDenied = !m.granted;
         log(`LeaseResponse[gimbal]: granted=${m.granted} generation=${m.generation}`);
-        if (!m.granted) {
+        if (
+          m.granted &&
+          (!controlGate.mayPublish() || (state.resumeGimbalLease && state.motionDenied))
+        ) {
+          executeLeaseAction(token, "release", GIMBAL_SCOPE);
+          log("input loss raced the gimbal grant; surrendered immediately");
+        } else if (!m.granted) {
           log(`gimbal lease denied (reason ${m.reason}); flight control is unaffected`);
         }
       }
@@ -866,6 +1007,7 @@ async function runSessionStreamReader(reader, token) {
             : "camera flight scope granted";
           log(`LeaseResponse[motion:${state.motionScope}]: granted generation=${m.generation}`);
         }
+        completePendingResume(token, after.granted);
       }
     }
   }
@@ -1365,11 +1507,12 @@ function activeGamepad() {
 
 /** Sends one control-fast datagram at `CONTROL_HZ`, carrying the latest key-derived axes (superseded samples are droppable, ADR-0011). */
 function startControlLoop(transport, token) {
+  const runStop = createDatagramRunStop();
   const started = startDatagramControl({
     datagrams: transport.datagrams,
     lifecycle: transportSessions,
     token,
-    run: (writer) => runControlLoop(writer, token),
+    run: (writer) => runControlLoop(writer, token, runStop),
     onError: (error) => log(`control loop stopped: ${error}`),
   });
   if (!started.ok) {
@@ -1380,12 +1523,24 @@ function startControlLoop(transport, token) {
     els.gamepad.textContent = `control unavailable — ${detail}`;
     els.overlay.textContent = "control unavailable";
     log(`control unavailable: ${detail}`);
+  } else {
+    const completion = started.completion;
+    state.controlCompletion = completion;
+    state.stopControlRun = runStop;
+    completion
+      .finally(() => {
+        if (state.controlCompletion === completion) {
+          state.controlCompletion = null;
+          state.stopControlRun = null;
+        }
+      })
+      .catch(() => {});
   }
   return started.ok;
 }
 
 /** Runs the control-fast send loop with an acquired, session-owned writer. */
-async function runControlLoop(writer, token) {
+async function runControlLoop(writer, token, runStop) {
   // The control runtime owns every edge baseline (arm/disarm/R3), so a button
   // held across a reconnect cannot read as a fresh edge — no priming here.
   const intervalMs = 1000 / CONTROL_HZ;
@@ -1395,11 +1550,8 @@ async function runControlLoop(writer, token) {
   // (which the host rejects as too old, ADR-0009). `sampled_at` is stamped right
   // before the write, after `ready`, so it reflects the real send moment.
   while (transportSessions.isActive(token) && state.connected) {
-      try {
-        await writer.ready;
-      } catch {
-        return; // writer closed (session ended)
-      }
+      const ready = await runStop.waitFor(writer.ready);
+      if (!ready) return;
       if (!transportSessions.isActive(token) || !state.connected) return;
       // A connected gamepad drives under its profile; the keyboard is the
       // fallback when none is present. The readout shows the live mapping.
@@ -1414,10 +1566,11 @@ async function runControlLoop(writer, token) {
         // client-side neutral would both violate the latch invariant and
         // refresh the very setpoint freshness the silence watchdog (the
         // independent backup) is watching.
-        sendLeaseRelease(token);
+        suspendControlForInputLoss(token);
         els.gamepad.textContent =
-          "control released — input lost; press Connect to resume control";
+          "control released — input lost; press Resume control";
         log("input lost — control authority released (host acknowledges or watchdog covers)");
+        showResumeAffordance();
         return;
       }
       // The control runtime maps every input; until its wasm has loaded there
@@ -1509,6 +1662,11 @@ async function runControlLoop(writer, token) {
 
 function velocityCapabilityFor(scope) {
   return capabilityFor(state.advertisedScopes, VEHICLE_ID, scope, INTENT_FAMILY_VELOCITY);
+}
+
+function motionCapabilityFor(scope) {
+  const family = scope === DIRECT_SCOPE ? INTENT_FAMILY_ATTITUDE_THRUST : INTENT_FAMILY_VELOCITY;
+  return capabilityFor(state.advertisedScopes, VEHICLE_ID, scope, family);
 }
 
 /** The fencing generation the client holds `scope` at — the binding every
@@ -1680,9 +1838,7 @@ function maybeAnnounceProfileActivation() {
  *  vehicle does not advertise a velocity intent. */
 function sendMotionFrame(writer, token, mode, plan) {
   const direct = state.motionScope === DIRECT_SCOPE;
-  const capability = direct
-    ? capabilityFor(state.advertisedScopes, VEHICLE_ID, DIRECT_SCOPE, INTENT_FAMILY_ATTITUDE_THRUST)
-    : velocityCapabilityFor(state.motionScope);
+  const capability = motionCapabilityFor(state.motionScope);
   if (!capability) return;
   const m = plan.motion;
   if (plan.arm && requestAction(state.motionScope, CONTROL_ACTION.arm, undefined, [CONTROL_ACTION.disarm])) {
@@ -2056,6 +2212,9 @@ els.connectBtn.addEventListener("click", () => {
   // only path that requests control.
   reconnect.requestConnect();
 });
+els.resumeBtn.addEventListener("click", () => {
+  void resumeControlInPlace();
+});
 // A launcher-pinned URL (host + port + cert all present, autoconnect=1)
 // connects through the SAME explicit path as the button — the URL already
 // states everything the click would add. Anything less than a fully
@@ -2086,8 +2245,13 @@ els.connectBtn.addEventListener("click", () => {
 // session likely idle-dropped while away, and only now can a reconnect succeed
 // (a hidden tab would just drop again).
 document.addEventListener("visibilitychange", () => {
-  if (document.visibilityState === "visible") reconnect.notifyVisible();
+  if (document.visibilityState === "visible") {
+    reconnect.notifyVisible();
+    showResumeAffordance();
+  }
 });
+
+window.addEventListener("focus", showResumeAffordance);
 
 // Losing window focus can swallow keyup events, leaving keys "stuck". Clear the
 // keyboard and arm-edge state immediately on blur so input released off-window
@@ -2097,10 +2261,10 @@ window.addEventListener("blur", () => {
   // await, and a refocus before its next tick must not un-happen the
   // loss. Frames under the current generation end here — and the
   // explicit release starts HERE too, not at the loop's next tick, so a
-  // Connect click racing the blur always finds the release in flight.
+  // resume action racing the blur always finds the release in flight.
   controlGate.latchInputLoss();
-  if (state.leaseGranted && transportSessions.active !== null) {
-    sendLeaseRelease(transportSessions.active);
-  }
+  const token = transportSessions.currentToken();
+  if (token) suspendControlForInputLoss(token);
   state.controlShell?.clearKeys();
+  showResumeAffordance();
 });

--- a/clients/web/resume-control.js
+++ b/clients/web/resume-control.js
@@ -1,0 +1,45 @@
+// Same-session control resumption after the input-loss latch relinquishes
+// authority. The gate re-arm and every live probe stay in this module so the
+// browser lifecycle and its race tests execute the same ordering.
+
+/**
+ * Re-arms control, waits for the release and writer to settle, then requests
+ * fresh authority without replacing the live transport.
+ */
+export async function resumeSessionControl({
+  gate,
+  releases,
+  controlSettled,
+  isSessionLive,
+  announceActivation,
+  requestLeases,
+  surrender,
+}) {
+  gate.reset();
+  await releases.settled();
+  await controlSettled();
+  if (!isSessionLive() || !gate.mayPublish()) {
+    return { requested: false, interrupted: true };
+  }
+
+  announceActivation();
+  try {
+    await requestLeases();
+  } catch (error) {
+    surrender();
+    throw error;
+  }
+  if (!isSessionLive() || !gate.mayPublish()) {
+    surrender();
+    return { requested: true, interrupted: true };
+  }
+  return { requested: true, interrupted: false };
+}
+
+/** Decides how a mid-session motion grant completes a pending resume. */
+export function resumeGrantDecision({ pending, granted, sessionLive, mayPublish }) {
+  if (!pending) return "unrelated";
+  if (!granted) return "denied";
+  if (!sessionLive || !mayPublish) return "surrender";
+  return "start";
+}

--- a/clients/web/transport-session.js
+++ b/clients/web/transport-session.js
@@ -60,6 +60,10 @@ export class TransportSessionLifecycle {
     return this.active?.token === token;
   }
 
+  currentToken() {
+    return this.active?.token ?? null;
+  }
+
   runIfActive(token, action) {
     if (!this.isActive(token)) return false;
     action();


### PR DESCRIPTION
## Context

Closes #190. Composes with the merged device-swap authority retention and idle-uplink enactment rejection.

The input-loss latch (blur) released both leases and terminated the control loop, and the only way back was the Connect button — a full WebTransport teardown and renegotiation of a healthy session, with a telemetry/video gap. Clicking anywhere outside the browser (the simulator window, another monitor) cost the whole session. Meanwhile the host-fenced rejection path already re-leased in place on the live stream — the asymmetry was policy, not machinery.

## What changed

- **`resume-control.js`** owns the resume ordering the safety argument depends on, executed identically by the browser and the lifecycle tests: gate re-arm synchronously BEFORE the first await; wait for the release acknowledgement AND the prior datagram run's completion; live-session + gate probe at every settlement point; announce-if-advanced before the lease request; an interrupted resume surrenders the request. `resumeGrantDecision` classifies the mid-session grant (start / denied / surrender / unrelated).
- **`main.js`** wires it: input loss now funnels through `suspendControlForInputLoss` (stops the datagram run, releases, fences the generation, marks recovery outstanding, remembers whether the gimbal lease was held so resume restores the same authority set). A visible **Resume control** button appears on refocus/visibility while the latch is set and a live session exists; with no live session it falls back to the full Connect path. A gimbal grant racing a blur is surrendered immediately; a denied resume is terminal for the session and directs to Connect.
- **`datagram-control.js`** gains a run-stop that interrupts a parked backpressure wait without closing the send stream, and the writer lock is released when a run ends — the same session's datagram stream can be re-acquired by the resumed loop.
- **Runtime: an unrecovered fresh generation re-enters neutral-activation recovery.** `prime_for_generation` now lands in `Neutralizing` when the fresh generation arrives with the link-loss clearance still outstanding, instead of publishing live immediately: a deflection held across the suspension stays gated, centered controls retransmit the neutral activation, and live output waits for the host's `LinkLossCleared` — the same contract a scope transfer's reacquisition keeps.
- **The resumed loop hands the runtime a fresh session generation** (`completePendingResume` advances it before `startControlLoop`), so the discrete edge baselines re-seed — a button pressed while control was suspended cannot fire as an edge on resume — and the recovery entry above actually engages.

## Guardrails

- Runtime: `an_unrecovered_fresh_generation_reenters_neutral_activation_recovery`, `a_button_pressed_while_suspended_fires_no_edge_on_the_fresh_generation`.
- Wasm twin (`control-runtime.test.mjs`): the full resume sequence with **positive controls on the same key** — the bound key demonstrably deflects while live and after recovery, so a dud key name can never make the negative checks pass vacuously.
- Lifecycle (`connect-lifecycle.test.mjs`): release-settlement and prior-run waits, same-transport identity, announce-before-request, blur-race latching, interrupted-resume surrender.
- `datagram-control.test.mjs`: run-stop interrupt and writer-lock release semantics.
- Structural (`control-structure.test.mjs`): the resume completion must advance the control generation before the loop restarts.

No evidence-graph-bound source is modified.

Local gates on the branch in an isolated worktree: workspace `fmt --check`; `clippy --all-targets -- -D warnings` and `cargo test --all-targets` (59 passed) for `pilotage-control-web`; wasm rebuild; all eight affected browser suites green.

Live acceptance still to be flown before merge: while flying, click the simulator window, click back, press Resume control, continue flying — telemetry/video uninterrupted, no re-arm surprise, held stick gated until centered.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)