### PR TITLE
Enforce flight tuning simulator boundaries (#497)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: flight build carries no simulation-only code
         run: bash scripts/check-flight-build.sh
 
+      - name: flight tuning boundary guard self-test
+        run: bash scripts/test-check-flight-tune-boundaries.sh
+
+      - name: flight tuning boundary guard
+        run: bash scripts/check-flight-tune-boundaries.sh
+
       - name: check-structure self-test
         run: bash scripts/test-check-structure.sh
 

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Prevent simulator adapter details from entering shared tuning contracts.
+set -euo pipefail
+
+default_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root="${1:-$default_root}"
+root="$(cd "$root" && pwd)"
+allowlist_is_override=0
+if [ "$#" -ge 2 ]; then
+    allowlist="$2"
+    allowlist_is_override=1
+else
+    allowlist="$root/scripts/flight-tune-xplane-import-allowlist.tsv"
+fi
+work="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-flight-tune-boundary.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+status=0
+
+report() {
+    echo "FORBIDDEN: $1" >&2
+    status=1
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "check-flight-tune-boundaries: required command $1 is not available" >&2
+        exit 1
+    fi
+}
+
+relative_path() {
+    printf '%s\n' "${1#"$root"/}"
+}
+
+is_production_rust_path() {
+    case "$1" in
+        */test_support.rs|*/test_support/*|*/tests.rs|*/tests/*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+collect_production_files() {
+    local directory file list_id list_path list_status
+    list_id=0
+    for directory in "$@"; do
+        [ -d "$directory" ] || continue
+        list_id=$((list_id + 1))
+        list_path="$work/source-list-$list_id"
+        list_status=0
+        rg --files "$directory" -g '*.rs' > "$list_path" || list_status=$?
+        if [ "$list_status" -gt 1 ]; then
+            report "cannot list Rust source files below $(relative_path "$directory")"
+            continue
+        fi
+        while IFS= read -r file; do
+            if is_production_rust_path "$file"; then
+                printf '%s\n' "$file"
+            fi
+        done < "$list_path"
+    done
+}
+
+collect_file_imports() {
+    local file="$1" relative="$2" matches="$3" match_status
+    if ! awk -v path="$relative" '
+        BEGIN { collecting = 0; statement = "" }
+        /^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?use[[:space:]]+(::)?flight_tune_xplane(::|[[:space:]]|;)/ {
+            collecting = 1
+        }
+        collecting {
+            statement = statement $0
+            if ($0 ~ /;/) {
+                gsub(/[[:space:]]/, "", statement)
+                print path "\t" statement
+                collecting = 0
+                statement = ""
+            }
+        }
+        END { if (collecting) exit 2 }
+    ' "$file" >> "$work/aviate-imports"; then
+        report "$relative has an incomplete flight_tune_xplane import"
+    fi
+
+    match_status=0
+    rg -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
+    if [ "$match_status" -gt 1 ]; then
+        report "$relative cannot be scanned for flight_tune_xplane references"
+        return
+    fi
+    while IFS=: read -r line_number source; do
+        [ -n "$line_number" ] || continue
+        if ! grep -Eq '^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?use[[:space:]]+(::)?flight_tune_xplane(::|[[:space:]]|;)' <<<"$source"; then
+            report "$relative:$line_number uses flight_tune_xplane outside a reviewed import"
+        fi
+    done < "$matches"
+}
+
+collect_aviate_imports() {
+    local file relative scan_id
+    collect_production_files "$root/tools/flight-tune-aviate/src" > "$work/aviate-files-unsorted"
+    LC_ALL=C sort -u "$work/aviate-files-unsorted" > "$work/aviate-files"
+    : > "$work/aviate-imports"
+    scan_id=0
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        scan_id=$((scan_id + 1))
+        relative="$(relative_path "$file")"
+        collect_file_imports "$file" "$relative" "$work/import-matches-$scan_id"
+    done < "$work/aviate-files"
+    LC_ALL=C sort -u "$work/aviate-imports" -o "$work/aviate-imports"
+}
+
+check_aviate_imports() {
+    collect_aviate_imports
+    if [ ! -f "$allowlist" ]; then
+        report "the flight_tune_xplane import allowlist is missing"
+        : > "$work/allowed-imports"
+    else
+        awk 'NF > 0 && $1 !~ /^#/ { print }' "$allowlist" \
+            | LC_ALL=C sort -u > "$work/allowed-imports"
+        if [ "$allowlist_is_override" -eq 0 ] && [ -s "$work/allowed-imports" ]; then
+            report "the production flight_tune_xplane import allowlist must stay empty"
+        fi
+    fi
+    if ! comm -23 "$work/aviate-imports" "$work/allowed-imports" \
+        > "$work/new-imports"; then
+        report "cannot compare flight_tune_xplane imports with the allowlist"
+        return
+    fi
+    while IFS= read -r import; do
+        [ -n "$import" ] && report "new flight_tune_xplane import: $import"
+    done < "$work/new-imports"
+}
+
+check_shared_contracts() {
+    if ! python3 "$default_root/scripts/check-flight-tune-contracts.py" "$root"; then
+        status=1
+    fi
+}
+
+require_command rg
+require_command cargo
+require_command python3
+require_command comm
+check_aviate_imports
+check_shared_contracts
+
+if [ "$status" -ne 0 ]; then
+    echo "check-flight-tune-boundaries: FAILED" >&2
+    exit 1
+fi
+
+echo "check-flight-tune-boundaries: OK"

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -48,8 +48,9 @@ collect_production_files() {
         list_id=$((list_id + 1))
         list_path="$work/source-list-$list_id"
         list_status=0
-        rg --files "$directory" -g '*.rs' > "$list_path" || list_status=$?
-        if [ "$list_status" -gt 1 ]; then
+        find "$directory" -type f -name '*.rs' -print > "$list_path" \
+            || list_status=$?
+        if [ "$list_status" -ne 0 ]; then
             report "cannot list Rust source files below $(relative_path "$directory")"
             continue
         fi
@@ -83,7 +84,7 @@ collect_file_imports() {
     fi
 
     match_status=0
-    rg -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
+    grep -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
     if [ "$match_status" -gt 1 ]; then
         report "$relative cannot be scanned for flight_tune_xplane references"
         return
@@ -139,7 +140,8 @@ check_shared_contracts() {
     fi
 }
 
-require_command rg
+require_command find
+require_command grep
 require_command cargo
 require_command python3
 require_command comm

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Check simulator-neutral tuning manifests and Rust contract identifiers."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+FORBIDDEN_PACKAGES = {"flight-tune-xplane", "pilotage-xplane-trial"}
+FORBIDDEN_IDENTIFIERS = (
+    "xplane",
+    "acf",
+    "aircraftfile",
+    "trialplugin",
+    "bridgeplugin",
+    "weatherplugin",
+    "hostapplicationid",
+    "sdkversion",
+)
+CAMPAIGN_SHARED_TYPES = {
+    "CampaignBudgetLimit",
+    "ExecutionTarget",
+    "CampaignPurpose",
+    "PinnedFile",
+    "SearchGroupConfig",
+    "SearchGroupKind",
+    "CampaignConfig",
+    "TrainingGuardScenarioConfig",
+    "TrainingSuiteConfig",
+}
+CAMPAIGN_ADAPTER_TYPES = {
+    "XPlaneCampaignConfig",
+    "XPlaneSupportBundleConfig",
+    "XPlaneRuntimePluginConfig",
+    "AviateCampaignConfig",
+}
+IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class ParseError(Exception):
+    """A Rust source file cannot be tokenized or divided into type bodies."""
+
+
+def report(message: str) -> None:
+    """Write one stable guard diagnostic."""
+    print(f"FORBIDDEN: {message}", file=sys.stderr)
+
+
+def normalized(identifier: str) -> str:
+    """Return the comparison form for one Rust identifier."""
+    return identifier.lower().replace("_", "").replace("-", "")
+
+
+def is_forbidden_identifier(identifier: str) -> bool:
+    """Test one identifier against all simulator-specific name fragments."""
+    value = normalized(identifier)
+    return any(fragment in value for fragment in FORBIDDEN_IDENTIFIERS)
+
+
+def check_manifest(manifest: Path, root: Path) -> bool:
+    """Use Cargo's resolved dependency view for one neutral package."""
+    if not manifest.is_file():
+        return True
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--manifest-path",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    relative = manifest.relative_to(root)
+    if result.returncode != 0:
+        detail = result.stderr.strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        report(f"{relative} cargo metadata failed{suffix}")
+        return False
+    try:
+        metadata = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        report(f"{relative} cargo metadata is not valid JSON: {error}")
+        return False
+
+    resolved = manifest.resolve()
+    package = next(
+        (
+            item
+            for item in metadata.get("packages", [])
+            if Path(item.get("manifest_path", "")).resolve() == resolved
+        ),
+        None,
+    )
+    if package is None:
+        report(f"{relative} is absent from cargo metadata")
+        return False
+
+    valid = True
+    for dependency in package.get("dependencies", []):
+        if (
+            dependency.get("kind") != "dev"
+            and dependency.get("name") in FORBIDDEN_PACKAGES
+        ):
+            report(f"{relative} has runtime dependency {dependency['name']}")
+            valid = False
+    return valid
+
+
+def raw_string_end(source: str, start: int) -> int | None:
+    """Return the end of a Rust raw string that starts at one byte offset."""
+    prefix_length = 0
+    if source.startswith("br", start):
+        prefix_length = 2
+    elif source.startswith("r", start):
+        prefix_length = 1
+    else:
+        return None
+    cursor = start + prefix_length
+    hashes = 0
+    while cursor < len(source) and source[cursor] == "#":
+        hashes += 1
+        cursor += 1
+    if cursor >= len(source) or source[cursor] != '"':
+        return None
+    terminator = '"' + ("#" * hashes)
+    end = source.find(terminator, cursor + 1)
+    if end < 0:
+        raise ParseError("an unterminated raw string")
+    return end + len(terminator)
+
+
+def quoted_end(source: str, start: int, quote: str) -> int:
+    """Return the end of one escaped Rust string."""
+    cursor = start + 1
+    while cursor < len(source):
+        if source[cursor] == "\\":
+            cursor += 2
+            continue
+        if source[cursor] == quote:
+            return cursor + 1
+        cursor += 1
+    raise ParseError("an unterminated string")
+
+
+def character_end(source: str, start: int) -> int | None:
+    """Return the end of one Rust character literal, but not a lifetime."""
+    cursor = start + 1
+    if cursor >= len(source) or source[cursor] == "\n":
+        return None
+    if source[cursor] == "\\":
+        cursor += 1
+        while cursor < len(source) and source[cursor] not in {"'", "\n"}:
+            cursor += 1
+    else:
+        cursor += 1
+    if cursor < len(source) and source[cursor] == "'":
+        return cursor + 1
+    return None
+
+
+def rust_tokens(source: str) -> list[str]:
+    """Return Rust identifier and punctuation tokens without comments or literals."""
+    tokens: list[str] = []
+    cursor = 0
+    while cursor < len(source):
+        if source[cursor].isspace():
+            cursor += 1
+            continue
+        if source.startswith("//", cursor):
+            end = source.find("\n", cursor + 2)
+            cursor = len(source) if end < 0 else end + 1
+            continue
+        if source.startswith("/*", cursor):
+            depth = 1
+            cursor += 2
+            while cursor < len(source) and depth > 0:
+                if source.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif source.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            if depth != 0:
+                raise ParseError("an unterminated block comment")
+            continue
+        raw_end = raw_string_end(source, cursor)
+        if raw_end is not None:
+            cursor = raw_end
+            continue
+        if source[cursor] == '"':
+            cursor = quoted_end(source, cursor, '"')
+            continue
+        if source[cursor] == "'":
+            character_literal_end = character_end(source, cursor)
+            if character_literal_end is not None:
+                cursor = character_literal_end
+                continue
+        raw_identifier = re.match(r"r#([A-Za-z_][A-Za-z0-9_]*)", source[cursor:])
+        if raw_identifier is not None:
+            tokens.append(raw_identifier.group(1))
+            cursor += len(raw_identifier.group(0))
+            continue
+        identifier = re.match(r"[A-Za-z_][A-Za-z0-9_]*", source[cursor:])
+        if identifier is not None:
+            tokens.append(identifier.group(0))
+            cursor += len(identifier.group(0))
+            continue
+        tokens.append(source[cursor])
+        cursor += 1
+    return tokens
+
+
+def group_end(tokens: list[str], start: int, opening: str, closing: str) -> int:
+    """Return the token after one balanced group."""
+    depth = 0
+    for index in range(start, len(tokens)):
+        if tokens[index] == opening:
+            depth += 1
+        elif tokens[index] == closing:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    raise ParseError(f"an unclosed {opening}{closing} group")
+
+
+def type_body_start(tokens: list[str], start: int) -> int | None:
+    """Find a named struct or enum body after its type name."""
+    paren_depth = 0
+    bracket_depth = 0
+    angle_depth = 0
+    for index in range(start, len(tokens)):
+        token = tokens[index]
+        if token == "(":
+            paren_depth += 1
+        elif token == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif token == "[":
+            bracket_depth += 1
+        elif token == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+        elif token == "<":
+            angle_depth += 1
+        elif token == ">":
+            angle_depth = max(0, angle_depth - 1)
+        elif token == "{" and paren_depth == bracket_depth == angle_depth == 0:
+            return index
+        elif token == ";" and paren_depth == bracket_depth == angle_depth == 0:
+            return None
+    raise ParseError("a type declaration has no body terminator")
+
+
+def top_level_segments(tokens: list[str]) -> list[list[str]]:
+    """Divide one type body at top-level commas."""
+    segments: list[list[str]] = []
+    current: list[str] = []
+    depths = {"(": 0, "[": 0, "{": 0, "<": 0}
+    closing = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens:
+        if token == "," and all(depth == 0 for depth in depths.values()):
+            if current:
+                segments.append(current)
+            current = []
+            continue
+        current.append(token)
+        if token in depths:
+            depths[token] += 1
+        elif token in closing:
+            opener = closing[token]
+            depths[opener] = max(0, depths[opener] - 1)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def strip_prefix(tokens: list[str]) -> list[str]:
+    """Remove field or variant attributes and visibility tokens."""
+    cursor = 0
+    while cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
+        cursor = group_end(tokens, cursor + 1, "[", "]")
+    if cursor < len(tokens) and tokens[cursor] == "pub":
+        cursor += 1
+        if cursor < len(tokens) and tokens[cursor] == "(":
+            cursor = group_end(tokens, cursor, "(", ")")
+    return tokens[cursor:]
+
+
+def named_field_identifiers(body: list[str]) -> list[tuple[str, str]]:
+    """Return named field identifiers from one braced body."""
+    records: list[tuple[str, str]] = []
+    for segment in top_level_segments(body):
+        candidate = strip_prefix(segment)
+        if ":" not in candidate:
+            continue
+        colon = candidate.index(":")
+        names = [token for token in candidate[:colon] if IDENTIFIER.fullmatch(token)]
+        if names:
+            records.append(("field", names[-1]))
+    return records
+
+
+def contract_identifiers(kind: str, body: list[str]) -> list[tuple[str, str]]:
+    """Return field or variant identifiers from one named type body."""
+    if kind == "struct":
+        return named_field_identifiers(body)
+
+    records: list[tuple[str, str]] = []
+    for segment in top_level_segments(body):
+        candidate = strip_prefix(segment)
+        if candidate and IDENTIFIER.fullmatch(candidate[0]):
+            records.append(("variant", candidate[0]))
+            if len(candidate) > 1 and candidate[1] == "{":
+                body_end = group_end(candidate, 1, "{", "}")
+                records.extend(named_field_identifiers(candidate[2 : body_end - 1]))
+    return records
+
+
+def public_types(tokens: list[str]) -> list[tuple[str, str, list[tuple[str, str]]]]:
+    """Return public named structs and enums with their contract identifiers."""
+    records: list[tuple[str, str, list[tuple[str, str]]]] = []
+    cursor = 0
+    public = False
+    while cursor < len(tokens):
+        if cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
+            cursor = group_end(tokens, cursor + 1, "[", "]")
+            continue
+        if tokens[cursor] == "pub":
+            public = True
+            cursor += 1
+            if cursor < len(tokens) and tokens[cursor] == "(":
+                cursor = group_end(tokens, cursor, "(", ")")
+            continue
+        if tokens[cursor] not in {"struct", "enum"}:
+            public = False
+            cursor += 1
+            continue
+        kind = tokens[cursor]
+        if cursor + 1 >= len(tokens) or not IDENTIFIER.fullmatch(tokens[cursor + 1]):
+            raise ParseError(f"a public {kind} has no identifier")
+        name = tokens[cursor + 1]
+        body_start = type_body_start(tokens, cursor + 2)
+        if body_start is None:
+            public = False
+            cursor += 2
+            continue
+        body_end = group_end(tokens, body_start, "{", "}")
+        if public:
+            records.append(
+                (
+                    kind,
+                    name,
+                    contract_identifiers(kind, tokens[body_start + 1 : body_end - 1]),
+                )
+            )
+        public = False
+        cursor = body_end
+    return records
+
+
+def is_production_path(path: Path, source_root: Path) -> bool:
+    """Exclude explicit Rust test modules from a production source scan."""
+    relative = path.relative_to(source_root)
+    return (
+        path.name not in {"tests.rs", "test_support.rs"}
+        and "tests" not in relative.parts
+        and "test_support" not in relative.parts
+    )
+
+
+def read_public_types(
+    path: Path, root: Path
+) -> list[tuple[str, str, list[tuple[str, str]]]] | None:
+    """Read and parse one Rust source file or report a fail-closed error."""
+    try:
+        return public_types(rust_tokens(path.read_text(encoding="utf-8")))
+    except (OSError, UnicodeError, ParseError) as error:
+        report(f"{path.relative_to(root)} cannot be parsed: {error}")
+        return None
+
+
+def check_type_identifiers(
+    path: Path,
+    root: Path,
+    records: list[tuple[str, str, list[tuple[str, str]]]],
+) -> bool:
+    """Reject simulator-specific fields and variants in public shared types."""
+    valid = True
+    relative = path.relative_to(root)
+    for _, type_name, identifiers in records:
+        for kind, identifier in identifiers:
+            if is_forbidden_identifier(identifier):
+                report(
+                    f"{relative} {type_name} has simulator-specific {kind} {identifier}"
+                )
+                valid = False
+    return valid
+
+
+def check_source_root(source_root: Path, root: Path) -> bool:
+    """Check all production Rust files below one shared runtime root."""
+    if not source_root.is_dir():
+        return True
+    valid = True
+    for path in sorted(source_root.rglob("*.rs")):
+        if not is_production_path(path, source_root):
+            continue
+        records = read_public_types(path, root)
+        if records is None:
+            valid = False
+        elif not check_type_identifiers(path, root, records):
+            valid = False
+    return valid
+
+
+def check_campaign_file(path: Path, root: Path) -> bool:
+    """Check classified public contracts in one campaign configuration file."""
+    records = read_public_types(path, root)
+    if records is None:
+        return False
+    valid = True
+    for kind, type_name, identifiers in records:
+        if type_name in CAMPAIGN_ADAPTER_TYPES:
+            continue
+        if type_name not in CAMPAIGN_SHARED_TYPES:
+            report(
+                f"{path.relative_to(root)} has unclassified public campaign contract {type_name}"
+            )
+            valid = False
+        if not check_type_identifiers(path, root, [(kind, type_name, identifiers)]):
+            valid = False
+    return valid
+
+
+def check_campaign_config(root: Path) -> bool:
+    """Check the campaign document and all production configuration modules."""
+    config_file = root / "tools/flight-tune-campaign/src/config.rs"
+    config_root = root / "tools/flight-tune-campaign/src/config"
+    paths: list[Path] = []
+    if config_file.is_file():
+        paths.append(config_file)
+    if config_root.is_dir():
+        paths.extend(
+            path
+            for path in sorted(config_root.rglob("*.rs"))
+            if is_production_path(path, config_root)
+        )
+    valid = True
+    for path in paths:
+        if not check_campaign_file(path, root):
+            valid = False
+    return valid
+
+
+def main() -> int:
+    """Run all simulator-neutral contract checks."""
+    if len(sys.argv) != 2:
+        print("usage: check-flight-tune-contracts.py ROOT", file=sys.stderr)
+        return 2
+    root = Path(sys.argv[1]).resolve()
+    valid = True
+    for manifest in (
+        root / "crates/pilotage-trial/Cargo.toml",
+        root / "tools/flight-tune/Cargo.toml",
+    ):
+        if not check_manifest(manifest, root):
+            valid = False
+    for source_root in (
+        root / "crates/pilotage-trial/src",
+        root / "tools/flight-tune/src",
+    ):
+        if not check_source_root(source_root, root):
+            valid = False
+    if not check_campaign_config(root):
+        valid = False
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# Prove that the tuning boundary guard rejects simulator-specific coupling.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$repo_root/scripts/check-flight-tune-boundaries.sh"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-flight-tune-boundary-test.XXXXXX")"
+fixture_allowlist="$fixture/import-allowlist.tsv"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p \
+    "$fixture/adapters/flight-tune-xplane/src" \
+    "$fixture/adapters/pilotage-xplane-trial/src" \
+    "$fixture/crates/pilotage-trial/src" \
+    "$fixture/scripts" \
+    "$fixture/tools/flight-tune/src" \
+    "$fixture/tools/flight-tune-aviate/src/bin" \
+    "$fixture/tools/flight-tune-aviate/src/support" \
+    "$fixture/tools/flight-tune-aviate/src/tests" \
+    "$fixture/tools/flight-tune-campaign/src/config"
+
+write_workspace() {
+    printf '%s\n' \
+        '[workspace]' \
+        'members = [' \
+        '    "adapters/flight-tune-xplane",' \
+        '    "adapters/pilotage-xplane-trial",' \
+        '    "crates/pilotage-trial",' \
+        '    "tools/flight-tune",' \
+        ']' \
+        'resolver = "2"' \
+        > "$fixture/Cargo.toml"
+}
+
+write_adapter_packages() {
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune-xplane"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        > "$fixture/adapters/flight-tune-xplane/Cargo.toml"
+    printf '%s\n' 'pub fn adapter() {}' \
+        > "$fixture/adapters/flight-tune-xplane/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "pilotage-xplane-trial"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        > "$fixture/adapters/pilotage-xplane-trial/Cargo.toml"
+    printf '%s\n' 'pub fn adapter() {}' \
+        > "$fixture/adapters/pilotage-xplane-trial/src/lib.rs"
+}
+
+write_clean_manifests() {
+    printf '%s\n' \
+        '[package]' \
+        'name = "pilotage-trial"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        > "$fixture/crates/pilotage-trial/Cargo.toml"
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        > "$fixture/tools/flight-tune/Cargo.toml"
+}
+
+write_allowlisted_import() {
+    printf '%s\n' \
+        'use flight_tune_xplane::CausalJoinConfig;' \
+        'pub fn marker() {}' \
+        > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+}
+
+write_shared_contract() {
+    printf '%s\n' \
+        'pub struct SharedContract {' \
+        '    pub id: String,' \
+        '}' \
+        > "$fixture/crates/pilotage-trial/src/lib.rs"
+    printf '%s\n' \
+        'pub struct RuntimeContract {' \
+        '    pub id: String,' \
+        '}' \
+        > "$fixture/tools/flight-tune/src/lib.rs"
+}
+
+write_campaign_contract() {
+    printf '%s\n' \
+        'pub enum ExecutionTarget { Simulator, Hardware }' \
+        'pub enum CampaignPurpose { Qualification, Canary }' \
+        'pub struct PinnedFile { pub path: String }' \
+        'pub struct SearchGroupConfig { pub id: String }' \
+        'pub enum SearchGroupKind { Controller, Feel }' \
+        'pub struct CampaignConfig {' \
+        '    pub id: String,' \
+        '}' \
+        'pub struct XPlaneCampaignConfig {' \
+        '    pub weather_plugin_digest: String,' \
+        '    pub sdk_version: String,' \
+        '}' \
+        > "$fixture/tools/flight-tune-campaign/src/config.rs"
+    printf '%s\n' \
+        'pub struct CampaignBudgetLimit { pub attempts: u64 }' \
+        'pub struct TrainingGuardScenarioConfig { pub id: String }' \
+        'pub struct TrainingSuiteConfig { pub id: String }' \
+        > "$fixture/tools/flight-tune-campaign/src/config/training_suite.rs"
+}
+
+run_guard() {
+    bash "$guard" "$fixture" "$fixture_allowlist"
+}
+
+expect_failure() {
+    local name="$1" expected="$2" output
+    if output="$(run_guard 2>&1)"; then
+        echo "the tuning boundary guard accepted $name" >&2
+        exit 1
+    fi
+    if ! grep -Fq "$expected" <<<"$output"; then
+        echo "the tuning boundary guard gave the wrong result for $name" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+expect_failure_with_all() {
+    local name="$1" output expected
+    shift
+    if output="$(run_guard 2>&1)"; then
+        echo "the tuning boundary guard accepted $name" >&2
+        exit 1
+    fi
+    for expected in "$@"; do
+        if ! grep -Fq "$expected" <<<"$output"; then
+            echo "the tuning boundary guard missed $expected for $name" >&2
+            echo "$output" >&2
+            exit 1
+        fi
+    done
+}
+
+write_workspace
+write_adapter_packages
+write_clean_manifests
+write_allowlisted_import
+write_shared_contract
+write_campaign_contract
+printf '%s\t%s\n' \
+    'tools/flight-tune-aviate/src/driver.rs' \
+    'useflight_tune_xplane::CausalJoinConfig;' \
+    > "$fixture_allowlist"
+run_guard >/dev/null
+
+printf '%s\n' 'pub fn marker() {}' \
+    > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+run_guard >/dev/null
+write_allowlisted_import
+
+printf '%s\n' 'use flight_tune_xplane::ScenarioRuntime;' \
+    > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+expect_failure \
+    'a changed allowlisted import' \
+    'new flight_tune_xplane import:'
+write_allowlisted_import
+
+printf '%s\n' 'use flight_tune_xplane::NewRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/new_runtime.rs"
+expect_failure \
+    'a new Aviate X-Plane import' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/new_runtime.rs"
+
+printf '%s\n' 'use flight_tune_xplane::BinRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/bin/runtime.rs"
+expect_failure \
+    'an import in a production bin module' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/bin/runtime.rs"
+
+printf '%s\n' 'pub use flight_tune_xplane::SupportRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/support/runtime.rs"
+expect_failure \
+    'an import in a production support module' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/support/runtime.rs"
+
+printf '%s\n' 'use flight_tune_xplane::TestOnlyType;' \
+    > "$fixture/tools/flight-tune-aviate/src/tests/runtime.rs"
+printf '%s\n' 'use flight_tune_xplane::TestSupportType;' \
+    > "$fixture/tools/flight-tune-aviate/src/test_support.rs"
+run_guard >/dev/null
+
+printf '%s\n' 'pub fn runtime() { flight_tune_xplane::run(); }' \
+    > "$fixture/tools/flight-tune-aviate/src/runtime.rs"
+expect_failure \
+    'a path reference outside a reviewed import' \
+    'uses flight_tune_xplane outside a reviewed import'
+rm "$fixture/tools/flight-tune-aviate/src/runtime.rs"
+
+cp "$fixture_allowlist" \
+    "$fixture/scripts/flight-tune-xplane-import-allowlist.tsv"
+if output="$(bash "$guard" "$fixture" 2>&1)"; then
+    echo 'the tuning boundary guard accepted a nonempty production allowlist' >&2
+    exit 1
+fi
+if ! grep -Fq 'production flight_tune_xplane import allowlist must stay empty' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report the production allowlist' >&2
+    exit 1
+fi
+
+mkdir -p "$fixture/failing-bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/rg"
+chmod +x "$fixture/failing-bin/rg"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored a source-list failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot list Rust source files below' <<<"$output"; then
+    echo 'the tuning boundary guard did not report a source-list failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/rg"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/comm"
+chmod +x "$fixture/failing-bin/comm"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored an import comparison failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot compare flight_tune_xplane imports with the allowlist' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report an import comparison failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/comm"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a direct flight-tune-xplane runtime dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an aliased flight-tune-xplane runtime dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a direct pilotage-xplane-trial runtime dependency' \
+    'runtime dependency pilotage-xplane-trial'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies.trial]' \
+    'package = "pilotage-xplane-trial"' \
+    'path = "../../adapters/pilotage-xplane-trial"' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an aliased pilotage-xplane-trial runtime dependency' \
+    'runtime dependency pilotage-xplane-trial'
+write_clean_manifests
+
+printf '%s\n' \
+    '[workspace]' \
+    'members = [' \
+    '    "adapters/flight-tune-xplane",' \
+    '    "adapters/pilotage-xplane-trial",' \
+    '    "crates/pilotage-trial",' \
+    '    "tools/flight-tune",' \
+    ']' \
+    'resolver = "2"' \
+    '[workspace.dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "adapters/flight-tune-xplane" }' \
+    > "$fixture/Cargo.toml"
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'adapter = { workspace = true }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an inherited workspace dependency alias' \
+    'runtime dependency flight-tune-xplane'
+write_workspace
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[build-dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a flight-tune-xplane build dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    '[dev-dependencies]' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+run_guard >/dev/null
+write_clean_manifests
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    pub xplane: String,' \
+    '    pub acf: String,' \
+    '    pub aircraft_file: String,' \
+    '    pub trial_plugin: String,' \
+    '    pub bridge_plugin: String,' \
+    '    pub weather_plugin: String,' \
+    '    pub host_application_id: String,' \
+    '    pub xplane_version: String,' \
+    '    pub sdk_version: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure_with_all \
+    'all forbidden shared field identifiers' \
+    'simulator-specific field xplane' \
+    'simulator-specific field acf' \
+    'simulator-specific field aircraft_file' \
+    'simulator-specific field trial_plugin' \
+    'simulator-specific field bridge_plugin' \
+    'simulator-specific field weather_plugin' \
+    'simulator-specific field host_application_id' \
+    'simulator-specific field xplane_version' \
+    'simulator-specific field sdk_version'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract<T>' \
+    'where' \
+    '    T: Clone,' \
+    '{' \
+    '    pub candidate_xplane_version_digest: T,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a generic shared struct with a later body brace' \
+    'simulator-specific field candidate_xplane_version_digest'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    // }' \
+    '    pub candidate_xplane_version_digest: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a shared field after a comment brace' \
+    'simulator-specific field candidate_xplane_version_digest'
+write_shared_contract
+
+printf '%s\n' \
+    'pub enum SharedContract {' \
+    '    Neutral,' \
+    '    XPlaneReplay(String),' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator name inside a shared enum variant' \
+    'simulator-specific variant XPlaneReplay'
+write_shared_contract
+
+printf '%s\n' \
+    'pub enum SharedContract {' \
+    '    Neutral { xplane_version: String },' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator name inside a shared enum field' \
+    'simulator-specific field xplane_version'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct CampaignConfig {' \
+    '    pub xplane: XPlaneCampaignConfig,' \
+    '}' \
+    'pub struct XPlaneCampaignConfig {' \
+    '    pub weather_plugin_digest: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+expect_failure \
+    'the former CampaignConfig xplane exception' \
+    'CampaignConfig has simulator-specific field xplane'
+write_campaign_contract
+
+printf '%s\n' \
+    '#[derive(Serialize)]' \
+    'pub struct SharedCampaignContract {' \
+    '    pub id: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+expect_failure \
+    'an unclassified public campaign contract' \
+    'unclassified public campaign contract SharedCampaignContract'
+write_campaign_contract
+
+printf '%s\n' \
+    'mod shared;' \
+    'pub use shared::SharedCampaignContract;' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+printf '%s\n' \
+    '#[derive(Serialize)]' \
+    'pub struct SharedCampaignContract {' \
+    '    pub xplane_version: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config/shared.rs"
+expect_failure_with_all \
+    'an unclassified campaign submodule contract' \
+    'unclassified public campaign contract SharedCampaignContract' \
+    'simulator-specific field xplane_version'
+rm "$fixture/tools/flight-tune-campaign/src/config/shared.rs"
+write_campaign_contract
+
+run_guard >/dev/null
+echo "flight tuning boundary guard self-test: OK"

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -214,8 +214,8 @@ if ! grep -Fq 'production flight_tune_xplane import allowlist must stay empty' \
 fi
 
 mkdir -p "$fixture/failing-bin"
-printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/rg"
-chmod +x "$fixture/failing-bin/rg"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/find"
+chmod +x "$fixture/failing-bin/find"
 if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
     echo 'the tuning boundary guard ignored a source-list failure' >&2
     exit 1
@@ -224,7 +224,19 @@ if ! grep -Fq 'cannot list Rust source files below' <<<"$output"; then
     echo 'the tuning boundary guard did not report a source-list failure' >&2
     exit 1
 fi
-rm "$fixture/failing-bin/rg"
+rm "$fixture/failing-bin/find"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/grep"
+chmod +x "$fixture/failing-bin/grep"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored an import-scan failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot be scanned for flight_tune_xplane references' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report an import-scan failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/grep"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/comm"
 chmod +x "$fixture/failing-bin/comm"
 if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then


### PR DESCRIPTION
Closes #497.

This change adds an interim simulator boundary gate.

The gate rejects these changes:
- A production flight-tune-aviate import from flight-tune-xplane.
- A runtime or build dependency from a neutral tuning package to an X-Plane package.
- A simulator-specific field or variant in a shared public contract.
- A nonempty production import allowlist.
- A scan or comparison command failure.

The source scanner checks named struct fields and named enum variant fields. It scans campaign config submodules. It permits simulator adapter contracts and test-only dependencies.

The scanner does not expand macros. The current shared roots do not use a macro to generate a public contract. The gate is an interim control until the scenario engine moves to a simulator-neutral layer.

Local verification:
- Cargo format passed.
- Cargo clippy passed for the workspace and all targets with warnings denied.
- Cargo tests passed for the workspace and all targets.
- Strict workspace documentation passed. It reported only three existing private-link warnings in pilotage-geo.
- The workspace release build passed.
- All local repository guard scripts passed.
- The boundary self-test and production gate passed.
- Ruff, mypy strict, shellcheck, and shell syntax checks passed.

SIM / NOT FOR FLIGHT.