### PR TITLE
Point the source-identity comments at the decision in force

### DIFF
--- a/crates/pilotage-adapter-api/src/telemetry.rs
+++ b/crates/pilotage-adapter-api/src/telemetry.rs
@@ -4,7 +4,7 @@ use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
 // Source identity moved to `pilotage-ingress` so the ingress rules can be
-// applied where no wire exists (ADR-0018, ADR-0026's host-absent posture).
+// applied where no wire exists (ADR-0018, ADR-0037's local-source path).
 // Re-exported here because this crate is the adapter-facing vocabulary.
 pub use pilotage_ingress::{
     MeasurementClock, MeasurementStamp, SourceIncarnation, SourceIntegrity, SourceRole,

--- a/crates/pilotage-ingress/src/lib.rs
+++ b/crates/pilotage-ingress/src/lib.rs
@@ -8,8 +8,8 @@
 //! refresh its age.
 //!
 //! Those rules are stated here in types that carry no wire dependency, because
-//! they are needed in postures where no wire exists. ADR-0026's host-absent
-//! `embedded` posture — a tablet talking straight to a panel — still has source
+//! they are needed in compositions where no wire exists. ADR-0037's local-source
+//! path — a tablet talking straight to a panel — still has source
 //! identity: the panel boots, reconnects, and can be swapped. Expressing
 //! identity only in protocol types would make the rules unavailable exactly
 //! where there is no protocol.


### PR DESCRIPTION
## What changes

ADR-0026 is superseded by ADR-0037. Two comments still cite the superseded decision,
which sends a reader to a document that no longer states the rule the code follows.