### PR TITLE
ARCH-01: Record source-neutral situational service ownership

### DIFF
--- a/docs/adr/0035-source-neutral-situational-services.md
+++ b/docs/adr/0035-source-neutral-situational-services.md
@@ -1,0 +1,173 @@
+# ADR-0035: Source-neutral situational services and Pilotage composition
+
+- Status: Accepted
+- Date: 2026-08-08
+
+## Context
+
+Pilotage can run on a small companion computer. It can also run on iPadOS with
+an EFB client. Each installation can use a different set of data sources.
+
+A source can be a local radio, installed avionics, an Internet provider, a
+sensor, a camera, or a flight controller. These sources do not have the same
+delay, quality, or failure modes. The system must keep the source information
+and the time information.
+
+Traffic data and aeronautical context have different state rules. Traffic data
+needs fast updates, fusion, coasting, and removal. Weather, NOTAM, TFR, and
+navigation data need product assembly, revision, validity, and expiry.
+
+A map is one data consumer. AI is another data consumer. Neither consumer is a
+required part of a headless installation.
+
+This record defines the owner of each state. It also defines the allowed
+dependency direction. A source-neutral model uses the same domain types for all
+sources.
+
+This record replaces the advisory-data ownership in proposed ADR-0023 and
+proposed ADR-0030. Those records must use the AeroContext and Surveillance
+names before acceptance.
+
+## Decision
+
+### Ownership
+
+| Component | Owns | Does not own |
+|---|---|---|
+| `aero-link` | Radio access, demodulation, framing, correction, stateless protocol decode, and `ReceptionEvent` | Traffic tracks, weather-product state, maps, or application routing |
+| `avionics-link` | Installed-avionics transport, protocol decode, and thin source adapters | A second traffic, weather, or navigation state engine |
+| Surveillance | Source-neutral traffic observations, identity, fusion, freshness, tracks, deltas, and snapshots | Radio access, weather products, maps, or Pilotage authority |
+| AeroContext | Weather, NOTAM, TFR, briefing, navigation-data snapshots, source comparison, revision, validity, and expiry | Traffic tracks, ownship navigation, flight control, or maps |
+| Navigate | Ownship navigation fusion, integrity, route execution, guidance, terrain functions, and navigation functions that use cameras or celestial data | Flight-control actuation, traffic tracks, weather-product state, or maps |
+| Aviate or another flight controller | Control-grade estimation, stabilization, command results, and actuation | EFB state or advisory product state |
+| Pilotage | Composition, capability profiles, sessions, authority, leases, fencing, audit, supervision, and read-only situation queries | A replacement mutable state engine for another domain |
+| Indicate | Instrument state contracts, panel sets, scene contracts, registry, and admission tests | Pilotage sessions, maps, or platform UI policy |
+
+`Communicate` is not a general data domain. Add a shared communication
+mechanism to it only when two components need the same transport, job, or
+store-and-forward behavior.
+
+### Dependency direction
+
+```mermaid
+flowchart LR
+    subgraph Sources["External data sources"]
+        RF["978 MHz and 1090 MHz receivers"]
+        PANEL["Garmin and installed avionics"]
+        NET_TRAFFIC["Internet traffic providers"]
+        NET_CONTEXT["AWC, NMS, and Leidos"]
+        SENSORS["iPad sensors and cameras"]
+    end
+
+    RF --> AL["aero-link"]
+    PANEL --> VL["avionics-link"]
+
+    AL -- "Traffic reception" --> SA["surveillance-aero-link"]
+    VL -- "Panel traffic" --> SV["surveillance-avionics-link"]
+    NET_TRAFFIC --> SI["Surveillance Internet adapters"]
+
+    SA --> SURV["Surveillance: normalize, fuse, and track traffic"]
+    SV --> SURV
+    SI --> SURV
+
+    AL -- "FIS-B APDU" --> AF["aerocontext-fisb"]
+    NET_CONTEXT --> AP["AeroContext provider adapters"]
+    AF --> CTX["AeroContext: weather, NOTAM, TFR, and navigation data"]
+    AP --> CTX
+
+    SENSORS --> NAV["Navigate: fuse navigation data, manage routes, and calculate guidance"]
+    VL -- "GNSS, AHRS, and flight plan" --> NAV
+
+    FC["Aviate or another flight controller"] -- "Measurements, state, and capabilities" --> NAV
+    NAV -- "Navigation solution and authorized guidance request" --> PILOT["Pilotage runtime"]
+    FC --> PILOT
+    SURV --> PILOT
+    CTX --> PILOT
+
+    PILOT --> VIEW["SituationView: read-only data with explicit time semantics"]
+    VIEW --> AI["Optional AI analysis"]
+    VIEW --> MAP["Optional map adapter"]
+    VIEW --> CLIENT["Map-independent client or API"]
+    MAP --> GEO["MapLibre, GeoLibre, or EFB UI"]
+
+    PILOT -- "Lease, fencing, and audit" --> FC
+```
+
+An adapter can depend on a source contract and a domain contract. A domain core
+must not depend on a source adapter.
+
+### Data and time rules
+
+- Attach the local monotonic receive time at the first software boundary.
+- Keep the source identity, origin, delivery path, and time quality.
+- Do not compare a raw provider clock with a local monotonic clock.
+- Map a trusted provider time into the local time domain in the source adapter.
+- Keep unknown or untrusted source time explicit.
+- Keep raw or decoded source data available for replay and diagnosis.
+- Do not make a display object the only copy of domain state.
+
+Surveillance emits `TrackDelta` and `TrackSnapshot` values. AeroContext emits
+product events and immutable snapshots. Navigate emits a navigation solution,
+integrity state, and guidance requests. Pilotage joins read-only handles to
+these values in `SituationView`.
+
+`SituationView` uses an explicit query time. It does not own the mutable state
+that it reads. It keeps enough source and age data to explain a result.
+
+AI and map adapters can read `SituationView`. They cannot bypass Pilotage
+authority. Only the Pilotage lease, fencing, and audit path can send an
+authorized command to the flight controller.
+
+### Queue rules
+
+Each data class has a separate bounded queue or bounded store.
+
+- For traffic display updates, the latest valid state can replace an older
+  pending state.
+- For FIS-B product fragments, the product store keeps the fragments that it
+  needs for assembly.
+- For map updates, the display can drop or combine obsolete updates.
+- For raw recording, an independent bounded path prevents disk work from
+  stopping reception.
+
+An output consumer must not stop a receiver or a control path.
+
+### Deployment rules
+
+A companion-computer build can run without MapLibre, GeoLibre, Swift, a
+browser, or AI. It links only the domain cores and adapters that its capability
+profile needs.
+
+An iPadOS build can link the same portable cores in the application process. It
+can use local sensors, installed avionics, Internet providers, or direct radio
+adapters. A process boundary is a deployment choice. It is not a package
+boundary.
+
+A high-rate local path can use DMA or shared memory. The path must still keep
+source identity, clock correspondence, calibration, health, and result
+contracts. Advisory data must not become a control-grade measurement without a
+declared navigation adapter and integrity policy.
+
+## Consequences
+
+- A new radio or provider adds an adapter. It does not change a domain core.
+- Local radio traffic, panel traffic, Internet traffic, replay, and simulation
+  use one Surveillance model.
+- FIS-B and Internet context use one AeroContext model.
+- A headless system can supply situation data to an API or to AI without a map.
+- A map can fail or restart without loss of domain state.
+- Each component can have its own test corpus, replay tool, resource limits,
+  and assurance evidence.
+- The first deployment can use one process. A later deployment can separate
+  processes without a change to domain ownership.
+
+## Alternatives considered
+
+- **One global mutable world model:** Rejected. It hides the owner of state and
+  makes independent tests and assurance difficult.
+- **A source-specific domain core:** Rejected. A new source would change the
+  domain model and its consumers.
+- **A map-specific canonical model:** Rejected. A headless installation and a
+  non-map consumer must use the same domain data.
+- **One process for each protocol message type:** Rejected. Package boundaries
+  and process boundaries solve different problems.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,10 @@ One file per decision, numbered in acceptance order. See
 | [0029](0029-panel-layout-look-plugins.md) | Panels, layout, and look are data-driven plugins over the scene and state contracts | Proposed |
 | [0030](0030-communicate-navdata-provisioning.md) | The host consumes aeronautical navdata through Communicate's cycle-dated snapshot surface | Proposed |
 | [0031](0031-nav-guidance-telemetry-display.md) | Navigation guidance rides telemetry as its own stamped role; deviation scaling is display policy | Proposed |
-| [0032](0032-ipad-native-client-shared-cores.md) | The iPad client is a thin native shell over the same Rust cores the web client runs as wasm | Proposed |
+| [0032](0032-ipad-native-client-shared-cores.md) | The Apple instrument composition boundary — Indicate owns the contract, the shells stay thin | Accepted |
+| [0033](0033-panel-registry-config-and-digest.md) | Compose panel registries as data and use one scene digest across shells | Accepted |
+| [0034](0034-extraction-boundary.md) | Keep instrument artifacts, gates, and pinned consumers at explicit repository boundaries | Accepted |
+| [0035](0035-source-neutral-situational-services.md) | Keep situational services source-neutral and compose them through Pilotage | Accepted |
 
 ## Provenance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,12 +2,12 @@
 
 Pilotage is a Rust-first, engine-independent platform for low-latency control,
 supervision, simulation, and training of maritime, aerial, and terrestrial
-vehicles. The target system spans a vehicle-side **host** that orchestrates
-flight control (Aviate, PX4), navigation (Navigate), and communication
-(Communicate); **operator clients** ranging from a full control terminal to an
-EFB-style preflight tool; and an optional **coordination server** for
-identity, rendezvous, and entitlements. This document is the orientation map;
-the [ADRs](adr/README.md) are the authoritative decisions.
+vehicles. A vehicle-side **host** composes flight control, navigation,
+surveillance, aeronautical context, and communication adapters. An **operator
+client** can be a full control terminal or an EFB preflight tool. An optional
+**coordination server** supplies identity, rendezvous, and entitlements. This
+document is the orientation map. The [ADRs](adr/README.md) contain the
+authoritative decisions.
 
 ## System shape (target)
 
@@ -21,10 +21,10 @@ the [ADRs](adr/README.md) are the authoritative decisions.
    Operator client(s) <═ WebTransport (QUIC) ═> Pilotage host
    (web / iPadOS /      │  direct; opt-in       ├─ authority engine (leases, generations)
     native; plugin      │  separately           ├─ vehicle adapter ── FC (Aviate | PX4)
-    panels/layout,      │  deployed relay       ├─ Navigate: fusion, FPL, guidance, EGPWS
-    ADR-0029; EFB or    │                       ├─ Communicate: advisory context
-    terminal posture    │                       └─ telemetry/control/media/advisory
-    by discovery,       │
+    panels/layout,      │  deployed relay       ├─ Navigate: navigation solution and guidance
+    ADR-0029; EFB or    │                       ├─ Surveillance: traffic fusion and tracks
+    terminal posture    │                       ├─ AeroContext: weather, notices, and navdata
+    by discovery,       │                       └─ telemetry/control/media/advisory
     ADR-0026)           │
       video ◄───────────┤
       telemetry ◄───────┤
@@ -63,10 +63,24 @@ Planes are contract boundaries; deployables are a deployment decision.
 |---|---|---|
 | Flight control (Aviate first; PX4 via adapter) | Control-grade estimation, stabilization, actuation | [ADR-0008](adr/0008-engine-independent-adapter-boundary.md), [ADR-0018](adr/0018-avionics-telemetry-and-aviate-adapter.md), [ADR-0024](adr/0024-navigation-authority-boundary.md) |
 | Navigate (sibling repository) | Multi-sensor fusion, integrity, flight-plan execution, guidance, terrain awareness | [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0024](adr/0024-navigation-authority-boundary.md) |
-| Communicate (aerocontext, repository `v99n62`) | Provenance-tracked advisory aeronautical context; AI-agent surface | [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0025](adr/0025-client-optional-operation-automation-principals.md) |
+| `aero-link` and `avionics-link` | Source access, protocol decode, and thin domain adapters | [ADR-0035](adr/0035-source-neutral-situational-services.md) |
+| Surveillance (sibling repository) | Source-neutral traffic observations, fusion, tracks, deltas, and snapshots | [ADR-0035](adr/0035-source-neutral-situational-services.md) |
+| AeroContext (repository `v99n62`) | Weather, NOTAM, TFR, briefing, navigation data, revision, validity, and expiry | [ADR-0035](adr/0035-source-neutral-situational-services.md) |
 | Pilotage host | Component orchestration + session/authority/media endpoint | [ADR-0003](adr/0003-separate-responsibility-planes.md), [ADR-0004](adr/0004-host-oriented-topology.md), [ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md) |
 | Operator client | Control terminal ↔ EFB by discovered capability; plugin displays | [ADR-0026](adr/0026-host-capability-profiles.md), [ADR-0029](adr/0029-panel-layout-look-plugins.md) |
 | Coordination server (optional) | Identity, host registry, rendezvous, entitlement-gated data services | [ADR-0027](adr/0027-optional-coordination-server.md) |
+
+## Situational services
+
+[ADR-0035](adr/0035-source-neutral-situational-services.md) assigns traffic
+state to Surveillance and advisory product state to AeroContext. `aero-link`
+and `avionics-link` supply source data through thin adapters. Pilotage reads
+the domain outputs through a read-only `SituationView`.
+
+Map adapters and AI are optional consumers of `SituationView`. A headless
+deployment does not need either consumer. `Communicate` does not own
+Surveillance or AeroContext. Add a shared communication mechanism to it only
+when two components need that mechanism.
 
 ## Load-bearing principles
 
@@ -119,7 +133,7 @@ Increment 8 is committed as the next slice; the order beyond it is indicative.
 |---|---|---|
 | 8 | Navigate skeleton: new repository with a sans-IO fusion/flight-plan core; flight-plan execution flies Aviate SITL through the FC's declared setpoint surface as an automation-class principal ([ADR-0023](adr/0023-vehicle-side-decomposition-fc-navigate-communicate.md), [ADR-0024](adr/0024-navigation-authority-boundary.md), [ADR-0025](adr/0025-client-optional-operation-automation-principals.md)); the FC-side guidance command-surface RFC below is a prerequisite | A preloaded plan flies headless in SITL with no client attached; a joining client sees automation as holder and takes over via the authority machinery |
 | 9 | Authority completion: handover/override wire vocabulary, identity/admission service, observer admission | Two operators transfer a scope with positive confirmation; a supervisor overrides; a monitor observes with no grantable scopes |
-| 10 | EFB slice: client embeds Communicate cores; briefing on a live map; data-gateway host profile ([ADR-0026](adr/0026-host-capability-profiles.md)) | Preflight brief and pack-for-flight on a client with no host process; the same client is a full terminal against a full-authority host |
+| 10 | EFB slice: client embeds AeroContext cores; briefing on a live map; data-gateway host profile ([ADR-0026](adr/0026-host-capability-profiles.md)) | Preflight brief and pack-for-flight on a client with no host process; the same client is a full terminal against a full-authority host |
 | 11 | Coordination server: registry + rendezvous + entitlement gate ([ADR-0027](adr/0027-optional-coordination-server.md)) | A WAN session forms behind NAT with no session data transiting the server |
 | 12 | Coordinator host: aggregate scopes decomposed over member hosts ([ADR-0028](adr/0028-multi-vehicle-and-swarm-coordinator-hosts.md)) | A swarm command reaches members under end-to-end fencing; displacing the coordinator on one member affects exactly that member |
 
@@ -164,7 +178,8 @@ Multiple camera sources and picture-in-picture;
 spectator stream fan-out (host- or relay-side replication); instructor and supervisory modes; organization
 policy and temporary guests; automation-assisted blended control; signed online
 device-registry updates; repeatable network-impairment benchmark harness; peer-host
-update and attestation; FIS-B/ADS-B providers in Communicate; host-to-host
+update and attestation; FIS-B providers in AeroContext; traffic providers in
+Surveillance; host-to-host
 collaboration behaviors over the reserved coordinator seam.
 
 ### P2 — preserve compatibility, defer implementation


### PR DESCRIPTION
## Summary\n\n- Record source-neutral ownership for reception, traffic, aeronautical context, navigation, control, and composition.\n- Keep the full dependency graph in Mermaid.\n- Define explicit time, queue, deployment, map, and AI boundaries.\n- Link the concise architecture overview to the accepted ADR.\n\n## Verification\n\n- check-structure: OK\n- check-certification-claims: OK\n- Full repository gates pass on the complete migration work.\n\nRefs #321