### PR TITLE
Sticks and keys work the control lifecycle, and the recovery ack reaches the runtime

### DIFF
--- a/clients/apple/App/FootprintProbe.swift
+++ b/clients/apple/App/FootprintProbe.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+#if DEBUG
+/// Prints the process physical footprint once per interval, so a
+/// console-attached run shows a leak as a slope, not a surprise.
+enum FootprintProbe {
+    static func start() {
+        guard LaunchRequest.openInstruments else { return }
+        Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
+            var info = task_vm_info_data_t()
+            var count = mach_msg_type_number_t(
+                MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+            let result = withUnsafeMutablePointer(to: &info) {
+                $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                    task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+                }
+            }
+            if result == KERN_SUCCESS {
+                let mb = Double(info.phys_footprint) / 1_048_576
+                print("harness memory: footprint \(Int(mb)) MB")
+            }
+        }
+    }
+}
+#endif

--- a/clients/apple/App/HostLinkModel.swift
+++ b/clients/apple/App/HostLinkModel.swift
@@ -357,9 +357,8 @@ final class HostLinkModel: ObservableObject {
             // An unleased arm press asks for control on its own, so a
             // suppressed one means the ask is already in flight or the
             // motion path is still recovering.
-            status = action == 1
-                ? "arm press ignored — control is not live yet"
-                : "disarm press ignored — nothing is held"
+            let control = action == 1 ? "arm" : "disarm"
+            status = "\(control) press ignored — control is not live yet"
         case .gimbalCapture(let active):
             gimbalCaptured = active
         case .notice(let text):
@@ -532,18 +531,19 @@ final class HostLinkModel: ObservableObject {
             print("harness demand: tick \(demandTicks) held=\(leaseHeld) climb=\(climb)")
         }
         #endif
-        if climb > 0 {
-            link?.sendMotion(roll: 0, pitch: 0, throttle: climb, yaw: 0)
-            return
-        }
         guard let pad = GCController.controllers()
             .compactMap(\.extendedGamepad)
             .first
         else {
-            // No pad: the held keys drive the same runtime — and with
-            // nothing held, this is the neutral tick that keeps a held
-            // lease alive.
-            link?.sendKeySample()
+            // No pad: the held keys drive the same runtime, exactly as
+            // the browser falls back to its keyboard profile. With
+            // nothing held this is the neutral tick that keeps a held
+            // lease alive; the harness climb overrides it.
+            if climb > 0 {
+                link?.sendMotion(roll: 0, pitch: 0, throttle: climb, yaw: 0)
+            } else {
+                link?.sendKeySample()
+            }
             return
         }
         // The raw sample in Standard Gamepad terms; every mapping,

--- a/clients/apple/App/HostLinkModel.swift
+++ b/clients/apple/App/HostLinkModel.swift
@@ -108,7 +108,15 @@ final class HostLinkModel: ObservableObject {
         }
         panels = choices
         watchControllers()
+        // The keyboard feeds the same runtime the pad does; the
+        // monitor only canonicalizes and guards, it binds nothing.
+        keyboardMonitor.start(
+            onKey: { [weak self] key, pressed in self?.link?.keyEvent(key: key, pressed: pressed) },
+            onClear: { [weak self] in self?.link?.clearKeys() }
+        )
     }
+
+    private let keyboardMonitor = KeyboardControlMonitor()
 
     /// Verifies and builds the paint pipeline on first use, so a map-only
     /// launch never pays for the glyph atlas or the gate. A refusal shows
@@ -303,6 +311,11 @@ final class HostLinkModel: ObservableObject {
             if controllerAttached {
                 selectPad(vendorName: lastPadVendor)
             }
+            // The tick loop runs for the whole admitted session, not
+            // just under a lease: the shared runtime gates what may
+            // not leave, and an arm press on the pad or keyboard is
+            // how an operator asks for control in the first place.
+            startControlLoop()
             if LaunchRequest.autoControl {
                 requestLease()
             }
@@ -320,7 +333,6 @@ final class HostLinkModel: ObservableObject {
                 // The engine already escalated the denial into the ask;
                 // the operator's one press keeps working on its own.
                 status = "asked the holder of \(scope) to hand over"
-                held ? startControlLoop() : stopControlLoop()
                 return
             }
             if held {
@@ -329,7 +341,6 @@ final class HostLinkModel: ObservableObject {
                 phase = .observing(host: catalog.hostVersion)
             }
             status = held ? "controlling \(scope)" : "observing (\(detail))"
-            held ? startControlLoop() : stopControlLoop()
             if held && LaunchRequest.autoArm {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
                     self?.arm()
@@ -343,9 +354,12 @@ final class HostLinkModel: ObservableObject {
         case .padSelected(let label, let armHint, let disarmHint):
             padHints = "\(label): arm \(armHint) · disarm \(disarmHint)"
         case .pressSuppressed(let action):
+            // An unleased arm press asks for control on its own, so a
+            // suppressed one means the ask is already in flight or the
+            // motion path is still recovering.
             status = action == 1
-                ? "arm press ignored — request control first"
-                : "disarm press ignored — request control first"
+                ? "arm press ignored — control is not live yet"
+                : "disarm press ignored — nothing is held"
         case .gimbalCapture(let active):
             gimbalCaptured = active
         case .notice(let text):
@@ -505,35 +519,12 @@ final class HostLinkModel: ObservableObject {
     /// The pressed-button set last printed by the harness.
     private var lastPressedPrint: [Int] = []
 
-    #if DEBUG
-    /// Prints the process physical footprint once per interval, so a
-    /// console-attached run shows a leak as a slope, not a surprise.
-    static func startFootprintProbe() {
-        guard LaunchRequest.openInstruments else { return }
-        Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
-            var info = task_vm_info_data_t()
-            var count = mach_msg_type_number_t(
-                MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
-            let result = withUnsafeMutablePointer(to: &info) {
-                $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                    task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
-                }
-            }
-            if result == KERN_SUCCESS {
-                let mb = Double(info.phys_footprint) / 1_048_576
-                print("harness memory: footprint \(Int(mb)) MB")
-            }
-        }
-    }
-    #endif
-
     private func sendDemand() {
-        guard leaseHeld else { return }
-        // The host's silence watchdog revokes a holder that stops
-        // sending: one second of quiet cost the lease while the screen
-        // still said "controlling". Frames flow at rate for as long as
-        // the lease is held — a neutral demand when no stick is attached
-        // is the holder's liveness, exactly as the browser streams it.
+        guard catalog != nil else { return }
+        // The tick runs whether or not control is held: the shared
+        // runtime gates what an observer may not send, turns an arm
+        // press into the ask for control, and — under a held lease —
+        // streams the liveness the host's silence watchdog demands.
         let climb: Float = climbUntil > Date() ? 0.6 : 0
         #if DEBUG
         demandTicks += 1
@@ -541,11 +532,18 @@ final class HostLinkModel: ObservableObject {
             print("harness demand: tick \(demandTicks) held=\(leaseHeld) climb=\(climb)")
         }
         #endif
+        if climb > 0 {
+            link?.sendMotion(roll: 0, pitch: 0, throttle: climb, yaw: 0)
+            return
+        }
         guard let pad = GCController.controllers()
             .compactMap(\.extendedGamepad)
             .first
         else {
-            link?.sendMotion(roll: 0, pitch: 0, throttle: climb, yaw: 0)
+            // No pad: the held keys drive the same runtime — and with
+            // nothing held, this is the neutral tick that keeps a held
+            // lease alive.
+            link?.sendKeySample()
             return
         }
         // The raw sample in Standard Gamepad terms; every mapping,

--- a/clients/apple/App/InstrumentRackView.swift
+++ b/clients/apple/App/InstrumentRackView.swift
@@ -295,13 +295,23 @@ struct InstrumentRackView: View {
                 if model.leaseHeld {
                     ArmTelegraphControl(model: model)
                     Spacer()
+                    // One word, never wrapped: the chip above already
+                    // says "Controlling", so this button only carries
+                    // the verb. The pad speaks it too — a disarm press
+                    // with the lever settled on SAFE stands down.
                     Button("Release", role: .destructive) { model.releaseLease() }
+                        .lineLimit(1)
+                        .fixedSize()
                 } else {
                     Spacer()
                     // One intent, one button: a denial with a standing
-                    // holder escalates to the ask on its own.
+                    // holder escalates to the ask on its own, and an
+                    // arm press on the pad or keyboard is this same
+                    // ask without reaching for the screen.
                     Button("Request control") { model.requestLease() }
                         .disabled(model.catalog == nil)
+                        .lineLimit(1)
+                        .fixedSize()
                 }
             }
             .font(.callout)

--- a/clients/apple/App/KeyboardControlMonitor.swift
+++ b/clients/apple/App/KeyboardControlMonitor.swift
@@ -47,6 +47,23 @@ final class KeyboardControlMonitor {
         ) { [weak self] _ in
             Task { @MainActor in self?.onClear?() }
         }
+        // A field taking focus is itself the release: a key held at
+        // that moment sends no further event, so waiting for one would
+        // leave it commanding the vehicle for as long as the operator
+        // types.
+        for began in [
+            UITextField.textDidBeginEditingNotification,
+            UITextView.textDidBeginEditingNotification,
+        ] {
+            NotificationCenter.default.addObserver(
+                forName: began, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.typing = true
+                    self?.onClear?()
+                }
+            }
+        }
     }
 
     private func attach(_ keyboard: GCKeyboard) {

--- a/clients/apple/App/KeyboardControlMonitor.swift
+++ b/clients/apple/App/KeyboardControlMonitor.swift
@@ -1,0 +1,93 @@
+import GameController
+import PilotageCore
+import UIKit
+
+/// Feeds hardware-keyboard transitions to the shared control runtime,
+/// the way the browser shell feeds `keydown`/`keyup`. The monitor owns
+/// no key table — names are canonicalized by `KeyboardKeyCanon` and
+/// what a key DOES lives in the shared keyboard profile — and it owns
+/// one safety rule: keys never fly the vehicle while the operator is
+/// typing into a text field, and everything held is dropped whenever
+/// capture ends, so a key released out of sight cannot keep a demand
+/// alive.
+@MainActor
+final class KeyboardControlMonitor {
+    /// One canonical key transition that should reach the runtime.
+    private var onKey: ((String, Bool) -> Void)?
+    /// Every held key must be dropped (focus left, scene left, or the
+    /// keyboard detached).
+    private var onClear: (() -> Void)?
+
+    /// Whether the last event was swallowed by a focused text field;
+    /// the transition into typing clears the held set exactly once.
+    private var typing = false
+
+    func start(onKey: @escaping (String, Bool) -> Void, onClear: @escaping () -> Void) {
+        self.onKey = onKey
+        self.onClear = onClear
+        if let keyboard = GCKeyboard.coalesced {
+            attach(keyboard)
+        }
+        NotificationCenter.default.addObserver(
+            forName: .GCKeyboardDidConnect, object: nil, queue: .main
+        ) { [weak self] _ in
+            // The keyboard object may not cross the isolation hop;
+            // the coalesced accessor re-resolves it on the actor.
+            Task { @MainActor in
+                if let keyboard = GCKeyboard.coalesced { self?.attach(keyboard) }
+            }
+        }
+        NotificationCenter.default.addObserver(
+            forName: .GCKeyboardDidDisconnect, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.onClear?() }
+        }
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.onClear?() }
+        }
+    }
+
+    private func attach(_ keyboard: GCKeyboard) {
+        keyboard.keyboardInput?.keyChangedHandler = { [weak self] _, _, code, pressed in
+            Task { @MainActor in self?.handle(code: code, pressed: pressed) }
+        }
+    }
+
+    private func handle(code: GCKeyCode, pressed: Bool) {
+        // A focused text field owns the keyboard: nothing typed there
+        // may double as a flight input, and whatever was already held
+        // must let go the moment typing starts.
+        if Self.textInputHasFocus() {
+            if !typing {
+                typing = true
+                onClear?()
+            }
+            return
+        }
+        typing = false
+        guard let name = KeyboardKeyCanon.canonicalName(for: code) else { return }
+        onKey?(name, pressed)
+    }
+
+    /// Whether any window's first responder is a text input right now.
+    private static func textInputHasFocus() -> Bool {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .contains { firstResponder(in: $0) is UITextInput }
+    }
+
+    private static func firstResponder(in view: UIView) -> UIResponder? {
+        if view.isFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let responder = firstResponder(in: subview) {
+                return responder
+            }
+        }
+        return nil
+    }
+}

--- a/clients/apple/App/PilotageApp.swift
+++ b/clients/apple/App/PilotageApp.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct PilotageApp: App {
     init() {
         #if DEBUG
-        HostLinkModel.startFootprintProbe()
+        FootprintProbe.start()
         #endif
     }
 

--- a/clients/apple/App/SituationContentView.swift
+++ b/clients/apple/App/SituationContentView.swift
@@ -70,7 +70,9 @@ struct SituationContentView: View {
     }
 
     /// The panel collapse in Apple's own idiom: one floating glass
-    /// circle whose arrows point the way the layout will move.
+    /// circle whose arrows say what pressing does to the MAP — outward
+    /// when it would take the whole window, inward when it would give
+    /// the columns back. The tile focus control speaks the same way.
     private var columnsToggle: some View {
         Button {
             withAnimation {
@@ -78,8 +80,8 @@ struct SituationContentView: View {
             }
         } label: {
             Image(systemName: columnVisibility == .detailOnly
-                ? "arrow.up.left.and.arrow.down.right"
-                : "arrow.down.right.and.arrow.up.left")
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right")
                 .font(Metrics.controlGlyph)
                 .frame(width: Metrics.control, height: Metrics.control)
                 .glassEffect(.regular, in: Circle())
@@ -164,10 +166,6 @@ struct SituationContentView: View {
             // Each floating control is placed against the safe area by the same rule, so
             // none of them sits at a different distance from an edge than the others.
             ZStack {
-                if let flight = model.replayingFlight {
-                    ReplayBannerView(flight: flight, stop: model.stopReplay)
-                        .mapControlPlacement(.topLeading)
-                }
                 MapControlsView(
                     camera: camera,
                     ownship: ownship.fix,
@@ -194,6 +192,9 @@ struct SituationContentView: View {
                 // strip centers in what remains.
                 HStack(spacing: 12) {
                     columnsToggle
+                    if let flight = model.replayingFlight {
+                        ReplayBannerView(flight: flight, stop: model.stopReplay)
+                    }
                     Spacer(minLength: 12)
                     if fcuShown, hostLink.catalog?.offersFlightControl == true {
                         FlightControlUnit { withAnimation { fcuShown = false } }

--- a/clients/apple/Packages/PilotageCore/Sources/PilotageCore/KeyboardKeyCanon.swift
+++ b/clients/apple/Packages/PilotageCore/Sources/PilotageCore/KeyboardKeyCanon.swift
@@ -1,0 +1,44 @@
+import GameController
+
+/// Translates hardware key codes into the canonical `KeyboardEvent.key`
+/// vocabulary the shared control runtime's keyboard profile speaks:
+/// single letters lower-cased, arrows and editing keys by their DOM
+/// names. The table is the whole translation — which keys DO anything
+/// stays in the profile data, so a rebinding never needs shell code.
+public enum KeyboardKeyCanon {
+    /// The canonical name for one key code, or nil for a key the
+    /// canonical vocabulary does not carry.
+    public static func canonicalName(for code: GCKeyCode) -> String? {
+        names[code]
+    }
+
+    private static let names: [GCKeyCode: String] = {
+        var names: [GCKeyCode: String] = [
+            .upArrow: "ArrowUp",
+            .downArrow: "ArrowDown",
+            .leftArrow: "ArrowLeft",
+            .rightArrow: "ArrowRight",
+            .returnOrEnter: "Enter",
+            .deleteOrBackspace: "Backspace",
+            .spacebar: " ",
+        ]
+        let letters: [(GCKeyCode, String)] = [
+            (.keyA, "a"), (.keyB, "b"), (.keyC, "c"), (.keyD, "d"),
+            (.keyE, "e"), (.keyF, "f"), (.keyG, "g"), (.keyH, "h"),
+            (.keyI, "i"), (.keyJ, "j"), (.keyK, "k"), (.keyL, "l"),
+            (.keyM, "m"), (.keyN, "n"), (.keyO, "o"), (.keyP, "p"),
+            (.keyQ, "q"), (.keyR, "r"), (.keyS, "s"), (.keyT, "t"),
+            (.keyU, "u"), (.keyV, "v"), (.keyW, "w"), (.keyX, "x"),
+            (.keyY, "y"), (.keyZ, "z"),
+        ]
+        let digits: [(GCKeyCode, String)] = [
+            (.one, "1"), (.two, "2"), (.three, "3"), (.four, "4"),
+            (.five, "5"), (.six, "6"), (.seven, "7"), (.eight, "8"),
+            (.nine, "9"), (.zero, "0"),
+        ]
+        for (code, name) in letters + digits {
+            names[code] = name
+        }
+        return names
+    }()
+}

--- a/clients/apple/Packages/PilotageCore/Tests/PilotageCoreTests/KeyboardKeyCanonTests.swift
+++ b/clients/apple/Packages/PilotageCore/Tests/PilotageCoreTests/KeyboardKeyCanonTests.swift
@@ -1,0 +1,32 @@
+import GameController
+import Testing
+
+@testable import PilotageCore
+
+@Test("The flight keys translate to the profile's canonical names")
+func flightKeysSpeakTheProfileVocabulary() {
+    // The shared keyboard profile binds exactly these: WASD on the
+    // left stick, arrows on the right, Enter to arm, Backspace to
+    // disarm. A drifted name here is a silently dead control.
+    #expect(KeyboardKeyCanon.canonicalName(for: .keyW) == "w")
+    #expect(KeyboardKeyCanon.canonicalName(for: .keyA) == "a")
+    #expect(KeyboardKeyCanon.canonicalName(for: .keyS) == "s")
+    #expect(KeyboardKeyCanon.canonicalName(for: .keyD) == "d")
+    #expect(KeyboardKeyCanon.canonicalName(for: .upArrow) == "ArrowUp")
+    #expect(KeyboardKeyCanon.canonicalName(for: .downArrow) == "ArrowDown")
+    #expect(KeyboardKeyCanon.canonicalName(for: .leftArrow) == "ArrowLeft")
+    #expect(KeyboardKeyCanon.canonicalName(for: .rightArrow) == "ArrowRight")
+    #expect(KeyboardKeyCanon.canonicalName(for: .returnOrEnter) == "Enter")
+    #expect(KeyboardKeyCanon.canonicalName(for: .deleteOrBackspace) == "Backspace")
+}
+
+@Test("Letters are lower-cased and unnamed keys stay silent")
+func lettersLowerCaseAndUnnamedKeysDrop() {
+    for (code, expected) in [(GCKeyCode.keyQ, "q"), (.keyZ, "z"), (.one, "1"), (.zero, "0")] {
+        #expect(KeyboardKeyCanon.canonicalName(for: code) == expected)
+    }
+    // Modifier keys have no canonical binding vocabulary today; they
+    // must drop rather than reach the runtime under an invented name.
+    #expect(KeyboardKeyCanon.canonicalName(for: .leftShift) == nil)
+    #expect(KeyboardKeyCanon.canonicalName(for: .escape) == nil)
+}

--- a/clients/apple/rust/pilotage-situation-ffi/src/link.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link.rs
@@ -57,6 +57,12 @@ pub(crate) enum LinkCommand {
     SelectPad {
         id: String,
     },
+    KeyEvent {
+        key: String,
+        pressed: bool,
+    },
+    ClearKeys,
+    KeySample,
     Takeover {
         vehicle_id: u64,
         scope: String,
@@ -186,6 +192,29 @@ impl LinkSession {
     /// Resolves a connected pad against the layered profile registry.
     pub fn select_pad(&self, id: String) {
         self.commands.send(LinkCommand::SelectPad { id }).ok();
+    }
+
+    /// Records one hardware-keyboard transition. `key` is the canonical
+    /// `KeyboardEvent.key` value with single letters lower-cased — the
+    /// convention the shared keyboard profile speaks, so the same
+    /// bindings drive the browser and this shell.
+    pub fn key_event(&self, key: String, pressed: bool) {
+        self.commands
+            .send(LinkCommand::KeyEvent { key, pressed })
+            .ok();
+    }
+
+    /// Drops every held key (a text field took focus, the scene left
+    /// the foreground, or the keyboard detached), so a key released
+    /// out of sight cannot keep flying the vehicle.
+    pub fn clear_keys(&self) {
+        self.commands.send(LinkCommand::ClearKeys).ok();
+    }
+
+    /// Runs one control tick synthesized from the held keys through
+    /// the same shared runtime the pad sample rides.
+    pub fn send_key_sample(&self) {
+        self.commands.send(LinkCommand::KeySample).ok();
     }
 
     /// Stops the driver and the connection.

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
@@ -12,9 +12,7 @@ use pilotage_client_session::{
     ClientAction, ClientConfig, ClientEngine, MotionDemand, ProfileIdentity, ReconnectPolicy,
     StreamId, TransportEvent,
 };
-use pilotage_control_web::{
-    ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES, GIMBAL_SCOPE, MOTION_SCOPE,
-};
+use pilotage_control_web::{ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES};
 use pilotage_instrument_feed::InstrumentFeed;
 use tokio::sync::mpsc;
 use wtransport::{ClientConfig as WtClientConfig, Connection, Endpoint};
@@ -54,6 +52,10 @@ pub(super) struct Link {
     pub(super) gated_ticks: u32,
     /// When the shell last spoke a motion demand, on the link clock.
     pub(super) last_demand_ms: u64,
+    /// A motion-lease ask is in flight from a control press; further
+    /// presses wait for the host's answer instead of re-asking the
+    /// holder on every edge.
+    pub(super) motion_request_pending: bool,
 }
 
 /// One second of link accounting, reset on report.
@@ -168,6 +170,7 @@ pub(crate) async fn run(
         telegraph_shown: None,
         gated_ticks: 0,
         last_demand_ms: 0,
+        motion_request_pending: false,
     };
     loop {
         match connect(&config, pinned).await {
@@ -319,23 +322,7 @@ async fn handle_command(
         Some(LinkCommand::RequestLease { vehicle_id, scope }) => {
             link.engine.request_lease(vehicle_id, &scope)
         }
-        Some(LinkCommand::ReleaseLease) => {
-            // Releasing control gives back everything held: the motion
-            // lane and the gimbal lane the runtime leased alongside it.
-            match link
-                .engine
-                .admission()
-                .and_then(|admission| admission.vehicles.first())
-                .map(|vehicle| vehicle.vehicle_id)
-            {
-                Some(vehicle_id) => {
-                    let mut actions = link.engine.release_lease(vehicle_id, MOTION_SCOPE);
-                    actions.extend(link.engine.release_lease(vehicle_id, GIMBAL_SCOPE));
-                    actions
-                }
-                None => Vec::new(),
-            }
-        }
+        Some(LinkCommand::ReleaseLease) => link.release_held_actions(),
         Some(LinkCommand::Motion {
             roll,
             pitch,
@@ -354,6 +341,15 @@ async fn handle_command(
             values,
             pressed,
         }) => link.pad_actions(&axes, &values, &pressed),
+        Some(LinkCommand::KeyEvent { key, pressed }) => {
+            link.control.key_event(&key, pressed);
+            Vec::new()
+        }
+        Some(LinkCommand::ClearKeys) => {
+            link.control.clear_keys();
+            Vec::new()
+        }
+        Some(LinkCommand::KeySample) => link.key_actions(),
         Some(LinkCommand::SelectPad { id }) => {
             // The resolved map installs at a transaction boundary; the
             // shell hears about it from the tick that lands it. Only a

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
@@ -12,7 +12,7 @@ use pilotage_client_session::{
     ClientAction, ClientConfig, ClientEngine, MotionDemand, ProfileIdentity, ReconnectPolicy,
     StreamId, TransportEvent,
 };
-use pilotage_control_web::{ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES, MOTION_SCOPE};
+use pilotage_control_web::{ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES};
 use pilotage_instrument_feed::InstrumentFeed;
 use tokio::sync::mpsc;
 use wtransport::{ClientConfig as WtClientConfig, Connection, Endpoint};
@@ -324,13 +324,7 @@ async fn handle_command(
 ) -> bool {
     let actions = match command {
         Some(LinkCommand::RequestLease { vehicle_id, scope }) => {
-            let actions = link.engine.request_lease(vehicle_id, &scope);
-            // The screen and the sticks make ONE ask: a press must not
-            // send a second one to a holder already deciding on this.
-            if scope == MOTION_SCOPE && !actions.is_empty() {
-                link.motion_request_pending = true;
-            }
-            actions
+            link.request_lease_actions(vehicle_id, &scope)
         }
         Some(LinkCommand::ReleaseLease) => link.release_held_actions(),
         Some(LinkCommand::Motion {

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
@@ -12,7 +12,7 @@ use pilotage_client_session::{
     ClientAction, ClientConfig, ClientEngine, MotionDemand, ProfileIdentity, ReconnectPolicy,
     StreamId, TransportEvent,
 };
-use pilotage_control_web::{ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES};
+use pilotage_control_web::{ArmTelegraph, ControlCoordinator, DEFAULT_PROFILE_BYTES, MOTION_SCOPE};
 use pilotage_instrument_feed::InstrumentFeed;
 use tokio::sync::mpsc;
 use wtransport::{ClientConfig as WtClientConfig, Connection, Endpoint};
@@ -320,7 +320,13 @@ async fn handle_command(
 ) -> bool {
     let actions = match command {
         Some(LinkCommand::RequestLease { vehicle_id, scope }) => {
-            link.engine.request_lease(vehicle_id, &scope)
+            let actions = link.engine.request_lease(vehicle_id, &scope);
+            // The screen and the sticks make ONE ask: a press must not
+            // send a second one to a holder already deciding on this.
+            if scope == MOTION_SCOPE && !actions.is_empty() {
+                link.motion_request_pending = true;
+            }
+            actions
         }
         Some(LinkCommand::ReleaseLease) => link.release_held_actions(),
         Some(LinkCommand::Motion {

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/driver.rs
@@ -56,6 +56,9 @@ pub(super) struct Link {
     /// presses wait for the host's answer instead of re-asking the
     /// holder on every edge.
     pub(super) motion_request_pending: bool,
+    /// When that ask left, on the link clock. An ask nobody answers
+    /// expires, so the sticks are never locked out for good.
+    pub(super) motion_ask_at_ms: Option<u64>,
 }
 
 /// One second of link accounting, reset on report.
@@ -171,6 +174,7 @@ pub(crate) async fn run(
         gated_ticks: 0,
         last_demand_ms: 0,
         motion_request_pending: false,
+        motion_ask_at_ms: None,
     };
     loop {
         match connect(&config, pinned).await {

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/events.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/events.rs
@@ -4,7 +4,7 @@
 //! loop moves bytes; this file decides what the shell hears.
 
 use pilotage_client_session::ModuleEvent;
-use pilotage_control_web::AuthorityEvent;
+use pilotage_control_web::{AuthorityEvent, MOTION_SCOPE};
 use pilotage_instrument_feed::{FeedParams, InstrumentFeed};
 use pilotage_protocol::wire;
 
@@ -24,6 +24,11 @@ impl Link {
             .as_ref()
             .map(|s| s.value.clone())
             .unwrap_or_default();
+        if scope == MOTION_SCOPE {
+            // The answer arrived, whatever it says: the next press may
+            // ask again.
+            self.motion_request_pending = false;
+        }
         let generation = response.generation.as_ref().map_or(0, |g| g.value);
         self.mirror_authority(
             &scope,
@@ -117,6 +122,29 @@ impl Link {
         }
     }
 
+    /// The host's recovery ack into the runtime's authority mirror:
+    /// regranted live output stays gated behind this signal (the
+    /// browser resumes on the same one). It must be the admitted
+    /// vehicle's, and the mirror itself rejects a generation that is
+    /// not the granted one.
+    fn emit_link_loss_cleared(&mut self, cleared: &wire::LinkLossCleared) {
+        let vehicle_id = cleared.vehicle.as_ref().map_or(0, |v| v.value);
+        let ours = self
+            .engine
+            .admission()
+            .and_then(|admission| admission.vehicles.first())
+            .is_some_and(|vehicle| vehicle.vehicle_id == vehicle_id);
+        if ours {
+            let scope = cleared
+                .scope
+                .as_ref()
+                .map(|s| s.value.clone())
+                .unwrap_or_default();
+            let generation = cleared.generation.as_ref().map_or(0, |g| g.value);
+            self.mirror_authority(&scope, AuthorityEvent::LinkLossCleared { generation });
+        }
+    }
+
     pub(super) fn emit(&mut self, event: ModuleEvent) {
         match event {
             ModuleEvent::Admitted(admission) => {
@@ -154,6 +182,7 @@ impl Link {
             }
             ModuleEvent::ControlRejected(rejected) => self.emit_rejection(&rejected),
             ModuleEvent::ConnectionDown { retry_at_ms } => {
+                self.motion_request_pending = false;
                 self.delivery.event(LinkEvent::Down { retry_at_ms });
             }
             ModuleEvent::ActionResult(result) => self.emit_action_result(result),
@@ -177,6 +206,7 @@ impl Link {
                     });
                 }
             }
+            ModuleEvent::LinkLossCleared(cleared) => self.emit_link_loss_cleared(&cleared),
             ModuleEvent::VideoStreamCorrupt { claimed_bytes } => {
                 self.delivery.event(LinkEvent::Notice {
                     text: format!(

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/events.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/events.rs
@@ -122,6 +122,27 @@ impl Link {
         }
     }
 
+    /// A confirmed release, into the mirror before the shell. The
+    /// runtime gates output on its own mirror of authority: a release
+    /// the mirror never hears leaves it reporting a granted, recovered
+    /// lease, so output stays "live" and a press takes the send path
+    /// instead of the ask path — dying with no lane to ride, and
+    /// leaving no way back from the sticks.
+    fn emit_lease_released(&mut self, released: &wire::LeaseReleased) {
+        let scope = released
+            .scope
+            .as_ref()
+            .map(|s| s.value.clone())
+            .unwrap_or_default();
+        let generation = released.generation.as_ref().map_or(0, |g| g.value);
+        self.mirror_authority(&scope, AuthorityEvent::LeaseReleased { generation });
+        self.delivery.event(LinkEvent::LeaseChanged {
+            held: false,
+            scope,
+            detail: "released".to_owned(),
+        });
+    }
+
     /// The host's recovery ack into the runtime's authority mirror:
     /// regranted live output stays gated behind this signal (the
     /// browser resumes on the same one). It must be the admitted
@@ -149,7 +170,10 @@ impl Link {
         match event {
             ModuleEvent::Admitted(admission) => {
                 // A fresh admission is a fresh transport session for the
-                // runtime's mirror and the telegraph alike.
+                // runtime's mirror and the telegraph alike. Any ask the
+                // last session left in flight is void with it, so the
+                // sticks may ask again.
+                self.motion_request_pending = false;
                 self.control.begin_session();
                 self.telegraph.reset();
                 self.publish_telegraph();
@@ -168,18 +192,7 @@ impl Link {
             }
             ModuleEvent::Telemetry(sample) => self.emit_telemetry(&sample),
             ModuleEvent::Lease(response) => self.emit_lease(&response),
-            ModuleEvent::LeaseReleased(released) => {
-                let scope = released
-                    .scope
-                    .as_ref()
-                    .map(|s| s.value.clone())
-                    .unwrap_or_default();
-                self.delivery.event(LinkEvent::LeaseChanged {
-                    held: false,
-                    scope,
-                    detail: "released".to_owned(),
-                });
-            }
+            ModuleEvent::LeaseReleased(released) => self.emit_lease_released(&released),
             ModuleEvent::ControlRejected(rejected) => self.emit_rejection(&rejected),
             ModuleEvent::ConnectionDown { retry_at_ms } => {
                 self.motion_request_pending = false;

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
@@ -24,6 +24,12 @@ const ACTION_GIMBAL_RECENTER: i32 = 4;
 /// silence that costs the lease one second later.
 const GATED_TICKS_REPORTED: u32 = 20;
 
+/// How long one ask for control owns the press. Long enough that a
+/// thumb on the button cannot prompt a standing holder over and over,
+/// short enough that a holder who never answers costs the operator one
+/// pause rather than the rest of the session.
+const ASK_HOLDS_MS: u64 = 10_000;
+
 impl Link {
     /// Runs one raw pad sample through the shared runtime and executes
     /// the plan. The iPad has no mode picker yet; the pilot scheme is
@@ -149,15 +155,23 @@ impl Link {
     /// swallowed safety press that stays silent is indistinguishable
     /// from a dead control.
     fn arm_press_while_gated(&mut self, vehicle_id: u64) -> Vec<ClientAction> {
-        // A standing holder is asked once. The lease answer that
-        // escalated into the handover arrives within the round trip, so
-        // the in-flight ask — not the unanswered request — is what a
-        // further press must wait on; otherwise every press prompts
-        // another pilot again.
-        if self.engine.holds(vehicle_id, MOTION_SCOPE)
-            || self.motion_request_pending
-            || self.engine.takeover_pending(vehicle_id, MOTION_SCOPE)
-        {
+        if self.engine.holds(vehicle_id, MOTION_SCOPE) {
+            self.delivery
+                .event(LinkEvent::PressSuppressed { action: 1 });
+            return Vec::new();
+        }
+        // One ask owns the control for a while. The lease answer that
+        // escalated into a handover arrives within the round trip, so
+        // watching only the unanswered request would let every press
+        // prompt another pilot again — and watching the handover alone
+        // would cost the operator the sticks for the whole session
+        // against a holder who never answers. The ask expires instead.
+        let asking =
+            self.motion_request_pending || self.engine.takeover_pending(vehicle_id, MOTION_SCOPE);
+        let waiting = self
+            .motion_ask_at_ms
+            .is_some_and(|asked_at| self.now_ms().saturating_sub(asked_at) < ASK_HOLDS_MS);
+        if asking && waiting {
             self.delivery
                 .event(LinkEvent::PressSuppressed { action: 1 });
             return Vec::new();
@@ -171,6 +185,7 @@ impl Link {
             return actions;
         }
         self.motion_request_pending = true;
+        self.motion_ask_at_ms = Some(self.now_ms());
         self.delivery.event(LinkEvent::Notice {
             text: "asking for vehicle.motion".to_owned(),
         });

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
@@ -44,13 +44,28 @@ impl Link {
             .collect();
         let mut sample = RawSample::default();
         self.control.pad_sample(axes, &raw, &mut sample);
+        self.runtime_actions(&sample)
+    }
+
+    /// Runs one tick synthesized from the held keys — the keyboard is
+    /// a device layer of the same runtime, so curves, edges, and the
+    /// quasimode apply to it unchanged.
+    pub(super) fn key_actions(&mut self) -> Vec<ClientAction> {
+        let mut sample = RawSample::default();
+        self.control.key_sample(&mut sample);
+        self.runtime_actions(&sample)
+    }
+
+    /// One canonical sample through the shared runtime and out as
+    /// engine actions, whatever device produced it.
+    fn runtime_actions(&mut self, sample: &RawSample) -> Vec<ClientAction> {
         let session = SessionState {
             now_ms: self.now_ms() as f64,
             mode: Mode::QuadPilot,
             connected: self.engine.admission().is_some(),
             input_lost: false,
         };
-        let plan = self.control.evaluate(&sample, &session);
+        let plan = self.control.evaluate(sample, &session);
         self.announce_device();
         self.execute_plan(&plan)
     }
@@ -89,26 +104,29 @@ impl Link {
             actions.extend(self.gimbal_plan_actions(vehicle_id, frame));
         }
         match plan.lease {
-            Some(LeaseAction::Request) => {
+            // The quasimode's auxiliary scope follows a HELD motion
+            // lease. An admitted observer's ticks must lease nothing:
+            // a bystander holding the gimbal is a camera nobody at the
+            // sticks can move.
+            Some(LeaseAction::Request) if self.engine.holds(vehicle_id, MOTION_SCOPE) => {
                 actions.extend(self.engine.request_lease_quiet(vehicle_id, GIMBAL_SCOPE));
             }
             Some(LeaseAction::Release) => {
                 actions.extend(self.engine.release_lease(vehicle_id, GIMBAL_SCOPE));
             }
-            None => {}
+            Some(LeaseAction::Request) | None => {}
         }
-        // A motion-lease plan only fires on a scope-member transfer,
-        // which the single built-in profile never maps; motion leases
-        // stay operator-pressed on this shell.
+        // The runtime's own motion-lease plan stays unexecuted: on this
+        // shell control is taken by a person, never by a reconnecting
+        // state machine, so acquisition rides the arm press below.
         if plan.arm {
             actions.extend(self.order_actions(true));
         }
         if plan.disarm {
-            actions.extend(self.order_actions(false));
+            actions.extend(self.standdown_actions());
         }
         if plan.arm_suppressed {
-            self.delivery
-                .event(LinkEvent::PressSuppressed { action: 1 });
+            actions.extend(self.arm_press_while_gated(vehicle_id));
         }
         if plan.disarm_suppressed {
             self.delivery
@@ -121,6 +139,75 @@ impl Link {
             });
         }
         actions
+    }
+
+    /// An arm edge the runtime consumed while motion output was gated.
+    /// Without the lease this press is the operator reaching for
+    /// control, so it becomes the cooperative ask itself — one ask per
+    /// answer, later presses wait. Holding the lease while gated
+    /// (recovery in progress) keeps the loud suppression report: a
+    /// swallowed safety press that stays silent is indistinguishable
+    /// from a dead control.
+    fn arm_press_while_gated(&mut self, vehicle_id: u64) -> Vec<ClientAction> {
+        if self.engine.holds(vehicle_id, MOTION_SCOPE) || self.motion_request_pending {
+            self.delivery
+                .event(LinkEvent::PressSuppressed { action: 1 });
+            return Vec::new();
+        }
+        let actions = self.engine.request_lease(vehicle_id, MOTION_SCOPE);
+        if actions.is_empty() {
+            // Not admitted: the press cannot become an ask, so it must
+            // still be surfaced rather than vanish.
+            self.delivery
+                .event(LinkEvent::PressSuppressed { action: 1 });
+            return actions;
+        }
+        self.motion_request_pending = true;
+        self.delivery.event(LinkEvent::Notice {
+            text: "asking for vehicle.motion".to_owned(),
+        });
+        actions
+    }
+
+    /// A live disarm edge. With the lever already on SAFE and the
+    /// vehicle confirmed disarmed there is nothing left to stop, so
+    /// the press means "stand down": the held scopes go back to the
+    /// host. The screen lever never lands here — a redundant tap on
+    /// SAFE is a no-op there — so only a deliberate control press
+    /// releases.
+    fn standdown_actions(&mut self) -> Vec<ClientAction> {
+        let vehicle_id = self
+            .engine
+            .admission()
+            .and_then(|admission| admission.vehicles.first())
+            .map(|vehicle| vehicle.vehicle_id);
+        let settled_safe = self.telegraph.order() == ArmOrder::Safe
+            && self.telegraph.confirmed() == ArmConfirmed::Disarmed;
+        if settled_safe
+            && let Some(vehicle_id) = vehicle_id
+            && self.engine.holds(vehicle_id, MOTION_SCOPE)
+        {
+            return self.release_held_actions();
+        }
+        self.order_actions(false)
+    }
+
+    /// Releasing control gives back everything held: the motion lane
+    /// and the gimbal lane the runtime leased alongside it.
+    pub(super) fn release_held_actions(&mut self) -> Vec<ClientAction> {
+        match self
+            .engine
+            .admission()
+            .and_then(|admission| admission.vehicles.first())
+            .map(|vehicle| vehicle.vehicle_id)
+        {
+            Some(vehicle_id) => {
+                let mut actions = self.engine.release_lease(vehicle_id, MOTION_SCOPE);
+                actions.extend(self.engine.release_lease(vehicle_id, GIMBAL_SCOPE));
+                actions
+            }
+            None => Vec::new(),
+        }
     }
 
     /// The plan's motion frame through the typed velocity path — the

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
@@ -147,6 +147,22 @@ impl Link {
         actions
     }
 
+    /// The shell's own ask for control, from the screen. It keeps the
+    /// press's bookkeeping, so the two doors onto one ask cannot put
+    /// two prompts in front of the same holder.
+    pub(super) fn request_lease_actions(
+        &mut self,
+        vehicle_id: u64,
+        scope: &str,
+    ) -> Vec<ClientAction> {
+        let actions = self.engine.request_lease(vehicle_id, scope);
+        if scope == MOTION_SCOPE && !actions.is_empty() {
+            self.motion_request_pending = true;
+            self.motion_ask_at_ms = Some(self.now_ms());
+        }
+        actions
+    }
+
     /// An arm edge the runtime consumed while motion output was gated.
     /// Without the lease this press is the operator reaching for
     /// control, so it becomes the cooperative ask itself — one ask per

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/pad.rs
@@ -149,7 +149,15 @@ impl Link {
     /// swallowed safety press that stays silent is indistinguishable
     /// from a dead control.
     fn arm_press_while_gated(&mut self, vehicle_id: u64) -> Vec<ClientAction> {
-        if self.engine.holds(vehicle_id, MOTION_SCOPE) || self.motion_request_pending {
+        // A standing holder is asked once. The lease answer that
+        // escalated into the handover arrives within the round trip, so
+        // the in-flight ask — not the unanswered request — is what a
+        // further press must wait on; otherwise every press prompts
+        // another pilot again.
+        if self.engine.holds(vehicle_id, MOTION_SCOPE)
+            || self.motion_request_pending
+            || self.engine.takeover_pending(vehicle_id, MOTION_SCOPE)
+        {
             self.delivery
                 .event(LinkEvent::PressSuppressed { action: 1 });
             return Vec::new();
@@ -175,6 +183,13 @@ impl Link {
     /// host. The screen lever never lands here — a redundant tap on
     /// SAFE is a no-op there — so only a deliberate control press
     /// releases.
+    ///
+    /// The lever also snaps to SAFE without anyone ordering it: a
+    /// refused arm and a vehicle that drops out of arm on its own both
+    /// land there. Neither is the operator standing down, so only a
+    /// telegraph in sync with the vehicle qualifies — the two
+    /// involuntary paths carry their own phase and keep the press a
+    /// plain disarm.
     fn standdown_actions(&mut self) -> Vec<ClientAction> {
         let vehicle_id = self
             .engine
@@ -182,7 +197,8 @@ impl Link {
             .and_then(|admission| admission.vehicles.first())
             .map(|vehicle| vehicle.vehicle_id);
         let settled_safe = self.telegraph.order() == ArmOrder::Safe
-            && self.telegraph.confirmed() == ArmConfirmed::Disarmed;
+            && self.telegraph.confirmed() == ArmConfirmed::Disarmed
+            && matches!(self.telegraph.phase(), TelegraphPhase::InSync);
         if settled_safe
             && let Some(vehicle_id) = vehicle_id
             && self.engine.holds(vehicle_id, MOTION_SCOPE)

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests.rs
@@ -127,6 +127,7 @@ fn admitted_link() -> Link {
         gated_ticks: 0,
         last_demand_ms: 0,
         motion_request_pending: false,
+        motion_ask_at_ms: None,
     }
 }
 

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use pilotage_client_session::{
-    ClientAction, ClientConfig, ClientEngine, MotionDemand, ReconnectPolicy, TransportEvent,
+    ClientAction, ClientConfig, ClientEngine, ModuleEvent, MotionDemand, ReconnectPolicy,
+    TransportEvent,
 };
 use pilotage_control_web::ControlCoordinator;
 use pilotage_protocol::wire;
@@ -21,6 +22,8 @@ use super::delivery::DeliveryQueue;
 use super::driver::{Link, LinkStats};
 use super::observer::LinkObserver;
 use super::records::LinkEvent;
+
+mod lifecycle;
 
 struct SilentObserver;
 
@@ -81,7 +84,20 @@ fn two_scope_welcome() -> wire::Envelope {
     }
 }
 
-fn admitted_link_with_two_lanes() -> Link {
+fn lease_response(scope: &str, granted: bool, generation: u64) -> wire::LeaseResponse {
+    wire::LeaseResponse {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        scope: Some(wire::ScopeId {
+            value: scope.into(),
+        }),
+        granted,
+        generation: Some(wire::Generation { value: generation }),
+        reason: i32::from(!granted),
+    }
+}
+
+/// An admitted link holding nothing yet: the observer's seat.
+fn admitted_link() -> Link {
     let mut engine = ClientEngine::new(ClientConfig {
         client_name: "routing-test".into(),
         reconnect: ReconnectPolicy::default(),
@@ -93,32 +109,11 @@ fn admitted_link_with_two_lanes() -> Link {
         )),
         0,
     );
-    for (scope, generation) in [("vehicle.motion", 4), ("vehicle.gimbal", 9)] {
-        engine.request_lease(1, scope);
-        let grant = wire::Envelope {
-            schema_version: 1,
-            payload: Some(wire::envelope::Payload::LeaseResponse(
-                wire::LeaseResponse {
-                    vehicle: Some(wire::VehicleId { value: 1 }),
-                    scope: Some(wire::ScopeId {
-                        value: scope.into(),
-                    }),
-                    granted: true,
-                    generation: Some(wire::Generation { value: generation }),
-                    reason: 0,
-                },
-            )),
-        };
-        engine.handle(
-            TransportEvent::BootstrapReceived(pilotage_protocol::encode_envelope_length_delimited(
-                &grant,
-            )),
-            0,
-        );
-    }
+    let mut control = ControlCoordinator::new();
+    control.activate_scheme(pilotage_control_web::DEFAULT_PROFILE_BYTES);
     Link {
         engine,
-        control: ControlCoordinator::new(),
+        control,
         feed: None,
         delivery: DeliveryQueue::start(Arc::new(SilentObserver)),
         started: Instant::now(),
@@ -131,7 +126,34 @@ fn admitted_link_with_two_lanes() -> Link {
         telegraph_shown: None,
         gated_ticks: 0,
         last_demand_ms: 0,
+        motion_request_pending: false,
     }
+}
+
+/// Grants one scope through both halves the driver keeps in step: the
+/// engine's lane and the runtime's authority mirror.
+fn grant(link: &mut Link, scope: &str, generation: u64) {
+    link.engine.request_lease(1, scope);
+    let envelope = wire::Envelope {
+        schema_version: 1,
+        payload: Some(wire::envelope::Payload::LeaseResponse(lease_response(
+            scope, true, generation,
+        ))),
+    };
+    link.engine.handle(
+        TransportEvent::BootstrapReceived(pilotage_protocol::encode_envelope_length_delimited(
+            &envelope,
+        )),
+        0,
+    );
+    link.emit(ModuleEvent::Lease(lease_response(scope, true, generation)));
+}
+
+fn admitted_link_with_two_lanes() -> Link {
+    let mut link = admitted_link();
+    grant(&mut link, "vehicle.motion", 4);
+    grant(&mut link, "vehicle.gimbal", 9);
+    link
 }
 
 /// The scope inside the first datagram action, or a panic that names

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
@@ -1,0 +1,223 @@
+//! The control lifecycle from the sticks: an admitted observer's
+//! ticks claim nothing; the arm press without the lease is the
+//! cooperative ask; a regrant resumes live output only on the host's
+//! recovery ack; held keys ride the pad's own runtime and lanes.
+
+use super::*;
+
+/// One pad tick in Standard Gamepad terms: sixteen buttons, the named
+/// indices pressed.
+fn pad_tick(link: &mut Link, axes: [f32; 4], pressed_indices: &[usize]) -> Vec<ClientAction> {
+    let mut values = [0.0_f32; 16];
+    let mut pressed = [false; 16];
+    for &index in pressed_indices {
+        values[index] = 1.0;
+        pressed[index] = true;
+    }
+    link.pad_actions(&axes, &values, &pressed)
+}
+
+fn datagram_count(actions: &[ClientAction]) -> usize {
+    actions
+        .iter()
+        .filter(|action| matches!(action, ClientAction::SendDatagram(_)))
+        .count()
+}
+
+/// The reliable-stream payloads inside the actions, by wire variant name.
+fn bootstrap_payloads(actions: &[ClientAction]) -> Vec<&'static str> {
+    actions
+        .iter()
+        .filter_map(|action| {
+            let ClientAction::SendBootstrap(bytes) = action else {
+                return None;
+            };
+            let (envelope, _) =
+                pilotage_protocol::decode_envelope_length_delimited(bytes).expect("decodes");
+            Some(match envelope.payload {
+                Some(wire::envelope::Payload::LeaseRequest(_)) => "lease-request",
+                Some(wire::envelope::Payload::LeaseRelease(_)) => "lease-release",
+                Some(wire::envelope::Payload::ControlActionCommand(_)) => "action",
+                _ => "other",
+            })
+        })
+        .collect()
+}
+
+/// An admitted observer's ticks must lease nothing and send nothing:
+/// watching a vehicle is not a claim on any of its scopes, and the
+/// runtime's own reacquisition plan must never leave this shell.
+#[test]
+fn an_admitted_observer_tick_asks_for_nothing() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    for _ in 0..3 {
+        let actions = pad_tick(&mut link, [0.3, -0.8, 0.0, 0.0], &[]);
+        assert_eq!(datagram_count(&actions), 0, "no frame without a lease");
+        assert!(
+            bootstrap_payloads(&actions).is_empty(),
+            "no lease traffic from an observer's deflected stick"
+        );
+    }
+}
+
+/// The arm press without the lease IS the ask — once per answer.
+#[test]
+fn an_arm_press_without_the_lease_becomes_one_cooperative_ask() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    // The swap lands on the first tick and re-seeds edge baselines on
+    // the second: a press can fire as an edge only after both.
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let ask = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert_eq!(
+        bootstrap_payloads(&ask),
+        vec!["lease-request"],
+        "the press becomes the motion-lease ask"
+    );
+    let released = pad_tick(&mut link, [0.0; 4], &[]);
+    assert!(bootstrap_payloads(&released).is_empty());
+    let second = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert!(
+        bootstrap_payloads(&second).is_empty(),
+        "a second press waits for the host's answer"
+    );
+    // The answer arrives (a denial): the next press may ask again.
+    link.emit(ModuleEvent::Lease(lease_response(
+        "vehicle.motion",
+        false,
+        5,
+    )));
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let third = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert_eq!(
+        bootstrap_payloads(&third),
+        vec!["lease-request"],
+        "an answered ask re-arms the press"
+    );
+}
+
+/// Denial fences the mirror; the regrant must walk neutral activation
+/// and resume live only on the host's cleared ack — the browser's own
+/// recovery contract, which this shell once dropped on the floor.
+#[test]
+fn a_regrant_after_denial_recovers_through_the_cleared_ack() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    // Denied: the mirror fences at the host's generation.
+    link.emit(ModuleEvent::Lease(lease_response(
+        "vehicle.motion",
+        false,
+        5,
+    )));
+    // The holder let go; our ask lands on a fresh generation.
+    grant(&mut link, "vehicle.motion", 6);
+    // Deflected before recovery: gated, nothing live leaves.
+    let deflected = pad_tick(&mut link, [0.0, -0.8, 0.0, 0.0], &[]);
+    assert_eq!(
+        datagram_count(&deflected),
+        0,
+        "no live frame before the cleared ack"
+    );
+    // Neutral controls stream the activation the host needs.
+    let neutral = pad_tick(&mut link, [0.0; 4], &[]);
+    assert!(
+        datagram_count(&neutral) > 0,
+        "neutral activation is retransmitted while recovering"
+    );
+    // The ack lands on the granted generation: recovery is complete.
+    link.emit(ModuleEvent::LinkLossCleared(wire::LinkLossCleared {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        scope: Some(wire::ScopeId {
+            value: "vehicle.motion".into(),
+        }),
+        generation: Some(wire::Generation { value: 6 }),
+    }));
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let live = pad_tick(&mut link, [0.0, -0.8, 0.0, 0.0], &[]);
+    assert!(
+        datagram_count(&live) > 0,
+        "live output resumes after the cleared ack"
+    );
+    assert_eq!(datagram_scope(&live), "vehicle.motion");
+}
+
+/// The first velocity intent inside the actions' datagrams.
+fn motion_velocity(actions: &[ClientAction]) -> wire::VelocityIntent {
+    let intent = actions
+        .iter()
+        .find_map(|action| {
+            let ClientAction::SendDatagram(bytes) = action else {
+                return None;
+            };
+            let envelope = wire::Envelope::decode(bytes.as_slice()).expect("frame decodes");
+            let Some(wire::envelope::Payload::ControlFrame(frame)) = envelope.payload else {
+                return None;
+            };
+            frame.intent.and_then(|intent| intent.family)
+        })
+        .expect("a typed intent leaves");
+    let wire::control_intent::Family::Velocity(velocity) = intent else {
+        panic!("the motion frame commands velocity");
+    };
+    velocity
+}
+
+/// Held keys ride the same runtime, curves, and lanes as the pad: the
+/// keyboard is a device layer, not a second control path.
+#[test]
+fn held_keys_fly_the_motion_lane_through_the_shared_runtime() {
+    let mut link = admitted_link_with_two_lanes();
+    let _ = link.key_actions();
+    let _ = link.key_actions();
+    link.control.key_event("w", true);
+    let live = link.key_actions();
+    assert_eq!(datagram_scope(&live), "vehicle.motion");
+    let velocity = motion_velocity(&live);
+    assert!(
+        velocity.vz.abs() > 0.0,
+        "a held climb key must command vertical velocity, got {velocity:?}"
+    );
+    link.control.clear_keys();
+    let neutral = link.key_actions();
+    let velocity = motion_velocity(&neutral);
+    assert_eq!(
+        velocity.vz, 0.0,
+        "cleared keys must fall back to a neutral stream"
+    );
+}
+
+/// Enter is the keyboard's arm control; without the lease the press is
+/// the same cooperative ask the pad's arm button makes.
+#[test]
+fn an_enter_press_without_the_lease_asks_for_control() {
+    let mut link = admitted_link();
+    let _ = link.key_actions();
+    let _ = link.key_actions();
+    link.control.key_event("Enter", true);
+    let ask = link.key_actions();
+    assert_eq!(
+        bootstrap_payloads(&ask),
+        vec!["lease-request"],
+        "the keyboard's arm press becomes the motion-lease ask"
+    );
+}
+
+/// With the lever on SAFE and the vehicle confirmed disarmed, the
+/// disarm press means "stand down": both held lanes go back.
+#[test]
+fn a_settled_safe_disarm_press_stands_down_control() {
+    let mut link = admitted_link_with_two_lanes();
+    link.telegraph.on_fc_arm_state(1);
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let standdown = pad_tick(&mut link, [0.0; 4], &[8]);
+    assert_eq!(
+        bootstrap_payloads(&standdown),
+        vec!["lease-release", "lease-release"],
+        "the settled-safe press releases the motion and gimbal lanes"
+    );
+}

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
@@ -3,6 +3,8 @@
 //! cooperative ask; a regrant resumes live output only on the host's
 //! recovery ack; held keys ride the pad's own runtime and lanes.
 
+use pilotage_control_web::ArmOrder;
+
 use super::*;
 
 /// One pad tick in Standard Gamepad terms: sixteen buttons, the named
@@ -38,10 +40,41 @@ fn bootstrap_payloads(actions: &[ClientAction]) -> Vec<&'static str> {
                 Some(wire::envelope::Payload::LeaseRequest(_)) => "lease-request",
                 Some(wire::envelope::Payload::LeaseRelease(_)) => "lease-release",
                 Some(wire::envelope::Payload::ControlActionCommand(_)) => "action",
+                Some(wire::envelope::Payload::ScopeTransferRequest(_)) => "transfer-request",
                 _ => "other",
             })
         })
         .collect()
+}
+
+/// Feeds one reliable envelope to the engine and routes the module
+/// events it answers with into the shell, exactly as the driver does.
+/// Tests that skip this step prove only what the shell believes, not
+/// what the engine actually did.
+fn deliver(link: &mut Link, envelope: &wire::Envelope) -> Vec<ClientAction> {
+    let actions = link.engine.handle(
+        TransportEvent::BootstrapReceived(pilotage_protocol::encode_envelope_length_delimited(
+            envelope,
+        )),
+        0,
+    );
+    let mut rest = Vec::new();
+    for action in actions {
+        match action {
+            ClientAction::Emit(event) => link.emit(event),
+            other => rest.push(other),
+        }
+    }
+    rest
+}
+
+fn lease_envelope(scope: &str, granted: bool, generation: u64) -> wire::Envelope {
+    wire::Envelope {
+        schema_version: 1,
+        payload: Some(wire::envelope::Payload::LeaseResponse(lease_response(
+            scope, granted, generation,
+        ))),
+    }
 }
 
 /// An admitted observer's ticks must lease nothing and send nothing:
@@ -98,9 +131,96 @@ fn an_arm_press_without_the_lease_becomes_one_cooperative_ask() {
     );
 }
 
+/// The ask that reached a standing holder is asked ONCE. The lease
+/// answer that escalated it arrives within the round trip and re-arms
+/// the press, so a shell that watches only its own unanswered request
+/// prompts the other pilot again for every press.
+#[test]
+fn a_press_while_a_handover_is_pending_does_not_ask_the_holder_again() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let ask = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert_eq!(bootstrap_payloads(&ask), vec!["lease-request"]);
+    // The host answers that another operator holds it; the engine
+    // turns the ask into the handover request on its own.
+    let escalation = deliver(&mut link, &lease_envelope("vehicle.motion", false, 5));
+    assert_eq!(
+        bootstrap_payloads(&escalation),
+        vec!["transfer-request"],
+        "the denial escalates into one ask to the holder"
+    );
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let again = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert!(
+        bootstrap_payloads(&again).is_empty(),
+        "a further press must not prompt the holder a second time, got {:?}",
+        bootstrap_payloads(&again)
+    );
+}
+
+/// Standing down must leave a way back from the sticks. The runtime
+/// gates on its OWN mirror of authority: a release it never hears
+/// leaves output "live", so the next press takes the send path, dies
+/// with no lane to ride, and answers nothing at all.
+#[test]
+fn the_sticks_can_take_control_again_after_standing_down() {
+    let mut link = admitted_link_with_two_lanes();
+    link.telegraph.on_fc_arm_state(1);
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let standdown = pad_tick(&mut link, [0.0; 4], &[8]);
+    assert_eq!(
+        bootstrap_payloads(&standdown),
+        vec!["lease-release", "lease-release"]
+    );
+    // The host confirms both releases.
+    for scope in ["vehicle.motion", "vehicle.gimbal"] {
+        link.emit(ModuleEvent::LeaseReleased(wire::LeaseReleased {
+            vehicle: Some(wire::VehicleId { value: 1 }),
+            scope: Some(wire::ScopeId {
+                value: scope.into(),
+            }),
+            released: true,
+            generation: Some(wire::Generation { value: 11 }),
+        }));
+    }
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let retake = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert_eq!(
+        bootstrap_payloads(&retake),
+        vec!["lease-request"],
+        "the arm press must ask for control again, got {:?}",
+        bootstrap_payloads(&retake)
+    );
+}
+
+/// A vehicle that drops out of arm on its own snaps the lever to SAFE
+/// without anyone ordering it. That is not the operator standing down,
+/// so the press stays a plain disarm and control is kept.
+#[test]
+fn an_uncommanded_disarm_does_not_hand_back_control() {
+    let mut link = admitted_link_with_two_lanes();
+    link.telegraph.set_order(ArmOrder::Armed);
+    link.telegraph.on_fc_arm_state(2);
+    // The vehicle leaves arm by itself: lever snaps to SAFE, dropped.
+    link.telegraph.on_fc_arm_state(1);
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let press = pad_tick(&mut link, [0.0; 4], &[8]);
+    assert!(
+        !bootstrap_payloads(&press).contains(&"lease-release"),
+        "an involuntary SAFE must not stand down control, got {:?}",
+        bootstrap_payloads(&press)
+    );
+}
+
 /// Denial fences the mirror; the regrant must walk neutral activation
-/// and resume live only on the host's cleared ack — the browser's own
-/// recovery contract, which this shell once dropped on the floor.
+/// and resume live only on the host's cleared ack — the recovery
+/// contract the browser has always honoured.
 #[test]
 fn a_regrant_after_denial_recovers_through_the_cleared_ack() {
     let mut link = admitted_link();

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
@@ -160,6 +160,28 @@ fn a_press_while_a_handover_is_pending_does_not_ask_the_holder_again() {
     );
 }
 
+/// A holder who never answers must cost the operator one pause, not
+/// the session: the ask expires and a later press asks again.
+#[test]
+fn an_unanswered_handover_lets_the_sticks_ask_again_later() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[9]);
+    let _ = deliver(&mut link, &lease_envelope("vehicle.motion", false, 5));
+    // The holder says nothing at all; the ask ages out.
+    link.motion_ask_at_ms = Some(0);
+    link.started = Instant::now() - std::time::Duration::from_secs(30);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let again = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert_eq!(
+        bootstrap_payloads(&again),
+        vec!["lease-request"],
+        "an ask nobody answered must not lock the sticks out for good"
+    );
+}
+
 /// Standing down must leave a way back from the sticks. The runtime
 /// gates on its OWN mirror of authority: a release it never hears
 /// leaves output "live", so the next press takes the send path, dies

--- a/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
+++ b/clients/apple/rust/pilotage-situation-ffi/src/link/tests/lifecycle.rs
@@ -161,7 +161,9 @@ fn a_press_while_a_handover_is_pending_does_not_ask_the_holder_again() {
 }
 
 /// A holder who never answers must cost the operator one pause, not
-/// the session: the ask expires and a later press asks again.
+/// the session: the ask expires and a later press asks again. Only the
+/// clock moves here — the ask itself is the one the press really made,
+/// so a shell that stopped timing its asks fails this.
 #[test]
 fn an_unanswered_handover_lets_the_sticks_ask_again_later() {
     let mut link = admitted_link();
@@ -171,14 +173,34 @@ fn an_unanswered_handover_lets_the_sticks_ask_again_later() {
     let _ = pad_tick(&mut link, [0.0; 4], &[9]);
     let _ = deliver(&mut link, &lease_envelope("vehicle.motion", false, 5));
     // The holder says nothing at all; the ask ages out.
-    link.motion_ask_at_ms = Some(0);
-    link.started = Instant::now() - std::time::Duration::from_secs(30);
+    link.started -= std::time::Duration::from_secs(30);
     let _ = pad_tick(&mut link, [0.0; 4], &[]);
     let again = pad_tick(&mut link, [0.0; 4], &[9]);
     assert_eq!(
         bootstrap_payloads(&again),
         vec!["lease-request"],
         "an ask nobody answered must not lock the sticks out for good"
+    );
+}
+
+/// The screen and the sticks are two doors onto one ask. A press that
+/// follows the button must not put a second prompt in front of the
+/// holder for the same operator intent.
+#[test]
+fn a_press_after_the_screen_asked_does_not_ask_the_holder_again() {
+    let mut link = admitted_link();
+    link.control.select_device("gamepad");
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    let _ = pad_tick(&mut link, [0.0; 4], &[]);
+    // The operator taps "Request control" on the screen — the same
+    // path the driver runs for that command.
+    let screen = link.request_lease_actions(1, "vehicle.motion");
+    assert_eq!(bootstrap_payloads(&screen), vec!["lease-request"]);
+    let press = pad_tick(&mut link, [0.0; 4], &[9]);
+    assert!(
+        bootstrap_payloads(&press).is_empty(),
+        "the press must defer to the ask the screen already made, got {:?}",
+        bootstrap_payloads(&press)
     );
 }
 

--- a/crates/pilotage-client-session/src/action.rs
+++ b/crates/pilotage-client-session/src/action.rs
@@ -42,6 +42,9 @@ pub enum ModuleEvent {
     LeaseReleased(wire::LeaseReleased),
     /// The host rejected a control frame. Fencing feedback, not noise.
     ControlRejected(wire::FrameRejected),
+    /// The host confirmed a scope's link-loss recovery: the vehicle's
+    /// brake is off this generation, so gated live output may resume.
+    LinkLossCleared(wire::LinkLossCleared),
     /// The host answered a discrete control action.
     ActionResult(wire::ControlActionResult),
     /// The host echoed a ping.

--- a/crates/pilotage-client-session/src/engine.rs
+++ b/crates/pilotage-client-session/src/engine.rs
@@ -408,6 +408,13 @@ impl ClientEngine {
                 actions.push(ClientAction::Emit(ModuleEvent::Authority(event)));
                 actions
             }
+            // The recovery ack must reach the shell's authority mirror:
+            // a regrant after any holder loss stays in neutral
+            // activation until this confirmation arrives, so dropping
+            // it here leaves live output gated forever.
+            Some(wire::envelope::Payload::LinkLossCleared(cleared)) => {
+                vec![ClientAction::Emit(ModuleEvent::LinkLossCleared(cleared))]
+            }
             _ => Vec::new(),
         }
     }

--- a/crates/pilotage-client-session/src/engine.rs
+++ b/crates/pilotage-client-session/src/engine.rs
@@ -222,6 +222,17 @@ impl ClientEngine {
         ))]
     }
 
+    /// Whether a handover for this scope is still in flight: the ask
+    /// reached a standing holder and no answer has come back. A shell
+    /// that repeats the ask on every press would prompt that holder
+    /// again for each one.
+    #[must_use]
+    pub fn takeover_pending(&self, vehicle_id: u64, scope: &str) -> bool {
+        self.pending_takeover
+            .as_ref()
+            .is_some_and(|(vehicle, pending)| *vehicle == vehicle_id && pending == scope)
+    }
+
     /// Offers the named held scope to another principal — the holder's
     /// half of a cooperative handover. Without that lane there is
     /// nothing to offer.

--- a/crates/pilotage-client-session/src/engine_transfer.rs
+++ b/crates/pilotage-client-session/src/engine_transfer.rs
@@ -27,6 +27,20 @@ impl ClientEngine {
             Some(wire::authority_event::Event::ScopeLeaseRevoked(revoked)) => {
                 self.on_scope_freed(revoked)
             }
+            // The offer's time ran out and the scope stayed where it
+            // was: nothing is pending any more, so a later ask is a
+            // fresh one rather than a wait for an answer that will
+            // never come.
+            Some(wire::authority_event::Event::ScopeTransferExpired(expired)) => {
+                let vehicle = expired.vehicle.as_ref().map_or(0, |v| v.value);
+                let scope = expired
+                    .scope
+                    .as_ref()
+                    .map(|s| s.value.clone())
+                    .unwrap_or_default();
+                self.clear_pending_takeover(vehicle, &scope);
+                Vec::new()
+            }
             _ => Vec::new(),
         }
     }
@@ -142,19 +156,22 @@ impl ClientEngine {
                     },
                 )));
             }
-        } else if self.lanes.remove(&(vehicle, scope.clone())).is_some() {
-            // Authority moved away from this lane: it is gone, and
-            // saying so beats a stream of fenced rejections.
+        } else {
+            // The scope went to someone else. Whatever this engine was
+            // waiting for is settled either way, and only a lane it
+            // actually held is worth reporting as lost.
             self.clear_pending_takeover(vehicle, &scope);
-            actions.push(ClientAction::Emit(ModuleEvent::Lease(
-                wire::LeaseResponse {
-                    vehicle: Some(wire::VehicleId { value: vehicle }),
-                    scope: Some(wire::ScopeId { value: scope }),
-                    granted: false,
-                    generation: Some(wire::Generation { value: generation }),
-                    reason: 1,
-                },
-            )));
+            if self.lanes.remove(&(vehicle, scope.clone())).is_some() {
+                actions.push(ClientAction::Emit(ModuleEvent::Lease(
+                    wire::LeaseResponse {
+                        vehicle: Some(wire::VehicleId { value: vehicle }),
+                        scope: Some(wire::ScopeId { value: scope }),
+                        granted: false,
+                        generation: Some(wire::Generation { value: generation }),
+                        reason: 1,
+                    },
+                )));
+            }
         }
         actions
     }

--- a/crates/pilotage-client-session/src/engine_transfer.rs
+++ b/crates/pilotage-client-session/src/engine_transfer.rs
@@ -70,6 +70,21 @@ impl ClientEngine {
         ))]
     }
 
+    /// Drops a pending ask this scope's outcome has settled. An ask
+    /// that outlives the handover it belongs to is a shell told to keep
+    /// waiting for an answer that can no longer come.
+    fn clear_pending_takeover(&mut self, vehicle: u64, scope: &str) {
+        if self
+            .pending_takeover
+            .as_ref()
+            .is_some_and(|(pending_vehicle, pending_scope)| {
+                *pending_vehicle == vehicle && pending_scope == scope
+            })
+        {
+            self.pending_takeover = None;
+        }
+    }
+
     /// Accepts the offer that answers this engine's own pending ask, and
     /// no other.
     fn on_transfer_offered(
@@ -130,6 +145,7 @@ impl ClientEngine {
         } else if self.lanes.remove(&(vehicle, scope.clone())).is_some() {
             // Authority moved away from this lane: it is gone, and
             // saying so beats a stream of fenced rejections.
+            self.clear_pending_takeover(vehicle, &scope);
             actions.push(ClientAction::Emit(ModuleEvent::Lease(
                 wire::LeaseResponse {
                     vehicle: Some(wire::VehicleId { value: vehicle }),

--- a/crates/pilotage-client-session/src/tests/takeover.rs
+++ b/crates/pilotage-client-session/src/tests/takeover.rs
@@ -40,6 +40,38 @@ fn a_scope_without_a_gimbal_advertisement_gets_no_intent() {
     assert!(gimbal_rate_intent(1.0, 1.0, None).is_none());
 }
 
+/// The recovery ack must reach the module layer: a shell that never
+/// hears it keeps regranted live output gated forever, so dropping
+/// the envelope here is a dead-stick bug wearing a clean log.
+#[test]
+fn the_recovery_ack_is_forwarded_to_the_modules() {
+    let mut engine = engine();
+    let cleared = wire::LinkLossCleared {
+        vehicle: Some(wire::VehicleId { value: 1 }),
+        scope: Some(wire::ScopeId {
+            value: "vehicle.motion".into(),
+        }),
+        generation: Some(wire::Generation { value: 6 }),
+    };
+    let envelope = wire::Envelope {
+        schema_version: 1,
+        payload: Some(wire::envelope::Payload::LinkLossCleared(cleared.clone())),
+    };
+    let bytes = pilotage_protocol::encode_envelope_length_delimited(&envelope);
+    engine.handle(TransportEvent::UniStreamOpened(StreamId(9)), 0);
+    let mut tagged = vec![0x01];
+    tagged.extend_from_slice(&bytes);
+    let actions = engine.handle(TransportEvent::UniStreamReceived(StreamId(9), tagged), 0);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            ClientAction::Emit(ModuleEvent::LinkLossCleared(forwarded))
+                if *forwarded == cleared
+        )),
+        "the cleared ack must surface as a module event, got {actions:?}"
+    );
+}
+
 /// Feeds one authority event through the session-events stream.
 fn authority_event(
     engine: &mut ClientEngine,

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -46,7 +46,7 @@ collect_swift_files() {
 # recorded count and may only shrink.
 swift_length_ceiling() {
     case "$1" in
-        ./clients/apple/App/HostLinkModel.swift) echo 676 ;;
+        ./clients/apple/App/HostLinkModel.swift) echo 674 ;;
         *) echo 500 ;;
     esac
 }


### PR DESCRIPTION
Three commits, each independently revertible, from one operator session: two interface complaints, one dead-stick class of bug found while fixing them, and the control lifecycle reaching the controls that fly the vehicle.

## The top row owns the replay banner, and the arrows say what the map will do

The replay banner floated at `.topLeading` while the column toggle sat in the top row, so the two overlapped and read as a broken corner. The banner joins the one top row, after the toggle.

The toggle's arrows pointed the wrong way: it showed "collapse" while the columns were open. The glyph now names what pressing DOES to the map — outward arrows take the map full-window, inward arrows give the columns back — the same way the tile focus control already speaks.

## The engine forwards the link-loss recovery ack

`ModuleEvent::LinkLossCleared` did not exist and the engine dropped `Payload::LinkLossCleared` on the floor. The browser has always consumed this ack (`control-loop.js`), and the shared runtime gates regranted live output behind it: after any denial or revocation the authority mirror clears `recovered`, and the regrant then sits in neutral activation forever. The operator sees a held lease and a dead stick, and one second later the host's silence watchdog revokes it.

The envelope now reaches the module layer; the Apple shell mirrors it into the runtime, filtered by the admitted vehicle exactly as the browser filters by vehicle and scope. The mirror itself still rejects a generation that is not the granted one.

Guardrails: an engine test that the ack surfaces as a module event, and a shell test walking deny → regrant → gated → neutral activation → cleared → live.

## Sticks and keys work the control lifecycle through the shared runtime

The operator could fly with the pad but could not TAKE control with it: acquisition and standdown were screen-only buttons, and a hardware keyboard did nothing at all.

- The tick loop now runs for the whole admitted session rather than only under a lease. The shared runtime gates what an observer may not send, so the loop is safe to run un-leased and is the only thing that can turn a control press into an intent.
- An arm press with no lease IS the cooperative ask. One ask owns the control for ten seconds, whichever door it came through — the screen button and the stick press share the same bookkeeping — so a thumb on the button cannot put prompt after prompt in front of a standing holder. The ask EXPIRES, because a holder who never answers must cost the operator one pause rather than the sticks for the rest of the session. A press that cannot become an ask still reports itself: a consumed safety press must never be silent.
- A disarm press with the lever settled on SAFE and the flight controller confirming disarmed means "stand down": both held lanes go back, through the same path the screen's Release button uses. The screen lever is unaffected; a redundant tap on SAFE stays a no-op.
- The hardware keyboard is a device layer of the same runtime, not a second control path: the same compiled profile (`keyboard.json`), curves, edges, and quasimode, reaching the same lanes. WASD and the arrows drive the canonical stick slots; Enter arms; Backspace disarms.
- A focused text field owns the keyboard: nothing typed there doubles as a flight input, and everything held is dropped on that transition, on backgrounding, and on keyboard disconnect, so a key released out of sight cannot keep a demand alive.
- The runtime's own motion-lease reacquisition plan stays unexecuted on this shell. Control is taken by a person, never by a reconnecting state machine.
- The gimbal quasimode's auxiliary lease now follows a HELD motion lease, so an observer's ticks cannot leave a bystander holding a camera nobody at the sticks can move.

Guardrails: an observer-invariant test (pre-grant ticks emit no frames and no lease traffic), one-ask-per-answer, settled-safe standdown, keys flying the motion lane with a neutral fallback, an Enter press asking for control, and a pure `GCKeyCode` → canonical-name table with its own Swift Testing case, so a drifted key name is a test failure rather than a silently dead control.

`Release` and `Request control` no longer wrap. The debug footprint probe moved to its own file, so `HostLinkModel.swift` shrank and its structure-gate pin ratcheted 676 → 674.

## Divergence worth naming

Lease ACQUISITION policy differs between the shells by intent: the browser auto-requests on connect, this shell requires a press. Mapping, curves, modes, edges, and the quasimode remain one shared implementation, which is the parity that matters.

## What the review caught

An independent review rejected the first version of this branch, with two findings that stood up to being tested rather than argued:

**A standdown left the pad with no way back.** `ModuleEvent::LeaseReleased` never reached the runtime's authority mirror, so after handing control back the mirror still reported a granted, recovered lease. Motion output stayed "live", which meant the next arm press took the SEND path instead of the ASK path, died with no lane to ride, and reported nothing at all. The first version of this PR called that a benign follow-up; it was neither benign nor a follow-up, because running the tick loop for the whole session is exactly what made it reachable. The release now reaches the mirror before it reaches the screen.

**Repeated presses did re-escalate at a holder.** The debounce watched the unanswered lease request, but a cooperative denial is answered within the round trip and the engine escalates it into a handover request, so every press prompted the other pilot again. Watching the handover instead traded that for a worse failure — a holder who simply ignores the prompt would cost the operator the sticks for the whole session — so the ask is time-bounded, and the two `pending_takeover` paths that never cleared (an expired offer, and a transfer committed to a third party) now clear.

Also from the review: a refused arm and a vehicle that drops out of arm on its own both snap the lever to SAFE without anyone ordering it, so standdown additionally requires a telegraph in sync; the DEBUG climb window no longer overrides an attached pad; a key held while a text field takes focus is now released by the focus change rather than by the next key event that may never come.

## Known follow-up (not in this PR)

A grounded, disarmed vehicle is settled-safe from its first telemetry, so the first disarm press stands down control without an arm cycle. Whether standing down should need a distinct gesture rather than a bare disarm press is an operator-facing decision, not one to settle inside a review.

An expired handover clears the ask but leaves the status line still reading that the holder was asked. The control path is right — the sticks ask again with no pause — but by this branch's own standard an ask that died owes the operator a word. It needs its own event: routing it through a not-granted lease response would mirror a revocation and fence a later grant, which is a dead stick, so the fix is a Notice or a dedicated event with its own test.

The ask timestamp is stamped in two places, the screen path and the press path. Both are guardrailed, but one site forgetting the stamp is exactly the defect the review found here, so the two belong behind one call.

## Verification

- `pilotage-situation-ffi`: 25 tests pass; fmt and clippy `-D warnings` clean.
- `pilotage-client-session`: 28 tests pass; fmt and clippy clean.
- `PilotageCore`: 4 Swift tests pass against a freshly built xcframework.
- `scripts/check-structure.sh`: OK.
- Device build for `generic/platform=iOS` succeeds and is installed on the iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

