### PR TITLE
Add reviewed X-Plane condition foundation (#448)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,15 @@ jobs:
       - name: cargo build --release
         run: cargo build --release
 
+      - name: X-Plane weather transaction state
+        run: bash scripts/check-xplane-weather-state.sh
+
+      - name: X-Plane weather clear protocol
+        run: python3 scripts/test-xplane-weather-clear.py
+
+      - name: X-Plane reset order
+        run: bash scripts/test-reset-xplane-order.sh
+
       - name: flight build carries no simulation-only code
         run: bash scripts/check-flight-build.sh
 

--- a/crates/pilotage-trial/src/condition.rs
+++ b/crates/pilotage-trial/src/condition.rs
@@ -1,0 +1,399 @@
+//! Deterministic environmental condition contracts.
+
+use core::f64::consts::TAU;
+
+use serde::{Deserialize, Serialize};
+
+mod timing;
+
+pub use timing::{DelayJitter, TimingCondition};
+
+use crate::{
+    CONDITION_SET_SCHEMA_VERSION, CodecError, Digest, MAX_GUST_EVENTS, MAX_MANIFEST_BYTES,
+    MAX_TEXT_BYTES, ValidationError, canonical,
+    validation::{count, duration, range, schema, text},
+};
+
+const MAX_WIND_SPEED_MPS: f64 = 100.0;
+const MAX_TURBULENCE_AMPLITUDE_MPS: f64 = 20.0;
+
+/// A horizontal wind in the aviation direction convention.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HorizontalWind {
+    /// Wind speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the wind comes from, clockwise from north.
+    pub direction_deg: f64,
+}
+
+/// One trapezoidal gust event.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GustEvent {
+    /// Event start in simulator nanoseconds from condition activation.
+    pub start_ns: u64,
+    /// Linear rise interval in simulator nanoseconds. Zero gives a step.
+    pub rise_ns: u64,
+    /// Full-amplitude interval in simulator nanoseconds.
+    pub hold_ns: u64,
+    /// Linear fall interval in simulator nanoseconds. Zero gives a step.
+    pub fall_ns: u64,
+    /// Gust speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the gust comes from.
+    pub direction_deg: f64,
+}
+
+/// A deterministic turbulence model.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum TurbulenceModel {
+    /// No turbulence component.
+    None,
+    /// Seeded, linearly interpolated horizontal noise.
+    BandLimitedNoise {
+        /// Maximum turbulence-vector magnitude in meters per second.
+        amplitude_mps: f64,
+        /// Interval between deterministic noise knots in simulator nanoseconds.
+        knot_interval_ns: u64,
+    },
+}
+
+/// Wind inputs for one condition set.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindCondition {
+    /// Constant base wind.
+    pub steady: HorizontalWind,
+    /// Ordered gust events.
+    pub gusts: Vec<GustEvent>,
+    /// Deterministic turbulence model.
+    pub turbulence: TurbulenceModel,
+}
+
+/// A versioned environmental condition artifact.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConditionSet {
+    /// Condition schema version.
+    pub schema_version: u16,
+    /// Stable condition-set name.
+    pub id: String,
+    /// Condition-set revision.
+    pub revision: u32,
+    /// Seed for all deterministic disturbance components.
+    pub seed: u64,
+    /// Wind and turbulence definition.
+    pub wind: WindCondition,
+    /// Deterministic source timing perturbation.
+    pub timing: TimingCondition,
+}
+
+/// One resolved wind sample for a simulator backend.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppliedWind {
+    /// Resulting horizontal wind speed in meters per second.
+    pub speed_mps: f64,
+    /// True direction that the resulting wind comes from.
+    pub direction_deg: f64,
+    /// North component of air motion in meters per second.
+    pub north_mps: f64,
+    /// East component of air motion in meters per second.
+    pub east_mps: f64,
+    /// Magnitude of the deterministic turbulence component.
+    pub turbulence_mps: f64,
+}
+
+impl ConditionSet {
+    /// Decode and validate a condition-set JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("condition set", bytes, MAX_MANIFEST_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validate the condition-set contract.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        schema(
+            "condition set",
+            self.schema_version,
+            CONDITION_SET_SCHEMA_VERSION,
+        )?;
+        text("condition_set.id", &self.id, MAX_TEXT_BYTES)?;
+        self.wind.validate()?;
+        self.timing.validate()
+    }
+
+    /// Encode canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("condition set", self, MAX_MANIFEST_BYTES)
+    }
+
+    /// Calculate the canonical condition-set identity.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+
+    /// Resolve the wind request at one simulator-time offset.
+    pub fn wind_at(&self, elapsed_ns: u64) -> Result<AppliedWind, ValidationError> {
+        self.wind_at_for_run(0, elapsed_ns)
+    }
+
+    /// Resolve the wind for one recorded run seed and simulator-time offset.
+    ///
+    /// The artifact seed defines the condition. The run seed gives each
+    /// repetition a separate deterministic disturbance without changing the
+    /// condition artifact identity.
+    pub fn wind_at_for_run(
+        &self,
+        run_seed: u64,
+        elapsed_ns: u64,
+    ) -> Result<AppliedWind, ValidationError> {
+        self.validate()?;
+        let mut vector = WindVector::from(self.wind.steady);
+        for gust in &self.wind.gusts {
+            vector.add_scaled(
+                WindVector::from(HorizontalWind {
+                    speed_mps: gust.speed_mps,
+                    direction_deg: gust.direction_deg,
+                }),
+                gust.scale_at(elapsed_ns),
+            );
+        }
+        let seed = self.seed ^ run_seed.rotate_left(17);
+        let turbulence = self.wind.turbulence.sample(seed, elapsed_ns);
+        vector.add_scaled(turbulence, 1.0);
+        Ok(vector.applied(turbulence.magnitude()))
+    }
+
+    /// Resolve the requested vehicle-source delay for one run and time.
+    pub fn source_delay_ns_for_run(
+        &self,
+        run_seed: u64,
+        elapsed_ns: u64,
+    ) -> Result<u64, ValidationError> {
+        self.validate()?;
+        Ok(self.timing.delay_ns(self.seed, run_seed, elapsed_ns))
+    }
+}
+
+impl WindCondition {
+    fn validate(&self) -> Result<(), ValidationError> {
+        self.steady.validate("condition_set.wind.steady")?;
+        count(
+            "condition_set.wind.gusts",
+            self.gusts.len(),
+            MAX_GUST_EVENTS,
+        )?;
+        let mut maximum_speed = self.steady.speed_mps;
+        for (index, gust) in self.gusts.iter().enumerate() {
+            gust.validate(index)?;
+            maximum_speed += gust.speed_mps;
+        }
+        self.turbulence.validate()?;
+        maximum_speed += self.turbulence.amplitude_mps();
+        range(
+            "condition_set.wind.maximum_possible_speed_mps",
+            maximum_speed,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )
+    }
+}
+
+impl HorizontalWind {
+    fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        range(
+            &format!("{field}.speed_mps"),
+            self.speed_mps,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )?;
+        range(
+            &format!("{field}.direction_deg"),
+            self.direction_deg,
+            0.0,
+            360.0,
+        )
+    }
+}
+
+impl GustEvent {
+    fn validate(&self, index: usize) -> Result<(), ValidationError> {
+        let field = format!("condition_set.wind.gusts[{index}]");
+        range(
+            &format!("{field}.speed_mps"),
+            self.speed_mps,
+            0.0,
+            MAX_WIND_SPEED_MPS,
+        )?;
+        range(
+            &format!("{field}.direction_deg"),
+            self.direction_deg,
+            0.0,
+            360.0,
+        )?;
+        if self.rise_ns == 0 && self.hold_ns == 0 && self.fall_ns == 0 {
+            return duration(&format!("{field}.duration"), 0);
+        }
+        self.start_ns
+            .checked_add(self.rise_ns)
+            .and_then(|end| end.checked_add(self.hold_ns))
+            .and_then(|end| end.checked_add(self.fall_ns))
+            .ok_or_else(|| ValidationError::TimeOverflow {
+                field: format!("{field}.end_ns"),
+            })?;
+        Ok(())
+    }
+
+    fn scale_at(self, elapsed_ns: u64) -> f64 {
+        let Some(relative) = elapsed_ns.checked_sub(self.start_ns) else {
+            return 0.0;
+        };
+        let rise_end = self.rise_ns;
+        let hold_end = rise_end.saturating_add(self.hold_ns);
+        let fall_end = hold_end.saturating_add(self.fall_ns);
+        if relative < rise_end {
+            return relative as f64 / self.rise_ns as f64;
+        }
+        if relative < hold_end {
+            return 1.0;
+        }
+        if relative < fall_end && self.fall_ns > 0 {
+            return (fall_end - relative) as f64 / self.fall_ns as f64;
+        }
+        0.0
+    }
+}
+
+impl TurbulenceModel {
+    fn validate(self) -> Result<(), ValidationError> {
+        match self {
+            Self::None => Ok(()),
+            Self::BandLimitedNoise {
+                amplitude_mps,
+                knot_interval_ns,
+            } => {
+                range(
+                    "condition_set.wind.turbulence.amplitude_mps",
+                    amplitude_mps,
+                    0.0,
+                    MAX_TURBULENCE_AMPLITUDE_MPS,
+                )?;
+                duration(
+                    "condition_set.wind.turbulence.knot_interval_ns",
+                    knot_interval_ns,
+                )
+            }
+        }
+    }
+
+    const fn amplitude_mps(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::BandLimitedNoise { amplitude_mps, .. } => amplitude_mps,
+        }
+    }
+
+    fn sample(self, seed: u64, elapsed_ns: u64) -> WindVector {
+        match self {
+            Self::None => WindVector::default(),
+            Self::BandLimitedNoise {
+                amplitude_mps,
+                knot_interval_ns,
+            } => {
+                if knot_interval_ns == 0 || !amplitude_mps.is_finite() {
+                    return WindVector::default();
+                }
+                let knot = elapsed_ns / knot_interval_ns;
+                let fraction = (elapsed_ns % knot_interval_ns) as f64 / knot_interval_ns as f64;
+                noise_vector(seed, knot, amplitude_mps).interpolate(
+                    noise_vector(seed, knot.wrapping_add(1), amplitude_mps),
+                    fraction,
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct WindVector {
+    north: f64,
+    east: f64,
+}
+
+impl From<HorizontalWind> for WindVector {
+    fn from(wind: HorizontalWind) -> Self {
+        let radians = wind.direction_deg.to_radians();
+        Self {
+            north: -wind.speed_mps * radians.cos(),
+            east: -wind.speed_mps * radians.sin(),
+        }
+    }
+}
+
+impl WindVector {
+    fn add_scaled(&mut self, other: Self, scale: f64) {
+        self.north += other.north * scale;
+        self.east += other.east * scale;
+    }
+
+    fn interpolate(self, other: Self, fraction: f64) -> Self {
+        Self {
+            north: self.north + (other.north - self.north) * fraction,
+            east: self.east + (other.east - self.east) * fraction,
+        }
+    }
+
+    fn magnitude(self) -> f64 {
+        self.north.hypot(self.east)
+    }
+
+    fn applied(self, turbulence_mps: f64) -> AppliedWind {
+        let speed_mps = self.magnitude();
+        let direction_deg = if speed_mps <= f64::EPSILON {
+            0.0
+        } else {
+            (-self.east)
+                .atan2(-self.north)
+                .to_degrees()
+                .rem_euclid(360.0)
+        };
+        AppliedWind {
+            speed_mps,
+            direction_deg,
+            north_mps: self.north,
+            east_mps: self.east,
+            turbulence_mps,
+        }
+    }
+}
+
+fn noise_vector(seed: u64, knot: u64, amplitude: f64) -> WindVector {
+    let angle = unit_interval(splitmix64(seed ^ knot.wrapping_mul(0x9e37_79b9_7f4a_7c15))) * TAU;
+    let magnitude = unit_interval(splitmix64(
+        seed ^ knot.wrapping_mul(0xbf58_476d_1ce4_e5b9) ^ 1,
+    )) * amplitude;
+    WindVector {
+        north: magnitude * angle.cos(),
+        east: magnitude * angle.sin(),
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn unit_interval(value: u64) -> f64 {
+    (value >> 11) as f64 * (1.0 / ((1_u64 << 53) as f64))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-trial/src/condition/tests.rs
+++ b/crates/pilotage-trial/src/condition/tests.rs
@@ -1,0 +1,374 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+
+fn condition(seed: u64) -> ConditionSet {
+    ConditionSet {
+        schema_version: CONDITION_SET_SCHEMA_VERSION,
+        id: "crosswind-gust".to_owned(),
+        revision: 1,
+        seed,
+        wind: WindCondition {
+            steady: HorizontalWind {
+                speed_mps: 5.0,
+                direction_deg: 270.0,
+            },
+            gusts: vec![GustEvent {
+                start_ns: 1_000_000_000,
+                rise_ns: 1_000_000_000,
+                hold_ns: 1_000_000_000,
+                fall_ns: 1_000_000_000,
+                speed_mps: 3.0,
+                direction_deg: 270.0,
+            }],
+            turbulence: TurbulenceModel::BandLimitedNoise {
+                amplitude_mps: 0.5,
+                knot_interval_ns: 200_000_000,
+            },
+        },
+        timing: TimingCondition::nominal(),
+    }
+}
+
+fn wind(value: &ConditionSet, elapsed_ns: u64) -> AppliedWind {
+    value.wind_at(elapsed_ns).expect("valid condition")
+}
+
+fn run_wind(value: &ConditionSet, run_seed: u64, elapsed_ns: u64) -> AppliedWind {
+    value
+        .wind_at_for_run(run_seed, elapsed_ns)
+        .expect("valid condition")
+}
+
+fn source_delay(value: &ConditionSet, run_seed: u64, elapsed_ns: u64) -> u64 {
+    value
+        .source_delay_ns_for_run(run_seed, elapsed_ns)
+        .expect("valid condition")
+}
+
+#[test]
+fn condition_set_rejects_an_unknown_schema_version() {
+    let mut value = condition(42);
+    value.schema_version = CONDITION_SET_SCHEMA_VERSION.wrapping_add(1);
+
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::UnsupportedSchemaVersion {
+            document: "condition set",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn the_same_seed_produces_the_same_schedule() {
+    let first = condition(42);
+    let second = condition(42);
+    let first_samples: Vec<_> = (0..100)
+        .map(|index| wind(&first, index * 50_000_000))
+        .collect();
+    let second_samples: Vec<_> = (0..100)
+        .map(|index| wind(&second, index * 50_000_000))
+        .collect();
+    assert_eq!(first_samples, second_samples);
+}
+
+#[test]
+fn a_different_seed_changes_the_turbulence_schedule() {
+    assert_ne!(
+        wind(&condition(42), 250_000_000),
+        wind(&condition(43), 250_000_000)
+    );
+}
+
+#[test]
+fn a_run_seed_is_repeatable_and_separates_repetitions() {
+    let value = condition(42);
+    let first = run_wind(&value, 7, 250_000_000);
+    let repeated = run_wind(&value, 7, 250_000_000);
+    let other = run_wind(&value, 8, 250_000_000);
+
+    assert_eq!(first, repeated);
+    assert_ne!(first, other);
+    assert_eq!(wind(&value, 250_000_000), run_wind(&value, 0, 250_000_000));
+}
+
+#[test]
+fn timing_jitter_is_repeatable_and_separates_runs() {
+    let mut value = condition(42);
+    value.timing = TimingCondition {
+        estimate_delay_ns: 2_000_000,
+        update_jitter: DelayJitter::SampleAndHold {
+            maximum_delay_ns: 3_000_000,
+            interval_ns: 100_000_000,
+        },
+    };
+
+    let first = source_delay(&value, 7, 250_000_000);
+    let repeated = source_delay(&value, 7, 250_000_000);
+    let other_interval = source_delay(&value, 7, 350_000_000);
+    let other_run = source_delay(&value, 8, 250_000_000);
+
+    assert_eq!(first, repeated);
+    assert!((2_000_000..=5_000_000).contains(&first));
+    assert!(first != other_interval || first != other_run);
+}
+
+#[test]
+fn a_gust_uses_rise_hold_and_fall_intervals() {
+    let mut value = condition(1);
+    value.wind.turbulence = TurbulenceModel::None;
+    assert!((wind(&value, 0).speed_mps - 5.0).abs() < 1e-9);
+    assert!((wind(&value, 1_500_000_000).speed_mps - 6.5).abs() < 1e-9);
+    assert!((wind(&value, 2_500_000_000).speed_mps - 8.0).abs() < 1e-9);
+    assert!((wind(&value, 3_500_000_000).speed_mps - 6.5).abs() < 1e-9);
+    assert!((wind(&value, 4_000_000_000).speed_mps - 5.0).abs() < 1e-9);
+}
+
+#[test]
+fn canonical_identity_changes_with_the_seed() {
+    let first = condition(42).canonical_digest().expect("valid condition");
+    let second = condition(43).canonical_digest().expect("valid condition");
+    assert_ne!(first, second);
+}
+
+#[test]
+fn validation_rejects_unbounded_weather() {
+    let mut value = condition(42);
+    value.wind.gusts[0].speed_mps = 100.0;
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn schedule_resolution_rejects_invalid_direct_construction() {
+    let mut value = condition(42);
+    value.wind.steady.speed_mps = f64::NAN;
+    assert!(matches!(
+        value.wind_at(0),
+        Err(ValidationError::NonFinite { .. })
+    ));
+    assert!(value.source_delay_ns_for_run(7, 0).is_err());
+}
+
+#[test]
+fn validation_rejects_unbounded_timing_variations() {
+    let mut value = condition(42);
+    value.timing.estimate_delay_ns = 100_000_001;
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn strict_json_rejects_unknown_fields() {
+    let mut json = serde_json::to_value(condition(42)).expect("condition value");
+    json.as_object_mut()
+        .expect("condition object")
+        .insert("unknown".to_owned(), serde_json::Value::Bool(true));
+    let bytes = serde_json::to_vec(&json).expect("condition JSON");
+    assert!(matches!(
+        ConditionSet::from_json(&bytes),
+        Err(CodecError::Decode { .. })
+    ));
+}
+
+#[test]
+fn all_zero_gust_duration_is_rejected() {
+    let mut value = condition(42);
+    value.wind.gusts[0].rise_ns = 0;
+    value.wind.gusts[0].hold_ns = 0;
+    value.wind.gusts[0].fall_ns = 0;
+    assert_eq!(
+        value.validate(),
+        Err(ValidationError::ZeroDuration {
+            field: "condition_set.wind.gusts[0].duration".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn gust_end_time_overflow_is_rejected() {
+    let mut value = condition(42);
+    value.wind.gusts[0].start_ns = u64::MAX;
+    value.wind.gusts[0].rise_ns = 1;
+    value.wind.gusts[0].hold_ns = 0;
+    value.wind.gusts[0].fall_ns = 0;
+    assert_eq!(
+        value.validate(),
+        Err(ValidationError::TimeOverflow {
+            field: "condition_set.wind.gusts[0].end_ns".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn zero_rise_and_fall_form_an_exact_pulse() {
+    let mut value = condition(42);
+    value.wind.turbulence = TurbulenceModel::None;
+    value.wind.gusts[0] = GustEvent {
+        start_ns: 1_000,
+        rise_ns: 0,
+        hold_ns: 1_000,
+        fall_ns: 0,
+        speed_mps: 3.0,
+        direction_deg: 270.0,
+    };
+    let speeds: Vec<_> = [999, 1_000, 1_999, 2_000]
+        .map(|time| wind(&value, time).speed_mps)
+        .into_iter()
+        .collect();
+    assert_eq!(speeds, vec![5.0, 8.0, 8.0, 5.0]);
+}
+
+#[test]
+fn zero_hold_forms_a_continuous_triangle() {
+    let mut value = condition(42);
+    value.wind.turbulence = TurbulenceModel::None;
+    value.wind.gusts[0] = GustEvent {
+        start_ns: 1_000,
+        rise_ns: 1_000,
+        hold_ns: 0,
+        fall_ns: 1_000,
+        speed_mps: 3.0,
+        direction_deg: 270.0,
+    };
+    assert!((wind(&value, 1_999).speed_mps - 7.997).abs() < 1e-9);
+    assert!((wind(&value, 2_000).speed_mps - 8.0).abs() < 1e-9);
+    assert!((wind(&value, 2_001).speed_mps - 7.997).abs() < 1e-9);
+}
+
+#[test]
+fn invalid_zero_turbulence_interval_is_total() {
+    let mut value = condition(42);
+    value.wind.gusts.clear();
+    value.wind.turbulence = TurbulenceModel::BandLimitedNoise {
+        amplitude_mps: 1.0,
+        knot_interval_ns: 0,
+    };
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::ZeroDuration { .. })
+    ));
+    assert!(value.wind_at(1_000).is_err());
+}
+
+#[test]
+fn invalid_zero_jitter_values_are_total() {
+    let mut value = condition(42);
+    value.timing = TimingCondition {
+        estimate_delay_ns: 2_000_000,
+        update_jitter: DelayJitter::SampleAndHold {
+            maximum_delay_ns: 3_000_000,
+            interval_ns: 0,
+        },
+    };
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::ZeroDuration { .. })
+    ));
+    assert!(value.source_delay_ns_for_run(7, 250_000_000).is_err());
+
+    value.timing.update_jitter = DelayJitter::SampleAndHold {
+        maximum_delay_ns: 0,
+        interval_ns: 250_000_000,
+    };
+    assert!(matches!(
+        value.validate(),
+        Err(ValidationError::ZeroDuration { .. })
+    ));
+    assert!(value.source_delay_ns_for_run(7, 250_000_000).is_err());
+}
+
+#[test]
+fn fixed_condition_timeline_matches_the_golden_values_after_reset() {
+    let value = ConditionSet {
+        schema_version: CONDITION_SET_SCHEMA_VERSION,
+        id: "golden-timeline".to_owned(),
+        revision: 1,
+        seed: 42,
+        wind: WindCondition {
+            steady: HorizontalWind {
+                speed_mps: 2.0,
+                direction_deg: 0.0,
+            },
+            gusts: vec![GustEvent {
+                start_ns: 1_000_000_000,
+                rise_ns: 1_000_000_000,
+                hold_ns: 1_000_000_000,
+                fall_ns: 1_000_000_000,
+                speed_mps: 4.0,
+                direction_deg: 0.0,
+            }],
+            turbulence: TurbulenceModel::None,
+        },
+        timing: TimingCondition {
+            estimate_delay_ns: 2_000_000,
+            update_jitter: DelayJitter::SampleAndHold {
+                maximum_delay_ns: 3_000_000,
+                interval_ns: 250_000_000,
+            },
+        },
+    };
+    let expected = [
+        (0, 2.0, 4_246_789),
+        (250_000_000, 2.0, 2_712_636),
+        (500_000_000, 2.0, 2_980_386),
+        (750_000_000, 2.0, 4_221_038),
+        (1_000_000_000, 2.0, 3_671_211),
+        (1_500_000_000, 4.0, 4_303_391),
+        (2_000_000_000, 6.0, 3_282_861),
+        (2_500_000_000, 6.0, 2_425_430),
+        (3_000_000_000, 6.0, 4_647_388),
+        (3_500_000_000, 4.0, 2_280_806),
+        (4_000_000_000, 2.0, 3_694_917),
+    ];
+    assert_eq!(
+        value
+            .canonical_digest()
+            .expect("golden condition")
+            .to_string(),
+        "69342e8bb6470366bfa640051ced0612a3cd10ae113f7c4f26c03d6637a3cb6e"
+    );
+
+    let first: Vec<_> = expected
+        .iter()
+        .map(|(time, _, _)| (run_wind(&value, 7, *time), source_delay(&value, 7, *time)))
+        .collect();
+    let reset: Vec<_> = expected
+        .iter()
+        .map(|(time, _, _)| (run_wind(&value, 7, *time), source_delay(&value, 7, *time)))
+        .collect();
+    assert_eq!(first, reset);
+
+    for ((wind, delay), (_, speed, expected_delay)) in first.iter().zip(expected) {
+        assert!((wind.speed_mps - speed).abs() < 1e-9);
+        assert!((wind.north_mps + speed).abs() < 1e-9);
+        assert!(wind.east_mps.abs() < 1e-9);
+        assert_eq!(*delay, expected_delay);
+    }
+}
+
+#[test]
+fn seeded_turbulence_matches_fixed_vector_samples() {
+    let value = condition(42);
+    let expected = [
+        (0, 0.314_943_760_183_277_5, 4.863_281_615_858_67),
+        (100_000_000, 0.099_427_857_735_345_15, 4.938_501_265_056_212),
+        (
+            200_000_000,
+            -0.116_088_044_712_587_21,
+            5.013_720_914_253_755,
+        ),
+        (250_000_000, -0.034_061_976_899_483_91, 5.026_713_109_005_16),
+        (400_000_000, 0.212_016_226_539_826, 5.065_689_693_259_377),
+    ];
+    for (time, north, east) in expected {
+        let sample = run_wind(&value, 7, time);
+        assert!((sample.north_mps - north).abs() < 1e-12);
+        assert!((sample.east_mps - east).abs() < 1e-12);
+    }
+}

--- a/crates/pilotage-trial/src/condition/timing.rs
+++ b/crates/pilotage-trial/src/condition/timing.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ValidationError, validation::duration};
+
+const MAX_SOURCE_DELAY_NS: u64 = 100_000_000;
+
+/// A deterministic update-jitter model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DelayJitter {
+    /// Do not add timing jitter.
+    None,
+    /// Hold one seeded extra delay for each fixed interval.
+    SampleAndHold {
+        /// Maximum additional delay in nanoseconds.
+        maximum_delay_ns: u64,
+        /// Interval between deterministic delay values in nanoseconds.
+        interval_ns: u64,
+    },
+}
+
+/// Source timing perturbation for one condition set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimingCondition {
+    /// Fixed estimate age in nanoseconds.
+    pub estimate_delay_ns: u64,
+    /// Seeded additional update delay.
+    pub update_jitter: DelayJitter,
+}
+
+impl TimingCondition {
+    /// Returns a condition with no source timing perturbation.
+    #[must_use]
+    pub const fn nominal() -> Self {
+        Self {
+            estimate_delay_ns: 0,
+            update_jitter: DelayJitter::None,
+        }
+    }
+
+    pub(super) fn validate(self) -> Result<(), ValidationError> {
+        let maximum = self
+            .estimate_delay_ns
+            .saturating_add(self.update_jitter.maximum_delay_ns());
+        if maximum > MAX_SOURCE_DELAY_NS {
+            return Err(ValidationError::OutOfRange {
+                field: "condition_set.timing.maximum_source_delay_ns".to_owned(),
+                actual: maximum as f64,
+                minimum: 0.0,
+                maximum: MAX_SOURCE_DELAY_NS as f64,
+            });
+        }
+        self.update_jitter.validate()
+    }
+
+    pub(super) fn delay_ns(self, condition_seed: u64, run_seed: u64, elapsed_ns: u64) -> u64 {
+        self.estimate_delay_ns.saturating_add(
+            self.update_jitter
+                .sample(condition_seed ^ run_seed.rotate_left(29), elapsed_ns),
+        )
+    }
+}
+
+impl DelayJitter {
+    const fn maximum_delay_ns(self) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::SampleAndHold {
+                maximum_delay_ns, ..
+            } => maximum_delay_ns,
+        }
+    }
+
+    fn validate(self) -> Result<(), ValidationError> {
+        match self {
+            Self::None => Ok(()),
+            Self::SampleAndHold {
+                maximum_delay_ns,
+                interval_ns,
+            } => {
+                duration(
+                    "condition_set.timing.update_jitter.maximum_delay_ns",
+                    maximum_delay_ns,
+                )?;
+                duration(
+                    "condition_set.timing.update_jitter.interval_ns",
+                    interval_ns,
+                )
+            }
+        }
+    }
+
+    fn sample(self, seed: u64, elapsed_ns: u64) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::SampleAndHold {
+                maximum_delay_ns,
+                interval_ns,
+            } => {
+                if interval_ns == 0 || maximum_delay_ns == 0 {
+                    return 0;
+                }
+                let interval = elapsed_ns / interval_ns;
+                splitmix64(seed ^ interval.wrapping_mul(0x9e37_79b9_7f4a_7c15))
+                    % maximum_delay_ns.saturating_add(1)
+            }
+        }
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}

--- a/crates/pilotage-trial/src/error.rs
+++ b/crates/pilotage-trial/src/error.rs
@@ -85,6 +85,12 @@ pub enum ValidationError {
         /// The field path.
         field: String,
     },
+    /// A nanosecond schedule exceeds the supported integer range.
+    #[error("{field} exceeds the u64 nanosecond range")]
+    TimeOverflow {
+        /// The field path.
+        field: String,
+    },
     /// A relation between identity fields is invalid.
     #[error("identity mismatch for {field}")]
     IdentityMismatch {

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -6,6 +6,7 @@ mod causal_api;
 pub use causal_api::*;
 
 mod canonical;
+mod condition;
 mod digest;
 mod error;
 mod identity;
@@ -13,16 +14,21 @@ mod limits;
 mod sample;
 mod validation;
 
+pub use condition::{
+    AppliedWind, ConditionSet, DelayJitter, GustEvent, HorizontalWind, TimingCondition,
+    TurbulenceModel, WindCondition,
+};
 pub use digest::Digest;
 pub use error::{CodecError, ValidationError};
 pub use identity::{
     ArtifactIdentity, ClockDomain, ClockMapping, ClockMappingQuality, RunIdentity, ScenarioIdentity,
 };
 pub use limits::{
-    BACKEND_CAPABILITIES_SCHEMA_VERSION, MAX_ACTUATOR_VALUES, MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS,
-    MAX_CONDITION_VALUES, MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES,
-    MAX_RAW_BUTTONS, MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS,
-    SCENARIO_SCHEMA_VERSION, TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
+    BACKEND_CAPABILITIES_SCHEMA_VERSION, CONDITION_SET_SCHEMA_VERSION, MAX_ACTUATOR_VALUES,
+    MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS, MAX_CONDITION_VALUES, MAX_GUST_EVENTS,
+    MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES, MAX_RAW_BUTTONS,
+    MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS, SCENARIO_SCHEMA_VERSION,
+    TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
 };
 pub use sample::{
     ActuatorState, AdapterDisposition, ConditionState, ControlAxes, ControlValue, HealthState,

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -10,6 +10,8 @@ pub const SCENARIO_SCHEMA_VERSION: u16 = 1;
 pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
 /// The supported trial sample schema version.
 pub const TRIAL_SAMPLE_SCHEMA_VERSION: u16 = 1;
+/// The supported environmental condition schema version.
+pub const CONDITION_SET_SCHEMA_VERSION: u16 = 1;
 
 /// The maximum trial manifest JSON size.
 pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
@@ -41,3 +43,5 @@ pub const MAX_ACTUATOR_VALUES: usize = 64;
 pub const MAX_CONDITION_VALUES: usize = 64;
 /// The permitted difference between a quaternion norm and one.
 pub const QUATERNION_NORM_TOLERANCE: f64 = 1.0e-3;
+/// The maximum number of gust events in one condition set.
+pub const MAX_GUST_EVENTS: usize = 64;

--- a/crates/pilotage-trial/src/validation.rs
+++ b/crates/pilotage-trial/src/validation.rs
@@ -115,3 +115,12 @@ pub(crate) fn range(
         maximum,
     })
 }
+
+pub(crate) fn duration(field: &str, value: u64) -> Result<(), ValidationError> {
+    if value > 0 {
+        return Ok(());
+    }
+    Err(ValidationError::ZeroDuration {
+        field: field.to_owned(),
+    })
+}

--- a/scripts/build-xplane-plugins.sh
+++ b/scripts/build-xplane-plugins.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Builds and installs the two X-Plane plugins the px4-xplane backend
+# Builds and installs the X-Plane plugins the px4-xplane backend
 # needs, plus the packaged QuadTailsitter aircraft:
 #
 #   1. px4xplane      - the MAVLink HIL bridge (external checkout,
@@ -8,6 +8,8 @@
 #                       (sim/xplane/autoflight)
 #   3. PilotageCamera  - this repository's vehicle camera export
 #                       (sim/xplane/camera)
+#   4. PilotageWeather - static regional weather control and readback
+#                       (sim/xplane/weather)
 #
 # The install target is the X-Plane root: XPLANE_ROOT, else the first
 # entry of the official installer registry that holds X-Plane.app.
@@ -87,6 +89,26 @@ clang++ -std=c++17 -O2 -shared -fPIC \
   -undefined dynamic_lookup -framework OpenGL \
   -o "${CAMERA_BUILD}/mac.xpl"
 
+# --- Build PilotageWeather -----------------------------------------------
+echo "building PilotageWeather..."
+WEATHER_BUILD="${REPO_ROOT}/target/xplane-weather"
+WEATHER_SRC="${REPO_ROOT}/sim/xplane/weather"
+mkdir -p "${WEATHER_BUILD}"
+clang++ -std=c++17 -O2 -Wall -Wextra -Werror -shared -fPIC \
+  -DAPL=1 -DIBM=0 -DLIN=0 -DXPLM200 -DXPLM210 -DXPLM300 -DXPLM301 -DXPLM303 \
+  -I "${PX4XPLANE_DIR}/lib/SDK/CHeaders/XPLM" -I "${WEATHER_SRC}" \
+  "${WEATHER_SRC}/PilotageWeather.cpp" \
+  "${WEATHER_SRC}/weather_state.cpp" \
+  -undefined dynamic_lookup \
+  -o "${WEATHER_BUILD}/mac.xpl"
+
+clang++ -std=c++17 -O2 -Wall -Wextra -Werror \
+  -I "${WEATHER_SRC}" \
+  "${WEATHER_SRC}/weather_state_tests.cpp" \
+  "${WEATHER_SRC}/weather_state.cpp" \
+  -o "${WEATHER_BUILD}/weather_state_tests"
+"${WEATHER_BUILD}/weather_state_tests"
+
 # --- Install -------------------------------------------------------------
 echo "installing plugins and aircraft..."
 PLUGINS="${XPLANE_ROOT}/Resources/plugins"
@@ -135,6 +157,9 @@ cp "${AUTOFLIGHT_BUILD}/mac.xpl" "${PLUGINS}/PilotageAutoFlight/64/mac.xpl"
 mkdir -p "${PLUGINS}/PilotageCamera/64"
 cp "${CAMERA_BUILD}/mac.xpl" "${PLUGINS}/PilotageCamera/64/mac.xpl"
 
+mkdir -p "${PLUGINS}/PilotageWeather/64"
+cp "${WEATHER_BUILD}/mac.xpl" "${PLUGINS}/PilotageWeather/64/mac.xpl"
+
 mkdir -p "${XPLANE_ROOT}/Aircraft/Extra Aircraft"
 rm -rf "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter"
 cp -R "${PX4XPLANE_DIR}/aircraft/QuadTailsitter" "${XPLANE_ROOT}/Aircraft/Extra Aircraft/"
@@ -147,4 +172,4 @@ if [[ -d "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter/Airfoil" ]]; the
     "${XPLANE_ROOT}/Aircraft/Extra Aircraft/QuadTailsitter/airfoils/"
 fi
 
-echo "done: px4xplane + PilotageAutoFlight + PilotageCamera + QuadTailsitter installed"
+echo "done: px4xplane + PilotageAutoFlight + PilotageCamera + PilotageWeather + QuadTailsitter installed"

--- a/scripts/check-xplane-weather-state.sh
+++ b/scripts/check-xplane-weather-state.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Test the X-Plane weather transaction without an X-Plane installation.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+weather_source="${repo_root}/sim/xplane/weather"
+weather_test_root="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-weather-state.XXXXXX")"
+trap 'rm -rf "${weather_test_root}"' EXIT
+
+weather_compiler="${CXX:-c++}"
+"${weather_compiler}" -std=c++17 -O2 -Wall -Wextra -Werror \
+  -I "${weather_source}" \
+  "${weather_source}/weather_state_tests.cpp" \
+  "${weather_source}/weather_state.cpp" \
+  -o "${weather_test_root}/weather_state_tests"
+"${weather_test_root}/weather_state_tests"
+
+fake_xplm="${weather_source}/test_support/xplm"
+"${weather_compiler}" -std=c++17 -O2 -Wall -Wextra -Werror \
+  -I "${fake_xplm}" -I "${weather_source}" \
+  "${weather_source}/weather_plugin_tests.cpp" \
+  "${weather_source}/PilotageWeather.cpp" \
+  "${weather_source}/weather_state.cpp" \
+  "${fake_xplm}/fake_xplm.cpp" \
+  -o "${weather_test_root}/weather_plugin_tests"
+"${weather_test_root}/weather_plugin_tests"
+
+echo "check-xplane-weather-state: OK"

--- a/scripts/monotonic-counter-compound-addition-allowlist.tsv
+++ b/scripts/monotonic-counter-compound-addition-allowlist.tsv
@@ -22,3 +22,7 @@ crates/pilotage-svs-build/src/payload/decode.rs	off += 34;
 crates/pilotage-svs-db/src/feature.rs	i += 1;
 crates/pilotage-svs-db/src/merkle.rs	i += 2;
 crates/pilotage-timing/src/latency.rs	self.len += 1;
+crates/pilotage-trial/src/condition.rs	maximum_speed += gust.speed_mps;
+crates/pilotage-trial/src/condition.rs	maximum_speed += self.turbulence.amplitude_mps();
+crates/pilotage-trial/src/condition.rs	self.east += other.east * scale;
+crates/pilotage-trial/src/condition.rs	self.north += other.north * scale;

--- a/scripts/reset-xplane-sim.sh
+++ b/scripts/reset-xplane-sim.sh
@@ -10,6 +10,11 @@
 # arguments.
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOME_FILE="${HOME}/.pilotage/xplane-home.json"
+PX4_DIR="${PX4_DIR:-${REPO_ROOT}/../PX4-Autopilot}"
+AVIATE_DIR="${AVIATE_DIR:-${REPO_ROOT}/../Aviate}"
+
 # Sends one X-Plane CMND datagram: "CMND\0" + command path + NUL.
 send_cmnd() {
   python3 - "$1" <<'PY'
@@ -20,12 +25,10 @@ socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(
 PY
 }
 
-# Where the vehicle parks between attempts. Captured once per X-Plane
-# boot (the launcher deletes the file when it starts a fresh X-Plane):
-# reset_flight reloads the flight WHERE THE VEHICLE IS, so a reset
-# after a flyaway would otherwise restart the session in a field.
-HOME_FILE="${HOME}/.pilotage/xplane-home.json"
-python3 - "$HOME_FILE" <<'PY_HOME'
+capture_home() {
+  # A grounded position prevents a reset after a flyaway from reloading
+  # the next session in a field or at altitude.
+  python3 - "$HOME_FILE" <<'PY_HOME'
 import json, os, socket, struct, sys, time
 path = sys.argv[1]
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -61,33 +64,34 @@ if not os.path.exists(path):
     elif len(got) == len(REFS):
         print("vehicle is airborne; home capture deferred to a grounded reset")
 PY_HOME
+}
 
-echo "reloading the X-Plane flight..."
-send_cmnd "sim/operation/reset_flight"
+clear_xplane_weather() {
+  echo "clearing the X-Plane weather transaction..."
+  python3 "${REPO_ROOT}/scripts/xplane_weather_clear.py"
+}
 
-echo "restarting the flight controller..."
-# Match ONLY this checkout's SITL binaries: bare patterns would kill
-# unrelated sessions on the machine. The AVIATE binary must restart on
-# reset too — its telemetry clock anchors at process boot, and the
-# adapter's reset latch clears only when a FRESH boot clock opens a new
-# source epoch.
-# The launcher passes both checkout roots; the fallbacks mirror the
-# launcher's own defaults (sibling checkouts of this repo) so a
-# hand-run script kills the same processes the launcher would.
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PX4_DIR="${PX4_DIR:-${REPO_ROOT}/../PX4-Autopilot}"
-AVIATE_DIR="${AVIATE_DIR:-${REPO_ROOT}/../Aviate}"
-pkill -9 -f "${PX4_DIR}/build/px4_sitl_default/bin/px4" 2>/dev/null || true
-pkill -TERM -f "${AVIATE_DIR}/target/debug/sitl-xplane-alia250" 2>/dev/null || true
+stop_flight_controller() {
+  echo "stopping the flight controller..."
+  # Checkout-qualified patterns cannot stop a controller in another lane.
+  pkill -9 -f "${PX4_DIR}/build/px4_sitl_default/bin/px4" 2>/dev/null || true
+  pkill -TERM -f "${AVIATE_DIR}/target/debug/sitl-xplane-alia250" 2>/dev/null || true
+}
 
-# The bridge needs a moment to observe the rewind and disconnect before
-# its listener can arm again; the reloaded flight needs one to settle
-# before a teleport sticks.
-sleep 3
+reload_flight() {
+  echo "reloading the X-Plane flight..."
+  send_cmnd "sim/operation/reset_flight"
+}
+
+settle_reloaded_flight() {
+  # The bridge must observe the time rewind before its listener can re-arm.
+  sleep 3
+}
 
 # Return the vehicle to its parking spot with its velocity zeroed, so a
 # reset after a flyaway is a reset, not a relocation.
-python3 - "$HOME_FILE" <<'PY_TELEPORT'
+teleport_home() {
+  python3 - "$HOME_FILE" <<'PY_TELEPORT'
 import json, os, socket, struct, sys
 path = sys.argv[1]
 if os.path.exists(path):
@@ -111,23 +115,43 @@ if os.path.exists(path):
     write("sim/flightmodel/position/local_z", home["z"])
     print("vehicle returned to its parking spot")
 PY_TELEPORT
+}
 
-echo "re-arming the SITL listener..."
-send_cmnd "px4xplane/connect"
+rearm_bridge() {
+  echo "re-arming the SITL listener..."
+  send_cmnd "px4xplane/connect"
+}
 
 # When `cargo xtask sim` supervises the session, the supervisor restarts
 # the flight-controller stage itself; a script-spawned second px4 would
 # fight it over the MAVLink ports.
-SUPERVISOR_PID_FILE="${REPO_ROOT}/target/xtask-sim/supervisor.pid"
-if [[ -f "${SUPERVISOR_PID_FILE}" ]] && kill -0 "$(cat "${SUPERVISOR_PID_FILE}")" 2>/dev/null; then
-  echo "done - the xtask supervisor restarts PX4; re-arm from the browser once it logs ready"
-  exit 0
-fi
+restart_flight_controller() {
+  local supervisor_pid_file="${REPO_ROOT}/target/xtask-sim/supervisor.pid"
+  if [[ -f "${supervisor_pid_file}" ]] && kill -0 "$(cat "${supervisor_pid_file}")" 2>/dev/null; then
+    echo "done - the xtask supervisor restarts PX4; re-arm from the browser once it logs ready"
+    return
+  fi
 
-ROOTFS="${PX4_DIR}/build/px4_sitl_default/rootfs-xplane"
-mkdir -p "${ROOTFS}"
-cd "${ROOTFS}"
-PX4_SIMULATOR=xplane PX4_SIM_HOSTNAME=127.0.0.1 \
-  PX4_SYS_AUTOSTART="${PX4_SYS_AUTOSTART:-5021}" \
-  nohup ../bin/px4 ../etc -s etc/init.d-posix/rcS -d > /tmp/px4_xplane_manual.log 2>&1 &
-echo "done - re-arm from the browser once PX4 logs ready (~10 s)"
+  local rootfs="${PX4_DIR}/build/px4_sitl_default/rootfs-xplane"
+  mkdir -p "${rootfs}"
+  cd "${rootfs}"
+  PX4_SIMULATOR=xplane PX4_SIM_HOSTNAME=127.0.0.1 \
+    PX4_SYS_AUTOSTART="${PX4_SYS_AUTOSTART:-5021}" \
+    nohup ../bin/px4 ../etc -s etc/init.d-posix/rcS -d > /tmp/px4_xplane_manual.log 2>&1 &
+  echo "done - re-arm from the browser once PX4 logs ready (~10 s)"
+}
+
+reset_xplane_session() {
+  capture_home
+  stop_flight_controller
+  reload_flight
+  settle_reloaded_flight
+  teleport_home
+  clear_xplane_weather
+  rearm_bridge
+  restart_flight_controller
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  reset_xplane_session
+fi

--- a/scripts/test-reset-xplane-order.sh
+++ b/scripts/test-reset-xplane-order.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Test reset ordering and the fail-closed weather boundary.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+reset_script="${repo_root}/scripts/reset-xplane-sim.sh"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-reset-order.XXXXXX")"
+trap 'rm -rf "${test_root}"' EXIT
+
+run_reset_fixture() {
+  local mode="$1"
+  local event_log="$2"
+  bash -s -- "${reset_script}" "${event_log}" "${mode}" <<'BASH'
+source "$1"
+event_log="$2"
+mode="$3"
+
+record() {
+  printf '%s\n' "$1" >> "${event_log}"
+}
+
+capture_home() { record capture; }
+stop_flight_controller() { record stop; }
+reload_flight() { record reload; }
+settle_reloaded_flight() { record settle; }
+teleport_home() { record teleport; }
+clear_xplane_weather() {
+  record clear
+  [[ "${mode}" == "success" ]]
+}
+rearm_bridge() { record rearm; }
+restart_flight_controller() { record restart; }
+
+reset_xplane_session
+BASH
+}
+
+success_log="${test_root}/success.log"
+run_reset_fixture success "${success_log}"
+success_events="$(<"${success_log}")"
+expected_success=$'capture\nstop\nreload\nsettle\nteleport\nclear\nrearm\nrestart'
+if [[ "${success_events}" != "${expected_success}" ]]; then
+  echo "reset success order is incorrect: ${success_events}" >&2
+  exit 1
+fi
+
+failure_log="${test_root}/failure.log"
+if run_reset_fixture failure "${failure_log}"; then
+  echo "weather refusal did not fail the reset" >&2
+  exit 1
+fi
+failure_events="$(<"${failure_log}")"
+expected_failure=$'capture\nstop\nreload\nsettle\nteleport\nclear'
+if [[ "${failure_events}" != "${expected_failure}" ]]; then
+  echo "reset crossed the failed weather boundary: ${failure_events}" >&2
+  exit 1
+fi
+
+echo "test-reset-xplane-order: OK"

--- a/scripts/test-xplane-weather-clear.py
+++ b/scripts/test-xplane-weather-clear.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Test the X-Plane weather clear UDP protocol with a local peer."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import queue
+import socket
+import struct
+import sys
+import threading
+import unittest
+from unittest import mock
+
+sys.dont_write_bytecode = True
+
+import xplane_weather_clear as weather
+
+WIRE_RREF_REQUEST_HEADER = b"RREF\x00"
+WIRE_RREF_RESPONSE_HEADER = b"RREF,"
+
+
+class MockXPlane:
+    """A bounded RREF and DREF peer for one clear transaction."""
+
+    def __init__(
+        self,
+        refusal_status: float | None = None,
+        same_ack_actual_only: bool = False,
+    ) -> None:
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.response_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            self.socket.bind(("127.0.0.1", 0))
+            self.response_socket.bind(("127.0.0.1", 0))
+        except BaseException:
+            self.socket.close()
+            self.response_socket.close()
+            raise
+        self.socket.settimeout(0.02)
+        self.address = self.socket.getsockname()
+        self.response_address = self.response_socket.getsockname()
+        self.refusal_status = refusal_status
+        self.same_ack_actual_only = same_ack_actual_only
+        self.same_ack_actual_sent = False
+        self.client: tuple[str, int] | None = None
+        self.subscriptions: dict[int, int] = {}
+        self.write_seen = threading.Event()
+        self.ack_sent = threading.Event()
+        self.release_actual = threading.Event()
+        self.unsubscribed = threading.Event()
+        self.stop = threading.Event()
+        self.failures: queue.Queue[BaseException] = queue.Queue()
+        self.values = {
+            weather.PROTOCOL: weather.PROTOCOL_VERSION,
+            weather.EXPECTED_GENERATION: 7.0,
+            weather.ACTUAL_SPEED: 0.0,
+            weather.ACTUAL_VERTICAL: 0.0,
+            weather.ACTUAL_TURBULENCE_PROFILE_MAX: 0.0,
+        }
+        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread.start()
+
+    def run(self) -> None:
+        """Serve requests until the test closes the peer."""
+        try:
+            while not self.stop.is_set():
+                try:
+                    packet, sender = self.socket.recvfrom(4096)
+                    self.client = sender
+                    self.handle(packet)
+                except socket.timeout:
+                    pass
+                except OSError:
+                    if not self.stop.is_set():
+                        raise
+                self.publish()
+        except BaseException as error:  # The test thread reports the error.
+            self.failures.put(error)
+
+    def handle(self, packet: bytes) -> None:
+        """Validate and apply one client datagram."""
+        if packet.startswith(WIRE_RREF_REQUEST_HEADER):
+            if len(packet) != 413:
+                raise AssertionError(f"RREF request has {len(packet)} bytes")
+            header, rate, index, name = struct.unpack("<5sii400s", packet)
+            if header != WIRE_RREF_REQUEST_HEADER:
+                raise AssertionError(f"invalid RREF header {header!r}")
+            expected = weather.REFS.get(index)
+            actual = name.split(b"\x00", 1)[0].decode("ascii")
+            if expected != actual:
+                raise AssertionError(f"RREF {index} requested {actual!r}")
+            self.subscriptions[index] = rate
+            if len(self.subscriptions) == len(weather.REFS) and all(
+                value == 0 for value in self.subscriptions.values()
+            ):
+                self.unsubscribed.set()
+            return
+        if packet.startswith(b"DREF\x00"):
+            if len(packet) != 509:
+                raise AssertionError(f"DREF request has {len(packet)} bytes")
+            generation = struct.unpack_from("<f", packet, 5)[0]
+            name = packet[9:].split(b"\x00", 1)[0].decode("ascii")
+            if name != "pilotage/weather/clear_generation" or generation != 7.0:
+                raise AssertionError(f"invalid clear write {name}={generation}")
+            self.accept_clear()
+            return
+        raise AssertionError(f"unknown datagram header {packet[:5]!r}")
+
+    def accept_clear(self) -> None:
+        """Publish either the selected refusal or a complete region ACK."""
+        self.write_seen.set()
+        self.values[weather.RESPONSE_GENERATION] = 7.0
+        if self.refusal_status is not None:
+            self.values[weather.STATUS] = self.refusal_status
+            return
+        self.values.update(
+            {
+                weather.APPLIED_GENERATION: 7.0,
+                weather.RESPONSE_OPERATION: weather.CLEAR_OPERATION,
+                weather.RESPONSE_WIND_SPEED: 0.0,
+                weather.RESPONSE_WIND_DIRECTION: 0.0,
+                weather.RESPONSE_TURBULENCE: 0.0,
+                weather.STATUS: weather.CLEAR_STATUS,
+            }
+        )
+
+    def publish(self) -> None:
+        """Send current values at a test-controlled observation boundary."""
+        if self.client is None:
+            return
+        entries = []
+        for index, rate in self.subscriptions.items():
+            if rate <= 0 or index not in self.values:
+                continue
+            if self.write_seen.is_set() and index in weather.ACTUAL_REFS:
+                send_same_ack_actual = (
+                    self.same_ack_actual_only and not self.same_ack_actual_sent
+                )
+                if not self.release_actual.is_set() and not send_same_ack_actual:
+                    continue
+            entries.append(struct.pack("<if", index, self.values[index]))
+        if entries:
+            self.response_socket.sendto(
+                WIRE_RREF_RESPONSE_HEADER + b"".join(entries), self.client
+            )
+            if self.write_seen.is_set():
+                self.ack_sent.set()
+                self.same_ack_actual_sent = True
+
+    def close(self) -> None:
+        """Stop the peer and surface its thread failure."""
+        self.stop.set()
+        self.socket.close()
+        self.response_socket.close()
+        self.thread.join(timeout=2.0)
+        if self.thread.is_alive():
+            raise AssertionError("mock X-Plane peer did not stop")
+        if not self.failures.empty():
+            raise self.failures.get_nowait()
+
+
+def run_clear(
+    peer: MockXPlane,
+    clear_timeout_s: float = 1.0,
+    use_default_response: bool = False,
+) -> tuple[threading.Event, queue.Queue[object]]:
+    """Run one client transaction without blocking the test thread."""
+    done = threading.Event()
+    result: queue.Queue[object] = queue.Queue()
+
+    def target() -> None:
+        try:
+            response_address = (
+                None if use_default_response else peer.response_address
+            )
+            result.put(
+                weather.clear_weather(
+                    peer.address,
+                    1.0,
+                    clear_timeout_s,
+                    response_address=response_address,
+                )
+            )
+        except BaseException as error:
+            result.put(error)
+        finally:
+            done.set()
+
+    threading.Thread(target=target, daemon=True).start()
+    return done, result
+
+
+class WeatherClearTests(unittest.TestCase):
+    """Weather clear protocol behavior tests."""
+
+    def test_clear_requires_fresh_actual_samples_after_ack(self) -> None:
+        peer = MockXPlane()
+        try:
+            done, result = run_clear(peer)
+            self.assertTrue(peer.write_seen.wait(1.0))
+            self.assertTrue(peer.ack_sent.wait(1.0))
+            self.assertFalse(done.is_set(), "pre-write actual values cannot prove calm")
+            peer.release_actual.set()
+            self.assertTrue(done.wait(2.0))
+            self.assertEqual(result.get_nowait(), 7)
+            self.assertTrue(peer.unsubscribed.wait(1.0))
+        finally:
+            peer.close()
+
+    def test_default_response_port_reaches_the_xplane_sender(self) -> None:
+        peer = MockXPlane()
+        self.assertEqual(weather.DEFAULT_RESPONSE_PORT, 49001)
+        prior_port = weather.DEFAULT_RESPONSE_PORT
+        weather.DEFAULT_RESPONSE_PORT = peer.response_address[1]
+        try:
+            done, result = run_clear(peer, use_default_response=True)
+            self.assertTrue(peer.write_seen.wait(1.0))
+            self.assertTrue(peer.ack_sent.wait(1.0))
+            peer.release_actual.set()
+            self.assertTrue(done.wait(2.0))
+            self.assertEqual(result.get_nowait(), 7)
+        finally:
+            weather.DEFAULT_RESPONSE_PORT = prior_port
+            peer.close()
+
+    def test_negative_transaction_status_fails_closed(self) -> None:
+        peer = MockXPlane(refusal_status=-3.0)
+        try:
+            done, result = run_clear(peer)
+            self.assertTrue(done.wait(2.0))
+            error = result.get_nowait()
+            self.assertIsInstance(error, weather.WeatherClearError)
+            self.assertIn("refused clear generation 7", str(error))
+            self.assertTrue(peer.unsubscribed.wait(1.0))
+        finally:
+            peer.close()
+
+    def test_same_ack_frame_actual_values_do_not_prove_convergence(self) -> None:
+        peer = MockXPlane(same_ack_actual_only=True)
+        try:
+            done, result = run_clear(peer, clear_timeout_s=0.1)
+            self.assertTrue(done.wait(1.0))
+            error = result.get_nowait()
+            self.assertIsInstance(error, weather.WeatherClearError)
+            self.assertIn("did not converge", str(error))
+            self.assertTrue(peer.unsubscribed.wait(1.0))
+        finally:
+            peer.close()
+
+    def test_wrong_source_is_ignored_and_truncated_frame_is_rejected(self) -> None:
+        packet = WIRE_RREF_RESPONSE_HEADER + struct.pack(
+            "<if", weather.PROTOCOL, 1.0
+        )
+        self.assertEqual(
+            weather.decode_rref(packet, ("127.0.0.1", 1), ("127.0.0.1", 2)),
+            {},
+        )
+        with self.assertRaisesRegex(weather.WeatherClearError, "truncated"):
+            weather.decode_rref(packet + b"x", ("127.0.0.1", 2), ("127.0.0.1", 2))
+        with self.assertRaisesRegex(weather.WeatherClearError, "invalid RREF header"):
+            weather.decode_rref(
+                WIRE_RREF_REQUEST_HEADER
+                + struct.pack("<if", weather.PROTOCOL, 1.0),
+                ("127.0.0.1", 2),
+                ("127.0.0.1", 2),
+            )
+
+    def test_request_and_response_headers_follow_the_wire_contract(self) -> None:
+        request = weather.rref_request(
+            10, weather.PROTOCOL, weather.REFS[weather.PROTOCOL]
+        )
+        self.assertEqual(request[:5], WIRE_RREF_REQUEST_HEADER)
+        packet = WIRE_RREF_RESPONSE_HEADER + struct.pack(
+            "<if", weather.PROTOCOL, weather.PROTOCOL_VERSION
+        )
+        self.assertEqual(
+            weather.decode_rref(packet, ("127.0.0.1", 2), ("127.0.0.1", 2)),
+            {weather.PROTOCOL: weather.PROTOCOL_VERSION},
+        )
+
+    def test_unknown_response_index_cannot_change_contract_values(self) -> None:
+        packet = WIRE_RREF_RESPONSE_HEADER + struct.pack("<if", 999, 42.0)
+        self.assertEqual(
+            weather.decode_rref(packet, ("127.0.0.1", 2), ("127.0.0.1", 2)),
+            {},
+        )
+
+    def test_actual_calm_bounds_reject_invalid_measurements(self) -> None:
+        valid = {
+            weather.ACTUAL_SPEED: weather.WIND_TOLERANCE_MPS,
+            weather.ACTUAL_VERTICAL: -weather.WIND_TOLERANCE_MPS,
+            weather.ACTUAL_TURBULENCE_PROFILE_MAX: (
+                weather.TURBULENCE_TOLERANCE
+            ),
+        }
+        self.assertTrue(weather.actual_is_calm(valid))
+        valid[weather.ACTUAL_VERTICAL] = weather.WIND_TOLERANCE_MPS
+        self.assertTrue(weather.actual_is_calm(valid))
+        for index, invalid_value in [
+            (weather.ACTUAL_SPEED, -0.01),
+            (weather.ACTUAL_SPEED, float("nan")),
+            (weather.ACTUAL_VERTICAL, float("inf")),
+            (weather.ACTUAL_TURBULENCE_PROFILE_MAX, -0.01),
+        ]:
+            invalid = dict(valid)
+            invalid[index] = invalid_value
+            self.assertFalse(weather.actual_is_calm(invalid))
+
+    def test_response_endpoint_must_be_loopback_with_a_valid_port(self) -> None:
+        for response_address in [("192.0.2.1", 49001), ("127.0.0.1", 0)]:
+            with self.assertRaisesRegex(
+                weather.WeatherClearError, "response address must be loopback"
+            ):
+                weather.clear_weather(response_address=response_address)
+
+    def test_cli_passes_the_selected_response_port(self) -> None:
+        captured: dict[str, tuple[str, int]] = {}
+
+        def clear(
+            address: tuple[str, int],
+            *,
+            response_address: tuple[str, int],
+        ) -> int:
+            captured["request"] = address
+            captured["response"] = response_address
+            return 7
+
+        argv = [
+            "xplane_weather_clear.py",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "49010",
+            "--response-port",
+            "49011",
+        ]
+        with mock.patch.object(sys, "argv", argv), mock.patch.object(
+            weather, "clear_weather", side_effect=clear
+        ), contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(weather.main(), 0)
+        self.assertEqual(captured["request"], ("127.0.0.1", 49010))
+        self.assertEqual(captured["response"], ("127.0.0.1", 49011))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/xplane_weather_clear.py
+++ b/scripts/xplane_weather_clear.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Clear X-Plane weather through the Pilotage transaction datarefs."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import math
+import socket
+import struct
+import time
+from collections.abc import Mapping
+
+PROTOCOL_VERSION = 1.0
+MAXIMUM_GENERATION = 16_777_215
+READ_HZ = 10
+CLEAR_STATUS = 3.0
+CLEAR_OPERATION = 2.0
+WIND_TOLERANCE_MPS = 0.5
+TURBULENCE_TOLERANCE = 0.05
+REQUIRED_CALM_SAMPLES = 3
+DEFAULT_RESPONSE_PORT = 49001
+RREF_REQUEST_HEADER = b"RREF\x00"
+RREF_RESPONSE_HEADER = b"RREF,"
+DREF_HEADER = b"DREF\x00"
+
+PROTOCOL = 101
+EXPECTED_GENERATION = 102
+RESPONSE_GENERATION = 103
+APPLIED_GENERATION = 104
+RESPONSE_OPERATION = 105
+RESPONSE_WIND_SPEED = 106
+RESPONSE_WIND_DIRECTION = 107
+RESPONSE_TURBULENCE = 108
+STATUS = 109
+ACTUAL_SPEED = 110
+ACTUAL_VERTICAL = 111
+ACTUAL_TURBULENCE_PROFILE_MAX = 112
+
+REFS = {
+    PROTOCOL: "pilotage/weather/protocol_version",
+    EXPECTED_GENERATION: "pilotage/weather/expected_generation",
+    RESPONSE_GENERATION: "pilotage/weather/response_generation",
+    APPLIED_GENERATION: "pilotage/weather/applied_generation",
+    RESPONSE_OPERATION: "pilotage/weather/response_operation",
+    RESPONSE_WIND_SPEED: "pilotage/weather/response_wind_speed_mps",
+    RESPONSE_WIND_DIRECTION: "pilotage/weather/response_wind_direction_deg",
+    RESPONSE_TURBULENCE: "pilotage/weather/response_turbulence_scale",
+    STATUS: "pilotage/weather/status",
+    ACTUAL_SPEED: "pilotage/weather/actual_speed_mps",
+    ACTUAL_VERTICAL: "pilotage/weather/actual_vertical_mps",
+    ACTUAL_TURBULENCE_PROFILE_MAX: (
+        "pilotage/weather/actual_turbulence_profile_max"
+    ),
+}
+
+ACTUAL_REFS = {
+    ACTUAL_SPEED,
+    ACTUAL_VERTICAL,
+    ACTUAL_TURBULENCE_PROFILE_MAX,
+}
+
+
+class WeatherClearError(RuntimeError):
+    """The weather transaction did not prove a calm simulator state."""
+
+
+def rref_request(rate: int, index: int, dataref: str) -> bytes:
+    """Make one X-Plane RREF subscription datagram."""
+    encoded = dataref.encode("ascii")
+    if len(encoded) >= 400:
+        raise WeatherClearError(f"dataref name is too long: {dataref}")
+    return struct.pack("<5sii400s", RREF_REQUEST_HEADER, rate, index, encoded)
+
+
+def dref_request(dataref: str, value: float) -> bytes:
+    """Make one X-Plane DREF write datagram."""
+    encoded = dataref.encode("ascii") + b"\x00"
+    if len(encoded) > 500:
+        raise WeatherClearError(f"dataref name is too long: {dataref}")
+    return DREF_HEADER + struct.pack("<f500s", value, encoded)
+
+
+def decode_rref(
+    packet: bytes,
+    sender: tuple[str, int],
+    expected_sender: tuple[str, int],
+) -> dict[int, float]:
+    """Decode one complete RREF response from the selected simulator."""
+    if sender != expected_sender:
+        return {}
+    if not packet.startswith(RREF_RESPONSE_HEADER):
+        raise WeatherClearError("X-Plane returned an invalid RREF header")
+    body = packet[len(RREF_RESPONSE_HEADER) :]
+    if len(body) < 8 or len(body) % 8 != 0:
+        raise WeatherClearError("X-Plane returned a truncated RREF response")
+    values = {}
+    for offset in range(0, len(body), 8):
+        index, value = struct.unpack_from("<if", body, offset)
+        if index in REFS:
+            values[index] = value
+    return values
+
+
+def subscribe(
+    sock: socket.socket,
+    address: tuple[str, int],
+    rate: int,
+) -> None:
+    """Set the update rate for all weather transaction datarefs."""
+    for index, dataref in REFS.items():
+        sock.sendto(rref_request(rate, index, dataref), address)
+
+
+def receive(
+    sock: socket.socket,
+    response_address: tuple[str, int],
+    deadline: float,
+) -> dict[int, float]:
+    """Receive one valid response before a monotonic deadline."""
+    while time.monotonic() < deadline:
+        sock.settimeout(min(0.25, max(0.001, deadline - time.monotonic())))
+        try:
+            packet, sender = sock.recvfrom(4096)
+        except socket.timeout:
+            continue
+        values = decode_rref(packet, sender, response_address)
+        if values:
+            return values
+    return {}
+
+
+def validate_generation(value: float | None) -> int:
+    """Decode the exact integer generation that float32 can carry."""
+    if (
+        value is None
+        or not math.isfinite(value)
+        or value < 1.0
+        or value > MAXIMUM_GENERATION
+        or value != math.floor(value)
+    ):
+        raise WeatherClearError(f"invalid expected_generation {value}")
+    return int(value)
+
+
+def response_is_clear(values: Mapping[int, float], generation: int) -> bool:
+    """Test the complete region-commit acknowledgement tuple."""
+    return (
+        values.get(RESPONSE_GENERATION) == generation
+        and values.get(APPLIED_GENERATION) == generation
+        and values.get(RESPONSE_OPERATION) == CLEAR_OPERATION
+        and values.get(RESPONSE_WIND_SPEED) == 0.0
+        and values.get(RESPONSE_WIND_DIRECTION) == 0.0
+        and values.get(RESPONSE_TURBULENCE) == 0.0
+        and values.get(STATUS) == CLEAR_STATUS
+    )
+
+
+def actual_is_calm(values: Mapping[int, float]) -> bool:
+    """Test one complete aircraft-point observation."""
+    actual = [
+        values.get(ACTUAL_SPEED),
+        values.get(ACTUAL_VERTICAL),
+        values.get(ACTUAL_TURBULENCE_PROFILE_MAX),
+    ]
+    if any(value is None or not math.isfinite(value) for value in actual):
+        return False
+    speed, vertical, turbulence = actual
+    return (
+        0.0 <= speed <= WIND_TOLERANCE_MPS
+        and abs(vertical) <= WIND_TOLERANCE_MPS
+        and 0.0 <= turbulence <= TURBULENCE_TOLERANCE
+    )
+
+
+def discover_generation(
+    sock: socket.socket,
+    response_address: tuple[str, int],
+    timeout_s: float,
+) -> int:
+    """Read the plugin protocol and next generation."""
+    values: dict[int, float] = {}
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        values.update(receive(sock, response_address, deadline))
+        if PROTOCOL in values and EXPECTED_GENERATION in values:
+            break
+    if values.get(PROTOCOL) != PROTOCOL_VERSION:
+        raise WeatherClearError(
+            f"PilotageWeather protocol is {values.get(PROTOCOL)}, "
+            f"expected {PROTOCOL_VERSION}"
+        )
+    return validate_generation(values.get(EXPECTED_GENERATION))
+
+
+def wait_for_clear(
+    sock: socket.socket,
+    response_address: tuple[str, int],
+    generation: int,
+    timeout_s: float,
+) -> None:
+    """Wait for a region ACK and fresh stable aircraft-point calm samples."""
+    response: dict[int, float] = {}
+    actual: dict[int, float] = {}
+    ack_seen = False
+    calm_samples = 0
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        update = receive(sock, response_address, deadline)
+        response.update(
+            {
+                key: value
+                for key, value in update.items()
+                if key not in ACTUAL_REFS
+            }
+        )
+        status = response.get(STATUS)
+        if (
+            response.get(RESPONSE_GENERATION) == generation
+            and status is not None
+            and status < 0.0
+        ):
+            raise WeatherClearError(
+                f"PilotageWeather refused clear generation {generation}: status {status}"
+            )
+        if not ack_seen:
+            if response_is_clear(response, generation):
+                ack_seen = True
+                actual.clear()
+            continue
+        if not response_is_clear(response, generation):
+            raise WeatherClearError("PilotageWeather clear acknowledgement changed")
+        actual.update({key: value for key, value in update.items() if key in ACTUAL_REFS})
+        if ACTUAL_REFS.issubset(actual):
+            calm_samples = calm_samples + 1 if actual_is_calm(actual) else 0
+            actual.clear()
+            if calm_samples == REQUIRED_CALM_SAMPLES:
+                return
+    raise WeatherClearError(
+        f"PilotageWeather clear generation {generation} did not converge"
+    )
+
+
+def clear_weather(
+    address: tuple[str, int] = ("127.0.0.1", 49000),
+    discovery_timeout_s: float = 5.0,
+    clear_timeout_s: float = 15.0,
+    response_address: tuple[str, int] | None = None,
+) -> int:
+    """Clear weather and return the acknowledged generation."""
+    try:
+        is_loopback = ipaddress.ip_address(address[0]).is_loopback
+    except ValueError as error:
+        raise WeatherClearError(f"invalid X-Plane address {address[0]}") from error
+    if not is_loopback or not 1 <= address[1] <= 65535:
+        raise WeatherClearError(f"X-Plane address must be loopback: {address}")
+    if response_address is None:
+        response_address = (address[0], DEFAULT_RESPONSE_PORT)
+    try:
+        response_is_loopback = ipaddress.ip_address(response_address[0]).is_loopback
+    except ValueError as error:
+        raise WeatherClearError(
+            f"invalid X-Plane response address {response_address[0]}"
+        ) from error
+    if not response_is_loopback or not 1 <= response_address[1] <= 65535:
+        raise WeatherClearError(
+            f"X-Plane response address must be loopback: {response_address}"
+        )
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    try:
+        subscribe(sock, address, READ_HZ)
+        generation = discover_generation(sock, response_address, discovery_timeout_s)
+        sock.sendto(
+            dref_request("pilotage/weather/clear_generation", float(generation)),
+            address,
+        )
+        wait_for_clear(sock, response_address, generation, clear_timeout_s)
+        return generation
+    finally:
+        subscribe(sock, address, 0)
+        sock.close()
+
+
+def main() -> int:
+    """Run the weather clear command."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=49000)
+    parser.add_argument("--response-port", type=int, default=DEFAULT_RESPONSE_PORT)
+    args = parser.parse_args()
+    try:
+        generation = clear_weather(
+            (args.host, args.port),
+            response_address=(args.host, args.response_port),
+        )
+    except WeatherClearError as error:
+        parser.exit(1, f"{error}\n")
+    print(f"weather clear generation {generation} acknowledged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sim/xplane/weather/PilotageWeather.cpp
+++ b/sim/xplane/weather/PilotageWeather.cpp
@@ -1,0 +1,419 @@
+// Transactional weather control for Pilotage simulation trials.
+
+#include "XPLMDataAccess.h"
+#include "XPLMPlugin.h"
+#include "XPLMProcessing.h"
+#include "XPLMUtilities.h"
+
+#include "weather_state.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+using pilotage::weather::CalmPayload;
+using pilotage::weather::PendingWeatherRequest;
+using pilotage::weather::RequestStatus;
+using pilotage::weather::WeatherOperation;
+using pilotage::weather::WeatherPayload;
+using pilotage::weather::WeatherTransactionState;
+
+constexpr int kMaximumWindLayers = 13;
+constexpr float kReadbackTolerance = 0.0001F;
+constexpr float kProtocolVersion = 1.0F;
+
+WeatherPayload staged;
+WeatherTransactionState transaction;
+float apply_generation = 0.0F;
+float clear_generation = 0.0F;
+float actual_speed_mps = 0.0F;
+float actual_direction_deg = 0.0F;
+float actual_vertical_mps = 0.0F;
+float actual_turbulence_profile_max = 0.0F;
+bool loop_registered = false;
+bool simulator_refs_bound = false;
+
+std::array<XPLMDataRef, 18> custom_refs{};
+XPLMDataRef update_immediately_ref = nullptr;
+XPLMDataRef change_mode_ref = nullptr;
+XPLMDataRef variability_ref = nullptr;
+XPLMDataRef wind_speed_ref = nullptr;
+XPLMDataRef wind_direction_ref = nullptr;
+XPLMDataRef shear_speed_ref = nullptr;
+XPLMDataRef shear_direction_ref = nullptr;
+XPLMDataRef turbulence_ref = nullptr;
+XPLMDataRef thermal_rate_ref = nullptr;
+XPLMDataRef actual_speed_ref = nullptr;
+XPLMDataRef actual_direction_ref = nullptr;
+XPLMDataRef actual_vertical_ref = nullptr;
+XPLMDataRef actual_turbulence_ref = nullptr;
+
+float ReadFloat(void* refcon) {
+    return *static_cast<float*>(refcon);
+}
+
+void WriteFloat(void* refcon, float value) {
+    *static_cast<float*>(refcon) = value;
+}
+
+void WriteApplyGeneration(void*, float value) {
+    apply_generation = value;
+    transaction.TriggerApply(value, staged);
+}
+
+void WriteClearGeneration(void*, float value) {
+    clear_generation = value;
+    transaction.TriggerClear(value);
+}
+
+float ReadExpectedGeneration(void*) {
+    return static_cast<float>(transaction.expected_generation());
+}
+
+float ReadResponseGeneration(void*) {
+    return static_cast<float>(transaction.response_generation());
+}
+
+float ReadAppliedGeneration(void*) {
+    return static_cast<float>(transaction.applied_generation());
+}
+
+float ReadResponseOperation(void*) {
+    return static_cast<float>(transaction.response_operation());
+}
+
+float ReadResponseWindSpeed(void*) {
+    return transaction.response_payload().wind_speed_mps;
+}
+
+float ReadResponseWindDirection(void*) {
+    return transaction.response_payload().wind_direction_deg;
+}
+
+float ReadResponseTurbulence(void*) {
+    return transaction.response_payload().turbulence_scale;
+}
+
+float ReadStatus(void*) {
+    return static_cast<float>(transaction.status());
+}
+
+float ReadProtocolVersion(void*) { return kProtocolVersion; }
+
+XPLMDataRef RegisterFloatValue(const char* name, bool writable, float* value,
+                               XPLMSetDataf_f writer = WriteFloat) {
+    return XPLMRegisterDataAccessor(
+        name, xplmType_Float, writable ? 1 : 0, nullptr, nullptr, ReadFloat,
+        writable ? writer : nullptr, nullptr, nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr, nullptr, value, value);
+}
+
+XPLMDataRef RegisterFloatReader(const char* name, XPLMGetDataf_f reader) {
+    return XPLMRegisterDataAccessor(
+        name, xplmType_Float, 0, nullptr, nullptr, reader, nullptr, nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        nullptr);
+}
+
+void RegisterCustomDatarefs() {
+    custom_refs[0] = RegisterFloatValue(
+        "pilotage/weather/wind_speed_mps", true, &staged.wind_speed_mps);
+    custom_refs[1] = RegisterFloatValue(
+        "pilotage/weather/wind_direction_deg", true,
+        &staged.wind_direction_deg);
+    custom_refs[2] = RegisterFloatValue(
+        "pilotage/weather/turbulence_scale", true,
+        &staged.turbulence_scale);
+    custom_refs[3] = RegisterFloatValue(
+        "pilotage/weather/apply_generation", true, &apply_generation,
+        WriteApplyGeneration);
+    custom_refs[4] = RegisterFloatValue(
+        "pilotage/weather/clear_generation", true, &clear_generation,
+        WriteClearGeneration);
+    custom_refs[5] = RegisterFloatReader(
+        "pilotage/weather/expected_generation", ReadExpectedGeneration);
+    custom_refs[6] = RegisterFloatReader(
+        "pilotage/weather/response_generation", ReadResponseGeneration);
+    custom_refs[7] = RegisterFloatReader(
+        "pilotage/weather/applied_generation", ReadAppliedGeneration);
+    custom_refs[8] = RegisterFloatReader(
+        "pilotage/weather/response_operation", ReadResponseOperation);
+    custom_refs[9] = RegisterFloatReader(
+        "pilotage/weather/response_wind_speed_mps", ReadResponseWindSpeed);
+    custom_refs[10] = RegisterFloatReader(
+        "pilotage/weather/response_wind_direction_deg",
+        ReadResponseWindDirection);
+    custom_refs[11] = RegisterFloatReader(
+        "pilotage/weather/response_turbulence_scale",
+        ReadResponseTurbulence);
+    custom_refs[12] =
+        RegisterFloatReader("pilotage/weather/status", ReadStatus);
+    custom_refs[13] = RegisterFloatValue(
+        "pilotage/weather/actual_speed_mps", false, &actual_speed_mps);
+    custom_refs[14] = RegisterFloatValue(
+        "pilotage/weather/actual_direction_deg", false,
+        &actual_direction_deg);
+    custom_refs[15] = RegisterFloatValue(
+        "pilotage/weather/actual_vertical_mps", false, &actual_vertical_mps);
+    custom_refs[16] = RegisterFloatValue(
+        "pilotage/weather/actual_turbulence_profile_max", false,
+        &actual_turbulence_profile_max);
+    custom_refs[17] = RegisterFloatReader(
+        "pilotage/weather/protocol_version", ReadProtocolVersion);
+}
+
+void BindSimulatorDatarefs() {
+    update_immediately_ref =
+        XPLMFindDataRef("sim/weather/region/update_immediately");
+    change_mode_ref = XPLMFindDataRef("sim/weather/region/change_mode");
+    variability_ref = XPLMFindDataRef("sim/weather/region/variability_pct");
+    wind_speed_ref = XPLMFindDataRef("sim/weather/region/wind_speed_msc");
+    wind_direction_ref =
+        XPLMFindDataRef("sim/weather/region/wind_direction_degt");
+    shear_speed_ref = XPLMFindDataRef("sim/weather/region/shear_speed_msc");
+    shear_direction_ref =
+        XPLMFindDataRef("sim/weather/region/shear_direction_degt");
+    turbulence_ref = XPLMFindDataRef("sim/weather/region/turbulence");
+    thermal_rate_ref = XPLMFindDataRef("sim/weather/region/thermal_rate_ms");
+    actual_speed_ref =
+        XPLMFindDataRef("sim/weather/aircraft/wind_now_speed_msc");
+    actual_direction_ref =
+        XPLMFindDataRef("sim/weather/aircraft/wind_now_direction_degt");
+    actual_vertical_ref =
+        XPLMFindDataRef("sim/weather/aircraft/wind_now_y_msc");
+    actual_turbulence_ref =
+        XPLMFindDataRef("sim/weather/aircraft/turbulence");
+    simulator_refs_bound = true;
+}
+
+bool HasType(XPLMDataRef dataref, XPLMDataTypeID type) {
+    return dataref != nullptr && (XPLMGetDataRefTypes(dataref) & type) != 0;
+}
+
+bool IsWritableScalar(XPLMDataRef dataref, XPLMDataTypeID type) {
+    return HasType(dataref, type) && XPLMCanWriteDataRef(dataref) != 0;
+}
+
+bool IsWritableWindArray(XPLMDataRef dataref) {
+    return IsWritableScalar(dataref, xplmType_FloatArray) &&
+           XPLMGetDatavf(dataref, nullptr, 0, 0) == kMaximumWindLayers;
+}
+
+bool RegionDatarefsAreUsable() {
+    return IsWritableScalar(update_immediately_ref, xplmType_Int) &&
+           IsWritableScalar(change_mode_ref, xplmType_Int) &&
+           IsWritableScalar(variability_ref, xplmType_Float) &&
+           IsWritableWindArray(wind_speed_ref) &&
+           IsWritableWindArray(wind_direction_ref) &&
+           IsWritableWindArray(shear_speed_ref) &&
+           IsWritableWindArray(shear_direction_ref) &&
+           IsWritableWindArray(turbulence_ref) &&
+           IsWritableScalar(thermal_rate_ref, xplmType_Float);
+}
+
+bool ActualDatarefsAreUsable() {
+    return HasType(actual_speed_ref, xplmType_Float) &&
+           HasType(actual_direction_ref, xplmType_Float) &&
+           HasType(actual_vertical_ref, xplmType_Float) &&
+           HasType(actual_turbulence_ref, xplmType_FloatArray) &&
+           XPLMGetDatavf(actual_turbulence_ref, nullptr, 0, 0) ==
+               kMaximumWindLayers;
+}
+
+bool NearlyEqual(float first, float second) {
+    return std::fabs(first - second) <= kReadbackTolerance;
+}
+
+bool DirectionMatches(float actual, float requested) {
+    if (NearlyEqual(actual, requested)) {
+        return true;
+    }
+    return (NearlyEqual(actual, 0.0F) && NearlyEqual(requested, 360.0F)) ||
+           (NearlyEqual(actual, 360.0F) && NearlyEqual(requested, 0.0F));
+}
+
+RequestStatus WriteRegionWeather(const WeatherPayload& payload) {
+    if (!RegionDatarefsAreUsable()) {
+        return RequestStatus::DatarefMissing;
+    }
+
+    std::array<float, kMaximumWindLayers> speed{};
+    std::array<float, kMaximumWindLayers> direction{};
+    std::array<float, kMaximumWindLayers> shear{};
+    std::array<float, kMaximumWindLayers> turbulence{};
+    speed.fill(payload.wind_speed_mps);
+    direction.fill(payload.wind_direction_deg);
+    turbulence.fill(payload.turbulence_scale);
+
+    XPLMSetDatai(change_mode_ref, 3);
+    XPLMSetDataf(variability_ref, 0.0F);
+    XPLMSetDatai(update_immediately_ref, 1);
+    XPLMSetDatavf(wind_speed_ref, speed.data(), 0, kMaximumWindLayers);
+    XPLMSetDatavf(wind_direction_ref, direction.data(), 0,
+                  kMaximumWindLayers);
+    XPLMSetDatavf(shear_speed_ref, shear.data(), 0, kMaximumWindLayers);
+    XPLMSetDatavf(shear_direction_ref, shear.data(), 0,
+                  kMaximumWindLayers);
+    XPLMSetDatavf(turbulence_ref, turbulence.data(), 0,
+                  kMaximumWindLayers);
+    XPLMSetDataf(thermal_rate_ref, 0.0F);
+
+    std::array<float, kMaximumWindLayers> read_speed{};
+    std::array<float, kMaximumWindLayers> read_direction{};
+    std::array<float, kMaximumWindLayers> read_shear_speed{};
+    std::array<float, kMaximumWindLayers> read_shear_direction{};
+    std::array<float, kMaximumWindLayers> read_turbulence{};
+    if (XPLMGetDatavf(wind_speed_ref, read_speed.data(), 0,
+                      kMaximumWindLayers) != kMaximumWindLayers ||
+        XPLMGetDatavf(wind_direction_ref, read_direction.data(), 0,
+                      kMaximumWindLayers) != kMaximumWindLayers ||
+        XPLMGetDatavf(shear_speed_ref, read_shear_speed.data(), 0,
+                      kMaximumWindLayers) != kMaximumWindLayers ||
+        XPLMGetDatavf(shear_direction_ref, read_shear_direction.data(), 0,
+                      kMaximumWindLayers) != kMaximumWindLayers ||
+        XPLMGetDatavf(turbulence_ref, read_turbulence.data(), 0,
+                      kMaximumWindLayers) != kMaximumWindLayers) {
+        return RequestStatus::ReadbackMismatch;
+    }
+
+    for (int index = 0; index < kMaximumWindLayers; ++index) {
+        if (!NearlyEqual(read_speed[index], payload.wind_speed_mps) ||
+            !DirectionMatches(read_direction[index],
+                              payload.wind_direction_deg) ||
+            !NearlyEqual(read_shear_speed[index], 0.0F) ||
+            !NearlyEqual(read_shear_direction[index], 0.0F) ||
+            !NearlyEqual(read_turbulence[index],
+                         payload.turbulence_scale)) {
+            return RequestStatus::ReadbackMismatch;
+        }
+    }
+    if (XPLMGetDatai(update_immediately_ref) != 1 ||
+        XPLMGetDatai(change_mode_ref) != 3 ||
+        !NearlyEqual(XPLMGetDataf(variability_ref), 0.0F) ||
+        !NearlyEqual(XPLMGetDataf(thermal_rate_ref), 0.0F)) {
+        return RequestStatus::ReadbackMismatch;
+    }
+    return RequestStatus::Applied;
+}
+
+void ApplyPendingRequest() {
+    PendingWeatherRequest request;
+    if (!transaction.TakePending(&request)) {
+        return;
+    }
+    const bool actual_datarefs_usable = ActualDatarefsAreUsable();
+    if (request.operation == WeatherOperation::Apply &&
+        !actual_datarefs_usable) {
+        transaction.Fail(request, RequestStatus::DatarefMissing);
+        return;
+    }
+    const RequestStatus result = WriteRegionWeather(request.payload);
+    if (result == RequestStatus::Applied) {
+        if (request.operation == WeatherOperation::Clear) {
+            staged = CalmPayload();
+            if (!actual_datarefs_usable) {
+                transaction.Fail(request, RequestStatus::DatarefMissing);
+                return;
+            }
+        }
+        transaction.Complete(request);
+    } else {
+        transaction.Fail(request, result);
+    }
+}
+
+void ReadActualWeather() {
+    if (actual_speed_ref != nullptr) {
+        actual_speed_mps = XPLMGetDataf(actual_speed_ref);
+    }
+    if (actual_direction_ref != nullptr) {
+        actual_direction_deg = XPLMGetDataf(actual_direction_ref);
+    }
+    if (actual_vertical_ref != nullptr) {
+        actual_vertical_mps = XPLMGetDataf(actual_vertical_ref);
+    }
+    std::array<float, kMaximumWindLayers> turbulence{};
+    actual_turbulence_profile_max =
+        std::numeric_limits<float>::quiet_NaN();
+    if (actual_turbulence_ref != nullptr &&
+        XPLMGetDatavf(actual_turbulence_ref, turbulence.data(), 0,
+                      kMaximumWindLayers) == kMaximumWindLayers) {
+        actual_turbulence_profile_max = 0.0F;
+        for (float value : turbulence) {
+            if (!std::isfinite(value) || value < 0.0F ||
+                value > pilotage::weather::kMaximumTurbulenceScale) {
+                actual_turbulence_profile_max =
+                    std::numeric_limits<float>::quiet_NaN();
+                break;
+            }
+            actual_turbulence_profile_max =
+                std::max(actual_turbulence_profile_max, value);
+        }
+    }
+}
+
+void ClearForUnload() {
+    if (simulator_refs_bound &&
+        WriteRegionWeather(CalmPayload()) != RequestStatus::Applied) {
+        XPLMDebugString(
+            "PilotageWeather: weather clear readback failed during unload\n");
+    }
+    staged = CalmPayload();
+    apply_generation = 0.0F;
+    clear_generation = 0.0F;
+    transaction.Disable();
+}
+
+float FlightLoop(float, float, int, void*) {
+    ApplyPendingRequest();
+    ReadActualWeather();
+    return -1.0F;
+}
+
+}  // namespace
+
+PLUGIN_API int XPluginStart(char* out_name, char* out_sig, char* out_desc) {
+    std::strcpy(out_name, "PilotageWeather");
+    std::strcpy(out_sig, "systems.sokoly.pilotage.weather");
+    std::strcpy(out_desc, "Transactional weather control for Pilotage trials");
+    transaction.Disable();
+    RegisterCustomDatarefs();
+    return 1;
+}
+
+PLUGIN_API void XPluginStop(void) {
+    if (loop_registered) {
+        XPLMUnregisterFlightLoopCallback(FlightLoop, nullptr);
+        loop_registered = false;
+    }
+    ClearForUnload();
+    for (XPLMDataRef ref : custom_refs) {
+        if (ref != nullptr) {
+            XPLMUnregisterDataAccessor(ref);
+        }
+    }
+}
+
+PLUGIN_API int XPluginEnable(void) {
+    BindSimulatorDatarefs();
+    transaction.Enable();
+    if (!loop_registered) {
+        XPLMRegisterFlightLoopCallback(FlightLoop, -1.0F, nullptr);
+        loop_registered = true;
+    }
+    return 1;
+}
+
+PLUGIN_API void XPluginDisable(void) {
+    if (loop_registered) {
+        XPLMUnregisterFlightLoopCallback(FlightLoop, nullptr);
+        loop_registered = false;
+    }
+    ClearForUnload();
+}
+
+PLUGIN_API void XPluginReceiveMessage(XPLMPluginID, int, void*) {}

--- a/sim/xplane/weather/test_support/xplm/XPLMDataAccess.h
+++ b/sim/xplane/weather/test_support/xplm/XPLMDataAccess.h
@@ -1,0 +1,56 @@
+#pragma once
+
+typedef void* XPLMDataRef;
+typedef int XPLMDataTypeID;
+
+enum {
+    xplmType_Unknown = 0,
+    xplmType_Int = 1,
+    xplmType_Float = 2,
+    xplmType_Double = 4,
+    xplmType_FloatArray = 8,
+    xplmType_IntArray = 16,
+    xplmType_Data = 32,
+};
+
+typedef int (*XPLMGetDatai_f)(void*);
+typedef void (*XPLMSetDatai_f)(void*, int);
+typedef float (*XPLMGetDataf_f)(void*);
+typedef void (*XPLMSetDataf_f)(void*, float);
+typedef double (*XPLMGetDatad_f)(void*);
+typedef void (*XPLMSetDatad_f)(void*, double);
+typedef int (*XPLMGetDatavi_f)(void*, int*, int, int);
+typedef void (*XPLMSetDatavi_f)(void*, int*, int, int);
+typedef int (*XPLMGetDatavf_f)(void*, float*, int, int);
+typedef void (*XPLMSetDatavf_f)(void*, float*, int, int);
+typedef int (*XPLMGetDatab_f)(void*, void*, int, int);
+typedef void (*XPLMSetDatab_f)(void*, void*, int, int);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+XPLMDataRef XPLMFindDataRef(const char* name);
+int XPLMCanWriteDataRef(XPLMDataRef dataref);
+XPLMDataTypeID XPLMGetDataRefTypes(XPLMDataRef dataref);
+int XPLMGetDatai(XPLMDataRef dataref);
+void XPLMSetDatai(XPLMDataRef dataref, int value);
+float XPLMGetDataf(XPLMDataRef dataref);
+void XPLMSetDataf(XPLMDataRef dataref, float value);
+int XPLMGetDatavf(XPLMDataRef dataref, float* values, int offset,
+                  int maximum);
+void XPLMSetDatavf(XPLMDataRef dataref, float* values, int offset, int count);
+XPLMDataRef XPLMRegisterDataAccessor(
+    const char* name, XPLMDataTypeID type, int writable,
+    XPLMGetDatai_f read_int, XPLMSetDatai_f write_int,
+    XPLMGetDataf_f read_float, XPLMSetDataf_f write_float,
+    XPLMGetDatad_f read_double, XPLMSetDatad_f write_double,
+    XPLMGetDatavi_f read_int_array, XPLMSetDatavi_f write_int_array,
+    XPLMGetDatavf_f read_float_array, XPLMSetDatavf_f write_float_array,
+    XPLMGetDatab_f read_data, XPLMSetDatab_f write_data, void* read_refcon,
+    void* write_refcon);
+void XPLMUnregisterDataAccessor(XPLMDataRef dataref);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sim/xplane/weather/test_support/xplm/XPLMPlugin.h
+++ b/sim/xplane/weather/test_support/xplm/XPLMPlugin.h
@@ -1,0 +1,9 @@
+#pragma once
+
+typedef int XPLMPluginID;
+
+#ifdef __cplusplus
+#define PLUGIN_API extern "C"
+#else
+#define PLUGIN_API
+#endif

--- a/sim/xplane/weather/test_support/xplm/XPLMProcessing.h
+++ b/sim/xplane/weather/test_support/xplm/XPLMProcessing.h
@@ -1,0 +1,15 @@
+#pragma once
+
+typedef float (*XPLMFlightLoop_f)(float, float, int, void*);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void XPLMRegisterFlightLoopCallback(XPLMFlightLoop_f callback, float interval,
+                                    void* refcon);
+void XPLMUnregisterFlightLoopCallback(XPLMFlightLoop_f callback, void* refcon);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sim/xplane/weather/test_support/xplm/XPLMUtilities.h
+++ b/sim/xplane/weather/test_support/xplm/XPLMUtilities.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void XPLMDebugString(const char* message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sim/xplane/weather/test_support/xplm/fake_xplm.cpp
+++ b/sim/xplane/weather/test_support/xplm/fake_xplm.cpp
@@ -1,0 +1,297 @@
+#include "fake_xplm.h"
+
+#include "XPLMProcessing.h"
+#include "XPLMUtilities.h"
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace {
+
+struct FakeDataRef {
+    std::string name;
+    XPLMDataTypeID type = xplmType_Unknown;
+    bool writable = false;
+    int int_value = 0;
+    float float_value = 0.0F;
+    std::vector<float> array_value;
+    fake_xplm::WriteMode write_mode = fake_xplm::WriteMode::Store;
+    XPLMGetDatai_f read_int = nullptr;
+    XPLMSetDatai_f write_int = nullptr;
+    XPLMGetDataf_f read_float = nullptr;
+    XPLMSetDataf_f write_float = nullptr;
+    void* read_refcon = nullptr;
+    void* write_refcon = nullptr;
+};
+
+struct FakeRegistry {
+    std::unordered_map<std::string, std::unique_ptr<FakeDataRef>> refs;
+    XPLMFlightLoop_f flight_loop = nullptr;
+    void* flight_loop_refcon = nullptr;
+    std::string debug_log;
+};
+
+FakeRegistry& Registry() {
+    static FakeRegistry registry;
+    return registry;
+}
+
+FakeDataRef* FromHandle(XPLMDataRef dataref) {
+    return static_cast<FakeDataRef*>(dataref);
+}
+
+FakeDataRef& Require(const std::string& name) {
+    const auto found = Registry().refs.find(name);
+    if (found == Registry().refs.end()) {
+        throw std::runtime_error("fake dataref not found: " + name);
+    }
+    return *found->second;
+}
+
+FakeDataRef& Add(const std::string& name, XPLMDataTypeID type,
+                 bool writable) {
+    auto dataref = std::make_unique<FakeDataRef>();
+    dataref->name = name;
+    dataref->type = type;
+    dataref->writable = writable;
+    FakeDataRef* value = dataref.get();
+    Registry().refs[name] = std::move(dataref);
+    return *value;
+}
+
+void AddInt(const char* name, int value, bool writable) {
+    FakeDataRef& dataref = Add(name, xplmType_Int, writable);
+    dataref.int_value = value;
+}
+
+void AddFloat(const char* name, float value, bool writable) {
+    FakeDataRef& dataref = Add(name, xplmType_Float, writable);
+    dataref.float_value = value;
+}
+
+void AddArray(const char* name, std::size_t count, bool writable) {
+    FakeDataRef& dataref = Add(name, xplmType_FloatArray, writable);
+    dataref.array_value.assign(count, 0.0F);
+}
+
+bool HasType(const FakeDataRef* dataref, XPLMDataTypeID type) {
+    return dataref != nullptr && (dataref->type & type) != 0;
+}
+
+}  // namespace
+
+namespace fake_xplm {
+
+void Reset() { Registry() = FakeRegistry{}; }
+
+void InstallWeatherDataRefs() {
+    AddInt("sim/weather/region/update_immediately", 0, true);
+    AddInt("sim/weather/region/change_mode", 0, true);
+    AddFloat("sim/weather/region/variability_pct", 50.0F, true);
+    AddArray("sim/weather/region/wind_speed_msc", 13, true);
+    AddArray("sim/weather/region/wind_direction_degt", 13, true);
+    AddArray("sim/weather/region/shear_speed_msc", 13, true);
+    AddArray("sim/weather/region/shear_direction_degt", 13, true);
+    AddArray("sim/weather/region/turbulence", 13, true);
+    AddFloat("sim/weather/region/thermal_rate_ms", 1.0F, true);
+    AddFloat("sim/weather/aircraft/wind_now_speed_msc", 0.0F, false);
+    AddFloat("sim/weather/aircraft/wind_now_direction_degt", 0.0F, false);
+    AddFloat("sim/weather/aircraft/wind_now_y_msc", 0.0F, false);
+    AddArray("sim/weather/aircraft/turbulence", 13, false);
+}
+
+void SetType(const std::string& name, XPLMDataTypeID type) {
+    Require(name).type = type;
+}
+
+void SetWritable(const std::string& name, bool writable) {
+    Require(name).writable = writable;
+}
+
+void SetArraySize(const std::string& name, std::size_t size) {
+    Require(name).array_value.resize(size);
+}
+
+void SetWriteMode(const std::string& name, WriteMode mode) {
+    Require(name).write_mode = mode;
+}
+
+void StoreInt(const std::string& name, int value) {
+    Require(name).int_value = value;
+}
+
+void StoreFloat(const std::string& name, float value) {
+    Require(name).float_value = value;
+}
+
+void StoreArray(const std::string& name, const std::vector<float>& values) {
+    Require(name).array_value = values;
+}
+
+int StoredInt(const std::string& name) { return Require(name).int_value; }
+
+float StoredFloat(const std::string& name) {
+    return Require(name).float_value;
+}
+
+std::vector<float> StoredArray(const std::string& name) {
+    return Require(name).array_value;
+}
+
+void RunFlightLoop() {
+    FakeRegistry& registry = Registry();
+    if (registry.flight_loop == nullptr) {
+        throw std::runtime_error("fake flight loop is not registered");
+    }
+    registry.flight_loop(0.0F, 0.0F, 1, registry.flight_loop_refcon);
+}
+
+}  // namespace fake_xplm
+
+extern "C" XPLMDataRef XPLMFindDataRef(const char* name) {
+    if (name == nullptr) {
+        return nullptr;
+    }
+    const auto found = Registry().refs.find(name);
+    return found == Registry().refs.end() ? nullptr : found->second.get();
+}
+
+extern "C" int XPLMCanWriteDataRef(XPLMDataRef dataref) {
+    const FakeDataRef* value = FromHandle(dataref);
+    return value != nullptr && value->writable ? 1 : 0;
+}
+
+extern "C" XPLMDataTypeID XPLMGetDataRefTypes(XPLMDataRef dataref) {
+    const FakeDataRef* value = FromHandle(dataref);
+    return value == nullptr ? xplmType_Unknown : value->type;
+}
+
+extern "C" int XPLMGetDatai(XPLMDataRef dataref) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_Int)) {
+        return 0;
+    }
+    return value->read_int == nullptr ? value->int_value
+                                      : value->read_int(value->read_refcon);
+}
+
+extern "C" void XPLMSetDatai(XPLMDataRef dataref, int input) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_Int) || !value->writable ||
+        value->write_mode == fake_xplm::WriteMode::Ignore) {
+        return;
+    }
+    if (value->write_int == nullptr) {
+        value->int_value = input;
+    } else {
+        value->write_int(value->write_refcon, input);
+    }
+}
+
+extern "C" float XPLMGetDataf(XPLMDataRef dataref) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_Float)) {
+        return 0.0F;
+    }
+    return value->read_float == nullptr
+               ? value->float_value
+               : value->read_float(value->read_refcon);
+}
+
+extern "C" void XPLMSetDataf(XPLMDataRef dataref, float input) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_Float) || !value->writable ||
+        value->write_mode == fake_xplm::WriteMode::Ignore) {
+        return;
+    }
+    if (value->write_float == nullptr) {
+        value->float_value = input;
+    } else {
+        value->write_float(value->write_refcon, input);
+    }
+}
+
+extern "C" int XPLMGetDatavf(XPLMDataRef dataref, float* output, int offset,
+                               int maximum) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_FloatArray)) {
+        return 0;
+    }
+    if (output == nullptr) {
+        return static_cast<int>(value->array_value.size());
+    }
+    if (offset < 0 || maximum <= 0 ||
+        static_cast<std::size_t>(offset) >= value->array_value.size()) {
+        return 0;
+    }
+    const std::size_t available = value->array_value.size() - offset;
+    const std::size_t count =
+        std::min(available, static_cast<std::size_t>(maximum));
+    std::copy_n(value->array_value.begin() + offset, count, output);
+    return static_cast<int>(count);
+}
+
+extern "C" void XPLMSetDatavf(XPLMDataRef dataref, float* input, int offset,
+                                int count) {
+    FakeDataRef* value = FromHandle(dataref);
+    if (!HasType(value, xplmType_FloatArray) || !value->writable ||
+        value->write_mode == fake_xplm::WriteMode::Ignore || input == nullptr ||
+        offset < 0 || count <= 0 ||
+        static_cast<std::size_t>(offset) >= value->array_value.size()) {
+        return;
+    }
+    const std::size_t available = value->array_value.size() - offset;
+    const std::size_t copied =
+        std::min(available, static_cast<std::size_t>(count));
+    std::copy_n(input, copied, value->array_value.begin() + offset);
+}
+
+extern "C" XPLMDataRef XPLMRegisterDataAccessor(
+    const char* name, XPLMDataTypeID type, int writable,
+    XPLMGetDatai_f read_int, XPLMSetDatai_f write_int,
+    XPLMGetDataf_f read_float, XPLMSetDataf_f write_float, XPLMGetDatad_f,
+    XPLMSetDatad_f, XPLMGetDatavi_f, XPLMSetDatavi_f, XPLMGetDatavf_f,
+    XPLMSetDatavf_f, XPLMGetDatab_f, XPLMSetDatab_f, void* read_refcon,
+    void* write_refcon) {
+    FakeDataRef& dataref = Add(name, type, writable != 0);
+    dataref.read_int = read_int;
+    dataref.write_int = write_int;
+    dataref.read_float = read_float;
+    dataref.write_float = write_float;
+    dataref.read_refcon = read_refcon;
+    dataref.write_refcon = write_refcon;
+    return &dataref;
+}
+
+extern "C" void XPLMUnregisterDataAccessor(XPLMDataRef dataref) {
+    for (auto iterator = Registry().refs.begin();
+         iterator != Registry().refs.end(); ++iterator) {
+        if (iterator->second.get() == dataref) {
+            Registry().refs.erase(iterator);
+            return;
+        }
+    }
+}
+
+extern "C" void XPLMRegisterFlightLoopCallback(
+    XPLMFlightLoop_f callback, float, void* refcon) {
+    Registry().flight_loop = callback;
+    Registry().flight_loop_refcon = refcon;
+}
+
+extern "C" void XPLMUnregisterFlightLoopCallback(
+    XPLMFlightLoop_f callback, void* refcon) {
+    if (Registry().flight_loop == callback &&
+        Registry().flight_loop_refcon == refcon) {
+        Registry().flight_loop = nullptr;
+        Registry().flight_loop_refcon = nullptr;
+    }
+}
+
+extern "C" void XPLMDebugString(const char* message) {
+    if (message != nullptr) {
+        Registry().debug_log += message;
+    }
+}

--- a/sim/xplane/weather/test_support/xplm/fake_xplm.h
+++ b/sim/xplane/weather/test_support/xplm/fake_xplm.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "XPLMDataAccess.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace fake_xplm {
+
+enum class WriteMode {
+    Store,
+    Ignore,
+};
+
+void Reset();
+void InstallWeatherDataRefs();
+void SetType(const std::string& name, XPLMDataTypeID type);
+void SetWritable(const std::string& name, bool writable);
+void SetArraySize(const std::string& name, std::size_t size);
+void SetWriteMode(const std::string& name, WriteMode mode);
+void StoreInt(const std::string& name, int value);
+void StoreFloat(const std::string& name, float value);
+void StoreArray(const std::string& name, const std::vector<float>& values);
+int StoredInt(const std::string& name);
+float StoredFloat(const std::string& name);
+std::vector<float> StoredArray(const std::string& name);
+void RunFlightLoop();
+
+}  // namespace fake_xplm

--- a/sim/xplane/weather/weather_plugin_tests.cpp
+++ b/sim/xplane/weather/weather_plugin_tests.cpp
@@ -1,0 +1,317 @@
+#include "XPLMDataAccess.h"
+#include "XPLMPlugin.h"
+#include "fake_xplm.h"
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <vector>
+
+PLUGIN_API int XPluginStart(char* out_name, char* out_sig, char* out_desc);
+PLUGIN_API void XPluginStop(void);
+PLUGIN_API int XPluginEnable(void);
+
+namespace {
+
+constexpr const char* kUpdate =
+    "sim/weather/region/update_immediately";
+constexpr const char* kChangeMode = "sim/weather/region/change_mode";
+constexpr const char* kVariability = "sim/weather/region/variability_pct";
+constexpr const char* kWindSpeed = "sim/weather/region/wind_speed_msc";
+constexpr const char* kWindDirection =
+    "sim/weather/region/wind_direction_degt";
+constexpr const char* kShearSpeed = "sim/weather/region/shear_speed_msc";
+constexpr const char* kShearDirection =
+    "sim/weather/region/shear_direction_degt";
+constexpr const char* kTurbulence = "sim/weather/region/turbulence";
+constexpr const char* kThermalRate = "sim/weather/region/thermal_rate_ms";
+constexpr const char* kActualTurbulence =
+    "sim/weather/aircraft/turbulence";
+constexpr const char* kStagedSpeed = "pilotage/weather/wind_speed_mps";
+constexpr const char* kStagedDirection =
+    "pilotage/weather/wind_direction_deg";
+constexpr const char* kStagedTurbulence =
+    "pilotage/weather/turbulence_scale";
+constexpr const char* kClearGeneration =
+    "pilotage/weather/clear_generation";
+constexpr const char* kApplyGeneration =
+    "pilotage/weather/apply_generation";
+constexpr const char* kStatus = "pilotage/weather/status";
+constexpr const char* kResponseGeneration =
+    "pilotage/weather/response_generation";
+constexpr const char* kResponseOperation =
+    "pilotage/weather/response_operation";
+constexpr const char* kAppliedGeneration =
+    "pilotage/weather/applied_generation";
+constexpr const char* kResponseSpeed =
+    "pilotage/weather/response_wind_speed_mps";
+constexpr const char* kResponseDirection =
+    "pilotage/weather/response_wind_direction_deg";
+constexpr const char* kResponseTurbulence =
+    "pilotage/weather/response_turbulence_scale";
+
+const std::array<const char*, 5> kRegionalArrays = {
+    kWindSpeed, kWindDirection, kShearSpeed, kShearDirection, kTurbulence};
+
+class PluginSession {
+  public:
+    PluginSession() {
+        std::array<char, 256> name{};
+        std::array<char, 256> signature{};
+        std::array<char, 256> description{};
+        assert(XPluginStart(name.data(), signature.data(),
+                            description.data()) == 1);
+        assert(XPluginEnable() == 1);
+    }
+
+    ~PluginSession() { XPluginStop(); }
+
+    PluginSession(const PluginSession&) = delete;
+    PluginSession& operator=(const PluginSession&) = delete;
+};
+
+XPLMDataRef Ref(const char* name) {
+    XPLMDataRef dataref = XPLMFindDataRef(name);
+    assert(dataref != nullptr);
+    return dataref;
+}
+
+float Read(const char* name) { return XPLMGetDataf(Ref(name)); }
+
+void Write(const char* name, float value) {
+    XPLMSetDataf(Ref(name), value);
+}
+
+std::vector<float> Filled(float value) {
+    return std::vector<float>(13, value);
+}
+
+void PrepareSimulator() {
+    fake_xplm::Reset();
+    fake_xplm::InstallWeatherDataRefs();
+}
+
+void FillRegion(float value) {
+    for (const char* name : kRegionalArrays) {
+        fake_xplm::StoreArray(name, Filled(value));
+    }
+    fake_xplm::StoreInt(kUpdate, 0);
+    fake_xplm::StoreInt(kChangeMode, 0);
+    fake_xplm::StoreFloat(kVariability, value);
+    fake_xplm::StoreFloat(kThermalRate, value);
+}
+
+void TriggerClear() {
+    Write(kClearGeneration, 1.0F);
+    fake_xplm::RunFlightLoop();
+}
+
+void AssertClearFailure(float expected_status) {
+    assert(Read(kStatus) == expected_status);
+    assert(Read(kStatus) != 3.0F);
+    assert(Read(kResponseGeneration) == 1.0F);
+    assert(Read(kResponseOperation) == 2.0F);
+    assert(Read(kAppliedGeneration) == 0.0F);
+}
+
+void CheckClearRefusal(const std::function<void()>& configure,
+                       float expected_status) {
+    PrepareSimulator();
+    configure();
+    PluginSession plugin;
+    TriggerClear();
+    AssertClearFailure(expected_status);
+}
+
+void AssertArrayEquals(const char* name, float expected) {
+    const std::vector<float> values = fake_xplm::StoredArray(name);
+    assert(values.size() == 13);
+    for (float value : values) {
+        assert(value == expected);
+    }
+}
+
+void TestRegionTypeAndWritableRefusal() {
+    CheckClearRefusal(
+        [] { fake_xplm::SetType(kUpdate, xplmType_Float); }, -2.0F);
+    CheckClearRefusal(
+        [] { fake_xplm::SetWritable(kChangeMode, false); }, -2.0F);
+    CheckClearRefusal(
+        [] { fake_xplm::SetType(kVariability, xplmType_Int); }, -2.0F);
+    CheckClearRefusal(
+        [] { fake_xplm::SetWritable(kThermalRate, false); }, -2.0F);
+    CheckClearRefusal(
+        [] { fake_xplm::SetType(kWindSpeed, xplmType_Float); }, -2.0F);
+    CheckClearRefusal(
+        [] { fake_xplm::SetWritable(kWindSpeed, false); }, -2.0F);
+}
+
+void TestEveryRegionArrayRequiresExactlyThirteenLayers() {
+    for (const char* name : kRegionalArrays) {
+        CheckClearRefusal(
+            [name] { fake_xplm::SetArraySize(name, 12); }, -2.0F);
+    }
+}
+
+void TestNoOpClearDoesNotAcknowledge() {
+    PrepareSimulator();
+    FillRegion(9.0F);
+    fake_xplm::SetWriteMode(kWindSpeed, fake_xplm::WriteMode::Ignore);
+    PluginSession plugin;
+    TriggerClear();
+    AssertClearFailure(-5.0F);
+    AssertArrayEquals(kWindSpeed, 9.0F);
+}
+
+void TestSuccessfulClearWritesCanonicalCalm() {
+    PrepareSimulator();
+    FillRegion(9.0F);
+    PluginSession plugin;
+    Write(kStagedSpeed, 12.0F);
+    Write(kStagedDirection, 275.0F);
+    Write(kStagedTurbulence, 4.0F);
+    TriggerClear();
+
+    assert(Read(kStatus) == 3.0F);
+    assert(Read(kAppliedGeneration) == 1.0F);
+    assert(Read(kResponseGeneration) == 1.0F);
+    assert(Read(kResponseOperation) == 2.0F);
+    assert(Read(kResponseSpeed) == 0.0F);
+    assert(Read(kResponseDirection) == 0.0F);
+    assert(Read(kResponseTurbulence) == 0.0F);
+    assert(Read(kStagedSpeed) == 0.0F);
+    assert(Read(kStagedDirection) == 0.0F);
+    assert(Read(kStagedTurbulence) == 0.0F);
+    for (const char* name : kRegionalArrays) {
+        AssertArrayEquals(name, 0.0F);
+    }
+    assert(fake_xplm::StoredInt(kUpdate) == 1);
+    assert(fake_xplm::StoredInt(kChangeMode) == 3);
+    assert(fake_xplm::StoredFloat(kVariability) == 0.0F);
+    assert(fake_xplm::StoredFloat(kThermalRate) == 0.0F);
+
+    Write(kApplyGeneration, 2.0F);
+    fake_xplm::RunFlightLoop();
+    assert(Read(kStatus) == 1.0F);
+    assert(Read(kAppliedGeneration) == 2.0F);
+    for (const char* name : kRegionalArrays) {
+        AssertArrayEquals(name, 0.0F);
+    }
+}
+
+void TestUpdateImmediatelyNoOpRefusesReadback() {
+    PrepareSimulator();
+    FillRegion(9.0F);
+    fake_xplm::SetWriteMode(kUpdate, fake_xplm::WriteMode::Ignore);
+    PluginSession plugin;
+    TriggerClear();
+    AssertClearFailure(-5.0F);
+    assert(fake_xplm::StoredInt(kUpdate) == 0);
+}
+
+void TestApplyUsesSnapshotAndStopClearsRegion() {
+    PrepareSimulator();
+    {
+        PluginSession plugin;
+        Write(kStagedSpeed, 5.0F);
+        Write(kStagedDirection, 270.0F);
+        Write(kStagedTurbulence, 2.0F);
+        Write(kApplyGeneration, 1.0F);
+        Write(kStagedSpeed, 9.0F);
+        Write(kStagedDirection, 90.0F);
+        Write(kStagedTurbulence, 4.0F);
+        fake_xplm::RunFlightLoop();
+
+        assert(Read(kStatus) == 1.0F);
+        assert(Read(kResponseSpeed) == 5.0F);
+        assert(Read(kResponseDirection) == 270.0F);
+        assert(Read(kResponseTurbulence) == 2.0F);
+        AssertArrayEquals(kWindSpeed, 5.0F);
+        AssertArrayEquals(kWindDirection, 270.0F);
+        AssertArrayEquals(kTurbulence, 2.0F);
+        assert(Read(kStagedSpeed) == 9.0F);
+        assert(Read(kStagedDirection) == 90.0F);
+        assert(Read(kStagedTurbulence) == 4.0F);
+    }
+    for (const char* name : kRegionalArrays) {
+        AssertArrayEquals(name, 0.0F);
+    }
+}
+
+void TestAircraftTurbulenceRequiresThirteenLayers() {
+    PrepareSimulator();
+    FillRegion(9.0F);
+    fake_xplm::SetArraySize(kActualTurbulence, 12);
+    PluginSession plugin;
+    Write(kStagedSpeed, 12.0F);
+    Write(kStagedDirection, 275.0F);
+    Write(kStagedTurbulence, 4.0F);
+    TriggerClear();
+    AssertClearFailure(-2.0F);
+    for (const char* name : kRegionalArrays) {
+        AssertArrayEquals(name, 0.0F);
+    }
+    assert(Read(kStagedSpeed) == 0.0F);
+    assert(Read(kStagedDirection) == 0.0F);
+    assert(Read(kStagedTurbulence) == 0.0F);
+}
+
+void TestProtocolVersionIsReadOnly() {
+    PrepareSimulator();
+    PluginSession plugin;
+    XPLMDataRef version = Ref("pilotage/weather/protocol_version");
+    assert((XPLMGetDataRefTypes(version) & xplmType_Float) != 0);
+    assert(XPLMCanWriteDataRef(version) == 0);
+    assert(XPLMGetDataf(version) == 1.0F);
+    XPLMSetDataf(version, 9.0F);
+    assert(XPLMGetDataf(version) == 1.0F);
+}
+
+void TestActualTurbulencePublishesMaximumLayer() {
+    PrepareSimulator();
+    fake_xplm::StoreArray(
+        kActualTurbulence,
+        {0.1F, 0.4F, 2.0F, 0.2F, 1.0F, 0.3F, 0.5F,
+         0.7F, 0.6F, 0.8F, 0.9F, 1.1F, 0.0F});
+    PluginSession plugin;
+    fake_xplm::RunFlightLoop();
+    assert(Read("pilotage/weather/actual_turbulence_profile_max") == 2.0F);
+
+    std::vector<float> invalid = Filled(0.0F);
+    invalid[4] = std::numeric_limits<float>::quiet_NaN();
+    fake_xplm::StoreArray(kActualTurbulence, invalid);
+    fake_xplm::RunFlightLoop();
+    assert(std::isnan(
+        Read("pilotage/weather/actual_turbulence_profile_max")));
+
+    fake_xplm::SetArraySize(kActualTurbulence, 12);
+    fake_xplm::RunFlightLoop();
+    assert(std::isnan(
+        Read("pilotage/weather/actual_turbulence_profile_max")));
+
+    for (float invalid_value : {-0.1F, 10.1F}) {
+        invalid = Filled(0.0F);
+        invalid[4] = invalid_value;
+        fake_xplm::StoreArray(kActualTurbulence, invalid);
+        fake_xplm::RunFlightLoop();
+        assert(std::isnan(
+            Read("pilotage/weather/actual_turbulence_profile_max")));
+    }
+}
+
+}  // namespace
+
+int main() {
+    TestRegionTypeAndWritableRefusal();
+    TestEveryRegionArrayRequiresExactlyThirteenLayers();
+    TestNoOpClearDoesNotAcknowledge();
+    TestSuccessfulClearWritesCanonicalCalm();
+    TestUpdateImmediatelyNoOpRefusesReadback();
+    TestApplyUsesSnapshotAndStopClearsRegion();
+    TestAircraftTurbulenceRequiresThirteenLayers();
+    TestProtocolVersionIsReadOnly();
+    TestActualTurbulencePublishesMaximumLayer();
+    return 0;
+}

--- a/sim/xplane/weather/weather_state.cpp
+++ b/sim/xplane/weather/weather_state.cpp
@@ -1,0 +1,161 @@
+#include "weather_state.h"
+
+#include <cmath>
+
+namespace pilotage::weather {
+namespace {
+
+bool DecodeGeneration(float value, std::uint32_t* generation) {
+    if (!std::isfinite(value) || value < 1.0F ||
+        value > static_cast<float>(kMaximumGeneration) ||
+        std::floor(value) != value) {
+        return false;
+    }
+    *generation = static_cast<std::uint32_t>(value);
+    return true;
+}
+
+}  // namespace
+
+bool IsValidPayload(const WeatherPayload& payload) {
+    return std::isfinite(payload.wind_speed_mps) &&
+           payload.wind_speed_mps >= 0.0F &&
+           payload.wind_speed_mps <= kMaximumWindSpeedMps &&
+           std::isfinite(payload.wind_direction_deg) &&
+           payload.wind_direction_deg >= 0.0F &&
+           payload.wind_direction_deg <= 360.0F &&
+           std::isfinite(payload.turbulence_scale) &&
+           payload.turbulence_scale >= 0.0F &&
+           payload.turbulence_scale <= kMaximumTurbulenceScale;
+}
+
+WeatherPayload CalmPayload() { return WeatherPayload{}; }
+
+void WeatherTransactionState::TriggerApply(
+    float generation, const WeatherPayload& staged) {
+    Trigger(WeatherOperation::Apply, generation, staged);
+}
+
+void WeatherTransactionState::TriggerClear(float generation) {
+    Trigger(WeatherOperation::Clear, generation, CalmPayload());
+}
+
+void WeatherTransactionState::Trigger(WeatherOperation operation,
+                                      float generation,
+                                      const WeatherPayload& payload) {
+    std::uint32_t decoded = 0;
+    if (!DecodeGeneration(generation, &decoded)) {
+        SetResponse(operation, 0, payload, RequestStatus::Invalid);
+        return;
+    }
+    if (!enabled_) {
+        SetResponse(operation, decoded, payload, RequestStatus::Unavailable);
+        return;
+    }
+    if (pending_.operation != WeatherOperation::None) {
+        SetResponse(operation, decoded, payload, RequestStatus::Busy);
+        return;
+    }
+    if (expected_generation_ == 0) {
+        SetResponse(operation, decoded, payload,
+                    RequestStatus::GenerationExhausted);
+        return;
+    }
+    if (decoded < expected_generation_) {
+        SetResponse(operation, decoded, payload,
+                    RequestStatus::StaleGeneration);
+        return;
+    }
+    if (decoded > expected_generation_) {
+        SetResponse(operation, decoded, payload,
+                    RequestStatus::OutOfSequenceGeneration);
+        return;
+    }
+
+    SetResponse(operation, decoded, payload, RequestStatus::Pending);
+    AdvanceExpectedGeneration();
+    if (operation == WeatherOperation::Apply && !IsValidPayload(payload)) {
+        status_ = RequestStatus::Invalid;
+        return;
+    }
+    pending_ = PendingWeatherRequest{operation, decoded, payload};
+}
+
+bool WeatherTransactionState::TakePending(PendingWeatherRequest* request) {
+    if (request == nullptr || pending_.operation == WeatherOperation::None) {
+        return false;
+    }
+    *request = pending_;
+    pending_ = PendingWeatherRequest{};
+    return true;
+}
+
+void WeatherTransactionState::Complete(
+    const PendingWeatherRequest& request) {
+    applied_generation_ = request.generation;
+    SetResponse(request.operation, request.generation, request.payload,
+                request.operation == WeatherOperation::Clear
+                    ? RequestStatus::Cleared
+                    : RequestStatus::Applied);
+}
+
+void WeatherTransactionState::Fail(const PendingWeatherRequest& request,
+                                   RequestStatus failure) {
+    SetResponse(request.operation, request.generation, request.payload, failure);
+}
+
+void WeatherTransactionState::Enable() {
+    if (!enabled_) {
+        *this = WeatherTransactionState{};
+    }
+}
+
+void WeatherTransactionState::Disable() {
+    *this = WeatherTransactionState{};
+    enabled_ = false;
+    status_ = RequestStatus::Unavailable;
+}
+
+void WeatherTransactionState::Reset() { *this = WeatherTransactionState{}; }
+
+std::uint32_t WeatherTransactionState::expected_generation() const {
+    return expected_generation_;
+}
+
+std::uint32_t WeatherTransactionState::response_generation() const {
+    return response_generation_;
+}
+
+std::uint32_t WeatherTransactionState::applied_generation() const {
+    return applied_generation_;
+}
+
+WeatherOperation WeatherTransactionState::response_operation() const {
+    return response_operation_;
+}
+
+const WeatherPayload& WeatherTransactionState::response_payload() const {
+    return response_payload_;
+}
+
+RequestStatus WeatherTransactionState::status() const { return status_; }
+
+void WeatherTransactionState::SetResponse(WeatherOperation operation,
+                                          std::uint32_t generation,
+                                          const WeatherPayload& payload,
+                                          RequestStatus status) {
+    response_operation_ = operation;
+    response_generation_ = generation;
+    response_payload_ = payload;
+    status_ = status;
+}
+
+void WeatherTransactionState::AdvanceExpectedGeneration() {
+    if (expected_generation_ == kMaximumGeneration) {
+        expected_generation_ = 0;
+    } else {
+        ++expected_generation_;
+    }
+}
+
+}  // namespace pilotage::weather

--- a/sim/xplane/weather/weather_state.h
+++ b/sim/xplane/weather/weather_state.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pilotage::weather {
+
+constexpr float kMaximumWindSpeedMps = 100.0F;
+constexpr float kMaximumTurbulenceScale = 10.0F;
+constexpr std::uint32_t kMaximumGeneration = 16777215U;
+
+struct WeatherPayload {
+    float wind_speed_mps = 0.0F;
+    float wind_direction_deg = 0.0F;
+    float turbulence_scale = 0.0F;
+};
+
+enum class WeatherOperation {
+    None = 0,
+    Apply = 1,
+    Clear = 2,
+};
+
+enum class RequestStatus {
+    Idle = 0,
+    Applied = 1,
+    Pending = 2,
+    Cleared = 3,
+    Invalid = -1,
+    DatarefMissing = -2,
+    StaleGeneration = -3,
+    OutOfSequenceGeneration = -4,
+    ReadbackMismatch = -5,
+    Busy = -6,
+    GenerationExhausted = -7,
+    Unavailable = -8,
+};
+
+struct PendingWeatherRequest {
+    WeatherOperation operation = WeatherOperation::None;
+    std::uint32_t generation = 0;
+    WeatherPayload payload{};
+};
+
+class WeatherTransactionState {
+  public:
+    void TriggerApply(float generation, const WeatherPayload& staged);
+    void TriggerClear(float generation);
+    bool TakePending(PendingWeatherRequest* request);
+    void Complete(const PendingWeatherRequest& request);
+    void Fail(const PendingWeatherRequest& request, RequestStatus failure);
+    void Enable();
+    void Disable();
+    void Reset();
+
+    [[nodiscard]] std::uint32_t expected_generation() const;
+    [[nodiscard]] std::uint32_t response_generation() const;
+    [[nodiscard]] std::uint32_t applied_generation() const;
+    [[nodiscard]] WeatherOperation response_operation() const;
+    [[nodiscard]] const WeatherPayload& response_payload() const;
+    [[nodiscard]] RequestStatus status() const;
+
+  private:
+    void Trigger(WeatherOperation operation, float generation,
+                 const WeatherPayload& payload);
+    void SetResponse(WeatherOperation operation, std::uint32_t generation,
+                     const WeatherPayload& payload, RequestStatus status);
+    void AdvanceExpectedGeneration();
+
+    std::uint32_t expected_generation_ = 1;
+    std::uint32_t response_generation_ = 0;
+    std::uint32_t applied_generation_ = 0;
+    WeatherOperation response_operation_ = WeatherOperation::None;
+    WeatherPayload response_payload_{};
+    RequestStatus status_ = RequestStatus::Idle;
+    PendingWeatherRequest pending_{};
+    bool enabled_ = true;
+};
+
+[[nodiscard]] bool IsValidPayload(const WeatherPayload& payload);
+[[nodiscard]] WeatherPayload CalmPayload();
+
+}  // namespace pilotage::weather

--- a/sim/xplane/weather/weather_state_tests.cpp
+++ b/sim/xplane/weather/weather_state_tests.cpp
@@ -1,0 +1,207 @@
+#include "weather_state.h"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+
+using pilotage::weather::CalmPayload;
+using pilotage::weather::kMaximumGeneration;
+using pilotage::weather::PendingWeatherRequest;
+using pilotage::weather::RequestStatus;
+using pilotage::weather::WeatherOperation;
+using pilotage::weather::WeatherPayload;
+using pilotage::weather::WeatherTransactionState;
+
+namespace {
+
+WeatherPayload Wind(float speed) {
+    return WeatherPayload{speed, 270.0F, 0.2F};
+}
+
+void AssertPayload(const WeatherPayload& actual,
+                   const WeatherPayload& expected) {
+    assert(actual.wind_speed_mps == expected.wind_speed_mps);
+    assert(actual.wind_direction_deg == expected.wind_direction_deg);
+    assert(actual.turbulence_scale == expected.turbulence_scale);
+}
+
+PendingWeatherRequest TakePending(WeatherTransactionState* state) {
+    PendingWeatherRequest request;
+    assert(state->TakePending(&request));
+    return request;
+}
+
+void TestIdleAndGenerationValidation() {
+    WeatherTransactionState state;
+    PendingWeatherRequest request;
+    assert(state.status() == RequestStatus::Idle);
+    assert(state.expected_generation() == 1);
+    assert(state.response_generation() == 0);
+    assert(state.applied_generation() == 0);
+    assert(!state.TakePending(&request));
+
+    state.TriggerApply(0.0F, Wind(5.0F));
+    assert(state.status() == RequestStatus::Invalid);
+    assert(state.expected_generation() == 1);
+    state.TriggerApply(1.5F, Wind(5.0F));
+    assert(state.status() == RequestStatus::Invalid);
+    state.TriggerApply(std::numeric_limits<float>::quiet_NaN(), Wind(5.0F));
+    assert(state.status() == RequestStatus::Invalid);
+    state.TriggerApply(16777216.0F, Wind(5.0F));
+    assert(state.status() == RequestStatus::Invalid);
+    state.TriggerApply(16777215.0F, Wind(5.0F));
+    assert(state.status() == RequestStatus::OutOfSequenceGeneration);
+    assert(state.expected_generation() == 1);
+}
+
+void TestApplyBindsAnImmutableRequest() {
+    WeatherTransactionState state;
+    WeatherPayload staged = Wind(5.0F);
+    state.TriggerApply(1.0F, staged);
+    staged.wind_speed_mps = 9.0F;
+
+    assert(state.status() == RequestStatus::Pending);
+    assert(state.expected_generation() == 2);
+    assert(state.response_generation() == 1);
+    assert(state.response_operation() == WeatherOperation::Apply);
+    AssertPayload(state.response_payload(), Wind(5.0F));
+
+    const PendingWeatherRequest request = TakePending(&state);
+    assert(request.operation == WeatherOperation::Apply);
+    assert(request.generation == 1);
+    AssertPayload(request.payload, Wind(5.0F));
+    state.Complete(request);
+
+    assert(state.status() == RequestStatus::Applied);
+    assert(state.applied_generation() == 1);
+    AssertPayload(state.response_payload(), Wind(5.0F));
+}
+
+void TestGenerationFailuresDoNotChangeAppliedIdentity() {
+    WeatherTransactionState state;
+    state.TriggerApply(1.0F, Wind(5.0F));
+    state.Complete(TakePending(&state));
+
+    state.TriggerApply(1.0F, Wind(7.0F));
+    assert(state.status() == RequestStatus::StaleGeneration);
+    assert(state.response_generation() == 1);
+    AssertPayload(state.response_payload(), Wind(7.0F));
+    assert(state.applied_generation() == 1);
+
+    state.TriggerApply(3.0F, Wind(7.0F));
+    assert(state.status() == RequestStatus::OutOfSequenceGeneration);
+    assert(state.response_generation() == 3);
+    assert(state.expected_generation() == 2);
+    assert(state.applied_generation() == 1);
+
+    state.TriggerApply(2.0F, Wind(101.0F));
+    assert(state.status() == RequestStatus::Invalid);
+    assert(state.response_generation() == 2);
+    assert(state.expected_generation() == 3);
+    assert(state.applied_generation() == 1);
+
+    state.TriggerApply(3.0F, Wind(7.0F));
+    const PendingWeatherRequest request = TakePending(&state);
+    state.Fail(request, RequestStatus::DatarefMissing);
+    assert(state.status() == RequestStatus::DatarefMissing);
+    assert(state.response_generation() == 3);
+    assert(state.expected_generation() == 4);
+    assert(state.applied_generation() == 1);
+}
+
+void TestClearUsesCanonicalCalmAndHasItsOwnAck() {
+    WeatherTransactionState state;
+    state.TriggerApply(1.0F, Wind(5.0F));
+    state.Complete(TakePending(&state));
+
+    state.TriggerClear(2.0F);
+    const PendingWeatherRequest request = TakePending(&state);
+    assert(request.operation == WeatherOperation::Clear);
+    assert(request.generation == 2);
+    AssertPayload(request.payload, CalmPayload());
+    state.Complete(request);
+
+    assert(state.status() == RequestStatus::Cleared);
+    assert(state.applied_generation() == 2);
+    assert(state.response_operation() == WeatherOperation::Clear);
+    AssertPayload(state.response_payload(), CalmPayload());
+}
+
+void TestBusyRequestCanRetryItsExpectedGeneration() {
+    WeatherTransactionState state;
+    state.TriggerApply(1.0F, Wind(5.0F));
+    state.TriggerClear(2.0F);
+    assert(state.status() == RequestStatus::Busy);
+    assert(state.response_generation() == 2);
+    assert(state.expected_generation() == 2);
+
+    state.Complete(TakePending(&state));
+    state.TriggerClear(2.0F);
+    state.Complete(TakePending(&state));
+    assert(state.status() == RequestStatus::Cleared);
+    assert(state.applied_generation() == 2);
+}
+
+void TestResetReturnsToIdleWithoutAnImplicitRequest() {
+    WeatherTransactionState state;
+    state.TriggerApply(1.0F, Wind(5.0F));
+    state.Complete(TakePending(&state));
+    state.Reset();
+
+    PendingWeatherRequest request;
+    assert(state.status() == RequestStatus::Idle);
+    assert(state.expected_generation() == 1);
+    assert(state.response_generation() == 0);
+    assert(state.applied_generation() == 0);
+    assert(!state.TakePending(&request));
+}
+
+void TestDisableRefusesRequestsAndEnableReturnsToIdle() {
+    WeatherTransactionState state;
+    state.TriggerApply(1.0F, Wind(5.0F));
+    state.Complete(TakePending(&state));
+    state.Disable();
+
+    state.TriggerApply(1.0F, Wind(7.0F));
+    assert(state.status() == RequestStatus::Unavailable);
+    assert(state.applied_generation() == 0);
+    assert(state.expected_generation() == 1);
+
+    state.Enable();
+    PendingWeatherRequest request;
+    assert(state.status() == RequestStatus::Idle);
+    assert(!state.TakePending(&request));
+    state.TriggerApply(1.0F, Wind(7.0F));
+    assert(state.status() == RequestStatus::Pending);
+}
+
+void TestGenerationExhaustionFailsClosed() {
+    WeatherTransactionState state;
+    std::uint32_t generation = 1;
+    while (true) {
+        state.TriggerClear(static_cast<float>(generation));
+        TakePending(&state);
+        if (generation == kMaximumGeneration) {
+            break;
+        }
+        generation += 1;
+    }
+    assert(state.expected_generation() == 0);
+    state.TriggerClear(1.0F);
+    assert(state.status() == RequestStatus::GenerationExhausted);
+    assert(state.applied_generation() == 0);
+}
+
+}  // namespace
+
+int main() {
+    TestIdleAndGenerationValidation();
+    TestApplyBindsAnImmutableRequest();
+    TestGenerationFailuresDoNotChangeAppliedIdentity();
+    TestClearUsesCanonicalCalmAndHasItsOwnAck();
+    TestBusyRequestCanRetryItsExpectedGeneration();
+    TestResetReturnsToIdleWithoutAnImplicitRequest();
+    TestDisableRefusesRequestsAndEnableReturnsToIdle();
+    TestGenerationExhaustionFailsClosed();
+    return 0;
+}

--- a/tools/xtask/src/backend/aviate_xplane.rs
+++ b/tools/xtask/src/backend/aviate_xplane.rs
@@ -14,9 +14,9 @@
 use std::path::{Path, PathBuf};
 
 use super::xplane_simulator::{
-    airframe_for, ensure_xplane_plugins, launch_xplane, send_xplane_command,
+    airframe_for, ensure_xplane_plugins_blocking, prepare_xplane_runtime_blocking,
     set_active_config_name, set_ground_sensor_contract, validate_xplane_install, xplane_root,
-    xplane_running,
+    xplane_running_blocking,
 };
 use super::{SessionContext, SimBackend, Stage};
 use crate::cli::Profile;
@@ -116,7 +116,7 @@ impl SimBackend for AviateXPlane {
     }
 
     fn prepare(&self, ctx: &SessionContext) -> Result<(), XtaskError> {
-        ensure_xplane_plugins(&ctx.repo_root);
+        ensure_xplane_plugins_blocking(&ctx.repo_root, xplane_running_blocking()?)?;
         // The airframe the flight controller mixes decides which channel
         // map the bridge must load, so this backend PINS it rather than
         // trusting whatever the last session left behind.
@@ -126,16 +126,21 @@ impl SimBackend for AviateXPlane {
         let Ok(root) = xplane_root() else {
             return Ok(());
         };
+        let simulator_running = xplane_running_blocking()?;
         set_active_config_name(&root, airframe);
         // Aviate's estimator consumes REAL sensors from boot to
         // touchdown; the bridge's fabricated ground-stationary contract
         // is a PX4-specific crutch this lane refuses.
         set_ground_sensor_contract(&root, false);
-        if xplane_running() {
-            print_line("X-Plane is already running; arming the SITL listener...");
-            send_xplane_command("px4xplane/connect");
-        } else {
-            launch_xplane(&root, airframe, &ctx.log_dir);
+        prepare_xplane_runtime_blocking(
+            &ctx.repo_root,
+            &root,
+            airframe,
+            &ctx.log_dir,
+            simulator_running,
+        )?;
+        if simulator_running {
+            print_line("X-Plane weather is ready and the SITL listener is armed");
         }
         Ok(())
     }

--- a/tools/xtask/src/backend/px4_xplane.rs
+++ b/tools/xtask/src/backend/px4_xplane.rs
@@ -17,9 +17,9 @@
 use std::path::Path;
 
 use super::xplane_simulator::{
-    Airframe, ensure_xplane_plugins, launch_xplane, selected_airframe, send_xplane_command,
+    Airframe, ensure_xplane_plugins_blocking, prepare_xplane_runtime_blocking, selected_airframe,
     set_active_config_name, set_ground_sensor_contract, validate_xplane_install, xplane_root,
-    xplane_running,
+    xplane_running_blocking,
 };
 use super::{SessionContext, SimBackend, Stage};
 use crate::cli::Profile;
@@ -84,7 +84,7 @@ impl SimBackend for Px4XPlane {
     }
 
     fn prepare(&self, ctx: &SessionContext) -> Result<(), XtaskError> {
-        ensure_xplane_plugins(&ctx.repo_root);
+        ensure_xplane_plugins_blocking(&ctx.repo_root, xplane_running_blocking()?)?;
         let Ok(airframe) = selected_airframe() else {
             // plan() re-runs the same resolution and reports the error.
             return Ok(());
@@ -92,22 +92,21 @@ impl SimBackend for Px4XPlane {
         let Ok(root) = xplane_root() else {
             return Ok(());
         };
+        let simulator_running = xplane_running_blocking()?;
         set_active_config_name(&root, airframe);
         // PX4's EKF wants the bridge's ground-stationary contract; the
         // aviate lane turns it off, so this lane must turn it back on.
         set_ground_sensor_contract(&root, true);
-        if xplane_running() {
-            // A running X-Plane never inherits the autoflight
-            // environment; arm the SITL listener directly. The command
-            // is the idempotent px4xplane/connect (a local px4xplane
-            // patch): a no-op when already armed or connected.
-            // Best-effort: the datagram is lost when no flight is
-            // loaded yet.
-            print_line("X-Plane is already running; arming the SITL listener...");
-            send_xplane_command("px4xplane/connect");
+        prepare_xplane_runtime_blocking(
+            &ctx.repo_root,
+            &root,
+            airframe,
+            &ctx.log_dir,
+            simulator_running,
+        )?;
+        if simulator_running {
+            print_line("X-Plane weather is ready and the SITL listener is armed");
             print_line("if PX4 cannot connect: Plugins > PX4 X-Plane > Connect to SITL");
-        } else {
-            launch_xplane(&root, airframe, &ctx.log_dir);
         }
         Ok(())
     }

--- a/tools/xtask/src/backend/px4_xplane/tests.rs
+++ b/tools/xtask/src/backend/px4_xplane/tests.rs
@@ -7,8 +7,10 @@
 use std::path::PathBuf;
 
 use super::super::xplane_simulator::{
-    Airframe, airframe_for, command_datagram, set_active_config_name, validate_xplane_install,
-    xplane_root_from,
+    Airframe, airframe_for, classify_xplane_probe_status, command_datagram,
+    plugin_install_required, record_plugin_install_stamp, run_plugin_build_blocking,
+    run_xplane_prepare_sequence, set_active_config_name, validate_xplane_install,
+    verify_weather_plugin_blocking, xplane_root_from, xplane_running_with_program_blocking,
 };
 use super::Px4XPlane;
 use crate::backend::{SessionContext, SimBackend};
@@ -120,12 +122,24 @@ fn install_validation_hints_at_the_build_script() {
         }
         other => panic!("expected a missing-plugin refusal, got {other:?}"),
     }
-    // With every plugin present, the missing aircraft is the next hint.
     for plugin in ["px4xplane", "PilotageAutoFlight", "PilotageCamera"] {
         let dir = root.join(format!("Resources/plugins/{plugin}/64"));
         std::fs::create_dir_all(&dir).expect("plugin dir");
         std::fs::write(dir.join("mac.xpl"), b"stub").expect("plugin stub");
     }
+    let refusal = validate_xplane_install(&root, qtailsitter());
+    match refusal {
+        Err(XtaskError::MissingArtifact { what, hint, .. }) => {
+            assert_eq!(what, "Pilotage X-Plane weather plugin");
+            assert!(hint.contains("build-xplane-plugins"));
+        }
+        other => panic!("expected a missing-weather-plugin refusal, got {other:?}"),
+    }
+    let weather = root.join("Resources/plugins/PilotageWeather/64");
+    std::fs::create_dir_all(&weather).expect("weather plugin dir");
+    std::fs::write(weather.join("mac.xpl"), b"stub").expect("weather plugin stub");
+
+    // With every plugin present, the missing aircraft is the next hint.
     let refusal = validate_xplane_install(&root, qtailsitter());
     match refusal {
         Err(XtaskError::MissingArtifact { what, path, .. }) => {
@@ -157,6 +171,175 @@ fn command_datagram_is_prologue_path_nul() {
         command_datagram("px4xplane/toggleEnable"),
         [b"CMND\0".as_slice(), b"px4xplane/toggleEnable\0".as_slice()].concat()
     );
+}
+
+#[test]
+fn stale_plugins_refuse_each_retry_without_a_restart() {
+    assert!(!plugin_install_required(true, true).expect("current plugins"));
+    assert!(plugin_install_required(false, false).expect("stopped simulator"));
+    for _attempt in 0..2 {
+        assert!(matches!(
+            plugin_install_required(false, true),
+            Err(XtaskError::SimulatorCapability { .. })
+        ));
+    }
+}
+
+#[test]
+fn post_build_refusal_keeps_the_retry_stale() {
+    use crate::session::preflight::stamp;
+
+    let root = scaffold("post-build-refusal");
+    let stamp_path = root.join("xplane-plugins.stamp");
+    let current = "stopped simulator install contract\n";
+    assert!(matches!(
+        record_plugin_install_stamp(&stamp_path, Some(current), true),
+        Err(XtaskError::SimulatorCapability { .. })
+    ));
+    assert!(
+        !stamp_path.exists(),
+        "a refused install must not look fresh"
+    );
+
+    let stored = stamp::read_stamp(&stamp_path);
+    let plugins_current = stamp::artifact_is_fresh(true, stored.as_deref(), Some(current));
+    assert!(!plugins_current);
+    assert!(matches!(
+        plugin_install_required(plugins_current, true),
+        Err(XtaskError::SimulatorCapability { .. })
+    ));
+}
+
+#[test]
+fn xplane_process_probe_fails_closed_on_probe_errors() {
+    let root = scaffold("process-probe");
+    assert!(matches!(
+        xplane_running_with_program_blocking(&root.join("missing-pgrep")),
+        Err(XtaskError::Io { .. })
+    ));
+    assert!(matches!(
+        xplane_running_with_program_blocking(std::path::Path::new("/usr/bin/true")),
+        Ok(true)
+    ));
+    assert!(matches!(
+        xplane_running_with_program_blocking(std::path::Path::new("/usr/bin/false")),
+        Ok(false)
+    ));
+    let unexpected = std::process::Command::new("/bin/sh")
+        .args(["-c", "exit 2"])
+        .status()
+        .expect("status 2");
+    assert!(matches!(
+        classify_xplane_probe_status(unexpected),
+        Err(XtaskError::CommandFailed { .. })
+    ));
+}
+
+#[test]
+fn plugin_build_spawn_and_exit_failures_keep_their_types() {
+    let root = scaffold("plugin-build-failures");
+    let missing = root.join("missing-command");
+    assert!(matches!(
+        run_plugin_build_blocking(&root, &missing),
+        Err(XtaskError::Io { .. })
+    ));
+    assert!(matches!(
+        run_plugin_build_blocking(&root, std::path::Path::new("/usr/bin/false")),
+        Err(XtaskError::CommandFailed { .. })
+    ));
+}
+
+#[test]
+fn weather_clear_proof_controls_controller_start() {
+    let root = scaffold("weather-proof-failure");
+    let scripts = root.join("scripts");
+    std::fs::create_dir_all(&scripts).expect("scripts dir");
+    std::fs::write(
+        scripts.join("xplane_weather_clear.py"),
+        "raise SystemExit(7)\n",
+    )
+    .expect("weather proof");
+    assert!(matches!(
+        verify_weather_plugin_blocking(&root),
+        Err(XtaskError::SimulatorCapability { .. })
+    ));
+    std::fs::write(
+        scripts.join("xplane_weather_clear.py"),
+        "raise SystemExit(0)\n",
+    )
+    .expect("weather proof");
+    assert!(verify_weather_plugin_blocking(&root).is_ok());
+}
+
+#[test]
+fn xplane_prepare_sequence_proves_weather_before_connect_or_fc_start() {
+    use std::cell::RefCell;
+
+    let warm_trace = RefCell::new(Vec::new());
+    run_xplane_prepare_sequence(
+        true,
+        || {
+            warm_trace.borrow_mut().push("proof");
+            Ok(())
+        },
+        || {
+            warm_trace.borrow_mut().push("launch");
+            Ok(())
+        },
+        || {
+            warm_trace.borrow_mut().push("cold-proof");
+            Ok(())
+        },
+        || warm_trace.borrow_mut().push("connect"),
+    )
+    .expect("warm prepare");
+    assert_eq!(warm_trace.into_inner(), ["proof", "connect"]);
+
+    let cold_trace = RefCell::new(Vec::new());
+    run_xplane_prepare_sequence(
+        false,
+        || {
+            cold_trace.borrow_mut().push("warm-proof");
+            Ok(())
+        },
+        || {
+            cold_trace.borrow_mut().push("launch");
+            Ok(())
+        },
+        || {
+            cold_trace.borrow_mut().push("proof");
+            Ok(())
+        },
+        || cold_trace.borrow_mut().push("connect"),
+    )
+    .expect("cold prepare");
+    assert_eq!(cold_trace.into_inner(), ["launch", "proof"]);
+
+    let refusal_trace = RefCell::new(Vec::new());
+    let refusal = run_xplane_prepare_sequence(
+        true,
+        || {
+            refusal_trace.borrow_mut().push("proof");
+            Err(XtaskError::SimulatorCapability {
+                capability: "test weather proof",
+                detail: "refused".to_owned(),
+            })
+        },
+        || {
+            refusal_trace.borrow_mut().push("launch");
+            Ok(())
+        },
+        || {
+            refusal_trace.borrow_mut().push("cold-proof");
+            Ok(())
+        },
+        || refusal_trace.borrow_mut().push("connect"),
+    );
+    assert!(matches!(
+        refusal,
+        Err(XtaskError::SimulatorCapability { .. })
+    ));
+    assert_eq!(refusal_trace.into_inner(), ["proof"]);
 }
 
 #[test]

--- a/tools/xtask/src/backend/xplane_simulator.rs
+++ b/tools/xtask/src/backend/xplane_simulator.rs
@@ -12,7 +12,15 @@ use std::path::{Path, PathBuf};
 
 use crate::error::XtaskError;
 use crate::output::print_line;
-use crate::readiness::stage_log;
+
+mod readiness;
+
+#[cfg(test)]
+pub(super) use readiness::{
+    classify_xplane_probe_status, run_xplane_prepare_sequence, verify_weather_plugin_blocking,
+    xplane_running_with_program_blocking,
+};
+pub(super) use readiness::{prepare_xplane_runtime_blocking, xplane_running_blocking};
 
 /// X-Plane's UDP command/data port on the local machine.
 const XPLANE_UDP_PORT: u16 = 49000;
@@ -139,6 +147,14 @@ pub(super) fn validate_xplane_install(root: &Path, airframe: &Airframe) -> Resul
             hint: "run scripts/build-xplane-plugins.sh",
         });
     }
+    let weather = root.join("Resources/plugins/PilotageWeather/64/mac.xpl");
+    if !weather.is_file() {
+        return Err(XtaskError::MissingArtifact {
+            what: "Pilotage X-Plane weather plugin",
+            path: weather,
+            hint: "run scripts/build-xplane-plugins.sh",
+        });
+    }
     let aircraft = root.join(airframe.acf_path);
     if !aircraft.is_file() {
         return Err(XtaskError::MissingArtifact {
@@ -152,49 +168,108 @@ pub(super) fn validate_xplane_install(root: &Path, airframe: &Airframe) -> Resul
 }
 
 /// Where the plugin build script's content stamp lives.
-const XPLANE_PLUGINS_STAMP: &str = "target/xtask-stamps/xplane-plugins.stamp";
+const XPLANE_PLUGINS_STAMP: &str = "target/xtask-stamps/xplane-plugins-stopped-simulator.stamp";
 
 /// The working-tree inputs whose content decides plugin staleness.
-const XPLANE_PLUGINS_SOURCES: [&str; 3] = [
+const XPLANE_PLUGINS_SOURCES: [&str; 4] = [
     "sim/xplane/autoflight",
     "sim/xplane/camera",
+    "sim/xplane/weather",
     "scripts/build-xplane-plugins.sh",
 ];
 
-/// Best-effort, content-stamped build + install of the two X-Plane
-/// plugins and the packaged aircraft. Non-fatal by contract: `plan`
-/// fails closed with hints when a required artifact is still absent.
-pub(super) fn ensure_xplane_plugins(repo_root: &Path) {
+/// Whether the prepare step changed the installed plugin files.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum XPlanePluginInstall {
+    /// The content stamp and all installed artifacts were current.
+    Current,
+    /// The prepare step built and installed the plugin set.
+    Rebuilt,
+}
+
+pub(super) fn plugin_install_required(
+    plugins_current: bool,
+    simulator_running: bool,
+) -> Result<bool, XtaskError> {
+    if plugins_current {
+        return Ok(false);
+    }
+    if simulator_running {
+        return Err(XtaskError::SimulatorCapability {
+            capability: "loaded X-Plane plugin set",
+            detail: "plugin files need an update while X-Plane is running; stop X-Plane and retry"
+                .to_owned(),
+        });
+    }
+    Ok(true)
+}
+
+/// Builds and installs the required X-Plane plugins when an input changes.
+/// The caller checks all required artifacts before it starts a session.
+pub(super) fn ensure_xplane_plugins_blocking(
+    repo_root: &Path,
+    simulator_running: bool,
+) -> Result<XPlanePluginInstall, XtaskError> {
     use crate::session::preflight::stamp;
     let installed = xplane_root()
         .map(|root| {
-            root.join("Resources/plugins/PilotageAutoFlight/64/mac.xpl")
-                .is_file()
+            [
+                "Resources/plugins/px4xplane/64/mac.xpl",
+                "Resources/plugins/PilotageAutoFlight/64/mac.xpl",
+                "Resources/plugins/PilotageCamera/64/mac.xpl",
+                "Resources/plugins/PilotageWeather/64/mac.xpl",
+            ]
+            .iter()
+            .all(|path| root.join(path).is_file())
         })
         .unwrap_or(false);
     let current = stamp::source_stamp(repo_root, &XPLANE_PLUGINS_SOURCES, &[]);
     let stamp_path = repo_root.join(XPLANE_PLUGINS_STAMP);
     let stored = stamp::read_stamp(&stamp_path);
-    if stamp::artifact_is_fresh(installed, stored.as_deref(), current.as_deref()) {
-        return;
+    let plugins_current =
+        stamp::artifact_is_fresh(installed, stored.as_deref(), current.as_deref());
+    if !plugin_install_required(plugins_current, simulator_running)? {
+        return Ok(XPlanePluginInstall::Current);
     }
     print_line("building and installing the X-Plane plugins...");
-    let built = std::process::Command::new("bash")
+    run_plugin_build_blocking(repo_root, Path::new("bash"))?;
+    record_plugin_install_stamp(&stamp_path, current.as_deref(), xplane_running_blocking()?)?;
+    print_line("X-Plane plugins installed");
+    Ok(XPlanePluginInstall::Rebuilt)
+}
+
+pub(super) fn record_plugin_install_stamp(
+    stamp_path: &Path,
+    current: Option<&str>,
+    simulator_running: bool,
+) -> Result<(), XtaskError> {
+    plugin_install_required(false, simulator_running)?;
+    if let Some(current) = current {
+        crate::session::preflight::stamp::write_stamp(stamp_path, current);
+    }
+    Ok(())
+}
+
+/// Run the plugin build with an explicit program for failure testing.
+pub(super) fn run_plugin_build_blocking(
+    repo_root: &Path,
+    program: &Path,
+) -> Result<(), XtaskError> {
+    let status = std::process::Command::new(program)
         .arg(repo_root.join("scripts/build-xplane-plugins.sh"))
         .current_dir(repo_root)
-        .status();
-    match built {
-        Ok(status) if status.success() => {
-            if let Some(current) = current {
-                stamp::write_stamp(&stamp_path, &current);
-            }
-            print_line("X-Plane plugins installed");
-        }
-        Ok(_) | Err(_) => print_line(
-            "X-Plane plugin build failed (see build-xplane-plugins output); \
-             the session will fail closed if a required plugin is missing",
-        ),
+        .status()
+        .map_err(|source| XtaskError::Io {
+            context: "starting the X-Plane plugin build",
+            source,
+        })?;
+    if !status.success() {
+        return Err(XtaskError::CommandFailed {
+            context: "X-Plane plugin build and install",
+            status: status.to_string(),
+        });
     }
+    Ok(())
 }
 
 /// Points the installed px4xplane config at the selected airframe's
@@ -267,49 +342,6 @@ pub(super) fn set_active_config_name(root: &Path, airframe: &Airframe) {
         if rewritten != content && std::fs::write(&config, rewritten).is_err() {
             print_line("could not update the px4xplane config_name; check config.ini");
         }
-    }
-}
-
-/// True when an X-Plane simulator process is running on this machine.
-pub(super) fn xplane_running() -> bool {
-    std::process::Command::new("pgrep")
-        .args(["-f", "X-Plane.app/Contents/MacOS/X-Plane"])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
-}
-
-/// Starts X-Plane detached with the PilotageAutoFlight environment. The
-/// process deliberately outlives the session: booting X-Plane costs
-/// minutes, and the operator owns its window.
-pub(super) fn launch_xplane(root: &Path, airframe: &Airframe, log_dir: &Path) {
-    print_line("starting X-Plane (a cold boot takes minutes)...");
-    // A fresh simulator gets a fresh parking spot: the reset script
-    // captures the vehicle's home position once per X-Plane boot and
-    // teleports back to it on every reset.
-    if let Some(home) = std::env::var_os("HOME") {
-        std::fs::remove_file(std::path::PathBuf::from(home).join(".pilotage/xplane-home.json"))
-            .ok();
-    }
-    let log = std::fs::File::create(stage_log(log_dir, "xplane"))
-        .ok()
-        .map_or(std::process::Stdio::null(), std::process::Stdio::from);
-    let spawned = std::process::Command::new(root.join("X-Plane.app/Contents/MacOS/X-Plane"))
-        .arg("--window=1400x900")
-        .arg("--pref:_show_qfl_on_start=0")
-        .current_dir(root)
-        .env("PILOTAGE_XPLANE_ACF", airframe.acf_path)
-        .env("PILOTAGE_XPLANE_CONNECT", "1")
-        // A cold simulator start plus a flight-controller boot can
-        // exceed the bridge's default one-minute connect window, and an
-        // expired window needs an operator click. Wait without a
-        // deadline instead (a local px4xplane patch).
-        .env("PX4XPLANE_CONNECT_TIMEOUT_S", "0")
-        .stdout(log)
-        .stderr(std::process::Stdio::null())
-        .spawn();
-    if spawned.is_err() {
-        print_line("could not start X-Plane; start it by hand and rerun");
     }
 }
 

--- a/tools/xtask/src/backend/xplane_simulator/readiness.rs
+++ b/tools/xtask/src/backend/xplane_simulator/readiness.rs
@@ -1,0 +1,159 @@
+//! X-Plane process and weather readiness gates.
+
+use std::path::Path;
+
+use super::{Airframe, send_xplane_command};
+use crate::error::XtaskError;
+use crate::output::print_line;
+use crate::readiness::stage_log;
+
+const WEATHER_READY_TIMEOUT_S: u64 = 420;
+
+/// Test whether an X-Plane simulator process is running on this machine.
+pub(in crate::backend) fn xplane_running_blocking() -> Result<bool, XtaskError> {
+    xplane_running_with_program_blocking(Path::new("pgrep"))
+}
+
+pub(in crate::backend) fn xplane_running_with_program_blocking(
+    program: &Path,
+) -> Result<bool, XtaskError> {
+    let status = std::process::Command::new(program)
+        .args(["-f", "X-Plane.app/Contents/MacOS/X-Plane"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|source| XtaskError::Io {
+            context: "probing for a running X-Plane process",
+            source,
+        })?;
+    classify_xplane_probe_status(status)
+}
+
+pub(in crate::backend) fn classify_xplane_probe_status(
+    status: std::process::ExitStatus,
+) -> Result<bool, XtaskError> {
+    match status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => Err(XtaskError::CommandFailed {
+            context: "X-Plane process probe",
+            status: status.to_string(),
+        }),
+    }
+}
+
+pub(in crate::backend) fn run_xplane_prepare_sequence<WarmProof, Launch, ColdProof, Connect>(
+    simulator_running: bool,
+    warm_proof: WarmProof,
+    launch: Launch,
+    cold_proof: ColdProof,
+    connect: Connect,
+) -> Result<(), XtaskError>
+where
+    WarmProof: FnOnce() -> Result<(), XtaskError>,
+    Launch: FnOnce() -> Result<(), XtaskError>,
+    ColdProof: FnOnce() -> Result<(), XtaskError>,
+    Connect: FnOnce(),
+{
+    if simulator_running {
+        warm_proof()?;
+        connect();
+        return Ok(());
+    }
+    launch()?;
+    cold_proof()
+}
+
+/// Prepare one running or cold X-Plane process before the FC can start.
+pub(in crate::backend) fn prepare_xplane_runtime_blocking(
+    repo_root: &Path,
+    root: &Path,
+    airframe: &Airframe,
+    log_dir: &Path,
+    simulator_running: bool,
+) -> Result<(), XtaskError> {
+    run_xplane_prepare_sequence(
+        simulator_running,
+        || verify_weather_plugin_blocking(repo_root),
+        || launch_xplane_blocking(root, airframe, log_dir),
+        || wait_for_weather_plugin_blocking(repo_root),
+        || send_xplane_command("px4xplane/connect"),
+    )
+}
+
+/// Prove an acknowledged calm transaction before a controller can start.
+pub(in crate::backend) fn verify_weather_plugin_blocking(
+    repo_root: &Path,
+) -> Result<(), XtaskError> {
+    let status = weather_clear_status_blocking(repo_root)?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(XtaskError::SimulatorCapability {
+        capability: "PilotageWeather clear transaction",
+        detail: status.to_string(),
+    })
+}
+
+fn wait_for_weather_plugin_blocking(repo_root: &Path) -> Result<(), XtaskError> {
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(WEATHER_READY_TIMEOUT_S);
+    let mut last_status = String::from("not started");
+    while std::time::Instant::now() < deadline {
+        let status = weather_clear_status_blocking(repo_root)?;
+        if status.success() {
+            return Ok(());
+        }
+        last_status = status.to_string();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    Err(XtaskError::SimulatorCapability {
+        capability: "PilotageWeather clear transaction",
+        detail: format!(
+            "did not succeed within {WEATHER_READY_TIMEOUT_S} s; last status {last_status}"
+        ),
+    })
+}
+
+fn weather_clear_status_blocking(repo_root: &Path) -> Result<std::process::ExitStatus, XtaskError> {
+    std::process::Command::new("python3")
+        .arg(repo_root.join("scripts/xplane_weather_clear.py"))
+        .current_dir(repo_root)
+        .status()
+        .map_err(|source| XtaskError::Io {
+            context: "running the X-Plane weather clear proof",
+            source,
+        })
+}
+
+fn launch_xplane_blocking(
+    root: &Path,
+    airframe: &Airframe,
+    log_dir: &Path,
+) -> Result<(), XtaskError> {
+    print_line("starting X-Plane (a cold boot takes minutes)...");
+    // The reset process captures one home position for each X-Plane process.
+    if let Some(home) = std::env::var_os("HOME") {
+        std::fs::remove_file(std::path::PathBuf::from(home).join(".pilotage/xplane-home.json"))
+            .ok();
+    }
+    let log = std::fs::File::create(stage_log(log_dir, "xplane"))
+        .ok()
+        .map_or(std::process::Stdio::null(), std::process::Stdio::from);
+    std::process::Command::new(root.join("X-Plane.app/Contents/MacOS/X-Plane"))
+        .arg("--window=1400x900")
+        .arg("--pref:_show_qfl_on_start=0")
+        .current_dir(root)
+        .env("PILOTAGE_XPLANE_ACF", airframe.acf_path)
+        .env("PILOTAGE_XPLANE_CONNECT", "1")
+        // A cold start can exceed the bridge connection time limit.
+        .env("PX4XPLANE_CONNECT_TIMEOUT_S", "0")
+        .stdout(log)
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|source| XtaskError::Spawn {
+            name: "X-Plane",
+            source,
+        })
+}

--- a/tools/xtask/src/error.rs
+++ b/tools/xtask/src/error.rs
@@ -83,6 +83,14 @@ pub enum XtaskError {
         /// The reported exit status.
         status: String,
     },
+    /// A running simulator did not prove a required live capability.
+    #[error("simulator capability {capability} is unavailable: {detail}")]
+    SimulatorCapability {
+        /// The capability that the backend requires before FC start.
+        capability: &'static str,
+        /// The observed refusal or protocol error.
+        detail: String,
+    },
     /// An I/O operation outside process management failed.
     #[error("I/O failure during {context}: {source}")]
     Io {


### PR DESCRIPTION
## Summary

- Add the versioned deterministic ConditionSet contract for wind, gust, turbulence, and source timing.
- Add the PilotageWeather X-Plane transaction plugin with generation fencing, exact regional writes, and conservative actual readback.
- Make reset clear weather after flight reset and teleport, and require three fresh calm observations before FC restart.
- Make both Aviate and PX4 X-Plane preparation prove the weather capability before connect, launch completion, or FC stages.
- Add C++, Python UDP, shell order, Rust, and CI guardrails.

## Scope

This PR is a reviewed foundation slice of #448. It does not close #448.

Applied and Cleared mean that X-Plane accepted the exact regional transaction. Actual convergence is separate evidence. Runtime condition timelines, vertical wind, shear, frame evidence, and the flight-tune binding remain in #447 and later #448 slices.

#471 and #478 must land before qualification. They must bind the shared installed plugin to its build and runtime identity and add a host-wide lease. This PR does not claim cross-work-root exclusivity.

## Verification

Exact head: f9e9df2f2c38907e81e77eaf5ab938bb3b6f6896

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- strict workspace cargo doc gates for missing docs and broken links
- cargo build --workspace --release
- X-Plane C++ state and fake-XPLM plugin tests
- Python UDP protocol tests: 6 passed
- reset order, shell syntax, shellcheck, structure, and monotonic-counter guards
- production Weather plugin compile and link against the real XPLM SDK with Wall, Wextra, and Werror

The running X-Plane instance has the stale installed Weather plugin and does not expose protocol v1. The exact new binary is checksum-verified and staged beside the installed plugin. Activation and the nonzero apply/readback/clear canary require explicit operator approval to replace the active plugin and restart X-Plane.