### PR TITLE
Preserve stage logs across relaunches and name transport errors in the viewer

### DIFF
--- a/clients/web/cockpit-readout.js
+++ b/clients/web/cockpit-readout.js
@@ -224,7 +224,22 @@ export function createCockpitReadout({
       )
     ) return;
     streamReadFailures.lastLoggedMs = nowMs;
-    log(`uni stream read failed: ${error} (${streamReadFailures.count} total this session)`);
+    log(
+      `uni stream read failed: ${describeTransportError(error)} ` +
+        `(${streamReadFailures.count} total this session)`,
+    );
+  }
+
+  // A bare `WebTransportError` cannot distinguish a host-side stream RESET
+  // (the reaper abandoning one mid-open frame — per-stream, recoverable)
+  // from session-level failure; the source and error code make the log a
+  // usable forensic record.
+  function describeTransportError(error) {
+    if (typeof WebTransportError !== "undefined" && error instanceof WebTransportError) {
+      const code = error.streamErrorCode === null ? "none" : error.streamErrorCode;
+      return `WebTransportError source=${error.source} streamErrorCode=${code}`;
+    }
+    return `${error}`;
   }
 
   async function acceptIncomingUniStreams(transport, token) {

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -18,7 +18,7 @@ const SIZE_CAPS = {
   "authority-transition.js": 22,
   "bootstrap.js": 88,
   "calibration.js": 285,
-  "cockpit-readout.js": 691,
+  "cockpit-readout.js": 706,
   "connect-authority.js": 63,
   "control-edges.js": 31,
   "control-gate.js": 39,

--- a/tools/xtask/src/log_archive.rs
+++ b/tools/xtask/src/log_archive.rs
@@ -1,0 +1,181 @@
+//! Preserves the previous sim run's stage logs before a new launch
+//! overwrites them.
+//!
+//! Stage logs are the primary incident record (writer deadlines, budget
+//! transitions, link-loss policy); truncating them at the next launch
+//! destroys exactly the evidence an operator relaunches to investigate.
+//! Each launch moves the prior run's `*.log` files into `prev/run-<epoch>/`
+//! keyed by the newest log's modification time, and prunes the oldest
+//! archives beyond a bounded count.
+
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use crate::error::XtaskError;
+
+/// Archived runs kept under `prev/`; the oldest beyond this are removed.
+const MAX_ARCHIVED_RUNS: usize = 10;
+
+/// Moves any `*.log` files directly inside `log_dir` into
+/// `prev/run-<epoch-seconds>/` and prunes old archives. Returns the archive
+/// directory, or `None` when there was nothing to preserve.
+///
+/// # Errors
+///
+/// Returns [`XtaskError::Io`] when the log directory cannot be scanned or a
+/// log file cannot be moved into the archive.
+pub fn archive_previous_logs(log_dir: &Path) -> Result<Option<PathBuf>, XtaskError> {
+    let logs = previous_logs(log_dir)?;
+    let Some(stamp) = newest_mtime_epoch(&logs) else {
+        return Ok(None);
+    };
+    let archive = log_dir.join("prev").join(format!("run-{stamp}"));
+    std::fs::create_dir_all(&archive).map_err(|source| XtaskError::Io {
+        context: "creating the previous-run log archive",
+        source,
+    })?;
+    for log in &logs {
+        let Some(name) = log.file_name() else {
+            continue;
+        };
+        std::fs::rename(log, archive.join(name)).map_err(|source| XtaskError::Io {
+            context: "moving a previous-run log into the archive",
+            source,
+        })?;
+    }
+    prune_old_archives(&log_dir.join("prev"))?;
+    Ok(Some(archive))
+}
+
+fn previous_logs(log_dir: &Path) -> Result<Vec<PathBuf>, XtaskError> {
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(XtaskError::Io {
+                context: "scanning the session log directory",
+                source,
+            });
+        }
+    };
+    let mut logs: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "log"))
+        .collect();
+    logs.sort();
+    Ok(logs)
+}
+
+fn newest_mtime_epoch(logs: &[PathBuf]) -> Option<u64> {
+    logs.iter()
+        .filter_map(|log| log.metadata().ok()?.modified().ok())
+        .filter_map(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
+        .map(|since| since.as_secs())
+        .max()
+}
+
+fn prune_old_archives(prev_dir: &Path) -> Result<(), XtaskError> {
+    let Ok(entries) = std::fs::read_dir(prev_dir) else {
+        return Ok(());
+    };
+    let mut runs: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    // `run-<epoch>` names sort chronologically while epoch seconds keep the
+    // same digit count; equal-width numeric names make lexical order safe.
+    runs.sort();
+    while runs.len() > MAX_ARCHIVED_RUNS {
+        let oldest = runs.remove(0);
+        std::fs::remove_dir_all(&oldest).map_err(|source| XtaskError::Io {
+            context: "pruning the oldest archived run logs",
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+    use std::path::PathBuf;
+
+    use super::{MAX_ARCHIVED_RUNS, archive_previous_logs};
+
+    /// Fresh scratch directory, removed on drop; keeps the tests std-only.
+    struct ScratchDir(PathBuf);
+
+    impl ScratchDir {
+        fn new(label: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("xtask-log-archive-{label}-{}", std::process::id()));
+            std::fs::remove_dir_all(&dir).ok();
+            std::fs::create_dir_all(&dir).expect("scratch dir");
+            Self(dir)
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    #[test]
+    fn logs_move_into_a_run_archive_and_the_log_dir_is_left_clean() {
+        let dir = ScratchDir::new("move");
+        std::fs::write(dir.path().join("session-host.log"), b"evidence").expect("write");
+        std::fs::write(dir.path().join("gazebo.log"), b"gz").expect("write");
+        std::fs::write(dir.path().join("supervisor.pid"), b"123").expect("write");
+
+        let archive = archive_previous_logs(dir.path())
+            .expect("archive succeeds")
+            .expect("logs existed");
+        let preserved =
+            std::fs::read_to_string(archive.join("session-host.log")).expect("preserved");
+        assert_eq!(preserved, "evidence", "log content survives the move");
+        assert!(
+            !dir.path().join("session-host.log").exists(),
+            "the live log dir no longer holds the previous run's log"
+        );
+        assert!(
+            dir.path().join("supervisor.pid").exists(),
+            "non-log files stay untouched"
+        );
+    }
+
+    #[test]
+    fn an_empty_log_dir_archives_nothing() {
+        let dir = ScratchDir::new("empty");
+        assert!(
+            archive_previous_logs(dir.path())
+                .expect("archive succeeds")
+                .is_none()
+        );
+        assert!(!dir.path().join("prev").exists(), "no archive dir appears");
+    }
+
+    #[test]
+    fn archives_beyond_the_bound_prune_oldest_first() {
+        let dir = ScratchDir::new("prune");
+        let prev = dir.path().join("prev");
+        for stamp in 0..=MAX_ARCHIVED_RUNS {
+            std::fs::create_dir_all(prev.join(format!("run-{stamp:010}"))).expect("mkdir");
+        }
+        std::fs::write(dir.path().join("viewer.log"), b"v").expect("write");
+        archive_previous_logs(dir.path()).expect("archive succeeds");
+
+        assert!(
+            !prev.join(format!("run-{:010}", 0)).exists(),
+            "the oldest archive is pruned"
+        );
+        let kept = std::fs::read_dir(&prev).expect("read prev").count();
+        assert_eq!(kept, MAX_ARCHIVED_RUNS, "the bound holds after pruning");
+    }
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -7,6 +7,7 @@ use std::process::ExitCode;
 mod backend;
 mod cli;
 mod error;
+mod log_archive;
 mod output;
 mod process;
 mod readiness;

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -36,11 +36,7 @@ const MAX_STAGE_RESTARTS: u32 = 3;
 pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     let backend = backend_for(&args.fc)?;
     let repo_root = repo_root()?;
-    let log_dir = repo_root.join("target/xtask-sim");
-    std::fs::create_dir_all(&log_dir).map_err(|source| XtaskError::Io {
-        context: "creating the session log directory",
-        source,
-    })?;
+    let log_dir = prepared_log_dir(&repo_root)?;
     let ctx = SessionContext {
         repo_root: repo_root.clone(),
         host_port: args.host_port,
@@ -249,6 +245,23 @@ pub fn run_reset(fc: &str) -> Result<(), XtaskError> {
 /// This repository's root: the checkout `cargo xtask` was INVOKED from.
 ///
 /// `cargo run` exports `CARGO_MANIFEST_DIR` into the child's runtime
+/// Ensures the stage-log directory exists with the previous run's logs
+/// preserved out of the way, announcing where they went.
+fn prepared_log_dir(repo_root: &std::path::Path) -> Result<PathBuf, XtaskError> {
+    let log_dir = repo_root.join("target/xtask-sim");
+    std::fs::create_dir_all(&log_dir).map_err(|source| XtaskError::Io {
+        context: "creating the session log directory",
+        source,
+    })?;
+    if let Some(archive) = crate::log_archive::archive_previous_logs(&log_dir)? {
+        print_line(&format!(
+            "previous run's logs preserved at {}",
+            archive.display()
+        ));
+    }
+    Ok(log_dir)
+}
+
 /// environment, pointing at the invoking workspace's `tools/xtask` — so a
 /// binary cached from another checkout (a worktree, a moved clone) still
 /// operates on the repository the user is standing in. The compile-time


### PR DESCRIPTION
Fixes #222. Debug-observability groundwork for the recurring T+~22 s one-way video wedge (#219 family), which recurred at 2026-07-23 17:48Z with the page fully responsive (post-#221) — and whose host-side record was destroyed by the investigative relaunch itself.

## Changes

**`xtask` log archive** — `cargo xtask sim` now moves the previous run's `target/xtask-sim/*.log` into `prev/run-<epoch>/` before launching (epoch = newest log's mtime), keeping a bounded 10 archives with oldest-first pruning. Non-log files (`supervisor.pid`) stay put. Unit tests cover the move with content survival, the empty-dir no-op, and the prune bound.

**Viewer transport-error detail** — uni-stream read failures now log `WebTransportError source=<stream|session> streamErrorCode=<code|none>`, which is the discrimination between a benign per-stream reaper RESET (#216 machinery) and session-level failure that the bare class name dropped.

## Investigation record (what this run established)

- Clean-profile headed Chrome, armed with input held, 150 s against live px4-gz: **no wedge**; one busy-drop degraded the budget one step (2 → 1 MB/s) with recovery beginning 5 s later.
- The #218 `VideoDeliveryState` path **works end-to-end** (live-verified: SIGSTOP-induced backpressure → host publishes degraded → viewer logs `video degraded — bandwidth (1.0 Mbit/s)` on catch-up).
- The 17:48 incident log shows **no** delivery banner before the wedge ⇒ the wedge is an abrupt transport event, not congestion buildup. Naming it needs the host log of the *next* occurrence — which this PR makes survivable.

Gates: `fmt --check`, `clippy -p xtask --all-targets -D warnings`, `cargo test -p xtask` (3 new tests), `control-structure` ratchet (cockpit-readout floor 691 → 706), cockpit-adjacent node suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmY4DtgmphoiiUQWEJGT9

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #224
- <kbd>&nbsp;1&nbsp;</kbd> #223 👈 
<!-- GitButler Footer Boundary Bottom -->