### PR TITLE
Add the simulator-neutral trial contract foundation (#447)

### DIFF
--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -11,7 +11,9 @@ mod digest;
 mod error;
 mod identity;
 mod limits;
+mod manifest;
 mod sample;
+mod scenario;
 mod validation;
 
 pub use condition::{
@@ -30,8 +32,13 @@ pub use limits::{
     MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS, SCENARIO_SCHEMA_VERSION,
     TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
 };
+pub use manifest::TrialManifest;
 pub use sample::{
     ActuatorState, AdapterDisposition, ConditionState, ControlAxes, ControlValue, HealthState,
     KinematicState, LifecycleObservation, LifecycleState, MissingReason, MissingSignal, NamedValue,
     Observed, Quaternion, RawInput, ReferenceFrame, SampleTime, TrialSample, Vector3,
+};
+pub use scenario::{
+    BackendCapabilities, BackendCapability, Comparison, ControlChannel, Phase, PhaseAction,
+    PhaseCondition, Scenario, SignalSelector, SignalSource, SineComponent, Waveform,
 };

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -40,6 +40,6 @@ pub use sample::{
 };
 pub use scenario::{
     BackendCapabilities, BackendCapability, Comparison, ControlChannel, ControlValueField, Phase,
-    PhaseAction, PhaseCondition, QuaternionComponent, Scenario, SignalSelector, SineComponent,
-    StartHeading, StartState, VectorComponent, Waveform,
+    PhaseAction, PhaseCondition, QuaternionComponent, Scenario, SignalSelectionError,
+    SignalSelector, SineComponent, StartHeading, StartState, VectorComponent, Waveform,
 };

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -39,7 +39,7 @@ pub use sample::{
     Observed, Quaternion, RawInput, ReferenceFrame, SampleTime, TrialSample, Vector3,
 };
 pub use scenario::{
-    BackendCapabilities, BackendCapability, Comparison, ControlChannel, Phase, PhaseAction,
-    PhaseCondition, Scenario, SignalSelector, SignalSource, SineComponent, StartHeading,
-    StartState, Waveform,
+    BackendCapabilities, BackendCapability, Comparison, ControlChannel, ControlValueField, Phase,
+    PhaseAction, PhaseCondition, QuaternionComponent, Scenario, SignalSelector, SineComponent,
+    StartHeading, StartState, VectorComponent, Waveform,
 };

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -40,5 +40,6 @@ pub use sample::{
 };
 pub use scenario::{
     BackendCapabilities, BackendCapability, Comparison, ControlChannel, Phase, PhaseAction,
-    PhaseCondition, Scenario, SignalSelector, SignalSource, SineComponent, Waveform,
+    PhaseCondition, Scenario, SignalSelector, SignalSource, SineComponent, StartHeading,
+    StartState, Waveform,
 };

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -5,7 +5,7 @@ pub const TRIAL_MANIFEST_SCHEMA_VERSION: u16 = 1;
 /// The supported run identity schema version.
 pub const RUN_IDENTITY_SCHEMA_VERSION: u16 = 1;
 /// The supported scenario schema version.
-pub const SCENARIO_SCHEMA_VERSION: u16 = 1;
+pub const SCENARIO_SCHEMA_VERSION: u16 = 2;
 /// The supported backend capabilities schema version.
 pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
 /// The supported trial sample schema version.

--- a/crates/pilotage-trial/src/manifest.rs
+++ b/crates/pilotage-trial/src/manifest.rs
@@ -1,0 +1,123 @@
+//! The complete immutable contract for one trial run.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BackendCapabilities, CodecError, Digest, MAX_MANIFEST_BYTES, Scenario,
+    TRIAL_MANIFEST_SCHEMA_VERSION, TrialSample, ValidationError, canonical, validation::schema,
+};
+
+/// The versioned immutable contract for one trial run.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialManifest {
+    /// The trial manifest schema version.
+    pub schema_version: u16,
+    /// The immutable run identity.
+    pub run: crate::RunIdentity,
+    /// The backend capability declaration.
+    pub backend: BackendCapabilities,
+    /// The scenario for this run.
+    pub scenario: Scenario,
+}
+
+impl TrialManifest {
+    /// Decodes and validates a trial manifest JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("trial manifest", bytes, MAX_MANIFEST_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validates the manifest and all identity links.
+    pub fn validate(&self) -> Result<(), CodecError> {
+        schema(
+            "trial manifest",
+            self.schema_version,
+            TRIAL_MANIFEST_SCHEMA_VERSION,
+        )?;
+        self.run.validate()?;
+        self.scenario.validate_for_backend(&self.backend)?;
+        self.validate_identity_links()?;
+        self.validate_condition_links()?;
+        Ok(())
+    }
+
+    /// Encodes canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("trial manifest", self, MAX_MANIFEST_BYTES)
+    }
+
+    /// Calculates the canonical trial manifest digest.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+
+    /// Validates one sample and its relation to the prior sample.
+    pub fn validate_sample(
+        &self,
+        previous: Option<&TrialSample>,
+        sample: &TrialSample,
+    ) -> Result<(), CodecError> {
+        self.validate()?;
+        self.validate_phase_index(sample)?;
+        if let Some(previous) = previous {
+            self.validate_phase_index(previous)?;
+            sample.validate_after(previous, &self.run)?;
+        } else {
+            sample.validate_for_run(&self.run)?;
+        }
+        Ok(())
+    }
+
+    fn validate_identity_links(&self) -> Result<(), CodecError> {
+        if self.run.simulator_backend != self.backend.backend {
+            return Err(identity_mismatch("run.simulator_backend").into());
+        }
+        if self.run.backend_capabilities_digest != self.backend.canonical_digest()? {
+            return Err(identity_mismatch("run.backend_capabilities_digest").into());
+        }
+        if self.run.scenario.id != self.scenario.id {
+            return Err(identity_mismatch("run.scenario.id").into());
+        }
+        if self.run.scenario.revision != self.scenario.revision {
+            return Err(identity_mismatch("run.scenario.revision").into());
+        }
+        if self.run.scenario.digest != self.scenario.canonical_digest()? {
+            return Err(identity_mismatch("run.scenario.digest").into());
+        }
+        Ok(())
+    }
+
+    fn validate_condition_links(&self) -> Result<(), ValidationError> {
+        for phase in &self.scenario.phases {
+            if let crate::PhaseAction::ApplyConditions { condition_set } = &phase.action
+                && condition_set != &self.run.condition_set
+            {
+                return Err(identity_mismatch("scenario.phase.condition_set"));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_phase_index(&self, sample: &TrialSample) -> Result<(), ValidationError> {
+        if usize::from(sample.phase_index) < self.scenario.phases.len() {
+            return Ok(());
+        }
+        Err(ValidationError::PhaseOutOfRange {
+            index: sample.phase_index,
+            phase_count: self.scenario.phases.len(),
+        })
+    }
+}
+
+fn identity_mismatch(field: &str) -> ValidationError {
+    ValidationError::IdentityMismatch {
+        field: field.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-trial/src/manifest/tests.rs
+++ b/crates/pilotage-trial/src/manifest/tests.rs
@@ -1,0 +1,497 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::{
+    ActuatorState, AdapterDisposition, ArtifactIdentity, BackendCapability, CausalStage,
+    ClockDomain, ClockMapping, ClockMappingQuality, ClockReading, ConditionState, ControlAxes,
+    ControlEventId, ControlStage, ControlValue, HealthState, KinematicState, LifecycleObservation,
+    LifecycleState, MAX_MANIFEST_BYTES, MAX_RAW_AXES, MissingReason, Observed, Phase, PhaseAction,
+    PhaseCondition, Quaternion, RUN_IDENTITY_SCHEMA_VERSION, RawInput, ReferenceFrame, RunIdentity,
+    SCENARIO_SCHEMA_VERSION, SampleTime, ScenarioIdentity, SimulatorTruthEvidence, SourceStamp,
+    StageProducerRole, StageStamp, TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
+    Vector3,
+};
+
+fn digest(byte: u8) -> Digest {
+    Digest::from_bytes([byte; 32])
+}
+
+fn artifact(id: &str, byte: u8) -> ArtifactIdentity {
+    ArtifactIdentity {
+        id: id.to_owned(),
+        revision: "r1".to_owned(),
+        digest: digest(byte),
+    }
+}
+
+fn backend() -> BackendCapabilities {
+    BackendCapabilities {
+        schema_version: crate::BACKEND_CAPABILITIES_SCHEMA_VERSION,
+        backend: artifact("xplane-backend", 1),
+        capabilities: vec![
+            BackendCapability::SimulatorTime,
+            BackendCapability::LifecycleState,
+            BackendCapability::ContactState,
+            BackendCapability::KinematicTruth,
+            BackendCapability::ConditionControl,
+            BackendCapability::WindControl,
+            BackendCapability::TurbulenceControl,
+        ],
+    }
+}
+
+fn scenario() -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "feel-release".to_owned(),
+        revision: 4,
+        phases: vec![Phase {
+            id: "observe-release".to_owned(),
+            max_sim_time_ns: 2_000_000_000,
+            required_capabilities: vec![
+                BackendCapability::SimulatorTime,
+                BackendCapability::LifecycleState,
+                BackendCapability::ContactState,
+            ],
+            entry_conditions: vec![PhaseCondition::Lifecycle {
+                state: LifecycleState::Armed,
+            }],
+            action: PhaseAction::Observe,
+            exit_conditions: vec![PhaseCondition::Lifecycle {
+                state: LifecycleState::Ready,
+            }],
+            abort_conditions: vec![PhaseCondition::Crashed { expected: true }],
+        }],
+    }
+}
+
+fn run_identity(backend: &BackendCapabilities, scenario: &Scenario) -> RunIdentity {
+    RunIdentity {
+        schema_version: RUN_IDENTITY_SCHEMA_VERSION,
+        run_id: "run-0001".to_owned(),
+        code_build: artifact("pilotage", 2),
+        vehicle_adapter: artifact("aviate-adapter", 3),
+        adapter_capabilities_digest: digest(4),
+        backend_capabilities_digest: backend.canonical_digest().expect("backend digest"),
+        device_profile: artifact("gamepad", 5),
+        control_scheme: artifact("scheme", 6),
+        control_feel_candidate: artifact("feel-a", 7),
+        flight_controller_candidate: artifact("fc-a", 8),
+        simulator_backend: backend.backend.clone(),
+        simulator: artifact("x-plane", 9),
+        vehicle_model: artifact("quadrotor", 10),
+        condition_set: artifact("wind-5mps", 11),
+        scenario: ScenarioIdentity {
+            id: scenario.id.clone(),
+            revision: scenario.revision,
+            digest: scenario.canonical_digest().expect("scenario digest"),
+        },
+        seed: 42,
+        repetition: 1,
+        clock_mappings: [
+            ClockDomain::Device,
+            ClockDomain::Client,
+            ClockDomain::Adapter,
+            ClockDomain::FlightController,
+            ClockDomain::Simulator,
+        ]
+        .map(|from| ClockMapping {
+            from,
+            to: ClockDomain::Recorder,
+            source_epoch: 1,
+            source_anchor_ns: 0,
+            recorder_anchor_ns: recorder_anchor(from),
+            rate_numerator: 1,
+            rate_denominator: 1,
+            valid_from_source_ns: 0,
+            valid_until_source_ns: 10_000_000_000,
+            uncertainty_ns: 0,
+            quality: ClockMappingQuality::Exact,
+        })
+        .into(),
+    }
+}
+
+fn recorder_anchor(domain: ClockDomain) -> u64 {
+    match domain {
+        ClockDomain::Device => 3,
+        ClockDomain::Client => 2,
+        ClockDomain::Recorder => 0,
+        ClockDomain::Adapter | ClockDomain::FlightController => 1,
+        ClockDomain::Simulator => 50,
+    }
+}
+
+fn manifest() -> TrialManifest {
+    let backend = backend();
+    let scenario = scenario();
+    TrialManifest {
+        schema_version: TRIAL_MANIFEST_SCHEMA_VERSION,
+        run: run_identity(&backend, &scenario),
+        backend,
+        scenario,
+    }
+}
+
+fn vector(value: f64) -> Vector3 {
+    Vector3 {
+        x: value,
+        y: value + 1.0,
+        z: value + 2.0,
+    }
+}
+
+fn kinematic_state() -> KinematicState {
+    KinematicState {
+        position_m: Observed::present(vector(1.0)),
+        velocity_mps: Observed::present(vector(2.0)),
+        acceleration_mps2: Observed::present(vector(3.0)),
+        attitude: Observed::present(Quaternion {
+            w: 1.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }),
+        body_rates_rad_s: Observed::present(vector(0.1)),
+    }
+}
+
+fn simulator_truth() -> SimulatorTruthEvidence {
+    SimulatorTruthEvidence {
+        position_m: Observed::present(vector(1.0)),
+        velocity_mps: Observed::present(vector(2.0)),
+        acceleration_mps2: Observed::present(vector(3.0)),
+        attitude: Observed::present(Quaternion {
+            w: 1.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }),
+        body_rates_rad_s: Observed::present(vector(0.1)),
+    }
+}
+
+fn sample_time(recorder_ns: u64, simulator_ns: u64) -> SampleTime {
+    SampleTime {
+        recorder_monotonic_ns: recorder_ns,
+        device: clock_reading(recorder_ns.saturating_sub(3)),
+        client: clock_reading(recorder_ns.saturating_sub(2)),
+        adapter: clock_reading(recorder_ns.saturating_sub(1)),
+        flight_controller: clock_reading(recorder_ns.saturating_sub(1)),
+        simulator: clock_reading(simulator_ns),
+        clock_discontinuities: Vec::new(),
+    }
+}
+
+fn clock_reading(time_ns: u64) -> Observed<ClockReading> {
+    Observed::present(ClockReading { epoch: 1, time_ns })
+}
+
+fn stage<T>(
+    producer: StageProducerRole,
+    clock: ClockDomain,
+    sequence: u64,
+    source_ns: u64,
+    recorder_ns: u64,
+    predecessor: Option<ControlEventId>,
+    value: T,
+) -> CausalStage<T> {
+    CausalStage::present(
+        StageStamp {
+            source: SourceStamp {
+                producer,
+                clock,
+                epoch: 1,
+                sequence,
+                time_ns: Observed::present(source_ns),
+            },
+            predecessor,
+            recorder_receive_ns: recorder_ns,
+            recorder_apply_ns: recorder_ns,
+        },
+        value,
+    )
+}
+
+fn event(stage: ControlStage, clock: ClockDomain, sequence: u64) -> ControlEventId {
+    ControlEventId {
+        stage,
+        clock,
+        epoch: 1,
+        sequence,
+    }
+}
+
+fn raw_input_stage(sequence: u64, recorder_ns: u64) -> CausalStage<RawInput> {
+    stage(
+        StageProducerRole::InputCapture,
+        ClockDomain::Device,
+        sequence,
+        recorder_ns.saturating_sub(13),
+        recorder_ns.saturating_sub(10),
+        None,
+        RawInput {
+            axes: vec![0.2, -0.1],
+            buttons: vec![false, true],
+        },
+    )
+}
+
+fn client_axes_stage(
+    sequence: u64,
+    recorder_ns: u64,
+    axes: ControlAxes,
+) -> CausalStage<ControlAxes> {
+    stage(
+        StageProducerRole::ControlClient,
+        ClockDomain::Client,
+        sequence,
+        recorder_ns.saturating_sub(10),
+        recorder_ns.saturating_sub(8),
+        Some(event(ControlStage::RawInput, ClockDomain::Device, sequence)),
+        axes,
+    )
+}
+
+fn client_control_stage(
+    sequence: u64,
+    recorder_ns: u64,
+    predecessor_stage: ControlStage,
+    axes: ControlAxes,
+) -> CausalStage<ControlValue> {
+    let (source_delta, event_delta) = match predecessor_stage {
+        ControlStage::NormalizedControl => (8, 6),
+        ControlStage::TypedIntent => (6, 4),
+        _ => (2, 2),
+    };
+    stage(
+        StageProducerRole::ControlClient,
+        ClockDomain::Client,
+        sequence,
+        recorder_ns.saturating_sub(source_delta),
+        recorder_ns.saturating_sub(event_delta),
+        Some(event(predecessor_stage, ClockDomain::Client, sequence)),
+        ControlValue::Axes { axes },
+    )
+}
+
+fn transmitted_stage(sequence: u64, recorder_ns: u64) -> CausalStage<ControlValue> {
+    stage(
+        StageProducerRole::VehicleAdapter,
+        ClockDomain::Adapter,
+        sequence,
+        recorder_ns.saturating_sub(3),
+        recorder_ns.saturating_sub(2),
+        Some(event(
+            ControlStage::AdapterDemand,
+            ClockDomain::Client,
+            sequence,
+        )),
+        ControlValue::Velocity {
+            frame: ReferenceFrame::LocalNed,
+            linear_mps: vector(0.2),
+            yaw_rate_rad_s: 0.0,
+        },
+    )
+}
+
+fn estimate_stage(sequence: u64, recorder_ns: u64) -> CausalStage<KinematicState> {
+    stage(
+        StageProducerRole::FlightController,
+        ClockDomain::FlightController,
+        sequence,
+        recorder_ns.saturating_sub(1),
+        recorder_ns,
+        None,
+        kinematic_state(),
+    )
+}
+
+fn truth_stage(sequence: u64, recorder_ns: u64) -> CausalStage<SimulatorTruthEvidence> {
+    stage(
+        StageProducerRole::SimulatorBackend,
+        ClockDomain::Simulator,
+        sequence,
+        recorder_ns.saturating_sub(50),
+        recorder_ns,
+        None,
+        simulator_truth(),
+    )
+}
+
+fn sample(manifest: &TrialManifest, sequence: u64, recorder_ns: u64) -> TrialSample {
+    let axes = ControlAxes {
+        roll: 0.2,
+        pitch: -0.1,
+        vertical: 0.3,
+        yaw: 0.0,
+    };
+    TrialSample {
+        schema_version: TRIAL_SAMPLE_SCHEMA_VERSION,
+        run_digest: manifest
+            .run
+            .canonical_digest()
+            .expect("run identity digest"),
+        sequence,
+        dropped_before: 0,
+        phase_index: 0,
+        time: sample_time(recorder_ns, recorder_ns - 50),
+        raw_input: raw_input_stage(sequence, recorder_ns),
+        normalized_control: client_axes_stage(sequence, recorder_ns, axes.clone()),
+        typed_intent: client_control_stage(
+            sequence,
+            recorder_ns,
+            ControlStage::NormalizedControl,
+            axes.clone(),
+        ),
+        adapter_demand: client_control_stage(
+            sequence,
+            recorder_ns,
+            ControlStage::TypedIntent,
+            axes,
+        ),
+        transmitted_setpoint: transmitted_stage(sequence, recorder_ns),
+        flight_controller_estimate: estimate_stage(sequence, recorder_ns),
+        simulator_truth: truth_stage(sequence, recorder_ns),
+        actuator: Observed::present(ActuatorState {
+            values: vec![0.2, 0.3, 0.2, 0.3],
+            saturated: false,
+        }),
+        adapter_disposition: Observed::present(AdapterDisposition::Accepted),
+        lifecycle: Observed::present(LifecycleObservation {
+            state: LifecycleState::Armed,
+            ground_contact: false,
+            crashed: false,
+        }),
+        condition_state: Observed::present(ConditionState {
+            wind_velocity_ned_mps: Observed::present(vector(5.0)),
+            turbulence_rms_mps: Observed::present(0.4),
+            values: Vec::new(),
+        }),
+        link_state: Observed::present(HealthState {
+            valid: true,
+            detail: None,
+        }),
+        estimator_state: Observed::present(HealthState {
+            valid: true,
+            detail: None,
+        }),
+    }
+}
+
+#[test]
+fn canonical_digest_does_not_depend_on_json_format() {
+    let manifest = manifest();
+    let compact = manifest.to_canonical_json().expect("compact manifest");
+    let pretty = serde_json::to_vec_pretty(&manifest).expect("pretty manifest");
+    let compact_value = TrialManifest::from_json(&compact).expect("compact parse");
+    let pretty_value = TrialManifest::from_json(&pretty).expect("pretty parse");
+
+    assert_eq!(
+        compact_value.canonical_digest().expect("compact digest"),
+        pretty_value.canonical_digest().expect("pretty digest")
+    );
+}
+
+#[test]
+fn unsupported_backend_capability_fails_before_a_run() {
+    let mut manifest = manifest();
+    manifest
+        .backend
+        .capabilities
+        .retain(|item| *item != BackendCapability::LifecycleState);
+
+    assert!(matches!(
+        manifest.validate(),
+        Err(CodecError::Validation(
+            ValidationError::UnsupportedCapability { .. }
+        ))
+    ));
+}
+
+#[test]
+fn manifest_size_limit_applies_before_json_decode() {
+    let bytes = vec![b' '; MAX_MANIFEST_BYTES + 1];
+
+    assert!(matches!(
+        TrialManifest::from_json(&bytes),
+        Err(CodecError::DocumentTooLarge { .. })
+    ));
+}
+
+#[test]
+fn sample_round_trip_preserves_a_missing_signal_reason() {
+    let manifest = manifest();
+    let mut sample = sample(&manifest, 0, 1_000);
+    sample.raw_input.observation = Observed::missing(
+        MissingReason::RecorderLag,
+        Some("writer queue full".to_owned()),
+    );
+
+    let bytes = sample
+        .to_canonical_json_for_run(&manifest.run)
+        .expect("sample JSON");
+    let decoded = TrialSample::from_json_for_run(&bytes, &manifest.run).expect("sample parse");
+
+    assert_eq!(decoded, sample);
+}
+
+#[test]
+fn a_sequence_gap_must_match_the_declared_loss() {
+    let manifest = manifest();
+    let previous = sample(&manifest, 7, 1_000);
+    let current = sample(&manifest, 9, 1_100);
+
+    assert!(matches!(
+        manifest.validate_sample(Some(&previous), &current),
+        Err(CodecError::Validation(ValidationError::SequenceGap {
+            expected: 8,
+            actual: 9
+        }))
+    ));
+}
+
+#[test]
+fn a_discontinuity_must_change_the_source_epoch() {
+    let manifest = manifest();
+    let previous = sample(&manifest, 0, 1_000);
+    let mut current = sample(&manifest, 1, 1_100);
+
+    current
+        .time
+        .clock_discontinuities
+        .push(ClockDomain::Simulator);
+    assert!(matches!(
+        manifest.validate_sample(Some(&previous), &current),
+        Err(CodecError::Validation(
+            ValidationError::InvalidClockObservation { .. }
+        ))
+    ));
+}
+
+#[test]
+fn raw_input_axis_count_has_a_hard_limit() {
+    let manifest = manifest();
+    let mut sample = sample(&manifest, 0, 1_000);
+    sample.raw_input.observation = Observed::present(RawInput {
+        axes: vec![0.0; MAX_RAW_AXES + 1],
+        buttons: Vec::new(),
+    });
+
+    assert!(matches!(
+        sample.validate_local(),
+        Err(ValidationError::TooManyItems { .. })
+    ));
+}
+
+#[test]
+fn a_semantic_backend_change_changes_its_digest() {
+    let first = backend();
+    let mut second = first.clone();
+    second.capabilities.push(BackendCapability::Reset);
+
+    assert_ne!(
+        first.canonical_digest().expect("first digest"),
+        second.canonical_digest().expect("second digest")
+    );
+}

--- a/crates/pilotage-trial/src/scenario.rs
+++ b/crates/pilotage-trial/src/scenario.rs
@@ -1,0 +1,94 @@
+//! Versioned scenario and backend contracts.
+
+mod backend;
+mod phase;
+mod waveform;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CodecError, Digest, MAX_MANIFEST_BYTES, MAX_PHASES, MAX_TEXT_BYTES, SCENARIO_SCHEMA_VERSION,
+    ValidationError, canonical,
+    validation::{nonempty_count, schema, text},
+};
+
+pub use backend::{BackendCapabilities, BackendCapability};
+pub use phase::{
+    Comparison, ControlChannel, Phase, PhaseAction, PhaseCondition, SignalSelector, SignalSource,
+};
+pub use waveform::{SineComponent, Waveform};
+
+/// A versioned sequence of test phases.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scenario {
+    /// The scenario schema version.
+    pub schema_version: u16,
+    /// The stable scenario identifier.
+    pub id: String,
+    /// The scenario revision number.
+    pub revision: u32,
+    /// The ordered test phases.
+    pub phases: Vec<Phase>,
+}
+
+impl Scenario {
+    /// Decodes and validates a scenario JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("scenario", bytes, MAX_MANIFEST_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validates the scenario without a backend selection.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        schema("scenario", self.schema_version, SCENARIO_SCHEMA_VERSION)?;
+        text("scenario.id", &self.id, MAX_TEXT_BYTES)?;
+        nonempty_count("scenario.phases", self.phases.len(), MAX_PHASES)?;
+        for (index, phase) in self.phases.iter().enumerate() {
+            phase.validate(index)?;
+            if self.phases[..index]
+                .iter()
+                .any(|prior| prior.id == phase.id)
+            {
+                return Err(ValidationError::DuplicateItem {
+                    field: "scenario.phases.id".to_owned(),
+                    index,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Validates the scenario against backend capabilities.
+    pub fn validate_for_backend(
+        &self,
+        backend: &BackendCapabilities,
+    ) -> Result<(), ValidationError> {
+        self.validate()?;
+        backend.validate()?;
+        for phase in &self.phases {
+            for capability in &phase.required_capabilities {
+                if !backend.supports(*capability) {
+                    return Err(ValidationError::UnsupportedCapability {
+                        phase: phase.id.clone(),
+                        capability: capability.as_str().to_owned(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Encodes canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("scenario", self, MAX_MANIFEST_BYTES)
+    }
+
+    /// Calculates the digest of canonical compact JSON.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+}

--- a/crates/pilotage-trial/src/scenario.rs
+++ b/crates/pilotage-trial/src/scenario.rs
@@ -2,6 +2,7 @@
 
 mod backend;
 mod phase;
+mod selector;
 mod waveform;
 
 use serde::{Deserialize, Serialize};
@@ -13,9 +14,9 @@ use crate::{
 };
 
 pub use backend::{BackendCapabilities, BackendCapability};
-pub use phase::{
-    Comparison, ControlChannel, Phase, PhaseAction, PhaseCondition, SignalSelector, SignalSource,
-    StartHeading, StartState,
+pub use phase::{Comparison, Phase, PhaseAction, PhaseCondition, StartHeading, StartState};
+pub use selector::{
+    ControlChannel, ControlValueField, QuaternionComponent, SignalSelector, VectorComponent,
 };
 pub use waveform::{SineComponent, Waveform};
 

--- a/crates/pilotage-trial/src/scenario.rs
+++ b/crates/pilotage-trial/src/scenario.rs
@@ -15,6 +15,7 @@ use crate::{
 pub use backend::{BackendCapabilities, BackendCapability};
 pub use phase::{
     Comparison, ControlChannel, Phase, PhaseAction, PhaseCondition, SignalSelector, SignalSource,
+    StartHeading, StartState,
 };
 pub use waveform::{SineComponent, Waveform};
 
@@ -92,3 +93,6 @@ impl Scenario {
             .map(|bytes| canonical::digest(&bytes))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-trial/src/scenario.rs
+++ b/crates/pilotage-trial/src/scenario.rs
@@ -16,7 +16,8 @@ use crate::{
 pub use backend::{BackendCapabilities, BackendCapability};
 pub use phase::{Comparison, Phase, PhaseAction, PhaseCondition, StartHeading, StartState};
 pub use selector::{
-    ControlChannel, ControlValueField, QuaternionComponent, SignalSelector, VectorComponent,
+    ControlChannel, ControlValueField, QuaternionComponent, SignalSelectionError, SignalSelector,
+    VectorComponent,
 };
 pub use waveform::{SineComponent, Waveform};
 

--- a/crates/pilotage-trial/src/scenario/backend.rs
+++ b/crates/pilotage-trial/src/scenario/backend.rs
@@ -1,0 +1,109 @@
+//! Backend capability declarations.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ArtifactIdentity, BACKEND_CAPABILITIES_SCHEMA_VERSION, CodecError, Digest, MAX_CAPABILITIES,
+    MAX_MANIFEST_BYTES, ValidationError, canonical,
+    validation::{count, schema, unique},
+};
+
+/// A capability that a trial backend can supply.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendCapability {
+    /// Reset the simulated vehicle and world.
+    Reset,
+    /// Report the simulator lifecycle state.
+    LifecycleState,
+    /// Report and control simulator time.
+    SimulatorTime,
+    /// Apply an environmental condition set.
+    ConditionControl,
+    /// Report kinematic truth data.
+    KinematicTruth,
+    /// Apply a deterministic random seed.
+    DeterministicSeed,
+    /// Arm and disarm the vehicle.
+    ArmDisarm,
+    /// Report ground contact and crash states.
+    ContactState,
+    /// Apply a controlled wind field.
+    WindControl,
+    /// Apply controlled turbulence.
+    TurbulenceControl,
+}
+
+impl BackendCapability {
+    /// Gets the stable capability name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reset => "reset",
+            Self::LifecycleState => "lifecycle_state",
+            Self::SimulatorTime => "simulator_time",
+            Self::ConditionControl => "condition_control",
+            Self::KinematicTruth => "kinematic_truth",
+            Self::DeterministicSeed => "deterministic_seed",
+            Self::ArmDisarm => "arm_disarm",
+            Self::ContactState => "contact_state",
+            Self::WindControl => "wind_control",
+            Self::TurbulenceControl => "turbulence_control",
+        }
+    }
+}
+
+/// A versioned declaration of backend capabilities.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendCapabilities {
+    /// The backend capabilities schema version.
+    pub schema_version: u16,
+    /// The backend artifact identity.
+    pub backend: ArtifactIdentity,
+    /// The capabilities that the backend supplies.
+    pub capabilities: Vec<BackendCapability>,
+}
+
+impl BackendCapabilities {
+    /// Decodes and validates a backend capabilities JSON document.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, CodecError> {
+        let value: Self = canonical::decode("backend capabilities", bytes, MAX_MANIFEST_BYTES)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    /// Validates the backend capability declaration.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        schema(
+            "backend capabilities",
+            self.schema_version,
+            BACKEND_CAPABILITIES_SCHEMA_VERSION,
+        )?;
+        self.backend.validate("backend_capabilities.backend")?;
+        count(
+            "backend_capabilities.capabilities",
+            self.capabilities.len(),
+            MAX_CAPABILITIES,
+        )?;
+        unique("backend_capabilities.capabilities", &self.capabilities)
+    }
+
+    /// Reports if the backend supplies a capability.
+    #[must_use]
+    pub fn supports(&self, capability: BackendCapability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+
+    /// Encodes canonical compact JSON after validation.
+    pub fn to_canonical_json(&self) -> Result<Vec<u8>, CodecError> {
+        self.validate()?;
+        canonical::encode("backend capabilities", self, MAX_MANIFEST_BYTES)
+    }
+
+    /// Calculates the digest of canonical compact JSON.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        self.to_canonical_json()
+            .map(|bytes| canonical::digest(&bytes))
+    }
+}

--- a/crates/pilotage-trial/src/scenario/phase.rs
+++ b/crates/pilotage-trial/src/scenario/phase.rs
@@ -1,0 +1,357 @@
+//! Phase actions and completion conditions.
+
+use serde::{Deserialize, Serialize};
+
+use super::{BackendCapability, Waveform};
+use crate::{
+    ArtifactIdentity, MAX_CAPABILITIES, MAX_CONDITION_VALUES, MAX_PHASE_CONDITIONS, MAX_TEXT_BYTES,
+    ValidationError,
+    validation::{count, duration, finite, text, unique},
+};
+
+/// A control channel for a stimulus.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlChannel {
+    /// The roll channel.
+    Roll,
+    /// The pitch channel.
+    Pitch,
+    /// The vertical channel.
+    Vertical,
+    /// The yaw channel.
+    Yaw,
+}
+
+/// A scalar comparison operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Comparison {
+    /// The signal is less than the limit.
+    LessThan,
+    /// The signal is less than or equal to the limit.
+    LessOrEqual,
+    /// The signal is greater than the limit.
+    GreaterThan,
+    /// The signal is greater than or equal to the limit.
+    GreaterOrEqual,
+    /// The absolute signal is less than or equal to the limit.
+    AbsoluteLessOrEqual,
+    /// The absolute signal is greater than or equal to the limit.
+    AbsoluteGreaterOrEqual,
+}
+
+/// A source of one scalar sample signal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignalSource {
+    /// An axis in the raw input report.
+    RawInputAxis,
+    /// A normalized control axis.
+    NormalizedControl,
+    /// A scalar in the typed intent.
+    TypedIntent,
+    /// A scalar in the adapter demand.
+    AdapterDemand,
+    /// A scalar in the transmitted setpoint.
+    TransmittedSetpoint,
+    /// An estimated position component.
+    EstimatePosition,
+    /// An estimated velocity component.
+    EstimateVelocity,
+    /// An estimated acceleration component.
+    EstimateAcceleration,
+    /// An estimated attitude component.
+    EstimateAttitude,
+    /// An estimated body rate component.
+    EstimateBodyRate,
+    /// A truth position component.
+    TruthPosition,
+    /// A truth velocity component.
+    TruthVelocity,
+    /// A truth acceleration component.
+    TruthAcceleration,
+    /// A truth attitude component.
+    TruthAttitude,
+    /// A truth body rate component.
+    TruthBodyRate,
+    /// An actuator value.
+    Actuator,
+    /// A named environmental condition value.
+    ConditionValue,
+}
+
+impl SignalSource {
+    const fn component_count(self) -> usize {
+        match self {
+            Self::RawInputAxis => crate::MAX_RAW_AXES,
+            Self::NormalizedControl => 4,
+            Self::TypedIntent | Self::AdapterDemand | Self::TransmittedSetpoint => 8,
+            Self::EstimateAttitude | Self::TruthAttitude => 4,
+            Self::Actuator => crate::MAX_ACTUATOR_VALUES,
+            Self::ConditionValue => MAX_CONDITION_VALUES,
+            _ => 3,
+        }
+    }
+
+    const fn required_capability(self) -> Option<BackendCapability> {
+        match self {
+            Self::TruthPosition
+            | Self::TruthVelocity
+            | Self::TruthAcceleration
+            | Self::TruthAttitude
+            | Self::TruthBodyRate => Some(BackendCapability::KinematicTruth),
+            Self::ConditionValue => Some(BackendCapability::ConditionControl),
+            _ => None,
+        }
+    }
+}
+
+/// A selector for one scalar in a trial sample.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignalSelector {
+    /// The signal source.
+    pub source: SignalSource,
+    /// The zero-based component index.
+    pub component: u16,
+}
+
+/// A condition for phase entry, exit, or abort.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PhaseCondition {
+    /// The condition is always true.
+    Always,
+    /// The lifecycle state has the specified value.
+    Lifecycle {
+        /// The required lifecycle state.
+        state: crate::LifecycleState,
+    },
+    /// The ground contact state has the specified value.
+    GroundContact {
+        /// The required ground contact state.
+        expected: bool,
+    },
+    /// The crash state has the specified value.
+    Crashed {
+        /// The required crash state.
+        expected: bool,
+    },
+    /// The control link validity has the specified value.
+    LinkValid {
+        /// The required link validity.
+        expected: bool,
+    },
+    /// The estimator validity has the specified value.
+    EstimatorValid {
+        /// The required estimator validity.
+        expected: bool,
+    },
+    /// The simulator time satisfies a comparison.
+    SimulatorTime {
+        /// The comparison operation.
+        comparison: Comparison,
+        /// The comparison time in nanoseconds.
+        value_ns: u64,
+    },
+    /// A scalar sample signal satisfies a comparison.
+    Signal {
+        /// The selected scalar signal.
+        selector: SignalSelector,
+        /// The comparison operation.
+        comparison: Comparison,
+        /// The comparison value.
+        value: f64,
+    },
+}
+
+/// The action for one scenario phase.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PhaseAction {
+    /// Reset the vehicle and the simulated world.
+    Reset,
+    /// Wait for the backend and vehicle to become ready.
+    WaitReady,
+    /// Apply one immutable environmental condition set.
+    ApplyConditions {
+        /// The condition set identity.
+        condition_set: ArtifactIdentity,
+    },
+    /// Arm the vehicle.
+    Arm,
+    /// Move the vehicle to the test start state.
+    ReachStartState,
+    /// Hold the start state before the stimulus.
+    Settle,
+    /// Apply one control stimulus.
+    Stimulus {
+        /// The control channel.
+        channel: ControlChannel,
+        /// The stimulus waveform.
+        waveform: Waveform,
+    },
+    /// Release the test control input.
+    ReleaseControl,
+    /// Observe the response without a new stimulus.
+    Observe,
+    /// Stop active control.
+    Stop,
+    /// Disarm the vehicle.
+    Disarm,
+    /// Mark the data collection phase.
+    CollectResults,
+}
+
+/// One bounded phase in a scenario.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Phase {
+    /// The phase identifier.
+    pub id: String,
+    /// The maximum phase duration in simulator nanoseconds.
+    pub max_sim_time_ns: u64,
+    /// The backend capabilities that the phase needs.
+    pub required_capabilities: Vec<BackendCapability>,
+    /// The conditions that permit phase entry.
+    pub entry_conditions: Vec<PhaseCondition>,
+    /// The phase action.
+    pub action: PhaseAction,
+    /// The conditions that complete the phase.
+    pub exit_conditions: Vec<PhaseCondition>,
+    /// The conditions that abort the trial.
+    pub abort_conditions: Vec<PhaseCondition>,
+}
+
+impl Phase {
+    pub(crate) fn validate(&self, index: usize) -> Result<(), ValidationError> {
+        let field = format!("scenario.phases[{index}]");
+        text(&format!("{field}.id"), &self.id, MAX_TEXT_BYTES)?;
+        duration(&format!("{field}.max_sim_time_ns"), self.max_sim_time_ns)?;
+        count(
+            &format!("{field}.required_capabilities"),
+            self.required_capabilities.len(),
+            MAX_CAPABILITIES,
+        )?;
+        unique(
+            &format!("{field}.required_capabilities"),
+            &self.required_capabilities,
+        )?;
+        self.validate_conditions(&field)?;
+        self.validate_action(&field)?;
+        self.validate_capability_declarations(&field)
+    }
+
+    fn validate_conditions(&self, field: &str) -> Result<(), ValidationError> {
+        validate_condition_list(field, "entry_conditions", &self.entry_conditions)?;
+        validate_condition_list(field, "exit_conditions", &self.exit_conditions)?;
+        validate_condition_list(field, "abort_conditions", &self.abort_conditions)
+    }
+
+    fn validate_action(&self, field: &str) -> Result<(), ValidationError> {
+        match &self.action {
+            PhaseAction::ApplyConditions { condition_set } => {
+                condition_set.validate(&format!("{field}.action.condition_set"))
+            }
+            PhaseAction::Stimulus { waveform, .. } => {
+                waveform.validate(&format!("{field}.action.waveform"))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn validate_capability_declarations(&self, field: &str) -> Result<(), ValidationError> {
+        self.require_declared(field, BackendCapability::SimulatorTime)?;
+        if let Some(capability) = action_capability(&self.action) {
+            self.require_declared(field, capability)?;
+        }
+        for condition in self
+            .entry_conditions
+            .iter()
+            .chain(&self.exit_conditions)
+            .chain(&self.abort_conditions)
+        {
+            if let Some(capability) = condition_capability(condition) {
+                self.require_declared(field, capability)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn require_declared(
+        &self,
+        field: &str,
+        capability: BackendCapability,
+    ) -> Result<(), ValidationError> {
+        if self.required_capabilities.contains(&capability) {
+            return Ok(());
+        }
+        Err(ValidationError::UnsupportedCapability {
+            phase: self.id.clone(),
+            capability: format!("{} (not declared in {field})", capability.as_str()),
+        })
+    }
+}
+
+fn validate_condition_list(
+    field: &str,
+    name: &str,
+    conditions: &[PhaseCondition],
+) -> Result<(), ValidationError> {
+    count(
+        &format!("{field}.{name}"),
+        conditions.len(),
+        MAX_PHASE_CONDITIONS,
+    )?;
+    for (index, condition) in conditions.iter().enumerate() {
+        if let PhaseCondition::Signal {
+            selector, value, ..
+        } = condition
+        {
+            validate_selector(field, name, index, selector)?;
+            finite(&format!("{field}.{name}[{index}].value"), *value)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_selector(
+    field: &str,
+    name: &str,
+    index: usize,
+    selector: &SignalSelector,
+) -> Result<(), ValidationError> {
+    let limit = selector.source.component_count();
+    if usize::from(selector.component) < limit {
+        return Ok(());
+    }
+    Err(ValidationError::OutOfRange {
+        field: format!("{field}.{name}[{index}].selector.component"),
+        actual: f64::from(selector.component),
+        minimum: 0.0,
+        maximum: (limit.saturating_sub(1)) as f64,
+    })
+}
+
+const fn action_capability(action: &PhaseAction) -> Option<BackendCapability> {
+    match action {
+        PhaseAction::Reset => Some(BackendCapability::Reset),
+        PhaseAction::WaitReady => Some(BackendCapability::LifecycleState),
+        PhaseAction::ApplyConditions { .. } => Some(BackendCapability::ConditionControl),
+        PhaseAction::Arm | PhaseAction::Disarm => Some(BackendCapability::ArmDisarm),
+        _ => None,
+    }
+}
+
+const fn condition_capability(condition: &PhaseCondition) -> Option<BackendCapability> {
+    match condition {
+        PhaseCondition::Lifecycle { .. } => Some(BackendCapability::LifecycleState),
+        PhaseCondition::GroundContact { .. } | PhaseCondition::Crashed { .. } => {
+            Some(BackendCapability::ContactState)
+        }
+        PhaseCondition::SimulatorTime { .. } => Some(BackendCapability::SimulatorTime),
+        PhaseCondition::Signal { selector, .. } => selector.source.required_capability(),
+        _ => None,
+    }
+}

--- a/crates/pilotage-trial/src/scenario/phase.rs
+++ b/crates/pilotage-trial/src/scenario/phase.rs
@@ -2,26 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{BackendCapability, Waveform};
+use super::{BackendCapability, ControlChannel, SignalSelector, Waveform};
 use crate::{
-    ArtifactIdentity, MAX_CAPABILITIES, MAX_CONDITION_VALUES, MAX_PHASE_CONDITIONS, MAX_TEXT_BYTES,
-    ValidationError,
+    ArtifactIdentity, MAX_CAPABILITIES, MAX_PHASE_CONDITIONS, MAX_TEXT_BYTES, ValidationError,
     validation::{count, duration, finite, range, text, unique},
 };
-
-/// A control channel for a stimulus.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ControlChannel {
-    /// The roll channel.
-    Roll,
-    /// The pitch channel.
-    Pitch,
-    /// The vertical channel.
-    Vertical,
-    /// The yaw channel.
-    Yaw,
-}
 
 /// A scalar comparison operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -39,82 +24,6 @@ pub enum Comparison {
     AbsoluteLessOrEqual,
     /// The absolute signal is greater than or equal to the limit.
     AbsoluteGreaterOrEqual,
-}
-
-/// A source of one scalar sample signal.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SignalSource {
-    /// An axis in the raw input report.
-    RawInputAxis,
-    /// A normalized control axis.
-    NormalizedControl,
-    /// A scalar in the typed intent.
-    TypedIntent,
-    /// A scalar in the adapter demand.
-    AdapterDemand,
-    /// A scalar in the transmitted setpoint.
-    TransmittedSetpoint,
-    /// An estimated position component.
-    EstimatePosition,
-    /// An estimated velocity component.
-    EstimateVelocity,
-    /// An estimated acceleration component.
-    EstimateAcceleration,
-    /// An estimated attitude component.
-    EstimateAttitude,
-    /// An estimated body rate component.
-    EstimateBodyRate,
-    /// A truth position component.
-    TruthPosition,
-    /// A truth velocity component.
-    TruthVelocity,
-    /// A truth acceleration component.
-    TruthAcceleration,
-    /// A truth attitude component.
-    TruthAttitude,
-    /// A truth body rate component.
-    TruthBodyRate,
-    /// An actuator value.
-    Actuator,
-    /// A named environmental condition value.
-    ConditionValue,
-}
-
-impl SignalSource {
-    const fn component_count(self) -> usize {
-        match self {
-            Self::RawInputAxis => crate::MAX_RAW_AXES,
-            Self::NormalizedControl => 4,
-            Self::TypedIntent | Self::AdapterDemand | Self::TransmittedSetpoint => 8,
-            Self::EstimateAttitude | Self::TruthAttitude => 4,
-            Self::Actuator => crate::MAX_ACTUATOR_VALUES,
-            Self::ConditionValue => MAX_CONDITION_VALUES,
-            _ => 3,
-        }
-    }
-
-    const fn required_capability(self) -> Option<BackendCapability> {
-        match self {
-            Self::TruthPosition
-            | Self::TruthVelocity
-            | Self::TruthAcceleration
-            | Self::TruthAttitude
-            | Self::TruthBodyRate => Some(BackendCapability::KinematicTruth),
-            Self::ConditionValue => Some(BackendCapability::ConditionControl),
-            _ => None,
-        }
-    }
-}
-
-/// A selector for one scalar in a trial sample.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SignalSelector {
-    /// The signal source.
-    pub source: SignalSource,
-    /// The zero-based component index.
-    pub component: u16,
 }
 
 /// A condition for phase entry, exit, or abort.
@@ -364,32 +273,22 @@ fn validate_condition_list(
     )?;
     for (index, condition) in conditions.iter().enumerate() {
         if let PhaseCondition::Signal {
-            selector, value, ..
+            selector,
+            comparison,
+            value,
         } = condition
         {
-            validate_selector(field, name, index, selector)?;
-            finite(&format!("{field}.{name}[{index}].value"), *value)?;
+            selector.validate(&format!("{field}.{name}[{index}].selector"))?;
+            let value_field = format!("{field}.{name}[{index}].value");
+            match comparison {
+                Comparison::AbsoluteLessOrEqual | Comparison::AbsoluteGreaterOrEqual => {
+                    range(&value_field, *value, 0.0, f64::MAX)?;
+                }
+                _ => finite(&value_field, *value)?,
+            }
         }
     }
     Ok(())
-}
-
-fn validate_selector(
-    field: &str,
-    name: &str,
-    index: usize,
-    selector: &SignalSelector,
-) -> Result<(), ValidationError> {
-    let limit = selector.source.component_count();
-    if usize::from(selector.component) < limit {
-        return Ok(());
-    }
-    Err(ValidationError::OutOfRange {
-        field: format!("{field}.{name}[{index}].selector.component"),
-        actual: f64::from(selector.component),
-        minimum: 0.0,
-        maximum: (limit.saturating_sub(1)) as f64,
-    })
 }
 
 const fn action_capability(action: &PhaseAction) -> Option<BackendCapability> {
@@ -410,7 +309,7 @@ const fn condition_capability(condition: &PhaseCondition) -> Option<BackendCapab
             Some(BackendCapability::ContactState)
         }
         PhaseCondition::SimulatorTime { .. } => Some(BackendCapability::SimulatorTime),
-        PhaseCondition::Signal { selector, .. } => selector.source.required_capability(),
+        PhaseCondition::Signal { selector, .. } => selector.required_capability(),
         _ => None,
     }
 }

--- a/crates/pilotage-trial/src/scenario/phase.rs
+++ b/crates/pilotage-trial/src/scenario/phase.rs
@@ -6,7 +6,7 @@ use super::{BackendCapability, Waveform};
 use crate::{
     ArtifactIdentity, MAX_CAPABILITIES, MAX_CONDITION_VALUES, MAX_PHASE_CONDITIONS, MAX_TEXT_BYTES,
     ValidationError,
-    validation::{count, duration, finite, text, unique},
+    validation::{count, duration, finite, range, text, unique},
 };
 
 /// A control channel for a stimulus.
@@ -182,7 +182,10 @@ pub enum PhaseAction {
     /// Arm the vehicle.
     Arm,
     /// Move the vehicle to the test start state.
-    ReachStartState,
+    ReachStartState {
+        /// The target state relative to the reset observation.
+        target: StartState,
+    },
     /// Hold the start state before the stimulus.
     Settle,
     /// Apply one control stimulus.
@@ -254,6 +257,7 @@ impl Phase {
             PhaseAction::ApplyConditions { condition_set } => {
                 condition_set.validate(&format!("{field}.action.condition_set"))
             }
+            PhaseAction::ReachStartState { target } => target.validate(field),
             PhaseAction::Stimulus { waveform, .. } => {
                 waveform.validate(&format!("{field}.action.waveform"))
             }
@@ -291,6 +295,60 @@ impl Phase {
             phase: self.id.clone(),
             capability: format!("{} (not declared in {field})", capability.as_str()),
         })
+    }
+}
+
+/// A test start state relative to the first observation after reset.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StartState {
+    /// The north-east-down position offset in meters.
+    pub relative_position_ned_m: [f64; 3],
+    /// The target heading.
+    pub heading: StartHeading,
+}
+
+/// The heading reference for a test start state.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum StartHeading {
+    /// Add an offset to the first heading after reset.
+    ResetOffset {
+        /// The clockwise heading offset in radians.
+        radians: f64,
+    },
+    /// Use a true heading clockwise from north.
+    True {
+        /// The true heading in radians.
+        radians: f64,
+    },
+}
+
+impl StartState {
+    fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        for (index, value) in self.relative_position_ned_m.iter().enumerate() {
+            range(
+                &format!("{field}.action.target.relative_position_ned_m[{index}]"),
+                *value,
+                -1_000.0,
+                1_000.0,
+            )?;
+        }
+        self.heading.validate(field)
+    }
+}
+
+impl StartHeading {
+    fn validate(self, field: &str) -> Result<(), ValidationError> {
+        let radians = match self {
+            Self::ResetOffset { radians } | Self::True { radians } => radians,
+        };
+        range(
+            &format!("{field}.action.target.heading.radians"),
+            radians,
+            -core::f64::consts::PI,
+            core::f64::consts::PI,
+        )
     }
 }
 
@@ -340,6 +398,7 @@ const fn action_capability(action: &PhaseAction) -> Option<BackendCapability> {
         PhaseAction::WaitReady => Some(BackendCapability::LifecycleState),
         PhaseAction::ApplyConditions { .. } => Some(BackendCapability::ConditionControl),
         PhaseAction::Arm | PhaseAction::Disarm => Some(BackendCapability::ArmDisarm),
+        PhaseAction::ReachStartState { .. } => Some(BackendCapability::KinematicTruth),
         _ => None,
     }
 }

--- a/crates/pilotage-trial/src/scenario/selector.rs
+++ b/crates/pilotage-trial/src/scenario/selector.rs
@@ -1,9 +1,16 @@
 //! Exact scalar selectors for scenario conditions.
 
+mod error;
+
 use serde::{Deserialize, Serialize};
 
 use super::BackendCapability;
-use crate::{MAX_ACTUATOR_VALUES, MAX_RAW_AXES, MAX_TEXT_BYTES, ValidationError, validation::text};
+use crate::{
+    ControlValue, MAX_ACTUATOR_VALUES, MAX_RAW_AXES, MAX_TEXT_BYTES, ReferenceFrame,
+    ValidationError, validation::text,
+};
+
+pub use error::SignalSelectionError;
 
 /// A control channel for a stimulus or normalized input.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -58,23 +65,50 @@ pub enum ControlValueField {
     /// The yaw field of an axes value.
     AxisYaw,
     /// The first linear field of a velocity value.
-    VelocityX,
+    VelocityX {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The second linear field of a velocity value.
-    VelocityY,
+    VelocityY {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The third linear field of a velocity value.
-    VelocityZ,
+    VelocityZ {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The yaw-rate field of a velocity value.
-    VelocityYawRate,
+    VelocityYawRate {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The scalar field of an attitude-thrust quaternion.
-    AttitudeW,
+    AttitudeW {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The first vector field of an attitude-thrust quaternion.
-    AttitudeX,
+    AttitudeX {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The second vector field of an attitude-thrust quaternion.
-    AttitudeY,
+    AttitudeY {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The third vector field of an attitude-thrust quaternion.
-    AttitudeZ,
+    AttitudeZ {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The thrust field of an attitude-thrust value.
-    AttitudeThrust,
+    AttitudeThrust {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The first rate field of a body-rate-thrust value.
     BodyRateX,
     /// The second rate field of a body-rate-thrust value.
@@ -84,13 +118,25 @@ pub enum ControlValueField {
     /// The thrust field of a body-rate-thrust value.
     BodyRateThrust,
     /// The first position field of a position-yaw value.
-    PositionX,
+    PositionX {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The second position field of a position-yaw value.
-    PositionY,
+    PositionY {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The third position field of a position-yaw value.
-    PositionZ,
+    PositionZ {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// The yaw field of a position-yaw value.
-    PositionYaw,
+    PositionYaw {
+        /// The reference frame that the value must use.
+        expected_frame: ReferenceFrame,
+    },
     /// One field of a scalar-channel value.
     ScalarChannel {
         /// The zero-based scalar-channel index.
@@ -220,6 +266,173 @@ impl SignalSelector {
 }
 
 impl ControlValueField {
+    /// Selects this scalar from one tagged control value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value has a different variant or reference
+    /// frame. It also returns an error if a scalar channel is not present.
+    pub fn select(&self, value: &ControlValue) -> Result<f64, SignalSelectionError> {
+        self.validate_runtime_shape(value)?;
+        match (self, value) {
+            (Self::AxisRoll, ControlValue::Axes { axes }) => Ok(axes.roll),
+            (Self::AxisPitch, ControlValue::Axes { axes }) => Ok(axes.pitch),
+            (Self::AxisVertical, ControlValue::Axes { axes }) => Ok(axes.vertical),
+            (Self::AxisYaw, ControlValue::Axes { axes }) => Ok(axes.yaw),
+            (Self::VelocityX { .. }, ControlValue::Velocity { linear_mps, .. }) => Ok(linear_mps.x),
+            (Self::VelocityY { .. }, ControlValue::Velocity { linear_mps, .. }) => Ok(linear_mps.y),
+            (Self::VelocityZ { .. }, ControlValue::Velocity { linear_mps, .. }) => Ok(linear_mps.z),
+            (Self::VelocityYawRate { .. }, ControlValue::Velocity { yaw_rate_rad_s, .. }) => {
+                Ok(*yaw_rate_rad_s)
+            }
+            (Self::AttitudeW { .. }, ControlValue::AttitudeThrust { attitude, .. }) => {
+                Ok(attitude.w)
+            }
+            (Self::AttitudeX { .. }, ControlValue::AttitudeThrust { attitude, .. }) => {
+                Ok(attitude.x)
+            }
+            (Self::AttitudeY { .. }, ControlValue::AttitudeThrust { attitude, .. }) => {
+                Ok(attitude.y)
+            }
+            (Self::AttitudeZ { .. }, ControlValue::AttitudeThrust { attitude, .. }) => {
+                Ok(attitude.z)
+            }
+            (Self::AttitudeThrust { .. }, ControlValue::AttitudeThrust { thrust, .. }) => {
+                Ok(*thrust)
+            }
+            (
+                Self::BodyRateX,
+                ControlValue::BodyRateThrust {
+                    body_rates_rad_s, ..
+                },
+            ) => Ok(body_rates_rad_s.x),
+            (
+                Self::BodyRateY,
+                ControlValue::BodyRateThrust {
+                    body_rates_rad_s, ..
+                },
+            ) => Ok(body_rates_rad_s.y),
+            (
+                Self::BodyRateZ,
+                ControlValue::BodyRateThrust {
+                    body_rates_rad_s, ..
+                },
+            ) => Ok(body_rates_rad_s.z),
+            (Self::BodyRateThrust, ControlValue::BodyRateThrust { thrust, .. }) => Ok(*thrust),
+            (Self::PositionX { .. }, ControlValue::PositionYaw { position_m, .. }) => {
+                Ok(position_m.x)
+            }
+            (Self::PositionY { .. }, ControlValue::PositionYaw { position_m, .. }) => {
+                Ok(position_m.y)
+            }
+            (Self::PositionZ { .. }, ControlValue::PositionYaw { position_m, .. }) => {
+                Ok(position_m.z)
+            }
+            (Self::PositionYaw { .. }, ControlValue::PositionYaw { yaw_rad, .. }) => Ok(*yaw_rad),
+            (Self::ScalarChannel { index }, ControlValue::ScalarChannels { values }) => values
+                .get(usize::from(*index))
+                .copied()
+                .ok_or(SignalSelectionError::ScalarChannelUnavailable {
+                    index: *index,
+                    count: values.len(),
+                }),
+            _ => Err(self.variant_mismatch(value)),
+        }
+    }
+
+    fn validate_runtime_shape(&self, value: &ControlValue) -> Result<(), SignalSelectionError> {
+        if self.expected_variant() != control_value_variant(value) {
+            return Err(self.variant_mismatch(value));
+        }
+        if let (Some(expected), Some(actual)) = (self.expected_frame(), control_value_frame(value))
+            && expected != actual
+        {
+            return Err(SignalSelectionError::ReferenceFrameMismatch {
+                selector: self.name(),
+                expected: reference_frame_name(expected),
+                actual: reference_frame_name(actual),
+            });
+        }
+        Ok(())
+    }
+
+    fn variant_mismatch(&self, value: &ControlValue) -> SignalSelectionError {
+        SignalSelectionError::ControlValueVariantMismatch {
+            selector: self.name(),
+            expected: self.expected_variant(),
+            actual: control_value_variant(value),
+        }
+    }
+
+    const fn expected_variant(&self) -> &'static str {
+        match self {
+            Self::AxisRoll | Self::AxisPitch | Self::AxisVertical | Self::AxisYaw => "axes",
+            Self::VelocityX { .. }
+            | Self::VelocityY { .. }
+            | Self::VelocityZ { .. }
+            | Self::VelocityYawRate { .. } => "velocity",
+            Self::AttitudeW { .. }
+            | Self::AttitudeX { .. }
+            | Self::AttitudeY { .. }
+            | Self::AttitudeZ { .. }
+            | Self::AttitudeThrust { .. } => "attitude_thrust",
+            Self::BodyRateX | Self::BodyRateY | Self::BodyRateZ | Self::BodyRateThrust => {
+                "body_rate_thrust"
+            }
+            Self::PositionX { .. }
+            | Self::PositionY { .. }
+            | Self::PositionZ { .. }
+            | Self::PositionYaw { .. } => "position_yaw",
+            Self::ScalarChannel { .. } => "scalar_channels",
+        }
+    }
+
+    const fn expected_frame(&self) -> Option<ReferenceFrame> {
+        match self {
+            Self::VelocityX { expected_frame }
+            | Self::VelocityY { expected_frame }
+            | Self::VelocityZ { expected_frame }
+            | Self::VelocityYawRate { expected_frame }
+            | Self::AttitudeW { expected_frame }
+            | Self::AttitudeX { expected_frame }
+            | Self::AttitudeY { expected_frame }
+            | Self::AttitudeZ { expected_frame }
+            | Self::AttitudeThrust { expected_frame }
+            | Self::PositionX { expected_frame }
+            | Self::PositionY { expected_frame }
+            | Self::PositionZ { expected_frame }
+            | Self::PositionYaw { expected_frame } => Some(*expected_frame),
+            _ => None,
+        }
+    }
+
+    const fn name(&self) -> &'static str {
+        match self {
+            Self::AxisRoll => "axis_roll",
+            Self::AxisPitch => "axis_pitch",
+            Self::AxisVertical => "axis_vertical",
+            Self::AxisYaw => "axis_yaw",
+            Self::VelocityX { .. } => "velocity_x",
+            Self::VelocityY { .. } => "velocity_y",
+            Self::VelocityZ { .. } => "velocity_z",
+            Self::VelocityYawRate { .. } => "velocity_yaw_rate",
+            Self::AttitudeW { .. } => "attitude_w",
+            Self::AttitudeX { .. } => "attitude_x",
+            Self::AttitudeY { .. } => "attitude_y",
+            Self::AttitudeZ { .. } => "attitude_z",
+            Self::AttitudeThrust { .. } => "attitude_thrust",
+            Self::BodyRateX => "body_rate_x",
+            Self::BodyRateY => "body_rate_y",
+            Self::BodyRateZ => "body_rate_z",
+            Self::BodyRateThrust => "body_rate_thrust",
+            Self::PositionX { .. } => "position_x",
+            Self::PositionY { .. } => "position_y",
+            Self::PositionZ { .. } => "position_z",
+            Self::PositionYaw { .. } => "position_yaw",
+            Self::ScalarChannel { .. } => "scalar_channel",
+        }
+    }
+
     fn validate(self, field: &str) -> Result<(), ValidationError> {
         match self {
             Self::ScalarChannel { index } => {
@@ -227,6 +440,33 @@ impl ControlValueField {
             }
             _ => Ok(()),
         }
+    }
+}
+
+const fn control_value_variant(value: &ControlValue) -> &'static str {
+    match value {
+        ControlValue::Axes { .. } => "axes",
+        ControlValue::Velocity { .. } => "velocity",
+        ControlValue::AttitudeThrust { .. } => "attitude_thrust",
+        ControlValue::BodyRateThrust { .. } => "body_rate_thrust",
+        ControlValue::PositionYaw { .. } => "position_yaw",
+        ControlValue::ScalarChannels { .. } => "scalar_channels",
+    }
+}
+
+const fn control_value_frame(value: &ControlValue) -> Option<ReferenceFrame> {
+    match value {
+        ControlValue::Velocity { frame, .. }
+        | ControlValue::AttitudeThrust { frame, .. }
+        | ControlValue::PositionYaw { frame, .. } => Some(*frame),
+        _ => None,
+    }
+}
+
+const fn reference_frame_name(frame: ReferenceFrame) -> &'static str {
+    match frame {
+        ReferenceFrame::LocalNed => "local_ned",
+        ReferenceFrame::BodyFrd => "body_frd",
     }
 }
 

--- a/crates/pilotage-trial/src/scenario/selector.rs
+++ b/crates/pilotage-trial/src/scenario/selector.rs
@@ -1,0 +1,243 @@
+//! Exact scalar selectors for scenario conditions.
+
+use serde::{Deserialize, Serialize};
+
+use super::BackendCapability;
+use crate::{MAX_ACTUATOR_VALUES, MAX_RAW_AXES, MAX_TEXT_BYTES, ValidationError, validation::text};
+
+/// A control channel for a stimulus or normalized input.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlChannel {
+    /// The roll channel.
+    Roll,
+    /// The pitch channel.
+    Pitch,
+    /// The vertical channel.
+    Vertical,
+    /// The yaw channel.
+    Yaw,
+}
+
+/// A component of a three-value vector.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VectorComponent {
+    /// The first component.
+    X,
+    /// The second component.
+    Y,
+    /// The third component.
+    Z,
+}
+
+/// A component of a quaternion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuaternionComponent {
+    /// The scalar component.
+    W,
+    /// The first vector component.
+    X,
+    /// The second vector component.
+    Y,
+    /// The third vector component.
+    Z,
+}
+
+/// One exact field of a tagged control value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ControlValueField {
+    /// The roll field of an axes value.
+    AxisRoll,
+    /// The pitch field of an axes value.
+    AxisPitch,
+    /// The vertical field of an axes value.
+    AxisVertical,
+    /// The yaw field of an axes value.
+    AxisYaw,
+    /// The first linear field of a velocity value.
+    VelocityX,
+    /// The second linear field of a velocity value.
+    VelocityY,
+    /// The third linear field of a velocity value.
+    VelocityZ,
+    /// The yaw-rate field of a velocity value.
+    VelocityYawRate,
+    /// The scalar field of an attitude-thrust quaternion.
+    AttitudeW,
+    /// The first vector field of an attitude-thrust quaternion.
+    AttitudeX,
+    /// The second vector field of an attitude-thrust quaternion.
+    AttitudeY,
+    /// The third vector field of an attitude-thrust quaternion.
+    AttitudeZ,
+    /// The thrust field of an attitude-thrust value.
+    AttitudeThrust,
+    /// The first rate field of a body-rate-thrust value.
+    BodyRateX,
+    /// The second rate field of a body-rate-thrust value.
+    BodyRateY,
+    /// The third rate field of a body-rate-thrust value.
+    BodyRateZ,
+    /// The thrust field of a body-rate-thrust value.
+    BodyRateThrust,
+    /// The first position field of a position-yaw value.
+    PositionX,
+    /// The second position field of a position-yaw value.
+    PositionY,
+    /// The third position field of a position-yaw value.
+    PositionZ,
+    /// The yaw field of a position-yaw value.
+    PositionYaw,
+    /// One field of a scalar-channel value.
+    ScalarChannel {
+        /// The zero-based scalar-channel index.
+        index: u16,
+    },
+}
+
+/// A selector for one exact scalar in a trial sample.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SignalSelector {
+    /// One raw input axis.
+    RawInputAxis {
+        /// The zero-based raw axis index.
+        index: u16,
+    },
+    /// One normalized control channel.
+    NormalizedControl {
+        /// The selected channel.
+        channel: ControlChannel,
+    },
+    /// One field of the typed intent.
+    TypedIntent {
+        /// The selected tagged-value field.
+        field: ControlValueField,
+    },
+    /// One field of the adapter demand.
+    AdapterDemand {
+        /// The selected tagged-value field.
+        field: ControlValueField,
+    },
+    /// One field of the transmitted setpoint.
+    TransmittedSetpoint {
+        /// The selected tagged-value field.
+        field: ControlValueField,
+    },
+    /// One estimated position component.
+    EstimatePosition {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One estimated velocity component.
+    EstimateVelocity {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One estimated acceleration component.
+    EstimateAcceleration {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One estimated attitude component.
+    EstimateAttitude {
+        /// The selected quaternion component.
+        component: QuaternionComponent,
+    },
+    /// One estimated body-rate component.
+    EstimateBodyRate {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One truth position component.
+    TruthPosition {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One truth velocity component.
+    TruthVelocity {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One truth acceleration component.
+    TruthAcceleration {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One truth attitude component.
+    TruthAttitude {
+        /// The selected quaternion component.
+        component: QuaternionComponent,
+    },
+    /// One truth body-rate component.
+    TruthBodyRate {
+        /// The selected vector component.
+        component: VectorComponent,
+    },
+    /// One actuator value.
+    Actuator {
+        /// The zero-based actuator index.
+        index: u16,
+    },
+    /// One additional environmental condition value.
+    ConditionValue {
+        /// The exact condition value name.
+        name: String,
+    },
+}
+
+impl SignalSelector {
+    pub(super) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        match self {
+            Self::RawInputAxis { index } => {
+                validate_index(&format!("{field}.index"), *index, MAX_RAW_AXES)
+            }
+            Self::TypedIntent { field: value }
+            | Self::AdapterDemand { field: value }
+            | Self::TransmittedSetpoint { field: value } => value.validate(field),
+            Self::Actuator { index } => {
+                validate_index(&format!("{field}.index"), *index, MAX_ACTUATOR_VALUES)
+            }
+            Self::ConditionValue { name } => text(&format!("{field}.name"), name, MAX_TEXT_BYTES),
+            _ => Ok(()),
+        }
+    }
+
+    pub(super) const fn required_capability(&self) -> Option<BackendCapability> {
+        match self {
+            Self::TruthPosition { .. }
+            | Self::TruthVelocity { .. }
+            | Self::TruthAcceleration { .. }
+            | Self::TruthAttitude { .. }
+            | Self::TruthBodyRate { .. } => Some(BackendCapability::KinematicTruth),
+            Self::ConditionValue { .. } => Some(BackendCapability::ConditionControl),
+            _ => None,
+        }
+    }
+}
+
+impl ControlValueField {
+    fn validate(self, field: &str) -> Result<(), ValidationError> {
+        match self {
+            Self::ScalarChannel { index } => {
+                validate_index(&format!("{field}.field.index"), index, MAX_ACTUATOR_VALUES)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+fn validate_index(field: &str, index: u16, limit: usize) -> Result<(), ValidationError> {
+    if usize::from(index) < limit {
+        return Ok(());
+    }
+    Err(ValidationError::OutOfRange {
+        field: field.to_owned(),
+        actual: f64::from(index),
+        minimum: 0.0,
+        maximum: limit.saturating_sub(1) as f64,
+    })
+}

--- a/crates/pilotage-trial/src/scenario/selector/error.rs
+++ b/crates/pilotage-trial/src/scenario/selector/error.rs
@@ -1,0 +1,36 @@
+//! Runtime scalar selection errors.
+
+use thiserror::Error;
+
+/// An error from selecting a scalar from one trial value.
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum SignalSelectionError {
+    /// The tagged control value has a different variant.
+    #[error("control selector {selector} requires {expected}; found {actual}")]
+    ControlValueVariantMismatch {
+        /// The scalar selector name.
+        selector: &'static str,
+        /// The required control value variant.
+        expected: &'static str,
+        /// The supplied control value variant.
+        actual: &'static str,
+    },
+    /// The control value uses a different reference frame.
+    #[error("control selector {selector} requires frame {expected}; found {actual}")]
+    ReferenceFrameMismatch {
+        /// The scalar selector name.
+        selector: &'static str,
+        /// The required reference frame.
+        expected: &'static str,
+        /// The supplied reference frame.
+        actual: &'static str,
+    },
+    /// The scalar channel is not in the control value.
+    #[error("scalar channel {index} is not in a control value with {count} channels")]
+    ScalarChannelUnavailable {
+        /// The selected channel index.
+        index: u16,
+        /// The available channel count.
+        count: usize,
+    },
+}

--- a/crates/pilotage-trial/src/scenario/tests.rs
+++ b/crates/pilotage-trial/src/scenario/tests.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::expect_used)]
 
 use super::*;
+use crate::MAX_ACTUATOR_VALUES;
 
 fn start_scenario(target: StartState) -> Scenario {
     Scenario {
@@ -33,6 +34,141 @@ fn a_relative_start_state_has_a_bounded_heading() {
     target.heading = StartHeading::True { radians: 4.0 };
     assert!(matches!(
         start_scenario(target).validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+fn condition_scenario(condition: PhaseCondition) -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "condition-validation".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "observe".to_owned(),
+            max_sim_time_ns: 1_000_000_000,
+            required_capabilities: vec![BackendCapability::SimulatorTime],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::Observe,
+            exit_conditions: vec![condition],
+            abort_conditions: Vec::new(),
+        }],
+    }
+}
+
+#[test]
+fn a_control_selector_names_the_tagged_value_field() {
+    let scenario = condition_scenario(PhaseCondition::Signal {
+        selector: SignalSelector::TypedIntent {
+            field: ControlValueField::VelocityYawRate,
+        },
+        comparison: Comparison::LessOrEqual,
+        value: 0.2,
+    });
+
+    let json = scenario.to_canonical_json().expect("scenario JSON");
+    let decoded = Scenario::from_json(&json).expect("scenario parse");
+    assert_eq!(decoded, scenario);
+}
+
+#[test]
+fn a_condition_selector_uses_a_stable_name() {
+    let mut scenario = condition_scenario(PhaseCondition::Signal {
+        selector: SignalSelector::ConditionValue {
+            name: "gust_phase".to_owned(),
+        },
+        comparison: Comparison::GreaterOrEqual,
+        value: 1.0,
+    });
+    scenario.phases[0]
+        .required_capabilities
+        .push(BackendCapability::ConditionControl);
+    assert!(scenario.validate().is_ok());
+
+    if let PhaseCondition::Signal {
+        selector: SignalSelector::ConditionValue { name },
+        ..
+    } = &mut scenario.phases[0].exit_conditions[0]
+    {
+        name.clear();
+    }
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::EmptyText { .. })
+    ));
+}
+
+#[test]
+fn a_scalar_channel_selector_has_a_hard_index_limit() {
+    let scenario = condition_scenario(PhaseCondition::Signal {
+        selector: SignalSelector::AdapterDemand {
+            field: ControlValueField::ScalarChannel {
+                index: MAX_ACTUATOR_VALUES as u16,
+            },
+        },
+        comparison: Comparison::LessOrEqual,
+        value: 0.0,
+    });
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn an_absolute_comparison_rejects_a_negative_threshold() {
+    let scenario = condition_scenario(PhaseCondition::Signal {
+        selector: SignalSelector::NormalizedControl {
+            channel: ControlChannel::Roll,
+        },
+        comparison: Comparison::AbsoluteLessOrEqual,
+        value: -0.1,
+    });
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}
+
+#[test]
+fn a_multisine_rejects_an_excessive_composed_envelope() {
+    let waveform = Waveform::Multisine {
+        bias: 0.5,
+        components: vec![
+            SineComponent {
+                amplitude: 0.4,
+                frequency_hz: 1.0,
+                phase_rad: 0.0,
+            },
+            SineComponent {
+                amplitude: -0.2,
+                frequency_hz: 2.0,
+                phase_rad: 0.0,
+            },
+        ],
+        duration_ns: 1_000_000_000,
+    };
+    let scenario = Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "bounded-multisine".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "stimulus".to_owned(),
+            max_sim_time_ns: 1_000_000_000,
+            required_capabilities: vec![BackendCapability::SimulatorTime],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::Stimulus {
+                channel: ControlChannel::Roll,
+                waveform,
+            },
+            exit_conditions: vec![PhaseCondition::Always],
+            abort_conditions: Vec::new(),
+        }],
+    };
+
+    assert!(matches!(
+        scenario.validate(),
         Err(ValidationError::OutOfRange { .. })
     ));
 }

--- a/crates/pilotage-trial/src/scenario/tests.rs
+++ b/crates/pilotage-trial/src/scenario/tests.rs
@@ -1,0 +1,38 @@
+#![allow(clippy::expect_used)]
+
+use super::*;
+
+fn start_scenario(target: StartState) -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "relative-start".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "reach-start".to_owned(),
+            max_sim_time_ns: 5_000_000_000,
+            required_capabilities: vec![
+                BackendCapability::SimulatorTime,
+                BackendCapability::KinematicTruth,
+            ],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::ReachStartState { target },
+            exit_conditions: vec![PhaseCondition::Always],
+            abort_conditions: vec![],
+        }],
+    }
+}
+
+#[test]
+fn a_relative_start_state_has_a_bounded_heading() {
+    let mut target = StartState {
+        relative_position_ned_m: [0.0, 0.0, -5.0],
+        heading: StartHeading::ResetOffset { radians: 0.0 },
+    };
+    assert!(start_scenario(target).validate().is_ok());
+
+    target.heading = StartHeading::True { radians: 4.0 };
+    assert!(matches!(
+        start_scenario(target).validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}

--- a/crates/pilotage-trial/src/scenario/tests.rs
+++ b/crates/pilotage-trial/src/scenario/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::expect_used)]
 
 use super::*;
-use crate::MAX_ACTUATOR_VALUES;
+use crate::{ControlValue, MAX_ACTUATOR_VALUES, ReferenceFrame, Vector3};
 
 fn start_scenario(target: StartState) -> Scenario {
     Scenario {
@@ -56,10 +56,12 @@ fn condition_scenario(condition: PhaseCondition) -> Scenario {
 }
 
 #[test]
-fn a_control_selector_names_the_tagged_value_field() {
+fn a_control_selector_names_the_tagged_value_field_and_frame() {
     let scenario = condition_scenario(PhaseCondition::Signal {
         selector: SignalSelector::TypedIntent {
-            field: ControlValueField::VelocityYawRate,
+            field: ControlValueField::VelocityYawRate {
+                expected_frame: ReferenceFrame::BodyFrd,
+            },
         },
         comparison: Comparison::LessOrEqual,
         value: 0.2,
@@ -68,6 +70,82 @@ fn a_control_selector_names_the_tagged_value_field() {
     let json = scenario.to_canonical_json().expect("scenario JSON");
     let decoded = Scenario::from_json(&json).expect("scenario parse");
     assert_eq!(decoded, scenario);
+
+    let mut document: serde_json::Value = serde_json::from_slice(&json).expect("JSON value");
+    let field = &mut document["phases"][0]["exit_conditions"][0]["selector"]["field"];
+    assert_eq!(field["expected_frame"], "body_frd");
+    field
+        .as_object_mut()
+        .expect("control value field")
+        .remove("expected_frame");
+    let missing_frame = serde_json::to_vec(&document).expect("missing-frame JSON");
+    assert!(Scenario::from_json(&missing_frame).is_err());
+}
+
+#[test]
+fn a_control_selector_rejects_a_different_reference_frame() {
+    let selector = ControlValueField::VelocityX {
+        expected_frame: ReferenceFrame::BodyFrd,
+    };
+    let body_value = velocity_value(ReferenceFrame::BodyFrd);
+    let local_value = velocity_value(ReferenceFrame::LocalNed);
+
+    assert_eq!(selector.select(&body_value), Ok(1.0));
+    assert!(matches!(
+        selector.select(&local_value),
+        Err(SignalSelectionError::ReferenceFrameMismatch {
+            expected: "body_frd",
+            actual: "local_ned",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_control_selector_rejects_a_different_value_variant() {
+    let selector = ControlValueField::AttitudeThrust {
+        expected_frame: ReferenceFrame::BodyFrd,
+    };
+    let value = ControlValue::BodyRateThrust {
+        body_rates_rad_s: Vector3 {
+            x: 0.1,
+            y: 0.2,
+            z: 0.3,
+        },
+        thrust: 0.4,
+    };
+
+    assert!(matches!(
+        selector.select(&value),
+        Err(SignalSelectionError::ControlValueVariantMismatch {
+            expected: "attitude_thrust",
+            actual: "body_rate_thrust",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_control_selector_rejects_an_unavailable_scalar_channel() {
+    let selector = ControlValueField::ScalarChannel { index: 1 };
+    let value = ControlValue::ScalarChannels { values: vec![0.2] };
+
+    assert_eq!(
+        selector.select(&value),
+        Err(SignalSelectionError::ScalarChannelUnavailable { index: 1, count: 1 })
+    );
+}
+
+fn velocity_value(frame: ReferenceFrame) -> ControlValue {
+    ControlValue::Velocity {
+        frame,
+        linear_mps: Vector3 {
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
+        },
+        yaw_rate_rad_s: 0.4,
+    }
 }
 
 #[test]

--- a/crates/pilotage-trial/src/scenario/waveform.rs
+++ b/crates/pilotage-trial/src/scenario/waveform.rs
@@ -133,7 +133,10 @@ fn validate_multisine(
             component.phase_rad,
         )?;
     }
-    Ok(())
+    let envelope = components.iter().fold(bias.abs(), |total, component| {
+        total + component.amplitude.abs()
+    });
+    range(&format!("{field}.envelope"), envelope, 0.0, 1.0)
 }
 
 fn positive_frequency(field: &str, index: usize, value: f64) -> Result<(), ValidationError> {

--- a/crates/pilotage-trial/src/scenario/waveform.rs
+++ b/crates/pilotage-trial/src/scenario/waveform.rs
@@ -1,0 +1,146 @@
+//! Control stimulus waveforms.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ArtifactIdentity, MAX_WAVE_COMPONENTS, ValidationError,
+    validation::{duration, finite, nonempty_count, range},
+};
+
+/// One component of a multisine waveform.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SineComponent {
+    /// The normalized component amplitude.
+    pub amplitude: f64,
+    /// The component frequency in hertz.
+    pub frequency_hz: f64,
+    /// The component phase in radians.
+    pub phase_rad: f64,
+}
+
+/// A bounded control stimulus.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Waveform {
+    /// Hold one normalized value.
+    Step {
+        /// The normalized value.
+        value: f64,
+    },
+    /// Move between two normalized values.
+    Ramp {
+        /// The first normalized value.
+        from: f64,
+        /// The final normalized value.
+        to: f64,
+        /// The ramp duration in simulator nanoseconds.
+        duration_ns: u64,
+    },
+    /// Hold a normalized value for a fixed duration.
+    Pulse {
+        /// The normalized value.
+        value: f64,
+        /// The pulse duration in simulator nanoseconds.
+        duration_ns: u64,
+    },
+    /// Change from one normalized value to its opposite test value.
+    Reversal {
+        /// The first normalized value.
+        first: f64,
+        /// The second normalized value.
+        second: f64,
+        /// The hold time for each value in simulator nanoseconds.
+        dwell_ns: u64,
+    },
+    /// Combine multiple sine components.
+    Multisine {
+        /// The normalized constant value.
+        bias: f64,
+        /// The sine components.
+        components: Vec<SineComponent>,
+        /// The waveform duration in simulator nanoseconds.
+        duration_ns: u64,
+    },
+    /// Replay an immutable recorded control artifact.
+    Recorded {
+        /// The recorded control artifact identity.
+        source: ArtifactIdentity,
+    },
+}
+
+impl Waveform {
+    pub(crate) fn validate(&self, field: &str) -> Result<(), ValidationError> {
+        match self {
+            Self::Step { value } => normalized(&format!("{field}.value"), *value),
+            Self::Ramp {
+                from,
+                to,
+                duration_ns,
+            } => {
+                normalized(&format!("{field}.from"), *from)?;
+                normalized(&format!("{field}.to"), *to)?;
+                duration(&format!("{field}.duration_ns"), *duration_ns)
+            }
+            Self::Pulse { value, duration_ns } => {
+                normalized(&format!("{field}.value"), *value)?;
+                duration(&format!("{field}.duration_ns"), *duration_ns)
+            }
+            Self::Reversal {
+                first,
+                second,
+                dwell_ns,
+            } => {
+                normalized(&format!("{field}.first"), *first)?;
+                normalized(&format!("{field}.second"), *second)?;
+                duration(&format!("{field}.dwell_ns"), *dwell_ns)
+            }
+            Self::Multisine {
+                bias,
+                components,
+                duration_ns,
+            } => validate_multisine(field, *bias, components, *duration_ns),
+            Self::Recorded { source } => source.validate(&format!("{field}.source")),
+        }
+    }
+}
+
+fn normalized(field: &str, value: f64) -> Result<(), ValidationError> {
+    range(field, value, -1.0, 1.0)
+}
+
+fn validate_multisine(
+    field: &str,
+    bias: f64,
+    components: &[SineComponent],
+    duration_ns: u64,
+) -> Result<(), ValidationError> {
+    normalized(&format!("{field}.bias"), bias)?;
+    nonempty_count(
+        &format!("{field}.components"),
+        components.len(),
+        MAX_WAVE_COMPONENTS,
+    )?;
+    duration(&format!("{field}.duration_ns"), duration_ns)?;
+    for (index, component) in components.iter().enumerate() {
+        normalized(
+            &format!("{field}.components[{index}].amplitude"),
+            component.amplitude,
+        )?;
+        positive_frequency(field, index, component.frequency_hz)?;
+        finite(
+            &format!("{field}.components[{index}].phase_rad"),
+            component.phase_rad,
+        )?;
+    }
+    Ok(())
+}
+
+fn positive_frequency(field: &str, index: usize, value: f64) -> Result<(), ValidationError> {
+    range(
+        &format!("{field}.components[{index}].frequency_hz"),
+        value,
+        f64::MIN_POSITIVE,
+        f64::MAX,
+    )
+}


### PR DESCRIPTION
Refs #447.

This PR adds the simulator-neutral contract for phased control trials. It does not close #447.

## Scope

- Add versioned trial scenario and manifest types.
- Bind each trial to an exact start state.
- Define reset, setup, settle, stimulus, release, observation, and stop phases.
- Define step, ramp, pulse, reversal, multisine, and recorded-input waveforms.
- Require typed capability checks before a run.
- Bind control selectors to exact tagged fields and reference frames.
- Reject negative absolute thresholds and an excessive multisine envelope.
- Keep scenario identity stable across JSON format changes.

## Boundary

This PR does not add a production runner, an X-Plane backend, an Aviate adapter, or a campaign executable. A later #447 PR adds the executable path after #497 lands. Issue #498 moves scenario execution to the simulator-neutral campaign layer before a second simulator is added.

Reversal sign authorization remains in #465. It must land before production qualification runs.

## Local verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- strict missing-documentation and rustdoc-link checks
- `cargo build --release`
- structure, production Rust lint, monotonic counter, Aviate control-feel boundary, X-Plane weather, X-Plane reset, flight-build, Buf, and Indicate compatibility gates

SIM / NOT FOR FLIGHT.