### PR TITLE
CTRL-15: one scope-tagged log line per authority transition

### DIFF
--- a/clients/web-control/src/authority.rs
+++ b/clients/web-control/src/authority.rs
@@ -218,6 +218,9 @@ impl AuthorityTable {
         match event {
             AuthorityEvent::LeaseGranted { generation } => apply_grant(slot, generation),
             AuthorityEvent::LeaseDenied => {
+                if slot.state.denied {
+                    return AuthorityDisposition::Ignored;
+                }
                 slot.pending = None;
                 slot.state.granted = false;
                 slot.state.denied = true;
@@ -226,6 +229,9 @@ impl AuthorityTable {
             AuthorityEvent::LeaseReleased { generation }
             | AuthorityEvent::Revoked { generation } => {
                 if fence_event_is_stale(slot, generation) {
+                    return AuthorityDisposition::Ignored;
+                }
+                if !slot.state.granted && slot.fence_active && slot.state.fence == generation {
                     return AuthorityDisposition::Ignored;
                 }
                 slot.pending = None;
@@ -241,6 +247,7 @@ impl AuthorityTable {
                 if scope != AuthorityScope::Motion
                     || !slot.state.granted
                     || generation != slot.state.generation
+                    || slot.state.recovered
                 {
                     return AuthorityDisposition::Ignored;
                 }
@@ -248,7 +255,7 @@ impl AuthorityTable {
                 AuthorityDisposition::Applied
             }
             AuthorityEvent::UplinkIdle => {
-                if scope != AuthorityScope::Motion {
+                if scope != AuthorityScope::Motion || slot.state.needs_arm {
                     return AuthorityDisposition::Ignored;
                 }
                 slot.state.needs_arm = true;
@@ -332,8 +339,8 @@ fn apply_action_result(
         return AuthorityDisposition::Ignored;
     }
     match action {
-        ACTION_ARM => slot.state.needs_arm = false,
-        ACTION_DISARM => slot.state.needs_arm = true,
+        ACTION_ARM if slot.state.needs_arm => slot.state.needs_arm = false,
+        ACTION_DISARM if !slot.state.needs_arm => slot.state.needs_arm = true,
         _ => return AuthorityDisposition::Ignored,
     }
     AuthorityDisposition::Applied

--- a/clients/web-control/src/authority/tests.rs
+++ b/clients/web-control/src/authority/tests.rs
@@ -154,3 +154,73 @@ fn recovery_requires_the_current_granted_motion_generation() {
     );
     assert!(table.state(motion).recovered());
 }
+
+#[test]
+fn duplicate_state_transitions_are_ignored() {
+    let mut table = AuthorityTable::default();
+    let motion = AuthorityScope::Motion;
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseGranted { generation: 11 }),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseGranted { generation: 11 }),
+        AuthorityDisposition::Ignored
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseReleased { generation: 12 }),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::Revoked { generation: 12 }),
+        AuthorityDisposition::Ignored
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseGranted { generation: 13 }),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LinkLossCleared { generation: 13 }),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LinkLossCleared { generation: 13 }),
+        AuthorityDisposition::Ignored
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::UplinkIdle),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::UplinkIdle),
+        AuthorityDisposition::Ignored
+    );
+    assert_eq!(
+        table.apply(
+            motion,
+            AuthorityEvent::ActionResult {
+                action: 1,
+                accepted: true,
+            }
+        ),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(
+            motion,
+            AuthorityEvent::ActionResult {
+                action: 1,
+                accepted: true,
+            }
+        ),
+        AuthorityDisposition::Ignored
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseDenied),
+        AuthorityDisposition::Applied
+    );
+    assert_eq!(
+        table.apply(motion, AuthorityEvent::LeaseDenied),
+        AuthorityDisposition::Ignored
+    );
+}

--- a/clients/web/authority-stream.test.mjs
+++ b/clients/web/authority-stream.test.mjs
@@ -64,6 +64,22 @@ function linkLossClearedLD(vehicle, scope, generation) {
   return new Uint8Array(ld);
 }
 
+function leaseGrantedLD(principal, vehicle, scope, generation) {
+  const granted = [];
+  bytesField(granted, 1, uint64Message(principal));
+  bytesField(granted, 2, uint64Message(vehicle));
+  bytesField(granted, 3, stringMessage(scope));
+  bytesField(granted, 4, uint64Message(generation));
+  const event = [];
+  bytesField(event, 1, granted);
+  const envelope = [];
+  bytesField(envelope, 3, event);
+  const ld = [];
+  varint(ld, envelope.length);
+  ld.push(...envelope);
+  return new Uint8Array(ld);
+}
+
 // ---- fragmented arrival on an OPEN stream ----
 {
   const bytes = linkLossClearedLD(7, "vehicle.motion", 42);
@@ -83,6 +99,18 @@ function linkLossClearedLD(vehicle, scope, generation) {
   check("it decoded as LinkLossCleared", dispatched[0]?.kind === "LinkLossCleared");
   check("no leftover after a complete envelope", buf.length === 0);
   check("the generation round-tripped", dispatched[0]?.message.generation === 42n);
+}
+
+// ---- broadcast grants carry the identity needed for table dedup ----------
+{
+  const decoded = decodeLengthDelimitedEnvelope(
+    leaseGrantedLD(5, 7, "vehicle.motion", 42),
+  );
+  check("a grant exposes its authority kind", decoded?.message.kind === "grant");
+  check("a grant exposes its principal", decoded?.message.principalId === 5n);
+  check("a grant exposes its vehicle", decoded?.message.vehicleId === 7n);
+  check("a grant exposes its scope", decoded?.message.scope === "vehicle.motion");
+  check("a grant exposes its generation", decoded?.message.generation === 42n);
 }
 
 // ---- two back-to-back envelopes in one chunk both dispatch ----

--- a/clients/web/authority-transition.js
+++ b/clients/web/authority-transition.js
@@ -1,0 +1,21 @@
+const APPLIED_LABEL = {
+  grant: ({ generation }) => `granted gen=${generation}`,
+  denial: ({ reason }) => `denied (terminal)${reason === undefined ? "" : ` reason=${reason}`}`,
+  release: ({ generation }) => `released fence=${generation}`,
+  revocation: ({ generation }) => `revoked fence=${generation}`,
+  recovery: ({ generation }) => `recovered gen=${generation}`,
+  uplinkIdle: () => "needs arm",
+  actionResult: ({ detail }) => (detail === 1 ? "armed" : "needs arm"),
+};
+
+/** Applies one reliable transition and reports only table-confirmed changes. */
+export function applyAuthorityTransition(control, log, scope, kind, details = {}) {
+  const disposition = control?.authorityEvent(scope, kind, details) ?? "ignored";
+  if (disposition === "stale") {
+    log(`authority[${scope}]: STALE ${kind} gen=${details.generation}`);
+  } else if (disposition === "applied") {
+    const describe = APPLIED_LABEL[kind];
+    log(`authority[${scope}]: ${describe ? describe(details) : kind}`);
+  }
+  return disposition;
+}

--- a/clients/web/control-runtime.test.mjs
+++ b/clients/web/control-runtime.test.mjs
@@ -7,6 +7,7 @@
 
 import { readFileSync } from "node:fs";
 import { loadControlShell } from "./control-shell.js";
+import { applyAuthorityTransition } from "./authority-transition.js";
 
 const wasmBytes = readFileSync(new URL("./control-runtime_bg.wasm", import.meta.url));
 const vectors = JSON.parse(
@@ -316,6 +317,36 @@ for (const group of vectors.groups) {
   );
   shell.authorityEvent("motion", "actionResult", { detail: 2, accepted: true });
   check("authority table: accepted disarm restores needs-arm", shell.authority("motion").needsArm);
+}
+
+// The unicast response and broadcast stream report the same host transition.
+// Only the table-confirmed first arrival is operator-visible.
+{
+  const shell = await loadControlShell(wasmBytes);
+  const lines = [];
+  const apply = (kind, generation) =>
+    applyAuthorityTransition(shell, (line) => lines.push(line), "motion", kind, { generation });
+  shell.beginSession();
+  apply("grant", 11n);
+  apply("grant", 11n);
+  check(
+    "authority logging: a unicast and broadcast grant produce one line",
+    lines.filter((line) => line === "authority[motion]: granted gen=11").length === 1,
+    lines,
+  );
+  apply("release", 12n);
+  apply("revocation", 12n);
+  check(
+    "authority logging: a release and revocation replay produce one line",
+    lines.filter((line) => line.includes("fence=12")).length === 1,
+    lines,
+  );
+  apply("grant", 12n);
+  check(
+    "authority logging: a stale grant is loud",
+    lines.at(-1) === "authority[motion]: STALE grant gen=12",
+    lines.at(-1),
+  );
 }
 
 // Operator-facing arm/disarm hints come from profile data, renamed by the

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -15,6 +15,7 @@ const GENERATED = new Set(["control-runtime.js", "instrument-runtime.js"]);
 const SIZE_CAPS = {
   "action-tracker.js": 90,
   "authority-stream.js": 17,
+  "authority-transition.js": 22,
   "bootstrap.js": 88,
   "calibration.js": 285,
   "connect-authority.js": 63,
@@ -101,6 +102,16 @@ if (leaseRequestOwners.join(",") !== "lease-executor.js") {
   failures += 1;
   console.error(
     `FAIL - lease requests must have one encoder owner (got ${leaseRequestOwners.join(",")})`,
+  );
+}
+
+const authorityApplyOwners = modules.filter((name) =>
+  readFileSync(new URL(`./${name}`, dir), "utf8").includes(".authorityEvent("),
+);
+if (authorityApplyOwners.join(",") !== "authority-transition.js") {
+  failures += 1;
+  console.error(
+    `FAIL - authority transitions must have one logging owner (got ${authorityApplyOwners.join(",")})`,
   );
 }
 

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -80,6 +80,7 @@ import { createDatagramRunStop, startDatagramControl } from "./datagram-control.
 import { resumeGrantDecision, resumeRefusalReason, resumeSessionControl } from "./resume-control.js";
 import { loadControlShell } from "./control-shell.js";
 import { writeLeaseAction } from "./lease-executor.js";
+import { applyAuthorityTransition } from "./authority-transition.js";
 import {
   INTENT_FAMILY_VELOCITY,
   INTENT_FAMILY_ATTITUDE_THRUST,
@@ -161,6 +162,7 @@ const hsiFaultPresenter = createDomFaultPresenter(els.hsi);
 const state = {
   transport: null,
   sessionId: 0,
+  principalId: 0n,
   sequence: 0,
   startNanos: BigInt(Date.now()) * 1_000_000n, // arbitrary local monotonic-ish origin for sampled_at (ADR-0009: endpoint-local, never compared raw across endpoints).
   // The runtime owns key bindings AND the held-key state; the shell only
@@ -802,10 +804,12 @@ async function resumeControlInPlace() {
 
 function applyLeaseResponse(scope, message) {
   const slot = authoritySlot(scope);
-  const disposition = state.controlShell?.authorityEvent(
+  const disposition = applyAuthorityTransition(
+    state.controlShell,
+    log,
     slot,
     message.granted ? "grant" : "denial",
-    { generation: message.generation },
+    { generation: message.generation, reason: message.reason },
   );
   if (disposition === "applied" && message.granted) {
     if (slot === "motion") state.sequence = 0;
@@ -875,10 +879,9 @@ async function runSessionStreamReader(reader, token) {
         const m = decoded.message;
         if (m.vehicleId === VEHICLE_ID && m.scope === state.motionScope) {
           releaseTracker.acknowledge();
-          state.controlShell?.authorityEvent("motion", "release", {
+          applyAuthorityTransition(state.controlShell, log, "motion", "release", {
             generation: m.generation,
           });
-          log(`LeaseReleased: released=${m.released} generation=${m.generation}`);
           if (state.pendingMotionScope) {
             // The scope handover's release boundary: flight moves to the
             // sibling scope. Both siblings share ONE authority group on the
@@ -895,15 +898,13 @@ async function runSessionStreamReader(reader, token) {
             log(`motion scope is now ${state.motionScope}`);
           }
         } else if (m.vehicleId === VEHICLE_ID && m.scope === GIMBAL_SCOPE) {
-          state.controlShell?.authorityEvent("gimbal", "release", {
+          applyAuthorityTransition(state.controlShell, log, "gimbal", "release", {
             generation: m.generation,
           });
-          log(`LeaseReleased[gimbal]: released=${m.released} generation=${m.generation}`);
         } else if (m.vehicleId === VEHICLE_ID && m.scope === SIM_LIFECYCLE_SCOPE) {
-          state.controlShell?.authorityEvent("lifecycle", "release", {
+          applyAuthorityTransition(state.controlShell, log, "lifecycle", "release", {
             generation: m.generation,
           });
-          log(`LeaseReleased[lifecycle]: released=${m.released} generation=${m.generation}`);
         } else {
           log(`ignoring LeaseReleased for vehicle=${m.vehicleId} scope=${m.scope}`);
         }
@@ -918,7 +919,6 @@ async function runSessionStreamReader(reader, token) {
         // vehicle's response must never install our generation.
         const m = decoded.message;
         const after = applyLeaseResponse(GIMBAL_SCOPE, m);
-        log(`LeaseResponse[gimbal]: granted=${m.granted} generation=${m.generation}`);
         if (
           after.granted &&
           (controlGate.isLatched() ||
@@ -928,9 +928,7 @@ async function runSessionStreamReader(reader, token) {
           if (action) void executeLeaseAction(token, action, GIMBAL_SCOPE);
           log("input loss raced the gimbal grant; surrendered immediately");
         } else if (after.denied) {
-          log(`gimbal lease denied (reason ${m.reason}); flight control is unaffected`);
-        } else if (after.disposition === "stale") {
-          log(`ignoring stale gimbal grant generation=${m.generation}`);
+          els.overlay.textContent = "gimbal lease denied; flight control is unaffected";
         }
       }
       if (
@@ -940,7 +938,6 @@ async function runSessionStreamReader(reader, token) {
       ) {
         const m = decoded.message;
         const after = applyLeaseResponse(SIM_LIFECYCLE_SCOPE, m);
-        log(`LeaseResponse[lifecycle]: granted=${m.granted} generation=${m.generation}`);
         if (after.granted && state.lifecycle.pendingPress) {
           state.lifecycle.pendingPress = false;
           if (requestAction(SIM_LIFECYCLE_SCOPE, CONTROL_ACTION.simReset)) {
@@ -948,9 +945,8 @@ async function runSessionStreamReader(reader, token) {
           }
         } else if (after.denied) {
           state.lifecycle.pendingPress = false;
-          log(`sim reset authorization denied (reason ${m.reason})`);
+          els.overlay.textContent = "simulation reset authorization denied";
         } else if (after.disposition === "stale") {
-          log(`ignoring stale lifecycle grant generation=${m.generation}`);
           const action = state.controlShell?.planAuthority("lifecycle", true);
           if (action) void executeLeaseAction(token, action, SIM_LIFECYCLE_SCOPE);
         }
@@ -968,18 +964,15 @@ async function runSessionStreamReader(reader, token) {
         // response never installs ours (filtered above).
         const m = decoded.message;
         const after = applyLeaseResponse(state.motionScope, m);
-        if (after.disposition === "stale") {
-          log(`ignoring stale motion grant generation=${m.generation}`);
-        } else if (after.denied) {
-          log(`motion lease denied (reason ${m.reason}); control stays suspended`);
-        } else {
+        if (after.denied) {
+          els.overlay.textContent = "motion lease denied; control stays suspended";
+        } else if (after.disposition !== "stale") {
           // Direct-flight state follows the GRANTED scope, never a local
           // optimistic flip.
           state.fpvActive = state.motionScope === DIRECT_SCOPE;
           els.overlay.textContent = state.fpvActive
             ? "direct (FPV) flight scope granted"
             : "camera flight scope granted";
-          log(`LeaseResponse[motion:${state.motionScope}]: granted generation=${m.generation}`);
         }
         if (after.disposition !== "stale") {
           completePendingResume(token, after.granted);
@@ -1014,6 +1007,7 @@ function handleBootstrapMessage(decoded, token) {
   if (!transportSessions.isActive(token)) return;
   if (decoded.kind === "ServerWelcome") {
     state.sessionId = decoded.message.sessionId;
+    state.principalId = decoded.message.principalId;
     state.advertisedScopes = decoded.message.advertisedScopes ?? [];
     // Correlation ids are per-connection; presses from a dead session must
     // not retransmit into a new one, and the new session has announced
@@ -1043,7 +1037,6 @@ function handleBootstrapMessage(decoded, token) {
       return;
     }
     applyLeaseResponse(MOTION_SCOPE, decoded.message);
-    log(`LeaseResponse: granted=${decoded.message.granted} generation=${decoded.message.generation}`);
     if (!decoded.message.granted) {
       els.overlay.textContent = `lease denied (reason ${decoded.message.reason})`;
     }
@@ -1124,23 +1117,34 @@ async function readOneUniStream(stream, token) {
   }
 }
 
-/** The dedicated authority-events stream is opened once at connection start and may carry several length-delimited envelopes over the stream's lifetime; decode every complete one buffered. */
 /** Handles one authority-stream envelope, decoded live as it arrives. */
 function dispatchAuthorityEnvelope(decoded, token) {
   if (!transportSessions.isActive(token)) return;
   if (decoded.kind === "AuthorityEvent") {
     els.overlay.textContent = `authority: ${decoded.message.arm}`;
-    log(`authority event: ${decoded.message.arm}`);
+    const message = decoded.message;
+    const slot = message.scope === GIMBAL_SCOPE ? "gimbal"
+      : message.scope === SIM_LIFECYCLE_SCOPE ? "lifecycle"
+        : motionGroup(message.scope) === motionGroup(state.motionScope) ? "motion" : null;
+    if (
+      slot &&
+      message.vehicleId === VEHICLE_ID &&
+      message.principalId === state.principalId &&
+      message.kind
+    ) {
+      applyAuthorityTransition(state.controlShell, log, slot, message.kind, {
+        generation: message.generation,
+      });
+    }
   } else if (decoded.kind === "LinkLossCleared") {
     const message = decoded.message;
     if (
       message.vehicleId === VEHICLE_ID &&
-      message.scope === motionGroup(state.motionScope) &&
-      state.controlShell?.authorityEvent("motion", "recovery", {
-        generation: message.generation,
-      }) === "applied"
+      message.scope === motionGroup(state.motionScope)
     ) {
-      log(`LinkLossCleared[motion]: recovery confirmed on generation=${decoded.message.generation}`);
+      applyAuthorityTransition(state.controlShell, log, "motion", "recovery", {
+        generation: message.generation,
+      });
     }
   }
 }
@@ -1357,28 +1361,26 @@ function handleFrameRejected(r) {
     r.reason === FRAME_REJECTION_UPLINK_IDLE &&
     motionGroup(r.scope) === motionGroup(state.motionScope)
   ) {
-    state.controlShell?.authorityEvent("motion", "uplinkIdle", {
+    applyAuthorityTransition(state.controlShell, log, "motion", "uplinkIdle", {
       generation: r.currentGeneration,
     });
     if (firstNotice) {
       els.overlay.textContent = "motion uplink idle — press arm to start control";
-      log("motion authority is granted but the vehicle uplink needs arm");
     }
   }
   if (
     (r.reason === 1 || r.reason === 2) &&
     r.scope === GIMBAL_SCOPE
   ) {
-    state.controlShell?.authorityEvent("gimbal", "revocation", {
+    applyAuthorityTransition(state.controlShell, log, "gimbal", "revocation", {
       generation: r.currentGeneration,
     });
-    log("host fenced our gimbal authority; the lease planner will re-request");
   }
   if (
     (r.reason === 1 || r.reason === 2) &&
     motionGroup(r.scope) === motionGroup(state.motionScope)
   ) {
-    state.controlShell?.authorityEvent("motion", "revocation", {
+    applyAuthorityTransition(state.controlShell, log, "motion", "revocation", {
       generation: r.currentGeneration,
     });
     const action = state.controlShell?.planAuthority("motion", true);
@@ -1388,7 +1390,6 @@ function handleFrameRejected(r) {
         action,
         state.motionScope,
       );
-      log("host fenced our motion authority; reacquiring the lease");
     }
   }
 }
@@ -1749,14 +1750,13 @@ function handleActionResult(m) {
   if (!entry) return; // a replay of an already-settled press
   if (motionGroup(entry.scope) === motionGroup(state.motionScope)) {
     const before = authorityFor(state.motionScope);
-    state.controlShell?.authorityEvent("motion", "actionResult", {
+    applyAuthorityTransition(state.controlShell, log, "motion", "actionResult", {
       detail: entry.action,
       accepted: m.accepted,
     });
     if (before.needsArm && !authorityFor(state.motionScope).needsArm) {
       state.lastFrameRejectionLogged = null;
       els.overlay.textContent = "arm sequence accepted — motion uplink active";
-      log("accepted arm result restored motion enactment");
     }
   }
   if (entry.scope === SIM_LIFECYCLE_SCOPE) {

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -1103,28 +1103,28 @@ function decodeIncarnation(bytes) {
   return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
 }
 
-// authority.proto AuthorityEvent: a oneof; we only care which arm fired and a
-// human-readable label, not full field decode, for the demo overlay.
-const AUTHORITY_ARM_NAMES = {
-  1: "ScopeLeaseGranted",
-  2: "ScopeTransferOffered",
-  3: "ScopeTransferAccepted",
-  4: "ScopeTransferCommitted",
-  5: "ScopeLeaseRevoked",
-  6: "EmergencyOverrideApplied",
-  7: "ScopeRegistered",
-  8: "ScopeTransferExpired",
-  9: "LinkStateChanged",
-  10: "WarningRaised",
-};
+const AUTHORITY_ARM_NAMES = [
+  null, "ScopeLeaseGranted", "ScopeTransferOffered", "ScopeTransferAccepted", "ScopeTransferCommitted",
+  "ScopeLeaseRevoked", "EmergencyOverrideApplied", "ScopeRegistered", "ScopeTransferExpired",
+  "LinkStateChanged", "WarningRaised",
+];
 
 function decodeAuthorityEvent(bytes) {
   if (!bytes) return { arm: "unknown" };
   const fields = parseFields(bytes);
   for (const fieldNumber of fields.keys()) {
-    if (AUTHORITY_ARM_NAMES[fieldNumber]) {
-      return { arm: AUTHORITY_ARM_NAMES[fieldNumber] };
-    }
+    const arm = AUTHORITY_ARM_NAMES[fieldNumber];
+    if (!arm) continue;
+    if (fieldNumber !== 1 && fieldNumber !== 5) return { arm };
+    const event = parseFields(firstBytes(fields, fieldNumber));
+    return {
+      arm,
+      kind: fieldNumber === 1 ? "grant" : "revocation",
+      principalId: decodeUint64Message(firstBytes(event, 1)),
+      vehicleId: decodeUint64Message(firstBytes(event, 2)),
+      scope: decodeStringMessage(firstBytes(event, 3)),
+      generation: decodeUint64Message(firstBytes(event, 4)),
+    };
   }
   return { arm: "unknown" };
 }


### PR DESCRIPTION
## Context

Closes #200. Slice 2 of the CTRL-14 tracker #192; stacked on #199 (the authority table is the dedup).

A single authority transition logged up to four lines — the raw authority-stream label plus the per-scope response line, doubled across motion and gimbal — the exact noise pattern that made the 2026-07-22 incident log hard to read.

## What changed

- **`authority-transition.js`** is the one place a reliable authority event becomes a log line: it applies the event through the runtime table and prints only on an `Applied` disposition (`authority[motion]: granted gen=11`, `released fence=12`, `denied (terminal)`, `recovered gen=11`, `needs arm`). An `Ignored` disposition — a duplicate arriving on the second channel — is silent; a `Stale` grant logs loudly as the correctness signal it is.
- **The authority stream now feeds the table.** `ScopeLeaseGranted`/`ScopeLeaseRevoked` arms are fully decoded (principal, vehicle, scope, generation — verified against `authority.proto` field numbering) and applied for THIS principal's scopes, so a transition seen first on the broadcast stream and again on the unicast response logs exactly once, whichever lands first.
- **Table idempotency hardened** so re-delivery is `Ignored` by construction: re-denial, same-fence release/revocation, already-recovered recovery, already-latched uplink-idle, and no-op action results.
- Ad-hoc per-scope log lines in the shell are removed; operator-facing overlay messages are unchanged.

Known gap, fixed in the slice-4 PR where the dispatch now lives: non-transition arms (overrides, warnings, transfers, other principals' lease traffic) temporarily reduce to the overlay without a log line on this branch; the raw-arm log line is restored there.

## Guardrails

- `authority/tests.rs`: idempotent re-delivery per event kind — the dedup is table-owned, twin-tested.
- `control-runtime.test.mjs`: the wasm surface returns `applied`/`ignored`/`stale` dispositions the logger keys on.
- `authority-stream.test.mjs`: hand-built wire fixtures (matching the proto field numbers) decode principal/scope/generation through the real decoder.
- Structural: `authorityEvent` application is confined to `authority-transition.js`.

Local gates on the branch tip in an isolated worktree: workspace `fmt --check`; clippy `-D warnings`; 67 crate tests; wasm rebuild; seven browser suites green.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #204
- <kbd>&nbsp;2&nbsp;</kbd> #203 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #199
<!-- GitButler Footer Boundary Bottom -->