### PR TITLE
Corpus sync, first firing: advance the family pin to corpus v4

### DIFF
--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -75,7 +75,7 @@ jobs:
         run: >
           cargo install --locked
           --git https://github.com/luofang34/Indicate.git
-          --rev 25ca50747af46436d81308f2672f8f99428da368
+          --rev 045ccc91457588c1722949845d00db546c2439bd
           pilotage-evidence
 
       - name: LINK-04 slice — honest verdict and bidirectional trace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "pilotage-alerts"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "thiserror",
 ]
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "pilotage-frames"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "libm",
 ]
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-feeder"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "pilotage-instrument-state",
 ]
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-glyphs"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "pilotage-sha256",
  "thiserror",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-panels"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "libm",
  "pilotage-alerts",
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-registry"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "pilotage-alerts",
  "pilotage-instrument-scene",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-scene"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "thiserror",
 ]
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-state"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "libm",
  "pilotage-alerts",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "pilotage-instrument-symbology"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 dependencies = [
  "pilotage-alerts",
  "pilotage-instrument-scene",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "pilotage-sha256"
 version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=25ca50747af46436d81308f2672f8f99428da368#25ca50747af46436d81308f2672f8f99428da368"
+source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 
 [[package]]
 name = "pilotage-svs-build"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ navigate-guidance = { git = "https://github.com/luofang34/Navigate.git", rev = "
 # the scene vocabulary, the panels, and the registry digest cannot drift
 # apart. The pilot of a change that moves the cross-shell scene digest
 # advances this pin as part of that change (ADR-0034).
-pilotage-frames = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-alerts = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-scene = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-state = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-glyphs = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-panels = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-feeder = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
-pilotage-instrument-registry = { git = "https://github.com/luofang34/Indicate.git", rev = "25ca50747af46436d81308f2672f8f99428da368" }
+pilotage-frames = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-alerts = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-scene = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-state = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-glyphs = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-panels = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-feeder = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+pilotage-instrument-registry = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
 aerocontext-core = "0.4.5"
 aerocontext-planning = "0.4.5"
 aerocontext-navdata = { version = "0.4.5", default-features = false }

--- a/clients/web/scene-conformance.test.mjs
+++ b/clients/web/scene-conformance.test.mjs
@@ -324,9 +324,9 @@ function conformCanvas(entry, v, out) {
 // upstream corpus edit arrives via a pin advance and MUST turn this suite
 // red until the interpreter is re-verified against the new corpus and the
 // literals are consciously moved. Never resolve a mismatch by unpinning.
-const EXPECTED_CORPUS_VERSION = 3;
+const EXPECTED_CORPUS_VERSION = 4;
 const EXPECTED_CORPUS_SHA256 =
-  "7130efd29b19c2f0fb4622cefd7357dd4e6c038f70efa27e0adbebc4d03cdc6f";
+  "1fb8e6de2734ff7506843b05869f39d501f0926599636c6110a7e3b0c6e1625e";
 
 const golden = JSON.parse(
   readFileSync(


### PR DESCRIPTION
The first post-extraction pin advance, structured to exercise luofang34/Indicate#35 ready-when check 2: change the corpus at its canonical home (Indicate PR luofang34/Pilotage#4, corpus v4 adding `frame-edge-overhang`), advance the pinned consumer, watch its CI go red.

**Commit 1 (deliberately red):** all nine pin sites advance to Indicate `045ccc91` (Cargo.toml ×8 + the evidence-gate install rev — the new coherence guard forces them together). The corpus identity literals stay at v3, so `scene-conformance.test.mjs` fails exactly two checks — `corpus version is the one this interpreter is verified against` and `corpus identity matches the verified pin` — while the self-consistency hash and all 43 case replays pass (the new case conforms on this interpreter; the red is purely the conscious-acknowledgment gate). That red run is the recorded evidence the sync mechanism works.

**Commit 2 (follows once the red run is recorded):** the literals move to v4 / `1fb8e6de…`, re-verifying this interpreter against the new corpus. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gPz9A5f9NbYFmop3UHMuw