### PR TITLE
Safety-fixed vs themable: the unskinnable set becomes structural (#263)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "pilotage-alerts",
  "pilotage-instrument-scene",
  "pilotage-instrument-state",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/pilotage-instrument-panels/src/hsi.rs
+++ b/crates/pilotage-instrument-panels/src/hsi.rs
@@ -6,7 +6,7 @@ use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWri
 use pilotage_instrument_state::HeadingReference;
 use pilotage_instrument_state::{NavSource, PanelData, SignalStatus};
 
-use pilotage_instrument_symbology::{annunciation, palette, source_label, status_paint};
+use pilotage_instrument_symbology::{annunciation, palette, safety, source_label, status_paint};
 
 use crate::{PANEL_H, PANEL_W};
 
@@ -76,7 +76,7 @@ pub fn draw_hsi(
     }
     if hdg.status.shows_value() {
         scene.fill_color(match data.heading.reference {
-            HeadingReference::SimLocalTrue => palette::AMBER,
+            HeadingReference::SimLocalTrue => safety::CAUTION_AMBER,
             _ => palette::WHITE,
         })?;
         scene.text(

--- a/crates/pilotage-instrument-panels/src/hsi/boxes.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/boxes.rs
@@ -6,7 +6,7 @@ use pilotage_instrument_scene::{Anchor, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::units::{MPS_TO_KT, RAD_TO_DEG, wrap_deg_360};
 use pilotage_instrument_state::{NavSource, PanelData};
 
-use pilotage_instrument_symbology::{fmt_label, palette};
+use pilotage_instrument_symbology::{fmt_label, palette, safety};
 
 use super::cdi::source_color;
 
@@ -94,7 +94,7 @@ pub fn heading_sel_box(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<
     scene.stroke(palette::GREY, 1.5)?;
     scene.rect(PaintMode::FillStroke, 366.0, 322.0, 112.0, 36.0)?;
     if !data.heading_bug_rose_rad.status.shows_value() {
-        scene.fill_color(palette::AMBER)?;
+        scene.fill_color(safety::CAUTION_AMBER)?;
         scene.text(422.0, 340.0, 15.0, Anchor::CENTER, "HDG REF")?;
         return Ok(());
     }

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -6,7 +6,7 @@ use pilotage_alerts::AlertOutput;
 use pilotage_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::{ChevronSense, PanelData, SignalStatus};
 
-use pilotage_instrument_symbology::{annunciation, palette, source_label, status_paint};
+use pilotage_instrument_symbology::{annunciation, palette, safety, source_label, status_paint};
 
 use crate::{PANEL_H, PANEL_W};
 
@@ -156,7 +156,7 @@ fn draw_recovery_chevrons(
     scene.save()?;
     scene.translate(240.0, 180.0)?;
     scene.rotate(-roll_rad)?;
-    scene.stroke(palette::RED, 6.0)?;
+    scene.stroke(safety::FAILURE_RED, 6.0)?;
     let toward: f32 = match sense {
         ChevronSense::HorizonBelow => 1.0,
         ChevronSense::HorizonAbove => -1.0,

--- a/crates/pilotage-instrument-panels/src/pfd/horizon.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/horizon.rs
@@ -9,7 +9,7 @@ use libm::{cosf, sinf};
 use pilotage_instrument_scene::{Anchor, PaintMode, SceneError, SceneWriter};
 use pilotage_instrument_state::units::RAD_TO_DEG;
 
-use pilotage_instrument_symbology::{fmt_label, palette};
+use pilotage_instrument_symbology::{fmt_label, palette, safety};
 
 const PX_PER_DEG_PITCH: f32 = 7.2;
 const ROLL_ARC_R: f32 = 144.0;
@@ -179,7 +179,7 @@ pub fn draw_roll_scale(scene: &mut SceneWriter<'_>, roll_rad: f32) -> Result<(),
 pub fn draw_aircraft_symbol(scene: &mut SceneWriter<'_>) -> Result<(), SceneError> {
     scene.save()?;
     scene.translate(240.0, 180.0)?;
-    scene.fill_color(palette::YELLOW)?;
+    scene.fill_color(safety::REFERENCE_YELLOW)?;
     scene.stroke(palette::BLACK, 1.0)?;
     scene.polygon(
         PaintMode::FillStroke,

--- a/crates/pilotage-instrument-panels/src/pfd/tapes.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/tapes.rs
@@ -10,7 +10,7 @@ use pilotage_instrument_scene::{
 use pilotage_instrument_state::AltitudeClass;
 use pilotage_instrument_state::{PanelData, Sig};
 
-use pilotage_instrument_symbology::{fmt_label, palette, status_paint};
+use pilotage_instrument_symbology::{fmt_label, palette, safety, status_paint};
 
 use super::VSpeeds;
 
@@ -77,8 +77,8 @@ pub fn speed_tape(
 fn speed_bands(scene: &mut SceneWriter<'_>, ias: f32, v: &VSpeeds) -> Result<(), SceneError> {
     let segs: [(f32, f32, Rgba8); 3] = [
         (v.vs_kt, v.vno_kt, palette::BAND_GREEN),
-        (v.vno_kt, v.vne_kt, palette::BAND_YELLOW),
-        (v.vne_kt, v.vne_kt + 1000.0, palette::RED),
+        (v.vno_kt, v.vne_kt, safety::BAND_CAUTION),
+        (v.vne_kt, v.vne_kt + 1000.0, safety::FAILURE_RED),
     ];
     for (lo, hi, color) in segs {
         band_rect(scene, ias, lo, hi, 86.0, 4.0, color)?;
@@ -165,7 +165,7 @@ fn pointed_readout(
     scene.fill_color(if sig.status.shows_value() {
         palette::WHITE
     } else {
-        palette::RED
+        safety::FAILURE_RED
     })?;
     let shown = if sig.status.shows_value() {
         text
@@ -262,8 +262,8 @@ pub fn altitude_tape(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<()
 fn reference_label(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(), SceneError> {
     let class = data.altitude.class;
     scene.fill_color(match class {
-        AltitudeClass::LocalRelative => palette::AMBER,
-        AltitudeClass::Unknown => palette::RED,
+        AltitudeClass::LocalRelative => safety::CAUTION_AMBER,
+        AltitudeClass::Unknown => safety::FAILURE_RED,
         _ => palette::WHITE,
     })?;
     scene.text(442.0, 222.0, 12.0, Anchor::CENTER, class.label())?;
@@ -309,7 +309,7 @@ fn baro_and_sel_boxes(scene: &mut SceneWriter<'_>, data: &PanelData) -> Result<(
         (false, Some(_)) => {
             // A selection in an incompatible reference never renders as
             // a plausible number; the amber marker says why it is gone.
-            scene.fill_color(palette::AMBER)?;
+            scene.fill_color(safety::CAUTION_AMBER)?;
             scene.text(435.0, 12.0, 14.0, Anchor::CENTER, "SEL REF")?;
         }
         (_, None) => {}

--- a/crates/pilotage-instrument-symbology/Cargo.toml
+++ b/crates/pilotage-instrument-symbology/Cargo.toml
@@ -12,3 +12,4 @@ workspace = true
 pilotage-alerts = { workspace = true }
 pilotage-instrument-scene = { workspace = true }
 pilotage-instrument-state = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-instrument-symbology/src/annunciation.rs
+++ b/crates/pilotage-instrument-symbology/src/annunciation.rs
@@ -15,7 +15,7 @@ use pilotage_alerts::{
 };
 use pilotage_instrument_scene::{Anchor, Rgba8, SceneError, SceneWriter};
 
-use crate::palette;
+use crate::safety;
 
 const STACK_X: f32 = 100.0;
 const STACK_BASE_Y: f32 = 352.0;
@@ -24,11 +24,15 @@ const ROW_STEP: f32 = 16.0;
 /// stack can never crowd primary symbology.
 const STACK_ROWS: usize = 3;
 
+// Alert-class colors are alert semantics (ADR-0029 never-skinnable), so
+// they come from the safety set and no theme path reaches them.
 fn class_color(class: AlertClass) -> Rgba8 {
     match class {
-        AlertClass::Warning => palette::RED,
-        AlertClass::Caution => palette::AMBER,
-        AlertClass::Advisory | AlertClass::Status | AlertClass::Maintenance => palette::WHITE,
+        AlertClass::Warning => safety::FAILURE_RED,
+        AlertClass::Caution => safety::CAUTION_AMBER,
+        AlertClass::Advisory | AlertClass::Status | AlertClass::Maintenance => {
+            safety::ANNUNCIATION_WHITE
+        }
     }
 }
 
@@ -96,7 +100,7 @@ pub fn draw_alert_stack(
     alerts: &AlertOutput,
 ) -> Result<(), SceneError> {
     if alerts.health() == ManagerHealth::Faulted {
-        scene.fill_color(palette::AMBER)?;
+        scene.fill_color(safety::CAUTION_AMBER)?;
         scene.text(
             STACK_X,
             STACK_BASE_Y - 4.0 * ROW_STEP,
@@ -126,7 +130,7 @@ pub fn draw_alert_stack(
         row = row.wrapping_add(1);
     }
     if truncated {
-        scene.fill_color(palette::AMBER)?;
+        scene.fill_color(safety::CAUTION_AMBER)?;
         scene.text(
             STACK_X,
             STACK_BASE_Y - (row as f32) * ROW_STEP,

--- a/crates/pilotage-instrument-symbology/src/lib.rs
+++ b/crates/pilotage-instrument-symbology/src/lib.rs
@@ -19,5 +19,7 @@
 pub mod annunciation;
 pub mod fixed_str;
 pub mod palette;
+pub mod safety;
 pub mod source_label;
 pub mod status_paint;
+pub mod theme;

--- a/crates/pilotage-instrument-symbology/src/palette.rs
+++ b/crates/pilotage-instrument-symbology/src/palette.rs
@@ -3,8 +3,17 @@
 //! Magenta marks GPS/derived guidance; green marks radio-nav; cyan marks
 //! pilot selections (bugs); white is primary data; amber flags degraded
 //! or stale signals; red marks failure and limits.
+//!
+//! `RED`, `AMBER`, `YELLOW`, and `BAND_YELLOW` are the [`crate::safety`]
+//! set under their conventional names. `WHITE` stays an independent
+//! constant because it is dual-role — the themable primary default and
+//! the advisory-row color — which is also why white is exempt from the
+//! theme imitation rule. The remaining constants are the default values
+//! of the themable set ([`crate::theme::Theme`]).
 
 use pilotage_instrument_scene::Rgba8;
+
+use crate::safety;
 
 /// Sky half of the attitude ball.
 pub const SKY: Rgba8 = Rgba8::rgb(0, 110, 210);
@@ -37,16 +46,16 @@ pub const GREEN: Rgba8 = Rgba8::rgb(0, 255, 0);
 pub const CYAN: Rgba8 = Rgba8::rgb(0, 255, 255);
 
 /// The fixed aircraft reference symbol and caution band.
-pub const YELLOW: Rgba8 = Rgba8::rgb(255, 255, 0);
+pub const YELLOW: Rgba8 = safety::REFERENCE_YELLOW;
 
 /// Degraded/stale signal flags.
-pub const AMBER: Rgba8 = Rgba8::rgb(255, 176, 0);
+pub const AMBER: Rgba8 = safety::CAUTION_AMBER;
 
 /// Failure flags and the never-exceed band.
-pub const RED: Rgba8 = Rgba8::rgb(255, 0, 0);
+pub const RED: Rgba8 = safety::FAILURE_RED;
 
 /// Normal-range band on the speed tape.
 pub const BAND_GREEN: Rgba8 = Rgba8::rgb(0, 160, 0);
 
 /// Caution-range band on the speed tape.
-pub const BAND_YELLOW: Rgba8 = Rgba8::rgb(230, 200, 0);
+pub const BAND_YELLOW: Rgba8 = safety::BAND_CAUTION;

--- a/crates/pilotage-instrument-symbology/src/safety.rs
+++ b/crates/pilotage-instrument-symbology/src/safety.rs
@@ -1,0 +1,30 @@
+//! The never-skinnable colors (ADR-0029): failure, caution, alert-class,
+//! and limit semantics.
+//!
+//! These constants are reachable from no configuration path — [`Theme`]
+//! has no field that can express or override them, and
+//! [`crate::theme::ValidTheme`] additionally rejects any themable color
+//! close enough to imitate one. A theme is therefore *unable* to change
+//! what `Missing`, `Stale`, `Degraded`, or `Failed` paints, rather than
+//! being asked not to.
+//!
+//! [`Theme`]: crate::theme::Theme
+
+use pilotage_instrument_scene::Rgba8;
+
+/// Failure flags, the red X, dashes behind hidden values, and the
+/// never-exceed band.
+pub const FAILURE_RED: Rgba8 = Rgba8::rgb(255, 0, 0);
+
+/// Degraded/stale flags, caution alert rows, and reversion/miscompare
+/// source labels.
+pub const CAUTION_AMBER: Rgba8 = Rgba8::rgb(255, 176, 0);
+
+/// Advisory and lower alert rows in the annunciation stack.
+pub const ANNUNCIATION_WHITE: Rgba8 = Rgba8::rgb(255, 255, 255);
+
+/// The fixed aircraft reference symbol and the caution band edge color.
+pub const REFERENCE_YELLOW: Rgba8 = Rgba8::rgb(255, 255, 0);
+
+/// Caution-range band on the speed tape.
+pub const BAND_CAUTION: Rgba8 = Rgba8::rgb(230, 200, 0);

--- a/crates/pilotage-instrument-symbology/src/source_label.rs
+++ b/crates/pilotage-instrument-symbology/src/source_label.rs
@@ -11,6 +11,7 @@ use pilotage_instrument_state::{ComparisonState, SourcedFunction};
 
 use crate::fmt_label;
 use crate::palette;
+use crate::safety;
 
 /// Draws the selected source id under a function prefix (e.g. `IAS2`), amber
 /// on a reversion or a sustained miscompare, with a `{prefix} CMP` cue on a
@@ -28,7 +29,7 @@ pub fn draw_source_label<T: Copy>(
     };
     let miscompare = selection.state == ComparisonState::Miscompare;
     let color = if miscompare || selection.reverted {
-        palette::AMBER
+        safety::CAUTION_AMBER
     } else {
         palette::GREEN
     };

--- a/crates/pilotage-instrument-symbology/src/status_paint.rs
+++ b/crates/pilotage-instrument-symbology/src/status_paint.rs
@@ -4,13 +4,16 @@ use pilotage_instrument_scene::{Anchor, PaintMode, Rgba8, SceneError, SceneWrite
 use pilotage_instrument_state::SignalStatus;
 
 use crate::palette;
+use crate::safety;
 
 /// The accent color a status imposes on its readout, `None` for normal.
+/// Status colors are flag semantics (ADR-0029 never-skinnable), so they
+/// come from the safety set and no theme path reaches them.
 pub fn status_accent(status: SignalStatus) -> Option<Rgba8> {
     match status {
         SignalStatus::Valid => None,
-        SignalStatus::Degraded | SignalStatus::Stale => Some(palette::AMBER),
-        SignalStatus::Missing | SignalStatus::Failed => Some(palette::RED),
+        SignalStatus::Degraded | SignalStatus::Stale => Some(safety::CAUTION_AMBER),
+        SignalStatus::Missing | SignalStatus::Failed => Some(safety::FAILURE_RED),
     }
 }
 
@@ -24,10 +27,10 @@ pub fn draw_red_x(
     h: f32,
     label: &str,
 ) -> Result<(), SceneError> {
-    scene.stroke(palette::RED, 4.0)?;
+    scene.stroke(safety::FAILURE_RED, 4.0)?;
     scene.line(x, y, x + w, y + h)?;
     scene.line(x + w, y, x, y + h)?;
-    scene.fill_color(palette::RED)?;
+    scene.fill_color(safety::FAILURE_RED)?;
     scene.text(x + w / 2.0, y + h / 2.0, 20.0, Anchor::CENTER, label)?;
     Ok(())
 }
@@ -39,7 +42,7 @@ pub fn draw_flag(
     y: f32,
     label: &str,
 ) -> Result<(), SceneError> {
-    scene.fill_color(palette::AMBER)?;
+    scene.fill_color(safety::CAUTION_AMBER)?;
     scene.text(x, y, 11.0, Anchor::CENTER, label)?;
     Ok(())
 }
@@ -66,7 +69,7 @@ pub fn readout_box(
         scene.fill_color(text_color)?;
         scene.text(x + w / 2.0, y + h / 2.0, size, Anchor::CENTER, text)?;
     } else {
-        scene.fill_color(palette::RED)?;
+        scene.fill_color(safety::FAILURE_RED)?;
         scene.text(x + w / 2.0, y + h / 2.0, size, Anchor::CENTER, "---")?;
     }
     Ok(())

--- a/crates/pilotage-instrument-symbology/src/theme.rs
+++ b/crates/pilotage-instrument-symbology/src/theme.rs
@@ -1,0 +1,315 @@
+//! The themable half of the palette, as validated data (ADR-0029).
+//!
+//! A shell supplies a [`Theme`]; only a [`ValidTheme`] can reach drawing
+//! code. The never-skinnable half does not depend on that boundary:
+//! safety colors are separate constants in [`crate::safety`], and a
+//! structure gate keeps their palette aliases inside this crate, whether
+//! or not a shell supplies a theme. Validation enforces what "themable"
+//! is allowed to mean:
+//!
+//! - **Imitation**: no themable color may sit within
+//!   [`SAFETY_DISTANCE_MIN`] (max-channel RGB distance) of any warning
+//!   hue — the four colored safety constants and the whole
+//!   red-through-yellow segment between them — so a theme cannot
+//!   manufacture or camouflage failure and caution colors.
+//!   [`crate::safety::ANNUNCIATION_WHITE`] is exempt by design: primary
+//!   symbology is legitimately white, and advisory rows signal by stack
+//!   position, not hue.
+//! - **Contrast**: primary symbology must keep at least
+//!   [`CONTRAST_LUMA_MIN`] of luma against every ground it draws over —
+//!   the panel, the readout boxes, both halves of the horizon, and the
+//!   tape background composited over each horizon half at its declared
+//!   alpha. Separately, the colored annunciation hues must keep
+//!   [`SAFETY_CONTRAST_LUMA_MIN`] of luma against the panel and box
+//!   grounds they paint over, so a theme cannot bury a failure flag in
+//!   an equiluminant ground (the red-on-green deficiency case).
+//! - **Opacity**: every themable color paints at full alpha except the
+//!   tape background, which keeps at least [`TAPE_ALPHA_MIN`] so tapes
+//!   stay legible over any horizon — no theme can fade symbology
+//!   toward invisibility.
+//! - **Source identity**: GPS and radio-nav guidance colors must stay
+//!   [`SAFETY_DISTANCE_MIN`] apart — source class survives theming.
+//!
+//! The thresholds are an explicit assurance decision, not an emergent
+//! property of the defaults.
+
+use pilotage_instrument_scene::Rgba8;
+
+use crate::safety;
+
+/// Minimum max-channel RGB distance from every safety color, and
+/// between the two guidance-source colors.
+pub const SAFETY_DISTANCE_MIN: u8 = 64;
+
+/// Minimum luma difference between primary symbology and each ground.
+pub const CONTRAST_LUMA_MIN: u8 = 96;
+
+/// Minimum luma difference between each colored annunciation hue and
+/// the panel/box grounds it paints over. Sits below
+/// [`CONTRAST_LUMA_MIN`] deliberately: failure red holds only 76 luma
+/// against the shipped black, so this floor defends against a theme
+/// burying safety paint in an equiluminant ground, not against ordinary
+/// low contrast.
+pub const SAFETY_CONTRAST_LUMA_MIN: u8 = 64;
+
+/// Minimum alpha of the semi-transparent tape background.
+pub const TAPE_ALPHA_MIN: u8 = 96;
+
+/// The shell-suppliable colors. Everything failure/caution/alert-class
+/// shaped is deliberately absent — see [`crate::safety`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Theme {
+    /// Sky half of the attitude ball.
+    pub sky: Rgba8,
+    /// Ground half of the attitude ball.
+    pub ground: Rgba8,
+    /// Primary symbology and scale marks.
+    pub primary: Rgba8,
+    /// Panel background.
+    pub panel_bg: Rgba8,
+    /// Semi-transparent tape/box background over the horizon.
+    pub tape_bg: Rgba8,
+    /// Solid readout-box background.
+    pub box_bg: Rgba8,
+    /// Box outlines and secondary marks.
+    pub outline: Rgba8,
+    /// GPS guidance, trends, and rate cues.
+    pub gps: Rgba8,
+    /// Radio-nav (VLOC) guidance.
+    pub radio_nav: Rgba8,
+    /// Pilot selections: bugs, selected values, baro.
+    pub selection: Rgba8,
+    /// Normal-range band on the speed tape.
+    pub band_normal: Rgba8,
+}
+
+impl Theme {
+    /// The shipped look — exactly the [`crate::palette`] constants, so
+    /// adopting the theme path repaints nothing.
+    pub const DEFAULT: Theme = Theme {
+        sky: Rgba8::rgb(0, 110, 210),
+        ground: Rgba8::rgb(140, 96, 44),
+        primary: Rgba8::rgb(255, 255, 255),
+        panel_bg: Rgba8::rgb(0, 0, 0),
+        tape_bg: Rgba8::rgba(20, 20, 20, 150),
+        box_bg: Rgba8::rgb(0, 0, 0),
+        outline: Rgba8::rgb(128, 128, 128),
+        gps: Rgba8::rgb(255, 0, 255),
+        radio_nav: Rgba8::rgb(0, 255, 0),
+        selection: Rgba8::rgb(0, 255, 255),
+        band_normal: Rgba8::rgb(0, 160, 0),
+    };
+
+    const fn all(&self) -> [(&'static str, Rgba8); 11] {
+        // Exhaustive destructuring: a new field fails to compile until
+        // it joins the validated list.
+        let Theme {
+            sky,
+            ground,
+            primary,
+            panel_bg,
+            tape_bg,
+            box_bg,
+            outline,
+            gps,
+            radio_nav,
+            selection,
+            band_normal,
+        } = *self;
+        [
+            ("sky", sky),
+            ("ground", ground),
+            ("primary", primary),
+            ("panel_bg", panel_bg),
+            ("tape_bg", tape_bg),
+            ("box_bg", box_bg),
+            ("outline", outline),
+            ("gps", gps),
+            ("radio_nav", radio_nav),
+            ("selection", selection),
+            ("band_normal", band_normal),
+        ]
+    }
+}
+
+/// Why a [`Theme`] was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ThemeError {
+    /// A themable color sits close enough to a safety hue to imitate
+    /// or camouflage it.
+    #[error("theme color {field} imitates the {near} safety hue")]
+    ImitatesSafetyColor {
+        /// The offending theme field.
+        field: &'static str,
+        /// The safety hue it approaches.
+        near: &'static str,
+    },
+    /// Primary symbology lacks contrast against a ground it draws over.
+    #[error("primary symbology holds {delta} luma against {ground}, floor {CONTRAST_LUMA_MIN}")]
+    InsufficientContrast {
+        /// The ground the primary color fails against.
+        ground: &'static str,
+        /// The measured luma difference.
+        delta: u8,
+    },
+    /// A color is more transparent than its floor allows.
+    #[error("{field} alpha {alpha} below its floor {floor}")]
+    AlphaBelowFloor {
+        /// The offending theme field.
+        field: &'static str,
+        /// The measured alpha.
+        alpha: u8,
+        /// The floor it missed.
+        floor: u8,
+    },
+    /// A colored annunciation hue would be buried against a ground it
+    /// paints over.
+    #[error(
+        "safety hue {hue} holds {delta} luma against {ground}, floor {SAFETY_CONTRAST_LUMA_MIN}"
+    )]
+    SafetyContrastBuried {
+        /// The safety hue at risk.
+        hue: &'static str,
+        /// The themable ground that would bury it.
+        ground: &'static str,
+        /// The measured luma difference.
+        delta: u8,
+    },
+    /// GPS and radio-nav guidance colors are not distinguishable.
+    #[error("gps and radio_nav colors are not distinguishable")]
+    IndistinctSourceColors,
+}
+
+/// The largest per-channel RGB difference (alpha excluded).
+fn max_channel_distance(a: Rgba8, b: Rgba8) -> u8 {
+    let dr = a.r.abs_diff(b.r);
+    let dg = a.g.abs_diff(b.g);
+    let db = a.b.abs_diff(b.b);
+    dr.max(dg).max(db)
+}
+
+/// Distance from the red-through-yellow hue segment `(255, g, 0)` for
+/// `g` in `0..=255`, which passes through every warning hue between
+/// [`safety::FAILURE_RED`] and [`safety::REFERENCE_YELLOW`] — including
+/// [`safety::CAUTION_AMBER`]. Checking the segment closes the corridor
+/// per-color distances leave open between neighbouring safety hues.
+fn distance_to_warning_segment(c: Rgba8) -> u8 {
+    c.r.abs_diff(255).max(c.b)
+}
+
+/// The four safety hues a themable color must keep its distance from.
+/// [`safety::ANNUNCIATION_WHITE`] is deliberately absent: primary
+/// symbology is legitimately white, and white advisory rows carry their
+/// meaning by position in the stack, not by hue.
+const SAFETY_HUES: [(&str, Rgba8); 4] = [
+    ("failure red", safety::FAILURE_RED),
+    ("caution amber", safety::CAUTION_AMBER),
+    ("reference yellow", safety::REFERENCE_YELLOW),
+    ("caution band", safety::BAND_CAUTION),
+];
+
+/// Integer Rec.601 luma, 0..=255.
+fn luma(c: Rgba8) -> u8 {
+    let weighted = 299u32 * u32::from(c.r) + 587 * u32::from(c.g) + 114 * u32::from(c.b);
+    (weighted / 1000) as u8
+}
+
+/// `top` alpha-composited over an opaque `bottom` — the color the eye
+/// actually meets where a translucent ground overlays the horizon.
+fn composite(top: Rgba8, bottom: Rgba8) -> Rgba8 {
+    let a = u32::from(top.a);
+    let mix = |t: u8, b: u8| ((u32::from(t) * a + u32::from(b) * (255 - a)) / 255) as u8;
+    Rgba8::rgb(
+        mix(top.r, bottom.r),
+        mix(top.g, bottom.g),
+        mix(top.b, bottom.b),
+    )
+}
+
+/// A theme that passed validation; the only theme drawing code accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValidTheme(Theme);
+
+impl ValidTheme {
+    /// The shipped look, pre-validated.
+    pub const DEFAULT: ValidTheme = ValidTheme(Theme::DEFAULT);
+
+    /// Validates `theme` against the rules in the module doc.
+    pub fn validate(theme: Theme) -> Result<ValidTheme, ThemeError> {
+        for (field, color) in theme.all() {
+            for (near, hue) in SAFETY_HUES {
+                if max_channel_distance(color, hue) < SAFETY_DISTANCE_MIN {
+                    return Err(ThemeError::ImitatesSafetyColor { field, near });
+                }
+            }
+            if distance_to_warning_segment(color) < SAFETY_DISTANCE_MIN {
+                return Err(ThemeError::ImitatesSafetyColor {
+                    field,
+                    near: "red-through-yellow segment",
+                });
+            }
+            // Only the tape ground is legitimately translucent; every
+            // other themable color paints at full opacity, so a theme
+            // cannot fade symbology toward invisibility.
+            let floor = if field == "tape_bg" {
+                TAPE_ALPHA_MIN
+            } else {
+                255
+            };
+            if color.a < floor {
+                return Err(ThemeError::AlphaBelowFloor {
+                    field,
+                    alpha: color.a,
+                    floor,
+                });
+            }
+        }
+        // Primary symbology draws over the panel, the readout boxes,
+        // both halves of the horizon, and the tapes; the tape ground is
+        // measured as the eye meets it — composited at its declared
+        // alpha over each horizon half — so a legal alpha cannot launder
+        // a bright horizon past an RGB-only check.
+        for (ground, color) in [
+            ("panel_bg", theme.panel_bg),
+            ("box_bg", theme.box_bg),
+            ("sky", theme.sky),
+            ("ground", theme.ground),
+            ("tape_bg over sky", composite(theme.tape_bg, theme.sky)),
+            (
+                "tape_bg over ground",
+                composite(theme.tape_bg, theme.ground),
+            ),
+        ] {
+            let delta = luma(theme.primary).abs_diff(luma(color));
+            if delta < CONTRAST_LUMA_MIN {
+                return Err(ThemeError::InsufficientContrast { ground, delta });
+            }
+        }
+        // The colored annunciation hues are unskinnable, but a theme
+        // could still bury them in an equiluminant ground; hold them
+        // apart from the grounds failure flags and dashes paint over.
+        for (hue, color) in [
+            ("failure red", safety::FAILURE_RED),
+            ("caution amber", safety::CAUTION_AMBER),
+        ] {
+            for (ground, ground_color) in [("panel_bg", theme.panel_bg), ("box_bg", theme.box_bg)] {
+                let delta = luma(color).abs_diff(luma(ground_color));
+                if delta < SAFETY_CONTRAST_LUMA_MIN {
+                    return Err(ThemeError::SafetyContrastBuried { hue, ground, delta });
+                }
+            }
+        }
+        if max_channel_distance(theme.gps, theme.radio_nav) < SAFETY_DISTANCE_MIN {
+            return Err(ThemeError::IndistinctSourceColors);
+        }
+        Ok(ValidTheme(theme))
+    }
+
+    /// The validated colors.
+    pub const fn get(&self) -> &Theme {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-symbology/src/theme/tests.rs
+++ b/crates/pilotage-instrument-symbology/src/theme/tests.rs
@@ -1,0 +1,306 @@
+//! Theme validation: the shipped look passes, hostile themes are
+//! refused, and the themable set stays equal to the palette defaults so
+//! adopting the theme path repaints nothing.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{TAPE_ALPHA_MIN, Theme, ThemeError, ValidTheme};
+use crate::{palette, safety};
+use pilotage_instrument_scene::Rgba8;
+
+#[test]
+fn the_default_theme_validates() {
+    ValidTheme::validate(Theme::DEFAULT).expect("shipped look must pass its own rules");
+    assert_eq!(*ValidTheme::DEFAULT.get(), Theme::DEFAULT);
+}
+
+#[test]
+fn the_default_theme_is_the_palette() {
+    let theme = Theme::DEFAULT;
+    assert_eq!(theme.sky, palette::SKY);
+    assert_eq!(theme.ground, palette::GROUND);
+    assert_eq!(theme.primary, palette::WHITE);
+    assert_eq!(theme.panel_bg, palette::BLACK);
+    assert_eq!(theme.tape_bg, palette::TAPE_BG);
+    assert_eq!(theme.box_bg, palette::BOX_BG);
+    assert_eq!(theme.outline, palette::GREY);
+    assert_eq!(theme.gps, palette::MAGENTA);
+    assert_eq!(theme.radio_nav, palette::GREEN);
+    assert_eq!(theme.selection, palette::CYAN);
+    assert_eq!(theme.band_normal, palette::BAND_GREEN);
+}
+
+#[test]
+fn the_palette_safety_constants_are_the_safety_module() {
+    assert_eq!(palette::RED, safety::FAILURE_RED);
+    assert_eq!(palette::AMBER, safety::CAUTION_AMBER);
+    assert_eq!(palette::YELLOW, safety::REFERENCE_YELLOW);
+    assert_eq!(palette::BAND_YELLOW, safety::BAND_CAUTION);
+    assert_eq!(palette::WHITE, safety::ANNUNCIATION_WHITE);
+}
+
+#[test]
+fn a_red_sky_is_rejected_as_imitation() {
+    let hostile = Theme {
+        sky: Rgba8::rgb(250, 4, 4),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::ImitatesSafetyColor {
+            field: "sky",
+            near: "failure red",
+        })
+    );
+}
+
+#[test]
+fn an_amber_selection_is_rejected_as_imitation() {
+    let hostile = Theme {
+        selection: Rgba8::rgb(240, 180, 30),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::ImitatesSafetyColor {
+            field: "selection",
+            near: "caution amber",
+        })
+    );
+}
+
+#[test]
+fn the_exact_reference_yellow_is_rejected_as_imitation() {
+    // A selection painted exactly the fixed aircraft-reference hue
+    // would make pilot bugs indistinguishable from the reference
+    // symbol.
+    let hostile = Theme {
+        selection: safety::REFERENCE_YELLOW,
+        ..Theme::DEFAULT
+    };
+    assert!(matches!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::ImitatesSafetyColor {
+            field: "selection",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn the_red_to_yellow_corridor_is_closed() {
+    // A saturated warning orange sits 88 from both FAILURE_RED and
+    // CAUTION_AMBER — past the per-color floor — but ON the warning
+    // hue segment, and must still be refused.
+    let hostile = Theme {
+        gps: Rgba8::rgb(255, 88, 0),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::ImitatesSafetyColor {
+            field: "gps",
+            near: "red-through-yellow segment",
+        })
+    );
+}
+
+#[test]
+fn low_contrast_primary_is_rejected_against_each_ground() {
+    let murky = Theme {
+        primary: Rgba8::rgb(60, 60, 60),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(murky),
+        Err(ThemeError::InsufficientContrast {
+            ground: "panel_bg",
+            delta: 60,
+        })
+    );
+    // The box ground is checked in its own right, not shadowed by the
+    // panel ground.
+    let grey_boxes = Theme {
+        box_bg: Rgba8::rgb(200, 200, 200),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(grey_boxes),
+        Err(ThemeError::InsufficientContrast {
+            ground: "box_bg",
+            delta: 55,
+        })
+    );
+    // And the tape ground: white digits sit directly on it. The tape is
+    // measured composited over the horizon, so an opaque wash fails
+    // against the sky half first.
+    let washed_tapes = Theme {
+        tape_bg: Rgba8::rgba(250, 250, 250, 255),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(washed_tapes),
+        Err(ThemeError::InsufficientContrast {
+            ground: "tape_bg over sky",
+            delta: 5,
+        })
+    );
+}
+
+#[test]
+fn a_bright_sky_is_rejected_for_primary_contrast() {
+    // The horizon halves are grounds primary draws over (pitch ladder,
+    // roll pointer, horizon line); a near-white sky would erase them.
+    let hostile = Theme {
+        sky: Rgba8::rgb(250, 250, 250),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::InsufficientContrast {
+            ground: "sky",
+            delta: 5,
+        })
+    );
+}
+
+#[test]
+fn a_translucent_tape_over_a_legal_sky_is_measured_composited() {
+    // Sky at luma 150 passes the plain check, and the tape's alpha 96
+    // is at its floor — but the composite the eye meets is too bright
+    // for white digits. An RGB-only check would wave this through.
+    let hostile = Theme {
+        sky: Rgba8::rgb(150, 150, 150),
+        tape_bg: Rgba8::rgba(200, 200, 200, 96),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::InsufficientContrast {
+            ground: "tape_bg over sky",
+            delta: 87,
+        })
+    );
+}
+
+#[test]
+fn a_ground_equiluminant_with_failure_red_is_rejected() {
+    // luma(0,130,0) == luma(FAILURE_RED): the "value not trustworthy"
+    // dashes would have zero luminance contrast against their own box,
+    // in the exact red-on-green pairing color deficiency cannot separate.
+    let hostile = Theme {
+        box_bg: Rgba8::rgb(0, 130, 0),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::SafetyContrastBuried {
+            hue: "failure red",
+            ground: "box_bg",
+            delta: 0,
+        })
+    );
+}
+
+#[test]
+fn a_panel_that_buries_caution_amber_is_rejected() {
+    let hostile = Theme {
+        panel_bg: Rgba8::rgb(100, 180, 100),
+        ..Theme::DEFAULT
+    };
+    assert!(matches!(
+        ValidTheme::validate(hostile),
+        Err(ThemeError::SafetyContrastBuried {
+            hue: "caution amber",
+            ground: "panel_bg",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn every_colored_safety_constant_is_screened_or_exempt() {
+    // SAFETY_HUES is a hand-maintained list; this keeps it honest
+    // against the safety module. A new safety constant must join the
+    // imitation screen or the documented white exemption.
+    let screened = super::SAFETY_HUES;
+    let exempt = [safety::ANNUNCIATION_WHITE];
+    for (name, color) in [
+        ("FAILURE_RED", safety::FAILURE_RED),
+        ("CAUTION_AMBER", safety::CAUTION_AMBER),
+        ("REFERENCE_YELLOW", safety::REFERENCE_YELLOW),
+        ("BAND_CAUTION", safety::BAND_CAUTION),
+        ("ANNUNCIATION_WHITE", safety::ANNUNCIATION_WHITE),
+    ] {
+        assert!(
+            screened.iter().any(|(_, hue)| *hue == color) || exempt.contains(&color),
+            "{name} escapes the imitation screen"
+        );
+    }
+}
+
+#[test]
+fn transparent_colors_are_rejected_everywhere() {
+    // Fully transparent primary symbology passes an RGB-only contrast
+    // check while rendering invisible; the alpha floor refuses it.
+    let ghost_primary = Theme {
+        primary: Rgba8::rgba(255, 255, 255, 0),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(ghost_primary),
+        Err(ThemeError::AlphaBelowFloor {
+            field: "primary",
+            alpha: 0,
+            floor: 255,
+        })
+    );
+    let seethrough_panel = Theme {
+        panel_bg: Rgba8::rgba(0, 0, 0, 200),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(seethrough_panel),
+        Err(ThemeError::AlphaBelowFloor {
+            field: "panel_bg",
+            alpha: 200,
+            floor: 255,
+        })
+    );
+    let seethrough_box = Theme {
+        box_bg: Rgba8::rgba(0, 0, 0, 200),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(seethrough_box),
+        Err(ThemeError::AlphaBelowFloor {
+            field: "box_bg",
+            alpha: 200,
+            floor: 255,
+        })
+    );
+    let ghost_tape = Theme {
+        tape_bg: Rgba8::rgba(20, 20, 20, 40),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(ghost_tape),
+        Err(ThemeError::AlphaBelowFloor {
+            field: "tape_bg",
+            alpha: 40,
+            floor: TAPE_ALPHA_MIN,
+        })
+    );
+}
+
+#[test]
+fn indistinct_source_colors_are_rejected() {
+    let monosource = Theme {
+        radio_nav: Rgba8::rgb(255, 40, 255),
+        ..Theme::DEFAULT
+    };
+    assert_eq!(
+        ValidTheme::validate(monosource),
+        Err(ThemeError::IndistinctSourceColors)
+    );
+}

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -176,10 +176,45 @@ check_calibration_id_uniqueness() {
     done <<< "$unexpected"
 }
 
+# The palette names RED, AMBER, YELLOW, and BAND_YELLOW alias the
+# never-skinnable safety set (ADR-0029). Outside the symbology crate,
+# safety-semantic paints must reference `safety::` directly so a future
+# palette-to-theme sweep cannot silently make failure, caution, or
+# reference colors skinnable.
+# Text-level ratchet, not a proof: it catches direct `palette::RED`
+# uses and `use ...::palette::RED` imports, but a module alias
+# (`use ... as p; p::RED`) slips through, like the AWK heuristics above.
+check_safety_palette_aliases() {
+    local file
+    while IFS= read -r file; do
+        is_excluded_path "$file" && continue
+        case "$file" in
+            ./crates/pilotage-instrument-symbology/*) continue ;;
+        esac
+        if grep -Eq 'palette::(RED|AMBER|YELLOW|BAND_YELLOW)\b' "$file"; then
+            echo "FORBIDDEN: $file references a safety palette alias; use the safety:: constants outside pilotage-instrument-symbology" >&2
+            status=1
+        fi
+    done < <(collect_rs_files)
+}
+
+# The theme imitation screen (SAFETY_HUES) and its exemption list are
+# hand-maintained; a new safety constant must visit them deliberately.
+check_safety_constant_count() {
+    local expected=5 actual
+    actual=$(grep -c '^pub const' ./crates/pilotage-instrument-symbology/src/safety.rs)
+    if [ "$actual" -ne "$expected" ]; then
+        echo "FORBIDDEN: safety.rs public constant count moved ($actual, pinned $expected); add the new constant to theme.rs SAFETY_HUES or its documented exemption, then update this pin" >&2
+        status=1
+    fi
+}
+
 check_forbidden_filenames
 check_file_length
 check_function_length
 check_calibration_id_uniqueness
+check_safety_palette_aliases
+check_safety_constant_count
 
 if [ "$status" -ne 0 ]; then
     echo "check-structure: FAILED" >&2


### PR DESCRIPTION
Safety-fixed vs themable: the unskinnable set becomes structural (#263)

Splits the symbology palette into a safety set (safety.rs — FAILURE_RED, CAUTION_AMBER, ANNUNCIATION_WHITE, REFERENCE_YELLOW, BAND_CAUTION; reachable from no configuration path) and a themable set supplied as validated data (theme.rs: Theme + ValidTheme + ThemeError with measured-value context). Rules: imitation distance >= 64 from all four warning hues AND the red-through-yellow segment between them (white exempt by documented design); luma contrast >= 96 for primary against panel, box, and tape grounds; full alpha everywhere except the tape ground with its own floor; distinguishable GPS/radio-nav pair. Theme::all() destructures exhaustively so a new field cannot escape validation. Every safety-semantic paint references the safety set directly — in the symbology crate and across the panels — and a structure-gate grep forbids the palette safety aliases outside symbology. Values are identical throughout, so scene bytes and the pinned frame hashes are unchanged. Hostile-theme tests drive every rule arm to rejection.

Stacked on luofang34/Pilotage#270. Refs luofang34/Pilotage#263 luofang34/Indicate#36 (AIR-FLAG-001..007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)