### PR TITLE
Bind trial timing to deterministic conditions (#448)

### DIFF
--- a/crates/pilotage-trial/src/condition.rs
+++ b/crates/pilotage-trial/src/condition.rs
@@ -4,6 +4,10 @@ use core::f64::consts::TAU;
 
 use serde::{Deserialize, Serialize};
 
+mod timing;
+
+pub use timing::{DelayJitter, TimingCondition};
+
 use crate::{
     CONDITION_SET_SCHEMA_VERSION, CodecError, Digest, MAX_GUST_EVENTS, MAX_MANIFEST_BYTES,
     MAX_TEXT_BYTES, ValidationError, canonical,
@@ -82,6 +86,8 @@ pub struct ConditionSet {
     pub seed: u64,
     /// Wind and turbulence definition.
     pub wind: WindCondition,
+    /// Deterministic source timing perturbation.
+    pub timing: TimingCondition,
 }
 
 /// One resolved wind sample for a simulator backend.
@@ -116,7 +122,8 @@ impl ConditionSet {
             CONDITION_SET_SCHEMA_VERSION,
         )?;
         text("condition_set.id", &self.id, MAX_TEXT_BYTES)?;
-        self.wind.validate()
+        self.wind.validate()?;
+        self.timing.validate()
     }
 
     /// Encode canonical compact JSON after validation.
@@ -158,6 +165,12 @@ impl ConditionSet {
         let turbulence = self.wind.turbulence.sample(seed, elapsed_ns);
         vector.add_scaled(turbulence, 1.0);
         vector.applied(turbulence.magnitude())
+    }
+
+    /// Resolves the requested vehicle-source delay for one run and time.
+    #[must_use]
+    pub fn source_delay_ns_for_run(&self, run_seed: u64, elapsed_ns: u64) -> u64 {
+        self.timing.delay_ns(self.seed, run_seed, elapsed_ns)
     }
 }
 

--- a/crates/pilotage-trial/src/condition.rs
+++ b/crates/pilotage-trial/src/condition.rs
@@ -134,6 +134,16 @@ impl ConditionSet {
     /// Resolve the wind request at one simulator-time offset.
     #[must_use]
     pub fn wind_at(&self, elapsed_ns: u64) -> AppliedWind {
+        self.wind_at_for_run(0, elapsed_ns)
+    }
+
+    /// Resolve the wind for one recorded run seed and simulator-time offset.
+    ///
+    /// The artifact seed defines the condition. The run seed gives each
+    /// repetition a separate deterministic disturbance without changing the
+    /// condition artifact identity.
+    #[must_use]
+    pub fn wind_at_for_run(&self, run_seed: u64, elapsed_ns: u64) -> AppliedWind {
         let mut vector = WindVector::from(self.wind.steady);
         for gust in &self.wind.gusts {
             vector.add_scaled(
@@ -144,7 +154,8 @@ impl ConditionSet {
                 gust.scale_at(elapsed_ns),
             );
         }
-        let turbulence = self.wind.turbulence.sample(self.seed, elapsed_ns);
+        let seed = self.seed ^ run_seed.rotate_left(17);
+        let turbulence = self.wind.turbulence.sample(seed, elapsed_ns);
         vector.add_scaled(turbulence, 1.0);
         vector.applied(turbulence.magnitude())
     }

--- a/crates/pilotage-trial/src/condition.rs
+++ b/crates/pilotage-trial/src/condition.rs
@@ -1,0 +1,361 @@
+//! Deterministic environmental condition contracts.
+
+use core::f64::consts::TAU;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CONDITION_SET_SCHEMA_VERSION, CodecError, Digest, MAX_GUST_EVENTS, MAX_MANIFEST_BYTES,
+    MAX_TEXT_BYTES, ValidationError, canonical,
+    validation::{count, duration, range, schema, text},
+};
+
+const MAX_WIND_SPEED_MPS: f64 = 100.0;
+const MAX_TURBULENCE_AMPLITUDE_MPS: f64 = 20.0;
+
+/// A horizontal wind in the aviation direction convention.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HorizontalWind {
+    /// Wind speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the wind comes from, clockwise from north.
+    pub direction_deg: f64,
+}
+
+/// One trapezoidal gust event.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GustEvent {
+    /// Event start in simulator nanoseconds from condition activation.
+    pub start_ns: u64,
+    /// Linear rise interval in simulator nanoseconds. Zero gives a step.
+    pub rise_ns: u64,
+    /// Full-amplitude interval in simulator nanoseconds.
+    pub hold_ns: u64,
+    /// Linear fall interval in simulator nanoseconds. Zero gives a step.
+    pub fall_ns: u64,
+    /// Gust speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the gust comes from.
+    pub direction_deg: f64,
+}
+
+/// A deterministic turbulence model.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum TurbulenceModel {
+    /// No turbulence component.
+    None,
+    /// Seeded, linearly interpolated horizontal noise.
+    BandLimitedNoise {
+        /// Maximum turbulence-vector magnitude in meters per second.
+        amplitude_mps: f64,
+        /// Interval between deterministic noise knots in simulator nanoseconds.
+        knot_interval_ns: u64,
+    },
+}
+
+/// Wind inputs for one condition set.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindCondition {
+    /// Constant base wind.
+    pub steady: HorizontalWind,
+    /// Ordered gust events.
+    pub gusts: Vec<GustEvent>,
+    /// Deterministic turbulence model.
+    pub turbulence: TurbulenceModel,
+}
+
+/// A versioned environmental condition artifact.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConditionSet {
+    /// Condition schema version.
+    pub schema_version: u16,
+    /// Stable condition-set name.
+    pub id: String,
+    /// Condition-set revision.
+    pub revision: u32,
+    /// Seed for all deterministic disturbance components.
+    pub seed: u64,
+    /// Wind and turbulence definition.
+    pub wind: WindCondition,
+}
+
+/// One resolved wind sample for a simulator backend.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppliedWind {
+    /// Resulting horizontal wind speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the resulting wind comes from.
+    pub direction_deg: f64,
+    /// North component of air motion in meters per second.
+    pub north_mps: f64,
+    /// East component of air motion in meters per second.
+    pub east_mps: f64,
+    /// Magnitude of the deterministic turbulence component.
+    pub turbulence_mps: f64,
+}
+
+impl ConditionSet {
+    /// Decode and validate a condition-set JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("condition set", bytes, MAX_MANIFEST_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validate the condition-set contract.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        schema(
+            "condition set",
+            self.schema_version,
+            CONDITION_SET_SCHEMA_VERSION,
+        )?;
+        text("condition_set.id", &self.id, MAX_TEXT_BYTES)?;
+        self.wind.validate()
+    }
+
+    /// Encode canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("condition set", self, MAX_MANIFEST_BYTES)
+    }
+
+    /// Calculate the canonical condition-set identity.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+
+    /// Resolve the wind request at one simulator-time offset.
+    #[must_use]
+    pub fn wind_at(&self, elapsed_ns: u64) -> AppliedWind {
+        let mut vector = WindVector::from(self.wind.steady);
+        for gust in &self.wind.gusts {
+            vector.add_scaled(
+                WindVector::from(HorizontalWind {
+                    speed_mps: gust.speed_mps,
+                    direction_deg: gust.direction_deg,
+                }),
+                gust.scale_at(elapsed_ns),
+            );
+        }
+        let turbulence = self.wind.turbulence.sample(self.seed, elapsed_ns);
+        vector.add_scaled(turbulence, 1.0);
+        vector.applied(turbulence.magnitude())
+    }
+}
+
+impl WindCondition {
+    fn validate(&self) -> Result<(), ValidationError> {
+        self.steady.validate("condition_set.wind.steady")?;
+        count(
+            "condition_set.wind.gusts",
+            self.gusts.len(),
+            MAX_GUST_EVENTS,
+        )?;
+        let mut maximum_speed = self.steady.speed_mps;
+        for (index, gust) in self.gusts.iter().enumerate() {
+            gust.validate(index)?;
+            maximum_speed += gust.speed_mps;
+        }
+        self.turbulence.validate()?;
+        maximum_speed += self.turbulence.amplitude_mps();
+        range(
+            "condition_set.wind.maximum_possible_speed_mps",
+            maximum_speed,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )
+    }
+}
+
+impl HorizontalWind {
+    fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        range(
+            &format!("{field}.speed_mps"),
+            self.speed_mps,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )?;
+        range(
+            &format!("{field}.direction_deg"),
+            self.direction_deg,
+            0.0,
+            360.0,
+        )
+    }
+}
+
+impl GustEvent {
+    fn validate(&self, index: usize) -> Result<(), ValidationError> {
+        let field = format!("condition_set.wind.gusts[{index}]");
+        range(
+            &format!("{field}.speed_mps"),
+            self.speed_mps,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )?;
+        range(
+            &format!("{field}.direction_deg"),
+            self.direction_deg,
+            0.0,
+            360.0,
+        )?;
+        if self.rise_ns == 0 && self.hold_ns == 0 && self.fall_ns == 0 {
+            return duration(&format!("{field}.duration"), 0);
+        }
+        Ok(())
+    }
+
+    fn scale_at(self, elapsed_ns: u64) -> f64 {
+        let Some(relative) = elapsed_ns.checked_sub(self.start_ns) else {
+            return 0.0;
+        };
+        let rise_end = self.rise_ns;
+        let hold_end = rise_end.saturating_add(self.hold_ns);
+        let fall_end = hold_end.saturating_add(self.fall_ns);
+        if relative < rise_end {
+            return relative as f64 / self.rise_ns as f64;
+        }
+        if relative < hold_end {
+            return 1.0;
+        }
+        if relative < fall_end && self.fall_ns > 0 {
+            return (fall_end - relative) as f64 / self.fall_ns as f64;
+        }
+        0.0
+    }
+}
+
+impl TurbulenceModel {
+    fn validate(self) -> Result<(), ValidationError> {
+        match self {
+            Self::None => Ok(()),
+            Self::BandLimitedNoise {
+                amplitude_mps,
+                knot_interval_ns,
+            } => {
+                range(
+                    "condition_set.wind.turbulence.amplitude_mps",
+                    amplitude_mps,
+                    0.0,
+                    MAX_TURBULENCE_AMPLITUDE_MPS,
+                )?;
+                duration(
+                    "condition_set.wind.turbulence.knot_interval_ns",
+                    knot_interval_ns,
+                )
+            }
+        }
+    }
+
+    const fn amplitude_mps(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::BandLimitedNoise { amplitude_mps, .. } => amplitude_mps,
+        }
+    }
+
+    fn sample(self, seed: u64, elapsed_ns: u64) -> WindVector {
+        match self {
+            Self::None => WindVector::default(),
+            Self::BandLimitedNoise {
+                amplitude_mps,
+                knot_interval_ns,
+            } => {
+                if knot_interval_ns == 0 || !amplitude_mps.is_finite() {
+                    return WindVector::default();
+                }
+                let knot = elapsed_ns / knot_interval_ns;
+                let fraction = (elapsed_ns % knot_interval_ns) as f64 / knot_interval_ns as f64;
+                noise_vector(seed, knot, amplitude_mps).interpolate(
+                    noise_vector(seed, knot.wrapping_add(1), amplitude_mps),
+                    fraction,
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct WindVector {
+    north: f64,
+    east: f64,
+}
+
+impl From<HorizontalWind> for WindVector {
+    fn from(wind: HorizontalWind) -> Self {
+        let radians = wind.direction_deg.to_radians();
+        Self {
+            north: -wind.speed_mps * radians.cos(),
+            east: -wind.speed_mps * radians.sin(),
+        }
+    }
+}
+
+impl WindVector {
+    fn add_scaled(&mut self, other: Self, scale: f64) {
+        self.north += other.north * scale;
+        self.east += other.east * scale;
+    }
+
+    fn interpolate(self, other: Self, fraction: f64) -> Self {
+        Self {
+            north: self.north + (other.north - self.north) * fraction,
+            east: self.east + (other.east - self.east) * fraction,
+        }
+    }
+
+    fn magnitude(self) -> f64 {
+        self.north.hypot(self.east)
+    }
+
+    fn applied(self, turbulence_mps: f64) -> AppliedWind {
+        let speed_mps = self.magnitude();
+        let direction_deg = if speed_mps <= f64::EPSILON {
+            0.0
+        } else {
+            (-self.east)
+                .atan2(-self.north)
+                .to_degrees()
+                .rem_euclid(360.0)
+        };
+        AppliedWind {
+            speed_mps,
+            direction_deg,
+            north_mps: self.north,
+            east_mps: self.east,
+            turbulence_mps,
+        }
+    }
+}
+
+fn noise_vector(seed: u64, knot: u64, amplitude: f64) -> WindVector {
+    let angle = unit_interval(splitmix64(seed ^ knot.wrapping_mul(0x9e37_79b9_7f4a_7c15))) * TAU;
+    let magnitude = unit_interval(splitmix64(
+        seed ^ knot.wrapping_mul(0xbf58_476d_1ce4_e5b9) ^ 1,
+    )) * amplitude;
+    WindVector {
+        north: magnitude * angle.cos(),
+        east: magnitude * angle.sin(),
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn unit_interval(value: u64) -> f64 {
+    (value >> 11) as f64 * (1.0 / ((1_u64 << 53) as f64))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-trial/src/condition/tests.rs
+++ b/crates/pilotage-trial/src/condition/tests.rs
@@ -26,6 +26,7 @@ fn condition(seed: u64) -> ConditionSet {
                 knot_interval_ns: 200_000_000,
             },
         },
+        timing: TimingCondition::nominal(),
     }
 }
 
@@ -66,6 +67,27 @@ fn a_run_seed_is_repeatable_and_separates_repetitions() {
 }
 
 #[test]
+fn timing_jitter_is_repeatable_and_separates_runs() {
+    let mut value = condition(42);
+    value.timing = TimingCondition {
+        estimate_delay_ns: 2_000_000,
+        update_jitter: DelayJitter::SampleAndHold {
+            maximum_delay_ns: 3_000_000,
+            interval_ns: 100_000_000,
+        },
+    };
+
+    let first = value.source_delay_ns_for_run(7, 250_000_000);
+    let repeated = value.source_delay_ns_for_run(7, 250_000_000);
+    let other_interval = value.source_delay_ns_for_run(7, 350_000_000);
+    let other_run = value.source_delay_ns_for_run(8, 250_000_000);
+
+    assert_eq!(first, repeated);
+    assert!((2_000_000..=5_000_000).contains(&first));
+    assert!(first != other_interval || first != other_run);
+}
+
+#[test]
 fn a_gust_uses_rise_hold_and_fall_intervals() {
     let mut value = condition(1);
     value.wind.turbulence = TurbulenceModel::None;
@@ -87,6 +109,16 @@ fn canonical_identity_changes_with_the_seed() {
 fn validation_rejects_unbounded_weather() {
     let mut value = condition(42);
     value.wind.gusts[0].speed_mps = 100.0;
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn validation_rejects_unbounded_timing_variations() {
+    let mut value = condition(42);
+    value.timing.estimate_delay_ns = 100_000_001;
     assert!(matches!(
         value.validate(),
         Err(ValidationError::OutOfRange { .. })

--- a/crates/pilotage-trial/src/condition/tests.rs
+++ b/crates/pilotage-trial/src/condition/tests.rs
@@ -1,0 +1,92 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+
+fn condition(seed: u64) -> ConditionSet {
+    ConditionSet {
+        schema_version: CONDITION_SET_SCHEMA_VERSION,
+        id: "crosswind-gust".to_owned(),
+        revision: 1,
+        seed,
+        wind: WindCondition {
+            steady: HorizontalWind {
+                speed_mps: 5.0,
+                direction_deg: 270.0,
+            },
+            gusts: vec![GustEvent {
+                start_ns: 1_000_000_000,
+                rise_ns: 1_000_000_000,
+                hold_ns: 1_000_000_000,
+                fall_ns: 1_000_000_000,
+                speed_mps: 3.0,
+                direction_deg: 270.0,
+            }],
+            turbulence: TurbulenceModel::BandLimitedNoise {
+                amplitude_mps: 0.5,
+                knot_interval_ns: 200_000_000,
+            },
+        },
+    }
+}
+
+#[test]
+fn the_same_seed_produces_the_same_schedule() {
+    let first = condition(42);
+    let second = condition(42);
+    let first_samples: Vec<_> = (0..100)
+        .map(|index| first.wind_at(index * 50_000_000))
+        .collect();
+    let second_samples: Vec<_> = (0..100)
+        .map(|index| second.wind_at(index * 50_000_000))
+        .collect();
+    assert_eq!(first_samples, second_samples);
+}
+
+#[test]
+fn a_different_seed_changes_the_turbulence_schedule() {
+    assert_ne!(
+        condition(42).wind_at(250_000_000),
+        condition(43).wind_at(250_000_000)
+    );
+}
+
+#[test]
+fn a_gust_uses_rise_hold_and_fall_intervals() {
+    let mut value = condition(1);
+    value.wind.turbulence = TurbulenceModel::None;
+    assert!((value.wind_at(0).speed_mps - 5.0).abs() < 1e-9);
+    assert!((value.wind_at(1_500_000_000).speed_mps - 6.5).abs() < 1e-9);
+    assert!((value.wind_at(2_500_000_000).speed_mps - 8.0).abs() < 1e-9);
+    assert!((value.wind_at(3_500_000_000).speed_mps - 6.5).abs() < 1e-9);
+    assert!((value.wind_at(4_000_000_000).speed_mps - 5.0).abs() < 1e-9);
+}
+
+#[test]
+fn canonical_identity_changes_with_the_seed() {
+    let first = condition(42).canonical_digest().expect("valid condition");
+    let second = condition(43).canonical_digest().expect("valid condition");
+    assert_ne!(first, second);
+}
+
+#[test]
+fn validation_rejects_unbounded_weather() {
+    let mut value = condition(42);
+    value.wind.gusts[0].speed_mps = 100.0;
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn strict_json_rejects_unknown_fields() {
+    let mut json = serde_json::to_value(condition(42)).expect("condition value");
+    json.as_object_mut()
+        .expect("condition object")
+        .insert("unknown".to_owned(), serde_json::Value::Bool(true));
+    let bytes = serde_json::to_vec(&json).expect("condition JSON");
+    assert!(matches!(
+        ConditionSet::from_json(&bytes),
+        Err(CodecError::Decode { .. })
+    ));
+}

--- a/crates/pilotage-trial/src/condition/tests.rs
+++ b/crates/pilotage-trial/src/condition/tests.rs
@@ -51,6 +51,21 @@ fn a_different_seed_changes_the_turbulence_schedule() {
 }
 
 #[test]
+fn a_run_seed_is_repeatable_and_separates_repetitions() {
+    let value = condition(42);
+    let first = value.wind_at_for_run(7, 250_000_000);
+    let repeated = value.wind_at_for_run(7, 250_000_000);
+    let other = value.wind_at_for_run(8, 250_000_000);
+
+    assert_eq!(first, repeated);
+    assert_ne!(first, other);
+    assert_eq!(
+        value.wind_at(250_000_000),
+        value.wind_at_for_run(0, 250_000_000)
+    );
+}
+
+#[test]
 fn a_gust_uses_rise_hold_and_fall_intervals() {
     let mut value = condition(1);
     value.wind.turbulence = TurbulenceModel::None;

--- a/crates/pilotage-trial/src/condition/timing.rs
+++ b/crates/pilotage-trial/src/condition/timing.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ValidationError, validation::duration};
+
+const MAX_SOURCE_DELAY_NS: u64 = 100_000_000;
+
+/// A deterministic update-jitter model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DelayJitter {
+    /// Do not add timing jitter.
+    None,
+    /// Hold one seeded extra delay for each fixed interval.
+    SampleAndHold {
+        /// Maximum additional delay in nanoseconds.
+        maximum_delay_ns: u64,
+        /// Interval between deterministic delay values in nanoseconds.
+        interval_ns: u64,
+    },
+}
+
+/// Source timing perturbation for one condition set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimingCondition {
+    /// Fixed estimate age in nanoseconds.
+    pub estimate_delay_ns: u64,
+    /// Seeded additional update delay.
+    pub update_jitter: DelayJitter,
+}
+
+impl TimingCondition {
+    /// Returns a condition with no source timing perturbation.
+    #[must_use]
+    pub const fn nominal() -> Self {
+        Self {
+            estimate_delay_ns: 0,
+            update_jitter: DelayJitter::None,
+        }
+    }
+
+    pub(super) fn validate(self) -> Result<(), ValidationError> {
+        let maximum = self
+            .estimate_delay_ns
+            .saturating_add(self.update_jitter.maximum_delay_ns());
+        if maximum > MAX_SOURCE_DELAY_NS {
+            return Err(ValidationError::OutOfRange {
+                field: "condition_set.timing.maximum_source_delay_ns".to_owned(),
+                actual: maximum as f64,
+                minimum: 0.0,
+                maximum: MAX_SOURCE_DELAY_NS as f64,
+            });
+        }
+        self.update_jitter.validate()
+    }
+
+    pub(super) fn delay_ns(self, condition_seed: u64, run_seed: u64, elapsed_ns: u64) -> u64 {
+        self.estimate_delay_ns.saturating_add(
+            self.update_jitter
+                .sample(condition_seed ^ run_seed.rotate_left(29), elapsed_ns),
+        )
+    }
+}
+
+impl DelayJitter {
+    const fn maximum_delay_ns(self) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::SampleAndHold {
+                maximum_delay_ns, ..
+            } => maximum_delay_ns,
+        }
+    }
+
+    fn validate(self) -> Result<(), ValidationError> {
+        match self {
+            Self::None => Ok(()),
+            Self::SampleAndHold {
+                maximum_delay_ns,
+                interval_ns,
+            } => {
+                duration(
+                    "condition_set.timing.update_jitter.maximum_delay_ns",
+                    maximum_delay_ns,
+                )?;
+                duration(
+                    "condition_set.timing.update_jitter.interval_ns",
+                    interval_ns,
+                )
+            }
+        }
+    }
+
+    fn sample(self, seed: u64, elapsed_ns: u64) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::SampleAndHold {
+                maximum_delay_ns,
+                interval_ns,
+            } => {
+                let interval = elapsed_ns / interval_ns;
+                splitmix64(seed ^ interval.wrapping_mul(0x9e37_79b9_7f4a_7c15))
+                    % maximum_delay_ns.saturating_add(1)
+            }
+        }
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -12,7 +12,8 @@ mod sample;
 mod validation;
 
 pub use condition::{
-    AppliedWind, ConditionSet, GustEvent, HorizontalWind, TurbulenceModel, WindCondition,
+    AppliedWind, ConditionSet, DelayJitter, GustEvent, HorizontalWind, TimingCondition,
+    TurbulenceModel, WindCondition,
 };
 pub use digest::Digest;
 pub use error::{CodecError, ValidationError};

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate contains data only. A runner supplies all input and output.
 
 mod canonical;
+mod condition;
 mod digest;
 mod error;
 mod identity;
@@ -10,16 +11,20 @@ mod limits;
 mod sample;
 mod validation;
 
+pub use condition::{
+    AppliedWind, ConditionSet, GustEvent, HorizontalWind, TurbulenceModel, WindCondition,
+};
 pub use digest::Digest;
 pub use error::{CodecError, ValidationError};
 pub use identity::{
     ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, RunIdentity, ScenarioIdentity,
 };
 pub use limits::{
-    BACKEND_CAPABILITIES_SCHEMA_VERSION, MAX_ACTUATOR_VALUES, MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS,
-    MAX_CONDITION_VALUES, MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES,
-    MAX_RAW_BUTTONS, MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS,
-    SCENARIO_SCHEMA_VERSION, TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
+    BACKEND_CAPABILITIES_SCHEMA_VERSION, CONDITION_SET_SCHEMA_VERSION, MAX_ACTUATOR_VALUES,
+    MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS, MAX_CONDITION_VALUES, MAX_GUST_EVENTS,
+    MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES, MAX_RAW_BUTTONS,
+    MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS, SCENARIO_SCHEMA_VERSION,
+    TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
 };
 pub use sample::{
     ActuatorState, AdapterDisposition, ConditionState, ControlAxes, ControlValue, HealthState,

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -8,6 +8,8 @@ pub const SCENARIO_SCHEMA_VERSION: u16 = 1;
 pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
 /// The supported trial sample schema version.
 pub const TRIAL_SAMPLE_SCHEMA_VERSION: u16 = 1;
+/// The supported environmental condition schema version.
+pub const CONDITION_SET_SCHEMA_VERSION: u16 = 1;
 
 /// The maximum trial manifest JSON size.
 pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
@@ -33,3 +35,5 @@ pub const MAX_RAW_BUTTONS: usize = 128;
 pub const MAX_ACTUATOR_VALUES: usize = 64;
 /// The maximum number of named condition values in one sample.
 pub const MAX_CONDITION_VALUES: usize = 64;
+/// The maximum number of gust events in one condition set.
+pub const MAX_GUST_EVENTS: usize = 64;

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -9,7 +9,7 @@ pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
 /// The supported trial sample schema version.
 pub const TRIAL_SAMPLE_SCHEMA_VERSION: u16 = 1;
 /// The supported environmental condition schema version.
-pub const CONDITION_SET_SCHEMA_VERSION: u16 = 1;
+pub const CONDITION_SET_SCHEMA_VERSION: u16 = 2;
 
 /// The maximum trial manifest JSON size.
 pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;

--- a/crates/pilotage-trial/src/validation.rs
+++ b/crates/pilotage-trial/src/validation.rs
@@ -115,3 +115,12 @@ pub(crate) fn range(
         maximum,
     })
 }
+
+pub(crate) fn duration(field: &str, value: u64) -> Result<(), ValidationError> {
+    if value > 0 {
+        return Ok(());
+    }
+    Err(ValidationError::ZeroDuration {
+        field: field.to_owned(),
+    })
+}

--- a/scripts/build-xplane-plugins.sh
+++ b/scripts/build-xplane-plugins.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Builds and installs the two X-Plane plugins the px4-xplane backend
+# Builds and installs the X-Plane plugins the px4-xplane backend
 # needs, plus the packaged QuadTailsitter aircraft:
 #
 #   1. px4xplane      - the MAVLink HIL bridge (external checkout,
@@ -8,6 +8,8 @@
 #                       (sim/xplane/autoflight)
 #   3. PilotageCamera  - this repository's vehicle camera export
 #                       (sim/xplane/camera)
+#   4. PilotageWeather - deterministic wind control and readback
+#                       (sim/xplane/weather)
 #
 # The install target is the X-Plane root: XPLANE_ROOT, else the first
 # entry of the official installer registry that holds X-Plane.app.
@@ -87,6 +89,26 @@ clang++ -std=c++17 -O2 -shared -fPIC \
   -undefined dynamic_lookup -framework OpenGL \
   -o "${CAMERA_BUILD}/mac.xpl"
 
+# --- Build PilotageWeather -----------------------------------------------
+echo "building PilotageWeather..."
+WEATHER_BUILD="${REPO_ROOT}/target/xplane-weather"
+WEATHER_SRC="${REPO_ROOT}/sim/xplane/weather"
+mkdir -p "${WEATHER_BUILD}"
+clang++ -std=c++17 -O2 -shared -fPIC \
+  -DAPL=1 -DIBM=0 -DLIN=0 -DXPLM200 -DXPLM210 -DXPLM300 -DXPLM301 -DXPLM303 \
+  -I "${PX4XPLANE_DIR}/lib/SDK/CHeaders/XPLM" -I "${WEATHER_SRC}" \
+  "${WEATHER_SRC}/PilotageWeather.cpp" \
+  "${WEATHER_SRC}/weather_state.cpp" \
+  -undefined dynamic_lookup \
+  -o "${WEATHER_BUILD}/mac.xpl"
+
+clang++ -std=c++17 -O2 -Wall -Wextra -Werror \
+  -I "${WEATHER_SRC}" \
+  "${WEATHER_SRC}/weather_state_tests.cpp" \
+  "${WEATHER_SRC}/weather_state.cpp" \
+  -o "${WEATHER_BUILD}/weather_state_tests"
+"${WEATHER_BUILD}/weather_state_tests"
+
 # --- Install -------------------------------------------------------------
 echo "installing plugins and aircraft..."
 PLUGINS="${XPLANE_ROOT}/Resources/plugins"
@@ -135,6 +157,9 @@ cp "${AUTOFLIGHT_BUILD}/mac.xpl" "${PLUGINS}/PilotageAutoFlight/64/mac.xpl"
 mkdir -p "${PLUGINS}/PilotageCamera/64"
 cp "${CAMERA_BUILD}/mac.xpl" "${PLUGINS}/PilotageCamera/64/mac.xpl"
 
+mkdir -p "${PLUGINS}/PilotageWeather/64"
+cp "${WEATHER_BUILD}/mac.xpl" "${PLUGINS}/PilotageWeather/64/mac.xpl"
+
 mkdir -p "${XPLANE_ROOT}/Aircraft/Extra Aircraft"
 rm -rf "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter"
 cp -R "${PX4XPLANE_DIR}/aircraft/QuadTailsitter" "${XPLANE_ROOT}/Aircraft/Extra Aircraft/"
@@ -147,4 +172,4 @@ if [[ -d "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter/Airfoil" ]]; the
     "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter/airfoils/"
 fi
 
-echo "done: px4xplane + PilotageAutoFlight + PilotageCamera + QuadTailsitter installed"
+echo "done: px4xplane + PilotageAutoFlight + PilotageCamera + PilotageWeather + QuadTailsitter installed"

--- a/scripts/monotonic-counter-compound-addition-allowlist.tsv
+++ b/scripts/monotonic-counter-compound-addition-allowlist.tsv
@@ -20,3 +20,7 @@ crates/pilotage-svs-build/src/payload/decode.rs	off += 34;
 crates/pilotage-svs-db/src/feature.rs	i += 1;
 crates/pilotage-svs-db/src/merkle.rs	i += 2;
 crates/pilotage-timing/src/latency.rs	self.len += 1;
+crates/pilotage-trial/src/condition.rs	maximum_speed += gust.speed_mps;
+crates/pilotage-trial/src/condition.rs	maximum_speed += self.turbulence.amplitude_mps();
+crates/pilotage-trial/src/condition.rs	self.east += other.east * scale;
+crates/pilotage-trial/src/condition.rs	self.north += other.north * scale;

--- a/sim/xplane/weather/PilotageWeather.cpp
+++ b/sim/xplane/weather/PilotageWeather.cpp
@@ -1,0 +1,179 @@
+// Deterministic weather control for Pilotage simulation trials.
+
+#include "XPLMDataAccess.h"
+#include "XPLMPlugin.h"
+#include "XPLMProcessing.h"
+
+#include "weather_state.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <string>
+
+namespace {
+
+using pilotage::weather::IsValidRequest;
+using pilotage::weather::RequestStatus;
+using pilotage::weather::WeatherRequest;
+
+constexpr int kMaximumWindLayers = 13;
+
+WeatherRequest requested;
+float applied_generation = -1.0F;
+float status = static_cast<float>(RequestStatus::Idle);
+float actual_speed_mps = 0.0F;
+float actual_direction_deg = 0.0F;
+bool loop_registered = false;
+
+std::array<XPLMDataRef, 8> custom_refs{};
+XPLMDataRef update_immediately_ref = nullptr;
+XPLMDataRef change_mode_ref = nullptr;
+XPLMDataRef variability_ref = nullptr;
+XPLMDataRef wind_speed_ref = nullptr;
+XPLMDataRef wind_direction_ref = nullptr;
+XPLMDataRef turbulence_ref = nullptr;
+XPLMDataRef actual_speed_ref = nullptr;
+XPLMDataRef actual_direction_ref = nullptr;
+
+float ReadFloat(void* refcon) {
+    return *static_cast<float*>(refcon);
+}
+
+void WriteFloat(void* refcon, float value) {
+    *static_cast<float*>(refcon) = value;
+}
+
+XPLMDataRef RegisterFloat(const char* name, bool writable, float* value) {
+    return XPLMRegisterDataAccessor(
+        name, xplmType_Float, writable ? 1 : 0, nullptr, nullptr, ReadFloat,
+        writable ? WriteFloat : nullptr, nullptr, nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr, nullptr, value, value);
+}
+
+void RegisterCustomDatarefs() {
+    custom_refs[0] = RegisterFloat("pilotage/weather/wind_speed_mps", true,
+                                   &requested.wind_speed_mps);
+    custom_refs[1] = RegisterFloat("pilotage/weather/wind_direction_deg", true,
+                                   &requested.wind_direction_deg);
+    custom_refs[2] = RegisterFloat("pilotage/weather/turbulence", true,
+                                   &requested.turbulence);
+    custom_refs[3] = RegisterFloat("pilotage/weather/apply_generation", true,
+                                   &requested.generation);
+    custom_refs[4] = RegisterFloat("pilotage/weather/applied_generation", false,
+                                   &applied_generation);
+    custom_refs[5] =
+        RegisterFloat("pilotage/weather/status", false, &status);
+    custom_refs[6] = RegisterFloat("pilotage/weather/actual_speed_mps", false,
+                                   &actual_speed_mps);
+    custom_refs[7] = RegisterFloat("pilotage/weather/actual_direction_deg", false,
+                                   &actual_direction_deg);
+}
+
+void BindSimulatorDatarefs() {
+    update_immediately_ref =
+        XPLMFindDataRef("sim/weather/region/update_immediately");
+    change_mode_ref = XPLMFindDataRef("sim/weather/region/change_mode");
+    variability_ref = XPLMFindDataRef("sim/weather/region/variability_pct");
+    wind_speed_ref = XPLMFindDataRef("sim/weather/region/wind_speed_msc");
+    wind_direction_ref =
+        XPLMFindDataRef("sim/weather/region/wind_direction_degt");
+    turbulence_ref = XPLMFindDataRef("sim/weather/region/turbulence");
+    actual_speed_ref =
+        XPLMFindDataRef("sim/weather/aircraft/wind_now_speed_msc");
+    actual_direction_ref =
+        XPLMFindDataRef("sim/weather/aircraft/wind_now_direction_degt");
+}
+
+bool RequiredDatarefsExist() {
+    return update_immediately_ref != nullptr && change_mode_ref != nullptr &&
+           variability_ref != nullptr && wind_speed_ref != nullptr &&
+           wind_direction_ref != nullptr && turbulence_ref != nullptr;
+}
+
+void ApplyRequest() {
+    if (!IsValidRequest(requested)) {
+        status = static_cast<float>(RequestStatus::Invalid);
+        return;
+    }
+    if (!RequiredDatarefsExist()) {
+        status = static_cast<float>(RequestStatus::DatarefMissing);
+        return;
+    }
+    const int layer_count = std::min(
+        {kMaximumWindLayers, XPLMGetDatavf(wind_speed_ref, nullptr, 0, 0),
+         XPLMGetDatavf(wind_direction_ref, nullptr, 0, 0),
+         XPLMGetDatavf(turbulence_ref, nullptr, 0, 0)});
+    if (layer_count <= 0) {
+        status = static_cast<float>(RequestStatus::DatarefMissing);
+        return;
+    }
+    std::array<float, kMaximumWindLayers> speed{};
+    std::array<float, kMaximumWindLayers> direction{};
+    std::array<float, kMaximumWindLayers> turbulence{};
+    speed.fill(requested.wind_speed_mps);
+    direction.fill(requested.wind_direction_deg);
+    turbulence.fill(requested.turbulence);
+
+    XPLMSetDatai(change_mode_ref, 3);
+    XPLMSetDataf(variability_ref, 0.0F);
+    XPLMSetDatai(update_immediately_ref, 1);
+    XPLMSetDatavf(wind_speed_ref, speed.data(), 0, layer_count);
+    XPLMSetDatavf(wind_direction_ref, direction.data(), 0, layer_count);
+    XPLMSetDatavf(turbulence_ref, turbulence.data(), 0, layer_count);
+    applied_generation = requested.generation;
+    status = static_cast<float>(RequestStatus::Applied);
+}
+
+float FlightLoop(float, float, int, void*) {
+    if (requested.generation != applied_generation) {
+        ApplyRequest();
+    }
+    if (actual_speed_ref != nullptr) {
+        actual_speed_mps = XPLMGetDataf(actual_speed_ref);
+    }
+    if (actual_direction_ref != nullptr) {
+        actual_direction_deg = XPLMGetDataf(actual_direction_ref);
+    }
+    return -1.0F;
+}
+
+}  // namespace
+
+PLUGIN_API int XPluginStart(char* out_name, char* out_sig, char* out_desc) {
+    std::strcpy(out_name, "PilotageWeather");
+    std::strcpy(out_sig, "systems.sokoly.pilotage.weather");
+    std::strcpy(out_desc, "Deterministic weather control for Pilotage trials");
+    RegisterCustomDatarefs();
+    return 1;
+}
+
+PLUGIN_API void XPluginStop(void) {
+    if (loop_registered) {
+        XPLMUnregisterFlightLoopCallback(FlightLoop, nullptr);
+        loop_registered = false;
+    }
+    for (XPLMDataRef ref : custom_refs) {
+        if (ref != nullptr) {
+            XPLMUnregisterDataAccessor(ref);
+        }
+    }
+}
+
+PLUGIN_API int XPluginEnable(void) {
+    BindSimulatorDatarefs();
+    if (!loop_registered) {
+        XPLMRegisterFlightLoopCallback(FlightLoop, -1.0F, nullptr);
+        loop_registered = true;
+    }
+    return 1;
+}
+
+PLUGIN_API void XPluginDisable(void) {
+    if (loop_registered) {
+        XPLMUnregisterFlightLoopCallback(FlightLoop, nullptr);
+        loop_registered = false;
+    }
+}
+
+PLUGIN_API void XPluginReceiveMessage(XPLMPluginID, int, void*) {}

--- a/sim/xplane/weather/weather_state.cpp
+++ b/sim/xplane/weather/weather_state.cpp
@@ -1,0 +1,21 @@
+#include "weather_state.h"
+
+#include <cmath>
+
+namespace pilotage::weather {
+
+bool IsValidRequest(const WeatherRequest& request) {
+    return std::isfinite(request.wind_speed_mps) &&
+           request.wind_speed_mps >= 0.0F &&
+           request.wind_speed_mps <= kMaximumWindSpeedMps &&
+           std::isfinite(request.wind_direction_deg) &&
+           request.wind_direction_deg >= 0.0F &&
+           request.wind_direction_deg <= 360.0F &&
+           std::isfinite(request.turbulence) && request.turbulence >= 0.0F &&
+           request.turbulence <= kMaximumTurbulence &&
+           std::isfinite(request.generation) && request.generation >= 0.0F &&
+           request.generation <= kMaximumGeneration &&
+           std::floor(request.generation) == request.generation;
+}
+
+}  // namespace pilotage::weather

--- a/sim/xplane/weather/weather_state.h
+++ b/sim/xplane/weather/weather_state.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace pilotage::weather {
+
+constexpr float kMaximumWindSpeedMps = 50.0F;
+constexpr float kMaximumTurbulence = 10.0F;
+constexpr float kMaximumGeneration = 16777215.0F;
+
+struct WeatherRequest {
+    float wind_speed_mps = 0.0F;
+    float wind_direction_deg = 0.0F;
+    float turbulence = 0.0F;
+    float generation = 0.0F;
+};
+
+enum class RequestStatus {
+    Idle = 0,
+    Applied = 1,
+    Invalid = -1,
+    DatarefMissing = -2,
+};
+
+bool IsValidRequest(const WeatherRequest& request);
+
+}  // namespace pilotage::weather

--- a/sim/xplane/weather/weather_state_tests.cpp
+++ b/sim/xplane/weather/weather_state_tests.cpp
@@ -1,0 +1,20 @@
+#include "weather_state.h"
+
+#include <cassert>
+#include <limits>
+
+using pilotage::weather::IsValidRequest;
+using pilotage::weather::WeatherRequest;
+
+int main() {
+    assert(IsValidRequest(WeatherRequest{5.0F, 270.0F, 0.2F, 1.0F}));
+    assert(IsValidRequest(WeatherRequest{0.0F, 360.0F, 0.0F, 0.0F}));
+    assert(!IsValidRequest(WeatherRequest{-1.0F, 0.0F, 0.0F, 1.0F}));
+    assert(!IsValidRequest(WeatherRequest{51.0F, 0.0F, 0.0F, 1.0F}));
+    assert(!IsValidRequest(WeatherRequest{1.0F, 361.0F, 0.0F, 1.0F}));
+    assert(!IsValidRequest(WeatherRequest{1.0F, 0.0F, 11.0F, 1.0F}));
+    assert(!IsValidRequest(WeatherRequest{1.0F, 0.0F, 0.0F, 1.5F}));
+    assert(!IsValidRequest(WeatherRequest{
+        std::numeric_limits<float>::quiet_NaN(), 0.0F, 0.0F, 1.0F}));
+    return 0;
+}

--- a/tools/xtask/src/backend/px4_xplane/tests.rs
+++ b/tools/xtask/src/backend/px4_xplane/tests.rs
@@ -120,12 +120,24 @@ fn install_validation_hints_at_the_build_script() {
         }
         other => panic!("expected a missing-plugin refusal, got {other:?}"),
     }
-    // With every plugin present, the missing aircraft is the next hint.
     for plugin in ["px4xplane", "PilotageAutoFlight", "PilotageCamera"] {
         let dir = root.join(format!("Resources/plugins/{plugin}/64"));
         std::fs::create_dir_all(&dir).expect("plugin dir");
         std::fs::write(dir.join("mac.xpl"), b"stub").expect("plugin stub");
     }
+    let refusal = validate_xplane_install(&root, qtailsitter());
+    match refusal {
+        Err(XtaskError::MissingArtifact { what, hint, .. }) => {
+            assert_eq!(what, "Pilotage X-Plane weather plugin");
+            assert!(hint.contains("build-xplane-plugins"));
+        }
+        other => panic!("expected a missing-weather-plugin refusal, got {other:?}"),
+    }
+    let weather = root.join("Resources/plugins/PilotageWeather/64");
+    std::fs::create_dir_all(&weather).expect("weather plugin dir");
+    std::fs::write(weather.join("mac.xpl"), b"stub").expect("weather plugin stub");
+
+    // With every plugin present, the missing aircraft is the next hint.
     let refusal = validate_xplane_install(&root, qtailsitter());
     match refusal {
         Err(XtaskError::MissingArtifact { what, path, .. }) => {

--- a/tools/xtask/src/backend/xplane_simulator.rs
+++ b/tools/xtask/src/backend/xplane_simulator.rs
@@ -139,6 +139,14 @@ pub(super) fn validate_xplane_install(root: &Path, airframe: &Airframe) -> Resul
             hint: "run scripts/build-xplane-plugins.sh",
         });
     }
+    let weather = root.join("Resources/plugins/PilotageWeather/64/mac.xpl");
+    if !weather.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "Pilotage X-Plane weather plugin",
+            path: weather,
+            hint: "run scripts/build-xplane-plugins.sh",
+        });
+    }
     let aircraft = root.join(airframe.acf_path);
     if !aircraft.is_file() {
         return Err(XtaskError::MissingArtifact {
@@ -155,21 +163,27 @@ pub(super) fn validate_xplane_install(root: &Path, airframe: &Airframe) -> Resul
 const XPLANE_PLUGINS_STAMP: &str = "target/xtask-stamps/xplane-plugins.stamp";
 
 /// The working-tree inputs whose content decides plugin staleness.
-const XPLANE_PLUGINS_SOURCES: [&str; 3] = [
+const XPLANE_PLUGINS_SOURCES: [&str; 4] = [
     "sim/xplane/autoflight",
     "sim/xplane/camera",
+    "sim/xplane/weather",
     "scripts/build-xplane-plugins.sh",
 ];
 
-/// Best-effort, content-stamped build + install of the two X-Plane
-/// plugins and the packaged aircraft. Non-fatal by contract: `plan`
-/// fails closed with hints when a required artifact is still absent.
+/// Build and install the required X-Plane plugins when an input changes.
+/// The caller checks all required artifacts before it starts a session.
 pub(super) fn ensure_xplane_plugins(repo_root: &Path) {
     use crate::session::preflight::stamp;
     let installed = xplane_root()
         .map(|root| {
-            root.join("Resources/plugins/PilotageAutoFlight/64/mac.xpl")
-                .is_file()
+            [
+                "Resources/plugins/px4xplane/64/mac.xpl",
+                "Resources/plugins/PilotageAutoFlight/64/mac.xpl",
+                "Resources/plugins/PilotageCamera/64/mac.xpl",
+                "Resources/plugins/PilotageWeather/64/mac.xpl",
+            ]
+            .iter()
+            .all(|path| root.join(path).is_file())
         })
         .unwrap_or(false);
     let current = stamp::source_stamp(repo_root, &XPLANE_PLUGINS_SOURCES, &[]);


### PR DESCRIPTION
## Summary

- Define deterministic wind conditions and start rules.
- Connect reviewed conditions to X-Plane weather control.
- Bind phase timing and repetitions to the trial identity.
- Add simulator plugin and contract tests.

Closes #448.

## Review status

The base contract is under repair in #500. This PR is draft until its rebased exact head passes static review and the full local CI.

## Verification

Final exact-head verification is pending.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #503 👈
- <kbd>&nbsp;3&nbsp;</kbd> #502
- <kbd>&nbsp;2&nbsp;</kbd> #501
- <kbd>&nbsp;1&nbsp;</kbd> #500
<!-- GitButler Footer Boundary Bottom -->
