### PR TITLE
Synchronize the Apple scene producer

### DIFF
--- a/clients/apple-instrument-consumer/Package.resolved
+++ b/clients/apple-instrument-consumer/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "baa6945a215f4a8e460402595dbd4b3217b5a49488dc8057bd9554fc6717aff8",
+  "originHash" : "14cae5a34f99cb5983b70c5b07fb2e1301590872de817b43c96f8dd6d07dfa66",
   "pins" : [
     {
       "identity" : "indicateappledisplay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luofang34/IndicateAppleDisplay.git",
       "state" : {
-        "revision" : "74e5845d09a58342fd282ec426759550dafc6887"
+        "revision" : "ca5fe14f22798fbee2d184970b928b04736f4083"
       }
     }
   ],

--- a/clients/apple-instrument-consumer/Package.swift
+++ b/clients/apple-instrument-consumer/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/luofang34/IndicateAppleDisplay.git",
-            revision: "74e5845d09a58342fd282ec426759550dafc6887"
+            revision: "ca5fe14f22798fbee2d184970b928b04736f4083"
         ),
     ],
     targets: [

--- a/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
+++ b/clients/apple-instrument-consumer/Sources/PilotageAppleInstrumentConsumer/InstrumentSceneProducer.swift
@@ -1,9 +1,11 @@
 import CoreGraphics
+import Foundation
 import IndicateAppleDisplay
 
 /// One committed composition frame that all panel producers share.
-public final class PilotageInstrumentComposition {
+public final class PilotageInstrumentComposition: @unchecked Sendable {
     private let verifiedRuntime: VerifiedInstrumentRuntime
+    private let lock = NSLock()
     private var panels: [UInt32: (scene: [UInt8], outcome: InstrumentRuntimePanelOutcome)] = [:]
 
     public init(verifiedRuntime: VerifiedInstrumentRuntime) {
@@ -12,6 +14,8 @@ public final class PilotageInstrumentComposition {
 
     /// Accepts one state frame and invalidates the current scenes.
     public func writeState(_ bytes: [UInt8], acceptedAtMs: UInt64) throws {
+        lock.lock()
+        defer { lock.unlock() }
         panels.removeAll(keepingCapacity: true)
         try verifiedRuntime.writeState(bytes, acceptedAtMs: acceptedAtMs)
     }
@@ -19,6 +23,8 @@ public final class PilotageInstrumentComposition {
     /// Produces and commits all composition panels with one runtime call.
     @discardableResult
     public func compose(nowMs: UInt64, pathHealthy: Bool) throws -> UInt32 {
+        lock.lock()
+        defer { lock.unlock() }
         panels.removeAll(keepingCapacity: true)
         let frame = verifiedRuntime.compositionFrame(
             nowMs: nowMs,
@@ -49,6 +55,8 @@ public final class PilotageInstrumentComposition {
     }
 
     fileprivate func frame(panel: UInt32, designFrame: CGRect) throws -> SceneFrame {
+        lock.lock()
+        defer { lock.unlock() }
         guard let committed = panels[panel] else {
             throw ProducerFault(reason: .notInitialized)
         }

--- a/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
+++ b/clients/apple-instrument-consumer/Tests/PilotageAppleInstrumentConsumerTests/CompatibilityGateTests.swift
@@ -38,6 +38,84 @@ private final class RuntimeDouble: InstrumentRuntimeServing {
     }
 }
 
+private final class BlockingRuntime: InstrumentRuntimeServing, @unchecked Sendable {
+    private let lock = NSLock()
+    private let compositionEntered = DispatchSemaphore(value: 0)
+    private let compositionMayFinish = DispatchSemaphore(value: 0)
+    private var outcome: InstrumentRuntimeCompositionOutcome
+    private var mustBlock = false
+
+    init(outcome: InstrumentRuntimeCompositionOutcome) {
+        self.outcome = outcome
+    }
+
+    func blockNextComposition(with outcome: InstrumentRuntimeCompositionOutcome) {
+        lock.lock()
+        self.outcome = outcome
+        mustBlock = true
+        lock.unlock()
+    }
+
+    func waitUntilCompositionStarts() -> Bool {
+        compositionEntered.wait(timeout: .now() + .seconds(5)) == .success
+    }
+
+    func releaseComposition() {
+        compositionMayFinish.signal()
+    }
+
+    func writeState(_: [UInt8], acceptedAtMs _: UInt64) throws {}
+
+    func compositionFrame(
+        nowMs _: UInt64,
+        pathHealthy _: Bool
+    ) -> InstrumentRuntimeCompositionOutcome {
+        lock.lock()
+        let result = outcome
+        let block = mustBlock
+        mustBlock = false
+        lock.unlock()
+        if block {
+            compositionEntered.signal()
+            if compositionMayFinish.wait(timeout: .now() + .seconds(5)) != .success {
+                Issue.record("The blocked runtime did not receive a release event")
+            }
+        }
+        return result
+    }
+}
+
+private final class ConcurrentResultProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var frame: SceneFrame?
+    private var reason: DisplayReason?
+    private var compositionFailure: String?
+
+    func store(frame: SceneFrame) {
+        lock.lock()
+        self.frame = frame
+        lock.unlock()
+    }
+
+    func store(reason: DisplayReason) {
+        lock.lock()
+        self.reason = reason
+        lock.unlock()
+    }
+
+    func store(compositionFailure: String) {
+        lock.lock()
+        self.compositionFailure = compositionFailure
+        lock.unlock()
+    }
+
+    var value: (frame: SceneFrame?, reason: DisplayReason?, compositionFailure: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (frame, reason, compositionFailure)
+    }
+}
+
 private struct CompatibilityPin: Decodable {
     let stateAbiVersion: UInt32
     let sceneFormatVersion: UInt32
@@ -90,6 +168,25 @@ private func requirements(width: CGFloat = 10) -> PanelRequirements {
         frameMin: CGSize(width: width, height: 10),
         frameMax: CGSize(width: width, height: 10),
         canonicalFrame: CGSize(width: width, height: 10)
+    )
+}
+
+private func runtimeOutcome(byte: UInt8, generation: UInt32) -> InstrumentRuntimeCompositionOutcome {
+    InstrumentRuntimeCompositionOutcome(
+        status: 0,
+        scene: [byte],
+        panels: [
+            InstrumentRuntimePanelOutcome(
+                panel: 0,
+                status: 0,
+                sceneOffset: 0,
+                sceneLength: 1,
+                frameWidth: 10,
+                frameHeight: 10,
+                generation: generation
+            ),
+        ],
+        generation: generation
     )
 }
 
@@ -224,6 +321,65 @@ func stateAcceptanceInvalidatesCachedScenes() throws {
     } catch {
         Issue.record("The producer returned an untyped error: \(error)")
     }
+}
+
+@Test("A producer cannot observe a composition update in progress")
+func producerWaitsForCompleteComposition() throws {
+    let runtime = BlockingRuntime(outcome: runtimeOutcome(byte: 1, generation: 1))
+    let verified = try AppleInstrumentCompatibilityGate.verify(
+        matchingIdentity(),
+        glyphAtlas: syntheticGlyphAtlas()
+    ) { runtime }
+    let composition = PilotageInstrumentComposition(verifiedRuntime: verified)
+    try composition.compose(nowMs: 1, pathHealthy: true)
+    runtime.blockNextComposition(with: runtimeOutcome(byte: 2, generation: 2))
+
+    let producer = composition.producer(panel: 0)
+    let probe = ConcurrentResultProbe()
+    let compositionFinished = DispatchSemaphore(value: 0)
+    let frameStarted = DispatchSemaphore(value: 0)
+    let frameFinished = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+        do {
+            _ = try composition.compose(nowMs: 2, pathHealthy: true)
+        } catch {
+            probe.store(compositionFailure: String(describing: error))
+        }
+        compositionFinished.signal()
+    }
+    #expect(runtime.waitUntilCompositionStarts())
+
+    DispatchQueue.global().async {
+        frameStarted.signal()
+        do {
+            probe.store(frame: try producer.frame(
+                designFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
+            ))
+        } catch let fault as ProducerFault {
+            probe.store(reason: fault.reason)
+        } catch {
+            probe.store(reason: .renderTrap)
+        }
+        frameFinished.signal()
+    }
+    #expect(frameStarted.wait(timeout: .now() + .seconds(5)) == .success)
+    let frameFinishedDuringUpdate = frameFinished.wait(
+        timeout: .now() + .milliseconds(20)
+    ) == .success
+
+    runtime.releaseComposition()
+    #expect(compositionFinished.wait(timeout: .now() + .seconds(5)) == .success)
+    if !frameFinishedDuringUpdate {
+        #expect(frameFinished.wait(timeout: .now() + .seconds(5)) == .success)
+    }
+
+    let result = probe.value
+    #expect(!frameFinishedDuringUpdate)
+    #expect(result.compositionFailure == nil)
+    #expect(result.reason == nil)
+    #expect(result.frame?.bytes == [2])
+    #expect(result.frame?.generation == 2)
 }
 
 @Test("A failed transaction removes the previous composition")


### PR DESCRIPTION
Summary:
- Pin the Apple consumer to IndicateAppleDisplay ca5fe14.
- Serialize runtime writes, composition updates, and render-worker frame reads.
- Add a concurrency regression test that verifies a producer sees only a complete committed composition.

Tests:
- swift test
- bash scripts/check-apple-instrument-consumer.sh
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- strict cargo doc
- cargo build --release
- structure, certification, compatibility, no-std, web, and schema gates

Closes #339