### PR TITLE
Enforce wrapping counter arithmetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,12 @@ jobs:
       - name: Production Rust lint guard
         run: sh scripts/check-production-rust-lints.sh
 
+      - name: Monotonic counter arithmetic guard self-test
+        run: bash scripts/test-check-monotonic-counter-arithmetic.sh
+
+      - name: Monotonic counter arithmetic guard
+        run: bash scripts/check-monotonic-counter-arithmetic.sh
+
       - name: cargo test
         run: cargo test --all-targets
 

--- a/clients/apple-situation/rust/pilotage-situation-ffi/examples/replay_capture.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/examples/replay_capture.rs
@@ -137,26 +137,44 @@ fn replay(
         if line.trim().is_empty() {
             continue;
         }
-        run.tally.lines += 1;
-        utc_millis += 100;
-        monotonic_micros += 100_000;
+        run.tally.lines = run.tally.lines.wrapping_add(1);
+        utc_millis = utc_millis.wrapping_add(100);
+        monotonic_micros = monotonic_micros.wrapping_add(100_000);
 
         let batch = match radio.accept_reception_event(line, 1, utc_millis, monotonic_micros) {
             Ok(batch) => batch,
             Err(error) => {
-                run.tally.rejected += 1;
+                run.tally.rejected = run.tally.rejected.wrapping_add(1);
                 if run.first_rejection.is_none() {
                     run.first_rejection = Some(describe(&error));
                 }
                 continue;
             }
         };
-        run.tally.events_consumed += batch.events_consumed;
-        run.tally.traffic_observations += batch.traffic_observations;
-        run.tally.traffic_refusals += batch.traffic_refusals;
-        run.tally.weather_products += batch.weather_products;
-        run.tally.track_records += batch.track_records.len() as u64;
-        run.tally.weather_records += batch.weather_records.len() as u64;
+        run.tally.events_consumed = run
+            .tally
+            .events_consumed
+            .wrapping_add(batch.events_consumed);
+        run.tally.traffic_observations = run
+            .tally
+            .traffic_observations
+            .wrapping_add(batch.traffic_observations);
+        run.tally.traffic_refusals = run
+            .tally
+            .traffic_refusals
+            .wrapping_add(batch.traffic_refusals);
+        run.tally.weather_products = run
+            .tally
+            .weather_products
+            .wrapping_add(batch.weather_products);
+        run.tally.track_records = run
+            .tally
+            .track_records
+            .wrapping_add(batch.track_records.len() as u64);
+        run.tally.weather_records = run
+            .tally
+            .weather_records
+            .wrapping_add(batch.weather_records.len() as u64);
 
         for record in batch.track_records {
             run.display = Some(presentation.accept_track_record(record, monotonic_micros)?);
@@ -165,7 +183,7 @@ fn replay(
             // An advisory is what becomes a map shape, so counting the records that carry
             // one separates "the radio heard no advisory" from "the shape path dropped it".
             if record.contains("\"advisories\"") {
-                run.tally.advisory_records += 1;
+                run.tally.advisory_records = run.tally.advisory_records.wrapping_add(1);
             }
             count_products(&record, &mut run.products);
             if synthesize {
@@ -223,7 +241,8 @@ fn report(path: &Path, run: &Run) -> Result<(), Box<dyn std::error::Error>> {
             writeln!(out, "map points         {}", batch.points.len())?;
             let mut by_layer: std::collections::BTreeMap<&str, usize> = Default::default();
             for point in &batch.points {
-                *by_layer.entry(point.layer_id.as_str()).or_default() += 1;
+                let count = by_layer.entry(point.layer_id.as_str()).or_default();
+                *count = count.wrapping_add(1);
             }
             for (layer, count) in by_layer {
                 writeln!(out, "  layer {layer:<22} {count}")?;
@@ -256,7 +275,8 @@ fn count_products(record: &str, out: &mut std::collections::BTreeMap<String, u64
     let mut identities = std::collections::BTreeSet::new();
     collect_product_ids(&value, &mut identities);
     for identity in identities {
-        *out.entry(identity).or_default() += 1;
+        let count = out.entry(identity).or_default();
+        *count = count.wrapping_add(1);
     }
 }
 

--- a/crates/pilotage-svs-build/src/verify.rs
+++ b/crates/pilotage-svs-build/src/verify.rs
@@ -270,8 +270,8 @@ fn decode_terrain_tile(
     let (min_lat, min_lon, spacing) = grid;
     let posts =
         decode_terrain(&tile.bytes).ok_or(VerifyError::PayloadDecode { reason: "terrain" })?;
-    state.counts.terrain_tiles += 1;
-    state.counts.terrain_posts += posts.len() as u32;
+    state.counts.terrain_tiles = state.counts.terrain_tiles.wrapping_add(1);
+    state.counts.terrain_posts = state.counts.terrain_posts.wrapping_add(posts.len() as u32);
     for post in &posts {
         let lat = min_lat + f64::from(post.i) * spacing;
         let lon = min_lon + f64::from(post.j) * spacing;
@@ -302,8 +302,8 @@ fn decode_obstacle_tile(
     let obstacles = decode_obstacles(&tile.bytes).ok_or(VerifyError::PayloadDecode {
         reason: "obstacles",
     })?;
-    state.counts.obstacle_tiles += 1;
-    state.counts.obstacles += obstacles.len() as u32;
+    state.counts.obstacle_tiles = state.counts.obstacle_tiles.wrapping_add(1);
+    state.counts.obstacles = state.counts.obstacles.wrapping_add(obstacles.len() as u32);
     for obstacle in &obstacles {
         state.seam_ok &= lands_in(li, lo, ctx, obstacle.lat_deg, obstacle.lon_deg);
         state.identities.push((
@@ -331,7 +331,7 @@ fn decode_aerodrome_tile(
     let aerodromes = decode_aerodromes(&tile.bytes).ok_or(VerifyError::PayloadDecode {
         reason: "aerodromes",
     })?;
-    state.counts.aerodrome_tiles += 1;
+    state.counts.aerodrome_tiles = state.counts.aerodrome_tiles.wrapping_add(1);
     for aerodrome in &aerodromes {
         state.seam_ok &= lands_in(li, lo, ctx, aerodrome.lat_deg, aerodrome.lon_deg);
         state.identities.push((
@@ -356,7 +356,7 @@ fn decode_runway_tile(
 ) -> Result<(), VerifyError> {
     let runways =
         decode_runways(&tile.bytes).ok_or(VerifyError::PayloadDecode { reason: "runways" })?;
-    state.counts.runway_tiles += 1;
+    state.counts.runway_tiles = state.counts.runway_tiles.wrapping_add(1);
     for runway in &runways {
         state.seam_ok &= lands_in(li, lo, ctx, runway.end_a_lat_deg, runway.end_a_lon_deg);
         state.identities.push((

--- a/scripts/check-monotonic-counter-arithmetic.sh
+++ b/scripts/check-monotonic-counter-arithmetic.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# The allowlist makes each production compound addition an explicit review item.
+# This prevents a monotonic counter from using debug-panicking arithmetic.
+set -euo pipefail
+
+root_dir="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+allowlist="${2:-$root_dir/scripts/monotonic-counter-compound-addition-allowlist.tsv}"
+actual=$(mktemp)
+trap 'rm -f "$actual"' EXIT
+
+collect_rs_files() {
+    git -C "$root_dir" ls-files --cached --others --exclude-standard -- '*.rs'
+}
+
+collect_compound_additions() {
+    local file
+    while IFS= read -r file; do
+        case "$file" in
+            */generated/*|*/tests/*|*/tests.rs|*/test.rs|*/*_tests.rs) continue ;;
+        esac
+        awk -v path="$file" '
+            index($0, "+=") {
+                line = $0
+                sub(/^[[:space:]]*/, "", line)
+                if (line !~ /^\/\//) {
+                    print path "\t" line
+                }
+            }
+        ' "$root_dir/$file"
+    done < <(collect_rs_files)
+}
+
+collect_compound_additions | LC_ALL=C sort > "$actual"
+if ! diff -u "$allowlist" "$actual"; then
+    echo "FORBIDDEN: production compound addition differs from the reviewed allowlist" >&2
+    echo "Use wrapping_add for a monotonic counter." >&2
+    exit 1
+fi
+
+echo "monotonic counter arithmetic: OK"

--- a/scripts/monotonic-counter-compound-addition-allowlist.tsv
+++ b/scripts/monotonic-counter-compound-addition-allowlist.tsv
@@ -1,0 +1,22 @@
+adapters/aviate/src/uplink.rs	*at += dt;
+adapters/aviate/src/uplink.rs	*v += (t - *v).clamp(-dv_max, dv_max);
+adapters/aviate/src/uplink.rs	r += 2.0 * core::f32::consts::PI;
+adapters/px4/src/gimbal.rs	*at += by;
+adapters/px4/src/uplink.rs	*at += by;
+adapters/px4/src/uplink.rs	wrapped += 2.0 * core::f32::consts::PI;
+crates/pilotage-camera-calibration/src/calibration/recovery.rs	sum_sq += err * err;
+crates/pilotage-geo/src/abi/codec.rs	self.off += b.len();
+crates/pilotage-input/src/button_tracker.rs	ButtonEdge::Pressed => presses += 1,
+crates/pilotage-input/src/button_tracker.rs	ButtonEdge::Released => releases += 1,
+crates/pilotage-navdata-tiles/src/mvt.rs	area += i64::from(points[index].0) * i64::from(points[next].1)
+crates/pilotage-navdata-tiles/src/tile.rs	area += i64::from(unique[index].0) * i64::from(unique[next].1)
+crates/pilotage-protocol/src/h264.rs	self.at += 1;
+crates/pilotage-svs-build/src/chain/terrain/prepare.rs	c += 1;
+crates/pilotage-svs-build/src/chain/terrain/prepare.rs	end += 1;
+crates/pilotage-svs-build/src/payload/decode.rs	off += 16;
+crates/pilotage-svs-build/src/payload/decode.rs	off += 25;
+crates/pilotage-svs-build/src/payload/decode.rs	off += 28;
+crates/pilotage-svs-build/src/payload/decode.rs	off += 34;
+crates/pilotage-svs-db/src/feature.rs	i += 1;
+crates/pilotage-svs-db/src/merkle.rs	i += 2;
+crates/pilotage-timing/src/latency.rs	self.len += 1;

--- a/scripts/test-check-monotonic-counter-arithmetic.sh
+++ b/scripts/test-check-monotonic-counter-arithmetic.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/scripts" "$fixture/src"
+cp "$root_dir/scripts/check-monotonic-counter-arithmetic.sh" "$fixture/scripts/"
+git -C "$fixture" init -q
+
+printf '%s\n' \
+    'pub fn advance(mut index: usize) -> usize {' \
+    '    index += 1;' \
+    '    index' \
+    '}' \
+    > "$fixture/src/lib.rs"
+printf '%s\t%s\n' \
+    'src/lib.rs' \
+    'index += 1;' \
+    > "$fixture/scripts/monotonic-counter-compound-addition-allowlist.tsv"
+
+bash "$fixture/scripts/check-monotonic-counter-arithmetic.sh" "$fixture" >/dev/null
+
+printf '%s\n' \
+    '' \
+    'pub fn advance_again(mut index: usize) -> usize {' \
+    '    index += 1;' \
+    '    index' \
+    '}' \
+    >> "$fixture/src/lib.rs"
+output="$fixture/duplicate.txt"
+if bash "$fixture/scripts/check-monotonic-counter-arithmetic.sh" "$fixture" \
+    >"$output" 2>&1; then
+    echo "the monotonic counter guard accepted a duplicate allowlisted addition" >&2
+    exit 1
+fi
+
+printf '%s\n' \
+    'pub fn advance(mut index: usize) -> usize {' \
+    '    index += 1;' \
+    '    index' \
+    '}' \
+    > "$fixture/src/lib.rs"
+printf '%s\n' \
+    '' \
+    'pub fn count(mut events: u64) -> u64 {' \
+    '    events += 1;' \
+    '    events' \
+    '}' \
+    >> "$fixture/src/lib.rs"
+output="$fixture/failure.txt"
+if bash "$fixture/scripts/check-monotonic-counter-arithmetic.sh" "$fixture" \
+    >"$output" 2>&1; then
+    echo "the monotonic counter guard accepted compound counter arithmetic" >&2
+    exit 1
+fi
+if ! grep -Fq 'events += 1;' "$output"; then
+    echo "the monotonic counter guard did not identify the rejected counter" >&2
+    exit 1
+fi
+
+printf '%s\n' \
+    'pub fn advance(mut index: usize) -> usize {' \
+    '    index += 1;' \
+    '    index' \
+    '}' \
+    '' \
+    'pub fn count(mut events: u64) -> u64 {' \
+    '    events = events.wrapping_add(1);' \
+    '    events' \
+    '}' \
+    > "$fixture/src/lib.rs"
+bash "$fixture/scripts/check-monotonic-counter-arithmetic.sh" "$fixture" >/dev/null
+
+echo "monotonic counter arithmetic guard self-test: OK"


### PR DESCRIPTION
Closes #401.

## Summary
- Use wrapping addition for replay clocks, replay tallies, map counts, and decoded SVS counts.
- Keep bounded cursors and numeric accumulators unchanged.
- Add a complete compound-addition allowlist and a self-test that rejects new and duplicate additions.

## Checks
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- strict cargo doc
- cargo build --release
- standalone Apple FFI fmt, clippy, and test
- guard self-test and repository guard
- first-party structure check without ignored build trees

The direct local structure command reports two ignored .build/aero-link files. Issue #402 tracks that guard defect.