### PR TITLE
Say what protocol_version now means on the wire source of truth

### DIFF
--- a/schemas/pilotage/v1/session.proto
+++ b/schemas/pilotage/v1/session.proto
@@ -43,8 +43,12 @@ message VideoDeliveryState {
 // bootstrap uses plain HTTPS for admission, then this message begins the
 // in-session handshake).
 message ClientHello {
-  // Highest `pilotage.v1` schema version the client can interpret; the host
-  // may reject or downgrade based on this (ADR-0014).
+  // Highest SESSION CAPABILITY version the client can interpret; the host
+  // rejects a client below its required version before Welcome
+  // (`UnsupportedProtocolVersion`), so a client is never exposed to a media
+  // framing it cannot decode. Deliberately independent of the envelope
+  // schema version (ADR-0014): capabilities move when the session's stream
+  // formats change, which the protobuf encoding does not track.
   uint32 protocol_version = 1;
   // Human-readable client identification (application name/version), for
   // diagnostics only; never used for authorization decisions.


### PR DESCRIPTION
Found while reviewing #239. That PR redefines `ClientHello.protocol_version` as the session CAPABILITY version (2, bumped for multiplexed video) and separates it from the envelope schema version (1) — correctly, and it updated the Rust and JavaScript sides. The protobuf definition still described the field as "Highest `pilotage.v1` schema version the client can interpret".

ADR-0014 makes the proto the wire-schema source of truth, so leaving it saying the opposite is drift in exactly the place a reader trusts most — and the natural misreading (that a capability bump requires a schema bump, or vice versa) is the coupling #239 deliberately removed.

Comment only; no field, number, or type changes, so `buf breaking` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmY4DtgmphoiiUQWEJGT9