### PR TITLE
Colour the base map by elevation and open the whole world to it

### DIFF
--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import PilotageMapLibreBinding
 import PilotageSituationCore
 import SwiftUI
@@ -81,6 +82,11 @@ private struct SituationMap: UIViewRepresentable {
             ?? SituationStyleResource.fallbackJSON
         let view = SituationMapView(styleJSON: styleJSON)
         view.initialPitchDegrees = 55
+        // Open over the ground the terrain archive covers rather than on the Atlantic, and
+        // let the map be pinched out until the whole world is on screen.
+        view.initialCenter = CLLocationCoordinate2D(latitude: 40.5, longitude: -76.5)
+        view.initialZoomLevel = 6
+        view.minimumZoomLevel = 0
         view.baseLayerIdentifiers = ["terrain-base": "pilotage-terrain-hillshade"]
         view.onFeatureTapped = onFeatureTapped
         return view

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
@@ -15,7 +15,7 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
     private let mapView: MLNMapView
     private let overlay = SituationOverlay()
     private var pendingBatch: DisplayBatch?
-    private var hasAppliedInitialPitch = false
+    private var hasAppliedInitialCamera = false
 
     /// Viewing angle away from straight down, in degrees, taken once the style loads.
     ///
@@ -23,6 +23,18 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
     /// height on their own and only from a camera that looks across the ground. A pilot
     /// can still tilt the map by hand afterwards.
     public var initialPitchDegrees: CGFloat = 0
+
+    /// Where the map opens, and how far out it may be pinched.
+    ///
+    /// Without a stated camera the map opens on the Atlantic at world zoom, which is a
+    /// place nobody asked for. Without a stated floor the renderer keeps whatever minimum
+    /// it happens to default to, and a pilot who pinches out to see the whole world finds
+    /// the map stops before it gets there.
+    public var initialCenter: CLLocationCoordinate2D?
+    /// Zoom the map opens at.
+    public var initialZoomLevel: Double = 6
+    /// Furthest the map may be pinched out. Zero shows the whole world.
+    public var minimumZoomLevel: Double = 0
 
     /// Create a map with the specified base style JSON.
     public init(frame: CGRect = .zero, styleJSON: String) {
@@ -53,22 +65,29 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
 
     /// Apply retained display values after a base style load.
     public func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
-        applyInitialPitch()
+        applyInitialCamera()
         applyPendingBatch()
     }
 
-    /// Tilt the camera once, and never against a pilot who has already moved it.
+    /// Place the camera once, and never against a pilot who has already moved it.
     ///
     /// A style reload raises this callback again, and a second tilt would throw away the
     /// view the pilot chose.
-    private func applyInitialPitch() {
-        guard !hasAppliedInitialPitch, initialPitchDegrees > 0 else {
-            return
-        }
-        hasAppliedInitialPitch = true
+    private func applyInitialCamera() {
+        guard !hasAppliedInitialCamera else { return }
+        hasAppliedInitialCamera = true
+        mapView.minimumZoomLevel = minimumZoomLevel
         let camera = mapView.camera
-        camera.pitch = min(initialPitchDegrees, mapView.maximumPitch)
+        if initialPitchDegrees > 0 {
+            camera.pitch = min(initialPitchDegrees, mapView.maximumPitch)
+        }
+        if let initialCenter {
+            camera.centerCoordinate = initialCenter
+        }
         mapView.setCamera(camera, animated: false)
+        if initialCenter != nil {
+            mapView.setZoomLevel(initialZoomLevel, animated: false)
+        }
     }
 
     private func applyPendingBatch() {

--- a/clients/apple-situation/Resources/SituationStyle.json
+++ b/clients/apple-situation/Resources/SituationStyle.json
@@ -15,7 +15,62 @@
       "id": "background",
       "type": "background",
       "paint": {
-        "background-color": "#0b1721"
+        "background-color": "#02060a"
+      }
+    },
+    {
+      "id": "pilotage-terrain-relief",
+      "type": "color-relief",
+      "source": "pilotage-terrain",
+      "paint": {
+        "color-relief-opacity": 1,
+        "color-relief-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "elevation"
+          ],
+          -11000,
+          "#01040a",
+          -4000,
+          "#02070e",
+          -1000,
+          "#030b14",
+          -200,
+          "#04101a",
+          -20,
+          "#061521",
+          -1,
+          "#081d29",
+          0,
+          "#4f5f3e",
+          60,
+          "#6a7649",
+          200,
+          "#828a58",
+          500,
+          "#9a9668",
+          900,
+          "#ab9b73",
+          1400,
+          "#ac8b63",
+          2000,
+          "#98724c",
+          2800,
+          "#7f5836",
+          3600,
+          "#6a4830",
+          4500,
+          "#7d6a5c",
+          5200,
+          "#a99c92",
+          6000,
+          "#e8e8e8",
+          8850,
+          "#ffffff"
+        ]
       }
     },
     {
@@ -23,10 +78,10 @@
       "type": "hillshade",
       "source": "pilotage-terrain",
       "paint": {
-        "hillshade-exaggeration": 0.42,
-        "hillshade-shadow-color": "#050b11",
-        "hillshade-highlight-color": "#526879",
-        "hillshade-accent-color": "#1b3243",
+        "hillshade-exaggeration": 0.35,
+        "hillshade-shadow-color": "#241f16",
+        "hillshade-highlight-color": "#cfc9b4",
+        "hillshade-accent-color": "#3a3226",
         "hillshade-illumination-direction": 315,
         "hillshade-illumination-anchor": "map"
       }

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -60,7 +60,7 @@ if ! jq -e '
     .sources["pilotage-terrain"].tileSize == 256 and
     .sources["pilotage-terrain"].url == "__PILOTAGE_TERRAIN_MBTILES_URL__" and
     ([.layers[] | select(.id == "pilotage-terrain-hillshade" and .type == "hillshade" and .source == "pilotage-terrain")] | length == 1) and
-    ([.layers[] | select(.source == "pilotage-terrain" and .type == "color-relief")] | length == 0) and
+    ([.layers[] | select(.id == "pilotage-terrain-relief" and .type == "color-relief" and .source == "pilotage-terrain")] | length == 1) and
     (has("terrain") | not)
 ' "$style" >/dev/null; then
     echo "FORBIDDEN: the situation style must use the Terrarium hillshade contract" >&2
@@ -70,11 +70,42 @@ fi
 if ! jq -e '
     .layers[] |
     select(.id == "pilotage-terrain-hillshade") |
-    .paint["hillshade-shadow-color"] == "#050b11" and
-    .paint["hillshade-highlight-color"] == "#526879" and
-    .paint["hillshade-accent-color"] == "#1b3243"
+    .paint["hillshade-shadow-color"] == "#241f16" and
+    .paint["hillshade-highlight-color"] == "#cfc9b4" and
+    .paint["hillshade-accent-color"] == "#3a3226"
 ' "$style" >/dev/null; then
-    echo "FORBIDDEN: the terrain hillshade must use the dark blue-grey palette" >&2
+    echo "FORBIDDEN: the terrain hillshade must use the warm neutral palette" >&2
+    status=1
+fi
+
+# The colour ramp is what separates sea from shore and low ground from high. A ramp that
+# reads the same on both sides of sea level draws a coastline that is not there, and a
+# ramp that is not driven by elevation is a flat wash that says nothing about height.
+relief_ramp="$(jq -c '
+    .layers[] | select(.id == "pilotage-terrain-relief") | .paint["color-relief-color"]
+' "$style")"
+if ! printf '%s' "$relief_ramp" | jq -e '
+    .[0] == "interpolate" and .[2] == ["elevation"] and
+    ((. | length) >= 12)
+' >/dev/null 2>&1; then
+    echo "FORBIDDEN: the terrain relief must interpolate colour over elevation" >&2
+    status=1
+fi
+
+# The ramp must start below sea level, so bathymetry reads as water and not as ground.
+if ! printf '%s' "$relief_ramp" | jq -e '.[3] < 0' >/dev/null 2>&1; then
+    echo "FORBIDDEN: the terrain relief must reach below sea level" >&2
+    status=1
+fi
+
+sea_colour="$(printf '%s' "$relief_ramp" | jq -r '
+    [range(3; length; 2) as $i | select(.[$i] == 0) | .[$i + 1]] | .[0] // ""
+')"
+below_colour="$(printf '%s' "$relief_ramp" | jq -r '
+    [range(3; length; 2) as $i | select(.[$i] == -1) | .[$i + 1]] | .[0] // ""
+')"
+if [ -z "$sea_colour" ] || [ -z "$below_colour" ] || [ "$sea_colour" = "$below_colour" ]; then
+    echo "FORBIDDEN: the terrain relief must change colour across sea level" >&2
     status=1
 fi
 

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -41,11 +41,50 @@ cp "$root/clients/apple-situation/project.yml" \
 PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null
 
-sed -i.bak 's/#526879/#ff0000/' \
+sed -i.bak 's/#cfc9b4/#ff0000/' \
     "$fixture/clients/apple-situation/Resources/SituationStyle.json"
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted an unsafe colour" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
+    "$fixture/clients/apple-situation/Resources/"
+
+# Sea and shore must not read the same. A ramp that does not change across sea level draws
+# a coastline where there is none and hides the one that is there.
+python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'FLATTEN'
+import json, sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-terrain-relief":
+        ramp = layer["paint"]["color-relief-color"]
+        sea = ramp[ramp.index(0) + 1]
+        ramp[ramp.index(-1) + 1] = sea
+json.dump(style, open(path, "w"), indent=2)
+FLATTEN
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a ramp that does not change across sea level" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
+    "$fixture/clients/apple-situation/Resources/"
+
+# Height has to come from elevation. A constant colour is a flat wash that says nothing.
+python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'CONSTANT'
+import json, sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-terrain-relief":
+        layer["paint"]["color-relief-color"] = "#808080"
+json.dump(style, open(path, "w"), indent=2)
+CONSTANT
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a relief that ignores elevation" >&2
     exit 1
 fi
 


### PR DESCRIPTION
The base map drew hillshade over one flat background colour. Everything was the same
blue-grey: a bay and the ground beside it read alike, so there was no coastline, and
height showed only as shading with no sense of how high.

The elevation model already carries what is needed. A colour-relief layer now reads it and
runs a ramp: below sea level to near black, deepening with depth, then a step at sea level
to olive, and up through khaki and tan to brown, bare rock and snow. Coastlines come from
the model crossing sea level rather than from a water layer the archive does not have.
Hillshade stays over the colour for relief, in warm neutrals so it shades the tint instead
of tinting it blue.

The map also states its camera. Without one it opened on the Atlantic at world zoom, which
is nowhere anyone asked for, and it kept whatever zoom floor the renderer defaulted to. It
now opens over the ground the archive covers and can be pinched out until the whole world
is on screen.

The check follows the change. It forbade a colour-relief layer, which was right while the
archive was a synthetic fixture and is wrong now that it holds published elevation. It
requires one, requires the ramp to be driven by elevation rather than constant, requires it
to reach below sea level, and requires the colour to change across sea level, because a
ramp that reads the same on both sides draws a coastline that is not there. Its self-test
gained a case for each.

Rendered from the archive: ocean darkens with real bathymetry to 7,000 m, the Chesapeake
and Delaware bays draw their outlines, the Appalachian ridges carry tan, and the Himalaya
reach snow.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #384
- <kbd>&nbsp;3&nbsp;</kbd> #383 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #381
- <kbd>&nbsp;1&nbsp;</kbd> #382
<!-- GitButler Footer Boundary Bottom -->