### PR TITLE
Remove production expect exemptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Production Rust lint guard self-test
+        run: sh scripts/test-check-production-rust-lints.sh
+
+      - name: Production Rust lint guard
+        run: sh scripts/check-production-rust-lints.sh
+
       - name: cargo test
         run: cargo test --all-targets
 

--- a/crates/pilotage-protocol/src/convert.rs
+++ b/crates/pilotage-protocol/src/convert.rs
@@ -395,12 +395,7 @@ pub fn decode_action_command_envelope(
 /// (ADR-0014).
 #[must_use]
 pub fn encode_envelope_length_delimited(envelope: &wire::Envelope) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(envelope.encoded_len() + 10);
-    #[allow(clippy::expect_used)]
-    envelope
-        .encode_length_delimited(&mut buf)
-        .expect("encoding into a growable Vec<u8> cannot fail");
-    buf
+    envelope.encode_length_delimited_to_vec()
 }
 
 /// Decodes exactly one length-delimited [`wire::Envelope`] from the front of

--- a/scripts/check-production-rust-lints.sh
+++ b/scripts/check-production-rust-lints.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Reject panic-capable Rust operations and unsafe code in production targets.
+set -eu
+
+repo_root=${1:-"$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"}
+
+cd "$repo_root"
+cargo clippy --workspace --lib --bins --examples -- \
+    -D warnings \
+    -F unsafe_code \
+    -F clippy::unwrap_used \
+    -F clippy::expect_used \
+    -F clippy::panic

--- a/scripts/test-check-production-rust-lints.sh
+++ b/scripts/test-check-production-rust-lints.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Prove that the production Rust lint guard rejects a local lint exemption.
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+guard="$repo_root/scripts/check-production-rust-lints.sh"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/src"
+
+cat > "$fixture/Cargo.toml" <<'EOF'
+[package]
+name = "production-lint-fixture"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+EOF
+
+cat > "$fixture/src/lib.rs" <<'EOF'
+pub fn first(values: &[u8]) -> Option<u8> {
+    values.first().copied()
+}
+EOF
+
+if ! sh "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "the production Rust lint guard rejected valid code" >&2
+    exit 1
+fi
+
+cat > "$fixture/src/lib.rs" <<'EOF'
+#[allow(clippy::expect_used)]
+pub fn first(values: &[u8]) -> u8 {
+    *values.first().expect("a value")
+}
+EOF
+
+if output=$(sh "$guard" "$fixture" 2>&1); then
+    echo "the production Rust lint guard accepted an expect exemption" >&2
+    exit 1
+fi
+case "$output" in
+    *expect_used*) ;;
+    *)
+        echo "the production Rust lint guard failed for an unrelated reason" >&2
+        echo "$output" >&2
+        exit 1
+        ;;
+esac
+
+echo "production Rust lint guard self-test: OK"

--- a/tools/loopback-probe/src/metrics.rs
+++ b/tools/loopback-probe/src/metrics.rs
@@ -69,8 +69,7 @@ impl Histogram {
         sorted.sort_unstable();
         let p50 = percentile(&sorted, 50);
         let p95 = percentile(&sorted, 95);
-        #[allow(clippy::expect_used)]
-        let max = *sorted.last().expect("checked non-empty above");
+        let max = sorted.last().copied()?;
         Some((p50, p95, max))
     }
 }


### PR DESCRIPTION
Remove the two production expect exemptions without changing behavior. Use the infallible Prost Vec encoder. Propagate an absent histogram maximum through Option. Add a production-only Clippy guard and a negative fixture that proves a local exemption fails.

Checks:
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- production Rust lint guard and self-test
- cargo test --all-targets
- cargo doc with missing-doc and link checks
- cargo build --release
- first-party structure check

The direct structure command still scans ignored AeroLink sources. Issue #402 tracks that separate fault.

Closes #400