### PR TITLE
Make Apple instruments one clocked composition transaction

### DIFF
--- a/clients/apple-instrument-bridge/src/bridge.rs
+++ b/clients/apple-instrument-bridge/src/bridge.rs
@@ -1,17 +1,23 @@
-//! The bridge object: one owned instrument runtime behind the FFI.
-//! The caller copies each state frame in, then asks for panel scenes.
+//! The bridge object for one clocked composition transaction.
 
 use std::sync::Mutex;
 
-use pilotage_instrument_runtime::{RenderStatus, Runtime, canonical_frame, descriptor};
+use pilotage_instrument_runtime::{RenderStatus, Runtime};
 
-use crate::records::{BridgeRenderOutcome, BridgeWriteOutcome};
+use crate::records::{
+    BridgeCompositionFrameOutcome, BridgeCompositionPanelOutcome, BridgeWriteOutcome,
+};
+
+struct BridgeState {
+    runtime: Runtime,
+    accepted_at_ms: Option<u64>,
+}
 
 /// One owned instrument runtime behind the FFI. Each bridge object has
 /// independent buffers, configuration, and generations.
 #[derive(uniffi::Object)]
 pub struct InstrumentBridge {
-    runtime: Mutex<Runtime>,
+    state: Mutex<BridgeState>,
 }
 
 impl Default for InstrumentBridge {
@@ -26,70 +32,89 @@ impl InstrumentBridge {
     #[uniffi::constructor]
     pub fn new() -> Self {
         Self {
-            runtime: Mutex::new(Runtime::new()),
+            state: Mutex::new(BridgeState {
+                runtime: Runtime::new(),
+                accepted_at_ms: None,
+            }),
         }
     }
 
-    /// Copies one ABI state frame into the runtime's state buffer.
-    /// The function refuses input that exceeds the fixed capacity.
-    pub fn write_state(&self, bytes: &[u8]) -> BridgeWriteOutcome {
-        let mut runtime = match self.runtime.lock() {
+    /// Copies one state frame and records its monotonic acceptance time.
+    pub fn write_state(&self, bytes: &[u8], accepted_at_ms: u64) -> BridgeWriteOutcome {
+        let mut state = match self.state.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        let buffer = runtime.state_mut();
-        buffer.fill(0);
-        if bytes.len() > buffer.len() {
+        state.accepted_at_ms = None;
+        let capacity = Runtime::state_capacity();
+        state.runtime.state_mut().fill(0);
+        if bytes.len() > capacity {
             return BridgeWriteOutcome {
                 status: 1,
                 actual: bytes.len() as u64,
-                capacity: buffer.len() as u64,
+                capacity: capacity as u64,
             };
         }
-        if let Some(target) = buffer.get_mut(..bytes.len()) {
+        if let Some(target) = state.runtime.state_mut().get_mut(..bytes.len()) {
             target.copy_from_slice(bytes);
         }
+        state.accepted_at_ms = Some(accepted_at_ms);
         BridgeWriteOutcome {
             status: 0,
             actual: bytes.len() as u64,
-            capacity: buffer.len() as u64,
+            capacity: capacity as u64,
         }
     }
 
-    /// Renders one panel from the last written state frame.
-    ///
-    /// The runtime draws every panel at its canonical frame. The outcome
-    /// returns this frame so the caller can compare it with the frame that
-    /// its display backend requested.
-    ///
-    /// A failure carries a nonzero status, empty scene bytes, and an
-    /// unchanged generation.
-    pub fn render(&self, panel: u32) -> BridgeRenderOutcome {
-        let mut runtime = match self.runtime.lock() {
+    /// Produces all composition panels from one state and one clock.
+    pub fn composition_frame(
+        &self,
+        now_ms: u64,
+        path_healthy: bool,
+    ) -> BridgeCompositionFrameOutcome {
+        let mut state = match self.state.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        let outcome = runtime.render(panel);
-        let (emitted_width, emitted_height) = descriptor(panel)
-            .map(|d| {
-                let frame = canonical_frame(d);
-                (frame.width, frame.height)
-            })
-            .unwrap_or((0.0, 0.0));
+        let age_delta_ms = state
+            .accepted_at_ms
+            .map_or(0, |accepted_at_ms| now_ms.saturating_sub(accepted_at_ms));
+        let outcome = state
+            .runtime
+            .render_composition(age_delta_ms, now_ms, path_healthy);
         let scene = if outcome.status == RenderStatus::Ok {
-            runtime
-                .scene()
+            state
+                .runtime
+                .composition_scene()
                 .get(..outcome.scene_len as usize)
                 .map_or_else(Vec::new, <[u8]>::to_vec)
         } else {
             Vec::new()
         };
-        BridgeRenderOutcome {
+        let panels = state
+            .runtime
+            .composition_panel_outcomes()
+            .iter()
+            .map(|panel| BridgeCompositionPanelOutcome {
+                panel: panel.panel,
+                status: panel.status as u32,
+                scene_offset: panel.scene_offset,
+                scene_len: panel.scene_len,
+                frame_width: panel.frame_width,
+                frame_height: panel.frame_height,
+                generation: panel.generation,
+            })
+            .collect();
+        BridgeCompositionFrameOutcome {
             status: outcome.status as u32,
             scene,
-            frame_width: emitted_width,
-            frame_height: emitted_height,
+            panels,
             generation: outcome.generation,
+            alert_status: outcome.alerts.status as u32,
+            active_alert_count: outcome.alerts.active_count,
+            alert_path_faulted: outcome.alerts.faulted,
+            alert_overflow: outcome.alerts.overflow,
+            alert_manager_generation: outcome.alerts.manager_generation,
         }
     }
 }

--- a/clients/apple-instrument-bridge/src/lib.rs
+++ b/clients/apple-instrument-bridge/src/lib.rs
@@ -13,9 +13,8 @@
 //! - This bridge marshals data. It holds no panel logic and no state
 //!   derivation. It holds no latching and no interpretation helper.
 //!
-//! Deliberate boundary: this bridge does not export alert stepping or
-//! panel configuration. The Apple shell owns those functions only if
-//! its product surface needs them.
+//! The composition call steps alerts once and produces all panel scenes.
+//! The bridge does not export a per-panel render call.
 //!
 //! Companion-computer builds do not link this crate. The crate has no
 //! Apple-platform dependency: it builds on any host, and CI proves it.
@@ -38,7 +37,8 @@ pub use enumeration::{
     state_abi_version,
 };
 pub use records::{
-    BridgeCompositionSlot, BridgePanelDescriptor, BridgeRenderOutcome, BridgeWriteOutcome,
+    BridgeCompositionFrameOutcome, BridgeCompositionPanelOutcome, BridgeCompositionSlot,
+    BridgePanelDescriptor, BridgeWriteOutcome,
 };
 
 #[cfg(test)]

--- a/clients/apple-instrument-bridge/src/records.rs
+++ b/clients/apple-instrument-bridge/src/records.rs
@@ -39,26 +39,46 @@ pub struct BridgeCompositionSlot {
     pub height: f32,
 }
 
-/// The typed result of one render call: the producer status, the scene
-/// bytes, the frame the scene was emitted at, and the panel's
-/// successful-production generation.
+/// One panel result in a composition transaction.
 #[derive(uniffi::Record)]
-pub struct BridgeRenderOutcome {
-    /// The typed producer status: the `RenderStatus` discriminant. Zero
-    /// means the scene rendered and self-validated.
+pub struct BridgeCompositionPanelOutcome {
+    /// The panel index in the runtime registry.
+    pub panel: u32,
+    /// The composition transaction status.
     pub status: u32,
-    /// The typed scene bytes. Empty on every failure; the caller does
-    /// not paint on a nonzero status.
-    pub scene: Vec<u8>,
-    /// Width of the frame the scene was emitted at. The caller
-    /// compares it with the frame it prepared and does not paint on
-    /// mismatch.
+    /// The panel scene offset in the shared scene buffer.
+    pub scene_offset: u32,
+    /// The panel scene length in bytes.
+    pub scene_len: u32,
+    /// The width used to produce the panel scene.
     pub frame_width: f32,
-    /// Height of the frame the scene was emitted at.
+    /// The height used to produce the panel scene.
     pub frame_height: f32,
-    /// The panel's successful-production generation. It advances only
-    /// on success, so it is a liveness signal no failed render can fake.
+    /// The panel generation after a successful transaction.
     pub generation: u32,
+}
+
+/// The typed result of one complete composition transaction.
+#[derive(uniffi::Record)]
+pub struct BridgeCompositionFrameOutcome {
+    /// The transaction status. Zero means all panels committed.
+    pub status: u32,
+    /// All panel scenes in composition order. This is empty on failure.
+    pub scene: Vec<u8>,
+    /// The typed result for each composition slot.
+    pub panels: Vec<BridgeCompositionPanelOutcome>,
+    /// The composition generation after a successful transaction.
+    pub generation: u32,
+    /// The alert-step status from the same transaction.
+    pub alert_status: u32,
+    /// The number of active alerts.
+    pub active_alert_count: u32,
+    /// The independent alert path is faulted.
+    pub alert_path_faulted: bool,
+    /// The alert manager dropped events.
+    pub alert_overflow: bool,
+    /// The alert-manager generation.
+    pub alert_manager_generation: u32,
 }
 
 /// The typed result of one state-buffer write.

--- a/clients/apple-instrument-bridge/src/tests.rs
+++ b/clients/apple-instrument-bridge/src/tests.rs
@@ -30,6 +30,7 @@ fn attitude_state() -> AircraftState {
             }),
             age_ms: Some(10.0),
         },
+        quality: indicate_instrument_state::EstimateQuality::Good,
         valid: indicate_instrument_state::ValidFlags {
             attitude: true,
             rates: true,
@@ -96,17 +97,53 @@ fn digest_identity_equals_the_pinned_tuple_values() {
 #[test]
 fn render_round_trip_carries_the_typed_outcome() {
     let bridge = InstrumentBridge::new();
-    assert_eq!(bridge.write_state(&encode(&attitude_state())).status, 0);
+    assert_eq!(
+        bridge.write_state(&encode(&attitude_state()), 100).status,
+        0
+    );
 
-    let first = bridge.render(0);
+    let first = bridge.composition_frame(100, true);
     assert_eq!(first.status, RenderStatus::Ok as u32);
     assert!(!first.scene.is_empty(), "the outcome carries scene bytes");
     assert_eq!(first.generation, 1);
-    assert_eq!((first.frame_width, first.frame_height), (480.0, 360.0));
+    assert_eq!(first.panels.len(), 2);
+    assert_eq!(
+        (first.panels[0].frame_width, first.panels[0].frame_height),
+        (480.0, 360.0)
+    );
+    assert!(first.panels.iter().all(|panel| panel.generation == 1));
 
-    let second = bridge.render(0);
+    let second = bridge.composition_frame(101, true);
     assert_eq!(second.status, RenderStatus::Ok as u32);
     assert_eq!(second.generation, 2, "a second success advances generation");
+}
+
+#[test]
+fn quiet_input_crosses_both_freshness_thresholds() {
+    let bridge = InstrumentBridge::new();
+    assert_eq!(
+        bridge.write_state(&encode(&attitude_state()), 100).status,
+        0
+    );
+
+    let fresh = bridge.composition_frame(100, true);
+    let stale = bridge.composition_frame(900, true);
+    let failed = bridge.composition_frame(3_200, true);
+    assert_eq!(fresh.status, RenderStatus::Ok as u32);
+    assert_eq!(stale.status, RenderStatus::Ok as u32);
+    assert_eq!(failed.status, RenderStatus::Ok as u32);
+    assert_eq!(
+        (fresh.generation, stale.generation, failed.generation),
+        (1, 2, 3)
+    );
+    assert_ne!(
+        fresh.scene, stale.scene,
+        "stale data must change the scenes"
+    );
+    assert_ne!(
+        stale.scene, failed.scene,
+        "failed data must change the scenes"
+    );
 }
 
 #[test]
@@ -116,9 +153,9 @@ fn a_truncated_state_fails_with_unchanged_generation() {
     // over-declared group length is: tag 0x05 claims 65535 payload
     // bytes against the 1024-byte buffer.
     let bridge = InstrumentBridge::new();
-    assert_eq!(bridge.write_state(&[7, 1, 0x05, 0xff, 0xff]).status, 0);
+    assert_eq!(bridge.write_state(&[7, 1, 0x05, 0xff, 0xff], 0).status, 0);
 
-    let outcome = bridge.render(0);
+    let outcome = bridge.composition_frame(0, true);
     assert_eq!(outcome.status, RenderStatus::StateTruncated as u32);
     assert!(outcome.scene.is_empty(), "a failure carries no scene bytes");
     assert_eq!(outcome.generation, 0, "a failure never advances generation");
@@ -128,9 +165,9 @@ fn a_truncated_state_fails_with_unchanged_generation() {
 fn state_write_accepts_exact_capacity_and_refuses_capacity_plus_one() {
     let bridge = InstrumentBridge::new();
     let capacity = indicate_instrument_state::abi::v7::CAPACITY;
-    assert_eq!(bridge.write_state(&vec![0; capacity]).status, 0);
+    assert_eq!(bridge.write_state(&vec![0; capacity], 0).status, 0);
 
-    let error = bridge.write_state(&vec![0; capacity + 1]);
+    let error = bridge.write_state(&vec![0; capacity + 1], 0);
     assert_eq!(error.status, 1);
     assert_eq!(error.actual, (capacity + 1) as u64);
     assert_eq!(error.capacity, capacity as u64);
@@ -140,14 +177,14 @@ fn state_write_accepts_exact_capacity_and_refuses_capacity_plus_one() {
 fn oversized_valid_prefix_is_not_truncated_into_an_accepted_frame() {
     let bridge = InstrumentBridge::new();
     let encoded = encode(&attitude_state());
-    assert_eq!(bridge.write_state(&encoded).status, 0);
-    let first = bridge.render(0);
+    assert_eq!(bridge.write_state(&encoded, 0).status, 0);
+    let first = bridge.composition_frame(0, true);
     assert_eq!(first.status, RenderStatus::Ok as u32);
 
     let mut oversized = encoded;
     oversized.resize(indicate_instrument_state::abi::v7::CAPACITY + 1, 0);
-    assert_eq!(bridge.write_state(&oversized).status, 1);
-    let refused = bridge.render(0);
+    assert_eq!(bridge.write_state(&oversized, 1).status, 1);
+    let refused = bridge.composition_frame(1, true);
     assert_ne!(refused.status, RenderStatus::Ok as u32);
     assert!(refused.scene.is_empty());
     assert_eq!(refused.generation, first.generation);

--- a/clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift
+++ b/clients/apple-instrument-bridge/swift/GeneratedBridgeAdapter.swift
@@ -28,8 +28,8 @@ public final class GeneratedInstrumentRuntime: InstrumentRuntimeServing {
         bridge = InstrumentBridge()
     }
 
-    public func writeState(_ bytes: [UInt8]) throws {
-        let outcome = bridge.writeState(bytes: Data(bytes))
+    public func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws {
+        let outcome = bridge.writeState(bytes: Data(bytes), acceptedAtMs: acceptedAtMs)
         switch outcome.status {
         case 0:
             return
@@ -43,14 +43,32 @@ public final class GeneratedInstrumentRuntime: InstrumentRuntimeServing {
         }
     }
 
-    public func render(panel: UInt32) -> InstrumentRuntimeRenderOutcome {
-        let outcome = bridge.render(panel: panel)
-        return InstrumentRuntimeRenderOutcome(
+    public func compositionFrame(
+        nowMs: UInt64,
+        pathHealthy: Bool
+    ) -> InstrumentRuntimeCompositionOutcome {
+        let outcome = bridge.compositionFrame(nowMs: nowMs, pathHealthy: pathHealthy)
+        let panels = outcome.panels.map { panel in
+            InstrumentRuntimePanelOutcome(
+                panel: panel.panel,
+                status: panel.status,
+                sceneOffset: panel.sceneOffset,
+                sceneLength: panel.sceneLen,
+                frameWidth: panel.frameWidth,
+                frameHeight: panel.frameHeight,
+                generation: panel.generation
+            )
+        }
+        return InstrumentRuntimeCompositionOutcome(
             status: outcome.status,
             scene: Array(outcome.scene),
-            frameWidth: outcome.frameWidth,
-            frameHeight: outcome.frameHeight,
-            generation: outcome.generation
+            panels: panels,
+            generation: outcome.generation,
+            alertStatus: outcome.alertStatus,
+            activeAlertCount: outcome.activeAlertCount,
+            alertPathFaulted: outcome.alertPathFaulted,
+            alertOverflow: outcome.alertOverflow,
+            alertManagerGeneration: outcome.alertManagerGeneration
         )
     }
 }

--- a/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/CompatibilityGate.swift
+++ b/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/CompatibilityGate.swift
@@ -45,33 +45,74 @@ public struct InstrumentRuntimeIdentity: Equatable, Sendable {
     }
 }
 
-/// The scene data returned by the generated Pilotage bridge.
-public struct InstrumentRuntimeRenderOutcome: Equatable, Sendable {
+/// One panel result in a runtime composition transaction.
+public struct InstrumentRuntimePanelOutcome: Equatable, Sendable {
+    public let panel: UInt32
     public let status: UInt32
-    public let scene: [UInt8]
+    public let sceneOffset: UInt32
+    public let sceneLength: UInt32
     public let frameWidth: Float
     public let frameHeight: Float
     public let generation: UInt32
 
     public init(
+        panel: UInt32,
         status: UInt32,
-        scene: [UInt8],
+        sceneOffset: UInt32,
+        sceneLength: UInt32,
         frameWidth: Float,
         frameHeight: Float,
         generation: UInt32
     ) {
+        self.panel = panel
         self.status = status
-        self.scene = scene
+        self.sceneOffset = sceneOffset
+        self.sceneLength = sceneLength
         self.frameWidth = frameWidth
         self.frameHeight = frameHeight
         self.generation = generation
     }
 }
 
+/// The scenes and status from one complete composition transaction.
+public struct InstrumentRuntimeCompositionOutcome: Equatable, Sendable {
+    public let status: UInt32
+    public let scene: [UInt8]
+    public let panels: [InstrumentRuntimePanelOutcome]
+    public let generation: UInt32
+    public let alertStatus: UInt32
+    public let activeAlertCount: UInt32
+    public let alertPathFaulted: Bool
+    public let alertOverflow: Bool
+    public let alertManagerGeneration: UInt32
+
+    public init(
+        status: UInt32,
+        scene: [UInt8],
+        panels: [InstrumentRuntimePanelOutcome],
+        generation: UInt32,
+        alertStatus: UInt32 = 0,
+        activeAlertCount: UInt32 = 0,
+        alertPathFaulted: Bool = false,
+        alertOverflow: Bool = false,
+        alertManagerGeneration: UInt32 = 0
+    ) {
+        self.status = status
+        self.scene = scene
+        self.panels = panels
+        self.generation = generation
+        self.alertStatus = alertStatus
+        self.activeAlertCount = activeAlertCount
+        self.alertPathFaulted = alertPathFaulted
+        self.alertOverflow = alertOverflow
+        self.alertManagerGeneration = alertManagerGeneration
+    }
+}
+
 /// The narrow runtime surface that the Apple shell consumes.
 public protocol InstrumentRuntimeServing: AnyObject {
-    func writeState(_ bytes: [UInt8]) throws
-    func render(panel: UInt32) -> InstrumentRuntimeRenderOutcome
+    func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws
+    func compositionFrame(nowMs: UInt64, pathHealthy: Bool) -> InstrumentRuntimeCompositionOutcome
 }
 
 /// A state write that the generated bridge refused.
@@ -88,12 +129,19 @@ public final class VerifiedInstrumentRuntime {
         self.runtime = runtime
     }
 
-    public func writeState(_ bytes: [UInt8]) throws {
-        try runtime.writeState(bytes)
+    public func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws {
+        try runtime.writeState(bytes, acceptedAtMs: acceptedAtMs)
+    }
+
+    public func compositionFrame(
+        nowMs: UInt64,
+        pathHealthy: Bool
+    ) -> InstrumentRuntimeCompositionOutcome {
+        runtime.compositionFrame(nowMs: nowMs, pathHealthy: pathHealthy)
     }
 }
 
-    /// Verifies the runtime and Apple display identities before runtime creation.
+/// Verifies the runtime and Apple display identities before runtime creation.
 public enum AppleInstrumentCompatibilityGate {
     public static let stateABI: UInt32 = 7
     public static let registrySceneDigest =

--- a/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
+++ b/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
@@ -1,30 +1,101 @@
 import CoreGraphics
 import IndicateAppleDisplay
 
-/// A scene producer that is available only after compatibility verification.
-public final class PilotageInstrumentSceneProducer: SceneProducing {
+/// One committed composition frame that all panel producers share.
+public final class PilotageInstrumentComposition {
     private let verifiedRuntime: VerifiedInstrumentRuntime
+    private var panels: [UInt32: (scene: [UInt8], outcome: InstrumentRuntimePanelOutcome)] = [:]
+
+    public init(verifiedRuntime: VerifiedInstrumentRuntime) {
+        self.verifiedRuntime = verifiedRuntime
+    }
+
+    /// Accepts one state frame and invalidates the current scenes.
+    public func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws {
+        panels.removeAll(keepingCapacity: true)
+        try verifiedRuntime.writeState(bytes, acceptedAtMs: acceptedAtMs)
+    }
+
+    /// Produces and commits all composition panels with one runtime call.
+    @discardableResult
+    public func compose(nowMs: UInt64, pathHealthy: Bool) throws -> UInt32 {
+        panels.removeAll(keepingCapacity: true)
+        let frame = verifiedRuntime.compositionFrame(
+            nowMs: nowMs,
+            pathHealthy: pathHealthy
+        )
+        try requireSuccess(frame.status)
+        try requireSuccess(frame.alertStatus)
+
+        var next: [UInt32: (scene: [UInt8], outcome: InstrumentRuntimePanelOutcome)] = [:]
+        next.reserveCapacity(frame.panels.count)
+        for outcome in frame.panels {
+            try requireSuccess(outcome.status)
+            let scene = try panelScene(outcome, in: frame.scene)
+            guard next.updateValue((scene, outcome), forKey: outcome.panel) == nil else {
+                throw ProducerFault(reason: .abiMismatch)
+            }
+        }
+        guard !next.isEmpty else {
+            throw ProducerFault(reason: .sceneFraming)
+        }
+        panels = next
+        return frame.generation
+    }
+
+    /// Creates one panel producer over the shared committed frame.
+    public func producer(panel: UInt32) -> PilotageInstrumentSceneProducer {
+        PilotageInstrumentSceneProducer(composition: self, panel: panel)
+    }
+
+    fileprivate func frame(panel: UInt32, designFrame: CGRect) throws -> SceneFrame {
+        guard let committed = panels[panel] else {
+            throw ProducerFault(reason: .notInitialized)
+        }
+        guard committed.outcome.frameWidth == Float(designFrame.width),
+              committed.outcome.frameHeight == Float(designFrame.height) else {
+            throw ProducerFault(reason: .abiMismatch)
+        }
+        return SceneFrame(
+            bytes: committed.scene,
+            generation: committed.outcome.generation
+        )
+    }
+}
+
+/// A panel producer over one committed composition frame.
+public final class PilotageInstrumentSceneProducer: SceneProducing {
+    private let composition: PilotageInstrumentComposition
     private let panel: UInt32
 
-    public init(verifiedRuntime: VerifiedInstrumentRuntime, panel: UInt32) {
-        self.verifiedRuntime = verifiedRuntime
+    fileprivate init(composition: PilotageInstrumentComposition, panel: UInt32) {
+        self.composition = composition
         self.panel = panel
     }
 
     public func frame(designFrame: CGRect) throws -> SceneFrame {
-        let outcome = verifiedRuntime.runtime.render(panel: panel)
-        guard outcome.status == 0 else {
-            let code = UInt16(exactly: outcome.status)
-            let reason = code.flatMap(DisplayReason.init(rawValue:)) ?? .renderTrap
-            throw ProducerFault(reason: reason == .ok ? .renderTrap : reason)
-        }
-        guard outcome.frameWidth == Float(designFrame.width),
-              outcome.frameHeight == Float(designFrame.height) else {
-            throw ProducerFault(reason: .abiMismatch)
-        }
-        guard !outcome.scene.isEmpty else {
-            throw ProducerFault(reason: .sceneFraming)
-        }
-        return SceneFrame(bytes: outcome.scene, generation: outcome.generation)
+        try composition.frame(panel: panel, designFrame: designFrame)
     }
+}
+
+private func requireSuccess(_ status: UInt32) throws {
+    guard status == 0 else {
+        let code = UInt16(exactly: status)
+        let reason = code.flatMap(DisplayReason.init(rawValue:)) ?? .renderTrap
+        throw ProducerFault(reason: reason == .ok ? .renderTrap : reason)
+    }
+}
+
+private func panelScene(
+    _ panel: InstrumentRuntimePanelOutcome,
+    in scene: [UInt8]
+) throws -> [UInt8] {
+    guard let start = Int(exactly: panel.sceneOffset),
+          let count = Int(exactly: panel.sceneLength),
+          count > 0,
+          start <= scene.count,
+          count <= scene.count - start else {
+        throw ProducerFault(reason: .sceneFraming)
+    }
+    return Array(scene[start ..< start + count])
 }

--- a/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
+++ b/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
@@ -5,19 +5,34 @@ import Testing
 @testable import PilotageAppleInstrumentConsumer
 
 private final class RuntimeDouble: InstrumentRuntimeServing {
-    var renderCalls = 0
-    var outcome = InstrumentRuntimeRenderOutcome(
+    var compositionCalls = 0
+    var writes: [(bytes: [UInt8], acceptedAtMs: UInt64)] = []
+    var outcome = InstrumentRuntimeCompositionOutcome(
         status: 0,
         scene: [1],
-        frameWidth: 10,
-        frameHeight: 10,
+        panels: [
+            InstrumentRuntimePanelOutcome(
+                panel: 0,
+                status: 0,
+                sceneOffset: 0,
+                sceneLength: 1,
+                frameWidth: 10,
+                frameHeight: 10,
+                generation: 1
+            ),
+        ],
         generation: 1
     )
 
-    func writeState(_: [UInt8]) throws {}
+    func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws {
+        writes.append((bytes, acceptedAtMs))
+    }
 
-    func render(panel _: UInt32) -> InstrumentRuntimeRenderOutcome {
-        renderCalls += 1
+    func compositionFrame(
+        nowMs _: UInt64,
+        pathHealthy _: Bool
+    ) -> InstrumentRuntimeCompositionOutcome {
+        compositionCalls += 1
         return outcome
     }
 }
@@ -52,6 +67,17 @@ private func matchingIdentity() -> InstrumentRuntimeIdentity {
     )
 }
 
+private func requirements(width: CGFloat = 10) -> PanelRequirements {
+    PanelRequirements(
+        id: "test",
+        title: "Test",
+        criticalLayers: [],
+        frameMin: CGSize(width: width, height: 10),
+        frameMax: CGSize(width: width, height: 10),
+        canonicalFrame: CGSize(width: width, height: 10)
+    )
+}
+
 @Test("The Swift gate equals the Pilotage consumer pin")
 func swiftGateMatchesConsumerPin() throws {
     let pin = try compatibilityPin()
@@ -66,7 +92,7 @@ func swiftGateMatchesConsumerPin() throws {
     )
 }
 
-@Test("Each compatibility mismatch stops scene production")
+@Test("Each compatibility mismatch stops composition production")
 func everyMismatchStopsBeforeProduction() {
     let expected = matchingIdentity()
     let cases: [(InstrumentCompatibilityField, InstrumentRuntimeIdentity)] = [
@@ -97,80 +123,140 @@ func everyMismatchStopsBeforeProduction() {
             Issue.record("The gate returned an untyped error: \(error)")
         }
         #expect(initializationCalls == 0)
-        #expect(runtime.renderCalls == 0)
+        #expect(runtime.compositionCalls == 0)
     }
 }
 
-@Test("A verified runtime can paint through IndicateAppleDisplay")
-func verifiedRuntimePaints() throws {
+@Test("A verified composition can paint through IndicateAppleDisplay")
+func verifiedCompositionPaints() throws {
     let runtime = RuntimeDouble()
     let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
-    let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
-    let requirements = PanelRequirements(
-        id: "test",
-        title: "Test",
-        criticalLayers: [],
-        frameMin: CGSize(width: 10, height: 10),
-        frameMax: CGSize(width: 10, height: 10),
-        canonicalFrame: CGSize(width: 10, height: 10)
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+    try composition.compose(nowMs: 100, pathHealthy: true)
+    let display = PanelDisplay(
+        requirements: requirements(),
+        producer: composition.producer(panel: 0)
     )
-    let display = PanelDisplay(requirements: requirements, producer: producer)
-    let outcome = display.render(pixelWidth: 10, pixelHeight: 10, nowMs: 0)
+
+    let outcome = display.render(pixelWidth: 10, pixelHeight: 10, nowMs: 100)
     #expect(!outcome.showingFailure)
-    #expect(runtime.renderCalls == 1)
+    #expect(runtime.compositionCalls == 1)
 }
 
-@Test("A frame mismatch is covered before paint")
+@Test("One runtime call supplies every panel producer")
+func oneRuntimeCallSuppliesEveryPanel() throws {
+    let runtime = RuntimeDouble()
+    runtime.outcome = InstrumentRuntimeCompositionOutcome(
+        status: 0,
+        scene: [1, 1],
+        panels: [
+            InstrumentRuntimePanelOutcome(
+                panel: 0, status: 0, sceneOffset: 0, sceneLength: 1,
+                frameWidth: 10, frameHeight: 10, generation: 7
+            ),
+            InstrumentRuntimePanelOutcome(
+                panel: 1, status: 0, sceneOffset: 1, sceneLength: 1,
+                frameWidth: 20, frameHeight: 10, generation: 7
+            ),
+        ],
+        generation: 7
+    )
+    let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+
+    #expect(try composition.compose(nowMs: 500, pathHealthy: true) == 7)
+    let first = try composition.producer(panel: 0).frame(
+        designFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
+    )
+    let second = try composition.producer(panel: 1).frame(
+        designFrame: CGRect(x: 0, y: 0, width: 20, height: 10)
+    )
+    #expect(first.bytes == [1])
+    #expect(second.bytes == [1])
+    #expect(runtime.compositionCalls == 1)
+}
+
+@Test("State acceptance time reaches the runtime and clears cached scenes")
+func stateAcceptanceInvalidatesCachedScenes() throws {
+    let runtime = RuntimeDouble()
+    let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+    try composition.compose(nowMs: 100, pathHealthy: true)
+
+    try composition.writeState([7, 0], acceptedAtMs: 250)
+    #expect(runtime.writes.count == 1)
+    #expect(runtime.writes[0].bytes == [7, 0])
+    #expect(runtime.writes[0].acceptedAtMs == 250)
+    do {
+        _ = try composition.producer(panel: 0).frame(
+            designFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
+        )
+        Issue.record("A state write left the previous scene available")
+    } catch let fault as ProducerFault {
+        #expect(fault.reason == .notInitialized)
+    } catch {
+        Issue.record("The producer returned an untyped error: \(error)")
+    }
+}
+
+@Test("A failed transaction removes the previous composition")
+func failedTransactionRemovesPreviousComposition() throws {
+    let runtime = RuntimeDouble()
+    let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+    try composition.compose(nowMs: 100, pathHealthy: true)
+    runtime.outcome = InstrumentRuntimeCompositionOutcome(
+        status: 11,
+        scene: [],
+        panels: [],
+        generation: 1
+    )
+
+    do {
+        try composition.compose(nowMs: 200, pathHealthy: true)
+        Issue.record("The composition accepted a failed transaction")
+    } catch let fault as ProducerFault {
+        #expect(fault.reason == .stateMalformed)
+    } catch {
+        Issue.record("The composition returned an untyped error: \(error)")
+    }
+    do {
+        _ = try composition.producer(panel: 0).frame(
+            designFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
+        )
+        Issue.record("The failed transaction left an old scene available")
+    } catch let fault as ProducerFault {
+        #expect(fault.reason == .notInitialized)
+    } catch {
+        Issue.record("The producer returned an untyped error: \(error)")
+    }
+}
+
+@Test("A panel frame mismatch fails before paint")
 func frameMismatchFailsClosed() throws {
     let runtime = RuntimeDouble()
-    runtime.outcome = InstrumentRuntimeRenderOutcome(
+    runtime.outcome = InstrumentRuntimeCompositionOutcome(
         status: 0,
         scene: [1],
-        frameWidth: 11,
-        frameHeight: 10,
+        panels: [
+            InstrumentRuntimePanelOutcome(
+                panel: 0, status: 0, sceneOffset: 0, sceneLength: 1,
+                frameWidth: 11, frameHeight: 10, generation: 1
+            ),
+        ],
         generation: 1
     )
     let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
-    let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
-    let requirements = PanelRequirements(
-        id: "test",
-        title: "Test",
-        criticalLayers: [],
-        frameMin: CGSize(width: 10, height: 10),
-        frameMax: CGSize(width: 10, height: 10),
-        canonicalFrame: CGSize(width: 10, height: 10)
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+    try composition.compose(nowMs: 0, pathHealthy: true)
+    let display = PanelDisplay(
+        requirements: requirements(),
+        producer: composition.producer(panel: 0)
     )
-    let display = PanelDisplay(requirements: requirements, producer: producer)
+
     let outcome = display.render(pixelWidth: 10, pixelHeight: 10, nowMs: 0)
     #expect(outcome.showingFailure)
     #expect(outcome.reason == .abiMismatch)
-}
-
-@Test("Producer status codes remain typed through the Apple display")
-func producerStatusCodesRemainTyped() throws {
-    for (status, reason) in [
-        (UInt32(11), DisplayReason.stateMalformed),
-        (UInt32(12), DisplayReason.configInvalid),
-    ] {
-        let runtime = RuntimeDouble()
-        runtime.outcome = InstrumentRuntimeRenderOutcome(
-            status: status,
-            scene: [],
-            frameWidth: 10,
-            frameHeight: 10,
-            generation: 0
-        )
-        let verified = try AppleInstrumentCompatibilityGate.verify(matchingIdentity()) { runtime }
-        let producer = PilotageInstrumentSceneProducer(verifiedRuntime: verified, panel: 0)
-        do {
-            _ = try producer.frame(designFrame: CGRect(x: 0, y: 0, width: 10, height: 10))
-            Issue.record("The producer accepted status \(status)")
-        } catch let fault as ProducerFault {
-            #expect(fault.reason == reason)
-        } catch {
-            Issue.record("The producer returned an untyped error: \(error)")
-        }
-    }
 }
 
 private func identity(

--- a/crates/pilotage-instrument-runtime/src/composition_frame.rs
+++ b/crates/pilotage-instrument-runtime/src/composition_frame.rs
@@ -1,0 +1,340 @@
+//! Atomic production of all panel scenes in the screen composition.
+
+use indicate_alerts::{AlertContext, ManagerHealth};
+use indicate_instrument_registry::{ConfigBlob, PanelDrawError};
+use indicate_instrument_scene::SceneWriter;
+use indicate_instrument_state::abi::v7::{self, AbiError};
+use indicate_instrument_state::{AircraftState, FreshnessPolicy, PanelData, Stamped};
+
+use crate::RenderStatus;
+use crate::composition::composition;
+use crate::registry::{canonical_frame, descriptor, panel_index};
+use crate::runtime::{
+    AlertStepOutcome, Runtime, derive_alert_events, scene_error_status, validate_panel_scene,
+};
+
+/// The result for one panel in a composition transaction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CompositionPanelOutcome {
+    /// The panel index in the runtime registry.
+    pub panel: u32,
+    /// The status of the complete composition transaction.
+    pub status: RenderStatus,
+    /// The panel scene offset in the composition scene buffer.
+    pub scene_offset: u32,
+    /// The panel scene length in bytes.
+    pub scene_len: u32,
+    /// The width used to produce the panel scene.
+    pub frame_width: f32,
+    /// The height used to produce the panel scene.
+    pub frame_height: f32,
+    /// The panel generation after a successful transaction.
+    pub generation: u32,
+}
+
+impl CompositionPanelOutcome {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            panel: 0,
+            status: RenderStatus::InvalidPanel,
+            scene_offset: 0,
+            scene_len: 0,
+            frame_width: 0.0,
+            frame_height: 0.0,
+            generation: 0,
+        }
+    }
+}
+
+/// The result of one complete screen-composition transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompositionFrameOutcome {
+    /// The status of the transaction.
+    pub status: RenderStatus,
+    /// The committed composition scene length. This is zero on failure.
+    pub scene_len: u32,
+    /// The composition generation. It advances only on full success.
+    pub generation: u32,
+    /// The alert result from the same state and clock.
+    pub alerts: AlertStepOutcome,
+}
+
+impl CompositionFrameOutcome {
+    fn failure(status: RenderStatus, generation: u32) -> Self {
+        Self {
+            status,
+            scene_len: 0,
+            generation,
+            alerts: AlertStepOutcome::failure(status),
+        }
+    }
+}
+
+impl Runtime {
+    /// Returns the committed bytes from the last successful composition.
+    pub fn composition_scene(&self) -> &[u8] {
+        &self.composition_scene
+    }
+
+    /// Returns the panel results from the last composition attempt.
+    pub fn composition_panel_outcomes(&self) -> &[CompositionPanelOutcome] {
+        &self.composition_panels
+    }
+
+    /// Produces every panel from one aged state and one alert step.
+    ///
+    /// `age_delta_ms` is the elapsed monotonic time since the state frame
+    /// was accepted. `now_ms` is the same clock at the frame boundary.
+    pub fn render_composition(
+        &mut self,
+        age_delta_ms: u64,
+        now_ms: u64,
+        path_healthy: bool,
+    ) -> CompositionFrameOutcome {
+        if !self.reset_composition_panels() {
+            return self.fail_composition(RenderStatus::InvalidPanel);
+        }
+        let report = match v7::decode_state(&self.state) {
+            Ok(report) => report,
+            Err(error) => return self.fail_composition(abi_error_status(error)),
+        };
+        let mut state = report.state;
+        age_state(&mut state, age_delta_ms);
+
+        let mut unusual = self.unusual;
+        let data = indicate_instrument_state::resolve_stateful(
+            &state,
+            &FreshnessPolicy::default(),
+            &self.profile,
+            &mut unusual,
+        );
+        let (alerts, alert_output, alert_outcome) = self.stage_alerts(&data, now_ms, path_healthy);
+        if let Err(status) = self.draw_composition(&data, &alert_output) {
+            return self.fail_composition(status);
+        }
+
+        self.unusual = unusual;
+        self.alerts = alerts;
+        self.alert_output = Some(alert_output);
+        self.unknown_groups = self
+            .unknown_groups
+            .wrapping_add(u32::from(report.unknown_groups));
+        self.extended_groups = self
+            .extended_groups
+            .wrapping_add(u32::from(report.extended_groups));
+        let Some(scene_len) = self.commit_composition() else {
+            return self.fail_composition(RenderStatus::InvalidPanel);
+        };
+        CompositionFrameOutcome {
+            status: RenderStatus::Ok,
+            scene_len,
+            generation: self.composition_generation,
+            alerts: alert_outcome,
+        }
+    }
+
+    fn stage_alerts(
+        &self,
+        data: &PanelData,
+        now_ms: u64,
+        path_healthy: bool,
+    ) -> (
+        indicate_alerts::AlertManager,
+        indicate_alerts::AlertOutput,
+        AlertStepOutcome,
+    ) {
+        let mut manager = self.alerts.clone();
+        let context = AlertContext {
+            declutter: data.presentation.unusual,
+            alerting_path_healthy: path_healthy,
+            ..AlertContext::default()
+        };
+        let output = manager.step(
+            &self.alert_profile,
+            &derive_alert_events(data),
+            context,
+            now_ms,
+        );
+        let outcome = AlertStepOutcome {
+            status: RenderStatus::Ok,
+            active_count: output.active().len() as u32,
+            faulted: output.health() == ManagerHealth::Faulted,
+            overflow: output.overflow(),
+            manager_generation: output.generation(),
+        };
+        (manager, output, outcome)
+    }
+
+    fn draw_composition(
+        &mut self,
+        data: &PanelData,
+        alerts: &indicate_alerts::AlertOutput,
+    ) -> Result<(), RenderStatus> {
+        let Some(composition) = composition() else {
+            return Err(RenderStatus::InvalidPanel);
+        };
+        if self.composition_panels.len() != composition.slots.len() {
+            return Err(RenderStatus::InvalidPanel);
+        }
+        let mut offset = 0usize;
+        for (slot_idx, slot) in composition.slots.iter().enumerate() {
+            let Some(panel_idx) = panel_index(slot.panel) else {
+                return Err(RenderStatus::InvalidPanel);
+            };
+            let len = self.draw_panel(panel_idx, data, alerts)?;
+            let Some(end) = offset.checked_add(len) else {
+                return Err(RenderStatus::SceneBufferFull);
+            };
+            let Some(target) = self.composition_scene.get_mut(offset..end) else {
+                return Err(RenderStatus::SceneBufferFull);
+            };
+            target.copy_from_slice(&self.scene[..len]);
+            self.composition_panels[slot_idx] = self.panel_outcome(panel_idx, offset, len);
+            offset = end;
+        }
+        Ok(())
+    }
+
+    fn reset_composition_panels(&mut self) -> bool {
+        let Some(composition) = composition() else {
+            return false;
+        };
+        if self.composition_panels.len() != composition.slots.len() {
+            return false;
+        }
+        for (outcome, slot) in self
+            .composition_panels
+            .iter_mut()
+            .zip(composition.slots.iter())
+        {
+            let Some(panel_idx) = panel_index(slot.panel) else {
+                return false;
+            };
+            let frame = descriptor(panel_idx as u32).map(canonical_frame);
+            *outcome = CompositionPanelOutcome {
+                panel: panel_idx as u32,
+                status: RenderStatus::InvalidPanel,
+                scene_offset: 0,
+                scene_len: 0,
+                frame_width: frame.map_or(0.0, |value| value.width),
+                frame_height: frame.map_or(0.0, |value| value.height),
+                generation: self.generation.get(panel_idx).copied().unwrap_or(0),
+            };
+        }
+        true
+    }
+
+    fn draw_panel(
+        &mut self,
+        panel_idx: usize,
+        data: &PanelData,
+        alerts: &indicate_alerts::AlertOutput,
+    ) -> Result<usize, RenderStatus> {
+        let Some(panel) = descriptor(panel_idx as u32) else {
+            return Err(RenderStatus::InvalidPanel);
+        };
+        let config_bytes = self.config.get(panel_idx).map_or(&[][..], Vec::as_slice);
+        let config = ConfigBlob::parse(config_bytes).map_err(|_| RenderStatus::ConfigInvalid)?;
+        let mut writer = SceneWriter::new(&mut self.scene).map_err(scene_error_status)?;
+        let frame = canonical_frame(panel);
+        let len = match (panel.draw)(data, &config, Some(alerts), frame, &mut writer) {
+            Ok(()) => writer.finish(),
+            Err(PanelDrawError::Scene(error)) => return Err(scene_error_status(error)),
+            Err(PanelDrawError::Config(_)) => return Err(RenderStatus::ConfigInvalid),
+        };
+        let status = validate_panel_scene(panel_idx, &self.scene[..len]);
+        if status != RenderStatus::Ok {
+            return Err(status);
+        }
+        Ok(len)
+    }
+
+    fn panel_outcome(
+        &self,
+        panel_idx: usize,
+        offset: usize,
+        len: usize,
+    ) -> CompositionPanelOutcome {
+        let frame = descriptor(panel_idx as u32).map(canonical_frame);
+        CompositionPanelOutcome {
+            panel: panel_idx as u32,
+            status: RenderStatus::Ok,
+            scene_offset: offset as u32,
+            scene_len: len as u32,
+            frame_width: frame.map_or(0.0, |value| value.width),
+            frame_height: frame.map_or(0.0, |value| value.height),
+            generation: self.panel_generation(panel_idx),
+        }
+    }
+
+    fn commit_composition(&mut self) -> Option<u32> {
+        if self
+            .composition_panels
+            .iter()
+            .any(|panel| self.generation.get(panel.panel as usize).is_none())
+        {
+            return None;
+        }
+        let mut scene_len = 0u32;
+        for panel in &mut self.composition_panels {
+            let panel_idx = panel.panel as usize;
+            if let Some(generation) = self.generation.get_mut(panel_idx) {
+                *generation = generation.wrapping_add(1);
+                panel.generation = *generation;
+            }
+            scene_len = scene_len.saturating_add(panel.scene_len);
+        }
+        self.composition_generation = self.composition_generation.wrapping_add(1);
+        Some(scene_len)
+    }
+
+    fn fail_composition(&mut self, status: RenderStatus) -> CompositionFrameOutcome {
+        for panel in &mut self.composition_panels {
+            panel.status = status;
+            panel.scene_offset = 0;
+            panel.scene_len = 0;
+            panel.generation = self
+                .generation
+                .get(panel.panel as usize)
+                .copied()
+                .unwrap_or(0);
+        }
+        CompositionFrameOutcome::failure(status, self.composition_generation)
+    }
+}
+
+fn abi_error_status(error: AbiError) -> RenderStatus {
+    match error {
+        AbiError::Truncated => RenderStatus::StateTruncated,
+        AbiError::BadVersion { .. } => RenderStatus::StateBadVersion,
+        AbiError::NonCanonicalOrder { .. } | AbiError::GroupTruncated { .. } => {
+            RenderStatus::StateMalformed
+        }
+    }
+}
+
+fn age_state(state: &mut AircraftState, delta_ms: u64) {
+    let delta = delta_ms as f32;
+    age_stamp(&mut state.attitude, delta);
+    age_stamp(&mut state.kinematics, delta);
+    age_stamp(&mut state.air, delta);
+    age_stamp(&mut state.nav, delta);
+    age_stamp(&mut state.wind, delta);
+    age_stamp(&mut state.heading, delta);
+    age_stamp(&mut state.variation, delta);
+    age_stamp(&mut state.dynamics, delta);
+    age_stamp(&mut state.director, delta);
+    age_stamp(&mut state.monitor_text, delta);
+}
+
+fn age_stamp<T>(stamp: &mut Stamped<T>, delta_ms: f32) {
+    if let Some(age_ms) = stamp.age_ms
+        && age_ms.is_finite()
+        && age_ms >= 0.0
+    {
+        stamp.age_ms = Some((age_ms + delta_ms).min(f32::MAX));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-instrument-runtime/src/composition_frame/tests.rs
+++ b/crates/pilotage-instrument-runtime/src/composition_frame/tests.rs
@@ -1,0 +1,176 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_instrument_scene::{Cmd, SceneCmds};
+use indicate_instrument_state::{AircraftState, SignalStatus, Stamped};
+
+use super::age_state;
+use crate::tests::{attitude_state, encoded_state_block, write_state};
+use crate::{RenderStatus, Runtime};
+
+fn panel_scene(runtime: &Runtime, slot: usize) -> Vec<u8> {
+    let panel = runtime
+        .composition_panel_outcomes()
+        .get(slot)
+        .expect("composition slot");
+    let start = panel.scene_offset as usize;
+    let end = start + panel.scene_len as usize;
+    runtime.composition_scene()[start..end].to_vec()
+}
+
+fn altitude_state() -> AircraftState {
+    let mut state = attitude_state();
+    state.kinematics = Stamped {
+        data: Some(indicate_instrument_state::Kinematics {
+            pos_ned_m: [0.0, 0.0, -300.0],
+            vel_ned_mps: [0.0; 3],
+        }),
+        age_ms: Some(10.0),
+    };
+    state
+}
+
+fn scene_texts(scene: &[u8]) -> Vec<String> {
+    SceneCmds::new(scene)
+        .expect("valid scene")
+        .map(|command| command.expect("valid command"))
+        .filter_map(|command| match command {
+            Cmd::Text { text, .. } => Some(String::from(text)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn alert_stack(scene: &[u8]) -> Vec<String> {
+    const STACK: &[&str] = &["ALT SRC", "NAV SRC", "TRN RATE", "ALRT FAIL", "MORE"];
+    scene_texts(scene)
+        .into_iter()
+        .filter(|text| STACK.contains(&text.as_str()))
+        .collect()
+}
+
+#[test]
+fn a_composition_commits_all_panels_and_one_generation() {
+    let mut runtime = Runtime::new();
+    write_state(&mut runtime, &attitude_state());
+
+    let outcome = runtime.render_composition(0, 100, true);
+    assert_eq!(outcome.status, RenderStatus::Ok);
+    assert_eq!(outcome.generation, 1);
+    assert!(outcome.scene_len > 0);
+    assert_eq!(runtime.composition_panel_outcomes().len(), 2);
+    assert_eq!(runtime.generation[..2], [1, 1]);
+
+    for panel in runtime.composition_panel_outcomes() {
+        assert_eq!(panel.status, RenderStatus::Ok);
+        assert!(panel.scene_len > 0);
+        assert_eq!(panel.generation, 1);
+        let start = panel.scene_offset as usize;
+        let end = start + panel.scene_len as usize;
+        assert!(SceneCmds::new(&runtime.composition_scene()[start..end]).is_ok());
+    }
+}
+
+#[test]
+fn elapsed_time_crosses_the_stale_and_failed_thresholds() {
+    let profile = indicate_instrument_state::AirframeDisplayProfile::simulator();
+    let policy = indicate_instrument_state::FreshnessPolicy::default();
+    let mut unusual = indicate_instrument_state::UnusualAttitudeState::default();
+    for (delta_ms, expected) in [
+        (0, SignalStatus::Valid),
+        (800, SignalStatus::Stale),
+        (3_100, SignalStatus::Failed),
+    ] {
+        let mut state = attitude_state();
+        age_state(&mut state, delta_ms);
+        let data =
+            indicate_instrument_state::resolve_stateful(&state, &policy, &profile, &mut unusual);
+        assert_eq!(data.roll_rad.status, expected);
+        assert_eq!(data.pitch_rad.status, expected);
+    }
+}
+
+#[test]
+fn quiet_input_drives_alerts_and_both_panels_from_one_step() {
+    let mut runtime = Runtime::new();
+    write_state(&mut runtime, &altitude_state());
+
+    let fresh = runtime.render_composition(0, 100, true);
+    assert_eq!(fresh.alerts.active_count, 0);
+    let stale = runtime.render_composition(800, 900, true);
+    assert_eq!(stale.alerts.active_count, 0);
+    let failed = runtime.render_composition(3_100, 3_200, true);
+    assert!(failed.alerts.active_count >= 1);
+
+    let pfd = alert_stack(&panel_scene(&runtime, 0));
+    let hsi = alert_stack(&panel_scene(&runtime, 1));
+    assert!(pfd.contains(&String::from("ALT SRC")), "{pfd:?}");
+    assert_eq!(pfd, hsi, "both panels must use one alert output");
+}
+
+#[test]
+fn web_sequence_and_composition_transaction_are_semantically_equal() {
+    for delta_ms in [0, 800, 3_100] {
+        let now_ms = 100 + delta_ms;
+        let state = altitude_state();
+
+        let mut apple = Runtime::new();
+        write_state(&mut apple, &state);
+        let apple_outcome = apple.render_composition(delta_ms, now_ms, true);
+        assert_eq!(apple_outcome.status, RenderStatus::Ok);
+        let apple_scenes = [panel_scene(&apple, 0), panel_scene(&apple, 1)];
+
+        let mut web_state = state;
+        age_state(&mut web_state, delta_ms);
+        let mut web = Runtime::new();
+        web.state = encoded_state_block(&web_state);
+        let web_alerts = web.step_alerts(now_ms, true);
+        assert_eq!(apple_outcome.alerts, web_alerts);
+        for (panel, expected_scene) in apple_scenes.iter().enumerate() {
+            let outcome = web.render(panel as u32);
+            assert_eq!(outcome.status, RenderStatus::Ok);
+            assert_eq!(
+                &web.scene()[..outcome.scene_len as usize],
+                expected_scene.as_slice()
+            );
+        }
+    }
+}
+
+#[test]
+fn one_panel_failure_commits_no_generation_or_alert_state() {
+    let mut runtime = Runtime::new();
+    write_state(&mut runtime, &attitude_state());
+    runtime.config[1] = vec![1, 0, 9];
+
+    let outcome = runtime.render_composition(0, 100, true);
+    assert_eq!(outcome.status, RenderStatus::ConfigInvalid);
+    assert_eq!(outcome.scene_len, 0);
+    assert_eq!(outcome.generation, 0);
+    assert_eq!(runtime.generation[..2], [0, 0]);
+    assert!(runtime.alert_output.is_none());
+    for panel in runtime.composition_panel_outcomes() {
+        assert_eq!(panel.status, RenderStatus::ConfigInvalid);
+        assert_eq!(panel.scene_len, 0);
+        assert_eq!(panel.generation, 0);
+    }
+}
+
+#[test]
+fn composition_and_panel_generations_wrap_together() {
+    let mut runtime = Runtime::new();
+    write_state(&mut runtime, &attitude_state());
+    runtime.composition_generation = u32::MAX;
+    runtime.generation[0] = u32::MAX;
+    runtime.generation[1] = u32::MAX;
+
+    let outcome = runtime.render_composition(0, 100, true);
+    assert_eq!(outcome.status, RenderStatus::Ok);
+    assert_eq!(outcome.generation, 0);
+    assert_eq!(runtime.generation[..2], [0, 0]);
+    assert!(
+        runtime
+            .composition_panel_outcomes()
+            .iter()
+            .all(|panel| panel.generation == 0)
+    );
+}

--- a/crates/pilotage-instrument-runtime/src/lib.rs
+++ b/crates/pilotage-instrument-runtime/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod compatibility;
 mod composition;
+mod composition_frame;
 pub mod feeder;
 mod registry;
 mod render_status;
@@ -32,6 +33,7 @@ pub use composition::{
     SCREEN_COMPOSITION, composition, composition_digest_hex, composition_slot_count,
     composition_slot_panel, composition_slot_rect,
 };
+pub use composition_frame::{CompositionFrameOutcome, CompositionPanelOutcome};
 pub use registry::{
     background_capability_code, canonical_frame, descriptor, panel_count, panel_design_height,
     panel_design_width, panel_id, panel_required_groups, panel_required_layers, panel_title,

--- a/crates/pilotage-instrument-runtime/src/registry.rs
+++ b/crates/pilotage-instrument-runtime/src/registry.rs
@@ -27,6 +27,10 @@ pub fn descriptor(panel: u32) -> Option<&'static PanelDescriptor> {
     registry()?.panels().nth(panel as usize)
 }
 
+pub(crate) fn panel_index(id: &str) -> Option<usize> {
+    registry()?.panels().position(|panel| panel.id == id)
+}
+
 /// The frame this runtime requests for a panel: its first canonical
 /// frame, falling back to the floor for a descriptor that declares none.
 /// The canonical frames are where the digest, admission matrix, and

--- a/crates/pilotage-instrument-runtime/src/runtime.rs
+++ b/crates/pilotage-instrument-runtime/src/runtime.rs
@@ -34,6 +34,9 @@ pub struct Runtime {
     pub(crate) state: Vec<u8>,
     pub(crate) scene: Vec<u8>,
     pub(crate) generation: Vec<u32>,
+    pub(crate) composition_scene: Vec<u8>,
+    pub(crate) composition_panels: Vec<crate::CompositionPanelOutcome>,
+    pub(crate) composition_generation: u32,
     /// Per-panel validated configuration blobs, indexed like the
     /// registry composition; empty means the panel's defaults.
     pub(crate) config: Vec<Vec<u8>>,
@@ -74,10 +77,14 @@ impl Runtime {
     /// and one generation counter per composed panel.
     pub fn new() -> Self {
         let panels = registry().map_or(0, |registry| registry.panels().count());
+        let slots = crate::composition_slot_count() as usize;
         Self {
             state: vec![0u8; v7::CAPACITY],
             scene: vec![0u8; SCENE_CAPACITY],
             generation: vec![0; panels],
+            composition_scene: vec![0; SCENE_CAPACITY.saturating_mul(slots)],
+            composition_panels: vec![crate::CompositionPanelOutcome::empty(); slots],
+            composition_generation: 0,
             config: vec![Vec::new(); panels],
             unknown_groups: 0,
             extended_groups: 0,
@@ -126,7 +133,7 @@ impl Runtime {
         self.extended_groups
     }
 
-    fn panel_generation(&self, panel_idx: usize) -> u32 {
+    pub(crate) fn panel_generation(&self, panel_idx: usize) -> u32 {
         self.generation.get(panel_idx).copied().unwrap_or(0)
     }
 
@@ -395,7 +402,7 @@ pub fn scene_error_status(error: SceneError) -> RenderStatus {
     }
 }
 
-fn validate_panel_scene(panel_idx: usize, scene: &[u8]) -> RenderStatus {
+pub(crate) fn validate_panel_scene(panel_idx: usize, scene: &[u8]) -> RenderStatus {
     // The critical-layer masks are owned by the panel descriptors
     // (ADR-0029): this runtime holds no mask or panel list of its own.
     let Some(required) = descriptor(panel_idx as u32).map(|d| d.required_layers) else {

--- a/crates/pilotage-instrument-runtime/src/tests.rs
+++ b/crates/pilotage-instrument-runtime/src/tests.rs
@@ -51,10 +51,14 @@ fn assert_outcome(outcome: RenderOutcome, status: RenderStatus, scene_len: u32, 
 
 fn scratch_runtime(state: Vec<u8>, scene: Vec<u8>, generation: Vec<u32>) -> Runtime {
     let panels = generation.len();
+    let slots = crate::composition_slot_count() as usize;
     Runtime {
         state,
         scene,
         generation,
+        composition_scene: vec![0u8; SCENE_CAPACITY.saturating_mul(slots)],
+        composition_panels: vec![crate::CompositionPanelOutcome::empty(); slots],
+        composition_generation: 0,
         config: vec![Vec::new(); panels],
         unknown_groups: 0,
         extended_groups: 0,

--- a/scripts/check-apple-instrument-consumer.sh
+++ b/scripts/check-apple-instrument-consumer.sh
@@ -18,7 +18,7 @@ cargo run --locked --quiet -p pilotage-instrument-apple-bridge \
   generate --library --language swift --out-dir "$output_root" "$library"
 
 for symbol in stateAbiVersion sceneFormatVersion corpusVersion corpusDigestHex \
-  sceneDigestHex compositionDigestHex InstrumentBridge; do
+  sceneDigestHex compositionDigestHex InstrumentBridge compositionFrame; do
   grep -q "$symbol" "$output_root"/*.swift
 done
 


### PR DESCRIPTION
Closes #335.

## Summary
- add one Rust-owned composition transaction with caller-supplied monotonic time
- age all stamped measurements from state acceptance time
- resolve state once, step alerts once, and render every validated composition slot
- commit panel and composition generations only when every panel succeeds
- replace the Apple per-panel FFI render calls with one typed composition-frame call
- give Swift panel producers one shared committed frame and clear it after writes or failures

## Acceptance evidence
- fresh, stale, and failed transitions cross 750 ms and 3000 ms without another state write
- quiet input drives the expected alert transition
- PFD and HSI use one alert output and commit atomically
- refused writes cannot reuse the prior state
- generation wrap and typed failures are covered
- the composition transaction matches the web runtime sequence for the same state and clock

## Local verification
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- strict cargo doc --no-deps
- cargo build --release
- bash scripts/check-structure.sh
- buf lint schemas
- bash scripts/check-apple-instrument-consumer.sh