### PR TITLE
Negotiate multiplexed video before media delivery

### DIFF
--- a/clients/web/session-bootstrap.js
+++ b/clients/web/session-bootstrap.js
@@ -2,6 +2,7 @@ import {
   encodeClientHelloEnvelope,
   encodeMediaAttachRequestEnvelope,
   encodeProfileActivationEnvelope,
+  SESSION_PROTOCOL_VERSION,
 } from "./wire.js";
 import { createActionTracker } from "./action-tracker.js";
 
@@ -41,7 +42,7 @@ export function createSessionBootstrap({
   async function sendClientHello(writer, token) {
     if (!transportSessions.isActive(token)) return false;
     const hello = encodeClientHelloEnvelope({
-      protocolVersion: 1,
+      protocolVersion: SESSION_PROTOCOL_VERSION,
       clientName: "pilotage-web-viewer",
       joinToken: new Uint8Array(0),
     });

--- a/clients/web/session-bootstrap.js
+++ b/clients/web/session-bootstrap.js
@@ -1,8 +1,7 @@
 import {
   encodeClientHelloEnvelope,
   encodeMediaAttachRequestEnvelope,
-  encodeProfileActivationEnvelope,
-  SESSION_PROTOCOL_VERSION,
+  encodeProfileActivationEnvelope, SESSION_PROTOCOL_VERSION,
 } from "./wire.js";
 import { createActionTracker } from "./action-tracker.js";
 

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -25,11 +25,9 @@ export const STREAM_KIND_VIDEO = 0x02;
 // hosts/session-host/src/runtime/stream_tag.rs `frame_video_payload_v2`).
 export const STREAM_KIND_VIDEO_V2 = 0x03;
 
-// The `pilotage.v1` schema version this build produces and accepts
-// (pilotage_protocol::convert::SCHEMA_VERSION mirrors this constant).
+// `pilotage_protocol::convert::SCHEMA_VERSION` mirrors this envelope version.
 export const SCHEMA_VERSION = 1;
-// Session capabilities evolve independently of protobuf envelope encoding.
-export const SESSION_PROTOCOL_VERSION = 2;
+export const SESSION_PROTOCOL_VERSION = 2; // Independent session capabilities.
 
 // Byte offsets of the fixed v2 capture-identity header (little-endian), a
 // by-hand mirror of `frame_video_payload_v2` in

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -28,6 +28,8 @@ export const STREAM_KIND_VIDEO_V2 = 0x03;
 // The `pilotage.v1` schema version this build produces and accepts
 // (pilotage_protocol::convert::SCHEMA_VERSION mirrors this constant).
 export const SCHEMA_VERSION = 1;
+// Session capabilities evolve independently of protobuf envelope encoding.
+export const SESSION_PROTOCOL_VERSION = 2;
 
 // Byte offsets of the fixed v2 capture-identity header (little-endian), a
 // by-hand mirror of `frame_video_payload_v2` in

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -18,6 +18,7 @@ import {
   parseVideoFrameV2,
   BUTTON_EDGE_PRESSED,
   SCHEMA_VERSION,
+  SESSION_PROTOCOL_VERSION,
 } from "./wire.js";
 
 let failures = 0;
@@ -29,6 +30,11 @@ function check(name, cond) {
     failures += 1;
   }
 }
+
+check(
+  "current clients advertise the multiplexed-video session capability",
+  SESSION_PROTOCOL_VERSION === 2,
+);
 
 // Minimal protobuf field walker: returns a Map of field number -> the raw bytes
 // (length-delimited fields) or numeric value (varint), enough to assert field

--- a/crates/pilotage-protocol/src/lib.rs
+++ b/crates/pilotage-protocol/src/lib.rs
@@ -29,7 +29,7 @@ pub use intent::{
 pub use session::{
     ClientHello, ControlActionCommand, ControlActionResult, FrameRejected, FrameRejectionReason,
     LeaseDenialReason, LeaseRelease, LeaseReleased, LeaseRequest, LeaseResponse, LinkLossCleared,
-    Ping, Pong, ProfileActivation, ScopeHolderSnapshot, ServerWelcome,
+    Ping, Pong, ProfileActivation, SESSION_PROTOCOL_VERSION, ScopeHolderSnapshot, ServerWelcome,
 };
 pub use video_frame::{
     CaptureHeader, ContractFault, DecodedFrame, Offsets, encode_v2 as encode_video_frame_v2,

--- a/crates/pilotage-protocol/src/session.rs
+++ b/crates/pilotage-protocol/src/session.rs
@@ -7,11 +7,17 @@ use pilotage_timing::MonoTimestamp;
 use crate::ids::{Generation, PrincipalId, ScopeId, SequenceNum, VehicleId};
 use crate::wire;
 
+/// Current session capability version advertised by first-party clients.
+///
+/// Version 2 adds the long-lived multiplexed video stream. This is independent
+/// of [`crate::SCHEMA_VERSION`], which versions protobuf envelope encoding.
+pub const SESSION_PROTOCOL_VERSION: u32 = 2;
+
 /// The first message a client sends after the WebTransport session is
 /// established (ADR-0005).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClientHello {
-    /// Highest `pilotage.v1` schema version the client can interpret.
+    /// Highest session capability version the client can interpret.
     pub protocol_version: u32,
     /// Human-readable client identification, for diagnostics only.
     pub client_name: String,

--- a/crates/pilotage-session/src/config.rs
+++ b/crates/pilotage-session/src/config.rs
@@ -15,7 +15,7 @@ use pilotage_protocol::VehicleId;
 /// Immutable knobs the engine reads while deciding actions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionConfig {
-    /// Lowest `pilotage.v1` schema version the host will serve. A
+    /// Lowest session capability version the host will serve. A
     /// `ClientHello` advertising a lower `protocol_version` is closed with
     /// [`CloseReason::UnsupportedProtocolVersion`].
     ///

--- a/docs/control/evidence-artifacts/ctrl01/actor-dedup.run.txt
+++ b/docs/control/evidence-artifacts/ctrl01/actor-dedup.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: CTRL-01
 suite: actor exactly-once dedup suite
 command: cargo test -p pilotage-session-host --lib engine_actor::tests::reliable_actions
-config-digest: 967ed8a16d39148eeb7ea6dda426664e9404c9be
+config-digest: afad387c195b9c8dff728d5fd9f91d853b9b3a99
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+run-id: local:afad387c195b9c8dff728d5fd9f91d853b9b3a99
 outcome: pass
 summary:
-test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.00s
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out; finished in 0.00s

--- a/docs/control/evidence-artifacts/ctrl01/wire-chain.run.txt
+++ b/docs/control/evidence-artifacts/ctrl01/wire-chain.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: CTRL-01
 suite: reliable action chain over the real transport
 command: cargo test -p pilotage-session-host --test reliable_actions_wire
-config-digest: 967ed8a16d39148eeb7ea6dda426664e9404c9be
+config-digest: afad387c195b9c8dff728d5fd9f91d853b9b3a99
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+run-id: local:afad387c195b9c8dff728d5fd9f91d853b9b3a99
 outcome: pass
 summary:
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

--- a/docs/control/evidence-graph.evg
+++ b/docs/control/evidence-graph.evg
@@ -350,22 +350,22 @@ attr outcome pass
 node RESULT-CTRL-DEDUP verification-result
 title actor exactly-once dedup suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::tests::reliable_actions
-attr config-digest 967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr config-digest afad387c195b9c8dff728d5fd9f91d853b9b3a99
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:1fbf6b07d02b5597e0138ee4fe1c7a95a5683ede
+attr source-digest git-blob:0bad809001caa76554bbcc6659921498070291fd
 attr artifact docs/control/evidence-artifacts/ctrl01/actor-dedup.run.txt
-attr output-digest sha256:c4d015348db1cd89a9b04cb8f869e9274f1399d52eb91016a7257fd15a361eb6
-attr run-id local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr output-digest sha256:a2bb8ddfa3c003b3aab3dfbb0249ede5b39fdbbefb86014f0616badc4edf6610
+attr run-id local:afad387c195b9c8dff728d5fd9f91d853b9b3a99
 attr outcome pass
 node RESULT-CTRL-WIRE verification-result
 title reliable action chain over the real transport — recorded pass
 attr command cargo test -p pilotage-session-host --test reliable_actions_wire
-attr config-digest 967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr config-digest afad387c195b9c8dff728d5fd9f91d853b9b3a99
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:57b14b52b87593c59296b9d6e0132ededf48069d
+attr source-digest git-blob:563e07a09e23e918a8147ab6f6fee7af8725d984
 attr artifact docs/control/evidence-artifacts/ctrl01/wire-chain.run.txt
-attr output-digest sha256:4f4a1854d44e446b22d8298f05c383db0492c0ae12213fd2fab0772d8d819a5e
-attr run-id local:967ed8a16d39148eeb7ea6dda426664e9404c9be
+attr output-digest sha256:1fcfa43c72bff51b2e32c13376b4bdffaefa514189d9426ff9f180b2776e6599
+attr run-id local:afad387c195b9c8dff728d5fd9f91d853b9b3a99
 attr outcome pass
 node RESULT-CTRL-SOURCE verification-result
 title input-source coordinator suite — recorded pass
@@ -428,6 +428,12 @@ title committed code baseline the recorded results were produced against (engine
 attr scm git
 attr commit 967ed8a16d39148eeb7ea6dda426664e9404c9be
 attr tree a5d55f59813d313df367c12e3d3fdedeffe18f4d
+
+node CFG-CTRL-VIDEO-V3 configuration-item
+title committed code baseline for session negotiation and transport results
+attr scm git
+attr commit afad387c195b9c8dff728d5fd9f91d853b9b3a99
+attr tree b43ad29521d5ff461ccfb1ccd8abbb47630ce382
 
 node CFG-CTRL-SOURCE configuration-item
 title committed input-source coordinator verification baseline
@@ -581,12 +587,12 @@ edge RESULT-CTRL-GROUP justified-by TOOL-CTRL-CARGO
 
 edge RESULT-CTRL-DEDUP result-of CASE-CTRL-ID-REUSE
 edge RESULT-CTRL-DEDUP covers CTRL-CHAN-002
-edge RESULT-CTRL-DEDUP justified-by CFG-CTRL01
+edge RESULT-CTRL-DEDUP justified-by CFG-CTRL-VIDEO-V3
 edge RESULT-CTRL-DEDUP justified-by TOOL-CTRL-CARGO
 
 edge RESULT-CTRL-WIRE result-of CASE-CTRL-WIRE-CHAIN
 edge RESULT-CTRL-WIRE covers CTRL-CHAN-002
-edge RESULT-CTRL-WIRE justified-by CFG-CTRL01
+edge RESULT-CTRL-WIRE justified-by CFG-CTRL-VIDEO-V3
 edge RESULT-CTRL-WIRE justified-by TOOL-CTRL-CARGO
 
 edge RESULT-CTRL-SOURCE result-of CASE-CTRL-SOURCE-BOOT

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -97,8 +97,11 @@ fn build_engine<A: VehicleAdapter>(adapter: &A, options: RuntimeOptions) -> Sess
             "SIMULATION legacy-compatibility mode enabled: numeric payload frames are admitted"
         );
     }
-    let config = SessionConfig::new(pilotage_protocol::SCHEMA_VERSION, env!("CARGO_PKG_VERSION"))
-        .with_legacy_compatibility(options.legacy_compatibility);
+    let config = SessionConfig::new(
+        pilotage_protocol::SESSION_PROTOCOL_VERSION,
+        env!("CARGO_PKG_VERSION"),
+    )
+    .with_legacy_compatibility(options.legacy_compatibility);
     SessionEngine::new(capabilities, staleness, config)
 }
 

--- a/hosts/session-host/src/runtime/connection.rs
+++ b/hosts/session-host/src/runtime/connection.rs
@@ -63,7 +63,12 @@ pub enum ToConnection {
     /// Bytes to write, length-delimited, on the reliable session stream
     /// (handshake, lease, action, and adapter-enactment replies — never
     /// authority events, which use ADR-0005's session-events stream).
-    BootstrapMessage(Vec<u8>),
+    BootstrapMessage {
+        /// Encoded length-delimited envelope.
+        bytes: Vec<u8>,
+        /// Whether a successful write proves media capability negotiation.
+        opens_media: bool,
+    },
     /// Bytes to write, length-delimited, on the reliable session-events stream.
     AuthorityMessage(Vec<u8>),
     /// Bytes to send as a single datagram, tagged with the ADR-0011 class a
@@ -120,13 +125,6 @@ pub async fn run_connection(
     send.set_priority(CONTROL_STREAM_PRIORITY);
     event_send.set_priority(CONTROL_STREAM_PRIORITY);
 
-    // Video is served only when a media task is running (the Gazebo adapter
-    // path); the reference path passes `None` and serves no video, unchanged
-    // from 1a.
-    let media_status = media
-        .as_ref()
-        .map(|media| media.register(client, connection.clone()));
-
     let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
     if to_engine
         .send(ToEngine::ClientConnected {
@@ -144,7 +142,14 @@ pub async fn run_connection(
 
     tokio::select! {
         () = run_reader(&connection, recv, client, start, &to_engine, media.as_ref()) => {}
-        () = run_writer(&connection, send, event_send, outbound_rx, media_status) => {}
+        () = run_writer(
+            &connection,
+            client,
+            send,
+            event_send,
+            outbound_rx,
+            media.as_ref(),
+        ) => {}
         () = send_blocked::run_send_blocked_watch(&connection, client.as_u64()) => {}
     }
 
@@ -255,12 +260,15 @@ impl ClientClock {
 /// write never delays servicing the read side.
 async fn run_writer(
     connection: &Connection,
+    client: ClientKey,
     mut send: SendStream,
     mut event_send: SendStream,
     mut outbound_rx: mpsc::Receiver<ToConnection>,
-    mut media_status: Option<watch::Receiver<pilotage_protocol::wire::VideoDeliveryState>>,
+    media: Option<&MediaHandle>,
 ) {
     let mut datagram_drops = DatagramDropCounters::default();
+    let mut media_status: Option<watch::Receiver<pilotage_protocol::wire::VideoDeliveryState>> =
+        None;
     loop {
         let message = if let Some(status) = media_status.as_mut() {
             tokio::select! {
@@ -284,9 +292,12 @@ async fn run_writer(
             break;
         };
         match message {
-            ToConnection::BootstrapMessage(bytes) => {
+            ToConnection::BootstrapMessage { bytes, opens_media } => {
                 if send.write_all(&bytes).await.is_err() {
                     break;
+                }
+                if opens_media && let Some(media) = media {
+                    media_status = Some(media.register(client, connection.clone()));
                 }
             }
             ToConnection::AuthorityMessage(bytes) => {
@@ -430,7 +441,7 @@ async fn drain_bootstrap_frames(
             }
             Ok((InboundBootstrap::MediaAttach, _rest)) => {
                 if let Some(media) = media {
-                    drop(media.register(client, connection.clone()));
+                    media.reattach(client, connection.clone());
                     debug!(
                         client = client.as_u64(),
                         "media attachment requested on live session"

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -462,15 +462,13 @@ fn u64_nanos_since(start: Instant) -> u64 {
 fn targets_reliable_stream(message: &ToConnection) -> bool {
     matches!(
         message,
-        ToConnection::BootstrapMessage(_) | ToConnection::AuthorityMessage(_)
+        ToConnection::BootstrapMessage { .. } | ToConnection::AuthorityMessage(_)
     )
 }
 
-/// Picks the [`ToConnection`] channel arm an [`OutboundMessage`] belongs on
-/// and encodes it (ADR-0005): `Pong` is a control-fast datagram; `Authority`
-/// travels on the dedicated authority-events stream so a bulk/bootstrap
-/// transfer can never head-of-line-block a lease/override event; every other
-/// arm is bootstrap/lease/handshake reply traffic on the bootstrap stream.
+/// Encodes an [`OutboundMessage`] on its [`ToConnection`] arm (ADR-0005); `Pong`
+/// is a datagram; `Authority` uses the dedicated event stream so bootstrap
+/// traffic cannot block it; every other arm uses the bootstrap stream.
 fn to_connection_message(envelope: &pilotage_session::OutboundMessage) -> ToConnection {
     match envelope {
         pilotage_session::OutboundMessage::Pong(pong) => ToConnection::Datagram {
@@ -488,9 +486,10 @@ fn to_connection_message(envelope: &pilotage_session::OutboundMessage) -> ToConn
         | pilotage_session::OutboundMessage::LeaseResponse(_)
         | pilotage_session::OutboundMessage::LeaseReleased(_)
         | pilotage_session::OutboundMessage::ControlActionResult(_)
-        | pilotage_session::OutboundMessage::FrameRejected(_) => {
-            ToConnection::BootstrapMessage(encode_envelope_message(envelope))
-        }
+        | pilotage_session::OutboundMessage::FrameRejected(_) => ToConnection::BootstrapMessage {
+            bytes: encode_envelope_message(envelope),
+            opens_media: matches!(envelope, pilotage_session::OutboundMessage::Welcome(_)),
+        },
     }
 }
 

--- a/hosts/session-host/src/runtime/engine_actor/tests.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests.rs
@@ -36,6 +36,25 @@ mod reliable_actions;
 use fixtures::*;
 
 #[test]
+fn an_accepted_welcome_is_the_media_registration_gate() {
+    let mut actor = actor();
+    let mut receiver = register_client(&mut actor);
+
+    actor.on_client_message(ClientKey::new(1), hello(), MonoTimestamp::from_nanos(0));
+
+    assert!(
+        matches!(
+            receiver.try_recv(),
+            Ok(ToConnection::BootstrapMessage {
+                opens_media: true,
+                ..
+            })
+        ),
+        "only the accepted welcome variant authorizes connection-layer media registration"
+    );
+}
+
+#[test]
 fn engage_link_loss_neutralizes_the_adapter() {
     let mut actor = actor();
     actor.enact(SessionOutcome {

--- a/hosts/session-host/src/runtime/engine_actor/tests/adapter_rejections.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests/adapter_rejections.rs
@@ -8,7 +8,7 @@ fn drain_rejections(
 ) -> Vec<pilotage_protocol::FrameRejected> {
     let mut rejections = Vec::new();
     while let Ok(message) = receiver.try_recv() {
-        let ToConnection::BootstrapMessage(bytes) = message else {
+        let ToConnection::BootstrapMessage { bytes, .. } = message else {
             continue;
         };
         let Ok(envelope) =

--- a/hosts/session-host/src/runtime/engine_actor/tests/reliable_actions.rs
+++ b/hosts/session-host/src/runtime/engine_actor/tests/reliable_actions.rs
@@ -23,7 +23,7 @@ fn arm_frame(action_id: u32) -> ScopedControlFrame {
 fn bootstrap_messages(receiver: &mut mpsc::Receiver<ToConnection>) -> usize {
     let mut count = 0;
     while let Ok(message) = receiver.try_recv() {
-        if matches!(message, ToConnection::BootstrapMessage(_)) {
+        if matches!(message, ToConnection::BootstrapMessage { .. }) {
             count += 1;
         }
     }
@@ -140,7 +140,7 @@ fn a_correlation_id_reused_with_different_content_is_refused() {
 fn drain_result_ids(receiver: &mut mpsc::Receiver<ToConnection>) -> Vec<u32> {
     let mut ids = Vec::new();
     while let Ok(message) = receiver.try_recv() {
-        let ToConnection::BootstrapMessage(bytes) = message else {
+        let ToConnection::BootstrapMessage { bytes, .. } = message else {
             continue;
         };
         let Ok(envelope) =

--- a/hosts/session-host/src/runtime/gazebo_launch.rs
+++ b/hosts/session-host/src/runtime/gazebo_launch.rs
@@ -73,6 +73,9 @@ fn gazebo_frames_already_taken() -> pilotage_adapter_gazebo::GazeboAdapterError 
 fn build_engine(adapter: &GazeboAdapter, max_control_age: Duration) -> SessionEngine {
     let capabilities = adapter.capabilities();
     let staleness = StalenessPolicy::new(max_control_age);
-    let config = SessionConfig::new(pilotage_protocol::SCHEMA_VERSION, env!("CARGO_PKG_VERSION"));
+    let config = SessionConfig::new(
+        pilotage_protocol::SESSION_PROTOCOL_VERSION,
+        env!("CARGO_PKG_VERSION"),
+    );
     SessionEngine::new(capabilities, staleness, config)
 }

--- a/hosts/session-host/src/runtime/media.rs
+++ b/hosts/session-host/src/runtime/media.rs
@@ -46,6 +46,11 @@ struct MediaClient {
 enum MediaCommand {
     /// Register a client so the next encoded frame is sent to it.
     Register(MediaClient),
+    /// Re-open source streams for an already-negotiated media client.
+    Reattach {
+        client: ClientKey,
+        connection: Connection,
+    },
     /// Deregister a client whose connection task has exited.
     Deregister(ClientKey),
 }
@@ -88,6 +93,22 @@ impl MediaHandle {
             );
         }
         receiver
+    }
+
+    /// Re-opens video streams only for a client whose accepted welcome already
+    /// registered media. Requests before negotiation are refused rather than
+    /// turning an unversioned connection into a V3 consumer.
+    pub fn reattach(&self, client: ClientKey, connection: Connection) {
+        if self
+            .commands
+            .try_send(MediaCommand::Reattach { client, connection })
+            .is_err()
+        {
+            warn!(
+                client = client.as_u64(),
+                "media re-attach dropped (queue full or task gone)"
+            );
+        }
     }
 
     /// Deregisters `client` on disconnect. Best-effort for the same reason as
@@ -217,6 +238,7 @@ fn apply_command(
             if let Some(entry) = clients.get_mut(&client) {
                 entry.connection = connection;
                 entry.sources.clear();
+                entry.status = status;
             } else {
                 let transport = transport_snapshot(&connection);
                 clients.insert(
@@ -231,6 +253,17 @@ fn apply_command(
                     },
                 );
             }
+        }
+        MediaCommand::Reattach { client, connection } => {
+            let Some(entry) = clients.get_mut(&client) else {
+                warn!(
+                    client = client.as_u64(),
+                    "media re-attach refused before protocol negotiation"
+                );
+                return;
+            };
+            entry.connection = connection;
+            entry.sources.clear();
         }
         MediaCommand::Deregister(client) => {
             clients.remove(&client);

--- a/hosts/session-host/src/runtime/media/transport_tests.rs
+++ b/hosts/session-host/src/runtime/media/transport_tests.rs
@@ -21,12 +21,33 @@ use wtransport::{ClientConfig, Connection, Endpoint, Identity, ServerConfig, Var
 
 use super::budget::{MAX_BYTES_PER_SECOND, MIN_BYTES_PER_SECOND};
 use super::encoding::encode_jpeg;
-use super::spawn_media_task;
+use super::{MediaCommand, apply_command, spawn_media_task};
 
 const IO_BOUND: Duration = Duration::from_secs(8);
 const FRAME_PERIOD: Duration = Duration::from_micros(11_111);
 const TELEMETRY_PERIOD: Duration = Duration::from_millis(5);
 const TELEMETRY_SAMPLES: u32 = 100;
+
+#[tokio::test]
+async fn reattach_before_negotiation_cannot_register_media() {
+    let (server, _client) = connected_pair().await;
+    let client = ClientKey::new(19);
+    let mut clients = std::collections::BTreeMap::new();
+
+    apply_command(
+        MediaCommand::Reattach {
+            client,
+            connection: server,
+        },
+        &mut clients,
+        0,
+    );
+
+    assert!(
+        clients.is_empty(),
+        "a media attach cannot create a client before an accepted welcome"
+    );
+}
 
 async fn connected_pair() -> (Connection, Connection) {
     let identity =

--- a/hosts/session-host/tests/hostile_pending_growth.rs
+++ b/hosts/session-host/tests/hostile_pending_growth.rs
@@ -49,7 +49,7 @@ fn hello_bytes() -> Vec<u8> {
     let envelope = wire::Envelope {
         schema_version: SCHEMA_VERSION,
         payload: Some(wire::envelope::Payload::ClientHello(wire::ClientHello {
-            protocol_version: SCHEMA_VERSION,
+            protocol_version: pilotage_protocol::SESSION_PROTOCOL_VERSION,
             client_name: "post-attack-client".to_owned(),
             join_token: Vec::new(),
         })),

--- a/hosts/session-host/tests/loopback.rs
+++ b/hosts/session-host/tests/loopback.rs
@@ -19,6 +19,7 @@ use tokio::time::timeout;
 use wtransport::{ClientConfig, Connection, Endpoint};
 
 const SCHEMA_VERSION: u32 = 1;
+const SESSION_PROTOCOL_VERSION: u32 = pilotage_protocol::SESSION_PROTOCOL_VERSION;
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Connects a `wtransport` client to `addr`, skipping certificate
@@ -132,11 +133,11 @@ async fn send_envelope(send: &mut wtransport::SendStream, envelope: &wire::Envel
         .expect("bootstrap write succeeds");
 }
 
-fn hello_envelope() -> wire::Envelope {
+fn hello_envelope(protocol_version: u32) -> wire::Envelope {
     wire::Envelope {
         schema_version: SCHEMA_VERSION,
         payload: Some(wire::envelope::Payload::ClientHello(wire::ClientHello {
-            protocol_version: SCHEMA_VERSION,
+            protocol_version,
             client_name: "loopback-test".to_owned(),
             join_token: Vec::new(),
         })),
@@ -265,6 +266,30 @@ async fn start_sim_compat_host() -> runtime::RunningHost {
 }
 
 #[tokio::test]
+async fn stale_session_protocol_is_closed_before_welcome() {
+    let host = start_sim_compat_host().await;
+    let connection = connect_client(host.local_addr).await;
+    let (mut send, mut recv) = timeout(TEST_TIMEOUT, connection.open_bi())
+        .await
+        .expect("open_bi does not time out")
+        .expect("bootstrap stream opens")
+        .await
+        .expect("bootstrap stream finishes opening");
+
+    send_envelope(&mut send, &hello_envelope(SESSION_PROTOCOL_VERSION - 1)).await;
+    let mut buf = [0_u8; 1024];
+    let read = timeout(TEST_TIMEOUT, recv.read(&mut buf))
+        .await
+        .expect("stale client is closed promptly");
+    assert!(
+        !matches!(read, Ok(Some(_))),
+        "an unsupported client receives no welcome that could authorize V3 media"
+    );
+
+    host.shutdown().await;
+}
+
+#[tokio::test]
 async fn hello_lease_frame_and_stale_generation_rejection() {
     let host = start_sim_compat_host().await;
     let addr = host.local_addr;
@@ -288,7 +313,7 @@ async fn hello_lease_frame_and_stale_generation_rejection() {
     // (ADR-0005); consume it before parsing length-delimited envelopes.
     read_authority_tag(&mut authority_recv, &mut authority_pending).await;
 
-    send_envelope(&mut send, &hello_envelope()).await;
+    send_envelope(&mut send, &hello_envelope(SESSION_PROTOCOL_VERSION)).await;
     let welcome_envelope = read_one_envelope(&mut recv, &mut pending).await;
     let welcome = match welcome_envelope.payload {
         Some(wire::envelope::Payload::ServerWelcome(welcome)) => welcome,

--- a/hosts/session-host/tests/reliable_actions_wire.rs
+++ b/hosts/session-host/tests/reliable_actions_wire.rs
@@ -142,7 +142,7 @@ async fn bind_session(connection: &Connection) -> BoundSession {
     send_envelope(
         &mut send,
         &envelope(wire::envelope::Payload::ClientHello(wire::ClientHello {
-            protocol_version: 1,
+            protocol_version: pilotage_protocol::SESSION_PROTOCOL_VERSION,
             client_name: "reliable-actions".to_owned(),
             join_token: vec![],
         })),

--- a/tools/loopback-probe/src/transport.rs
+++ b/tools/loopback-probe/src/transport.rs
@@ -12,9 +12,6 @@ use wtransport::{ClientConfig, Connection, Endpoint, endpoint::endpoint_side};
 use crate::error::ProbeError;
 use crate::wire_session::{StreamMessage, decode_one, encode_client_hello, encode_lease_request};
 
-/// The `pilotage.v1` schema version this client claims support for in its
-/// `ClientHello`.
-const CLIENT_PROTOCOL_VERSION: u32 = pilotage_protocol::SCHEMA_VERSION;
 /// Human-readable client identity for diagnostics only (ADR-0005).
 const CLIENT_NAME: &str = "loopback-probe";
 /// Read-buffer size for one `recv_stream.read` call on the bidi stream;
@@ -146,7 +143,7 @@ pub async fn handshake(
     let mut buf = Vec::new();
 
     let hello = ClientHello {
-        protocol_version: CLIENT_PROTOCOL_VERSION,
+        protocol_version: pilotage_protocol::SESSION_PROTOCOL_VERSION,
         client_name: CLIENT_NAME.to_string(),
         join_token: Vec::new(),
     };


### PR DESCRIPTION
Fixes #234.

## What changed
- separate the session capability version from the protobuf schema version and advertise capability v2 from first-party clients
- reject stale v1 sessions before Welcome, so they can never be exposed to V3 multiplexed media
- register media only after the accepted Welcome is written
- refuse MediaAttach from clients that have not passed negotiation
- add wire, actor, media, and live loopback regression coverage

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- `bash scripts/check-structure.sh`