### PR TITLE
Pace the publish-gated control-loop path: closed-gate spin froze the page in Chrome and Safari

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
       - name: viewer input-loss gate (latched blur, no post-latch frames, held-button safety)
         run: node clients/web/control-gate.test.mjs
 
+      - name: control-loop macrotask pacing (gated un-latched path must not microtask-spin)
+        run: node clients/web/control-pacing.test.mjs
+
       - name: motion-lease reacquisition (release fence, stale-grant rejection, terminal denial)
         run: node clients/web/motion-lease.test.mjs
 

--- a/clients/web/control-loop.js
+++ b/clients/web/control-loop.js
@@ -551,7 +551,18 @@ export function createControlLoop({
         requestSimReset();
       }
       maybeAnnounceProfileActivation();
-      if (!controlGate.mayPublish()) continue;
+      if (!controlGate.mayPublish()) {
+        // The gate can be closed WITHOUT the latch: a window the operator
+        // never focused (launcher-opened tab, autoconnect while working in
+        // the terminal) has no blur to latch, yet hasFocus() is false. The
+        // writer's ready promise resolves immediately when idle, so skipping
+        // the interval here would spin the loop on microtasks alone —
+        // starving timers, rendering, and the transport readers, with no
+        // way back (the focus event that would open the gate rides the
+        // starved macrotask queue).
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        continue;
+      }
       if (plan.motion) sendMotionFrame(writer, token, mode, plan);
       if (plan.gimbal) sendGimbalFrame(writer, token, plan.gimbal);
       if (plan.lease) executeLeaseAction(token, plan.lease, gimbalScope);

--- a/clients/web/control-pacing.test.mjs
+++ b/clients/web/control-pacing.test.mjs
@@ -1,0 +1,130 @@
+// The control loop must yield to MACROTASKS between iterations on EVERY
+// path — including the publish-gated one. A path that re-enters the loop
+// through only-microtask awaits (an immediately-ready datagram writer plus a
+// bare `continue`) starves timers, rendering, and the WebTransport readers:
+// the page freezes at 100% CPU and never recovers, because even the focus
+// and click events that would open the gate ride the starved macrotask
+// queue. The gated state is reachable un-latched: a launcher-opened window
+// the operator never focused has `document.hasFocus() === false` with no
+// blur event ever delivered, so `mayPublish()` is false while `isLatched()`
+// is false.
+//
+// The check is event-based, not wall-clock: a zero-delay timer scheduled at
+// loop start must fire before the loop completes its tick quota. In a
+// microtask spin the timer can only run after the loop exits.
+//
+// Run: node clients/web/control-pacing.test.mjs
+
+import { createControlLoop } from "./control-loop.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) {
+    console.log(`ok   - ${name}`);
+  } else {
+    console.error(`FAIL - ${name}`);
+    failures += 1;
+  }
+}
+
+// activeGamepad() probes the browser gamepad API; node has no navigator with
+// gamepads, so give it an empty probe.
+globalThis.navigator ??= {};
+
+const TICK_QUOTA = 30;
+
+async function runGatedLoop({ mayPublish }) {
+  let ticks = 0;
+  let active = true;
+  const state = {
+    connected: true,
+    controlShell: null,
+    selectedPadId: null,
+    pendingReset: false,
+    actionTracker: { pending: new Map(), nextId: 1 },
+    controlCompletion: null,
+    stopControlRun: null,
+    motionScope: "vehicle.motion",
+  };
+  state.controlShell = {
+    beginControlRun() {},
+    tickFromKeys() {
+      ticks += 1;
+      if (ticks >= TICK_QUOTA) active = false;
+      return { motion: null, gimbal: null, lease: null, motionLease: null };
+    },
+  };
+  const loop = createControlLoop({
+    state,
+    els: { flightMode: { value: "rover" } },
+    transportSessions: {
+      isActive: () => active,
+      trackWriter: () => true,
+      untrackWriter() {},
+      currentToken: () => 1,
+    },
+    controlGate: { isLatched: () => false, mayPublish: () => mayPublish, reset() {} },
+    releaseTracker: {},
+    vehicleId: "veh",
+    motionScope: "vehicle.motion",
+    directScope: "vehicle.motion.direct",
+    gimbalScope: "vehicle.gimbal",
+    lifecycleScope: "vehicle.lifecycle",
+    frameRejectionUplinkIdle: () => false,
+    // Fast cadence keeps the paced run short; pacing is what's under test,
+    // not the interval width.
+    controlHz: 200,
+    log() {},
+    surface: new Proxy({}, { get: () => () => {} }),
+    updateControlReadout() {},
+    reportSuppressedPresses() {},
+    currentTelemetryHeading: () => null,
+    lengthDelimit: (bytes) => bytes,
+    maybeAnnounceProfileActivation() {},
+    requestReconnect() {},
+  });
+
+  let ticksWhenTimerFired = null;
+  setTimeout(() => {
+    ticksWhenTimerFired = ticks;
+  }, 0);
+
+  const writer = { ready: Promise.resolve(), releaseLock() {}, write: async () => {} };
+  const started = loop.startControlLoop(
+    { datagrams: { createWritable: () => ({ getWriter: () => writer }) } },
+    1,
+  );
+  check("the loop starts", started);
+  await state.controlCompletion;
+  // Let the zero-delay timer run if it has not yet.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return { ticks, ticksWhenTimerFired };
+}
+
+// ---- the gated (mayPublish false, un-latched) path must still pace ---------
+{
+  const { ticks, ticksWhenTimerFired } = await runGatedLoop({ mayPublish: false });
+  check(`the gated loop ran its quota (${ticks}/${TICK_QUOTA})`, ticks === TICK_QUOTA);
+  check(
+    "a zero-delay timer fires BEFORE the gated loop finishes its quota " +
+      `(fired at tick ${ticksWhenTimerFired})`,
+    ticksWhenTimerFired !== null && ticksWhenTimerFired < TICK_QUOTA,
+  );
+}
+
+// ---- positive control: the publishing path paces the same way --------------
+{
+  const { ticks, ticksWhenTimerFired } = await runGatedLoop({ mayPublish: true });
+  check(`the publishing loop ran its quota (${ticks}/${TICK_QUOTA})`, ticks === TICK_QUOTA);
+  check(
+    "a zero-delay timer interleaves with the publishing loop " +
+      `(fired at tick ${ticksWhenTimerFired})`,
+    ticksWhenTimerFired !== null && ticksWhenTimerFired < TICK_QUOTA,
+  );
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall control-pacing checks passed");

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -22,7 +22,7 @@ const SIZE_CAPS = {
   "connect-authority.js": 63,
   "control-edges.js": 31,
   "control-gate.js": 39,
-  "control-loop.js": 809,
+  "control-loop.js": 820,
   "control-shell.js": 341,
   "datagram-control.js": 80,
   "instrument-health.js": 395,


### PR DESCRIPTION
Fixes #220 — the browser-agnostic page freeze (Chrome AND Safari) that survived the transport-layer fixes.

## The defect

`runControlLoop` had exactly one path that skipped the tick-interval pacing:

```js
if (!controlGate.mayPublish()) continue;
```

`mayPublish()` is `!latched && document.hasFocus()`. The design assumed a closed gate implies a latched blur, but the gate is reachable **closed and un-latched**: a window the operator never focused (launcher-opened tab; autoconnect is visibility-gated, not focus-gated) has `hasFocus() === false` with no blur ever delivered. On that path the loop's only await is `writer.ready` — pre-resolved on an idle datagram writer — so it re-enters through microtasks alone, starving every macrotask (rendering, timers, input events, WebTransport reader wakeups) at 100% CPU. Unrecoverable by construction: the focus event that would reopen the gate rides the starved queue. Root-caused live with `sample` (1742/1742 main-thread samples in JIT frames) plus a CDP `Debugger.pause` stack: `runControlLoop → evaluateInputTick → tickFromKeys → wasm WebControl::evaluate`.

## The fix

The gated path now awaits the same tick interval as every other loop path before continuing. Semantics are unchanged: no frame is published while the gate is closed, and a later focus (which sets `hasFocus()` true with no latch to clear) resumes publishing on the next tick.

## Guardrail (fails pre-fix)

`control-pacing.test.mjs` drives the **real** `startControlLoop` with a closed un-latched gate and an always-ready writer. The assertion is event-based, not wall-clock: a zero-delay timer scheduled at loop start must fire before the loop finishes a 30-tick quota. On the unfixed code the timer fires only after the quota (pure microtask spin); post-fix it interleaves at tick 1. A `mayPublish: true` positive control shows the publishing path paces identically. Wired into CI as its own step.

## Verification

- Guard test: FAIL on unfixed code (`fired at tick 30`), PASS post-fix (`fired at tick 1`).
- Hidden-connect CDP rig against the live session: hang within 5 s pre-fix (stack captured), 120 s alive post-fix, same session.
- Visible-connect rig: 120 s alive both before and after (the freeze was strictly the un-focused state).
- `control-structure`, `control-gate`, `control-edges`, `reconnect`, `connect-lifecycle` suites green; control-loop.js size floor consciously bumped 809 → 820 for the pacing block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmY4DtgmphoiiUQWEJGT9