### PR TITLE
Limit the structure guard to first-party source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: cargo build --release
         run: cargo build --release
 
+      - name: check-structure self-test
+        run: bash scripts/test-check-structure.sh
+
       - name: check-structure
         run: bash scripts/check-structure.sh
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -3,7 +3,7 @@
 # rustc/clippy lints:
 #   - no mod.rs files
 #   - no utils.rs / helpers.rs / common.rs files
-#   - no tracked .rs file over 500 lines (excluding target/ and any
+#   - no first-party .rs file over 500 lines (excluding target/ and any
 #     /generated/ path)
 #   - no lib.rs over 100 lines
 #   - no function body over 80 lines
@@ -30,9 +30,8 @@ is_excluded_path() {
 }
 
 collect_rs_files() {
-    find . \
-        -type d \( -name target -o -name generated \) -prune -o \
-        -type f -name '*.rs' -print
+    git ls-files --cached --others --exclude-standard -- '*.rs' \
+        | sed 's#^#./#'
 }
 
 check_forbidden_filenames() {
@@ -217,12 +216,23 @@ check_indicate_pin_coherence() {
     fi
 }
 
-check_forbidden_filenames
-check_file_length
-check_function_length
-check_calibration_id_uniqueness
-check_safety_palette_aliases
-check_indicate_pin_coherence
+case "${1:-}" in
+    "")
+        check_forbidden_filenames
+        check_file_length
+        check_function_length
+        check_calibration_id_uniqueness
+        check_safety_palette_aliases
+        check_indicate_pin_coherence
+        ;;
+    --forbidden-filenames-only)
+        check_forbidden_filenames
+        ;;
+    *)
+        echo "usage: $0 [--forbidden-filenames-only]" >&2
+        exit 2
+        ;;
+esac
 
 if [ "$status" -ne 0 ]; then
     echo "check-structure: FAILED" >&2

--- a/scripts/test-check-structure.sh
+++ b/scripts/test-check-structure.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/scripts" "$fixture/src" "$fixture/.build/vendor/src"
+cp "$root_dir/scripts/check-structure.sh" "$fixture/scripts/"
+git -C "$fixture" init -q
+
+printf '%s\n' '.build/' > "$fixture/.gitignore"
+printf '%s\n' '//! Test crate.' > "$fixture/src/lib.rs"
+printf '%s\n' 'pub fn ignored_dependency() {}' \
+    > "$fixture/.build/vendor/src/mod.rs"
+git -C "$fixture" add .gitignore scripts/check-structure.sh src/lib.rs
+
+bash "$fixture/scripts/check-structure.sh" --forbidden-filenames-only \
+    >/dev/null
+
+mkdir -p "$fixture/scratch"
+printf '%s\n' 'pub fn first_party_module() {}' > "$fixture/scratch/mod.rs"
+output="$fixture/failure.txt"
+if bash "$fixture/scripts/check-structure.sh" --forbidden-filenames-only \
+    >"$output" 2>&1; then
+    echo "the structure guard accepted a nonignored mod.rs file" >&2
+    exit 1
+fi
+if ! grep -qF './scratch/mod.rs' "$output"; then
+    echo "the structure guard did not name the nonignored mod.rs file" >&2
+    exit 1
+fi
+
+echo "check-structure self-test: OK"


### PR DESCRIPTION
Limit the guard to tracked and nonignored Rust files. This excludes ignored dependency and build trees. It continues to scan new first-party files.

Add a focused self-test. The test proves that an ignored dependency mod.rs passes and a nonignored untracked mod.rs fails. Add the self-test to CI.

Verification:
- bash scripts/test-check-structure.sh
- bash scripts/check-structure.sh
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --quiet
- RUSTDOCFLAGS strict cargo doc --no-deps
- cargo build --release

Closes #402