### PR TITLE
Stop tracking the scheme list Xcode writes for one account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ clients/apple/.build/
 clients/apple/Pilotage.xcodeproj/
 clients/apple/Resources/SituationCoastline.mbtiles
 clients/apple/Resources/SituationTerrain.mbtiles
+
+# Xcode writes one of these for each person who opens a package, under their own
+# account name, and rewrites it whenever a scheme is shown or hidden.
+xcuserdata/


### PR DESCRIPTION
## What changes

Xcode writes one `xcschememanagement.plist` for each person who opens a package, under
their own account name, and rewrites it whenever a scheme is shown or hidden. Four of
them were committed by accident.

The files are removed from the branch that added them, and the ignore rule lands here so
the next person to open a package does not commit theirs.