### PR TITLE
Report why the host rejected a frame

### DIFF
--- a/tools/loopback-probe/src/metrics.rs
+++ b/tools/loopback-probe/src/metrics.rs
@@ -100,6 +100,13 @@ pub struct RunMetrics {
     pub frames_sent: u64,
     /// `FrameRejected` notices received from the host.
     pub frames_rejected: u64,
+    /// How many rejections carried each reason, in first-seen order.
+    ///
+    /// A count alone says a run failed; the REASON says whether the
+    /// vehicle refused the demand, the session lost its lease, or the
+    /// measurement the adapter needs never arrived. Without it a
+    /// diagnosis costs a whole run.
+    pub rejection_reasons: Vec<(String, u64)>,
     /// Telemetry samples received.
     pub telemetry_received: u64,
     /// The most recently observed telemetry pose (`x_m`, `y_m`,
@@ -126,9 +133,25 @@ impl RunMetrics {
             rtt: RttEstimator::new(),
             frames_sent: 0,
             frames_rejected: 0,
+            rejection_reasons: Vec::new(),
             telemetry_received: 0,
             last_pose: None,
             dropped_events: 0,
+        }
+    }
+
+    /// Records one rejection and the reason the host gave for it.
+    pub fn note_rejection(&mut self, reason: &pilotage_protocol::FrameRejectionReason) {
+        self.frames_rejected = self.frames_rejected.saturating_add(1);
+        let label = format!("{reason:?}");
+        if let Some(entry) = self
+            .rejection_reasons
+            .iter_mut()
+            .find(|(seen, _)| *seen == label)
+        {
+            entry.1 = entry.1.saturating_add(1);
+        } else {
+            self.rejection_reasons.push((label, 1));
         }
     }
 

--- a/tools/loopback-probe/src/run.rs
+++ b/tools/loopback-probe/src/run.rs
@@ -197,7 +197,7 @@ async fn wait_for_rejection(
         };
         match tokio::time::timeout(remaining, events_rx.recv()).await {
             Ok(Some(ReceiverEvent::FrameRejected(rejected))) => {
-                metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+                metrics.note_rejection(&rejected.reason);
                 if rejected.sequence == sequence {
                     return true;
                 }
@@ -241,8 +241,8 @@ fn drain_pending_events(
                     metrics.last_pose = observation.pose;
                 }
             }
-            ReceiverEvent::FrameRejected(_) => {
-                metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+            ReceiverEvent::FrameRejected(rejected) => {
+                metrics.note_rejection(&rejected.reason);
             }
             ReceiverEvent::VideoFrame { source_id, jpeg } => {
                 fold_video_frame(source_id, &jpeg, video, &mut last_video_at);

--- a/tools/loopback-probe/src/sender.rs
+++ b/tools/loopback-probe/src/sender.rs
@@ -265,8 +265,8 @@ fn handle_event(
             }
             fold_telemetry(&observation, state, metrics);
         }
-        ReceiverEvent::FrameRejected(_) => {
-            metrics.frames_rejected = metrics.frames_rejected.saturating_add(1);
+        ReceiverEvent::FrameRejected(rejected) => {
+            metrics.note_rejection(&rejected.reason);
         }
         ReceiverEvent::Pong { pong, received_at } => {
             let rtt = estimated_age(received_at, pong.echoed_sender_sent_at, ZERO_OFFSET);

--- a/tools/loopback-probe/src/summary.rs
+++ b/tools/loopback-probe/src/summary.rs
@@ -26,6 +26,9 @@ pub fn print_summary(
         metrics.frames_accepted()
     ));
     print_line(&format!("frames rejected:     {}", metrics.frames_rejected));
+    for (reason, count) in &metrics.rejection_reasons {
+        print_line(&format!("  rejected as {reason}: {count}"));
+    }
     print_line(&format!(
         "telemetry received:  {}",
         metrics.telemetry_received


### PR DESCRIPTION
A rejected control frame reports WHY (typed reject reasons on the probe surface), not just how many — the difference between a five-minute fix and a night of guessing, measured twice this week.

Workspace gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Du4vE4uPnuahuQv2E6J4S