### PR TITLE
Align the standalone Apple FFI lint boundary

### DIFF
--- a/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml
@@ -56,11 +56,12 @@ tempfile = "3.23.0"
 
 [workspace.lints.rust]
 missing_docs = "deny"
-unsafe_code = "deny"
+unsafe_code = "forbid"
 
 [workspace.lints.clippy]
 await_holding_lock = "deny"
 dbg_macro = "deny"
+disallowed_types = "deny"
 expect_used = "deny"
 let_underscore_future = "deny"
 let_underscore_must_use = "deny"

--- a/clients/apple-situation/rust/pilotage-situation-ffi/clippy.toml
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/clippy.toml
@@ -1,5 +1,9 @@
 # UniFFI expands error derives through anyhow internally. The hand-written
 # facade uses typed thiserror variants and does not expose anyhow types.
+disallowed-types = [
+    { path = "anyhow::Error", reason = "typed errors only in this workspace; use thiserror enums" },
+]
+
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true

--- a/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs
+++ b/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs
@@ -3,8 +3,12 @@
 //! This standalone crate links the Surveillance and Airmass domain crates.
 //! Generated bindings and binary artifacts stay outside the source tree.
 
+// UniFFI derive output uses a dynamic error.
+#[allow(clippy::disallowed_types)]
 mod error;
 mod reception;
+// UniFFI derive output uses a dynamic error.
+#[allow(clippy::disallowed_types)]
 mod records;
 mod session;
 

--- a/scripts/check-apple-situation-client.sh
+++ b/scripts/check-apple-situation-client.sh
@@ -12,6 +12,10 @@ terrain_revision_file="$client/MAPLIBRE_TERRAIN_REVISION"
 terrain_build="$client/scripts/build-maplibre-terrain.sh"
 geojson_edge="$client/Packages/PilotageGeoJSONEdge/Sources/PilotageGeoJSONEdge/FeatureCollection.swift"
 map_overlay="$client/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationOverlay.swift"
+ffi="$client/rust/pilotage-situation-ffi"
+ffi_manifest="$ffi/Cargo.toml"
+ffi_clippy_config="$ffi/clippy.toml"
+ffi_lib="$ffi/src/lib.rs"
 status=0
 
 require_pattern() {
@@ -47,10 +51,60 @@ check_revision() {
         "$name and the Apple job checkout must match"
 }
 
+check_ffi_lint_scope() {
+    local lint_exemption unexpected_exemptions
+    lint_exemption='#[allow(clippy::disallowed_types)]'
+    if ! awk -v expected="$lint_exemption" '
+        $0 == expected {
+            if ((getline module_line) <= 0) {
+                bad = 1
+                next
+            }
+            if (module_line == "mod error;" || module_line == "mod records;") {
+                seen[module_line]++
+            } else {
+                bad = 1
+            }
+            next
+        }
+        /clippy::disallowed_types/ { bad = 1 }
+        END {
+            if (seen["mod error;"] != 1 || seen["mod records;"] != 1) {
+                bad = 1
+            }
+            exit bad
+        }
+    ' "$ffi_lib"; then
+        echo "FORBIDDEN: the UniFFI lint exemption must apply only to the error and record modules" >&2
+        status=1
+    fi
+    unexpected_exemptions=$(grep -RInF 'clippy::disallowed_types' "$ffi/src" \
+        | grep -vF "$ffi_lib:" || true)
+    if [ -n "$unexpected_exemptions" ]; then
+        echo "FORBIDDEN: no other FFI source module can allow disallowed types" >&2
+        status=1
+    fi
+    if grep -RIn 'anyhow' "$ffi/src" >/dev/null; then
+        echo "FORBIDDEN: the FFI source must not name anyhow" >&2
+        status=1
+    fi
+    if grep -In 'anyhow' "$ffi_manifest" >/dev/null; then
+        echo "FORBIDDEN: the standalone FFI crate must not depend on anyhow" >&2
+        status=1
+    fi
+}
+
 check_revision "$client/AERO_LINK_REVISION" AERO_LINK_REVISION
 check_revision "$client/AIRMASS_REVISION" AIRMASS_REVISION
 check_revision "$client/SURVEILLANCE_REVISION" SURVEILLANCE_REVISION
 
+require_fixed 'unsafe_code = "forbid"' "$ffi_manifest" \
+    "the standalone FFI crate must forbid unsafe code"
+require_fixed 'disallowed_types = "deny"' "$ffi_manifest" \
+    "the standalone FFI crate must deny disallowed types"
+require_fixed 'path = "anyhow::Error"' "$ffi_clippy_config" \
+    "the standalone FFI crate must disallow anyhow errors"
+check_ffi_lint_scope
 require_pattern 'exact: "6\.28\.0"' \
     "$maplibre_manifest" \
     "the MapLibre Native package must use the reviewed exact version"
@@ -149,7 +203,6 @@ require_pattern 'SURVEILLANCE_SOURCE.*external/Surveillance' \
 runtime="$client/App/AeroLinkRadioRuntime.swift"
 model="$client/App/SituationClientModel.swift"
 radio_app="$client/App"
-ffi="$client/rust/pilotage-situation-ffi"
 if [ "$(grep -Rhc 'ALDriverDiscovery()' "$radio_app"/*.swift | awk '{ total += $1 } END { print total + 0 }')" -ne 1 ]; then
     echo "FORBIDDEN: the host process must create one ALDriverDiscovery" >&2
     status=1

--- a/scripts/test-check-apple-situation-client.sh
+++ b/scripts/test-check-apple-situation-client.sh
@@ -55,9 +55,66 @@ cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs" \
 cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/reception/traffic.rs" \
     "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/reception/weather.rs" \
     "$client_fixture/rust/pilotage-situation-ffi/src/reception/"
+cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml" \
+    "$root/clients/apple-situation/rust/pilotage-situation-ffi/clippy.toml" \
+    "$client_fixture/rust/pilotage-situation-ffi/"
 cp "$root/scripts/check-apple-situation-client.sh" "$fixture/scripts/"
 
 bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null
+
+sed -i.bak 's/unsafe_code = "forbid"/unsafe_code = "deny"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/Cargo.toml"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted an unsafe-code lint downgrade" >&2
+    exit 1
+fi
+sed -i.bak 's/unsafe_code = "deny"/unsafe_code = "forbid"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/Cargo.toml"
+
+sed -i.bak 's/disallowed_types = "deny"/disallowed_types = "warn"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/Cargo.toml"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted a disallowed-type lint downgrade" >&2
+    exit 1
+fi
+sed -i.bak 's/disallowed_types = "warn"/disallowed_types = "deny"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/Cargo.toml"
+
+sed -i.bak 's/path = "anyhow::Error"/path = "removed::Error"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/clippy.toml"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted the anyhow-error type" >&2
+    exit 1
+fi
+sed -i.bak 's/path = "removed::Error"/path = "anyhow::Error"/' \
+    "$client_fixture/rust/pilotage-situation-ffi/clippy.toml"
+
+sed -i.bak 's/^#\[allow(clippy::disallowed_types/#![allow(clippy::disallowed_types/' \
+    "$client_fixture/rust/pilotage-situation-ffi/src/lib.rs"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted a crate-wide UniFFI lint exemption" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs" \
+    "$client_fixture/rust/pilotage-situation-ffi/src/"
+
+printf '%s\n' 'pub type DynamicError = uniffi::__anyhow::Error;' \
+    >> "$client_fixture/rust/pilotage-situation-ffi/src/lib.rs"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted anyhow in FFI source" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/src/lib.rs" \
+    "$client_fixture/rust/pilotage-situation-ffi/src/"
+
+printf '%s\n' 'anyhow = "1"' \
+    >> "$client_fixture/rust/pilotage-situation-ffi/Cargo.toml"
+if bash "$fixture/scripts/check-apple-situation-client.sh" "$fixture" >/dev/null 2>&1; then
+    echo "the Apple situation client guard accepted an anyhow dependency" >&2
+    exit 1
+fi
+cp "$root/clients/apple-situation/rust/pilotage-situation-ffi/Cargo.toml" \
+    "$client_fixture/rust/pilotage-situation-ffi/"
 
 sed -i.bak 's/linkedLibrary("sqlite3")/linkedLibrary("removed-sqlite3")/' \
     "$fixture/clients/apple-situation/Packages/PilotageSituationCore/Package.swift"


### PR DESCRIPTION
Make the standalone Rust manifest forbid unsafe code and deny disallowed types. Add anyhow::Error to the standalone Clippy type ban.

UniFFI derives use an internal dynamic error. Scope that generated-code exemption to the error and record modules. Extend the Apple guard to reject a crate-wide exemption, any other module exemption, any anyhow token in FFI source, and any anyhow dependency. Add negative fixtures for each lint boundary.

Verification:
- standalone cargo fmt, Clippy, tests, strict docs, and release build
- root cargo fmt, Clippy, full tests, strict docs, and release build
- Apple guard and self-test
- production lint, counter, and structure guards

Closes #403