### PR TITLE
Connect every ownship seam to a caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: situation layer controls
         run: bash scripts/check-situation-layer-controls.sh
 
+      - name: situation ownship wiring self-test
+        run: bash scripts/test-check-situation-ownship-wiring.sh
+
+      - name: situation ownship wiring
+        run: bash scripts/check-situation-ownship-wiring.sh
+
       - name: Apple situation client guard self-test
         run: bash scripts/test-check-apple-situation-client.sh
 

--- a/clients/apple-situation/App/OwnshipPosition.swift
+++ b/clients/apple-situation/App/OwnshipPosition.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 import Foundation
+import UIKit
 import PilotageSituationCore
 
 /// Where a position for the aircraft came from.
@@ -61,6 +62,15 @@ final class DeviceLocationProvider: NSObject, CLLocationManagerDelegate {
     var onFix: ((OwnshipFix) -> Void)?
     /// Receives the reader's answer to the permission request.
     var onAuthorisation: ((DeviceLocationAuthorisation) -> Void)?
+
+    /// What the platform answers right now, without waiting to be told.
+    ///
+    /// The published copy of this is only filled once the provider has been started, so a
+    /// decision about whether to start cannot be made from it without asking the question
+    /// the answer depends on.
+    var authorisation: DeviceLocationAuthorisation {
+        Self.reading(manager.authorizationStatus)
+    }
 
     private let manager = CLLocationManager()
     private var isRunning = false
@@ -136,13 +146,15 @@ final class DeviceLocationProvider: NSObject, CLLocationManagerDelegate {
     }
 
     private func report(_ status: CLAuthorizationStatus) {
+        onAuthorisation?(Self.reading(status))
+    }
+
+    /// Read one platform answer, in one place, so the pushed and the pulled answer agree.
+    private static func reading(_ status: CLAuthorizationStatus) -> DeviceLocationAuthorisation {
         switch status {
-        case .notDetermined:
-            onAuthorisation?(.undetermined)
-        case .authorizedWhenInUse, .authorizedAlways:
-            onAuthorisation?(.granted)
-        default:
-            onAuthorisation?(.denied)
+        case .notDetermined: .undetermined
+        case .authorizedWhenInUse, .authorizedAlways: .granted
+        default: .denied
         }
     }
 }
@@ -179,6 +191,13 @@ final class OwnshipModel: ObservableObject {
     /// Which way the aircraft is pointing, from the best source that has an answer.
     @Published private(set) var heading: HeadingFix?
 
+    /// How closely the map is tied to the aircraft.
+    ///
+    /// Held here rather than in the view because a closure that reads it outlives the
+    /// view value that created it, and a captured view value holds the mode as it was
+    /// when the closure was made rather than as it is when the closure runs.
+    @Published var follow: FollowMode = .idle
+
     private let device = DeviceLocationProvider()
     private let compass = DeviceHeadingProvider()
     private var deviceFix: OwnshipFix?
@@ -193,6 +212,9 @@ final class OwnshipModel: ObservableObject {
         }
         device.onAuthorisation = { [weak self] authorisation in
             self?.deviceAuthorisation = authorisation
+            // Permission granted part way through a run is the same situation as
+            // permission held at the start of one.
+            self?.startIfPermitted()
         }
         compass.onHeading = { [weak self] heading in
             self?.deviceHeading = heading
@@ -226,10 +248,26 @@ final class OwnshipModel: ObservableObject {
         compass.start()
     }
 
+    /// Take the orientation again, because a tablet is turned while it is being read.
+    func refreshOrientation() {
+        compass.refreshOrientation()
+    }
+
     /// Stop asking.
     func stop() {
         device.stop()
         compass.stop()
+    }
+
+    /// Start locating when the reader has already agreed to it.
+    ///
+    /// A reader who granted permission on an earlier run has not withdrawn it by closing
+    /// the application. Waiting for a press before asking the sensors anything means the
+    /// first press reports no position and no heading, and the control appears broken at
+    /// exactly the moment it is first used.
+    func startIfPermitted() {
+        guard device.authorisation == .granted else { return }
+        start()
     }
 
     /// Ask for permission if it has not been asked for, and start locating.
@@ -237,7 +275,7 @@ final class OwnshipModel: ObservableObject {
     /// A reader pressing the control is the request. The map follows as soon as there is
     /// a position, which may be after the reader answers a prompt.
     func requestPositionIfNeeded() {
-        device.start()
+        start()
     }
 
     /// Take a position reported by the aircraft over the radio link.
@@ -355,6 +393,7 @@ final class DeviceHeadingProvider: NSObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
     private var isRunning = false
 
+
     /// Whether this device can report which way it is pointing.
     nonisolated static var available: Bool { CLLocationManager.headingAvailable() }
 
@@ -362,19 +401,65 @@ final class DeviceHeadingProvider: NSObject, CLLocationManagerDelegate {
         super.init()
         manager.delegate = self
         // A degree of filtering keeps a map from shivering while the aircraft holds course.
-        manager.headingFilter = 1
-        manager.headingOrientation = .portrait
+        manager.headingFilter = 3
+        // A tablet flown in landscape reads ninety degrees off if the platform is told it
+        // is upright, and the reading is plausible enough that nobody notices it is wrong.
+        applyOrientation()
+    }
+
+    /// Take the orientation again, because a tablet is turned while it is being read.
+    func refreshOrientation() {
+        applyOrientation()
+    }
+
+    /// Tell the platform which way the tablet is being held.
+    ///
+    /// The interface orientation rather than the device orientation, because the device
+    /// answers `unknown` until it has been moved, and a tablet started flat on a table in
+    /// landscape would be told it is upright and read ninety degrees off.
+    private func applyOrientation() {
+        // Landscape is named from opposite ends by the two enumerations: turning the
+        // tablet left turns the content right, so the platform's interface orientation and
+        // the location service's device orientation swap the two. Passing one straight
+        // through as the other reads a hundred and eighty degrees off.
+        manager.headingOrientation = switch Self.interfaceOrientation {
+        case .landscapeLeft: .landscapeRight
+        case .landscapeRight: .landscapeLeft
+        case .portraitUpsideDown: .portraitUpsideDown
+        default: .portrait
+        }
+    }
+
+    /// Which way the window is drawn, which is which way the reader holds the tablet.
+    private static var interfaceOrientation: UIInterfaceOrientation {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?
+            .interfaceOrientation ?? .portrait
     }
 
     func start() {
         guard Self.available, !isRunning else { return }
         isRunning = true
+        applyOrientation()
         manager.startUpdatingHeading()
     }
 
     func stop() {
         isRunning = false
         manager.stopUpdatingHeading()
+    }
+
+    /// Let the platform ask the reader to swing the tablet through a figure of eight.
+    ///
+    /// A magnetometer near a keyboard cover or a metal panel reports a negative accuracy,
+    /// which is the platform saying it does not know which way it is pointing. Refusing
+    /// the prompt leaves a compass that is present, started, and permanently silent, with
+    /// nothing on screen to say why.
+    nonisolated func locationManagerShouldDisplayHeadingCalibration(
+        _ manager: CLLocationManager
+    ) -> Bool {
+        true
     }
 
     nonisolated func locationManager(

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -18,7 +18,6 @@ private struct SituationContentView: View {
     @State private var menuPresented = false
     @State private var camera = SituationCamera(headingDegrees: 0, pitchDegrees: 0)
     @State private var mapCommands: SituationMapCommands?
-    @State private var follow: FollowMode = .idle
     @State private var modesPresented = false
     @State private var selectedMapModeID = MapMode.available.first?.id ?? "terrain"
     @Namespace private var mapControlNamespace
@@ -40,7 +39,7 @@ private struct SituationContentView: View {
                 onMovedByReader: {
                     // A hand on the map ends both the following and the panel: the reader
                     // has said what they want to look at.
-                    follow = .idle
+                    ownship.follow = .idle
                     modesPresented = false
                 }
             )
@@ -56,7 +55,7 @@ private struct SituationContentView: View {
                     camera: camera,
                     ownship: ownship.fix,
                     canLocate: ownship.canLocate,
-                    follow: follow,
+                    follow: ownship.follow,
                     namespace: mapControlNamespace,
                     resetHeading: { mapCommands?.resetHeading() },
                     resetPitch: { mapCommands?.resetPitch() },
@@ -83,6 +82,41 @@ private struct SituationContentView: View {
                     .mapControlPlacement(.bottomTrailing)
             }
         }
+        .task {
+            // The controls report what they are doing through the model, so a run can be
+            // read from the file it leaves rather than from the screen.
+            model.currentOwnship = { [ownship] in
+                (
+                    ownship.fix,
+                    ownship.heading,
+                    ownship.follow,
+                    ownship.deviceAuthorisation,
+                    ownship.deviceLocationEnabled
+                )
+            }
+            model.onOwnship = { [ownship] reported in
+                ownship.observeAircraft(reported.map(OwnshipFix.init))
+            }
+            ownship.startIfPermitted()
+            model.refreshEvidence()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: UIDevice.orientationDidChangeNotification
+            )
+        ) { _ in
+            ownship.refreshOrientation()
+        }
+        // Following is a mode, not a jump: the camera keeps up as the aircraft moves,
+        // without the ease a press gets, because a course correction eased on every
+        // reading leaves the map permanently behind the aircraft.
+        .onChange(of: ownship.fix) { _, _ in applyFollow(animated: false) }
+        .onChange(of: ownship.heading) { _, _ in applyFollow(animated: false) }
+        .onChange(of: ownship.follow) { _, _ in model.refreshEvidence() }
+        // The file records what changed about the answer, not every degree of it.
+        .onChange(of: ownship.heading?.source) { _, _ in model.refreshEvidence() }
+        .onChange(of: ownship.fix == nil) { _, _ in model.refreshEvidence() }
+        .onChange(of: ownship.deviceAuthorisation) { _, _ in model.refreshEvidence() }
         .sheet(isPresented: $menuPresented) {
             SituationMenuView(model: model)
         }
@@ -111,23 +145,25 @@ private extension SituationContentView {
     func cycleFollow() {
         // Pressing this is also how a reader asks for permission the first time.
         ownship.requestPositionIfNeeded()
-        follow = follow.next
-        applyFollow()
+        ownship.follow = ownship.follow.next
+        applyFollow(animated: true)
     }
 
     /// Put the camera where the current mode says it belongs.
-    func applyFollow() {
-        guard let fix = ownship.fix else { return }
-        if follow.followsPosition {
-            mapCommands?.centre(fix.coordinate)
+    func applyFollow(animated: Bool) {
+        // Position and heading are separate answers. Coupling them meant a map that would
+        // not turn with the aircraft until it also knew where the aircraft was, and indoors
+        // that is most of the time.
+        if ownship.follow.followsPosition, let fix = ownship.fix {
+            mapCommands?.centre(fix.coordinate, animated)
         }
-        switch follow {
+        switch ownship.follow {
         case .heading:
             // A heading if the device or the aircraft has one, and course over the ground
             // only when neither does. They differ in wind, and the map should turn to
             // where the aircraft points rather than where it is drifting.
             if let heading = ownship.heading {
-                mapCommands?.setHeading(heading.trueDegrees)
+                mapCommands?.setHeading(heading.trueDegrees, animated)
             }
         case .centred:
             mapCommands?.resetHeading()
@@ -174,8 +210,8 @@ private extension SituationContentView {
 struct SituationMapCommands {
     let resetHeading: () -> Void
     let resetPitch: () -> Void
-    let centre: (CLLocationCoordinate2D) -> Void
-    let setHeading: (Double) -> Void
+    let centre: (CLLocationCoordinate2D, Bool) -> Void
+    let setHeading: (Double, Bool) -> Void
 }
 
 private struct SituationMap: UIViewRepresentable {
@@ -210,8 +246,8 @@ private struct SituationMap: UIViewRepresentable {
                 SituationMapCommands(
                     resetHeading: { view.resetHeading() },
                     resetPitch: { view.resetPitch() },
-                    centre: { view.centre(on: $0) },
-                    setHeading: { view.setHeading($0) }
+                    centre: { view.centre(on: $0, animated: $1) },
+                    setHeading: { view.setHeading($0, animated: $1) }
                 )
             )
         }

--- a/scripts/check-situation-ownship-wiring.sh
+++ b/scripts/check-situation-ownship-wiring.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Keep every ownship seam connected to a caller.
+#
+# Each fault this guards against was a declaration with nothing on the other end: a
+# reader the model offered and the view never set, an evidence write nothing asked for,
+# a compass the position request never started. All of them compile, and all of them
+# look correct in the file that declares them. Only the call site proves the wire.
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+app="$root/clients/apple-situation/App"
+status=0
+
+require_pattern() {
+    local pattern=$1
+    local file=$2
+    local message=$3
+    if ! grep -Eq "$pattern" "$file"; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+# A seam must be reached from outside the file that declares it.
+#
+# Counting uses across the whole directory is not enough: a model that declares a reader
+# and reads it in the same file looks wired from every angle except the one that matters,
+# which is whether anything ever supplies it. The caller may live in any other file, so
+# the rule is "some other file names it", not "a named file names it".
+require_caller() {
+    local name=$1
+    local message=$2
+    local declaring
+    local outside
+    declaring=$(grep -El "(var|func) $name\b" "$app"/*.swift || true)
+    outside=$(grep -El "\b$name\b" "$app"/*.swift | grep -Fxv "$declaring" || true)
+    if [ -z "$outside" ]; then
+        echo "FORBIDDEN: $message" >&2
+        status=1
+    fi
+}
+
+require_caller currentOwnship \
+    "the view must give the model a reader for ownship state, or the file it writes cannot describe the run"
+require_caller onOwnship \
+    "the aircraft's own return must reach the ownship model"
+require_caller refreshEvidence \
+    "something must ask for an evidence write, or a run with no radio traffic leaves no record"
+require_caller startIfPermitted \
+    "a reader who already granted permission must not have to press a control before the sensors are asked anything"
+require_caller refreshOrientation \
+    "a turned tablet must reach the heading orientation, or heading up reads ninety degrees off"
+
+if ! grep -A 2 'func requestPositionIfNeeded()' "$app/OwnshipPosition.swift" \
+    | grep -Eq '^\s+start\(\)'; then
+    echo "FORBIDDEN: asking for a position must start every sensor a heading needs, not the receiver alone" >&2
+    status=1
+fi
+
+require_pattern 'compass\.start\(\)' "$app/OwnshipPosition.swift" \
+    "the compass must be started, or a heading up map has nothing to turn to"
+require_pattern 'locationManagerShouldDisplayHeadingCalibration' "$app/OwnshipPosition.swift" \
+    "a compass that cannot trust its reading must be allowed to ask the reader to swing the tablet"
+require_pattern 'trueHeading >= 0' "$app/OwnshipPosition.swift" \
+    "a true heading is absent until the platform has variation, and the magnetic reading must answer instead"
+require_pattern 'case \.landscapeLeft: \.landscapeRight' "$app/OwnshipPosition.swift" \
+    "the interface and device orientations name landscape from opposite ends and must be swapped"
+require_pattern '@Published var follow' "$app/OwnshipPosition.swift" \
+    "the follow mode must live in the model, because a closure that reads it outlives the view value"
+
+# Following is a mode. A camera that only moves when the control is pressed is a jump
+# wearing the name of a mode, and it stops the moment the aircraft does anything.
+require_pattern 'onChange\(of: ownship\.fix\)' "$app/PilotageSituationApp.swift" \
+    "the map must follow the position as it changes, not only when the control is pressed"
+require_pattern 'onChange\(of: ownship\.heading\)' "$app/PilotageSituationApp.swift" \
+    "the map must turn with the aircraft as the heading changes"
+require_pattern 'applyFollow\(animated: false\)' "$app/PilotageSituationApp.swift" \
+    "a camera eased on every reading trails the aircraft, so continuous following must not animate"
+
+exit "$status"

--- a/scripts/test-check-situation-ownship-wiring.sh
+++ b/scripts/test-check-situation-ownship-wiring.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Prove that the ownship wiring guard rejects each way the wire was cut before.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-ownship-wiring.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+app="$fixture/clients/apple-situation/App"
+mkdir -p "$app" "$fixture/scripts"
+cp "$repo_root/clients/apple-situation/App/"*.swift "$app/"
+cp "$repo_root/scripts/check-situation-ownship-wiring.sh" "$fixture/scripts/"
+
+gate="$fixture/scripts/check-situation-ownship-wiring.sh"
+bash "$gate" "$fixture" >/dev/null
+
+# Each case removes one wire and expects a refusal. The message names the fault the
+# removal recreates, so a failure here reads as the fault rather than as a broken test.
+reject() {
+    local message=$1
+    if bash "$gate" "$fixture" >/dev/null 2>&1; then
+        echo "the ownship wiring guard accepted $message" >&2
+        exit 1
+    fi
+}
+
+restore() {
+    cp "$repo_root/clients/apple-situation/App/$1" "$app/$1"
+}
+
+sed -i.bak '/model.currentOwnship = /,+9d' "$app/PilotageSituationApp.swift"
+reject "a model whose ownship reader is never set"
+restore PilotageSituationApp.swift
+
+sed -i.bak '/model.refreshEvidence()/d' "$app/PilotageSituationApp.swift"
+reject "an evidence write nothing asks for"
+restore PilotageSituationApp.swift
+
+sed -i.bak '/ownship.refreshOrientation()/d' "$app/PilotageSituationApp.swift"
+reject "a turned tablet that never reaches the heading orientation"
+restore PilotageSituationApp.swift
+
+sed -i.bak '/onChange(of: ownship.heading)/d' "$app/PilotageSituationApp.swift"
+reject "a map that turns only when the control is pressed"
+restore PilotageSituationApp.swift
+
+sed -i.bak 's/applyFollow(animated: false)/applyFollow(animated: true)/' \
+    "$app/PilotageSituationApp.swift"
+reject "a camera eased on every reading"
+restore PilotageSituationApp.swift
+
+sed -i.bak 's/^        compass.start()$//' "$app/OwnshipPosition.swift"
+reject "a position request that leaves the compass stopped"
+restore OwnshipPosition.swift
+
+sed -i.bak 's/case .landscapeLeft: .landscapeRight/case .landscapeLeft: .landscapeLeft/' \
+    "$app/OwnshipPosition.swift"
+reject "an interface orientation passed straight through as a device orientation"
+restore OwnshipPosition.swift
+
+sed -i.bak 's/trueHeading >= 0/trueHeading > -999/' "$app/OwnshipPosition.swift"
+reject "a true heading trusted before the platform has variation"
+restore OwnshipPosition.swift
+
+sed -i.bak 's/@Published var follow/var follow/' "$app/OwnshipPosition.swift"
+reject "a follow mode a closure would read as it was rather than as it is"
+restore OwnshipPosition.swift
+
+bash "$gate" "$fixture" >/dev/null
+echo "ownship wiring guard rejects each cut wire"


### PR DESCRIPTION
The model offered a reader for ownship state, an evidence write and a compass,
and nothing on the view side supplied any of them. All three compile and read
correctly in the file that declares them, so the faults showed only as behaviour:
a map that would not turn with the device, a control that reported nothing, and
an evidence file that stopped changing on a run with no radio traffic.

Asking for a position now starts every sensor a heading needs rather than the
receiver alone, and a reader who granted permission on an earlier run is not made
to press a control before the sensors are asked anything. Following is continuous
and unanimated, because a camera eased on each reading trails the aircraft. The
interface and device orientations name landscape from opposite ends, so the
heading orientation swaps them.

The guard rejects each cut wire, and its self-test proves the guard rejects them.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #412
- <kbd>&nbsp;3&nbsp;</kbd> #411 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #410
- <kbd>&nbsp;1&nbsp;</kbd> #407
<!-- GitButler Footer Boundary Bottom -->