### PR TITLE
Add situation layer controls and traffic detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
       - name: situation presentation boundary
         run: bash scripts/check-situation-presentation-boundary.sh
 
+      - name: situation layer controls self-test
+        run: bash scripts/test-check-situation-layer-controls.sh
+
+      - name: situation layer controls
+        run: bash scripts/check-situation-layer-controls.sh
+
       - name: Apple situation client guard self-test
         run: bash scripts/test-check-apple-situation-client.sh
 

--- a/clients/apple-situation/App/AeroLinkRadioState.swift
+++ b/clients/apple-situation/App/AeroLinkRadioState.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import PilotageRadioSource
 import PilotageSituationCore
 
@@ -60,7 +61,7 @@ actor AeroLinkRadioState {
         idleAvailability = .unplugged
         reconnectRequested = true
         do {
-            let display = try session.currentDisplay()
+            let display = try session.currentDisplay(nowMicros: Self.monotonicMicros)
             lastError = nil
             await emit(display: display)
         } catch {
@@ -214,7 +215,7 @@ actor AeroLinkRadioState {
                 utcMillis: utcMillis,
                 monotonicMicros: monotonicMicros
             )
-            let display = try accept(records)
+            let display = try accept(records, monotonicMicros: monotonicMicros)
             lastError = nil
             await emit(display: display)
         } catch {
@@ -253,7 +254,7 @@ actor AeroLinkRadioState {
                     utcMillis: utcMillis,
                     monotonicMicros: monotonicMicros
                 )
-                try accept(records, into: &display)
+                try accept(records, monotonicMicros: monotonicMicros, into: &display)
                 acceptedLine = true
             } catch {
                 live.diagnostics.rejectedInputs &+= 1
@@ -276,21 +277,31 @@ actor AeroLinkRadioState {
         }
     }
 
-    private func accept(_ records: RadioRecordBatch) throws -> DisplayBatch? {
+    private func accept(
+        _ records: RadioRecordBatch,
+        monotonicMicros: UInt64
+    ) throws -> DisplayBatch? {
         var display = DisplayAccumulator()
-        try accept(records, into: &display)
+        try accept(records, monotonicMicros: monotonicMicros, into: &display)
         return display.batch
     }
 
     private func accept(
         _ records: RadioRecordBatch,
+        monotonicMicros: UInt64,
         into display: inout DisplayAccumulator
     ) throws {
         for record in records.trackRecords {
-            display.append(try session.acceptTrackRecord(recordJson: record))
+            display.append(try session.acceptTrackRecord(
+                recordJson: record,
+                nowMicros: monotonicMicros
+            ))
         }
         for record in records.weatherRecords {
-            display.append(try session.acceptWeatherRecord(recordJson: record))
+            display.append(try session.acceptWeatherRecord(
+                recordJson: record,
+                nowMicros: monotonicMicros
+            ))
         }
     }
 
@@ -339,6 +350,10 @@ actor AeroLinkRadioState {
             return .ready
         }
         return receivers.isEmpty ? nil : .checking
+    }
+
+    private static var monotonicMicros: UInt64 {
+        DispatchTime.now().uptimeNanoseconds / 1_000
     }
 }
 

--- a/clients/apple-situation/App/LayerControlsView.swift
+++ b/clients/apple-situation/App/LayerControlsView.swift
@@ -1,0 +1,33 @@
+import PilotageSituationCore
+import SwiftUI
+
+struct LayerControlsView: View {
+    let layers: [DisplayLayerControl]
+    let setEnabled: (String, Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Layers")
+                .font(.headline)
+            ForEach(layers, id: \.id) { layer in
+                Toggle(
+                    isOn: Binding(
+                        get: { layer.enabled },
+                        set: { setEnabled(layer.id, $0) }
+                    )
+                ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(layer.title)
+                            .font(.subheadline.weight(.semibold))
+                        Text("\(layer.sourceStateLabel): \(layer.sourceDetail)")
+                            .font(.caption)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: 330)
+        .padding(12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -16,14 +16,34 @@ private struct SituationContentView: View {
     @StateObject private var model = SituationClientModel()
 
     var body: some View {
-        ZStack(alignment: .top) {
-            SituationMap(batch: model.display)
-            VStack(spacing: 8) {
-                RadioStatusView(source: model.radioSource)
-                if let message = model.errorMessage {
-                    Text(message)
-                        .padding(12)
-                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+        ZStack {
+            SituationMap(batch: model.display, onFeatureTapped: model.selectTraffic)
+            VStack {
+                HStack(alignment: .top) {
+                    VStack(spacing: 8) {
+                        RadioStatusView(source: model.radioSource)
+                        if let message = model.errorMessage {
+                            Text(message)
+                                .padding(12)
+                                .background(
+                                    .ultraThinMaterial,
+                                    in: RoundedRectangle(cornerRadius: 8)
+                                )
+                        }
+                    }
+                    Spacer()
+                    LayerControlsView(
+                        layers: model.display?.layers ?? [],
+                        setEnabled: model.setLayerEnabled
+                    )
+                }
+                Spacer()
+                HStack {
+                    PositionlessTrafficView(
+                        items: model.display?.positionlessTraffic ?? [],
+                        select: model.selectTraffic
+                    )
+                    Spacer()
                 }
             }
             .padding()
@@ -35,19 +55,38 @@ private struct SituationContentView: View {
                 await model.suspend()
             }
         }
+        .sheet(
+            isPresented: Binding(
+                get: { model.selectedTraffic != nil },
+                set: { presented in
+                    if !presented {
+                        model.clearTrafficSelection()
+                    }
+                }
+            )
+        ) {
+            if let detail = model.selectedTraffic {
+                TrafficDetailView(detail: detail)
+            }
+        }
     }
 }
 
 private struct SituationMap: UIViewRepresentable {
     let batch: DisplayBatch?
+    let onFeatureTapped: (String) -> Void
 
     func makeUIView(context: Context) -> SituationMapView {
         let styleJSON = (try? SituationStyleResource.load())
             ?? SituationStyleResource.fallbackJSON
-        return SituationMapView(styleJSON: styleJSON)
+        let view = SituationMapView(styleJSON: styleJSON)
+        view.baseLayerIdentifiers = ["terrain-base": "pilotage-terrain-hillshade"]
+        view.onFeatureTapped = onFeatureTapped
+        return view
     }
 
     func updateUIView(_ mapView: SituationMapView, context: Context) {
+        mapView.onFeatureTapped = onFeatureTapped
         if let batch {
             mapView.apply(batch)
         }

--- a/clients/apple-situation/App/PositionlessTrafficView.swift
+++ b/clients/apple-situation/App/PositionlessTrafficView.swift
@@ -1,0 +1,32 @@
+import PilotageSituationCore
+import SwiftUI
+
+struct PositionlessTrafficView: View {
+    let items: [DisplayTrafficListItem]
+    let select: (String) -> Void
+
+    var body: some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Traffic without position")
+                    .font(.headline)
+                ForEach(items, id: \.id) { item in
+                    Button {
+                        select(item.id)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.title)
+                                .font(.subheadline.weight(.semibold))
+                            Text(item.summary)
+                                .font(.caption)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: 330, alignment: .leading)
+            .padding(12)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}

--- a/clients/apple-situation/App/RadioPresentationObservation.swift
+++ b/clients/apple-situation/App/RadioPresentationObservation.swift
@@ -1,0 +1,48 @@
+import PilotageRadioSource
+import PilotageSituationCore
+
+extension PresentationSourceObservation {
+    init(source: RadioSourceSnapshot, terrainAvailable: Bool) {
+        self.init(
+            terrainAvailable: terrainAvailable,
+            radioState: PresentationRadioState(source.availability),
+            radioReceivers: source.receivers.map(PresentationReceiverObservation.init)
+        )
+    }
+}
+
+private extension PresentationReceiverObservation {
+    init(_ receiver: RadioReceiver) {
+        self.init(
+            band: PresentationRadioBand(receiver.band),
+            state: PresentationRadioState(receiver.availability)
+        )
+    }
+}
+
+private extension PresentationRadioBand {
+    init(_ band: RadioBand) {
+        switch band {
+        case .adsb1090: self = .adsb1090
+        case .uat978: self = .uat978
+        }
+    }
+}
+
+private extension PresentationRadioState {
+    init(_ availability: RadioAvailability) {
+        switch availability {
+        case .checking: self = .checking
+        case .permissionDenied: self = .permissionDenied
+        case .driverDisabled: self = .driverDisabled
+        case .unplugged: self = .unplugged
+        case .ready: self = .ready
+        case .streaming: self = .streaming
+        case .suspended: self = .suspended
+        case .underpowered: self = .underpowered
+        case .enumerationFailure: self = .enumerationFailure
+        case .endpointFailure: self = .endpointFailure
+        case .deviceRemoved: self = .deviceRemoved
+        }
+    }
+}

--- a/clients/apple-situation/App/SituationClientModel.swift
+++ b/clients/apple-situation/App/SituationClientModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PilotageRadioSource
 import PilotageSituationCore
 import SwiftUI
@@ -6,14 +7,12 @@ import SwiftUI
 final class SituationClientModel: ObservableObject {
     @Published private(set) var display: DisplayBatch?
     @Published private(set) var errorMessage: String?
-    @Published private(set) var radioSource = RadioSourceSnapshot(
-        availability: .suspended,
-        receivers: [],
-        bandFailures: []
-    )
+    @Published private(set) var radioSource: RadioSourceSnapshot
+    @Published private(set) var selectedTraffic: DisplayTrafficDetail?
 
     private let session: PresentationSession
     private let domain: RadioDomainSession?
+    private let terrainAvailable: Bool
     private let discovery = AeroLinkDiscoveryGate()
     private var runtime: AeroLinkRadioRuntime?
     private var maintenanceTask: Task<Void, Never>?
@@ -24,12 +23,28 @@ final class SituationClientModel: ObservableObject {
     private var isActive = false
 
     init() {
+        let source = RadioSourceSnapshot(
+            availability: .suspended,
+            receivers: [],
+            bandFailures: []
+        )
         let session = PresentationSession()
         self.session = session
+        radioSource = source
+        terrainAvailable = Bundle.main.url(
+            forResource: "SituationTerrain",
+            withExtension: "mbtiles"
+        ) != nil
         var createdDomain: RadioDomainSession?
         var initialDisplay: DisplayBatch?
         do {
-            initialDisplay = try session.currentDisplay()
+            initialDisplay = try session.observeSources(
+                observation: PresentationSourceObservation(
+                    source: source,
+                    terrainAvailable: terrainAvailable
+                ),
+                nowMicros: Self.monotonicMicros
+            )
             createdDomain = try RadioDomainSession()
         } catch {
             startupError = Self.join(startupError, error.localizedDescription)
@@ -100,10 +115,46 @@ final class SituationClientModel: ObservableObject {
 
     private func apply(_ emission: RadioRuntimeEmission) {
         radioSource = emission.source
-        if let display = emission.display {
-            self.display = display
+        var presentationError: String?
+        do {
+            let next = try session.observeSources(
+                observation: PresentationSourceObservation(
+                    source: emission.source,
+                    terrainAvailable: terrainAvailable
+                ),
+                nowMicros: Self.monotonicMicros
+            )
+            applyDisplay(next)
+        } catch {
+            presentationError = error.localizedDescription
         }
-        errorMessage = Self.join(startupError, emission.errorMessage)
+        errorMessage = Self.join(
+            startupError,
+            Self.join(emission.errorMessage, presentationError)
+        )
+    }
+
+    func setLayerEnabled(id: String, enabled: Bool) {
+        do {
+            applyDisplay(try session.setLayerEnabled(layerId: id, enabled: enabled))
+        } catch {
+            errorMessage = Self.join(startupError, error.localizedDescription)
+        }
+    }
+
+    func selectTraffic(id: String) {
+        selectedTraffic = display?.trafficDetails.first { $0.id == id }
+    }
+
+    func clearTrafficSelection() {
+        selectedTraffic = nil
+    }
+
+    private func applyDisplay(_ next: DisplayBatch) {
+        display = next
+        if let selected = selectedTraffic {
+            selectedTraffic = next.trafficDetails.first { $0.id == selected.id }
+        }
     }
 
     private static func join(_ first: String?, _ second: String?) -> String? {
@@ -112,5 +163,9 @@ final class SituationClientModel: ObservableObject {
         case (.some(let value), .none), (.none, .some(let value)): value
         case (.some(let first), .some(let second)): "\(first)\n\(second)"
         }
+    }
+
+    private static var monotonicMicros: UInt64 {
+        DispatchTime.now().uptimeNanoseconds / 1_000
     }
 }

--- a/clients/apple-situation/App/TrafficDetailView.swift
+++ b/clients/apple-situation/App/TrafficDetailView.swift
@@ -1,0 +1,63 @@
+import PilotageSituationCore
+import SwiftUI
+
+struct TrafficDetailView: View {
+    let detail: DisplayTrafficDetail
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Identity") {
+                    LabeledContent("Primary", value: detail.primaryIdentity)
+                    ForEach(detail.otherIdentities, id: \.self) { identity in
+                        LabeledContent("Associated", value: identity)
+                    }
+                    if let reason = detail.otherIdentitiesAbsenceReason {
+                        Text(reason)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Section("Lifecycle") {
+                    LabeledContent("State", value: detail.lifecycle)
+                    LabeledContent("Newest observation", value: detail.newestObservationAge)
+                }
+                Section("Fields") {
+                    ForEach(detail.fields, id: \.id) { field in
+                        TrafficDetailFieldView(field: field)
+                    }
+                }
+            }
+            .navigationTitle(detail.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct TrafficDetailFieldView: View {
+    let field: DisplayTrafficDetailField
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(field.title)
+                .font(.headline)
+            if let value = field.value {
+                Text(value)
+            }
+            if let reason = field.absenceReason {
+                Text(reason)
+                    .foregroundStyle(.secondary)
+            }
+            if let age = field.age {
+                Text(age)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let source = field.source {
+                Text(source)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
@@ -7,6 +7,10 @@ import UIKit
 public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate {
     /// Receives an error that occurs after the map style loads.
     public var onOverlayError: ((Error) -> Void)?
+    /// Receives the stable identity of a tapped display feature.
+    public var onFeatureTapped: ((String) -> Void)?
+    /// Maps portable base-layer identities to base-style layer identities.
+    public var baseLayerIdentifiers: [String: String] = [:]
 
     private let mapView: MLNMapView
     private let overlay = SituationOverlay()
@@ -19,6 +23,7 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.delegate = self
         addSubview(mapView)
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
         NSLayoutConstraint.activate([
             mapView.leadingAnchor.constraint(equalTo: leadingAnchor),
             mapView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -48,9 +53,34 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
             return
         }
         do {
+            applyBaseLayerVisibility(batch.layers, to: style)
             try overlay.apply(batch, to: style)
         } catch {
             onOverlayError?(error)
         }
+    }
+
+    private func applyBaseLayerVisibility(
+        _ layers: [DisplayLayerControl],
+        to style: MLNStyle
+    ) {
+        for layer in layers {
+            guard let identifier = baseLayerIdentifiers[layer.id] else { continue }
+            style.layer(withIdentifier: identifier)?.isVisible = layer.enabled
+        }
+    }
+
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended, !overlay.interactiveLayerIdentifiers.isEmpty else {
+            return
+        }
+        let features = mapView.visibleFeatures(
+            at: gesture.location(in: mapView),
+            styleLayerIdentifiers: overlay.interactiveLayerIdentifiers
+        )
+        guard let identifier = features.compactMap({ $0.identifier as? String }).first else {
+            return
+        }
+        onFeatureTapped?(identifier)
     }
 }

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
@@ -15,8 +15,11 @@ public enum SituationOverlayError: Error, Equatable {
 @MainActor
 final class SituationOverlay {
     private var layerIdentifiers: [String] = []
+    private var pointLayerIdentifiers: Set<String> = []
     private var points: [String: DisplayPoint] = [:]
     private var sourceIdentifiers: [String] = []
+
+    var interactiveLayerIdentifiers: Set<String> { pointLayerIdentifiers }
 
     func apply(_ batch: DisplayBatch, to mapStyle: MLNStyle) throws {
         updatePoints(with: batch)
@@ -135,7 +138,7 @@ final class SituationOverlay {
         layer.circleRadius = constant(style.radiusPoints)
         layer.circleStrokeColor = constant(color(style.outline))
         layer.circleStrokeWidth = constant(style.outlineWidthPoints)
-        add(layer, to: mapStyle)
+        add(layer, to: mapStyle, interactive: true)
     }
 
     private func addMarkerLayer(
@@ -154,7 +157,7 @@ final class SituationOverlay {
         layer.textRotation = NSExpression(forKeyPath: "rotation")
         layer.textRotationAlignment = constant("map")
         layer.textAllowsOverlap = constant(style.markerAllowsOverlap)
-        add(layer, to: mapStyle)
+        add(layer, to: mapStyle, interactive: true)
     }
 
     private func addPointLabelLayer(
@@ -172,7 +175,7 @@ final class SituationOverlay {
             offsetY: style.labelOffsetY,
             allowsOverlap: style.labelAllowsOverlap
         )
-        add(layer, to: mapStyle)
+        add(layer, to: mapStyle, interactive: true)
     }
 
     private func addFillLayer(
@@ -231,9 +234,16 @@ final class SituationOverlay {
         layer.textAllowsOverlap = constant(allowsOverlap)
     }
 
-    private func add(_ layer: MLNStyleLayer, to mapStyle: MLNStyle) {
+    private func add(
+        _ layer: MLNStyleLayer,
+        to mapStyle: MLNStyle,
+        interactive: Bool = false
+    ) {
         mapStyle.addLayer(layer)
         layerIdentifiers.append(layer.identifier)
+        if interactive {
+            pointLayerIdentifiers.insert(layer.identifier)
+        }
     }
 
     private func removeManagedContent(from mapStyle: MLNStyle) {
@@ -248,6 +258,7 @@ final class SituationOverlay {
             }
         }
         layerIdentifiers.removeAll(keepingCapacity: true)
+        pointLayerIdentifiers.removeAll(keepingCapacity: true)
         sourceIdentifiers.removeAll(keepingCapacity: true)
     }
 

--- a/clients/apple-situation/Packages/PilotageSituationCore/Tests/PilotageSituationCoreTests/PilotageSituationCoreTests.swift
+++ b/clients/apple-situation/Packages/PilotageSituationCore/Tests/PilotageSituationCoreTests/PilotageSituationCoreTests.swift
@@ -10,3 +10,27 @@ func producerSchemasLink() {
     #expect(versions.surveillance > 0)
     #expect(versions.airmass > 0)
 }
+
+@Test("Layer controls cross the generated facade")
+func layerControlsCrossFacade() throws {
+    let session = PresentationSession()
+    let batch = try session.observeSources(
+        observation: PresentationSourceObservation(
+            terrainAvailable: true,
+            radioState: .streaming,
+            radioReceivers: [
+                PresentationReceiverObservation(band: .adsb1090, state: .streaming),
+            ]
+        ),
+        nowMicros: 10
+    )
+
+    let allEnabled = batch.layers.allSatisfy(\.enabled)
+    #expect(batch.layers.count == 4)
+    #expect(allEnabled)
+    #expect(batch.layers.first { $0.id == "traffic" }?.sourceState == .live)
+    #expect(
+        batch.layers.first { $0.id == "weather-reports" }?
+            .sourceDetail.contains("does not mean clear weather") == true
+    )
+}

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/error.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/error.rs
@@ -33,6 +33,12 @@ pub enum FfiError {
         /// Validation or decode detail.
         message: String,
     },
+    /// A layer identity is not in the portable catalog.
+    #[error("display layer is not known: {layer_id}")]
+    UnknownLayer {
+        /// Rejected layer identity.
+        layer_id: String,
+    },
     /// The session state is not available.
     #[error("session state is not available: {message}")]
     SessionState {

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs
@@ -11,8 +11,11 @@ mod session;
 pub use error::FfiError;
 pub use reception::RadioDomainSession;
 pub use records::{
-    DisplayBatch, DisplayColor, DisplayCoordinate, DisplayCoordinateRing, DisplayPoint,
-    DisplayPointChange, DisplayPointChangeKind, DisplayPointStyle, DisplayShape, DisplayShapeStyle,
+    DisplayBatch, DisplayColor, DisplayCoordinate, DisplayCoordinateRing, DisplayLayerControl,
+    DisplayLayerSourceState, DisplayPoint, DisplayPointChange, DisplayPointChangeKind,
+    DisplayPointStyle, DisplayShape, DisplayShapeStyle, DisplayTrafficDetail,
+    DisplayTrafficDetailField, DisplayTrafficListItem, PresentationRadioBand,
+    PresentationRadioState, PresentationReceiverObservation, PresentationSourceObservation,
     ProducerSchemaVersions, RadioRecordBatch, WeatherStationPosition,
 };
 pub use session::PresentationSession;

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/reception/tests.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/reception/tests.rs
@@ -32,7 +32,7 @@ fn serialized_receptions_drive_surveillance_and_clear_on_suspend() {
         observations += batch.traffic_observations;
         for record in batch.track_records {
             session
-                .accept_track_record(record)
+                .accept_track_record(record, 1_000_000)
                 .expect("track record must be accepted");
         }
     }
@@ -40,7 +40,7 @@ fn serialized_receptions_drive_surveillance_and_clear_on_suspend() {
     assert_eq!(observations, 2);
     assert_eq!(
         session
-            .current_display()
+            .current_display(1_000_000)
             .expect("display state must be available")
             .points
             .len(),
@@ -74,7 +74,7 @@ fn fis_b_reception_reaches_typed_airmass_presentation() {
     assert_eq!(batch.weather_products, 1);
     assert_eq!(batch.weather_records.len(), 1);
     let display = session
-        .accept_weather_record(batch.weather_records[0].clone())
+        .accept_weather_record(batch.weather_records[0].clone(), 1_000_000)
         .expect("weather record must be accepted");
     assert_eq!(display.points.len(), 1);
     assert_eq!(display.points[0].label.as_deref(), Some("KJFK"));

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
@@ -1,5 +1,13 @@
 //! Flat records that cross the Apple FFI boundary.
 
+mod presentation;
+
+pub use presentation::{
+    DisplayLayerControl, DisplayLayerSourceState, DisplayTrafficDetail, DisplayTrafficDetailField,
+    DisplayTrafficListItem, PresentationRadioBand, PresentationRadioState,
+    PresentationReceiverObservation, PresentationSourceObservation,
+};
+
 /// Schema versions of the linked domain producers.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Record)]
 pub struct ProducerSchemaVersions {
@@ -120,6 +128,8 @@ pub struct DisplayShapeStyle {
 pub struct DisplayPoint {
     /// Stable feature identity.
     pub id: String,
+    /// Stable application layer identity.
+    pub layer_id: String,
     /// Feature position.
     pub coordinate: DisplayCoordinate,
     /// Style identity.
@@ -169,6 +179,8 @@ pub struct DisplayPointChange {
 pub struct DisplayShape {
     /// Stable feature identity.
     pub id: String,
+    /// Stable application layer identity.
+    pub layer_id: String,
     /// Polygon rings.
     pub rings: Vec<DisplayCoordinateRing>,
     /// Style identity.
@@ -184,6 +196,8 @@ pub struct DisplayShape {
 /// One complete set of display values and styles.
 #[derive(Clone, Debug, PartialEq, uniffi::Record)]
 pub struct DisplayBatch {
+    /// User-controlled display layers.
+    pub layers: Vec<DisplayLayerControl>,
     /// Point style catalog.
     pub point_styles: Vec<DisplayPointStyle>,
     /// Polygon style catalog.
@@ -194,6 +208,10 @@ pub struct DisplayBatch {
     pub point_changes: Vec<DisplayPointChange>,
     /// Polygon features.
     pub shapes: Vec<DisplayShape>,
+    /// Traffic tracks that do not have a map position.
+    pub positionless_traffic: Vec<DisplayTrafficListItem>,
+    /// Detail values for retained traffic tracks.
+    pub traffic_details: Vec<DisplayTrafficDetail>,
     /// Products that had no display value.
     pub omitted_products: u64,
 }
@@ -218,11 +236,18 @@ pub struct RadioRecordBatch {
 impl From<pilotage_presentation::DisplayBatch> for DisplayBatch {
     fn from(value: pilotage_presentation::DisplayBatch) -> Self {
         Self {
+            layers: value.layers.into_iter().map(Into::into).collect(),
             point_styles: value.point_styles.into_iter().map(Into::into).collect(),
             shape_styles: value.shape_styles.into_iter().map(Into::into).collect(),
             points: value.points.into_iter().map(Into::into).collect(),
             point_changes: value.point_changes.into_iter().map(Into::into).collect(),
             shapes: value.shapes.into_iter().map(Into::into).collect(),
+            positionless_traffic: value
+                .positionless_traffic
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            traffic_details: value.traffic_details.into_iter().map(Into::into).collect(),
             omitted_products: value.omitted_products,
         }
     }
@@ -293,6 +318,7 @@ impl From<pilotage_presentation::PointFeature> for DisplayPoint {
     fn from(value: pilotage_presentation::PointFeature) -> Self {
         Self {
             id: value.id,
+            layer_id: value.layer_id,
             coordinate: value.coordinate.into(),
             style_id: value.style_id,
             label: value.label,
@@ -356,6 +382,7 @@ impl From<pilotage_presentation::ShapeFeature> for DisplayShape {
     fn from(value: pilotage_presentation::ShapeFeature) -> Self {
         Self {
             id: value.id,
+            layer_id: value.layer_id,
             rings: value
                 .rings
                 .into_iter()

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records/presentation.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records/presentation.rs
@@ -1,0 +1,255 @@
+//! Layer, source, and traffic detail records.
+
+/// State of one layer source.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum DisplayLayerSourceState {
+    /// The source supplies current values.
+    Live,
+    /// The source exists, but it does not supply current values.
+    Stale,
+    /// The source is not available.
+    Absent,
+}
+
+/// One user-controlled display layer.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct DisplayLayerControl {
+    /// Stable application identity.
+    pub id: String,
+    /// User-facing layer name.
+    pub title: String,
+    /// Whether the layer is visible.
+    pub enabled: bool,
+    /// Current source state.
+    pub source_state: DisplayLayerSourceState,
+    /// User-facing source state.
+    pub source_state_label: String,
+    /// Explanation of the source state.
+    pub source_detail: String,
+}
+
+/// A radio band observed by the host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum PresentationRadioBand {
+    /// The 1090 MHz ADS-B band.
+    Adsb1090,
+    /// The 978 MHz UAT band.
+    Uat978,
+}
+
+/// A raw radio state observed by the host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum PresentationRadioState {
+    /// The host checks the source.
+    Checking,
+    /// The host does not have permission to use the source.
+    PermissionDenied,
+    /// The user disabled the source.
+    DriverDisabled,
+    /// No receiver is attached.
+    Unplugged,
+    /// A receiver is ready.
+    Ready,
+    /// A receiver supplies data.
+    Streaming,
+    /// The host stopped reception.
+    Suspended,
+    /// The source does not have sufficient power.
+    Underpowered,
+    /// Source enumeration failed.
+    EnumerationFailure,
+    /// A source endpoint failed.
+    EndpointFailure,
+    /// The source was removed.
+    DeviceRemoved,
+}
+
+/// State of one receiver observed by the host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct PresentationReceiverObservation {
+    /// Receiver band.
+    pub band: PresentationRadioBand,
+    /// Receiver state.
+    pub state: PresentationRadioState,
+}
+
+/// Raw source facts observed by the host.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct PresentationSourceObservation {
+    /// Whether the terrain archive is available.
+    pub terrain_available: bool,
+    /// State of the radio subsystem.
+    pub radio_state: PresentationRadioState,
+    /// States of attached receivers.
+    pub radio_receivers: Vec<PresentationReceiverObservation>,
+}
+
+impl Default for PresentationSourceObservation {
+    fn default() -> Self {
+        Self {
+            terrain_available: false,
+            radio_state: PresentationRadioState::Suspended,
+            radio_receivers: Vec::new(),
+        }
+    }
+}
+
+impl PresentationSourceObservation {
+    pub(crate) fn into_portable(
+        self,
+        weather_positions_available: bool,
+    ) -> pilotage_presentation::SourceObservation {
+        pilotage_presentation::SourceObservation {
+            terrain_available: self.terrain_available,
+            weather_positions_available,
+            radio_state: self.radio_state.into(),
+            radio_receivers: self.radio_receivers.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// One traffic item that has no map position.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct DisplayTrafficListItem {
+    /// Stable display identity.
+    pub id: String,
+    /// Primary display text.
+    pub title: String,
+    /// Ready-to-display lifecycle summary.
+    pub summary: String,
+}
+
+/// One traffic field and its evidence.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct DisplayTrafficDetailField {
+    /// Stable field identity.
+    pub id: String,
+    /// User-facing field name.
+    pub title: String,
+    /// Ready-to-display value.
+    pub value: Option<String>,
+    /// Ready-to-display age.
+    pub age: Option<String>,
+    /// Ready-to-display source.
+    pub source: Option<String>,
+    /// Reason that the value is absent.
+    pub absence_reason: Option<String>,
+}
+
+/// Complete display detail for one retained traffic track.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
+pub struct DisplayTrafficDetail {
+    /// Stable display identity.
+    pub id: String,
+    /// Primary display text.
+    pub title: String,
+    /// Primary over-the-air identity.
+    pub primary_identity: String,
+    /// Other associated over-the-air identities.
+    pub other_identities: Vec<String>,
+    /// Reason that no other identity is present.
+    pub other_identities_absence_reason: Option<String>,
+    /// Ready-to-display lifecycle state.
+    pub lifecycle: String,
+    /// Age of the newest observation.
+    pub newest_observation_age: String,
+    /// Fields in display order.
+    pub fields: Vec<DisplayTrafficDetailField>,
+}
+
+impl From<pilotage_presentation::LayerSourceState> for DisplayLayerSourceState {
+    fn from(value: pilotage_presentation::LayerSourceState) -> Self {
+        match value {
+            pilotage_presentation::LayerSourceState::Live => Self::Live,
+            pilotage_presentation::LayerSourceState::Stale => Self::Stale,
+            pilotage_presentation::LayerSourceState::Absent => Self::Absent,
+        }
+    }
+}
+
+impl From<pilotage_presentation::LayerControl> for DisplayLayerControl {
+    fn from(value: pilotage_presentation::LayerControl) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            enabled: value.enabled,
+            source_state: value.source_state.into(),
+            source_state_label: value.source_state_label,
+            source_detail: value.source_detail,
+        }
+    }
+}
+
+impl From<PresentationRadioBand> for pilotage_presentation::RadioBand {
+    fn from(value: PresentationRadioBand) -> Self {
+        match value {
+            PresentationRadioBand::Adsb1090 => Self::Adsb1090,
+            PresentationRadioBand::Uat978 => Self::Uat978,
+        }
+    }
+}
+
+impl From<PresentationRadioState> for pilotage_presentation::RadioReceptionState {
+    fn from(value: PresentationRadioState) -> Self {
+        match value {
+            PresentationRadioState::Checking => Self::Checking,
+            PresentationRadioState::PermissionDenied => Self::PermissionDenied,
+            PresentationRadioState::DriverDisabled => Self::DriverDisabled,
+            PresentationRadioState::Unplugged => Self::Unplugged,
+            PresentationRadioState::Ready => Self::Ready,
+            PresentationRadioState::Streaming => Self::Streaming,
+            PresentationRadioState::Suspended => Self::Suspended,
+            PresentationRadioState::Underpowered => Self::Underpowered,
+            PresentationRadioState::EnumerationFailure => Self::EnumerationFailure,
+            PresentationRadioState::EndpointFailure => Self::EndpointFailure,
+            PresentationRadioState::DeviceRemoved => Self::DeviceRemoved,
+        }
+    }
+}
+
+impl From<PresentationReceiverObservation> for pilotage_presentation::RadioReceiverObservation {
+    fn from(value: PresentationReceiverObservation) -> Self {
+        Self {
+            band: value.band.into(),
+            state: value.state.into(),
+        }
+    }
+}
+
+impl From<pilotage_presentation::TrafficListItem> for DisplayTrafficListItem {
+    fn from(value: pilotage_presentation::TrafficListItem) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            summary: value.summary,
+        }
+    }
+}
+
+impl From<pilotage_presentation::TrafficDetailField> for DisplayTrafficDetailField {
+    fn from(value: pilotage_presentation::TrafficDetailField) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            value: value.value,
+            age: value.age,
+            source: value.source,
+            absence_reason: value.absence_reason,
+        }
+    }
+}
+
+impl From<pilotage_presentation::TrafficDetail> for DisplayTrafficDetail {
+    fn from(value: pilotage_presentation::TrafficDetail) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            primary_identity: value.primary_identity,
+            other_identities: value.other_identities,
+            other_identities_absence_reason: value.other_identities_absence_reason,
+            lifecycle: value.lifecycle,
+            newest_observation_age: value.newest_observation_age,
+            fields: value.fields.into_iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs
@@ -10,7 +10,8 @@ use airmass_geojson::{Wgs84Position, map_snapshot_transition};
 use pilotage_presentation::{PointChange, PresentationAdapter};
 use surveillance_core::{TrackRecord, TrackRecordHeader};
 
-use crate::{DisplayBatch, FfiError, WeatherStationPosition};
+use crate::WeatherStationPosition;
+use crate::{DisplayBatch, FfiError, PresentationRadioState, PresentationSourceObservation};
 
 #[cfg(test)]
 mod tests;
@@ -20,6 +21,7 @@ struct SessionState {
     presentation: PresentationAdapter,
     weather_snapshot: Option<WeatherSnapshotEnvelope>,
     weather_positions: BTreeMap<String, Wgs84Position>,
+    source_observation: PresentationSourceObservation,
 }
 
 /// Retains display state for the Swift host.
@@ -40,22 +42,32 @@ impl PresentationSession {
     }
 
     /// Accept one versioned Surveillance track record.
-    pub fn accept_track_record(&self, record_json: String) -> Result<DisplayBatch, FfiError> {
+    pub fn accept_track_record(
+        &self,
+        record_json: String,
+        now_micros: u64,
+    ) -> Result<DisplayBatch, FfiError> {
         validate_track_header(&record_json)?;
         let record: TrackRecord = serde_json::from_str(&record_json).map_err(track_record_error)?;
         let delta = record.into_delta().map_err(track_record_error)?;
         let mut state = self.lock_state()?;
+        state.presentation.advance_time(now_micros);
         let change = state.presentation.apply_traffic_delta(&delta);
         Ok(display_for_state(&state, change.into_iter().collect()))
     }
 
     /// Accept one versioned Airmass weather snapshot record.
-    pub fn accept_weather_record(&self, record_json: String) -> Result<DisplayBatch, FfiError> {
+    pub fn accept_weather_record(
+        &self,
+        record_json: String,
+        now_micros: u64,
+    ) -> Result<DisplayBatch, FfiError> {
         validate_weather_header(&record_json)?;
         let record: WeatherSnapshotRecord =
             serde_json::from_str(&record_json).map_err(weather_record_error)?;
         let current = record.into_envelope().map_err(weather_record_error)?;
         let mut state = self.lock_state()?;
+        state.presentation.advance_time(now_micros);
         if weather_record_is_stale(state.weather_snapshot.as_ref(), &current) {
             return Ok(display_for_state(&state, Vec::new()));
         }
@@ -74,6 +86,7 @@ impl PresentationSession {
         let mut state = self.lock_state()?;
         let mut changes = state.presentation.clear_weather();
         state.weather_positions = catalog;
+        apply_source_observation(&mut state);
         if let Some(current) = state.weather_snapshot.clone() {
             let deltas = map_weather_initial(&state, &current);
             changes.extend(apply_weather_deltas(&mut state.presentation, deltas));
@@ -84,16 +97,56 @@ impl PresentationSession {
     /// Clear retained traffic and weather display state.
     pub fn clear_radio_records(&self) -> Result<DisplayBatch, FfiError> {
         let mut state = self.lock_state()?;
-        state.presentation = PresentationAdapter::default();
+        state.presentation.clear_radio_state();
         state.weather_snapshot = None;
+        state.source_observation.radio_state = PresentationRadioState::Suspended;
+        state.source_observation.radio_receivers.clear();
+        apply_source_observation(&mut state);
+        Ok(display_for_state(&state, Vec::new()))
+    }
+
+    /// Record source facts and advance the display clock.
+    pub fn observe_sources(
+        &self,
+        observation: PresentationSourceObservation,
+        now_micros: u64,
+    ) -> Result<DisplayBatch, FfiError> {
+        let mut state = self.lock_state()?;
+        state.source_observation = observation;
+        state.presentation.advance_time(now_micros);
+        apply_source_observation(&mut state);
+        Ok(display_for_state(&state, Vec::new()))
+    }
+
+    /// Set one application layer control.
+    pub fn set_layer_enabled(
+        &self,
+        layer_id: String,
+        enabled: bool,
+    ) -> Result<DisplayBatch, FfiError> {
+        let mut state = self.lock_state()?;
+        if !state.presentation.set_layer_enabled(&layer_id, enabled) {
+            return Err(FfiError::UnknownLayer { layer_id });
+        }
         Ok(display_for_state(&state, Vec::new()))
     }
 
     /// Get display values for the newest accepted records.
-    pub fn current_display(&self) -> Result<DisplayBatch, FfiError> {
-        let state = self.lock_state()?;
+    pub fn current_display(&self, now_micros: u64) -> Result<DisplayBatch, FfiError> {
+        let mut state = self.lock_state()?;
+        state.presentation.advance_time(now_micros);
         Ok(display_for_state(&state, Vec::new()))
     }
+}
+
+fn apply_source_observation(state: &mut SessionState) {
+    let weather_positions_available = !state.weather_positions.is_empty();
+    state.presentation.observe_sources(
+        state
+            .source_observation
+            .clone()
+            .into_portable(weather_positions_available),
+    );
 }
 
 impl PresentationSession {

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
@@ -7,7 +7,10 @@ use surveillance_core::{
 };
 
 use super::PresentationSession;
-use crate::DisplayPointChangeKind;
+use crate::{
+    DisplayLayerSourceState, DisplayPointChangeKind, PresentationRadioBand, PresentationRadioState,
+    PresentationReceiverObservation, PresentationSourceObservation,
+};
 
 #[test]
 fn versioned_track_record_crosses_the_facade() {
@@ -15,7 +18,7 @@ fn versioned_track_record_crosses_the_facade() {
     let record = track_record(9, 2, 42.36);
     let encoded = serde_json::to_string(&record).expect("track record must encode");
     let batch = session
-        .accept_track_record(encoded)
+        .accept_track_record(encoded, 10)
         .expect("track record must be accepted");
 
     assert_eq!(batch.points.len(), 1);
@@ -30,11 +33,11 @@ fn stale_track_record_does_not_replace_newer_state() {
     for record in [track_record(9, 2, 42.36), track_record(9, 1, 41.0)] {
         let encoded = serde_json::to_string(&record).expect("track record must encode");
         session
-            .accept_track_record(encoded)
+            .accept_track_record(encoded, 10)
             .expect("track record must be accepted");
     }
     let batch = session
-        .current_display()
+        .current_display(10)
         .expect("display batch must be available");
 
     assert_eq!(batch.points[0].coordinate.latitude_deg, 42.36);
@@ -47,7 +50,7 @@ fn merged_record_keeps_the_transfer_target() {
     for record in [track_record(9, 1, 42.36), track_record(10, 2, 42.37)] {
         let encoded = serde_json::to_string(&record).expect("track record must encode");
         session
-            .accept_track_record(encoded)
+            .accept_track_record(encoded, 10)
             .expect("track record must be accepted");
     }
     let removal = TrackRecord::new(TrackDelta::Removed {
@@ -61,7 +64,7 @@ fn merged_record_keeps_the_transfer_target() {
     });
     let encoded = serde_json::to_string(&removal).expect("removal record must encode");
     let batch = session
-        .accept_track_record(encoded)
+        .accept_track_record(encoded, 10)
         .expect("removal record must be accepted");
 
     assert_eq!(batch.points.len(), 1);
@@ -70,6 +73,76 @@ fn merged_record_keeps_the_transfer_target() {
         batch.point_changes[0].transfer_to.as_deref(),
         Some("traffic-8-10")
     );
+}
+
+#[test]
+fn source_observation_crosses_the_facade_without_claiming_clear_weather() {
+    let session = PresentationSession::new();
+    let batch = session
+        .observe_sources(
+            PresentationSourceObservation {
+                terrain_available: true,
+                radio_state: PresentationRadioState::Streaming,
+                radio_receivers: vec![PresentationReceiverObservation {
+                    band: PresentationRadioBand::Adsb1090,
+                    state: PresentationRadioState::Streaming,
+                }],
+            },
+            20,
+        )
+        .expect("source facts must be accepted");
+
+    assert_eq!(batch.layers.len(), 4);
+    let traffic = layer(&batch, "traffic");
+    assert_eq!(traffic.source_state, DisplayLayerSourceState::Live);
+    let weather = layer(&batch, "weather-reports");
+    assert_eq!(weather.source_state, DisplayLayerSourceState::Absent);
+    assert!(
+        weather
+            .source_detail
+            .contains("does not mean clear weather")
+    );
+}
+
+#[test]
+fn layer_toggle_retains_domain_state_across_the_facade() {
+    let session = PresentationSession::new();
+    session
+        .set_layer_enabled("traffic".into(), false)
+        .expect("traffic layer must exist");
+    let encoded =
+        serde_json::to_string(&track_record(9, 2, 42.36)).expect("track record must encode");
+    let hidden = session
+        .accept_track_record(encoded, 10)
+        .expect("track record must be accepted");
+    assert!(hidden.points.is_empty());
+    assert_eq!(hidden.traffic_details.len(), 1);
+
+    let visible = session
+        .set_layer_enabled("traffic".into(), true)
+        .expect("traffic layer must exist");
+    assert_eq!(visible.points.len(), 1);
+    assert!(visible.point_changes.is_empty());
+}
+
+#[test]
+fn positionless_track_crosses_as_a_list_item() {
+    let session = PresentationSession::new();
+    let track = TrackSnapshot::new(TrackId::new(12), track_key(12), 10);
+    let record = TrackRecord::new(TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(8),
+        SnapshotRevision::new(1),
+        track,
+    )));
+    let encoded = serde_json::to_string(&record).expect("track record must encode");
+    let batch = session
+        .accept_track_record(encoded, 2_000_010)
+        .expect("positionless track must be accepted");
+
+    assert!(batch.points.is_empty());
+    assert_eq!(batch.positionless_traffic.len(), 1);
+    assert_eq!(batch.traffic_details.len(), 1);
+    assert_eq!(batch.traffic_details[0].fields.len(), 8);
 }
 
 fn track_record(id: u64, revision: u64, latitude_deg: f64) -> TrackRecord {
@@ -97,4 +170,12 @@ fn track_record(id: u64, revision: u64, latitude_deg: f64) -> TrackRecord {
 
 fn track_key(id: u64) -> TrackKey {
     TrackKey::new(AddressNamespace::Icao, 0xA0_B1_00 + id as u32)
+}
+
+fn layer<'a>(batch: &'a crate::DisplayBatch, id: &str) -> &'a crate::DisplayLayerControl {
+    batch
+        .layers
+        .iter()
+        .find(|layer| layer.id == id)
+        .expect("expected layer must exist")
 }

--- a/crates/pilotage-presentation/src/detail.rs
+++ b/crates/pilotage-presentation/src/detail.rs
@@ -1,0 +1,391 @@
+//! Traffic list and detail display values.
+
+use surveillance_core::{
+    AddressNamespace, AirGroundState, AirspeedKind, Band, DeliveryPath, EmergencyState,
+    FieldProvenance, HeadingReference, ObservationOrigin, TimedField, TrackKey, TrackPhase,
+    TrackSnapshot, TrackSnapshotHandle, VelocityObservation, VerticalRateSource, Wgs84Position,
+};
+
+/// One traffic item that has no map position.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrafficListItem {
+    /// Stable display identity.
+    pub id: String,
+    /// Primary display text.
+    pub title: String,
+    /// Ready-to-display lifecycle summary.
+    pub summary: String,
+}
+
+/// One traffic field and its evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrafficDetailField {
+    /// Stable field identity.
+    pub id: String,
+    /// User-facing field name.
+    pub title: String,
+    /// Ready-to-display value.
+    pub value: Option<String>,
+    /// Ready-to-display age.
+    pub age: Option<String>,
+    /// Ready-to-display source.
+    pub source: Option<String>,
+    /// Reason that the value is absent.
+    pub absence_reason: Option<String>,
+}
+
+/// Complete display detail for one retained traffic track.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrafficDetail {
+    /// Stable display identity.
+    pub id: String,
+    /// Primary display text.
+    pub title: String,
+    /// Primary over-the-air identity.
+    pub primary_identity: String,
+    /// Other associated over-the-air identities.
+    pub other_identities: Vec<String>,
+    /// Reason that no other identity is present.
+    pub other_identities_absence_reason: Option<String>,
+    /// Ready-to-display lifecycle state.
+    pub lifecycle: String,
+    /// Age of the newest observation.
+    pub newest_observation_age: String,
+    /// Fields in display order.
+    pub fields: Vec<TrafficDetailField>,
+}
+
+pub(crate) fn detail_for(handle: &TrackSnapshotHandle, now_micros: u64) -> TrafficDetail {
+    let track = handle.snapshot();
+    let other_identities: Vec<_> = track
+        .identities
+        .associated()
+        .iter()
+        .copied()
+        .map(identity_label)
+        .collect();
+    let other_identities_absence_reason = other_identities
+        .is_empty()
+        .then(|| "No other identity is associated with this track.".into());
+    TrafficDetail {
+        id: crate::traffic::traffic_id(handle.producer_instance_id().get(), track.id.get()),
+        title: traffic_title(track),
+        primary_identity: identity_label(track.key),
+        other_identities,
+        other_identities_absence_reason,
+        lifecycle: phase_label(track.phase).into(),
+        newest_observation_age: format_age(
+            now_micros.saturating_sub(track.last_observed_at_micros),
+        ),
+        fields: detail_fields(track, now_micros),
+    }
+}
+
+pub(crate) fn positionless_item(
+    handle: &TrackSnapshotHandle,
+    now_micros: u64,
+) -> Option<TrafficListItem> {
+    let track = handle.snapshot();
+    if track.position.is_some() {
+        return None;
+    }
+    Some(TrafficListItem {
+        id: crate::traffic::traffic_id(handle.producer_instance_id().get(), track.id.get()),
+        title: traffic_title(track),
+        summary: format!(
+            "Position absent · {} · Newest observation {}",
+            phase_label(track.phase),
+            format_age(now_micros.saturating_sub(track.last_observed_at_micros))
+        ),
+    })
+}
+
+fn detail_fields(track: &TrackSnapshot, now_micros: u64) -> Vec<TrafficDetailField> {
+    vec![
+        field(
+            "position",
+            "Position",
+            track.position.as_ref(),
+            now_micros,
+            format_position,
+            "The track has no position observation.",
+        ),
+        field(
+            "pressure-altitude",
+            "Pressure altitude",
+            track.pressure_altitude_ft.as_ref(),
+            now_micros,
+            |value| Some(format!("{value} ft")),
+            "The track has no pressure altitude observation.",
+        ),
+        field(
+            "geometric-altitude",
+            "Geometric altitude",
+            track.geometric_altitude_ft.as_ref(),
+            now_micros,
+            |value| Some(format!("{value} ft")),
+            "The track has no geometric altitude observation.",
+        ),
+        field(
+            "velocity",
+            "Velocity",
+            track.velocity.as_ref(),
+            now_micros,
+            format_velocity,
+            "The track has no velocity observation.",
+        ),
+        field(
+            "callsign",
+            "Callsign",
+            track.callsign.as_ref(),
+            now_micros,
+            |value| nonempty(value.text.trim()),
+            "The track has no callsign observation.",
+        ),
+        field(
+            "transponder-code",
+            "Transponder code",
+            track.squawk.as_ref(),
+            now_micros,
+            |value| Some(format!("{:04}", value.code())),
+            "The track has no transponder code observation.",
+        ),
+        field(
+            "air-ground",
+            "Air-ground state",
+            track.air_ground.as_ref(),
+            now_micros,
+            |value| Some(air_ground_label(*value).into()),
+            "The track has no air-ground observation.",
+        ),
+        field(
+            "emergency",
+            "Emergency state",
+            track.emergency.as_ref(),
+            now_micros,
+            |value| Some(emergency_label(*value).into()),
+            "The track has no emergency observation.",
+        ),
+    ]
+}
+
+fn field<T>(
+    id: &'static str,
+    title: &'static str,
+    timed: Option<&TimedField<T>>,
+    now_micros: u64,
+    format_value: impl FnOnce(&T) -> Option<String>,
+    absence_reason: &'static str,
+) -> TrafficDetailField {
+    let Some(timed) = timed else {
+        return absent_field(id, title, absence_reason);
+    };
+    let Some(value) = format_value(&timed.value) else {
+        return absent_field(id, title, absence_reason);
+    };
+    TrafficDetailField {
+        id: id.into(),
+        title: title.into(),
+        value: Some(value),
+        age: Some(field_age(timed, now_micros)),
+        source: Some(source_label(timed.provenance)),
+        absence_reason: None,
+    }
+}
+
+fn absent_field(
+    id: &'static str,
+    title: &'static str,
+    absence_reason: &'static str,
+) -> TrafficDetailField {
+    TrafficDetailField {
+        id: id.into(),
+        title: title.into(),
+        value: None,
+        age: None,
+        source: None,
+        absence_reason: Some(absence_reason.into()),
+    }
+}
+
+fn traffic_title(track: &TrackSnapshot) -> String {
+    track
+        .callsign
+        .as_ref()
+        .and_then(|field| nonempty(field.value.text.trim()))
+        .unwrap_or_else(|| identity_label(track.key))
+}
+
+fn identity_label(key: TrackKey) -> String {
+    let namespace = match key.namespace {
+        AddressNamespace::Icao => "ICAO",
+        AddressNamespace::AdsbNonIcao => "ADS-B non-ICAO",
+        AddressNamespace::SelfAssigned => "Self-assigned",
+        AddressNamespace::TisbTrackFile => "TIS-B track file",
+        AddressNamespace::TisbModeATrackFile => "TIS-B Mode A track file",
+        AddressNamespace::SurfaceVehicle => "Surface vehicle",
+        AddressNamespace::FixedBeacon => "Fixed beacon",
+        _ => "Unknown namespace",
+    };
+    format!("{namespace} {:06X}", key.address)
+}
+
+fn format_position(value: &Wgs84Position) -> Option<String> {
+    Some(format!(
+        "{:.5}°, {:.5}°",
+        value.latitude_deg, value.longitude_deg
+    ))
+}
+
+fn format_velocity(value: &VelocityObservation) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(speed) = value.ground_speed_kt {
+        parts.push(format!("{speed:.0} kt ground speed"));
+    }
+    if let Some(track) = value.track_angle_deg_true {
+        parts.push(format!("{track:.0}° true track"));
+    }
+    if let Some(speed) = value.airspeed_kt {
+        let kind = value.airspeed_kind.map_or("airspeed", airspeed_label);
+        parts.push(format!("{speed:.0} kt {kind}"));
+    }
+    if let Some(heading) = value.heading_deg {
+        let reference = value.heading_reference.map_or("heading", heading_label);
+        parts.push(format!("{heading:.0}° {reference}"));
+    }
+    if let Some(rate) = value.vertical_rate_fpm {
+        let source = value
+            .vertical_rate_source
+            .map_or("vertical rate", vertical_rate_label);
+        parts.push(format!("{rate:+} ft/min {source}"));
+    }
+    (!parts.is_empty()).then(|| parts.join(" · "))
+}
+
+fn source_label(provenance: FieldProvenance) -> String {
+    let band = provenance.origin.band().map_or("No radio band", band_label);
+    let delivery = delivery_label(provenance.source.delivery);
+    let origin = origin_label(provenance.origin);
+    if provenance.source.is_unspecified() {
+        format!("{band} · {delivery} · {origin}")
+    } else {
+        format!(
+            "{band} · {delivery} · {origin} · input {}, epoch {}",
+            provenance.source.id, provenance.source.epoch
+        )
+    }
+}
+
+fn field_age<T>(field: &TimedField<T>, now_micros: u64) -> String {
+    let age = format_age(field.age_micros(now_micros));
+    if field.time.is_established() {
+        age
+    } else {
+        format!("At least {age}")
+    }
+}
+
+fn format_age(age_micros: u64) -> String {
+    if age_micros < 1_000_000 {
+        return format!("{} ms old", age_micros / 1_000);
+    }
+    if age_micros < 60_000_000 {
+        return format!("{:.1} s old", age_micros as f64 / 1_000_000.0);
+    }
+    format!("{:.1} min old", age_micros as f64 / 60_000_000.0)
+}
+
+fn phase_label(phase: TrackPhase) -> &'static str {
+    match phase {
+        TrackPhase::Active => "Active",
+        TrackPhase::Coasting => "Coasting",
+        _ => "Unknown",
+    }
+}
+
+fn band_label(band: Band) -> &'static str {
+    match band {
+        Band::Adsb1090 => "1090 MHz",
+        Band::Uat978 => "978 MHz",
+        _ => "Unknown radio band",
+    }
+}
+
+fn delivery_label(delivery: DeliveryPath) -> &'static str {
+    match delivery {
+        DeliveryPath::Unspecified => "Unspecified link",
+        DeliveryPath::LocalReceiver => "Local receiver",
+        DeliveryPath::InstalledAvionics => "Installed avionics",
+        DeliveryPath::NetworkProvider => "Network provider",
+        DeliveryPath::Replay => "Replay link",
+        DeliveryPath::Simulator => "Simulator link",
+        _ => "Unknown link",
+    }
+}
+
+fn origin_label(origin: ObservationOrigin) -> &'static str {
+    match origin {
+        ObservationOrigin::AdsbDirect { .. } => "Direct ADS-B",
+        ObservationOrigin::ModeSReply => "Mode S reply",
+        ObservationOrigin::AdsR { .. } => "ADS-R",
+        ObservationOrigin::Tisb { .. } => "TIS-B",
+        ObservationOrigin::Radar => "Radar",
+        ObservationOrigin::Mlat => "Multilateration",
+        ObservationOrigin::ProviderFused => "Provider fusion",
+        ObservationOrigin::PanelFused => "Panel fusion",
+        ObservationOrigin::Replay => "Replay origin",
+        ObservationOrigin::Unknown => "Unknown origin",
+        _ => "Unknown origin",
+    }
+}
+
+fn air_ground_label(state: AirGroundState) -> &'static str {
+    match state {
+        AirGroundState::Subsonic | AirGroundState::Supersonic => "Airborne",
+        AirGroundState::Ground => "On ground",
+        AirGroundState::Reserved => "Reserved",
+        _ => "Unknown",
+    }
+}
+
+fn emergency_label(state: EmergencyState) -> &'static str {
+    match state {
+        EmergencyState::None => "None",
+        EmergencyState::General => "General emergency",
+        EmergencyState::Medical => "Medical emergency",
+        EmergencyState::MinimumFuel => "Minimum fuel",
+        EmergencyState::NoCommunication => "No radio communication",
+        EmergencyState::UnlawfulInterference => "Unlawful interference",
+        EmergencyState::DownedAircraft => "Downed aircraft",
+        EmergencyState::Reserved => "Reserved",
+        _ => "Unknown",
+    }
+}
+
+fn airspeed_label(kind: AirspeedKind) -> &'static str {
+    match kind {
+        AirspeedKind::Indicated => "indicated airspeed",
+        AirspeedKind::True => "true airspeed",
+        _ => "airspeed",
+    }
+}
+
+fn heading_label(reference: HeadingReference) -> &'static str {
+    match reference {
+        HeadingReference::TrueNorth => "true heading",
+        HeadingReference::MagneticNorth => "magnetic heading",
+        _ => "heading",
+    }
+}
+
+fn vertical_rate_label(source: VerticalRateSource) -> &'static str {
+    match source {
+        VerticalRateSource::Barometric => "barometric",
+        VerticalRateSource::Geometric => "geometric",
+        _ => "vertical rate",
+    }
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_owned())
+}

--- a/crates/pilotage-presentation/src/layer.rs
+++ b/crates/pilotage-presentation/src/layer.rs
@@ -1,0 +1,314 @@
+//! Layer controls and source-state policy.
+
+use std::collections::BTreeMap;
+
+/// Stable identity of the terrain base layer.
+pub const TERRAIN_LAYER_ID: &str = "terrain-base";
+/// Stable identity of the traffic layer.
+pub const TRAFFIC_LAYER_ID: &str = "traffic";
+/// Stable identity of the weather report layer.
+pub const WEATHER_REPORT_LAYER_ID: &str = "weather-reports";
+/// Stable identity of the weather advisory layer.
+pub const WEATHER_ADVISORY_LAYER_ID: &str = "weather-advisories";
+
+/// State of one display source.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LayerSourceState {
+    /// The source supplies current values.
+    Live,
+    /// The source exists, but it does not supply current values.
+    Stale,
+    /// The source is not available.
+    Absent,
+}
+
+impl LayerSourceState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Live => "Live",
+            Self::Stale => "Stale",
+            Self::Absent => "Absent",
+        }
+    }
+}
+
+/// One user-controlled display layer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LayerControl {
+    /// Stable application identity.
+    pub id: String,
+    /// User-facing layer name.
+    pub title: String,
+    /// Whether the layer is visible.
+    pub enabled: bool,
+    /// Current source state.
+    pub source_state: LayerSourceState,
+    /// User-facing source state.
+    pub source_state_label: String,
+    /// Explanation of the source state.
+    pub source_detail: String,
+}
+
+/// A radio band that can supply situation data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RadioBand {
+    /// The 1090 MHz ADS-B band.
+    Adsb1090,
+    /// The 978 MHz UAT band.
+    Uat978,
+}
+
+/// A raw reception state from the host.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RadioReceptionState {
+    /// The host checks the source.
+    Checking,
+    /// The host does not have permission to use the source.
+    PermissionDenied,
+    /// The user disabled the source.
+    DriverDisabled,
+    /// No receiver is attached.
+    Unplugged,
+    /// A receiver is ready.
+    Ready,
+    /// A receiver supplies data.
+    Streaming,
+    /// The host stopped reception.
+    Suspended,
+    /// The source does not have sufficient power.
+    Underpowered,
+    /// Source enumeration failed.
+    EnumerationFailure,
+    /// A source endpoint failed.
+    EndpointFailure,
+    /// The source was removed.
+    DeviceRemoved,
+}
+
+/// State of one attached radio receiver.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RadioReceiverObservation {
+    /// Receiver band.
+    pub band: RadioBand,
+    /// Receiver state.
+    pub state: RadioReceptionState,
+}
+
+/// Raw source facts supplied by the composition host.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceObservation {
+    /// Whether the terrain archive is available.
+    pub terrain_available: bool,
+    /// Whether weather station positions are available.
+    pub weather_positions_available: bool,
+    /// State of the radio subsystem.
+    pub radio_state: RadioReceptionState,
+    /// States of attached receivers.
+    pub radio_receivers: Vec<RadioReceiverObservation>,
+}
+
+impl Default for SourceObservation {
+    fn default() -> Self {
+        Self {
+            terrain_available: false,
+            weather_positions_available: false,
+            radio_state: RadioReceptionState::Suspended,
+            radio_receivers: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LayerPolicy {
+    enabled: BTreeMap<&'static str, bool>,
+    sources: SourceObservation,
+}
+
+impl Default for LayerPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: [
+                (TERRAIN_LAYER_ID, true),
+                (TRAFFIC_LAYER_ID, true),
+                (WEATHER_REPORT_LAYER_ID, true),
+                (WEATHER_ADVISORY_LAYER_ID, true),
+            ]
+            .into_iter()
+            .collect(),
+            sources: SourceObservation::default(),
+        }
+    }
+}
+
+impl LayerPolicy {
+    pub(crate) fn set_enabled(&mut self, id: &str, enabled: bool) -> bool {
+        let Some(value) = self.enabled.get_mut(id) else {
+            return false;
+        };
+        *value = enabled;
+        true
+    }
+
+    pub(crate) fn is_enabled(&self, id: &str) -> bool {
+        self.enabled.get(id).copied().unwrap_or(false)
+    }
+
+    pub(crate) fn observe_sources(&mut self, sources: SourceObservation) {
+        self.sources = sources;
+    }
+
+    pub(crate) fn controls(&self, has_traffic: bool, has_weather: bool) -> Vec<LayerControl> {
+        vec![
+            self.terrain_control(),
+            self.traffic_control(has_traffic),
+            self.weather_control(has_weather),
+            self.advisory_control(),
+        ]
+    }
+
+    fn terrain_control(&self) -> LayerControl {
+        if self.sources.terrain_available {
+            self.control(
+                TERRAIN_LAYER_ID,
+                "Terrain base",
+                LayerSourceState::Live,
+                "The bundled terrain source is available.",
+            )
+        } else {
+            self.control(
+                TERRAIN_LAYER_ID,
+                "Terrain base",
+                LayerSourceState::Absent,
+                "The bundled terrain source is not available.",
+            )
+        }
+    }
+
+    fn traffic_control(&self, has_traffic: bool) -> LayerControl {
+        let states = self.relevant_states(|_| true);
+        if states
+            .iter()
+            .any(|state| **state == RadioReceptionState::Streaming)
+        {
+            return self.control(
+                TRAFFIC_LAYER_ID,
+                "Traffic",
+                LayerSourceState::Live,
+                &self.live_band_detail(),
+            );
+        }
+        if has_traffic || states.iter().any(|state| source_is_present(**state)) {
+            return self.control(
+                TRAFFIC_LAYER_ID,
+                "Traffic",
+                LayerSourceState::Stale,
+                "Traffic reception is not live. Retained tracks can be old.",
+            );
+        }
+        self.control(
+            TRAFFIC_LAYER_ID,
+            "Traffic",
+            LayerSourceState::Absent,
+            "No traffic source is available.",
+        )
+    }
+
+    fn weather_control(&self, has_weather: bool) -> LayerControl {
+        if !self.sources.weather_positions_available {
+            return self.control(
+                WEATHER_REPORT_LAYER_ID,
+                "Weather reports",
+                LayerSourceState::Absent,
+                "Weather station positions are not available. This state does not mean clear weather.",
+            );
+        }
+        let states = self.relevant_states(|band| band == RadioBand::Uat978);
+        if states
+            .iter()
+            .any(|state| **state == RadioReceptionState::Streaming)
+        {
+            return self.control(
+                WEATHER_REPORT_LAYER_ID,
+                "Weather reports",
+                LayerSourceState::Live,
+                "978 MHz weather reception is live.",
+            );
+        }
+        if has_weather || states.iter().any(|state| source_is_present(**state)) {
+            return self.control(
+                WEATHER_REPORT_LAYER_ID,
+                "Weather reports",
+                LayerSourceState::Stale,
+                "Weather reception is not live. Retained reports can be old.",
+            );
+        }
+        self.control(
+            WEATHER_REPORT_LAYER_ID,
+            "Weather reports",
+            LayerSourceState::Absent,
+            "No weather report source is available. This state does not mean clear weather.",
+        )
+    }
+
+    fn advisory_control(&self) -> LayerControl {
+        self.control(
+            WEATHER_ADVISORY_LAYER_ID,
+            "Weather advisories",
+            LayerSourceState::Absent,
+            "No weather advisory source is available. This state does not mean clear weather.",
+        )
+    }
+
+    fn control(
+        &self,
+        id: &'static str,
+        title: &'static str,
+        source_state: LayerSourceState,
+        source_detail: &str,
+    ) -> LayerControl {
+        LayerControl {
+            id: id.into(),
+            title: title.into(),
+            enabled: self.is_enabled(id),
+            source_state,
+            source_state_label: source_state.label().into(),
+            source_detail: source_detail.into(),
+        }
+    }
+
+    fn relevant_states(&self, include: impl Fn(RadioBand) -> bool) -> Vec<&RadioReceptionState> {
+        let mut states: Vec<_> = self
+            .sources
+            .radio_receivers
+            .iter()
+            .filter(|receiver| include(receiver.band))
+            .map(|receiver| &receiver.state)
+            .collect();
+        if self.sources.radio_receivers.is_empty() {
+            states.push(&self.sources.radio_state);
+        }
+        states
+    }
+
+    fn live_band_detail(&self) -> String {
+        let live_1090 = self.sources.radio_receivers.iter().any(|receiver| {
+            receiver.band == RadioBand::Adsb1090 && receiver.state == RadioReceptionState::Streaming
+        });
+        let live_978 = self.sources.radio_receivers.iter().any(|receiver| {
+            receiver.band == RadioBand::Uat978 && receiver.state == RadioReceptionState::Streaming
+        });
+        match (live_1090, live_978) {
+            (true, true) => "1090 MHz and 978 MHz traffic reception are live.".into(),
+            (true, false) => "1090 MHz traffic reception is live.".into(),
+            (false, true) => "978 MHz traffic reception is live.".into(),
+            (false, false) => "Traffic reception is live.".into(),
+        }
+    }
+}
+
+fn source_is_present(state: RadioReceptionState) -> bool {
+    matches!(
+        state,
+        RadioReceptionState::Checking | RadioReceptionState::Ready | RadioReceptionState::Streaming
+    )
+}

--- a/crates/pilotage-presentation/src/lib.rs
+++ b/crates/pilotage-presentation/src/lib.rs
@@ -3,6 +3,8 @@
 //! The crate converts domain feature changes into display values. It does
 //! not contain a platform API or an output encoding.
 
+mod detail;
+mod layer;
 mod model;
 mod policy;
 mod traffic;
@@ -11,6 +13,12 @@ mod weather;
 #[cfg(test)]
 mod tests;
 
+pub use detail::{TrafficDetail, TrafficDetailField, TrafficListItem};
+pub use layer::{
+    LayerControl, LayerSourceState, RadioBand, RadioReceiverObservation, RadioReceptionState,
+    SourceObservation, TERRAIN_LAYER_ID, TRAFFIC_LAYER_ID, WEATHER_ADVISORY_LAYER_ID,
+    WEATHER_REPORT_LAYER_ID,
+};
 pub use model::{
     Color, Coordinate, CoordinateRing, DisplayBatch, PointChange, PointFeature, PointStyle,
     ShapeFeature, ShapeStyle,

--- a/crates/pilotage-presentation/src/model.rs
+++ b/crates/pilotage-presentation/src/model.rs
@@ -126,6 +126,8 @@ pub struct ShapeStyle {
 pub struct PointFeature {
     /// Stable feature identity.
     pub id: String,
+    /// Stable application layer identity.
+    pub layer_id: String,
     /// Feature position.
     pub coordinate: Coordinate,
     /// Style identity from the point style catalog.
@@ -177,6 +179,8 @@ pub enum PointChange {
 pub struct ShapeFeature {
     /// Stable feature identity.
     pub id: String,
+    /// Stable application layer identity.
+    pub layer_id: String,
     /// Polygon rings. The first ring is the exterior ring.
     pub rings: Vec<CoordinateRing>,
     /// Style identity from the shape style catalog.
@@ -192,6 +196,8 @@ pub struct ShapeFeature {
 /// One complete set of display values and its style catalog.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DisplayBatch {
+    /// User-controlled display layers.
+    pub layers: Vec<crate::layer::LayerControl>,
     /// Point style catalog.
     pub point_styles: Vec<PointStyle>,
     /// Shape style catalog.
@@ -202,6 +208,10 @@ pub struct DisplayBatch {
     pub point_changes: Vec<PointChange>,
     /// Polygon features.
     pub shapes: Vec<ShapeFeature>,
+    /// Traffic tracks that do not have a map position.
+    pub positionless_traffic: Vec<crate::detail::TrafficListItem>,
+    /// Detail values for retained traffic tracks.
+    pub traffic_details: Vec<crate::detail::TrafficDetail>,
     /// Supported domain products that had no display value.
     pub omitted_products: u64,
 }
@@ -209,9 +219,12 @@ pub struct DisplayBatch {
 impl DisplayBatch {
     /// Add features and omission counts from another batch.
     pub fn append(&mut self, other: Self) {
+        self.layers = other.layers;
         self.points.extend(other.points);
         self.point_changes.extend(other.point_changes);
         self.shapes.extend(other.shapes);
+        self.positionless_traffic = other.positionless_traffic;
+        self.traffic_details = other.traffic_details;
         self.omitted_products = self.omitted_products.wrapping_add(other.omitted_products);
     }
 }

--- a/crates/pilotage-presentation/src/policy.rs
+++ b/crates/pilotage-presentation/src/policy.rs
@@ -3,8 +3,9 @@
 use std::collections::BTreeMap;
 
 use airmass_geojson::FeatureDelta as WeatherFeatureDelta;
-use surveillance_core::TrackDelta;
+use surveillance_core::{TrackDelta, TrackSnapshotHandle};
 
+use crate::layer::{LayerPolicy, SourceObservation, TRAFFIC_LAYER_ID, WEATHER_REPORT_LAYER_ID};
 use crate::{DisplayBatch, PointChange, PointFeature, PointStyle, ShapeStyle};
 
 pub(crate) const TRAFFIC_ACTIVE_STYLE: &str = "traffic-active";
@@ -24,9 +25,12 @@ pub(crate) const ADVISORY_CWA_STYLE: &str = "advisory-cwa";
 /// Converts typed domain feature changes to display values.
 #[derive(Clone, Debug, Default)]
 pub struct PresentationAdapter {
+    layers: LayerPolicy,
     traffic_points: BTreeMap<(u64, u64), PointFeature>,
     traffic_revisions: BTreeMap<(u64, u64), u64>,
+    traffic_tracks: BTreeMap<(u64, u64), TrackSnapshotHandle>,
     weather_points: BTreeMap<String, PointFeature>,
+    now_micros: u64,
 }
 
 impl PresentationAdapter {
@@ -40,13 +44,34 @@ impl PresentationAdapter {
     #[must_use]
     pub fn empty_batch(&self) -> DisplayBatch {
         DisplayBatch {
+            layers: self.layers.controls(
+                !self.traffic_tracks.is_empty(),
+                !self.weather_points.is_empty(),
+            ),
             point_styles: point_styles(),
             shape_styles: shape_styles(),
             points: Vec::new(),
             point_changes: Vec::new(),
             shapes: Vec::new(),
+            positionless_traffic: Vec::new(),
+            traffic_details: Vec::new(),
             omitted_products: 0,
         }
+    }
+
+    /// Advance the display clock without changing domain state.
+    pub fn advance_time(&mut self, now_micros: u64) {
+        self.now_micros = self.now_micros.max(now_micros);
+    }
+
+    /// Record raw source facts from the composition host.
+    pub fn observe_sources(&mut self, sources: SourceObservation) {
+        self.layers.observe_sources(sources);
+    }
+
+    /// Set the visibility of one known layer.
+    pub fn set_layer_enabled(&mut self, id: &str, enabled: bool) -> bool {
+        self.layers.set_enabled(id, enabled)
     }
 
     /// Apply one ordered Surveillance delta.
@@ -62,6 +87,7 @@ impl PresentationAdapter {
             return None;
         }
         self.traffic_revisions.insert(key, snapshot_revision);
+        self.retain_track(key, delta);
         let source_change = surveillance_geojson::map_track_delta(delta)?;
         let change = crate::traffic::point_change(
             &source_change,
@@ -70,7 +96,7 @@ impl PresentationAdapter {
             self.traffic_points.get(&key),
         )?;
         self.apply_point_change(key, &change);
-        Some(change)
+        self.layers.is_enabled(TRAFFIC_LAYER_ID).then_some(change)
     }
 
     /// Apply one ordered Airmass feature change.
@@ -86,13 +112,15 @@ impl PresentationAdapter {
             }
             PointChange::Stale { .. } => {}
         }
-        Some(change)
+        self.layers
+            .is_enabled(WEATHER_REPORT_LAYER_ID)
+            .then_some(change)
     }
 
     /// Remove all weather points without changing traffic state.
     pub fn clear_weather(&mut self) -> Vec<PointChange> {
         let points = std::mem::take(&mut self.weather_points);
-        points
+        let changes: Vec<_> = points
             .into_iter()
             .map(|(id, point)| PointChange::Remove {
                 id,
@@ -100,16 +128,64 @@ impl PresentationAdapter {
                 producer_instance_id: point.producer_instance_id,
                 snapshot_revision: point.snapshot_revision,
             })
-            .collect()
+            .collect();
+        if self.layers.is_enabled(WEATHER_REPORT_LAYER_ID) {
+            changes
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Clear state supplied by radio reception and keep application controls.
+    pub fn clear_radio_state(&mut self) {
+        self.traffic_points.clear();
+        self.traffic_revisions.clear();
+        self.traffic_tracks.clear();
+        self.weather_points.clear();
     }
 
     /// Convert current traffic and weather values into one batch.
     #[must_use]
     pub fn adapt(&self) -> DisplayBatch {
         let mut batch = self.empty_batch();
-        batch.points.extend(self.traffic_points.values().cloned());
-        batch.points.extend(self.weather_points.values().cloned());
+        if self.layers.is_enabled(TRAFFIC_LAYER_ID) {
+            batch.points.extend(self.traffic_points.values().cloned());
+            batch.positionless_traffic = self
+                .traffic_tracks
+                .values()
+                .filter_map(|track| crate::detail::positionless_item(track, self.now_micros))
+                .collect();
+        }
+        if self.layers.is_enabled(WEATHER_REPORT_LAYER_ID) {
+            batch.points.extend(self.weather_points.values().cloned());
+        }
+        batch.traffic_details = self
+            .traffic_tracks
+            .values()
+            .map(|track| crate::detail::detail_for(track, self.now_micros))
+            .collect();
         batch
+    }
+
+    fn retain_track(&mut self, key: (u64, u64), delta: &TrackDelta) {
+        match delta {
+            TrackDelta::Created(handle)
+            | TrackDelta::Updated(handle)
+            | TrackDelta::Coasting(handle) => {
+                self.now_micros = self
+                    .now_micros
+                    .max(handle.snapshot().last_observed_at_micros);
+                if handle.snapshot().ownship_shadow {
+                    self.traffic_tracks.remove(&key);
+                } else {
+                    self.traffic_tracks.insert(key, handle.clone());
+                }
+            }
+            TrackDelta::Removed { .. } => {
+                self.traffic_tracks.remove(&key);
+            }
+            _ => {}
+        }
     }
 
     fn apply_point_change(&mut self, key: (u64, u64), change: &PointChange) {

--- a/crates/pilotage-presentation/src/tests.rs
+++ b/crates/pilotage-presentation/src/tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+mod layer;
 mod traffic;
 mod weather;

--- a/crates/pilotage-presentation/src/tests/layer.rs
+++ b/crates/pilotage-presentation/src/tests/layer.rs
@@ -1,0 +1,113 @@
+use crate::{
+    LayerSourceState, PresentationAdapter, RadioBand, RadioReceiverObservation,
+    RadioReceptionState, SourceObservation, TERRAIN_LAYER_ID, TRAFFIC_LAYER_ID,
+    WEATHER_ADVISORY_LAYER_ID, WEATHER_REPORT_LAYER_ID,
+};
+
+#[test]
+fn every_mvp_layer_starts_on_and_reports_absence() {
+    let batch = PresentationAdapter::new().adapt();
+
+    assert_eq!(batch.layers.len(), 4);
+    for layer in &batch.layers {
+        assert!(layer.enabled);
+    }
+    assert_eq!(
+        source_state(&batch, TERRAIN_LAYER_ID),
+        LayerSourceState::Absent
+    );
+    assert_eq!(
+        source_state(&batch, TRAFFIC_LAYER_ID),
+        LayerSourceState::Absent
+    );
+    assert_eq!(
+        source_state(&batch, WEATHER_REPORT_LAYER_ID),
+        LayerSourceState::Absent
+    );
+    assert_eq!(
+        source_state(&batch, WEATHER_ADVISORY_LAYER_ID),
+        LayerSourceState::Absent
+    );
+    assert!(
+        layer(&batch, WEATHER_REPORT_LAYER_ID)
+            .source_detail
+            .contains("does not mean clear weather")
+    );
+}
+
+#[test]
+fn raw_source_facts_select_live_and_stale_states() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.observe_sources(SourceObservation {
+        terrain_available: true,
+        weather_positions_available: true,
+        radio_state: RadioReceptionState::Streaming,
+        radio_receivers: vec![
+            RadioReceiverObservation {
+                band: RadioBand::Adsb1090,
+                state: RadioReceptionState::Streaming,
+            },
+            RadioReceiverObservation {
+                band: RadioBand::Uat978,
+                state: RadioReceptionState::Ready,
+            },
+        ],
+    });
+    let batch = adapter.adapt();
+
+    assert_eq!(
+        source_state(&batch, TERRAIN_LAYER_ID),
+        LayerSourceState::Live
+    );
+    assert_eq!(
+        source_state(&batch, TRAFFIC_LAYER_ID),
+        LayerSourceState::Live
+    );
+    assert_eq!(
+        source_state(&batch, WEATHER_REPORT_LAYER_ID),
+        LayerSourceState::Stale
+    );
+    assert_eq!(
+        source_state(&batch, WEATHER_ADVISORY_LAYER_ID),
+        LayerSourceState::Absent
+    );
+}
+
+#[test]
+fn live_1090_receiver_does_not_make_weather_live() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.observe_sources(SourceObservation {
+        terrain_available: true,
+        weather_positions_available: true,
+        radio_state: RadioReceptionState::Streaming,
+        radio_receivers: vec![RadioReceiverObservation {
+            band: RadioBand::Adsb1090,
+            state: RadioReceptionState::Streaming,
+        }],
+    });
+
+    assert_eq!(
+        source_state(&adapter.adapt(), WEATHER_REPORT_LAYER_ID),
+        LayerSourceState::Absent
+    );
+}
+
+#[test]
+fn unknown_layer_identity_does_not_change_the_catalog() {
+    let mut adapter = PresentationAdapter::new();
+
+    assert!(!adapter.set_layer_enabled("future-layer", false));
+    assert_eq!(adapter.adapt().layers.len(), 4);
+}
+
+fn source_state(batch: &crate::DisplayBatch, id: &str) -> LayerSourceState {
+    layer(batch, id).source_state
+}
+
+fn layer<'a>(batch: &'a crate::DisplayBatch, id: &str) -> &'a crate::LayerControl {
+    batch
+        .layers
+        .iter()
+        .find(|layer| layer.id == id)
+        .expect("the layer catalog must contain the expected identity")
+}

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -1,11 +1,11 @@
 use surveillance_core::{
-    AddressNamespace, Callsign, EmergencyState, FieldProvenance, FieldQuality, ObservationOrigin,
-    ObservationTime, ProducerInstanceId, RemovalReason, SnapshotRevision, SourceRef, TimedField,
-    TrackDelta, TrackId, TrackKey, TrackPhase, TrackSnapshot, TrackSnapshotHandle,
-    VelocityObservation, Wgs84Position,
+    AddressNamespace, AirGroundState, Band, Callsign, DeliveryPath, EmergencyState,
+    FieldProvenance, FieldQuality, ObservationOrigin, ObservationTime, ProducerInstanceId,
+    RemovalReason, SnapshotRevision, SourceRef, Squawk, TimedField, TrackDelta, TrackId, TrackKey,
+    TrackPhase, TrackSnapshot, TrackSnapshotHandle, VelocityObservation, Wgs84Position,
 };
 
-use crate::{PointChange, PresentationAdapter};
+use crate::{PointChange, PresentationAdapter, TRAFFIC_LAYER_ID};
 
 #[test]
 fn active_track_becomes_a_policy_styled_upsert() {
@@ -93,6 +93,88 @@ fn merged_removal_names_the_surviving_feature() {
     assert_eq!(batch.points[0].id, "traffic-7-43");
 }
 
+#[test]
+fn disabled_traffic_retains_the_newest_state_without_replay() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&updated_delta(42, 3, false, EmergencyState::None));
+    assert!(adapter.set_layer_enabled(TRAFFIC_LAYER_ID, false));
+
+    let hidden_change = adapter.apply_traffic_delta(&updated_delta_with_latitude(42, 4, 43.0));
+    let hidden = adapter.adapt();
+    assert!(hidden_change.is_none());
+    assert!(hidden.points.is_empty());
+    assert_eq!(hidden.traffic_details.len(), 1);
+
+    assert!(adapter.set_layer_enabled(TRAFFIC_LAYER_ID, true));
+    let visible = adapter.adapt();
+    assert_eq!(visible.points.len(), 1);
+    assert_eq!(visible.points[0].coordinate.latitude_deg, 43.0);
+    assert!(visible.point_changes.is_empty());
+}
+
+#[test]
+fn positionless_track_has_a_list_item_and_complete_absence_reasons() {
+    let mut track = TrackSnapshot::new(TrackId::new(51), track_key(51), 10);
+    track.callsign = Some(radio_timed(Callsign::new("MODESONLY")));
+    track.pressure_altitude_ft = Some(radio_timed(7_000));
+    let delta = TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(1),
+        track,
+    ));
+    let mut adapter = PresentationAdapter::new();
+    adapter.advance_time(2_000_010);
+
+    assert!(adapter.apply_traffic_delta(&delta).is_none());
+    let batch = adapter.adapt();
+    assert!(batch.points.is_empty());
+    assert_eq!(batch.positionless_traffic.len(), 1);
+    assert_eq!(batch.positionless_traffic[0].title, "MODESONLY");
+    let detail = &batch.traffic_details[0];
+    let position = detail
+        .fields
+        .iter()
+        .find(|field| field.id == "position")
+        .expect("position field must exist");
+    assert!(position.value.is_none());
+    assert_eq!(
+        position.absence_reason.as_deref(),
+        Some("The track has no position observation.")
+    );
+}
+
+#[test]
+fn traffic_detail_keeps_field_age_band_and_link() {
+    let mut track = complete_track(61);
+    track
+        .identities
+        .associate(TrackKey::new(AddressNamespace::SelfAssigned, 0x00_C0DE));
+    let delta = TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(2),
+        track,
+    ));
+    let mut adapter = PresentationAdapter::new();
+    adapter.advance_time(2_000_010);
+    adapter.apply_traffic_delta(&delta);
+
+    let batch = adapter.adapt();
+    let detail = &batch.traffic_details[0];
+    assert_eq!(detail.primary_identity, "ICAO A0B13D");
+    assert_eq!(detail.other_identities, ["Self-assigned 00C0DE"]);
+    assert_eq!(detail.lifecycle, "Active");
+    assert_eq!(detail.newest_observation_age, "2.0 s old");
+    assert_eq!(detail.fields.len(), 8);
+    for field in &detail.fields {
+        assert!(field.value.is_some(), "{} must have a value", field.id);
+        assert_eq!(field.age.as_deref(), Some("2.0 s old"));
+        let source = field.source.as_deref().expect("field source must exist");
+        assert!(source.contains("1090 MHz"));
+        assert!(source.contains("Local receiver"));
+        assert!(field.absence_reason.is_none());
+    }
+}
+
 fn updated_delta(
     id: u64,
     revision: u64,
@@ -115,6 +197,19 @@ fn coasting_delta(id: u64, revision: u64, emergency: EmergencyState) -> TrackDel
         false,
         TrackPhase::Coasting,
         emergency,
+    ))
+}
+
+fn updated_delta_with_latitude(id: u64, revision: u64, latitude_deg: f64) -> TrackDelta {
+    let mut track = complete_track(id);
+    track.position = Some(radio_timed(Wgs84Position {
+        latitude_deg,
+        longitude_deg: -71.0096,
+    }));
+    TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(revision),
+        track,
     ))
 }
 
@@ -145,6 +240,27 @@ fn track_handle(
     )
 }
 
+fn complete_track(id: u64) -> TrackSnapshot {
+    let mut track = TrackSnapshot::new(TrackId::new(id), track_key(id), 10);
+    track.position = Some(radio_timed(Wgs84Position {
+        latitude_deg: 42.3656,
+        longitude_deg: -71.0096,
+    }));
+    track.pressure_altitude_ft = Some(radio_timed(5_500));
+    track.geometric_altitude_ft = Some(radio_timed(5_650));
+    track.velocity = Some(radio_timed(
+        serde_json::from_str(r#"{"ground_speed_kt":120.0,"track_angle_deg_true":92.0}"#)
+            .expect("velocity fixture must decode"),
+    ));
+    track.callsign = Some(radio_timed(Callsign::new("N61TEST")));
+    track.squawk = Some(radio_timed(
+        Squawk::try_from(1_200).expect("squawk fixture must be valid"),
+    ));
+    track.air_ground = Some(radio_timed(AirGroundState::Subsonic));
+    track.emergency = Some(radio_timed(EmergencyState::None));
+    track
+}
+
 fn track_key(id: u64) -> TrackKey {
     TrackKey::new(AddressNamespace::Icao, 0xA0_B1_00 + id as u32)
 }
@@ -158,6 +274,21 @@ fn timed<T>(value: T) -> TimedField<T> {
             ObservationOrigin::Replay,
             AddressNamespace::Icao,
             SourceRef::default(),
+        ),
+    )
+}
+
+fn radio_timed<T>(value: T) -> TimedField<T> {
+    TimedField::new(
+        value,
+        ObservationTime::local(10),
+        FieldQuality::default(),
+        FieldProvenance::new(
+            ObservationOrigin::AdsbDirect {
+                band: Band::Adsb1090,
+            },
+            AddressNamespace::Icao,
+            SourceRef::new(4, 2, DeliveryPath::LocalReceiver),
         ),
     )
 }

--- a/crates/pilotage-presentation/src/tests/weather.rs
+++ b/crates/pilotage-presentation/src/tests/weather.rs
@@ -8,7 +8,7 @@ use airmass_core::{
 };
 use airmass_geojson::{FeatureDelta, Wgs84Position, map_snapshot_transition};
 
-use crate::{PointChange, PresentationAdapter};
+use crate::{PointChange, PresentationAdapter, WEATHER_REPORT_LAYER_ID};
 
 #[test]
 fn typed_flight_categories_select_the_color_policy() {
@@ -130,6 +130,22 @@ fn clearing_weather_emits_removal() {
 
     assert!(matches!(changes.as_slice(), [PointChange::Remove { .. }]));
     assert!(adapter.adapt().points.is_empty());
+}
+
+#[test]
+fn disabled_weather_retains_the_current_report() {
+    let delta = initial_delta(Some(FlightCategory::Vfr));
+    let mut adapter = PresentationAdapter::new();
+    assert!(adapter.set_layer_enabled(WEATHER_REPORT_LAYER_ID, false));
+
+    assert!(adapter.apply_weather_delta(&delta).is_none());
+    assert!(adapter.adapt().points.is_empty());
+
+    assert!(adapter.set_layer_enabled(WEATHER_REPORT_LAYER_ID, true));
+    let batch = adapter.adapt();
+    assert_eq!(batch.points.len(), 1);
+    assert_eq!(batch.points[0].layer_id, WEATHER_REPORT_LAYER_ID);
+    assert!(batch.point_changes.is_empty());
 }
 
 fn initial_delta(category: Option<FlightCategory>) -> FeatureDelta {

--- a/crates/pilotage-presentation/src/traffic.rs
+++ b/crates/pilotage-presentation/src/traffic.rs
@@ -2,6 +2,7 @@
 
 use surveillance_geojson::{AircraftFeature, FeatureDelta};
 
+use crate::layer::TRAFFIC_LAYER_ID;
 use crate::policy::{TRAFFIC_ACTIVE_STYLE, TRAFFIC_COASTING_STYLE, TRAFFIC_EMERGENCY_STYLE};
 use crate::{Coordinate, PointChange, PointFeature};
 
@@ -54,6 +55,7 @@ fn point_for_feature(feature: &AircraftFeature) -> Option<PointFeature> {
     let track = feature.snapshot();
     Some(PointFeature {
         id: traffic_id(feature.producer_instance_id().get(), feature.id().get()),
+        layer_id: TRAFFIC_LAYER_ID.into(),
         coordinate,
         style_id: traffic_style(feature).into(),
         label: traffic_display_label(feature),
@@ -112,6 +114,6 @@ fn traffic_display_label(feature: &AircraftFeature) -> Option<String> {
     })
 }
 
-fn traffic_id(producer_instance_id: u64, track_id: u64) -> String {
+pub(crate) fn traffic_id(producer_instance_id: u64, track_id: u64) -> String {
     format!("traffic-{producer_instance_id}-{track_id}")
 }

--- a/crates/pilotage-presentation/src/weather.rs
+++ b/crates/pilotage-presentation/src/weather.rs
@@ -3,6 +3,7 @@
 use airmass_core::{FlightCategory, WeatherReportType};
 use airmass_geojson::{FeatureDelta, TextReportFeature, WeatherFeatureId};
 
+use crate::layer::WEATHER_REPORT_LAYER_ID;
 use crate::policy::{
     WEATHER_IFR_STYLE, WEATHER_LIFR_STYLE, WEATHER_MVFR_STYLE, WEATHER_UNKNOWN_STYLE,
     WEATHER_VFR_STYLE,
@@ -44,6 +45,7 @@ fn point_for_report(feature: &TextReportFeature) -> Option<PointFeature> {
     let revisions = feature.revisions();
     Some(PointFeature {
         id: feature_id(feature.id()),
+        layer_id: WEATHER_REPORT_LAYER_ID.into(),
         coordinate,
         style_id: category_style(
             feature

--- a/scripts/check-situation-layer-controls.sh
+++ b/scripts/check-situation-layer-controls.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Keep situation layer and traffic detail policy in portable Rust.
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+portable="$root/crates/pilotage-presentation/src"
+ffi="$root/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs"
+app="$root/clients/apple-situation/App"
+binding="$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources"
+status=0
+
+require_pattern() {
+    local pattern=$1
+    local file=$2
+    local message=$3
+    if ! grep -Eq "$pattern" "$file"; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+require_pattern 'pub struct LayerControl' "$portable/layer.rs" \
+    "portable Rust must own layer controls"
+require_pattern 'pub struct SourceObservation' "$portable/layer.rs" \
+    "portable Rust must own source facts"
+require_pattern 'does not mean clear weather' "$portable/layer.rs" \
+    "an absent weather source must not imply clear weather"
+require_pattern 'pub layer_id: String' "$portable/model.rs" \
+    "display features must use an extensible application layer identity"
+require_pattern 'pub positionless_traffic:' "$portable/model.rs" \
+    "the display batch must carry positionless traffic"
+require_pattern 'pub traffic_details:' "$portable/model.rs" \
+    "the display batch must carry traffic detail"
+require_pattern 'traffic_tracks:' "$portable/policy.rs" \
+    "the adapter must retain complete traffic tracks"
+require_pattern 'is_enabled[(]TRAFFIC_LAYER_ID[)]' "$portable/policy.rs" \
+    "traffic visibility must be portable policy"
+require_pattern 'is_enabled[(]WEATHER_REPORT_LAYER_ID[)]' "$portable/policy.rs" \
+    "weather visibility must be portable policy"
+require_pattern '[.]age_micros[(]now_micros[)]' "$portable/detail.rs" \
+    "traffic detail must use each field age"
+require_pattern 'source_label[(]timed[.]provenance[)]' "$portable/detail.rs" \
+    "traffic detail must use each field provenance"
+require_pattern 'absence_reason:' "$portable/detail.rs" \
+    "traffic detail must state why a field is absent"
+require_pattern 'disabled_traffic_retains_the_newest_state_without_replay' \
+    "$portable/tests/traffic.rs" \
+    "a test must prove disabled traffic retains current state"
+require_pattern 'positionless_track_has_a_list_item' "$portable/tests/traffic.rs" \
+    "a test must prove positionless traffic is listed"
+require_pattern 'pub fn observe_sources' "$ffi" \
+    "the facade must send raw source facts to portable Rust"
+require_pattern 'pub fn set_layer_enabled' "$ffi" \
+    "the facade must send layer controls to portable Rust"
+require_pattern 'LayerControlsView' "$app/PilotageSituationApp.swift" \
+    "the application must show layer controls"
+require_pattern 'PositionlessTrafficView' "$app/PilotageSituationApp.swift" \
+    "the application must show positionless traffic"
+require_pattern 'TrafficDetailView' "$app/PilotageSituationApp.swift" \
+    "the application must show traffic detail"
+require_pattern 'visibleFeatures[(]' \
+    "$binding/PilotageMapLibreBinding/SituationMapView.swift" \
+    "the map binding must identify a tapped rendered feature"
+require_pattern 'onFeatureTapped[?][(]identifier[)]' \
+    "$binding/PilotageMapLibreBinding/SituationMapView.swift" \
+    "the map binding must return only the stable feature identity"
+
+if grep -RInE \
+    '"(terrain-base|traffic|weather-reports|weather-advisories)"|TrackSnapshot|TimedField|Pressure altitude|Transponder code' \
+    "$binding"; then
+    echo "FORBIDDEN: the map binding contains domain or layer policy" >&2
+    status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+    echo "situation layer controls: FAILED" >&2
+    exit 1
+fi
+
+echo "situation layer controls: OK"

--- a/scripts/test-check-situation-layer-controls.sh
+++ b/scripts/test-check-situation-layer-controls.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Prove that the situation layer control guard rejects policy drift.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-layer-controls.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+portable="$fixture/crates/pilotage-presentation/src"
+ffi="$fixture/clients/apple-situation/rust/pilotage-situation-ffi/src"
+app="$fixture/clients/apple-situation/App"
+binding="$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding"
+mkdir -p "$portable/tests" "$ffi" "$app" "$binding" "$fixture/scripts"
+
+cp "$repo_root/crates/pilotage-presentation/src/layer.rs" "$portable/"
+cp "$repo_root/crates/pilotage-presentation/src/model.rs" "$portable/"
+cp "$repo_root/crates/pilotage-presentation/src/policy.rs" "$portable/"
+cp "$repo_root/crates/pilotage-presentation/src/detail.rs" "$portable/"
+cp "$repo_root/crates/pilotage-presentation/src/tests/traffic.rs" "$portable/tests/"
+cp "$repo_root/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs" "$ffi/"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+cp "$repo_root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"*.swift "$binding/"
+cp "$repo_root/scripts/check-situation-layer-controls.sh" "$fixture/scripts/"
+
+bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null
+
+sed -i.bak 's/[.]age_micros(now_micros)/.lost_age(now_micros)/' "$portable/detail.rs"
+if bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the layer control guard accepted traffic detail without field age" >&2
+    exit 1
+fi
+sed -i.bak 's/[.]lost_age(now_micros)/.age_micros(now_micros)/' "$portable/detail.rs"
+
+printf '\nlet forbiddenLayerPolicy = "weather-reports"\n' >> "$binding/SituationOverlay.swift"
+if bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the layer control guard accepted layer policy in the map binding" >&2
+    exit 1
+fi
+sed -i.bak '/forbiddenLayerPolicy/d' "$binding/SituationOverlay.swift"
+
+sed -i.bak 's/visibleFeatures(/hiddenFeatures(/' "$binding/SituationMapView.swift"
+if bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the layer control guard accepted a missing tap query" >&2
+    exit 1
+fi
+
+echo "situation layer controls self-test: OK"


### PR DESCRIPTION
Closes #357

Depends on #360.

## Summary

- Add four default-on layer controls for terrain, traffic, weather reports, and weather advisories.
- Keep source-state meaning and all display text in portable Rust.
- Keep reception active and retain current domain state while a layer is hidden.
- Show positionless traffic in a list.
- Show traffic identity, lifecycle, field values, field age, field source, and explicit absence reasons.
- Return only a stable feature identity from the thin MapLibre tap binding.

The current Airmass feature adapter supplies typed report points. It does not supply advisory shapes. The advisory layer therefore states that its source is absent. Both weather layers state that absence does not mean clear weather.

## Review correction

The review found and fixed one source-state error. A live 1090 MHz receiver no longer makes the 978 MHz weather source appear live. A behavior test prevents regression.

## Guardrail

- Add a CI guard that keeps display policy, layer state, traffic evidence, and absence meaning in portable Rust.
- Add a mutation self-test for field age, renderer-boundary drift, and tap identity lookup.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- strict workspace documentation build
- `cargo build --release`
- complete Apple client CI, including Rust facade tests, XCFramework generation, Swift package tests, MapLibre build, driver coexistence, and arm64 simulator app build
- presentation, layer-control, Apple-client, terrain, and structure guards
- all guard self-tests

USB CDC and attached iOS device detection found no physical target on the validation host.
