### PR TITLE
LAN discovery: one-URL handoff, mDNS name, pilotage.local alias

### DIFF
--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -173,10 +173,12 @@ pub fn parse_listening(line: &str) -> Option<(u16, String)> {
 
 /// The pinned viewer URL for a ready session. `autoconnect=1` tells the
 /// viewer to connect on load — the URL already pins host, port, and
-/// certificate, so a Connect click would add nothing.
-pub fn viewer_url(viewer_port: u16, host_port: u16, cert: &str) -> String {
+/// certificate, so a Connect click would add nothing. `host` is the
+/// address the CLIENT reaches this machine at: loopback for the local
+/// browser, the LAN address for a tablet on the same network.
+pub fn viewer_url(host: &str, viewer_port: u16, host_port: u16, cert: &str) -> String {
     format!(
-        "http://127.0.0.1:{viewer_port}/index.html?host=127.0.0.1&port={host_port}&cert={cert}&autoconnect=1"
+        "http://{host}:{viewer_port}/index.html?host={host}&port={host_port}&cert={cert}&autoconnect=1"
     )
 }
 
@@ -225,9 +227,23 @@ mod tests {
     fn viewer_url_pins_host_port_certificate_and_autoconnect() {
         let cert = "0f".repeat(32);
         assert_eq!(
-            viewer_url(8080, 4433, &cert),
+            viewer_url("127.0.0.1", 8080, 4433, &cert),
             format!(
                 "http://127.0.0.1:8080/index.html?host=127.0.0.1&port=4433&cert={cert}&autoconnect=1"
+            )
+        );
+    }
+
+    #[test]
+    fn viewer_url_reaches_the_session_from_another_device() {
+        // The LAN banner hands an iPad the whole story in one URL: the
+        // page origin AND the WebTransport host must both be the
+        // address that device can actually reach.
+        let cert = "0f".repeat(32);
+        assert_eq!(
+            viewer_url("192.168.4.17", 8080, 4433, &cert),
+            format!(
+                "http://192.168.4.17:8080/index.html?host=192.168.4.17&port=4433&cert={cert}&autoconnect=1"
             )
         );
     }

--- a/tools/xtask/src/readiness.rs
+++ b/tools/xtask/src/readiness.rs
@@ -186,8 +186,16 @@ pub fn viewer_url(host: &str, viewer_port: u16, host_port: u16, cert: &str) -> S
 /// CURRENT session's connect parameters. A viewer tab whose URL pins an
 /// older session's certificate re-reads this after a failed connect and
 /// converges on the live session instead of retrying a dead hash forever.
-pub fn session_manifest(host: &str, host_port: u16, cert: &str) -> String {
-    format!("{{\"host\":\"{host}\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n")
+pub fn session_manifest(host: &str, host_ip: Option<&str>, host_port: u16, cert: &str) -> String {
+    // `host` is the name a client should dial (the mDNS name on a LAN
+    // session); `hostIp` rides along for a client that cannot resolve
+    // it. Decoders that know only the three original fields ignore it.
+    match host_ip.filter(|ip| *ip != host) {
+        Some(ip) => format!(
+            "{{\"host\":\"{host}\",\"hostIp\":\"{ip}\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n"
+        ),
+        None => format!("{{\"host\":\"{host}\",\"port\":{host_port},\"certHash\":\"{cert}\"}}\n"),
+    }
 }
 
 /// The log file a stage writes under `log_dir`.
@@ -249,12 +257,23 @@ mod tests {
     }
 
     #[test]
+    fn session_manifest_names_the_host_and_keeps_the_address_beside_it() {
+        let cert = "c".repeat(64);
+        assert_eq!(
+            super::session_manifest("mac.local", Some("192.168.4.17"), 4433, &cert),
+            format!(
+                "{{\"host\":\"mac.local\",\"hostIp\":\"192.168.4.17\",\"port\":4433,\"certHash\":\"{cert}\"}}\n"
+            )
+        );
+    }
+
+    #[test]
     fn session_manifest_carries_exactly_the_listening_values() {
         let cert = "0f".repeat(32);
         // The viewer's validator requires this exact shape (host string,
         // integer port, 64-hex certHash); a drift here strands stale tabs.
         assert_eq!(
-            super::session_manifest("127.0.0.1", 4433, &cert),
+            super::session_manifest("127.0.0.1", None, 4433, &cert),
             format!("{{\"host\":\"127.0.0.1\",\"port\":4433,\"certHash\":\"{cert}\"}}\n")
         );
     }

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -95,7 +95,9 @@ pub async fn run_sim(args: &SimArgs) -> Result<(), XtaskError> {
     let pid_file = log_dir.join("supervisor.pid");
     claim_supervisor(&pid_file, &mut children)?;
 
-    announce::publish_connect_facts(args, &ctx, actual_port, &certificate);
+    // Held for the session's lifetime: dropping it (any exit path from
+    // here) unregisters the `pilotage.local` alias with the session.
+    let _mdns_alias = announce::publish_connect_facts(args, &ctx, actual_port, &certificate);
 
     let outcome = supervise(&mut children, &stages, &mut cancel).await;
     std::fs::remove_file(&pid_file).ok();

--- a/tools/xtask/src/session/announce.rs
+++ b/tools/xtask/src/session/announce.rs
@@ -25,12 +25,12 @@ pub(super) fn publish_connect_facts(
     let mdns = if ctx.lan { mdns_hostname() } else { None };
     // The DEDICATED alias outranks the machine name: `pilotage.local`
     // is the same on every machine that runs a session, so a client's
-    // saved manifest URL is device-independent. Best-effort — a failed
-    // registration (dns-sd absent, name conflict on this network)
-    // falls back to the machine's own advertised name.
+    // saved manifest URL is device-independent. Best-effort covers a
+    // machine without dns-sd; a NAME CONFLICT on the network surfaces
+    // asynchronously after spawn and is not detected here — the
+    // machine-name URL printed beside the alias is the recovery.
     let alias = lan_ip
         .as_deref()
-        .filter(|_| ctx.lan)
         .and_then(|ip| register_mdns_alias(ip, args.viewer_port));
     let session_host = alias
         .as_ref()

--- a/tools/xtask/src/session/announce.rs
+++ b/tools/xtask/src/session/announce.rs
@@ -15,7 +15,7 @@ pub(super) fn publish_connect_facts(
     ctx: &SessionContext,
     actual_port: u16,
     certificate: &str,
-) {
+) -> Option<MdnsAlias> {
     let lan_ip = if ctx.lan { lan_address() } else { None };
     // The mDNS name is the LAN identity that SURVIVES: DHCP renumbers
     // the address between sessions, and every stale URL then reads as
@@ -23,8 +23,19 @@ pub(super) fn publish_connect_facts(
     // pinned by digest, never by name, so what resolves the host can
     // change freely without touching the trust anchor.
     let mdns = if ctx.lan { mdns_hostname() } else { None };
-    let session_host = mdns
-        .clone()
+    // The DEDICATED alias outranks the machine name: `pilotage.local`
+    // is the same on every machine that runs a session, so a client's
+    // saved manifest URL is device-independent. Best-effort — a failed
+    // registration (dns-sd absent, name conflict on this network)
+    // falls back to the machine's own advertised name.
+    let alias = lan_ip
+        .as_deref()
+        .filter(|_| ctx.lan)
+        .and_then(|ip| register_mdns_alias(ip, args.viewer_port));
+    let session_host = alias
+        .as_ref()
+        .map(|_| MDNS_ALIAS_HOST.to_owned())
+        .or(mdns)
         .or_else(|| lan_ip.clone())
         .unwrap_or_else(|| "127.0.0.1".to_owned());
     write_session_manifest(
@@ -41,6 +52,43 @@ pub(super) fn publish_connect_facts(
         actual_port,
         certificate,
     );
+    alias
+}
+
+/// The device-independent LAN name a session answers to while it runs.
+const MDNS_ALIAS_HOST: &str = "pilotage.local";
+
+/// A best-effort mDNS host alias held for the session's lifetime: the
+/// spawned `dns-sd -P` proxy keeps the registration alive, and dropping
+/// this kills it, so the name never outlives the session it names.
+pub(super) struct MdnsAlias {
+    child: std::process::Child,
+}
+
+impl Drop for MdnsAlias {
+    fn drop(&mut self) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+    }
+}
+
+/// Registers `pilotage.local` as a proxy for this machine's address.
+fn register_mdns_alias(ip: &str, viewer_port: u16) -> Option<MdnsAlias> {
+    let child = std::process::Command::new("dns-sd")
+        .args([
+            "-P",
+            "Pilotage",
+            "_pilotage._tcp",
+            "local",
+            &viewer_port.to_string(),
+            MDNS_ALIAS_HOST,
+            ip,
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    Some(MdnsAlias { child })
 }
 
 /// This machine's mDNS name (`<name>.local`), the LAN identity Bonjour

--- a/tools/xtask/src/session/announce.rs
+++ b/tools/xtask/src/session/announce.rs
@@ -16,31 +16,94 @@ pub(super) fn publish_connect_facts(
     actual_port: u16,
     certificate: &str,
 ) {
-    let session_host = if ctx.lan {
-        lan_address().unwrap_or_else(|| "127.0.0.1".to_owned())
-    } else {
-        "127.0.0.1".to_owned()
+    let lan_ip = if ctx.lan { lan_address() } else { None };
+    // The mDNS name is the LAN identity that SURVIVES: DHCP renumbers
+    // the address between sessions, and every stale URL then reads as
+    // a dead host. The name is pure discovery — the certificate is
+    // pinned by digest, never by name, so what resolves the host can
+    // change freely without touching the trust anchor.
+    let mdns = if ctx.lan { mdns_hostname() } else { None };
+    let session_host = mdns
+        .clone()
+        .or_else(|| lan_ip.clone())
+        .unwrap_or_else(|| "127.0.0.1".to_owned());
+    write_session_manifest(
+        ctx,
+        &session_host,
+        lan_ip.as_deref(),
+        actual_port,
+        certificate,
+    );
+    announce_ready(
+        args,
+        &session_host,
+        lan_ip.as_deref(),
+        actual_port,
+        certificate,
+    );
+}
+
+/// This machine's mDNS name (`<name>.local`), the LAN identity Bonjour
+/// already publishes. On macOS that identity is the LOCAL host name
+/// (`scutil --get LocalHostName`), which can differ from the kernel
+/// hostname — mDNS answers only for the advertised one, so publishing
+/// the kernel name would hand out a URL no other device can resolve.
+/// `None` when no usable name exists; the caller falls back to the
+/// numeric address.
+fn mdns_hostname() -> Option<String> {
+    let advertised = std::process::Command::new("scutil")
+        .args(["--get", "LocalHostName"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok());
+    let fallback = || {
+        std::process::Command::new("hostname")
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
     };
-    write_session_manifest(ctx, &session_host, actual_port, certificate);
-    announce_ready(args, &session_host, actual_port, certificate);
+    let name = advertised.or_else(fallback)?.trim().to_owned();
+    if name.is_empty() || name.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(if name.ends_with(".local") {
+        name
+    } else {
+        format!("{name}.local")
+    })
 }
 
 /// Prints the ready URL and opens it in the default browser when asked.
 /// Under `--lan` the native connect facts follow: the same three values a
 /// browser takes from the query string, for a client that takes them from
 /// a settings screen instead.
-fn announce_ready(args: &SimArgs, session_host: &str, actual_port: u16, certificate: &str) {
+fn announce_ready(
+    args: &SimArgs,
+    session_host: &str,
+    lan_ip: Option<&str>,
+    actual_port: u16,
+    certificate: &str,
+) {
     let url = viewer_url("127.0.0.1", args.viewer_port, actual_port, certificate);
     print_line("");
     print_line(&format!("session ready: {url}"));
     if args.lan {
         // The same session from another device on this network — an
         // iPad's browser takes the whole story from the URL, exactly
-        // like the local one.
+        // like the local one. The mDNS name leads because it survives
+        // DHCP renumbering; the numeric address follows for a client
+        // that cannot resolve it.
         print_line(&format!(
             "on the LAN:    {}",
             viewer_url(session_host, args.viewer_port, actual_port, certificate)
         ));
+        if let Some(ip) = lan_ip.filter(|ip| *ip != session_host) {
+            print_line(&format!(
+                "  by address:  {}",
+                viewer_url(ip, args.viewer_port, actual_port, certificate)
+            ));
+        }
         print_line(&format!(
             "native clients: https://{session_host}:{actual_port}/pilotage"
         ));
@@ -71,9 +134,18 @@ fn lan_address() -> Option<String> {
 /// certificate — re-reads it after a failed connect and converges on
 /// THIS session. Best-effort: a failed write only loses stale-tab
 /// convergence, never the session.
-fn write_session_manifest(ctx: &SessionContext, session_host: &str, port: u16, certificate: &str) {
+fn write_session_manifest(
+    ctx: &SessionContext,
+    session_host: &str,
+    lan_ip: Option<&str>,
+    port: u16,
+    certificate: &str,
+) {
     let path = ctx.repo_root.join("clients/web/session.json");
-    if let Err(error) = std::fs::write(&path, session_manifest(session_host, port, certificate)) {
+    if let Err(error) = std::fs::write(
+        &path,
+        session_manifest(session_host, lan_ip, port, certificate),
+    ) {
         print_line(&format!(
             "warning: could not write {}: {error}",
             path.display()

--- a/tools/xtask/src/session/announce.rs
+++ b/tools/xtask/src/session/announce.rs
@@ -30,10 +30,17 @@ pub(super) fn publish_connect_facts(
 /// browser takes from the query string, for a client that takes them from
 /// a settings screen instead.
 fn announce_ready(args: &SimArgs, session_host: &str, actual_port: u16, certificate: &str) {
-    let url = viewer_url(args.viewer_port, actual_port, certificate);
+    let url = viewer_url("127.0.0.1", args.viewer_port, actual_port, certificate);
     print_line("");
     print_line(&format!("session ready: {url}"));
     if args.lan {
+        // The same session from another device on this network — an
+        // iPad's browser takes the whole story from the URL, exactly
+        // like the local one.
+        print_line(&format!(
+            "on the LAN:    {}",
+            viewer_url(session_host, args.viewer_port, actual_port, certificate)
+        ));
         print_line(&format!(
             "native clients: https://{session_host}:{actual_port}/pilotage"
         ));


### PR DESCRIPTION
## What this stack does

One-URL LAN handoff for a session: `--lan` binds the viewer on 0.0.0.0 and prints a URL carrying host, port, and certificate; the served manifest lets a stale tab converge on the live session. The session answers to a name that survives DHCP: the machine's advertised mDNS name, and above it the dedicated `pilotage.local` alias (dns-sd proxy held for exactly the session's lifetime) — the same saved URL reaches a session on any development machine. The certificate stays pinned by digest, never by name: discovery can evolve (IP → .local → WAN DNS) without touching the trust anchor.

## Verification

Exercised from iPad Safari and the native client across DHCP renumbering; manifest test pins the wire shape. Workspace gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Du4vE4uPnuahuQv2E6J4S