### PR TITLE
Gate the Apple instrument consumer before paint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Authorize the private git dependency (Navigate)
+        env:
+          NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$NAVIGATE_DEPLOY_KEY" > ~/.ssh/navigate_ci
+          chmod 600 ~/.ssh/navigate_ci
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n' >> ~/.ssh/config
+          git config --global url."ssh://git@github-navigate/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,15 @@ jobs:
       - name: Indicate compatibility identity
         run: bash scripts/check-indicate-compatibility.sh
 
+      - name: companion host excludes Apple bridge dependencies
+        run: |
+          tree=$(cargo tree -p pilotage-session-host -e normal)
+          for forbidden in pilotage-instrument-apple-bridge uniffi; do
+            if grep -q "$forbidden" <<<"$tree"; then
+              echo "pilotage-session-host depends on $forbidden"; exit 1
+            fi
+          done
+
       - name: geospatial contract (SVS-01)
         # Datum discipline, coherence, view/projection, availability, and the
         # fail-closed versioned ABI for synthetic vision and conformal HUD.
@@ -305,3 +314,15 @@ jobs:
           else
             echo "origin/${base} has no .proto files yet; nothing to compare against."
           fi
+
+  apple-instrument-consumer:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate the bridge and test the Apple consumer
+        run: bash scripts/check-apple-instrument-consumer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,15 @@ jobs:
           printf 'Host github-navigate\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/navigate_ci\n  IdentitiesOnly yes\n' >> ~/.ssh/config
           git config --global url."ssh://git@github-navigate/luofang34/Navigate".insteadOf "https://github.com/luofang34/Navigate"
 
+      - name: Authorize the private Swift dependency (IndicateAppleDisplay)
+        env:
+          INDICATE_APPLE_DISPLAY_DEPLOY_KEY: ${{ secrets.INDICATE_APPLE_DISPLAY_DEPLOY_KEY }}
+        run: |
+          printf '%s\n' "$INDICATE_APPLE_DISPLAY_DEPLOY_KEY" > ~/.ssh/indicate_apple_display_ci
+          chmod 600 ~/.ssh/indicate_apple_display_ci
+          printf 'Host github-indicate-apple-display\n  HostName github.com\n  User git\n  IdentityFile ~/.ssh/indicate_apple_display_ci\n  IdentitiesOnly yes\n' >> ~/.ssh/config
+          git config --global url."ssh://git@github-indicate-apple-display/luofang34/IndicateAppleDisplay".insteadOf "https://github.com/luofang34/IndicateAppleDisplay"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ adapters/**/bridge/build/
 *.bak
 *.orig
 clients/web/session.json
+
+**.build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "askama"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
 ]
 
 [[package]]
@@ -166,6 +214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +295,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +370,45 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -583,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +899,23 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1613,6 +1767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-instrument-apple-bridge"
+version = "0.1.0"
+dependencies = [
+ "indicate-instrument-state",
+ "pilotage-instrument-runtime",
+ "uniffi",
+]
+
+[[package]]
 name = "pilotage-instrument-runtime"
 version = "0.1.0"
 dependencies = [
@@ -1776,6 +1939,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -2269,6 +2438,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2485,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2427,6 +2620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2636,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -2463,6 +2668,18 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2514,6 +2731,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -2628,6 +2854,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2940,127 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uniffi"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
 
 [[package]]
 name = "untrusted"
@@ -2819,6 +3175,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2971,6 +3336,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "clients/web-instruments",
     "clients/web-instrument-shell",
     "clients/web-control",
+    "clients/apple-instrument-bridge",
 ]
 
 [workspace.package]
@@ -82,6 +83,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 sha2 = "0.10.9"
 ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+uniffi = "0.29"
 pilotage-timing = { path = "crates/pilotage-timing" }
 pilotage-protocol = { path = "crates/pilotage-protocol" }
 pilotage-authority = { path = "crates/pilotage-authority" }

--- a/clients/README.md
+++ b/clients/README.md
@@ -4,6 +4,14 @@ Thin platform layers over the portable core
 ([ADR-0002](../docs/adr/0002-cargo-workspace-portable-sans-io-core.md)). No business
 rule or wire-level state machine may live only here.
 
+Contents:
+
+- `apple-instrument-bridge/` — thin generated FFI bridge (uniffi) to the
+  instrument runtime for Apple shells ([ADR-0032](../docs/adr/0032-ipad-native-client-shared-cores.md)).
+  Companion-computer builds do not link it.
+- `apple-instrument-consumer/` — thin Swift compatibility gate and scene
+  producer for IndicateAppleDisplay. It does not own panel logic.
+
 Planned contents:
 
 - `web/` — v1 browser client: wasm build of the core plus browser ports (Gamepad,

--- a/clients/apple-instrument-bridge/Cargo.toml
+++ b/clients/apple-instrument-bridge/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pilotage-instrument-apple-bridge"
+description = "Thin generated FFI bridge (uniffi) to the Pilotage instrument runtime for Apple shells (ADR-0032)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+pilotage-instrument-runtime = { workspace = true }
+uniffi = { workspace = true, features = ["cli"] }
+
+[dev-dependencies]
+indicate-instrument-state = { workspace = true }

--- a/clients/apple-instrument-bridge/src/bin/pilotage_uniffi_bindgen.rs
+++ b/clients/apple-instrument-bridge/src/bin/pilotage_uniffi_bindgen.rs
@@ -1,0 +1,5 @@
+//! Generates foreign-language bindings for the Apple instrument bridge.
+
+fn main() {
+    uniffi::uniffi_bindgen_main();
+}

--- a/clients/apple-instrument-bridge/src/bridge.rs
+++ b/clients/apple-instrument-bridge/src/bridge.rs
@@ -1,0 +1,95 @@
+//! The bridge object: one owned instrument runtime behind the FFI.
+//! The caller copies each state frame in, then asks for panel scenes.
+
+use std::sync::Mutex;
+
+use pilotage_instrument_runtime::{RenderStatus, Runtime, canonical_frame, descriptor};
+
+use crate::records::{BridgeRenderOutcome, BridgeWriteOutcome};
+
+/// One owned instrument runtime behind the FFI. Each bridge object has
+/// independent buffers, configuration, and generations.
+#[derive(uniffi::Object)]
+pub struct InstrumentBridge {
+    runtime: Mutex<Runtime>,
+}
+
+impl Default for InstrumentBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[uniffi::export]
+impl InstrumentBridge {
+    /// Constructs a bridge with a fresh runtime.
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            runtime: Mutex::new(Runtime::new()),
+        }
+    }
+
+    /// Copies one ABI state frame into the runtime's state buffer.
+    /// The function refuses input that exceeds the fixed capacity.
+    pub fn write_state(&self, bytes: &[u8]) -> BridgeWriteOutcome {
+        let mut runtime = match self.runtime.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let buffer = runtime.state_mut();
+        buffer.fill(0);
+        if bytes.len() > buffer.len() {
+            return BridgeWriteOutcome {
+                status: 1,
+                actual: bytes.len() as u64,
+                capacity: buffer.len() as u64,
+            };
+        }
+        if let Some(target) = buffer.get_mut(..bytes.len()) {
+            target.copy_from_slice(bytes);
+        }
+        BridgeWriteOutcome {
+            status: 0,
+            actual: bytes.len() as u64,
+            capacity: buffer.len() as u64,
+        }
+    }
+
+    /// Renders one panel from the last written state frame.
+    ///
+    /// The runtime draws every panel at its canonical frame. The outcome
+    /// returns this frame so the caller can compare it with the frame that
+    /// its display backend requested.
+    ///
+    /// A failure carries a nonzero status, empty scene bytes, and an
+    /// unchanged generation.
+    pub fn render(&self, panel: u32) -> BridgeRenderOutcome {
+        let mut runtime = match self.runtime.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let outcome = runtime.render(panel);
+        let (emitted_width, emitted_height) = descriptor(panel)
+            .map(|d| {
+                let frame = canonical_frame(d);
+                (frame.width, frame.height)
+            })
+            .unwrap_or((0.0, 0.0));
+        let scene = if outcome.status == RenderStatus::Ok {
+            runtime
+                .scene()
+                .get(..outcome.scene_len as usize)
+                .map_or_else(Vec::new, <[u8]>::to_vec)
+        } else {
+            Vec::new()
+        };
+        BridgeRenderOutcome {
+            status: outcome.status as u32,
+            scene,
+            frame_width: emitted_width,
+            frame_height: emitted_height,
+            generation: outcome.generation,
+        }
+    }
+}

--- a/clients/apple-instrument-bridge/src/enumeration.rs
+++ b/clients/apple-instrument-bridge/src/enumeration.rs
@@ -1,0 +1,92 @@
+//! The enumeration and digest-identity functions: panel descriptors,
+//! the screen-composition layout, and the compatibility-tuple values.
+//! Each function mirrors one neutral helper of the runtime and adds no
+//! judgement of its own.
+
+use pilotage_instrument_runtime::{canonical_frame, descriptor};
+
+use crate::records::{BridgeCompositionSlot, BridgePanelDescriptor};
+
+/// Number of panels in the composed registry.
+#[uniffi::export]
+pub fn panel_count() -> u32 {
+    pilotage_instrument_runtime::panel_count()
+}
+
+/// The descriptor at `index` in composition order, or `None` for an
+/// unknown index.
+#[uniffi::export]
+pub fn panel_descriptor(index: u32) -> Option<BridgePanelDescriptor> {
+    let descriptor = descriptor(index)?;
+    let frame = canonical_frame(descriptor);
+    Some(BridgePanelDescriptor {
+        id: descriptor.id.to_string(),
+        title: descriptor.title.to_string(),
+        required_layers: u32::from(descriptor.required_layers),
+        required_groups: descriptor.required_groups.bits(),
+        design_width: frame.width,
+        design_height: frame.height,
+        background_capability: pilotage_instrument_runtime::background_capability_code(index),
+    })
+}
+
+/// Number of slots in the validated screen composition.
+#[uniffi::export]
+pub fn composition_slot_count() -> u32 {
+    pilotage_instrument_runtime::composition_slot_count()
+}
+
+/// The slot at `index` in paint order, or `None` for an unknown index.
+#[uniffi::export]
+pub fn composition_slot(index: u32) -> Option<BridgeCompositionSlot> {
+    let rect = pilotage_instrument_runtime::composition_slot_rect(index)?;
+    Some(BridgeCompositionSlot {
+        panel: pilotage_instrument_runtime::composition_slot_panel(index),
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+    })
+}
+
+/// The state-frame ABI version this build was compiled against:
+/// compatibility-tuple value 1.
+#[uniffi::export]
+pub fn state_abi_version() -> u32 {
+    pilotage_instrument_runtime::abi_version()
+}
+
+/// The scene format version this build was compiled against:
+/// compatibility-tuple value 2.
+#[uniffi::export]
+pub fn scene_format_version() -> u32 {
+    pilotage_instrument_runtime::scene_format_version()
+}
+
+/// The conformance-corpus version this build was compiled against:
+/// compatibility-tuple value 3.
+#[uniffi::export]
+pub fn corpus_version() -> u32 {
+    pilotage_instrument_runtime::corpus_version()
+}
+
+/// The conformance-corpus digest as lowercase hex: compatibility-tuple
+/// value 3.
+#[uniffi::export]
+pub fn corpus_digest_hex() -> String {
+    pilotage_instrument_runtime::corpus_digest_hex().to_string()
+}
+
+/// The registry scene digest as lowercase hex: compatibility-tuple
+/// value 4.
+#[uniffi::export]
+pub fn scene_digest_hex() -> String {
+    pilotage_instrument_runtime::scene_digest_hex()
+}
+
+/// The screen-composition digest as lowercase hex: compatibility-tuple
+/// value 5.
+#[uniffi::export]
+pub fn composition_digest_hex() -> String {
+    pilotage_instrument_runtime::composition_digest_hex()
+}

--- a/clients/apple-instrument-bridge/src/lib.rs
+++ b/clients/apple-instrument-bridge/src/lib.rs
@@ -1,0 +1,45 @@
+//! The thin Apple bridge to the Pilotage instrument runtime (ADR-0032).
+//!
+//! This crate is a narrow generated FFI surface. uniffi generates the
+//! bindings from the exported items. A hand-written C header was
+//! rejected by ADR-0032.
+//!
+//! The ownership split:
+//!
+//! - Indicate owns the instrument contract and the panels.
+//! - `pilotage-instrument-runtime` owns the instrument logic.
+//! - IndicateAppleDisplay owns display interpretation and failure
+//!   latching on the Apple platform.
+//! - This bridge marshals data. It holds no panel logic and no state
+//!   derivation. It holds no latching and no interpretation helper.
+//!
+//! Deliberate boundary: this bridge does not export alert stepping or
+//! panel configuration. The Apple shell owns those functions only if
+//! its product surface needs them.
+//!
+//! Companion-computer builds do not link this crate. The crate has no
+//! Apple-platform dependency: it builds on any host, and CI proves it.
+//!
+//! The digest functions are the consumer's before-paint compatibility
+//! check input (ADR-0032's tuple). The caller verifies them against its
+//! pinned values before first paint. The caller does not paint on
+//! mismatch. The verification is the caller's gate, not this crate's.
+
+uniffi::setup_scaffolding!();
+
+mod bridge;
+mod enumeration;
+mod records;
+
+pub use bridge::InstrumentBridge;
+pub use enumeration::{
+    composition_digest_hex, composition_slot, composition_slot_count, corpus_digest_hex,
+    corpus_version, panel_count, panel_descriptor, scene_digest_hex, scene_format_version,
+    state_abi_version,
+};
+pub use records::{
+    BridgeCompositionSlot, BridgePanelDescriptor, BridgeRenderOutcome, BridgeWriteOutcome,
+};
+
+#[cfg(test)]
+mod tests;

--- a/clients/apple-instrument-bridge/src/records.rs
+++ b/clients/apple-instrument-bridge/src/records.rs
@@ -1,0 +1,73 @@
+//! The plain-data records the FFI carries. Every field is a value the
+//! runtime already publishes; these types only give it a name across
+//! the boundary.
+
+/// One panel descriptor, as plain data for the FFI consumer.
+#[derive(uniffi::Record)]
+pub struct BridgePanelDescriptor {
+    /// The stable panel id.
+    pub id: String,
+    /// The operator-facing panel title.
+    pub title: String,
+    /// The required-layer bitset.
+    pub required_layers: u32,
+    /// The required state groups as a bitset over the wire tags.
+    pub required_groups: u32,
+    /// Width of the frame the runtime draws the panel at, in logical
+    /// units.
+    pub design_width: f32,
+    /// Height of the frame the runtime draws the panel at, in logical
+    /// units.
+    pub design_height: f32,
+    /// Background capability code: 0 not-used, 1 opaque, 2 cedeable.
+    pub background_capability: u32,
+}
+
+/// One composition slot, as plain data for the FFI consumer. Slot
+/// index is the paint order.
+#[derive(uniffi::Record)]
+pub struct BridgeCompositionSlot {
+    /// The panel id this slot paints.
+    pub panel: String,
+    /// Left edge of the slot's rectangle, in screen units.
+    pub x: f32,
+    /// Top edge of the slot's rectangle, in screen units.
+    pub y: f32,
+    /// Width of the slot's rectangle, in screen units.
+    pub width: f32,
+    /// Height of the slot's rectangle, in screen units.
+    pub height: f32,
+}
+
+/// The typed result of one render call: the producer status, the scene
+/// bytes, the frame the scene was emitted at, and the panel's
+/// successful-production generation.
+#[derive(uniffi::Record)]
+pub struct BridgeRenderOutcome {
+    /// The typed producer status: the `RenderStatus` discriminant. Zero
+    /// means the scene rendered and self-validated.
+    pub status: u32,
+    /// The typed scene bytes. Empty on every failure; the caller does
+    /// not paint on a nonzero status.
+    pub scene: Vec<u8>,
+    /// Width of the frame the scene was emitted at. The caller
+    /// compares it with the frame it prepared and does not paint on
+    /// mismatch.
+    pub frame_width: f32,
+    /// Height of the frame the scene was emitted at.
+    pub frame_height: f32,
+    /// The panel's successful-production generation. It advances only
+    /// on success, so it is a liveness signal no failed render can fake.
+    pub generation: u32,
+}
+
+/// The typed result of one state-buffer write.
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct BridgeWriteOutcome {
+    /// Zero for acceptance. One means the frame exceeds capacity.
+    pub status: u32,
+    /// Length supplied by the caller.
+    pub actual: u64,
+    /// Maximum length accepted by the runtime.
+    pub capacity: u64,
+}

--- a/clients/apple-instrument-bridge/src/tests.rs
+++ b/clients/apple-instrument-bridge/src/tests.rs
@@ -1,0 +1,154 @@
+//! Bridge proofs over the rlib: enumeration matches the runtime, the
+//! render round trip carries the typed outcome, and the digest identity
+//! equals the pinned compatibility-tuple values.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_instrument_state::abi::v7::encode_state;
+use indicate_instrument_state::{AircraftState, Attitude, Quat, Stamped};
+use pilotage_instrument_runtime::RenderStatus;
+
+use crate::{
+    InstrumentBridge, composition_digest_hex, composition_slot, composition_slot_count,
+    corpus_digest_hex, corpus_version, panel_count, panel_descriptor, scene_digest_hex,
+    scene_format_version, state_abi_version,
+};
+
+const PINNED_SCENE_DIGEST: &str =
+    "f82d905643b48822de25665761ad3e29daa334d937f18b1e98a3e215353cb704";
+const PINNED_COMPOSITION_DIGEST: &str =
+    "6761e8e1ed137e682530274c8f02353d2ab40e7142a36cd4321a6835323b463c";
+const PINNED_CORPUS_DIGEST: &str =
+    "1fb8e6de2734ff7506843b05869f39d501f0926599636c6110a7e3b0c6e1625e";
+
+fn attitude_state() -> AircraftState {
+    AircraftState {
+        attitude: Stamped {
+            data: Some(Attitude {
+                quat: Quat::IDENTITY,
+                rates_rps: [0.0; 3],
+            }),
+            age_ms: Some(10.0),
+        },
+        valid: indicate_instrument_state::ValidFlags {
+            attitude: true,
+            rates: true,
+            position: true,
+            velocity_horizontal: true,
+            velocity_vertical: true,
+            ..Default::default()
+        },
+        ..AircraftState::default()
+    }
+}
+
+fn encode(state: &AircraftState) -> Vec<u8> {
+    let mut block = vec![0u8; indicate_instrument_state::abi::v7::CAPACITY];
+    let len = encode_state(state, &mut block).expect("encodes");
+    block.truncate(len);
+    block
+}
+
+#[test]
+fn enumeration_matches_the_runtime() {
+    assert_eq!(panel_count(), pilotage_instrument_runtime::panel_count());
+    let pfd = panel_descriptor(0).expect("panel 0");
+    assert_eq!(pfd.id, "pfd");
+    assert_eq!(pfd.design_width, 480.0);
+    assert_eq!(pfd.design_height, 360.0);
+    let hsi = panel_descriptor(1).expect("panel 1");
+    assert_eq!(hsi.id, "hsi");
+    assert!(panel_descriptor(99).is_none(), "unknown index fails closed");
+
+    assert_eq!(
+        composition_slot_count(),
+        pilotage_instrument_runtime::composition_slot_count()
+    );
+    assert_eq!(composition_slot_count(), 2);
+    let first = composition_slot(0).expect("slot 0");
+    assert_eq!(first.panel, "pfd");
+    assert_eq!(
+        (first.x, first.y, first.width, first.height),
+        (0.0, 0.0, 480.0, 360.0)
+    );
+    let second = composition_slot(1).expect("slot 1");
+    assert_eq!(second.panel, "hsi");
+    assert_eq!((second.x, second.y), (480.0, 0.0));
+    assert!(composition_slot(9).is_none(), "unknown slot fails closed");
+}
+
+#[test]
+fn digest_identity_equals_the_pinned_tuple_values() {
+    assert_eq!(
+        state_abi_version(),
+        pilotage_instrument_runtime::abi_version()
+    );
+    assert_eq!(
+        scene_format_version(),
+        pilotage_instrument_runtime::scene_format_version()
+    );
+    assert_eq!(corpus_version(), 4);
+    assert_eq!(corpus_digest_hex(), PINNED_CORPUS_DIGEST);
+    assert_eq!(scene_digest_hex(), PINNED_SCENE_DIGEST);
+    assert_eq!(composition_digest_hex(), PINNED_COMPOSITION_DIGEST);
+}
+
+#[test]
+fn render_round_trip_carries_the_typed_outcome() {
+    let bridge = InstrumentBridge::new();
+    assert_eq!(bridge.write_state(&encode(&attitude_state())).status, 0);
+
+    let first = bridge.render(0);
+    assert_eq!(first.status, RenderStatus::Ok as u32);
+    assert!(!first.scene.is_empty(), "the outcome carries scene bytes");
+    assert_eq!(first.generation, 1);
+    assert_eq!((first.frame_width, first.frame_height), (480.0, 360.0));
+
+    let second = bridge.render(0);
+    assert_eq!(second.status, RenderStatus::Ok as u32);
+    assert_eq!(second.generation, 2, "a second success advances generation");
+}
+
+#[test]
+fn a_truncated_state_fails_with_unchanged_generation() {
+    // The state buffer is fixed-capacity and the v7 frame is
+    // self-delimiting, so a short write is not a truncation. An
+    // over-declared group length is: tag 0x05 claims 65535 payload
+    // bytes against the 1024-byte buffer.
+    let bridge = InstrumentBridge::new();
+    assert_eq!(bridge.write_state(&[7, 1, 0x05, 0xff, 0xff]).status, 0);
+
+    let outcome = bridge.render(0);
+    assert_eq!(outcome.status, RenderStatus::StateTruncated as u32);
+    assert!(outcome.scene.is_empty(), "a failure carries no scene bytes");
+    assert_eq!(outcome.generation, 0, "a failure never advances generation");
+}
+
+#[test]
+fn state_write_accepts_exact_capacity_and_refuses_capacity_plus_one() {
+    let bridge = InstrumentBridge::new();
+    let capacity = indicate_instrument_state::abi::v7::CAPACITY;
+    assert_eq!(bridge.write_state(&vec![0; capacity]).status, 0);
+
+    let error = bridge.write_state(&vec![0; capacity + 1]);
+    assert_eq!(error.status, 1);
+    assert_eq!(error.actual, (capacity + 1) as u64);
+    assert_eq!(error.capacity, capacity as u64);
+}
+
+#[test]
+fn oversized_valid_prefix_is_not_truncated_into_an_accepted_frame() {
+    let bridge = InstrumentBridge::new();
+    let encoded = encode(&attitude_state());
+    assert_eq!(bridge.write_state(&encoded).status, 0);
+    let first = bridge.render(0);
+    assert_eq!(first.status, RenderStatus::Ok as u32);
+
+    let mut oversized = encoded;
+    oversized.resize(indicate_instrument_state::abi::v7::CAPACITY + 1, 0);
+    assert_eq!(bridge.write_state(&oversized).status, 1);
+    let refused = bridge.render(0);
+    assert_ne!(refused.status, RenderStatus::Ok as u32);
+    assert!(refused.scene.is_empty());
+    assert_eq!(refused.generation, first.generation);
+}

--- a/clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift
+++ b/clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift
@@ -1,0 +1,56 @@
+import Foundation
+import PilotageAppleInstrumentConsumer
+import pilotage_instrument_apple_bridge
+
+/// Adapts the generated UniFFI module to the Apple consumer contract.
+public final class GeneratedInstrumentRuntime: InstrumentRuntimeServing {
+    private let bridge: InstrumentBridge
+
+    public static var identity: InstrumentRuntimeIdentity {
+        InstrumentRuntimeIdentity(
+            stateABI: stateAbiVersion(),
+            sceneFormat: sceneFormatVersion(),
+            corpusVersion: corpusVersion(),
+            corpusDigest: corpusDigestHex(),
+            registrySceneDigest: sceneDigestHex(),
+            screenCompositionDigest: compositionDigestHex()
+        )
+    }
+
+    /// Verifies the linked identity before it creates the Rust runtime.
+    public static func verifiedRuntime() throws -> VerifiedInstrumentRuntime {
+        try AppleInstrumentCompatibilityGate.verify(identity) {
+            GeneratedInstrumentRuntime()
+        }
+    }
+
+    private init() {
+        bridge = InstrumentBridge()
+    }
+
+    public func writeState(_ bytes: [UInt8]) throws {
+        let outcome = bridge.writeState(bytes: Data(bytes))
+        switch outcome.status {
+        case 0:
+            return
+        case 1:
+            throw InstrumentStateWriteError.frameTooLarge(
+                actual: outcome.actual,
+                capacity: outcome.capacity
+            )
+        default:
+            throw InstrumentStateWriteError.unexpectedStatus(outcome.status)
+        }
+    }
+
+    public func render(panel: UInt32) -> InstrumentRuntimeRenderOutcome {
+        let outcome = bridge.render(panel: panel)
+        return InstrumentRuntimeRenderOutcome(
+            status: outcome.status,
+            scene: Array(outcome.scene),
+            frameWidth: outcome.frameWidth,
+            frameHeight: outcome.frameHeight,
+            generation: outcome.generation
+        )
+    }
+}

--- a/clients/apple-instrument-consumer/Package.resolved
+++ b/clients/apple-instrument-consumer/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "originHash" : "baa6945a215f4a8e460402595dbd4b3217b5a49488dc8057bd9554fc6717aff8",
+  "pins" : [
+    {
+      "identity" : "indicateappledisplay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luofang34/IndicateAppleDisplay.git",
+      "state" : {
+        "revision" : "74e5845d09a58342fd282ec426759550dafc6887"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/clients/apple-instrument-consumer/Package.swift
+++ b/clients/apple-instrument-consumer/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "PilotageAppleInstrumentConsumer",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "PilotageAppleInstrumentConsumer",
+            targets: ["PilotageAppleInstrumentConsumer"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/luofang34/IndicateAppleDisplay.git",
+            revision: "74e5845d09a58342fd282ec426759550dafc6887"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "PilotageAppleInstrumentConsumer",
+            dependencies: [
+                .product(name: "IndicateAppleDisplay", package: "IndicateAppleDisplay"),
+            ]
+        ),
+        .testTarget(
+            name: "PilotageAppleInstrumentConsumerTests",
+            dependencies: ["PilotageAppleInstrumentConsumer"]
+        ),
+    ]
+)

--- a/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/CompatibilityGate.swift
+++ b/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/CompatibilityGate.swift
@@ -1,0 +1,137 @@
+import IndicateAppleDisplay
+
+/// One value in the instrument compatibility identity.
+public enum InstrumentCompatibilityField: String, Sendable {
+    case stateABI
+    case sceneFormat
+    case corpusVersion
+    case corpusDigest
+    case registrySceneDigest
+    case screenCompositionDigest
+}
+
+/// A compatibility refusal that occurs before scene production.
+public enum InstrumentCompatibilityError: Error, Equatable, Sendable {
+    case mismatch(
+        field: InstrumentCompatibilityField,
+        actual: String,
+        expected: String
+    )
+}
+
+/// The identity exported by one linked Pilotage instrument runtime.
+public struct InstrumentRuntimeIdentity: Equatable, Sendable {
+    public let stateABI: UInt32
+    public let sceneFormat: UInt32
+    public let corpusVersion: UInt32
+    public let corpusDigest: String
+    public let registrySceneDigest: String
+    public let screenCompositionDigest: String
+
+    public init(
+        stateABI: UInt32,
+        sceneFormat: UInt32,
+        corpusVersion: UInt32,
+        corpusDigest: String,
+        registrySceneDigest: String,
+        screenCompositionDigest: String
+    ) {
+        self.stateABI = stateABI
+        self.sceneFormat = sceneFormat
+        self.corpusVersion = corpusVersion
+        self.corpusDigest = corpusDigest
+        self.registrySceneDigest = registrySceneDigest
+        self.screenCompositionDigest = screenCompositionDigest
+    }
+}
+
+/// The scene data returned by the generated Pilotage bridge.
+public struct InstrumentRuntimeRenderOutcome: Equatable, Sendable {
+    public let status: UInt32
+    public let scene: [UInt8]
+    public let frameWidth: Float
+    public let frameHeight: Float
+    public let generation: UInt32
+
+    public init(
+        status: UInt32,
+        scene: [UInt8],
+        frameWidth: Float,
+        frameHeight: Float,
+        generation: UInt32
+    ) {
+        self.status = status
+        self.scene = scene
+        self.frameWidth = frameWidth
+        self.frameHeight = frameHeight
+        self.generation = generation
+    }
+}
+
+/// The narrow runtime surface that the Apple shell consumes.
+public protocol InstrumentRuntimeServing: AnyObject {
+    func writeState(_ bytes: [UInt8]) throws
+    func render(panel: UInt32) -> InstrumentRuntimeRenderOutcome
+}
+
+/// A state write that the generated bridge refused.
+public enum InstrumentStateWriteError: Error, Equatable, Sendable {
+    case frameTooLarge(actual: UInt64, capacity: UInt64)
+    case unexpectedStatus(UInt32)
+}
+
+/// A runtime that passed the complete compatibility gate.
+public final class VerifiedInstrumentRuntime {
+    let runtime: any InstrumentRuntimeServing
+
+    fileprivate init(runtime: any InstrumentRuntimeServing) {
+        self.runtime = runtime
+    }
+
+    public func writeState(_ bytes: [UInt8]) throws {
+        try runtime.writeState(bytes)
+    }
+}
+
+    /// Verifies the runtime and Apple display identities before runtime creation.
+public enum AppleInstrumentCompatibilityGate {
+    public static let stateABI: UInt32 = 7
+    public static let registrySceneDigest =
+        "f82d905643b48822de25665761ad3e29daa334d937f18b1e98a3e215353cb704"
+    public static let screenCompositionDigest =
+        "6761e8e1ed137e682530274c8f02353d2ab40e7142a36cd4321a6835323b463c"
+
+    public static func verify(
+        _ actual: InstrumentRuntimeIdentity,
+        makeRuntime: () throws -> any InstrumentRuntimeServing
+    ) throws -> VerifiedInstrumentRuntime {
+        let expected = InstrumentRuntimeIdentity(
+            stateABI: stateABI,
+            sceneFormat: UInt32(SceneBackend.formatVersion),
+            corpusVersion: UInt32(SceneBackend.conformanceCorpusVersion),
+            corpusDigest: SceneBackend.conformanceCorpusDigest,
+            registrySceneDigest: registrySceneDigest,
+            screenCompositionDigest: screenCompositionDigest
+        )
+        let checks: [(InstrumentCompatibilityField, String, String)] = [
+            (.stateABI, String(actual.stateABI), String(expected.stateABI)),
+            (.sceneFormat, String(actual.sceneFormat), String(expected.sceneFormat)),
+            (.corpusVersion, String(actual.corpusVersion), String(expected.corpusVersion)),
+            (.corpusDigest, actual.corpusDigest, expected.corpusDigest),
+            (.registrySceneDigest, actual.registrySceneDigest, expected.registrySceneDigest),
+            (
+                .screenCompositionDigest,
+                actual.screenCompositionDigest,
+                expected.screenCompositionDigest
+            ),
+        ]
+        for (field, value, required) in checks where value != required {
+            throw InstrumentCompatibilityError.mismatch(
+                field: field,
+                actual: value,
+                expected: required
+            )
+        }
+        return VerifiedInstrumentRuntime(runtime: try makeRuntime())
+    }
+}

--- a/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
+++ b/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
@@ -1,0 +1,30 @@
+import CoreGraphics
+import IndicateAppleDisplay
+
+/// A scene producer that is available only after compatibility verification.
+public final class PilotageInstrumentSceneProducer: SceneProducing {
+    private let verifiedRuntime: VerifiedInstrumentRuntime
+    private let panel: UInt32
+
+    public init(verifiedRuntime: VerifiedInstrumentRuntime, panel: UInt32) {
+        self.verifiedRuntime = verifiedRuntime
+        self.panel = panel
+    }
+
+    public func frame(designFrame: CGRect) throws -> SceneFrame {
+        let outcome = verifiedRuntime.runtime.render(panel: panel)
+        guard outcome.status == 0 else {
+            let code = UInt16(exactly: outcome.status)
+            let reason = code.flatMap(DisplayReason.init(rawValue:)) ?? .renderTrap
+            throw ProducerFault(reason: reason == .ok ? .renderTrap : reason)
+        }
+        guard outcome.frameWidth == Float(designFrame.width),
+              outcome.frameHeight == Float(designFrame.height) else {
+            throw ProducerFault(reason: .abiMismatch)
+        }
+        guard !outcome.scene.isEmpty else {
+            throw ProducerFault(reason: .sceneFraming)
+        }
+        return SceneFrame(bytes: outcome.scene, generation: outcome.generation)
+    }
+}

--- a/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
+++ b/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
@@ -1,0 +1,193 @@
+import CoreGraphics
+import Foundation
+import IndicateAppleDisplay
+import Testing
+@testable import PilotageAppleInstrumentConsumer
+
+private final class RuntimeDouble: InstrumentRuntimeServing {
+    var renderCalls = 0
+    var outcome = InstrumentRuntimeRenderOutcome(
+        status: 0,
+        scene: [1],
+        frameWidth: 10,
+        frameHeight: 10,
+        generation: 1
+    )
+
+    func writeState(_: [UInt8]) throws {}
+
+    func render(panel _: UInt32) -> InstrumentRuntimeRenderOutcome {
+        renderCalls += 1
+        return outcome
+    }
+}
+
+private struct CompatibilityPin: Decodable {
+    let stateAbiVersion: UInt32
+    let sceneFormatVersion: UInt32
+    let corpusVersion: UInt32
+    let corpusDigest: String
+    let registrySceneDigest: String
+    let screenCompositionDigest: String
+}
+
+private func compatibilityPin() throws -> CompatibilityPin {
+    let url = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("instrument-compatibility.json")
+    return try JSONDecoder().decode(CompatibilityPin.self, from: Data(contentsOf: url))
+}
+
+private func matchingIdentity() -> InstrumentRuntimeIdentity {
+    InstrumentRuntimeIdentity(
+        stateABI: AppleInstrumentCompatibilityGate.stateABI,
+        sceneFormat: UInt32(SceneBackend.formatVersion),
+        corpusVersion: UInt32(SceneBackend.conformanceCorpusVersion),
+        corpusDigest: SceneBackend.conformanceCorpusDigest,
+        registrySceneDigest: AppleInstrumentCompatibilityGate.registrySceneDigest,
+        screenCompositionDigest: AppleInstrumentCompatibilityGate.screenCompositionDigest
+    )
+}
+
+@Test("The Swift gate equals the Pilotage consumer pin")
+func swiftGateMatchesConsumerPin() throws {
+    let pin = try compatibilityPin()
+    #expect(AppleInstrumentCompatibilityGate.stateABI == pin.stateAbiVersion)
+    #expect(UInt32(SceneBackend.formatVersion) == pin.sceneFormatVersion)
+    #expect(UInt32(SceneBackend.conformanceCorpusVersion) == pin.corpusVersion)
+    #expect(SceneBackend.conformanceCorpusDigest == pin.corpusDigest)
+    #expect(AppleInstrumentCompatibilityGate.registrySceneDigest == pin.registrySceneDigest)
+    #expect(
+        AppleInstrumentCompatibilityGate.screenCompositionDigest ==
+            pin.screenCompositionDigest
+    )
+}
+
+@Test("Each compatibility mismatch stops scene production")
+func everyMismatchStopsBeforeProduction() {
+    let expected = matchingIdentity()
+    let cases: [(InstrumentCompatibilityField, InstrumentRuntimeIdentity)] = [
+        (.stateABI, identity(expected, stateABI: expected.stateABI + 1)),
+        (.sceneFormat, identity(expected, sceneFormat: expected.sceneFormat + 1)),
+        (.corpusVersion, identity(expected, corpusVersion: expected.corpusVersion + 1)),
+        (.corpusDigest, identity(expected, corpusDigest: "invalid")),
+        (.registrySceneDigest, identity(expected, registrySceneDigest: "invalid")),
+        (.screenCompositionDigest, identity(expected, screenCompositionDigest: "invalid")),
+    ]
+
+    for (field, mismatched) in cases {
+        let runtime = RuntimeDouble()
+        var initializationCalls = 0
+        do {
+            _ = try AppleInstrumentCompatibilityGate.verify(mismatched) {
+                initializationCalls += 1
+                return runtime
+            }
+            Issue.record("The gate accepted a mismatch in \(field.rawValue)")
+        } catch let error as InstrumentCompatibilityError {
+            guard case let .mismatch(actualField, _, _) = error else {
+                Issue.record("The gate returned an unexpected error")
+                continue
+            }
+            #expect(actualField == field)
+        } catch {
+            Issue.record("The gate returned an untyped error: \(error)")
+        }
+        #expect(initializationCalls == 0)
+        #expect(runtime.renderCalls == 0)
+    }
+}
+
+@Test("A verified runtime can paint through IndicateAppleDisplay")
+func verifiedRuntimePaints() throws {
+    let runtime = RuntimeDouble()
+    let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+    let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
+    let requirements = PanelRequirements(
+        id: "test",
+        title: "Test",
+        criticalLayers: [],
+        frameMin: CGSize(width: 10, height: 10),
+        frameMax: CGSize(width: 10, height: 10),
+        canonicalFrame: CGSize(width: 10, height: 10)
+    )
+    let display = PanelDisplay(requirements: requirements, producer: producer)
+    let outcome = display.render(pixelWidth: 10, pixelHeight: 10, nowMs: 0)
+    #expect(!outcome.showingFailure)
+    #expect(runtime.renderCalls == 1)
+}
+
+@Test("A frame mismatch is covered before paint")
+func frameMismatchFailsClosed() throws {
+    let runtime = RuntimeDouble()
+    runtime.outcome = InstrumentRuntimeRenderOutcome(
+        status: 0,
+        scene: [1],
+        frameWidth: 11,
+        frameHeight: 10,
+        generation: 1
+    )
+    let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+    let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
+    let requirements = PanelRequirements(
+        id: "test",
+        title: "Test",
+        criticalLayers: [],
+        frameMin: CGSize(width: 10, height: 10),
+        frameMax: CGSize(width: 10, height: 10),
+        canonicalFrame: CGSize(width: 10, height: 10)
+    )
+    let display = PanelDisplay(requirements: requirements, producer: producer)
+    let outcome = display.render(pixelWidth: 10, pixelHeight: 10, nowMs: 0)
+    #expect(outcome.showingFailure)
+    #expect(outcome.reason == .abiMismatch)
+}
+
+@Test("Producer status codes remain typed through the Apple display")
+func producerStatusCodesRemainTyped() throws {
+    for (status, reason) in [
+        (UInt32(11), DisplayReason.stateMalformed),
+        (UInt32(12), DisplayReason.configInvalid),
+    ] {
+        let runtime = RuntimeDouble()
+        runtime.outcome = InstrumentRuntimeRenderOutcome(
+            status: status,
+            scene: [],
+            frameWidth: 10,
+            frameHeight: 10,
+            generation: 0
+        )
+        let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+        let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
+        do {
+            _ = try producer.frame(designFrame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            Issue.record("The producer accepted status \(status)")
+        } catch let fault as ProducerFault {
+            #expect(fault.reason == reason)
+        } catch {
+            Issue.record("The producer returned an untyped error: \(error)")
+        }
+    }
+}
+
+private func identity(
+    _ base: InstrumentRuntimeIdentity,
+    stateABI: UInt32? = nil,
+    sceneFormat: UInt32? = nil,
+    corpusVersion: UInt32? = nil,
+    corpusDigest: String? = nil,
+    registrySceneDigest: String? = nil,
+    screenCompositionDigest: String? = nil
+) -> InstrumentRuntimeIdentity {
+    InstrumentRuntimeIdentity(
+        stateABI: stateABI ?? base.stateABI,
+        sceneFormat: sceneFormat ?? base.sceneFormat,
+        corpusVersion: corpusVersion ?? base.corpusVersion,
+        corpusDigest: corpusDigest ?? base.corpusDigest,
+        registrySceneDigest: registrySceneDigest ?? base.registrySceneDigest,
+        screenCompositionDigest: screenCompositionDigest ?? base.screenCompositionDigest
+    )
+}

--- a/scripts/check-apple-instrument-consumer.sh
+++ b/scripts/check-apple-instrument-consumer.sh
@@ -29,9 +29,13 @@ if [ "$(uname -s)" = "Darwin" ]; then
     -Xcc "-fmodule-map-file=$module_map" "$generated_swift" \
     -emit-module -o "$output_root/pilotage_instrument_apple_bridge.swiftmodule"
   swift test --package-path clients/apple-instrument-consumer
+  consumer_bin_path="$(
+    swift build --package-path clients/apple-instrument-consumer --show-bin-path
+  )"
   swiftc -parse-as-library \
     -I "$output_root" \
-    -I clients/apple-instrument-consumer/.build/out/Products/Debug \
+    -I "$consumer_bin_path" \
+    -I "$consumer_bin_path/Modules" \
     -Xcc "-fmodule-map-file=$module_map" \
     clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift \
     -emit-module -o "$output_root/PilotageGeneratedBridgeAdapter.swiftmodule"

--- a/scripts/check-apple-instrument-consumer.sh
+++ b/scripts/check-apple-instrument-consumer.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Generates the bridge binding and verifies the native Apple consumer.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+case "$(uname -s)" in
+  Darwin) library="target/debug/libpilotage_instrument_apple_bridge.dylib" ;;
+  Linux) library="target/debug/libpilotage_instrument_apple_bridge.so" ;;
+  *) echo "unsupported host for Apple bridge generation" >&2; exit 1 ;;
+esac
+
+output_root="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-apple-bindings.XXXXXX")"
+trap 'rm -rf "$output_root"' EXIT
+
+cargo build --locked -p pilotage-instrument-apple-bridge --lib
+cargo run --locked --quiet -p pilotage-instrument-apple-bridge \
+  --bin pilotage_uniffi_bindgen -- \
+  generate --library --language swift --out-dir "$output_root" "$library"
+
+for symbol in stateAbiVersion sceneFormatVersion corpusVersion corpusDigestHex \
+  sceneDigestHex compositionDigestHex InstrumentBridge; do
+  grep -q "$symbol" "$output_root"/*.swift
+done
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  generated_swift="$(find "$output_root" -maxdepth 1 -name '*.swift' -print -quit)"
+  module_map="$output_root/pilotage_instrument_apple_bridgeFFI.modulemap"
+  swiftc -parse-as-library -I "$output_root" \
+    -Xcc "-fmodule-map-file=$module_map" "$generated_swift" \
+    -emit-module -o "$output_root/pilotage_instrument_apple_bridge.swiftmodule"
+  swift test --package-path clients/apple-instrument-consumer
+  swiftc -parse-as-library \
+    -I "$output_root" \
+    -I clients/apple-instrument-consumer/.build/out/Products/Debug \
+    -Xcc "-fmodule-map-file=$module_map" \
+    clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift \
+    -emit-module -o "$output_root/PilotageGeneratedBridgeAdapter.swiftmodule"
+  (
+    cd clients/apple-instrument-consumer
+    xcodebuild -scheme PilotageAppleInstrumentConsumer \
+      -destination 'generic/platform=iOS Simulator' \
+      -derivedDataPath "$output_root/DerivedData" \
+      CODE_SIGNING_ALLOWED=NO build
+  )
+fi
+
+echo "Apple instrument consumer checks passed"


### PR DESCRIPTION
Closes #326

Adds a thin UniFFI bridge over the portable instrument runtime and a Swift consumer pinned to IndicateAppleDisplay revision 74e5845d09a58342fd282ec426759550dafc6887.

The generated bridge exports the complete compatibility identity. The Swift gate checks that identity before it calls the runtime factory, so every mismatch produces zero runtime initializations and zero scene renders. Oversized state input clears the fixed buffer and fails without truncation. The scene producer remains unavailable until verification succeeds.

CI generates and compiles the real Swift binding, runs Swift tests through IndicateAppleDisplay, and builds unsigned for a generic iOS Simulator. A separate dependency guard proves that pilotage-session-host does not depend on the Apple bridge or UniFFI.

Local acceptance passed: formatting, Clippy, full Rust tests on repeat, documentation gates, release build, structure and certification guards, no-std checks, Indicate compatibility, six Rust bridge tests, five Swift tests, generated adapter compile, iOS Simulator build, dependency closure checks, Web/WASM build, and all 42 Web tests.