### PR TITLE
Define bounded causal trial contracts (#504)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,16 @@ name = "pilotage-timing"
 version = "0.1.0"
 
 [[package]]
+name = "pilotage-trial"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/pilotage-client-session",
     "crates/pilotage-instrument-feed",
     "crates/pilotage-presentation",
+    "crates/pilotage-trial",
     "adapters/reference-headless",
     "adapters/aviate",
     "adapters/px4",
@@ -84,7 +85,7 @@ aerocontext-navdata = { version = "0.4.5", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.18", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde_json = { version = "1.0.150", features = ["float_roundtrip"] }
 png = "0.18.1"
 rusqlite = { version = "0.40.2", default-features = false, features = ["bundled", "serialize"] }
 prost = "0.14.4"
@@ -128,6 +129,7 @@ pilotage-session = { path = "crates/pilotage-session" }
 pilotage-mission = { path = "crates/pilotage-mission" }
 pilotage-instrument-runtime = { path = "crates/pilotage-instrument-runtime" }
 pilotage-presentation = { path = "crates/pilotage-presentation" }
+pilotage-trial = { path = "crates/pilotage-trial" }
 pilotage-terrain-query = { path = "crates/pilotage-terrain-query" }
 
 [workspace.lints.rust]

--- a/crates/pilotage-trial/Cargo.toml
+++ b/crates/pilotage-trial/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pilotage-trial"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/pilotage-trial/src/canonical.rs
+++ b/crates/pilotage-trial/src/canonical.rs
@@ -1,0 +1,43 @@
+//! Canonical JSON and digest operations.
+
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use crate::{CodecError, Digest};
+
+pub(crate) fn decode<T: DeserializeOwned>(
+    document: &'static str,
+    bytes: &[u8],
+    limit: usize,
+) -> Result<T, CodecError> {
+    check_size(document, bytes.len(), limit)?;
+    serde_json::from_slice(bytes).map_err(|source| CodecError::Decode { document, source })
+}
+
+pub(crate) fn encode<T: Serialize>(
+    document: &'static str,
+    value: &T,
+    limit: usize,
+) -> Result<Vec<u8>, CodecError> {
+    let bytes =
+        serde_json::to_vec(value).map_err(|source| CodecError::Encode { document, source })?;
+    check_size(document, bytes.len(), limit)?;
+    Ok(bytes)
+}
+
+pub(crate) fn digest(bytes: &[u8]) -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+fn check_size(document: &'static str, size: usize, limit: usize) -> Result<(), CodecError> {
+    if size <= limit {
+        return Ok(());
+    }
+    Err(CodecError::DocumentTooLarge {
+        document,
+        size,
+        limit,
+    })
+}

--- a/crates/pilotage-trial/src/causal_api.rs
+++ b/crates/pilotage-trial/src/causal_api.rs
@@ -1,0 +1,11 @@
+//! Public causal trial contract exports.
+
+pub use crate::identity::RecorderTimeInterval;
+pub use crate::limits::{
+    MAX_CONTROL_EVENT_HISTORY, MAX_RUN_IDENTITY_BYTES, QUATERNION_NORM_TOLERANCE,
+    RUN_IDENTITY_SCHEMA_VERSION,
+};
+pub use crate::sample::{
+    CausalStage, ClockReading, ControlEventId, ControlStage, SimulatorTruthEvidence, SourceStamp,
+    StageProducerRole, StageStamp, TrialStreamValidator,
+};

--- a/crates/pilotage-trial/src/digest.rs
+++ b/crates/pilotage-trial/src/digest.rs
@@ -1,0 +1,82 @@
+//! A fixed SHA-256 digest value.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+const DIGEST_BYTES: usize = 32;
+const DIGEST_HEX_BYTES: usize = DIGEST_BYTES * 2;
+
+/// A SHA-256 digest.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Digest([u8; DIGEST_BYTES]);
+
+impl Digest {
+    /// Creates a digest from its bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; DIGEST_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    /// Gets the digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; DIGEST_BYTES] {
+        &self.0
+    }
+
+    /// Reports if all digest bytes are zero.
+    #[must_use]
+    pub fn is_zero(self) -> bool {
+        self.0.iter().all(|byte| *byte == 0)
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        decode_hex(&value).map_err(de::Error::custom)
+    }
+}
+
+fn decode_hex(value: &str) -> Result<Digest, &'static str> {
+    if value.len() != DIGEST_HEX_BYTES {
+        return Err("a digest must contain 64 hexadecimal characters");
+    }
+    let mut output = [0_u8; DIGEST_BYTES];
+    for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+        let high = decode_nibble(pair[0])?;
+        let low = decode_nibble(pair[1])?;
+        output[index] = (high << 4) | low;
+    }
+    Ok(Digest(output))
+}
+
+fn decode_nibble(value: u8) -> Result<u8, &'static str> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => Err("a digest contains a non-hexadecimal character"),
+    }
+}

--- a/crates/pilotage-trial/src/error.rs
+++ b/crates/pilotage-trial/src/error.rs
@@ -1,0 +1,275 @@
+//! Errors for trial contract processing.
+
+use thiserror::Error;
+
+/// An error in the content of a trial document.
+#[derive(Debug, Error, PartialEq)]
+pub enum ValidationError {
+    /// A document uses an unsupported schema version.
+    #[error("{document} schema version {actual} is not supported; expected {expected}")]
+    UnsupportedSchemaVersion {
+        /// The document name.
+        document: &'static str,
+        /// The supplied version.
+        actual: u16,
+        /// The supported version.
+        expected: u16,
+    },
+    /// A required text value is empty.
+    #[error("{field} must not be empty")]
+    EmptyText {
+        /// The field path.
+        field: String,
+    },
+    /// A text value is too long.
+    #[error("{field} has {size} bytes; the limit is {limit}")]
+    TextTooLong {
+        /// The field path.
+        field: String,
+        /// The supplied byte count.
+        size: usize,
+        /// The maximum byte count.
+        limit: usize,
+    },
+    /// A required digest contains only zero bytes.
+    #[error("{field} must not be a zero digest")]
+    ZeroDigest {
+        /// The field path.
+        field: String,
+    },
+    /// A required list is empty.
+    #[error("{field} must contain an item")]
+    EmptyList {
+        /// The field path.
+        field: String,
+    },
+    /// A list has too many items.
+    #[error("{field} has {count} items; the limit is {limit}")]
+    TooManyItems {
+        /// The field path.
+        field: String,
+        /// The supplied item count.
+        count: usize,
+        /// The maximum item count.
+        limit: usize,
+    },
+    /// A list contains a duplicate item.
+    #[error("{field} contains a duplicate item at index {index}")]
+    DuplicateItem {
+        /// The field path.
+        field: String,
+        /// The index of the second item.
+        index: usize,
+    },
+    /// A number is not finite.
+    #[error("{field} must be finite")]
+    NonFinite {
+        /// The field path.
+        field: String,
+    },
+    /// A number is outside its permitted range.
+    #[error("{field} value {actual} is outside {minimum} through {maximum}")]
+    OutOfRange {
+        /// The field path.
+        field: String,
+        /// The supplied value.
+        actual: f64,
+        /// The minimum value.
+        minimum: f64,
+        /// The maximum value.
+        maximum: f64,
+    },
+    /// A duration is zero.
+    #[error("{field} must be greater than zero")]
+    ZeroDuration {
+        /// The field path.
+        field: String,
+    },
+    /// A relation between identity fields is invalid.
+    #[error("identity mismatch for {field}")]
+    IdentityMismatch {
+        /// The field path.
+        field: String,
+    },
+    /// A clock mapping is invalid.
+    #[error("clock mapping {index} is invalid: {reason}")]
+    InvalidClockMapping {
+        /// The mapping index.
+        index: usize,
+        /// The cause of the error.
+        reason: &'static str,
+    },
+    /// A stage source has no mapping for its clock epoch.
+    #[error("{field} has no mapping for {clock} epoch {epoch}")]
+    MissingClockMapping {
+        /// The field path.
+        field: String,
+        /// The clock domain name.
+        clock: String,
+        /// The source clock epoch.
+        epoch: u64,
+    },
+    /// A present stage value uses an unusable clock mapping.
+    #[error("{field} uses an unusable mapping for {clock} epoch {epoch}")]
+    UnusableClockMapping {
+        /// The field path.
+        field: String,
+        /// The clock domain name.
+        clock: String,
+        /// The source clock epoch.
+        epoch: u64,
+    },
+    /// A stage source time is outside the mapping validity interval.
+    #[error("{field} time {time_ns} ns is outside the mapping for {clock} epoch {epoch}")]
+    ClockTimeOutsideMapping {
+        /// The field path.
+        field: String,
+        /// The clock domain name.
+        clock: String,
+        /// The source clock epoch.
+        epoch: u64,
+        /// The source time.
+        time_ns: u64,
+    },
+    /// A clock observation is not internally consistent.
+    #[error("{field} has an invalid clock observation: {reason}")]
+    InvalidClockObservation {
+        /// The field path.
+        field: String,
+        /// The cause of the error.
+        reason: &'static str,
+    },
+    /// A causal stage stamp is not internally consistent.
+    #[error("{field} has an invalid stage stamp: {reason}")]
+    InvalidStageStamp {
+        /// The field path.
+        field: String,
+        /// The cause of the error.
+        reason: &'static str,
+    },
+    /// A derived control event references an event that is not in the trace.
+    #[error("{field} references unknown {stage} event {clock} epoch {epoch} sequence {sequence}")]
+    UnknownControlPredecessor {
+        /// The derived stage field path.
+        field: String,
+        /// The predecessor stage name.
+        stage: String,
+        /// The predecessor clock domain name.
+        clock: String,
+        /// The predecessor clock epoch.
+        epoch: u64,
+        /// The predecessor event sequence number.
+        sequence: u64,
+    },
+    /// A mapped control event occurs definitely before its predecessor.
+    #[error(
+        "{field} mapped latest time {current_latest_ns} ns is before predecessor earliest time {predecessor_earliest_ns} ns"
+    )]
+    CausalMappedSourceOrder {
+        /// The derived stage field path.
+        field: String,
+        /// The predecessor earliest mapped time.
+        predecessor_earliest_ns: u64,
+        /// The derived event latest mapped time.
+        current_latest_ns: u64,
+    },
+    /// An attitude quaternion is not a unit quaternion.
+    #[error("{field} norm {norm} differs from one by more than {tolerance}")]
+    InvalidQuaternionNorm {
+        /// The field path.
+        field: String,
+        /// The supplied quaternion norm.
+        norm: f64,
+        /// The permitted difference from one.
+        tolerance: f64,
+    },
+    /// A phase needs a capability that the backend does not supply.
+    #[error("phase {phase} needs unsupported capability {capability}")]
+    UnsupportedCapability {
+        /// The phase identifier.
+        phase: String,
+        /// The capability name.
+        capability: String,
+    },
+    /// A sample uses a phase index that is outside the scenario.
+    #[error("sample phase index {index} is outside {phase_count} phases")]
+    PhaseOutOfRange {
+        /// The supplied phase index.
+        index: u16,
+        /// The scenario phase count.
+        phase_count: usize,
+    },
+    /// Two adjacent samples have different run digests.
+    #[error("adjacent samples have different run digests")]
+    MixedRun,
+    /// A sample sequence number is not after the prior number.
+    #[error("sample sequence {current} does not follow {previous}")]
+    SequenceOrder {
+        /// The prior sequence number.
+        previous: u64,
+        /// The current sequence number.
+        current: u64,
+    },
+    /// A sample gap does not agree with its gap count.
+    #[error("sample sequence {actual} does not match expected sequence {expected}")]
+    SequenceGap {
+        /// The sequence number that includes the declared gap.
+        expected: u64,
+        /// The supplied sequence number.
+        actual: u64,
+    },
+    /// A sample returns to an earlier phase.
+    #[error("sample phase {current} is before prior phase {previous}")]
+    PhaseOrder {
+        /// The prior phase index.
+        previous: u16,
+        /// The current phase index.
+        current: u16,
+    },
+    /// A clock moves back without a discontinuity record.
+    #[error("{clock} clock moved from {previous_ns} ns to {current_ns} ns")]
+    ClockRegression {
+        /// The clock domain name.
+        clock: String,
+        /// The prior time.
+        previous_ns: u64,
+        /// The current time.
+        current_ns: u64,
+    },
+}
+
+/// An error during trial JSON processing.
+#[derive(Debug, Error)]
+pub enum CodecError {
+    /// A JSON document exceeds its fixed size limit.
+    #[error("{document} has {size} bytes; the limit is {limit}")]
+    DocumentTooLarge {
+        /// The document name.
+        document: &'static str,
+        /// The supplied byte count.
+        size: usize,
+        /// The maximum byte count.
+        limit: usize,
+    },
+    /// JSON decoding failed.
+    #[error("cannot decode {document} JSON")]
+    Decode {
+        /// The document name.
+        document: &'static str,
+        /// The JSON error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// JSON encoding failed.
+    #[error("cannot encode {document} JSON")]
+    Encode {
+        /// The document name.
+        document: &'static str,
+        /// The JSON error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// Content validation failed.
+    #[error(transparent)]
+    Validation(#[from] ValidationError),
+}

--- a/crates/pilotage-trial/src/identity.rs
+++ b/crates/pilotage-trial/src/identity.rs
@@ -1,0 +1,479 @@
+//! Immutable identity data for one trial run.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CodecError, Digest, MAX_CLOCK_MAPPINGS, MAX_RUN_IDENTITY_BYTES, MAX_TEXT_BYTES,
+    RUN_IDENTITY_SCHEMA_VERSION, ValidationError, canonical,
+    validation::{count, digest, schema, text},
+};
+
+/// The identity of one immutable artifact.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactIdentity {
+    /// The stable artifact identifier.
+    pub id: String,
+    /// The artifact revision.
+    pub revision: String,
+    /// The artifact content digest.
+    pub digest: Digest,
+}
+
+impl ArtifactIdentity {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        text(&format!("{field}.id"), &self.id, MAX_TEXT_BYTES)?;
+        text(&format!("{field}.revision"), &self.revision, MAX_TEXT_BYTES)?;
+        digest(&format!("{field}.digest"), self.digest)
+    }
+}
+
+/// The identity of one scenario revision.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScenarioIdentity {
+    /// The stable scenario identifier.
+    pub id: String,
+    /// The scenario revision number.
+    pub revision: u32,
+    /// The digest of the canonical scenario JSON.
+    pub digest: Digest,
+}
+
+impl ScenarioIdentity {
+    pub(crate) fn validate(&self) -> Result<(), ValidationError> {
+        text("run.scenario.id", &self.id, MAX_TEXT_BYTES)?;
+        digest("run.scenario.digest", self.digest)
+    }
+}
+
+/// A clock domain in a trial trace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClockDomain {
+    /// The input device clock.
+    Device,
+    /// The control client clock.
+    Client,
+    /// The recorder host clock.
+    Recorder,
+    /// The adapter clock.
+    Adapter,
+    /// The flight controller clock.
+    FlightController,
+    /// The simulator clock.
+    Simulator,
+}
+
+/// The quality of one clock mapping.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClockMappingQuality {
+    /// The source supplies an exact mapping.
+    Exact,
+    /// Measurement supplies an estimated mapping.
+    Estimated,
+    /// The mapping is not usable for timing analysis.
+    Unusable,
+}
+
+/// A mapping from one source clock epoch to the recorder clock.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClockMapping {
+    /// The source clock.
+    pub from: ClockDomain,
+    /// The target clock. This value must be [`ClockDomain::Recorder`].
+    pub to: ClockDomain,
+    /// The source clock epoch.
+    pub source_epoch: u64,
+    /// The source time at the mapping anchor.
+    pub source_anchor_ns: u64,
+    /// The recorder time at the mapping anchor.
+    pub recorder_anchor_ns: u64,
+    /// The identity-bearing recorder-rate numerator for one source-clock unit.
+    pub rate_numerator: u64,
+    /// The identity-bearing recorder-rate denominator for one source-clock unit.
+    pub rate_denominator: u64,
+    /// The first source time for which this mapping is valid.
+    pub valid_from_source_ns: u64,
+    /// The last source time for which this mapping is valid.
+    pub valid_until_source_ns: u64,
+    /// The maximum mapping uncertainty.
+    pub uncertainty_ns: u64,
+    /// The mapping quality.
+    pub quality: ClockMappingQuality,
+}
+
+/// The bounded recorder time for one mapped source time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RecorderTimeInterval {
+    /// The first possible recorder time.
+    pub earliest_ns: u64,
+    /// The last possible recorder time.
+    pub latest_ns: u64,
+}
+
+impl ClockMapping {
+    /// Maps a valid source time to a checked recorder time interval.
+    ///
+    /// The interval contains both adjacent integer nanoseconds when the rate
+    /// produces a fractional recorder time.
+    #[must_use]
+    pub fn mapped_recorder_interval(&self, source_time_ns: u64) -> Option<RecorderTimeInterval> {
+        if self.quality == ClockMappingQuality::Unusable
+            || !self.has_valid_shape()
+            || !(self.valid_from_source_ns..=self.valid_until_source_ns).contains(&source_time_ns)
+        {
+            return None;
+        }
+        self.checked_recorder_interval(source_time_ns)
+    }
+
+    fn has_valid_shape(&self) -> bool {
+        self.from != ClockDomain::Recorder
+            && self.to == ClockDomain::Recorder
+            && self.rate_numerator != 0
+            && self.rate_denominator != 0
+            && self.valid_from_source_ns <= self.valid_until_source_ns
+            && (self.valid_from_source_ns..=self.valid_until_source_ns)
+                .contains(&self.source_anchor_ns)
+            && (self.quality != ClockMappingQuality::Exact || self.uncertainty_ns == 0)
+            && self
+                .checked_recorder_interval(self.valid_from_source_ns)
+                .is_some()
+            && self
+                .checked_recorder_interval(self.valid_until_source_ns)
+                .is_some()
+    }
+
+    fn checked_recorder_interval(&self, source_time_ns: u64) -> Option<RecorderTimeInterval> {
+        if self.rate_numerator == 0 || self.rate_denominator == 0 {
+            return None;
+        }
+        let source_delta = source_time_ns.abs_diff(self.source_anchor_ns);
+        let scaled = u128::from(source_delta)
+            .checked_mul(u128::from(self.rate_numerator))?
+            .checked_div(u128::from(self.rate_denominator))?;
+        let remainder = u128::from(source_delta)
+            .checked_mul(u128::from(self.rate_numerator))?
+            .checked_rem(u128::from(self.rate_denominator))?;
+        let lower_delta = u64::try_from(scaled).ok()?;
+        let upper_delta = u64::try_from(scaled.checked_add(u128::from(remainder != 0))?).ok()?;
+        if source_time_ns >= self.source_anchor_ns {
+            let earliest_ns = self.recorder_anchor_ns.checked_add(lower_delta)?;
+            let latest_ns = self.recorder_anchor_ns.checked_add(upper_delta)?;
+            self.add_uncertainty(earliest_ns, latest_ns)
+        } else {
+            let earliest_ns = self.recorder_anchor_ns.checked_sub(upper_delta)?;
+            let latest_ns = self.recorder_anchor_ns.checked_sub(lower_delta)?;
+            self.add_uncertainty(earliest_ns, latest_ns)
+        }
+    }
+
+    fn add_uncertainty(&self, earliest_ns: u64, latest_ns: u64) -> Option<RecorderTimeInterval> {
+        Some(RecorderTimeInterval {
+            earliest_ns: earliest_ns.checked_sub(self.uncertainty_ns)?,
+            latest_ns: latest_ns.checked_add(self.uncertainty_ns)?,
+        })
+    }
+}
+
+/// The immutable identity of one trial run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunIdentity {
+    /// The run identity schema version.
+    pub schema_version: u16,
+    /// The unique run identifier.
+    pub run_id: String,
+    /// The code build identity.
+    pub code_build: ArtifactIdentity,
+    /// The vehicle adapter identity.
+    pub vehicle_adapter: ArtifactIdentity,
+    /// The vehicle adapter capabilities digest.
+    pub adapter_capabilities_digest: Digest,
+    /// The simulator backend capabilities digest.
+    pub backend_capabilities_digest: Digest,
+    /// The input device profile identity.
+    pub device_profile: ArtifactIdentity,
+    /// The control scheme identity.
+    pub control_scheme: ArtifactIdentity,
+    /// The control feel candidate identity.
+    pub control_feel_candidate: ArtifactIdentity,
+    /// The flight controller candidate identity.
+    pub flight_controller_candidate: ArtifactIdentity,
+    /// The simulator backend identity.
+    pub simulator_backend: ArtifactIdentity,
+    /// The simulator build identity.
+    pub simulator: ArtifactIdentity,
+    /// The simulated vehicle model identity.
+    pub vehicle_model: ArtifactIdentity,
+    /// The environmental condition set identity.
+    pub condition_set: ArtifactIdentity,
+    /// The scenario identity.
+    pub scenario: ScenarioIdentity,
+    /// The deterministic scenario seed.
+    pub seed: u64,
+    /// The repetition number for this run.
+    pub repetition: u32,
+    /// The identity-bearing ordered list of clock mappings.
+    ///
+    /// Mapping order and an equivalent unreduced rate are distinct identities.
+    pub clock_mappings: Vec<ClockMapping>,
+}
+
+impl RunIdentity {
+    /// Decodes and validates a run identity JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("run identity", bytes, MAX_RUN_IDENTITY_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validates all required identity data.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        schema(
+            "run identity",
+            self.schema_version,
+            RUN_IDENTITY_SCHEMA_VERSION,
+        )?;
+        text("run.run_id", &self.run_id, MAX_TEXT_BYTES)?;
+        self.validate_artifacts()?;
+        digest(
+            "run.adapter_capabilities_digest",
+            self.adapter_capabilities_digest,
+        )?;
+        digest(
+            "run.backend_capabilities_digest",
+            self.backend_capabilities_digest,
+        )?;
+        self.scenario.validate()?;
+        self.validate_clock_mappings()
+    }
+
+    /// Encodes canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("run identity", self, MAX_RUN_IDENTITY_BYTES)
+    }
+
+    /// Calculates the canonical run identity digest.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+
+    fn validate_artifacts(&self) -> Result<(), ValidationError> {
+        self.code_build.validate("run.code_build")?;
+        self.vehicle_adapter.validate("run.vehicle_adapter")?;
+        self.device_profile.validate("run.device_profile")?;
+        self.control_scheme.validate("run.control_scheme")?;
+        self.control_feel_candidate
+            .validate("run.control_feel_candidate")?;
+        self.flight_controller_candidate
+            .validate("run.flight_controller_candidate")?;
+        self.simulator_backend.validate("run.simulator_backend")?;
+        self.simulator.validate("run.simulator")?;
+        self.vehicle_model.validate("run.vehicle_model")?;
+        self.condition_set.validate("run.condition_set")
+    }
+
+    fn validate_clock_mappings(&self) -> Result<(), ValidationError> {
+        count(
+            "run.clock_mappings",
+            self.clock_mappings.len(),
+            MAX_CLOCK_MAPPINGS,
+        )?;
+        for (index, mapping) in self.clock_mappings.iter().enumerate() {
+            self.validate_clock_mapping(index, mapping)?;
+        }
+        Ok(())
+    }
+
+    fn validate_clock_mapping(
+        &self,
+        index: usize,
+        mapping: &ClockMapping,
+    ) -> Result<(), ValidationError> {
+        if mapping.from == ClockDomain::Recorder || mapping.to != ClockDomain::Recorder {
+            return invalid_clock_mapping(index, "each source must map directly to the recorder");
+        }
+        if mapping.rate_numerator == 0 || mapping.rate_denominator == 0 {
+            return invalid_clock_mapping(index, "the clock rate ratio must be greater than zero");
+        }
+        if mapping.valid_from_source_ns > mapping.valid_until_source_ns {
+            return invalid_clock_mapping(index, "the validity interval is reversed");
+        }
+        if !(mapping.valid_from_source_ns..=mapping.valid_until_source_ns)
+            .contains(&mapping.source_anchor_ns)
+        {
+            return invalid_clock_mapping(
+                index,
+                "the source anchor is outside the validity interval",
+            );
+        }
+        if mapping.quality == ClockMappingQuality::Exact && mapping.uncertainty_ns != 0 {
+            return invalid_clock_mapping(index, "an exact mapping must have zero uncertainty");
+        }
+        if mapping
+            .checked_recorder_interval(mapping.valid_from_source_ns)
+            .is_none()
+            || mapping
+                .checked_recorder_interval(mapping.valid_until_source_ns)
+                .is_none()
+        {
+            return invalid_clock_mapping(index, "the mapping interval exceeds the recorder clock");
+        }
+        let duplicate = self.clock_mappings[..index]
+            .iter()
+            .any(|item| item.from == mapping.from && item.source_epoch == mapping.source_epoch);
+        if duplicate {
+            return invalid_clock_mapping(index, "the source clock epoch occurs more than once");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_stage_clock(
+        &self,
+        field: &str,
+        clock: ClockDomain,
+        epoch: u64,
+        source_time_ns: Option<u64>,
+        recorder_receive_ns: u64,
+    ) -> Result<(), ValidationError> {
+        let Some(time_ns) = source_time_ns else {
+            return if clock == ClockDomain::Recorder {
+                self.validate_clock_epoch(field, clock, epoch)
+            } else {
+                Ok(())
+            };
+        };
+        let mapped = self.map_clock_time(field, clock, epoch, time_ns)?;
+        if mapped.latest_ns > recorder_receive_ns {
+            return invalid_stage_stamp(field, "the mapped source time is after the receive time");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_sample_clock(
+        &self,
+        field: &str,
+        clock: ClockDomain,
+        epoch: u64,
+        source_time_ns: u64,
+        recorder_sample_ns: u64,
+    ) -> Result<(), ValidationError> {
+        let mapped = self.map_clock_time(field, clock, epoch, source_time_ns)?;
+        if !(mapped.earliest_ns..=mapped.latest_ns).contains(&recorder_sample_ns) {
+            return invalid_clock_observation(
+                field,
+                "the mapped time differs from the recorder sample time",
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_clock_epoch(
+        &self,
+        field: &str,
+        clock: ClockDomain,
+        epoch: u64,
+    ) -> Result<(), ValidationError> {
+        if clock == ClockDomain::Recorder {
+            return if epoch == 0 {
+                Ok(())
+            } else {
+                invalid_clock_observation(field, "the recorder clock epoch must be zero")
+            };
+        }
+        self.clock_mapping(field, clock, epoch).map(|_| ())
+    }
+
+    pub(crate) fn map_clock_time(
+        &self,
+        field: &str,
+        clock: ClockDomain,
+        epoch: u64,
+        source_time_ns: u64,
+    ) -> Result<RecorderTimeInterval, ValidationError> {
+        if clock == ClockDomain::Recorder {
+            self.validate_clock_epoch(field, clock, epoch)?;
+            return Ok(RecorderTimeInterval {
+                earliest_ns: source_time_ns,
+                latest_ns: source_time_ns,
+            });
+        }
+        let mapping = self.clock_mapping(field, clock, epoch)?;
+        validate_mapping_use(field, clock, epoch, source_time_ns, mapping)
+    }
+
+    fn clock_mapping(
+        &self,
+        field: &str,
+        clock: ClockDomain,
+        epoch: u64,
+    ) -> Result<&ClockMapping, ValidationError> {
+        self.clock_mappings
+            .iter()
+            .find(|mapping| mapping.from == clock && mapping.source_epoch == epoch)
+            .ok_or_else(|| ValidationError::MissingClockMapping {
+                field: field.to_owned(),
+                clock: format!("{clock:?}"),
+                epoch,
+            })
+    }
+}
+
+fn validate_mapping_use(
+    field: &str,
+    clock: ClockDomain,
+    epoch: u64,
+    source_time_ns: u64,
+    mapping: &ClockMapping,
+) -> Result<RecorderTimeInterval, ValidationError> {
+    if mapping.quality == ClockMappingQuality::Unusable {
+        return Err(ValidationError::UnusableClockMapping {
+            field: field.to_owned(),
+            clock: format!("{clock:?}"),
+            epoch,
+        });
+    }
+    if !(mapping.valid_from_source_ns..=mapping.valid_until_source_ns).contains(&source_time_ns) {
+        return Err(ValidationError::ClockTimeOutsideMapping {
+            field: field.to_owned(),
+            clock: format!("{clock:?}"),
+            epoch,
+            time_ns: source_time_ns,
+        });
+    }
+    let Some(mapped) = mapping.mapped_recorder_interval(source_time_ns) else {
+        return invalid_clock_observation(
+            field,
+            "the source time does not map to the recorder clock",
+        );
+    };
+    Ok(mapped)
+}
+
+fn invalid_clock_mapping(index: usize, reason: &'static str) -> Result<(), ValidationError> {
+    Err(ValidationError::InvalidClockMapping { index, reason })
+}
+
+fn invalid_stage_stamp(field: &str, reason: &'static str) -> Result<(), ValidationError> {
+    Err(ValidationError::InvalidStageStamp {
+        field: field.to_owned(),
+        reason,
+    })
+}
+
+fn invalid_clock_observation<T>(field: &str, reason: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::InvalidClockObservation {
+        field: field.to_owned(),
+        reason,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-trial/src/identity/tests.rs
+++ b/crates/pilotage-trial/src/identity/tests.rs
@@ -1,0 +1,286 @@
+use super::{
+    ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, RunIdentity, ScenarioIdentity,
+};
+use crate::{
+    CodecError, Digest, MAX_RUN_IDENTITY_BYTES, RUN_IDENTITY_SCHEMA_VERSION, ValidationError,
+};
+
+fn digest(value: u8) -> Digest {
+    Digest::from_bytes([value; 32])
+}
+
+fn artifact(id: &str, value: u8) -> ArtifactIdentity {
+    ArtifactIdentity {
+        id: id.to_owned(),
+        revision: "1".to_owned(),
+        digest: digest(value),
+    }
+}
+
+fn mapping(from: ClockDomain) -> ClockMapping {
+    ClockMapping {
+        from,
+        to: ClockDomain::Recorder,
+        source_epoch: 7,
+        source_anchor_ns: 100,
+        recorder_anchor_ns: 200,
+        rate_numerator: 1,
+        rate_denominator: 1,
+        valid_from_source_ns: 0,
+        valid_until_source_ns: 1_000,
+        uncertainty_ns: 0,
+        quality: ClockMappingQuality::Exact,
+    }
+}
+
+fn run_identity() -> RunIdentity {
+    RunIdentity {
+        schema_version: RUN_IDENTITY_SCHEMA_VERSION,
+        run_id: "run-1".to_owned(),
+        code_build: artifact("code", 1),
+        vehicle_adapter: artifact("adapter", 2),
+        adapter_capabilities_digest: digest(3),
+        backend_capabilities_digest: digest(4),
+        device_profile: artifact("device", 5),
+        control_scheme: artifact("scheme", 6),
+        control_feel_candidate: artifact("feel", 7),
+        flight_controller_candidate: artifact("controller", 8),
+        simulator_backend: artifact("backend", 9),
+        simulator: artifact("simulator", 10),
+        vehicle_model: artifact("model", 11),
+        condition_set: artifact("conditions", 12),
+        scenario: ScenarioIdentity {
+            id: "scenario".to_owned(),
+            revision: 1,
+            digest: digest(13),
+        },
+        seed: 14,
+        repetition: 0,
+        clock_mappings: [
+            ClockDomain::Device,
+            ClockDomain::Client,
+            ClockDomain::Adapter,
+            ClockDomain::FlightController,
+            ClockDomain::Simulator,
+        ]
+        .map(mapping)
+        .into(),
+    }
+}
+
+#[test]
+fn public_run_digest_is_stable_after_json_normalization() {
+    let run = run_identity();
+    let compact = run.to_canonical_json().expect("canonical run identity");
+    let pretty = serde_json::to_vec_pretty(&run).expect("pretty run identity");
+    let decoded = RunIdentity::from_json(&pretty).expect("validated run identity");
+
+    assert_eq!(decoded, run);
+    assert_eq!(
+        decoded.to_canonical_json().expect("canonical decoded"),
+        compact
+    );
+    assert_eq!(
+        decoded.canonical_digest().expect("decoded digest"),
+        run.canonical_digest().expect("source digest")
+    );
+    assert_eq!(
+        run.canonical_digest().expect("golden digest").to_string(),
+        "fe8f15ae1f4213e7c80f16189b1462f806f828d225e4b8a73eed5426472e5388"
+    );
+}
+
+#[test]
+fn run_identity_rejects_an_unknown_schema_version() {
+    let mut run = run_identity();
+    run.schema_version = RUN_IDENTITY_SCHEMA_VERSION.wrapping_add(1);
+
+    assert!(matches!(
+        run.validate(),
+        Err(ValidationError::UnsupportedSchemaVersion {
+            document: "run identity",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn unused_clock_domains_do_not_require_fake_mappings() {
+    let mut run = run_identity();
+    run.clock_mappings.clear();
+
+    assert_eq!(run.validate(), Ok(()));
+}
+
+#[test]
+fn clock_mapping_rejects_an_interval_before_the_recorder_epoch() {
+    let mut run = run_identity();
+    run.clock_mappings[0].source_anchor_ns = 100;
+    run.clock_mappings[0].recorder_anchor_ns = 0;
+
+    assert_eq!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping {
+            index: 0,
+            reason: "the mapping interval exceeds the recorder clock",
+        })
+    );
+}
+
+#[test]
+fn clock_mapping_rejects_uncertainty_underflow() {
+    let mut run = run_identity();
+    run.clock_mappings[0].source_anchor_ns = 0;
+    run.clock_mappings[0].recorder_anchor_ns = 0;
+    run.clock_mappings[0].quality = ClockMappingQuality::Estimated;
+    run.clock_mappings[0].uncertainty_ns = 1;
+
+    assert!(matches!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping { index: 0, .. })
+    ));
+}
+
+#[test]
+fn fractional_rate_returns_both_adjacent_recorder_nanoseconds() {
+    let mut mapping = mapping(ClockDomain::Device);
+    mapping.source_anchor_ns = 0;
+    mapping.recorder_anchor_ns = 100;
+    mapping.rate_numerator = 3;
+    mapping.rate_denominator = 2;
+
+    let interval = mapping
+        .mapped_recorder_interval(1)
+        .expect("mapped recorder interval");
+    assert_eq!(interval.earliest_ns, 101);
+    assert_eq!(interval.latest_ns, 102);
+}
+
+#[test]
+fn public_mapping_api_rejects_an_invalid_target() {
+    let mut mapping = mapping(ClockDomain::Device);
+    mapping.to = ClockDomain::Client;
+
+    assert_eq!(mapping.mapped_recorder_interval(100), None);
+}
+
+#[test]
+fn clock_mapping_must_target_the_recorder() {
+    let mut run = run_identity();
+    run.clock_mappings[0].to = ClockDomain::Client;
+
+    assert_eq!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping {
+            index: 0,
+            reason: "each source must map directly to the recorder",
+        })
+    );
+}
+
+#[test]
+fn clock_mapping_epoch_is_unique_for_each_source() {
+    let mut run = run_identity();
+    run.clock_mappings.push(mapping(ClockDomain::Device));
+
+    assert_eq!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping {
+            index: 5,
+            reason: "the source clock epoch occurs more than once",
+        })
+    );
+}
+
+#[test]
+fn clock_mapping_anchor_must_be_in_its_validity_interval() {
+    let mut run = run_identity();
+    run.clock_mappings[0].source_anchor_ns = 1_001;
+
+    assert_eq!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping {
+            index: 0,
+            reason: "the source anchor is outside the validity interval",
+        })
+    );
+}
+
+#[test]
+fn run_identity_decode_rejects_a_zero_clock_rate() {
+    let mut run = run_identity();
+    run.clock_mappings[0].rate_denominator = 0;
+    let bytes = serde_json::to_vec(&run).expect("run identity JSON");
+
+    assert!(matches!(
+        RunIdentity::from_json(&bytes),
+        Err(CodecError::Validation(
+            ValidationError::InvalidClockMapping { index: 0, .. }
+        ))
+    ));
+}
+
+#[test]
+fn run_identity_decode_rejects_an_unknown_field() {
+    let run = run_identity();
+    let mut value = serde_json::to_value(run).expect("run identity value");
+    value
+        .as_object_mut()
+        .expect("run identity object")
+        .insert("unknown".to_owned(), serde_json::Value::Bool(true));
+    let bytes = serde_json::to_vec(&value).expect("run identity JSON");
+
+    assert!(matches!(
+        RunIdentity::from_json(&bytes),
+        Err(CodecError::Decode {
+            document: "run identity",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn run_identity_size_limit_applies_before_decode() {
+    let bytes = vec![b' '; MAX_RUN_IDENTITY_BYTES + 1];
+
+    assert!(matches!(
+        RunIdentity::from_json(&bytes),
+        Err(CodecError::DocumentTooLarge {
+            document: "run identity",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn clock_mapping_rejects_an_interval_after_the_recorder_limit() {
+    let mut run = run_identity();
+    run.clock_mappings[0].source_anchor_ns = 0;
+    run.clock_mappings[0].recorder_anchor_ns = u64::MAX;
+    run.clock_mappings[0].valid_from_source_ns = 0;
+    run.clock_mappings[0].valid_until_source_ns = 1;
+
+    assert_eq!(
+        run.validate(),
+        Err(ValidationError::InvalidClockMapping {
+            index: 0,
+            reason: "the mapping interval exceeds the recorder clock",
+        })
+    );
+}
+
+#[test]
+fn fractional_rate_before_the_anchor_contains_both_adjacent_times() {
+    let mut value = mapping(ClockDomain::Device);
+    value.source_anchor_ns = 2;
+    value.recorder_anchor_ns = 100;
+    value.rate_numerator = 3;
+    value.rate_denominator = 2;
+    value.valid_from_source_ns = 1;
+
+    let interval = value
+        .mapped_recorder_interval(1)
+        .expect("mapped recorder interval");
+    assert_eq!(interval.earliest_ns, 98);
+    assert_eq!(interval.latest_ns, 99);
+}

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! This crate contains data only. A runner supplies all input and output.
 
+mod causal_api;
+pub use causal_api::*;
+
 mod canonical;
 mod digest;
 mod error;
@@ -12,18 +15,9 @@ mod validation;
 
 pub use digest::Digest;
 pub use error::{CodecError, ValidationError};
-pub use limits::{
-    MAX_CONTROL_EVENT_HISTORY, MAX_RUN_IDENTITY_BYTES, QUATERNION_NORM_TOLERANCE,
-    RUN_IDENTITY_SCHEMA_VERSION,
-};
-pub use sample::{
-    CausalStage, ClockReading, ControlEventId, ControlStage, SimulatorTruthEvidence, SourceStamp,
-    StageProducerRole, StageStamp, TrialStreamValidator,
-};
 pub use identity::{
     ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, RunIdentity, ScenarioIdentity,
 };
-pub use identity::RecorderTimeInterval;
 pub use limits::{
     BACKEND_CAPABILITIES_SCHEMA_VERSION, MAX_ACTUATOR_VALUES, MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS,
     MAX_CONDITION_VALUES, MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES,

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -1,0 +1,37 @@
+//! Versioned data contracts for repeatable control trials.
+//!
+//! This crate contains data only. A runner supplies all input and output.
+
+mod canonical;
+mod digest;
+mod error;
+mod identity;
+mod limits;
+mod sample;
+mod validation;
+
+pub use digest::Digest;
+pub use error::{CodecError, ValidationError};
+pub use limits::{
+    MAX_CONTROL_EVENT_HISTORY, MAX_RUN_IDENTITY_BYTES, QUATERNION_NORM_TOLERANCE,
+    RUN_IDENTITY_SCHEMA_VERSION,
+};
+pub use sample::{
+    CausalStage, ClockReading, ControlEventId, ControlStage, SimulatorTruthEvidence, SourceStamp,
+    StageProducerRole, StageStamp, TrialStreamValidator,
+};
+pub use identity::{
+    ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, RunIdentity, ScenarioIdentity,
+};
+pub use identity::RecorderTimeInterval;
+pub use limits::{
+    BACKEND_CAPABILITIES_SCHEMA_VERSION, MAX_ACTUATOR_VALUES, MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS,
+    MAX_CONDITION_VALUES, MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES,
+    MAX_RAW_BUTTONS, MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS,
+    SCENARIO_SCHEMA_VERSION, TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
+};
+pub use sample::{
+    ActuatorState, AdapterDisposition, ConditionState, ControlAxes, ControlValue, HealthState,
+    KinematicState, LifecycleObservation, LifecycleState, MissingReason, MissingSignal, NamedValue,
+    Observed, Quaternion, RawInput, ReferenceFrame, SampleTime, TrialSample, Vector3,
+};

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -1,0 +1,43 @@
+//! Fixed limits for trial data.
+
+/// The supported trial manifest schema version.
+pub const TRIAL_MANIFEST_SCHEMA_VERSION: u16 = 1;
+/// The supported run identity schema version.
+pub const RUN_IDENTITY_SCHEMA_VERSION: u16 = 1;
+/// The supported scenario schema version.
+pub const SCENARIO_SCHEMA_VERSION: u16 = 1;
+/// The supported backend capabilities schema version.
+pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
+/// The supported trial sample schema version.
+pub const TRIAL_SAMPLE_SCHEMA_VERSION: u16 = 1;
+
+/// The maximum trial manifest JSON size.
+pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+/// The maximum run identity JSON size.
+pub const MAX_RUN_IDENTITY_BYTES: usize = 64 * 1024;
+/// The maximum trial sample JSON size.
+pub const MAX_SAMPLE_BYTES: usize = 64 * 1024;
+/// The maximum UTF-8 byte count for one text value.
+pub const MAX_TEXT_BYTES: usize = 256;
+/// The maximum number of phases in one scenario.
+pub const MAX_PHASES: usize = 128;
+/// The maximum number of conditions in one phase condition list.
+pub const MAX_PHASE_CONDITIONS: usize = 32;
+/// The maximum number of capabilities in one list.
+pub const MAX_CAPABILITIES: usize = 32;
+/// The maximum number of clock mappings in one run identity.
+pub const MAX_CLOCK_MAPPINGS: usize = 16;
+/// The maximum number of unconsumed events for one control stage.
+pub const MAX_CONTROL_EVENT_HISTORY: usize = 1_024;
+/// The maximum number of components in one multisine waveform.
+pub const MAX_WAVE_COMPONENTS: usize = 32;
+/// The maximum number of axes in one raw input sample.
+pub const MAX_RAW_AXES: usize = 32;
+/// The maximum number of buttons in one raw input sample.
+pub const MAX_RAW_BUTTONS: usize = 128;
+/// The maximum number of actuator values in one sample.
+pub const MAX_ACTUATOR_VALUES: usize = 64;
+/// The maximum number of named condition values in one sample.
+pub const MAX_CONDITION_VALUES: usize = 64;
+/// The permitted difference between a quaternion norm and one.
+pub const QUATERNION_NORM_TOLERANCE: f64 = 1.0e-3;

--- a/crates/pilotage-trial/src/sample.rs
+++ b/crates/pilotage-trial/src/sample.rs
@@ -1,0 +1,385 @@
+//! Versioned samples for one trial trace.
+
+mod control;
+mod missing;
+mod stage;
+mod state;
+mod stream;
+mod time;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ClockDomain, CodecError, Digest, MAX_SAMPLE_BYTES, RunIdentity, TRIAL_SAMPLE_SCHEMA_VERSION,
+    ValidationError, canonical,
+    validation::{digest, schema},
+};
+
+pub use control::{AdapterDisposition, ControlAxes, ControlValue, RawInput, ReferenceFrame};
+pub use missing::{MissingReason, MissingSignal, Observed};
+pub use stage::{
+    CausalStage, ControlEventId, ControlStage, SourceStamp, StageProducerRole, StageStamp,
+};
+pub use state::{
+    ActuatorState, ConditionState, HealthState, KinematicState, LifecycleObservation,
+    LifecycleState, NamedValue, Quaternion, SimulatorTruthEvidence, Vector3,
+};
+pub use stream::TrialStreamValidator;
+pub use time::{ClockReading, SampleTime};
+
+/// One versioned sample in a trial trace.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialSample {
+    /// The trial sample schema version.
+    pub schema_version: u16,
+    /// The canonical digest of the run identity.
+    pub run_digest: Digest,
+    /// The monotonic sequence number in this run.
+    pub sequence: u64,
+    /// The number of lost samples before this sample.
+    pub dropped_before: u32,
+    /// The zero-based scenario phase index.
+    pub phase_index: u16,
+    /// The sample times in all available clocks.
+    pub time: SampleTime,
+    /// The raw device input.
+    pub raw_input: CausalStage<RawInput>,
+    /// The normalized input channels.
+    pub normalized_control: CausalStage<ControlAxes>,
+    /// The typed control intent.
+    pub typed_intent: CausalStage<ControlValue>,
+    /// The demand that the adapter receives.
+    pub adapter_demand: CausalStage<ControlValue>,
+    /// The setpoint that the adapter transmits.
+    pub transmitted_setpoint: CausalStage<ControlValue>,
+    /// The flight controller kinematic estimate.
+    pub flight_controller_estimate: CausalStage<KinematicState>,
+    /// The simulator kinematic truth evidence.
+    pub simulator_truth: CausalStage<SimulatorTruthEvidence>,
+    /// The actuator effort and saturation state.
+    pub actuator: Observed<ActuatorState>,
+    /// The adapter decision for the control demand.
+    pub adapter_disposition: Observed<AdapterDisposition>,
+    /// The simulator and vehicle lifecycle state.
+    pub lifecycle: Observed<LifecycleObservation>,
+    /// The measured environmental condition state.
+    pub condition_state: Observed<ConditionState>,
+    /// The control link validity state.
+    pub link_state: Observed<HealthState>,
+    /// The flight controller estimator validity state.
+    pub estimator_state: Observed<HealthState>,
+}
+
+impl TrialSample {
+    /// Decodes a sample and validates its run identity link.
+    pub fn from_json_for_run(bytes: &[u8], run: &RunIdentity) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("trial sample", bytes, MAX_SAMPLE_BYTES)?;
+        value.validate_for_run(run)?;
+        Ok(value)
+    }
+
+    /// Validates local content without a run identity link.
+    pub fn validate_local(&self) -> Result<(), ValidationError> {
+        schema(
+            "trial sample",
+            self.schema_version,
+            TRIAL_SAMPLE_SCHEMA_VERSION,
+        )?;
+        digest("sample.run_digest", self.run_digest)?;
+        self.time.validate()?;
+        self.validate_causal_stages_local()?;
+        self.validate_state_signals()?;
+        self.validate_status_signals()
+    }
+
+    /// Validates the sample and its canonical run identity link.
+    pub fn validate_for_run(&self, run: &RunIdentity) -> Result<(), CodecError> {
+        run.validate()?;
+        self.validate_local()?;
+        if self.run_digest != run.canonical_digest()? {
+            return Err(ValidationError::IdentityMismatch {
+                field: "sample.run_digest".to_owned(),
+            }
+            .into());
+        }
+        self.time.validate_for_run(run)?;
+        self.validate_causal_stage_clocks(run)?;
+        self.validate_control_lineage_shape()?;
+        Ok(())
+    }
+
+    /// Validates this sample after one adjacent recorded sample in the same run.
+    ///
+    /// This operation does not retain earlier present values across a missing
+    /// observation. Use [`TrialStreamValidator`] to validate a complete trace.
+    pub fn validate_adjacent_only(
+        &self,
+        previous: &Self,
+        run: &RunIdentity,
+    ) -> Result<(), CodecError> {
+        self.validate_after(previous, run)
+    }
+
+    pub(crate) fn validate_after(
+        &self,
+        previous: &Self,
+        run: &RunIdentity,
+    ) -> Result<(), CodecError> {
+        previous.validate_local()?;
+        self.validate_local()?;
+        if previous.run_digest != self.run_digest {
+            return Err(ValidationError::MixedRun.into());
+        }
+        previous.validate_for_run(run)?;
+        self.validate_for_run(run)?;
+        validate_sequence(previous, self)?;
+        if self.phase_index < previous.phase_index {
+            return Err(ValidationError::PhaseOrder {
+                previous: previous.phase_index,
+                current: self.phase_index,
+            }
+            .into());
+        }
+        validate_clock_order(previous, self)?;
+        self.validate_causal_stage_order(previous)?;
+        Ok(())
+    }
+
+    /// Encodes canonical compact JSON after run-bound validation.
+    pub fn to_canonical_json_for_run(&self, run: &RunIdentity) -> Result<Vec<u8>, CodecError> {
+        self.validate_for_run(run)?;
+        canonical::encode("trial sample", self, MAX_SAMPLE_BYTES)
+    }
+
+    /// Calculates the digest of run-bound canonical compact JSON.
+    pub fn canonical_digest_for_run(&self, run: &RunIdentity) -> Result<Digest, CodecError> {
+        self.to_canonical_json_for_run(run)
+            .map(|bytes| canonical::digest(&bytes))
+    }
+
+    fn validate_causal_stages_local(&self) -> Result<(), ValidationError> {
+        let recorder_ns = self.time.recorder_monotonic_ns;
+        self.raw_input.validate_local_with(
+            "sample.raw_input",
+            StageProducerRole::InputCapture,
+            recorder_ns,
+            RawInput::validate,
+        )?;
+        self.normalized_control.validate_local_with(
+            "sample.normalized_control",
+            StageProducerRole::ControlClient,
+            recorder_ns,
+            ControlAxes::validate,
+        )?;
+        self.typed_intent.validate_local_with(
+            "sample.typed_intent",
+            StageProducerRole::ControlClient,
+            recorder_ns,
+            ControlValue::validate,
+        )?;
+        self.adapter_demand.validate_local_with(
+            "sample.adapter_demand",
+            StageProducerRole::ControlClient,
+            recorder_ns,
+            ControlValue::validate,
+        )?;
+        self.transmitted_setpoint.validate_local_with(
+            "sample.transmitted_setpoint",
+            StageProducerRole::VehicleAdapter,
+            recorder_ns,
+            ControlValue::validate,
+        )?;
+        self.flight_controller_estimate.validate_local_with(
+            "sample.flight_controller_estimate",
+            StageProducerRole::FlightController,
+            recorder_ns,
+            KinematicState::validate,
+        )?;
+        self.simulator_truth.validate_local_with(
+            "sample.simulator_truth",
+            StageProducerRole::SimulatorBackend,
+            recorder_ns,
+            SimulatorTruthEvidence::validate,
+        )
+    }
+
+    fn validate_causal_stage_clocks(&self, run: &RunIdentity) -> Result<(), ValidationError> {
+        self.raw_input.validate_clock("sample.raw_input", run)?;
+        self.normalized_control
+            .validate_clock("sample.normalized_control", run)?;
+        self.typed_intent
+            .validate_clock("sample.typed_intent", run)?;
+        self.adapter_demand
+            .validate_clock("sample.adapter_demand", run)?;
+        self.transmitted_setpoint
+            .validate_clock("sample.transmitted_setpoint", run)?;
+        self.flight_controller_estimate
+            .validate_clock("sample.flight_controller_estimate", run)?;
+        self.simulator_truth
+            .validate_clock("sample.simulator_truth", run)
+    }
+
+    fn validate_control_lineage_shape(&self) -> Result<(), ValidationError> {
+        self.raw_input
+            .validate_predecessor_stage("sample.raw_input", None)?;
+        self.normalized_control.validate_predecessor_stage(
+            "sample.normalized_control",
+            Some(ControlStage::RawInput),
+        )?;
+        self.typed_intent.validate_predecessor_stage(
+            "sample.typed_intent",
+            Some(ControlStage::NormalizedControl),
+        )?;
+        self.adapter_demand
+            .validate_predecessor_stage("sample.adapter_demand", Some(ControlStage::TypedIntent))?;
+        self.transmitted_setpoint.validate_predecessor_stage(
+            "sample.transmitted_setpoint",
+            Some(ControlStage::AdapterDemand),
+        )?;
+        self.flight_controller_estimate
+            .validate_predecessor_stage("sample.flight_controller_estimate", None)?;
+        self.simulator_truth
+            .validate_predecessor_stage("sample.simulator_truth", None)
+    }
+
+    fn validate_causal_stage_order(&self, previous: &Self) -> Result<(), ValidationError> {
+        let discontinuity = |stage: &StageStamp| self.time.has_discontinuity(stage.source.clock);
+        self.raw_input.validate_after(
+            &previous.raw_input,
+            "sample.raw_input",
+            discontinuity(&self.raw_input.stamp),
+        )?;
+        self.normalized_control.validate_after(
+            &previous.normalized_control,
+            "sample.normalized_control",
+            discontinuity(&self.normalized_control.stamp),
+        )?;
+        self.typed_intent.validate_after(
+            &previous.typed_intent,
+            "sample.typed_intent",
+            discontinuity(&self.typed_intent.stamp),
+        )?;
+        self.adapter_demand.validate_after(
+            &previous.adapter_demand,
+            "sample.adapter_demand",
+            discontinuity(&self.adapter_demand.stamp),
+        )?;
+        self.transmitted_setpoint.validate_after(
+            &previous.transmitted_setpoint,
+            "sample.transmitted_setpoint",
+            discontinuity(&self.transmitted_setpoint.stamp),
+        )?;
+        self.flight_controller_estimate.validate_after(
+            &previous.flight_controller_estimate,
+            "sample.flight_controller_estimate",
+            discontinuity(&self.flight_controller_estimate.stamp),
+        )?;
+        self.simulator_truth.validate_after(
+            &previous.simulator_truth,
+            "sample.simulator_truth",
+            discontinuity(&self.simulator_truth.stamp),
+        )
+    }
+
+    fn validate_state_signals(&self) -> Result<(), ValidationError> {
+        self.actuator
+            .validate_with("sample.actuator", ActuatorState::validate)?;
+        self.condition_state
+            .validate_with("sample.condition_state", ConditionState::validate)
+    }
+
+    fn validate_status_signals(&self) -> Result<(), ValidationError> {
+        self.adapter_disposition
+            .validate_with("sample.adapter_disposition", AdapterDisposition::validate)?;
+        self.lifecycle
+            .validate_with("sample.lifecycle", LifecycleObservation::validate)?;
+        self.link_state
+            .validate_with("sample.link_state", HealthState::validate)?;
+        self.estimator_state
+            .validate_with("sample.estimator_state", HealthState::validate)
+    }
+}
+
+fn validate_sequence(previous: &TrialSample, current: &TrialSample) -> Result<(), ValidationError> {
+    if current.sequence <= previous.sequence {
+        return Err(ValidationError::SequenceOrder {
+            previous: previous.sequence,
+            current: current.sequence,
+        });
+    }
+    let increment = u64::from(current.dropped_before).wrapping_add(1);
+    let Some(expected) = previous.sequence.checked_add(increment) else {
+        return Err(ValidationError::SequenceOrder {
+            previous: previous.sequence,
+            current: current.sequence,
+        });
+    };
+    if current.sequence != expected {
+        return Err(ValidationError::SequenceGap {
+            expected,
+            actual: current.sequence,
+        });
+    }
+    Ok(())
+}
+
+fn validate_clock_order(
+    previous: &TrialSample,
+    current: &TrialSample,
+) -> Result<(), ValidationError> {
+    if current.time.recorder_monotonic_ns < previous.time.recorder_monotonic_ns {
+        return Err(ValidationError::ClockRegression {
+            clock: format!("{:?}", ClockDomain::Recorder),
+            previous_ns: previous.time.recorder_monotonic_ns,
+            current_ns: current.time.recorder_monotonic_ns,
+        });
+    }
+    const DOMAINS: [ClockDomain; 5] = [
+        ClockDomain::Device,
+        ClockDomain::Client,
+        ClockDomain::Adapter,
+        ClockDomain::FlightController,
+        ClockDomain::Simulator,
+    ];
+    for domain in DOMAINS {
+        let Some(prior) = previous.time.source_reading(domain) else {
+            continue;
+        };
+        let Some(next) = current.time.source_reading(domain) else {
+            continue;
+        };
+        let has_discontinuity = current.time.has_discontinuity(domain);
+        if prior.epoch == next.epoch && next.time_ns < prior.time_ns {
+            return Err(ValidationError::ClockRegression {
+                clock: format!("{domain:?}"),
+                previous_ns: prior.time_ns,
+                current_ns: next.time_ns,
+            });
+        }
+        if prior.epoch == next.epoch && has_discontinuity {
+            return invalid_clock_observation(
+                "sample.time.clock_discontinuities",
+                "a clock discontinuity must change the source epoch",
+            );
+        }
+        if prior.epoch != next.epoch && !has_discontinuity {
+            return invalid_clock_observation(
+                "sample.time.clock_discontinuities",
+                "a source epoch change needs a clock discontinuity",
+            );
+        }
+    }
+    Ok(())
+}
+
+fn invalid_clock_observation<T>(field: &str, reason: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::InvalidClockObservation {
+        field: field.to_owned(),
+        reason,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-trial/src/sample/control.rs
+++ b/crates/pilotage-trial/src/sample/control.rs
@@ -1,0 +1,199 @@
+//! Control values at each stage of the sample path.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    MAX_ACTUATOR_VALUES, MAX_RAW_AXES, MAX_RAW_BUTTONS, MAX_TEXT_BYTES, ValidationError,
+    validation::{count, finite, nonempty_count, optional_text, range},
+};
+
+use super::{Quaternion, Vector3};
+
+/// A coordinate frame for a control value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceFrame {
+    /// The local north-east-down frame.
+    LocalNed,
+    /// The body forward-right-down frame.
+    BodyFrd,
+}
+
+/// Four normalized input channels.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControlAxes {
+    /// The normalized roll value.
+    pub roll: f64,
+    /// The normalized pitch value.
+    pub pitch: f64,
+    /// The normalized vertical value.
+    pub vertical: f64,
+    /// The normalized yaw value.
+    pub yaw: f64,
+}
+
+impl ControlAxes {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        range(&format!("{field}.roll"), self.roll, -1.0, 1.0)?;
+        range(&format!("{field}.pitch"), self.pitch, -1.0, 1.0)?;
+        range(&format!("{field}.vertical"), self.vertical, -1.0, 1.0)?;
+        range(&format!("{field}.yaw"), self.yaw, -1.0, 1.0)
+    }
+}
+
+/// One raw device input report.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawInput {
+    /// The device axis values in profile order.
+    pub axes: Vec<f64>,
+    /// The device button values in profile order.
+    pub buttons: Vec<bool>,
+}
+
+impl RawInput {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        count(&format!("{field}.axes"), self.axes.len(), MAX_RAW_AXES)?;
+        count(
+            &format!("{field}.buttons"),
+            self.buttons.len(),
+            MAX_RAW_BUTTONS,
+        )?;
+        for (index, value) in self.axes.iter().enumerate() {
+            finite(&format!("{field}.axes[{index}]"), *value)?;
+        }
+        Ok(())
+    }
+}
+
+/// A typed control value at one pipeline stage.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ControlValue {
+    /// Four normalized control axes.
+    Axes {
+        /// The normalized control axes.
+        axes: ControlAxes,
+    },
+    /// Linear velocity and yaw rate.
+    Velocity {
+        /// The coordinate frame.
+        frame: ReferenceFrame,
+        /// The linear velocity in meters per second.
+        linear_mps: Vector3,
+        /// The yaw rate in radians per second.
+        yaw_rate_rad_s: f64,
+    },
+    /// Attitude and normalized thrust.
+    AttitudeThrust {
+        /// The coordinate frame.
+        frame: ReferenceFrame,
+        /// The requested attitude.
+        attitude: Quaternion,
+        /// The normalized thrust from zero through one.
+        thrust: f64,
+    },
+    /// Body rate and normalized thrust.
+    BodyRateThrust {
+        /// The body rate in radians per second.
+        body_rates_rad_s: Vector3,
+        /// The normalized thrust from zero through one.
+        thrust: f64,
+    },
+    /// Position and yaw angle.
+    PositionYaw {
+        /// The coordinate frame.
+        frame: ReferenceFrame,
+        /// The position in meters.
+        position_m: Vector3,
+        /// The yaw angle in radians.
+        yaw_rad: f64,
+    },
+    /// Ordered scalar channels for an adapter-specific control type.
+    ScalarChannels {
+        /// The ordered channel values.
+        values: Vec<f64>,
+    },
+}
+
+impl ControlValue {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        match self {
+            Self::Axes { axes } => axes.validate(field),
+            Self::Velocity {
+                linear_mps,
+                yaw_rate_rad_s,
+                ..
+            } => {
+                linear_mps.validate(&format!("{field}.linear_mps"))?;
+                finite(&format!("{field}.yaw_rate_rad_s"), *yaw_rate_rad_s)
+            }
+            Self::AttitudeThrust {
+                attitude, thrust, ..
+            } => {
+                attitude.validate(&format!("{field}.attitude"))?;
+                range(&format!("{field}.thrust"), *thrust, 0.0, 1.0)
+            }
+            Self::BodyRateThrust {
+                body_rates_rad_s,
+                thrust,
+            } => {
+                body_rates_rad_s.validate(&format!("{field}.body_rates_rad_s"))?;
+                range(&format!("{field}.thrust"), *thrust, 0.0, 1.0)
+            }
+            Self::PositionYaw {
+                position_m,
+                yaw_rad,
+                ..
+            } => {
+                position_m.validate(&format!("{field}.position_m"))?;
+                finite(&format!("{field}.yaw_rad"), *yaw_rad)
+            }
+            Self::ScalarChannels { values } => validate_scalars(field, values),
+        }
+    }
+}
+
+/// The adapter decision for one control demand.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AdapterDisposition {
+    /// The adapter accepted the demand without a constraint.
+    Accepted,
+    /// The adapter constrained the demand.
+    Constrained {
+        /// The constraint reason.
+        reason: Option<String>,
+    },
+    /// The adapter rejected the demand.
+    Rejected {
+        /// The rejection reason.
+        reason: Option<String>,
+    },
+}
+
+impl AdapterDisposition {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        match self {
+            Self::Accepted => Ok(()),
+            Self::Constrained { reason } | Self::Rejected { reason } => optional_text(
+                &format!("{field}.reason"),
+                reason.as_deref(),
+                MAX_TEXT_BYTES,
+            ),
+        }
+    }
+}
+
+fn validate_scalars(field: &str, values: &[f64]) -> Result<(), ValidationError> {
+    nonempty_count(
+        &format!("{field}.values"),
+        values.len(),
+        MAX_ACTUATOR_VALUES,
+    )?;
+    for (index, value) in values.iter().enumerate() {
+        finite(&format!("{field}.values[{index}]"), *value)?;
+    }
+    Ok(())
+}

--- a/crates/pilotage-trial/src/sample/missing.rs
+++ b/crates/pilotage-trial/src/sample/missing.rs
@@ -1,0 +1,107 @@
+//! Explicit missing signal records.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{MAX_TEXT_BYTES, ValidationError, validation::optional_text};
+
+/// The cause of a missing signal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingReason {
+    /// The source did not publish the signal.
+    NotPublished,
+    /// The signal does not apply to this backend or phase.
+    NotApplicable,
+    /// A component rejected the value.
+    Rejected,
+    /// The most recent value is too old.
+    Stale,
+    /// The source marked the value as invalid.
+    Invalid,
+    /// A sequence gap removed the value.
+    SequenceGap,
+    /// Recorder lag removed the value.
+    RecorderLag,
+    /// A clock discontinuity prevents alignment.
+    ClockDiscontinuity,
+}
+
+/// A record that explains one missing signal.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MissingSignal {
+    /// The missing signal reason.
+    pub reason: MissingReason,
+    /// Additional bounded information about the reason.
+    pub detail: Option<String>,
+}
+
+impl MissingSignal {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        optional_text(
+            &format!("{field}.detail"),
+            self.detail.as_deref(),
+            MAX_TEXT_BYTES,
+        )
+    }
+}
+
+/// A present value or an explicit missing signal record.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Observed<T> {
+    /// The signal has a value.
+    Present {
+        /// The signal value.
+        value: T,
+    },
+    /// The signal has no value.
+    Missing {
+        /// The missing signal record.
+        missing: MissingSignal,
+    },
+}
+
+impl<T> Observed<T> {
+    /// Creates a present signal value.
+    #[must_use]
+    pub const fn present(value: T) -> Self {
+        Self::Present { value }
+    }
+
+    /// Creates a missing signal record.
+    #[must_use]
+    pub const fn missing(reason: MissingReason, detail: Option<String>) -> Self {
+        Self::Missing {
+            missing: MissingSignal { reason, detail },
+        }
+    }
+
+    /// Gets the present value.
+    #[must_use]
+    pub const fn value(&self) -> Option<&T> {
+        match self {
+            Self::Present { value } => Some(value),
+            Self::Missing { .. } => None,
+        }
+    }
+
+    /// Gets the missing signal record.
+    #[must_use]
+    pub const fn missing_signal(&self) -> Option<&MissingSignal> {
+        match self {
+            Self::Present { .. } => None,
+            Self::Missing { missing } => Some(missing),
+        }
+    }
+
+    pub(crate) fn validate_with<F>(&self, field: &str, validate: F) -> Result<(), ValidationError>
+    where
+        F: FnOnce(&T, &str) -> Result<(), ValidationError>,
+    {
+        match self {
+            Self::Present { value } => validate(value, field),
+            Self::Missing { missing } => missing.validate(field),
+        }
+    }
+}

--- a/crates/pilotage-trial/src/sample/stage.rs
+++ b/crates/pilotage-trial/src/sample/stage.rs
@@ -1,0 +1,253 @@
+//! Attributable stamps for each causal stage.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ClockDomain, MissingReason, Observed, RunIdentity, ValidationError};
+
+/// The producer role for one causal stage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StageProducerRole {
+    /// The input capture producer.
+    InputCapture,
+    /// The control client producer.
+    ControlClient,
+    /// The vehicle adapter producer.
+    VehicleAdapter,
+    /// The flight controller producer.
+    FlightController,
+    /// The simulator backend producer.
+    SimulatorBackend,
+}
+
+/// One stage in the direct control-event chain.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlStage {
+    /// The raw input stage.
+    RawInput,
+    /// The normalized control stage.
+    NormalizedControl,
+    /// The typed intent stage.
+    TypedIntent,
+    /// The adapter demand stage.
+    AdapterDemand,
+    /// The transmitted setpoint stage.
+    TransmittedSetpoint,
+}
+
+/// The identity of one event in the direct control-event chain.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControlEventId {
+    /// The control stage that produced the event.
+    pub stage: ControlStage,
+    /// The source clock domain.
+    pub clock: ClockDomain,
+    /// The source clock epoch.
+    pub epoch: u64,
+    /// The source event sequence number.
+    pub sequence: u64,
+}
+
+/// The source identity and time for one causal stage.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceStamp {
+    /// The producer role.
+    pub producer: StageProducerRole,
+    /// The source clock domain.
+    pub clock: ClockDomain,
+    /// The source clock epoch.
+    pub epoch: u64,
+    /// The source event or explicit missing-record sequence number in this epoch.
+    pub sequence: u64,
+    /// The event time or an explicit missing-time record.
+    pub time_ns: Observed<u64>,
+}
+
+/// Source, recorder receive, and recorder apply times for one stage.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StageStamp {
+    /// The source stamp.
+    pub source: SourceStamp,
+    /// The direct predecessor for a present derived control event.
+    pub predecessor: Option<ControlEventId>,
+    /// The recorder time when it received this observation record.
+    pub recorder_receive_ns: u64,
+    /// The recorder time when it first made this observation current in the trace.
+    pub recorder_apply_ns: u64,
+}
+
+/// One causal stage with its stamp and explicit observation state.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CausalStage<T> {
+    /// The attributable stage stamp.
+    pub stamp: StageStamp,
+    /// The stage value or an explicit missing-signal record.
+    pub observation: Observed<T>,
+}
+
+impl<T> CausalStage<T> {
+    /// Creates a present causal stage.
+    #[must_use]
+    pub const fn present(stamp: StageStamp, value: T) -> Self {
+        Self {
+            stamp,
+            observation: Observed::present(value),
+        }
+    }
+
+    /// Creates a missing causal stage.
+    #[must_use]
+    pub const fn missing(stamp: StageStamp, reason: MissingReason, detail: Option<String>) -> Self {
+        Self {
+            stamp,
+            observation: Observed::missing(reason, detail),
+        }
+    }
+
+    /// Gets the present stage value.
+    #[must_use]
+    pub const fn value(&self) -> Option<&T> {
+        self.observation.value()
+    }
+
+    pub(crate) fn validate_local_with<F>(
+        &self,
+        field: &str,
+        expected_producer: StageProducerRole,
+        sample_recorder_ns: u64,
+        validate: F,
+    ) -> Result<(), ValidationError>
+    where
+        F: FnOnce(&T, &str) -> Result<(), ValidationError>,
+    {
+        if self.stamp.source.producer != expected_producer {
+            return invalid_stamp(field, "the stage has an unexpected producer role");
+        }
+        self.stamp.validate(field, sample_recorder_ns)?;
+        self.stamp
+            .source
+            .time_ns
+            .validate_with(&format!("{field}.stamp.source.time_ns"), present_time)?;
+        self.observation.validate_with(field, validate)
+    }
+
+    pub(crate) fn validate_clock(
+        &self,
+        field: &str,
+        run: &RunIdentity,
+    ) -> Result<(), ValidationError> {
+        run.validate_stage_clock(
+            field,
+            self.stamp.source.clock,
+            self.stamp.source.epoch,
+            self.stamp.source.time_ns.value().copied(),
+            self.stamp.recorder_receive_ns,
+        )
+    }
+
+    pub(crate) fn validate_after(
+        &self,
+        previous: &Self,
+        field: &str,
+        has_clock_discontinuity: bool,
+    ) -> Result<(), ValidationError>
+    where
+        T: PartialEq,
+    {
+        let current = &self.stamp.source;
+        let prior = &previous.stamp.source;
+        if current.clock != prior.clock {
+            return invalid_stamp(field, "the source clock changes inside one run");
+        }
+        if current.epoch != prior.epoch {
+            return if has_clock_discontinuity {
+                Ok(())
+            } else {
+                invalid_stamp(
+                    field,
+                    "the source epoch changes without a clock discontinuity",
+                )
+            };
+        }
+        if has_clock_discontinuity {
+            return invalid_stamp(field, "a clock discontinuity must change the source epoch");
+        }
+        if current.sequence < prior.sequence {
+            return invalid_stamp(field, "the source sequence moves back in one epoch");
+        }
+        if current.sequence == prior.sequence
+            && (self.stamp != previous.stamp || self.observation != previous.observation)
+        {
+            return invalid_stamp(field, "one source sequence has different content");
+        }
+        if matches!(
+            (prior.time_ns.value(), current.time_ns.value()),
+            (Some(prior_ns), Some(current_ns)) if current_ns < prior_ns
+        ) {
+            return invalid_stamp(field, "the source time moves back in one epoch");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_predecessor_stage(
+        &self,
+        field: &str,
+        present_predecessor: Option<ControlStage>,
+    ) -> Result<(), ValidationError> {
+        let expected = self.observation.value().and(present_predecessor);
+        if self.stamp.predecessor.map(|event| event.stage) == expected {
+            return Ok(());
+        }
+        invalid_stamp(field, "the direct predecessor stage does not match")
+    }
+}
+
+impl StageStamp {
+    pub(crate) fn control_event_id(&self, stage: ControlStage) -> ControlEventId {
+        ControlEventId {
+            stage,
+            clock: self.source.clock,
+            epoch: self.source.epoch,
+            sequence: self.source.sequence,
+        }
+    }
+
+    fn validate(&self, field: &str, sample_recorder_ns: u64) -> Result<(), ValidationError> {
+        if self.recorder_receive_ns > self.recorder_apply_ns {
+            return invalid_stamp(field, "the recorder apply time is before the receive time");
+        }
+        if self.recorder_apply_ns > sample_recorder_ns {
+            return invalid_stamp(field, "the sample time is before the recorder apply time");
+        }
+        if self.source.clock == ClockDomain::Recorder {
+            if self.source.epoch != 0 {
+                return invalid_stamp(field, "the recorder clock epoch must be zero");
+            }
+            if self
+                .source
+                .time_ns
+                .value()
+                .is_some_and(|time_ns| *time_ns > self.recorder_receive_ns)
+            {
+                return invalid_stamp(field, "the recorder receive time is before the source time");
+            }
+        }
+        Ok(())
+    }
+}
+
+fn present_time(_value: &u64, _field: &str) -> Result<(), ValidationError> {
+    Ok(())
+}
+
+fn invalid_stamp(field: &str, reason: &'static str) -> Result<(), ValidationError> {
+    Err(ValidationError::InvalidStageStamp {
+        field: field.to_owned(),
+        reason,
+    })
+}

--- a/crates/pilotage-trial/src/sample/state.rs
+++ b/crates/pilotage-trial/src/sample/state.rs
@@ -1,0 +1,276 @@
+//! Vehicle, actuator, and environment state values.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    MAX_ACTUATOR_VALUES, MAX_CONDITION_VALUES, MAX_TEXT_BYTES, QUATERNION_NORM_TOLERANCE,
+    ValidationError,
+    validation::{count, finite, nonempty_count, optional_text, range, text},
+};
+
+use super::Observed;
+
+/// A three-component vector.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Vector3 {
+    /// The first component.
+    pub x: f64,
+    /// The second component.
+    pub y: f64,
+    /// The third component.
+    pub z: f64,
+}
+
+impl Vector3 {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        finite(&format!("{field}.x"), self.x)?;
+        finite(&format!("{field}.y"), self.y)?;
+        finite(&format!("{field}.z"), self.z)
+    }
+}
+
+/// A scalar-first attitude quaternion.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Quaternion {
+    /// The scalar component.
+    pub w: f64,
+    /// The first vector component.
+    pub x: f64,
+    /// The second vector component.
+    pub y: f64,
+    /// The third vector component.
+    pub z: f64,
+}
+
+impl Quaternion {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        finite(&format!("{field}.w"), self.w)?;
+        finite(&format!("{field}.x"), self.x)?;
+        finite(&format!("{field}.y"), self.y)?;
+        finite(&format!("{field}.z"), self.z)?;
+        let norm = (self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z).sqrt();
+        if (norm - 1.0).abs() <= QUATERNION_NORM_TOLERANCE {
+            return Ok(());
+        }
+        Err(ValidationError::InvalidQuaternionNorm {
+            field: field.to_owned(),
+            norm,
+            tolerance: QUATERNION_NORM_TOLERANCE,
+        })
+    }
+}
+
+/// Kinematic state in the local north-east-down and body frames.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KinematicState {
+    /// The local north-east-down position in meters.
+    pub position_m: Observed<Vector3>,
+    /// The local north-east-down velocity in meters per second.
+    pub velocity_mps: Observed<Vector3>,
+    /// The local north-east-down acceleration in meters per second squared.
+    pub acceleration_mps2: Observed<Vector3>,
+    /// The body attitude relative to the local north-east-down frame.
+    pub attitude: Observed<Quaternion>,
+    /// The body rates in radians per second.
+    pub body_rates_rad_s: Observed<Vector3>,
+}
+
+impl KinematicState {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        self.position_m
+            .validate_with(&format!("{field}.position_m"), Vector3::validate)?;
+        self.velocity_mps
+            .validate_with(&format!("{field}.velocity_mps"), Vector3::validate)?;
+        self.acceleration_mps2
+            .validate_with(&format!("{field}.acceleration_mps2"), Vector3::validate)?;
+        self.attitude
+            .validate_with(&format!("{field}.attitude"), Quaternion::validate)?;
+        self.body_rates_rad_s
+            .validate_with(&format!("{field}.body_rates_rad_s"), Vector3::validate)
+    }
+}
+
+/// Simulator truth that is permitted only in an evidence field.
+///
+/// This type is different from [`KinematicState`]. A command input cannot use
+/// simulator truth where it requires an estimate.
+///
+/// ```compile_fail
+/// use pilotage_trial::{KinematicState, SimulatorTruthEvidence};
+///
+/// fn use_estimate(_estimate: &KinematicState) {}
+/// fn reject_truth(truth: &SimulatorTruthEvidence) {
+///     use_estimate(truth);
+/// }
+/// ```
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SimulatorTruthEvidence {
+    /// The local north-east-down position in meters.
+    pub position_m: Observed<Vector3>,
+    /// The local north-east-down velocity in meters per second.
+    pub velocity_mps: Observed<Vector3>,
+    /// The local north-east-down acceleration in meters per second squared.
+    pub acceleration_mps2: Observed<Vector3>,
+    /// The body attitude relative to the local north-east-down frame.
+    pub attitude: Observed<Quaternion>,
+    /// The body rates in radians per second.
+    pub body_rates_rad_s: Observed<Vector3>,
+}
+
+impl SimulatorTruthEvidence {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        self.position_m
+            .validate_with(&format!("{field}.position_m"), Vector3::validate)?;
+        self.velocity_mps
+            .validate_with(&format!("{field}.velocity_mps"), Vector3::validate)?;
+        self.acceleration_mps2
+            .validate_with(&format!("{field}.acceleration_mps2"), Vector3::validate)?;
+        self.attitude
+            .validate_with(&format!("{field}.attitude"), Quaternion::validate)?;
+        self.body_rates_rad_s
+            .validate_with(&format!("{field}.body_rates_rad_s"), Vector3::validate)
+    }
+}
+
+/// Actuator effort and saturation data.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActuatorState {
+    /// The ordered actuator effort values.
+    pub values: Vec<f64>,
+    /// The actuator saturation state.
+    pub saturated: bool,
+}
+
+impl ActuatorState {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        nonempty_count(
+            &format!("{field}.values"),
+            self.values.len(),
+            MAX_ACTUATOR_VALUES,
+        )?;
+        for (index, value) in self.values.iter().enumerate() {
+            finite(&format!("{field}.values[{index}]"), *value)?;
+        }
+        Ok(())
+    }
+}
+
+/// One named scalar condition value.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NamedValue {
+    /// The stable value name.
+    pub name: String,
+    /// The measured value.
+    pub value: f64,
+}
+
+/// The measured environmental condition state.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConditionState {
+    /// The wind velocity in the local north-east-down frame.
+    pub wind_velocity_ned_mps: Observed<Vector3>,
+    /// The root mean square turbulence velocity.
+    pub turbulence_rms_mps: Observed<f64>,
+    /// Additional ordered condition values.
+    pub values: Vec<NamedValue>,
+}
+
+impl ConditionState {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        self.wind_velocity_ned_mps
+            .validate_with(&format!("{field}.wind_velocity_ned_mps"), Vector3::validate)?;
+        self.turbulence_rms_mps.validate_with(
+            &format!("{field}.turbulence_rms_mps"),
+            |value, value_field| range(value_field, *value, 0.0, f64::MAX),
+        )?;
+        count(
+            &format!("{field}.values"),
+            self.values.len(),
+            MAX_CONDITION_VALUES,
+        )?;
+        validate_named_values(field, &self.values)
+    }
+}
+
+/// A simulator lifecycle state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleState {
+    /// The backend is stopped.
+    Stopped,
+    /// The backend is resetting the trial.
+    Resetting,
+    /// The backend is waiting for state convergence.
+    Converging,
+    /// The backend is ready to start.
+    Ready,
+    /// The vehicle is armed.
+    Armed,
+    /// The vehicle is disarmed.
+    Disarmed,
+    /// The backend is stopping the trial.
+    Stopping,
+}
+
+/// Lifecycle and safety observations for one sample.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleObservation {
+    /// The lifecycle state.
+    pub state: LifecycleState,
+    /// The ground contact state.
+    pub ground_contact: bool,
+    /// The crash state.
+    pub crashed: bool,
+}
+
+impl LifecycleObservation {
+    pub(crate) const fn validate(&self, _field: &str) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+/// A validity state for a link or estimator.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HealthState {
+    /// The validity state.
+    pub valid: bool,
+    /// Additional bounded validity information.
+    pub detail: Option<String>,
+}
+
+impl HealthState {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        optional_text(
+            &format!("{field}.detail"),
+            self.detail.as_deref(),
+            MAX_TEXT_BYTES,
+        )
+    }
+}
+
+fn validate_named_values(field: &str, values: &[NamedValue]) -> Result<(), ValidationError> {
+    for (index, item) in values.iter().enumerate() {
+        text(
+            &format!("{field}.values[{index}].name"),
+            &item.name,
+            MAX_TEXT_BYTES,
+        )?;
+        finite(&format!("{field}.values[{index}].value"), item.value)?;
+        if values[..index].iter().any(|prior| prior.name == item.name) {
+            return Err(ValidationError::DuplicateItem {
+                field: format!("{field}.values.name"),
+                index,
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/pilotage-trial/src/sample/stream.rs
+++ b/crates/pilotage-trial/src/sample/stream.rs
@@ -1,0 +1,426 @@
+//! Stateful validation for a complete trial sample stream.
+
+use std::collections::VecDeque;
+
+use crate::{ClockDomain, CodecError, MAX_CONTROL_EVENT_HISTORY, RunIdentity, ValidationError};
+
+use super::{
+    CausalStage, ClockReading, ControlEventId, ControlStage, SourceStamp, StageStamp, TrialSample,
+};
+
+/// Stateful validation for all recorded samples in one run.
+///
+/// This validator rejects a definite causal order violation. Mapping overlap
+/// remains bounded evidence and does not prove an exact stage latency.
+#[derive(Clone, Debug)]
+pub struct TrialStreamValidator<'run> {
+    run: &'run RunIdentity,
+    previous: Option<TrialSample>,
+    sample_clocks: SampleClockHistory,
+    stage_times: StageTimeHistory,
+    control_lineage: ControlLineageHistory,
+    validated_samples: u64,
+}
+
+impl<'run> TrialStreamValidator<'run> {
+    /// Creates an empty validator for one validated run identity.
+    pub fn new(run: &'run RunIdentity) -> Result<Self, CodecError> {
+        run.validate()?;
+        Ok(Self {
+            run,
+            previous: None,
+            sample_clocks: SampleClockHistory::default(),
+            stage_times: StageTimeHistory::default(),
+            control_lineage: ControlLineageHistory::default(),
+            validated_samples: 0,
+        })
+    }
+
+    /// Gets the number of samples that this validator accepted.
+    #[must_use]
+    pub const fn validated_samples(&self) -> u64 {
+        self.validated_samples
+    }
+
+    /// Validates and records the next sample in one complete trace.
+    pub fn validate_next(&mut self, sample: &TrialSample) -> Result<(), CodecError> {
+        if let Some(previous) = &self.previous {
+            sample.validate_adjacent_only(previous, self.run)?;
+        } else {
+            sample.validate_for_run(self.run)?;
+        }
+        let mut sample_clocks = self.sample_clocks.clone();
+        let mut stage_times = self.stage_times.clone();
+        let mut control_lineage = self.control_lineage.clone();
+        sample_clocks.validate_and_record(sample)?;
+        stage_times.validate_and_record(sample)?;
+        control_lineage.validate_and_record(sample, self.run)?;
+        self.sample_clocks = sample_clocks;
+        self.stage_times = stage_times;
+        self.control_lineage = control_lineage;
+        self.previous = Some(sample.clone());
+        self.validated_samples = self.validated_samples.wrapping_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct SampleClockHistory {
+    device: ClockTraceState,
+    client: ClockTraceState,
+    adapter: ClockTraceState,
+    flight_controller: ClockTraceState,
+    simulator: ClockTraceState,
+}
+
+impl SampleClockHistory {
+    fn validate_and_record(&mut self, sample: &TrialSample) -> Result<(), ValidationError> {
+        self.device.observe(
+            "sample.time.device",
+            ClockDomain::Device,
+            sample.time.source_reading(ClockDomain::Device).copied(),
+            sample.time.has_discontinuity(ClockDomain::Device),
+        )?;
+        self.client.observe(
+            "sample.time.client",
+            ClockDomain::Client,
+            sample.time.source_reading(ClockDomain::Client).copied(),
+            sample.time.has_discontinuity(ClockDomain::Client),
+        )?;
+        self.adapter.observe(
+            "sample.time.adapter",
+            ClockDomain::Adapter,
+            sample.time.source_reading(ClockDomain::Adapter).copied(),
+            sample.time.has_discontinuity(ClockDomain::Adapter),
+        )?;
+        self.flight_controller.observe(
+            "sample.time.flight_controller",
+            ClockDomain::FlightController,
+            sample
+                .time
+                .source_reading(ClockDomain::FlightController)
+                .copied(),
+            sample.time.has_discontinuity(ClockDomain::FlightController),
+        )?;
+        self.simulator.observe(
+            "sample.time.simulator",
+            ClockDomain::Simulator,
+            sample.time.source_reading(ClockDomain::Simulator).copied(),
+            sample.time.has_discontinuity(ClockDomain::Simulator),
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ClockTraceState {
+    last_present: Option<ClockReading>,
+    discontinuity_pending: bool,
+}
+
+impl ClockTraceState {
+    fn observe(
+        &mut self,
+        field: &str,
+        domain: ClockDomain,
+        current: Option<ClockReading>,
+        has_discontinuity: bool,
+    ) -> Result<(), ValidationError> {
+        let Some(current) = current else {
+            if has_discontinuity && self.discontinuity_pending {
+                return invalid_clock(field, "a second discontinuity has no intervening reading");
+            }
+            self.discontinuity_pending |= has_discontinuity;
+            return Ok(());
+        };
+        if let Some(previous) = self.last_present {
+            self.validate_present(
+                field,
+                domain,
+                previous,
+                current,
+                has_discontinuity || self.discontinuity_pending,
+            )?;
+        }
+        self.last_present = Some(current);
+        self.discontinuity_pending = false;
+        Ok(())
+    }
+
+    fn validate_present(
+        &self,
+        field: &str,
+        domain: ClockDomain,
+        previous: ClockReading,
+        current: ClockReading,
+        has_discontinuity: bool,
+    ) -> Result<(), ValidationError> {
+        if previous.epoch == current.epoch && current.time_ns < previous.time_ns {
+            return Err(ValidationError::ClockRegression {
+                clock: format!("{domain:?}"),
+                previous_ns: previous.time_ns,
+                current_ns: current.time_ns,
+            });
+        }
+        if previous.epoch == current.epoch && has_discontinuity {
+            return invalid_clock(field, "a clock discontinuity must change the source epoch");
+        }
+        if previous.epoch != current.epoch && !has_discontinuity {
+            return invalid_clock(field, "a source epoch change needs a clock discontinuity");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct StageTimeHistory {
+    raw_input: StageTimeState,
+    normalized_control: StageTimeState,
+    typed_intent: StageTimeState,
+    adapter_demand: StageTimeState,
+    transmitted_setpoint: StageTimeState,
+    flight_controller_estimate: StageTimeState,
+    simulator_truth: StageTimeState,
+}
+
+impl StageTimeHistory {
+    fn validate_and_record(&mut self, sample: &TrialSample) -> Result<(), ValidationError> {
+        self.raw_input
+            .observe("sample.raw_input", &sample.raw_input.stamp.source)?;
+        self.normalized_control.observe(
+            "sample.normalized_control",
+            &sample.normalized_control.stamp.source,
+        )?;
+        self.typed_intent
+            .observe("sample.typed_intent", &sample.typed_intent.stamp.source)?;
+        self.adapter_demand
+            .observe("sample.adapter_demand", &sample.adapter_demand.stamp.source)?;
+        self.transmitted_setpoint.observe(
+            "sample.transmitted_setpoint",
+            &sample.transmitted_setpoint.stamp.source,
+        )?;
+        self.flight_controller_estimate.observe(
+            "sample.flight_controller_estimate",
+            &sample.flight_controller_estimate.stamp.source,
+        )?;
+        self.simulator_truth.observe(
+            "sample.simulator_truth",
+            &sample.simulator_truth.stamp.source,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct StageTimeState {
+    last_present: Option<StageTimePoint>,
+}
+
+impl StageTimeState {
+    fn observe(&mut self, field: &str, source: &SourceStamp) -> Result<(), ValidationError> {
+        let Some(time_ns) = source.time_ns.value().copied() else {
+            return Ok(());
+        };
+        let current = StageTimePoint {
+            clock: source.clock,
+            epoch: source.epoch,
+            time_ns,
+        };
+        if let Some(previous) = self.last_present
+            && previous.clock == current.clock
+            && previous.epoch == current.epoch
+            && current.time_ns < previous.time_ns
+        {
+            return invalid_stage(field, "the source time moves back after a missing record");
+        }
+        self.last_present = Some(current);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct StageTimePoint {
+    clock: ClockDomain,
+    epoch: u64,
+    time_ns: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ControlLineageHistory {
+    raw_input: EventHistory,
+    normalized_control: EventHistory,
+    typed_intent: EventHistory,
+    adapter_demand: EventHistory,
+}
+
+impl ControlLineageHistory {
+    fn validate_and_record(
+        &mut self,
+        sample: &TrialSample,
+        run: &RunIdentity,
+    ) -> Result<(), ValidationError> {
+        self.raw_input.record(
+            ControlStage::RawInput,
+            &sample.raw_input,
+            "sample.raw_input",
+        )?;
+        self.raw_input
+            .consume(&sample.normalized_control, "sample.normalized_control", run)?;
+        self.raw_input.validate_limit("sample.normalized_control")?;
+        self.normalized_control.record(
+            ControlStage::NormalizedControl,
+            &sample.normalized_control,
+            "sample.normalized_control",
+        )?;
+        self.normalized_control
+            .consume(&sample.typed_intent, "sample.typed_intent", run)?;
+        self.normalized_control
+            .validate_limit("sample.typed_intent")?;
+        self.typed_intent.record(
+            ControlStage::TypedIntent,
+            &sample.typed_intent,
+            "sample.typed_intent",
+        )?;
+        self.typed_intent
+            .consume(&sample.adapter_demand, "sample.adapter_demand", run)?;
+        self.typed_intent.validate_limit("sample.adapter_demand")?;
+        self.adapter_demand.record(
+            ControlStage::AdapterDemand,
+            &sample.adapter_demand,
+            "sample.adapter_demand",
+        )?;
+        self.adapter_demand.consume(
+            &sample.transmitted_setpoint,
+            "sample.transmitted_setpoint",
+            run,
+        )?;
+        self.adapter_demand
+            .validate_limit("sample.transmitted_setpoint")
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct EventHistory {
+    events: VecDeque<EventRecord>,
+}
+
+impl EventHistory {
+    fn record<T>(
+        &mut self,
+        stage: ControlStage,
+        event: &CausalStage<T>,
+        field: &str,
+    ) -> Result<(), ValidationError> {
+        if event.value().is_none() {
+            return Ok(());
+        }
+        let id = event.stamp.control_event_id(stage);
+        if let Some(existing) = self.events.iter().find(|record| record.id == id) {
+            return if existing.stamp == event.stamp {
+                Ok(())
+            } else {
+                invalid_stage(field, "one control event has different stamps")
+            };
+        }
+        self.events.push_back(EventRecord {
+            id,
+            stamp: event.stamp.clone(),
+        });
+        Ok(())
+    }
+
+    fn consume<T>(
+        &mut self,
+        current: &CausalStage<T>,
+        field: &str,
+        run: &RunIdentity,
+    ) -> Result<(), ValidationError> {
+        if current.value().is_none() {
+            return Ok(());
+        }
+        let Some(predecessor_id) = current.stamp.predecessor else {
+            return invalid_stage(field, "the control event has no predecessor identity");
+        };
+        let Some(position) = self
+            .events
+            .iter()
+            .position(|record| record.id == predecessor_id)
+        else {
+            return Err(ValidationError::UnknownControlPredecessor {
+                field: field.to_owned(),
+                stage: format!("{:?}", predecessor_id.stage),
+                clock: format!("{:?}", predecessor_id.clock),
+                epoch: predecessor_id.epoch,
+                sequence: predecessor_id.sequence,
+            });
+        };
+        let predecessor = self.events[position].stamp.clone();
+        validate_event_order(&predecessor, &current.stamp, field, run)?;
+        let retained = self.events.split_off(position);
+        self.events = retained;
+        Ok(())
+    }
+
+    fn validate_limit(&self, field: &str) -> Result<(), ValidationError> {
+        if self.events.len() <= MAX_CONTROL_EVENT_HISTORY {
+            return Ok(());
+        }
+        Err(ValidationError::TooManyItems {
+            field: format!("{field}.unconsumed_predecessors"),
+            count: self.events.len(),
+            limit: MAX_CONTROL_EVENT_HISTORY,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EventRecord {
+    id: ControlEventId,
+    stamp: StageStamp,
+}
+
+fn validate_event_order(
+    predecessor: &StageStamp,
+    current: &StageStamp,
+    field: &str,
+    run: &RunIdentity,
+) -> Result<(), ValidationError> {
+    let Some(predecessor_ns) = predecessor.source.time_ns.value().copied() else {
+        return Ok(());
+    };
+    let Some(current_ns) = current.source.time_ns.value().copied() else {
+        return Ok(());
+    };
+    let predecessor_time = run.map_clock_time(
+        field,
+        predecessor.source.clock,
+        predecessor.source.epoch,
+        predecessor_ns,
+    )?;
+    let current_time = run.map_clock_time(
+        field,
+        current.source.clock,
+        current.source.epoch,
+        current_ns,
+    )?;
+    if current_time.latest_ns < predecessor_time.earliest_ns {
+        return Err(ValidationError::CausalMappedSourceOrder {
+            field: field.to_owned(),
+            predecessor_earliest_ns: predecessor_time.earliest_ns,
+            current_latest_ns: current_time.latest_ns,
+        });
+    }
+    Ok(())
+}
+
+fn invalid_clock<T>(field: &str, reason: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::InvalidClockObservation {
+        field: field.to_owned(),
+        reason,
+    })
+}
+
+fn invalid_stage<T>(field: &str, reason: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::InvalidStageStamp {
+        field: field.to_owned(),
+        reason,
+    })
+}

--- a/crates/pilotage-trial/src/sample/tests.rs
+++ b/crates/pilotage-trial/src/sample/tests.rs
@@ -1,0 +1,423 @@
+use std::any::TypeId;
+
+use super::{
+    ActuatorState, AdapterDisposition, CausalStage, ClockReading, ConditionState, ControlAxes,
+    ControlEventId, ControlStage, ControlValue, HealthState, KinematicState, LifecycleObservation,
+    LifecycleState, Observed, Quaternion, RawInput, SampleTime, SimulatorTruthEvidence,
+    SourceStamp, StageProducerRole, StageStamp, TrialSample, TrialStreamValidator, Vector3,
+};
+use crate::{
+    ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, CodecError, Digest,
+    MAX_SAMPLE_BYTES, RUN_IDENTITY_SCHEMA_VERSION, RunIdentity, ScenarioIdentity,
+    TRIAL_SAMPLE_SCHEMA_VERSION, ValidationError,
+};
+
+mod clock;
+mod stream;
+
+fn digest(value: u8) -> Digest {
+    Digest::from_bytes([value; 32])
+}
+
+fn artifact(id: &str, value: u8) -> ArtifactIdentity {
+    ArtifactIdentity {
+        id: id.to_owned(),
+        revision: "1".to_owned(),
+        digest: digest(value),
+    }
+}
+
+fn mapping(from: ClockDomain) -> ClockMapping {
+    ClockMapping {
+        from,
+        to: ClockDomain::Recorder,
+        source_epoch: 7,
+        source_anchor_ns: 10,
+        recorder_anchor_ns: 20,
+        rate_numerator: 1,
+        rate_denominator: 1,
+        valid_from_source_ns: 0,
+        valid_until_source_ns: 1_000,
+        uncertainty_ns: 1,
+        quality: ClockMappingQuality::Estimated,
+    }
+}
+
+fn run_identity() -> RunIdentity {
+    RunIdentity {
+        schema_version: RUN_IDENTITY_SCHEMA_VERSION,
+        run_id: "run-1".to_owned(),
+        code_build: artifact("code", 1),
+        vehicle_adapter: artifact("adapter", 2),
+        adapter_capabilities_digest: digest(3),
+        backend_capabilities_digest: digest(4),
+        device_profile: artifact("device", 5),
+        control_scheme: artifact("scheme", 6),
+        control_feel_candidate: artifact("feel", 7),
+        flight_controller_candidate: artifact("controller", 8),
+        simulator_backend: artifact("backend", 9),
+        simulator: artifact("simulator", 10),
+        vehicle_model: artifact("model", 11),
+        condition_set: artifact("conditions", 12),
+        scenario: ScenarioIdentity {
+            id: "scenario".to_owned(),
+            revision: 1,
+            digest: digest(13),
+        },
+        seed: 14,
+        repetition: 0,
+        clock_mappings: [
+            ClockDomain::Device,
+            ClockDomain::Client,
+            ClockDomain::Adapter,
+            ClockDomain::FlightController,
+            ClockDomain::Simulator,
+        ]
+        .map(mapping)
+        .into(),
+    }
+}
+
+fn stage<T>(
+    producer: StageProducerRole,
+    clock: ClockDomain,
+    sequence: u64,
+    predecessor: Option<ControlEventId>,
+    value: T,
+) -> CausalStage<T> {
+    let offset = sequence.saturating_sub(1).saturating_mul(2);
+    let source_time_ns = 10_u64.saturating_add(offset);
+    let recorder_event_ns = 21_u64.saturating_add(offset);
+    CausalStage::present(
+        StageStamp {
+            source: SourceStamp {
+                producer,
+                clock,
+                epoch: 7,
+                sequence,
+                time_ns: Observed::present(source_time_ns),
+            },
+            predecessor,
+            recorder_receive_ns: recorder_event_ns,
+            recorder_apply_ns: recorder_event_ns,
+        },
+        value,
+    )
+}
+
+fn event(stage: ControlStage, clock: ClockDomain, sequence: u64) -> ControlEventId {
+    ControlEventId {
+        stage,
+        clock,
+        epoch: 7,
+        sequence,
+    }
+}
+
+fn raw_input_stage() -> CausalStage<RawInput> {
+    stage(
+        StageProducerRole::InputCapture,
+        ClockDomain::Device,
+        1,
+        None,
+        RawInput {
+            axes: vec![0.1],
+            buttons: vec![false],
+        },
+    )
+}
+
+fn vector() -> Vector3 {
+    Vector3 {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    }
+}
+
+fn kinematic_state() -> KinematicState {
+    KinematicState {
+        position_m: Observed::present(vector()),
+        velocity_mps: Observed::present(vector()),
+        acceleration_mps2: Observed::present(vector()),
+        attitude: Observed::present(Quaternion {
+            w: 1.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }),
+        body_rates_rad_s: Observed::present(vector()),
+    }
+}
+
+fn simulator_truth() -> SimulatorTruthEvidence {
+    SimulatorTruthEvidence {
+        position_m: Observed::present(vector()),
+        velocity_mps: Observed::present(vector()),
+        acceleration_mps2: Observed::present(vector()),
+        attitude: Observed::present(Quaternion {
+            w: 1.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }),
+        body_rates_rad_s: Observed::present(vector()),
+    }
+}
+
+fn sample(run: &RunIdentity) -> TrialSample {
+    let axes = ControlAxes {
+        roll: 0.1,
+        pitch: 0.2,
+        vertical: 0.3,
+        yaw: 0.4,
+    };
+    TrialSample {
+        schema_version: TRIAL_SAMPLE_SCHEMA_VERSION,
+        run_digest: run.canonical_digest().expect("run identity digest"),
+        sequence: 1,
+        dropped_before: 0,
+        phase_index: 0,
+        time: sample_time(),
+        raw_input: raw_input_stage(),
+        normalized_control: stage(
+            StageProducerRole::ControlClient,
+            ClockDomain::Client,
+            2,
+            Some(event(ControlStage::RawInput, ClockDomain::Device, 1)),
+            axes.clone(),
+        ),
+        typed_intent: stage(
+            StageProducerRole::ControlClient,
+            ClockDomain::Client,
+            3,
+            Some(event(
+                ControlStage::NormalizedControl,
+                ClockDomain::Client,
+                2,
+            )),
+            ControlValue::Axes { axes: axes.clone() },
+        ),
+        adapter_demand: stage(
+            StageProducerRole::ControlClient,
+            ClockDomain::Client,
+            4,
+            Some(event(ControlStage::TypedIntent, ClockDomain::Client, 3)),
+            ControlValue::Axes { axes: axes.clone() },
+        ),
+        transmitted_setpoint: stage(
+            StageProducerRole::VehicleAdapter,
+            ClockDomain::Adapter,
+            5,
+            Some(event(ControlStage::AdapterDemand, ClockDomain::Client, 4)),
+            ControlValue::Axes { axes },
+        ),
+        flight_controller_estimate: stage(
+            StageProducerRole::FlightController,
+            ClockDomain::FlightController,
+            6,
+            None,
+            kinematic_state(),
+        ),
+        simulator_truth: stage(
+            StageProducerRole::SimulatorBackend,
+            ClockDomain::Simulator,
+            7,
+            None,
+            simulator_truth(),
+        ),
+        actuator: Observed::present(ActuatorState {
+            values: vec![0.2],
+            saturated: false,
+        }),
+        adapter_disposition: Observed::present(AdapterDisposition::Accepted),
+        lifecycle: Observed::present(LifecycleObservation {
+            state: LifecycleState::Armed,
+            ground_contact: false,
+            crashed: false,
+        }),
+        condition_state: Observed::present(condition_state(0.1)),
+        link_state: Observed::present(health()),
+        estimator_state: Observed::present(health()),
+    }
+}
+
+fn sample_time() -> SampleTime {
+    SampleTime {
+        recorder_monotonic_ns: 40,
+        device: clock_reading(30),
+        client: clock_reading(30),
+        adapter: clock_reading(30),
+        flight_controller: clock_reading(30),
+        simulator: clock_reading(30),
+        clock_discontinuities: Vec::new(),
+    }
+}
+
+fn clock_reading(time_ns: u64) -> Observed<ClockReading> {
+    Observed::present(ClockReading { epoch: 7, time_ns })
+}
+
+fn condition_state(turbulence_rms_mps: f64) -> ConditionState {
+    ConditionState {
+        wind_velocity_ned_mps: Observed::present(vector()),
+        turbulence_rms_mps: Observed::present(turbulence_rms_mps),
+        values: Vec::new(),
+    }
+}
+
+fn health() -> HealthState {
+    HealthState {
+        valid: true,
+        detail: None,
+    }
+}
+
+#[test]
+fn sample_verifies_the_public_run_identity_digest() {
+    let run = run_identity();
+    let sample = sample(&run);
+    let bytes = sample
+        .to_canonical_json_for_run(&run)
+        .expect("canonical sample");
+
+    assert_eq!(
+        TrialSample::from_json_for_run(&bytes, &run).expect("sample for run"),
+        sample
+    );
+}
+
+#[test]
+fn sample_rejects_a_changed_run_identity() {
+    let run = run_identity();
+    let sample = sample(&run);
+    let mut changed_run = run;
+    changed_run.seed = changed_run.seed.wrapping_add(1);
+
+    assert!(matches!(
+        sample.validate_for_run(&changed_run),
+        Err(CodecError::Validation(ValidationError::IdentityMismatch { field }))
+            if field == "sample.run_digest"
+    ));
+}
+
+#[test]
+fn adjacent_samples_reject_mixed_run_identities() {
+    let run = run_identity();
+    let previous = sample(&run);
+    let mut changed_run = run.clone();
+    changed_run.seed = changed_run.seed.wrapping_add(1);
+    let mut current = sample(&changed_run);
+    current.sequence = 2;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::MixedRun))
+    ));
+}
+
+#[test]
+fn adjacent_samples_reject_an_undeclared_sequence_gap() {
+    let run = run_identity();
+    let mut previous = sample(&run);
+    previous.sequence = 7;
+    let mut current = sample(&run);
+    current.sequence = 9;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::SequenceGap {
+            expected: 8,
+            actual: 9,
+        }))
+    ));
+}
+
+#[test]
+fn adjacent_samples_accept_an_exact_declared_loss() {
+    let run = run_identity();
+    let mut previous = sample(&run);
+    previous.sequence = 7;
+    let mut current = sample(&run);
+    current.sequence = 9;
+    current.dropped_before = 1;
+
+    assert!(current.validate_after(&previous, &run).is_ok());
+}
+
+#[test]
+fn simulator_truth_has_a_distinct_evidence_type() {
+    assert_ne!(
+        TypeId::of::<KinematicState>(),
+        TypeId::of::<SimulatorTruthEvidence>()
+    );
+}
+
+#[test]
+fn negative_turbulence_rms_is_rejected() {
+    assert!(matches!(
+        condition_state(-0.1).validate("condition"),
+        Err(ValidationError::OutOfRange { field, .. })
+            if field == "condition.turbulence_rms_mps"
+    ));
+}
+
+#[test]
+fn non_unit_quaternion_is_rejected() {
+    let quaternion = Quaternion {
+        w: 0.0,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+
+    assert!(matches!(
+        quaternion.validate("attitude"),
+        Err(ValidationError::InvalidQuaternionNorm { field, .. }) if field == "attitude"
+    ));
+}
+
+#[test]
+fn quaternion_accepts_a_small_norm_error() {
+    let quaternion = Quaternion {
+        w: 1.000_5,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+
+    assert_eq!(quaternion.validate("attitude"), Ok(()));
+}
+
+#[test]
+fn sample_decode_rejects_an_unknown_field() {
+    let run = run_identity();
+    let mut value = serde_json::to_value(sample(&run)).expect("sample value");
+    value
+        .as_object_mut()
+        .expect("sample object")
+        .insert("unknown".to_owned(), serde_json::Value::Bool(true));
+    let bytes = serde_json::to_vec(&value).expect("sample JSON");
+
+    assert!(matches!(
+        TrialSample::from_json_for_run(&bytes, &run),
+        Err(CodecError::Decode {
+            document: "trial sample",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn sample_size_limit_applies_before_decode() {
+    let run = run_identity();
+    let bytes = vec![b' '; MAX_SAMPLE_BYTES + 1];
+
+    assert!(matches!(
+        TrialSample::from_json_for_run(&bytes, &run),
+        Err(CodecError::DocumentTooLarge {
+            document: "trial sample",
+            ..
+        })
+    ));
+}

--- a/crates/pilotage-trial/src/sample/tests/clock.rs
+++ b/crates/pilotage-trial/src/sample/tests/clock.rs
@@ -1,0 +1,356 @@
+use super::*;
+
+#[test]
+fn same_epoch_clock_regression_rejects_a_discontinuity_record() {
+    let run = run_identity();
+    let previous = sample(&run);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.time.simulator = clock_reading(29);
+    current
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Simulator);
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(
+            ValidationError::ClockRegression { .. }
+        ))
+    ));
+}
+
+#[test]
+fn clock_epoch_change_requires_a_discontinuity_and_mapping() {
+    let mut run = run_identity();
+    let mut next_epoch = mapping(ClockDomain::Simulator);
+    next_epoch.source_epoch = 8;
+    next_epoch.source_anchor_ns = 30;
+    next_epoch.recorder_anchor_ns = 40;
+    run.clock_mappings.push(next_epoch);
+    let previous = sample(&run);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.time.simulator = Observed::present(ClockReading {
+        epoch: 8,
+        time_ns: 30,
+    });
+    current.simulator_truth.stamp.source.epoch = 8;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(
+            ValidationError::InvalidClockObservation { .. }
+        ))
+    ));
+    current
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Simulator);
+    assert!(current.validate_after(&previous, &run).is_ok());
+}
+
+#[test]
+fn recorder_clock_rejects_a_discontinuity_marker() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Recorder);
+
+    assert!(matches!(
+        sample.validate_local(),
+        Err(ValidationError::InvalidClockObservation { .. })
+    ));
+}
+
+#[test]
+fn public_clock_accessor_preserves_the_epoch() {
+    let run = run_identity();
+    let value = sample(&run);
+
+    assert_eq!(
+        value.time.reading(ClockDomain::Simulator),
+        Some(ClockReading {
+            epoch: 7,
+            time_ns: 30,
+        })
+    );
+    assert_eq!(
+        value.time.reading(ClockDomain::Recorder),
+        Some(ClockReading {
+            epoch: 0,
+            time_ns: 40,
+        })
+    );
+}
+
+#[test]
+fn causal_stage_rejects_receive_apply_reversal() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.raw_input.stamp.recorder_apply_ns = 19;
+
+    assert!(matches!(
+        sample.validate_local(),
+        Err(ValidationError::InvalidStageStamp { field, .. }) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn causal_stage_rejects_an_unexpected_producer_role() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.simulator_truth.stamp.source.producer = StageProducerRole::ControlClient;
+
+    assert!(matches!(
+        sample.validate_local(),
+        Err(ValidationError::InvalidStageStamp { field, .. })
+            if field == "sample.simulator_truth"
+    ));
+}
+
+#[test]
+fn causal_stage_rejects_a_mapped_source_time_after_receive() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.raw_input.stamp.source.time_ns = Observed::present(12);
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn causal_stage_rejects_a_source_sequence_regression() {
+    let run = run_identity();
+    let mut previous = sample(&run);
+    previous.raw_input.stamp.source.sequence = 5;
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.raw_input.stamp.source.sequence = 4;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn one_source_sequence_cannot_change_its_observation() {
+    let run = run_identity();
+    let previous = sample(&run);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.raw_input.observation = Observed::present(RawInput {
+        axes: vec![0.9],
+        buttons: vec![false],
+    });
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn one_source_sequence_cannot_change_its_event_times() {
+    let run = run_identity();
+    let previous = sample(&run);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.raw_input.stamp.recorder_receive_ns = 22;
+    current.raw_input.stamp.recorder_apply_ns = 31;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn causal_stage_source_clock_cannot_change_inside_one_run() {
+    let run = run_identity();
+    let previous = sample(&run);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.raw_input.stamp.source.clock = ClockDomain::Simulator;
+    current.raw_input.stamp.source.time_ns = Observed::present(10);
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn causal_stage_discontinuity_must_change_the_epoch() {
+    let run = run_identity();
+    let mut previous = sample(&run);
+    previous.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    current.time.clock_discontinuities.push(ClockDomain::Device);
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn causal_stage_epoch_change_requires_a_discontinuity() {
+    let mut run = run_identity();
+    let mut next_epoch = mapping(ClockDomain::Device);
+    next_epoch.source_epoch = 8;
+    run.clock_mappings.push(next_epoch);
+    let mut previous = sample(&run);
+    previous.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    let mut current = sample(&run);
+    current.sequence = 2;
+    current.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    current.raw_input.stamp.source.epoch = 8;
+
+    assert!(matches!(
+        current.validate_after(&previous, &run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+    current.time.clock_discontinuities.push(ClockDomain::Device);
+    assert!(current.validate_after(&previous, &run).is_ok());
+}
+
+#[test]
+fn present_stage_can_record_a_missing_source_time_without_a_fake_mapping() {
+    let mut run = run_identity();
+    run.clock_mappings
+        .retain(|mapping| mapping.from != ClockDomain::Device);
+    let mut sample = sample(&run);
+    sample.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    sample.raw_input.stamp.source.time_ns = Observed::missing(
+        crate::MissingReason::NotPublished,
+        Some("device time was not published".to_owned()),
+    );
+
+    assert!(sample.validate_for_run(&run).is_ok());
+}
+
+#[test]
+fn present_sample_clock_requires_its_epoch_mapping() {
+    let mut run = run_identity();
+    run.clock_mappings
+        .retain(|mapping| mapping.from != ClockDomain::Simulator);
+    let sample = sample(&run);
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::MissingClockMapping {
+            field,
+            ..
+        })) if field == "sample.time.simulator"
+    ));
+}
+
+#[test]
+fn sample_clock_must_map_to_the_recorder_sample_time() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.time.simulator = clock_reading(28);
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(
+            ValidationError::InvalidClockObservation { field, .. }
+        )) if field == "sample.time.simulator"
+    ));
+}
+
+#[test]
+fn missing_stage_can_record_a_missing_source_time() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    let mut stamp = sample.raw_input.stamp.clone();
+    stamp.source.time_ns = Observed::missing(crate::MissingReason::NotPublished, None);
+    sample.raw_input = CausalStage::missing(
+        stamp,
+        crate::MissingReason::NotPublished,
+        Some("the device did not publish a report".to_owned()),
+    );
+
+    assert!(sample.validate_for_run(&run).is_ok());
+}
+
+#[test]
+fn present_stage_requires_its_exact_clock_epoch() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.raw_input.stamp.source.epoch = 8;
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::MissingClockMapping {
+            field,
+            epoch: 8,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn present_stage_rejects_time_outside_the_mapping_interval() {
+    let run = run_identity();
+    let mut sample = sample(&run);
+    sample.raw_input.stamp.source.time_ns = Observed::present(1_001);
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::ClockTimeOutsideMapping {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn present_stage_rejects_an_unusable_mapping() {
+    let mut run = run_identity();
+    let device_mapping = run
+        .clock_mappings
+        .iter_mut()
+        .find(|mapping| mapping.from == ClockDomain::Device)
+        .expect("device mapping");
+    device_mapping.quality = ClockMappingQuality::Unusable;
+    let mut sample = sample(&run);
+    sample.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+
+    assert!(matches!(
+        sample.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::UnusableClockMapping {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}

--- a/crates/pilotage-trial/src/sample/tests/stream.rs
+++ b/crates/pilotage-trial/src/sample/tests/stream.rs
@@ -1,0 +1,452 @@
+use super::*;
+
+fn stream<'run>(run: &'run RunIdentity) -> TrialStreamValidator<'run> {
+    TrialStreamValidator::new(run).expect("validated stream")
+}
+
+fn next_sample(run: &RunIdentity, sequence: u64) -> TrialSample {
+    let mut value = sample(run);
+    value.sequence = sequence;
+    value
+}
+
+fn missing<T>(stage: &mut CausalStage<T>) {
+    stage.stamp.predecessor = None;
+    stage.observation = Observed::missing(crate::MissingReason::NotPublished, None);
+}
+
+fn make_control_tail_missing(value: &mut TrialSample) {
+    missing(&mut value.normalized_control);
+    missing(&mut value.typed_intent);
+    missing(&mut value.adapter_demand);
+    missing(&mut value.transmitted_setpoint);
+}
+
+fn add_epoch(run: &mut RunIdentity, domain: ClockDomain, epoch: u64) {
+    let mut value = mapping(domain);
+    value.source_epoch = epoch;
+    run.clock_mappings.push(value);
+}
+
+#[test]
+fn complete_stream_accepts_one_correlated_sample() {
+    let run = run_identity();
+    let value = sample(&run);
+    let mut validator = stream(&run);
+
+    assert!(validator.validate_next(&value).is_ok());
+    assert_eq!(validator.validated_samples(), 1);
+}
+
+#[test]
+fn single_sample_rejects_the_wrong_predecessor_stage() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    value
+        .normalized_control
+        .stamp
+        .predecessor
+        .as_mut()
+        .expect("predecessor")
+        .stage = ControlStage::TypedIntent;
+
+    assert!(matches!(
+        value.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.normalized_control"
+    ));
+}
+
+#[test]
+fn stream_rejects_an_unknown_predecessor_event() {
+    let run = run_identity();
+    let source = event(ControlStage::RawInput, ClockDomain::Device, 1);
+    let unknown = [
+        ControlEventId {
+            clock: ClockDomain::Simulator,
+            ..source
+        },
+        ControlEventId { epoch: 8, ..source },
+        ControlEventId {
+            sequence: 99,
+            ..source
+        },
+    ];
+
+    for predecessor in unknown {
+        let mut value = sample(&run);
+        value.normalized_control.stamp.predecessor = Some(predecessor);
+        let mut validator = stream(&run);
+        assert!(matches!(
+            validator.validate_next(&value),
+            Err(CodecError::Validation(
+                ValidationError::UnknownControlPredecessor { field, .. }
+            )) if field == "sample.normalized_control"
+        ));
+        assert_eq!(validator.validated_samples(), 0);
+    }
+}
+
+#[test]
+fn present_derived_event_requires_a_predecessor() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    value.normalized_control.stamp.predecessor = None;
+
+    assert!(matches!(
+        value.validate_for_run(&run),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.normalized_control"
+    ));
+}
+
+#[test]
+fn nonderived_stages_cannot_claim_a_control_predecessor() {
+    let run = run_identity();
+    let predecessor = Some(event(ControlStage::RawInput, ClockDomain::Device, 1));
+    for field in [
+        "sample.raw_input",
+        "sample.flight_controller_estimate",
+        "sample.simulator_truth",
+    ] {
+        let mut value = sample(&run);
+        match field {
+            "sample.raw_input" => value.raw_input.stamp.predecessor = predecessor,
+            "sample.flight_controller_estimate" => {
+                value.flight_controller_estimate.stamp.predecessor = predecessor;
+            }
+            _ => value.simulator_truth.stamp.predecessor = predecessor,
+        }
+        assert!(matches!(
+            value.validate_for_run(&run),
+            Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+                field: actual,
+                ..
+            })) if actual == field
+        ));
+    }
+}
+
+#[test]
+fn pipeline_lag_can_reference_a_prior_raw_event() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut second = next_sample(&run, 2);
+    second.raw_input.stamp.source.sequence = 2;
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    assert!(validator.validate_next(&second).is_ok());
+}
+
+#[test]
+fn explicit_missing_control_stages_are_valid_stream_records() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    make_control_tail_missing(&mut value);
+    let mut validator = stream(&run);
+
+    assert!(validator.validate_next(&value).is_ok());
+}
+
+#[test]
+fn a_present_stage_cannot_reference_a_missing_upstream_event() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    missing(&mut value.raw_input);
+    let mut validator = stream(&run);
+
+    assert!(matches!(
+        validator.validate_next(&value),
+        Err(CodecError::Validation(ValidationError::UnknownControlPredecessor {
+            field,
+            ..
+        })) if field == "sample.normalized_control"
+    ));
+}
+
+#[test]
+fn recorder_observation_order_does_not_replace_source_lineage() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    value.raw_input.stamp.recorder_apply_ns = 24;
+    let mut validator = stream(&run);
+
+    assert!(validator.validate_next(&value).is_ok());
+}
+
+#[test]
+fn mapped_event_time_cannot_be_definitely_before_the_predecessor() {
+    let run = run_identity();
+    let mut value = sample(&run);
+    value.raw_input.stamp.source.time_ns = Observed::present(15);
+    value.raw_input.stamp.recorder_receive_ns = 26;
+    value.raw_input.stamp.recorder_apply_ns = 26;
+    value.normalized_control.stamp.recorder_receive_ns = 30;
+    value.normalized_control.stamp.recorder_apply_ns = 30;
+    let mut validator = stream(&run);
+
+    assert!(matches!(
+        validator.validate_next(&value),
+        Err(CodecError::Validation(ValidationError::CausalMappedSourceOrder {
+            field,
+            ..
+        })) if field == "sample.normalized_control"
+    ));
+}
+
+#[test]
+fn overlapping_mapped_intervals_remain_valid_bounded_evidence() {
+    let run = run_identity();
+    let value = sample(&run);
+    let mut validator = stream(&run);
+
+    assert!(validator.validate_next(&value).is_ok());
+}
+
+#[test]
+fn stage_time_regression_after_a_missing_record_is_rejected() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut missing_time = next_sample(&run, 2);
+    missing_time.raw_input.stamp.source.sequence = 2;
+    missing_time.raw_input.stamp.source.time_ns =
+        Observed::missing(crate::MissingReason::NotPublished, None);
+    let mut regression = next_sample(&run, 3);
+    regression.raw_input.stamp.source.sequence = 3;
+    regression.raw_input.stamp.source.time_ns = Observed::present(5);
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    validator
+        .validate_next(&missing_time)
+        .expect("missing source time");
+    assert!(matches!(
+        validator.validate_next(&regression),
+        Err(CodecError::Validation(ValidationError::InvalidStageStamp {
+            field,
+            ..
+        })) if field == "sample.raw_input"
+    ));
+}
+
+#[test]
+fn stage_time_can_resume_forward_after_a_missing_record() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut missing_time = next_sample(&run, 2);
+    missing_time.raw_input.stamp.source.sequence = 2;
+    missing_time.raw_input.stamp.source.time_ns =
+        Observed::missing(crate::MissingReason::NotPublished, None);
+    let mut resumed = next_sample(&run, 3);
+    resumed.raw_input.stamp.source.sequence = 3;
+    resumed.raw_input.stamp.source.time_ns = Observed::present(11);
+    resumed.raw_input.stamp.recorder_receive_ns = 22;
+    resumed.raw_input.stamp.recorder_apply_ns = 22;
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    validator
+        .validate_next(&missing_time)
+        .expect("missing source time");
+    assert!(validator.validate_next(&resumed).is_ok());
+}
+
+#[test]
+fn sample_clock_regression_after_a_missing_reading_is_rejected() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut missing_time = next_sample(&run, 2);
+    missing_time.time.device = Observed::missing(crate::MissingReason::NotPublished, None);
+    let mut regression = next_sample(&run, 3);
+    regression.time.device = clock_reading(29);
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    validator
+        .validate_next(&missing_time)
+        .expect("missing clock reading");
+    assert!(matches!(
+        validator.validate_next(&regression),
+        Err(CodecError::Validation(
+            ValidationError::ClockRegression { .. }
+        ))
+    ));
+}
+
+#[test]
+fn pending_discontinuity_accepts_a_new_epoch_after_missing() {
+    let mut run = run_identity();
+    add_epoch(&mut run, ClockDomain::Simulator, 8);
+    let first = sample(&run);
+    let mut discontinuity = next_sample(&run, 2);
+    discontinuity.time.simulator =
+        Observed::missing(crate::MissingReason::ClockDiscontinuity, None);
+    discontinuity
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Simulator);
+    discontinuity.simulator_truth.stamp.source.epoch = 8;
+    let mut resumed = discontinuity.clone();
+    resumed.sequence = 3;
+    resumed.time.simulator = Observed::present(ClockReading {
+        epoch: 8,
+        time_ns: 30,
+    });
+    resumed.time.clock_discontinuities.clear();
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    validator
+        .validate_next(&discontinuity)
+        .expect("discontinuity sample");
+    assert!(validator.validate_next(&resumed).is_ok());
+}
+
+#[test]
+fn pending_discontinuity_rejects_a_return_to_the_same_epoch() {
+    let mut run = run_identity();
+    add_epoch(&mut run, ClockDomain::Simulator, 8);
+    let first = sample(&run);
+    let mut discontinuity = next_sample(&run, 2);
+    discontinuity.time.simulator =
+        Observed::missing(crate::MissingReason::ClockDiscontinuity, None);
+    discontinuity
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Simulator);
+    discontinuity.simulator_truth.stamp.source.epoch = 8;
+    let mut resumed = discontinuity.clone();
+    resumed.sequence = 3;
+    resumed.time.simulator = clock_reading(30);
+    resumed.time.clock_discontinuities.clear();
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    validator
+        .validate_next(&discontinuity)
+        .expect("discontinuity sample");
+    assert!(matches!(
+        validator.validate_next(&resumed),
+        Err(CodecError::Validation(
+            ValidationError::InvalidClockObservation { .. }
+        ))
+    ));
+}
+
+#[test]
+fn failed_validation_does_not_change_stream_state() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut invalid = next_sample(&run, 2);
+    invalid.time.device = clock_reading(29);
+    let mut corrected = next_sample(&run, 2);
+    corrected.time.device = clock_reading(31);
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    assert!(validator.validate_next(&invalid).is_err());
+    assert_eq!(validator.validated_samples(), 1);
+    assert!(validator.validate_next(&corrected).is_ok());
+    assert_eq!(validator.validated_samples(), 2);
+}
+
+#[test]
+fn declared_sample_loss_does_not_authorize_clock_regression() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut current = next_sample(&run, 3);
+    current.dropped_before = 1;
+    current.time.device = clock_reading(29);
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    assert!(matches!(
+        validator.validate_next(&current),
+        Err(CodecError::Validation(
+            ValidationError::ClockRegression { .. }
+        ))
+    ));
+}
+
+#[test]
+fn declared_sample_loss_does_not_authorize_an_unknown_predecessor() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut current = next_sample(&run, 3);
+    current.dropped_before = 1;
+    current.raw_input.stamp.source.sequence = 3;
+    current.normalized_control.stamp.source.sequence = 3;
+    current.normalized_control.stamp.predecessor =
+        Some(event(ControlStage::RawInput, ClockDomain::Device, 2));
+    let mut validator = stream(&run);
+
+    validator.validate_next(&first).expect("first sample");
+    assert!(matches!(
+        validator.validate_next(&current),
+        Err(CodecError::Validation(
+            ValidationError::UnknownControlPredecessor { .. }
+        ))
+    ));
+}
+
+#[test]
+fn unconsumed_control_event_history_has_a_hard_limit() {
+    let run = run_identity();
+    let first = sample(&run);
+    let mut validator = stream(&run);
+    validator.validate_next(&first).expect("first sample");
+
+    for sequence in 2..=u64::try_from(crate::MAX_CONTROL_EVENT_HISTORY).expect("history limit") {
+        let mut value = next_sample(&run, sequence);
+        value.raw_input.stamp.source.sequence = sequence;
+        validator.validate_next(&value).expect("bounded backlog");
+    }
+    let sequence = u64::try_from(crate::MAX_CONTROL_EVENT_HISTORY)
+        .expect("history limit")
+        .wrapping_add(1);
+    let mut overflow = next_sample(&run, sequence);
+    overflow.raw_input.stamp.source.sequence = sequence;
+
+    assert!(matches!(
+        validator.validate_next(&overflow),
+        Err(CodecError::Validation(ValidationError::TooManyItems {
+            limit: crate::MAX_CONTROL_EVENT_HISTORY,
+            ..
+        }))
+    ));
+}
+
+#[test]
+fn missing_downstream_cannot_grow_event_history_without_a_limit() {
+    let run = run_identity();
+    let mut first = sample(&run);
+    make_control_tail_missing(&mut first);
+    let mut validator = stream(&run);
+    validator.validate_next(&first).expect("first sample");
+
+    for sequence in 2..=u64::try_from(crate::MAX_CONTROL_EVENT_HISTORY).expect("history limit") {
+        let mut value = next_sample(&run, sequence);
+        value.raw_input.stamp.source.sequence = sequence;
+        make_control_tail_missing(&mut value);
+        validator.validate_next(&value).expect("bounded backlog");
+    }
+    let sequence = u64::try_from(crate::MAX_CONTROL_EVENT_HISTORY)
+        .expect("history limit")
+        .wrapping_add(1);
+    let mut overflow = next_sample(&run, sequence);
+    overflow.raw_input.stamp.source.sequence = sequence;
+    make_control_tail_missing(&mut overflow);
+
+    assert!(matches!(
+        validator.validate_next(&overflow),
+        Err(CodecError::Validation(ValidationError::TooManyItems {
+            limit: crate::MAX_CONTROL_EVENT_HISTORY,
+            ..
+        }))
+    ));
+}

--- a/crates/pilotage-trial/src/sample/time.rs
+++ b/crates/pilotage-trial/src/sample/time.rs
@@ -1,0 +1,143 @@
+//! Sample times and clock discontinuities.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ClockDomain, MAX_CLOCK_MAPPINGS, RunIdentity, ValidationError, validation::unique};
+
+use super::Observed;
+
+/// One time in a named source clock epoch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClockReading {
+    /// The source clock epoch.
+    pub epoch: u64,
+    /// The time in nanoseconds.
+    pub time_ns: u64,
+}
+
+/// Times for one sample in each available clock domain.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SampleTime {
+    /// The mandatory recorder monotonic time.
+    pub recorder_monotonic_ns: u64,
+    /// The input device time.
+    pub device: Observed<ClockReading>,
+    /// The control client time.
+    pub client: Observed<ClockReading>,
+    /// The adapter time.
+    pub adapter: Observed<ClockReading>,
+    /// The flight controller time.
+    pub flight_controller: Observed<ClockReading>,
+    /// The simulator time.
+    pub simulator: Observed<ClockReading>,
+    /// Clock domains that had a discontinuity before this sample.
+    pub clock_discontinuities: Vec<ClockDomain>,
+}
+
+impl SampleTime {
+    /// Gets the available reading for one clock domain.
+    #[must_use]
+    pub fn reading(&self, domain: ClockDomain) -> Option<ClockReading> {
+        match domain {
+            ClockDomain::Recorder => Some(ClockReading {
+                epoch: 0,
+                time_ns: self.recorder_monotonic_ns,
+            }),
+            _ => self.source_reading(domain).copied(),
+        }
+    }
+
+    pub(crate) fn source_reading(&self, domain: ClockDomain) -> Option<&ClockReading> {
+        match domain {
+            ClockDomain::Device => self.device.value(),
+            ClockDomain::Client => self.client.value(),
+            ClockDomain::Recorder => None,
+            ClockDomain::Adapter => self.adapter.value(),
+            ClockDomain::FlightController => self.flight_controller.value(),
+            ClockDomain::Simulator => self.simulator.value(),
+        }
+    }
+
+    /// Reports if a clock discontinuity occurs before this sample.
+    #[must_use]
+    pub fn has_discontinuity(&self, domain: ClockDomain) -> bool {
+        self.clock_discontinuities.contains(&domain)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), ValidationError> {
+        crate::validation::count(
+            "sample.time.clock_discontinuities",
+            self.clock_discontinuities.len(),
+            MAX_CLOCK_MAPPINGS,
+        )?;
+        unique(
+            "sample.time.clock_discontinuities",
+            &self.clock_discontinuities,
+        )?;
+        if self.has_discontinuity(ClockDomain::Recorder) {
+            return invalid_clock_observation(
+                "sample.time.clock_discontinuities",
+                "the recorder clock cannot have a discontinuity in one run",
+            );
+        }
+        self.device
+            .validate_with("sample.time.device", ClockReading::validate)?;
+        self.client
+            .validate_with("sample.time.client", ClockReading::validate)?;
+        self.adapter
+            .validate_with("sample.time.adapter", ClockReading::validate)?;
+        self.flight_controller
+            .validate_with("sample.time.flight_controller", ClockReading::validate)?;
+        self.simulator
+            .validate_with("sample.time.simulator", ClockReading::validate)
+    }
+
+    pub(crate) fn validate_for_run(&self, run: &RunIdentity) -> Result<(), ValidationError> {
+        const DOMAINS: [ClockDomain; 5] = [
+            ClockDomain::Device,
+            ClockDomain::Client,
+            ClockDomain::Adapter,
+            ClockDomain::FlightController,
+            ClockDomain::Simulator,
+        ];
+        for domain in DOMAINS {
+            let Some(reading) = self.source_reading(domain) else {
+                continue;
+            };
+            run.validate_sample_clock(
+                clock_field(domain),
+                domain,
+                reading.epoch,
+                reading.time_ns,
+                self.recorder_monotonic_ns,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl ClockReading {
+    fn validate(&self, _field: &str) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+fn clock_field(domain: ClockDomain) -> &'static str {
+    match domain {
+        ClockDomain::Device => "sample.time.device",
+        ClockDomain::Client => "sample.time.client",
+        ClockDomain::Recorder => "sample.time.recorder_monotonic_ns",
+        ClockDomain::Adapter => "sample.time.adapter",
+        ClockDomain::FlightController => "sample.time.flight_controller",
+        ClockDomain::Simulator => "sample.time.simulator",
+    }
+}
+
+fn invalid_clock_observation<T>(field: &str, reason: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::InvalidClockObservation {
+        field: field.to_owned(),
+        reason,
+    })
+}

--- a/crates/pilotage-trial/src/validation.rs
+++ b/crates/pilotage-trial/src/validation.rs
@@ -1,0 +1,117 @@
+//! Shared validation rules for trial data.
+
+use crate::{Digest, ValidationError};
+
+pub(crate) fn schema(
+    document: &'static str,
+    actual: u16,
+    expected: u16,
+) -> Result<(), ValidationError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(ValidationError::UnsupportedSchemaVersion {
+        document,
+        actual,
+        expected,
+    })
+}
+
+pub(crate) fn text(field: &str, value: &str, limit: usize) -> Result<(), ValidationError> {
+    if value.trim().is_empty() {
+        return Err(ValidationError::EmptyText {
+            field: field.to_owned(),
+        });
+    }
+    if value.len() > limit {
+        return Err(ValidationError::TextTooLong {
+            field: field.to_owned(),
+            size: value.len(),
+            limit,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn optional_text(
+    field: &str,
+    value: Option<&str>,
+    limit: usize,
+) -> Result<(), ValidationError> {
+    match value {
+        Some(value) => text(field, value, limit),
+        None => Ok(()),
+    }
+}
+
+pub(crate) fn digest(field: &str, value: Digest) -> Result<(), ValidationError> {
+    if value.is_zero() {
+        return Err(ValidationError::ZeroDigest {
+            field: field.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn count(field: &str, count: usize, limit: usize) -> Result<(), ValidationError> {
+    if count > limit {
+        return Err(ValidationError::TooManyItems {
+            field: field.to_owned(),
+            count,
+            limit,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn nonempty_count(
+    field: &str,
+    count: usize,
+    limit: usize,
+) -> Result<(), ValidationError> {
+    if count == 0 {
+        return Err(ValidationError::EmptyList {
+            field: field.to_owned(),
+        });
+    }
+    self::count(field, count, limit)
+}
+
+pub(crate) fn unique<T: PartialEq>(field: &str, values: &[T]) -> Result<(), ValidationError> {
+    for (index, value) in values.iter().enumerate() {
+        if values[..index].contains(value) {
+            return Err(ValidationError::DuplicateItem {
+                field: field.to_owned(),
+                index,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn finite(field: &str, value: f64) -> Result<(), ValidationError> {
+    if value.is_finite() {
+        return Ok(());
+    }
+    Err(ValidationError::NonFinite {
+        field: field.to_owned(),
+    })
+}
+
+pub(crate) fn range(
+    field: &str,
+    value: f64,
+    minimum: f64,
+    maximum: f64,
+) -> Result<(), ValidationError> {
+    finite(field, value)?;
+    if (minimum..=maximum).contains(&value) {
+        return Ok(());
+    }
+    Err(ValidationError::OutOfRange {
+        field: field.to_owned(),
+        actual: value,
+        minimum,
+        maximum,
+    })
+}


### PR DESCRIPTION
## Scope

- Define bounded trial identity, stage, sample, stream, and limit contracts.
- Keep the causal export surface format-stable.
- Add regression tests for the contract invariants.

Closes #504.

## Review

Exact head: `b4a1a4f106bec823b48cdc24a63c94e104791e9f`.

Independent review returned LAND with no P0-P3 findings.

## Verification

The full local CI passed at the exact head. It included format, Clippy for all targets with warnings denied, tests for all targets, strict documentation gates, release build, repository guard scripts, and applicable Apple and web compatibility tests.