### PR TITLE
Migrate to Indicate v0.2.0: the family speaks its own name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # The Navigate and Indicate crates are private git dependencies; libgit2
+  # The Navigate crates are private git dependencies; libgit2
   # cannot use the runner's rewritten ssh credentials, the git CLI can.
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   PROTOC_SHA256: a7be2928c0454f132c599e25b79b7ad1b57663f2337d7f7e468a1d59b98ec1b0
@@ -23,27 +23,19 @@ jobs:
           # base commit must be present locally; a shallow clone would hide it.
           fetch-depth: 0
 
-      - name: Authorize the private git dependencies (Navigate, Indicate)
+      - name: Authorize the private git dependency (Navigate)
         env:
           NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
-          INDICATE_DEPLOY_KEY: ${{ secrets.INDICATE_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "$NAVIGATE_DEPLOY_KEY" > ~/.ssh/navigate_ci
-          printf '%s\n' "$INDICATE_DEPLOY_KEY" > ~/.ssh/indicate_ci
-          chmod 600 ~/.ssh/navigate_ci ~/.ssh/indicate_ci
+          chmod 600 ~/.ssh/navigate_ci
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          # One read-only deploy key per upstream repository. GitHub binds an
-          # ssh authentication to the single repository whose deploy key it
-          # is, so each pin needs its own host alias with its own identity; a
-          # shared core.sshCommand would offer one repository's key for the
-          # other and be refused.
-          {
-            printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n'
-            printf 'Host github-indicate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/indicate_ci\n  IdentitiesOnly yes\n'
-          } >> ~/.ssh/config
+          # A read-only deploy key, bound by GitHub to the one repository
+          # whose key it is, offered through a dedicated host alias.
+          # Indicate is public and needs no credential.
+          printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n' >> ~/.ssh/config
           git config --global url."ssh://git@github-navigate/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
-          git config --global url."ssh://git@github-indicate/luofang34/Indicate".insteadOf "https://github.com/luofang34/Indicate"
 
       - name: Install system dependencies (hidapi on Linux)
         run: |

--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -11,7 +11,7 @@
 # missing selector, or a missing artifact — reddens this job. Durable
 # evidence resolution is enforced; the review verdict is not.
 #
-# The gate tool itself lives upstream (pilotage-evidence in the Indicate
+# The gate tool itself lives upstream (indicate-evidence in the Indicate
 # repository, pinned below at the same rev the workspace pins); its own
 # tests and negative-fixture batteries run in that repository's CI. The
 # instruments evidence graph travels with the panels and is gated there
@@ -24,7 +24,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # The gate binary is a private git dependency; the git CLI can use the
+  # Navigate is a private git dependency; the git CLI can use the
   # runner's rewritten ssh credentials, libgit2 cannot.
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
@@ -40,27 +40,19 @@ jobs:
           # recorded baseline unverifiable.
           fetch-depth: 0
 
-      - name: Authorize the private git dependencies (Navigate, Indicate)
+      - name: Authorize the private git dependency (Navigate)
         env:
           NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
-          INDICATE_DEPLOY_KEY: ${{ secrets.INDICATE_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "$NAVIGATE_DEPLOY_KEY" > ~/.ssh/navigate_ci
-          printf '%s\n' "$INDICATE_DEPLOY_KEY" > ~/.ssh/indicate_ci
-          chmod 600 ~/.ssh/navigate_ci ~/.ssh/indicate_ci
+          chmod 600 ~/.ssh/navigate_ci
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          # One read-only deploy key per upstream repository. GitHub binds an
-          # ssh authentication to the single repository whose deploy key it
-          # is, so each pin needs its own host alias with its own identity; a
-          # shared core.sshCommand would offer one repository's key for the
-          # other and be refused.
-          {
-            printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n'
-            printf 'Host github-indicate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/indicate_ci\n  IdentitiesOnly yes\n'
-          } >> ~/.ssh/config
+          # A read-only deploy key, bound by GitHub to the one repository
+          # whose key it is, offered through a dedicated host alias.
+          # Indicate is public and needs no credential.
+          printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n' >> ~/.ssh/config
           git config --global url."ssh://git@github-navigate/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
-          git config --global url."ssh://git@github-indicate/luofang34/Indicate".insteadOf "https://github.com/luofang34/Indicate"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -71,12 +63,14 @@ jobs:
       - name: Install the pinned evidence gate
         # The rev here is the same Indicate pin the workspace manifest
         # carries, so the gate that judges these graphs is the one the
-        # family's own CI tests.
+        # family's own CI tests. --force: the restored cargo cache may
+        # hold an evidence-gate binary owned by a different crate name
+        # or rev, and a stale gate must be overwritten, never kept.
         run: >
-          cargo install --locked
+          cargo install --locked --force
           --git https://github.com/luofang34/Indicate.git
-          --rev 045ccc91457588c1722949845d00db546c2439bd
-          pilotage-evidence
+          --rev 14e9a7591a8a659b71d4a19e027c07b7448d6bcb
+          indicate-evidence
 
       - name: LINK-04 slice — honest verdict and bidirectional trace
         # Informational. The source-role slice is structurally traced and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicate-alerts"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-frames"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "indicate-instrument-descriptor"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-alerts",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-instrument-feeder"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-instrument-state",
+]
+
+[[package]]
+name = "indicate-instrument-glyphs"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-sha256",
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-instrument-panels"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-alerts",
+ "indicate-instrument-descriptor",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
+ "indicate-instrument-symbology",
+ "libm",
+]
+
+[[package]]
+name = "indicate-instrument-registry"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-instrument-descriptor",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
+ "indicate-sha256",
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-instrument-scene"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-instrument-state"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-alerts",
+ "indicate-frames",
+ "libm",
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-instrument-symbology"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+dependencies = [
+ "indicate-alerts",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
+ "thiserror",
+]
+
+[[package]]
+name = "indicate-sha256"
+version = "0.1.0"
+source = "git+https://github.com/luofang34/Indicate.git?rev=14e9a7591a8a659b71d4a19e027c07b7448d6bcb#14e9a7591a8a659b71d4a19e027c07b7448d6bcb"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,9 +1466,9 @@ dependencies = [
 name = "pilotage-adapter-api"
 version = "0.1.0"
 dependencies = [
+ "indicate-frames",
  "pilotage-calibration-id",
  "pilotage-camera-calibration",
- "pilotage-frames",
  "pilotage-ingress",
  "pilotage-protocol",
  "pilotage-timing",
@@ -1431,14 +1535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pilotage-alerts"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "pilotage-authority"
 version = "0.1.0"
 dependencies = [
@@ -1456,9 +1552,9 @@ version = "0.1.0"
 name = "pilotage-camera-calibration"
 version = "0.1.0"
 dependencies = [
+ "indicate-frames",
  "libm",
  "pilotage-calibration-id",
- "pilotage-frames",
  "sha2 0.10.9",
  "thiserror",
 ]
@@ -1490,21 +1586,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pilotage-frames"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "pilotage-geo"
 version = "0.1.0"
 dependencies = [
+ "indicate-frames",
  "libm",
  "pilotage-calibration-id",
  "pilotage-camera-calibration",
- "pilotage-frames",
  "thiserror",
 ]
 
@@ -1525,78 +1613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pilotage-instrument-feeder"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "pilotage-instrument-state",
-]
-
-[[package]]
-name = "pilotage-instrument-glyphs"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "pilotage-sha256",
- "thiserror",
-]
-
-[[package]]
-name = "pilotage-instrument-panels"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "libm",
- "pilotage-alerts",
- "pilotage-instrument-registry",
- "pilotage-instrument-scene",
- "pilotage-instrument-state",
- "pilotage-instrument-symbology",
-]
-
-[[package]]
-name = "pilotage-instrument-registry"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "pilotage-alerts",
- "pilotage-instrument-scene",
- "pilotage-instrument-state",
- "pilotage-sha256",
- "thiserror",
-]
-
-[[package]]
-name = "pilotage-instrument-scene"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "pilotage-instrument-state"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "libm",
- "pilotage-alerts",
- "pilotage-frames",
- "thiserror",
-]
-
-[[package]]
-name = "pilotage-instrument-symbology"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
-dependencies = [
- "pilotage-alerts",
- "pilotage-instrument-scene",
- "pilotage-instrument-state",
- "thiserror",
-]
-
-[[package]]
 name = "pilotage-instruments-web"
 version = "0.1.0"
 dependencies = [
@@ -1612,13 +1628,13 @@ dependencies = [
 name = "pilotage-instruments-web-shell"
 version = "0.1.0"
 dependencies = [
- "pilotage-alerts",
- "pilotage-instrument-feeder",
- "pilotage-instrument-glyphs",
- "pilotage-instrument-panels",
- "pilotage-instrument-registry",
- "pilotage-instrument-scene",
- "pilotage-instrument-state",
+ "indicate-alerts",
+ "indicate-instrument-feeder",
+ "indicate-instrument-glyphs",
+ "indicate-instrument-panels",
+ "indicate-instrument-registry",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -1701,11 +1717,6 @@ dependencies = [
  "tracing-subscriber",
  "wtransport",
 ]
-
-[[package]]
-name = "pilotage-sha256"
-version = "0.1.0"
-source = "git+https://github.com/luofang34/Indicate.git?rev=045ccc91457588c1722949845d00db546c2439bd#045ccc91457588c1722949845d00db546c2439bd"
 
 [[package]]
 name = "pilotage-svs-build"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,14 @@ navigate-guidance = { git = "https://github.com/luofang34/Navigate.git", rev = "
 # the scene vocabulary, the panels, and the registry digest cannot drift
 # apart. The pilot of a change that moves the cross-shell scene digest
 # advances this pin as part of that change (ADR-0034).
-pilotage-frames = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-alerts = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-scene = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-state = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-glyphs = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-panels = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-feeder = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
-pilotage-instrument-registry = { git = "https://github.com/luofang34/Indicate.git", rev = "045ccc91457588c1722949845d00db546c2439bd" }
+indicate-frames = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-alerts = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-scene = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-state = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-glyphs = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-panels = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-feeder = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
+indicate-instrument-registry = { git = "https://github.com/luofang34/Indicate.git", rev = "14e9a7591a8a659b71d4a19e027c07b7448d6bcb" }
 aerocontext-core = "0.4.5"
 aerocontext-planning = "0.4.5"
 aerocontext-navdata = { version = "0.4.5", default-features = false }

--- a/clients/web-instrument-shell/Cargo.toml
+++ b/clients/web-instrument-shell/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["rlib"]
 workspace = true
 
 [dependencies]
-pilotage-alerts = { workspace = true }
-pilotage-instrument-feeder = { workspace = true }
-pilotage-instrument-glyphs = { workspace = true }
-pilotage-instrument-panels = { workspace = true }
-pilotage-instrument-registry = { workspace = true }
-pilotage-instrument-scene = { workspace = true }
-pilotage-instrument-state = { workspace = true }
+indicate-alerts = { workspace = true }
+indicate-instrument-feeder = { workspace = true }
+indicate-instrument-glyphs = { workspace = true }
+indicate-instrument-panels = { workspace = true }
+indicate-instrument-registry = { workspace = true }
+indicate-instrument-scene = { workspace = true }
+indicate-instrument-state = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/clients/web-instrument-shell/src/alert_tests.rs
+++ b/clients/web-instrument-shell/src/alert_tests.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_instrument_scene::SceneCmds;
-use pilotage_instrument_state::{AircraftState, Stamped};
+use indicate_instrument_scene::SceneCmds;
+use indicate_instrument_state::{AircraftState, Stamped};
 
 use crate::exports::InstrumentRuntime;
 use crate::render_status::RenderStatus;
@@ -13,7 +13,7 @@ use crate::tests::{attitude_state, unpack, write_state};
 fn failed_alt_state() -> AircraftState {
     let mut state = attitude_state();
     state.kinematics = Stamped {
-        data: Some(pilotage_instrument_state::Kinematics {
+        data: Some(indicate_instrument_state::Kinematics {
             pos_ned_m: [0.0, 0.0, -300.0],
             vel_ned_mps: [0.0; 3],
         }),
@@ -31,7 +31,7 @@ fn committed_scene_texts(rt: &InstrumentRuntime, len: usize) -> Vec<String> {
         .expect("valid scene")
         .map(|c| c.expect("valid command"))
         .filter_map(|c| match c {
-            pilotage_instrument_scene::Cmd::Text { text, .. } => Some(String::from(text)),
+            indicate_instrument_scene::Cmd::Text { text, .. } => Some(String::from(text)),
             _ => None,
         })
         .collect()

--- a/clients/web-instrument-shell/src/exports.rs
+++ b/clients/web-instrument-shell/src/exports.rs
@@ -4,18 +4,18 @@
 //! resource owns its buffers, configuration, and generations; this module has
 //! no process-global or thread-local mutable state.
 
-use pilotage_alerts::{
+use indicate_alerts::{
     AlertCondition, AlertContext, AlertEvent, AlertManager, AlertOutput, AlertProfile, AltFault,
     DynFault, ManagerHealth, NavFault,
 };
-use pilotage_instrument_registry::{ConfigBlob, PanelDrawError};
-use pilotage_instrument_scene::{LayerError, SceneError, SceneWriter, validate_layers};
-use pilotage_instrument_state::FreshnessPolicy;
-use pilotage_instrument_state::abi::v6::{self, AbiError};
-use pilotage_instrument_state::{NavSource, SignalStatus};
+use indicate_instrument_registry::{ConfigBlob, PanelDrawError};
+use indicate_instrument_scene::{LayerError, SceneError, SceneWriter, validate_layers};
+use indicate_instrument_state::FreshnessPolicy;
+use indicate_instrument_state::abi::v6::{self, AbiError};
+use indicate_instrument_state::{NavSource, SignalStatus};
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::panel_registry::{descriptor, registry, splice_v_speeds};
+use crate::panel_registry::{canonical_frame, descriptor, registry, splice_v_speeds};
 use crate::render_status::RenderStatus;
 
 pub(crate) const SCENE_CAPACITY: usize = 64 * 1024;
@@ -37,10 +37,10 @@ pub(crate) struct Runtime {
     /// tier entry/exit cannot chatter (ATT-01). Stepping twice per frame
     /// (PFD then HSI) is idempotent: the latches depend on the input
     /// magnitudes, not on step count.
-    pub(crate) unusual: pilotage_instrument_state::UnusualAttitudeState,
+    pub(crate) unusual: indicate_instrument_state::UnusualAttitudeState,
     /// Display thresholds; the simulator profile's numbers are benchmark
     /// data, not an aircraft approval.
-    pub(crate) profile: pilotage_instrument_state::AirframeDisplayProfile,
+    pub(crate) profile: indicate_instrument_state::AirframeDisplayProfile,
     /// The single alert state machine (ALR-01). Stepped once per
     /// [`InstrumentRuntime::step_alerts`] call; every panel render then
     /// consumes the one cached [`AlertOutput`], so the PFD and HSI can
@@ -56,7 +56,7 @@ pub(crate) struct Runtime {
 
 impl Runtime {
     fn new() -> Self {
-        let panels = registry().map_or(0, |registry| registry.panels().len());
+        let panels = registry().map_or(0, |registry| registry.panels().count());
         Self {
             state: vec![0u8; v6::CAPACITY],
             scene: vec![0u8; SCENE_CAPACITY],
@@ -64,8 +64,8 @@ impl Runtime {
             config: vec![Vec::new(); panels],
             unknown_groups: 0,
             extended_groups: 0,
-            unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-            profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
+            unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+            profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
             alerts: AlertManager::new(),
             alert_profile: AlertProfile::simulator(),
             alert_output: None,
@@ -174,7 +174,7 @@ pub(crate) fn render_into(runtime: &mut Runtime, panel: u32) -> RenderAttempt {
             return RenderAttempt::failure(RenderStatus::StateMalformed, generation);
         }
     };
-    let data = pilotage_instrument_state::resolve_stateful(
+    let data = indicate_instrument_state::resolve_stateful(
         &state,
         &FreshnessPolicy::default(),
         &runtime.profile,
@@ -189,7 +189,10 @@ pub(crate) fn render_into(runtime: &mut Runtime, panel: u32) -> RenderAttempt {
         Err(error) => return RenderAttempt::failure(scene_error_status(error), generation),
     };
     let alerts = runtime.alert_output.as_ref();
-    let len = match (panel_descriptor.draw)(&data, &config, alerts, &mut writer) {
+    // The same canonical frame the design-dimension exports publish, so
+    // the frame this scene is emitted at is the one the backend maps.
+    let frame = canonical_frame(panel_descriptor);
+    let len = match (panel_descriptor.draw)(&data, &config, alerts, frame, &mut writer) {
         Ok(()) => writer.finish(),
         Err(PanelDrawError::Scene(error)) => {
             return RenderAttempt::failure(scene_error_status(error), generation);
@@ -208,7 +211,7 @@ pub(crate) fn render_into(runtime: &mut Runtime, panel: u32) -> RenderAttempt {
 /// display of a lost primary never depends on the manager. Every
 /// condition is asserted or cleared each step; both operations are
 /// idempotent in the manager.
-fn derive_alert_events(data: &pilotage_instrument_state::PanelData) -> [AlertEvent; 3] {
+fn derive_alert_events(data: &indicate_instrument_state::PanelData) -> [AlertEvent; 3] {
     let cond = |active: bool, c: AlertCondition| {
         if active {
             AlertEvent::Assert(c)
@@ -304,7 +307,6 @@ impl InstrumentRuntime {
         let Some((index, panel)) = registry().and_then(|registry| {
             registry
                 .panels()
-                .iter()
                 .enumerate()
                 .find(|(_, panel)| panel.id == "pfd")
         }) else {
@@ -408,7 +410,7 @@ impl InstrumentRuntime {
                 return RenderStatus::StateMalformed as u64;
             }
         };
-        let data = pilotage_instrument_state::resolve_stateful(
+        let data = indicate_instrument_state::resolve_stateful(
             &state,
             &FreshnessPolicy::default(),
             &runtime.profile,
@@ -437,7 +439,7 @@ impl InstrumentRuntime {
     /// construction. A serialization failure returns an empty buffer,
     /// which no verifier accepts.
     pub fn glyph_manifest(&self) -> Vec<u8> {
-        let manifest = pilotage_instrument_glyphs::PANEL_GLYPHS;
+        let manifest = indicate_instrument_glyphs::PANEL_GLYPHS;
         let mut out = vec![0u8; manifest.canonical_len()];
         match manifest.write_canonical(&mut out) {
             Ok(len) => {
@@ -451,7 +453,7 @@ impl InstrumentRuntime {
     /// The compile-time-recorded glyph content hash the backend must
     /// match against both the canonical bytes and its own pinned value.
     pub fn glyph_recorded_hash(&self) -> Vec<u8> {
-        pilotage_instrument_glyphs::PANEL_GLYPHS
+        indicate_instrument_glyphs::PANEL_GLYPHS
             .recorded_hash()
             .to_vec()
     }

--- a/clients/web-instrument-shell/src/feeder_exports.rs
+++ b/clients/web-instrument-shell/src/feeder_exports.rs
@@ -3,16 +3,16 @@
 //! client script holds no wire- or measurement-interpreting logic
 //! (ADR-0029). The script wrappers keep only decode-shape validation
 //! and marshalling; every semantic judgement runs in
-//! `pilotage-instrument-feeder`, the same crate a native shell links.
+//! `indicate-instrument-feeder`, the same crate a native shell links.
 
-use pilotage_instrument_feeder::avionics::{
+use indicate_instrument_feeder::avionics::{
     AvionicsIngress, AvionicsSample, IncarnationPolicy, IngressConfig,
 };
-use pilotage_instrument_feeder::fc_state::{FcReport, FcStateTracker};
-use pilotage_instrument_feeder::nav_display::nav_display_state;
-use pilotage_instrument_feeder::nav_guidance::{Guidance, NavGuidanceTracker};
-use pilotage_instrument_feeder::turn::TurnDerivation;
-use pilotage_instrument_feeder::{RawStamp, StampFault};
+use indicate_instrument_feeder::fc_state::{FcReport, FcStateTracker};
+use indicate_instrument_feeder::nav_display::nav_display_state;
+use indicate_instrument_feeder::nav_guidance::{Guidance, NavGuidanceTracker};
+use indicate_instrument_feeder::turn::TurnDerivation;
+use indicate_instrument_feeder::{RawStamp, StampFault};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -241,7 +241,7 @@ pub fn feeder_stamp_fault(role: u8, clock: u8, integrity: u8, lane_role: u8) -> 
         acquired_at_ns: 0,
         clock,
     };
-    pilotage_instrument_feeder::stamp_fault_for_role(&probe, lane_role).map(|fault| {
+    indicate_instrument_feeder::stamp_fault_for_role(&probe, lane_role).map(|fault| {
         let (field, rule) = match fault {
             StampFault::RoleMismatch => ("role", "role-mismatch"),
             StampFault::IllegalClock => ("clock", "malformed"),

--- a/clients/web-instrument-shell/src/feeder_exports/feeder_shapes.rs
+++ b/clients/web-instrument-shell/src/feeder_exports/feeder_shapes.rs
@@ -2,8 +2,8 @@
 //! camelCase objects with BigInt u64s and 32-hex incarnations on the
 //! JavaScript side, wire-coded plain data on the Rust side.
 
-use pilotage_instrument_feeder::RawStamp;
-use pilotage_instrument_feeder::avionics::{
+use indicate_instrument_feeder::RawStamp;
+use indicate_instrument_feeder::avionics::{
     AttitudeGroup, AvionicsSample, Coherence, IngressCounters, IngressSnapshot, KinematicsGroup,
 };
 use serde::{Deserialize, Serialize};

--- a/clients/web-instrument-shell/src/feeder_exports/feeder_shapes/lanes.rs
+++ b/clients/web-instrument-shell/src/feeder_exports/feeder_shapes/lanes.rs
@@ -2,11 +2,11 @@
 //! declarations, FC-state reports and views, and navigation guidance in
 //! both directions across the script boundary.
 
-use pilotage_instrument_feeder::RawStamp;
-use pilotage_instrument_feeder::fc_state::{FcCommand, FcReport, FcView};
-use pilotage_instrument_feeder::nav_guidance::{Guidance, NavCounters, NavReject, NavSnapshot};
-use pilotage_instrument_feeder::turn::TurnDeclaration;
-use pilotage_instrument_state::{IdentStr, NavData, NavFromTo, NavSource, Stamped};
+use indicate_instrument_feeder::RawStamp;
+use indicate_instrument_feeder::fc_state::{FcCommand, FcReport, FcView};
+use indicate_instrument_feeder::nav_guidance::{Guidance, NavCounters, NavReject, NavSnapshot};
+use indicate_instrument_feeder::turn::TurnDeclaration;
+use indicate_instrument_state::{IdentStr, NavData, NavFromTo, NavSource, Stamped};
 use serde::{Deserialize, Serialize};
 
 use super::JsStamp;

--- a/clients/web-instrument-shell/src/lib.rs
+++ b/clients/web-instrument-shell/src/lib.rs
@@ -7,7 +7,7 @@
 //! 1. JS constructs [`InstrumentRuntime`], calls [`InstrumentRuntime::init`],
 //!    then queries its fixed state and scene buffer offsets.
 //! 2. Each frame, JS writes a packed
-//!    [`pilotage_instrument_state::abi`] state block into the state
+//!    [`indicate_instrument_state::abi`] state block into the state
 //!    buffer and calls [`InstrumentRuntime::render_result`] with a panel id.
 //! 3. The returned `u64` carries status in bits 0..7, scene length in
 //!    bits 8..31, and generation in bits 32..63. Status zero means the scene

--- a/clients/web-instrument-shell/src/panel_registry.rs
+++ b/clients/web-instrument-shell/src/panel_registry.rs
@@ -6,9 +6,9 @@
 //! mirroring shell constants. The surface is append-only, like every
 //! other wasm export here.
 
-use pilotage_instrument_panels::BUILTIN_PANELS;
-use pilotage_instrument_registry::{
-    BackgroundCapability, ConfigBlob, PanelDescriptor, Registry, keys,
+use indicate_instrument_panels::BUILTIN_PANELS;
+use indicate_instrument_registry::{
+    BackgroundCapability, ConfigBlob, DesignFrame, PanelDescriptor, Registry, keys,
 };
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -23,13 +23,28 @@ pub(crate) fn registry() -> Option<Registry> {
 }
 
 pub(crate) fn descriptor(panel: u32) -> Option<&'static PanelDescriptor> {
-    registry()?.panels().get(panel as usize)
+    registry()?.panels().nth(panel as usize)
+}
+
+/// The frame this shell requests for a panel: its first canonical frame,
+/// falling back to the floor for a descriptor that declares none. The
+/// canonical frames are where the digest, admission matrix, and raster
+/// baselines are pinned, so drawing at one keeps every emitted scene
+/// comparable with the recorded artefacts. The same value feeds the draw
+/// call and the design-dimension exports, so the frame the producer emits
+/// at and the frame the backend maps into pixels cannot diverge.
+pub(crate) fn canonical_frame(descriptor: &PanelDescriptor) -> DesignFrame {
+    descriptor
+        .canonical_frames
+        .first()
+        .copied()
+        .unwrap_or(descriptor.frame_min)
 }
 
 /// Number of composed panels.
 #[wasm_bindgen]
 pub fn panel_count() -> u32 {
-    registry().map_or(0, |registry| registry.panels().len() as u32)
+    registry().map_or(0, |registry| registry.panels().count() as u32)
 }
 
 /// Stable panel id (canvas ids and health keys derive from this), or
@@ -57,16 +72,20 @@ pub fn panel_required_groups(panel: u32) -> u32 {
     descriptor(panel).map_or(0, |d| d.required_groups.bits())
 }
 
-/// Design-frame width in logical units, or zero.
+/// Width of the frame this shell draws the panel at, in logical units,
+/// or zero. This is the same canonical frame the render path hands the
+/// panel's draw entry point, so the backend that sizes its canvas from
+/// this maps exactly the frame the scene was emitted at.
 #[wasm_bindgen]
 pub fn panel_design_width(panel: u32) -> f32 {
-    descriptor(panel).map_or(0.0, |d| d.design_frame.width)
+    descriptor(panel).map_or(0.0, |d| canonical_frame(d).width)
 }
 
-/// Design-frame height in logical units, or zero.
+/// Height of the frame this shell draws the panel at, in logical units,
+/// or zero.
 #[wasm_bindgen]
 pub fn panel_design_height(panel: u32) -> f32 {
-    descriptor(panel).map_or(0.0, |d| d.design_frame.height)
+    descriptor(panel).map_or(0.0, |d| canonical_frame(d).height)
 }
 
 /// Background capability code: 0 not-used, 1 opaque, 2 cedeable;
@@ -90,8 +109,8 @@ pub fn scene_digest_hex() -> String {
     let Some(registry) = registry() else {
         return String::new();
     };
-    let mut scratch = vec![0u8; pilotage_instrument_scene::MAX_SCENE_BYTES];
-    match pilotage_instrument_registry::scene_digest(&registry, &mut scratch) {
+    let mut scratch = vec![0u8; indicate_instrument_scene::MAX_SCENE_BYTES];
+    match indicate_instrument_registry::scene_digest(&registry, &mut scratch) {
         Ok(digest) => {
             const HEX: &[u8; 16] = b"0123456789abcdef";
             let mut out = String::with_capacity(64);
@@ -113,7 +132,7 @@ pub fn scene_digest_hex() -> String {
 /// grows a key can never be silently dropped by this splice.
 pub(crate) fn splice_v_speeds(
     blob: &[u8],
-    schema: &[pilotage_instrument_registry::ConfigKey],
+    schema: &[indicate_instrument_registry::ConfigKey],
     payload: Option<[u8; 20]>,
 ) -> Option<Vec<u8>> {
     let parsed = ConfigBlob::parse(blob).ok()?;

--- a/clients/web-instrument-shell/src/panel_registry/tests.rs
+++ b/clients/web-instrument-shell/src/panel_registry/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_instrument_panels::PFD_CONFIG_SCHEMA;
-use pilotage_instrument_registry::keys;
+use indicate_instrument_panels::PFD_CONFIG_SCHEMA;
+use indicate_instrument_registry::keys;
 
 use super::splice_v_speeds;
 

--- a/clients/web-instrument-shell/src/tests.rs
+++ b/clients/web-instrument-shell/src/tests.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_instrument_scene::{
+use indicate_instrument_scene::{
     LayerId, MAX_LAYER_COMMANDS, MAX_SCENE_BYTES, SceneCmds, SceneWriter,
 };
-use pilotage_instrument_state::abi::v6::{CAPACITY, VERSION, encode_state};
-use pilotage_instrument_state::{AircraftState, Attitude, Quat, Stamped};
+use indicate_instrument_state::abi::v6::{CAPACITY, VERSION, encode_state};
+use indicate_instrument_state::{AircraftState, Attitude, Quat, Stamped};
 
 use super::{InstrumentRuntime, RenderStatus, abi_version};
 use crate::exports::{
@@ -40,8 +40,8 @@ pub(crate) fn attitude_state() -> AircraftState {
             }),
             age_ms: Some(10.0),
         },
-        quality: pilotage_instrument_state::EstimateQuality::Good,
-        valid: pilotage_instrument_state::ValidFlags {
+        quality: indicate_instrument_state::EstimateQuality::Good,
+        valid: indicate_instrument_state::ValidFlags {
             attitude: true,
             rates: true,
             position: true,
@@ -98,10 +98,10 @@ fn scene_runtime(scene: &[u8]) -> Runtime {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     }
 }
@@ -245,10 +245,10 @@ fn a_non_canonical_state_frame_fails_malformed() {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     };
     assert_attempt(
@@ -268,10 +268,10 @@ fn render_into_reports_buffer_and_truncation_failures() {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     };
     assert_attempt(
@@ -290,10 +290,10 @@ fn render_into_reports_buffer_and_truncation_failures() {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     };
     assert_attempt(
@@ -310,10 +310,10 @@ fn render_into_reports_buffer_and_truncation_failures() {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     };
     assert_attempt(render_into(&mut valid, 2), RenderStatus::InvalidPanel, 0, 0);
@@ -333,10 +333,10 @@ fn malformed_scene_never_advances_or_commits_length() {
         config: vec![Vec::new(); 2],
         unknown_groups: 0,
         extended_groups: 0,
-        unusual: pilotage_instrument_state::UnusualAttitudeState::default(),
-        profile: pilotage_instrument_state::AirframeDisplayProfile::simulator(),
-        alerts: pilotage_alerts::AlertManager::new(),
-        alert_profile: pilotage_alerts::AlertProfile::simulator(),
+        unusual: indicate_instrument_state::UnusualAttitudeState::default(),
+        profile: indicate_instrument_state::AirframeDisplayProfile::simulator(),
+        alerts: indicate_alerts::AlertManager::new(),
+        alert_profile: indicate_alerts::AlertProfile::simulator(),
         alert_output: None,
     };
     assert_attempt(
@@ -350,7 +350,7 @@ fn malformed_scene_never_advances_or_commits_length() {
 
 #[test]
 fn every_encode_error_maps_to_its_own_status() {
-    use pilotage_instrument_scene::SceneError;
+    use indicate_instrument_scene::SceneError;
 
     use crate::exports::scene_error_status;
     use crate::render_status::RenderStatus;
@@ -473,7 +473,7 @@ fn malformed_scene_framing_gates_visible_commit() {
 
 #[test]
 fn glyph_exports_surface_the_verified_pack() {
-    use pilotage_instrument_glyphs::PANEL_GLYPHS;
+    use indicate_instrument_glyphs::PANEL_GLYPHS;
 
     use crate::exports::InstrumentRuntime;
 

--- a/clients/web/instruments.js
+++ b/clients/web/instruments.js
@@ -2,7 +2,7 @@
 //
 // Loads the pilotage-instruments-web WASM module (built by
 // scripts/build-web-instruments.sh), writes packed aircraft state into its
-// linear memory (mirroring pilotage-instrument-state/src/abi.rs exactly),
+// linear memory (mirroring indicate-instrument-state/src/abi.rs exactly),
 // and interprets the returned scene-command bytes onto a Canvas2D.
 //
 // Rendering is transactional: a frame reaches the visible canvas
@@ -76,7 +76,7 @@ const REQUIRED_RUNTIME_METHODS = [
 // pattern) so wasm-target divergence from the host-verified contract
 // fails the suite, not just a Rust unit test.
 export const EXPECTED_SCENE_DIGEST =
-  "bd85b8537f0b3e4abf8cf3ad3d36c6abfdceac15355639af2804d58dd9c61931";
+  "3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca";
 
 // Registry enumeration exported at module level by the bindings; the
 // backend derives its panel map from these instead of mirroring one.

--- a/clients/web/nav-display.js
+++ b/clients/web/nav-display.js
@@ -1,6 +1,6 @@
 // The client's navigation display profile (ADR-0031) — a thin wrapper
 // over the shared feeder core (#252). The one meters-to-dots conversion
-// runs in pilotage-instrument-feeder via the instrument wasm build; the
+// runs in indicate-instrument-feeder via the instrument wasm build; the
 // constants are mirrored here for consumers that size expectations, and
 // the wrapper restores the instrument model's NaN coding for an
 // unconstrained vertical profile.

--- a/clients/web/scene-conformance.test.mjs
+++ b/clients/web/scene-conformance.test.mjs
@@ -2,7 +2,7 @@
 //
 // Run: node clients/web/scene-conformance.test.mjs
 //
-// The reference rasterizer (pilotage-instrument-raster) authors
+// The reference rasterizer (indicate-instrument-raster) authors
 // the IR crate's corpus/scene-conformance-corpus.json: for each case
 // it pins the reference verdict,
 // typed failure class, unknown-opcode count, layer-gate results, and a
@@ -121,7 +121,7 @@ function q(v) {
 
 const MODE_LETTERS = { 1: "F", 2: "S", 3: "FS" };
 
-// A wire decoder mirroring pilotage-instrument-scene's SceneCmds/decode_payload:
+// A wire decoder mirroring indicate-instrument-scene's SceneCmds/decode_payload:
 // known-opcode payloads are shape-validated (a hard BadPayload), unknown opcodes
 // are skipped by length. Returns { ok, error, trace } where trace matches the
 // reference command trace exactly.
@@ -331,7 +331,7 @@ const EXPECTED_CORPUS_SHA256 =
 const golden = JSON.parse(
   readFileSync(
     join(
-      crateDir("pilotage-instrument-scene"),
+      crateDir("indicate-instrument-scene"),
       "corpus",
       "scene-conformance-corpus.json",
     ),
@@ -360,6 +360,15 @@ check(
 );
 
 const entries = golden.entries.map((e) => ({ entry: e, bytes: entryBytes(e) }));
+
+// The gate-accept census is pinned alongside the corpus identity: a corpus
+// edit that flips a verdict (or adds a case, as frame-edge-overhang did in
+// v4) must move this count consciously, with the interpreter re-verified —
+// the count is read off the golden, never adjusted to make a run green.
+check(
+  "corpus v4 carries 26 gate-accepted cases",
+  golden.entries.filter((e) => e.gate.verdict === "accept").length === 26,
+);
 
 // Corpus hash drift guard: both backends recompute it from the reconstructed
 // bytes, so a Rust/JS generator divergence would surface here.

--- a/clients/web/state-abi.js
+++ b/clients/web/state-abi.js
@@ -1,5 +1,5 @@
 // State-frame ABI v6 writer: the JS side of the tagged-group contract in
-// the pilotage-instrument-state crate's abi/v6.rs (pinned upstream).
+// the indicate-instrument-state crate's abi/v6.rs (pinned upstream).
 //
 // The frame is self-delimiting: [version u8][group count u8] then, per
 // present group in strictly ascending tag order, [tag u8][payload length

--- a/clients/web/state-abi.test.mjs
+++ b/clients/web/state-abi.test.mjs
@@ -2,7 +2,7 @@
 //
 // Run: node clients/web/state-abi.test.mjs
 //
-// The committed golden frames in the pilotage-instrument-state crate's
+// The committed golden frames in the indicate-instrument-state crate's
 // fixtures/ directory (the codec owner's own tree, so they travel with
 // the crate and arrive here at the pinned upstream rev) are generated
 // by the upstream `cargo xtask gen-state-fixture` from the shared Rust
@@ -28,7 +28,7 @@ function check(name, cond) {
 }
 
 function goldenHex(stem) {
-  const path = join(crateDir("pilotage-instrument-state"), "fixtures", `${stem}.hex`);
+  const path = join(crateDir("indicate-instrument-state"), "fixtures", `${stem}.hex`);
   return readFileSync(path, "utf8").trim();
 }
 

--- a/clients/web/telemetry-ingress.js
+++ b/clients/web/telemetry-ingress.js
@@ -3,7 +3,7 @@
 // freshness advances only when a source group presents a new
 // epoch/sequence. Every semantic judgement (identity pinning,
 // incarnation policy, wrap-safe ordering, coherence, the fail-closed
-// authorization regimes) runs in pilotage-instrument-feeder via the
+// authorization regimes) runs in indicate-instrument-feeder via the
 // instrument wasm build; this module keeps decode-shape validation of
 // the script's own object dialect, marshalling, and the constructor
 // contracts its consumers rely on.

--- a/clients/web/turn-derivation.js
+++ b/clients/web/turn-derivation.js
@@ -1,7 +1,7 @@
 // Measurement-coherent turn-rate derivation (DYN-01) — a thin wrapper
 // over the shared feeder core (#252). The semantics (stream identity,
 // wrap-safe ordering, dt bounds, circular differencing) run in
-// pilotage-instrument-feeder via the instrument wasm build; this module
+// indicate-instrument-feeder via the instrument wasm build; this module
 // keeps only the script-side stamp dialect (string clock names) and
 // marshalling.
 

--- a/crates/pilotage-adapter-api/Cargo.toml
+++ b/crates/pilotage-adapter-api/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 pilotage-ingress = { workspace = true }
 pilotage-protocol = { workspace = true }
 pilotage-timing = { workspace = true }
-pilotage-frames = { workspace = true }
+indicate-frames = { workspace = true }
 pilotage-calibration-id = { workspace = true }
 # CAL-01 (#90): the camera calibration contract now lives in its own no_std
 # crate; adapter-api re-exports it so consumer paths are unchanged.

--- a/crates/pilotage-camera-calibration/Cargo.toml
+++ b/crates/pilotage-camera-calibration/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-pilotage-frames = { workspace = true }
+indicate-frames = { workspace = true }
 pilotage-calibration-id = { workspace = true }
 libm = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pilotage-camera-calibration/src/calibration.rs
+++ b/crates/pilotage-camera-calibration/src/calibration.rs
@@ -34,7 +34,7 @@ mod sim;
 mod validate;
 mod verified;
 
-use pilotage_frames::Quat;
+use indicate_frames::Quat;
 
 pub use budget::{AlignmentAllowances, AlignmentErrorBudget, derive_budget, radians_per_pixel};
 pub use canonical::{

--- a/crates/pilotage-camera-calibration/src/calibration/geometry.rs
+++ b/crates/pilotage-camera-calibration/src/calibration/geometry.rs
@@ -8,7 +8,7 @@
 //! distinction; the types here keep every unit and coordinate frame explicit
 //! (`_px` pixels, `_m` meters, `_rad` radians) so nothing is implied.
 
-use pilotage_frames::FrameId;
+use indicate_frames::FrameId;
 
 /// The optical coordinate convention a camera's projection is expressed in.
 ///

--- a/crates/pilotage-camera-calibration/src/calibration/sim.rs
+++ b/crates/pilotage-camera-calibration/src/calibration/sim.rs
@@ -17,7 +17,7 @@ use super::identity::{
     Residuals, ToolVersion, ValidityStatus,
 };
 use super::recovery::recovery_report;
-use pilotage_frames::FrameId;
+use indicate_frames::FrameId;
 
 /// The FPV camera's physical id, matching the Gazebo bridge `camera_id` for the
 /// onboard camera and the calibration id the artifact publishes.

--- a/crates/pilotage-camera-calibration/src/calibration/tests.rs
+++ b/crates/pilotage-camera-calibration/src/calibration/tests.rs
@@ -1,7 +1,7 @@
 //! Verification tests for the calibration contract.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_frames::FrameId;
+use indicate_frames::FrameId;
 
 use super::CameraCalibration;
 use super::error::CalibrationError;

--- a/crates/pilotage-camera-calibration/src/calibration/validate.rs
+++ b/crates/pilotage-camera-calibration/src/calibration/validate.rs
@@ -9,7 +9,7 @@
 //! reason, never clamping or repairing. It runs from [`super::verify`] and is
 //! mirrored by the browser admission path in `clients/web/calibration.js`.
 
-use pilotage_frames::FrameId;
+use indicate_frames::FrameId;
 
 use super::CameraCalibration;
 use super::budget::AlignmentAllowances;

--- a/crates/pilotage-camera-calibration/src/calibration/verified.rs
+++ b/crates/pilotage-camera-calibration/src/calibration/verified.rs
@@ -10,8 +10,8 @@
 //! reconstructs its own calibration reference from [`Self::calibration_id`] and
 //! [`Self::content_hash`], so this crate does not depend on the projector.
 
+use indicate_frames::Quat;
 use pilotage_calibration_id::CalibrationId;
-use pilotage_frames::Quat;
 
 /// The resolved geometry of a verified calibration: its identity and content
 /// hash, the body→camera rotation, the field-of-view half-tangents, and the

--- a/crates/pilotage-geo/Cargo.toml
+++ b/crates/pilotage-geo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-pilotage-frames = { workspace = true }
+indicate-frames = { workspace = true }
 pilotage-calibration-id = { workspace = true }
 # HUD-03 (#38): the conformal projector consumes the unforgeable VerifiedCameraModel
 # minted only by CAL-01's verified path. Acyclic: camera-calibration does not

--- a/crates/pilotage-geo/src/abi.rs
+++ b/crates/pilotage-geo/src/abi.rs
@@ -17,7 +17,7 @@
 //! read. [`encode_frame`] serializes only a [`ValidatedSvsFrame`], so an invalid
 //! frame cannot be encoded, and it is allocation-free.
 
-use pilotage_frames::Epoch;
+use indicate_frames::Epoch;
 
 use crate::availability::{
     AvailabilityProfile, ExternalHealth, SvsAvailability, SvsInputs, derive_inputs,

--- a/crates/pilotage-geo/src/abi/codec.rs
+++ b/crates/pilotage-geo/src/abi/codec.rs
@@ -2,7 +2,7 @@
 //! panic-free. This is the byte layer only; the frame types and the public
 //! [`encode`]/[`decode`] entry points live in the parent module.
 
-use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+use indicate_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
 use crate::availability::{AvailabilityProfile, ExternalHealth, InputHealth};
 use crate::datum::{

--- a/crates/pilotage-geo/src/abi/tests.rs
+++ b/crates/pilotage-geo/src/abi/tests.rs
@@ -3,7 +3,7 @@
 //! that an untrusted or incoherent input can never yield an available scene.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+use indicate_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
 use super::{
     ABI_VERSION, RawSvsFrame, SVS_FRAME_LEN, ValidatedSvsFrame, decode_frame, encode_frame,

--- a/crates/pilotage-geo/src/availability.rs
+++ b/crates/pilotage-geo/src/availability.rs
@@ -11,7 +11,7 @@
 //! coverage, renderer) are producer-stated ([`ExternalHealth`]). An untrusted
 //! reading can never produce an [`SvsAvailability::Available`] scene.
 
-use pilotage_frames::Epoch;
+use indicate_frames::Epoch;
 
 use crate::identity::{IntegrityLevel, PositionQuality, StatedAttitude, StatedPosition};
 

--- a/crates/pilotage-geo/src/availability/tests.rs
+++ b/crates/pilotage-geo/src/availability/tests.rs
@@ -121,7 +121,7 @@ fn availability_reason_wire_codes_round_trip_and_reject_unknown() {
 
 // ---- derivation from validated inputs --------------------------------------
 
-use pilotage_frames::{ClockDomain, Epoch, Quat, TimeScale};
+use indicate_frames::{ClockDomain, Epoch, Quat, TimeScale};
 
 use super::{
     AvailabilityProfile, AvailabilityProfileId, ExternalHealth, derive_inputs,

--- a/crates/pilotage-geo/src/conformal.rs
+++ b/crates/pilotage-geo/src/conformal.rs
@@ -33,7 +33,7 @@
 //!
 //! SIM / NOT FOR FLIGHT.
 
-use pilotage_frames::{AngularVelocity, Epoch, FrameId, ROTATION_NORM_TOLERANCE, Velocity};
+use indicate_frames::{AngularVelocity, Epoch, FrameId, ROTATION_NORM_TOLERANCE, Velocity};
 
 use crate::availability::{
     AvailabilityProfile, ExternalHealth, SvsAvailability, derive_inputs, health_from_integrity,

--- a/crates/pilotage-geo/src/conformal/interp.rs
+++ b/crates/pilotage-geo/src/conformal/interp.rs
@@ -15,7 +15,7 @@
 //! the error budget) and its coherent identity. Re-deriving a value nothing reads
 //! would add antimeridian and datum-realization edge cases for no consumer.
 
-use pilotage_frames::Quat;
+use indicate_frames::Quat;
 
 use super::KinematicSample;
 

--- a/crates/pilotage-geo/src/conformal/project.rs
+++ b/crates/pilotage-geo/src/conformal/project.rs
@@ -47,8 +47,8 @@
 //! whose calibration does not match the [`crate::ProjectionView`]'s, so there is
 //! no path to a registered scene without a genuinely verified calibration.
 
+use indicate_frames::{Quat, ROTATION_NORM_TOLERANCE};
 use pilotage_camera_calibration::VerifiedCameraModel;
-use pilotage_frames::{Quat, ROTATION_NORM_TOLERANCE};
 
 use super::policy::ConformalError;
 use crate::view::{CalibrationRef, NearFarPolicy};

--- a/crates/pilotage-geo/src/conformal/tests.rs
+++ b/crates/pilotage-geo/src/conformal/tests.rs
@@ -15,7 +15,7 @@ mod kinematics;
 mod projection;
 mod verdict;
 
-use pilotage_frames::{ClockDomain, Epoch, FrameId, Quat, Tagged, TimeScale};
+use indicate_frames::{ClockDomain, Epoch, FrameId, Quat, Tagged, TimeScale};
 
 use pilotage_camera_calibration::{
     SIM_FPV_CALIBRATION_HASH, SIM_FPV_CALIBRATION_ID, VerifiedCameraModel, sim_fpv_calibration,

--- a/crates/pilotage-geo/src/conformal/tests/kinematics.rs
+++ b/crates/pilotage-geo/src/conformal/tests/kinematics.rs
@@ -9,7 +9,7 @@
 
 use super::*;
 
-use pilotage_frames::FrameId;
+use indicate_frames::FrameId;
 
 use crate::availability::AvailabilityReason;
 use crate::identity::IntegrityLevel;

--- a/crates/pilotage-geo/src/datum.rs
+++ b/crates/pilotage-geo/src/datum.rs
@@ -12,7 +12,7 @@
 //!
 //! # Mapping to instrument-state `AltitudeClass`
 //!
-//! This crate is foundational and `pilotage-instrument-state` is a consumer, so
+//! This crate is foundational and `indicate-instrument-state` is a consumer, so
 //! it cannot depend on this crate's inverse; the vertical vocabulary is minted
 //! here with an explicit mapping instead of a dependency:
 //!

--- a/crates/pilotage-geo/src/identity.rs
+++ b/crates/pilotage-geo/src/identity.rs
@@ -27,7 +27,7 @@
 //! silently-inferred difference, and a future sample is a typed refusal, never a
 //! saturated zero.
 
-use pilotage_frames::{Epoch, Quat};
+use indicate_frames::{Epoch, Quat};
 
 use crate::datum::GeodeticPosition;
 use crate::error::AgeError;
@@ -204,7 +204,7 @@ pub struct StatedPosition {
 
 /// A vehicle attitude with its identity stamp and angular accuracy. The attitude
 /// rotates body directions to the local navigation frame; the frame pairing is
-/// a `pilotage-frames` concern the consumer applies, never implied here.
+/// a `indicate-frames` concern the consumer applies, never implied here.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StatedAttitude {
     /// Body → local-navigation rotation.

--- a/crates/pilotage-geo/src/identity/tests.rs
+++ b/crates/pilotage-geo/src/identity/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for source identity, typed age, and coherent-snapshot binding.
 #![allow(clippy::expect_used, clippy::panic)]
 
-use pilotage_frames::{ClockDomain, Epoch, TimeScale};
+use indicate_frames::{ClockDomain, Epoch, TimeScale};
 
 use super::{CoherentSnapshot, IntegrityLevel, SourceIncarnation, SourceStamp};
 use crate::error::AgeError;

--- a/crates/pilotage-geo/src/lib.rs
+++ b/crates/pilotage-geo/src/lib.rs
@@ -19,8 +19,8 @@
 //! # Consumed vocabularies
 //!
 //! Reference frames, clock domains, time scales, epochs, and rotations come
-//! from `pilotage-frames` ([`pilotage_frames::FrameId`],
-//! [`pilotage_frames::Epoch`], [`pilotage_frames::Quat`]); source identity
+//! from `indicate-frames` ([`indicate_frames::FrameId`],
+//! [`indicate_frames::Epoch`], [`indicate_frames::Quat`]); source identity
 //! reuses the AV-01 `MeasurementStamp` shape ([`identity`] documents the
 //! mapping). The vertical-datum vocabulary parallels instrument-state's
 //! `AltitudeClass` with a documented mapping ([`datum`]) rather than a

--- a/docs/adr/0017-instrument-display-runtime.md
+++ b/docs/adr/0017-instrument-display-runtime.md
@@ -57,9 +57,9 @@ into instrument state, and it is the only place the two vocabularies meet.
 
 | Crate | Owns |
 |---|---|
-| `pilotage-instrument-state` | Unified aircraft/nav/selection state, per-signal validity, unit conversions, quaternion→attitude derivations |
-| `pilotage-instrument-scene` | The draw-command IR: command enum, fixed-capacity encoder/decoder over caller-provided buffers, versioned little-endian binary encoding |
-| `pilotage-instrument-panels` | The instruments: PFD, HSI, six-pack as pure functions `(state, layout) → scene commands` |
+| `indicate-instrument-state` | Unified aircraft/nav/selection state, per-signal validity, unit conversions, quaternion→attitude derivations |
+| `indicate-instrument-scene` | The draw-command IR: command enum, fixed-capacity encoder/decoder over caller-provided buffers, versioned little-endian binary encoding |
+| `indicate-instrument-panels` | The instruments: PFD, HSI, six-pack as pure functions `(state, layout) → scene commands` |
 
 These are the workspace's first strictly `#![no_std]` crates (existing core
 crates are IO-free but assume alloc). They use `f32` and `libm` only, no
@@ -157,7 +157,7 @@ claim). The byte-level contract is specified in the
   markers themselves.
 - Frames are bounded: per-layer command count, graphics-state stack depth,
   and scene byte budgets are compile-time constants in
-  `pilotage-instrument-scene::layer`. `validate_layers` enforces these with
+  `indicate-instrument-scene::layer`. `validate_layers` enforces these with
   the duplicate, ordering, nesting, state-isolation, and framing rules.
 - Version policy: unknown *opcodes* inside a layer remain counted skips;
   an unknown *layer id* fails the whole frame, because content whose

--- a/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
+++ b/docs/adr/0018-avionics-telemetry-and-aviate-adapter.md
@@ -90,7 +90,7 @@ missing data.
 
 The wire stays raw because derivation is display policy: barometric-style
 altitude (−z), vertical speed (−vz), groundspeed (√(vx²+vy²)), and
-Euler attitude all derive in `pilotage-instrument-state`, where they are unit
+Euler attitude all derive in `indicate-instrument-state`, where they are unit
 tests in a `no_std` crate rather than per-host arithmetic. A host that
 forwards the estimate untouched cannot skew it.
 

--- a/docs/adr/0021-simulator-camera-calibration-contract.md
+++ b/docs/adr/0021-simulator-camera-calibration-contract.md
@@ -34,7 +34,7 @@ would be a safety-relevant category error.
   validity status). It lives in `pilotage-adapter-api::calibration`.
 
 - **Every unit and frame is explicit.** Field names carry units (`_px`, `_m`,
-  `_rad`); the extrinsics name both frames using the `pilotage-frames`
+  `_rad`); the extrinsics name both frames using the `indicate-frames`
   vocabulary (`FrameId::Body` → `FrameId::Installation`, the sensor mount) and
   never invent a frame; the optical convention (OpenCV: `+Z` forward, `+X`
   right, `+Y` down) is a stored enum, not an assumption; a units marker is

--- a/docs/adr/0033-panel-registry-config-and-digest.md
+++ b/docs/adr/0033-panel-registry-config-and-digest.md
@@ -17,7 +17,7 @@ v6; absence resolves Missing by construction).
 ## Decision
 
 - **The registry is plain data composed by each shell.** A
-  `PanelDescriptor` (in `pilotage-instrument-registry`) carries
+  `PanelDescriptor` (in `indicate-instrument-registry`) carries
   identity, title, required layers, required state groups, design
   frame, background capability, config schema, honest-status group
   regions, panel-contributed extreme states, the pinned raster

--- a/docs/adr/0034-extraction-boundary.md
+++ b/docs/adr/0034-extraction-boundary.md
@@ -35,14 +35,14 @@ A panel is authored in the logical frame its descriptor declares
 ## Decision 2 — artifact ownership at the boundary
 
 - The scene-conformance corpus lives with the IR that defines its
-  vocabulary: `crates/pilotage-instrument-scene/corpus/`. The
+  vocabulary: `crates/indicate-instrument-scene/corpus/`. The
   reference rasterizer reads it as a sibling crate; the browser suite
   reads into the crate tree and pins `corpusSha256`, so a corpus edit
   reddens every consumer — that pin is the cross-repo sync mechanism,
   and the first post-extraction corpus change must be watched through
   it (ready-when check 2).
 - The REN-04 timing artifact lives with the crate whose tests consume
-  it: `crates/pilotage-instrument-raster/evidence/`.
+  it: `crates/indicate-instrument-raster/evidence/`.
 - `docs/instruments/evidence-graph.evg` and its artifacts travel WITH
   the panels at extraction: its locators point into the closure and
   into the instruments docs that travel with it, and a

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -189,7 +189,7 @@ check_safety_palette_aliases() {
     while IFS= read -r file; do
         is_excluded_path "$file" && continue
         if grep -Eq 'palette::(RED|AMBER|YELLOW|BAND_YELLOW)\b' "$file"; then
-            echo "FORBIDDEN: $file references a safety palette alias; use the safety:: constants outside pilotage-instrument-symbology" >&2
+            echo "FORBIDDEN: $file references a safety palette alias; use the safety:: constants outside indicate-instrument-symbology" >&2
             status=1
         fi
     done < <(collect_rs_files)


### PR DESCRIPTION
Closes #319.

The eight upstream pins move `045ccc9` → `14e9a759` (v0.2.0) in one step, crossing the crate-family rename. Every dependency declaration, `use`, doc mention, and the evidence-gate install now say `indicate-*`; nothing in the tree says `pilotage-instrument-*` / `pilotage_instrument_*` anymore.

## API adaptation (issue steps 3–5, 7)

- **`DrawFn` gains a `DesignFrame`.** The shell requests each panel's **first canonical frame** (falling back to `frame_min`, which every canonical set must contain) via one helper, `panel_registry::canonical_frame`. The same value feeds the draw call **and** the `panel_design_width/height` exports, so the frame the producer emits at and the frame the backend maps into pixels cannot diverge — "ask for the frame and map with the same one" holds structurally, not by convention.
- **No frame-acceptance predicate** (step 6 skipped per the issue follow-up): the shell only ever requests a canonical frame, so no predicate is needed, and writing one here would recreate exactly the divergence luofang34/Indicate#31 exists to eliminate. Descriptor field fallout (`design_frame` → `frame_min`/`frame_max`/`canonical_frames`/`raster_baselines`) is absorbed by the same helper.
- **`Panels` is its own iterator**: `.len()`/`.get()`/`.iter()` become `.count()`/`.nth()`/plain iteration.
- Step 2 is obsolete (Indicate is public; cold fetch verified below with no environment variable and no `.cargo/config.toml`). No pin-consistency check format is invented here — that waits for luofang34/Indicate#33. Indicate#30 is deliberately not waited for: the rename, `DrawFn`, and descriptor moves happen once regardless; #30 is additive work on top.

## The digest story (steps 8–9)

**Moved, deliberately:** the pinned composition digest (`EXPECTED_SCENE_DIGEST`, checked against the wasm's own `scene_digest_hex()` export) moves `bd85b853…` → `3efb08c5…`, which is v0.2.0's value as pinned upstream in its CHANGELOG and `descriptors.rs`. It moves because the digest hashes descriptor **contract fields** whose shape changed (the frame-range vocabulary) — a deliberate upstream contract change, not a paint change.

**Not moved — the proof this is a pure API migration:**
- Corpus v4 identity: byte-identical between 045ccc9 and v0.2.0 (`corpusVersion` 4, sha `1fb8e6de…`; only the corpus file's `generatedBy` string was renamed upstream). The pinned literals do not move.
- The glyph pack hash `281eef62…`: present unchanged at both revs.
- The upstream raster baselines (reference-rasterizer pixel hashes): identical at 045ccc9 and v0.2.0.
- avionics-link's rendered-scene fingerprint: untouched by anything here.

**New check (step 8's landing):** `scene-conformance.test.mjs` now pins the corpus **gate-accept census — 26** — read off the golden (v3 carried 25; `frame-edge-overhang` is a valid scene). A future corpus edit that flips a verdict must move that literal consciously alongside the version/sha pins.

The JS-mirrored state ABI version is verified against `abi::v6::VERSION` as read from the crate: the wasm exports `abi_version()` from the crate constant and `load()` refuses a mismatch; the suites drive that check against the real artifact.

## CI workflows

Indicate is public, so its deploy key, host alias, and `insteadOf` rewrite leave both workflows (the step-2-obsolete fallout). Navigate keeps its key and the git-CLI fetch env. The evidence gate installs `indicate-evidence` at the same rev the workspace pins (binary is still `evidence-gate`).

## Verification (isolated worktree of this branch, not the blended workspace)

- Cold fetch: cleared `~/.cargo/git/db/indicate-*`, ran `cargo fetch` with `CARGO_NET_GIT_FETCH_WITH_CLI` explicitly unset — succeeds.
- Old-name grep over every tracked file and the full tree: zero hits.
- Full gate battery, all passing: fmt / clippy `-D warnings` / test `--all-targets` (1199 tests) / doc `-D missing_docs -D broken_intra_doc_links` / release build / structure + certification guards / no_std thumbv7em / protocol-free tree check / wasm build / all 41 node suites including the four real-browser ones.
- Evidence gate, run with `indicate-evidence` installed at this PR's pin: both HARD `--require-resolvable` runs **pass**. The four advisory invocations (`--trace`, `--resolve-selectors` on both graphs) report `INVALID — review 'pending'`: that is the pre-existing honest-PENDING review state (both traces resolve forward and backward; the graphs are untouched by this PR and carry the same digests as main), and those steps are `continue-on-error` in CI by design — a pending review must never block a merge.
- Browser conformance replays corpus v4: 43 cases, 0 typed divergences, 26 gate-accepted.
- `instruments.test.mjs`: "the wasm build reproduces the pinned scene digest" — the export equals the literal equals v0.2.0's value.

## Scope note

The extraction checklist and the INST-01 tracking issue moved to where the code lives: luofang34/Pilotage#262 → luofang34/Indicate#35, luofang34/Pilotage#268 → luofang34/Indicate#36.

Merge only after independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
