### PR TITLE
Amend ADR-0005: media units ride one long-lived stream per source

### DIFF
--- a/docs/adr/0005-webtransport-primary-transport.md
+++ b/docs/adr/0005-webtransport-primary-transport.md
@@ -31,7 +31,7 @@ delivery and a media pipeline) no longer holds.
   | `telemetry-fast` | Datagrams | Unordered, best effort |
   | `authority-events` | Reliable ordered stream (dedicated) | Lease grants, handover, override, revocation, acknowledgements |
   | `bulk` | One stream per transfer | Profiles, capabilities, configuration, log fragments; no head-of-line contention with authority events |
-  | `media` | Unidirectional stream per frame or GOP | Encoded video units with bounded lifetime; late units abandoned, not awaited |
+  | `media` | Unidirectional stream per source, amended from per frame or GOP — see Amendments below | Encoded video units with bounded lifetime; late units abandoned, not awaited |
 
 - **Video** is encoded on the host (low-latency H.264 first; AV1/HEVC as adapters
   and hardware allow), carried as media-class streams, decoded in the browser with
@@ -84,3 +84,47 @@ system floor governs.
 - **WebTransport for data + WebRTC for media only:** doubles the transport surface
   for one feature (built-in CC) that we intend to own anyway; worst of both worlds
   for a small team.
+
+## Amendments
+
+### 2026-07-24 — Media units are multiplexed on one long-lived stream per source
+
+The original media row specified a unidirectional stream per frame or GOP. That
+framing is not portable across browser engines.
+
+WebKit grants a WebTransport session a one-shot connection-level flow-control
+window (~16 MiB) and never returns the window consumed by streams that have
+CLOSED. A stream-per-frame producer therefore spends the connection's entire
+byte budget after a fixed VOLUME of media and the peer stops consuming
+permanently — while datagrams continue to flow, because they are not
+connection-flow-controlled. Measured against a minimal server and page, with
+Chrome as the control (the reproducer and full measurements are recorded under
+VID-09):
+
+| Variant (Safari 27.0) | Streams at wedge | Bytes at wedge | `MAX_DATA` received |
+|---|---|---|---|
+| stream-per-unit, 16 KiB units | 1,023 | 16,774,110 | 0 |
+| stream-per-unit, 4 KiB units | 4,092 | 16,764,903 | 0 |
+| stream-per-unit + explicit reader cancel | 1,023 | 16,774,110 | 0 |
+| one long-lived stream, same byte rate | — | 51.9 MB, still climbing | rising |
+
+Two unit sizes separate a byte ceiling from a stream-count ceiling: four times
+the streams reach the same ~16 MiB wall. Stream-count credit is extended
+normally throughout, and the congestion counters stay clean, so this is neither
+stream exhaustion nor congestion. An explicit client-side cancel reclaims
+nothing, so the receiver has no workaround available to it.
+
+The media class is therefore **one long-lived unidirectional stream per source**
+carrying length-delimited encoded units. The properties the original row bought
+are preserved by moving where they are enforced:
+
+- **Late units are abandoned, not awaited.** Admission control sheds whole units
+  before the transport, so at most one unit per source is ever in flight, and a
+  write that outlives its deadline RESETs the stream and the next unit opens a
+  fresh one. Droppability moves from the unit to the stream.
+- **Head-of-line blocking stays bounded** by that same one-unit depth; a slow
+  consumer costs the stream, not the source.
+- **Sources stay independent**: one source's stream reset cannot delay another's.
+
+A receiver distinguishes the framings by the stream's kind tag, so the unit body
+layout (ADR-0020 capture identity, ADR-0016 codec tag) is unchanged.


### PR DESCRIPTION
The shipped code (#230) no longer matches ADR-0005's media row, which specifies "Unidirectional stream per frame or GOP". This records the decision and, more importantly, *why it is not a free choice*.

**The constraint.** WebKit grants a WebTransport session a one-shot connection-level flow-control window (~16 MiB) and never returns the window consumed by CLOSED streams. A stream-per-frame producer spends the connection's whole byte budget after a fixed VOLUME of media and the peer stops consuming permanently — while datagrams keep flowing, because they are not connection-flow-controlled. That asymmetry is exactly what made the failure look like a transport bug for days: telemetry and instruments stayed live while video died.

**The measurement**, included in the amendment so a future reader does not have to re-derive it: two unit sizes reach the same ~16 MiB ceiling with four times the streams (1,023 × 16 KiB vs 4,092 × 4 KiB), stream-count credit is extended normally throughout, congestion counters stay clean, an explicit client-side cancel reclaims nothing, and the same server on one long-lived stream passes 51.9 MB and keeps going. Chrome is the control.

**What the amendment preserves.** The original row bought three properties, all kept by moving where they are enforced: late units are abandoned not awaited (admission control sheds whole units before the transport, so at most one is in flight per source, and a write past its deadline RESETs the stream); head-of-line blocking stays bounded by that same one-unit depth; sources stay independent. The unit body layout (ADR-0020 capture identity, ADR-0016 codec tag) is unchanged — only the stream lifetime differs, and receivers tell the two framings apart by the kind tag.

The table row now points at the amendment rather than silently contradicting the code, following the ADR-0008 amendment pattern.

Docs only — no code changes. The reproducer and full measurements live under VID-09 rather than in the tree: it needs a real browser and manual interaction, so it can never run in CI, while the automated guard that actually prevents regression (`many_frames_ride_a_single_stream`: N frames must open exactly one stream) already landed with #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmY4DtgmphoiiUQWEJGT9