### PR TITLE
Raise traffic and weather to the altitude they report

### DIFF
--- a/clients/apple-situation/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift
+++ b/clients/apple-situation/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift
@@ -47,12 +47,24 @@ public struct GeoJSONPolygonFeature: Equatable, Sendable {
     public let rings: [[GeoJSONPosition]]
     /// Ready-to-display text.
     public let label: String?
+    /// Floor of the shape, in metres above the terrain surface beneath it.
+    public let baseAboveTerrainMetres: Double?
+    /// Ceiling of the shape, in metres above the terrain surface beneath it.
+    public let topAboveTerrainMetres: Double?
 
     /// Create one polygon feature.
-    public init(id: String, rings: [[GeoJSONPosition]], label: String?) {
+    public init(
+        id: String,
+        rings: [[GeoJSONPosition]],
+        label: String?,
+        baseAboveTerrainMetres: Double? = nil,
+        topAboveTerrainMetres: Double? = nil
+    ) {
         self.id = id
         self.rings = rings
         self.label = label
+        self.baseAboveTerrainMetres = baseAboveTerrainMetres
+        self.topAboveTerrainMetres = topAboveTerrainMetres
     }
 }
 
@@ -95,6 +107,12 @@ public enum GeoJSONFeatureCollectionEncoder {
     private static func polygonObject(_ polygon: GeoJSONPolygonFeature) -> [String: Any] {
         var properties: [String: Any] = [:]
         properties["label"] = polygon.label
+        // A renderer reads a raised height from the feature, so the height travels as a
+        // property rather than as a constant on the layer.
+        // Both keys are always written. A key-path expression on a missing property has
+        // no height to read, and the shape would vanish rather than lie flat.
+        properties["base"] = polygon.baseAboveTerrainMetres ?? 0
+        properties["top"] = polygon.topAboveTerrainMetres ?? 0
         return [
             "geometry": [
                 "coordinates": polygon.rings.map { $0.map(positionObject) },

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
@@ -115,7 +115,11 @@ final class SituationOverlay {
             .map(GeoJSONPolygonFeature.init)
         let data = try GeoJSONFeatureCollectionEncoder.encode(polygons: features)
         let source = try addSource(data: data, identifier: sourceID("shape", shapeStyle.id), to: mapStyle)
-        addFillLayer(style: shapeStyle, source: source, to: mapStyle)
+        if shapeStyle.extruded {
+            addFillExtrusionLayer(style: shapeStyle, source: source, to: mapStyle)
+        } else {
+            addFillLayer(style: shapeStyle, source: source, to: mapStyle)
+        }
         addLineLayer(style: shapeStyle, source: source, to: mapStyle)
         addShapeLabelLayer(style: shapeStyle, source: source, to: mapStyle)
     }
@@ -185,6 +189,24 @@ final class SituationOverlay {
     ) {
         let layer = MLNFillStyleLayer(identifier: layerID("fill", style.id), source: source)
         layer.fillColor = constant(color(style.fill))
+        add(layer, to: mapStyle)
+    }
+
+    /// Raise one shape family between the heights its features carry.
+    ///
+    /// A polygon draped on the terrain cannot say how high a target or a weather volume
+    /// sits. A feature with no height falls back to the surface, which draws the same
+    /// outline a flat fill would.
+    private func addFillExtrusionLayer(
+        style: DisplayShapeStyle,
+        source: MLNShapeSource,
+        to mapStyle: MLNStyle
+    ) {
+        let layer = MLNFillExtrusionStyleLayer(identifier: layerID("fill", style.id), source: source)
+        layer.fillExtrusionColor = constant(color(style.fill))
+        layer.fillExtrusionOpacity = constant(Double(style.fill.alpha) / 255.0)
+        layer.fillExtrusionBase = NSExpression(forKeyPath: "base")
+        layer.fillExtrusionHeight = NSExpression(forKeyPath: "top")
         add(layer, to: mapStyle)
     }
 
@@ -329,7 +351,9 @@ private extension GeoJSONPolygonFeature {
                     )
                 }
             },
-            label: shape.label
+            label: shape.label,
+            baseAboveTerrainMetres: shape.baseAboveTerrainM,
+            topAboveTerrainMetres: shape.topAboveTerrainM
         )
     }
 }

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
@@ -119,6 +119,8 @@ pub struct DisplayShapeStyle {
     pub label_offset_y: f64,
     /// Whether the label can overlap another symbol.
     pub label_allows_overlap: bool,
+    /// Whether the renderer raises this shape to the heights its features carry.
+    pub extruded: bool,
     /// Order among shape styles.
     pub order: i32,
 }
@@ -189,6 +191,10 @@ pub struct DisplayShape {
     pub style_id: String,
     /// Feature label.
     pub label: Option<String>,
+    /// Floor of the shape, in metres above the terrain surface beneath it.
+    pub base_above_terrain_m: Option<f64>,
+    /// Ceiling of the shape, in metres above the terrain surface beneath it.
+    pub top_above_terrain_m: Option<f64>,
     /// Producer instance identity.
     pub producer_instance_id: u64,
     /// Snapshot revision.
@@ -311,6 +317,7 @@ impl From<pilotage_presentation::ShapeStyle> for DisplayShapeStyle {
             label_offset_x: value.label_offset_x,
             label_offset_y: value.label_offset_y,
             label_allows_overlap: value.label_allows_overlap,
+            extruded: value.extruded,
             order: value.order,
         }
     }
@@ -395,6 +402,8 @@ impl From<pilotage_presentation::ShapeFeature> for DisplayShape {
                 .collect(),
             style_id: value.style_id,
             label: value.label,
+            base_above_terrain_m: value.base_above_terrain_m,
+            top_above_terrain_m: value.top_above_terrain_m,
             producer_instance_id: value.producer_instance_id,
             snapshot_revision: value.snapshot_revision,
         }

--- a/crates/pilotage-presentation/src/model.rs
+++ b/crates/pilotage-presentation/src/model.rs
@@ -117,6 +117,11 @@ pub struct ShapeStyle {
     pub label_offset_y: f64,
     /// Whether the label can overlap another symbol.
     pub label_allows_overlap: bool,
+    /// Whether the renderer raises this shape to the heights its features carry.
+    ///
+    /// A style that is not extruded draws flat on the terrain surface however the feature
+    /// states its heights, because a renderer without a terrain build cannot raise it.
+    pub extruded: bool,
     /// Order among shape styles. A greater value is above a smaller value.
     pub order: i32,
 }
@@ -189,6 +194,15 @@ pub struct ShapeFeature {
     pub style_id: String,
     /// Feature label.
     pub label: Option<String>,
+    /// Floor of the shape, in metres above the terrain surface beneath it.
+    ///
+    /// The renderer measures a raised shape from the terrain surface, and a reported
+    /// altitude is measured from mean sea level. The difference is the terrain elevation
+    /// under the feature, which this crate cannot read, so a shape over high ground rides
+    /// that much too high. The label carries the reported altitude and stays exact.
+    pub base_above_terrain_m: Option<f64>,
+    /// Ceiling of the shape, in metres above the terrain surface beneath it.
+    pub top_above_terrain_m: Option<f64>,
     /// Producer instance identity.
     pub producer_instance_id: u64,
     /// Snapshot revision.

--- a/crates/pilotage-presentation/src/policy.rs
+++ b/crates/pilotage-presentation/src/policy.rs
@@ -14,6 +14,7 @@ use crate::{DisplayBatch, PointChange, PointFeature, PointStyle, ShapeFeature, S
 pub(crate) const TRAFFIC_ACTIVE_STYLE: &str = "traffic-active";
 pub(crate) const TRAFFIC_COASTING_STYLE: &str = "traffic-coasting";
 pub(crate) const TRAFFIC_EMERGENCY_STYLE: &str = "traffic-emergency";
+pub(crate) const TRAFFIC_ALTITUDE_STYLE: &str = "traffic-altitude";
 pub(crate) const WEATHER_VFR_STYLE: &str = "weather-vfr";
 pub(crate) const WEATHER_MVFR_STYLE: &str = "weather-mvfr";
 pub(crate) const WEATHER_IFR_STYLE: &str = "weather-ifr";
@@ -30,6 +31,7 @@ pub(crate) const ADVISORY_CWA_STYLE: &str = "advisory-cwa";
 pub struct PresentationAdapter {
     layers: LayerPolicy,
     traffic_points: BTreeMap<(u64, u64), PointFeature>,
+    traffic_pads: BTreeMap<(u64, u64), ShapeFeature>,
     traffic_revisions: BTreeMap<(u64, u64), u64>,
     traffic_tracks: BTreeMap<(u64, u64), TrackSnapshotHandle>,
     weather_points: BTreeMap<String, PointFeature>,
@@ -146,6 +148,7 @@ impl PresentationAdapter {
     /// Clear state supplied by radio reception and keep application controls.
     pub fn clear_radio_state(&mut self) {
         self.traffic_points.clear();
+        self.traffic_pads.clear();
         self.traffic_revisions.clear();
         self.traffic_tracks.clear();
         self.weather_points.clear();
@@ -158,6 +161,7 @@ impl PresentationAdapter {
         let mut batch = self.empty_batch();
         if self.layers.is_enabled(TRAFFIC_LAYER_ID) {
             batch.points.extend(self.traffic_points.values().cloned());
+            batch.shapes.extend(self.traffic_pads.values().cloned());
             batch.positionless_traffic = self
                 .traffic_tracks
                 .values()
@@ -216,6 +220,12 @@ impl PresentationAdapter {
     fn apply_point_change(&mut self, key: (u64, u64), change: &PointChange) {
         match change {
             PointChange::Upsert { point } => {
+                match crate::traffic::altitude_pad(point) {
+                    Some(pad) => self.traffic_pads.insert(key, pad),
+                    // A track that loses its altitude must lose its pad with it, or the
+                    // display keeps a height the track no longer reports.
+                    None => self.traffic_pads.remove(&key),
+                };
                 self.traffic_points.insert(key, point.clone());
             }
             PointChange::Stale {
@@ -230,6 +240,7 @@ impl PresentationAdapter {
             }
             PointChange::Remove { .. } => {
                 self.traffic_points.remove(&key);
+                self.traffic_pads.remove(&key);
             }
         }
     }
@@ -286,37 +297,50 @@ fn point(
 
 fn shape_styles() -> Vec<ShapeStyle> {
     vec![
-        shape(
+        extruded_shape(
+            TRAFFIC_ALTITUDE_STYLE,
+            [0, 229, 255, 150],
+            [0, 229, 255, 255],
+            60,
+        ),
+        extruded_shape(
             ADVISORY_AIRMET_STYLE,
             [255, 193, 7, 70],
             [255, 193, 7, 255],
             10,
         ),
-        shape(
+        extruded_shape(
             ADVISORY_G_AIRMET_STYLE,
             [255, 152, 0, 70],
             [255, 152, 0, 255],
             20,
         ),
-        shape(
+        extruded_shape(
             ADVISORY_CWA_STYLE,
             [156, 39, 176, 70],
             [206, 147, 216, 255],
             30,
         ),
-        shape(
+        extruded_shape(
             ADVISORY_SIGMET_STYLE,
             [244, 67, 54, 75],
             [244, 67, 54, 255],
             40,
         ),
-        shape(
+        extruded_shape(
             ADVISORY_CONVECTIVE_STYLE,
             [213, 0, 0, 85],
             [255, 82, 82, 255],
             50,
         ),
     ]
+}
+
+fn extruded_shape(id: &str, fill: [u8; 4], outline: [u8; 4], order: i32) -> ShapeStyle {
+    ShapeStyle {
+        extruded: true,
+        ..shape(id, fill, outline, order)
+    }
 }
 
 fn shape(id: &str, fill: [u8; 4], outline: [u8; 4], order: i32) -> ShapeStyle {
@@ -331,6 +355,7 @@ fn shape(id: &str, fill: [u8; 4], outline: [u8; 4], order: i32) -> ShapeStyle {
         label_offset_x: 0.0,
         label_offset_y: 0.0,
         label_allows_overlap: false,
+        extruded: false,
         order,
     }
 }

--- a/crates/pilotage-presentation/src/tests/advisory.rs
+++ b/crates/pilotage-presentation/src/tests/advisory.rs
@@ -67,6 +67,35 @@ fn each_advisory_type_selects_its_own_color() {
 }
 
 #[test]
+fn a_band_states_each_limit_in_its_own_reference() {
+    // A flight level printed as a mean-sea-level height, or a surface limit printed as
+    // zero feet, states an altitude the advisory never gave.
+    let band = AdvisoryAltitudeBand::new(
+        AdvisoryAltitude::new(0, AdvisoryAltitudeReference::Surface),
+        AdvisoryAltitude::new(24_000, AdvisoryAltitudeReference::FlightLevel),
+    )
+    .expect("fixture band is ordered");
+    let mut store = weather_store();
+    let current = store
+        .accept(
+            advisory_ingress_with_band(WeatherAdvisoryType::Airmet, band),
+            time(100),
+        )
+        .expect("an advisory must be valid")
+        .into_publication()
+        .expect("an advisory must publish");
+    let mut adapter = PresentationAdapter::new();
+    for delta in map_snapshot_transition(None, current.envelope(), &station_position) {
+        adapter.apply_weather_delta(&delta);
+    }
+
+    let batch = adapter.adapt();
+
+    assert_eq!(batch.shapes.len(), 1);
+    assert_eq!(batch.shapes[0].label.as_deref(), Some("AIRMET SFC-FL240"));
+}
+
+#[test]
 fn a_disabled_advisory_layer_withholds_the_shape_and_keeps_it() {
     let mut adapter = PresentationAdapter::new();
     assert!(adapter.set_layer_enabled(WEATHER_ADVISORY_LAYER_ID, false));
@@ -133,6 +162,13 @@ fn weather_store() -> WeatherStore {
 }
 
 fn advisory_ingress(advisory_type: WeatherAdvisoryType) -> WeatherIngress {
+    advisory_ingress_with_band(advisory_type, band())
+}
+
+fn advisory_ingress_with_band(
+    advisory_type: WeatherAdvisoryType,
+    band: AdvisoryAltitudeBand,
+) -> WeatherIngress {
     // The store rejects an advisory whose validity does not match the product period, so
     // the fixture states one interval in both places.
     let validity = AdvisoryValidity::Period(UtcInterval::new(
@@ -145,7 +181,7 @@ fn advisory_ingress(advisory_type: WeatherAdvisoryType) -> WeatherIngress {
         present(validity),
         present(geometry()),
         absent(),
-        present(band()),
+        present(band),
     );
     let product = WeatherProduct::new(
         field(WeatherPayload::new("application/octet-stream", Vec::new())),

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -335,3 +335,66 @@ fn radio_timed<T>(value: T) -> TimedField<T> {
         ),
     )
 }
+
+#[test]
+fn a_track_with_an_altitude_draws_a_pad_at_that_height() {
+    // A symbol is draped on the terrain surface whatever altitude it carries, so the pad
+    // is the only part of the display that answers "above me or below me". A regression
+    // here shows as traffic that silently returns to one flat plane.
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&delta_with_altitude(42, 3, Some(5_500)));
+
+    let batch = adapter.adapt();
+
+    assert_eq!(batch.shapes.len(), 1, "one track must draw one pad");
+    let pad = &batch.shapes[0];
+    assert_eq!(pad.layer_id, TRAFFIC_LAYER_ID);
+    assert_eq!(pad.style_id, "traffic-altitude");
+    let base = pad.base_above_terrain_m.expect("a pad states its floor");
+    let top = pad.top_above_terrain_m.expect("a pad states its ceiling");
+    assert!((base - 5_500.0 * 0.3048).abs() < 1e-6);
+    assert!(top > base, "a pad must have thickness to be visible");
+    assert_eq!(pad.rings.len(), 1);
+    assert_eq!(pad.rings[0].coordinates.len(), 5);
+    assert!(
+        batch
+            .shape_styles
+            .iter()
+            .any(|style| style.id == pad.style_id && style.extruded),
+        "a pad must name an extruded style"
+    );
+}
+
+#[test]
+fn a_track_without_an_altitude_stays_a_point() {
+    // An invented height would claim knowledge the track never reported.
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&delta_with_altitude(42, 3, None));
+
+    let batch = adapter.adapt();
+
+    assert_eq!(batch.points.len(), 1);
+    assert!(batch.shapes.is_empty());
+}
+
+#[test]
+fn a_track_that_loses_its_altitude_loses_its_pad() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&delta_with_altitude(42, 3, Some(5_500)));
+    assert_eq!(adapter.adapt().shapes.len(), 1);
+
+    adapter.apply_traffic_delta(&delta_with_altitude(42, 4, None));
+
+    assert!(adapter.adapt().shapes.is_empty());
+}
+
+fn delta_with_altitude(id: u64, revision: u64, pressure_altitude_ft: Option<i32>) -> TrackDelta {
+    let mut track = complete_track(id);
+    track.pressure_altitude_ft = pressure_altitude_ft.map(radio_timed);
+    track.geometric_altitude_ft = None;
+    TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(revision),
+        track,
+    ))
+}

--- a/crates/pilotage-presentation/src/traffic.rs
+++ b/crates/pilotage-presentation/src/traffic.rs
@@ -3,8 +3,78 @@
 use surveillance_geojson::{AircraftFeature, FeatureDelta};
 
 use crate::layer::TRAFFIC_LAYER_ID;
-use crate::policy::{TRAFFIC_ACTIVE_STYLE, TRAFFIC_COASTING_STYLE, TRAFFIC_EMERGENCY_STYLE};
-use crate::{Coordinate, PointChange, PointFeature};
+use crate::policy::{
+    TRAFFIC_ACTIVE_STYLE, TRAFFIC_ALTITUDE_STYLE, TRAFFIC_COASTING_STYLE, TRAFFIC_EMERGENCY_STYLE,
+};
+use crate::{Coordinate, CoordinateRing, PointChange, PointFeature, ShapeFeature};
+
+/// Half-width of one traffic pad in metres.
+///
+/// A pad marks where a target sits in the vertical, so it has to stay legible beside the
+/// symbol without covering the ground under it.
+const PAD_HALF_WIDTH_M: f64 = 220.0;
+
+/// Thickness of one traffic pad in metres.
+///
+/// A pad with no thickness is invisible from directly above, which is the view a pilot
+/// starts from.
+const PAD_THICKNESS_M: f64 = 60.0;
+
+const FEET_TO_METRES: f64 = 0.3048;
+const METRES_PER_DEGREE_LATITUDE: f64 = 111_320.0;
+
+/// Raise one traffic point into a pad at the altitude it reports.
+///
+/// A symbol is draped onto the terrain surface whatever altitude it carries, so a target
+/// at 8,000 ft and one at 800 ft draw in the same place. The pad is the part of the
+/// display that answers "above me or below me". A track with no altitude produces no pad
+/// and keeps its symbol, because an invented height would claim knowledge the track has
+/// not reported.
+pub(crate) fn altitude_pad(point: &PointFeature) -> Option<ShapeFeature> {
+    let altitude_m = f64::from(point.altitude_ft?) * FEET_TO_METRES;
+    if altitude_m <= 0.0 {
+        return None;
+    }
+    Some(ShapeFeature {
+        id: format!("{}-pad", point.id),
+        layer_id: TRAFFIC_LAYER_ID.into(),
+        rings: vec![pad_ring(point.coordinate)?],
+        style_id: TRAFFIC_ALTITUDE_STYLE.into(),
+        label: None,
+        base_above_terrain_m: Some(altitude_m),
+        top_above_terrain_m: Some(altitude_m + PAD_THICKNESS_M),
+        producer_instance_id: point.producer_instance_id,
+        snapshot_revision: point.snapshot_revision,
+    })
+}
+
+fn pad_ring(centre: Coordinate) -> Option<CoordinateRing> {
+    let latitude_span = PAD_HALF_WIDTH_M / METRES_PER_DEGREE_LATITUDE;
+    // A degree of longitude shortens toward the pole, so a pad built from the latitude
+    // span alone would stretch east to west at high latitude.
+    let longitude_scale = centre.latitude_deg.to_radians().cos();
+    if longitude_scale <= f64::EPSILON {
+        return None;
+    }
+    let longitude_span = latitude_span / longitude_scale;
+    let corners = [
+        (latitude_span, -longitude_span),
+        (latitude_span, longitude_span),
+        (-latitude_span, longitude_span),
+        (-latitude_span, -longitude_span),
+        (latitude_span, -longitude_span),
+    ];
+    let coordinates: Vec<Coordinate> = corners
+        .into_iter()
+        .filter_map(|(latitude_offset, longitude_offset)| {
+            Coordinate::checked(
+                centre.latitude_deg + latitude_offset,
+                centre.longitude_deg + longitude_offset,
+            )
+        })
+        .collect();
+    (coordinates.len() == corners.len()).then_some(CoordinateRing { coordinates })
+}
 
 pub(crate) fn point_change(
     change: &FeatureDelta,

--- a/crates/pilotage-presentation/src/weather/advisory.rs
+++ b/crates/pilotage-presentation/src/weather/advisory.rs
@@ -13,6 +13,11 @@ use crate::policy::{
 };
 use crate::{Coordinate, CoordinateRing, ShapeFeature};
 
+const FEET_TO_METRES: f64 = 0.3048;
+
+/// Least thickness one advisory volume draws with, in metres.
+const MINIMUM_VOLUME_THICKNESS_M: f64 = 150.0;
+
 /// Convert one advisory shape feature into a display shape.
 ///
 /// A polyline advisory returns nothing. The display shape carries polygon rings, and a
@@ -26,15 +31,40 @@ pub(crate) fn shape_for_advisory(
         return None;
     }
     let advisory = feature.advisory();
+    let (base_above_terrain_m, top_above_terrain_m) = extrusion(advisory);
     Some(ShapeFeature {
         id,
         layer_id: WEATHER_ADVISORY_LAYER_ID.into(),
         rings,
         style_id: style_for(advisory_type(advisory)).into(),
         label: label(advisory),
+        base_above_terrain_m,
+        top_above_terrain_m,
         producer_instance_id: feature.id().producer_instance_id().get(),
         snapshot_revision: feature.revisions().snapshot_revision().get(),
     })
+}
+
+/// Turn one altitude band into the heights the renderer raises the outline between.
+///
+/// An advisory without a band stays flat. A volume drawn from an invented band would
+/// state an altitude range the advisory never gave.
+fn extrusion(advisory: &WeatherAdvisory) -> (Option<f64>, Option<f64>) {
+    let Some(band) = advisory
+        .altitude_band()
+        .as_present()
+        .map(|field| field.value)
+    else {
+        return (None, None);
+    };
+    let base = f64::from(band.base().feet()) * FEET_TO_METRES;
+    let top = f64::from(band.top().feet()) * FEET_TO_METRES;
+    // A band whose limits are equal draws nothing, and a surface-to-surface advisory is
+    // still an area a pilot must see.
+    if top - base < MINIMUM_VOLUME_THICKNESS_M {
+        return (Some(base), Some(base + MINIMUM_VOLUME_THICKNESS_M));
+    }
+    (Some(base), Some(top))
 }
 
 fn ring(source: &AdvisoryShapeRing) -> Option<CoordinateRing> {
@@ -95,11 +125,19 @@ fn band(advisory: &WeatherAdvisory) -> Option<String> {
     ))
 }
 
+/// Name one limit in the vocabulary its reference belongs to.
+///
+/// A limit printed in the wrong reference reads as a different altitude: a flight level
+/// shown as a mean-sea-level height, or a surface limit shown as zero feet, both state a
+/// height the advisory did not.
 fn altitude(value: AdvisoryAltitude) -> String {
     let feet = value.feet();
     match value.reference() {
+        AdvisoryAltitudeReference::MeanSeaLevel => format!("{feet} MSL"),
         AdvisoryAltitudeReference::AboveGroundLevel => format!("{feet} AGL"),
-        _ => format!("{feet} MSL"),
+        AdvisoryAltitudeReference::FlightLevel => format!("FL{:03}", feet / 100),
+        AdvisoryAltitudeReference::Surface => "SFC".to_owned(),
+        _ => format!("{feet} ft"),
     }
 }
 


### PR DESCRIPTION
A symbol and a circle are draped onto the terrain surface, so a target at 8,000 ft and a
target at 800 ft draw in the same place and the altitude survives only in the label. The
display is meant to answer "above me or below me" at a glance, and a draped symbol cannot.

The style spec has no way to place a point symbol at a height, so an extruded polygon is
the path. A shape style declares whether the renderer raises it, and a shape feature
carries the floor and ceiling it is raised between. A track with an altitude now also
produces a small pad at that height, above the symbol that keeps marking its ground
position. A track with no altitude keeps its symbol alone: an invented height would claim
knowledge the track never reported.

An advisory volume rides the same mechanism, with the floor and ceiling from the altitude
band Airmass decodes.

The height is measured from the terrain surface, which is what the renderer draws from.
A reported altitude is measured from mean sea level, so a feature over high ground rides
the terrain elevation too high. This crate cannot read the elevation model, and the label
carries the reported altitude and stays exact. Closes the display half; the datum
correction stays open.

Replay of the recorded five-minute reception produces twelve shapes where the flat build
produced four: eight traffic pads and four advisory volumes.

Closes #374.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #388
- <kbd>&nbsp;4&nbsp;</kbd> #379
- <kbd>&nbsp;3&nbsp;</kbd> #377
- <kbd>&nbsp;2&nbsp;</kbd> #376 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #375
<!-- GitButler Footer Boundary Bottom -->