### PR TITLE
MEDIA-05: reap mid-open video streams without leaking credit

### DIFF
--- a/hosts/session-host/Cargo.toml
+++ b/hosts/session-host/Cargo.toml
@@ -33,7 +33,7 @@ jpeg-encoder = "0.7.0"
 pilotage-adapter-reference.workspace = true
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-wtransport = { workspace = true, features = ["dangerous-configuration"] }
+wtransport = { workspace = true, features = ["dangerous-configuration", "quinn"] }
 
 [lints]
 workspace = true

--- a/hosts/session-host/src/runtime/media/frame_writer.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer.rs
@@ -10,10 +10,15 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::{error, warn};
 use wtransport::error::{ConnectionError, StreamOpeningError, StreamWriteError};
+use wtransport::stream::OpeningUniStream;
 use wtransport::{Connection, SendStream, VarInt};
 
 use super::{EncodedFrame, now_ns};
 use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME_V2, frame_video_payload_v2};
+
+use reaper::OpenReapers;
+
+mod reaper;
 
 /// Longest a single frame's uni-stream write may take before the stream
 /// is reset and the writer moves on. A client that stops consuming one
@@ -24,6 +29,11 @@ use crate::runtime::stream_tag::{FOURCC_MJPEG, VIDEO_FRAME_V2, frame_video_paylo
 /// Generous against transient congestion (a healthy frame completes in
 /// milliseconds on the deployment link).
 const FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(2);
+
+/// A peer that withholds uni-stream credit for this long is starving the
+/// connection, not merely delaying one frame. This stage allocates no stream,
+/// so cancellation is safe and later frames may retry loudly.
+const STREAM_CREDIT_STARVATION_BOUND: Duration = Duration::from_secs(30);
 
 /// Application error code carried on the RESET_STREAM of a
 /// deadline-exceeded frame. Informational to the peer, which discards the
@@ -147,9 +157,15 @@ trait FrameStream {
 /// Opens per-frame outbound streams on a connection.
 trait FrameChannel {
     /// The stream this channel opens.
-    type Stream: FrameStream;
-    /// Opens one host-initiated uni stream.
-    fn open(&self) -> impl Future<Output = Result<Self::Stream, StreamError>> + Send;
+    type Stream: FrameStream + Send + 'static;
+    /// The allocated stream while its WebTransport header is being flushed.
+    type Opening: Send + 'static;
+    /// Waits for stream credit, returning only after allocation.
+    fn request_open(&self) -> impl Future<Output = Result<Self::Opening, StreamError>> + Send;
+    /// Flushes the WebTransport stream header for an allocated stream.
+    fn finish_open(
+        opening: Self::Opening,
+    ) -> impl Future<Output = Result<Self::Stream, StreamError>> + Send + 'static;
 }
 
 impl FrameStream for SendStream {
@@ -174,11 +190,13 @@ impl FrameStream for SendStream {
 
 impl FrameChannel for Connection {
     type Stream = SendStream;
+    type Opening = OpeningUniStream;
 
-    async fn open(&self) -> Result<SendStream, StreamError> {
-        // The open-request error is connection-level (its cause preserved);
-        // the opening error can be a peer refusal of this stream alone.
-        let opening = self.open_uni().await.map_err(classify_open_request)?;
+    async fn request_open(&self) -> Result<OpeningUniStream, StreamError> {
+        self.open_uni().await.map_err(classify_open_request)
+    }
+
+    async fn finish_open(opening: OpeningUniStream) -> Result<SendStream, StreamError> {
         opening.await.map_err(|e| classify_open(&e))
     }
 }
@@ -201,26 +219,33 @@ pub(super) async fn client_writer(
 /// What one frame's delivery attempt produced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeadlinePhase {
-    Open,
+    CreditWait,
+    HeaderFlush,
     Write,
 }
 
 impl DeadlinePhase {
     fn as_str(self) -> &'static str {
         match self {
-            Self::Open => "open",
+            Self::CreditWait => "open_credit",
+            Self::HeaderFlush => "open_header",
             Self::Write => "write",
         }
     }
 }
 
+#[derive(Debug)]
 enum FrameOutcome {
     /// Written and finished cleanly.
     Sent,
     /// The frame exceeded its deadline. `reset` is true when the stream
-    /// had opened and was explicitly reset, false when the open itself
-    /// timed out (there was no stream to reset).
-    Stalled { phase: DeadlinePhase, reset: bool },
+    /// was immediately reset. `reaper_owned` is true when an allocated
+    /// stream is still opening under detached ownership.
+    Stalled {
+        phase: DeadlinePhase,
+        reset: bool,
+        reaper_owned: bool,
+    },
     /// The peer stopped or refused this stream alone; the connection and
     /// other sources are healthy — one-frame loss, keep writing.
     PeerStop {
@@ -254,11 +279,10 @@ struct LossCounters {
     local_closes: u64,
 }
 
-/// Drains the handoff channel, delivering one frame per stream under a
-/// single absolute per-frame deadline that covers BOTH opening the stream
-/// and writing it. A frame lost to a deadline, a peer stop/refusal, or a
-/// local close costs one frame and the writer proceeds; only
-/// connection-level loss retires the writer.
+/// Drains the handoff channel, delivering one frame per stream. Stream-credit
+/// waits have an allocation-free starvation bound; header flush and writing
+/// share a per-frame deadline. Frame-local loss keeps the writer alive, while
+/// connection-level loss retires it.
 async fn drain_frames<C: FrameChannel>(
     client: ClientKey,
     source_id: u8,
@@ -267,6 +291,7 @@ async fn drain_frames<C: FrameChannel>(
     start: Instant,
 ) {
     let mut counters = LossCounters::default();
+    let mut reapers = OpenReapers::new(client, source_id);
     while let Some(frame) = frames.recv().await {
         // Stamp publication at the moment of write, distinct from the receive
         // stamp taken at dequeue, so a consumer can separate host queueing
@@ -285,8 +310,15 @@ async fn drain_frames<C: FrameChannel>(
             error!("video frame exceeds u32 length prefix; skipping");
             continue;
         };
-        let deadline = Instant::now() + FRAME_WRITE_DEADLINE;
-        let outcome = deliver_frame(channel, deadline, VIDEO_FRAME_V2, &body).await;
+        let outcome = deliver_frame(
+            channel,
+            &mut reapers,
+            STREAM_CREDIT_STARVATION_BOUND,
+            FRAME_WRITE_DEADLINE,
+            VIDEO_FRAME_V2,
+            &body,
+        )
+        .await;
         if !record_outcome(client, source_id, outcome, &mut counters) {
             return;
         }
@@ -303,7 +335,11 @@ fn record_outcome(
 ) -> bool {
     match outcome {
         FrameOutcome::Sent => {}
-        FrameOutcome::Stalled { phase, reset } => {
+        FrameOutcome::Stalled {
+            phase,
+            reset,
+            reaper_owned,
+        } => {
             counters.stalls = counters.stalls.wrapping_add(1);
             warn!(
                 client = client.as_u64(),
@@ -311,6 +347,7 @@ fn record_outcome(
                 phase = phase.as_str(),
                 total_stalls = counters.stalls,
                 stream_reset = reset,
+                reaper_owned,
                 "video frame exceeded its deadline; continuing with the next frame"
             );
         }
@@ -360,29 +397,52 @@ fn record_outcome(
     true
 }
 
-/// Opens a stream and writes the tag then the framed body, all under one
-/// absolute `deadline`. An open that exceeds the deadline yields a stall
-/// with no stream to reset; a write that exceeds it explicitly resets the
-/// opened stream (RESET_STREAM), retained across the timed region so the
-/// reset can fire rather than a dropped-future FIN. Typed open/write
-/// failures pass their peer-local vs connection-fatal classification
-/// through unchanged.
+/// Opens a stream and writes the tag then the framed body. Stream-credit wait
+/// has its own allocation-free bound. Once allocated, the header flush and
+/// body write share the frame budget; an expired header flush transfers its
+/// still-live future to the reaper, while an expired body write resets the
+/// stream immediately.
 async fn deliver_frame<C: FrameChannel>(
     channel: &C,
-    deadline: Instant,
+    reapers: &mut OpenReapers,
+    credit_bound: Duration,
+    frame_budget: Duration,
     tag: u8,
     body: &[u8],
 ) -> FrameOutcome {
-    let mut stream = match tokio::time::timeout_at(deadline, channel.open()).await {
-        Ok(Ok(stream)) => stream,
+    let Some(reaper_permit) = reapers.reserve().await else {
+        error!("video open reaper semaphore closed; retiring writer");
+        return FrameOutcome::ConnectionFatal {
+            phase: "open_header",
+            kind: FatalKind::NotConnected,
+        };
+    };
+    let opening = match tokio::time::timeout(credit_bound, channel.request_open()).await {
+        Ok(Ok(opening)) => opening,
         Ok(Err(error)) => return error.into_outcome(),
         Err(_elapsed) => {
             return FrameOutcome::Stalled {
-                phase: DeadlinePhase::Open,
+                phase: DeadlinePhase::CreditWait,
                 reset: false,
+                reaper_owned: false,
             };
         }
     };
+    let deadline = Instant::now() + frame_budget;
+    let mut completion = Box::pin(C::finish_open(opening));
+    let mut stream = match tokio::time::timeout_at(deadline, &mut completion).await {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(error)) => return error.into_outcome(),
+        Err(_elapsed) => {
+            reapers.own(completion, reaper_permit);
+            return FrameOutcome::Stalled {
+                phase: DeadlinePhase::HeaderFlush,
+                reset: false,
+                reaper_owned: true,
+            };
+        }
+    };
+    drop(reaper_permit);
     match tokio::time::timeout_at(deadline, write_body(&mut stream, tag, body)).await {
         Ok(Ok(())) => FrameOutcome::Sent,
         Ok(Err(error)) => error.into_outcome(),
@@ -391,6 +451,7 @@ async fn deliver_frame<C: FrameChannel>(
             FrameOutcome::Stalled {
                 phase: DeadlinePhase::Write,
                 reset: true,
+                reaper_owned: false,
             }
         }
     }
@@ -422,4 +483,8 @@ async fn write_body<S: FrameStream>(
 }
 
 #[cfg(test)]
+mod classification_tests;
+#[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod transport_tests;

--- a/hosts/session-host/src/runtime/media/frame_writer/classification_tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/classification_tests.rs
@@ -1,0 +1,72 @@
+//! Error-classification tests for every pinned wtransport variant.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use wtransport::VarInt;
+use wtransport::error::{ConnectionError, StreamOpeningError, StreamWriteError};
+
+use super::{FatalKind, StreamError, classify_open, classify_open_request, classify_write};
+
+#[test]
+fn classify_write_maps_every_pinned_variant() {
+    assert_eq!(
+        classify_write(&StreamWriteError::Stopped(VarInt::from_u32(9)), "write"),
+        StreamError::PeerStop {
+            phase: "write",
+            code: Some(9),
+        },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::Closed, "finish"),
+        StreamError::LocalClose { phase: "finish" },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::NotConnected, "write"),
+        StreamError::ConnectionFatal {
+            phase: "write",
+            kind: FatalKind::NotConnected,
+        },
+    );
+    assert_eq!(
+        classify_write(&StreamWriteError::QuicProto, "write"),
+        StreamError::ConnectionFatal {
+            phase: "write",
+            kind: FatalKind::QuicProto,
+        },
+    );
+}
+
+#[test]
+fn classify_open_maps_every_pinned_variant() {
+    assert_eq!(
+        classify_open(&StreamOpeningError::Refused),
+        StreamError::PeerStop {
+            phase: "open",
+            code: None,
+        },
+    );
+    assert_eq!(
+        classify_open(&StreamOpeningError::NotConnected),
+        StreamError::ConnectionFatal {
+            phase: "open",
+            kind: FatalKind::NotConnected,
+        },
+    );
+}
+
+#[test]
+fn an_open_request_error_preserves_its_concrete_cause() {
+    let classified = classify_open_request(ConnectionError::TimedOut);
+    assert_eq!(
+        classified,
+        StreamError::ConnectionFatal {
+            phase: "open",
+            kind: FatalKind::OpenRequest(ConnectionError::TimedOut),
+        },
+    );
+    let via_source = std::error::Error::source(&classified)
+        .and_then(std::error::Error::source)
+        .and_then(|error| error.downcast_ref::<ConnectionError>());
+    assert_eq!(via_source, Some(&ConnectionError::TimedOut));
+    assert!(classified.to_string().contains("timed out"), "{classified}");
+}

--- a/hosts/session-host/src/runtime/media/frame_writer/reaper.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/reaper.rs
@@ -1,0 +1,181 @@
+//! Bounded ownership for allocated WebTransport streams whose header flush
+//! exceeds the frame deadline.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use pilotage_session::ClientKey;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::{error, warn};
+
+use super::{FrameStream, StreamError};
+
+pub(super) const MAX_PENDING_OPEN_REAPERS: usize = 8;
+
+pub(super) struct OpenReapers {
+    client: ClientKey,
+    source_id: u8,
+    slots: Arc<Semaphore>,
+    active: Arc<AtomicUsize>,
+    total_spawned: u64,
+}
+
+impl OpenReapers {
+    pub(super) fn new(client: ClientKey, source_id: u8) -> Self {
+        Self {
+            client,
+            source_id,
+            slots: Arc::new(Semaphore::new(MAX_PENDING_OPEN_REAPERS)),
+            active: Arc::new(AtomicUsize::new(0)),
+            total_spawned: 0,
+        }
+    }
+
+    pub(super) async fn reserve(&self) -> Option<OwnedSemaphorePermit> {
+        if self.slots.available_permits() == 0 {
+            warn!(
+                client = self.client.as_u64(),
+                source_id = self.source_id,
+                pending_reapers = self.active.load(Ordering::Acquire),
+                reaper_bound = MAX_PENDING_OPEN_REAPERS,
+                "video open reaper bound reached; waiting before allocating another stream"
+            );
+        }
+        self.slots.clone().acquire_owned().await.ok()
+    }
+
+    pub(super) fn own<F, S>(&mut self, completion: Pin<Box<F>>, permit: OwnedSemaphorePermit)
+    where
+        F: Future<Output = Result<S, StreamError>> + Send + 'static,
+        S: FrameStream + Send + 'static,
+    {
+        self.total_spawned = self.total_spawned.wrapping_add(1);
+        let reaper_id = self.total_spawned;
+        let active = Arc::clone(&self.active);
+        let pending = active.fetch_add(1, Ordering::AcqRel).saturating_add(1);
+        let client = self.client.as_u64();
+        let source_id = self.source_id;
+        warn!(
+            client,
+            source_id,
+            reaper_id,
+            pending_reapers = pending,
+            total_reapers = self.total_spawned,
+            "video stream header flush exceeded its deadline; reaper owns allocated stream"
+        );
+        drop(tokio::spawn(async move {
+            reap(completion, permit, active, client, source_id, reaper_id).await;
+        }));
+    }
+
+    #[cfg(test)]
+    pub(super) fn available_slots(&self) -> usize {
+        self.slots.available_permits()
+    }
+}
+
+async fn reap<F, S>(
+    completion: Pin<Box<F>>,
+    permit: OwnedSemaphorePermit,
+    active: Arc<AtomicUsize>,
+    client: u64,
+    source_id: u8,
+    reaper_id: u64,
+) where
+    F: Future<Output = Result<S, StreamError>> + Send,
+    S: FrameStream,
+{
+    match completion.await {
+        Ok(mut stream) => {
+            stream.reset();
+            warn!(
+                client,
+                source_id, reaper_id, "video open reaper reset allocated stream"
+            );
+        }
+        Err(error) => {
+            warn!(client, source_id, reaper_id, %error, "video open reaper observed opening failure");
+        }
+    }
+    let remaining = active.fetch_sub(1, Ordering::AcqRel).saturating_sub(1);
+    drop(permit);
+    if remaining >= MAX_PENDING_OPEN_REAPERS {
+        error!(
+            client,
+            source_id, reaper_id, remaining, "video open reaper count invariant failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use std::sync::atomic::Ordering;
+
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::*;
+
+    struct MockStream {
+        reset_events: mpsc::UnboundedSender<()>,
+    }
+
+    impl FrameStream for MockStream {
+        async fn write_all(&mut self, _buf: &[u8]) -> Result<(), StreamError> {
+            Ok(())
+        }
+
+        async fn finish(&mut self) -> Result<(), StreamError> {
+            Ok(())
+        }
+
+        fn reset(&mut self) {
+            self.reset_events.send(()).ok();
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_open_reapers_are_bounded_counted_and_reset_on_completion() {
+        let mut reapers = OpenReapers::new(ClientKey::new(9), 3);
+        let (reset_tx, mut reset_rx) = mpsc::unbounded_channel();
+        let mut releases = Vec::with_capacity(MAX_PENDING_OPEN_REAPERS);
+
+        for _ in 0..MAX_PENDING_OPEN_REAPERS {
+            let permit = reapers.reserve().await.expect("reaper slot is available");
+            let (release_tx, release_rx) = oneshot::channel();
+            releases.push(release_tx);
+            let reset_events = reset_tx.clone();
+            reapers.own(
+                Box::pin(async move {
+                    release_rx.await.expect("test releases the open");
+                    Ok(MockStream { reset_events })
+                }),
+                permit,
+            );
+        }
+
+        assert_eq!(reapers.available_slots(), 0, "the configured bound is hard");
+        assert_eq!(
+            reapers.active.load(Ordering::Acquire),
+            MAX_PENDING_OPEN_REAPERS,
+            "every detached open is counted"
+        );
+        assert_eq!(
+            reapers.total_spawned, MAX_PENDING_OPEN_REAPERS as u64,
+            "the lifetime count includes every detached open"
+        );
+
+        for release in releases {
+            release.send(()).expect("reaper still owns the open");
+        }
+        for _ in 0..MAX_PENDING_OPEN_REAPERS {
+            reset_rx
+                .recv()
+                .await
+                .expect("each open resolves to a reset");
+        }
+    }
+}

--- a/hosts/session-host/src/runtime/media/frame_writer/tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests.rs
@@ -12,15 +12,15 @@ use pilotage_adapter_api::{
     SourceIncarnation, SourceIntegrity, SourceRole, VideoCaptureStamp,
 };
 use pilotage_session::ClientKey;
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tokio::time::Instant;
 
 use wtransport::VarInt;
-use wtransport::error::{ConnectionError, StreamOpeningError, StreamWriteError};
+use wtransport::error::{StreamOpeningError, StreamWriteError};
 
 use super::{
-    EncodedFrame, FatalKind, FrameChannel, FrameStream, StreamError, classify_open,
-    classify_open_request, classify_write, drain_frames,
+    EncodedFrame, FrameChannel, FrameStream, StreamError, classify_open, classify_write,
+    drain_frames,
 };
 
 fn capture_stamp() -> VideoCaptureStamp {
@@ -53,9 +53,13 @@ fn encoded_frame() -> EncodedFrame {
 #[derive(Default)]
 struct Tally {
     opened: AtomicU32,
-    open_cancelled: AtomicU32,
+    credit_wait_cancelled: AtomicU32,
+    header_cancelled: AtomicU32,
     finished: AtomicU32,
     reset: AtomicU32,
+    header_started: Notify,
+    header_release: Notify,
+    reset_observed: Notify,
 }
 
 /// How a mock stream behaves once opened. The failure cases construct a
@@ -80,8 +84,10 @@ enum Write {
 /// `StreamOpeningError`s through the production `classify_open`.
 #[derive(Clone, Copy)]
 enum Open {
-    /// `open()` never completes (the peer's stream allowance is full).
-    Stall,
+    /// The allocation-free stream-credit wait never completes.
+    CreditStall,
+    /// Allocation completes, but the WebTransport header flush stalls.
+    HeaderStall(Write),
     /// The peer refused this stream alone (`StreamOpeningError::Refused`).
     Refused,
     /// The connection is gone (`StreamOpeningError::NotConnected`).
@@ -119,6 +125,7 @@ impl FrameStream for MockStream {
 
     fn reset(&mut self) {
         self.tally.reset.fetch_add(1, Ordering::SeqCst);
+        self.tally.reset_observed.notify_one();
     }
 }
 
@@ -129,40 +136,82 @@ struct MockChannel {
     tally: Arc<Tally>,
 }
 
-struct OpenCancellationProbe {
+struct MockOpening {
+    open: Open,
     tally: Arc<Tally>,
 }
 
-impl Drop for OpenCancellationProbe {
+struct CreditWaitCancellationProbe {
+    tally: Arc<Tally>,
+}
+
+impl Drop for CreditWaitCancellationProbe {
     fn drop(&mut self) {
-        self.tally.open_cancelled.fetch_add(1, Ordering::SeqCst);
+        self.tally
+            .credit_wait_cancelled
+            .fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct HeaderCancellationProbe {
+    tally: Arc<Tally>,
+    completed: bool,
+}
+
+impl Drop for HeaderCancellationProbe {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.tally.header_cancelled.fetch_add(1, Ordering::SeqCst);
+        }
     }
 }
 
 impl FrameChannel for MockChannel {
     type Stream = MockStream;
+    type Opening = MockOpening;
 
-    async fn open(&self) -> Result<MockStream, StreamError> {
+    async fn request_open(&self) -> Result<MockOpening, StreamError> {
         let n = self.tally.opened.fetch_add(1, Ordering::SeqCst) as usize;
-        match self
+        let open = self
             .script
             .get(n)
             .copied()
-            .unwrap_or(Open::Ready(Write::Ok))
-        {
-            Open::Stall => {
-                let _cancellation_probe = OpenCancellationProbe {
+            .unwrap_or(Open::Ready(Write::Ok));
+        match open {
+            Open::CreditStall => {
+                let _cancellation_probe = CreditWaitCancellationProbe {
                     tally: self.tally.clone(),
                 };
-                std::future::pending::<Result<MockStream, StreamError>>().await
+                std::future::pending::<Result<MockOpening, StreamError>>().await
             }
-            Open::Refused => Err(classify_open(&StreamOpeningError::Refused)),
-            Open::ConnFatal => Err(classify_open(&StreamOpeningError::NotConnected)),
-            Open::Ready(write) => Ok(MockStream {
-                write,
+            _ => Ok(MockOpening {
+                open,
                 tally: self.tally.clone(),
             }),
         }
+    }
+
+    async fn finish_open(opening: MockOpening) -> Result<MockStream, StreamError> {
+        let write = match opening.open {
+            Open::CreditStall => std::future::pending::<Write>().await,
+            Open::HeaderStall(write) => {
+                let mut cancellation_probe = HeaderCancellationProbe {
+                    tally: opening.tally.clone(),
+                    completed: false,
+                };
+                opening.tally.header_started.notify_one();
+                opening.tally.header_release.notified().await;
+                cancellation_probe.completed = true;
+                write
+            }
+            Open::Refused => return Err(classify_open(&StreamOpeningError::Refused)),
+            Open::ConnFatal => return Err(classify_open(&StreamOpeningError::NotConnected)),
+            Open::Ready(write) => write,
+        };
+        Ok(MockStream {
+            write,
+            tally: opening.tally,
+        })
     }
 }
 
@@ -206,15 +255,14 @@ async fn a_stalled_write_resets_once_and_the_next_frame_proceeds() {
     );
 }
 
-/// A stalled OPEN also costs one frame: the per-frame deadline covers
-/// opening, so an open that never completes is skipped (nothing to
-/// reset) and the next frame opens its own stream and finishes.
+/// A stalled allocation-free credit wait costs one frame. It is safe to
+/// cancel because no QUIC stream exists yet.
 #[tokio::test(start_paused = true)]
-async fn a_stalled_open_is_skipped_and_the_next_frame_proceeds() {
+async fn a_stalled_credit_wait_is_cancelled_and_the_next_frame_proceeds() {
     let mut rx = queue(2).await;
     let tally = Arc::new(Tally::default());
     let channel = MockChannel {
-        script: vec![Open::Stall, Open::Ready(Write::Ok)],
+        script: vec![Open::CreditStall, Open::Ready(Write::Ok)],
         tally: tally.clone(),
     };
 
@@ -226,7 +274,7 @@ async fn a_stalled_open_is_skipped_and_the_next_frame_proceeds() {
         "the next frame opens its own stream after the stalled open"
     );
     assert_eq!(
-        tally.open_cancelled.load(Ordering::SeqCst),
+        tally.credit_wait_cancelled.load(Ordering::SeqCst),
         1,
         "the timed-out open future is cancelled and returns its stream allowance wait"
     );
@@ -239,6 +287,50 @@ async fn a_stalled_open_is_skipped_and_the_next_frame_proceeds() {
         tally.reset.load(Ordering::SeqCst),
         0,
         "a stalled open has no stream to reset"
+    );
+}
+
+/// Once a QUIC stream is allocated, its header-flush future stays owned.
+/// The reaper awaits it and sends RESET_STREAM instead of dropping a
+/// headerless stream with FIN.
+#[tokio::test(start_paused = true)]
+async fn a_stalled_header_flush_is_reaped_with_reset_and_writing_continues() {
+    let mut rx = queue(2).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::HeaderStall(Write::Ok), Open::Ready(Write::Ok)],
+        tally: tally.clone(),
+    };
+    let reset_observed = tally.reset_observed.notified();
+    let task = tokio::spawn(async move {
+        drain_frames(ClientKey::new(1), 0, &channel, &mut rx, Instant::now()).await;
+    });
+
+    tally.header_started.notified().await;
+    tokio::time::advance(super::FRAME_WRITE_DEADLINE).await;
+    task.await.expect("frame writer joins");
+
+    assert_eq!(
+        tally.header_cancelled.load(Ordering::SeqCst),
+        0,
+        "the allocated stream's header future remains owned after its deadline"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "the next frame finishes while the first is reaped"
+    );
+    tally.header_release.notify_one();
+    reset_observed.await;
+    assert_eq!(
+        tally.reset.load(Ordering::SeqCst),
+        1,
+        "the reaper resets the allocated stream exactly once"
+    );
+    assert_eq!(
+        tally.header_cancelled.load(Ordering::SeqCst),
+        0,
+        "completing through the reaper never cancellation-drops the header future"
     );
 }
 
@@ -361,79 +453,4 @@ async fn a_local_close_loses_one_frame_and_the_writer_survives() {
         0,
         "a local close does not reset a stream"
     );
-}
-
-// ---- direct classifier matrix: every pinned wtransport variant --------------
-//
-// The drain tests above route through `classify_write`/`classify_open`,
-// but these pin the mapping itself so a reversed production classifier
-// (peer-local vs connection-fatal swapped) fails outright.
-
-#[test]
-fn classify_write_maps_every_pinned_variant() {
-    assert_eq!(
-        classify_write(&StreamWriteError::Stopped(VarInt::from_u32(9)), "write"),
-        StreamError::PeerStop {
-            phase: "write",
-            code: Some(9),
-        },
-    );
-    assert_eq!(
-        classify_write(&StreamWriteError::Closed, "finish"),
-        StreamError::LocalClose { phase: "finish" },
-    );
-    assert_eq!(
-        classify_write(&StreamWriteError::NotConnected, "write"),
-        StreamError::ConnectionFatal {
-            phase: "write",
-            kind: FatalKind::NotConnected,
-        },
-    );
-    assert_eq!(
-        classify_write(&StreamWriteError::QuicProto, "write"),
-        StreamError::ConnectionFatal {
-            phase: "write",
-            kind: FatalKind::QuicProto,
-        },
-    );
-}
-
-#[test]
-fn classify_open_maps_every_pinned_variant() {
-    assert_eq!(
-        classify_open(&StreamOpeningError::Refused),
-        StreamError::PeerStop {
-            phase: "open",
-            code: None,
-        },
-    );
-    assert_eq!(
-        classify_open(&StreamOpeningError::NotConnected),
-        StreamError::ConnectionFatal {
-            phase: "open",
-            kind: FatalKind::NotConnected,
-        },
-    );
-}
-
-#[test]
-fn an_open_request_error_preserves_its_concrete_cause() {
-    // A concrete ConnectionError must survive classification, not be
-    // erased to a static string: it is retained in the OpenRequest kind
-    // and reachable through the error source chain and Display.
-    let classified = classify_open_request(ConnectionError::TimedOut);
-    assert_eq!(
-        classified,
-        StreamError::ConnectionFatal {
-            phase: "open",
-            kind: FatalKind::OpenRequest(ConnectionError::TimedOut),
-        },
-    );
-    // The source chain reaches the exact ConnectionError.
-    let via_source = std::error::Error::source(&classified)
-        .and_then(std::error::Error::source)
-        .and_then(|e| e.downcast_ref::<ConnectionError>());
-    assert_eq!(via_source, Some(&ConnectionError::TimedOut));
-    // ...and its Display carries the concrete cause for the log.
-    assert!(classified.to_string().contains("timed out"), "{classified}");
 }

--- a/hosts/session-host/src/runtime/media/frame_writer/transport_tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/transport_tests.rs
@@ -1,0 +1,215 @@
+//! Real WebTransport coverage for allocated stream cleanup and credit reuse.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use pilotage_session::ClientKey;
+use tokio::sync::{Semaphore, mpsc};
+use tokio::time::timeout;
+use wtransport::config::QuicTransportConfig;
+use wtransport::quinn::VarInt as QuinnVarInt;
+use wtransport::stream::OpeningUniStream;
+use wtransport::{ClientConfig, Connection, Endpoint, Identity, SendStream, ServerConfig, VarInt};
+
+use super::reaper::OpenReapers;
+use super::{
+    DeadlinePhase, FrameChannel, FrameOutcome, FrameStream, StreamError, classify_open,
+    classify_open_request, classify_write, deliver_frame,
+};
+
+const IO_BOUND: Duration = Duration::from_secs(5);
+const SOAK_CYCLES: usize = 32;
+
+struct GatedConnection {
+    connection: Connection,
+    header_gates: Arc<Semaphore>,
+    reset_events: mpsc::UnboundedSender<bool>,
+}
+
+struct GatedOpening {
+    opening: OpeningUniStream,
+    header_gates: Arc<Semaphore>,
+    reset_events: mpsc::UnboundedSender<bool>,
+}
+
+struct ObservedSendStream {
+    stream: SendStream,
+    reset_events: mpsc::UnboundedSender<bool>,
+}
+
+impl FrameStream for ObservedSendStream {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), StreamError> {
+        self.stream
+            .write_all(buf)
+            .await
+            .map_err(|error| classify_write(&error, "write"))
+    }
+
+    async fn finish(&mut self) -> Result<(), StreamError> {
+        self.stream
+            .finish()
+            .await
+            .map_err(|error| classify_write(&error, "finish"))
+    }
+
+    fn reset(&mut self) {
+        let reset = self
+            .stream
+            .reset(VarInt::from_u32(super::STALL_RESET_CODE))
+            .is_ok();
+        self.reset_events.send(reset).ok();
+    }
+}
+
+impl FrameChannel for GatedConnection {
+    type Stream = ObservedSendStream;
+    type Opening = GatedOpening;
+
+    async fn request_open(&self) -> Result<GatedOpening, StreamError> {
+        let opening = self
+            .connection
+            .open_uni()
+            .await
+            .map_err(classify_open_request)?;
+        Ok(GatedOpening {
+            opening,
+            header_gates: Arc::clone(&self.header_gates),
+            reset_events: self.reset_events.clone(),
+        })
+    }
+
+    async fn finish_open(opening: GatedOpening) -> Result<ObservedSendStream, StreamError> {
+        let permit = opening
+            .header_gates
+            .acquire_owned()
+            .await
+            .expect("test gate remains open");
+        permit.forget();
+        let stream = opening
+            .opening
+            .await
+            .map_err(|error| classify_open(&error))?;
+        Ok(ObservedSendStream {
+            stream,
+            reset_events: opening.reset_events,
+        })
+    }
+}
+
+async fn connected_pair() -> (Connection, Connection) {
+    let identity =
+        Identity::self_signed(["localhost", "127.0.0.1"]).expect("test identity constructs");
+    let server_config = ServerConfig::builder()
+        .with_bind_address(([127, 0, 0, 1], 0).into())
+        .with_identity(identity)
+        .build();
+    let server = Endpoint::server(server_config).expect("server endpoint binds");
+    let server_addr = server.local_addr().expect("server has a local address");
+
+    let mut client_config = ClientConfig::builder()
+        .with_bind_default()
+        .with_no_cert_validation()
+        .build();
+    let mut transport = QuicTransportConfig::default();
+    transport.max_concurrent_uni_streams(QuinnVarInt::from_u32(8));
+    client_config
+        .quic_config_mut()
+        .transport_config(Arc::new(transport));
+    let client = Endpoint::client(client_config).expect("client endpoint binds");
+    let url = format!("https://127.0.0.1:{}/media-test", server_addr.port());
+
+    let accept = async {
+        server
+            .accept()
+            .await
+            .await
+            .expect("session request arrives")
+            .accept()
+            .await
+            .expect("server accepts session")
+    };
+    let connect = async {
+        client
+            .connect(url)
+            .await
+            .expect("client connects to server")
+    };
+    timeout(IO_BOUND, async { tokio::join!(accept, connect) })
+        .await
+        .expect("connection setup stays bounded")
+}
+
+#[tokio::test]
+async fn repeated_mid_open_deadlines_recycle_real_quic_credit() {
+    let (server, client) = connected_pair().await;
+    let header_gates = Arc::new(Semaphore::new(0));
+    let (reset_tx, mut reset_rx) = mpsc::unbounded_channel();
+    let channel = GatedConnection {
+        connection: server,
+        header_gates: Arc::clone(&header_gates),
+        reset_events: reset_tx,
+    };
+    let mut reapers = OpenReapers::new(ClientKey::new(21), 4);
+
+    for _ in 0..SOAK_CYCLES {
+        let outcome = deliver_frame(
+            &channel,
+            &mut reapers,
+            IO_BOUND,
+            Duration::ZERO,
+            0x02,
+            b"abandoned-frame",
+        )
+        .await;
+        assert!(
+            matches!(
+                outcome,
+                FrameOutcome::Stalled {
+                    phase: DeadlinePhase::HeaderFlush,
+                    reset: false,
+                    reaper_owned: true,
+                }
+            ),
+            "the allocated open transfers to its reaper: {outcome:?}"
+        );
+        header_gates.add_permits(1);
+        let reset = timeout(IO_BOUND, reset_rx.recv())
+            .await
+            .expect("the allocated stream is reaped")
+            .expect("the reset observer remains connected");
+        assert!(reset, "the real QUIC stream accepts RESET_STREAM");
+    }
+
+    header_gates.add_permits(1);
+    let outcome = deliver_frame(
+        &channel,
+        &mut reapers,
+        IO_BOUND,
+        IO_BOUND,
+        0x02,
+        b"healthy-frame",
+    )
+    .await;
+    assert!(matches!(outcome, FrameOutcome::Sent));
+
+    let mut healthy = timeout(IO_BOUND, client.accept_uni())
+        .await
+        .expect("healthy stream is surfaced")
+        .expect("connection remains healthy");
+    let mut body = [0_u8; 14];
+    timeout(IO_BOUND, healthy.read_exact(&mut body))
+        .await
+        .expect("healthy frame arrives")
+        .expect("healthy frame is complete");
+    assert_eq!(&body, b"\x02healthy-frame");
+    assert_eq!(
+        timeout(IO_BOUND, healthy.read(&mut [0_u8; 1]))
+            .await
+            .expect("healthy FIN arrives")
+            .expect("healthy stream has no read error"),
+        None,
+        "the healthy frame finishes cleanly"
+    );
+}


### PR DESCRIPTION
Closes #215

## Root cause

The video writer timed the two-stage `wtransport::Connection::open_uni` operation as one future. Cancelling its second await abandoned an already allocated QUIC send stream while the WebTransport stream header was still flushing. Quinn then treated the dropped stream as a graceful FIN, leaving the browser with a headerless stream it could not surface or cancel and eventually exhausting stream credit.

## Changes

- Split the frame-channel seam into an allocation-free stream-credit wait and an allocated WebTransport header flush.
- Give stream-credit starvation its own 30-second bound and phase-specific diagnostics; the per-frame deadline begins only after allocation.
- Transfer every timed-out allocated open to a detached reaper that awaits completion and explicitly resets the resulting stream.
- Bound each writer to eight pending reapers and log both active and lifetime counts.
- Preserve the existing immediate reset behavior for body-write stalls and the typed peer-local versus connection-fatal classifications.
- Split classifier tests into a dedicated module to retain the repository size guardrails.

## Guardrails

- A stage-two blocking fake proves deadline expiry does not cancellation-drop the opening future, writing continues, and the reaper resets exactly once without FIN.
- A bounded-reaper test proves the hard cap, active count, lifetime count, and reset behavior.
- A real wtransport loopback soak advertises only eight uni-stream credits, forces 32 mid-open deadlines, observes an accepted RESET_STREAM for every allocated stream, and then delivers a healthy frame with a clean FIN.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS='-D missing_docs -D rustdoc::broken_intra_doc_links' cargo doc --no-deps`
- `cargo build --release`
- `bash scripts/check-structure.sh`
- instrument requirement, certification-claim, standards-registry, trace-inventory, bare-metal target, and timing gates
