### PR TITLE
Restore multiplexed video in the loopback probe

### DIFF
--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
+config-digest: e3f507a2e6b054c3e8e7c97f5413beef9094e2be
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+run-id: local:e3f507a2e6b054c3e8e7c97f5413beef9094e2be
 outcome: pass
 summary:
-test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -217,12 +217,12 @@ attr outcome pass
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr config-digest e3f507a2e6b054c3e8e7c97f5413beef9094e2be
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:22c8f6e33ee12ecfa1075d017a73b5e77ebc0828
+attr source-digest git-blob:df617d3617a8686db56c1600409b7a0856c31907
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:3c2b1962e64c629567607d5287764942711070b46cbe1083663dbc9005cc1afe
-attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr output-digest sha256:8e066de0a9cf43a34f0285ac52518d656c1c4fc5148f1ae13aa75db96a6180e1
+attr run-id local:e3f507a2e6b054c3e8e7c97f5413beef9094e2be
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
@@ -260,6 +260,12 @@ title committed code baseline the recorded results were produced against (engine
 attr scm git
 attr commit f75f99d46eed66cae2384b303029e6b84b5f9ed7
 attr tree 9b6e82ce4092a7fa8190e159d9626492462642e4
+
+node CFG-LINK-PROBE-V3 configuration-item
+title committed code baseline for the multiplexed-video receiver result
+attr scm git
+attr commit e3f507a2e6b054c3e8e7c97f5413beef9094e2be
+attr tree b8987caac4d291894ca5d09fa2a67fd03e222c9a
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)
@@ -367,7 +373,7 @@ edge RESULT-LINK-CAPTURE justified-by TOOL-LINK-CARGO
 
 edge RESULT-LINK-CAPTURE-RT result-of CASE-LINK-CAPTURE-RT
 edge RESULT-LINK-CAPTURE-RT covers LINK-PROV-003
-edge RESULT-LINK-CAPTURE-RT justified-by CFG-LINK-WORKTREE
+edge RESULT-LINK-CAPTURE-RT justified-by CFG-LINK-PROBE-V3
 edge RESULT-LINK-CAPTURE-RT justified-by TOOL-LINK-CARGO
 
 edge RESULT-LINK-CAPTURE-SINK result-of CASE-LINK-CAPTURE-SINK

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -2,13 +2,11 @@
 //! Telemetry, `Pong`, and `FrameRejected` all arrive as datagrams (the host's
 //! control-fast/telemetry class mapping) and are routed by envelope arm.
 //!
-//! Host-initiated uni streams carry two kinds of traffic (ADR-0005): the
-//! dedicated authority-events stream, opened once per connection, and one
-//! fresh stream per video frame (media = one uni stream per frame). Every
-//! host-initiated uni stream leads with a 1-byte kind tag; this module accepts
-//! every such stream in a loop and dispatches each on that tag, spawning a
-//! short-lived reader task per video-frame stream so a slow video decode never
-//! blocks accepting the next stream.
+//! Host-initiated uni streams carry authority events and video (ADR-0005).
+//! Every stream leads with a 1-byte kind tag; authority and per-source video
+//! streams remain open and dispatch complete records as they arrive. Each
+//! accepted stream gets its own reader task so a slow video decode never
+//! blocks accepting another source.
 //!
 //! Every hand-off to the run loop's bounded event channel uses `try_send`,
 //! never the blocking `send().await`: the channel's consumer (`handle_event`)
@@ -57,9 +55,8 @@ pub enum ReceiverEvent {
     /// An authority/mode event read from the host's dedicated authority-events
     /// stream (ADR-0005). Counted only, to prove the stream is live.
     Authority,
-    /// One raw JPEG frame body read off a per-frame video uni stream
-    /// (ADR-0005 media = one uni stream per frame). Inter-arrival latency is
-    /// measured by the run loop's own wall clock at the point it receives
+    /// One raw JPEG frame body read from a video stream. Inter-arrival latency
+    /// is measured by the run loop's own wall clock at the point it receives
     /// this event, not by a timestamp carried on the event itself.
     VideoFrame {
         /// Video source this frame came from: 0 = onboard FPV, 1 = chase.
@@ -72,9 +69,8 @@ pub enum ReceiverEvent {
 /// Spawns the receiver task: branches poll datagrams (telemetry, `Pong`,
 /// `FrameRejected`), the bootstrap bidi stream's `recv` half (to observe a
 /// post-handshake stream close), and every host-initiated uni stream accepted
-/// over the connection's lifetime (the dedicated authority-events stream plus
-/// one fresh stream per video frame, ADR-0005). Named so an aborted-task audit
-/// can identify it (ADR-0015).
+/// over the connection's lifetime. Named so an aborted-task audit can identify
+/// it (ADR-0015).
 ///
 /// Takes only `recv_stream`; the bidi stream's send half stays in the run
 /// loop, kept open but unwritten after the handshake.

--- a/tools/loopback-probe/src/receiver/uni_stream.rs
+++ b/tools/loopback-probe/src/receiver/uni_stream.rs
@@ -1,12 +1,10 @@
 //! Reading of host-initiated unidirectional streams (ADR-0005): the dedicated
-//! authority-events stream and the per-frame video streams.
+//! authority-events stream and the video streams.
 //!
 //! Every host-initiated uni stream leads with a 1-byte kind tag; each accepted
-//! stream is read to completion by a short-lived task so a slow video decode
-//! never blocks accepting the next stream. The authority-events stream stays
-//! open for the connection's lifetime (repeated length-delimited envelopes); a
-//! video-frame stream carries exactly one
-//! `[source_id][fourcc][u32 LE len][jpeg]` body (ADR-0016) and closes.
+//! stream gets its own reader task so a slow video decode never blocks
+//! accepting the next stream. Authority and multiplexed video streams stay
+//! open and dispatch complete records as they arrive.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -22,12 +20,18 @@ use super::{ReceiverEvent, drain_stream_frames, forward_event};
 const AUTHORITY_EVENTS_TAG: u8 = 0x01;
 /// Kind tag prefixing a per-frame video uni stream (ADR-0005).
 const VIDEO_FRAME_TAG: u8 = 0x02;
+/// Kind tag prefixing a per-frame capture-identity video stream.
+const VIDEO_FRAME_V2_TAG: u8 = 0x03;
+/// Kind tag prefixing a long-lived, length-delimited video stream.
+const VIDEO_STREAM_V3_TAG: u8 = 0x04;
+/// Byte count of the big-endian length prefix on each V3 record.
+const VIDEO_RECORD_PREFIX_LEN: usize = 4;
+/// Reject implausible declarations before buffering toward their length.
+const MAX_VIDEO_RECORD_LEN: usize = 64 * 1024 * 1024;
 
 /// Reads exactly one host-initiated uni stream to completion: the leading
 /// kind-tag byte, then the tag-specific body, forwarding the decoded
-/// [`ReceiverEvent`]s. The authority-events stream stays open for the
-/// connection's lifetime and is read incrementally (repeated envelopes); a
-/// video-frame stream carries exactly one framed JPEG and then closes.
+/// [`ReceiverEvent`]s. Long-lived stream kinds are decoded incrementally.
 pub(super) async fn read_one_uni_stream(
     mut stream: RecvStream,
     start: Instant,
@@ -44,6 +48,12 @@ pub(super) async fn read_one_uni_stream(
             read_authority_stream(stream, buf, chunk, start, events_tx, dropped_events).await;
         }
         VIDEO_FRAME_TAG => read_video_stream(stream, buf, chunk, events_tx, dropped_events).await,
+        VIDEO_FRAME_V2_TAG => {
+            read_video_v2_stream(stream, buf, chunk, events_tx, dropped_events).await;
+        }
+        VIDEO_STREAM_V3_TAG => {
+            read_video_record_stream(stream, buf, chunk, events_tx, dropped_events).await;
+        }
         other => warn!(
             tag = other,
             "unrecognized uni-stream kind tag; dropping stream"
@@ -102,6 +112,122 @@ async fn read_authority_stream(
 
 /// FourCC of the only video codec this viewer decodes: Motion JPEG (ADR-0016).
 const FOURCC_MJPEG: [u8; 4] = *b"MJPG";
+
+/// Reads one capture-identity frame carried by the retired V2 stream kind.
+async fn read_video_v2_stream(
+    mut stream: RecvStream,
+    mut buf: Vec<u8>,
+    mut chunk: [u8; 64 * 1024],
+    events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
+) {
+    loop {
+        match stream.read(&mut chunk).await {
+            Ok(Some(count)) => buf.extend_from_slice(&chunk[..count]),
+            Ok(None) => {
+                forward_video_v2_body(&buf, &events_tx, &dropped_events);
+                return;
+            }
+            Err(source) => {
+                warn!(%source, "video-frame V2 stream read failed");
+                return;
+            }
+        }
+    }
+}
+
+/// Reads repeated length-delimited V2 frame bodies from a live V3 stream.
+async fn read_video_record_stream(
+    mut stream: RecvStream,
+    mut buf: Vec<u8>,
+    mut chunk: [u8; 64 * 1024],
+    events_tx: mpsc::Sender<ReceiverEvent>,
+    dropped_events: Arc<AtomicU64>,
+) {
+    loop {
+        if let Err(declared) = drain_video_records(&mut buf, &events_tx, &dropped_events) {
+            warn!(
+                declared,
+                limit = MAX_VIDEO_RECORD_LEN,
+                "video record exceeds probe buffer limit; dropping stream"
+            );
+            return;
+        }
+        match stream.read(&mut chunk).await {
+            Ok(Some(count)) => buf.extend_from_slice(&chunk[..count]),
+            Ok(None) => {
+                if !buf.is_empty() {
+                    warn!(
+                        buffered = buf.len(),
+                        "video stream closed with a partial record"
+                    );
+                }
+                return;
+            }
+            Err(source) => {
+                warn!(%source, "multiplexed video stream read failed");
+                return;
+            }
+        }
+    }
+}
+
+/// Forwards every complete V3 record in `buf`, retaining only a partial tail.
+fn drain_video_records(
+    buf: &mut Vec<u8>,
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
+) -> Result<(), usize> {
+    loop {
+        if buf.len() < VIDEO_RECORD_PREFIX_LEN {
+            return Ok(());
+        }
+        let declared = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        if declared > MAX_VIDEO_RECORD_LEN {
+            return Err(declared);
+        }
+        let end = VIDEO_RECORD_PREFIX_LEN + declared;
+        if buf.len() < end {
+            return Ok(());
+        }
+        forward_video_v2_body(
+            &buf[VIDEO_RECORD_PREFIX_LEN..end],
+            events_tx,
+            dropped_events,
+        );
+        buf.drain(..end);
+    }
+}
+
+/// Decodes and forwards one capture-identity video body.
+fn forward_video_v2_body(
+    body: &[u8],
+    events_tx: &mpsc::Sender<ReceiverEvent>,
+    dropped_events: &AtomicU64,
+) {
+    let frame = match pilotage_protocol::video_frame::decode_v2(body) {
+        Ok(frame) => frame,
+        Err(source) => {
+            warn!(%source, "dropping malformed video frame body");
+            return;
+        }
+    };
+    if frame.codec != FOURCC_MJPEG {
+        warn!(
+            codec = %String::from_utf8_lossy(&frame.codec),
+            "unknown video codec FourCC; skipping frame"
+        );
+        return;
+    }
+    forward_event(
+        events_tx,
+        dropped_events,
+        ReceiverEvent::VideoFrame {
+            source_id: frame.header.source_id,
+            jpeg: frame.payload.to_vec(),
+        },
+    );
+}
 
 /// Reads one video-frame stream to completion
 /// (`[source_id][fourcc][u32 LE len][payload]`, ADR-0016), then forwards the
@@ -174,7 +300,43 @@ fn try_take_video_payload(buf: &mut Vec<u8>) -> Option<(u8, [u8; 4], Vec<u8>)> {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
-    use super::{FOURCC_MJPEG, try_take_video_payload};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use pilotage_protocol::video_frame::{CaptureHeader, encode_v2};
+    use tokio::sync::mpsc;
+
+    use super::{
+        FOURCC_MJPEG, VIDEO_RECORD_PREFIX_LEN, drain_video_records, try_take_video_payload,
+    };
+    use crate::receiver::ReceiverEvent;
+
+    fn capture_header(source_id: u8, sequence: u32) -> CaptureHeader {
+        CaptureHeader {
+            source_id,
+            source_epoch: 1,
+            source_incarnation: [sequence as u8; 16],
+            sequence,
+            capture_time_ns: u64::from(sequence),
+            capture_clock: 2,
+            mapping_available: false,
+            mapping_target_clock: 0,
+            mapping_offset_ns: 0,
+            clock_error_bound_ns: 0,
+            receive_time_ns: u64::from(sequence),
+            publication_time_ns: u64::from(sequence),
+            camera_id: u32::from(source_id),
+            calibration_id: 0,
+        }
+    }
+
+    fn video_record(source_id: u8, sequence: u32, jpeg: &[u8]) -> Vec<u8> {
+        let body = encode_v2(&capture_header(source_id, sequence), FOURCC_MJPEG, jpeg)
+            .expect("small payload encodes");
+        let mut record = Vec::with_capacity(VIDEO_RECORD_PREFIX_LEN + body.len());
+        record.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        record.extend_from_slice(&body);
+        record
+    }
 
     #[test]
     fn video_payload_waits_for_full_declared_length() {
@@ -202,5 +364,55 @@ mod tests {
         assert_eq!(source_id, 0, "reads the FPV source id");
         assert_eq!(first, vec![0xAB]);
         assert_eq!(buf, vec![b'M', b'J']);
+    }
+
+    #[test]
+    fn multiplexed_records_dispatch_live_across_read_boundaries() {
+        let first = video_record(0, 1, &[1, 2, 3]);
+        let second = video_record(1, 2, &[4, 5]);
+        let split = first.len() + 2;
+        let wire = [first, second].concat();
+        let (events_tx, mut events_rx) = mpsc::channel(4);
+        let dropped = AtomicU64::new(0);
+        let mut buf = wire[..split].to_vec();
+
+        drain_video_records(&mut buf, &events_tx, &dropped).expect("partial second record waits");
+        match events_rx
+            .try_recv()
+            .expect("first record dispatches before close")
+        {
+            ReceiverEvent::VideoFrame { source_id, jpeg } => {
+                assert_eq!(source_id, 0);
+                assert_eq!(jpeg, vec![1, 2, 3]);
+            }
+            _ => panic!("expected the first video frame"),
+        }
+        assert!(events_rx.try_recv().is_err(), "partial record is retained");
+
+        buf.extend_from_slice(&wire[split..]);
+        drain_video_records(&mut buf, &events_tx, &dropped).expect("second record completes");
+        match events_rx.try_recv().expect("second record dispatches") {
+            ReceiverEvent::VideoFrame { source_id, jpeg } => {
+                assert_eq!(source_id, 1);
+                assert_eq!(jpeg, vec![4, 5]);
+            }
+            _ => panic!("expected the second video frame"),
+        }
+        assert!(buf.is_empty(), "all complete records are consumed");
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn oversized_record_is_rejected_from_its_prefix() {
+        let declared = super::MAX_VIDEO_RECORD_LEN + 1;
+        let mut buf = (declared as u32).to_be_bytes().to_vec();
+        let (events_tx, _events_rx) = mpsc::channel(1);
+        let dropped = AtomicU64::new(0);
+
+        assert_eq!(
+            drain_video_records(&mut buf, &events_tx, &dropped),
+            Err(declared)
+        );
+        assert_eq!(buf.len(), VIDEO_RECORD_PREFIX_LEN);
     }
 }

--- a/tools/loopback-probe/src/video.rs
+++ b/tools/loopback-probe/src/video.rs
@@ -1,7 +1,6 @@
-//! Decodes MJPEG video frames received on host-initiated uni streams
-//! (ADR-0005 media = one uni stream per frame) and tracks the run's video
-//! statistics: frame count, decoded dimensions, and arrival-to-display
-//! latency.
+//! Decodes MJPEG video frames received on host-initiated uni streams and
+//! tracks the run's video statistics: frame count, decoded dimensions, and
+//! arrival-to-display latency.
 //!
 //! Decode uses the `image` crate's JPEG decoder; this binary owns I/O and
 //! decode work (ADR-0002 sans-IO applies only to `crates/`).
@@ -61,9 +60,9 @@ pub struct VideoStats {
     /// Frames that failed to decode.
     pub frames_decode_failed: u64,
     /// Arrival-to-decoded-display latency, measured from the client's own
-    /// clock: the gap between this frame's uni stream finishing and the
-    /// previous frame's, i.e. inter-arrival time, folded into a histogram so
-    /// p50/p95/max frame cadence is reportable alongside true fps.
+    /// clock: the gap between this frame and the previous frame, folded into a
+    /// histogram so p50/p95/max frame cadence is reportable alongside true
+    /// fps.
     pub inter_arrival: Histogram,
     /// Decoded width/height of the most recently decoded frame, if any.
     pub last_dims: Option<(u32, u32)>,


### PR DESCRIPTION
Fixes #233.

## What changed

- recognize the capture-identity V2 and multiplexed V3 video stream tags
- decode repeated big-endian length-delimited V2 bodies while the source stream remains open
- preserve split records, reject declarations over 64 MiB before buffering, and keep event-drop accounting intact
- update probe documentation to describe long-lived per-source streams

## Regression guard

The probe test now sends two V3 records on one logical stream with the second split across read boundaries. It proves the first frame dispatches before stream close, the partial record waits, and both source IDs and JPEG bodies arrive independently. A separate test pins the record-size bound.

## Validation

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps
- cargo build --release
- bash scripts/check-structure.sh