### PR TITLE
ARCH-INST-01: Define the Apple instrument composition boundary

### DIFF
--- a/docs/adr/0032-ipad-native-client-shared-cores.md
+++ b/docs/adr/0032-ipad-native-client-shared-cores.md
@@ -1,85 +1,145 @@
-# ADR-0032: The iPad client is a thin native shell over the same Rust cores the web client runs as wasm
+# ADR-0032: The Apple instrument composition boundary — Indicate owns the contract, the shells stay thin
 
-- Status: Proposed
-- Date: 2026-07-29
+- Status: Accepted
+- Date: 2026-08-08 (revises the 2026-07-29 record)
+- Tracking issue: [ARCH-INST-01](https://github.com/luofang34/Pilotage/issues/322)
 
 ## Context
 
-The client must serve iPadOS natively — EFB preflight with no host at
-all, and the full control terminal against a host — as one codebase
-posture-switched by discovery ([ADR-0026](0026-host-capability-profiles.md)).
-The architecture already forbids the trap that makes native ports
-expensive: no business rule or wire-level state machine may live only in
-one platform layer ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)),
-panels are pure state→scene functions over a versioned scene-command IR
-with two conformance-checked backends ([ADR-0017](0017-instrument-display-runtime.md),
-[ADR-0029](0029-panel-layout-look-plugins.md)), and the instrument crate
-family is `no_std`. Communicate's crates are proven
-`aarch64-apple-ios`-clean with a uniffi FFI surface designed for exactly
-this embedding. The known debt is the web client's JS-only feeder logic
-(telemetry ingress gating, derivations), which [ADR-0029](0029-panel-layout-look-plugins.md)
-already commits to moving behind the shared core boundary.
+The client must serve iPadOS natively. It must run EFB preflight with no
+host. It must run the full control terminal against a host. One codebase
+switches posture by discovery ([ADR-0026](0026-host-capability-profiles.md)).
 
-This record sets the design envelope; implementation is deferred.
+The instrument family now lives in the Indicate repository
+([ADR-0034](0034-extraction-boundary.md)). ADR-0035 assigns the ownership:
+Indicate owns the instrument state contracts, the panel sets, the scene
+contracts, the registry, and the admission tests. A Swift CoreGraphics scene
+interpreter exists and passes the scene conformance corpus
+([#255](https://github.com/luofang34/Pilotage/issues/255)). The boundary
+between Pilotage, Indicate, and the Apple backend was not written down. This
+record defines that boundary.
+
+The earlier revision of this record used the names Communicate and
+aerocontext. [ADR-0035](0035-source-neutral-situational-services.md) owns the
+current names. The advisory domain is AeroContext. This record uses the
+ADR-0035 names.
 
 ## Decision
 
-- **One core, three shells.** The session, wire, ingress, authority-view,
-  input, instrument-state, and mission/plan vocabularies run as the same
-  Rust crates everywhere: the browser drives them as wasm, the iPad links
-  them as a static library behind a generated FFI (the aerocontext uniffi
-  precedent), and any Linux native station links them directly. The Swift
-  layer owns only: windowing/scenes, touch and hardware input, keychain
-  credentials, lifecycle, and rendering surfaces.
-- **Panels render from the scene IR, natively.** A Metal/CoreGraphics
-  scene-command interpreter joins the browser canvas interpreter and the
-  reference rasterizer as a third backend under the same conformance
-  corpus and layer contract. Panel code, glyphs, and budgets are reused
-  byte-identically; no Swift redraws an instrument.
-- **Transport stays in Rust.** The iPad speaks the ordinary session
-  protocol through the same QUIC/WebTransport client stack compiled into
-  the app, driven by the sans-IO session core — not through a parallel
-  platform networking implementation. Platform sockets are the only
-  boundary crossed.
-- **EFB posture embeds Communicate in-process** per
-  [ADR-0026](0026-host-capability-profiles.md): navdata sync/store,
-  identifier resolution, route expansion, and briefings run on-device
-  through Communicate's device-clean crates; the same snapshot surface
-  the host consumes ([ADR-0030](0030-communicate-navdata-provisioning.md))
-  feeds preflight with no host present.
-- **Porting debt is named, not discovered.** Before the iPad shell
-  starts, the JS-only feeder logic moves behind the shared boundary
-  ([ADR-0029](0029-panel-layout-look-plugins.md)): telemetry ingress
-  gating, turn/heading derivations, and the display-profile scaling
-  introduced by [ADR-0031](0031-nav-guidance-telemetry-display.md). The
-  wasm and FFI builds then drive one implementation, and the conformance
-  suite runs against both ports ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)).
+### The contract and panel owner is Indicate
+
+- Indicate owns the instrument state contract, the scene contract, the panel
+  sets, the registry, and the admission tests.
+- Pilotage consumes Indicate at one exact revision
+  ([ADR-0034](0034-extraction-boundary.md)).
+- Pilotage does not copy panel logic, glyphs, or contract vocabulary into a
+  platform layer.
+
+### The Apple display backend is IndicateAppleDisplay
+
+- IndicateAppleDisplay is the Swift package that decodes scene bytes and
+  paints them with CoreGraphics on Apple platforms.
+- IndicateAppleDisplay owns display interpretation and failure latching on
+  the Apple platform.
+- IndicateAppleDisplay does not own panel logic. It does not own state
+  derivation. It interprets the scene bytes that the shared runtime produces.
+
+### Pilotage owns one portable instrument runtime
+
+- Pilotage keeps one platform-neutral Rust crate: the Pilotage instrument
+  runtime.
+- The runtime owns these functions:
+  - state decode and resolve;
+  - feeder state;
+  - alert step;
+  - panel configuration;
+  - scene generation and validation;
+  - successful-production generation;
+  - typed producer status.
+- The runtime does not depend on `wasm_bindgen`, `serde_wasm_bindgen`, the
+  Pilotage protocol, JavaScript, Swift, or a UI framework.
+- The browser shell is a thin WASM adapter over the runtime. The Apple shell
+  is a thin bridge over the same runtime. Both adapters marshal data. Neither
+  adapter owns a decision.
+
+### The Apple bridge is a narrow generated FFI
+
+- The Apple bridge exposes a generated FFI surface (the uniffi precedent of
+  the AeroContext crates).
+- The surface enumerates panel descriptors and the screen-composition layout.
+- The surface returns typed scene bytes, the frame, the successful-production
+  generation, the typed producer status, and the digest identity.
+- Swift code does not implement panel logic. Swift code does not derive
+  state. The Swift layer owns windowing, input, credentials, lifecycle, and
+  rendering surfaces only.
+
+### The compatibility tuple gates paint
+
+The compatibility tuple has five values:
+
+1. the state ABI version;
+2. the scene format version;
+3. the corpus version and the corpus digest;
+4. the registry scene digest;
+5. the screen-composition digest.
+
+- The runtime computes the tuple from the Indicate revision that it links.
+- Each shell pins the same tuple and checks it before the first paint.
+- A mismatch stops the paint. The shell shows the failure. The shell does not
+  paint instruments from a backend that it did not verify.
+- Pilotage verifies the backend that it ships. Pilotage does not keep a
+  global reverse-dependency registry for Indicate
+  ([#255](https://github.com/luofang34/Pilotage/issues/255)).
+
+### One core, thin shells
+
+- The session, wire, ingress, authority-view, input, instrument-state, and
+  mission vocabularies run as the same Rust crates everywhere. The browser
+  drives them as wasm. The iPad links them as a static library behind the
+  generated FFI. A Linux native station links them directly.
+- Panels render from the scene IR on every platform. IndicateAppleDisplay
+  joins the browser canvas interpreter and the reference rasterizer as a
+  third backend under the same conformance corpus and layer contract
+  ([ADR-0017](0017-instrument-display-runtime.md),
+  [ADR-0029](0029-panel-layout-look-plugins.md)).
+- Transport stays in Rust. The iPad speaks the ordinary session protocol
+  through the same QUIC/WebTransport client stack compiled into the app.
+  Platform sockets are the only boundary crossed.
+- The EFB posture embeds AeroContext in-process per
+  [ADR-0026](0026-host-capability-profiles.md): navdata sync and store,
+  identifier resolution, route expansion, and briefings run on-device. The
+  same snapshot surface that the host consumes feeds preflight with no host
+  present ([ADR-0035](0035-source-neutral-situational-services.md)).
+- A companion-computer build stays free of Swift and Apple dependencies
+  ([ADR-0035](0035-source-neutral-situational-services.md)).
 
 ## Consequences
 
-- The iPad app's platform-specific surface is deliberately boring: shell,
-  input, credentials, rendering context, and a QUIC socket — everything
-  that decides anything is shared and already tested.
-- WebTransport-over-QUIC from a native app avoids the browser's
-  certificate constraints; the host trust story (certificate strategy,
-  [ADR-0004](0004-host-oriented-topology.md)) still applies and is not
-  weakened by the native path.
-- The scene-IR native backend is the main new build; the conformance
-  corpus makes its correctness a mechanical comparison rather than a
-  visual judgment.
-- Apple-platform release mechanics (signing, App Store or ad-hoc
-  distribution, background execution limits for sync) are deployment
-  concerns recorded when implementation starts, not architecture.
+- The platform-specific surface of the Apple app is deliberately small:
+  shell, input, credentials, rendering context, and a QUIC socket. Every
+  decision lives in shared, tested code.
+- The compatibility tuple makes a backend mismatch a stopped paint, not a
+  wrong picture. Each consumer proves the backend that it ships.
+- The portable runtime has one implementation for the WASM adapter and the
+  Apple bridge. The conformance suite runs against both ports
+  ([ADR-0002](0002-cargo-workspace-portable-sans-io-core.md)).
+- WebTransport-over-QUIC from a native app avoids the certificate
+  constraints of the browser. The host trust story
+  ([ADR-0004](0004-host-oriented-topology.md)) still applies.
+- Apple-platform release mechanics (signing, distribution, background
+  execution limits) are deployment concerns. Implementation records them.
 
 ## Alternatives considered
 
-- **SwiftUI-native instruments reusing only the data model:** rejected;
-  it forks panel behavior and assurance, exactly what the scene IR
-  exists to prevent.
-- **Wrapping the web client in a WKWebView:** rejected as the product
-  path (kept as a debugging convenience); it inherits browser transport
-  and certificate constraints, cannot embed Communicate natively, and
+- **SwiftUI-native instruments that reuse only the data model:** rejected.
+  This forks panel behavior and assurance. The scene IR exists to prevent
+  that fork.
+- **A WKWebView wrapper around the web client:** rejected as the product
+  path. It inherits the browser transport and certificate constraints. It
   makes hardware input and lifecycle second-class.
-- **Platform networking (Network.framework QUIC) with a Swift session
-  layer:** rejected; it duplicates the wire/session state machines in a
-  second language, the one cost ADR-0002 exists to prevent.
+- **Platform networking with a Swift session layer:** rejected. It
+  duplicates the wire and session state machines in a second language.
+  ADR-0002 exists to prevent that cost.
+- **A hand-written C header for the Apple bridge:** rejected. A generated
+  FFI keeps the surface mechanically aligned with the Rust types. The
+  AeroContext crates prove the generator on this toolchain.

--- a/docs/adr/0034-extraction-boundary.md
+++ b/docs/adr/0034-extraction-boundary.md
@@ -60,8 +60,8 @@ A panel is authored in the logical frame its descriptor declares
   that allocates.
 - The REN-03 raster baselines travel with their descriptors (already
   the case); the raster crate runs the gate on whichever side the
-  crates live. `states::typical` is owned by the registry crate and
-  moves with it.
+  crates live. `states::typical` is owned by the descriptor crate
+  (`indicate-instrument-descriptor`) and moves with it.
 - The browser shell's instrument half is protocol-free by crate
   boundary (`pilotage-instruments-web-shell`), enforced by a CI step,
   so the shell code that stays behind depends on the extracted family


### PR DESCRIPTION
## Summary\n\n- Define Indicate as the instrument contract and panel owner.\n- Define IndicateAppleDisplay as the Apple scene backend.\n- Define the portable Pilotage runtime, the generated FFI boundary, and the compatibility tuple.\n- Correct the extraction ownership note in ADR-0034.\n\n## Verification\n\n- check-structure: OK\n- Full repository gates pass on the complete migration work.\n\nCloses #322