### PR TITLE
Build every archive the style needs, not only the first one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,11 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      # The coastline archive is built from Natural Earth shapefiles, and project
+      # generation builds it, so the job needs the converter that reads them.
+      - name: Install GDAL
+        run: brew install gdal
+
       - name: Test the Apple situation client
         env:
           AERO_LINK_SOURCE: ${{ github.workspace }}/external/aero-link

--- a/clients/apple-situation/scripts/generate-project.sh
+++ b/clients/apple-situation/scripts/generate-project.sh
@@ -6,10 +6,12 @@ client_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 : "${AERO_LINK_HOST_BUNDLE_IDENTIFIER:=org.luofang.pilotage.situation}"
 : "${AERO_LINK_DRIVER_BUNDLE_IDENTIFIER:=${AERO_LINK_HOST_BUNDLE_IDENTIFIER}.aerolink-driver}"
 
-# The terrain archive is a build artifact rather than a repository file, so a fresh
-# checkout has no base map until this runs. It exits at once when the archive already
-# matches its manifest.
+# The base map is built from artifacts rather than repository files, so a fresh checkout
+# has no map until these run. The style requires both archives and refuses to resolve
+# without either, so a missing one is a blank screen and not a degraded map. Each exits at
+# once when its archive already matches its manifest.
 sh "$client_root/scripts/build-situation-terrain.sh"
+sh "$client_root/scripts/build-situation-coastline.sh"
 
 case "${PILOTAGE_MAPLIBRE_TERRAIN:-0}" in
     0) PILOTAGE_MAPLIBRE_SWIFT_CONDITIONS='' ;;

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -337,6 +337,17 @@ if [ -f "$coastline_archive" ]; then
     fi
 fi
 
+# Both archives are build artifacts the style refuses to resolve without. A generator that
+# builds one and not the other leaves a fresh checkout with a blank screen rather than a
+# map, and the failure appears only on a machine that has never built before.
+generator="$client/scripts/generate-project.sh"
+for builder in build-situation-terrain.sh build-situation-coastline.sh; do
+    if ! grep -Fq "$builder" "$generator"; then
+        echo "FORBIDDEN: project generation must build $builder" >&2
+        status=1
+    fi
+done
+
 if [ "$status" -ne 0 ]; then
     echo "Terrain base layer: FAILED" >&2
     exit 1

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -34,6 +34,7 @@ cp "$root/clients/apple-situation/Resources/SituationStyle.json" \
     "$root/clients/apple-situation/Resources/SituationTerrain.provenance.md" \
     "$fixture/clients/apple-situation/Resources/"
 cp "$root/clients/apple-situation/scripts/build-situation-terrain.sh" \
+    "$root/clients/apple-situation/scripts/generate-project.sh" \
     "$fixture/clients/apple-situation/scripts/"
 cp "$root/clients/apple-situation/scripts/build-situation-coastline.sh" \
     "$fixture/clients/apple-situation/scripts/"
@@ -211,6 +212,17 @@ if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
 fi
 cp "$root/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift" \
     "$fixture/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"
+
+# An archive the style requires but nothing builds is a blank screen on a fresh checkout.
+sed -i.bak '/build-situation-coastline.sh/d' \
+    "$fixture/clients/apple-situation/scripts/generate-project.sh"
+if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the terrain guard accepted a generator that skips an archive the style needs" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/scripts/generate-project.sh" \
+    "$fixture/clients/apple-situation/scripts/"
 
 printf '\nbuild_package(source);\n' >> "$fixture/crates/pilotage-terrain-build/src/lib.rs"
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \


### PR DESCRIPTION
The style names two sources now, elevation and coastline, and it refuses to resolve when
either archive is missing. Project generation built only the elevation archive, so a
checkout that had never built the coastline one got no map at all: the resolver threw, the
client fell back to a plain background, and nothing said why.

The failure was invisible on any machine that had already built the coastline archive by
hand, which is every machine the change was written on.

Generation now builds both. Each script still exits at once when its archive matches its
manifest, so the second one costs nothing on a warm tree.

The check gained the rule, because the next archive will arrive the same way: a source the
style requires and a generator that does not know about it. Its self-test removes the
coastline builder from the generator and expects a refusal.

Verified by moving the coastline archive aside, running generation, and watching it pack
17,171 tiles back.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>