### PR TITLE
Evidence: re-anchor the LINK-04 baselines to the merged commit

### DIFF
--- a/docs/link/evidence-artifacts/link04/capture-rt.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-rt.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture (receiver round trip)
 command: cargo test -p loopback-probe receiver::
-config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
+config-digest: c680b63a02e947283f30f7ed8c15ce727a41c717
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
+run-id: local:c680b63a02e947283f30f7ed8c15ce727a41c717
 outcome: pass
 summary:
 test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture-sink.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture-sink.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture sink round trip
 command: cargo test -p loopback-probe capture::
-config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
+config-digest: c680b63a02e947283f30f7ed8c15ce727a41c717
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
+run-id: local:c680b63a02e947283f30f7ed8c15ce727a41c717
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 56 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/capture.run.txt
+++ b/docs/link/evidence-artifacts/link04/capture.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: loopback-probe capture projection
 command: cargo test -p loopback-probe telemetry::
-config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
+config-digest: c680b63a02e947283f30f7ed8c15ce727a41c717
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
+run-id: local:c680b63a02e947283f30f7ed8c15ce727a41c717
 outcome: pass
 summary:
 test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/host-wire.run.txt
+++ b/docs/link/evidence-artifacts/link04/host-wire.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: host wire-mapping
 command: cargo test -p pilotage-session-host --lib engine_actor::telemetry
-config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
+config-digest: c680b63a02e947283f30f7ed8c15ce727a41c717
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
+run-id: local:c680b63a02e947283f30f7ed8c15ce727a41c717
 outcome: pass
 summary:
 test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 102 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link05/authz-regime.run.txt
+++ b/docs/link/evidence-artifacts/link05/authz-regime.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: browser avionics-ingress authorization regime
 command: node clients/web/telemetry-ingress.test.mjs
-config-digest: e1590407163cd20442a78c37cebcb9d121e0ba83
+config-digest: c680b63a02e947283f30f7ed8c15ce727a41c717
 tool-version: node v26.5.0
-run-id: local:e1590407163cd20442a78c37cebcb9d121e0ba83
+run-id: local:c680b63a02e947283f30f7ed8c15ce727a41c717
 outcome: pass
 summary:
   33 browser ingress checks passed; LINK-AUTHZ-005 cases:

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -195,45 +195,45 @@ attr outcome pass
 node RESULT-LINK-WIRE verification-result
 title host wire-mapping suite — recorded pass
 attr command cargo test -p pilotage-session-host --lib engine_actor::telemetry
-attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
+attr config-digest c680b63a02e947283f30f7ed8c15ce727a41c717
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:f8de90fe18e5ed843e14f8819c039f6b1a01240a
 attr artifact docs/link/evidence-artifacts/link04/host-wire.run.txt
-attr output-digest sha256:ccd75759791331c24955a90dca2602a016dbb8df04d6110336d39e25db3700e1
-attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
+attr output-digest sha256:ac977008fe5b0a44eaec967cf8d9ffb950d4e9e0297805bf95fa00dbc84cf675
+attr run-id local:c680b63a02e947283f30f7ed8c15ce727a41c717
 attr outcome pass
 
 node RESULT-LINK-CAPTURE verification-result
 title loopback-probe capture projection suite — recorded pass
 attr command cargo test -p loopback-probe telemetry::
-attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
+attr config-digest c680b63a02e947283f30f7ed8c15ce727a41c717
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:5e51d88198b070b2f19e1fe168a1644a9060a574
 attr artifact docs/link/evidence-artifacts/link04/capture.run.txt
-attr output-digest sha256:55a109d3ec0ec250f65412bea91472c4c3fba210ed7e5744f1cc1d2898d00ebd
-attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
+attr output-digest sha256:38f530a1e08703443727fbb2ccbbddc2301043f18212d031db3cd59cf4999211
+attr run-id local:c680b63a02e947283f30f7ed8c15ce727a41c717
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-RT verification-result
 title loopback-probe receiver round-trip suite — recorded pass
 attr command cargo test -p loopback-probe receiver::
-attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
+attr config-digest c680b63a02e947283f30f7ed8c15ce727a41c717
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:2e27b07a8d496d35161273285223db8e56c0904f
 attr artifact docs/link/evidence-artifacts/link04/capture-rt.run.txt
-attr output-digest sha256:1c6a5f8b789a6ed2033f4f75e858c974b2a7e14d3a07bb4854f7a9516a7a5f53
-attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
+attr output-digest sha256:a2a8da4a4837372be6adbb4f6d17415fb4156689a5ec8069b987842e295bc96b
+attr run-id local:c680b63a02e947283f30f7ed8c15ce727a41c717
 attr outcome pass
 
 node RESULT-LINK-CAPTURE-SINK verification-result
 title loopback-probe capture sink suite — recorded pass
 attr command cargo test -p loopback-probe capture::
-attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
+attr config-digest c680b63a02e947283f30f7ed8c15ce727a41c717
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:08a2aa127c1c55b63da7730fbd8e264481c66a93
 attr artifact docs/link/evidence-artifacts/link04/capture-sink.run.txt
-attr output-digest sha256:287ebc97e371b7da50674d2a7c53c2973a7ff099e1865ac74a9145a975a29b5e
-attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
+attr output-digest sha256:bbe8adda87cca7788d76c1354e4e47c2672f4c0bf02098289aa4eac8ea6387de
+attr run-id local:c680b63a02e947283f30f7ed8c15ce727a41c717
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -241,12 +241,12 @@ attr outcome pass
 node RESULT-LINK-AUTHZ verification-result
 title browser authorization-regime suite — recorded pass
 attr command node clients/web/telemetry-ingress.test.mjs
-attr config-digest e1590407163cd20442a78c37cebcb9d121e0ba83
+attr config-digest c680b63a02e947283f30f7ed8c15ce727a41c717
 attr tool-version node v26.5.0
 attr source-digest git-blob:84b54f0bdae56a7baf99bda938113e10a2f6d435
 attr artifact docs/link/evidence-artifacts/link05/authz-regime.run.txt
-attr output-digest sha256:dc188d5c25dbafad856d593564eb0885af3d95a41b4fa5e867c8fe907fca4518
-attr run-id local:e1590407163cd20442a78c37cebcb9d121e0ba83
+attr output-digest sha256:d65c6957f085306a1036c09928a6e7a59be37acbaee27a2bf79c8c8893f87784
+attr run-id local:c680b63a02e947283f30f7ed8c15ce727a41c717
 attr outcome pass
 
 node CFG-LINK-EXTRACTION configuration-item
@@ -258,20 +258,20 @@ attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)
 attr scm git
-attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
-attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
+attr commit c680b63a02e947283f30f7ed8c15ce727a41c717
+attr tree 49c412a2fcdfb609c4ef4efd35b3ac58792139a6
 
 node CFG-LINK-PROBE-V3 configuration-item
 title committed code baseline for the multiplexed-video receiver result
 attr scm git
-attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
-attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
+attr commit c680b63a02e947283f30f7ed8c15ce727a41c717
+attr tree 49c412a2fcdfb609c4ef4efd35b3ac58792139a6
 
 node CFG-LINK-AUTHZ configuration-item
 title committed code baseline for the client authorization-regime result (LINK-05 lands after LINK-04, on its own commit)
 attr scm git
-attr commit e1590407163cd20442a78c37cebcb9d121e0ba83
-attr tree 36c1cdcd1c2e96aa65a562186f80a4259b1b5ebc
+attr commit c680b63a02e947283f30f7ed8c15ce727a41c717
+attr tree 49c412a2fcdfb609c4ef4efd35b3ac58792139a6
 
 node TOOL-LINK-CARGO tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
## The break

#250 was squash-merged. The squash replaces the lane commits with a single new one, so `e159040` — the baseline every LINK-04 result named — no longer exists in merged history. All five results now fail the hard `--require-resolvable` gate with "baseline is not reachable from HEAD", and **`main`'s own evidence-trace-gate is red**. #251 and #258 inherit the failure because they branch from main.

## The fix

Re-anchor `CFG-LINK-WORKTREE`, `CFG-LINK-PROBE-V3`, `CFG-LINK-AUTHZ` and their five results to `c680b63` — the merged commit that actually carries these sources.

This is the graph's own MERGE/REBASE RULE applied to the case it names: a `config-digest` must name a commit reachable from merged history, not a lane commit that a rebase or squash will rewrite.

## Why this one holds

The previous baseline was rewritten twice before this: once when #257 merged and GitButler rebased the lane, and again by #250's squash. Anchoring on a commit that is already in `main` is what ends that cycle — `c680b63` cannot be rewritten.

## Verification

All five bound test sources are byte-identical at `c680b63`, so no `source-digest` moves. Each suite was re-run there and reproduces its recorded pass exactly:

| suite | result |
|---|---|
| `node clients/web/telemetry-ingress.test.mjs` | 33 checks |
| `cargo test -p loopback-probe telemetry::` | 4 passed |
| `cargo test -p loopback-probe receiver::` | 9 passed |
| `cargo test -p loopback-probe capture::` | 1 passed |
| `cargo test -p pilotage-session-host --lib engine_actor::telemetry` | 6 passed |

Only the provenance headers and their `output-digest`s change. Gate verified locally against `main` in an isolated worktree: exit 0, sole remaining finding is the tolerated `review-incomplete REVIEW-LINK04`.

## Merge note

Squash or merge-commit are both safe for *this* PR — it anchors to a commit that is already on main, so no future rewrite can orphan it.