### PR TITLE
Panel registry: descriptors as composed data, config as bounded TLV (#264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           -p pilotage-instrument-panels
           -p pilotage-instrument-raster
           -p pilotage-instrument-feeder
+          -p pilotage-instrument-registry
           --target thumbv7em-none-eabihf
 
       - name: target timing gate (REN-04)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "pilotage-alerts",
  "pilotage-frames",
  "pilotage-instrument-glyphs",
+ "pilotage-instrument-registry",
  "pilotage-instrument-scene",
  "pilotage-instrument-state",
  "pilotage-instrument-symbology",
@@ -1569,6 +1570,16 @@ dependencies = [
  "pilotage-instrument-scene",
  "pilotage-instrument-state",
  "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
+name = "pilotage-instrument-registry"
+version = "0.1.0"
+dependencies = [
+ "pilotage-alerts",
+ "pilotage-instrument-scene",
+ "pilotage-instrument-state",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/pilotage-instrument-panels",
     "crates/pilotage-instrument-raster",
     "crates/pilotage-instrument-feeder",
+    "crates/pilotage-instrument-registry",
     "crates/pilotage-evidence",
     "crates/pilotage-mission",
     "adapters/reference-headless",
@@ -99,6 +100,7 @@ pilotage-instrument-symbology = { path = "crates/pilotage-instrument-symbology" 
 pilotage-instrument-panels = { path = "crates/pilotage-instrument-panels" }
 pilotage-instrument-raster = { path = "crates/pilotage-instrument-raster" }
 pilotage-instrument-feeder = { path = "crates/pilotage-instrument-feeder" }
+pilotage-instrument-registry = { path = "crates/pilotage-instrument-registry" }
 pilotage-adapter-reference = { path = "adapters/reference-headless" }
 pilotage-adapter-gazebo = { path = "adapters/gazebo" }
 pilotage-adapter-aviate = { path = "adapters/aviate" }

--- a/clients/web-instruments/src/exports.rs
+++ b/clients/web-instruments/src/exports.rs
@@ -9,7 +9,7 @@ use pilotage_alerts::{
     DynFault, ManagerHealth, NavFault,
 };
 use pilotage_instrument_panels::{PfdConfig, VSpeeds, draw_hsi, draw_pfd};
-use pilotage_instrument_scene::{LayerError, LayerId, SceneError, SceneWriter, validate_layers};
+use pilotage_instrument_scene::{LayerError, SceneError, SceneWriter, validate_layers};
 use pilotage_instrument_state::FreshnessPolicy;
 use pilotage_instrument_state::abi::v6::{self, AbiError};
 use pilotage_instrument_state::{NavSource, SignalStatus};
@@ -23,16 +23,10 @@ const PANEL_PFD: u32 = 0;
 const PANEL_HSI: u32 = 1;
 const PANEL_COUNT: usize = 2;
 
-const fn layer_bit(layer: LayerId) -> u8 {
-    1u8 << layer.to_u8()
-}
-
-const PFD_CRITICAL_LAYERS: u8 =
-    layer_bit(LayerId::Attitude) | layer_bit(LayerId::Tapes) | layer_bit(LayerId::Annunciation);
-const HSI_CRITICAL_LAYERS: u8 = layer_bit(LayerId::Attitude)
-    | layer_bit(LayerId::Tapes)
-    | layer_bit(LayerId::Guidance)
-    | layer_bit(LayerId::Annunciation);
+// The critical-layer masks are owned by the panel descriptors
+// (ADR-0029): this shell holds no mask of its own.
+const PFD_CRITICAL_LAYERS: u8 = pilotage_instrument_panels::PFD_DESCRIPTOR.required_layers;
+const HSI_CRITICAL_LAYERS: u8 = pilotage_instrument_panels::HSI_DESCRIPTOR.required_layers;
 
 pub(crate) struct Runtime {
     pub(crate) state: Vec<u8>,

--- a/crates/pilotage-instrument-panels/Cargo.toml
+++ b/crates/pilotage-instrument-panels/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 libm = { workspace = true }
 pilotage-alerts = { workspace = true }
+pilotage-instrument-registry = { workspace = true }
 pilotage-instrument-scene = { workspace = true }
 pilotage-instrument-state = { workspace = true }
 pilotage-instrument-symbology = { workspace = true }

--- a/crates/pilotage-instrument-panels/src/descriptors.rs
+++ b/crates/pilotage-instrument-panels/src/descriptors.rs
@@ -1,0 +1,111 @@
+//! Built-in panel descriptors: the registry entries every shell
+//! composes (ADR-0029, ADR-0033).
+//!
+//! The masks and identities that used to live as shell constants are
+//! owned here, beside the panels they describe. `group_regions` and
+//! `extreme_states` are populated when their consumers land (the
+//! admission harness and the canonical-state corpus); `raster_baseline`
+//! is populated when the pinned frame hashes travel into the
+//! descriptors.
+
+use pilotage_alerts::AlertOutput;
+use pilotage_instrument_registry::{
+    BackgroundCapability, ConfigBlob, DesignFrame, GroupSet, PanelDescriptor, PanelDrawError,
+};
+use pilotage_instrument_scene::{LayerId, SceneWriter};
+use pilotage_instrument_state::{GroupId, PanelData};
+
+use crate::pfd::PFD_CONFIG_SCHEMA;
+use crate::{PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+
+const fn layer_bit(layer: LayerId) -> u8 {
+    1u8 << layer.to_u8()
+}
+
+fn draw_pfd_panel(
+    data: &PanelData,
+    config: &ConfigBlob<'_>,
+    alerts: Option<&AlertOutput>,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    let cfg = PfdConfig::from_config(config)?;
+    draw_pfd(data, &cfg, alerts, scene)?;
+    Ok(())
+}
+
+fn draw_hsi_panel(
+    data: &PanelData,
+    config: &ConfigBlob<'_>,
+    alerts: Option<&AlertOutput>,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    // The HSI takes no configuration; the empty schema makes any keyed
+    // blob a shell-side rejection before this runs, and a re-check here
+    // keeps the property when a shell skips its gate.
+    config.require_schema(HSI_DESCRIPTOR.config_schema)?;
+    draw_hsi(data, alerts, scene)?;
+    Ok(())
+}
+
+/// The primary flight display.
+pub const PFD_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
+    id: "pfd",
+    title: "PFD",
+    required_layers: layer_bit(LayerId::Attitude)
+        | layer_bit(LayerId::Tapes)
+        | layer_bit(LayerId::Annunciation),
+    required_groups: GroupSet::of(&[
+        GroupId::Attitude,
+        GroupId::Kinematics,
+        GroupId::Air,
+        GroupId::Selections,
+        GroupId::Trust,
+        GroupId::Altitude,
+        GroupId::Dynamics,
+    ]),
+    design_frame: DesignFrame {
+        width: PANEL_W,
+        height: PANEL_H,
+    },
+    background: BackgroundCapability::Cedeable,
+    config_schema: PFD_CONFIG_SCHEMA,
+    group_regions: &[],
+    extreme_states: &[],
+    raster_baseline: None,
+    draw: draw_pfd_panel,
+};
+
+/// The horizontal situation indicator.
+pub const HSI_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
+    id: "hsi",
+    title: "HSI",
+    required_layers: layer_bit(LayerId::Attitude)
+        | layer_bit(LayerId::Tapes)
+        | layer_bit(LayerId::Guidance)
+        | layer_bit(LayerId::Annunciation),
+    required_groups: GroupSet::of(&[
+        GroupId::Kinematics,
+        GroupId::Nav,
+        GroupId::Wind,
+        GroupId::Selections,
+        GroupId::Trust,
+        GroupId::Heading,
+        GroupId::Variation,
+    ]),
+    design_frame: DesignFrame {
+        width: PANEL_W,
+        height: PANEL_H,
+    },
+    background: BackgroundCapability::Opaque,
+    config_schema: &[],
+    group_regions: &[],
+    extreme_states: &[],
+    raster_baseline: None,
+    draw: draw_hsi_panel,
+};
+
+/// The panels this crate ships, in shell display order.
+pub const BUILTIN_PANELS: &[PanelDescriptor] = &[PFD_DESCRIPTOR, HSI_DESCRIPTOR];
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-panels/src/descriptors/tests.rs
+++ b/crates/pilotage-instrument-panels/src/descriptors/tests.rs
@@ -1,0 +1,230 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::vec;
+use std::vec::Vec;
+
+use pilotage_instrument_registry::{ConfigBlob, EMPTY_CONFIG, Registry, keys};
+use pilotage_instrument_scene::SceneWriter;
+use pilotage_instrument_state::{
+    AircraftState, Attitude, FreshnessPolicy, PanelData, Quat, Stamped, resolve,
+};
+
+use super::{BUILTIN_PANELS, HSI_DESCRIPTOR, PFD_DESCRIPTOR};
+use crate::{BackgroundMode, PfdConfig, draw_hsi, draw_pfd};
+
+fn resolved() -> PanelData {
+    let state = AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: Quat {
+                    w: 1.0,
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                rates_rps: [0.0, 0.0, 0.0],
+            }),
+            age_ms: Some(50.0),
+        },
+        ..AircraftState::default()
+    };
+    resolve(&state, &FreshnessPolicy::default())
+}
+
+fn scene_via_descriptor(
+    descriptor: &pilotage_instrument_registry::PanelDescriptor,
+    config: &ConfigBlob<'_>,
+) -> Vec<u8> {
+    let data = resolved();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut writer = SceneWriter::new(&mut buf).expect("fits");
+    (descriptor.draw)(&data, config, None, &mut writer).expect("draws");
+    let used = writer.finish();
+    buf[..used].to_vec()
+}
+
+#[test]
+fn the_builtin_composition_validates() {
+    Registry::new(BUILTIN_PANELS).expect("shipped panels must compose");
+}
+
+#[test]
+fn descriptor_draws_match_the_direct_entry_points() {
+    let data = resolved();
+    let mut direct_buf = vec![0u8; 64 * 1024];
+    let mut writer = SceneWriter::new(&mut direct_buf).expect("fits");
+    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("draws");
+    let used = writer.finish();
+    assert_eq!(
+        scene_via_descriptor(&PFD_DESCRIPTOR, &EMPTY_CONFIG),
+        direct_buf[..used].to_vec(),
+        "descriptor PFD must be the same panel as draw_pfd"
+    );
+
+    let mut hsi_buf = vec![0u8; 64 * 1024];
+    let mut writer = SceneWriter::new(&mut hsi_buf).expect("fits");
+    draw_hsi(&data, None, &mut writer).expect("draws");
+    let used = writer.finish();
+    assert_eq!(
+        scene_via_descriptor(&HSI_DESCRIPTOR, &EMPTY_CONFIG),
+        hsi_buf[..used].to_vec(),
+        "descriptor HSI must be the same panel as draw_hsi"
+    );
+}
+
+#[test]
+fn svs_background_cedes_exactly_like_none() {
+    // Accept-and-cede (ADR-0033): until the SVS renderer exists, an
+    // SVS-configured PFD emits byte-identical scenes to a None
+    // background — nothing above the Background band may depend on it.
+    let data = resolved();
+    let mut scenes = Vec::new();
+    for background in [
+        BackgroundMode::None,
+        BackgroundMode::Svs {
+            viewport: crate::SvsViewport {
+                x: 0.0,
+                y: 0.0,
+                width: 480.0,
+                height: 360.0,
+            },
+            quality: 2,
+        },
+    ] {
+        let cfg = PfdConfig {
+            background,
+            v_speeds: None,
+        };
+        let mut buf = vec![0u8; 64 * 1024];
+        let mut writer = SceneWriter::new(&mut buf).expect("fits");
+        draw_pfd(&data, &cfg, None, &mut writer).expect("draws");
+        let used = writer.finish();
+        scenes.push(buf[..used].to_vec());
+    }
+    assert_eq!(scenes[0], scenes[1]);
+}
+
+#[test]
+fn an_svs_config_blob_decodes_and_still_cedes() {
+    // BACKGROUND_MODE=2 with a viewport and quality: the decoded config
+    // must carry the request, and the drawn scene must equal None's.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.push(2);
+    bytes.extend_from_slice(&keys::SVS_VIEWPORT.0.to_le_bytes());
+    bytes.extend_from_slice(&16u16.to_le_bytes());
+    for v in [0.0f32, 0.0, 480.0, 240.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    bytes.extend_from_slice(&keys::SVS_QUALITY.0.to_le_bytes());
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.push(1);
+    let blob = ConfigBlob::parse(&bytes).expect("well-formed");
+    let cfg = PfdConfig::from_config(&blob).expect("decodes");
+    assert!(matches!(
+        cfg.background,
+        BackgroundMode::Svs { quality: 1, .. }
+    ));
+
+    let via_svs = scene_via_descriptor(&PFD_DESCRIPTOR, &blob);
+    let none_bytes = {
+        let mut b = Vec::new();
+        b.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+        b.extend_from_slice(&1u16.to_le_bytes());
+        b.push(1);
+        b
+    };
+    let none_blob = ConfigBlob::parse(&none_bytes).expect("well-formed");
+    assert_eq!(via_svs, scene_via_descriptor(&PFD_DESCRIPTOR, &none_blob));
+}
+
+#[test]
+fn svs_keys_are_validated_and_refused_when_inert() {
+    use pilotage_instrument_registry::ConfigError;
+    // A malformed viewport payload is refused even when the selected
+    // background never consumes it.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(&keys::SVS_VIEWPORT.0.to_le_bytes());
+    bytes.extend_from_slice(&3u16.to_le_bytes());
+    bytes.extend_from_slice(&[1, 2, 3]);
+    let blob = ConfigBlob::parse(&bytes).expect("well-formed framing");
+    assert_eq!(
+        PfdConfig::from_config(&blob),
+        Err(ConfigError::BadValue {
+            key: keys::SVS_VIEWPORT.0,
+            len: 3,
+        })
+    );
+    // A well-formed viewport under a non-SVS background is inert, and
+    // inert is refused rather than silently dropped.
+    let mut inert = Vec::new();
+    inert.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+    inert.extend_from_slice(&1u16.to_le_bytes());
+    inert.push(0);
+    inert.extend_from_slice(&keys::SVS_VIEWPORT.0.to_le_bytes());
+    inert.extend_from_slice(&16u16.to_le_bytes());
+    for v in [0.0f32, 0.0, 480.0, 360.0] {
+        inert.extend_from_slice(&v.to_le_bytes());
+    }
+    let blob = ConfigBlob::parse(&inert).expect("well-formed framing");
+    assert_eq!(
+        PfdConfig::from_config(&blob),
+        Err(ConfigError::InertKey {
+            key: keys::SVS_VIEWPORT.0,
+        })
+    );
+    // A viewport outside the design frame is refused.
+    let mut outside = Vec::new();
+    outside.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+    outside.extend_from_slice(&1u16.to_le_bytes());
+    outside.push(2);
+    outside.extend_from_slice(&keys::SVS_VIEWPORT.0.to_le_bytes());
+    outside.extend_from_slice(&16u16.to_le_bytes());
+    for v in [-10.0f32, 0.0, 480.0, 360.0] {
+        outside.extend_from_slice(&v.to_le_bytes());
+    }
+    let blob = ConfigBlob::parse(&outside).expect("well-formed framing");
+    assert_eq!(
+        PfdConfig::from_config(&blob),
+        Err(ConfigError::BadValue {
+            key: keys::SVS_VIEWPORT.0,
+            len: 16,
+        })
+    );
+}
+
+#[test]
+fn a_collapsed_v_speed_ladder_is_refused() {
+    use pilotage_instrument_registry::ConfigError;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&keys::V_SPEEDS.0.to_le_bytes());
+    bytes.extend_from_slice(&20u16.to_le_bytes());
+    for v in [0.0f32, 0.0, 0.0, 0.0, 0.5] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    let blob = ConfigBlob::parse(&bytes).expect("well-formed framing");
+    assert_eq!(
+        PfdConfig::from_config(&blob),
+        Err(ConfigError::BadValue {
+            key: keys::V_SPEEDS.0,
+            len: 20,
+        })
+    );
+}
+
+#[test]
+fn the_hsi_rejects_any_configuration_key() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&keys::BACKGROUND_MODE.0.to_le_bytes());
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.push(0);
+    let blob = ConfigBlob::parse(&bytes).expect("well-formed");
+    let data = resolved();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut writer = SceneWriter::new(&mut buf).expect("fits");
+    assert!((HSI_DESCRIPTOR.draw)(&data, &blob, None, &mut writer).is_err());
+}

--- a/crates/pilotage-instrument-panels/src/lib.rs
+++ b/crates/pilotage-instrument-panels/src/lib.rs
@@ -19,11 +19,13 @@ extern crate std;
 
 #[cfg(test)]
 mod alert_stack_tests;
+mod descriptors;
 mod hsi;
 mod pfd;
 
+pub use descriptors::{BUILTIN_PANELS, HSI_DESCRIPTOR, PFD_DESCRIPTOR};
 pub use hsi::draw_hsi;
-pub use pfd::{BackgroundMode, PfdConfig, VSpeeds, draw_pfd};
+pub use pfd::{BackgroundMode, PFD_CONFIG_SCHEMA, PfdConfig, SvsViewport, VSpeeds, draw_pfd};
 
 /// Logical panel width all panels draw against.
 pub const PANEL_W: f32 = 480.0;

--- a/crates/pilotage-instrument-panels/src/pfd.rs
+++ b/crates/pilotage-instrument-panels/src/pfd.rs
@@ -11,7 +11,10 @@ use pilotage_instrument_symbology::{annunciation, palette, safety, source_label,
 use crate::{PANEL_H, PANEL_W};
 
 mod horizon;
+mod panel_config;
 mod tapes;
+
+pub use panel_config::PFD_CONFIG_SCHEMA;
 
 /// Airframe reference speeds (knots) driving the speed-tape color bands.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -34,13 +37,37 @@ pub struct VSpeeds {
 /// background layer at all: the safety compositor owns that band (a
 /// hypothetical SVS raster composes strictly below the critical overlay),
 /// and the layers above it are byte-identical either way.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum BackgroundMode {
     /// Flat-shaded sky-over-ground attitude ball.
     #[default]
     Horizon,
     /// No background layer; the compositor supplies that band.
     None,
+    /// Synthetic-vision imagery in the background band, accept-and-cede
+    /// (ADR-0033): the panel validates and carries the request but
+    /// emits exactly what [`BackgroundMode::None`] emits — the band is
+    /// ceded to whatever renders the imagery, and the critical overlay
+    /// above it never depends on the choice.
+    Svs {
+        /// Viewport within the design frame the imagery should fill.
+        viewport: SvsViewport,
+        /// Quality tier requested from the renderer.
+        quality: u8,
+    },
+}
+
+/// The design-frame rectangle synthetic vision should fill.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SvsViewport {
+    /// Left edge.
+    pub x: f32,
+    /// Top edge.
+    pub y: f32,
+    /// Width.
+    pub width: f32,
+    /// Height.
+    pub height: f32,
 }
 
 /// PFD panel configuration.
@@ -89,7 +116,9 @@ pub fn draw_pfd(
             }
             scene.end_layer(LayerId::Background)?;
         }
-        BackgroundMode::None => {}
+        // Svs cedes the band exactly like None until the SVS renderer
+        // exists; a guardrail test pins the equivalence.
+        BackgroundMode::None | BackgroundMode::Svs { .. } => {}
     }
 
     scene.begin_layer(LayerId::Attitude)?;

--- a/crates/pilotage-instrument-panels/src/pfd/panel_config.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/panel_config.rs
@@ -1,0 +1,155 @@
+//! PFD configuration decoding from the shell-delivered blob (ADR-0033).
+
+use pilotage_instrument_registry::{ConfigBlob, ConfigError, ConfigKey, keys};
+
+use super::{BackgroundMode, PfdConfig, SvsViewport, VSpeeds};
+use crate::{PANEL_H, PANEL_W};
+
+/// Every key the PFD understands; a shell refuses anything else before
+/// the blob reaches this decoder, and the decoder refuses it again.
+pub const PFD_CONFIG_SCHEMA: &[ConfigKey] = &[
+    keys::BACKGROUND_MODE,
+    keys::V_SPEEDS,
+    keys::SVS_VIEWPORT,
+    keys::SVS_QUALITY,
+];
+
+impl PfdConfig {
+    /// Decodes `config`; absent keys keep the shipped defaults, and an
+    /// uninterpretable value is refused whole — a config error must
+    /// never half-apply. Every present key is validated regardless of
+    /// which mode consumes it, and an SVS key set under a non-SVS
+    /// background is refused as inert: silently ignoring an option a
+    /// caller believes is set would misstate what the panel displays
+    /// (ADR-0033).
+    pub fn from_config(config: &ConfigBlob<'_>) -> Result<PfdConfig, ConfigError> {
+        config.require_schema(PFD_CONFIG_SCHEMA)?;
+        let viewport = decode_viewport(config)?;
+        let quality = decode_quality(config)?;
+        Ok(PfdConfig {
+            background: decode_background(config, viewport, quality)?,
+            v_speeds: decode_v_speeds(config)?,
+        })
+    }
+}
+
+fn decode_background(
+    config: &ConfigBlob<'_>,
+    viewport: Option<SvsViewport>,
+    quality: Option<u8>,
+) -> Result<BackgroundMode, ConfigError> {
+    let mode = config.get(keys::BACKGROUND_MODE);
+    if !matches!(mode, Some([2])) {
+        if viewport.is_some() {
+            return Err(ConfigError::InertKey {
+                key: keys::SVS_VIEWPORT.0,
+            });
+        }
+        if quality.is_some() {
+            return Err(ConfigError::InertKey {
+                key: keys::SVS_QUALITY.0,
+            });
+        }
+    }
+    match mode {
+        None | Some([0]) => Ok(BackgroundMode::Horizon),
+        Some([1]) => Ok(BackgroundMode::None),
+        Some([2]) => Ok(BackgroundMode::Svs {
+            viewport: viewport.unwrap_or(SvsViewport {
+                x: 0.0,
+                y: 0.0,
+                width: PANEL_W,
+                height: PANEL_H,
+            }),
+            quality: quality.unwrap_or(0),
+        }),
+        Some(other) => Err(ConfigError::BadValue {
+            key: keys::BACKGROUND_MODE.0,
+            len: other.len(),
+        }),
+    }
+}
+
+fn decode_viewport(config: &ConfigBlob<'_>) -> Result<Option<SvsViewport>, ConfigError> {
+    let Some(bytes) = config.get(keys::SVS_VIEWPORT) else {
+        return Ok(None);
+    };
+    let bad = || ConfigError::BadValue {
+        key: keys::SVS_VIEWPORT.0,
+        len: bytes.len(),
+    };
+    let [x, y, width, height] = decode_f32s::<4>(bytes).ok_or_else(bad)?;
+    // Within the design frame, as the descriptor field documents —
+    // imagery cannot be requested where the panel does not draw.
+    let sane = x >= 0.0
+        && y >= 0.0
+        && width > 0.0
+        && height > 0.0
+        && x + width <= PANEL_W
+        && y + height <= PANEL_H;
+    if sane {
+        Ok(Some(SvsViewport {
+            x,
+            y,
+            width,
+            height,
+        }))
+    } else {
+        Err(bad())
+    }
+}
+
+fn decode_quality(config: &ConfigBlob<'_>) -> Result<Option<u8>, ConfigError> {
+    match config.get(keys::SVS_QUALITY) {
+        None => Ok(None),
+        Some([quality]) => Ok(Some(*quality)),
+        Some(other) => Err(ConfigError::BadValue {
+            key: keys::SVS_QUALITY.0,
+            len: other.len(),
+        }),
+    }
+}
+
+fn decode_v_speeds(config: &ConfigBlob<'_>) -> Result<Option<VSpeeds>, ConfigError> {
+    let Some(bytes) = config.get(keys::V_SPEEDS) else {
+        return Ok(None);
+    };
+    let bad = || ConfigError::BadValue {
+        key: keys::V_SPEEDS.0,
+        len: bytes.len(),
+    };
+    let [vs0, vs, vfe, vno, vne] = decode_f32s::<5>(bytes).ok_or_else(bad)?;
+    let speeds = [vs0, vs, vfe, vno, vne];
+    // The tape draws bands only over a coherent ladder; a non-finite,
+    // unordered, or collapsed set (which would paint a nearly all-red
+    // tape) is refused rather than painted somewhere misleading. The
+    // band-defining speeds must be strictly ordered.
+    let sane = speeds.iter().all(|v| v.is_finite() && *v >= 0.0)
+        && vs0 <= vs
+        && vs < vfe
+        && vfe <= vno
+        && vno < vne;
+    if sane {
+        Ok(Some(VSpeeds {
+            vs0_kt: vs0,
+            vs_kt: vs,
+            vfe_kt: vfe,
+            vno_kt: vno,
+            vne_kt: vne,
+        }))
+    } else {
+        Err(bad())
+    }
+}
+
+fn decode_f32s<const N: usize>(bytes: &[u8]) -> Option<[f32; N]> {
+    if bytes.len() != N * 4 {
+        return None;
+    }
+    let mut out = [0.0f32; N];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let word: [u8; 4] = bytes.get(i * 4..i * 4 + 4)?.try_into().ok()?;
+        *slot = f32::from_le_bytes(word);
+    }
+    Some(out)
+}

--- a/crates/pilotage-instrument-registry/Cargo.toml
+++ b/crates/pilotage-instrument-registry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pilotage-instrument-registry"
+description = "Panel registry: descriptors, config blobs, and shell composition of panel plugins (ADR-0029, ADR-0033)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-alerts = { workspace = true }
+pilotage-instrument-scene = { workspace = true }
+pilotage-instrument-state = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-instrument-registry/src/config.rs
+++ b/crates/pilotage-instrument-registry/src/config.rs
@@ -1,0 +1,170 @@
+//! Panel configuration as a bounded key-TLV blob (ADR-0033).
+//!
+//! Configuration crosses the wasm/FFI boundary as one byte slice, so a
+//! new panel option never grows a per-panel binding surface. The wire is
+//! a sequence of `[key u16 LE][len u16 LE][payload]` entries in strictly
+//! ascending key order, at most [`CONFIG_BLOB_MAX`] bytes total. A shell
+//! introspects a panel's declared schema first and refuses a blob
+//! carrying any key outside it — unknown configuration is rejected, not
+//! skipped, because silently ignoring an option a caller believes is set
+//! misstates what the panel displays.
+
+/// Maximum encoded size of a configuration blob.
+pub const CONFIG_BLOB_MAX: usize = 256;
+
+/// A configuration key. Well-known assignments live in [`keys`];
+/// out-of-repo panels take keys from `0x8000` up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ConfigKey(pub u16);
+
+/// Well-known configuration keys.
+pub mod keys {
+    use super::ConfigKey;
+
+    /// PFD background selection: `[0]` horizon, `[1]` none (compositor
+    /// band), `[2]` synthetic vision (accept-and-cede until the SVS
+    /// renderer lands).
+    pub const BACKGROUND_MODE: ConfigKey = ConfigKey(0x0001);
+    /// Speed-tape bands: five `f32` LE (vs0, vs, vfe, vno, vne) knots.
+    pub const V_SPEEDS: ConfigKey = ConfigKey(0x0002);
+    /// SVS viewport within the design frame: four `f32` LE (x, y,
+    /// width, height).
+    pub const SVS_VIEWPORT: ConfigKey = ConfigKey(0x0003);
+    /// SVS quality tier: one byte.
+    pub const SVS_QUALITY: ConfigKey = ConfigKey(0x0004);
+}
+
+/// Why a configuration blob was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ConfigError {
+    /// The blob exceeds [`CONFIG_BLOB_MAX`].
+    #[error("config blob of {len} bytes exceeds the {CONFIG_BLOB_MAX}-byte bound")]
+    TooLong {
+        /// The offending encoded length.
+        len: usize,
+    },
+    /// An entry header or payload runs past the end of the blob.
+    #[error("config blob truncated inside the entry with key {key}")]
+    Truncated {
+        /// The key whose entry is cut short; `0` when truncation lands
+        /// before the key itself is readable.
+        key: u16,
+    },
+    /// Keys are not strictly ascending (order is the dedup guarantee).
+    #[error("config key {key} repeats or descends")]
+    KeysNotAscending {
+        /// The out-of-order key.
+        key: u16,
+    },
+    /// A key outside the consulted schema.
+    #[error("config key {key} is not in this panel's schema")]
+    UnknownKey {
+        /// The refused key.
+        key: u16,
+    },
+    /// A known key whose payload cannot mean anything.
+    #[error("config key {key} carries an uninterpretable {len}-byte value")]
+    BadValue {
+        /// The key with the bad payload.
+        key: u16,
+        /// The payload length delivered.
+        len: usize,
+    },
+    /// A key that is set but meaningless under another key's setting —
+    /// refused rather than silently ignored, so a caller cannot believe
+    /// an option is in effect when it is not.
+    #[error("config key {key} is set but inert under the selected mode")]
+    InertKey {
+        /// The inert key.
+        key: u16,
+    },
+}
+
+/// A validated configuration blob; construction proves the framing.
+#[derive(Debug, Clone, Copy)]
+pub struct ConfigBlob<'a> {
+    bytes: &'a [u8],
+}
+
+/// The empty configuration every panel accepts.
+pub const EMPTY_CONFIG: ConfigBlob<'static> = ConfigBlob { bytes: &[] };
+
+impl<'a> ConfigBlob<'a> {
+    /// Validates framing: bound, entry structure, strictly ascending
+    /// keys. Key *meaning* stays with the consumer ([`Self::get`]).
+    pub fn parse(bytes: &'a [u8]) -> Result<ConfigBlob<'a>, ConfigError> {
+        if bytes.len() > CONFIG_BLOB_MAX {
+            return Err(ConfigError::TooLong { len: bytes.len() });
+        }
+        let mut off = 0;
+        let mut previous: Option<u16> = None;
+        while off < bytes.len() {
+            let (key, len) = entry_header(bytes, off)?;
+            if let Some(previous) = previous
+                && key <= previous
+            {
+                return Err(ConfigError::KeysNotAscending { key });
+            }
+            previous = Some(key);
+            off += 4 + len;
+        }
+        Ok(ConfigBlob { bytes })
+    }
+
+    /// The payload of `key`, or `None` when absent.
+    pub fn get(&self, key: ConfigKey) -> Option<&'a [u8]> {
+        let mut off = 0;
+        while off < self.bytes.len() {
+            let (entry_key, len) = entry_header(self.bytes, off).ok()?;
+            if entry_key == key.0 {
+                return self.bytes.get(off + 4..off + 4 + len);
+            }
+            off += 4 + len;
+        }
+        None
+    }
+
+    /// Refuses any key outside `schema` (the shell-side gate).
+    pub fn require_schema(&self, schema: &[ConfigKey]) -> Result<(), ConfigError> {
+        let mut off = 0;
+        while off < self.bytes.len() {
+            // Construction proved the framing; a gate must still fail
+            // closed rather than stop scanning if that ever breaks.
+            let (key, len) = entry_header(self.bytes, off)?;
+            if !schema.iter().any(|k| k.0 == key) {
+                return Err(ConfigError::UnknownKey { key });
+            }
+            off += 4 + len;
+        }
+        Ok(())
+    }
+
+    /// The validated bytes.
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+}
+
+/// Reads `[key u16 LE][len u16 LE]` at `off` and bounds-checks the
+/// payload it announces.
+fn entry_header(bytes: &[u8], off: usize) -> Result<(u16, usize), ConfigError> {
+    let header: [u8; 4] = match bytes.get(off..off + 4).and_then(|h| h.try_into().ok()) {
+        Some(header) => header,
+        None => {
+            let key = bytes
+                .get(off..off + 2)
+                .and_then(|k| k.try_into().ok())
+                .map_or(0, u16::from_le_bytes);
+            return Err(ConfigError::Truncated { key });
+        }
+    };
+    let key = u16::from_le_bytes([header[0], header[1]]);
+    let len = u16::from_le_bytes([header[2], header[3]]) as usize;
+    if bytes.len() < off + 4 + len {
+        return Err(ConfigError::Truncated { key });
+    }
+    Ok((key, len))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-registry/src/config/tests.rs
+++ b/crates/pilotage-instrument-registry/src/config/tests.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{CONFIG_BLOB_MAX, ConfigBlob, ConfigError, ConfigKey, keys};
+
+fn entry(key: u16, payload: &[u8]) -> std::vec::Vec<u8> {
+    let mut bytes = std::vec::Vec::new();
+    bytes.extend_from_slice(&key.to_le_bytes());
+    bytes.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+#[test]
+fn an_empty_blob_parses_and_yields_nothing() {
+    let blob = ConfigBlob::parse(&[]).expect("empty is the default config");
+    assert_eq!(blob.get(keys::BACKGROUND_MODE), None);
+    assert_eq!(blob.require_schema(&[]), Ok(()));
+}
+
+#[test]
+fn entries_are_retrievable_by_key() {
+    let mut bytes = entry(keys::BACKGROUND_MODE.0, &[1]);
+    bytes.extend_from_slice(&entry(keys::V_SPEEDS.0, &[0; 20]));
+    let blob = ConfigBlob::parse(&bytes).expect("two well-formed entries");
+    assert_eq!(blob.get(keys::BACKGROUND_MODE), Some(&[1u8][..]));
+    assert_eq!(blob.get(keys::V_SPEEDS).map(<[u8]>::len), Some(20));
+    assert_eq!(blob.get(keys::SVS_QUALITY), None);
+}
+
+#[test]
+fn an_oversize_blob_is_refused() {
+    let bytes = [0u8; CONFIG_BLOB_MAX + 1];
+    assert_eq!(
+        ConfigBlob::parse(&bytes).map(|_| ()),
+        Err(ConfigError::TooLong {
+            len: CONFIG_BLOB_MAX + 1
+        })
+    );
+}
+
+#[test]
+fn truncation_is_refused_wherever_it_falls() {
+    // Inside an entry header.
+    assert_eq!(
+        ConfigBlob::parse(&[0x01, 0x00, 0x05]).map(|_| ()),
+        Err(ConfigError::Truncated { key: 1 })
+    );
+    // Payload runs past the end.
+    let mut bytes = entry(keys::BACKGROUND_MODE.0, &[1]);
+    bytes.pop();
+    assert_eq!(
+        ConfigBlob::parse(&bytes).map(|_| ()),
+        Err(ConfigError::Truncated {
+            key: keys::BACKGROUND_MODE.0
+        })
+    );
+}
+
+#[test]
+fn descending_or_repeated_keys_are_refused() {
+    let mut descending = entry(keys::V_SPEEDS.0, &[0; 20]);
+    descending.extend_from_slice(&entry(keys::BACKGROUND_MODE.0, &[0]));
+    assert_eq!(
+        ConfigBlob::parse(&descending).map(|_| ()),
+        Err(ConfigError::KeysNotAscending {
+            key: keys::BACKGROUND_MODE.0
+        })
+    );
+    let mut repeated = entry(keys::BACKGROUND_MODE.0, &[0]);
+    repeated.extend_from_slice(&entry(keys::BACKGROUND_MODE.0, &[1]));
+    assert_eq!(
+        ConfigBlob::parse(&repeated).map(|_| ()),
+        Err(ConfigError::KeysNotAscending {
+            key: keys::BACKGROUND_MODE.0
+        })
+    );
+}
+
+#[test]
+fn a_key_outside_the_schema_is_rejected_not_skipped() {
+    let bytes = entry(0x8000, &[7]);
+    let blob = ConfigBlob::parse(&bytes).expect("well-formed foreign entry");
+    assert_eq!(
+        blob.require_schema(&[keys::BACKGROUND_MODE, keys::V_SPEEDS]),
+        Err(ConfigError::UnknownKey { key: 0x8000 })
+    );
+    assert_eq!(blob.require_schema(&[ConfigKey(0x8000)]), Ok(()));
+}

--- a/crates/pilotage-instrument-registry/src/descriptor.rs
+++ b/crates/pilotage-instrument-registry/src/descriptor.rs
@@ -1,0 +1,117 @@
+//! The panel descriptor: everything a shell needs to wire one panel.
+
+use pilotage_alerts::AlertOutput;
+use pilotage_instrument_scene::{SceneError, SceneWriter};
+use pilotage_instrument_state::{AircraftState, GroupId, PanelData};
+
+use crate::config::{ConfigBlob, ConfigError, ConfigKey};
+use crate::group_set::GroupSet;
+
+/// A panel's draw entry point: pure resolved-state → scene, with its
+/// configuration delivered as the validated blob the shell accepted.
+pub type DrawFn = fn(
+    &PanelData,
+    &ConfigBlob<'_>,
+    Option<&AlertOutput>,
+    &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError>;
+
+/// Why a panel draw failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelDrawError {
+    /// The scene writer refused a command. The typed reason rides
+    /// along; [`SceneError`] carries no `Display` of its own.
+    #[error("scene writer refused a command")]
+    Scene(SceneError),
+    /// The configuration blob does not decode for this panel.
+    #[error("config error: {0}")]
+    Config(#[from] ConfigError),
+}
+
+impl From<SceneError> for PanelDrawError {
+    fn from(error: SceneError) -> Self {
+        PanelDrawError::Scene(error)
+    }
+}
+
+/// What the panel does with the `Background` scene band.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundCapability {
+    /// Never draws the band (a compositor may still not use it).
+    NotUsed,
+    /// Owns the band with opaque content of its own.
+    Opaque,
+    /// Draws the band by default but cedes it on request — the panel
+    /// stays complete when the band is supplied elsewhere (SVS, video).
+    Cedeable,
+}
+
+/// The logical space a panel draws against; backends scale, panels
+/// never see viewport pixels.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DesignFrame {
+    /// Logical width.
+    pub width: f32,
+    /// Logical height.
+    pub height: f32,
+}
+
+/// An axis-aligned rectangle in design-frame units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Region {
+    /// Left edge.
+    pub x: f32,
+    /// Top edge.
+    pub y: f32,
+    /// Width.
+    pub width: f32,
+    /// Height.
+    pub height: f32,
+}
+
+/// A panel-contributed extreme state for conformance and digest runs:
+/// the panel names the situations that stress it beyond the shared
+/// canonical set.
+#[derive(Debug, Clone, Copy)]
+pub struct ExtremeState {
+    /// Stable identity of the fixture (lowercase, digits, dashes).
+    pub id: &'static str,
+    /// Builds the state; a plain fn keeps descriptors `static`.
+    pub build: fn() -> AircraftState,
+}
+
+/// One panel, as data. A shell composes descriptors into a
+/// [`crate::Registry`] and consumes only this — no shell may hold a
+/// panel list, index, or layer mask of its own (ADR-0029).
+#[derive(Debug, Clone, Copy)]
+pub struct PanelDescriptor {
+    /// Stable identity (lowercase, digits, dashes): canvas ids, health
+    /// keys, and evidence records key off this.
+    pub id: &'static str,
+    /// Operator-facing title.
+    pub title: &'static str,
+    /// Scene layers that must be present and complete in every frame,
+    /// as a bitset over [`pilotage_instrument_scene::LayerId`].
+    pub required_layers: u8,
+    /// State groups this panel consumes — the withholding matrix the
+    /// admission harness drives honest-status checks from.
+    pub required_groups: GroupSet,
+    /// The logical space this panel draws against.
+    pub design_frame: DesignFrame,
+    /// What the panel does with the `Background` band.
+    pub background: BackgroundCapability,
+    /// Configuration keys this panel understands; a shell refuses a
+    /// blob carrying any other key.
+    pub config_schema: &'static [ConfigKey],
+    /// Where each consumed group paints, for honest-status region
+    /// checks; populated when the admission harness consumes it.
+    pub group_regions: &'static [(GroupId, Region)],
+    /// Panel-contributed stress fixtures beyond the canonical states.
+    pub extreme_states: &'static [ExtremeState],
+    /// Pinned raster baseline: SHA-256 hex of the reference
+    /// rasterizer's render of the shared "typical" corpus state, or
+    /// `None` until the baseline travels into the descriptor.
+    pub raster_baseline: Option<&'static str>,
+    /// The draw entry point.
+    pub draw: DrawFn,
+}

--- a/crates/pilotage-instrument-registry/src/group_set.rs
+++ b/crates/pilotage-instrument-registry/src/group_set.rs
@@ -1,0 +1,49 @@
+//! Bitset over [`GroupId`]: which state groups a panel consumes.
+
+use pilotage_instrument_state::GroupId;
+
+/// A set of state groups, as a bitset keyed by [`GroupId`] wire tags.
+/// Const-constructible so descriptors can declare their needs in
+/// `static` data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GroupSet(u32);
+
+impl GroupSet {
+    /// The empty set.
+    pub const EMPTY: GroupSet = GroupSet(0);
+
+    /// The set containing exactly `groups`.
+    pub const fn of(groups: &[GroupId]) -> GroupSet {
+        let mut bits = 0u32;
+        let mut i = 0;
+        while i < groups.len() {
+            bits |= 1 << groups[i] as u32;
+            i += 1;
+        }
+        GroupSet(bits)
+    }
+
+    /// Whether `group` is in the set.
+    pub const fn contains(&self, group: GroupId) -> bool {
+        self.0 & (1 << group as u32) != 0
+    }
+
+    /// Number of groups in the set.
+    pub const fn len(&self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// Whether the set is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// The raw bitset, bit position = [`GroupId`] wire tag. This is the
+    /// wasm/FFI encoding of the set.
+    pub const fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-registry/src/group_set/tests.rs
+++ b/crates/pilotage-instrument-registry/src/group_set/tests.rs
@@ -1,0 +1,25 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_instrument_state::GroupId;
+
+use super::GroupSet;
+
+#[test]
+fn membership_matches_construction() {
+    let set = GroupSet::of(&[GroupId::Attitude, GroupId::Nav, GroupId::MonitorText]);
+    assert!(set.contains(GroupId::Attitude));
+    assert!(set.contains(GroupId::Nav));
+    assert!(set.contains(GroupId::MonitorText));
+    assert!(!set.contains(GroupId::Wind));
+    assert_eq!(set.len(), 3);
+    assert!(!set.is_empty());
+    assert!(GroupSet::EMPTY.is_empty());
+}
+
+#[test]
+fn bits_use_wire_tags_as_positions() {
+    // The bitset is a wasm/FFI encoding: bit position must equal the
+    // group's wire tag, not an enum ordinal.
+    let set = GroupSet::of(&[GroupId::Attitude, GroupId::Trust]);
+    assert_eq!(set.bits(), (1 << 0x01) | (1 << 0x07));
+}

--- a/crates/pilotage-instrument-registry/src/lib.rs
+++ b/crates/pilotage-instrument-registry/src/lib.rs
@@ -1,0 +1,30 @@
+//! Panel registry: the descriptor contract shells compose (ADR-0029,
+//! ADR-0033).
+//!
+//! A panel is a plugin over three stable contracts — the state-group
+//! vocabulary, the scene-command IR, and the glyph vocabulary. This
+//! crate holds the descriptor a shell consumes instead of hard-coded
+//! panel enumeration: identity, required layers and state groups, the
+//! design frame, background capability, the bounded key-TLV
+//! configuration schema, and the draw entry point. A registry is plain
+//! data composed by each shell ([`Registry::new`] validates the
+//! composition at init); an out-of-repo panel registers by being listed
+//! in the shell's descriptor slice, never by link-time magic.
+
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+mod config;
+mod descriptor;
+mod group_set;
+mod registry;
+
+pub use config::{CONFIG_BLOB_MAX, ConfigBlob, ConfigError, ConfigKey, EMPTY_CONFIG, keys};
+pub use descriptor::{
+    BackgroundCapability, DesignFrame, DrawFn, ExtremeState, PanelDescriptor, PanelDrawError,
+    Region,
+};
+pub use group_set::GroupSet;
+pub use registry::{Registry, RegistryError};

--- a/crates/pilotage-instrument-registry/src/registry.rs
+++ b/crates/pilotage-instrument-registry/src/registry.rs
@@ -1,0 +1,209 @@
+//! Registry composition and its init-time validation.
+
+use pilotage_instrument_scene::LAYER_COUNT;
+
+use crate::descriptor::PanelDescriptor;
+
+/// A validated panel composition. Construction is the gate: a shell
+/// that composes nonsense fails at init, not at draw time.
+#[derive(Debug, Clone, Copy)]
+pub struct Registry {
+    panels: &'static [PanelDescriptor],
+}
+
+/// Why a composition was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RegistryError {
+    /// A shell with no panels has nothing to display.
+    #[error("a registry must contain at least one panel")]
+    Empty,
+    /// A panel id violates the lowercase/digits/dashes charset.
+    #[error("panel {index} has a malformed id")]
+    BadId {
+        /// Position in the composed slice.
+        index: usize,
+    },
+    /// Two panels share an id.
+    #[error("panel {index} repeats an earlier panel's id")]
+    DuplicateId {
+        /// Position of the second occurrence.
+        index: usize,
+    },
+    /// An empty title cannot label health or layout surfaces.
+    #[error("panel {index} has an empty title")]
+    EmptyTitle {
+        /// Position in the composed slice.
+        index: usize,
+    },
+    /// A panel that requires no layers would pass every completeness
+    /// check vacuously.
+    #[error("panel {index} declares no required layers")]
+    NoRequiredLayers {
+        /// Position in the composed slice.
+        index: usize,
+    },
+    /// Required-layer bits beyond the defined scene layers.
+    #[error("panel {index} requires undefined layer bits {bits:#04x}")]
+    UndefinedLayerBits {
+        /// Position in the composed slice.
+        index: usize,
+        /// The offending mask.
+        bits: u8,
+    },
+    /// A non-finite or non-positive design frame.
+    #[error("panel {index} has a degenerate design frame")]
+    BadDesignFrame {
+        /// Position in the composed slice.
+        index: usize,
+    },
+    /// Schema keys must be strictly ascending (unique by construction).
+    #[error("panel {index} schema key {key} repeats or descends")]
+    SchemaKeysNotAscending {
+        /// Position in the composed slice.
+        index: usize,
+        /// The out-of-order key.
+        key: u16,
+    },
+    /// A group region for a group the panel does not consume.
+    #[error("panel {index} declares a region for group {group} it does not require")]
+    RegionGroupNotRequired {
+        /// Position in the composed slice.
+        index: usize,
+        /// The wire tag of the unrequired group.
+        group: u8,
+    },
+    /// A group region outside the design frame (or degenerate).
+    #[error("panel {index} declares a region for group {group} outside its design frame")]
+    RegionOutsideFrame {
+        /// Position in the composed slice.
+        index: usize,
+        /// The wire tag of the group.
+        group: u8,
+    },
+    /// Two extreme states of one panel share an id.
+    #[error("panel {index} repeats the extreme-state id at position {position}")]
+    DuplicateExtremeId {
+        /// Position in the composed slice.
+        index: usize,
+        /// Position of the second occurrence within the panel.
+        position: usize,
+    },
+    /// An extreme-state id violates the lowercase/digits/dashes charset.
+    #[error("panel {index} extreme state {position} has a malformed id")]
+    BadExtremeId {
+        /// Position in the composed slice.
+        index: usize,
+        /// Position of the offending extreme state within the panel.
+        position: usize,
+    },
+}
+
+/// Bits a required-layer mask may set: one per defined scene layer.
+/// The u16 intermediate keeps the shift well-defined right up to the
+/// mask's own u8 capacity; growing past eight layers must widen the
+/// descriptor mask deliberately, not overflow silently.
+const DEFINED_LAYER_BITS: u8 = {
+    assert!(LAYER_COUNT <= 8, "layer mask is a u8");
+    ((1u16 << LAYER_COUNT) - 1) as u8
+};
+
+fn id_ok(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+impl Registry {
+    /// Validates and composes `panels`.
+    pub fn new(panels: &'static [PanelDescriptor]) -> Result<Registry, RegistryError> {
+        if panels.is_empty() {
+            return Err(RegistryError::Empty);
+        }
+        for (index, panel) in panels.iter().enumerate() {
+            validate_panel(index, panel)?;
+            if panels[..index].iter().any(|earlier| earlier.id == panel.id) {
+                return Err(RegistryError::DuplicateId { index });
+            }
+        }
+        Ok(Registry { panels })
+    }
+
+    /// The composed descriptors, in shell order.
+    pub const fn panels(&self) -> &'static [PanelDescriptor] {
+        self.panels
+    }
+
+    /// The descriptor with `id`, if composed.
+    pub fn by_id(&self, id: &str) -> Option<&'static PanelDescriptor> {
+        self.panels.iter().find(|panel| panel.id == id)
+    }
+}
+
+fn validate_panel(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryError> {
+    if !id_ok(panel.id) {
+        return Err(RegistryError::BadId { index });
+    }
+    if panel.title.is_empty() {
+        return Err(RegistryError::EmptyTitle { index });
+    }
+    if panel.required_layers == 0 {
+        return Err(RegistryError::NoRequiredLayers { index });
+    }
+    if panel.required_layers & !DEFINED_LAYER_BITS != 0 {
+        return Err(RegistryError::UndefinedLayerBits {
+            index,
+            bits: panel.required_layers,
+        });
+    }
+    let frame = panel.design_frame;
+    if !(frame.width.is_finite()
+        && frame.height.is_finite()
+        && frame.width > 0.0
+        && frame.height > 0.0)
+    {
+        return Err(RegistryError::BadDesignFrame { index });
+    }
+    let mut previous: Option<u16> = None;
+    for key in panel.config_schema {
+        if previous.is_some_and(|previous| key.0 <= previous) {
+            return Err(RegistryError::SchemaKeysNotAscending { index, key: key.0 });
+        }
+        previous = Some(key.0);
+    }
+    for (group, region) in panel.group_regions {
+        if !panel.required_groups.contains(*group) {
+            return Err(RegistryError::RegionGroupNotRequired {
+                index,
+                group: *group as u8,
+            });
+        }
+        let inside = region.x >= 0.0
+            && region.y >= 0.0
+            && region.width > 0.0
+            && region.height > 0.0
+            && region.x + region.width <= frame.width
+            && region.y + region.height <= frame.height;
+        if !inside {
+            return Err(RegistryError::RegionOutsideFrame {
+                index,
+                group: *group as u8,
+            });
+        }
+    }
+    for (position, extreme) in panel.extreme_states.iter().enumerate() {
+        if !id_ok(extreme.id) {
+            return Err(RegistryError::BadExtremeId { index, position });
+        }
+        if panel.extreme_states[..position]
+            .iter()
+            .any(|earlier| earlier.id == extreme.id)
+        {
+            return Err(RegistryError::DuplicateExtremeId { index, position });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-registry/src/registry/tests.rs
+++ b/crates/pilotage-instrument-registry/src/registry/tests.rs
@@ -1,0 +1,196 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_alerts::AlertOutput;
+use pilotage_instrument_scene::{LAYER_COUNT, SceneWriter};
+use pilotage_instrument_state::{AircraftState, GroupId, PanelData};
+
+use super::{Registry, RegistryError};
+use crate::config::ConfigBlob;
+use crate::descriptor::{
+    BackgroundCapability, DesignFrame, ExtremeState, PanelDescriptor, PanelDrawError, Region,
+};
+use crate::group_set::GroupSet;
+
+fn draw_nothing(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    Ok(())
+}
+
+fn nothing_fed() -> AircraftState {
+    AircraftState::default()
+}
+
+const fn panel(id: &'static str) -> PanelDescriptor {
+    PanelDescriptor {
+        id,
+        title: "Panel",
+        required_layers: 0b0000_0110,
+        required_groups: GroupSet::of(&[GroupId::Attitude, GroupId::Air]),
+        design_frame: DesignFrame {
+            width: 480.0,
+            height: 360.0,
+        },
+        background: BackgroundCapability::NotUsed,
+        config_schema: &[],
+        group_regions: &[],
+        extreme_states: &[],
+        raster_baseline: None,
+        draw: draw_nothing,
+    }
+}
+
+#[test]
+fn a_valid_composition_is_accepted_and_queryable() {
+    static PANELS: [PanelDescriptor; 2] = [panel("alpha"), panel("beta-2")];
+    let registry = Registry::new(&PANELS).expect("two well-formed panels");
+    assert_eq!(registry.panels().len(), 2);
+    assert_eq!(registry.by_id("beta-2").expect("registered").id, "beta-2");
+    assert!(registry.by_id("gamma").is_none());
+}
+
+#[test]
+fn an_empty_composition_is_refused() {
+    assert_eq!(Registry::new(&[]).map(|_| ()), Err(RegistryError::Empty));
+}
+
+#[test]
+fn malformed_and_duplicate_ids_are_refused() {
+    static UPPER: [PanelDescriptor; 1] = [panel("PFD")];
+    assert_eq!(
+        Registry::new(&UPPER).map(|_| ()),
+        Err(RegistryError::BadId { index: 0 })
+    );
+    static DUP: [PanelDescriptor; 2] = [panel("pfd"), panel("pfd")];
+    assert_eq!(
+        Registry::new(&DUP).map(|_| ()),
+        Err(RegistryError::DuplicateId { index: 1 })
+    );
+}
+
+#[test]
+fn layer_mask_abuse_is_refused() {
+    static NONE: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.required_layers = 0;
+        p
+    }];
+    assert_eq!(
+        Registry::new(&NONE).map(|_| ()),
+        Err(RegistryError::NoRequiredLayers { index: 0 })
+    );
+    static BEYOND: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.required_layers = 1 << LAYER_COUNT;
+        p
+    }];
+    assert_eq!(
+        Registry::new(&BEYOND).map(|_| ()),
+        Err(RegistryError::UndefinedLayerBits {
+            index: 0,
+            bits: 1 << LAYER_COUNT,
+        })
+    );
+}
+
+#[test]
+fn a_degenerate_design_frame_is_refused() {
+    static FLAT: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.design_frame = DesignFrame {
+            width: 480.0,
+            height: 0.0,
+        };
+        p
+    }];
+    assert_eq!(
+        Registry::new(&FLAT).map(|_| ()),
+        Err(RegistryError::BadDesignFrame { index: 0 })
+    );
+}
+
+#[test]
+fn schema_key_order_is_enforced() {
+    use crate::config::ConfigKey;
+    static UNSORTED: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.config_schema = &[ConfigKey(2), ConfigKey(1)];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&UNSORTED).map(|_| ()),
+        Err(RegistryError::SchemaKeysNotAscending { index: 0, key: 1 })
+    );
+}
+
+#[test]
+fn group_regions_must_stay_honest() {
+    static FOREIGN: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.group_regions = &[(
+            GroupId::Nav,
+            Region {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+        )];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&FOREIGN).map(|_| ()),
+        Err(RegistryError::RegionGroupNotRequired {
+            index: 0,
+            group: GroupId::Nav as u8,
+        })
+    );
+    static OUTSIDE: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.group_regions = &[(
+            GroupId::Attitude,
+            Region {
+                x: 470.0,
+                y: 0.0,
+                width: 20.0,
+                height: 10.0,
+            },
+        )];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&OUTSIDE).map(|_| ()),
+        Err(RegistryError::RegionOutsideFrame {
+            index: 0,
+            group: GroupId::Attitude as u8,
+        })
+    );
+}
+
+#[test]
+fn extreme_state_ids_must_be_unique_and_well_formed() {
+    static DUP: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.extreme_states = &[
+            ExtremeState {
+                id: "unusual-nose-high",
+                build: nothing_fed,
+            },
+            ExtremeState {
+                id: "unusual-nose-high",
+                build: nothing_fed,
+            },
+        ];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&DUP).map(|_| ()),
+        Err(RegistryError::DuplicateExtremeId {
+            index: 0,
+            position: 1,
+        })
+    );
+}

--- a/docs/adr/0029-panel-layout-look-plugins.md
+++ b/docs/adr/0029-panel-layout-look-plugins.md
@@ -1,7 +1,8 @@
 # ADR-0029: Panels, layout, and look are data-driven plugins over the scene and state contracts
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-29
+- Concrete contracts: [ADR-0033](0033-panel-registry-config-and-digest.md)
 
 ## Context
 

--- a/docs/adr/0033-panel-registry-config-and-digest.md
+++ b/docs/adr/0033-panel-registry-config-and-digest.md
@@ -1,0 +1,94 @@
+# ADR-0033: Panel registry as composed data, key-TLV configuration, theme floors, and the scene digest
+
+- Status: Accepted
+- Date: 2026-08-06
+
+## Context
+
+[ADR-0029](0029-panel-layout-look-plugins.md) decided that panels are
+data-driven plugins over the state-group, scene-IR, and glyph contracts.
+This record fixes the concrete shapes that decision left open: how a
+shell learns what panels exist, how per-panel options cross the
+wasm/FFI boundary, which theme constraints are the safety floor, and
+what single invariant proves a panel renders identically on every
+shell. The state-group side is already concrete (tagged-group state ABI
+v6; absence resolves Missing by construction).
+
+## Decision
+
+- **The registry is plain data composed by each shell.** A
+  `PanelDescriptor` (in `pilotage-instrument-registry`) carries
+  identity, title, required layers, required state groups, design
+  frame, background capability, config schema, honest-status group
+  regions, panel-contributed extreme states, the pinned raster
+  baseline, and the draw entry point. `Registry::new` validates the
+  composition at init — malformed ids, undefined layer bits, degenerate
+  frames, unordered schemas, and dishonest group regions fail the shell
+  before anything draws. There is no link-time registration magic: an
+  out-of-repo panel registers by being listed in the shell's descriptor
+  slice, so what a station displays is reviewable configuration.
+- **Configuration is a bounded key-TLV blob.** `[key u16 LE][len u16
+  LE][payload]`, strictly ascending keys, at most 256 bytes, crossing
+  every boundary as one byte slice. A key outside the panel's declared
+  schema is rejected, never skipped: silently ignoring an option a
+  caller believes is set would misstate what the panel displays.
+  Well-known keys start at `0x0001`; out-of-repo panels take `0x8000`
+  and up.
+- **SVS is accept-and-cede.** `BackgroundMode::Svs { viewport, quality }`
+  is validated configuration a PFD carries today and draws exactly as
+  `BackgroundMode::None` — the Background band is ceded, and nothing
+  above that band may depend on the choice (pinned by a
+  byte-equivalence test). The SVS renderer, when it lands, consumes the
+  ceded band; no panel changes shape.
+- **Theme floors are assurance decisions, recorded here.** A themable
+  color within max-channel distance 64 of any warning hue or of the
+  red-through-yellow segment is refused (white is exempt: primary
+  symbology is legitimately white, and white advisory rows signal by
+  stack position). Primary symbology holds 96 luma against every ground
+  it draws over, with the translucent tape ground measured composited
+  over each horizon half at its declared alpha. The colored
+  annunciation hues hold 64 luma against the panel and box grounds —
+  below the primary floor deliberately, because failure red holds only
+  76 against the shipped black; the rule defends against equiluminant
+  burial (the red-on-green deficiency case), not ordinary legibility.
+  Every themable color paints at full alpha except the tape ground with
+  its own floor of 96. Tightening any floor is a reviewable change to
+  these numbers, not a code archaeology exercise.
+- **One digest proves cross-shell identity.** The migration invariant
+  is a streaming SHA-256 over a domain separator, the scene/state
+  contract versions, and, per registered panel: the role-tagged,
+  length-prefixed panel id with the contract-relevant descriptor
+  fields (required layers, required groups, design frame, background
+  capability, config schema), then per corpus state — the shared
+  canonical set plus that panel's own extreme states — the role-tagged
+  state id and emitted scene bytes. Everything draws with the empty
+  config and no alerts, so the digest is invariant to SVS by
+  construction; theme independence holds because panels take no theme
+  parameter at this boundary. Shells report the same digest or they
+  are not showing the same instruments; pixel hashes remain
+  per-backend rasterizer regression tests, not the cross-shell
+  contract.
+
+## Consequences
+
+- Adding a panel touches the registry composition and the shell's
+  descriptor list — not shell match ladders, health tables, or markup.
+- The admission harness gets its matrix from the descriptor
+  (`required_groups` × withholding, `group_regions` for honest-status
+  checks), so a dishonest panel is refused mechanically.
+- The digest moves exactly once per deliberate contract change, with
+  the review note saying why; an unexplained digest move is a defect.
+- Config keys form a small registry of their own; retiring a key means
+  rejecting it (schemas drop it), never silently ignoring it.
+
+## Alternatives considered
+
+- **Link-time plugin registration (linkme/inventory):** rejected — what
+  a station displays must be reviewable data, not an emergent property
+  of what happened to link.
+- **Per-panel typed config across the boundary:** rejected — every new
+  option would grow the wasm/FFI surface; one validated blob keeps the
+  boundary append-only.
+- **Pixel hashes as the cross-shell invariant:** rejected — they bind a
+  rasterizer, not the panel contract; two conformant backends
+  legitimately rasterize differently.


### PR DESCRIPTION
A panel becomes a plugin over the stable contracts (ADR-0029, ADR-0033): pilotage-instrument-registry holds the PanelDescriptor a shell consumes — identity, title, required layers, required state groups (GroupSet over the wire tags), design frame, background capability, config schema, honest-status group regions, extreme-state hooks, raster-baseline slot, and the draw entry point. Registry::new validates the composition at init with typed context errors; there is no link-time registration magic.

Configuration crosses every boundary as one bounded key-TLV blob (ascending u16 keys, 256-byte cap, unknown key rejected rather than skipped). The PFD decodes it via PfdConfig::from_config; BackgroundMode::Svs { viewport, quality } is accept-and-cede — validated and carried, drawn exactly as None, pinned by byte-equivalence tests — so the SVS renderer consumes a ceded band later without any panel change.

panels/src/descriptors.rs owns the PFD/HSI descriptors and BUILTIN_PANELS; the shell critical-layer masks now read from the descriptors (the shell holds no mask of its own), pinned equal by the descriptor-vs-direct draw equality tests. ADR-0029 moves to Accepted; ADR-0033 records the registry-as-data, config-TLV, theme-floor, and digest decisions. The registry crate joins the thumbv7em no_std gate. Frame hashes unchanged.

Refs luofang34/Pilotage#264 luofang34/Indicate#36 (AIR-OUT-003, AIR-OUT-005).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> luofang34/Pilotage#291
- <kbd>&nbsp;7&nbsp;</kbd> luofang34/Pilotage#289
- <kbd>&nbsp;6&nbsp;</kbd> luofang34/Pilotage#288
- <kbd>&nbsp;5&nbsp;</kbd> luofang34/Pilotage#287
- <kbd>&nbsp;4&nbsp;</kbd> luofang34/Pilotage#286
- <kbd>&nbsp;3&nbsp;</kbd> luofang34/Pilotage#285
- <kbd>&nbsp;2&nbsp;</kbd> luofang34/Pilotage#284
- <kbd>&nbsp;1&nbsp;</kbd> luofang34/Pilotage#283 👈 
<!-- GitButler Footer Boundary Bottom -->

Closes luofang34/Pilotage#264.