### PR TITLE
Draw coastline from offline polygons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ clients/apple-situation/Packages/PilotageMapLibreBinding/.build/
 clients/apple-situation/Packages/PilotageMapLibreTerrain/Artifacts/
 clients/apple-situation/.build/
 clients/apple-situation/PilotageSituation.xcodeproj/
+clients/apple-situation/Resources/SituationCoastline.mbtiles
 clients/apple-situation/Resources/SituationTerrain.mbtiles

--- a/clients/apple-situation/App/SituationStyleResource.swift
+++ b/clients/apple-situation/App/SituationStyleResource.swift
@@ -5,7 +5,8 @@ enum SituationStyleResource {
     {"version":8,"name":"Pilotage terrain unavailable","sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#0b1721"}}]}
     """
 
-    private static let archiveToken = "__PILOTAGE_TERRAIN_MBTILES_URL__"
+    private static let coastlineArchiveToken = "__PILOTAGE_COASTLINE_MBTILES_URL__"
+    private static let terrainArchiveToken = "__PILOTAGE_TERRAIN_MBTILES_URL__"
 
     /// Closest zoom the map allows.
     ///
@@ -33,21 +34,31 @@ enum SituationStyleResource {
         guard let styleURL = bundle.url(forResource: "SituationStyle", withExtension: "json") else {
             throw SituationStyleResourceError.missingStyle
         }
-        guard let archiveFileURL = bundle.url(
+        guard let coastlineArchiveFileURL = bundle.url(
+            forResource: "SituationCoastline",
+            withExtension: "mbtiles"
+        ) else {
+            throw SituationStyleResourceError.missingCoastlineArchive
+        }
+        guard let terrainArchiveFileURL = bundle.url(
             forResource: "SituationTerrain",
             withExtension: "mbtiles"
         ) else {
-            throw SituationStyleResourceError.missingArchive
+            throw SituationStyleResourceError.missingTerrainArchive
         }
         let data = try Data(contentsOf: styleURL)
         let object = try JSONSerialization.jsonObject(with: data)
         guard var style = object as? [String: Any],
               var sources = style["sources"] as? [String: Any],
+              var coastline = sources["pilotage-coastline"] as? [String: Any],
+              coastline["url"] as? String == coastlineArchiveToken,
               var terrain = sources["pilotage-terrain"] as? [String: Any],
-              terrain["url"] as? String == archiveToken else {
+              terrain["url"] as? String == terrainArchiveToken else {
             throw SituationStyleResourceError.invalidTemplate
         }
-        terrain["url"] = try archiveURL(for: archiveFileURL).absoluteString
+        coastline["url"] = try archiveURL(for: coastlineArchiveFileURL).absoluteString
+        terrain["url"] = try archiveURL(for: terrainArchiveFileURL).absoluteString
+        sources["pilotage-coastline"] = coastline
         sources["pilotage-terrain"] = terrain
         style["sources"] = sources
 #if PILOTAGE_MAPLIBRE_TERRAIN
@@ -81,7 +92,8 @@ enum SituationStyleResource {
 
 private enum SituationStyleResourceError: LocalizedError {
     case missingStyle
-    case missingArchive
+    case missingCoastlineArchive
+    case missingTerrainArchive
     case invalidTemplate
     case invalidEncoding
     case invalidArchiveURL
@@ -90,10 +102,12 @@ private enum SituationStyleResourceError: LocalizedError {
         switch self {
         case .missingStyle:
             "The application bundle has no SituationStyle.json resource."
-        case .missingArchive:
+        case .missingCoastlineArchive:
+            "The application bundle has no SituationCoastline.mbtiles resource."
+        case .missingTerrainArchive:
             "The application bundle has no SituationTerrain.mbtiles resource."
         case .invalidTemplate:
-            "SituationStyle.json has no terrain archive token."
+            "SituationStyle.json has an invalid archive token."
         case .invalidEncoding:
             "The resolved situation style is not UTF-8 text."
         case .invalidArchiveURL:

--- a/clients/apple-situation/Resources/SituationCoastline.manifest.json
+++ b/clients/apple-situation/Resources/SituationCoastline.manifest.json
@@ -1,0 +1,62 @@
+{
+  "plan_sha256": "1ea2b7719ae2fce191ce3160d5c6424c5aef0abcf65777275481406dabd5a095",
+  "archive_sha256": "d54e07e7be017d822470ddf0f2587361047b77d2ced1ed54e6c4e520a5fda89e",
+  "tiles_written": 17171,
+  "archive_bytes": 7995392,
+  "source_name": "Natural Earth",
+  "dataset_scale": "1:10m",
+  "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.",
+  "closest_zoom": 15,
+  "sources": [
+    {
+      "name": "ocean",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_ocean.zip",
+      "sha256": "db626fcd5d50b096b156c78a2cc95011b39f32a61b4e47d147e3f7a77b8b2719",
+      "shapefile": "ne_10m_ocean.shp"
+    },
+    {
+      "name": "land",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_land.zip",
+      "sha256": "e547d749445eaa0964aba76738090ec88f5e63c4585122170f98c67a7ea922dc",
+      "shapefile": "ne_10m_land.shp"
+    },
+    {
+      "name": "lakes",
+      "version": "5.0.0",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes.zip",
+      "sha256": "0803a06f9c3cb4671d89b68c48b142aad9366ba40f665245e12a913fbc61722a",
+      "shapefile": "ne_10m_lakes.shp"
+    }
+  ],
+  "bands": [
+    {
+      "name": "world",
+      "min_zoom": 0,
+      "max_zoom": 5,
+      "min_lat_deg": -85.0511287798066,
+      "max_lat_deg": 85.0511287798066,
+      "min_lon_deg": -180.0,
+      "max_lon_deg": 180.0
+    },
+    {
+      "name": "region",
+      "min_zoom": 6,
+      "max_zoom": 10,
+      "min_lat_deg": 37.5,
+      "max_lat_deg": 43.5,
+      "min_lon_deg": -81.0,
+      "max_lon_deg": -72.0
+    },
+    {
+      "name": "local",
+      "min_zoom": 11,
+      "max_zoom": 15,
+      "min_lat_deg": 40.1,
+      "max_lat_deg": 41.1,
+      "min_lon_deg": -75.25,
+      "max_lon_deg": -74.25
+    }
+  ]
+}

--- a/clients/apple-situation/Resources/SituationCoastline.plan.json
+++ b/clients/apple-situation/Resources/SituationCoastline.plan.json
@@ -1,0 +1,58 @@
+{
+  "source_name": "Natural Earth",
+  "dataset_scale": "1:10m",
+  "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.",
+  "closest_zoom": 15,
+  "sources": [
+    {
+      "name": "ocean",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_ocean.zip",
+      "sha256": "db626fcd5d50b096b156c78a2cc95011b39f32a61b4e47d147e3f7a77b8b2719",
+      "shapefile": "ne_10m_ocean.shp"
+    },
+    {
+      "name": "land",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_land.zip",
+      "sha256": "e547d749445eaa0964aba76738090ec88f5e63c4585122170f98c67a7ea922dc",
+      "shapefile": "ne_10m_land.shp"
+    },
+    {
+      "name": "lakes",
+      "version": "5.0.0",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes.zip",
+      "sha256": "0803a06f9c3cb4671d89b68c48b142aad9366ba40f665245e12a913fbc61722a",
+      "shapefile": "ne_10m_lakes.shp"
+    }
+  ],
+  "bands": [
+    {
+      "name": "world",
+      "min_zoom": 0,
+      "max_zoom": 5,
+      "min_lat_deg": -85.0511287798066,
+      "max_lat_deg": 85.0511287798066,
+      "min_lon_deg": -180.0,
+      "max_lon_deg": 180.0
+    },
+    {
+      "name": "region",
+      "min_zoom": 6,
+      "max_zoom": 10,
+      "min_lat_deg": 37.5,
+      "max_lat_deg": 43.5,
+      "min_lon_deg": -81.0,
+      "max_lon_deg": -72.0
+    },
+    {
+      "name": "local",
+      "min_zoom": 11,
+      "max_zoom": 15,
+      "min_lat_deg": 40.1,
+      "max_lat_deg": 41.1,
+      "min_lon_deg": -75.25,
+      "max_lon_deg": -74.25
+    }
+  ]
+}

--- a/clients/apple-situation/Resources/SituationCoastline.provenance.md
+++ b/clients/apple-situation/Resources/SituationCoastline.provenance.md
@@ -1,0 +1,37 @@
+# Situation coastline archive
+
+This archive holds coastline data for the situation map. Coastline data means the ocean,
+land, and lake polygons that classify the map surface.
+
+## Source
+
+The build script uses the Natural Earth 1:10m physical vectors. The committed plan gives
+the source URL and the SHA-256 checksum for each source archive. The build stops if a
+checksum is not correct.
+
+Natural Earth data is in the public domain. The map carries this attribution:
+
+> Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.
+
+## Scale
+
+The source scale is 1:10m. This scale gives a stable coastline at the closest zoom in the
+plan. It does not give survey accuracy in a harbor.
+
+The plan uses three zoom bands. The world band supports a full-globe view. The region band
+supports the normal flight area. The local band supports the closest zoom.
+
+## Build
+
+The archive is a build artifact. The repository does not contain the archive. Build it
+from the repository root:
+
+```text
+sh clients/apple-situation/scripts/build-situation-coastline.sh
+```
+
+The script requires GDAL with the GeoPackage and MBTiles drivers. The script caches each
+verified source archive under `clients/apple-situation/.build/coastline-sources`.
+
+The script writes `SituationCoastline.manifest.json`. The manifest records the plan
+checksum, the archive checksum, the tile count, and the source data.

--- a/clients/apple-situation/Resources/SituationStyle.json
+++ b/clients/apple-situation/Resources/SituationStyle.json
@@ -5,6 +5,11 @@
     "type": "globe"
   },
   "sources": {
+    "pilotage-coastline": {
+      "type": "vector",
+      "url": "__PILOTAGE_COASTLINE_MBTILES_URL__",
+      "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com."
+    },
     "pilotage-terrain": {
       "type": "raster-dem",
       "url": "__PILOTAGE_TERRAIN_MBTILES_URL__",
@@ -22,11 +27,41 @@
       }
     },
     {
+      "id": "pilotage-ocean-fill",
+      "type": "fill",
+      "source": "pilotage-coastline",
+      "source-layer": "ocean",
+      "paint": {
+        "fill-color": "#061927",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "pilotage-land-fill",
+      "type": "fill",
+      "source": "pilotage-coastline",
+      "source-layer": "land",
+      "paint": {
+        "fill-color": "#526044",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "pilotage-lake-fill",
+      "type": "fill",
+      "source": "pilotage-coastline",
+      "source-layer": "lakes",
+      "paint": {
+        "fill-color": "#061927",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "pilotage-terrain-relief",
       "type": "color-relief",
       "source": "pilotage-terrain",
       "paint": {
-        "color-relief-opacity": 1,
+        "color-relief-opacity": 0.6,
         "color-relief-color": [
           "interpolate",
           [
@@ -42,11 +77,11 @@
           -1000,
           "#030b14",
           -200,
-          "#04101a",
+          "#394537",
           -20,
-          "#061521",
+          "#4a563c",
           -1,
-          "#081d29",
+          "#4f5f3e",
           0,
           "#4f5f3e",
           60,

--- a/clients/apple-situation/scripts/build-situation-coastline.sh
+++ b/clients/apple-situation/scripts/build-situation-coastline.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# Fetch coastline polygons and pack the offline vector archive.
+set -eu
+
+client_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+plan="$client_root/Resources/SituationCoastline.plan.json"
+archive="$client_root/Resources/SituationCoastline.mbtiles"
+manifest="$client_root/Resources/SituationCoastline.manifest.json"
+force=${1:-}
+
+for tool in curl jq shasum unzip ogr2ogr sqlite3 awk; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "$tool is required to build the coastline archive" >&2
+        exit 2
+    fi
+done
+
+plan_digest=$(shasum -a 256 "$plan" | awk '{print $1}')
+if [ "$force" != "--force" ] && [ -f "$archive" ] && [ -f "$manifest" ] &&
+    [ "$(jq -r '.plan_sha256 // ""' "$manifest")" = "$plan_digest" ] &&
+    [ "$(shasum -a 256 "$archive" | awk '{print $1}')" = "$(jq -r '.archive_sha256 // ""' "$manifest")" ]; then
+    echo "coastline archive is ready for the current plan"
+    exit 0
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/situation-coastline.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+source_cache="$client_root/.build/coastline-sources"
+mkdir -p "$source_cache"
+
+jq -r '.sources[] | [.name, .version, .url, .sha256, .shapefile] | @tsv' "$plan" |
+    while IFS="$(printf '\t')" read -r name version url expected_digest shapefile; do
+        source_archive="$source_cache/$name-$version.zip"
+        actual_digest=""
+        if [ -f "$source_archive" ]; then
+            actual_digest=$(shasum -a 256 "$source_archive" | awk '{print $1}')
+        fi
+        if [ "$actual_digest" != "$expected_digest" ]; then
+            fetched="$work/$name.zip"
+            curl --fail --location --silent --show-error --retry 3 \
+                --output "$fetched" "$url"
+            actual_digest=$(shasum -a 256 "$fetched" | awk '{print $1}')
+            if [ "$actual_digest" != "$expected_digest" ]; then
+                echo "the $name source checksum is not correct" >&2
+                exit 2
+            fi
+            mv "$fetched" "$source_archive"
+        fi
+        source_dir="$work/$name"
+        mkdir -p "$source_dir"
+        unzip -q "$source_archive" -d "$source_dir"
+        if [ ! -f "$source_dir/$shapefile" ]; then
+            echo "the $name source has no $shapefile file" >&2
+            exit 2
+        fi
+    done
+
+geopackage="$work/coastline.gpkg"
+jq -r '.sources[].name' "$plan" |
+    while read -r source_name; do
+        shapefile=$(jq -r --arg name "$source_name" \
+            '.sources[] | select(.name == $name) | .shapefile' "$plan")
+        jq -r '.bands[] | [.name, .min_zoom, .max_zoom, .min_lat_deg, .max_lat_deg, .min_lon_deg, .max_lon_deg] | @tsv' "$plan" |
+            while IFS="$(printf '\t')" read -r band_name _min_zoom _max_zoom min_lat max_lat min_lon max_lon; do
+                layer_name="${source_name}_${band_name}"
+                if [ -f "$geopackage" ]; then
+                    ogr2ogr -update -nln "$layer_name" \
+                        -clipsrc "$min_lon" "$min_lat" "$max_lon" "$max_lat" \
+                        -select featurecla -nlt MULTIPOLYGON -dim XY -makevalid \
+                        "$geopackage" "$work/$source_name/$shapefile"
+                else
+                    ogr2ogr -f GPKG -nln "$layer_name" \
+                        -clipsrc "$min_lon" "$min_lat" "$max_lon" "$max_lat" \
+                        -select featurecla -nlt MULTIPOLYGON -dim XY -makevalid \
+                        "$geopackage" "$work/$source_name/$shapefile"
+                fi
+            done
+    done
+
+jq '
+    [
+        .sources[] as $source |
+        .bands[] as $band |
+        {
+            key: ($source.name + "_" + $band.name),
+            value: {
+                target_name: $source.name,
+                description: ($source.name + " polygons"),
+                minzoom: $band.min_zoom,
+                maxzoom: $band.max_zoom
+            }
+        }
+    ] | from_entries
+' "$plan" > "$work/layers.json"
+
+minimum_zoom=$(jq -r '[.bands[].min_zoom] | min' "$plan")
+maximum_zoom=$(jq -r '[.bands[].max_zoom] | max' "$plan")
+GDAL_NUM_THREADS=1 ogr2ogr -f MBTiles \
+    -dsco "NAME=Pilotage situation coastline" \
+    -dsco "DESCRIPTION=Natural Earth 1:10m coastline polygons" \
+    -dsco "MINZOOM=$minimum_zoom" \
+    -dsco "MAXZOOM=$maximum_zoom" \
+    -dsco "BOUNDS=-180,-85.0511287798066,180,85.0511287798066" \
+    -dsco "CONF=$work/layers.json" \
+    "$work/archive.mbtiles" "$geopackage"
+
+tiles_written=$(sqlite3 "$work/archive.mbtiles" 'SELECT COUNT(*) FROM tiles;')
+if [ "$tiles_written" -eq 0 ]; then
+    echo "the coastline archive has no tiles" >&2
+    exit 2
+fi
+
+mv "$work/archive.mbtiles" "$archive"
+archive_digest=$(shasum -a 256 "$archive" | awk '{print $1}')
+jq -n \
+    --arg plan_sha256 "$plan_digest" \
+    --arg archive_sha256 "$archive_digest" \
+    --argjson tiles_written "$tiles_written" \
+    --argjson bytes "$(wc -c < "$archive" | tr -d ' ')" \
+    --slurpfile plan "$plan" '
+    {
+        plan_sha256: $plan_sha256,
+        archive_sha256: $archive_sha256,
+        tiles_written: $tiles_written,
+        archive_bytes: $bytes,
+        source_name: $plan[0].source_name,
+        dataset_scale: $plan[0].dataset_scale,
+        attribution: $plan[0].attribution,
+        closest_zoom: $plan[0].closest_zoom,
+        sources: $plan[0].sources,
+        bands: $plan[0].bands
+    }
+' > "$manifest"
+
+echo "packed $tiles_written coastline tiles into $archive"

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -11,6 +11,11 @@ plan="$client/Resources/SituationTerrain.plan.json"
 manifest="$client/Resources/SituationTerrain.manifest.json"
 fetcher="$client/scripts/build-situation-terrain.sh"
 provenance="$client/Resources/SituationTerrain.provenance.md"
+coastline_archive="$client/Resources/SituationCoastline.mbtiles"
+coastline_plan="$client/Resources/SituationCoastline.plan.json"
+coastline_manifest="$client/Resources/SituationCoastline.manifest.json"
+coastline_fetcher="$client/scripts/build-situation-coastline.sh"
+coastline_provenance="$client/Resources/SituationCoastline.provenance.md"
 resolver="$client/App/SituationStyleResource.swift"
 map_view="$client/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift"
 project="$client/project.yml"
@@ -20,7 +25,8 @@ status=0
 # working tree holds one. The plan and the manifest are committed and are always checked:
 # they are what says which tiles an archive should contain and what one build produced.
 for path in "$builder/src/lib.rs" "$builder/src/tests.rs" "$style" "$plan" "$manifest" \
-    "$fetcher" "$provenance" "$resolver" "$map_view" "$project"; do
+    "$fetcher" "$provenance" "$coastline_plan" "$coastline_manifest" \
+    "$coastline_fetcher" "$coastline_provenance" "$resolver" "$map_view" "$project"; do
     if [ ! -f "$path" ]; then
         echo "FORBIDDEN: required terrain file is missing: $path" >&2
         status=1
@@ -68,6 +74,56 @@ if ! jq -e '
 fi
 
 if ! jq -e '
+    .sources["pilotage-coastline"].type == "vector" and
+    .sources["pilotage-coastline"].url == "__PILOTAGE_COASTLINE_MBTILES_URL__" and
+    ([.layers[] | select(
+        .id == "pilotage-ocean-fill" and
+        .type == "fill" and
+        .source == "pilotage-coastline" and
+        .["source-layer"] == "ocean"
+    )] | length == 1) and
+    ([.layers[] | select(
+        .id == "pilotage-land-fill" and
+        .type == "fill" and
+        .source == "pilotage-coastline" and
+        .["source-layer"] == "land"
+    )] | length == 1) and
+    ([.layers[] | select(
+        .id == "pilotage-lake-fill" and
+        .type == "fill" and
+        .source == "pilotage-coastline" and
+        .["source-layer"] == "lakes"
+    )] | length == 1) and
+    ((.layers | map(.id) | index("pilotage-ocean-fill")) <
+        (.layers | map(.id) | index("pilotage-terrain-relief"))) and
+    ((.layers | map(.id) | index("pilotage-land-fill")) <
+        (.layers | map(.id) | index("pilotage-terrain-relief"))) and
+    ((.layers | map(.id) | index("pilotage-lake-fill")) <
+        (.layers | map(.id) | index("pilotage-terrain-relief")))
+' "$style" >/dev/null; then
+    echo "FORBIDDEN: the style must draw coastline polygons below terrain relief" >&2
+    status=1
+fi
+
+if ! jq -e '
+    ([.layers[] | select(.id == "pilotage-ocean-fill") |
+        select(.paint["fill-color"] == "#061927" and .paint["fill-opacity"] == 1)] |
+        length == 1) and
+    ([.layers[] | select(.id == "pilotage-land-fill") |
+        select(.paint["fill-color"] == "#526044" and .paint["fill-opacity"] == 1)] |
+        length == 1) and
+    ([.layers[] | select(.id == "pilotage-lake-fill") |
+        select(.paint["fill-color"] == "#061927" and .paint["fill-opacity"] == 1)] |
+        length == 1) and
+    ([.layers[] | select(.id == "pilotage-terrain-relief") |
+        select(.paint["color-relief-opacity"] > 0 and
+            .paint["color-relief-opacity"] < 1)] | length == 1)
+' "$style" >/dev/null; then
+    echo "FORBIDDEN: coastline polygons must remain visible below terrain relief" >&2
+    status=1
+fi
+
+if ! jq -e '
     .layers[] |
     select(.id == "pilotage-terrain-hillshade") |
     .paint["hillshade-shadow-color"] == "#241f16" and
@@ -78,9 +134,7 @@ if ! jq -e '
     status=1
 fi
 
-# The colour ramp is what separates sea from shore and low ground from high. A ramp that
-# reads the same on both sides of sea level draws a coastline that is not there, and a
-# ramp that is not driven by elevation is a flat wash that says nothing about height.
+# The colour ramp shows elevation and depth. The polygons classify land and water.
 relief_ramp="$(jq -c '
     .layers[] | select(.id == "pilotage-terrain-relief") | .paint["color-relief-color"]
 ' "$style")"
@@ -104,8 +158,8 @@ sea_colour="$(printf '%s' "$relief_ramp" | jq -r '
 below_colour="$(printf '%s' "$relief_ramp" | jq -r '
     [range(3; length; 2) as $i | select(.[$i] == -1) | .[$i + 1]] | .[0] // ""
 ')"
-if [ -z "$sea_colour" ] || [ -z "$below_colour" ] || [ "$sea_colour" = "$below_colour" ]; then
-    echo "FORBIDDEN: the terrain relief must change colour across sea level" >&2
+if [ -z "$sea_colour" ] || [ -z "$below_colour" ] || [ "$sea_colour" != "$below_colour" ]; then
+    echo "FORBIDDEN: the elevation ramp must not classify water at sea level" >&2
     status=1
 fi
 
@@ -136,6 +190,7 @@ fi
 
 if ! grep -Fq 'components.scheme = "mbtiles"' "$resolver" \
     || ! grep -Fq 'archiveURL.path.hasPrefix("/")' "$resolver" \
+    || ! grep -Fq 'forResource: "SituationCoastline"' "$resolver" \
     || ! grep -Fq 'forResource: "SituationTerrain"' "$resolver"; then
     echo "FORBIDDEN: the client must resolve an absolute bundled mbtiles URL at run time" >&2
     status=1
@@ -151,10 +206,11 @@ if ! grep -Eq '^[[:space:]]*- path: Resources[[:space:]]*$' "$project"; then
     status=1
 fi
 
-if grep -Eq '^clients/apple-situation/Resources/SituationTerrain\.mbtiles$' "$root/.gitignore"; then
+if grep -Eq '^clients/apple-situation/Resources/SituationTerrain\.mbtiles$' "$root/.gitignore" \
+    && grep -Eq '^clients/apple-situation/Resources/SituationCoastline\.mbtiles$' "$root/.gitignore"; then
     :
 else
-    echo "FORBIDDEN: the terrain archive must stay a build artifact, not a repository file" >&2
+    echo "FORBIDDEN: map archives must stay build artifacts" >&2
     status=1
 fi
 
@@ -173,6 +229,39 @@ if ! jq -e '
     status=1
 fi
 
+if ! jq -e '
+    .dataset_scale == "1:10m" and
+    .closest_zoom == ([.bands[].max_zoom] | max) and
+    ([.sources[].name] | sort) == ["lakes", "land", "ocean"] and
+    all(.sources[];
+        (.url | startswith("https://naturalearth.s3.amazonaws.com/")) and
+        (.sha256 | test("^[0-9a-f]{64}$")) and
+        (.shapefile | endswith(".shp"))) and
+    ([.bands[] | select(.min_zoom == 0 and .min_lon_deg <= -180 and
+        .max_lon_deg >= 180)] | length == 1) and
+    ([range(0; .closest_zoom + 1) as $zoom |
+        ([.bands[] | select(.min_zoom <= $zoom and .max_zoom >= $zoom)] | length)] |
+        all(. == 1)) and
+    (.attribution | length > 0)
+' "$coastline_plan" >/dev/null; then
+    echo "FORBIDDEN: the coastline plan must define verified data for each map zoom" >&2
+    status=1
+fi
+
+terrain_deepest_zoom="$(jq -r '[.bands[].max_zoom] | max' "$manifest")"
+coastline_closest_zoom="$(jq -r '.closest_zoom' "$coastline_plan")"
+if [ "$coastline_closest_zoom" -ne "$((terrain_deepest_zoom + 2))" ]; then
+    echo "FORBIDDEN: the coastline plan must reach the closest map zoom" >&2
+    status=1
+fi
+
+if ! grep -Fq 'GDAL_NUM_THREADS=1 ogr2ogr -f MBTiles' "$coastline_fetcher" \
+    || ! grep -Fq 'shasum -a 256' "$coastline_fetcher" \
+    || ! grep -Fq "CONF=\$work/layers.json" "$coastline_fetcher"; then
+    echo "FORBIDDEN: the coastline builder must verify and pack the source polygons" >&2
+    status=1
+fi
+
 plan_digest="$(shasum -a 256 "$plan" | awk '{print $1}')"
 if [ "$(jq -r '.plan_sha256 // ""' "$manifest")" != "$plan_digest" ]; then
     echo "FORBIDDEN: the terrain manifest does not describe the committed plan" >&2
@@ -181,6 +270,23 @@ fi
 
 if ! jq -e '.tiles_written > 0 and .tiles_written == .tiles_requested' "$manifest" >/dev/null; then
     echo "FORBIDDEN: the terrain manifest must record a complete fetch" >&2
+    status=1
+fi
+
+coastline_plan_digest="$(shasum -a 256 "$coastline_plan" | awk '{print $1}')"
+if [ "$(jq -r '.plan_sha256 // ""' "$coastline_manifest")" != "$coastline_plan_digest" ]; then
+    echo "FORBIDDEN: the coastline manifest does not describe the committed plan" >&2
+    status=1
+fi
+
+if ! jq -e --slurpfile plan "$coastline_plan" '
+    .tiles_written > 0 and
+    .dataset_scale == $plan[0].dataset_scale and
+    .closest_zoom == $plan[0].closest_zoom and
+    .sources == $plan[0].sources and
+    .bands == $plan[0].bands
+' "$coastline_manifest" >/dev/null; then
+    echo "FORBIDDEN: the coastline manifest must record a complete build" >&2
     status=1
 fi
 
@@ -197,10 +303,36 @@ if ! grep -Fq "$attribution" "$provenance"; then
     status=1
 fi
 
+coastline_attribution="$(jq -r '.attribution' "$coastline_plan")"
+if ! jq -e --arg text "$coastline_attribution" \
+    '.sources["pilotage-coastline"].attribution == $text' "$style" >/dev/null; then
+    echo "FORBIDDEN: the style must carry the coastline attribution" >&2
+    status=1
+fi
+if ! grep -Fq "$coastline_attribution" "$coastline_provenance"; then
+    echo "FORBIDDEN: the coastline provenance must carry the attribution" >&2
+    status=1
+fi
+
 if [ -f "$archive" ]; then
     actual_digest="$(shasum -a 256 "$archive" | awk '{print $1}')"
     if [ "$actual_digest" != "$(jq -r '.archive_sha256 // ""' "$manifest")" ]; then
         echo "FORBIDDEN: the terrain archive does not match its manifest" >&2
+        status=1
+    fi
+fi
+
+if [ -f "$coastline_archive" ]; then
+    actual_digest="$(shasum -a 256 "$coastline_archive" | awk '{print $1}')"
+    if [ "$actual_digest" != "$(jq -r '.archive_sha256 // ""' "$coastline_manifest")" ]; then
+        echo "FORBIDDEN: the coastline archive does not match its manifest" >&2
+        status=1
+    fi
+    if ! sqlite3 "$coastline_archive" \
+        "SELECT value FROM metadata WHERE name = 'json';" | jq -e '
+            [.vector_layers[].id] | sort == ["lakes", "land", "ocean"]
+        ' >/dev/null; then
+        echo "FORBIDDEN: the coastline archive must contain ocean, land, and lakes" >&2
         status=1
     fi
 fi

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -26,11 +26,16 @@ cp "$root/crates/pilotage-terrain-build/examples/build_situation_fixture.rs" \
 cp "$root/clients/apple-situation/App/SituationStyleResource.swift" \
     "$fixture/clients/apple-situation/App/"
 cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
+    "$root/clients/apple-situation/Resources/SituationCoastline.plan.json" \
+    "$root/clients/apple-situation/Resources/SituationCoastline.manifest.json" \
+    "$root/clients/apple-situation/Resources/SituationCoastline.provenance.md" \
     "$root/clients/apple-situation/Resources/SituationTerrain.plan.json" \
     "$root/clients/apple-situation/Resources/SituationTerrain.manifest.json" \
     "$root/clients/apple-situation/Resources/SituationTerrain.provenance.md" \
     "$fixture/clients/apple-situation/Resources/"
 cp "$root/clients/apple-situation/scripts/build-situation-terrain.sh" \
+    "$fixture/clients/apple-situation/scripts/"
+cp "$root/clients/apple-situation/scripts/build-situation-coastline.sh" \
     "$fixture/clients/apple-situation/scripts/"
 cp "$root/.gitignore" "$fixture/"
 cp "$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift" \
@@ -51,22 +56,50 @@ fi
 cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
     "$fixture/clients/apple-situation/Resources/"
 
-# Sea and shore must not read the same. A ramp that does not change across sea level draws
-# a coastline where there is none and hides the one that is there.
-python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'FLATTEN'
+# The polygon layers are the source of the coastline. The elevation ramp is not a
+# coastline source.
+python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'REMOVE_COASTLINE'
+import json, sys
+path = sys.argv[1]
+style = json.load(open(path))
+del style["sources"]["pilotage-coastline"]
+style["layers"] = [
+    layer for layer in style["layers"]
+    if layer["id"] not in {
+        "pilotage-ocean-fill",
+        "pilotage-land-fill",
+        "pilotage-lake-fill",
+    }
+]
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-terrain-relief":
+        layer["paint"]["color-relief-opacity"] = 1
+        ramp = layer["paint"]["color-relief-color"]
+        ramp[ramp.index(-1) + 1] = "#081d29"
+json.dump(style, open(path, "w"), indent=2)
+REMOVE_COASTLINE
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted an elevation-only coastline" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
+    "$fixture/clients/apple-situation/Resources/"
+
+# The ramp must not classify water at sea level.
+python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'THRESHOLD'
 import json, sys
 path = sys.argv[1]
 style = json.load(open(path))
 for layer in style["layers"]:
     if layer["id"] == "pilotage-terrain-relief":
         ramp = layer["paint"]["color-relief-color"]
-        sea = ramp[ramp.index(0) + 1]
-        ramp[ramp.index(-1) + 1] = sea
+        ramp[ramp.index(-1) + 1] = "#081d29"
 json.dump(style, open(path, "w"), indent=2)
-FLATTEN
+THRESHOLD
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
-    echo "the terrain guard accepted a ramp that does not change across sea level" >&2
+    echo "the terrain guard accepted a sea-level threshold" >&2
     exit 1
 fi
 cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
@@ -113,6 +146,16 @@ fi
 cp "$root/clients/apple-situation/Resources/SituationTerrain.plan.json" \
     "$fixture/clients/apple-situation/Resources/"
 
+sed -i.bak 's/"closest_zoom": 15/"closest_zoom": 14/' \
+    "$fixture/clients/apple-situation/Resources/SituationCoastline.plan.json"
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a coastline plan below the closest zoom" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/Resources/SituationCoastline.plan.json" \
+    "$fixture/clients/apple-situation/Resources/"
+
 # Attribution is a licence condition of the tile source and has to reach the map.
 python3 - "$fixture/clients/apple-situation/Resources/SituationStyle.json" <<'STRIP'
 import json, sys
@@ -132,7 +175,9 @@ cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
 # A committed archive would put a large build artifact in history and hide which tiles it
 # was built from.
 grep -v '^clients/apple-situation/Resources/SituationTerrain\.mbtiles$' \
-    "$root/.gitignore" > "$fixture/.gitignore"
+    "$root/.gitignore" | \
+    grep -v '^clients/apple-situation/Resources/SituationCoastline\.mbtiles$' \
+    > "$fixture/.gitignore"
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted a committed terrain archive" >&2


### PR DESCRIPTION
Closes #386.

## Summary

- Build verified Natural Earth ocean, land, and lake polygons into an offline MBTiles archive.
- Draw polygon fills below the elevation relief.
- Keep bathymetry in the elevation ramp.
- Reject a style that uses a sea-level threshold as the coastline.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`
- `RUSTDOCFLAGS='-D missing_docs -D rustdoc::broken_intra_doc_links' cargo doc --workspace --no-deps --locked`
- `cargo build --workspace --release --locked`
- `sh clients/apple-situation/scripts/ci-ios.sh`
- `bash scripts/test-check-terrain-base-layer.sh`
- Two forced coastline builds produced the same archive SHA-256.