### PR TITLE
State the documentation language the repository writes in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Pilotage Repository Instructions
+
+## Documentation language
+
+All project-authored documentation MUST use ASD-STE100 Simplified Technical
+English.
+
+- Write in English.
+- Use an approved word when it has the required meaning.
+- Use one word for one meaning.
+- Use short, direct sentences.
+- Use active voice when you can identify the actor.
+- Give one instruction or one main statement in each sentence.
+- Define a necessary technical name before you use it.
+- Use the same technical name in all related documents and diagrams.
+- Keep code identifiers, protocol fields, quotations, and product names exact.
+- Apply these rules to all new text and to all text that you change.
+
+Do not copy noncompliant legacy text into a new document. Record a broad legacy
+rewrite as separate work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Pilotage Repository Instructions
+
+Write all project-authored documentation in ASD-STE100 Simplified Technical
+English. Apply the full documentation language rules in `AGENTS.md`.


### PR DESCRIPTION
## What changes

`AGENTS.md` states the documentation language, and `CLAUDE.md` points at it.

The rules were followed and never written down, so a reader had to infer them from the
text already here. This is the arrangement the radio link repository already uses.