### PR TITLE
Build a per-cycle Navdata tile bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
       - name: AirspaceView contract
         run: bash scripts/check-airspace-view-contract.sh
 
+      - name: Navdata tile bundle guard self-test
+        run: bash scripts/test-check-navdata-tile-bundle.sh
+
+      - name: Navdata tile bundle guard
+        run: bash scripts/check-navdata-tile-bundle.sh
+
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D missing_docs -D rustdoc::broken_intra_doc_links"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-navdata-tiles"
+version = "0.1.0"
+dependencies = [
+ "aerocontext-core",
+ "aerocontext-navdata",
+ "chrono",
+ "flate2",
+ "pilotage-airspace-view",
+ "prost",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-presentation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/pilotage-conformance",
     "crates/pilotage-situation-view",
     "crates/pilotage-airspace-view",
+    "crates/pilotage-navdata-tiles",
     "crates/pilotage-calibration-id",
     "crates/pilotage-camera-calibration",
     "crates/pilotage-geo",
@@ -83,6 +84,7 @@ png = "0.18.1"
 rusqlite = { version = "0.40.2", default-features = false, features = ["bundled", "serialize"] }
 prost = "0.14.4"
 prost-build = "0.14.4"
+flate2 = "1.1.9"
 libm = "0.2.16"
 libc = "0.2.177"
 wasm-bindgen = "=0.2.126"
@@ -105,6 +107,7 @@ pilotage-adapter-api = { path = "crates/pilotage-adapter-api" }
 pilotage-mavlink = { path = "crates/pilotage-mavlink" }
 pilotage-situation-view = { path = "crates/pilotage-situation-view" }
 pilotage-airspace-view = { path = "crates/pilotage-airspace-view" }
+pilotage-navdata-tiles = { path = "crates/pilotage-navdata-tiles" }
 pilotage-calibration-id = { path = "crates/pilotage-calibration-id" }
 pilotage-camera-calibration = { path = "crates/pilotage-camera-calibration" }
 pilotage-geo = { path = "crates/pilotage-geo" }

--- a/crates/pilotage-airspace-view/src/model.rs
+++ b/crates/pilotage-airspace-view/src/model.rs
@@ -50,7 +50,9 @@ impl IdentifiedNavdataSnapshotV1 {
         &self.identity
     }
 
-    pub(crate) const fn snapshot(&self) -> &NavDataSnapshot {
+    /// Gets the immutable Navdata snapshot.
+    #[must_use]
+    pub const fn snapshot(&self) -> &NavDataSnapshot {
         &self.snapshot
     }
 }

--- a/crates/pilotage-navdata-tiles/Cargo.toml
+++ b/crates/pilotage-navdata-tiles/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pilotage-navdata-tiles"
+version = "0.1.0"
+edition.workspace = true
+description = "Deterministic offline Navdata vector MBTiles builder"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+aerocontext-core = { workspace = true }
+flate2 = { workspace = true }
+pilotage-airspace-view = { workspace = true }
+prost = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+aerocontext-navdata = { workspace = true }
+chrono = { workspace = true }

--- a/crates/pilotage-navdata-tiles/examples/build_navdata_tiles.rs
+++ b/crates/pilotage-navdata-tiles/examples/build_navdata_tiles.rs
@@ -1,0 +1,116 @@
+//! Builds one measured Navdata baseline archive from an `.acnav` snapshot blob.
+
+use std::error::Error;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use pilotage_airspace_view::{IdentifiedNavdataSnapshotV1, NavdataIdentityV1, navdata_cycle_id};
+use pilotage_navdata_tiles::{NavdataTileConfig, build_mbtiles};
+use sha2::{Digest, Sha256};
+
+#[derive(serde::Serialize)]
+struct Measurement {
+    cycle: String,
+    snapshot_id: String,
+    snapshot_digest: String,
+    source_format_version: u16,
+    source_blob_bytes: u64,
+    source_points: u64,
+    source_airways: u64,
+    source_runways: u64,
+    source_airspaces: u64,
+    output_file: String,
+    output_sha256: String,
+    elapsed_milliseconds: u128,
+    report: pilotage_navdata_tiles::NavdataTileReport,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let (input, output) = arguments()?;
+    let blob = fs::read(&input)?;
+    let source_blob_bytes = blob.len() as u64;
+    let info = aerocontext_navdata::inspect(&blob)?;
+    let digest = info.sha256_hex();
+    let cycle = navdata_cycle_id(&info.snapshot);
+    let identity = NavdataIdentityV1 {
+        cycle: cycle.clone(),
+        snapshot_id: format!("{cycle}:sha256:{digest}"),
+        snapshot_digest: format!("sha256:{digest}"),
+    };
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(identity, info.snapshot)?;
+    let started = Instant::now();
+    let bundle = build_mbtiles(&snapshot, NavdataTileConfig::default())?;
+    let elapsed_milliseconds = started.elapsed().as_millis();
+    fs::write(&output, bundle.bytes())?;
+    let measurement = measurement(
+        &output,
+        info.format_version,
+        source_blob_bytes,
+        &snapshot,
+        bundle.report(),
+        elapsed_milliseconds,
+        bundle.bytes(),
+    );
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+    serde_json::to_writer_pretty(&mut writer, &measurement)?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn arguments() -> Result<(PathBuf, PathBuf), io::Error> {
+    let mut arguments = std::env::args_os().skip(1);
+    let input = arguments
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing input .acnav path"))?;
+    let output = arguments.next().map(PathBuf::from).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "missing output .mbtiles path")
+    })?;
+    if arguments.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected input and output paths only",
+        ));
+    }
+    Ok((input, output))
+}
+
+fn measurement(
+    output: &Path,
+    source_format_version: u16,
+    source_blob_bytes: u64,
+    snapshot: &IdentifiedNavdataSnapshotV1,
+    report: &pilotage_navdata_tiles::NavdataTileReport,
+    elapsed_milliseconds: u128,
+    bytes: &[u8],
+) -> Measurement {
+    let navdata = snapshot.snapshot();
+    Measurement {
+        cycle: snapshot.identity().cycle.clone(),
+        snapshot_id: snapshot.identity().snapshot_id.clone(),
+        snapshot_digest: snapshot.identity().snapshot_digest.clone(),
+        source_format_version,
+        source_blob_bytes,
+        source_points: navdata.points.len() as u64,
+        source_airways: navdata.airways.len() as u64,
+        source_runways: navdata.runways.len() as u64,
+        source_airspaces: navdata.airspaces.len() as u64,
+        output_file: output.file_name().map_or_else(
+            || output.display().to_string(),
+            |name| name.to_string_lossy().into(),
+        ),
+        output_sha256: hex_digest(bytes),
+        elapsed_milliseconds,
+        report: *report,
+    }
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/crates/pilotage-navdata-tiles/src/archive.rs
+++ b/crates/pilotage-navdata-tiles/src/archive.rs
@@ -1,0 +1,254 @@
+//! Canonical MBTiles 1.3 schema and serialization.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use flate2::{Compression, GzBuilder};
+use pilotage_airspace_view::NavdataIdentityV1;
+use rusqlite::{Connection, MAIN_DB, params};
+
+use crate::config::NavdataTileConfig;
+use crate::feature::LayerKind;
+use crate::mercator::TileCoord;
+use crate::mvt::encode_tile;
+use crate::tile::VectorTile;
+use crate::{NAVDATA_TILE_SCHEMA_VERSION, NavdataTileError};
+
+const SCHEMA: &str = "
+    CREATE TABLE metadata (
+        name TEXT PRIMARY KEY NOT NULL,
+        value TEXT NOT NULL
+    ) WITHOUT ROWID;
+    CREATE TABLE tiles (
+        zoom_level INTEGER NOT NULL,
+        tile_column INTEGER NOT NULL,
+        tile_row INTEGER NOT NULL,
+        tile_data BLOB NOT NULL,
+        PRIMARY KEY (zoom_level, tile_column, tile_row)
+    ) WITHOUT ROWID;
+";
+
+struct TileBlob {
+    coord: TileCoord,
+    bytes: Vec<u8>,
+}
+
+pub(crate) fn encode_archive(
+    identity: &NavdataIdentityV1,
+    config: NavdataTileConfig,
+    tiles: &[VectorTile],
+) -> Result<Vec<u8>, NavdataTileError> {
+    let blobs = encode_tiles(tiles)?;
+    let metadata = metadata(identity, config, tiles)?;
+    let mut connection = Connection::open_in_memory().map_err(|source| mbtiles("open", source))?;
+    connection
+        .execute_batch(
+            "PRAGMA page_size = 4096;
+             PRAGMA journal_mode = OFF;
+             PRAGMA synchronous = OFF;
+             PRAGMA auto_vacuum = NONE;",
+        )
+        .map_err(|source| mbtiles("configure", source))?;
+    connection
+        .execute_batch(SCHEMA)
+        .map_err(|source| mbtiles("create schema", source))?;
+    insert_contents(&mut connection, &metadata, &blobs)?;
+    connection
+        .execute_batch("VACUUM;")
+        .map_err(|source| mbtiles("vacuum", source))?;
+    let serialized = connection
+        .serialize(MAIN_DB)
+        .map_err(|source| mbtiles("serialize", source))?;
+    Ok(serialized.to_vec())
+}
+
+fn encode_tiles(tiles: &[VectorTile]) -> Result<Vec<TileBlob>, NavdataTileError> {
+    tiles
+        .iter()
+        .map(|tile| {
+            let encoded = encode_tile(tile)?;
+            let bytes = compress(tile.coord, &encoded)?;
+            Ok(TileBlob {
+                coord: tile.coord,
+                bytes,
+            })
+        })
+        .collect()
+}
+
+fn compress(coord: TileCoord, bytes: &[u8]) -> Result<Vec<u8>, NavdataTileError> {
+    let mut encoder = GzBuilder::new()
+        .mtime(0)
+        .operating_system(255)
+        .write(Vec::new(), Compression::best());
+    encoder
+        .write_all(bytes)
+        .map_err(|source| compression_error(coord, source))?;
+    encoder
+        .finish()
+        .map_err(|source| compression_error(coord, source))
+}
+
+fn insert_contents(
+    connection: &mut Connection,
+    metadata: &BTreeMap<&'static str, String>,
+    tiles: &[TileBlob],
+) -> Result<(), NavdataTileError> {
+    let transaction = connection
+        .transaction()
+        .map_err(|source| mbtiles("begin transaction", source))?;
+    insert_metadata(&transaction, metadata)?;
+    insert_tiles(&transaction, tiles)?;
+    transaction
+        .commit()
+        .map_err(|source| mbtiles("commit", source))
+}
+
+fn insert_metadata(
+    transaction: &rusqlite::Transaction<'_>,
+    metadata: &BTreeMap<&'static str, String>,
+) -> Result<(), NavdataTileError> {
+    let mut statement = transaction
+        .prepare("INSERT INTO metadata (name, value) VALUES (?1, ?2)")
+        .map_err(|source| mbtiles("prepare metadata", source))?;
+    for (name, value) in metadata {
+        statement
+            .execute(params![name, value])
+            .map_err(|source| mbtiles("insert metadata", source))?;
+    }
+    Ok(())
+}
+
+fn insert_tiles(
+    transaction: &rusqlite::Transaction<'_>,
+    tiles: &[TileBlob],
+) -> Result<(), NavdataTileError> {
+    let mut statement = transaction
+        .prepare(
+            "INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data)
+             VALUES (?1, ?2, ?3, ?4)",
+        )
+        .map_err(|source| mbtiles("prepare tiles", source))?;
+    for tile in tiles {
+        let width = 1u32 << u32::from(tile.coord.zoom);
+        let tms_row = width.wrapping_sub(1).wrapping_sub(tile.coord.y);
+        statement
+            .execute(params![tile.coord.zoom, tile.coord.x, tms_row, tile.bytes])
+            .map_err(|source| mbtiles("insert tile", source))?;
+    }
+    Ok(())
+}
+
+fn metadata(
+    identity: &NavdataIdentityV1,
+    config: NavdataTileConfig,
+    tiles: &[VectorTile],
+) -> Result<BTreeMap<&'static str, String>, NavdataTileError> {
+    let layer_json = serde_json::to_string(&VectorMetadata::new(config, tiles))
+        .map_err(|source| NavdataTileError::LayerMetadataEncoding { source })?;
+    let min_zoom = tiles.iter().map(|tile| tile.coord.zoom).min().unwrap_or(0);
+    let max_zoom = tiles.iter().map(|tile| tile.coord.zoom).max().unwrap_or(0);
+    Ok(BTreeMap::from([
+        (
+            "bounds",
+            "-180,-85.0511287798066,180,85.0511287798066".to_owned(),
+        ),
+        (
+            "description",
+            "Cycle-scoped aeronautical baseline".to_owned(),
+        ),
+        ("format", "pbf".to_owned()),
+        ("json", layer_json),
+        ("maxzoom", max_zoom.to_string()),
+        ("minzoom", min_zoom.to_string()),
+        ("name", format!("Pilotage Navdata {}", identity.cycle)),
+        ("pilotage_cycle", identity.cycle.clone()),
+        ("pilotage_schema", NAVDATA_TILE_SCHEMA_VERSION.to_string()),
+        ("pilotage_snapshot_digest", identity.snapshot_digest.clone()),
+        ("pilotage_snapshot_id", identity.snapshot_id.clone()),
+        ("type", "baselayer".to_owned()),
+        ("version", NAVDATA_TILE_SCHEMA_VERSION.to_string()),
+    ]))
+}
+
+#[derive(serde::Serialize)]
+struct VectorMetadata {
+    vector_layers: Vec<VectorLayerMetadata>,
+}
+
+impl VectorMetadata {
+    fn new(config: NavdataTileConfig, tiles: &[VectorTile]) -> Self {
+        Self {
+            vector_layers: LayerKind::all()
+                .into_iter()
+                .filter_map(|layer| {
+                    let (minzoom, maxzoom) = layer_zoom_range(tiles, layer)?;
+                    Some(VectorLayerMetadata {
+                        id: layer.name(),
+                        fields: layer_fields(layer),
+                        minzoom: minzoom.max(layer.min_zoom(config)),
+                        maxzoom: maxzoom.min(config.max_zoom),
+                    })
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct VectorLayerMetadata {
+    id: &'static str,
+    fields: BTreeMap<&'static str, &'static str>,
+    minzoom: u8,
+    maxzoom: u8,
+}
+
+fn layer_zoom_range(tiles: &[VectorTile], layer: LayerKind) -> Option<(u8, u8)> {
+    let mut zooms = tiles
+        .iter()
+        .filter(|tile| {
+            tile.layers
+                .get(&layer)
+                .is_some_and(|features| !features.is_empty())
+        })
+        .map(|tile| tile.coord.zoom);
+    let first = zooms.next()?;
+    Some(zooms.fold((first, first), |(minimum, maximum), zoom| {
+        (minimum.min(zoom), maximum.max(zoom))
+    }))
+}
+
+fn layer_fields(layer: LayerKind) -> BTreeMap<&'static str, &'static str> {
+    let mut fields = BTreeMap::from([
+        ("identifier", "String"),
+        ("kind", "String"),
+        ("name", "String"),
+        ("subject_cycle", "String"),
+        ("subject_id", "String"),
+    ]);
+    match layer {
+        LayerKind::Airway => {
+            fields.insert("location", "String");
+        }
+        LayerKind::Airspace => {
+            fields.insert("geometry_quality", "String");
+            fields.insert("lower", "String");
+            fields.insert("upper", "String");
+        }
+        LayerKind::Aerodrome | LayerKind::Navaid | LayerKind::Fix => {}
+    }
+    fields
+}
+
+fn compression_error(coord: TileCoord, source: std::io::Error) -> NavdataTileError {
+    NavdataTileError::TileCompression {
+        zoom: coord.zoom,
+        x: coord.x,
+        y: coord.y,
+        source,
+    }
+}
+
+fn mbtiles(operation: &'static str, source: rusqlite::Error) -> NavdataTileError {
+    NavdataTileError::Mbtiles { operation, source }
+}

--- a/crates/pilotage-navdata-tiles/src/build.rs
+++ b/crates/pilotage-navdata-tiles/src/build.rs
@@ -1,0 +1,49 @@
+//! Top-level deterministic build operation.
+
+use pilotage_airspace_view::{IdentifiedNavdataSnapshotV1, NavdataIdentityV1};
+
+use crate::NavdataTileError;
+use crate::archive::encode_archive;
+use crate::config::NavdataTileConfig;
+use crate::model::{NavdataTileBundle, NavdataTileReport};
+use crate::source::extract_features;
+use crate::tile::partition_features;
+
+/// Builds a deterministic vector MBTiles archive from one identified snapshot.
+///
+/// # Errors
+///
+/// Returns [`NavdataTileError`] if the configuration or identity is invalid.
+/// It also returns an error if a coordinate, vector tile, compression step, or
+/// MBTiles operation fails.
+pub fn build_mbtiles(
+    snapshot: &IdentifiedNavdataSnapshotV1,
+    config: NavdataTileConfig,
+) -> Result<NavdataTileBundle, NavdataTileError> {
+    config.validate()?;
+    validate_identity(snapshot.identity())?;
+    let source = extract_features(snapshot.snapshot(), &snapshot.identity().cycle)?;
+    let tiled = partition_features(&source.features, config);
+    let bytes = encode_archive(snapshot.identity(), config, &tiled.tiles)?;
+    let report = NavdataTileReport {
+        tile_count: tiled.tiles.len() as u64,
+        tile_feature_count: tiled.tile_feature_count,
+        features: source.counts,
+        omitted: source.omitted,
+        archive_bytes: bytes.len() as u64,
+    };
+    Ok(NavdataTileBundle { bytes, report })
+}
+
+fn validate_identity(identity: &NavdataIdentityV1) -> Result<(), NavdataTileError> {
+    for (field, value) in [
+        ("cycle", identity.cycle.as_str()),
+        ("snapshot_id", identity.snapshot_id.as_str()),
+        ("snapshot_digest", identity.snapshot_digest.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(NavdataTileError::EmptyIdentity { field });
+        }
+    }
+    Ok(())
+}

--- a/crates/pilotage-navdata-tiles/src/config.rs
+++ b/crates/pilotage-navdata-tiles/src/config.rs
@@ -1,0 +1,67 @@
+//! Tile build configuration.
+
+use crate::NavdataTileError;
+
+/// Default highest zoom in a Navdata baseline bundle.
+pub const DEFAULT_MAX_ZOOM: u8 = 8;
+
+/// Display scale for each baseline layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NavdataTileConfig {
+    /// First zoom that contains published airspace bounds.
+    pub airspace_min_zoom: u8,
+    /// First zoom that contains airways.
+    pub airway_min_zoom: u8,
+    /// First zoom that contains aerodromes.
+    pub aerodrome_min_zoom: u8,
+    /// First zoom that contains navaids.
+    pub navaid_min_zoom: u8,
+    /// First zoom that contains fixes.
+    pub fix_min_zoom: u8,
+    /// Highest zoom produced for all layers.
+    pub max_zoom: u8,
+}
+
+impl Default for NavdataTileConfig {
+    fn default() -> Self {
+        Self {
+            airspace_min_zoom: 0,
+            airway_min_zoom: 2,
+            aerodrome_min_zoom: 3,
+            navaid_min_zoom: 5,
+            fix_min_zoom: 6,
+            max_zoom: DEFAULT_MAX_ZOOM,
+        }
+    }
+}
+
+impl NavdataTileConfig {
+    pub(crate) fn validate(self) -> Result<(), NavdataTileError> {
+        if self.max_zoom > 14 {
+            return Err(NavdataTileError::InvalidConfig {
+                reason: format!("max_zoom {} is greater than 14", self.max_zoom),
+            });
+        }
+        for (layer, minimum) in self.minimums() {
+            if minimum > self.max_zoom {
+                return Err(NavdataTileError::InvalidConfig {
+                    reason: format!(
+                        "{layer} minimum zoom {minimum} is greater than max_zoom {}",
+                        self.max_zoom
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) const fn minimums(self) -> [(&'static str, u8); 5] {
+        [
+            ("airspace", self.airspace_min_zoom),
+            ("airway", self.airway_min_zoom),
+            ("aerodrome", self.aerodrome_min_zoom),
+            ("navaid", self.navaid_min_zoom),
+            ("fix", self.fix_min_zoom),
+        ]
+    }
+}

--- a/crates/pilotage-navdata-tiles/src/error.rs
+++ b/crates/pilotage-navdata-tiles/src/error.rs
@@ -1,0 +1,107 @@
+//! Typed failures for Navdata tile construction and access.
+
+use std::io;
+use std::path::PathBuf;
+
+/// Failure to build or read a Navdata tile bundle.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum NavdataTileError {
+    /// A tile scale is invalid.
+    #[error("invalid Navdata tile configuration: {reason}")]
+    InvalidConfig {
+        /// Configuration defect.
+        reason: String,
+    },
+    /// A required snapshot identity field is empty.
+    #[error("Navdata identity field {field} is empty")]
+    EmptyIdentity {
+        /// Empty field name.
+        field: &'static str,
+    },
+    /// A coordinate is not valid WGS84 input.
+    #[error("feature {identifier} has invalid WGS84 coordinate ({latitude}, {longitude})")]
+    InvalidCoordinate {
+        /// Published feature identifier.
+        identifier: String,
+        /// Latitude in degrees.
+        latitude: f64,
+        /// Longitude in degrees.
+        longitude: f64,
+    },
+    /// Mapbox Vector Tile encoding failed.
+    #[error("could not encode tile {zoom}/{x}/{y}")]
+    VectorTileEncoding {
+        /// Tile zoom.
+        zoom: u8,
+        /// Tile column.
+        x: u32,
+        /// XYZ tile row.
+        y: u32,
+        /// Protocol Buffer failure.
+        #[source]
+        source: prost::EncodeError,
+    },
+    /// Gzip compression failed.
+    #[error("could not compress tile {zoom}/{x}/{y}")]
+    TileCompression {
+        /// Tile zoom.
+        zoom: u8,
+        /// Tile column.
+        x: u32,
+        /// XYZ tile row.
+        y: u32,
+        /// Compression I/O failure.
+        #[source]
+        source: io::Error,
+    },
+    /// Vector layer metadata encoding failed.
+    #[error("could not encode vector layer metadata")]
+    LayerMetadataEncoding {
+        /// JSON failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// SQLite MBTiles construction or access failed.
+    #[error("MBTiles operation failed during {operation}")]
+    Mbtiles {
+        /// Operation that failed.
+        operation: &'static str,
+        /// SQLite failure.
+        #[source]
+        source: rusqlite::Error,
+    },
+    /// An installed archive could not be read.
+    #[error("could not read Navdata tile bundle {path}")]
+    ArchiveRead {
+        /// Archive path.
+        path: PathBuf,
+        /// File read failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The archive does not contain required metadata.
+    #[error("Navdata tile bundle has no {name} metadata")]
+    MissingMetadata {
+        /// Missing metadata key.
+        name: &'static str,
+    },
+    /// The archive metadata has an unsupported value.
+    #[error("Navdata tile bundle metadata {name} has unsupported value {value}")]
+    UnsupportedMetadata {
+        /// Metadata key.
+        name: &'static str,
+        /// Unsupported value.
+        value: String,
+    },
+    /// An XYZ tile coordinate is outside its zoom matrix.
+    #[error("tile coordinate {zoom}/{x}/{y} is outside its zoom matrix")]
+    InvalidTileCoordinate {
+        /// Tile zoom.
+        zoom: u8,
+        /// Tile column.
+        x: u32,
+        /// XYZ tile row.
+        y: u32,
+    },
+}

--- a/crates/pilotage-navdata-tiles/src/feature.rs
+++ b/crates/pilotage-navdata-tiles/src/feature.rs
@@ -1,0 +1,144 @@
+//! Renderer-edge baseline feature representation.
+
+use std::collections::BTreeMap;
+
+use pilotage_airspace_view::{SubjectExtentV1, SubjectFamilyV1, SubjectReferenceV1};
+use sha2::{Digest, Sha256};
+
+use crate::config::NavdataTileConfig;
+use crate::mercator::WorldPoint;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LayerKind {
+    Airspace,
+    Airway,
+    Aerodrome,
+    Navaid,
+    Fix,
+}
+
+impl LayerKind {
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::Airspace => "airspaces",
+            Self::Airway => "airways",
+            Self::Aerodrome => "aerodromes",
+            Self::Navaid => "navaids",
+            Self::Fix => "fixes",
+        }
+    }
+
+    pub(crate) const fn min_zoom(self, config: NavdataTileConfig) -> u8 {
+        match self {
+            Self::Airspace => config.airspace_min_zoom,
+            Self::Airway => config.airway_min_zoom,
+            Self::Aerodrome => config.aerodrome_min_zoom,
+            Self::Navaid => config.navaid_min_zoom,
+            Self::Fix => config.fix_min_zoom,
+        }
+    }
+
+    pub(crate) const fn all() -> [Self; 5] {
+        [
+            Self::Airspace,
+            Self::Airway,
+            Self::Aerodrome,
+            Self::Navaid,
+            Self::Fix,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BaselineGeometry {
+    Point(WorldPoint),
+    Lines(Vec<Vec<WorldPoint>>),
+    Polygon(Vec<WorldPoint>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BaselineFeature {
+    pub(crate) layer: LayerKind,
+    pub(crate) feature_id: u64,
+    pub(crate) properties: BTreeMap<String, String>,
+    pub(crate) geometry: BaselineGeometry,
+}
+
+pub(crate) fn standard_properties(
+    cycle: &str,
+    family: SubjectFamilyV1,
+    identifier: &str,
+    parent: Option<&str>,
+    region: Option<&str>,
+    name: Option<&str>,
+) -> BTreeMap<String, String> {
+    let subject = SubjectReferenceV1 {
+        cycle: cycle.to_owned(),
+        family,
+        identifier: identifier.to_owned(),
+        parent_identifier: parent.map(str::to_owned),
+        region: region.map(str::to_owned),
+        extent: SubjectExtentV1::Whole,
+    };
+    properties(cycle, identifier, name, subject.stable_subject_id())
+}
+
+pub(crate) fn airway_properties(
+    cycle: &str,
+    identifier: &str,
+    location: &str,
+) -> BTreeMap<String, String> {
+    let stable_id = stable_subject_id("airway", Some(location), identifier, None);
+    let mut values = properties(cycle, identifier, None, stable_id);
+    values.insert("location".to_owned(), location.to_owned());
+    values
+}
+
+fn properties(
+    cycle: &str,
+    identifier: &str,
+    name: Option<&str>,
+    stable_id: String,
+) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::from([
+        ("identifier".to_owned(), identifier.to_owned()),
+        ("subject_cycle".to_owned(), cycle.to_owned()),
+        ("subject_id".to_owned(), stable_id),
+    ]);
+    if let Some(name) = name.filter(|value| !value.trim().is_empty()) {
+        values.insert("name".to_owned(), name.to_owned());
+    }
+    values
+}
+
+fn stable_subject_id(
+    family: &str,
+    parent: Option<&str>,
+    identifier: &str,
+    region: Option<&str>,
+) -> String {
+    let parent = canonical_ident(parent.unwrap_or(""));
+    let identifier = canonical_ident(identifier);
+    let region = canonical_ident(region.unwrap_or(""));
+    format!(
+        "subject-v1|{family}|{}:{parent}|{}:{identifier}|{}:{region}",
+        parent.len(),
+        identifier.len(),
+        region.len()
+    )
+}
+
+fn canonical_ident(value: &str) -> String {
+    value.trim().to_ascii_uppercase()
+}
+
+pub(crate) fn feature_id(stable_id: &str, discriminator: &str) -> u64 {
+    let mut digest = Sha256::new();
+    digest.update(stable_id.as_bytes());
+    digest.update([0]);
+    digest.update(discriminator.as_bytes());
+    let bytes = digest.finalize();
+    u64::from_be_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
+}

--- a/crates/pilotage-navdata-tiles/src/geometry.rs
+++ b/crates/pilotage-navdata-tiles/src/geometry.rs
@@ -1,0 +1,135 @@
+//! Deterministic clipping for vector tile geometry.
+
+use crate::mercator::{TileBounds, WorldPoint};
+
+pub(crate) fn point_bounds(points: &[WorldPoint]) -> Option<(WorldPoint, WorldPoint)> {
+    let first = *points.first()?;
+    let mut min = first;
+    let mut max = first;
+    for point in &points[1..] {
+        min.x = min.x.min(point.x);
+        min.y = min.y.min(point.y);
+        max.x = max.x.max(point.x);
+        max.y = max.y.max(point.y);
+    }
+    Some((min, max))
+}
+
+pub(crate) fn clip_segment(
+    start: WorldPoint,
+    end: WorldPoint,
+    bounds: TileBounds,
+) -> Option<(WorldPoint, WorldPoint)> {
+    let delta_x = end.x - start.x;
+    let delta_y = end.y - start.y;
+    let mut lower = 0.0;
+    let mut upper = 1.0;
+    for (p, q) in [
+        (-delta_x, start.x - bounds.min_x),
+        (delta_x, bounds.max_x - start.x),
+        (-delta_y, start.y - bounds.min_y),
+        (delta_y, bounds.max_y - start.y),
+    ] {
+        if p.abs() <= f64::EPSILON {
+            if q < 0.0 {
+                return None;
+            }
+            continue;
+        }
+        let ratio = q / p;
+        if p < 0.0 {
+            lower = f64::max(lower, ratio);
+        } else {
+            upper = f64::min(upper, ratio);
+        }
+        if lower > upper {
+            return None;
+        }
+    }
+    Some((
+        interpolate(start, end, lower),
+        interpolate(start, end, upper),
+    ))
+}
+
+pub(crate) fn clip_polygon(points: &[WorldPoint], bounds: TileBounds) -> Vec<WorldPoint> {
+    let mut output = points.to_vec();
+    output = clip_edge(
+        &output,
+        |point| point.x >= bounds.min_x,
+        |a, b| intersect_vertical(a, b, bounds.min_x),
+    );
+    output = clip_edge(
+        &output,
+        |point| point.x <= bounds.max_x,
+        |a, b| intersect_vertical(a, b, bounds.max_x),
+    );
+    output = clip_edge(
+        &output,
+        |point| point.y >= bounds.min_y,
+        |a, b| intersect_horizontal(a, b, bounds.min_y),
+    );
+    clip_edge(
+        &output,
+        |point| point.y <= bounds.max_y,
+        |a, b| intersect_horizontal(a, b, bounds.max_y),
+    )
+}
+
+fn clip_edge(
+    input: &[WorldPoint],
+    inside: impl Fn(WorldPoint) -> bool,
+    intersection: impl Fn(WorldPoint, WorldPoint) -> WorldPoint,
+) -> Vec<WorldPoint> {
+    let Some(mut previous) = input.last().copied() else {
+        return Vec::new();
+    };
+    let mut output = Vec::new();
+    for &current in input {
+        let current_inside = inside(current);
+        let previous_inside = inside(previous);
+        if current_inside {
+            if !previous_inside {
+                output.push(intersection(previous, current));
+            }
+            output.push(current);
+        } else if previous_inside {
+            output.push(intersection(previous, current));
+        }
+        previous = current;
+    }
+    output
+}
+
+fn intersect_vertical(start: WorldPoint, end: WorldPoint, x: f64) -> WorldPoint {
+    let delta = end.x - start.x;
+    let ratio = if delta.abs() <= f64::EPSILON {
+        0.0
+    } else {
+        (x - start.x) / delta
+    };
+    WorldPoint {
+        x,
+        y: start.y + ratio * (end.y - start.y),
+    }
+}
+
+fn intersect_horizontal(start: WorldPoint, end: WorldPoint, y: f64) -> WorldPoint {
+    let delta = end.y - start.y;
+    let ratio = if delta.abs() <= f64::EPSILON {
+        0.0
+    } else {
+        (y - start.y) / delta
+    };
+    WorldPoint {
+        x: start.x + ratio * (end.x - start.x),
+        y,
+    }
+}
+
+fn interpolate(start: WorldPoint, end: WorldPoint, ratio: f64) -> WorldPoint {
+    WorldPoint {
+        x: start.x + ratio * (end.x - start.x),
+        y: start.y + ratio * (end.y - start.y),
+    }
+}

--- a/crates/pilotage-navdata-tiles/src/lib.rs
+++ b/crates/pilotage-navdata-tiles/src/lib.rs
@@ -1,0 +1,34 @@
+//! Builds deterministic offline vector tiles from one Navdata snapshot.
+//!
+//! The builder accepts an immutable snapshot with its cycle, snapshot identity,
+//! and digest. It emits gzip-compressed Mapbox Vector Tiles in one MBTiles 1.3
+//! archive. It does not read a provider source or use a network.
+
+#![forbid(unsafe_code)]
+
+mod archive;
+mod build;
+mod config;
+mod error;
+mod feature;
+mod geometry;
+mod mercator;
+mod model;
+mod mvt;
+mod reader;
+mod source;
+mod tile;
+
+#[cfg(test)]
+mod tests;
+
+pub use build::build_mbtiles;
+pub use config::NavdataTileConfig;
+pub use error::NavdataTileError;
+pub use model::{
+    BaselineFeatureCounts, NavdataTileBundle, NavdataTileReport, OmittedFeatureCounts,
+};
+pub use reader::OfflineTileReader;
+
+/// Schema version for the Navdata baseline tile bundle.
+pub const NAVDATA_TILE_SCHEMA_VERSION: u16 = 1;

--- a/crates/pilotage-navdata-tiles/src/mercator.rs
+++ b/crates/pilotage-navdata-tiles/src/mercator.rs
@@ -1,0 +1,112 @@
+//! WGS84 to Web Mercator tile coordinates.
+
+use aerocontext_core::GeoPoint;
+
+use crate::NavdataTileError;
+
+pub(crate) const EXTENT: i32 = 4096;
+pub(crate) const MAX_LATITUDE: f64 = 85.051_128_779_806_6;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct WorldPoint {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct TileCoord {
+    pub(crate) zoom: u8,
+    pub(crate) x: u32,
+    pub(crate) y: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct TileBounds {
+    pub(crate) min_x: f64,
+    pub(crate) min_y: f64,
+    pub(crate) max_x: f64,
+    pub(crate) max_y: f64,
+}
+
+pub(crate) fn project(identifier: &str, point: GeoPoint) -> Result<WorldPoint, NavdataTileError> {
+    if !point.lat.is_finite()
+        || !point.lon.is_finite()
+        || !(-90.0..=90.0).contains(&point.lat)
+        || !(-180.0..=180.0).contains(&point.lon)
+    {
+        return Err(NavdataTileError::InvalidCoordinate {
+            identifier: identifier.to_owned(),
+            latitude: point.lat,
+            longitude: point.lon,
+        });
+    }
+    let latitude = point.lat.clamp(-MAX_LATITUDE, MAX_LATITUDE);
+    let sin_latitude = latitude.to_radians().sin();
+    let x = (point.lon + 180.0) / 360.0;
+    let y = 0.5 - ((1.0 + sin_latitude) / (1.0 - sin_latitude)).ln() / (4.0 * std::f64::consts::PI);
+    Ok(WorldPoint {
+        x: x.clamp(0.0, 1.0),
+        y: y.clamp(0.0, 1.0),
+    })
+}
+
+pub(crate) fn tile_for_point(point: WorldPoint, zoom: u8) -> TileCoord {
+    let width = matrix_width(zoom);
+    let x = matrix_index(point.x, width);
+    let y = matrix_index(point.y, width);
+    TileCoord { zoom, x, y }
+}
+
+pub(crate) fn tiles_for_bounds(
+    min: WorldPoint,
+    max: WorldPoint,
+    zoom: u8,
+) -> impl Iterator<Item = TileCoord> {
+    let width = matrix_width(zoom);
+    let min_x = matrix_index(min.x.min(max.x), width);
+    let max_x = matrix_index(min.x.max(max.x), width);
+    let min_y = matrix_index(min.y.min(max.y), width);
+    let max_y = matrix_index(min.y.max(max.y), width);
+    (min_x..=max_x).flat_map(move |x| (min_y..=max_y).map(move |y| TileCoord { zoom, x, y }))
+}
+
+pub(crate) fn bounds(tile: TileCoord) -> TileBounds {
+    let width = f64::from(matrix_width(tile.zoom));
+    TileBounds {
+        min_x: f64::from(tile.x) / width,
+        min_y: f64::from(tile.y) / width,
+        max_x: f64::from(tile.x.wrapping_add(1)) / width,
+        max_y: f64::from(tile.y.wrapping_add(1)) / width,
+    }
+}
+
+pub(crate) fn local_point(point: WorldPoint, tile: TileCoord) -> (i32, i32) {
+    let width = f64::from(matrix_width(tile.zoom));
+    let x = ((point.x * width - f64::from(tile.x)) * f64::from(EXTENT)).round();
+    let y = ((point.y * width - f64::from(tile.y)) * f64::from(EXTENT)).round();
+    (clamp_extent(x), clamp_extent(y))
+}
+
+fn matrix_width(zoom: u8) -> u32 {
+    1u32 << u32::from(zoom)
+}
+
+fn matrix_index(value: f64, width: u32) -> u32 {
+    let index = (value * f64::from(width)).floor();
+    let index = if index.is_finite() && index >= 0.0 {
+        index as u32
+    } else {
+        0
+    };
+    index.min(width.wrapping_sub(1))
+}
+
+fn clamp_extent(value: f64) -> i32 {
+    if value <= 0.0 {
+        0
+    } else if value >= f64::from(EXTENT) {
+        EXTENT
+    } else {
+        value as i32
+    }
+}

--- a/crates/pilotage-navdata-tiles/src/model.rs
+++ b/crates/pilotage-navdata-tiles/src/model.rs
@@ -1,0 +1,79 @@
+//! Public bundle and report types.
+
+/// Drawable baseline records by layer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub struct BaselineFeatureCounts {
+    /// Aerodrome point subjects.
+    pub aerodromes: u64,
+    /// Ground navigation aid point subjects.
+    pub navaids: u64,
+    /// Published fix point subjects.
+    pub fixes: u64,
+    /// Airway subjects with at least one resolved segment.
+    pub airways: u64,
+    /// Airspace records with drawable published bounds.
+    pub airspaces: u64,
+}
+
+impl BaselineFeatureCounts {
+    /// Gets the total number of drawable baseline records.
+    #[must_use]
+    pub const fn total(self) -> u64 {
+        self.aerodromes + self.navaids + self.fixes + self.airways + self.airspaces
+    }
+}
+
+/// Snapshot records that the first baseline schema cannot draw.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub struct OmittedFeatureCounts {
+    /// Point kinds that have no baseline layer.
+    pub other_points: u64,
+    /// Airways with fewer than one resolved segment.
+    pub unresolved_airways: u64,
+    /// Runways without WGS84 end positions in the snapshot model.
+    pub runways_without_geometry: u64,
+    /// Airspaces without a resolvable horizontal bound.
+    pub airspaces_without_geometry: u64,
+}
+
+/// Deterministic facts produced with one archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct NavdataTileReport {
+    /// Number of populated vector tiles.
+    pub tile_count: u64,
+    /// Number of feature copies across all tiles.
+    pub tile_feature_count: u64,
+    /// Drawable baseline records by layer.
+    pub features: BaselineFeatureCounts,
+    /// Snapshot records that have no drawable baseline geometry.
+    pub omitted: OmittedFeatureCounts,
+    /// Complete archive size in bytes.
+    pub archive_bytes: u64,
+}
+
+/// One deterministic MBTiles archive and its report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NavdataTileBundle {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) report: NavdataTileReport,
+}
+
+impl NavdataTileBundle {
+    /// Gets the complete MBTiles archive bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Takes the complete MBTiles archive bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Gets facts from this build.
+    #[must_use]
+    pub const fn report(&self) -> &NavdataTileReport {
+        &self.report
+    }
+}

--- a/crates/pilotage-navdata-tiles/src/mvt.rs
+++ b/crates/pilotage-navdata-tiles/src/mvt.rs
@@ -1,0 +1,249 @@
+//! Mapbox Vector Tile 2.1 Protocol Buffer encoding.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use prost::Message;
+
+use crate::NavdataTileError;
+use crate::feature::LayerKind;
+use crate::mercator::EXTENT;
+use crate::tile::VectorTile;
+
+#[derive(Debug, Clone)]
+pub(crate) enum TileGeometry {
+    Point((i32, i32)),
+    Lines(Vec<Vec<(i32, i32)>>),
+    Polygon(Vec<(i32, i32)>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TileFeature {
+    pub(crate) id: u64,
+    pub(crate) properties: BTreeMap<String, String>,
+    pub(crate) geometry: TileGeometry,
+}
+
+pub(crate) fn encode_tile(tile: &VectorTile) -> Result<Vec<u8>, NavdataTileError> {
+    let layers = LayerKind::all()
+        .into_iter()
+        .filter_map(|kind| {
+            tile.layers
+                .get(&kind)
+                .filter(|features| !features.is_empty())
+                .map(|features| encode_layer(kind, features))
+        })
+        .collect();
+    let message = proto::Tile { layers };
+    let mut bytes = Vec::new();
+    message
+        .encode(&mut bytes)
+        .map_err(|source| NavdataTileError::VectorTileEncoding {
+            zoom: tile.coord.zoom,
+            x: tile.coord.x,
+            y: tile.coord.y,
+            source,
+        })?;
+    Ok(bytes)
+}
+
+fn encode_layer(kind: LayerKind, features: &[TileFeature]) -> proto::Layer {
+    let keys: Vec<String> = features
+        .iter()
+        .flat_map(|feature| feature.properties.keys().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let values: Vec<String> = features
+        .iter()
+        .flat_map(|feature| feature.properties.values().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let key_index = indexes(&keys);
+    let value_index = indexes(&values);
+    let features = features
+        .iter()
+        .filter_map(|feature| encode_feature(feature, &key_index, &value_index))
+        .collect();
+    proto::Layer {
+        version: 2,
+        name: kind.name().to_owned(),
+        features,
+        keys,
+        values: values
+            .into_iter()
+            .map(|value| proto::Value {
+                string_value: Some(value),
+            })
+            .collect(),
+        extent: Some(EXTENT as u32),
+    }
+}
+
+fn encode_feature(
+    feature: &TileFeature,
+    key_index: &BTreeMap<String, u32>,
+    value_index: &BTreeMap<String, u32>,
+) -> Option<proto::Feature> {
+    let (geometry_type, geometry) = encode_geometry(&feature.geometry)?;
+    let tags = feature
+        .properties
+        .iter()
+        .flat_map(|(key, value)| [key_index[key], value_index[value]])
+        .collect();
+    Some(proto::Feature {
+        id: Some(feature.id),
+        tags,
+        r#type: Some(geometry_type as i32),
+        geometry,
+    })
+}
+
+fn encode_geometry(geometry: &TileGeometry) -> Option<(proto::GeomType, Vec<u32>)> {
+    match geometry {
+        TileGeometry::Point(point) => Some((proto::GeomType::Point, encode_point(*point))),
+        TileGeometry::Lines(lines) => {
+            let encoded = encode_lines(lines);
+            (!encoded.is_empty()).then_some((proto::GeomType::Linestring, encoded))
+        }
+        TileGeometry::Polygon(points) => {
+            encode_polygon(points).map(|encoded| (proto::GeomType::Polygon, encoded))
+        }
+    }
+}
+
+fn encode_point(point: (i32, i32)) -> Vec<u32> {
+    vec![command(1, 1), zigzag(point.0), zigzag(point.1)]
+}
+
+fn encode_lines(lines: &[Vec<(i32, i32)>]) -> Vec<u32> {
+    let mut geometry = Vec::new();
+    let mut cursor = (0, 0);
+    for line in lines {
+        let points = deduplicate(line);
+        if points.len() < 2 {
+            continue;
+        }
+        geometry.push(command(1, 1));
+        push_delta(&mut geometry, &mut cursor, points[0]);
+        geometry.push(command(2, (points.len() - 1) as u32));
+        for point in &points[1..] {
+            push_delta(&mut geometry, &mut cursor, *point);
+        }
+    }
+    geometry
+}
+
+fn encode_polygon(points: &[(i32, i32)]) -> Option<Vec<u32>> {
+    let mut points = deduplicate(points);
+    if points.first() == points.last() {
+        points.pop();
+    }
+    if points.len() < 3 || signed_area(&points) == 0 {
+        return None;
+    }
+    if signed_area(&points) < 0 {
+        points.reverse();
+    }
+    let mut geometry = vec![command(1, 1), zigzag(points[0].0), zigzag(points[0].1)];
+    let mut cursor = points[0];
+    geometry.push(command(2, (points.len() - 1) as u32));
+    for point in &points[1..] {
+        push_delta(&mut geometry, &mut cursor, *point);
+    }
+    geometry.push(command(7, 1));
+    Some(geometry)
+}
+
+fn deduplicate(points: &[(i32, i32)]) -> Vec<(i32, i32)> {
+    let mut result = Vec::with_capacity(points.len());
+    for point in points {
+        if result.last() != Some(point) {
+            result.push(*point);
+        }
+    }
+    result
+}
+
+fn signed_area(points: &[(i32, i32)]) -> i64 {
+    let mut area = 0i64;
+    for index in 0..points.len() {
+        let next = index.wrapping_add(1) % points.len();
+        area += i64::from(points[index].0) * i64::from(points[next].1)
+            - i64::from(points[next].0) * i64::from(points[index].1);
+    }
+    area
+}
+
+fn push_delta(geometry: &mut Vec<u32>, cursor: &mut (i32, i32), point: (i32, i32)) {
+    geometry.push(zigzag(point.0 - cursor.0));
+    geometry.push(zigzag(point.1 - cursor.1));
+    *cursor = point;
+}
+
+fn indexes(values: &[String]) -> BTreeMap<String, u32> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| (value.clone(), index as u32))
+        .collect()
+}
+
+const fn command(id: u32, count: u32) -> u32 {
+    (count << 3) | id
+}
+
+const fn zigzag(value: i32) -> u32 {
+    ((value << 1) ^ (value >> 31)) as u32
+}
+
+pub(crate) mod proto {
+    #[derive(Clone, PartialEq, prost::Message)]
+    pub(crate) struct Tile {
+        #[prost(message, repeated, tag = "3")]
+        pub(crate) layers: Vec<Layer>,
+    }
+
+    #[derive(Clone, PartialEq, prost::Message)]
+    pub(crate) struct Layer {
+        #[prost(uint32, required, tag = "15")]
+        pub(crate) version: u32,
+        #[prost(string, required, tag = "1")]
+        pub(crate) name: String,
+        #[prost(message, repeated, tag = "2")]
+        pub(crate) features: Vec<Feature>,
+        #[prost(string, repeated, tag = "3")]
+        pub(crate) keys: Vec<String>,
+        #[prost(message, repeated, tag = "4")]
+        pub(crate) values: Vec<Value>,
+        #[prost(uint32, optional, tag = "5")]
+        pub(crate) extent: Option<u32>,
+    }
+
+    #[derive(Clone, PartialEq, prost::Message)]
+    pub(crate) struct Feature {
+        #[prost(uint64, optional, tag = "1")]
+        pub(crate) id: Option<u64>,
+        #[prost(uint32, repeated, packed = "true", tag = "2")]
+        pub(crate) tags: Vec<u32>,
+        #[prost(enumeration = "GeomType", optional, tag = "3")]
+        pub(crate) r#type: Option<i32>,
+        #[prost(uint32, repeated, packed = "true", tag = "4")]
+        pub(crate) geometry: Vec<u32>,
+    }
+
+    #[derive(Clone, PartialEq, prost::Message)]
+    pub(crate) struct Value {
+        #[prost(string, optional, tag = "1")]
+        pub(crate) string_value: Option<String>,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
+    #[repr(i32)]
+    pub(crate) enum GeomType {
+        Unknown = 0,
+        Point = 1,
+        Linestring = 2,
+        Polygon = 3,
+    }
+}

--- a/crates/pilotage-navdata-tiles/src/reader.rs
+++ b/crates/pilotage-navdata-tiles/src/reader.rs
@@ -1,0 +1,123 @@
+//! Offline archive access for clients and verification tools.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+
+use pilotage_airspace_view::NavdataIdentityV1;
+use rusqlite::{Connection, MAIN_DB, OptionalExtension, params};
+
+use crate::{NAVDATA_TILE_SCHEMA_VERSION, NavdataTileError};
+
+/// Read-only access to one installed Navdata MBTiles archive.
+pub struct OfflineTileReader {
+    connection: Connection,
+    identity: NavdataIdentityV1,
+}
+
+impl OfflineTileReader {
+    /// Opens an installed archive without a network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NavdataTileError`] if the file cannot be read or the archive
+    /// schema and identity metadata are not valid.
+    pub fn open_file_blocking(path: &Path) -> Result<Self, NavdataTileError> {
+        let bytes = fs::read(path).map_err(|source| NavdataTileError::ArchiveRead {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::from_bytes(&bytes)
+    }
+
+    /// Opens complete MBTiles bytes in a read-only in-memory database.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NavdataTileError`] if the bytes are not a supported Navdata
+    /// tile bundle.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, NavdataTileError> {
+        let mut connection =
+            Connection::open_in_memory().map_err(|source| mbtiles("open", source))?;
+        connection
+            .deserialize_read_exact(MAIN_DB, Cursor::new(bytes), bytes.len(), true)
+            .map_err(|source| mbtiles("deserialize", source))?;
+        connection
+            .execute_batch("PRAGMA query_only = ON;")
+            .map_err(|source| mbtiles("set read-only", source))?;
+        validate_metadata(&connection)?;
+        let identity = NavdataIdentityV1 {
+            cycle: metadata(&connection, "pilotage_cycle")?,
+            snapshot_id: metadata(&connection, "pilotage_snapshot_id")?,
+            snapshot_digest: metadata(&connection, "pilotage_snapshot_digest")?,
+        };
+        Ok(Self {
+            connection,
+            identity,
+        })
+    }
+
+    /// Gets the identity carried in the archive.
+    #[must_use]
+    pub const fn identity(&self) -> &NavdataIdentityV1 {
+        &self.identity
+    }
+
+    /// Gets a gzip-compressed Mapbox Vector Tile by XYZ coordinate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NavdataTileError`] when the coordinate is outside its tile
+    /// matrix or SQLite cannot read the archive.
+    pub fn tile_xyz(&self, zoom: u8, x: u32, y: u32) -> Result<Option<Vec<u8>>, NavdataTileError> {
+        let Some(width) = 1u32.checked_shl(u32::from(zoom)) else {
+            return Err(invalid_coordinate(zoom, x, y));
+        };
+        if x >= width || y >= width {
+            return Err(invalid_coordinate(zoom, x, y));
+        }
+        let tms_row = width.wrapping_sub(1).wrapping_sub(y);
+        self.connection
+            .query_row(
+                "SELECT tile_data FROM tiles
+                 WHERE zoom_level = ?1 AND tile_column = ?2 AND tile_row = ?3",
+                params![zoom, x, tms_row],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|source| mbtiles("read tile", source))
+    }
+}
+
+fn validate_metadata(connection: &Connection) -> Result<(), NavdataTileError> {
+    for (name, expected) in [
+        ("format", "pbf"),
+        ("pilotage_schema", &NAVDATA_TILE_SCHEMA_VERSION.to_string()),
+    ] {
+        let value = metadata(connection, name)?;
+        if value != expected {
+            return Err(NavdataTileError::UnsupportedMetadata { name, value });
+        }
+    }
+    Ok(())
+}
+
+fn metadata(connection: &Connection, name: &'static str) -> Result<String, NavdataTileError> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE name = ?1",
+            [name],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|source| mbtiles("read metadata", source))?
+        .ok_or(NavdataTileError::MissingMetadata { name })
+}
+
+fn invalid_coordinate(zoom: u8, x: u32, y: u32) -> NavdataTileError {
+    NavdataTileError::InvalidTileCoordinate { zoom, x, y }
+}
+
+fn mbtiles(operation: &'static str, source: rusqlite::Error) -> NavdataTileError {
+    NavdataTileError::Mbtiles { operation, source }
+}

--- a/crates/pilotage-navdata-tiles/src/source.rs
+++ b/crates/pilotage-navdata-tiles/src/source.rs
@@ -1,0 +1,392 @@
+//! Conversion from a typed Navdata snapshot to baseline features.
+
+use std::collections::BTreeMap;
+
+use aerocontext_core::navdata::{
+    Airspace, AirspaceKind, AltitudeDatum, AltitudeLimit, ControlledClass, NavPoint, NavPointKind,
+    RestrictiveKind,
+};
+use aerocontext_core::{Area, GeoPoint, NavDataSnapshot};
+use pilotage_airspace_view::SubjectFamilyV1;
+
+use crate::NavdataTileError;
+use crate::feature::{
+    BaselineFeature, BaselineGeometry, LayerKind, airway_properties, feature_id,
+    standard_properties,
+};
+use crate::mercator::{WorldPoint, project};
+use crate::model::{BaselineFeatureCounts, OmittedFeatureCounts};
+
+pub(crate) struct SourceFeatures {
+    pub(crate) features: Vec<BaselineFeature>,
+    pub(crate) counts: BaselineFeatureCounts,
+    pub(crate) omitted: OmittedFeatureCounts,
+}
+
+pub(crate) fn extract_features(
+    snapshot: &NavDataSnapshot,
+    cycle: &str,
+) -> Result<SourceFeatures, NavdataTileError> {
+    let point_index = PointIndex::new(&snapshot.points);
+    let mut result = SourceFeatures {
+        features: Vec::new(),
+        counts: BaselineFeatureCounts::default(),
+        omitted: OmittedFeatureCounts {
+            runways_without_geometry: snapshot.runways.len() as u64,
+            ..OmittedFeatureCounts::default()
+        },
+    };
+    add_points(snapshot, cycle, &mut result)?;
+    add_airways(snapshot, cycle, &point_index, &mut result)?;
+    add_airspaces(snapshot, cycle, &point_index, &mut result)?;
+    result.features.sort_by_key(|feature| feature.feature_id);
+    Ok(result)
+}
+
+fn add_points(
+    snapshot: &NavDataSnapshot,
+    cycle: &str,
+    result: &mut SourceFeatures,
+) -> Result<(), NavdataTileError> {
+    for point in &snapshot.points {
+        let Some((layer, family)) = point_family(point) else {
+            result.omitted.other_points = result.omitted.other_points.wrapping_add(1);
+            continue;
+        };
+        let geometry = BaselineGeometry::Point(project(&point.ident, point.position)?);
+        let mut properties = standard_properties(
+            cycle,
+            family,
+            &point.ident,
+            None,
+            point.region.as_deref(),
+            point.name.as_deref(),
+        );
+        properties.insert("kind".to_owned(), layer.name().to_owned());
+        let stable_id = property(&properties, "subject_id");
+        let discriminator = coordinate_key(point.position);
+        result.features.push(BaselineFeature {
+            layer,
+            feature_id: feature_id(stable_id, &discriminator),
+            properties,
+            geometry,
+        });
+        increment_point_count(layer, &mut result.counts);
+    }
+    Ok(())
+}
+
+fn add_airways(
+    snapshot: &NavDataSnapshot,
+    cycle: &str,
+    point_index: &PointIndex,
+    result: &mut SourceFeatures,
+) -> Result<(), NavdataTileError> {
+    for airway in &snapshot.airways {
+        let paths = airway_paths(airway, point_index)?;
+        if paths.is_empty() {
+            result.omitted.unresolved_airways = result.omitted.unresolved_airways.wrapping_add(1);
+            continue;
+        }
+        push_airway(cycle, airway, paths, result);
+    }
+    Ok(())
+}
+
+fn airway_paths(
+    airway: &aerocontext_core::navdata::Airway,
+    point_index: &PointIndex,
+) -> Result<Vec<Vec<WorldPoint>>, NavdataTileError> {
+    let mut paths = Vec::new();
+    let mut current = Vec::new();
+    for pair in airway.points.windows(2) {
+        if pair[0].gap_to_next {
+            finish_path(&mut paths, &mut current);
+            continue;
+        }
+        let Some((start, end)) = resolve_segment(airway, pair, point_index)? else {
+            finish_path(&mut paths, &mut current);
+            continue;
+        };
+        if current.last() == Some(&start) {
+            current.push(end);
+        } else {
+            finish_path(&mut paths, &mut current);
+            current.extend([start, end]);
+        }
+    }
+    finish_path(&mut paths, &mut current);
+    Ok(paths)
+}
+
+fn resolve_segment(
+    airway: &aerocontext_core::navdata::Airway,
+    pair: &[aerocontext_core::navdata::AirwayPoint],
+    point_index: &PointIndex,
+) -> Result<Option<(WorldPoint, WorldPoint)>, NavdataTileError> {
+    let (Some(start), Some(end)) = (
+        point_index.find(&pair[0].ident, pair[0].icao_region.as_deref()),
+        point_index.find(&pair[1].ident, pair[1].icao_region.as_deref()),
+    ) else {
+        return Ok(None);
+    };
+    let start = project(&airway.ident, start)?;
+    let end = project(&airway.ident, end)?;
+    Ok((start != end).then_some((start, end)))
+}
+
+fn finish_path(paths: &mut Vec<Vec<WorldPoint>>, current: &mut Vec<WorldPoint>) {
+    if current.len() >= 2 {
+        paths.push(std::mem::take(current));
+    } else {
+        current.clear();
+    }
+}
+
+fn push_airway(
+    cycle: &str,
+    airway: &aerocontext_core::navdata::Airway,
+    paths: Vec<Vec<WorldPoint>>,
+    result: &mut SourceFeatures,
+) {
+    let location = airway.location.code();
+    let mut properties = airway_properties(cycle, &airway.ident, location);
+    properties.insert("kind".to_owned(), "airway".to_owned());
+    let stable_id = property(&properties, "subject_id");
+    result.features.push(BaselineFeature {
+        layer: LayerKind::Airway,
+        feature_id: feature_id(stable_id, location),
+        properties,
+        geometry: BaselineGeometry::Lines(paths),
+    });
+    result.counts.airways = result.counts.airways.wrapping_add(1);
+}
+
+fn add_airspaces(
+    snapshot: &NavDataSnapshot,
+    cycle: &str,
+    point_index: &PointIndex,
+    result: &mut SourceFeatures,
+) -> Result<(), NavdataTileError> {
+    for (index, airspace) in snapshot.airspaces.iter().enumerate() {
+        let Some(points) = airspace_polygon(airspace, point_index) else {
+            result.omitted.airspaces_without_geometry =
+                result.omitted.airspaces_without_geometry.wrapping_add(1);
+            continue;
+        };
+        let projected = points
+            .into_iter()
+            .map(|point| project(&airspace.designator, point))
+            .collect::<Result<Vec<_>, _>>()?;
+        if projected.len() < 3 {
+            result.omitted.airspaces_without_geometry =
+                result.omitted.airspaces_without_geometry.wrapping_add(1);
+            continue;
+        }
+        push_airspace(cycle, airspace, projected, index, result);
+    }
+    Ok(())
+}
+
+fn push_airspace(
+    cycle: &str,
+    airspace: &Airspace,
+    points: Vec<WorldPoint>,
+    index: usize,
+    result: &mut SourceFeatures,
+) {
+    let mut properties = standard_properties(
+        cycle,
+        SubjectFamilyV1::Airspace,
+        &airspace.designator,
+        airspace.center_ident.as_deref(),
+        None,
+        airspace.name.as_deref(),
+    );
+    properties.insert("kind".to_owned(), airspace_kind(&airspace.kind));
+    properties.insert("lower".to_owned(), altitude(&airspace.lower));
+    properties.insert("upper".to_owned(), altitude(&airspace.upper));
+    properties.insert("geometry_quality".to_owned(), "snapshot_bound".to_owned());
+    let stable_id = property(&properties, "subject_id");
+    result.features.push(BaselineFeature {
+        layer: LayerKind::Airspace,
+        feature_id: feature_id(stable_id, &format!("shelf-{index}")),
+        properties,
+        geometry: BaselineGeometry::Polygon(points),
+    });
+    result.counts.airspaces = result.counts.airspaces.wrapping_add(1);
+}
+
+fn point_family(point: &NavPoint) -> Option<(LayerKind, SubjectFamilyV1)> {
+    match point.kind {
+        NavPointKind::Airport => Some((LayerKind::Aerodrome, SubjectFamilyV1::Aerodrome)),
+        NavPointKind::Navaid => Some((LayerKind::Navaid, SubjectFamilyV1::Navaid)),
+        NavPointKind::Waypoint => Some((LayerKind::Fix, SubjectFamilyV1::Fix)),
+        NavPointKind::Other(_) => None,
+        _ => None,
+    }
+}
+
+fn increment_point_count(layer: LayerKind, counts: &mut BaselineFeatureCounts) {
+    match layer {
+        LayerKind::Aerodrome => counts.aerodromes = counts.aerodromes.wrapping_add(1),
+        LayerKind::Navaid => counts.navaids = counts.navaids.wrapping_add(1),
+        LayerKind::Fix => counts.fixes = counts.fixes.wrapping_add(1),
+        LayerKind::Airway | LayerKind::Airspace => {}
+    }
+}
+
+fn airspace_polygon(airspace: &Airspace, index: &PointIndex) -> Option<Vec<GeoPoint>> {
+    match airspace.bounds.as_ref()? {
+        Area::BoundingBox {
+            south_west,
+            north_east,
+        } => Some(rectangle(*south_west, *north_east)),
+        Area::PointRadius { center, radius_nm } => circle(*center, *radius_nm),
+        Area::LocationRadius { ident, radius_nm } => circle(index.find(ident, None)?, *radius_nm),
+        Area::Polygon { vertices } if vertices.len() >= 3 => Some(vertices.clone()),
+        Area::Polygon { .. } => None,
+        _ => None,
+    }
+}
+
+fn rectangle(south_west: GeoPoint, north_east: GeoPoint) -> Vec<GeoPoint> {
+    vec![
+        south_west,
+        GeoPoint {
+            lat: south_west.lat,
+            lon: north_east.lon,
+        },
+        north_east,
+        GeoPoint {
+            lat: north_east.lat,
+            lon: south_west.lon,
+        },
+    ]
+}
+
+fn circle(center: GeoPoint, radius_nm: f64) -> Option<Vec<GeoPoint>> {
+    if !radius_nm.is_finite() || radius_nm <= 0.0 {
+        return None;
+    }
+    let latitude_radius = radius_nm / 60.0;
+    let longitude_scale = center.lat.to_radians().cos().abs().max(1.0e-6);
+    let longitude_radius = (latitude_radius / longitude_scale).min(180.0);
+    Some(
+        (0..64)
+            .map(|step| {
+                let angle = f64::from(step) * std::f64::consts::TAU / 64.0;
+                GeoPoint {
+                    lat: center.lat + latitude_radius * angle.sin(),
+                    lon: center.lon + longitude_radius * angle.cos(),
+                }
+            })
+            .collect(),
+    )
+}
+
+fn airspace_kind(kind: &AirspaceKind) -> String {
+    match kind {
+        AirspaceKind::Controlled(class) => format!("class-{}", controlled_class(class)),
+        AirspaceKind::Restrictive(kind) => restrictive_kind(kind).to_owned(),
+        _ => "other".to_owned(),
+    }
+}
+
+fn controlled_class(class: &ControlledClass) -> &str {
+    match class {
+        ControlledClass::B => "b",
+        ControlledClass::C => "c",
+        ControlledClass::D => "d",
+        ControlledClass::E => "e",
+        ControlledClass::Other(_) => "other",
+        _ => "other",
+    }
+}
+
+fn restrictive_kind(kind: &RestrictiveKind) -> &str {
+    match kind {
+        RestrictiveKind::Prohibited => "prohibited",
+        RestrictiveKind::Restricted => "restricted",
+        RestrictiveKind::Moa => "moa",
+        RestrictiveKind::Alert => "alert",
+        RestrictiveKind::Warning => "warning",
+        RestrictiveKind::Danger => "danger",
+        RestrictiveKind::Training => "training",
+        RestrictiveKind::Other(_) => "other",
+        _ => "other",
+    }
+}
+
+fn altitude(limit: &AltitudeLimit) -> String {
+    let datum = match limit.datum {
+        AltitudeDatum::Ground => "ground",
+        AltitudeDatum::Msl => "msl",
+        AltitudeDatum::Agl => "agl",
+        AltitudeDatum::FlightLevel => "flight-level",
+        AltitudeDatum::Unlimited => "unlimited",
+        AltitudeDatum::Unknown => "unknown",
+        _ => "unknown",
+    };
+    limit
+        .value_ft
+        .map_or_else(|| datum.to_owned(), |value| format!("{value}:{datum}"))
+}
+
+fn coordinate_key(point: GeoPoint) -> String {
+    format!("{:.12}:{:.12}", point.lat, point.lon)
+}
+
+fn property<'a>(properties: &'a BTreeMap<String, String>, name: &str) -> &'a str {
+    properties.get(name).map_or("", String::as_str)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PointMatch {
+    One(GeoPoint),
+    Ambiguous,
+}
+
+struct PointIndex {
+    exact: BTreeMap<(String, String), PointMatch>,
+    any_region: BTreeMap<String, PointMatch>,
+}
+
+impl PointIndex {
+    fn new(points: &[NavPoint]) -> Self {
+        let mut index = Self {
+            exact: BTreeMap::new(),
+            any_region: BTreeMap::new(),
+        };
+        for point in points {
+            let ident = canonical(&point.ident);
+            let region = canonical(point.region.as_deref().unwrap_or(""));
+            insert_point(&mut index.exact, (ident.clone(), region), point.position);
+            insert_point(&mut index.any_region, ident, point.position);
+        }
+        index
+    }
+
+    fn find(&self, ident: &str, region: Option<&str>) -> Option<GeoPoint> {
+        let ident = canonical(ident);
+        let found = if let Some(region) = region {
+            self.exact.get(&(ident, canonical(region)))
+        } else {
+            self.any_region.get(&ident)
+        };
+        match found {
+            Some(PointMatch::One(point)) => Some(*point),
+            Some(PointMatch::Ambiguous) | None => None,
+        }
+    }
+}
+
+fn insert_point<K: Ord>(map: &mut BTreeMap<K, PointMatch>, key: K, point: GeoPoint) {
+    map.entry(key)
+        .and_modify(|value| *value = PointMatch::Ambiguous)
+        .or_insert(PointMatch::One(point));
+}
+
+fn canonical(value: &str) -> String {
+    value.trim().to_ascii_uppercase()
+}

--- a/crates/pilotage-navdata-tiles/src/tests.rs
+++ b/crates/pilotage-navdata-tiles/src/tests.rs
@@ -1,0 +1,307 @@
+//! Tests for deterministic offline Navdata tile bundles.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+use std::io::{Cursor, Read};
+
+use aerocontext_core::navdata::{
+    Airspace, AirspaceKind, Airway, AirwayLocation, AirwayPoint, ControlledClass, NavPoint,
+    NavPointKind, Runway,
+};
+use aerocontext_core::{Area, GeoPoint, NavDataCycle, NavDataSnapshot};
+use chrono::NaiveDate;
+use flate2::read::GzDecoder;
+use pilotage_airspace_view::{IdentifiedNavdataSnapshotV1, NavdataIdentityV1, navdata_cycle_id};
+use prost::Message;
+use rusqlite::{Connection, MAIN_DB};
+
+use super::*;
+use crate::mvt::proto;
+
+fn test_config() -> NavdataTileConfig {
+    NavdataTileConfig {
+        airspace_min_zoom: 0,
+        airway_min_zoom: 0,
+        aerodrome_min_zoom: 0,
+        navaid_min_zoom: 0,
+        fix_min_zoom: 0,
+        max_zoom: 0,
+    }
+}
+
+fn identified() -> IdentifiedNavdataSnapshotV1 {
+    let cycle =
+        NavDataCycle::faa_nasr(NaiveDate::from_ymd_opt(2026, 6, 11).expect("valid test date"))
+            .expect("valid cycle");
+    let points = vec![
+        point("KBOS", NavPointKind::Airport, 42.3656, -71.0096, "K1"),
+        point("PUT", NavPointKind::Navaid, 41.9555, -71.8443, "K1"),
+        point("DREEM", NavPointKind::Waypoint, 42.2, -71.5, "K1"),
+        point(
+            "PRIVATE",
+            NavPointKind::Other("private-use".to_owned()),
+            42.0,
+            -71.0,
+            "K1",
+        ),
+    ];
+    let airway = Airway::new(
+        "V1",
+        AirwayLocation::Conus,
+        vec![
+            AirwayPoint::new("PUT").with_icao_region(Some("K1".to_owned())),
+            AirwayPoint::new("DREEM").with_icao_region(Some("K1".to_owned())),
+        ],
+    );
+    let airspace = Airspace::new(AirspaceKind::Controlled(ControlledClass::B), "BOS-B")
+        .with_center_ident(Some("KBOS".to_owned()))
+        .with_bounds(Some(Area::BoundingBox {
+            south_west: GeoPoint {
+                lat: 42.0,
+                lon: -71.5,
+            },
+            north_east: GeoPoint {
+                lat: 42.7,
+                lon: -70.5,
+            },
+        }));
+    let snapshot = NavDataSnapshot::new(cycle, points)
+        .with_airways(vec![airway])
+        .with_runways(vec![Runway::new("KBOS", "04L/22R")])
+        .with_airspaces(vec![airspace]);
+    let identity = NavdataIdentityV1 {
+        cycle: navdata_cycle_id(&snapshot),
+        snapshot_id: "snapshot-test-1".to_owned(),
+        snapshot_digest: "sha256:test-digest".to_owned(),
+    };
+    IdentifiedNavdataSnapshotV1::try_new(identity, snapshot).expect("matching cycle")
+}
+
+fn point(ident: &str, kind: NavPointKind, lat: f64, lon: f64, region: &str) -> NavPoint {
+    NavPoint::new(ident, kind, GeoPoint { lat, lon }).with_region(Some(region.to_owned()))
+}
+
+#[test]
+fn same_snapshot_produces_identical_archive_bytes() {
+    let snapshot = identified();
+    let first = build_mbtiles(&snapshot, test_config()).expect("first build");
+    let second = build_mbtiles(&snapshot, test_config()).expect("second build");
+
+    assert_eq!(first.bytes(), second.bytes());
+    assert_eq!(&first.bytes()[..16], b"SQLite format 3\0");
+    assert_eq!(first.report().tile_count, 1);
+    assert_eq!(first.report().archive_bytes, first.bytes().len() as u64);
+}
+
+#[test]
+fn archive_carries_identity_and_reads_without_a_network() {
+    let snapshot = identified();
+    let bundle = build_mbtiles(&snapshot, test_config()).expect("tile build");
+    let reader = OfflineTileReader::from_bytes(bundle.bytes()).expect("offline reader");
+
+    assert_eq!(reader.identity(), snapshot.identity());
+    let tile = reader
+        .tile_xyz(0, 0, 0)
+        .expect("tile query")
+        .expect("global tile");
+    assert_eq!(&tile[..3], &[0x1f, 0x8b, 0x08]);
+    assert!(reader.tile_xyz(1, 2, 0).is_err());
+}
+
+#[test]
+fn every_drawable_feature_has_cycle_scoped_stable_subject_properties() {
+    let snapshot = identified();
+    let bundle = build_mbtiles(&snapshot, test_config()).expect("tile build");
+    let reader = OfflineTileReader::from_bytes(bundle.bytes()).expect("offline reader");
+    let compressed = reader
+        .tile_xyz(0, 0, 0)
+        .expect("tile query")
+        .expect("global tile");
+    let tile = decode_tile(&compressed);
+    let mut seen_layers = Vec::new();
+
+    for layer in &tile.layers {
+        seen_layers.push(layer.name.as_str());
+        for feature in &layer.features {
+            let properties = properties(layer, feature);
+            assert!(properties["subject_id"].starts_with("subject-v1|"));
+            assert_eq!(properties["subject_cycle"], snapshot.identity().cycle);
+            if layer.name == "airways" {
+                assert_eq!(properties["subject_id"], "subject-v1|airway|1:C|2:V1|0:");
+            }
+            assert!(feature.id.is_some());
+        }
+    }
+    seen_layers.sort_unstable();
+    assert_eq!(
+        seen_layers,
+        ["aerodromes", "airspaces", "airways", "fixes", "navaids"]
+    );
+}
+
+#[test]
+fn report_states_drawable_and_typed_omitted_records() {
+    let bundle = build_mbtiles(&identified(), test_config()).expect("tile build");
+    let report = bundle.report();
+
+    assert_eq!(report.features.total(), 5);
+    assert_eq!(report.features.aerodromes, 1);
+    assert_eq!(report.features.navaids, 1);
+    assert_eq!(report.features.fixes, 1);
+    assert_eq!(report.features.airways, 1);
+    assert_eq!(report.features.airspaces, 1);
+    assert_eq!(report.omitted.other_points, 1);
+    assert_eq!(report.omitted.runways_without_geometry, 1);
+    assert_eq!(report.omitted.unresolved_airways, 0);
+}
+
+#[test]
+fn published_airway_gap_does_not_create_a_segment() {
+    let source = identified();
+    let mut raw = source.snapshot().clone();
+    raw.airways[0].points[0].gap_to_next = true;
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(source.identity().clone(), raw)
+        .expect("matching cycle");
+    let bundle = build_mbtiles(&snapshot, test_config()).expect("tile build");
+
+    assert_eq!(bundle.report().features.airways, 0);
+    assert_eq!(bundle.report().omitted.unresolved_airways, 1);
+}
+
+#[test]
+fn empty_snapshot_identity_is_refused() {
+    let source = identified();
+    let identity = NavdataIdentityV1 {
+        cycle: source.identity().cycle.clone(),
+        snapshot_id: String::new(),
+        snapshot_digest: "digest".to_owned(),
+    };
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(identity, source.snapshot().clone())
+        .expect("cycle still matches");
+    let error = build_mbtiles(&snapshot, test_config()).expect_err("empty identity must fail");
+
+    assert!(matches!(
+        error,
+        NavdataTileError::EmptyIdentity {
+            field: "snapshot_id"
+        }
+    ));
+}
+
+#[test]
+fn gzip_header_is_reproducible() {
+    let bundle = build_mbtiles(&identified(), test_config()).expect("tile build");
+    let reader = OfflineTileReader::from_bytes(bundle.bytes()).expect("offline reader");
+    let tile = reader
+        .tile_xyz(0, 0, 0)
+        .expect("tile query")
+        .expect("global tile");
+
+    assert_eq!(&tile[4..8], &[0, 0, 0, 0]);
+    assert_eq!(tile[9], 255);
+}
+
+#[test]
+fn invalid_coordinate_is_a_typed_build_failure() {
+    let source = identified();
+    let mut raw = source.snapshot().clone();
+    raw.points[0].position.lat = 91.0;
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(source.identity().clone(), raw)
+        .expect("matching cycle");
+    let error = build_mbtiles(&snapshot, test_config()).expect_err("latitude must fail");
+
+    assert!(matches!(
+        error,
+        NavdataTileError::InvalidCoordinate { latitude: 91.0, .. }
+    ));
+}
+
+#[test]
+fn invalid_zoom_policy_is_refused_before_tiling() {
+    let mut config = test_config();
+    config.max_zoom = 15;
+    let error = build_mbtiles(&identified(), config).expect_err("zoom must fail");
+
+    assert!(matches!(error, NavdataTileError::InvalidConfig { .. }));
+}
+
+#[test]
+fn connected_airway_segments_use_one_mvt_path() {
+    let source = identified();
+    let mut raw = source.snapshot().clone();
+    raw.points
+        .push(point("JFK", NavPointKind::Navaid, 40.6398, -73.7789, "K1"));
+    raw.airways[0]
+        .points
+        .push(AirwayPoint::new("JFK").with_icao_region(Some("K1".to_owned())));
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(source.identity().clone(), raw)
+        .expect("matching cycle");
+    let bundle = build_mbtiles(&snapshot, test_config()).expect("tile build");
+    let reader = OfflineTileReader::from_bytes(bundle.bytes()).expect("offline reader");
+    let compressed = reader
+        .tile_xyz(0, 0, 0)
+        .expect("tile query")
+        .expect("global tile");
+    let tile = decode_tile(&compressed);
+    let airway = tile
+        .layers
+        .iter()
+        .find(|layer| layer.name == "airways")
+        .and_then(|layer| layer.features.first())
+        .expect("airway feature");
+
+    assert_eq!(airway.geometry[0], 9);
+    assert_eq!(airway.geometry[3], 18);
+}
+
+#[test]
+fn vector_manifest_lists_only_layers_that_occur() {
+    let source = identified();
+    let mut raw = source.snapshot().clone();
+    raw.airspaces.clear();
+    let snapshot = IdentifiedNavdataSnapshotV1::try_new(source.identity().clone(), raw)
+        .expect("matching cycle");
+    let bundle = build_mbtiles(&snapshot, test_config()).expect("tile build");
+    let mut connection = Connection::open_in_memory().expect("in-memory database");
+    connection
+        .deserialize_read_exact(
+            MAIN_DB,
+            Cursor::new(bundle.bytes()),
+            bundle.bytes().len(),
+            true,
+        )
+        .expect("MBTiles bytes");
+    let json: String = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE name = 'json'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("vector metadata");
+
+    assert!(!json.contains("airspaces"));
+    assert!(json.contains("airways"));
+}
+
+fn decode_tile(compressed: &[u8]) -> proto::Tile {
+    let mut decoder = GzDecoder::new(compressed);
+    let mut bytes = Vec::new();
+    decoder.read_to_end(&mut bytes).expect("gzip tile");
+    proto::Tile::decode(bytes.as_slice()).expect("MVT tile")
+}
+
+fn properties(layer: &proto::Layer, feature: &proto::Feature) -> BTreeMap<String, String> {
+    feature
+        .tags
+        .chunks_exact(2)
+        .map(|pair| {
+            let key = layer.keys[pair[0] as usize].clone();
+            let value = layer.values[pair[1] as usize]
+                .string_value
+                .clone()
+                .expect("string property");
+            (key, value)
+        })
+        .collect()
+}

--- a/crates/pilotage-navdata-tiles/src/tile.rs
+++ b/crates/pilotage-navdata-tiles/src/tile.rs
@@ -1,0 +1,174 @@
+//! Spatial partitioning into clipped vector tiles.
+
+use std::collections::BTreeMap;
+
+use crate::config::NavdataTileConfig;
+use crate::feature::{BaselineFeature, BaselineGeometry, LayerKind};
+use crate::geometry::{clip_polygon, clip_segment, point_bounds};
+use crate::mercator::{
+    TileCoord, WorldPoint, bounds, local_point, tile_for_point, tiles_for_bounds,
+};
+use crate::mvt::{TileFeature, TileGeometry};
+
+pub(crate) struct VectorTile {
+    pub(crate) coord: TileCoord,
+    pub(crate) layers: BTreeMap<LayerKind, Vec<TileFeature>>,
+}
+
+pub(crate) struct TiledFeatures {
+    pub(crate) tiles: Vec<VectorTile>,
+    pub(crate) tile_feature_count: u64,
+}
+
+type PendingTiles = BTreeMap<TileCoord, BTreeMap<LayerKind, Vec<TileFeature>>>;
+
+pub(crate) fn partition_features(
+    features: &[BaselineFeature],
+    config: NavdataTileConfig,
+) -> TiledFeatures {
+    let mut pending = PendingTiles::new();
+    for feature in features {
+        let minimum = feature.layer.min_zoom(config);
+        for zoom in minimum..=config.max_zoom {
+            match &feature.geometry {
+                BaselineGeometry::Point(point) => add_point(&mut pending, feature, *point, zoom),
+                BaselineGeometry::Lines(lines) => {
+                    add_lines(&mut pending, feature, lines, zoom);
+                }
+                BaselineGeometry::Polygon(points) => {
+                    add_polygon(&mut pending, feature, points, zoom);
+                }
+            }
+        }
+    }
+    let tile_feature_count = pending
+        .values()
+        .flat_map(BTreeMap::values)
+        .map(|features| features.len() as u64)
+        .sum();
+    let tiles = pending
+        .into_iter()
+        .map(|(coord, layers)| VectorTile { coord, layers })
+        .collect();
+    TiledFeatures {
+        tiles,
+        tile_feature_count,
+    }
+}
+
+fn add_point(pending: &mut PendingTiles, feature: &BaselineFeature, point: WorldPoint, zoom: u8) {
+    let tile = tile_for_point(point, zoom);
+    push_feature(
+        pending,
+        tile,
+        feature,
+        TileGeometry::Point(local_point(point, tile)),
+    );
+}
+
+fn add_lines(
+    pending: &mut PendingTiles,
+    feature: &BaselineFeature,
+    lines: &[Vec<WorldPoint>],
+    zoom: u8,
+) {
+    let mut by_tile: BTreeMap<TileCoord, Vec<Vec<(i32, i32)>>> = BTreeMap::new();
+    for line in lines {
+        let mut line_by_tile: BTreeMap<TileCoord, Vec<Vec<(i32, i32)>>> = BTreeMap::new();
+        for segment in line.windows(2) {
+            let Some((min, max)) = point_bounds(segment) else {
+                continue;
+            };
+            for tile in tiles_for_bounds(min, max, zoom) {
+                let Some((start, end)) = clip_segment(segment[0], segment[1], bounds(tile)) else {
+                    continue;
+                };
+                let local = vec![local_point(start, tile), local_point(end, tile)];
+                if local[0] != local[1] {
+                    append_segment(line_by_tile.entry(tile).or_default(), local);
+                }
+            }
+        }
+        for (tile, parts) in line_by_tile {
+            by_tile.entry(tile).or_default().extend(parts);
+        }
+    }
+    for (tile, parts) in by_tile {
+        push_feature(pending, tile, feature, TileGeometry::Lines(parts));
+    }
+}
+
+fn append_segment(parts: &mut Vec<Vec<(i32, i32)>>, segment: Vec<(i32, i32)>) {
+    if let Some(part) = parts
+        .last_mut()
+        .filter(|part| part.last() == segment.first())
+    {
+        part.extend_from_slice(&segment[1..]);
+    } else {
+        parts.push(segment);
+    }
+}
+
+fn add_polygon(
+    pending: &mut PendingTiles,
+    feature: &BaselineFeature,
+    points: &[WorldPoint],
+    zoom: u8,
+) {
+    let Some((min, max)) = point_bounds(points) else {
+        return;
+    };
+    for tile in tiles_for_bounds(min, max, zoom) {
+        let clipped = clip_polygon(points, bounds(tile));
+        if clipped.len() < 3 {
+            continue;
+        }
+        let local: Vec<_> = clipped
+            .into_iter()
+            .map(|point| local_point(point, tile))
+            .collect();
+        if polygon_is_drawable(&local) {
+            push_feature(pending, tile, feature, TileGeometry::Polygon(local));
+        }
+    }
+}
+
+fn push_feature(
+    pending: &mut PendingTiles,
+    tile: TileCoord,
+    feature: &BaselineFeature,
+    geometry: TileGeometry,
+) {
+    pending
+        .entry(tile)
+        .or_default()
+        .entry(feature.layer)
+        .or_default()
+        .push(TileFeature {
+            id: feature.feature_id,
+            properties: feature.properties.clone(),
+            geometry,
+        });
+}
+
+fn polygon_is_drawable(points: &[(i32, i32)]) -> bool {
+    let mut unique = Vec::new();
+    for point in points {
+        if unique.last() != Some(point) {
+            unique.push(*point);
+        }
+    }
+    if unique.first() == unique.last() {
+        unique.pop();
+    }
+    if unique.len() < 3 {
+        return false;
+    }
+    let mut area = 0i64;
+    for index in 0..unique.len() {
+        let next = index.wrapping_add(1) % unique.len();
+        area += i64::from(unique[index].0) * i64::from(unique[next].1)
+            - i64::from(unique[next].0) * i64::from(unique[index].1);
+    }
+    area != 0
+}

--- a/docs/navdata-baseline-tile-bundle.md
+++ b/docs/navdata-baseline-tile-bundle.md
@@ -1,0 +1,131 @@
+# Navdata baseline tile bundle
+
+## Purpose
+
+The build converts one identified Navdata snapshot to one offline tile bundle.
+Run the build one time for each Navdata cycle. Do not run it on the client.
+
+The bundle is a renderer-edge encoding. It is not domain state.
+
+## Format decision
+
+The bundle uses MBTiles 1.3. Each tile is a gzip-compressed Mapbox Vector Tile
+2.1 Protocol Buffer.
+
+MapLibre Native reads MBTiles from an application bundle on iOS. This path does
+not require a local HTTP server. The `maplibre-rs` local source can read the same
+SQLite rows and give the same Mapbox Vector Tile bytes to the renderer.
+
+The build does not use PMTiles. The validated iOS path uses MBTiles. No validated
+PMTiles path exists. A tile directory would use more files and would not add a
+client capability.
+
+The format follows the [MBTiles 1.3 specification](https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md)
+and the [Mapbox Vector Tile 2.1 specification](https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md).
+
+## Identity
+
+The metadata table has these required Pilotage rows.
+
+| Row | Meaning |
+|---|---|
+| `pilotage_schema` | Tile bundle schema version. |
+| `pilotage_cycle` | Navdata authority and effective date. |
+| `pilotage_snapshot_id` | Immutable snapshot identity. |
+| `pilotage_snapshot_digest` | Digest of the canonical snapshot payload. |
+
+Each feature has `subject_id` and `subject_cycle` properties. The
+`subject_id` value is stable in one cycle. A live overlay can use the same value
+to name the baseline subject. The composition must compare the cycle values
+before it joins two sources.
+
+## Layer split
+
+Schema version 1 has these baseline layers.
+
+| Layer | First zoom | Geometry |
+|---|---:|---|
+| `airspaces` | 0 | Published horizontal bounds. |
+| `airways` | 2 | Resolved published segments. |
+| `aerodromes` | 3 | Published points. |
+| `navaids` | 5 | Published points. |
+| `fixes` | 6 | Published points. |
+
+An airway gap does not make a line segment. An unresolved airway point does not
+make a line segment. The report counts an airway as omitted when it has no
+resolved segment.
+
+The schema version 1 input has runway attributes but has no WGS84 runway-end
+positions. The bundle omits runways and reports the count. A later schema can
+add a runway layer when its Navdata input carries the required positions.
+
+The schema version 1 input has no procedure collection. The bundle has no
+procedure layer.
+
+Airspace bounds can enclose more area than the exact boundary. The feature
+property `geometry_quality=snapshot_bound` identifies this limit. Do not use the
+tile geometry for a regulatory decision.
+
+Weather, traffic, and aeronautical updates stay in live presentation layers.
+They do not enter the cycle bundle.
+
+## Offline access
+
+The application installs the MBTiles file as a bundle resource. The Swift
+binding gives MapLibre Native an absolute `mbtiles://` URL. The style does not
+contain a device path.
+
+`OfflineTileReader` opens installed archive bytes in a read-only SQLite
+database. It has no network dependency. It verifies the schema and the three
+Navdata identity values before it returns a tile.
+
+## Reproducibility
+
+The builder orders metadata, tiles, layers, properties, and values. It clips
+geometry in Web Mercator coordinates. It uses a fixed tile extent. It writes a
+gzip header with a zero time value. It writes a fixed SQLite schema and page
+size, and then it runs `VACUUM`.
+
+The same identified snapshot and the same configuration produce identical
+archive bytes. The continuous integration test builds the same fixture two
+times and compares all bytes.
+
+## Operator command
+
+Run this command with an `.acnav` snapshot blob and an output path.
+
+```text
+cargo run --release -p pilotage-navdata-tiles \
+  --example build_navdata_tiles -- INPUT.acnav OUTPUT.mbtiles
+```
+
+The example decodes the blob before it calls the builder. The builder receives
+only an `IdentifiedNavdataSnapshotV1` value.
+
+## Full-cycle measurement
+
+The measurement used the FAA NASR cycle effective on 2026-06-11. It used the
+format version 4 snapshot. The host was an Apple M3 Max with 16 CPU cores and
+48 GB of memory. The host used macOS 27.0 build 26A5368g and Rust 1.95.0. The
+build used the release profile on 2026-08-09.
+
+| Fact | Value |
+|---|---:|
+| Input size | 4,489,535 bytes |
+| Input payload SHA-256 | `8be6d025d4731fd6353055fa8913516d959869971457fded6a0b6a67c9ef421a` |
+| Input points | 93,595 |
+| Input airways | 1,519 |
+| Input runways | 23,178 |
+| Input airspaces | 0 |
+| Drawable aerodromes | 22,024 |
+| Drawable navaids | 1,553 |
+| Drawable fixes | 70,018 |
+| Drawable airways | 1,414 |
+| Populated tiles | 7,354 |
+| Tile feature copies | 385,745 |
+| Output size | 17,448,960 bytes |
+| First build time | 2.276 seconds |
+| Second build time | 2.400 seconds |
+| Output SHA-256 from both builds | `10a7f0392a5f1d0c653f03725d0e5b4c470a1940e1de9bf8b872de2b0e1788cf` |
+
+The two output files had identical bytes.

--- a/scripts/check-navdata-tile-bundle.sh
+++ b/scripts/check-navdata-tile-bundle.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Keep the Navdata tile build deterministic, identified, and offline.
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+crate="$root/crates/pilotage-navdata-tiles"
+manifest="$crate/Cargo.toml"
+builder="$crate/src/build.rs"
+archive="$crate/src/archive.rs"
+reader="$crate/src/reader.rs"
+tests="$crate/src/tests.rs"
+contract="$root/docs/navdata-baseline-tile-bundle.md"
+status=0
+
+require_text() {
+    local pattern="$1"
+    local file="$2"
+    local message="$3"
+    if [ ! -f "$file" ] || ! grep -qF "$pattern" "$file"; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+if [ -f "$manifest" ] && grep -Eq '^(reqwest|hyper|ureq|wtransport|tokio)[[:space:]]*=' "$manifest"; then
+    echo "FORBIDDEN: the Navdata tile crate has a network or async transport dependency" >&2
+    status=1
+fi
+
+if [ -f "$builder" ] && grep -Eq 'std::fs|fs::|aerocontext_navdata|inspect\(|decode\(' "$builder"; then
+    echo "FORBIDDEN: the tile builder reads a source file instead of an identified snapshot" >&2
+    status=1
+fi
+
+require_text 'snapshot: &IdentifiedNavdataSnapshotV1' "$builder" \
+    'the builder must accept one identified Navdata snapshot'
+require_text 'pilotage_cycle' "$archive" \
+    'the archive must carry the Navdata cycle identity'
+require_text 'pilotage_snapshot_id' "$archive" \
+    'the archive must carry the snapshot identity'
+require_text 'pilotage_snapshot_digest' "$archive" \
+    'the archive must carry the snapshot digest'
+require_text '("format", "pbf".to_owned())' "$archive" \
+    'the archive must identify Mapbox Vector Tile payloads'
+require_text 'GzBuilder::new()' "$archive" \
+    'the archive must gzip each vector tile deterministically'
+require_text 'pub struct OfflineTileReader' "$reader" \
+    'the crate must keep a no-network installed-bundle reader'
+require_text 'subject_id' "$crate/src/feature.rs" \
+    'each drawable feature must carry a stable subject identifier'
+require_text 'same_snapshot_produces_identical_archive_bytes' "$tests" \
+    'the crate must compare complete archive bytes across two builds'
+require_text 'Output SHA-256 from both builds' "$contract" \
+    'the contract must record a full-cycle reproducibility measurement'
+require_text 'The two output files had identical bytes.' "$contract" \
+    'the full-cycle measurement must state the reproducibility result'
+
+if [ "$status" -ne 0 ]; then
+    echo "Navdata tile bundle guard: FAILED" >&2
+    exit 1
+fi
+
+echo "Navdata tile bundle guard: OK"

--- a/scripts/test-check-navdata-tile-bundle.sh
+++ b/scripts/test-check-navdata-tile-bundle.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Exercise the failure paths in the Navdata tile bundle guard.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-navdata-tiles.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/crates" "$fixture/docs"
+cp -R "$repo_root/crates/pilotage-navdata-tiles" "$fixture/crates/"
+cp "$repo_root/docs/navdata-baseline-tile-bundle.md" "$fixture/docs/"
+
+guard="$repo_root/scripts/check-navdata-tile-bundle.sh"
+bash "$guard" "$fixture" >/dev/null
+
+printf '\nreqwest = "0.12"\n' >> "$fixture/crates/pilotage-navdata-tiles/Cargo.toml"
+if bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a network dependency" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-navdata-tiles/Cargo.toml" \
+    "$fixture/crates/pilotage-navdata-tiles/Cargo.toml"
+
+sed -i.bak 's/snapshot: &IdentifiedNavdataSnapshotV1/snapshot: \&NavDataSnapshot/' \
+    "$fixture/crates/pilotage-navdata-tiles/src/build.rs"
+if bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a builder without snapshot identity" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-navdata-tiles/src/build.rs" \
+    "$fixture/crates/pilotage-navdata-tiles/src/build.rs"
+
+sed -i.bak '/pilotage_snapshot_digest/d' \
+    "$fixture/crates/pilotage-navdata-tiles/src/archive.rs"
+if bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted missing digest metadata" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-navdata-tiles/src/archive.rs" \
+    "$fixture/crates/pilotage-navdata-tiles/src/archive.rs"
+
+sed -i.bak 's/subject_id/baseline_id/g' \
+    "$fixture/crates/pilotage-navdata-tiles/src/feature.rs"
+if bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted features without subject identifiers" >&2
+    exit 1
+fi
+cp "$repo_root/crates/pilotage-navdata-tiles/src/feature.rs" \
+    "$fixture/crates/pilotage-navdata-tiles/src/feature.rs"
+
+sed -i.bak '/same_snapshot_produces_identical_archive_bytes/d' \
+    "$fixture/crates/pilotage-navdata-tiles/src/tests.rs"
+if bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: the guard accepted a missing byte reproducibility test" >&2
+    exit 1
+fi
+
+echo "Navdata tile bundle guard self-test: OK"


### PR DESCRIPTION
Closes #350

Summary
- build deterministic gzip-compressed Mapbox Vector Tiles in MBTiles 1.3 from one identified Navdata snapshot
- carry cycle, snapshot identity, and snapshot digest in archive metadata
- add stable subject identity properties to aerodrome, navaid, fix, airway, and airspace features
- provide a read-only offline archive reader with no network dependency
- report runways and unresolved geometry instead of inventing positions

Guardrail
- add a self-tested CI guard for the identified-snapshot boundary, offline dependencies, bundle identity, stable subject IDs, and byte reproducibility

Full-cycle evidence
- FAA NASR 2026-06-11 format v4
- 7,354 populated tiles and 95,009 drawable records
- 17,448,960 output bytes
- 2.276 s and 2.400 s release builds
- both outputs: SHA-256 10a7f0392a5f1d0c653f03725d0e5b4c470a1940e1de9bf8b872de2b0e1788cf

Review fixes
- list only layers that occur in the MBTiles vector manifest
- keep connected airway segments in one MVT path and split published gaps

Verification
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- RUSTDOCFLAGS=-D missing_docs -D rustdoc::broken_intra_doc_links cargo doc --no-deps
- cargo build --release
- Navdata tile bundle guard and self-test
- repository structure guard