### PR TITLE
Define the SituationView V1 contract and corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,12 @@ jobs:
       - name: cargo test
         run: cargo test --all-targets
 
+      - name: SituationView conformance corpus
+        run: cargo test -p pilotage-situation-view --test corpus
+
+      - name: SituationView dependency boundary
+        run: bash scripts/check-situation-view-boundary.sh
+
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D missing_docs -D rustdoc::broken_intra_doc_links"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-situation-view"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-svs-build"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/pilotage-adapter-api",
     "crates/pilotage-mavlink",
     "crates/pilotage-conformance",
+    "crates/pilotage-situation-view",
     "crates/pilotage-calibration-id",
     "crates/pilotage-camera-calibration",
     "crates/pilotage-geo",
@@ -91,6 +92,7 @@ pilotage-ingress = { path = "crates/pilotage-ingress" }
 pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-mavlink = { path = "crates/pilotage-mavlink" }
+pilotage-situation-view = { path = "crates/pilotage-situation-view" }
 pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-camera-calibration = { path = "crates/pilotage-camera-calibration" }
 pilotage-geo = { path = "crates/pilotage-geo" }

--- a/crates/README.md
+++ b/crates/README.md
@@ -18,4 +18,5 @@ Seed crates (created as implementation starts, split further per the size limits
 | `pilotage-input` | Canonical input model, device profiles, normalization pipeline |
 | `pilotage-timing` | Time model, latency accounting, staleness policy |
 | `pilotage-adapter-api` | Adapter traits and capability model |
+| `pilotage-situation-view` | Versioned read-only situation query and result contract |
 | `pilotage-conformance` | Shared fixtures and behavioral test suites |

--- a/crates/pilotage-situation-view/Cargo.toml
+++ b/crates/pilotage-situation-view/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pilotage-situation-view"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-situation-view/corpus/situation-view-v1.json
+++ b/crates/pilotage-situation-view/corpus/situation-view-v1.json
@@ -1,0 +1,896 @@
+{
+  "corpus_version": 1,
+  "cases": [
+    {
+      "name": "mixed_age_inputs",
+      "request": {
+        "schema_version": 1,
+        "query": {
+          "time": {
+            "axis": "valid_time",
+            "evaluation_utc": {
+              "unix_seconds": 1000,
+              "subsecond_nanoseconds": 0
+            }
+          },
+          "domains": [
+            { "domain": "surveillance", "subject": "all_tracks" },
+            { "domain": "airmass", "subject": "regional_weather" }
+          ],
+          "requirements": {
+            "freshness": [
+              {
+                "requirement_id": "traffic_recent",
+                "field": {
+                  "domain": "surveillance",
+                  "subject": "all_tracks",
+                  "field": "position"
+                },
+                "age": "ingress",
+                "maximum_age_nanoseconds": 10000000000
+              },
+              {
+                "requirement_id": "weather_recent",
+                "field": {
+                  "domain": "airmass",
+                  "subject": "regional_weather",
+                  "field": "precipitation"
+                },
+                "age": "observation",
+                "maximum_age_nanoseconds": 15000000000
+              }
+            ],
+            "coherence": [
+              {
+                "requirement_id": "mixed_age_spread",
+                "kind": "maximum_ingress_age_spread",
+                "fields": [
+                  {
+                    "domain": "surveillance",
+                    "subject": "all_tracks",
+                    "field": "position"
+                  },
+                  {
+                    "domain": "airmass",
+                    "subject": "regional_weather",
+                    "field": "precipitation"
+                  }
+                ],
+                "maximum_spread_nanoseconds": 10000000000
+              }
+            ]
+          }
+        },
+        "host_evaluation": {
+          "clock_id": "host-clock",
+          "nanoseconds": 30000000000
+        }
+      },
+      "captures": [
+        {
+          "state": "available",
+          "snapshot": {
+            "domain": "surveillance",
+            "subject": "all_tracks",
+            "domain_schema_version": 3,
+            "producer_instance_id": "traffic-producer-a",
+            "snapshot_revision": 7,
+            "domain_identity": { "kind": "common" },
+            "fields": [
+              {
+                "field": "position",
+                "value": {
+                  "state": "present",
+                  "value": { "latitude_degrees": 41, "longitude_degrees": -72 }
+                },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "receiver-a" },
+                    "source_epoch": { "state": "present", "value": "receiver-a-epoch-1" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "host-clock", "nanoseconds": 25000000000 }
+                    },
+                    "source_time": {
+                      "state": "present",
+                      "value": { "unix_seconds": 995, "subsecond_nanoseconds": 0 }
+                    },
+                    "time_quality": { "state": "present", "value": "trusted" },
+                    "validity": {
+                      "state": "present",
+                      "value": {
+                        "start": { "unix_seconds": 990, "subsecond_nanoseconds": 0 },
+                        "end": { "unix_seconds": 1010, "subsecond_nanoseconds": 0 }
+                      }
+                    },
+                    "data_quality": {
+                      "state": "present",
+                      "value": { "integrity": "valid" }
+                    },
+                    "time_uncertainty_nanoseconds": {
+                      "state": "present",
+                      "value": 100000000
+                    }
+                  }
+                ]
+              }
+            ],
+            "clock_correspondences": []
+          }
+        },
+        {
+          "state": "available",
+          "snapshot": {
+            "domain": "airmass",
+            "subject": "regional_weather",
+            "domain_schema_version": 2,
+            "producer_instance_id": "weather-producer-a",
+            "snapshot_revision": 11,
+            "domain_identity": { "kind": "common" },
+            "fields": [
+              {
+                "field": "precipitation",
+                "value": {
+                  "state": "present",
+                  "value": { "rate_millimeters_per_hour": 3 }
+                },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "weather-feed-a" },
+                    "source_epoch": { "state": "present", "value": "weather-feed-a-epoch-8" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "host-clock", "nanoseconds": 12000000000 }
+                    },
+                    "source_time": {
+                      "state": "present",
+                      "value": { "unix_seconds": 980, "subsecond_nanoseconds": 0 }
+                    },
+                    "time_quality": { "state": "present", "value": "trusted" },
+                    "validity": {
+                      "state": "present",
+                      "value": {
+                        "start": { "unix_seconds": 970, "subsecond_nanoseconds": 0 },
+                        "end": { "unix_seconds": 1030, "subsecond_nanoseconds": 0 }
+                      }
+                    },
+                    "data_quality": {
+                      "state": "present",
+                      "value": { "coverage": "regional" }
+                    },
+                    "time_uncertainty_nanoseconds": {
+                      "state": "present",
+                      "value": 2000000000
+                    }
+                  }
+                ]
+              }
+            ],
+            "clock_correspondences": []
+          }
+        }
+      ],
+      "expected": {
+        "schema_version": 1,
+        "query_time": {
+          "axis": "valid_time",
+          "evaluation_utc": { "unix_seconds": 1000, "subsecond_nanoseconds": 0 }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 30000000000 },
+        "consistency": "best_available_non_atomic",
+        "domains": [
+          {
+            "state": "available",
+            "domain": "surveillance",
+            "subject": "all_tracks",
+            "result": {
+              "domain_schema_version": 3,
+              "producer_instance_id": "traffic-producer-a",
+              "snapshot_revision": 7,
+              "domain_identity": { "kind": "common" },
+              "fields": [
+                {
+                  "field": "position",
+                  "value": {
+                    "state": "present",
+                    "value": { "latitude_degrees": 41, "longitude_degrees": -72 }
+                  },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "receiver-a" },
+                      "source_epoch": { "state": "present", "value": "receiver-a-epoch-1" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "host-clock", "nanoseconds": 25000000000 }
+                      },
+                      "source_time": {
+                        "state": "present",
+                        "value": { "unix_seconds": 995, "subsecond_nanoseconds": 0 }
+                      },
+                      "time_quality": { "state": "present", "value": "trusted" },
+                      "validity": {
+                        "state": "present",
+                        "value": {
+                          "start": { "unix_seconds": 990, "subsecond_nanoseconds": 0 },
+                          "end": { "unix_seconds": 1010, "subsecond_nanoseconds": 0 }
+                        }
+                      },
+                      "data_quality": {
+                        "state": "present",
+                        "value": { "integrity": "valid" }
+                      },
+                      "time_uncertainty_nanoseconds": {
+                        "state": "present",
+                        "value": 100000000
+                      },
+                      "ingress_age": {
+                        "state": "known",
+                        "nanoseconds": 5000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      },
+                      "observation_age": {
+                        "state": "known",
+                        "nanoseconds": 5000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 100000000 }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "clock_correspondences": []
+            }
+          },
+          {
+            "state": "available",
+            "domain": "airmass",
+            "subject": "regional_weather",
+            "result": {
+              "domain_schema_version": 2,
+              "producer_instance_id": "weather-producer-a",
+              "snapshot_revision": 11,
+              "domain_identity": { "kind": "common" },
+              "fields": [
+                {
+                  "field": "precipitation",
+                  "value": {
+                    "state": "present",
+                    "value": { "rate_millimeters_per_hour": 3 }
+                  },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "weather-feed-a" },
+                      "source_epoch": { "state": "present", "value": "weather-feed-a-epoch-8" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "host-clock", "nanoseconds": 12000000000 }
+                      },
+                      "source_time": {
+                        "state": "present",
+                        "value": { "unix_seconds": 980, "subsecond_nanoseconds": 0 }
+                      },
+                      "time_quality": { "state": "present", "value": "trusted" },
+                      "validity": {
+                        "state": "present",
+                        "value": {
+                          "start": { "unix_seconds": 970, "subsecond_nanoseconds": 0 },
+                          "end": { "unix_seconds": 1030, "subsecond_nanoseconds": 0 }
+                        }
+                      },
+                      "data_quality": {
+                        "state": "present",
+                        "value": { "coverage": "regional" }
+                      },
+                      "time_uncertainty_nanoseconds": {
+                        "state": "present",
+                        "value": 2000000000
+                      },
+                      "ingress_age": {
+                        "state": "known",
+                        "nanoseconds": 18000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      },
+                      "observation_age": {
+                        "state": "known",
+                        "nanoseconds": 20000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 2000000000 }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "clock_correspondences": []
+            }
+          }
+        ],
+        "requirement_assessments": [
+          { "requirement_id": "traffic_recent", "state": "satisfied" },
+          {
+            "requirement_id": "weather_recent",
+            "state": "not_satisfied",
+            "reason": "maximum_age_exceeded"
+          },
+          {
+            "requirement_id": "mixed_age_spread",
+            "state": "not_satisfied",
+            "reason": "maximum_spread_exceeded"
+          }
+        ]
+      }
+    },
+    {
+      "name": "unknown_age",
+      "request": {
+        "schema_version": 1,
+        "query": {
+          "time": {
+            "axis": "valid_time",
+            "evaluation_utc": { "unix_seconds": 2000, "subsecond_nanoseconds": 0 }
+          },
+          "domains": [
+            { "domain": "aeronautical_updates", "subject": "all_updates" }
+          ],
+          "requirements": {
+            "freshness": [
+              {
+                "requirement_id": "update_observation_age",
+                "field": {
+                  "domain": "aeronautical_updates",
+                  "subject": "all_updates",
+                  "field": "restrictions"
+                },
+                "age": "observation",
+                "maximum_age_nanoseconds": 30000000000
+              }
+            ],
+            "coherence": []
+          }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 100000000000 }
+      },
+      "captures": [
+        {
+          "state": "available",
+          "snapshot": {
+            "domain": "aeronautical_updates",
+            "subject": "all_updates",
+            "domain_schema_version": 1,
+            "producer_instance_id": "update-producer-a",
+            "snapshot_revision": 4,
+            "domain_identity": { "kind": "common" },
+            "fields": [
+              {
+                "field": "restrictions",
+                "value": { "state": "present", "value": ["TFR-1"] },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "notice-feed" },
+                    "source_epoch": { "state": "present", "value": "notice-feed-epoch-2" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "remote-clock", "nanoseconds": 40000000000 }
+                    },
+                    "source_time": { "state": "missing", "reason": "invalid_time_evidence" },
+                    "time_quality": { "state": "missing", "reason": "invalid_time_evidence" },
+                    "validity": {
+                      "state": "present",
+                      "value": {
+                        "start": { "unix_seconds": 1900, "subsecond_nanoseconds": 0 },
+                        "end": { "unix_seconds": 2100, "subsecond_nanoseconds": 0 }
+                      }
+                    },
+                    "data_quality": { "state": "present", "value": { "status": "active" } },
+                    "time_uncertainty_nanoseconds": {
+                      "state": "missing",
+                      "reason": "invalid_time_evidence"
+                    }
+                  }
+                ]
+              }
+            ],
+            "clock_correspondences": [
+              {
+                "source_clock_id": "remote-clock",
+                "target_clock_id": "host-clock",
+                "offset_nanoseconds": 50000000000,
+                "uncertainty_nanoseconds": 1000000000,
+                "valid_source": {
+                  "start_nanoseconds": 0,
+                  "end_nanoseconds": 30000000000
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "schema_version": 1,
+        "query_time": {
+          "axis": "valid_time",
+          "evaluation_utc": { "unix_seconds": 2000, "subsecond_nanoseconds": 0 }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 100000000000 },
+        "consistency": "best_available_non_atomic",
+        "domains": [
+          {
+            "state": "available",
+            "domain": "aeronautical_updates",
+            "subject": "all_updates",
+            "result": {
+              "domain_schema_version": 1,
+              "producer_instance_id": "update-producer-a",
+              "snapshot_revision": 4,
+              "domain_identity": { "kind": "common" },
+              "fields": [
+                {
+                  "field": "restrictions",
+                  "value": { "state": "present", "value": ["TFR-1"] },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "notice-feed" },
+                      "source_epoch": { "state": "present", "value": "notice-feed-epoch-2" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "remote-clock", "nanoseconds": 40000000000 }
+                      },
+                      "source_time": { "state": "missing", "reason": "invalid_time_evidence" },
+                      "time_quality": { "state": "missing", "reason": "invalid_time_evidence" },
+                      "validity": {
+                        "state": "present",
+                        "value": {
+                          "start": { "unix_seconds": 1900, "subsecond_nanoseconds": 0 },
+                          "end": { "unix_seconds": 2100, "subsecond_nanoseconds": 0 }
+                        }
+                      },
+                      "data_quality": {
+                        "state": "present",
+                        "value": { "status": "active" }
+                      },
+                      "time_uncertainty_nanoseconds": {
+                        "state": "missing",
+                        "reason": "invalid_time_evidence"
+                      },
+                      "ingress_age": {
+                        "state": "unknown",
+                        "reason": "clock_correspondence_out_of_range"
+                      },
+                      "observation_age": {
+                        "state": "unknown",
+                        "reason": "missing_source_time"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "clock_correspondences": [
+                {
+                  "source_clock_id": "remote-clock",
+                  "target_clock_id": "host-clock",
+                  "offset_nanoseconds": 50000000000,
+                  "uncertainty_nanoseconds": 1000000000,
+                  "valid_source": {
+                    "start_nanoseconds": 0,
+                    "end_nanoseconds": 30000000000
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "requirement_assessments": [
+          {
+            "requirement_id": "update_observation_age",
+            "state": "indeterminate",
+            "reason": "unknown_age"
+          }
+        ]
+      }
+    },
+    {
+      "name": "missing_domain",
+      "request": {
+        "schema_version": 1,
+        "query": {
+          "time": {
+            "axis": "valid_time",
+            "evaluation_utc": { "unix_seconds": 3000, "subsecond_nanoseconds": 0 }
+          },
+          "domains": [
+            { "domain": "airmass", "subject": "regional_weather" }
+          ],
+          "requirements": { "freshness": [], "coherence": [] }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 50000000000 }
+      },
+      "captures": [
+        {
+          "state": "missing",
+          "domain": "airmass",
+          "subject": "regional_weather",
+          "reason": "domain_unavailable"
+        }
+      ],
+      "expected": {
+        "schema_version": 1,
+        "query_time": {
+          "axis": "valid_time",
+          "evaluation_utc": { "unix_seconds": 3000, "subsecond_nanoseconds": 0 }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 50000000000 },
+        "consistency": "best_available_non_atomic",
+        "domains": [
+          {
+            "state": "missing",
+            "domain": "airmass",
+            "subject": "regional_weather",
+            "reason": "domain_unavailable"
+          }
+        ],
+        "requirement_assessments": []
+      }
+    },
+    {
+      "name": "source_restart",
+      "request": {
+        "schema_version": 1,
+        "query": {
+          "time": {
+            "axis": "valid_time",
+            "evaluation_utc": { "unix_seconds": 4000, "subsecond_nanoseconds": 0 }
+          },
+          "domains": [
+            { "domain": "surveillance", "subject": "all_tracks" }
+          ],
+          "requirements": { "freshness": [], "coherence": [] }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 50000000000 }
+      },
+      "captures": [
+        {
+          "state": "available",
+          "snapshot": {
+            "domain": "surveillance",
+            "subject": "all_tracks",
+            "domain_schema_version": 3,
+            "producer_instance_id": "traffic-producer-stable",
+            "snapshot_revision": 9,
+            "domain_identity": { "kind": "common" },
+            "fields": [
+              {
+                "field": "expired_track",
+                "value": { "state": "missing", "reason": "expired" },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "transponder-42" },
+                    "source_epoch": { "state": "present", "value": "boot-1" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "host-clock", "nanoseconds": 20000000000 }
+                    },
+                    "source_time": {
+                      "state": "present",
+                      "value": { "unix_seconds": 3980, "subsecond_nanoseconds": 0 }
+                    },
+                    "time_quality": { "state": "present", "value": "trusted" },
+                    "validity": { "state": "missing", "reason": "expired" },
+                    "data_quality": { "state": "missing", "reason": "expired" },
+                    "time_uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                  }
+                ]
+              },
+              {
+                "field": "current_track",
+                "value": { "state": "present", "value": { "track_id": "42-new" } },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "transponder-42" },
+                    "source_epoch": { "state": "present", "value": "boot-2" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "host-clock", "nanoseconds": 45000000000 }
+                    },
+                    "source_time": {
+                      "state": "present",
+                      "value": { "unix_seconds": 3998, "subsecond_nanoseconds": 0 }
+                    },
+                    "time_quality": { "state": "present", "value": "trusted" },
+                    "validity": {
+                      "state": "present",
+                      "value": {
+                        "start": { "unix_seconds": 3998, "subsecond_nanoseconds": 0 },
+                        "end": { "unix_seconds": 4008, "subsecond_nanoseconds": 0 }
+                      }
+                    },
+                    "data_quality": { "state": "present", "value": { "integrity": "valid" } },
+                    "time_uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                  }
+                ]
+              }
+            ],
+            "clock_correspondences": []
+          }
+        }
+      ],
+      "expected": {
+        "schema_version": 1,
+        "query_time": {
+          "axis": "valid_time",
+          "evaluation_utc": { "unix_seconds": 4000, "subsecond_nanoseconds": 0 }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 50000000000 },
+        "consistency": "best_available_non_atomic",
+        "domains": [
+          {
+            "state": "available",
+            "domain": "surveillance",
+            "subject": "all_tracks",
+            "result": {
+              "domain_schema_version": 3,
+              "producer_instance_id": "traffic-producer-stable",
+              "snapshot_revision": 9,
+              "domain_identity": { "kind": "common" },
+              "fields": [
+                {
+                  "field": "expired_track",
+                  "value": { "state": "missing", "reason": "expired" },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "transponder-42" },
+                      "source_epoch": { "state": "present", "value": "boot-1" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "host-clock", "nanoseconds": 20000000000 }
+                      },
+                      "source_time": {
+                        "state": "present",
+                        "value": { "unix_seconds": 3980, "subsecond_nanoseconds": 0 }
+                      },
+                      "time_quality": { "state": "present", "value": "trusted" },
+                      "validity": { "state": "missing", "reason": "expired" },
+                      "data_quality": { "state": "missing", "reason": "expired" },
+                      "time_uncertainty_nanoseconds": { "state": "present", "value": 0 },
+                      "ingress_age": {
+                        "state": "known",
+                        "nanoseconds": 30000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      },
+                      "observation_age": {
+                        "state": "known",
+                        "nanoseconds": 20000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "field": "current_track",
+                  "value": { "state": "present", "value": { "track_id": "42-new" } },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "transponder-42" },
+                      "source_epoch": { "state": "present", "value": "boot-2" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "host-clock", "nanoseconds": 45000000000 }
+                      },
+                      "source_time": {
+                        "state": "present",
+                        "value": { "unix_seconds": 3998, "subsecond_nanoseconds": 0 }
+                      },
+                      "time_quality": { "state": "present", "value": "trusted" },
+                      "validity": {
+                        "state": "present",
+                        "value": {
+                          "start": { "unix_seconds": 3998, "subsecond_nanoseconds": 0 },
+                          "end": { "unix_seconds": 4008, "subsecond_nanoseconds": 0 }
+                        }
+                      },
+                      "data_quality": {
+                        "state": "present",
+                        "value": { "integrity": "valid" }
+                      },
+                      "time_uncertainty_nanoseconds": { "state": "present", "value": 0 },
+                      "ingress_age": {
+                        "state": "known",
+                        "nanoseconds": 5000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      },
+                      "observation_age": {
+                        "state": "known",
+                        "nanoseconds": 2000000000,
+                        "uncertainty_nanoseconds": { "state": "present", "value": 0 }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "clock_correspondences": []
+            }
+          }
+        ],
+        "requirement_assessments": []
+      }
+    },
+    {
+      "name": "clock_correspondence_uncertainty",
+      "request": {
+        "schema_version": 1,
+        "query": {
+          "time": {
+            "axis": "valid_time",
+            "evaluation_utc": { "unix_seconds": 5000, "subsecond_nanoseconds": 0 }
+          },
+          "domains": [
+            { "domain": "airmass", "subject": "regional_weather" }
+          ],
+          "requirements": {
+            "freshness": [
+              {
+                "requirement_id": "wind_ingress_bound",
+                "field": {
+                  "domain": "airmass",
+                  "subject": "regional_weather",
+                  "field": "wind"
+                },
+                "age": "ingress",
+                "maximum_age_nanoseconds": 11000000000
+              }
+            ],
+            "coherence": []
+          }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 100000000000 }
+      },
+      "captures": [
+        {
+          "state": "available",
+          "snapshot": {
+            "domain": "airmass",
+            "subject": "regional_weather",
+            "domain_schema_version": 2,
+            "producer_instance_id": "weather-producer-b",
+            "snapshot_revision": 12,
+            "domain_identity": { "kind": "common" },
+            "fields": [
+              {
+                "field": "wind",
+                "value": { "state": "present", "value": { "knots": 20 } },
+                "contributors": [
+                  {
+                    "source_identity": { "state": "present", "value": "wind-sensor" },
+                    "source_epoch": { "state": "present", "value": "wind-sensor-epoch-4" },
+                    "ingress_time": {
+                      "state": "present",
+                      "value": { "clock_id": "sensor-clock", "nanoseconds": 80000000000 }
+                    },
+                    "source_time": {
+                      "state": "present",
+                      "value": { "unix_seconds": 4995, "subsecond_nanoseconds": 0 }
+                    },
+                    "time_quality": { "state": "present", "value": "estimated" },
+                    "validity": {
+                      "state": "present",
+                      "value": {
+                        "start": { "unix_seconds": 4990, "subsecond_nanoseconds": 0 },
+                        "end": { "unix_seconds": 5010, "subsecond_nanoseconds": 0 }
+                      }
+                    },
+                    "data_quality": { "state": "present", "value": { "grade": "estimated" } },
+                    "time_uncertainty_nanoseconds": {
+                      "state": "present",
+                      "value": 1000000000
+                    }
+                  }
+                ]
+              }
+            ],
+            "clock_correspondences": [
+              {
+                "source_clock_id": "sensor-clock",
+                "target_clock_id": "host-clock",
+                "offset_nanoseconds": 10000000000,
+                "uncertainty_nanoseconds": 2000000000,
+                "valid_source": {
+                  "start_nanoseconds": 0,
+                  "end_nanoseconds": 100000000000
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "schema_version": 1,
+        "query_time": {
+          "axis": "valid_time",
+          "evaluation_utc": { "unix_seconds": 5000, "subsecond_nanoseconds": 0 }
+        },
+        "host_evaluation": { "clock_id": "host-clock", "nanoseconds": 100000000000 },
+        "consistency": "best_available_non_atomic",
+        "domains": [
+          {
+            "state": "available",
+            "domain": "airmass",
+            "subject": "regional_weather",
+            "result": {
+              "domain_schema_version": 2,
+              "producer_instance_id": "weather-producer-b",
+              "snapshot_revision": 12,
+              "domain_identity": { "kind": "common" },
+              "fields": [
+                {
+                  "field": "wind",
+                  "value": { "state": "present", "value": { "knots": 20 } },
+                  "contributors": [
+                    {
+                      "source_identity": { "state": "present", "value": "wind-sensor" },
+                      "source_epoch": { "state": "present", "value": "wind-sensor-epoch-4" },
+                      "ingress_time": {
+                        "state": "present",
+                        "value": { "clock_id": "sensor-clock", "nanoseconds": 80000000000 }
+                      },
+                      "source_time": {
+                        "state": "present",
+                        "value": { "unix_seconds": 4995, "subsecond_nanoseconds": 0 }
+                      },
+                      "time_quality": { "state": "present", "value": "estimated" },
+                      "validity": {
+                        "state": "present",
+                        "value": {
+                          "start": { "unix_seconds": 4990, "subsecond_nanoseconds": 0 },
+                          "end": { "unix_seconds": 5010, "subsecond_nanoseconds": 0 }
+                        }
+                      },
+                      "data_quality": {
+                        "state": "present",
+                        "value": { "grade": "estimated" }
+                      },
+                      "time_uncertainty_nanoseconds": {
+                        "state": "present",
+                        "value": 1000000000
+                      },
+                      "ingress_age": {
+                        "state": "known",
+                        "nanoseconds": 10000000000,
+                        "uncertainty_nanoseconds": {
+                          "state": "present",
+                          "value": 2000000000
+                        }
+                      },
+                      "observation_age": {
+                        "state": "known",
+                        "nanoseconds": 5000000000,
+                        "uncertainty_nanoseconds": {
+                          "state": "present",
+                          "value": 1000000000
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "clock_correspondences": [
+                {
+                  "source_clock_id": "sensor-clock",
+                  "target_clock_id": "host-clock",
+                  "offset_nanoseconds": 10000000000,
+                  "uncertainty_nanoseconds": 2000000000,
+                  "valid_source": {
+                    "start_nanoseconds": 0,
+                    "end_nanoseconds": 100000000000
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "requirement_assessments": [
+          {
+            "requirement_id": "wind_ingress_bound",
+            "state": "not_satisfied",
+            "reason": "maximum_age_exceeded"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/pilotage-situation-view/src/compose.rs
+++ b/crates/pilotage-situation-view/src/compose.rs
@@ -1,0 +1,223 @@
+//! Reference composition over immutable snapshot handles.
+
+use std::collections::BTreeSet;
+
+use crate::{
+    AvailableDomainResultV1, ConsistencyGuaranteeV1, ContributorResultV1, DomainResultV1,
+    DomainSelectionV1, FieldResultV1, SITUATION_VIEW_SCHEMA_VERSION, SituationViewError,
+    SituationViewRequestV1, SituationViewResultV1, SnapshotCaptureV1, SnapshotSourceV1,
+};
+
+mod age;
+mod requirements;
+
+/// Version 1 read-only situation query interface.
+pub trait SituationViewV1 {
+    /// Error returned by the implementation.
+    type Error;
+
+    /// Evaluates one host-attached request.
+    fn query(&self, request: &SituationViewRequestV1)
+    -> Result<SituationViewResultV1, Self::Error>;
+}
+
+/// Reference composer that captures from one source.
+#[derive(Debug, Clone)]
+pub struct ComposingSituationViewV1<S> {
+    source: S,
+}
+
+impl<S> ComposingSituationViewV1<S> {
+    /// Creates a composer for `source`.
+    #[must_use]
+    pub const fn new(source: S) -> Self {
+        Self { source }
+    }
+
+    /// Returns the snapshot source.
+    #[must_use]
+    pub const fn source(&self) -> &S {
+        &self.source
+    }
+}
+
+impl<S: SnapshotSourceV1> SituationViewV1 for ComposingSituationViewV1<S> {
+    type Error = SituationViewError;
+
+    fn query(
+        &self,
+        request: &SituationViewRequestV1,
+    ) -> Result<SituationViewResultV1, Self::Error> {
+        validate_request(request)?;
+        let domains = capture_domains(&self.source, request)?;
+        let requirement_assessments = requirements::assess(request, &domains);
+        Ok(SituationViewResultV1 {
+            schema_version: SITUATION_VIEW_SCHEMA_VERSION,
+            query_time: request.query.time.clone(),
+            host_evaluation: request.host_evaluation.clone(),
+            consistency: ConsistencyGuaranteeV1::BestAvailableNonAtomic,
+            domains,
+            requirement_assessments,
+        })
+    }
+}
+
+fn validate_request(request: &SituationViewRequestV1) -> Result<(), SituationViewError> {
+    if request.schema_version != SITUATION_VIEW_SCHEMA_VERSION {
+        return Err(SituationViewError::UnsupportedSchemaVersion {
+            found: request.schema_version,
+            expected: SITUATION_VIEW_SCHEMA_VERSION,
+        });
+    }
+    validate_utc(request)?;
+    validate_domain_selections(&request.query.domains)?;
+    validate_requirement_ids(request)
+}
+
+fn validate_utc(request: &SituationViewRequestV1) -> Result<(), SituationViewError> {
+    let instant = request.query.time.evaluation_utc;
+    if instant.unix_nanoseconds().is_some() {
+        Ok(())
+    } else {
+        Err(SituationViewError::InvalidUtcInstant {
+            location: "request.query.time.evaluation_utc".to_string(),
+            subsecond_nanoseconds: instant.subsecond_nanoseconds,
+        })
+    }
+}
+
+fn validate_domain_selections(selections: &[DomainSelectionV1]) -> Result<(), SituationViewError> {
+    let mut seen = BTreeSet::new();
+    for selection in selections {
+        let key = (selection.domain.clone(), selection.subject.clone());
+        if !seen.insert(key) {
+            return Err(SituationViewError::DuplicateDomainSelection {
+                domain: selection.domain.clone(),
+                subject: selection.subject.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_requirement_ids(request: &SituationViewRequestV1) -> Result<(), SituationViewError> {
+    let freshness = request
+        .query
+        .requirements
+        .freshness
+        .iter()
+        .map(|item| item.requirement_id.as_str());
+    let coherence = request
+        .query
+        .requirements
+        .coherence
+        .iter()
+        .map(|item| item.requirement_id.as_str());
+    let mut seen = BTreeSet::new();
+    for requirement_id in freshness.chain(coherence) {
+        if !seen.insert(requirement_id) {
+            return Err(SituationViewError::DuplicateRequirementId {
+                requirement_id: requirement_id.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn capture_domains<S: SnapshotSourceV1>(
+    source: &S,
+    request: &SituationViewRequestV1,
+) -> Result<Vec<DomainResultV1>, SituationViewError> {
+    request
+        .query
+        .domains
+        .iter()
+        .map(|selection| {
+            let capture = source.capture(selection, &request.query.time);
+            compose_capture(selection, capture, request)
+        })
+        .collect()
+}
+
+fn compose_capture(
+    selection: &DomainSelectionV1,
+    capture: SnapshotCaptureV1,
+    request: &SituationViewRequestV1,
+) -> Result<DomainResultV1, SituationViewError> {
+    match capture {
+        SnapshotCaptureV1::Available { snapshot } => {
+            validate_capture(selection, &snapshot)?;
+            let fields = snapshot
+                .fields
+                .iter()
+                .map(|field| compose_field(field, &snapshot.clock_correspondences, request))
+                .collect();
+            Ok(DomainResultV1::Available {
+                domain: selection.domain.clone(),
+                subject: selection.subject.clone(),
+                result: AvailableDomainResultV1 {
+                    domain_schema_version: snapshot.domain_schema_version,
+                    producer_instance_id: snapshot.producer_instance_id.clone(),
+                    snapshot_revision: snapshot.snapshot_revision,
+                    domain_identity: snapshot.domain_identity.clone(),
+                    fields,
+                    clock_correspondences: snapshot.clock_correspondences.clone(),
+                },
+            })
+        }
+        SnapshotCaptureV1::Missing { reason } => Ok(DomainResultV1::Missing {
+            domain: selection.domain.clone(),
+            subject: selection.subject.clone(),
+            reason,
+        }),
+    }
+}
+
+fn validate_capture(
+    selection: &DomainSelectionV1,
+    snapshot: &crate::DomainSnapshotV1,
+) -> Result<(), SituationViewError> {
+    if snapshot.domain == selection.domain && snapshot.subject == selection.subject {
+        return Ok(());
+    }
+    Err(SituationViewError::SnapshotSelectionMismatch {
+        selected_domain: selection.domain.clone(),
+        selected_subject: selection.subject.clone(),
+        actual_domain: snapshot.domain.clone(),
+        actual_subject: snapshot.subject.clone(),
+    })
+}
+
+fn compose_field(
+    field: &crate::FieldSnapshotV1,
+    correspondences: &[crate::ClockCorrespondenceV1],
+    request: &SituationViewRequestV1,
+) -> FieldResultV1 {
+    let contributors = field
+        .contributors
+        .iter()
+        .map(|evidence| ContributorResultV1 {
+            evidence: evidence.clone(),
+            ingress_age: age::ingress_age(
+                &evidence.ingress_time,
+                &request.host_evaluation,
+                correspondences,
+            ),
+            observation_age: age::observation_age(
+                &evidence.source_time,
+                &evidence.time_quality,
+                &evidence.time_uncertainty_nanoseconds,
+                request.query.time.evaluation_utc,
+            ),
+        })
+        .collect();
+    FieldResultV1 {
+        field: field.field.clone(),
+        value: field.value.clone(),
+        contributors,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-situation-view/src/compose/age.rs
+++ b/crates/pilotage-situation-view/src/compose/age.rs
@@ -1,0 +1,129 @@
+//! Age calculation with explicit clock evidence.
+
+use crate::{
+    AgeUnknownReasonV1, AgeV1, ClockCorrespondenceV1, EvidenceV1, MonotonicStampV1, TimeQualityV1,
+    UtcInstantV1,
+};
+
+pub(super) fn ingress_age(
+    ingress: &EvidenceV1<MonotonicStampV1>,
+    evaluation: &MonotonicStampV1,
+    correspondences: &[ClockCorrespondenceV1],
+) -> AgeV1 {
+    let EvidenceV1::Present { value: ingress } = ingress else {
+        return AgeV1::Unknown {
+            reason: AgeUnknownReasonV1::MissingIngressTime,
+        };
+    };
+    let mapped = map_ingress(ingress, evaluation, correspondences);
+    let Ok((mapped_nanoseconds, uncertainty_nanoseconds)) = mapped else {
+        return AgeV1::Unknown {
+            reason: mapped
+                .err()
+                .unwrap_or(AgeUnknownReasonV1::InvalidClockCorrespondence),
+        };
+    };
+    let Some(nanoseconds) = evaluation.nanoseconds.checked_sub(mapped_nanoseconds) else {
+        return AgeV1::Unknown {
+            reason: AgeUnknownReasonV1::IngressAfterEvaluation,
+        };
+    };
+    AgeV1::Known {
+        nanoseconds,
+        uncertainty_nanoseconds: EvidenceV1::Present {
+            value: uncertainty_nanoseconds,
+        },
+    }
+}
+
+fn map_ingress(
+    ingress: &MonotonicStampV1,
+    evaluation: &MonotonicStampV1,
+    correspondences: &[ClockCorrespondenceV1],
+) -> Result<(u64, u64), AgeUnknownReasonV1> {
+    if ingress.clock_id == evaluation.clock_id {
+        return Ok((ingress.nanoseconds, 0));
+    }
+    let candidates: Vec<&ClockCorrespondenceV1> = correspondences
+        .iter()
+        .filter(|item| {
+            item.source_clock_id == ingress.clock_id && item.target_clock_id == evaluation.clock_id
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Err(AgeUnknownReasonV1::MissingClockCorrespondence);
+    }
+    if candidates
+        .iter()
+        .any(|item| item.valid_source.start_nanoseconds > item.valid_source.end_nanoseconds)
+    {
+        return Err(AgeUnknownReasonV1::InvalidClockCorrespondence);
+    }
+    let valid: Vec<&ClockCorrespondenceV1> = candidates
+        .into_iter()
+        .filter(|item| item.valid_source.contains(ingress.nanoseconds))
+        .collect();
+    match valid.as_slice() {
+        [] => Err(AgeUnknownReasonV1::ClockCorrespondenceOutOfRange),
+        [correspondence] => translate(ingress.nanoseconds, correspondence),
+        _ => Err(AgeUnknownReasonV1::AmbiguousClockCorrespondence),
+    }
+}
+
+fn translate(
+    source_nanoseconds: u64,
+    correspondence: &ClockCorrespondenceV1,
+) -> Result<(u64, u64), AgeUnknownReasonV1> {
+    if correspondence.valid_source.start_nanoseconds > correspondence.valid_source.end_nanoseconds {
+        return Err(AgeUnknownReasonV1::InvalidClockCorrespondence);
+    }
+    let mapped = i128::from(source_nanoseconds)
+        .checked_add(i128::from(correspondence.offset_nanoseconds))
+        .ok_or(AgeUnknownReasonV1::InvalidClockCorrespondence)?;
+    let mapped =
+        u64::try_from(mapped).map_err(|_| AgeUnknownReasonV1::InvalidClockCorrespondence)?;
+    Ok((mapped, correspondence.uncertainty_nanoseconds))
+}
+
+pub(super) fn observation_age(
+    source_time: &EvidenceV1<UtcInstantV1>,
+    time_quality: &EvidenceV1<TimeQualityV1>,
+    uncertainty: &EvidenceV1<u64>,
+    evaluation: UtcInstantV1,
+) -> AgeV1 {
+    let EvidenceV1::Present { value: source_time } = source_time else {
+        return unknown(AgeUnknownReasonV1::MissingSourceTime);
+    };
+    let EvidenceV1::Present {
+        value: time_quality,
+    } = time_quality
+    else {
+        return unknown(AgeUnknownReasonV1::MissingTimeQuality);
+    };
+    if matches!(time_quality, TimeQualityV1::Untrusted) {
+        return unknown(AgeUnknownReasonV1::UntrustedSourceTime);
+    }
+    let Some(evaluation_ns) = evaluation.unix_nanoseconds() else {
+        return unknown(AgeUnknownReasonV1::InvalidUtcTime);
+    };
+    let Some(source_ns) = source_time.unix_nanoseconds() else {
+        return unknown(AgeUnknownReasonV1::InvalidUtcTime);
+    };
+    let Some(age_ns) = evaluation_ns.checked_sub(source_ns) else {
+        return unknown(AgeUnknownReasonV1::AgeOverflow);
+    };
+    if age_ns < 0 {
+        return unknown(AgeUnknownReasonV1::SourceTimeAfterEvaluation);
+    }
+    let Ok(nanoseconds) = u64::try_from(age_ns) else {
+        return unknown(AgeUnknownReasonV1::AgeOverflow);
+    };
+    AgeV1::Known {
+        nanoseconds,
+        uncertainty_nanoseconds: uncertainty.clone(),
+    }
+}
+
+const fn unknown(reason: AgeUnknownReasonV1) -> AgeV1 {
+    AgeV1::Unknown { reason }
+}

--- a/crates/pilotage-situation-view/src/compose/requirements.rs
+++ b/crates/pilotage-situation-view/src/compose/requirements.rs
@@ -1,0 +1,252 @@
+//! Freshness and coherence assessment.
+
+use serde_json::Value;
+
+use crate::{
+    AgeV1, CoherenceRequirementV1, CoherenceRuleV1, DomainResultV1, EvidenceV1, FieldResultV1,
+    FieldScopeV1, FreshnessAgeV1, FreshnessRequirementV1, RequirementAssessmentV1,
+    RequirementReasonV1, RequirementStatusV1, SituationViewRequestV1, SnapshotRequirementV1,
+};
+
+pub(super) fn assess(
+    request: &SituationViewRequestV1,
+    domains: &[DomainResultV1],
+) -> Vec<RequirementAssessmentV1> {
+    let freshness = request
+        .query
+        .requirements
+        .freshness
+        .iter()
+        .map(|item| assess_freshness(item, domains));
+    let coherence = request
+        .query
+        .requirements
+        .coherence
+        .iter()
+        .map(|item| assess_coherence(item, domains));
+    freshness.chain(coherence).collect()
+}
+
+fn assess_freshness(
+    requirement: &FreshnessRequirementV1,
+    domains: &[DomainResultV1],
+) -> RequirementAssessmentV1 {
+    let status = match find_field(domains, &requirement.field) {
+        FieldLookup::MissingDomain => not_satisfied(RequirementReasonV1::MissingDomain),
+        FieldLookup::MissingField => not_satisfied(RequirementReasonV1::MissingField),
+        FieldLookup::Present(field) => freshness_status(requirement, field),
+    };
+    RequirementAssessmentV1 {
+        requirement_id: requirement.requirement_id.clone(),
+        status,
+    }
+}
+
+fn freshness_status(
+    requirement: &FreshnessRequirementV1,
+    field: &FieldResultV1,
+) -> RequirementStatusV1 {
+    if matches!(field.value, EvidenceV1::Missing { .. }) {
+        return not_satisfied(RequirementReasonV1::MissingField);
+    }
+    if field.contributors.is_empty() {
+        return indeterminate(RequirementReasonV1::MissingContributor);
+    }
+    for contributor in &field.contributors {
+        let age = match requirement.age {
+            FreshnessAgeV1::Ingress => &contributor.ingress_age,
+            FreshnessAgeV1::Observation => &contributor.observation_age,
+        };
+        match age_upper_bound(age) {
+            AgeBound::Known(upper) if upper > requirement.maximum_age_nanoseconds => {
+                return not_satisfied(RequirementReasonV1::MaximumAgeExceeded);
+            }
+            AgeBound::Known(_) => {}
+            AgeBound::UnknownAge => {
+                return indeterminate(RequirementReasonV1::UnknownAge);
+            }
+            AgeBound::UnknownUncertainty => {
+                return indeterminate(RequirementReasonV1::UnknownUncertainty);
+            }
+        }
+    }
+    RequirementStatusV1::Satisfied
+}
+
+fn assess_coherence(
+    requirement: &CoherenceRequirementV1,
+    domains: &[DomainResultV1],
+) -> RequirementAssessmentV1 {
+    let status = match &requirement.rule {
+        CoherenceRuleV1::MaximumIngressAgeSpread {
+            fields,
+            maximum_spread_nanoseconds,
+        } => spread_status(fields, *maximum_spread_nanoseconds, domains),
+        CoherenceRuleV1::EqualFieldValues { fields } => equal_value_status(fields, domains),
+        CoherenceRuleV1::ExactSnapshots { snapshots } => exact_snapshot_status(snapshots, domains),
+    };
+    RequirementAssessmentV1 {
+        requirement_id: requirement.requirement_id.clone(),
+        status,
+    }
+}
+
+fn spread_status(
+    scopes: &[FieldScopeV1],
+    maximum: u64,
+    domains: &[DomainResultV1],
+) -> RequirementStatusV1 {
+    let mut lower = u64::MAX;
+    let mut upper = 0_u64;
+    let mut count = 0_usize;
+    for scope in scopes {
+        let FieldLookup::Present(field) = find_field(domains, scope) else {
+            return not_satisfied(missing_scope_reason(domains, scope));
+        };
+        if field.contributors.is_empty() {
+            return indeterminate(RequirementReasonV1::MissingContributor);
+        }
+        for contributor in &field.contributors {
+            let Some((item_lower, item_upper)) = age_interval(&contributor.ingress_age) else {
+                return indeterminate(age_reason(&contributor.ingress_age));
+            };
+            lower = lower.min(item_lower);
+            upper = upper.max(item_upper);
+            count = count.saturating_add(1);
+        }
+    }
+    if count == 0 {
+        return indeterminate(RequirementReasonV1::MissingContributor);
+    }
+    if upper.saturating_sub(lower) <= maximum {
+        RequirementStatusV1::Satisfied
+    } else {
+        not_satisfied(RequirementReasonV1::MaximumSpreadExceeded)
+    }
+}
+
+fn equal_value_status(scopes: &[FieldScopeV1], domains: &[DomainResultV1]) -> RequirementStatusV1 {
+    let mut expected: Option<&Value> = None;
+    for scope in scopes {
+        let lookup = find_field(domains, scope);
+        let FieldLookup::Present(field) = lookup else {
+            return not_satisfied(missing_scope_reason(domains, scope));
+        };
+        let EvidenceV1::Present { value } = &field.value else {
+            return not_satisfied(RequirementReasonV1::MissingField);
+        };
+        if let Some(first) = expected
+            && first != value
+        {
+            return not_satisfied(RequirementReasonV1::FieldValuesDiffer);
+        }
+        expected = Some(value);
+    }
+    RequirementStatusV1::Satisfied
+}
+
+fn exact_snapshot_status(
+    requirements: &[SnapshotRequirementV1],
+    domains: &[DomainResultV1],
+) -> RequirementStatusV1 {
+    for requirement in requirements {
+        let found = domains.iter().find(|domain| match domain {
+            DomainResultV1::Available {
+                domain, subject, ..
+            }
+            | DomainResultV1::Missing {
+                domain, subject, ..
+            } => domain == &requirement.domain && subject == &requirement.subject,
+        });
+        match found {
+            Some(DomainResultV1::Available { result, .. })
+                if result.producer_instance_id == requirement.producer_instance_id
+                    && result.snapshot_revision == requirement.snapshot_revision => {}
+            Some(DomainResultV1::Missing { .. }) | None => {
+                return not_satisfied(RequirementReasonV1::MissingDomain);
+            }
+            Some(DomainResultV1::Available { .. }) => {
+                return not_satisfied(RequirementReasonV1::SnapshotIdentityMismatch);
+            }
+        }
+    }
+    RequirementStatusV1::Satisfied
+}
+
+enum FieldLookup<'a> {
+    MissingDomain,
+    MissingField,
+    Present(&'a FieldResultV1),
+}
+
+fn find_field<'a>(domains: &'a [DomainResultV1], scope: &FieldScopeV1) -> FieldLookup<'a> {
+    let domain = domains.iter().find(|domain| match domain {
+        DomainResultV1::Available {
+            domain, subject, ..
+        }
+        | DomainResultV1::Missing {
+            domain, subject, ..
+        } => domain == &scope.domain && subject == &scope.subject,
+    });
+    let Some(DomainResultV1::Available { result, .. }) = domain else {
+        return FieldLookup::MissingDomain;
+    };
+    result
+        .fields
+        .iter()
+        .find(|field| field.field == scope.field)
+        .map_or(FieldLookup::MissingField, FieldLookup::Present)
+}
+
+enum AgeBound {
+    Known(u64),
+    UnknownAge,
+    UnknownUncertainty,
+}
+
+fn age_upper_bound(age: &AgeV1) -> AgeBound {
+    match age {
+        AgeV1::Known {
+            nanoseconds,
+            uncertainty_nanoseconds: EvidenceV1::Present { value },
+        } => AgeBound::Known(nanoseconds.saturating_add(*value)),
+        AgeV1::Known { .. } => AgeBound::UnknownUncertainty,
+        AgeV1::Unknown { .. } => AgeBound::UnknownAge,
+    }
+}
+
+fn age_interval(age: &AgeV1) -> Option<(u64, u64)> {
+    let AgeV1::Known {
+        nanoseconds,
+        uncertainty_nanoseconds: EvidenceV1::Present { value },
+    } = age
+    else {
+        return None;
+    };
+    Some((
+        nanoseconds.saturating_sub(*value),
+        nanoseconds.saturating_add(*value),
+    ))
+}
+
+fn age_reason(age: &AgeV1) -> RequirementReasonV1 {
+    match age {
+        AgeV1::Known { .. } => RequirementReasonV1::UnknownUncertainty,
+        AgeV1::Unknown { .. } => RequirementReasonV1::UnknownAge,
+    }
+}
+
+fn missing_scope_reason(domains: &[DomainResultV1], scope: &FieldScopeV1) -> RequirementReasonV1 {
+    match find_field(domains, scope) {
+        FieldLookup::MissingDomain => RequirementReasonV1::MissingDomain,
+        FieldLookup::MissingField | FieldLookup::Present(_) => RequirementReasonV1::MissingField,
+    }
+}
+
+const fn not_satisfied(reason: RequirementReasonV1) -> RequirementStatusV1 {
+    RequirementStatusV1::NotSatisfied { reason }
+}
+
+const fn indeterminate(reason: RequirementReasonV1) -> RequirementStatusV1 {
+    RequirementStatusV1::Indeterminate { reason }
+}

--- a/crates/pilotage-situation-view/src/compose/tests.rs
+++ b/crates/pilotage-situation-view/src/compose/tests.rs
@@ -1,0 +1,74 @@
+use std::cell::Cell;
+
+use crate::{
+    ComposingSituationViewV1, DomainSelectionV1, MissingDataReasonV1, MonotonicStampV1,
+    QueryAxisV1, QueryRequirementsV1, SITUATION_VIEW_SCHEMA_VERSION, SituationViewError,
+    SituationViewQueryV1, SituationViewRequestV1, SituationViewV1, SnapshotCaptureV1,
+    SnapshotSourceV1, TimeQueryV1, UtcInstantV1,
+};
+
+struct CountingSource {
+    captures: Cell<u32>,
+}
+
+impl SnapshotSourceV1 for CountingSource {
+    fn capture(&self, _selection: &DomainSelectionV1, _time: &TimeQueryV1) -> SnapshotCaptureV1 {
+        self.captures.set(self.captures.get().wrapping_add(1));
+        SnapshotCaptureV1::Missing {
+            reason: MissingDataReasonV1::DomainUnavailable,
+        }
+    }
+}
+
+fn request() -> SituationViewRequestV1 {
+    SituationViewRequestV1::attach(
+        SituationViewQueryV1 {
+            time: TimeQueryV1 {
+                axis: QueryAxisV1::ValidTime,
+                evaluation_utc: UtcInstantV1 {
+                    unix_seconds: 1,
+                    subsecond_nanoseconds: 0,
+                },
+            },
+            domains: vec![
+                DomainSelectionV1 {
+                    domain: "surveillance".to_string(),
+                    subject: "all_tracks".to_string(),
+                },
+                DomainSelectionV1 {
+                    domain: "airmass".to_string(),
+                    subject: "regional_weather".to_string(),
+                },
+            ],
+            requirements: QueryRequirementsV1::default(),
+        },
+        MonotonicStampV1 {
+            clock_id: "host".to_string(),
+            nanoseconds: 1,
+        },
+    )
+}
+
+#[test]
+fn composer_captures_each_selected_domain_once() {
+    let view = ComposingSituationViewV1::new(CountingSource {
+        captures: Cell::new(0),
+    });
+    let result = view.query(&request()).expect("request must be valid");
+    assert_eq!(result.domains.len(), 2);
+    assert_eq!(view.source().captures.get(), 2);
+}
+
+#[test]
+fn composer_rejects_an_unknown_request_version() {
+    let view = ComposingSituationViewV1::new(CountingSource {
+        captures: Cell::new(0),
+    });
+    let mut request = request();
+    request.schema_version = SITUATION_VIEW_SCHEMA_VERSION.wrapping_add(1);
+    assert!(matches!(
+        view.query(&request),
+        Err(SituationViewError::UnsupportedSchemaVersion { .. })
+    ));
+    assert_eq!(view.source().captures.get(), 0);
+}

--- a/crates/pilotage-situation-view/src/conformance.rs
+++ b/crates/pilotage-situation-view/src/conformance.rs
@@ -1,0 +1,205 @@
+//! Shared deterministic corpus for every SituationView implementation.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ComposingSituationViewV1, DomainSnapshotV1, MissingDataReasonV1, SITUATION_VIEW_CORPUS_VERSION,
+    SituationViewError, SituationViewRequestV1, SituationViewResultV1, SituationViewV1,
+    SnapshotCaptureV1, SnapshotSourceV1, TimeQueryV1,
+};
+
+const CORPUS_JSON: &str = include_str!("../corpus/situation-view-v1.json");
+
+/// One domain capture in a corpus case.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum CorpusCaptureV1 {
+    /// An immutable domain snapshot is available.
+    Available {
+        /// Captured snapshot value.
+        snapshot: DomainSnapshotV1,
+    },
+    /// The selected domain snapshot is not available.
+    Missing {
+        /// Stable domain name.
+        domain: String,
+        /// Domain-owned snapshot subject identity.
+        subject: String,
+        /// Reason that capture cannot return a handle.
+        reason: MissingDataReasonV1,
+    },
+}
+
+impl CorpusCaptureV1 {
+    fn key(&self) -> (&str, &str) {
+        match self {
+            Self::Available { snapshot } => (&snapshot.domain, &snapshot.subject),
+            Self::Missing {
+                domain, subject, ..
+            } => (domain, subject),
+        }
+    }
+
+    fn into_capture(self) -> SnapshotCaptureV1 {
+        match self {
+            Self::Available { snapshot } => SnapshotCaptureV1::Available {
+                snapshot: Arc::new(snapshot),
+            },
+            Self::Missing { reason, .. } => SnapshotCaptureV1::Missing { reason },
+        }
+    }
+}
+
+/// One deterministic corpus input and its required result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusCaseV1 {
+    /// Stable case name.
+    pub name: String,
+    /// Host-attached request.
+    pub request: SituationViewRequestV1,
+    /// Domain capture states for the request.
+    pub captures: Vec<CorpusCaptureV1>,
+    /// Exact required result.
+    pub expected: SituationViewResultV1,
+}
+
+/// Versioned collection of SituationView conformance cases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SituationViewCorpusV1 {
+    /// Corpus schema version.
+    pub corpus_version: u16,
+    /// Deterministic cases.
+    pub cases: Vec<CorpusCaseV1>,
+}
+
+/// Loads and validates the linked V1 corpus.
+///
+/// # Errors
+///
+/// Returns [`SituationViewError::CorpusDecode`] for invalid JSON. Returns
+/// [`SituationViewError::UnsupportedCorpusVersion`] for another version.
+pub fn load_corpus_v1() -> Result<SituationViewCorpusV1, SituationViewError> {
+    let corpus: SituationViewCorpusV1 = serde_json::from_str(CORPUS_JSON)
+        .map_err(|source| SituationViewError::CorpusDecode { source })?;
+    if corpus.corpus_version != SITUATION_VIEW_CORPUS_VERSION {
+        return Err(SituationViewError::UnsupportedCorpusVersion {
+            found: corpus.corpus_version,
+            expected: SITUATION_VIEW_CORPUS_VERSION,
+        });
+    }
+    Ok(corpus)
+}
+
+/// Runs the corpus through one implementation adapter.
+///
+/// The adapter receives the complete case. It can install the capture states
+/// in its own test boundary before it evaluates the request.
+///
+/// # Errors
+///
+/// Returns the adapter error for a failed case. Returns
+/// [`SituationViewError::CorpusMismatch`] when a result is not exact.
+pub fn verify_corpus_v1<F>(
+    corpus: &SituationViewCorpusV1,
+    mut evaluate: F,
+) -> Result<(), SituationViewError>
+where
+    F: FnMut(&CorpusCaseV1) -> Result<SituationViewResultV1, SituationViewError>,
+{
+    for case in &corpus.cases {
+        let actual = evaluate(case)?;
+        if actual != case.expected {
+            return Err(SituationViewError::CorpusMismatch {
+                case_name: case.name.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Runs the linked corpus through the reference composer.
+///
+/// # Errors
+///
+/// Returns a typed corpus, setup, request, or comparison error.
+pub fn verify_reference_corpus_v1() -> Result<(), SituationViewError> {
+    let corpus = load_corpus_v1()?;
+    verify_corpus_v1(&corpus, evaluate_reference_case)
+}
+
+fn evaluate_reference_case(
+    case: &CorpusCaseV1,
+) -> Result<SituationViewResultV1, SituationViewError> {
+    let source = CorpusSnapshotSourceV1::new(case)?;
+    ComposingSituationViewV1::new(source).query(&case.request)
+}
+
+#[derive(Debug, Clone)]
+struct CorpusSnapshotSourceV1 {
+    captures: BTreeMap<(String, String), SnapshotCaptureV1>,
+}
+
+impl CorpusSnapshotSourceV1 {
+    fn new(case: &CorpusCaseV1) -> Result<Self, SituationViewError> {
+        let mut captures = BTreeMap::new();
+        for capture in case.captures.iter().cloned() {
+            let (domain, subject) = capture.key();
+            let domain = domain.to_string();
+            let subject = subject.to_string();
+            let key = (domain.clone(), subject.clone());
+            if captures.insert(key, capture.into_capture()).is_some() {
+                return Err(SituationViewError::DuplicateCorpusCapture {
+                    case_name: case.name.clone(),
+                    domain,
+                    subject,
+                });
+            }
+        }
+        Ok(Self { captures })
+    }
+}
+
+impl SnapshotSourceV1 for CorpusSnapshotSourceV1 {
+    fn capture(
+        &self,
+        selection: &crate::DomainSelectionV1,
+        _time: &TimeQueryV1,
+    ) -> SnapshotCaptureV1 {
+        self.captures
+            .get(&(selection.domain.clone(), selection.subject.clone()))
+            .cloned()
+            .unwrap_or(SnapshotCaptureV1::Missing {
+                reason: MissingDataReasonV1::DomainUnavailable,
+            })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{load_corpus_v1, verify_reference_corpus_v1};
+
+    #[test]
+    fn linked_corpus_has_all_required_cases() {
+        let corpus = load_corpus_v1().expect("corpus must decode");
+        let names: Vec<&str> = corpus.cases.iter().map(|case| case.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "mixed_age_inputs",
+                "unknown_age",
+                "missing_domain",
+                "source_restart",
+                "clock_correspondence_uncertainty",
+            ]
+        );
+    }
+
+    #[test]
+    fn reference_composer_matches_linked_corpus() {
+        verify_reference_corpus_v1().expect("reference composer must match corpus");
+    }
+}

--- a/crates/pilotage-situation-view/src/contract.rs
+++ b/crates/pilotage-situation-view/src/contract.rs
@@ -1,0 +1,156 @@
+//! Caller query and host-attached request types.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{MonotonicStampV1, SITUATION_VIEW_SCHEMA_VERSION, UtcInstantV1};
+
+/// Time axis fixed by a query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryAxisV1 {
+    /// Select data that is in effect at the UTC value.
+    ValidTime,
+    /// Select data that the system held at the UTC value.
+    KnowledgeTime,
+}
+
+/// The time selection for one query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimeQueryV1 {
+    /// Axis fixed by the query.
+    pub axis: QueryAxisV1,
+    /// UTC value on the selected axis.
+    pub evaluation_utc: UtcInstantV1,
+}
+
+/// One domain and subject selected by the caller.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DomainSelectionV1 {
+    /// Stable domain name.
+    pub domain: String,
+    /// Domain-owned snapshot subject identity.
+    pub subject: String,
+}
+
+/// One field in a selected domain snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldScopeV1 {
+    /// Stable domain name.
+    pub domain: String,
+    /// Domain-owned snapshot subject identity.
+    pub subject: String,
+    /// Domain-owned field name.
+    pub field: String,
+}
+
+/// Age used by a freshness requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FreshnessAgeV1 {
+    /// Use the age from local ingress.
+    Ingress,
+    /// Use the age from the source observation time.
+    Observation,
+}
+
+/// Maximum age for one field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FreshnessRequirementV1 {
+    /// Caller-owned requirement identity.
+    pub requirement_id: String,
+    /// Field to assess.
+    pub field: FieldScopeV1,
+    /// Age to compare.
+    pub age: FreshnessAgeV1,
+    /// Largest accepted age, including its uncertainty bound.
+    pub maximum_age_nanoseconds: u64,
+}
+
+/// Required identity for one captured snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotRequirementV1 {
+    /// Stable domain name.
+    pub domain: String,
+    /// Domain-owned snapshot subject identity.
+    pub subject: String,
+    /// Required producer instance ID.
+    pub producer_instance_id: String,
+    /// Required snapshot revision.
+    pub snapshot_revision: u64,
+}
+
+/// Rule for one coherence requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum CoherenceRuleV1 {
+    /// Limit the possible ingress-age spread for a set of fields.
+    MaximumIngressAgeSpread {
+        /// Fields that must be coherent.
+        fields: Vec<FieldScopeV1>,
+        /// Largest accepted spread.
+        maximum_spread_nanoseconds: u64,
+    },
+    /// Require a set of fields to contain equal JSON values.
+    EqualFieldValues {
+        /// Fields that must contain the same value.
+        fields: Vec<FieldScopeV1>,
+    },
+    /// Require exact producer instance IDs and revisions.
+    ExactSnapshots {
+        /// Snapshot identities that the result must contain.
+        snapshots: Vec<SnapshotRequirementV1>,
+    },
+}
+
+/// One caller-supplied coherence requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoherenceRequirementV1 {
+    /// Caller-owned requirement identity.
+    pub requirement_id: String,
+    /// Coherence rule to assess.
+    #[serde(flatten)]
+    pub rule: CoherenceRuleV1,
+}
+
+/// Freshness and coherence requirements for one query.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct QueryRequirementsV1 {
+    /// Field freshness requirements.
+    pub freshness: Vec<FreshnessRequirementV1>,
+    /// Cross-field or cross-domain coherence requirements.
+    pub coherence: Vec<CoherenceRequirementV1>,
+}
+
+/// Caller-owned part of a situation query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SituationViewQueryV1 {
+    /// Time axis and UTC value.
+    pub time: TimeQueryV1,
+    /// Domains that the caller selects.
+    pub domains: Vec<DomainSelectionV1>,
+    /// Caller freshness and coherence requirements.
+    pub requirements: QueryRequirementsV1,
+}
+
+/// Versioned request after the composition host attaches its clock stamp.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SituationViewRequestV1 {
+    /// Contract schema version.
+    pub schema_version: u16,
+    /// Caller-owned query.
+    pub query: SituationViewQueryV1,
+    /// Host monotonic stamp at evaluation.
+    pub host_evaluation: MonotonicStampV1,
+}
+
+impl SituationViewRequestV1 {
+    /// Attaches the host evaluation stamp to a caller query.
+    #[must_use]
+    pub const fn attach(query: SituationViewQueryV1, host_evaluation: MonotonicStampV1) -> Self {
+        Self {
+            schema_version: SITUATION_VIEW_SCHEMA_VERSION,
+            query,
+            host_evaluation,
+        }
+    }
+}

--- a/crates/pilotage-situation-view/src/error.rs
+++ b/crates/pilotage-situation-view/src/error.rs
@@ -1,0 +1,81 @@
+//! Typed contract and corpus errors.
+
+/// Error from request validation, snapshot capture, or corpus verification.
+#[derive(Debug, thiserror::Error)]
+pub enum SituationViewError {
+    /// The request uses an unsupported schema version.
+    #[error("SituationView schema version {found} is not supported; expected {expected}")]
+    UnsupportedSchemaVersion {
+        /// Version in the request.
+        found: u16,
+        /// Version supported by this implementation.
+        expected: u16,
+    },
+    /// A UTC instant has an invalid subsecond value.
+    #[error("{location} has invalid subsecond nanoseconds {subsecond_nanoseconds}")]
+    InvalidUtcInstant {
+        /// Location of the invalid instant.
+        location: String,
+        /// Invalid subsecond value.
+        subsecond_nanoseconds: u32,
+    },
+    /// The query selects one domain subject more than once.
+    #[error("domain {domain} subject {subject} is selected more than once")]
+    DuplicateDomainSelection {
+        /// Stable domain name.
+        domain: String,
+        /// Domain-owned subject identity.
+        subject: String,
+    },
+    /// The query uses one requirement ID more than once.
+    #[error("requirement ID {requirement_id} is used more than once")]
+    DuplicateRequirementId {
+        /// Duplicate caller-owned requirement ID.
+        requirement_id: String,
+    },
+    /// A source returned a snapshot for a different selection.
+    #[error(
+        "capture for {selected_domain}/{selected_subject} returned {actual_domain}/{actual_subject}"
+    )]
+    SnapshotSelectionMismatch {
+        /// Selected domain name.
+        selected_domain: String,
+        /// Selected subject identity.
+        selected_subject: String,
+        /// Captured domain name.
+        actual_domain: String,
+        /// Captured subject identity.
+        actual_subject: String,
+    },
+    /// The corpus JSON cannot be decoded.
+    #[error("SituationView corpus cannot be decoded: {source}")]
+    CorpusDecode {
+        /// JSON decoding error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// The corpus uses an unsupported version.
+    #[error("SituationView corpus version {found} is not supported; expected {expected}")]
+    UnsupportedCorpusVersion {
+        /// Version in the corpus.
+        found: u16,
+        /// Version supported by this implementation.
+        expected: u16,
+    },
+    /// A corpus case contains one capture more than once.
+    #[error("corpus case {case_name} repeats capture {domain}/{subject}")]
+    DuplicateCorpusCapture {
+        /// Corpus case name.
+        case_name: String,
+        /// Stable domain name.
+        domain: String,
+        /// Domain-owned subject identity.
+        subject: String,
+    },
+    /// An implementation result differs from the required corpus result.
+    #[error("SituationView corpus case {case_name} produced a different result")]
+    CorpusMismatch {
+        /// Corpus case name.
+        case_name: String,
+    },
+}

--- a/crates/pilotage-situation-view/src/evidence.rs
+++ b/crates/pilotage-situation-view/src/evidence.rs
@@ -1,0 +1,61 @@
+//! Evidence states that do not use sentinel values.
+
+use serde::{Deserialize, Serialize};
+
+/// Reason that a requested value or item is not present.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingDataReasonV1 {
+    /// The producer has not accepted evidence for the item.
+    NotObserved,
+    /// A source reported that the item is not available.
+    SourceReportedUnavailable,
+    /// The item passed its freshness or validity limit.
+    Expired,
+    /// The item failed an acceptance rule.
+    Rejected,
+    /// The item has no meaning for the selected subject.
+    NotApplicable,
+    /// The producer cannot represent the item.
+    Unsupported,
+    /// A declared resource limit prevented retention.
+    ResourceLimit,
+    /// The selected domain is not installed or is not available.
+    DomainUnavailable,
+    /// The selected knowledge state is not in the retained data.
+    KnowledgeStateUnavailable,
+    /// Valid time evidence is not available.
+    InvalidTimeEvidence,
+    /// The domain schema defines a more specific reason.
+    DomainSpecific {
+        /// Stable reason code from the domain schema.
+        code: String,
+    },
+}
+
+/// A present value or an explicit reason for a missing value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum EvidenceV1<T> {
+    /// The evidence contains a value.
+    Present {
+        /// The evidence value.
+        value: T,
+    },
+    /// The evidence does not contain a value.
+    Missing {
+        /// Reason that the value is not present.
+        reason: MissingDataReasonV1,
+    },
+}
+
+impl<T> EvidenceV1<T> {
+    /// Returns the present value.
+    #[must_use]
+    pub const fn as_ref(&self) -> Option<&T> {
+        match self {
+            Self::Present { value } => Some(value),
+            Self::Missing { .. } => None,
+        }
+    }
+}

--- a/crates/pilotage-situation-view/src/lib.rs
+++ b/crates/pilotage-situation-view/src/lib.rs
@@ -1,0 +1,46 @@
+//! Versioned contract for read-only situation queries.
+//!
+//! A composition host captures one immutable handle for each selected domain.
+//! The host reports the identity and the age evidence from each handle.
+//! The result uses best-available, non-atomic consistency across domains.
+
+mod compose;
+mod conformance;
+mod contract;
+mod error;
+mod evidence;
+mod result;
+mod snapshot;
+mod time;
+
+pub use compose::{ComposingSituationViewV1, SituationViewV1};
+pub use conformance::{
+    CorpusCaptureV1, CorpusCaseV1, SituationViewCorpusV1, load_corpus_v1, verify_corpus_v1,
+    verify_reference_corpus_v1,
+};
+pub use contract::{
+    CoherenceRequirementV1, CoherenceRuleV1, DomainSelectionV1, FieldScopeV1, FreshnessAgeV1,
+    FreshnessRequirementV1, QueryAxisV1, QueryRequirementsV1, SituationViewQueryV1,
+    SituationViewRequestV1, SnapshotRequirementV1, TimeQueryV1,
+};
+pub use error::SituationViewError;
+pub use evidence::{EvidenceV1, MissingDataReasonV1};
+pub use result::{
+    AvailableDomainResultV1, ConsistencyGuaranteeV1, ContributorResultV1, DomainResultV1,
+    FieldResultV1, RequirementAssessmentV1, RequirementReasonV1, RequirementStatusV1,
+    SituationViewResultV1,
+};
+pub use snapshot::{
+    ContributorEvidenceV1, DomainIdentityV1, DomainSnapshotV1, FieldSnapshotV1, SnapshotCaptureV1,
+    SnapshotSourceV1,
+};
+pub use time::{
+    AgeUnknownReasonV1, AgeV1, ClockCorrespondenceV1, MonotonicIntervalV1, MonotonicStampV1,
+    TimeQualityV1, UtcInstantV1, UtcIntervalV1,
+};
+
+/// Schema version for the first request and result contract.
+pub const SITUATION_VIEW_SCHEMA_VERSION: u16 = 1;
+
+/// Schema version for the first conformance corpus.
+pub const SITUATION_VIEW_CORPUS_VERSION: u16 = 1;

--- a/crates/pilotage-situation-view/src/result.rs
+++ b/crates/pilotage-situation-view/src/result.rs
@@ -1,0 +1,150 @@
+//! Versioned result and requirement assessment types.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    AgeV1, ClockCorrespondenceV1, ContributorEvidenceV1, DomainIdentityV1, MissingDataReasonV1,
+    MonotonicStampV1, TimeQueryV1,
+};
+
+/// Cross-domain consistency supplied by the first contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsistencyGuaranteeV1 {
+    /// Each domain has one immutable handle. Domains are not atomic together.
+    BestAvailableNonAtomic,
+}
+
+/// Contributor evidence with its two separate ages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContributorResultV1 {
+    /// Source, epoch, time, validity, quality, and uncertainty evidence.
+    #[serde(flatten)]
+    pub evidence: ContributorEvidenceV1,
+    /// Age from local ingress to host evaluation.
+    pub ingress_age: AgeV1,
+    /// Age from source observation to evaluation UTC.
+    pub observation_age: AgeV1,
+}
+
+/// One composed field and its contributors.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldResultV1 {
+    /// Domain-owned field name.
+    pub field: String,
+    /// Field value or an explicit missing reason.
+    pub value: crate::EvidenceV1<Value>,
+    /// Bounded source contributors.
+    pub contributors: Vec<ContributorResultV1>,
+}
+
+/// Available domain result with its snapshot identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AvailableDomainResultV1 {
+    /// Version of the complete domain record.
+    pub domain_schema_version: u32,
+    /// Opaque identity for one continuous domain producer instance.
+    pub producer_instance_id: String,
+    /// Revision for this subject and producer instance.
+    pub snapshot_revision: u64,
+    /// Domain-specific identity fields.
+    pub domain_identity: DomainIdentityV1,
+    /// Composed fields.
+    pub fields: Vec<FieldResultV1>,
+    /// Clock mappings supplied with the captured snapshot.
+    pub clock_correspondences: Vec<ClockCorrespondenceV1>,
+}
+
+/// Result for one selected domain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum DomainResultV1 {
+    /// The view captured one immutable snapshot handle.
+    Available {
+        /// Stable domain name.
+        domain: String,
+        /// Domain-owned snapshot subject identity.
+        subject: String,
+        /// Available snapshot result.
+        result: AvailableDomainResultV1,
+    },
+    /// The selected domain snapshot is not available.
+    Missing {
+        /// Stable domain name.
+        domain: String,
+        /// Domain-owned snapshot subject identity.
+        subject: String,
+        /// Reason that the selected domain is missing.
+        reason: MissingDataReasonV1,
+    },
+}
+
+/// Reason for a failed or indeterminate requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementReasonV1 {
+    /// A selected domain is missing.
+    MissingDomain,
+    /// A selected field is missing.
+    MissingField,
+    /// A field has no contributor evidence.
+    MissingContributor,
+    /// A required age is unknown.
+    UnknownAge,
+    /// An age uncertainty is not available.
+    UnknownUncertainty,
+    /// A maximum age is exceeded.
+    MaximumAgeExceeded,
+    /// A maximum age spread is exceeded.
+    MaximumSpreadExceeded,
+    /// Required field values are different.
+    FieldValuesDiffer,
+    /// A producer instance ID or revision is different.
+    SnapshotIdentityMismatch,
+}
+
+/// Assessment state for one caller requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum RequirementStatusV1 {
+    /// The result satisfies the requirement.
+    Satisfied,
+    /// The result does not satisfy the requirement.
+    NotSatisfied {
+        /// Reason that the requirement failed.
+        reason: RequirementReasonV1,
+    },
+    /// The available evidence cannot decide the requirement.
+    Indeterminate {
+        /// Reason that the assessment is indeterminate.
+        reason: RequirementReasonV1,
+    },
+}
+
+/// Assessment for one caller requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequirementAssessmentV1 {
+    /// Caller-owned requirement identity.
+    pub requirement_id: String,
+    /// Requirement assessment.
+    #[serde(flatten)]
+    pub status: RequirementStatusV1,
+}
+
+/// Complete versioned result for one request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SituationViewResultV1 {
+    /// Contract schema version.
+    pub schema_version: u16,
+    /// Query axis and UTC value from the request.
+    pub query_time: TimeQueryV1,
+    /// Host monotonic evaluation stamp from the request.
+    pub host_evaluation: MonotonicStampV1,
+    /// Cross-domain consistency guarantee.
+    pub consistency: ConsistencyGuaranteeV1,
+    /// Results in the same order as the selected domains.
+    pub domains: Vec<DomainResultV1>,
+    /// Assessments in request order.
+    pub requirement_assessments: Vec<RequirementAssessmentV1>,
+}

--- a/crates/pilotage-situation-view/src/snapshot.rs
+++ b/crates/pilotage-situation-view/src/snapshot.rs
@@ -1,0 +1,102 @@
+//! Immutable snapshot capture boundary.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    ClockCorrespondenceV1, DomainSelectionV1, EvidenceV1, MissingDataReasonV1, MonotonicStampV1,
+    TimeQualityV1, TimeQueryV1, UtcInstantV1, UtcIntervalV1,
+};
+
+/// Source and time evidence for one field contributor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContributorEvidenceV1 {
+    /// Source identity or an explicit missing reason.
+    pub source_identity: EvidenceV1<String>,
+    /// Source epoch or an explicit missing reason.
+    pub source_epoch: EvidenceV1<String>,
+    /// Local monotonic ingress stamp.
+    pub ingress_time: EvidenceV1<MonotonicStampV1>,
+    /// Source observation or product time.
+    pub source_time: EvidenceV1<UtcInstantV1>,
+    /// Quality of the source time.
+    pub time_quality: EvidenceV1<TimeQualityV1>,
+    /// Source or product validity interval.
+    pub validity: EvidenceV1<UtcIntervalV1>,
+    /// Domain-owned quality evidence.
+    pub data_quality: EvidenceV1<Value>,
+    /// Error bound for the source time.
+    pub time_uncertainty_nanoseconds: EvidenceV1<u64>,
+}
+
+/// One field in an immutable domain snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldSnapshotV1 {
+    /// Domain-owned field name.
+    pub field: String,
+    /// Field value or an explicit missing reason.
+    pub value: EvidenceV1<Value>,
+    /// Bounded contributors defined by the domain schema.
+    pub contributors: Vec<ContributorEvidenceV1>,
+}
+
+/// Domain-specific identity that supplements the common snapshot envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum DomainIdentityV1 {
+    /// The common producer and revision identity is sufficient.
+    Common,
+    /// Navdata also supplies its cycle, snapshot ID, and digest.
+    Navdata {
+        /// Published navigation-data cycle.
+        cycle: String,
+        /// Identity for one immutable built snapshot.
+        snapshot_id: String,
+        /// Digest of the canonical snapshot content and cycle.
+        snapshot_digest: String,
+    },
+}
+
+/// One immutable domain snapshot with its common envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DomainSnapshotV1 {
+    /// Stable domain name.
+    pub domain: String,
+    /// Domain-owned snapshot subject identity.
+    pub subject: String,
+    /// Version of the complete domain record.
+    pub domain_schema_version: u32,
+    /// Opaque identity for one continuous domain producer instance.
+    pub producer_instance_id: String,
+    /// Revision for this subject and producer instance.
+    pub snapshot_revision: u64,
+    /// Domain-specific identity fields.
+    pub domain_identity: DomainIdentityV1,
+    /// Source-derived fields in the composed view.
+    pub fields: Vec<FieldSnapshotV1>,
+    /// Mappings from contributor clocks to the host clock.
+    pub clock_correspondences: Vec<ClockCorrespondenceV1>,
+}
+
+/// Result of one immutable snapshot capture.
+#[derive(Debug, Clone)]
+pub enum SnapshotCaptureV1 {
+    /// The source returned one retainable immutable handle.
+    Available {
+        /// Retained snapshot handle.
+        snapshot: Arc<DomainSnapshotV1>,
+    },
+    /// The source cannot return the selected snapshot.
+    Missing {
+        /// Reason that the selected snapshot is not available.
+        reason: MissingDataReasonV1,
+    },
+}
+
+/// Source that captures one immutable handle for a selected domain.
+pub trait SnapshotSourceV1 {
+    /// Captures one handle for `selection` at the selected query time.
+    fn capture(&self, selection: &DomainSelectionV1, time: &TimeQueryV1) -> SnapshotCaptureV1;
+}

--- a/crates/pilotage-situation-view/src/time.rs
+++ b/crates/pilotage-situation-view/src/time.rs
@@ -1,0 +1,142 @@
+//! Civil and monotonic time types for the contract.
+
+use serde::{Deserialize, Serialize};
+
+use crate::EvidenceV1;
+
+/// A UTC instant with nanosecond resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UtcInstantV1 {
+    /// Whole seconds from the Unix epoch.
+    pub unix_seconds: i64,
+    /// Nanoseconds after `unix_seconds`.
+    pub subsecond_nanoseconds: u32,
+}
+
+impl UtcInstantV1 {
+    /// Returns the instant as a signed nanosecond count.
+    #[must_use]
+    pub fn unix_nanoseconds(self) -> Option<i128> {
+        if self.subsecond_nanoseconds >= 1_000_000_000 {
+            return None;
+        }
+        Some(
+            i128::from(self.unix_seconds)
+                .saturating_mul(1_000_000_000)
+                .saturating_add(i128::from(self.subsecond_nanoseconds)),
+        )
+    }
+}
+
+/// An inclusive UTC interval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UtcIntervalV1 {
+    /// First valid UTC instant.
+    pub start: UtcInstantV1,
+    /// Last valid UTC instant.
+    pub end: UtcInstantV1,
+}
+
+/// A point on one identified monotonic clock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MonotonicStampV1 {
+    /// Opaque identity for one continuous monotonic clock.
+    pub clock_id: String,
+    /// Nanoseconds from the local clock origin.
+    pub nanoseconds: u64,
+}
+
+/// An inclusive interval on one monotonic clock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MonotonicIntervalV1 {
+    /// First stamp for which the mapping is valid.
+    pub start_nanoseconds: u64,
+    /// Last stamp for which the mapping is valid.
+    pub end_nanoseconds: u64,
+}
+
+impl MonotonicIntervalV1 {
+    /// Returns true when `stamp` is in the inclusive interval.
+    #[must_use]
+    pub const fn contains(&self, stamp: u64) -> bool {
+        self.start_nanoseconds <= stamp && stamp <= self.end_nanoseconds
+    }
+}
+
+/// A bounded mapping from a source clock to a target clock.
+///
+/// The mapping is `target = source + offset_nanoseconds`. The uncertainty is
+/// a symmetric error bound. The mapping applies only in `valid_source`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClockCorrespondenceV1 {
+    /// Clock that supplied the source stamp.
+    pub source_clock_id: String,
+    /// Clock to which the source stamp maps.
+    pub target_clock_id: String,
+    /// Signed offset from the source clock to the target clock.
+    pub offset_nanoseconds: i64,
+    /// Symmetric mapping error bound.
+    pub uncertainty_nanoseconds: u64,
+    /// Source-clock interval in which the mapping is valid.
+    pub valid_source: MonotonicIntervalV1,
+}
+
+/// Quality of a source observation or product time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeQualityV1 {
+    /// A trusted source supplied the time.
+    Trusted,
+    /// A documented mapping or estimate supplied the time.
+    Estimated,
+    /// The source time is not valid for age calculation.
+    Untrusted,
+}
+
+/// Reason that an age cannot be calculated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgeUnknownReasonV1 {
+    /// The ingress stamp is not present.
+    MissingIngressTime,
+    /// The source time is not present.
+    MissingSourceTime,
+    /// The source time quality is not present.
+    MissingTimeQuality,
+    /// The source time quality does not permit an age calculation.
+    UntrustedSourceTime,
+    /// No clock correspondence maps the ingress stamp to the host clock.
+    MissingClockCorrespondence,
+    /// The ingress stamp is outside the mapping valid interval.
+    ClockCorrespondenceOutOfRange,
+    /// More than one valid mapping applies to the ingress stamp.
+    AmbiguousClockCorrespondence,
+    /// A clock mapping cannot produce a monotonic stamp.
+    InvalidClockCorrespondence,
+    /// The ingress stamp is after the evaluation stamp.
+    IngressAfterEvaluation,
+    /// The source time is after the evaluation time.
+    SourceTimeAfterEvaluation,
+    /// A UTC value is outside the contract representation.
+    InvalidUtcTime,
+    /// The age is larger than the contract representation.
+    AgeOverflow,
+}
+
+/// A calculated age or a reason that the age is unknown.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum AgeV1 {
+    /// The age value is known.
+    Known {
+        /// Age at the evaluation point.
+        nanoseconds: u64,
+        /// Symmetric error bound for the age.
+        uncertainty_nanoseconds: EvidenceV1<u64>,
+    },
+    /// The required time evidence is not valid.
+    Unknown {
+        /// Reason that the age is unknown.
+        reason: AgeUnknownReasonV1,
+    },
+}

--- a/crates/pilotage-situation-view/tests/corpus.rs
+++ b/crates/pilotage-situation-view/tests/corpus.rs
@@ -1,0 +1,16 @@
+//! Public conformance-corpus test for the reference composer.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use pilotage_situation_view::{load_corpus_v1, verify_reference_corpus_v1};
+
+#[test]
+fn corpus_contains_five_required_scenarios() {
+    let corpus = load_corpus_v1().expect("corpus must decode");
+    assert_eq!(corpus.cases.len(), 5);
+}
+
+#[test]
+fn reference_composer_passes_the_shared_corpus() {
+    verify_reference_corpus_v1().expect("reference composer must conform");
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,10 @@ The [domain snapshot envelope contract](domain-snapshot-envelope.md) defines
 immutable domain output. It defines producer identity, snapshot revision,
 retainable handles, field evidence, absence, and schema-version rules.
 
+The [SituationView V1 contract](situation-view-contract.md) defines the
+versioned query and result. It defines clock correspondence, best-available
+consistency, age assessment, and the shared conformance corpus.
+
 ## Load-bearing principles
 
 1. **Sans-IO core** ([ADR-0002](adr/0002-cargo-workspace-portable-sans-io-core.md)):

--- a/docs/situation-view-contract.md
+++ b/docs/situation-view-contract.md
@@ -1,0 +1,222 @@
+# SituationView V1 contract
+
+This contract defines the read-only `SituationView` request and result.
+It also defines the conformance corpus for each implementation.
+
+## Scope
+
+`SituationView` reads immutable domain snapshot handles.
+It does not collect source data.
+It does not decode source protocols.
+It does not own mutable domain state.
+
+The contract is source-neutral.
+The contract does not use a provider type or a link-service type.
+A domain core does not depend on this contract.
+
+The Rust types are in `pilotage-situation-view`.
+`SITUATION_VIEW_SCHEMA_VERSION` identifies the request and result schema.
+V1 uses schema version `1`.
+
+## Time query
+
+The caller supplies one time axis and one UTC value.
+The valid-time axis selects data that is in effect at the UTC value.
+The knowledge-time axis selects data that the system held at the UTC value.
+The caller must not use one UTC value for both axes.
+
+The caller selects each required domain and snapshot subject.
+The caller can also supply freshness requirements.
+The caller can also supply coherence requirements.
+
+The composition host attaches one monotonic evaluation stamp.
+The stamp contains the host clock identity and a nanosecond value.
+The result repeats the time axis, the UTC value, and the host stamp.
+
+The caller uses `SituationViewQueryV1`.
+The host uses `SituationViewRequestV1::attach` to make the request.
+
+## Snapshot capture
+
+The host calls the snapshot source one time for each selected domain subject.
+The source returns one retainable immutable handle or one missing-data reason.
+The host keeps the selection order in the result.
+
+A valid-time source selects a handle for data that is in effect.
+It can use a supplied fixed handle.
+It can also capture its best available handle.
+
+A knowledge-time source uses a retained handle ring or replay data.
+It must not use a current handle as a fallback.
+It returns `knowledge_state_unavailable` when the selected state is not
+available.
+
+## Consistency guarantee
+
+V1 uses `best_available_non_atomic` consistency.
+The host captures one immutable handle from each selected domain.
+The host does not use one transaction across domains.
+Two domain handles can represent different update times.
+
+Each available domain result contains these values:
+
+| Value | Requirement |
+|---|---|
+| Domain schema version | Identifies the complete domain record schema. |
+| Producer instance ID | Identifies one continuous domain producer. |
+| Snapshot revision | Orders states for one subject and producer. |
+| Domain identity | Contains domain-specific identity when required. |
+| Fields | Contains values and contributor evidence. |
+| Clock correspondences | Maps contributor clocks to the host clock. |
+
+A Navdata result uses the `navdata` domain identity.
+It contains the navigation-data cycle, snapshot ID, and snapshot digest.
+These values do not replace the producer instance ID or snapshot revision.
+
+A missing domain result contains the domain, subject, and missing-data reason.
+It does not make a producer ID or revision.
+
+## Field evidence
+
+Each field contains a present value or a missing-data reason.
+The value uses JSON only as a source-neutral exchange value.
+The domain schema defines the value meaning.
+
+Each field contains a bounded contributor list.
+The domain schema defines the contributor bound.
+Each contributor contains these items:
+
+- source identity;
+- source epoch;
+- local monotonic ingress time;
+- source observation or product time;
+- source time quality;
+- validity interval;
+- domain-owned data quality; and
+- source time uncertainty.
+
+Each item uses `EvidenceV1`.
+`EvidenceV1` contains a value or an explicit missing-data reason.
+The contract does not use a sentinel value for missing evidence.
+A domain can supply a stable domain-specific reason code.
+
+A source restart changes the source epoch.
+It does not change the domain producer instance ID.
+A domain producer restart changes the producer instance ID.
+
+## Clock correspondence
+
+`ClockCorrespondenceV1` maps one source monotonic clock to one target
+monotonic clock.
+It contains these values:
+
+- source clock identity;
+- target clock identity;
+- signed nanosecond offset;
+- symmetric uncertainty in nanoseconds; and
+- an inclusive valid interval on the source clock.
+
+The mapping is:
+
+```text
+target stamp = source stamp + offset
+```
+
+The host uses the mapping only when the source stamp is in the valid interval.
+One source stamp must have no more than one valid mapping to the host clock.
+An implementation can use short valid intervals to limit clock drift.
+It can publish a new mapping when the offset or uncertainty changes.
+
+Stamps on the same clock do not need a correspondence.
+Their mapping uncertainty is zero.
+
+The ingress age is:
+
+```text
+host evaluation stamp - mapped ingress stamp
+```
+
+The observation age is:
+
+```text
+evaluation UTC - source observation time
+```
+
+The result reports the two ages separately.
+A known age contains its nanosecond value and uncertainty evidence.
+
+The result reports ingress age as unknown in these conditions:
+
+- the ingress stamp is missing;
+- a required correspondence is missing;
+- the source stamp is outside the valid interval;
+- more than one valid correspondence applies;
+- the mapping cannot make a target stamp; or
+- the mapped ingress stamp is after the host evaluation stamp.
+
+The result reports observation age as unknown in these conditions:
+
+- the source time is missing;
+- the source time quality is missing or untrusted;
+- a UTC value is invalid; or
+- the source time is after the evaluation UTC.
+
+The view does not compare raw stamps from different clocks.
+
+## Freshness requirements
+
+A freshness requirement selects one field and one age type.
+It also supplies a maximum age.
+
+The view checks all contributors for the selected field.
+The view adds the age uncertainty to the age value.
+The requirement is satisfied only when each upper bound is not more than the
+maximum age.
+
+The requirement is not satisfied when a domain or field is missing.
+The requirement is not satisfied when an upper bound is more than the maximum.
+The result is indeterminate when an age or its uncertainty is unknown.
+
+## Coherence requirements
+
+V1 defines three coherence rules.
+
+`maximum_ingress_age_spread` limits the possible age spread for selected
+fields.
+The assessment includes each contributor uncertainty.
+
+`equal_field_values` requires equal JSON values for selected fields.
+This rule can require one navigation-data cycle in a rendered composition.
+
+`exact_snapshots` requires stated producer instance IDs and revisions.
+The rule does not compare revisions from different producer instances.
+
+Each requirement has a caller-owned ID.
+The result contains one assessment for each ID.
+The result keeps request order.
+
+## Conformance corpus
+
+The shared corpus is
+`crates/pilotage-situation-view/corpus/situation-view-v1.json`.
+`SITUATION_VIEW_CORPUS_VERSION` identifies its schema.
+V1 uses corpus version `1`.
+
+The corpus contains these exact cases:
+
+| Case | Required behavior |
+|---|---|
+| `mixed_age_inputs` | Report different ingress and observation ages. Assess failed freshness and coherence limits. |
+| `unknown_age` | Report unknown ingress and observation ages when time evidence is not valid. |
+| `missing_domain` | Keep the selected domain and report an explicit reason. |
+| `source_restart` | Keep one producer identity and two source epochs. |
+| `clock_correspondence_uncertainty` | Apply the valid clock mapping and include its uncertainty in freshness. |
+
+Each case contains a host-attached request, domain capture states, and one exact
+required result.
+An implementation test installs the capture states and runs the request.
+It calls `verify_corpus_v1` to compare the complete result.
+
+CI runs the corpus for the reference composer.
+Each additional implementation must add a test that calls the same corpus
+runner.

--- a/scripts/check-situation-view-boundary.sh
+++ b/scripts/check-situation-view-boundary.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Keep the SituationView contract independent from providers and link services.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+metadata="$(cargo metadata --no-deps --format-version 1)"
+dependencies="$(jq -r '
+  .packages[]
+  | select(.name == "pilotage-situation-view")
+  | .dependencies[]
+  | select(.kind == null or .kind == "normal")
+  | .name
+' <<<"$metadata")"
+
+status=0
+while IFS= read -r dependency; do
+    [ -z "$dependency" ] && continue
+    case "$dependency" in
+        serde|serde_json|thiserror) ;;
+        *)
+            echo "FORBIDDEN: pilotage-situation-view has direct dependency $dependency" >&2
+            status=1
+            ;;
+    esac
+done <<<"$dependencies"
+
+if rg -n -i \
+    '\b(aero[_-]?link|avionics[_-]?link|aerocontext|maplibre|gdl90|fis[_-]?b)\b' \
+    crates/pilotage-situation-view/src \
+    crates/pilotage-situation-view/corpus; then
+    echo "FORBIDDEN: SituationView contains a provider or link-service type" >&2
+    status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+    echo "check-situation-view-boundary: FAILED" >&2
+    exit 1
+fi
+
+echo "check-situation-view-boundary: OK"


### PR DESCRIPTION
## Contract

This change adds the versioned `SituationView` V1 contract.
The caller supplies one UTC time axis and freshness or coherence requirements.
The composition host attaches its monotonic evaluation stamp and clock identity.
The result keeps one immutable snapshot identity for each selected domain.
It reports ingress age and observation age as separate values.

V1 uses best-available, non-atomic consistency.
The clock correspondence contains an offset, uncertainty, and valid interval.
A dependency guard keeps provider and link-service types out of the contract.

## Corpus

The shared JSON corpus contains exact requests, capture states, and results.
It covers mixed ages, unknown age, a missing domain, a source restart, and clock-correspondence uncertainty.
CI runs the corpus against the reference composer.
The public corpus runner is available to each additional implementation.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- `bash scripts/check-structure.sh`
- `bash scripts/check-situation-view-boundary.sh`
- ADR lifecycle checks

Closes #341.
Refs #321.