### PR TITLE
Let a device on the network join the session xtask starts

### DIFF
--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -26,6 +26,8 @@ pub struct SessionContext {
     pub profile: Profile,
     /// Directory stage logs are written under.
     pub log_dir: PathBuf,
+    /// Serve the session to the local network rather than loopback only.
+    pub lan: bool,
 }
 
 /// One plannable launch step: a process and the signal proving it is up.

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -215,6 +215,7 @@ mod tests {
             viewer_port: 8080,
             profile: Profile::Simulation,
             log_dir,
+            lan: false,
         }
     }
 

--- a/tools/xtask/src/backend/px4_gz/tests.rs
+++ b/tools/xtask/src/backend/px4_gz/tests.rs
@@ -18,6 +18,7 @@ fn context(repo_root: PathBuf) -> SessionContext {
         viewer_port: 8080,
         profile: Profile::Simulation,
         log_dir: std::env::temp_dir(),
+        lan: false,
     }
 }
 

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -50,6 +50,10 @@ pub struct SimArgs {
     /// Open the ready URL in the default browser (default on;
     /// `--no-open` suppresses it, `--open` states it explicitly).
     pub open: bool,
+    /// Serve the session to the local network (`--lan`): the viewer and
+    /// its connect manifest become reachable from another device, and the
+    /// native connect facts are printed.
+    pub lan: bool,
 }
 
 /// A parsed xtask invocation.
@@ -113,6 +117,7 @@ fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
     let mut host_port: u16 = 4433;
     let mut viewer_port: u16 = 8080;
     let mut open = true;
+    let mut lan = false;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
@@ -122,6 +127,7 @@ fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
             "--viewer-port" => viewer_port = required_port(&mut iter, "--viewer-port")?,
             "--open" => open = true,
             "--no-open" => open = false,
+            "--lan" => lan = true,
             other => {
                 return Err(XtaskError::Usage {
                     message: format!("unknown sim flag {other:?}"),
@@ -135,6 +141,7 @@ fn parse_sim(args: &[String]) -> Result<SimArgs, XtaskError> {
         host_port,
         viewer_port,
         open,
+        lan,
     })
 }
 
@@ -183,6 +190,7 @@ commands:
       --viewer-port <port> static viewer port (default: 8080)
       --open               open the ready URL (default)
       --no-open            do not open the ready URL
+      --lan                serve the session to the local network
 
   reset [options]
       Reset the running simulation world and restart its FC.
@@ -212,6 +220,7 @@ mod tests {
         assert_eq!(sim.host_port, 4433);
         assert_eq!(sim.viewer_port, 8080);
         assert!(sim.open, "the browser opens by default");
+        assert!(!sim.lan, "the session serves loopback only by default");
     }
 
     #[test]
@@ -236,6 +245,7 @@ mod tests {
         assert!(sim_help.contains("default: 8080"));
         assert!(sim_help.contains("--open"));
         assert!(sim_help.contains("--no-open"));
+        assert!(sim_help.contains("--lan"));
 
         let reset_help = &USAGE[reset_start..help_start];
         assert!(reset_help.contains("--fc <name>"));
@@ -245,10 +255,12 @@ mod tests {
 
     #[test]
     fn no_open_suppresses_the_browser() {
-        let Command::Sim(sim) = parse_args(&args(&["sim", "--no-open"])).expect("parses") else {
+        let Command::Sim(sim) = parse_args(&args(&["sim", "--no-open", "--lan"])).expect("parses")
+        else {
             panic!("expected sim");
         };
         assert!(!sim.open);
+        assert!(sim.lan, "--lan is honored");
     }
 
     #[test]

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -184,8 +184,8 @@ pub fn viewer_url(viewer_port: u16, host_port: u16, cert: &str) -> String {
 /// CURRENT session's connect parameters. A viewer tab whose URL pins an
 /// older session's certificate re-reads this after a failed connect and
 /// converges on the live session instead of retrying a dead hash forever.
-pub fn session_manifest(host_port: u16, cert: &str) -> String {
-    format!("{{\"host\":\"127.0.0.1\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n")
+pub fn session_manifest(host: &str, host_port: u16, cert: &str) -> String {
+    format!("{{\"host\":\"{host}\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n")
 }
 
 /// The log file a stage writes under `log_dir`.
@@ -238,7 +238,7 @@ mod tests {
         // The viewer's validator requires this exact shape (host string,
         // integer port, 64-hex certHash); a drift here strands stale tabs.
         assert_eq!(
-            super::session_manifest(4433, &cert),
+            super::session_manifest("127.0.0.1", 4433, &cert),
             format!("{{\"host\":\"127.0.0.1\",\"port\":4433,\"certHash\":\"{cert}\"}}\n")
         );
     }

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -12,9 +12,7 @@ use crate::cli::SimArgs;
 use crate::error::XtaskError;
 use crate::output::print_line;
 use crate::process::{ManagedChild, ProcessSpec};
-use crate::readiness::{
-    Readiness, ReadySignal, await_ready, session_manifest, stage_log, viewer_url,
-};
+use crate::readiness::{Readiness, ReadySignal, await_ready, stage_log};
 use preflight::{build_host, prepare_web_assets};
 
 pub(crate) mod preflight;
@@ -43,6 +41,7 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
         viewer_port: args.viewer_port,
         profile: args.profile,
         log_dir: log_dir.clone(),
+        lan: args.lan,
     };
 
     refuse_stale_session(backend.stale_process_patterns())?;
@@ -96,8 +95,7 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     let pid_file = log_dir.join("supervisor.pid");
     claim_supervisor(&pid_file, &mut children)?;
 
-    write_session_manifest(&ctx, actual_port, &certificate);
-    announce_ready(args, actual_port, &certificate);
+    announce::publish_connect_facts(args, &ctx, actual_port, &certificate);
 
     let outcome = supervise(&mut children, &stages, &mut cancel).await;
     std::fs::remove_file(&pid_file).ok();
@@ -107,32 +105,6 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     std::fs::remove_file(ctx.repo_root.join("clients/web/session.json")).ok();
     teardown(&mut children);
     outcome
-}
-
-/// Prints the ready URL and opens it in the default browser when asked.
-fn announce_ready(args: &SimArgs, actual_port: u16, certificate: &str) {
-    let url = viewer_url(args.viewer_port, actual_port, certificate);
-    print_line("");
-    print_line(&format!("session ready: {url}"));
-    print_line("press ctrl-c to stop the session");
-    if args.open {
-        open_in_browser(&url);
-    }
-}
-
-/// Writes the served session manifest (`clients/web/session.json`): any
-/// viewer tab — including one whose URL pins an older session's
-/// certificate — re-reads it after a failed connect and converges on
-/// THIS session. Best-effort: a failed write only loses stale-tab
-/// convergence, never the session.
-fn write_session_manifest(ctx: &SessionContext, port: u16, certificate: &str) {
-    let path = ctx.repo_root.join("clients/web/session.json");
-    if let Err(error) = std::fs::write(&path, session_manifest(port, certificate)) {
-        print_line(&format!(
-            "warning: could not write {}: {error}",
-            path.display()
-        ));
-    }
 }
 
 /// Registers the SIGINT handler and returns a receiver that flips to
@@ -382,8 +354,11 @@ fn viewer_stage(ctx: &SessionContext) -> Result<Stage, XtaskError> {
          \tdef end_headers(self):\n\
          \t\tself.send_header('Cache-Control', 'no-store')\n\
          \t\tsuper().end_headers()\n\
-         http.server.test(HandlerClass=H, port={port}, bind='127.0.0.1')\n",
-        port = ctx.viewer_port
+         http.server.test(HandlerClass=H, port={port}, bind='{bind}')\n",
+        port = ctx.viewer_port,
+        // Loopback by default: serving the working tree to the network is
+        // an explicit request, never a side effect of running a sim.
+        bind = if ctx.lan { "0.0.0.0" } else { "127.0.0.1" }
     );
     Ok(Stage {
         spec: ProcessSpec {
@@ -481,6 +456,8 @@ fn open_in_browser(url: &str) {
         tracing::warn!(%error, opener, "could not open the browser; use the printed URL");
     }
 }
+
+mod announce;
 
 #[cfg(test)]
 mod tests;

--- a/tools/xtask/src/session/announce.rs
+++ b/tools/xtask/src/session/announce.rs
@@ -1,0 +1,75 @@
+//! The ready banner and the served connect facts.
+
+use crate::backend::SessionContext;
+use crate::cli::SimArgs;
+use crate::output::print_line;
+use crate::readiness::{session_manifest, viewer_url};
+
+use super::open_in_browser;
+
+/// Resolves the session's reachable address, writes the manifest, and
+/// prints the banner — one call so the three artifacts can never carry
+/// different facts.
+pub(super) fn publish_connect_facts(
+    args: &SimArgs,
+    ctx: &SessionContext,
+    actual_port: u16,
+    certificate: &str,
+) {
+    let session_host = if ctx.lan {
+        lan_address().unwrap_or_else(|| "127.0.0.1".to_owned())
+    } else {
+        "127.0.0.1".to_owned()
+    };
+    write_session_manifest(ctx, &session_host, actual_port, certificate);
+    announce_ready(args, &session_host, actual_port, certificate);
+}
+
+/// Prints the ready URL and opens it in the default browser when asked.
+/// Under `--lan` the native connect facts follow: the same three values a
+/// browser takes from the query string, for a client that takes them from
+/// a settings screen instead.
+fn announce_ready(args: &SimArgs, session_host: &str, actual_port: u16, certificate: &str) {
+    let url = viewer_url(args.viewer_port, actual_port, certificate);
+    print_line("");
+    print_line(&format!("session ready: {url}"));
+    if args.lan {
+        print_line(&format!(
+            "native clients: https://{session_host}:{actual_port}/pilotage"
+        ));
+        print_line(&format!("  certificate sha-256: {certificate}"));
+        print_line(&format!(
+            "  connect manifest: http://{session_host}:{}/session.json",
+            args.viewer_port
+        ));
+    }
+    print_line("press ctrl-c to stop the session");
+    if args.open {
+        open_in_browser(&url);
+    }
+}
+
+/// The address another device on this network reaches this machine at:
+/// the local address of a routed UDP socket. No datagram is sent; a
+/// machine with no route reports nothing and the caller falls back to
+/// loopback rather than guessing among interfaces.
+fn lan_address() -> Option<String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("192.0.2.1:9").ok()?;
+    Some(socket.local_addr().ok()?.ip().to_string())
+}
+
+/// Writes the served session manifest (`clients/web/session.json`): any
+/// viewer tab — including one whose URL pins an older session's
+/// certificate — re-reads it after a failed connect and converges on
+/// THIS session. Best-effort: a failed write only loses stale-tab
+/// convergence, never the session.
+fn write_session_manifest(ctx: &SessionContext, session_host: &str, port: u16, certificate: &str) {
+    let path = ctx.repo_root.join("clients/web/session.json");
+    if let Err(error) = std::fs::write(&path, session_manifest(session_host, port, certificate)) {
+        print_line(&format!(
+            "warning: could not write {}: {error}",
+            path.display()
+        ));
+    }
+}

--- a/tools/xtask/src/session/tests.rs
+++ b/tools/xtask/src/session/tests.rs
@@ -390,6 +390,7 @@ async fn viewer_server_sets_cache_control_no_store() {
         viewer_port: free_port(),
         profile: Profile::Simulation,
         log_dir: repo_root.clone(),
+        lan: false,
     };
     let stage = viewer_stage(&ctx).expect("the viewer stage plans");
     let mut child = ManagedChild::spawn(&stage.spec).expect("the viewer server spawns");


### PR DESCRIPTION
Under --lan the viewer serves the network, the manifest carries the address another device reaches this machine at, and the ready banner prints the native connect facts: the WebTransport URL, the certificate hash, and the manifest URL a client can fetch them from. Hash pinning is the same trust model the browser uses; no certificate authority appears.

Loopback remains the default. Serving the working tree to the network is an explicit request, never a side effect of running a sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
