### PR TITLE
Stop the map where its elevation stops, and carry one style to both renderers

### DIFF
--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -87,6 +87,7 @@ private struct SituationMap: UIViewRepresentable {
         view.initialCenter = CLLocationCoordinate2D(latitude: 40.5, longitude: -76.5)
         view.initialZoomLevel = 6
         view.minimumZoomLevel = 0
+        view.maximumZoomLevel = SituationStyleResource.maximumZoomLevel
         view.baseLayerIdentifiers = ["terrain-base": "pilotage-terrain-hillshade"]
         view.onFeatureTapped = onFeatureTapped
         return view

--- a/clients/apple-situation/App/SituationStyleResource.swift
+++ b/clients/apple-situation/App/SituationStyleResource.swift
@@ -7,6 +7,28 @@ enum SituationStyleResource {
 
     private static let archiveToken = "__PILOTAGE_TERRAIN_MBTILES_URL__"
 
+    /// Closest zoom the map allows.
+    ///
+    /// A raster-dem source draws past its deepest tile by stretching the one it has. Two
+    /// doublings keep a close view usable while the shape on screen still comes from
+    /// measured ground; past that the picture is invention. The value is read from the
+    /// manifest that ships beside the archive, so a plan that gains a closer band raises
+    /// the ceiling with it instead of leaving a second number to change by hand.
+    /// Doublings of stretch allowed past the deepest tile.
+    static let overzoomSteps: Double = 2
+
+    static var maximumZoomLevel: Double {
+        guard let url = Bundle.main.url(
+            forResource: "SituationTerrain.manifest",
+            withExtension: "json"
+        ),
+            let data = try? Data(contentsOf: url),
+            let manifest = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let bands = manifest["bands"] as? [[String: Any]] else { return 14 }
+        let deepest = bands.compactMap { $0["max_zoom"] as? Double }.max() ?? 13
+        return deepest + overzoomSteps
+    }
+
     static func load(bundle: Bundle = .main) throws -> String {
         guard let styleURL = bundle.url(forResource: "SituationStyle", withExtension: "json") else {
             throw SituationStyleResourceError.missingStyle

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
@@ -35,6 +35,13 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
     public var initialZoomLevel: Double = 6
     /// Furthest the map may be pinched out. Zero shows the whole world.
     public var minimumZoomLevel: Double = 0
+    /// Closest the map may be pinched in.
+    ///
+    /// A raster-dem source keeps drawing past its highest zoom by stretching the tile it
+    /// has. One step of that is a softer picture; several are a wash of colour that states
+    /// detail the elevation model never carried. The floor belongs just above the archive,
+    /// so the map stops where its data stops.
+    public var maximumZoomLevel: Double = 14
 
     /// Create a map with the specified base style JSON.
     public init(frame: CGRect = .zero, styleJSON: String) {
@@ -77,6 +84,7 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
         guard !hasAppliedInitialCamera else { return }
         hasAppliedInitialCamera = true
         mapView.minimumZoomLevel = minimumZoomLevel
+        mapView.maximumZoomLevel = maximumZoomLevel
         let camera = mapView.camera
         if initialPitchDegrees > 0 {
             camera.pitch = min(initialPitchDegrees, mapView.maximumPitch)

--- a/clients/apple-situation/Resources/SituationStyle.json
+++ b/clients/apple-situation/Resources/SituationStyle.json
@@ -1,6 +1,9 @@
 {
   "version": 8,
   "name": "Pilotage situation base",
+  "projection": {
+    "type": "globe"
+  },
   "sources": {
     "pilotage-terrain": {
       "type": "raster-dem",

--- a/clients/apple-situation/Resources/SituationTerrain.manifest.json
+++ b/clients/apple-situation/Resources/SituationTerrain.manifest.json
@@ -1,9 +1,9 @@
 {
-  "plan_sha256": "d2126f2fe3d8088dd3e83b9806067268c6c0e1e8da5e35db46a51ba25967b289",
-  "archive_sha256": "6c8f1bdeef56a777e45d7a7085b16df42e1cc0fbc44f629650dd5b40aaf3ac4d",
-  "tiles_requested": 2225,
-  "tiles_written": 2225,
-  "archive_bytes": 146153472,
+  "plan_sha256": "ae33522ca56b9931b3ee3ce7b6a2fb35a11a08c42512c52134283c7df1a4f2f6",
+  "archive_sha256": "2ec00e12fb93c3e7799932000cc9a91dd109e456d751143d039e50fbeb504551",
+  "tiles_requested": 3233,
+  "tiles_written": 3233,
+  "archive_bytes": 253530112,
   "source": "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png",
   "source_name": "AWS Terrain Tiles",
   "attribution": "Elevation from AWS Terrain Tiles. Sources include SRTM, ASTER GDEM, NRCan CDEM, and USGS 3DEP.",
@@ -25,6 +25,15 @@
       "max_lat_deg": 43.5,
       "min_lon_deg": -81.0,
       "max_lon_deg": -72.0
+    },
+    {
+      "name": "local",
+      "min_zoom": 11,
+      "max_zoom": 13,
+      "min_lat_deg": 40.1,
+      "max_lat_deg": 41.1,
+      "min_lon_deg": -75.25,
+      "max_lon_deg": -74.25
     }
   ]
 }

--- a/clients/apple-situation/Resources/SituationTerrain.plan.json
+++ b/clients/apple-situation/Resources/SituationTerrain.plan.json
@@ -22,6 +22,15 @@
       "max_lat_deg": 43.5,
       "min_lon_deg": -81.0,
       "max_lon_deg": -72.0
+    },
+    {
+      "name": "local",
+      "min_zoom": 11,
+      "max_zoom": 13,
+      "min_lat_deg": 40.1,
+      "max_lat_deg": 41.1,
+      "min_lon_deg": -75.25,
+      "max_lon_deg": -74.25
     }
   ]
 }

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -109,6 +109,26 @@ if [ -z "$sea_colour" ] || [ -z "$below_colour" ] || [ "$sea_colour" = "$below_c
     status=1
 fi
 
+# One style file drives both renderers. The web renderer draws a globe from this key and
+# this one ignores it, so the two stay on the same data and the same colours.
+if ! jq -e '.projection.type == "globe"' "$style" >/dev/null; then
+    echo "FORBIDDEN: the style must declare the globe projection for the web renderer" >&2
+    status=1
+fi
+
+# A raster-dem source keeps drawing past its deepest tile by stretching what it has. The
+# map has to stop near where the archive stops, and the limit has to follow the plan
+# rather than be written twice.
+if ! grep -Fq 'SituationTerrain.manifest' "$resolver" \
+    || ! grep -Fq 'maximumZoomLevel' "$resolver"; then
+    echo "FORBIDDEN: the closest zoom must be read from the terrain manifest" >&2
+    status=1
+fi
+if ! grep -Fq 'mapView.maximumZoomLevel = maximumZoomLevel' "$map_view"; then
+    echo "FORBIDDEN: the map must apply a closest zoom" >&2
+    status=1
+fi
+
 if grep -Eqi 'https?://' "$style"; then
     echo "FORBIDDEN: the base style must have no network URL" >&2
     status=1

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -140,6 +140,33 @@ if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
 fi
 cp "$root/.gitignore" "$fixture/"
 
+# The web renderer gets its globe from the same style file this one reads.
+python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'FLAT'
+import json, sys
+path = sys.argv[1]
+style = json.load(open(path))
+del style["projection"]
+json.dump(style, open(path, "w"), indent=2)
+FLAT
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a style with no globe projection" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
+    "$fixture/clients/apple-situation/Resources/"
+
+# A map with no closest zoom stretches one elevation pixel across the screen.
+sed -i.bak 's/mapView.maximumZoomLevel = maximumZoomLevel//' \
+    "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift"
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a map with no closest zoom" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift" \
+    "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"
+
 printf '\nbuild_package(source);\n' >> "$fixture/crates/pilotage-terrain-build/src/lib.rs"
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then


### PR DESCRIPTION
Two faults, both of them the map claiming to know more than it does.

The archive reached zoom 10, about 115 m for each elevation sample at this latitude, and
the map let a reader keep pinching in. A raster-dem source draws past its deepest tile by
stretching the one it has, so a close view became first a staircase of elevation pixels and
then a wash of colour across the screen. Nothing said the detail had run out.

The archive gains a local band at zooms 11 to 13 over the ground the aircraft flies, which
is where a close view is worth having, and the map now stops one step past the deepest
tile. That closest zoom is read from the manifest that ships beside the archive, so a plan
that gains a closer band moves the limit with it rather than leaving a second number to
update by hand.

The style also states a globe projection. The web renderer draws a globe from that key and
this one ignores it, so one style file and one tile archive serve both, with the same
colours, the same elevation and the same layers. There is no globe on the iPad: MapLibre
Native has no globe projection, and the upstream request for one has no owner, no branch
and no pull request.

The check gained the three rules: the style must declare the projection, the closest zoom
must come from the manifest, and the map must apply one. Its self-test gained a case for
each.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #384 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #383
- <kbd>&nbsp;2&nbsp;</kbd> #381
- <kbd>&nbsp;1&nbsp;</kbd> #382
<!-- GitButler Footer Boundary Bottom -->