### PR TITLE
Validate the shell composition once, not twice per panel per frame (#296)

### DIFF
--- a/clients/web-instruments/src/panel_registry.rs
+++ b/clients/web-instruments/src/panel_registry.rs
@@ -13,9 +13,13 @@ use pilotage_instrument_registry::{
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /// The validated shell composition, or `None` if the shipped panels no
-/// longer compose — which the panels crate's own tests make unreachable.
+/// longer compose — which the panels crate's own tests make
+/// unreachable. Validated once and memoized: the input is `&'static`
+/// and `Registry::new` is pure, so the answer cannot change between
+/// calls, and the render path asks for it twice per panel per frame.
 pub(crate) fn registry() -> Option<Registry> {
-    Registry::new(BUILTIN_PANELS).ok()
+    static COMPOSED: std::sync::OnceLock<Option<Registry>> = std::sync::OnceLock::new();
+    *COMPOSED.get_or_init(|| Registry::new(BUILTIN_PANELS).ok())
 }
 
 pub(crate) fn descriptor(panel: u32) -> Option<&'static PanelDescriptor> {


### PR DESCRIPTION
registry() memoizes the validated composition in a OnceLock: the input is &'static, Registry::new is pure, and the render path resolves a descriptor twice per panel per frame — O(panels × regions) work whose answer cannot change, in the one path every added panel multiplies. Failure semantics unchanged: a composition that does not validate still memoizes as None and surfaces as InvalidPanel, fail-visible.

Closes #296.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>