### PR TITLE
Add reviewed flight-quality metric foundation (#449)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pilotage-flight-quality"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "pilotage-geo"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/pilotage-presentation",
     "crates/pilotage-trial",
     "crates/pilotage-control-feel",
+    "crates/pilotage-flight-quality",
     "adapters/reference-headless",
     "adapters/aviate",
     "adapters/px4",
@@ -132,6 +133,7 @@ pilotage-instrument-runtime = { path = "crates/pilotage-instrument-runtime" }
 pilotage-presentation = { path = "crates/pilotage-presentation" }
 pilotage-trial = { path = "crates/pilotage-trial" }
 pilotage-control-feel = { path = "crates/pilotage-control-feel" }
+pilotage-flight-quality = { path = "crates/pilotage-flight-quality" }
 pilotage-terrain-query = { path = "crates/pilotage-terrain-query" }
 
 [workspace.lints.rust]

--- a/crates/pilotage-flight-quality/Cargo.toml
+++ b/crates/pilotage-flight-quality/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pilotage-flight-quality"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "Deterministic offline flight-quality metrics and hard trial gates"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/pilotage-flight-quality/src/control.rs
+++ b/crates/pilotage-flight-quality/src/control.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+
+use crate::series::{
+    integral_abs_linear, integral_square_linear, validate_metric_results, validate_times,
+    validate_values,
+};
+use crate::{ControlPoint, MetricError};
+
+/// Control-effort and actuator-saturation metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControlMetrics {
+    /// The root mean square normalized control effort.
+    pub effort_rms: f64,
+    /// The time integral of absolute normalized control effort, in seconds.
+    pub integrated_abs_effort_s: f64,
+    /// The fraction of phase time with active saturation.
+    pub saturation_fraction: f64,
+    /// The longest continuous saturation interval, in seconds.
+    pub longest_saturation_s: f64,
+}
+
+/// Calculates control effort and saturation metrics.
+///
+/// Effort is linear between samples. Saturation is constant from one sample
+/// until the next sample. The last sample has no independent duration.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when the series is invalid.
+pub fn measure_control(samples: &[ControlPoint]) -> Result<ControlMetrics, MetricError> {
+    validate_times(samples, |sample| sample.time_s)?;
+    validate_values(samples, "effort", |sample| sample.effort)?;
+    let duration_s = samples[samples.len() - 1].time_s - samples[0].time_s;
+    let mut square_integral = 0.0;
+    let mut absolute_integral = 0.0;
+    let mut saturated_s = 0.0;
+    let mut longest_saturation_s = 0.0_f64;
+    let mut active_saturation_s = 0.0;
+    for pair in samples.windows(2) {
+        let dt = pair[1].time_s - pair[0].time_s;
+        square_integral += integral_square_linear(pair[0].effort, pair[1].effort, dt);
+        absolute_integral += integral_abs_linear(pair[0].effort, pair[1].effort, dt);
+        if pair[0].saturated {
+            saturated_s += dt;
+            active_saturation_s += dt;
+            longest_saturation_s = longest_saturation_s.max(active_saturation_s);
+        } else {
+            active_saturation_s = 0.0;
+        }
+    }
+    let metrics = ControlMetrics {
+        effort_rms: (square_integral / duration_s).sqrt(),
+        integrated_abs_effort_s: absolute_integral,
+        saturation_fraction: saturated_s / duration_s,
+        longest_saturation_s,
+    };
+    validate_metric_results(&[
+        ("control.effort_rms", metrics.effort_rms),
+        (
+            "control.integrated_abs_effort_s",
+            metrics.integrated_abs_effort_s,
+        ),
+        ("control.saturation_fraction", metrics.saturation_fraction),
+        ("control.longest_saturation_s", metrics.longest_saturation_s),
+    ])?;
+    Ok(metrics)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/control/tests.rs
+++ b/crates/pilotage-flight-quality/src/control/tests.rs
@@ -1,0 +1,90 @@
+use super::measure_control;
+use crate::{ControlPoint, MetricError};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-10, "{actual} != {expected}");
+}
+
+#[test]
+fn a_control_pulse_has_exact_effort_and_saturation_metrics() {
+    let samples = [
+        ControlPoint {
+            time_s: 0.0,
+            effort: 0.0,
+            saturated: false,
+        },
+        ControlPoint {
+            time_s: 1.0,
+            effort: 1.0,
+            saturated: true,
+        },
+        ControlPoint {
+            time_s: 2.0,
+            effort: 1.0,
+            saturated: true,
+        },
+        ControlPoint {
+            time_s: 3.0,
+            effort: 0.0,
+            saturated: false,
+        },
+    ];
+    let metrics = measure_control(&samples).expect("valid control trace");
+
+    assert_close(metrics.effort_rms, (5.0_f64 / 9.0).sqrt());
+    assert_close(metrics.integrated_abs_effort_s, 2.0);
+    assert_close(metrics.saturation_fraction, 2.0 / 3.0);
+    assert_close(metrics.longest_saturation_s, 2.0);
+}
+
+#[test]
+fn separated_saturation_intervals_do_not_merge() {
+    let samples = [
+        ControlPoint {
+            time_s: 0.0,
+            effort: 0.5,
+            saturated: true,
+        },
+        ControlPoint {
+            time_s: 1.0,
+            effort: 0.5,
+            saturated: false,
+        },
+        ControlPoint {
+            time_s: 2.0,
+            effort: 0.5,
+            saturated: true,
+        },
+        ControlPoint {
+            time_s: 2.5,
+            effort: 0.5,
+            saturated: false,
+        },
+    ];
+    let metrics = measure_control(&samples).expect("valid control trace");
+
+    assert_close(metrics.longest_saturation_s, 1.0);
+}
+
+#[test]
+fn a_non_finite_derived_control_metric_is_a_typed_error() {
+    let samples = [
+        ControlPoint {
+            time_s: 0.0,
+            effort: f64::MAX,
+            saturated: false,
+        },
+        ControlPoint {
+            time_s: 1.0,
+            effort: f64::MAX,
+            saturated: false,
+        },
+    ];
+
+    assert_eq!(
+        measure_control(&samples),
+        Err(MetricError::NonFiniteResult {
+            field: "control.effort_rms",
+        })
+    );
+}

--- a/crates/pilotage-flight-quality/src/error.rs
+++ b/crates/pilotage-flight-quality/src/error.rs
@@ -1,0 +1,64 @@
+use thiserror::Error;
+
+/// An error in a metric input or phase selection.
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum MetricError {
+    /// A series has fewer samples than the metric needs.
+    #[error("the series needs {needed} samples but has {actual}")]
+    TooFewSamples {
+        /// The minimum sample count.
+        needed: usize,
+        /// The supplied sample count.
+        actual: usize,
+    },
+    /// A sample time is not finite.
+    #[error("sample {index} has a non-finite time")]
+    NonFiniteTime {
+        /// The sample index.
+        index: usize,
+    },
+    /// A sample value is not finite.
+    #[error("sample {index} has a non-finite {field}")]
+    NonFiniteValue {
+        /// The sample index.
+        index: usize,
+        /// The value field.
+        field: &'static str,
+    },
+    /// A calculated metric value is not finite.
+    #[error("the calculated {field} metric is not finite")]
+    NonFiniteResult {
+        /// The metric field.
+        field: &'static str,
+    },
+    /// A sample time does not increase.
+    #[error("sample {index} has time {current_s}, which does not follow {previous_s}")]
+    NonMonotonicTime {
+        /// The sample index.
+        index: usize,
+        /// The time of the prior sample, in seconds.
+        previous_s: f64,
+        /// The time of this sample, in seconds.
+        current_s: f64,
+    },
+    /// An event time is outside the supplied series.
+    #[error("{field} time {time_s} is outside the series")]
+    EventOutsideSeries {
+        /// The event field.
+        field: &'static str,
+        /// The event time, in seconds.
+        time_s: f64,
+    },
+    /// A step has no change in value.
+    #[error("the step has zero amplitude")]
+    ZeroStep,
+    /// The vehicle has no clear direction at release.
+    #[error("the release velocity has no clear direction")]
+    NoReleaseDirection,
+    /// A numeric parameter is outside its fixed metric domain.
+    #[error("{field} is not valid")]
+    InvalidParameter {
+        /// The parameter field.
+        field: &'static str,
+    },
+}

--- a/crates/pilotage-flight-quality/src/gate.rs
+++ b/crates/pilotage-flight-quality/src/gate.rs
@@ -1,0 +1,164 @@
+use serde::{Deserialize, Serialize};
+
+/// One hard trial gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardGate {
+    /// The trial identity is valid and complete.
+    TrialIdentity,
+    /// The trial has no crash or unexpected contact.
+    CrashOrUnexpectedContact,
+    /// All required command, estimate, and truth values are finite.
+    FiniteSignals,
+    /// Position stays inside the declared bound.
+    PositionBound,
+    /// Attitude stays inside the declared bound.
+    AttitudeBound,
+    /// Body rate stays inside the declared bound.
+    RateBound,
+    /// Load stays inside the declared bound.
+    LoadBound,
+    /// Actuator saturation stays inside the declared duration bound.
+    ActuatorSaturationDuration,
+    /// The estimator stays valid.
+    EstimatorValidity,
+    /// The command link stays valid.
+    CommandLinkValidity,
+    /// The vehicle recovers before the phase deadline.
+    RecoveryDeadline,
+}
+
+impl HardGate {
+    /// The fixed hard-gate evaluation order for scorer version one.
+    pub const ORDER: [Self; 11] = [
+        Self::CrashOrUnexpectedContact,
+        Self::TrialIdentity,
+        Self::FiniteSignals,
+        Self::PositionBound,
+        Self::AttitudeBound,
+        Self::RateBound,
+        Self::LoadBound,
+        Self::ActuatorSaturationDuration,
+        Self::EstimatorValidity,
+        Self::CommandLinkValidity,
+        Self::RecoveryDeadline,
+    ];
+}
+
+/// Typed context for one hard gate outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub enum GateContext {
+    /// The outcome applies to the complete trial.
+    Trial,
+    /// The outcome applies to one phase.
+    Phase {
+        /// The phase index.
+        phase_index: usize,
+    },
+    /// The outcome applies to one sample.
+    Sample {
+        /// The phase index.
+        phase_index: usize,
+        /// The sample index.
+        sample_index: usize,
+        /// Trial time, in seconds.
+        time_s: f64,
+    },
+    /// The outcome compares one observed value with one limit.
+    Limit {
+        /// The phase index.
+        phase_index: usize,
+        /// The sample index.
+        sample_index: usize,
+        /// Trial time, in seconds.
+        time_s: f64,
+        /// The observed value.
+        observed: f64,
+        /// The applicable limit.
+        limit: f64,
+    },
+}
+
+/// The result for one hard gate.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HardGateOutcome {
+    /// The evaluated gate.
+    pub gate: HardGate,
+    /// Whether the trial passed this gate.
+    pub passed: bool,
+    /// The location or limit for this outcome.
+    pub context: GateContext,
+}
+
+impl HardGateOutcome {
+    /// Creates a passing gate outcome.
+    #[must_use]
+    pub const fn pass(gate: HardGate, context: GateContext) -> Self {
+        Self {
+            gate,
+            passed: true,
+            context,
+        }
+    }
+
+    /// Creates a failing gate outcome.
+    #[must_use]
+    pub const fn fail(gate: HardGate, context: GateContext) -> Self {
+        Self {
+            gate,
+            passed: false,
+            context,
+        }
+    }
+}
+
+/// The ordered hard gate results for one trial.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HardGateReport {
+    outcomes: Vec<HardGateOutcome>,
+}
+
+impl HardGateReport {
+    /// Creates a report from ordered gate outcomes.
+    #[must_use]
+    pub fn new(outcomes: Vec<HardGateOutcome>) -> Self {
+        Self { outcomes }
+    }
+
+    /// Returns all gate outcomes in evaluation order.
+    #[must_use]
+    pub fn outcomes(&self) -> &[HardGateOutcome] {
+        &self.outcomes
+    }
+
+    /// Returns true only when the report has outcomes and all gates pass.
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.outcomes.len() == HardGate::ORDER.len()
+            && self.ordered_prefix_is_valid()
+            && self.outcomes.iter().all(|outcome| outcome.passed)
+    }
+
+    /// Returns true when outcomes are a nonempty prefix of the fixed order.
+    #[must_use]
+    pub fn ordered_prefix_is_valid(&self) -> bool {
+        !self.outcomes.is_empty()
+            && self.outcomes.len() <= HardGate::ORDER.len()
+            && self
+                .outcomes
+                .iter()
+                .zip(HardGate::ORDER)
+                .all(|(outcome, required)| outcome.gate == required)
+    }
+
+    /// Returns each failed gate outcome.
+    pub fn failures(&self) -> impl Iterator<Item = &HardGateOutcome> {
+        self.outcomes.iter().filter(|outcome| !outcome.passed)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/gate/tests.rs
+++ b/crates/pilotage-flight-quality/src/gate/tests.rs
@@ -1,0 +1,49 @@
+use super::{GateContext, HardGate, HardGateOutcome, HardGateReport};
+
+#[test]
+fn one_hard_failure_keeps_the_report_failed() {
+    let report = HardGateReport::new(vec![
+        HardGateOutcome::pass(HardGate::TrialIdentity, GateContext::Trial),
+        HardGateOutcome::fail(
+            HardGate::RecoveryDeadline,
+            GateContext::Phase { phase_index: 4 },
+        ),
+    ]);
+
+    assert!(!report.passed());
+    assert_eq!(report.failures().count(), 1);
+}
+
+#[test]
+fn an_empty_report_does_not_claim_a_pass() {
+    assert!(!HardGateReport::default().passed());
+}
+
+#[test]
+fn only_the_complete_fixed_order_can_pass() {
+    let outcomes = HardGate::ORDER
+        .into_iter()
+        .map(|gate| HardGateOutcome::pass(gate, GateContext::Trial))
+        .collect();
+    let report = HardGateReport::new(outcomes);
+
+    assert!(report.ordered_prefix_is_valid());
+    assert!(report.passed());
+}
+
+#[test]
+fn an_omission_or_reorder_cannot_claim_a_pass() {
+    let omitted = HardGateReport::new(vec![HardGateOutcome::pass(
+        HardGate::CrashOrUnexpectedContact,
+        GateContext::Trial,
+    )]);
+    let reordered = HardGateReport::new(vec![
+        HardGateOutcome::pass(HardGate::TrialIdentity, GateContext::Trial),
+        HardGateOutcome::pass(HardGate::CrashOrUnexpectedContact, GateContext::Trial),
+    ]);
+
+    assert!(omitted.ordered_prefix_is_valid());
+    assert!(!omitted.passed());
+    assert!(!reordered.ordered_prefix_is_valid());
+    assert!(!reordered.passed());
+}

--- a/crates/pilotage-flight-quality/src/lib.rs
+++ b/crates/pilotage-flight-quality/src/lib.rs
@@ -1,0 +1,45 @@
+//! Deterministic offline flight-quality metrics and hard trial gates.
+//!
+//! This crate reads scalar projections from a saved trial. It does not own the
+//! trial schema. A caller selects one phase and one axis before it creates a
+//! metric input series.
+//!
+//! The metric rules are fixed. The scorer uses linear interpolation between
+//! samples. It uses time weights for distributions. It does not filter input
+//! data. It calculates jerk from adjacent acceleration samples.
+//!
+//! Hard gates are separate from continuous metrics. A hard gate failure cannot
+//! become a passing result through a continuous score.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![forbid(unsafe_code)]
+
+/// The identity of the fixed numerical rules in this crate.
+pub const FLIGHT_QUALITY_SCORER_VERSION: u16 = 1;
+
+mod control;
+mod error;
+mod gate;
+mod release;
+mod response;
+mod sample;
+mod series;
+mod signal;
+
+pub use control::{ControlMetrics, measure_control};
+pub use error::MetricError;
+pub use gate::{GateContext, HardGate, HardGateOutcome, HardGateReport};
+pub use release::{
+    HOLD_ZERO_HYSTERESIS_M, HoldMetrics, ReleaseMetrics, STOP_DWELL_S, STOP_SPEED_MPS,
+    measure_hold, measure_release,
+};
+pub use response::{
+    DELAY_FRACTION, RISE_HIGH_FRACTION, RISE_LOW_FRACTION, ResponseMetrics, SETTLING_FRACTION,
+    STEADY_STATE_WINDOW_S, StepSpec, measure_step_response,
+};
+pub use sample::{ControlPoint, MotionPoint, TimedValue};
+pub use signal::{JerkMetrics, SignalStats, measure_jerk, measure_signal};
+
+#[cfg(test)]
+mod test_trace;

--- a/crates/pilotage-flight-quality/src/release.rs
+++ b/crates/pilotage-flight-quality/src/release.rs
@@ -1,0 +1,333 @@
+use serde::{Deserialize, Serialize};
+
+use crate::series::{
+    linear_value_at, timed_window, validate_event, validate_metric_results,
+    validate_optional_metric_results, validate_times, validate_values,
+};
+use crate::{MetricError, MotionPoint, TimedValue};
+
+/// The speed threshold that marks a stopped vehicle.
+pub const STOP_SPEED_MPS: f64 = 0.05;
+/// The time that speed must stay below the stop threshold.
+pub const STOP_DWELL_S: f64 = 0.20;
+/// The position-error hysteresis for a final-hold zero crossing.
+pub const HOLD_ZERO_HYSTERESIS_M: f64 = 0.01;
+
+/// Metrics from input release to final-hold entry.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseMetrics {
+    /// Time from release to the first confirmed stop entry, in seconds.
+    pub release_to_stop_s: Option<f64>,
+    /// Travel in the release direction before the confirmed stop, in meters.
+    pub brake_distance_m: Option<f64>,
+    /// Travel back toward the release point before final hold, in meters.
+    pub return_toward_release_m: f64,
+    /// The first opposite-direction velocity excursion, in meters per second.
+    pub opposite_velocity_peak_mps: f64,
+}
+
+/// Metrics for motion around the final hold point.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HoldMetrics {
+    /// The largest opposite-side excursion after the first target crossing.
+    pub rebound_distance_m: f64,
+    /// The number of target crossings outside the fixed hysteresis.
+    pub zero_crossings: u32,
+}
+
+/// Calculates release and brake metrics on one selected axis.
+///
+/// The function confirms a stop only when speed stays at or below 0.05 m/s
+/// for 0.20 seconds. It measures release return before `hold_start_s`.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when the series or event times are invalid, or
+/// when the vehicle has no clear velocity direction at release.
+pub fn measure_release(
+    motion: &[MotionPoint],
+    release_time_s: f64,
+    hold_start_s: f64,
+) -> Result<ReleaseMetrics, MetricError> {
+    validate_motion(motion, release_time_s, hold_start_s)?;
+    let release_velocity = value_at(motion, release_time_s, |point| point.velocity_mps);
+    validate_metric_results(&[("release.velocity_mps", release_velocity)])?;
+    if release_velocity.abs() <= STOP_SPEED_MPS {
+        return Err(MetricError::NoReleaseDirection);
+    }
+    let direction = release_velocity.signum();
+    let stop_time = confirmed_stop_time(motion, release_time_s, hold_start_s);
+    let release_position = value_at(motion, release_time_s, |point| point.position_m);
+    validate_metric_results(&[("release.position_m", release_position)])?;
+    let brake_distance = stop_time.map(|time_s| {
+        maximum_directional_displacement(
+            motion,
+            release_time_s,
+            time_s,
+            release_position,
+            direction,
+        )
+    });
+    let metrics = ReleaseMetrics {
+        release_to_stop_s: stop_time.map(|time_s| time_s - release_time_s),
+        brake_distance_m: brake_distance,
+        return_toward_release_m: release_return(
+            motion,
+            release_time_s,
+            hold_start_s,
+            release_position,
+            direction,
+        ),
+        opposite_velocity_peak_mps: opposite_velocity_peak(
+            motion,
+            release_time_s,
+            hold_start_s,
+            direction,
+        ),
+    };
+    validate_optional_metric_results(&[
+        ("release.release_to_stop_s", metrics.release_to_stop_s),
+        ("release.brake_distance_m", metrics.brake_distance_m),
+    ])?;
+    validate_metric_results(&[
+        (
+            "release.return_toward_release_m",
+            metrics.return_toward_release_m,
+        ),
+        (
+            "release.opposite_velocity_peak_mps",
+            metrics.opposite_velocity_peak_mps,
+        ),
+    ])?;
+    Ok(metrics)
+}
+
+/// Calculates rebound and zero crossings around one final hold point.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when the position series or hold time is invalid.
+pub fn measure_hold(
+    position: &[TimedValue],
+    hold_start_s: f64,
+    hold_position_m: f64,
+) -> Result<HoldMetrics, MetricError> {
+    crate::series::validate_timed_values(position)?;
+    validate_event(position, "hold_start", hold_start_s, |sample| sample.time_s)?;
+    if !hold_position_m.is_finite() {
+        return Err(MetricError::InvalidParameter {
+            field: "hold_position_m",
+        });
+    }
+    let end_s = position[position.len() - 1].time_s;
+    if hold_start_s >= end_s {
+        return Err(MetricError::InvalidParameter {
+            field: "hold_start_s",
+        });
+    }
+    let window = timed_window(position, hold_start_s, end_s);
+    for sample in &window {
+        validate_metric_results(&[("hold.position_error_m", sample.value - hold_position_m)])?;
+    }
+    let metrics = hold_excursions(&window, hold_position_m);
+    validate_metric_results(&[("hold.rebound_distance_m", metrics.rebound_distance_m)])?;
+    Ok(metrics)
+}
+
+fn validate_motion(
+    motion: &[MotionPoint],
+    release_time_s: f64,
+    hold_start_s: f64,
+) -> Result<(), MetricError> {
+    validate_times(motion, |point| point.time_s)?;
+    validate_values(motion, "position_m", |point| point.position_m)?;
+    validate_values(motion, "velocity_mps", |point| point.velocity_mps)?;
+    validate_event(motion, "release", release_time_s, |point| point.time_s)?;
+    validate_event(motion, "hold_start", hold_start_s, |point| point.time_s)?;
+    if hold_start_s <= release_time_s {
+        return Err(MetricError::InvalidParameter {
+            field: "hold_start_s",
+        });
+    }
+    Ok(())
+}
+
+fn value_at(motion: &[MotionPoint], time_s: f64, value: impl Fn(&MotionPoint) -> f64) -> f64 {
+    linear_value_at(motion, time_s, |point| point.time_s, value)
+}
+
+fn confirmed_stop_time(
+    motion: &[MotionPoint],
+    release_time_s: f64,
+    hold_start_s: f64,
+) -> Option<f64> {
+    let mut low_intervals = Vec::new();
+    for pair in motion.windows(2) {
+        let start = pair[0].time_s.max(release_time_s);
+        let end = pair[1].time_s.min(hold_start_s);
+        if start >= end {
+            continue;
+        }
+        let v0 = value_at(motion, start, |point| point.velocity_mps);
+        let v1 = value_at(motion, end, |point| point.velocity_mps);
+        if let Some(interval) = low_speed_interval(start, v0, end, v1) {
+            low_intervals.push(interval);
+        }
+    }
+    first_dwell_interval(&low_intervals, STOP_DWELL_S)
+}
+
+fn low_speed_interval(t0: f64, v0: f64, t1: f64, v1: f64) -> Option<(f64, f64)> {
+    if v0 == v1 {
+        return (v0.abs() <= STOP_SPEED_MPS).then_some((t0, t1));
+    }
+    let delta = v1 - v0;
+    let at_negative = (-STOP_SPEED_MPS - v0) / delta;
+    let at_positive = (STOP_SPEED_MPS - v0) / delta;
+    let start_fraction = at_negative.min(at_positive).clamp(0.0, 1.0);
+    let end_fraction = at_negative.max(at_positive).clamp(0.0, 1.0);
+    let middle = (start_fraction + end_fraction) / 2.0;
+    let middle_velocity = v0 + middle * delta;
+    if start_fraction > end_fraction || middle_velocity.abs() > STOP_SPEED_MPS {
+        return None;
+    }
+    let duration = t1 - t0;
+    Some((t0 + start_fraction * duration, t0 + end_fraction * duration))
+}
+
+fn first_dwell_interval(intervals: &[(f64, f64)], dwell_s: f64) -> Option<f64> {
+    let mut merged: Option<(f64, f64)> = None;
+    for &(start, end) in intervals {
+        match merged {
+            Some((first, prior_end)) if start <= prior_end + f64::EPSILON => {
+                merged = Some((first, prior_end.max(end)));
+            }
+            Some((first, prior_end)) => {
+                if prior_end - first >= dwell_s {
+                    return Some(first);
+                }
+                merged = Some((start, end));
+            }
+            None => merged = Some((start, end)),
+        }
+    }
+    merged.and_then(|(start, end)| (end - start >= dwell_s).then_some(start))
+}
+
+fn release_return(
+    motion: &[MotionPoint],
+    release_time_s: f64,
+    hold_start_s: f64,
+    release_position: f64,
+    direction: f64,
+) -> f64 {
+    let mut running_maximum = 0.0_f64;
+    let mut maximum_return = 0.0_f64;
+    for position in values_in_window(motion, release_time_s, hold_start_s, |point| {
+        point.position_m
+    }) {
+        let displacement = (position - release_position) * direction;
+        running_maximum = running_maximum.max(displacement);
+        maximum_return = maximum_return.max(running_maximum - displacement);
+    }
+    maximum_return
+}
+
+fn opposite_velocity_peak(
+    motion: &[MotionPoint],
+    release_time_s: f64,
+    hold_start_s: f64,
+    direction: f64,
+) -> f64 {
+    let mut active = false;
+    let mut peak = 0.0_f64;
+    for velocity in values_in_window(motion, release_time_s, hold_start_s, |point| {
+        point.velocity_mps
+    }) {
+        let directed = velocity * direction;
+        if !active {
+            if directed < -STOP_SPEED_MPS {
+                active = true;
+                peak = -directed;
+            }
+        } else if directed >= -STOP_SPEED_MPS {
+            break;
+        } else {
+            peak = peak.max(-directed);
+        }
+    }
+    peak
+}
+
+fn maximum_directional_displacement(
+    motion: &[MotionPoint],
+    start_s: f64,
+    end_s: f64,
+    origin_m: f64,
+    direction: f64,
+) -> f64 {
+    values_in_window(motion, start_s, end_s, |point| point.position_m)
+        .into_iter()
+        .map(|position| (position - origin_m) * direction)
+        .fold(0.0_f64, f64::max)
+}
+
+fn values_in_window(
+    motion: &[MotionPoint],
+    start_s: f64,
+    end_s: f64,
+    value: impl Fn(&MotionPoint) -> f64 + Copy,
+) -> Vec<f64> {
+    let mut values = Vec::with_capacity(motion.len() + 2);
+    values.push(value_at(motion, start_s, value));
+    values.extend(
+        motion
+            .iter()
+            .filter(|point| point.time_s > start_s && point.time_s < end_s)
+            .map(value),
+    );
+    values.push(value_at(motion, end_s, value));
+    values
+}
+
+fn hold_excursions(window: &[TimedValue], target: f64) -> HoldMetrics {
+    let mut first_sign: Option<i8> = None;
+    let mut current_sign: Option<i8> = None;
+    let mut crossings = 0_u32;
+    let mut rebound = 0.0_f64;
+    for sample in window {
+        let error = sample.value - target;
+        let sign = hysteresis_sign(error);
+        let Some(sign) = sign else {
+            continue;
+        };
+        first_sign.get_or_insert(sign);
+        if current_sign.is_some_and(|prior| prior != sign) {
+            crossings = crossings.wrapping_add(1);
+        }
+        current_sign = Some(sign);
+        if crossings > 0 && first_sign.is_some_and(|initial| initial != sign) {
+            rebound = rebound.max(error.abs());
+        }
+    }
+    HoldMetrics {
+        rebound_distance_m: rebound,
+        zero_crossings: crossings,
+    }
+}
+
+fn hysteresis_sign(error: f64) -> Option<i8> {
+    if error > HOLD_ZERO_HYSTERESIS_M {
+        Some(1)
+    } else if error < -HOLD_ZERO_HYSTERESIS_M {
+        Some(-1)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/release.rs
+++ b/crates/pilotage-flight-quality/src/release.rs
@@ -58,7 +58,7 @@ pub fn measure_release(
         return Err(MetricError::NoReleaseDirection);
     }
     let direction = release_velocity.signum();
-    let stop_time = confirmed_stop_time(motion, release_time_s, hold_start_s);
+    let stop_time = confirmed_stop_time(motion, release_time_s, hold_start_s)?;
     let release_position = value_at(motion, release_time_s, |point| point.position_m);
     validate_metric_results(&[("release.position_m", release_position)])?;
     let brake_distance = stop_time.map(|time_s| {
@@ -79,7 +79,7 @@ pub fn measure_release(
             hold_start_s,
             release_position,
             direction,
-        ),
+        )?,
         opposite_velocity_peak_mps: opposite_velocity_peak(
             motion,
             release_time_s,
@@ -162,7 +162,7 @@ fn confirmed_stop_time(
     motion: &[MotionPoint],
     release_time_s: f64,
     hold_start_s: f64,
-) -> Option<f64> {
+) -> Result<Option<f64>, MetricError> {
     let mut low_intervals = Vec::new();
     for pair in motion.windows(2) {
         let start = pair[0].time_s.max(release_time_s);
@@ -172,11 +172,12 @@ fn confirmed_stop_time(
         }
         let v0 = value_at(motion, start, |point| point.velocity_mps);
         let v1 = value_at(motion, end, |point| point.velocity_mps);
+        validate_metric_results(&[("release.stop_velocity_delta_mps", v1 - v0)])?;
         if let Some(interval) = low_speed_interval(start, v0, end, v1) {
             low_intervals.push(interval);
         }
     }
-    first_dwell_interval(&low_intervals, STOP_DWELL_S)
+    Ok(first_dwell_interval(&low_intervals, STOP_DWELL_S))
 }
 
 fn low_speed_interval(t0: f64, v0: f64, t1: f64, v1: f64) -> Option<(f64, f64)> {
@@ -222,17 +223,20 @@ fn release_return(
     hold_start_s: f64,
     release_position: f64,
     direction: f64,
-) -> f64 {
+) -> Result<f64, MetricError> {
     let mut running_maximum = 0.0_f64;
     let mut maximum_return = 0.0_f64;
     for position in values_in_window(motion, release_time_s, hold_start_s, |point| {
         point.position_m
     }) {
         let displacement = (position - release_position) * direction;
+        validate_metric_results(&[("release.displacement_m", displacement)])?;
         running_maximum = running_maximum.max(displacement);
-        maximum_return = maximum_return.max(running_maximum - displacement);
+        let return_distance = running_maximum - displacement;
+        validate_metric_results(&[("release.return_distance_m", return_distance)])?;
+        maximum_return = maximum_return.max(return_distance);
     }
-    maximum_return
+    Ok(maximum_return)
 }
 
 fn opposite_velocity_peak(

--- a/crates/pilotage-flight-quality/src/release/tests.rs
+++ b/crates/pilotage-flight-quality/src/release/tests.rs
@@ -1,0 +1,260 @@
+use super::{measure_hold, measure_release};
+use crate::{MetricError, MotionPoint, TimedValue};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-10, "{actual} != {expected}");
+}
+
+#[test]
+fn a_linear_brake_has_exact_stop_time_and_distance() {
+    let motion = (0..=40)
+        .map(|index| {
+            let time_s = f64::from(index) / 10.0;
+            let velocity = (2.0 - time_s).max(0.0);
+            let position = if time_s <= 2.0 {
+                2.0 * time_s - 0.5 * time_s * time_s
+            } else {
+                2.0
+            };
+            MotionPoint {
+                time_s,
+                position_m: position,
+                velocity_mps: velocity,
+            }
+        })
+        .collect::<Vec<_>>();
+    let metrics = measure_release(&motion, 0.0, 3.0).expect("valid brake trace");
+
+    assert_close(metrics.release_to_stop_s.expect("stop"), 1.95);
+    assert_close(metrics.brake_distance_m.expect("distance"), 1.9975);
+    assert_eq!(metrics.return_toward_release_m, 0.0);
+    assert_eq!(metrics.opposite_velocity_peak_mps, 0.0);
+}
+
+#[test]
+fn release_return_is_separate_from_final_hold_rebound() {
+    let motion = vec![
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: 2.0,
+            velocity_mps: 0.0,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: 1.5,
+            velocity_mps: -0.5,
+        },
+        MotionPoint {
+            time_s: 3.0,
+            position_m: 1.5,
+            velocity_mps: 0.0,
+        },
+    ];
+    let release = measure_release(&motion, 0.0, 2.0).expect("valid release trace");
+    assert_close(release.return_toward_release_m, 0.5);
+    assert_close(release.opposite_velocity_peak_mps, 0.5);
+
+    let hold = [
+        TimedValue {
+            time_s: 2.0,
+            value: 1.7,
+        },
+        TimedValue {
+            time_s: 2.5,
+            value: 1.4,
+        },
+        TimedValue {
+            time_s: 3.0,
+            value: 1.55,
+        },
+        TimedValue {
+            time_s: 3.5,
+            value: 1.48,
+        },
+        TimedValue {
+            time_s: 4.0,
+            value: 1.5,
+        },
+    ];
+    let rebound = measure_hold(&hold, 2.0, 1.5).expect("valid hold trace");
+    assert_close(rebound.rebound_distance_m, 0.1);
+    assert_eq!(rebound.zero_crossings, 3);
+}
+
+#[test]
+fn the_zero_crossing_hysteresis_ignores_center_noise() {
+    let position = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.2,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 0.005,
+        },
+        TimedValue {
+            time_s: 2.0,
+            value: -0.004,
+        },
+        TimedValue {
+            time_s: 3.0,
+            value: -0.1,
+        },
+    ];
+    let metrics = measure_hold(&position, 0.0, 0.0).expect("valid hold trace");
+
+    assert_eq!(metrics.zero_crossings, 1);
+    assert_close(metrics.rebound_distance_m, 0.1);
+}
+
+#[test]
+fn release_uses_the_largest_return_and_the_first_opposite_lobe() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: 2.0,
+            velocity_mps: -0.4,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: 1.0,
+            velocity_mps: 0.2,
+        },
+        MotionPoint {
+            time_s: 3.0,
+            position_m: 1.5,
+            velocity_mps: -0.8,
+        },
+        MotionPoint {
+            time_s: 4.0,
+            position_m: 1.5,
+            velocity_mps: 0.0,
+        },
+    ];
+    let metrics = measure_release(&motion, 0.0, 3.5).expect("valid release trace");
+
+    assert_close(metrics.return_toward_release_m, 1.0);
+    assert_close(metrics.opposite_velocity_peak_mps, 0.4);
+}
+
+#[test]
+fn interpolated_event_boundaries_contribute_to_opposite_velocity() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: 1.0,
+            velocity_mps: -1.0,
+        },
+    ];
+    let metrics = measure_release(&motion, 0.5, 1.5).expect("valid release trace");
+
+    assert_close(metrics.opposite_velocity_peak_mps, 0.5);
+}
+
+#[test]
+fn a_stop_after_hold_entry_does_not_change_release_metrics() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: 1.0,
+            velocity_mps: 0.2,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: 1.2,
+            velocity_mps: 0.0,
+        },
+        MotionPoint {
+            time_s: 3.0,
+            position_m: 1.2,
+            velocity_mps: 0.0,
+        },
+    ];
+    let metrics = measure_release(&motion, 0.0, 1.0).expect("valid release phase");
+
+    assert_eq!(metrics.release_to_stop_s, None);
+    assert_eq!(metrics.brake_distance_m, None);
+}
+
+#[test]
+fn a_zero_duration_hold_is_not_evidence() {
+    let position = [
+        TimedValue {
+            time_s: 0.0,
+            value: 1.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 0.0,
+        },
+    ];
+
+    assert_eq!(
+        measure_hold(&position, 1.0, 0.0),
+        Err(MetricError::InvalidParameter {
+            field: "hold_start_s",
+        })
+    );
+}
+
+#[test]
+fn a_non_finite_derived_release_metric_is_a_typed_error() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: f64::MAX,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: -f64::MAX,
+            velocity_mps: 1.0,
+        },
+    ];
+
+    assert!(matches!(
+        measure_release(&motion, 0.0, 1.0),
+        Err(MetricError::NonFiniteResult { .. })
+    ));
+}
+
+#[test]
+fn a_non_finite_hold_error_is_a_typed_error() {
+    let position = [
+        TimedValue {
+            time_s: 0.0,
+            value: f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+
+    assert_eq!(
+        measure_hold(&position, 0.0, -f64::MAX),
+        Err(MetricError::NonFiniteResult {
+            field: "hold.position_error_m",
+        })
+    );
+}

--- a/crates/pilotage-flight-quality/src/release/tests.rs
+++ b/crates/pilotage-flight-quality/src/release/tests.rs
@@ -258,3 +258,115 @@ fn a_non_finite_hold_error_is_a_typed_error() {
         })
     );
 }
+
+#[test]
+fn signed_zero_release_and_hold_times_select_the_first_sample() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: 0.5,
+            velocity_mps: 0.0,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: 0.5,
+            velocity_mps: 0.0,
+        },
+    ];
+    let release = measure_release(&motion, -0.0, 1.5)
+        .expect("signed zero identifies the first release sample");
+    assert!(release.release_to_stop_s.is_some());
+
+    let position = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.2,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 0.0,
+        },
+    ];
+    let hold =
+        measure_hold(&position, -0.0, 0.0).expect("signed zero identifies the first hold sample");
+    assert_eq!(hold.zero_crossings, 0);
+}
+
+#[test]
+fn non_finite_stop_velocity_delta_has_typed_context() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: f64::MAX,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: 0.0,
+            velocity_mps: -f64::MAX,
+        },
+    ];
+
+    assert_eq!(
+        measure_release(&motion, 0.0, 1.0),
+        Err(MetricError::NonFiniteResult {
+            field: "release.stop_velocity_delta_mps",
+        })
+    );
+}
+
+#[test]
+fn non_finite_release_displacement_has_typed_context() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: -f64::MAX,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: f64::MAX,
+            velocity_mps: 1.0,
+        },
+    ];
+
+    assert_eq!(
+        measure_release(&motion, 0.0, 1.0),
+        Err(MetricError::NonFiniteResult {
+            field: "release.displacement_m",
+        })
+    );
+}
+
+#[test]
+fn non_finite_release_return_distance_has_typed_context() {
+    let motion = [
+        MotionPoint {
+            time_s: 0.0,
+            position_m: 0.0,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 1.0,
+            position_m: f64::MAX,
+            velocity_mps: 1.0,
+        },
+        MotionPoint {
+            time_s: 2.0,
+            position_m: -f64::MAX,
+            velocity_mps: 1.0,
+        },
+    ];
+
+    assert_eq!(
+        measure_release(&motion, 0.0, 2.0),
+        Err(MetricError::NonFiniteResult {
+            field: "release.return_distance_m",
+        })
+    );
+}

--- a/crates/pilotage-flight-quality/src/response.rs
+++ b/crates/pilotage-flight-quality/src/response.rs
@@ -1,0 +1,271 @@
+use serde::{Deserialize, Serialize};
+
+use crate::series::{
+    integral_abs_linear, interpolate, timed_window, validate_event, validate_metric_results,
+    validate_optional_metric_results, validate_timed_values,
+};
+use crate::{MetricError, TimedValue};
+
+/// The directional step fraction that marks a detected response.
+pub const DELAY_FRACTION: f64 = 0.02;
+/// The lower directional fraction for rise time.
+pub const RISE_LOW_FRACTION: f64 = 0.10;
+/// The upper directional fraction for rise time.
+pub const RISE_HIGH_FRACTION: f64 = 0.90;
+/// The half-width of the settling band around the target.
+pub const SETTLING_FRACTION: f64 = 0.05;
+/// The final response interval used for steady-state error.
+pub const STEADY_STATE_WINDOW_S: f64 = 0.50;
+
+/// The input event and values for one scalar step.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StepSpec {
+    /// The input event time, in seconds.
+    pub input_time_s: f64,
+    /// The value before the step.
+    pub initial_value: f64,
+    /// The requested final value.
+    pub target_value: f64,
+}
+
+/// Continuous metrics for one scalar step response.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseMetrics {
+    /// Time from input to 2 percent of the command step, in seconds.
+    pub input_to_command_delay_s: Option<f64>,
+    /// Time from input to 2 percent of the response step, in seconds.
+    pub input_to_response_delay_s: Option<f64>,
+    /// Time from 10 percent to 90 percent of the response, in seconds.
+    pub rise_time_s: Option<f64>,
+    /// Time from input to final entry in the 5 percent band, in seconds.
+    pub settling_time_s: Option<f64>,
+    /// The largest response beyond the target, in response units.
+    pub overshoot: f64,
+    /// Overshoot divided by the absolute step amplitude.
+    pub overshoot_fraction: f64,
+    /// The largest response behind the initial value, in response units.
+    pub undershoot: f64,
+    /// The signed mean response error in the final fixed window.
+    pub steady_state_error: f64,
+    /// The time integral of absolute response error after the input event.
+    pub integrated_absolute_error: f64,
+}
+
+/// Calculates fixed step-response metrics from saved scalar series.
+///
+/// The function uses the first directional threshold crossing. It uses the
+/// last entry into the settling band. It returns `None` when a threshold is
+/// not reached before the series ends.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when a series is invalid, an event is outside a
+/// series, or the step amplitude is zero.
+pub fn measure_step_response(
+    command: &[TimedValue],
+    response: &[TimedValue],
+    spec: StepSpec,
+) -> Result<ResponseMetrics, MetricError> {
+    validate_inputs(command, response, spec)?;
+    let command_progress = progress_window(command, spec);
+    let response_progress = progress_window(response, spec);
+    let command_delay =
+        first_crossing(&command_progress, DELAY_FRACTION).map(|time_s| time_s - spec.input_time_s);
+    let response_delay =
+        first_crossing(&response_progress, DELAY_FRACTION).map(|time_s| time_s - spec.input_time_s);
+    let rise_time = crossing_delta(&response_progress, RISE_LOW_FRACTION, RISE_HIGH_FRACTION);
+    let settling_time = settling_time(&response_progress).map(|time_s| time_s - spec.input_time_s);
+    let (overshoot, undershoot) = excursions(&response_progress, spec);
+    let response_error = response_error(response, spec);
+    let amplitude = (spec.target_value - spec.initial_value).abs();
+    let metrics = ResponseMetrics {
+        input_to_command_delay_s: command_delay,
+        input_to_response_delay_s: response_delay,
+        rise_time_s: rise_time,
+        settling_time_s: settling_time,
+        overshoot,
+        overshoot_fraction: overshoot / amplitude,
+        undershoot,
+        steady_state_error: steady_state_error(&response_error),
+        integrated_absolute_error: integrated_absolute_error(&response_error),
+    };
+    validate_response_metrics(metrics)
+}
+
+fn validate_response_metrics(metrics: ResponseMetrics) -> Result<ResponseMetrics, MetricError> {
+    validate_optional_metric_results(&[
+        (
+            "response.input_to_command_delay_s",
+            metrics.input_to_command_delay_s,
+        ),
+        (
+            "response.input_to_response_delay_s",
+            metrics.input_to_response_delay_s,
+        ),
+        ("response.rise_time_s", metrics.rise_time_s),
+        ("response.settling_time_s", metrics.settling_time_s),
+    ])?;
+    validate_metric_results(&[
+        ("response.overshoot", metrics.overshoot),
+        ("response.overshoot_fraction", metrics.overshoot_fraction),
+        ("response.undershoot", metrics.undershoot),
+        ("response.steady_state_error", metrics.steady_state_error),
+        (
+            "response.integrated_absolute_error",
+            metrics.integrated_absolute_error,
+        ),
+    ])?;
+    Ok(metrics)
+}
+
+fn validate_inputs(
+    command: &[TimedValue],
+    response: &[TimedValue],
+    spec: StepSpec,
+) -> Result<(), MetricError> {
+    validate_timed_values(command)?;
+    validate_timed_values(response)?;
+    for (field, value) in [
+        ("input_time_s", spec.input_time_s),
+        ("initial_value", spec.initial_value),
+        ("target_value", spec.target_value),
+    ] {
+        if !value.is_finite() {
+            return Err(MetricError::InvalidParameter { field });
+        }
+    }
+    if spec.initial_value == spec.target_value {
+        return Err(MetricError::ZeroStep);
+    }
+    validate_event(command, "input", spec.input_time_s, |sample| sample.time_s)?;
+    validate_event(response, "input", spec.input_time_s, |sample| sample.time_s)?;
+    if spec.input_time_s >= command[command.len() - 1].time_s
+        || spec.input_time_s >= response[response.len() - 1].time_s
+    {
+        return Err(MetricError::InvalidParameter {
+            field: "input_time_s",
+        });
+    }
+    Ok(())
+}
+
+fn progress_window(samples: &[TimedValue], spec: StepSpec) -> Vec<TimedValue> {
+    let end_s = samples[samples.len() - 1].time_s;
+    let amplitude = (spec.target_value - spec.initial_value).abs();
+    let direction = (spec.target_value - spec.initial_value).signum();
+    timed_window(samples, spec.input_time_s, end_s)
+        .into_iter()
+        .map(|sample| TimedValue {
+            time_s: sample.time_s,
+            value: (sample.value - spec.initial_value) * direction / amplitude,
+        })
+        .collect()
+}
+
+fn first_crossing(progress: &[TimedValue], threshold: f64) -> Option<f64> {
+    if progress[0].value >= threshold {
+        return Some(progress[0].time_s);
+    }
+    progress.windows(2).find_map(|pair| {
+        let before = pair[0];
+        let after = pair[1];
+        if before.value < threshold && after.value >= threshold {
+            Some(interpolate(
+                before.value,
+                before.time_s,
+                after.value,
+                after.time_s,
+                threshold,
+            ))
+        } else {
+            None
+        }
+    })
+}
+
+fn crossing_delta(progress: &[TimedValue], low: f64, high: f64) -> Option<f64> {
+    let low_time = first_crossing(progress, low)?;
+    let high_time = first_crossing(progress, high)?;
+    Some(high_time - low_time)
+}
+
+fn settling_time(progress: &[TimedValue]) -> Option<f64> {
+    let low = 1.0 - SETTLING_FRACTION;
+    let high = 1.0 + SETTLING_FRACTION;
+    if !(low..=high).contains(&progress[progress.len() - 1].value) {
+        return None;
+    }
+    let last_outside = progress
+        .iter()
+        .rposition(|sample| !(low..=high).contains(&sample.value));
+    let Some(index) = last_outside else {
+        return Some(progress[0].time_s);
+    };
+    let before = progress[index];
+    let after = progress[index + 1];
+    let boundary = if before.value < low { low } else { high };
+    Some(interpolate(
+        before.value,
+        before.time_s,
+        after.value,
+        after.time_s,
+        boundary,
+    ))
+}
+
+fn excursions(progress: &[TimedValue], spec: StepSpec) -> (f64, f64) {
+    let maximum = progress
+        .iter()
+        .map(|sample| sample.value)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let minimum = progress
+        .iter()
+        .map(|sample| sample.value)
+        .fold(f64::INFINITY, f64::min);
+    let amplitude = (spec.target_value - spec.initial_value).abs();
+    (
+        (maximum - 1.0).max(0.0) * amplitude,
+        (-minimum).max(0.0) * amplitude,
+    )
+}
+
+fn response_error(samples: &[TimedValue], spec: StepSpec) -> Vec<TimedValue> {
+    let end_s = samples[samples.len() - 1].time_s;
+    timed_window(samples, spec.input_time_s, end_s)
+        .into_iter()
+        .map(|sample| TimedValue {
+            time_s: sample.time_s,
+            value: sample.value - spec.target_value,
+        })
+        .collect()
+}
+
+fn steady_state_error(error: &[TimedValue]) -> f64 {
+    let end_s = error[error.len() - 1].time_s;
+    let start_s = (end_s - STEADY_STATE_WINDOW_S).max(error[0].time_s);
+    let window = timed_window(error, start_s, end_s);
+    let integral = window
+        .windows(2)
+        .map(|pair| (pair[0].value + pair[1].value) * (pair[1].time_s - pair[0].time_s) / 2.0)
+        .sum::<f64>();
+    integral / (end_s - start_s)
+}
+
+fn integrated_absolute_error(error: &[TimedValue]) -> f64 {
+    error
+        .windows(2)
+        .map(|pair| {
+            integral_abs_linear(
+                pair[0].value,
+                pair[1].value,
+                pair[1].time_s - pair[0].time_s,
+            )
+        })
+        .sum()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/response.rs
+++ b/crates/pilotage-flight-quality/src/response.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::series::{
     integral_abs_linear, interpolate, timed_window, validate_event, validate_metric_results,
-    validate_optional_metric_results, validate_timed_values,
+    validate_optional_metric_results, validate_timed_values, validate_values,
 };
 use crate::{MetricError, TimedValue};
 
@@ -70,7 +70,13 @@ pub fn measure_step_response(
 ) -> Result<ResponseMetrics, MetricError> {
     validate_inputs(command, response, spec)?;
     let command_progress = progress_window(command, spec);
+    validate_values(&command_progress, "response.command_progress", |sample| {
+        sample.value
+    })?;
     let response_progress = progress_window(response, spec);
+    validate_values(&response_progress, "response.response_progress", |sample| {
+        sample.value
+    })?;
     let command_delay =
         first_crossing(&command_progress, DELAY_FRACTION).map(|time_s| time_s - spec.input_time_s);
     let response_delay =
@@ -79,6 +85,7 @@ pub fn measure_step_response(
     let settling_time = settling_time(&response_progress).map(|time_s| time_s - spec.input_time_s);
     let (overshoot, undershoot) = excursions(&response_progress, spec);
     let response_error = response_error(response, spec);
+    validate_values(&response_error, "response.error", |sample| sample.value)?;
     let amplitude = (spec.target_value - spec.initial_value).abs();
     let metrics = ResponseMetrics {
         input_to_command_delay_s: command_delay,
@@ -139,6 +146,10 @@ fn validate_inputs(
     if spec.initial_value == spec.target_value {
         return Err(MetricError::ZeroStep);
     }
+    validate_metric_results(&[(
+        "response.step_delta",
+        spec.target_value - spec.initial_value,
+    )])?;
     validate_event(command, "input", spec.input_time_s, |sample| sample.time_s)?;
     validate_event(response, "input", spec.input_time_s, |sample| sample.time_s)?;
     if spec.input_time_s >= command[command.len() - 1].time_s

--- a/crates/pilotage-flight-quality/src/response/tests.rs
+++ b/crates/pilotage-flight-quality/src/response/tests.rs
@@ -196,7 +196,7 @@ fn a_non_finite_derived_response_metric_is_a_typed_error() {
         },
     ];
 
-    assert!(matches!(
+    assert_eq!(
         measure_step_response(
             &samples,
             &samples,
@@ -206,6 +206,156 @@ fn a_non_finite_derived_response_metric_is_a_typed_error() {
                 target_value: -f64::MAX,
             },
         ),
-        Err(MetricError::NonFiniteResult { .. })
-    ));
+        Err(MetricError::NonFiniteResult {
+            field: "response.step_delta",
+        })
+    );
+}
+
+#[test]
+fn signed_zero_input_time_is_the_first_step_sample() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1.0,
+        },
+    ];
+
+    let metrics = measure_step_response(
+        &samples,
+        &samples,
+        StepSpec {
+            input_time_s: -0.0,
+            initial_value: 0.0,
+            target_value: 1.0,
+        },
+    )
+    .expect("signed zero identifies the first sample");
+
+    assert_eq!(metrics.input_to_command_delay_s, Some(0.02));
+    assert_eq!(metrics.input_to_response_delay_s, Some(0.02));
+}
+
+#[test]
+fn non_finite_command_progress_has_typed_context() {
+    let command = [
+        TimedValue {
+            time_s: 0.0,
+            value: -f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+    let response = [
+        TimedValue {
+            time_s: 0.0,
+            value: -f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 0.0,
+        },
+    ];
+
+    assert_eq!(
+        measure_step_response(
+            &command,
+            &response,
+            StepSpec {
+                input_time_s: 0.0,
+                initial_value: -f64::MAX,
+                target_value: 0.0,
+            },
+        ),
+        Err(MetricError::NonFiniteValue {
+            index: 1,
+            field: "response.command_progress",
+        })
+    );
+}
+
+#[test]
+fn non_finite_response_progress_has_typed_context() {
+    let command = [
+        TimedValue {
+            time_s: 0.0,
+            value: -f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 0.0,
+        },
+    ];
+    let response = [
+        TimedValue {
+            time_s: 0.0,
+            value: -f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+
+    assert_eq!(
+        measure_step_response(
+            &command,
+            &response,
+            StepSpec {
+                input_time_s: 0.0,
+                initial_value: -f64::MAX,
+                target_value: 0.0,
+            },
+        ),
+        Err(MetricError::NonFiniteValue {
+            index: 1,
+            field: "response.response_progress",
+        })
+    );
+}
+
+#[test]
+fn non_finite_response_error_has_typed_context() {
+    let command = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: -f64::MAX,
+        },
+    ];
+    let response = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+
+    assert_eq!(
+        measure_step_response(
+            &command,
+            &response,
+            StepSpec {
+                input_time_s: 0.0,
+                initial_value: 0.0,
+                target_value: -f64::MAX,
+            },
+        ),
+        Err(MetricError::NonFiniteValue {
+            index: 1,
+            field: "response.error",
+        })
+    );
 }

--- a/crates/pilotage-flight-quality/src/response/tests.rs
+++ b/crates/pilotage-flight-quality/src/response/tests.rs
@@ -1,0 +1,211 @@
+use super::{StepSpec, measure_step_response};
+use crate::test_trace::sample_value;
+use crate::{MetricError, TimedValue};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-10, "{actual} != {expected}");
+}
+
+#[test]
+fn a_linear_step_has_exact_delay_rise_and_settle_metrics() {
+    let command = sample_value(10, 4.0, |time| ((time - 1.2) / 1.0).clamp(0.0, 1.0));
+    let response = sample_value(10, 4.0, |time| ((time - 1.5) / 2.0).clamp(0.0, 1.0));
+    let metrics = measure_step_response(
+        &command,
+        &response,
+        StepSpec {
+            input_time_s: 1.0,
+            initial_value: 0.0,
+            target_value: 1.0,
+        },
+    )
+    .expect("valid analytic trace");
+
+    assert_close(
+        metrics.input_to_command_delay_s.expect("command delay"),
+        0.22,
+    );
+    assert_close(
+        metrics.input_to_response_delay_s.expect("response delay"),
+        0.54,
+    );
+    assert_close(metrics.rise_time_s.expect("rise"), 1.6);
+    assert_close(metrics.settling_time_s.expect("settle"), 2.4);
+    assert_eq!(metrics.overshoot, 0.0);
+    assert_eq!(metrics.undershoot, 0.0);
+    assert_close(metrics.steady_state_error, 0.0);
+    assert_close(metrics.integrated_absolute_error, 1.5);
+}
+
+#[test]
+fn a_damped_shape_reports_overshoot_and_final_settle_entry() {
+    let command = vec![
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1.0,
+        },
+        TimedValue {
+            time_s: 4.0,
+            value: 1.0,
+        },
+    ];
+    let response = vec![
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1.2,
+        },
+        TimedValue {
+            time_s: 2.0,
+            value: 0.9,
+        },
+        TimedValue {
+            time_s: 3.0,
+            value: 1.0,
+        },
+        TimedValue {
+            time_s: 4.0,
+            value: 1.0,
+        },
+    ];
+    let metrics = measure_step_response(
+        &command,
+        &response,
+        StepSpec {
+            input_time_s: 0.0,
+            initial_value: 0.0,
+            target_value: 1.0,
+        },
+    )
+    .expect("valid analytic trace");
+
+    assert_close(metrics.overshoot, 0.2);
+    assert_close(metrics.overshoot_fraction, 0.2);
+    assert_close(metrics.settling_time_s.expect("settle"), 2.5);
+}
+
+#[test]
+fn linear_metrics_are_independent_of_input_sample_rate() {
+    let run = |rate_hz| {
+        let series = sample_value(rate_hz, 2.0, |time| ((time - 0.2) / 1.0).clamp(0.0, 1.0));
+        measure_step_response(
+            &series,
+            &series,
+            StepSpec {
+                input_time_s: 0.0,
+                initial_value: 0.0,
+                target_value: 1.0,
+            },
+        )
+        .expect("valid analytic trace")
+    };
+    let slow = run(10);
+    let fast = run(100);
+
+    assert_close(
+        slow.input_to_response_delay_s.expect("slow delay"),
+        fast.input_to_response_delay_s.expect("fast delay"),
+    );
+    assert_close(
+        slow.rise_time_s.expect("slow rise"),
+        fast.rise_time_s.expect("fast rise"),
+    );
+    assert_close(
+        slow.settling_time_s.expect("slow settle"),
+        fast.settling_time_s.expect("fast settle"),
+    );
+    assert_close(
+        slow.integrated_absolute_error,
+        fast.integrated_absolute_error,
+    );
+}
+
+#[test]
+fn a_non_finite_trace_fails_with_sample_context() {
+    let bad = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::NAN,
+        },
+    ];
+    let error = measure_step_response(
+        &bad,
+        &bad,
+        StepSpec {
+            input_time_s: 0.0,
+            initial_value: 0.0,
+            target_value: 1.0,
+        },
+    )
+    .expect_err("non-finite value");
+
+    assert_eq!(
+        error,
+        MetricError::NonFiniteValue {
+            index: 1,
+            field: "value",
+        }
+    );
+}
+
+#[test]
+fn response_result_json_is_byte_stable() {
+    let metrics = super::ResponseMetrics {
+        input_to_command_delay_s: Some(0.1),
+        input_to_response_delay_s: Some(0.2),
+        rise_time_s: Some(0.3),
+        settling_time_s: None,
+        overshoot: 0.4,
+        overshoot_fraction: 0.5,
+        undershoot: 0.6,
+        steady_state_error: -0.1,
+        integrated_absolute_error: 0.7,
+    };
+    let bytes = serde_json::to_vec(&metrics).expect("serialize response metrics");
+
+    assert_eq!(
+        bytes,
+        br#"{"input_to_command_delay_s":0.1,"input_to_response_delay_s":0.2,"rise_time_s":0.3,"settling_time_s":null,"overshoot":0.4,"overshoot_fraction":0.5,"undershoot":0.6,"steady_state_error":-0.1,"integrated_absolute_error":0.7}"#
+    );
+    let decoded: super::ResponseMetrics =
+        serde_json::from_slice(&bytes).expect("deserialize response metrics");
+    assert_eq!(decoded, metrics);
+}
+
+#[test]
+fn a_non_finite_derived_response_metric_is_a_typed_error() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+
+    assert!(matches!(
+        measure_step_response(
+            &samples,
+            &samples,
+            StepSpec {
+                input_time_s: 0.0,
+                initial_value: f64::MAX,
+                target_value: -f64::MAX,
+            },
+        ),
+        Err(MetricError::NonFiniteResult { .. })
+    ));
+}

--- a/crates/pilotage-flight-quality/src/sample.rs
+++ b/crates/pilotage-flight-quality/src/sample.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+/// One scalar value at one trial time.
+///
+/// The caller supplies seconds and the documented unit for the metric. The
+/// caller must project vector data onto one axis before it builds this value.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimedValue {
+    /// Trial time, in seconds.
+    pub time_s: f64,
+    /// The scalar value.
+    pub value: f64,
+}
+
+/// One position and velocity point for a release metric.
+///
+/// Position is in meters. Velocity is in meters per second. Both values use
+/// the same selected axis.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MotionPoint {
+    /// Trial time, in seconds.
+    pub time_s: f64,
+    /// Position on the selected axis, in meters.
+    pub position_m: f64,
+    /// Velocity on the selected axis, in meters per second.
+    pub velocity_mps: f64,
+}
+
+/// One actuator-demand point for a control metric.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPoint {
+    /// Trial time, in seconds.
+    pub time_s: f64,
+    /// Normalized control demand.
+    pub effort: f64,
+    /// Whether an actuator limit is active.
+    pub saturated: bool,
+}

--- a/crates/pilotage-flight-quality/src/series.rs
+++ b/crates/pilotage-flight-quality/src/series.rs
@@ -1,0 +1,212 @@
+use crate::{MetricError, TimedValue};
+
+pub(crate) fn validate_times<T>(
+    samples: &[T],
+    time: impl Fn(&T) -> f64,
+) -> Result<(), MetricError> {
+    if samples.len() < 2 {
+        return Err(MetricError::TooFewSamples {
+            needed: 2,
+            actual: samples.len(),
+        });
+    }
+    let mut previous = time(&samples[0]);
+    if !previous.is_finite() {
+        return Err(MetricError::NonFiniteTime { index: 0 });
+    }
+    for (index, sample) in samples.iter().enumerate().skip(1) {
+        let current = time(sample);
+        if !current.is_finite() {
+            return Err(MetricError::NonFiniteTime { index });
+        }
+        if current <= previous {
+            return Err(MetricError::NonMonotonicTime {
+                index,
+                previous_s: previous,
+                current_s: current,
+            });
+        }
+        previous = current;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_values<T>(
+    samples: &[T],
+    field: &'static str,
+    value: impl Fn(&T) -> f64,
+) -> Result<(), MetricError> {
+    for (index, sample) in samples.iter().enumerate() {
+        if !value(sample).is_finite() {
+            return Err(MetricError::NonFiniteValue { index, field });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_timed_values(samples: &[TimedValue]) -> Result<(), MetricError> {
+    validate_times(samples, |sample| sample.time_s)?;
+    validate_values(samples, "value", |sample| sample.value)
+}
+
+pub(crate) fn validate_metric_results(results: &[(&'static str, f64)]) -> Result<(), MetricError> {
+    for &(field, value) in results {
+        if !value.is_finite() {
+            return Err(MetricError::NonFiniteResult { field });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_optional_metric_results(
+    results: &[(&'static str, Option<f64>)],
+) -> Result<(), MetricError> {
+    for &(field, value) in results {
+        if value.is_some_and(|value| !value.is_finite()) {
+            return Err(MetricError::NonFiniteResult { field });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_event<T>(
+    samples: &[T],
+    field: &'static str,
+    time_s: f64,
+    time: impl Fn(&T) -> f64,
+) -> Result<(), MetricError> {
+    if !time_s.is_finite()
+        || time_s < time(&samples[0])
+        || time_s > time(&samples[samples.len() - 1])
+    {
+        return Err(MetricError::EventOutsideSeries { field, time_s });
+    }
+    Ok(())
+}
+
+pub(crate) fn linear_value_at<T>(
+    samples: &[T],
+    at_s: f64,
+    time: impl Fn(&T) -> f64,
+    value: impl Fn(&T) -> f64,
+) -> f64 {
+    match samples.binary_search_by(|sample| time(sample).total_cmp(&at_s)) {
+        Ok(index) => value(&samples[index]),
+        Err(index) => {
+            let before = &samples[index - 1];
+            let after = &samples[index];
+            interpolate(time(before), value(before), time(after), value(after), at_s)
+        }
+    }
+}
+
+pub(crate) fn interpolate(t0: f64, v0: f64, t1: f64, v1: f64, at_s: f64) -> f64 {
+    let fraction = (at_s - t0) / (t1 - t0);
+    v0 + fraction * (v1 - v0)
+}
+
+pub(crate) fn timed_window(samples: &[TimedValue], start_s: f64, end_s: f64) -> Vec<TimedValue> {
+    let mut window = Vec::with_capacity(samples.len() + 2);
+    window.push(TimedValue {
+        time_s: start_s,
+        value: linear_value_at(
+            samples,
+            start_s,
+            |sample| sample.time_s,
+            |sample| sample.value,
+        ),
+    });
+    window.extend(
+        samples
+            .iter()
+            .copied()
+            .filter(|sample| sample.time_s > start_s && sample.time_s < end_s),
+    );
+    if end_s > start_s {
+        window.push(TimedValue {
+            time_s: end_s,
+            value: linear_value_at(
+                samples,
+                end_s,
+                |sample| sample.time_s,
+                |sample| sample.value,
+            ),
+        });
+    }
+    window
+}
+
+pub(crate) fn integral_square_linear(v0: f64, v1: f64, duration_s: f64) -> f64 {
+    duration_s * (v0 * v0 + v0 * v1 + v1 * v1) / 3.0
+}
+
+pub(crate) fn integral_abs_linear(v0: f64, v1: f64, duration_s: f64) -> f64 {
+    if v0 * v1 >= 0.0 {
+        return duration_s * (v0.abs() + v1.abs()) / 2.0;
+    }
+    let total = v0.abs() + v1.abs();
+    let first_fraction = v0.abs() / total;
+    duration_s * (v0.abs() * first_fraction + v1.abs() * (1.0 - first_fraction)) / 2.0
+}
+
+pub(crate) fn weighted_percentile(values: &mut [(f64, f64)], quantile: f64) -> f64 {
+    values.sort_by(|left, right| left.0.total_cmp(&right.0));
+    let total_weight: f64 = values.iter().map(|entry| entry.1).sum();
+    let threshold = total_weight * quantile;
+    let mut cumulative = 0.0;
+    for &(value, weight) in values.iter() {
+        cumulative += weight;
+        if cumulative >= threshold {
+            return value;
+        }
+    }
+    values.last().map_or(0.0, |entry| entry.0)
+}
+
+pub(crate) fn weighted_abs_percentile_linear(samples: &[TimedValue], quantile: f64) -> f64 {
+    let duration_s = samples[samples.len() - 1].time_s - samples[0].time_s;
+    let target_duration_s = duration_s * quantile;
+    let upper = samples
+        .iter()
+        .map(|sample| sample.value.abs())
+        .fold(0.0_f64, f64::max);
+    let mut lower_bits = 0_u64;
+    let mut upper_bits = upper.to_bits();
+    while lower_bits < upper_bits {
+        let candidate_bits = lower_bits + (upper_bits - lower_bits) / 2;
+        let candidate = f64::from_bits(candidate_bits);
+        if duration_at_or_below(samples, candidate) >= target_duration_s {
+            upper_bits = candidate_bits;
+        } else {
+            lower_bits = candidate_bits + 1;
+        }
+    }
+    f64::from_bits(lower_bits)
+}
+
+fn duration_at_or_below(samples: &[TimedValue], threshold: f64) -> f64 {
+    samples
+        .windows(2)
+        .map(|pair| segment_duration_at_or_below(pair[0], pair[1], threshold))
+        .sum()
+}
+
+fn segment_duration_at_or_below(start: TimedValue, end: TimedValue, threshold: f64) -> f64 {
+    let duration_s = end.time_s - start.time_s;
+    let delta = end.value - start.value;
+    if delta == 0.0 {
+        return if start.value.abs() <= threshold {
+            duration_s
+        } else {
+            0.0
+        };
+    }
+    let negative_crossing = (-threshold - start.value) / delta;
+    let positive_crossing = (threshold - start.value) / delta;
+    let first = negative_crossing.min(positive_crossing).clamp(0.0, 1.0);
+    let last = negative_crossing.max(positive_crossing).clamp(0.0, 1.0);
+    (last - first) * duration_s
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/series.rs
+++ b/crates/pilotage-flight-quality/src/series.rs
@@ -90,7 +90,14 @@ pub(crate) fn linear_value_at<T>(
     time: impl Fn(&T) -> f64,
     value: impl Fn(&T) -> f64,
 ) -> f64 {
-    match samples.binary_search_by(|sample| time(sample).total_cmp(&at_s)) {
+    match samples.binary_search_by(|sample| {
+        let sample_time = time(sample);
+        if sample_time == at_s {
+            std::cmp::Ordering::Equal
+        } else {
+            sample_time.total_cmp(&at_s)
+        }
+    }) {
         Ok(index) => value(&samples[index]),
         Err(index) => {
             let before = &samples[index - 1];

--- a/crates/pilotage-flight-quality/src/series/tests.rs
+++ b/crates/pilotage-flight-quality/src/series/tests.rs
@@ -1,6 +1,8 @@
 use crate::{MetricError, TimedValue};
 
-use super::{integral_abs_linear, validate_timed_values, weighted_abs_percentile_linear};
+use super::{
+    integral_abs_linear, linear_value_at, validate_timed_values, weighted_abs_percentile_linear,
+};
 
 #[test]
 fn non_monotonic_time_has_typed_context() {
@@ -59,4 +61,23 @@ fn absolute_percentile_preserves_a_zero_duration_atom() {
     ];
 
     assert_eq!(weighted_abs_percentile_linear(&samples, 0.95), 0.0);
+}
+
+#[test]
+fn linear_lookup_treats_signed_zero_as_one_series_endpoint() {
+    let samples = [
+        TimedValue {
+            time_s: -1.0,
+            value: 1.0,
+        },
+        TimedValue {
+            time_s: -0.0,
+            value: 2.0,
+        },
+    ];
+
+    assert_eq!(
+        linear_value_at(&samples, 0.0, |sample| sample.time_s, |sample| sample.value,),
+        2.0
+    );
 }

--- a/crates/pilotage-flight-quality/src/series/tests.rs
+++ b/crates/pilotage-flight-quality/src/series/tests.rs
@@ -1,0 +1,62 @@
+use crate::{MetricError, TimedValue};
+
+use super::{integral_abs_linear, validate_timed_values, weighted_abs_percentile_linear};
+
+#[test]
+fn non_monotonic_time_has_typed_context() {
+    let samples = [
+        TimedValue {
+            time_s: 1.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1.0,
+        },
+    ];
+    assert!(matches!(
+        validate_timed_values(&samples),
+        Err(MetricError::NonMonotonicTime { index: 1, .. })
+    ));
+}
+
+#[test]
+fn absolute_integral_splits_a_zero_crossing() {
+    assert!((integral_abs_linear(-1.0, 1.0, 2.0) - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn linear_absolute_percentile_uses_segment_duration() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 2.0,
+            value: 2.0,
+        },
+    ];
+    let percentile = weighted_abs_percentile_linear(&samples, 0.95);
+    assert!((percentile - 1.9).abs() < 1e-12);
+}
+
+#[test]
+fn absolute_percentile_preserves_a_zero_duration_atom() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 0.95,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1e100,
+        },
+    ];
+
+    assert_eq!(weighted_abs_percentile_linear(&samples, 0.95), 0.0);
+}

--- a/crates/pilotage-flight-quality/src/signal.rs
+++ b/crates/pilotage-flight-quality/src/signal.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+
+use crate::series::{
+    integral_square_linear, validate_metric_results, validate_timed_values,
+    weighted_abs_percentile_linear, weighted_percentile,
+};
+use crate::{MetricError, TimedValue};
+
+/// Time-weighted statistics for one scalar signal.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignalStats {
+    /// The root mean square value in the signal unit.
+    pub rms: f64,
+    /// The duration-weighted 95th percentile of absolute value.
+    pub p95_abs: f64,
+    /// The largest absolute value.
+    pub peak_abs: f64,
+}
+
+/// Acceleration and jerk metrics for one selected axis.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JerkMetrics {
+    /// The largest absolute acceleration, in meters per second squared.
+    pub peak_acceleration_mps2: f64,
+    /// The largest absolute jerk, in meters per second cubed.
+    pub peak_jerk_mps3: f64,
+    /// The duration-weighted 95th percentile of absolute jerk.
+    pub jerk_p95_mps3: f64,
+    /// The root mean square jerk, in meters per second cubed.
+    pub jerk_rms_mps3: f64,
+    /// The integral of absolute jerk, in meters per second squared.
+    pub integrated_abs_jerk_mps2: f64,
+}
+
+/// Calculates RMS, P95 absolute value, and peak absolute value.
+///
+/// RMS uses the exact square integral for each linear sample segment. P95
+/// uses the time distribution of the absolute piecewise-linear signal.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when the series is invalid.
+pub fn measure_signal(samples: &[TimedValue]) -> Result<SignalStats, MetricError> {
+    validate_timed_values(samples)?;
+    let duration_s = samples[samples.len() - 1].time_s - samples[0].time_s;
+    let mut square_integral = 0.0;
+    let mut peak = 0.0_f64;
+    for pair in samples.windows(2) {
+        let dt = pair[1].time_s - pair[0].time_s;
+        square_integral += integral_square_linear(pair[0].value, pair[1].value, dt);
+        peak = peak.max(pair[0].value.abs()).max(pair[1].value.abs());
+    }
+    let metrics = SignalStats {
+        rms: (square_integral / duration_s).sqrt(),
+        p95_abs: weighted_abs_percentile_linear(samples, 0.95),
+        peak_abs: peak,
+    };
+    validate_metric_results(&[
+        ("signal.rms", metrics.rms),
+        ("signal.p95_abs", metrics.p95_abs),
+        ("signal.peak_abs", metrics.peak_abs),
+    ])?;
+    Ok(metrics)
+}
+
+/// Calculates acceleration and jerk metrics.
+///
+/// The function treats acceleration as linear between samples. Jerk is the
+/// constant slope on each sample interval. The function does not filter data.
+///
+/// # Errors
+///
+/// Returns [`MetricError`] when the acceleration series is invalid.
+pub fn measure_jerk(acceleration: &[TimedValue]) -> Result<JerkMetrics, MetricError> {
+    validate_timed_values(acceleration)?;
+    let duration_s = acceleration[acceleration.len() - 1].time_s - acceleration[0].time_s;
+    let mut peak_acceleration = 0.0_f64;
+    let mut peak_jerk = 0.0_f64;
+    let mut jerk_square_integral = 0.0;
+    let mut integrated_abs_jerk = 0.0;
+    let mut weighted_jerk = Vec::with_capacity(acceleration.len() - 1);
+    for pair in acceleration.windows(2) {
+        let dt = pair[1].time_s - pair[0].time_s;
+        let jerk = (pair[1].value - pair[0].value) / dt;
+        peak_acceleration = peak_acceleration
+            .max(pair[0].value.abs())
+            .max(pair[1].value.abs());
+        peak_jerk = peak_jerk.max(jerk.abs());
+        jerk_square_integral += jerk * jerk * dt;
+        integrated_abs_jerk += jerk.abs() * dt;
+        weighted_jerk.push((jerk.abs(), dt));
+    }
+    let metrics = JerkMetrics {
+        peak_acceleration_mps2: peak_acceleration,
+        peak_jerk_mps3: peak_jerk,
+        jerk_p95_mps3: weighted_percentile(&mut weighted_jerk, 0.95),
+        jerk_rms_mps3: (jerk_square_integral / duration_s).sqrt(),
+        integrated_abs_jerk_mps2: integrated_abs_jerk,
+    };
+    validate_metric_results(&[
+        (
+            "jerk.peak_acceleration_mps2",
+            metrics.peak_acceleration_mps2,
+        ),
+        ("jerk.peak_jerk_mps3", metrics.peak_jerk_mps3),
+        ("jerk.jerk_p95_mps3", metrics.jerk_p95_mps3),
+        ("jerk.jerk_rms_mps3", metrics.jerk_rms_mps3),
+        (
+            "jerk.integrated_abs_jerk_mps2",
+            metrics.integrated_abs_jerk_mps2,
+        ),
+    ])?;
+    Ok(metrics)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/crates/pilotage-flight-quality/src/signal/tests.rs
+++ b/crates/pilotage-flight-quality/src/signal/tests.rs
@@ -1,0 +1,109 @@
+use super::{measure_jerk, measure_signal};
+use crate::test_trace::sample_value;
+use crate::{MetricError, TimedValue};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-10, "{actual} != {expected}");
+}
+
+#[test]
+fn a_constant_signal_has_exact_rms_p95_and_peak() {
+    let samples = sample_value(20, 2.0, |_| -2.0);
+    let metrics = measure_signal(&samples).expect("valid constant trace");
+
+    assert_close(metrics.rms, 2.0);
+    assert_close(metrics.p95_abs, 2.0);
+    assert_close(metrics.peak_abs, 2.0);
+}
+
+#[test]
+fn an_acceleration_ramp_has_exact_jerk_metrics() {
+    let acceleration = sample_value(10, 2.0, |time| time);
+    let metrics = measure_jerk(&acceleration).expect("valid acceleration trace");
+
+    assert_close(metrics.peak_acceleration_mps2, 2.0);
+    assert_close(metrics.peak_jerk_mps3, 1.0);
+    assert_close(metrics.jerk_p95_mps3, 1.0);
+    assert_close(metrics.jerk_rms_mps3, 1.0);
+    assert_close(metrics.integrated_abs_jerk_mps2, 2.0);
+}
+
+#[test]
+fn a_linear_jerk_metric_is_independent_of_input_sample_rate() {
+    let slow = measure_jerk(&sample_value(10, 3.0, |time| 2.0 * time)).expect("valid slow trace");
+    let fast = measure_jerk(&sample_value(100, 3.0, |time| 2.0 * time)).expect("valid fast trace");
+
+    assert_close(slow.peak_jerk_mps3, fast.peak_jerk_mps3);
+    assert_close(slow.jerk_rms_mps3, fast.jerk_rms_mps3);
+    assert_close(slow.integrated_abs_jerk_mps2, fast.integrated_abs_jerk_mps2);
+}
+
+#[test]
+fn a_linear_signal_percentile_is_independent_of_input_sample_rate() {
+    let slow = measure_signal(&sample_value(10, 2.0, |time| time)).expect("valid slow trace");
+    let fast = measure_signal(&sample_value(100, 2.0, |time| time)).expect("valid fast trace");
+
+    assert_close(slow.p95_abs, 1.9);
+    assert_close(slow.p95_abs, fast.p95_abs);
+}
+
+#[test]
+fn a_zero_duration_atom_has_an_exact_zero_p95() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 0.95,
+            value: 0.0,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: 1e100,
+        },
+    ];
+    let metrics = measure_signal(&samples).expect("finite large-dynamic-range signal");
+
+    assert_eq!(metrics.p95_abs, 0.0);
+}
+
+#[test]
+fn a_non_finite_derived_signal_metric_is_a_typed_error() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: f64::MAX,
+        },
+    ];
+
+    assert_eq!(
+        measure_signal(&samples),
+        Err(MetricError::NonFiniteResult {
+            field: "signal.rms",
+        })
+    );
+}
+
+#[test]
+fn a_non_finite_derived_jerk_metric_is_a_typed_error() {
+    let samples = [
+        TimedValue {
+            time_s: 0.0,
+            value: f64::MAX,
+        },
+        TimedValue {
+            time_s: 1.0,
+            value: -f64::MAX,
+        },
+    ];
+
+    assert!(matches!(
+        measure_jerk(&samples),
+        Err(MetricError::NonFiniteResult { .. })
+    ));
+}

--- a/crates/pilotage-flight-quality/src/test_trace.rs
+++ b/crates/pilotage-flight-quality/src/test_trace.rs
@@ -1,0 +1,18 @@
+use crate::TimedValue;
+
+pub(crate) fn sample_value(
+    rate_hz: u32,
+    duration_s: f64,
+    value: impl Fn(f64) -> f64,
+) -> Vec<TimedValue> {
+    let count = (duration_s * f64::from(rate_hz)).round() as u32;
+    (0..=count)
+        .map(|index| {
+            let time_s = f64::from(index) / f64::from(rate_hz);
+            TimedValue {
+                time_s,
+                value: value(time_s),
+            }
+        })
+        .collect()
+}

--- a/scripts/monotonic-counter-compound-addition-allowlist.tsv
+++ b/scripts/monotonic-counter-compound-addition-allowlist.tsv
@@ -7,6 +7,14 @@ crates/pilotage-camera-calibration/src/calibration/recovery.rs	sum_sq += err * e
 crates/pilotage-control-feel/src/shaper.rs	self.neutral_s += dt_s;
 crates/pilotage-control-feel/src/shaper.rs	self.rate += rate_delta;
 crates/pilotage-control-feel/src/shaper.rs	self.stable_s += dt_s;
+crates/pilotage-flight-quality/src/control.rs	absolute_integral += integral_abs_linear(pair[0].effort, pair[1].effort, dt);
+crates/pilotage-flight-quality/src/control.rs	active_saturation_s += dt;
+crates/pilotage-flight-quality/src/control.rs	saturated_s += dt;
+crates/pilotage-flight-quality/src/control.rs	square_integral += integral_square_linear(pair[0].effort, pair[1].effort, dt);
+crates/pilotage-flight-quality/src/series.rs	cumulative += weight;
+crates/pilotage-flight-quality/src/signal.rs	integrated_abs_jerk += jerk.abs() * dt;
+crates/pilotage-flight-quality/src/signal.rs	jerk_square_integral += jerk * jerk * dt;
+crates/pilotage-flight-quality/src/signal.rs	square_integral += integral_square_linear(pair[0].value, pair[1].value, dt);
 crates/pilotage-geo/src/abi/codec.rs	self.off += b.len();
 crates/pilotage-input/src/button_tracker.rs	ButtonEdge::Pressed => presses += 1,
 crates/pilotage-input/src/button_tracker.rs	ButtonEdge::Released => releases += 1,


### PR DESCRIPTION
## Summary

- Add a simulator-neutral flight-quality metric library.
- Keep hard trial gates separate from continuous metrics.
- Calculate deterministic response, release, hold, control, signal, and jerk metrics.
- Reject incomplete hard-gate reports and non-finite source or calculated values.
- Treat `-0.0` and `+0.0` as the same event time at a series boundary.
- Add stable serde forms and analytic regression tests.

## Scope

This PR is a reviewed foundation slice of #449. It does not close #449.

The remaining #449 work includes missing-data rules, entry and exit discontinuity, mode-transfer, estimate-to-truth, wind-recovery metrics, complete score serialization, and saved-trial recomputation.

#447 owns complete phase and run evidence. #451 owns search, aggregation, journal, and promotion. #467 owns scoped physical targets, campaign crash-floor validation, matrix coverage, and independent qualification. This PR does not implement those contracts.

The response metric uses final entry into the settling band. A later qualification contract must require sufficient observation after that entry before it uses the value.

## Verification

Exact head: c0cba4e155a4f3eba7c9f00cc20a8c5af89c8266

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS='-D missing_docs -D rustdoc::broken_intra_doc_links' cargo doc --no-deps`
- `cargo build --release`
- Production Rust lint self-test and guard.
- Monotonic counter self-test and guard.
- Aviate control-feel boundary self-test and guard.
- X-Plane weather state, clear protocol, and reset-order guards.
- Flight build guard.
- Structure self-test and guard.
- Indicate compatibility identity guard.

SIM / NOT FOR FLIGHT.
