### PR TITLE
Place vertical features above terrain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-terrain-query"
+version = "0.1.0"
+dependencies = [
+ "libm",
+ "png",
+ "rusqlite",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-timing"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/pilotage-svs-db",
     "crates/pilotage-svs-build",
     "crates/pilotage-terrain-build",
+    "crates/pilotage-terrain-query",
     "crates/pilotage-mission",
     "crates/pilotage-instrument-runtime",
     "crates/pilotage-presentation",
@@ -121,6 +122,7 @@ pilotage-session = { path = "crates/pilotage-session" }
 pilotage-mission = { path = "crates/pilotage-mission" }
 pilotage-instrument-runtime = { path = "crates/pilotage-instrument-runtime" }
 pilotage-presentation = { path = "crates/pilotage-presentation" }
+pilotage-terrain-query = { path = "crates/pilotage-terrain-query" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clients/apple-situation/App/SituationClientModel.swift
+++ b/clients/apple-situation/App/SituationClientModel.swift
@@ -39,6 +39,7 @@ final class SituationClientModel: ObservableObject {
 
     private let session: PresentationSession
     private let domain: RadioDomainSession?
+    private let terrainArchivePath: String?
     private let terrainAvailable: Bool
     private let discovery = AeroLinkDiscoveryGate()
     private let evidenceWriter = SituationEvidenceWriter()
@@ -71,27 +72,40 @@ final class SituationClientModel: ObservableObject {
         let session = PresentationSession()
         self.session = session
         radioSource = source
-        terrainAvailable = Bundle.main.url(
+        let terrainArchivePath = Bundle.main.url(
             forResource: "SituationTerrain",
             withExtension: "mbtiles"
-        ) != nil
+        )?.path
+        self.terrainArchivePath = terrainArchivePath
+        var loadedTerrain = false
+        var initialError: String?
+        if let terrainArchivePath {
+            do {
+                try session.loadTerrainArchiveBlocking(archivePath: terrainArchivePath)
+                loadedTerrain = true
+            } catch {
+                initialError = Self.join(initialError, error.localizedDescription)
+            }
+        }
         var createdDomain: RadioDomainSession?
         var initialDisplay: DisplayBatch?
         do {
             initialDisplay = try session.observeSources(
                 observation: PresentationSourceObservation(
                     source: source,
-                    terrainAvailable: terrainAvailable
+                    terrainAvailable: loadedTerrain
                 ),
                 nowMicros: Self.monotonicMicros
             )
             createdDomain = try RadioDomainSession()
         } catch {
-            startupError = Self.join(startupError, error.localizedDescription)
+            initialError = Self.join(initialError, error.localizedDescription)
         }
+        terrainAvailable = loadedTerrain
         domain = createdDomain
+        startupError = initialError
         display = initialDisplay
-        errorMessage = startupError
+        errorMessage = initialError
     }
 
     func activate() async {
@@ -252,7 +266,10 @@ final class SituationClientModel: ObservableObject {
     /// looks exactly like a map fed from a radio.
     func startReplay(_ flight: Flight) {
         stopReplay()
-        guard let run = SituationReplayRun(flight: flight) else {
+        guard let run = SituationReplayRun(
+            flight: flight,
+            terrainArchivePath: terrainArchivePath
+        ) else {
             errorMessage = Self.join(startupError, "\(flight.receptionFileName) cannot be read.")
             return
         }

--- a/clients/apple-situation/App/SituationReplaySource.swift
+++ b/clients/apple-situation/App/SituationReplaySource.swift
@@ -34,12 +34,16 @@ final class SituationReplayRun {
     private let session: PresentationSession
     private let lines: [String]
 
-    init?(flight: Flight) {
+    init?(flight: Flight, terrainArchivePath: String?) {
         guard let text = try? String(contentsOf: flight.receptionURL, encoding: .utf8),
               let domain = try? RadioDomainSession() else { return nil }
+        let session = PresentationSession()
+        if let terrainArchivePath {
+            try? session.loadTerrainArchiveBlocking(archivePath: terrainArchivePath)
+        }
         self.flight = flight
         self.domain = domain
-        session = PresentationSession()
+        self.session = session
         lines = text.split(separator: "\n").map(String.init)
     }
 

--- a/clients/apple-situation/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift
+++ b/clients/apple-situation/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift
@@ -51,6 +51,8 @@ public struct GeoJSONPolygonFeature: Equatable, Sendable {
     public let baseAboveTerrainMetres: Double?
     /// Ceiling of the shape, in metres above the terrain surface beneath it.
     public let topAboveTerrainMetres: Double?
+    /// Whether the height keeps a reported altitude because terrain was not available.
+    public let usesReportedAltitudeFallback: Bool
 
     /// Create one polygon feature.
     public init(
@@ -58,13 +60,15 @@ public struct GeoJSONPolygonFeature: Equatable, Sendable {
         rings: [[GeoJSONPosition]],
         label: String?,
         baseAboveTerrainMetres: Double? = nil,
-        topAboveTerrainMetres: Double? = nil
+        topAboveTerrainMetres: Double? = nil,
+        usesReportedAltitudeFallback: Bool = false
     ) {
         self.id = id
         self.rings = rings
         self.label = label
         self.baseAboveTerrainMetres = baseAboveTerrainMetres
         self.topAboveTerrainMetres = topAboveTerrainMetres
+        self.usesReportedAltitudeFallback = usesReportedAltitudeFallback
     }
 }
 
@@ -113,6 +117,11 @@ public enum GeoJSONFeatureCollectionEncoder {
         // no height to read, and the shape would vanish rather than lie flat.
         properties["base"] = polygon.baseAboveTerrainMetres ?? 0
         properties["top"] = polygon.topAboveTerrainMetres ?? 0
+        properties["uses_reported_altitude_fallback"] = polygon.usesReportedAltitudeFallback
+        properties["below_terrain"] = min(
+            polygon.baseAboveTerrainMetres ?? 0,
+            polygon.topAboveTerrainMetres ?? 0
+        ) < 0
         return [
             "geometry": [
                 "coordinates": polygon.rings.map { $0.map(positionObject) },

--- a/clients/apple-situation/Packages/PilotageGeoJSONEdge/Tests/PilotageGeoJSONEdgeTests/FeatureCollectionTests.swift
+++ b/clients/apple-situation/Packages/PilotageGeoJSONEdge/Tests/PilotageGeoJSONEdgeTests/FeatureCollectionTests.swift
@@ -38,6 +38,36 @@ func polygonEncoding() throws {
     #expect(rings == [[[-75.0, 40.0], [-75.0, 41.0], [-74.0, 41.0], [-75.0, 40.0]]])
 }
 
+@Test("Polygon encoding keeps negative terrain heights and fallback state")
+func negativeTerrainHeightEncoding() throws {
+    let ring = [
+        GeoJSONPosition(longitudeDegrees: -75.0, latitudeDegrees: 40.0),
+        GeoJSONPosition(longitudeDegrees: -75.0, latitudeDegrees: 41.0),
+        GeoJSONPosition(longitudeDegrees: -74.0, latitudeDegrees: 40.0),
+        GeoJSONPosition(longitudeDegrees: -75.0, latitudeDegrees: 40.0),
+    ]
+    let data = try GeoJSONFeatureCollectionEncoder.encode(
+        polygons: [
+            GeoJSONPolygonFeature(
+                id: "traffic-below-terrain",
+                rings: [ring],
+                label: "REPORTED ALTITUDE",
+                baseAboveTerrainMetres: -100,
+                topAboveTerrainMetres: -40,
+                usesReportedAltitudeFallback: true
+            ),
+        ]
+    )
+    let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let features = try #require(object["features"] as? [[String: Any]])
+    let properties = try #require(features.first?["properties"] as? [String: Any])
+
+    #expect(properties["base"] as? Double == -100)
+    #expect(properties["top"] as? Double == -40)
+    #expect(properties["below_terrain"] as? Bool == true)
+    #expect(properties["uses_reported_altitude_fallback"] as? Bool == true)
+}
+
 private func firstCoordinate(in data: Data) throws -> [Double] {
     let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
     let features = try #require(object["features"] as? [[String: Any]])

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift
@@ -164,6 +164,7 @@ final class SituationOverlay {
         let source = try addSource(data: data, identifier: sourceID("shape", shapeStyle.id), to: mapStyle)
         if shapeStyle.extruded {
             addFillExtrusionLayer(style: shapeStyle, source: source, to: mapStyle)
+            addBelowTerrainFillLayer(style: shapeStyle, source: source, to: mapStyle)
         } else {
             addFillLayer(style: shapeStyle, source: source, to: mapStyle)
         }
@@ -251,10 +252,23 @@ final class SituationOverlay {
         to mapStyle: MLNStyle
     ) {
         let layer = MLNFillExtrusionStyleLayer(identifier: layerID("fill", style.id), source: source)
+        layer.predicate = NSPredicate(format: "below_terrain == NO")
         layer.fillExtrusionColor = constant(color(style.fill))
         layer.fillExtrusionOpacity = constant(Double(style.fill.alpha) / 255.0)
         layer.fillExtrusionBase = NSExpression(forKeyPath: "base")
         layer.fillExtrusionHeight = NSExpression(forKeyPath: "top")
+        add(layer, to: mapStyle)
+    }
+
+    /// Draw a flat fill when MapLibre cannot use a negative extrusion height.
+    private func addBelowTerrainFillLayer(
+        style: DisplayShapeStyle,
+        source: MLNShapeSource,
+        to mapStyle: MLNStyle
+    ) {
+        let layer = MLNFillStyleLayer(identifier: layerID("below", style.id), source: source)
+        layer.predicate = NSPredicate(format: "below_terrain == YES")
+        layer.fillColor = constant(color(style.fill))
         add(layer, to: mapStyle)
     }
 
@@ -403,7 +417,8 @@ private extension GeoJSONPolygonFeature {
             },
             label: shape.label,
             baseAboveTerrainMetres: shape.baseAboveTerrainM,
-            topAboveTerrainMetres: shape.topAboveTerrainM
+            topAboveTerrainMetres: shape.topAboveTerrainM,
+            usesReportedAltitudeFallback: shape.usesReportedAltitudeFallback
         )
     }
 }

--- a/clients/apple-situation/Packages/PilotageSituationCore/Package.swift
+++ b/clients/apple-situation/Packages/PilotageSituationCore/Package.swift
@@ -18,7 +18,10 @@ let package = Package(
         ),
         .target(
             name: "PilotageSituationCore",
-            dependencies: ["PilotageSituationFFI"]
+            dependencies: ["PilotageSituationFFI"],
+            linkerSettings: [
+                .linkedLibrary("sqlite3"),
+            ]
         ),
         .testTarget(
             name: "PilotageSituationCoreTests",

--- a/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.lock
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aero-link"
 version = "0.1.0"
 dependencies = [
@@ -348,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,16 +422,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -684,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +768,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "nom"
@@ -773,12 +839,26 @@ dependencies = [
  "airmass-geojson",
  "pilotage-navdata-cycle",
  "pilotage-presentation",
+ "pilotage-terrain-query",
+ "png",
+ "rusqlite",
  "serde_json",
  "surveillance-aero-link",
  "surveillance-core",
  "surveillance-geojson",
+ "tempfile",
  "thiserror",
  "uniffi",
+]
+
+[[package]]
+name = "pilotage-terrain-query"
+version = "0.1.0"
+dependencies = [
+ "libm",
+ "png",
+ "rusqlite",
+ "thiserror",
 ]
 
 [[package]]
@@ -788,10 +868,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "postcard"
@@ -837,6 +936,19 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -961,6 +1073,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "siphasher"
@@ -1340,6 +1458,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasm-bindgen"

--- a/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml
@@ -33,6 +33,7 @@ airmass-core = { path = ".build/airmass/crates/airmass-core", features = ["std"]
 airmass-geojson = { path = ".build/airmass/crates/airmass-geojson" }
 pilotage-navdata-cycle = { path = "../../../../crates/pilotage-navdata-cycle" }
 pilotage-presentation = { path = "../../../../crates/pilotage-presentation" }
+pilotage-terrain-query = { path = "../../../../crates/pilotage-terrain-query" }
 serde_json = "1.0"
 surveillance-aero-link = { path = ".build/surveillance/crates/surveillance-aero-link", features = ["std"] }
 surveillance-core = { path = ".build/surveillance/crates/surveillance-core", features = ["std"] }
@@ -47,6 +48,11 @@ airmass-geojson = { path = ".build/airmass/crates/airmass-geojson" }
 [patch."https://github.com/luofang34/Surveillance.git"]
 surveillance-core = { path = ".build/surveillance/crates/surveillance-core" }
 surveillance-geojson = { path = ".build/surveillance/crates/surveillance-geojson" }
+
+[dev-dependencies]
+png = "0.18.1"
+rusqlite = { version = "0.40.2", default-features = false }
+tempfile = "3.23.0"
 
 [workspace.lints.rust]
 missing_docs = "deny"

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/error.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/error.rs
@@ -33,6 +33,22 @@ pub enum FfiError {
         /// Validation or decode detail.
         message: String,
     },
+    /// A terrain archive could not be opened or validated.
+    #[error("terrain archive is not available: {message}")]
+    TerrainArchive {
+        /// Archive failure detail.
+        message: String,
+    },
+    /// Terrain elevation could not be read for one position.
+    #[error("terrain elevation is not available at ({latitude_deg}, {longitude_deg}): {message}")]
+    TerrainElevation {
+        /// Latitude in degrees.
+        latitude_deg: f64,
+        /// Longitude in degrees.
+        longitude_deg: f64,
+        /// Query failure detail.
+        message: String,
+    },
     /// A layer identity is not in the portable catalog.
     #[error("display layer is not known: {layer_id}")]
     UnknownLayer {

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
@@ -195,6 +195,8 @@ pub struct DisplayShape {
     pub base_above_terrain_m: Option<f64>,
     /// Ceiling of the shape, in metres above the terrain surface beneath it.
     pub top_above_terrain_m: Option<f64>,
+    /// Whether the height keeps a reported altitude because terrain was not available.
+    pub uses_reported_altitude_fallback: bool,
     /// Producer instance identity.
     pub producer_instance_id: u64,
     /// Snapshot revision.
@@ -404,6 +406,7 @@ impl From<pilotage_presentation::ShapeFeature> for DisplayShape {
             label: value.label,
             base_above_terrain_m: value.base_above_terrain_m,
             top_above_terrain_m: value.top_above_terrain_m,
+            uses_reported_altitude_fallback: value.uses_reported_altitude_fallback,
             producer_instance_id: value.producer_instance_id,
             snapshot_revision: value.snapshot_revision,
         }

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/session.rs
@@ -7,7 +7,8 @@ use airmass_core::{
     WeatherSnapshotEnvelope, WeatherSnapshotRecord, WeatherSnapshotRecordHeader, WeatherStationId,
 };
 use airmass_geojson::{Wgs84Position, map_snapshot_transition};
-use pilotage_presentation::{PointChange, PresentationAdapter};
+use pilotage_presentation::{Coordinate, PointChange, PresentationAdapter};
+use pilotage_terrain_query::TerrainArchive;
 use surveillance_core::{TrackRecord, TrackRecordHeader};
 
 use crate::WeatherStationPosition;
@@ -19,6 +20,7 @@ mod tests;
 #[derive(Default)]
 struct SessionState {
     presentation: PresentationAdapter,
+    terrain: Option<TerrainArchive>,
     weather_snapshot: Option<WeatherSnapshotEnvelope>,
     weather_positions: BTreeMap<String, Wgs84Position>,
     source_observation: PresentationSourceObservation,
@@ -52,7 +54,15 @@ impl PresentationSession {
         let delta = record.into_delta().map_err(track_record_error)?;
         let mut state = self.lock_state()?;
         state.presentation.advance_time(now_micros);
-        let change = state.presentation.apply_traffic_delta(&delta);
+        let SessionState {
+            presentation,
+            terrain,
+            ..
+        } = &mut *state;
+        let change = presentation
+            .apply_traffic_delta_with_terrain_blocking(&delta, |coordinate| {
+                terrain_elevation_blocking(terrain, coordinate)
+            })?;
         Ok(display_for_state(&state, change.into_iter().collect()))
     }
 
@@ -72,7 +82,7 @@ impl PresentationSession {
             return Ok(display_for_state(&state, Vec::new()));
         }
         let deltas = map_weather_transition(&state, &current);
-        let changes = apply_weather_deltas(&mut state.presentation, deltas);
+        let changes = apply_weather_deltas(&mut state, deltas)?;
         state.weather_snapshot = Some(current);
         Ok(display_for_state(&state, changes))
     }
@@ -116,7 +126,7 @@ impl PresentationSession {
         apply_source_observation(&mut state);
         if let Some(current) = state.weather_snapshot.clone() {
             let deltas = map_weather_initial(&state, &current);
-            changes.extend(apply_weather_deltas(&mut state.presentation, deltas));
+            changes.extend(apply_weather_deltas(&mut state, deltas)?);
         }
         Ok(display_for_state(&state, changes))
     }
@@ -130,6 +140,19 @@ impl PresentationSession {
         state.source_observation.radio_receivers.clear();
         apply_source_observation(&mut state);
         Ok(display_for_state(&state, Vec::new()))
+    }
+
+    /// Open the Terrarium archive used for vertical placement.
+    ///
+    /// Call this function before the session accepts traffic or weather records.
+    pub fn load_terrain_archive_blocking(&self, archive_path: String) -> Result<(), FfiError> {
+        let terrain = TerrainArchive::open_blocking(&archive_path).map_err(|source| {
+            FfiError::TerrainArchive {
+                message: source.to_string(),
+            }
+        })?;
+        self.lock_state()?.terrain = Some(terrain);
+        Ok(())
     }
 
     /// Record source facts and advance the display clock.
@@ -227,13 +250,39 @@ fn map_weather_initial(
 }
 
 fn apply_weather_deltas(
-    presentation: &mut PresentationAdapter,
+    state: &mut SessionState,
     deltas: Vec<airmass_geojson::FeatureDelta>,
-) -> Vec<PointChange> {
-    deltas
-        .iter()
-        .filter_map(|delta| presentation.apply_weather_delta(delta))
-        .collect()
+) -> Result<Vec<PointChange>, FfiError> {
+    let mut changes = Vec::new();
+    for delta in &deltas {
+        let SessionState {
+            presentation,
+            terrain,
+            ..
+        } = &mut *state;
+        let change = presentation
+            .apply_weather_delta_with_terrain_blocking(delta, |coordinate| {
+                terrain_elevation_blocking(terrain, coordinate)
+            })?;
+        changes.extend(change);
+    }
+    Ok(changes)
+}
+
+fn terrain_elevation_blocking(
+    terrain: &mut Option<TerrainArchive>,
+    coordinate: Coordinate,
+) -> Result<Option<f64>, FfiError> {
+    let Some(terrain) = terrain else {
+        return Ok(None);
+    };
+    terrain
+        .elevation_m_blocking(coordinate.latitude_deg, coordinate.longitude_deg)
+        .map_err(|source| FfiError::TerrainElevation {
+            latitude_deg: coordinate.latitude_deg,
+            longitude_deg: coordinate.longitude_deg,
+            message: source.to_string(),
+        })
 }
 
 fn weather_position_catalog(

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/session/tests.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+use png::{BitDepth, ColorType, Encoder};
+use rusqlite::{Connection, params};
 use surveillance_core::{
     AddressNamespace, FieldProvenance, FieldQuality, ObservationOrigin, ObservationTime,
     ProducerInstanceId, RemovalReason, SnapshotRevision, SourceRef, TimedField, TrackDelta,
     TrackId, TrackKey, TrackRecord, TrackSnapshot, TrackSnapshotHandle, Wgs84Position,
 };
+use tempfile::NamedTempFile;
 
 use super::PresentationSession;
 use crate::{
@@ -26,6 +29,28 @@ fn versioned_track_record_crosses_the_facade() {
     assert_eq!(batch.points[0].altitude_ft, Some(5_500));
     assert_eq!(batch.point_changes.len(), 1);
     assert_eq!(batch.point_changes[0].kind, DisplayPointChangeKind::Upsert);
+}
+
+#[test]
+fn loaded_terrain_places_a_track_pad_above_the_surface() {
+    let archive = terrain_archive(400.0);
+    let session = PresentationSession::new();
+    session
+        .load_terrain_archive_blocking(archive.path().to_string_lossy().into_owned())
+        .expect("terrain archive must load");
+    let encoded =
+        serde_json::to_string(&track_record(9, 2, 42.36)).expect("track record must encode");
+
+    let batch = session
+        .accept_track_record(encoded, 10)
+        .expect("track record must be accepted");
+
+    let pad = &batch.shapes[0];
+    let base = pad
+        .base_above_terrain_m
+        .expect("traffic pad must state its floor");
+    assert!((base - (5_500.0 * 0.3048 - 400.0)).abs() < 1e-6);
+    assert!(!pad.uses_reported_altitude_fallback);
 }
 
 #[test]
@@ -184,4 +209,64 @@ fn layer<'a>(batch: &'a crate::DisplayBatch, id: &str) -> &'a crate::DisplayLaye
         .iter()
         .find(|layer| layer.id == id)
         .expect("expected layer must exist")
+}
+
+fn terrain_archive(elevation_m: f64) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("create terrain fixture");
+    let connection = Connection::open(file.path()).expect("open terrain fixture");
+    connection
+        .execute_batch(
+            "CREATE TABLE metadata (name TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE tiles (
+                 zoom_level INTEGER NOT NULL,
+                 tile_column INTEGER NOT NULL,
+                 tile_row INTEGER NOT NULL,
+                 tile_data BLOB NOT NULL,
+                 PRIMARY KEY (zoom_level, tile_column, tile_row)
+             );",
+        )
+        .expect("create terrain fixture schema");
+    for (name, value) in [
+        ("encoding", "terrarium"),
+        ("format", "png"),
+        ("minzoom", "0"),
+        ("maxzoom", "0"),
+        ("tile_size", "2"),
+    ] {
+        connection
+            .execute(
+                "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
+                params![name, value],
+            )
+            .expect("insert terrain fixture metadata");
+    }
+    connection
+        .execute(
+            "INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data)
+             VALUES (0, 0, 0, ?1)",
+            [terrarium_png(elevation_m)],
+        )
+        .expect("insert terrain fixture tile");
+    drop(connection);
+    file
+}
+
+fn terrarium_png(elevation_m: f64) -> Vec<u8> {
+    let code = ((elevation_m + 32_768.0) * 256.0).round() as u32;
+    let pixel = [
+        ((code >> 16) & 0xff) as u8,
+        ((code >> 8) & 0xff) as u8,
+        (code & 0xff) as u8,
+    ];
+    let pixels = pixel.repeat(4);
+    let mut bytes = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, 2, 2);
+    encoder.set_color(ColorType::Rgb);
+    encoder.set_depth(BitDepth::Eight);
+    let mut writer = encoder.write_header().expect("write terrain PNG header");
+    writer
+        .write_image_data(&pixels)
+        .expect("write terrain PNG pixels");
+    writer.finish().expect("finish terrain PNG");
+    bytes
 }

--- a/crates/pilotage-presentation/src/lib.rs
+++ b/crates/pilotage-presentation/src/lib.rs
@@ -8,6 +8,7 @@ mod layer;
 mod model;
 mod policy;
 mod traffic;
+mod vertical;
 mod weather;
 
 #[cfg(test)]

--- a/crates/pilotage-presentation/src/model.rs
+++ b/crates/pilotage-presentation/src/model.rs
@@ -196,13 +196,13 @@ pub struct ShapeFeature {
     pub label: Option<String>,
     /// Floor of the shape, in metres above the terrain surface beneath it.
     ///
-    /// The renderer measures a raised shape from the terrain surface, and a reported
-    /// altitude is measured from mean sea level. The difference is the terrain elevation
-    /// under the feature, which this crate cannot read, so a shape over high ground rides
-    /// that much too high. The label carries the reported altitude and stays exact.
+    /// This value keeps the reported altitude when
+    /// [`uses_reported_altitude_fallback`](Self::uses_reported_altitude_fallback) is true.
     pub base_above_terrain_m: Option<f64>,
     /// Ceiling of the shape, in metres above the terrain surface beneath it.
     pub top_above_terrain_m: Option<f64>,
+    /// Whether the height keeps a reported altitude because terrain was not available.
+    pub uses_reported_altitude_fallback: bool,
     /// Producer instance identity.
     pub producer_instance_id: u64,
     /// Snapshot revision.

--- a/crates/pilotage-presentation/src/policy.rs
+++ b/crates/pilotage-presentation/src/policy.rs
@@ -9,7 +9,9 @@ use crate::layer::{
     LayerPolicy, SourceObservation, TRAFFIC_LAYER_ID, WEATHER_ADVISORY_LAYER_ID,
     WEATHER_REPORT_LAYER_ID,
 };
-use crate::{DisplayBatch, PointChange, PointFeature, PointStyle, ShapeFeature, ShapeStyle};
+use crate::{
+    Coordinate, DisplayBatch, PointChange, PointFeature, PointStyle, ShapeFeature, ShapeStyle,
+};
 
 pub(crate) const TRAFFIC_ACTIVE_STYLE: &str = "traffic-active";
 pub(crate) const TRAFFIC_COASTING_STYLE: &str = "traffic-coasting";
@@ -83,6 +85,45 @@ impl PresentationAdapter {
 
     /// Apply one ordered Surveillance delta.
     pub fn apply_traffic_delta(&mut self, delta: &TrackDelta) -> Option<PointChange> {
+        let (key, snapshot_revision, change) = self.prepare_traffic_delta(delta)?;
+        self.commit_traffic_delta(key, snapshot_revision, delta, change.as_ref(), None);
+        change.filter(|_| self.layers.is_enabled(TRAFFIC_LAYER_ID))
+    }
+
+    /// Apply one ordered Surveillance delta and read terrain for a positioned upsert.
+    ///
+    /// # Errors
+    ///
+    /// Returns the terrain reader error without changing retained display state.
+    pub fn apply_traffic_delta_with_terrain_blocking<E>(
+        &mut self,
+        delta: &TrackDelta,
+        mut elevation_at: impl FnMut(Coordinate) -> Result<Option<f64>, E>,
+    ) -> Result<Option<PointChange>, E> {
+        let Some((key, snapshot_revision, change)) = self.prepare_traffic_delta(delta) else {
+            return Ok(None);
+        };
+        let terrain_elevation_m = match change.as_ref() {
+            Some(PointChange::Upsert { point }) if point.altitude_ft.is_some() => {
+                elevation_at(point.coordinate)?
+            }
+            Some(PointChange::Stale { .. } | PointChange::Remove { .. }) | None => None,
+            Some(PointChange::Upsert { .. }) => None,
+        };
+        self.commit_traffic_delta(
+            key,
+            snapshot_revision,
+            delta,
+            change.as_ref(),
+            terrain_elevation_m,
+        );
+        Ok(change.filter(|_| self.layers.is_enabled(TRAFFIC_LAYER_ID)))
+    }
+
+    fn prepare_traffic_delta(
+        &self,
+        delta: &TrackDelta,
+    ) -> Option<((u64, u64), u64, Option<PointChange>)> {
         let producer_instance_id = delta.producer_instance_id().get();
         let snapshot_revision = delta.snapshot_revision().get();
         let key = (producer_instance_id, delta.id().get());
@@ -93,23 +134,61 @@ impl PresentationAdapter {
         if !is_newer {
             return None;
         }
+        let change = surveillance_geojson::map_track_delta(delta).and_then(|source_change| {
+            crate::traffic::point_change(
+                &source_change,
+                producer_instance_id,
+                snapshot_revision,
+                self.traffic_points.get(&key),
+            )
+        });
+        Some((key, snapshot_revision, change))
+    }
+
+    fn commit_traffic_delta(
+        &mut self,
+        key: (u64, u64),
+        snapshot_revision: u64,
+        delta: &TrackDelta,
+        change: Option<&PointChange>,
+        terrain_elevation_m: Option<f64>,
+    ) {
         self.traffic_revisions.insert(key, snapshot_revision);
         self.retain_track(key, delta);
-        let source_change = surveillance_geojson::map_track_delta(delta)?;
-        let change = crate::traffic::point_change(
-            &source_change,
-            producer_instance_id,
-            snapshot_revision,
-            self.traffic_points.get(&key),
-        )?;
-        self.apply_point_change(key, &change);
-        self.layers.is_enabled(TRAFFIC_LAYER_ID).then_some(change)
+        if let Some(change) = change {
+            self.apply_point_change(key, change, terrain_elevation_m);
+        }
     }
 
     /// Apply one ordered Airmass feature change.
     pub fn apply_weather_delta(&mut self, delta: &WeatherFeatureDelta) -> Option<PointChange> {
+        self.apply_weather_delta_with_sample(delta, None)
+    }
+
+    /// Apply one Airmass feature change and read terrain for an advisory footprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns the terrain reader error without changing retained display state.
+    pub fn apply_weather_delta_with_terrain_blocking<E>(
+        &mut self,
+        delta: &WeatherFeatureDelta,
+        mut elevation_at: impl FnMut(Coordinate) -> Result<Option<f64>, E>,
+    ) -> Result<Option<PointChange>, E> {
+        let terrain_elevation_m = match crate::weather::terrain_coordinate(delta) {
+            Some(coordinate) => elevation_at(coordinate)?,
+            None => None,
+        };
+        Ok(self.apply_weather_delta_with_sample(delta, terrain_elevation_m))
+    }
+
+    fn apply_weather_delta_with_sample(
+        &mut self,
+        delta: &WeatherFeatureDelta,
+        terrain_elevation_m: Option<f64>,
+    ) -> Option<PointChange> {
         let id = crate::weather::feature_id_for_delta(delta)?;
-        self.apply_weather_shape(&id, delta);
+        self.apply_weather_shape(&id, delta, terrain_elevation_m);
         let change = crate::weather::point_change(delta, self.weather_points.get(&id))?;
         match &change {
             PointChange::Upsert { point } => {
@@ -182,10 +261,15 @@ impl PresentationAdapter {
         batch
     }
 
-    fn apply_weather_shape(&mut self, id: &str, delta: &WeatherFeatureDelta) {
+    fn apply_weather_shape(
+        &mut self,
+        id: &str,
+        delta: &WeatherFeatureDelta,
+        terrain_elevation_m: Option<f64>,
+    ) {
         match delta {
             WeatherFeatureDelta::Upsert(_) => {
-                if let Some(shape) = crate::weather::shape_change(delta) {
+                if let Some(shape) = crate::weather::shape_change(delta, terrain_elevation_m) {
                     self.weather_shapes.insert(id.to_owned(), shape);
                 }
             }
@@ -217,10 +301,15 @@ impl PresentationAdapter {
         }
     }
 
-    fn apply_point_change(&mut self, key: (u64, u64), change: &PointChange) {
+    fn apply_point_change(
+        &mut self,
+        key: (u64, u64),
+        change: &PointChange,
+        terrain_elevation_m: Option<f64>,
+    ) {
         match change {
             PointChange::Upsert { point } => {
-                match crate::traffic::altitude_pad(point) {
+                match crate::traffic::altitude_pad(point, terrain_elevation_m) {
                     Some(pad) => self.traffic_pads.insert(key, pad),
                     // A track that loses its altitude must lose its pad with it, or the
                     // display keeps a height the track no longer reports.

--- a/crates/pilotage-presentation/src/tests.rs
+++ b/crates/pilotage-presentation/src/tests.rs
@@ -3,4 +3,5 @@
 mod advisory;
 mod layer;
 mod traffic;
+mod vertical;
 mod weather;

--- a/crates/pilotage-presentation/src/tests/advisory.rs
+++ b/crates/pilotage-presentation/src/tests/advisory.rs
@@ -30,8 +30,9 @@ fn an_advisory_becomes_a_shape_with_its_type_and_band() {
     assert_eq!(shape.style_id, "advisory-convective");
     assert_eq!(
         shape.label.as_deref(),
-        Some("CONV SIGMET 2000 MSL-24000 MSL")
+        Some("CONV SIGMET 2000 MSL-24000 MSL\nREPORTED ALTITUDE")
     );
+    assert!(shape.uses_reported_altitude_fallback);
     assert_eq!(shape.rings.len(), 1);
     assert_eq!(shape.rings[0].coordinates.len(), 5);
     let style_ids: Vec<&str> = batch
@@ -92,7 +93,62 @@ fn a_band_states_each_limit_in_its_own_reference() {
     let batch = adapter.adapt();
 
     assert_eq!(batch.shapes.len(), 1);
-    assert_eq!(batch.shapes[0].label.as_deref(), Some("AIRMET SFC-FL240"));
+    assert_eq!(
+        batch.shapes[0].label.as_deref(),
+        Some("AIRMET SFC-FL240\nREPORTED ALTITUDE")
+    );
+}
+
+#[test]
+fn terrain_elevation_places_an_msl_advisory_above_the_surface() {
+    let mut adapter = PresentationAdapter::new();
+    for delta in advisory_deltas(WeatherAdvisoryType::Airmet) {
+        adapter
+            .apply_weather_delta_with_terrain_blocking(&delta, |_| {
+                Ok::<_, std::convert::Infallible>(Some(400.0))
+            })
+            .expect("terrain reader is infallible");
+    }
+
+    let batch = adapter.adapt();
+    let shape = &batch.shapes[0];
+    let base = shape
+        .base_above_terrain_m
+        .expect("an advisory states its floor");
+
+    assert!((base - (2_000.0 * 0.3048 - 400.0)).abs() < 1e-6);
+    assert!(!shape.uses_reported_altitude_fallback);
+    assert_eq!(shape.label.as_deref(), Some("AIRMET 2000 MSL-24000 MSL"));
+}
+
+#[test]
+fn an_agl_advisory_does_not_read_or_subtract_terrain() {
+    let band = AdvisoryAltitudeBand::new(
+        AdvisoryAltitude::new(2_000, AdvisoryAltitudeReference::AboveGroundLevel),
+        AdvisoryAltitude::new(3_000, AdvisoryAltitudeReference::AboveGroundLevel),
+    )
+    .expect("fixture band is ordered");
+    let mut adapter = PresentationAdapter::new();
+    let terrain_reads = Cell::new(0u32);
+    for delta in advisory_deltas_with_band(WeatherAdvisoryType::Airmet, band) {
+        adapter
+            .apply_weather_delta_with_terrain_blocking(&delta, |_| {
+                terrain_reads.set(terrain_reads.get().wrapping_add(1));
+                Ok::<_, std::convert::Infallible>(Some(400.0))
+            })
+            .expect("terrain reader is infallible");
+    }
+
+    let batch = adapter.adapt();
+    let shape = &batch.shapes[0];
+    let base = shape
+        .base_above_terrain_m
+        .expect("an advisory states its floor");
+
+    assert!((base - 2_000.0 * 0.3048).abs() < 1e-6);
+    assert_eq!(terrain_reads.get(), 0);
+    assert!(!shape.uses_reported_altitude_fallback);
+    assert_eq!(shape.label.as_deref(), Some("AIRMET 2000 AGL-3000 AGL"));
 }
 
 #[test]
@@ -147,9 +203,16 @@ fn advisory_layer_state(adapter: &PresentationAdapter) -> String {
 }
 
 fn advisory_deltas(advisory_type: WeatherAdvisoryType) -> Vec<FeatureDelta> {
+    advisory_deltas_with_band(advisory_type, band())
+}
+
+fn advisory_deltas_with_band(
+    advisory_type: WeatherAdvisoryType,
+    band: AdvisoryAltitudeBand,
+) -> Vec<FeatureDelta> {
     let mut store = weather_store();
     let current = store
-        .accept(advisory_ingress(advisory_type), time(100))
+        .accept(advisory_ingress_with_band(advisory_type, band), time(100))
         .expect("an advisory must be valid")
         .into_publication()
         .expect("an advisory must publish");
@@ -159,10 +222,6 @@ fn advisory_deltas(advisory_type: WeatherAdvisoryType) -> Vec<FeatureDelta> {
 fn weather_store() -> WeatherStore {
     WeatherStore::new(StoreConfig::default(), ProducerInstanceId::new(23))
         .expect("default weather store must be valid")
-}
-
-fn advisory_ingress(advisory_type: WeatherAdvisoryType) -> WeatherIngress {
-    advisory_ingress_with_band(advisory_type, band())
 }
 
 fn advisory_ingress_with_band(
@@ -267,3 +326,4 @@ const fn time(monotonic_micros: u64) -> EvaluationTime {
         MonotonicTime::from_micros(monotonic_micros),
     )
 }
+use std::cell::Cell;

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -354,6 +354,8 @@ fn a_track_with_an_altitude_draws_a_pad_at_that_height() {
     let top = pad.top_above_terrain_m.expect("a pad states its ceiling");
     assert!((base - 5_500.0 * 0.3048).abs() < 1e-6);
     assert!(top > base, "a pad must have thickness to be visible");
+    assert!(pad.uses_reported_altitude_fallback);
+    assert_eq!(pad.label.as_deref(), Some("REPORTED ALTITUDE"));
     assert_eq!(pad.rings.len(), 1);
     assert_eq!(pad.rings[0].coordinates.len(), 5);
     assert!(
@@ -366,6 +368,41 @@ fn a_track_with_an_altitude_draws_a_pad_at_that_height() {
 }
 
 #[test]
+fn terrain_elevation_places_a_traffic_pad_above_the_surface() {
+    let mut adapter = PresentationAdapter::new();
+    adapter
+        .apply_traffic_delta_with_terrain_blocking(&delta_with_altitude(42, 3, Some(5_500)), |_| {
+            Ok::<_, std::convert::Infallible>(Some(400.0))
+        })
+        .expect("terrain reader is infallible");
+
+    let batch = adapter.adapt();
+    let pad = &batch.shapes[0];
+    let base = pad.base_above_terrain_m.expect("a pad states its floor");
+
+    assert!((base - (5_500.0 * 0.3048 - 400.0)).abs() < 1e-6);
+    assert!(!pad.uses_reported_altitude_fallback);
+    assert_eq!(pad.label, None);
+}
+
+#[test]
+fn a_negative_terrain_height_keeps_the_traffic_pad() {
+    let mut adapter = PresentationAdapter::new();
+    adapter
+        .apply_traffic_delta_with_terrain_blocking(&delta_with_altitude(42, 3, Some(1_000)), |_| {
+            Ok::<_, std::convert::Infallible>(Some(400.0))
+        })
+        .expect("terrain reader is infallible");
+
+    let batch = adapter.adapt();
+    let base = batch.shapes[0]
+        .base_above_terrain_m
+        .expect("a pad states its floor");
+
+    assert!(base < 0.0);
+}
+
+#[test]
 fn a_track_without_an_altitude_stays_a_point() {
     // An invented height would claim knowledge the track never reported.
     let mut adapter = PresentationAdapter::new();
@@ -375,6 +412,18 @@ fn a_track_without_an_altitude_stays_a_point() {
 
     assert_eq!(batch.points.len(), 1);
     assert!(batch.shapes.is_empty());
+}
+
+#[test]
+fn a_track_without_an_altitude_does_not_read_terrain() {
+    let mut adapter = PresentationAdapter::new();
+    adapter
+        .apply_traffic_delta_with_terrain_blocking(&delta_with_altitude(42, 3, None), |_| {
+            Err::<Option<f64>, _>("terrain must not be read")
+        })
+        .expect("a point without a vertical shape does not need terrain");
+
+    assert_eq!(adapter.adapt().points.len(), 1);
 }
 
 #[test]

--- a/crates/pilotage-presentation/src/tests/vertical.rs
+++ b/crates/pilotage-presentation/src/tests/vertical.rs
@@ -1,0 +1,15 @@
+use crate::vertical::reported_height;
+
+#[test]
+fn reported_altitude_uses_terrain_sea_and_explicit_fallback() {
+    let over_ground = reported_height(1_000.0, Some(400.0));
+    let over_sea = reported_height(1_000.0, Some(0.0));
+    let missing = reported_height(1_000.0, None);
+
+    assert_eq!(over_ground.metres, 600.0);
+    assert!(!over_ground.uses_reported_altitude_fallback);
+    assert_eq!(over_sea.metres, 1_000.0);
+    assert!(!over_sea.uses_reported_altitude_fallback);
+    assert_eq!(missing.metres, 1_000.0);
+    assert!(missing.uses_reported_altitude_fallback);
+}

--- a/crates/pilotage-presentation/src/traffic.rs
+++ b/crates/pilotage-presentation/src/traffic.rs
@@ -30,19 +30,23 @@ const METRES_PER_DEGREE_LATITUDE: f64 = 111_320.0;
 /// display that answers "above me or below me". A track with no altitude produces no pad
 /// and keeps its symbol, because an invented height would claim knowledge the track has
 /// not reported.
-pub(crate) fn altitude_pad(point: &PointFeature) -> Option<ShapeFeature> {
-    let altitude_m = f64::from(point.altitude_ft?) * FEET_TO_METRES;
-    if altitude_m <= 0.0 {
-        return None;
-    }
+pub(crate) fn altitude_pad(
+    point: &PointFeature,
+    terrain_elevation_m: Option<f64>,
+) -> Option<ShapeFeature> {
+    let reported_altitude_m = f64::from(point.altitude_ft?) * FEET_TO_METRES;
+    let placement = crate::vertical::reported_height(reported_altitude_m, terrain_elevation_m);
+    let altitude_m = placement.metres;
+    let uses_reported_altitude_fallback = placement.uses_reported_altitude_fallback;
     Some(ShapeFeature {
         id: format!("{}-pad", point.id),
         layer_id: TRAFFIC_LAYER_ID.into(),
         rings: vec![pad_ring(point.coordinate)?],
         style_id: TRAFFIC_ALTITUDE_STYLE.into(),
-        label: None,
+        label: uses_reported_altitude_fallback.then(|| "REPORTED ALTITUDE".to_owned()),
         base_above_terrain_m: Some(altitude_m),
         top_above_terrain_m: Some(altitude_m + PAD_THICKNESS_M),
+        uses_reported_altitude_fallback,
         producer_instance_id: point.producer_instance_id,
         snapshot_revision: point.snapshot_revision,
     })

--- a/crates/pilotage-presentation/src/vertical.rs
+++ b/crates/pilotage-presentation/src/vertical.rs
@@ -1,0 +1,18 @@
+//! Shared vertical placement arithmetic.
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct TerrainHeight {
+    pub metres: f64,
+    pub uses_reported_altitude_fallback: bool,
+}
+
+pub(crate) fn reported_height(
+    reported_altitude_m: f64,
+    terrain_elevation_m: Option<f64>,
+) -> TerrainHeight {
+    let terrain_elevation_m = terrain_elevation_m.filter(|value| value.is_finite());
+    TerrainHeight {
+        metres: reported_altitude_m - terrain_elevation_m.unwrap_or(0.0),
+        uses_reported_altitude_fallback: terrain_elevation_m.is_none(),
+    }
+}

--- a/crates/pilotage-presentation/src/weather.rs
+++ b/crates/pilotage-presentation/src/weather.rs
@@ -24,11 +24,25 @@ pub(crate) fn feature_id_for_delta(delta: &FeatureDelta) -> Option<String> {
 ///
 /// A text report and an advisory arrive through the same delta stream, so a caller asks
 /// for both and takes whichever the feature carries.
-pub(crate) fn shape_change(delta: &FeatureDelta) -> Option<ShapeFeature> {
+pub(crate) fn shape_change(
+    delta: &FeatureDelta,
+    terrain_elevation_m: Option<f64>,
+) -> Option<ShapeFeature> {
     let FeatureDelta::Upsert(feature) = delta else {
         return None;
     };
-    advisory::shape_for_advisory(feature_id(feature.id()), feature.advisory_shape()?)
+    advisory::shape_for_advisory(
+        feature_id(feature.id()),
+        feature.advisory_shape()?,
+        terrain_elevation_m,
+    )
+}
+
+pub(crate) fn terrain_coordinate(delta: &FeatureDelta) -> Option<Coordinate> {
+    let FeatureDelta::Upsert(feature) = delta else {
+        return None;
+    };
+    advisory::terrain_coordinate(feature.advisory_shape()?)
 }
 
 pub(crate) fn point_change(

--- a/crates/pilotage-presentation/src/weather/advisory.rs
+++ b/crates/pilotage-presentation/src/weather/advisory.rs
@@ -25,21 +25,23 @@ const MINIMUM_VOLUME_THICKNESS_M: f64 = 150.0;
 pub(crate) fn shape_for_advisory(
     id: String,
     feature: &AdvisoryShapeFeature,
+    terrain_elevation_m: Option<f64>,
 ) -> Option<ShapeFeature> {
     let rings: Vec<CoordinateRing> = feature.rings().iter().filter_map(ring).collect();
     if rings.is_empty() {
         return None;
     }
     let advisory = feature.advisory();
-    let (base_above_terrain_m, top_above_terrain_m) = extrusion(advisory);
+    let extrusion = extrusion(advisory, terrain_elevation_m);
     Some(ShapeFeature {
         id,
         layer_id: WEATHER_ADVISORY_LAYER_ID.into(),
         rings,
         style_id: style_for(advisory_type(advisory)).into(),
-        label: label(advisory),
-        base_above_terrain_m,
-        top_above_terrain_m,
+        label: label(advisory, extrusion.uses_reported_altitude_fallback),
+        base_above_terrain_m: extrusion.base_m,
+        top_above_terrain_m: extrusion.top_m,
+        uses_reported_altitude_fallback: extrusion.uses_reported_altitude_fallback,
         producer_instance_id: feature.id().producer_instance_id().get(),
         snapshot_revision: feature.revisions().snapshot_revision().get(),
     })
@@ -49,22 +51,75 @@ pub(crate) fn shape_for_advisory(
 ///
 /// An advisory without a band stays flat. A volume drawn from an invented band would
 /// state an altitude range the advisory never gave.
-fn extrusion(advisory: &WeatherAdvisory) -> (Option<f64>, Option<f64>) {
+fn extrusion(advisory: &WeatherAdvisory, terrain_elevation_m: Option<f64>) -> Extrusion {
     let Some(band) = advisory
         .altitude_band()
         .as_present()
         .map(|field| field.value)
     else {
-        return (None, None);
+        return Extrusion::default();
     };
-    let base = f64::from(band.base().feet()) * FEET_TO_METRES;
-    let top = f64::from(band.top().feet()) * FEET_TO_METRES;
+    let terrain_elevation_m = terrain_elevation_m.filter(|value| value.is_finite());
+    let (base, base_fallback) = height_above_terrain(band.base(), terrain_elevation_m);
+    let (top, top_fallback) = height_above_terrain(band.top(), terrain_elevation_m);
     // A band whose limits are equal draws nothing, and a surface-to-surface advisory is
     // still an area a pilot must see.
     if top - base < MINIMUM_VOLUME_THICKNESS_M {
-        return (Some(base), Some(base + MINIMUM_VOLUME_THICKNESS_M));
+        return Extrusion {
+            base_m: Some(base),
+            top_m: Some(base + MINIMUM_VOLUME_THICKNESS_M),
+            uses_reported_altitude_fallback: base_fallback || top_fallback,
+        };
     }
-    (Some(base), Some(top))
+    Extrusion {
+        base_m: Some(base),
+        top_m: Some(top),
+        uses_reported_altitude_fallback: base_fallback || top_fallback,
+    }
+}
+
+#[derive(Default)]
+struct Extrusion {
+    base_m: Option<f64>,
+    top_m: Option<f64>,
+    uses_reported_altitude_fallback: bool,
+}
+
+fn height_above_terrain(
+    altitude: AdvisoryAltitude,
+    terrain_elevation_m: Option<f64>,
+) -> (f64, bool) {
+    let reported_m = f64::from(altitude.feet()) * FEET_TO_METRES;
+    match altitude.reference() {
+        AdvisoryAltitudeReference::Surface => (0.0, false),
+        AdvisoryAltitudeReference::AboveGroundLevel => (reported_m, false),
+        AdvisoryAltitudeReference::MeanSeaLevel | AdvisoryAltitudeReference::FlightLevel => {
+            let placement = crate::vertical::reported_height(reported_m, terrain_elevation_m);
+            (placement.metres, placement.uses_reported_altitude_fallback)
+        }
+        _ => (reported_m, true),
+    }
+}
+
+pub(crate) fn terrain_coordinate(feature: &AdvisoryShapeFeature) -> Option<Coordinate> {
+    let band = feature
+        .advisory()
+        .altitude_band()
+        .as_present()
+        .map(|field| field.value)?;
+    let needs_terrain = [band.base(), band.top()].into_iter().any(|altitude| {
+        matches!(
+            altitude.reference(),
+            AdvisoryAltitudeReference::MeanSeaLevel | AdvisoryAltitudeReference::FlightLevel
+        )
+    });
+    if !needs_terrain {
+        return None;
+    }
+    // One extrusion has one height for its full footprint. An exterior-ring position is
+    // inside the stated footprint boundary and gives a stable sample for every renderer.
+    let position = feature.rings().first()?.positions().first()?;
+    Coordinate::checked(position.latitude_deg(), position.longitude_deg())
 }
 
 fn ring(source: &AdvisoryShapeRing) -> Option<CoordinateRing> {
@@ -108,11 +163,16 @@ const fn style_for(advisory_type: Option<WeatherAdvisoryType>) -> &'static str {
 ///
 /// An outline alone cannot answer "does this affect my cruise altitude", so the band
 /// travels with the label until the renderer draws the volume.
-fn label(advisory: &WeatherAdvisory) -> Option<String> {
+fn label(advisory: &WeatherAdvisory, uses_reported_altitude_fallback: bool) -> Option<String> {
     let name = type_name(advisory_type(advisory)?);
-    Some(match band(advisory) {
+    let label = match band(advisory) {
         Some(band) => format!("{name} {band}"),
         None => name.to_owned(),
+    };
+    Some(if uses_reported_altitude_fallback {
+        format!("{label}\nREPORTED ALTITUDE")
+    } else {
+        label
     })
 }
 

--- a/crates/pilotage-terrain-query/Cargo.toml
+++ b/crates/pilotage-terrain-query/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pilotage-terrain-query"
+description = "Runtime elevation queries for Terrarium MBTiles archives"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+libm = { workspace = true }
+png = { workspace = true }
+rusqlite = { version = "0.40.2", default-features = false }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/crates/pilotage-terrain-query/src/archive.rs
+++ b/crates/pilotage-terrain-query/src/archive.rs
@@ -1,0 +1,221 @@
+//! Read-only MBTiles access and decoded-tile caching.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+
+use crate::TerrainQueryError;
+use crate::tile::{DecodedTile, TileAddress, WEB_MERCATOR_MAX_LAT_DEG, address_for_position};
+
+const TILE_CACHE_CAPACITY: usize = 16;
+
+/// A read-only Terrarium MBTiles archive.
+pub struct TerrainArchive {
+    path: PathBuf,
+    connection: Connection,
+    min_zoom: u8,
+    max_zoom: u8,
+    tile_size: u32,
+    cache: VecDeque<(TileAddress, DecodedTile)>,
+}
+
+impl TerrainArchive {
+    /// Open and validate one Terrarium MBTiles archive.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TerrainQueryError`] if SQLite cannot open the file or the
+    /// required metadata does not describe 8-bit RGB Terrarium PNG tiles.
+    pub fn open_blocking(path: impl AsRef<Path>) -> Result<Self, TerrainQueryError> {
+        let path = path.as_ref();
+        let archive_path = path.to_path_buf();
+        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|source| TerrainQueryError::ArchiveOpen {
+                path: archive_path.clone(),
+                source,
+            })?;
+        let encoding = metadata(&connection, &archive_path, "encoding")?;
+        validate_metadata(&archive_path, "encoding", &encoding, "terrarium")?;
+        let format = metadata(&connection, &archive_path, "format")?;
+        validate_metadata(&archive_path, "format", &format, "png")?;
+        let min_zoom = metadata_u8(&connection, &archive_path, "minzoom")?;
+        let max_zoom = metadata_u8(&connection, &archive_path, "maxzoom")?;
+        if min_zoom > max_zoom || max_zoom > 30 {
+            return Err(TerrainQueryError::UnsupportedMetadata {
+                path: archive_path,
+                name: "zoom range",
+                value: format!("{min_zoom}-{max_zoom}"),
+            });
+        }
+        let tile_size = metadata_u32(&connection, &archive_path, "tile_size")?;
+        if tile_size == 0 {
+            return Err(TerrainQueryError::UnsupportedMetadata {
+                path: archive_path,
+                name: "tile_size",
+                value: tile_size.to_string(),
+            });
+        }
+        Ok(Self {
+            path: archive_path,
+            connection,
+            min_zoom,
+            max_zoom,
+            tile_size,
+            cache: VecDeque::with_capacity(TILE_CACHE_CAPACITY),
+        })
+    }
+
+    /// Read elevation at one WGS84 position.
+    ///
+    /// The result is `None` when the position is outside Web Mercator or no
+    /// archive tile covers it. The reader tries less detailed zooms before it
+    /// reports no coverage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TerrainQueryError`] if the position is invalid, SQLite fails,
+    /// or a selected tile does not contain an 8-bit RGB PNG.
+    pub fn elevation_m_blocking(
+        &mut self,
+        latitude_deg: f64,
+        longitude_deg: f64,
+    ) -> Result<Option<f64>, TerrainQueryError> {
+        validate_position(latitude_deg, longitude_deg)?;
+        if !(-WEB_MERCATOR_MAX_LAT_DEG..=WEB_MERCATOR_MAX_LAT_DEG).contains(&latitude_deg) {
+            return Ok(None);
+        }
+        for zoom in (self.min_zoom..=self.max_zoom).rev() {
+            let (address, pixel) =
+                address_for_position(zoom, latitude_deg, longitude_deg, self.tile_size);
+            if let Some(elevation) = self.cached_elevation(address, pixel)? {
+                return Ok(Some(elevation));
+            }
+        }
+        Ok(None)
+    }
+
+    fn cached_elevation(
+        &mut self,
+        address: TileAddress,
+        pixel: crate::tile::PixelAddress,
+    ) -> Result<Option<f64>, TerrainQueryError> {
+        if let Some(index) = self.cache.iter().position(|(key, _)| *key == address) {
+            let Some(entry) = self.cache.remove(index) else {
+                return Ok(None);
+            };
+            let elevation = entry.1.elevation_m(pixel);
+            self.cache.push_front(entry);
+            return Ok(elevation);
+        }
+        let Some(bytes) = tile_bytes(&self.connection, &self.path, address)? else {
+            return Ok(None);
+        };
+        let tile = DecodedTile::decode(address, &bytes, self.tile_size, &self.path)?;
+        let elevation = tile.elevation_m(pixel);
+        self.cache.push_front((address, tile));
+        self.cache.truncate(TILE_CACHE_CAPACITY);
+        Ok(elevation)
+    }
+}
+
+fn tile_bytes(
+    connection: &Connection,
+    archive_path: &Path,
+    address: TileAddress,
+) -> Result<Option<Vec<u8>>, TerrainQueryError> {
+    let tms_row = (1u32 << u32::from(address.zoom)) - 1 - address.y;
+    connection
+        .query_row(
+            "SELECT tile_data FROM tiles
+             WHERE zoom_level = ?1 AND tile_column = ?2 AND tile_row = ?3",
+            params![address.zoom, address.x, tms_row],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|source| TerrainQueryError::ArchiveRead {
+            path: archive_path.to_path_buf(),
+            context: format!("tile {}/{}/{}", address.zoom, address.x, address.y),
+            source,
+        })
+}
+
+fn metadata(
+    connection: &Connection,
+    archive_path: &Path,
+    name: &'static str,
+) -> Result<String, TerrainQueryError> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE name = ?1",
+            [name],
+            |row| row.get(0),
+        )
+        .map_err(|source| TerrainQueryError::ArchiveRead {
+            path: archive_path.to_path_buf(),
+            context: format!("metadata {name}"),
+            source,
+        })
+}
+
+fn metadata_u8(
+    connection: &Connection,
+    archive_path: &Path,
+    name: &'static str,
+) -> Result<u8, TerrainQueryError> {
+    let value = metadata(connection, archive_path, name)?;
+    value
+        .parse()
+        .map_err(|_| TerrainQueryError::UnsupportedMetadata {
+            path: archive_path.to_path_buf(),
+            name,
+            value,
+        })
+}
+
+fn metadata_u32(
+    connection: &Connection,
+    archive_path: &Path,
+    name: &'static str,
+) -> Result<u32, TerrainQueryError> {
+    let value = metadata(connection, archive_path, name)?;
+    value
+        .parse()
+        .map_err(|_| TerrainQueryError::UnsupportedMetadata {
+            path: archive_path.to_path_buf(),
+            name,
+            value,
+        })
+}
+
+fn validate_metadata(
+    archive_path: &Path,
+    name: &'static str,
+    value: &str,
+    required: &str,
+) -> Result<(), TerrainQueryError> {
+    if value == required {
+        Ok(())
+    } else {
+        Err(TerrainQueryError::UnsupportedMetadata {
+            path: archive_path.to_path_buf(),
+            name,
+            value: value.to_owned(),
+        })
+    }
+}
+
+fn validate_position(latitude_deg: f64, longitude_deg: f64) -> Result<(), TerrainQueryError> {
+    let valid = latitude_deg.is_finite()
+        && longitude_deg.is_finite()
+        && (-90.0..=90.0).contains(&latitude_deg)
+        && (-180.0..=180.0).contains(&longitude_deg);
+    if valid {
+        Ok(())
+    } else {
+        Err(TerrainQueryError::InvalidPosition {
+            latitude_deg,
+            longitude_deg,
+        })
+    }
+}

--- a/crates/pilotage-terrain-query/src/error.rs
+++ b/crates/pilotage-terrain-query/src/error.rs
@@ -1,0 +1,87 @@
+//! Terrain query errors.
+
+use std::path::PathBuf;
+
+/// A Terrarium MBTiles query failed.
+#[derive(Debug, thiserror::Error)]
+pub enum TerrainQueryError {
+    /// SQLite could not open the archive.
+    #[error("terrain archive {path:?} could not be opened")]
+    ArchiveOpen {
+        /// Archive path.
+        path: PathBuf,
+        /// SQLite failure.
+        #[source]
+        source: rusqlite::Error,
+    },
+    /// SQLite could not read required archive data.
+    #[error("terrain archive {path:?} query failed for {context}")]
+    ArchiveRead {
+        /// Archive path.
+        path: PathBuf,
+        /// Data that the query tried to read.
+        context: String,
+        /// SQLite failure.
+        #[source]
+        source: rusqlite::Error,
+    },
+    /// The archive metadata is not valid for terrain queries.
+    #[error("terrain archive {path:?} metadata {name} has unsupported value {value}")]
+    UnsupportedMetadata {
+        /// Archive path.
+        path: PathBuf,
+        /// Metadata key.
+        name: &'static str,
+        /// Rejected value.
+        value: String,
+    },
+    /// The WGS84 position is not finite or is outside its valid range.
+    #[error("terrain position ({latitude_deg}, {longitude_deg}) is invalid")]
+    InvalidPosition {
+        /// Latitude in degrees.
+        latitude_deg: f64,
+        /// Longitude in degrees.
+        longitude_deg: f64,
+    },
+    /// A Terrarium tile could not be decoded.
+    #[error("terrain archive {path:?} tile {zoom}/{x}/{y} is not a valid PNG")]
+    TileDecode {
+        /// Archive path.
+        path: PathBuf,
+        /// Web Mercator zoom.
+        zoom: u8,
+        /// Web Mercator tile column.
+        x: u32,
+        /// Web Mercator XYZ tile row.
+        y: u32,
+        /// PNG failure.
+        #[source]
+        source: png::DecodingError,
+    },
+    /// A decoded tile does not use the required image layout.
+    #[error("terrain archive {path:?} tile {zoom}/{x}/{y} has unsupported image layout {layout}")]
+    UnsupportedTile {
+        /// Archive path.
+        path: PathBuf,
+        /// Web Mercator zoom.
+        zoom: u8,
+        /// Web Mercator tile column.
+        x: u32,
+        /// Web Mercator XYZ tile row.
+        y: u32,
+        /// Image layout detail.
+        layout: String,
+    },
+    /// The PNG decoder cannot allocate the required image buffer.
+    #[error("terrain archive {path:?} tile {zoom}/{x}/{y} is too large to decode")]
+    TileTooLarge {
+        /// Archive path.
+        path: PathBuf,
+        /// Web Mercator zoom.
+        zoom: u8,
+        /// Web Mercator tile column.
+        x: u32,
+        /// Web Mercator XYZ tile row.
+        y: u32,
+    },
+}

--- a/crates/pilotage-terrain-query/src/lib.rs
+++ b/crates/pilotage-terrain-query/src/lib.rs
@@ -1,0 +1,16 @@
+//! Reads terrain elevation from a Terrarium MBTiles archive.
+//!
+//! The reader selects the deepest tile that covers a WGS84 position. It uses
+//! a less detailed tile when a sparse archive has no tile at the first zoom.
+
+#![forbid(unsafe_code)]
+
+mod archive;
+mod error;
+mod tile;
+
+#[cfg(test)]
+mod tests;
+
+pub use archive::TerrainArchive;
+pub use error::TerrainQueryError;

--- a/crates/pilotage-terrain-query/src/tests.rs
+++ b/crates/pilotage-terrain-query/src/tests.rs
@@ -1,0 +1,135 @@
+//! Tests for runtime Terrarium archive queries.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use png::{BitDepth, ColorType, Encoder};
+use rusqlite::{Connection, params};
+use tempfile::NamedTempFile;
+
+use crate::{TerrainArchive, TerrainQueryError};
+
+#[test]
+fn deepest_covering_tile_supplies_elevation() {
+    let file = archive(&[(0, 0, 0, 100.0), (1, 1, 0, 400.0)]);
+    let mut terrain = TerrainArchive::open_blocking(file.path()).expect("open terrain archive");
+
+    let elevation = terrain
+        .elevation_m_blocking(-0.1, 0.1)
+        .expect("query terrain")
+        .expect("terrain coverage");
+
+    assert!((elevation - 400.0).abs() <= 1.0 / 256.0);
+}
+
+#[test]
+fn missing_deep_tile_uses_a_less_detailed_tile() {
+    let file = archive(&[(0, 0, 0, 1_000.0), (1, 0, 1, 200.0)]);
+    let mut terrain = TerrainArchive::open_blocking(file.path()).expect("open terrain archive");
+
+    let elevation = terrain
+        .elevation_m_blocking(-0.1, 0.1)
+        .expect("query terrain")
+        .expect("world tile coverage");
+
+    assert!((elevation - 1_000.0).abs() <= 1.0 / 256.0);
+}
+
+#[test]
+fn no_covering_tile_is_an_explicit_absence() {
+    let file = archive(&[(1, 0, 1, 200.0)]);
+    let mut terrain = TerrainArchive::open_blocking(file.path()).expect("open terrain archive");
+
+    let elevation = terrain
+        .elevation_m_blocking(-0.1, 0.1)
+        .expect("query terrain");
+
+    assert_eq!(elevation, None);
+}
+
+#[test]
+fn a_non_terrarium_archive_is_rejected() {
+    let file = archive(&[(0, 0, 0, 0.0)]);
+    let connection = Connection::open(file.path()).expect("open fixture archive");
+    connection
+        .execute(
+            "UPDATE metadata SET value = 'mapbox' WHERE name = 'encoding'",
+            [],
+        )
+        .expect("change fixture metadata");
+    drop(connection);
+
+    let error = TerrainArchive::open_blocking(file.path())
+        .err()
+        .expect("encoding must be checked");
+
+    assert!(matches!(
+        error,
+        TerrainQueryError::UnsupportedMetadata {
+            name: "encoding",
+            ..
+        }
+    ));
+}
+
+fn archive(tiles: &[(u8, u32, u32, f64)]) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("create fixture archive");
+    let connection = Connection::open(file.path()).expect("open fixture archive");
+    connection
+        .execute_batch(
+            "CREATE TABLE metadata (name TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE tiles (
+                 zoom_level INTEGER NOT NULL,
+                 tile_column INTEGER NOT NULL,
+                 tile_row INTEGER NOT NULL,
+                 tile_data BLOB NOT NULL,
+                 PRIMARY KEY (zoom_level, tile_column, tile_row)
+             );",
+        )
+        .expect("create fixture schema");
+    let max_zoom = tiles.iter().map(|tile| tile.0).max().unwrap_or(0);
+    for (name, value) in [
+        ("encoding", "terrarium".to_owned()),
+        ("format", "png".to_owned()),
+        ("minzoom", "0".to_owned()),
+        ("maxzoom", max_zoom.to_string()),
+        ("tile_size", "2".to_owned()),
+    ] {
+        connection
+            .execute(
+                "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
+                params![name, value],
+            )
+            .expect("insert fixture metadata");
+    }
+    for (zoom, x, tms_y, elevation_m) in tiles {
+        connection
+            .execute(
+                "INSERT INTO tiles (zoom_level, tile_column, tile_row, tile_data)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![zoom, x, tms_y, terrarium_png(*elevation_m)],
+            )
+            .expect("insert fixture tile");
+    }
+    drop(connection);
+    file
+}
+
+fn terrarium_png(elevation_m: f64) -> Vec<u8> {
+    let code = ((elevation_m + 32_768.0) * 256.0).round() as u32;
+    let pixel = [
+        ((code >> 16) & 0xff) as u8,
+        ((code >> 8) & 0xff) as u8,
+        (code & 0xff) as u8,
+    ];
+    let pixels = pixel.repeat(4);
+    let mut bytes = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, 2, 2);
+    encoder.set_color(ColorType::Rgb);
+    encoder.set_depth(BitDepth::Eight);
+    let mut writer = encoder.write_header().expect("write fixture PNG header");
+    writer
+        .write_image_data(&pixels)
+        .expect("write fixture PNG pixels");
+    writer.finish().expect("finish fixture PNG");
+    bytes
+}

--- a/crates/pilotage-terrain-query/src/tile.rs
+++ b/crates/pilotage-terrain-query/src/tile.rs
@@ -1,0 +1,134 @@
+//! Web Mercator addressing and Terrarium pixel decoding.
+
+use std::f64::consts::PI;
+use std::io::Cursor;
+use std::path::Path;
+
+use png::{BitDepth, ColorType, Decoder};
+
+use crate::TerrainQueryError;
+
+pub(crate) const WEB_MERCATOR_MAX_LAT_DEG: f64 = 85.051_128_779_806_6;
+const TERRARIUM_OFFSET_M: f64 = 32_768.0;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct TileAddress {
+    pub zoom: u8,
+    pub x: u32,
+    pub y: u32,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PixelAddress {
+    pub x: u32,
+    pub y: u32,
+}
+
+pub(crate) struct DecodedTile {
+    width: u32,
+    pixels: Vec<u8>,
+}
+
+impl DecodedTile {
+    pub(crate) fn decode(
+        address: TileAddress,
+        png_bytes: &[u8],
+        expected_size: u32,
+        archive_path: &Path,
+    ) -> Result<Self, TerrainQueryError> {
+        let decoder = Decoder::new(Cursor::new(png_bytes));
+        let mut reader = decoder
+            .read_info()
+            .map_err(|source| decode_error(archive_path, address, source))?;
+        let buffer_size = reader
+            .output_buffer_size()
+            .ok_or(TerrainQueryError::TileTooLarge {
+                path: archive_path.to_path_buf(),
+                zoom: address.zoom,
+                x: address.x,
+                y: address.y,
+            })?;
+        let mut pixels = vec![0; buffer_size];
+        let info = reader
+            .next_frame(&mut pixels)
+            .map_err(|source| decode_error(archive_path, address, source))?;
+        if info.width != expected_size
+            || info.height != expected_size
+            || info.color_type != ColorType::Rgb
+            || info.bit_depth != BitDepth::Eight
+        {
+            return Err(TerrainQueryError::UnsupportedTile {
+                path: archive_path.to_path_buf(),
+                zoom: address.zoom,
+                x: address.x,
+                y: address.y,
+                layout: format!(
+                    "{}x{} {:?} {:?}",
+                    info.width, info.height, info.color_type, info.bit_depth
+                ),
+            });
+        }
+        pixels.truncate(info.buffer_size());
+        Ok(Self {
+            width: info.width,
+            pixels,
+        })
+    }
+
+    pub(crate) fn elevation_m(&self, pixel: PixelAddress) -> Option<f64> {
+        let index = (u64::from(pixel.y) * u64::from(self.width) + u64::from(pixel.x)) * 3;
+        let index = usize::try_from(index).ok()?;
+        let channels = self.pixels.get(index..index.checked_add(3)?)?;
+        Some(
+            f64::from(channels[0]) * 256.0
+                + f64::from(channels[1])
+                + f64::from(channels[2]) / 256.0
+                - TERRARIUM_OFFSET_M,
+        )
+    }
+}
+
+pub(crate) fn address_for_position(
+    zoom: u8,
+    latitude_deg: f64,
+    longitude_deg: f64,
+    tile_size: u32,
+) -> (TileAddress, PixelAddress) {
+    let side = 1u32 << u32::from(zoom);
+    let world_x = ((longitude_deg + 180.0) / 360.0).clamp(0.0, 1.0);
+    let latitude_rad = latitude_deg.to_radians();
+    let world_y = (1.0 - libm::asinh(libm::tan(latitude_rad)) / PI) / 2.0;
+    let (x, pixel_x) = axis_address(world_x, side, tile_size);
+    let (y, pixel_y) = axis_address(world_y, side, tile_size);
+    (
+        TileAddress { zoom, x, y },
+        PixelAddress {
+            x: pixel_x,
+            y: pixel_y,
+        },
+    )
+}
+
+fn axis_address(world: f64, side: u32, tile_size: u32) -> (u32, u32) {
+    let scaled = world.clamp(0.0, 1.0) * f64::from(side);
+    let tile = scaled.floor().clamp(0.0, f64::from(side - 1)) as u32;
+    let fraction = (scaled - f64::from(tile)).clamp(0.0, 1.0);
+    let pixel = (fraction * f64::from(tile_size))
+        .floor()
+        .clamp(0.0, f64::from(tile_size - 1)) as u32;
+    (tile, pixel)
+}
+
+fn decode_error(
+    archive_path: &Path,
+    address: TileAddress,
+    source: png::DecodingError,
+) -> TerrainQueryError {
+    TerrainQueryError::TileDecode {
+        path: archive_path.to_path_buf(),
+        zoom: address.zoom,
+        x: address.x,
+        y: address.y,
+        source,
+    }
+}

--- a/scripts/check-apple-situation-client.sh
+++ b/scripts/check-apple-situation-client.sh
@@ -6,9 +6,12 @@ root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 client="$root/clients/apple-situation"
 driver_entitlements="$client/Configuration/AeroLinkDriverDevelopment.entitlements"
 maplibre_manifest="$client/Packages/PilotageMapLibreBinding/Package.swift"
+core_manifest="$client/Packages/PilotageSituationCore/Package.swift"
 terrain_manifest="$client/Packages/PilotageMapLibreTerrain/Package.swift"
 terrain_revision_file="$client/MAPLIBRE_TERRAIN_REVISION"
 terrain_build="$client/scripts/build-maplibre-terrain.sh"
+geojson_edge="$client/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift"
+map_overlay="$client/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift"
 status=0
 
 require_pattern() {
@@ -54,6 +57,8 @@ require_pattern 'exact: "6\.28\.0"' \
 require_pattern 'maplibre/maplibre-gl-native-distribution' \
     "$maplibre_manifest" \
     "the binding must use the official MapLibre Native distribution"
+require_fixed '.linkedLibrary("sqlite3")' "$core_manifest" \
+    "the situation core package must link the terrain archive database library"
 require_pattern 'PILOTAGE_MAPLIBRE_TERRAIN' "$maplibre_manifest" \
     "the terrain renderer must require its explicit build flag"
 require_pattern 'if terrainRendererEnabled' "$maplibre_manifest" \
@@ -173,6 +178,16 @@ require_pattern 'session[.]acceptTrackRecord' "$client/App/AeroLinkRadioState.sw
     "typed traffic records must enter the presentation session"
 require_pattern 'session[.]acceptWeatherRecord' "$client/App/AeroLinkRadioState.swift" \
     "typed weather records must enter the presentation session"
+require_pattern 'session[.]loadTerrainArchiveBlocking' "$model" \
+    "the application must open terrain before it presents vertical features"
+require_pattern 'pilotage_terrain_query::TerrainArchive' "$ffi/src/session.rs" \
+    "the FFI host must use the shared terrain archive reader"
+require_fixed 'properties["uses_reported_altitude_fallback"]' "$geojson_edge" \
+    "a terrain fallback must cross the display edge"
+require_fixed 'NSPredicate(format: "below_terrain == NO")' "$map_overlay" \
+    "the extrusion layer must reject negative heights"
+require_fixed 'NSPredicate(format: "below_terrain == YES")' "$map_overlay" \
+    "a flat fill must draw a negative height"
 require_pattern 'split[(]whereSeparator: .[.]isNewline[)]' "$runtime" \
     "the host must split nonempty serialized event lines"
 require_pattern 'guard batch[.]transferConsumed else' "$runtime" \

--- a/scripts/check-situation-presentation-boundary.sh
+++ b/scripts/check-situation-presentation-boundary.sh
@@ -14,6 +14,11 @@ if grep -RInE 'MapLibre|MLN[A-Z]|GeoJSON|UIKit|SwiftUI' "$rust_root"; then
     status=1
 fi
 
+if grep -RInE 'pilotage[_-]terrain[_-]query|rusqlite|png::Decoder' "$rust_root/src"; then
+    echo "FORBIDDEN: the portable presentation adapter reads a terrain archive" >&2
+    status=1
+fi
+
 if [ -f "$traffic_source" ] && grep -nE 'surveillance[_-]core' "$traffic_source"; then
     echo "FORBIDDEN: traffic display policy bypasses the typed feature adapter" >&2
     status=1

--- a/scripts/test-check-apple-situation-client.sh
+++ b/scripts/test-check-apple-situation-client.sh
@@ -11,6 +11,9 @@ mkdir -p \
     "$client_fixture/App" \
     "$client_fixture/Configuration" \
     "$client_fixture/Packages/PilotageMapLibreBinding" \
+    "$client_fixture/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding" \
+    "$client_fixture/Packages/PilotageSituationCore" \
+    "$client_fixture/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge" \
     "$client_fixture/Packages/PilotageMapLibreTerrain" \
     "$client_fixture/rust/pilotage-situation-ffi/src/reception" \
     "$client_fixture/scripts" \
@@ -33,6 +36,12 @@ cp "$root/clients/apple-situation/Configuration/AeroLinkDriverDevelopment.entitl
     "$client_fixture/Configuration/"
 cp "$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Package.swift" \
     "$client_fixture/Packages/PilotageMapLibreBinding/"
+cp "$root/clients/apple-situation/Packages/PilotageSituationCore/Package.swift" \
+    "$client_fixture/Packages/PilotageSituationCore/"
+cp "$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift" \
+    "$client_fixture/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"
+cp "$root/clients/apple-situation/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift" \
+    "$client_fixture/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/"
 cp "$root/clients/apple-situation/Packages/PilotageMapLibreTerrain/Package.swift" \
     "$client_fixture/Packages/PilotageMapLibreTerrain/"
 cp "$root/clients/apple-situation/scripts/build-maplibre-terrain.sh" "$client_fixture/scripts/"
@@ -49,6 +58,15 @@ cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/reception/traf
 cp "$root/scripts/check-apple-situation-client.sh" "$fixture/scripts/"
 
 bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null
+
+sed -i.bak 's/linkedLibrary("sqlite3")/linkedLibrary("removed-sqlite3")/' \
+    "$fixture/clients/apple-situation/Packages/PilotageSituationCore/Package.swift"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted a missing SQLite link" >&2
+    exit 1
+fi
+sed -i.bak 's/linkedLibrary("removed-sqlite3")/linkedLibrary("sqlite3")/' \
+    "$fixture/clients/apple-situation/Packages/PilotageSituationCore/Package.swift"
 
 sed -i.bak 's/exact: "6\.28\.0"/exact: "6.27.0"/' \
     "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Package.swift"
@@ -178,6 +196,24 @@ fi
 sed -i.bak '/let handle = connection[.]handle/i\
         guard result.hasConsumedTransfer else { return }' \
     "$fixture/clients/apple-situation/App/AeroLinkRadioState.swift"
+
+sed -i.bak 's/loadTerrainArchiveBlocking/loadTerrainArchiveRemoved/' \
+    "$fixture/clients/apple-situation/App/SituationClientModel.swift"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted missing terrain archive loading" >&2
+    exit 1
+fi
+sed -i.bak 's/loadTerrainArchiveRemoved/loadTerrainArchiveBlocking/' \
+    "$fixture/clients/apple-situation/App/SituationClientModel.swift"
+
+sed -i.bak 's/below_terrain == YES/below_terrain removed/' \
+    "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted a missing negative-height fill" >&2
+    exit 1
+fi
+sed -i.bak 's/below_terrain removed/below_terrain == YES/' \
+    "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift"
 printf '\nlet decoder = JSONDecoder()\n' \
     >> "$fixture/clients/apple-situation/App/AeroLinkRadioRuntime.swift"
 if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then

--- a/scripts/test-check-situation-presentation-boundary.sh
+++ b/scripts/test-check-situation-presentation-boundary.sh
@@ -23,6 +23,13 @@ if bash "$repo_root/scripts/check-situation-presentation-boundary.sh" "$fixture"
 fi
 rm "$rust_root/backend.rs"
 
+printf '%s\n' 'use rusqlite::Connection;' > "$rust_root/terrain_archive.rs"
+if bash "$repo_root/scripts/check-situation-presentation-boundary.sh" "$fixture" >/dev/null 2>&1; then
+    echo "test failed: terrain archive input entered the portable adapter" >&2
+    exit 1
+fi
+rm "$rust_root/terrain_archive.rs"
+
 printf '%s\n' 'use surveillance_core::TrackSnapshot;' >> "$rust_root/traffic.rs"
 if bash "$repo_root/scripts/check-situation-presentation-boundary.sh" "$fixture" >/dev/null 2>&1; then
     echo "test failed: traffic policy bypassed the typed feature adapter" >&2


### PR DESCRIPTION
## Summary

- Read elevation from the existing Terrarium MBTiles archive at run time.
- Convert traffic and MSL weather heights to height above terrain.
- Keep the reported altitude and mark the fallback when terrain is not available.
- Load terrain for live and replay Apple sessions.
- Draw negative heights with a flat MapLibre fill.
- Guard the portable presentation boundary and the Apple runtime link.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --exclude pilotage-session-host --locked`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps --locked`
- `cargo build --workspace --release --locked`
- `sh clients/apple-situation/scripts/ci-ios.sh`
- Presentation and Apple guard checks and mutation tests
- Structure and diff checks

## Local test note

The full workspace test reached one timeout in `pilotage-session-host`: `three_source_slow_client_converges_without_losing_telemetry`. The isolated test had the same timeout. This branch does not change that crate or its dependencies. The same main commit passes GitHub CI. All other workspace tests pass locally.

Closes #387