### PR TITLE
Give the map corner back to orientation, in the platform's own chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Select the newest Xcode on the runner
+        run: |
+          # The package declares a tools version the runner's default Xcode is older
+          # than, and the failure reads as a package problem rather than a runner one.
+          newest=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$newest" ]; then sudo xcode-select -s "$newest"; fi
+          xcodebuild -version
+          swift --version
+
       - name: Authorize the private git dependency (Navigate)
         env:
           NAVIGATE_DEPLOY_KEY: ${{ secrets.NAVIGATE_DEPLOY_KEY }}
@@ -449,6 +458,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Select the newest Xcode on the runner
+        run: |
+          # The package declares a tools version the runner's default Xcode is older
+          # than, and the failure reads as a package problem rather than a runner one.
+          newest=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$newest" ]; then sudo xcode-select -s "$newest"; fi
+          xcodebuild -version
+          swift --version
 
       - name: Authorize the private situation domain dependencies
         env:

--- a/clients/apple-situation/App/Info.plist
+++ b/clients/apple-situation/App/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Pilotage centres the map on your aircraft and shows where you are against terrain, traffic and weather.</string>
 	<key>NSSystemExtensionUsageDescription</key>
 	<string>Pilotage uses its USB driver to receive traffic and weather data.</string>
 	<key>UILaunchScreen</key>

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -88,13 +88,18 @@ struct MapControlsView<ModesContent: View>: View {
                     }
                     .glassEffect(.clear.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.level", in: namespace)
+                    .glassEffectTransition(.matchedGeometry)
                 }
                 if camera.isRotated {
-                    control(label: "Facing \(CompassRose.spokenHeading(camera.headingDegrees)), turn back to north", action: resetHeading) {
+                    control(
+                        label: "Facing \(CompassRose.spokenHeading(camera.headingDegrees)), turn back to north",
+                        action: resetHeading
+                    ) {
                         CompassRose(headingDegrees: camera.headingDegrees)
                     }
                     .glassEffect(.regular.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.compass", in: namespace)
+                    .glassEffectTransition(.matchedGeometry)
                 }
             }
         }
@@ -137,11 +142,17 @@ struct MapControlsView<ModesContent: View>: View {
 
 /// A compass that names the direction the map faces.
 ///
-/// The letter carries the answer at a glance and the needle carries the precision. A
-/// needle alone asks a reader to estimate an angle from a small shape; a letter alone
-/// loses everything between the eight points.
+/// The letter carries the answer at a glance and the dial carries the precision. A dial
+/// alone asks a reader to estimate an angle from a small shape; a letter alone loses
+/// everything between the eight points.
+///
+/// It is drawn to the control it sits in, not to a glyph box: a dial with a ring of air
+/// around it reads as a smaller control beside its neighbours even when the buttons match.
 struct CompassRose: View {
     let headingDegrees: Double
+    var diameter: CGFloat = Metrics.control
+
+    private var radius: CGFloat { diameter / 2 }
 
     var body: some View {
         ZStack {
@@ -151,20 +162,24 @@ struct CompassRose: View {
                 ForEach(0..<16, id: \.self) { tick in
                     Capsule()
                         .fill(.secondary.opacity(tick.isMultiple(of: 4) ? 0.9 : 0.45))
-                        .frame(width: 1.2, height: tick.isMultiple(of: 4) ? 4 : 2.5)
-                        .offset(y: -10)
+                        .frame(
+                            width: diameter * 0.03,
+                            height: diameter * (tick.isMultiple(of: 4) ? 0.13 : 0.08)
+                        )
+                        .offset(y: -radius * 0.74)
                         .rotationEffect(.degrees(Double(tick) * 22.5))
                 }
                 // The needle points at north, which is what the control offers to return to.
                 Triangle()
                     .fill(.red)
-                    .frame(width: 6, height: 5)
-                    .offset(y: -10)
+                    .frame(width: diameter * 0.13, height: diameter * 0.11)
+                    .offset(y: -radius * 0.78)
             }
             .rotationEffect(.degrees(-headingDegrees))
             Text(Self.cardinal(headingDegrees))
-                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .font(.system(size: diameter * 0.34, weight: .semibold, design: .rounded))
         }
+        .frame(width: diameter, height: diameter)
     }
 
     /// The compass point the map faces, as a letter a reader reads without thinking.
@@ -186,6 +201,7 @@ struct CompassRose: View {
     }
 }
 
+
 /// A north needle.
 struct Triangle: Shape {
     func path(in rect: CGRect) -> Path {
@@ -195,17 +211,5 @@ struct Triangle: Shape {
         path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
         path.closeSubpath()
         return path
-    }
-}
-
-
-/// The platform's own treatment for a control that floats over a map.
-///
-/// The style is the system's, so these controls follow the platform as it changes rather
-/// than carrying a copy of one release's material.
-extension View {
-    /// Apply the platform's treatment for a map control.
-    func mapControlButton() -> some View {
-        buttonStyle(.glass).clipShape(Circle())
     }
 }

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -1,0 +1,211 @@
+import PilotageMapLibreBinding
+import SwiftUI
+
+/// The controls that undo what a reader did to the camera.
+///
+/// The chrome is the system button style, so the platform decides how a control sits over
+/// a map. Hand-drawn material was one release behind the moment it was written.
+///
+/// Each one appears only when there is something to undo. A compass on a map that faces
+/// north, or a level control on a map that already looks straight down, is a control that
+/// does nothing: it teaches a reader to ignore that corner, which is the corner where the
+/// map says it is no longer oriented the way they assume.
+/// Identity the map-modes panel grows out of.
+enum MapControlIdentity {
+    static let modes = "pilotage.map.modes"
+}
+
+struct MapControlsView<ModesContent: View>: View {
+    let camera: SituationCamera
+    let ownship: OwnshipFix?
+    let canLocate: Bool
+    let follow: FollowMode
+    let namespace: Namespace.ID
+    let resetHeading: () -> Void
+    let resetPitch: () -> Void
+    let cycleFollow: () -> Void
+    @Binding var modesPresented: Bool
+    @ViewBuilder let modesContent: () -> ModesContent
+    @State private var levelling = false
+    @State private var pillFlash = false
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            if modesPresented {
+                // The panel takes the corner the pill was in. It does not sit beside the
+                // control that opened it: the control became it.
+                modesContent()
+                    .transition(
+                        .scale(scale: 0.18, anchor: .topTrailing).combined(with: .opacity)
+                    )
+            } else {
+                controls
+                    .transition(
+                        .scale(scale: 0.9, anchor: .topTrailing).combined(with: .opacity)
+                    )
+            }
+        }
+        .animation(.spring(response: 0.34, dampingFraction: 0.82), value: modesPresented)
+    }
+
+    /// One glass container holds every map control.
+    ///
+    /// Clear glass rather than regular: these float over a map a reader is reading, and
+    /// the map has to stay legible under them. Interactive glass keeps the press response
+    /// a button gives up when it stops using the system button style, which is the price
+    /// of choosing the variant.
+    ///
+    /// A glass identity on each control lets one grow out of the group and shrink back
+    /// into it. The group flashes as it takes one back, the way a surface does when
+    /// something rejoins it.
+    private var controls: some View {
+        GlassEffectContainer(spacing: Metrics.controlSpacing) {
+            VStack(spacing: Metrics.controlSpacing) {
+                VStack(spacing: 0) {
+                    control(label: "Map modes") { modesPresented = true } content: {
+                        Image(systemName: "globe.americas.fill")
+                    }
+                    if canLocate {
+                        control(label: follow.label, action: cycleFollow) {
+                            Image(systemName: follow.symbol)
+                        }
+                    }
+                }
+                .glassEffect(.clear.interactive(), in: .capsule)
+                .glassEffectUnion(id: "pilotage.map.pill", namespace: namespace)
+                .glassEffectID("pilotage.map.pill", in: namespace)
+                .brightness(pillFlash ? 0.22 : 0)
+                .animation(.easeOut(duration: 0.22), value: pillFlash)
+
+                if camera.isTilted {
+                    control(label: "Look straight down") {
+                        levelling = true
+                        resetPitch()
+                    } content: {
+                        // The control names the state it is about to reach as it goes, so
+                        // the press is acknowledged before the control leaves.
+                        Text(levelling ? "3D" : "2D")
+                    }
+                    .glassEffect(.clear.interactive(), in: .circle)
+                    .glassEffectID("pilotage.map.level", in: namespace)
+                }
+                if camera.isRotated {
+                    control(label: "Facing \(CompassRose.spokenHeading(camera.headingDegrees)), turn back to north", action: resetHeading) {
+                        CompassRose(headingDegrees: camera.headingDegrees)
+                    }
+                    .glassEffect(.regular.interactive(), in: .circle)
+                    .glassEffectID("pilotage.map.compass", in: namespace)
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: camera.isTilted)
+        .animation(.easeInOut(duration: 0.3), value: camera.isRotated)
+        .animation(.easeInOut(duration: 0.3), value: canLocate)
+        .onChange(of: camera.isTilted) { _, tilted in
+            if !tilted { levelling = false; flashPill() }
+        }
+        .onChange(of: camera.isRotated) { _, rotated in
+            if !rotated { flashPill() }
+        }
+    }
+
+    /// One control: the same square, the same glyph weight, the same target.
+    private func control(
+        label: String,
+        action: @escaping () -> Void,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        Button(action: action) {
+            content()
+                .font(Metrics.controlGlyph)
+                .frame(width: Metrics.control, height: Metrics.control)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+
+    /// Mark the group taking a control back.
+    private func flashPill() {
+        pillFlash = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 220_000_000)
+            pillFlash = false
+        }
+    }
+}
+
+/// A compass that names the direction the map faces.
+///
+/// The letter carries the answer at a glance and the needle carries the precision. A
+/// needle alone asks a reader to estimate an angle from a small shape; a letter alone
+/// loses everything between the eight points.
+struct CompassRose: View {
+    let headingDegrees: Double
+
+    var body: some View {
+        ZStack {
+            // The dial turns with the map. The letter does not, because a reader reads a
+            // letter upright or not at all.
+            ZStack {
+                ForEach(0..<16, id: \.self) { tick in
+                    Capsule()
+                        .fill(.secondary.opacity(tick.isMultiple(of: 4) ? 0.9 : 0.45))
+                        .frame(width: 1.2, height: tick.isMultiple(of: 4) ? 4 : 2.5)
+                        .offset(y: -10)
+                        .rotationEffect(.degrees(Double(tick) * 22.5))
+                }
+                // The needle points at north, which is what the control offers to return to.
+                Triangle()
+                    .fill(.red)
+                    .frame(width: 6, height: 5)
+                    .offset(y: -10)
+            }
+            .rotationEffect(.degrees(-headingDegrees))
+            Text(Self.cardinal(headingDegrees))
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+        }
+    }
+
+    /// The compass point the map faces, as a letter a reader reads without thinking.
+    static func cardinal(_ headingDegrees: Double) -> String {
+        let points = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+        let normalised = (headingDegrees.truncatingRemainder(dividingBy: 360) + 360)
+            .truncatingRemainder(dividingBy: 360)
+        let index = Int((normalised / 45).rounded()) % points.count
+        return points[index]
+    }
+
+    /// The same direction, said in full for a reader who cannot see it.
+    static func spokenHeading(_ headingDegrees: Double) -> String {
+        let names = [
+            "N": "north", "NE": "north east", "E": "east", "SE": "south east",
+            "S": "south", "SW": "south west", "W": "west", "NW": "north west",
+        ]
+        return names[cardinal(headingDegrees)] ?? "north"
+    }
+}
+
+/// A north needle.
+struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+
+/// The platform's own treatment for a control that floats over a map.
+///
+/// The style is the system's, so these controls follow the platform as it changes rather
+/// than carrying a copy of one release's material.
+extension View {
+    /// Apply the platform's treatment for a map control.
+    func mapControlButton() -> some View {
+        buttonStyle(.glass).clipShape(Circle())
+    }
+}

--- a/clients/apple-situation/App/MapLayoutMetrics.swift
+++ b/clients/apple-situation/App/MapLayoutMetrics.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// The measurements every floating map control shares.
+///
+/// One place, because the alternative is what it replaced: a control that was wider than
+/// the one under it because each carried its own numbers. A reader reads a column of
+/// controls as one thing only when they are one width.
+enum Metrics {
+    /// Side of a single round or capsule control.
+    ///
+    /// Forty-four points is the platform's smallest comfortable target, and a map is used
+    /// with a thumb while the aircraft moves.
+    static let control: CGFloat = 52
+
+    /// Size of the glyph inside a control.
+    static let controlGlyph: Font = .system(size: 19, weight: .semibold)
+
+    /// Box the compass dial is drawn in, inside a control.
+    static let controlGlyphBox: CGFloat = 30
+
+    /// Gap between controls in a stack.
+    static let controlSpacing: CGFloat = 10
+
+    /// Distance from a control to the edge of the safe area.
+    ///
+    /// The map runs under the status bar and the home indicator, and the controls do not.
+    /// This is the margin between the two.
+    static let edgeInset: CGFloat = 12
+
+    /// Corner radius of a floating panel.
+    static let panelCorner: CGFloat = 26
+
+    /// Padding inside a floating panel.
+    static let panelPadding: CGFloat = 18
+
+    /// Width of a floating panel.
+    static let panelWidth: CGFloat = 320
+}
+
+extension View {
+    /// Place a floating control against the safe area, with the standard margin.
+    ///
+    /// Declared once rather than as a padding value repeated at each corner, so a control
+    /// added later cannot sit at a different distance from the edge than the rest.
+    func mapControlPlacement(_ alignment: Alignment) -> some View {
+        frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+            .padding(Metrics.edgeInset)
+    }
+}

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -1,0 +1,163 @@
+import PilotageSituationCore
+import SwiftUI
+
+/// One way of drawing the ground.
+///
+/// A mode is a base map, not a layer: exactly one is drawn, and the layers below the tiles
+/// are what sits on top of it. Terrain is the only one this build carries. Satellite, VFR
+/// and IFR are the same shape of thing and arrive as data rather than as new screens.
+struct MapMode: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let symbol: String
+
+    /// The base maps this build can draw.
+    ///
+    /// Built from what exists rather than from what is planned. A tile for a mode the
+    /// client cannot draw is a promise the map does not keep.
+    static let available: [MapMode] = [
+        MapMode(id: "terrain", title: "Terrain", symbol: "mountain.2.fill"),
+    ]
+}
+
+/// Choose how the ground is drawn and what sits on it.
+///
+/// The panel Apple's map uses for the same job: the base map as tiles across the top, the
+/// layers as switches under them, and the credit for the data at the foot of it, where a
+/// reader who wants it can find it and a reader who does not is not made to read it.
+struct MapModesView: View {
+    let modes: [MapMode]
+    @Binding var selectedModeID: String
+    let layers: [DisplayLayerControl]
+    let setLayerEnabled: (String, Bool) -> Void
+    let attributions: [String]
+    let close: () -> Void
+    @State private var attributionPresented = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            header
+            modeTiles
+            if !layers.isEmpty {
+                layerSwitches
+            }
+            attributionFooter
+        }
+        .padding(Metrics.panelPadding)
+        .glassEffect(
+            .regular,
+            in: .rect(cornerRadius: Metrics.panelCorner)
+        )
+        // The panel is as big as what it holds. A fixed width leaves a column of empty
+        // glass beside one tile, and a detent invites a drag the panel does not answer.
+        .frame(width: Metrics.panelWidth)
+        .fixedSize(horizontal: false, vertical: true)
+        .sheet(isPresented: $attributionPresented) {
+            MapAttributionView(notices: attributions)
+        }
+    }
+
+    private var header: some View {
+        ZStack {
+            Text("Map Modes")
+                .font(.title3.weight(.semibold))
+            HStack {
+                Spacer()
+                Button(action: close) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .semibold))
+                        // The same target as every other control. A close button smaller
+                        // than the rest is the one a reader misses.
+                        .frame(width: Metrics.control, height: Metrics.control)
+                }
+                .buttonStyle(.glass)
+                .accessibilityLabel("Close map modes")
+            }
+        }
+    }
+
+    private var modeTiles: some View {
+        HStack(alignment: .top, spacing: 16) {
+            ForEach(modes) { mode in
+                Button {
+                    selectedModeID = mode.id
+                } label: {
+                    VStack(spacing: 8) {
+                        Image(systemName: mode.symbol)
+                            .font(.system(size: 26))
+                            .frame(width: 74, height: 74)
+                            .glassEffect(.regular, in: .rect(cornerRadius: 14))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 14)
+                                    .stroke(
+                                        selectedModeID == mode.id ? Color.accentColor : .clear,
+                                        lineWidth: 3
+                                    )
+                            }
+                        Text(mode.title)
+                            .font(.footnote)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(mode.title)
+                .accessibilityAddTraits(selectedModeID == mode.id ? [.isSelected] : [])
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var layerSwitches: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(layers.enumerated()), id: \.element.id) { index, layer in
+                Toggle(
+                    isOn: Binding(
+                        get: { layer.enabled },
+                        set: { setLayerEnabled(layer.id, $0) }
+                    )
+                ) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(layer.title)
+                        Text(layer.sourceStateLabel)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 14)
+                if index < layers.count - 1 {
+                    Divider().padding(.leading, 14)
+                }
+            }
+        }
+        .glassEffect(.regular, in: .rect(cornerRadius: 16))
+    }
+
+    /// The credit for the data, at the foot of the panel that chose it.
+    private var attributionFooter: some View {
+        Button {
+            attributionPresented = true
+        } label: {
+            Text(summary)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Map data sources, \(summary)")
+        .accessibilityHint("Shows the full notice for every source")
+    }
+
+    /// Name the providers without spelling out every source.
+    private var summary: String {
+        let providers = attributions.compactMap { notice -> String? in
+            if notice.contains("Natural Earth") { return "Natural Earth" }
+            if notice.contains("AWS Terrain Tiles") { return "AWS Terrain Tiles" }
+            return nil
+        }
+        guard let first = providers.first else { return "Map data" }
+        return providers.count > 1
+            ? "© \(first) and other data providers"
+            : "© \(first)"
+    }
+}

--- a/clients/apple-situation/App/OwnshipPosition.swift
+++ b/clients/apple-situation/App/OwnshipPosition.swift
@@ -1,0 +1,394 @@
+import CoreLocation
+import Foundation
+import PilotageSituationCore
+
+/// Where a position for the aircraft came from.
+///
+/// The two are usually the same and are not always. An iPad in a bag on the back seat
+/// still reports a position, and a panel or a receiver that hears the aircraft's own
+/// transmission reports where the aircraft is. A display that swaps between them without
+/// saying so is worse than one that offers only the tablet.
+enum OwnshipSource: String, Equatable, Sendable {
+    /// This device's own receiver.
+    case device
+    /// The aircraft, over the radio link.
+    case aircraft
+
+    /// How the source reads to someone deciding whether to trust the mark.
+    var title: String {
+        switch self {
+        case .device: "This iPad"
+        case .aircraft: "Aircraft"
+        }
+    }
+}
+
+/// One position for the aircraft.
+struct OwnshipFix: Equatable, Sendable {
+    /// WGS84 latitude in degrees.
+    let latitudeDegrees: Double
+    /// WGS84 longitude in degrees.
+    let longitudeDegrees: Double
+    /// Direction of travel in degrees from true north, when the source reports one.
+    let courseDegrees: Double?
+    /// Where the position came from.
+    let source: OwnshipSource
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitudeDegrees, longitude: longitudeDegrees)
+    }
+}
+
+/// Whether the client may ask this device for a position, and what it answered.
+enum DeviceLocationAuthorisation: Equatable, Sendable {
+    /// The reader has not been asked.
+    case undetermined
+    /// The reader said yes.
+    case granted
+    /// The reader said no, or the device forbids it.
+    case denied
+}
+
+/// Reads a position from the device.
+///
+/// Not every iPad has a satellite receiver: the cellular models do and the others do not.
+/// This reports nothing on a tablet that cannot answer, which is the case the aircraft
+/// source exists for, so the control is driven by whether a position exists rather than by
+/// which hardware is present.
+@MainActor
+final class DeviceLocationProvider: NSObject, CLLocationManagerDelegate {
+    /// Receives each position the device reports.
+    var onFix: ((OwnshipFix) -> Void)?
+    /// Receives the reader's answer to the permission request.
+    var onAuthorisation: ((DeviceLocationAuthorisation) -> Void)?
+
+    private let manager = CLLocationManager()
+    private var isRunning = false
+
+    /// Whether the device's own location service is switched on.
+    nonisolated static var servicesEnabled: Bool {
+        CLLocationManager.locationServicesEnabled()
+    }
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        // An aircraft moves far enough that a metre of filtering costs nothing and saves a
+        // wake-up for every jitter of the fix.
+        manager.distanceFilter = 5
+    }
+
+    /// Ask for a position, requesting permission the first time.
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        report(manager.authorizationStatus)
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.startUpdatingLocation()
+        default:
+            break
+        }
+    }
+
+    /// Stop asking. A map nobody is looking at does not need a position.
+    func stop() {
+        isRunning = false
+        manager.stopUpdatingLocation()
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.report(status)
+            if status == .authorizedWhenInUse || status == .authorizedAlways, self.isRunning {
+                self.manager.startUpdatingLocation()
+            }
+        }
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]
+    ) {
+        guard let location = locations.last else { return }
+        let fix = OwnshipFix(
+            latitudeDegrees: location.coordinate.latitude,
+            longitudeDegrees: location.coordinate.longitude,
+            courseDegrees: location.course >= 0 ? location.course : nil,
+            source: .device
+        )
+        Task { @MainActor [weak self] in
+            self?.onFix?(fix)
+        }
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didFailWithError error: Error
+    ) {
+        // A failure to fix is not a failure of the client. The aircraft source may still
+        // answer, and the control follows whether a position exists.
+    }
+
+    private func report(_ status: CLAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            onAuthorisation?(.undetermined)
+        case .authorizedWhenInUse, .authorizedAlways:
+            onAuthorisation?(.granted)
+        default:
+            onAuthorisation?(.denied)
+        }
+    }
+}
+
+/// The position the map may centre on, from whichever source has one.
+///
+/// The aircraft is preferred when it reports, because that is where the aircraft is; the
+/// device answers otherwise. A tablet with no satellite receiver still gets the control as
+/// soon as a panel or a receiver supplies a position, so the control follows whether a
+/// position exists rather than which hardware is in the bag.
+@MainActor
+final class OwnshipModel: ObservableObject {
+    /// The position to centre on, or nothing when no source has one.
+    @Published private(set) var fix: OwnshipFix?
+    /// What this device answered when asked for a position.
+    @Published private(set) var deviceAuthorisation: DeviceLocationAuthorisation = .undetermined
+    /// Whether the control that centres the map is worth offering.
+    ///
+    /// Offered unless the answer is already no. A fix comes and goes indoors, and a reader
+    /// who has not been asked for permission yet has not refused: pressing the control is
+    /// how they are asked. Hiding it until a fix exists means the reader never gets to ask
+    /// for one, which is the state this replaced.
+    var canLocate: Bool {
+        fix != nil || deviceAuthorisation != .denied
+    }
+
+    /// Whether the device is willing to locate at all.
+    ///
+    /// An application can hold permission on a device whose location service is switched
+    /// off entirely. Without this the two states look the same from outside: permission
+    /// granted and no position ever arriving.
+    var deviceLocationEnabled: Bool { DeviceLocationProvider.servicesEnabled }
+
+    /// Which way the aircraft is pointing, from the best source that has an answer.
+    @Published private(set) var heading: HeadingFix?
+
+    private let device = DeviceLocationProvider()
+    private let compass = DeviceHeadingProvider()
+    private var deviceFix: OwnshipFix?
+    private var aircraftFix: OwnshipFix?
+    private var deviceHeading: HeadingFix?
+    private var aircraftHeading: HeadingFix?
+
+    init() {
+        device.onFix = { [weak self] fix in
+            self?.deviceFix = fix
+            self?.resolve()
+        }
+        device.onAuthorisation = { [weak self] authorisation in
+            self?.deviceAuthorisation = authorisation
+        }
+        compass.onHeading = { [weak self] heading in
+            self?.deviceHeading = heading
+            self?.resolveHeading()
+        }
+    }
+
+    /// Take a heading reported by a panel or receiver in the aircraft.
+    ///
+    /// Nothing calls this yet. A GDL 90 source carries one, and it beats a tablet that may
+    /// be lying on a seat.
+    func observeAircraftHeading(_ heading: HeadingFix?) {
+        aircraftHeading = heading
+        resolveHeading()
+    }
+
+    private func resolveHeading() {
+        // The aircraft knows better than the tablet. Failing both, course over the ground
+        // is the last answer, and it is marked as such because it is not heading.
+        let course = fix?.courseDegrees.map {
+            HeadingFix(trueDegrees: $0, source: .courseOverGround)
+        }
+        let next = aircraftHeading ?? deviceHeading ?? course
+        guard next != heading else { return }
+        heading = next
+    }
+
+    /// Begin asking this device for a position.
+    func start() {
+        device.start()
+        compass.start()
+    }
+
+    /// Stop asking.
+    func stop() {
+        device.stop()
+        compass.stop()
+    }
+
+    /// Ask for permission if it has not been asked for, and start locating.
+    ///
+    /// A reader pressing the control is the request. The map follows as soon as there is
+    /// a position, which may be after the reader answers a prompt.
+    func requestPositionIfNeeded() {
+        device.start()
+    }
+
+    /// Take a position reported by the aircraft over the radio link.
+    func observeAircraft(_ fix: OwnshipFix?) {
+        aircraftFix = fix
+        resolve()
+    }
+
+    private func resolve() {
+        let next = aircraftFix ?? deviceFix
+        guard next != fix else { return }
+        fix = next
+        resolveHeading()
+    }
+}
+
+extension OwnshipFix {
+    /// Read the aircraft's own return as a position to centre on.
+    init(_ ownship: DisplayOwnship) {
+        self.init(
+            latitudeDegrees: ownship.coordinate.latitudeDeg,
+            longitudeDegrees: ownship.coordinate.longitudeDeg,
+            courseDegrees: ownship.courseDeg,
+            source: .aircraft
+        )
+    }
+}
+
+/// How closely the map is tied to the aircraft.
+///
+/// Three states rather than two, because "centred" and "turning with me" are different
+/// questions. North-up keeps the chart oriented the way it is printed; heading-up puts
+/// what is ahead of the aircraft at the top of the screen, which is how most flying is
+/// actually done. A reader has to be able to see which one they are in without moving the
+/// map to find out.
+enum FollowMode: Equatable, Sendable {
+    /// The map goes where the reader puts it.
+    case idle
+    /// The map stays on the aircraft, north up.
+    case centred
+    /// The map stays on the aircraft and turns with it.
+    case heading
+
+    /// The next state when the control is pressed.
+    var next: FollowMode {
+        switch self {
+        case .idle: .centred
+        case .centred: .heading
+        case .heading: .centred
+        }
+    }
+
+    /// The mark that says which state this is.
+    var symbol: String {
+        switch self {
+        case .idle: "location"
+        case .centred: "location.fill"
+        case .heading: "location.north.line.fill"
+        }
+    }
+
+    /// What the state means, said in full.
+    var label: String {
+        switch self {
+        case .idle: "Centre the map on the aircraft"
+        case .centred: "Following the aircraft, turn the map with it"
+        case .heading: "Turning with the aircraft, stop turning"
+        }
+    }
+
+    /// Whether the map should stay on the aircraft.
+    var followsPosition: Bool { self != .idle }
+}
+
+/// Which direction the aircraft is pointing, and where that came from.
+///
+/// Three references, and they are not the same number:
+///
+/// - magnetic heading is what a magnetometer reads;
+/// - true heading is that corrected for magnetic variation, which the platform computes
+///   from position and its own declination model;
+/// - course over the ground is where the aircraft is going, which in wind is not where it
+///   is pointing.
+///
+/// The map draws in true north, so a heading-up map wants true heading. A panel or a
+/// GDL 90 source supplies a better one than a tablet on a yoke mount, and takes priority
+/// when it arrives.
+struct HeadingFix: Equatable, Sendable {
+    /// Degrees clockwise from true north.
+    let trueDegrees: Double
+    /// Where the value came from.
+    let source: Source
+
+    enum Source: String, Equatable, Sendable {
+        /// This device's magnetometer, corrected for variation by the platform.
+        case deviceTrue
+        /// This device's magnetometer, uncorrected because no correction was available.
+        case deviceMagnetic
+        /// Course over the ground, which is not heading.
+        case courseOverGround
+        /// A panel or receiver in the aircraft.
+        case aircraft
+    }
+}
+
+/// Reads which way the device is pointing.
+///
+/// Not every iPad has a magnetometer, so this reports nothing on a tablet that cannot
+/// answer and the map falls back to course over the ground.
+@MainActor
+final class DeviceHeadingProvider: NSObject, CLLocationManagerDelegate {
+    /// Receives each heading the device reports.
+    var onHeading: ((HeadingFix) -> Void)?
+
+    private let manager = CLLocationManager()
+    private var isRunning = false
+
+    /// Whether this device can report which way it is pointing.
+    nonisolated static var available: Bool { CLLocationManager.headingAvailable() }
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        // A degree of filtering keeps a map from shivering while the aircraft holds course.
+        manager.headingFilter = 1
+        manager.headingOrientation = .portrait
+    }
+
+    func start() {
+        guard Self.available, !isRunning else { return }
+        isRunning = true
+        manager.startUpdatingHeading()
+    }
+
+    func stop() {
+        isRunning = false
+        manager.stopUpdatingHeading()
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateHeading newHeading: CLHeading
+    ) {
+        // A negative accuracy means the reading is not trustworthy at all, and a negative
+        // true heading means the platform had no variation to apply.
+        guard newHeading.headingAccuracy >= 0 else { return }
+        let fix: HeadingFix = newHeading.trueHeading >= 0
+            ? HeadingFix(trueDegrees: newHeading.trueHeading, source: .deviceTrue)
+            : HeadingFix(trueDegrees: newHeading.magneticHeading, source: .deviceMagnetic)
+        Task { @MainActor [weak self] in
+            self?.onHeading?(fix)
+        }
+    }
+}

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -16,6 +16,13 @@ private struct SituationContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var model = SituationClientModel()
     @State private var menuPresented = false
+    @State private var camera = SituationCamera(headingDegrees: 0, pitchDegrees: 0)
+    @State private var mapCommands: SituationMapCommands?
+    @State private var follow: FollowMode = .idle
+    @State private var modesPresented = false
+    @State private var selectedMapModeID = MapMode.available.first?.id ?? "terrain"
+    @Namespace private var mapControlNamespace
+    @StateObject private var ownship = OwnshipModel()
 
     var body: some View {
         // The map owns the screen. Status, layers, reception and flights live in the
@@ -24,59 +31,60 @@ private struct SituationContentView: View {
             // The map is the document, so it runs to the glass. A safe-area inset here
             // leaves a black band above and below that reads as a broken screen rather
             // than as a margin. The controls above it keep the inset.
-            SituationMap(batch: model.mapDisplay, onFeatureTapped: model.selectTraffic)
-                .ignoresSafeArea()
-            VStack {
-                HStack(alignment: .top) {
-                    if let flight = model.replayingFlight {
-                        ReplayBannerView(flight: flight, stop: model.stopReplay)
-                    }
-                    Spacer()
-                    Button {
-                        model.reloadFlights()
-                        menuPresented = true
-                    } label: {
-                        Image(systemName: "line.3.horizontal")
-                            .font(.title2)
-                            .padding(12)
-                            .background(.ultraThinMaterial, in: Circle())
-                            // A reader must not have to open the drawer to learn that a
-                            // receiver died. An empty map with no mark reads as clear air.
-                            .overlay(alignment: .topTrailing) {
-                                if model.hasAttention {
-                                    Circle()
-                                        .fill(.orange)
-                                        .frame(width: 12, height: 12)
-                                        .overlay(Circle().stroke(.black.opacity(0.5)))
-                                }
-                            }
-                    }
-                    .accessibilityLabel(
-                        model.hasAttention
-                            ? "Situation menu, reception needs attention"
-                            : "Situation menu"
-                    )
+            SituationMap(
+                batch: model.mapDisplay,
+                onFeatureTapped: model.selectTraffic,
+                onCameraChanged: { camera = $0 },
+                onReady: { mapCommands = $0 },
+                onAttributions: model.observeMapAttributions,
+                onMovedByReader: {
+                    // A hand on the map ends both the following and the panel: the reader
+                    // has said what they want to look at.
+                    follow = .idle
+                    modesPresented = false
                 }
-                Spacer()
-                HStack {
-                    PositionlessTrafficView(
-                        items: model.mapDisplay?.positionlessTraffic ?? [],
-                        select: model.selectTraffic
-                    )
-                    Spacer()
+            )
+            .ignoresSafeArea()
+            // Each floating control is placed against the safe area by the same rule, so
+            // none of them sits at a different distance from an edge than the others.
+            ZStack {
+                if let flight = model.replayingFlight {
+                    ReplayBannerView(flight: flight, stop: model.stopReplay)
+                        .mapControlPlacement(.topLeading)
                 }
+                MapControlsView(
+                    camera: camera,
+                    ownship: ownship.fix,
+                    canLocate: ownship.canLocate,
+                    follow: follow,
+                    namespace: mapControlNamespace,
+                    resetHeading: { mapCommands?.resetHeading() },
+                    resetPitch: { mapCommands?.resetPitch() },
+                    cycleFollow: cycleFollow,
+                    modesPresented: $modesPresented,
+                    modesContent: {
+                        MapModesView(
+                            modes: MapMode.available,
+                            selectedModeID: $selectedMapModeID,
+                            layers: model.mapDisplay?.layers ?? [],
+                            setLayerEnabled: model.setLayerEnabled,
+                            attributions: model.mapAttributions,
+                            close: { modesPresented = false }
+                        )
+                    }
+                )
+                .mapControlPlacement(.topTrailing)
+                PositionlessTrafficView(
+                    items: model.mapDisplay?.positionlessTraffic ?? [],
+                    select: model.selectTraffic
+                )
+                .mapControlPlacement(.bottomLeading)
+                menuButton
+                    .mapControlPlacement(.bottomTrailing)
             }
-            .padding()
         }
         .sheet(isPresented: $menuPresented) {
             SituationMenuView(model: model)
-        }
-        .task(id: scenePhase) {
-            if scenePhase == .active {
-                await model.activate()
-            } else {
-                await model.suspend()
-            }
         }
         .sheet(
             isPresented: Binding(
@@ -95,9 +103,88 @@ private struct SituationContentView: View {
     }
 }
 
+private extension SituationContentView {
+    /// Step through not following, following, and turning with the aircraft.
+    ///
+    /// Following is a mode rather than a jump, so the map keeps up as the position moves
+    /// and stops the moment the reader drags it.
+    func cycleFollow() {
+        // Pressing this is also how a reader asks for permission the first time.
+        ownship.requestPositionIfNeeded()
+        follow = follow.next
+        applyFollow()
+    }
+
+    /// Put the camera where the current mode says it belongs.
+    func applyFollow() {
+        guard let fix = ownship.fix else { return }
+        if follow.followsPosition {
+            mapCommands?.centre(fix.coordinate)
+        }
+        switch follow {
+        case .heading:
+            // A heading if the device or the aircraft has one, and course over the ground
+            // only when neither does. They differ in wind, and the map should turn to
+            // where the aircraft points rather than where it is drifting.
+            if let heading = ownship.heading {
+                mapCommands?.setHeading(heading.trueDegrees)
+            }
+        case .centred:
+            mapCommands?.resetHeading()
+        case .idle:
+            break
+        }
+    }
+
+    var menuButton: some View {
+        Button {
+            model.reloadFlights()
+            menuPresented = true
+        } label: {
+            Image(systemName: "line.3.horizontal")
+                .font(Metrics.controlGlyph)
+                .frame(width: Metrics.control, height: Metrics.control)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .glassEffect(.clear.interactive(), in: .circle)
+        // A reader must not have to open the drawer to learn that a receiver died. An
+        // empty map with no mark reads as clear air.
+        .overlay(alignment: .topTrailing) {
+            if model.hasAttention {
+                Circle()
+                    .fill(.orange)
+                    .frame(width: 12, height: 12)
+                    .overlay(Circle().stroke(.black.opacity(0.5)))
+            }
+        }
+        .accessibilityLabel(
+            model.hasAttention
+                ? "Situation menu, reception needs attention"
+                : "Situation menu"
+        )
+    }
+}
+
+/// What the controls can ask of the map.
+///
+/// The controls live in the view hierarchy above the map and must not hold the map itself,
+/// so they hold this instead.
+@MainActor
+struct SituationMapCommands {
+    let resetHeading: () -> Void
+    let resetPitch: () -> Void
+    let centre: (CLLocationCoordinate2D) -> Void
+    let setHeading: (Double) -> Void
+}
+
 private struct SituationMap: UIViewRepresentable {
     let batch: DisplayBatch?
     let onFeatureTapped: (String) -> Void
+    let onCameraChanged: (SituationCamera) -> Void
+    let onReady: (SituationMapCommands) -> Void
+    let onAttributions: ([String]) -> Void
+    let onMovedByReader: () -> Void
 
     func makeUIView(context: Context) -> SituationMapView {
         let styleJSON = (try? SituationStyleResource.load())
@@ -112,11 +199,29 @@ private struct SituationMap: UIViewRepresentable {
         view.maximumZoomLevel = SituationStyleResource.maximumZoomLevel
         view.baseLayerIdentifiers = ["terrain-base": "pilotage-terrain-hillshade"]
         view.onFeatureTapped = onFeatureTapped
+        view.onCameraChanged = onCameraChanged
+        view.onStyleLoaded = { onAttributions($0.sourceAttributions) }
+        view.onMovedByReader = onMovedByReader
+        // The handle is published after the view exists, and the publish is deferred so it
+        // does not change application state while the view tree is being built.
+        DispatchQueue.main.async { [weak view] in
+            guard let view else { return }
+            onReady(
+                SituationMapCommands(
+                    resetHeading: { view.resetHeading() },
+                    resetPitch: { view.resetPitch() },
+                    centre: { view.centre(on: $0) },
+                    setHeading: { view.setHeading($0) }
+                )
+            )
+        }
         return view
     }
 
     func updateUIView(_ mapView: SituationMapView, context: Context) {
         mapView.onFeatureTapped = onFeatureTapped
+        mapView.onCameraChanged = onCameraChanged
+        mapView.onMovedByReader = onMovedByReader
         if let batch {
             mapView.apply(batch)
         }

--- a/clients/apple-situation/App/SituationClientModel.swift
+++ b/clients/apple-situation/App/SituationClientModel.swift
@@ -13,6 +13,11 @@ final class SituationClientModel: ObservableObject {
     @Published private(set) var replayDisplay: DisplayBatch?
     /// Recordings the container holds.
     @Published private(set) var flights: [Flight] = []
+    /// The notice each map source asks to be shown.
+    ///
+    /// Reported by the map once its style is loaded, because the style is what says which
+    /// sources are drawing and what each one asks for.
+    @Published private(set) var mapAttributions: [String] = []
     /// Whether the client claims the radios.
     @Published var adsbEnabled: Bool {
         didSet {
@@ -43,6 +48,10 @@ final class SituationClientModel: ObservableObject {
     private let terrainAvailable: Bool
     private let discovery = AeroLinkDiscoveryGate()
     private let evidenceWriter = SituationEvidenceWriter()
+    /// Receives the aircraft's own position whenever a batch carries one.
+    var onOwnship: ((DisplayOwnship?) -> Void)?
+    /// Reads the position the map may centre on, for the evidence file.
+    var currentOwnship: (() -> (OwnshipFix?, HeadingFix?, FollowMode, DeviceLocationAuthorisation, Bool))?
     private var replayTask: Task<Void, Never>?
     private var pendingDisplay: DisplayBatch?
     private var publishTask: Task<Void, Never>?
@@ -248,10 +257,29 @@ final class SituationClientModel: ObservableObject {
         pendingDisplay = nil
         lastPublishMicros = Self.monotonicMicros
         display = next
+        // The aircraft's own return is a position the client can be sure belongs to this
+        // aircraft, so it reaches the ownship model rather than stopping at the map.
+        onOwnship?(next.ownship)
         if let selected = selectedTraffic {
             selectedTraffic = next.trafficDetails.first { $0.id == selected.id }
         }
         recordEvidence()
+    }
+
+    /// Write the evidence again after the view has supplied its readers.
+    ///
+    /// The first write happens as the client activates, before the view is on screen, so
+    /// everything the view reports would otherwise stay absent until something else
+    /// changed. A file that says nothing because it was written too early is worse than
+    /// one that says nothing because there is nothing to say.
+    func refreshEvidence() {
+        recordEvidence()
+    }
+
+    /// Take the notices the loaded style asks to be shown.
+    func observeMapAttributions(_ notices: [String]) {
+        guard notices != mapAttributions else { return }
+        mapAttributions = notices
     }
 
     /// Recordings the container holds.
@@ -324,6 +352,11 @@ final class SituationClientModel: ObservableObject {
             SituationEvidence(
                 batch: display,
                 radioSource: radioSource,
+                ownship: currentOwnship?().0,
+                heading: currentOwnship?().1,
+                follow: currentOwnship?().2 ?? .idle,
+                deviceLocationAuthorisation: currentOwnship?().3 ?? .undetermined,
+                deviceLocationEnabled: currentOwnship?().4 ?? false,
                 replay: replayRun,
                 driverEnabled: discovery.driverIsEnabled(),
                 terrainArchiveAvailable: terrainAvailable,

--- a/clients/apple-situation/App/SituationEvidence.swift
+++ b/clients/apple-situation/App/SituationEvidence.swift
@@ -58,6 +58,29 @@ struct SituationEvidence: Codable, Equatable {
     var replayWeatherRecords: UInt64?
     /// Records the display refused during the replay.
     var replayRefusedRecords: UInt64?
+    /// Where the aircraft position came from, when one exists.
+    ///
+    /// The control that centres the map appears only when a position exists and fills only
+    /// while the map follows it, so a run that shows neither needs to say which.
+    var ownshipSource: String?
+    /// Whether this device answered when asked for a position.
+    var deviceLocationAuthorisation: String?
+    /// Whether the device's own location service is switched on at all.
+    var deviceLocationEnabled: Bool?
+    /// Whether the aircraft's own return carried a position this run.
+    var aircraftReportedPosition: Bool?
+    /// Which way the aircraft is pointing, and where that came from.
+    ///
+    /// A heading-up map that will not turn has one of three causes and they need
+    /// different work: the device has no magnetometer, it has one and reports nothing, or
+    /// the map is not in the mode.
+    var headingSource: String?
+    /// Heading in degrees from true north, when one is known.
+    var headingDegrees: Double?
+    /// Whether this device can report which way it is pointing at all.
+    var deviceHeadingAvailable: Bool?
+    /// Which way the map is tied to the aircraft.
+    var followMode: String?
     /// First error the client reported, if any.
     var errorMessage: String?
 }
@@ -68,6 +91,11 @@ extension SituationEvidence {
     init(
         batch: DisplayBatch?,
         radioSource: RadioSourceSnapshot,
+        ownship: OwnshipFix?,
+        heading: HeadingFix?,
+        follow: FollowMode,
+        deviceLocationAuthorisation: DeviceLocationAuthorisation,
+        deviceLocationEnabled: Bool,
         replay: SituationReplayRun?,
         driverEnabled: Bool?,
         terrainArchiveAvailable: Bool,
@@ -112,6 +140,14 @@ extension SituationEvidence {
         replayTrackRecords = replay?.trackRecords
         replayWeatherRecords = replay?.weatherRecords
         replayRefusedRecords = replay?.refusedRecords
+        ownshipSource = ownship?.source.rawValue
+        self.deviceLocationAuthorisation = String(describing: deviceLocationAuthorisation)
+        self.deviceLocationEnabled = deviceLocationEnabled
+        aircraftReportedPosition = batch?.ownship != nil
+        headingSource = heading?.source.rawValue
+        headingDegrees = heading?.trueDegrees
+        deviceHeadingAvailable = DeviceHeadingProvider.available
+        followMode = String(describing: follow)
         self.errorMessage = errorMessage
     }
 

--- a/clients/apple-situation/App/SituationMenuView.swift
+++ b/clients/apple-situation/App/SituationMenuView.swift
@@ -96,6 +96,35 @@ struct SituationMenuView: View {
     }
 }
 
+/// The complete notice for every source the map draws.
+struct MapAttributionView: View {
+    let notices: [String]
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if notices.isEmpty {
+                    Text("The map is drawing no source that states a notice.")
+                        .foregroundStyle(.secondary)
+                }
+                ForEach(notices, id: \.self) { notice in
+                    Text(notice)
+                        .font(.footnote)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .navigationTitle("Map data")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
 /// States that the map is a recording and not the air around the aircraft.
 struct ReplayBannerView: View {
     let flight: Flight

--- a/clients/apple-situation/Packages/PilotageGeoJSONEdge/Package.swift
+++ b/clients/apple-situation/Packages/PilotageGeoJSONEdge/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Package.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import Foundation
 import PackageDescription
@@ -23,7 +23,7 @@ let mapLibrePackage = terrainRendererEnabled
 let package = Package(
     name: "PilotageMapLibreBinding",
     platforms: [
-        .iOS(.v18),
+        .iOS(.v26),
     ],
     products: [
         .library(name: "PilotageMapLibreBinding", targets: ["PilotageMapLibreBinding"]),

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationCamera.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationCamera.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Where the camera is pointing.
+///
+/// Heading and tilt are reported apart from the renderer so the controls that undo them do
+/// not have to import it. A reader who has turned or tilted the map needs one way back to
+/// north and one way back to straight down, and needs to see that there is something to
+/// undo.
+public struct SituationCamera: Equatable, Sendable {
+    /// Clockwise rotation of the map away from north, in degrees.
+    public let headingDegrees: Double
+    /// Angle away from straight down, in degrees.
+    public let pitchDegrees: Double
+
+    /// Create a camera reading.
+    public init(headingDegrees: Double, pitchDegrees: Double) {
+        self.headingDegrees = headingDegrees
+        self.pitchDegrees = pitchDegrees
+    }
+
+    /// Whether the map is turned far enough off north for a reader to notice.
+    ///
+    /// A fraction of a degree is a rounding artefact of a pinch, not a decision, and a
+    /// control that appears for one would flicker during an ordinary zoom.
+    public var isRotated: Bool { headingDegrees.magnitude > 0.5 && headingDegrees.magnitude < 359.5 }
+
+    /// Whether the map is tilted away from straight down.
+    public var isTilted: Bool { pitchDegrees > 0.5 }
+}

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
@@ -132,21 +132,41 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
         mapView.setCenter(coordinate, animated: animated)
     }
 
+    /// How long a turn or a tilt the reader asked for takes to land.
+    ///
+    /// The renderer's own default eases for long enough to read as lag on a control that
+    /// should feel like a switch.
+    private static let cameraMoveDuration: TimeInterval = 0.22
+
     /// Face the map along a direction, keeping position, zoom and tilt.
     public func setHeading(_ degrees: Double, animated: Bool = true) {
-        mapView.setDirection(degrees, animated: animated)
+        let camera = mapView.camera
+        camera.heading = degrees
+        move(to: camera, animated: animated)
     }
 
     /// Turn the map back to north, keeping everything else.
     public func resetHeading(animated: Bool = true) {
-        mapView.setDirection(0, animated: animated)
+        setHeading(0, animated: animated)
     }
 
     /// Look straight down, keeping heading and position.
     public func resetPitch(animated: Bool = true) {
         let camera = mapView.camera
         camera.pitch = 0
-        mapView.setCamera(camera, animated: animated)
+        move(to: camera, animated: animated)
+    }
+
+    private func move(to camera: MLNMapCamera, animated: Bool) {
+        guard animated else {
+            mapView.setCamera(camera, animated: false)
+            return
+        }
+        mapView.setCamera(
+            camera,
+            withDuration: Self.cameraMoveDuration,
+            animationTimingFunction: CAMediaTimingFunction(name: .easeOut)
+        )
     }
 
     /// Apply one complete display batch when the base style is ready.

--- a/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift
@@ -9,6 +9,19 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
     public var onOverlayError: ((Error) -> Void)?
     /// Receives the stable identity of a tapped display feature.
     public var onFeatureTapped: ((String) -> Void)?
+    /// Receives the camera angles whenever the reader moves the map.
+    ///
+    /// Heading and tilt are the two things a reader has to be able to undo. The controls
+    /// that undo them live in the application, so the application has to know the angles.
+    public var onCameraChanged: ((SituationCamera) -> Void)?
+    /// Receives this view once its style is loaded and its sources can be read.
+    public var onStyleLoaded: ((SituationMapView) -> Void)?
+    /// Reports that the reader moved the map with their hands.
+    ///
+    /// A map that is following the aircraft has to stop the moment a reader drags it, or
+    /// the map fights them and then snaps back. Only a gesture counts: a move the client
+    /// made itself is the following working.
+    public var onMovedByReader: (() -> Void)?
     /// Maps portable base-layer identities to base-style layer identities.
     public var baseLayerIdentifiers: [String: String] = [:]
 
@@ -49,8 +62,12 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
         super.init(frame: frame)
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.delegate = self
+        configureOrnaments()
         addSubview(mapView)
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
+        for recogniser in mapView.gestureRecognizers ?? [] {
+            recogniser.addTarget(self, action: #selector(handleMapGesture))
+        }
         NSLayoutConstraint.activate([
             mapView.leadingAnchor.constraint(equalTo: leadingAnchor),
             mapView.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -64,6 +81,74 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
         nil
     }
 
+    @objc private func handleMapGesture(_ recogniser: UIGestureRecognizer) {
+        guard recogniser.state == .began || recogniser.state == .changed else { return }
+        onMovedByReader?()
+    }
+
+    /// Decide which of the renderer's own controls stay on the map.
+    ///
+    /// The renderer's licence does not ask for its wordmark, and its own header says so, so
+    /// the map does not carry it. Its compass goes because the client draws heading itself:
+    /// track-up against north-up is a mode a pilot flies by, not an ornament.
+    ///
+    /// Its attribution control goes as well, and the notices do not. The sources each state
+    /// one and a licence is not satisfied by a control nobody opens; the client shows them
+    /// where a reader is already choosing what the map draws.
+    private func configureOrnaments() {
+        mapView.showsLogoView = false
+        mapView.showsCompassView = false
+        mapView.showsAttributionButton = false
+    }
+
+    /// The notice each source of this style asks to be shown.
+    ///
+    /// Read from the style rather than written twice, so a source added without its notice
+    /// cannot appear on the map.
+    public var sourceAttributions: [String] {
+        guard let sources = mapView.style?.sources else { return [] }
+        return sources
+            .compactMap { ($0 as? MLNTileSource)?.attributionInfos }
+            .flatMap { $0 }
+            .map { $0.title.string }
+            .reduce(into: [String]()) { unique, title in
+                let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty, !unique.contains(trimmed) {
+                    unique.append(trimmed)
+                }
+            }
+    }
+
+    /// Current camera angles.
+    public var camera: SituationCamera {
+        SituationCamera(
+            headingDegrees: mapView.direction,
+            pitchDegrees: mapView.camera.pitch
+        )
+    }
+
+    /// Put a coordinate in the middle of the map, keeping zoom, heading and tilt.
+    public func centre(on coordinate: CLLocationCoordinate2D, animated: Bool = true) {
+        mapView.setCenter(coordinate, animated: animated)
+    }
+
+    /// Face the map along a direction, keeping position, zoom and tilt.
+    public func setHeading(_ degrees: Double, animated: Bool = true) {
+        mapView.setDirection(degrees, animated: animated)
+    }
+
+    /// Turn the map back to north, keeping everything else.
+    public func resetHeading(animated: Bool = true) {
+        mapView.setDirection(0, animated: animated)
+    }
+
+    /// Look straight down, keeping heading and position.
+    public func resetPitch(animated: Bool = true) {
+        let camera = mapView.camera
+        camera.pitch = 0
+        mapView.setCamera(camera, animated: animated)
+    }
+
     /// Apply one complete display batch when the base style is ready.
     public func apply(_ batch: DisplayBatch) {
         pendingBatch = batch
@@ -74,6 +159,18 @@ public final class SituationMapView: UIView, @preconcurrency MLNMapViewDelegate 
     public func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
         applyInitialCamera()
         applyPendingBatch()
+        onCameraChanged?(camera)
+        onStyleLoaded?(self)
+    }
+
+    /// Report the camera after every move the reader makes.
+    public func mapView(_ mapView: MLNMapView, regionDidChangeAnimated animated: Bool) {
+        onCameraChanged?(camera)
+    }
+
+    /// Report the camera while the reader is still moving it, so a control tracks the drag.
+    public func mapViewRegionIsChanging(_ mapView: MLNMapView) {
+        onCameraChanged?(camera)
     }
 
     /// Place the camera once, and never against a pilot who has already moved it.

--- a/clients/apple-situation/Packages/PilotageMapLibreTerrain/Package.swift
+++ b/clients/apple-situation/Packages/PilotageMapLibreTerrain/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "PilotageMapLibreTerrain",
     platforms: [
-        .iOS(.v18),
+        .iOS(.v26),
     ],
     products: [
         .library(name: "MapLibre", targets: ["MapLibre"]),

--- a/clients/apple-situation/Packages/PilotageRadioSource/Package.swift
+++ b/clients/apple-situation/Packages/PilotageRadioSource/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "PilotageRadioSource",
     platforms: [
-        .iOS(.v18),
+        .iOS(.v26),
         .macOS(.v15),
     ],
     products: [

--- a/clients/apple-situation/Packages/PilotageSituationCore/Package.swift
+++ b/clients/apple-situation/Packages/PilotageSituationCore/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "PilotageSituationCore",
     platforms: [
-        .iOS(.v18),
+        .iOS(.v26),
         .macOS(.v15),
     ],
     products: [

--- a/clients/apple-situation/project.yml
+++ b/clients/apple-situation/project.yml
@@ -2,7 +2,7 @@ name: PilotageSituation
 options:
   bundleIdPrefix: org.luofang.pilotage
   deploymentTarget:
-    iOS: "18.4"
+    iOS: "26.0"
 settings:
   base:
     AERO_LINK_DRIVER_BUNDLE_IDENTIFIER: ${AERO_LINK_DRIVER_BUNDLE_IDENTIFIER}

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/records.rs
@@ -203,6 +203,33 @@ pub struct DisplayShape {
     pub snapshot_revision: u64,
 }
 
+/// Where the aircraft carrying this display is.
+#[derive(Clone, Copy, Debug, PartialEq, uniffi::Record)]
+pub struct DisplayOwnship {
+    /// Reported position.
+    pub coordinate: DisplayCoordinate,
+    /// Direction of travel over the ground in degrees from true north, when reported.
+    pub course_deg: Option<f64>,
+    /// Selected display altitude in feet.
+    pub altitude_ft: Option<i32>,
+    /// Producer instance identity.
+    pub producer_instance_id: u64,
+    /// Snapshot revision.
+    pub snapshot_revision: u64,
+}
+
+impl From<pilotage_presentation::OwnshipFeature> for DisplayOwnship {
+    fn from(value: pilotage_presentation::OwnshipFeature) -> Self {
+        Self {
+            coordinate: value.coordinate.into(),
+            course_deg: value.course_deg,
+            altitude_ft: value.altitude_ft,
+            producer_instance_id: value.producer_instance_id,
+            snapshot_revision: value.snapshot_revision,
+        }
+    }
+}
+
 /// One complete set of display values and styles.
 #[derive(Clone, Debug, PartialEq, uniffi::Record)]
 pub struct DisplayBatch {
@@ -224,6 +251,8 @@ pub struct DisplayBatch {
     pub traffic_details: Vec<DisplayTrafficDetail>,
     /// Products that had no display value.
     pub omitted_products: u64,
+    /// Where the aircraft is, when its own return has been heard.
+    pub ownship: Option<DisplayOwnship>,
 }
 
 /// Versioned domain records emitted for one radio operation.
@@ -259,6 +288,7 @@ impl From<pilotage_presentation::DisplayBatch> for DisplayBatch {
                 .collect(),
             traffic_details: value.traffic_details.into_iter().map(Into::into).collect(),
             omitted_products: value.omitted_products,
+            ownship: value.ownship.map(Into::into),
         }
     }
 }

--- a/crates/pilotage-presentation/src/lib.rs
+++ b/crates/pilotage-presentation/src/lib.rs
@@ -21,7 +21,7 @@ pub use layer::{
     WEATHER_REPORT_LAYER_ID,
 };
 pub use model::{
-    Color, Coordinate, CoordinateRing, DisplayBatch, PointChange, PointFeature, PointStyle,
-    ShapeFeature, ShapeStyle,
+    Color, Coordinate, CoordinateRing, DisplayBatch, OwnshipFeature, PointChange, PointFeature,
+    PointStyle, ShapeFeature, ShapeStyle,
 };
 pub use policy::PresentationAdapter;

--- a/crates/pilotage-presentation/src/model.rs
+++ b/crates/pilotage-presentation/src/model.rs
@@ -209,6 +209,26 @@ pub struct ShapeFeature {
     pub snapshot_revision: u64,
 }
 
+/// Where the aircraft carrying this display is.
+///
+/// The receiver hears the aircraft's own transmission, and the surveillance domain marks
+/// that return so it is not drawn as traffic beside itself. The position in it is still a
+/// position, and it is the one a display should centre on: it is where the aircraft is,
+/// which a tablet on the back seat is not.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OwnshipFeature {
+    /// Reported position.
+    pub coordinate: Coordinate,
+    /// Direction of travel over the ground, in degrees from true north, when reported.
+    pub course_deg: Option<f64>,
+    /// Selected display altitude in feet.
+    pub altitude_ft: Option<i32>,
+    /// Producer instance identity.
+    pub producer_instance_id: u64,
+    /// Snapshot revision.
+    pub snapshot_revision: u64,
+}
+
 /// One complete set of display values and its style catalog.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DisplayBatch {
@@ -230,6 +250,8 @@ pub struct DisplayBatch {
     pub traffic_details: Vec<crate::detail::TrafficDetail>,
     /// Supported domain products that had no display value.
     pub omitted_products: u64,
+    /// Where the aircraft is, when its own return has been heard.
+    pub ownship: Option<OwnshipFeature>,
 }
 
 impl DisplayBatch {

--- a/crates/pilotage-presentation/src/policy.rs
+++ b/crates/pilotage-presentation/src/policy.rs
@@ -10,7 +10,8 @@ use crate::layer::{
     WEATHER_REPORT_LAYER_ID,
 };
 use crate::{
-    Coordinate, DisplayBatch, PointChange, PointFeature, PointStyle, ShapeFeature, ShapeStyle,
+    Coordinate, DisplayBatch, OwnshipFeature, PointChange, PointFeature, PointStyle, ShapeFeature,
+    ShapeStyle,
 };
 
 pub(crate) const TRAFFIC_ACTIVE_STYLE: &str = "traffic-active";
@@ -38,6 +39,7 @@ pub struct PresentationAdapter {
     traffic_tracks: BTreeMap<(u64, u64), TrackSnapshotHandle>,
     weather_points: BTreeMap<String, PointFeature>,
     weather_shapes: BTreeMap<String, ShapeFeature>,
+    ownship: Option<OwnshipFeature>,
     now_micros: u64,
 }
 
@@ -65,6 +67,7 @@ impl PresentationAdapter {
             positionless_traffic: Vec::new(),
             traffic_details: Vec::new(),
             omitted_products: 0,
+            ownship: self.ownship,
         }
     }
 
@@ -232,6 +235,7 @@ impl PresentationAdapter {
         self.traffic_tracks.clear();
         self.weather_points.clear();
         self.weather_shapes.clear();
+        self.ownship = None;
     }
 
     /// Convert current traffic and weather values into one batch.
@@ -289,7 +293,10 @@ impl PresentationAdapter {
                     .now_micros
                     .max(handle.snapshot().last_observed_at_micros);
                 if handle.snapshot().ownship_shadow {
+                    // The aircraft's own return is not traffic, and it is not nothing
+                    // either: it carries where the aircraft is.
                     self.traffic_tracks.remove(&key);
+                    self.ownship = ownship_feature(handle);
                 } else {
                     self.traffic_tracks.insert(key, handle.clone());
                 }
@@ -333,6 +340,31 @@ impl PresentationAdapter {
             }
         }
     }
+}
+
+/// Read where the aircraft is from its own return.
+///
+/// A return with no position says the aircraft was heard and not where it was, so it
+/// yields nothing rather than a coordinate the track never carried.
+fn ownship_feature(handle: &surveillance_core::TrackSnapshotHandle) -> Option<OwnshipFeature> {
+    let snapshot = handle.snapshot();
+    let position = snapshot.position.as_ref()?;
+    let coordinate =
+        Coordinate::checked(position.value.latitude_deg, position.value.longitude_deg)?;
+    Some(OwnshipFeature {
+        coordinate,
+        course_deg: snapshot
+            .velocity
+            .as_ref()
+            .and_then(|value| value.value.track_angle_deg_true),
+        altitude_ft: snapshot
+            .pressure_altitude_ft
+            .as_ref()
+            .map(|field| field.value)
+            .or_else(|| snapshot.geometric_altitude_ft.as_ref().map(|f| f.value)),
+        producer_instance_id: handle.producer_instance_id().get(),
+        snapshot_revision: handle.snapshot_revision().get(),
+    })
 }
 
 fn point_styles() -> Vec<PointStyle> {

--- a/crates/pilotage-presentation/src/tests.rs
+++ b/crates/pilotage-presentation/src/tests.rs
@@ -2,6 +2,7 @@
 
 mod advisory;
 mod layer;
+mod ownship;
 mod traffic;
 mod vertical;
 mod weather;

--- a/crates/pilotage-presentation/src/tests/ownship.rs
+++ b/crates/pilotage-presentation/src/tests/ownship.rs
@@ -1,0 +1,60 @@
+use surveillance_core::{ProducerInstanceId, SnapshotRevision, TrackDelta, TrackSnapshotHandle};
+
+use crate::PresentationAdapter;
+
+use super::traffic::complete_track;
+
+#[test]
+fn the_aircraft_own_return_becomes_a_position_and_not_traffic() {
+    // The receiver hears the aircraft's own transmission. Drawing it as traffic would put
+    // a target on top of the aircraft; throwing it away loses the one position the client
+    // can be sure belongs to this aircraft.
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+
+    let batch = adapter.adapt();
+
+    assert!(batch.points.is_empty(), "the aircraft is not traffic");
+    let ownship = batch
+        .ownship
+        .expect("the aircraft's own return carries a position");
+    assert!((ownship.coordinate.latitude_deg - 42.3656).abs() < 1e-9);
+    assert!((ownship.coordinate.longitude_deg + 71.0096).abs() < 1e-9);
+}
+
+#[test]
+fn an_own_return_with_no_position_reports_none() {
+    // Heard is not located. A coordinate invented here would be drawn as the aircraft.
+    let mut adapter = PresentationAdapter::new();
+    let mut track = complete_track(42);
+    track.position = None;
+    track.ownship_shadow = true;
+    adapter.apply_traffic_delta(&TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(3),
+        track,
+    )));
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+#[test]
+fn clearing_radio_state_forgets_where_the_aircraft_was() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+    assert!(adapter.adapt().ownship.is_some());
+
+    adapter.clear_radio_state();
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+fn ownship_delta(id: u64, revision: u64) -> TrackDelta {
+    let mut track = complete_track(id);
+    track.ownship_shadow = true;
+    TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(revision),
+        track,
+    ))
+}

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -283,7 +283,7 @@ fn track_handle(
     )
 }
 
-fn complete_track(id: u64) -> TrackSnapshot {
+pub(super) fn complete_track(id: u64) -> TrackSnapshot {
     let mut track = TrackSnapshot::new(TrackId::new(id), track_key(id), 10);
     track.position = Some(radio_timed(Wgs84Position {
         latitude_deg: 42.3656,
@@ -441,61 +441,6 @@ fn delta_with_altitude(id: u64, revision: u64, pressure_altitude_ft: Option<i32>
     let mut track = complete_track(id);
     track.pressure_altitude_ft = pressure_altitude_ft.map(radio_timed);
     track.geometric_altitude_ft = None;
-    TrackDelta::Updated(TrackSnapshotHandle::new(
-        ProducerInstanceId::new(7),
-        SnapshotRevision::new(revision),
-        track,
-    ))
-}
-
-#[test]
-fn the_aircraft_own_return_becomes_a_position_and_not_traffic() {
-    // The receiver hears the aircraft's own transmission. Drawing it as traffic would put
-    // a target on top of the aircraft; throwing it away loses the one position the client
-    // can be sure belongs to this aircraft.
-    let mut adapter = PresentationAdapter::new();
-    adapter.apply_traffic_delta(&ownship_delta(42, 3));
-
-    let batch = adapter.adapt();
-
-    assert!(batch.points.is_empty(), "the aircraft is not traffic");
-    let ownship = batch
-        .ownship
-        .expect("the aircraft's own return carries a position");
-    assert!((ownship.coordinate.latitude_deg - 42.3656).abs() < 1e-9);
-    assert!((ownship.coordinate.longitude_deg + 71.0096).abs() < 1e-9);
-}
-
-#[test]
-fn an_own_return_with_no_position_reports_none() {
-    // Heard is not located. A coordinate invented here would be drawn as the aircraft.
-    let mut adapter = PresentationAdapter::new();
-    let mut track = complete_track(42);
-    track.position = None;
-    track.ownship_shadow = true;
-    adapter.apply_traffic_delta(&TrackDelta::Updated(TrackSnapshotHandle::new(
-        ProducerInstanceId::new(7),
-        SnapshotRevision::new(3),
-        track,
-    )));
-
-    assert!(adapter.adapt().ownship.is_none());
-}
-
-#[test]
-fn clearing_radio_state_forgets_where_the_aircraft_was() {
-    let mut adapter = PresentationAdapter::new();
-    adapter.apply_traffic_delta(&ownship_delta(42, 3));
-    assert!(adapter.adapt().ownship.is_some());
-
-    adapter.clear_radio_state();
-
-    assert!(adapter.adapt().ownship.is_none());
-}
-
-fn ownship_delta(id: u64, revision: u64) -> TrackDelta {
-    let mut track = complete_track(id);
-    track.ownship_shadow = true;
     TrackDelta::Updated(TrackSnapshotHandle::new(
         ProducerInstanceId::new(7),
         SnapshotRevision::new(revision),

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -447,3 +447,58 @@ fn delta_with_altitude(id: u64, revision: u64, pressure_altitude_ft: Option<i32>
         track,
     ))
 }
+
+#[test]
+fn the_aircraft_own_return_becomes_a_position_and_not_traffic() {
+    // The receiver hears the aircraft's own transmission. Drawing it as traffic would put
+    // a target on top of the aircraft; throwing it away loses the one position the client
+    // can be sure belongs to this aircraft.
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+
+    let batch = adapter.adapt();
+
+    assert!(batch.points.is_empty(), "the aircraft is not traffic");
+    let ownship = batch
+        .ownship
+        .expect("the aircraft's own return carries a position");
+    assert!((ownship.coordinate.latitude_deg - 42.3656).abs() < 1e-9);
+    assert!((ownship.coordinate.longitude_deg + 71.0096).abs() < 1e-9);
+}
+
+#[test]
+fn an_own_return_with_no_position_reports_none() {
+    // Heard is not located. A coordinate invented here would be drawn as the aircraft.
+    let mut adapter = PresentationAdapter::new();
+    let mut track = complete_track(42);
+    track.position = None;
+    track.ownship_shadow = true;
+    adapter.apply_traffic_delta(&TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(3),
+        track,
+    )));
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+#[test]
+fn clearing_radio_state_forgets_where_the_aircraft_was() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+    assert!(adapter.adapt().ownship.is_some());
+
+    adapter.clear_radio_state();
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+fn ownship_delta(id: u64, revision: u64) -> TrackDelta {
+    let mut track = complete_track(id);
+    track.ownship_shadow = true;
+    TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(revision),
+        track,
+    ))
+}


### PR DESCRIPTION
Three controls the renderer draws by default were deciding what the corners of an aviation
display say, and the client was drawing its own material to match them.

The wordmark goes. The renderer's licence does not ask for it and its own header says so.

The renderer's compass goes, and the client draws heading itself. Track-up against north-up
is a mode a pilot flies by rather than an ornament, and a small image answers neither
"which way am I facing" nor "how do I get back".

The renderer's attribution control goes too, and the notices do not. A licence is not
satisfied by a control nobody opens. Every source of the loaded style is read for what it
asks to be shown, and the credit sits under the switches that choose what the map draws,
where a reader already is, with the full text one tap away. Reading it from the style
rather than writing it twice means a source added without its notice cannot appear.

In place of all that the top right carries only what undoes what a reader did. A compass
appears when the map is turned off north and returns it; a level control appears when the
map is tilted and looks straight down again. Each is absent when there is nothing to undo,
because a control that does nothing teaches a reader to ignore the corner that says the map
is no longer oriented the way they assume. The compass names the direction as well as
drawing it, and the dial turns under an upright letter, since a letter read at an angle is
not read.

The menu moves to the bottom right. A map is worked with two thumbs on the lower corners,
and the menu at the top right sat under the compass.

Every control now takes the system button style instead of hand-drawn material, so the
chrome follows the platform rather than carrying a copy of one release's look. That needs
the platform: the client floor moves to iOS 26.

Camera angles leave the binding as a value, so the controls that undo them do not import
the renderer.

The arrow that centres on the aircraft is not here. There is no position to centre on yet.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #412
- <kbd>&nbsp;3&nbsp;</kbd> #411
- <kbd>&nbsp;2&nbsp;</kbd> #410
- <kbd>&nbsp;1&nbsp;</kbd> #407 👈 
<!-- GitButler Footer Boundary Bottom -->