### PR TITLE
The instrument and geodesy suites delegate Euler conversion to the convention owner (#307)

### DIFF
--- a/crates/pilotage-instrument-panels/src/hsi/tests.rs
+++ b/crates/pilotage-instrument-panels/src/hsi/tests.rs
@@ -47,13 +47,7 @@ fn heading_only(heading_rad: f32) -> PanelData {
 }
 
 fn quat_yaw(yaw: f32) -> pilotage_instrument_state::Quat {
-    let h = yaw / 2.0;
-    pilotage_instrument_state::Quat {
-        w: libm::cosf(h),
-        x: 0.0,
-        y: 0.0,
-        z: libm::sinf(h),
-    }
+    pilotage_instrument_state::Quat::from_euler(0.0, 0.0, yaw)
 }
 
 fn render(data: &PanelData) -> Vec<u8> {

--- a/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
+++ b/crates/pilotage-instrument-panels/src/pfd/attitude_tests.rs
@@ -13,17 +13,11 @@ use super::{PfdConfig, VSpeeds};
 
 /// f32 ZYX euler → quaternion for orientation fixtures.
 fn quat_euler(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
-    let d = core::f32::consts::PI / 180.0;
-    let (r, p, y) = (roll_deg * d / 2.0, pitch_deg * d / 2.0, yaw_deg * d / 2.0);
-    let (cr, sr) = (libm::cosf(r), libm::sinf(r));
-    let (cp, sp) = (libm::cosf(p), libm::sinf(p));
-    let (cy, sy) = (libm::cosf(y), libm::sinf(y));
-    Quat {
-        w: cr * cp * cy + sr * sp * sy,
-        x: sr * cp * cy - cr * sp * sy,
-        y: cr * sp * cy + sr * cp * sy,
-        z: cr * cp * sy - sr * sp * cy,
-    }
+    Quat::from_euler(
+        roll_deg.to_radians(),
+        pitch_deg.to_radians(),
+        yaw_deg.to_radians(),
+    )
 }
 
 fn oriented(roll_deg: f32, pitch_deg: f32) -> PanelData {

--- a/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
+++ b/crates/pilotage-instrument-raster/src/raster/tests/attitude_behavior.rs
@@ -43,17 +43,11 @@ const RED: [u8; 3] = [255, 0, 0];
 
 /// f32 ZYX euler → quaternion, matching the panel orientation fixtures.
 fn euler_quat(roll_deg: f32, pitch_deg: f32, yaw_deg: f32) -> Quat {
-    let d = core::f32::consts::PI / 180.0;
-    let (r, p, y) = (roll_deg * d / 2.0, pitch_deg * d / 2.0, yaw_deg * d / 2.0);
-    let (cr, sr) = (libm::cosf(r), libm::sinf(r));
-    let (cp, sp) = (libm::cosf(p), libm::sinf(p));
-    let (cy, sy) = (libm::cosf(y), libm::sinf(y));
-    Quat {
-        w: cr * cp * cy + sr * sp * sy,
-        x: sr * cp * cy - cr * sp * sy,
-        y: cr * sp * cy + sr * cp * sy,
-        z: cr * cp * sy - sr * sp * cy,
-    }
+    Quat::from_euler(
+        roll_deg.to_radians(),
+        pitch_deg.to_radians(),
+        yaw_deg.to_radians(),
+    )
 }
 
 /// A valid flying state at the given orientation, populated enough that the

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,10 +2,10 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p pilotage-instrument-panels
-config-digest: 8363e9e81d6654506e95051bec48ea32df50ef10
+config-digest: 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:8363e9e81d6654506e95051bec48ea32df50ef10
+run-id: local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 outcome: pass
 summary:
+test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -2,10 +2,10 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: SO(3) presentation unit
 command: cargo test -p pilotage-instrument-state
-config-digest: 8363e9e81d6654506e95051bec48ea32df50ef10
+config-digest: 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:8363e9e81d6654506e95051bec48ea32df50ef10
+run-id: local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 outcome: pass
 summary:
+test result: ok. 165 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 128 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,10 +2,10 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p pilotage-instrument-raster
-config-digest: 8363e9e81d6654506e95051bec48ea32df50ef10
+config-digest: 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:8363e9e81d6654506e95051bec48ea32df50ef10
+run-id: local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 outcome: pass
 summary:
+test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
-test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p pilotage-instrument-raster
-attr config-digest 8363e9e81d6654506e95051bec48ea32df50ef10
+attr config-digest 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:7ab0d7f2dafef691899dde6f837e3f8561554ec6
+attr source-digest git-blob:68630e48c7285cd5e2f73f433a66f1644c185a95
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:0ab9ca48a268dde5998ccbfd86b3c6e704d56bca5d395373ebccafe86daf2bed
-attr run-id local:8363e9e81d6654506e95051bec48ea32df50ef10
+attr output-digest sha256:a7faef431a9e3b8d1a4c28254cc1f5a93666bf298fa69d985298029ab83ee2fb
+attr run-id local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p pilotage-instrument-state
-attr config-digest 8363e9e81d6654506e95051bec48ea32df50ef10
+attr config-digest 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:4e4b9d1da1c6dfb7b7d1077d96155e6a79ff961b
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:7a7cb6afb1445cda0cc7e17d0040331f5bb85caafc6decbd6f2da238578e295e
-attr run-id local:8363e9e81d6654506e95051bec48ea32df50ef10
+attr output-digest sha256:df1bf46f5e8f58dd27bb8c1f6bd809e3abaa7172f47ad45f5ed864d2c3427864
+attr run-id local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p pilotage-instrument-panels
-attr config-digest 8363e9e81d6654506e95051bec48ea32df50ef10
+attr config-digest 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:a836ec8a29f0cddb7905a9f1d5c3876ae163f38e
+attr source-digest git-blob:fbd04a43041666fbb7419aa4d96ac652c0ab6565
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:5381d3d7be80198c8755c93f1dfef1f464c65a5429820018e1cad34fee2af924
-attr run-id local:8363e9e81d6654506e95051bec48ea32df50ef10
+attr output-digest sha256:00f97443ee16d25e3dfc052dbc31f2c4a8f9147ff7e06f9be1b5c0a275289966
+attr run-id local:0fd556b83e1304b3679c0f81e6ae61ba74311bb1
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit 8363e9e81d6654506e95051bec48ea32df50ef10
-attr tree 3a6c8ec4986deb01fbbaecf8f569ba596a5d225d
+attr commit 0fd556b83e1304b3679c0f81e6ae61ba74311bb1
+attr tree 34ff21a6610519a113059d08261e6e23acfa4104
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
Retires the hand-rolled ZYX Euler-to-quaternion expansions within reach of `Quat::from_euler`: the three instrument-suite helpers (#307) and the geodesy conformal suite's copy — all four survive as one-line degree-taking adapters that delegate, so the call sites stay in degrees and no convention content remains in them. The remaining hand-written expansions (mavlink codec, session gate, aviate fixtures) build protocol or array types in crates with no frames dependency and stay.

Bit-identity holds because the adapters compute the same f32 operations: `to_radians` is a multiply by the same `PI/180` constant the deleted code used, halving by `/2.0` and `*0.5` are the same exact scaling, and `from_euler`'s four component expressions are term-for-term the deleted ones. The pinned conformal sim hash is an end-to-end witness on the geodesy side. (One caveat recorded: `from_euler(0,0,yaw)` produces `-0.0` in place of `0.0` in a zero component when `|yaw| > π` — value-identical, bit-different; no current fixture reaches it.)

The PFD and raster attitude suites are digest-bound evidence sources, so the ATT-01 results re-record over real runs in the companion evidence commit, anchored to the code commit; verified with the evidence gate: verdict VALID, `--require-resolvable` exit 0.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gPz9A5f9NbYFmop3UHMuw