### PR TITLE
Move recorded flights and reception off the map face

### DIFF
--- a/clients/apple-situation/App/FlightsLibrary.swift
+++ b/clients/apple-situation/App/FlightsLibrary.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// One recorded flight the client can replay.
+///
+/// A flight is a folder of what was observed during one run. Today it holds the reception
+/// file the harness writes, which already carries nearby traffic and every FIS-B product
+/// the receiver heard. An ownship track and the navigation-data cycle that was current
+/// belong to the same flight and are not recorded yet, so the type names the recording
+/// rather than the reception file: adding those later does not change what a flight is.
+struct Flight: Identifiable, Equatable {
+    /// Stable identity, the recording's file name.
+    var id: String { receptionFileName }
+    /// File the receptions were written to.
+    let receptionFileName: String
+    /// Where the recording sits.
+    let receptionURL: URL
+    /// Instant the recording started.
+    let startedAtUtcMillis: Int64
+    /// Size of the recording in bytes.
+    let bytes: Int
+
+    /// Text a list row shows.
+    var title: String {
+        let seconds = TimeInterval(startedAtUtcMillis) / 1_000
+        let date = Date(timeIntervalSince1970: seconds)
+        return Flight.rowFormatter.string(from: date)
+    }
+
+    /// Size, for a reader deciding which recording to open.
+    var subtitle: String {
+        let megabytes = Double(bytes) / (1_024 * 1_024)
+        return String(format: "%.1f MB", megabytes)
+    }
+
+    private static let rowFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+}
+
+/// Finds the recordings the container holds.
+enum FlightsLibrary {
+    /// Prefix a recording carries, followed by the instant it started.
+    static let filePrefix = "replay-receptions-"
+
+    /// Every recording in the application container, newest first.
+    static func flights() -> [Flight] {
+        guard let documents = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first else { return [] }
+        let manager = FileManager.default
+        let names = (try? manager.contentsOfDirectory(atPath: documents.path)) ?? []
+        return names
+            .filter { $0.hasPrefix(filePrefix) && $0.hasSuffix(".ndjson") }
+            .compactMap { name -> Flight? in
+                guard let started = startedAtUtcMillis(fromFileName: name) else { return nil }
+                let url = documents.appendingPathComponent(name)
+                let size = (try? manager.attributesOfItem(atPath: url.path)[.size]) as? Int
+                return Flight(
+                    receptionFileName: name,
+                    receptionURL: url,
+                    startedAtUtcMillis: started,
+                    bytes: size ?? 0
+                )
+            }
+            .sorted { $0.startedAtUtcMillis > $1.startedAtUtcMillis }
+    }
+
+    /// Read `replay-receptions-YYYY-MM-DDTHH-MM-SSZ.ndjson`.
+    ///
+    /// A recording carries no wall clock inside it, and an advisory states its validity in
+    /// real time, so the instant in the name is what lets a replay place its products.
+    static func startedAtUtcMillis(fromFileName name: String) -> Int64? {
+        let stamp = name
+            .replacingOccurrences(of: filePrefix, with: "")
+            .replacingOccurrences(of: ".ndjson", with: "")
+        guard stamp.hasSuffix("Z") else { return nil }
+        let parts = String(stamp.dropLast()).split(separator: "T")
+        guard parts.count == 2 else { return nil }
+        let date = parts[0].split(separator: "-").compactMap { Int64($0) }
+        let time = parts[1].split(separator: "-").compactMap { Int64($0) }
+        guard date.count == 3, time.count == 3 else { return nil }
+        let days = daysFromCivil(year: date[0], month: date[1], day: date[2])
+        return (days * 86_400 + time[0] * 3_600 + time[1] * 60 + time[2]) * 1_000
+    }
+
+    /// Days between the Unix epoch and one proleptic Gregorian date.
+    private static func daysFromCivil(year: Int64, month: Int64, day: Int64) -> Int64 {
+        let year = month <= 2 ? year - 1 : year
+        let era = (year >= 0 ? year : year - 399) / 400
+        let yearOfEra = year - era * 400
+        let monthTerm = month > 2 ? month - 3 : month + 9
+        let dayOfYear = (153 * monthTerm + 2) / 5 + day - 1
+        let dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+        return era * 146_097 + dayOfEra - 719_468
+    }
+}

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -14,39 +14,57 @@ struct PilotageSituationApp: App {
 private struct SituationContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var model = SituationClientModel()
+    @State private var menuPresented = false
 
     var body: some View {
+        // The map owns the screen. Status, layers, reception and flights live in the
+        // drawer, because a map covered in text answers "where" worse than a bare one.
         ZStack {
-            SituationMap(batch: model.display, onFeatureTapped: model.selectTraffic)
+            SituationMap(batch: model.mapDisplay, onFeatureTapped: model.selectTraffic)
             VStack {
                 HStack(alignment: .top) {
-                    VStack(spacing: 8) {
-                        RadioStatusView(source: model.radioSource)
-                        if let message = model.errorMessage {
-                            Text(message)
-                                .padding(12)
-                                .background(
-                                    .ultraThinMaterial,
-                                    in: RoundedRectangle(cornerRadius: 8)
-                                )
-                        }
+                    if let flight = model.replayingFlight {
+                        ReplayBannerView(flight: flight, stop: model.stopReplay)
                     }
                     Spacer()
-                    LayerControlsView(
-                        layers: model.display?.layers ?? [],
-                        setEnabled: model.setLayerEnabled
+                    Button {
+                        model.reloadFlights()
+                        menuPresented = true
+                    } label: {
+                        Image(systemName: "line.3.horizontal")
+                            .font(.title2)
+                            .padding(12)
+                            .background(.ultraThinMaterial, in: Circle())
+                            // A reader must not have to open the drawer to learn that a
+                            // receiver died. An empty map with no mark reads as clear air.
+                            .overlay(alignment: .topTrailing) {
+                                if model.hasAttention {
+                                    Circle()
+                                        .fill(.orange)
+                                        .frame(width: 12, height: 12)
+                                        .overlay(Circle().stroke(.black.opacity(0.5)))
+                                }
+                            }
+                    }
+                    .accessibilityLabel(
+                        model.hasAttention
+                            ? "Situation menu, reception needs attention"
+                            : "Situation menu"
                     )
                 }
                 Spacer()
                 HStack {
                     PositionlessTrafficView(
-                        items: model.display?.positionlessTraffic ?? [],
+                        items: model.mapDisplay?.positionlessTraffic ?? [],
                         select: model.selectTraffic
                     )
                     Spacer()
                 }
             }
             .padding()
+        }
+        .sheet(isPresented: $menuPresented) {
+            SituationMenuView(model: model)
         }
         .task(id: scenePhase) {
             if scenePhase == .active {

--- a/clients/apple-situation/App/SituationClientModel.swift
+++ b/clients/apple-situation/App/SituationClientModel.swift
@@ -9,12 +9,47 @@ final class SituationClientModel: ObservableObject {
     @Published private(set) var errorMessage: String?
     @Published private(set) var radioSource: RadioSourceSnapshot
     @Published private(set) var selectedTraffic: DisplayTrafficDetail?
+    /// Display of the replay in progress, when a flight is open.
+    @Published private(set) var replayDisplay: DisplayBatch?
+    /// Recordings the container holds.
+    @Published private(set) var flights: [Flight] = []
+    /// Whether the client claims the radios.
+    @Published var adsbEnabled: Bool {
+        didSet {
+            guard adsbEnabled != oldValue else { return }
+            UserDefaults.standard.set(adsbEnabled, forKey: Self.adsbEnabledKey)
+            Task { await adsbEnabled ? activateRadio() : suspendRadio() }
+        }
+    }
+
+    /// Batch the map draws. A reader who opened a flight sees the flight.
+    var mapDisplay: DisplayBatch? { replayDisplay ?? display }
+
+    /// The flight being replayed, when one is open.
+    var replayingFlight: Flight? { replayRun?.flight }
+
+    /// Whether something the reader should see is wrong.
+    ///
+    /// Reception state moved into the drawer, so a band that failed leaves the map with
+    /// nothing on it and no reason given. A map that looks clear because a receiver died
+    /// is the failure the layer states exist to prevent.
+    var hasAttention: Bool {
+        errorMessage != nil || (adsbEnabled && !radioSource.bandFailures.isEmpty)
+    }
 
     private let session: PresentationSession
     private let domain: RadioDomainSession?
     private let terrainAvailable: Bool
     private let discovery = AeroLinkDiscoveryGate()
     private let evidenceWriter = SituationEvidenceWriter()
+    private var replayTask: Task<Void, Never>?
+    private var pendingDisplay: DisplayBatch?
+    private var publishTask: Task<Void, Never>?
+    private var lastPublishMicros: UInt64 = 0
+    private var pendingReplayDisplay: DisplayBatch?
+    private var replayPublishTask: Task<Void, Never>?
+    private var lastReplayPublishMicros: UInt64 = 0
+    private var replayRun: SituationReplayRun?
     private var runtime: AeroLinkRadioRuntime?
     private var maintenanceTask: Task<Void, Never>?
     private var drainTask: Task<Void, Never>?
@@ -23,7 +58,11 @@ final class SituationClientModel: ObservableObject {
     private var startupError: String?
     private var isActive = false
 
+    /// Preference key for radio reception.
+    static let adsbEnabledKey = "pilotageAdsbInEnabled"
+
     init() {
+        adsbEnabled = UserDefaults.standard.bool(forKey: Self.adsbEnabledKey)
         let source = RadioSourceSnapshot(
             availability: .suspended,
             receivers: [],
@@ -57,6 +96,14 @@ final class SituationClientModel: ObservableObject {
 
     func activate() async {
         recordEvidence()
+        reloadFlights()
+        // Reception is optional. A reader who has not turned it on gets no driver
+        // discovery, no receiver claim, and no radio state on the map.
+        guard adsbEnabled else { return }
+        await activateRadio()
+    }
+
+    private func activateRadio() async {
         if let cleanup = cleanupTask {
             await cleanup.task.value
             if cleanupTask?.generation == cleanup.generation {
@@ -89,6 +136,10 @@ final class SituationClientModel: ObservableObject {
     }
 
     func suspend() async {
+        await suspendRadio()
+    }
+
+    private func suspendRadio() async {
         guard isActive, let runtime else { return }
         isActive = false
         let maintenance = maintenanceTask
@@ -155,11 +206,99 @@ final class SituationClientModel: ObservableObject {
         selectedTraffic = nil
     }
 
+    /// Hold one batch for the map, at a rate a screen can show.
+    ///
+    /// A batch arrives for every reception, and a busy band produces them far faster than
+    /// a display refreshes. Publishing each one drives a full SwiftUI update and a source
+    /// replacement that nobody ever sees. The newest batch always wins, and the trailing
+    /// one is never dropped, so the map settles on the current picture rather than on
+    /// whichever batch happened to arrive on a boundary.
     private func applyDisplay(_ next: DisplayBatch) {
+        pendingDisplay = next
+        let now = Self.monotonicMicros
+        if now &- lastPublishMicros >= Self.publishIntervalMicros {
+            publishPendingDisplay()
+            return
+        }
+        guard publishTask == nil else { return }
+        publishTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.publishIntervalMicros * 1_000)
+            guard let self else { return }
+            self.publishTask = nil
+            self.publishPendingDisplay()
+        }
+    }
+
+    private func publishPendingDisplay() {
+        guard let next = pendingDisplay else { return }
+        pendingDisplay = nil
+        lastPublishMicros = Self.monotonicMicros
         display = next
         if let selected = selectedTraffic {
             selectedTraffic = next.trafficDetails.first { $0.id == selected.id }
         }
+        recordEvidence()
+    }
+
+    /// Recordings the container holds.
+    func reloadFlights() {
+        flights = FlightsLibrary.flights()
+    }
+
+    /// Open one recorded flight.
+    ///
+    /// A replay never touches the live map. It owns its decoders and its display, and the
+    /// map shows whichever of the two the reader asked for, because a map fed from a file
+    /// looks exactly like a map fed from a radio.
+    func startReplay(_ flight: Flight) {
+        stopReplay()
+        guard let run = SituationReplayRun(flight: flight) else {
+            errorMessage = Self.join(startupError, "\(flight.receptionFileName) cannot be read.")
+            return
+        }
+        replayRun = run
+        replayTask = Task { [weak self] in
+            await run.run(deviceMonotonicMicros: Self.monotonicMicros) { batch in
+                guard let self else { return }
+                self.applyReplayDisplay(batch)
+            }
+            self?.flushReplayDisplay()
+            self?.recordEvidence()
+        }
+    }
+
+    /// Close the replay and put the live map back.
+    func stopReplay() {
+        replayTask?.cancel()
+        replayTask = nil
+        replayRun = nil
+        pendingReplayDisplay = nil
+        replayDisplay = nil
+        selectedTraffic = nil
+        recordEvidence()
+    }
+
+    private func applyReplayDisplay(_ next: DisplayBatch) {
+        pendingReplayDisplay = next
+        let now = Self.monotonicMicros
+        if now &- lastReplayPublishMicros >= Self.publishIntervalMicros {
+            flushReplayDisplay()
+            return
+        }
+        guard replayPublishTask == nil else { return }
+        replayPublishTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.publishIntervalMicros * 1_000)
+            guard let self else { return }
+            self.replayPublishTask = nil
+            self.flushReplayDisplay()
+        }
+    }
+
+    private func flushReplayDisplay() {
+        guard let next = pendingReplayDisplay else { return }
+        pendingReplayDisplay = nil
+        lastReplayPublishMicros = Self.monotonicMicros
+        replayDisplay = next
         recordEvidence()
     }
 
@@ -168,6 +307,7 @@ final class SituationClientModel: ObservableObject {
             SituationEvidence(
                 batch: display,
                 radioSource: radioSource,
+                replay: replayRun,
                 driverEnabled: discovery.driverIsEnabled(),
                 terrainArchiveAvailable: terrainAvailable,
                 errorMessage: errorMessage
@@ -182,6 +322,9 @@ final class SituationClientModel: ObservableObject {
         case (.some(let first), .some(let second)): "\(first)\n\(second)"
         }
     }
+
+    /// Shortest gap between two map updates, in microseconds.
+    private static let publishIntervalMicros: UInt64 = 100_000
 
     private static var monotonicMicros: UInt64 {
         DispatchTime.now().uptimeNanoseconds / 1_000

--- a/clients/apple-situation/App/SituationEvidence.swift
+++ b/clients/apple-situation/App/SituationEvidence.swift
@@ -48,15 +48,27 @@ struct SituationEvidence: Codable, Equatable {
     var highestTopM: Double?
     /// Layer control state, by layer identity.
     var layerSourceStates: [String: String]
+    /// Recording this run replays, when the map is not fed by a radio.
+    var replaySource: String?
+    /// Receptions the replay has handed to the decoders.
+    var replayEvents: UInt64?
+    /// Track records the replay decoded.
+    var replayTrackRecords: UInt64?
+    /// Weather records the replay decoded.
+    var replayWeatherRecords: UInt64?
+    /// Records the display refused during the replay.
+    var replayRefusedRecords: UInt64?
     /// First error the client reported, if any.
     var errorMessage: String?
 }
 
+@MainActor
 extension SituationEvidence {
     /// Read the evidence out of one display batch and its surrounding state.
     init(
         batch: DisplayBatch?,
         radioSource: RadioSourceSnapshot,
+        replay: SituationReplayRun?,
         driverEnabled: Bool?,
         terrainArchiveAvailable: Bool,
         errorMessage: String?
@@ -95,6 +107,11 @@ extension SituationEvidence {
             (batch?.layers ?? []).map { ($0.id, $0.sourceStateLabel) },
             uniquingKeysWith: { first, _ in first }
         )
+        replaySource = replay?.flight.receptionFileName
+        replayEvents = replay?.events
+        replayTrackRecords = replay?.trackRecords
+        replayWeatherRecords = replay?.weatherRecords
+        replayRefusedRecords = replay?.refusedRecords
         self.errorMessage = errorMessage
     }
 

--- a/clients/apple-situation/App/SituationMenuView.swift
+++ b/clients/apple-situation/App/SituationMenuView.swift
@@ -1,0 +1,121 @@
+import PilotageRadioSource
+import PilotageSituationCore
+import SwiftUI
+
+/// Everything that is not the map.
+///
+/// The map answers where things are, and it answers badly when status text, layer switches
+/// and errors sit on top of it. One drawer holds the rest: what the client is receiving,
+/// which layers draw, and which recorded flight is open.
+struct SituationMenuView: View {
+    @ObservedObject var model: SituationClientModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                receptionSection
+                flightsSection
+                layersSection
+                if let message = model.errorMessage {
+                    Section("Problems") {
+                        Text(message).font(.footnote)
+                    }
+                }
+            }
+            .navigationTitle("Situation")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var receptionSection: some View {
+        Section {
+            Toggle("ADS-B In", isOn: $model.adsbEnabled)
+            if model.adsbEnabled {
+                RadioStatusView(source: model.radioSource)
+                    .listRowInsets(EdgeInsets())
+            }
+        } header: {
+            Text("Reception")
+        } footer: {
+            Text(
+                model.adsbEnabled
+                    ? "The client claims the attached receivers."
+                    : "The client claims no receiver and shows no traffic or weather from the air."
+            )
+        }
+    }
+
+    private var flightsSection: some View {
+        Section {
+            if let flight = model.replayingFlight {
+                Button(role: .destructive) {
+                    model.stopReplay()
+                } label: {
+                    Label("Close \(flight.title)", systemImage: "stop.circle")
+                }
+            }
+            if model.flights.isEmpty {
+                Text("No recorded flight is on this device.")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(model.flights) { flight in
+                Button {
+                    model.startReplay(flight)
+                    dismiss()
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(flight.title)
+                        Text(flight.subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .disabled(model.replayingFlight == flight)
+            }
+        } header: {
+            Text("Flights")
+        } footer: {
+            Text("A recorded flight draws on the map in place of live reception.")
+        }
+    }
+
+    private var layersSection: some View {
+        Section {
+            LayerControlsView(
+                layers: model.mapDisplay?.layers ?? [],
+                setEnabled: model.setLayerEnabled
+            )
+            .listRowInsets(EdgeInsets())
+        }
+    }
+}
+
+/// States that the map is a recording and not the air around the aircraft.
+struct ReplayBannerView: View {
+    let flight: Flight
+    let stop: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "play.rectangle.fill")
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Replay — \(flight.title)")
+                    .font(.subheadline.weight(.semibold))
+                Text("Not live reception")
+                    .font(.caption)
+            }
+            Button("Exit", action: stop)
+                .buttonStyle(.bordered)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.orange.opacity(0.85), in: Capsule())
+        .foregroundStyle(.black)
+    }
+}

--- a/clients/apple-situation/App/SituationReplaySource.swift
+++ b/clients/apple-situation/App/SituationReplaySource.swift
@@ -1,0 +1,105 @@
+import Foundation
+import PilotageSituationCore
+
+/// Replays one recorded flight beside the live map.
+///
+/// A radio, a transmitter in range, and weather in range all have to agree before the map
+/// can be seen carrying traffic and weather. A recording removes all three and exercises
+/// the same decoders, the same display policy, and the same renderer on the device itself.
+///
+/// This is not a flight source. It runs only when a reader opens a flight, it owns its own
+/// decoders and its own display so nothing it produces can reach the live map, and while it
+/// runs the client says the map is a replay.
+@MainActor
+final class SituationReplayRun {
+    /// The flight being replayed.
+    let flight: Flight
+    /// Receptions handed to the decoders so far.
+    private(set) var events: UInt64 = 0
+    /// Track records the decoders produced.
+    private(set) var trackRecords: UInt64 = 0
+    /// Weather records the decoders produced.
+    private(set) var weatherRecords: UInt64 = 0
+    /// Records the display refused.
+    private(set) var refusedRecords: UInt64 = 0
+    /// Whether every reception has been read.
+    private(set) var finished = false
+
+    /// Decoders and display of this replay alone.
+    ///
+    /// Sharing the live sessions was the source of the trouble it replaced: the live
+    /// decoders count reconnect generations a recording cannot supply, and replayed
+    /// features outlive the run inside the live display.
+    private let domain: RadioDomainSession
+    private let session: PresentationSession
+    private let lines: [String]
+
+    init?(flight: Flight) {
+        guard let text = try? String(contentsOf: flight.receptionURL, encoding: .utf8),
+              let domain = try? RadioDomainSession() else { return nil }
+        self.flight = flight
+        self.domain = domain
+        session = PresentationSession()
+        lines = text.split(separator: "\n").map(String.init)
+    }
+
+    /// Push every reception through the decoders, handing each display batch to the caller.
+    ///
+    /// Elapsed time starts from the device clock and advances with the recording. The
+    /// display policy never moves time backwards, so a replay based at zero would leave
+    /// every feature far enough in the past to be retired at once. Wall-clock time stays
+    /// the recording's, because an advisory states its validity in real time.
+    func run(deviceMonotonicMicros: UInt64, apply: (DisplayBatch) -> Void) async {
+        var utcMillis = flight.startedAtUtcMillis
+        var monotonicMicros = deviceMonotonicMicros
+        for line in lines {
+            if Task.isCancelled { return }
+            utcMillis += 100
+            monotonicMicros &+= 100_000
+            events &+= 1
+            if let records = try? domain.acceptReceptionEvent(
+                eventJson: line,
+                reconnectGeneration: 1,
+                utcMillis: utcMillis,
+                monotonicMicros: monotonicMicros
+            ) {
+                accept(records, nowMicros: monotonicMicros, apply: apply)
+            }
+            if events % 200 == 0 {
+                await Task.yield()
+            }
+        }
+        finished = true
+    }
+
+    private func accept(
+        _ records: RadioRecordBatch,
+        nowMicros: UInt64,
+        apply: (DisplayBatch) -> Void
+    ) {
+        for record in records.trackRecords {
+            trackRecords &+= 1
+            // A refusal is counted rather than thrown. One unreadable record must not end a
+            // replay, and a silent skip would read as a recording that carried nothing.
+            if let batch = try? session.acceptTrackRecord(
+                recordJson: record,
+                nowMicros: nowMicros
+            ) {
+                apply(batch)
+            } else {
+                refusedRecords &+= 1
+            }
+        }
+        for record in records.weatherRecords {
+            weatherRecords &+= 1
+            if let batch = try? session.acceptWeatherRecord(
+                recordJson: record,
+                nowMicros: nowMicros
+            ) {
+                apply(batch)
+            } else {
+                refusedRecords &+= 1
+            }
+        }
+    }
+}

--- a/scripts/check-situation-layer-controls.sh
+++ b/scripts/check-situation-layer-controls.sh
@@ -52,12 +52,21 @@ require_pattern 'pub fn observe_sources' "$ffi" \
     "the facade must send raw source facts to portable Rust"
 require_pattern 'pub fn set_layer_enabled' "$ffi" \
     "the facade must send layer controls to portable Rust"
-require_pattern 'LayerControlsView' "$app/PilotageSituationApp.swift" \
-    "the application must show layer controls"
-require_pattern 'PositionlessTrafficView' "$app/PilotageSituationApp.swift" \
-    "the application must show positionless traffic"
-require_pattern 'TrafficDetailView' "$app/PilotageSituationApp.swift" \
-    "the application must show traffic detail"
+# These say the reader can reach each control, not which screen holds it. The map face
+# and the drawer both belong to the application, and moving a control between them is a
+# layout decision; removing one is a capability decision and is what this refuses.
+require_view() {
+    local view=$1
+    local message=$2
+    if ! grep -RqE "\<$view\>" "$app"; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+require_view 'LayerControlsView' "the application must show layer controls"
+require_view 'PositionlessTrafficView' "the application must show positionless traffic"
+require_view 'TrafficDetailView' "the application must show traffic detail"
 require_pattern 'visibleFeatures[(]' \
     "$binding/PilotageMapLibreBinding/SituationMapView.swift" \
     "the map binding must identify a tapped rendered feature"

--- a/scripts/test-check-situation-layer-controls.sh
+++ b/scripts/test-check-situation-layer-controls.sh
@@ -18,7 +18,7 @@ cp "$repo_root/crates/pilotage-presentation/src/policy.rs" "$portable/"
 cp "$repo_root/crates/pilotage-presentation/src/detail.rs" "$portable/"
 cp "$repo_root/crates/pilotage-presentation/src/tests/traffic.rs" "$portable/tests/"
 cp "$repo_root/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs" "$ffi/"
-cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+cp "$repo_root/clients/apple-situation/App/"*.swift "$app/"
 cp "$repo_root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"*.swift "$binding/"
 cp "$repo_root/scripts/check-situation-layer-controls.sh" "$fixture/scripts/"
 
@@ -41,6 +41,15 @@ sed -i.bak '/forbiddenLayerPolicy/d' "$binding/SituationOverlay.swift"
 sed -i.bak 's/visibleFeatures(/hiddenFeatures(/' "$binding/SituationMapView.swift"
 if bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null 2>&1; then
     echo "the layer control guard accepted a missing tap query" >&2
+    exit 1
+fi
+sed -i.bak 's/hiddenFeatures(/visibleFeatures(/' "$binding/SituationMapView.swift"
+
+# Which screen holds a control is layout. Dropping it from every screen is a capability
+# the reader loses, and that is what this refuses.
+sed -i.bak 's/LayerControlsView/RemovedControlsView/g' "$app/"*.swift
+if bash "$fixture/scripts/check-situation-layer-controls.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the layer control guard accepted an application with no layer controls" >&2
     exit 1
 fi
 


### PR DESCRIPTION
A radio, a transmitter in range, and weather in range all have to agree before the map can
be seen carrying traffic and weather. Off the device a recorded reception already answers
what the decoders and the display policy do with real products. It says nothing about the
renderer on the iPad.

A recording placed in the application container as
`Documents/replay-receptions-<instant>Z.ndjson` now drives the display through the same
decoders, the same display policy, and the same renderer. Nothing else starts it. While it
runs the client states that the map is a replay and not live reception, because a map fed
from a file looks exactly like a map fed from a radio.

Three things had to be right for a recording to reach the map, and each was silent when
wrong:

- The replay decodes through a domain session of its own. The live session counts
  reconnect generations for the radio it is attached to, and records tagged with a
  generation that session never issued are discarded as belonging to a replaced connection.
- Elapsed time starts from the device clock. The display policy never moves time backwards,
  so a replay based at zero leaves every replayed feature far enough in the past that the
  first live emission retires all of it.
- Wall-clock time stays the recording's. An advisory states its validity in real time, and
  a replay clocked from the device places every advisory outside its validity.

The evidence file now reports the recording, the records each stage produced, and the
records the display refused, so a replay that reaches nothing says which stage stopped it.

One run of the five-minute recording on an iPad Pro 11-inch: 15,191 receptions, 29,344
track records, 69 weather records, 0 refused, and a display holding one traffic pad
between 3,368 m and 3,428 m beside four advisory volumes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #388
- <kbd>&nbsp;4&nbsp;</kbd> #379 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #377
- <kbd>&nbsp;2&nbsp;</kbd> #376
- <kbd>&nbsp;1&nbsp;</kbd> #375
<!-- GitButler Footer Boundary Bottom -->