### PR TITLE
Enforce flight tuning simulator boundaries (#497)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: flight build carries no simulation-only code
         run: bash scripts/check-flight-build.sh
 
+      - name: flight tuning boundary guard self-test
+        run: bash scripts/test-check-flight-tune-boundaries.sh
+
+      - name: flight tuning boundary guard
+        run: bash scripts/check-flight-tune-boundaries.sh
+
       - name: check-structure self-test
         run: bash scripts/test-check-structure.sh
 

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Prevent simulator adapter details from entering shared tuning contracts.
+set -euo pipefail
+
+default_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root="${1:-$default_root}"
+root="$(cd "$root" && pwd)"
+allowlist_is_override=0
+if [ "$#" -ge 2 ]; then
+    allowlist="$2"
+    allowlist_is_override=1
+else
+    allowlist="$root/scripts/flight-tune-xplane-import-allowlist.tsv"
+fi
+work="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-flight-tune-boundary.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+status=0
+
+report() {
+    echo "FORBIDDEN: $1" >&2
+    status=1
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "check-flight-tune-boundaries: required command $1 is not available" >&2
+        exit 1
+    fi
+}
+
+relative_path() {
+    printf '%s\n' "${1#"$root"/}"
+}
+
+is_production_rust_path() {
+    case "$1" in
+        */test_support.rs|*/test_support/*|*/tests.rs|*/tests/*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+collect_production_files() {
+    local directory file list_id list_path list_status
+    list_id=0
+    for directory in "$@"; do
+        [ -d "$directory" ] || continue
+        list_id=$((list_id + 1))
+        list_path="$work/source-list-$list_id"
+        list_status=0
+        rg --files "$directory" -g '*.rs' > "$list_path" || list_status=$?
+        if [ "$list_status" -gt 1 ]; then
+            report "cannot list Rust source files below $(relative_path "$directory")"
+            continue
+        fi
+        while IFS= read -r file; do
+            if is_production_rust_path "$file"; then
+                printf '%s\n' "$file"
+            fi
+        done < "$list_path"
+    done
+}
+
+collect_file_imports() {
+    local file="$1" relative="$2" matches="$3" match_status
+    if ! awk -v path="$relative" '
+        BEGIN { collecting = 0; statement = "" }
+        /^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?use[[:space:]]+(::)?flight_tune_xplane(::|[[:space:]]|;)/ {
+            collecting = 1
+        }
+        collecting {
+            statement = statement $0
+            if ($0 ~ /;/) {
+                gsub(/[[:space:]]/, "", statement)
+                print path "\t" statement
+                collecting = 0
+                statement = ""
+            }
+        }
+        END { if (collecting) exit 2 }
+    ' "$file" >> "$work/aviate-imports"; then
+        report "$relative has an incomplete flight_tune_xplane import"
+    fi
+
+    match_status=0
+    rg -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
+    if [ "$match_status" -gt 1 ]; then
+        report "$relative cannot be scanned for flight_tune_xplane references"
+        return
+    fi
+    while IFS=: read -r line_number source; do
+        [ -n "$line_number" ] || continue
+        if ! grep -Eq '^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?use[[:space:]]+(::)?flight_tune_xplane(::|[[:space:]]|;)' <<<"$source"; then
+            report "$relative:$line_number uses flight_tune_xplane outside a reviewed import"
+        fi
+    done < "$matches"
+}
+
+collect_aviate_imports() {
+    local file relative scan_id
+    collect_production_files "$root/tools/flight-tune-aviate/src" > "$work/aviate-files-unsorted"
+    LC_ALL=C sort -u "$work/aviate-files-unsorted" > "$work/aviate-files"
+    : > "$work/aviate-imports"
+    scan_id=0
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        scan_id=$((scan_id + 1))
+        relative="$(relative_path "$file")"
+        collect_file_imports "$file" "$relative" "$work/import-matches-$scan_id"
+    done < "$work/aviate-files"
+    LC_ALL=C sort -u "$work/aviate-imports" -o "$work/aviate-imports"
+}
+
+check_aviate_imports() {
+    collect_aviate_imports
+    if [ ! -f "$allowlist" ]; then
+        report "the flight_tune_xplane import allowlist is missing"
+        : > "$work/allowed-imports"
+    else
+        awk 'NF > 0 && $1 !~ /^#/ { print }' "$allowlist" \
+            | LC_ALL=C sort -u > "$work/allowed-imports"
+        if [ "$allowlist_is_override" -eq 0 ] && [ -s "$work/allowed-imports" ]; then
+            report "the production flight_tune_xplane import allowlist must stay empty"
+        fi
+    fi
+    if ! comm -23 "$work/aviate-imports" "$work/allowed-imports" \
+        > "$work/new-imports"; then
+        report "cannot compare flight_tune_xplane imports with the allowlist"
+        return
+    fi
+    while IFS= read -r import; do
+        [ -n "$import" ] && report "new flight_tune_xplane import: $import"
+    done < "$work/new-imports"
+}
+
+check_shared_contracts() {
+    if ! python3 "$default_root/scripts/check-flight-tune-contracts.py" "$root"; then
+        status=1
+    fi
+}
+
+require_command rg
+require_command cargo
+require_command python3
+require_command comm
+check_aviate_imports
+check_shared_contracts
+
+if [ "$status" -ne 0 ]; then
+    echo "check-flight-tune-boundaries: FAILED" >&2
+    exit 1
+fi
+
+echo "check-flight-tune-boundaries: OK"

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -5,10 +5,8 @@ set -euo pipefail
 default_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 root="${1:-$default_root}"
 root="$(cd "$root" && pwd)"
-allowlist_is_override=0
 if [ "$#" -ge 2 ]; then
     allowlist="$2"
-    allowlist_is_override=1
 else
     allowlist="$root/scripts/flight-tune-xplane-import-allowlist.tsv"
 fi
@@ -120,9 +118,6 @@ check_aviate_imports() {
     else
         awk 'NF > 0 && $1 !~ /^#/ { print }' "$allowlist" \
             | LC_ALL=C sort -u > "$work/allowed-imports"
-        if [ "$allowlist_is_override" -eq 0 ] && [ -s "$work/allowed-imports" ]; then
-            report "the production flight_tune_xplane import allowlist must stay empty"
-        fi
     fi
     if ! comm -23 "$work/aviate-imports" "$work/allowed-imports" \
         > "$work/new-imports"; then

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -39,7 +39,7 @@ is_production_rust_path() {
 }
 
 collect_production_files() {
-    local directory file list_id list_path list_status
+    local directory file link list_id link_path list_path list_status
     list_id=0
     for directory in "$@"; do
         [ -d "$directory" ] || continue
@@ -52,6 +52,18 @@ collect_production_files() {
             report "cannot list Rust source files below $(relative_path "$directory")"
             continue
         fi
+        link_path="$work/source-links-$list_id"
+        list_status=0
+        find "$directory" -type l -print > "$link_path" || list_status=$?
+        if [ "$list_status" -ne 0 ]; then
+            report "cannot list source links below $(relative_path "$directory")"
+            continue
+        fi
+        while IFS= read -r link; do
+            if is_production_rust_path "$link"; then
+                report "production Rust source path $(relative_path "$link") is a symlink"
+            fi
+        done < "$link_path"
         while IFS= read -r file; do
             if is_production_rust_path "$file"; then
                 printf '%s\n' "$file"

--- a/scripts/check-flight-tune-boundaries.sh
+++ b/scripts/check-flight-tune-boundaries.sh
@@ -48,8 +48,9 @@ collect_production_files() {
         list_id=$((list_id + 1))
         list_path="$work/source-list-$list_id"
         list_status=0
-        rg --files "$directory" -g '*.rs' > "$list_path" || list_status=$?
-        if [ "$list_status" -gt 1 ]; then
+        find "$directory" -type f -name '*.rs' -print > "$list_path" \
+            || list_status=$?
+        if [ "$list_status" -ne 0 ]; then
             report "cannot list Rust source files below $(relative_path "$directory")"
             continue
         fi
@@ -83,7 +84,7 @@ collect_file_imports() {
     fi
 
     match_status=0
-    rg -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
+    grep -n 'flight_tune_xplane' "$file" > "$matches" || match_status=$?
     if [ "$match_status" -gt 1 ]; then
         report "$relative cannot be scanned for flight_tune_xplane references"
         return
@@ -139,7 +140,8 @@ check_shared_contracts() {
     fi
 }
 
-require_command rg
+require_command find
+require_command grep
 require_command cargo
 require_command python3
 require_command comm

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Check simulator-neutral tuning manifests and Rust contract identifiers."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+FORBIDDEN_PACKAGES = {"flight-tune-xplane", "pilotage-xplane-trial"}
+FORBIDDEN_IDENTIFIERS = (
+    "xplane",
+    "acf",
+    "aircraftfile",
+    "trialplugin",
+    "bridgeplugin",
+    "weatherplugin",
+    "hostapplicationid",
+    "sdkversion",
+)
+CAMPAIGN_SHARED_TYPES = {
+    "CampaignBudgetLimit",
+    "ExecutionTarget",
+    "CampaignPurpose",
+    "PinnedFile",
+    "SearchGroupConfig",
+    "SearchGroupKind",
+    "CampaignConfig",
+    "TrainingGuardScenarioConfig",
+    "TrainingSuiteConfig",
+}
+CAMPAIGN_ADAPTER_TYPES = {
+    "XPlaneCampaignConfig",
+    "XPlaneSupportBundleConfig",
+    "XPlaneRuntimePluginConfig",
+    "AviateCampaignConfig",
+}
+IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class ParseError(Exception):
+    """A Rust source file cannot be tokenized or divided into type bodies."""
+
+
+def report(message: str) -> None:
+    """Write one stable guard diagnostic."""
+    print(f"FORBIDDEN: {message}", file=sys.stderr)
+
+
+def normalized(identifier: str) -> str:
+    """Return the comparison form for one Rust identifier."""
+    return identifier.lower().replace("_", "").replace("-", "")
+
+
+def is_forbidden_identifier(identifier: str) -> bool:
+    """Test one identifier against all simulator-specific name fragments."""
+    value = normalized(identifier)
+    return any(fragment in value for fragment in FORBIDDEN_IDENTIFIERS)
+
+
+def check_manifest(manifest: Path, root: Path) -> bool:
+    """Use Cargo's resolved dependency view for one neutral package."""
+    if not manifest.is_file():
+        return True
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--manifest-path",
+            str(manifest),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    relative = manifest.relative_to(root)
+    if result.returncode != 0:
+        detail = result.stderr.strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        report(f"{relative} cargo metadata failed{suffix}")
+        return False
+    try:
+        metadata = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        report(f"{relative} cargo metadata is not valid JSON: {error}")
+        return False
+
+    resolved = manifest.resolve()
+    package = next(
+        (
+            item
+            for item in metadata.get("packages", [])
+            if Path(item.get("manifest_path", "")).resolve() == resolved
+        ),
+        None,
+    )
+    if package is None:
+        report(f"{relative} is absent from cargo metadata")
+        return False
+
+    valid = True
+    for dependency in package.get("dependencies", []):
+        if (
+            dependency.get("kind") != "dev"
+            and dependency.get("name") in FORBIDDEN_PACKAGES
+        ):
+            report(f"{relative} has runtime dependency {dependency['name']}")
+            valid = False
+    return valid
+
+
+def raw_string_end(source: str, start: int) -> int | None:
+    """Return the end of a Rust raw string that starts at one byte offset."""
+    prefix_length = 0
+    if source.startswith("br", start):
+        prefix_length = 2
+    elif source.startswith("r", start):
+        prefix_length = 1
+    else:
+        return None
+    cursor = start + prefix_length
+    hashes = 0
+    while cursor < len(source) and source[cursor] == "#":
+        hashes += 1
+        cursor += 1
+    if cursor >= len(source) or source[cursor] != '"':
+        return None
+    terminator = '"' + ("#" * hashes)
+    end = source.find(terminator, cursor + 1)
+    if end < 0:
+        raise ParseError("an unterminated raw string")
+    return end + len(terminator)
+
+
+def quoted_end(source: str, start: int, quote: str) -> int:
+    """Return the end of one escaped Rust string."""
+    cursor = start + 1
+    while cursor < len(source):
+        if source[cursor] == "\\":
+            cursor += 2
+            continue
+        if source[cursor] == quote:
+            return cursor + 1
+        cursor += 1
+    raise ParseError("an unterminated string")
+
+
+def character_end(source: str, start: int) -> int | None:
+    """Return the end of one Rust character literal, but not a lifetime."""
+    cursor = start + 1
+    if cursor >= len(source) or source[cursor] == "\n":
+        return None
+    if source[cursor] == "\\":
+        cursor += 1
+        while cursor < len(source) and source[cursor] not in {"'", "\n"}:
+            cursor += 1
+    else:
+        cursor += 1
+    if cursor < len(source) and source[cursor] == "'":
+        return cursor + 1
+    return None
+
+
+def rust_tokens(source: str) -> list[str]:
+    """Return Rust identifier and punctuation tokens without comments or literals."""
+    tokens: list[str] = []
+    cursor = 0
+    while cursor < len(source):
+        if source[cursor].isspace():
+            cursor += 1
+            continue
+        if source.startswith("//", cursor):
+            end = source.find("\n", cursor + 2)
+            cursor = len(source) if end < 0 else end + 1
+            continue
+        if source.startswith("/*", cursor):
+            depth = 1
+            cursor += 2
+            while cursor < len(source) and depth > 0:
+                if source.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif source.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            if depth != 0:
+                raise ParseError("an unterminated block comment")
+            continue
+        raw_end = raw_string_end(source, cursor)
+        if raw_end is not None:
+            cursor = raw_end
+            continue
+        if source[cursor] == '"':
+            cursor = quoted_end(source, cursor, '"')
+            continue
+        if source[cursor] == "'":
+            character_literal_end = character_end(source, cursor)
+            if character_literal_end is not None:
+                cursor = character_literal_end
+                continue
+        raw_identifier = re.match(r"r#([A-Za-z_][A-Za-z0-9_]*)", source[cursor:])
+        if raw_identifier is not None:
+            tokens.append(raw_identifier.group(1))
+            cursor += len(raw_identifier.group(0))
+            continue
+        identifier = re.match(r"[A-Za-z_][A-Za-z0-9_]*", source[cursor:])
+        if identifier is not None:
+            tokens.append(identifier.group(0))
+            cursor += len(identifier.group(0))
+            continue
+        tokens.append(source[cursor])
+        cursor += 1
+    return tokens
+
+
+def group_end(tokens: list[str], start: int, opening: str, closing: str) -> int:
+    """Return the token after one balanced group."""
+    depth = 0
+    for index in range(start, len(tokens)):
+        if tokens[index] == opening:
+            depth += 1
+        elif tokens[index] == closing:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    raise ParseError(f"an unclosed {opening}{closing} group")
+
+
+def type_body_start(tokens: list[str], start: int) -> int | None:
+    """Find a named struct or enum body after its type name."""
+    paren_depth = 0
+    bracket_depth = 0
+    angle_depth = 0
+    for index in range(start, len(tokens)):
+        token = tokens[index]
+        if token == "(":
+            paren_depth += 1
+        elif token == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif token == "[":
+            bracket_depth += 1
+        elif token == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+        elif token == "<":
+            angle_depth += 1
+        elif token == ">":
+            angle_depth = max(0, angle_depth - 1)
+        elif token == "{" and paren_depth == bracket_depth == angle_depth == 0:
+            return index
+        elif token == ";" and paren_depth == bracket_depth == angle_depth == 0:
+            return None
+    raise ParseError("a type declaration has no body terminator")
+
+
+def top_level_segments(tokens: list[str]) -> list[list[str]]:
+    """Divide one type body at top-level commas."""
+    segments: list[list[str]] = []
+    current: list[str] = []
+    depths = {"(": 0, "[": 0, "{": 0, "<": 0}
+    closing = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens:
+        if token == "," and all(depth == 0 for depth in depths.values()):
+            if current:
+                segments.append(current)
+            current = []
+            continue
+        current.append(token)
+        if token in depths:
+            depths[token] += 1
+        elif token in closing:
+            opener = closing[token]
+            depths[opener] = max(0, depths[opener] - 1)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def strip_prefix(tokens: list[str]) -> list[str]:
+    """Remove field or variant attributes and visibility tokens."""
+    cursor = 0
+    while cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
+        cursor = group_end(tokens, cursor + 1, "[", "]")
+    if cursor < len(tokens) and tokens[cursor] == "pub":
+        cursor += 1
+        if cursor < len(tokens) and tokens[cursor] == "(":
+            cursor = group_end(tokens, cursor, "(", ")")
+    return tokens[cursor:]
+
+
+def named_field_identifiers(body: list[str]) -> list[tuple[str, str]]:
+    """Return named field identifiers from one braced body."""
+    records: list[tuple[str, str]] = []
+    for segment in top_level_segments(body):
+        candidate = strip_prefix(segment)
+        if ":" not in candidate:
+            continue
+        colon = candidate.index(":")
+        names = [token for token in candidate[:colon] if IDENTIFIER.fullmatch(token)]
+        if names:
+            records.append(("field", names[-1]))
+    return records
+
+
+def contract_identifiers(kind: str, body: list[str]) -> list[tuple[str, str]]:
+    """Return field or variant identifiers from one named type body."""
+    if kind == "struct":
+        return named_field_identifiers(body)
+
+    records: list[tuple[str, str]] = []
+    for segment in top_level_segments(body):
+        candidate = strip_prefix(segment)
+        if candidate and IDENTIFIER.fullmatch(candidate[0]):
+            records.append(("variant", candidate[0]))
+            if len(candidate) > 1 and candidate[1] == "{":
+                body_end = group_end(candidate, 1, "{", "}")
+                records.extend(named_field_identifiers(candidate[2 : body_end - 1]))
+    return records
+
+
+def public_types(tokens: list[str]) -> list[tuple[str, str, list[tuple[str, str]]]]:
+    """Return public named structs and enums with their contract identifiers."""
+    records: list[tuple[str, str, list[tuple[str, str]]]] = []
+    cursor = 0
+    public = False
+    while cursor < len(tokens):
+        if cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
+            cursor = group_end(tokens, cursor + 1, "[", "]")
+            continue
+        if tokens[cursor] == "pub":
+            public = True
+            cursor += 1
+            if cursor < len(tokens) and tokens[cursor] == "(":
+                cursor = group_end(tokens, cursor, "(", ")")
+            continue
+        if tokens[cursor] not in {"struct", "enum"}:
+            public = False
+            cursor += 1
+            continue
+        kind = tokens[cursor]
+        if cursor + 1 >= len(tokens) or not IDENTIFIER.fullmatch(tokens[cursor + 1]):
+            raise ParseError(f"a public {kind} has no identifier")
+        name = tokens[cursor + 1]
+        body_start = type_body_start(tokens, cursor + 2)
+        if body_start is None:
+            public = False
+            cursor += 2
+            continue
+        body_end = group_end(tokens, body_start, "{", "}")
+        if public:
+            records.append(
+                (
+                    kind,
+                    name,
+                    contract_identifiers(kind, tokens[body_start + 1 : body_end - 1]),
+                )
+            )
+        public = False
+        cursor = body_end
+    return records
+
+
+def is_production_path(path: Path, source_root: Path) -> bool:
+    """Exclude explicit Rust test modules from a production source scan."""
+    relative = path.relative_to(source_root)
+    return (
+        path.name not in {"tests.rs", "test_support.rs"}
+        and "tests" not in relative.parts
+        and "test_support" not in relative.parts
+    )
+
+
+def read_public_types(
+    path: Path, root: Path
+) -> list[tuple[str, str, list[tuple[str, str]]]] | None:
+    """Read and parse one Rust source file or report a fail-closed error."""
+    try:
+        return public_types(rust_tokens(path.read_text(encoding="utf-8")))
+    except (OSError, UnicodeError, ParseError) as error:
+        report(f"{path.relative_to(root)} cannot be parsed: {error}")
+        return None
+
+
+def check_type_identifiers(
+    path: Path,
+    root: Path,
+    records: list[tuple[str, str, list[tuple[str, str]]]],
+) -> bool:
+    """Reject simulator-specific fields and variants in public shared types."""
+    valid = True
+    relative = path.relative_to(root)
+    for _, type_name, identifiers in records:
+        for kind, identifier in identifiers:
+            if is_forbidden_identifier(identifier):
+                report(
+                    f"{relative} {type_name} has simulator-specific {kind} {identifier}"
+                )
+                valid = False
+    return valid
+
+
+def check_source_root(source_root: Path, root: Path) -> bool:
+    """Check all production Rust files below one shared runtime root."""
+    if not source_root.is_dir():
+        return True
+    valid = True
+    for path in sorted(source_root.rglob("*.rs")):
+        if not is_production_path(path, source_root):
+            continue
+        records = read_public_types(path, root)
+        if records is None:
+            valid = False
+        elif not check_type_identifiers(path, root, records):
+            valid = False
+    return valid
+
+
+def check_campaign_file(path: Path, root: Path) -> bool:
+    """Check classified public contracts in one campaign configuration file."""
+    records = read_public_types(path, root)
+    if records is None:
+        return False
+    valid = True
+    for kind, type_name, identifiers in records:
+        if type_name in CAMPAIGN_ADAPTER_TYPES:
+            continue
+        if type_name not in CAMPAIGN_SHARED_TYPES:
+            report(
+                f"{path.relative_to(root)} has unclassified public campaign contract {type_name}"
+            )
+            valid = False
+        if not check_type_identifiers(path, root, [(kind, type_name, identifiers)]):
+            valid = False
+    return valid
+
+
+def check_campaign_config(root: Path) -> bool:
+    """Check the campaign document and all production configuration modules."""
+    config_file = root / "tools/flight-tune-campaign/src/config.rs"
+    config_root = root / "tools/flight-tune-campaign/src/config"
+    paths: list[Path] = []
+    if config_file.is_file():
+        paths.append(config_file)
+    if config_root.is_dir():
+        paths.extend(
+            path
+            for path in sorted(config_root.rglob("*.rs"))
+            if is_production_path(path, config_root)
+        )
+    valid = True
+    for path in paths:
+        if not check_campaign_file(path, root):
+            valid = False
+    return valid
+
+
+def main() -> int:
+    """Run all simulator-neutral contract checks."""
+    if len(sys.argv) != 2:
+        print("usage: check-flight-tune-contracts.py ROOT", file=sys.stderr)
+        return 2
+    root = Path(sys.argv[1]).resolve()
+    valid = True
+    for manifest in (
+        root / "crates/pilotage-trial/Cargo.toml",
+        root / "tools/flight-tune/Cargo.toml",
+    ):
+        if not check_manifest(manifest, root):
+            valid = False
+    for source_root in (
+        root / "crates/pilotage-trial/src",
+        root / "tools/flight-tune/src",
+    ):
+        if not check_source_root(source_root, root):
+            valid = False
+    if not check_campaign_config(root):
+        valid = False
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -37,6 +37,22 @@ CAMPAIGN_ADAPTER_TYPES = {
     "XPlaneRuntimePluginConfig",
     "AviateCampaignConfig",
 }
+CAMPAIGN_SHARED_IDENTIFIER_ALLOWLIST = frozenset(
+    {
+        (
+            "tools/flight-tune-campaign/src/config.rs",
+            "CampaignConfig",
+            "field",
+            "aviate_xplane_contract",
+        ),
+        (
+            "tools/flight-tune-campaign/src/config.rs",
+            "CampaignConfig",
+            "field",
+            "xplane",
+        ),
+    }
+)
 IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
@@ -60,7 +76,11 @@ def is_forbidden_identifier(identifier: str) -> bool:
     return any(fragment in value for fragment in FORBIDDEN_IDENTIFIERS)
 
 
-def check_manifest(manifest: Path, root: Path) -> bool:
+def check_manifest(
+    manifest: Path,
+    root: Path,
+    allowed_adapter_dependencies: frozenset[str] = frozenset(),
+) -> bool:
     """Use Cargo's resolved dependency view for one neutral package."""
     if not manifest.is_file():
         return True
@@ -105,11 +125,18 @@ def check_manifest(manifest: Path, root: Path) -> bool:
 
     valid = True
     for dependency in package.get("dependencies", []):
-        if (
-            dependency.get("kind") != "dev"
-            and dependency.get("name") in FORBIDDEN_PACKAGES
-        ):
-            report(f"{relative} has runtime dependency {dependency['name']}")
+        name = dependency.get("name")
+        if dependency.get("kind") == "dev" or name not in FORBIDDEN_PACKAGES:
+            continue
+        canonical_adapter_dependency = (
+            name in allowed_adapter_dependencies
+            and dependency.get("rename") is None
+            and dependency.get("kind") is None
+            and dependency.get("optional") is False
+            and dependency.get("target") is None
+        )
+        if not canonical_adapter_dependency:
+            report(f"{relative} has noncanonical runtime dependency {name}")
             valid = False
     return valid
 
@@ -263,8 +290,8 @@ def top_level_segments(tokens: list[str]) -> list[list[str]]:
     """Divide one type body at top-level commas."""
     segments: list[list[str]] = []
     current: list[str] = []
-    depths = {"(": 0, "[": 0, "{": 0, "<": 0}
-    closing = {")": "(", "]": "[", "}": "{", ">": "<"}
+    depths = {"(": 0, "[": 0, "{": 0}
+    closing = {")": "(", "]": "[", "}": "{"}
     for token in tokens:
         if token == "," and all(depth == 0 for depth in depths.values()):
             if current:
@@ -376,6 +403,27 @@ def is_production_path(path: Path, source_root: Path) -> bool:
     )
 
 
+def production_rust_paths(source_root: Path, root: Path) -> tuple[list[Path], bool]:
+    """List production Rust files and reject source-path symlinks."""
+    if source_root.is_symlink():
+        report(f"{source_root.relative_to(root)} production source root is a symlink")
+        return [], False
+    if not source_root.is_dir():
+        return [], True
+
+    valid = True
+    for path in sorted(source_root.rglob("*")):
+        if path.is_symlink() and is_production_path(path, source_root):
+            report(f"{path.relative_to(root)} production source path is a symlink")
+            valid = False
+    paths = [
+        path
+        for path in sorted(source_root.rglob("*.rs"))
+        if not path.is_symlink() and is_production_path(path, source_root)
+    ]
+    return paths, valid
+
+
 def read_public_types(
     path: Path, root: Path
 ) -> list[tuple[str, str, list[tuple[str, str]]]] | None:
@@ -391,13 +439,16 @@ def check_type_identifiers(
     path: Path,
     root: Path,
     records: list[tuple[str, str, list[tuple[str, str]]]],
+    allowed: frozenset[tuple[str, str, str]] = frozenset(),
 ) -> bool:
     """Reject simulator-specific fields and variants in public shared types."""
     valid = True
     relative = path.relative_to(root)
     for _, type_name, identifiers in records:
         for kind, identifier in identifiers:
-            if is_forbidden_identifier(identifier):
+            if (type_name, kind, identifier) not in allowed and is_forbidden_identifier(
+                identifier
+            ):
                 report(
                     f"{relative} {type_name} has simulator-specific {kind} {identifier}"
                 )
@@ -407,12 +458,8 @@ def check_type_identifiers(
 
 def check_source_root(source_root: Path, root: Path) -> bool:
     """Check all production Rust files below one shared runtime root."""
-    if not source_root.is_dir():
-        return True
-    valid = True
-    for path in sorted(source_root.rglob("*.rs")):
-        if not is_production_path(path, source_root):
-            continue
+    paths, valid = production_rust_paths(source_root, root)
+    for path in paths:
         records = read_public_types(path, root)
         if records is None:
             valid = False
@@ -427,6 +474,14 @@ def check_campaign_file(path: Path, root: Path) -> bool:
     if records is None:
         return False
     valid = True
+    relative = path.relative_to(root).as_posix()
+    allowed = frozenset(
+        (type_name, kind, identifier)
+        for allowed_path, type_name, kind, identifier in (
+            CAMPAIGN_SHARED_IDENTIFIER_ALLOWLIST
+        )
+        if allowed_path == relative
+    )
     for kind, type_name, identifiers in records:
         if type_name in CAMPAIGN_ADAPTER_TYPES:
             continue
@@ -435,7 +490,12 @@ def check_campaign_file(path: Path, root: Path) -> bool:
                 f"{path.relative_to(root)} has unclassified public campaign contract {type_name}"
             )
             valid = False
-        if not check_type_identifiers(path, root, [(kind, type_name, identifiers)]):
+        if not check_type_identifiers(
+            path,
+            root,
+            [(kind, type_name, identifiers)],
+            allowed,
+        ):
             valid = False
     return valid
 
@@ -445,15 +505,15 @@ def check_campaign_config(root: Path) -> bool:
     config_file = root / "tools/flight-tune-campaign/src/config.rs"
     config_root = root / "tools/flight-tune-campaign/src/config"
     paths: list[Path] = []
-    if config_file.is_file():
-        paths.append(config_file)
-    if config_root.is_dir():
-        paths.extend(
-            path
-            for path in sorted(config_root.rglob("*.rs"))
-            if is_production_path(path, config_root)
-        )
     valid = True
+    if config_file.is_symlink():
+        report(f"{config_file.relative_to(root)} production source path is a symlink")
+        valid = False
+    elif config_file.is_file():
+        paths.append(config_file)
+    config_paths, config_paths_valid = production_rust_paths(config_root, root)
+    paths.extend(config_paths)
+    valid = valid and config_paths_valid
     for path in paths:
         if not check_campaign_file(path, root):
             valid = False
@@ -467,11 +527,15 @@ def main() -> int:
         return 2
     root = Path(sys.argv[1]).resolve()
     valid = True
-    for manifest in (
-        root / "crates/pilotage-trial/Cargo.toml",
-        root / "tools/flight-tune/Cargo.toml",
+    for manifest, allowed_adapter_dependencies in (
+        (root / "crates/pilotage-trial/Cargo.toml", frozenset()),
+        (root / "tools/flight-tune/Cargo.toml", frozenset()),
+        (
+            root / "tools/flight-tune-aviate/Cargo.toml",
+            frozenset(FORBIDDEN_PACKAGES),
+        ),
     ):
-        if not check_manifest(manifest, root):
+        if not check_manifest(manifest, root, allowed_adapter_dependencies):
             valid = False
     for source_root in (
         root / "crates/pilotage-trial/src",

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import subprocess
 import sys
+import tomllib
+from collections import Counter
 from pathlib import Path
+from typing import Any
 
 FORBIDDEN_PACKAGES = {"flight-tune-xplane", "pilotage-xplane-trial"}
 FORBIDDEN_IDENTIFIERS = (
@@ -31,12 +35,30 @@ CAMPAIGN_SHARED_TYPES = {
     "TrainingGuardScenarioConfig",
     "TrainingSuiteConfig",
 }
-CAMPAIGN_ADAPTER_TYPES = {
-    "XPlaneCampaignConfig",
-    "XPlaneSupportBundleConfig",
-    "XPlaneRuntimePluginConfig",
-    "AviateCampaignConfig",
-}
+CAMPAIGN_ADAPTER_TYPE_ALLOWLIST = frozenset(
+    {
+        ("tools/flight-tune-campaign/src/config.rs", "XPlaneCampaignConfig"),
+        ("tools/flight-tune-campaign/src/config.rs", "XPlaneSupportBundleConfig"),
+        ("tools/flight-tune-campaign/src/config.rs", "XPlaneRuntimePluginConfig"),
+        ("tools/flight-tune-campaign/src/config.rs", "AviateCampaignConfig"),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch/readback.rs",
+            "AviateXPlaneLaunchBinding",
+        ),
+        (
+            "tools/flight-tune-campaign/src/preparation/machine.rs",
+            "XPlaneMachinePaths",
+        ),
+        (
+            "tools/flight-tune-campaign/src/resource_admission/canary.rs",
+            "ResourceXPlaneProducerIdentity",
+        ),
+        (
+            "tools/flight-tune-campaign/src/runtime_launcher/xplane/error.rs",
+            "XPlaneCampaignRuntimeError",
+        ),
+    }
+)
 CAMPAIGN_SHARED_IDENTIFIER_ALLOWLIST = frozenset(
     {
         (
@@ -51,9 +73,589 @@ CAMPAIGN_SHARED_IDENTIFIER_ALLOWLIST = frozenset(
             "field",
             "xplane",
         ),
+        (
+            "tools/flight-tune-campaign/src/config.rs",
+            "CampaignConfig",
+            "field_type:xplane",
+            "XPlaneCampaignConfig",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/error.rs",
+            "DeploymentError",
+            "variant",
+            "XPlaneAttestation",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/error.rs",
+            "DeploymentError",
+            "variant",
+            "XPlaneIdentity",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/graph.rs",
+            "VerifiedDeploymentGraph",
+            "field",
+            "xplane_primary",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/graph.rs",
+            "VerifiedDeploymentGraph",
+            "field",
+            "xplane_support",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch.rs",
+            "ResolvedDeployment",
+            "field",
+            "xplane_runtime",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch.rs",
+            "ResolvedDeployment",
+            "field",
+            "aviate_xplane_binding",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch.rs",
+            "ResolvedDeployment",
+            "field_type:aviate_xplane_binding",
+            "AviateXPlaneLaunchBinding",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/manifest.rs",
+            "DeploymentManifest",
+            "field",
+            "xplane_runtime",
+        ),
+        (
+            "tools/flight-tune-campaign/src/environment.rs",
+            "EnvironmentError",
+            "variant",
+            "XPlane",
+        ),
+        (
+            "tools/flight-tune-campaign/src/environment.rs",
+            "EnvironmentError",
+            "variant",
+            "XPlaneBackend",
+        ),
+        (
+            "tools/flight-tune-campaign/src/error.rs",
+            "CampaignError",
+            "variant",
+            "XPlaneRegistry",
+        ),
+        (
+            "tools/flight-tune-campaign/src/error.rs",
+            "CampaignError",
+            "variant",
+            "XPlaneManifest",
+        ),
+        (
+            "tools/flight-tune-campaign/src/plan.rs",
+            "CampaignPlan",
+            "field",
+            "xplane",
+        ),
+        (
+            "tools/flight-tune-campaign/src/preparation/machine.rs",
+            "CampaignMachinePaths",
+            "field",
+            "xplane",
+        ),
+        (
+            "tools/flight-tune-campaign/src/preparation/machine.rs",
+            "CampaignMachinePaths",
+            "field_type:xplane",
+            "XPlaneMachinePaths",
+        ),
+        (
+            "tools/flight-tune-campaign/src/resource_admission/canary.rs",
+            "ResourceProducerIdentity",
+            "field",
+            "xplane",
+        ),
+        (
+            "tools/flight-tune-campaign/src/resource_admission/canary.rs",
+            "ResourceProducerIdentity",
+            "field_type:xplane",
+            "ResourceXPlaneProducerIdentity",
+        ),
     }
 )
+CAMPAIGN_SIMULATOR_ALIAS_LIMITS = {
+    (
+        "tools/flight-tune-campaign/src/bin/flight_tune_campaign.rs",
+        "CampaignRuntimeError",
+        "XPlaneCampaignRuntimeError",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/bin/flight_tune_campaign_present.rs",
+        "PresentationRuntimeError",
+        "XPlaneCampaignRuntimeError",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/bin/flight_tune_deploy.rs",
+        "DeploymentRuntimeError",
+        "XPlaneCampaignRuntimeError",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/bin/flight_tune_deploy.rs",
+        "PostInstallRuntimeError",
+        "XPlaneCampaignRuntimeError",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/deployment/launch/aviate_xplane.rs",
+        "Running",
+        "AviateXPlaneProcess",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/live.rs",
+        "Backend",
+        "XPlaneTuningBackend",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "Environment",
+        "AviateXPlaneEnvironment",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "Error",
+        "XPlaneCampaignRuntimeError",
+    ): 2,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "Guard",
+        "AviateXPlaneRuntimeGuard",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "VerifiedSession",
+        "VerifiedXPlaneCampaignSession",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "XPlaneLease",
+        "XPlaneCampaignRuntimeGuard",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "XPlaneLease",
+        "XPlaneLease",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+        "XPlaneLease",
+        "XPlaneRuntimePlatform",
+    ): 2,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "Environment",
+        "AviateXPlaneEnvironment",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "Error",
+        "XPlaneCampaignRuntimeError",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "Listener",
+        "XPlaneTrialListener",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "PlatformProbe",
+        "XPlaneProbe",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "PlatformProbe",
+        "XPlaneRuntimePlatform",
+    ): 4,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "Process",
+        "XPlaneProcess",
+    ): 1,
+    (
+        "tools/flight-tune-campaign/src/runtime_launcher/xplane/platform.rs",
+        "Session",
+        "VerifiedXPlaneCampaignSession",
+    ): 1,
+}
+CAMPAIGN_SIMULATOR_PUBLIC_USE_ALLOWLIST = frozenset(
+    {
+        (
+            "tools/flight-tune-campaign/src/deployment.rs",
+            "useexercise::{AviateXPlaneExerciseDomain,DEPLOYMENT_EXERCISE_FINAL_RECEIPT_SCHEMA_VERSION,DEPLOYMENT_EXERCISE_HEAD_SCHEMA_VERSION,DEPLOYMENT_EXERCISE_INTENT_SCHEMA_VERSION,DEPLOYMENT_EXERCISE_PLAN_SCHEMA_VERSION,DEPLOYMENT_EXERCISE_RESULT_SCHEMA_VERSION,DeploymentExercise,DeploymentExerciseActivationRequest,DeploymentExerciseCommandReceipt,DeploymentExerciseDomain,DeploymentExerciseError,DeploymentExerciseExpectedGeneration,DeploymentExerciseFinalReceipt,DeploymentExerciseHead,DeploymentExerciseIntent,DeploymentExerciseLiveState,DeploymentExerciseLiveStateKind,DeploymentExerciseMutationPermit,DeploymentExercisePlan,DeploymentExercisePrepareRequest,DeploymentExerciseResult,DeploymentExerciseRuntimeIdentity,DeploymentExerciseStatus,DeploymentExerciseStep,DeploymentExerciseStepOutcome,PreparedExerciseMutation,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment.rs",
+            "uselaunch::{ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DeploymentRuntimeReadback,ResolvedDeployment,SIMULATOR_LAUNCH_RECEIPT_SCHEMA_VERSION,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,SimulatorLaunchReceipt,VerifiedSimulatorDeployment,publish_simulator_launch_release_blocking,simulator_launch_released_blocking,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment.rs",
+            "uselaunch::{ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DeploymentRuntimeReadback,ResolvedDeployment,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,VerifiedSimulatorDeployment,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/exercise.rs",
+            "usedomain::{AviateXPlaneExerciseDomain,DeploymentExerciseDomain,DeploymentExerciseMutationPermit,PreparedExerciseMutation,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/exercise/domain.rs",
+            "useaviate_xplane::AviateXPlaneExerciseDomain;",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch.rs",
+            "useaviate_xplane::{AviateXPlaneProcess,AviateXPlaneProcessAdapter};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/deployment/launch.rs",
+            "usereadback::{AviateLaunchContract,AviateXPlaneLaunchBinding,DeploymentRuntimeReadback,SimulatorDeploymentReadback,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "useconfig::{AviateCampaignConfig,CAMPAIGN_SCHEMA_VERSION,CampaignBudgetLimit,CampaignConfig,CampaignPurpose,ExecutionTarget,PinnedFile,SearchGroupConfig,SearchGroupKind,TrainingGuardScenarioConfig,TrainingSuiteConfig,XPlaneCampaignConfig,XPlaneRuntimePluginConfig,XPlaneSupportBundleConfig,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "useconfig::{AviateCampaignConfig,CAMPAIGN_SCHEMA_VERSION,CampaignBudgetLimit,CampaignConfig,ExecutionTarget,PinnedFile,SearchGroupConfig,SearchGroupKind,TrainingGuardScenarioConfig,TrainingSuiteConfig,XPlaneCampaignConfig,XPlaneRuntimePluginConfig,XPlaneSupportBundleConfig,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "usedeployment::{ActivationRequest,ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DEPLOYMENT_MUTATION_RECEIPT_SCHEMA_VERSION,DEPLOYMENT_STATUS_SCHEMA_VERSION,DeploymentError,DeploymentInstaller,DeploymentManifest,DeploymentMutation,DeploymentMutationReceipt,DeploymentMutationWorkflowError,DeploymentMutationWorkflowResult,DeploymentObject,DeploymentReceipt,DeploymentRuntimeObject,DeploymentRuntimeReadback,DeploymentState,DeploymentStatusReceipt,LiveAttestationStatus,PostInstallCampaign,PreparedActivation,PreparedRollback,QualifiedDeployment,ResolvedDeployment,SIMULATOR_LAUNCH_RECEIPT_SCHEMA_VERSION,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,SimulatorLaunchReceipt,VerifiedSimulatorDeployment,publish_simulator_launch_release_blocking,release_activation_request_blocking,simulator_launch_released_blocking,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "usedeployment::{ActivationRequest,ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DEPLOYMENT_MUTATION_RECEIPT_SCHEMA_VERSION,DEPLOYMENT_STATUS_SCHEMA_VERSION,DeploymentError,DeploymentInstaller,DeploymentManifest,DeploymentMutation,DeploymentMutationReceipt,DeploymentObject,DeploymentReceipt,DeploymentRuntimeObject,DeploymentRuntimeReadback,DeploymentState,DeploymentStatusReceipt,LiveAttestationStatus,PostInstallCampaign,QualifiedDeployment,ResolvedDeployment,SIMULATOR_LAUNCH_RECEIPT_SCHEMA_VERSION,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,SimulatorLaunchReceipt,VerifiedSimulatorDeployment,publish_simulator_launch_release_blocking,release_activation_request_blocking,simulator_launch_released_blocking,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "usedeployment::{ActivationRequest,ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DEPLOYMENT_MUTATION_RECEIPT_SCHEMA_VERSION,DEPLOYMENT_STATUS_SCHEMA_VERSION,DeploymentError,DeploymentInstaller,DeploymentManifest,DeploymentMutation,DeploymentMutationReceipt,DeploymentObject,DeploymentReceipt,DeploymentRuntimeObject,DeploymentRuntimeReadback,DeploymentState,DeploymentStatusReceipt,LiveAttestationStatus,PostInstallCampaign,QualifiedDeployment,ResolvedDeployment,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,VerifiedSimulatorDeployment,release_activation_request_blocking,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "usedeployment::{ActivationRequest,ActiveDeployment,AviateLaunchContract,AviateXPlaneLaunchBinding,AviateXPlaneProcess,AviateXPlaneProcessAdapter,DeploymentError,DeploymentInstaller,DeploymentManifest,DeploymentObject,DeploymentReceipt,DeploymentRuntimeObject,DeploymentRuntimeReadback,PostInstallCampaign,QualifiedDeployment,ResolvedDeployment,SimulatorDeploymentLauncher,SimulatorDeploymentReadback,SimulatorLaunchAdapter,SimulatorLaunchGate,VerifiedSimulatorDeployment,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "uselive::AviateXPlaneEnvironment;",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "useplan::{AviateRuntimePlan,CAMPAIGN_RUN_BUDGET_SCHEMA_VERSION,CampaignPlan,CampaignRunBudget,LoadedFeelProfile,XPlaneRuntimePlan,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/lib.rs",
+            "usepreparation::{AviateMachinePaths,CAMPAIGN_MACHINE_PATHS_SCHEMA_VERSION,CampaignMachinePaths,PreparedCampaign,TypedMachinePathRenderer,XPlaneMachinePaths,pin_machine_file,prepare_campaign,prepare_campaign_for_machine,prepare_typed_machine_document,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/preparation.rs",
+            "usemachine::{AviateMachinePaths,CAMPAIGN_MACHINE_PATHS_SCHEMA_VERSION,CampaignMachinePaths,XPlaneMachinePaths,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/resource_admission.rs",
+            "usecanary::{RESOURCE_CAPACITY_CANARY_SCHEMA_VERSION,ResourceAviateProducerIdentity,ResourceCapacityCanary,ResourceCapacityCanaryReceipt,ResourceProducerIdentity,ResourceRuntimeIdentity,ResourceXPlaneProducerIdentity,seal_capacity_canary_blocking,verify_capacity_canary_blocking,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/runtime_launcher.rs",
+            "usexplane::{AviateXPlaneEnvironmentLauncher,AviateXPlaneRuntimeGuard,VerifiedXPlaneCampaignSession,XPlaneCampaignRuntimeConfig,XPlaneCampaignRuntimeError,};",
+        ),
+        (
+            "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+            "useconfig::XPlaneCampaignRuntimeConfig;",
+        ),
+        (
+            "tools/flight-tune-campaign/src/runtime_launcher/xplane.rs",
+            "useerror::XPlaneCampaignRuntimeError;",
+        ),
+    }
+)
+CAMPAIGN_SIMULATOR_RESTRICTED_PUBLIC_USE_ALLOWLIST = frozenset(
+    {
+        (
+            "tools/flight-tune-campaign/src/deployment/exercise/domain.rs",
+            "pub(incrate::deployment)",
+            "useaviate_xplane::{execute_exact_qualification_with_factory_blocking,prepare_exact_qualification_restore_blocking,};",
+        ),
+    }
+)
+SHARED_SIMULATOR_SOURCE_DIGESTS = {
+    "tools/flight-tune/src/bin/flight-tune-feedback/feedback/arguments.rs": (
+        "f13cd464fa5057e77c58c52850157ffd65f5743a98a0cbfc2d3c309cb111501d"
+    ),
+}
+MANUAL_SERIALIZATION_SOURCE_DIGESTS = {
+    "crates/pilotage-trial/src/digest.rs": (
+        "05c3468ac925693ff225dff1276c1ed360e107528e603dd4a47156d2a36fbef7"
+    ),
+}
+GENERATED_INCLUDE_ALLOWLIST = {
+    "tools/flight-tune/src/flight_quality/identity.rs": (
+        "include",
+        "!",
+        "(",
+        "concat",
+        "!",
+        "(",
+        "env",
+        "!",
+        "(",
+        '"OUT_DIR"',
+        ")",
+        ",",
+        '"/evaluator_source_identity.rs"',
+        ")",
+        ")",
+    ),
+    "tools/flight-tune-aviate/src/runtime/identity.rs": (
+        "include",
+        "!",
+        "(",
+        "concat",
+        "!",
+        "(",
+        "env",
+        "!",
+        "(",
+        '"OUT_DIR"',
+        ")",
+        ",",
+        '"/runtime_source_identity.rs"',
+        ")",
+        ")",
+    ),
+}
+GENERATED_INCLUDE_INPUTS = {
+    "tools/flight-tune/src/flight_quality/identity.rs": (
+        "tools/flight-tune/build.rs",
+        "tools/flight-tune/build_support/evaluator_source_identity.rs",
+    ),
+    "tools/flight-tune-aviate/src/runtime/identity.rs": (
+        "tools/flight-tune-aviate/build.rs",
+        "tools/flight-tune-aviate/build_support/runtime_source_identity.rs",
+    ),
+}
+GENERATED_INPUT_DIGESTS = {
+    "tools/flight-tune/build.rs": frozenset(
+        {
+            "b56dd4918f6443ceb9804f5e4fb04d464268cb29ebeba76b7dc69a5a07a475cd",
+            "f0424a1bc2c4cc2fe118246db46bd3b912f6c5c5460e487c53285f93629c0aac",
+        }
+    ),
+    "tools/flight-tune/build_support/evaluator_source_identity.rs": frozenset(
+        {"ce2adf92e3954858395151639c9bfd38234debd19157d1eaa94e96c47a223915"}
+    ),
+    "tools/flight-tune-aviate/build.rs": frozenset(
+        {"843c7d7845f1342e41b4fc457654da121d2b22120e0ea3ff5cc3a6c1c1dc23f7"}
+    ),
+    "tools/flight-tune-aviate/build_support/runtime_source_identity.rs": frozenset(
+        {"d29a99fcf0c26af600616584f874171cbbc90b723a37d4c92e6b706c91fd7497"}
+    ),
+}
+GENERATED_BUILD_TARGETS = {
+    "tools/flight-tune/Cargo.toml": (
+        "tools/flight-tune/src/flight_quality/identity.rs",
+        "tools/flight-tune/build.rs",
+    ),
+    "tools/flight-tune-aviate/Cargo.toml": (
+        "tools/flight-tune-aviate/src/runtime/identity.rs",
+        "tools/flight-tune-aviate/build.rs",
+    ),
+}
+TEST_ONLY_MODULE_NAMES = {"tests", "test_support"}
+NON_PRODUCTION_TARGET_KINDS = {"bench", "custom-build", "example", "test"}
+CRATES_IO_SOURCE = "registry+https://github.com/rust-lang/crates.io-index"
+CARGO_LOCK_PACKAGE_ALLOWLIST = frozenset(
+    {
+        (
+            "libc",
+            "0.2.186",
+            CRATES_IO_SOURCE,
+            "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
+        ),
+        (
+            "libm",
+            "0.2.16",
+            CRATES_IO_SOURCE,
+            "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981",
+        ),
+        (
+            "libproc",
+            "0.14.11",
+            CRATES_IO_SOURCE,
+            "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757",
+        ),
+        (
+            "rustix",
+            "1.1.4",
+            CRATES_IO_SOURCE,
+            "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
+        ),
+        (
+            "serde",
+            "1.0.228",
+            CRATES_IO_SOURCE,
+            "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
+        ),
+        (
+            "serde_derive",
+            "1.0.228",
+            CRATES_IO_SOURCE,
+            "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
+        ),
+        (
+            "serde_json",
+            "1.0.150",
+            CRATES_IO_SOURCE,
+            "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
+        ),
+        (
+            "sha2",
+            "0.10.9",
+            CRATES_IO_SOURCE,
+            "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283",
+        ),
+        (
+            "sha2",
+            "0.11.0",
+            CRATES_IO_SOURCE,
+            "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4",
+        ),
+        (
+            "thiserror",
+            "2.0.18",
+            CRATES_IO_SOURCE,
+            "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4",
+        ),
+        (
+            "thiserror-impl",
+            "2.0.18",
+            CRATES_IO_SOURCE,
+            "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5",
+        ),
+        (
+            "tokio",
+            "1.52.3",
+            CRATES_IO_SOURCE,
+            "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
+        ),
+        (
+            "toml",
+            "1.1.4+spec-1.1.0",
+            CRATES_IO_SOURCE,
+            "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5",
+        ),
+        (
+            "tracing",
+            "0.1.44",
+            CRATES_IO_SOURCE,
+            "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
+        ),
+        (
+            "tracing-subscriber",
+            "0.3.23",
+            CRATES_IO_SOURCE,
+            "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319",
+        ),
+    }
+)
+CARGO_LOCK_TRACKED_PACKAGES = frozenset(
+    record[0] for record in CARGO_LOCK_PACKAGE_ALLOWLIST
+)
+CARGO_LOCK_REQUIRED_VERSIONS = {
+    "libc": "0.2.186",
+    "libm": "0.2.16",
+    "libproc": "0.14.11",
+    "rustix": "1.1.4",
+    "serde": "1.0.228",
+    "serde_derive": "1.0.228",
+    "serde_json": "1.0.150",
+    "sha2": "0.10.9",
+    "thiserror": "2.0.18",
+    "thiserror-impl": "2.0.18",
+    "tokio": "1.52.3",
+    "toml": "1.1.4+spec-1.1.0",
+    "tracing": "0.1.44",
+    "tracing-subscriber": "0.3.23",
+}
 IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+GROUP_CLOSINGS = {"(": ")", "[": "]", "{": "}"}
+SAFE_CONTRACT_ATTRIBUTES = {
+    "allow",
+    "cfg",
+    "default",
+    "deprecated",
+    "derive",
+    "doc",
+    "error",
+    "forbid",
+    "from",
+    "ignore",
+    "inline",
+    "must_use",
+    "non_exhaustive",
+    "path",
+    "repr",
+    "serde",
+    "source",
+    "test",
+    "warn",
+}
+SAFE_CONTRACT_DERIVES = {
+    "Clone",
+    "Copy",
+    "Debug",
+    "Default",
+    "Deserialize",
+    "Eq",
+    "Error",
+    "Hash",
+    "Ord",
+    "PartialEq",
+    "PartialOrd",
+    "Serialize",
+}
+SAFE_QUALIFIED_DERIVES = {
+    ("serde", "Deserialize"),
+    ("serde", "Serialize"),
+    ("thiserror", "Error"),
+}
+SAFE_SERDE_OPTIONS = {
+    "content",
+    "default",
+    "deny_unknown_fields",
+    "rename",
+    "rename_all",
+    "serde",
+    "skip",
+    "skip_serializing_if",
+    "tag",
+}
+RUST_SIMPLE_ESCAPES = {
+    "0": "\0",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "\\": "\\",
+    '"': '"',
+    "'": "'",
+}
+DIRECT_DEPENDENCY_ALLOWLIST_HEADER = (
+    "manifest",
+    "dependency_key",
+    "actual_package",
+    "kind",
+    "target",
+    "optional",
+    "source_kind",
+    "source_ref",
+    "default_features",
+    "features",
+    "version_req",
+)
 
 
 class ParseError(Exception):
@@ -76,14 +678,250 @@ def is_forbidden_identifier(identifier: str) -> bool:
     return any(fragment in value for fragment in FORBIDDEN_IDENTIFIERS)
 
 
+def read_direct_dependency_allowlist(
+    root: Path,
+) -> frozenset[tuple[str, ...]] | None:
+    """Read the reviewed direct production dependency baseline."""
+    path = root / "scripts/flight-tune-direct-dependency-allowlist.tsv"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        report(f"direct dependency allowlist cannot be read: {error}")
+        return None
+    if not lines or tuple(lines[0].split("\t")) != DIRECT_DEPENDENCY_ALLOWLIST_HEADER:
+        report("direct dependency allowlist has an invalid header")
+        return None
+    records = [tuple(line.split("\t")) for line in lines[1:]]
+    if any(
+        len(record) != len(DIRECT_DEPENDENCY_ALLOWLIST_HEADER) for record in records
+    ):
+        report("direct dependency allowlist has an invalid record")
+        return None
+    if records != sorted(set(records)):
+        report("direct dependency allowlist is not sorted or has a duplicate")
+        return None
+    return frozenset(records)
+
+
+def check_cargo_source_overrides(root: Path) -> bool:
+    """Reject project-controlled Cargo source substitution routes."""
+    valid = True
+    manifest = root / "Cargo.toml"
+    try:
+        workspace_document = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+        report(f"Cargo.toml cannot be parsed for source overrides: {error}")
+        return False
+    if workspace_document.get("patch") or workspace_document.get("replace"):
+        report("Cargo.toml has an unreviewed dependency source override")
+        valid = False
+    for relative in (".cargo/config", ".cargo/config.toml"):
+        path = root / relative
+        if not path.exists():
+            continue
+        if not is_regular_file_without_symlinks(path, root):
+            report(f"{relative} is not a regular in-workspace Cargo configuration")
+            valid = False
+            continue
+        try:
+            document = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+            report(f"{relative} cannot be parsed for source overrides: {error}")
+            valid = False
+            continue
+        if any(
+            document.get(key)
+            for key in ("include", "patch", "paths", "replace", "source")
+        ):
+            report(f"{relative} has an unreviewed dependency source override")
+            valid = False
+    return valid
+
+
+def check_cargo_lock_packages(root: Path, required_names: set[str]) -> bool:
+    """Bind protected registry dependencies to reviewed lockfile records."""
+    lock_path = root / "Cargo.lock"
+    if not lock_path.exists() and not required_names:
+        return True
+    if not is_regular_file_without_symlinks(lock_path, root):
+        report("Cargo.lock is missing or is not a regular in-workspace file")
+        return False
+    try:
+        document = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+        report(f"Cargo.lock cannot be parsed: {error}")
+        return False
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        report("Cargo.lock has no package records")
+        return False
+
+    valid = True
+    observed_versions: set[tuple[str, str]] = set()
+    for package in packages:
+        if not isinstance(package, dict):
+            report("Cargo.lock has an invalid package record")
+            valid = False
+            continue
+        name = package.get("name")
+        if name not in CARGO_LOCK_TRACKED_PACKAGES:
+            continue
+        record = (
+            name,
+            package.get("version"),
+            package.get("source"),
+            package.get("checksum"),
+        )
+        if record not in CARGO_LOCK_PACKAGE_ALLOWLIST:
+            report(f"Cargo.lock has an unreviewed registry identity for {name}")
+            valid = False
+        elif isinstance(record[1], str):
+            observed_versions.add((name, record[1]))
+    for name in sorted(required_names):
+        version = CARGO_LOCK_REQUIRED_VERSIONS.get(name)
+        if version is None:
+            report(f"Cargo.lock has no reviewed version rule for {name}")
+            valid = False
+        elif (name, version) not in observed_versions:
+            report(f"Cargo.lock has no reviewed registry identity for {name} {version}")
+            valid = False
+    return valid
+
+
+def dependency_record(
+    manifest: Path, dependency: dict[str, Any], root: Path
+) -> tuple[str, ...] | None:
+    """Return the stable identity of one direct Cargo dependency."""
+    name = dependency.get("name")
+    rename = dependency.get("rename")
+    kind_value = dependency.get("kind")
+    target_value = dependency.get("target")
+    optional = dependency.get("optional")
+    default_features = dependency.get("uses_default_features")
+    features = dependency.get("features")
+    version_req = dependency.get("req")
+    if not (
+        isinstance(name, str)
+        and (rename is None or isinstance(rename, str))
+        and (kind_value is None or isinstance(kind_value, str))
+        and (target_value is None or isinstance(target_value, str))
+        and isinstance(optional, bool)
+        and isinstance(default_features, bool)
+        and isinstance(features, list)
+        and all(isinstance(feature, str) for feature in features)
+        and isinstance(version_req, str)
+    ):
+        report(f"{manifest.relative_to(root)} has incomplete dependency metadata")
+        return None
+    source = dependency.get("source")
+    dependency_path = dependency.get("path")
+    if isinstance(source, str):
+        source_kind = "source"
+        source_ref = source
+    elif isinstance(dependency_path, str):
+        source_kind = "path"
+        resolved_path = Path(dependency_path).resolve()
+        try:
+            source_ref = resolved_path.relative_to(root.resolve()).as_posix()
+        except ValueError:
+            source_ref = resolved_path.as_posix()
+    else:
+        report(f"{manifest.relative_to(root)} has a dependency without a source")
+        return None
+    return (
+        manifest.relative_to(root).as_posix(),
+        rename if rename is not None else name,
+        name,
+        "normal" if kind_value is None else kind_value,
+        "" if target_value is None else target_value,
+        str(optional).lower(),
+        source_kind,
+        source_ref,
+        str(default_features).lower(),
+        ",".join(sorted(features)),
+        version_req,
+    )
+
+
+def target_kinds(target: dict[str, Any]) -> set[str]:
+    """Return the declared Cargo kinds for one target."""
+    kinds = target.get("kind", [])
+    return {kind for kind in kinds if isinstance(kind, str)}
+
+
+def check_package_targets(package: dict[str, Any], manifest: Path, root: Path) -> bool:
+    """Bind production Cargo targets to the source paths that the guard scans."""
+    valid = True
+    source_root = manifest.parent / "src"
+    targets = [
+        target for target in package.get("targets", []) if isinstance(target, dict)
+    ]
+    for target in targets:
+        kinds = target_kinds(target)
+        if not kinds:
+            report(f"{manifest.relative_to(root)} has a target without a kind")
+            valid = False
+            continue
+        if kinds.issubset(NON_PRODUCTION_TARGET_KINDS):
+            continue
+        source_value = target.get("src_path")
+        if not isinstance(source_value, str):
+            report(f"{manifest.relative_to(root)} has a target without a source path")
+            valid = False
+            continue
+        source = Path(source_value)
+        if not path_is_within(source, source_root) or not is_production_path(
+            source, source_root
+        ):
+            report(
+                f"{manifest.relative_to(root)} has a production target outside its scanned source root"
+            )
+            valid = False
+        elif not is_regular_file_without_symlinks(source, root):
+            report(f"{manifest.relative_to(root)} has an unsafe production target path")
+            valid = False
+
+    relative = manifest.relative_to(root).as_posix()
+    generated_target = GENERATED_BUILD_TARGETS.get(relative)
+    custom_builds = [
+        target for target in targets if "custom-build" in target_kinds(target)
+    ]
+    if generated_target is None:
+        if custom_builds:
+            report(
+                f"{manifest.relative_to(root)} has an unreviewed custom build target"
+            )
+            valid = False
+        return valid
+    generated_artifacts = (
+        generated_target[0],
+        *GENERATED_INCLUDE_INPUTS.get(generated_target[0], ()),
+    )
+    if not custom_builds and not any(
+        (root / artifact).exists() for artifact in generated_artifacts
+    ):
+        return valid
+    expected_build = (root / generated_target[1]).resolve()
+    actual_builds = {
+        Path(build_source).resolve()
+        for target in custom_builds
+        if isinstance((build_source := target.get("src_path")), str)
+    }
+    if actual_builds != {expected_build}:
+        report(f"{manifest.relative_to(root)} has an unreviewed custom build target")
+        valid = False
+    return valid
+
+
 def check_manifest(
     manifest: Path,
     root: Path,
+    direct_dependency_allowlist: frozenset[tuple[str, ...]],
     allowed_adapter_dependencies: frozenset[str] = frozenset(),
-) -> bool:
+) -> tuple[bool, set[str]]:
     """Use Cargo's resolved dependency view for one neutral package."""
     if not manifest.is_file():
-        return True
+        return True, set()
     result = subprocess.run(
         [
             "cargo",
@@ -97,18 +935,19 @@ def check_manifest(
         check=False,
         capture_output=True,
         text=True,
+        cwd=root,
     )
     relative = manifest.relative_to(root)
     if result.returncode != 0:
         detail = result.stderr.strip().splitlines()
         suffix = f": {detail[-1]}" if detail else ""
         report(f"{relative} cargo metadata failed{suffix}")
-        return False
+        return False, set()
     try:
         metadata = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         report(f"{relative} cargo metadata is not valid JSON: {error}")
-        return False
+        return False, set()
 
     resolved = manifest.resolve()
     package = next(
@@ -121,12 +960,38 @@ def check_manifest(
     )
     if package is None:
         report(f"{relative} is absent from cargo metadata")
-        return False
+        return False, set()
 
-    valid = True
+    valid = check_package_targets(package, manifest, root)
+    registry_names: set[str] = set()
     for dependency in package.get("dependencies", []):
         name = dependency.get("name")
-        if dependency.get("kind") == "dev" or name not in FORBIDDEN_PACKAGES:
+        rename = dependency.get("rename")
+        if rename in {"serde", "thiserror"} and rename != name:
+            report(f"{relative} aliases dependency {name} as protected crate {rename}")
+            valid = False
+        if name in {"serde", "thiserror"} and rename is not None:
+            report(f"{relative} renames protected dependency {name}")
+            valid = False
+        if dependency.get("kind") == "dev":
+            continue
+        record = dependency_record(manifest, dependency, root)
+        if record is None:
+            valid = False
+        else:
+            if record[6] == "source":
+                registry_names.add(record[2])
+                if record[2] == "serde" and "derive" in record[9].split(","):
+                    registry_names.add("serde_derive")
+                if record[2] == "thiserror":
+                    registry_names.add("thiserror-impl")
+            if record not in direct_dependency_allowlist:
+                dependency_key = record[1]
+                report(
+                    f"{relative} has unreviewed direct production dependency {dependency_key}"
+                )
+                valid = False
+        if name not in FORBIDDEN_PACKAGES:
             continue
         canonical_adapter_dependency = (
             name in allowed_adapter_dependencies
@@ -138,7 +1003,7 @@ def check_manifest(
         if not canonical_adapter_dependency:
             report(f"{relative} has noncanonical runtime dependency {name}")
             valid = False
-    return valid
+    return valid, registry_names
 
 
 def raw_string_end(source: str, start: int) -> int | None:
@@ -193,8 +1058,8 @@ def character_end(source: str, start: int) -> int | None:
     return None
 
 
-def rust_tokens(source: str) -> list[str]:
-    """Return Rust identifier and punctuation tokens without comments or literals."""
+def rust_tokens(source: str, *, keep_literals: bool = False) -> list[str]:
+    """Return Rust identifier and punctuation tokens without comments."""
     tokens: list[str] = []
     cursor = 0
     while cursor < len(source):
@@ -222,10 +1087,15 @@ def rust_tokens(source: str) -> list[str]:
             continue
         raw_end = raw_string_end(source, cursor)
         if raw_end is not None:
+            if keep_literals:
+                tokens.append(source[cursor:raw_end])
             cursor = raw_end
             continue
         if source[cursor] == '"':
-            cursor = quoted_end(source, cursor, '"')
+            string_end = quoted_end(source, cursor, '"')
+            if keep_literals:
+                tokens.append(source[cursor:string_end])
+            cursor = string_end
             continue
         if source[cursor] == "'":
             character_literal_end = character_end(source, cursor)
@@ -260,13 +1130,40 @@ def group_end(tokens: list[str], start: int, opening: str, closing: str) -> int:
     raise ParseError(f"an unclosed {opening}{closing} group")
 
 
-def type_body_start(tokens: list[str], start: int) -> int | None:
-    """Find a named struct or enum body after its type name."""
+def statement_end(tokens: list[str], start: int) -> int:
+    """Return the token after one top-level semicolon."""
+    depths = {"(": 0, "[": 0, "{": 0}
+    closing = {
+        ")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    for index in range(start, len(tokens)):
+        token = tokens[index]
+        if token == ";" and all(depth == 0 for depth in depths.values()):
+            return index + 1
+        if token in depths:
+            depths[token] += 1
+        elif token in closing:
+            opener = closing[token]
+            depths[opener] = max(0, depths[opener] - 1)
+    return len(tokens)
+
+
+def type_body_start(tokens: list[str], start: int) -> tuple[int, str] | None:
+    """Find a braced or tuple body after one named type."""
     paren_depth = 0
     bracket_depth = 0
     angle_depth = 0
+    has_where_clause = False
     for index in range(start, len(tokens)):
         token = tokens[index]
+        if (
+            token == "("
+            and paren_depth == bracket_depth == angle_depth == 0
+            and not has_where_clause
+        ):
+            return index, "("
         if token == "(":
             paren_depth += 1
         elif token == ")":
@@ -279,10 +1176,12 @@ def type_body_start(tokens: list[str], start: int) -> int | None:
             angle_depth += 1
         elif token == ">":
             angle_depth = max(0, angle_depth - 1)
+        elif token == "where" and paren_depth == bracket_depth == angle_depth == 0:
+            has_where_clause = True
         elif token == "{" and paren_depth == bracket_depth == angle_depth == 0:
-            return index
+            return index, "{"
         elif token == ";" and paren_depth == bracket_depth == angle_depth == 0:
-            return None
+            return index, ";"
     raise ParseError("a type declaration has no body terminator")
 
 
@@ -321,7 +1220,9 @@ def strip_prefix(tokens: list[str]) -> list[str]:
     return tokens[cursor:]
 
 
-def named_field_identifiers(body: list[str]) -> list[tuple[str, str]]:
+def named_field_identifiers(
+    body: list[str], context_prefix: str = ""
+) -> list[tuple[str, str]]:
     """Return named field identifiers from one braced body."""
     records: list[tuple[str, str]] = []
     for segment in top_level_segments(body):
@@ -331,34 +1232,98 @@ def named_field_identifiers(body: list[str]) -> list[tuple[str, str]]:
         colon = candidate.index(":")
         names = [token for token in candidate[:colon] if IDENTIFIER.fullmatch(token)]
         if names:
-            records.append(("field", names[-1]))
+            name = names[-1]
+            records.append(("field", name))
+            records.extend(
+                simulator_type_identifiers(
+                    candidate[colon + 1 :], f"field_type:{context_prefix}{name}"
+                )
+            )
     return records
 
 
-def contract_identifiers(kind: str, body: list[str]) -> list[tuple[str, str]]:
+def simulator_type_identifiers(
+    tokens: list[str], context: str
+) -> list[tuple[str, str]]:
+    """Return simulator-specific identifiers from one contract type context."""
+    return [
+        (context, token)
+        for token in tokens
+        if IDENTIFIER.fullmatch(token) and is_forbidden_identifier(token)
+    ]
+
+
+def tuple_field_identifiers(
+    body: list[str], context_prefix: str
+) -> list[tuple[str, str]]:
+    """Return simulator-specific type identifiers from tuple fields."""
+    records: list[tuple[str, str]] = []
+    for index, segment in enumerate(top_level_segments(body)):
+        records.extend(
+            simulator_type_identifiers(
+                strip_prefix(segment), f"{context_prefix}:{index}"
+            )
+        )
+    return records
+
+
+def contract_identifiers(
+    kind: str, body: list[str], opening: str
+) -> list[tuple[str, str]]:
     """Return field or variant identifiers from one named type body."""
     if kind == "struct":
-        return named_field_identifiers(body)
+        return (
+            named_field_identifiers(body)
+            if opening == "{"
+            else tuple_field_identifiers(body, "tuple_field_type")
+        )
 
     records: list[tuple[str, str]] = []
     for segment in top_level_segments(body):
         candidate = strip_prefix(segment)
         if candidate and IDENTIFIER.fullmatch(candidate[0]):
-            records.append(("variant", candidate[0]))
+            variant = candidate[0]
+            records.append(("variant", variant))
             if len(candidate) > 1 and candidate[1] == "{":
                 body_end = group_end(candidate, 1, "{", "}")
-                records.extend(named_field_identifiers(candidate[2 : body_end - 1]))
+                records.extend(
+                    named_field_identifiers(candidate[2 : body_end - 1], f"{variant}.")
+                )
+            elif len(candidate) > 1 and candidate[1] == "(":
+                body_end = group_end(candidate, 1, "(", ")")
+                records.extend(
+                    tuple_field_identifiers(
+                        candidate[2 : body_end - 1], f"variant_type:{variant}"
+                    )
+                )
     return records
 
 
-def public_types(tokens: list[str]) -> list[tuple[str, str, list[tuple[str, str]]]]:
+def derives_serialization(attributes: list[list[str]]) -> bool:
+    """Return true when one attribute set derives a Serde contract."""
+    for attribute in attributes:
+        if len(attribute) < 4 or attribute[0:2] != ["derive", "("]:
+            continue
+        for segment in top_level_segments(attribute[2:-1]):
+            derive = derive_path(segment)
+            if derive is not None and derive[-1] in {"Deserialize", "Serialize"}:
+                return True
+    return False
+
+
+def public_types(
+    tokens: list[str],
+) -> list[tuple[str, str, list[tuple[str, str]], bool]]:
     """Return public named structs and enums with their contract identifiers."""
-    records: list[tuple[str, str, list[tuple[str, str]]]] = []
+    records: list[tuple[str, str, list[tuple[str, str]], bool]] = []
     cursor = 0
     public = False
+    attributes: list[list[str]] = []
     while cursor < len(tokens):
         if cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
-            cursor = group_end(tokens, cursor + 1, "[", "]")
+            end = group_end(tokens, cursor + 1, "[", "]")
+            attributes.append(tokens[cursor + 2 : end - 1])
+            cursor = end
             continue
         if tokens[cursor] == "pub":
             public = True
@@ -368,28 +1333,50 @@ def public_types(tokens: list[str]) -> list[tuple[str, str, list[tuple[str, str]
             continue
         if tokens[cursor] not in {"struct", "enum"}:
             public = False
+            attributes = []
             cursor += 1
             continue
         kind = tokens[cursor]
         if cursor + 1 >= len(tokens) or not IDENTIFIER.fullmatch(tokens[cursor + 1]):
             raise ParseError(f"a public {kind} has no identifier")
         name = tokens[cursor + 1]
-        body_start = type_body_start(tokens, cursor + 2)
-        if body_start is None:
+        body = type_body_start(tokens, cursor + 2)
+        if body is None:
             public = False
             cursor += 2
             continue
-        body_end = group_end(tokens, body_start, "{", "}")
+        body_start, opening = body
+        if opening == ";":
+            body_end = body_start + 1
+            body_identifiers: list[tuple[str, str]] = []
+            declaration_end = body_end
+            tail: list[str] = []
+        else:
+            closing = GROUP_CLOSINGS[opening]
+            body_end = group_end(tokens, body_start, opening, closing)
+            body_identifiers = contract_identifiers(
+                kind, tokens[body_start + 1 : body_end - 1], opening
+            )
+            declaration_end = (
+                statement_end(tokens, body_end) if opening == "(" else body_end
+            )
+            tail = tokens[body_end : declaration_end - 1]
         if public:
+            identifiers = simulator_type_identifiers(
+                tokens[cursor + 2 : body_start] + tail, "header_type"
+            )
+            identifiers.extend(body_identifiers)
             records.append(
                 (
                     kind,
                     name,
-                    contract_identifiers(kind, tokens[body_start + 1 : body_end - 1]),
+                    identifiers,
+                    derives_serialization(attributes),
                 )
             )
         public = False
-        cursor = body_end
+        attributes = []
+        cursor = declaration_end
     return records
 
 
@@ -400,6 +1387,641 @@ def is_production_path(path: Path, source_root: Path) -> bool:
         path.name not in {"tests.rs", "test_support.rs"}
         and "tests" not in relative.parts
         and "test_support" not in relative.parts
+    )
+
+
+def cfg_expression_requires_test(tokens: list[str]) -> bool:
+    """Return true when one cfg expression cannot select a non-test build."""
+    if tokens == ["test"]:
+        return True
+    if len(tokens) < 3 or tokens[1] != "(" or tokens[-1] != ")":
+        return False
+    arguments = top_level_segments(tokens[2:-1])
+    if tokens[0] == "all":
+        return any(cfg_expression_requires_test(argument) for argument in arguments)
+    if tokens[0] == "any":
+        return bool(arguments) and all(
+            cfg_expression_requires_test(argument) for argument in arguments
+        )
+    return False
+
+
+def attributes_require_test(attributes: list[list[str]]) -> bool:
+    """Return true when one item has a cfg attribute that requires test."""
+    for attribute in attributes:
+        if (
+            len(attribute) >= 4
+            and attribute[0:2] == ["cfg", "("]
+            and attribute[-1] == ")"
+            and cfg_expression_requires_test(attribute[2:-1])
+        ):
+            return True
+    return False
+
+
+def raw_rust_string_value(token: str) -> str | None:
+    """Decode a Rust raw string or raw byte string."""
+    if token.startswith("br"):
+        cursor = 2
+    elif token.startswith("r"):
+        cursor = 1
+    else:
+        return None
+    hashes = 0
+    while cursor < len(token) and token[cursor] == "#":
+        hashes += 1
+        cursor += 1
+    if cursor >= len(token) or token[cursor] != '"':
+        return None
+    terminator = '"' + ("#" * hashes)
+    if not token.endswith(terminator):
+        return None
+    return token[cursor + 1 : -len(terminator)]
+
+
+def rust_unicode_escape(content: str, start: int) -> tuple[str, int] | None:
+    """Decode one Rust Unicode escape after its opening brace."""
+    end = content.find("}", start)
+    if end < 0:
+        return None
+    digits = content[start:end].replace("_", "")
+    if not digits or len(digits) > 6 or re.fullmatch(r"[0-9A-Fa-f]+", digits) is None:
+        return None
+    value = int(digits, 16)
+    if value > 0x10FFFF or 0xD800 <= value <= 0xDFFF:
+        return None
+    return chr(value), end + 1
+
+
+def escaped_rust_string_value(content: str) -> str | None:
+    """Decode the escape forms that Rust permits in a string literal."""
+    value: list[str] = []
+    cursor = 0
+    while cursor < len(content):
+        if content[cursor] != "\\":
+            value.append(content[cursor])
+            cursor += 1
+            continue
+        cursor += 1
+        if cursor >= len(content):
+            return None
+        escape = content[cursor]
+        if escape in RUST_SIMPLE_ESCAPES:
+            value.append(RUST_SIMPLE_ESCAPES[escape])
+            cursor += 1
+        elif escape == "x" and re.fullmatch(
+            r"[0-9A-Fa-f]{2}", content[cursor + 1 : cursor + 3]
+        ):
+            value.append(chr(int(content[cursor + 1 : cursor + 3], 16)))
+            cursor += 3
+        elif escape == "u" and content[cursor + 1 : cursor + 2] == "{":
+            decoded = rust_unicode_escape(content, cursor + 2)
+            if decoded is None:
+                return None
+            character, cursor = decoded
+            value.append(character)
+        elif escape == "\n":
+            cursor += 1
+            while cursor < len(content) and content[cursor].isspace():
+                cursor += 1
+        else:
+            return None
+    return "".join(value)
+
+
+def rust_string_value(token: str) -> str | None:
+    """Decode a Rust string or byte string literal."""
+    raw_value = raw_rust_string_value(token)
+    if raw_value is not None:
+        return raw_value
+    literal = token[1:] if token.startswith(('b"', 'c"')) else token
+    if len(literal) < 2 or not literal.startswith('"') or not literal.endswith('"'):
+        return None
+    return escaped_rust_string_value(literal[1:-1])
+
+
+def path_attribute_value(attributes: list[list[str]]) -> str | None:
+    """Return the path from one Rust path attribute."""
+    for attribute in attributes:
+        if len(attribute) == 3 and attribute[0:2] == ["path", "="]:
+            return rust_string_value(attribute[2])
+    return None
+
+
+def item_attributes(tokens: list[str], start: int) -> tuple[list[list[str]], int]:
+    """Read consecutive outer attributes before one Rust item."""
+    attributes: list[list[str]] = []
+    cursor = start
+    while cursor + 1 < len(tokens) and tokens[cursor : cursor + 2] == ["#", "["]:
+        end = group_end(tokens, cursor + 1, "[", "]")
+        attributes.append(tokens[cursor + 2 : end - 1])
+        cursor = end
+    return attributes, cursor
+
+
+def attribute_at(tokens: list[str], start: int) -> tuple[list[str], int] | None:
+    """Return one outer or inner Rust attribute at a token offset."""
+    if tokens[start : start + 2] == ["#", "["]:
+        bracket = start + 1
+    elif tokens[start : start + 3] == ["#", "!", "["]:
+        bracket = start + 2
+    else:
+        return None
+    end = group_end(tokens, bracket, "[", "]")
+    return tokens[bracket + 1 : end - 1], end
+
+
+def derive_path(segment: list[str]) -> tuple[str, ...] | None:
+    """Return one simple or qualified derive path."""
+    if not segment or not IDENTIFIER.fullmatch(segment[0]):
+        return None
+    identifiers = [segment[0]]
+    cursor = 1
+    while cursor < len(segment):
+        if (
+            cursor + 2 >= len(segment)
+            or segment[cursor : cursor + 2] != [":", ":"]
+            or not IDENTIFIER.fullmatch(segment[cursor + 2])
+        ):
+            return None
+        identifiers.append(segment[cursor + 2])
+        cursor += 3
+    return tuple(identifiers)
+
+
+def check_derive_attribute(path: Path, root: Path, attribute: list[str]) -> bool:
+    """Reject a derive macro outside the frozen safe set."""
+    if len(attribute) < 4 or attribute[1] != "(" or attribute[-1] != ")":
+        report(f"{path.relative_to(root)} has an unsupported derive attribute")
+        return False
+    valid = True
+    for segment in top_level_segments(attribute[2:-1]):
+        derive = derive_path(segment)
+        allowed = derive in SAFE_QUALIFIED_DERIVES or (
+            derive is not None
+            and len(derive) == 1
+            and derive[0] in SAFE_CONTRACT_DERIVES
+        )
+        if not allowed:
+            name = "::".join(derive) if derive is not None else "unsupported"
+            report(f"{path.relative_to(root)} has an unreviewed derive macro {name}")
+            valid = False
+    return valid
+
+
+def check_serde_attribute(path: Path, root: Path, attribute: list[str]) -> bool:
+    """Reject a simulator-specific serialized name in one Serde attribute."""
+    options = {
+        token for token in attribute if IDENTIFIER.fullmatch(token)
+    } - SAFE_SERDE_OPTIONS
+    if options:
+        report(
+            f"{path.relative_to(root)} has an unreviewed Serde option {min(options)}"
+        )
+        return False
+    for token in attribute:
+        literal = rust_string_value(token)
+        if literal is None:
+            continue
+        for fragment in FORBIDDEN_IDENTIFIERS:
+            if fragment in normalized(literal):
+                report(
+                    f"{path.relative_to(root)} has a simulator-specific Serde name {fragment}"
+                )
+                return False
+    return True
+
+
+def check_contract_attributes(path: Path, root: Path, tokens: list[str]) -> bool:
+    """Reject a procedural attribute that can hide a shared contract."""
+    valid = True
+    cursor = 0
+    while cursor < len(tokens):
+        parsed = attribute_at(tokens, cursor)
+        if parsed is None:
+            cursor += 1
+            continue
+        attribute, cursor = parsed
+        name = attribute[0] if attribute else "empty"
+        if name not in SAFE_CONTRACT_ATTRIBUTES:
+            report(
+                f"{path.relative_to(root)} has an unreviewed contract attribute {name}"
+            )
+            valid = False
+        elif name == "derive" and not check_derive_attribute(path, root, attribute):
+            valid = False
+        elif name == "serde" and not check_serde_attribute(path, root, attribute):
+            valid = False
+    if not check_protected_macro_imports(path, root, tokens):
+        valid = False
+    if has_manual_serialization_impl(tokens):
+        relative = path.relative_to(root).as_posix()
+        try:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError as error:
+            report(f"{path.relative_to(root)} cannot be hashed: {error}")
+            return False
+        if MANUAL_SERIALIZATION_SOURCE_DIGESTS.get(relative) != digest:
+            report(f"{path.relative_to(root)} has an unreviewed manual Serde impl")
+            valid = False
+    return valid
+
+
+def unqualified_derives(tokens: list[str]) -> set[str]:
+    """Return each unqualified derive macro name in one Rust source."""
+    derives: set[str] = set()
+    cursor = 0
+    while cursor < len(tokens):
+        parsed = attribute_at(tokens, cursor)
+        if parsed is None:
+            cursor += 1
+            continue
+        attribute, cursor = parsed
+        if not attribute or attribute[0] != "derive" or len(attribute) < 4:
+            continue
+        for segment in top_level_segments(attribute[2:-1]):
+            derive = derive_path(segment)
+            if derive is not None and len(derive) == 1:
+                derives.add(derive[0])
+    return derives
+
+
+def check_protected_macro_imports(path: Path, root: Path, tokens: list[str]) -> bool:
+    """Bind unqualified Serde and thiserror derives to their canonical crates."""
+    required = unqualified_derives(tokens).intersection(
+        {"Serialize", "Deserialize", "Error"}
+    )
+    canonical_imports: set[str] = set()
+    valid = True
+    cursor = 0
+    while cursor < len(tokens):
+        if tokens[cursor] != "use":
+            cursor += 1
+            continue
+        try:
+            end = tokens.index(";", cursor + 1)
+        except ValueError:
+            end = len(tokens)
+        statement = tokens[cursor + 1 : end]
+        root_name = next(
+            (token for token in statement if IDENTIFIER.fullmatch(token)), None
+        )
+        protected = {"Serialize", "Deserialize", "Error"}.intersection(statement)
+        if "as" in statement and (protected or root_name in {"serde", "thiserror"}):
+            report(f"{path.relative_to(root)} aliases a protected derive import")
+            valid = False
+        for name in protected.intersection({"Serialize", "Deserialize"}):
+            if root_name == "serde":
+                canonical_imports.add(name)
+            else:
+                report(
+                    f"{path.relative_to(root)} imports protected derive {name} from a noncanonical crate"
+                )
+                valid = False
+        if "Error" in protected and "Error" in required:
+            if root_name == "thiserror":
+                canonical_imports.add("Error")
+            else:
+                report(
+                    f"{path.relative_to(root)} imports protected derive Error from a noncanonical crate"
+                )
+                valid = False
+        cursor = end + 1
+    for name in sorted(required - canonical_imports):
+        report(
+            f"{path.relative_to(root)} uses unqualified derive {name} without its canonical import"
+        )
+        valid = False
+    return valid
+
+
+def has_manual_serialization_impl(tokens: list[str]) -> bool:
+    """Return true when source implements Serialize or Deserialize by hand."""
+    cursor = 0
+    while cursor < len(tokens):
+        if tokens[cursor] != "impl":
+            cursor += 1
+            continue
+        end = item_end(tokens, cursor, len(tokens))
+        header = tokens[cursor:end]
+        body = header.index("{") if "{" in header else len(header)
+        before_body = header[:body]
+        if "for" in before_body:
+            trait = before_body[: before_body.index("for")]
+            if "Serialize" in trait or "Deserialize" in trait:
+                return True
+        if any(
+            header[index : index + 2] in (["fn", "serialize"], ["fn", "deserialize"])
+            for index in range(len(header) - 1)
+        ):
+            return True
+        cursor = end
+    return False
+
+
+def item_after_visibility(tokens: list[str], start: int) -> int:
+    """Return the first token after an optional visibility qualifier."""
+    cursor = start
+    if cursor < len(tokens) and tokens[cursor] == "pub":
+        cursor += 1
+        if cursor < len(tokens) and tokens[cursor] == "(":
+            cursor = group_end(tokens, cursor, "(", ")")
+    return cursor
+
+
+def macro_invocation_at(
+    tokens: list[str], start: int
+) -> tuple[str, tuple[str, ...], int] | None:
+    """Return one function-like macro invocation at an item start."""
+    cursor = start
+    if tokens[cursor : cursor + 2] == [":", ":"]:
+        cursor += 2
+    if cursor >= len(tokens) or not IDENTIFIER.fullmatch(tokens[cursor]):
+        return None
+    macro_name = tokens[cursor]
+    cursor += 1
+    while (
+        cursor + 2 < len(tokens)
+        and tokens[cursor : cursor + 2] == [":", ":"]
+        and IDENTIFIER.fullmatch(tokens[cursor + 2])
+    ):
+        macro_name = tokens[cursor + 2]
+        cursor += 3
+    if (
+        cursor + 1 >= len(tokens)
+        or tokens[cursor] != "!"
+        or tokens[cursor + 1] not in GROUP_CLOSINGS
+    ):
+        return None
+    opening = tokens[cursor + 1]
+    end = group_end(tokens, cursor + 1, opening, GROUP_CLOSINGS[opening])
+    return macro_name, tuple(tokens[start:end]), end
+
+
+def item_end(tokens: list[str], start: int, limit: int) -> int:
+    """Return the end of one item without entering its body."""
+    cursor = start
+    while cursor < limit:
+        token = tokens[cursor]
+        if token in {"(", "["}:
+            cursor = group_end(tokens, cursor, token, GROUP_CLOSINGS[token])
+        elif token == "{":
+            return group_end(tokens, cursor, "{", "}")
+        elif token == ";":
+            return cursor + 1
+        else:
+            cursor += 1
+    return limit
+
+
+def inline_module_body(
+    tokens: list[str], start: int, limit: int
+) -> tuple[int, int, int] | None:
+    """Return the body limits and item end for one inline module."""
+    if start + 1 >= limit or tokens[start] != "mod":
+        return None
+    cursor = start + 2
+    while cursor < limit:
+        if tokens[cursor] == ";":
+            return None
+        if tokens[cursor] == "{":
+            end = group_end(tokens, cursor, "{", "}")
+            return cursor + 1, end - 1, end
+        cursor += 1
+    return None
+
+
+def check_item_macros(
+    path: Path, root: Path, tokens: list[str]
+) -> tuple[bool, frozenset[int]]:
+    """Reject macros that can create hidden production contracts."""
+    relative = path.relative_to(root).as_posix()
+    approved_generated_includes: set[int] = set()
+
+    def check_items(start: int, limit: int, allow_generated_include: bool) -> bool:
+        valid = True
+        cursor = start
+        while cursor < limit:
+            attributes, item_start = item_attributes(tokens, cursor)
+            item_start = item_after_visibility(tokens, item_start)
+            if item_start >= limit:
+                break
+            if (
+                tokens[item_start : item_start + 2] == ["macro_rules", "!"]
+                or tokens[item_start] == "macro"
+            ):
+                report(f"{path.relative_to(root)} has a production macro definition")
+                valid = False
+            invocation = macro_invocation_at(tokens, item_start)
+            if invocation is not None:
+                macro_name, invocation_tokens, end = invocation
+                allowed = GENERATED_INCLUDE_ALLOWLIST.get(relative)
+                if (
+                    not allow_generated_include
+                    or attributes
+                    or allowed != invocation_tokens
+                ):
+                    report(
+                        f"{path.relative_to(root)} has an unreviewed item macro {macro_name}"
+                    )
+                    valid = False
+                else:
+                    approved_generated_includes.add(item_start)
+                cursor = end
+                continue
+            module_body = inline_module_body(tokens, item_start, limit)
+            if module_body is not None:
+                body_start, body_end, end = module_body
+                if not check_items(body_start, body_end, False):
+                    valid = False
+                cursor = end
+                continue
+            cursor = item_end(tokens, item_start, limit)
+        return valid
+
+    return check_items(0, len(tokens), True), frozenset(approved_generated_includes)
+
+
+def path_is_within(path: Path, root: Path) -> bool:
+    """Return true when one resolved path stays below a resolved root."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def is_regular_file_without_symlinks(path: Path, root: Path) -> bool:
+    """Return true for one regular in-root file with no symlink component."""
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    cursor = root
+    if cursor.is_symlink():
+        return False
+    for part in relative.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            return False
+    return path.is_file() and path_is_within(path.resolve(), root.resolve())
+
+
+def check_module_source_boundary(
+    path: Path, source_root: Path, root: Path, tokens: list[str]
+) -> bool:
+    """Reject a production route into an excluded or external Rust source."""
+    valid = True
+    cursor = 0
+    resolved_source_root = source_root.resolve()
+    while cursor < len(tokens):
+        attributes, item_start = item_attributes(tokens, cursor)
+        item_start = item_after_visibility(tokens, item_start)
+        if item_start + 1 >= len(tokens) or tokens[item_start] != "mod":
+            cursor = max(cursor + 1, item_start)
+            continue
+        module_name = tokens[item_start + 1]
+        requires_test = attributes_require_test(attributes)
+        if any(
+            attribute and attribute[0] == "cfg_attr" and "path" in attribute
+            for attribute in attributes
+        ):
+            report(f"{path.relative_to(root)} has a conditional module path")
+            valid = False
+        if module_name in TEST_ONLY_MODULE_NAMES and not requires_test:
+            report(
+                f"{path.relative_to(root)} module {module_name} is not restricted to cfg(test)"
+            )
+            valid = False
+        attribute_path = path_attribute_value(attributes)
+        if any(attribute and attribute[0] == "path" for attribute in attributes) and (
+            attribute_path is None
+        ):
+            report(f"{path.relative_to(root)} has an unsupported module path")
+            valid = False
+        if attribute_path is not None:
+            declared_target = path.parent / attribute_path
+            target = declared_target.resolve()
+            if not path_is_within(target, resolved_source_root):
+                report(
+                    f"{path.relative_to(root)} path attribute leaves its source root"
+                )
+                valid = False
+            elif target.suffix != ".rs":
+                report(f"{path.relative_to(root)} has a non-Rust module path")
+                valid = False
+            elif not is_regular_file_without_symlinks(
+                declared_target, resolved_source_root
+            ):
+                report(f"{path.relative_to(root)} has an unsafe module path")
+                valid = False
+            elif (
+                not is_production_path(target, resolved_source_root)
+                and not requires_test
+            ):
+                report(
+                    f"{path.relative_to(root)} path attribute imports test-only source without cfg(test)"
+                )
+                valid = False
+        cursor = item_start + 2
+    return valid
+
+
+def check_generated_includes(
+    path: Path,
+    root: Path,
+    tokens: list[str],
+    approved_positions: frozenset[int] = frozenset(),
+) -> bool:
+    """Reject a Rust source include outside the exact frozen baseline."""
+    valid = True
+    relative = path.relative_to(root).as_posix()
+    if relative in GENERATED_INCLUDE_ALLOWLIST and any(
+        tokens[index : index + 3] == ["#", "!", "["] for index in range(len(tokens) - 2)
+    ):
+        report(f"{path.relative_to(root)} has an attributed generated source file")
+        valid = False
+    cursor = 0
+    approved_count = 0
+    while cursor + 2 < len(tokens):
+        if (
+            tokens[cursor : cursor + 2] != ["include", "!"]
+            or tokens[cursor + 2] not in GROUP_CLOSINGS
+        ):
+            cursor += 1
+            continue
+        opening = tokens[cursor + 2]
+        end = group_end(tokens, cursor + 2, opening, GROUP_CLOSINGS[opening])
+        invocation = tuple(tokens[cursor:end])
+        if (
+            GENERATED_INCLUDE_ALLOWLIST.get(relative) != invocation
+            or cursor not in approved_positions
+        ):
+            report(f"{path.relative_to(root)} has an unreviewed generated Rust include")
+            valid = False
+        else:
+            approved_count += 1
+            if approved_count > 1:
+                report(
+                    f"{path.relative_to(root)} repeats its reviewed generated Rust include"
+                )
+                valid = False
+        cursor = end
+    if relative in GENERATED_INCLUDE_ALLOWLIST and approved_count == 0:
+        report(f"{path.relative_to(root)} omits its reviewed generated Rust include")
+        valid = False
+    return valid
+
+
+def first_simulator_fragment(tokens: list[str]) -> str | None:
+    """Return the first simulator-specific source fragment."""
+    for token in tokens:
+        literal_value = rust_string_value(token)
+        value = normalized(literal_value if literal_value is not None else token)
+        for fragment in FORBIDDEN_IDENTIFIERS:
+            if fragment in value:
+                return fragment
+    return None
+
+
+def check_simulator_fragments(path: Path, root: Path, tokens: list[str]) -> bool:
+    """Bind each shared simulator exception to its exact frozen source."""
+    fragment = first_simulator_fragment(tokens)
+    if fragment is None:
+        return True
+    relative = path.relative_to(root).as_posix()
+    try:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as error:
+        report(f"{path.relative_to(root)} cannot be hashed: {error}")
+        return False
+    if SHARED_SIMULATOR_SOURCE_DIGESTS.get(relative) == digest:
+        return True
+    report(f"{path.relative_to(root)} has a new simulator-specific token {fragment}")
+    return False
+
+
+def read_controlled_tokens(path: Path, root: Path) -> list[str] | None:
+    """Read one Rust source with literals for source-boundary checks."""
+    try:
+        return rust_tokens(path.read_text(encoding="utf-8"), keep_literals=True)
+    except (OSError, UnicodeError, ParseError) as error:
+        report(f"{path.relative_to(root)} cannot be parsed: {error}")
+        return None
+
+
+def check_source_controls(path: Path, source_root: Path, root: Path) -> bool:
+    """Check module reachability and generated source includes for one file."""
+    tokens = read_controlled_tokens(path, root)
+    if tokens is None:
+        return False
+    item_macros_valid, approved_positions = check_item_macros(path, root, tokens)
+    return all(
+        (
+            check_module_source_boundary(path, source_root, root, tokens),
+            check_generated_includes(path, root, tokens, approved_positions),
+            item_macros_valid,
+        )
     )
 
 
@@ -421,12 +2043,15 @@ def production_rust_paths(source_root: Path, root: Path) -> tuple[list[Path], bo
         for path in sorted(source_root.rglob("*.rs"))
         if not path.is_symlink() and is_production_path(path, source_root)
     ]
+    for path in paths:
+        if not check_source_controls(path, source_root, root):
+            valid = False
     return paths, valid
 
 
 def read_public_types(
     path: Path, root: Path
-) -> list[tuple[str, str, list[tuple[str, str]]]] | None:
+) -> list[tuple[str, str, list[tuple[str, str]], bool]] | None:
     """Read and parse one Rust source file or report a fail-closed error."""
     try:
         return public_types(rust_tokens(path.read_text(encoding="utf-8")))
@@ -438,13 +2063,13 @@ def read_public_types(
 def check_type_identifiers(
     path: Path,
     root: Path,
-    records: list[tuple[str, str, list[tuple[str, str]]]],
+    records: list[tuple[str, str, list[tuple[str, str]], bool]],
     allowed: frozenset[tuple[str, str, str]] = frozenset(),
 ) -> bool:
     """Reject simulator-specific fields and variants in public shared types."""
     valid = True
     relative = path.relative_to(root)
-    for _, type_name, identifiers in records:
+    for _, type_name, identifiers, _ in records:
         for kind, identifier in identifiers:
             if (type_name, kind, identifier) not in allowed and is_forbidden_identifier(
                 identifier
@@ -460,6 +2085,14 @@ def check_source_root(source_root: Path, root: Path) -> bool:
     """Check all production Rust files below one shared runtime root."""
     paths, valid = production_rust_paths(source_root, root)
     for path in paths:
+        controlled_tokens = read_controlled_tokens(path, root)
+        if controlled_tokens is None:
+            valid = False
+        else:
+            if not check_simulator_fragments(path, root, controlled_tokens):
+                valid = False
+            if not check_contract_attributes(path, root, controlled_tokens):
+                valid = False
         records = read_public_types(path, root)
         if records is None:
             valid = False
@@ -470,11 +2103,17 @@ def check_source_root(source_root: Path, root: Path) -> bool:
 
 def check_campaign_file(path: Path, root: Path) -> bool:
     """Check classified public contracts in one campaign configuration file."""
+    controlled_tokens = read_controlled_tokens(path, root)
     records = read_public_types(path, root)
-    if records is None:
+    if controlled_tokens is None or records is None:
         return False
-    valid = True
+    valid = check_contract_attributes(path, root, controlled_tokens)
+    if not check_campaign_aliases(path, root, controlled_tokens):
+        valid = False
     relative = path.relative_to(root).as_posix()
+    classified_config = relative == "tools/flight-tune-campaign/src/config.rs" or (
+        relative.startswith("tools/flight-tune-campaign/src/config/")
+    )
     allowed = frozenset(
         (type_name, kind, identifier)
         for allowed_path, type_name, kind, identifier in (
@@ -482,41 +2121,177 @@ def check_campaign_file(path: Path, root: Path) -> bool:
         )
         if allowed_path == relative
     )
-    for kind, type_name, identifiers in records:
-        if type_name in CAMPAIGN_ADAPTER_TYPES:
+    for kind, type_name, identifiers, serialized in records:
+        if (relative, type_name) in CAMPAIGN_ADAPTER_TYPE_ALLOWLIST:
             continue
-        if type_name not in CAMPAIGN_SHARED_TYPES:
+        if classified_config and type_name not in CAMPAIGN_SHARED_TYPES:
             report(
                 f"{path.relative_to(root)} has unclassified public campaign contract {type_name}"
             )
             valid = False
+        checked_identifiers = (
+            identifiers
+            if classified_config or serialized
+            else [
+                (context, identifier)
+                for context, identifier in identifiers
+                if not context.startswith(
+                    ("field_type:", "header_type", "tuple_field_type:", "variant_type:")
+                )
+            ]
+        )
         if not check_type_identifiers(
             path,
             root,
-            [(kind, type_name, identifiers)],
+            [(kind, type_name, checked_identifiers, serialized)],
             allowed,
         ):
             valid = False
     return valid
 
 
-def check_campaign_config(root: Path) -> bool:
-    """Check the campaign document and all production configuration modules."""
-    config_file = root / "tools/flight-tune-campaign/src/config.rs"
-    config_root = root / "tools/flight-tune-campaign/src/config"
-    paths: list[Path] = []
+def check_campaign_aliases(path: Path, root: Path, tokens: list[str]) -> bool:
+    """Reject a new simulator-specific alias or public re-export."""
+    relative = path.relative_to(root).as_posix()
+    alias_counts: Counter[tuple[str, str, str]] = Counter()
+    public_use_counts: Counter[tuple[str, str]] = Counter()
     valid = True
-    if config_file.is_symlink():
-        report(f"{config_file.relative_to(root)} production source path is a symlink")
-        valid = False
-    elif config_file.is_file():
-        paths.append(config_file)
-    config_paths, config_paths_valid = production_rust_paths(config_root, root)
-    paths.extend(config_paths)
-    valid = valid and config_paths_valid
+    cursor = 0
+    while cursor < len(tokens):
+        if tokens[cursor] == "pub":
+            item_start = item_after_visibility(tokens, cursor)
+            public_use = item_start < len(tokens) and tokens[item_start] == "use"
+            public_extern_crate = tokens[item_start : item_start + 2] == [
+                "extern",
+                "crate",
+            ]
+            if public_use or public_extern_crate:
+                end = statement_end(tokens, item_start + 1)
+                if first_simulator_fragment(tokens[item_start:end]) is not None:
+                    public_use_record = (relative, "".join(tokens[item_start:end]))
+                    public_use_counts[public_use_record] += 1
+                    visibility = "".join(tokens[cursor:item_start])
+                    reviewed_public_use = (
+                        public_use
+                        and (
+                            (
+                                visibility == "pub"
+                                and public_use_record
+                                in CAMPAIGN_SIMULATOR_PUBLIC_USE_ALLOWLIST
+                            )
+                            or (
+                                relative,
+                                visibility,
+                                public_use_record[1],
+                            )
+                            in CAMPAIGN_SIMULATOR_RESTRICTED_PUBLIC_USE_ALLOWLIST
+                        )
+                        and public_use_counts[public_use_record] == 1
+                    )
+                    if not reviewed_public_use:
+                        report(
+                            f"{path.relative_to(root)} has a simulator-specific public re-export"
+                        )
+                        valid = False
+                cursor = end
+                continue
+        if tokens[cursor : cursor + 2] == ["extern", "crate"]:
+            end = statement_end(tokens, cursor + 2)
+            if first_simulator_fragment(tokens[cursor:end]) is not None:
+                report(
+                    f"{path.relative_to(root)} has a simulator-specific extern crate"
+                )
+                valid = False
+            cursor = end
+            continue
+        if (
+            tokens[cursor] == "type"
+            and cursor + 1 < len(tokens)
+            and IDENTIFIER.fullmatch(tokens[cursor + 1])
+        ):
+            end = statement_end(tokens, cursor + 2)
+            statement = tokens[cursor + 2 : end - 1]
+            if "=" in statement:
+                alias_name = tokens[cursor + 1]
+                equals = statement.index("=")
+                for token in [alias_name, *statement[equals + 1 :]]:
+                    if IDENTIFIER.fullmatch(token) and is_forbidden_identifier(token):
+                        alias_counts[(relative, alias_name, token)] += 1
+            cursor = end
+            continue
+        if tokens[cursor] == "use":
+            end = statement_end(tokens, cursor + 1)
+            statement = tokens[cursor + 1 : end - 1]
+            if "as" in statement and any(
+                IDENTIFIER.fullmatch(token) and is_forbidden_identifier(token)
+                for token in statement
+            ):
+                report(
+                    f"{path.relative_to(root)} has a simulator-specific import alias"
+                )
+                valid = False
+            cursor = end
+            continue
+        cursor += 1
+    for record, count in alias_counts.items():
+        if count > CAMPAIGN_SIMULATOR_ALIAS_LIMITS.get(record, 0):
+            _, alias_name, token = record
+            report(
+                f"{path.relative_to(root)} has unreviewed simulator type alias {alias_name} for {token}"
+            )
+            valid = False
+    return valid
+
+
+def check_campaign_contracts(root: Path) -> bool:
+    """Check every production contract in the campaign source root."""
+    campaign_root = root / "tools/flight-tune-campaign/src"
+    paths, valid = production_rust_paths(campaign_root, root)
     for path in paths:
         if not check_campaign_file(path, root):
             valid = False
+    return valid
+
+
+def check_generated_include_inputs(root: Path) -> bool:
+    """Check each source file that creates one allowlisted generated include."""
+    valid = True
+    for include_source, input_paths in GENERATED_INCLUDE_INPUTS.items():
+        include_path = root / include_source
+        if not include_path.exists() and not any(
+            (root / input_path).exists() for input_path in input_paths
+        ):
+            continue
+        package_parts = Path(include_source).parts[:2]
+        package_root = root.joinpath(*package_parts)
+        for input_path in input_paths:
+            generator = root / input_path
+            if not is_regular_file_without_symlinks(generator, root):
+                if include_path.exists() or generator.exists():
+                    report(
+                        f"{input_path} generated source input is missing or is a symlink"
+                    )
+                    valid = False
+                continue
+            try:
+                digest = hashlib.sha256(generator.read_bytes()).hexdigest()
+            except OSError as error:
+                report(f"{input_path} generated source input cannot be hashed: {error}")
+                valid = False
+                continue
+            if digest not in GENERATED_INPUT_DIGESTS.get(input_path, frozenset()):
+                report(f"{input_path} generated source input has an unreviewed digest")
+                valid = False
+            tokens = read_controlled_tokens(generator, root)
+            if tokens is None:
+                valid = False
+                continue
+            if not check_module_source_boundary(generator, package_root, root, tokens):
+                valid = False
+            if not check_generated_includes(generator, root, tokens):
+                valid = False
+            if not check_simulator_fragments(generator, root, tokens):
+                valid = False
     return valid
 
 
@@ -527,6 +2302,12 @@ def main() -> int:
         return 2
     root = Path(sys.argv[1]).resolve()
     valid = True
+    if not check_cargo_source_overrides(root):
+        valid = False
+    direct_dependency_allowlist = read_direct_dependency_allowlist(root)
+    if direct_dependency_allowlist is None:
+        return 1
+    registry_names: set[str] = set()
     for manifest, allowed_adapter_dependencies in (
         (root / "crates/pilotage-trial/Cargo.toml", frozenset()),
         (root / "tools/flight-tune/Cargo.toml", frozenset()),
@@ -534,16 +2315,39 @@ def main() -> int:
             root / "tools/flight-tune-aviate/Cargo.toml",
             frozenset(FORBIDDEN_PACKAGES),
         ),
+        (
+            root / "tools/flight-tune-campaign/Cargo.toml",
+            frozenset(FORBIDDEN_PACKAGES),
+        ),
     ):
-        if not check_manifest(manifest, root, allowed_adapter_dependencies):
+        manifest_valid, manifest_registry_names = check_manifest(
+            manifest, root, direct_dependency_allowlist, allowed_adapter_dependencies
+        )
+        registry_names.update(manifest_registry_names)
+        if not manifest_valid:
             valid = False
+    if not check_cargo_lock_packages(root, registry_names):
+        valid = False
     for source_root in (
         root / "crates/pilotage-trial/src",
         root / "tools/flight-tune/src",
     ):
         if not check_source_root(source_root, root):
             valid = False
-    if not check_campaign_config(root):
+    aviate_paths, aviate_sources_valid = production_rust_paths(
+        root / "tools/flight-tune-aviate/src", root
+    )
+    if not aviate_sources_valid:
+        valid = False
+    for path in aviate_paths:
+        controlled_tokens = read_controlled_tokens(path, root)
+        if controlled_tokens is None or not check_contract_attributes(
+            path, root, controlled_tokens
+        ):
+            valid = False
+    if not check_campaign_contracts(root):
+        valid = False
+    if not check_generated_include_inputs(root):
         valid = False
     return 0 if valid else 1
 

--- a/scripts/flight-tune-direct-dependency-allowlist.tsv
+++ b/scripts/flight-tune-direct-dependency-allowlist.tsv
@@ -1,0 +1,61 @@
+manifest	dependency_key	actual_package	kind	target	optional	source_kind	source_ref	default_features	features	version_req
+crates/pilotage-trial/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+crates/pilotage-trial/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+crates/pilotage-trial/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+crates/pilotage-trial/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
+tools/flight-tune-aviate/Cargo.toml	flight-tune	flight-tune	normal		false	path	tools/flight-tune	true		*
+tools/flight-tune-aviate/Cargo.toml	flight-tune-xplane	flight-tune-xplane	normal		false	path	tools/flight-tune-xplane	true		*
+tools/flight-tune-aviate/Cargo.toml	libm	libm	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.2.16
+tools/flight-tune-aviate/Cargo.toml	pilotage-adapter-api	pilotage-adapter-api	normal		false	path	crates/pilotage-adapter-api	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-adapter-aviate	pilotage-adapter-aviate	normal		false	path	adapters/aviate	false	sim	*
+tools/flight-tune-aviate/Cargo.toml	pilotage-control-feel	pilotage-control-feel	normal		false	path	crates/pilotage-control-feel	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-durable-storage	pilotage-durable-storage	normal		false	path	crates/pilotage-durable-storage	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-mavlink	pilotage-mavlink	normal		false	path	crates/pilotage-mavlink	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-protocol	pilotage-protocol	normal		false	path	crates/pilotage-protocol	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-timing	pilotage-timing	normal		false	path	crates/pilotage-timing	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-trial	pilotage-trial	normal		false	path	crates/pilotage-trial	true		*
+tools/flight-tune-aviate/Cargo.toml	pilotage-xplane-trial	pilotage-xplane-trial	normal		false	path	crates/pilotage-xplane-trial	true		*
+tools/flight-tune-aviate/Cargo.toml	serde	serde	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune-aviate/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune-aviate/Cargo.toml	sha2	sha2	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune-aviate/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune-aviate/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
+tools/flight-tune-aviate/Cargo.toml	tokio	tokio	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	net,rt,time	^1.48.0
+tools/flight-tune-aviate/Cargo.toml	toml	toml	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^1.1.4
+tools/flight-tune-aviate/Cargo.toml	tracing	tracing	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.1.44
+tools/flight-tune-campaign/Cargo.toml	flight-tune	flight-tune	normal		false	path	tools/flight-tune	true		*
+tools/flight-tune-campaign/Cargo.toml	flight-tune-aviate	flight-tune-aviate	normal		false	path	tools/flight-tune-aviate	true		*
+tools/flight-tune-campaign/Cargo.toml	flight-tune-xplane	flight-tune-xplane	normal		false	path	tools/flight-tune-xplane	true		*
+tools/flight-tune-campaign/Cargo.toml	libc	libc	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.2.177
+tools/flight-tune-campaign/Cargo.toml	libproc	libproc	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.14.11
+tools/flight-tune-campaign/Cargo.toml	pilotage-control-feel	pilotage-control-feel	normal		false	path	crates/pilotage-control-feel	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-durable-storage	pilotage-durable-storage	normal		false	path	crates/pilotage-durable-storage	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-mavlink	pilotage-mavlink	normal		false	path	crates/pilotage-mavlink	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-protocol	pilotage-protocol	normal		false	path	crates/pilotage-protocol	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-trial	pilotage-trial	normal		false	path	crates/pilotage-trial	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-tuning-feedback	pilotage-tuning-feedback	normal		false	path	crates/pilotage-tuning-feedback	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-tuning-journal-proof	pilotage-tuning-journal-proof	normal		false	path	crates/pilotage-tuning-journal-proof	true		*
+tools/flight-tune-campaign/Cargo.toml	pilotage-xplane-trial	pilotage-xplane-trial	normal		false	path	crates/pilotage-xplane-trial	true		*
+tools/flight-tune-campaign/Cargo.toml	rustix	rustix	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	fs	^1.1.4
+tools/flight-tune-campaign/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune-campaign/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune-campaign/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune-campaign/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
+tools/flight-tune-campaign/Cargo.toml	toml	toml	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^1.1.4
+tools/flight-tune-campaign/Cargo.toml	tracing	tracing	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.1.44
+tools/flight-tune-campaign/Cargo.toml	tracing-subscriber	tracing-subscriber	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	fmt	^0.3.23
+tools/flight-tune/Cargo.toml	pilotage-durable-storage	pilotage-durable-storage	normal		false	path	crates/pilotage-durable-storage	true		*
+tools/flight-tune/Cargo.toml	pilotage-flight-quality	pilotage-flight-quality	normal		false	path	crates/pilotage-flight-quality	true		*
+tools/flight-tune/Cargo.toml	pilotage-trial	pilotage-trial	normal		false	path	crates/pilotage-trial	true		*
+tools/flight-tune/Cargo.toml	pilotage-tuning-feedback	pilotage-tuning-feedback	normal		false	path	crates/pilotage-tuning-feedback	true		*
+tools/flight-tune/Cargo.toml	pilotage-tuning-journal-proof	pilotage-tuning-journal-proof	normal		false	path	crates/pilotage-tuning-journal-proof	true		*
+tools/flight-tune/Cargo.toml	serde	serde	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune/Cargo.toml	serde_json	serde_json	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune/Cargo.toml	sha2	sha2	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
+tools/flight-tune/Cargo.toml	tracing	tracing	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.1.44

--- a/scripts/flight-tune-xplane-import-allowlist.tsv
+++ b/scripts/flight-tune-xplane-import-allowlist.tsv
@@ -1,5 +1,6 @@
 tools/flight-tune-aviate/src/driver.rs	useflight_tune_xplane::CausalJoinConfig;
 tools/flight-tune-aviate/src/evidence/readback.rs	useflight_tune_xplane::PlantExecutionEvidence;
+tools/flight-tune-aviate/src/evidence/record.rs	useflight_tune_xplane::TruthObservation;
 tools/flight-tune-aviate/src/evidence/record/selection.rs	useflight_tune_xplane::{PlantExecutionEvidence,TruthObservation};
 tools/flight-tune-aviate/src/runtime.rs	useflight_tune_xplane::{ScenarioObservation,ScenarioRuntime,ScenarioRuntimeError,ScenarioStopContext,TruthObservation,};
 tools/flight-tune-aviate/src/runtime/conditions.rs	useflight_tune_xplane::TruthObservation;

--- a/scripts/flight-tune-xplane-import-allowlist.tsv
+++ b/scripts/flight-tune-xplane-import-allowlist.tsv
@@ -1,0 +1,9 @@
+tools/flight-tune-aviate/src/driver.rs	useflight_tune_xplane::CausalJoinConfig;
+tools/flight-tune-aviate/src/evidence/readback.rs	useflight_tune_xplane::PlantExecutionEvidence;
+tools/flight-tune-aviate/src/evidence/record/selection.rs	useflight_tune_xplane::{PlantExecutionEvidence,TruthObservation};
+tools/flight-tune-aviate/src/runtime.rs	useflight_tune_xplane::{ScenarioObservation,ScenarioRuntime,ScenarioRuntimeError,ScenarioStopContext,TruthObservation,};
+tools/flight-tune-aviate/src/runtime/conditions.rs	useflight_tune_xplane::TruthObservation;
+tools/flight-tune-aviate/src/runtime/phase.rs	useflight_tune_xplane::TruthObservation;
+tools/flight-tune-aviate/src/runtime/preparation.rs	useflight_tune_xplane::ScenarioRuntimeError;
+tools/flight-tune-aviate/src/runtime/telemetry.rs	useflight_tune_xplane::TruthObservation;
+tools/flight-tune-aviate/src/runtime/timing.rs	useflight_tune_xplane::TruthObservation;

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# Prove that the tuning boundary guard rejects simulator-specific coupling.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$repo_root/scripts/check-flight-tune-boundaries.sh"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-flight-tune-boundary-test.XXXXXX")"
+fixture_allowlist="$fixture/import-allowlist.tsv"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p \
+    "$fixture/adapters/flight-tune-xplane/src" \
+    "$fixture/adapters/pilotage-xplane-trial/src" \
+    "$fixture/crates/pilotage-trial/src" \
+    "$fixture/scripts" \
+    "$fixture/tools/flight-tune/src" \
+    "$fixture/tools/flight-tune-aviate/src/bin" \
+    "$fixture/tools/flight-tune-aviate/src/support" \
+    "$fixture/tools/flight-tune-aviate/src/tests" \
+    "$fixture/tools/flight-tune-campaign/src/config"
+
+write_workspace() {
+    printf '%s\n' \
+        '[workspace]' \
+        'members = [' \
+        '    "adapters/flight-tune-xplane",' \
+        '    "adapters/pilotage-xplane-trial",' \
+        '    "crates/pilotage-trial",' \
+        '    "tools/flight-tune",' \
+        ']' \
+        'resolver = "2"' \
+        > "$fixture/Cargo.toml"
+}
+
+write_adapter_packages() {
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune-xplane"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        > "$fixture/adapters/flight-tune-xplane/Cargo.toml"
+    printf '%s\n' 'pub fn adapter() {}' \
+        > "$fixture/adapters/flight-tune-xplane/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "pilotage-xplane-trial"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        > "$fixture/adapters/pilotage-xplane-trial/Cargo.toml"
+    printf '%s\n' 'pub fn adapter() {}' \
+        > "$fixture/adapters/pilotage-xplane-trial/src/lib.rs"
+}
+
+write_clean_manifests() {
+    printf '%s\n' \
+        '[package]' \
+        'name = "pilotage-trial"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        > "$fixture/crates/pilotage-trial/Cargo.toml"
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        > "$fixture/tools/flight-tune/Cargo.toml"
+}
+
+write_allowlisted_import() {
+    printf '%s\n' \
+        'use flight_tune_xplane::CausalJoinConfig;' \
+        'pub fn marker() {}' \
+        > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+}
+
+write_shared_contract() {
+    printf '%s\n' \
+        'pub struct SharedContract {' \
+        '    pub id: String,' \
+        '}' \
+        > "$fixture/crates/pilotage-trial/src/lib.rs"
+    printf '%s\n' \
+        'pub struct RuntimeContract {' \
+        '    pub id: String,' \
+        '}' \
+        > "$fixture/tools/flight-tune/src/lib.rs"
+}
+
+write_campaign_contract() {
+    printf '%s\n' \
+        'pub enum ExecutionTarget { Simulator, Hardware }' \
+        'pub enum CampaignPurpose { Qualification, Canary }' \
+        'pub struct PinnedFile { pub path: String }' \
+        'pub struct SearchGroupConfig { pub id: String }' \
+        'pub enum SearchGroupKind { Controller, Feel }' \
+        'pub struct CampaignConfig {' \
+        '    pub id: String,' \
+        '}' \
+        'pub struct XPlaneCampaignConfig {' \
+        '    pub weather_plugin_digest: String,' \
+        '    pub sdk_version: String,' \
+        '}' \
+        > "$fixture/tools/flight-tune-campaign/src/config.rs"
+    printf '%s\n' \
+        'pub struct CampaignBudgetLimit { pub attempts: u64 }' \
+        'pub struct TrainingGuardScenarioConfig { pub id: String }' \
+        'pub struct TrainingSuiteConfig { pub id: String }' \
+        > "$fixture/tools/flight-tune-campaign/src/config/training_suite.rs"
+}
+
+run_guard() {
+    bash "$guard" "$fixture" "$fixture_allowlist"
+}
+
+expect_failure() {
+    local name="$1" expected="$2" output
+    if output="$(run_guard 2>&1)"; then
+        echo "the tuning boundary guard accepted $name" >&2
+        exit 1
+    fi
+    if ! grep -Fq "$expected" <<<"$output"; then
+        echo "the tuning boundary guard gave the wrong result for $name" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+expect_failure_with_all() {
+    local name="$1" output expected
+    shift
+    if output="$(run_guard 2>&1)"; then
+        echo "the tuning boundary guard accepted $name" >&2
+        exit 1
+    fi
+    for expected in "$@"; do
+        if ! grep -Fq "$expected" <<<"$output"; then
+            echo "the tuning boundary guard missed $expected for $name" >&2
+            echo "$output" >&2
+            exit 1
+        fi
+    done
+}
+
+write_workspace
+write_adapter_packages
+write_clean_manifests
+write_allowlisted_import
+write_shared_contract
+write_campaign_contract
+printf '%s\t%s\n' \
+    'tools/flight-tune-aviate/src/driver.rs' \
+    'useflight_tune_xplane::CausalJoinConfig;' \
+    > "$fixture_allowlist"
+run_guard >/dev/null
+
+printf '%s\n' 'pub fn marker() {}' \
+    > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+run_guard >/dev/null
+write_allowlisted_import
+
+printf '%s\n' 'use flight_tune_xplane::ScenarioRuntime;' \
+    > "$fixture/tools/flight-tune-aviate/src/driver.rs"
+expect_failure \
+    'a changed allowlisted import' \
+    'new flight_tune_xplane import:'
+write_allowlisted_import
+
+printf '%s\n' 'use flight_tune_xplane::NewRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/new_runtime.rs"
+expect_failure \
+    'a new Aviate X-Plane import' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/new_runtime.rs"
+
+printf '%s\n' 'use flight_tune_xplane::BinRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/bin/runtime.rs"
+expect_failure \
+    'an import in a production bin module' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/bin/runtime.rs"
+
+printf '%s\n' 'pub use flight_tune_xplane::SupportRuntimeType;' \
+    > "$fixture/tools/flight-tune-aviate/src/support/runtime.rs"
+expect_failure \
+    'an import in a production support module' \
+    'new flight_tune_xplane import:'
+rm "$fixture/tools/flight-tune-aviate/src/support/runtime.rs"
+
+printf '%s\n' 'use flight_tune_xplane::TestOnlyType;' \
+    > "$fixture/tools/flight-tune-aviate/src/tests/runtime.rs"
+printf '%s\n' 'use flight_tune_xplane::TestSupportType;' \
+    > "$fixture/tools/flight-tune-aviate/src/test_support.rs"
+run_guard >/dev/null
+
+printf '%s\n' 'pub fn runtime() { flight_tune_xplane::run(); }' \
+    > "$fixture/tools/flight-tune-aviate/src/runtime.rs"
+expect_failure \
+    'a path reference outside a reviewed import' \
+    'uses flight_tune_xplane outside a reviewed import'
+rm "$fixture/tools/flight-tune-aviate/src/runtime.rs"
+
+cp "$fixture_allowlist" \
+    "$fixture/scripts/flight-tune-xplane-import-allowlist.tsv"
+if output="$(bash "$guard" "$fixture" 2>&1)"; then
+    echo 'the tuning boundary guard accepted a nonempty production allowlist' >&2
+    exit 1
+fi
+if ! grep -Fq 'production flight_tune_xplane import allowlist must stay empty' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report the production allowlist' >&2
+    exit 1
+fi
+
+mkdir -p "$fixture/failing-bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/rg"
+chmod +x "$fixture/failing-bin/rg"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored a source-list failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot list Rust source files below' <<<"$output"; then
+    echo 'the tuning boundary guard did not report a source-list failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/rg"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/comm"
+chmod +x "$fixture/failing-bin/comm"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored an import comparison failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot compare flight_tune_xplane imports with the allowlist' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report an import comparison failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/comm"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a direct flight-tune-xplane runtime dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an aliased flight-tune-xplane runtime dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a direct pilotage-xplane-trial runtime dependency' \
+    'runtime dependency pilotage-xplane-trial'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies.trial]' \
+    'package = "pilotage-xplane-trial"' \
+    'path = "../../adapters/pilotage-xplane-trial"' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an aliased pilotage-xplane-trial runtime dependency' \
+    'runtime dependency pilotage-xplane-trial'
+write_clean_manifests
+
+printf '%s\n' \
+    '[workspace]' \
+    'members = [' \
+    '    "adapters/flight-tune-xplane",' \
+    '    "adapters/pilotage-xplane-trial",' \
+    '    "crates/pilotage-trial",' \
+    '    "tools/flight-tune",' \
+    ']' \
+    'resolver = "2"' \
+    '[workspace.dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "adapters/flight-tune-xplane" }' \
+    > "$fixture/Cargo.toml"
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'adapter = { workspace = true }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'an inherited workspace dependency alias' \
+    'runtime dependency flight-tune-xplane'
+write_workspace
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[build-dependencies]' \
+    'adapter = { package = "flight-tune-xplane", path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a flight-tune-xplane build dependency' \
+    'runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    '[dev-dependencies]' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+run_guard >/dev/null
+write_clean_manifests
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    pub xplane: String,' \
+    '    pub acf: String,' \
+    '    pub aircraft_file: String,' \
+    '    pub trial_plugin: String,' \
+    '    pub bridge_plugin: String,' \
+    '    pub weather_plugin: String,' \
+    '    pub host_application_id: String,' \
+    '    pub xplane_version: String,' \
+    '    pub sdk_version: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure_with_all \
+    'all forbidden shared field identifiers' \
+    'simulator-specific field xplane' \
+    'simulator-specific field acf' \
+    'simulator-specific field aircraft_file' \
+    'simulator-specific field trial_plugin' \
+    'simulator-specific field bridge_plugin' \
+    'simulator-specific field weather_plugin' \
+    'simulator-specific field host_application_id' \
+    'simulator-specific field xplane_version' \
+    'simulator-specific field sdk_version'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract<T>' \
+    'where' \
+    '    T: Clone,' \
+    '{' \
+    '    pub candidate_xplane_version_digest: T,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a generic shared struct with a later body brace' \
+    'simulator-specific field candidate_xplane_version_digest'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    // }' \
+    '    pub candidate_xplane_version_digest: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a shared field after a comment brace' \
+    'simulator-specific field candidate_xplane_version_digest'
+write_shared_contract
+
+printf '%s\n' \
+    'pub enum SharedContract {' \
+    '    Neutral,' \
+    '    XPlaneReplay(String),' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator name inside a shared enum variant' \
+    'simulator-specific variant XPlaneReplay'
+write_shared_contract
+
+printf '%s\n' \
+    'pub enum SharedContract {' \
+    '    Neutral { xplane_version: String },' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator name inside a shared enum field' \
+    'simulator-specific field xplane_version'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct CampaignConfig {' \
+    '    pub xplane: XPlaneCampaignConfig,' \
+    '}' \
+    'pub struct XPlaneCampaignConfig {' \
+    '    pub weather_plugin_digest: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+expect_failure \
+    'the former CampaignConfig xplane exception' \
+    'CampaignConfig has simulator-specific field xplane'
+write_campaign_contract
+
+printf '%s\n' \
+    '#[derive(Serialize)]' \
+    'pub struct SharedCampaignContract {' \
+    '    pub id: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+expect_failure \
+    'an unclassified public campaign contract' \
+    'unclassified public campaign contract SharedCampaignContract'
+write_campaign_contract
+
+printf '%s\n' \
+    'mod shared;' \
+    'pub use shared::SharedCampaignContract;' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+printf '%s\n' \
+    '#[derive(Serialize)]' \
+    'pub struct SharedCampaignContract {' \
+    '    pub xplane_version: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config/shared.rs"
+expect_failure_with_all \
+    'an unclassified campaign submodule contract' \
+    'unclassified public campaign contract SharedCampaignContract' \
+    'simulator-specific field xplane_version'
+rm "$fixture/tools/flight-tune-campaign/src/config/shared.rs"
+write_campaign_contract
+
+run_guard >/dev/null
+echo "flight tuning boundary guard self-test: OK"

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -214,8 +214,8 @@ if ! grep -Fq 'production flight_tune_xplane import allowlist must stay empty' \
 fi
 
 mkdir -p "$fixture/failing-bin"
-printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/rg"
-chmod +x "$fixture/failing-bin/rg"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/find"
+chmod +x "$fixture/failing-bin/find"
 if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
     echo 'the tuning boundary guard ignored a source-list failure' >&2
     exit 1
@@ -224,7 +224,19 @@ if ! grep -Fq 'cannot list Rust source files below' <<<"$output"; then
     echo 'the tuning boundary guard did not report a source-list failure' >&2
     exit 1
 fi
-rm "$fixture/failing-bin/rg"
+rm "$fixture/failing-bin/find"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/grep"
+chmod +x "$fixture/failing-bin/grep"
+if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then
+    echo 'the tuning boundary guard ignored an import-scan failure' >&2
+    exit 1
+fi
+if ! grep -Fq 'cannot be scanned for flight_tune_xplane references' \
+    <<<"$output"; then
+    echo 'the tuning boundary guard did not report an import-scan failure' >&2
+    exit 1
+fi
+rm "$fixture/failing-bin/grep"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/comm"
 chmod +x "$fixture/failing-bin/comm"
 if output="$(PATH="$fixture/failing-bin:$PATH" run_guard 2>&1)"; then

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -27,6 +27,7 @@ write_workspace() {
         '    "adapters/pilotage-xplane-trial",' \
         '    "crates/pilotage-trial",' \
         '    "tools/flight-tune",' \
+        '    "tools/flight-tune-aviate",' \
         ']' \
         'resolver = "2"' \
         > "$fixture/Cargo.toml"
@@ -66,6 +67,17 @@ write_clean_manifests() {
         'edition = "2021"' \
         '[dependencies]' \
         > "$fixture/tools/flight-tune/Cargo.toml"
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune-aviate"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+        'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+        > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+    printf '%s\n' 'pub fn host() {}' \
+        > "$fixture/tools/flight-tune-aviate/src/lib.rs"
 }
 
 write_allowlisted_import() {
@@ -201,17 +213,71 @@ expect_failure \
     'uses flight_tune_xplane outside a reviewed import'
 rm "$fixture/tools/flight-tune-aviate/src/runtime.rs"
 
+printf '%s\n' 'use flight_tune_xplane::SymlinkRuntime;' \
+    > "$fixture/symlink-runtime.rs"
+ln -s "$fixture/symlink-runtime.rs" \
+    "$fixture/tools/flight-tune-aviate/src/symlink_runtime.rs"
+expect_failure \
+    'a production Aviate source symlink' \
+    'production Rust source path tools/flight-tune-aviate/src/symlink_runtime.rs is a symlink'
+rm "$fixture/tools/flight-tune-aviate/src/symlink_runtime.rs"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'xplane-adapter = { package = "flight-tune-xplane", path = "../../adapters/flight-tune-xplane" }' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'a renamed Aviate X-Plane dependency' \
+    'noncanonical runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane", optional = true }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'an optional Aviate X-Plane dependency' \
+    'noncanonical runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[build-dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'an Aviate X-Plane build dependency' \
+    'noncanonical runtime dependency flight-tune-xplane'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[target."cfg(unix)".dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'a target-specific Aviate X-Plane dependency' \
+    'noncanonical runtime dependency flight-tune-xplane'
+write_clean_manifests
+
 cp "$fixture_allowlist" \
     "$fixture/scripts/flight-tune-xplane-import-allowlist.tsv"
-if output="$(bash "$guard" "$fixture" 2>&1)"; then
-    echo 'the tuning boundary guard accepted a nonempty production allowlist' >&2
-    exit 1
-fi
-if ! grep -Fq 'production flight_tune_xplane import allowlist must stay empty' \
-    <<<"$output"; then
-    echo 'the tuning boundary guard did not report the production allowlist' >&2
-    exit 1
-fi
+bash "$guard" "$fixture" >/dev/null
 
 mkdir -p "$fixture/failing-bin"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$fixture/failing-bin/find"
@@ -307,9 +373,10 @@ printf '%s\n' \
     '[workspace]' \
     'members = [' \
     '    "adapters/flight-tune-xplane",' \
-    '    "adapters/pilotage-xplane-trial",' \
-    '    "crates/pilotage-trial",' \
-    '    "tools/flight-tune",' \
+        '    "adapters/pilotage-xplane-trial",' \
+        '    "crates/pilotage-trial",' \
+        '    "tools/flight-tune",' \
+        '    "tools/flight-tune-aviate",' \
     ']' \
     'resolver = "2"' \
     '[workspace.dependencies]' \
@@ -417,6 +484,54 @@ write_shared_contract
 
 printf '%s\n' \
     'pub enum SharedContract {' \
+    '    Neutral = 1 << 0,' \
+    '    XPlaneReplay = 2,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator variant after a shift expression' \
+    'simulator-specific variant XPlaneReplay'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    pub mask: [u8; 1 << 2],' \
+    '    pub xplane_new: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a simulator field after a shift expression' \
+    'simulator-specific field xplane_new'
+write_shared_contract
+
+mkdir -p "$fixture/shared-symlink-target"
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    pub xplane_new: String,' \
+    '}' \
+    > "$fixture/shared-symlink-target/contract.rs"
+ln -s "$fixture/shared-symlink-target" \
+    "$fixture/crates/pilotage-trial/src/contracts"
+expect_failure \
+    'a neutral source directory symlink' \
+    'production source path is a symlink'
+rm "$fixture/crates/pilotage-trial/src/contracts"
+
+mkdir -p "$fixture/campaign-symlink-target"
+printf '%s\n' \
+    'pub struct CampaignConfig {' \
+    '    pub xplane_new: String,' \
+    '}' \
+    > "$fixture/campaign-symlink-target/contract.rs"
+ln -s "$fixture/campaign-symlink-target" \
+    "$fixture/tools/flight-tune-campaign/src/config/contracts"
+expect_failure \
+    'a campaign config source directory symlink' \
+    'production source path is a symlink'
+rm "$fixture/tools/flight-tune-campaign/src/config/contracts"
+
+printf '%s\n' \
+    'pub enum SharedContract {' \
     '    Neutral { xplane_version: String },' \
     '}' \
     > "$fixture/crates/pilotage-trial/src/lib.rs"
@@ -428,14 +543,27 @@ write_shared_contract
 printf '%s\n' \
     'pub struct CampaignConfig {' \
     '    pub xplane: XPlaneCampaignConfig,' \
+    '    pub aviate_xplane_contract: PinnedFile,' \
+    '}' \
+    'pub struct XPlaneCampaignConfig {' \
+    '    pub weather_plugin_digest: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+run_guard >/dev/null
+
+printf '%s\n' \
+    'pub struct CampaignConfig {' \
+    '    pub xplane: XPlaneCampaignConfig,' \
+    '    pub aviate_xplane_contract: PinnedFile,' \
+    '    pub xplane_new: XPlaneCampaignConfig,' \
     '}' \
     'pub struct XPlaneCampaignConfig {' \
     '    pub weather_plugin_digest: String,' \
     '}' \
     > "$fixture/tools/flight-tune-campaign/src/config.rs"
 expect_failure \
-    'the former CampaignConfig xplane exception' \
-    'CampaignConfig has simulator-specific field xplane'
+    'a new CampaignConfig X-Plane field' \
+    'CampaignConfig has simulator-specific field xplane_new'
 write_campaign_contract
 
 printf '%s\n' \

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -12,6 +12,7 @@ mkdir -p \
     "$fixture/adapters/flight-tune-xplane/src" \
     "$fixture/adapters/pilotage-xplane-trial/src" \
     "$fixture/crates/pilotage-trial/src" \
+    "$fixture/injected/src" \
     "$fixture/scripts" \
     "$fixture/tools/flight-tune/src" \
     "$fixture/tools/flight-tune-aviate/src/bin" \
@@ -26,8 +27,10 @@ write_workspace() {
         '    "adapters/flight-tune-xplane",' \
         '    "adapters/pilotage-xplane-trial",' \
         '    "crates/pilotage-trial",' \
+        '    "injected",' \
         '    "tools/flight-tune",' \
         '    "tools/flight-tune-aviate",' \
+        '    "tools/flight-tune-campaign",' \
         ']' \
         'resolver = "2"' \
         > "$fixture/Cargo.toml"
@@ -50,6 +53,16 @@ write_adapter_packages() {
         > "$fixture/adapters/pilotage-xplane-trial/Cargo.toml"
     printf '%s\n' 'pub fn adapter() {}' \
         > "$fixture/adapters/pilotage-xplane-trial/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "injected"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[lib]' \
+        'proc-macro = true' \
+        > "$fixture/injected/Cargo.toml"
+    printf '%s\n' 'extern crate proc_macro;' \
+        > "$fixture/injected/src/lib.rs"
 }
 
 write_clean_manifests() {
@@ -78,6 +91,23 @@ write_clean_manifests() {
         > "$fixture/tools/flight-tune-aviate/Cargo.toml"
     printf '%s\n' 'pub fn host() {}' \
         > "$fixture/tools/flight-tune-aviate/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "flight-tune-campaign"' \
+        'version = "0.0.0"' \
+        'edition = "2021"' \
+        '[dependencies]' \
+        > "$fixture/tools/flight-tune-campaign/Cargo.toml"
+    printf '%s\n' 'pub mod config;' \
+        > "$fixture/tools/flight-tune-campaign/src/lib.rs"
+}
+
+write_dependency_allowlist() {
+    printf '%s\n' \
+        $'manifest\tdependency_key\tactual_package\tkind\ttarget\toptional\tsource_kind\tsource_ref\tdefault_features\tfeatures\tversion_req' \
+        $'tools/flight-tune-aviate/Cargo.toml\tflight-tune-xplane\tflight-tune-xplane\tnormal\t\tfalse\tpath\tadapters/flight-tune-xplane\ttrue\t\t*' \
+        $'tools/flight-tune-aviate/Cargo.toml\tpilotage-xplane-trial\tpilotage-xplane-trial\tnormal\t\tfalse\tpath\tadapters/pilotage-xplane-trial\ttrue\t\t*' \
+        > "$fixture/scripts/flight-tune-direct-dependency-allowlist.tsv"
 }
 
 write_allowlisted_import() {
@@ -158,6 +188,7 @@ expect_failure_with_all() {
 write_workspace
 write_adapter_packages
 write_clean_manifests
+write_dependency_allowlist
 write_allowlisted_import
 write_shared_contract
 write_campaign_contract
@@ -166,6 +197,48 @@ printf '%s\t%s\n' \
     'useflight_tune_xplane::CausalJoinConfig;' \
     > "$fixture_allowlist"
 run_guard >/dev/null
+
+printf '%s\n' '' '[patch.crates-io]' \
+    'serde = { path = "crates/pilotage-trial" }' \
+    >> "$fixture/Cargo.toml"
+expect_failure \
+    'a workspace Cargo patch source override' \
+    'Cargo.toml has an unreviewed dependency source override'
+write_workspace
+
+mkdir -p "$fixture/.cargo"
+printf '%s\n' 'paths = ["../injected"]' \
+    > "$fixture/.cargo/config.toml"
+expect_failure \
+    'a Cargo configuration path source override' \
+    '.cargo/config.toml has an unreviewed dependency source override'
+rm "$fixture/.cargo/config.toml"
+
+printf '%s\n' 'include = ["source-override.toml"]' \
+    > "$fixture/.cargo/config.toml"
+printf '%s\n' \
+    '[source.crates-io]' \
+    'replace-with = "local-registry"' \
+    > "$fixture/.cargo/source-override.toml"
+expect_failure \
+    'an included Cargo configuration source override' \
+    '.cargo/config.toml has an unreviewed dependency source override'
+rm "$fixture/.cargo/config.toml"
+rm "$fixture/.cargo/source-override.toml"
+
+printf '%s\n' \
+    'version = 4' \
+    '' \
+    '[[package]]' \
+    'name = "serde"' \
+    'version = "999.0.0"' \
+    'source = "registry+https://github.com/rust-lang/crates.io-index"' \
+    'checksum = "0000000000000000000000000000000000000000000000000000000000000000"' \
+    > "$fixture/Cargo.lock"
+expect_failure \
+    'an unreviewed Cargo lockfile registry identity' \
+    'Cargo.lock has an unreviewed registry identity for serde'
+rm "$fixture/Cargo.lock"
 
 printf '%s\n' 'pub fn marker() {}' \
     > "$fixture/tools/flight-tune-aviate/src/driver.rs"
@@ -205,6 +278,61 @@ printf '%s\n' 'use flight_tune_xplane::TestOnlyType;' \
 printf '%s\n' 'use flight_tune_xplane::TestSupportType;' \
     > "$fixture/tools/flight-tune-aviate/src/test_support.rs"
 run_guard >/dev/null
+
+printf '%s\n' \
+    '#[cfg(test)]' \
+    '#[path = "tests/runtime.rs"]' \
+    'mod runtime_fixture;' \
+    > "$fixture/tools/flight-tune-aviate/src/lib.rs"
+run_guard >/dev/null
+
+printf '%s\n' \
+    '#[path = "tests/runtime.rs"]' \
+    'mod runtime_fixture;' \
+    > "$fixture/tools/flight-tune-aviate/src/lib.rs"
+expect_failure \
+    'an unguarded test-path module' \
+    'path attribute imports test-only source without cfg(test)'
+
+printf '%s\n' 'mod test_support;' \
+    > "$fixture/tools/flight-tune-aviate/src/lib.rs"
+expect_failure \
+    'an unguarded test-support module' \
+    'module test_support is not restricted to cfg(test)'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[lib]' \
+    'path = "src/tests/runtime.rs"' \
+    '[dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'a production Cargo target in a test-only path' \
+    'has a production target outside its scanned source root'
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune-aviate"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[lib]' \
+    'path = "src/tests/runtime.rs"' \
+    'crate-type = ["cdylib"]' \
+    '[dependencies]' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
+    'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
+    > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+expect_failure \
+    'a production cdylib target in a test-only path' \
+    'has a production target outside its scanned source root'
+write_clean_manifests
 
 printf '%s\n' 'pub fn runtime() { flight_tune_xplane::run(); }' \
     > "$fixture/tools/flight-tune-aviate/src/runtime.rs"
@@ -375,8 +503,10 @@ printf '%s\n' \
     '    "adapters/flight-tune-xplane",' \
         '    "adapters/pilotage-xplane-trial",' \
         '    "crates/pilotage-trial",' \
+        '    "injected",' \
         '    "tools/flight-tune",' \
         '    "tools/flight-tune-aviate",' \
+        '    "tools/flight-tune-campaign",' \
     ']' \
     'resolver = "2"' \
     '[workspace.dependencies]' \
@@ -419,6 +549,19 @@ printf '%s\n' \
     'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
     > "$fixture/tools/flight-tune/Cargo.toml"
 run_guard >/dev/null
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    '[dependencies]' \
+    'injected = { path = "../../injected" }' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+expect_failure \
+    'a new direct production dependency' \
+    'has unreviewed direct production dependency injected'
 write_clean_manifests
 
 printf '%s\n' \
@@ -504,6 +647,250 @@ expect_failure \
     'simulator-specific field xplane_new'
 write_shared_contract
 
+printf '%s\n' \
+    'macro_rules! define_contract {' \
+    "    (\$field:ident) => {" \
+    "        pub struct SharedContract { pub \$field: String }" \
+    '    };' \
+    '}' \
+    'define_contract!(xplane_version);' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a macro-generated simulator field' \
+    'has a new simulator-specific token xplane'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract {' \
+    '    #[serde(rename = "x\u{70}lane_new")]' \
+    '    pub id: String,' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure_with_all \
+    'an escaped simulator-specific serialized field name' \
+    'has a new simulator-specific token xplane' \
+    'has a simulator-specific Serde name xplane'
+write_shared_contract
+
+printf '%s\n' \
+    'pub struct SharedContract { pub id: String }' \
+    'impl serde::Serialize for SharedContract {' \
+    '    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>' \
+    '    where S: serde::Serializer {' \
+    '        let key = concat!("x", "plane");' \
+    '        serializer.serialize_str(key)' \
+    '    }' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a hand-written shared serializer' \
+    'has an unreviewed manual Serde impl'
+write_shared_contract
+
+printf '%s\n' \
+    'use serde::Serialize as WireFormat;' \
+    'pub struct SharedContract { pub id: String }' \
+    'impl WireFormat for SharedContract {' \
+    '    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>' \
+    '    where S: serde::Serializer {' \
+    '        serializer.serialize_str("neutral")' \
+    '    }' \
+    '}' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure_with_all \
+    'an aliased hand-written shared serializer' \
+    'aliases a protected derive import' \
+    'has an unreviewed manual Serde impl'
+write_shared_contract
+
+printf '%s\n' \
+    'use injected::Serialize;' \
+    '#[derive(Serialize)]' \
+    'pub struct SharedContract { pub id: String }' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a noncanonical protected derive import' \
+    'imports protected derive Serialize from a noncanonical crate'
+write_shared_contract
+
+printf '%s\n' \
+    '#[path = "../../../outside-contract.rs"]' \
+    'mod outside_contract;' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+printf '%s\n' \
+    'pub struct SharedContract { pub xplane_version: String }' \
+    > "$fixture/outside-contract.rs"
+expect_failure \
+    'a production path outside the shared source root' \
+    'path attribute leaves its source root'
+rm "$fixture/outside-contract.rs"
+write_shared_contract
+
+printf '%s\n' \
+    '#[cfg_attr(not(test), path = "../../../outside-contract.rs")]' \
+    'mod outside_contract;' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+expect_failure \
+    'a conditional production module path' \
+    'has a conditional module path'
+write_shared_contract
+
+printf '%s\n' \
+    '#[path = "hidden.txt"]' \
+    'mod hidden;' \
+    > "$fixture/crates/pilotage-trial/src/lib.rs"
+printf '%s\n' \
+    'pub struct SharedContract { pub xplane_version: String }' \
+    > "$fixture/crates/pilotage-trial/src/hidden.txt"
+expect_failure \
+    'a production module with a non-Rust extension' \
+    'has a non-Rust module path'
+rm "$fixture/crates/pilotage-trial/src/hidden.txt"
+write_shared_contract
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/unreviewed.rs"));' \
+    > "$fixture/tools/flight-tune/src/lib.rs"
+expect_failure \
+    'an unreviewed generated source include' \
+    'has an unreviewed generated Rust include'
+write_shared_contract
+
+printf '%s\n' \
+    'include!{concat!(env!("OUT_DIR"), "/unreviewed.rs")};' \
+    > "$fixture/tools/flight-tune/src/lib.rs"
+expect_failure \
+    'an unreviewed brace-delimited generated source include' \
+    'has an unreviewed generated Rust include'
+write_shared_contract
+
+printf '%s\n' \
+    'include![concat!(env!("OUT_DIR"), "/unreviewed.rs")];' \
+    > "$fixture/tools/flight-tune/src/lib.rs"
+expect_failure \
+    'an unreviewed bracket-delimited generated source include' \
+    'has an unreviewed generated Rust include'
+write_shared_contract
+
+mkdir -p \
+    "$fixture/tools/flight-tune/src/flight_quality" \
+    "$fixture/tools/flight-tune/build_support"
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+printf '%s\n' \
+    '#[path = "build_support/evaluator_source_identity.rs"]' \
+    'mod evaluator_source_identity;' \
+    'fn main() {}' \
+    > "$fixture/tools/flight-tune/build.rs"
+printf '%s\n' 'pub fn generate() {}' \
+    > "$fixture/tools/flight-tune/build_support/evaluator_source_identity.rs"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "flight-tune"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    'build = "malicious_build.rs"' \
+    '[dependencies]' \
+    > "$fixture/tools/flight-tune/Cargo.toml"
+printf '%s\n' 'fn main() {}' \
+    > "$fixture/tools/flight-tune/malicious_build.rs"
+expect_failure \
+    'an alternate generated-source build target' \
+    'has an unreviewed custom build target'
+rm "$fixture/tools/flight-tune/malicious_build.rs"
+write_clean_manifests
+
+printf '%s\n' \
+    '[package]' \
+    'name = "pilotage-trial"' \
+    'version = "0.0.0"' \
+    'edition = "2021"' \
+    'build = "build.rs"' \
+    '[dependencies]' \
+    > "$fixture/crates/pilotage-trial/Cargo.toml"
+printf '%s\n' 'fn main() {}' \
+    > "$fixture/crates/pilotage-trial/build.rs"
+expect_failure \
+    'a custom build target in a shared contract package' \
+    'has an unreviewed custom build target'
+rm "$fixture/crates/pilotage-trial/build.rs"
+write_clean_manifests
+
+printf '%s\n' \
+    '#![cfg(any())]' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'a file-disabled allowlisted include' \
+    'has an attributed generated source file'
+
+printf '%s\n' \
+    '#[cfg(any())]' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'a conditionally disabled allowlisted include' \
+    'has an unreviewed item macro include'
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'an unfrozen allowlisted include generator' \
+    'generated source input has an unreviewed digest'
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'a repeated allowlisted generated include' \
+    'repeats its reviewed generated Rust include'
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+
+printf '%s\n' 'pub const IDENTITY: &str = "manual";' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'an allowlisted identity file without its generated include' \
+    'omits its reviewed generated Rust include'
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+
+printf '%s\n' \
+    'fn hidden_identity() {' \
+    '    include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    '}' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+expect_failure \
+    'an allowlisted generated include inside a function block' \
+    'has an unreviewed generated Rust include'
+
+printf '%s\n' \
+    'include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));' \
+    > "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+
+printf '%s\n' \
+    'mod payload;' \
+    'fn main() {}' \
+    > "$fixture/tools/flight-tune/build.rs"
+printf '%s\n' \
+    'const GENERATED: &str = "pub struct Shared { pub xplane_version: String }";' \
+    > "$fixture/tools/flight-tune/payload.rs"
+expect_failure \
+    'an allowlisted generator with an unfrozen payload route' \
+    'generated source input has an unreviewed digest'
+rm "$fixture/tools/flight-tune/payload.rs"
+rm "$fixture/tools/flight-tune/src/flight_quality/identity.rs"
+rm "$fixture/tools/flight-tune/build_support/evaluator_source_identity.rs"
+rm "$fixture/tools/flight-tune/build.rs"
+
 mkdir -p "$fixture/shared-symlink-target"
 printf '%s\n' \
     'pub struct SharedContract {' \
@@ -553,6 +940,96 @@ run_guard >/dev/null
 
 printf '%s\n' \
     'pub struct CampaignConfig {' \
+    '    #[serde(flatten)]' \
+    '    pub xplane: XPlaneCampaignConfig,' \
+    '    pub aviate_xplane_contract: PinnedFile,' \
+    '}' \
+    'pub struct XPlaneCampaignConfig {' \
+    '    pub weather_plugin_digest: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+expect_failure \
+    'a flattened campaign adapter field' \
+    'has an unreviewed Serde option flatten'
+
+printf '%s\n' \
+    '#[derive(Serialize)]' \
+    '#[serde(transparent)]' \
+    'pub struct CampaignWrapper(pub XPlaneCampaignConfig);' \
+    > "$fixture/tools/flight-tune-campaign/src/config/wrapper_escape.rs"
+expect_failure \
+    'a transparent campaign adapter wrapper' \
+    'has an unreviewed Serde option transparent'
+rm "$fixture/tools/flight-tune-campaign/src/config/wrapper_escape.rs"
+
+printf '%s\n' \
+    'pub struct SearchGroupConfig {' \
+    '    pub backend: XPlaneCampaignConfig,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config/field_type_escape.rs"
+expect_failure \
+    'a neutral campaign field with an adapter type' \
+    'SearchGroupConfig has simulator-specific field_type:backend XPlaneCampaignConfig'
+rm "$fixture/tools/flight-tune-campaign/src/config/field_type_escape.rs"
+
+printf '%s\n' \
+    'pub struct SearchGroupConfig(pub XPlaneCampaignConfig);' \
+    > "$fixture/tools/flight-tune-campaign/src/config/newtype_escape.rs"
+expect_failure \
+    'a campaign newtype with an adapter type' \
+    'SearchGroupConfig has simulator-specific tuple_field_type:0 XPlaneCampaignConfig'
+rm "$fixture/tools/flight-tune-campaign/src/config/newtype_escape.rs"
+
+printf '%s\n' \
+    'use serde::{Deserialize, Serialize};' \
+    '#[derive(Serialize, Deserialize)]' \
+    'pub struct SharedCampaignContract(pub XPlaneCampaignConfig);' \
+    > "$fixture/tools/flight-tune-campaign/src/newtype_escape.rs"
+expect_failure \
+    'a serialized campaign newtype outside config' \
+    'SharedCampaignContract has simulator-specific tuple_field_type:0 XPlaneCampaignConfig'
+rm "$fixture/tools/flight-tune-campaign/src/newtype_escape.rs"
+
+printf '%s\n' \
+    'pub struct SearchGroupConfig<Backend = XPlaneCampaignConfig> {' \
+    '    pub backend: Backend,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config/header_escape.rs"
+expect_failure \
+    'a campaign generic default with an adapter type' \
+    'SearchGroupConfig has simulator-specific header_type XPlaneCampaignConfig'
+rm "$fixture/tools/flight-tune-campaign/src/config/header_escape.rs"
+
+printf '%s\n' \
+    'pub struct SearchGroupConfig<Backend>(pub Backend)' \
+    'where' \
+    '    Backend: XPlaneBackend;' \
+    > "$fixture/tools/flight-tune-campaign/src/config/tuple_tail_escape.rs"
+expect_failure \
+    'a campaign tuple tail with an adapter bound' \
+    'SearchGroupConfig has simulator-specific header_type XPlaneBackend'
+rm "$fixture/tools/flight-tune-campaign/src/config/tuple_tail_escape.rs"
+
+printf '%s\n' \
+    'type BackendConfig = XPlaneCampaignConfig;' \
+    'pub struct SearchGroupConfig { pub backend: BackendConfig }' \
+    > "$fixture/tools/flight-tune-campaign/src/config/alias_escape.rs"
+expect_failure \
+    'a campaign adapter type alias' \
+    'has unreviewed simulator type alias BackendConfig for XPlaneCampaignConfig'
+rm "$fixture/tools/flight-tune-campaign/src/config/alias_escape.rs"
+
+printf '%s\n' \
+    'use crate::XPlaneCampaignConfig as BackendConfig;' \
+    'pub struct SearchGroupConfig { pub backend: BackendConfig }' \
+    > "$fixture/tools/flight-tune-campaign/src/config/import_alias_escape.rs"
+expect_failure \
+    'a campaign adapter import alias' \
+    'has a simulator-specific import alias'
+rm "$fixture/tools/flight-tune-campaign/src/config/import_alias_escape.rs"
+
+printf '%s\n' \
+    'pub struct CampaignConfig {' \
     '    pub xplane: XPlaneCampaignConfig,' \
     '    pub aviate_xplane_contract: PinnedFile,' \
     '    pub xplane_new: XPlaneCampaignConfig,' \
@@ -565,6 +1042,62 @@ expect_failure \
     'a new CampaignConfig X-Plane field' \
     'CampaignConfig has simulator-specific field xplane_new'
 write_campaign_contract
+
+printf '%s\n' \
+    '#[path = "escape.rs"]' \
+    'mod escape;' \
+    > "$fixture/tools/flight-tune-campaign/src/config.rs"
+printf '%s\n' \
+    'pub struct CampaignConfig { pub xplane_new: String }' \
+    > "$fixture/tools/flight-tune-campaign/src/escape.rs"
+expect_failure \
+    'a campaign sibling shared field' \
+    'CampaignConfig has simulator-specific field xplane_new'
+rm "$fixture/tools/flight-tune-campaign/src/escape.rs"
+write_campaign_contract
+
+printf '%s\n' \
+    'macro_rules! define_contract {' \
+    "    (\$field:ident) => {" \
+    "        pub struct CampaignConfig { pub \$field: String }" \
+    '    };' \
+    '}' \
+    'define_contract!(xplane_new);' \
+    > "$fixture/tools/flight-tune-campaign/src/config/macro_escape.rs"
+expect_failure_with_all \
+    'a macro-generated campaign field' \
+    'has a production macro definition' \
+    'has an unreviewed item macro define_contract'
+rm "$fixture/tools/flight-tune-campaign/src/config/macro_escape.rs"
+
+printf '%s\n' \
+    '#[inject_contract]' \
+    'pub struct CampaignConfig { pub id: String }' \
+    > "$fixture/tools/flight-tune-campaign/src/config/attribute_escape.rs"
+expect_failure \
+    'a campaign procedural attribute contract' \
+    'has an unreviewed contract attribute inject_contract'
+rm "$fixture/tools/flight-tune-campaign/src/config/attribute_escape.rs"
+
+printf '%s\n' \
+    '#[derive(InjectContract)]' \
+    'pub struct CampaignConfig { pub id: String }' \
+    > "$fixture/tools/flight-tune-campaign/src/config/derive_escape.rs"
+expect_failure \
+    'a campaign procedural derive contract' \
+    'has an unreviewed derive macro InjectContract'
+rm "$fixture/tools/flight-tune-campaign/src/config/derive_escape.rs"
+
+printf '%s\n' \
+    'pub struct XPlaneCampaignConfig {' \
+    '    pub xplane_new: String,' \
+    '}' \
+    > "$fixture/tools/flight-tune-campaign/src/config/adapter_escape.rs"
+expect_failure_with_all \
+    'an adapter type name outside its exact file' \
+    'unclassified public campaign contract XPlaneCampaignConfig' \
+    'XPlaneCampaignConfig has simulator-specific field xplane_new'
+rm "$fixture/tools/flight-tune-campaign/src/config/adapter_escape.rs"
 
 printf '%s\n' \
     '#[derive(Serialize)]' \
@@ -593,6 +1126,30 @@ expect_failure_with_all \
     'simulator-specific field xplane_version'
 rm "$fixture/tools/flight-tune-campaign/src/config/shared.rs"
 write_campaign_contract
+
+printf '%s\n' \
+    'pub use crate::config::XPlaneCampaignConfig;' \
+    > "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
+expect_failure \
+    'a simulator-specific public use re-export' \
+    'has a simulator-specific public re-export'
+rm "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
+
+printf '%s\n' \
+    'pub extern crate flight_tune_xplane as neutral_adapter;' \
+    > "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
+expect_failure \
+    'a simulator-specific public extern crate re-export' \
+    'has a simulator-specific public re-export'
+rm "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
+
+printf '%s\n' \
+    'extern crate flight_tune_xplane as neutral_adapter;' \
+    > "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
+expect_failure \
+    'a simulator-specific private extern crate alias' \
+    'has a simulator-specific extern crate'
+rm "$fixture/tools/flight-tune-campaign/src/reexport_escape.rs"
 
 run_guard >/dev/null
 echo "flight tuning boundary guard self-test: OK"


### PR DESCRIPTION
Closes #497.

This change adds an interim simulator boundary gate.

The gate freezes the current production boundary.
It permits the removal of a frozen dependency.
It rejects a new or changed dependency.

The gate checks these inputs:

- The exact 10-statement `flight_tune_xplane` import union in `flight-tune-aviate`.
- The exact 60-record direct normal and build dependency union in the protected tuning manifests.
- The Cargo package, source, path, target, optional flag, default features, features, and version request for each direct dependency.
- The reviewed Cargo.lock version, source, and checksum for each protected registry dependency and derive provider.
- Workspace and project Cargo source override routes.
- Each production Cargo target and custom build target.
- Each production Rust source path, module path, generated include, and generator input.
- Shared public contract identifiers, type references, Serde attributes, derive providers, manual serialization, aliases, and public re-exports.

The generated identity include must be present exactly once.
It must be a top-level item in its reviewed source file.

The gate scans production source roots.
It excludes development dependencies and test-only source paths.

This gate is lexical and direct.
It does not claim arbitrary transitive dependency analysis.
It does not claim compiler macro expansion.
Issue #498 owns the structural simulator-neutral lift at a campaign boundary.

Verification:

- Ruff format and lint passed.
- Mypy strict passed.
- Shell syntax and ShellCheck passed.
- The production gate passed.
- The fault-injection self-test passed.
- The current guard passed on all 44 frozen issue boundaries.
- Cargo format passed.
- Cargo Clippy passed for all targets with warnings denied.
- Cargo tests passed for all targets.
- Strict Cargo documentation passed.
- Cargo release build passed.

The documentation gate reported three existing private-link warnings in `pilotage-geo`.

SIM / NOT FOR FLIGHT.
