### PR TITLE
Dress the map modes panel in the platform's own chrome, and adapt it to narrow windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: situation layer controls
         run: bash scripts/check-situation-layer-controls.sh
 
+      - name: situation map attribution self-test
+        run: bash scripts/test-check-situation-map-attribution.sh
+
+      - name: situation map attribution
+        run: bash scripts/check-situation-map-attribution.sh
+
       - name: situation ownship wiring self-test
         run: bash scripts/test-check-situation-ownship-wiring.sh
 

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -90,14 +90,21 @@ struct MapControlsView<ModesContent: View>: View {
                     .glassEffectID("pilotage.map.level", in: namespace)
                     .glassEffectTransition(.matchedGeometry)
                     // A child inserted with its parent has no transition of its own to
-                    // run: the parent's covers the whole subtree. The label is given its
-                    // own appearance so it can arrive after the shape it sits in.
-                    .onAppear {
-                        withAnimation(.easeOut(duration: 0.22).delay(0.12)) {
+                    // run: the parent's covers the whole subtree. Delaying the animation
+                    // curve does not escape that, because the state still changes in the
+                    // cycle that inserts the parent and is folded into it. Waiting first
+                    // puts the change in a later cycle, where it is an insertion of its
+                    // own and the label's own transition runs.
+                    .task {
+                        // The state outlives the control, which comes and goes with the
+                        // camera, so a run starts from hidden rather than from whatever
+                        // the last one left.
+                        levelLabelShown = false
+                        try? await Task.sleep(for: .milliseconds(180))
+                        withAnimation(.easeOut(duration: 0.25)) {
                             levelLabelShown = true
                         }
                     }
-                    .onDisappear { levelLabelShown = false }
                 }
                 if camera.isRotated {
                     control(

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -26,7 +26,7 @@ struct MapControlsView<ModesContent: View>: View {
     let cycleFollow: () -> Void
     @Binding var modesPresented: Bool
     @ViewBuilder let modesContent: () -> ModesContent
-    @State private var pillFlash = false
+    @State private var levelLabelShown = false
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -58,7 +58,7 @@ struct MapControlsView<ModesContent: View>: View {
     /// into it. The group flashes as it takes one back, the way a surface does when
     /// something rejoins it.
     private var controls: some View {
-        GlassEffectContainer(spacing: Metrics.controlSpacing) {
+        GlassEffectContainer(spacing: Metrics.controlBlend) {
             VStack(spacing: Metrics.controlSpacing) {
                 VStack(spacing: 0) {
                     control(label: "Map modes") { modesPresented = true } content: {
@@ -72,20 +72,29 @@ struct MapControlsView<ModesContent: View>: View {
                 }
                 .glassEffect(.clear.interactive(), in: .capsule)
                 .glassEffectID("pilotage.map.pill", in: namespace)
-                .brightness(pillFlash ? 0.22 : 0)
-                .animation(.easeOut(duration: 0.22), value: pillFlash)
 
                 if camera.isTilted {
                     control(label: "Look straight down", action: resetPitch) {
-                        // The label arrives from below the control rather than fading in
-                        // on the spot, so the glass looks like it is filling with the
-                        // control rather than having one drawn on it.
-                        Text("2D")
-                            .transition(.blurReplace(.downUp))
+                        // The shape arrives first and the label rises into it. A label
+                        // carried along by the shape that grew it appears finished on
+                        // arrival; this one reads as the control filling.
+                        if levelLabelShown {
+                            Text("2D")
+                                .transition(.blurReplace(.downUp))
+                        }
                     }
                     .glassEffect(.clear.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.level", in: namespace)
                     .glassEffectTransition(.matchedGeometry)
+                    // A child inserted with its parent has no transition of its own to
+                    // run: the parent's covers the whole subtree. The label is given its
+                    // own appearance so it can arrive after the shape it sits in.
+                    .onAppear {
+                        withAnimation(.easeOut(duration: 0.22).delay(0.12)) {
+                            levelLabelShown = true
+                        }
+                    }
+                    .onDisappear { levelLabelShown = false }
                 }
                 if camera.isRotated {
                     control(
@@ -103,12 +112,6 @@ struct MapControlsView<ModesContent: View>: View {
         .animation(.easeInOut(duration: 0.3), value: camera.isTilted)
         .animation(.easeInOut(duration: 0.3), value: camera.isRotated)
         .animation(.easeInOut(duration: 0.3), value: canLocate)
-        .onChange(of: camera.isTilted) { _, tilted in
-            if !tilted { flashPill() }
-        }
-        .onChange(of: camera.isRotated) { _, rotated in
-            if !rotated { flashPill() }
-        }
     }
 
     /// One control: the same square, the same glyph weight, the same target.
@@ -127,14 +130,6 @@ struct MapControlsView<ModesContent: View>: View {
         .accessibilityLabel(label)
     }
 
-    /// Mark the group taking a control back.
-    private func flashPill() {
-        pillFlash = true
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 220_000_000)
-            pillFlash = false
-        }
-    }
 }
 
 /// A compass that names the direction the map faces.

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -25,12 +25,14 @@ struct MapControlsView<ModesContent: View>: View {
     let resetPitch: () -> Void
     let cycleFollow: () -> Void
     @Binding var modesPresented: Bool
+    /// Whether the panel grows out of this group or arrives from the edge of the screen.
+    let modesGrowFromControls: Bool
     @ViewBuilder let modesContent: () -> ModesContent
     @State private var levelLabelShown = false
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            if modesPresented {
+            if modesPresented, modesGrowFromControls {
                 // The panel takes the corner the pill was in. It does not sit beside the
                 // control that opened it: the control became it.
                 modesContent()
@@ -44,7 +46,10 @@ struct MapControlsView<ModesContent: View>: View {
                     )
             }
         }
-        .animation(.spring(response: 0.34, dampingFraction: 0.82), value: modesPresented)
+        .animation(
+            .spring(response: 0.34, dampingFraction: 0.82),
+            value: modesPresented && modesGrowFromControls
+        )
     }
 
     /// One glass container holds every map control.

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -58,7 +58,7 @@ struct MapControlsView<ModesContent: View>: View {
     /// into it. The group flashes as it takes one back, the way a surface does when
     /// something rejoins it.
     private var controls: some View {
-        GlassEffectContainer(spacing: Metrics.controlBlend) {
+        GlassEffectContainer(spacing: Metrics.controlSpacing) {
             VStack(spacing: Metrics.controlSpacing) {
                 VStack(spacing: 0) {
                     control(label: "Map modes") { modesPresented = true } content: {
@@ -79,8 +79,11 @@ struct MapControlsView<ModesContent: View>: View {
                         // carried along by the shape that grew it appears finished on
                         // arrival; this one reads as the control filling.
                         if levelLabelShown {
+                            // Stated as a rise rather than left to a named transition,
+                            // because the direction is the point: the label comes up into
+                            // the control from under it.
                             Text("2D")
-                                .transition(.blurReplace(.downUp))
+                                .transition(.offset(y: 10).combined(with: .opacity))
                         }
                     }
                     .glassEffect(.clear.interactive(), in: .circle)

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -26,7 +26,6 @@ struct MapControlsView<ModesContent: View>: View {
     let cycleFollow: () -> Void
     @Binding var modesPresented: Bool
     @ViewBuilder let modesContent: () -> ModesContent
-    @State private var levelling = false
     @State private var pillFlash = false
 
     var body: some View {
@@ -72,19 +71,17 @@ struct MapControlsView<ModesContent: View>: View {
                     }
                 }
                 .glassEffect(.clear.interactive(), in: .capsule)
-                .glassEffectUnion(id: "pilotage.map.pill", namespace: namespace)
                 .glassEffectID("pilotage.map.pill", in: namespace)
                 .brightness(pillFlash ? 0.22 : 0)
                 .animation(.easeOut(duration: 0.22), value: pillFlash)
 
                 if camera.isTilted {
-                    control(label: "Look straight down") {
-                        levelling = true
-                        resetPitch()
-                    } content: {
-                        // The control names the state it is about to reach as it goes, so
-                        // the press is acknowledged before the control leaves.
-                        Text(levelling ? "3D" : "2D")
+                    control(label: "Look straight down", action: resetPitch) {
+                        // The label arrives from below the control rather than fading in
+                        // on the spot, so the glass looks like it is filling with the
+                        // control rather than having one drawn on it.
+                        Text("2D")
+                            .transition(.blurReplace(.downUp))
                     }
                     .glassEffect(.clear.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.level", in: namespace)
@@ -97,7 +94,7 @@ struct MapControlsView<ModesContent: View>: View {
                     ) {
                         CompassRose(headingDegrees: camera.headingDegrees)
                     }
-                    .glassEffect(.regular.interactive(), in: .circle)
+                    .glassEffect(.clear.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.compass", in: namespace)
                     .glassEffectTransition(.matchedGeometry)
                 }
@@ -107,7 +104,7 @@ struct MapControlsView<ModesContent: View>: View {
         .animation(.easeInOut(duration: 0.3), value: camera.isRotated)
         .animation(.easeInOut(duration: 0.3), value: canLocate)
         .onChange(of: camera.isTilted) { _, tilted in
-            if !tilted { levelling = false; flashPill() }
+            if !tilted { flashPill() }
         }
         .onChange(of: camera.isRotated) { _, rotated in
             if !rotated { flashPill() }

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -32,13 +32,17 @@ struct MapControlsView<ModesContent: View>: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            if modesPresented, modesGrowFromControls {
-                // The panel takes the corner the pill was in. It does not sit beside the
-                // control that opened it: the control became it.
-                modesContent()
-                    .transition(
-                        .scale(scale: 0.18, anchor: .topTrailing).combined(with: .opacity)
-                    )
+            if modesPresented {
+                // Beside the map the panel takes the corner the pill was in: it does not
+                // sit next to the control that opened it, the control became it. Brought
+                // up from an edge instead, the corner is simply given up, because a group
+                // of controls left floating over a panel is a second thing to read.
+                if modesGrowFromControls {
+                    modesContent()
+                        .transition(
+                            .scale(scale: 0.18, anchor: .topTrailing).combined(with: .opacity)
+                        )
+                }
             } else {
                 controls
                     .transition(
@@ -46,10 +50,7 @@ struct MapControlsView<ModesContent: View>: View {
                     )
             }
         }
-        .animation(
-            .spring(response: 0.34, dampingFraction: 0.82),
-            value: modesPresented && modesGrowFromControls
-        )
+        .animation(.spring(response: 0.34, dampingFraction: 0.82), value: modesPresented)
     }
 
     /// One glass container holds every map control.

--- a/clients/apple-situation/App/MapControlsView.swift
+++ b/clients/apple-situation/App/MapControlsView.swift
@@ -74,17 +74,15 @@ struct MapControlsView<ModesContent: View>: View {
                 .glassEffectID("pilotage.map.pill", in: namespace)
 
                 if camera.isTilted {
+                    // The label sits over the control rather than inside it. A button
+                    // hands its label to its style, which is free to rebuild it, and a
+                    // view rebuilt by something else does not keep the transition it was
+                    // given. Over the top, the label answers to nothing but its own state.
                     control(label: "Look straight down", action: resetPitch) {
-                        // The shape arrives first and the label rises into it. A label
-                        // carried along by the shape that grew it appears finished on
-                        // arrival; this one reads as the control filling.
-                        if levelLabelShown {
-                            // Stated as a rise rather than left to a named transition,
-                            // because the direction is the point: the label comes up into
-                            // the control from under it.
-                            Text("2D")
-                                .transition(.offset(y: 10).combined(with: .opacity))
-                        }
+                        Color.clear
+                    }
+                    .overlay {
+                        risingLabel
                     }
                     .glassEffect(.clear.interactive(), in: .circle)
                     .glassEffectID("pilotage.map.level", in: namespace)
@@ -122,6 +120,25 @@ struct MapControlsView<ModesContent: View>: View {
         .animation(.easeInOut(duration: 0.3), value: camera.isTilted)
         .animation(.easeInOut(duration: 0.3), value: camera.isRotated)
         .animation(.easeInOut(duration: 0.3), value: canLocate)
+    }
+
+    /// The word the level control shows, arriving from under it.
+    ///
+    /// Clipped to the control it fills, so the word travels from the edge of the shape
+    /// rather than from wherever the layout would otherwise have started it. Without the
+    /// clip the direction belongs to whatever alignment the surrounding stack happens to
+    /// use, which is how a rise becomes a slide from the side.
+    private var risingLabel: some View {
+        ZStack {
+            if levelLabelShown {
+                Text("2D")
+                    .font(Metrics.controlGlyph)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .frame(width: Metrics.control, height: Metrics.control)
+        .clipShape(.circle)
+        .allowsHitTesting(false)
     }
 
     /// One control: the same square, the same glyph weight, the same target.

--- a/clients/apple-situation/App/MapLayoutMetrics.swift
+++ b/clients/apple-situation/App/MapLayoutMetrics.swift
@@ -21,6 +21,14 @@ enum Metrics {
     /// Gap between controls in a stack.
     static let controlSpacing: CGFloat = 10
 
+    /// How near two glass controls must be before their shapes start to blend.
+    ///
+    /// Below the gap between controls, so the group does not swell and blur every time a
+    /// control joins or leaves it. Apple's own example uses a blend distance equal to its
+    /// gap, but its controls sit a half diameter apart and these sit a fifth of one apart:
+    /// at that proximity an equal distance keeps the shapes blending at rest.
+    static let controlBlend: CGFloat = 4
+
     /// Distance from a control to the edge of the safe area.
     ///
     /// The map runs under the status bar and the home indicator, and the controls do not.

--- a/clients/apple-situation/App/MapLayoutMetrics.swift
+++ b/clients/apple-situation/App/MapLayoutMetrics.swift
@@ -19,15 +19,12 @@ enum Metrics {
     static let controlGlyphBox: CGFloat = 30
 
     /// Gap between controls in a stack.
-    static let controlSpacing: CGFloat = 10
-
-    /// How near two glass controls must be before their shapes start to blend.
     ///
-    /// Below the gap between controls, so the group does not swell and blur every time a
-    /// control joins or leaves it. Apple's own example uses a blend distance equal to its
-    /// gap, but its controls sit a half diameter apart and these sit a fifth of one apart:
-    /// at that proximity an equal distance keeps the shapes blending at rest.
-    static let controlBlend: CGFloat = 4
+    /// Also the blend distance of the glass container that holds them, and the two are
+    /// the same number on purpose. A container blends only the shapes that sit within its
+    /// spacing, so a distance below this gap leaves each control its own island: it stops
+    /// growing out of the group and starts arriving from nowhere.
+    static let controlSpacing: CGFloat = 10
 
     /// Distance from a control to the edge of the safe area.
     ///

--- a/clients/apple-situation/App/MapLayoutMetrics.swift
+++ b/clients/apple-situation/App/MapLayoutMetrics.swift
@@ -43,12 +43,25 @@ enum Metrics {
 }
 
 extension View {
-    /// Place a floating control against the safe area, with the standard margin.
+    /// Place a floating control against the window, clear of whatever the system reserves.
+    ///
+    /// The margin is the larger of the standard one and the system's own inset, not the
+    /// sum. Added to the inset instead, a control ends up further from the top edge than
+    /// from the side by exactly the height of the status bar, which reads as the corner
+    /// being weighted rather than as a margin. Taking the larger keeps the control clear
+    /// of the status bar where there is one, and square to the corner where there is not.
     ///
     /// Declared once rather than as a padding value repeated at each corner, so a control
     /// added later cannot sit at a different distance from the edge than the rest.
     func mapControlPlacement(_ alignment: Alignment) -> some View {
-        frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
-            .padding(Metrics.edgeInset)
+        GeometryReader { proxy in
+            let safe = proxy.safeAreaInsets
+            frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+                .padding(.top, max(Metrics.edgeInset, safe.top))
+                .padding(.bottom, max(Metrics.edgeInset, safe.bottom))
+                .padding(.leading, max(Metrics.edgeInset, safe.leading))
+                .padding(.trailing, max(Metrics.edgeInset, safe.trailing))
+        }
+        .ignoresSafeArea()
     }
 }

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -63,15 +63,19 @@ struct MapModesView: View {
                 .font(.title2.weight(.semibold))
             HStack {
                 Spacer()
-                // The role carries the dismissing meaning; the glyph carries the mark. The
-                // role's own label is the word "Close", and a panel this small is closed
-                // with a cross. No frame: the glass style pads its own label, and an outer
-                // frame pads it a second time, which is what made this one outsize.
+                // The role carries the dismissing meaning and the symbol carries the
+                // mark, because the role's own label is the word "Close". The symbol is
+                // already a filled disc, so a glass style around it draws a second ring
+                // outside the first.
                 Button(role: .close, action: close) {
-                    Image(systemName: "xmark")
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 28))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(.circle)
                 }
-                .buttonStyle(.glass)
-                .buttonBorderShape(.circle)
+                .buttonStyle(.plain)
                 .accessibilityLabel("Close map modes")
             }
         }

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -38,6 +38,12 @@ struct MapModesView: View {
     /// as wide as the screen, because a sheet that stops short of the sides reads as a
     /// card that failed to load rather than as a deliberate width.
     var fixedWidth: Bool = true
+    /// Whether the panel draws the surface it sits on.
+    ///
+    /// Beside the map it is its own card. Brought up from an edge the sheet is already a
+    /// card, and drawing another inside it stacks two surfaces with two sets of corners,
+    /// which reads as the panel having failed to fill something.
+    var drawsSurface: Bool = true
     @State private var attributionPresented = false
 
     var body: some View {
@@ -51,8 +57,8 @@ struct MapModesView: View {
         }
         .padding(Metrics.panelPadding)
         .glassEffect(
-            .regular,
-            in: .rect(cornerRadius: Metrics.panelCorner)
+            drawsSurface ? .regular : .identity,
+            in: .rect(cornerRadius: drawsSurface ? Metrics.panelCorner : 0)
         )
         // The panel is as big as what it holds. A fixed width leaves a column of empty
         // glass beside one tile, and a detent invites a drag the panel does not answer.

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -60,18 +60,15 @@ struct MapModesView: View {
     private var header: some View {
         ZStack {
             Text("Map Modes")
-                .font(.title3.weight(.semibold))
+                .font(.title2.weight(.semibold))
             HStack {
                 Spacer()
-                Button(action: close) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 16, weight: .semibold))
-                        // The same target as every other control. A close button smaller
-                        // than the rest is the one a reader misses.
-                        .frame(width: Metrics.control, height: Metrics.control)
-                }
-                .buttonStyle(.glass)
-                .accessibilityLabel("Close map modes")
+                // The platform's own close button, sized by the platform. A frame here is
+                // what made this one larger than the title it sits beside: the glass style
+                // pads its own label, and an outer frame pads it a second time.
+                Button(role: .close, action: close)
+                    .buttonStyle(.glass)
+                    .accessibilityLabel("Close map modes")
             }
         }
     }

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -32,6 +32,12 @@ struct MapModesView: View {
     let setLayerEnabled: (String, Bool) -> Void
     let attributions: [String]
     let close: () -> Void
+    /// Whether the panel carries its own width, or takes the width it is given.
+    ///
+    /// Beside the map it is a card of a set width. Brought up from the bottom edge it is
+    /// as wide as the screen, because a sheet that stops short of the sides reads as a
+    /// card that failed to load rather than as a deliberate width.
+    var fixedWidth: Bool = true
     @State private var attributionPresented = false
 
     var body: some View {
@@ -50,7 +56,8 @@ struct MapModesView: View {
         )
         // The panel is as big as what it holds. A fixed width leaves a column of empty
         // glass beside one tile, and a detent invites a drag the panel does not answer.
-        .frame(width: Metrics.panelWidth)
+        .frame(width: fixedWidth ? Metrics.panelWidth : nil)
+        .frame(maxWidth: fixedWidth ? nil : .infinity)
         .fixedSize(horizontal: false, vertical: true)
         .sheet(isPresented: $attributionPresented) {
             MapAttributionView(notices: attributions)

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -60,22 +60,28 @@ struct MapModesView: View {
     private var header: some View {
         ZStack {
             Text("Map Modes")
-                .font(.title2.weight(.semibold))
+                .font(.title3.weight(.bold))
             HStack {
                 Spacer()
-                // The role carries the dismissing meaning and the symbol carries the
-                // mark, because the role's own label is the word "Close". The symbol is
-                // already a filled disc, so a glass style around it draws a second ring
-                // outside the first.
+                // The disc and the cross are set apart, because the button they copy has
+                // a wider disc and a smaller cross than any one number gives.
+                //
+                // The role's own label answers to neither the image scale nor the control
+                // size, so naming the symbol is what makes it move at all. The font then
+                // sets the cross. The disc follows the label it is given, so a frame wider
+                // than the label sets the disc and leaves the cross alone: the disc comes
+                // out ten points above the frame. A frame narrower than the label does
+                // nothing at all, because the control size holds a floor under the disc,
+                // and that is what earlier frames were being swallowed by.
                 Button(role: .close, action: close) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 28))
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 44, height: 44)
-                        .contentShape(.circle)
+                    Image(systemName: "xmark")
+                        .font(.system(size: 23, weight: .regular))
+                        .frame(width: 35, height: 35)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+                .controlSize(.small)
+                .foregroundStyle(.secondary)
                 .accessibilityLabel("Close map modes")
             }
         }
@@ -143,8 +149,10 @@ struct MapModesView: View {
             attributionPresented = true
         } label: {
             Text(summary)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
+                // Small and dim on purpose. The credit is owed and has to be there; a
+                // reader looking at the map is not the one it is owed to.
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
         }
@@ -166,3 +174,5 @@ struct MapModesView: View {
             : "© \(first)"
     }
 }
+
+

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -63,12 +63,16 @@ struct MapModesView: View {
                 .font(.title2.weight(.semibold))
             HStack {
                 Spacer()
-                // The platform's own close button, sized by the platform. A frame here is
-                // what made this one larger than the title it sits beside: the glass style
-                // pads its own label, and an outer frame pads it a second time.
-                Button(role: .close, action: close)
-                    .buttonStyle(.glass)
-                    .accessibilityLabel("Close map modes")
+                // The role carries the dismissing meaning; the glyph carries the mark. The
+                // role's own label is the word "Close", and a panel this small is closed
+                // with a cross. No frame: the glass style pads its own label, and an outer
+                // frame pads it a second time, which is what made this one outsize.
+                Button(role: .close, action: close) {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+                .accessibilityLabel("Close map modes")
             }
         }
     }

--- a/clients/apple-situation/App/MapModesView.swift
+++ b/clients/apple-situation/App/MapModesView.swift
@@ -1,6 +1,19 @@
 import PilotageSituationCore
 import SwiftUI
 
+/// The card a panel draws under itself, where it is its own card.
+private struct PanelSurface: ViewModifier {
+    let active: Bool
+
+    func body(content: Content) -> some View {
+        if active {
+            content.glassEffect(.regular, in: .rect(cornerRadius: Metrics.panelCorner))
+        } else {
+            content
+        }
+    }
+}
+
 /// One way of drawing the ground.
 ///
 /// A mode is a base map, not a layer: exactly one is drawn, and the layers below the tiles
@@ -56,10 +69,9 @@ struct MapModesView: View {
             attributionFooter
         }
         .padding(Metrics.panelPadding)
-        .glassEffect(
-            drawsSurface ? .regular : .identity,
-            in: .rect(cornerRadius: drawsSurface ? Metrics.panelCorner : 0)
-        )
+        // Applied or not applied, never applied as an identity: asking for glass that
+        // changes nothing still lays a surface, and inside a sheet that is a second card.
+        .modifier(PanelSurface(active: drawsSurface))
         // The panel is as big as what it holds. A fixed width leaves a column of empty
         // glass beside one tile, and a detent invites a drag the panel does not answer.
         .frame(width: fixedWidth ? Metrics.panelWidth : nil)

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -14,6 +14,7 @@ struct PilotageSituationApp: App {
 
 private struct SituationContentView: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @StateObject private var model = SituationClientModel()
     @State private var menuPresented = false
     @State private var camera = SituationCamera(headingDegrees: 0, pitchDegrees: 0)
@@ -61,16 +62,8 @@ private struct SituationContentView: View {
                     resetPitch: { mapCommands?.resetPitch() },
                     cycleFollow: cycleFollow,
                     modesPresented: $modesPresented,
-                    modesContent: {
-                        MapModesView(
-                            modes: MapMode.available,
-                            selectedModeID: $selectedMapModeID,
-                            layers: model.mapDisplay?.layers ?? [],
-                            setLayerEnabled: model.setLayerEnabled,
-                            attributions: model.mapAttributions,
-                            close: { modesPresented = false }
-                        )
-                    }
+                    modesGrowFromControls: modesFitBesideTheMap,
+                    modesContent: { mapModes(fixedWidth: true) }
                 )
                 .mapControlPlacement(.topTrailing)
                 PositionlessTrafficView(
@@ -117,6 +110,17 @@ private struct SituationContentView: View {
         .onChange(of: ownship.heading?.source) { _, _ in model.refreshEvidence() }
         .onChange(of: ownship.fix == nil) { _, _ in model.refreshEvidence() }
         .onChange(of: ownship.deviceAuthorisation) { _, _ in model.refreshEvidence() }
+        // Narrow, the panel would cover the map it describes, so it comes up from the
+        // bottom edge at the full width instead, which is where a reader's thumb is and
+        // what the platform does with anything that cannot fit beside its subject.
+        .sheet(isPresented: Binding(
+            get: { modesPresented && !modesFitBesideTheMap },
+            set: { presented in if !presented { modesPresented = false } }
+        )) {
+            mapModes(fixedWidth: false)
+                .presentationSizing(.fitted)
+                .presentationBackground(.clear)
+        }
         .sheet(isPresented: $menuPresented) {
             SituationMenuView(model: model)
         }
@@ -138,6 +142,29 @@ private struct SituationContentView: View {
 }
 
 private extension SituationContentView {
+    /// Whether the panel can sit beside the map rather than over it.
+    ///
+    /// The platform's own answer to "is there room for two things across", which is the
+    /// question being asked. A width in points would have to be picked and then re-picked
+    /// for every window size a reader can drag to.
+    var modesFitBesideTheMap: Bool { horizontalSizeClass == .regular }
+
+    /// The panel itself, wherever it is shown from.
+    ///
+    /// One view for both presentations, because a reader who learns it narrow should not
+    /// have to learn it again wide.
+    @ViewBuilder func mapModes(fixedWidth: Bool) -> some View {
+        MapModesView(
+            modes: MapMode.available,
+            selectedModeID: $selectedMapModeID,
+            layers: model.mapDisplay?.layers ?? [],
+            setLayerEnabled: model.setLayerEnabled,
+            attributions: model.mapAttributions,
+            close: { modesPresented = false },
+            fixedWidth: fixedWidth
+        )
+    }
+
     /// Step through not following, following, and turning with the aircraft.
     ///
     /// Following is a mode rather than a jump, so the map keeps up as the position moves

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -12,6 +12,21 @@ struct PilotageSituationApp: App {
     }
 }
 
+/// What a launch asked the application to do before a hand touched it.
+///
+/// Only in a debug build. A screen that can be opened from outside is a way in, and the
+/// shipped application has no reason to offer one. It exists so a window at an awkward
+/// size can be photographed and measured without somebody holding the tablet.
+enum LaunchRequest {
+    static var openMapModes: Bool {
+        #if DEBUG
+        ProcessInfo.processInfo.arguments.contains("-OpenMapModes")
+        #else
+        false
+        #endif
+    }
+}
+
 private struct SituationContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -19,7 +34,11 @@ private struct SituationContentView: View {
     @State private var menuPresented = false
     @State private var camera = SituationCamera(headingDegrees: 0, pitchDegrees: 0)
     @State private var mapCommands: SituationMapCommands?
-    @State private var modesPresented = false
+    @State private var modesPresented = LaunchRequest.openMapModes
+    /// How tall the panel wants to be, so a sheet can be exactly that tall.
+    @State private var modesHeight: CGFloat = 360
+    /// How tall the window is, so a sheet cannot ask to be taller than one.
+    @State private var windowHeight: CGFloat = 800
     @State private var selectedMapModeID = MapMode.available.first?.id ?? "terrain"
     @Namespace private var mapControlNamespace
     @StateObject private var ownship = OwnshipModel()
@@ -75,6 +94,11 @@ private struct SituationContentView: View {
                     .mapControlPlacement(.bottomTrailing)
             }
         }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            windowHeight = height
+        }
         .task {
             // The controls report what they are doing through the model, so a run can be
             // read from the file it leaves rather than from the screen.
@@ -117,9 +141,26 @@ private struct SituationContentView: View {
             get: { modesPresented && !modesFitBesideTheMap },
             set: { presented in if !presented { modesPresented = false } }
         )) {
-            mapModes(fixedWidth: false, drawsSurface: false)
-                .presentationSizing(.fitted)
-                .presentationBackground(.regularMaterial)
+            // A sheet is sized by its detent, not by asking it to fit: left to itself it
+            // takes the whole screen and centres the panel in it, which is the empty band
+            // above and below that read as a second surface. The panel's own height is
+            // intrinsic, so measuring it cannot chase the sheet it is setting.
+            // Short, the panel wants more height than the window has, and a detent taller
+            // than its window crops the panel at both ends rather than shrinking it. The
+            // ask is capped at the window and the content scrolls for the rest, which it
+            // only does when there is a rest.
+            ScrollView {
+                mapModes(fixedWidth: false, drawsSurface: false)
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { height in
+                        modesHeight = height
+                    }
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .presentationDetents([.height(min(modesHeight, windowHeight * 0.92))])
+            .presentationBackground(.regularMaterial)
+            .presentationDragIndicator(.hidden)
         }
         .sheet(isPresented: $menuPresented) {
             SituationMenuView(model: model)

--- a/clients/apple-situation/App/PilotageSituationApp.swift
+++ b/clients/apple-situation/App/PilotageSituationApp.swift
@@ -117,9 +117,9 @@ private struct SituationContentView: View {
             get: { modesPresented && !modesFitBesideTheMap },
             set: { presented in if !presented { modesPresented = false } }
         )) {
-            mapModes(fixedWidth: false)
+            mapModes(fixedWidth: false, drawsSurface: false)
                 .presentationSizing(.fitted)
-                .presentationBackground(.clear)
+                .presentationBackground(.regularMaterial)
         }
         .sheet(isPresented: $menuPresented) {
             SituationMenuView(model: model)
@@ -153,7 +153,7 @@ private extension SituationContentView {
     ///
     /// One view for both presentations, because a reader who learns it narrow should not
     /// have to learn it again wide.
-    @ViewBuilder func mapModes(fixedWidth: Bool) -> some View {
+    @ViewBuilder func mapModes(fixedWidth: Bool, drawsSurface: Bool = true) -> some View {
         MapModesView(
             modes: MapMode.available,
             selectedModeID: $selectedMapModeID,
@@ -161,7 +161,8 @@ private extension SituationContentView {
             setLayerEnabled: model.setLayerEnabled,
             attributions: model.mapAttributions,
             close: { modesPresented = false },
-            fixedWidth: fixedWidth
+            fixedWidth: fixedWidth,
+            drawsSurface: drawsSurface
         )
     }
 

--- a/clients/apple-situation/App/SituationClientModel.swift
+++ b/clients/apple-situation/App/SituationClientModel.swift
@@ -15,9 +15,11 @@ final class SituationClientModel: ObservableObject {
     @Published private(set) var flights: [Flight] = []
     /// The notice each map source asks to be shown.
     ///
-    /// Reported by the map once its style is loaded, because the style is what says which
-    /// sources are drawing and what each one asks for.
-    @Published private(set) var mapAttributions: [String] = []
+    /// Taken from the style document, which is what says which sources draw and what each
+    /// one asks for. The loaded map may report the same notices later and is welcome to,
+    /// but a credit that waits for a map to finish loading is a credit a reader can open
+    /// the panel and not find.
+    @Published private(set) var mapAttributions: [String] = SituationStyleResource.attributions()
     /// Whether the client claims the radios.
     @Published var adsbEnabled: Bool {
         didSet {
@@ -278,7 +280,8 @@ final class SituationClientModel: ObservableObject {
 
     /// Take the notices the loaded style asks to be shown.
     func observeMapAttributions(_ notices: [String]) {
-        guard notices != mapAttributions else { return }
+        // A map that reports nothing has not withdrawn the notices its style declares.
+        guard !notices.isEmpty, notices != mapAttributions else { return }
         mapAttributions = notices
     }
 

--- a/clients/apple-situation/App/SituationStyleResource.swift
+++ b/clients/apple-situation/App/SituationStyleResource.swift
@@ -30,6 +30,25 @@ enum SituationStyleResource {
         return deepest + overzoomSteps
     }
 
+    /// The notice each source in the style asks to be shown.
+    ///
+    /// Read from the style document the map is built from, so a source added without its
+    /// notice cannot appear on the map. Taken from the document rather than from the
+    /// loaded map because the panel that shows these is opened before the map has
+    /// finished loading as often as after, and a credit that depends on timing is a
+    /// credit that is sometimes missing.
+    static func attributions(bundle: Bundle = .main) -> [String] {
+        guard let url = bundle.url(forResource: "SituationStyle", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let style = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sources = style["sources"] as? [String: Any] else { return [] }
+        return sources.values
+            .compactMap { ($0 as? [String: Any])?["attribution"] as? String }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .sorted()
+    }
+
     static func load(bundle: Bundle = .main) throws -> String {
         guard let styleURL = bundle.url(forResource: "SituationStyle", withExtension: "json") else {
             throw SituationStyleResourceError.missingStyle

--- a/clients/apple-situation/project.yml
+++ b/clients/apple-situation/project.yml
@@ -39,7 +39,7 @@ targets:
         SUPPORTS_MACCATALYST: false
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: false
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) ${PILOTAGE_MAPLIBRE_SWIFT_CONDITIONS}"
-        TARGETED_DEVICE_FAMILY: 2
+        TARGETED_DEVICE_FAMILY: "1,2"
     dependencies:
       - package: PilotageSituationCore
         product: PilotageSituationCore

--- a/clients/apple-situation/scripts/capture-map-modes-extremes.sh
+++ b/clients/apple-situation/scripts/capture-map-modes-extremes.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Photograph the map modes panel at the window shapes that break it.
+#
+# The panel is drawn two ways and the narrow one has two extremes: tall, where a sheet
+# left to itself takes the whole screen, and short, where it asks for more height than
+# the window has. Neither is reachable on a full screen tablet, and neither shows up in a
+# build. A phone in portrait is the tall one and the same phone turned is the short one,
+# so both are one command away instead of a message asking somebody to drag a window.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+device="${MAP_MODES_SIM:-}"
+out="${1:-${TMPDIR:-/tmp}/map-modes-extremes}"
+bundle="org.luofang.pilotage.situation"
+
+if [ -z "$device" ]; then
+    device=$(xcrun simctl list devices available \
+        | awk '/iPhone/ { match($0, /\(([0-9A-F-]{36})\)/, m); if (m[1] != "") { print m[1]; exit } }' \
+        || true)
+fi
+if [ -z "$device" ]; then
+    device=$(xcrun simctl list devices available | grep -m1 -oE '[0-9A-F]{8}-[0-9A-F-]{27}')
+fi
+[ -n "$device" ] || { echo "no simulator to photograph on" >&2; exit 1; }
+
+mkdir -p "$out"
+xcrun simctl bootstatus "$device" -b >/dev/null 2>&1 || true
+
+app="${MAP_MODES_APP:-}"
+if [ -z "$app" ]; then
+    app=$(find "$here" -maxdepth 6 -path "*Debug-iphonesimulator/PilotageSituation.app" \
+        -print -quit 2>/dev/null || true)
+fi
+[ -n "$app" ] || { echo "build for a simulator first, or set MAP_MODES_APP" >&2; exit 1; }
+
+xcrun simctl install "$device" "$app" >/dev/null
+
+shoot() {
+    local name=$1 orientation=$2
+    xcrun devicectl device orientation set --device "$device" "$orientation" >/dev/null 2>&1 || true
+    xcrun simctl terminate "$device" "$bundle" >/dev/null 2>&1 || true
+    sleep 1
+    # The panel opens itself, because there is no way to reach in and press it.
+    xcrun simctl launch "$device" "$bundle" -OpenMapModes >/dev/null
+    sleep 8
+    xcrun simctl io "$device" screenshot "$out/$name.png" >/dev/null
+    echo "  $name -> $out/$name.png"
+}
+
+echo "map modes, narrow:"
+shoot narrow-tall portrait
+shoot narrow-short landscapeLeft
+xcrun devicectl device orientation set --device "$device" portrait >/dev/null 2>&1 || true

--- a/scripts/check-situation-map-attribution.sh
+++ b/scripts/check-situation-map-attribution.sh
@@ -27,7 +27,7 @@ if ! grep -q 'horizontalSizeClass == .regular' "$app_root/PilotageSituationApp.s
     echo "FORBIDDEN: the panel must ask the platform whether there is room beside the map" >&2
     status=1
 fi
-for shape in 'modesGrowFromControls' 'presentationSizing(.fitted)'; do
+for shape in 'modesGrowFromControls' 'presentationDetents'; do
     if ! grep -qF "$shape" "$app_root/PilotageSituationApp.swift"; then
         echo "FORBIDDEN: the panel lost one of its two presentations ($shape)" >&2
         status=1
@@ -41,6 +41,12 @@ fi
 # with two sets of corners, which reads as something having failed to fill.
 if ! grep -q 'drawsSurface: false' "$app_root/PilotageSituationApp.swift"; then
     echo "FORBIDDEN: the panel must not draw a second surface inside the sheet that carries it" >&2
+    status=1
+fi
+# A sheet takes the height its detent asks for, and a detent taller than the window crops
+# the panel at both ends instead of shrinking it. Short windows are where this shows.
+if ! grep -q 'min(modesHeight, windowHeight' "$app_root/PilotageSituationApp.swift"; then
+    echo "FORBIDDEN: the sheet must not ask to be taller than the window it opens in" >&2
     status=1
 fi
 

--- a/scripts/check-situation-map-attribution.sh
+++ b/scripts/check-situation-map-attribution.sh
@@ -37,6 +37,12 @@ if ! grep -q 'fixedWidth' "$panel"; then
     echo "FORBIDDEN: a panel brought up from the bottom edge must take the width it is given" >&2
     status=1
 fi
+# A sheet is already a card. A panel that draws its own inside one stacks two surfaces
+# with two sets of corners, which reads as something having failed to fill.
+if ! grep -q 'drawsSurface: false' "$app_root/PilotageSituationApp.swift"; then
+    echo "FORBIDDEN: the panel must not draw a second surface inside the sheet that carries it" >&2
+    status=1
+fi
 
 # The close button belongs to the platform, and two modifiers are what let it draw one.
 # The glass style supplies the disc, and the icon label style keeps the cross instead of

--- a/scripts/check-situation-map-attribution.sh
+++ b/scripts/check-situation-map-attribution.sh
@@ -18,6 +18,31 @@ if ! grep -q 'static func attributions' "$resource"; then
     status=1
 fi
 
+# The close button belongs to the platform, and two modifiers are what let it draw one.
+# The glass style supplies the disc, and the icon label style keeps the cross instead of
+# the word the role carries. Removing either leaves something that looks like the other
+# one is at fault: a bare tinted cross, or a glass button that says "Close".
+if ! grep -q 'Button(role: .close, action: close)' "$panel"; then
+    echo "FORBIDDEN: the panel must be closed by the platform's own close button" >&2
+    status=1
+fi
+if ! grep -A 6 'Button(role: .close, action: close)' "$panel" | grep -qF 'buttonStyle(.glass)'; then
+    echo "FORBIDDEN: the close button needs the glass style, or the role draws a bare cross on nothing" >&2
+    status=1
+fi
+# The role carries a text label of its own, and that label is the word "Close". Either
+# naming the symbol or asking for icons only keeps it off the panel; neither leaves it
+# free to appear.
+if ! grep -A 6 'Button(role: .close, action: close)' "$panel" \
+    | grep -Eq 'labelStyle\(.iconOnly\)|systemName: "xmark"'; then
+    echo "FORBIDDEN: the close button must name its symbol or ask for icons only, or it shows the word Close" >&2
+    status=1
+fi
+if grep -A 8 'Button(role: .close' "$panel" | grep -Eq 'secondarySystemFill|background\(.*in: .circle\)'; then
+    echo "FORBIDDEN: the close button must not be redrawn by hand over the platform's own" >&2
+    status=1
+fi
+
 python3 - "$style" "$panel" <<'PY' || status=1
 import json
 import sys

--- a/scripts/check-situation-map-attribution.sh
+++ b/scripts/check-situation-map-attribution.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Keep every map source's notice on screen.
+#
+# A source draws ground a reader looks at, and the people who surveyed that ground ask to
+# be named for it. The failure is silent in both directions: a source added without a
+# notice draws anyway, and a notice reworded out of the panel's provider table falls back
+# to a generic line that credits nobody. Neither shows up as a crash or a failed build.
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+style="$root/clients/apple-situation/Resources/SituationStyle.json"
+panel="$root/clients/apple-situation/App/MapModesView.swift"
+resource="$root/clients/apple-situation/App/SituationStyleResource.swift"
+status=0
+
+if ! grep -q 'static func attributions' "$resource"; then
+    echo "FORBIDDEN: the notices must be read from the style document, not from a loaded map" >&2
+    status=1
+fi
+
+python3 - "$style" "$panel" <<'PY' || status=1
+import json
+import sys
+
+style_path, panel_path = sys.argv[1], sys.argv[2]
+with open(style_path) as handle:
+    sources = json.load(handle).get("sources", {})
+panel = open(panel_path).read()
+
+failed = False
+for name, source in sources.items():
+    notice = (source.get("attribution") or "").strip()
+    if not notice:
+        print(f"FORBIDDEN: style source {name!r} draws without a notice", file=sys.stderr)
+        failed = True
+        continue
+    # The panel names one provider and says there are others. The name it looks for has
+    # to still be in the notice, or the panel silently credits nobody.
+    quoted = [
+        part.split('"')[0]
+        for part in panel.split('contains("')[1:]
+    ]
+    if not any(fragment and fragment in notice for fragment in quoted):
+        print(
+            f"FORBIDDEN: no provider name in the map modes panel matches the notice for "
+            f"{name!r}, so the panel falls back to a line that credits nobody",
+            file=sys.stderr,
+        )
+        failed = True
+
+sys.exit(1 if failed else 0)
+PY
+
+exit "$status"

--- a/scripts/check-situation-map-attribution.sh
+++ b/scripts/check-situation-map-attribution.sh
@@ -18,6 +18,26 @@ if ! grep -q 'static func attributions' "$resource"; then
     status=1
 fi
 
+# The panel is shown two ways and both have to survive. Beside the map it grows out of
+# the control that opened it; too narrow for that, it comes up from the bottom edge at the
+# full width. Losing either leaves a panel that is correct at one window size and covers
+# the map it describes at the other, which no build failure reports.
+app_root="$root/clients/apple-situation/App"
+if ! grep -q 'horizontalSizeClass == .regular' "$app_root/PilotageSituationApp.swift"; then
+    echo "FORBIDDEN: the panel must ask the platform whether there is room beside the map" >&2
+    status=1
+fi
+for shape in 'modesGrowFromControls' 'presentationSizing(.fitted)'; do
+    if ! grep -qF "$shape" "$app_root/PilotageSituationApp.swift"; then
+        echo "FORBIDDEN: the panel lost one of its two presentations ($shape)" >&2
+        status=1
+    fi
+done
+if ! grep -q 'fixedWidth' "$panel"; then
+    echo "FORBIDDEN: a panel brought up from the bottom edge must take the width it is given" >&2
+    status=1
+fi
+
 # The close button belongs to the platform, and two modifiers are what let it draw one.
 # The glass style supplies the disc, and the icon label style keeps the cross instead of
 # the word the role carries. Removing either leaves something that looks like the other

--- a/scripts/check-situation-ownship-wiring.sh
+++ b/scripts/check-situation-ownship-wiring.sh
@@ -74,6 +74,14 @@ require_pattern '@Published var follow' "$app/OwnshipPosition.swift" \
 require_pattern 'GlassEffectContainer\(spacing: Metrics\.controlSpacing\)' "$app/MapControlsView.swift" \
     "the glass blend distance must equal the gap between controls, or a control cannot morph out of the group"
 
+# A view inserted alongside its parent is covered by the parent's transition and never
+# runs its own. Only a change made in a later cycle is an insertion the label can animate,
+# so the wait is load bearing and reads like a decoration.
+if ! grep -A 6 'levelLabelShown = false' "$app/MapControlsView.swift" | grep -q 'Task.sleep'; then
+    echo "FORBIDDEN: the label must change state in a later cycle than the control it sits in, or its own transition never runs" >&2
+    status=1
+fi
+
 # Following is a mode. A camera that only moves when the control is pressed is a jump
 # wearing the name of a mode, and it stops the moment the aircraft does anything.
 require_pattern 'onChange\(of: ownship\.fix\)' "$app/PilotageSituationApp.swift" \

--- a/scripts/check-situation-ownship-wiring.sh
+++ b/scripts/check-situation-ownship-wiring.sh
@@ -68,6 +68,12 @@ require_pattern 'case \.landscapeLeft: \.landscapeRight' "$app/OwnshipPosition.s
 require_pattern '@Published var follow' "$app/OwnshipPosition.swift" \
     "the follow mode must live in the model, because a closure that reads it outlives the view value"
 
+# A glass container blends only the shapes that sit within its spacing. Give it less than
+# the gap between the controls and each one becomes its own island: it stops growing out of
+# the group and starts arriving from nowhere, which is a one-token change with no error.
+require_pattern 'GlassEffectContainer\(spacing: Metrics\.controlSpacing\)' "$app/MapControlsView.swift" \
+    "the glass blend distance must equal the gap between controls, or a control cannot morph out of the group"
+
 # Following is a mode. A camera that only moves when the control is pressed is a jump
 # wearing the name of a mode, and it stops the moment the aircraft does anything.
 require_pattern 'onChange\(of: ownship\.fix\)' "$app/PilotageSituationApp.swift" \

--- a/scripts/test-check-situation-map-attribution.sh
+++ b/scripts/test-check-situation-map-attribution.sh
@@ -68,8 +68,12 @@ sed -i.bak 's/drawsSurface: false/drawsSurface: true/' "$app/PilotageSituationAp
 reject "a panel drawing a second surface inside the sheet"
 cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
 
-sed -i.bak '/presentationSizing(.fitted)/d' "$app/PilotageSituationApp.swift"
+sed -i.bak '/presentationDetents/d' "$app/PilotageSituationApp.swift"
 reject "a panel that lost its narrow presentation"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+
+sed -i.bak 's/min(modesHeight, windowHeight \* 0.92)/modesHeight/' "$app/PilotageSituationApp.swift"
+reject "a sheet that may ask to be taller than its window"
 cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
 
 sed -i.bak 's/horizontalSizeClass == .regular/true/' "$app/PilotageSituationApp.swift"

--- a/scripts/test-check-situation-map-attribution.sh
+++ b/scripts/test-check-situation-map-attribution.sh
@@ -64,6 +64,10 @@ sed -i.bak '/static func attributions/d' "$app/SituationStyleResource.swift"
 reject "notices read from a loaded map rather than from the style document"
 cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"
 
+sed -i.bak 's/drawsSurface: false/drawsSurface: true/' "$app/PilotageSituationApp.swift"
+reject "a panel drawing a second surface inside the sheet"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+
 sed -i.bak '/presentationSizing(.fitted)/d' "$app/PilotageSituationApp.swift"
 reject "a panel that lost its narrow presentation"
 cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"

--- a/scripts/test-check-situation-map-attribution.sh
+++ b/scripts/test-check-situation-map-attribution.sh
@@ -10,6 +10,7 @@ app="$fixture/clients/apple-situation/App"
 resources="$fixture/clients/apple-situation/Resources"
 mkdir -p "$app" "$resources" "$fixture/scripts"
 cp "$repo_root/clients/apple-situation/App/MapModesView.swift" "$app/"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
 cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"
 cp "$repo_root/clients/apple-situation/Resources/SituationStyle.json" "$resources/"
 cp "$repo_root/scripts/check-situation-map-attribution.sh" "$fixture/scripts/"
@@ -63,5 +64,13 @@ sed -i.bak '/static func attributions/d' "$app/SituationStyleResource.swift"
 reject "notices read from a loaded map rather than from the style document"
 cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"
 
+sed -i.bak '/presentationSizing(.fitted)/d' "$app/PilotageSituationApp.swift"
+reject "a panel that lost its narrow presentation"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+
+sed -i.bak 's/horizontalSizeClass == .regular/true/' "$app/PilotageSituationApp.swift"
+reject "a panel that never asks whether there is room beside the map"
+cp "$repo_root/clients/apple-situation/App/PilotageSituationApp.swift" "$app/"
+
 bash "$gate" "$fixture" >/dev/null
-echo "attribution guard rejects an uncredited source"
+echo "attribution and presentation guards reject each loss"

--- a/scripts/test-check-situation-map-attribution.sh
+++ b/scripts/test-check-situation-map-attribution.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Prove that the attribution guard rejects a source that credits nobody.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-attribution.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+app="$fixture/clients/apple-situation/App"
+resources="$fixture/clients/apple-situation/Resources"
+mkdir -p "$app" "$resources" "$fixture/scripts"
+cp "$repo_root/clients/apple-situation/App/MapModesView.swift" "$app/"
+cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"
+cp "$repo_root/clients/apple-situation/Resources/SituationStyle.json" "$resources/"
+cp "$repo_root/scripts/check-situation-map-attribution.sh" "$fixture/scripts/"
+
+gate="$fixture/scripts/check-situation-map-attribution.sh"
+bash "$gate" "$fixture" >/dev/null
+
+reject() {
+    if bash "$gate" "$fixture" >/dev/null 2>&1; then
+        echo "the attribution guard accepted $1" >&2
+        exit 1
+    fi
+}
+
+python3 - "$resources/SituationStyle.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+style["sources"]["pilotage-uncredited"] = {"type": "raster", "tiles": ["http://x/{z}/{x}/{y}"]}
+json.dump(style, open(path, "w"))
+PY
+reject "a source that draws without a notice"
+cp "$repo_root/clients/apple-situation/Resources/SituationStyle.json" "$resources/"
+
+python3 - "$resources/SituationStyle.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+style["sources"]["pilotage-coastline"]["attribution"] = "Made with a renamed provider."
+style["sources"]["pilotage-terrain"]["attribution"] = "Heights from a renamed provider."
+json.dump(style, open(path, "w"))
+PY
+reject "notices no provider name in the panel matches"
+cp "$repo_root/clients/apple-situation/Resources/SituationStyle.json" "$resources/"
+
+sed -i.bak '/static func attributions/d' "$app/SituationStyleResource.swift"
+reject "notices read from a loaded map rather than from the style document"
+cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"
+
+bash "$gate" "$fixture" >/dev/null
+echo "attribution guard rejects an uncredited source"

--- a/scripts/test-check-situation-map-attribution.sh
+++ b/scripts/test-check-situation-map-attribution.sh
@@ -47,6 +47,18 @@ PY
 reject "notices no provider name in the panel matches"
 cp "$repo_root/clients/apple-situation/Resources/SituationStyle.json" "$resources/"
 
+sed -i.bak 's/Button(role: .close, action: close)/Button(action: close)/' "$app/MapModesView.swift"
+reject "a panel closed by something other than the platform's close button"
+cp "$repo_root/clients/apple-situation/App/MapModesView.swift" "$app/"
+
+sed -i.bak 's/Image(systemName: "xmark")/Text(verbatim: "")/' "$app/MapModesView.swift"
+reject "a close button that renders the word the role carries"
+cp "$repo_root/clients/apple-situation/App/MapModesView.swift" "$app/"
+
+sed -i.bak '/buttonStyle(.glass)/d' "$app/MapModesView.swift"
+reject "a close button with no disc under its cross"
+cp "$repo_root/clients/apple-situation/App/MapModesView.swift" "$app/"
+
 sed -i.bak '/static func attributions/d' "$app/SituationStyleResource.swift"
 reject "notices read from a loaded map rather than from the style document"
 cp "$repo_root/clients/apple-situation/App/SituationStyleResource.swift" "$app/"

--- a/scripts/test-check-situation-ownship-wiring.sh
+++ b/scripts/test-check-situation-ownship-wiring.sh
@@ -49,6 +49,10 @@ sed -i.bak 's/applyFollow(animated: false)/applyFollow(animated: true)/' \
 reject "a camera eased on every reading"
 restore PilotageSituationApp.swift
 
+sed -i.bak 's/try? await Task.sleep(for: .milliseconds(180))//' "$app/MapControlsView.swift"
+reject "a label whose state changes in the cycle that inserts its control"
+restore MapControlsView.swift
+
 sed -i.bak 's/GlassEffectContainer(spacing: Metrics.controlSpacing)/GlassEffectContainer(spacing: 4)/' \
     "$app/MapControlsView.swift"
 reject "a blend distance below the gap, which leaves each control its own island"

--- a/scripts/test-check-situation-ownship-wiring.sh
+++ b/scripts/test-check-situation-ownship-wiring.sh
@@ -49,6 +49,11 @@ sed -i.bak 's/applyFollow(animated: false)/applyFollow(animated: true)/' \
 reject "a camera eased on every reading"
 restore PilotageSituationApp.swift
 
+sed -i.bak 's/GlassEffectContainer(spacing: Metrics.controlSpacing)/GlassEffectContainer(spacing: 4)/' \
+    "$app/MapControlsView.swift"
+reject "a blend distance below the gap, which leaves each control its own island"
+restore MapControlsView.swift
+
 sed -i.bak 's/^        compass.start()$//' "$app/OwnshipPosition.swift"
 reject "a position request that leaves the compass stopped"
 restore OwnshipPosition.swift


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #412 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #411
- <kbd>&nbsp;2&nbsp;</kbd> #410
- <kbd>&nbsp;1&nbsp;</kbd> #407
<!-- GitButler Footer Boundary Bottom -->