### PR TITLE
Fold source trust into the nav display group

### DIFF
--- a/crates/pilotage-instrument-state/src/resolve.rs
+++ b/crates/pilotage-instrument-state/src/resolve.rs
@@ -265,7 +265,7 @@ pub fn resolve_stateful(
         track_rad: finite(track),
         baro_hpa: finite(baro),
         wind,
-        nav: nav_resolved(state, policy, &integrity, rose),
+        nav: nav_resolved(state, policy, &integrity, rose, trust),
         selections: sanitized_selections(state.selections),
         integrity,
         presentation,
@@ -390,11 +390,17 @@ fn nav_resolved(
     policy: &FreshnessPolicy,
     integrity: &StateIntegrity,
     rose: crate::heading::HeadingReference,
+    trust: Trust,
 ) -> NavResolved {
     let nav_fresh = policy.status_for_age(state.nav.age_ms);
     match state.nav.data {
         Some(data) => {
-            let status = nav_fresh.worst(fault_status(integrity.nav));
+            // Nav folds source trust like every other group: a source that
+            // declares itself Unusable, or a snapshot whose groups cannot be
+            // paired, must not draw a confident CDI. `ValidFlags` has no nav
+            // bit, so the declared-valid input is neutral here; giving nav its
+            // own bit is a wire and ABI change tracked separately.
+            let status = trust.fold(true, nav_fresh, integrity.nav, true);
             // Guidance from an unidentifiable source must not draw a
             // CDI at all; failing the group removes it.
             let data = if matches!(data.source, NavSource::Unknown) {

--- a/crates/pilotage-instrument-state/src/resolve/tests.rs
+++ b/crates/pilotage-instrument-state/src/resolve/tests.rs
@@ -286,6 +286,64 @@ fn unknown_nav_source_fails_the_group_and_clears_guidance() {
     assert_eq!(p.nav.data.cdi_dots, 0.0, "guidance values cleared");
 }
 
+#[test]
+fn an_unusable_source_cannot_draw_a_confident_cdi() {
+    let mut s = flying_state();
+    s.nav = Stamped {
+        data: Some(pilotage_state_navdata_valid()),
+        age_ms: Some(10.0),
+    };
+    s.quality = EstimateQuality::Unusable;
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_ne!(
+        p.nav.status,
+        SignalStatus::Valid,
+        "a source declaring itself unusable must degrade the nav display"
+    );
+    assert!(
+        !p.nav.status.shows_value(),
+        "an unusable CDI must not be read"
+    );
+}
+
+#[test]
+fn an_incoherent_snapshot_degrades_the_nav_group() {
+    let mut s = flying_state();
+    s.nav = Stamped {
+        data: Some(pilotage_state_navdata_valid()),
+        age_ms: Some(10.0),
+    };
+    s.snapshot.coherence = crate::aircraft::SnapshotCoherence::ExcessiveSkew;
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.nav.status, SignalStatus::Degraded);
+}
+
+#[test]
+fn a_trusted_fresh_source_still_resolves_valid() {
+    // The folding must not degrade the ordinary path.
+    let mut s = flying_state();
+    s.nav = Stamped {
+        data: Some(pilotage_state_navdata_valid()),
+        age_ms: Some(10.0),
+    };
+    s.quality = EstimateQuality::Good;
+    s.snapshot.coherence = crate::aircraft::SnapshotCoherence::Coherent;
+    let p = resolve(&s, &FreshnessPolicy::default());
+    assert_eq!(p.nav.status, SignalStatus::Valid);
+}
+
+fn pilotage_state_navdata_valid() -> crate::aircraft::NavData {
+    crate::aircraft::NavData {
+        source: crate::aircraft::NavSource::Gps,
+        course_rad: 1.0,
+        cdi_dots: 1.5,
+        fromto: crate::aircraft::NavFromTo::To,
+        vdev_dots: None,
+        dist_nm: None,
+        course_reference: crate::heading::HeadingReference::SimLocalTrue,
+    }
+}
+
 fn pilotage_state_navdata_unknown() -> crate::aircraft::NavData {
     crate::aircraft::NavData {
         source: crate::aircraft::NavSource::Unknown,


### PR DESCRIPTION
Closes #247.

## The gap

`nav_resolved` (`crates/pilotage-instrument-state/src/resolve.rs`) computed its
status as freshness worst-of integrity fault. Every other group folds `Trust`,
which also carries `EstimateQuality` and `SnapshotCoherence`. So a source
declaring itself `Unusable`, or a snapshot whose groups could not be paired,
still drew a confident CDI.

The live path could not reach it — the ADR-0031 feeder (`clients/web/nav-display.js`)
refuses to build the group at all when the wire `solution_quality` is unusable —
but the gap was latent for any future nav feeder. It matters more now than when
it was filed: multi-source feeding (#252, #254) is exactly the case where a
source's own declaration of distrust has to reach the display rather than being
filtered by one particular feeder remembering to do it.

## What changed

`nav_resolved` takes `Trust` and folds it like the other groups.

`ValidFlags` has no nav bit, so the declared-valid input is neutral (`true`).
Giving nav its own bit is a wire and ABI change — the second half of #247's
"also worth deciding" — and is deliberately not attempted here; it belongs with
the extensible group contract (#256).

## Why the pinned frame hashes did not move

REN-03 pins SHA-256 hashes of the rendered PFD and HSI, and the code says a
mismatch is a determinism regression rather than a value to re-pin casually. It
was the main risk in this change, so it is worth stating why it is absent:
`demo_state()` carries `EstimateQuality::Good` and `SnapshotMeta::default()`,
whose `SnapshotCoherence::Insufficient` maps to `SignalStatus::Valid`. Folding
`Valid.worst(Valid)` into an already-`Valid` status is a no-op, so the rendered
frames are byte-identical and both pinned hashes still match.

## Verification

Three tests pin both directions: an `Unusable` source no longer resolves `Valid`
and its CDI does not show a value; an `ExcessiveSkew` snapshot degrades the
group; and a trusted, fresh, coherent source still resolves `Valid`, so the fold
cannot quietly degrade the ordinary path.

Gates run locally, all green: `cargo fmt --all --check`, `cargo clippy
--all-targets -- -D warnings`, `cargo test --all-targets` (including the REN-03
frame hashes and the reference rasterizer suite), and
`node clients/web/nav-display.test.mjs`.

## Merge order

Independent of #257; either may land first.