### PR TITLE
Carry ADS-B altitude into traffic display points

### DIFF
--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
@@ -136,6 +136,8 @@ pub struct DisplayPoint {
     pub style_id: String,
     /// Primary label.
     pub label: Option<String>,
+    /// Selected display altitude in feet.
+    pub altitude_ft: Option<i32>,
     /// Clockwise rotation from geographic north.
     pub rotation_deg: f64,
     /// Producer instance identity.
@@ -322,6 +324,7 @@ impl From<pilotage_presentation::PointFeature> for DisplayPoint {
             coordinate: value.coordinate.into(),
             style_id: value.style_id,
             label: value.label,
+            altitude_ft: value.altitude_ft,
             rotation_deg: value.rotation_deg,
             producer_instance_id: value.producer_instance_id,
             snapshot_revision: value.snapshot_revision,

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
@@ -23,6 +23,7 @@ fn versioned_track_record_crosses_the_facade() {
 
     assert_eq!(batch.points.len(), 1);
     assert_eq!(batch.points[0].snapshot_revision, 2);
+    assert_eq!(batch.points[0].altitude_ft, Some(5_500));
     assert_eq!(batch.point_changes.len(), 1);
     assert_eq!(batch.point_changes[0].kind, DisplayPointChangeKind::Upsert);
 }
@@ -147,11 +148,22 @@ fn positionless_track_crosses_as_a_list_item() {
 
 fn track_record(id: u64, revision: u64, latitude_deg: f64) -> TrackRecord {
     let mut track = TrackSnapshot::new(TrackId::new(id), track_key(id), 10);
-    track.position = Some(TimedField::new(
-        Wgs84Position {
-            latitude_deg,
-            longitude_deg: -71.0,
-        },
+    track.position = Some(timed(Wgs84Position {
+        latitude_deg,
+        longitude_deg: -71.0,
+    }));
+    track.pressure_altitude_ft = Some(timed(5_500));
+    let handle = TrackSnapshotHandle::new(
+        ProducerInstanceId::new(8),
+        SnapshotRevision::new(revision),
+        track,
+    );
+    TrackRecord::new(TrackDelta::Updated(handle))
+}
+
+fn timed<T>(value: T) -> TimedField<T> {
+    TimedField::new(
+        value,
         ObservationTime::local(10),
         FieldQuality::default(),
         FieldProvenance::new(
@@ -159,13 +171,7 @@ fn track_record(id: u64, revision: u64, latitude_deg: f64) -> TrackRecord {
             AddressNamespace::Icao,
             SourceRef::default(),
         ),
-    ));
-    let handle = TrackSnapshotHandle::new(
-        ProducerInstanceId::new(8),
-        SnapshotRevision::new(revision),
-        track,
-    );
-    TrackRecord::new(TrackDelta::Updated(handle))
+    )
 }
 
 fn track_key(id: u64) -> TrackKey {

--- a/crates/pilotage-presentation/src/model.rs
+++ b/crates/pilotage-presentation/src/model.rs
@@ -134,6 +134,8 @@ pub struct PointFeature {
     pub style_id: String,
     /// Primary label.
     pub label: Option<String>,
+    /// Selected display altitude in feet.
+    pub altitude_ft: Option<i32>,
     /// Clockwise rotation from geographic north.
     pub rotation_deg: f64,
     /// Producer instance identity.

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -26,6 +26,27 @@ fn active_track_becomes_a_policy_styled_upsert() {
 }
 
 #[test]
+fn pressure_altitude_is_the_traffic_comparison_value() {
+    let point = point_with_altitudes(Some(5_500), Some(5_650));
+
+    assert_eq!(point.altitude_ft, Some(5_500));
+}
+
+#[test]
+fn geometric_altitude_is_the_display_fallback() {
+    let point = point_with_altitudes(None, Some(5_650));
+
+    assert_eq!(point.altitude_ft, Some(5_650));
+}
+
+#[test]
+fn absent_track_altitude_stays_absent() {
+    let point = point_with_altitudes(None, None);
+
+    assert_eq!(point.altitude_ft, None);
+}
+
+#[test]
 fn ownship_shadow_is_not_a_traffic_target() {
     let mut adapter = PresentationAdapter::new();
     let delta = updated_delta(42, 3, true, EmergencyState::None);
@@ -211,6 +232,28 @@ fn updated_delta_with_latitude(id: u64, revision: u64, latitude_deg: f64) -> Tra
         SnapshotRevision::new(revision),
         track,
     ))
+}
+
+fn point_with_altitudes(
+    pressure_altitude_ft: Option<i32>,
+    geometric_altitude_ft: Option<i32>,
+) -> crate::PointFeature {
+    let mut track = complete_track(42);
+    track.pressure_altitude_ft = pressure_altitude_ft.map(radio_timed);
+    track.geometric_altitude_ft = geometric_altitude_ft.map(radio_timed);
+    let delta = TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(3),
+        track,
+    ));
+    let mut adapter = PresentationAdapter::new();
+    let change = adapter
+        .apply_traffic_delta(&delta)
+        .expect("positioned track must produce a point");
+    let PointChange::Upsert { point } = change else {
+        panic!("positioned track must produce an upsert");
+    };
+    point
 }
 
 fn track_handle(

--- a/crates/pilotage-presentation/src/traffic.rs
+++ b/crates/pilotage-presentation/src/traffic.rs
@@ -59,6 +59,7 @@ fn point_for_feature(feature: &AircraftFeature) -> Option<PointFeature> {
         coordinate,
         style_id: traffic_style(feature).into(),
         label: traffic_display_label(feature),
+        altitude_ft: display_altitude_ft(feature),
         rotation_deg: track
             .velocity
             .as_ref()
@@ -67,6 +68,21 @@ fn point_for_feature(feature: &AircraftFeature) -> Option<PointFeature> {
         producer_instance_id: feature.producer_instance_id().get(),
         snapshot_revision: feature.snapshot_revision().get(),
     })
+}
+
+fn display_altitude_ft(feature: &AircraftFeature) -> Option<i32> {
+    let track = feature.snapshot();
+    // Traffic displays compare the pressure altitude that transponders report.
+    track
+        .pressure_altitude_ft
+        .as_ref()
+        .map(|field| field.value)
+        .or_else(|| {
+            track
+                .geometric_altitude_ft
+                .as_ref()
+                .map(|field| field.value)
+        })
 }
 
 fn traffic_style(feature: &AircraftFeature) -> &'static str {

--- a/crates/pilotage-presentation/src/weather.rs
+++ b/crates/pilotage-presentation/src/weather.rs
@@ -56,6 +56,7 @@ fn point_for_report(feature: &TextReportFeature) -> Option<PointFeature> {
         )
         .into(),
         label: Some(feature.id().station_id().as_str().into()),
+        altitude_ft: None,
         rotation_deg: 0.0,
         producer_instance_id: feature.id().producer_instance_id().get(),
         snapshot_revision: revisions.snapshot_revision().get(),


### PR DESCRIPTION
## Summary

- Add optional `altitude_ft` to each display point and Apple FFI point.
- Use pressure altitude when it is available.
- Use geometric altitude only when pressure altitude is not available.
- Keep altitude absent when the track has no altitude.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- `cargo test --manifest-path clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml --all-targets`
- `scripts/check-situation-presentation-boundary.sh`

Closes #368