### PR TITLE
CTRL-16: the runtime plan is the sole publishing authority; the gate is a write-boundary interlock

### DIFF
--- a/clients/web-control/src/coordinator/tests.rs
+++ b/clients/web-control/src/coordinator/tests.rs
@@ -33,6 +33,7 @@ fn session(_motion_granted: bool, _motion_recovered: bool) -> SessionState {
         now_ms: 100_000.0,
         mode: Mode::QuadPilot,
         connected: true,
+        input_lost: false,
     }
 }
 

--- a/clients/web-control/src/golden.rs
+++ b/clients/web-control/src/golden.rs
@@ -154,6 +154,7 @@ impl Harness {
             now_ms: 100_000.0,
             mode: Mode::from_str_or_pilot(&session.mode),
             connected: true,
+            input_lost: false,
         };
         self.coordinator.evaluate(&sample, &state)
     }

--- a/clients/web-control/src/runtime.rs
+++ b/clients/web-control/src/runtime.rs
@@ -187,6 +187,11 @@ impl ControlRuntime {
             self.prev_arm = sample.pressed(usize::from(active.flight.arm_button));
             self.prev_disarm = sample.pressed(usize::from(active.flight.disarm_button));
         }
+        if session.input_lost {
+            let plan = self.consume_lost_input(sample, &active);
+            self.active = Some(active);
+            return plan;
+        }
         let plan = if self.pending.is_some() {
             self.evaluate_handover(sample, session, &active)
         } else {
@@ -196,6 +201,17 @@ impl ControlRuntime {
             self.active = Some(active);
         }
         plan
+    }
+
+    fn consume_lost_input(&mut self, sample: &RawSample, active: &CompiledProfile) -> ControlPlan {
+        self.reset_baseline = reset_held(sample, &active.gimbal);
+        let arm = self.edge_fired(sample, active.flight.arm_button, true);
+        let disarm = self.edge_fired(sample, active.flight.disarm_button, false);
+        ControlPlan {
+            arm_suppressed: arm,
+            disarm_suppressed: disarm,
+            ..ControlPlan::default()
+        }
     }
 
     /// The normal tick: flight motion (masked while LT is held), the gimbal

--- a/clients/web-control/src/runtime/tests.rs
+++ b/clients/web-control/src/runtime/tests.rs
@@ -9,6 +9,7 @@ use crate::sample::{ButtonSample, Mode, RawSample, SessionState};
 
 // The motion-lease reacquisition tests share these helpers but would push this
 // file past the module size limit, so they live in a sibling submodule.
+mod input_loss;
 mod motion;
 
 /// A second profile with DIFFERENT bindings: the modifier and reset move to
@@ -55,6 +56,7 @@ fn session_gen(_generation: u32, mode: Mode, _granted: bool) -> SessionState {
         now_ms: 100_000.0,
         mode,
         connected: true,
+        input_lost: false,
     }
 }
 

--- a/clients/web-control/src/runtime/tests/input_loss.rs
+++ b/clients/web-control/src/runtime/tests/input_loss.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{sample, session, with_default};
+use crate::plan::ControlPlan;
+use crate::sample::Mode;
+
+#[test]
+fn input_loss_emits_no_publishable_plan_and_consumes_edges() {
+    let mut runtime = with_default();
+    let live = session(Mode::QuadPilot, true);
+    runtime.evaluate(&sample(&[0.0; 4], &[]), &live);
+
+    let mut lost = live;
+    lost.input_lost = true;
+    assert_eq!(
+        runtime.evaluate(&sample(&[0.0; 4], &[]), &lost),
+        ControlPlan::default()
+    );
+
+    let pressed = runtime.evaluate(&sample(&[0.0; 4], &[9]), &lost);
+    assert!(pressed.arm_suppressed);
+    assert!(pressed.motion.is_none());
+    assert!(pressed.gimbal.is_none());
+    assert!(pressed.lease.is_none());
+    assert!(pressed.motion_lease.is_none());
+    assert!(!pressed.arm);
+    assert!(!pressed.disarm);
+
+    let held = runtime.evaluate(&sample(&[0.0; 4], &[9]), &live);
+    assert!(
+        !held.arm,
+        "a press consumed during input loss cannot re-fire"
+    );
+}

--- a/clients/web-control/src/sample.rs
+++ b/clients/web-control/src/sample.rs
@@ -90,4 +90,6 @@ pub struct SessionState {
     pub mode: Mode,
     /// Whether a transport session is live; a dead session emits nothing.
     pub connected: bool,
+    /// Whether synchronous input loss is latched; publishable output is empty.
+    pub input_lost: bool,
 }

--- a/clients/web-control/src/wasm.rs
+++ b/clients/web-control/src/wasm.rs
@@ -181,6 +181,7 @@ impl WebControl {
         mode: u32,
         now_ms: f64,
         connected: bool,
+        input_lost: bool,
         source: u32,
     ) -> u32 {
         self.load_sample(axis_count as usize, button_count as usize, source);
@@ -188,6 +189,7 @@ impl WebControl {
             now_ms,
             mode: mode_from_u32(mode),
             connected,
+            input_lost,
         };
         let plan = self.coordinator.evaluate(&self.sample, &state);
         self.store_plan(&plan)

--- a/clients/web/connect-authority.js
+++ b/clients/web/connect-authority.js
@@ -20,7 +20,7 @@
 /**
  * @param {object} deps
  * @param {boolean} deps.manual explicit user connect (only path to control)
- * @param {{ reset: () => void, mayPublish: () => boolean }} deps.gate
+ * @param {{ reset: () => void, isLatched: () => boolean }} deps.gate
  * @param {{ settled: () => Promise<any> }} deps.releases
  * @param {(leaseProbe: () => boolean) => Promise<object>} deps.openAndBootstrap
  *   transport construction + handshake + bootstrap; must pass `leaseProbe`
@@ -46,10 +46,10 @@ export async function negotiateSessionAuthority({
     gate.reset(); // synchronous, BEFORE the first await
     await releases.settled();
   }
-  const session = await openAndBootstrap(() => manual && gate.mayPublish());
+  const session = await openAndBootstrap(() => manual && !gate.isLatched());
   if (!session || !session.completed) return session;
   if (session.leaseGranted) {
-    if (gate.mayPublish()) {
+    if (!gate.isLatched()) {
       if (startControl(session) === false) controlUnavailable(session);
     } else {
       // The blur raced the grant: input loss latched after the lease

--- a/clients/web/control-runtime.test.mjs
+++ b/clients/web/control-runtime.test.mjs
@@ -32,8 +32,35 @@ function toSession(session) {
   return {
     mode: session.mode,
     connected: true,
+    inputLost: false,
     nowMs: 100_000,
   };
+}
+
+// A latched input-loss tick consumes controls but gives the shell no
+// publishable frame, edge, or lease action, even with live authority.
+{
+  const shell = await loadControlShell(wasmBytes);
+  shell.beginSession();
+  shell.authorityEvent("motion", "grant", { generation: 1n });
+  shell.authorityEvent("gimbal", "grant", { generation: 1n });
+  shell.beginControlRun();
+  const live = toSession({ mode: "quad-pilot" });
+  shell.tickFromKeys(live);
+  const lost = { ...live, inputLost: true };
+  const empty = shell.tickFromKeys(lost);
+  check(
+    "input loss: a granted live session emits an empty publishable plan",
+    empty.motion === null && empty.gimbal === null && empty.lease === null &&
+      empty.motionLease === null && !empty.arm && !empty.disarm,
+    empty,
+  );
+  shell.keyEvent("Enter", true);
+  const pressed = shell.tickFromKeys(lost);
+  check("input loss: a consumed arm press remains loud", pressed.armSuppressed, pressed);
+  const resumed = shell.tickFromKeys(live);
+  check("input loss: the consumed press cannot re-fire on resume", !resumed.arm, resumed);
+  shell.keyEvent("Enter", false);
 }
 
 function syncScope(shell, scope, granted, denied, generation) {

--- a/clients/web/control-shell.js
+++ b/clients/web/control-shell.js
@@ -305,7 +305,7 @@ export class ControlShell {
       buttonCount,
       mode,
       session.nowMs,
-      session.connected,
+      session.connected, session.inputLost === true,
       source,
     );
     return this.#readPlan(result);

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -115,6 +115,16 @@ if (authorityApplyOwners.join(",") !== "authority-transition.js") {
   );
 }
 
+const mayPublishCalls = modules.reduce(
+  (count, name) =>
+    count + (readFileSync(new URL(`./${name}`, dir), "utf8").match(/\.mayPublish\(/g)?.length ?? 0),
+  0,
+);
+if (mayPublishCalls !== 1) {
+  failures += 1;
+  console.error(`FAIL - mayPublish must guard only the datagram write (got ${mayPublishCalls})`);
+}
+
 // And the shell must still drive the runtime through the one seam.
 const main = readFileSync(new URL("./main.js", dir), "utf8");
 function require(label, pattern) {

--- a/clients/web/main.js
+++ b/clients/web/main.js
@@ -823,7 +823,7 @@ function completePendingResume(token, granted) {
     pending: state.resumePendingToken === token,
     granted,
     sessionLive: transportSessions.isActive(token) && state.connected,
-    mayPublish: controlGate.mayPublish(),
+    mayPublish: !controlGate.isLatched(),
   });
   if (decision === "unrelated") return;
   if (decision === "surrender") {
@@ -1548,7 +1548,7 @@ function evaluateInputTick(mode) {
   }
   const sessionState = {
     mode,
-    connected: state.connected,
+    connected: state.connected, inputLost: controlGate.isLatched(),
     nowMs: performance.now(),
   };
   const plan = pad
@@ -1599,7 +1599,7 @@ async function runControlLoop(writer, token, runStop) {
       if (!ready) return;
       if (!transportSessions.isActive(token) || !state.connected) return;
       const mode = els.flightMode ? els.flightMode.value : "rover";
-      if (!controlGate.mayPublish()) {
+      if (controlGate.isLatched()) {
         // Input loss RELINQUISHES control authority. The latch is
         // absolute: NO frame — not even a neutral — is sent under this
         // generation, because the explicit LeaseRelease (sent by the

--- a/clients/web/resume-control.js
+++ b/clients/web/resume-control.js
@@ -18,7 +18,7 @@ export async function resumeSessionControl({
   gate.reset();
   await releases.settled();
   await controlSettled();
-  if (!isSessionLive() || !gate.mayPublish()) {
+  if (!isSessionLive() || gate.isLatched()) {
     return { requested: false, interrupted: true };
   }
 
@@ -29,7 +29,7 @@ export async function resumeSessionControl({
     surrender();
     throw error;
   }
-  if (!isSessionLive() || !gate.mayPublish()) {
+  if (!isSessionLive() || gate.isLatched()) {
     surrender();
     return { requested: true, interrupted: true };
   }

--- a/docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
+++ b/docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: CTRL-01
 suite: input-source coordinator suite
 command: cargo test -p pilotage-control-web --lib coordinator
-config-digest: fed8d7845176b056d5de53ada125b01117742d7d
+config-digest: 655630c24e6e6a1167cc7662a4ee878f00344935
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:fed8d7845176b056d5de53ada125b01117742d7d
+run-id: local:655630c24e6e6a1167cc7662a4ee878f00344935
 outcome: pass
 summary:
-test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.01s
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 0.00s

--- a/docs/control/evidence-graph.evg
+++ b/docs/control/evidence-graph.evg
@@ -370,12 +370,12 @@ attr outcome pass
 node RESULT-CTRL-SOURCE verification-result
 title input-source coordinator suite — recorded pass
 attr command cargo test -p pilotage-control-web --lib coordinator
-attr config-digest fed8d7845176b056d5de53ada125b01117742d7d
+attr config-digest 655630c24e6e6a1167cc7662a4ee878f00344935
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:253e38e50ca0bfc1c85b864b37847c3a7f67e2dc
+attr source-digest git-blob:d1d9b319c28be95ee84202948d2315dc9be31ed6
 attr artifact docs/control/evidence-artifacts/ctrl01/source-coordinator.run.txt
-attr output-digest sha256:2c423c71efe784b9a76fc59af82a5dbfb66eb2280207fda0f580f5793e600ab3
-attr run-id local:fed8d7845176b056d5de53ada125b01117742d7d
+attr output-digest sha256:127818308dc7777bea5f81f9c69bcf5a859769159070494b1639038bc4bf5426
+attr run-id local:655630c24e6e6a1167cc7662a4ee878f00344935
 attr outcome pass
 node RESULT-CTRL-FIXTURE verification-result
 title browser-encoded wire fixture suite — recorded pass
@@ -432,8 +432,8 @@ attr tree a5d55f59813d313df367c12e3d3fdedeffe18f4d
 node CFG-CTRL-SOURCE configuration-item
 title committed input-source coordinator verification baseline
 attr scm git
-attr commit fed8d7845176b056d5de53ada125b01117742d7d
-attr tree 0f581a45bdd187bc1a924b8699e16f28df2e138c
+attr commit 655630c24e6e6a1167cc7662a4ee878f00344935
+attr tree cc529ab568435856f6d389effc240a46350d1fa9
 
 node TOOL-CTRL-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
## Context

Closes #201. Slice 3 of the CTRL-14 tracker #192; stacked on the CTRL-15 logging slice.

`controlGate.mayPublish()` was consulted at four sites with four intents while the runtime independently decided output — two gates with different reset semantics whose interaction had to be re-derived at every change.

## What changed

- **`input_lost` is a `SessionState` fact.** While set, the runtime evaluates to an EMPTY plan — no frame, no gimbal, no lease action — through `consume_lost_input`, which still advances the discrete edge baselines and reports arm/disarm presses as SUPPRESSED. The latch invariant ("not even a neutral") and the CTRL-13 per-press loudness are now the same runtime-owned, twin-tested property.
- **Exactly one `mayPublish()` call site remains** — the datagram write boundary, as the belt-and-braces interlock (it keeps the live focus probe for a blur the DOM never delivered). Every other consumer became an explicit `isLatched()` lifecycle query: the loop's input-loss exit, the resume decision points, and the connect-time lease probe. Focus is consulted nowhere else.
- The CTRL-04 lifecycle and race tests pass UNCHANGED — they construct the real gate and remain the latch's specification.
- The CTRL-01 input-source evidence baseline is re-recorded at this head (a session fixture gained the `input_lost` field).

## Guardrails

- `runtime/tests/input_loss.rs` + the wasm twin: a lost tick under a granted, recovered lease emits an empty plan; a press during loss reports suppressed and cannot re-fire on resume (baselines advance).
- Structural: the module scan counts `.mayPublish(` calls across every `clients/web` module and fails unless exactly one exists.
- Evidence: source/config/output digests rebound at this head.

Local gates on the branch tip in an isolated worktree: workspace `fmt --check`; clippy `-D warnings`; 68 crate tests; wasm rebuild; seven browser suites green.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #204 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #203
- <kbd>&nbsp;1&nbsp;</kbd> #199
<!-- GitButler Footer Boundary Bottom -->