### PR TITLE
Mission executor, Communicate navdata provisioning, and live nav display (ADRs 0023-0032)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # The Navigate crates are a private git dependency; libgit2 cannot use
+  # the runner's rewritten ssh credentials, the git CLI can.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   PROTOC_SHA256: a7be2928c0454f132c599e25b79b7ad1b57663f2337d7f7e468a1d59b98ec1b0
   PROTOC_VERSION: "26.1"
 
@@ -19,6 +22,17 @@ jobs:
           # buf breaking compares the working tree against the base ref, so the
           # base commit must be present locally; a shallow clone would hide it.
           fetch-depth: 0
+
+      - name: Authorize the private Navigate dependency
+        env:
+          NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$NAVIGATE_DEPLOY_KEY" > ~/.ssh/navigate_ci
+          chmod 600 ~/.ssh/navigate_ci
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/navigate_ci -o IdentitiesOnly=yes"
+          git config --global url."ssh://git@github.com/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
 
       - name: Install system dependencies (hidapi on Linux)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: telemetry ingress gate contract
         run: node clients/web/telemetry-ingress.test.mjs
 
+      - name: navigation display profile (ADR-0031 deviation scaling and signs)
+        run: node clients/web/nav-display.test.mjs
+
       - name: telemetry display retirement contract
         run: node clients/web/telemetry-display.test.mjs
 

--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -19,6 +19,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Workspace resolution touches the private Navigate git dependency even
+  # for a single-crate build; the git CLI can use the runner's rewritten
+  # ssh credentials, libgit2 cannot.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   FIXTURES: crates/pilotage-evidence/tests/fixtures
 
 jobs:
@@ -32,6 +36,17 @@ jobs:
           # commits against real history; a shallow clone would make every
           # recorded baseline unverifiable.
           fetch-depth: 0
+
+      - name: Authorize the private Navigate dependency
+        env:
+          NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$NAVIGATE_DEPLOY_KEY" > ~/.ssh/navigate_ci
+          chmod 600 ~/.ssh/navigate_ci
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/navigate_ci -o IdentitiesOnly=yes"
+          git config --global url."ssh://git@github.com/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aerocontext-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e733a8983bf1bbe492df4f67b5e5211e507beda67b4bdd17ea9fe0008352ccf9"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "aerocontext-navdata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7393fd2c21f87675ab644d4b4e31bc07b22cbe47ee27732b0a6fdd960631288b"
+dependencies = [
+ "aerocontext-core",
+ "chrono",
+ "hex",
+ "postcard",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aerocontext-planning"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1715f4920a935d73d439575f09d3b6d92549fd3ee715022ac674bd36787247f9"
+dependencies = [
+ "aerocontext-core",
+ "chrono",
+ "quick-xml",
+ "thiserror",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +60,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -47,7 +107,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -59,7 +119,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -200,6 +271,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,7 +389,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -365,7 +457,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -397,6 +489,18 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -552,6 +656,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +783,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hid-probe"
@@ -611,6 +829,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -844,6 +1086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1145,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "navigate-contract"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "navigate-fpl"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+dependencies = [
+ "navigate-contract",
+ "navigate-geodesy",
+ "thiserror",
+]
+
+[[package]]
+name = "navigate-fusion"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+dependencies = [
+ "nalgebra",
+ "navigate-contract",
+ "navigate-geodesy",
+ "thiserror",
+]
+
+[[package]]
+name = "navigate-geodesy"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+dependencies = [
+ "navigate-contract",
+ "thiserror",
+]
+
+[[package]]
+name = "navigate-guidance"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+dependencies = [
+ "navigate-contract",
+ "navigate-geodesy",
+ "thiserror",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1275,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -971,6 +1324,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1248,6 +1607,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-mission"
+version = "0.1.0"
+dependencies = [
+ "aerocontext-core",
+ "aerocontext-navdata",
+ "aerocontext-planning",
+ "chrono",
+ "navigate-contract",
+ "navigate-fpl",
+ "navigate-fusion",
+ "navigate-geodesy",
+ "navigate-guidance",
+ "pilotage-protocol",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-protocol"
 version = "0.1.0"
 dependencies = [
@@ -1274,13 +1650,18 @@ dependencies = [
 name = "pilotage-session-host"
 version = "0.1.0"
 dependencies = [
+ "aerocontext-core",
+ "aerocontext-navdata",
+ "chrono",
  "jpeg-encoder",
+ "navigate-contract",
  "pilotage-adapter-api",
  "pilotage-adapter-aviate",
  "pilotage-adapter-gazebo",
  "pilotage-adapter-px4",
  "pilotage-adapter-reference",
  "pilotage-authority",
+ "pilotage-mission",
  "pilotage-protocol",
  "pilotage-session",
  "pilotage-timing",
@@ -1356,6 +1737,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1442,7 +1835,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -1456,7 +1849,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1479,6 +1872,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -1629,6 +2031,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rcgen"
@@ -1789,6 +2197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +2281,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1948,6 +2365,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,7 +2457,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2049,7 +2490,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2140,7 +2581,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2162,7 +2603,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2314,7 +2755,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2338,10 +2779,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2530,7 +3034,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2551,7 +3055,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2571,7 +3075,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2611,7 +3115,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/pilotage-instrument-panels",
     "crates/pilotage-instrument-raster",
     "crates/pilotage-evidence",
+    "crates/pilotage-mission",
     "adapters/reference-headless",
     "adapters/aviate",
     "adapters/px4",
@@ -44,6 +45,19 @@ edition = "2024"
 # types, the transport, and the canonical object name cannot drift apart.
 aviate-xil-contract = { git = "https://github.com/luofang34/Aviate.git", rev = "ac9bd248406a892fbe97a712d921326c96abd8b6" }
 aviate-xil-shm = { git = "https://github.com/luofang34/Aviate.git", rev = "ac9bd248406a892fbe97a712d921326c96abd8b6" }
+# The Navigate crates are consumed only at one exact upstream revision:
+# all five crates must always pin the identical rev so the contract
+# vocabulary, fusion, plan sequencing, guidance, and geodesy cannot
+# drift apart (the same discipline as the aviate-xil pins above).
+navigate-contract = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+navigate-geodesy = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+navigate-fusion = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+navigate-fpl = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+navigate-guidance = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+aerocontext-core = "0.4.5"
+aerocontext-planning = "0.4.5"
+aerocontext-navdata = { version = "0.4.5", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.18", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
@@ -84,6 +98,7 @@ pilotage-adapter-gazebo = { path = "adapters/gazebo" }
 pilotage-adapter-aviate = { path = "adapters/aviate" }
 pilotage-adapter-px4 = { path = "adapters/px4" }
 pilotage-session = { path = "crates/pilotage-session" }
+pilotage-mission = { path = "crates/pilotage-mission" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clients/web-instruments/src/decode_envelope.rs
+++ b/clients/web-instruments/src/decode_envelope.rs
@@ -16,6 +16,13 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::wire_js::{incarnation_hex, to_js};
 
+mod groups;
+
+use groups::{
+    Avionics, FcState, Gimbal, NavGuidance, SimTruth, avionics_message, fc_state_message,
+    gimbal_message, nav_guidance_message, sim_truth_message,
+};
+
 /// `{ kind, message }`, the browser's envelope-decode result shape.
 #[derive(Serialize)]
 struct Decoded<M> {
@@ -58,47 +65,6 @@ struct Stamp {
     integrity: i32,
 }
 
-#[derive(Serialize, Clone, Copy)]
-struct Quat {
-    w: f32,
-    x: f32,
-    y: f32,
-    z: f32,
-}
-
-#[derive(Serialize, Clone, Copy)]
-struct Attitude {
-    quat: Quat,
-    rates: [f32; 3],
-}
-
-#[derive(Serialize, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
-struct Kinematics {
-    pos_ned: [f32; 3],
-    vel_ned: [f32; 3],
-}
-
-/// Raw avionics estimate in the exact shape the browser ingress consumes: the
-/// attitude and kinematics groups are present only when their acquisition stamp
-/// is, and the flattened `quat`/`rates`/`posNed`/`velNed` mirror those groups.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct Avionics {
-    attitude: Option<Attitude>,
-    kinematics: Option<Kinematics>,
-    quat: Option<Quat>,
-    rates: Option<[f32; 3]>,
-    pos_ned: Option<[f32; 3]>,
-    vel_ned: Option<[f32; 3]>,
-    valid_flags: u32,
-    quality: u32,
-    arm_state: u32,
-    attitude_stamp: Option<Stamp>,
-    kinematics_stamp: Option<Stamp>,
-    estimator_status_stamp: Option<Stamp>,
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Pose {
@@ -115,30 +81,14 @@ struct Velocity {
     angular_rad_s: f32,
 }
 
-/// Simulation-truth oracle sample in the browser's shape: the simulator's
-/// pose under its own provenance stamp. Kept structurally apart from
-/// `Avionics` — truth is never merged into the estimate the panels consume.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SimTruth {
-    quat: Quat,
-    pos_ned: [f32; 3],
-    vel_ned: [f32; 3],
-    valid_flags: u32,
-    stamp: Stamp,
-}
-
-/// FC-owned arm/mode state under its own provenance stamp.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FcState {
-    arm_state: u32,
-    stamp: Stamp,
-}
-
 /// A telemetry sample. `pose`/`velocity` are absent when the host supplies no
 /// coherent projection; the flattened `xM`/`yM`/`headingRad`/`linearXMps`/
 /// `angularRadS` mirror them so a consumer can read either form.
+///
+/// Every stamped sub-message the wire carries has a field here. A group the
+/// host encodes and this struct omits is invisible to the viewer without any
+/// decode error to notice it by, so the wasm/JS conformance test pins the
+/// presence of each one against the JS reference decoder.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TelemetryMessage {
@@ -155,6 +105,8 @@ struct TelemetryMessage {
     avionics: Option<Avionics>,
     sim_truth: Option<SimTruth>,
     fc_state: Option<FcState>,
+    gimbal: Option<Gimbal>,
+    nav_guidance: Option<NavGuidance>,
 }
 
 /// Decodes one bare (non-length-delimited) datagram `Envelope`, returning
@@ -231,82 +183,10 @@ fn telemetry_message(sample: wire::TelemetrySample) -> TelemetryMessage {
         avionics: sample.avionics.map(avionics_message),
         sim_truth: sample.sim_truth.and_then(|truth| sim_truth_message(*truth)),
         fc_state: sample.fc_state.and_then(|state| fc_state_message(*state)),
-    }
-}
-
-/// `None` when the wire sample carries no provenance stamp: truth without
-/// identity is unconsumable and is dropped, never defaulted.
-fn sim_truth_message(state: wire::SimTruthState) -> Option<SimTruth> {
-    let stamp = state.stamp?;
-    // Exact-role gate: a truth lane whose stamp does not carry the
-    // simulation-truth role is mislabeled and unconsumable.
-    if stamp.role != wire::SourceRole::SimulationTruth as i32 {
-        return None;
-    }
-    Some(SimTruth {
-        quat: Quat {
-            w: state.quat_w,
-            x: state.quat_x,
-            y: state.quat_y,
-            z: state.quat_z,
-        },
-        pos_ned: [state.pos_n_m, state.pos_e_m, state.pos_d_m],
-        vel_ned: [state.vel_n_mps, state.vel_e_mps, state.vel_d_mps],
-        valid_flags: state.valid_flags,
-        stamp: stamp_message(stamp),
-    })
-}
-
-/// `None` when the wire report carries no provenance stamp: an unstamped
-/// arm state is exactly what this lane exists to prevent.
-fn fc_state_message(state: wire::FcState) -> Option<FcState> {
-    let stamp = state.stamp?;
-    // Exact-role gate: FC state must carry the FC-state role.
-    if stamp.role != wire::SourceRole::FcState as i32 {
-        return None;
-    }
-    Some(FcState {
-        arm_state: state.arm_state,
-        stamp: stamp_message(stamp),
-    })
-}
-
-// Surfaces the deprecated wire lane `arm_state` verbatim (hosts leave it 0);
-// consumers take arm from the stamped `fcState` message instead.
-#[allow(deprecated)]
-fn avionics_message(state: wire::AvionicsState) -> Avionics {
-    let attitude_stamp = state.attitude_stamp.map(stamp_message);
-    let kinematics_stamp = state.kinematics_stamp.map(stamp_message);
-    let estimator_status_stamp = state.estimator_status_stamp.map(stamp_message);
-    // A group's values are meaningful only when its acquisition stamp is
-    // present; absent that, the group is null, never proto3 zero displayed as a
-    // measurement (ADR-0018).
-    let attitude = attitude_stamp.as_ref().map(|_| Attitude {
-        quat: Quat {
-            w: state.quat_w,
-            x: state.quat_x,
-            y: state.quat_y,
-            z: state.quat_z,
-        },
-        rates: [state.rate_p_rad_s, state.rate_q_rad_s, state.rate_r_rad_s],
-    });
-    let kinematics = kinematics_stamp.as_ref().map(|_| Kinematics {
-        pos_ned: [state.pos_n_m, state.pos_e_m, state.pos_d_m],
-        vel_ned: [state.vel_n_mps, state.vel_e_mps, state.vel_d_mps],
-    });
-    Avionics {
-        quat: attitude.map(|attitude| attitude.quat),
-        rates: attitude.map(|attitude| attitude.rates),
-        pos_ned: kinematics.map(|kinematics| kinematics.pos_ned),
-        vel_ned: kinematics.map(|kinematics| kinematics.vel_ned),
-        attitude,
-        kinematics,
-        valid_flags: state.valid_flags,
-        quality: state.quality,
-        arm_state: state.arm_state,
-        attitude_stamp,
-        kinematics_stamp,
-        estimator_status_stamp,
+        gimbal: sample.gimbal.and_then(|gimbal| gimbal_message(*gimbal)),
+        nav_guidance: sample
+            .nav_guidance
+            .and_then(|guidance| nav_guidance_message(*guidance)),
     }
 }
 
@@ -325,121 +205,4 @@ fn stamp_message(stamp: wire::MeasurementStamp) -> Stamp {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::panic)]
-mod tests {
-    use super::{avionics_message, stamp_message, telemetry_message};
-    use pilotage_protocol::wire;
-
-    fn stamp(source_id: u64, incarnation: Vec<u8>) -> wire::MeasurementStamp {
-        wire::MeasurementStamp {
-            role: wire::SourceRole::OperationalEstimate as i32,
-            integrity: wire::SourceIntegrity::ChecksummedOnly as i32,
-            source_id,
-            source_epoch: 3,
-            sequence: 9,
-            acquired_at_ns: 123,
-            clock: wire::MeasurementClock::Simulation as i32,
-            source_incarnation: incarnation,
-        }
-    }
-
-    #[allow(deprecated)]
-    fn full_avionics() -> wire::AvionicsState {
-        wire::AvionicsState {
-            quat_w: 1.0,
-            quat_x: 0.2,
-            quat_y: 0.3,
-            quat_z: 0.4,
-            rate_p_rad_s: 0.5,
-            rate_q_rad_s: 0.6,
-            rate_r_rad_s: 0.7,
-            pos_n_m: 10.0,
-            pos_e_m: 11.0,
-            pos_d_m: -2.0,
-            vel_n_mps: 1.0,
-            vel_e_mps: 2.0,
-            vel_d_mps: 3.0,
-            valid_flags: 0x0f,
-            quality: 0,
-            arm_state: 1,
-            attitude_stamp: Some(stamp(7, vec![0xAB; 16])),
-            kinematics_stamp: Some(stamp(8, vec![0xCD; 16])),
-            estimator_status_stamp: Some(stamp(9, vec![0xEF; 16])),
-        }
-    }
-
-    #[test]
-    fn present_groups_flatten_and_mirror_their_nested_form() {
-        let avionics = avionics_message(full_avionics());
-        let attitude = avionics.attitude.expect("attitude present with its stamp");
-        let quat = avionics.quat.expect("flat quat mirrors attitude");
-        assert_eq!(quat.w, attitude.quat.w);
-        assert_eq!(avionics.rates.expect("flat rates"), attitude.rates);
-        let kinematics = avionics
-            .kinematics
-            .expect("kinematics present with its stamp");
-        assert_eq!(avionics.pos_ned.expect("flat pos"), kinematics.pos_ned);
-        assert_eq!(avionics.vel_ned.expect("flat vel"), kinematics.vel_ned);
-    }
-
-    #[test]
-    fn absent_stamp_zeroes_no_group() {
-        let mut state = full_avionics();
-        state.attitude_stamp = None;
-        let avionics = avionics_message(state);
-        // The proto3 quat defaults are not a measurement without an attitude
-        // stamp: the group and its flattened mirror must be absent, not zero.
-        assert!(avionics.attitude.is_none());
-        assert!(avionics.quat.is_none());
-        assert!(avionics.rates.is_none());
-        // The kinematics group, whose stamp survives, is unaffected.
-        assert!(avionics.kinematics.is_some());
-    }
-
-    #[test]
-    fn incarnation_is_hex_only_when_sixteen_bytes() {
-        assert_eq!(
-            stamp_message(stamp(1, vec![0xAB; 16]))
-                .source_incarnation
-                .as_deref(),
-            Some("abababababababababababababababab")
-        );
-        assert!(
-            stamp_message(stamp(1, vec![0xAB; 4]))
-                .source_incarnation
-                .is_none()
-        );
-        assert!(
-            stamp_message(stamp(1, Vec::new()))
-                .source_incarnation
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn pose_absence_leaves_flattened_fields_absent() {
-        let sample = wire::TelemetrySample {
-            vehicle: Some(wire::VehicleId { value: 1 }),
-            tick: Some(wire::SimTick { value: 5 }),
-            observed_at: Some(wire::MonoTimestamp { nanos: 900 }),
-            pose: None,
-            velocity: Some(wire::Velocity2d {
-                linear_x_mps: 4.0,
-                linear_y_mps: 0.0,
-                angular_rad_s: 0.1,
-            }),
-            avionics: None,
-            sim_truth: None,
-            fc_state: None,
-            gimbal: None,
-        };
-        let message = telemetry_message(sample);
-        assert_eq!(message.vehicle_id, 1);
-        assert!(message.pose.is_none());
-        assert!(message.x_m.is_none());
-        // Velocity present flattens through.
-        assert_eq!(message.linear_x_mps, Some(4.0));
-        assert_eq!(message.angular_rad_s, Some(0.1));
-        assert!(message.avionics.is_none());
-    }
-}
+mod tests;

--- a/clients/web-instruments/src/decode_envelope/groups.rs
+++ b/clients/web-instruments/src/decode_envelope/groups.rs
@@ -1,0 +1,234 @@
+//! The stamped signal groups a `TelemetrySample` carries, in the browser
+//! ingress's field vocabulary.
+//!
+//! Every group here is independent: its own source identity, epoch, sequence,
+//! clock, and role (ADR-0018). Each decode is fail-closed twice over — a
+//! group without its provenance stamp is `None` rather than proto3 zeros
+//! presented as a measurement, and a stamp whose role does not match the lane
+//! exactly is `None` rather than a mislabeled lane feeding a display or a
+//! control decision.
+
+use pilotage_protocol::wire;
+use serde::Serialize;
+
+use super::{Stamp, stamp_message};
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Serialize, Clone, Copy)]
+pub(super) struct Quat {
+    w: f32,
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+#[derive(Serialize, Clone, Copy)]
+pub(super) struct Attitude {
+    quat: Quat,
+    rates: [f32; 3],
+}
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Kinematics {
+    pos_ned: [f32; 3],
+    vel_ned: [f32; 3],
+}
+
+/// Raw avionics estimate in the exact shape the browser ingress consumes: the
+/// attitude and kinematics groups are present only when their acquisition stamp
+/// is, and the flattened `quat`/`rates`/`posNed`/`velNed` mirror those groups.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Avionics {
+    attitude: Option<Attitude>,
+    kinematics: Option<Kinematics>,
+    quat: Option<Quat>,
+    rates: Option<[f32; 3]>,
+    pos_ned: Option<[f32; 3]>,
+    vel_ned: Option<[f32; 3]>,
+    valid_flags: u32,
+    quality: u32,
+    arm_state: u32,
+    attitude_stamp: Option<Stamp>,
+    kinematics_stamp: Option<Stamp>,
+    estimator_status_stamp: Option<Stamp>,
+}
+
+/// Simulation-truth oracle sample in the browser's shape: the simulator's
+/// pose under its own provenance stamp. Kept structurally apart from
+/// `Avionics` — truth is never merged into the estimate the panels consume.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SimTruth {
+    quat: Quat,
+    pos_ned: [f32; 3],
+    vel_ned: [f32; 3],
+    valid_flags: u32,
+    stamp: Stamp,
+}
+
+/// FC-owned arm/mode state under its own provenance stamp.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct FcState {
+    arm_state: u32,
+    stamp: Stamp,
+}
+
+/// Gimbal payload-device orientation under its own provenance stamp.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Gimbal {
+    quat: Quat,
+    rates_rad_s: [f32; 3],
+    flags: u32,
+    failure_flags: u32,
+    stamp: Stamp,
+}
+
+/// Active-leg navigation guidance in raw canonical units (ADR-0031): meters
+/// and radians, never dots. Scaling deviations to an instrument's dot scale
+/// is the client display profile's job, so the same sample can drive panels
+/// with different full-scale deflection.
+///
+/// `lateralDeviationM` is NaN when the guidance tracks no lateral course and
+/// `verticalDeviationM` is NaN without a vertical constraint; both reach JS
+/// as NaN so a consumer removes that deviation rather than centering it.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct NavGuidance {
+    to_ident: String,
+    from_ident: String,
+    course_rad: f32,
+    lateral_deviation_m: f32,
+    vertical_deviation_m: f32,
+    distance_to_waypoint_m: f32,
+    leg_index: u32,
+    waypoint_count: u32,
+    solution_quality: u32,
+    stamp: Stamp,
+}
+
+/// `None` when the wire sample carries no provenance stamp: truth without
+/// identity is unconsumable and is dropped, never defaulted.
+pub(super) fn sim_truth_message(state: wire::SimTruthState) -> Option<SimTruth> {
+    let stamp = state.stamp?;
+    // Exact-role gate: a truth lane whose stamp does not carry the
+    // simulation-truth role is mislabeled and unconsumable.
+    if stamp.role != wire::SourceRole::SimulationTruth as i32 {
+        return None;
+    }
+    Some(SimTruth {
+        quat: Quat {
+            w: state.quat_w,
+            x: state.quat_x,
+            y: state.quat_y,
+            z: state.quat_z,
+        },
+        pos_ned: [state.pos_n_m, state.pos_e_m, state.pos_d_m],
+        vel_ned: [state.vel_n_mps, state.vel_e_mps, state.vel_d_mps],
+        valid_flags: state.valid_flags,
+        stamp: stamp_message(stamp),
+    })
+}
+
+/// `None` when the wire report carries no provenance stamp: an unstamped
+/// arm state is exactly what this lane exists to prevent.
+pub(super) fn fc_state_message(state: wire::FcState) -> Option<FcState> {
+    let stamp = state.stamp?;
+    // Exact-role gate: FC state must carry the FC-state role.
+    if stamp.role != wire::SourceRole::FcState as i32 {
+        return None;
+    }
+    Some(FcState {
+        arm_state: state.arm_state,
+        stamp: stamp_message(stamp),
+    })
+}
+
+/// `None` without a payload-device stamp, so a mislabeled lane can never
+/// point the camera view or be read as vehicle attitude.
+pub(super) fn gimbal_message(state: wire::GimbalAttitude) -> Option<Gimbal> {
+    let stamp = state.stamp?;
+    // Exact-role gate: the gimbal lane must carry the payload-device role.
+    if stamp.role != wire::SourceRole::PayloadDevice as i32 {
+        return None;
+    }
+    Some(Gimbal {
+        quat: Quat {
+            w: state.quat_w,
+            x: state.quat_x,
+            y: state.quat_y,
+            z: state.quat_z,
+        },
+        rates_rad_s: [state.rate_x_rad_s, state.rate_y_rad_s, state.rate_z_rad_s],
+        flags: state.flags,
+        failure_flags: state.failure_flags,
+        stamp: stamp_message(stamp),
+    })
+}
+
+/// `None` without a navigation-solution stamp: guidance is display context,
+/// and a lane wearing another role is not the navigation component's
+/// solution — it is never accepted as a substitute for one.
+pub(super) fn nav_guidance_message(state: wire::NavGuidanceState) -> Option<NavGuidance> {
+    let stamp = state.stamp?;
+    // Exact-role gate: guidance must carry the navigation-solution role.
+    if stamp.role != wire::SourceRole::NavigationSolution as i32 {
+        return None;
+    }
+    Some(NavGuidance {
+        to_ident: state.to_ident,
+        from_ident: state.from_ident,
+        course_rad: state.course_rad,
+        lateral_deviation_m: state.lateral_deviation_m,
+        vertical_deviation_m: state.vertical_deviation_m,
+        distance_to_waypoint_m: state.distance_to_waypoint_m,
+        leg_index: state.leg_index,
+        waypoint_count: state.waypoint_count,
+        solution_quality: state.solution_quality,
+        stamp: stamp_message(stamp),
+    })
+}
+
+// Surfaces the deprecated wire lane `arm_state` verbatim (hosts leave it 0);
+// consumers take arm from the stamped `fcState` message instead.
+#[allow(deprecated)]
+pub(super) fn avionics_message(state: wire::AvionicsState) -> Avionics {
+    let attitude_stamp = state.attitude_stamp.map(stamp_message);
+    let kinematics_stamp = state.kinematics_stamp.map(stamp_message);
+    let estimator_status_stamp = state.estimator_status_stamp.map(stamp_message);
+    // A group's values are meaningful only when its acquisition stamp is
+    // present; absent that, the group is null, never proto3 zero displayed as a
+    // measurement (ADR-0018).
+    let attitude = attitude_stamp.as_ref().map(|_| Attitude {
+        quat: Quat {
+            w: state.quat_w,
+            x: state.quat_x,
+            y: state.quat_y,
+            z: state.quat_z,
+        },
+        rates: [state.rate_p_rad_s, state.rate_q_rad_s, state.rate_r_rad_s],
+    });
+    let kinematics = kinematics_stamp.as_ref().map(|_| Kinematics {
+        pos_ned: [state.pos_n_m, state.pos_e_m, state.pos_d_m],
+        vel_ned: [state.vel_n_mps, state.vel_e_mps, state.vel_d_mps],
+    });
+    Avionics {
+        quat: attitude.map(|attitude| attitude.quat),
+        rates: attitude.map(|attitude| attitude.rates),
+        pos_ned: kinematics.map(|kinematics| kinematics.pos_ned),
+        vel_ned: kinematics.map(|kinematics| kinematics.vel_ned),
+        attitude,
+        kinematics,
+        valid_flags: state.valid_flags,
+        quality: state.quality,
+        arm_state: state.arm_state,
+        attitude_stamp,
+        kinematics_stamp,
+        estimator_status_stamp,
+    }
+}

--- a/clients/web-instruments/src/decode_envelope/groups/tests.rs
+++ b/clients/web-instruments/src/decode_envelope/groups/tests.rs
@@ -1,0 +1,184 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_protocol::wire;
+
+use super::{avionics_message, gimbal_message, nav_guidance_message};
+use crate::decode_envelope::stamp_message;
+
+fn stamp(source_id: u64, incarnation: Vec<u8>) -> wire::MeasurementStamp {
+    wire::MeasurementStamp {
+        role: wire::SourceRole::OperationalEstimate as i32,
+        integrity: wire::SourceIntegrity::ChecksummedOnly as i32,
+        source_id,
+        source_epoch: 3,
+        sequence: 9,
+        acquired_at_ns: 123,
+        clock: wire::MeasurementClock::Simulation as i32,
+        source_incarnation: incarnation,
+    }
+}
+
+fn stamp_with_role(role: wire::SourceRole) -> wire::MeasurementStamp {
+    wire::MeasurementStamp {
+        role: role as i32,
+        ..stamp(11, vec![0x5A; 16])
+    }
+}
+
+#[allow(deprecated)]
+fn full_avionics() -> wire::AvionicsState {
+    wire::AvionicsState {
+        quat_w: 1.0,
+        quat_x: 0.2,
+        quat_y: 0.3,
+        quat_z: 0.4,
+        rate_p_rad_s: 0.5,
+        rate_q_rad_s: 0.6,
+        rate_r_rad_s: 0.7,
+        pos_n_m: 10.0,
+        pos_e_m: 11.0,
+        pos_d_m: -2.0,
+        vel_n_mps: 1.0,
+        vel_e_mps: 2.0,
+        vel_d_mps: 3.0,
+        valid_flags: 0x0f,
+        quality: 0,
+        arm_state: 1,
+        attitude_stamp: Some(stamp(7, vec![0xAB; 16])),
+        kinematics_stamp: Some(stamp(8, vec![0xCD; 16])),
+        estimator_status_stamp: Some(stamp(9, vec![0xEF; 16])),
+    }
+}
+
+fn guidance(stamp: Option<wire::MeasurementStamp>) -> wire::NavGuidanceState {
+    wire::NavGuidanceState {
+        stamp,
+        to_ident: String::from("WP02"),
+        from_ident: String::from("WP01"),
+        course_rad: 1.25,
+        lateral_deviation_m: -30.0,
+        vertical_deviation_m: 12.5,
+        distance_to_waypoint_m: 3704.0,
+        leg_index: 2,
+        waypoint_count: 5,
+        solution_quality: 1,
+    }
+}
+
+fn gimbal(stamp: Option<wire::MeasurementStamp>) -> wire::GimbalAttitude {
+    wire::GimbalAttitude {
+        quat_w: 1.0,
+        quat_x: 0.0,
+        quat_y: 0.25,
+        quat_z: 0.0,
+        rate_x_rad_s: 0.5,
+        rate_y_rad_s: -0.5,
+        rate_z_rad_s: 0.75,
+        stamp,
+        flags: 0b101,
+        failure_flags: 0b10,
+    }
+}
+
+#[test]
+fn present_groups_flatten_and_mirror_their_nested_form() {
+    let avionics = avionics_message(full_avionics());
+    let attitude = avionics.attitude.expect("attitude present with its stamp");
+    let quat = avionics.quat.expect("flat quat mirrors attitude");
+    assert_eq!(quat.w, attitude.quat.w);
+    assert_eq!(avionics.rates.expect("flat rates"), attitude.rates);
+    let kinematics = avionics
+        .kinematics
+        .expect("kinematics present with its stamp");
+    assert_eq!(avionics.pos_ned.expect("flat pos"), kinematics.pos_ned);
+    assert_eq!(avionics.vel_ned.expect("flat vel"), kinematics.vel_ned);
+}
+
+#[test]
+fn absent_stamp_zeroes_no_group() {
+    let mut state = full_avionics();
+    state.attitude_stamp = None;
+    let avionics = avionics_message(state);
+    // The proto3 quat defaults are not a measurement without an attitude
+    // stamp: the group and its flattened mirror must be absent, not zero.
+    assert!(avionics.attitude.is_none());
+    assert!(avionics.quat.is_none());
+    assert!(avionics.rates.is_none());
+    // The kinematics group, whose stamp survives, is unaffected.
+    assert!(avionics.kinematics.is_some());
+}
+
+#[test]
+fn incarnation_is_hex_only_when_sixteen_bytes() {
+    assert_eq!(
+        stamp_message(stamp(1, vec![0xAB; 16]))
+            .source_incarnation
+            .as_deref(),
+        Some("abababababababababababababababab")
+    );
+    assert!(
+        stamp_message(stamp(1, vec![0xAB; 4]))
+            .source_incarnation
+            .is_none()
+    );
+    assert!(
+        stamp_message(stamp(1, Vec::new()))
+            .source_incarnation
+            .is_none()
+    );
+}
+
+#[test]
+fn gimbal_needs_a_payload_device_stamp() {
+    let device = gimbal_message(gimbal(Some(stamp_with_role(
+        wire::SourceRole::PayloadDevice,
+    ))))
+    .expect("payload-device stamp admits the lane");
+    assert_eq!(device.quat.y, 0.25);
+    assert_eq!(device.rates_rad_s, [0.5, -0.5, 0.75]);
+    assert_eq!(device.flags, 0b101);
+    assert_eq!(device.failure_flags, 0b10);
+    assert!(gimbal_message(gimbal(None)).is_none());
+    // A device report wearing another lane's role is mislabeled: it must
+    // never reach the camera view as an orientation.
+    assert!(gimbal_message(gimbal(Some(stamp_with_role(wire::SourceRole::FcState)))).is_none());
+}
+
+#[test]
+fn nav_guidance_needs_a_navigation_solution_stamp() {
+    let nav = nav_guidance_message(guidance(Some(stamp_with_role(
+        wire::SourceRole::NavigationSolution,
+    ))))
+    .expect("navigation-solution stamp admits the lane");
+    assert_eq!(nav.to_ident, "WP02");
+    assert_eq!(nav.from_ident, "WP01");
+    assert_eq!(nav.course_rad, 1.25);
+    assert_eq!(nav.lateral_deviation_m, -30.0);
+    assert_eq!(nav.vertical_deviation_m, 12.5);
+    assert_eq!(nav.distance_to_waypoint_m, 3704.0);
+    assert_eq!(nav.leg_index, 2);
+    assert_eq!(nav.waypoint_count, 5);
+    assert_eq!(nav.solution_quality, 1);
+    assert_eq!(nav.stamp.role, wire::SourceRole::NavigationSolution as i32);
+    assert!(nav_guidance_message(guidance(None)).is_none());
+    // Guidance is display context and never a fallback for a missing
+    // estimate: an estimate-role lane is not a navigation solution.
+    assert!(
+        nav_guidance_message(guidance(Some(stamp_with_role(
+            wire::SourceRole::OperationalEstimate
+        ))))
+        .is_none()
+    );
+}
+
+#[test]
+fn nav_guidance_carries_not_tracking_through_as_nan() {
+    let mut state = guidance(Some(stamp_with_role(wire::SourceRole::NavigationSolution)));
+    state.lateral_deviation_m = f32::NAN;
+    state.vertical_deviation_m = f32::NAN;
+    let nav = nav_guidance_message(state).expect("stamped guidance decodes");
+    // Zero would read as on-course; the absence must survive the decode so
+    // the display profile can remove the deviation instead of centering it.
+    assert!(nav.lateral_deviation_m.is_nan());
+    assert!(nav.vertical_deviation_m.is_nan());
+}

--- a/clients/web-instruments/src/decode_envelope/tests.rs
+++ b/clients/web-instruments/src/decode_envelope/tests.rs
@@ -1,0 +1,99 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_protocol::wire;
+
+use super::telemetry_message;
+
+fn stamp(role: wire::SourceRole) -> wire::MeasurementStamp {
+    wire::MeasurementStamp {
+        role: role as i32,
+        integrity: wire::SourceIntegrity::ChecksummedOnly as i32,
+        source_id: 4,
+        source_epoch: 1,
+        sequence: 2,
+        acquired_at_ns: 500,
+        clock: wire::MeasurementClock::Simulation as i32,
+        source_incarnation: vec![0x11; 16],
+    }
+}
+
+fn empty_sample() -> wire::TelemetrySample {
+    wire::TelemetrySample {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        tick: Some(wire::SimTick { value: 5 }),
+        observed_at: Some(wire::MonoTimestamp { nanos: 900 }),
+        pose: None,
+        velocity: None,
+        avionics: None,
+        sim_truth: None,
+        fc_state: None,
+        gimbal: None,
+        nav_guidance: None,
+    }
+}
+
+#[test]
+fn pose_absence_leaves_flattened_fields_absent() {
+    let mut sample = empty_sample();
+    sample.velocity = Some(wire::Velocity2d {
+        linear_x_mps: 4.0,
+        linear_y_mps: 0.0,
+        angular_rad_s: 0.1,
+    });
+    let message = telemetry_message(sample);
+    assert_eq!(message.vehicle_id, 1);
+    assert!(message.pose.is_none());
+    assert!(message.x_m.is_none());
+    // Velocity present flattens through.
+    assert_eq!(message.linear_x_mps, Some(4.0));
+    assert_eq!(message.angular_rad_s, Some(0.1));
+    assert!(message.avionics.is_none());
+}
+
+#[test]
+fn every_stamped_group_the_sample_carries_reaches_the_message() {
+    let mut sample = empty_sample();
+    sample.gimbal = Some(Box::new(wire::GimbalAttitude {
+        quat_w: 1.0,
+        stamp: Some(stamp(wire::SourceRole::PayloadDevice)),
+        ..Default::default()
+    }));
+    sample.nav_guidance = Some(Box::new(wire::NavGuidanceState {
+        stamp: Some(stamp(wire::SourceRole::NavigationSolution)),
+        to_ident: String::from("WP01"),
+        ..Default::default()
+    }));
+    sample.fc_state = Some(Box::new(wire::FcState {
+        arm_state: 2,
+        stamp: Some(stamp(wire::SourceRole::FcState)),
+        ..Default::default()
+    }));
+    let message = telemetry_message(sample);
+    // A group the host encodes and this decode drops is invisible in the
+    // browser with no error to notice it by, so each wiring is pinned.
+    assert!(
+        message.gimbal.is_some(),
+        "gimbal lane must reach the viewer"
+    );
+    assert!(
+        message.nav_guidance.is_some(),
+        "guidance lane must reach the viewer"
+    );
+    assert!(message.fc_state.is_some(), "fc lane must reach the viewer");
+}
+
+#[test]
+fn unstamped_groups_are_absent_rather_than_defaulted() {
+    let mut sample = empty_sample();
+    sample.gimbal = Some(Box::new(wire::GimbalAttitude {
+        quat_w: 1.0,
+        ..Default::default()
+    }));
+    sample.nav_guidance = Some(Box::new(wire::NavGuidanceState {
+        to_ident: String::from("WP01"),
+        ..Default::default()
+    }));
+    let message = telemetry_message(sample);
+    assert!(message.gimbal.is_none());
+    assert!(message.nav_guidance.is_none());
+}

--- a/clients/web/cockpit-readout.js
+++ b/clients/web/cockpit-readout.js
@@ -209,6 +209,10 @@ export function createCockpitReadout({
   function retireSessionPresentation(phase) {
     instruments.ingress = newSimulatorAvionicsIngress();
     instruments.fcState = new FcStateTracker();
+    // A restarted host mints a new guidance incarnation; a tracker that
+    // survives the session boundary would pin the dead session's identity
+    // and refuse the new one forever.
+    instruments.navGuidance = new NavGuidanceTracker();
     snapshotHistory.reset();
     turnDerivation.reset();
     h264Registry?.closeAll();
@@ -218,6 +222,7 @@ export function createCockpitReadout({
   function beginTelemetrySession() {
     instruments.ingress = newSimulatorAvionicsIngress();
     instruments.fcState = new FcStateTracker();
+    instruments.navGuidance = new NavGuidanceTracker();
     setTelemetrySessionState(els, "awaiting");
   }
 

--- a/clients/web/cockpit-readout.js
+++ b/clients/web/cockpit-readout.js
@@ -14,7 +14,13 @@ import {
 } from "./instrument-health.js";
 import { TurnDerivation } from "./turn-derivation.js";
 import { fcArmToken, formatTelemetrySummary, setTelemetrySessionState } from "./telemetry-display.js";
-import { AvionicsIngress, FcStateTracker, INCARNATION_POLICY } from "./telemetry-ingress.js";
+import {
+  AvionicsIngress,
+  FcStateTracker,
+  INCARNATION_POLICY,
+  NavGuidanceTracker,
+} from "./telemetry-ingress.js";
+import { navDisplayState } from "./nav-display.js";
 import { SnapshotAssociator, associateIfAccepted } from "./snapshot-association.js";
 import { CalibrationRegistry, loadCalibrationRegistry } from "./calibration.js";
 import { readinessTransition, shouldLogReadFailure } from "./video-diagnostics.js";
@@ -105,6 +111,7 @@ export function createCockpitReadout({
     moduleFault: null,
     ingress: newSimulatorAvionicsIngress(),
     fcState: new FcStateTracker(),
+    navGuidance: new NavGuidanceTracker(),
     health: {
       [PANEL.PFD]: new PanelHealth({ tickIntervalMs: WATCHDOG_INTERVAL_MS }),
       [PANEL.HSI]: new PanelHealth({ tickIntervalMs: WATCHDOG_INTERVAL_MS }),
@@ -534,6 +541,7 @@ export function createCockpitReadout({
             if (accepted.kinematics) snapshotHistory.observe(accepted.kinematics.stamp);
           }
           if (telemetry.vehicleId !== vehicleId) continue;
+          instruments.navGuidance.observe(telemetry.navGuidance ?? null, performance.now());
           const fcView = instruments.fcState.observe(telemetry.fcState ?? null, performance.now());
           state.lastFcView = fcView;
           logFcCommandVerdict(fcView);
@@ -645,7 +653,7 @@ export function createCockpitReadout({
       attitude,
       kinematics,
       air: null,
-      nav: null,
+      nav: navDisplayState(instruments.navGuidance.snapshot(performance.now())),
       wind: null,
       selections: { headingBugRad: 0, headingBugReference: 2 },
       heading,

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -18,7 +18,7 @@ const SIZE_CAPS = {
   "authority-transition.js": 22,
   "bootstrap.js": 88,
   "calibration.js": 285,
-  "cockpit-readout.js": 731,
+  "cockpit-readout.js": 736,
   "connect-authority.js": 63,
   "control-edges.js": 31,
   "control-gate.js": 39,

--- a/clients/web/control-structure.test.mjs
+++ b/clients/web/control-structure.test.mjs
@@ -18,7 +18,7 @@ const SIZE_CAPS = {
   "authority-transition.js": 22,
   "bootstrap.js": 88,
   "calibration.js": 285,
-  "cockpit-readout.js": 724,
+  "cockpit-readout.js": 731,
   "connect-authority.js": 63,
   "control-edges.js": 31,
   "control-gate.js": 39,
@@ -32,6 +32,7 @@ const SIZE_CAPS = {
   "lease-release.js": 67,
   "main.js": 192,
   "media-recovery.js": 50,
+  "nav-display.js": 85,
   "reconnect.js": 150,
   "resume-control.js": 59,
   "session-discovery.js": 68,
@@ -39,7 +40,7 @@ const SIZE_CAPS = {
   "session-transport.js": 285,
   "snapshot-association.js": 266,
   "telemetry-display.js": 75,
-  "telemetry-ingress.js": 689,
+  "telemetry-ingress.js": 825,
   "stream-cancellation.js": 16,
   "transport-session.js": 128,
   "turn-derivation.js": 101,
@@ -53,7 +54,7 @@ const SIZE_CAPS = {
   "video-identity.js": 291,
   "video-routing.js": 37,
   "wire-bounds.js": 120,
-  "wire.js": 1171,
+  "wire.js": 1208,
 };
 
 const dir = new URL("./", import.meta.url);

--- a/clients/web/nav-display.js
+++ b/clients/web/nav-display.js
@@ -1,0 +1,85 @@
+// The client's navigation display profile (ADR-0031): the one place where
+// the wire's canonical guidance units become the instrument model's display
+// vocabulary. The wire carries meters and radians; the HSI's CDI and vertical
+// scale are calibrated in dots, and the meters-per-dot deflection is per
+// airframe class, so it lives here as a named constant with tests rather than
+// on the wire where it would bind every display to one policy.
+
+// Full-scale lateral deflection is ±2 dots, so ±2 dots = ±50 m of cross-track
+// error — the terminal-area scale a small unmanned airframe is flown to.
+export const LATERAL_M_PER_DOT = 25;
+// Full-scale vertical deflection is ±2.5 dots, so ±2.5 dots = ±20 m off the
+// vertical profile.
+export const VDEV_M_PER_DOT = 8;
+export const M_PER_NM = 1852;
+
+// Instrument-model codings (pilotage-instrument-state): NavSource,
+// NavFromTo, and HeadingReference as the packed ABI encodes them.
+const NAV_SOURCE_GPS = 1;
+const FROMTO_OFF = 0;
+const FROMTO_TO = 1;
+const HEADING_REFERENCE_TRUE = 1;
+// Solution qualities this build can present. Unusable, and any coding a
+// later host introduces, remove the display rather than drawing guidance
+// the client cannot vouch for.
+const PRESENTABLE_QUALITIES = Object.freeze([0, 1]);
+
+/**
+ * Converts one accepted guidance snapshot into the instrument runtime's `nav`
+ * group, or `null` when guidance must not display at all.
+ *
+ * `snapshot` is what `NavGuidanceTracker.snapshot()` returns:
+ * `{ navGuidance, ageMs }`, or `null` before any accepted sample. Returning
+ * `null` removes the whole group — the ADR-0031 contract that absent guidance
+ * is displayed as absent, never as a centered needle.
+ */
+export function navDisplayState(snapshot) {
+  if (!snapshot || !snapshot.navGuidance || !Number.isFinite(snapshot.ageMs)) return null;
+  const guidance = snapshot.navGuidance;
+  if (!PRESENTABLE_QUALITIES.includes(guidance.solutionQuality)) return null;
+
+  // Guidance that tracks no lateral course has no cross-track geometry to
+  // draw. Clearing the TO/FROM flag removes the deviation bar, and the
+  // deflection value goes to a finite zero the panel never paints — the
+  // instrument model requires a finite CDI value, and NaN would fail the
+  // whole group including the course and distance that are still valid.
+  const tracking = Number.isFinite(guidance.lateralDeviationM);
+  return {
+    source: NAV_SOURCE_GPS,
+    fromto: tracking ? FROMTO_TO : FROMTO_OFF,
+    courseRad: guidance.courseRad,
+    // The wire's course is measured from true north; the rose's own
+    // reference is the simulator's local true north, and both measure from
+    // true, so the conversion needs no variation sample.
+    courseReference: HEADING_REFERENCE_TRUE,
+    cdiDots: tracking ? lateralDots(guidance.lateralDeviationM) : 0,
+    vdevDots: verticalDots(guidance.verticalDeviationM),
+    distNm: guidance.distanceToWaypointM / M_PER_NM,
+    ageMs: snapshot.ageMs,
+  };
+}
+
+// Fly-to convention. The panel draws the deviation bar at
+// `cdi_dots * PX_PER_DOT` in a course-up frame where +x is the pilot's
+// right, and the bar marks where the course line is relative to ownship.
+// The wire's cross-track deviation is positive when ownship is RIGHT of
+// course, which puts the course to ownship's LEFT — so the deflection is
+// negative, and flying toward the bar closes the error.
+function lateralDots(lateralDeviationM) {
+  return -lateralDeviationM / LATERAL_M_PER_DOT;
+}
+
+// Fly-to convention, with the screen's downward y accounted for. The panel
+// draws the vertical pointer at `CY + vdev_dots * PX_PER_DOT` where larger y
+// is LOWER on the display, and the pointer marks where the profile is
+// relative to ownship. The wire's vertical deviation is positive when
+// ownship is ABOVE the profile, which puts the profile BELOW ownship — lower
+// on the display — so the deflection is positive, and flying down toward the
+// pointer closes the error. The sign is therefore NOT the mirror of the
+// lateral one: both are fly-to, and the axes disagree on which way is up.
+//
+// An unconstrained vertical profile stays NaN, the instrument model's coding
+// for a quantity with no sample, and the scale is not drawn.
+function verticalDots(verticalDeviationM) {
+  return Number.isFinite(verticalDeviationM) ? verticalDeviationM / VDEV_M_PER_DOT : NaN;
+}

--- a/clients/web/nav-display.test.mjs
+++ b/clients/web/nav-display.test.mjs
@@ -1,0 +1,148 @@
+// The navigation display profile (ADR-0031): canonical wire units in,
+// instrument-model display vocabulary out. The deflection signs are the
+// safety-relevant part — a mirrored CDI flies the crew to the wrong side of
+// course (FHA FC-HDG-03) — so both are pinned against the panel geometry
+// that consumes them.
+//
+// Run: node clients/web/nav-display.test.mjs
+
+import assert from "node:assert/strict";
+
+import {
+  LATERAL_M_PER_DOT,
+  M_PER_NM,
+  VDEV_M_PER_DOT,
+  navDisplayState,
+} from "./nav-display.js";
+
+function snapshot(overrides = {}, ageMs = 40) {
+  return {
+    navGuidance: {
+      toIdent: "WP02",
+      fromIdent: "WP01",
+      courseRad: 1.25,
+      lateralDeviationM: 0,
+      verticalDeviationM: 0,
+      distanceToWaypointM: 3704,
+      legIndex: 2,
+      waypointCount: 5,
+      solutionQuality: 0,
+      ...overrides,
+    },
+    ageMs,
+  };
+}
+
+function testEveryQuantityMapsIntoTheInstrumentVocabulary() {
+  const nav = navDisplayState(snapshot({ lateralDeviationM: 50, verticalDeviationM: -16 }));
+  assert.equal(nav.source, 1, "GPS/FMS course, drawn magenta");
+  assert.equal(nav.fromto, 1, "flying toward the active waypoint");
+  assert.equal(nav.courseRad, 1.25, "course passes through in radians");
+  assert.equal(nav.courseReference, 1, "true north, the reference the wire declares");
+  // Full-scale lateral is two dots at 25 m each: 50 m is exactly full scale.
+  assert.equal(nav.cdiDots, -2);
+  assert.equal(LATERAL_M_PER_DOT * 2, 50, "full-scale lateral deflection is ±50 m");
+  // Full-scale vertical is two and a half dots at 8 m each: 16 m is two dots.
+  assert.equal(nav.vdevDots, -2);
+  assert.equal(VDEV_M_PER_DOT * 2.5, 20, "full-scale vertical deflection is ±20 m");
+  assert.equal(nav.distNm, 3704 / M_PER_NM);
+  assert.equal(nav.distNm, 2, "3704 m is exactly 2 NM");
+  assert.equal(nav.ageMs, 40, "the freshness the tracker measured carries through");
+}
+testEveryQuantityMapsIntoTheInstrumentVocabulary();
+console.log("ok - testEveryQuantityMapsIntoTheInstrumentVocabulary");
+
+function testLateralDeflectionIsFlyTo() {
+  // The panel draws the deviation bar at `cdi_dots * 37.5 px` in a course-up
+  // frame where +x is the pilot's right, and the bar marks where the COURSE
+  // is relative to ownship. The wire's cross-track deviation is positive
+  // when ownship is right of course, so the course lies to ownship's LEFT
+  // and the bar must deflect LEFT (negative) for the crew to fly toward it.
+  const rightOfCourse = navDisplayState(snapshot({ lateralDeviationM: 25 }));
+  assert.equal(rightOfCourse.cdiDots, -1, "ownship right of course deflects the bar left");
+
+  const leftOfCourse = navDisplayState(snapshot({ lateralDeviationM: -25 }));
+  assert.equal(leftOfCourse.cdiDots, 1, "ownship left of course deflects the bar right");
+
+  // On course centers the bar, with the flag still showing TO.
+  // Negating zero yields -0, which paints exactly where +0 does.
+  const onCourse = navDisplayState(snapshot({ lateralDeviationM: 0 }));
+  assert.ok(onCourse.cdiDots === 0, "on course centers the bar");
+  assert.equal(onCourse.fromto, 1);
+
+  // Beyond full scale the value is NOT clamped here: the panel owns its own
+  // deflection limit, and clamping twice would hide a scaling error.
+  assert.equal(navDisplayState(snapshot({ lateralDeviationM: 500 })).cdiDots, -20);
+}
+testLateralDeflectionIsFlyTo();
+console.log("ok - testLateralDeflectionIsFlyTo");
+
+function testVerticalDeflectionIsFlyTo() {
+  // The panel draws the vertical pointer at `CY + vdev_dots * 38.4 px`, and
+  // screen y grows DOWNWARD, so a positive value puts the pointer BELOW
+  // center. The pointer marks where the profile is relative to ownship: the
+  // wire's vertical deviation is positive when ownship is ABOVE the profile,
+  // which puts the profile below ownship, so the deflection is POSITIVE and
+  // the crew flies down toward it. The sign is not the mirror of the lateral
+  // one — the two axes disagree on which way is up.
+  const aboveProfile = navDisplayState(snapshot({ verticalDeviationM: 8 }));
+  assert.equal(aboveProfile.vdevDots, 1, "above the profile puts the pointer below center");
+
+  const belowProfile = navDisplayState(snapshot({ verticalDeviationM: -8 }));
+  assert.equal(belowProfile.vdevDots, -1, "below the profile puts the pointer above center");
+
+  assert.equal(navDisplayState(snapshot({ verticalDeviationM: 0 })).vdevDots, 0);
+}
+testVerticalDeflectionIsFlyTo();
+console.log("ok - testVerticalDeflectionIsFlyTo");
+
+function testUntrackedLateralCourseRemovesTheBarWithoutFailingTheGroup() {
+  const nav = navDisplayState(snapshot({ lateralDeviationM: NaN }));
+  // TO/FROM off is what removes the deviation bar; the deflection value is
+  // then inert and must stay FINITE, because a NaN CDI fails the whole nav
+  // group and would take the still-valid course and distance down with it.
+  assert.equal(nav.fromto, 0, "no lateral geometry removes the deviation bar");
+  assert.equal(nav.cdiDots, 0);
+  assert.equal(Number.isFinite(nav.cdiDots), true, "an inert CDI is still a finite value");
+  assert.equal(nav.courseRad, 1.25, "the course still displays");
+  assert.equal(nav.distNm, 2, "the distance still displays");
+}
+testUntrackedLateralCourseRemovesTheBarWithoutFailingTheGroup();
+console.log("ok - testUntrackedLateralCourseRemovesTheBarWithoutFailingTheGroup");
+
+function testUnconstrainedVerticalProfileHasNoSample() {
+  const nav = navDisplayState(snapshot({ verticalDeviationM: NaN }));
+  // NaN is the instrument model's coding for "no sample"; the vertical
+  // scale is not drawn at all, rather than drawn centered.
+  assert.equal(Number.isNaN(nav.vdevDots), true);
+  // The lateral guidance is untouched by the missing vertical constraint.
+  assert.equal(nav.fromto, 1);
+  assert.ok(nav.cdiDots === 0);
+}
+testUnconstrainedVerticalProfileHasNoSample();
+console.log("ok - testUnconstrainedVerticalProfileHasNoSample");
+
+function testUnusableSolutionRemovesTheGroupEntirely() {
+  // ADR-0031: unusable removes the display. Returning a centered needle, or
+  // guidance with a caution, would present a solution the client cannot
+  // vouch for as flyable.
+  assert.equal(navDisplayState(snapshot({ solutionQuality: 2 })), null);
+  // Degraded still flies: it is a usable solution, displayed normally.
+  assert.equal(navDisplayState(snapshot({ solutionQuality: 1 })).fromto, 1);
+  // A quality coding this build does not know fails closed like unusable.
+  assert.equal(navDisplayState(snapshot({ solutionQuality: 7 })), null);
+}
+testUnusableSolutionRemovesTheGroupEntirely();
+console.log("ok - testUnusableSolutionRemovesTheGroupEntirely");
+
+function testAbsentGuidanceIsAbsentNotCentered() {
+  assert.equal(navDisplayState(null), null, "no accepted sample yet");
+  assert.equal(navDisplayState({ navGuidance: null, ageMs: 10 }), null);
+  // An unmeasurable age cannot feed the ABI's freshness slot, and guidance
+  // with no freshness is not displayable.
+  assert.equal(navDisplayState(snapshot({}, NaN)), null);
+}
+testAbsentGuidanceIsAbsentNotCentered();
+console.log("ok - testAbsentGuidanceIsAbsentNotCentered");
+
+console.log("\nall nav display profile checks passed");

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -26,14 +26,17 @@ export const ROLE = Object.freeze({
   OPERATIONAL_ESTIMATE: 1,
   SIMULATION_TRUTH: 2,
   FC_STATE: 3,
+  NAVIGATION_SOLUTION: 6,
 });
 // Role-specific stamp rules: which clock domains a role may legitimately
 // stamp. Estimates carry source clocks; truth is simulation-clocked; FC
-// state is stamped at host receipt (its wire carries no source time).
+// state is stamped at host receipt (its wire carries no source time), as is
+// navigation guidance, which the host's navigation component computes.
 const ROLE_CLOCKS = Object.freeze({
   [ROLE.OPERATIONAL_ESTIMATE]: [CLOCK_VEHICLE_BOOT, CLOCK_SIMULATION],
   [ROLE.SIMULATION_TRUTH]: [CLOCK_SIMULATION],
   [ROLE.FC_STATE]: [CLOCK_HOST_MONOTONIC],
+  [ROLE.NAVIGATION_SOLUTION]: [CLOCK_HOST_MONOTONIC],
 });
 const KNOWN_INTEGRITY = Object.freeze([1, 2, 3]);
 const QUALITY_UNUSABLE = 2;
@@ -686,4 +689,137 @@ function sanitizeFcCommand(lastCommand) {
   const result = lastCommand.result;
   if (!Number.isInteger(result) || result < 0) return null;
   return { arm: lastCommand.arm, result };
+}
+
+// Navigation guidance freshness, fail closed (ADR-0031). A guidance sample
+// is accepted only when its COMPLETE stamp validates for the
+// navigation-solution role; the source identity (id + incarnation) is
+// pinned at first acceptance for the session; and the epoch/sequence pair
+// must strictly ADVANCE in wrapping serial order, so a duplicate or a
+// reordered sample never refreshes age and never regresses the displayed
+// leg. The sample's own values stay raw here — meters and radians — and
+// reach the instrument's dot scale only through the display profile.
+//
+// Age is reported rather than judged: the panel's freshness policy owns
+// when guidance stops showing, so there is no second staleness rule here
+// to diverge from it.
+export class NavGuidanceTracker {
+  constructor() {
+    this.last = null;
+    this.lastRejectReason = null;
+    this.counters = {
+      accepted: 0,
+      invalidStamps: 0,
+      wrongSource: 0,
+      duplicates: 0,
+      malformedGuidance: 0,
+    };
+  }
+
+  // Feeds one decoded navGuidance lane (or null) and returns the current
+  // snapshot. Only a NEW sample — pinned identity, epoch advanced, or same
+  // epoch with the sequence strictly newer in wrapping order — restarts the
+  // age clock.
+  observe(navGuidance, nowMs) {
+    if (!Number.isFinite(nowMs)) throw new TypeError("nowMs must be finite");
+    if (this.accepts(navGuidance)) {
+      const stamp = navGuidance.stamp;
+      this.last = {
+        navGuidance: freezeGuidance(navGuidance),
+        sourceId: stamp.sourceId,
+        sourceIncarnation: stamp.sourceIncarnation,
+        sourceEpoch: stamp.sourceEpoch,
+        sequence: stamp.sequence,
+        firstSeenMs: nowMs,
+      };
+      this.bump("accepted");
+    }
+    return this.snapshot(nowMs);
+  }
+
+  // Whether a sample is a valid, strictly-new observation from the pinned
+  // source. Every rejection is fail-closed: the previous snapshot (and its
+  // age) stands, so guidance goes stale rather than jumping to a leg that
+  // failed its provenance check.
+  accepts(navGuidance) {
+    if (!navGuidance) return false;
+    if (stampFaultForRole(navGuidance.stamp, ROLE.NAVIGATION_SOLUTION) !== null) {
+      return this.reject("invalidStamps");
+    }
+    if (!guidanceIsWellFormed(navGuidance)) return this.reject("malformedGuidance");
+    const last = this.last;
+    if (last === null) return true;
+    const stamp = navGuidance.stamp;
+    // Identity is pinned for the session: a different source id or
+    // incarnation is not this navigation component's guidance stream.
+    if (stamp.sourceId !== last.sourceId || stamp.sourceIncarnation !== last.sourceIncarnation) {
+      return this.reject("wrongSource");
+    }
+    if (stamp.sourceEpoch === last.sourceEpoch) {
+      return serialIsNewer(stamp.sequence, last.sequence) || this.reject("duplicates");
+    }
+    // A newer epoch (navigation restart) restarts the numbering; an older
+    // epoch is a replay.
+    return serialIsNewer(stamp.sourceEpoch, last.sourceEpoch) || this.reject("duplicates");
+  }
+
+  // The display view: null before any accepted sample. `ageMs` is measured
+  // against the receive clock from when the newest sample was accepted.
+  snapshot(nowMs) {
+    if (!Number.isFinite(nowMs)) throw new TypeError("nowMs must be finite");
+    if (this.last === null) return null;
+    return Object.freeze({
+      navGuidance: this.last.navGuidance,
+      ageMs: nowMs - this.last.firstSeenMs,
+    });
+  }
+
+  diagnostics() {
+    return Object.freeze({ ...this.counters, lastRejectReason: this.lastRejectReason });
+  }
+
+  reject(reason) {
+    this.lastRejectReason = reason;
+    this.bump(reason);
+    return false;
+  }
+
+  bump(name, amount = 1) {
+    this.counters[name] = increment(this.counters[name], amount);
+  }
+}
+
+// Guidance whose numbers are not numbers at all is unusable whole: a
+// non-finite course or distance has no display, and a leg index or quality
+// outside the schema's coding is a sample this build cannot interpret.
+// NaN deviations are the schema's "not tracking" encoding and stay legal.
+function guidanceIsWellFormed(guidance) {
+  const finite = [guidance.courseRad, guidance.distanceToWaypointM].every(Number.isFinite);
+  const counted = [guidance.legIndex, guidance.waypointCount, guidance.solutionQuality].every(
+    (value) => Number.isInteger(value) && value >= 0,
+  );
+  const deviationsNumeric = [guidance.lateralDeviationM, guidance.verticalDeviationM].every(
+    (value) => typeof value === "number",
+  );
+  return (
+    finite &&
+    counted &&
+    deviationsNumeric &&
+    typeof guidance.toIdent === "string" &&
+    typeof guidance.fromIdent === "string"
+  );
+}
+
+function freezeGuidance(guidance) {
+  return Object.freeze({
+    toIdent: guidance.toIdent,
+    fromIdent: guidance.fromIdent,
+    courseRad: guidance.courseRad,
+    lateralDeviationM: guidance.lateralDeviationM,
+    verticalDeviationM: guidance.verticalDeviationM,
+    distanceToWaypointM: guidance.distanceToWaypointM,
+    legIndex: guidance.legIndex,
+    waypointCount: guidance.waypointCount,
+    solutionQuality: guidance.solutionQuality,
+  });
 }

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -5,6 +5,7 @@ import {
   COHERENCE,
   FcStateTracker,
   INCARNATION_POLICY,
+  NavGuidanceTracker,
   serialIsNewer,
   stampFaultForRole,
 } from "./telemetry-ingress.js";
@@ -761,3 +762,150 @@ function testFcVerdictLaneIsCarriedAndSanitized() {
 }
 testFcVerdictLaneIsCarriedAndSanitized();
 console.log("ok - testFcVerdictLaneIsCarriedAndSanitized");
+
+function guidance(sequence, overrides = {}, stampOverrides = {}) {
+  return {
+    toIdent: "WP02",
+    fromIdent: "WP01",
+    courseRad: 1.25,
+    lateralDeviationM: -30,
+    verticalDeviationM: 12.5,
+    distanceToWaypointM: 3704,
+    legIndex: 2,
+    waypointCount: 5,
+    solutionQuality: 0,
+    ...overrides,
+    stamp: {
+      sourceId: 0x0a1en,
+      sourceIncarnation: INCARNATION_A,
+      sourceEpoch: 1,
+      sequence,
+      acquiredAtNanos: BigInt(sequence) * 1_000_000n,
+      clock: 3, // host-monotonic: the navigation-solution role's only clock
+      role: 6,
+      integrity: 1, // unprotected: a host-internal side input
+      ...stampOverrides,
+    },
+  };
+}
+
+function testNavGuidanceAgesFromTheNewestAcceptedSample() {
+  const tracker = new NavGuidanceTracker();
+  assert.equal(tracker.observe(null, 0), null, "no guidance before any sample");
+
+  let view = tracker.observe(guidance(1), 1000);
+  assert.equal(view.ageMs, 0);
+  assert.equal(view.navGuidance.toIdent, "WP02");
+  assert.equal(view.navGuidance.lateralDeviationM, -30, "meters reach the display profile raw");
+  assert.equal(view.navGuidance.stamp, undefined, "the snapshot carries values, not provenance");
+
+  // The SAME sample re-published keeps aging: duplicates never refresh.
+  view = tracker.observe(guidance(1), 4500);
+  assert.equal(view.ageMs, 3500, "duplicate must not reset the age clock");
+
+  // A NEW sample restarts freshness and replaces the leg.
+  view = tracker.observe(guidance(2, { toIdent: "WP03", legIndex: 3 }), 4600);
+  assert.equal(view.ageMs, 0);
+  assert.equal(view.navGuidance.toIdent, "WP03");
+
+  // Silence ages the last accepted sample; the panel's freshness policy,
+  // not this tracker, decides when that stops displaying.
+  assert.equal(tracker.observe(null, 9600).ageMs, 5000);
+  assert.equal(tracker.diagnostics().accepted, 2);
+  assert.equal(tracker.diagnostics().duplicates, 1);
+}
+testNavGuidanceAgesFromTheNewestAcceptedSample();
+console.log("ok - testNavGuidanceAgesFromTheNewestAcceptedSample");
+
+function testNavGuidanceRejectsReorderedAndOldSamples() {
+  const tracker = new NavGuidanceTracker();
+  tracker.observe(guidance(10, { toIdent: "WP10" }), 1000);
+
+  // A reordered OLDER sample must not present as fresh, and must not
+  // regress the displayed leg to one already flown.
+  let view = tracker.observe(guidance(9, { toIdent: "WP09" }), 4500);
+  assert.equal(view.navGuidance.toIdent, "WP10", "older sequence must not replace the leg");
+  assert.equal(view.ageMs, 3500, "older sequence must not refresh age");
+
+  // Wrapping serial order: u32 wrap is an advance, not a regression.
+  const wrapped = new NavGuidanceTracker();
+  wrapped.observe(guidance(0xffffffff), 0);
+  assert.equal(wrapped.observe(guidance(0), 10).ageMs, 0, "u32 sequence wrap is an advance");
+
+  // A newer epoch (navigation restart) restarts the numbering; an older
+  // epoch is a replay.
+  view = tracker.observe(guidance(1, { toIdent: "WP01" }, { sourceEpoch: 2 }), 4600);
+  assert.equal(view.navGuidance.toIdent, "WP01", "newer epoch restarts the numbering");
+  view = tracker.observe(guidance(50, { toIdent: "WP50" }, { sourceEpoch: 1 }), 4700);
+  assert.equal(view.navGuidance.toIdent, "WP01", "older epoch is a replay");
+}
+testNavGuidanceRejectsReorderedAndOldSamples();
+console.log("ok - testNavGuidanceRejectsReorderedAndOldSamples");
+
+function testNavGuidancePinsIdentityAndValidatesProvenance() {
+  const tracker = new NavGuidanceTracker();
+  tracker.observe(guidance(1, { toIdent: "WP01" }), 0);
+
+  // Pinned identity: another incarnation or id is not this stream.
+  let view = tracker.observe(
+    guidance(2, { toIdent: "OTHER" }, { sourceIncarnation: INCARNATION_B }),
+    10,
+  );
+  assert.equal(view.navGuidance.toIdent, "WP01", "foreign incarnation rejected");
+  view = tracker.observe(guidance(2, { toIdent: "OTHER" }, { sourceId: 7n }), 20);
+  assert.equal(view.navGuidance.toIdent, "WP01", "foreign source id rejected");
+  assert.equal(tracker.diagnostics().wrongSource, 2);
+
+  // Malformed provenance is rejected whole. The role gate is the load-
+  // bearing one: guidance is display context, never a stand-in for the
+  // estimate lane, so an estimate-role sample is not guidance.
+  for (const stampOverrides of [
+    { role: 1 },
+    { role: 3 },
+    { clock: 2 }, // simulation clock on a host-computed solution
+    { integrity: 0 }, // unspecified integrity
+    { sourceEpoch: -1 },
+    { acquiredAtNanos: 5 }, // not a BigInt u64
+    { sourceIncarnation: "abc" },
+  ]) {
+    view = tracker.observe(guidance(3, { toIdent: "BAD" }, stampOverrides), 30);
+    assert.equal(
+      view.navGuidance.toIdent,
+      "WP01",
+      `must reject ${JSON.stringify(stampOverrides)}`,
+    );
+  }
+  assert.equal(tracker.diagnostics().invalidStamps, 7);
+  assert.equal(tracker.diagnostics().lastRejectReason, "invalidStamps");
+}
+testNavGuidancePinsIdentityAndValidatesProvenance();
+console.log("ok - testNavGuidancePinsIdentityAndValidatesProvenance");
+
+function testNavGuidanceRejectsUninterpretableSamples() {
+  const tracker = new NavGuidanceTracker();
+  tracker.observe(guidance(1, { toIdent: "WP01" }), 0);
+
+  for (const overrides of [
+    { courseRad: NaN },
+    { distanceToWaypointM: Infinity },
+    { legIndex: -1 },
+    { waypointCount: 1.5 },
+    { toIdent: 42 },
+  ]) {
+    const view = tracker.observe(guidance(9, { toIdent: "BAD", ...overrides }), 10);
+    assert.equal(view.navGuidance.toIdent, "WP01", `must reject ${JSON.stringify(overrides)}`);
+  }
+  assert.equal(tracker.diagnostics().malformedGuidance, 5);
+
+  // NaN deviations are the schema's "not tracking" encoding, not a fault:
+  // they are accepted so the display profile can remove that deviation.
+  const view = tracker.observe(
+    guidance(9, { lateralDeviationM: NaN, verticalDeviationM: NaN }),
+    20,
+  );
+  assert.equal(Number.isNaN(view.navGuidance.lateralDeviationM), true);
+  assert.equal(Number.isNaN(view.navGuidance.verticalDeviationM), true);
+  assert.equal(view.ageMs, 0, "an untracked deviation is still a fresh sample");
+}
+testNavGuidanceRejectsUninterpretableSamples();
+console.log("ok - testNavGuidanceRejectsUninterpretableSamples");

--- a/clients/web/telemetry-ingress.test.mjs
+++ b/clients/web/telemetry-ingress.test.mjs
@@ -909,3 +909,28 @@ function testNavGuidanceRejectsUninterpretableSamples() {
 }
 testNavGuidanceRejectsUninterpretableSamples();
 console.log("ok - testNavGuidanceRejectsUninterpretableSamples");
+
+function testNavGuidanceReplacementTrackerAcceptsTheSuccessorSession() {
+  // The reconnect contract the cockpit's session reset relies on: a
+  // tracker pinned to a dead session's incarnation refuses the restarted
+  // host forever, so the session boundary REPLACES the tracker and the
+  // replacement accepts the successor identity as its own first pin.
+  const pinned = new NavGuidanceTracker();
+  pinned.observe(guidance(1, { toIdent: "WP01" }), 0);
+  const rejected = pinned.observe(
+    guidance(1, { toIdent: "WP09" }, { sourceIncarnation: INCARNATION_B }),
+    10,
+  );
+  assert.equal(rejected.navGuidance.toIdent, "WP01", "the dead pin persists");
+  assert.equal(pinned.diagnostics().wrongSource, 1);
+
+  const replacement = new NavGuidanceTracker();
+  const accepted = replacement.observe(
+    guidance(1, { toIdent: "WP09" }, { sourceIncarnation: INCARNATION_B }),
+    20,
+  );
+  assert.equal(accepted.navGuidance.toIdent, "WP09", "a fresh tracker pins the new session");
+  assert.equal(replacement.diagnostics().wrongSource, 0);
+}
+testNavGuidanceReplacementTrackerAcceptsTheSuccessorSession();
+console.log("ok - testNavGuidanceReplacementTrackerAcceptsTheSuccessorSession");

--- a/clients/web/wire-wasm.test.mjs
+++ b/clients/web/wire-wasm.test.mjs
@@ -205,6 +205,8 @@ function stampBytes(s) {
     ...varintField(4, s.acquiredAtNanos),
     ...varintField(5, s.clock),
     ...lenField(6, s.incarnation),
+    ...(s.role ? varintField(7, s.role) : []),
+    ...(s.integrity ? varintField(8, s.integrity) : []),
   ];
 }
 
@@ -245,6 +247,104 @@ const envelopeBytes = new Uint8Array([...varintField(1, 1), ...lenField(4, sampl
   check("telemetry: attitude stamp sourceId is BigInt", typeof wasm.message.avionics.attitudeStamp.sourceId === "bigint");
   check("telemetry: attitude stamp incarnation is 32 hex", /^[0-9a-f]{32}$/.test(wasm.message.avionics.attitudeStamp.sourceIncarnation));
   check("telemetry: kinematics absent (no stamp) is nullish", wasm.message.avionics.kinematics === null || wasm.message.avionics.kinematics === undefined);
+}
+
+// ---- stamped sub-message presence parity ------------------------------------
+// A group the host encodes and only ONE decoder surfaces is invisible in
+// whichever client uses the other, with no decode error to notice it by.
+// These checks pin, for every stamped group the sample carries, that the two
+// decoders agree on presence — when the group is well-formed, when its
+// provenance stamp is missing, and when its stamp wears another lane's role.
+
+const ROLE = { estimate: 1, simulationTruth: 2, fcState: 3, payloadDevice: 5, navigationSolution: 6 };
+const STAMPED_GROUPS = ["avionics", "simTruth", "fcState", "gimbal", "navGuidance"];
+
+function laneStamp(role, clock) {
+  return { ...stamp, role, clock, integrity: 2 };
+}
+function present(value) {
+  return value !== null && value !== undefined;
+}
+// Each stamped group, encoded with its stamp at the tag the schema gives it.
+// `role` null omits the stamp entirely.
+function groupBytes(role, clock, stampField, body) {
+  return [...body, ...(role === null ? [] : lenField(stampField, stampBytes(laneStamp(role, clock))))];
+}
+function sampleWithGroups({ truthRole, fcRole, gimbalRole, navRole }) {
+  return new Uint8Array([
+    ...varintField(1, 1),
+    ...lenField(4, [
+      ...lenField(1, varintField(1, 1)),
+      ...lenField(6, avionicsBytes),
+      ...lenField(7, groupBytes(truthRole, 2, 11, [...floatField(1, 1.0), ...floatField(5, 12.0)])),
+      ...lenField(8, groupBytes(fcRole, 3, 2, varintField(1, 2))),
+      ...lenField(9, groupBytes(gimbalRole, 1, 8, [...floatField(1, 1.0), ...varintField(9, 0b101)])),
+      ...lenField(10, groupBytes(navRole, 3, 1, [
+        ...lenField(2, [...new TextEncoder().encode("WP02")]),
+        ...lenField(3, [...new TextEncoder().encode("WP01")]),
+        ...floatField(4, 1.25),
+        ...floatField(5, -30.0),
+        ...floatField(6, 12.5),
+        ...floatField(7, 3704.0),
+        ...varintField(8, 2),
+        ...varintField(9, 5),
+        ...varintField(10, 1),
+      ])),
+    ]),
+  ]);
+}
+
+// Correctly stamped: every group must reach BOTH decoders, with equal values.
+{
+  const bytes = sampleWithGroups({
+    truthRole: ROLE.simulationTruth,
+    fcRole: ROLE.fcState,
+    gimbalRole: ROLE.payloadDevice,
+    navRole: ROLE.navigationSolution,
+  });
+  const wasm = decodeDatagramEnvelope(bytes).message;
+  const ref = decodeBareEnvelope(bytes).message;
+  for (const group of STAMPED_GROUPS) {
+    check(`presence parity: ${group} reaches both decoders`, present(wasm[group]) && present(ref[group]));
+    check(`presence parity: ${group} decodes identically`, deepEqual(wasm[group], ref[group]));
+  }
+  // Neither decoder may carry a top-level field the other lacks: a group
+  // added to one side only shows up here as a key-set difference.
+  const wasmKeys = Object.keys(wasm).sort().join(",");
+  const refKeys = Object.keys(ref).sort().join(",");
+  check(`presence parity: identical top-level field sets (${wasmKeys})`, wasmKeys === refKeys);
+  check("presence parity: navGuidance carries meters and radians, never dots",
+    wasm.navGuidance.lateralDeviationM === -30.0 && wasm.navGuidance.courseRad === 1.25
+    && wasm.navGuidance.distanceToWaypointM === 3704.0);
+  check("presence parity: navGuidance carries the leg and its solution quality",
+    wasm.navGuidance.toIdent === "WP02" && wasm.navGuidance.fromIdent === "WP01"
+    && wasm.navGuidance.legIndex === 2 && wasm.navGuidance.waypointCount === 5
+    && wasm.navGuidance.solutionQuality === 1);
+}
+
+// Unstamped: every role-gated group must be ABSENT in both, never defaulted.
+{
+  const bytes = sampleWithGroups({ truthRole: null, fcRole: null, gimbalRole: null, navRole: null });
+  const wasm = decodeDatagramEnvelope(bytes).message;
+  const ref = decodeBareEnvelope(bytes).message;
+  for (const group of ["simTruth", "fcState", "gimbal", "navGuidance"]) {
+    check(`presence parity: unstamped ${group} is absent in both`, !present(wasm[group]) && !present(ref[group]));
+  }
+}
+
+// Mislabeled: a stamp wearing another lane's role must fail the gate in both.
+{
+  const bytes = sampleWithGroups({
+    truthRole: ROLE.fcState,
+    fcRole: ROLE.simulationTruth,
+    gimbalRole: ROLE.navigationSolution,
+    navRole: ROLE.estimate,
+  });
+  const wasm = decodeDatagramEnvelope(bytes).message;
+  const ref = decodeBareEnvelope(bytes).message;
+  for (const group of ["simTruth", "fcState", "gimbal", "navGuidance"]) {
+    check(`presence parity: mislabeled ${group} is refused by both`, !present(wasm[group]) && !present(ref[group]));
+  }
 }
 
 // ---- H.264 chunk classification (shared pilotage_protocol::h264) ------------

--- a/clients/web/wire.js
+++ b/clients/web/wire.js
@@ -922,7 +922,7 @@ function decodeAdvertisedScopes(hostCapabilitiesBytes) {
 }
 
 // telemetry.proto TelemetrySample: vehicle=1, tick=2, observed_at=3, pose=4,
-// velocity=5, avionics=6, sim_truth=7, fc_state=8, gimbal=9
+// velocity=5, avionics=6, sim_truth=7, fc_state=8, gimbal=9, nav_guidance=10
 // Pose2d: x_m=1, y_m=2, heading_rad=3 (all float, wire type 5)
 function decodeTelemetrySample(bytes) {
   if (!bytes) return {};
@@ -944,6 +944,7 @@ function decodeTelemetrySample(bytes) {
     simTruth: decodeSimTruthState(firstBytes(fields, 7)),
     fcState: decodeFcState(firstBytes(fields, 8)),
     gimbal: decodeGimbalAttitude(firstBytes(fields, 9)),
+    navGuidance: decodeNavGuidance(firstBytes(fields, 10)),
   };
 }
 
@@ -1029,6 +1030,42 @@ function decodeGimbalAttitude(bytes) {
     failureFlags: firstVarint(f, 10) ?? 0,
     stamp,
   };
+}
+
+// telemetry.proto NavGuidanceState (ADR-0031): stamp=1, to_ident=2,
+// from_ident=3 (string), course_rad=4, lateral_deviation_m=5,
+// vertical_deviation_m=6, distance_to_waypoint_m=7 (float), leg_index=8,
+// waypoint_count=9, solution_quality=10 (varint). Active-leg geometry in raw
+// canonical units — meters and radians, never dots; scaling to an
+// instrument's dot scale is client display policy. Unconsumable (null)
+// without a navigation-solution stamp, so no other lane can stand in for the
+// navigation component's own solution.
+function decodeNavGuidance(bytes) {
+  if (!bytes) return null;
+  const f = parseFields(bytes);
+  const stamp = decodeMeasurementStamp(firstBytes(f, 1));
+  // Exact-role gate: guidance must carry the navigation-solution role.
+  if (stamp === null || stamp.role !== 6) return null;
+  return {
+    toIdent: decodeStringField(f, 2),
+    fromIdent: decodeStringField(f, 3),
+    courseRad: decodeFloat32(firstBytes(f, 4)),
+    // NaN survives the decode: guidance that tracks no lateral course, or a
+    // leg with no vertical constraint, must remove that deviation rather
+    // than present a centered needle.
+    lateralDeviationM: decodeFloat32(firstBytes(f, 5)),
+    verticalDeviationM: decodeFloat32(firstBytes(f, 6)),
+    distanceToWaypointM: decodeFloat32(firstBytes(f, 7)),
+    legIndex: firstVarint(f, 8) ?? 0,
+    waypointCount: firstVarint(f, 9) ?? 0,
+    solutionQuality: firstVarint(f, 10) ?? 0,
+    stamp,
+  };
+}
+
+function decodeStringField(fields, fieldNumber) {
+  const raw = firstBytes(fields, fieldNumber);
+  return raw ? new TextDecoder().decode(raw) : "";
 }
 
 function decodePose2d(bytes) {

--- a/clients/web/wire.test.mjs
+++ b/clients/web/wire.test.mjs
@@ -580,6 +580,63 @@ check(
     wrongMessage.gimbal === null);
 }
 
+// ---- ADR-0031 navigation-solution lane: nav_guidance (10) -------------------
+// Active-leg guidance travels under its own navigation-solution stamp in raw
+// canonical units. It is unconsumable (null) without that stamp or under any
+// other role: guidance is display context and never a substitute for the
+// estimate lane.
+{
+  function navGuidance(role, { lateral = -30.0, vertical = 12.5 } = {}) {
+    const out = [];
+    if (role !== null) {
+      bytesField(out, 1, measurementStamp(21, 2, 7, 7_000_000, 3, 0x44, role));
+    }
+    bytesField(out, 2, new TextEncoder().encode("WP02"));
+    bytesField(out, 3, new TextEncoder().encode("WP01"));
+    f32Field(out, 4, 1.25); // course_rad
+    f32Field(out, 5, lateral); // lateral_deviation_m
+    f32Field(out, 6, vertical); // vertical_deviation_m
+    f32Field(out, 7, 3704.0); // distance_to_waypoint_m
+    for (const [field, value] of [[8, 2], [9, 5], [10, 1]]) {
+      varint(out, (field << 3) | 0);
+      varint(out, value);
+    }
+    return out;
+  }
+  function decodeGuidanceOnly(guidanceBytes) {
+    const telemetry = [];
+    bytesField(telemetry, 1, uint64Message(1));
+    bytesField(telemetry, 10, guidanceBytes);
+    const envelope = [];
+    varint(envelope, (1 << 3) | 0);
+    varint(envelope, SCHEMA_VERSION);
+    bytesField(envelope, 4, telemetry);
+    return decodeBareEnvelope(new Uint8Array(envelope)).message;
+  }
+
+  const nav = decodeGuidanceOnly(navGuidance(6)).navGuidance;
+  check("guidance lane decodes leg identifiers", nav?.toIdent === "WP02" && nav?.fromIdent === "WP01");
+  check("guidance lane decodes course and deviations in canonical units",
+    nav?.courseRad === 1.25 && nav?.lateralDeviationM === -30.0
+    && nav?.verticalDeviationM === 12.5 && nav?.distanceToWaypointM === 3704.0);
+  check("guidance lane decodes leg position and solution quality",
+    nav?.legIndex === 2 && nav?.waypointCount === 5 && nav?.solutionQuality === 1);
+  check("guidance stamp carries the navigation-solution role",
+    nav?.stamp?.role === 6 && nav?.stamp?.clock === 3);
+
+  // Not tracking a lateral course, and a leg with no vertical constraint,
+  // both reach the display profile as NaN — zero would read as on-course.
+  const untracked = decodeGuidanceOnly(navGuidance(6, { lateral: NaN, vertical: NaN })).navGuidance;
+  check("guidance carries an untracked lateral course through as NaN",
+    Number.isNaN(untracked?.lateralDeviationM));
+  check("guidance carries an unconstrained vertical profile through as NaN",
+    Number.isNaN(untracked?.verticalDeviationM));
+
+  check("an unstamped nav_guidance decodes to null", decodeGuidanceOnly(navGuidance(null)).navGuidance === null);
+  check("a guidance lane with a non-navigation role decodes to null",
+    decodeGuidanceOnly(navGuidance(1)).navGuidance === null);
+}
+
 // --- a fully neutral frame reports EVERY axis on the wire ---------------
 // The host's full-coverage neutral checks (link-loss recovery, reset-latch
 // clearance) require every declared axis REPORTED; proto3 default-skipping

--- a/crates/pilotage-mission/Cargo.toml
+++ b/crates/pilotage-mission/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pilotage-mission"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+navigate-contract = { workspace = true }
+navigate-geodesy = { workspace = true }
+navigate-fusion = { workspace = true }
+navigate-fpl = { workspace = true }
+navigate-guidance = { workspace = true }
+aerocontext-core = { workspace = true }
+aerocontext-planning = { workspace = true }
+aerocontext-navdata = { workspace = true }
+chrono = { workspace = true }
+pilotage-protocol = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-mission/src/body_frame.rs
+++ b/crates/pilotage-mission/src/body_frame.rs
@@ -1,0 +1,95 @@
+//! Horizontal NED to body-FRD rotation and yaw geometry, pure `f64`.
+
+use core::f64::consts::PI;
+
+/// Rotates a horizontal NED velocity into body FRD at yaw `psi`
+/// (radians, zero north, positive east):
+/// `vx = vn·cosψ + ve·sinψ`, `vy = −vn·sinψ + ve·cosψ`.
+pub(crate) fn ned_to_body(vn: f64, ve: f64, psi: f64) -> (f64, f64) {
+    let (sin, cos) = psi.sin_cos();
+    (vn * cos + ve * sin, -vn * sin + ve * cos)
+}
+
+/// Bearing of a horizontal NED vector, radians in `(-π, π]`, zero
+/// north, positive toward east.
+pub(crate) fn bearing_rad(vn: f64, ve: f64) -> f64 {
+    ve.atan2(vn)
+}
+
+/// Wraps an angle to `(-π, π]` so a heading error never asks for the
+/// long way around.
+pub(crate) fn wrap_to_pi(angle: f64) -> f64 {
+    let wrapped = (-angle + PI).rem_euclid(2.0 * PI);
+    -(wrapped - PI)
+}
+
+/// Clamps to `[-limit, limit]`.
+pub(crate) fn clamp_symmetric(value: f64, limit: f64) -> f64 {
+    value.clamp(-limit, limit)
+}
+
+/// Caps a horizontal vector's magnitude by scaling, so the ceiling
+/// trades speed for nothing else — the direction survives.
+pub(crate) fn cap_horizontal(vn: f64, ve: f64, max: f64) -> (f64, f64) {
+    let speed = (vn * vn + ve * ve).sqrt();
+    if speed <= max || speed <= 0.0 {
+        (vn, ve)
+    } else {
+        let scale = max / speed;
+        (vn * scale, ve * scale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use core::f64::consts::{FRAC_PI_2, PI};
+
+    use super::{bearing_rad, cap_horizontal, ned_to_body, wrap_to_pi};
+
+    const EPS: f64 = 1e-12;
+
+    #[test]
+    fn rotation_signs_pinned_by_hand_computed_cases() {
+        // Facing north: body equals NED.
+        let (vx, vy) = ned_to_body(1.0, 0.5, 0.0);
+        assert!((vx - 1.0).abs() < EPS && (vy - 0.5).abs() < EPS);
+        // Facing east, moving north: pure leftward body motion.
+        let (vx, vy) = ned_to_body(1.0, 0.0, FRAC_PI_2);
+        assert!(vx.abs() < EPS && (vy + 1.0).abs() < EPS);
+        // Facing east, moving east: pure forward.
+        let (vx, vy) = ned_to_body(0.0, 1.0, FRAC_PI_2);
+        assert!((vx - 1.0).abs() < EPS && vy.abs() < EPS);
+        // Facing northeast, moving north: forward-left at 45 degrees.
+        let (vx, vy) = ned_to_body(1.0, 0.0, PI / 4.0);
+        let expected = FRAC_PI_2.sin() / 2.0_f64.sqrt();
+        assert!((vx - expected).abs() < 1e-9 && (vy + expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bearing_is_zero_north_positive_east() {
+        assert!(bearing_rad(1.0, 0.0).abs() < EPS);
+        assert!((bearing_rad(0.0, 1.0) - FRAC_PI_2).abs() < EPS);
+        assert!((bearing_rad(-1.0, 0.0) - PI).abs() < EPS);
+        assert!((bearing_rad(0.0, -1.0) + FRAC_PI_2).abs() < EPS);
+    }
+
+    #[test]
+    fn wrap_keeps_errors_on_the_short_way() {
+        assert!((wrap_to_pi(3.0 * PI / 2.0) + FRAC_PI_2).abs() < EPS);
+        assert!((wrap_to_pi(-3.0 * PI / 2.0) - FRAC_PI_2).abs() < EPS);
+        assert!((wrap_to_pi(PI) - PI).abs() < EPS);
+        assert!(wrap_to_pi(2.0 * PI).abs() < EPS);
+    }
+
+    #[test]
+    fn horizontal_cap_scales_without_rotating() {
+        let (vn, ve) = cap_horizontal(3.0, 4.0, 2.5);
+        let speed = (vn * vn + ve * ve).sqrt();
+        assert!((speed - 2.5).abs() < 1e-9);
+        assert!((vn / ve - 3.0 / 4.0).abs() < 1e-9);
+        let (vn, ve) = cap_horizontal(1.0, 1.0, 2.5);
+        assert!((vn - 1.0).abs() < EPS && (ve - 1.0).abs() < EPS);
+    }
+}

--- a/crates/pilotage-mission/src/config.rs
+++ b/crates/pilotage-mission/src/config.rs
@@ -1,0 +1,91 @@
+//! Mission configuration with documented defaults.
+
+use navigate_contract::{ClockDomainId, DurationNanos, GeodeticPosition};
+
+/// Ceilings every emitted intent is clamped within.
+///
+/// The defaults mirror the reference adapters' advertised
+/// `vehicle.motion` limits; the host MAY tighten them from the actually
+/// advertised capabilities before constructing the engine. The engine
+/// never emits beyond them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MissionLimits {
+    /// Ceiling on the commanded horizontal speed, m/s. Default 2.5.
+    /// An over-ceiling horizontal vector is scaled, never clipped per
+    /// axis, so the cap cannot rotate the commanded direction.
+    pub max_horizontal_mps: f64,
+    /// Ceiling on the magnitude of the commanded vertical rate, m/s.
+    /// Default 1.0.
+    pub max_vertical_mps: f64,
+    /// Ceiling on the magnitude of the commanded yaw rate, rad/s.
+    /// Default 0.8.
+    pub max_yaw_rate_rps: f64,
+}
+
+impl Default for MissionLimits {
+    fn default() -> Self {
+        Self {
+            max_horizontal_mps: 2.5,
+            max_vertical_mps: 1.0,
+            max_yaw_rate_rps: 0.8,
+        }
+    }
+}
+
+/// Configuration of a [`crate::MissionEngine`].
+///
+/// The engine is sans-IO: `clock` names the single clock domain every
+/// `now`, every sample stamp, and every fusion judgment lives on; the
+/// engine itself never reads a clock.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MissionConfig {
+    /// Route string expanded against the navdata snapshot at build.
+    pub route: String,
+    /// Mission anchor in radians/meters ([`GeodeticPosition`]). The host
+    /// converts from the snapshot's degrees exactly once, at plan build
+    /// (ADR-0030); nothing downstream ever sees degrees.
+    pub anchor: GeodeticPosition,
+    /// Cruise height above the anchor altitude, meters. Default 15.0.
+    /// `0.0` disables the climb phase: the mission goes straight from
+    /// arming to enroute guidance.
+    pub cruise_height_m: f64,
+    /// Commanded climb rate during the climb phase, m/s. Default 0.8.
+    pub climb_rate_mps: f64,
+    /// Along-track cruise speed asked of guidance, m/s. Default 2.0.
+    pub cruise_mps: f64,
+    /// Intent ceilings; see [`MissionLimits`] for the defaults.
+    pub limits: MissionLimits,
+    /// Yaw alignment gain, inverse seconds: radians of heading error to
+    /// rad/s of commanded yaw rate. Default 1.0.
+    pub yaw_gain_per_s: f64,
+    /// 1-sigma of the synthesized GNSS position fix per NED axis,
+    /// meters. Default 1.5.
+    pub gnss_sigma_m: f64,
+    /// Hint to the host for how often to call [`crate::MissionEngine::tick`]
+    /// and frame the result. Default 50 ms — well inside the session
+    /// holder-silence watchdog. The engine itself never schedules.
+    pub frame_interval: DurationNanos,
+    /// The clock domain all mission time lives on.
+    pub clock: ClockDomainId,
+}
+
+impl MissionConfig {
+    /// A config over the documented defaults; the route, anchor, and
+    /// clock domain have no meaningful default and are always the
+    /// caller's.
+    #[must_use]
+    pub fn new(route: String, anchor: GeodeticPosition, clock: ClockDomainId) -> Self {
+        Self {
+            route,
+            anchor,
+            cruise_height_m: 15.0,
+            climb_rate_mps: 0.8,
+            cruise_mps: 2.0,
+            limits: MissionLimits::default(),
+            yaw_gain_per_s: 1.0,
+            gnss_sigma_m: 1.5,
+            frame_interval: DurationNanos::from_millis(50),
+            clock,
+        }
+    }
+}

--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -1,0 +1,229 @@
+//! The sans-IO mission engine: snapshot + route in, typed intents and
+//! actions out. All time is caller-supplied; nothing here reads a clock
+//! or performs I/O.
+
+mod output;
+mod tick;
+
+use core::mem::Discriminant;
+
+use aerocontext_core::NavDataSnapshot;
+use aerocontext_planning::route::expand_str;
+use navigate_contract::{
+    AltitudeConstraint, FlightPlan, GeodeticPosition, MonotonicNanos, ObservationStamp, PlanRole,
+    SensorClass, SourceComposition, SourceEpoch, SourceId, SymmetricCov3, Waypoint,
+    WrappingSequence,
+};
+use navigate_fpl::{ExecutionConfig, PlanExecution};
+use navigate_fusion::{FusionConfig, NavigationFilter, Observation, ObservationValue};
+use navigate_geodesy::{LocalTangentPlane, NedOffset};
+use navigate_guidance::{GuidanceRefusal, VelocityGuidanceConfig};
+
+pub use output::{MissionAction, MissionCounters, MissionEvent, MissionOutput, MissionState};
+
+use crate::config::MissionConfig;
+use crate::error::MissionBuildError;
+use crate::ownship::{OwnshipSample, TruthRole};
+use crate::provenance::{MissionPlanRecord, SnapshotProvenance};
+
+/// The single synthesized-GNSS source identity the engine stamps its
+/// observations with.
+const OWNSHIP_SOURCE: SourceId = SourceId::new(1);
+
+/// A deterministic mission executor over the Navigate stack.
+///
+/// The host owns the boundary: it converts telemetry into
+/// [`OwnshipSample`]s, frames the emitted intents/actions onto the
+/// session wire, and supplies every `now` on the configured clock
+/// domain. The engine owns the judgment: admission, sequencing,
+/// guidance, and the phase machine.
+#[derive(Debug)]
+pub struct MissionEngine {
+    config: MissionConfig,
+    plane: LocalTangentPlane,
+    filter: NavigationFilter,
+    execution: PlanExecution,
+    guidance: VelocityGuidanceConfig,
+    state: MissionState,
+    counters: MissionCounters,
+    pending_events: Vec<MissionEvent>,
+    last_yaw_rad: f64,
+    next_action_id: u64,
+    outstanding_arm: Option<u64>,
+    arm_needs_send: bool,
+    last_refusal: Option<Discriminant<GuidanceRefusal>>,
+}
+
+impl MissionEngine {
+    /// Expands the route against the snapshot, builds the mission plan,
+    /// and returns the engine with its pack-for-flight record.
+    ///
+    /// Waypoint positions convert from the snapshot's degrees to
+    /// radians exactly once, here (ADR-0030). Every waypoint carries an
+    /// `At` constraint of anchor altitude plus the cruise height.
+    ///
+    /// # Errors
+    ///
+    /// Any [`MissionBuildError`]: expansion failure (with cycle
+    /// context), an empty expansion, an implausible anchor, or a plan
+    /// that fails structural validation.
+    pub fn new(
+        snapshot: &NavDataSnapshot,
+        provenance: SnapshotProvenance,
+        config: MissionConfig,
+    ) -> Result<(Self, MissionPlanRecord), MissionBuildError> {
+        let expanded = expand_str(&config.route, snapshot).map_err(|source| {
+            MissionBuildError::RouteExpansion {
+                route: config.route.clone(),
+                cycle: snapshot.cycle.effective_on,
+                source,
+            }
+        })?;
+        if expanded.points.is_empty() {
+            return Err(MissionBuildError::EmptyRoute {
+                route: config.route.clone(),
+            });
+        }
+        let waypoints = build_waypoints(&expanded.points, &config);
+        let expanded_idents: Vec<String> = waypoints.iter().map(|wp| wp.ident.clone()).collect();
+        let record = MissionPlanRecord {
+            provenance,
+            route_input: config.route.clone(),
+            waypoint_count: waypoints.len(),
+            expanded_idents,
+        };
+        let plan = FlightPlan::new(
+            format!("mission:{}", config.route),
+            PlanRole::Mission,
+            waypoints,
+        );
+        let execution = PlanExecution::new(plan, ExecutionConfig::default())?;
+        let plane = LocalTangentPlane::new(config.anchor)?;
+        let filter = NavigationFilter::new(FusionConfig::default(), config.clock);
+        let guidance = guidance_config(&config);
+        let engine = Self {
+            config,
+            plane,
+            filter,
+            execution,
+            guidance,
+            state: MissionState::AwaitSolution,
+            counters: MissionCounters::default(),
+            pending_events: Vec::new(),
+            last_yaw_rad: 0.0,
+            next_action_id: 0,
+            outstanding_arm: None,
+            arm_needs_send: false,
+            last_refusal: None,
+        };
+        Ok((engine, record))
+    }
+
+    /// Offers one ownship sample. Only [`TruthRole::SimulationTruth`]
+    /// samples become observations — see [`OwnshipSample`] for why any
+    /// other role is a counted refusal, never an aid. `now` is the
+    /// admission reference on the engine's clock domain.
+    pub fn on_ownship(&mut self, sample: &OwnshipSample, now: MonotonicNanos) {
+        if sample.role != TruthRole::SimulationTruth {
+            self.counters.rejected_role = self.counters.rejected_role.wrapping_add(1);
+            return;
+        }
+        self.last_yaw_rad = sample.yaw_rad;
+        let position =
+            self.plane
+                .from_ned(&NedOffset::new(sample.ned[0], sample.ned[1], sample.ned[2]));
+        let variance = self.config.gnss_sigma_m * self.config.gnss_sigma_m;
+        let stamp = ObservationStamp::new(
+            OWNSHIP_SOURCE,
+            // Epoch stays 0 until a reset/relaunch story exists; the
+            // filter treats a new epoch as a new source incarnation.
+            SourceEpoch::new(0),
+            WrappingSequence::new(sample.sequence),
+            sample.acquired_at,
+            self.config.clock,
+        );
+        let observation = Observation::new(
+            stamp,
+            ObservationValue::PositionFix {
+                position,
+                covariance: SymmetricCov3::from_diagonal(variance, variance, variance),
+            },
+            SourceComposition::of(SensorClass::Gnss),
+        );
+        if !self.filter.ingest(&observation, now).is_accepted() {
+            self.counters.fusion_rejected = self.counters.fusion_rejected.wrapping_add(1);
+        }
+    }
+
+    /// Reports the correlated result of a previously emitted action.
+    /// Acceptance advances the phase machine; rejection schedules a
+    /// re-send with a fresh id on the next tick. Results for unknown
+    /// ids, or outside the arming phase, are inert.
+    pub fn on_action_result(&mut self, action_id: u64, accepted: bool) {
+        if self.state != MissionState::Arming || self.outstanding_arm != Some(action_id) {
+            return;
+        }
+        self.outstanding_arm = None;
+        if accepted {
+            self.pending_events
+                .push(MissionEvent::ArmAccepted { action_id });
+            if self.config.cruise_height_m > 0.0 {
+                self.state = MissionState::Climb;
+                self.pending_events.push(MissionEvent::ClimbStarted);
+            } else {
+                self.state = MissionState::Enroute;
+                self.pending_events.push(MissionEvent::EnrouteStarted);
+            }
+        } else {
+            self.counters.arm_rejected = self.counters.arm_rejected.wrapping_add(1);
+            self.arm_needs_send = true;
+            self.pending_events
+                .push(MissionEvent::ArmRejected { action_id });
+        }
+    }
+
+    /// The named refusal/rejection counters.
+    #[must_use]
+    pub const fn counters(&self) -> &MissionCounters {
+        &self.counters
+    }
+
+    /// The current mission phase.
+    #[must_use]
+    pub const fn state(&self) -> MissionState {
+        self.state
+    }
+}
+
+/// Converts expanded route points into plan waypoints: degrees to
+/// radians once, cruise altitude as an `At` constraint everywhere.
+fn build_waypoints(
+    points: &[aerocontext_planning::route::RoutePoint],
+    config: &MissionConfig,
+) -> Vec<Waypoint> {
+    let cruise_alt_m = config.anchor.altitude_m + config.cruise_height_m;
+    points
+        .iter()
+        .enumerate()
+        .map(|(index, point)| {
+            let ident = point.ident.clone().unwrap_or_else(|| format!("RP{index}"));
+            let position = GeodeticPosition::new(
+                point.position.lat.to_radians(),
+                point.position.lon.to_radians(),
+                cruise_alt_m,
+            );
+            Waypoint::new(ident, position).with_altitude(AltitudeConstraint::At(cruise_alt_m))
+        })
+        .collect()
+}
+
+/// Guidance shaped by the mission config: cruise speed and ceilings are
+/// the mission's; the lateral/vertical gains and the arrival slowdown
+/// keep the upstream defaults.
+fn guidance_config(config: &MissionConfig) -> VelocityGuidanceConfig {
+    let mut guidance = VelocityGuidanceConfig::default();
+    guidance.cruise_mps = config.cruise_mps;
+    guidance.max_horizontal_mps = config.limits.max_horizontal_mps;
+    guidance.max_vertical_mps = config.limits.max_vertical_mps;
+    guidance
+}

--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -2,6 +2,7 @@
 //! actions out. All time is caller-supplied; nothing here reads a clock
 //! or performs I/O.
 
+mod nav_guidance;
 mod output;
 mod tick;
 
@@ -10,15 +11,16 @@ use core::mem::Discriminant;
 use aerocontext_core::NavDataSnapshot;
 use aerocontext_planning::route::expand_str;
 use navigate_contract::{
-    AltitudeConstraint, FlightPlan, GeodeticPosition, MonotonicNanos, ObservationStamp, PlanRole,
-    SensorClass, SourceComposition, SourceEpoch, SourceId, SymmetricCov3, Waypoint,
-    WrappingSequence,
+    AltitudeConstraint, FlightPlan, GeodeticPosition, MonotonicNanos, NavigationSolution,
+    ObservationStamp, PlanRole, SensorClass, SourceComposition, SourceEpoch, SourceId,
+    SymmetricCov3, Waypoint, WrappingSequence,
 };
 use navigate_fpl::{ExecutionConfig, PlanExecution};
 use navigate_fusion::{FusionConfig, NavigationFilter, Observation, ObservationValue};
 use navigate_geodesy::{LocalTangentPlane, NedOffset};
 use navigate_guidance::{GuidanceRefusal, VelocityGuidanceConfig};
 
+pub use nav_guidance::{NavGuidance, NavQuality};
 pub use output::{MissionAction, MissionCounters, MissionEvent, MissionOutput, MissionState};
 
 use crate::config::MissionConfig;
@@ -46,6 +48,10 @@ pub struct MissionEngine {
     guidance: VelocityGuidanceConfig,
     state: MissionState,
     counters: MissionCounters,
+    /// The solution the last tick published, backing the display-facing
+    /// guidance view. A tick whose filter published nothing clears it, so
+    /// [`MissionEngine::nav_guidance`] cannot serve stale geometry.
+    last_solution: Option<NavigationSolution>,
     pending_events: Vec<MissionEvent>,
     last_yaw_rad: f64,
     next_action_id: u64,
@@ -109,6 +115,7 @@ impl MissionEngine {
             guidance,
             state: MissionState::AwaitSolution,
             counters: MissionCounters::default(),
+            last_solution: None,
             pending_events: Vec::new(),
             last_yaw_rad: 0.0,
             next_action_id: 0,

--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -53,7 +53,10 @@ pub struct MissionEngine {
     /// [`MissionEngine::nav_guidance`] cannot serve stale geometry.
     last_solution: Option<NavigationSolution>,
     pending_events: Vec<MissionEvent>,
-    last_yaw_rad: f64,
+    /// The latest known heading. `None` until a sample carries an
+    /// attitude group: intents need the NED→body rotation, and guessing
+    /// zero would silently rotate every command to due north.
+    last_yaw_rad: Option<f64>,
     next_action_id: u64,
     outstanding_arm: Option<u64>,
     arm_needs_send: bool,
@@ -117,7 +120,7 @@ impl MissionEngine {
             counters: MissionCounters::default(),
             last_solution: None,
             pending_events: Vec::new(),
-            last_yaw_rad: 0.0,
+            last_yaw_rad: None,
             next_action_id: 0,
             outstanding_arm: None,
             arm_needs_send: false,
@@ -135,7 +138,9 @@ impl MissionEngine {
             self.counters.rejected_role = self.counters.rejected_role.wrapping_add(1);
             return;
         }
-        self.last_yaw_rad = sample.yaw_rad;
+        if let Some(yaw) = sample.yaw_rad {
+            self.last_yaw_rad = Some(yaw);
+        }
         let position =
             self.plane
                 .from_ned(&NedOffset::new(sample.ned[0], sample.ned[1], sample.ned[2]));

--- a/crates/pilotage-mission/src/engine/nav_guidance.rs
+++ b/crates/pilotage-mission/src/engine/nav_guidance.rs
@@ -1,0 +1,151 @@
+//! Display-facing navigation guidance: the plan-relative geometry the
+//! executor is flying, in canonical units.
+//!
+//! This is display context (ADR-0031, ADR-0024): never an input to
+//! control validation and never a stand-in for a missing estimate.
+//! Absence is meaningful — an executor flying nothing has no guidance,
+//! and consumers remove the deviation display rather than centering it.
+//! Scaling deviations to instrument dots is display policy and happens
+//! past this boundary (ADR-0017).
+
+use navigate_contract::{AltitudeConstraint, GeodeticPosition, SolutionQuality};
+use navigate_fpl::Leg;
+use navigate_geodesy::{cross_track_m, distance_m, initial_bearing_rad};
+
+use super::{MissionEngine, MissionState};
+
+#[cfg(test)]
+mod tests;
+
+/// Quality of the navigation solution the guidance geometry rests on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NavQuality {
+    /// Within the filter's accuracy bounds and admission health.
+    Good,
+    /// Usable with caution: bounds exceeded or sources degraded.
+    Degraded,
+    /// Not usable for any navigation decision; consumers remove the
+    /// guidance display rather than annotating it.
+    Unusable,
+}
+
+/// A solution quality this vocabulary cannot read is treated as
+/// [`NavQuality::Unusable`]: the upstream classification grows in the
+/// contract crate first, and an unreadable grade is not a good one.
+impl From<SolutionQuality> for NavQuality {
+    fn from(quality: SolutionQuality) -> Self {
+        match quality {
+            SolutionQuality::Good => Self::Good,
+            SolutionQuality::Degraded => Self::Degraded,
+            _ => Self::Unusable,
+        }
+    }
+}
+
+/// One guidance sample: the active leg's geometry relative to the
+/// current navigation solution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NavGuidance {
+    /// Identifier of the waypoint being flown toward.
+    pub to_ident: String,
+    /// Identifier of the leg's origin fix; `None` on a direct-to leg,
+    /// which is flown from the present position.
+    pub from_ident: Option<String>,
+    /// Desired track, radians clockwise from true north in `[0, 2π)`. On
+    /// a direct-to leg this is the live bearing to the waypoint.
+    pub course_rad: f64,
+    /// Cross-track deviation in meters, positive right of course.
+    /// `None` when no lateral course is being tracked: a direct-to leg —
+    /// the climb and the initial leg — anchors its track at ownship and
+    /// has no cross-track geometry, as does a leg whose endpoints sit too
+    /// close together to define a direction.
+    pub lateral_deviation_m: Option<f64>,
+    /// Deviation from the vertical profile in meters, positive above the
+    /// profile; `None` when the active waypoint carries no altitude
+    /// constraint.
+    pub vertical_deviation_m: Option<f64>,
+    /// Great-circle distance to the active waypoint, meters.
+    pub distance_to_waypoint_m: f64,
+    /// Index of the active leg's destination waypoint in fly order.
+    pub leg_index: u32,
+    /// Waypoints in the plan being flown.
+    pub waypoint_count: u32,
+    /// Quality of the solution this geometry rests on.
+    pub quality: NavQuality,
+}
+
+impl MissionEngine {
+    /// The guidance the executor is flying, or `None` when it is flying
+    /// nothing: before a first solution, while arming, and once the plan
+    /// is complete. The geometry comes from the solution and active leg
+    /// the latest [`MissionEngine::tick`] left behind, so this reads
+    /// state and never re-runs fusion or sequencing.
+    ///
+    /// A tick whose filter published nothing clears the solution, so
+    /// guidance disappears with it instead of aging silently on a
+    /// display.
+    #[must_use]
+    pub fn nav_guidance(&self) -> Option<NavGuidance> {
+        let solution = self.last_solution.as_ref()?;
+        match self.state {
+            MissionState::AwaitSolution | MissionState::Arming | MissionState::Complete => None,
+            MissionState::Climb | MissionState::Enroute => {
+                let leg = self.execution.active_leg()?;
+                Some(leg_guidance(
+                    &solution.position,
+                    &leg,
+                    self.execution.plan().waypoints.len(),
+                    solution.integrity.quality.into(),
+                ))
+            }
+        }
+    }
+}
+
+/// The plan-relative geometry of one active leg from `position`.
+///
+/// The track runs from the leg's origin fix to its destination; a
+/// direct-to leg has no origin fix, so its course is the live bearing to
+/// the waypoint and no cross-track deviation exists to report.
+fn leg_guidance(
+    position: &GeodeticPosition,
+    leg: &Leg<'_>,
+    waypoint_count: usize,
+    quality: NavQuality,
+) -> NavGuidance {
+    let to = leg.to;
+    let course_rad = leg.from.map_or_else(
+        || initial_bearing_rad(position, &to.position),
+        |from| initial_bearing_rad(&from.position, &to.position),
+    );
+    NavGuidance {
+        to_ident: to.ident.clone(),
+        from_ident: leg.from.map(|from| from.ident.clone()),
+        course_rad,
+        lateral_deviation_m: leg
+            .from
+            .and_then(|from| cross_track_m(position, &from.position, &to.position).ok()),
+        vertical_deviation_m: profile_deviation_m(position.altitude_m, to.altitude.as_ref()),
+        distance_to_waypoint_m: distance_m(position, &to.position),
+        leg_index: u32::try_from(leg.index).unwrap_or(u32::MAX),
+        waypoint_count: u32::try_from(waypoint_count).unwrap_or(u32::MAX),
+        quality,
+    }
+}
+
+/// Signed deviation from a waypoint's altitude constraint, positive above
+/// the profile — the sign convention guidance itself derives.
+///
+/// An `At` constraint reports the signed deviation both ways; the
+/// one-sided forms report only their violation direction and zero while
+/// satisfied. A waypoint with no constraint — or one wearing a constraint
+/// this vocabulary cannot read — has no profile to deviate from and
+/// reports nothing rather than an invented zero.
+fn profile_deviation_m(altitude_m: f64, constraint: Option<&AltitudeConstraint>) -> Option<f64> {
+    match constraint? {
+        AltitudeConstraint::At(target_m) => Some(altitude_m - target_m),
+        AltitudeConstraint::AtOrAbove(floor_m) => Some((altitude_m - floor_m).min(0.0)),
+        AltitudeConstraint::AtOrBelow(ceiling_m) => Some((altitude_m - ceiling_m).max(0.0)),
+        _ => None,
+    }
+}

--- a/crates/pilotage-mission/src/engine/nav_guidance/tests.rs
+++ b/crates/pilotage-mission/src/engine/nav_guidance/tests.rs
@@ -1,0 +1,151 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use navigate_contract::{AltitudeConstraint, GeodeticPosition, SolutionQuality, Waypoint};
+use navigate_fpl::Leg;
+
+use super::{NavQuality, leg_guidance, profile_deviation_m};
+
+/// One degree of arc on the mean-radius sphere, meters: the scale every
+/// hand-computed expectation below is derived from.
+const METERS_PER_DEGREE: f64 = 111_195.0;
+
+fn position(lat_deg: f64, lon_deg: f64, altitude_m: f64) -> GeodeticPosition {
+    GeodeticPosition::new(lat_deg.to_radians(), lon_deg.to_radians(), altitude_m)
+}
+
+/// The eastbound equatorial leg every deviation expectation is measured
+/// against: `EASTA` at 0°E, `EASTB` at 1°E, both crossing at 1000 m.
+fn eastbound_leg() -> (Waypoint, Waypoint) {
+    (
+        Waypoint::new("EASTA".to_owned(), position(0.0, 0.0, 1000.0)),
+        Waypoint::new("EASTB".to_owned(), position(0.0, 1.0, 1000.0))
+            .with_altitude(AltitudeConstraint::At(1000.0)),
+    )
+}
+
+#[test]
+fn eastbound_leg_pins_course_deviations_and_distance() {
+    let (from, to) = eastbound_leg();
+    let leg = Leg {
+        from: Some(&from),
+        to: &to,
+        index: 1,
+    };
+    // 0.01° south of the track at its midpoint, 50 m above the profile.
+    let ownship = position(-0.01, 0.5, 1050.0);
+
+    let guidance = leg_guidance(&ownship, &leg, 3, NavQuality::Good);
+
+    assert_eq!(guidance.to_ident, "EASTB");
+    assert_eq!(guidance.from_ident.as_deref(), Some("EASTA"));
+    assert_eq!(guidance.leg_index, 1);
+    assert_eq!(guidance.waypoint_count, 3);
+    assert_eq!(guidance.quality, NavQuality::Good);
+
+    // An equatorial eastbound great circle courses due east exactly.
+    let course_error = guidance.course_rad - std::f64::consts::FRAC_PI_2;
+    assert!(course_error.abs() < 1e-12, "course {}", guidance.course_rad);
+
+    // Right of an eastbound track is south, and 0.01° of arc is 1112 m.
+    let lateral = guidance
+        .lateral_deviation_m
+        .expect("a leg with an origin fix has cross-track geometry");
+    let expected_lateral = 0.01 * METERS_PER_DEGREE;
+    assert!(
+        (lateral - expected_lateral).abs() < 1.0,
+        "right of track must be positive {expected_lateral} m, got {lateral}"
+    );
+
+    // 0.5° of longitude ahead and 0.01° of latitude aside: the
+    // great-circle leg is hypot(0.5, 0.01)° long.
+    let expected_distance = 0.5_f64.hypot(0.01) * METERS_PER_DEGREE;
+    assert!(
+        (guidance.distance_to_waypoint_m - expected_distance).abs() < 5.0,
+        "distance {expected_distance} m, got {}",
+        guidance.distance_to_waypoint_m
+    );
+
+    assert_eq!(guidance.vertical_deviation_m, Some(50.0));
+}
+
+#[test]
+fn left_of_track_is_negative() {
+    let (from, to) = eastbound_leg();
+    let leg = Leg {
+        from: Some(&from),
+        to: &to,
+        index: 1,
+    };
+    let guidance = leg_guidance(&position(0.01, 0.5, 1000.0), &leg, 3, NavQuality::Degraded);
+
+    let lateral = guidance
+        .lateral_deviation_m
+        .expect("a leg with an origin fix has cross-track geometry");
+    assert!(
+        (lateral + 0.01 * METERS_PER_DEGREE).abs() < 1.0,
+        "left of track must be negative, got {lateral}"
+    );
+    assert_eq!(guidance.quality, NavQuality::Degraded);
+    assert_eq!(guidance.vertical_deviation_m, Some(0.0));
+}
+
+#[test]
+fn direct_to_courses_at_the_waypoint_and_reports_no_cross_track() {
+    let (_, to) = eastbound_leg();
+    let leg = Leg {
+        from: None,
+        to: &to,
+        index: 0,
+    };
+    // Due south-west of the waypoint: the live bearing to it is the
+    // course, and no track exists to deviate from.
+    let guidance = leg_guidance(&position(-0.01, 0.5, 1000.0), &leg, 3, NavQuality::Good);
+
+    assert_eq!(guidance.from_ident, None);
+    assert_eq!(guidance.lateral_deviation_m, None);
+    assert_eq!(guidance.leg_index, 0);
+    let bearing_deg = guidance.course_rad.to_degrees();
+    assert!(
+        (0.0..90.0).contains(&bearing_deg),
+        "a waypoint north-east of ownship bears between north and east, got {bearing_deg}"
+    );
+}
+
+#[test]
+fn an_unconstrained_waypoint_reports_no_vertical_deviation() {
+    let (from, _) = eastbound_leg();
+    let unconstrained = Waypoint::new("FREEE".to_owned(), position(0.0, 1.0, 1000.0));
+    let leg = Leg {
+        from: Some(&from),
+        to: &unconstrained,
+        index: 1,
+    };
+    let guidance = leg_guidance(&position(0.0, 0.5, 2000.0), &leg, 2, NavQuality::Good);
+    assert_eq!(guidance.vertical_deviation_m, None);
+}
+
+#[test]
+fn one_sided_constraints_report_only_their_violation_direction() {
+    let floor = AltitudeConstraint::AtOrAbove(1000.0);
+    assert_eq!(profile_deviation_m(1500.0, Some(&floor)), Some(0.0));
+    assert_eq!(profile_deviation_m(900.0, Some(&floor)), Some(-100.0));
+
+    let ceiling = AltitudeConstraint::AtOrBelow(1000.0);
+    assert_eq!(profile_deviation_m(500.0, Some(&ceiling)), Some(0.0));
+    assert_eq!(profile_deviation_m(1100.0, Some(&ceiling)), Some(100.0));
+
+    assert_eq!(profile_deviation_m(1100.0, None), None);
+}
+
+#[test]
+fn an_unreadable_solution_quality_is_unusable() {
+    assert_eq!(NavQuality::from(SolutionQuality::Good), NavQuality::Good);
+    assert_eq!(
+        NavQuality::from(SolutionQuality::Degraded),
+        NavQuality::Degraded
+    );
+    assert_eq!(
+        NavQuality::from(SolutionQuality::Unusable),
+        NavQuality::Unusable
+    );
+}

--- a/crates/pilotage-mission/src/engine/output.rs
+++ b/crates/pilotage-mission/src/engine/output.rs
@@ -99,4 +99,8 @@ pub struct MissionCounters {
     pub guidance_refused: u64,
     /// Arm actions the vehicle rejected.
     pub arm_rejected: u64,
+    /// Ticks that produced a guided velocity but no intent because no
+    /// sample has carried a heading yet (the NED→body rotation needs
+    /// one; zero would steer toward due north).
+    pub missing_yaw: u64,
 }

--- a/crates/pilotage-mission/src/engine/output.rs
+++ b/crates/pilotage-mission/src/engine/output.rs
@@ -1,0 +1,102 @@
+//! Typed outputs of one engine tick: intent, action, state, events,
+//! and the refusal counters.
+
+use navigate_guidance::GuidanceRefusal;
+use pilotage_protocol::{ControlAction, ControlIntent};
+
+/// The mission phase the engine is in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MissionState {
+    /// Waiting for the fusion filter to publish a first solution.
+    AwaitSolution,
+    /// Arm requested; waiting for the correlated action result.
+    Arming,
+    /// Climbing to the cruise height above the anchor.
+    Climb,
+    /// Flying the plan under velocity guidance.
+    Enroute,
+    /// The plan is complete; every tick commands zero velocity so the
+    /// adapter's brake-then-hold takes over.
+    Complete,
+}
+
+/// A discrete action the host must send as a `ControlActionCommand` on
+/// the reliable stream, with this engine-chosen correlation id.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MissionAction {
+    /// The typed action.
+    pub action: ControlAction,
+    /// Nonzero correlation id; the host reports the correlated result
+    /// back via [`crate::MissionEngine::on_action_result`].
+    pub action_id: u64,
+}
+
+/// One observable mission event surfaced by a tick.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum MissionEvent {
+    /// An arm action was emitted with this correlation id.
+    ArmRequested {
+        /// Correlation id of the emitted action.
+        action_id: u64,
+    },
+    /// The vehicle accepted the arm action.
+    ArmAccepted {
+        /// Correlation id of the accepted action.
+        action_id: u64,
+    },
+    /// The vehicle rejected the arm action; the next tick re-sends with
+    /// a fresh id.
+    ArmRejected {
+        /// Correlation id of the rejected action.
+        action_id: u64,
+    },
+    /// The climb phase began.
+    ClimbStarted,
+    /// Enroute guidance began.
+    EnrouteStarted,
+    /// A waypoint captured and the next leg is active.
+    LegAdvanced {
+        /// Index of the newly active `to` waypoint in fly order.
+        to_index: usize,
+    },
+    /// The final waypoint captured; emitted exactly once.
+    MissionComplete,
+    /// Guidance refused to issue a setpoint this tick; no intent was
+    /// emitted (the host's silence watchdog is the backstop). Repeats of
+    /// the same refusal kind are counted but not re-surfaced until the
+    /// kind changes or guidance succeeds again.
+    GuidanceRefused {
+        /// The typed refusal.
+        reason: GuidanceRefusal,
+    },
+}
+
+/// What one call to [`crate::MissionEngine::tick`] produced.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MissionOutput {
+    /// The typed intent to frame this tick, when the engine has one.
+    pub intent: Option<ControlIntent>,
+    /// A discrete action to send, when one is due.
+    pub action: Option<MissionAction>,
+    /// The phase after this tick.
+    pub state: MissionState,
+    /// Events surfaced by this tick, in occurrence order.
+    pub events: Vec<MissionEvent>,
+}
+
+/// Named refusal/rejection counters; every refusal increments exactly
+/// one. Counters wrap rather than saturate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MissionCounters {
+    /// Ownship samples refused for a non-truth source role.
+    pub rejected_role: u64,
+    /// Synthesized observations the fusion filter refused (its own
+    /// per-reason counters live on the filter).
+    pub fusion_rejected: u64,
+    /// Ticks on which guidance refused to issue a setpoint.
+    pub guidance_refused: u64,
+    /// Arm actions the vehicle rejected.
+    pub arm_rejected: u64,
+}

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -165,7 +165,14 @@ impl MissionEngine {
                     self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
                     return None;
                 };
-                Some(self.compose_intent(&velocity))
+                let Some(yaw) = self.last_yaw_rad else {
+                    // Without a known heading the NED command cannot be
+                    // rotated into the body frame honestly; a guessed
+                    // zero would steer every command toward due north.
+                    self.counters.missing_yaw = self.counters.missing_yaw.wrapping_add(1);
+                    return None;
+                };
+                Some(self.compose_intent(&velocity, yaw))
             }
             Err(refusal) => {
                 self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
@@ -184,7 +191,7 @@ impl MissionEngine {
     /// rate toward the course of the commanded horizontal velocity —
     /// chosen over the leg course so the nose also follows cross-track
     /// corrections and stays defined on direct-to legs.
-    fn compose_intent(&self, velocity: &NedVelocity) -> ControlIntent {
+    fn compose_intent(&self, velocity: &NedVelocity, yaw_rad: f64) -> ControlIntent {
         let limits = &self.config.limits;
         let (vn, ve) = cap_horizontal(
             velocity.north_mps,
@@ -192,14 +199,14 @@ impl MissionEngine {
             limits.max_horizontal_mps,
         );
         let vd = clamp_symmetric(velocity.down_mps, limits.max_vertical_mps);
-        let (vx, vy) = ned_to_body(vn, ve, self.last_yaw_rad);
+        let (vx, vy) = ned_to_body(vn, ve, yaw_rad);
         let horizontal_mps = (vn * vn + ve * ve).sqrt();
         let yaw_rate = if horizontal_mps < YAW_COURSE_FLOOR_MPS {
             0.0
         } else {
             let course = bearing_rad(vn, ve);
             clamp_symmetric(
-                self.config.yaw_gain_per_s * wrap_to_pi(course - self.last_yaw_rad),
+                self.config.yaw_gain_per_s * wrap_to_pi(course - yaw_rad),
                 limits.max_yaw_rate_rps,
             )
         };

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -1,0 +1,217 @@
+//! The tick: one caller-supplied `now` becomes at most one intent, at
+//! most one action, and the events the phase machine surfaced.
+
+use core::mem::discriminant;
+
+use navigate_contract::{
+    GeodeticPosition, GuidanceSetpoint, MonotonicNanos, NavigationSolution, NedVelocity, Waypoint,
+};
+use navigate_fpl::SequenceEvent;
+use navigate_guidance::guide_velocity;
+use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame, VelocityIntent};
+
+use crate::body_frame::{bearing_rad, cap_horizontal, clamp_symmetric, ned_to_body, wrap_to_pi};
+
+use super::{MissionAction, MissionEngine, MissionEvent, MissionOutput, MissionState};
+
+/// Altitude margin below the cruise target at which the climb phase
+/// hands over to enroute guidance, meters.
+const CLIMB_CAPTURE_MARGIN_M: f64 = 1.0;
+
+/// Commanded horizontal speed below which the course is numerically
+/// meaningless and the yaw rate is held at zero, m/s.
+const YAW_COURSE_FLOOR_MPS: f64 = 0.05;
+
+impl MissionEngine {
+    /// Advances the mission one step at `now` (engine clock domain).
+    ///
+    /// A tick that emits no intent is deliberate — a guidance refusal or
+    /// a not-yet-initialized filter — and the host's holder-silence
+    /// watchdog is the backstop for a stretch of them.
+    pub fn tick(&mut self, now: MonotonicNanos) -> MissionOutput {
+        let mut events = core::mem::take(&mut self.pending_events);
+        let mut intent = None;
+        let mut action = None;
+        match self.state {
+            MissionState::AwaitSolution => {
+                if self.filter.tick(now).is_some() {
+                    self.state = MissionState::Arming;
+                    action = Some(self.send_arm(&mut events));
+                }
+            }
+            MissionState::Arming => {
+                if self.arm_needs_send {
+                    action = Some(self.send_arm(&mut events));
+                }
+            }
+            MissionState::Climb => intent = self.climb_tick(now, &mut events),
+            MissionState::Enroute => intent = self.enroute_tick(now, &mut events),
+            MissionState::Complete => intent = Some(zero_velocity_intent()),
+        }
+        MissionOutput {
+            intent,
+            action,
+            state: self.state,
+            events,
+        }
+    }
+
+    /// Emits an arm action under a fresh nonzero wrapping id. The action
+    /// goes out once; only a rejected result schedules another send.
+    fn send_arm(&mut self, events: &mut Vec<MissionEvent>) -> MissionAction {
+        self.next_action_id = self.next_action_id.wrapping_add(1);
+        if self.next_action_id == 0 {
+            // The session wire reserves zero; skip it on wrap.
+            self.next_action_id = 1;
+        }
+        let action_id = self.next_action_id;
+        self.outstanding_arm = Some(action_id);
+        self.arm_needs_send = false;
+        events.push(MissionEvent::ArmRequested { action_id });
+        MissionAction {
+            action: ControlAction::Arm,
+            action_id,
+        }
+    }
+
+    /// Climb straight up until the solution altitude reaches the cruise
+    /// target (within [`CLIMB_CAPTURE_MARGIN_M`]), then hand over to
+    /// enroute guidance on the same tick so no tick goes intent-less at
+    /// the seam.
+    fn climb_tick(
+        &mut self,
+        now: MonotonicNanos,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<ControlIntent> {
+        let solution = self.filter.tick(now)?;
+        let target_m = self.config.anchor.altitude_m + self.config.cruise_height_m;
+        if solution.position.altitude_m >= target_m - CLIMB_CAPTURE_MARGIN_M {
+            self.state = MissionState::Enroute;
+            events.push(MissionEvent::EnrouteStarted);
+            return self.guide(&solution, now, events);
+        }
+        let up_mps = clamp_symmetric(
+            self.config.climb_rate_mps,
+            self.config.limits.max_vertical_mps,
+        );
+        Some(ControlIntent::Velocity(VelocityIntent {
+            frame: ReferenceFrame::BodyFrd,
+            vx: 0.0,
+            vy: 0.0,
+            vz: -up_mps as f32,
+            yaw_rate: 0.0,
+        }))
+    }
+
+    fn enroute_tick(
+        &mut self,
+        now: MonotonicNanos,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<ControlIntent> {
+        let solution = self.filter.tick(now)?;
+        self.guide(&solution, now, events)
+    }
+
+    /// Sequences the plan on the solution position, then derives one
+    /// velocity intent toward the active leg.
+    fn guide(
+        &mut self,
+        solution: &NavigationSolution,
+        now: MonotonicNanos,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<ControlIntent> {
+        match self.execution.advance(&solution.position) {
+            SequenceEvent::LegAdvanced { to_index } => {
+                events.push(MissionEvent::LegAdvanced { to_index });
+            }
+            SequenceEvent::PlanComplete => {
+                self.state = MissionState::Complete;
+                events.push(MissionEvent::MissionComplete);
+                return Some(zero_velocity_intent());
+            }
+            // Non-exhaustive upstream: any event that neither advances
+            // nor completes leaves the active leg unchanged.
+            _ => {}
+        }
+        // Owned copies release the borrow of the execution before the
+        // counters and refusal latch are touched below.
+        let (leg_from, leg_to): (Option<GeodeticPosition>, Waypoint) = {
+            let leg = self.execution.active_leg()?;
+            (leg.from.map(|wp| wp.position), leg.to.clone())
+        };
+        let guided = guide_velocity(
+            solution,
+            leg_from.as_ref(),
+            &leg_to,
+            now,
+            self.config.clock,
+            &self.guidance,
+        );
+        match guided {
+            Ok(command) => {
+                self.last_refusal = None;
+                let GuidanceSetpoint::Velocity { velocity } = command.setpoint else {
+                    // guide_velocity only issues velocity setpoints; a
+                    // foreign shape is refused rather than misread.
+                    self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
+                    return None;
+                };
+                Some(self.compose_intent(&velocity))
+            }
+            Err(refusal) => {
+                self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
+                let kind = discriminant(&refusal);
+                if self.last_refusal != Some(kind) {
+                    self.last_refusal = Some(kind);
+                    events.push(MissionEvent::GuidanceRefused { reason: refusal });
+                }
+                None
+            }
+        }
+    }
+
+    /// Clamps the commanded NED velocity to the mission limits, rotates
+    /// it into body FRD at the latest sample yaw, and commands a yaw
+    /// rate toward the course of the commanded horizontal velocity —
+    /// chosen over the leg course so the nose also follows cross-track
+    /// corrections and stays defined on direct-to legs.
+    fn compose_intent(&self, velocity: &NedVelocity) -> ControlIntent {
+        let limits = &self.config.limits;
+        let (vn, ve) = cap_horizontal(
+            velocity.north_mps,
+            velocity.east_mps,
+            limits.max_horizontal_mps,
+        );
+        let vd = clamp_symmetric(velocity.down_mps, limits.max_vertical_mps);
+        let (vx, vy) = ned_to_body(vn, ve, self.last_yaw_rad);
+        let horizontal_mps = (vn * vn + ve * ve).sqrt();
+        let yaw_rate = if horizontal_mps < YAW_COURSE_FLOOR_MPS {
+            0.0
+        } else {
+            let course = bearing_rad(vn, ve);
+            clamp_symmetric(
+                self.config.yaw_gain_per_s * wrap_to_pi(course - self.last_yaw_rad),
+                limits.max_yaw_rate_rps,
+            )
+        };
+        ControlIntent::Velocity(VelocityIntent {
+            frame: ReferenceFrame::BodyFrd,
+            vx: vx as f32,
+            vy: vy as f32,
+            vz: vd as f32,
+            yaw_rate: yaw_rate as f32,
+        })
+    }
+}
+
+/// The zero-velocity intent completion holds: the adapter's
+/// brake-then-hold takes over from an explicit stationary command.
+fn zero_velocity_intent() -> ControlIntent {
+    ControlIntent::Velocity(VelocityIntent {
+        frame: ReferenceFrame::BodyFrd,
+        vx: 0.0,
+        vy: 0.0,
+        vz: 0.0,
+        yaw_rate: 0.0,
+    })
+}

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -34,7 +34,7 @@ impl MissionEngine {
         let mut action = None;
         match self.state {
             MissionState::AwaitSolution => {
-                if self.filter.tick(now).is_some() {
+                if self.publish_solution(now).is_some() {
                     self.state = MissionState::Arming;
                     action = Some(self.send_arm(&mut events));
                 }
@@ -54,6 +54,15 @@ impl MissionEngine {
             state: self.state,
             events,
         }
+    }
+
+    /// Publishes the filter's solution for `now` and remembers it as the
+    /// basis of the display-facing guidance view. A tick that publishes
+    /// nothing forgets the previous solution: guidance that cannot be
+    /// recomputed must disappear rather than age on an instrument.
+    fn publish_solution(&mut self, now: MonotonicNanos) -> Option<NavigationSolution> {
+        self.last_solution = self.filter.tick(now);
+        self.last_solution
     }
 
     /// Emits an arm action under a fresh nonzero wrapping id. The action
@@ -83,7 +92,7 @@ impl MissionEngine {
         now: MonotonicNanos,
         events: &mut Vec<MissionEvent>,
     ) -> Option<ControlIntent> {
-        let solution = self.filter.tick(now)?;
+        let solution = self.publish_solution(now)?;
         let target_m = self.config.anchor.altitude_m + self.config.cruise_height_m;
         if solution.position.altitude_m >= target_m - CLIMB_CAPTURE_MARGIN_M {
             self.state = MissionState::Enroute;
@@ -108,7 +117,7 @@ impl MissionEngine {
         now: MonotonicNanos,
         events: &mut Vec<MissionEvent>,
     ) -> Option<ControlIntent> {
-        let solution = self.filter.tick(now)?;
+        let solution = self.publish_solution(now)?;
         self.guide(&solution, now, events)
     }
 

--- a/crates/pilotage-mission/src/error.rs
+++ b/crates/pilotage-mission/src/error.rs
@@ -1,0 +1,46 @@
+//! Typed failures building a mission from a snapshot and a route.
+
+use aerocontext_core::NavDataError;
+use aerocontext_navdata::blob::BlobError;
+use aerocontext_planning::route::RouteError;
+use chrono::NaiveDate;
+use navigate_contract::PlanValidationError;
+use navigate_geodesy::GeodesyError;
+
+/// Why a mission could not be built. Every variant carries the context
+/// an operator needs to act on the refusal.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MissionBuildError {
+    /// The navdata blob failed its container checks (magic, checksum,
+    /// version, truncation) or did not decode.
+    #[error("navdata blob rejected")]
+    Blob(#[from] BlobError),
+    /// A navdata cycle window could not be constructed.
+    #[error("navdata cycle rejected")]
+    Cycle(#[from] NavDataError),
+    /// The route string did not expand against the snapshot; the cycle
+    /// date tells the operator which data the expansion was judged on.
+    #[error("route {route:?} did not expand (snapshot cycle effective {cycle})")]
+    RouteExpansion {
+        /// The route string as given.
+        route: String,
+        /// Effective date of the snapshot the expansion ran against.
+        cycle: NaiveDate,
+        /// The expansion failure.
+        #[source]
+        source: RouteError,
+    },
+    /// The route expanded to no geometry (e.g. procedure-only tokens).
+    #[error("route {route:?} expanded to no points")]
+    EmptyRoute {
+        /// The route string as given.
+        route: String,
+    },
+    /// The mission anchor cannot anchor a local tangent plane.
+    #[error("mission anchor rejected by geodesy")]
+    Geodesy(#[from] GeodesyError),
+    /// The built flight plan failed structural validation.
+    #[error("mission plan invalid")]
+    PlanInvalid(#[from] PlanValidationError),
+}

--- a/crates/pilotage-mission/src/fixture.rs
+++ b/crates/pilotage-mission/src/fixture.rs
@@ -1,0 +1,111 @@
+//! Deterministic demo navdata: three waypoints and one airway laid out
+//! around a caller-chosen anchor, packed through the same blob container
+//! as published data.
+//!
+//! Geometry uses [`navigate_geodesy::LocalTangentPlane`] at the anchor —
+//! exact NED-to-geodetic, no small-angle shortcuts — so the offsets
+//! below are true meters at any plausible anchor.
+
+use aerocontext_core::{
+    Airway, AirwayLocation, AirwayPoint, GeoPoint, NavDataCycle, NavDataSnapshot, NavPoint,
+    NavPointKind,
+};
+use aerocontext_navdata::blob;
+use chrono::NaiveDate;
+use navigate_contract::GeodeticPosition;
+use navigate_geodesy::{LocalTangentPlane, NedOffset};
+
+use crate::error::MissionBuildError;
+
+/// An anchor in the degree convention navdata snapshots use. The demo
+/// snapshot is the one place degrees enter; plan build converts to
+/// radians once (ADR-0030).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeoPointDegrees {
+    /// Latitude in degrees, north positive.
+    pub lat_deg: f64,
+    /// Longitude in degrees, east positive.
+    pub lon_deg: f64,
+    /// Height above the WGS84 ellipsoid, meters.
+    pub alt_m: f64,
+}
+
+/// The demo airway designator. The route tokenizer only recognizes
+/// published family prefixes (V/J/T/Q and the letter families) plus
+/// digits, so the demo airway must wear a real family shape; `V901`
+/// exists only inside the fixture snapshot.
+pub const DEMO_AIRWAY: &str = "V901";
+
+/// The demo route: entry fix, airway traversal, exit fix — exercising
+/// airway expansion, which must emit `DEMOB` between the two.
+pub const DEMO_ROUTE: &str = "DEMOA V901 DEMOC";
+
+/// The demo cycle's fixed effective date: 2026-01-22, an FAA NASR
+/// effective date on the 28-day AIRAC grid.
+pub const DEMO_EFFECTIVE_DATE: NaiveDate = match NaiveDate::from_ymd_opt(2026, 1, 22) {
+    Some(date) => date,
+    None => NaiveDate::MIN,
+};
+
+/// NED offsets of the demo waypoints from the anchor, meters:
+/// `DEMOA` ~120 m northeast, `DEMOB` 250 m east, `DEMOC` ~180 m
+/// southeast.
+const DEMO_OFFSETS: [(&str, f64, f64); 3] = [
+    ("DEMOA", 85.0, 85.0),
+    ("DEMOB", 0.0, 250.0),
+    ("DEMOC", -127.0, 127.0),
+];
+
+/// Builds the demo snapshot: `DEMOA`/`DEMOB`/`DEMOC` around `anchor`
+/// plus the airway [`DEMO_AIRWAY`] joining them in order.
+///
+/// # Errors
+///
+/// [`MissionBuildError::Geodesy`] for an implausible anchor;
+/// [`MissionBuildError::Cycle`] cannot occur for the fixed demo date but
+/// is propagated rather than swallowed.
+pub fn demo_snapshot(anchor_deg: GeoPointDegrees) -> Result<NavDataSnapshot, MissionBuildError> {
+    let origin = GeodeticPosition::new(
+        anchor_deg.lat_deg.to_radians(),
+        anchor_deg.lon_deg.to_radians(),
+        anchor_deg.alt_m,
+    );
+    let plane = LocalTangentPlane::new(origin)?;
+    let points = DEMO_OFFSETS
+        .iter()
+        .map(|&(ident, north_m, east_m)| {
+            let position = plane.from_ned(&NedOffset::new(north_m, east_m, 0.0));
+            NavPoint::new(
+                ident,
+                NavPointKind::Waypoint,
+                GeoPoint {
+                    lat: position.latitude_rad.to_degrees(),
+                    lon: position.longitude_rad.to_degrees(),
+                },
+            )
+        })
+        .collect();
+    let airway = Airway::new(
+        DEMO_AIRWAY,
+        AirwayLocation::Conus,
+        DEMO_OFFSETS
+            .iter()
+            .map(|&(ident, _, _)| AirwayPoint::new(ident))
+            .collect(),
+    );
+    let cycle = NavDataCycle::faa_nasr(DEMO_EFFECTIVE_DATE)?;
+    Ok(NavDataSnapshot::new(cycle, points).with_airways(vec![airway]))
+}
+
+/// [`demo_snapshot`] packed through the versioned blob container, so the
+/// demo path exercises exactly the decode-and-verify road published data
+/// travels.
+///
+/// # Errors
+///
+/// [`demo_snapshot`]'s errors, plus [`MissionBuildError::Blob`] should
+/// the container refuse to encode.
+pub fn demo_blob(anchor_deg: GeoPointDegrees) -> Result<Vec<u8>, MissionBuildError> {
+    let snapshot = demo_snapshot(anchor_deg)?;
+    Ok(blob::encode(&snapshot)?)
+}

--- a/crates/pilotage-mission/src/lib.rs
+++ b/crates/pilotage-mission/src/lib.rs
@@ -1,0 +1,29 @@
+//! Sans-IO mission engine: a packed navdata snapshot plus a route
+//! string becomes a validated flight plan, and truth-role ownship
+//! samples become typed velocity intents and discrete actions toward
+//! the Pilotage control boundary.
+//!
+//! Nothing here reads a clock or performs I/O. `now` is always a
+//! caller-supplied [`navigate_contract::MonotonicNanos`] on the single
+//! clock domain fixed in [`MissionConfig`]; telemetry arrives as
+//! host-converted [`OwnshipSample`]s; outputs are
+//! [`pilotage_protocol::ControlIntent`] and
+//! [`pilotage_protocol::ControlAction`] values. Framing, sessions,
+//! leases, and authority stay with the host task.
+
+pub mod config;
+pub mod engine;
+pub mod error;
+pub mod fixture;
+pub mod ownship;
+pub mod provenance;
+
+mod body_frame;
+
+pub use config::{MissionConfig, MissionLimits};
+pub use engine::{
+    MissionAction, MissionCounters, MissionEngine, MissionEvent, MissionOutput, MissionState,
+};
+pub use error::MissionBuildError;
+pub use ownship::{OwnshipSample, TruthRole};
+pub use provenance::{MissionPlanRecord, SnapshotProvenance, decode_snapshot};

--- a/crates/pilotage-mission/src/lib.rs
+++ b/crates/pilotage-mission/src/lib.rs
@@ -23,6 +23,7 @@ mod body_frame;
 pub use config::{MissionConfig, MissionLimits};
 pub use engine::{
     MissionAction, MissionCounters, MissionEngine, MissionEvent, MissionOutput, MissionState,
+    NavGuidance, NavQuality,
 };
 pub use error::MissionBuildError;
 pub use ownship::{OwnshipSample, TruthRole};

--- a/crates/pilotage-mission/src/ownship.rs
+++ b/crates/pilotage-mission/src/ownship.rs
@@ -1,0 +1,44 @@
+//! Ownship samples as the host converts them, and the source-role
+//! honesty gate the engine holds them to.
+
+use navigate_contract::MonotonicNanos;
+
+/// The LINK-04 source-role vocabulary as the mission engine consumes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TruthRole {
+    /// Ground truth exported by a simulator.
+    SimulationTruth,
+    /// State exported by the flight controller's own estimator.
+    FcState,
+    /// The host's operational estimate.
+    OperationalEstimate,
+}
+
+/// One ownship kinematic sample, converted by the host task from
+/// vehicle telemetry.
+///
+/// **Only [`TruthRole::SimulationTruth`] samples become observations.**
+/// The engine synthesizes a GNSS-class position fix from truth — a
+/// simulation-only stand-in for a real receiver. FC-state and
+/// operational-estimate samples are estimator-derived: feeding them back
+/// as aids would double-count information the estimator already holds
+/// (the ADR-0024 correlation rule), so the engine refuses them with a
+/// counted rejection and never launders them into a fix. A physical
+/// vehicle needs a genuine independent position source before this
+/// engine can guide it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OwnshipSample {
+    /// Position as NED meters from the mission anchor.
+    pub ned: [f64; 3],
+    /// Velocity in NED, m/s. The synthesized observation is
+    /// position-only; velocity aiding is a designed extension.
+    pub ned_velocity: [f64; 3],
+    /// Heading, radians, zero north, positive toward east.
+    pub yaw_rad: f64,
+    /// Which estimator family produced this sample.
+    pub role: TruthRole,
+    /// Monotonic acquisition time on the engine's clock domain.
+    pub acquired_at: MonotonicNanos,
+    /// Per-source sample sequence, wrap-aware.
+    pub sequence: u32,
+}

--- a/crates/pilotage-mission/src/ownship.rs
+++ b/crates/pilotage-mission/src/ownship.rs
@@ -33,8 +33,12 @@ pub struct OwnshipSample {
     /// Velocity in NED, m/s. The synthesized observation is
     /// position-only; velocity aiding is a designed extension.
     pub ned_velocity: [f64; 3],
-    /// Heading, radians, zero north, positive toward east.
-    pub yaw_rad: f64,
+    /// Heading, radians, zero north, positive toward east. Absent when
+    /// the source carried no attitude group: the engine can still feed
+    /// fusion from position, but it cannot rotate NED into the body
+    /// frame honestly, so a tick without a known heading emits no
+    /// intent (zero would silently rotate commands to due north).
+    pub yaw_rad: Option<f64>,
     /// Which estimator family produced this sample.
     pub role: TruthRole,
     /// Monotonic acquisition time on the engine's clock domain.

--- a/crates/pilotage-mission/src/provenance.rs
+++ b/crates/pilotage-mission/src/provenance.rs
@@ -1,0 +1,68 @@
+//! Snapshot provenance (ADR-0030): which authority and cycle a flight is
+//! packed against, bound to the blob's verified content hash.
+
+use aerocontext_core::NavDataSnapshot;
+use aerocontext_navdata::blob;
+use chrono::NaiveDate;
+
+use crate::error::MissionBuildError;
+
+/// The provenance record of one decoded navdata snapshot.
+///
+/// `sha256_hex` is the blob container's verified payload checksum — a
+/// content fingerprint, not a re-hash — so two hosts holding the same
+/// record hold byte-identical navdata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotProvenance {
+    /// Publishing authority slug, e.g. `"faa-nasr"`.
+    pub authority: String,
+    /// First date the snapshot's cycle is effective.
+    pub effective_on: NaiveDate,
+    /// First date a successor cycle is effective.
+    pub next_effective_on: NaiveDate,
+    /// Verified SHA-256 of the blob payload, lowercase hex.
+    pub sha256_hex: String,
+    /// Whether the snapshot is a generated fixture rather than published
+    /// data; a fixture-built plan must never be mistaken for one packed
+    /// from an authority's cycle.
+    pub fixture: bool,
+}
+
+/// Decodes a navdata blob and derives its provenance record. Pure: the
+/// bytes are the caller's, and `fixture` is the caller's honest claim
+/// about where they came from.
+///
+/// # Errors
+///
+/// [`MissionBuildError::Blob`] when the container checks or the payload
+/// decode fail.
+pub fn decode_snapshot(
+    bytes: &[u8],
+    fixture: bool,
+) -> Result<(NavDataSnapshot, SnapshotProvenance), MissionBuildError> {
+    let info = blob::inspect(bytes)?;
+    let provenance = SnapshotProvenance {
+        authority: info.snapshot.cycle.authority.slug().to_owned(),
+        effective_on: info.snapshot.cycle.effective_on,
+        next_effective_on: info.snapshot.cycle.next_effective_on,
+        sha256_hex: info.sha256_hex(),
+        fixture,
+    };
+    Ok((info.snapshot, provenance))
+}
+
+/// The pack-for-flight record (ADR-0030) returned when a mission is
+/// built: what data the plan came from and what the route expanded to,
+/// for evidence and operator display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissionPlanRecord {
+    /// Provenance of the snapshot the plan was expanded against.
+    pub provenance: SnapshotProvenance,
+    /// The route string as given to the engine.
+    pub route_input: String,
+    /// Waypoint identifiers in fly order, exactly as planned (anonymous
+    /// lat/lon points carry their generated identifiers).
+    pub expanded_idents: Vec<String>,
+    /// Number of waypoints in the built plan.
+    pub waypoint_count: usize,
+}

--- a/crates/pilotage-mission/tests/fixture_roundtrip.rs
+++ b/crates/pilotage-mission/tests/fixture_roundtrip.rs
@@ -1,0 +1,59 @@
+//! Fixture blob round-trip and airway expansion through the public API.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use aerocontext_planning::route::expand_str;
+use chrono::NaiveDate;
+use pilotage_mission::decode_snapshot;
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+
+const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+
+#[test]
+fn demo_blob_round_trips_with_faithful_provenance() {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (decoded, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let original = fixture::demo_snapshot(ANCHOR).expect("demo snapshot builds");
+    assert_eq!(decoded, original, "container round-trip is lossless");
+    assert!(provenance.fixture);
+    assert_eq!(provenance.authority, "faa-nasr");
+    assert_eq!(provenance.effective_on, fixture::DEMO_EFFECTIVE_DATE);
+    assert_eq!(
+        provenance.next_effective_on,
+        NaiveDate::from_ymd_opt(2026, 2, 19).expect("valid date"),
+        "28-day cycle window"
+    );
+    assert_eq!(provenance.sha256_hex.len(), 64);
+    assert!(provenance.sha256_hex.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn demo_route_expands_through_the_airway_in_order() {
+    let snapshot = fixture::demo_snapshot(ANCHOR).expect("demo snapshot builds");
+    let expanded = expand_str(fixture::DEMO_ROUTE, &snapshot).expect("route expands");
+    let idents: Vec<Option<&str>> = expanded
+        .points
+        .iter()
+        .map(|point| point.ident.as_deref())
+        .collect();
+    assert_eq!(
+        idents,
+        vec![Some("DEMOA"), Some("DEMOB"), Some("DEMOC")],
+        "airway traversal emits the intermediate fix"
+    );
+    let via: Vec<Option<&str>> = expanded
+        .points
+        .iter()
+        .map(|point| point.via_airway.as_deref())
+        .collect();
+    assert_eq!(
+        via,
+        vec![None, Some(fixture::DEMO_AIRWAY), Some(fixture::DEMO_AIRWAY)],
+        "DEMOB and DEMOC come from the airway, DEMOA from its own token"
+    );
+    assert!(expanded.procedures.is_empty());
+}

--- a/crates/pilotage-mission/tests/mission_engine.rs
+++ b/crates/pilotage-mission/tests/mission_engine.rs
@@ -1,0 +1,319 @@
+//! Deterministic closed-loop mission tests: a kinematic truth model
+//! integrates the engine's own commanded intents at 20 Hz, so the loop
+//! contains no clock reads, no sleeps, and no randomness.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
+use navigate_guidance::GuidanceRefusal;
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+use pilotage_mission::{
+    MissionConfig, MissionEngine, MissionEvent, MissionState, OwnshipSample, TruthRole,
+    decode_snapshot,
+};
+use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame};
+
+const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+const STEP_NANOS: u64 = 50_000_000;
+const STEP_S: f64 = 0.05;
+const LIMIT_EPS: f64 = 1e-3;
+
+/// Planar truth: NED position and yaw integrated from the engine's own
+/// BodyFrd commands (the inverse of the engine's NED-to-body rotation).
+struct Truth {
+    ned: [f64; 3],
+    ned_velocity: [f64; 3],
+    yaw: f64,
+    sequence: u32,
+}
+
+impl Truth {
+    fn new() -> Self {
+        Self {
+            ned: [0.0; 3],
+            ned_velocity: [0.0; 3],
+            yaw: 0.0,
+            sequence: 0,
+        }
+    }
+
+    fn sample(&self, now: MonotonicNanos) -> OwnshipSample {
+        OwnshipSample {
+            ned: self.ned,
+            ned_velocity: self.ned_velocity,
+            yaw_rad: self.yaw,
+            role: TruthRole::SimulationTruth,
+            acquired_at: now,
+            sequence: self.sequence,
+        }
+    }
+
+    fn integrate(&mut self, intent: &ControlIntent) {
+        let ControlIntent::Velocity(v) = intent else {
+            panic!("mission emits only velocity intents, got {intent:?}");
+        };
+        assert_eq!(v.frame, ReferenceFrame::BodyFrd);
+        let (vx, vy, vz) = (f64::from(v.vx), f64::from(v.vy), f64::from(v.vz));
+        let (sin, cos) = self.yaw.sin_cos();
+        self.ned_velocity = [vx * cos - vy * sin, vx * sin + vy * cos, vz];
+        for axis in 0..3 {
+            self.ned[axis] += self.ned_velocity[axis] * STEP_S;
+        }
+        self.yaw += f64::from(v.yaw_rate) * STEP_S;
+    }
+}
+
+fn assert_within_limits(intent: &ControlIntent) {
+    let ControlIntent::Velocity(v) = intent else {
+        panic!("mission emits only velocity intents, got {intent:?}");
+    };
+    let horizontal = f64::from(v.vx).hypot(f64::from(v.vy));
+    assert!(horizontal <= 2.5 + LIMIT_EPS, "horizontal {horizontal}");
+    assert!(
+        f64::from(v.vz).abs() <= 1.0 + LIMIT_EPS,
+        "vertical {}",
+        v.vz
+    );
+    assert!(
+        f64::from(v.yaw_rate).abs() <= 0.8 + LIMIT_EPS,
+        "yaw rate {}",
+        v.yaw_rate
+    );
+}
+
+fn build_engine() -> (MissionEngine, pilotage_mission::MissionPlanRecord) {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let anchor = GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    );
+    let config = MissionConfig::new(
+        fixture::DEMO_ROUTE.to_owned(),
+        anchor,
+        ClockDomainId::new(7),
+    );
+    MissionEngine::new(&snapshot, provenance, config).expect("mission builds")
+}
+
+/// One closed-loop step: sample, tick, accept any arm, integrate any
+/// intent, collect events.
+fn step(
+    engine: &mut MissionEngine,
+    truth: &mut Truth,
+    now: &mut MonotonicNanos,
+    arm_requests: &mut u32,
+    events: &mut Vec<MissionEvent>,
+) {
+    *now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+    truth.sequence = truth.sequence.wrapping_add(1);
+    engine.on_ownship(&truth.sample(*now), *now);
+    let out = engine.tick(*now);
+    if let Some(action) = out.action {
+        assert!(matches!(action.action, ControlAction::Arm));
+        *arm_requests += 1;
+        engine.on_action_result(action.action_id, true);
+    }
+    if let Some(intent) = out.intent {
+        assert_within_limits(&intent);
+        truth.integrate(&intent);
+    }
+    events.extend(out.events);
+}
+
+fn count<F: Fn(&MissionEvent) -> bool>(events: &[MissionEvent], predicate: F) -> usize {
+    events.iter().filter(|event| predicate(event)).count()
+}
+
+/// The full flight surfaces each lifecycle event exactly once, in a
+/// refusal-free run.
+fn assert_flight_events(events: &[MissionEvent]) {
+    assert_eq!(
+        count(events, |e| matches!(e, MissionEvent::ArmRequested { .. })),
+        1
+    );
+    assert_eq!(
+        count(events, |e| matches!(e, MissionEvent::ArmAccepted { .. })),
+        1
+    );
+    assert_eq!(
+        count(events, |e| matches!(e, MissionEvent::ClimbStarted)),
+        1
+    );
+    assert_eq!(
+        count(events, |e| matches!(e, MissionEvent::EnrouteStarted)),
+        1
+    );
+    for to_index in [1usize, 2] {
+        assert_eq!(
+            count(events, |e| matches!(
+                e,
+                MissionEvent::LegAdvanced { to_index: t } if *t == to_index
+            )),
+            1,
+            "leg advance to {to_index}"
+        );
+    }
+    assert_eq!(
+        count(events, |e| matches!(e, MissionEvent::MissionComplete)),
+        1
+    );
+    assert_eq!(
+        count(events, |e| matches!(
+            e,
+            MissionEvent::GuidanceRefused { .. }
+        )),
+        0
+    );
+}
+
+#[test]
+fn mission_arms_once_climbs_flies_the_route_and_completes() {
+    let (mut engine, record) = build_engine();
+    assert_eq!(record.expanded_idents, vec!["DEMOA", "DEMOB", "DEMOC"]);
+    assert_eq!(record.waypoint_count, 3);
+    assert!(record.provenance.fixture);
+
+    let mut truth = Truth::new();
+    let mut now = MonotonicNanos::from_nanos(1_000_000_000);
+    let mut arm_requests = 0;
+    let mut events = Vec::new();
+    let mut completed = false;
+    for _ in 0..20_000 {
+        step(
+            &mut engine,
+            &mut truth,
+            &mut now,
+            &mut arm_requests,
+            &mut events,
+        );
+        if engine.state() == MissionState::Complete {
+            completed = true;
+            break;
+        }
+    }
+    assert!(completed, "mission completes within the step budget");
+    assert_eq!(
+        arm_requests, 1,
+        "arm goes out once, never re-sent after acceptance"
+    );
+    assert_flight_events(&events);
+    assert_eq!(engine.counters().guidance_refused, 0);
+    assert_eq!(engine.counters().fusion_rejected, 0);
+
+    let height_m = -truth.ned[2];
+    assert!(height_m > 10.0, "still at cruise height, got {height_m}");
+    let (dn, de) = (truth.ned[0] - (-127.0), truth.ned[1] - 127.0);
+    let to_democ = dn.hypot(de);
+    assert!(
+        to_democ <= 110.0,
+        "completed inside DEMOC capture, {to_democ} m out"
+    );
+
+    // Completion holds: zero velocity every tick, the event never repeats.
+    for _ in 0..3 {
+        let mut post_events = Vec::new();
+        step(
+            &mut engine,
+            &mut truth,
+            &mut now,
+            &mut arm_requests,
+            &mut post_events,
+        );
+        assert_eq!(arm_requests, 1);
+        assert!(post_events.is_empty(), "no events after completion");
+        assert!(truth.ned_velocity.iter().all(|v| v.abs() < 1e-9));
+    }
+}
+
+#[test]
+fn non_truth_roles_are_refused_and_never_drive_the_mission() {
+    let (mut engine, _) = build_engine();
+    let mut now = MonotonicNanos::from_nanos(1_000_000_000);
+    let truth = Truth::new();
+    for index in 0..50u32 {
+        now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+        let mut sample = truth.sample(now);
+        sample.sequence = index;
+        sample.role = if index % 2 == 0 {
+            TruthRole::FcState
+        } else {
+            TruthRole::OperationalEstimate
+        };
+        engine.on_ownship(&sample, now);
+        let out = engine.tick(now);
+        assert!(out.intent.is_none());
+        assert!(out.action.is_none());
+        assert_eq!(
+            out.state,
+            MissionState::AwaitSolution,
+            "no laundered solution"
+        );
+    }
+    assert_eq!(engine.counters().rejected_role, 50);
+    assert_eq!(engine.counters().fusion_rejected, 0);
+}
+
+#[test]
+fn observation_silence_refuses_guidance_with_one_surfaced_event() {
+    let (mut engine, _) = build_engine();
+    let mut truth = Truth::new();
+    let mut now = MonotonicNanos::from_nanos(1_000_000_000);
+    let mut arm_requests = 0;
+    let mut events = Vec::new();
+    for _ in 0..2_000 {
+        step(
+            &mut engine,
+            &mut truth,
+            &mut now,
+            &mut arm_requests,
+            &mut events,
+        );
+        if engine.state() == MissionState::Enroute {
+            break;
+        }
+    }
+    assert_eq!(engine.state(), MissionState::Enroute, "reached enroute");
+
+    // Six seconds of observation silence: solution quality decays to
+    // Unusable and guidance must refuse rather than guess.
+    now = MonotonicNanos::from_nanos(now.as_nanos() + 6_000_000_000);
+    let out = engine.tick(now);
+    assert!(out.intent.is_none(), "no intent on a refused tick");
+    let refusals: Vec<&MissionEvent> = out
+        .events
+        .iter()
+        .filter(|e| matches!(e, MissionEvent::GuidanceRefused { .. }))
+        .collect();
+    assert_eq!(refusals.len(), 1, "exactly one surfaced refusal");
+    assert!(
+        matches!(
+            refusals[0],
+            MissionEvent::GuidanceRefused {
+                reason: GuidanceRefusal::IntegrityBelowFloor { .. }
+            }
+        ),
+        "refusal names the integrity floor, got {:?}",
+        refusals[0]
+    );
+    let refused = engine.counters().guidance_refused;
+    assert!(refused >= 1);
+
+    // The same refusal kind repeats: counted, not re-surfaced.
+    now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+    let out = engine.tick(now);
+    assert!(out.intent.is_none());
+    assert_eq!(
+        count(&out.events, |e| matches!(
+            e,
+            MissionEvent::GuidanceRefused { .. }
+        )),
+        0
+    );
+    assert!(engine.counters().guidance_refused > refused);
+}

--- a/crates/pilotage-mission/tests/mission_engine.rs
+++ b/crates/pilotage-mission/tests/mission_engine.rs
@@ -45,7 +45,7 @@ impl Truth {
         OwnshipSample {
             ned: self.ned,
             ned_velocity: self.ned_velocity,
-            yaw_rad: self.yaw,
+            yaw_rad: Some(self.yaw),
             role: TruthRole::SimulationTruth,
             acquired_at: now,
             sequence: self.sequence,
@@ -413,4 +413,63 @@ fn observation_silence_refuses_guidance_with_one_surfaced_event() {
         0
     );
     assert!(engine.counters().guidance_refused > refused);
+}
+
+/// A sample stream that never carries a heading feeds fusion but cannot
+/// be rotated into the body frame: no intent, a counted refusal, and
+/// flight resumes the moment a heading arrives.
+#[test]
+fn a_missing_heading_withholds_intents_and_is_counted() {
+    // Zero cruise height goes straight to Enroute, where intents need
+    // the NED→body rotation (the climb command is body-vertical only).
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let anchor = GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    );
+    let mut config = MissionConfig::new(
+        fixture::DEMO_ROUTE.to_owned(),
+        anchor,
+        ClockDomainId::new(7),
+    );
+    config.cruise_height_m = 0.0;
+    let (mut engine, _record) =
+        MissionEngine::new(&snapshot, provenance, config).expect("mission builds");
+    let mut truth = Truth::new();
+    let mut now = MonotonicNanos::from_nanos(0);
+    let mut armed = false;
+    let mut saw_missing_yaw_intentless_tick = false;
+    for _ in 0..40 {
+        now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+        truth.sequence = truth.sequence.wrapping_add(1);
+        let mut sample = truth.sample(now);
+        sample.yaw_rad = None;
+        engine.on_ownship(&sample, now);
+        let out = engine.tick(now);
+        if let Some(action) = out.action {
+            engine.on_action_result(action.action_id, true);
+            armed = true;
+        }
+        if armed && matches!(out.state, MissionState::Enroute) && out.intent.is_none() {
+            saw_missing_yaw_intentless_tick = true;
+        }
+        assert!(
+            out.intent.is_none(),
+            "an unheaded stream must never produce a body-frame intent"
+        );
+    }
+    assert!(saw_missing_yaw_intentless_tick, "enroute was reached");
+    assert!(engine.counters().missing_yaw > 0, "the refusal is counted");
+
+    // One headed sample restores flight on the very next tick.
+    now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+    truth.sequence = truth.sequence.wrapping_add(1);
+    engine.on_ownship(&truth.sample(now), now);
+    let out = engine.tick(now);
+    assert!(
+        out.intent.is_some(),
+        "a known heading resumes intent emission"
+    );
 }

--- a/crates/pilotage-mission/tests/mission_engine.rs
+++ b/crates/pilotage-mission/tests/mission_engine.rs
@@ -8,8 +8,8 @@ use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
 use navigate_guidance::GuidanceRefusal;
 use pilotage_mission::fixture::{self, GeoPointDegrees};
 use pilotage_mission::{
-    MissionConfig, MissionEngine, MissionEvent, MissionState, OwnshipSample, TruthRole,
-    decode_snapshot,
+    MissionConfig, MissionEngine, MissionEvent, MissionState, NavGuidance, NavQuality,
+    OwnshipSample, TruthRole, decode_snapshot,
 };
 use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame};
 
@@ -229,6 +229,103 @@ fn mission_arms_once_climbs_flies_the_route_and_completes() {
         assert!(post_events.is_empty(), "no events after completion");
         assert!(truth.ned_velocity.iter().all(|v| v.abs() < 1e-9));
     }
+}
+
+#[test]
+fn guidance_is_absent_until_a_leg_is_being_flown() {
+    let (mut engine, _) = build_engine();
+    assert!(
+        engine.nav_guidance().is_none(),
+        "no solution yet, so nothing to display"
+    );
+
+    // Fly up to the arm request and leave it outstanding: a solution now
+    // exists, but the executor is not flying a leg yet.
+    let mut truth = Truth::new();
+    let mut now = MonotonicNanos::from_nanos(1_000_000_000);
+    let mut requested = false;
+    for _ in 0..50 {
+        now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
+        truth.sequence = truth.sequence.wrapping_add(1);
+        engine.on_ownship(&truth.sample(now), now);
+        if engine.tick(now).action.is_some() {
+            requested = true;
+            break;
+        }
+    }
+    assert!(requested, "the arm request goes out within the step budget");
+    assert_eq!(engine.state(), MissionState::Arming);
+    assert!(
+        engine.nav_guidance().is_none(),
+        "arming is not flying a leg: no guidance display"
+    );
+}
+
+#[test]
+fn guidance_tracks_the_active_leg_and_leaves_with_the_plan() {
+    let (mut engine, _) = build_engine();
+    let mut truth = Truth::new();
+    let mut now = MonotonicNanos::from_nanos(1_000_000_000);
+    let mut arm_requests = 0;
+    let mut events = Vec::new();
+    let mut climb: Option<NavGuidance> = None;
+    let mut sequenced: Option<NavGuidance> = None;
+
+    for _ in 0..20_000 {
+        step(
+            &mut engine,
+            &mut truth,
+            &mut now,
+            &mut arm_requests,
+            &mut events,
+        );
+        if engine.state() == MissionState::Complete {
+            break;
+        }
+        let Some(guidance) = engine.nav_guidance() else {
+            continue;
+        };
+        if engine.state() == MissionState::Climb && climb.is_none() {
+            climb = Some(guidance);
+        } else if guidance.leg_index > 0 && sequenced.is_none() {
+            sequenced = Some(guidance);
+        }
+    }
+    assert_eq!(engine.state(), MissionState::Complete);
+
+    // The climb flies direct-to: guidance is published with the live
+    // bearing to the first fix and a real distance, but no lateral course
+    // is being tracked, so there is nothing to deviate from.
+    let climb = climb.expect("the climb phase publishes guidance");
+    assert_eq!(climb.to_ident, "DEMOA");
+    assert_eq!(climb.from_ident, None);
+    assert_eq!(climb.lateral_deviation_m, None);
+    assert_eq!(climb.leg_index, 0);
+    assert_eq!(climb.waypoint_count, 3);
+    assert!((0.0..std::f64::consts::TAU).contains(&climb.course_rad));
+    assert!(
+        climb.distance_to_waypoint_m > 0.0 && climb.distance_to_waypoint_m.is_finite(),
+        "the climb still reports a real distance to run, got {}",
+        climb.distance_to_waypoint_m
+    );
+
+    // Past the first capture the leg has an origin fix, so cross-track
+    // deviation exists and the course is the leg's track.
+    let sequenced = sequenced.expect("a sequenced leg publishes guidance");
+    assert_eq!(sequenced.from_ident.as_deref(), Some("DEMOA"));
+    assert_eq!(sequenced.to_ident, "DEMOB");
+    assert_eq!(sequenced.leg_index, 1);
+    assert_eq!(sequenced.quality, NavQuality::Good);
+    assert!(sequenced.lateral_deviation_m.is_some_and(f64::is_finite));
+    assert!(
+        sequenced.vertical_deviation_m.is_some_and(f64::is_finite),
+        "every demo waypoint carries an altitude constraint"
+    );
+
+    assert!(
+        engine.nav_guidance().is_none(),
+        "a completed plan removes the guidance display rather than freezing it"
+    );
 }
 
 #[test]

--- a/crates/pilotage-protocol/build.rs
+++ b/crates/pilotage-protocol/build.rs
@@ -45,6 +45,7 @@ fn main() -> ExitCode {
         .boxed(".pilotage.v1.TelemetrySample.sim_truth")
         .boxed(".pilotage.v1.TelemetrySample.fc_state")
         .boxed(".pilotage.v1.TelemetrySample.gimbal")
+        .boxed(".pilotage.v1.TelemetrySample.nav_guidance")
         .compile_protos(&protos, &[schema_root])
     {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/pilotage-protocol/src/convert/tests.rs
+++ b/crates/pilotage-protocol/src/convert/tests.rs
@@ -165,6 +165,7 @@ fn envelope_roundtrips_for_telemetry_sample_arm() {
         sim_truth: None,
         fc_state: None,
         gimbal: None,
+        nav_guidance: None,
     };
     let envelope = wire::Envelope {
         schema_version: SCHEMA_VERSION,

--- a/docs/adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md
+++ b/docs/adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md
@@ -1,0 +1,105 @@
+# ADR-0023: Vehicle-side decomposition: flight control, Navigate, and Communicate behind typed contracts
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The session host is the companion layer two sibling systems already point at.
+Aviate defines itself as a motion-control kernel — state estimation,
+stabilization, actuation — excludes navigation, mission management,
+networking, and UI by specification, and points full protocol support at a
+companion computer. aerocontext (repository `v99n62`) assembles
+provenance-tracked advisory aeronautical context (FSS briefings — against the
+vendor's test service today — NOTAMs, weather, NASR/CIFP navdata) under a
+normative advisory-only boundary, with command escalation deliberately gated
+on an authority model it does not own. [ADR-0019](0019-pluggable-vehicle-link-shm-first.md) already
+records the target topology in which the vehicle splits into flight-control,
+navigation, and communication components; the navigation component does not
+exist yet, and no record names the constellation.
+
+The decomposition must serve: flying with no client attached (preloaded plan,
+loss-of-communication procedures — [ADR-0025](0025-client-optional-operation-automation-principals.md));
+live instrument, warning, and context data to clients when present; slow AI
+agents as future commanders ([ADR-0025](0025-client-optional-operation-automation-principals.md));
+and EFB-style preflight with no vehicle at all
+([ADR-0026](0026-host-capability-profiles.md)).
+
+## Decision
+
+- The Pilotage **system** comprises three deployment roles: the vehicle-side
+  **host**, one or more **operator clients**, and an optional **coordination
+  server** ([ADR-0027](0027-optional-coordination-server.md)). This record
+  decides the vehicle side.
+- The vehicle side is three separately governed components composed by the
+  Pilotage host:
+  1. **Flight control** — the FC (Aviate first; PX4 through its adapter):
+     control-grade estimation, stabilization, actuation. It joins through the
+     `VehicleAdapter` boundary ([ADR-0008](0008-engine-independent-adapter-boundary.md))
+     over its declared links ([ADR-0018](0018-avionics-telemetry-and-aviate-adapter.md),
+     [ADR-0019](0019-pluggable-vehicle-link-shm-first.md)). The FC never
+     depends on the other components.
+  2. **Navigate** — a new sibling repository owning global navigation:
+     modular filter-based multi-sensor fusion (GNSS, celestial, visual, and
+     others; operable with any subset including a single source), integrity
+     assessment, flight-plan management and execution, guidance, and terrain
+     awareness (EGPWS-class). The authority split with the FC is
+     [ADR-0024](0024-navigation-authority-boundary.md).
+  3. **Communicate** — the aerocontext repository evolved in place, playing
+     the communication role: external aeronautical context (FSS briefings,
+     NOTAMs, weather, NASR/CIFP navdata; FIS-B, ADS-B, and traffic as they
+     land) with structural provenance and freshness. Its advisory-only
+     boundary is preserved verbatim: Communicate products never gate,
+     command, or actuate.
+- The **host orchestrates**: the session/authority/media endpoint it already
+  is, plus component supervision and lifecycle, and the contracts below. The
+  host remains the unit of deployment
+  ([ADR-0004](0004-host-oriented-topology.md)).
+- **Contracts are typed boundaries, not process boundaries**
+  ([ADR-0003](0003-separate-responsibility-planes.md) discipline). Each
+  component contract MUST be defined so that in-process linking (library
+  crates) and sidecar processes are both conforming deployments. First
+  increments MAY link Navigate and Communicate cores in-process; a later
+  split into processes MUST NOT change any contract. Navigate domain logic
+  follows the sans-IO rule ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md));
+  Communicate's cores already take time as data.
+- **Two data disciplines, never blurred.** Measurements (FC and Navigate
+  state) ride the telemetry plane under stamped, coherence-gated admission
+  ([ADR-0018](0018-avionics-telemetry-and-aviate-adapter.md)). Advisory
+  context (Communicate products) rides bulk/advisory message classes under
+  provenance and freshness tracking. An advisory product MUST NOT be
+  presented or consumed as a measurement, and a measurement MUST NOT be
+  re-served as advisory context without its stamps.
+
+```text
+Operator clients ⇄ WebTransport ⇄ Pilotage host ─ adapter ─ FC (Aviate | PX4)
+                                     ├─ Navigate    (fusion, FPL, guidance, EGPWS)
+                                     └─ Communicate (advisory context, provenance)
+```
+
+## Consequences
+
+- Repositories stay separately governed with their own licenses and release
+  cadence; cross-repo consumption uses pinned dependencies (the
+  `aviate-xil-contract` precedent) or a process surface.
+- Navigate's guidance commands enter the same fenced control path as any
+  operator ([ADR-0024](0024-navigation-authority-boundary.md),
+  [ADR-0025](0025-client-optional-operation-automation-principals.md)) — no
+  privileged side door to the adapter exists for on-vehicle components.
+- Communicate's gated command seam (`ControlCommandProvider`) maps onto
+  Pilotage authority: escalation beyond advisory happens only through leased
+  scopes ([ADR-0025](0025-client-optional-operation-automation-principals.md)).
+- The moving-map and EFB data path is defined: navigation solution
+  (Navigate) + navdata snapshots (Communicate) + signed terrain packages
+  (`pilotage-svs-db`).
+- "Communicate" is a role name; aerocontext keeps its product identity, CI,
+  and publishing.
+
+## Alternatives considered
+
+- **Fold navigation and data into the host binary as modules:** rejected;
+  it erases the certification and fault boundaries both sibling systems
+  already assert, and couples release cadence across three products.
+- **A new Communicate repository lifting aerocontext crates:** rejected for
+  now; it duplicates a maturing product's CI and publishing. Revisit if the
+  vehicle role and the EFB/agent product diverge materially.

--- a/docs/adr/0024-navigation-authority-boundary.md
+++ b/docs/adr/0024-navigation-authority-boundary.md
@@ -1,0 +1,80 @@
+# ADR-0024: Control-grade estimation stays with the flight controller; Navigate owns the global solution and guidance
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The FC owns an estimator sized for stabilization: high-rate, sensor-direct,
+with externally supplied inputs bounded and removable by its own specification
+(GNSS-class inputs never drive inner attitude/rate loops; on unrecoverable
+fault it degrades monotonically and waits for external supervision). Navigate
+([ADR-0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md)) fuses
+heterogeneous sources — GNSS, celestial, visual, and others — into a
+navigation-grade global solution and executes flight plans against it. The two
+estimates serve different loops and different failure budgets; blurring them
+would let a navigation fault propagate into stabilization.
+
+## Decision
+
+- **The FC owns the control-grade estimator** required for stabilization and
+  remains fully operational without Navigate.
+- **Navigate owns the global navigation charter enumerated in
+  [ADR-0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md)** —
+  multi-sensor fusion, integrity assessment, flight-plan management and
+  execution, guidance, and terrain awareness; that record's list is
+  authoritative, this record decides the boundary rules.
+- **Guidance interface:** Navigate flies the vehicle by streaming setpoints
+  through the FC's declared command surface (position and velocity setpoints,
+  deviation tracking, as the FC declares them); a trajectory-level handoff,
+  if ever adopted, is an FC-side surface extension, not an assumption. These
+  commands enter through the host's fenced control path as an
+  automation-class principal
+  ([ADR-0025](0025-client-optional-operation-automation-principals.md)); the
+  FC does not distinguish Navigate from any other commander.
+- **Aiding interface:** Navigate MAY supply timestamped, bounded aiding
+  observations with covariance and integrity metadata. The FC independently
+  validates, fuses, or rejects each observation; acceptance is never assumed,
+  and a rejected observation changes nothing about guidance authority.
+- **Correlation rule:** fused outputs derived from shared measurements MUST
+  NOT be treated as independent aids. Every aiding observation declares its
+  source composition; an observation that ingests measurements the FC also
+  consumes directly (the same GNSS receiver, FC-exported state) is either
+  excluded or declared correlated so the FC can discount it.
+- **Placement of learned components:** visual navigation belongs to Navigate.
+  If latency-critical learned control policies are adopted, they execute
+  within the FC's control architecture under its supervision discipline
+  (degradation ladder, envelope protection) — an FC-side extension to be
+  specified with the FC — never in Navigate.
+- **Integrity:** the navigation solution carries integrity and quality
+  metadata with every estimate. Guidance decisions that require integrity
+  fail closed when it is absent or degraded; terrain awareness continues on
+  best-available data with its quality shown explicitly.
+- **Displays:** the navigation solution joins the telemetry source-role
+  vocabulary as its own role — never relabeled as FC state or simulation
+  truth.
+
+## Consequences
+
+- Two estimators exist by design. Divergence between them is a monitored,
+  displayable condition — not an error to be hidden by picking one silently.
+- The aiding-observation schema (reference frames, covariance encoding,
+  integrity terms, source composition) is an interface RFC owed jointly with
+  the Aviate side, like the native-link RFC deferred in
+  [ADR-0019](0019-pluggable-vehicle-link-shm-first.md).
+- Single-source operation degrades gracefully: with only one navigation
+  source, Navigate's integrity output narrows honestly rather than
+  fabricating confidence; with no source, guidance refuses and the FC keeps
+  flying on its own estimator.
+- Terrain awareness (EGPWS-class) binds Navigate's solution to signed terrain
+  packages (`pilotage-svs-db`) independently of the FC estimate.
+
+## Alternatives considered
+
+- **Navigate as the FC's navigation authority** (FC outer loops consume the
+  fused solution): rejected — a navigation fault would propagate directly
+  into the control loop, and it contradicts the FC's
+  bounded-external-influence specification.
+- **Guidance-only with no aiding path:** rejected as the only mode; it
+  remains the degenerate case whenever no aiding is offered or every
+  observation is rejected.

--- a/docs/adr/0025-client-optional-operation-automation-principals.md
+++ b/docs/adr/0025-client-optional-operation-automation-principals.md
@@ -1,0 +1,81 @@
+# ADR-0025: Client-optional operation: mission execution and agents are automation-class principals
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The host must fly the vehicle with no client attached: a preloaded flight
+plan or mission, and loss-of-communication procedures that regulation
+requires, must execute headless. Today every control frame originates in a
+client; nothing host-side can originate flight.
+
+The authority machinery already anticipates non-human commanders:
+[ADR-0006](0006-capability-auth-scoped-leases-fencing.md) gives every lease
+an authority class, [ADR-0010](0010-authority-state-machines.md) names
+automation-agent acquisition and release and engages link loss per scope
+from a per-vehicle, adapter-published action menu that already includes
+engaging an automation mode, and the authority engine implements an
+`Automation` class.
+Communicate ([ADR-0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md))
+already serves AI agents through an MCP surface whose command escalation is
+deliberately gated on an authority model.
+
+## Decision
+
+- **The mission executor is a principal, not a privilege.** Navigate's
+  flight-plan execution, supervised by the host, acquires control scopes
+  through the same authority engine as any client — an automation-class
+  principal with fenced generations, liveness watchdogs, and audit events.
+  No component-to-adapter bypass exists.
+- **Preloaded plans, missions, and procedures are host-resident
+  configuration**, loadable before departure and replaceable in flight by an
+  authorized principal. Client absence is normal operation, not a failure
+  mode.
+- **Loss of communication engages automation through link-loss policy.** The
+  *engage automation mode* action already in the adapter-published menu
+  ([ADR-0010](0010-authority-state-machines.md)) receives its concrete
+  semantics: when a vehicle's selected policy is automation engagement, a
+  scope losing its holder is handed to the mission executor, which flies the
+  applicable configured procedure (loss-of-comm procedure, mission
+  continuation, return-and-land class). Policy selection stays per vehicle
+  and engagement and clearance stay per scope
+  ([ADR-0008](0008-engine-independent-adapter-boundary.md),
+  [ADR-0010](0010-authority-state-machines.md)). Which procedure applies is
+  vehicle and deployment configuration, selected before flight.
+- **Humans recover authority through the normal machinery.** Automation
+  yields through handover per policy; emergency override displaces it
+  exactly as it would a human holder, advancing the fencing generation.
+- **Slow AI agents attach as agent-class principals.** Advisory access flows
+  through Communicate's MCP surface and confers no authority. Command
+  escalation happens only by holding leased scopes under the same fencing —
+  never a parallel path. Agent pacing rides the existing message classes;
+  watchdog and deadman machinery applies unchanged, so a stalled agent is
+  fenced out like a silent operator.
+
+## Consequences
+
+- Headless operation is a first-class host mode; the client is an observer
+  and commander that may come and go.
+- UI MUST show automation as the effective holder of a scope exactly as it
+  shows a human, extending the corresponding
+  [ADR-0010](0010-authority-state-machines.md) consequence.
+- The authority policy matrix (which classes may preempt automation, veto
+  rules, renewed-verification requirements) remains the
+  [ADR-0010](0010-authority-state-machines.md) open question, now including
+  automation and agent rows.
+- The regulatory content of procedures — what a loss-of-comm procedure
+  requires in a given airspace — is configuration data with provenance, not
+  platform code.
+- Structured session events ([ADR-0012](0012-structured-session-events.md))
+  record automation acquisition, enactment, and yield transitions for
+  replay and audit.
+
+## Alternatives considered
+
+- **A privileged host-internal control path for autonomy:** rejected; it
+  would bypass fencing, watchdogs, and audit — precisely the machinery that
+  makes displacing a faulty commander safe.
+- **Agents as a separate protocol surface with their own authority model:**
+  rejected; two authority models over one actuator set cannot both be
+  authoritative.

--- a/docs/adr/0026-host-capability-profiles.md
+++ b/docs/adr/0026-host-capability-profiles.md
@@ -1,0 +1,72 @@
+# ADR-0026: Client posture follows discovered host capability: full-authority, data-gateway, or embedded
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The client must serve two postures with one codebase: a fully capable control
+terminal beside a full host, and an EFB-style preflight and monitoring tool
+beside a limited host — or no host at all, as on a tablet with no vehicle
+attached. Limited hosts exist in practice as data gateways (FlightStream-class
+receivers exposing AHRS, GNSS, ADS-B, FIS-B, and flight-plan exchange but no
+actuators). Host capability discovery already exists: scopes are published,
+not hard-coded ([ADR-0006](0006-capability-auth-scoped-leases-fencing.md)),
+and adapters advertise what they cannot do
+([ADR-0013](0013-interactive-and-accelerated-sessions.md)).
+
+## Decision
+
+- **A host advertises a capability profile** — the truthful union of what its
+  components provide. Two advertised profiles anchor the hosted range:
+  - **full-authority**: actuator scopes plus telemetry, media, and advisory
+    context; the complete control terminal experience.
+  - **data-gateway**: telemetry and advisory context with zero actuator
+    scopes — e.g. a bridge to an AHRS/GNSS/ADS-B receiver, including
+    flight-plan send/receive where the device supports it. A data-gateway
+    host is an ordinary adapter family
+    ([ADR-0008](0008-engine-independent-adapter-boundary.md),
+    [ADR-0019](0019-pluggable-vehicle-link-shm-first.md)); no new protocol
+    exists for it.
+- **The third posture is host-absent: embedded.** No session host process
+  runs at all — the client embeds Communicate cores in-process for
+  preflight (aerocontext's device-clean crates make this a supported
+  target). The same display contracts and data model apply; nothing is
+  advertised because there is nothing to discover.
+- **Clients adapt by discovery, not build variants.** EFB behavior is the
+  client experience when no actuator scope is advertised or no host is
+  present; the full terminal is the same client when authority scopes exist.
+  A client MUST NOT hard-code the posture it expects.
+- **Displays render honestly by capability**: absent capabilities produce
+  the existing Missing-status discipline, never placeholders that imply a
+  capability exists.
+- **Preflight functions** — briefing on a live map, pack-for-flight data
+  currency, on-device AI highlighting of briefings — come from Communicate
+  cores in every profile, embedded or hosted. Features requiring vendor
+  credentials or entitlements need the coordination server
+  ([ADR-0027](0027-optional-coordination-server.md)) and degrade to absent
+  without it.
+
+## Consequences
+
+- Session bootstrap handles the host-absent case as a normal path, not an
+  error.
+- The authority machinery is uniform: against a data-gateway profile there
+  is simply nothing to lease; no client or host branch exists for "EFB
+  mode".
+- One client across web, iPadOS, and native rests on the portable cores
+  ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)) and the
+  display plugin contracts
+  ([ADR-0029](0029-panel-layout-look-plugins.md)).
+- Profile truthfulness is a trust statement: a host MUST NOT advertise
+  scopes its components cannot enact; capability advertisement joins the
+  host trust model tracked in [ADR-0004](0004-host-oriented-topology.md).
+
+## Alternatives considered
+
+- **A separate EFB application family:** rejected; it forks the client
+  architecture and the data model, and the EFB posture is a capability
+  subset, not a different product shape.
+- **Requiring a host process everywhere, embedded via localhost:** rejected;
+  it forces a server runtime into a tablet app for pure preflight and adds a
+  bootstrap path with no capability gain over in-process linking.

--- a/docs/adr/0027-optional-coordination-server.md
+++ b/docs/adr/0027-optional-coordination-server.md
@@ -1,0 +1,97 @@
+# ADR-0027: Optional coordination server: identity, rendezvous, and entitlements — never the session data plane
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+WAN deployments need authentication and authorization, discovery and
+rendezvous across NAT, fleet inventory, and access to vendor-credentialed
+data services (FSS briefing requests, and eventually flight-plan filing).
+The services area reserves an identity/admission service.
+[ADR-0003](0003-separate-responsibility-planes.md) and
+[ADR-0004](0004-host-oriented-topology.md) keep central services optional
+in a narrow sense — no centrally operated simulator fleet, no centrally
+scheduled compute; this record strengthens that stance for the server
+role. aerocontext ships a working embryo of the entitlement arm: a proxy
+daemon holding vendor secrets server-side, gating calls on
+verifiable-credential presentations (the aerocred stack). A local
+deployment must work with no server configured at all.
+
+## Decision
+
+- One optional **coordination server** role composes four functions:
+  1. **Identity and admission** — passkey/WebAuthn authentication,
+     membership, short-lived session capabilities
+     ([ADR-0003](0003-separate-responsibility-planes.md),
+     [ADR-0006](0006-capability-auth-scoped-leases-fencing.md)).
+  2. **Host registry and fleet inventory** — registration, capability
+     advertisement, and fleet views; fleet orchestration remains outside
+     the session data-plane correctness boundary
+     ([ADR-0004](0004-host-oriented-topology.md)).
+  3. **Rendezvous** — brokering direct client↔host QUIC path
+     establishment: endpoint discovery, address exchange, and hole-punch
+     coordination.
+  4. **Entitlement-gated data services** — vendor-credentialed providers
+     behind verifiable-credential presentations: airman eligibility, plus
+     a paid entitlement where the service policy requires one; the
+     aerocontext proxy/aerocred stack is this arm. FSS briefing request is
+     the first such service. Flight-plan filing joins when it lands — in
+     aerocontext it is a deliberately stubbed surface behind its command
+     safety boundary, and its command-class nature also implicates the
+     escalation machinery of
+     [ADR-0025](0025-client-optional-operation-automation-principals.md),
+     not the entitlement gate alone.
+- **Identity has a home in every deployment.** The server hosts the
+  identity/admission plane for WAN deployments; with no server configured,
+  the host itself issues session capabilities under its local policy —
+  planes are contract boundaries
+  ([ADR-0003](0003-separate-responsibility-planes.md)), so the identity
+  service MAY be co-resident with the host for local deployments.
+- **The server MUST NOT carry session data.** No control, telemetry,
+  authority events, or media transit it. Active sessions MUST survive
+  server unavailability; local and LAN sessions MUST form with no server
+  configured. This is a new, stronger commitment than the accepted
+  records make, and it is this record's core decision.
+- **NAT fallback is an opt-in, separately deployed relay.** When no direct
+  path can be established, a MASQUE-style QUIC relay
+  ([ADR-0004](0004-host-oriented-topology.md),
+  [ADR-0005](0005-webtransport-primary-transport.md)) MAY carry the
+  session. The relay is never part of the server role, never required, and
+  is chosen explicitly by the deploying operator — a relay's operator sees
+  encrypted QUIC, but its availability and throughput become part of the
+  session's fate, which is exactly why it is a deliberate deployment
+  choice rather than a silent fallback.
+- **Feature gating is explicit and partial.** Capabilities that require
+  vendor credentials or verified identity are available only through the
+  server; their absence degrades those features only, never the session or
+  local data.
+
+## Consequences
+
+- Server outage costs new WAN rendezvous and entitlement-gated services;
+  active sessions, local sessions, and all locally held data are
+  unaffected.
+- Host registration, update, and attestation — the trust model for who may
+  appear in a fleet — remains the open question tracked in
+  [ADR-0004](0004-host-oriented-topology.md).
+- The entitlement mechanism reuses the aerocontext proxy/aerocred design
+  (server-held vendor secrets, challenge-nonce verifiable presentations)
+  rather than inventing a second gate.
+- Rendezvous requires the host to maintain a registration channel to the
+  server when WAN-reachable operation is desired; the channel carries
+  registration and signaling only.
+
+## Alternatives considered
+
+- **Server-relayed data plane (SFU/TURN-style):** rejected; it puts a
+  center in the latency path and makes the operator carry sessions — the
+  opposite of this record's server-out-of-data-plane decision, and beyond
+  even the relay allowance [ADR-0004](0004-host-oriented-topology.md)
+  grants.
+- **Direct-only with no relay anywhere:** rejected; address-dependent NATs
+  on both ends would make some deployments simply impossible, and the
+  operator deserves the option to accept a relay knowingly.
+- **Folding entitlements into the host:** rejected; vendor secrets must
+  not live on vehicles, and entitlement verification is an
+  identity-plane concern.

--- a/docs/adr/0028-multi-vehicle-and-swarm-coordinator-hosts.md
+++ b/docs/adr/0028-multi-vehicle-and-swarm-coordinator-hosts.md
@@ -1,0 +1,92 @@
+# ADR-0028: Multi-vehicle operation scales from roster attach to swarm aggregation via coordinator hosts
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+Clients and hosts are not one-to-one. One vehicle may be crewed by several
+operators — one flying, one on a refueling or payload scope, one monitoring
+sensors. One operator may command many vehicles, up to addressing a swarm as
+a whole rather than any specific vehicle. And hosts must eventually
+collaborate with no terminal attached at all.
+
+The wire and the state machines are already vehicle-plural: authority is
+keyed per (vehicle, scope) with independent generations
+([ADR-0006](0006-capability-auth-scoped-leases-fencing.md)), every control
+frame, lease, authority event, and telemetry sample carries a vehicle
+identifier, one principal may hold scopes on many vehicles, and sessions may
+contain multiple vehicles ([ADR-0013](0013-interactive-and-accelerated-sessions.md)).
+What is vehicle-singular is deployment: each host process embeds one adapter
+advertising one vehicle, and the client drives one vehicle.
+
+## Decision
+
+- **Multiple operators on one vehicle is the existing design**
+  ([ADR-0006](0006-capability-auth-scoped-leases-fencing.md),
+  [ADR-0010](0010-authority-state-machines.md),
+  [ADR-0011](0011-message-classes-and-channel-semantics.md)). Completing it
+  is mostly roadmap: the handover/override wire vocabulary and
+  authenticated principals realize accepted designs. The one element this
+  record adds is an **observer admission** — telemetry and media with no
+  grantable scopes — for monitoring stations.
+- **One client, many vehicles — roster attach.** A client MAY attach
+  multiple sessions concurrently and hold scopes across them; the client
+  keys all per-vehicle state, including media sources, by (session,
+  vehicle) and never assumes global identifiers. A host MAY equally compose
+  multiple vehicles behind one session through a composite adapter — a
+  session already contains many independently addressed vehicles by design
+  ([ADR-0013](0013-interactive-and-accelerated-sessions.md)). The adapter
+  contract carries per-vehicle identity for capabilities, control,
+  telemetry, and link-loss policy; extending the media-source surface with
+  vehicle attribution is part of completing roster attach.
+- **Swarm aggregation lives in a coordinator host.** A coordinator is a
+  host role that advertises **aggregate scopes** (e.g. `swarm.motion`)
+  through ordinary capability discovery. Holding an aggregate scope leases
+  the coordinator's decomposition authority: the coordinator translates
+  aggregate commands into per-vehicle commands and acts as an
+  automation-class principal
+  ([ADR-0025](0025-client-optional-operation-automation-principals.md)) of
+  each member vehicle's host, over the ordinary client protocol. Fencing
+  applies end to end: member hosts fence the coordinator exactly like any
+  client, and displacing the coordinator on one member affects exactly that
+  member.
+- **Aggregate semantics are coordinator implementation, not wire
+  vocabulary.** Formation geometry, role assignment, and member selection
+  live in the coordinator; the wire stays per-vehicle frames plus aggregate
+  scopes. A member vehicle needs no swarm concept at all.
+- **Peer collaboration without a terminal reuses the same seam.**
+  Host-to-host attachment over the client protocol is the reserved
+  envelope for vehicles collaborating with no operator present; no separate
+  peer protocol class is introduced. The concrete collaboration behaviors
+  are deferred by design.
+
+## Consequences
+
+- Coordinator failure is safe by construction: each member scope engages
+  its own link-loss policy ([ADR-0010](0010-authority-state-machines.md)),
+  including *engage automation* for mission continuation
+  ([ADR-0025](0025-client-optional-operation-automation-principals.md)).
+- Who may lease aggregate scopes, and how aggregate authority interacts
+  with a per-member holder (a swarm command racing a direct member lease),
+  joins the [ADR-0010](0010-authority-state-machines.md) policy matrix.
+- The roster client is a client-plane feature: vehicle list, per-vehicle
+  authority display, and media keyed by session — no protocol change.
+- A coordinator host is a normal host: registered, discovered, and
+  admitted like any other ([ADR-0004](0004-host-oriented-topology.md),
+  [ADR-0027](0027-optional-coordination-server.md)).
+
+## Alternatives considered
+
+- **Client-side fan-out as the swarm mechanism:** rejected as the
+  destination — coordination dies with the client and offers no envelope
+  for terminal-less collaboration. It remains the degenerate near-term
+  case that roster attach provides for free.
+- **Server-mediated fleet command:** rejected; it places a center in the
+  command path, contradicting
+  [ADR-0003](0003-separate-responsibility-planes.md) /
+  [ADR-0004](0004-host-oriented-topology.md).
+- **Swarm vocabulary on the wire (broadcast frames, group addresses):**
+  rejected for now; it would push aggregation semantics into every host
+  and client, and the coordinator model covers the scenarios with the
+  vocabulary already deployed.

--- a/docs/adr/0029-panel-layout-look-plugins.md
+++ b/docs/adr/0029-panel-layout-look-plugins.md
@@ -1,0 +1,84 @@
+# ADR-0029: Panels, layout, and look are data-driven plugins over the scene and state contracts
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+Operators will replace the PFD style, add a moving map, or restyle the whole
+station; they may or may not have a gimbal camera or a joystick. The
+instrument runtime ([ADR-0017](0017-instrument-display-runtime.md)) already
+proves the load-bearing seam: the versioned scene-command IR is consumed by
+two independent backends (browser canvas and the reference rasterizer) under
+a conformance corpus. But everything above that seam is welded: the panel set
+is enumerated in four layers (wasm exports, client script, health targets,
+markup), the packed state ABI is closed, palette/geometry/glyphs are
+compile-time constants, and some wire-adjacent feeder logic lives only in
+client script contrary to
+[ADR-0002](0002-cargo-workspace-portable-sans-io-core.md).
+
+## Decision
+
+- **A panel is a plugin over three stable contracts**: (1) an extensible
+  **state-group contract** — typed signal groups with validity and age,
+  declared per panel, replacing the closed fixed-layout ABI; (2) the
+  **scene-command IR** ([ADR-0017](0017-instrument-display-runtime.md));
+  (3) the **glyph vocabulary**. A panel remains a pure state→scene
+  function; the shell enforces layer masks and budgets generically.
+- **A panel registry replaces hard-coded enumeration.** A panel descriptor
+  — identity, required layers, required state groups, preferred aspect —
+  is the single source every shell (web, native) consumes for wiring,
+  health tracking, and layout slots. A required group that is unfed
+  renders honest Missing status, never a blank or a default.
+- **All panels share one data model.** The state vocabulary, the navigation
+  solution ([ADR-0024](0024-navigation-authority-boundary.md)), navdata
+  snapshots (Communicate), and signed terrain packages (`pilotage-svs-db`)
+  feed every panel through the same group contract; a replacement PFD and
+  a moving map consume the same groups, not private feeds.
+- **Look and layout are data, with a safety-fixed floor.** Theming inputs
+  (palette, proportions, glyph pack selection) are validated data. A
+  defined set of visual attributes is never skinnable: failure pages,
+  flag colors, alert semantics, and required-layer isolation. Panel
+  placement and selection are declarative configuration consumed by web
+  and native shells alike.
+- **Feeder logic is shared core.** Ingress gating, coherence decisions,
+  and derivations that interpret wire or measurement semantics live in
+  sans-IO core crates driven by each platform
+  ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)); client
+  script holds no wire- or measurement-interpreting logic.
+- **Foreign panels are admitted by conformance, not trust.** A harness
+  validates a plugin panel's scenes — layer contract, budgets, glyph
+  vocabulary coverage, and honest-status rendering under injected
+  Missing/Stale/Failed inputs — the inverse of the existing backend
+  conformance, before a panel may join an operational layout.
+
+## Consequences
+
+- Which attributes are safety-fixed versus skinnable is an explicit
+  assurance decision recorded with the theming schema, not an emergent
+  property of what happens to be a constant.
+- The registry and extensible state groups are substantial, staged work:
+  the wasm boundary, the shells, and the health model all consume the
+  descriptor instead of literals.
+- The moving map becomes buildable: its data path exists once navigation
+  solution and navdata groups flow through the group contract.
+- iPadOS and native stations reuse panels unchanged; platform work is
+  shell and ports, not panel code.
+- Plugin isolation and versioning (how a third-party panel is loaded,
+  sandboxed, and version-matched to the contracts) is an open question
+  tracked below.
+
+## Open questions
+
+- Plugin packaging and isolation: separate wasm modules against a frozen
+  import contract versus out-of-process scene producers over a channel.
+- The assurance bar for third-party panels in operational (non-simulation)
+  deployments.
+
+## Alternatives considered
+
+- **Fork-and-recompile as the customization model:** rejected; every look
+  or panel variant becomes a divergent build of safety-adjacent code.
+- **A widget toolkit with arbitrary drawing:** rejected; the frozen scene
+  vocabulary and glyph discipline are what make honest-status rendering
+  and conformance checking tractable.

--- a/docs/adr/0030-communicate-navdata-provisioning.md
+++ b/docs/adr/0030-communicate-navdata-provisioning.md
@@ -1,0 +1,90 @@
+# ADR-0030: The host consumes aeronautical navdata through Communicate's cycle-dated snapshot surface
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+Mission execution ([ADR-0025](0025-client-optional-operation-automation-principals.md))
+and the moving-map/EFB path ([ADR-0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md),
+[ADR-0026](0026-host-capability-profiles.md)) need aeronautical entities —
+airports, fixes, navaids, airways, airspace — with known effectivity.
+Communicate already ships exactly that: NASR/CIFP data packed into a
+versioned, checksummed blob format with 28-day cycle selection, a
+provenance-tracked manifest/sync distribution chain, identifier
+resolution, and route expansion, all available as a device-clean library
+slice with no network or runtime dependencies.
+
+Terrain is adjacent but different: `pilotage-svs-db` packages are
+self-authenticating (Ed25519 signature plus Merkle tile root verified
+against a host-held trust root), the build chain processes only synthetic
+in-memory sources, and no decodable container format exists to move a
+package between machines. Communicate's manifest/sync chain is
+content-blind in transport but its store/selection layer decodes its own
+blob format to select cycles.
+
+## Decision
+
+- **Navdata enters the host only through Communicate's snapshot
+  surface**: cycle-dated snapshots decoded from its versioned blob
+  format, selected by effectivity date. No other ingestion path (direct
+  NASR/CIFP parsing, ad-hoc waypoint files) exists on the host.
+- **Provenance travels with use.** A plan built from navdata records its
+  source: route input, authority, cycle effectivity, and blob digest —
+  the auditable "pack for flight" record. Fixture snapshots for
+  simulation traverse the same encode/decode path and are marked as
+  fixtures in that record.
+- **Advisory discipline holds** ([ADR-0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md)):
+  navdata is advisory context. It shapes plans, guidance targets, and
+  displays; it never enters the telemetry plane as measurement and never
+  gates the authority machinery.
+- **Units convert exactly once.** Communicate's vocabulary (decimal
+  degrees, nautical miles) converts to the canonical radians/meters
+  vocabulary at the host's Navigate binding — one named boundary, no
+  mixed-unit arithmetic anywhere else.
+- **Currency gates mission start, not mission continuation.** Starting a
+  mission requires a snapshot effective for the operation date; an
+  explicit, logged override exists for simulation and development. A
+  cycle rolling over in flight never invalidates the active plan.
+- **Terrain distribution is deferred with its design recorded.**
+  Communicate's manifest/sync chain is the intended discovery and
+  transport for terrain packages, carrying them as opaque blobs whose
+  trust anchor stays the package's own signature against the host's
+  trust root — the manifest checksum is transport integrity, never
+  content authority. Four prerequisites gate implementation:
+  1. real DEM/obstacle ingestion in the terrain build chain (only
+     synthetic in-memory sources exist);
+  2. a decodable package container format (encoding exists for
+     reproducibility comparison only);
+  3. a format-agnostic binding in Communicate's store/selection layer
+     (which requires its own blob format for cycle selection);
+  4. host-side staged handoff from the synced store into verify-and-
+     activate under the host trust root.
+  Terrain distributed this way earns SVS and moving-map display use
+  only. Terrain-awareness credit (EGPWS-class) belongs to Navigate's own
+  qualification ([ADR-0024](0024-navigation-authority-boundary.md)) and
+  is never implied by distribution.
+
+## Consequences
+
+- Simulation and tests fabricate small snapshots and push them through
+  the real blob encode/decode path — the consumer code under test is
+  identical to the live-sync path, with no network.
+- The EFB client's embedded posture ([ADR-0026](0026-host-capability-profiles.md))
+  consumes the same library slice; host and client read one navdata
+  truth.
+- Route expansion failures (unresolved identifier, unknown airway) are
+  typed refusals carrying the snapshot's cycle — a stale store is
+  diagnosable from the error alone.
+- Communicate remains free of operational authority: the host decides
+  what a mission may do with the data; Communicate only vouches for what
+  the data is and where it came from.
+
+## Alternatives considered
+
+- **Host-side NASR/CIFP ingestion:** rejected; it duplicates a mature,
+  tested pack/verify/select chain and splits provenance across repos.
+- **Wrapping terrain packages in Communicate's blob format:** rejected;
+  double-wrapping obscures the package's own signature, and the
+  manifest-as-transport split (checksum for transport, signature for
+  content) keeps trust anchored where verification happens.

--- a/docs/adr/0031-nav-guidance-telemetry-display.md
+++ b/docs/adr/0031-nav-guidance-telemetry-display.md
@@ -1,0 +1,76 @@
+# ADR-0031: Navigation guidance rides telemetry as its own stamped role; deviation scaling is display policy
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The instrument runtime already models lateral navigation display — a
+selected `NavSource`, TO/FROM resolution, course with its declared north,
+deviation in dots, and distance — and the HSI draws it when fed. Nothing
+feeds it: the mission executor ([ADR-0025](0025-client-optional-operation-automation-principals.md))
+holds the active leg, desired course, cross-track and vertical deviation,
+and distance-to-waypoint, but that state never leaves the host. The
+telemetry plane's pattern for exactly this situation is established:
+independent sub-messages under their own `MeasurementStamp` (source
+identity, epoch, wrapping sequence, acquisition time, clock, role,
+integrity), gated fail-closed at the client ingress
+([ADR-0018](0018-avionics-telemetry-and-aviate-adapter.md)).
+[ADR-0024](0024-navigation-authority-boundary.md) already commits the
+navigation solution to joining the source-role vocabulary as its own
+role, never relabeled as FC state or simulation truth.
+
+## Decision
+
+- **A `NavGuidanceState` sub-message joins `TelemetrySample`**,
+  additively, under its own `MeasurementStamp` with a new
+  `SOURCE_ROLE_NAVIGATION_SOLUTION`. It carries the active-leg geometry
+  in raw canonical units: TO/FROM identifiers, desired course in radians
+  with true-north reference, lateral deviation in meters (positive right
+  of course, the geodesy convention), vertical deviation in meters
+  (positive above profile; absent without a vertical constraint),
+  distance to the active waypoint in meters, leg index and waypoint
+  count, and the backing solution quality.
+- **The producer is the navigation/mission component, never the
+  adapter.** The mission executor publishes guidance state to the host's
+  telemetry assembly through a host-internal side input; the FC adapter
+  contract is untouched. On a vehicle without an active plan the field is
+  absent — absence means no guidance, and receivers remove the deviation
+  display rather than centering it.
+- **Deviation scaling to dots is display policy**
+  ([ADR-0017](0017-instrument-display-runtime.md)): the wire carries
+  meters; the client's display profile converts to the instrument
+  model's dot scale (full-scale deflection per vehicle class). No dots
+  cross the wire.
+- **Ingress gates the new role like every other group**: wrap-aware
+  sequence and epoch admission per source, role checked explicitly
+  (guidance is display context — never an input to control validation or
+  a fallback for a missing estimate), freshness aged from the stamp, and
+  `solution_quality` unusable removes the display.
+- **This is the extensible-group pattern** ([ADR-0029](0029-panel-layout-look-plugins.md)):
+  one typed, stamped, role-gated signal group added end to end without
+  touching any other group — the shape every future instrument-cluster
+  signal (engine data, traffic, terrain bands) follows.
+
+## Consequences
+
+- The HSI course pointer, CDI, TO ident, and distance readout come alive
+  in any session with an active mission — simulation today, and the same
+  path serves a real vehicle whose Navigate component publishes guidance.
+- `buf breaking` passes by construction; clients that predate the field
+  ignore it.
+- The dots-per-meter display profile is a client-side named constant
+  with tests, adjustable per airframe class without wire change.
+- A future moving map consumes the same group plus navdata snapshots
+  ([ADR-0030](0030-communicate-navdata-provisioning.md)); no second
+  guidance vocabulary is introduced for it.
+
+## Alternatives considered
+
+- **Publishing dots on the wire:** rejected; display scaling is per
+  airframe and per panel, and baking it into telemetry couples every
+  display to one deflection policy.
+- **Deriving deviation client-side from position plus plan:** rejected
+  for now; it requires shipping the active plan and duplicating leg
+  geometry in every client, and the executor's own numbers are the
+  truth being flown. Revisit when clients plan independently (EFB).

--- a/docs/adr/0032-ipad-native-client-shared-cores.md
+++ b/docs/adr/0032-ipad-native-client-shared-cores.md
@@ -1,0 +1,85 @@
+# ADR-0032: The iPad client is a thin native shell over the same Rust cores the web client runs as wasm
+
+- Status: Proposed
+- Date: 2026-07-29
+
+## Context
+
+The client must serve iPadOS natively — EFB preflight with no host at
+all, and the full control terminal against a host — as one codebase
+posture-switched by discovery ([ADR-0026](0026-host-capability-profiles.md)).
+The architecture already forbids the trap that makes native ports
+expensive: no business rule or wire-level state machine may live only in
+one platform layer ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)),
+panels are pure state→scene functions over a versioned scene-command IR
+with two conformance-checked backends ([ADR-0017](0017-instrument-display-runtime.md),
+[ADR-0029](0029-panel-layout-look-plugins.md)), and the instrument crate
+family is `no_std`. Communicate's crates are proven
+`aarch64-apple-ios`-clean with a uniffi FFI surface designed for exactly
+this embedding. The known debt is the web client's JS-only feeder logic
+(telemetry ingress gating, derivations), which [ADR-0029](0029-panel-layout-look-plugins.md)
+already commits to moving behind the shared core boundary.
+
+This record sets the design envelope; implementation is deferred.
+
+## Decision
+
+- **One core, three shells.** The session, wire, ingress, authority-view,
+  input, instrument-state, and mission/plan vocabularies run as the same
+  Rust crates everywhere: the browser drives them as wasm, the iPad links
+  them as a static library behind a generated FFI (the aerocontext uniffi
+  precedent), and any Linux native station links them directly. The Swift
+  layer owns only: windowing/scenes, touch and hardware input, keychain
+  credentials, lifecycle, and rendering surfaces.
+- **Panels render from the scene IR, natively.** A Metal/CoreGraphics
+  scene-command interpreter joins the browser canvas interpreter and the
+  reference rasterizer as a third backend under the same conformance
+  corpus and layer contract. Panel code, glyphs, and budgets are reused
+  byte-identically; no Swift redraws an instrument.
+- **Transport stays in Rust.** The iPad speaks the ordinary session
+  protocol through the same QUIC/WebTransport client stack compiled into
+  the app, driven by the sans-IO session core — not through a parallel
+  platform networking implementation. Platform sockets are the only
+  boundary crossed.
+- **EFB posture embeds Communicate in-process** per
+  [ADR-0026](0026-host-capability-profiles.md): navdata sync/store,
+  identifier resolution, route expansion, and briefings run on-device
+  through Communicate's device-clean crates; the same snapshot surface
+  the host consumes ([ADR-0030](0030-communicate-navdata-provisioning.md))
+  feeds preflight with no host present.
+- **Porting debt is named, not discovered.** Before the iPad shell
+  starts, the JS-only feeder logic moves behind the shared boundary
+  ([ADR-0029](0029-panel-layout-look-plugins.md)): telemetry ingress
+  gating, turn/heading derivations, and the display-profile scaling
+  introduced by [ADR-0031](0031-nav-guidance-telemetry-display.md). The
+  wasm and FFI builds then drive one implementation, and the conformance
+  suite runs against both ports ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)).
+
+## Consequences
+
+- The iPad app's platform-specific surface is deliberately boring: shell,
+  input, credentials, rendering context, and a QUIC socket — everything
+  that decides anything is shared and already tested.
+- WebTransport-over-QUIC from a native app avoids the browser's
+  certificate constraints; the host trust story (certificate strategy,
+  [ADR-0004](0004-host-oriented-topology.md)) still applies and is not
+  weakened by the native path.
+- The scene-IR native backend is the main new build; the conformance
+  corpus makes its correctness a mechanical comparison rather than a
+  visual judgment.
+- Apple-platform release mechanics (signing, App Store or ad-hoc
+  distribution, background execution limits for sync) are deployment
+  concerns recorded when implementation starts, not architecture.
+
+## Alternatives considered
+
+- **SwiftUI-native instruments reusing only the data model:** rejected;
+  it forks panel behavior and assurance, exactly what the scene IR
+  exists to prevent.
+- **Wrapping the web client in a WKWebView:** rejected as the product
+  path (kept as a debugging convenience); it inherits browser transport
+  and certificate constraints, cannot embed Communicate natively, and
+  makes hardware input and lifecycle second-class.
+- **Platform networking (Network.framework QUIC) with a Swift session
+  layer:** rejected; it duplicates the wire/session state machines in a
+  second language, the one cost ADR-0002 exists to prevent.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,8 @@ One file per decision, numbered in acceptance order. See
 | [0028](0028-multi-vehicle-and-swarm-coordinator-hosts.md) | Multi-vehicle operation scales from roster attach to swarm aggregation via coordinator hosts | Proposed |
 | [0029](0029-panel-layout-look-plugins.md) | Panels, layout, and look are data-driven plugins over the scene and state contracts | Proposed |
 | [0030](0030-communicate-navdata-provisioning.md) | The host consumes aeronautical navdata through Communicate's cycle-dated snapshot surface | Proposed |
+| [0031](0031-nav-guidance-telemetry-display.md) | Navigation guidance rides telemetry as its own stamped role; deviation scaling is display policy | Proposed |
+| [0032](0032-ipad-native-client-shared-cores.md) | The iPad client is a thin native shell over the same Rust cores the web client runs as wasm | Proposed |
 
 ## Provenance
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,10 +22,21 @@ One file per decision, numbered in acceptance order. See
 | [0013](0013-interactive-and-accelerated-sessions.md) | Single-vehicle operation and horizontally scalable accelerated training | Accepted |
 | [0014](0014-protobuf-wire-schema.md) | Protobuf as the wire-schema source of truth | Accepted |
 | [0015](0015-workspace-quality-gates.md) | Workspace-enforced quality gates | Accepted |
-| [0016](0016-codec-pluggable-media-plane.md) | Codec-pluggable media plane; the control core never sees the codec | Accepted |
+| [0016](0016-codec-pluggable-media-plane.md) | The media plane is codec-pluggable; the control core never sees the codec | Accepted |
 | [0017](0017-instrument-display-runtime.md) | Instrument display runtime as a no_std sans-IO crate family emitting a versioned scene-command IR | Accepted |
 | [0018](0018-avionics-telemetry-and-aviate-adapter.md) | Avionics state rides telemetry additively; Aviate joins through a MAVLink adapter | Accepted |
 | [0019](0019-pluggable-vehicle-link-shm-first.md) | Vehicle links are pluggable below the adapter; co-located SITL binds shared memory | Accepted |
+| [0020](0020-video-capture-identity-and-clock-mapping.md) | Video frames carry a capture identity and an explicit clock mapping | Accepted |
+| [0021](0021-simulator-camera-calibration-contract.md) | Versioned, hashed simulator camera/design-eye calibration | Accepted |
+| [0022](0022-geospatial-projection-availability-contract.md) | Transport-independent geospatial, projection, and availability contract | Accepted |
+| [0023](0023-vehicle-side-decomposition-fc-navigate-communicate.md) | Vehicle-side decomposition: flight control, Navigate, and Communicate behind typed contracts | Proposed |
+| [0024](0024-navigation-authority-boundary.md) | Control-grade estimation stays with the flight controller; Navigate owns the global solution and guidance | Proposed |
+| [0025](0025-client-optional-operation-automation-principals.md) | Client-optional operation: mission execution and agents are automation-class principals | Proposed |
+| [0026](0026-host-capability-profiles.md) | Client posture follows discovered host capability: full-authority, data-gateway, or embedded | Proposed |
+| [0027](0027-optional-coordination-server.md) | Optional coordination server: identity, rendezvous, and entitlements — never the session data plane | Proposed |
+| [0028](0028-multi-vehicle-and-swarm-coordinator-hosts.md) | Multi-vehicle operation scales from roster attach to swarm aggregation via coordinator hosts | Proposed |
+| [0029](0029-panel-layout-look-plugins.md) | Panels, layout, and look are data-driven plugins over the scene and state contracts | Proposed |
+| [0030](0030-communicate-navdata-provisioning.md) | The host consumes aeronautical navdata through Communicate's cycle-dated snapshot surface | Proposed |
 
 ## Provenance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,34 +1,49 @@
 # Pilotage architecture overview
 
 Pilotage is a Rust-first, engine-independent platform for low-latency control,
-supervision, simulation, and training of maritime, aerial, and terrestrial vehicles.
-This document is the orientation map; the [ADRs](adr/README.md) are the authoritative
-decisions.
+supervision, simulation, and training of maritime, aerial, and terrestrial
+vehicles. The target system spans a vehicle-side **host** that orchestrates
+flight control (Aviate, PX4), navigation (Navigate), and communication
+(Communicate); **operator clients** ranging from a full control terminal to an
+EFB-style preflight tool; and an optional **coordination server** for
+identity, rendezvous, and entitlements. This document is the orientation map;
+the [ADRs](adr/README.md) are the authoritative decisions.
 
-## System shape (v1 hosted deployment)
+## System shape (target)
 
 ```text
-                 Passkey / WebAuthn
-                        |
-                        v
-              Identity & admission service ──> short-lived session capability
-                        |
-             session bootstrap (HTTPS)
-                        |
-   Browser client <═ WebTransport (QUIC) ═> Session host
-   (wasm core +        │                     ├─ authority engine (scoped leases, generations)
-    browser ports)     │                     ├─ Gazebo + renderer capture
-                       │                     ├─ vehicle adapter
-      video ◄──────────┤                     └─ telemetry / control / media endpoint
-      telemetry ◄──────┤
-      control ─────────►
-      authority events ◄──►
+               Optional coordination server (ADR-0027)
+     identity/admission · host registry · rendezvous · entitlements
+    (never carries session data; optional — local deployments need none)
+               |                                |
+        HTTPS bootstrap                registration/signaling
+               |                                |
+   Operator client(s) <═ WebTransport (QUIC) ═> Pilotage host
+   (web / iPadOS /      │  direct; opt-in       ├─ authority engine (leases, generations)
+    native; plugin      │  separately           ├─ vehicle adapter ── FC (Aviate | PX4)
+    panels/layout,      │  deployed relay       ├─ Navigate: fusion, FPL, guidance, EGPWS
+    ADR-0029; EFB or    │                       ├─ Communicate: advisory context
+    terminal posture    │                       └─ telemetry/control/media/advisory
+    by discovery,       │
+    ADR-0026)           │
+      video ◄───────────┤
+      telemetry ◄───────┤
+      advisory ◄────────┤
+      control ──────────►
+      authority events ◄►
 ```
 
-The same two deployables run a local demonstration over loopback or LAN with no
-special integration path. Peer-hosted simulators and real-vehicle gateways are future
-session hosts behind the same contracts; central services stay optional
-([ADR-0004](adr/0004-host-oriented-topology.md)).
+Clients and hosts are not one-to-one: several operators may hold different
+scopes on one vehicle, one client may attach a roster of vehicles, and a
+coordinator host aggregates a swarm behind ordinary scopes
+([ADR-0028](adr/0028-multi-vehicle-and-swarm-coordinator-hosts.md)). The host
+flies with no client attached: the mission executor is an automation-class
+principal under the same authority machinery
+([ADR-0025](adr/0025-client-optional-operation-automation-principals.md)).
+
+The v1 hosted deployment ships two deployables (identity/signaling service +
+session host) and runs the same binaries over loopback or LAN with no special
+integration path ([ADR-0004](adr/0004-host-oriented-topology.md)).
 
 ## The five planes
 
@@ -36,12 +51,22 @@ session hosts behind the same contracts; central services stay optional
 |---|---|---|
 | Identity & admission | Passkeys, membership, session capabilities | [ADR-0003](adr/0003-separate-responsibility-planes.md), [ADR-0006](adr/0006-capability-auth-scoped-leases-fencing.md) |
 | Authority | Scoped leases, fencing generations, handover/override state machines | [ADR-0006](adr/0006-capability-auth-scoped-leases-fencing.md), [ADR-0010](adr/0010-authority-state-machines.md) |
-| Real-time data | Control frames, fast telemetry, authority events, bulk config | [ADR-0005](adr/0005-webtransport-primary-transport.md), [ADR-0011](adr/0011-message-classes-and-channel-semantics.md) |
-| Media | Capture, encode, delivery, adaptation, timing correlation | [ADR-0005](adr/0005-webtransport-primary-transport.md) |
+| Real-time data | Control frames, fast telemetry, authority events, bulk config, advisory context | [ADR-0005](adr/0005-webtransport-primary-transport.md), [ADR-0011](adr/0011-message-classes-and-channel-semantics.md), [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md) |
+| Media | Capture, encode, delivery, adaptation, timing correlation | [ADR-0005](adr/0005-webtransport-primary-transport.md), [ADR-0016](adr/0016-codec-pluggable-media-plane.md) |
 | Session host | Simulator/vehicle gateway, adapter, real-time endpoint | [ADR-0004](adr/0004-host-oriented-topology.md), [ADR-0008](adr/0008-engine-independent-adapter-boundary.md) |
 
-Planes are contract boundaries; v1 ships them as two deployables (identity/signaling
-service + session host).
+Planes are contract boundaries; deployables are a deployment decision.
+
+## System components
+
+| Component | Role | Decided in |
+|---|---|---|
+| Flight control (Aviate first; PX4 via adapter) | Control-grade estimation, stabilization, actuation | [ADR-0008](adr/0008-engine-independent-adapter-boundary.md), [ADR-0018](adr/0018-avionics-telemetry-and-aviate-adapter.md), [ADR-0024](adr/0024-navigation-authority-boundary.md) |
+| Navigate (sibling repository) | Multi-sensor fusion, integrity, flight-plan execution, guidance, terrain awareness | [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0024](adr/0024-navigation-authority-boundary.md) |
+| Communicate (aerocontext, repository `v99n62`) | Provenance-tracked advisory aeronautical context; AI-agent surface | [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0025](adr/0025-client-optional-operation-automation-principals.md) |
+| Pilotage host | Component orchestration + session/authority/media endpoint | [ADR-0003](adr/0003-separate-responsibility-planes.md), [ADR-0004](adr/0004-host-oriented-topology.md), [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md) |
+| Operator client | Control terminal ↔ EFB by discovered capability; plugin displays | [ADR-0026](adr/0026-host-capability-profiles.md), [ADR-0029](adr/0029-panel-layout-look-plugins.md) |
+| Coordination server (optional) | Identity, host registry, rendezvous, entitlement-gated data services | [ADR-0027](adr/0027-optional-coordination-server.md) |
 
 ## Load-bearing principles
 
@@ -62,6 +87,16 @@ service + session host).
 5. **Schema-first protocol** ([ADR-0014](adr/0014-protobuf-wire-schema.md)):
    `schemas/` (protobuf) is the source of truth; hosts and clients evolve
    independently under mechanical breaking-change detection.
+6. **Advisory and measurement never blur** ([ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md)):
+   measurements ride stamped, coherence-gated telemetry
+   ([ADR-0018](adr/0018-avionics-telemetry-and-aviate-adapter.md)); advisory
+   context rides provenance- and freshness-tracked classes; neither is ever
+   presented as the other.
+7. **One authority machinery for every commander**
+   ([ADR-0025](adr/0025-client-optional-operation-automation-principals.md)):
+   humans, the mission executor, coordinators, and AI agents are all fenced
+   principals under the same leases, watchdogs, and audit — no privileged
+   side door.
 
 ## Implementation increments
 
@@ -75,6 +110,18 @@ service + session host).
 | 5 | Override and failure: emergency override, revocation, link-loss policy | Previous generation ineffective immediately; configured failover executes |
 | 6 | Peer-host preparation: self-contained host package, registration, direct + relay paths | A non-platform-operated host creates a session without central simulator scheduling |
 | 7 | Recording and replay: structured authority/timing log, deterministic replay | A recorded session reproduces authority transitions and applied-control ordering |
+
+### Next increments (component build-out)
+
+Increment 8 is committed as the next slice; the order beyond it is indicative.
+
+| # | Deliverable | Acceptance signal |
+|---|---|---|
+| 8 | Navigate skeleton: new repository with a sans-IO fusion/flight-plan core; flight-plan execution flies Aviate SITL through the FC's declared setpoint surface as an automation-class principal ([ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0024](adr/0024-navigation-authority-boundary.md), [ADR-0025](adr/0025-client-optional-operation-automation-principals.md)); the FC-side guidance command-surface RFC below is a prerequisite | A preloaded plan flies headless in SITL with no client attached; a joining client sees automation as holder and takes over via the authority machinery |
+| 9 | Authority completion: handover/override wire vocabulary, identity/admission service, observer admission | Two operators transfer a scope with positive confirmation; a supervisor overrides; a monitor observes with no grantable scopes |
+| 10 | EFB slice: client embeds Communicate cores; briefing on a live map; data-gateway host profile ([ADR-0026](adr/0026-host-capability-profiles.md)) | Preflight brief and pack-for-flight on a client with no host process; the same client is a full terminal against a full-authority host |
+| 11 | Coordination server: registry + rendezvous + entitlement gate ([ADR-0027](adr/0027-optional-coordination-server.md)) | A WAN session forms behind NAT with no session data transiting the server |
+| 12 | Coordinator host: aggregate scopes decomposed over member hosts ([ADR-0028](adr/0028-multi-vehicle-and-swarm-coordinator-hosts.md)) | A swarm command reaches members under end-to-end fencing; displacing the coordinator on one member affects exactly that member |
 
 ## Backlog
 
@@ -90,18 +137,35 @@ service + session host).
 - p95/p99 closed-loop latency targets under specified network profiles (after
   increment 2 measurements).
 - Expected simultaneous operators and spectators per host (increment 3).
-- Emergency-override authority-class matrix and takeover-veto policy (increment 5).
+- Emergency-override authority-class matrix and takeover-veto policy, now
+  including automation, agent, and aggregate-scope rows (increments 5, 8, 12).
 - Host registration and trust model; threat model for malicious hosts, clients, and
   compromised tokens (increment 6).
 - Recording retention and privacy policy (increment 7).
+- Aiding-observation schema RFC with the Aviate side — frames, covariance,
+  integrity terms, source composition ([ADR-0024](adr/0024-navigation-authority-boundary.md))
+  — before any aiding lands (increment 8 exit).
+- Guidance command-surface RFC with the Aviate side: position/velocity
+  setpoint ingress mapped into the FC command path, and deviation-setpoint
+  carriage and consumption defined
+  ([ADR-0024](adr/0024-navigation-authority-boundary.md)) (increment 8
+  prerequisite).
+- Loss-of-communication procedure configuration: format, provenance, and
+  selection rules ([ADR-0025](adr/0025-client-optional-operation-automation-principals.md))
+  (increment 8).
+- Panel descriptor and extensible state-group contract design, and the
+  safety-fixed vs skinnable attribute set
+  ([ADR-0029](adr/0029-panel-layout-look-plugins.md)) — before plugin work
+  begins.
 
 ### P1 — design now, implement after the core path is stable
 
-WebTransport for control/telemetry; multiple camera sources and picture-in-picture;
+Multiple camera sources and picture-in-picture;
 spectator stream fan-out (host- or relay-side replication); instructor and supervisory modes; organization
 policy and temporary guests; automation-assisted blended control; signed online
 device-registry updates; repeatable network-impairment benchmark harness; peer-host
-update and attestation.
+update and attestation; FIS-B/ADS-B providers in Communicate; host-to-host
+collaboration behaviors over the reserved coordinator seam.
 
 ### P2 — preserve compatibility, defer implementation
 
@@ -119,4 +183,8 @@ advanced SVC and spectator quality tiers; tournament/adjudication tooling.
 | Simulator | Tick delay, renderer slowdown, adapter restart, vehicle respawn, dynamic camera addition |
 | Host lifecycle | Registration, update, reconnect, crash recovery, peer-host trust and revocation |
 | Link loss | Per-vehicle configuration, default inheritance, stale-input hold limit, neutralization or automation transition |
+| Navigation | Fusion integrity honesty, single-source degradation, FC/Navigate divergence display, aiding rejection paths |
+| Autonomy | Headless plan execution, link-loss automation engagement, human takeover and give-back, stalled-automation fencing |
+| Multi-vehicle | Roster attach, coordinator displacement per member, member link-loss independence, media keyed by session |
+| Capability profiles | Host-absent bootstrap, data-gateway honesty (zero actuator scopes), EFB↔terminal continuity |
 | Observability | Correlation from client sample through simulator application to resulting telemetry/video |

--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: e3f507a2e6b054c3e8e7c97f5413beef9094e2be
+config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:e3f507a2e6b054c3e8e7c97f5413beef9094e2be
+run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
 outcome: pass
 summary:
 test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-sink.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-sink.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture sink round trip
 command: cargo test -p loopback-probe capture::
-config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
+config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
 outcome: pass
 summary:
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.00s
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 56 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture projection
 command: cargo test -p loopback-probe telemetry::
-config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
+config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
 outcome: pass
 summary:
-test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 0.00s
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/host-wire.run.txt
+++ b/docs/link/evidence-artifacts/link04/host-wire.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: host wire-mapping
 command: cargo test -p pilotage-session-host --lib engine_actor::telemetry
-config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
+config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
 outcome: pass
 summary:
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 0.00s
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 102 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link05/authz-regime.run.txt
+++ b/docs/link/evidence-artifacts/link05/authz-regime.run.txt
@@ -2,12 +2,12 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: browser avionics-ingress authorization regime
 command: node clients/web/telemetry-ingress.test.mjs
-config-digest: f75f99d46eed66cae2384b303029e6b84b5f9ed7
+config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
 tool-version: node v26.5.0
-run-id: local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
 outcome: pass
 summary:
-  28 browser ingress checks passed; LINK-AUTHZ-005 cases:
+  33 browser ingress checks passed; LINK-AUTHZ-005 cases:
   ok - testInterleavedLaneWithinBudgetKeepsItsAuthorization
   ok - testNumericBeyondSkewBudgetIsNotAuthorized
   ok - testDuplicateStatusDowngradeIsNotReversibleByANewerNumeric

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -195,45 +195,45 @@ attr outcome pass
 node RESULT-LINK-WIRE verification-result
 title host wire-mapping suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::telemetry
-attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:f8de90fe18e5ed843e14f8819c039f6b1a01240a
 attr artifact docs/link/evidence-artifacts/link04/host-wire.run.txt
-attr output-digest sha256:6a78076e7d8bb2d263dc2d5f3993ed248e13a70ef96288c671266be44f7895d7
-attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr output-digest sha256:ccd75759791331c24955a90dca2602a016dbb8df04d6110336d39e25db3700e1
+attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
 attr outcome pass
 
 node RESULT-LINK-CAPTURE verification-result
 title loopback-probe capture projection suite — recorded pass
 attr command cargo test -p loopback-probe telemetry::
-attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:4cc1cc78aea89d713d4e7c12fd770e0cbc173267
+attr source-digest git-blob:5e51d88198b070b2f19e1fe168a1644a9060a574
 attr artifact docs/link/evidence-artifacts/link04/capture.run.txt
-attr output-digest sha256:f08379106c9914561729e90c046d090cb7b9717f184c0f8e46961a6f0c049f90
-attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr output-digest sha256:55a109d3ec0ec250f65412bea91472c4c3fba210ed7e5744f1cc1d2898d00ebd
+attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest e3f507a2e6b054c3e8e7c97f5413beef9094e2be
+attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:df617d3617a8686db56c1600409b7a0856c31907
+attr source-digest git-blob:2e27b07a8d496d35161273285223db8e56c0904f
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:8e066de0a9cf43a34f0285ac52518d656c1c4fc5148f1ae13aa75db96a6180e1
-attr run-id local:e3f507a2e6b054c3e8e7c97f5413beef9094e2be
+attr output-digest sha256:1c6a5f8b789a6ed2033f4f75e858c974b2a7e14d3a07bb4854f7a9516a7a5f53
+attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
 title loopback-probe capture sink suite — recorded pass
 attr command cargo test -p loopback-probe capture::
-attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:fab4a30681c88e02875c7892bec1d7c4f094facb
+attr source-digest git-blob:08a2aa127c1c55b63da7730fbd8e264481c66a93
 attr artifact docs/link/evidence-artifacts/link04/capture-sink.run.txt
-attr output-digest sha256:72db92aa7f96ca6e0b8f7d8dc6f42f10cc0a4617dec4459e25e86446971b655f
-attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr output-digest sha256:287ebc97e371b7da50674d2a7c53c2973a7ff099e1865ac74a9145a975a29b5e
+attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -241,12 +241,12 @@ attr outcome pass
 node RESULT-LINK-AUTHZ verification-result
 title browser authorization-regime suite — recorded pass
 attr command node clients/web/telemetry-ingress.test.mjs
-attr config-digest f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
 attr tool-version node v26.5.0
-attr source-digest git-blob:5debe53552fbab04c08f9d8cff891541f3cf9c13
+attr source-digest git-blob:84b54f0bdae56a7baf99bda938113e10a2f6d435
 attr artifact docs/link/evidence-artifacts/link05/authz-regime.run.txt
-attr output-digest sha256:c41a448821b4654cabecc501fadb180266bc5a78156d299870ccbc55eee82567
-attr run-id local:f75f99d46eed66cae2384b303029e6b84b5f9ed7
+attr output-digest sha256:dc188d5c25dbafad856d593564eb0885af3d95a41b4fa5e867c8fe907fca4518
+attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
 attr outcome pass
 
 node CFG-LINK-EXTRACTION configuration-item
@@ -258,20 +258,20 @@ attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
-attr commit f75f99d46eed66cae2384b303029e6b84b5f9ed7
-attr tree 9b6e82ce4092a7fa8190e159d9626492462642e4
+attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
+attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
 
 node CFG-LINK-PROBE-V3 configuration-item
 title committed code baseline for the multiplexed-video receiver result
 attr scm git
-attr commit e3f507a2e6b054c3e8e7c97f5413beef9094e2be
-attr tree b8987caac4d291894ca5d09fa2a67fd03e222c9a
+attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
+attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)
 attr scm git
-attr commit f75f99d46eed66cae2384b303029e6b84b5f9ed7
-attr tree 9b6e82ce4092a7fa8190e159d9626492462642e4
+attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
+attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
 
 node TOOL-LINK-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified

--- a/docs/mission/README.md
+++ b/docs/mission/README.md
@@ -17,12 +17,21 @@ PILOTAGE_MISSION_ROUTE=fixture cargo xtask sim --fc aviate-gz
 ```
 
 `PILOTAGE_MISSION_ROUTE` enables the executor (`fixture` selects the
-built-in demo route through the fixture snapshot; any other value is a
-route string over the store configured by `PILOTAGE_MISSION_NAVDATA` +
-`PILOTAGE_MISSION_DATE`). The host logs the pack-for-flight record
-(route, cycle, digest, fixture flag) at startup and the mission state
+built-in demo route). Any other value is a route string expanded against
+the configured navdata: by default the fixture snapshot (so custom
+routes must name fixture idents), or a real synced store when
+`PILOTAGE_MISSION_NAVDATA` points at one, with `PILOTAGE_MISSION_DATE`
+selecting the cycle. The host logs the pack-for-flight record (route,
+cycle, digest, fixture flag) at startup and the mission state
 transitions and counters as it flies. A browser joining the session
 mid-flight sees automation holding `vehicle.motion`.
+
+Terminal behavior: after the final waypoint captures (`PlanComplete`)
+the executor holds a zero-velocity hover — the adapters' brake-then-hold
+takes over — with the vehicle armed and the motion lease held
+indefinitely, and navigation guidance goes absent (the HSI removes the
+needle). Landing, disarm, and lease-release policy at mission end is
+part of the failure-detection scope tracked in issue #245.
 
 Run records in this directory are structured captures of acceptance
 flights: the pack-for-flight line, state transitions, terminal counters,

--- a/docs/mission/README.md
+++ b/docs/mission/README.md
@@ -1,0 +1,29 @@
+# Mission executor — demo runs
+
+The in-process mission executor ([ADR-0025](../adr/0025-client-optional-operation-automation-principals.md))
+flies a route built from Communicate-provisioned navdata
+([ADR-0030](../adr/0030-communicate-navdata-provisioning.md)) through the
+session host's fenced authority path: it attaches as an automation-class
+local principal (hello → welcome → profile activation → lease → typed
+arm → typed velocity intents), with the same fencing, watchdog, and
+rejection accounting as any remote client. Navigate supplies fusion,
+plan sequencing, and velocity guidance; the FC never sees anything but
+ordinary adapter setpoints.
+
+Run it against a live SITL session:
+
+```sh
+PILOTAGE_MISSION_ROUTE=fixture cargo xtask sim --fc aviate-gz
+```
+
+`PILOTAGE_MISSION_ROUTE` enables the executor (`fixture` selects the
+built-in demo route through the fixture snapshot; any other value is a
+route string over the store configured by `PILOTAGE_MISSION_NAVDATA` +
+`PILOTAGE_MISSION_DATE`). The host logs the pack-for-flight record
+(route, cycle, digest, fixture flag) at startup and the mission state
+transitions and counters as it flies. A browser joining the session
+mid-flight sees automation holding `vehicle.motion`.
+
+Run records in this directory are structured captures of acceptance
+flights: the pack-for-flight line, state transitions, terminal counters,
+and the gate context they flew under.

--- a/docs/mission/mission01-fixture-aviate.run.txt
+++ b/docs/mission/mission01-fixture-aviate.run.txt
@@ -1,0 +1,42 @@
+MISSION-01 acceptance flight — fixture navdata, Aviate SITL, headless
+=====================================================================
+
+Command: PILOTAGE_MISSION_ROUTE=fixture RUST_LOG=info cargo xtask sim --fc aviate-gz
+Stack: Gazebo (aviate x500 flightdeck) + Aviate SITL FC + pilotage-session-host
+       (aviate adapter, shm telemetry) + in-process mission executor.
+No client attached at any point. Navigate pin dcee4e14e93d8fccb0a9f89e4be38ab
+c0804861a; aerocontext 0.4.5 (crates.io).
+
+Chain exercised end to end:
+  Communicate fixture blob (real .acnav container, sha256-verified decode)
+  -> route "DEMOA V901 DEMOC" expanded via airway V901 to DEMOA DEMOB DEMOC
+  -> navigate FlightPlan (degrees->radians once, ADR-0030 unit boundary)
+  -> automation-class local principal (hello/welcome/activation/lease,
+     ClientKey u64::MAX, fenced generation 1, ADR-0025 no-bypass path)
+  -> typed Arm via ControlActionCommand (accepted, action_id 1)
+  -> Navigate fusion (sim-truth-derived GNSS, SimulationTruth role only)
+  -> guide_velocity -> BodyFrd velocity intents within advertised limits
+     (tightened to 2.5 / 1.0 / 0.8)
+  -> aviate adapter -> Aviate SITL (armed 10:13:33, "Armed successfully").
+
+Host log (ANSI-stripped, mission lines verbatim):
+
+2026-07-29T10:13:33.234596Z INFO mission packed for flight route=DEMOA V901 DEMOC waypoints=3 expanded=["DEMOA", "DEMOB", "DEMOC"] authority=faa-nasr effective_on=2026-01-22 sha256=74952060bf48e49f3176de552610543bdc9add6fdaf8b8985283898c2dd18ff2 fixture=true
+2026-07-29T10:13:33.370978Z INFO mission engine ready under advertised limits route=DEMOA V901 DEMOC max_horizontal_mps=2.5 max_vertical_mps=1.0 max_yaw_rate_rps=0.8
+2026-07-29T10:13:33.371013Z INFO control profile activation accepted client=18446744073709551615 profile=automation.mission profile_revision=1 activation_revision=1
+2026-07-29T10:13:33.371029Z INFO mission motion lease granted generation=1
+2026-07-29T10:13:33.386665Z INFO mission event event=ArmRequested { action_id: 1 }
+2026-07-29T10:13:33.386818Z INFO mission action result action=Arm accepted=true
+2026-07-29T10:13:33.437121Z INFO mission event event=ClimbStarted
+2026-07-29T10:13:51.635548Z INFO mission event event=EnrouteStarted
+2026-07-29T10:14:03.785534Z INFO mission event event=LegAdvanced { to_index: 1 }
+2026-07-29T10:15:20.584060Z INFO mission event event=LegAdvanced { to_index: 2 }
+2026-07-29T10:16:02.133766Z INFO mission complete
+
+Timeline: arm+climb 18 s, enroute 2 m 11 s, wheels-up to complete 2 m 29 s.
+Zero GuidanceRefused events, zero FrameRejected lines in the host log for
+the mission principal over the full flight.
+
+Gate context: cargo fmt --check, clippy --all-targets -D warnings, and
+cargo test --all-targets (50 test binaries) all green at flight time.
+SIM / NOT FOR FLIGHT — fixture navdata, sim-truth-derived GNSS.

--- a/hosts/session-host/Cargo.toml
+++ b/hosts/session-host/Cargo.toml
@@ -20,7 +20,12 @@ pilotage-adapter-reference = { workspace = true }
 pilotage-adapter-gazebo = { workspace = true }
 pilotage-adapter-aviate = { workspace = true }
 pilotage-adapter-px4 = { workspace = true }
+pilotage-mission = { workspace = true }
 pilotage-timing = { workspace = true }
+navigate-contract = { workspace = true }
+aerocontext-core = { workspace = true }
+aerocontext-navdata = { workspace = true }
+chrono = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "time", "sync", "net"] }
 wtransport = { workspace = true, features = ["quinn"] }

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -115,6 +115,15 @@ pub enum HostError {
         #[source]
         source: std::num::ParseFloatError,
     },
+    /// `PILOTAGE_MISSION_CRUISE_HEIGHT` parsed but cannot be flown: a
+    /// negative height would plan every waypoint below the launch
+    /// elevation, and a non-finite one disables every altitude
+    /// comparison downstream.
+    #[error("PILOTAGE_MISSION_CRUISE_HEIGHT must be a finite height >= 0 m, got {height}")]
+    MissionCruiseHeightRange {
+        /// The rejected height in meters.
+        height: f64,
+    },
     /// Loading or selecting the mission navdata snapshot failed.
     #[error("failed to load mission navdata: {0}")]
     MissionNavdata(#[source] crate::mission_navdata::NavdataError),

--- a/hosts/session-host/src/error.rs
+++ b/hosts/session-host/src/error.rs
@@ -77,4 +77,50 @@ pub enum HostError {
     /// Starting the PX4 MAVLink link failed.
     #[error("failed to start the PX4 adapter: {0}")]
     Px4Adapter(#[source] pilotage_adapter_px4::Px4AdapterError),
+    /// A `PILOTAGE_MISSION_*` variable could not be decoded as UTF-8.
+    #[error("{variable} is not valid UTF-8: {source}")]
+    MissionVarEncoding {
+        /// The environment variable being parsed.
+        variable: &'static str,
+        /// The environment decoding failure.
+        #[source]
+        source: std::env::VarError,
+    },
+    /// `PILOTAGE_MISSION_ANCHOR` was not `lat_deg,lon_deg,alt_m`.
+    #[error("invalid PILOTAGE_MISSION_ANCHOR value {value:?} (expected \"lat_deg,lon_deg,alt_m\")")]
+    MissionAnchor {
+        /// The rejected value.
+        value: String,
+    },
+    /// `PILOTAGE_MISSION_DATE` did not parse as an ISO calendar date.
+    #[error("invalid PILOTAGE_MISSION_DATE value {value:?} (expected YYYY-MM-DD): {source}")]
+    MissionDate {
+        /// The rejected value.
+        value: String,
+        /// The date parse failure.
+        #[source]
+        source: chrono::ParseError,
+    },
+    /// A navdata store needs an explicit flight date to select a cycle;
+    /// guessing "today" would silently change which data a flight is
+    /// packed against (ADR-0030).
+    #[error("PILOTAGE_MISSION_DATE is required when PILOTAGE_MISSION_NAVDATA is a store directory")]
+    MissionDateMissing,
+    /// `PILOTAGE_MISSION_CRUISE_HEIGHT` was not a number.
+    #[error("invalid PILOTAGE_MISSION_CRUISE_HEIGHT value {value:?}: {source}")]
+    MissionCruiseHeight {
+        /// The rejected value.
+        value: String,
+        /// The float parse failure.
+        #[source]
+        source: std::num::ParseFloatError,
+    },
+    /// Loading or selecting the mission navdata snapshot failed.
+    #[error("failed to load mission navdata: {0}")]
+    MissionNavdata(#[source] crate::mission_navdata::NavdataError),
+    /// The mission plan did not build from the loaded snapshot and route.
+    /// Boxed: the build error carries route/cycle context and would
+    /// otherwise dominate every `Result<_, HostError>` on the startup path.
+    #[error("failed to build the mission plan: {0}")]
+    MissionBuild(#[source] Box<pilotage_mission::MissionBuildError>),
 }

--- a/hosts/session-host/src/lib.rs
+++ b/hosts/session-host/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod cli;
 pub mod error;
+pub mod mission_navdata;
 pub mod output;
 pub mod runtime;
 pub mod tls_identity;

--- a/hosts/session-host/src/mission_navdata.rs
+++ b/hosts/session-host/src/mission_navdata.rs
@@ -1,0 +1,210 @@
+//! Mission navdata loading at the binary edge (ADR-0030): the one place a
+//! snapshot enters the process, always through the versioned blob
+//! container's decode-and-verify path.
+//!
+//! Fixture mode packs the generated demo snapshot through the real
+//! container and decodes it back, so the demo travels exactly the road
+//! published data does. Store mode scans a directory of published
+//! `*/*.acnav` blobs, keeps the cycles whose effectivity covers the
+//! flight date, prefers the `faa-nasr` authority, and lets the newest
+//! effective date win.
+
+use std::path::{Path, PathBuf};
+
+use aerocontext_core::NavDataSnapshot;
+use aerocontext_navdata::blob;
+use chrono::NaiveDate;
+use pilotage_mission::{MissionBuildError, SnapshotProvenance, decode_snapshot};
+use tracing::info;
+
+use crate::runtime::{MissionNavdataSource, MissionOptions};
+
+/// The authority slug preferred when a store holds several covering cycles.
+const PREFERRED_AUTHORITY: &str = "faa-nasr";
+
+/// Why the mission navdata could not be loaded or selected.
+#[derive(Debug, thiserror::Error)]
+pub enum NavdataError {
+    /// The fixture snapshot could not be generated or round-tripped.
+    /// Boxed: the build error carries route/cycle context and would
+    /// otherwise dominate every `Result` on the startup path.
+    #[error("fixture navdata failed: {0}")]
+    Fixture(#[source] Box<MissionBuildError>),
+    /// A store directory or blob file could not be read.
+    #[error("failed to read {path}: {source}")]
+    Io {
+        /// The path that failed.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A `.acnav` blob failed the container's verify-and-decode.
+    #[error("navdata blob {path} rejected: {source}")]
+    Blob {
+        /// The rejected blob's path.
+        path: PathBuf,
+        /// The container failure.
+        #[source]
+        source: Box<blob::BlobError>,
+    },
+    /// The selected blob decoded at inspect time but not at load time.
+    #[error("navdata blob {path} failed to decode: {source}")]
+    Decode {
+        /// The failing blob's path.
+        path: PathBuf,
+        /// The decode failure.
+        #[source]
+        source: Box<MissionBuildError>,
+    },
+    /// No blob in the store covers the flight date.
+    #[error("no cycle in store {store} covers {date}")]
+    NoCoveringCycle {
+        /// The scanned store directory.
+        store: PathBuf,
+        /// The uncovered flight date.
+        date: NaiveDate,
+    },
+}
+
+/// A decoded, provenance-bound snapshot ready for mission planning.
+#[derive(Debug, Clone)]
+pub struct LoadedNavdata {
+    /// The decoded snapshot.
+    pub snapshot: NavDataSnapshot,
+    /// The blob-verified provenance record (ADR-0030).
+    pub provenance: SnapshotProvenance,
+}
+
+/// Loads the snapshot the mission options name.
+///
+/// # Errors
+///
+/// Returns [`NavdataError`] when the fixture cannot be generated, the
+/// store cannot be read, a blob fails verification, or no cycle covers
+/// the flight date.
+pub fn load(options: &MissionOptions) -> Result<LoadedNavdata, NavdataError> {
+    match &options.navdata {
+        MissionNavdataSource::Fixture => {
+            if let Some(date) = options.date {
+                info!(%date, "PILOTAGE_MISSION_DATE ignored: the fixture cycle is fixed");
+            }
+            let blob = pilotage_mission::fixture::demo_blob(options.anchor)
+                .map_err(|source| NavdataError::Fixture(Box::new(source)))?;
+            let (snapshot, provenance) = decode_snapshot(&blob, true)
+                .map_err(|source| NavdataError::Fixture(Box::new(source)))?;
+            Ok(LoadedNavdata {
+                snapshot,
+                provenance,
+            })
+        }
+        MissionNavdataSource::Store(store) => {
+            // Parse enforcement: a store always carries a flight date.
+            let date = options.date.unwrap_or(NaiveDate::MIN);
+            load_from_store(store, date)
+        }
+    }
+}
+
+/// One store blob whose effectivity covers the flight date.
+struct Candidate {
+    path: PathBuf,
+    authority: String,
+    effective_on: NaiveDate,
+    bytes: Vec<u8>,
+}
+
+/// Scans `{store}/*/*.acnav`, keeps cycles covering `date`, prefers
+/// [`PREFERRED_AUTHORITY`], newest `effective_on` winning, and decodes the
+/// selected blob through the same verify path the fixture uses.
+fn load_from_store(store: &Path, date: NaiveDate) -> Result<LoadedNavdata, NavdataError> {
+    let mut best: Option<Candidate> = None;
+    for path in store_blob_paths(store)? {
+        let bytes = std::fs::read(&path).map_err(|source| NavdataError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let info = blob::inspect(&bytes).map_err(|source| NavdataError::Blob {
+            path: path.clone(),
+            source: Box::new(source),
+        })?;
+        let cycle = &info.snapshot.cycle;
+        if !(cycle.effective_on <= date && date < cycle.next_effective_on) {
+            continue;
+        }
+        let candidate = Candidate {
+            path,
+            authority: cycle.authority.slug().to_owned(),
+            effective_on: cycle.effective_on,
+            bytes,
+        };
+        if best
+            .as_ref()
+            .is_none_or(|current| candidate_outranks(&candidate, current))
+        {
+            best = Some(candidate);
+        }
+    }
+    let Some(chosen) = best else {
+        return Err(NavdataError::NoCoveringCycle {
+            store: store.to_path_buf(),
+            date,
+        });
+    };
+    info!(path = %chosen.path.display(), authority = %chosen.authority,
+        effective_on = %chosen.effective_on, "mission navdata selected from store");
+    let (snapshot, provenance) =
+        decode_snapshot(&chosen.bytes, false).map_err(|source| NavdataError::Decode {
+            path: chosen.path,
+            source: Box::new(source),
+        })?;
+    Ok(LoadedNavdata {
+        snapshot,
+        provenance,
+    })
+}
+
+/// Preferred-authority first, then the newest effective date.
+fn candidate_outranks(candidate: &Candidate, current: &Candidate) -> bool {
+    let candidate_preferred = candidate.authority == PREFERRED_AUTHORITY;
+    let current_preferred = current.authority == PREFERRED_AUTHORITY;
+    if candidate_preferred != current_preferred {
+        return candidate_preferred;
+    }
+    candidate.effective_on > current.effective_on
+}
+
+/// Every `{store}/*/*.acnav` path, in directory-listing order.
+fn store_blob_paths(store: &Path) -> Result<Vec<PathBuf>, NavdataError> {
+    let read_dir = |path: &Path| {
+        std::fs::read_dir(path).map_err(|source| NavdataError::Io {
+            path: path.to_path_buf(),
+            source,
+        })
+    };
+    let mut paths = Vec::new();
+    for entry in read_dir(store)? {
+        let entry = entry.map_err(|source| NavdataError::Io {
+            path: store.to_path_buf(),
+            source,
+        })?;
+        let subdir = entry.path();
+        if !subdir.is_dir() {
+            continue;
+        }
+        for file in read_dir(&subdir)? {
+            let file = file.map_err(|source| NavdataError::Io {
+                path: subdir.clone(),
+                source,
+            })?;
+            let path = file.path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "acnav")
+            {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
+}

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -208,7 +208,12 @@ async fn spawn_host_runtime(
     let mission = match options.mission.take() {
         Some(mission_options) => {
             let plan = automation::prepare(&mission_options)?;
-            Some(automation::spawn_mission_task(&engine_tx, start, plan))
+            Some(automation::spawn_mission_task(
+                &engine_tx,
+                start,
+                plan,
+                matches!(adapter, AdapterKind::Reference),
+            ))
         }
         None => None,
     };

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -19,7 +19,9 @@ mod stream_tag;
 mod wire_codec;
 // The mission rig is exported for the in-process integration test: the
 // same actor/principal wiring the runtime uses, without a transport.
-pub use automation::{AutomationStatus, MissionRig, spawn_reference_mission_rig};
+pub use automation::{
+    AutomationStatus, MissionRig, TelemetryObserver, spawn_reference_mission_rig,
+};
 pub use options::{DEFAULT_MISSION_ANCHOR, MissionNavdataSource, MissionOptions, RuntimeOptions};
 // The envelope encoder is exported for the wire-fixture test: the committed
 // browser fixture must be THIS host's bytes, not a hand-maintained copy.

--- a/hosts/session-host/src/runtime.rs
+++ b/hosts/session-host/src/runtime.rs
@@ -4,6 +4,8 @@
 //!
 //! [`SessionEngine`]: pilotage_session::SessionEngine
 
+mod adapter_launch;
+mod automation;
 mod aviate_profile;
 mod connection;
 mod engine_actor;
@@ -15,9 +17,12 @@ mod registry;
 mod shutdown;
 mod stream_tag;
 mod wire_codec;
+// The mission rig is exported for the in-process integration test: the
+// same actor/principal wiring the runtime uses, without a transport.
+pub use automation::{AutomationStatus, MissionRig, spawn_reference_mission_rig};
+pub use options::{DEFAULT_MISSION_ANCHOR, MissionNavdataSource, MissionOptions, RuntimeOptions};
 // The envelope encoder is exported for the wire-fixture test: the committed
 // browser fixture must be THIS host's bytes, not a hand-maintained copy.
-pub use options::RuntimeOptions;
 pub use wire_codec::encode_envelope_message;
 
 use std::net::SocketAddr;
@@ -119,7 +124,7 @@ fn build_engine<A: VehicleAdapter>(adapter: &A, options: RuntimeOptions) -> Sess
 /// WebTransport endpoint cannot bind, or the Gazebo sidecar bridge cannot be
 /// spawned and connected.
 pub async fn start(port: u16, adapter: AdapterKind) -> Result<RunningHost, HostError> {
-    start_with_options(port, adapter, RuntimeOptions::from_env()).await
+    start_with_options(port, adapter, RuntimeOptions::from_env()?).await
 }
 
 /// [`start`] with explicit [`RuntimeOptions`] instead of the environment.
@@ -178,11 +183,12 @@ pub async fn start_with_options(
     })
 }
 
-/// Builds the chosen adapter (and, for Gazebo, its media task) and spawns the
-/// per-adapter `run_until_shutdown` task.
+/// Builds the chosen adapter, spawns the per-adapter `run_until_shutdown`
+/// task, and — when the mission executor is configured — spawns the
+/// in-process mission principal against the same engine actor.
 async fn spawn_host_runtime(
     adapter: AdapterKind,
-    options: RuntimeOptions,
+    mut options: RuntimeOptions,
     endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
     engine_tx: mpsc::Sender<ToEngine>,
     engine_rx: mpsc::Receiver<ToEngine>,
@@ -191,141 +197,39 @@ async fn spawn_host_runtime(
     // A single monotonic origin feeds every `host_time` stamp across the host
     // (ADR-0009): the engine actor, each connection task, and — so a video
     // frame's receive/publication stamps stay comparable with them — the media
-    // task all derive from this `Instant`.
+    // task all derive from this `Instant`. The mission principal shares it
+    // too, so its frame sample stamps are exact host-clock time.
     let start = tokio::time::Instant::now();
-    match adapter {
-        AdapterKind::Reference => {
-            let (engine, adapter) = build_reference(options);
-            Ok(tokio::spawn(run_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                None,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-                start,
-            )))
+    // Mission navdata and route are validated (and the ADR-0030
+    // pack-for-flight record logged) before the host listens, so a bad
+    // route or store fails startup instead of a silent no-mission run.
+    let mission = match options.mission.take() {
+        Some(mission_options) => {
+            let plan = automation::prepare(&mission_options)?;
+            Some(automation::spawn_mission_task(&engine_tx, start, plan))
         }
-        AdapterKind::Gazebo => {
-            let (engine, adapter, frames) =
-                gazebo_launch::build_gazebo(HOST_VEHICLE, MAX_CONTROL_AGE).await?;
-            let (media, media_task) = media::spawn_media_task(frames, start);
-            Ok(tokio::spawn(run_with_media_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                media,
-                media_task,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-                start,
-            )))
-        }
-        AdapterKind::Aviate => {
-            spawn_aviate_runtime(endpoint, options, engine_tx, engine_rx, shutdown_rx, start).await
-        }
-        AdapterKind::Px4 => {
-            spawn_px4_runtime(endpoint, options, engine_tx, engine_rx, shutdown_rx, start).await
-        }
-    }
-}
-
-/// Builds the PX4 adapter and spawns its runtime, wiring the media task only
-/// when the adapter exposes a video frame source.
-async fn spawn_px4_runtime(
-    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
-    options: RuntimeOptions,
-    engine_tx: mpsc::Sender<ToEngine>,
-    engine_rx: mpsc::Receiver<ToEngine>,
-    shutdown_rx: oneshot::Receiver<()>,
-    start: tokio::time::Instant,
-) -> Result<tokio::task::JoinHandle<()>, HostError> {
-    let config = px4_config::from_env()?;
-    let mut adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE, config)
-        .await
-        .map_err(HostError::Px4Adapter)?;
-    let engine = build_engine(&adapter, options);
-    match adapter.subscribe_frames() {
-        Some(frames) => {
-            let (media, media_task) = media::spawn_media_task(frames, start);
-            Ok(tokio::spawn(run_with_media_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                media,
-                media_task,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-                start,
-            )))
-        }
-        None => Ok(tokio::spawn(run_until_shutdown(
-            endpoint,
-            engine,
-            adapter,
-            None,
-            engine_tx,
-            engine_rx,
-            shutdown_rx,
-            start,
-        ))),
-    }
-}
-
-/// Builds the Aviate adapter and spawns its runtime, wiring the media task only
-/// when the adapter exposes a video frame source.
-async fn spawn_aviate_runtime(
-    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
-    options: RuntimeOptions,
-    engine_tx: mpsc::Sender<ToEngine>,
-    engine_rx: mpsc::Receiver<ToEngine>,
-    shutdown_rx: oneshot::Receiver<()>,
-    start: tokio::time::Instant,
-) -> Result<tokio::task::JoinHandle<()>, HostError> {
-    // PILOTAGE_AVIATE_PROFILE selects the session profile (LINK-04):
-    // "physical" (FC estimate + FC state; no truth), the default
-    // "simulation" (estimate + FC state, plus the truth oracle when the
-    // co-located shm block attaches), or "oracle-only" (truth stream
-    // only; no uplink, no operational control). Parsing fails closed and
-    // Physical gets the conservative link configuration.
-    let profile = aviate_profile::profile_from_env(std::env::var("PILOTAGE_AVIATE_PROFILE"))?;
-    let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
-        HOST_VEHICLE,
-        profile,
-        aviate_profile::link_config(profile),
+        None => None,
+    };
+    let runtime = adapter_launch::spawn_adapter_runtime(
+        adapter,
+        options,
+        endpoint,
+        engine_tx,
+        engine_rx,
+        shutdown_rx,
+        start,
     )
-    .await
-    .map_err(HostError::AviateAdapter)?;
-    let engine = build_engine(&adapter, options);
-    match adapter.subscribe_frames() {
-        Some(frames) => {
-            let (media, media_task) = media::spawn_media_task(frames, start);
-            Ok(tokio::spawn(run_with_media_until_shutdown(
-                endpoint,
-                engine,
-                adapter,
-                media,
-                media_task,
-                engine_tx,
-                engine_rx,
-                shutdown_rx,
-                start,
-            )))
-        }
-        None => Ok(tokio::spawn(run_until_shutdown(
-            endpoint,
-            engine,
-            adapter,
-            None,
-            engine_tx,
-            engine_rx,
-            shutdown_rx,
-            start,
-        ))),
-    }
+    .await?;
+    Ok(match mission {
+        None => runtime,
+        Some((mission_task, _status)) => tokio::spawn(async move {
+            runtime.await.ok();
+            // The principal holds only a weak engine handle, so it drains
+            // out once the engine actor is gone; joining it here keeps
+            // teardown complete before the host reports shutdown.
+            mission_task.await.ok();
+        }),
+    })
 }
 
 /// Runs the accept loop and engine actor until `shutdown_rx` fires, then

--- a/hosts/session-host/src/runtime/adapter_launch.rs
+++ b/hosts/session-host/src/runtime/adapter_launch.rs
@@ -1,0 +1,161 @@
+//! Per-adapter construction and runtime spawning: builds the selected
+//! vehicle adapter (and its media task when it exposes video frames) and
+//! spawns the shared `run_until_shutdown` lifecycle.
+
+use tokio::sync::{mpsc, oneshot};
+use wtransport::Endpoint;
+
+use crate::cli::AdapterKind;
+use crate::error::HostError;
+
+use super::engine_actor::ToEngine;
+use super::{
+    HOST_VEHICLE, MAX_CONTROL_AGE, RuntimeOptions, aviate_profile, build_engine, build_reference,
+    gazebo_launch, media, px4_config, run_until_shutdown, run_with_media_until_shutdown,
+};
+
+/// Builds the chosen adapter (and, for Gazebo, its media task) and spawns the
+/// per-adapter `run_until_shutdown` task.
+pub(super) async fn spawn_adapter_runtime(
+    adapter: AdapterKind,
+    options: RuntimeOptions,
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
+) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    match adapter {
+        AdapterKind::Reference => {
+            let (engine, adapter) = build_reference(options);
+            Ok(tokio::spawn(run_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                None,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
+        AdapterKind::Gazebo => {
+            let (engine, adapter, frames) =
+                gazebo_launch::build_gazebo(HOST_VEHICLE, MAX_CONTROL_AGE).await?;
+            let (media, media_task) = media::spawn_media_task(frames, start);
+            Ok(tokio::spawn(run_with_media_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                media,
+                media_task,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
+        AdapterKind::Aviate => {
+            spawn_aviate_runtime(endpoint, options, engine_tx, engine_rx, shutdown_rx, start).await
+        }
+        AdapterKind::Px4 => {
+            spawn_px4_runtime(endpoint, options, engine_tx, engine_rx, shutdown_rx, start).await
+        }
+    }
+}
+
+/// Builds the PX4 adapter and spawns its runtime, wiring the media task only
+/// when the adapter exposes a video frame source.
+async fn spawn_px4_runtime(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    options: RuntimeOptions,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
+) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    let config = px4_config::from_env()?;
+    let mut adapter = pilotage_adapter_px4::Px4Adapter::start(HOST_VEHICLE, config)
+        .await
+        .map_err(HostError::Px4Adapter)?;
+    let engine = build_engine(&adapter, options);
+    match adapter.subscribe_frames() {
+        Some(frames) => {
+            let (media, media_task) = media::spawn_media_task(frames, start);
+            Ok(tokio::spawn(run_with_media_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                media,
+                media_task,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
+        None => Ok(tokio::spawn(run_until_shutdown(
+            endpoint,
+            engine,
+            adapter,
+            None,
+            engine_tx,
+            engine_rx,
+            shutdown_rx,
+            start,
+        ))),
+    }
+}
+
+/// Builds the Aviate adapter and spawns its runtime, wiring the media task only
+/// when the adapter exposes a video frame source.
+async fn spawn_aviate_runtime(
+    endpoint: Endpoint<wtransport::endpoint::endpoint_side::Server>,
+    options: RuntimeOptions,
+    engine_tx: mpsc::Sender<ToEngine>,
+    engine_rx: mpsc::Receiver<ToEngine>,
+    shutdown_rx: oneshot::Receiver<()>,
+    start: tokio::time::Instant,
+) -> Result<tokio::task::JoinHandle<()>, HostError> {
+    // PILOTAGE_AVIATE_PROFILE selects the session profile (LINK-04):
+    // "physical" (FC estimate + FC state; no truth), the default
+    // "simulation" (estimate + FC state, plus the truth oracle when the
+    // co-located shm block attaches), or "oracle-only" (truth stream
+    // only; no uplink, no operational control). Parsing fails closed and
+    // Physical gets the conservative link configuration.
+    let profile = aviate_profile::profile_from_env(std::env::var("PILOTAGE_AVIATE_PROFILE"))?;
+    let mut adapter = pilotage_adapter_aviate::AviateAdapter::start(
+        HOST_VEHICLE,
+        profile,
+        aviate_profile::link_config(profile),
+    )
+    .await
+    .map_err(HostError::AviateAdapter)?;
+    let engine = build_engine(&adapter, options);
+    match adapter.subscribe_frames() {
+        Some(frames) => {
+            let (media, media_task) = media::spawn_media_task(frames, start);
+            Ok(tokio::spawn(run_with_media_until_shutdown(
+                endpoint,
+                engine,
+                adapter,
+                media,
+                media_task,
+                engine_tx,
+                engine_rx,
+                shutdown_rx,
+                start,
+            )))
+        }
+        None => Ok(tokio::spawn(run_until_shutdown(
+            endpoint,
+            engine,
+            adapter,
+            None,
+            engine_tx,
+            engine_rx,
+            shutdown_rx,
+            start,
+        ))),
+    }
+}

--- a/hosts/session-host/src/runtime/automation.rs
+++ b/hosts/session-host/src/runtime/automation.rs
@@ -1,0 +1,199 @@
+//! The in-process mission principal (ADR-0025, ADR-0030): a local
+//! automation client that speaks the session vocabulary verbatim —
+//! hello, profile activation, lease, typed intent frames, reliable
+//! action commands — against the same engine actor remote operators
+//! reach over WebTransport, so it is fenced by exactly the same
+//! authority rules.
+//!
+//! The task holds only a [`tokio::sync::mpsc::WeakSender`] to the engine
+//! actor: it can never keep the actor's command channel open on its own,
+//! so host shutdown proceeds exactly as without a mission and the task
+//! drains out behind the actor.
+
+mod ownship;
+mod task;
+
+use navigate_contract::{ClockDomainId, GeodeticPosition};
+use pilotage_mission::{MissionConfig, MissionEngine, MissionState};
+use pilotage_session::ClientKey;
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tracing::info;
+
+use crate::error::HostError;
+use crate::mission_navdata::{self, LoadedNavdata};
+use crate::runtime::engine_actor::{ENGINE_QUEUE_CAPACITY, EngineActor, ToEngine};
+use crate::runtime::registry::OUTBOUND_QUEUE_CAPACITY;
+use crate::runtime::{MissionOptions, RuntimeOptions};
+
+/// The mission principal's driver-assigned client key. The accept loop
+/// allocates keys from zero with a `fetch_add`, so `u64::MAX` can only
+/// collide after 2^64 - 1 accepted connections — beyond any process
+/// lifetime — making it collision-free for the local principal.
+const MISSION_CLIENT: ClientKey = ClientKey::new(u64::MAX);
+
+/// The single clock domain every mission `now`, ownship stamp, and fusion
+/// judgment lives on: the host's shared monotonic origin (ADR-0009).
+const MISSION_CLOCK: ClockDomainId = ClockDomainId::new(1);
+
+/// Observable progress of the in-process mission principal, published on
+/// a watch channel for logs and the integration test.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AutomationStatus {
+    /// Session id assigned by the welcome, once the handshake completed.
+    pub session: Option<u64>,
+    /// The control-profile activation announcement has been sent.
+    pub activation_sent: bool,
+    /// Fencing generation of the held motion lease.
+    pub lease_generation: Option<u64>,
+    /// Authority moved away (denied, revoked, or granted to another
+    /// principal): the mission stopped framing and holds — it never
+    /// re-leases on its own, human takeover wins (ADR-0025).
+    pub fenced: bool,
+    /// The vehicle accepted the arm action.
+    pub arm_accepted: bool,
+    /// Current mission phase, once the engine is built.
+    pub mission_state: Option<MissionState>,
+    /// Typed intent frames submitted to the session engine.
+    pub frames_sent: u64,
+    /// `FrameRejected` notices received back for submitted frames.
+    pub frames_rejected: u64,
+    /// The engine closed this principal's connection.
+    pub closed: bool,
+}
+
+/// A validated mission: the decoded snapshot, its provenance, and the
+/// options the flight engine is built from once capabilities are known.
+pub(crate) struct MissionPlan {
+    navdata: LoadedNavdata,
+    options: MissionOptions,
+}
+
+impl MissionPlan {
+    /// The anchor in radians/meters, converted exactly once (ADR-0030).
+    fn anchor(&self) -> GeodeticPosition {
+        GeodeticPosition::new(
+            self.options.anchor.lat_deg.to_radians(),
+            self.options.anchor.lon_deg.to_radians(),
+            self.options.anchor.alt_m,
+        )
+    }
+
+    /// The mission config over this plan's route and anchor; limits are
+    /// tightened by the caller from the advertised capabilities.
+    fn config(&self) -> MissionConfig {
+        let mut config =
+            MissionConfig::new(self.options.route.clone(), self.anchor(), MISSION_CLOCK);
+        if let Some(cruise_height_m) = self.options.cruise_height_m {
+            config.cruise_height_m = cruise_height_m;
+        }
+        config
+    }
+}
+
+/// Loads the navdata, proves the route builds against it, and logs the
+/// ADR-0030 pack-for-flight record — all at startup, so a bad route or
+/// store fails the host before it listens.
+///
+/// # Errors
+///
+/// [`HostError::MissionNavdata`] when the snapshot cannot be loaded;
+/// [`HostError::MissionBuild`] when the route does not build against it.
+pub(crate) fn prepare(options: &MissionOptions) -> Result<MissionPlan, HostError> {
+    let navdata = mission_navdata::load(options).map_err(HostError::MissionNavdata)?;
+    let plan = MissionPlan {
+        navdata,
+        options: options.clone(),
+    };
+    let (_, record) = MissionEngine::new(
+        &plan.navdata.snapshot,
+        plan.navdata.provenance.clone(),
+        plan.config(),
+    )
+    .map_err(|source| HostError::MissionBuild(Box::new(source)))?;
+    info!(
+        route = %record.route_input,
+        waypoints = record.waypoint_count,
+        expanded = ?record.expanded_idents,
+        authority = %record.provenance.authority,
+        effective_on = %record.provenance.effective_on,
+        sha256 = %record.provenance.sha256_hex,
+        fixture = record.provenance.fixture,
+        "mission packed for flight"
+    );
+    Ok(plan)
+}
+
+/// Spawns the mission principal against `engine_tx`'s actor, sharing the
+/// host's monotonic origin `start`. Returns the task handle and the
+/// status watch.
+pub(crate) fn spawn_mission_task(
+    engine_tx: &mpsc::Sender<ToEngine>,
+    start: Instant,
+    plan: MissionPlan,
+) -> (JoinHandle<()>, watch::Receiver<AutomationStatus>) {
+    let (status_tx, status_rx) = watch::channel(AutomationStatus::default());
+    let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+    let task = task::MissionTask::new(engine_tx.downgrade(), start, plan, status_tx);
+    let handle = tokio::spawn(async move {
+        task.run(outbound_tx, outbound_rx).await;
+        tracing::debug!(task = "mission-automation", "task exited");
+    });
+    (handle, status_rx)
+}
+
+/// An in-process test rig: the reference engine actor plus the mission
+/// principal, wired exactly as the host runtime wires them for
+/// [`crate::cli::AdapterKind::Reference`] — no transport endpoint.
+pub struct MissionRig {
+    engine_tx: mpsc::Sender<ToEngine>,
+    status: watch::Receiver<AutomationStatus>,
+    actor: JoinHandle<()>,
+    automation: JoinHandle<()>,
+}
+
+impl MissionRig {
+    /// A fresh handle on the mission principal's status watch.
+    #[must_use]
+    pub fn status(&self) -> watch::Receiver<AutomationStatus> {
+        self.status.clone()
+    }
+
+    /// Closes the engine actor's command channel and waits for the actor
+    /// and the mission principal to drain out, proving the shutdown
+    /// ordering the host relies on.
+    pub async fn shutdown(self) {
+        drop(self.engine_tx);
+        self.actor.await.ok();
+        self.automation.await.ok();
+    }
+}
+
+/// Spawns [`MissionRig`] over the fixture mission with a zero cruise
+/// height (the planar reference vehicle has no climb axis).
+///
+/// # Errors
+///
+/// [`HostError`] when the fixture snapshot or demo route fails to build.
+pub fn spawn_reference_mission_rig() -> Result<MissionRig, HostError> {
+    let options = MissionOptions {
+        route: pilotage_mission::fixture::DEMO_ROUTE.to_owned(),
+        navdata: crate::runtime::MissionNavdataSource::Fixture,
+        anchor: crate::runtime::DEFAULT_MISSION_ANCHOR,
+        date: None,
+        cruise_height_m: Some(0.0),
+    };
+    let plan = prepare(&options)?;
+    let start = Instant::now();
+    let (engine, adapter) = super::build_reference(RuntimeOptions::default());
+    let (engine_tx, engine_rx) = mpsc::channel(ENGINE_QUEUE_CAPACITY);
+    let actor = tokio::spawn(EngineActor::new(engine, adapter, start).run(engine_rx));
+    let (automation, status) = spawn_mission_task(&engine_tx, start, plan);
+    Ok(MissionRig {
+        engine_tx,
+        status,
+        actor,
+        automation,
+    })
+}

--- a/hosts/session-host/src/runtime/automation.rs
+++ b/hosts/session-host/src/runtime/automation.rs
@@ -131,16 +131,25 @@ pub(crate) fn prepare(options: &MissionOptions) -> Result<MissionPlan, HostError
 }
 
 /// Spawns the mission principal against `engine_tx`'s actor, sharing the
-/// host's monotonic origin `start`. Returns the task handle and the
-/// status watch.
+/// host's monotonic origin `start`. `planar_pose_is_truth` declares
+/// whether this host's unstamped planar poses are the simulator's own
+/// state — true only for the deterministic reference adapter. Returns
+/// the task handle and the status watch.
 pub(crate) fn spawn_mission_task(
     engine_tx: &mpsc::Sender<ToEngine>,
     start: Instant,
     plan: MissionPlan,
+    planar_pose_is_truth: bool,
 ) -> (JoinHandle<()>, watch::Receiver<AutomationStatus>) {
     let (status_tx, status_rx) = watch::channel(AutomationStatus::default());
     let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
-    let task = task::MissionTask::new(engine_tx.downgrade(), start, plan, status_tx);
+    let task = task::MissionTask::new(
+        engine_tx.downgrade(),
+        start,
+        plan,
+        status_tx,
+        planar_pose_is_truth,
+    );
     let handle = tokio::spawn(async move {
         task.run(outbound_tx, outbound_rx).await;
         tracing::debug!(task = "mission-automation", "task exited");
@@ -230,7 +239,7 @@ pub fn spawn_reference_mission_rig() -> Result<MissionRig, HostError> {
     let (engine, adapter) = super::build_reference(RuntimeOptions::default());
     let (engine_tx, engine_rx) = mpsc::channel(ENGINE_QUEUE_CAPACITY);
     let actor = tokio::spawn(EngineActor::new(engine, adapter, start).run(engine_rx));
-    let (automation, status) = spawn_mission_task(&engine_tx, start, plan);
+    let (automation, status) = spawn_mission_task(&engine_tx, start, plan, true);
     Ok(MissionRig {
         engine_tx,
         status,

--- a/hosts/session-host/src/runtime/automation.rs
+++ b/hosts/session-host/src/runtime/automation.rs
@@ -23,6 +23,7 @@ use tracing::info;
 
 use crate::error::HostError;
 use crate::mission_navdata::{self, LoadedNavdata};
+use crate::runtime::connection::ToConnection;
 use crate::runtime::engine_actor::{ENGINE_QUEUE_CAPACITY, EngineActor, ToEngine};
 use crate::runtime::registry::OUTBOUND_QUEUE_CAPACITY;
 use crate::runtime::{MissionOptions, RuntimeOptions};
@@ -32,6 +33,10 @@ use crate::runtime::{MissionOptions, RuntimeOptions};
 /// collide after 2^64 - 1 accepted connections — beyond any process
 /// lifetime — making it collision-free for the local principal.
 const MISSION_CLIENT: ClientKey = ClientKey::new(u64::MAX);
+
+/// The observing client's key, allocated from the same collision-free end
+/// of the space as [`MISSION_CLIENT`].
+const OBSERVER_CLIENT: ClientKey = ClientKey::new(u64::MAX - 1);
 
 /// The single clock domain every mission `now`, ownship stamp, and fusion
 /// judgment lives on: the host's shared monotonic origin (ADR-0009).
@@ -153,11 +158,47 @@ pub struct MissionRig {
     automation: JoinHandle<()>,
 }
 
+/// A synthetic client registered with the engine actor purely to read
+/// what it broadcasts: the same outbound path a remote connection's
+/// writer half drains, so a test reads exactly the bytes that would go on
+/// the wire.
+pub struct TelemetryObserver {
+    outbound: mpsc::Receiver<ToConnection>,
+}
+
+impl TelemetryObserver {
+    /// The next best-effort datagram broadcast to this observer, or
+    /// `None` once the engine actor is gone.
+    pub async fn next_datagram(&mut self) -> Option<Vec<u8>> {
+        while let Some(message) = self.outbound.recv().await {
+            if let ToConnection::Datagram { bytes, .. } = message {
+                return Some(bytes);
+            }
+        }
+        None
+    }
+}
+
 impl MissionRig {
     /// A fresh handle on the mission principal's status watch.
     #[must_use]
     pub fn status(&self) -> watch::Receiver<AutomationStatus> {
         self.status.clone()
+    }
+
+    /// Registers an observing client with the engine actor and hands back
+    /// its outbound datagrams. Dropping the observer closes the channel
+    /// and the actor evicts it on the next send.
+    pub async fn observe(&self) -> TelemetryObserver {
+        let (outbound_tx, outbound) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        self.engine_tx
+            .send(ToEngine::ClientConnected {
+                client: OBSERVER_CLIENT,
+                sender: outbound_tx,
+            })
+            .await
+            .ok();
+        TelemetryObserver { outbound }
     }
 
     /// Closes the engine actor's command channel and waits for the actor

--- a/hosts/session-host/src/runtime/automation/ownship.rs
+++ b/hosts/session-host/src/runtime/automation/ownship.rs
@@ -1,0 +1,137 @@
+//! Telemetry-to-ownship conversion for the mission principal.
+//!
+//! Acquisition time on the mission clock is the HOST's publication stamp
+//! (the shared monotonic origin): a measurement group's own stamp rides a
+//! foreign clock domain (vehicle boot / simulation) and is never
+//! subtracted against host time without an explicit correlation
+//! (ADR-0009). Source ROLES, by contrast, are taken from the stamps
+//! verbatim — the mission engine's honesty gate (ADR-0024) decides what
+//! each role may become.
+
+use navigate_contract::MonotonicNanos;
+use pilotage_mission::{OwnshipSample, TruthRole};
+use pilotage_protocol::wire;
+
+/// Converts one wire telemetry sample into an ownship sample, preferring
+/// the simulation-truth group, then stamped avionics kinematics, then the
+/// planar pose. `received_at` is the fallback acquisition time when the
+/// sample carries no host publication stamp.
+pub(super) fn ownship_from_wire(
+    sample: &wire::TelemetrySample,
+    received_at: MonotonicNanos,
+) -> Option<OwnshipSample> {
+    let acquired_at = sample
+        .observed_at
+        .as_ref()
+        .map_or(received_at, |stamp| MonotonicNanos::from_nanos(stamp.nanos));
+    if let Some(truth) = sample.sim_truth.as_deref() {
+        return from_sim_truth(truth, acquired_at);
+    }
+    if let Some(avionics) = sample.avionics.as_ref()
+        && let Some(ownship) = from_avionics(avionics, acquired_at)
+    {
+        return Some(ownship);
+    }
+    from_pose(sample, acquired_at)
+}
+
+/// A stamped simulator-truth group; truth without provenance is
+/// unconsumable and yields nothing.
+fn from_sim_truth(
+    truth: &wire::SimTruthState,
+    acquired_at: MonotonicNanos,
+) -> Option<OwnshipSample> {
+    let stamp = truth.stamp.as_ref()?;
+    Some(OwnshipSample {
+        ned: [
+            f64::from(truth.pos_n_m),
+            f64::from(truth.pos_e_m),
+            f64::from(truth.pos_d_m),
+        ],
+        ned_velocity: [
+            f64::from(truth.vel_n_mps),
+            f64::from(truth.vel_e_mps),
+            f64::from(truth.vel_d_mps),
+        ],
+        yaw_rad: quat_yaw(truth.quat_w, truth.quat_x, truth.quat_y, truth.quat_z),
+        role: role_from_wire(stamp.role)?,
+        acquired_at,
+        sequence: stamp.sequence,
+    })
+}
+
+/// A stamped avionics kinematics group under its declared role; yaw comes
+/// from the attitude group when one rides along, zero otherwise (the
+/// mission engine refuses non-truth roles before yaw ever matters).
+fn from_avionics(
+    avionics: &wire::AvionicsState,
+    acquired_at: MonotonicNanos,
+) -> Option<OwnshipSample> {
+    let stamp = avionics.kinematics_stamp.as_ref()?;
+    let yaw_rad = avionics.attitude_stamp.as_ref().map_or(0.0, |_| {
+        quat_yaw(
+            avionics.quat_w,
+            avionics.quat_x,
+            avionics.quat_y,
+            avionics.quat_z,
+        )
+    });
+    Some(OwnshipSample {
+        ned: [
+            f64::from(avionics.pos_n_m),
+            f64::from(avionics.pos_e_m),
+            f64::from(avionics.pos_d_m),
+        ],
+        ned_velocity: [
+            f64::from(avionics.vel_n_mps),
+            f64::from(avionics.vel_e_mps),
+            f64::from(avionics.vel_d_mps),
+        ],
+        yaw_rad,
+        role: role_from_wire(stamp.role)?,
+        acquired_at,
+        sequence: stamp.sequence,
+    })
+}
+
+/// The planar fallback. An UNSTAMPED planar pose is only published by the
+/// deterministic reference simulation, whose pose IS the simulator's own
+/// state (it has no estimator to launder), so it carries the
+/// simulation-truth role by construction; depth and vertical rate are
+/// synthesized as zero and yaw is the planar heading.
+fn from_pose(sample: &wire::TelemetrySample, acquired_at: MonotonicNanos) -> Option<OwnshipSample> {
+    let pose = sample.pose.as_ref()?;
+    let speed = sample
+        .velocity
+        .as_ref()
+        .map_or(0.0, |velocity| f64::from(velocity.linear_x_mps));
+    let heading = f64::from(pose.heading_rad);
+    let (sin, cos) = heading.sin_cos();
+    Some(OwnshipSample {
+        ned: [f64::from(pose.x_m), f64::from(pose.y_m), 0.0],
+        ned_velocity: [speed * cos, speed * sin, 0.0],
+        yaw_rad: heading,
+        role: TruthRole::SimulationTruth,
+        acquired_at,
+        sequence: sample.tick.as_ref().map_or(0, |tick| tick.value as u32),
+    })
+}
+
+/// Maps a wire source role onto the mission vocabulary; roles the mission
+/// has no reading for (video, payload device) yield nothing.
+fn role_from_wire(role: i32) -> Option<TruthRole> {
+    match wire::SourceRole::try_from(role).ok()? {
+        wire::SourceRole::SimulationTruth => Some(TruthRole::SimulationTruth),
+        wire::SourceRole::OperationalEstimate => Some(TruthRole::OperationalEstimate),
+        wire::SourceRole::FcState => Some(TruthRole::FcState),
+        wire::SourceRole::Unspecified
+        | wire::SourceRole::VideoCapture
+        | wire::SourceRole::PayloadDevice => None,
+    }
+}
+
+/// Heading (yaw about NED down) of a body-FRD-to-NED quaternion.
+fn quat_yaw(w: f32, x: f32, y: f32, z: f32) -> f64 {
+    let (w, x, y, z) = (f64::from(w), f64::from(x), f64::from(y), f64::from(z));
+    (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
+}

--- a/hosts/session-host/src/runtime/automation/ownship.rs
+++ b/hosts/session-host/src/runtime/automation/ownship.rs
@@ -13,12 +13,15 @@ use pilotage_mission::{OwnshipSample, TruthRole};
 use pilotage_protocol::wire;
 
 /// Converts one wire telemetry sample into an ownship sample, preferring
-/// the simulation-truth group, then stamped avionics kinematics, then the
-/// planar pose. `received_at` is the fallback acquisition time when the
-/// sample carries no host publication stamp.
+/// the simulation-truth group, then stamped avionics kinematics, then —
+/// only when the host declares its planar poses ARE simulator state
+/// (`planar_pose_is_truth`) — the planar pose. `received_at` is the
+/// fallback acquisition time when the sample carries no host publication
+/// stamp.
 pub(super) fn ownship_from_wire(
     sample: &wire::TelemetrySample,
     received_at: MonotonicNanos,
+    planar_pose_is_truth: bool,
 ) -> Option<OwnshipSample> {
     let acquired_at = sample
         .observed_at
@@ -27,12 +30,20 @@ pub(super) fn ownship_from_wire(
     if let Some(truth) = sample.sim_truth.as_deref() {
         return from_sim_truth(truth, acquired_at);
     }
+    // A stamped kinematics group is authoritative for this sample: a
+    // role the mission has no reading for refuses the sample outright.
+    // Falling through to the pose fallback would UPGRADE an unreadable
+    // stamped role to simulation truth — the fail-open ADR-0024 breach.
     if let Some(avionics) = sample.avionics.as_ref()
-        && let Some(ownship) = from_avionics(avionics, acquired_at)
+        && avionics.kinematics_stamp.is_some()
     {
-        return Some(ownship);
+        return from_avionics(avionics, acquired_at);
     }
-    from_pose(sample, acquired_at)
+    if planar_pose_is_truth {
+        from_pose(sample, acquired_at)
+    } else {
+        None
+    }
 }
 
 /// A stamped simulator-truth group; truth without provenance is
@@ -53,7 +64,12 @@ fn from_sim_truth(
             f64::from(truth.vel_e_mps),
             f64::from(truth.vel_d_mps),
         ],
-        yaw_rad: quat_yaw(truth.quat_w, truth.quat_x, truth.quat_y, truth.quat_z),
+        yaw_rad: Some(quat_yaw(
+            truth.quat_w,
+            truth.quat_x,
+            truth.quat_y,
+            truth.quat_z,
+        )),
         role: role_from_wire(stamp.role)?,
         acquired_at,
         sequence: stamp.sequence,
@@ -61,14 +77,14 @@ fn from_sim_truth(
 }
 
 /// A stamped avionics kinematics group under its declared role; yaw comes
-/// from the attitude group when one rides along, zero otherwise (the
-/// mission engine refuses non-truth roles before yaw ever matters).
+/// from the attitude group when one rides along and is absent otherwise —
+/// a substituted zero would read as a due-north heading.
 fn from_avionics(
     avionics: &wire::AvionicsState,
     acquired_at: MonotonicNanos,
 ) -> Option<OwnshipSample> {
     let stamp = avionics.kinematics_stamp.as_ref()?;
-    let yaw_rad = avionics.attitude_stamp.as_ref().map_or(0.0, |_| {
+    let yaw_rad = avionics.attitude_stamp.as_ref().map(|_| {
         quat_yaw(
             avionics.quat_w,
             avionics.quat_x,
@@ -94,11 +110,11 @@ fn from_avionics(
     })
 }
 
-/// The planar fallback. An UNSTAMPED planar pose is only published by the
-/// deterministic reference simulation, whose pose IS the simulator's own
-/// state (it has no estimator to launder), so it carries the
-/// simulation-truth role by construction; depth and vertical rate are
-/// synthesized as zero and yaw is the planar heading.
+/// The planar fallback, reachable only when the spawn site declared the
+/// host's planar poses to be the simulator's own state (the deterministic
+/// reference adapter, which has no estimator to launder). The
+/// simulation-truth role is that declaration, not an inference; depth and
+/// vertical rate are synthesized as zero and yaw is the planar heading.
 fn from_pose(sample: &wire::TelemetrySample, acquired_at: MonotonicNanos) -> Option<OwnshipSample> {
     let pose = sample.pose.as_ref()?;
     let speed = sample
@@ -110,7 +126,7 @@ fn from_pose(sample: &wire::TelemetrySample, acquired_at: MonotonicNanos) -> Opt
     Some(OwnshipSample {
         ned: [f64::from(pose.x_m), f64::from(pose.y_m), 0.0],
         ned_velocity: [speed * cos, speed * sin, 0.0],
-        yaw_rad: heading,
+        yaw_rad: Some(heading),
         role: TruthRole::SimulationTruth,
         acquired_at,
         sequence: sample.tick.as_ref().map_or(0, |tick| tick.value as u32),
@@ -138,4 +154,88 @@ fn role_from_wire(role: i32) -> Option<TruthRole> {
 fn quat_yaw(w: f32, x: f32, y: f32, z: f32) -> f64 {
     let (w, x, y, z) = (f64::from(w), f64::from(x), f64::from(y), f64::from(z));
     (2.0 * (w * z + x * y)).atan2(1.0 - 2.0 * (y * y + z * z))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    fn now() -> MonotonicNanos {
+        MonotonicNanos::from_nanos(1_000_000)
+    }
+
+    fn stamped_kinematics(role: wire::SourceRole) -> wire::TelemetrySample {
+        wire::TelemetrySample {
+            avionics: Some(wire::AvionicsState {
+                pos_n_m: 1.0,
+                pos_e_m: 2.0,
+                pos_d_m: -3.0,
+                kinematics_stamp: Some(wire::MeasurementStamp {
+                    role: role as i32,
+                    sequence: 7,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            // A pose rides along so a fall-through would have something
+            // to upgrade — the tests below prove it never does.
+            pose: Some(wire::Pose2d {
+                x_m: 9.0,
+                y_m: 9.0,
+                heading_rad: 1.0,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn an_unreadable_stamped_role_is_refused_not_upgraded_to_pose_truth() {
+        let sample = stamped_kinematics(wire::SourceRole::NavigationSolution);
+        assert_eq!(ownship_from_wire(&sample, now(), true), None);
+        assert_eq!(ownship_from_wire(&sample, now(), false), None);
+    }
+
+    #[test]
+    fn a_planar_pose_is_truth_only_by_declaration() {
+        let sample = wire::TelemetrySample {
+            pose: Some(wire::Pose2d {
+                x_m: 4.0,
+                y_m: 5.0,
+                heading_rad: 0.5,
+            }),
+            ..Default::default()
+        };
+        let declared =
+            ownship_from_wire(&sample, now(), true).expect("declared planar truth converts");
+        assert_eq!(declared.role, TruthRole::SimulationTruth);
+        assert_eq!(declared.yaw_rad, Some(0.5));
+        assert_eq!(ownship_from_wire(&sample, now(), false), None);
+    }
+
+    #[test]
+    fn kinematics_without_an_attitude_group_carries_no_yaw() {
+        let sample = stamped_kinematics(wire::SourceRole::SimulationTruth);
+        let ownship = ownship_from_wire(&sample, now(), false).expect("truth role converts");
+        assert_eq!(
+            ownship.yaw_rad, None,
+            "a substituted zero would read as due north"
+        );
+        assert_eq!(ownship.ned, [1.0, 2.0, -3.0]);
+    }
+
+    #[test]
+    fn an_attitude_group_supplies_the_yaw() {
+        let mut sample = stamped_kinematics(wire::SourceRole::SimulationTruth);
+        let avionics = sample.avionics.as_mut().expect("fixture carries avionics");
+        avionics.quat_w = 1.0;
+        avionics.attitude_stamp = Some(wire::MeasurementStamp::default());
+        let ownship = ownship_from_wire(&sample, now(), false).expect("truth role converts");
+        assert_eq!(
+            ownship.yaw_rad,
+            Some(0.0),
+            "identity quaternion is a zero yaw"
+        );
+    }
 }

--- a/hosts/session-host/src/runtime/automation/ownship.rs
+++ b/hosts/session-host/src/runtime/automation/ownship.rs
@@ -124,9 +124,13 @@ fn role_from_wire(role: i32) -> Option<TruthRole> {
         wire::SourceRole::SimulationTruth => Some(TruthRole::SimulationTruth),
         wire::SourceRole::OperationalEstimate => Some(TruthRole::OperationalEstimate),
         wire::SourceRole::FcState => Some(TruthRole::FcState),
+        // Guidance output is the mission's own plan-relative product
+        // (ADR-0024/0031): reading it back as an ownship observation
+        // would close a loop on the executor's own numbers.
         wire::SourceRole::Unspecified
         | wire::SourceRole::VideoCapture
-        | wire::SourceRole::PayloadDevice => None,
+        | wire::SourceRole::PayloadDevice
+        | wire::SourceRole::NavigationSolution => None,
     }
 }
 

--- a/hosts/session-host/src/runtime/automation/task.rs
+++ b/hosts/session-host/src/runtime/automation/task.rs
@@ -72,6 +72,10 @@ pub(super) struct MissionTask {
     /// Stamps the guidance group; bound to the session at the welcome,
     /// since the incarnation token it carries is derived from it.
     nav_guidance: Option<NavGuidancePublisher>,
+    /// Whether this host's UNSTAMPED planar poses are the simulator's
+    /// own state (true only for the deterministic reference adapter).
+    /// Anything else must arrive under a stamped role or be refused.
+    planar_pose_is_truth: bool,
 }
 
 impl MissionTask {
@@ -80,6 +84,7 @@ impl MissionTask {
         start: Instant,
         plan: MissionPlan,
         status: watch::Sender<AutomationStatus>,
+        planar_pose_is_truth: bool,
     ) -> Self {
         Self {
             engine,
@@ -95,6 +100,33 @@ impl MissionTask {
             next_action_id: 0,
             pending_actions: HashMap::new(),
             nav_guidance: None,
+            planar_pose_is_truth,
+        }
+    }
+
+    /// A task with no plan, for unit tests of session/fencing behavior
+    /// that is independent of mission content.
+    #[cfg(test)]
+    pub(super) fn without_plan(
+        engine: mpsc::WeakSender<ToEngine>,
+        start: Instant,
+        status: watch::Sender<AutomationStatus>,
+    ) -> Self {
+        Self {
+            engine,
+            start,
+            plan: None,
+            status,
+            session: None,
+            principal: None,
+            generation: None,
+            fenced: false,
+            mission: None,
+            sequence: 0,
+            next_action_id: 0,
+            pending_actions: HashMap::new(),
+            nav_guidance: None,
+            planar_pose_is_truth: true,
         }
     }
 

--- a/hosts/session-host/src/runtime/automation/task.rs
+++ b/hosts/session-host/src/runtime/automation/task.rs
@@ -1,0 +1,323 @@
+//! The mission principal's task loop: registration with the engine
+//! actor, the tick that turns mission-engine output into typed frames
+//! and reliable action commands, and the exit record. The session flow
+//! and authority fencing live in the submodules.
+
+mod fencing;
+mod session_flow;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use navigate_contract::MonotonicNanos;
+use pilotage_mission::{MissionAction, MissionEngine, MissionEvent};
+use pilotage_protocol::{
+    ClientHello, ControlActionCommand, ControlIntent, ControlPayload, Generation, PrincipalId,
+    SESSION_PROTOCOL_VERSION, ScopeId, ScopedControlFrame, SequenceNum, SessionId,
+};
+use pilotage_session::DomainEnvelope;
+use pilotage_timing::MonoTimestamp;
+use tokio::sync::{mpsc, watch};
+use tokio::time::Instant;
+use tracing::{info, warn};
+
+use crate::runtime::HOST_VEHICLE;
+use crate::runtime::connection::ToConnection;
+use crate::runtime::engine_actor::ToEngine;
+
+use super::ownship;
+use super::{AutomationStatus, MISSION_CLIENT, MissionPlan};
+
+/// The scope the mission principal leases and frames against.
+const MISSION_SCOPE: &str = "vehicle.motion";
+
+/// The announced control-profile identity (INPUT-01 traceability).
+const PROFILE_ID: &str = "automation.mission";
+
+/// The profile document's own revision.
+const PROFILE_REVISION: u32 = 1;
+
+/// The principal's single activation revision: one profile, installed
+/// once per session, so the monotonic revision never advances.
+const ACTIVATION_REVISION: u32 = 1;
+
+/// Stable content digest for the automation profile announcement. The
+/// engine binds session and monotonic revision only, but the digest must
+/// be stable so evidence records agree across runs.
+const PROFILE_DIGEST: [u8; 32] = *b"pilotage.automation.mission.v1\0\0";
+
+/// No device profile is selected; the id stays empty and the digest zero.
+const NO_DEVICE_DIGEST: [u8; 32] = [0; 32];
+
+/// Mission tick cadence. Matches the `MissionConfig::frame_interval`
+/// default and sits well inside the holder-silence watchdog window.
+const TICK_INTERVAL: Duration = Duration::from_millis(50);
+
+/// The in-process mission principal's state.
+pub(super) struct MissionTask {
+    engine: mpsc::WeakSender<ToEngine>,
+    start: Instant,
+    plan: Option<MissionPlan>,
+    status: watch::Sender<AutomationStatus>,
+    session: Option<SessionId>,
+    principal: Option<PrincipalId>,
+    generation: Option<Generation>,
+    fenced: bool,
+    mission: Option<MissionEngine>,
+    sequence: u32,
+    next_action_id: u32,
+    pending_actions: HashMap<u32, u64>,
+}
+
+impl MissionTask {
+    pub(super) fn new(
+        engine: mpsc::WeakSender<ToEngine>,
+        start: Instant,
+        plan: MissionPlan,
+        status: watch::Sender<AutomationStatus>,
+    ) -> Self {
+        Self {
+            engine,
+            start,
+            plan: Some(plan),
+            status,
+            session: None,
+            principal: None,
+            generation: None,
+            fenced: false,
+            mission: None,
+            sequence: 0,
+            next_action_id: 0,
+            pending_actions: HashMap::new(),
+        }
+    }
+
+    /// Registers with the engine actor, opens the session, and services
+    /// engine replies and the mission tick until the actor goes away or
+    /// the engine closes the connection.
+    pub(super) async fn run(
+        mut self,
+        outbound_tx: mpsc::Sender<ToConnection>,
+        mut outbound_rx: mpsc::Receiver<ToConnection>,
+    ) {
+        let connected = self
+            .send_command(ToEngine::ClientConnected {
+                client: MISSION_CLIENT,
+                sender: outbound_tx,
+            })
+            .await;
+        if !connected {
+            return;
+        }
+        let hello = DomainEnvelope::Hello(ClientHello {
+            protocol_version: SESSION_PROTOCOL_VERSION,
+            client_name: "mission-executor".to_owned(),
+            join_token: Vec::new(),
+        });
+        if !self.send_message(hello).await {
+            return;
+        }
+        let mut ticker = tokio::time::interval(TICK_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                message = outbound_rx.recv() => match message {
+                    Some(message) => {
+                        if !self.on_connection_message(message).await {
+                            break;
+                        }
+                    }
+                    None => break,
+                },
+                _ = ticker.tick() => {
+                    if !self.on_tick().await {
+                        break;
+                    }
+                }
+            }
+        }
+        self.log_counters();
+    }
+
+    /// Handles one engine-actor delivery; `false` stops the task.
+    async fn on_connection_message(&mut self, message: ToConnection) -> bool {
+        match message {
+            ToConnection::BootstrapMessage { bytes, .. } => self.on_bootstrap(&bytes).await,
+            ToConnection::AuthorityMessage(bytes) => {
+                self.on_authority(&bytes);
+                true
+            }
+            ToConnection::Datagram { bytes, .. } => {
+                self.on_datagram(&bytes);
+                true
+            }
+            ToConnection::Close => {
+                warn!("engine closed the mission principal's connection");
+                self.update(|status| status.closed = true);
+                false
+            }
+        }
+    }
+
+    /// One mission tick: events are logged, an intent becomes a typed
+    /// frame, an action becomes a reliable command. Never runs while
+    /// fenced — human takeover wins and the task only holds (ADR-0025).
+    async fn on_tick(&mut self) -> bool {
+        if self.fenced || self.generation.is_none() {
+            return true;
+        }
+        let nanos = self.elapsed_nanos();
+        let output = {
+            let Some(mission) = self.mission.as_mut() else {
+                return true;
+            };
+            mission.tick(MonotonicNanos::from_nanos(nanos))
+        };
+        self.log_events(&output.events);
+        self.update(|status| status.mission_state = Some(output.state));
+        if let Some(action) = output.action
+            && !self.send_action(action).await
+        {
+            return false;
+        }
+        if let Some(intent) = output.intent
+            && !self
+                .send_intent(intent, MonoTimestamp::from_nanos(nanos))
+                .await
+        {
+            return false;
+        }
+        true
+    }
+
+    /// Frames one typed intent under the held lease with a wrap-advancing
+    /// sequence and an exact host-clock sample stamp.
+    async fn send_intent(&mut self, intent: ControlIntent, sampled_at: MonoTimestamp) -> bool {
+        let (Some(session), Some(generation)) = (self.session, self.generation) else {
+            return true;
+        };
+        self.sequence = self.sequence.wrapping_add(1);
+        let frame = ScopedControlFrame {
+            session,
+            vehicle: HOST_VEHICLE,
+            scope: ScopeId::new(MISSION_SCOPE),
+            generation,
+            sequence: SequenceNum::new(self.sequence),
+            sampled_at,
+            profile_revision: PROFILE_REVISION,
+            activation_revision: ACTIVATION_REVISION,
+            payload: ControlPayload::default(),
+            intent: Some(intent),
+            actions: Vec::new(),
+            action_ids: Vec::new(),
+        };
+        if !self
+            .send_message_at(DomainEnvelope::Frame(frame), sampled_at)
+            .await
+        {
+            return false;
+        }
+        self.update(|status| status.frames_sent = status.frames_sent.wrapping_add(1));
+        true
+    }
+
+    /// Sends one discrete action as a reliable `ControlActionCommand`
+    /// under a fresh nonzero wire correlation id, remembering the mission
+    /// engine's own id for the answering result.
+    async fn send_action(&mut self, action: MissionAction) -> bool {
+        let (Some(session), Some(generation)) = (self.session, self.generation) else {
+            return true;
+        };
+        self.next_action_id = self.next_action_id.wrapping_add(1);
+        if self.next_action_id == 0 {
+            // The wire reserves zero for "no correlation"; skip it on wrap.
+            self.next_action_id = 1;
+        }
+        let wire_id = self.next_action_id;
+        self.pending_actions.insert(wire_id, action.action_id);
+        info!(action = ?action.action, action_id = wire_id, "mission action command");
+        let command = ControlActionCommand {
+            session,
+            vehicle: HOST_VEHICLE,
+            scope: ScopeId::new(MISSION_SCOPE),
+            generation,
+            activation_revision: ACTIVATION_REVISION,
+            action: action.action,
+            action_id: wire_id,
+        };
+        self.send_message(DomainEnvelope::ActionCommand(command))
+            .await
+    }
+
+    fn log_events(&self, events: &[MissionEvent]) {
+        for event in events {
+            match event {
+                MissionEvent::GuidanceRefused { reason } => {
+                    warn!(?reason, "mission guidance refused");
+                }
+                MissionEvent::MissionComplete => info!("mission complete"),
+                other => info!(event = ?other, "mission event"),
+            }
+        }
+    }
+
+    /// The exit record: every named mission counter plus the frame
+    /// bookkeeping, so a run's refusals are visible even without a
+    /// status watcher.
+    fn log_counters(&self) {
+        let status = self.status.borrow().clone();
+        let Some(mission) = self.mission.as_ref() else {
+            info!("mission principal exiting before the engine was built");
+            return;
+        };
+        let counters = mission.counters();
+        info!(
+            state = ?mission.state(),
+            rejected_role = counters.rejected_role,
+            fusion_rejected = counters.fusion_rejected,
+            guidance_refused = counters.guidance_refused,
+            arm_rejected = counters.arm_rejected,
+            frames_sent = status.frames_sent,
+            frames_rejected = status.frames_rejected,
+            "mission principal exiting"
+        );
+    }
+
+    fn elapsed_nanos(&self) -> u64 {
+        u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+    }
+
+    fn mission_now(&self) -> MonotonicNanos {
+        MonotonicNanos::from_nanos(self.elapsed_nanos())
+    }
+
+    fn host_now(&self) -> MonoTimestamp {
+        MonoTimestamp::from_nanos(self.elapsed_nanos())
+    }
+
+    /// Sends one command to the engine actor through the weak handle;
+    /// `false` means the actor is gone and the task should exit.
+    async fn send_command(&self, command: ToEngine) -> bool {
+        let Some(sender) = self.engine.upgrade() else {
+            return false;
+        };
+        sender.send(command).await.is_ok()
+    }
+
+    async fn send_message(&self, message: DomainEnvelope) -> bool {
+        self.send_message_at(message, self.host_now()).await
+    }
+
+    async fn send_message_at(&self, message: DomainEnvelope, now: MonoTimestamp) -> bool {
+        self.send_command(ToEngine::ClientMessage {
+            client: MISSION_CLIENT,
+            message,
+            now,
+        })
+        .await
+    }
+
+    fn update(&self, apply: impl FnOnce(&mut AutomationStatus)) {
+        self.status.send_modify(apply);
+    }
+}

--- a/hosts/session-host/src/runtime/automation/task.rs
+++ b/hosts/session-host/src/runtime/automation/task.rs
@@ -4,13 +4,14 @@
 //! and authority fencing live in the submodules.
 
 mod fencing;
+mod nav_guidance;
 mod session_flow;
 
 use std::collections::HashMap;
 use std::time::Duration;
 
 use navigate_contract::MonotonicNanos;
-use pilotage_mission::{MissionAction, MissionEngine, MissionEvent};
+use pilotage_mission::{MissionAction, MissionEngine, MissionEvent, NavGuidance};
 use pilotage_protocol::{
     ClientHello, ControlActionCommand, ControlIntent, ControlPayload, Generation, PrincipalId,
     SESSION_PROTOCOL_VERSION, ScopeId, ScopedControlFrame, SequenceNum, SessionId,
@@ -27,6 +28,7 @@ use crate::runtime::engine_actor::ToEngine;
 
 use super::ownship;
 use super::{AutomationStatus, MISSION_CLIENT, MissionPlan};
+use nav_guidance::{NavGuidancePublisher, NavPublication};
 
 /// The scope the mission principal leases and frames against.
 const MISSION_SCOPE: &str = "vehicle.motion";
@@ -67,6 +69,9 @@ pub(super) struct MissionTask {
     sequence: u32,
     next_action_id: u32,
     pending_actions: HashMap<u32, u64>,
+    /// Stamps the guidance group; bound to the session at the welcome,
+    /// since the incarnation token it carries is derived from it.
+    nav_guidance: Option<NavGuidancePublisher>,
 }
 
 impl MissionTask {
@@ -89,6 +94,7 @@ impl MissionTask {
             sequence: 0,
             next_action_id: 0,
             pending_actions: HashMap::new(),
+            nav_guidance: None,
         }
     }
 
@@ -136,6 +142,10 @@ impl MissionTask {
                 }
             }
         }
+        // A principal that stops flying stops guiding: clear the group so
+        // no instrument keeps a frozen leg on screen after it is gone.
+        let nanos = self.elapsed_nanos();
+        self.publish_nav_guidance(None, nanos).await;
         self.log_counters();
     }
 
@@ -175,6 +185,10 @@ impl MissionTask {
         };
         self.log_events(&output.events);
         self.update(|status| status.mission_state = Some(output.state));
+        let guidance = self.mission.as_ref().and_then(MissionEngine::nav_guidance);
+        if !self.publish_nav_guidance(guidance.as_ref(), nanos).await {
+            return false;
+        }
         if let Some(action) = output.action
             && !self.send_action(action).await
         {
@@ -188,6 +202,32 @@ impl MissionTask {
             return false;
         }
         true
+    }
+
+    /// Hands this tick's guidance to the telemetry assembly, or clears
+    /// what it holds once the executor stops flying a leg (ADR-0031):
+    /// display context travels as its own stamped group, and absence —
+    /// never zeros — is how "no guidance" reaches an instrument.
+    async fn publish_nav_guidance(
+        &mut self,
+        guidance: Option<&NavGuidance>,
+        acquired_at_ns: u64,
+    ) -> bool {
+        let Some(publisher) = self.nav_guidance.as_mut() else {
+            return true;
+        };
+        let Some(publication) = publisher.publication(guidance, acquired_at_ns) else {
+            return true;
+        };
+        let state = match publication {
+            NavPublication::Sample(state) => Some(Box::new(state)),
+            NavPublication::Clear => None,
+        };
+        self.send_command(ToEngine::NavGuidance {
+            vehicle: HOST_VEHICLE,
+            state,
+        })
+        .await
     }
 
     /// Frames one typed intent under the held lease with a wrap-advancing

--- a/hosts/session-host/src/runtime/automation/task/fencing.rs
+++ b/hosts/session-host/src/runtime/automation/task/fencing.rs
@@ -36,6 +36,12 @@ impl MissionTask {
         if !our_pair(granted.vehicle.as_ref(), granted.scope.as_ref()) {
             return;
         }
+        // Fencing is permanent for this task: a later grant naming this
+        // principal must not re-arm the generation or the status, or the
+        // status would claim a lease the tick loop refuses to use.
+        if self.fenced {
+            return;
+        }
         if self.our_principal(granted.principal.as_ref()) {
             if let Some(generation) = granted.generation.as_ref() {
                 self.generation = Some(Generation::new(generation.value));
@@ -101,4 +107,47 @@ impl MissionTask {
 fn our_pair(vehicle: Option<&wire::VehicleId>, scope: Option<&wire::ScopeId>) -> bool {
     vehicle.is_some_and(|id| id.value == HOST_VEHICLE.as_u64())
         && scope.is_some_and(|id| id.value == MISSION_SCOPE)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use pilotage_protocol::PrincipalId;
+    use tokio::sync::{mpsc, watch};
+
+    use super::super::MissionTask;
+    use crate::runtime::{HOST_VEHICLE, automation::AutomationStatus};
+    use pilotage_protocol::wire;
+
+    #[tokio::test]
+    async fn a_grant_after_fencing_does_not_re_arm_the_generation() {
+        let (engine_tx, _engine_rx) = mpsc::channel(4);
+        let (status_tx, status_rx) = watch::channel(AutomationStatus::default());
+        let mut task = MissionTask::without_plan(
+            engine_tx.downgrade(),
+            tokio::time::Instant::now(),
+            status_tx,
+        );
+        task.principal = Some(PrincipalId::new(9));
+        task.fence("test fence");
+        let granted = wire::ScopeLeaseGranted {
+            vehicle: Some(wire::VehicleId {
+                value: HOST_VEHICLE.as_u64(),
+            }),
+            scope: Some(wire::ScopeId {
+                value: super::MISSION_SCOPE.to_owned(),
+            }),
+            principal: Some(wire::PrincipalId { value: 9 }),
+            generation: Some(wire::Generation { value: 5 }),
+            ..Default::default()
+        };
+        task.on_granted_event(&granted);
+        assert!(task.fenced, "fencing is permanent for the task");
+        assert_eq!(
+            task.generation, None,
+            "a later grant must not re-arm a fenced principal"
+        );
+        assert_eq!(status_rx.borrow().lease_generation, None);
+    }
 }

--- a/hosts/session-host/src/runtime/automation/task/fencing.rs
+++ b/hosts/session-host/src/runtime/automation/task/fencing.rs
@@ -1,0 +1,104 @@
+//! Authority-event fencing for the mission principal: any transition
+//! that moves the motion scope away from this principal stops the
+//! mission cold, and re-leasing is a human decision, never automation's
+//! (ADR-0025).
+
+use pilotage_protocol::{Generation, wire};
+use tracing::warn;
+
+use crate::runtime::HOST_VEHICLE;
+
+use super::{MISSION_SCOPE, MissionTask};
+
+impl MissionTask {
+    pub(super) fn on_authority(&mut self, bytes: &[u8]) {
+        let envelope = match pilotage_protocol::decode_envelope_length_delimited(bytes) {
+            Ok((envelope, _rest)) => envelope,
+            Err(error) => {
+                warn!(%error, "undecodable authority event");
+                return;
+            }
+        };
+        let Some(wire::envelope::Payload::AuthorityEvent(event)) = envelope.payload else {
+            return;
+        };
+        use wire::authority_event::Event;
+        match event.event {
+            Some(Event::ScopeLeaseGranted(granted)) => self.on_granted_event(&granted),
+            Some(Event::ScopeLeaseRevoked(revoked)) => self.on_revoked_event(&revoked),
+            Some(Event::EmergencyOverrideApplied(applied)) => self.on_override_event(&applied),
+            Some(Event::ScopeTransferCommitted(committed)) => self.on_transfer_event(&committed),
+            _ => {}
+        }
+    }
+
+    fn on_granted_event(&mut self, granted: &wire::ScopeLeaseGranted) {
+        if !our_pair(granted.vehicle.as_ref(), granted.scope.as_ref()) {
+            return;
+        }
+        if self.our_principal(granted.principal.as_ref()) {
+            if let Some(generation) = granted.generation.as_ref() {
+                self.generation = Some(Generation::new(generation.value));
+                self.update(|status| status.lease_generation = Some(generation.value));
+            }
+        } else if self.generation.is_some() {
+            self.fence("the motion scope was granted to another principal");
+        }
+    }
+
+    fn on_revoked_event(&mut self, revoked: &wire::ScopeLeaseRevoked) {
+        if !our_pair(revoked.vehicle.as_ref(), revoked.scope.as_ref()) {
+            return;
+        }
+        if self.our_principal(revoked.principal.as_ref()) && self.generation.is_some() {
+            self.fence("the motion lease was revoked");
+        }
+    }
+
+    fn on_override_event(&mut self, applied: &wire::EmergencyOverrideApplied) {
+        if !our_pair(applied.vehicle.as_ref(), applied.scope.as_ref()) {
+            return;
+        }
+        if !self.our_principal(applied.principal.as_ref()) && self.generation.is_some() {
+            self.fence("an emergency override preempted the motion scope");
+        }
+    }
+
+    fn on_transfer_event(&mut self, committed: &wire::ScopeTransferCommitted) {
+        if !our_pair(committed.vehicle.as_ref(), committed.scope.as_ref()) {
+            return;
+        }
+        if !self.our_principal(committed.to_principal.as_ref()) && self.generation.is_some() {
+            self.fence("the motion scope transferred to another principal");
+        }
+    }
+
+    fn our_principal(&self, principal: Option<&wire::PrincipalId>) -> bool {
+        match (self.principal, principal) {
+            (Some(ours), Some(event)) => event.value == ours.as_u64(),
+            _ => false,
+        }
+    }
+
+    /// Drops the held generation and stops framing, permanently for this
+    /// task: re-leasing is a human decision, never automation's
+    /// (ADR-0025).
+    pub(super) fn fence(&mut self, reason: &str) {
+        if self.fenced {
+            return;
+        }
+        self.fenced = true;
+        self.generation = None;
+        warn!(reason, "mission authority fenced; holding without re-lease");
+        self.update(|status| {
+            status.fenced = true;
+            status.lease_generation = None;
+        });
+    }
+}
+
+/// Whether an authority event names this principal's (vehicle, scope).
+fn our_pair(vehicle: Option<&wire::VehicleId>, scope: Option<&wire::ScopeId>) -> bool {
+    vehicle.is_some_and(|id| id.value == HOST_VEHICLE.as_u64())
+        && scope.is_some_and(|id| id.value == MISSION_SCOPE)
+}

--- a/hosts/session-host/src/runtime/automation/task/nav_guidance.rs
+++ b/hosts/session-host/src/runtime/automation/task/nav_guidance.rs
@@ -109,7 +109,7 @@ fn to_wire(guidance: &NavGuidance, stamp: wire::MeasurementStamp) -> wire::NavGu
         stamp: Some(stamp),
         to_ident: guidance.to_ident.clone(),
         from_ident: guidance.from_ident.clone().unwrap_or_default(),
-        course_rad: guidance.course_rad as f32,
+        course_rad: course_to_wire(guidance.course_rad),
         lateral_deviation_m: deviation_to_wire(guidance.lateral_deviation_m),
         vertical_deviation_m: deviation_to_wire(guidance.vertical_deviation_m),
         distance_to_waypoint_m: guidance.distance_to_waypoint_m as f32,
@@ -125,4 +125,16 @@ fn to_wire(guidance: &NavGuidance, stamp: wire::MeasurementStamp) -> wire::NavGu
 
 fn deviation_to_wire(deviation_m: Option<f64>) -> f32 {
     deviation_m.map_or(f32::NAN, |value| value as f32)
+}
+
+/// Narrows a course to the wire's half-open `[0, 2π)` contract. An f64 a
+/// few ULPs below 2π rounds UP to exactly f32 τ in the narrowing, which
+/// would leave the documented range; due north owns that boundary.
+fn course_to_wire(course_rad: f64) -> f32 {
+    let narrowed = course_rad as f32;
+    if narrowed >= std::f32::consts::TAU {
+        0.0
+    } else {
+        narrowed
+    }
 }

--- a/hosts/session-host/src/runtime/automation/task/nav_guidance.rs
+++ b/hosts/session-host/src/runtime/automation/task/nav_guidance.rs
@@ -1,0 +1,128 @@
+//! Mission guidance onto the telemetry plane (ADR-0031): the executor's
+//! plan-relative geometry becomes one stamped wire group per publication.
+//!
+//! The stamp is the host's own — this principal is the source, so the
+//! acquisition time is host-monotonic (the shared origin every host
+//! stamp derives from, ADR-0009) and the integrity is that of an
+//! in-process observation, not an authenticated link. The sequence
+//! advances only for a NEW sample, so a re-published cached group stays
+//! byte-identical, and guidance that ends is cleared rather than frozen
+//! or centered.
+
+use pilotage_mission::{NavGuidance, NavQuality};
+use pilotage_protocol::{SessionId, wire};
+
+#[cfg(test)]
+mod tests;
+
+/// Source identity of the mission principal's guidance group. Role
+/// travels in the stamp, so this id may collide with another role's
+/// without ambiguity.
+const NAV_GUIDANCE_SOURCE_ID: u64 = 1;
+
+/// Epoch of that source. The principal publishes guidance for exactly one
+/// mission per session, so nothing restarts under a live incarnation.
+const NAV_GUIDANCE_EPOCH: u32 = 0;
+
+/// Label half of the guidance incarnation token, so an incarnation from
+/// this group cannot be confused with another group's that happens to
+/// share a session.
+const INCARNATION_TAG: &[u8; 8] = b"pmisnav\0";
+
+/// What one mission tick owes the telemetry assembly.
+pub(super) enum NavPublication {
+    /// A new guidance sample under an advanced sequence.
+    Sample(wire::NavGuidanceState),
+    /// Guidance ended: the stored state must be dropped so the field goes
+    /// absent on the wire.
+    Clear,
+}
+
+/// Stamps the mission executor's guidance for one session.
+pub(super) struct NavGuidancePublisher {
+    sequence: u32,
+    incarnation: [u8; 16],
+    published: bool,
+}
+
+impl NavGuidancePublisher {
+    /// Binds a publisher to `session`, deriving the equality-only
+    /// incarnation token once: receivers compare it for equality, so it
+    /// must stay fixed for as long as this principal flies, while a
+    /// later session is visibly a different attachment.
+    pub(super) fn for_session(session: SessionId) -> Self {
+        let mut incarnation = [0u8; 16];
+        let (tag, id) = incarnation.split_at_mut(INCARNATION_TAG.len());
+        tag.copy_from_slice(INCARNATION_TAG);
+        id.copy_from_slice(&session.as_u64().to_le_bytes());
+        Self {
+            sequence: 0,
+            incarnation,
+            published: false,
+        }
+    }
+
+    /// What to send for this tick's `guidance`, or `None` when the wire
+    /// already says the right thing: a clear is owed once, not on every
+    /// tick a plan is not being flown.
+    pub(super) fn publication(
+        &mut self,
+        guidance: Option<&NavGuidance>,
+        acquired_at_ns: u64,
+    ) -> Option<NavPublication> {
+        match guidance {
+            Some(guidance) => {
+                self.sequence = self.sequence.wrapping_add(1);
+                self.published = true;
+                Some(NavPublication::Sample(to_wire(
+                    guidance,
+                    self.stamp(acquired_at_ns),
+                )))
+            }
+            None if self.published => {
+                self.published = false;
+                Some(NavPublication::Clear)
+            }
+            None => None,
+        }
+    }
+
+    fn stamp(&self, acquired_at_ns: u64) -> wire::MeasurementStamp {
+        wire::MeasurementStamp {
+            source_id: NAV_GUIDANCE_SOURCE_ID,
+            source_epoch: NAV_GUIDANCE_EPOCH,
+            sequence: self.sequence,
+            acquired_at_ns,
+            clock: wire::MeasurementClock::HostMonotonic as i32,
+            source_incarnation: self.incarnation.to_vec(),
+            role: wire::SourceRole::NavigationSolution as i32,
+            integrity: wire::SourceIntegrity::Unprotected as i32,
+        }
+    }
+}
+
+/// The wire shape of one guidance sample. A deviation the executor is not
+/// tracking travels as NaN — the schema's "no reading" encoding — because
+/// zero would read as on-course or on-profile.
+fn to_wire(guidance: &NavGuidance, stamp: wire::MeasurementStamp) -> wire::NavGuidanceState {
+    wire::NavGuidanceState {
+        stamp: Some(stamp),
+        to_ident: guidance.to_ident.clone(),
+        from_ident: guidance.from_ident.clone().unwrap_or_default(),
+        course_rad: guidance.course_rad as f32,
+        lateral_deviation_m: deviation_to_wire(guidance.lateral_deviation_m),
+        vertical_deviation_m: deviation_to_wire(guidance.vertical_deviation_m),
+        distance_to_waypoint_m: guidance.distance_to_waypoint_m as f32,
+        leg_index: guidance.leg_index,
+        waypoint_count: guidance.waypoint_count,
+        solution_quality: match guidance.quality {
+            NavQuality::Good => 0,
+            NavQuality::Degraded => 1,
+            NavQuality::Unusable => 2,
+        },
+    }
+}
+
+fn deviation_to_wire(deviation_m: Option<f64>) -> f32 {
+    deviation_m.map_or(f32::NAN, |value| value as f32)
+}

--- a/hosts/session-host/src/runtime/automation/task/nav_guidance/tests.rs
+++ b/hosts/session-host/src/runtime/automation/task/nav_guidance/tests.rs
@@ -1,0 +1,132 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_mission::{NavGuidance, NavQuality};
+use pilotage_protocol::{SessionId, wire};
+
+use super::{NavGuidancePublisher, NavPublication};
+
+fn guidance() -> NavGuidance {
+    NavGuidance {
+        to_ident: "DEMOB".to_owned(),
+        from_ident: Some("DEMOA".to_owned()),
+        course_rad: 1.25,
+        lateral_deviation_m: Some(-12.5),
+        vertical_deviation_m: Some(3.0),
+        distance_to_waypoint_m: 480.0,
+        leg_index: 1,
+        waypoint_count: 3,
+        quality: NavQuality::Degraded,
+    }
+}
+
+fn sample(publication: Option<NavPublication>) -> wire::NavGuidanceState {
+    match publication {
+        Some(NavPublication::Sample(state)) => state,
+        Some(NavPublication::Clear) => panic!("expected a guidance sample, got a clear"),
+        None => panic!("expected a guidance sample, got nothing"),
+    }
+}
+
+#[test]
+fn every_sample_carries_the_navigation_role_under_the_host_clock() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    let state = sample(publisher.publication(Some(&guidance()), 1_000));
+    let stamp = state.stamp.expect("a guidance sample is stamped");
+
+    assert_eq!(stamp.role, wire::SourceRole::NavigationSolution as i32);
+    assert_eq!(stamp.clock, wire::MeasurementClock::HostMonotonic as i32);
+    assert_eq!(stamp.integrity, wire::SourceIntegrity::Unprotected as i32);
+    assert_eq!(stamp.acquired_at_ns, 1_000);
+    assert_eq!(stamp.source_epoch, 0);
+    assert_eq!(stamp.source_incarnation.len(), 16);
+}
+
+#[test]
+fn the_sequence_advances_once_per_sample_under_a_fixed_incarnation() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    let first = sample(publisher.publication(Some(&guidance()), 1_000));
+    let second = sample(publisher.publication(Some(&guidance()), 2_000));
+    let (first, second) = (
+        first.stamp.expect("stamped"),
+        second.stamp.expect("stamped"),
+    );
+
+    assert_eq!(first.sequence, 1);
+    assert_eq!(second.sequence, 2);
+    assert_eq!(
+        first.source_incarnation, second.source_incarnation,
+        "the attachment token is equality-only: it must not move under a live session"
+    );
+}
+
+#[test]
+fn a_different_session_is_a_different_incarnation() {
+    let mut one = NavGuidancePublisher::for_session(SessionId::new(7));
+    let mut other = NavGuidancePublisher::for_session(SessionId::new(8));
+    let one = sample(one.publication(Some(&guidance()), 0));
+    let other = sample(other.publication(Some(&guidance()), 0));
+
+    assert_ne!(
+        one.stamp.expect("stamped").source_incarnation,
+        other.stamp.expect("stamped").source_incarnation
+    );
+}
+
+#[test]
+fn guidance_that_ends_is_cleared_exactly_once() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    assert!(
+        publisher.publication(None, 0).is_none(),
+        "nothing was ever published, so nothing is owed"
+    );
+
+    sample(publisher.publication(Some(&guidance()), 1_000));
+    assert!(
+        matches!(
+            publisher.publication(None, 2_000),
+            Some(NavPublication::Clear)
+        ),
+        "the end of guidance is announced"
+    );
+    assert!(
+        publisher.publication(None, 3_000).is_none(),
+        "the clear is owed once, not every tick"
+    );
+}
+
+#[test]
+fn field_values_survive_the_conversion() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    let state = sample(publisher.publication(Some(&guidance()), 0));
+
+    assert_eq!(state.to_ident, "DEMOB");
+    assert_eq!(state.from_ident, "DEMOA");
+    assert!((state.course_rad - 1.25).abs() < 1e-6);
+    assert!((state.lateral_deviation_m + 12.5).abs() < 1e-6);
+    assert!((state.vertical_deviation_m - 3.0).abs() < 1e-6);
+    assert!((state.distance_to_waypoint_m - 480.0).abs() < 1e-3);
+    assert_eq!(state.leg_index, 1);
+    assert_eq!(state.waypoint_count, 3);
+    assert_eq!(state.solution_quality, 1);
+}
+
+#[test]
+fn an_undefined_deviation_travels_as_nan_and_a_direct_to_leg_has_no_origin() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    let direct_to = NavGuidance {
+        from_ident: None,
+        lateral_deviation_m: None,
+        vertical_deviation_m: None,
+        quality: NavQuality::Unusable,
+        ..guidance()
+    };
+    let state = sample(publisher.publication(Some(&direct_to), 0));
+
+    assert!(state.from_ident.is_empty());
+    assert!(
+        state.lateral_deviation_m.is_nan(),
+        "a direct-to leg has no cross-track reading, and zero would read as on-course"
+    );
+    assert!(state.vertical_deviation_m.is_nan());
+    assert_eq!(state.solution_quality, 2);
+}

--- a/hosts/session-host/src/runtime/automation/task/nav_guidance/tests.rs
+++ b/hosts/session-host/src/runtime/automation/task/nav_guidance/tests.rs
@@ -130,3 +130,18 @@ fn an_undefined_deviation_travels_as_nan_and_a_direct_to_leg_has_no_origin() {
     assert!(state.vertical_deviation_m.is_nan());
     assert_eq!(state.solution_quality, 2);
 }
+
+#[test]
+fn a_course_a_hair_under_north_narrows_inside_the_half_open_range() {
+    let mut publisher = NavGuidancePublisher::for_session(SessionId::new(7));
+    // A few f64 ULPs below 2π rounds UP to exactly f32 τ in the
+    // narrowing; the wire contract is half-open [0, 2π), so due north
+    // owns that boundary.
+    let near_north = NavGuidance {
+        course_rad: std::f64::consts::TAU - 1e-9,
+        ..guidance()
+    };
+    let state = sample(publisher.publication(Some(&near_north), 0));
+    assert_eq!(state.course_rad, 0.0, "the boundary folds to due north");
+    assert!((0.0..std::f32::consts::TAU).contains(&state.course_rad));
+}

--- a/hosts/session-host/src/runtime/automation/task/session_flow.rs
+++ b/hosts/session-host/src/runtime/automation/task/session_flow.rs
@@ -74,6 +74,11 @@ impl MissionTask {
     /// mission ceilings to the advertised envelope, build the flight
     /// engine, then announce the profile and request the motion lease.
     async fn on_welcome(&mut self, welcome: ServerWelcome) -> bool {
+        // Fencing is permanent for this task: even a fresh welcome must
+        // not restart activation or re-lease the motion scope.
+        if self.fenced {
+            return false;
+        }
         self.session = Some(welcome.session);
         self.principal = Some(welcome.principal);
         self.nav_guidance = Some(NavGuidancePublisher::for_session(welcome.session));
@@ -82,7 +87,13 @@ impl MissionTask {
             return true;
         };
         let mut config = plan.config();
-        tighten_limits(&mut config.limits, &welcome.host_capabilities);
+        if !tighten_limits(&mut config.limits, &welcome.host_capabilities) {
+            // Streaming velocity intents the host never advertised would
+            // fail open against the command gate; a mission with no
+            // authorized envelope does not fly.
+            self.fence("no vehicle.motion velocity capability advertised");
+            return false;
+        }
         let limits = config.limits;
         match MissionEngine::new(
             &plan.navdata.snapshot,
@@ -212,7 +223,7 @@ impl MissionTask {
         if !ours {
             return;
         }
-        if let Some(ownship) = ownship::ownship_from_wire(sample, now) {
+        if let Some(ownship) = ownship::ownship_from_wire(sample, now, self.planar_pose_is_truth) {
             mission.on_ownship(&ownship, now);
         }
     }
@@ -223,10 +234,12 @@ impl MissionTask {
 /// ceiling; a zero advertisement means "no bound" on the wire and leaves
 /// the configured ceiling in force. Vertical mirrors the command gate's
 /// effective bound (`max_vertical`, falling back to `max_linear`).
-fn tighten_limits(limits: &mut MissionLimits, capabilities: &wire::HostCapabilities) {
+/// Returns false when no velocity capability is advertised at all — the
+/// mission has no authorized envelope and must not fly.
+fn tighten_limits(limits: &mut MissionLimits, capabilities: &wire::HostCapabilities) -> bool {
     let Some(intent) = velocity_capability(capabilities) else {
-        warn!("no vehicle.motion velocity capability advertised; keeping configured limits");
-        return;
+        error!("no vehicle.motion velocity capability advertised; the mission cannot fly");
+        return false;
     };
     tighten(&mut limits.max_horizontal_mps, intent.max_linear);
     let vertical = if intent.max_vertical > 0.0 {
@@ -236,6 +249,7 @@ fn tighten_limits(limits: &mut MissionLimits, capabilities: &wire::HostCapabilit
     };
     tighten(&mut limits.max_vertical_mps, vertical);
     tighten(&mut limits.max_yaw_rate_rps, intent.max_angular);
+    true
 }
 
 fn tighten(limit: &mut f64, advertised: f32) {
@@ -267,4 +281,55 @@ fn velocity_capability(capabilities: &wire::HostCapabilities) -> Option<&wire::I
         .intents
         .iter()
         .find(|intent| intent.family == wire::IntentFamily::Velocity as i32)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    fn advertised(max_linear: f32) -> wire::HostCapabilities {
+        wire::HostCapabilities {
+            vehicles: vec![wire::VehicleDescriptor {
+                vehicle: Some(wire::VehicleId {
+                    value: HOST_VEHICLE.as_u64(),
+                }),
+                scopes: vec![wire::ScopeDescriptor {
+                    scope: Some(wire::ScopeId {
+                        value: MISSION_SCOPE.to_owned(),
+                    }),
+                    intents: vec![wire::IntentCapability {
+                        family: wire::IntentFamily::Velocity as i32,
+                        max_linear,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_missing_velocity_capability_is_mission_fatal_not_fail_open() {
+        let mut limits = MissionLimits::default();
+        let configured = limits;
+        assert!(!tighten_limits(
+            &mut limits,
+            &wire::HostCapabilities::default()
+        ));
+        assert_eq!(
+            limits, configured,
+            "refusal, not silent flight on unadvertised ceilings"
+        );
+    }
+
+    #[test]
+    fn an_advertised_envelope_tightens_the_configured_ceilings() {
+        let mut limits = MissionLimits::default();
+        assert!(tighten_limits(&mut limits, &advertised(1.0)));
+        assert_eq!(limits.max_horizontal_mps, 1.0);
+    }
 }

--- a/hosts/session-host/src/runtime/automation/task/session_flow.rs
+++ b/hosts/session-host/src/runtime/automation/task/session_flow.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::runtime::HOST_VEHICLE;
 
+use super::nav_guidance::NavGuidancePublisher;
 use super::{
     ACTIVATION_REVISION, MISSION_SCOPE, MissionTask, NO_DEVICE_DIGEST, PROFILE_DIGEST, PROFILE_ID,
     PROFILE_REVISION, ownship,
@@ -75,6 +76,7 @@ impl MissionTask {
     async fn on_welcome(&mut self, welcome: ServerWelcome) -> bool {
         self.session = Some(welcome.session);
         self.principal = Some(welcome.principal);
+        self.nav_guidance = Some(NavGuidancePublisher::for_session(welcome.session));
         self.update(|status| status.session = Some(welcome.session.as_u64()));
         let Some(plan) = self.plan.take() else {
             return true;

--- a/hosts/session-host/src/runtime/automation/task/session_flow.rs
+++ b/hosts/session-host/src/runtime/automation/task/session_flow.rs
@@ -1,0 +1,268 @@
+//! The mission principal's session flow: bootstrap-stream replies
+//! (welcome, lease, action results, rejections) and best-effort
+//! datagrams (telemetry, rejection notices), decoded with the same wire
+//! vocabulary remote clients read.
+
+use pilotage_mission::{MissionEngine, MissionLimits};
+use pilotage_protocol::{
+    ControlAction, ControlActionResult, FrameRejected, FrameRejectionReason, LeaseRequest,
+    LeaseResponse, ProfileActivation, ScopeId, ServerWelcome, wire,
+};
+use pilotage_session::DomainEnvelope;
+use prost::Message;
+use tracing::{debug, error, info, warn};
+
+use crate::runtime::HOST_VEHICLE;
+
+use super::{
+    ACTIVATION_REVISION, MISSION_SCOPE, MissionTask, NO_DEVICE_DIGEST, PROFILE_DIGEST, PROFILE_ID,
+    PROFILE_REVISION, ownship,
+};
+
+impl MissionTask {
+    /// One reliable bootstrap-stream reply, decoded with the same
+    /// envelope framing the remote clients read.
+    pub(super) async fn on_bootstrap(&mut self, bytes: &[u8]) -> bool {
+        let envelope = match pilotage_protocol::decode_envelope_length_delimited(bytes) {
+            Ok((envelope, _rest)) => envelope,
+            Err(error) => {
+                warn!(%error, "undecodable bootstrap reply");
+                return true;
+            }
+        };
+        match envelope.payload {
+            Some(wire::envelope::Payload::ServerWelcome(welcome)) => {
+                match ServerWelcome::try_from(welcome) {
+                    Ok(welcome) => self.on_welcome(welcome).await,
+                    Err(error) => {
+                        error!(%error, "welcome failed to convert");
+                        false
+                    }
+                }
+            }
+            Some(wire::envelope::Payload::LeaseResponse(response)) => {
+                match LeaseResponse::try_from(response) {
+                    Ok(response) => self.on_lease_response(&response),
+                    Err(error) => warn!(%error, "lease response failed to convert"),
+                }
+                true
+            }
+            Some(wire::envelope::Payload::ControlActionResult(result)) => {
+                match ControlActionResult::try_from(result) {
+                    Ok(result) => self.on_action_result(&result),
+                    Err(error) => warn!(%error, "action result failed to convert"),
+                }
+                true
+            }
+            Some(wire::envelope::Payload::FrameRejected(rejection)) => {
+                match FrameRejected::try_from(rejection) {
+                    Ok(rejection) => self.on_frame_rejected(&rejection),
+                    Err(error) => warn!(%error, "frame rejection failed to convert"),
+                }
+                true
+            }
+            Some(wire::envelope::Payload::LeaseReleased(released)) => {
+                debug!(?released, "lease release acknowledged");
+                true
+            }
+            _ => true,
+        }
+    }
+
+    /// The welcome closes the handshake: capture identities, tighten the
+    /// mission ceilings to the advertised envelope, build the flight
+    /// engine, then announce the profile and request the motion lease.
+    async fn on_welcome(&mut self, welcome: ServerWelcome) -> bool {
+        self.session = Some(welcome.session);
+        self.principal = Some(welcome.principal);
+        self.update(|status| status.session = Some(welcome.session.as_u64()));
+        let Some(plan) = self.plan.take() else {
+            return true;
+        };
+        let mut config = plan.config();
+        tighten_limits(&mut config.limits, &welcome.host_capabilities);
+        let limits = config.limits;
+        match MissionEngine::new(
+            &plan.navdata.snapshot,
+            plan.navdata.provenance.clone(),
+            config,
+        ) {
+            Ok((engine, record)) => {
+                info!(
+                    route = %record.route_input,
+                    max_horizontal_mps = limits.max_horizontal_mps,
+                    max_vertical_mps = limits.max_vertical_mps,
+                    max_yaw_rate_rps = limits.max_yaw_rate_rps,
+                    "mission engine ready under advertised limits"
+                );
+                self.mission = Some(engine);
+            }
+            Err(error) => {
+                error!(%error, "mission engine failed to build");
+                return false;
+            }
+        }
+        let activation = DomainEnvelope::ProfileActivation(ProfileActivation {
+            session: welcome.session,
+            profile_id: PROFILE_ID.to_owned(),
+            profile_revision: PROFILE_REVISION,
+            activation_revision: ACTIVATION_REVISION,
+            digest: PROFILE_DIGEST,
+            device_profile_id: String::new(),
+            device_profile_revision: 0,
+            device_digest: NO_DEVICE_DIGEST,
+        });
+        if !self.send_message(activation).await {
+            return false;
+        }
+        self.update(|status| status.activation_sent = true);
+        let lease = DomainEnvelope::Lease(LeaseRequest {
+            vehicle: HOST_VEHICLE,
+            scope: ScopeId::new(MISSION_SCOPE),
+        });
+        self.send_message(lease).await
+    }
+
+    fn on_lease_response(&mut self, response: &LeaseResponse) {
+        if response.vehicle != HOST_VEHICLE || response.scope.as_str() != MISSION_SCOPE {
+            return;
+        }
+        if response.granted {
+            info!(
+                generation = response.generation.as_u64(),
+                "mission motion lease granted"
+            );
+            self.generation = Some(response.generation);
+            self.update(|status| status.lease_generation = Some(response.generation.as_u64()));
+        } else {
+            error!(reason = ?response.reason, "mission motion lease denied");
+            self.fence("the motion lease was denied");
+        }
+    }
+
+    /// Routes a correlated action result back into the mission engine.
+    fn on_action_result(&mut self, result: &ControlActionResult) {
+        let Some(mission_id) = self.pending_actions.remove(&result.action_id) else {
+            debug!(action_id = result.action_id, "uncorrelated action result");
+            return;
+        };
+        info!(
+            action = ?result.action,
+            accepted = result.accepted,
+            detail = %result.detail,
+            "mission action result"
+        );
+        if let Some(mission) = self.mission.as_mut() {
+            mission.on_action_result(mission_id, result.accepted);
+        }
+        if result.accepted && matches!(result.action, ControlAction::Arm) {
+            self.update(|status| status.arm_accepted = true);
+        }
+    }
+
+    fn on_frame_rejected(&mut self, rejection: &FrameRejected) {
+        warn!(
+            reason = ?rejection.reason,
+            sequence = rejection.sequence.as_u32(),
+            current_generation = rejection.current_generation.as_u64(),
+            "mission frame rejected"
+        );
+        self.update(|status| status.frames_rejected = status.frames_rejected.wrapping_add(1));
+        // A stale-generation or no-holder rejection means authority moved
+        // on while an event was still in flight; stop framing rather than
+        // keep hammering a superseded grant.
+        if matches!(
+            rejection.reason,
+            FrameRejectionReason::StaleGeneration | FrameRejectionReason::NoHolder
+        ) {
+            self.fence("frames are rejected under a superseded authority");
+        }
+    }
+
+    /// One best-effort datagram: telemetry feeding the mission's ownship
+    /// path, or a frame-rejection notice.
+    pub(super) fn on_datagram(&mut self, bytes: &[u8]) {
+        let Ok(envelope) = wire::Envelope::decode(bytes) else {
+            debug!("undecodable datagram payload");
+            return;
+        };
+        match envelope.payload {
+            Some(wire::envelope::Payload::TelemetrySample(sample)) => self.on_telemetry(&sample),
+            Some(wire::envelope::Payload::FrameRejected(rejection)) => {
+                match FrameRejected::try_from(rejection) {
+                    Ok(rejection) => self.on_frame_rejected(&rejection),
+                    Err(error) => warn!(%error, "frame rejection failed to convert"),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_telemetry(&mut self, sample: &wire::TelemetrySample) {
+        let now = self.mission_now();
+        let Some(mission) = self.mission.as_mut() else {
+            return;
+        };
+        let ours = sample
+            .vehicle
+            .as_ref()
+            .is_some_and(|vehicle| vehicle.value == HOST_VEHICLE.as_u64());
+        if !ours {
+            return;
+        }
+        if let Some(ownship) = ownship::ownship_from_wire(sample, now) {
+            mission.on_ownship(&ownship, now);
+        }
+    }
+}
+
+/// Tightens the mission ceilings to the advertised `vehicle.motion`
+/// velocity envelope: a nonzero advertised bound lowers the configured
+/// ceiling; a zero advertisement means "no bound" on the wire and leaves
+/// the configured ceiling in force. Vertical mirrors the command gate's
+/// effective bound (`max_vertical`, falling back to `max_linear`).
+fn tighten_limits(limits: &mut MissionLimits, capabilities: &wire::HostCapabilities) {
+    let Some(intent) = velocity_capability(capabilities) else {
+        warn!("no vehicle.motion velocity capability advertised; keeping configured limits");
+        return;
+    };
+    tighten(&mut limits.max_horizontal_mps, intent.max_linear);
+    let vertical = if intent.max_vertical > 0.0 {
+        intent.max_vertical
+    } else {
+        intent.max_linear
+    };
+    tighten(&mut limits.max_vertical_mps, vertical);
+    tighten(&mut limits.max_yaw_rate_rps, intent.max_angular);
+}
+
+fn tighten(limit: &mut f64, advertised: f32) {
+    if advertised > 0.0 {
+        *limit = limit.min(f64::from(advertised));
+    }
+}
+
+/// The advertised velocity capability for this principal's (vehicle,
+/// scope), if the welcome carried one.
+fn velocity_capability(capabilities: &wire::HostCapabilities) -> Option<&wire::IntentCapability> {
+    capabilities
+        .vehicles
+        .iter()
+        .find(|vehicle| {
+            vehicle
+                .vehicle
+                .as_ref()
+                .is_some_and(|id| id.value == HOST_VEHICLE.as_u64())
+        })?
+        .scopes
+        .iter()
+        .find(|scope| {
+            scope
+                .scope
+                .as_ref()
+                .is_some_and(|id| id.value == MISSION_SCOPE)
+        })?
+        .intents
+        .iter()
+        .find(|intent| intent.family == wire::IntentFamily::Velocity as i32)
+}

--- a/hosts/session-host/src/runtime/engine_actor.rs
+++ b/hosts/session-host/src/runtime/engine_actor.rs
@@ -3,13 +3,15 @@
 //! messages here instead of touching engine state directly, so the state
 //! machine is driven from exactly one place.
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use pilotage_adapter_api::{StepBudget, VehicleAdapter};
+use pilotage_protocol::{VehicleId, wire};
 use pilotage_session::{ClientKey, DomainEnvelope, SessionAction, SessionEngine, SessionOutcome};
 use pilotage_timing::{BoundedLatencyLog, MonoTimestamp, Stage, StageLatency};
+use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -19,7 +21,9 @@ use crate::runtime::wire_codec::{
     encode_envelope_message, encode_pong_datagram, encode_telemetry_datagram,
 };
 
+mod command;
 mod telemetry;
+pub use command::ToEngine;
 use telemetry::sample_to_wire;
 
 #[cfg(test)]
@@ -49,34 +53,6 @@ pub const TICK_INTERVAL: Duration = Duration::from_millis(10);
 /// Capacity of the per-stage latency ring buffer dumped at shutdown.
 const LATENCY_LOG_CAPACITY: usize = 4096;
 
-/// One command a connection task submits to the engine actor.
-#[derive(Debug)]
-pub enum ToEngine {
-    /// A client connected; the actor should register its outbound sender in
-    /// the client registry keyed on `client`.
-    ClientConnected {
-        /// Driver-assigned key for the new connection.
-        client: ClientKey,
-        /// Outbound sender the actor unicasts/broadcasts through.
-        sender: mpsc::Sender<ToConnection>,
-    },
-    /// A decoded client message ready for [`SessionEngine::handle_client_message`].
-    ClientMessage {
-        /// Sender of the message.
-        client: ClientKey,
-        /// The decoded message.
-        message: DomainEnvelope,
-        /// The driver's receive timestamp, for staleness/latency accounting.
-        now: MonoTimestamp,
-    },
-    /// A one-shot latency summary request, used by the shutdown path to log
-    /// the accumulated per-stage timings before the process exits.
-    DumpLatencySummary {
-        /// Where to send the formatted summary line.
-        reply: oneshot::Sender<String>,
-    },
-}
-
 /// Owns the [`SessionEngine`], the embedded vehicle adapter, the client
 /// registry, and the per-stage latency log; runs until its command channel
 /// closes.
@@ -98,6 +74,11 @@ pub struct EngineActor<A: VehicleAdapter> {
     /// was already fenced, so an unenacted policy means the vehicle may
     /// still be executing its last command with nobody in control.
     link_loss_enact_failures: u64,
+    /// Latest navigation guidance per vehicle, published by the host's
+    /// navigation component (ADR-0031). A vehicle with no entry has no
+    /// guidance to show: its telemetry carries the field absent rather
+    /// than a centered or zeroed one.
+    nav_guidance: BTreeMap<VehicleId, wire::NavGuidanceState>,
     /// The single monotonic origin shared with every connection task's
     /// client-message stamps (ADR-0009: one `host_time` reference domain).
     /// Passed in rather than sampled here so tick-driven timestamps and
@@ -124,6 +105,7 @@ impl<A: VehicleAdapter> EngineActor<A> {
             action_dedup: ActionDedup::default(),
             adapter_rejection_dedup: RejectionDedup::default(),
             link_loss_enact_failures: 0,
+            nav_guidance: BTreeMap::new(),
             start,
         }
     }
@@ -161,6 +143,14 @@ impl<A: VehicleAdapter> EngineActor<A> {
             } => {
                 self.on_client_message(client, message, now);
             }
+            ToEngine::NavGuidance { vehicle, state } => match state {
+                Some(state) => {
+                    self.nav_guidance.insert(vehicle, *state);
+                }
+                None => {
+                    self.nav_guidance.remove(&vehicle);
+                }
+            },
             ToEngine::DumpLatencySummary { reply } => {
                 let summary = self.latency_summary();
                 // The receiver may have already given up waiting; a dropped
@@ -220,7 +210,16 @@ impl<A: VehicleAdapter> EngineActor<A> {
     fn broadcast_telemetry(&mut self, now: MonoTimestamp) {
         let batch = self.adapter.sample_telemetry();
         for sample in batch.samples {
-            let wire_sample = sample_to_wire(sample, now);
+            let vehicle = sample.vehicle;
+            let mut wire_sample = sample_to_wire(sample, now);
+            // Guidance is a host-internal side input, not adapter output
+            // (ADR-0031): the assembly attaches the vehicle's latest
+            // state, re-publishing it unchanged until the navigation
+            // component supplies a new one.
+            wire_sample.nav_guidance = self
+                .nav_guidance
+                .get(&vehicle)
+                .map(|state| Box::new(state.clone()));
             let bytes = encode_telemetry_datagram(wire_sample);
             self.broadcast_datagram(bytes);
         }

--- a/hosts/session-host/src/runtime/engine_actor/command.rs
+++ b/hosts/session-host/src/runtime/engine_actor/command.rs
@@ -1,0 +1,52 @@
+//! The engine actor's inbound command vocabulary: everything a
+//! connection task or an in-process principal asks the single
+//! engine-owning task to do.
+
+use pilotage_protocol::{VehicleId, wire};
+use pilotage_session::{ClientKey, DomainEnvelope};
+use pilotage_timing::MonoTimestamp;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::runtime::connection::ToConnection;
+
+/// One command a connection task submits to the engine actor.
+#[derive(Debug)]
+pub enum ToEngine {
+    /// A client connected; the actor should register its outbound sender in
+    /// the client registry keyed on `client`.
+    ClientConnected {
+        /// Driver-assigned key for the new connection.
+        client: ClientKey,
+        /// Outbound sender the actor unicasts/broadcasts through.
+        sender: mpsc::Sender<ToConnection>,
+    },
+    /// A decoded client message ready for [`SessionEngine::handle_client_message`].
+    ///
+    /// [`SessionEngine::handle_client_message`]: pilotage_session::SessionEngine::handle_client_message
+    ClientMessage {
+        /// Sender of the message.
+        client: ClientKey,
+        /// The decoded message.
+        message: DomainEnvelope,
+        /// The driver's receive timestamp, for staleness/latency accounting.
+        now: MonoTimestamp,
+    },
+    /// Navigation guidance for one vehicle, published by the host's
+    /// navigation component rather than an FC adapter (ADR-0031). The
+    /// actor holds the latest state and attaches it to that vehicle's
+    /// outgoing telemetry until it is replaced or cleared.
+    NavGuidance {
+        /// The vehicle the guidance describes.
+        vehicle: VehicleId,
+        /// The stamped guidance state, or `None` to clear it: no plan
+        /// being flown means the field goes absent on the wire, never
+        /// zeroed or centered.
+        state: Option<Box<wire::NavGuidanceState>>,
+    },
+    /// A one-shot latency summary request, used by the shutdown path to log
+    /// the accumulated per-stage timings before the process exits.
+    DumpLatencySummary {
+        /// Where to send the formatted summary line.
+        reply: oneshot::Sender<String>,
+    },
+}

--- a/hosts/session-host/src/runtime/engine_actor/telemetry.rs
+++ b/hosts/session-host/src/runtime/engine_actor/telemetry.rs
@@ -42,6 +42,9 @@ pub(super) fn sample_to_wire(
             .fc_state
             .map(|state| Box::new(fc_state_to_wire(state))),
         gimbal: sample.gimbal.map(|gimbal| Box::new(gimbal_to_wire(gimbal))),
+        // Guidance does not come from the adapter; the engine actor
+        // attaches the navigation component's own state (ADR-0031).
+        nav_guidance: None,
     }
 }
 

--- a/hosts/session-host/src/runtime/options.rs
+++ b/hosts/session-host/src/runtime/options.rs
@@ -132,16 +132,7 @@ fn mission_from_env() -> Result<Option<MissionOptions>, HostError> {
     }
     let cruise_height_m = match mission_var("PILOTAGE_MISSION_CRUISE_HEIGHT")? {
         None => None,
-        Some(value) => {
-            Some(
-                value
-                    .parse::<f64>()
-                    .map_err(|source| HostError::MissionCruiseHeight {
-                        value: value.clone(),
-                        source,
-                    })?,
-            )
-        }
+        Some(value) => Some(parse_cruise_height(&value)?),
     };
     Ok(Some(MissionOptions {
         route,
@@ -150,6 +141,23 @@ fn mission_from_env() -> Result<Option<MissionOptions>, HostError> {
         date,
         cruise_height_m,
     }))
+}
+
+/// Parses and range-screens `PILOTAGE_MISSION_CRUISE_HEIGHT`. A negative
+/// height would plan every waypoint below the launch elevation, and a
+/// non-finite one disables every altitude comparison downstream; zero
+/// legitimately disables the climb phase.
+fn parse_cruise_height(value: &str) -> Result<f64, HostError> {
+    let height = value
+        .parse::<f64>()
+        .map_err(|source| HostError::MissionCruiseHeight {
+            value: value.to_owned(),
+            source,
+        })?;
+    if !height.is_finite() || height < 0.0 {
+        return Err(HostError::MissionCruiseHeightRange { height });
+    }
+    Ok(height)
 }
 
 /// Reads one `PILOTAGE_MISSION_*` variable, treating "unset" as `None` and
@@ -179,4 +187,35 @@ fn parse_anchor(value: &str) -> Result<GeoPointDegrees, HostError> {
         lon_deg: parse(lon)?,
         alt_m: parse(alt)?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
+
+    use super::parse_cruise_height;
+    use crate::error::HostError;
+
+    #[test]
+    fn a_negative_cruise_height_is_refused_with_the_value() {
+        let error = parse_cruise_height("-5.0").expect_err("below launch elevation");
+        assert!(
+            matches!(error, HostError::MissionCruiseHeightRange { height } if height == -5.0),
+            "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_finite_cruise_height_is_refused() {
+        let error = parse_cruise_height("NaN").expect_err("not flyable");
+        assert!(matches!(error, HostError::MissionCruiseHeightRange { .. }));
+        let error = parse_cruise_height("inf").expect_err("not flyable");
+        assert!(matches!(error, HostError::MissionCruiseHeightRange { .. }));
+    }
+
+    #[test]
+    fn zero_cruise_height_legitimately_disables_the_climb() {
+        let height = parse_cruise_height("0").expect("zero is the no-climb configuration");
+        assert_eq!(height, 0.0);
+    }
 }

--- a/hosts/session-host/src/runtime/options.rs
+++ b/hosts/session-host/src/runtime/options.rs
@@ -1,10 +1,46 @@
-//! Runtime policy switches for a host instance.
+//! Runtime policy switches for a host instance, parsed from the process
+//! environment at startup.
+//!
+//! Environment variables:
+//!
+//! - `PILOTAGE_LEGACY_COMPAT`: `1`/`true` admits legacy numeric payload
+//!   frames (SIMULATION compatibility). Production control is typed-only.
+//! - `PILOTAGE_MISSION_ROUTE`: presence enables the in-process mission
+//!   executor (ADR-0025 automation principal). The value is the route
+//!   string expanded against the navdata snapshot; the literal `fixture`
+//!   selects [`pilotage_mission::fixture::DEMO_ROUTE`].
+//! - `PILOTAGE_MISSION_NAVDATA`: `fixture` (the default) builds the demo
+//!   snapshot and round-trips it through the real blob container; any
+//!   other value is a navdata store directory whose `*/*.acnav` blobs are
+//!   scanned per ADR-0030.
+//! - `PILOTAGE_MISSION_ANCHOR`: mission anchor as `lat_deg,lon_deg,alt_m`
+//!   (default `47.397742,8.545594,488.0`).
+//! - `PILOTAGE_MISSION_DATE`: `YYYY-MM-DD` flight date used to select a
+//!   covering cycle from a store. Required for a store; ignored (with a
+//!   log line) for the fixture, whose cycle is fixed.
+//! - `PILOTAGE_MISSION_CRUISE_HEIGHT`: cruise height above the anchor in
+//!   meters. `0` skips the climb phase (planar vehicles); unset keeps the
+//!   [`pilotage_mission::MissionConfig`] default.
+
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+use pilotage_mission::fixture::GeoPointDegrees;
+
+use crate::error::HostError;
+
+/// The anchor used when `PILOTAGE_MISSION_ANCHOR` is unset.
+pub const DEFAULT_MISSION_ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.397742,
+    lon_deg: 8.545594,
+    alt_m: 488.0,
+};
 
 /// Runtime policy switches for a host instance.
 ///
 /// [`super::start`] derives these from the process environment; tests inject
 /// them directly through [`super::start_with_options`].
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct RuntimeOptions {
     /// SIMULATION compatibility: admit numeric legacy payload frames at the
     /// gate's translation boundary. Production control is TYPED-ONLY —
@@ -13,16 +49,134 @@ pub struct RuntimeOptions {
     /// [`super::start`] turns it on only for the explicit
     /// `PILOTAGE_LEGACY_COMPAT=1` opt-in.
     pub legacy_compatibility: bool,
+    /// The in-process mission executor, enabled only when
+    /// `PILOTAGE_MISSION_ROUTE` is present. `None` leaves every existing
+    /// host behavior untouched: no automation task, no extra logs.
+    pub mission: Option<MissionOptions>,
+}
+
+/// Where the mission executor's navdata snapshot comes from (ADR-0030).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MissionNavdataSource {
+    /// The generated demo snapshot, packed and decoded through the same
+    /// blob container published data travels.
+    Fixture,
+    /// A store directory scanned for `*/*.acnav` blobs; the newest
+    /// `faa-nasr` cycle covering the mission date wins.
+    Store(PathBuf),
+}
+
+/// Configuration of the in-process mission executor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MissionOptions {
+    /// Route string expanded against the snapshot at plan build.
+    pub route: String,
+    /// Snapshot source: fixture or a scanned store directory.
+    pub navdata: MissionNavdataSource,
+    /// Mission anchor, in the degree convention navdata uses; converted to
+    /// radians exactly once at plan build (ADR-0030).
+    pub anchor: GeoPointDegrees,
+    /// Flight date used to select a covering cycle from a store; `None`
+    /// only for the fixture, whose cycle is fixed.
+    pub date: Option<NaiveDate>,
+    /// Cruise height override in meters (`0.0` skips the climb phase);
+    /// `None` keeps the [`pilotage_mission::MissionConfig`] default.
+    pub cruise_height_m: Option<f64>,
 }
 
 impl RuntimeOptions {
-    pub(super) fn from_env() -> Self {
+    pub(super) fn from_env() -> Result<Self, HostError> {
         let legacy_compatibility = matches!(
             std::env::var("PILOTAGE_LEGACY_COMPAT").as_deref(),
             Ok("1" | "true")
         );
-        Self {
+        Ok(Self {
             legacy_compatibility,
+            mission: mission_from_env()?,
+        })
+    }
+}
+
+/// Parses the `PILOTAGE_MISSION_*` family; `PILOTAGE_MISSION_ROUTE` being
+/// unset disables the executor entirely.
+fn mission_from_env() -> Result<Option<MissionOptions>, HostError> {
+    let Some(route) = mission_var("PILOTAGE_MISSION_ROUTE")? else {
+        return Ok(None);
+    };
+    let route = if route == "fixture" {
+        pilotage_mission::fixture::DEMO_ROUTE.to_owned()
+    } else {
+        route
+    };
+    let navdata = match mission_var("PILOTAGE_MISSION_NAVDATA")? {
+        None => MissionNavdataSource::Fixture,
+        Some(value) if value == "fixture" => MissionNavdataSource::Fixture,
+        Some(path) => MissionNavdataSource::Store(PathBuf::from(path)),
+    };
+    let anchor = match mission_var("PILOTAGE_MISSION_ANCHOR")? {
+        None => DEFAULT_MISSION_ANCHOR,
+        Some(value) => parse_anchor(&value)?,
+    };
+    let date =
+        match mission_var("PILOTAGE_MISSION_DATE")? {
+            None => None,
+            Some(value) => Some(NaiveDate::parse_from_str(&value, "%Y-%m-%d").map_err(
+                |source| HostError::MissionDate {
+                    value: value.clone(),
+                    source,
+                },
+            )?),
+        };
+    if date.is_none() && matches!(navdata, MissionNavdataSource::Store(_)) {
+        return Err(HostError::MissionDateMissing);
+    }
+    let cruise_height_m = match mission_var("PILOTAGE_MISSION_CRUISE_HEIGHT")? {
+        None => None,
+        Some(value) => {
+            Some(
+                value
+                    .parse::<f64>()
+                    .map_err(|source| HostError::MissionCruiseHeight {
+                        value: value.clone(),
+                        source,
+                    })?,
+            )
+        }
+    };
+    Ok(Some(MissionOptions {
+        route,
+        navdata,
+        anchor,
+        date,
+        cruise_height_m,
+    }))
+}
+
+/// Reads one `PILOTAGE_MISSION_*` variable, treating "unset" as `None` and
+/// a non-UTF-8 value as a startup error rather than a silent fallback.
+fn mission_var(variable: &'static str) -> Result<Option<String>, HostError> {
+    match std::env::var(variable) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(source @ std::env::VarError::NotUnicode(_)) => {
+            Err(HostError::MissionVarEncoding { variable, source })
         }
     }
+}
+
+/// Parses `lat_deg,lon_deg,alt_m` into the fixture's degree convention.
+fn parse_anchor(value: &str) -> Result<GeoPointDegrees, HostError> {
+    let invalid = || HostError::MissionAnchor {
+        value: value.to_owned(),
+    };
+    let parts: Vec<&str> = value.split(',').map(str::trim).collect();
+    let [lat, lon, alt] = parts.as_slice() else {
+        return Err(invalid());
+    };
+    let parse = |part: &str| part.parse::<f64>().map_err(|_| invalid());
+    Ok(GeoPointDegrees {
+        lat_deg: parse(lat)?,
+        lon_deg: parse(lon)?,
+        alt_m: parse(alt)?,
+    })
 }

--- a/hosts/session-host/tests/loopback.rs
+++ b/hosts/session-host/tests/loopback.rs
@@ -259,6 +259,7 @@ async fn start_sim_compat_host() -> runtime::RunningHost {
         AdapterKind::Reference,
         runtime::RuntimeOptions {
             legacy_compatibility: true,
+            mission: None,
         },
     )
     .await

--- a/hosts/session-host/tests/mission_reference.rs
+++ b/hosts/session-host/tests/mission_reference.rs
@@ -5,22 +5,30 @@
 //! The planar skiff cannot traverse geodetic waypoints meaningfully, so
 //! the test scopes to the fenced in-process path itself: the principal
 //! completes the handshake, announces its activation, leases the motion
-//! scope, arms over the reliable action path, then streams typed intent
-//! frames for 200 ticks with ZERO `FrameRejected` and the lease still
-//! held. Every wait is event-driven on the status watch under a bounded
-//! timeout — never a sleep-and-poll.
+//! scope, arms over the reliable action path, publishes stamped
+//! navigation guidance onto the telemetry the actor broadcasts, then
+//! streams typed intent frames for 200 ticks with ZERO `FrameRejected`
+//! and the lease still held. Every wait is event-driven on the status
+//! watch or the broadcast datagrams under a bounded timeout — never a
+//! sleep-and-poll.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
 use std::time::Duration;
 
 use pilotage_mission::MissionState;
-use pilotage_session_host::runtime::{self, AutomationStatus};
+use pilotage_protocol::wire;
+use pilotage_session_host::runtime::{self, AutomationStatus, TelemetryObserver};
+use prost::Message;
 use tokio::time::timeout;
 
 /// Virtual-time bound (the test runs under a paused clock, so this never
 /// costs wall time); a stalled rig fails fast at this deadline.
 const TEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The fixture route's fixes, in fly order: guidance names one of these
+/// or it is not describing the mission being flown.
+const DEMO_IDENTS: [&str; 3] = ["DEMOA", "DEMOB", "DEMOC"];
 
 /// Awaits the first status satisfying `predicate`, event-driven on the
 /// watch channel.
@@ -47,6 +55,93 @@ async fn await_status(
     .unwrap_or_else(|_| panic!("timed out awaiting {what}"))
 }
 
+/// Decodes a broadcast datagram the way every telemetry consumer does,
+/// yielding the guidance group when the sample carries one.
+fn nav_guidance_of(bytes: &[u8]) -> Option<wire::NavGuidanceState> {
+    let envelope = wire::Envelope::decode(bytes).ok()?;
+    match envelope.payload? {
+        wire::envelope::Payload::TelemetrySample(sample) => sample.nav_guidance.map(|state| *state),
+        _ => None,
+    }
+}
+
+/// Collects guidance samples from broadcast telemetry until `wanted`
+/// distinct stamp sequences have been seen, in publication order.
+async fn collect_guidance(
+    observer: &mut TelemetryObserver,
+    wanted: usize,
+) -> Vec<wire::NavGuidanceState> {
+    timeout(TEST_TIMEOUT, async {
+        let mut samples: Vec<wire::NavGuidanceState> = Vec::new();
+        while samples.len() < wanted {
+            let datagram = observer
+                .next_datagram()
+                .await
+                .expect("the engine actor keeps broadcasting while awaited on");
+            let Some(guidance) = nav_guidance_of(&datagram) else {
+                continue;
+            };
+            let sequence = guidance.stamp.as_ref().map(|stamp| stamp.sequence);
+            let repeated = samples
+                .last()
+                .is_some_and(|last| last.stamp.as_ref().map(|s| s.sequence) == sequence);
+            // The actor re-publishes the cached group on every tick; only
+            // a new mission publication advances the sequence.
+            if !repeated {
+                samples.push(guidance);
+            }
+        }
+        samples
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out awaiting {wanted} guidance publications"))
+}
+
+/// Asserts the guidance the actor broadcasts: its own role, a 16-byte
+/// incarnation, an advancing sequence, and route-true field values — in
+/// the bytes a remote client would receive.
+fn assert_guidance_broadcast(guidance: &[wire::NavGuidanceState]) {
+    let stamps: Vec<wire::MeasurementStamp> = guidance
+        .iter()
+        .map(|state| state.stamp.clone().expect("guidance carries its stamp"))
+        .collect();
+    for stamp in &stamps {
+        assert_eq!(
+            stamp.role,
+            wire::SourceRole::NavigationSolution as i32,
+            "guidance travels under its own role, never relabeled"
+        );
+        assert_eq!(stamp.source_incarnation.len(), 16);
+    }
+    assert!(
+        stamps[1].sequence > stamps[0].sequence,
+        "each publication advances the group sequence: {:?}",
+        stamps
+            .iter()
+            .map(|stamp| stamp.sequence)
+            .collect::<Vec<_>>()
+    );
+    for state in guidance {
+        assert!(!state.to_ident.is_empty(), "the active waypoint is named");
+        assert!(
+            DEMO_IDENTS.contains(&state.to_ident.as_str()),
+            "the active waypoint comes from the flown route, got {}",
+            state.to_ident
+        );
+        assert!(
+            state.distance_to_waypoint_m.is_finite(),
+            "distance {} is not a reading",
+            state.distance_to_waypoint_m
+        );
+        assert!(
+            (0.0..std::f32::consts::TAU).contains(&state.course_rad),
+            "course {} is outside [0, 2π)",
+            state.course_rad
+        );
+        assert_eq!(state.waypoint_count, 3, "the demo route has three fixes");
+    }
+}
+
 #[tokio::test(start_paused = true)]
 async fn mission_principal_arms_and_streams_accepted_frames() {
     let rig = runtime::spawn_reference_mission_rig().expect("mission rig spawns");
@@ -69,6 +164,12 @@ async fn mission_principal_arms_and_streams_accepted_frames() {
         armed.frames_rejected, 0,
         "no frame was rejected on the way to arming"
     );
+
+    let mut observer = rig.observe().await;
+    let guidance = collect_guidance(&mut observer, 2).await;
+    assert_guidance_broadcast(&guidance);
+    // Eviction is the actor's own path for a departed client.
+    drop(observer);
 
     // With a zero cruise height the mission goes straight enroute and
     // streams a typed intent frame every tick; 200 of them all stay

--- a/hosts/session-host/tests/mission_reference.rs
+++ b/hosts/session-host/tests/mission_reference.rs
@@ -1,0 +1,103 @@
+//! In-process mission-executor integration test: the reference engine
+//! actor and the mission principal wired exactly as the runtime wires
+//! them for the reference adapter — no transport endpoint, no network.
+//!
+//! The planar skiff cannot traverse geodetic waypoints meaningfully, so
+//! the test scopes to the fenced in-process path itself: the principal
+//! completes the handshake, announces its activation, leases the motion
+//! scope, arms over the reliable action path, then streams typed intent
+//! frames for 200 ticks with ZERO `FrameRejected` and the lease still
+//! held. Every wait is event-driven on the status watch under a bounded
+//! timeout — never a sleep-and-poll.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::time::Duration;
+
+use pilotage_mission::MissionState;
+use pilotage_session_host::runtime::{self, AutomationStatus};
+use tokio::time::timeout;
+
+/// Virtual-time bound (the test runs under a paused clock, so this never
+/// costs wall time); a stalled rig fails fast at this deadline.
+const TEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Awaits the first status satisfying `predicate`, event-driven on the
+/// watch channel.
+async fn await_status(
+    status: &mut tokio::sync::watch::Receiver<AutomationStatus>,
+    what: &str,
+    predicate: impl Fn(&AutomationStatus) -> bool,
+) -> AutomationStatus {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            {
+                let current = status.borrow_and_update();
+                if predicate(&current) {
+                    return current.clone();
+                }
+            }
+            status
+                .changed()
+                .await
+                .expect("the mission principal stays alive while awaited on");
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out awaiting {what}"))
+}
+
+#[tokio::test(start_paused = true)]
+async fn mission_principal_arms_and_streams_accepted_frames() {
+    let rig = runtime::spawn_reference_mission_rig().expect("mission rig spawns");
+    let mut status = rig.status();
+
+    // Handshake, activation, then the motion lease, in session order.
+    let leased = await_status(&mut status, "the motion lease grant", |status| {
+        status.lease_generation.is_some()
+    })
+    .await;
+    assert!(leased.session.is_some(), "the welcome precedes the lease");
+    assert!(
+        leased.activation_sent,
+        "the profile activation precedes the lease"
+    );
+
+    // The arm rides the reliable action path and comes back accepted.
+    let armed = await_status(&mut status, "arm acceptance", |status| status.arm_accepted).await;
+    assert_eq!(
+        armed.frames_rejected, 0,
+        "no frame was rejected on the way to arming"
+    );
+
+    // With a zero cruise height the mission goes straight enroute and
+    // streams a typed intent frame every tick; 200 of them all stay
+    // accepted, the lease stays held, and the holder-silence watchdog
+    // never fires.
+    let streamed = await_status(&mut status, "200 streamed intent frames", |status| {
+        status.frames_sent >= 200
+    })
+    .await;
+    assert_eq!(
+        streamed.frames_rejected, 0,
+        "every streamed frame was accepted: zero FrameRejected"
+    );
+    assert!(!streamed.fenced, "authority never moved away");
+    assert!(!streamed.closed, "the engine never closed the principal");
+    assert!(
+        streamed.lease_generation.is_some(),
+        "the lease is still held after 200 ticks"
+    );
+    assert!(
+        matches!(
+            streamed.mission_state,
+            Some(MissionState::Enroute | MissionState::Complete)
+        ),
+        "a zero-cruise mission is enroute (or complete) after arming, got {:?}",
+        streamed.mission_state
+    );
+
+    // Shutdown drains cleanly: the actor exits when its command channel
+    // closes and the principal (holding only a weak handle) follows.
+    rig.shutdown().await;
+}

--- a/schemas/pilotage/v1/telemetry.proto
+++ b/schemas/pilotage/v1/telemetry.proto
@@ -55,6 +55,10 @@ enum SourceRole {
   // FC link: not a vehicle estimate and never eligible for control
   // validation. Carries the device's own boot clock, not host time.
   SOURCE_ROLE_PAYLOAD_DEVICE = 5;
+  // The vehicle's navigation/guidance component's plan-relative output:
+  // display context only. Never an input to control validation, and never
+  // a fallback for a missing estimate.
+  SOURCE_ROLE_NAVIGATION_SOLUTION = 6;
 }
 
 // Integrity classification of the path that delivered an observation. The
@@ -210,6 +214,43 @@ message GimbalAttitude {
   uint32 failure_flags = 10;
 }
 
+// Active-leg guidance from the vehicle's navigation component (ADR-0031)
+// under its own provenance stamp: display context in raw canonical units.
+// Scaling deviations to instrument dots is display policy and never
+// crosses the wire. Absence means no guidance — receivers remove the
+// deviation display rather than centering it.
+message NavGuidanceState {
+  // Identity and acquisition of this guidance sample. Absence makes the
+  // sample unconsumable: guidance without provenance is discarded.
+  MeasurementStamp stamp = 1;
+  // Identifier of the waypoint being flown toward.
+  string to_ident = 2;
+  // Identifier of the leg's origin fix; empty on a direct-to leg, which
+  // is flown from the present position and has no upstream fix.
+  string from_ident = 3;
+  // Desired track of the active leg, radians clockwise from true north in
+  // [0, 2π). On a direct-to leg this is the live bearing to the waypoint.
+  float course_rad = 4;
+  // Cross-track deviation from the desired track in meters, positive
+  // right of course. NaN when guidance is not tracking a lateral course
+  // (e.g. climb): a direct-to leg's track is anchored at ownship, so
+  // there is no cross-track geometry, and zero would read as on-course.
+  float lateral_deviation_m = 5;
+  // Deviation from the vertical profile in meters, positive above the
+  // profile; NaN when the active leg carries no vertical constraint.
+  float vertical_deviation_m = 6;
+  // Great-circle distance to the active waypoint, meters.
+  float distance_to_waypoint_m = 7;
+  // Index of the active leg's destination waypoint in fly order, 0-based.
+  uint32 leg_index = 8;
+  // Waypoints in the plan being flown.
+  uint32 waypoint_count = 9;
+  // Quality of the navigation solution this guidance rests on: 0 good,
+  // 1 degraded, 2 unusable. Consumers remove the guidance display on
+  // unusable rather than displaying it with a caution.
+  uint32 solution_quality = 10;
+}
+
 // A single best-effort telemetry sample for one vehicle.
 message TelemetrySample {
   VehicleId vehicle = 1;
@@ -229,4 +270,7 @@ message TelemetrySample {
   FcState fc_state = 8;
   // Gimbal payload-device orientation with its own provenance stamp.
   GimbalAttitude gimbal = 9;
+  // Active-leg navigation guidance with its own provenance stamp,
+  // published by the navigation component rather than the FC adapter.
+  NavGuidanceState nav_guidance = 10;
 }

--- a/tools/loopback-probe/src/capture.rs
+++ b/tools/loopback-probe/src/capture.rs
@@ -160,6 +160,7 @@ mod tests {
                 ..Default::default()
             })),
             gimbal: None,
+            nav_guidance: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(9));
 

--- a/tools/loopback-probe/src/receiver.rs
+++ b/tools/loopback-probe/src/receiver.rs
@@ -330,6 +330,7 @@ mod tests {
                 sim_truth: None,
                 fc_state: None,
                 gimbal: None,
+                nav_guidance: None,
             },
         ));
         let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(5)).expect("telemetry");
@@ -380,6 +381,7 @@ mod tests {
                     ..Default::default()
                 })),
                 gimbal: None,
+                nav_guidance: None,
             },
         ));
         let event = decode_datagram_event(&bytes, MonoTimestamp::from_nanos(9)).expect("telemetry");

--- a/tools/loopback-probe/src/telemetry.rs
+++ b/tools/loopback-probe/src/telemetry.rs
@@ -186,6 +186,7 @@ mod tests {
             sim_truth: None,
             fc_state: None,
             gimbal: None,
+            nav_guidance: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(100));
         assert_eq!(observation.pose, Some((1.5, 2.5, 0.25)));
@@ -206,6 +207,7 @@ mod tests {
             sim_truth: None,
             fc_state: None,
             gimbal: None,
+            nav_guidance: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(0));
         assert_eq!(observation.pose, None);
@@ -241,6 +243,7 @@ mod tests {
                 ..Default::default()
             })),
             gimbal: None,
+            nav_guidance: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(9));
         let truth = observation.sim_truth.expect("truth lane captured");
@@ -280,6 +283,7 @@ mod tests {
                 ..Default::default()
             })),
             gimbal: None,
+            nav_guidance: None,
         };
         let observation = observation_from_sample(&sample, MonoTimestamp::from_nanos(1));
         assert_eq!(observation.sim_truth, None, "truth without provenance");


### PR DESCRIPTION
## What

The increment-8 slice end to end, in four commits:

1. **Architecture decisions (ADRs 0023–0030 + architecture.md)** — system decomposition (Host/Client/Server; FC + Navigate + Communicate vehicle side), navigation authority boundary, automation principals, host capability profiles, coordination server, multi-vehicle/swarm topology, panel plugins, and Communicate navdata provisioning (terrain distribution deferred behind four recorded prerequisites). Fixes the ADR index rows for 0020–0022.
2. **In-process mission executor** — `crates/pilotage-mission` (sans-IO engine: aerocontext route expansion over cycle-dated snapshots + the git-pinned Navigate stack; sim-truth-only GNSS synthesis per the ADR-0024 correlation rule) and the session-host automation-class local principal on the engine funnel: ordinary session vocabulary, authority-event fencing, no privileged path (ADR-0025). Navdata loads at the binary edge through the real blob container (ADR-0030).
3. **Navigation guidance to the HSI (ADR-0031)** — `NavGuidanceState` rides `TelemetrySample` under its own `SOURCE_ROLE_NAVIGATION_SOLUTION`; both client decoders gate on the exact role; ingress gains a `NavGuidanceTracker`; `nav-display.js` owns meters→dots with both fly-to sign conventions pinned against panel geometry. Also fixes the wasm decoder silently dropping the gimbal group and pins decoder sub-message presence parity.
4. **ADR-0032** — the iPad client design envelope (one core, three shells). Design only.

## Evidence

- Acceptance flight record: `docs/mission/mission01-fixture-aviate.run.txt` (aviate-gz headless, route `DEMOA V901 DEMOC` via airway expansion, armed through the fenced path, climb + three waypoints in 2 m 29 s, zero refusals / zero rejected frames). Two later live flights with the HSI active (course pointer, CDI, vertical deviation, DIST NM).
- `buf lint` + `buf breaking --against origin/main`: OK. Full local gate green: fmt, clippy `--all-targets -D warnings`, `cargo test --all-targets` (50 binaries), doc gate, structure checks; node suites (wire, wire-wasm conformance incl. new presence-parity block, telemetry-ingress, nav-display, control-structure) all pass.

## Follow-ups filed

#245 (mission failure detection), #246 (stochastic takeoff flip), #247 (nav quality folding in instrument-state), #248 (TO-ident ABI string capability), #249 (CDI realism scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #251
- <kbd>&nbsp;1&nbsp;</kbd> #250 👈 
<!-- GitButler Footer Boundary Bottom -->