### PR TITLE
Extract source identity into a leaf crate with the ingress admission gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           cargo check
           -p pilotage-frames
           -p pilotage-geo
+          -p pilotage-ingress
           -p pilotage-alerts
           -p pilotage-instrument-state
           -p pilotage-instrument-scene

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "pilotage-calibration-id",
  "pilotage-camera-calibration",
  "pilotage-frames",
+ "pilotage-ingress",
  "pilotage-protocol",
  "pilotage-timing",
  "serde",
@@ -1154,6 +1155,10 @@ dependencies = [
  "pilotage-frames",
  "thiserror",
 ]
+
+[[package]]
+name = "pilotage-ingress"
+version = "0.1.0"
 
 [[package]]
 name = "pilotage-input"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/pilotage-protocol",
     "crates/pilotage-authority",
     "crates/pilotage-session",
+    "crates/pilotage-ingress",
     "crates/pilotage-input",
     "crates/pilotage-timing",
     "crates/pilotage-adapter-api",
@@ -63,6 +64,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 pilotage-timing = { path = "crates/pilotage-timing" }
 pilotage-protocol = { path = "crates/pilotage-protocol" }
 pilotage-authority = { path = "crates/pilotage-authority" }
+pilotage-ingress = { path = "crates/pilotage-ingress" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-mavlink = { path = "crates/pilotage-mavlink" }

--- a/crates/pilotage-adapter-api/Cargo.toml
+++ b/crates/pilotage-adapter-api/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
+pilotage-ingress = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
 pilotage-frames = { workspace = true }

--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -3,107 +3,12 @@
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
-/// The monotonic clock in which a measurement's acquisition timestamp is
-/// expressed. Timestamps from different domains are never subtracted without
-/// an explicit correlation supplied by the adapter boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MeasurementClock {
-    /// Monotonic time since the producing vehicle computer booted.
-    VehicleBoot,
-    /// Monotonic simulation time supplied by the simulator.
-    Simulation,
-    /// Monotonic time on the ground host that received the observation,
-    /// for reports whose wire carries no source timestamp (an FC
-    /// heartbeat). Receive time is not acquisition time; consumers may
-    /// only reason about staleness in this domain, never correlate it
-    /// with vehicle or simulation clocks without an explicit mapping.
-    HostMonotonic,
-}
-
-/// Opaque identity of one source attachment or boot instance.
-///
-/// Unlike [`MeasurementStamp::source_epoch`], this value is compared only for
-/// equality. A new incarnation cannot be ordered relative to an earlier one;
-/// the receiver must authorize that transition at a lifecycle boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SourceIncarnation([u8; 16]);
-
-impl SourceIncarnation {
-    /// Constructs an incarnation from its complete 128-bit representation.
-    #[must_use]
-    pub const fn new(bytes: [u8; 16]) -> Self {
-        Self(bytes)
-    }
-
-    /// Returns the complete opaque representation.
-    #[must_use]
-    pub const fn into_bytes(self) -> [u8; 16] {
-        self.0
-    }
-}
-
-/// Explicit role of the source behind a measurement. Role is carried in
-/// provenance — never encoded into id ranges — so a configured source id
-/// can collide across roles without ambiguity, and consumers gate on the
-/// role itself (panels and control accept only
-/// [`SourceRole::OperationalEstimate`]).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SourceRole {
-    /// FC estimator output: the only role eligible for primary panels
-    /// and operational command construction.
-    OperationalEstimate,
-    /// Simulator ground truth: logging, assertions, and comparison in
-    /// simulation profiles only.
-    SimulationTruth,
-    /// FC-owned vehicle state (arm/mode/failsafe) reports.
-    FcState,
-    /// Video capture identity for camera frames.
-    VideoCapture,
-    /// Payload-device orientation/state (gimbal attitude) relayed over
-    /// the FC link: never a vehicle estimate, never eligible for control
-    /// validation, carrying the device's own boot clock.
-    PayloadDevice,
-}
-
-/// Integrity classification of the path that delivered an observation.
-/// The distinction that matters end-to-end is authenticated source data
-/// versus merely checksummed or unprotected observations; a consumer
-/// making a safety claim must require the level the claim needs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SourceIntegrity {
-    /// Cryptographically authenticated end-to-end source data.
-    Authenticated,
-    /// Checksummed (CRC-style) but unauthenticated transport.
-    ChecksummedOnly,
-    /// No integrity protection beyond the transport's own boundaries
-    /// (a local shared-memory mapping relies on host process isolation).
-    Unprotected,
-}
-
-/// Identity and acquisition stamp for one independently advancing
-/// measurement group.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MeasurementStamp {
-    /// Explicit source role; consumers gate on this, never on id ranges.
-    pub role: SourceRole,
-    /// Integrity classification of the path that delivered this
-    /// observation; every role carries it so authenticated, checksummed,
-    /// and unprotected inputs stay distinguishable end to end.
-    pub integrity: SourceIntegrity,
-    /// Adapter-defined source identifier, stable within one vehicle and
-    /// one role. Ids may collide across roles; the role disambiguates.
-    pub source_id: u64,
-    /// Opaque attachment/boot identity for the producing source.
-    pub source_incarnation: SourceIncarnation,
-    /// Source boot/attachment generation. A reset changes this value.
-    pub source_epoch: u32,
-    /// Wrapping group sequence, advanced only for a new measurement.
-    pub sequence: u32,
-    /// Acquisition time in nanoseconds in [`Self::clock`].
-    pub acquired_at_ns: u64,
-    /// Clock domain for [`Self::acquired_at_ns`].
-    pub clock: MeasurementClock,
-}
+// Source identity moved to `pilotage-ingress` so the ingress rules can be
+// applied where no wire exists (ADR-0018, ADR-0026's host-absent posture).
+// Re-exported here because this crate is the adapter-facing vocabulary.
+pub use pilotage_ingress::{
+    MeasurementClock, MeasurementStamp, SourceIncarnation, SourceIntegrity, SourceRole,
+};
 
 /// A planar pose: position and heading, independent of any specific vehicle
 /// model's internal representation.

--- a/crates/pilotage-ingress/Cargo.toml
+++ b/crates/pilotage-ingress/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pilotage-ingress"
+description = "Protocol-free source identity and the ingress admission gate (ADR-0018)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/pilotage-ingress/src/admission.rs
+++ b/crates/pilotage-ingress/src/admission.rs
@@ -1,0 +1,175 @@
+//! The ingress admission gate (ADR-0018).
+
+use crate::stamp::MeasurementStamp;
+
+/// Why a measurement group was refused.
+///
+/// A refusal is counted and never replaces display state or refreshes its age;
+/// a stale value that keeps its true age is honest, a stale value refreshed by
+/// a rejected frame is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectReason {
+    /// The attachment changed to an incarnation the receiver has not
+    /// authorized at a lifecycle boundary.
+    UnauthorizedIncarnation,
+    /// The epoch went backwards within one incarnation.
+    OlderEpoch,
+    /// The sequence repeats one already seen at this epoch.
+    DuplicateSequence,
+    /// The sequence went backwards under wrap-safe serial comparison.
+    ReorderedSequence,
+    /// Acquisition time regressed within one attachment and epoch.
+    AcquisitionRegressed,
+    /// The clock domain changed without a new attachment, so no ordering
+    /// between the old and new timestamps can be established.
+    ClockDomainChanged,
+}
+
+/// The gate's decision for one measurement group.
+///
+/// Dropping this verdict silently applies nothing while looking like the
+/// group was ingested, which is the one failure the gate exists to prevent —
+/// so it must be honored, not discarded.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Admission {
+    /// The group may replace display state.
+    Accepted {
+        /// The attachment or epoch changed, so every other group carried by
+        /// the previous identity must be cleared before this one is applied.
+        /// One display generation must never mix values across a source reset.
+        identity_changed: bool,
+    },
+    /// The group was refused for this reason and must not be applied.
+    Rejected(RejectReason),
+}
+
+/// Admits or refuses one measurement group's stream from one source.
+///
+/// A caller holds one gate per (source, role, group): the stamp carries a
+/// single sequence, and ADR-0018 advances attitude, kinematics, and estimator
+/// status independently.
+#[derive(Debug, Default)]
+pub struct SourceGate {
+    seen: Option<MeasurementStamp>,
+    accepted: u32,
+    rejected: u32,
+}
+
+impl SourceGate {
+    /// Creates a gate that has seen nothing.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            seen: None,
+            accepted: 0,
+            rejected: 0,
+        }
+    }
+
+    /// Groups admitted so far. Wraps rather than saturating; the value is a
+    /// diagnostic counter, not a limit.
+    #[must_use]
+    pub const fn accepted(&self) -> u32 {
+        self.accepted
+    }
+
+    /// Groups refused so far.
+    #[must_use]
+    pub const fn rejected(&self) -> u32 {
+        self.rejected
+    }
+
+    /// The stamp of the last admitted group.
+    #[must_use]
+    pub const fn last_admitted(&self) -> Option<&MeasurementStamp> {
+        self.seen.as_ref()
+    }
+
+    /// Decides whether `stamp`'s group may replace display state.
+    ///
+    /// `authorize_attachment` is consulted only when the attachment changes.
+    /// Deployment profiles differ here: an aircraft profile pins a
+    /// source-issued incarnation during authenticated bootstrap, while a
+    /// simulator profile may accept a bounded number of unseen incarnations.
+    /// The policy is the caller's; the ordering rules are this gate's.
+    pub fn admit(
+        &mut self,
+        stamp: &MeasurementStamp,
+        authorize_attachment: impl FnOnce(&MeasurementStamp) -> bool,
+    ) -> Admission {
+        let Some(seen) = self.seen else {
+            return self.settle(stamp, first_attachment(stamp, authorize_attachment));
+        };
+        if !seen.same_attachment(stamp) {
+            return self.settle(stamp, first_attachment(stamp, authorize_attachment));
+        }
+        self.settle(stamp, continue_attachment(&seen, stamp))
+    }
+
+    fn settle(&mut self, stamp: &MeasurementStamp, outcome: Admission) -> Admission {
+        match outcome {
+            Admission::Accepted { .. } => {
+                self.accepted = self.accepted.wrapping_add(1);
+                self.seen = Some(*stamp);
+            }
+            Admission::Rejected(_) => {
+                self.rejected = self.rejected.wrapping_add(1);
+            }
+        }
+        outcome
+    }
+}
+
+fn first_attachment(
+    stamp: &MeasurementStamp,
+    authorize: impl FnOnce(&MeasurementStamp) -> bool,
+) -> Admission {
+    if authorize(stamp) {
+        Admission::Accepted {
+            identity_changed: true,
+        }
+    } else {
+        Admission::Rejected(RejectReason::UnauthorizedIncarnation)
+    }
+}
+
+fn continue_attachment(seen: &MeasurementStamp, stamp: &MeasurementStamp) -> Admission {
+    if stamp.source_epoch != seen.source_epoch {
+        return if serial_gt(stamp.source_epoch, seen.source_epoch) {
+            // A new epoch is a source reset inside one attachment: ordering
+            // established under the old epoch no longer applies.
+            Admission::Accepted {
+                identity_changed: true,
+            }
+        } else {
+            Admission::Rejected(RejectReason::OlderEpoch)
+        };
+    }
+    if stamp.clock != seen.clock {
+        return Admission::Rejected(RejectReason::ClockDomainChanged);
+    }
+    if stamp.sequence == seen.sequence {
+        return Admission::Rejected(RejectReason::DuplicateSequence);
+    }
+    if !serial_gt(stamp.sequence, seen.sequence) {
+        return Admission::Rejected(RejectReason::ReorderedSequence);
+    }
+    if stamp.acquired_at_ns < seen.acquired_at_ns {
+        return Admission::Rejected(RejectReason::AcquisitionRegressed);
+    }
+    Admission::Accepted {
+        identity_changed: false,
+    }
+}
+
+/// Wrap-safe serial comparison (RFC 1982): whether `a` is newer than `b`.
+///
+/// A counter that wraps must not make the next value look ancient, so
+/// "newer" is defined as being within the forward half of the number space.
+fn serial_gt(a: u32, b: u32) -> bool {
+    a != b && a.wrapping_sub(b) < (1 << 31)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-ingress/src/admission/tests.rs
+++ b/crates/pilotage-ingress/src/admission/tests.rs
@@ -1,0 +1,224 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::source::{MeasurementClock, SourceIncarnation, SourceIntegrity, SourceRole};
+
+fn incarnation(tag: u8) -> SourceIncarnation {
+    let mut bytes = [0u8; 16];
+    bytes[15] = tag;
+    SourceIncarnation::new(bytes)
+}
+
+fn stamp(epoch: u32, sequence: u32, acquired_at_ns: u64) -> MeasurementStamp {
+    MeasurementStamp {
+        role: SourceRole::OperationalEstimate,
+        integrity: SourceIntegrity::Authenticated,
+        source_id: 7,
+        source_incarnation: incarnation(1),
+        source_epoch: epoch,
+        sequence,
+        acquired_at_ns,
+        clock: MeasurementClock::VehicleBoot,
+    }
+}
+
+fn allow(_: &MeasurementStamp) -> bool {
+    true
+}
+
+fn deny(_: &MeasurementStamp) -> bool {
+    false
+}
+
+/// Admits a stamp the test depends on having been accepted.
+///
+/// A setup line that silently stopped establishing state would leave the
+/// assertion below it passing for the wrong reason.
+fn establish(gate: &mut SourceGate, stamp: &MeasurementStamp) {
+    assert!(
+        matches!(gate.admit(stamp, allow), Admission::Accepted { .. }),
+        "setup stamp must be admitted"
+    );
+}
+
+#[test]
+fn the_first_group_from_an_authorized_attachment_is_admitted() {
+    let mut gate = SourceGate::new();
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: true
+        },
+        gate.admit(&stamp(1, 10, 1_000), allow)
+    );
+    assert_eq!(1, gate.accepted());
+}
+
+#[test]
+fn an_unauthorized_attachment_is_refused_and_leaves_no_state() {
+    let mut gate = SourceGate::new();
+    assert_eq!(
+        Admission::Rejected(RejectReason::UnauthorizedIncarnation),
+        gate.admit(&stamp(1, 10, 1_000), deny)
+    );
+    assert!(gate.last_admitted().is_none());
+    assert_eq!(1, gate.rejected());
+}
+
+#[test]
+fn advancing_sequence_within_one_epoch_is_admitted_without_clearing_state() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: false
+        },
+        gate.admit(&stamp(1, 11, 1_100), allow)
+    );
+}
+
+#[test]
+fn a_duplicate_sequence_cannot_refresh_state() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    // A re-publication carries the complete original stamp, so it is a
+    // duplicate rather than a new measurement, however late it arrives.
+    assert_eq!(
+        Admission::Rejected(RejectReason::DuplicateSequence),
+        gate.admit(&stamp(1, 10, 9_999), allow)
+    );
+    assert_eq!(10, gate.last_admitted().expect("a stamp").sequence);
+}
+
+#[test]
+fn a_reordered_sequence_is_refused() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    assert_eq!(
+        Admission::Rejected(RejectReason::ReorderedSequence),
+        gate.admit(&stamp(1, 9, 1_100), allow)
+    );
+}
+
+#[test]
+fn sequence_comparison_survives_the_wrap_boundary() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, u32::MAX, 1_000));
+    // Wrapping past the maximum is the next measurement, not an ancient one.
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: false
+        },
+        gate.admit(&stamp(1, 0, 1_100), allow)
+    );
+    // ...and the value before the wrap is still older.
+    assert_eq!(
+        Admission::Rejected(RejectReason::ReorderedSequence),
+        gate.admit(&stamp(1, u32::MAX - 1, 1_200), allow)
+    );
+}
+
+#[test]
+fn a_newer_epoch_clears_the_previous_identity() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 500, 5_000));
+    // A source reset restarts the sequence; the epoch is what orders it, and
+    // the caller must clear the other groups from the previous epoch.
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: true
+        },
+        gate.admit(&stamp(2, 0, 10), allow)
+    );
+}
+
+#[test]
+fn an_older_epoch_is_refused() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(5, 10, 1_000));
+    assert_eq!(
+        Admission::Rejected(RejectReason::OlderEpoch),
+        gate.admit(&stamp(4, 11, 1_100), allow)
+    );
+}
+
+#[test]
+fn epoch_comparison_survives_the_wrap_boundary() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(u32::MAX, 10, 1_000));
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: true
+        },
+        gate.admit(&stamp(0, 0, 1_100), allow)
+    );
+}
+
+#[test]
+fn acquisition_time_may_not_regress_within_one_epoch() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 5_000));
+    assert_eq!(
+        Admission::Rejected(RejectReason::AcquisitionRegressed),
+        gate.admit(&stamp(1, 11, 4_999), allow)
+    );
+}
+
+#[test]
+fn a_clock_domain_change_within_one_attachment_is_refused() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    let mut moved = stamp(1, 11, 1_100);
+    moved.clock = MeasurementClock::HostMonotonic;
+    // Two domains cannot be ordered without an explicit correlation, so the
+    // gate refuses rather than inventing one.
+    assert_eq!(
+        Admission::Rejected(RejectReason::ClockDomainChanged),
+        gate.admit(&moved, allow)
+    );
+}
+
+#[test]
+fn a_new_attachment_is_re_authorized_and_clears_the_previous_identity() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(9, 900, 9_000));
+    let mut reattached = stamp(1, 0, 10);
+    reattached.source_incarnation = incarnation(2);
+    // Epoch ordering is meaningless across incarnations: a lower epoch under a
+    // newly authorized attachment is legitimate.
+    assert_eq!(
+        Admission::Accepted {
+            identity_changed: true
+        },
+        gate.admit(&reattached, allow)
+    );
+}
+
+#[test]
+fn an_unauthorized_reattachment_cannot_displace_the_current_source() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    let mut reattached = stamp(1, 11, 1_100);
+    reattached.source_incarnation = incarnation(2);
+    assert_eq!(
+        Admission::Rejected(RejectReason::UnauthorizedIncarnation),
+        gate.admit(&reattached, deny)
+    );
+    assert_eq!(
+        incarnation(1),
+        gate.last_admitted().expect("a stamp").source_incarnation
+    );
+}
+
+#[test]
+fn a_different_role_on_the_same_id_is_a_different_attachment() {
+    let mut gate = SourceGate::new();
+    establish(&mut gate, &stamp(1, 10, 1_000));
+    let mut other = stamp(1, 11, 1_100);
+    other.role = SourceRole::SimulationTruth;
+    // Ids may collide across roles, so the role must disambiguate rather than
+    // letting simulation truth advance an operational stream.
+    assert_eq!(
+        Admission::Rejected(RejectReason::UnauthorizedIncarnation),
+        gate.admit(&other, deny)
+    );
+}

--- a/crates/pilotage-ingress/src/lib.rs
+++ b/crates/pilotage-ingress/src/lib.rs
@@ -1,0 +1,28 @@
+//! Protocol-free source identity and the ingress admission gate (ADR-0018).
+//!
+//! ADR-0018 defines how a receiver decides whether a measurement group may
+//! replace display state: a group is admitted only when its incarnation is
+//! authorized and its epoch and sequence advance under wrap-safe serial
+//! arithmetic. Duplicates, reordering, already-seen incarnations, older epochs,
+//! and acquisition-time regressions are counted and cannot replace state or
+//! refresh its age.
+//!
+//! Those rules are stated here in types that carry no wire dependency, because
+//! they are needed in postures where no wire exists. ADR-0026's host-absent
+//! `embedded` posture — a tablet talking straight to a panel — still has source
+//! identity: the panel boots, reconnects, and can be swapped. Expressing
+//! identity only in protocol types would make the rules unavailable exactly
+//! where there is no protocol.
+//!
+//! The crate is `no_std` and allocation-free so it can sit under the instrument
+//! family (ADR-0017), whose leaf crates it is intended to feed.
+
+#![no_std]
+
+mod admission;
+mod source;
+mod stamp;
+
+pub use admission::{Admission, RejectReason, SourceGate};
+pub use source::{MeasurementClock, SourceIncarnation, SourceIntegrity, SourceRole};
+pub use stamp::MeasurementStamp;

--- a/crates/pilotage-ingress/src/source.rs
+++ b/crates/pilotage-ingress/src/source.rs
@@ -1,0 +1,82 @@
+//! Source identity vocabulary shared by every ingress path.
+
+/// The monotonic clock in which a measurement's acquisition timestamp is
+/// expressed. Timestamps from different domains are never subtracted without
+/// an explicit correlation supplied by the adapter boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeasurementClock {
+    /// Monotonic time since the producing vehicle computer booted.
+    VehicleBoot,
+    /// Monotonic simulation time supplied by the simulator.
+    Simulation,
+    /// Monotonic time on the ground host that received the observation,
+    /// for reports whose wire carries no source timestamp (an FC
+    /// heartbeat). Receive time is not acquisition time; consumers may
+    /// only reason about staleness in this domain, never correlate it
+    /// with vehicle or simulation clocks without an explicit mapping.
+    HostMonotonic,
+}
+
+/// Opaque attachment or boot identity for a producing source.
+///
+/// Unlike an epoch, this value is compared only for equality. A new
+/// incarnation cannot be ordered relative to an earlier one; the receiver must
+/// authorize that transition at a lifecycle boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SourceIncarnation([u8; 16]);
+
+impl SourceIncarnation {
+    /// Constructs an incarnation from its complete 128-bit representation.
+    #[must_use]
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the complete opaque representation.
+    #[must_use]
+    pub const fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// Explicit role of the source behind a measurement.
+///
+/// Role is carried in provenance — never encoded into id ranges — so a
+/// configured source id can collide across roles without ambiguity, and
+/// consumers gate on the role itself (panels and control accept only
+/// [`SourceRole::OperationalEstimate`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceRole {
+    /// Estimator output: the only role eligible for primary panels and
+    /// operational command construction.
+    OperationalEstimate,
+    /// Simulator ground truth: logging, assertions, and comparison in
+    /// simulation profiles only.
+    SimulationTruth,
+    /// Vehicle state (arm/mode/failsafe) reports.
+    FcState,
+    /// Video capture identity for camera frames.
+    VideoCapture,
+    /// Payload-device orientation or state relayed over the vehicle link:
+    /// never a vehicle estimate, never eligible for control validation,
+    /// carrying the device's own boot clock.
+    PayloadDevice,
+}
+
+/// Integrity classification of the path that delivered an observation.
+///
+/// Every role carries it so authenticated, checksummed, and unprotected
+/// inputs stay distinguishable end to end. The distinction that matters
+/// end-to-end is authenticated source data versus merely checksummed or
+/// unprotected observations; a consumer making a safety claim must require
+/// the level the claim needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceIntegrity {
+    /// Cryptographically authenticated end-to-end source data.
+    Authenticated,
+    /// Checksummed (CRC-style) but unauthenticated transport.
+    ChecksummedOnly,
+    /// No integrity protection beyond the transport's own boundaries
+    /// (a local shared-memory mapping relies on host process isolation).
+    Unprotected,
+}

--- a/crates/pilotage-ingress/src/stamp.rs
+++ b/crates/pilotage-ingress/src/stamp.rs
@@ -1,0 +1,41 @@
+//! Identity and acquisition stamp for one measurement group.
+
+use crate::source::{MeasurementClock, SourceIncarnation, SourceIntegrity, SourceRole};
+
+/// Identity and acquisition stamp for one independently advancing
+/// measurement group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeasurementStamp {
+    /// Explicit source role; consumers gate on this, never on id ranges.
+    pub role: SourceRole,
+    /// Integrity classification of the delivering path.
+    pub integrity: SourceIntegrity,
+    /// Source identifier, stable within one vehicle and one role. Ids may
+    /// collide across roles; the role disambiguates.
+    pub source_id: u64,
+    /// Opaque attachment/boot identity for the producing source.
+    pub source_incarnation: SourceIncarnation,
+    /// Source boot/attachment generation. A reset changes this value.
+    pub source_epoch: u32,
+    /// Wrapping group sequence, advanced only for a new measurement.
+    pub sequence: u32,
+    /// Acquisition time in nanoseconds in [`Self::clock`].
+    pub acquired_at_ns: u64,
+    /// Clock domain for [`Self::acquired_at_ns`].
+    pub clock: MeasurementClock,
+}
+
+impl MeasurementStamp {
+    /// Whether two stamps describe the same source attachment.
+    ///
+    /// Identity is the triple of role, id, and incarnation. Epoch orders
+    /// within one incarnation and is meaningless across incarnations, so an
+    /// attachment change invalidates any ordering established under the
+    /// previous one.
+    #[must_use]
+    pub fn same_attachment(&self, other: &Self) -> bool {
+        self.source_id == other.source_id
+            && self.role == other.role
+            && self.source_incarnation == other.source_incarnation
+    }
+}


### PR DESCRIPTION
Closes #253. First of a sequence toward multi-source instrument feeding; the
later steps (#252 feeder crate, #254 composite adapter, #256 extensible groups)
build on this one.

## Why

ADR-0018 defines when a measurement group may replace display state. Two things
were in the way of applying those rules anywhere but the browser:

1. The identity vocabulary lived in `pilotage-adapter-api`, which depends on
   `pilotage-protocol` and `pilotage-timing`. The feeder that must apply the
   rules has to stay a leaf (ADR-0017's constraint on the instrument family).
2. The rules themselves existed only in `clients/web/telemetry-ingress.js`.

ADR-0026's host-absent `embedded` posture makes this concrete: a tablet talking
straight to a panel has no wire, but it still has source identity — the panel
boots, reconnects, and can be swapped. Identity expressed only in protobuf terms
is unavailable exactly where there is no protobuf.

## What changed

`MeasurementClock`, `SourceIncarnation`, `SourceRole`, `SourceIntegrity`, and
`MeasurementStamp` move to the new `pilotage-ingress` crate — `no_std`,
allocation-free, zero dependencies — and `pilotage-adapter-api` re-exports them,
so every existing `use pilotage_adapter_api::…` path is unchanged. This is a
move, not a copy; there is one definition.

`SourceGate` states the admission rules once:

- wrap-safe serial ordering (RFC 1982) for both epoch and sequence, so a counter
  that wraps does not make the next value look ancient;
- incarnation compared for equality only, with authorization delegated to a
  caller-supplied predicate — an aircraft profile pins a source-issued
  incarnation, a simulator profile may accept a bounded number of unseen ones,
  and that policy difference is the caller's, not the gate's;
- duplicates, reordering, acquisition-time regressions, and unexplained clock
  domain changes refused with a typed reason;
- a refusal is counted and never refreshes state age — a stale value keeping its
  true age is honest, one refreshed by a rejected frame is not;
- acceptance reports `identity_changed`, so a caller clears the other groups
  rather than letting one display generation mix values across a source reset.

## Verification

14 unit tests covering each rule, including both wrap boundaries, epoch ordering
being meaningless across incarnations, and role disambiguating colliding ids.

Gates run locally, all green: `cargo fmt --all --check`, `cargo clippy
--all-targets -- -D warnings`, `cargo test --all-targets`, `cargo doc --no-deps`
with `-D missing_docs -D rustdoc::broken_intra_doc_links`,
`scripts/check-structure.sh`, `scripts/check-instrument-requirements.sh`, and
`cargo check -p pilotage-ingress --target thumbv7em-none-eabihf`. The crate is
added to the existing no_std CI gate so the claim cannot rot.

## Not in this PR

The gate is not yet wired into any ingress path — `telemetry-ingress.js` still
owns the live rules. Replacing it is #252, which needs these types to exist
first. Doing both at once would mix a mechanical extraction with a behavioural
port in one review.