### PR TITLE
Bound graceful video stream finish

### DIFF
--- a/hosts/session-host/src/runtime/media/frame_writer.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer.rs
@@ -42,6 +42,9 @@ mod reaper;
 /// milliseconds on the deployment link).
 const FRAME_WRITE_DEADLINE: Duration = Duration::from_secs(2);
 
+/// Graceful source-stream shutdown bound for stalled clients.
+const STREAM_FINISH_DEADLINE: Duration = Duration::from_secs(2);
+
 /// A peer that withholds uni-stream credit for this long is starving the
 /// connection, not merely delaying one frame. This stage allocates no stream,
 /// so cancellation is safe and later frames may retry loudly.
@@ -257,8 +260,29 @@ async fn drain_frames<C: FrameChannel>(
     }
     // Deregistration or shutdown: end the source's stream cleanly so the
     // client sees a close rather than a reset it would treat as loss.
-    if let Some(mut stream) = stream {
-        stream.finish().await.ok();
+    if let Some(stream) = stream {
+        finish_stream(client, source_id, stream).await;
+    }
+}
+
+async fn finish_stream<S: FrameStream>(client: ClientKey, source_id: u8, mut stream: S) {
+    match tokio::time::timeout(STREAM_FINISH_DEADLINE, stream.finish()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => warn!(
+            client = client.as_u64(),
+            source_id,
+            source = %error,
+            "video stream finish failed"
+        ),
+        Err(_elapsed) => {
+            stream.reset();
+            warn!(
+                client = client.as_u64(),
+                source_id,
+                deadline_ms = STREAM_FINISH_DEADLINE.as_millis(),
+                "video stream finish timed out; stream reset"
+            );
+        }
     }
 }
 

--- a/hosts/session-host/src/runtime/media/frame_writer/tests.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::expect_used, clippy::panic)]
 
+mod finish;
 mod multiplex;
 
 use std::sync::Arc;
@@ -101,6 +102,8 @@ enum Write {
     ConnFatal,
     /// Writes and finishes normally.
     Ok,
+    /// Writes normally, but graceful finish never completes.
+    FinishStall,
 }
 
 /// How a mock `open()` behaves; the failure cases route real
@@ -141,12 +144,15 @@ impl FrameStream for MockStream {
             )),
             Write::Closed => Err(classify_write(&StreamWriteError::Closed, "write")),
             Write::ConnFatal => Err(classify_write(&StreamWriteError::NotConnected, "write")),
-            Write::Ok => Ok(()),
+            Write::Ok | Write::FinishStall => Ok(()),
         }
     }
 
     async fn finish(&mut self) -> Result<(), StreamError> {
         self.tally.finished.fetch_add(1, Ordering::SeqCst);
+        if matches!(self.write, Write::FinishStall) {
+            std::future::pending::<()>().await;
+        }
         Ok(())
     }
 

--- a/hosts/session-host/src/runtime/media/frame_writer/tests/finish.rs
+++ b/hosts/session-host/src/runtime/media/frame_writer/tests/finish.rs
@@ -1,0 +1,35 @@
+//! Graceful stream-finish bounds.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use super::{MockChannel, Open, Tally, Write, drain_test_frames, queue};
+
+#[tokio::test(start_paused = true)]
+async fn a_stalled_finish_is_bounded_and_reset() {
+    let mut rx = queue(1).await;
+    let tally = Arc::new(Tally::default());
+    let channel = MockChannel {
+        script: vec![Open::Ready(Write::FinishStall)],
+        tally: tally.clone(),
+    };
+    let outer_bound = super::super::STREAM_FINISH_DEADLINE + Duration::from_secs(1);
+
+    let completed = tokio::time::timeout(outer_bound, drain_test_frames(&channel, &mut rx)).await;
+
+    assert!(
+        completed.is_ok(),
+        "writer shutdown must complete within its finish deadline"
+    );
+    assert_eq!(
+        tally.finished.load(Ordering::SeqCst),
+        1,
+        "graceful finish is attempted once"
+    );
+    assert_eq!(
+        tally.reset.load(Ordering::SeqCst),
+        1,
+        "a finish that misses its deadline is reset exactly once"
+    );
+}


### PR DESCRIPTION
Fixes #235.

## What changed
- cap final source-stream `finish()` acknowledgement at two seconds
- reset a stream that misses the finish deadline so re-attach and shutdown cannot wedge on a stalled client
- log both finish errors and deadline resets with client/source context
- add a virtual-time regression that stalls only FIN acknowledgement and proves bounded exit plus exactly one reset

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- `bash scripts/check-structure.sh`