### PR TITLE
CDI realism: Navigate pin ace50f6 and closed-loop tracking scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "navigate-contract"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+source = "git+https://github.com/luofang34/Navigate.git?rev=ace50f68b3ffae6237bbb53f6af687c335518272#ace50f68b3ffae6237bbb53f6af687c335518272"
 dependencies = [
  "thiserror",
 ]
@@ -1188,7 +1188,7 @@ dependencies = [
 [[package]]
 name = "navigate-fpl"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+source = "git+https://github.com/luofang34/Navigate.git?rev=ace50f68b3ffae6237bbb53f6af687c335518272#ace50f68b3ffae6237bbb53f6af687c335518272"
 dependencies = [
  "navigate-contract",
  "navigate-geodesy",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "navigate-fusion"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+source = "git+https://github.com/luofang34/Navigate.git?rev=ace50f68b3ffae6237bbb53f6af687c335518272#ace50f68b3ffae6237bbb53f6af687c335518272"
 dependencies = [
  "nalgebra",
  "navigate-contract",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "navigate-geodesy"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+source = "git+https://github.com/luofang34/Navigate.git?rev=ace50f68b3ffae6237bbb53f6af687c335518272#ace50f68b3ffae6237bbb53f6af687c335518272"
 dependencies = [
  "navigate-contract",
  "thiserror",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "navigate-guidance"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Navigate.git?rev=dcee4e14e93d8fccb0a9f89e4be38abc0804861a#dcee4e14e93d8fccb0a9f89e4be38abc0804861a"
+source = "git+https://github.com/luofang34/Navigate.git?rev=ace50f68b3ffae6237bbb53f6af687c335518272#ace50f68b3ffae6237bbb53f6af687c335518272"
 dependencies = [
  "navigate-contract",
  "navigate-geodesy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ aviate-xil-shm = { git = "https://github.com/luofang34/Aviate.git", rev = "ac9bd
 # all five crates must always pin the identical rev so the contract
 # vocabulary, fusion, plan sequencing, guidance, and geodesy cannot
 # drift apart (the same discipline as the aviate-xil pins above).
-navigate-contract = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
-navigate-geodesy = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
-navigate-fusion = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
-navigate-fpl = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
-navigate-guidance = { git = "https://github.com/luofang34/Navigate.git", rev = "dcee4e14e93d8fccb0a9f89e4be38abc0804861a" }
+navigate-contract = { git = "https://github.com/luofang34/Navigate.git", rev = "ace50f68b3ffae6237bbb53f6af687c335518272" }
+navigate-geodesy = { git = "https://github.com/luofang34/Navigate.git", rev = "ace50f68b3ffae6237bbb53f6af687c335518272" }
+navigate-fusion = { git = "https://github.com/luofang34/Navigate.git", rev = "ace50f68b3ffae6237bbb53f6af687c335518272" }
+navigate-fpl = { git = "https://github.com/luofang34/Navigate.git", rev = "ace50f68b3ffae6237bbb53f6af687c335518272" }
+navigate-guidance = { git = "https://github.com/luofang34/Navigate.git", rev = "ace50f68b3ffae6237bbb53f6af687c335518272" }
 aerocontext-core = "0.4.5"
 aerocontext-planning = "0.4.5"
 aerocontext-navdata = { version = "0.4.5", default-features = false }

--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -75,7 +75,7 @@ impl MissionEngine {
     ///
     /// Any [`MissionBuildError`]: expansion failure (with cycle
     /// context), an empty expansion, an implausible anchor, or a plan
-    /// that fails structural validation.
+    /// the sequencer refuses to activate.
     pub fn new(
         snapshot: &NavDataSnapshot,
         provenance: SnapshotProvenance,

--- a/crates/pilotage-mission/src/engine/output.rs
+++ b/crates/pilotage-mission/src/engine/output.rs
@@ -1,6 +1,7 @@
 //! Typed outputs of one engine tick: intent, action, state, events,
 //! and the refusal counters.
 
+use navigate_fpl::SequenceReason;
 use navigate_guidance::GuidanceRefusal;
 use pilotage_protocol::{ControlAction, ControlIntent};
 
@@ -59,6 +60,11 @@ pub enum MissionEvent {
     LegAdvanced {
         /// Index of the newly active `to` waypoint in fly order.
         to_index: usize,
+        /// Which sequencing rule authorized the advance: turn
+        /// anticipation ahead of a fly-by fix, or the capture radius.
+        /// Telemetry carries it so an early transition is attributable
+        /// to the rule rather than read as a skipped waypoint.
+        reason: SequenceReason,
     },
     /// The final waypoint captured; emitted exactly once.
     MissionComplete,

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -129,11 +129,16 @@ impl MissionEngine {
         now: MonotonicNanos,
         events: &mut Vec<MissionEvent>,
     ) -> Option<ControlIntent> {
-        match self.execution.advance(&solution.position) {
-            SequenceEvent::LegAdvanced { to_index } => {
-                events.push(MissionEvent::LegAdvanced { to_index });
+        match self
+            .execution
+            .advance(&solution.position, self.commanded_groundspeed_mps())
+        {
+            SequenceEvent::LegAdvanced {
+                to_index, reason, ..
+            } => {
+                events.push(MissionEvent::LegAdvanced { to_index, reason });
             }
-            SequenceEvent::PlanComplete => {
+            SequenceEvent::PlanComplete { .. } => {
                 self.state = MissionState::Complete;
                 events.push(MissionEvent::MissionComplete);
                 return Some(zero_velocity_intent());
@@ -184,6 +189,23 @@ impl MissionEngine {
                 None
             }
         }
+    }
+
+    /// The groundspeed the sequencer sizes fly-by turn anticipation on:
+    /// the fastest along-track speed this engine can actually command.
+    /// Cruise is what guidance is asked for, but the horizontal ceiling
+    /// caps every emitted intent, so a host that tightens the ceiling
+    /// below cruise would otherwise have its turns anticipated at a
+    /// speed the vehicle is never commanded to fly.
+    ///
+    /// Guidance tapers this speed approaching a fix, which would shrink
+    /// the anticipation distance exactly where it is being tested
+    /// against; the commanded cruise keeps the sizing independent of the
+    /// distance already run.
+    fn commanded_groundspeed_mps(&self) -> f64 {
+        self.config
+            .cruise_mps
+            .min(self.config.limits.max_horizontal_mps)
     }
 
     /// Clamps the commanded NED velocity to the mission limits, rotates

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -192,16 +192,19 @@ impl MissionEngine {
     }
 
     /// The groundspeed the sequencer sizes fly-by turn anticipation on:
-    /// the fastest along-track speed this engine can actually command.
-    /// Cruise is what guidance is asked for, but the horizontal ceiling
-    /// caps every emitted intent, so a host that tightens the ceiling
-    /// below cruise would otherwise have its turns anticipated at a
-    /// speed the vehicle is never commanded to fly.
+    /// the along-track speed this engine commands, cruise bounded by the
+    /// horizontal ceiling. A host that tightens the ceiling below cruise
+    /// would otherwise have its turns anticipated at a speed the vehicle
+    /// is never commanded to fly.
     ///
-    /// Guidance tapers this speed approaching a fix, which would shrink
-    /// the anticipation distance exactly where it is being tested
-    /// against; the commanded cruise keeps the sizing independent of the
-    /// distance already run.
+    /// Anticipation only matters when it exceeds the capture radius, and
+    /// the capture radius sits outside guidance's arrival-slowdown
+    /// radius — so wherever anticipation can fire, the approach taper
+    /// has not begun and commanded cruise is the speed being flown.
+    /// A cross-track correction can push the composed groundspeed above
+    /// this value (up to the ceiling), under-sizing the anticipation
+    /// toward a later turn; the sequencer's capture radius bounds that
+    /// error.
     fn commanded_groundspeed_mps(&self) -> f64 {
         self.config
             .cruise_mps

--- a/crates/pilotage-mission/src/error.rs
+++ b/crates/pilotage-mission/src/error.rs
@@ -44,6 +44,6 @@ pub enum MissionBuildError {
     /// defect, an execution parameter that cannot be flown, or a
     /// waypoint constraint the sequencer refuses (an approach speed
     /// under the floor, a leg no longer than the capture radius).
-    #[error("mission plan cannot be activated")]
+    #[error("mission plan cannot be activated: {0}")]
     PlanActivation(#[from] PlanActivationError),
 }

--- a/crates/pilotage-mission/src/error.rs
+++ b/crates/pilotage-mission/src/error.rs
@@ -4,7 +4,7 @@ use aerocontext_core::NavDataError;
 use aerocontext_navdata::blob::BlobError;
 use aerocontext_planning::route::RouteError;
 use chrono::NaiveDate;
-use navigate_contract::PlanValidationError;
+use navigate_fpl::PlanActivationError;
 use navigate_geodesy::GeodesyError;
 
 /// Why a mission could not be built. Every variant carries the context
@@ -40,7 +40,10 @@ pub enum MissionBuildError {
     /// The mission anchor cannot anchor a local tangent plane.
     #[error("mission anchor rejected by geodesy")]
     Geodesy(#[from] GeodesyError),
-    /// The built flight plan failed structural validation.
-    #[error("mission plan invalid")]
-    PlanInvalid(#[from] PlanValidationError),
+    /// The built flight plan could not be activated: a structural
+    /// defect, an execution parameter that cannot be flown, or a
+    /// waypoint constraint the sequencer refuses (an approach speed
+    /// under the floor, a leg no longer than the capture radius).
+    #[error("mission plan cannot be activated")]
+    PlanActivation(#[from] PlanActivationError),
 }

--- a/crates/pilotage-mission/tests/cdi_realism.rs
+++ b/crates/pilotage-mission/tests/cdi_realism.rs
@@ -1,0 +1,313 @@
+//! CDI realism (Pilotage #249): the display-facing cross-track deviation
+//! is checked closed-loop, against a vehicle that is actually off course.
+//!
+//! A deviation readout can be wrong in three ways a static geometry test
+//! never reaches: it can carry the wrong sign, it can carry a magnitude
+//! that does not match where the vehicle is, and it can fail to move as
+//! the vehicle corrects. Each scenario here displaces the vehicle from
+//! the course it is tracking and then flies the engine's own commands
+//! back onto it, so the assertions are about a needle that deflects the
+//! right way and comes home.
+//!
+//! The assertions sit at the mission level rather than on the broadcast
+//! wire: `hosts/session-host/tests/mission_reference.rs` already pins the
+//! publication path — that guidance reaches telemetry stamped, named
+//! after a fixture fix, and framed as `NavGuidanceState` — and it flies a
+//! planar skiff that cannot traverse geodetic waypoints, so it cannot
+//! produce a real deviation to judge. The geometry is decided in
+//! `MissionEngine::nav_guidance`, and that is where a wrong sign or a
+//! diverging correction is observable.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+// An explicit path keeps the rig out of the integration-test target list:
+// every `tests/*.rs` is compiled as its own binary, so a sibling module
+// file would become a second, empty test target.
+#[path = "cdi_realism/closed_loop.rs"]
+mod closed_loop;
+
+use closed_loop::{CORNER_IDENTS, Rig, corner_engine, fixture_engine, right_of_course_ned};
+use navigate_fpl::SequenceReason;
+use pilotage_mission::{MissionEvent, NavQuality};
+
+/// Lateral disturbance a displacement scenario applies, m/s. Above the
+/// guidance correction ceiling, so the deviation grows while the push is
+/// on; small enough per 50 ms step that the fusion innovation gate admits
+/// every fix, making the displacement an observed one rather than a
+/// teleport the filter would reject.
+const PUSH_MPS: f64 = 6.0;
+
+/// Lateral displacement a scenario builds before releasing the push,
+/// meters.
+const DISPLACEMENT_M: f64 = 40.0;
+
+/// Deviation under which a displaced vehicle counts as recaptured,
+/// meters.
+const RECAPTURED_M: f64 = 5.0;
+
+/// Deviation under which a corner transient counts as decayed, meters.
+const CORNER_DECAYED_M: f64 = 10.0;
+
+/// Per-step growth tolerated inside a converging trace, meters. The
+/// filter's estimate lags a pushed truth and catches up once the push
+/// releases, so the reported deviation can tick up before it turns over.
+const JITTER_M: f64 = 0.5;
+
+/// How a deviation decayed.
+struct Convergence {
+    /// Deviation magnitude the correction started from, meters.
+    start_m: f64,
+    /// Step at which the magnitude first reached half the start.
+    half_at: usize,
+    /// Step at which the magnitude first fell under the target.
+    settled_at: usize,
+    /// Largest single-step increase in magnitude anywhere in the trace.
+    worst_rise_m: f64,
+}
+
+/// Flies the engine's own commands until the deviation falls under
+/// `target_m`, reporting the trace.
+///
+/// Fails when the budget runs out — a correction that never arrives is
+/// the defect this file exists to catch — when the plan sequences to
+/// another leg mid-correction, since a deviation measured against a
+/// different track is a different number, or when the desired track moves
+/// while the vehicle corrects toward it.
+fn converge_on_leg(
+    rig: &mut Rig,
+    leg_index: u32,
+    course_rad: f64,
+    target_m: f64,
+    budget: usize,
+) -> Convergence {
+    let start_m = rig
+        .expect_deviation("correcting a lateral displacement")
+        .abs();
+    let mut previous_m = start_m;
+    let mut half_at = None;
+    let mut worst_rise_m = 0.0_f64;
+    for taken in 1..=budget {
+        rig.step();
+        let guidance = rig.expect_guidance("correcting a lateral displacement");
+        assert_eq!(
+            guidance.leg_index, leg_index,
+            "leg sequenced at step {taken}: the correction ran out of leg to fly"
+        );
+        assert!(
+            (guidance.course_rad - course_rad).abs() < 1e-9,
+            "the desired track moved to {} while correcting toward {course_rad}",
+            guidance.course_rad
+        );
+        let deviation_m = guidance
+            .lateral_deviation_m
+            .expect("a fixed leg reports cross-track deviation")
+            .abs();
+        worst_rise_m = worst_rise_m.max(deviation_m - previous_m);
+        previous_m = deviation_m;
+        if half_at.is_none() && deviation_m <= start_m / 2.0 {
+            half_at = Some(taken);
+        }
+        if deviation_m < target_m {
+            return Convergence {
+                start_m,
+                half_at: half_at.unwrap_or(taken),
+                settled_at: taken,
+                worst_rise_m,
+            };
+        }
+    }
+    panic!("{start_m} m of deviation never fell under {target_m} m in {budget} steps");
+}
+
+/// Displaces the vehicle `DISPLACEMENT_M` to one side of the leg it is
+/// tracking and flies it back. `side` is `1.0` for right of course,
+/// `-1.0` for left.
+fn displace_and_recapture(side: f64) {
+    let mut rig = Rig::new(corner_engine());
+    // The corner route's direct-to leg runs along the extension of its
+    // first fixed leg, so the correction starts from a settled course
+    // rather than from a transition transient of its own.
+    assert!(
+        rig.fly_until(5_000, |g| g.leg_index == 1
+            && g.lateral_deviation_m.is_some_and(|d| d.abs() < 1.0))
+            .is_some(),
+        "the first fixed leg is tracked within the step budget"
+    );
+    let tracking = rig.expect_guidance("tracking the first fixed leg");
+    assert_eq!(tracking.to_ident, CORNER_IDENTS[1]);
+    assert_eq!(tracking.quality, NavQuality::Good);
+
+    rig.disturbance_ned = right_of_course_ned(tracking.course_rad, PUSH_MPS * side);
+    assert!(
+        rig.fly_until(1_000, |g| g
+            .lateral_deviation_m
+            .is_some_and(|d| d.abs() >= DISPLACEMENT_M))
+            .is_some(),
+        "the disturbance builds {DISPLACEMENT_M} m of deviation within the step budget"
+    );
+    rig.disturbance_ned = [0.0; 2];
+
+    let displaced_m = rig.expect_deviation("displaced from the tracked leg");
+    assert_eq!(
+        displaced_m.signum(),
+        side,
+        "a vehicle pushed {} of course must read {} deviation, got {displaced_m}",
+        if side > 0.0 { "right" } else { "left" },
+        if side > 0.0 { "positive" } else { "negative" },
+    );
+    assert!(
+        (DISPLACEMENT_M..DISPLACEMENT_M + 2.0).contains(&displaced_m.abs()),
+        "the readout must match the displacement it was flown to, got {displaced_m}"
+    );
+    assert_eq!(
+        rig.engine.counters().fusion_rejected,
+        0,
+        "the displacement was observed, not rejected as an outlier"
+    );
+
+    let trace = converge_on_leg(&mut rig, 1, tracking.course_rad, RECAPTURED_M, 800);
+    assert!(
+        trace.half_at <= 300,
+        "{} m halved only after {} steps",
+        trace.start_m,
+        trace.half_at
+    );
+    assert!(
+        trace.settled_at <= 600,
+        "recapture took {} steps",
+        trace.settled_at
+    );
+    assert!(
+        trace.worst_rise_m < JITTER_M,
+        "the deviation grew {} m mid-correction",
+        trace.worst_rise_m
+    );
+}
+
+#[test]
+fn cdi_realism_displaced_capture_converges_from_right_of_course() {
+    displace_and_recapture(1.0);
+}
+
+#[test]
+fn cdi_realism_displaced_capture_converges_from_left_of_course() {
+    displace_and_recapture(-1.0);
+}
+
+/// A 90° dogleg: the desired track turns a quarter circle at the corner,
+/// and the deviation the corner geometry hands the new leg decays.
+#[test]
+fn cdi_realism_dogleg_turns_the_course_a_quarter_circle() {
+    let mut rig = Rig::new(corner_engine());
+    assert!(
+        rig.fly_until(5_000, |g| g.leg_index == 1).is_some(),
+        "the inbound leg is reached within the step budget"
+    );
+    // The last guidance published before the corner sequences is what the
+    // display was showing on the way in; the turn is the difference
+    // between that and the first guidance published after.
+    let mut inbound = rig.expect_guidance("flying the inbound leg");
+    let mut advance = None;
+    for _ in 0..10_000 {
+        advance = rig.step().events.iter().find_map(|event| match event {
+            MissionEvent::LegAdvanced {
+                to_index: 2,
+                reason,
+            } => Some(*reason),
+            _ => None,
+        });
+        if advance.is_some() {
+            break;
+        }
+        inbound = rig.expect_guidance("approaching the corner");
+    }
+    let reason = advance.expect("the corner sequences within the step budget");
+    let outbound = rig.expect_guidance("flying the leg past the corner");
+    assert_eq!(inbound.to_ident, CORNER_IDENTS[1]);
+    assert_eq!(outbound.to_ident, CORNER_IDENTS[2]);
+
+    let turn_rad = wrap_to_pi(outbound.course_rad - inbound.course_rad);
+    assert!(
+        (turn_rad - core::f64::consts::FRAC_PI_2).abs() < 0.01,
+        "the corner turns {turn_rad} rad, not a quarter circle right"
+    );
+
+    // The identity below holds only because the corner is crossed by
+    // capture radius rather than anticipated: at the instant the fix
+    // sequences the vehicle is still short of it, and for a square corner
+    // the distance still to run becomes cross-track deviation from the new
+    // leg, one for one. At the mission cruise speed the fly-by turn radius
+    // is on the order of a meter, so anticipation never reaches the
+    // capture radius.
+    assert_eq!(
+        reason,
+        SequenceReason::Overflown,
+        "an anticipated corner would sequence before the run-in this asserts on"
+    );
+    let short_of_corner_m = inbound.distance_to_waypoint_m;
+    let transient_m = outbound
+        .lateral_deviation_m
+        .expect("the leg past the corner has an origin fix");
+    assert!(
+        transient_m > 0.0,
+        "short of a right turn is right of the new course, got {transient_m}"
+    );
+    assert!(
+        (transient_m - short_of_corner_m).abs() < 2.0,
+        "a square corner hands the new leg its own run-in: {short_of_corner_m} m short read as {transient_m} m off"
+    );
+
+    let trace = converge_on_leg(&mut rig, 2, outbound.course_rad, CORNER_DECAYED_M, 2_000);
+    assert!(
+        trace.settled_at <= 1_500,
+        "the corner transient took {} steps to decay",
+        trace.settled_at
+    );
+    assert!(
+        trace.worst_rise_m < JITTER_M,
+        "the corner transient grew {} m before decaying",
+        trace.worst_rise_m
+    );
+}
+
+/// The shipped demo route's first transition, on the geometry an operator
+/// actually flies: its anchor lies well right of the `DEMOA`→`DEMOB`
+/// track, so the display must show most of a capture radius of right
+/// deviation the moment the first fix sequences — and then null it.
+#[test]
+fn cdi_realism_demo_fixture_transition_deflects_right_and_recovers() {
+    let mut rig = Rig::new(fixture_engine());
+    assert!(
+        rig.fly_until(5_000, |g| g.leg_index == 1).is_some(),
+        "the demo route sequences its first fix within the step budget"
+    );
+    let entry = rig.expect_guidance("entering the demo route's first fixed leg");
+    assert_eq!(entry.from_ident.as_deref(), Some("DEMOA"));
+    assert_eq!(entry.to_ident, "DEMOB");
+    let transient_m = entry
+        .lateral_deviation_m
+        .expect("a fixed leg reports cross-track deviation");
+    assert!(
+        (90.0..100.0).contains(&transient_m),
+        "the demo transition sits nearly a capture radius right of the new track, got {transient_m}"
+    );
+
+    let trace = converge_on_leg(&mut rig, 1, entry.course_rad, CORNER_DECAYED_M, 2_000);
+    assert!(
+        trace.settled_at <= 1_200,
+        "the demo transient took {} steps to decay",
+        trace.settled_at
+    );
+    assert!(
+        trace.worst_rise_m < JITTER_M,
+        "the demo transient grew {} m before decaying",
+        trace.worst_rise_m
+    );
+}
+
+/// Folds a course difference into `[-π, π]`: a quarter turn right is
+/// `+π/2` whichever side of north the two courses fall.
+fn wrap_to_pi(angle_rad: f64) -> f64 {
+    let wrapped = (angle_rad + core::f64::consts::PI).rem_euclid(core::f64::consts::TAU);
+    wrapped - core::f64::consts::PI
+}

--- a/crates/pilotage-mission/tests/cdi_realism.rs
+++ b/crates/pilotage-mission/tests/cdi_realism.rs
@@ -1,5 +1,5 @@
-//! CDI realism (Pilotage #249): the display-facing cross-track deviation
-//! is checked closed-loop, against a vehicle that is actually off course.
+//! CDI realism: the display-facing cross-track deviation is checked
+//! closed-loop, against a vehicle that is actually off course.
 //!
 //! A deviation readout can be wrong in three ways a static geometry test
 //! never reaches: it can carry the wrong sign, it can carry a magnitude
@@ -26,9 +26,11 @@
 #[path = "cdi_realism/closed_loop.rs"]
 mod closed_loop;
 
-use closed_loop::{CORNER_IDENTS, Rig, corner_engine, fixture_engine, right_of_course_ned};
-use navigate_fpl::SequenceReason;
-use pilotage_mission::{MissionEvent, NavQuality};
+use closed_loop::{
+    CORNER_IDENTS, Rig, corner_engine, fixture_engine, right_of_course_ned, try_engine_over_offsets,
+};
+use navigate_fpl::{PlanActivationError, SequenceReason};
+use pilotage_mission::{MissionBuildError, MissionEvent, NavQuality};
 
 /// Lateral disturbance a displacement scenario applies, m/s. Above the
 /// guidance correction ceiling, so the deviation grows while the push is
@@ -310,4 +312,32 @@ fn cdi_realism_demo_fixture_transition_deflects_right_and_recovers() {
 fn wrap_to_pi(angle_rad: f64) -> f64 {
     let wrapped = (angle_rad + core::f64::consts::PI).rem_euclid(core::f64::consts::TAU);
     wrapped - core::f64::consts::PI
+}
+
+/// A route whose final leg cannot clear the capture radius refuses to
+/// build as a typed activation error, and the rendered refusal names the
+/// offending leg — what an operator reading the single host log line
+/// actually sees. Guards the boundary where the sequencer's activation
+/// check surfaces out of `MissionEngine::new`.
+#[test]
+fn activation_refuses_a_leg_no_longer_than_the_capture_radius() {
+    let idents = ["TIGHA", "TIGHB", "TIGHC"];
+    // 500 m first leg, then a 90 m closer — inside the 100 m capture
+    // radius the mission defaults configure.
+    let offsets = [(0.0, 400.0), (0.0, 900.0), (-90.0, 900.0)];
+    let error = try_engine_over_offsets(&idents, &offsets, "TIGHA TIGHB TIGHC")
+        .map(|_| ())
+        .expect_err("a 90 m leg inside the 100 m capture radius must refuse to build");
+    assert!(
+        matches!(
+            error,
+            MissionBuildError::PlanActivation(PlanActivationError::CaptureRadiusExceedsLeg { .. })
+        ),
+        "expected a typed capture-radius refusal, got {error:?}"
+    );
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("TIGHC") && rendered.contains("capture radius"),
+        "the rendered refusal must name the offending leg: {rendered}"
+    );
 }

--- a/crates/pilotage-mission/tests/cdi_realism/closed_loop.rs
+++ b/crates/pilotage-mission/tests/cdi_realism/closed_loop.rs
@@ -1,0 +1,266 @@
+//! The closed-loop rig the CDI scenarios fly: a kinematic truth model
+//! integrates the engine's own commanded intents at 20 Hz, plus an
+//! optional lateral disturbance standing in for the wind that pushes a
+//! vehicle off the course it is tracking.
+//!
+//! Nothing here reads a clock or randomizes: every step advances a
+//! caller-owned `now` by a fixed interval, so a scenario's step counts
+//! are reproducible numbers a regression can be measured against.
+
+use aerocontext_core::{GeoPoint, NavDataCycle, NavDataSnapshot, NavPoint, NavPointKind};
+use aerocontext_navdata::blob;
+use chrono::NaiveDate;
+use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
+use navigate_geodesy::{LocalTangentPlane, NedOffset};
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+use pilotage_mission::{
+    MissionConfig, MissionEngine, MissionOutput, MissionState, NavGuidance, OwnshipSample,
+    TruthRole, decode_snapshot,
+};
+use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame};
+
+/// The anchor every scenario flies from, matching the closed-loop tests
+/// in `mission_engine.rs` so both suites read the same geometry.
+pub const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+
+/// Tick interval, nanoseconds: 20 Hz, the engine's own frame hint.
+const STEP_NANOS: u64 = 50_000_000;
+
+/// Tick interval in seconds, the truth model's integration step.
+const STEP_S: f64 = 0.05;
+
+/// The corner route's fixes in fly order. Five-letter, digit-free idents:
+/// the route tokenizer reads a trailing digit as a procedure and a
+/// published family prefix as an airway.
+pub const CORNER_IDENTS: [&str; 3] = ["CORNA", "CORNB", "CORNC"];
+
+/// The corner route as a string: three fixes flown in order, no airway.
+pub const CORNER_ROUTE: &str = "CORNA CORNB CORNC";
+
+/// NED offsets of the corner route's fixes from the anchor, meters.
+///
+/// `CORNA` and `CORNB` sit due east of the anchor, so the initial
+/// direct-to leg runs along the extension of the first fixed leg and
+/// arrives with no cross-track transient of its own — a scenario that
+/// displaces the vehicle deliberately starts from a settled course.
+/// `CORNC` lies due south of `CORNB`, making a 90° right turn at the
+/// corner. Both fixed legs are 500 m, far outside the 100 m capture
+/// radius, leaving room for a deviation to be built and nulled inside
+/// one leg.
+const CORNER_OFFSETS: [(f64, f64); 3] = [(0.0, 400.0), (0.0, 900.0), (-500.0, 900.0)];
+
+/// The corner snapshot's cycle date, on the same 28-day AIRAC grid the
+/// demo fixture uses.
+const CORNER_EFFECTIVE_DATE: NaiveDate = match NaiveDate::from_ymd_opt(2026, 1, 22) {
+    Some(date) => date,
+    None => NaiveDate::MIN,
+};
+
+/// Planar truth: NED position and yaw integrated from the engine's own
+/// BodyFrd commands (the exact inverse of the engine's NED-to-body
+/// rotation), plus the lateral disturbance the scenario is applying.
+struct Truth {
+    ned: [f64; 3],
+    ned_velocity: [f64; 3],
+    yaw: f64,
+    sequence: u32,
+}
+
+impl Truth {
+    fn new() -> Self {
+        Self {
+            ned: [0.0; 3],
+            ned_velocity: [0.0; 3],
+            yaw: 0.0,
+            sequence: 0,
+        }
+    }
+
+    fn sample(&self, now: MonotonicNanos) -> OwnshipSample {
+        OwnshipSample {
+            ned: self.ned,
+            ned_velocity: self.ned_velocity,
+            yaw_rad: Some(self.yaw),
+            role: TruthRole::SimulationTruth,
+            acquired_at: now,
+            sequence: self.sequence,
+        }
+    }
+
+    fn integrate(&mut self, intent: &ControlIntent, disturbance_ned: [f64; 2]) {
+        let ControlIntent::Velocity(v) = intent else {
+            panic!("mission emits only velocity intents, got {intent:?}");
+        };
+        assert_eq!(v.frame, ReferenceFrame::BodyFrd);
+        let (vx, vy, vz) = (f64::from(v.vx), f64::from(v.vy), f64::from(v.vz));
+        let (sin, cos) = self.yaw.sin_cos();
+        self.ned_velocity = [
+            vx * cos - vy * sin + disturbance_ned[0],
+            vx * sin + vy * cos + disturbance_ned[1],
+            vz,
+        ];
+        for axis in 0..3 {
+            self.ned[axis] += self.ned_velocity[axis] * STEP_S;
+        }
+        self.yaw += f64::from(v.yaw_rate) * STEP_S;
+    }
+}
+
+/// One engine flown closed-loop against [`Truth`].
+pub struct Rig {
+    pub engine: MissionEngine,
+    truth: Truth,
+    now: MonotonicNanos,
+    /// Horizontal NED velocity added to the truth each step, m/s: the
+    /// disturbance a scenario uses to displace the vehicle from the
+    /// course it is tracking. A rate the fusion innovation gate accepts
+    /// keeps the displacement an observed one rather than a teleport the
+    /// filter would reject outright.
+    pub disturbance_ned: [f64; 2],
+}
+
+impl Rig {
+    #[must_use]
+    pub fn new(engine: MissionEngine) -> Self {
+        Self {
+            engine,
+            truth: Truth::new(),
+            now: MonotonicNanos::from_nanos(1_000_000_000),
+            disturbance_ned: [0.0; 2],
+        }
+    }
+
+    /// One closed-loop step: sample, tick, accept any arm, integrate any
+    /// intent.
+    pub fn step(&mut self) -> MissionOutput {
+        self.now = MonotonicNanos::from_nanos(self.now.as_nanos() + STEP_NANOS);
+        self.truth.sequence = self.truth.sequence.wrapping_add(1);
+        self.engine
+            .on_ownship(&self.truth.sample(self.now), self.now);
+        let out = self.engine.tick(self.now);
+        if let Some(action) = out.action {
+            assert!(matches!(action.action, ControlAction::Arm));
+            self.engine.on_action_result(action.action_id, true);
+        }
+        if let Some(intent) = out.intent.as_ref() {
+            self.truth.integrate(intent, self.disturbance_ned);
+        }
+        out
+    }
+
+    /// Steps until `settled` accepts the published guidance, returning
+    /// the step count it took. `None` means the budget ran out — a
+    /// scenario asserts on that rather than reading a partial result.
+    pub fn fly_until(
+        &mut self,
+        budget: usize,
+        settled: impl Fn(&NavGuidance) -> bool,
+    ) -> Option<usize> {
+        for taken in 1..=budget {
+            self.step();
+            assert_ne!(
+                self.engine.state(),
+                MissionState::Complete,
+                "the plan completed before the scenario's condition held"
+            );
+            if self.guidance().is_some_and(|g| settled(&g)) {
+                return Some(taken);
+            }
+        }
+        None
+    }
+
+    /// The guidance a display would be showing right now.
+    #[must_use]
+    pub fn guidance(&self) -> Option<NavGuidance> {
+        self.engine.nav_guidance()
+    }
+
+    /// The published guidance, or a failure naming what was expected of
+    /// it: a scenario asserting on deviation geometry has no meaningful
+    /// fallback when the executor is flying nothing.
+    #[must_use]
+    pub fn expect_guidance(&self, what: &str) -> NavGuidance {
+        self.guidance()
+            .unwrap_or_else(|| panic!("guidance must be published while {what}"))
+    }
+
+    /// The cross-track deviation a display would be showing, meters.
+    #[must_use]
+    pub fn expect_deviation(&self, what: &str) -> f64 {
+        self.expect_guidance(what)
+            .lateral_deviation_m
+            .unwrap_or_else(|| panic!("a fixed leg reports cross-track deviation while {what}"))
+    }
+}
+
+/// The NED unit vector right of `course_rad`, scaled by `speed_mps`.
+///
+/// A course is a bearing clockwise from north, so its along-track unit is
+/// `(cos, sin)` in (north, east) and right of it is that quarter turn
+/// clockwise. Deriving the push direction from the published course is
+/// what makes the sign assertion independent: geodesy's "positive right
+/// of track" must agree with the bearing convention, not merely with
+/// itself.
+#[must_use]
+pub fn right_of_course_ned(course_rad: f64, speed_mps: f64) -> [f64; 2] {
+    let (sin, cos) = course_rad.sin_cos();
+    [-sin * speed_mps, cos * speed_mps]
+}
+
+/// The demo-fixture engine: the shipped three-fix route, so a scenario
+/// can pin the geometry an operator actually flies.
+#[must_use]
+pub fn fixture_engine() -> MissionEngine {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    engine_over(&blob, fixture::DEMO_ROUTE)
+}
+
+/// The corner-route engine: [`CORNER_OFFSETS`] packed through the same
+/// blob container published data travels.
+#[must_use]
+pub fn corner_engine() -> MissionEngine {
+    let plane = LocalTangentPlane::new(anchor_position()).expect("the anchor is plausible");
+    let points = CORNER_IDENTS
+        .iter()
+        .zip(CORNER_OFFSETS)
+        .map(|(ident, (north_m, east_m))| {
+            let position = plane.from_ned(&NedOffset::new(north_m, east_m, 0.0));
+            NavPoint::new(
+                *ident,
+                NavPointKind::Waypoint,
+                GeoPoint {
+                    lat: position.latitude_rad.to_degrees(),
+                    lon: position.longitude_rad.to_degrees(),
+                },
+            )
+        })
+        .collect();
+    let cycle = NavDataCycle::faa_nasr(CORNER_EFFECTIVE_DATE).expect("the corner cycle is valid");
+    let snapshot = NavDataSnapshot::new(cycle, points);
+    let blob = blob::encode(&snapshot).expect("the corner snapshot encodes");
+    engine_over(&blob, CORNER_ROUTE)
+}
+
+/// The anchor as the engine sees it: radians and meters.
+fn anchor_position() -> GeodeticPosition {
+    GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    )
+}
+
+/// Builds an engine over a packed snapshot and a route, on the documented
+/// mission defaults.
+fn engine_over(packed: &[u8], route: &str) -> MissionEngine {
+    let (snapshot, provenance) = decode_snapshot(packed, true).expect("the blob decodes");
+    let config = MissionConfig::new(route.to_owned(), anchor_position(), ClockDomainId::new(7));
+    let (engine, _record) =
+        MissionEngine::new(&snapshot, provenance, config).expect("the mission builds");
+    engine
+}

--- a/crates/pilotage-mission/tests/cdi_realism/closed_loop.rs
+++ b/crates/pilotage-mission/tests/cdi_realism/closed_loop.rs
@@ -14,8 +14,8 @@ use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
 use navigate_geodesy::{LocalTangentPlane, NedOffset};
 use pilotage_mission::fixture::{self, GeoPointDegrees};
 use pilotage_mission::{
-    MissionConfig, MissionEngine, MissionOutput, MissionState, NavGuidance, OwnshipSample,
-    TruthRole, decode_snapshot,
+    MissionBuildError, MissionConfig, MissionEngine, MissionOutput, MissionPlanRecord,
+    MissionState, NavGuidance, OwnshipSample, TruthRole, decode_snapshot,
 };
 use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame};
 
@@ -224,10 +224,23 @@ pub fn fixture_engine() -> MissionEngine {
 /// blob container published data travels.
 #[must_use]
 pub fn corner_engine() -> MissionEngine {
+    let (engine, _record) = try_engine_over_offsets(&CORNER_IDENTS, &CORNER_OFFSETS, CORNER_ROUTE)
+        .expect("the corner mission builds");
+    engine
+}
+
+/// Packs arbitrary NED fix offsets through the blob container published
+/// data travels and attempts the mission build, surfacing the typed
+/// refusal a route the sequencer cannot activate earns.
+pub fn try_engine_over_offsets(
+    idents: &[&str],
+    offsets: &[(f64, f64)],
+    route: &str,
+) -> Result<(MissionEngine, MissionPlanRecord), MissionBuildError> {
     let plane = LocalTangentPlane::new(anchor_position()).expect("the anchor is plausible");
-    let points = CORNER_IDENTS
+    let points = idents
         .iter()
-        .zip(CORNER_OFFSETS)
+        .zip(offsets.iter().copied())
         .map(|(ident, (north_m, east_m))| {
             let position = plane.from_ned(&NedOffset::new(north_m, east_m, 0.0));
             NavPoint::new(
@@ -240,10 +253,12 @@ pub fn corner_engine() -> MissionEngine {
             )
         })
         .collect();
-    let cycle = NavDataCycle::faa_nasr(CORNER_EFFECTIVE_DATE).expect("the corner cycle is valid");
+    let cycle = NavDataCycle::faa_nasr(CORNER_EFFECTIVE_DATE).expect("the cycle is valid");
     let snapshot = NavDataSnapshot::new(cycle, points);
-    let blob = blob::encode(&snapshot).expect("the corner snapshot encodes");
-    engine_over(&blob, CORNER_ROUTE)
+    let blob = blob::encode(&snapshot).expect("the snapshot encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("the blob decodes");
+    let config = MissionConfig::new(route.to_owned(), anchor_position(), ClockDomainId::new(7));
+    MissionEngine::new(&snapshot, provenance, config)
 }
 
 /// The anchor as the engine sees it: radians and meters.

--- a/crates/pilotage-mission/tests/mission_engine.rs
+++ b/crates/pilotage-mission/tests/mission_engine.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
 use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
+use navigate_fpl::SequenceReason;
 use navigate_guidance::GuidanceRefusal;
 use pilotage_mission::fixture::{self, GeoPointDegrees};
 use pilotage_mission::{
@@ -149,11 +150,16 @@ fn assert_flight_events(events: &[MissionEvent]) {
         count(events, |e| matches!(e, MissionEvent::EnrouteStarted)),
         1
     );
+    // Every demo advance is capture-driven: at the mission cruise speed
+    // the fly-by turn radius is on the order of a meter, so the distance
+    // of turn anticipation stays far inside the capture radius and no
+    // transition is authorized early.
     for to_index in [1usize, 2] {
         assert_eq!(
             count(events, |e| matches!(
                 e,
-                MissionEvent::LegAdvanced { to_index: t } if *t == to_index
+                MissionEvent::LegAdvanced { to_index: t, reason: SequenceReason::Overflown }
+                    if *t == to_index
             )),
             1,
             "leg advance to {to_index}"

--- a/docs/mission/mission02-fixture-aviate.run.txt
+++ b/docs/mission/mission02-fixture-aviate.run.txt
@@ -11,10 +11,11 @@ No client attached at any point. Navigate pin ace50f68b3ffae6237bbb53f6af6
 Purpose: re-record the MISSION-01 chain at the turn-types Navigate pin.
 Sequencing is now groundspeed-aware (advance() takes the commanded
 groundspeed, cruise bounded by the tightened ceiling) and every sequence
-event carries its reason. At this ceiling (2.5 m/s) the bank-limit model
-earns a turn radius of ~2 m, so anticipation distance never approaches
-the 100 m capture radius: both advances report reason=Overflown, exactly
-as the cdi_realism suite predicts for every mission at current config.
+event carries its reason. At the commanded groundspeed (2.0 m/s cruise,
+under the 2.5 m/s ceiling) the bank-limit model earns a turn radius of
+~1.3 m, so anticipation distance never approaches the 100 m capture
+radius: both advances report reason=Overflown, exactly as the
+cdi_realism suite predicts for every mission at current config.
 
 Chain exercised end to end (unchanged from MISSION-01):
   Communicate fixture blob (real .acnav container, sha256-verified decode)
@@ -49,8 +50,9 @@ Zero GuidanceRefused events, zero FrameRejected lines in the host log for
 the mission principal over the full flight. Leg timings corroborate the
 capture geometry: the DEMOB leg (185.6 m plus the post-sequence
 cross-track transient) ran 77 s and the final leg completed 39 s after
-its advance — the terminal fix captures 100 m out, 76.8 m of the
-176.8 m leg plus transient at the tapering approach speed.
+its advance — the terminal fix captures 100 m out, and the corner's
+100 m run-in already projects ~29 m along the outbound course, leaving
+~48 m of along-track plus the corner transient to null.
 
 Gate context: cargo fmt --check; clippy --all-targets -D warnings;
 mission + session-host tests 136 passed (cdi_realism 4/4, twice,

--- a/docs/mission/mission02-fixture-aviate.run.txt
+++ b/docs/mission/mission02-fixture-aviate.run.txt
@@ -1,0 +1,60 @@
+MISSION-02 acceptance flight — fixture navdata, Aviate SITL, headless
+=====================================================================
+
+Command: PILOTAGE_MISSION_ROUTE=fixture RUST_LOG=info cargo xtask sim --fc aviate-gz --no-open
+Stack: Gazebo (aviate x500 flightdeck) + Aviate SITL FC + pilotage-session-host
+       (aviate adapter, shm telemetry) + in-process mission executor.
+No client attached at any point. Navigate pin ace50f68b3ffae6237bbb53f6af6
+87c335518272 (turn types + procedure constraints); aerocontext 0.4.5
+(crates.io).
+
+Purpose: re-record the MISSION-01 chain at the turn-types Navigate pin.
+Sequencing is now groundspeed-aware (advance() takes the commanded
+groundspeed, cruise bounded by the tightened ceiling) and every sequence
+event carries its reason. At this ceiling (2.5 m/s) the bank-limit model
+earns a turn radius of ~2 m, so anticipation distance never approaches
+the 100 m capture radius: both advances report reason=Overflown, exactly
+as the cdi_realism suite predicts for every mission at current config.
+
+Chain exercised end to end (unchanged from MISSION-01):
+  Communicate fixture blob (real .acnav container, sha256-verified decode)
+  -> route "DEMOA V901 DEMOC" expanded via airway V901 to DEMOA DEMOB DEMOC
+  -> navigate FlightPlan (degrees->radians once, ADR-0030 unit boundary)
+  -> automation-class local principal (hello/welcome/activation/lease,
+     ClientKey u64::MAX, fenced generation 1, ADR-0025 no-bypass path)
+  -> typed Arm via ControlActionCommand (accepted, action_id 1)
+  -> Navigate fusion (sim-truth-derived GNSS, SimulationTruth role only)
+  -> guide_velocity -> BodyFrd velocity intents within advertised limits
+     (tightened to 2.5 / 1.0 / 0.8)
+  -> aviate adapter -> Aviate SITL (armed 22:02:48, "Armed successfully").
+
+Host log (ANSI-stripped, mission lines verbatim):
+
+2026-07-29T22:02:48.445360Z INFO mission packed for flight route=DEMOA V901 DEMOC waypoints=3 expanded=["DEMOA", "DEMOB", "DEMOC"] authority=faa-nasr effective_on=2026-01-22 sha256=74952060bf48e49f3176de552610543bdc9add6fdaf8b8985283898c2dd18ff2 fixture=true
+2026-07-29T22:02:48.541386Z INFO mission engine ready under advertised limits route=DEMOA V901 DEMOC max_horizontal_mps=2.5 max_vertical_mps=1.0 max_yaw_rate_rps=0.8
+2026-07-29T22:02:48.541412Z INFO control profile activation accepted client=18446744073709551615 profile=automation.mission profile_revision=1 activation_revision=1
+2026-07-29T22:02:48.541430Z INFO mission motion lease granted generation=1
+2026-07-29T22:02:48.547076Z INFO mission event event=ArmRequested { action_id: 1 }
+2026-07-29T22:02:48.547105Z INFO mission action command action=Arm action_id=1
+2026-07-29T22:02:48.547195Z INFO mission action result action=Arm accepted=true detail=
+2026-07-29T22:02:48.597535Z INFO mission event event=ArmAccepted { action_id: 1 }
+2026-07-29T22:02:48.597559Z INFO mission event event=ClimbStarted
+2026-07-29T22:03:06.546962Z INFO mission event event=EnrouteStarted
+2026-07-29T22:03:18.697245Z INFO mission event event=LegAdvanced { to_index: 1, reason: Overflown }
+2026-07-29T22:04:35.896753Z INFO mission event event=LegAdvanced { to_index: 2, reason: Overflown }
+2026-07-29T22:05:14.718582Z INFO mission complete
+
+Timeline: arm+climb 18 s, enroute 2 m 8 s, wheels-up to complete 2 m 26 s.
+Zero GuidanceRefused events, zero FrameRejected lines in the host log for
+the mission principal over the full flight. Leg timings corroborate the
+capture geometry: the DEMOB leg (185.6 m plus the post-sequence
+cross-track transient) ran 77 s and the final leg completed 39 s after
+its advance — the terminal fix captures 100 m out, 76.8 m of the
+176.8 m leg plus transient at the tapering approach speed.
+
+Gate context: cargo fmt --check; clippy --all-targets -D warnings;
+mission + session-host tests 136 passed (cdi_realism 4/4, twice,
+identical); cargo check --workspace; release build; structure check;
+wasm wire-decode conformance; doc gate (-D missing_docs -D
+broken_intra_doc_links) — all green at flight time.
+SIM / NOT FOR FLIGHT — fixture navdata, sim-truth-derived GNSS.


### PR DESCRIPTION
Closes #249. Stacked on #250.

## Navigate pin bump (dcee4e14 → ace50f68)

The five `navigate-*` pins move to the turn-types merge (Navigate PR #2):
groundspeed-aware leg sequencing, `{turn, reason}` on sequence events,
and activation-time refusals (`PlanActivationError`: sub-floor speeds,
legs shorter than the capture radius, non-finite config).

Engine adaptations:

- `PlanExecution::advance` now takes the commanded groundspeed; the
  engine passes `cruise_mps.min(limits.max_horizontal_mps)` — the speed
  the vehicle is actually flown at, so a host-tightened ceiling shrinks
  turn anticipation with it. The config value (not guidance's live
  along-speed) is deliberate: guidance tapers approaching a fix, which
  would shrink anticipation exactly where it is compared against
  distance-to-run.
- `MissionEvent::LegAdvanced` carries `reason: SequenceReason`
  (`Anticipated` vs `Overflown`). No `turn` field: every waypoint built
  from navdata defaults to fly-by, so it would be structurally constant.
- `MissionBuildError::PlanInvalid` → `PlanActivation` (typed
  `PlanActivationError` source).

Fixture legs are 185.6 m / 176.8 m — both clear the 100 m capture-radius
activation guardrail.

## CDI realism tests (#249)

`crates/pilotage-mission/tests/cdi_realism.rs` closes the loop through
the real chain (fusion → sequencing → guidance → truth kinematics) and
pins what a pilot flying the needle depends on:

1. **Displaced capture, right of course** — a lateral velocity
   disturbance (admitted by the innovation gate; `fusion_rejected == 0`
   asserted) pushes the vehicle ~40 m right: deviation reads POSITIVE,
   halves within 300 steps, under 5 m within 600, never grows
   step-to-step above 0.5 m, and neither the leg index nor the desired
   track moves during convergence.
2. **Displaced capture, left of course** — the mirror, pinning the
   NEGATIVE sign and the same envelope.
3. **90° dogleg** — course swings +π/2 (within 0.01 rad) on an
   `Overflown` sequence; the post-corner transient equals the run-in
   still owed to the corner within 2 m and decays under 10 m.
4. **Shipped demo route** — the fixture's first transition deflects
   right into [90, 100) m and recovers under 10 m.

Assertions are mutation-tested: a negated cross-track sign and a dropped
leg origin each fail all four scenarios. Known limitation (documented in
the rig): a reflected lateral axis in `ned_to_body` is absorbed by the
closed loop's compensating fixed point — `body_frame` unit tests remain
the guard for that defect class.

## Acceptance flight

`docs/mission/mission02-fixture-aviate.run.txt` records a fresh headless
fixture mission at this pin (Gazebo + Aviate SITL), showing the new
`LegAdvanced { .., reason }` event shape in flight. The mission01 record
is preserved as evidence of what the previous pin flew.

## Gates

fmt, clippy `-D warnings` (all targets), mission+session-host tests
(136 passed), workspace check, release build, structure check, wasm
wire-decode conformance, doc gate (`-D missing_docs -D
broken_intra_doc_links`) — all green. cdi_realism determinism: two
identical 4/4 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #251 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #250
<!-- GitButler Footer Boundary Bottom -->