### PR TITLE
Define cycle-scoped AirspaceView resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,12 @@ jobs:
       - name: SituationView dependency boundary
         run: bash scripts/check-situation-view-boundary.sh
 
+      - name: AirspaceView contract self-test
+        run: bash scripts/test-check-airspace-view-contract.sh
+
+      - name: AirspaceView contract
+        run: bash scripts/check-airspace-view-contract.sh
+
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D missing_docs -D rustdoc::broken_intra_doc_links"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-airspace-view"
+version = "0.1.0"
+dependencies = [
+ "aerocontext-core",
+ "chrono",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-authority"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/pilotage-mavlink",
     "crates/pilotage-conformance",
     "crates/pilotage-situation-view",
+    "crates/pilotage-airspace-view",
     "crates/pilotage-calibration-id",
     "crates/pilotage-camera-calibration",
     "crates/pilotage-geo",
@@ -103,6 +104,7 @@ pilotage-input = { path = "crates/pilotage-input" }
 pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-mavlink = { path = "crates/pilotage-mavlink" }
 pilotage-situation-view = { path = "crates/pilotage-situation-view" }
+pilotage-airspace-view = { path = "crates/pilotage-airspace-view" }
 pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-camera-calibration = { path = "crates/pilotage-camera-calibration" }
 pilotage-geo = { path = "crates/pilotage-geo" }

--- a/crates/pilotage-airspace-view/Cargo.toml
+++ b/crates/pilotage-airspace-view/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pilotage-airspace-view"
+version = "0.1.0"
+edition.workspace = true
+description = "Cycle-scoped AirspaceView geometry resolution contract"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+aerocontext-core = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+chrono = { workspace = true }

--- a/crates/pilotage-airspace-view/src/error.rs
+++ b/crates/pilotage-airspace-view/src/error.rs
@@ -1,0 +1,18 @@
+//! Errors that reject an inconsistent Navdata input.
+
+use thiserror::Error;
+
+/// Failure to construct an identified Navdata snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AirspaceViewError {
+    /// The supplied identity names a different cycle from the snapshot data.
+    #[error(
+        "Navdata identity cycle {identity_cycle:?} does not match snapshot cycle {snapshot_cycle:?}"
+    )]
+    SnapshotCycleMismatch {
+        /// Cycle in the supplied identity.
+        identity_cycle: String,
+        /// Cycle derived from the snapshot.
+        snapshot_cycle: String,
+    },
+}

--- a/crates/pilotage-airspace-view/src/lib.rs
+++ b/crates/pilotage-airspace-view/src/lib.rs
@@ -1,0 +1,23 @@
+//! Cycle-scoped geometry resolution for aeronautical updates.
+//!
+//! [`AirspaceViewV1`] derives a read-only result from one identified Navdata
+//! snapshot and a set of updates. It keeps updates that have no map geometry.
+
+mod error;
+mod model;
+mod resolve;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::AirspaceViewError;
+pub use model::{
+    AeronauticalUpdateV1, AirspaceViewItemV1, AirspaceViewResultV1, GeometryCoverageV1,
+    GeometryResolutionV1, GeometryV1, IdentifiedNavdataSnapshotV1, MapCompletenessV1,
+    NavdataIdentityV1, ResolutionFailureReasonV1, ResolvedGeometryV1, SubjectExtentV1,
+    SubjectFamilyV1, SubjectIdentityV1, SubjectReferenceV1, UpdateGeometryV1, navdata_cycle_id,
+};
+pub use resolve::AirspaceViewV1;
+
+/// Schema version for the first AirspaceView request and result contract.
+pub const AIRSPACE_VIEW_SCHEMA_VERSION: u16 = 1;

--- a/crates/pilotage-airspace-view/src/model.rs
+++ b/crates/pilotage-airspace-view/src/model.rs
@@ -1,0 +1,372 @@
+//! Versioned input and result types for AirspaceView resolution.
+
+use aerocontext_core::{Area, GeoPoint, NavDataSnapshot};
+use serde::{Deserialize, Serialize};
+
+use crate::AirspaceViewError;
+
+/// Identity of one immutable Navdata snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NavdataIdentityV1 {
+    /// Authority and effective date for the cycle.
+    pub cycle: String,
+    /// Identity of the immutable built snapshot.
+    pub snapshot_id: String,
+    /// Digest of the canonical snapshot content and cycle.
+    pub snapshot_digest: String,
+}
+
+/// One immutable Navdata snapshot with its required identity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IdentifiedNavdataSnapshotV1 {
+    identity: NavdataIdentityV1,
+    snapshot: NavDataSnapshot,
+}
+
+impl IdentifiedNavdataSnapshotV1 {
+    /// Makes an identified snapshot after it verifies the cycle identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AirspaceViewError::SnapshotCycleMismatch`] when the supplied
+    /// cycle does not identify `snapshot`.
+    pub fn try_new(
+        identity: NavdataIdentityV1,
+        snapshot: NavDataSnapshot,
+    ) -> Result<Self, AirspaceViewError> {
+        let snapshot_cycle = navdata_cycle_id(&snapshot);
+        if identity.cycle != snapshot_cycle {
+            return Err(AirspaceViewError::SnapshotCycleMismatch {
+                identity_cycle: identity.cycle,
+                snapshot_cycle,
+            });
+        }
+        Ok(Self { identity, snapshot })
+    }
+
+    /// Gets the complete Navdata identity.
+    #[must_use]
+    pub const fn identity(&self) -> &NavdataIdentityV1 {
+        &self.identity
+    }
+
+    pub(crate) const fn snapshot(&self) -> &NavDataSnapshot {
+        &self.snapshot
+    }
+}
+
+/// Makes the stable cycle identity used by this contract.
+#[must_use]
+pub fn navdata_cycle_id(snapshot: &NavDataSnapshot) -> String {
+    format!(
+        "{}:{}",
+        snapshot.cycle.authority.slug(),
+        snapshot.cycle.effective_on
+    )
+}
+
+/// Family of a subject named by an aeronautical update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectFamilyV1 {
+    /// Airport or another landing facility.
+    Aerodrome,
+    /// Ground-based navigation aid.
+    Navaid,
+    /// Published fix or waypoint.
+    Fix,
+    /// One runway at an aerodrome.
+    Runway,
+    /// One controlled or special-use airspace subject.
+    Airspace,
+    /// Instrument or other published procedure.
+    Procedure,
+    /// Aeronautical service or frequency.
+    Service,
+    /// A family that this schema does not name.
+    Other,
+}
+
+impl SubjectFamilyV1 {
+    pub(crate) const fn slug(self) -> &'static str {
+        match self {
+            Self::Aerodrome => "aerodrome",
+            Self::Navaid => "navaid",
+            Self::Fix => "fix",
+            Self::Runway => "runway",
+            Self::Airspace => "airspace",
+            Self::Procedure => "procedure",
+            Self::Service => "service",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Extent of the named subject that an update changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum SubjectExtentV1 {
+    /// The update changes the complete subject.
+    Whole,
+    /// The update changes one measured runway segment.
+    RunwaySegment {
+        /// Runway end from which the offsets are measured.
+        from_end: String,
+        /// Offset from the named end, in feet.
+        start_offset_ft: u32,
+        /// Length of the changed segment, in feet.
+        length_ft: u32,
+    },
+    /// The update changes one facility component.
+    FacilityComponent {
+        /// Published component name.
+        component: String,
+    },
+    /// The source states another partial extent.
+    OtherPartial {
+        /// Source-neutral description of the extent.
+        description: String,
+    },
+}
+
+/// A cycle-scoped reference to one baseline subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectReferenceV1 {
+    /// Navdata cycle in which the identifier has meaning.
+    pub cycle: String,
+    /// Subject family.
+    pub family: SubjectFamilyV1,
+    /// Published subject identifier.
+    pub identifier: String,
+    /// Parent identifier, such as the aerodrome for a runway.
+    pub parent_identifier: Option<String>,
+    /// Authority region that disambiguates a navigation point.
+    pub region: Option<String>,
+    /// Part of the subject that the update changes.
+    pub extent: SubjectExtentV1,
+}
+
+impl SubjectReferenceV1 {
+    /// Makes the renderer-edge identifier for the baseline subject.
+    ///
+    /// The cycle stays outside this value. A composition compares cycle
+    /// identities before it uses the same subject identifier in two inputs.
+    #[must_use]
+    pub fn stable_subject_id(&self) -> String {
+        let parent = canonical_ident(self.parent_identifier.as_deref().unwrap_or(""));
+        let identifier = canonical_ident(&self.identifier);
+        let region = canonical_ident(self.region.as_deref().unwrap_or(""));
+        format!(
+            "subject-v1|{}|{}:{}|{}:{}|{}:{}",
+            self.family.slug(),
+            parent.len(),
+            parent,
+            identifier.len(),
+            identifier,
+            region.len(),
+            region
+        )
+    }
+}
+
+/// Stable baseline subject identity with its Navdata cycle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectIdentityV1 {
+    /// Navdata cycle in which the stable identifier has meaning.
+    pub cycle: String,
+    /// Stable identifier within the named cycle.
+    pub stable_id: String,
+}
+
+impl From<&SubjectReferenceV1> for SubjectIdentityV1 {
+    fn from(subject: &SubjectReferenceV1) -> Self {
+        Self {
+            cycle: subject.cycle.clone(),
+            stable_id: subject.stable_subject_id(),
+        }
+    }
+}
+
+fn canonical_ident(value: &str) -> String {
+    value.trim().to_ascii_uppercase()
+}
+
+/// Source-neutral horizontal geometry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum GeometryV1 {
+    /// One WGS84 position.
+    Point {
+        /// Published position.
+        position: GeoPoint,
+    },
+    /// One WGS84 line segment.
+    Line {
+        /// First endpoint.
+        start: GeoPoint,
+        /// Second endpoint.
+        end: GeoPoint,
+    },
+    /// One horizontal area.
+    Area {
+        /// Published area.
+        area: Area,
+    },
+}
+
+/// Amount of a subject described by one geometry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum GeometryCoverageV1 {
+    /// Geometry describes the complete subject.
+    WholeSubject,
+    /// Geometry describes only the stated extent.
+    Partial {
+        /// Exact partial extent represented by the geometry.
+        extent: SubjectExtentV1,
+    },
+}
+
+/// Geometry carried directly by an update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UpdateGeometryV1 {
+    /// Horizontal geometry.
+    pub geometry: GeometryV1,
+    /// Subject extent represented by the geometry.
+    pub coverage: GeometryCoverageV1,
+}
+
+/// One source-neutral aeronautical update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AeronauticalUpdateV1 {
+    /// Stable update identity.
+    pub update_id: String,
+    /// Complete display text for the non-map surface.
+    pub display_text: String,
+    /// Baseline subject, when the update names one.
+    pub subject: Option<SubjectReferenceV1>,
+    /// Direct geometry, when the update supplies it.
+    pub geometry: Option<UpdateGeometryV1>,
+}
+
+/// Typed reason that geometry resolution did not supply geometry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "reason")]
+pub enum ResolutionFailureReasonV1 {
+    /// The identifier belongs to a different Navdata cycle.
+    IdentifierFromAnotherCycle {
+        /// Cycle named by the update.
+        subject_cycle: String,
+        /// Cycle used by the resolver.
+        snapshot_cycle: String,
+    },
+    /// The snapshot has no matching identifier in the selected family.
+    UnknownIdentifier {
+        /// Selected subject family.
+        family: SubjectFamilyV1,
+        /// Identifier that did not match.
+        identifier: String,
+    },
+    /// The identifier matches more than one baseline subject.
+    AmbiguousMatch {
+        /// Selected subject family.
+        family: SubjectFamilyV1,
+        /// Identifier that matched more than once.
+        identifier: String,
+        /// Number of matches.
+        matches: u32,
+    },
+    /// The Navdata snapshot does not contain this subject family.
+    SubjectFamilyNotCarried {
+        /// Family that is not carried.
+        family: SubjectFamilyV1,
+    },
+    /// The snapshot contains the subject but not useful horizontal geometry.
+    GeometryNotCarried {
+        /// Subject family.
+        family: SubjectFamilyV1,
+        /// Identifier of the subject without geometry.
+        identifier: String,
+    },
+    /// The snapshot cannot make geometry for the stated partial extent.
+    PartialGeometryNotCarried {
+        /// Subject family.
+        family: SubjectFamilyV1,
+        /// Identifier of the partial subject.
+        identifier: String,
+        /// Partial extent that must not become whole-subject geometry.
+        extent: SubjectExtentV1,
+    },
+    /// Direct geometry describes a different extent from the named subject.
+    DirectGeometryExtentMismatch {
+        /// Extent named by the update subject.
+        subject_extent: SubjectExtentV1,
+        /// Extent declared for the direct geometry.
+        geometry_coverage: GeometryCoverageV1,
+    },
+}
+
+/// Geometry produced for one update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedGeometryV1 {
+    /// Horizontal geometry.
+    pub geometry: GeometryV1,
+    /// Subject extent represented by the geometry.
+    pub coverage: GeometryCoverageV1,
+}
+
+/// How an update acquired, or did not acquire, geometry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum GeometryResolutionV1 {
+    /// The update supplied its own geometry. No lookup occurred.
+    Direct,
+    /// AirspaceView resolved the subject against the named snapshot.
+    ResolvedFromNavdata,
+    /// Baseline resolution failed for a typed reason.
+    Unresolved {
+        /// Reason that geometry is absent.
+        reason: ResolutionFailureReasonV1,
+    },
+    /// The update names no subject geometry.
+    NoSubjectGeometry,
+}
+
+/// One update in the derived AirspaceView result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AirspaceViewItemV1 {
+    /// Stable update identity.
+    pub update_id: String,
+    /// Complete text for the required non-map surface.
+    pub display_text: String,
+    /// Cycle-scoped baseline subject identity, when a subject exists.
+    pub subject_identity: Option<SubjectIdentityV1>,
+    /// Geometry when direct input or baseline resolution supplied it.
+    pub geometry: Option<ResolvedGeometryV1>,
+    /// Resolution disposition.
+    pub resolution: GeometryResolutionV1,
+}
+
+/// Contract statement about the role of the map surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "role")]
+pub enum MapCompletenessV1 {
+    /// The map is supplemental. A list must show every update.
+    SupplementalOnly {
+        /// Number of result items that have no geometry.
+        updates_without_geometry: u32,
+    },
+}
+
+/// Complete derived result for one Navdata snapshot and update set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AirspaceViewResultV1 {
+    /// Contract schema version.
+    pub schema_version: u16,
+    /// Identity of the one snapshot used for all resolution.
+    pub navdata_identity: NavdataIdentityV1,
+    /// Every input update in input order.
+    pub updates: Vec<AirspaceViewItemV1>,
+    /// The map is never the only update surface.
+    pub map_completeness: MapCompletenessV1,
+}

--- a/crates/pilotage-airspace-view/src/resolve.rs
+++ b/crates/pilotage-airspace-view/src/resolve.rs
@@ -1,0 +1,270 @@
+//! Stateless resolution of update subjects against one Navdata snapshot.
+
+use aerocontext_core::{NavDataSnapshot, NavPoint, NavPointKind};
+
+use crate::{
+    AIRSPACE_VIEW_SCHEMA_VERSION, AeronauticalUpdateV1, AirspaceViewItemV1, AirspaceViewResultV1,
+    GeometryCoverageV1, GeometryResolutionV1, GeometryV1, IdentifiedNavdataSnapshotV1,
+    MapCompletenessV1, ResolutionFailureReasonV1, ResolvedGeometryV1, SubjectExtentV1,
+    SubjectFamilyV1, SubjectIdentityV1, SubjectReferenceV1,
+};
+
+/// Stateless AirspaceView resolver.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AirspaceViewV1;
+
+impl AirspaceViewV1 {
+    /// Resolves all updates against exactly one immutable Navdata snapshot.
+    #[must_use]
+    pub fn derive(
+        snapshot: &IdentifiedNavdataSnapshotV1,
+        updates: &[AeronauticalUpdateV1],
+    ) -> AirspaceViewResultV1 {
+        let items: Vec<AirspaceViewItemV1> = updates
+            .iter()
+            .map(|update| derive_item(snapshot, update))
+            .collect();
+        let updates_without_geometry = items.iter().fold(0_u32, |count, item| {
+            if item.geometry.is_none() {
+                count.wrapping_add(1)
+            } else {
+                count
+            }
+        });
+        AirspaceViewResultV1 {
+            schema_version: AIRSPACE_VIEW_SCHEMA_VERSION,
+            navdata_identity: snapshot.identity().clone(),
+            updates: items,
+            map_completeness: MapCompletenessV1::SupplementalOnly {
+                updates_without_geometry,
+            },
+        }
+    }
+}
+
+fn derive_item(
+    snapshot: &IdentifiedNavdataSnapshotV1,
+    update: &AeronauticalUpdateV1,
+) -> AirspaceViewItemV1 {
+    let subject_identity = update.subject.as_ref().map(SubjectIdentityV1::from);
+    if let Some(direct) = &update.geometry {
+        if let Some(reason) = direct_geometry_mismatch(update, &direct.coverage) {
+            return item(
+                update,
+                subject_identity,
+                None,
+                GeometryResolutionV1::Unresolved { reason },
+            );
+        }
+        return item(
+            update,
+            subject_identity,
+            Some(ResolvedGeometryV1 {
+                geometry: direct.geometry.clone(),
+                coverage: direct.coverage.clone(),
+            }),
+            GeometryResolutionV1::Direct,
+        );
+    }
+    let Some(subject) = &update.subject else {
+        return item(
+            update,
+            subject_identity,
+            None,
+            GeometryResolutionV1::NoSubjectGeometry,
+        );
+    };
+    match resolve_subject(snapshot, subject) {
+        Ok(geometry) => item(
+            update,
+            subject_identity,
+            Some(geometry),
+            GeometryResolutionV1::ResolvedFromNavdata,
+        ),
+        Err(reason) => item(
+            update,
+            subject_identity,
+            None,
+            GeometryResolutionV1::Unresolved { reason },
+        ),
+    }
+}
+
+fn direct_geometry_mismatch(
+    update: &AeronauticalUpdateV1,
+    coverage: &GeometryCoverageV1,
+) -> Option<ResolutionFailureReasonV1> {
+    let subject = update.subject.as_ref()?;
+    let matches = match (&subject.extent, coverage) {
+        (SubjectExtentV1::Whole, GeometryCoverageV1::WholeSubject) => true,
+        (subject_extent, GeometryCoverageV1::Partial { extent }) => subject_extent == extent,
+        _ => false,
+    };
+    (!matches).then(|| ResolutionFailureReasonV1::DirectGeometryExtentMismatch {
+        subject_extent: subject.extent.clone(),
+        geometry_coverage: coverage.clone(),
+    })
+}
+
+fn item(
+    update: &AeronauticalUpdateV1,
+    subject_identity: Option<SubjectIdentityV1>,
+    geometry: Option<ResolvedGeometryV1>,
+    resolution: GeometryResolutionV1,
+) -> AirspaceViewItemV1 {
+    AirspaceViewItemV1 {
+        update_id: update.update_id.clone(),
+        display_text: update.display_text.clone(),
+        subject_identity,
+        geometry,
+        resolution,
+    }
+}
+
+fn resolve_subject(
+    snapshot: &IdentifiedNavdataSnapshotV1,
+    subject: &SubjectReferenceV1,
+) -> Result<ResolvedGeometryV1, ResolutionFailureReasonV1> {
+    if subject.cycle != snapshot.identity().cycle {
+        return Err(ResolutionFailureReasonV1::IdentifierFromAnotherCycle {
+            subject_cycle: subject.cycle.clone(),
+            snapshot_cycle: snapshot.identity().cycle.clone(),
+        });
+    }
+    match subject.family {
+        SubjectFamilyV1::Aerodrome | SubjectFamilyV1::Navaid | SubjectFamilyV1::Fix => {
+            resolve_point(snapshot.snapshot(), subject)
+        }
+        SubjectFamilyV1::Runway => resolve_runway(snapshot.snapshot(), subject),
+        SubjectFamilyV1::Airspace => resolve_airspace(snapshot.snapshot(), subject),
+        SubjectFamilyV1::Procedure | SubjectFamilyV1::Service | SubjectFamilyV1::Other => {
+            Err(ResolutionFailureReasonV1::SubjectFamilyNotCarried {
+                family: subject.family,
+            })
+        }
+    }
+}
+
+fn resolve_point(
+    snapshot: &NavDataSnapshot,
+    subject: &SubjectReferenceV1,
+) -> Result<ResolvedGeometryV1, ResolutionFailureReasonV1> {
+    let matches: Vec<&NavPoint> = snapshot
+        .points
+        .iter()
+        .filter(|point| point_matches(point, subject))
+        .collect();
+    let point = one_match(subject, &matches)?;
+    require_whole_extent(subject)?;
+    Ok(ResolvedGeometryV1 {
+        geometry: GeometryV1::Point {
+            position: point.position,
+        },
+        coverage: GeometryCoverageV1::WholeSubject,
+    })
+}
+
+fn point_matches(point: &NavPoint, subject: &SubjectReferenceV1) -> bool {
+    point.ident.eq_ignore_ascii_case(&subject.identifier)
+        && subject.region.as_deref().is_none_or(|region| {
+            point
+                .region
+                .as_deref()
+                .is_some_and(|point_region| point_region.eq_ignore_ascii_case(region))
+        })
+        && matches!(
+            (&point.kind, subject.family),
+            (NavPointKind::Airport, SubjectFamilyV1::Aerodrome)
+                | (NavPointKind::Navaid, SubjectFamilyV1::Navaid)
+                | (NavPointKind::Waypoint, SubjectFamilyV1::Fix)
+        )
+}
+
+fn resolve_runway(
+    snapshot: &NavDataSnapshot,
+    subject: &SubjectReferenceV1,
+) -> Result<ResolvedGeometryV1, ResolutionFailureReasonV1> {
+    let parent = subject.parent_identifier.as_deref().unwrap_or("");
+    let matches: Vec<_> = snapshot
+        .runways
+        .iter()
+        .filter(|runway| {
+            runway.airport_ident.eq_ignore_ascii_case(parent)
+                && runway.designator.eq_ignore_ascii_case(&subject.identifier)
+        })
+        .collect();
+    one_match(subject, &matches)?;
+    match &subject.extent {
+        SubjectExtentV1::Whole => Err(ResolutionFailureReasonV1::GeometryNotCarried {
+            family: subject.family,
+            identifier: subject.identifier.clone(),
+        }),
+        extent => Err(ResolutionFailureReasonV1::PartialGeometryNotCarried {
+            family: subject.family,
+            identifier: subject.identifier.clone(),
+            extent: extent.clone(),
+        }),
+    }
+}
+
+fn resolve_airspace(
+    snapshot: &NavDataSnapshot,
+    subject: &SubjectReferenceV1,
+) -> Result<ResolvedGeometryV1, ResolutionFailureReasonV1> {
+    let matches: Vec<_> = snapshot
+        .airspaces
+        .iter()
+        .filter(|airspace| {
+            airspace
+                .designator
+                .eq_ignore_ascii_case(&subject.identifier)
+        })
+        .collect();
+    let airspace = one_match(subject, &matches)?;
+    require_whole_extent(subject)?;
+    let area =
+        airspace
+            .bounds
+            .clone()
+            .ok_or_else(|| ResolutionFailureReasonV1::GeometryNotCarried {
+                family: subject.family,
+                identifier: subject.identifier.clone(),
+            })?;
+    Ok(ResolvedGeometryV1 {
+        geometry: GeometryV1::Area { area },
+        coverage: GeometryCoverageV1::WholeSubject,
+    })
+}
+
+fn require_whole_extent(subject: &SubjectReferenceV1) -> Result<(), ResolutionFailureReasonV1> {
+    match &subject.extent {
+        SubjectExtentV1::Whole => Ok(()),
+        extent => Err(ResolutionFailureReasonV1::PartialGeometryNotCarried {
+            family: subject.family,
+            identifier: subject.identifier.clone(),
+            extent: extent.clone(),
+        }),
+    }
+}
+
+fn one_match<'a, T>(
+    subject: &SubjectReferenceV1,
+    matches: &[&'a T],
+) -> Result<&'a T, ResolutionFailureReasonV1> {
+    match matches {
+        [] => Err(ResolutionFailureReasonV1::UnknownIdentifier {
+            family: subject.family,
+            identifier: subject.identifier.clone(),
+        }),
+        [value] => Ok(*value),
+        _ => Err(ResolutionFailureReasonV1::AmbiguousMatch {
+            family: subject.family,
+            identifier: subject.identifier.clone(),
+            matches: bounded_match_count(matches.len()),
+        }),
+    }
+}
+
+fn bounded_match_count(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
+}

--- a/crates/pilotage-airspace-view/src/tests.rs
+++ b/crates/pilotage-airspace-view/src/tests.rs
@@ -1,0 +1,49 @@
+//! AirspaceView contract tests.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod resolution;
+
+use aerocontext_core::{GeoPoint, NavDataCycle, NavDataSnapshot, NavPoint, NavPointKind};
+use chrono::NaiveDate;
+
+use crate::{
+    AeronauticalUpdateV1, IdentifiedNavdataSnapshotV1, NavdataIdentityV1, SubjectExtentV1,
+    SubjectFamilyV1, SubjectReferenceV1, navdata_cycle_id,
+};
+
+fn snapshot(effective_on: NaiveDate, points: Vec<NavPoint>) -> IdentifiedNavdataSnapshotV1 {
+    let cycle = NavDataCycle::faa_nasr(effective_on).expect("test cycle must be valid");
+    let snapshot = NavDataSnapshot::new(cycle, points);
+    let identity = NavdataIdentityV1 {
+        cycle: navdata_cycle_id(&snapshot),
+        snapshot_id: format!("snapshot-{effective_on}"),
+        snapshot_digest: format!("digest-{effective_on}"),
+    };
+    IdentifiedNavdataSnapshotV1::try_new(identity, snapshot)
+        .expect("test identity must match the snapshot")
+}
+
+fn navaid(ident: &str, lat: f64) -> NavPoint {
+    NavPoint::new(ident, NavPointKind::Navaid, GeoPoint { lat, lon: -71.0 })
+}
+
+fn subject(cycle: &str, family: SubjectFamilyV1, identifier: &str) -> SubjectReferenceV1 {
+    SubjectReferenceV1 {
+        cycle: cycle.to_owned(),
+        family,
+        identifier: identifier.to_owned(),
+        parent_identifier: None,
+        region: None,
+        extent: SubjectExtentV1::Whole,
+    }
+}
+
+fn update(subject: Option<SubjectReferenceV1>) -> AeronauticalUpdateV1 {
+    AeronauticalUpdateV1 {
+        update_id: "update-1".into(),
+        display_text: "Facility status changed".into(),
+        subject,
+        geometry: None,
+    }
+}

--- a/crates/pilotage-airspace-view/src/tests/resolution.rs
+++ b/crates/pilotage-airspace-view/src/tests/resolution.rs
@@ -1,0 +1,269 @@
+//! Resolution behavior for all three subject cases.
+
+use aerocontext_core::{GeoPoint, NavDataCycle, NavDataSnapshot, Runway};
+use chrono::NaiveDate;
+
+use super::{navaid, snapshot, subject, update};
+use crate::{
+    AeronauticalUpdateV1, AirspaceViewError, AirspaceViewV1, GeometryCoverageV1,
+    GeometryResolutionV1, GeometryV1, IdentifiedNavdataSnapshotV1, MapCompletenessV1,
+    NavdataIdentityV1, ResolutionFailureReasonV1, SubjectExtentV1, SubjectFamilyV1,
+    UpdateGeometryV1, navdata_cycle_id,
+};
+
+#[test]
+fn direct_geometry_skips_subject_resolution() {
+    let snapshot = snapshot(date(2026, 1, 22), Vec::new());
+    let mut update = update(Some(subject(
+        "another-cycle",
+        SubjectFamilyV1::Procedure,
+        "IAP-1",
+    )));
+    update.geometry = Some(UpdateGeometryV1 {
+        geometry: GeometryV1::Point {
+            position: GeoPoint {
+                lat: 42.0,
+                lon: -71.0,
+            },
+        },
+        coverage: GeometryCoverageV1::WholeSubject,
+    });
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert!(result.updates[0].geometry.is_some());
+    assert_eq!(result.updates[0].resolution, GeometryResolutionV1::Direct);
+    assert_eq!(
+        result.updates[0]
+            .subject_identity
+            .as_ref()
+            .map(|identity| identity.cycle.as_str()),
+        Some("another-cycle")
+    );
+}
+
+#[test]
+fn direct_geometry_cannot_enlarge_a_partial_subject() {
+    let snapshot = snapshot(date(2026, 1, 22), Vec::new());
+    let mut partial = subject(
+        &snapshot.identity().cycle,
+        SubjectFamilyV1::Runway,
+        "04L/22R",
+    );
+    partial.extent = SubjectExtentV1::RunwaySegment {
+        from_end: "04L".into(),
+        start_offset_ft: 0,
+        length_ft: 1_000,
+    };
+    let mut update = update(Some(partial));
+    update.geometry = Some(UpdateGeometryV1 {
+        geometry: GeometryV1::Point {
+            position: GeoPoint {
+                lat: 42.0,
+                lon: -71.0,
+            },
+        },
+        coverage: GeometryCoverageV1::WholeSubject,
+    });
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert!(result.updates[0].geometry.is_none());
+    assert!(matches!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::DirectGeometryExtentMismatch { .. }
+        }
+    ));
+}
+
+#[test]
+fn unresolved_update_stays_in_the_result_without_geometry() {
+    let snapshot = snapshot(date(2026, 1, 22), Vec::new());
+    let update = update(Some(subject(
+        &snapshot.identity().cycle,
+        SubjectFamilyV1::Navaid,
+        "MISSING",
+    )));
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert_eq!(result.updates.len(), 1);
+    assert!(result.updates[0].geometry.is_none());
+    assert!(matches!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::UnknownIdentifier { .. }
+        }
+    ));
+    assert_eq!(
+        result.map_completeness,
+        MapCompletenessV1::SupplementalOnly {
+            updates_without_geometry: 1
+        }
+    );
+}
+
+#[test]
+fn one_update_has_cycle_scoped_results() {
+    let first = snapshot(date(2026, 1, 22), vec![navaid("BOS", 42.3)]);
+    let second = snapshot(date(2026, 2, 19), vec![navaid("BOS", 42.4)]);
+    let update = update(Some(subject(
+        &first.identity().cycle,
+        SubjectFamilyV1::Navaid,
+        "BOS",
+    )));
+
+    let first_result = AirspaceViewV1::derive(&first, std::slice::from_ref(&update));
+    let second_result = AirspaceViewV1::derive(&second, &[update]);
+
+    assert_eq!(
+        first_result.updates[0].resolution,
+        GeometryResolutionV1::ResolvedFromNavdata
+    );
+    assert!(matches!(
+        second_result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::IdentifierFromAnotherCycle { .. }
+        }
+    ));
+}
+
+#[test]
+fn duplicate_identifier_is_typed_as_ambiguous() {
+    let snapshot = snapshot(
+        date(2026, 1, 22),
+        vec![navaid("DUP", 42.0), navaid("DUP", 43.0)],
+    );
+    let update = update(Some(subject(
+        &snapshot.identity().cycle,
+        SubjectFamilyV1::Navaid,
+        "DUP",
+    )));
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert!(matches!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::AmbiguousMatch { matches: 2, .. }
+        }
+    ));
+}
+
+#[test]
+fn unsupported_subject_family_is_typed_and_kept() {
+    let snapshot = snapshot(date(2026, 1, 22), Vec::new());
+    let update = update(Some(subject(
+        &snapshot.identity().cycle,
+        SubjectFamilyV1::Procedure,
+        "RNAV-22",
+    )));
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert!(matches!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::SubjectFamilyNotCarried {
+                family: SubjectFamilyV1::Procedure
+            }
+        }
+    ));
+}
+
+#[test]
+fn partial_runway_closure_never_becomes_whole_runway_geometry() {
+    let cycle = NavDataCycle::faa_nasr(date(2026, 1, 22)).expect("test cycle must be valid");
+    let data =
+        NavDataSnapshot::new(cycle, Vec::new()).with_runways(vec![Runway::new("KBOS", "04L/22R")]);
+    let snapshot = identified(data);
+    let mut runway = subject(
+        &snapshot.identity().cycle,
+        SubjectFamilyV1::Runway,
+        "04L/22R",
+    );
+    runway.parent_identifier = Some("KBOS".into());
+    runway.extent = SubjectExtentV1::RunwaySegment {
+        from_end: "04L".into(),
+        start_offset_ft: 0,
+        length_ft: 1_000,
+    };
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update(Some(runway))]);
+
+    assert!(result.updates[0].geometry.is_none());
+    assert!(matches!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::Unresolved {
+            reason: ResolutionFailureReasonV1::PartialGeometryNotCarried { .. }
+        }
+    ));
+}
+
+#[test]
+fn non_geometric_update_requires_the_list_surface() {
+    let snapshot = snapshot(date(2026, 1, 22), Vec::new());
+    let update = AeronauticalUpdateV1 {
+        update_id: "service-1".into(),
+        display_text: "Satellite service unavailable".into(),
+        subject: None,
+        geometry: None,
+    };
+
+    let result = AirspaceViewV1::derive(&snapshot, &[update]);
+
+    assert_eq!(
+        result.updates[0].resolution,
+        GeometryResolutionV1::NoSubjectGeometry
+    );
+    assert!(matches!(
+        result.map_completeness,
+        MapCompletenessV1::SupplementalOnly {
+            updates_without_geometry: 1
+        }
+    ));
+}
+
+#[test]
+fn stable_subject_identity_does_not_hide_cycle_scope() {
+    let first = subject("cycle-a", SubjectFamilyV1::Navaid, " bos ");
+    let second = subject("cycle-b", SubjectFamilyV1::Navaid, "BOS");
+
+    assert_eq!(first.stable_subject_id(), second.stable_subject_id());
+    assert_ne!(first.cycle, second.cycle);
+}
+
+#[test]
+fn inconsistent_snapshot_identity_is_rejected() {
+    let cycle = NavDataCycle::faa_nasr(date(2026, 1, 22)).expect("test cycle must be valid");
+    let data = NavDataSnapshot::new(cycle, Vec::new());
+    let error = IdentifiedNavdataSnapshotV1::try_new(
+        NavdataIdentityV1 {
+            cycle: "faa-nasr:2026-02-19".into(),
+            snapshot_id: "snapshot".into(),
+            snapshot_digest: "digest".into(),
+        },
+        data,
+    )
+    .expect_err("a mismatched cycle must fail");
+
+    assert!(matches!(
+        error,
+        AirspaceViewError::SnapshotCycleMismatch { .. }
+    ));
+}
+
+fn identified(data: NavDataSnapshot) -> IdentifiedNavdataSnapshotV1 {
+    let identity = NavdataIdentityV1 {
+        cycle: navdata_cycle_id(&data),
+        snapshot_id: "snapshot".into(),
+        snapshot_digest: "digest".into(),
+    };
+    IdentifiedNavdataSnapshotV1::try_new(identity, data)
+        .expect("test identity must match the snapshot")
+}
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid")
+}

--- a/docs/airspace-view-resolution-contract.md
+++ b/docs/airspace-view-resolution-contract.md
@@ -1,0 +1,75 @@
+# AirspaceView resolution contract
+
+This contract defines how `AirspaceViewV1` adds horizontal geometry to an
+aeronautical update.
+
+## Owner
+
+`pilotage-airspace-view` owns subject resolution.
+The `AeronauticalUpdates` domain owns each update.
+The Navdata domain owns each baseline snapshot.
+The resolver owns no mutable state.
+The resolver reads one immutable Navdata snapshot for one result.
+
+## Snapshot identity
+
+The result contains the Navdata cycle, snapshot ID, and snapshot digest.
+The resolver verifies that the supplied cycle identifies the snapshot data.
+An update subject also contains a Navdata cycle.
+The resolver does not use an identifier with a different cycle.
+The result keeps the subject cycle and stable identifier together.
+
+## Geometry cases
+
+An update can contain direct geometry.
+The resolver uses direct geometry without a baseline lookup.
+
+An update can name a baseline subject.
+The resolver looks for that subject in the selected snapshot.
+The result contains the stable subject identifier when a subject exists.
+
+An update can have no useful horizontal geometry.
+The resolver keeps this update in the result.
+The item has no geometry.
+The item contains a typed disposition.
+
+## Typed failures
+
+The result uses a typed reason for each failed lookup.
+The reasons include these conditions:
+
+- the identifier belongs to another cycle;
+- the identifier is unknown;
+- the identifier has more than one match;
+- the snapshot does not carry the subject family;
+- the snapshot carries the subject but not its geometry; and
+- the snapshot cannot make the stated partial geometry.
+
+A failed lookup does not remove the update.
+
+## Partial subjects
+
+The resolver does not enlarge a partial subject to a complete subject.
+The `RunwaySegment` extent identifies a measured part of a runway.
+The `FacilityComponent` extent identifies one facility component.
+Direct partial geometry uses `GeometryCoverageV1::Partial`.
+A direct geometry extent must equal the subject extent.
+An extent mismatch returns `DirectGeometryExtentMismatch` and no geometry.
+A baseline that cannot make the partial geometry returns
+`PartialGeometryNotCarried`.
+
+FAA NOTAM examples include a closure of the first 1,000 feet of one runway.
+FAA guidance also identifies approach-light components as separate outages.
+These records do not mean that the complete runway is closed.
+
+Sources:
+
+- [FAA NOTAM examples](https://www.faa.gov/air_traffic/publications/atpubs/notam_html/appendix_a.html)
+- [FAA lighting aid NOTAM guidance](https://www.faa.gov/air_traffic/publications/atpubs/notam_html/chap5_section_2.html)
+
+## Client rule
+
+A map is supplemental.
+It is not a complete view of aeronautical updates.
+The client must show a list that contains every result item.
+An empty map does not mean that no update applies.

--- a/scripts/check-airspace-view-contract.sh
+++ b/scripts/check-airspace-view-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Keep the AirspaceView resolver stateless, source-neutral, and map-independent.
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+crate="$root/crates/pilotage-airspace-view"
+model="$crate/src/model.rs"
+resolver="$crate/src/resolve.rs"
+contract="$root/docs/airspace-view-resolution-contract.md"
+status=0
+
+require_text() {
+    local pattern="$1"
+    local file="$2"
+    local message="$3"
+    if [ ! -f "$file" ] || ! grep -qF "$pattern" "$file"; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+if [ -d "$crate" ] && grep -RInE 'MapLibre|MLN[A-Z]|UIKit|SwiftUI|GeoJSON' "$crate"; then
+    echo "FORBIDDEN: AirspaceView names a display implementation" >&2
+    status=1
+fi
+
+require_text 'pub struct AirspaceViewV1;' "$resolver" \
+    'AirspaceView must remain a stateless derived resolver'
+require_text 'pub struct SubjectIdentityV1' "$model" \
+    'a stable subject identifier must retain its Navdata cycle'
+require_text 'IdentifierFromAnotherCycle' "$model" \
+    'cycle mismatch must remain a typed resolution failure'
+require_text 'PartialGeometryNotCarried' "$model" \
+    'partial geometry must fail explicitly when the baseline cannot supply it'
+require_text 'DirectGeometryExtentMismatch' "$model" \
+    'direct geometry must not enlarge a partial subject'
+require_text 'SupplementalOnly' "$model" \
+    'the result must state that a map is supplemental'
+require_text 'The resolver does not enlarge a partial subject to a complete subject.' "$contract" \
+    'the partial-subject rule is missing from the contract'
+require_text 'An empty map does not mean that no update applies.' "$contract" \
+    'the contract does not require a complete non-map surface'
+
+if [ "$status" -ne 0 ]; then
+    echo "AirspaceView contract: FAILED" >&2
+    exit 1
+fi
+
+echo "AirspaceView contract: OK"

--- a/scripts/test-check-airspace-view-contract.sh
+++ b/scripts/test-check-airspace-view-contract.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Exercise the failure paths in the AirspaceView contract guard.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-airspace-view.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/crates" "$fixture/docs"
+cp -R "$repo_root/crates/pilotage-airspace-view" "$fixture/crates/"
+cp "$repo_root/docs/airspace-view-resolution-contract.md" "$fixture/docs/"
+
+bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null
+
+printf '%s\n' 'pub const ENGINE: &str = "MapLibre";' \
+    >> "$fixture/crates/pilotage-airspace-view/src/resolve.rs"
+if bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a display implementation" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-airspace-view/src/resolve.rs" \
+    "$fixture/crates/pilotage-airspace-view/src/resolve.rs"
+
+sed -i.bak '/IdentifierFromAnotherCycle/d' \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+if bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a missing cycle failure" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-airspace-view/src/model.rs" \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+
+sed -i.bak '/DirectGeometryExtentMismatch/d' \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+if bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted direct geometry that can enlarge a partial subject" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-airspace-view/src/model.rs" \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+
+sed -i.bak '/pub struct SubjectIdentityV1/d' \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+if bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a subject identifier without its cycle" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-airspace-view/src/model.rs" \
+    "$fixture/crates/pilotage-airspace-view/src/model.rs"
+
+sed -i.bak '/does not enlarge a partial subject/d' \
+    "$fixture/docs/airspace-view-resolution-contract.md"
+if bash "$repo_root/scripts/check-airspace-view-contract.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a missing partial-subject rule" >&2
+    exit 1
+fi
+
+echo "AirspaceView contract self-test: OK"


### PR DESCRIPTION
Closes #349.

## Summary

- Add a stateless `AirspaceViewV1` resolver.
- Bind each result to one Navdata cycle, snapshot ID, and digest.
- Keep the subject cycle with each stable subject ID.
- Keep unresolved updates in the result with typed reasons and no geometry.
- State that the map is supplemental and that the client must show every update on a list.

## Partial subjects

- Keep a partial runway or facility component typed as partial.
- Do not enlarge a partial subject to the complete subject.
- Reject inconsistent direct geometry with a typed reason.
- Return a typed reason when the baseline cannot make partial geometry.

The contract uses the [FAA NOTAM examples](https://www.faa.gov/air_traffic/publications/atpubs/notam_html/appendix_a.html) and the [FAA lighting aid NOTAM guidance](https://www.faa.gov/air_traffic/publications/atpubs/notam_html/chap5_section_2.html).

## Guardrail

- Add a self-tested CI guard for the stateless, source-neutral, and map-independent boundary.
- Guard cycle retention, typed partial failures, supplemental map status, and the required list surface.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- All repository contract guards
- All Node and browser conformance tests
- Apple instrument consumer checks
- iOS situation package checks
- `buf lint schemas`