### PR TITLE
Make flight-tune evidence crash-durable (#458)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,21 @@ jobs:
       - name: Aviate control-feel boundary guard
         run: bash scripts/check-aviate-control-feel-boundary.sh
 
+      - name: flight-tune journal storage boundary self-test
+        run: bash scripts/test-check-flight-tune-journal-storage-boundary.sh
+
+      - name: flight-tune journal storage boundary
+        run: bash scripts/check-flight-tune-journal-storage-boundary.sh
+
       - name: cargo test
         run: cargo test --all-targets
+
+      - name: durable storage non-Unix contract and consumer
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: |
+          cargo check -p pilotage-durable-storage --tests --target wasm32-unknown-unknown
+          cargo check -p flight-tune --target wasm32-unknown-unknown
 
       - name: SituationView conformance corpus
         run: cargo test -p pilotage-situation-view --test corpus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
 name = "flight-tune"
 version = "0.1.0"
 dependencies = [
+ "pilotage-durable-storage",
  "pilotage-flight-quality",
  "pilotage-trial",
  "serde",
@@ -1843,6 +1844,16 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "pilotage-durable-storage"
+version = "0.1.0"
+dependencies = [
+ "rustix",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/pilotage-trial",
     "crates/pilotage-control-feel",
     "crates/pilotage-flight-quality",
+    "crates/pilotage-durable-storage",
     "adapters/reference-headless",
     "adapters/aviate",
     "adapters/px4",
@@ -105,6 +106,7 @@ wtransport = "0.7.1"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 sha2 = "0.10.9"
+rustix = { version = "=1.1.4", features = ["fs"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 uniffi = "0.32"
 pilotage-timing = { path = "crates/pilotage-timing" }
@@ -135,6 +137,7 @@ pilotage-presentation = { path = "crates/pilotage-presentation" }
 pilotage-trial = { path = "crates/pilotage-trial" }
 pilotage-control-feel = { path = "crates/pilotage-control-feel" }
 pilotage-flight-quality = { path = "crates/pilotage-flight-quality" }
+pilotage-durable-storage = { path = "crates/pilotage-durable-storage" }
 pilotage-terrain-query = { path = "crates/pilotage-terrain-query" }
 
 [workspace.lints.rust]

--- a/crates/pilotage-durable-storage/Cargo.toml
+++ b/crates/pilotage-durable-storage/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pilotage-durable-storage"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[features]
+default = []
+fault-injection = []
+
+[dependencies]
+sha2.workspace = true
+thiserror.workspace = true
+
+[target.'cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))'.dependencies]
+rustix.workspace = true
+
+[dev-dependencies]
+tempfile = "3.23.0"
+
+[lints]
+workspace = true

--- a/crates/pilotage-durable-storage/src/error.rs
+++ b/crates/pilotage-durable-storage/src/error.rs
@@ -1,0 +1,299 @@
+use std::ffi::OsStr;
+use std::io;
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+use std::path::Path;
+
+use thiserror::Error;
+
+#[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+use crate::{ContentDigest, DurabilityStep, StorageOperation};
+use crate::{ObjectIdentity, RootIdentity, StorageContext};
+
+/// A result from durable storage.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// An error from a guarded compare-and-swap operation.
+#[derive(Debug, Error)]
+pub enum CompareExchangeError<E> {
+    /// Durable storage rejected or could not complete the operation.
+    #[error("{source}")]
+    Storage {
+        /// Durable-storage failure.
+        #[source]
+        source: StorageError,
+    },
+    /// The caller rejected authorization before the rename.
+    #[error("compare-and-swap validation rejected authorization: {source}")]
+    Validation {
+        /// Caller validation failure.
+        #[source]
+        source: E,
+    },
+    /// Caller validation and temporary cleanup both failed.
+    #[error(
+        "compare-and-swap validation and temporary cleanup failed: validation={validation}; cleanup={cleanup}"
+    )]
+    ValidationAndCleanup {
+        /// Caller validation failure.
+        validation: E,
+        /// Durable-storage cleanup failure.
+        #[source]
+        cleanup: StorageError,
+    },
+}
+
+impl<E> CompareExchangeError<E> {
+    pub(crate) const fn storage(source: StorageError) -> Self {
+        Self::Storage { source }
+    }
+}
+
+impl<E> From<StorageError> for CompareExchangeError<E> {
+    fn from(source: StorageError) -> Self {
+        Self::storage(source)
+    }
+}
+
+/// A fail-closed durable-storage error.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// The target platform cannot supply the storage contract.
+    #[error("durable storage is not supported on this platform: {context:?}")]
+    UnsupportedPlatform {
+        /// Available operation context.
+        context: StorageContext,
+    },
+    /// A caller supplied more or less than one normal component.
+    #[error("invalid object name {name:?}: {context:?}")]
+    InvalidObjectName {
+        /// Lossless operating-system name when available.
+        name: Box<OsStr>,
+        /// Available operation context.
+        context: StorageContext,
+    },
+    /// An operating-system operation failed.
+    #[error("storage I/O failed: {context:?}")]
+    Io {
+        /// Exact boundary that failed.
+        context: StorageContext,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
+    /// A name identifies an unsupported object type.
+    #[error("managed object has the wrong type: {context:?}")]
+    WrongType {
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// A managed object has permissions other than the required exact mode.
+    #[error("managed object mode {actual:#o} is not {required:#o}: {context:?}")]
+    WrongMode {
+        /// Required permission bits.
+        required: u32,
+        /// Observed permission bits.
+        actual: u32,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// A regular managed object has an unsafe link count.
+    #[error("managed file link count {actual} is not one: {context:?}")]
+    LinkedObject {
+        /// Observed link count.
+        actual: u64,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// Exact object bytes do not match the required value.
+    #[error("managed object bytes do not match: {context:?}")]
+    ContentMismatch {
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// A file is larger than the caller's read limit.
+    #[error("managed object size {actual} exceeds limit {limit}: {context:?}")]
+    ObjectTooLarge {
+        /// Caller limit in bytes.
+        limit: usize,
+        /// Observed size in bytes.
+        actual: u64,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// The root path no longer identifies the held root.
+    #[error("storage root changed from {expected:?} to {actual:?}: {context:?}")]
+    RootChanged {
+        /// Held root identity.
+        expected: RootIdentity,
+        /// Current name identity, if the name exists.
+        actual: Option<RootIdentity>,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// A descendant name no longer identifies its held object.
+    #[error("managed object changed from {expected:?} to {actual:?}: {context:?}")]
+    IdentityChanged {
+        /// Held object identity.
+        expected: ObjectIdentity,
+        /// Current name identity, if the name exists.
+        actual: Option<ObjectIdentity>,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// Another process holds the writer lease.
+    #[error("another writer holds the storage lease: {context:?}")]
+    WriterConflict {
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// The mutable object does not equal the caller's expected value.
+    #[error("compare-and-swap expected value is stale: {context:?}")]
+    StaleExpected {
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// Readback and the second barrier cannot resolve a commit result.
+    #[error("storage commit result is ambiguous: {context:?}")]
+    AmbiguousCommit {
+        /// Exact recovery boundary that failed.
+        context: StorageContext,
+        /// The first failed durability boundary, when recovery also failed.
+        prior: Option<Box<StorageError>>,
+        /// Failure from the unresolved recovery boundary.
+        #[source]
+        source: Box<StorageError>,
+    },
+    /// A non-cooperating change or invalid managed relationship was found.
+    #[error("managed storage is corrupt: {reason}: {context:?}")]
+    Corruption {
+        /// Stable description of the failed invariant.
+        reason: &'static str,
+        /// Exact boundary that failed.
+        context: StorageContext,
+    },
+    /// A test fault fired at a real storage boundary.
+    #[error("injected storage fault: {context:?}")]
+    InjectedFault {
+        /// Exact boundary where the fault fired.
+        context: StorageContext,
+    },
+    /// The shared fault controller was poisoned.
+    #[error("fault controller is poisoned: {context:?}")]
+    FaultControllerPoisoned {
+        /// Exact boundary requested by the caller.
+        context: StorageContext,
+    },
+}
+
+impl StorageError {
+    /// Get the available structured context.
+    #[must_use]
+    pub const fn context(&self) -> &StorageContext {
+        match self {
+            Self::UnsupportedPlatform { context }
+            | Self::InvalidObjectName { context, .. }
+            | Self::Io { context, .. }
+            | Self::WrongType { context }
+            | Self::WrongMode { context, .. }
+            | Self::LinkedObject { context, .. }
+            | Self::ContentMismatch { context }
+            | Self::ObjectTooLarge { context, .. }
+            | Self::RootChanged { context, .. }
+            | Self::IdentityChanged { context, .. }
+            | Self::WriterConflict { context }
+            | Self::StaleExpected { context }
+            | Self::AmbiguousCommit { context, .. }
+            | Self::Corruption { context, .. }
+            | Self::InjectedFault { context }
+            | Self::FaultControllerPoisoned { context } => context,
+        }
+    }
+
+    /// Report whether authorization must stop after this error.
+    #[must_use]
+    pub const fn poisons_authorization(&self) -> bool {
+        matches!(
+            self,
+            Self::AmbiguousCommit { .. }
+                | Self::StaleExpected { .. }
+                | Self::RootChanged { .. }
+                | Self::IdentityChanged { .. }
+                | Self::WrongType { .. }
+                | Self::WrongMode { .. }
+                | Self::LinkedObject { .. }
+                | Self::ContentMismatch { .. }
+                | Self::Corruption { .. }
+        )
+    }
+
+    /// Report whether another process holds the writer lease.
+    #[must_use]
+    pub const fn is_writer_locked(&self) -> bool {
+        matches!(self, Self::WriterConflict { .. })
+    }
+
+    pub(crate) fn invalid_name(name: &OsStr) -> Self {
+        Self::InvalidObjectName {
+            name: name.into(),
+            context: StorageContext::root_open(),
+        }
+    }
+
+    #[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+    pub(crate) fn invalid_name_at(name: &OsStr, context: &StorageContext) -> Self {
+        Self::InvalidObjectName {
+            name: name.into(),
+            context: context.clone(),
+        }
+    }
+
+    #[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+    pub(crate) fn at_object(
+        mut self,
+        operation: StorageOperation,
+        object: ContentDigest,
+        step: DurabilityStep,
+    ) -> Self {
+        let context = self.context_mut();
+        context.operation = operation;
+        context.object = Some(object);
+        context.step = step;
+        self
+    }
+
+    #[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+    fn context_mut(&mut self) -> &mut StorageContext {
+        match self {
+            Self::UnsupportedPlatform { context }
+            | Self::InvalidObjectName { context, .. }
+            | Self::Io { context, .. }
+            | Self::WrongType { context }
+            | Self::WrongMode { context, .. }
+            | Self::LinkedObject { context, .. }
+            | Self::ContentMismatch { context }
+            | Self::ObjectTooLarge { context, .. }
+            | Self::RootChanged { context, .. }
+            | Self::IdentityChanged { context, .. }
+            | Self::WriterConflict { context }
+            | Self::StaleExpected { context }
+            | Self::AmbiguousCommit { context, .. }
+            | Self::Corruption { context, .. }
+            | Self::InjectedFault { context }
+            | Self::FaultControllerPoisoned { context } => context,
+        }
+    }
+
+    #[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+    pub(crate) fn unsupported() -> Self {
+        Self::UnsupportedPlatform {
+            context: StorageContext::root_open(),
+        }
+    }
+
+    #[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+    pub(crate) fn unsupported_at(path: &Path) -> Self {
+        Self::UnsupportedPlatform {
+            context: StorageContext::root_open_at(path),
+        }
+    }
+}

--- a/crates/pilotage-durable-storage/src/fault.rs
+++ b/crates/pilotage-durable-storage/src/fault.rs
@@ -1,0 +1,191 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use crate::{DurabilityStep, StorageContext, StorageError, StorageOperation, StorageResult};
+
+/// The effect of one injected storage fault.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FaultAction {
+    /// Return an error before the file-system call starts.
+    FailBefore,
+    /// Complete the file-system call and lose its acknowledgement.
+    LoseAckAfter,
+}
+
+/// One typed fault at a numbered real boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FaultRule {
+    operation: StorageOperation,
+    step: DurabilityStep,
+    occurrence: u64,
+    action: FaultAction,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl FaultRule {
+    /// Inject a fault at the first matching boundary.
+    #[must_use]
+    pub const fn once(
+        operation: StorageOperation,
+        step: DurabilityStep,
+        action: FaultAction,
+    ) -> Self {
+        Self::on_occurrence(operation, step, 1, action)
+    }
+
+    /// Inject a fault at a selected one-based matching boundary.
+    #[must_use]
+    pub const fn on_occurrence(
+        operation: StorageOperation,
+        step: DurabilityStep,
+        occurrence: u64,
+        action: FaultAction,
+    ) -> Self {
+        Self {
+            operation,
+            step,
+            occurrence,
+            action,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+struct RuleState {
+    rule: FaultRule,
+    consumed: bool,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestHook(Option<Box<dyn FnOnce() + Send>>);
+
+#[cfg(test)]
+impl std::fmt::Debug for TestHook {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TestHook")
+            .field("armed", &self.0.is_some())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+struct FaultState {
+    observed: BTreeMap<(StorageOperation, DurabilityStep), u64>,
+    rules: Vec<RuleState>,
+    #[cfg(test)]
+    test_hook: TestHook,
+}
+
+/// A shared deterministic controller for real storage boundaries.
+#[derive(Clone, Debug, Default)]
+pub struct FaultController(Arc<Mutex<FaultState>>);
+
+#[cfg_attr(
+    any(
+        not(test),
+        not(any(target_vendor = "apple", target_os = "linux", target_os = "android"))
+    ),
+    allow(dead_code)
+)]
+impl FaultController {
+    /// Make a controller with the specified rules.
+    #[must_use]
+    pub fn new(rules: impl IntoIterator<Item = FaultRule>) -> Self {
+        let rules = rules
+            .into_iter()
+            .map(|rule| RuleState {
+                rule,
+                consumed: false,
+            })
+            .collect();
+        Self(Arc::new(Mutex::new(FaultState {
+            observed: BTreeMap::new(),
+            rules,
+            #[cfg(test)]
+            test_hook: TestHook::default(),
+        })))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_test_hook(&self, hook: impl FnOnce() + Send + 'static) -> StorageResult<()> {
+        let mut state = self.lock(&StorageContext::root_open())?;
+        state.test_hook = TestHook(Some(Box::new(hook)));
+        Ok(())
+    }
+
+    /// Get the number of rules that did not fire.
+    pub fn remaining_rules(&self) -> StorageResult<usize> {
+        let state = self.lock(&StorageContext::root_open())?;
+        Ok(state.rules.iter().filter(|rule| !rule.consumed).count())
+    }
+
+    /// Report whether all rules fired.
+    pub fn is_exhausted(&self) -> StorageResult<bool> {
+        Ok(self.remaining_rules()? == 0)
+    }
+
+    pub(crate) fn before(&self, context: &StorageContext) -> StorageResult<()> {
+        let mut state = self.lock(context)?;
+        let key = (context.operation, context.step);
+        let occurrence = state.observed.entry(key).or_insert(0);
+        *occurrence = occurrence.wrapping_add(1);
+        let occurrence = *occurrence;
+        Self::fire(&mut state, context, occurrence, FaultAction::FailBefore)
+    }
+
+    pub(crate) fn after(&self, context: &StorageContext) -> StorageResult<()> {
+        let mut state = self.lock(context)?;
+        let occurrence = state
+            .observed
+            .get(&(context.operation, context.step))
+            .copied()
+            .unwrap_or(0);
+        Self::fire(&mut state, context, occurrence, FaultAction::LoseAckAfter)
+    }
+
+    fn fire(
+        state: &mut FaultState,
+        context: &StorageContext,
+        occurrence: u64,
+        action: FaultAction,
+    ) -> StorageResult<()> {
+        if let Some(rule) = state.rules.iter_mut().find(|candidate| {
+            !candidate.consumed
+                && candidate.rule.operation == context.operation
+                && candidate.rule.step == context.step
+                && candidate.rule.occurrence == occurrence
+                && candidate.rule.action == action
+        }) {
+            rule.consumed = true;
+            #[cfg(test)]
+            if let Some(hook) = state.test_hook.0.take() {
+                hook();
+            }
+            return Err(StorageError::InjectedFault {
+                context: context.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn lock<'a>(
+        &'a self,
+        context: &StorageContext,
+    ) -> StorageResult<std::sync::MutexGuard<'a, FaultState>> {
+        self.0
+            .lock()
+            .map_err(|_| StorageError::FaultControllerPoisoned {
+                context: context.clone(),
+            })
+    }
+}

--- a/crates/pilotage-durable-storage/src/lib.rs
+++ b/crates/pilotage-durable-storage/src/lib.rs
@@ -1,0 +1,51 @@
+//! Private crash-durable storage with anchored Unix directory handles.
+//!
+//! All cooperating writers must hold the anchored writer lease. A process with
+//! the same user access can write without that lease. The store stops when it
+//! detects such a change. POSIX does not compare file bytes and rename a file
+//! in one operation. A same-user process can change a name after the last
+//! validation. The operating system does not make validation and return one
+//! operation. Isolate the storage root from non-cooperating same-user code.
+
+#![allow(clippy::result_large_err)]
+
+mod error;
+#[cfg(any(
+    test,
+    feature = "fault-injection",
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android"
+))]
+mod fault;
+mod types;
+
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+mod non_unix;
+#[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+mod unix;
+
+pub use error::{CompareExchangeError, StorageError, StorageResult};
+#[cfg(any(test, feature = "fault-injection"))]
+pub use fault::{FaultAction, FaultController, FaultRule};
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+pub use non_unix::{DurableDirectory, DurableStore, WriterLease};
+pub use types::{
+    CasOutcome, ContentDigest, DurabilityStep, ExactObject, ExpectedValue, ObjectIdentity,
+    ObjectInspection, ObjectKind, ObjectName, OwnedTemporary, PrivateTreeLimits,
+    PrivateTreeManifest, PutOutcome, RootIdentity, StorageContext, StorageOperation, digest_bytes,
+};
+#[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+pub use unix::{DurableDirectory, DurableStore, WriterLease};
+
+#[cfg(all(
+    test,
+    any(target_vendor = "apple", target_os = "linux", target_os = "android")
+))]
+mod tests;
+
+#[cfg(all(
+    test,
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android"))
+))]
+mod non_unix_tests;

--- a/crates/pilotage-durable-storage/src/non_unix.rs
+++ b/crates/pilotage-durable-storage/src/non_unix.rs
@@ -1,0 +1,180 @@
+use std::path::Path;
+
+use crate::{
+    CasOutcome, CompareExchangeError, ContentDigest, ExactObject, ExpectedValue, ObjectInspection,
+    ObjectName, OwnedTemporary, PrivateTreeLimits, PrivateTreeManifest, PutOutcome, RootIdentity,
+    StorageError, StorageResult,
+};
+
+/// A storage root that refuses use on an unsupported platform.
+#[derive(Clone, Debug)]
+pub struct DurableStore {
+    _private: (),
+}
+
+/// A storage directory that refuses use on an unsupported platform.
+#[derive(Clone, Debug)]
+pub struct DurableDirectory {
+    _private: (),
+}
+
+/// A writer lease that cannot exist on an unsupported platform.
+#[derive(Debug)]
+pub struct WriterLease {
+    _private: (),
+}
+
+impl DurableStore {
+    /// Refuse a weaker storage implementation.
+    pub fn open_or_create(path: &Path) -> StorageResult<Self> {
+        Err(StorageError::unsupported_at(path))
+    }
+
+    /// Refuse a fault-enabled weaker storage implementation.
+    #[cfg(any(test, feature = "fault-injection"))]
+    pub fn open_or_create_with_faults(
+        path: &Path,
+        _faults: crate::FaultController,
+    ) -> StorageResult<Self> {
+        Err(StorageError::unsupported_at(path))
+    }
+
+    /// Return the unavailable root identity.
+    #[must_use]
+    pub const fn root_identity(&self) -> RootIdentity {
+        RootIdentity {
+            device: 0,
+            inode: 0,
+        }
+    }
+
+    /// Return the unavailable root directory.
+    #[must_use]
+    pub const fn root_directory(&self) -> DurableDirectory {
+        DurableDirectory { _private: () }
+    }
+
+    /// Refuse a writer lease on an unsupported platform.
+    pub fn acquire_writer(&self) -> StorageResult<WriterLease> {
+        Err(StorageError::unsupported())
+    }
+}
+
+impl DurableDirectory {
+    /// Refuse child access on an unsupported platform.
+    pub fn child(&self, _lease: &WriterLease, _name: &ObjectName) -> StorageResult<Self> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse object lookup on an unsupported platform.
+    pub fn exists(&self, _name: &ObjectName) -> StorageResult<bool> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse directory listing on an unsupported platform.
+    pub fn list(&self) -> StorageResult<Vec<ObjectName>> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse object inspection on an unsupported platform.
+    pub fn inspect(&self, _name: &ObjectName) -> StorageResult<ObjectInspection> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse exact reads on an unsupported platform.
+    pub fn read_exact(
+        &self,
+        _name: &ObjectName,
+        _maximum_bytes: usize,
+    ) -> StorageResult<ExactObject> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse digest-bound reads on an unsupported platform.
+    pub fn read_digest(
+        &self,
+        _name: &ObjectName,
+        _expected: ContentDigest,
+        _maximum_bytes: usize,
+    ) -> StorageResult<ExactObject> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse immutable publication on an unsupported platform.
+    pub fn put_immutable_no_replace(
+        &self,
+        _lease: &WriterLease,
+        _name: &ObjectName,
+        _object: &ExactObject,
+    ) -> StorageResult<PutOutcome> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse temporary inspection on an unsupported platform.
+    pub fn inspect_owned_temporary(
+        &self,
+        _name: &ObjectName,
+        _maximum_bytes: usize,
+    ) -> StorageResult<OwnedTemporary> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse private-tree inspection on an unsupported platform.
+    pub fn inspect_private_tree(
+        &self,
+        _name: &ObjectName,
+        _limits: PrivateTreeLimits,
+    ) -> StorageResult<PrivateTreeManifest> {
+        Err(StorageError::unsupported())
+    }
+}
+
+impl WriterLease {
+    /// Refuse writer-lease validation on an unsupported platform.
+    pub fn validate(&self, _directory: &DurableDirectory) -> StorageResult<()> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse compare-and-swap on an unsupported platform.
+    pub fn compare_exchange_file(
+        &self,
+        _directory: &DurableDirectory,
+        _name: &ObjectName,
+        _expected: ExpectedValue,
+        _new: ExactObject,
+    ) -> StorageResult<CasOutcome> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse guarded compare-and-swap on an unsupported platform.
+    pub fn compare_exchange_file_guarded<E>(
+        &self,
+        _directory: &DurableDirectory,
+        _name: &ObjectName,
+        _expected: ExpectedValue,
+        _new: ExactObject,
+        _validate: impl FnOnce() -> Result<(), E>,
+    ) -> Result<CasOutcome, CompareExchangeError<E>> {
+        Err(CompareExchangeError::Storage {
+            source: StorageError::unsupported(),
+        })
+    }
+
+    /// Refuse exact tree removal on an unsupported platform.
+    pub fn remove_private_tree(
+        &self,
+        _directory: &DurableDirectory,
+        _manifest: &PrivateTreeManifest,
+    ) -> StorageResult<()> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse owned temporary cleanup on an unsupported platform.
+    pub fn cleanup_owned_temporary(
+        &self,
+        _directory: &DurableDirectory,
+        _temporary: &OwnedTemporary,
+    ) -> StorageResult<()> {
+        Err(StorageError::unsupported())
+    }
+}

--- a/crates/pilotage-durable-storage/src/non_unix_tests.rs
+++ b/crates/pilotage-durable-storage/src/non_unix_tests.rs
@@ -1,0 +1,11 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use crate::{DurableStore, StorageError};
+
+#[test]
+fn non_unix_store_refuses_a_weaker_contract() {
+    let path = std::path::Path::new("storage");
+    let error = DurableStore::open_or_create(path).expect_err("reject unsupported storage");
+    assert!(matches!(error, StorageError::UnsupportedPlatform { .. }));
+    assert_eq!(error.context().requested_root.as_deref(), Some(path));
+}

--- a/crates/pilotage-durable-storage/src/tests.rs
+++ b/crates/pilotage-durable-storage/src/tests.rs
@@ -1,0 +1,433 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod attacks;
+mod cas;
+mod faults;
+mod lease;
+mod removal_recovery;
+
+use std::error::Error;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use crate::{
+    CasOutcome, CompareExchangeError, DurableStore, ExactObject, ExpectedValue, ObjectName,
+    PrivateTreeLimits, PutOutcome, StorageError, digest_bytes,
+};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+fn fixture() -> Result<(TempDir, PathBuf, DurableStore), Box<dyn Error>> {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-durable-")
+        .tempdir_in(test_parent()?)?;
+    let root = temporary.path().join("store");
+    let store = DurableStore::open_or_create(&root)?;
+    Ok((temporary, root, store))
+}
+
+fn test_parent() -> Result<PathBuf, Box<dyn Error>> {
+    #[cfg(target_vendor = "apple")]
+    {
+        Ok(PathBuf::from("/private/tmp"))
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        Ok(std::env::temp_dir().canonicalize()?)
+    }
+}
+
+fn name(value: &str) -> Result<ObjectName, StorageError> {
+    ObjectName::new(value)
+}
+
+fn tree_limits() -> PrivateTreeLimits {
+    PrivateTreeLimits::new(128, 1024 * 1024, 8 * 1024 * 1024)
+}
+
+#[test]
+fn object_name_accepts_one_non_utf8_component() -> TestResult {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = ObjectName::new(OsStr::from_bytes(b"object-\xff"))?;
+    assert_eq!(name.as_os_str().as_bytes(), b"object-\xff");
+    for invalid in ["", ".", "..", "a/b", "/absolute"] {
+        assert!(matches!(
+            ObjectName::new(invalid),
+            Err(StorageError::InvalidObjectName { .. })
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn root_child_and_files_have_exact_private_modes() -> TestResult {
+    let (_temporary, root, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let child_name = name("objects")?;
+    let child = store.root_directory().child(&lease, &child_name)?;
+    let object_name = name("one")?;
+    let object = ExactObject::from_bytes(b"private".to_vec());
+    assert_eq!(
+        child.put_immutable_no_replace(&lease, &object_name, &object)?,
+        PutOutcome::Published
+    );
+    assert_eq!(
+        std::fs::metadata(&root)?.permissions().mode() & 0o777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::metadata(root.join("objects"))?
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::metadata(root.join("objects/one"))?
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    Ok(())
+}
+
+#[test]
+fn immutable_publication_is_exact_and_idempotent() -> TestResult {
+    let (_temporary, _root, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object_name = name("entry")?;
+    let object = ExactObject::from_bytes(b"complete".to_vec());
+    assert_eq!(
+        root.put_immutable_no_replace(&lease, &object_name, &object)?,
+        PutOutcome::Published
+    );
+    assert_eq!(root.read_exact(&object_name, 8)?, object);
+    assert_eq!(
+        root.put_immutable_no_replace(&lease, &object_name, &object)?,
+        PutOutcome::AlreadyExact
+    );
+    let wrong = ExactObject::from_bytes(b"changed!".to_vec());
+    let error = root
+        .put_immutable_no_replace(&lease, &object_name, &wrong)
+        .expect_err("different bytes must fail");
+    assert!(matches!(error, StorageError::ContentMismatch { .. }));
+    assert!(error.poisons_authorization());
+    Ok(())
+}
+
+#[test]
+fn mutable_and_immutable_destinations_reject_internal_names() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object = ExactObject::from_bytes(b"object".to_vec());
+    for value in [".pilotage-tmp-user", ".pilotage-writer-lock"] {
+        let reserved = name(value)?;
+        let immutable = root
+            .put_immutable_no_replace(&lease, &reserved, &object)
+            .expect_err("an internal immutable name must fail");
+        assert!(matches!(immutable, StorageError::InvalidObjectName { .. }));
+        assert_eq!(immutable.context().component.as_ref(), Some(&reserved));
+        assert_eq!(immutable.context().object, Some(object.digest()));
+
+        let mutable = lease
+            .compare_exchange_file(&root, &reserved, ExpectedValue::Absent, object.clone())
+            .expect_err("an internal mutable name must fail");
+        assert!(matches!(mutable, StorageError::InvalidObjectName { .. }));
+        assert_eq!(mutable.context().component.as_ref(), Some(&reserved));
+        assert_eq!(mutable.context().object, Some(object.digest()));
+    }
+    assert!(!root_path.join(".pilotage-tmp-user").exists());
+    Ok(())
+}
+
+#[test]
+fn temporary_namespace_exhaustion_reports_the_selected_object() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    for counter in 0_u64..64 {
+        let path = root_path.join(format!(
+            ".pilotage-tmp-{}-{counter:016x}",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"")?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    let object = ExactObject::from_bytes(b"selected".to_vec());
+    let error = store
+        .root_directory()
+        .put_immutable_no_replace(&lease, &name("destination")?, &object)
+        .expect_err("an exhausted private namespace must fail");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert_eq!(error.context().object, Some(object.digest()));
+    Ok(())
+}
+
+#[test]
+fn read_limit_is_enforced_before_allocation() -> TestResult {
+    let (_temporary, _root, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object_name = name("bounded")?;
+    root.put_immutable_no_replace(
+        &lease,
+        &object_name,
+        &ExactObject::from_bytes(vec![7_u8; 64]),
+    )?;
+    assert!(matches!(
+        root.read_exact(&object_name, 63),
+        Err(StorageError::ObjectTooLarge { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn digest_bound_read_errors_keep_the_expected_digest() -> TestResult {
+    let (_temporary, _root_path, store) = fixture()?;
+    let root = store.root_directory();
+    let missing = name("missing")?;
+    let expected = digest_bytes(b"expected");
+    let error = root
+        .read_digest(&missing, expected, 8)
+        .expect_err("a missing digest-bound object must fail");
+    assert!(matches!(error, StorageError::Io { .. }));
+    assert_eq!(error.context().component.as_ref(), Some(&missing));
+    assert_eq!(error.context().object, Some(expected));
+    Ok(())
+}
+
+#[test]
+fn regular_read_handles_are_nonblocking() -> TestResult {
+    let (_temporary, _root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object_name = name("nonblocking")?;
+    root.put_immutable_no_replace(
+        &lease,
+        &object_name,
+        &ExactObject::from_bytes(b"object".to_vec()),
+    )?;
+    let flags = crate::unix::regular_open_flags_for_test(&root, &object_name)?;
+    assert!(flags.contains(rustix::fs::OFlags::NONBLOCK));
+    Ok(())
+}
+
+#[test]
+fn private_tree_manifest_enforces_file_and_total_bounds() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    let tree = root.child(&lease, &tree_name)?;
+    tree.put_immutable_no_replace(
+        &lease,
+        &name("object")?,
+        &ExactObject::from_bytes(b"eight123".to_vec()),
+    )?;
+
+    for limits in [
+        PrivateTreeLimits::new(2, 7, 64),
+        PrivateTreeLimits::new(2, 64, 7),
+    ] {
+        assert!(matches!(
+            root.inspect_private_tree(&tree_name, limits),
+            Err(StorageError::ObjectTooLarge { .. })
+        ));
+    }
+    assert_eq!(std::fs::read(root_path.join("tree/object"))?, b"eight123");
+    Ok(())
+}
+
+#[test]
+fn one_writer_lease_excludes_another_open_session() -> TestResult {
+    let (_temporary, root, store) = fixture()?;
+    let first = store.acquire_writer()?;
+    let second_store = DurableStore::open_or_create(&root)?;
+    let error = second_store
+        .acquire_writer()
+        .err()
+        .ok_or_else(|| std::io::Error::other("second writer unexpectedly acquired the lock"))?;
+    assert!(error.is_writer_locked());
+    drop(first);
+    second_store.acquire_writer()?;
+    Ok(())
+}
+
+#[test]
+fn compare_exchange_rejects_stale_and_sibling_values() -> TestResult {
+    let (_temporary, _root, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let first = ExactObject::from_bytes(b"first".to_vec());
+    let second = ExactObject::from_bytes(b"second".to_vec());
+    let sibling = ExactObject::from_bytes(b"sibling".to_vec());
+    assert_eq!(
+        lease.compare_exchange_file(&root, &head, ExpectedValue::Absent, first.clone(),)?,
+        CasOutcome::Exchanged
+    );
+    assert_eq!(
+        lease.compare_exchange_file(
+            &root,
+            &head,
+            ExpectedValue::Exact(first.clone()),
+            second.clone(),
+        )?,
+        CasOutcome::Exchanged
+    );
+    let stale = lease
+        .compare_exchange_file(&root, &head, ExpectedValue::Exact(first), sibling)
+        .expect_err("a stale writer must not replace a sibling");
+    assert!(matches!(stale, StorageError::StaleExpected { .. }));
+    assert!(stale.poisons_authorization());
+    assert_eq!(root.read_exact(&head, 6)?, second);
+    Ok(())
+}
+
+#[test]
+fn exact_new_value_is_an_idempotent_cas_success() -> TestResult {
+    let (_temporary, _root, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let value = ExactObject::from_bytes(b"value".to_vec());
+    lease.compare_exchange_file(&root, &head, ExpectedValue::Absent, value.clone())?;
+    assert_eq!(
+        lease.compare_exchange_file(&root, &head, ExpectedValue::Absent, value)?,
+        CasOutcome::AlreadyExact
+    );
+    Ok(())
+}
+
+#[test]
+fn guarded_compare_exchange_cleans_up_after_validation_rejection() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let new = ExactObject::from_bytes(b"new".to_vec());
+    let error = lease
+        .compare_exchange_file_guarded(&root, &head, ExpectedValue::Absent, new, || {
+            Err(std::io::Error::other("validation rejected"))
+        })
+        .expect_err("caller validation must stop authorization");
+    assert!(matches!(error, CompareExchangeError::Validation { .. }));
+    assert!(!root.exists(&head)?);
+    assert!(std::fs::read_dir(root_path)?.all(|entry| {
+        entry.is_ok_and(|entry| {
+            !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".pilotage-tmp-")
+        })
+    }));
+    Ok(())
+}
+
+#[test]
+fn guarded_compare_exchange_rechecks_a_sibling_after_validation() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let old = ExactObject::from_bytes(b"old".to_vec());
+    let new = ExactObject::from_bytes(b"new".to_vec());
+    let sibling = ExactObject::from_bytes(b"sib".to_vec());
+    lease.compare_exchange_file(&root, &head, ExpectedValue::Absent, old.clone())?;
+
+    let sibling_path = root_path.join("sibling");
+    let head_path = root_path.join(head.as_os_str());
+    let error = lease
+        .compare_exchange_file_guarded(&root, &head, ExpectedValue::Exact(old), new, || {
+            std::fs::write(&sibling_path, sibling.bytes())?;
+            std::fs::set_permissions(&sibling_path, std::fs::Permissions::from_mode(0o600))?;
+            std::fs::rename(&sibling_path, &head_path)
+        })
+        .expect_err("a sibling created by validation must not be replaced");
+    assert!(matches!(
+        error,
+        CompareExchangeError::Storage {
+            source: StorageError::StaleExpected { .. }
+        }
+    ));
+    assert_eq!(root.read_exact(&head, sibling.bytes().len())?, sibling);
+    Ok(())
+}
+
+#[test]
+fn guarded_compare_exchange_rechecks_the_temporary_after_validation() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let new = ExactObject::from_bytes(b"new".to_vec());
+    let error = lease
+        .compare_exchange_file_guarded(&root, &head, ExpectedValue::Absent, new, || {
+            let temporary = std::fs::read_dir(&root_path)?
+                .filter_map(Result::ok)
+                .find(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with(".pilotage-tmp-")
+                })
+                .ok_or_else(|| std::io::Error::other("no CAS temporary"))?;
+            std::fs::write(temporary.path(), b"bad")
+        })
+        .expect_err("a changed temporary must not be authorized");
+    assert!(matches!(
+        error,
+        CompareExchangeError::Storage {
+            source: StorageError::ContentMismatch { .. }
+        }
+    ));
+    assert!(!root.exists(&head)?);
+    Ok(())
+}
+
+#[test]
+fn sequential_writer_cannot_replace_a_sibling_head() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let head = name("HEAD")?;
+    let parent = ExactObject::from_bytes(b"parent".to_vec());
+    let winner = ExactObject::from_bytes(b"winner".to_vec());
+    let sibling = ExactObject::from_bytes(b"loser!".to_vec());
+    let first_lease = store.acquire_writer()?;
+    first_lease.compare_exchange_file(
+        &store.root_directory(),
+        &head,
+        ExpectedValue::Absent,
+        parent.clone(),
+    )?;
+    drop(first_lease);
+
+    let winner_store = DurableStore::open_or_create(&root_path)?;
+    let winner_lease = winner_store.acquire_writer()?;
+    winner_lease.compare_exchange_file(
+        &winner_store.root_directory(),
+        &head,
+        ExpectedValue::Exact(parent.clone()),
+        winner.clone(),
+    )?;
+    drop(winner_lease);
+
+    let stale_store = DurableStore::open_or_create(&root_path)?;
+    let stale_lease = stale_store.acquire_writer()?;
+    let error = stale_lease
+        .compare_exchange_file(
+            &stale_store.root_directory(),
+            &head,
+            ExpectedValue::Exact(parent),
+            sibling,
+        )
+        .expect_err("a later writer must not replace a sibling");
+    assert!(matches!(error, StorageError::StaleExpected { .. }));
+    assert_eq!(stale_store.root_directory().read_exact(&head, 6)?, winner);
+    Ok(())
+}

--- a/crates/pilotage-durable-storage/src/tests/attacks.rs
+++ b/crates/pilotage-durable-storage/src/tests/attacks.rs
@@ -1,0 +1,467 @@
+use std::os::unix::fs::{PermissionsExt, symlink};
+
+use super::{TestResult, fixture, name, test_parent, tree_limits};
+use crate::{
+    DurabilityStep, DurableStore, ExactObject, ObjectName, StorageError, StorageOperation,
+};
+
+#[test]
+fn root_symlink_and_symlinked_tmp_ancestor_are_rejected() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-root-link-")
+        .tempdir_in(test_parent()?)?;
+    let target = temporary.path().join("target");
+    std::fs::create_dir(&target)?;
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700))?;
+    let root_link = temporary.path().join("root");
+    symlink(&target, &root_link)?;
+    assert!(DurableStore::open_or_create(&root_link).is_err());
+
+    let real_ancestor = temporary.path().join("real");
+    std::fs::create_dir(&real_ancestor)?;
+    std::fs::set_permissions(&real_ancestor, std::fs::Permissions::from_mode(0o700))?;
+    let alias_ancestor = temporary.path().join("alias");
+    symlink(&real_ancestor, &alias_ancestor)?;
+    let requested = alias_ancestor.join("store");
+    let error = DurableStore::open_or_create(&requested)
+        .err()
+        .ok_or_else(|| std::io::Error::other("a symlinked ancestor was accepted"))?;
+    assert_eq!(
+        error.context().requested_root.as_deref(),
+        Some(requested.as_path())
+    );
+    assert_eq!(error.context().component.as_ref(), Some(&name("alias")?));
+
+    #[cfg(target_vendor = "apple")]
+    {
+        let through_tmp = std::path::Path::new("/tmp")
+            .join(format!("pilotage-reject-symlink-{}", std::process::id()));
+        assert!(DurableStore::open_or_create(&through_tmp).is_err());
+    }
+    Ok(())
+}
+
+#[test]
+fn invalid_root_component_keeps_the_requested_root() -> TestResult {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let requested = std::path::PathBuf::from(OsString::from_vec(
+        b"/private/tmp/pilotage-invalid-\0-root".to_vec(),
+    ));
+    let error = DurableStore::open_or_create(&requested)
+        .err()
+        .ok_or_else(|| std::io::Error::other("a NUL root component was accepted"))?;
+    assert!(matches!(error, StorageError::InvalidObjectName { .. }));
+    assert_eq!(
+        error.context().requested_root.as_deref(),
+        Some(requested.as_path())
+    );
+    Ok(())
+}
+
+#[test]
+fn existing_public_root_and_child_are_not_repaired_in_place() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-public-root-")
+        .tempdir_in(test_parent()?)?;
+    let public_root = temporary.path().join("store");
+    std::fs::create_dir(&public_root)?;
+    std::fs::set_permissions(&public_root, std::fs::Permissions::from_mode(0o755))?;
+    let error = DurableStore::open_or_create(&public_root)
+        .err()
+        .ok_or_else(|| std::io::Error::other("a public root was accepted"))?;
+    assert!(matches!(error, StorageError::WrongMode { .. }));
+    assert_eq!(error.context().component.as_ref(), Some(&name("store")?));
+    assert!(error.context().root.is_some());
+    assert_eq!(
+        std::fs::metadata(&public_root)?.permissions().mode() & 0o777,
+        0o755
+    );
+
+    std::fs::set_permissions(&public_root, std::fs::Permissions::from_mode(0o700))?;
+    let store = DurableStore::open_or_create(&public_root)?;
+    let lease = store.acquire_writer()?;
+    std::fs::create_dir(public_root.join("public-child"))?;
+    std::fs::set_permissions(
+        public_root.join("public-child"),
+        std::fs::Permissions::from_mode(0o755),
+    )?;
+    assert!(matches!(
+        store.root_directory().child(&lease, &name("public-child")?),
+        Err(StorageError::WrongMode { .. })
+    ));
+    assert_eq!(
+        std::fs::metadata(public_root.join("public-child"))?
+            .permissions()
+            .mode()
+            & 0o777,
+        0o755
+    );
+    Ok(())
+}
+
+#[test]
+fn root_name_swap_is_detected_before_later_access() -> TestResult {
+    let (_temporary, root, store) = fixture()?;
+    let moved = root.with_extension("held");
+    std::fs::rename(&root, &moved)?;
+    std::fs::create_dir(&root)?;
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))?;
+    let error = store
+        .root_directory()
+        .list()
+        .expect_err("a replacement root must fail");
+    assert!(matches!(error, StorageError::RootChanged { .. }));
+    assert!(error.context().requested_root.as_deref() == Some(root.as_path()));
+    assert_eq!(error.context().component.as_ref(), Some(&name("store")?));
+    Ok(())
+}
+
+#[test]
+fn writer_validation_rejects_a_replaced_lock_name() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let lock = root_path.join(".pilotage-writer-lock");
+    std::fs::rename(&lock, root_path.join("held-writer-lock"))?;
+    std::fs::write(&lock, b"")?;
+    std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o600))?;
+
+    let error = lease
+        .validate(&root)
+        .expect_err("a replacement lock name must invalidate the held lease");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert_eq!(
+        error.context().component.as_ref(),
+        Some(&name(".pilotage-writer-lock")?)
+    );
+
+    let second_store = DurableStore::open_or_create(&root_path)?;
+    let _second_lease = second_store.acquire_writer()?;
+    Ok(())
+}
+
+#[test]
+fn intermediate_directory_swap_is_detected() -> TestResult {
+    let (temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let child_name = name("child")?;
+    let child = store.root_directory().child(&lease, &child_name)?;
+    let held = root_path.join("held-child");
+    std::fs::rename(root_path.join("child"), &held)?;
+    let outside = temporary.path().join("outside");
+    std::fs::create_dir(&outside)?;
+    symlink(&outside, root_path.join("child"))?;
+    let error = child
+        .list()
+        .expect_err("an intermediate symlink swap must fail");
+    assert!(matches!(
+        error,
+        StorageError::IdentityChanged { .. } | StorageError::WrongType { .. }
+    ));
+    assert_eq!(error.context().component.as_ref(), Some(&child_name));
+    Ok(())
+}
+
+#[test]
+fn public_and_hard_linked_files_are_rejected() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let private_name = name("private")?;
+    root.put_immutable_no_replace(
+        &lease,
+        &private_name,
+        &ExactObject::from_bytes(b"bytes".to_vec()),
+    )?;
+    std::fs::hard_link(root_path.join("private"), root_path.join("alias"))?;
+    assert!(matches!(
+        root.read_exact(&private_name, 5),
+        Err(StorageError::LinkedObject { .. })
+    ));
+
+    std::fs::write(root_path.join("public"), b"public")?;
+    std::fs::set_permissions(
+        root_path.join("public"),
+        std::fs::Permissions::from_mode(0o644),
+    )?;
+    assert!(matches!(
+        root.exists(&name("public")?),
+        Err(StorageError::WrongMode { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn direct_object_read_does_not_follow_a_symlink() -> TestResult {
+    let (temporary, root_path, store) = fixture()?;
+    let outside = temporary.path().join("outside-object");
+    std::fs::write(&outside, b"outside")?;
+    symlink(&outside, root_path.join("linked-object"))?;
+    assert!(matches!(
+        store
+            .root_directory()
+            .read_exact(&name("linked-object")?, 7),
+        Err(StorageError::WrongType { .. })
+    ));
+    assert_eq!(std::fs::read(outside)?, b"outside");
+    Ok(())
+}
+
+#[test]
+fn safe_temporary_cleanup_refuses_public_files() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let private_temp = name(".pilotage-tmp-1-0000000000000000")?;
+    std::fs::write(root_path.join(private_temp.as_os_str()), b"partial")?;
+    std::fs::set_permissions(
+        root_path.join(private_temp.as_os_str()),
+        std::fs::Permissions::from_mode(0o600),
+    )?;
+    let owned = root.inspect_owned_temporary(&private_temp, 7)?;
+    lease.cleanup_owned_temporary(&root, &owned)?;
+    assert!(!root_path.join(private_temp.as_os_str()).exists());
+
+    let public_temp = ObjectName::new(".pilotage-tmp-1-0000000000000001")?;
+    std::fs::write(root_path.join(public_temp.as_os_str()), b"partial")?;
+    std::fs::set_permissions(
+        root_path.join(public_temp.as_os_str()),
+        std::fs::Permissions::from_mode(0o644),
+    )?;
+    assert!(matches!(
+        root.inspect_owned_temporary(&public_temp, 7),
+        Err(StorageError::WrongMode { .. })
+    ));
+    assert!(root_path.join(public_temp.as_os_str()).exists());
+    Ok(())
+}
+
+#[test]
+fn temporary_cleanup_rejects_a_new_hard_link() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let temporary_name = name(".pilotage-tmp-1-0000000000000002")?;
+    let temporary_path = root_path.join(temporary_name.as_os_str());
+    std::fs::write(&temporary_path, b"partial")?;
+    std::fs::set_permissions(&temporary_path, std::fs::Permissions::from_mode(0o600))?;
+    let owned = root.inspect_owned_temporary(&temporary_name, 7)?;
+    let alias = root_path.join("temporary-alias");
+    std::fs::hard_link(&temporary_path, &alias)?;
+    assert!(matches!(
+        lease.cleanup_owned_temporary(&root, &owned),
+        Err(StorageError::LinkedObject { .. })
+    ));
+    assert!(temporary_path.exists());
+    assert!(alias.exists());
+    Ok(())
+}
+
+#[test]
+fn temporary_cleanup_rejects_a_token_moved_to_another_root() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-temp-root-owner-")
+        .tempdir_in(test_parent()?)?;
+    let first_path = temporary.path().join("first");
+    let second_path = temporary.path().join("second");
+    let first = DurableStore::open_or_create(&first_path)?;
+    let second = DurableStore::open_or_create(&second_path)?;
+    let first_lease = first.acquire_writer()?;
+    let second_lease = second.acquire_writer()?;
+    let temporary_name = name(".pilotage-tmp-1-0000000000000003")?;
+    let source = first_path.join(temporary_name.as_os_str());
+    let destination = second_path.join(temporary_name.as_os_str());
+    std::fs::write(&source, b"partial")?;
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o600))?;
+    let owned = first
+        .root_directory()
+        .inspect_owned_temporary(&temporary_name, 7)?;
+    std::fs::rename(&source, &destination)?;
+
+    let error = second_lease
+        .cleanup_owned_temporary(&second.root_directory(), &owned)
+        .expect_err("a token from another root must not authorize deletion");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert!(destination.exists());
+    drop(first_lease);
+    Ok(())
+}
+
+#[test]
+fn temporary_cleanup_rejects_a_token_moved_to_another_directory() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let first_name = name("first")?;
+    let second_name = name("second")?;
+    let first = root.child(&lease, &first_name)?;
+    let second = root.child(&lease, &second_name)?;
+    let temporary_name = name(".pilotage-tmp-1-0000000000000004")?;
+    let source = root_path
+        .join(first_name.as_os_str())
+        .join(temporary_name.as_os_str());
+    let destination = root_path
+        .join(second_name.as_os_str())
+        .join(temporary_name.as_os_str());
+    std::fs::write(&source, b"partial")?;
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o600))?;
+    let owned = first.inspect_owned_temporary(&temporary_name, 7)?;
+    std::fs::rename(&source, &destination)?;
+
+    let error = lease
+        .cleanup_owned_temporary(&second, &owned)
+        .expect_err("a token from another directory must not authorize deletion");
+    assert!(matches!(error, StorageError::IdentityChanged { .. }));
+    assert!(destination.exists());
+    Ok(())
+}
+
+#[test]
+fn removal_postcondition_rejects_a_recreated_name_without_deleting_it() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let recreated = name("recreated")?;
+    let recreated_path = root_path.join(recreated.as_os_str());
+    std::fs::write(&recreated_path, b"replacement")?;
+    std::fs::set_permissions(&recreated_path, std::fs::Permissions::from_mode(0o600))?;
+    let context = root.handle.context(
+        Some(&recreated),
+        StorageOperation::RemoveTree,
+        DurabilityStep::AfterMutation,
+    );
+
+    let error = crate::unix::validate_absent_after(&lease, &root, &recreated, context)
+        .expect_err("a recreated name must invalidate removal success");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert_eq!(std::fs::read(recreated_path)?, b"replacement");
+    Ok(())
+}
+
+#[test]
+fn tree_preflight_makes_public_tree_a_zero_delete() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    let tree = root.child(&lease, &tree_name)?;
+    for child in ["private", "public"] {
+        tree.put_immutable_no_replace(
+            &lease,
+            &name(child)?,
+            &ExactObject::from_bytes(child.as_bytes().to_vec()),
+        )?;
+    }
+    std::fs::set_permissions(
+        root_path.join("tree/public"),
+        std::fs::Permissions::from_mode(0o644),
+    )?;
+    let public_directory = root_path.join("tree/public-directory");
+    std::fs::create_dir(&public_directory)?;
+    std::fs::set_permissions(&public_directory, std::fs::Permissions::from_mode(0o755))?;
+    assert!(matches!(
+        root.inspect_private_tree(&tree_name, tree_limits()),
+        Err(StorageError::WrongMode { .. })
+    ));
+    assert!(root_path.join("tree/private").exists());
+    assert!(root_path.join("tree/public").exists());
+    assert!(public_directory.exists());
+    Ok(())
+}
+
+#[test]
+fn exact_private_tree_removal_does_not_follow_links() -> TestResult {
+    let (temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    root.child(&lease, &tree_name)?;
+    let outside = temporary.path().join("outside-file");
+    std::fs::write(&outside, b"outside")?;
+    symlink(&outside, root_path.join("tree/link"))?;
+    assert!(
+        root.inspect_private_tree(&tree_name, tree_limits())
+            .is_err()
+    );
+    assert_eq!(std::fs::read(&outside)?, b"outside");
+    assert!(root_path.join("tree/link").exists());
+    Ok(())
+}
+
+#[test]
+fn exact_private_tree_removal_deletes_only_the_selected_tree() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    let tree = root.child(&lease, &tree_name)?;
+    let nested_name = name("nested")?;
+    let nested = tree.child(&lease, &nested_name)?;
+    nested.put_immutable_no_replace(
+        &lease,
+        &name("object")?,
+        &ExactObject::from_bytes(b"object".to_vec()),
+    )?;
+    root.put_immutable_no_replace(
+        &lease,
+        &name("keep")?,
+        &ExactObject::from_bytes(b"keep".to_vec()),
+    )?;
+    let manifest = root.inspect_private_tree(&tree_name, tree_limits())?;
+    assert_eq!(manifest.object_count(), 3);
+    lease.remove_private_tree(&root, &manifest)?;
+    assert!(!root_path.join("tree").exists());
+    assert_eq!(std::fs::read(root_path.join("keep"))?, b"keep");
+    Ok(())
+}
+
+#[test]
+fn exact_tree_removal_rejects_an_unlisted_private_descendant() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    let tree = root.child(&lease, &tree_name)?;
+    let manifest = root.inspect_private_tree(&tree_name, tree_limits())?;
+    tree.put_immutable_no_replace(
+        &lease,
+        &name("unknown")?,
+        &ExactObject::from_bytes(b"unknown".to_vec()),
+    )?;
+
+    let error = lease
+        .remove_private_tree(&root, &manifest)
+        .expect_err("an object absent from the manifest must stop deletion");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert!(root_path.join("tree").exists());
+    assert_eq!(std::fs::read(root_path.join("tree/unknown"))?, b"unknown");
+    Ok(())
+}
+
+#[test]
+fn exact_tree_removal_rejects_in_place_file_changes() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let tree_name = name("tree")?;
+    let tree = root.child(&lease, &tree_name)?;
+    let file_name = name("object")?;
+    tree.put_immutable_no_replace(
+        &lease,
+        &file_name,
+        &ExactObject::from_bytes(b"original".to_vec()),
+    )?;
+    let manifest = root.inspect_private_tree(&tree_name, tree_limits())?;
+    let file_path = root_path.join("tree/object");
+    std::fs::write(&file_path, b"modified")?;
+
+    let error = lease
+        .remove_private_tree(&root, &manifest)
+        .expect_err("changed file bytes must stop tree removal");
+    assert!(matches!(error, StorageError::ContentMismatch { .. }));
+    assert!(root_path.join("tree").exists());
+    assert_eq!(std::fs::read(file_path)?, b"modified");
+    Ok(())
+}

--- a/crates/pilotage-durable-storage/src/tests/cas.rs
+++ b/crates/pilotage-durable-storage/src/tests/cas.rs
@@ -1,0 +1,25 @@
+use std::os::unix::fs::PermissionsExt;
+
+use super::{TestResult, fixture, name};
+
+#[test]
+fn absent_compare_exchange_never_replaces_an_existing_name() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let _lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let source = name("prepared")?;
+    let destination = name("existing")?;
+    let source_path = root_path.join(source.as_os_str());
+    let destination_path = root_path.join(destination.as_os_str());
+    std::fs::write(&source_path, b"new")?;
+    std::fs::set_permissions(&source_path, std::fs::Permissions::from_mode(0o600))?;
+    std::fs::write(&destination_path, b"old")?;
+    std::fs::set_permissions(&destination_path, std::fs::Permissions::from_mode(0o600))?;
+
+    let error = crate::unix::rename_absent_for_test(&root, &source, &destination)
+        .expect_err("NOREPLACE must reject an existing destination");
+    assert_eq!(error, rustix::io::Errno::EXIST);
+    assert_eq!(std::fs::read(source_path)?, b"new");
+    assert_eq!(std::fs::read(destination_path)?, b"old");
+    Ok(())
+}

--- a/crates/pilotage-durable-storage/src/tests/faults.rs
+++ b/crates/pilotage-durable-storage/src/tests/faults.rs
@@ -1,0 +1,494 @@
+use super::{TestResult, fixture, name, test_parent, tree_limits};
+use crate::{
+    CasOutcome, DurabilityStep, DurableStore, ExactObject, ExpectedValue, FaultAction,
+    FaultController, FaultRule, PutOutcome, StorageError, StorageOperation,
+};
+use std::os::unix::fs::MetadataExt;
+
+#[test]
+fn root_parent_sync_failure_is_repaired_by_reopen() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-root-fault-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::OpenRoot,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let error = DurableStore::open_or_create_with_faults(&root_path, faults.clone())
+        .err()
+        .ok_or_else(|| std::io::Error::other("a root barrier fault was ignored"))?;
+    assert!(matches!(error, StorageError::InjectedFault { .. }));
+    assert_eq!(
+        error.context().requested_root.as_deref(),
+        Some(root_path.as_path())
+    );
+    assert_eq!(error.context().component.as_ref(), Some(&name("store")?));
+    assert!(error.context().root.is_some());
+    assert!(faults.is_exhausted()?);
+    let reopened = DurableStore::open_or_create(&root_path)?;
+    reopened.acquire_writer()?;
+    Ok(())
+}
+
+#[test]
+fn lost_creation_ack_reopens_and_stabilizes_exact_directories() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-create-ack-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let root_faults = FaultController::new([FaultRule::once(
+        StorageOperation::OpenRoot,
+        DurabilityStep::Creation,
+        FaultAction::LoseAckAfter,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, root_faults.clone())?;
+    assert!(root_faults.is_exhausted()?);
+
+    let child_faults = FaultController::new([FaultRule::once(
+        StorageOperation::CreateDirectory,
+        DurabilityStep::Creation,
+        FaultAction::LoseAckAfter,
+    )]);
+    let faulted = DurableStore::open_or_create_with_faults(&root_path, child_faults.clone())?;
+    let lease = faulted.acquire_writer()?;
+    faulted.root_directory().child(&lease, &name("child")?)?;
+    assert!(child_faults.is_exhausted()?);
+    drop(store);
+    Ok(())
+}
+
+#[test]
+fn writer_lock_parent_sync_failure_is_repaired_by_retry() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::AcquireWriter,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    assert!(store.acquire_writer().is_err());
+    assert!(faults.is_exhausted()?);
+    store.acquire_writer()?;
+    Ok(())
+}
+
+#[test]
+fn directory_parent_sync_failure_is_repaired_by_retry() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-dir-fault-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let _store = DurableStore::open_or_create(&root_path)?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::CreateDirectory,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let faulted = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = faulted.acquire_writer()?;
+    let child_name = name("child")?;
+    assert!(faulted.root_directory().child(&lease, &child_name).is_err());
+    assert!(faults.is_exhausted()?);
+    drop(lease);
+    let retry = DurableStore::open_or_create(&root_path)?;
+    let retry_lease = retry.acquire_writer()?;
+    retry.root_directory().child(&retry_lease, &child_name)?;
+    Ok(())
+}
+
+#[test]
+fn immutable_lost_link_ack_recovers_exact_object() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectPublication,
+        FaultAction::LoseAckAfter,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object_name = name("object")?;
+    let object = ExactObject::from_bytes(b"durable".to_vec());
+    assert_eq!(
+        root.put_immutable_no_replace(&lease, &object_name, &object)?,
+        PutOutcome::Published
+    );
+    assert_eq!(root.read_exact(&object_name, 7)?, object);
+    assert!(faults.is_exhausted()?);
+    assert!(root.list()?.iter().all(|name| {
+        !name
+            .as_os_str()
+            .to_string_lossy()
+            .starts_with(".pilotage-tmp-")
+    }));
+    Ok(())
+}
+
+#[test]
+fn immutable_crash_state_is_repaired_after_reopen() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-publish-crash-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let faults = FaultController::new([
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectPublication,
+            FaultAction::LoseAckAfter,
+        ),
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+            FaultAction::FailBefore,
+        ),
+    ]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let object_name = name("object")?;
+    let object = ExactObject::from_bytes(b"durable".to_vec());
+    let error = root
+        .put_immutable_no_replace(&lease, &object_name, &object)
+        .expect_err("readback failure must stop linked publication recovery");
+    assert!(matches!(error, StorageError::AmbiguousCommit { .. }));
+    assert!(error.poisons_authorization());
+    assert!(faults.is_exhausted()?);
+
+    let linked_temporary = find_one_temporary(&root_path)?;
+    let destination_metadata = std::fs::metadata(root_path.join("object"))?;
+    let temporary_metadata = std::fs::metadata(&linked_temporary)?;
+    assert_eq!(destination_metadata.dev(), temporary_metadata.dev());
+    assert_eq!(destination_metadata.ino(), temporary_metadata.ino());
+    assert_eq!(destination_metadata.nlink(), 2);
+    assert_eq!(temporary_metadata.nlink(), 2);
+    assert!(matches!(
+        root.read_exact(&object_name, 7),
+        Err(StorageError::LinkedObject { .. })
+    ));
+    drop(root);
+    drop(lease);
+    drop(store);
+
+    let reopened = DurableStore::open_or_create(&root_path)?;
+    let reopened_lease = reopened.acquire_writer()?;
+    let reopened_root = reopened.root_directory();
+    assert_eq!(
+        reopened_root.put_immutable_no_replace(&reopened_lease, &object_name, &object)?,
+        PutOutcome::AlreadyExact
+    );
+    assert_eq!(reopened_root.read_exact(&object_name, 7)?, object);
+    assert_eq!(std::fs::metadata(root_path.join("object"))?.nlink(), 1);
+    assert!(!linked_temporary.exists());
+    Ok(())
+}
+
+fn find_one_temporary(
+    root: &std::path::Path,
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let mut found = None;
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if !entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".pilotage-tmp-")
+        {
+            continue;
+        }
+        if found.replace(entry.path()).is_some() {
+            return Err(std::io::Error::other("more than one temporary remained").into());
+        }
+    }
+    found.ok_or_else(|| std::io::Error::other("no linked temporary remained").into())
+}
+
+#[test]
+fn immutable_parent_sync_failure_uses_a_recovery_barrier() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let object_name = name("object")?;
+    let object = ExactObject::from_bytes(b"durable".to_vec());
+    assert_eq!(
+        store
+            .root_directory()
+            .put_immutable_no_replace(&lease, &object_name, &object,)?,
+        PutOutcome::Published
+    );
+    assert_eq!(store.root_directory().read_exact(&object_name, 7)?, object);
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn lost_temporary_unlink_ack_is_resolved_without_deleting_another_name() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::Deletion,
+        FaultAction::LoseAckAfter,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let object_name = name("object")?;
+    let object = ExactObject::from_bytes(b"durable".to_vec());
+    store
+        .root_directory()
+        .put_immutable_no_replace(&lease, &object_name, &object)?;
+    assert_eq!(store.root_directory().read_exact(&object_name, 7)?, object);
+    assert!(store.root_directory().list()?.iter().all(|entry| {
+        !entry
+            .as_os_str()
+            .to_string_lossy()
+            .starts_with(".pilotage-tmp-")
+    }));
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn lost_tree_unlink_ack_is_resolved_at_the_parent() -> TestResult {
+    let (_temporary, root_path, setup) = fixture()?;
+    let setup_lease = setup.acquire_writer()?;
+    let tree_name = name("tree")?;
+    setup.root_directory().child(&setup_lease, &tree_name)?;
+    drop(setup_lease);
+
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::RemoveTree,
+        DurabilityStep::Deletion,
+        FaultAction::LoseAckAfter,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let manifest = root.inspect_private_tree(&tree_name, tree_limits())?;
+    lease.remove_private_tree(&root, &manifest)?;
+    assert!(!root.exists(&tree_name)?);
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn existing_immutable_object_gets_new_durability_barriers() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let object_name = name("object")?;
+    let object = ExactObject::from_bytes(b"durable".to_vec());
+    store
+        .root_directory()
+        .put_immutable_no_replace(&lease, &object_name, &object)?;
+    drop(lease);
+
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let reopened = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let reopened_lease = reopened.acquire_writer()?;
+    assert!(
+        reopened
+            .root_directory()
+            .put_immutable_no_replace(&reopened_lease, &object_name, &object)
+            .is_err()
+    );
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn cas_parent_sync_failure_recovers_by_exact_readback() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::CompareExchange,
+        DurabilityStep::ParentDirectory,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let head = name("HEAD")?;
+    let value = ExactObject::from_bytes(b"new".to_vec());
+    assert_eq!(
+        lease.compare_exchange_file(
+            &store.root_directory(),
+            &head,
+            ExpectedValue::Absent,
+            value.clone(),
+        )?,
+        CasOutcome::AlreadyExact
+    );
+    assert_eq!(store.root_directory().read_exact(&head, 3)?, value);
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn cas_lost_rename_ack_recovers_exact_new_value() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::CompareExchange,
+        DurabilityStep::AuthorizationRename,
+        FaultAction::LoseAckAfter,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let head = name("HEAD")?;
+    let value = ExactObject::from_bytes(b"new".to_vec());
+    assert_eq!(
+        lease.compare_exchange_file(
+            &store.root_directory(),
+            &head,
+            ExpectedValue::Absent,
+            value.clone(),
+        )?,
+        CasOutcome::AlreadyExact
+    );
+    assert_eq!(store.root_directory().read_exact(&head, 3)?, value);
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn cas_post_commit_readback_failure_is_ambiguous_and_poisoning() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::CompareExchange,
+        DurabilityStep::AuthorizationReadback,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    let new = ExactObject::from_bytes(b"new".to_vec());
+    let error = lease
+        .compare_exchange_file(&root, &head, ExpectedValue::Absent, new.clone())
+        .expect_err("a failed post-commit readback must be ambiguous");
+    assert!(matches!(error, StorageError::AmbiguousCommit { .. }));
+    assert!(error.poisons_authorization());
+    assert!(faults.is_exhausted()?);
+    assert_eq!(root.read_exact(&head, new.bytes().len())?, new);
+    drop(lease);
+
+    let reopened = DurableStore::open_or_create(&root_path)?;
+    let reopened_lease = reopened.acquire_writer()?;
+    assert_eq!(
+        reopened_lease.compare_exchange_file(
+            &reopened.root_directory(),
+            &head,
+            ExpectedValue::Absent,
+            new,
+        )?,
+        CasOutcome::AlreadyExact
+    );
+    Ok(())
+}
+
+#[test]
+fn already_exact_barrier_failure_is_ambiguous() -> TestResult {
+    for step in [DurabilityStep::ObjectData, DurabilityStep::ParentDirectory] {
+        let (_temporary, root_path, store) = fixture()?;
+        let head = name("HEAD")?;
+        let value = ExactObject::from_bytes(b"new".to_vec());
+        let setup_lease = store.acquire_writer()?;
+        setup_lease.compare_exchange_file(
+            &store.root_directory(),
+            &head,
+            ExpectedValue::Absent,
+            value.clone(),
+        )?;
+        drop(setup_lease);
+
+        let faults = FaultController::new([FaultRule::once(
+            StorageOperation::CompareExchange,
+            step,
+            FaultAction::FailBefore,
+        )]);
+        let reopened = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+        let lease = reopened.acquire_writer()?;
+        let error = lease
+            .compare_exchange_file(
+                &reopened.root_directory(),
+                &head,
+                ExpectedValue::Absent,
+                value.clone(),
+            )
+            .expect_err("an exact-new barrier failure must be ambiguous");
+        assert!(matches!(error, StorageError::AmbiguousCommit { .. }));
+        assert!(error.poisons_authorization());
+        assert!(faults.is_exhausted()?);
+    }
+    Ok(())
+}
+
+#[test]
+fn cas_second_barrier_failure_is_ambiguous_and_poisoning() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([
+        FaultRule::once(
+            StorageOperation::CompareExchange,
+            DurabilityStep::ParentDirectory,
+            FaultAction::FailBefore,
+        ),
+        FaultRule::once(
+            StorageOperation::CompareExchange,
+            DurabilityStep::RecoveryBarrier,
+            FaultAction::FailBefore,
+        ),
+    ]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let error = lease
+        .compare_exchange_file(
+            &store.root_directory(),
+            &name("HEAD")?,
+            ExpectedValue::Absent,
+            ExactObject::from_bytes(b"new".to_vec()),
+        )
+        .expect_err("two failed barriers must be ambiguous");
+    assert!(matches!(error, StorageError::AmbiguousCommit { .. }));
+    assert!(error.poisons_authorization());
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn cas_fail_before_rename_keeps_old_value_and_cleans_temp() -> TestResult {
+    let (_temporary, root_path, _store) = fixture()?;
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::CompareExchange,
+        DurabilityStep::AuthorizationRename,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let head = name("HEAD")?;
+    assert!(
+        lease
+            .compare_exchange_file(
+                &root,
+                &head,
+                ExpectedValue::Absent,
+                ExactObject::from_bytes(b"new".to_vec()),
+            )
+            .is_err()
+    );
+    assert!(!root.exists(&head)?);
+    assert!(root.list()?.iter().all(|name| {
+        !name
+            .as_os_str()
+            .to_string_lossy()
+            .starts_with(".pilotage-tmp-")
+    }));
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}

--- a/crates/pilotage-durable-storage/src/tests/lease.rs
+++ b/crates/pilotage-durable-storage/src/tests/lease.rs
@@ -1,0 +1,35 @@
+use super::{TestResult, fixture, name};
+use crate::{ExactObject, StorageError};
+
+#[test]
+fn a_removed_writer_lock_is_poisoning_and_stops_mutation() -> TestResult {
+    let (_temporary, root_path, store) = fixture()?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    std::fs::remove_file(root_path.join(".pilotage-writer-lock"))?;
+
+    let error = lease
+        .validate(&root)
+        .expect_err("a removed writer lock must invalidate the lease");
+    assert!(matches!(
+        error,
+        StorageError::IdentityChanged { actual: None, .. }
+    ));
+    assert!(error.poisons_authorization());
+    assert_eq!(
+        error.context().component.as_ref(),
+        Some(&name(".pilotage-writer-lock")?)
+    );
+
+    let destination = name("must-not-exist")?;
+    let mutation = root
+        .put_immutable_no_replace(
+            &lease,
+            &destination,
+            &ExactObject::from_bytes(b"blocked".to_vec()),
+        )
+        .expect_err("an invalid lease must stop a later mutation");
+    assert!(mutation.poisons_authorization());
+    assert!(!root_path.join(destination.as_os_str()).exists());
+    Ok(())
+}

--- a/crates/pilotage-durable-storage/src/tests/removal_recovery.rs
+++ b/crates/pilotage-durable-storage/src/tests/removal_recovery.rs
@@ -1,0 +1,85 @@
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use super::{TestResult, name, test_parent};
+use crate::{
+    DurabilityStep, DurableStore, FaultAction, FaultController, FaultRule, StorageError,
+    StorageOperation,
+};
+
+#[test]
+fn temporary_unlink_retry_rejects_changed_bytes() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-unlink-rewrite-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let faults = deletion_faults();
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let temporary_name = name(".pilotage-tmp-1-000000000000000a")?;
+    let temporary_path = root_path.join(temporary_name.as_os_str());
+    std::fs::write(&temporary_path, b"partial")?;
+    std::fs::set_permissions(&temporary_path, std::fs::Permissions::from_mode(0o600))?;
+    let identity = std::fs::metadata(&temporary_path)?;
+    let owned = root.inspect_owned_temporary(&temporary_name, 7)?;
+    let rewrite_path = temporary_path.clone();
+    faults.set_test_hook(move || {
+        std::fs::write(&rewrite_path, b"changed").expect("rewrite exact removal target");
+    })?;
+
+    let error = lease
+        .cleanup_owned_temporary(&root, &owned)
+        .expect_err("retry must reject changed temporary bytes");
+    assert!(matches!(error, StorageError::ContentMismatch { .. }));
+    assert!(error.poisons_authorization());
+    assert_eq!(std::fs::read(&temporary_path)?, b"changed");
+    assert_eq!(std::fs::metadata(&temporary_path)?.ino(), identity.ino());
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+#[test]
+fn temporary_unlink_retry_revalidates_the_writer_lease() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-unlink-lease-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let faults = deletion_faults();
+    let store = DurableStore::open_or_create_with_faults(&root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let root = store.root_directory();
+    let temporary_name = name(".pilotage-tmp-1-000000000000000b")?;
+    let temporary_path = root_path.join(temporary_name.as_os_str());
+    std::fs::write(&temporary_path, b"partial")?;
+    std::fs::set_permissions(&temporary_path, std::fs::Permissions::from_mode(0o600))?;
+    let owned = root.inspect_owned_temporary(&temporary_name, 7)?;
+    let lock = root_path.join(".pilotage-writer-lock");
+    let held = root_path.join("held-writer-lock");
+    let replacement = lock.clone();
+    let moved = held.clone();
+    faults.set_test_hook(move || {
+        std::fs::rename(&replacement, &moved).expect("move held writer lock");
+        std::fs::write(&replacement, b"").expect("make replacement writer lock");
+        std::fs::set_permissions(&replacement, std::fs::Permissions::from_mode(0o600))
+            .expect("make replacement writer lock private");
+    })?;
+
+    let error = lease
+        .cleanup_owned_temporary(&root, &owned)
+        .expect_err("retry must reject a replaced writer lease name");
+    assert!(matches!(error, StorageError::Corruption { .. }));
+    assert!(error.poisons_authorization());
+    assert_eq!(std::fs::read(&temporary_path)?, b"partial");
+    assert!(lock.exists());
+    assert!(held.exists());
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+fn deletion_faults() -> FaultController {
+    FaultController::new([FaultRule::once(
+        StorageOperation::RemoveTemporary,
+        DurabilityStep::Deletion,
+        FaultAction::FailBefore,
+    )])
+}

--- a/crates/pilotage-durable-storage/src/types.rs
+++ b/crates/pilotage-durable-storage/src/types.rs
@@ -1,0 +1,411 @@
+use std::ffi::{OsStr, OsString};
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::{StorageError, StorageResult};
+
+/// A SHA-256 content digest.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ContentDigest(pub [u8; 32]);
+
+/// Calculate the digest of exact object bytes.
+#[must_use]
+pub fn digest_bytes(bytes: &[u8]) -> ContentDigest {
+    ContentDigest(Sha256::digest(bytes).into())
+}
+
+/// One file-system name component.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ObjectName(OsString);
+
+impl ObjectName {
+    /// Validate and copy one normal path component.
+    pub fn new(name: impl AsRef<OsStr>) -> StorageResult<Self> {
+        let name = name.as_ref();
+        let mut components = Path::new(name).components();
+        let is_normal =
+            matches!(components.next(), Some(Component::Normal(value)) if value == name);
+        if !is_normal || components.next().is_some() || contains_nul(name) {
+            return Err(StorageError::invalid_name(name));
+        }
+        Ok(Self(name.to_os_string()))
+    }
+
+    /// Get the operating-system string for this component.
+    #[must_use]
+    pub fn as_os_str(&self) -> &OsStr {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for ObjectName {
+    type Error = StorageError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for ObjectName {
+    type Error = StorageError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[cfg(unix)]
+fn contains_nul(value: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    value.as_bytes().contains(&0)
+}
+
+#[cfg(not(unix))]
+fn contains_nul(value: &OsStr) -> bool {
+    value.to_string_lossy().contains('\0')
+}
+
+/// Exact bytes and their calculated digest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExactObject {
+    digest: ContentDigest,
+    bytes: Vec<u8>,
+}
+
+impl ExactObject {
+    /// Build an object from its complete bytes.
+    #[must_use]
+    pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
+        let bytes = bytes.into();
+        let digest = digest_bytes(&bytes);
+        Self { digest, bytes }
+    }
+
+    /// Get the content digest.
+    #[must_use]
+    pub const fn digest(&self) -> ContentDigest {
+        self.digest
+    }
+
+    /// Get the complete bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+/// A verified private temporary object owned by one anchored storage directory.
+#[derive(Debug)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+pub struct OwnedTemporary {
+    pub(crate) name: ObjectName,
+    pub(crate) identity: ObjectIdentity,
+    pub(crate) object: ExactObject,
+    pub(crate) owner_root: RootIdentity,
+    pub(crate) owner_directory: ObjectIdentity,
+}
+
+impl OwnedTemporary {
+    /// Get the owned temporary name.
+    #[must_use]
+    pub const fn name(&self) -> &ObjectName {
+        &self.name
+    }
+
+    /// Get the exact temporary identity.
+    #[must_use]
+    pub const fn identity(&self) -> ObjectIdentity {
+        self.identity
+    }
+
+    /// Get the complete temporary bytes and digest.
+    #[must_use]
+    pub const fn object(&self) -> &ExactObject {
+        &self.object
+    }
+}
+
+/// An exact private tree captured in one anchored storage directory.
+#[derive(Debug)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+pub struct PrivateTreeManifest {
+    pub(crate) owner_root: RootIdentity,
+    pub(crate) owner_directory: ObjectIdentity,
+    pub(crate) root: PrivateTreeNode,
+    pub(crate) total_file_bytes: usize,
+}
+
+impl PrivateTreeManifest {
+    /// Get the top-level tree name.
+    #[must_use]
+    pub const fn name(&self) -> &ObjectName {
+        &self.root.name
+    }
+
+    /// Get the exact top-level tree identity.
+    #[must_use]
+    pub const fn identity(&self) -> ObjectIdentity {
+        self.root.identity
+    }
+
+    /// Get the number of objects in the exact tree.
+    #[must_use]
+    pub fn object_count(&self) -> usize {
+        self.root.object_count()
+    }
+
+    /// Get the total regular-file byte count in the exact tree.
+    #[must_use]
+    pub const fn total_file_bytes(&self) -> usize {
+        self.total_file_bytes
+    }
+}
+
+/// Bounds for one private tree manifest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PrivateTreeLimits {
+    /// Maximum number of files and directories.
+    pub maximum_objects: usize,
+    /// Maximum bytes in one regular file.
+    pub maximum_file_bytes: usize,
+    /// Maximum total bytes in all regular files.
+    pub maximum_total_bytes: usize,
+}
+
+impl PrivateTreeLimits {
+    /// Make exact manifest bounds.
+    #[must_use]
+    pub const fn new(
+        maximum_objects: usize,
+        maximum_file_bytes: usize,
+        maximum_total_bytes: usize,
+    ) -> Self {
+        Self {
+            maximum_objects,
+            maximum_file_bytes,
+            maximum_total_bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+pub(crate) struct PrivateTreeNode {
+    pub(crate) name: ObjectName,
+    pub(crate) identity: ObjectIdentity,
+    pub(crate) kind: ObjectKind,
+    pub(crate) file: Option<PrivateFileManifest>,
+    pub(crate) children: Vec<PrivateTreeNode>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(
+    not(any(target_vendor = "apple", target_os = "linux", target_os = "android")),
+    allow(dead_code)
+)]
+pub(crate) struct PrivateFileManifest {
+    pub(crate) digest: ContentDigest,
+    pub(crate) size: usize,
+}
+
+impl PrivateTreeNode {
+    fn object_count(&self) -> usize {
+        self.children.iter().fold(1_usize, |count, child| {
+            count.saturating_add(child.object_count())
+        })
+    }
+}
+
+/// The device and inode of an open storage root.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RootIdentity {
+    /// Device number.
+    pub device: u64,
+    /// Inode number.
+    pub inode: u64,
+}
+
+/// The device and inode of a managed object.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ObjectIdentity {
+    /// Device number.
+    pub device: u64,
+    /// Inode number.
+    pub inode: u64,
+}
+
+/// A managed object type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ObjectKind {
+    /// A regular private file.
+    RegularFile,
+    /// A private directory.
+    Directory,
+}
+
+/// Verified metadata for a managed object.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ObjectInspection {
+    /// Stable identity for the inspected name binding.
+    pub identity: ObjectIdentity,
+    /// Verified object type.
+    pub kind: ObjectKind,
+    /// Exact permission bits.
+    pub mode: u32,
+    /// Link count at inspection time.
+    pub link_count: u64,
+    /// File size in bytes.
+    pub size: u64,
+}
+
+/// The expected value for a mutable compare-and-swap object.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ExpectedValue {
+    /// The object name must be absent.
+    Absent,
+    /// The object must contain these exact bytes.
+    Exact(ExactObject),
+}
+
+/// The result of a compare-and-swap operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CasOutcome {
+    /// The store replaced the expected value.
+    Exchanged,
+    /// Exact readback found the requested new value.
+    AlreadyExact,
+}
+
+/// The result of an immutable no-replace publication.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PutOutcome {
+    /// The store published the object.
+    Published,
+    /// The exact object was already durable.
+    AlreadyExact,
+}
+
+/// A storage operation used by errors and fault rules.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum StorageOperation {
+    /// Open or create the storage root.
+    OpenRoot,
+    /// Validate the anchored session.
+    ValidateRoot,
+    /// Create or open a child directory.
+    CreateDirectory,
+    /// Read a directory.
+    ListDirectory,
+    /// Inspect a managed object.
+    InspectObject,
+    /// Read a managed object.
+    ReadObject,
+    /// Publish an immutable object.
+    PublishImmutable,
+    /// Acquire the anchored writer lease.
+    AcquireWriter,
+    /// Validate the anchored writer lease.
+    ValidateWriter,
+    /// Compare and exchange a mutable file.
+    CompareExchange,
+    /// Remove an owned temporary file.
+    RemoveTemporary,
+    /// Remove an exact private tree.
+    RemoveTree,
+}
+
+/// A durability boundary used by errors and fault rules.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum DurabilityStep {
+    /// No durable mutation has started.
+    Selection,
+    /// Validate identity before a mutation.
+    BeforeMutation,
+    /// Create a private directory or file.
+    Creation,
+    /// Synchronize complete file data.
+    ObjectData,
+    /// Verify complete bytes after synchronization.
+    ObjectReadback,
+    /// Publish an immutable name.
+    ObjectPublication,
+    /// Synchronize the object directory.
+    ParentDirectory,
+    /// Rename the mutable authorization object.
+    AuthorizationRename,
+    /// Read the authorization object after an error.
+    AuthorizationReadback,
+    /// Apply the second durability barrier after readback.
+    RecoveryBarrier,
+    /// Unlink a verified object.
+    Deletion,
+    /// Validate identity after a mutation.
+    AfterMutation,
+}
+
+/// Context available at one storage boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageContext {
+    /// Requested root path when the caller supplied it.
+    pub requested_root: Option<PathBuf>,
+    /// Bound root identity when root open succeeded.
+    pub root: Option<RootIdentity>,
+    /// Selected object digest when bytes are known.
+    pub object: Option<ContentDigest>,
+    /// Selected path component when one is known.
+    pub component: Option<ObjectName>,
+    /// Active storage operation.
+    pub operation: StorageOperation,
+    /// Active durability step.
+    pub step: DurabilityStep,
+}
+
+impl StorageContext {
+    /// Make context before a root identity or component is available.
+    #[must_use]
+    pub const fn root_open() -> Self {
+        Self {
+            requested_root: None,
+            root: None,
+            object: None,
+            component: None,
+            operation: StorageOperation::OpenRoot,
+            step: DurabilityStep::Selection,
+        }
+    }
+
+    pub(crate) fn root_open_at(path: &Path) -> Self {
+        Self {
+            requested_root: Some(path.to_path_buf()),
+            ..Self::root_open()
+        }
+    }
+
+    #[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+    pub(crate) fn new(
+        root: RootIdentity,
+        component: Option<&ObjectName>,
+        object: Option<ContentDigest>,
+        operation: StorageOperation,
+        step: DurabilityStep,
+    ) -> Self {
+        Self {
+            requested_root: None,
+            root: Some(root),
+            object,
+            component: component.cloned(),
+            operation,
+            step,
+        }
+    }
+}

--- a/crates/pilotage-durable-storage/src/unix.rs
+++ b/crates/pilotage-durable-storage/src/unix.rs
@@ -1,0 +1,36 @@
+mod anchor;
+mod barrier;
+mod cas;
+mod directory;
+mod metadata;
+mod objects;
+mod remove;
+mod store;
+mod temporary;
+mod writer;
+
+#[cfg(test)]
+pub(crate) use cas::rename_absent as rename_absent_for_test;
+pub use directory::DurableDirectory;
+#[cfg(test)]
+pub(crate) use remove::validate_absent_after;
+
+#[cfg(test)]
+pub(crate) fn regular_open_flags_for_test(
+    directory: &DurableDirectory,
+    name: &crate::ObjectName,
+) -> crate::StorageResult<rustix::fs::OFlags> {
+    let context = directory.handle.context(
+        Some(name),
+        crate::StorageOperation::ReadObject,
+        crate::DurabilityStep::ObjectReadback,
+    );
+    let fd = objects::open_regular(&directory.handle, name, &context)?;
+    rustix::fs::fcntl_getfl(&fd).map_err(|source| crate::StorageError::Io {
+        context,
+        source: source.into(),
+    })
+}
+
+pub use store::DurableStore;
+pub use writer::WriterLease;

--- a/crates/pilotage-durable-storage/src/unix/anchor.rs
+++ b/crates/pilotage-durable-storage/src/unix/anchor.rs
@@ -1,0 +1,237 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rustix::fd::OwnedFd;
+use rustix::fs::{AtFlags, OFlags, fstat, openat, statat};
+use rustix::io::Errno;
+
+use crate::fault::FaultController;
+use crate::{
+    DurabilityStep, ObjectIdentity, ObjectName, RootIdentity, StorageContext, StorageError,
+    StorageOperation, StorageResult,
+};
+
+use super::metadata::{PRIVATE_DIRECTORY_MODE, identity, inspect_private};
+
+pub(crate) struct Anchor {
+    pub(crate) root_parent: OwnedFd,
+    pub(crate) root_leaf: ObjectName,
+    pub(crate) root_fd: Arc<OwnedFd>,
+    pub(crate) identity: RootIdentity,
+    pub(crate) faults: FaultController,
+    pub(crate) requested_root: PathBuf,
+}
+
+#[derive(Clone)]
+pub(crate) struct DirectoryHandle {
+    pub(crate) anchor: Arc<Anchor>,
+    pub(crate) fd: Arc<OwnedFd>,
+    pub(crate) identity: ObjectIdentity,
+    pub(crate) bindings: Arc<Vec<DirectoryBinding>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct DirectoryBinding {
+    parent: Arc<OwnedFd>,
+    name: ObjectName,
+    identity: ObjectIdentity,
+}
+
+impl DirectoryHandle {
+    pub(crate) fn root(anchor: Arc<Anchor>) -> Self {
+        let identity = ObjectIdentity {
+            device: anchor.identity.device,
+            inode: anchor.identity.inode,
+        };
+        Self {
+            fd: Arc::clone(&anchor.root_fd),
+            anchor,
+            identity,
+            bindings: Arc::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn child(&self, fd: OwnedFd, name: ObjectName, identity: ObjectIdentity) -> Self {
+        let mut bindings = self.bindings.as_ref().clone();
+        bindings.push(DirectoryBinding {
+            parent: Arc::clone(&self.fd),
+            name,
+            identity,
+        });
+        Self {
+            anchor: Arc::clone(&self.anchor),
+            fd: Arc::new(fd),
+            identity,
+            bindings: Arc::new(bindings),
+        }
+    }
+
+    pub(crate) fn context(
+        &self,
+        name: Option<&ObjectName>,
+        operation: StorageOperation,
+        step: DurabilityStep,
+    ) -> StorageContext {
+        self.context_with_object(name, None, operation, step)
+    }
+
+    pub(crate) fn context_with_object(
+        &self,
+        name: Option<&ObjectName>,
+        object: Option<crate::ContentDigest>,
+        operation: StorageOperation,
+        step: DurabilityStep,
+    ) -> StorageContext {
+        let mut context = StorageContext::new(self.anchor.identity, name, object, operation, step);
+        context.requested_root = Some(self.anchor.requested_root.clone());
+        context
+    }
+
+    pub(crate) fn validate(&self, context: &StorageContext) -> StorageResult<()> {
+        self.anchor.validate_root(context)?;
+        for binding in self.bindings.iter() {
+            binding.validate(context)?;
+        }
+        let stat = fstat(&self.fd).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        let inspected = inspect_private(&stat, context)?;
+        if inspected.identity != self.identity {
+            return Err(StorageError::IdentityChanged {
+                expected: self.identity,
+                actual: Some(inspected.identity),
+                context: context.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn same_anchor(&self, other: &Arc<Anchor>) -> bool {
+        Arc::ptr_eq(&self.anchor, other)
+    }
+}
+
+impl Anchor {
+    pub(crate) fn context(
+        &self,
+        name: Option<&ObjectName>,
+        operation: StorageOperation,
+        step: DurabilityStep,
+    ) -> StorageContext {
+        let mut context = StorageContext::new(self.identity, name, None, operation, step);
+        context.requested_root = Some(self.requested_root.clone());
+        context
+    }
+
+    pub(crate) fn validate_root(&self, context: &StorageContext) -> StorageResult<()> {
+        let mut context = context.clone();
+        context.component = Some(self.root_leaf.clone());
+        let named = statat(
+            &self.root_parent,
+            self.root_leaf.as_os_str(),
+            AtFlags::SYMLINK_NOFOLLOW,
+        );
+        let stat = match named {
+            Ok(stat) => stat,
+            Err(Errno::NOENT) => {
+                return Err(StorageError::RootChanged {
+                    expected: self.identity,
+                    actual: None,
+                    context,
+                });
+            }
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context,
+                    source: source.into(),
+                });
+            }
+        };
+        let actual_identity = identity(&stat);
+        let actual = RootIdentity {
+            device: actual_identity.device,
+            inode: actual_identity.inode,
+        };
+        if actual != self.identity {
+            return Err(StorageError::RootChanged {
+                expected: self.identity,
+                actual: Some(actual),
+                context,
+            });
+        }
+        let inspected = inspect_private(&stat, &context)?;
+        if inspected.mode != PRIVATE_DIRECTORY_MODE {
+            return Err(StorageError::Corruption {
+                reason: "root mode changed",
+                context,
+            });
+        }
+        let held = fstat(&self.root_fd).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        if identity(&held) != actual_identity {
+            return Err(StorageError::RootChanged {
+                expected: self.identity,
+                actual: Some(actual),
+                context,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl DirectoryBinding {
+    fn validate(&self, context: &StorageContext) -> StorageResult<()> {
+        let mut context = context.clone();
+        context.component = Some(self.name.clone());
+        let stat = statat(
+            &self.parent,
+            self.name.as_os_str(),
+            AtFlags::SYMLINK_NOFOLLOW,
+        );
+        let stat = match stat {
+            Ok(stat) => stat,
+            Err(Errno::NOENT) => {
+                return Err(StorageError::IdentityChanged {
+                    expected: self.identity,
+                    actual: None,
+                    context,
+                });
+            }
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context,
+                    source: source.into(),
+                });
+            }
+        };
+        let actual = identity(&stat);
+        if actual != self.identity {
+            return Err(StorageError::IdentityChanged {
+                expected: self.identity,
+                actual: Some(actual),
+                context,
+            });
+        }
+        let inspected = inspect_private(&stat, &context)?;
+        if inspected.identity != self.identity {
+            return Err(StorageError::IdentityChanged {
+                expected: self.identity,
+                actual: Some(inspected.identity),
+                context,
+            });
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn open_directory(parent: &OwnedFd, name: &ObjectName) -> rustix::io::Result<OwnedFd> {
+    openat(
+        parent,
+        name.as_os_str(),
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+}

--- a/crates/pilotage-durable-storage/src/unix/barrier.rs
+++ b/crates/pilotage-durable-storage/src/unix/barrier.rs
@@ -1,0 +1,42 @@
+use std::io;
+use std::os::fd::AsFd;
+
+use rustix::fs::fsync;
+
+use crate::fault::FaultController;
+use crate::{StorageContext, StorageError, StorageResult};
+
+pub(crate) fn syscall<T>(
+    faults: &FaultController,
+    context: &StorageContext,
+    call: impl FnOnce() -> rustix::io::Result<T>,
+) -> StorageResult<T> {
+    faults.before(context)?;
+    let value = call().map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: io::Error::from(source),
+    })?;
+    faults.after(context)?;
+    Ok(value)
+}
+
+pub(crate) fn sync_file(
+    fd: impl AsFd,
+    faults: &FaultController,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    syscall(faults, context, || {
+        fsync(fd.as_fd())?;
+        #[cfg(target_vendor = "apple")]
+        rustix::fs::fcntl_fullfsync(fd.as_fd())?;
+        Ok(())
+    })
+}
+
+pub(crate) fn sync_directory(
+    fd: impl AsFd,
+    faults: &FaultController,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    syscall(faults, context, || fsync(fd.as_fd()))
+}

--- a/crates/pilotage-durable-storage/src/unix/cas.rs
+++ b/crates/pilotage-durable-storage/src/unix/cas.rs
@@ -1,0 +1,438 @@
+use std::convert::Infallible;
+
+use rustix::fs::{AtFlags, renameat, statat};
+#[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+use rustix::fs::{RenameFlags, renameat_with};
+use rustix::io::Errno;
+
+use crate::{
+    CasOutcome, CompareExchangeError, DurabilityStep, ExactObject, ExpectedValue, ObjectKind,
+    ObjectName, StorageContext, StorageError, StorageOperation, StorageResult,
+};
+
+use super::barrier::{sync_directory, sync_file, syscall};
+use super::directory::DurableDirectory;
+use super::metadata::inspect_private;
+use super::objects;
+use super::temporary;
+use super::writer::WriterLease;
+
+impl WriterLease {
+    /// Replace a mutable file under the anchored writer lease.
+    ///
+    /// The call rejects an old value mismatch that it can observe. POSIX does
+    /// not combine an exact byte comparison and a rename in one operation.
+    pub fn compare_exchange_file(
+        &self,
+        directory: &DurableDirectory,
+        name: &ObjectName,
+        expected: ExpectedValue,
+        new: ExactObject,
+    ) -> StorageResult<CasOutcome> {
+        match self.compare_exchange_file_guarded(directory, name, expected, new, || {
+            Ok::<(), Infallible>(())
+        }) {
+            Ok(outcome) => Ok(outcome),
+            Err(CompareExchangeError::Storage { source }) => Err(source),
+            Err(CompareExchangeError::Validation { source }) => match source {},
+            Err(CompareExchangeError::ValidationAndCleanup { validation, .. }) => {
+                match validation {}
+            }
+        }
+    }
+
+    /// Replace a mutable file after one caller validation.
+    ///
+    /// The store calls `validate` after it makes the new temporary object and
+    /// after an expected-value check. It checks the temporary object and the
+    /// expected value again after caller validation. It does not call
+    /// `validate` when the destination already has the exact new value.
+    pub fn compare_exchange_file_guarded<E>(
+        &self,
+        directory: &DurableDirectory,
+        name: &ObjectName,
+        expected: ExpectedValue,
+        new: ExactObject,
+        validate: impl FnOnce() -> Result<(), E>,
+    ) -> Result<CasOutcome, CompareExchangeError<E>> {
+        compare_exchange_guarded(self, directory, name, expected, new, validate)
+    }
+
+    fn validate_expected_again(
+        &self,
+        directory: &DurableDirectory,
+        name: &ObjectName,
+        expected: &ExpectedValue,
+        new: &ExactObject,
+        context: &StorageContext,
+    ) -> StorageResult<Recheck> {
+        self.validate_for(&directory.handle, context)?;
+        let current = read_current(directory, name, limit_for(expected, new), context)?;
+        if expected_matches(current.as_ref(), expected) {
+            return Ok(Recheck::Proceed);
+        }
+        if current.as_ref() == Some(new) {
+            return Ok(Recheck::AlreadyExact);
+        }
+        Err(StorageError::StaleExpected {
+            context: context.clone(),
+        })
+    }
+}
+
+fn compare_exchange_guarded<E>(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    expected: ExpectedValue,
+    new: ExactObject,
+    validate: impl FnOnce() -> Result<(), E>,
+) -> Result<CasOutcome, CompareExchangeError<E>> {
+    temporary::reject_reserved_destination(
+        directory,
+        name,
+        &new,
+        StorageOperation::CompareExchange,
+    )?;
+    let before = context(directory, name, &new, DurabilityStep::BeforeMutation);
+    lease.validate_for(&directory.handle, &before)?;
+    match read_current(directory, name, limit_for(&expected, &new), &before)? {
+        Some(current) if current == new => {
+            stabilize_known_value(lease, directory, name, &new)?;
+            return Ok(CasOutcome::AlreadyExact);
+        }
+        current if expected_matches(current.as_ref(), &expected) => {}
+        _ => return Err(StorageError::StaleExpected { context: before }.into()),
+    }
+    let temporary = temporary::create(directory, lease, StorageOperation::CompareExchange, &new)?;
+    match lease.validate_expected_again(directory, name, &expected, &new, &before) {
+        Ok(Recheck::Proceed) => {}
+        Ok(Recheck::AlreadyExact) => {
+            cleanup_known_value(lease, directory, name, &new, &temporary)?;
+            return Ok(CasOutcome::AlreadyExact);
+        }
+        Err(error) => return Err(error.into()),
+    }
+    temporary::verify_owned(directory, &temporary, StorageOperation::CompareExchange)?;
+    if let Err(source) = validate() {
+        return match lease.cleanup_owned_temporary(directory, &temporary) {
+            Ok(()) => Err(CompareExchangeError::Validation { source }),
+            Err(cleanup) => Err(CompareExchangeError::ValidationAndCleanup {
+                validation: source,
+                cleanup,
+            }),
+        };
+    }
+    temporary::verify_owned(directory, &temporary, StorageOperation::CompareExchange)?;
+    match lease.validate_expected_again(directory, name, &expected, &new, &before) {
+        Ok(Recheck::Proceed) => {}
+        Ok(Recheck::AlreadyExact) => {
+            cleanup_known_value(lease, directory, name, &new, &temporary)?;
+            return Ok(CasOutcome::AlreadyExact);
+        }
+        Err(error) => return Err(error.into()),
+    }
+    exchange_prepared(lease, directory, name, &expected, &new, &temporary).map_err(Into::into)
+}
+
+fn cleanup_known_value(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    new: &ExactObject,
+    temporary: &crate::OwnedTemporary,
+) -> StorageResult<()> {
+    let readback = context(directory, name, new, DurabilityStep::AuthorizationReadback);
+    lease
+        .cleanup_owned_temporary(directory, temporary)
+        .map_err(|source| unresolved(readback.clone(), source))?;
+    stabilize_known_value(lease, directory, name, new)
+}
+
+fn stabilize_known_value(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    new: &ExactObject,
+) -> StorageResult<()> {
+    let readback = context(directory, name, new, DurabilityStep::AuthorizationReadback);
+    make_authorization_durable(lease, directory, name, new)
+        .map_err(|source| unresolved(readback, source))
+}
+
+fn exchange_prepared(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    expected: &ExpectedValue,
+    new: &ExactObject,
+    temporary: &crate::OwnedTemporary,
+) -> StorageResult<CasOutcome> {
+    let rename = context(directory, name, new, DurabilityStep::AuthorizationRename);
+    let renamed = syscall(&directory.handle.anchor.faults, &rename, || {
+        rename_authorization(directory, temporary.name(), name, expected)
+    });
+    if let Err(error) = renamed {
+        return recover(lease, directory, name, expected, new, temporary, error);
+    }
+    let parent = context(directory, name, new, DurabilityStep::ParentDirectory);
+    if let Err(error) = sync_directory(
+        &directory.handle.fd,
+        &directory.handle.anchor.faults,
+        &parent,
+    ) {
+        return recover(lease, directory, name, expected, new, temporary, error);
+    }
+    validate_committed(lease, directory, name, new)?;
+    Ok(CasOutcome::Exchanged)
+}
+
+fn validate_committed(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    new: &ExactObject,
+) -> StorageResult<()> {
+    let readback = context(directory, name, new, DurabilityStep::AuthorizationReadback);
+    directory
+        .handle
+        .anchor
+        .faults
+        .before(&readback)
+        .and_then(|()| {
+            objects::verify_exact(
+                &directory.handle,
+                name,
+                new,
+                StorageOperation::CompareExchange,
+            )?;
+            directory.handle.anchor.faults.after(&readback)
+        })
+        .map_err(|source| unresolved(readback, source))?;
+    let after = context(directory, name, new, DurabilityStep::AfterMutation);
+    lease
+        .validate_for(&directory.handle, &after)
+        .map_err(|source| unresolved(after, source))
+}
+
+fn rename_authorization(
+    directory: &DurableDirectory,
+    temporary: &ObjectName,
+    destination: &ObjectName,
+    expected: &ExpectedValue,
+) -> rustix::io::Result<()> {
+    if matches!(expected, ExpectedValue::Absent) {
+        return rename_absent(directory, temporary, destination);
+    }
+    renameat(
+        &directory.handle.fd,
+        temporary.as_os_str(),
+        &directory.handle.fd,
+        destination.as_os_str(),
+    )
+}
+
+#[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
+pub(crate) fn rename_absent(
+    directory: &DurableDirectory,
+    temporary: &ObjectName,
+    destination: &ObjectName,
+) -> rustix::io::Result<()> {
+    renameat_with(
+        &directory.handle.fd,
+        temporary.as_os_str(),
+        &directory.handle.fd,
+        destination.as_os_str(),
+        RenameFlags::NOREPLACE,
+    )
+}
+
+fn recover(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    expected: &ExpectedValue,
+    new: &ExactObject,
+    temporary: &crate::OwnedTemporary,
+    original: StorageError,
+) -> StorageResult<CasOutcome> {
+    let readback = context(directory, name, new, DurabilityStep::AuthorizationReadback);
+    let recovered = directory
+        .handle
+        .anchor
+        .faults
+        .before(&readback)
+        .and_then(|()| {
+            let value = read_current(directory, name, limit_for(expected, new), &readback)?;
+            directory.handle.anchor.faults.after(&readback)?;
+            Ok(value)
+        });
+    let current = match recovered {
+        Ok(value) => value,
+        Err(error) => return Err(ambiguous(readback, Some(original), error)),
+    };
+    if current.as_ref() == Some(new) {
+        let temporary_exists = match directory.exists(temporary.name()) {
+            Ok(exists) => exists,
+            Err(source) => return Err(ambiguous(readback, Some(original), source)),
+        };
+        if temporary_exists && let Err(source) = lease.cleanup_owned_temporary(directory, temporary)
+        {
+            return Err(ambiguous(readback, Some(original), source));
+        }
+        let barrier = context(directory, name, new, DurabilityStep::RecoveryBarrier);
+        if let Err(error) = sync_directory(
+            &directory.handle.fd,
+            &directory.handle.anchor.faults,
+            &barrier,
+        ) {
+            return Err(ambiguous(barrier, Some(original), error));
+        }
+        if let Err(source) = validate_committed(lease, directory, name, new) {
+            return Err(ambiguous(barrier, Some(original), source));
+        }
+        return Ok(CasOutcome::AlreadyExact);
+    }
+    if expected_matches(current.as_ref(), expected) {
+        if directory.exists(temporary.name())? {
+            lease.cleanup_owned_temporary(directory, temporary)?;
+        }
+        return Err(original);
+    }
+    Err(StorageError::StaleExpected { context: readback })
+}
+
+fn read_current(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    maximum_bytes: usize,
+    context: &StorageContext,
+) -> StorageResult<Option<ExactObject>> {
+    let stat = match statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Ok(stat) => stat,
+        Err(Errno::NOENT) => return Ok(None),
+        Err(source) => {
+            return Err(StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            });
+        }
+    };
+    let inspected = inspect_private(&stat, context)?;
+    if inspected.kind != ObjectKind::RegularFile {
+        return Err(StorageError::WrongType {
+            context: context.clone(),
+        });
+    }
+    if inspected.size > maximum_bytes as u64 {
+        return Err(StorageError::Corruption {
+            reason: "mutable object exceeds all exact values",
+            context: context.clone(),
+        });
+    }
+    objects::read_exact(&directory.handle, name, maximum_bytes).map(Some)
+}
+
+fn make_authorization_durable(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    new: &ExactObject,
+) -> StorageResult<()> {
+    objects::verify_exact(
+        &directory.handle,
+        name,
+        new,
+        StorageOperation::CompareExchange,
+    )?;
+    let object = context(directory, name, new, DurabilityStep::ObjectData);
+    let named = statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|source| StorageError::Io {
+        context: object.clone(),
+        source: source.into(),
+    })?;
+    let named_inspection = inspect_private(&named, &object)?;
+    let fd = objects::open_regular(&directory.handle, name, &object)?;
+    objects::verify_open_identity(&fd, named_inspection.identity, &object)?;
+    if let Err(error) = sync_file(&fd, &directory.handle.anchor.faults, &object) {
+        return Err(ambiguous(object, None, error));
+    }
+    let parent = context(directory, name, new, DurabilityStep::ParentDirectory);
+    if let Err(error) = sync_directory(
+        &directory.handle.fd,
+        &directory.handle.anchor.faults,
+        &parent,
+    ) {
+        return Err(ambiguous(parent, None, error));
+    }
+    objects::verify_exact(
+        &directory.handle,
+        name,
+        new,
+        StorageOperation::CompareExchange,
+    )?;
+    let after = context(directory, name, new, DurabilityStep::AfterMutation);
+    lease.validate_for(&directory.handle, &after)
+}
+
+fn expected_matches(current: Option<&ExactObject>, expected: &ExpectedValue) -> bool {
+    match (current, expected) {
+        (None, ExpectedValue::Absent) => true,
+        (Some(actual), ExpectedValue::Exact(required)) => actual == required,
+        _ => false,
+    }
+}
+
+enum Recheck {
+    Proceed,
+    AlreadyExact,
+}
+
+fn limit_for(expected: &ExpectedValue, new: &ExactObject) -> usize {
+    match expected {
+        ExpectedValue::Absent => new.bytes().len(),
+        ExpectedValue::Exact(old) => old.bytes().len().max(new.bytes().len()),
+    }
+}
+
+fn ambiguous(
+    context: StorageContext,
+    prior: Option<StorageError>,
+    source: StorageError,
+) -> StorageError {
+    StorageError::AmbiguousCommit {
+        context,
+        prior: prior.map(Box::new),
+        source: Box::new(source),
+    }
+}
+
+fn unresolved(context: StorageContext, source: StorageError) -> StorageError {
+    if matches!(source, StorageError::AmbiguousCommit { .. }) {
+        source
+    } else {
+        ambiguous(context, None, source)
+    }
+}
+
+fn context(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    object: &ExactObject,
+    step: DurabilityStep,
+) -> StorageContext {
+    directory.handle.context_with_object(
+        Some(name),
+        Some(object.digest()),
+        StorageOperation::CompareExchange,
+        step,
+    )
+}

--- a/crates/pilotage-durable-storage/src/unix/directory.rs
+++ b/crates/pilotage-durable-storage/src/unix/directory.rs
@@ -1,0 +1,266 @@
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+
+use rustix::fs::{AtFlags, Dir, fchmod, fstat, mkdirat, statat};
+use rustix::io::Errno;
+
+use crate::{
+    ContentDigest, DurabilityStep, ExactObject, ObjectInspection, ObjectName, OwnedTemporary,
+    PrivateTreeLimits, PrivateTreeManifest, PutOutcome, StorageError, StorageOperation,
+    StorageResult,
+};
+
+use super::anchor::{DirectoryHandle, open_directory};
+use super::barrier::{sync_directory, syscall};
+use super::metadata::{directory_mode, identity, inspect_private};
+use super::objects;
+use super::temporary;
+use super::writer::WriterLease;
+
+/// One verified directory in an anchored storage session.
+#[derive(Clone)]
+pub struct DurableDirectory {
+    pub(crate) handle: DirectoryHandle,
+}
+
+impl DurableDirectory {
+    pub(crate) const fn new(handle: DirectoryHandle) -> Self {
+        Self { handle }
+    }
+
+    /// Create or open one exact private child directory.
+    pub fn child(&self, lease: &WriterLease, name: &ObjectName) -> StorageResult<Self> {
+        let context = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::BeforeMutation,
+        );
+        lease.validate_for(&self.handle, &context)?;
+        let existed = match statat(&self.handle.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+            Ok(_) => true,
+            Err(Errno::NOENT) => false,
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context,
+                    source: source.into(),
+                });
+            }
+        };
+        if !existed {
+            self.create_child(lease, name)?;
+        }
+        let fd = open_directory(&self.handle.fd, name).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        let stat = fstat(&fd).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        let inspected = inspect_private(&stat, &context)?;
+        let child = Self::new(self.handle.child(fd, name.clone(), inspected.identity));
+        child.handle.validate(&context)?;
+        let child_barrier = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::ObjectData,
+        );
+        sync_directory(&child.handle.fd, &self.handle.anchor.faults, &child_barrier)?;
+        let parent_barrier = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::ParentDirectory,
+        );
+        sync_directory(&self.handle.fd, &self.handle.anchor.faults, &parent_barrier)?;
+        let after = child.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::AfterMutation,
+        );
+        lease.validate_for(&child.handle, &after)?;
+        Ok(child)
+    }
+
+    /// Report whether one name identifies a valid managed object.
+    pub fn exists(&self, name: &ObjectName) -> StorageResult<bool> {
+        let context = self.handle.context(
+            Some(name),
+            StorageOperation::InspectObject,
+            DurabilityStep::Selection,
+        );
+        self.handle.validate(&context)?;
+        let result = match statat(&self.handle.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+            Ok(stat) => {
+                inspect_private(&stat, &context)?;
+                true
+            }
+            Err(Errno::NOENT) => false,
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context,
+                    source: source.into(),
+                });
+            }
+        };
+        self.handle.validate(&context)?;
+        Ok(result)
+    }
+
+    /// List normal components in byte order.
+    pub fn list(&self) -> StorageResult<Vec<ObjectName>> {
+        let context = self.handle.context(
+            None,
+            StorageOperation::ListDirectory,
+            DurabilityStep::Selection,
+        );
+        self.handle.validate(&context)?;
+        let directory = Dir::read_from(&self.handle.fd).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        let mut names = Vec::new();
+        for entry in directory {
+            let entry = entry.map_err(|source| StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            })?;
+            let bytes = entry.file_name().to_bytes();
+            if bytes == b"." || bytes == b".." {
+                continue;
+            }
+            let name = OsStr::from_bytes(bytes);
+            names.push(
+                ObjectName::new(name).map_err(|_| StorageError::invalid_name_at(name, &context))?,
+            );
+        }
+        names.sort();
+        self.handle.validate(&context)?;
+        Ok(names)
+    }
+
+    /// Inspect one exact private object without following links.
+    pub fn inspect(&self, name: &ObjectName) -> StorageResult<ObjectInspection> {
+        objects::inspect(&self.handle, name)
+    }
+
+    /// Read a regular private object up to an exact byte limit.
+    pub fn read_exact(
+        &self,
+        name: &ObjectName,
+        maximum_bytes: usize,
+    ) -> StorageResult<ExactObject> {
+        objects::read_exact(&self.handle, name, maximum_bytes)
+    }
+
+    /// Read a private object and require one SHA-256 digest.
+    pub fn read_digest(
+        &self,
+        name: &ObjectName,
+        expected: ContentDigest,
+        maximum_bytes: usize,
+    ) -> StorageResult<ExactObject> {
+        objects::read_digest(&self.handle, name, expected, maximum_bytes)
+    }
+
+    /// Publish an immutable object without replacing another object.
+    pub fn put_immutable_no_replace(
+        &self,
+        lease: &WriterLease,
+        name: &ObjectName,
+        object: &ExactObject,
+    ) -> StorageResult<PutOutcome> {
+        objects::put_immutable(self, lease, name, object)
+    }
+
+    /// Inspect a private temporary object created by this store.
+    pub fn inspect_owned_temporary(
+        &self,
+        name: &ObjectName,
+        maximum_bytes: usize,
+    ) -> StorageResult<OwnedTemporary> {
+        temporary::inspect_owned(self, name, maximum_bytes)
+    }
+
+    /// Capture one exact private tree manifest without following links.
+    pub fn inspect_private_tree(
+        &self,
+        name: &ObjectName,
+        limits: PrivateTreeLimits,
+    ) -> StorageResult<PrivateTreeManifest> {
+        super::remove::inspect_private_tree(self, name, limits)
+    }
+
+    fn create_child(&self, lease: &WriterLease, name: &ObjectName) -> StorageResult<()> {
+        let create = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::Creation,
+        );
+        let creation = syscall(&self.handle.anchor.faults, &create, || {
+            mkdirat(&self.handle.fd, name.as_os_str(), directory_mode())
+        });
+        let fd = match creation {
+            Ok(()) => open_directory(&self.handle.fd, name),
+            Err(original) => {
+                match statat(&self.handle.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+                    Ok(stat) => {
+                        inspect_private(&stat, &create)?;
+                        open_directory(&self.handle.fd, name)
+                    }
+                    Err(Errno::NOENT) => return Err(original),
+                    Err(source) => {
+                        return Err(StorageError::Io {
+                            context: create,
+                            source: source.into(),
+                        });
+                    }
+                }
+            }
+        }
+        .map_err(|source| StorageError::Io {
+            context: create.clone(),
+            source: source.into(),
+        })?;
+        fchmod(&fd, directory_mode()).map_err(|source| StorageError::Io {
+            context: create.clone(),
+            source: source.into(),
+        })?;
+        let stat = fstat(&fd).map_err(|source| StorageError::Io {
+            context: create.clone(),
+            source: source.into(),
+        })?;
+        inspect_private(&stat, &create)?;
+        let object = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::ObjectData,
+        );
+        sync_directory(&fd, &self.handle.anchor.faults, &object)?;
+        let parent = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::ParentDirectory,
+        );
+        sync_directory(&self.handle.fd, &self.handle.anchor.faults, &parent)?;
+        let after = self.handle.context(
+            Some(name),
+            StorageOperation::CreateDirectory,
+            DurabilityStep::AfterMutation,
+        );
+        lease.validate_for(&self.handle, &after)?;
+        let named = statat(&self.handle.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW).map_err(
+            |source| StorageError::Io {
+                context: parent.clone(),
+                source: source.into(),
+            },
+        )?;
+        if identity(&named) != identity(&stat) {
+            return Err(StorageError::IdentityChanged {
+                expected: identity(&stat),
+                actual: Some(identity(&named)),
+                context: parent,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/pilotage-durable-storage/src/unix/metadata.rs
+++ b/crates/pilotage-durable-storage/src/unix/metadata.rs
@@ -24,7 +24,7 @@ pub(crate) fn identity(stat: &Stat) -> ObjectIdentity {
 }
 
 pub(crate) fn mode(stat: &Stat) -> u32 {
-    u32::from(stat.st_mode) & 0o7777
+    widen_mode(stat.st_mode) & 0o7777
 }
 
 pub(crate) fn inspect_private(
@@ -49,7 +49,7 @@ pub(crate) fn inspect_private(
             context: context.clone(),
         });
     }
-    let link_count = u64::from(stat.st_nlink);
+    let link_count = widen_link_count(stat.st_nlink);
     if kind == ObjectKind::RegularFile && link_count != 1 {
         return Err(StorageError::LinkedObject {
             actual: link_count,
@@ -86,7 +86,15 @@ pub(crate) fn inspect_temporary(
         identity: identity(stat),
         kind: ObjectKind::RegularFile,
         mode: actual,
-        link_count: u64::from(stat.st_nlink),
+        link_count: widen_link_count(stat.st_nlink),
         size: stat.st_size.max(0) as u64,
     })
+}
+
+fn widen_mode<T: Into<u32>>(value: T) -> u32 {
+    value.into()
+}
+
+fn widen_link_count<T: Into<u64>>(value: T) -> u64 {
+    value.into()
 }

--- a/crates/pilotage-durable-storage/src/unix/metadata.rs
+++ b/crates/pilotage-durable-storage/src/unix/metadata.rs
@@ -1,0 +1,92 @@
+use rustix::fs::{FileType, Mode, Stat};
+
+use crate::{
+    ObjectIdentity, ObjectInspection, ObjectKind, StorageContext, StorageError, StorageResult,
+};
+
+pub(crate) const PRIVATE_DIRECTORY_MODE: u32 = 0o700;
+pub(crate) const PRIVATE_FILE_MODE: u32 = 0o600;
+
+pub(crate) fn directory_mode() -> Mode {
+    Mode::RWXU
+}
+
+pub(crate) fn file_mode() -> Mode {
+    Mode::RUSR | Mode::WUSR
+}
+
+#[allow(clippy::unnecessary_cast)]
+pub(crate) fn identity(stat: &Stat) -> ObjectIdentity {
+    ObjectIdentity {
+        device: stat.st_dev as u64,
+        inode: stat.st_ino as u64,
+    }
+}
+
+pub(crate) fn mode(stat: &Stat) -> u32 {
+    (stat.st_mode as u32) & 0o7777
+}
+
+pub(crate) fn inspect_private(
+    stat: &Stat,
+    context: &StorageContext,
+) -> StorageResult<ObjectInspection> {
+    let file_type = FileType::from_raw_mode(stat.st_mode);
+    let (kind, required) = if file_type.is_file() {
+        (ObjectKind::RegularFile, PRIVATE_FILE_MODE)
+    } else if file_type.is_dir() {
+        (ObjectKind::Directory, PRIVATE_DIRECTORY_MODE)
+    } else {
+        return Err(StorageError::WrongType {
+            context: context.clone(),
+        });
+    };
+    let actual = mode(stat);
+    if actual != required {
+        return Err(StorageError::WrongMode {
+            required,
+            actual,
+            context: context.clone(),
+        });
+    }
+    let link_count = stat.st_nlink as u64;
+    if kind == ObjectKind::RegularFile && link_count != 1 {
+        return Err(StorageError::LinkedObject {
+            actual: link_count,
+            context: context.clone(),
+        });
+    }
+    Ok(ObjectInspection {
+        identity: identity(stat),
+        kind,
+        mode: actual,
+        link_count,
+        size: stat.st_size.max(0) as u64,
+    })
+}
+
+pub(crate) fn inspect_temporary(
+    stat: &Stat,
+    context: &StorageContext,
+) -> StorageResult<ObjectInspection> {
+    if !FileType::from_raw_mode(stat.st_mode).is_file() {
+        return Err(StorageError::WrongType {
+            context: context.clone(),
+        });
+    }
+    let actual = mode(stat);
+    if actual != PRIVATE_FILE_MODE {
+        return Err(StorageError::WrongMode {
+            required: PRIVATE_FILE_MODE,
+            actual,
+            context: context.clone(),
+        });
+    }
+    Ok(ObjectInspection {
+        identity: identity(stat),
+        kind: ObjectKind::RegularFile,
+        mode: actual,
+        link_count: stat.st_nlink as u64,
+        size: stat.st_size.max(0) as u64,
+    })
+}

--- a/crates/pilotage-durable-storage/src/unix/metadata.rs
+++ b/crates/pilotage-durable-storage/src/unix/metadata.rs
@@ -24,7 +24,7 @@ pub(crate) fn identity(stat: &Stat) -> ObjectIdentity {
 }
 
 pub(crate) fn mode(stat: &Stat) -> u32 {
-    (stat.st_mode as u32) & 0o7777
+    u32::from(stat.st_mode) & 0o7777
 }
 
 pub(crate) fn inspect_private(
@@ -49,7 +49,7 @@ pub(crate) fn inspect_private(
             context: context.clone(),
         });
     }
-    let link_count = stat.st_nlink as u64;
+    let link_count = u64::from(stat.st_nlink);
     if kind == ObjectKind::RegularFile && link_count != 1 {
         return Err(StorageError::LinkedObject {
             actual: link_count,
@@ -86,7 +86,7 @@ pub(crate) fn inspect_temporary(
         identity: identity(stat),
         kind: ObjectKind::RegularFile,
         mode: actual,
-        link_count: stat.st_nlink as u64,
+        link_count: u64::from(stat.st_nlink),
         size: stat.st_size.max(0) as u64,
     })
 }

--- a/crates/pilotage-durable-storage/src/unix/objects.rs
+++ b/crates/pilotage-durable-storage/src/unix/objects.rs
@@ -1,0 +1,383 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+
+use rustix::fd::OwnedFd;
+use rustix::fs::{AtFlags, Mode, OFlags, fstat, openat, statat};
+
+use crate::{
+    ContentDigest, DurabilityStep, ExactObject, ObjectInspection, ObjectName, PutOutcome,
+    StorageError, StorageOperation, StorageResult,
+};
+
+use super::anchor::DirectoryHandle;
+use super::barrier::sync_directory;
+use super::directory::DurableDirectory;
+use super::metadata::{inspect_private, inspect_temporary};
+use super::temporary;
+use super::writer::WriterLease;
+
+pub(crate) fn inspect(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+) -> StorageResult<ObjectInspection> {
+    let context = directory.context(
+        Some(name),
+        StorageOperation::InspectObject,
+        DurabilityStep::Selection,
+    );
+    directory.validate(&context)?;
+    let stat =
+        statat(&directory.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW).map_err(|source| {
+            StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            }
+        })?;
+    let inspected = inspect_private(&stat, &context)?;
+    directory.validate(&context)?;
+    Ok(inspected)
+}
+
+pub(crate) fn read_exact(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    maximum_bytes: usize,
+) -> StorageResult<ExactObject> {
+    read_exact_with_links(directory, name, maximum_bytes, 1)
+}
+
+pub(crate) fn read_digest(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    expected: ContentDigest,
+    maximum_bytes: usize,
+) -> StorageResult<ExactObject> {
+    let actual = read_exact(directory, name, maximum_bytes).map_err(|error| {
+        error.at_object(
+            StorageOperation::ReadObject,
+            expected,
+            DurabilityStep::ObjectReadback,
+        )
+    })?;
+    if actual.digest() == expected {
+        Ok(actual)
+    } else {
+        Err(StorageError::ContentMismatch {
+            context: directory.context_with_object(
+                Some(name),
+                Some(expected),
+                StorageOperation::ReadObject,
+                DurabilityStep::ObjectReadback,
+            ),
+        })
+    }
+}
+
+pub(crate) fn read_exact_with_links(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    maximum_bytes: usize,
+    expected_links: u64,
+) -> StorageResult<ExactObject> {
+    let context = directory.context(
+        Some(name),
+        StorageOperation::ReadObject,
+        DurabilityStep::ObjectReadback,
+    );
+    directory.validate(&context)?;
+    let named_before =
+        statat(&directory.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW).map_err(|source| {
+            StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            }
+        })?;
+    let inspected = inspect_temporary(&named_before, &context)?;
+    if inspected.link_count != expected_links {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context,
+        });
+    }
+    enforce_limit(inspected.size, maximum_bytes, &context)?;
+    let fd = open_regular(directory, name, &context)?;
+    let opened = verify_open_temporary_identity(&fd, inspected.identity, &context)?;
+    if opened.link_count != expected_links {
+        return Err(StorageError::LinkedObject {
+            actual: opened.link_count,
+            context,
+        });
+    }
+    let mut file = File::from(fd);
+    let first = read_limited(&mut file, maximum_bytes, &context)?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source,
+        })?;
+    let second = read_limited(&mut file, maximum_bytes, &context)?;
+    if first != second || first.len() as u64 != inspected.size {
+        return Err(StorageError::ContentMismatch {
+            context: context.clone(),
+        });
+    }
+    let held_after = verify_open_temporary_identity(&file, inspected.identity, &context)?;
+    let named_after =
+        statat(&directory.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW).map_err(|source| {
+            StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            }
+        })?;
+    let after = inspect_temporary(&named_after, &context)?;
+    if after.identity != inspected.identity {
+        return Err(StorageError::IdentityChanged {
+            expected: inspected.identity,
+            actual: Some(after.identity),
+            context,
+        });
+    }
+    if held_after.link_count != expected_links
+        || after.link_count != expected_links
+        || held_after.size != inspected.size
+        || after.size != inspected.size
+        || first.len() as u64 != after.size
+    {
+        return Err(StorageError::ContentMismatch {
+            context: context.clone(),
+        });
+    }
+    directory.validate(&context)?;
+    Ok(ExactObject::from_bytes(first))
+}
+
+pub(crate) fn put_immutable(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    object: &ExactObject,
+) -> StorageResult<PutOutcome> {
+    temporary::reject_reserved_destination(
+        directory,
+        name,
+        object,
+        StorageOperation::PublishImmutable,
+    )?;
+    let before = directory.handle.context_with_object(
+        Some(name),
+        Some(object.digest()),
+        StorageOperation::PublishImmutable,
+        DurabilityStep::BeforeMutation,
+    );
+    lease.validate_for(&directory.handle, &before)?;
+    if temporary::recover_linked_publication(directory, lease, name, object)? {
+        make_existing_durable(&directory.handle, name, object)?;
+        let after = directory.handle.context_with_object(
+            Some(name),
+            Some(object.digest()),
+            StorageOperation::PublishImmutable,
+            DurabilityStep::AfterMutation,
+        );
+        lease.validate_for(&directory.handle, &after)?;
+        return Ok(PutOutcome::AlreadyExact);
+    }
+    if exists_raw(&directory.handle, name, &before)? {
+        verify_exact(
+            &directory.handle,
+            name,
+            object,
+            StorageOperation::PublishImmutable,
+        )?;
+        make_existing_durable(&directory.handle, name, object)?;
+        let after = directory.handle.context_with_object(
+            Some(name),
+            Some(object.digest()),
+            StorageOperation::PublishImmutable,
+            DurabilityStep::AfterMutation,
+        );
+        lease.validate_for(&directory.handle, &after)?;
+        return Ok(PutOutcome::AlreadyExact);
+    }
+    let temporary =
+        temporary::create(directory, lease, StorageOperation::PublishImmutable, object)?;
+    temporary::publish_link(directory, lease, &temporary, name, object)?;
+    make_existing_durable(&directory.handle, name, object)?;
+    let after = directory.handle.context_with_object(
+        Some(name),
+        Some(object.digest()),
+        StorageOperation::PublishImmutable,
+        DurabilityStep::AfterMutation,
+    );
+    lease.validate_for(&directory.handle, &after)?;
+    Ok(PutOutcome::Published)
+}
+
+pub(crate) fn verify_exact(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    expected: &ExactObject,
+    operation: StorageOperation,
+) -> StorageResult<()> {
+    let actual = read_exact(directory, name, expected.bytes().len()).map_err(|error| {
+        error.at_object(operation, expected.digest(), DurabilityStep::ObjectReadback)
+    })?;
+    if actual.digest() != expected.digest() || actual.bytes() != expected.bytes() {
+        let context = directory.context_with_object(
+            Some(name),
+            Some(expected.digest()),
+            operation,
+            DurabilityStep::ObjectReadback,
+        );
+        return Err(StorageError::ContentMismatch { context });
+    }
+    Ok(())
+}
+
+pub(crate) fn exists_raw(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    context: &crate::StorageContext,
+) -> StorageResult<bool> {
+    match statat(&directory.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(stat) => {
+            inspect_private(&stat, context)?;
+            Ok(true)
+        }
+        Err(rustix::io::Errno::NOENT) => Ok(false),
+        Err(source) => Err(StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        }),
+    }
+}
+
+pub(crate) fn make_existing_durable(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    object: &ExactObject,
+) -> StorageResult<()> {
+    verify_exact(directory, name, object, StorageOperation::PublishImmutable)?;
+    let context = directory.context_with_object(
+        Some(name),
+        Some(object.digest()),
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectData,
+    );
+    let fd = open_regular(directory, name, &context)?;
+    let named =
+        statat(&directory.fd, name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW).map_err(|source| {
+            StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            }
+        })?;
+    let named_inspection = inspect_private(&named, &context)?;
+    verify_open_identity(&fd, named_inspection.identity, &context)?;
+    super::barrier::sync_file(&fd, &directory.anchor.faults, &context)?;
+    let parent = crate::StorageContext {
+        step: DurabilityStep::ParentDirectory,
+        ..context
+    };
+    sync_directory(&directory.fd, &directory.anchor.faults, &parent)?;
+    verify_exact(directory, name, object, StorageOperation::PublishImmutable)
+}
+
+pub(crate) fn open_regular(
+    directory: &DirectoryHandle,
+    name: &ObjectName,
+    context: &crate::StorageContext,
+) -> StorageResult<OwnedFd> {
+    openat(
+        &directory.fd,
+        name.as_os_str(),
+        OFlags::RDONLY | OFlags::NONBLOCK | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })
+}
+
+pub(crate) fn verify_open_identity(
+    fd: impl std::os::fd::AsFd,
+    expected: crate::ObjectIdentity,
+    context: &crate::StorageContext,
+) -> StorageResult<ObjectInspection> {
+    let stat = fstat(fd).map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_private(&stat, context)?;
+    if inspected.identity != expected {
+        return Err(StorageError::IdentityChanged {
+            expected,
+            actual: Some(inspected.identity),
+            context: context.clone(),
+        });
+    }
+    Ok(inspected)
+}
+
+fn verify_open_temporary_identity(
+    fd: impl std::os::fd::AsFd,
+    expected: crate::ObjectIdentity,
+    context: &crate::StorageContext,
+) -> StorageResult<ObjectInspection> {
+    let stat = fstat(fd).map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_temporary(&stat, context)?;
+    if inspected.identity != expected {
+        return Err(StorageError::IdentityChanged {
+            expected,
+            actual: Some(inspected.identity),
+            context: context.clone(),
+        });
+    }
+    Ok(inspected)
+}
+
+fn enforce_limit(
+    actual: u64,
+    maximum_bytes: usize,
+    context: &crate::StorageContext,
+) -> StorageResult<()> {
+    if actual > maximum_bytes as u64 {
+        return Err(StorageError::ObjectTooLarge {
+            limit: maximum_bytes,
+            actual,
+            context: context.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn read_limited(
+    file: &mut File,
+    maximum_bytes: usize,
+    context: &crate::StorageContext,
+) -> StorageResult<Vec<u8>> {
+    let take = maximum_bytes
+        .checked_add(1)
+        .ok_or_else(|| StorageError::Corruption {
+            reason: "read limit cannot be represented",
+            context: context.clone(),
+        })?;
+    let mut bytes = Vec::new();
+    file.take(take as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source,
+        })?;
+    if bytes.len() > maximum_bytes {
+        return Err(StorageError::ObjectTooLarge {
+            limit: maximum_bytes,
+            actual: bytes.len() as u64,
+            context: context.clone(),
+        });
+    }
+    Ok(bytes)
+}

--- a/crates/pilotage-durable-storage/src/unix/remove.rs
+++ b/crates/pilotage-durable-storage/src/unix/remove.rs
@@ -1,0 +1,231 @@
+use rustix::fs::{AtFlags, statat, unlinkat};
+use rustix::io::Errno;
+
+use crate::{
+    DurabilityStep, ObjectKind, ObjectName, PrivateTreeManifest, StorageContext, StorageError,
+    StorageOperation, StorageResult, types::PrivateTreeNode,
+};
+
+use super::barrier::{sync_directory, syscall};
+use super::directory::DurableDirectory;
+use super::writer::WriterLease;
+
+mod manifest;
+
+pub(crate) use manifest::inspect_private_tree;
+
+impl WriterLease {
+    /// Remove one exact private tree manifest.
+    pub fn remove_private_tree(
+        &self,
+        directory: &DurableDirectory,
+        manifest: &PrivateTreeManifest,
+    ) -> StorageResult<()> {
+        let context = directory.handle.context(
+            Some(&manifest.root.name),
+            StorageOperation::RemoveTree,
+            DurabilityStep::BeforeMutation,
+        );
+        self.validate_for(&directory.handle, &context)?;
+        manifest::validate_owner(directory, manifest, &context)?;
+        if self.protects_writer_lock(directory, &manifest.root.name) {
+            return Err(StorageError::Corruption {
+                reason: "writer lease file cannot be removed",
+                context,
+            });
+        }
+        manifest::verify(directory, &manifest.root, &context)?;
+        remove_node(self, directory, &manifest.root)
+    }
+
+    /// Remove one verified owned temporary file.
+    pub fn cleanup_owned_temporary(
+        &self,
+        directory: &DurableDirectory,
+        temporary: &crate::OwnedTemporary,
+    ) -> StorageResult<()> {
+        super::temporary::cleanup(directory, self, temporary)
+    }
+
+    fn protects_writer_lock(&self, directory: &DurableDirectory, name: &ObjectName) -> bool {
+        std::sync::Arc::ptr_eq(&directory.handle.fd, &self.anchor.root_fd)
+            && Self::is_writer_lock_name(name)
+    }
+}
+
+fn remove_node(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+) -> StorageResult<()> {
+    let context = directory.handle.context(
+        Some(&node.name),
+        StorageOperation::RemoveTree,
+        DurabilityStep::BeforeMutation,
+    );
+    manifest::verify_exact_node(directory, node, &context)?;
+    if node.kind == ObjectKind::Directory {
+        let child = manifest::open_manifest_directory(directory, node, &context)?;
+        for descendant in &node.children {
+            remove_node(lease, &child, descendant)?;
+        }
+        if !child.list()?.is_empty() {
+            return Err(StorageError::Corruption {
+                reason: "deletion directory gained an unknown object",
+                context,
+            });
+        }
+    }
+    lease.validate_for(&directory.handle, &context)?;
+    manifest::verify_exact_node(directory, node, &context)?;
+    let deletion = node.file.as_ref().map_or_else(
+        || {
+            directory.handle.context(
+                Some(&node.name),
+                StorageOperation::RemoveTree,
+                DurabilityStep::Deletion,
+            )
+        },
+        |file| {
+            directory.handle.context_with_object(
+                Some(&node.name),
+                Some(file.digest),
+                StorageOperation::RemoveTree,
+                DurabilityStep::Deletion,
+            )
+        },
+    );
+    let flags = if node.kind == ObjectKind::Directory {
+        AtFlags::REMOVEDIR
+    } else {
+        AtFlags::empty()
+    };
+    let result = syscall(&directory.handle.anchor.faults, &deletion, || {
+        unlinkat(&directory.handle.fd, node.name.as_os_str(), flags)
+    });
+    if let Err(error) = result {
+        return recover_unlink(lease, directory, node, deletion, error);
+    }
+    finish_removed(lease, directory, node, deletion)
+}
+
+fn recover_unlink(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    deletion: StorageContext,
+    original: StorageError,
+) -> StorageResult<()> {
+    match statat(
+        &directory.handle.fd,
+        node.name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Err(Errno::NOENT) => {
+            let barrier = StorageContext {
+                step: DurabilityStep::RecoveryBarrier,
+                ..deletion
+            };
+            sync_directory(
+                &directory.handle.fd,
+                &directory.handle.anchor.faults,
+                &barrier,
+            )?;
+            let mut after = barrier;
+            after.step = DurabilityStep::AfterMutation;
+            validate_absent_after(lease, directory, &node.name, after)
+        }
+        Ok(_) => {
+            let mut after = deletion.clone();
+            after.step = DurabilityStep::AfterMutation;
+            lease.validate_for(&directory.handle, &after)?;
+            Err(original)
+        }
+        Err(source) => Err(StorageError::Io {
+            context: deletion,
+            source: source.into(),
+        }),
+    }
+}
+
+fn finish_removed(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    deletion: StorageContext,
+) -> StorageResult<()> {
+    let parent = StorageContext {
+        step: DurabilityStep::ParentDirectory,
+        ..deletion
+    };
+    if let Err(first) = sync_directory(
+        &directory.handle.fd,
+        &directory.handle.anchor.faults,
+        &parent,
+    ) {
+        match statat(
+            &directory.handle.fd,
+            node.name.as_os_str(),
+            AtFlags::SYMLINK_NOFOLLOW,
+        ) {
+            Err(Errno::NOENT) => {}
+            Ok(_) => {
+                return Err(StorageError::Corruption {
+                    reason: "removed name reappeared before its durability barrier",
+                    context: parent,
+                });
+            }
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context: parent,
+                    source: source.into(),
+                });
+            }
+        }
+        let recovery = StorageContext {
+            step: DurabilityStep::RecoveryBarrier,
+            ..parent
+        };
+        if let Err(second) = sync_directory(
+            &directory.handle.fd,
+            &directory.handle.anchor.faults,
+            &recovery,
+        ) {
+            return Err(StorageError::AmbiguousCommit {
+                context: recovery,
+                prior: Some(Box::new(first)),
+                source: Box::new(second),
+            });
+        }
+        let mut after = recovery;
+        after.step = DurabilityStep::AfterMutation;
+        return validate_absent_after(lease, directory, &node.name, after);
+    }
+    let mut after = parent;
+    after.step = DurabilityStep::AfterMutation;
+    validate_absent_after(lease, directory, &node.name, after)
+}
+
+pub(crate) fn validate_absent_after(
+    lease: &WriterLease,
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    context: StorageContext,
+) -> StorageResult<()> {
+    lease.validate_for(&directory.handle, &context)?;
+    match statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Err(Errno::NOENT) => Ok(()),
+        Ok(_) => Err(StorageError::Corruption {
+            reason: "removed name reappeared after its durability barrier",
+            context,
+        }),
+        Err(source) => Err(StorageError::Io {
+            context,
+            source: source.into(),
+        }),
+    }
+}

--- a/crates/pilotage-durable-storage/src/unix/remove/manifest.rs
+++ b/crates/pilotage-durable-storage/src/unix/remove/manifest.rs
@@ -1,0 +1,348 @@
+use rustix::fs::{AtFlags, statat};
+
+use crate::{
+    DurabilityStep, ObjectInspection, ObjectKind, ObjectName, PrivateTreeLimits,
+    PrivateTreeManifest, StorageContext, StorageError, StorageOperation, StorageResult,
+    types::{PrivateFileManifest, PrivateTreeNode},
+};
+
+use super::super::anchor::open_directory;
+use super::super::directory::DurableDirectory;
+use super::super::metadata::inspect_private;
+use super::super::objects;
+
+struct TreeBudget {
+    remaining_objects: usize,
+    remaining_bytes: usize,
+}
+
+pub(crate) fn inspect_private_tree(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    limits: PrivateTreeLimits,
+) -> StorageResult<PrivateTreeManifest> {
+    let context = directory.handle.context(
+        Some(name),
+        StorageOperation::InspectObject,
+        DurabilityStep::Selection,
+    );
+    let mut budget = TreeBudget {
+        remaining_objects: limits.maximum_objects,
+        remaining_bytes: limits.maximum_total_bytes,
+    };
+    let root = build(directory, name, limits, &mut budget, &context)?;
+    verify(directory, &root, &context)?;
+    Ok(PrivateTreeManifest {
+        owner_root: directory.handle.anchor.identity,
+        owner_directory: directory.handle.identity,
+        root,
+        total_file_bytes: limits
+            .maximum_total_bytes
+            .saturating_sub(budget.remaining_bytes),
+    })
+}
+
+pub(super) fn validate_owner(
+    directory: &DurableDirectory,
+    manifest: &PrivateTreeManifest,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    if manifest.owner_root != directory.handle.anchor.identity {
+        return Err(StorageError::Corruption {
+            reason: "private tree manifest belongs to a different storage root",
+            context: context.clone(),
+        });
+    }
+    if manifest.owner_directory != directory.handle.identity {
+        return Err(StorageError::IdentityChanged {
+            expected: manifest.owner_directory,
+            actual: Some(directory.handle.identity),
+            context: context.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn build(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    limits: PrivateTreeLimits,
+    budget: &mut TreeBudget,
+    context: &StorageContext,
+) -> StorageResult<PrivateTreeNode> {
+    budget.take_object(context)?;
+    directory.handle.validate(context)?;
+    let stat = statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_private(&stat, context)?;
+    let mut node = PrivateTreeNode {
+        name: name.clone(),
+        identity: inspected.identity,
+        kind: inspected.kind,
+        file: None,
+        children: Vec::new(),
+    };
+    if inspected.kind == ObjectKind::RegularFile {
+        node.file = Some(capture_file(
+            directory, name, inspected, limits, budget, context,
+        )?);
+    } else {
+        build_children(directory, limits, budget, context, &mut node)?;
+    }
+    directory.handle.validate(context)?;
+    Ok(node)
+}
+
+fn build_children(
+    directory: &DurableDirectory,
+    limits: PrivateTreeLimits,
+    budget: &mut TreeBudget,
+    context: &StorageContext,
+    node: &mut PrivateTreeNode,
+) -> StorageResult<()> {
+    let child = open_manifest_directory(directory, node, context)?;
+    for child_name in child.list()? {
+        let child_context = child.handle.context(
+            Some(&child_name),
+            StorageOperation::RemoveTree,
+            DurabilityStep::BeforeMutation,
+        );
+        node.children
+            .push(build(&child, &child_name, limits, budget, &child_context)?);
+    }
+    Ok(())
+}
+
+impl TreeBudget {
+    fn take_object(&mut self, context: &StorageContext) -> StorageResult<()> {
+        self.remaining_objects =
+            self.remaining_objects
+                .checked_sub(1)
+                .ok_or_else(|| StorageError::Corruption {
+                    reason: "private tree exceeds the manifest object limit",
+                    context: context.clone(),
+                })?;
+        Ok(())
+    }
+}
+
+fn capture_file(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    inspected: ObjectInspection,
+    limits: PrivateTreeLimits,
+    budget: &mut TreeBudget,
+    context: &StorageContext,
+) -> StorageResult<PrivateFileManifest> {
+    let size = usize::try_from(inspected.size).map_err(|_| StorageError::ObjectTooLarge {
+        limit: limits.maximum_file_bytes,
+        actual: inspected.size,
+        context: context.clone(),
+    })?;
+    let limit = limits.maximum_file_bytes.min(budget.remaining_bytes);
+    if size > limit {
+        return Err(StorageError::ObjectTooLarge {
+            limit,
+            actual: inspected.size,
+            context: context.clone(),
+        });
+    }
+    let object = objects::read_exact(&directory.handle, name, size)?;
+    budget.remaining_bytes -= size;
+    let digest = object.digest();
+    let after = objects::inspect(&directory.handle, name).map_err(|error| {
+        error.at_object(
+            StorageOperation::RemoveTree,
+            digest,
+            DurabilityStep::ObjectReadback,
+        )
+    })?;
+    verify_captured_file(directory, name, inspected, after, digest)?;
+    Ok(PrivateFileManifest { digest, size })
+}
+
+fn verify_captured_file(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    before: ObjectInspection,
+    after: ObjectInspection,
+    digest: crate::ContentDigest,
+) -> StorageResult<()> {
+    let context = directory.handle.context_with_object(
+        Some(name),
+        Some(digest),
+        StorageOperation::RemoveTree,
+        DurabilityStep::ObjectReadback,
+    );
+    if after.identity != before.identity {
+        return Err(StorageError::IdentityChanged {
+            expected: before.identity,
+            actual: Some(after.identity),
+            context,
+        });
+    }
+    if after.size != before.size {
+        return Err(StorageError::ContentMismatch { context });
+    }
+    Ok(())
+}
+
+pub(super) fn verify(
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    directory.handle.validate(context)?;
+    verify_node(directory, node, context)?;
+    if node.kind == ObjectKind::RegularFile {
+        verify_regular_manifest(directory, node, context)?;
+        return directory.handle.validate(context);
+    }
+    if node.file.is_some() {
+        return Err(StorageError::Corruption {
+            reason: "a directory manifest has a regular-file value",
+            context: context.clone(),
+        });
+    }
+    let child = open_manifest_directory(directory, node, context)?;
+    verify_child_names(&child, node, context)?;
+    for descendant in &node.children {
+        let child_context = child.handle.context(
+            Some(&descendant.name),
+            StorageOperation::RemoveTree,
+            DurabilityStep::BeforeMutation,
+        );
+        verify(&child, descendant, &child_context)?;
+    }
+    directory.handle.validate(context)
+}
+
+fn verify_regular_manifest(
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let Some(file) = node.file.as_ref() else {
+        return Err(StorageError::Corruption {
+            reason: "a regular-file manifest has no exact file value",
+            context: context.clone(),
+        });
+    };
+    if !node.children.is_empty() {
+        return Err(StorageError::Corruption {
+            reason: "a regular-file manifest has descendants",
+            context: context.clone(),
+        });
+    }
+    verify_file(directory, node, file, context)
+}
+
+fn verify_child_names(
+    child: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let actual = child.list()?;
+    let exact = actual.len() == node.children.len()
+        && actual
+            .iter()
+            .zip(&node.children)
+            .all(|(name, expected)| name == &expected.name);
+    if exact {
+        Ok(())
+    } else {
+        Err(StorageError::Corruption {
+            reason: "private tree differs from its exact manifest",
+            context: context.clone(),
+        })
+    }
+}
+
+fn verify_file(
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    file: &PrivateFileManifest,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let object_context = directory.handle.context_with_object(
+        Some(&node.name),
+        Some(file.digest),
+        StorageOperation::RemoveTree,
+        DurabilityStep::ObjectReadback,
+    );
+    let actual = objects::read_digest(&directory.handle, &node.name, file.digest, file.size)
+        .map_err(|error| {
+            error.at_object(
+                StorageOperation::RemoveTree,
+                file.digest,
+                DurabilityStep::ObjectReadback,
+            )
+        })?;
+    if actual.bytes().len() != file.size {
+        return Err(StorageError::ContentMismatch {
+            context: object_context,
+        });
+    }
+    verify_node(directory, node, &object_context)?;
+    directory.handle.validate(context)
+}
+
+pub(super) fn verify_exact_node(
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    verify_node(directory, node, context)?;
+    if let Some(file) = &node.file {
+        verify_file(directory, node, file, context)?;
+    }
+    Ok(())
+}
+
+fn verify_node(
+    directory: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let stat = statat(
+        &directory.handle.fd,
+        node.name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_private(&stat, context)?;
+    if inspected.identity != node.identity || inspected.kind != node.kind {
+        return Err(StorageError::IdentityChanged {
+            expected: node.identity,
+            actual: Some(inspected.identity),
+            context: context.clone(),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn open_manifest_directory(
+    parent: &DurableDirectory,
+    node: &PrivateTreeNode,
+    context: &StorageContext,
+) -> StorageResult<DurableDirectory> {
+    let fd = open_directory(&parent.handle.fd, &node.name).map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    Ok(DurableDirectory::new(parent.handle.child(
+        fd,
+        node.name.clone(),
+        node.identity,
+    )))
+}

--- a/crates/pilotage-durable-storage/src/unix/store.rs
+++ b/crates/pilotage-durable-storage/src/unix/store.rs
@@ -1,0 +1,251 @@
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+use rustix::fd::OwnedFd;
+use rustix::fs::{ABS, AtFlags, Mode, OFlags, fchmod, fstat, mkdirat, openat, statat};
+use rustix::io::Errno;
+
+use crate::fault::FaultController;
+use crate::{
+    DurabilityStep, ObjectName, RootIdentity, StorageContext, StorageError, StorageOperation,
+    StorageResult,
+};
+
+use super::anchor::{Anchor, DirectoryHandle, open_directory};
+use super::barrier::{sync_directory, syscall};
+use super::directory::DurableDirectory;
+use super::metadata::{PRIVATE_DIRECTORY_MODE, directory_mode, identity, inspect_private};
+use super::writer::WriterLease;
+
+/// An anchored private durable-storage session.
+#[derive(Clone)]
+pub struct DurableStore {
+    pub(crate) anchor: Arc<Anchor>,
+}
+
+impl DurableStore {
+    /// Open or create one exact private Unix storage root.
+    pub fn open_or_create(path: &Path) -> StorageResult<Self> {
+        Self::open_with_controller(path, FaultController::default())
+    }
+
+    /// Open or create a store with deterministic storage faults.
+    #[cfg(any(test, feature = "fault-injection"))]
+    pub fn open_or_create_with_faults(path: &Path, faults: FaultController) -> StorageResult<Self> {
+        Self::open_with_controller(path, faults)
+    }
+
+    /// Get the device and inode bound to this session.
+    #[must_use]
+    pub fn root_identity(&self) -> RootIdentity {
+        self.anchor.identity
+    }
+
+    /// Get the anchored root directory.
+    #[must_use]
+    pub fn root_directory(&self) -> DurableDirectory {
+        DurableDirectory::new(DirectoryHandle::root(Arc::clone(&self.anchor)))
+    }
+
+    /// Acquire the one nonblocking writer lease for this root.
+    pub fn acquire_writer(&self) -> StorageResult<WriterLease> {
+        WriterLease::acquire(Arc::clone(&self.anchor))
+    }
+
+    fn open_with_controller(path: &Path, faults: FaultController) -> StorageResult<Self> {
+        let context = StorageContext::root_open_at(path);
+        let (parent, leaf) = open_parent(path, &context)?;
+        let root_fd = open_or_create_root(&parent, &leaf, &faults, &context)?;
+        let mut selected = context.clone();
+        selected.component = Some(leaf.clone());
+        let stat = fstat(&root_fd).map_err(|source| StorageError::Io {
+            context: selected.clone(),
+            source: source.into(),
+        })?;
+        let object_identity = identity(&stat);
+        let root_identity = RootIdentity {
+            device: object_identity.device,
+            inode: object_identity.inode,
+        };
+        let mut bound = selected;
+        bound.root = Some(root_identity);
+        bound.component = Some(leaf.clone());
+        let inspected = inspect_private(&stat, &bound)?;
+        if inspected.mode != PRIVATE_DIRECTORY_MODE {
+            return Err(StorageError::WrongMode {
+                required: PRIVATE_DIRECTORY_MODE,
+                actual: inspected.mode,
+                context: bound,
+            });
+        }
+        let root_barrier = StorageContext {
+            step: DurabilityStep::ObjectData,
+            ..bound.clone()
+        };
+        sync_directory(&root_fd, &faults, &root_barrier)?;
+        let parent_barrier = StorageContext {
+            step: DurabilityStep::ParentDirectory,
+            ..bound
+        };
+        sync_directory(&parent, &faults, &parent_barrier)?;
+        let anchor = Arc::new(Anchor {
+            root_parent: parent,
+            root_leaf: leaf,
+            root_fd: Arc::new(root_fd),
+            identity: root_identity,
+            faults,
+            requested_root: path.to_path_buf(),
+        });
+        let validate = anchor.context(
+            None,
+            StorageOperation::ValidateRoot,
+            DurabilityStep::AfterMutation,
+        );
+        anchor.validate_root(&validate)?;
+        Ok(Self { anchor })
+    }
+}
+
+fn open_parent(path: &Path, context: &StorageContext) -> StorageResult<(OwnedFd, ObjectName)> {
+    if !path.is_absolute() {
+        return Err(StorageError::Corruption {
+            reason: "storage root must be absolute",
+            context: context.clone(),
+        });
+    }
+    let mut names = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(name) => names.push(
+                ObjectName::new(name).map_err(|_| StorageError::invalid_name_at(name, context))?,
+            ),
+            Component::CurDir | Component::ParentDir | Component::Prefix(_) => {
+                return Err(StorageError::Corruption {
+                    reason: "storage root contains a traversal component",
+                    context: context.clone(),
+                });
+            }
+        }
+    }
+    let leaf = names.pop().ok_or_else(|| StorageError::Corruption {
+        reason: "storage root must have a leaf component",
+        context: context.clone(),
+    })?;
+    let mut parent = openat(
+        ABS,
+        c"/",
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    for name in names {
+        let mut component_context = context.clone();
+        component_context.component = Some(name.clone());
+        parent = open_directory(&parent, &name).map_err(|source| StorageError::Io {
+            context: component_context,
+            source: source.into(),
+        })?;
+    }
+    Ok((parent, leaf))
+}
+
+fn open_or_create_root(
+    parent: &OwnedFd,
+    leaf: &ObjectName,
+    faults: &FaultController,
+    context: &StorageContext,
+) -> StorageResult<OwnedFd> {
+    let mut context = context.clone();
+    context.component = Some(leaf.clone());
+    match statat(parent, leaf.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(_) => return open_existing_root(parent, leaf, &context),
+        Err(Errno::NOENT) => {}
+        Err(source) => {
+            return Err(StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            });
+        }
+    }
+    let create_context = StorageContext {
+        step: DurabilityStep::Creation,
+        ..context.clone()
+    };
+    let creation = syscall(faults, &create_context, || {
+        mkdirat(parent, leaf.as_os_str(), directory_mode())
+    });
+    let root = match creation {
+        Ok(()) => open_directory(parent, leaf).map_err(|source| StorageError::Io {
+            context: create_context.clone(),
+            source: source.into(),
+        })?,
+        Err(original) => match statat(parent, leaf.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
+            Ok(_) => open_existing_root(parent, leaf, &context)?,
+            Err(Errno::NOENT) => return Err(original),
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context: create_context,
+                    source: source.into(),
+                });
+            }
+        },
+    };
+    fchmod(&root, directory_mode()).map_err(|source| StorageError::Io {
+        context: create_context.clone(),
+        source: source.into(),
+    })?;
+    let root_identity = verify_exact_root(&root, &context)?;
+    let mut bound = context;
+    bound.root = Some(root_identity);
+    let object_context = StorageContext {
+        step: DurabilityStep::ObjectData,
+        ..bound.clone()
+    };
+    sync_directory(&root, faults, &object_context)?;
+    let parent_context = StorageContext {
+        step: DurabilityStep::ParentDirectory,
+        ..bound
+    };
+    sync_directory(parent, faults, &parent_context)?;
+    Ok(root)
+}
+
+fn open_existing_root(
+    parent: &OwnedFd,
+    leaf: &ObjectName,
+    context: &StorageContext,
+) -> StorageResult<OwnedFd> {
+    let root = open_directory(parent, leaf).map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    verify_exact_root(&root, context)?;
+    Ok(root)
+}
+
+fn verify_exact_root(root: &OwnedFd, context: &StorageContext) -> StorageResult<RootIdentity> {
+    let stat = fstat(root).map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let actual = identity(&stat);
+    let mut bound = context.clone();
+    let root_identity = RootIdentity {
+        device: actual.device,
+        inode: actual.inode,
+    };
+    bound.root = Some(root_identity);
+    let inspected = inspect_private(&stat, &bound)?;
+    if inspected.mode != PRIVATE_DIRECTORY_MODE {
+        return Err(StorageError::WrongMode {
+            required: PRIVATE_DIRECTORY_MODE,
+            actual: inspected.mode,
+            context: bound,
+        });
+    }
+    Ok(root_identity)
+}

--- a/crates/pilotage-durable-storage/src/unix/temporary.rs
+++ b/crates/pilotage-durable-storage/src/unix/temporary.rs
@@ -1,0 +1,324 @@
+use std::fs::File;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+
+use rustix::fd::OwnedFd;
+use rustix::fs::{OFlags, fchmod, fstat, openat};
+use rustix::io::Errno;
+
+use crate::{
+    DurabilityStep, ExactObject, ObjectName, OwnedTemporary, StorageContext, StorageError,
+    StorageOperation, StorageResult,
+};
+
+use super::barrier::{sync_file, syscall};
+use super::directory::DurableDirectory;
+use super::metadata::{file_mode, inspect_temporary};
+use super::objects;
+use super::writer::WriterLease;
+
+mod publication;
+mod removal;
+
+pub(crate) use publication::{publish_link, recover_linked_publication};
+
+const TEMPORARY_PREFIX: &[u8] = b".pilotage-tmp-";
+
+pub(crate) fn create(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    operation: StorageOperation,
+    object: &ExactObject,
+) -> StorageResult<OwnedTemporary> {
+    let (name, fd) = create_unique(directory, lease, operation, object)?;
+    let mut file = File::from(fd);
+    let write = context(
+        directory,
+        &name,
+        object,
+        operation,
+        DurabilityStep::Creation,
+    );
+    file.write_all(object.bytes())
+        .map_err(|source| StorageError::Io {
+            context: write,
+            source,
+        })?;
+    let fd = OwnedFd::from(file);
+    fchmod(&fd, file_mode()).map_err(|source| StorageError::Io {
+        context: context(
+            directory,
+            &name,
+            object,
+            operation,
+            DurabilityStep::Creation,
+        ),
+        source: source.into(),
+    })?;
+    let data = context(
+        directory,
+        &name,
+        object,
+        operation,
+        DurabilityStep::ObjectData,
+    );
+    sync_file(&fd, &directory.handle.anchor.faults, &data)?;
+    let stat = fstat(&fd).map_err(|source| StorageError::Io {
+        context: data.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_temporary(&stat, &data)?;
+    if inspected.link_count != 1 {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context: data,
+        });
+    }
+    let temporary = OwnedTemporary {
+        name,
+        identity: inspected.identity,
+        object: object.clone(),
+        owner_root: directory.handle.anchor.identity,
+        owner_directory: directory.handle.identity,
+    };
+    verify_owned(directory, &temporary, operation)?;
+    let after = context(
+        directory,
+        &temporary.name,
+        &temporary.object,
+        operation,
+        DurabilityStep::AfterMutation,
+    );
+    lease.validate_for(&directory.handle, &after)?;
+    Ok(temporary)
+}
+
+pub(crate) fn inspect_owned(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    maximum_bytes: usize,
+) -> StorageResult<OwnedTemporary> {
+    require_temporary_name(name, directory)?;
+    let object = objects::read_exact(&directory.handle, name, maximum_bytes)?;
+    let inspected = objects::inspect(&directory.handle, name)?;
+    Ok(OwnedTemporary {
+        name: name.clone(),
+        identity: inspected.identity,
+        object,
+        owner_root: directory.handle.anchor.identity,
+        owner_directory: directory.handle.identity,
+    })
+}
+
+pub(crate) fn cleanup(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    temporary: &OwnedTemporary,
+) -> StorageResult<()> {
+    let operation = StorageOperation::RemoveTemporary;
+    let context = context(
+        directory,
+        &temporary.name,
+        &temporary.object,
+        operation,
+        DurabilityStep::BeforeMutation,
+    );
+    lease.validate_for(&directory.handle, &context)?;
+    verify_owned(directory, temporary, operation)?;
+    let inspected = objects::inspect(&directory.handle, &temporary.name)?;
+    if inspected.link_count != 1 {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context,
+        });
+    }
+    removal::unlink_exact(
+        directory,
+        lease,
+        &temporary.name,
+        temporary.identity,
+        &temporary.object,
+        1,
+        operation,
+    )
+}
+
+fn create_unique(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    operation: StorageOperation,
+    object: &ExactObject,
+) -> StorageResult<(ObjectName, OwnedFd)> {
+    for _ in 0..64 {
+        let name = lease.next_temporary_name()?;
+        let create = context(
+            directory,
+            &name,
+            object,
+            operation,
+            DurabilityStep::Creation,
+        );
+        lease.validate_for(&directory.handle, &create)?;
+        match syscall(&directory.handle.anchor.faults, &create, || {
+            openat(
+                &directory.handle.fd,
+                name.as_os_str(),
+                OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                file_mode(),
+            )
+        }) {
+            Ok(fd) => return Ok((name, fd)),
+            Err(StorageError::Io { source, .. })
+                if source.raw_os_error() == Some(Errno::EXIST.raw_os_error()) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(StorageError::Corruption {
+        reason: "temporary name space is exhausted",
+        context: directory.handle.context_with_object(
+            None,
+            Some(object.digest()),
+            operation,
+            DurabilityStep::Creation,
+        ),
+    })
+}
+
+pub(crate) fn verify_owned(
+    directory: &DurableDirectory,
+    temporary: &OwnedTemporary,
+    operation: StorageOperation,
+) -> StorageResult<()> {
+    let ownership = context(
+        directory,
+        &temporary.name,
+        &temporary.object,
+        operation,
+        DurabilityStep::ObjectReadback,
+    );
+    if temporary.owner_root != directory.handle.anchor.identity {
+        return Err(StorageError::Corruption {
+            reason: "temporary token belongs to a different storage root",
+            context: ownership,
+        });
+    }
+    if temporary.owner_directory != directory.handle.identity {
+        return Err(StorageError::IdentityChanged {
+            expected: temporary.owner_directory,
+            actual: Some(directory.handle.identity),
+            context: ownership,
+        });
+    }
+    let actual = objects::read_exact(
+        &directory.handle,
+        &temporary.name,
+        temporary.object.bytes().len(),
+    )
+    .map_err(|error| {
+        error.at_object(
+            operation,
+            temporary.object.digest(),
+            DurabilityStep::ObjectReadback,
+        )
+    })?;
+    if actual != temporary.object {
+        return Err(StorageError::ContentMismatch {
+            context: context(
+                directory,
+                &temporary.name,
+                &temporary.object,
+                operation,
+                DurabilityStep::ObjectReadback,
+            ),
+        });
+    }
+    let inspected = objects::inspect(&directory.handle, &temporary.name).map_err(|error| {
+        error.at_object(
+            operation,
+            temporary.object.digest(),
+            DurabilityStep::ObjectReadback,
+        )
+    })?;
+    if inspected.identity != temporary.identity {
+        return Err(StorageError::IdentityChanged {
+            expected: temporary.identity,
+            actual: Some(inspected.identity),
+            context: context(
+                directory,
+                &temporary.name,
+                &temporary.object,
+                operation,
+                DurabilityStep::ObjectReadback,
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn require_temporary_name(name: &ObjectName, directory: &DurableDirectory) -> StorageResult<()> {
+    if !is_temporary_name(name) {
+        return Err(StorageError::Corruption {
+            reason: "name is not an owned temporary component",
+            context: directory.handle.context(
+                Some(name),
+                StorageOperation::InspectObject,
+                DurabilityStep::Selection,
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_reserved_destination(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    object: &ExactObject,
+    operation: StorageOperation,
+) -> StorageResult<()> {
+    if has_temporary_prefix(name) || WriterLease::is_writer_lock_name(name) {
+        return Err(StorageError::InvalidObjectName {
+            name: name.as_os_str().into(),
+            context: directory.handle.context_with_object(
+                Some(name),
+                Some(object.digest()),
+                operation,
+                DurabilityStep::Selection,
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn is_temporary_name(name: &ObjectName) -> bool {
+    let bytes = name.as_os_str().as_bytes();
+    let Some(remainder) = bytes.strip_prefix(TEMPORARY_PREFIX) else {
+        return false;
+    };
+    let Some(separator) = remainder.iter().position(|byte| *byte == b'-') else {
+        return false;
+    };
+    let (process, counter) = remainder.split_at(separator);
+    let counter = &counter[1..];
+    !process.is_empty()
+        && process.iter().all(u8::is_ascii_digit)
+        && counter.len() == 16
+        && counter
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn has_temporary_prefix(name: &ObjectName) -> bool {
+    name.as_os_str().as_bytes().starts_with(TEMPORARY_PREFIX)
+}
+
+pub(super) fn context(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    object: &ExactObject,
+    operation: StorageOperation,
+    step: DurabilityStep,
+) -> StorageContext {
+    directory
+        .handle
+        .context_with_object(Some(name), Some(object.digest()), operation, step)
+}

--- a/crates/pilotage-durable-storage/src/unix/temporary/publication.rs
+++ b/crates/pilotage-durable-storage/src/unix/temporary/publication.rs
@@ -1,0 +1,310 @@
+use rustix::fs::{AtFlags, Stat, linkat, statat};
+use rustix::io::Errno;
+
+use crate::{
+    DurabilityStep, ExactObject, ObjectIdentity, ObjectName, OwnedTemporary, StorageContext,
+    StorageError, StorageOperation, StorageResult,
+};
+
+use super::super::barrier::syscall;
+use super::super::directory::DurableDirectory;
+use super::super::metadata::{identity, inspect_temporary};
+use super::super::objects;
+use super::super::writer::WriterLease;
+use super::{cleanup, context, is_temporary_name, removal, verify_owned};
+
+pub(crate) fn publish_link(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    temporary: &OwnedTemporary,
+    destination: &ObjectName,
+    expected: &ExactObject,
+) -> StorageResult<()> {
+    let publish = context(
+        directory,
+        destination,
+        expected,
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectPublication,
+    );
+    lease.validate_for(&directory.handle, &publish)?;
+    verify_owned(directory, temporary, StorageOperation::PublishImmutable)?;
+    let result = syscall(&directory.handle.anchor.faults, &publish, || {
+        linkat(
+            &directory.handle.fd,
+            temporary.name.as_os_str(),
+            &directory.handle.fd,
+            destination.as_os_str(),
+            AtFlags::empty(),
+        )
+    });
+    match result {
+        Ok(()) => unlink_linked_temporary(directory, lease, temporary, destination),
+        Err(error) => recover_link(directory, lease, temporary, destination, expected, error),
+    }
+}
+
+pub(crate) fn recover_linked_publication(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    destination: &ObjectName,
+    expected: &ExactObject,
+) -> StorageResult<bool> {
+    let before = context(
+        directory,
+        destination,
+        expected,
+        StorageOperation::PublishImmutable,
+        DurabilityStep::BeforeMutation,
+    );
+    lease.validate_for(&directory.handle, &before)?;
+    let Some(destination_stat) = stat_optional(directory, destination, &before)? else {
+        return Ok(false);
+    };
+    let inspected = inspect_temporary(&destination_stat, &before)?;
+    if inspected.link_count == 1 {
+        return Ok(false);
+    }
+    if inspected.link_count != 2 {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context: before,
+        });
+    }
+    let temporary_name = find_temporary_link(directory, inspected.identity, expected)?;
+    let temporary = OwnedTemporary {
+        name: temporary_name,
+        identity: inspected.identity,
+        object: expected.clone(),
+        owner_root: directory.handle.anchor.identity,
+        owner_directory: directory.handle.identity,
+    };
+    unlink_linked_temporary(directory, lease, &temporary, destination)?;
+    Ok(true)
+}
+
+fn find_temporary_link(
+    directory: &DurableDirectory,
+    expected_identity: ObjectIdentity,
+    expected: &ExactObject,
+) -> StorageResult<ObjectName> {
+    let mut found = None;
+    for name in directory.list()?.into_iter().filter(is_temporary_name) {
+        let selection = context(
+            directory,
+            &name,
+            expected,
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+        );
+        let Some(stat) = stat_optional(directory, &name, &selection)? else {
+            continue;
+        };
+        if identity(&stat) != expected_identity {
+            continue;
+        }
+        validate_linked_stat(&stat, expected_identity, &selection)?;
+        if found.replace(name).is_some() {
+            return Err(StorageError::Corruption {
+                reason: "linked publication has more than one owned temporary name",
+                context: selection,
+            });
+        }
+    }
+    found.ok_or_else(|| StorageError::Corruption {
+        reason: "linked publication has no exact owned temporary name",
+        context: directory.handle.context_with_object(
+            None,
+            Some(expected.digest()),
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+        ),
+    })
+}
+
+fn recover_link(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    temporary: &OwnedTemporary,
+    destination: &ObjectName,
+    expected: &ExactObject,
+    original: StorageError,
+) -> StorageResult<()> {
+    let readback = context(
+        directory,
+        destination,
+        expected,
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectReadback,
+    );
+    let named = match stat_with_fault(directory, destination, &readback) {
+        Ok(value) => value,
+        Err(source) => return Err(ambiguous(readback, original, source)),
+    };
+    match named {
+        Some(stat) if identity(&stat) == temporary.identity => {
+            unlink_linked_temporary(directory, lease, temporary, destination)
+        }
+        Some(_) => Err(StorageError::Corruption {
+            reason: "immutable destination appeared during publication",
+            context: readback,
+        }),
+        None => {
+            cleanup(directory, lease, temporary)?;
+            Err(original)
+        }
+    }
+}
+
+fn unlink_linked_temporary(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    temporary: &OwnedTemporary,
+    destination: &ObjectName,
+) -> StorageResult<()> {
+    verify_linked_pair(directory, temporary, destination)?;
+    removal::unlink_exact(
+        directory,
+        lease,
+        &temporary.name,
+        temporary.identity,
+        &temporary.object,
+        2,
+        StorageOperation::PublishImmutable,
+    )?;
+    objects::verify_exact(
+        &directory.handle,
+        destination,
+        &temporary.object,
+        StorageOperation::PublishImmutable,
+    )?;
+    let after = context(
+        directory,
+        destination,
+        &temporary.object,
+        StorageOperation::PublishImmutable,
+        DurabilityStep::AfterMutation,
+    );
+    lease.validate_for(&directory.handle, &after)
+}
+
+fn verify_linked_pair(
+    directory: &DurableDirectory,
+    temporary: &OwnedTemporary,
+    destination: &ObjectName,
+) -> StorageResult<()> {
+    for name in [&temporary.name, destination] {
+        let actual = objects::read_exact_with_links(
+            &directory.handle,
+            name,
+            temporary.object.bytes().len(),
+            2,
+        )
+        .map_err(|error| {
+            error.at_object(
+                StorageOperation::PublishImmutable,
+                temporary.object.digest(),
+                DurabilityStep::ObjectReadback,
+            )
+        })?;
+        if actual != temporary.object {
+            return Err(StorageError::ContentMismatch {
+                context: context(
+                    directory,
+                    name,
+                    &temporary.object,
+                    StorageOperation::PublishImmutable,
+                    DurabilityStep::ObjectReadback,
+                ),
+            });
+        }
+        let selection = context(
+            directory,
+            name,
+            &temporary.object,
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+        );
+        let stat = stat_required(directory, name, &selection)?;
+        validate_linked_stat(&stat, temporary.identity, &selection)?;
+    }
+    Ok(())
+}
+
+fn validate_linked_stat(
+    stat: &Stat,
+    expected: ObjectIdentity,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let inspected = inspect_temporary(stat, context)?;
+    if inspected.identity != expected {
+        return Err(StorageError::IdentityChanged {
+            expected,
+            actual: Some(inspected.identity),
+            context: context.clone(),
+        });
+    }
+    if inspected.link_count != 2 {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context: context.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn stat_with_fault(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    context: &StorageContext,
+) -> StorageResult<Option<Stat>> {
+    syscall(&directory.handle.anchor.faults, context, || {
+        match statat(
+            &directory.handle.fd,
+            name.as_os_str(),
+            AtFlags::SYMLINK_NOFOLLOW,
+        ) {
+            Ok(stat) => Ok(Some(stat)),
+            Err(Errno::NOENT) => Ok(None),
+            Err(error) => Err(error),
+        }
+    })
+}
+
+fn stat_optional(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    context: &StorageContext,
+) -> StorageResult<Option<Stat>> {
+    match statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Ok(stat) => Ok(Some(stat)),
+        Err(Errno::NOENT) => Ok(None),
+        Err(source) => Err(StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        }),
+    }
+}
+
+fn stat_required(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    context: &StorageContext,
+) -> StorageResult<Stat> {
+    stat_optional(directory, name, context)?.ok_or_else(|| StorageError::Corruption {
+        reason: "linked publication name disappeared during validation",
+        context: context.clone(),
+    })
+}
+
+fn ambiguous(context: StorageContext, prior: StorageError, source: StorageError) -> StorageError {
+    StorageError::AmbiguousCommit {
+        context,
+        prior: Some(Box::new(prior)),
+        source: Box::new(source),
+    }
+}

--- a/crates/pilotage-durable-storage/src/unix/temporary/removal.rs
+++ b/crates/pilotage-durable-storage/src/unix/temporary/removal.rs
@@ -1,0 +1,259 @@
+use rustix::fs::{AtFlags, statat, unlinkat};
+use rustix::io::Errno;
+
+use crate::{
+    DurabilityStep, ExactObject, ObjectIdentity, ObjectName, StorageContext, StorageError,
+    StorageOperation, StorageResult,
+};
+
+use super::super::barrier::{sync_directory, syscall};
+use super::super::directory::DurableDirectory;
+use super::super::metadata::inspect_temporary;
+use super::super::writer::WriterLease;
+use super::context;
+
+#[derive(Clone, Copy)]
+struct UnlinkTarget<'a> {
+    name: &'a ObjectName,
+    identity: ObjectIdentity,
+    object: &'a ExactObject,
+    link_count: u64,
+}
+
+pub(super) fn unlink_exact(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    expected: ObjectIdentity,
+    object: &ExactObject,
+    expected_links: u64,
+    operation: StorageOperation,
+) -> StorageResult<()> {
+    let target = UnlinkTarget {
+        name,
+        identity: expected,
+        object,
+        link_count: expected_links,
+    };
+    let deletion = directory.handle.context_with_object(
+        Some(name),
+        Some(object.digest()),
+        operation,
+        DurabilityStep::Deletion,
+    );
+    target.prepare(directory, lease, &deletion)?;
+    let unlinked = syscall(&directory.handle.anchor.faults, &deletion, || {
+        unlinkat(
+            &directory.handle.fd,
+            target.name.as_os_str(),
+            AtFlags::empty(),
+        )
+    });
+    if let Err(original) = unlinked {
+        resolve_unlink(directory, lease, target, &deletion, original)?;
+    }
+    finish_removal(directory, lease, name, object, operation, deletion)
+}
+
+impl UnlinkTarget<'_> {
+    fn prepare(
+        self,
+        directory: &DurableDirectory,
+        lease: &WriterLease,
+        context: &StorageContext,
+    ) -> StorageResult<()> {
+        lease.validate_for(&directory.handle, context)?;
+        let actual = super::super::objects::read_exact_with_links(
+            &directory.handle,
+            self.name,
+            self.object.bytes().len(),
+            self.link_count,
+        )
+        .map_err(|error| {
+            error.at_object(
+                context.operation,
+                self.object.digest(),
+                DurabilityStep::ObjectReadback,
+            )
+        })?;
+        if actual != *self.object {
+            return Err(StorageError::ContentMismatch {
+                context: context.clone(),
+            });
+        }
+        validate_name(
+            directory,
+            self.name,
+            self.identity,
+            self.link_count,
+            context,
+        )
+    }
+}
+
+fn validate_name(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    expected: ObjectIdentity,
+    expected_links: u64,
+    context: &StorageContext,
+) -> StorageResult<()> {
+    let stat = statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|source| StorageError::Io {
+        context: context.clone(),
+        source: source.into(),
+    })?;
+    let inspected = inspect_temporary(&stat, context)?;
+    if inspected.identity != expected {
+        return Err(StorageError::IdentityChanged {
+            expected,
+            actual: Some(inspected.identity),
+            context: context.clone(),
+        });
+    }
+    if inspected.link_count != expected_links {
+        return Err(StorageError::LinkedObject {
+            actual: inspected.link_count,
+            context: context.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn resolve_unlink(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    target: UnlinkTarget<'_>,
+    context: &StorageContext,
+    original: StorageError,
+) -> StorageResult<()> {
+    match statat(
+        &directory.handle.fd,
+        target.name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Err(Errno::NOENT) => Ok(()),
+        Ok(_) => {
+            target.prepare(directory, lease, context)?;
+            let retried = syscall(&directory.handle.anchor.faults, context, || {
+                unlinkat(
+                    &directory.handle.fd,
+                    target.name.as_os_str(),
+                    AtFlags::empty(),
+                )
+            });
+            resolve_retry(directory, target.name, context, original, retried)
+        }
+        Err(source) => Err(StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        }),
+    }
+}
+
+fn resolve_retry(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    context: &StorageContext,
+    original: StorageError,
+    retried: StorageResult<()>,
+) -> StorageResult<()> {
+    let Err(retry) = retried else {
+        return Ok(());
+    };
+    match statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Err(Errno::NOENT) => Ok(()),
+        Ok(_) => Err(retry),
+        Err(source) => Err(StorageError::AmbiguousCommit {
+            context: context.clone(),
+            prior: Some(Box::new(original)),
+            source: Box::new(StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            }),
+        }),
+    }
+}
+
+fn finish_removal(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    object: &ExactObject,
+    operation: StorageOperation,
+    deletion: StorageContext,
+) -> StorageResult<()> {
+    let parent = StorageContext {
+        step: DurabilityStep::ParentDirectory,
+        ..deletion
+    };
+    let first = sync_directory(
+        &directory.handle.fd,
+        &directory.handle.anchor.faults,
+        &parent,
+    );
+    if let Err(first_error) = first {
+        return recover_barrier(
+            directory,
+            lease,
+            name,
+            object,
+            operation,
+            parent,
+            first_error,
+        );
+    }
+    validate_after(directory, lease, name, object, operation)
+}
+
+fn recover_barrier(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    object: &ExactObject,
+    operation: StorageOperation,
+    parent: StorageContext,
+    first: StorageError,
+) -> StorageResult<()> {
+    let recovery = StorageContext {
+        step: DurabilityStep::RecoveryBarrier,
+        ..parent
+    };
+    if let Err(second) = sync_directory(
+        &directory.handle.fd,
+        &directory.handle.anchor.faults,
+        &recovery,
+    ) {
+        return Err(StorageError::AmbiguousCommit {
+            context: recovery,
+            prior: Some(Box::new(first)),
+            source: Box::new(second),
+        });
+    }
+    validate_after(directory, lease, name, object, operation)
+}
+
+fn validate_after(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    object: &ExactObject,
+    operation: StorageOperation,
+) -> StorageResult<()> {
+    let after = context(
+        directory,
+        name,
+        object,
+        operation,
+        DurabilityStep::AfterMutation,
+    );
+    super::super::remove::validate_absent_after(lease, directory, name, after)
+}

--- a/crates/pilotage-durable-storage/src/unix/writer.rs
+++ b/crates/pilotage-durable-storage/src/unix/writer.rs
@@ -1,0 +1,196 @@
+use std::cell::Cell;
+use std::sync::Arc;
+
+use rustix::fd::OwnedFd;
+use rustix::fs::{AtFlags, FlockOperation, Mode, OFlags, fchmod, flock, fstat, openat, statat};
+use rustix::io::Errno;
+
+use crate::{
+    DurabilityStep, ObjectIdentity, ObjectName, StorageContext, StorageError, StorageOperation,
+    StorageResult,
+};
+
+use super::anchor::{Anchor, DirectoryHandle};
+use super::barrier::{sync_directory, sync_file};
+use super::metadata::{file_mode, identity, inspect_private};
+
+const WRITER_LOCK: &str = ".pilotage-writer-lock";
+
+/// An owned nonblocking writer lease for one anchored root.
+pub struct WriterLease {
+    pub(crate) anchor: Arc<Anchor>,
+    lock_fd: OwnedFd,
+    lock_identity: ObjectIdentity,
+    next_temporary: Cell<u64>,
+}
+
+impl WriterLease {
+    pub(crate) fn acquire(anchor: Arc<Anchor>) -> StorageResult<Self> {
+        let name = ObjectName::new(WRITER_LOCK)?;
+        let context = anchor.context(
+            Some(&name),
+            StorageOperation::AcquireWriter,
+            DurabilityStep::BeforeMutation,
+        );
+        anchor.validate_root(&context)?;
+        let (lock_fd, created) = open_lock(&anchor, &name, &context)?;
+        if created {
+            fchmod(&lock_fd, file_mode()).map_err(|source| StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            })?;
+        }
+        let stat = fstat(&lock_fd).map_err(|source| StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        })?;
+        let inspected = inspect_private(&stat, &context)?;
+        let object = StorageContext {
+            step: DurabilityStep::ObjectData,
+            ..context.clone()
+        };
+        sync_file(&lock_fd, &anchor.faults, &object)?;
+        let parent = StorageContext {
+            step: DurabilityStep::ParentDirectory,
+            ..context.clone()
+        };
+        sync_directory(&anchor.root_fd, &anchor.faults, &parent)?;
+        match flock(&lock_fd, FlockOperation::NonBlockingLockExclusive) {
+            Ok(()) => {}
+            Err(error) if error == Errno::WOULDBLOCK || error == Errno::AGAIN => {
+                return Err(StorageError::WriterConflict { context });
+            }
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context,
+                    source: source.into(),
+                });
+            }
+        }
+        let lease = Self {
+            anchor,
+            lock_fd,
+            lock_identity: inspected.identity,
+            next_temporary: Cell::new(0),
+        };
+        let root = DirectoryHandle::root(Arc::clone(&lease.anchor));
+        let after = lease.anchor.context(
+            Some(&name),
+            StorageOperation::AcquireWriter,
+            DurabilityStep::AfterMutation,
+        );
+        lease.validate_for(&root, &after)?;
+        Ok(lease)
+    }
+
+    /// Validate the held lease and its anchored name binding.
+    pub fn validate(&self, directory: &super::directory::DurableDirectory) -> StorageResult<()> {
+        let name = ObjectName::new(WRITER_LOCK)?;
+        let context = directory.handle.context(
+            Some(&name),
+            StorageOperation::ValidateWriter,
+            DurabilityStep::Selection,
+        );
+        self.validate_for(&directory.handle, &context)
+    }
+
+    pub(crate) fn validate_for(
+        &self,
+        directory: &DirectoryHandle,
+        context: &StorageContext,
+    ) -> StorageResult<()> {
+        if !directory.same_anchor(&self.anchor) {
+            return Err(StorageError::Corruption {
+                reason: "writer lease belongs to a different storage root",
+                context: context.clone(),
+            });
+        }
+        directory.validate(context)?;
+        let name = ObjectName::new(WRITER_LOCK)?;
+        let mut lock_context = context.clone();
+        lock_context.component = Some(name.clone());
+        let named = match statat(
+            &self.anchor.root_fd,
+            name.as_os_str(),
+            AtFlags::SYMLINK_NOFOLLOW,
+        ) {
+            Ok(named) => named,
+            Err(Errno::NOENT) => {
+                return Err(StorageError::IdentityChanged {
+                    expected: self.lock_identity,
+                    actual: None,
+                    context: lock_context,
+                });
+            }
+            Err(source) => {
+                return Err(StorageError::Io {
+                    context: lock_context,
+                    source: source.into(),
+                });
+            }
+        };
+        let inspected = inspect_private(&named, &lock_context)?;
+        let held = fstat(&self.lock_fd).map_err(|source| StorageError::Io {
+            context: lock_context.clone(),
+            source: source.into(),
+        })?;
+        if inspected.identity != self.lock_identity || identity(&held) != self.lock_identity {
+            return Err(StorageError::Corruption {
+                reason: "writer lease name binding changed",
+                context: lock_context,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn next_temporary_name(&self) -> StorageResult<ObjectName> {
+        let current = self.next_temporary.get();
+        self.next_temporary.set(current.wrapping_add(1));
+        ObjectName::new(format!(
+            ".pilotage-tmp-{}-{current:016x}",
+            std::process::id()
+        ))
+    }
+
+    pub(crate) fn is_writer_lock_name(name: &ObjectName) -> bool {
+        name.as_os_str() == WRITER_LOCK
+    }
+}
+
+fn open_lock(
+    anchor: &Anchor,
+    name: &ObjectName,
+    context: &StorageContext,
+) -> StorageResult<(OwnedFd, bool)> {
+    let created = openat(
+        &anchor.root_fd,
+        name.as_os_str(),
+        OFlags::RDWR
+            | OFlags::CREATE
+            | OFlags::EXCL
+            | OFlags::NONBLOCK
+            | OFlags::NOFOLLOW
+            | OFlags::CLOEXEC,
+        file_mode(),
+    );
+    match created {
+        Ok(fd) => Ok((fd, true)),
+        Err(Errno::EXIST) => {
+            let fd = openat(
+                &anchor.root_fd,
+                name.as_os_str(),
+                OFlags::RDWR | OFlags::NONBLOCK | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .map_err(|source| StorageError::Io {
+                context: context.clone(),
+                source: source.into(),
+            })?;
+            Ok((fd, false))
+        }
+        Err(source) => Err(StorageError::Io {
+            context: context.clone(),
+            source: source.into(),
+        }),
+    }
+}

--- a/scripts/check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/check-flight-tune-journal-storage-boundary.sh
@@ -12,18 +12,26 @@ if [ ! -f "$journal_file" ] || [ ! -d "$journal_root" ]; then
 fi
 
 sources=("$journal_file")
+if ! source_list="$(
+    find "$journal_root" \
+        -type f \
+        -name '*.rs' \
+        ! -name 'tests.rs' \
+        ! -path '*/tests/*' \
+        -print
+)"; then
+    echo "the flight-tune journal source scan failed" >&2
+    exit 1
+fi
 while IFS= read -r source; do
-    sources+=("$source")
-done < <(
-    rg --files "$journal_root" \
-        -g '*.rs' \
-        -g '!**/tests.rs' \
-        -g '!**/tests/**'
-)
+    if [ -n "$source" ]; then
+        sources+=("$source")
+    fi
+done <<< "$source_list"
 
 forbidden='(^|[^[:alnum:]_])(fs|File|OpenOptions|NamedTempFile|TempDir|rustix|libc|nix|cap_std|camino|tempfile|walkdir|Command|Stdio)([^[:alnum:]_]|$)|std[[:space:]]*::[[:space:]]*process'
 
-if matches="$(rg -n "$forbidden" "${sources[@]}" 2>&1)"; then
+if matches="$(grep -En "$forbidden" "${sources[@]}" 2>&1)"; then
     printf '%s\n' "$matches"
     echo "FORBIDDEN: the core journal bypasses pilotage-durable-storage" >&2
     exit 1

--- a/scripts/check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/check-flight-tune-journal-storage-boundary.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Keep core journal file-system access behind the durable-storage crate.
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+journal_file="$repo_root/tools/flight-tune/src/journal.rs"
+journal_root="$repo_root/tools/flight-tune/src/journal"
+
+if [ ! -f "$journal_file" ] || [ ! -d "$journal_root" ]; then
+    echo "the flight-tune journal source is missing" >&2
+    exit 1
+fi
+
+sources=("$journal_file")
+while IFS= read -r source; do
+    sources+=("$source")
+done < <(
+    rg --files "$journal_root" \
+        -g '*.rs' \
+        -g '!**/tests.rs' \
+        -g '!**/tests/**'
+)
+
+forbidden='(^|[^[:alnum:]_])(fs|File|OpenOptions|NamedTempFile|TempDir|rustix|libc|nix|cap_std|camino|tempfile|walkdir|Command|Stdio)([^[:alnum:]_]|$)|std[[:space:]]*::[[:space:]]*process'
+
+if rg -n --pcre2 "$forbidden" "${sources[@]}"; then
+    echo "FORBIDDEN: the core journal bypasses pilotage-durable-storage" >&2
+    exit 1
+fi
+
+echo "flight-tune journal storage boundary: OK"

--- a/scripts/check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/check-flight-tune-journal-storage-boundary.sh
@@ -23,9 +23,17 @@ done < <(
 
 forbidden='(^|[^[:alnum:]_])(fs|File|OpenOptions|NamedTempFile|TempDir|rustix|libc|nix|cap_std|camino|tempfile|walkdir|Command|Stdio)([^[:alnum:]_]|$)|std[[:space:]]*::[[:space:]]*process'
 
-if rg -n --pcre2 "$forbidden" "${sources[@]}"; then
+if matches="$(rg -n "$forbidden" "${sources[@]}" 2>&1)"; then
+    printf '%s\n' "$matches"
     echo "FORBIDDEN: the core journal bypasses pilotage-durable-storage" >&2
     exit 1
+else
+    status=$?
+    if [ "$status" -ne 1 ]; then
+        printf '%s\n' "$matches" >&2
+        echo "the flight-tune journal storage scan failed" >&2
+        exit "$status"
+    fi
 fi
 
 echo "flight-tune journal storage boundary: OK"

--- a/scripts/test-check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/test-check-flight-tune-journal-storage-boundary.sh
@@ -32,8 +32,16 @@ printf '%s\n' 'use std::fs;' > "$journal_root/tests.rs"
 bash "$guard" "$fixture" >/dev/null
 
 mkdir -p "$fixture/bin"
-printf '%s\n' '#!/bin/sh' 'exit 2' > "$fixture/bin/rg"
-chmod +x "$fixture/bin/rg"
+printf '%s\n' '#!/bin/sh' 'exit 2' > "$fixture/bin/find"
+chmod +x "$fixture/bin/find"
+if PATH="$fixture/bin:$PATH" bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "the journal storage boundary ignored a source scan failure" >&2
+    exit 1
+fi
+rm "$fixture/bin/find"
+
+printf '%s\n' '#!/bin/sh' 'exit 2' > "$fixture/bin/grep"
+chmod +x "$fixture/bin/grep"
 if PATH="$fixture/bin:$PATH" bash "$guard" "$fixture" >/dev/null 2>&1; then
     echo "the journal storage boundary ignored a scanner failure" >&2
     exit 1

--- a/scripts/test-check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/test-check-flight-tune-journal-storage-boundary.sh
@@ -31,4 +31,12 @@ printf '%s\n' 'use pilotage_durable_storage::DurableStore;' > "$journal_root/sto
 printf '%s\n' 'use std::fs;' > "$journal_root/tests.rs"
 bash "$guard" "$fixture" >/dev/null
 
+mkdir -p "$fixture/bin"
+printf '%s\n' '#!/bin/sh' 'exit 2' > "$fixture/bin/rg"
+chmod +x "$fixture/bin/rg"
+if PATH="$fixture/bin:$PATH" bash "$guard" "$fixture" >/dev/null 2>&1; then
+    echo "the journal storage boundary ignored a scanner failure" >&2
+    exit 1
+fi
+
 echo "flight-tune journal storage boundary self-test: OK"

--- a/scripts/test-check-flight-tune-journal-storage-boundary.sh
+++ b/scripts/test-check-flight-tune-journal-storage-boundary.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Prove that the journal storage boundary rejects direct file-system access.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$repo_root/scripts/check-flight-tune-journal-storage-boundary.sh"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-journal-boundary.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+journal_root="$fixture/tools/flight-tune/src/journal"
+mkdir -p "$journal_root"
+printf '%s\n' 'pub struct Journal;' > "$fixture/tools/flight-tune/src/journal.rs"
+printf '%s\n' 'use pilotage_durable_storage::DurableStore;' > "$journal_root/storage.rs"
+
+bash "$guard" "$fixture" >/dev/null
+
+assert_rejected() {
+    local source="$1"
+    printf '%s\n' "$source" > "$journal_root/storage.rs"
+    if bash "$guard" "$fixture" >/dev/null 2>&1; then
+        echo "the journal storage boundary accepted: $source" >&2
+        exit 1
+    fi
+}
+
+assert_rejected 'use std::{fs as durable};'
+assert_rejected 'use rustix::fs::renameat;'
+assert_rejected 'use std::process::Command;'
+
+printf '%s\n' 'use pilotage_durable_storage::DurableStore;' > "$journal_root/storage.rs"
+printf '%s\n' 'use std::fs;' > "$journal_root/tests.rs"
+bash "$guard" "$fixture" >/dev/null
+
+echo "flight-tune journal storage boundary self-test: OK"

--- a/tools/flight-tune/Cargo.toml
+++ b/tools/flight-tune/Cargo.toml
@@ -9,6 +9,7 @@ description = "Deterministic host-side flight parameter search and promotion"
 workspace = true
 
 [dependencies]
+pilotage-durable-storage = { workspace = true }
 pilotage-flight-quality = { workspace = true }
 pilotage-trial = { workspace = true }
 serde = { workspace = true }
@@ -18,3 +19,6 @@ thiserror = { workspace = true }
 
 [build-dependencies]
 sha2 = { workspace = true }
+
+[dev-dependencies]
+pilotage-durable-storage = { workspace = true, features = ["fault-injection"] }

--- a/tools/flight-tune/src/engine.rs
+++ b/tools/flight-tune/src/engine.rs
@@ -1,21 +1,25 @@
 //! Isolated training, promotion, and final qualification.
 
 mod evaluate;
+mod open;
 mod promotion;
 mod qualification;
 mod reconcile;
 mod session;
 
-pub(crate) use qualification::final_outcome;
+#[cfg(test)]
+mod tests;
 
-use std::path::Path;
+#[cfg(test)]
+pub(crate) use open::validate_open_components;
+pub(crate) use qualification::final_outcome;
 
 use crate::journal::{AttemptRole, CampaignPhase};
 use crate::{
     Candidate, CandidateEvaluation, Digest, FinalQualificationOutcome, GateEvaluator, Journal,
     MetricEvaluator, PromotionDecision, ProposalContext, ProposalStrategy, SearchStage,
-    SessionChallenge, SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter,
-    SimulatorVehicleFactory, TrainingView, TuneError, VehicleBinding,
+    SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter, TrainingView, TuneError,
+    VehicleBinding,
 };
 
 /// Why one bounded training search call stopped.
@@ -58,80 +62,6 @@ where
     M: MetricEvaluator,
     P: ProposalStrategy,
 {
-    /// Opens a matching campaign or creates a new campaign.
-    ///
-    /// The constructor binds the vehicle adapter to the validated simulator
-    /// session. It also cleans and quarantines an incomplete prepared attempt.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`TuneError`] when identity, binding, recovery, or storage fails.
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_or_resume<F>(
-        journal_root: impl AsRef<Path>,
-        stage: SearchStage,
-        fixed_seed: u64,
-        initial_candidate: Candidate,
-        mut backend: B,
-        vehicle_factory: F,
-        mut gates: G,
-        mut metric: M,
-        strategy: P,
-    ) -> Result<Self, TuneError>
-    where
-        F: SimulatorVehicleFactory<Adapter = V>,
-    {
-        session::validate_component_identities(
-            &backend,
-            &vehicle_factory,
-            &gates,
-            &metric,
-            &strategy,
-        )?;
-        let runtimes =
-            session::runtime_identities(&backend, &vehicle_factory, &gates, &metric, &strategy);
-        let vehicle_identity = vehicle_factory.vehicle_identity().clone();
-        let mut journal = Journal::open_or_create(
-            journal_root,
-            &stage,
-            fixed_seed,
-            runtimes,
-            &initial_candidate,
-        )?;
-        let session_digest = journal.session_digest()?;
-        let challenge = SessionChallenge::new(session_digest);
-        let receipt = backend
-            .open_session_blocking(&challenge)
-            .map_err(|source| TuneError::Adapter {
-                adapter: backend.simulator_identity().id.clone(),
-                operation: "open simulator session",
-                source,
-            })?;
-        session::validate_simulator_receipt(&journal, receipt)?;
-        let capability = SimulatorCapability::new(receipt);
-        let vehicle = vehicle_factory
-            .bind_blocking(&capability)
-            .map_err(|source| TuneError::Adapter {
-                adapter: vehicle_identity.id,
-                operation: "bind simulator vehicle",
-                source,
-            })?;
-        session::validate_vehicle_binding(&journal, &vehicle)?;
-        evaluate::recover_pending_blocking(&mut journal, &mut backend, &mut gates, &mut metric)?;
-        let mut tuner = Self {
-            stage,
-            backend,
-            vehicle,
-            capability,
-            gates,
-            metric,
-            strategy,
-            journal,
-        };
-        tuner.reconcile_settled_candidate_blocking()?;
-        Ok(tuner)
-    }
-
     /// Evaluates at most `attempt_limit` adaptive training challengers.
     ///
     /// This method does not run promotion or final qualification scenarios.
@@ -143,6 +73,7 @@ where
         &mut self,
         attempt_limit: u64,
     ) -> Result<TuningSummary, TuneError> {
+        self.journal.ensure_usable()?;
         self.require_phase(CampaignPhase::Searching, "run training")?;
         self.recover_pending_blocking()?;
         self.ensure_training_baseline_blocking()?;
@@ -161,6 +92,7 @@ where
     ///
     /// Returns [`TuneError`] when training is incomplete or already closed.
     pub fn freeze_candidate(&mut self) -> Result<Digest, TuneError> {
+        self.journal.ensure_usable()?;
         self.require_phase(CampaignPhase::Searching, "freeze training candidate")?;
         self.recover_pending_blocking()?;
         self.ensure_safe_baseline()?;
@@ -177,6 +109,7 @@ where
     ///
     /// Returns [`TuneError`] when training is not frozen or execution fails.
     pub fn run_promotion_once_blocking(&mut self) -> Result<PromotionDecision, TuneError> {
+        self.journal.ensure_usable()?;
         if let Some(decision) = self.journal.state().promotion_decision.clone() {
             self.reconcile_settled_candidate_blocking()?;
             return Ok(decision);
@@ -217,6 +150,7 @@ where
     pub fn run_final_qualification_once_blocking(
         &mut self,
     ) -> Result<FinalQualificationOutcome, TuneError> {
+        self.journal.ensure_usable()?;
         if let Some(outcome) = self.journal.state().final_outcome.clone() {
             self.reconcile_settled_candidate_blocking()?;
             return Ok(outcome);
@@ -239,6 +173,7 @@ where
     ///
     /// Returns [`TuneError`] when final qualification did not pass.
     pub fn qualified_candidate(&self) -> Result<Candidate, TuneError> {
+        self.journal.ensure_usable()?;
         if self.journal.state().final_outcome != Some(FinalQualificationOutcome::Qualified) {
             return Err(invalid_state(
                 "read qualified candidate",
@@ -297,13 +232,20 @@ where
                 history: &history,
             },
         };
-        let Some(proposal) =
-            self.strategy
-                .propose(&context)
-                .map_err(|error| TuneError::Proposal {
+        self.journal.ensure_usable()?;
+        let proposal = match self.strategy.propose(&context) {
+            Ok(proposal) => {
+                self.journal.ensure_usable()?;
+                proposal
+            }
+            Err(error) => {
+                self.journal.ensure_usable().ok();
+                return Err(TuneError::Proposal {
                     detail: error.to_string(),
-                })?
-        else {
+                });
+            }
+        };
+        let Some(proposal) = proposal else {
             return Ok(false);
         };
         validate_proposal(&self.stage, &incumbent, &proposal, &history)?;
@@ -352,6 +294,10 @@ where
     }
 
     fn recover_pending_blocking(&mut self) -> Result<(), TuneError> {
+        self.journal.ensure_usable()?;
+        if self.journal.state().pending.is_none() {
+            return Ok(());
+        }
         let result = evaluate::recover_pending_blocking(
             &mut self.journal,
             &mut self.backend,

--- a/tools/flight-tune/src/engine/evaluate.rs
+++ b/tools/flight-tune/src/engine/evaluate.rs
@@ -1,3 +1,4 @@
+mod cleanup;
 mod contract;
 mod record;
 
@@ -12,6 +13,7 @@ use crate::{
     SampleEvent, SearchStage, SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter,
     TelemetrySample, TuneError, VehicleBinding,
 };
+use cleanup::{cleanup_status, finish_cleanup, operation_status, quarantine_after_error};
 use contract::*;
 use record::{RunProgress, record_terminal};
 
@@ -33,6 +35,7 @@ pub(super) fn candidate_digest(candidate: &Candidate) -> Result<Digest, TuneErro
 }
 
 pub(super) fn ensure_candidate_blocking<V>(
+    journal: &Journal,
     vehicle: &mut VehicleBinding<V>,
     capability: &SimulatorCapability,
     candidate: &Candidate,
@@ -41,11 +44,13 @@ pub(super) fn ensure_candidate_blocking<V>(
 where
     V: SimulatorVehicleAdapter,
 {
+    journal.ensure_usable()?;
     let receipt =
         vehicle
             .adapter_mut()
             .ensure_candidate_blocking(capability, candidate, candidate_digest);
-    validate_candidate_receipt(receipt, capability, candidate_digest)
+    validate_candidate_receipt(receipt, capability, candidate_digest)?;
+    journal.ensure_usable()
 }
 
 pub(super) fn recover_pending_blocking<B, G, M>(
@@ -59,6 +64,7 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    journal.ensure_usable()?;
     let Some(pending) = journal.state().pending.clone() else {
         return Ok(());
     };
@@ -68,8 +74,9 @@ where
             "process stopped after AttemptPrepared; automatic replay is forbidden",
         )?;
     }
+    journal.ensure_usable()?;
     let stop = operation_status(|| backend.stop_blocking());
-    let cleanup = cleanup_status(backend, gates, metric, true);
+    let cleanup = cleanup_status(journal, backend, gates, metric, true)?;
     journal.record_cleanup(pending.trial_id, stop, cleanup.clone())?;
     if cleanup.succeeded() {
         Ok(())
@@ -101,12 +108,14 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    journal.ensure_usable()?;
     let set = role.scenario_set();
     let scenario_count = scenarios(stage, set).len();
     let expected_runs = scenario_count * stage.repetitions as usize;
     let mut runs = Vec::new();
     for scenario in scenarios(stage, set) {
         for repetition in 0..stage.repetitions {
+            journal.ensure_usable()?;
             let seed = derive_seed(journal.session().fixed_seed, set, scenario, repetition);
             let context = RunContext {
                 set,
@@ -115,6 +124,7 @@ where
                 seed,
             };
             let terminal = run_until_terminal(
+                journal,
                 stage,
                 &context,
                 candidate,
@@ -151,6 +161,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn run_until_terminal<B, V, G, M>(
+    journal: &Journal,
     stage: &SearchStage,
     context: &RunContext<'_>,
     candidate: &Candidate,
@@ -167,20 +178,33 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
     if let Err(source) = backend.prepare_blocking(capability, context.scenario, context.seed) {
         return RunTerminal::Failed {
             error: adapter_error(backend, "prepare", source),
             started: false,
         };
     }
-    if let Err(error) = ensure_candidate_blocking(vehicle, capability, candidate, candidate_digest)
+    if let Err(error) =
+        ensure_candidate_blocking(journal, vehicle, capability, candidate, candidate_digest)
     {
         return RunTerminal::Failed {
             error,
             started: false,
         };
     }
-    if let Err(error) = begin_evaluators(context.scenario, gates, metric) {
+    if let Err(error) = begin_evaluators(journal, context.scenario, gates, metric) {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
+    if let Err(error) = journal.ensure_usable() {
         return RunTerminal::Failed {
             error,
             started: false,
@@ -201,10 +225,11 @@ where
             started: true,
         };
     }
-    stream_samples(stage, context, backend, gates, metric)
+    stream_samples(journal, stage, context, backend, gates, metric)
 }
 
 fn stream_samples<B, G, M>(
+    journal: &Journal,
     stage: &SearchStage,
     context: &RunContext<'_>,
     backend: &mut B,
@@ -217,51 +242,43 @@ where
     M: MetricEvaluator,
 {
     let timeout = Duration::from_millis(u64::from(context.scenario.sample_timeout_ms));
-    let mut expected_sequence = 0_u64;
-    let mut elapsed_ms = 0_u64;
+    let mut position = StreamPosition::default();
     loop {
+        if let Err(error) = journal.ensure_usable() {
+            return RunTerminal::Failed {
+                error,
+                started: true,
+            };
+        }
         match backend.sample_blocking(timeout) {
             Ok(SampleEvent::Sample(sample)) => {
-                if expected_sequence >= u64::from(context.scenario.max_samples) {
-                    return hard_failure(
-                        context,
-                        sample.sequence,
-                        sample.elapsed_ms,
-                        GateOutcome::fail(
-                            "core.sample_limit",
-                            "the simulator exceeded the scenario sample limit",
-                        ),
-                    );
-                }
-                if let Err(error) = validate_sample(&sample, expected_sequence, elapsed_ms) {
-                    return RunTerminal::Failed {
-                        error,
-                        started: true,
-                    };
-                }
-                elapsed_ms = sample.elapsed_ms;
-                expected_sequence = expected_sequence.wrapping_add(1);
-                match evaluate_sample(stage, &sample, gates, metric) {
-                    Ok(Some(gate)) => {
-                        return hard_failure(context, sample.sequence, sample.elapsed_ms, gate);
-                    }
-                    Ok(None) => {}
-                    Err(error) => {
-                        return RunTerminal::Failed {
-                            error,
-                            started: true,
-                        };
-                    }
+                if let Some(terminal) = process_sample(
+                    journal,
+                    stage,
+                    context,
+                    sample,
+                    &mut position,
+                    gates,
+                    metric,
+                ) {
+                    return terminal;
                 }
             }
             Ok(SampleEvent::Complete) => {
-                return finish_stream_blocking(context, expected_sequence, backend, gates, metric);
+                return finish_stream_blocking(
+                    journal,
+                    context,
+                    position.expected_sequence,
+                    backend,
+                    gates,
+                    metric,
+                );
             }
             Ok(SampleEvent::TimedOut) => {
                 return hard_failure(
                     context,
-                    expected_sequence,
-                    elapsed_ms,
+                    position.expected_sequence,
+                    position.elapsed_ms,
                     GateOutcome::fail(
                         "core.sample_timeout",
                         "the simulator did not supply a sample before the timeout",
@@ -278,7 +295,62 @@ where
     }
 }
 
+#[derive(Default)]
+struct StreamPosition {
+    expected_sequence: u64,
+    elapsed_ms: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_sample<G, M>(
+    journal: &Journal,
+    stage: &SearchStage,
+    context: &RunContext<'_>,
+    sample: TelemetrySample,
+    position: &mut StreamPosition,
+    gates: &mut G,
+    metric: &mut M,
+) -> Option<RunTerminal>
+where
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    if position.expected_sequence >= u64::from(context.scenario.max_samples) {
+        return Some(hard_failure(
+            context,
+            sample.sequence,
+            sample.elapsed_ms,
+            GateOutcome::fail(
+                "core.sample_limit",
+                "the simulator exceeded the scenario sample limit",
+            ),
+        ));
+    }
+    if let Err(error) = validate_sample(&sample, position.expected_sequence, position.elapsed_ms) {
+        return Some(RunTerminal::Failed {
+            error,
+            started: true,
+        });
+    }
+    position.elapsed_ms = sample.elapsed_ms;
+    position.expected_sequence = position.expected_sequence.wrapping_add(1);
+    match evaluate_sample(journal, stage, &sample, gates, metric) {
+        Ok(Some(gate)) => Some(hard_failure(
+            context,
+            sample.sequence,
+            sample.elapsed_ms,
+            gate,
+        )),
+        Ok(None) => None,
+        Err(error) => Some(RunTerminal::Failed {
+            error,
+            started: true,
+        }),
+    }
+}
+
 fn finish_stream_blocking<B, G, M>(
+    journal: &Journal,
     context: &RunContext<'_>,
     sample_count: u64,
     backend: &mut B,
@@ -301,10 +373,11 @@ where
             ),
         );
     }
-    finish_normal_run_blocking(backend, gates, metric)
+    finish_normal_run_blocking(journal, backend, gates, metric)
 }
 
 fn evaluate_sample<G, M>(
+    journal: &Journal,
     stage: &SearchStage,
     sample: &TelemetrySample,
     gates: &mut G,
@@ -314,12 +387,14 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    journal.ensure_usable()?;
     let outcomes = gates
         .evaluate(sample)
         .map_err(|source| evaluator_error(gates.identity(), "evaluate hard gates", source))?;
     if let Some(failure) = validate_gate_outcomes(&stage.required_hard_gates, &outcomes)? {
         return Ok(Some(failure));
     }
+    journal.ensure_usable()?;
     metric
         .observe(sample)
         .map_err(|source| evaluator_error(metric.identity(), "observe metric", source))?;
@@ -327,6 +402,7 @@ where
 }
 
 fn finish_normal_run_blocking<B, G, M>(
+    journal: &Journal,
     backend: &mut B,
     gates: &mut G,
     metric: &mut M,
@@ -336,15 +412,33 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: true,
+        };
+    }
     if let Err(source) = backend.stop_blocking() {
         return RunTerminal::Failed {
             error: adapter_error(backend, "stop", source),
             started: true,
         };
     }
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
     if let Err(source) = gates.finish() {
         return RunTerminal::Failed {
             error: evaluator_error(gates.identity(), "finish hard gates", source),
+            started: false,
+        };
+    }
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
             started: false,
         };
     }
@@ -384,104 +478,6 @@ fn hard_failure(
             sample_sequence,
             elapsed_ms,
             gate,
-        },
-    }
-}
-
-fn finish_cleanup<B, G, M>(
-    journal: &mut Journal,
-    trial_id: u64,
-    mut stop: OperationStatus,
-    backend: &mut B,
-    stop_required: Option<()>,
-    gates: &mut G,
-    metric: &mut M,
-) -> Result<(), TuneError>
-where
-    B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    if stop_required.is_some() {
-        stop = operation_status(|| backend.stop_blocking());
-    }
-    let cleanup = cleanup_status(backend, gates, metric, stop_required.is_some());
-    let succeeded = stop.succeeded() && cleanup.succeeded();
-    journal.record_cleanup(trial_id, stop, cleanup.clone())?;
-    if succeeded {
-        Ok(())
-    } else {
-        Err(TuneError::InvalidState {
-            operation: "cleanup",
-            detail: "the simulator or evaluator is not clean".to_owned(),
-        })
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn quarantine_after_error<B, G, M>(
-    journal: &mut Journal,
-    trial_id: u64,
-    error: TuneError,
-    mut stop: OperationStatus,
-    backend: &mut B,
-    stop_required: Option<()>,
-    gates: &mut G,
-    metric: &mut M,
-) -> Result<(), TuneError>
-where
-    B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    journal.quarantine_attempt(trial_id, error.to_string())?;
-    if stop_required.is_some() {
-        stop = operation_status(|| backend.stop_blocking());
-    }
-    let cleanup = cleanup_status(backend, gates, metric, true);
-    journal.record_cleanup(trial_id, stop, cleanup)?;
-    Err(error)
-}
-
-fn cleanup_status<B, G, M>(
-    backend: &mut B,
-    gates: &mut G,
-    metric: &mut M,
-    cancel_evaluators: bool,
-) -> OperationStatus
-where
-    B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    let mut failures = Vec::new();
-    if cancel_evaluators {
-        if let Err(error) = gates.cancel() {
-            failures.push(format!("hard gate cancel: {error}"));
-        }
-        if let Err(error) = metric.cancel() {
-            failures.push(format!("metric cancel: {error}"));
-        }
-    }
-    if let Err(error) = backend.cleanup_blocking() {
-        failures.push(format!("simulator cleanup: {error}"));
-    }
-    if failures.is_empty() {
-        OperationStatus::Succeeded
-    } else {
-        OperationStatus::Failed {
-            detail: failures.join("; "),
-        }
-    }
-}
-
-fn operation_status(
-    operation: impl FnOnce() -> Result<(), crate::AdapterError>,
-) -> OperationStatus {
-    match operation() {
-        Ok(()) => OperationStatus::Succeeded,
-        Err(error) => OperationStatus::Failed {
-            detail: error.to_string(),
         },
     }
 }

--- a/tools/flight-tune/src/engine/evaluate/cleanup.rs
+++ b/tools/flight-tune/src/engine/evaluate/cleanup.rs
@@ -1,0 +1,136 @@
+use crate::journal::OperationStatus;
+use crate::{GateEvaluator, Journal, MetricEvaluator, SimulatorBackend, TuneError};
+
+pub(super) fn finish_cleanup<B, G, M>(
+    journal: &mut Journal,
+    trial_id: u64,
+    mut stop: OperationStatus,
+    backend: &mut B,
+    stop_required: Option<()>,
+    gates: &mut G,
+    metric: &mut M,
+) -> Result<(), TuneError>
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    journal.ensure_usable()?;
+    if stop_required.is_some() {
+        stop = authorized_operation_status(journal, || backend.stop_blocking())?;
+    }
+    let cleanup = cleanup_status(journal, backend, gates, metric, stop_required.is_some())?;
+    let succeeded = stop.succeeded() && cleanup.succeeded();
+    journal.record_cleanup(trial_id, stop, cleanup.clone())?;
+    if succeeded {
+        Ok(())
+    } else {
+        Err(TuneError::InvalidState {
+            operation: "cleanup",
+            detail: "the simulator or evaluator is not clean".to_owned(),
+        })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn quarantine_after_error<B, G, M>(
+    journal: &mut Journal,
+    trial_id: u64,
+    error: TuneError,
+    mut stop: OperationStatus,
+    backend: &mut B,
+    stop_required: Option<()>,
+    gates: &mut G,
+    metric: &mut M,
+) -> Result<(), TuneError>
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    if let Err(journal_error) = journal.quarantine_attempt(trial_id, error.to_string()) {
+        return preserve_primary(journal, error, journal_error);
+    }
+    journal.ensure_usable()?;
+    if stop_required.is_some() {
+        stop = match authorized_operation_status(journal, || backend.stop_blocking()) {
+            Ok(status) => status,
+            Err(cleanup_error) => return preserve_primary(journal, error, cleanup_error),
+        };
+    }
+    let cleanup = match cleanup_status(journal, backend, gates, metric, true) {
+        Ok(status) => status,
+        Err(cleanup_error) => return preserve_primary(journal, error, cleanup_error),
+    };
+    if let Err(journal_error) = journal.record_cleanup(trial_id, stop, cleanup) {
+        return preserve_primary(journal, error, journal_error);
+    }
+    Err(error)
+}
+
+pub(super) fn cleanup_status<B, G, M>(
+    journal: &Journal,
+    backend: &mut B,
+    gates: &mut G,
+    metric: &mut M,
+    cancel_evaluators: bool,
+) -> Result<OperationStatus, TuneError>
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    let mut failures = Vec::new();
+    if cancel_evaluators {
+        journal.ensure_usable()?;
+        if let Err(error) = gates.cancel() {
+            failures.push(format!("hard gate cancel: {error}"));
+        }
+        journal.ensure_usable()?;
+        if let Err(error) = metric.cancel() {
+            failures.push(format!("metric cancel: {error}"));
+        }
+    }
+    journal.ensure_usable()?;
+    if let Err(error) = backend.cleanup_blocking() {
+        failures.push(format!("simulator cleanup: {error}"));
+    }
+    if failures.is_empty() {
+        Ok(OperationStatus::Succeeded)
+    } else {
+        Ok(OperationStatus::Failed {
+            detail: failures.join("; "),
+        })
+    }
+}
+
+pub(super) fn operation_status(
+    operation: impl FnOnce() -> Result<(), crate::AdapterError>,
+) -> OperationStatus {
+    match operation() {
+        Ok(()) => OperationStatus::Succeeded,
+        Err(error) => OperationStatus::Failed {
+            detail: error.to_string(),
+        },
+    }
+}
+
+fn authorized_operation_status(
+    journal: &Journal,
+    operation: impl FnOnce() -> Result<(), crate::AdapterError>,
+) -> Result<OperationStatus, TuneError> {
+    journal.ensure_usable()?;
+    Ok(operation_status(operation))
+}
+
+fn preserve_primary(
+    journal: &Journal,
+    primary: TuneError,
+    secondary: TuneError,
+) -> Result<(), TuneError> {
+    if journal.ensure_usable().is_err() {
+        Err(primary)
+    } else {
+        Err(secondary)
+    }
+}

--- a/tools/flight-tune/src/engine/evaluate/contract.rs
+++ b/tools/flight-tune/src/engine/evaluate/contract.rs
@@ -43,6 +43,7 @@ pub(super) fn validate_sample(
 }
 
 pub(super) fn begin_evaluators<G, M>(
+    journal: &Journal,
     scenario: &ScenarioRef,
     gates: &mut G,
     metric: &mut M,
@@ -51,9 +52,11 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    journal.ensure_usable()?;
     gates
         .begin(scenario)
         .map_err(|source| evaluator_error(gates.identity(), "begin hard gates", source))?;
+    journal.ensure_usable()?;
     metric
         .begin(scenario)
         .map_err(|source| evaluator_error(metric.identity(), "begin metric", source))

--- a/tools/flight-tune/src/engine/evaluate/record.rs
+++ b/tools/flight-tune/src/engine/evaluate/record.rs
@@ -101,6 +101,7 @@ where
 {
     runs.push(run_record(stage, context, values));
     if runs.len() < expected_runs {
+        journal.ensure_usable()?;
         if let Err(source) = backend.cleanup_blocking() {
             let error = adapter_error(backend, "cleanup", source);
             return quarantine_after_error(

--- a/tools/flight-tune/src/engine/open.rs
+++ b/tools/flight-tune/src/engine/open.rs
@@ -1,0 +1,172 @@
+use std::path::Path;
+
+use crate::{
+    Candidate, GateEvaluator, Journal, MetricEvaluator, ProposalStrategy, RuntimeIdentities,
+    SearchStage, SessionChallenge, SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter,
+    SimulatorVehicleFactory, TuneError,
+};
+
+use super::{Tuner, evaluate, session};
+
+impl<B, V, G, M, P> Tuner<B, V, G, M, P>
+where
+    B: SimulatorBackend,
+    V: SimulatorVehicleAdapter,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+    P: ProposalStrategy,
+{
+    /// Opens a matching campaign or creates a new campaign.
+    ///
+    /// The constructor binds the vehicle adapter to the validated simulator
+    /// session. It also cleans and quarantines an incomplete prepared attempt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when identity, binding, recovery, or storage fails.
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_or_resume<F>(
+        journal_root: impl AsRef<Path>,
+        stage: SearchStage,
+        fixed_seed: u64,
+        initial_candidate: Candidate,
+        backend: B,
+        vehicle_factory: F,
+        gates: G,
+        metric: M,
+        strategy: P,
+    ) -> Result<Self, TuneError>
+    where
+        F: SimulatorVehicleFactory<Adapter = V>,
+    {
+        let runtimes =
+            validate_open_components(&backend, &vehicle_factory, &gates, &metric, &strategy)?;
+        let journal = Journal::open_or_create(
+            journal_root,
+            &stage,
+            fixed_seed,
+            runtimes,
+            &initial_candidate,
+        )?;
+        Self::finish_open(
+            stage,
+            backend,
+            vehicle_factory,
+            gates,
+            metric,
+            strategy,
+            journal,
+        )
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn open_or_resume_with_faults<F>(
+        journal_root: impl AsRef<Path>,
+        stage: SearchStage,
+        fixed_seed: u64,
+        initial_candidate: Candidate,
+        backend: B,
+        vehicle_factory: F,
+        gates: G,
+        metric: M,
+        strategy: P,
+        faults: pilotage_durable_storage::FaultController,
+    ) -> Result<Self, TuneError>
+    where
+        F: SimulatorVehicleFactory<Adapter = V>,
+    {
+        let runtimes =
+            validate_open_components(&backend, &vehicle_factory, &gates, &metric, &strategy)?;
+        let journal = Journal::open_or_create_with_faults(
+            journal_root,
+            &stage,
+            fixed_seed,
+            runtimes,
+            &initial_candidate,
+            faults,
+        )?;
+        Self::finish_open(
+            stage,
+            backend,
+            vehicle_factory,
+            gates,
+            metric,
+            strategy,
+            journal,
+        )
+    }
+
+    fn finish_open<F>(
+        stage: SearchStage,
+        mut backend: B,
+        vehicle_factory: F,
+        mut gates: G,
+        mut metric: M,
+        strategy: P,
+        mut journal: Journal,
+    ) -> Result<Self, TuneError>
+    where
+        F: SimulatorVehicleFactory<Adapter = V>,
+    {
+        let vehicle_identity = vehicle_factory.vehicle_identity().clone();
+        journal.ensure_usable()?;
+        let session_digest = journal.session_digest()?;
+        let challenge = SessionChallenge::new(session_digest);
+        let receipt = backend
+            .open_session_blocking(&challenge)
+            .map_err(|source| TuneError::Adapter {
+                adapter: backend.simulator_identity().id.clone(),
+                operation: "open simulator session",
+                source,
+            })?;
+        session::validate_simulator_receipt(&journal, receipt)?;
+        let capability = SimulatorCapability::new(receipt);
+        journal.ensure_usable()?;
+        let vehicle = vehicle_factory
+            .bind_blocking(&capability)
+            .map_err(|source| TuneError::Adapter {
+                adapter: vehicle_identity.id,
+                operation: "bind simulator vehicle",
+                source,
+            })?;
+        session::validate_vehicle_binding(&journal, &vehicle)?;
+        evaluate::recover_pending_blocking(&mut journal, &mut backend, &mut gates, &mut metric)?;
+        let mut tuner = Self {
+            stage,
+            backend,
+            vehicle,
+            capability,
+            gates,
+            metric,
+            strategy,
+            journal,
+        };
+        tuner.reconcile_settled_candidate_blocking()?;
+        Ok(tuner)
+    }
+}
+
+pub(crate) fn validate_open_components<B, F, G, M, P>(
+    backend: &B,
+    vehicle_factory: &F,
+    gates: &G,
+    metric: &M,
+    strategy: &P,
+) -> Result<RuntimeIdentities, TuneError>
+where
+    B: SimulatorBackend,
+    F: SimulatorVehicleFactory,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+    P: ProposalStrategy,
+{
+    session::validate_component_identities(backend, vehicle_factory, gates, metric, strategy)?;
+    Ok(session::runtime_identities(
+        backend,
+        vehicle_factory,
+        gates,
+        metric,
+        strategy,
+    ))
+}

--- a/tools/flight-tune/src/engine/reconcile.rs
+++ b/tools/flight-tune/src/engine/reconcile.rs
@@ -15,6 +15,7 @@ where
     P: ProposalStrategy,
 {
     pub(super) fn reconcile_settled_candidate_blocking(&mut self) -> Result<(), TuneError> {
+        self.journal.ensure_usable()?;
         if self.journal.state().pending.is_some() {
             return Err(invalid_state(
                 "reconcile active candidate",
@@ -23,7 +24,13 @@ where
         }
         let digest = self.settled_candidate_digest();
         let candidate = self.journal.read_candidate(digest)?;
-        evaluate::ensure_candidate_blocking(&mut self.vehicle, &self.capability, &candidate, digest)
+        evaluate::ensure_candidate_blocking(
+            &self.journal,
+            &mut self.vehicle,
+            &self.capability,
+            &candidate,
+            digest,
+        )
     }
 
     pub(super) fn finish_with_candidate_reconciliation_blocking(
@@ -31,6 +38,12 @@ where
         operation: &'static str,
         primary: Result<(), TuneError>,
     ) -> Result<(), TuneError> {
+        if let Err(poisoned) = self.journal.ensure_usable() {
+            return match primary {
+                Ok(()) => Err(poisoned),
+                Err(primary) => Err(primary),
+            };
+        }
         if self.journal.state().pending.is_some() {
             return primary.and_then(|()| {
                 Err(invalid_state(

--- a/tools/flight-tune/src/engine/tests.rs
+++ b/tools/flight-tune/src/engine/tests.rs
@@ -1,0 +1,4 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+#[cfg(unix)]
+mod journal_poison;

--- a/tools/flight-tune/src/engine/tests/journal_poison.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison.rs
@@ -1,0 +1,368 @@
+mod authorization;
+mod catalog;
+mod evidence;
+mod external_action;
+mod prospective_authorization;
+#[allow(dead_code)]
+#[path = "../../../tests/tuner/test_rig.rs"]
+mod rig;
+mod writer_lease;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use pilotage_durable_storage::{
+    DurabilityStep, FaultAction, FaultController, FaultRule, StorageError, StorageOperation,
+};
+
+use crate::{Journal, JournalEvent, TuneError, Tuner};
+use evidence::{
+    ActionSnapshot, EvidenceSnapshot, completed_baseline_actions,
+    completed_without_final_cleanup_actions,
+};
+use rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, FakeVehicle, ObservedViews,
+    QuadraticMetric, SequenceStrategy, candidate, stage,
+};
+
+type TestTuner = Tuner<FakeBackend, FakeVehicle, EnvelopeGates, QuadraticMetric, SequenceStrategy>;
+
+#[test]
+fn an_ambiguous_preparation_poison_stops_all_external_action() {
+    let directory = TestDirectory::new("prepared-head-poison");
+    let faults = head_faults(2);
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
+    let before = ActionSnapshot::new(&state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("poison prepared HEAD");
+
+    assert_ambiguous(error);
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(ActionSnapshot::new(&state, &proposals), before);
+    assert_eq!(tuner.journal().entries().len(), 1);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
+    drop(tuner);
+
+    let reopened = reopen_journal(&directory, state);
+    assert_eq!(reopened.entries().len(), 2);
+    assert!(matches!(
+        reopened.entries()[1].event,
+        JournalEvent::AttemptPrepared { .. }
+    ));
+    let pending = reopened.state().pending.as_ref().expect("pending attempt");
+    assert!(pending.outcome.is_none());
+}
+
+#[test]
+fn an_ambiguous_cleanup_poison_skips_candidate_reconciliation() {
+    let directory = TestDirectory::new("cleanup-head-poison");
+    let faults = head_faults(4);
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("poison cleanup HEAD");
+
+    assert_ambiguous(error);
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(
+        ActionSnapshot::new(&state, &proposals),
+        completed_baseline_actions()
+    );
+    assert_eq!(tuner.journal().entries().len(), 3);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
+    drop(tuner);
+
+    let reopened = reopen_journal(&directory, state);
+    assert_eq!(reopened.entries().len(), 4);
+    assert!(matches!(
+        reopened.entries()[3].event,
+        JournalEvent::CleanupRecorded { .. }
+    ));
+    assert!(reopened.state().pending.is_none());
+    assert!(reopened.state().training_baseline.is_some());
+}
+
+#[test]
+fn an_ambiguous_completion_poison_skips_cleanup_and_reconciliation() {
+    let directory = TestDirectory::new("completed-head-poison");
+    let faults = head_faults(3);
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("poison completed HEAD");
+
+    assert_ambiguous(error);
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(
+        ActionSnapshot::new(&state, &proposals),
+        completed_without_final_cleanup_actions()
+    );
+    assert_eq!(tuner.journal().entries().len(), 2);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
+    drop(tuner);
+
+    let reopened = reopen_journal(&directory, state);
+    assert_eq!(reopened.entries().len(), 3);
+    assert!(matches!(
+        reopened.entries()[2].event,
+        JournalEvent::AttemptCompleted { .. }
+    ));
+    let pending = reopened.state().pending.as_ref().expect("pending attempt");
+    assert!(pending.outcome.is_some());
+}
+
+#[test]
+fn an_ambiguous_quarantine_preserves_the_primary_error() {
+    let directory = TestDirectory::new("quarantine-head-poison");
+    let faults = head_faults(3);
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
+    state.0.borrow_mut().bad_candidate_readback_on_ensure = Some(2);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("poison quarantine HEAD");
+
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+    assert!(faults.is_exhausted().expect("read fault state"));
+    let actions = state.0.borrow();
+    assert_eq!(actions.prepare_count, 1);
+    assert_eq!(actions.ensure_count, 2);
+    assert_eq!(actions.start_count, 0);
+    assert_eq!(actions.stop_count, 0);
+    assert_eq!(actions.cleanup_count, 0);
+    drop(actions);
+    assert_eq!(tuner.journal().entries().len(), 2);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
+    drop(tuner);
+
+    let reopened = reopen_journal(&directory, state);
+    assert_eq!(reopened.entries().len(), 3);
+    assert!(matches!(
+        reopened.entries()[2].event,
+        JournalEvent::AttemptQuarantined { .. }
+    ));
+}
+
+#[test]
+fn a_stale_head_authorization_poison_stops_all_external_action() {
+    let directory = TestDirectory::new("stale-head-poison");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) =
+        open_with_faults(&directory, state.clone(), FaultController::default());
+    let mut conflicting = fs::read(directory.path().join("HEAD.json")).expect("read journal head");
+    let digest_tail = conflicting.len().wrapping_sub(3);
+    conflicting[digest_tail] = if conflicting[digest_tail] == b'0' {
+        b'1'
+    } else {
+        b'0'
+    };
+    fs::write(directory.path().join("HEAD.json"), conflicting).expect("replace journal head");
+    let before = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject stale HEAD");
+
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::ContentMismatch { context }
+                if context.object.is_some())
+    ));
+    assert_snapshot(&tuner, &directory, &state, &proposals, &before);
+    assert_eq!(tuner.journal().entries().len(), 1);
+    assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &before);
+}
+
+#[test]
+fn a_failed_authorization_rename_leaves_an_inert_orphan() {
+    let directory = TestDirectory::new("inert-orphan");
+    let faults = FaultController::new([FaultRule::on_occurrence(
+        StorageOperation::CompareExchange,
+        DurabilityStep::AuthorizationRename,
+        2,
+        FaultAction::FailBefore,
+    )]);
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
+    let head_before = fs::read(directory.path().join("HEAD.json")).expect("read journal head");
+    let actions_before = ActionSnapshot::new(&state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("fail before HEAD rename");
+
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::InjectedFault { .. })
+    ));
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(ActionSnapshot::new(&state, &proposals), actions_before);
+    assert_eq!(tuner.journal().entries().len(), 1);
+    assert_eq!(
+        fs::read(directory.path().join("HEAD.json")).expect("read unchanged journal head"),
+        head_before
+    );
+    assert_eq!(
+        fs::read_dir(directory.path().join("entries"))
+            .expect("read entry directory")
+            .count(),
+        2
+    );
+    drop(tuner);
+
+    let reopened = reopen_journal(&directory, state);
+    assert_eq!(reopened.entries().len(), 1);
+    assert!(matches!(
+        reopened.entries()[0].event,
+        JournalEvent::Started { .. }
+    ));
+}
+
+fn open_with_faults(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    faults: FaultController,
+) -> (TestTuner, ObservedViews) {
+    let strategy = SequenceStrategy::new(Vec::new());
+    let proposals = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        faults,
+    )
+    .expect("open fault-enabled tuner");
+    (tuner, proposals)
+}
+
+fn reopen_journal(directory: &TestDirectory, state: FakeHandle) -> Journal {
+    let backend = FakeBackend::new(state.clone());
+    let factory = FakeFactory::new(state.clone());
+    let gates = EnvelopeGates::tracked(2.0, state.clone());
+    let metric = QuadraticMetric::new(state);
+    let strategy = SequenceStrategy::new(Vec::new());
+    let runtimes =
+        super::super::validate_open_components(&backend, &factory, &gates, &metric, &strategy)
+            .expect("validate runtime identities");
+    Journal::open_or_create(directory.path(), &stage(), 91, runtimes, &candidate(0.0))
+        .expect("reopen durable journal")
+}
+
+fn head_faults(parent_occurrence: u64) -> FaultController {
+    FaultController::new([
+        FaultRule::on_occurrence(
+            StorageOperation::CompareExchange,
+            DurabilityStep::ParentDirectory,
+            parent_occurrence,
+            FaultAction::LoseAckAfter,
+        ),
+        FaultRule::once(
+            StorageOperation::CompareExchange,
+            DurabilityStep::RecoveryBarrier,
+            FaultAction::LoseAckAfter,
+        ),
+    ])
+}
+
+fn assert_ambiguous(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::AmbiguousCommit { .. })
+    ));
+}
+
+fn assert_poisoned_operations(
+    tuner: &mut TestTuner,
+    directory: &TestDirectory,
+    state: &FakeHandle,
+    proposals: &ObservedViews,
+    expected: &EvidenceSnapshot,
+) {
+    assert_poisoned(tuner.run_training_attempts_blocking(0));
+    assert_snapshot(tuner, directory, state, proposals, expected);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(tuner, directory, state, proposals, expected);
+    assert_poisoned(tuner.run_promotion_once_blocking());
+    assert_snapshot(tuner, directory, state, proposals, expected);
+    assert_poisoned(tuner.run_final_qualification_once_blocking());
+    assert_snapshot(tuner, directory, state, proposals, expected);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(tuner, directory, state, proposals, expected);
+}
+
+fn assert_poisoned<T>(result: Result<T, TuneError>) {
+    assert!(matches!(result, Err(TuneError::JournalPoisoned)));
+}
+
+fn assert_snapshot(
+    tuner: &TestTuner,
+    directory: &TestDirectory,
+    state: &FakeHandle,
+    proposals: &ObservedViews,
+    expected: &EvidenceSnapshot,
+) {
+    assert_eq!(
+        &EvidenceSnapshot::new(tuner, directory, state, proposals),
+        expected
+    );
+}
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(label: &str) -> Self {
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = test_root().join(format!("flight-tune-{label}-{}-{time}", std::process::id()));
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn test_root() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/private/tmp")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::env::temp_dir()
+            .canonicalize()
+            .expect("canonical test temporary directory")
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path).ok();
+    }
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/authorization.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/authorization.rs
@@ -1,0 +1,197 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
+
+use pilotage_durable_storage::FaultController;
+#[cfg(unix)]
+use pilotage_durable_storage::StorageError;
+
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{EvidenceSnapshot, TestDirectory, TestTuner, assert_poisoned, assert_snapshot};
+use crate::{FinalQualificationOutcome, TuneError, Tuner};
+
+#[test]
+fn a_changed_head_stops_pending_outcome_recovery_before_external_action() {
+    let directory = TestDirectory::new("pending-outcome-head-change");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
+    state.0.borrow_mut().panic_on_cleanup = Some(2);
+    let stopped = catch_unwind(AssertUnwindSafe(|| {
+        tuner.run_training_attempts_blocking(0).ok();
+    }));
+    assert!(stopped.is_err());
+    state.0.borrow_mut().panic_on_cleanup = None;
+    let pending = tuner
+        .journal()
+        .state()
+        .pending
+        .as_ref()
+        .expect("pending outcome");
+    assert!(pending.outcome.is_some());
+    change_head_digest(directory.path());
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject changed HEAD before recovery");
+
+    assert_changed_head(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+fn a_changed_head_stops_a_qualified_candidate_read() {
+    let directory = TestDirectory::new("qualified-read-head-change");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), vec![0.5]);
+    seal_qualified(&mut tuner);
+    change_head_digest(directory.path());
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .qualified_candidate()
+        .expect_err("reject qualified read with changed HEAD");
+
+    assert_changed_head(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.run_final_qualification_once_blocking());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+fn a_changed_head_stops_saved_result_reconciliation() {
+    let directory = TestDirectory::new("saved-result-head-change");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), vec![0.5]);
+    seal_qualified(&mut tuner);
+    change_head_digest(directory.path());
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_final_qualification_once_blocking()
+        .expect_err("reject saved result reconciliation with changed HEAD");
+
+    assert_changed_head(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+#[cfg(unix)]
+fn a_replaced_root_poison_stops_the_first_public_action() {
+    let directory = TestDirectory::new("replaced-root");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
+    let swap = RootSwap::install(directory.path());
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject replaced journal root");
+
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::RootChanged { .. })
+    ));
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    drop(tuner);
+    drop(swap);
+}
+
+fn open_tuner(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    proposals: Vec<f64>,
+) -> (TestTuner, super::rig::ObservedViews) {
+    let strategy = SequenceStrategy::new(proposals);
+    let views = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        FaultController::default(),
+    )
+    .expect("open tuner");
+    (tuner, views)
+}
+
+fn seal_qualified(tuner: &mut TestTuner) {
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run training");
+    tuner.freeze_candidate().expect("freeze candidate");
+    tuner.run_promotion_once_blocking().expect("run promotion");
+    assert_eq!(
+        tuner
+            .run_final_qualification_once_blocking()
+            .expect("run qualification"),
+        FinalQualificationOutcome::Qualified
+    );
+}
+
+fn assert_changed_head(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::ContentMismatch { context }
+                if context.object.is_some())
+    ));
+}
+
+fn change_head_digest(root: &Path) {
+    let head = root.join("HEAD.json");
+    let mut bytes = fs::read(&head).expect("read journal head");
+    let digest_tail = bytes.len().checked_sub(3).expect("HEAD digest byte");
+    bytes[digest_tail] = if bytes[digest_tail] == b'0' {
+        b'1'
+    } else {
+        b'0'
+    };
+    fs::write(head, bytes).expect("change journal head");
+}
+
+#[cfg(unix)]
+struct RootSwap {
+    root: PathBuf,
+    held: PathBuf,
+}
+
+#[cfg(unix)]
+impl RootSwap {
+    fn install(root: &Path) -> Self {
+        let held = root.with_extension("held");
+        fs::rename(root, &held).expect("hold anchored journal root");
+        symlink(&held, root).expect("replace journal root with symlink");
+        Self {
+            root: root.to_path_buf(),
+            held,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for RootSwap {
+    fn drop(&mut self) {
+        fs::remove_file(&self.root).expect("remove replacement symlink");
+        fs::rename(&self.held, &self.root).expect("restore anchored journal root");
+    }
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/catalog.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/catalog.rs
@@ -1,0 +1,192 @@
+use std::fs;
+
+use pilotage_durable_storage::{FaultController, StorageError};
+
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{EvidenceSnapshot, TestDirectory, TestTuner, assert_poisoned, assert_snapshot};
+use crate::{Digest, JournalEvent, TuneError, Tuner};
+
+#[test]
+fn an_ancestor_entry_change_poison_stops_the_next_action() {
+    let directory = TestDirectory::new("changed-ancestor-entry");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
+    tuner
+        .run_training_attempts_blocking(0)
+        .expect("complete baseline");
+    let started = serde_json::to_vec(&tuner.journal().entries()[0]).expect("encode started entry");
+    let digest = crate::identity::digest_bytes(&started);
+    change_bytes(
+        &directory
+            .path()
+            .join("entries")
+            .join(format!("{digest}.json")),
+    );
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject changed ancestor");
+
+    assert_digest_mismatch(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+fn a_missing_stage_poison_stops_the_next_action() {
+    let directory = TestDirectory::new("missing-stage");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
+    let stage = tuner.journal().session().stage_digest;
+    fs::remove_file(
+        directory
+            .path()
+            .join("stages")
+            .join(format!("{stage}.json")),
+    )
+    .expect("remove stage");
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject missing stage");
+
+    assert_missing_object(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+fn a_changed_noncurrent_candidate_poison_stops_the_next_action() {
+    let directory = TestDirectory::new("changed-historical-candidate");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), vec![1.0, 0.5]);
+    tuner
+        .run_training_attempts_blocking(2)
+        .expect("complete two challengers");
+    let current = tuner.journal().state().training_incumbent;
+    let initial = tuner.journal().session().initial_candidate_digest;
+    let historical = prepared_candidates(&tuner)
+        .find(|digest| *digest != current && *digest != initial)
+        .expect("noncurrent prepared candidate");
+    change_bytes(
+        &directory
+            .path()
+            .join("candidates")
+            .join(format!("{historical}.json")),
+    );
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .freeze_candidate()
+        .expect_err("reject changed candidate");
+
+    assert_digest_mismatch(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+#[test]
+fn a_missing_qualified_candidate_poison_stops_the_read() {
+    let directory = TestDirectory::new("missing-qualified-candidate");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), vec![0.5]);
+    seal_qualified(&mut tuner);
+    let selected = tuner
+        .journal()
+        .state()
+        .selected_release_candidate(tuner.journal().session().initial_candidate_digest);
+    fs::remove_file(
+        directory
+            .path()
+            .join("candidates")
+            .join(format!("{selected}.json")),
+    )
+    .expect("remove qualified candidate");
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .qualified_candidate()
+        .expect_err("reject missing qualified candidate");
+
+    assert_missing_object(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.run_final_qualification_once_blocking());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+}
+
+fn open_tuner(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    proposals: Vec<f64>,
+) -> (TestTuner, super::rig::ObservedViews) {
+    let strategy = SequenceStrategy::new(proposals);
+    let views = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        FaultController::default(),
+    )
+    .expect("open tuner");
+    (tuner, views)
+}
+
+fn seal_qualified(tuner: &mut TestTuner) {
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run training");
+    tuner.freeze_candidate().expect("freeze candidate");
+    tuner.run_promotion_once_blocking().expect("run promotion");
+    tuner
+        .run_final_qualification_once_blocking()
+        .expect("run qualification");
+}
+
+fn prepared_candidates(tuner: &TestTuner) -> impl Iterator<Item = Digest> + '_ {
+    tuner
+        .journal()
+        .entries()
+        .iter()
+        .filter_map(|entry| match entry.event {
+            JournalEvent::AttemptPrepared { candidate, .. } => Some(candidate),
+            _ => None,
+        })
+}
+
+fn change_bytes(path: &std::path::Path) {
+    let mut bytes = fs::read(path).expect("read evidence object");
+    bytes.push(b' ');
+    fs::write(path, bytes).expect("change evidence object");
+}
+
+fn assert_digest_mismatch(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::ContentMismatch { context }
+                if context.object.is_some())
+    ));
+}
+
+fn assert_missing_object(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::Io { source, .. }
+                if source.kind() == std::io::ErrorKind::NotFound)
+    ));
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/evidence.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/evidence.rs
@@ -1,0 +1,187 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+use super::rig::{FakeHandle, ObservedViews};
+use super::{TestDirectory, TestTuner};
+use crate::{CampaignPhase, JournalEntry};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct EvidenceSnapshot {
+    actions: ActionSnapshot,
+    entries: Vec<JournalEntry>,
+    phase: CampaignPhase,
+    training_attempt_count: u64,
+    head_bytes: Vec<u8>,
+    catalog: BTreeMap<PathBuf, CatalogEntry>,
+}
+
+impl EvidenceSnapshot {
+    pub(super) fn new(
+        tuner: &TestTuner,
+        directory: &TestDirectory,
+        state: &FakeHandle,
+        proposals: &ObservedViews,
+    ) -> Self {
+        Self {
+            actions: ActionSnapshot::new(state, proposals),
+            entries: tuner.journal().entries().to_vec(),
+            phase: tuner.journal().phase(),
+            training_attempt_count: tuner.journal().training_attempt_count(),
+            head_bytes: fs::read(directory.path().join("HEAD.json")).expect("read journal head"),
+            catalog: catalog(directory.path()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CatalogEntry {
+    kind: CatalogKind,
+    mode: u32,
+    link_count: u64,
+    bytes: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CatalogKind {
+    Directory,
+    File,
+    Symlink,
+    Other,
+}
+
+fn catalog(root: &Path) -> BTreeMap<PathBuf, CatalogEntry> {
+    let mut entries = BTreeMap::new();
+    collect_catalog(root, root, &mut entries);
+    entries
+}
+
+fn collect_catalog(root: &Path, path: &Path, entries: &mut BTreeMap<PathBuf, CatalogEntry>) {
+    let metadata = fs::symlink_metadata(path).expect("inspect evidence object");
+    let relative = path.strip_prefix(root).expect("relative evidence path");
+    let bytes = metadata
+        .is_file()
+        .then(|| fs::read(path).expect("read evidence object"));
+    entries.insert(
+        relative.to_path_buf(),
+        CatalogEntry {
+            kind: catalog_kind(&metadata),
+            mode: metadata.permissions().mode() & 0o777,
+            link_count: metadata.nlink(),
+            bytes,
+        },
+    );
+    if metadata.is_dir() {
+        let mut children = fs::read_dir(path)
+            .expect("read evidence directory")
+            .map(|entry| entry.expect("read evidence entry").path())
+            .collect::<Vec<_>>();
+        children.sort();
+        for child in children {
+            collect_catalog(root, &child, entries);
+        }
+    }
+}
+
+fn catalog_kind(metadata: &fs::Metadata) -> CatalogKind {
+    let kind = metadata.file_type();
+    if kind.is_dir() {
+        CatalogKind::Directory
+    } else if kind.is_file() {
+        CatalogKind::File
+    } else if kind.is_symlink() {
+        CatalogKind::Symlink
+    } else {
+        CatalogKind::Other
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ActionSnapshot {
+    backend: [usize; 7],
+    vehicle: [usize; 3],
+    gates: [usize; 4],
+    metric: [usize; 4],
+    strategy_proposals: usize,
+    lifecycle: Vec<String>,
+}
+
+impl ActionSnapshot {
+    pub(super) fn new(state: &FakeHandle, proposals: &ObservedViews) -> Self {
+        let state = state.0.borrow();
+        Self {
+            backend: [
+                state.open_session_count,
+                state.prepare_count,
+                state.start_count,
+                state.sample_poll_count,
+                state.sample_count,
+                state.stop_count,
+                state.cleanup_count,
+            ],
+            vehicle: [state.bind_count, state.ensure_count, state.apply_count],
+            gates: [
+                state.gate_begin_count,
+                state.gate_evaluate_count,
+                state.gate_finish_count,
+                state.gate_cancel_count,
+            ],
+            metric: [
+                state.metric_begin_count,
+                state.metric_observe_count,
+                state.metric_finish_count,
+                state.metric_cancel_count,
+            ],
+            strategy_proposals: proposals.borrow().len(),
+            lifecycle: state.lifecycle.clone(),
+        }
+    }
+}
+
+pub(super) fn completed_baseline_actions() -> ActionSnapshot {
+    ActionSnapshot {
+        backend: [1, 2, 2, 4, 2, 2, 2],
+        vehicle: [1, 3, 1],
+        gates: [2, 2, 2, 0],
+        metric: [2, 2, 2, 0],
+        strategy_proposals: 0,
+        lifecycle: vec![
+            "open_session".to_owned(),
+            "apply".to_owned(),
+            "prepare".to_owned(),
+            "start".to_owned(),
+            "sample".to_owned(),
+            "stop".to_owned(),
+            "cleanup".to_owned(),
+            "prepare".to_owned(),
+            "start".to_owned(),
+            "sample".to_owned(),
+            "stop".to_owned(),
+            "cleanup".to_owned(),
+        ],
+    }
+}
+
+pub(super) fn completed_without_final_cleanup_actions() -> ActionSnapshot {
+    ActionSnapshot {
+        backend: [1, 2, 2, 4, 2, 2, 1],
+        vehicle: [1, 3, 1],
+        gates: [2, 2, 2, 0],
+        metric: [2, 2, 2, 0],
+        strategy_proposals: 0,
+        lifecycle: vec![
+            "open_session".to_owned(),
+            "apply".to_owned(),
+            "prepare".to_owned(),
+            "start".to_owned(),
+            "sample".to_owned(),
+            "stop".to_owned(),
+            "cleanup".to_owned(),
+            "prepare".to_owned(),
+            "start".to_owned(),
+            "sample".to_owned(),
+            "stop".to_owned(),
+        ],
+    }
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/external_action.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/external_action.rs
@@ -1,0 +1,89 @@
+use pilotage_durable_storage::{FaultController, StorageError};
+
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{EvidenceSnapshot, TestDirectory, TestTuner, assert_poisoned, assert_snapshot};
+use crate::{TuneError, Tuner};
+
+#[test]
+fn a_head_change_during_prepare_stops_the_next_external_action() {
+    let directory = TestDirectory::new("prepare-head-change");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone());
+    let before = action_counts(&state);
+    state.0.borrow_mut().change_head_on_prepare = Some(directory.path().to_path_buf());
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject HEAD change after prepare");
+
+    assert_changed_head(error);
+    let after = action_counts(&state);
+    assert_eq!(after.prepare, before.prepare.wrapping_add(1));
+    assert_eq!(after.ensure, before.ensure);
+    assert_eq!(after.gate_begin, before.gate_begin);
+    assert_eq!(after.metric_begin, before.metric_begin);
+    assert_eq!(after.start, before.start);
+    assert_eq!(after.stop, before.stop);
+    assert_eq!(after.cleanup, before.cleanup);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &poisoned);
+}
+
+fn open_tuner(
+    directory: &TestDirectory,
+    state: FakeHandle,
+) -> (TestTuner, super::rig::ObservedViews) {
+    let strategy = SequenceStrategy::new(Vec::new());
+    let views = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        FaultController::default(),
+    )
+    .expect("open tuner");
+    (tuner, views)
+}
+
+#[derive(Clone, Copy)]
+struct ActionCounts {
+    prepare: usize,
+    ensure: usize,
+    gate_begin: usize,
+    metric_begin: usize,
+    start: usize,
+    stop: usize,
+    cleanup: usize,
+}
+
+fn action_counts(state: &FakeHandle) -> ActionCounts {
+    let state = state.0.borrow();
+    ActionCounts {
+        prepare: state.prepare_count,
+        ensure: state.ensure_count,
+        gate_begin: state.gate_begin_count,
+        metric_begin: state.metric_begin_count,
+        start: state.start_count,
+        stop: state.stop_count,
+        cleanup: state.cleanup_count,
+    }
+}
+
+fn assert_changed_head(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::ContentMismatch { context }
+                if context.object.is_some())
+    ));
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/prospective_authorization.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/prospective_authorization.rs
@@ -1,0 +1,151 @@
+use std::fs;
+
+use pilotage_durable_storage::{FaultController, StorageError};
+
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{EvidenceSnapshot, TestDirectory, TestTuner, assert_poisoned, assert_snapshot};
+use crate::{AttemptRole, JournalEvent, TuneError, Tuner};
+
+#[test]
+fn a_missing_head_entry_before_cas_keeps_the_old_head_and_poisons() {
+    let directory = TestDirectory::new("prospective-missing-head-entry");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone());
+    let initial = candidate(0.0);
+    let initial_digest = tuner.journal().session().initial_candidate_digest;
+    let plan = AttemptRole::TrainingBaseline
+        .plan_digest(
+            &stage(),
+            initial_digest,
+            tuner.journal().session().fixed_seed,
+        )
+        .expect("create run plan");
+    let started_digest = entry_digest(&tuner.journal().entries()[0]);
+    let started_path = directory
+        .path()
+        .join("entries")
+        .join(format!("{started_digest}.json"));
+    let head_before = read_head(&directory);
+
+    let error = tuner
+        .journal
+        .prepare_attempt_with_before_authorization_for_test(
+            AttemptRole::TrainingBaseline,
+            &initial,
+            plan,
+            || {
+                assert_eq!(root_temporary_count(&directory), 1);
+                fs::remove_file(&started_path).expect("remove current head entry");
+            },
+        )
+        .expect_err("reject missing current head entry");
+
+    assert_missing_object(error);
+    assert_eq!(read_head(&directory), head_before);
+    assert_eq!(root_temporary_count(&directory), 0);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &poisoned);
+}
+
+#[test]
+fn a_missing_pending_candidate_before_cas_keeps_the_old_head_and_poisons() {
+    let directory = TestDirectory::new("prospective-missing-pending-candidate");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone());
+    let initial = candidate(0.0);
+    let initial_digest = tuner.journal().session().initial_candidate_digest;
+    let plan = AttemptRole::TrainingBaseline
+        .plan_digest(
+            &stage(),
+            initial_digest,
+            tuner.journal().session().fixed_seed,
+        )
+        .expect("create run plan");
+    let (trial_id, prepared_candidate) = tuner
+        .journal
+        .prepare_attempt(AttemptRole::TrainingBaseline, &initial, plan)
+        .expect("prepare pending attempt");
+    let candidate_path = directory
+        .path()
+        .join("candidates")
+        .join(format!("{prepared_candidate}.json"));
+    let head_before = read_head(&directory);
+
+    let error = tuner
+        .journal
+        .append_event_with_before_authorization_for_test(
+            JournalEvent::AttemptQuarantined {
+                trial_id,
+                reason: "test quarantine".to_owned(),
+            },
+            || {
+                assert_eq!(root_temporary_count(&directory), 1);
+                fs::remove_file(&candidate_path).expect("remove pending candidate");
+            },
+        )
+        .expect_err("reject missing pending candidate");
+
+    assert_missing_object(error);
+    assert_eq!(read_head(&directory), head_before);
+    assert_eq!(root_temporary_count(&directory), 0);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &poisoned);
+}
+
+fn open_tuner(
+    directory: &TestDirectory,
+    state: FakeHandle,
+) -> (TestTuner, super::rig::ObservedViews) {
+    let strategy = SequenceStrategy::new(Vec::new());
+    let views = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        FaultController::default(),
+    )
+    .expect("open tuner");
+    (tuner, views)
+}
+
+fn entry_digest(entry: &crate::JournalEntry) -> crate::Digest {
+    let bytes = serde_json::to_vec(entry).expect("encode journal entry");
+    crate::identity::digest_bytes(&bytes)
+}
+
+fn read_head(directory: &TestDirectory) -> Vec<u8> {
+    fs::read(directory.path().join("HEAD.json")).expect("read journal head")
+}
+
+fn root_temporary_count(directory: &TestDirectory) -> usize {
+    fs::read_dir(directory.path())
+        .expect("read journal root")
+        .map(|entry| entry.expect("read root entry"))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(".pilotage-tmp-"))
+        })
+        .count()
+}
+
+fn assert_missing_object(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::Io { source, .. }
+                if source.kind() == std::io::ErrorKind::NotFound)
+    ));
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/writer_lease.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/writer_lease.rs
@@ -1,0 +1,155 @@
+use std::fs::{self, OpenOptions};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+use pilotage_durable_storage::{DurableStore, FaultController, StorageError, WriterLease};
+
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{EvidenceSnapshot, TestDirectory, TestTuner, assert_poisoned, assert_snapshot};
+use crate::{FinalQualificationOutcome, TuneError, Tuner};
+
+#[test]
+fn a_replaced_writer_lock_stops_saved_result_reconciliation() {
+    let directory = TestDirectory::new("replaced-writer-lock");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone());
+    seal_qualified(&mut tuner);
+    let mut swap = WriterLockSwap::install(directory.path());
+    let expected = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+
+    let error = tuner
+        .run_final_qualification_once_blocking()
+        .expect_err("reject replaced writer lock");
+
+    assert_writer_binding_changed(error);
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
+    drop(tuner);
+    swap.restore();
+}
+
+#[test]
+fn a_writer_lock_change_after_the_final_catalog_scan_fails_that_audit() {
+    let directory = TestDirectory::new("final-scan-writer-lock-change");
+    let state = FakeHandle::new();
+    let (tuner, proposals) = open_tuner(&directory, state.clone());
+    let mut swap = None;
+
+    let error = tuner
+        .journal()
+        .ensure_usable_with_final_hook_for_test(|| {
+            swap = Some(WriterLockSwap::install(directory.path()));
+        })
+        .expect_err("reject writer lock changed after the catalog scan");
+
+    assert_writer_binding_changed(error);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned(tuner.qualified_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &poisoned);
+    drop(tuner);
+    swap.as_mut().expect("installed writer swap").restore();
+}
+
+fn open_tuner(
+    directory: &TestDirectory,
+    state: FakeHandle,
+) -> (TestTuner, super::rig::ObservedViews) {
+    let strategy = SequenceStrategy::new(vec![0.5]);
+    let views = strategy.views.clone();
+    let tuner = Tuner::open_or_resume_with_faults(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+        FaultController::default(),
+    )
+    .expect("open tuner");
+    (tuner, views)
+}
+
+fn seal_qualified(tuner: &mut TestTuner) {
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run training");
+    tuner.freeze_candidate().expect("freeze candidate");
+    tuner.run_promotion_once_blocking().expect("run promotion");
+    assert_eq!(
+        tuner
+            .run_final_qualification_once_blocking()
+            .expect("run qualification"),
+        FinalQualificationOutcome::Qualified
+    );
+}
+
+fn assert_writer_binding_changed(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(source.as_ref(), StorageError::Corruption { reason, .. }
+                if *reason == "writer lease name binding changed")
+    ));
+}
+
+struct WriterLockSwap {
+    original: PathBuf,
+    held: PathBuf,
+    second_lease: Option<WriterLease>,
+    second_store: Option<DurableStore>,
+    restored: bool,
+}
+
+impl WriterLockSwap {
+    fn install(root: &Path) -> Self {
+        let original = root.join(".pilotage-writer-lock");
+        let held = root.with_extension("held-writer-lock");
+        fs::rename(&original, &held).expect("hold writer lock outside the journal root");
+        let replacement = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&original)
+            .expect("create replacement writer lock");
+        replacement.sync_all().expect("sync replacement lock");
+        drop(replacement);
+        let second_store = DurableStore::open_or_create(root).expect("open replacement store");
+        let second_lease = second_store
+            .acquire_writer()
+            .expect("acquire replacement writer lock");
+        Self {
+            original,
+            held,
+            second_lease: Some(second_lease),
+            second_store: Some(second_store),
+            restored: false,
+        }
+    }
+
+    fn restore(&mut self) {
+        drop(self.second_lease.take());
+        drop(self.second_store.take());
+        fs::remove_file(&self.original).expect("remove replacement writer lock");
+        fs::rename(&self.held, &self.original).expect("restore held writer lock");
+        self.restored = true;
+    }
+}
+
+impl Drop for WriterLockSwap {
+    fn drop(&mut self) {
+        if self.restored {
+            return;
+        }
+        drop(self.second_lease.take());
+        drop(self.second_store.take());
+        fs::remove_file(&self.original).ok();
+        fs::rename(&self.held, &self.original).ok();
+    }
+}

--- a/tools/flight-tune/src/error.rs
+++ b/tools/flight-tune/src/error.rs
@@ -99,6 +99,30 @@ pub enum TuneError {
     JournalLocked {
         /// The journal root.
         path: PathBuf,
+        /// The structured writer-lease conflict.
+        #[source]
+        source: Box<pilotage_durable_storage::StorageError>,
+    },
+    /// The live journal has an unresolved durable publication result.
+    #[error("the live tuning journal is poisoned")]
+    JournalPoisoned,
+    /// The private durable store rejected a journal operation.
+    #[error("durable journal storage failed: {source}")]
+    Storage {
+        /// The structured durable-storage failure.
+        #[source]
+        source: Box<pilotage_durable_storage::StorageError>,
+    },
+    /// Journal authorization and its temporary cleanup both failed.
+    #[error(
+        "journal authorization failed: {authorization}; temporary cleanup also failed: {cleanup}"
+    )]
+    AuthorizationAndCleanupFailed {
+        /// The authorization failure.
+        authorization: Box<TuneError>,
+        /// The durable-storage cleanup failure.
+        #[source]
+        cleanup: Box<pilotage_durable_storage::StorageError>,
     },
     /// A journal belongs to a different tuning session.
     #[error("journal session does not match the requested session")]
@@ -156,4 +180,18 @@ pub enum TuneError {
         #[source]
         source: serde_json::Error,
     },
+}
+
+impl TuneError {
+    pub(crate) fn poisons_journal(&self) -> bool {
+        match self {
+            Self::JournalPoisoned
+            | Self::DigestMismatch { .. }
+            | Self::AuthorizationAndCleanupFailed { .. } => true,
+            Self::Storage { source } | Self::JournalLocked { source, .. } => {
+                source.poisons_authorization()
+            }
+            _ => false,
+        }
+    }
 }

--- a/tools/flight-tune/src/journal.rs
+++ b/tools/flight-tune/src/journal.rs
@@ -9,7 +9,8 @@ pub use event::{
     PromotionDecision,
 };
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 
@@ -56,9 +57,10 @@ pub struct JournalEntry {
 
 /// A content-addressed journal with one locked writer and one atomic head.
 pub struct Journal {
-    root: PathBuf,
+    storage: storage::JournalStorage,
     stage: SearchStage,
-    _writer_lock: storage::WriterLock,
+    writer: storage::WriterLock,
+    poisoned: AtomicBool,
     entries: Vec<JournalEntry>,
     entry_digests: Vec<Digest>,
     state: JournalState,
@@ -77,6 +79,30 @@ impl Journal {
         runtimes: RuntimeIdentities,
         initial_candidate: &Candidate,
     ) -> Result<Self, TuneError> {
+        Self::validate_open_inputs(stage, &runtimes, initial_candidate)?;
+        let opened = storage::open(root.as_ref())?;
+        Self::open_with_storage(opened, stage, fixed_seed, runtimes, initial_candidate)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_or_create_with_faults(
+        root: impl AsRef<Path>,
+        stage: &SearchStage,
+        fixed_seed: u64,
+        runtimes: RuntimeIdentities,
+        initial_candidate: &Candidate,
+        faults: pilotage_durable_storage::FaultController,
+    ) -> Result<Self, TuneError> {
+        Self::validate_open_inputs(stage, &runtimes, initial_candidate)?;
+        let opened = storage::open_with_faults(root.as_ref(), faults)?;
+        Self::open_with_storage(opened, stage, fixed_seed, runtimes, initial_candidate)
+    }
+
+    fn validate_open_inputs(
+        stage: &SearchStage,
+        runtimes: &RuntimeIdentities,
+        initial_candidate: &Candidate,
+    ) -> Result<(), TuneError> {
         stage.validate()?;
         initial_candidate.validate()?;
         stage.validate_challenger(initial_candidate, initial_candidate)?;
@@ -86,9 +112,17 @@ impl Journal {
                 detail: "the harness build identity does not match this build".to_owned(),
             });
         }
-        let root = root.as_ref().to_path_buf();
-        storage::ensure_layout(&root)?;
-        let writer_lock = storage::acquire_writer_lock(&root)?;
+        Ok(())
+    }
+
+    fn open_with_storage(
+        opened: (storage::JournalStorage, storage::WriterLock),
+        stage: &SearchStage,
+        fixed_seed: u64,
+        runtimes: RuntimeIdentities,
+        initial_candidate: &Candidate,
+    ) -> Result<Self, TuneError> {
+        let (storage, writer) = opened;
         let candidate_digest = storage::document_digest("candidate", initial_candidate)?;
         let session = SessionIdentity {
             stage_digest: storage::document_digest("search stage", stage)?,
@@ -97,10 +131,10 @@ impl Journal {
             fixed_seed,
             runtimes,
         };
-        if storage::head_exists(&root)? {
-            return Self::resume(root, stage.clone(), writer_lock, session);
+        if storage::head_exists(&storage)? {
+            return Self::resume(storage, stage.clone(), writer, session);
         }
-        Self::start(root, stage.clone(), writer_lock, session, initial_candidate)
+        Self::start(storage, stage.clone(), writer, session, initial_candidate)
     }
 
     /// Returns the immutable session identity.
@@ -142,11 +176,66 @@ impl Journal {
     ///
     /// Returns [`TuneError`] when the candidate artifact is not valid.
     pub fn training_incumbent(&self) -> Result<Candidate, TuneError> {
+        self.ensure_usable()?;
         self.read_candidate(self.state.training_incumbent)
     }
 
     pub(crate) fn read_candidate(&self, digest: Digest) -> Result<Candidate, TuneError> {
-        storage::read_candidate(&self.root, digest)
+        self.ensure_usable()?;
+        storage::read_candidate(&self.storage, digest).inspect_err(|_| {
+            self.poisoned.store(true, Ordering::Release);
+        })
+    }
+
+    pub(crate) fn ensure_usable(&self) -> Result<(), TuneError> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(TuneError::JournalPoisoned);
+        }
+        storage::verify_live_snapshot(
+            &self.storage,
+            &self.writer,
+            &self.stage,
+            &self.entries,
+            &self.entry_digests,
+        )
+        .inspect_err(|_| {
+            self.poisoned.store(true, Ordering::Release);
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ensure_usable_with_final_hook_for_test(
+        &self,
+        before_final_writer_validation: impl FnOnce(),
+    ) -> Result<(), TuneError> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(TuneError::JournalPoisoned);
+        }
+        storage::verify_live_snapshot_with_final_hook_for_test(
+            &self.storage,
+            &self.writer,
+            &self.stage,
+            &self.entries,
+            &self.entry_digests,
+            before_final_writer_validation,
+        )
+        .inspect_err(|_| {
+            self.poisoned.store(true, Ordering::Release);
+        })
+    }
+
+    fn record_storage_result<T>(&self, result: Result<T, TuneError>) -> Result<T, TuneError> {
+        result.inspect_err(|error| {
+            if error.poisons_journal() {
+                self.poisoned.store(true, Ordering::Release);
+            }
+        })
+    }
+
+    fn record_append_result<T>(&self, result: Result<T, TuneError>) -> Result<T, TuneError> {
+        result.inspect_err(|_| {
+            self.poisoned.store(true, Ordering::Release);
+        })
     }
 
     pub(crate) fn state(&self) -> &JournalState {
@@ -163,16 +252,54 @@ impl Journal {
         candidate: &Candidate,
         plan_digest: Digest,
     ) -> Result<(u64, Digest), TuneError> {
+        self.prepare_attempt_with_hook(role, candidate, plan_digest, || {})
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_attempt_with_before_authorization_for_test(
+        &mut self,
+        role: AttemptRole,
+        candidate: &Candidate,
+        plan_digest: Digest,
+        before_authorization: impl FnOnce(),
+    ) -> Result<(u64, Digest), TuneError> {
+        self.prepare_attempt_with_hook(role, candidate, plan_digest, before_authorization)
+    }
+
+    fn prepare_attempt_with_hook(
+        &mut self,
+        role: AttemptRole,
+        candidate: &Candidate,
+        plan_digest: Digest,
+        before_authorization: impl FnOnce(),
+    ) -> Result<(u64, Digest), TuneError> {
+        self.ensure_usable()?;
         candidate.validate()?;
-        let candidate_digest = storage::store_candidate(&self.root, candidate)?;
+        let candidate_digest = self.record_storage_result(storage::store_candidate(
+            &self.storage,
+            &self.writer,
+            candidate,
+        ))?;
         let trial_id = self.state.next_trial_id;
-        self.append(JournalEvent::AttemptPrepared {
-            trial_id,
-            role,
-            candidate: candidate_digest,
-            plan_digest,
-        })?;
+        self.append_with_hook(
+            JournalEvent::AttemptPrepared {
+                trial_id,
+                role,
+                candidate: candidate_digest,
+                plan_digest,
+            },
+            before_authorization,
+        )?;
         Ok((trial_id, candidate_digest))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn append_event_with_before_authorization_for_test(
+        &mut self,
+        event: JournalEvent,
+        before_authorization: impl FnOnce(),
+    ) -> Result<(), TuneError> {
+        self.append_with_hook(event, before_authorization)
     }
 
     pub(crate) fn complete_attempt(
@@ -181,6 +308,7 @@ impl Journal {
         evaluation: CandidateEvaluation,
         selected: Option<bool>,
     ) -> Result<(), TuneError> {
+        self.ensure_usable()?;
         let role = self.state.pending_role(trial_id)?;
         evaluation.validate(role.scenario_set())?;
         self.append(JournalEvent::AttemptCompleted {
@@ -195,6 +323,7 @@ impl Journal {
         trial_id: u64,
         reason: impl Into<String>,
     ) -> Result<(), TuneError> {
+        self.ensure_usable()?;
         self.append(JournalEvent::AttemptQuarantined {
             trial_id,
             reason: reason.into(),
@@ -207,6 +336,7 @@ impl Journal {
         stop: OperationStatus,
         cleanup: OperationStatus,
     ) -> Result<(), TuneError> {
+        self.ensure_usable()?;
         self.append(JournalEvent::CleanupRecorded {
             trial_id,
             stop,
@@ -215,6 +345,7 @@ impl Journal {
     }
 
     pub(crate) fn freeze(&mut self) -> Result<Digest, TuneError> {
+        self.ensure_usable()?;
         let candidate = self.state.training_incumbent;
         self.append(JournalEvent::Frozen {
             baseline: self.session().initial_candidate_digest,
@@ -236,17 +367,17 @@ impl Journal {
     }
 
     fn start(
-        root: PathBuf,
+        storage: storage::JournalStorage,
         stage: SearchStage,
-        writer_lock: storage::WriterLock,
+        writer: storage::WriterLock,
         session: SessionIdentity,
         initial_candidate: &Candidate,
     ) -> Result<Self, TuneError> {
-        let stored = storage::store_stage(&root, &stage)?;
+        let stored = storage::store_stage(&storage, &writer, &stage)?;
         if stored != session.stage_digest {
             return Err(TuneError::DigestMismatch { expected: stored });
         }
-        let candidate = storage::store_candidate(&root, initial_candidate)?;
+        let candidate = storage::store_candidate(&storage, &writer, initial_candidate)?;
         let entry = JournalEntry {
             schema_version: JOURNAL_SCHEMA_VERSION,
             sequence: 0,
@@ -254,14 +385,19 @@ impl Journal {
             session,
             event: JournalEvent::Started { candidate },
         };
-        let digest = storage::append_entry(&root, &entry)?;
+        let digest = storage::document_digest("journal entry", &entry)?;
         let entries = vec![entry];
         let entry_digests = vec![digest];
         let state = replay(&entries, &entry_digests, &stage)?;
+        let published = storage::append_entry(&storage, &writer, &stage, &entries, &entry_digests)?;
+        if published != digest {
+            return Err(TuneError::DigestMismatch { expected: digest });
+        }
         Ok(Self {
-            root,
+            storage,
             stage,
-            _writer_lock: writer_lock,
+            writer,
+            poisoned: AtomicBool::new(false),
             entries,
             entry_digests,
             state,
@@ -269,32 +405,42 @@ impl Journal {
     }
 
     fn resume(
-        root: PathBuf,
+        storage: storage::JournalStorage,
         stage: SearchStage,
-        writer_lock: storage::WriterLock,
+        writer: storage::WriterLock,
         session: SessionIdentity,
     ) -> Result<Self, TuneError> {
-        let stored_entries = storage::load_entries(&root)?;
+        let stored_entries = storage::load_entries(&storage)?;
         let (entry_digests, entries): (Vec<_>, Vec<_>) = stored_entries.into_iter().unzip();
         if entries.first().map(|entry| &entry.session) != Some(&session)
-            || storage::read_stage(&root, session.stage_digest)? != stage
+            || storage::read_stage(&storage, session.stage_digest)? != stage
         {
             return Err(TuneError::JournalSessionMismatch);
         }
         let state = replay(&entries, &entry_digests, &stage)?;
         let journal = Self {
-            root,
+            storage,
             stage,
-            _writer_lock: writer_lock,
+            writer,
+            poisoned: AtomicBool::new(false),
             entries,
             entry_digests,
             state,
         };
-        journal.verify_candidates()?;
+        journal.ensure_usable()?;
         Ok(journal)
     }
 
     fn append(&mut self, event: JournalEvent) -> Result<(), TuneError> {
+        self.append_with_hook(event, || {})
+    }
+
+    fn append_with_hook(
+        &mut self,
+        event: JournalEvent,
+        before_authorization: impl FnOnce(),
+    ) -> Result<(), TuneError> {
+        self.ensure_usable()?;
         let previous = self
             .entries
             .last()
@@ -312,7 +458,15 @@ impl Journal {
         let mut digests = self.entry_digests.clone();
         digests.push(entry_digest);
         let state = replay(&entries, &digests, &self.stage)?;
-        if storage::append_entry(&self.root, &entry)? != entry_digest {
+        let published = storage::append_entry_with_hook(
+            &self.storage,
+            &self.writer,
+            &self.stage,
+            &entries,
+            &digests,
+            before_authorization,
+        );
+        if self.record_append_result(published)? != entry_digest {
             return Err(TuneError::DigestMismatch {
                 expected: entry_digest,
             });
@@ -320,17 +474,6 @@ impl Journal {
         self.entries = entries;
         self.entry_digests = digests;
         self.state = state;
-        Ok(())
-    }
-
-    fn verify_candidates(&self) -> Result<(), TuneError> {
-        let initial = self.read_candidate(self.session().initial_candidate_digest)?;
-        for entry in &self.entries {
-            if let JournalEvent::AttemptPrepared { candidate, .. } = entry.event {
-                let stored = self.read_candidate(candidate)?;
-                self.stage.validate_challenger(&initial, &stored)?;
-            }
-        }
         Ok(())
     }
 }

--- a/tools/flight-tune/src/journal/storage.rs
+++ b/tools/flight-tune/src/journal/storage.rs
@@ -1,12 +1,18 @@
 use std::collections::HashSet;
-use std::fs::{self, File, OpenOptions, TryLockError};
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
+use pilotage_durable_storage::{
+    ContentDigest, DurableDirectory, DurableStore, ExactObject, ExpectedValue, ObjectName,
+    PutOutcome, StorageError, WriterLease,
+};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::identity::digest_bytes;
+mod append;
+mod layout;
+
+pub(super) use append::append_entry;
+pub(super) use append::append_entry_with_hook;
+
 use crate::journal::JournalEntry;
 use crate::{Candidate, Digest, SearchStage, TuneError};
 
@@ -14,9 +20,8 @@ use crate::{Candidate, Digest, SearchStage, TuneError};
 #[path = "storage/tests.rs"]
 mod tests;
 
-const MAX_DOCUMENT_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_DOCUMENT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_CHAIN_ENTRIES: usize = 100_000;
-const TEMPORARY_ATTEMPTS: u32 = 1_024;
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -24,92 +29,269 @@ struct HeadPointer {
     digest: Digest,
 }
 
-pub(super) struct WriterLock {
-    _file: File,
+pub(super) struct JournalStorage {
+    _store: DurableStore,
+    root: DurableDirectory,
+    marker: DurableDirectory,
+    candidates: DurableDirectory,
+    stages: DurableDirectory,
+    entries: DurableDirectory,
 }
 
-pub(super) fn ensure_layout(root: &Path) -> Result<(), TuneError> {
-    create_directory(root)?;
-    create_directory(&candidate_directory(root))?;
-    create_directory(&stage_directory(root))?;
-    create_directory(&entry_directory(root))
+pub(super) type WriterLock = WriterLease;
+
+pub(super) fn open(root: &Path) -> Result<(JournalStorage, WriterLock), TuneError> {
+    let store = DurableStore::open_or_create(root).map_err(storage_error)?;
+    finish_open(root, store)
 }
 
-pub(super) fn acquire_writer_lock(root: &Path) -> Result<WriterLock, TuneError> {
-    let path = root.join("WRITER.lock");
-    let file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&path)
-        .map_err(|source| io_error("open writer lock", &path, source))?;
-    match file.try_lock() {
-        Ok(()) => Ok(WriterLock { _file: file }),
-        Err(TryLockError::WouldBlock) => Err(TuneError::JournalLocked {
-            path: root.to_path_buf(),
-        }),
-        Err(TryLockError::Error(source)) => Err(io_error("lock journal writer", &path, source)),
+#[cfg(test)]
+pub(super) fn open_with_faults(
+    root: &Path,
+    faults: pilotage_durable_storage::FaultController,
+) -> Result<(JournalStorage, WriterLock), TuneError> {
+    let store = DurableStore::open_or_create_with_faults(root, faults).map_err(storage_error)?;
+    finish_open(root, store)
+}
+
+fn finish_open(
+    root_path: &Path,
+    store: DurableStore,
+) -> Result<(JournalStorage, WriterLock), TuneError> {
+    let opened = layout::open(root_path, &store)?;
+    Ok((
+        JournalStorage {
+            _store: store,
+            root: opened.root,
+            marker: opened.marker,
+            candidates: opened.candidates,
+            stages: opened.stages,
+            entries: opened.entries,
+        },
+        opened.writer,
+    ))
+}
+
+pub(super) fn head_exists(storage: &JournalStorage) -> Result<bool, TuneError> {
+    storage
+        .root
+        .exists(&object_name("HEAD.json")?)
+        .map_err(storage_error)
+}
+
+pub(super) fn verify_head_exact(
+    storage: &JournalStorage,
+    expected: Digest,
+) -> Result<(), TuneError> {
+    let name = object_name("HEAD.json")?;
+    let expected_head = exact_head(expected)?;
+    let actual = storage
+        .root
+        .read_digest(&name, expected_head.digest(), MAX_DOCUMENT_BYTES)
+        .map_err(storage_error)?;
+    if actual != expected_head {
+        return Err(invalid_journal(
+            "the journal head does not match the live authorization",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn verify_live_snapshot(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+) -> Result<(), TuneError> {
+    verify_live_snapshot_with_hook(storage, writer, stage, entries, entry_digests, || {})
+}
+
+#[cfg(test)]
+pub(super) fn verify_live_snapshot_with_final_hook_for_test(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+    before_final_writer_validation: impl FnOnce(),
+) -> Result<(), TuneError> {
+    verify_live_snapshot_with_hook(
+        storage,
+        writer,
+        stage,
+        entries,
+        entry_digests,
+        before_final_writer_validation,
+    )
+}
+
+fn verify_live_snapshot_with_hook(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+    before_final_writer_validation: impl FnOnce(),
+) -> Result<(), TuneError> {
+    layout::verify_authorized(&storage.root)?;
+    layout::verify_handles(
+        &storage.marker,
+        &storage.candidates,
+        &storage.stages,
+        &storage.entries,
+    )?;
+    writer.validate(&storage.root).map_err(storage_error)?;
+    let expected_head = entry_digests
+        .last()
+        .copied()
+        .ok_or_else(|| invalid_journal("the live journal has no head"))?;
+    verify_head_exact(storage, expected_head)?;
+    verify_entry_chain(storage, entries, entry_digests)?;
+    verify_stage_and_candidates(storage, stage, entries)?;
+    verify_head_exact(storage, expected_head)?;
+    layout::verify_authorized(&storage.root)?;
+    layout::verify_handles(
+        &storage.marker,
+        &storage.candidates,
+        &storage.stages,
+        &storage.entries,
+    )?;
+    before_final_writer_validation();
+    writer.validate(&storage.root).map_err(storage_error)
+}
+
+fn verify_entry_chain(
+    storage: &JournalStorage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+) -> Result<(), TuneError> {
+    let stored = load_entries(storage)?;
+    let matches = entries.len() == entry_digests.len()
+        && stored.len() == entries.len()
+        && stored.iter().zip(entry_digests.iter().zip(entries)).all(
+            |((stored_digest, stored_entry), (live_digest, live_entry))| {
+                stored_digest == live_digest && stored_entry == live_entry
+            },
+        );
+    if matches {
+        Ok(())
+    } else {
+        Err(invalid_journal(
+            "the durable journal chain does not match the live journal",
+        ))
     }
 }
 
-pub(super) fn head_exists(root: &Path) -> Result<bool, TuneError> {
-    let path = head_path(root);
-    path.try_exists()
-        .map_err(|source| io_error("inspect journal head", &path, source))
+fn verify_stage_and_candidates(
+    storage: &JournalStorage,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+) -> Result<(), TuneError> {
+    let session = entries
+        .first()
+        .map(|entry| &entry.session)
+        .ok_or_else(|| invalid_journal("the live journal has no session"))?;
+    if read_stage(storage, session.stage_digest)? != *stage {
+        return Err(invalid_journal(
+            "the durable search stage does not match the live stage",
+        ));
+    }
+    let initial = read_candidate(storage, session.initial_candidate_digest)?;
+    for candidate in candidate_digests_to_verify(session.initial_candidate_digest, entries) {
+        let stored = read_candidate(storage, candidate)?;
+        stage.validate_challenger(&initial, &stored)?;
+    }
+    Ok(())
+}
+
+fn candidate_digests_to_verify(initial: Digest, entries: &[JournalEntry]) -> Vec<Digest> {
+    let mut seen = HashSet::from([initial]);
+    entries
+        .iter()
+        .filter_map(|entry| match entry.event {
+            crate::JournalEvent::AttemptPrepared { candidate, .. } => Some(candidate),
+            _ => None,
+        })
+        .filter(|candidate| seen.insert(*candidate))
+        .collect()
 }
 
 pub(super) fn document_digest<T: Serialize>(
     document: &'static str,
     value: &T,
 ) -> Result<Digest, TuneError> {
-    let bytes = encode(document, value)?;
-    Ok(digest_bytes(&bytes))
+    Ok(exact_document(document, value)?.0)
 }
 
-pub(super) fn store_candidate(root: &Path, candidate: &Candidate) -> Result<Digest, TuneError> {
-    let bytes = encode("candidate", candidate)?;
-    let digest = digest_bytes(&bytes);
-    write_immutable(&candidate_path(root, digest), &bytes, digest)?;
+pub(super) fn store_candidate(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    candidate: &Candidate,
+) -> Result<Digest, TuneError> {
+    let (digest, object) = exact_document("candidate", candidate)?;
+    write_immutable(
+        &storage.candidates,
+        writer,
+        &object_name(format!("{digest}.json"))?,
+        &object,
+        digest,
+    )?;
     Ok(digest)
 }
 
-pub(super) fn read_candidate(root: &Path, digest: Digest) -> Result<Candidate, TuneError> {
-    let path = candidate_path(root, digest);
-    let bytes = read_verified(&path, digest)?;
-    let candidate: Candidate = decode("candidate", &path, &bytes)?;
+pub(super) fn read_candidate(
+    storage: &JournalStorage,
+    digest: Digest,
+) -> Result<Candidate, TuneError> {
+    let name = object_name(format!("{digest}.json"))?;
+    let bytes = read_verified(&storage.candidates, &name, digest)?;
+    let candidate: Candidate = decode("candidate", &name, &bytes)?;
     candidate.validate()?;
     Ok(candidate)
 }
 
-pub(super) fn store_stage(root: &Path, stage: &SearchStage) -> Result<Digest, TuneError> {
-    let bytes = encode("search stage", stage)?;
-    let digest = digest_bytes(&bytes);
-    write_immutable(&stage_path(root, digest), &bytes, digest)?;
+pub(super) fn store_stage(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+) -> Result<Digest, TuneError> {
+    let (digest, object) = exact_document("search stage", stage)?;
+    write_immutable(
+        &storage.stages,
+        writer,
+        &object_name(format!("{digest}.json"))?,
+        &object,
+        digest,
+    )?;
     Ok(digest)
 }
 
-pub(super) fn read_stage(root: &Path, digest: Digest) -> Result<SearchStage, TuneError> {
-    let path = stage_path(root, digest);
-    let bytes = read_verified(&path, digest)?;
-    let stage: SearchStage = decode("search stage", &path, &bytes)?;
+pub(super) fn read_stage(
+    storage: &JournalStorage,
+    digest: Digest,
+) -> Result<SearchStage, TuneError> {
+    let name = object_name(format!("{digest}.json"))?;
+    let bytes = read_verified(&storage.stages, &name, digest)?;
+    let stage: SearchStage = decode("search stage", &name, &bytes)?;
     stage.validate()?;
     Ok(stage)
 }
 
-pub(super) fn append_entry(root: &Path, entry: &JournalEntry) -> Result<Digest, TuneError> {
-    let bytes = encode("journal entry", entry)?;
-    let digest = digest_bytes(&bytes);
-    write_immutable(&entry_path(root, digest), &bytes, digest)?;
-    let head = encode("journal head", &HeadPointer { digest })?;
-    atomic_replace(&head_path(root), &head)?;
-    Ok(digest)
-}
-
-pub(super) fn load_entries(root: &Path) -> Result<Vec<(Digest, JournalEntry)>, TuneError> {
-    let head_file = head_path(root);
-    let head_bytes = read_limited(&head_file)?;
-    let head: HeadPointer = decode("journal head", &head_file, &head_bytes)?;
+pub(super) fn load_entries(
+    storage: &JournalStorage,
+) -> Result<Vec<(Digest, JournalEntry)>, TuneError> {
+    let head_name = object_name("HEAD.json")?;
+    let head_object = storage
+        .root
+        .read_exact(&head_name, MAX_DOCUMENT_BYTES)
+        .map_err(storage_error)?;
+    let head: HeadPointer = decode("journal head", &head_name, head_object.bytes())?;
+    if head_object.bytes() != exact_head(head.digest)?.bytes() {
+        return Err(invalid_journal(
+            "the journal head does not use canonical bytes",
+        ));
+    }
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
     let mut next = Some(head.digest);
@@ -119,9 +301,9 @@ pub(super) fn load_entries(root: &Path) -> Result<Vec<(Digest, JournalEntry)>, T
                 "the journal chain is too long or has a cycle",
             ));
         }
-        let path = entry_path(root, digest);
-        let bytes = read_verified(&path, digest)?;
-        let entry: JournalEntry = decode("journal entry", &path, &bytes)?;
+        let name = object_name(format!("{digest}.json"))?;
+        let bytes = read_verified(&storage.entries, &name, digest)?;
+        let entry: JournalEntry = decode("journal entry", &name, &bytes)?;
         next = entry.previous;
         entries.push((digest, entry));
     }
@@ -129,87 +311,58 @@ pub(super) fn load_entries(root: &Path) -> Result<Vec<(Digest, JournalEntry)>, T
     Ok(entries)
 }
 
-fn create_directory(path: &Path) -> Result<(), TuneError> {
-    fs::create_dir_all(path).map_err(|source| io_error("create directory", path, source))
+fn expected_head(previous: Option<Digest>) -> Result<ExpectedValue, TuneError> {
+    previous
+        .map(exact_head)
+        .transpose()
+        .map(|head| head.map_or(ExpectedValue::Absent, ExpectedValue::Exact))
 }
 
-fn write_immutable(path: &Path, bytes: &[u8], digest: Digest) -> Result<(), TuneError> {
-    if path
-        .try_exists()
-        .map_err(|source| io_error("inspect immutable object", path, source))?
-    {
-        let existing = read_limited(path)?;
-        if existing == bytes {
-            return Ok(());
-        }
+fn exact_head(digest: Digest) -> Result<ExactObject, TuneError> {
+    let bytes = encode("journal head", &HeadPointer { digest })?;
+    Ok(ExactObject::from_bytes(bytes))
+}
+
+fn exact_document<T: Serialize>(
+    document: &'static str,
+    value: &T,
+) -> Result<(Digest, ExactObject), TuneError> {
+    let object = ExactObject::from_bytes(encode(document, value)?);
+    let digest = digest_from_storage(object.digest());
+    Ok((digest, object))
+}
+
+fn write_immutable(
+    directory: &DurableDirectory,
+    writer: &WriterLock,
+    name: &ObjectName,
+    object: &ExactObject,
+    digest: Digest,
+) -> Result<(), TuneError> {
+    if digest_from_storage(object.digest()) != digest {
         return Err(TuneError::DigestMismatch { expected: digest });
     }
-    atomic_replace(path, bytes)
-}
-
-fn atomic_replace(path: &Path, bytes: &[u8]) -> Result<(), TuneError> {
-    check_size(path.display().to_string(), bytes.len())?;
-    let (mut file, temporary) = create_unique_temporary(path)?;
-    file.write_all(bytes)
-        .map_err(|source| io_error("write temporary file", &temporary, source))?;
-    file.sync_all()
-        .map_err(|source| io_error("synchronize temporary file", &temporary, source))?;
-    fs::rename(&temporary, path).map_err(|source| io_error("replace file", path, source))?;
-    synchronize_parent(path)
-}
-
-fn create_unique_temporary(path: &Path) -> Result<(File, PathBuf), TuneError> {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|source| TuneError::InvalidJournal {
-            detail: format!("system time is before the Unix epoch: {source}"),
-        })?
-        .as_nanos();
-    let mut attempt = 0_u32;
-    while attempt < TEMPORARY_ATTEMPTS {
-        let temporary = temporary_path(path, timestamp, attempt);
-        match OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&temporary)
-        {
-            Ok(file) => return Ok((file, temporary)),
-            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
-                attempt = attempt.wrapping_add(1);
-            }
-            Err(source) => return Err(io_error("create temporary file", &temporary, source)),
-        }
+    let outcome = directory
+        .put_immutable_no_replace(writer, name, object)
+        .map_err(storage_error)?;
+    match outcome {
+        PutOutcome::Published | PutOutcome::AlreadyExact => Ok(()),
     }
-    Err(invalid_journal("cannot allocate a unique temporary file"))
 }
 
-fn synchronize_parent(path: &Path) -> Result<(), TuneError> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| invalid_journal("an atomic file has no parent directory"))?;
-    let directory =
-        File::open(parent).map_err(|source| io_error("open parent directory", parent, source))?;
-    directory
-        .sync_all()
-        .map_err(|source| io_error("synchronize parent directory", parent, source))
-}
-
-fn read_verified(path: &Path, expected: Digest) -> Result<Vec<u8>, TuneError> {
-    let bytes = read_limited(path)?;
-    if digest_bytes(&bytes) != expected {
+fn read_verified(
+    directory: &DurableDirectory,
+    name: &ObjectName,
+    expected: Digest,
+) -> Result<Vec<u8>, TuneError> {
+    let expected_storage = ContentDigest(*expected.as_bytes());
+    let object = directory
+        .read_digest(name, expected_storage, MAX_DOCUMENT_BYTES)
+        .map_err(storage_error)?;
+    if digest_from_storage(object.digest()) != expected {
         return Err(TuneError::DigestMismatch { expected });
     }
-    Ok(bytes)
-}
-
-fn read_limited(path: &Path) -> Result<Vec<u8>, TuneError> {
-    let metadata = fs::metadata(path).map_err(|source| io_error("inspect file", path, source))?;
-    check_size(path.display().to_string(), metadata.len() as usize)?;
-    let mut file = File::open(path).map_err(|source| io_error("open file", path, source))?;
-    let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.read_to_end(&mut bytes)
-        .map_err(|source| io_error("read file", path, source))?;
-    Ok(bytes)
+    Ok(object.bytes().to_vec())
 }
 
 fn encode<T: Serialize>(document: &'static str, value: &T) -> Result<Vec<u8>, TuneError> {
@@ -221,72 +374,49 @@ fn encode<T: Serialize>(document: &'static str, value: &T) -> Result<Vec<u8>, Tu
 
 fn decode<T: DeserializeOwned>(
     document: &'static str,
-    path: &Path,
+    name: &ObjectName,
     bytes: &[u8],
 ) -> Result<T, TuneError> {
     serde_json::from_slice(bytes).map_err(|source| TuneError::Decode {
         document,
-        path: path.to_path_buf(),
+        path: PathBuf::from(name.as_os_str()),
         source,
     })
 }
 
 fn check_size(document: String, size: usize) -> Result<(), TuneError> {
-    let size = u64::try_from(size).unwrap_or(u64::MAX);
     if size > MAX_DOCUMENT_BYTES {
         return Err(TuneError::DocumentTooLarge {
             document,
-            size,
-            limit: MAX_DOCUMENT_BYTES,
+            size: u64::try_from(size).unwrap_or(u64::MAX),
+            limit: u64::try_from(MAX_DOCUMENT_BYTES).unwrap_or(u64::MAX),
         });
     }
     Ok(())
 }
 
-fn candidate_directory(root: &Path) -> PathBuf {
-    root.join("candidates")
+fn object_name(name: impl AsRef<std::ffi::OsStr>) -> Result<ObjectName, TuneError> {
+    ObjectName::new(name).map_err(storage_error)
 }
 
-fn entry_directory(root: &Path) -> PathBuf {
-    root.join("entries")
+fn digest_from_storage(digest: ContentDigest) -> Digest {
+    Digest::from_bytes(digest.0)
 }
 
-fn stage_directory(root: &Path) -> PathBuf {
-    root.join("stages")
+fn writer_error(path: &Path, source: StorageError) -> TuneError {
+    if source.is_writer_locked() {
+        TuneError::JournalLocked {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        }
+    } else {
+        storage_error(source)
+    }
 }
 
-fn candidate_path(root: &Path, digest: Digest) -> PathBuf {
-    candidate_directory(root).join(format!("{digest}.json"))
-}
-
-fn entry_path(root: &Path, digest: Digest) -> PathBuf {
-    entry_directory(root).join(format!("{digest}.json"))
-}
-
-fn stage_path(root: &Path, digest: Digest) -> PathBuf {
-    stage_directory(root).join(format!("{digest}.json"))
-}
-
-fn head_path(root: &Path) -> PathBuf {
-    root.join("HEAD.json")
-}
-
-fn temporary_path(path: &Path, timestamp: u128, attempt: u32) -> PathBuf {
-    let mut name = path.as_os_str().to_owned();
-    name.push(format!(
-        ".next.{}.{}.{}",
-        std::process::id(),
-        timestamp,
-        attempt
-    ));
-    PathBuf::from(name)
-}
-
-fn io_error(operation: &'static str, path: &Path, source: std::io::Error) -> TuneError {
-    TuneError::Io {
-        operation,
-        path: path.to_path_buf(),
-        source,
+fn storage_error(source: StorageError) -> TuneError {
+    TuneError::Storage {
+        source: Box::new(source),
     }
 }
 

--- a/tools/flight-tune/src/journal/storage/append.rs
+++ b/tools/flight-tune/src/journal/storage/append.rs
@@ -1,0 +1,267 @@
+use pilotage_durable_storage::{CasOutcome, CompareExchangeError};
+
+use super::{
+    JournalStorage, WriterLock, decode, document_digest, exact_document, exact_head, expected_head,
+    head_exists, invalid_journal, layout, object_name, read_candidate, read_stage, read_verified,
+    storage_error, verify_head_exact, verify_live_snapshot, verify_stage_and_candidates,
+    write_immutable,
+};
+use crate::journal::{JournalEntry, JournalEvent};
+use crate::{Candidate, Digest, SearchStage, TuneError};
+
+pub(in crate::journal) fn append_entry(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+) -> Result<Digest, TuneError> {
+    append_entry_with_hook(storage, writer, stage, entries, entry_digests, || {})
+}
+
+pub(in crate::journal) fn append_entry_with_hook(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+    before_authorization: impl FnOnce(),
+) -> Result<Digest, TuneError> {
+    append_entry_inner(
+        storage,
+        writer,
+        stage,
+        entries,
+        entry_digests,
+        before_authorization,
+    )
+}
+
+fn append_entry_inner(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+    before_authorization: impl FnOnce(),
+) -> Result<Digest, TuneError> {
+    let ProspectiveParts {
+        entry,
+        expected_digest,
+        current_entries,
+        current_digests,
+    } = prospective_parts(entries, entry_digests)?;
+    verify_prospective_snapshot(
+        storage,
+        writer,
+        stage,
+        entries,
+        current_entries,
+        current_digests,
+        false,
+    )?;
+    let (digest, object) = exact_document("journal entry", entry)?;
+    if digest != expected_digest {
+        return Err(TuneError::DigestMismatch {
+            expected: expected_digest,
+        });
+    }
+    let entry_name = object_name(format!("{digest}.json"))?;
+    write_immutable(&storage.entries, writer, &entry_name, &object, digest)?;
+    verify_prospective_snapshot(
+        storage,
+        writer,
+        stage,
+        entries,
+        current_entries,
+        current_digests,
+        true,
+    )?;
+
+    let expected = expected_head(entry.previous)?;
+    let new_head = exact_head(digest)?;
+    let outcome = writer
+        .compare_exchange_file_guarded(
+            &storage.root,
+            &object_name("HEAD.json")?,
+            expected,
+            new_head,
+            || {
+                before_authorization();
+                verify_prospective_snapshot(
+                    storage,
+                    writer,
+                    stage,
+                    entries,
+                    current_entries,
+                    current_digests,
+                    true,
+                )
+            },
+        )
+        .map_err(map_guarded_error)?;
+    match outcome {
+        CasOutcome::Exchanged | CasOutcome::AlreadyExact => Ok(digest),
+    }
+}
+
+fn map_guarded_error(error: CompareExchangeError<TuneError>) -> TuneError {
+    match error {
+        CompareExchangeError::Storage { source } => storage_error(source),
+        CompareExchangeError::Validation { source } => source,
+        CompareExchangeError::ValidationAndCleanup {
+            validation,
+            cleanup,
+        } => TuneError::AuthorizationAndCleanupFailed {
+            authorization: Box::new(validation),
+            cleanup: Box::new(cleanup),
+        },
+    }
+}
+
+struct ProspectiveParts<'a> {
+    entry: &'a JournalEntry,
+    expected_digest: Digest,
+    current_entries: &'a [JournalEntry],
+    current_digests: &'a [Digest],
+}
+
+fn prospective_parts<'a>(
+    entries: &'a [JournalEntry],
+    entry_digests: &'a [Digest],
+) -> Result<ProspectiveParts<'a>, TuneError> {
+    let (entry, current_entries) = entries
+        .split_last()
+        .ok_or_else(|| invalid_journal("the prospective journal has no entry"))?;
+    let (digest, current_digests) = entry_digests
+        .split_last()
+        .ok_or_else(|| invalid_journal("the prospective journal has no digest"))?;
+    if current_entries.len() != current_digests.len() {
+        return Err(invalid_journal(
+            "the prospective journal digest count does not match",
+        ));
+    }
+    Ok(ProspectiveParts {
+        entry,
+        expected_digest: *digest,
+        current_entries,
+        current_digests,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_prospective_snapshot(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    current_entries: &[JournalEntry],
+    current_digests: &[Digest],
+    entry_must_exist: bool,
+) -> Result<(), TuneError> {
+    if current_entries.is_empty() {
+        verify_initial_snapshot(storage, writer)?;
+    } else {
+        verify_live_snapshot(storage, writer, stage, current_entries, current_digests)?;
+    }
+    verify_stage_and_candidates(storage, stage, entries)?;
+    let entry = entries
+        .last()
+        .ok_or_else(|| invalid_journal("the prospective journal has no entry"))?;
+    verify_prospective_entry_references(storage, entry)?;
+    if entry_must_exist {
+        verify_prospective_entry_object(storage, entry)?;
+    }
+    verify_current_authorization_tail(storage, writer, current_digests)
+}
+
+fn verify_initial_snapshot(storage: &JournalStorage, writer: &WriterLock) -> Result<(), TuneError> {
+    layout::verify_initial_authorization(&storage.root)?;
+    layout::verify_handles(
+        &storage.marker,
+        &storage.candidates,
+        &storage.stages,
+        &storage.entries,
+    )?;
+    if head_exists(storage)? {
+        return Err(invalid_journal("the initial journal already has a head"));
+    }
+    writer.validate(&storage.root).map_err(storage_error)
+}
+
+fn verify_prospective_entry_object(
+    storage: &JournalStorage,
+    entry: &JournalEntry,
+) -> Result<(), TuneError> {
+    let expected = document_digest("journal entry", entry)?;
+    let name = object_name(format!("{expected}.json"))?;
+    let bytes = read_verified(&storage.entries, &name, expected)?;
+    let stored: JournalEntry = decode("journal entry", &name, &bytes)?;
+    if stored == *entry {
+        Ok(())
+    } else {
+        Err(invalid_journal(
+            "the prospective journal entry bytes do not match",
+        ))
+    }
+}
+
+fn verify_current_authorization_tail(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    current_digests: &[Digest],
+) -> Result<(), TuneError> {
+    if let Some(digest) = current_digests.last().copied() {
+        verify_head_exact(storage, digest)?;
+        layout::verify_authorized(&storage.root)?;
+    } else {
+        if head_exists(storage)? {
+            return Err(invalid_journal("the initial journal already has a head"));
+        }
+        layout::verify_initial_authorization(&storage.root)?;
+    }
+    layout::verify_handles(
+        &storage.marker,
+        &storage.candidates,
+        &storage.stages,
+        &storage.entries,
+    )?;
+    writer.validate(&storage.root).map_err(storage_error)
+}
+
+fn verify_prospective_entry_references(
+    storage: &JournalStorage,
+    entry: &JournalEntry,
+) -> Result<(), TuneError> {
+    let stage = read_stage(storage, entry.session.stage_digest)?;
+    let initial = read_candidate(storage, entry.session.initial_candidate_digest)?;
+    stage.validate_challenger(&initial, &initial)?;
+    match &entry.event {
+        JournalEvent::Started { candidate }
+        | JournalEvent::AttemptPrepared { candidate, .. }
+        | JournalEvent::Sealed { candidate, .. } => {
+            verify_candidate_reference(storage, &stage, &initial, *candidate)
+        }
+        JournalEvent::Frozen {
+            baseline,
+            candidate,
+        } => {
+            verify_candidate_reference(storage, &stage, &initial, *baseline)?;
+            verify_candidate_reference(storage, &stage, &initial, *candidate)
+        }
+        JournalEvent::AttemptCompleted { .. }
+        | JournalEvent::AttemptQuarantined { .. }
+        | JournalEvent::CleanupRecorded { .. }
+        | JournalEvent::PromotionClosed { .. } => Ok(()),
+    }
+}
+
+fn verify_candidate_reference(
+    storage: &JournalStorage,
+    stage: &SearchStage,
+    initial: &Candidate,
+    digest: Digest,
+) -> Result<(), TuneError> {
+    let candidate = read_candidate(storage, digest)?;
+    stage.validate_challenger(initial, &candidate)
+}

--- a/tools/flight-tune/src/journal/storage/layout.rs
+++ b/tools/flight-tune/src/journal/storage/layout.rs
@@ -1,0 +1,337 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
+use pilotage_durable_storage::{
+    DurableDirectory, DurableStore, ExactObject, ObjectInspection, ObjectKind, ObjectName,
+    WriterLease,
+};
+
+use super::{
+    HeadPointer, MAX_DOCUMENT_BYTES, decode, exact_head, invalid_journal, object_name,
+    storage_error, writer_error,
+};
+use crate::TuneError;
+
+pub(super) const LAYOUT_MARKER: &str = ".flight-tune-journal-v2";
+const WRITER_LOCK: &str = ".pilotage-writer-lock";
+const HEAD: &str = "HEAD.json";
+const DIRECTORIES: [&str; 3] = ["candidates", "stages", "entries"];
+
+pub(super) struct OpenedLayout {
+    pub(super) root: DurableDirectory,
+    pub(super) marker: DurableDirectory,
+    pub(super) candidates: DurableDirectory,
+    pub(super) stages: DurableDirectory,
+    pub(super) entries: DurableDirectory,
+    pub(super) writer: WriterLease,
+}
+
+pub(super) fn open(root_path: &Path, store: &DurableStore) -> Result<OpenedLayout, TuneError> {
+    open_with_hook(root_path, store, || {})
+}
+
+#[cfg(test)]
+pub(super) fn open_with_acquisition_hook_for_test(
+    root_path: &Path,
+    store: &DurableStore,
+    after_acquisition: impl FnOnce(),
+) -> Result<OpenedLayout, TuneError> {
+    open_with_hook(root_path, store, after_acquisition)
+}
+
+fn open_with_hook(
+    root_path: &Path,
+    store: &DurableStore,
+    after_acquisition: impl FnOnce(),
+) -> Result<OpenedLayout, TuneError> {
+    let root = store.root_directory();
+    let before = inspect_layout(&root)?;
+    let writer = store
+        .acquire_writer()
+        .map_err(|source| writer_error(root_path, source))?;
+    after_acquisition();
+    let after = inspect_layout(&root)?;
+    validate_acquisition(&before, &after)?;
+    let marker = root
+        .child(&writer, &object_name(LAYOUT_MARKER)?)
+        .map_err(storage_error)?;
+    require_empty_marker(&marker)?;
+    let candidates = open_directory(&root, &writer, DIRECTORIES[0])?;
+    let stages = open_directory(&root, &writer, DIRECTORIES[1])?;
+    let entries = open_directory(&root, &writer, DIRECTORIES[2])?;
+    Ok(OpenedLayout {
+        root,
+        marker,
+        candidates,
+        stages,
+        entries,
+        writer,
+    })
+}
+
+pub(super) fn verify_handles(
+    marker: &DurableDirectory,
+    candidates: &DurableDirectory,
+    stages: &DurableDirectory,
+    entries: &DurableDirectory,
+) -> Result<(), TuneError> {
+    require_empty_marker(marker)?;
+    candidates.list().map_err(storage_error)?;
+    stages.list().map_err(storage_error)?;
+    entries.list().map_err(storage_error)?;
+    Ok(())
+}
+
+pub(super) fn verify_authorized(root: &DurableDirectory) -> Result<(), TuneError> {
+    let layout = inspect_layout(root)?;
+    let has_head = layout
+        .objects
+        .iter()
+        .any(|object| is_name(&object.name, HEAD));
+    if layout.phase == LayoutPhase::Marked && has_head {
+        Ok(())
+    } else {
+        Err(invalid_layout(
+            "the live journal does not have an authorized marked layout",
+        ))
+    }
+}
+
+pub(super) fn verify_initial_authorization(root: &DurableDirectory) -> Result<(), TuneError> {
+    let layout = inspect_layout(root)?;
+    let has_head = layout
+        .objects
+        .iter()
+        .any(|object| is_name(&object.name, HEAD));
+    let has_all_directories = DIRECTORIES.iter().all(|name| {
+        layout
+            .objects
+            .iter()
+            .any(|object| is_name(&object.name, name))
+    });
+    if layout.phase == LayoutPhase::Marked && !has_head && has_all_directories {
+        Ok(())
+    } else {
+        Err(invalid_layout(
+            "the initial journal does not have a complete marked layout",
+        ))
+    }
+}
+
+fn open_directory(
+    root: &DurableDirectory,
+    writer: &WriterLease,
+    name: &str,
+) -> Result<DurableDirectory, TuneError> {
+    root.child(writer, &object_name(name)?)
+        .map_err(storage_error)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LayoutSnapshot {
+    phase: LayoutPhase,
+    objects: Vec<LayoutObject>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LayoutPhase {
+    Bootstrap,
+    Marked,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LayoutObject {
+    name: ObjectName,
+    inspection: ObjectInspection,
+    exact: Option<ExactObject>,
+}
+
+fn inspect_layout(root: &DurableDirectory) -> Result<LayoutSnapshot, TuneError> {
+    let names = root.list().map_err(storage_error)?;
+    let marked = contains(&names, LAYOUT_MARKER);
+    if marked {
+        inspect_marked(root, names)
+    } else {
+        inspect_bootstrap(root, names)
+    }
+}
+
+fn inspect_bootstrap(
+    root: &DurableDirectory,
+    names: Vec<ObjectName>,
+) -> Result<LayoutSnapshot, TuneError> {
+    if names.is_empty() {
+        return Ok(LayoutSnapshot {
+            phase: LayoutPhase::Bootstrap,
+            objects: Vec::new(),
+        });
+    }
+    if names.len() != 1 || !is_name(&names[0], WRITER_LOCK) {
+        return Err(invalid_layout("the root has evidence from another layout"));
+    }
+    let lock = inspect_file(root, names[0].clone(), Some(0))?;
+    Ok(LayoutSnapshot {
+        phase: LayoutPhase::Bootstrap,
+        objects: vec![lock],
+    })
+}
+
+fn inspect_marked(
+    root: &DurableDirectory,
+    names: Vec<ObjectName>,
+) -> Result<LayoutSnapshot, TuneError> {
+    let has_head = contains(&names, HEAD);
+    if !contains(&names, WRITER_LOCK) {
+        return Err(invalid_layout("a marked layout has no writer lock"));
+    }
+    if has_head && DIRECTORIES.iter().any(|name| !contains(&names, name)) {
+        return Err(invalid_layout(
+            "an authorized layout does not have all data directories",
+        ));
+    }
+    if !has_head && !has_bootstrap_prefix(&names) {
+        return Err(invalid_layout(
+            "a partial layout does not have an ordered directory prefix",
+        ));
+    }
+    let mut objects = Vec::with_capacity(names.len());
+    for name in names {
+        let object = inspect_marked_object(root, name)?;
+        objects.push(object);
+    }
+    Ok(LayoutSnapshot {
+        phase: LayoutPhase::Marked,
+        objects,
+    })
+}
+
+fn inspect_marked_object(
+    root: &DurableDirectory,
+    name: ObjectName,
+) -> Result<LayoutObject, TuneError> {
+    if is_name(&name, LAYOUT_MARKER) || DIRECTORIES.iter().any(|value| is_name(&name, value)) {
+        return inspect_directory(root, name);
+    }
+    if is_name(&name, WRITER_LOCK) {
+        return inspect_file(root, name, Some(0));
+    }
+    if is_name(&name, HEAD) {
+        return inspect_head(root, name);
+    }
+    if is_strict_temporary(&name) {
+        return inspect_file(root, name, None);
+    }
+    Err(invalid_layout(
+        "a marked layout has an unsupported root object",
+    ))
+}
+
+fn inspect_directory(root: &DurableDirectory, name: ObjectName) -> Result<LayoutObject, TuneError> {
+    let inspection = root.inspect(&name).map_err(storage_error)?;
+    require_kind(inspection.kind, ObjectKind::Directory)?;
+    Ok(LayoutObject {
+        name,
+        inspection,
+        exact: None,
+    })
+}
+
+fn require_empty_marker(marker: &DurableDirectory) -> Result<(), TuneError> {
+    if marker.list().map_err(storage_error)?.is_empty() {
+        Ok(())
+    } else {
+        Err(invalid_layout("the layout marker is not empty"))
+    }
+}
+
+fn inspect_file(
+    root: &DurableDirectory,
+    name: ObjectName,
+    maximum_bytes: Option<usize>,
+) -> Result<LayoutObject, TuneError> {
+    let inspection = root.inspect(&name).map_err(storage_error)?;
+    require_kind(inspection.kind, ObjectKind::RegularFile)?;
+    let exact = maximum_bytes
+        .map(|limit| root.read_exact(&name, limit).map_err(storage_error))
+        .transpose()?;
+    Ok(LayoutObject {
+        name,
+        inspection,
+        exact,
+    })
+}
+
+fn inspect_head(root: &DurableDirectory, name: ObjectName) -> Result<LayoutObject, TuneError> {
+    let mut object = inspect_file(root, name.clone(), Some(MAX_DOCUMENT_BYTES))?;
+    let exact = object
+        .exact
+        .as_ref()
+        .ok_or_else(|| invalid_layout("the journal head was not read"))?;
+    let head: HeadPointer = decode("journal head", &name, exact.bytes())?;
+    if exact != &exact_head(head.digest)? {
+        return Err(invalid_journal(
+            "the journal head does not use canonical bytes",
+        ));
+    }
+    object.exact = Some(exact.clone());
+    Ok(object)
+}
+
+fn validate_acquisition(before: &LayoutSnapshot, after: &LayoutSnapshot) -> Result<(), TuneError> {
+    match before.phase {
+        LayoutPhase::Bootstrap if before.objects.is_empty() && exact_lock_only(after) => Ok(()),
+        LayoutPhase::Bootstrap | LayoutPhase::Marked if before == after => Ok(()),
+        LayoutPhase::Bootstrap | LayoutPhase::Marked => Err(invalid_layout(
+            "the journal layout changed during writer acquisition",
+        )),
+    }
+}
+
+fn exact_lock_only(layout: &LayoutSnapshot) -> bool {
+    layout.phase == LayoutPhase::Bootstrap
+        && layout.objects.len() == 1
+        && is_name(&layout.objects[0].name, WRITER_LOCK)
+}
+
+fn require_kind(actual: ObjectKind, expected: ObjectKind) -> Result<(), TuneError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(invalid_layout("a journal layout object has the wrong type"))
+    }
+}
+
+fn contains(names: &[ObjectName], expected: &str) -> bool {
+    names.iter().any(|name| is_name(name, expected))
+}
+
+fn has_bootstrap_prefix(names: &[ObjectName]) -> bool {
+    let present = DIRECTORIES.map(|name| contains(names, name));
+    !present.windows(2).any(|pair| !pair[0] && pair[1])
+}
+
+fn is_name(name: &ObjectName, expected: &str) -> bool {
+    name.as_os_str() == OsStr::new(expected)
+}
+
+fn is_strict_temporary(name: &ObjectName) -> bool {
+    let Some(value) = name.as_os_str().to_str() else {
+        return false;
+    };
+    let Some(value) = value.strip_prefix(".pilotage-tmp-") else {
+        return false;
+    };
+    let Some((process, counter)) = value.split_once('-') else {
+        return false;
+    };
+    !process.is_empty()
+        && process.bytes().all(|byte| byte.is_ascii_digit())
+        && counter.len() == 16
+        && counter
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn invalid_layout(detail: &'static str) -> TuneError {
+    invalid_journal(format!("journal layout is not valid: {detail}"))
+}

--- a/tools/flight-tune/src/journal/storage/tests.rs
+++ b/tools/flight-tune/src/journal/storage/tests.rs
@@ -1,12 +1,384 @@
 #![allow(clippy::expect_used)]
 
-use super::{MAX_DOCUMENT_BYTES, encode};
-use crate::TuneError;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use pilotage_durable_storage::{DurableStore, ExpectedValue, ObjectName};
+
+use super::layout::LAYOUT_MARKER;
+use super::{MAX_DOCUMENT_BYTES, encode, exact_head, open};
+use crate::{Digest, TuneError};
+
+#[path = "tests/prospective.rs"]
+mod prospective;
 
 #[test]
 fn an_oversized_document_is_rejected_before_a_write() {
-    let content = "x".repeat(MAX_DOCUMENT_BYTES as usize);
+    let content = "x".repeat(MAX_DOCUMENT_BYTES);
     let error = encode("oversized test document", &content).expect_err("reject oversized data");
 
     assert!(matches!(error, TuneError::DocumentTooLarge { .. }));
+}
+
+#[test]
+fn legacy_evidence_is_rejected_without_a_catalog_change() {
+    let directory = TestDirectory::with_root("legacy-layout");
+    write_private(&directory.path().join("HEAD.json"), b"old-head");
+    write_private(&directory.path().join("legacy-sentinel"), b"old-evidence");
+    let before = catalog(directory.path());
+
+    let error = open(directory.path()).err().expect("reject legacy layout");
+
+    assert_invalid_layout(error);
+    assert_eq!(catalog(directory.path()), before);
+    assert!(!directory.path().join(".pilotage-writer-lock").exists());
+    assert!(!directory.path().join(LAYOUT_MARKER).exists());
+}
+
+#[test]
+fn an_empty_root_bootstraps_the_versioned_layout() {
+    let directory = TestDirectory::with_root("empty-bootstrap");
+
+    let opened = open(directory.path()).expect("bootstrap empty root");
+    drop(opened);
+
+    assert_bootstrap_objects(directory.path());
+}
+
+#[test]
+fn an_exact_lock_only_root_resumes_bootstrap() {
+    let directory = TestDirectory::new("lock-bootstrap");
+    let store = DurableStore::open_or_create(directory.path()).expect("create durable root");
+    let lease = store.acquire_writer().expect("create writer lock");
+    drop(lease);
+    drop(store);
+
+    let opened = open(directory.path()).expect("resume lock-only bootstrap");
+    drop(opened);
+
+    assert_bootstrap_objects(directory.path());
+}
+
+#[test]
+fn a_marked_partial_bootstrap_with_a_strict_temp_recovers() {
+    let directory = TestDirectory::new("partial-bootstrap");
+    create_layout_prefix(directory.path(), &["candidates"]);
+    write_private(
+        &directory.path().join(".pilotage-tmp-17-00000000000000af"),
+        b"partial",
+    );
+
+    let opened = open(directory.path()).expect("resume partial bootstrap");
+    drop(opened);
+
+    assert_bootstrap_objects(directory.path());
+    assert!(
+        directory
+            .path()
+            .join(".pilotage-tmp-17-00000000000000af")
+            .is_file()
+    );
+}
+
+#[test]
+fn a_partial_bootstrap_rejects_an_out_of_order_directory() {
+    let directory = TestDirectory::new("out-of-order-bootstrap");
+    create_layout_prefix(directory.path(), &["stages"]);
+    let before = catalog(directory.path());
+
+    let error = open(directory.path())
+        .err()
+        .expect("reject out-of-order bootstrap");
+
+    assert_invalid_layout(error);
+    assert_eq!(catalog(directory.path()), before);
+    assert!(!directory.path().join("candidates").exists());
+    assert!(!directory.path().join("entries").exists());
+}
+
+#[test]
+fn an_authorized_layout_accepts_a_strict_root_temporary() {
+    let directory = TestDirectory::new("authorized-orphan-temp");
+    create_authorized_layout(directory.path());
+    write_private(
+        &directory.path().join(".pilotage-tmp-17-00000000000000af"),
+        b"orphan",
+    );
+
+    let opened = open(directory.path()).expect("accept strict orphan temporary");
+    drop(opened);
+
+    assert!(
+        directory
+            .path()
+            .join(".pilotage-tmp-17-00000000000000af")
+            .is_file()
+    );
+}
+
+#[test]
+fn an_acquisition_race_cannot_publish_the_layout_marker() {
+    let directory = TestDirectory::new("acquisition-race");
+    let store = DurableStore::open_or_create(directory.path()).expect("create durable root");
+    let foreign = directory.path().join("legacy-sentinel");
+
+    let error =
+        super::layout::open_with_acquisition_hook_for_test(directory.path(), &store, || {
+            write_private(&foreign, b"foreign")
+        })
+        .err()
+        .expect("reject a raced foreign object");
+
+    assert_invalid_layout(error);
+    assert!(foreign.is_file());
+    assert!(directory.path().join(".pilotage-writer-lock").is_file());
+    assert!(!directory.path().join(LAYOUT_MARKER).exists());
+    for name in ["candidates", "stages", "entries"] {
+        assert!(!directory.path().join(name).exists());
+    }
+}
+
+#[test]
+fn an_authorized_incomplete_layout_is_rejected_without_a_change() {
+    let directory = TestDirectory::new("incomplete-authorized-layout");
+    let store = DurableStore::open_or_create(directory.path()).expect("create durable root");
+    let root = store.root_directory();
+    let lease = store.acquire_writer().expect("create writer lock");
+    root.child(&lease, &name(LAYOUT_MARKER))
+        .expect("create layout marker");
+    root.child(&lease, &name("candidates"))
+        .expect("create candidate directory");
+    root.child(&lease, &name("stages"))
+        .expect("create stage directory");
+    lease
+        .compare_exchange_file(
+            &root,
+            &name("HEAD.json"),
+            ExpectedValue::Absent,
+            exact_head(Digest::from_bytes([31; 32])).expect("encode head"),
+        )
+        .expect("publish head");
+    drop(lease);
+    drop(store);
+    let before = catalog(directory.path());
+
+    let error = open(directory.path())
+        .err()
+        .expect("reject incomplete authorized layout");
+
+    assert_invalid_layout(error);
+    assert_eq!(catalog(directory.path()), before);
+    assert!(!directory.path().join("entries").exists());
+}
+
+#[test]
+fn a_marker_does_not_authorize_an_unknown_root_object() {
+    let directory = TestDirectory::new("marked-unknown-object");
+    create_layout_prefix(directory.path(), &[]);
+    write_private(&directory.path().join("legacy-sentinel"), b"not-owned");
+    let before = catalog(directory.path());
+
+    let error = open(directory.path())
+        .err()
+        .expect("reject unknown root object");
+
+    assert_invalid_layout(error);
+    assert_eq!(catalog(directory.path()), before);
+}
+
+#[test]
+fn a_nonempty_marker_cannot_create_missing_data_directories() {
+    let directory = TestDirectory::new("nonempty-marker");
+    create_layout_prefix(directory.path(), &[]);
+    fs::create_dir(directory.path().join(LAYOUT_MARKER).join("foreign"))
+        .expect("add marker content");
+    let before = catalog(directory.path());
+
+    let error = open(directory.path())
+        .err()
+        .expect("reject nonempty marker");
+
+    assert_invalid_layout(error);
+    assert_eq!(catalog(directory.path()), before);
+    for name in ["candidates", "stages", "entries"] {
+        assert!(!directory.path().join(name).exists());
+    }
+}
+
+fn create_layout_prefix(root_path: &Path, directories: &[&str]) {
+    let store = DurableStore::open_or_create(root_path).expect("create durable root");
+    let root = store.root_directory();
+    let lease = store.acquire_writer().expect("create writer lock");
+    root.child(&lease, &name(LAYOUT_MARKER))
+        .expect("create layout marker");
+    for directory in directories {
+        root.child(&lease, &name(directory))
+            .expect("create partial directory");
+    }
+}
+
+fn create_authorized_layout(root_path: &Path) {
+    let store = DurableStore::open_or_create(root_path).expect("create durable root");
+    let root = store.root_directory();
+    let lease = store.acquire_writer().expect("create writer lock");
+    root.child(&lease, &name(LAYOUT_MARKER))
+        .expect("create layout marker");
+    for directory in ["candidates", "stages", "entries"] {
+        root.child(&lease, &name(directory))
+            .expect("create data directory");
+    }
+    lease
+        .compare_exchange_file(
+            &root,
+            &name("HEAD.json"),
+            ExpectedValue::Absent,
+            exact_head(Digest::from_bytes([31; 32])).expect("encode head"),
+        )
+        .expect("publish head");
+}
+
+fn assert_bootstrap_objects(root: &Path) {
+    for name in [
+        ".pilotage-writer-lock",
+        LAYOUT_MARKER,
+        "candidates",
+        "stages",
+        "entries",
+    ] {
+        assert!(root.join(name).exists(), "missing bootstrap object {name}");
+    }
+}
+
+fn assert_invalid_layout(error: TuneError) {
+    assert!(matches!(
+        error,
+        TuneError::InvalidJournal { detail } if detail.starts_with("journal layout is not valid:")
+    ));
+}
+
+fn name(value: &str) -> ObjectName {
+    ObjectName::new(value).expect("valid object name")
+}
+
+fn write_private(path: &Path, bytes: &[u8]) {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .expect("create private file");
+    file.write_all(bytes).expect("write private file");
+    file.sync_all().expect("sync private file");
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CatalogEntry {
+    kind: CatalogKind,
+    mode: u32,
+    link_count: u64,
+    bytes: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CatalogKind {
+    Directory,
+    File,
+    Symlink,
+    Other,
+}
+
+fn catalog(root: &Path) -> BTreeMap<PathBuf, CatalogEntry> {
+    let mut entries = BTreeMap::new();
+    collect_catalog(root, root, &mut entries);
+    entries
+}
+
+fn collect_catalog(root: &Path, path: &Path, entries: &mut BTreeMap<PathBuf, CatalogEntry>) {
+    let metadata = fs::symlink_metadata(path).expect("inspect catalog object");
+    let relative = path.strip_prefix(root).expect("relative catalog path");
+    let bytes = metadata
+        .is_file()
+        .then(|| fs::read(path).expect("read catalog object"));
+    entries.insert(
+        relative.to_path_buf(),
+        CatalogEntry {
+            kind: catalog_kind(&metadata),
+            mode: metadata.permissions().mode() & 0o777,
+            link_count: metadata.nlink(),
+            bytes,
+        },
+    );
+    if metadata.is_dir() {
+        let mut children = fs::read_dir(path)
+            .expect("read catalog directory")
+            .map(|entry| entry.expect("read catalog entry").path())
+            .collect::<Vec<_>>();
+        children.sort();
+        for child in children {
+            collect_catalog(root, &child, entries);
+        }
+    }
+}
+
+fn catalog_kind(metadata: &fs::Metadata) -> CatalogKind {
+    let kind = metadata.file_type();
+    if kind.is_dir() {
+        CatalogKind::Directory
+    } else if kind.is_file() {
+        CatalogKind::File
+    } else if kind.is_symlink() {
+        CatalogKind::Symlink
+    } else {
+        CatalogKind::Other
+    }
+}
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(label: &str) -> Self {
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = test_root().join(format!("flight-tune-{label}-{}-{time}", std::process::id()));
+        Self { path }
+    }
+
+    fn with_root(label: &str) -> Self {
+        let directory = Self::new(label);
+        fs::create_dir(directory.path()).expect("create private root");
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700))
+            .expect("set private root mode");
+        directory
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn test_root() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/private/tmp")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::env::temp_dir()
+            .canonicalize()
+            .expect("canonical test temporary directory")
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path).ok();
+    }
 }

--- a/tools/flight-tune/src/journal/storage/tests/prospective.rs
+++ b/tools/flight-tune/src/journal/storage/tests/prospective.rs
@@ -1,0 +1,186 @@
+use std::collections::BTreeMap;
+use std::fs;
+
+use pilotage_durable_storage::{ContentDigest, StorageError};
+
+use super::super::{
+    append_entry_with_hook, candidate_digests_to_verify, document_digest, store_candidate,
+    store_stage,
+};
+use super::TestDirectory;
+use crate::identity::harness_build_identity;
+use crate::journal::{JOURNAL_SCHEMA_VERSION, JournalEntry, JournalEvent, SessionIdentity};
+use crate::{
+    ArtifactIdentity, AttemptRole, Candidate, CandidateLineage, Digest, ParameterBounds,
+    PromotionPolicy, QualificationPolicy, RuntimeIdentities, ScenarioRef, SearchStage, TuneError,
+};
+
+#[test]
+fn a_changed_prospective_candidate_cannot_publish_a_head() {
+    let directory = TestDirectory::new("prospective-candidate-change");
+    let (storage, writer) = super::super::open(directory.path()).expect("open journal storage");
+    let stage = test_stage();
+    let initial = test_candidate();
+    let stage_digest = store_stage(&storage, &writer, &stage).expect("store stage");
+    let candidate_digest =
+        store_candidate(&storage, &writer, &initial).expect("store initial candidate");
+    let entry = started_entry(stage_digest, candidate_digest, &initial);
+    let entry_digest = document_digest("journal entry", &entry).expect("digest entry");
+    let candidate_path = directory
+        .path()
+        .join("candidates")
+        .join(format!("{candidate_digest}.json"));
+
+    let error = append_entry_with_hook(
+        &storage,
+        &writer,
+        &stage,
+        std::slice::from_ref(&entry),
+        std::slice::from_ref(&entry_digest),
+        || change_bytes(&candidate_path),
+    )
+    .expect_err("reject changed prospective candidate");
+
+    assert!(matches!(
+        error,
+        TuneError::Storage { source }
+            if matches!(
+                source.as_ref(),
+                StorageError::ContentMismatch { context }
+                    if context.object == Some(ContentDigest(*candidate_digest.as_bytes()))
+            )
+    ));
+    assert!(!directory.path().join("HEAD.json").exists());
+    assert!(
+        directory
+            .path()
+            .join("entries")
+            .join(format!("{entry_digest}.json"))
+            .is_file()
+    );
+}
+
+#[test]
+fn candidate_audit_reads_each_digest_once_in_entry_order() {
+    let initial = Digest::from_bytes([21; 32]);
+    let first = Digest::from_bytes([22; 32]);
+    let second = Digest::from_bytes([23; 32]);
+    let session = started_entry(Digest::from_bytes([20; 32]), initial, &test_candidate()).session;
+    let candidates = [initial, first, first, second, initial];
+    let entries = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(sequence, candidate)| JournalEntry {
+            schema_version: JOURNAL_SCHEMA_VERSION,
+            sequence: u64::try_from(sequence).expect("small sequence"),
+            previous: None,
+            session: session.clone(),
+            event: JournalEvent::AttemptPrepared {
+                trial_id: u64::try_from(sequence).expect("small trial identity"),
+                role: AttemptRole::TrainingBaseline,
+                candidate,
+                plan_digest: Digest::from_bytes([24; 32]),
+            },
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        candidate_digests_to_verify(initial, &entries),
+        vec![first, second]
+    );
+}
+
+fn started_entry(
+    stage_digest: Digest,
+    candidate_digest: Digest,
+    initial: &Candidate,
+) -> JournalEntry {
+    JournalEntry {
+        schema_version: JOURNAL_SCHEMA_VERSION,
+        sequence: 0,
+        previous: None,
+        session: SessionIdentity {
+            stage_digest,
+            initial_candidate_digest: candidate_digest,
+            candidate_lineage: initial.lineage().clone(),
+            fixed_seed: 91,
+            runtimes: test_runtimes(),
+        },
+        event: JournalEvent::Started {
+            candidate: candidate_digest,
+        },
+    }
+}
+
+fn test_candidate() -> Candidate {
+    Candidate::new(
+        CandidateLineage {
+            schema: "test-candidate-v1".to_owned(),
+            base_preset_digest: Digest::from_bytes([7; 32]),
+            plant_digest: Digest::from_bytes([8; 32]),
+        },
+        BTreeMap::from([("gain".to_owned(), 0.0), ("mode".to_owned(), 1.0)]),
+    )
+    .expect("valid candidate")
+}
+
+fn test_stage() -> SearchStage {
+    SearchStage {
+        id: "test-stage".to_owned(),
+        allowlist: BTreeMap::from([(
+            "gain".to_owned(),
+            ParameterBounds {
+                minimum: 0.0,
+                maximum: 2.0,
+            },
+        )]),
+        fixed_parameters: BTreeMap::from([("mode".to_owned(), 1.0)]),
+        required_hard_gates: vec!["envelope".to_owned()],
+        training_scenarios: vec![scenario("training", 1)],
+        promotion_scenarios: vec![scenario("promotion", 2)],
+        final_qualification_scenarios: vec![scenario("qualification", 3)],
+        repetitions: 2,
+        promotion: PromotionPolicy {
+            minimum_loss_improvement: 0.0,
+            minimum_relative_loss_improvement: 0.2,
+            maximum_control_effort_increase: 1.0,
+        },
+        qualification: QualificationPolicy {
+            maximum_loss_confidence_upper: 0.5,
+            maximum_p95_loss: 0.5,
+            maximum_mean_control_effort: 1.0,
+            objective_maxima: BTreeMap::from([("test.response".to_owned(), 0.75)]),
+        },
+    }
+}
+
+fn scenario(id: &str, digest_byte: u8) -> ScenarioRef {
+    ScenarioRef {
+        id: id.to_owned(),
+        digest: Digest::from_bytes([digest_byte; 32]),
+        max_samples: 8,
+        sample_timeout_ms: 100,
+    }
+}
+
+fn test_runtimes() -> RuntimeIdentities {
+    RuntimeIdentities {
+        harness_build: harness_build_identity(),
+        strategy: identity("strategy", 11),
+        metric: identity("metric", 12),
+        hard_gates: identity("hard-gates", 13),
+        simulator: identity("simulator", 14),
+        airframe: identity("airframe", 15),
+        vehicle: identity("vehicle", 16),
+    }
+}
+
+fn identity(id: &str, digest_byte: u8) -> ArtifactIdentity {
+    ArtifactIdentity::new(id, Digest::from_bytes([digest_byte; 32])).expect("valid identity")
+}
+
+fn change_bytes(path: &std::path::Path) {
+    let mut bytes = fs::read(path).expect("read candidate");
+    bytes.push(b' ');
+    fs::write(path, bytes).expect("change candidate");
+}

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -9,6 +9,9 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(test)]
+extern crate self as flight_tune;
+
 mod adapter;
 mod engine;
 mod error;

--- a/tools/flight-tune/tests/tuner.rs
+++ b/tools/flight-tune/tests/tuner.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::expect_used, clippy::panic)]
 
+#[path = "tuner/journal_storage.rs"]
+mod journal_storage;
 #[path = "tuner/no_samples.rs"]
 mod no_samples;
 #[path = "tuner/reconciliation.rs"]
@@ -9,8 +11,7 @@ mod reconciliation;
 #[path = "tuner/test_rig.rs"]
 mod test_rig;
 
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::Path;
 
 use flight_tune::{
     CampaignPhase, CandidateEvaluation, FinalQualificationOutcome, JournalEvent, PromotionDecision,
@@ -18,7 +19,7 @@ use flight_tune::{
 };
 use test_rig::{
     EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, FakeVehicle, QuadraticMetric,
-    SequenceStrategy, assert_receipt_error, candidate, stage,
+    SequenceStrategy, TestDirectory, assert_receipt_error, candidate, stage,
 };
 
 type TestTuner = Tuner<FakeBackend, FakeVehicle, EnvelopeGates, QuadraticMetric, SequenceStrategy>;
@@ -280,7 +281,7 @@ fn candidate_readback_mismatch_is_quarantined_before_cleanup() {
         2.0,
     )
     .expect("open tuner");
-    state.0.borrow_mut().bad_candidate_readback_on_ensure = Some(3);
+    state.0.borrow_mut().bad_candidate_readback_on_ensure = Some(2);
 
     let error = tuner
         .run_training_attempts_blocking(0)
@@ -465,30 +466,4 @@ fn assert_promotion_uses_paired_seeds(state: &FakeHandle) {
     assert_eq!(promotion.len(), 4);
     assert_eq!(promotion[0].1, promotion[2].1);
     assert_eq!(promotion[1].1, promotion[3].1);
-}
-
-struct TestDirectory {
-    path: PathBuf,
-}
-
-impl TestDirectory {
-    fn new(label: &str) -> Self {
-        let time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        let path =
-            std::env::temp_dir().join(format!("flight-tune-{label}-{}-{time}", std::process::id()));
-        Self { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TestDirectory {
-    fn drop(&mut self) {
-        std::fs::remove_dir_all(&self.path).ok();
-    }
 }

--- a/tools/flight-tune/tests/tuner/journal_storage.rs
+++ b/tools/flight-tune/tests/tuner/journal_storage.rs
@@ -1,0 +1,77 @@
+use std::fs;
+
+use flight_tune::TuneError;
+use pilotage_durable_storage::StorageError;
+
+use super::test_rig::{FakeHandle, SequenceStrategy};
+use super::{TestDirectory, open};
+
+#[test]
+fn a_semantic_but_noncanonical_head_is_rejected() {
+    let directory = TestDirectory::new("noncanonical-head");
+    let state = FakeHandle::new();
+    let tuner = open(
+        directory.path(),
+        state.clone(),
+        SequenceStrategy::new(Vec::new()),
+        2.0,
+    )
+    .expect("open tuner");
+    drop(tuner);
+
+    let head_path = directory.path().join("HEAD.json");
+    let canonical = fs::read(&head_path).expect("read canonical head");
+    let mut noncanonical = vec![b' '];
+    noncanonical.extend(canonical);
+    fs::write(&head_path, noncanonical).expect("write noncanonical head");
+
+    let result = open(
+        directory.path(),
+        state,
+        SequenceStrategy::new(Vec::new()),
+        2.0,
+    );
+    assert!(matches!(
+        result,
+        Err(TuneError::InvalidJournal { detail })
+            if detail == "the journal head does not use canonical bytes"
+    ));
+}
+
+#[test]
+fn changed_candidate_bytes_fail_the_digest_named_read() {
+    let directory = TestDirectory::new("candidate-content-mismatch");
+    let state = FakeHandle::new();
+    let tuner = open(
+        directory.path(),
+        state.clone(),
+        SequenceStrategy::new(Vec::new()),
+        2.0,
+    )
+    .expect("open tuner");
+    drop(tuner);
+
+    let candidate_path = fs::read_dir(directory.path().join("candidates"))
+        .expect("read candidate directory")
+        .next()
+        .expect("candidate object")
+        .expect("read candidate entry")
+        .path();
+    let canonical = fs::read(&candidate_path).expect("read candidate object");
+    let mut changed = vec![b' '];
+    changed.extend(canonical);
+    fs::write(candidate_path, changed).expect("change candidate object");
+
+    let result = open(
+        directory.path(),
+        state,
+        SequenceStrategy::new(Vec::new()),
+        2.0,
+    );
+    assert!(matches!(
+        result,
+        Err(TuneError::Storage { source })
+            if matches!(source.as_ref(), StorageError::ContentMismatch { context }
+                if context.object.is_some())
+    ));
+}

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -1,30 +1,48 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use flight_tune::{
-    AdapterError, ArtifactIdentity, Candidate, CandidateLineage, CandidateReceipt, Digest,
-    EvaluatorError, GateEvaluator, GateOutcome, MetricEvaluator, MetricValues, ParameterBounds,
-    PromotionPolicy, Proposal, ProposalContext, ProposalError, ProposalStrategy,
-    QualificationPolicy, SampleEvent, ScenarioRef, ScenarioStartReceipt, SearchStage,
-    SessionChallenge, SimulatorBackend, SimulatorCapability, SimulatorSessionReceipt,
-    SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample, TrainingObservation,
-    TuneError, VehicleBinding, VehicleBindingReceipt,
+    AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, Digest, SampleEvent, ScenarioRef,
+    ScenarioStartReceipt, SessionChallenge, SimulatorBackend, SimulatorCapability,
+    SimulatorSessionReceipt, SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample,
+    VehicleBinding, VehicleBindingReceipt,
+};
+
+#[path = "test_rig/scoring.rs"]
+mod scoring;
+
+#[allow(unused_imports)]
+pub use scoring::{
+    EnvelopeGates, ObservedViews, QuadraticMetric, SequenceStrategy, assert_receipt_error,
+    candidate, stage,
 };
 
 #[derive(Debug, Default)]
 pub struct FakeState {
     pub gain: f64,
     pub active_candidate_digest: Option<Digest>,
+    pub open_session_count: usize,
     pub prepare_count: usize,
+    pub bind_count: usize,
     pub ensure_count: usize,
     pub apply_count: usize,
     pub start_count: usize,
     pub sample_count: usize,
+    pub sample_poll_count: usize,
     pub stop_count: usize,
     pub cleanup_count: usize,
     pub metric_observe_count: usize,
+    pub gate_begin_count: usize,
+    pub gate_evaluate_count: usize,
+    pub gate_finish_count: usize,
+    pub gate_cancel_count: usize,
+    pub metric_begin_count: usize,
+    pub metric_finish_count: usize,
+    pub metric_cancel_count: usize,
     pub scenario_runs: Vec<(String, u64, f64)>,
     pub lifecycle: Vec<String>,
     pub current_scenario: Option<ScenarioRef>,
@@ -32,6 +50,8 @@ pub struct FakeState {
     pub next_sequence: u64,
     pub panic_on_prepare: Option<usize>,
     pub panic_on_start: Option<usize>,
+    pub panic_on_cleanup: Option<usize>,
+    pub change_head_on_prepare: Option<PathBuf>,
     pub bad_candidate_readback_on_ensure: Option<usize>,
     pub bad_candidate_readback_on_apply: Option<usize>,
     pub bad_scenario_readback: bool,
@@ -81,11 +101,10 @@ impl SimulatorBackend for FakeBackend {
         &mut self,
         challenge: &SessionChallenge,
     ) -> Result<SimulatorSessionReceipt, AdapterError> {
-        self.state
-            .0
-            .borrow_mut()
-            .lifecycle
-            .push("open_session".to_owned());
+        let mut state = self.state.0.borrow_mut();
+        state.open_session_count = state.open_session_count.wrapping_add(1);
+        state.lifecycle.push("open_session".to_owned());
+        drop(state);
         Ok(SimulatorSessionReceipt {
             session_digest: challenge.session_digest(),
             simulator_digest: self.simulator.digest,
@@ -105,9 +124,14 @@ impl SimulatorBackend for FakeBackend {
         if state.panic_on_prepare == Some(state.prepare_count) {
             panic!("simulated process stop after AttemptPrepared");
         }
+        let head_change = state.change_head_on_prepare.take();
         state.current_scenario = Some(scenario.clone());
         state.current_seed = seed;
         state.next_sequence = 0;
+        drop(state);
+        if let Some(root) = head_change {
+            change_head_digest(&root);
+        }
         Ok(())
     }
 
@@ -142,6 +166,7 @@ impl SimulatorBackend for FakeBackend {
 
     fn sample_blocking(&mut self, _timeout: Duration) -> Result<SampleEvent, AdapterError> {
         let mut state = self.state.0.borrow_mut();
+        state.sample_poll_count = state.sample_poll_count.wrapping_add(1);
         if state.complete_without_sample {
             return Ok(SampleEvent::Complete);
         }
@@ -174,8 +199,23 @@ impl SimulatorBackend for FakeBackend {
         let mut state = self.state.0.borrow_mut();
         state.cleanup_count = state.cleanup_count.wrapping_add(1);
         state.lifecycle.push("cleanup".to_owned());
+        if state.panic_on_cleanup == Some(state.cleanup_count) {
+            panic!("simulated process stop after outcome publication");
+        }
         Ok(())
     }
+}
+
+fn change_head_digest(root: &Path) {
+    let head = root.join("HEAD.json");
+    let mut bytes = std::fs::read(&head).expect("read journal head");
+    let digest_tail = bytes.len().checked_sub(3).expect("HEAD digest byte");
+    bytes[digest_tail] = if bytes[digest_tail] == b'0' {
+        b'1'
+    } else {
+        b'0'
+    };
+    std::fs::write(head, bytes).expect("change journal head");
 }
 
 pub struct FakeVehicle {
@@ -255,6 +295,9 @@ impl SimulatorVehicleFactory for FakeFactory {
         self,
         capability: &SimulatorCapability,
     ) -> Result<VehicleBinding<Self::Adapter>, AdapterError> {
+        let mut state = self.state.0.borrow_mut();
+        state.bind_count = state.bind_count.wrapping_add(1);
+        drop(state);
         if !self.allow_binding {
             return Err(AdapterError::new(
                 "hardware-like adapter has no simulator session binding",
@@ -270,214 +313,42 @@ impl SimulatorVehicleFactory for FakeFactory {
     }
 }
 
-pub struct EnvelopeGates {
-    identity: ArtifactIdentity,
-    limit: f64,
-}
-
-impl EnvelopeGates {
-    pub fn new(limit: f64) -> Self {
-        Self {
-            identity: identity("gates", &format!("envelope-limit={limit}")),
-            limit,
-        }
-    }
-}
-
-impl GateEvaluator for EnvelopeGates {
-    fn identity(&self) -> &ArtifactIdentity {
-        &self.identity
-    }
-
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
-        Ok(())
-    }
-
-    fn evaluate(&mut self, sample: &TelemetrySample) -> Result<Vec<GateOutcome>, EvaluatorError> {
-        let gain = sample
-            .values
-            .get("gain")
-            .copied()
-            .ok_or_else(|| EvaluatorError::new("sample has no gain"))?;
-        if gain > self.limit {
-            Ok(vec![GateOutcome::fail(
-                "envelope",
-                "gain exceeded the test envelope",
-            )])
-        } else {
-            Ok(vec![GateOutcome::pass("envelope")])
-        }
-    }
-
-    fn finish(&mut self) -> Result<(), EvaluatorError> {
-        Ok(())
-    }
-
-    fn cancel(&mut self) -> Result<(), EvaluatorError> {
-        Ok(())
-    }
-}
-
-pub struct QuadraticMetric {
-    identity: ArtifactIdentity,
-    state: FakeHandle,
-    gain: Option<f64>,
-}
-
-impl QuadraticMetric {
-    pub fn new(state: FakeHandle) -> Self {
-        Self {
-            identity: identity("metric", "quadratic-target-one"),
-            state,
-            gain: None,
-        }
-    }
-}
-
-impl MetricEvaluator for QuadraticMetric {
-    fn identity(&self) -> &ArtifactIdentity {
-        &self.identity
-    }
-
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
-        self.gain = None;
-        Ok(())
-    }
-
-    fn observe(&mut self, sample: &TelemetrySample) -> Result<(), EvaluatorError> {
-        let mut state = self.state.0.borrow_mut();
-        state.metric_observe_count = state.metric_observe_count.wrapping_add(1);
-        drop(state);
-        self.gain = sample.values.get("gain").copied();
-        Ok(())
-    }
-
-    fn finish(&mut self) -> Result<MetricValues, EvaluatorError> {
-        let gain = self
-            .gain
-            .take()
-            .ok_or_else(|| EvaluatorError::new("metric has no sample"))?;
-        Ok(MetricValues {
-            loss: (gain - 1.0).powi(2),
-            control_effort: gain.abs() / 2.0,
-            objectives: BTreeMap::from([("test.response".to_owned(), gain.abs())]),
-        })
-    }
-
-    fn cancel(&mut self) -> Result<(), EvaluatorError> {
-        self.gain = None;
-        Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub struct SequenceStrategy {
-    identity: ArtifactIdentity,
-    values: Vec<f64>,
-    pub views: ObservedViews,
-}
-
-pub type ObservedViews = Rc<RefCell<Vec<(Vec<String>, Vec<TrainingObservation>)>>>;
-
-impl SequenceStrategy {
-    pub fn new(values: Vec<f64>) -> Self {
-        Self {
-            identity: identity("strategy", &format!("sequence={values:?}")),
-            values,
-            views: Rc::new(RefCell::new(Vec::new())),
-        }
-    }
-}
-
-impl ProposalStrategy for SequenceStrategy {
-    fn identity(&self) -> &ArtifactIdentity {
-        &self.identity
-    }
-
-    fn propose(&self, context: &ProposalContext<'_>) -> Result<Option<Proposal>, ProposalError> {
-        self.views.borrow_mut().push((
-            context
-                .training
-                .scenarios
-                .iter()
-                .map(|scenario| scenario.id.clone())
-                .collect(),
-            context.training.history.to_vec(),
-        ));
-        let Some(value) = self
-            .values
-            .get(context.training.attempt_index as usize)
-            .copied()
-        else {
-            return Ok(None);
-        };
-        let candidate = context
-            .training
-            .incumbent
-            .with_parameter("gain", value)
-            .map_err(|error| ProposalError::new(error.to_string()))?;
-        Ok(Some(Proposal {
-            candidate,
-            reason: format!("training sequence selected gain {value}"),
-        }))
-    }
-}
-
-pub fn candidate(gain: f64) -> Candidate {
-    Candidate::new(
-        CandidateLineage {
-            schema: "aviate-candidate-v1".to_owned(),
-            base_preset_digest: Digest::from_bytes([7; 32]),
-            plant_digest: Digest::from_bytes([8; 32]),
-        },
-        BTreeMap::from([("gain".to_owned(), gain), ("mode".to_owned(), 1.0)]),
-    )
-    .expect("candidate")
-}
-
-pub fn stage() -> SearchStage {
-    SearchStage {
-        id: "inner-loop".to_owned(),
-        allowlist: BTreeMap::from([(
-            "gain".to_owned(),
-            ParameterBounds {
-                minimum: 0.0,
-                maximum: 2.0,
-            },
-        )]),
-        fixed_parameters: BTreeMap::from([("mode".to_owned(), 1.0)]),
-        required_hard_gates: vec!["envelope".to_owned()],
-        training_scenarios: vec![scenario("training-calm", 1)],
-        promotion_scenarios: vec![scenario("promotion-gust", 2)],
-        final_qualification_scenarios: vec![scenario("final-crosswind", 3)],
-        repetitions: 2,
-        promotion: PromotionPolicy {
-            minimum_loss_improvement: 0.0,
-            minimum_relative_loss_improvement: 0.2,
-            maximum_control_effort_increase: 1.0,
-        },
-        qualification: QualificationPolicy {
-            maximum_loss_confidence_upper: 0.5,
-            maximum_p95_loss: 0.5,
-            maximum_mean_control_effort: 1.0,
-            objective_maxima: BTreeMap::from([("test.response".to_owned(), 0.75)]),
-        },
-    }
-}
-
-fn scenario(id: &str, digest_byte: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: Digest::from_bytes([digest_byte; 32]),
-        max_samples: 8,
-        sample_timeout_ms: 100,
-    }
-}
-
 fn identity(id: &str, content: &str) -> ArtifactIdentity {
     ArtifactIdentity::from_text(id, content).expect("artifact identity")
 }
 
-pub fn assert_receipt_error(error: TuneError) {
-    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+pub struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    pub fn new(label: &str) -> Self {
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = test_root().join(format!("flight-tune-{label}-{}-{time}", std::process::id()));
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn test_root() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/private/tmp")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::env::temp_dir()
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.path).ok();
+    }
 }

--- a/tools/flight-tune/tests/tuner/test_rig/scoring.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/scoring.rs
@@ -1,0 +1,258 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use flight_tune::{
+    ArtifactIdentity, Candidate, CandidateLineage, Digest, EvaluatorError, GateEvaluator,
+    GateOutcome, MetricEvaluator, MetricValues, ParameterBounds, PromotionPolicy, Proposal,
+    ProposalContext, ProposalError, ProposalStrategy, QualificationPolicy, ScenarioRef,
+    SearchStage, TelemetrySample, TrainingObservation, TuneError,
+};
+
+use super::{FakeHandle, FakeState, identity};
+
+pub struct EnvelopeGates {
+    identity: ArtifactIdentity,
+    limit: f64,
+    state: Option<FakeHandle>,
+}
+
+impl EnvelopeGates {
+    pub fn new(limit: f64) -> Self {
+        Self {
+            identity: identity("gates", &format!("envelope-limit={limit}")),
+            limit,
+            state: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn tracked(limit: f64, state: FakeHandle) -> Self {
+        Self {
+            identity: identity("gates", &format!("envelope-limit={limit}")),
+            limit,
+            state: Some(state),
+        }
+    }
+
+    fn record(&self, update: impl FnOnce(&mut FakeState)) {
+        if let Some(state) = &self.state {
+            update(&mut state.0.borrow_mut());
+        }
+    }
+}
+
+impl GateEvaluator for EnvelopeGates {
+    fn identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+        self.record(|state| {
+            state.gate_begin_count = state.gate_begin_count.wrapping_add(1);
+        });
+        Ok(())
+    }
+
+    fn evaluate(&mut self, sample: &TelemetrySample) -> Result<Vec<GateOutcome>, EvaluatorError> {
+        self.record(|state| {
+            state.gate_evaluate_count = state.gate_evaluate_count.wrapping_add(1);
+        });
+        let gain = sample
+            .values
+            .get("gain")
+            .copied()
+            .ok_or_else(|| EvaluatorError::new("sample has no gain"))?;
+        if gain > self.limit {
+            Ok(vec![GateOutcome::fail(
+                "envelope",
+                "gain exceeded the test envelope",
+            )])
+        } else {
+            Ok(vec![GateOutcome::pass("envelope")])
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), EvaluatorError> {
+        self.record(|state| {
+            state.gate_finish_count = state.gate_finish_count.wrapping_add(1);
+        });
+        Ok(())
+    }
+
+    fn cancel(&mut self) -> Result<(), EvaluatorError> {
+        self.record(|state| {
+            state.gate_cancel_count = state.gate_cancel_count.wrapping_add(1);
+        });
+        Ok(())
+    }
+}
+
+pub struct QuadraticMetric {
+    identity: ArtifactIdentity,
+    state: FakeHandle,
+    gain: Option<f64>,
+}
+
+impl QuadraticMetric {
+    pub fn new(state: FakeHandle) -> Self {
+        Self {
+            identity: identity("metric", "quadratic-target-one"),
+            state,
+            gain: None,
+        }
+    }
+}
+
+impl MetricEvaluator for QuadraticMetric {
+    fn identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+        let mut state = self.state.0.borrow_mut();
+        state.metric_begin_count = state.metric_begin_count.wrapping_add(1);
+        drop(state);
+        self.gain = None;
+        Ok(())
+    }
+
+    fn observe(&mut self, sample: &TelemetrySample) -> Result<(), EvaluatorError> {
+        let mut state = self.state.0.borrow_mut();
+        state.metric_observe_count = state.metric_observe_count.wrapping_add(1);
+        drop(state);
+        self.gain = sample.values.get("gain").copied();
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<MetricValues, EvaluatorError> {
+        let mut state = self.state.0.borrow_mut();
+        state.metric_finish_count = state.metric_finish_count.wrapping_add(1);
+        drop(state);
+        let gain = self
+            .gain
+            .take()
+            .ok_or_else(|| EvaluatorError::new("metric has no sample"))?;
+        Ok(MetricValues {
+            loss: (gain - 1.0).powi(2),
+            control_effort: gain.abs() / 2.0,
+            objectives: BTreeMap::from([("test.response".to_owned(), gain.abs())]),
+        })
+    }
+
+    fn cancel(&mut self) -> Result<(), EvaluatorError> {
+        let mut state = self.state.0.borrow_mut();
+        state.metric_cancel_count = state.metric_cancel_count.wrapping_add(1);
+        drop(state);
+        self.gain = None;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct SequenceStrategy {
+    identity: ArtifactIdentity,
+    values: Vec<f64>,
+    pub views: ObservedViews,
+}
+
+pub type ObservedViews = Rc<RefCell<Vec<(Vec<String>, Vec<TrainingObservation>)>>>;
+
+impl SequenceStrategy {
+    pub fn new(values: Vec<f64>) -> Self {
+        Self {
+            identity: identity("strategy", &format!("sequence={values:?}")),
+            values,
+            views: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+}
+
+impl ProposalStrategy for SequenceStrategy {
+    fn identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    fn propose(&self, context: &ProposalContext<'_>) -> Result<Option<Proposal>, ProposalError> {
+        self.views.borrow_mut().push((
+            context
+                .training
+                .scenarios
+                .iter()
+                .map(|scenario| scenario.id.clone())
+                .collect(),
+            context.training.history.to_vec(),
+        ));
+        let Some(value) = self
+            .values
+            .get(context.training.attempt_index as usize)
+            .copied()
+        else {
+            return Ok(None);
+        };
+        let candidate = context
+            .training
+            .incumbent
+            .with_parameter("gain", value)
+            .map_err(|error| ProposalError::new(error.to_string()))?;
+        Ok(Some(Proposal {
+            candidate,
+            reason: format!("training sequence selected gain {value}"),
+        }))
+    }
+}
+
+pub fn candidate(gain: f64) -> Candidate {
+    Candidate::new(
+        CandidateLineage {
+            schema: "aviate-candidate-v1".to_owned(),
+            base_preset_digest: Digest::from_bytes([7; 32]),
+            plant_digest: Digest::from_bytes([8; 32]),
+        },
+        BTreeMap::from([("gain".to_owned(), gain), ("mode".to_owned(), 1.0)]),
+    )
+    .expect("candidate")
+}
+
+pub fn stage() -> SearchStage {
+    SearchStage {
+        id: "inner-loop".to_owned(),
+        allowlist: BTreeMap::from([(
+            "gain".to_owned(),
+            ParameterBounds {
+                minimum: 0.0,
+                maximum: 2.0,
+            },
+        )]),
+        fixed_parameters: BTreeMap::from([("mode".to_owned(), 1.0)]),
+        required_hard_gates: vec!["envelope".to_owned()],
+        training_scenarios: vec![scenario("training-calm", 1)],
+        promotion_scenarios: vec![scenario("promotion-gust", 2)],
+        final_qualification_scenarios: vec![scenario("final-crosswind", 3)],
+        repetitions: 2,
+        promotion: PromotionPolicy {
+            minimum_loss_improvement: 0.0,
+            minimum_relative_loss_improvement: 0.2,
+            maximum_control_effort_increase: 1.0,
+        },
+        qualification: QualificationPolicy {
+            maximum_loss_confidence_upper: 0.5,
+            maximum_p95_loss: 0.5,
+            maximum_mean_control_effort: 1.0,
+            objective_maxima: BTreeMap::from([("test.response".to_owned(), 0.75)]),
+        },
+    }
+}
+
+fn scenario(id: &str, digest_byte: u8) -> ScenarioRef {
+    ScenarioRef {
+        id: id.to_owned(),
+        digest: Digest::from_bytes([digest_byte; 32]),
+        max_samples: 8,
+        sample_timeout_ms: 100,
+    }
+}
+
+pub fn assert_receipt_error(error: TuneError) {
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+}


### PR DESCRIPTION
Closes #458.

## Scope

- Add a reusable Unix private durable-storage crate.
- Bind each session to held root, directory, object, and writer-lease identities.
- Add exact immutable publication, guarded compare-and-swap, recovery removal, and typed fault boundaries.
- Return a typed refusal on unsupported platforms.
- Move the core flight-tune journal behind this storage boundary.
- Make `HEAD` the sole authorization object.
- Rebuild one exact backward chain on reopen.
- Poison the live tuner after an unresolved storage result.
- Stop all external actions, cleanup, and reconciliation after poison.
- Add CI gates for the storage boundary and non-Unix consumer contract.

## Safety boundary

POSIX does not combine an exact byte comparison and a rename or unlink in one operation. A non-cooperating process with the same user can change a name after the final validation and before the system call. The crate detects observable changes and fails closed. The storage root must remain isolated from non-cooperating same-user code.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- `cargo build --release`
- durable-storage: 54 tests
- flight-tune: 44 unit tests and 21 integration tests
- durable-storage and flight-tune Wasm checks with `RUSTFLAGS="-D warnings"`
- production Rust lint guard and self-test
- monotonic counter guard and self-test
- Aviate control-feel boundary guard and self-test
- flight-tune journal storage boundary guard and self-test
- X-Plane weather state, clear protocol, and reset-order checks
- flight build, structure, and certification-claim checks

Two independent read-only reviews found no P0 or P1 blocker.