### PR TITLE
Give the aircraft own return its own test module

### DIFF
--- a/crates/pilotage-presentation/src/tests.rs
+++ b/crates/pilotage-presentation/src/tests.rs
@@ -2,6 +2,7 @@
 
 mod advisory;
 mod layer;
+mod ownship;
 mod traffic;
 mod vertical;
 mod weather;

--- a/crates/pilotage-presentation/src/tests/ownship.rs
+++ b/crates/pilotage-presentation/src/tests/ownship.rs
@@ -1,0 +1,60 @@
+use surveillance_core::{ProducerInstanceId, SnapshotRevision, TrackDelta, TrackSnapshotHandle};
+
+use crate::PresentationAdapter;
+
+use super::traffic::complete_track;
+
+#[test]
+fn the_aircraft_own_return_becomes_a_position_and_not_traffic() {
+    // The receiver hears the aircraft's own transmission. Drawing it as traffic would put
+    // a target on top of the aircraft; throwing it away loses the one position the client
+    // can be sure belongs to this aircraft.
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+
+    let batch = adapter.adapt();
+
+    assert!(batch.points.is_empty(), "the aircraft is not traffic");
+    let ownship = batch
+        .ownship
+        .expect("the aircraft's own return carries a position");
+    assert!((ownship.coordinate.latitude_deg - 42.3656).abs() < 1e-9);
+    assert!((ownship.coordinate.longitude_deg + 71.0096).abs() < 1e-9);
+}
+
+#[test]
+fn an_own_return_with_no_position_reports_none() {
+    // Heard is not located. A coordinate invented here would be drawn as the aircraft.
+    let mut adapter = PresentationAdapter::new();
+    let mut track = complete_track(42);
+    track.position = None;
+    track.ownship_shadow = true;
+    adapter.apply_traffic_delta(&TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(3),
+        track,
+    )));
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+#[test]
+fn clearing_radio_state_forgets_where_the_aircraft_was() {
+    let mut adapter = PresentationAdapter::new();
+    adapter.apply_traffic_delta(&ownship_delta(42, 3));
+    assert!(adapter.adapt().ownship.is_some());
+
+    adapter.clear_radio_state();
+
+    assert!(adapter.adapt().ownship.is_none());
+}
+
+fn ownship_delta(id: u64, revision: u64) -> TrackDelta {
+    let mut track = complete_track(id);
+    track.ownship_shadow = true;
+    TrackDelta::Updated(TrackSnapshotHandle::new(
+        ProducerInstanceId::new(7),
+        SnapshotRevision::new(revision),
+        track,
+    ))
+}

--- a/crates/pilotage-presentation/src/tests/traffic.rs
+++ b/crates/pilotage-presentation/src/tests/traffic.rs
@@ -283,7 +283,7 @@ fn track_handle(
     )
 }
 
-fn complete_track(id: u64) -> TrackSnapshot {
+pub(super) fn complete_track(id: u64) -> TrackSnapshot {
     let mut track = TrackSnapshot::new(TrackId::new(id), track_key(id), 10);
     track.position = Some(radio_timed(Wgs84Position {
         latitude_deg: 42.3656,
@@ -441,61 +441,6 @@ fn delta_with_altitude(id: u64, revision: u64, pressure_altitude_ft: Option<i32>
     let mut track = complete_track(id);
     track.pressure_altitude_ft = pressure_altitude_ft.map(radio_timed);
     track.geometric_altitude_ft = None;
-    TrackDelta::Updated(TrackSnapshotHandle::new(
-        ProducerInstanceId::new(7),
-        SnapshotRevision::new(revision),
-        track,
-    ))
-}
-
-#[test]
-fn the_aircraft_own_return_becomes_a_position_and_not_traffic() {
-    // The receiver hears the aircraft's own transmission. Drawing it as traffic would put
-    // a target on top of the aircraft; throwing it away loses the one position the client
-    // can be sure belongs to this aircraft.
-    let mut adapter = PresentationAdapter::new();
-    adapter.apply_traffic_delta(&ownship_delta(42, 3));
-
-    let batch = adapter.adapt();
-
-    assert!(batch.points.is_empty(), "the aircraft is not traffic");
-    let ownship = batch
-        .ownship
-        .expect("the aircraft's own return carries a position");
-    assert!((ownship.coordinate.latitude_deg - 42.3656).abs() < 1e-9);
-    assert!((ownship.coordinate.longitude_deg + 71.0096).abs() < 1e-9);
-}
-
-#[test]
-fn an_own_return_with_no_position_reports_none() {
-    // Heard is not located. A coordinate invented here would be drawn as the aircraft.
-    let mut adapter = PresentationAdapter::new();
-    let mut track = complete_track(42);
-    track.position = None;
-    track.ownship_shadow = true;
-    adapter.apply_traffic_delta(&TrackDelta::Updated(TrackSnapshotHandle::new(
-        ProducerInstanceId::new(7),
-        SnapshotRevision::new(3),
-        track,
-    )));
-
-    assert!(adapter.adapt().ownship.is_none());
-}
-
-#[test]
-fn clearing_radio_state_forgets_where_the_aircraft_was() {
-    let mut adapter = PresentationAdapter::new();
-    adapter.apply_traffic_delta(&ownship_delta(42, 3));
-    assert!(adapter.adapt().ownship.is_some());
-
-    adapter.clear_radio_state();
-
-    assert!(adapter.adapt().ownship.is_none());
-}
-
-fn ownship_delta(id: u64, revision: u64) -> TrackDelta {
-    let mut track = complete_track(id);
-    track.ownship_shadow = true;
     TrackDelta::Updated(TrackSnapshotHandle::new(
         ProducerInstanceId::new(7),
         SnapshotRevision::new(revision),


### PR DESCRIPTION
The traffic tests crossed the file size limit, and the tests that cross it prove
the opposite of what the file is named for: that the aircraft own return is a
position and not a target. They read better beside that claim.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #412
- <kbd>&nbsp;3&nbsp;</kbd> #411
- <kbd>&nbsp;2&nbsp;</kbd> #410 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #407
<!-- GitButler Footer Boundary Bottom -->