### PR TITLE
Make the coastline archive complete over the world

### DIFF
--- a/clients/apple/Resources/SituationCoastline.manifest.json
+++ b/clients/apple/Resources/SituationCoastline.manifest.json
@@ -1,12 +1,12 @@
 {
-  "plan_sha256": "1ea2b7719ae2fce191ce3160d5c6424c5aef0abcf65777275481406dabd5a095",
-  "archive_sha256": "d54e07e7be017d822470ddf0f2587361047b77d2ced1ed54e6c4e520a5fda89e",
-  "tiles_written": 17171,
-  "archive_bytes": 7995392,
+  "plan_sha256": "ba97418e145471e7aac00e217a6b22e2d4c8be6a3d3fda902f82ca480f77d69c",
+  "archive_sha256": "9cf9cbefca1fea731b873888da82110207492f920677f7811190d104a3432df7",
+  "tiles_written": 21845,
+  "archive_bytes": 13955072,
   "source_name": "Natural Earth",
   "dataset_scale": "1:10m",
   "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.",
-  "closest_zoom": 15,
+  "closest_zoom": 7,
   "sources": [
     {
       "name": "ocean",
@@ -34,29 +34,11 @@
     {
       "name": "world",
       "min_zoom": 0,
-      "max_zoom": 5,
+      "max_zoom": 7,
       "min_lat_deg": -85.0511287798066,
       "max_lat_deg": 85.0511287798066,
       "min_lon_deg": -180.0,
       "max_lon_deg": 180.0
-    },
-    {
-      "name": "region",
-      "min_zoom": 6,
-      "max_zoom": 10,
-      "min_lat_deg": 37.5,
-      "max_lat_deg": 43.5,
-      "min_lon_deg": -81.0,
-      "max_lon_deg": -72.0
-    },
-    {
-      "name": "local",
-      "min_zoom": 11,
-      "max_zoom": 15,
-      "min_lat_deg": 40.1,
-      "max_lat_deg": 41.1,
-      "min_lon_deg": -75.25,
-      "max_lon_deg": -74.25
     }
   ]
 }

--- a/clients/apple/Resources/SituationCoastline.plan.json
+++ b/clients/apple/Resources/SituationCoastline.plan.json
@@ -2,7 +2,7 @@
   "source_name": "Natural Earth",
   "dataset_scale": "1:10m",
   "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.",
-  "closest_zoom": 15,
+  "closest_zoom": 7,
   "sources": [
     {
       "name": "ocean",
@@ -30,29 +30,11 @@
     {
       "name": "world",
       "min_zoom": 0,
-      "max_zoom": 5,
+      "max_zoom": 7,
       "min_lat_deg": -85.0511287798066,
       "max_lat_deg": 85.0511287798066,
       "min_lon_deg": -180.0,
       "max_lon_deg": 180.0
-    },
-    {
-      "name": "region",
-      "min_zoom": 6,
-      "max_zoom": 10,
-      "min_lat_deg": 37.5,
-      "max_lat_deg": 43.5,
-      "min_lon_deg": -81.0,
-      "max_lon_deg": -72.0
-    },
-    {
-      "name": "local",
-      "min_zoom": 11,
-      "max_zoom": 15,
-      "min_lat_deg": 40.1,
-      "max_lat_deg": 41.1,
-      "min_lon_deg": -75.25,
-      "max_lon_deg": -74.25
     }
   ]
 }

--- a/clients/apple/Resources/SituationCoastline.provenance.md
+++ b/clients/apple/Resources/SituationCoastline.provenance.md
@@ -18,8 +18,12 @@ Natural Earth data is in the public domain. The map carries this attribution:
 The source scale is 1:10m. This scale gives a stable coastline at the closest zoom in the
 plan. It does not give survey accuracy in a harbor.
 
-The plan uses three zoom bands. The world band supports a full-globe view. The region band
-supports the normal flight area. The local band supports the closest zoom.
+The plan uses one zoom band, and that band covers the world. A vector tile that the
+archive does not hold draws nothing, and no shallower tile takes its place. A band that
+stops at a longitude therefore stops the land and the sea at a straight line, and the
+reader sees a rectangle of bare background. Above the deepest zoom in the plan, the
+renderer stretches the tiles that it has. The picture then changes with the zoom, and
+never with the position of the reader.
 
 ## Build
 

--- a/clients/apple/scripts/build-situation-coastline.sh
+++ b/clients/apple/scripts/build-situation-coastline.sh
@@ -112,6 +112,7 @@ fi
 
 mv "$work/archive.mbtiles" "$archive"
 archive_digest=$(shasum -a 256 "$archive" | awk '{print $1}')
+
 jq -n \
     --arg plan_sha256 "$plan_digest" \
     --arg archive_sha256 "$archive_digest" \

--- a/clients/web/situation-map.js
+++ b/clients/web/situation-map.js
@@ -164,14 +164,16 @@ export function wireSituationMapStage(doc, { log = () => {} } = {}) {
     }
     await loadStylesheet(doc, VENDOR_STYLESHEET.href);
 
-    const [template, coastlineTileJson, terrainTileJson, terrainManifest] =
-      await Promise.all([
-        fetchJson(ASSETS_BASE + manifest.style),
-        fetchJson(ASSETS_BASE + manifest.sources?.["pilotage-coastline"]),
-        fetchJson(ASSETS_BASE + manifest.sources?.["pilotage-terrain"]),
-        fetchJson(ASSETS_BASE + manifest.terrain_manifest),
-      ]);
-    if (template === null || coastlineTileJson === null || terrainTileJson === null) {
+    const sourceNames = Object.keys(manifest.sources ?? {});
+    const [template, terrainManifest, ...tileJsonDocuments] = await Promise.all([
+      fetchJson(ASSETS_BASE + manifest.style),
+      fetchJson(ASSETS_BASE + manifest.terrain_manifest),
+      ...sourceNames.map((name) => fetchJson(ASSETS_BASE + manifest.sources[name])),
+    ]);
+    const tileJsonBySource = Object.fromEntries(
+      sourceNames.map((name, index) => [name, tileJsonDocuments[index]]),
+    );
+    if (template === null || tileJsonDocuments.some((document) => document === null)) {
       setUnavailable(MAP_REASON.STYLE_INVALID, "the asset export is incomplete");
       return null;
     }
@@ -181,8 +183,7 @@ export function wireSituationMapStage(doc, { log = () => {} } = {}) {
       style = resolveSituationStyle({
         template,
         assetsBase: ASSETS_BASE,
-        coastlineTileJson,
-        terrainTileJson,
+        tileJsonBySource,
         glyphsPath: typeof manifest.glyphs === "string" ? manifest.glyphs : null,
       });
     } catch (error) {

--- a/clients/web/situation-style.js
+++ b/clients/web/situation-style.js
@@ -13,6 +13,14 @@ export const GLYPHS_TOKEN = "__PILOTAGE_GLYPHS_URL__";
 export const COASTLINE_TOKEN = "__PILOTAGE_COASTLINE_MBTILES_URL__";
 export const TERRAIN_TOKEN = "__PILOTAGE_TERRAIN_MBTILES_URL__";
 
+/** Which archive token each style source carries. A source is resolved
+ *  against the export named here, so a source added to the style without
+ *  an export is a typed refusal rather than a silent empty layer. */
+const SOURCE_TOKENS = Object.freeze({
+  "pilotage-coastline": COASTLINE_TOKEN,
+  "pilotage-terrain": TERRAIN_TOKEN,
+});
+
 /** Zoom levels the camera may go past the deepest terrain tile. A
  *  raster-dem source draws past its deepest tile by stretching the one it
  *  has, and far past it the picture is invention. The value matches the
@@ -96,9 +104,9 @@ function inlineTileSource(source, tileJson, assetsBase) {
  *
  * `template` is the parsed SituationStyle.json document. `assetsBase` is the
  * URL prefix the exported asset tree is served under, ending in "/".
- * `coastlineTileJson` and `terrainTileJson` are the parsed exported TileJSON
- * documents. `glyphsPath` is the fonts directory relative to `assetsBase`,
- * or null when the export carries no fonts.
+ * `tileJsonBySource` maps each style source name to its parsed exported
+ * TileJSON document. `glyphsPath` is the fonts directory relative to
+ * `assetsBase`, or null when the export carries no fonts.
  *
  * Returns a new style object; the template is not modified. Throws
  * SituationStyleError when the template does not carry the expected tokens.
@@ -106,30 +114,25 @@ function inlineTileSource(source, tileJson, assetsBase) {
 export function resolveSituationStyle({
   template,
   assetsBase,
-  coastlineTileJson,
-  terrainTileJson,
+  tileJsonBySource,
   glyphsPath,
 }) {
   const style = structuredClone(template);
   const sources = style?.sources;
-  const coastline = sources?.["pilotage-coastline"];
-  const terrain = sources?.["pilotage-terrain"];
-  if (coastline?.url !== COASTLINE_TOKEN || terrain?.url !== TERRAIN_TOKEN) {
-    throw new SituationStyleError(
-      STYLE_REASON.INVALID_TEMPLATE,
-      "the style template does not carry the archive URL tokens",
+  for (const [name, token] of Object.entries(SOURCE_TOKENS)) {
+    const source = sources?.[name];
+    if (source?.url !== token) {
+      throw new SituationStyleError(
+        STYLE_REASON.INVALID_TEMPLATE,
+        `the style template does not carry the archive URL token for ${name}`,
+      );
+    }
+    delete source.url;
+    Object.assign(
+      source,
+      inlineTileSource(name, tileJsonBySource?.[name], assetsBase),
     );
   }
-  delete coastline.url;
-  Object.assign(
-    coastline,
-    inlineTileSource("pilotage-coastline", coastlineTileJson, assetsBase),
-  );
-  delete terrain.url;
-  Object.assign(
-    terrain,
-    inlineTileSource("pilotage-terrain", terrainTileJson, assetsBase),
-  );
   // Without a glyph source the renderer draws no text at all. A missing font
   // set costs the labels, not the map: the glyphs key is dropped rather than
   // the style refused.

--- a/clients/web/situation-style.test.mjs
+++ b/clients/web/situation-style.test.mjs
@@ -41,25 +41,20 @@ const styleResolverSwift = readFileSync(
 const mapDefaultsSwift = readFileSync(join(appleApp, "PilotageApp.swift"), "utf8");
 
 const ASSETS_BASE = "http://client.test/situation-assets/";
-const coastlineTileJson = {
-  tilejson: "3.0.0",
-  tiles: ["coastline/{z}/{x}/{y}.pbf"],
-  minzoom: 0,
-  maxzoom: 15,
-};
-const terrainTileJson = {
-  tilejson: "3.0.0",
-  tiles: ["terrain/{z}/{x}/{y}.png"],
-  minzoom: 0,
-  maxzoom: 13,
+const tileJsonBySource = {
+  "pilotage-coastline": {
+    tilejson: "3.0.0", tiles: ["coastline/{z}/{x}/{y}.pbf"], minzoom: 0, maxzoom: 7,
+  },
+  "pilotage-terrain": {
+    tilejson: "3.0.0", tiles: ["terrain/{z}/{x}/{y}.png"], minzoom: 0, maxzoom: 13,
+  },
 };
 
 function resolved(overrides = {}) {
   return resolveSituationStyle({
     template: sharedStyle,
     assetsBase: ASSETS_BASE,
-    coastlineTileJson,
-    terrainTileJson,
+    tileJsonBySource,
     glyphsPath: "fonts",
     ...overrides,
   });
@@ -71,7 +66,7 @@ function testTokensResolveToInlineTileSources() {
   assert.equal(coastline.url, undefined, "the archive token is consumed");
   assert.deepEqual(coastline.tiles, [`${ASSETS_BASE}coastline/{z}/{x}/{y}.pbf`]);
   assert.equal(coastline.minzoom, 0);
-  assert.equal(coastline.maxzoom, 15);
+  assert.equal(coastline.maxzoom, 7, "overzoom past the deepest tile is the renderer's");
   const terrain = style.sources["pilotage-terrain"];
   assert.deepEqual(terrain.tiles, [`${ASSETS_BASE}terrain/{z}/{x}/{y}.png`]);
   assert.equal(terrain.maxzoom, 13, "overzoom past the deepest tile is the renderer's");
@@ -79,6 +74,46 @@ function testTokensResolveToInlineTileSources() {
 }
 testTokensResolveToInlineTileSources();
 console.log("ok - testTokensResolveToInlineTileSources");
+
+function testTheCoastlineSourceStopsWhereTheArchiveIsStillGlobal() {
+  // A vector tile the archive does not hold draws nothing, and no
+  // shallower tile stands in for it the way a raster tile's parent does.
+  // Past the deepest zoom a source declares, the renderer stretches the
+  // tile it has instead of asking for one that does not exist. So the
+  // depth the source declares has to be a depth the archive holds
+  // EVERYWHERE, and the plan is what states that.
+  const plan = JSON.parse(
+    readFileSync(new URL("../apple/Resources/SituationCoastline.plan.json", import.meta.url)),
+  );
+  for (const band of plan.bands) {
+    assert.ok(
+      band.min_lon_deg <= -180 && band.max_lon_deg >= 180 &&
+        band.min_lat_deg <= -85 && band.max_lat_deg >= 85,
+      `band ${band.name} covers the world`,
+    );
+  }
+  for (let zoom = 0; zoom <= plan.closest_zoom; zoom += 1) {
+    const covering = plan.bands.filter(
+      (band) => band.min_zoom <= zoom && band.max_zoom >= zoom,
+    );
+    assert.equal(covering.length, 1, `exactly one band covers zoom ${zoom}`);
+  }
+  assert.equal(
+    plan.closest_zoom,
+    Math.max(...plan.bands.map((band) => band.max_zoom)),
+    "the closest zoom is the deepest band",
+  );
+  // The export writes the source's ceiling from the tiles the archive
+  // holds, so the fixture above states what the plan promises. Reading
+  // the export itself would make this suite need a build artifact.
+  assert.equal(
+    tileJsonBySource["pilotage-coastline"].maxzoom,
+    plan.closest_zoom,
+    "the fixture stops where the plan says the archive stops",
+  );
+}
+testTheCoastlineSourceStopsWhereTheArchiveIsStillGlobal();
+console.log("ok - testTheCoastlineSourceStopsWhereTheArchiveIsStillGlobal");
 
 function testResolutionPreservesTheSharedContract() {
   const style = resolved();
@@ -123,12 +158,20 @@ console.log("ok - testInvalidTemplateIsATypedRefusal");
 function testUnusableTileJsonIsATypedRefusal() {
   for (const broken of [null, {}, { tiles: [] }, { tiles: ["a"], minzoom: 0 }]) {
     assert.throws(
-      () => resolved({ coastlineTileJson: broken }),
+      () =>
+        resolved({
+          tileJsonBySource: { ...tileJsonBySource, "pilotage-coastline": broken },
+        }),
       (error) =>
         error instanceof SituationStyleError &&
         error.reason === STYLE_REASON.INVALID_TILEJSON,
     );
   }
+  // A source the export does not describe is refused, never left empty.
+  assert.throws(
+    () => resolved({ tileJsonBySource: { "pilotage-coastline": tileJsonBySource["pilotage-coastline"] } }),
+    (error) => error instanceof SituationStyleError,
+  );
 }
 testUnusableTileJsonIsATypedRefusal();
 console.log("ok - testUnusableTileJsonIsATypedRefusal");

--- a/docs/web-situation-map.md
+++ b/docs/web-situation-map.md
@@ -46,10 +46,25 @@ from the south and the web tile URL scheme counts from the north. The export
 also decompresses each vector tile, because a static file server sends no
 `Content-Encoding` header.
 
-The archives hold zoom bands: a world band plus deeper regional bands. A
-view outside a deep band shows no coastline fill at that zoom, and the
-terrain stretches its deepest world tile. Both renderers show a banded
-archive the same way.
+The two archives hold their zoom bands differently, because the renderer
+treats a missing tile differently in each.
+
+A raster tile that the terrain archive does not hold is drawn from the
+tile above it, stretched. The terrain archive can therefore hold a world
+band plus deeper bands over the area that is flown: the relief outside
+those bands is coarse, and it is always drawn.
+
+A vector tile that the coastline archive does not hold draws nothing at
+all, and no shallower tile stands in for it. A band that stops at a
+longitude therefore stops the land and the sea at a straight line, and the
+reader sees a rectangle of bare background. The coastline archive is for
+that reason complete over the world at every zoom it holds. Above its
+deepest zoom the renderer stretches the tiles that it has, so the picture
+changes with the zoom and never with the position of the reader.
+
+The cost of that completeness sets the depth. Zoom 7 over the world is
+21845 tiles and about 13 MB. Each deeper zoom multiplies both by four, and
+the 1:10m source data does not carry more shape than zoom 7 shows.
 
 Serve the repository root statically and open the viewer:
 

--- a/scripts/build-web-situation-assets.sh
+++ b/scripts/build-web-situation-assets.sh
@@ -78,8 +78,8 @@ staging="$out.new"
 rm -rf "$staging"
 trap 'rm -rf "$staging"' EXIT
 
-python3 - "$style" "$terrain_manifest" "$coastline_archive" "$terrain_archive" \
-    "$fonts" "$staging" <<'EOF'
+python3 - "$style" "$terrain_manifest" "$coastline_archive" \
+    "$terrain_archive" "$fonts" "$staging" <<'EOF'
 import gzip
 import json
 import shutil
@@ -112,12 +112,12 @@ with open(style_path, encoding="utf-8") as handle:
 sources = style.get("sources")
 if not isinstance(sources, dict):
     fail("the style has no sources object")
-coastline_source = sources.get("pilotage-coastline", {})
-terrain_source = sources.get("pilotage-terrain", {})
-if coastline_source.get("url") != COASTLINE_TOKEN:
-    fail("the style coastline source does not carry the archive token")
-if terrain_source.get("url") != TERRAIN_TOKEN:
-    fail("the style terrain source does not carry the archive token")
+for name, token in (
+    ("pilotage-coastline", COASTLINE_TOKEN),
+    ("pilotage-terrain", TERRAIN_TOKEN),
+):
+    if sources.get(name, {}).get("url") != token:
+        fail(f"the style source {name} does not carry its archive token")
 if style.get("glyphs") != f"{GLYPHS_TOKEN}/{{fontstack}}/{{range}}.pbf":
     fail("the style does not carry the glyphs token")
 

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -105,6 +105,49 @@ if ! jq -e '
     status=1
 fi
 
+# A vector tile the archive does not hold draws nothing, and no shallower
+# tile stands in for it the way a raster tile's parent does. So every zoom a
+# vector source declares must be covered EVERYWHERE: a band that stops at a
+# longitude stops the map's land and sea at a straight line, and a reader
+# meets a rectangle of bare background or of flat water with no shore. Above
+# the deepest declared zoom the renderer stretches every tile alike, so the
+# picture changes with zoom and never with where a reader is looking.
+if ! jq -e '
+    (.bands | length) >= 1 and
+    all(.bands[];
+        .min_lon_deg <= -180 and .max_lon_deg >= 180 and
+        .min_lat_deg <= -85 and .max_lat_deg >= 85) and
+    (.closest_zoom == ([.bands[].max_zoom] | max)) and
+    ([range(0; .closest_zoom + 1) as $zoom |
+        ([.bands[] | select(.min_zoom <= $zoom and .max_zoom >= $zoom)] | length)] |
+        all(. == 1))
+' "$coastline_plan" >/dev/null; then
+    echo "FORBIDDEN: every zoom the coastline declares must cover the world" >&2
+    status=1
+fi
+
+# The archive must hold what the plan promises: a zoom that declares global
+# coverage and ships a handful of tiles is a plan the build did not keep.
+if [ -f "$coastline_archive" ]; then
+    deepest="$(jq -r '.closest_zoom' "$coastline_plan")"
+    tiles_at_deepest="$(sqlite3 "$coastline_archive" \
+        "SELECT COUNT(*) FROM tiles WHERE zoom_level = $deepest;")"
+    expected="$(python3 -c "print(4 ** $deepest)")"
+    # An unreadable archive answers with nothing, and an empty string in an
+    # arithmetic comparison is an error that the enclosing `if` would read
+    # as "not less than" — a silent pass on the one input that proves least.
+    if ! printf '%s' "$tiles_at_deepest" | grep -Eq '^[0-9]+$'; then
+        echo "FORBIDDEN: the coastline archive did not answer for its deepest zoom" >&2
+        status=1
+    # A band that covers the world holds a large fraction of its zoom's
+    # tiles. Half is far below what a real build produces and far above
+    # what a regional band could reach.
+    elif [ "$tiles_at_deepest" -lt "$((expected / 2))" ]; then
+        echo "FORBIDDEN: the coastline archive does not cover the world at its deepest zoom" >&2
+        status=1
+    fi
+fi
+
 if ! jq -e '
     ([.layers[] | select(.id == "pilotage-ocean-fill") |
         select(.paint["fill-color"] == "#061927" and .paint["fill-opacity"] == 1)] |
@@ -214,6 +257,7 @@ else
     status=1
 fi
 
+
 # A world band keeps a zoomed-out map from showing empty ocean, and a regional band gives
 # the zoom a pilot reads. An archive with only one of them looks correct at one zoom and
 # blank at the other.
@@ -245,13 +289,6 @@ if ! jq -e '
     (.attribution | length > 0)
 ' "$coastline_plan" >/dev/null; then
     echo "FORBIDDEN: the coastline plan must define verified data for each map zoom" >&2
-    status=1
-fi
-
-terrain_deepest_zoom="$(jq -r '[.bands[].max_zoom] | max' "$manifest")"
-coastline_closest_zoom="$(jq -r '.closest_zoom' "$coastline_plan")"
-if [ "$coastline_closest_zoom" -ne "$((terrain_deepest_zoom + 2))" ]; then
-    echo "FORBIDDEN: the coastline plan must reach the closest map zoom" >&2
     status=1
 fi
 

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -47,8 +47,23 @@ cp "$root/clients/apple/project.yml" \
 PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null
 
-sed -i.bak 's/#cfc9b4/#ff0000/' \
-    "$fixture/clients/apple/Resources/SituationStyle.json"
+# A mutation that changes nothing proves nothing. The guard then reads an
+# untouched fixture, accepts it correctly, and the case reports a hole that
+# is not there. Every mutation has to say what it expects to change, so a
+# pattern that stops matching the file it edits fails here and not later.
+mutate() {
+    local file="$1"
+    shift
+    local before
+    before="$(shasum -a 256 "$file" | awk '{print $1}')"
+    sed -i.bak "$@" "$file"
+    if [ "$(shasum -a 256 "$file" | awk '{print $1}')" = "$before" ]; then
+        echo "the mutation changed nothing in $file: $*" >&2
+        exit 1
+    fi
+}
+
+mutate "$fixture/clients/apple/Resources/SituationStyle.json" 's/#cfc9b4/#ff0000/'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted an unsafe colour" >&2
@@ -56,6 +71,99 @@ if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
 fi
 cp "$root/clients/apple/Resources/SituationStyle.json" \
     "$fixture/clients/apple/Resources/"
+
+# Every mutation below must be refused; the helper restores the style
+# between them.
+# A plan the guard reads is also a plan its manifest describes, and the
+# manifest carries the plan's digest. Rewriting the plan therefore fails the
+# digest check FIRST, and every case below would be "rejected" for a reason
+# that has nothing to do with the invariant it claims to prove. The manifest
+# is re-synced from the mutated plan so the only thing left wrong is the
+# invariant under test, and the case asserts the message it expects.
+reject_plan() {
+    local expected="$1"
+    local plan="$fixture/clients/apple/Resources/SituationCoastline.plan.json"
+    local manifest="$fixture/clients/apple/Resources/SituationCoastline.manifest.json"
+    if cmp -s "$root/clients/apple/Resources/SituationCoastline.plan.json" "$plan"; then
+        echo "the mutation for \"$expected\" changed nothing in the plan" >&2
+        exit 1
+    fi
+    python3 - "$plan" "$manifest" <<'RESYNC'
+import hashlib
+import json
+import sys
+
+plan_path, manifest_path = sys.argv[1], sys.argv[2]
+plan = json.load(open(plan_path, encoding="utf-8"))
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+manifest["plan_sha256"] = hashlib.sha256(open(plan_path, "rb").read()).hexdigest()
+for key in ("dataset_scale", "closest_zoom", "sources", "bands"):
+    manifest[key] = plan[key]
+json.dump(manifest, open(manifest_path, "w", encoding="utf-8"), indent=2)
+open(manifest_path, "a", encoding="utf-8").write("\n")
+RESYNC
+    local output
+    if output="$(PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+        bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" 2>&1)"; then
+        echo "the terrain guard accepted $expected" >&2
+        exit 1
+    fi
+    if ! printf '%s' "$output" | grep -Fq "$expected"; then
+        echo "the terrain guard refused $expected for another reason:" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+    cp "$root/clients/apple/Resources/SituationCoastline.plan.json" "$plan"
+    cp "$root/clients/apple/Resources/SituationCoastline.manifest.json" "$manifest"
+}
+
+reject_style() {
+    if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+        bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
+        echo "the terrain guard accepted $1" >&2
+        exit 1
+    fi
+    cp "$root/clients/apple/Resources/SituationStyle.json" \
+        "$fixture/clients/apple/Resources/"
+}
+
+# Every zoom a vector source declares must cover the world: a band that
+# stops at a longitude stops the map's shapes at a straight line.
+python3 - "$fixture/clients/apple/Resources/SituationCoastline.plan.json" <<'BAND_REGIONAL'
+import json
+import sys
+path = sys.argv[1]
+plan = json.load(open(path))
+plan["bands"].append({
+    "name": "region", "min_zoom": 8, "max_zoom": 9,
+    "min_lat_deg": 45.7, "max_lat_deg": 48.1,
+    "min_lon_deg": 5.8, "max_lon_deg": 10.6,
+})
+plan["closest_zoom"] = 9
+json.dump(plan, open(path, "w"))
+BAND_REGIONAL
+reject_plan "every zoom the coastline declares must cover the world"
+
+python3 - "$fixture/clients/apple/Resources/SituationCoastline.plan.json" <<'BAND_GAP'
+import json
+import sys
+path = sys.argv[1]
+plan = json.load(open(path))
+plan["bands"][0]["min_zoom"] = 2
+json.dump(plan, open(path, "w"))
+BAND_GAP
+reject_plan "every zoom the coastline declares must cover the world"
+
+python3 - "$fixture/clients/apple/Resources/SituationCoastline.plan.json" <<'CLOSEST'
+import json
+import sys
+path = sys.argv[1]
+plan = json.load(open(path))
+plan["closest_zoom"] = plan["closest_zoom"] + 1
+json.dump(plan, open(path, "w"))
+CLOSEST
+reject_plan "every zoom the coastline declares must cover the world"
+
 
 # The polygon layers are the source of the coastline. The elevation ramp is not a
 # coastline source.
@@ -124,8 +232,7 @@ fi
 
 cp "$root/clients/apple/Resources/SituationStyle.json" \
     "$fixture/clients/apple/Resources/"
-sed -i.bak 's/components.scheme = "mbtiles"/components.scheme = "file"/' \
-    "$fixture/clients/apple/App/SituationStyleResource.swift"
+mutate "$fixture/clients/apple/App/SituationStyleResource.swift" 's/components.scheme = "mbtiles"/components.scheme = "file"/'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted a non-MBTiles resource URL" >&2
@@ -137,8 +244,7 @@ cp "$root/clients/apple/App/SituationStyleResource.swift" \
 
 # A manifest that no longer describes the committed plan means the archive on disk was
 # built for different tiles than the ones the repository asks for.
-sed -i.bak 's/"min_zoom": 6/"min_zoom": 7/' \
-    "$fixture/clients/apple/Resources/SituationTerrain.plan.json"
+mutate "$fixture/clients/apple/Resources/SituationTerrain.plan.json" 's/"min_zoom": 6/"min_zoom": 7/'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted a manifest that does not match its plan" >&2
@@ -147,15 +253,8 @@ fi
 cp "$root/clients/apple/Resources/SituationTerrain.plan.json" \
     "$fixture/clients/apple/Resources/"
 
-sed -i.bak 's/"closest_zoom": 15/"closest_zoom": 14/' \
-    "$fixture/clients/apple/Resources/SituationCoastline.plan.json"
-if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
-    bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
-    echo "the terrain guard accepted a coastline plan below the closest zoom" >&2
-    exit 1
-fi
-cp "$root/clients/apple/Resources/SituationCoastline.plan.json" \
-    "$fixture/clients/apple/Resources/"
+mutate "$fixture/clients/apple/Resources/SituationCoastline.plan.json" 's/"closest_zoom": 7/"closest_zoom": 6/'
+reject_plan "every zoom the coastline declares must cover the world"
 
 # Attribution is a licence condition of the tile source and has to reach the map.
 python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'STRIP'
@@ -203,8 +302,7 @@ cp "$root/clients/apple/Resources/SituationStyle.json" \
     "$fixture/clients/apple/Resources/"
 
 # A map with no closest zoom stretches one elevation pixel across the screen.
-sed -i.bak 's/mapView.maximumZoomLevel = maximumZoomLevel//' \
-    "$fixture/clients/apple/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift"
+mutate "$fixture/clients/apple/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/SituationMapView.swift" 's/mapView.maximumZoomLevel = maximumZoomLevel//'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted a map with no closest zoom" >&2
@@ -214,8 +312,7 @@ cp "$root/clients/apple/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibr
     "$fixture/clients/apple/Packages/PilotageMapLibreBinding/Sources/PilotageMapLibreBinding/"
 
 # An archive the style requires but nothing builds is a blank screen on a fresh checkout.
-sed -i.bak '/build-situation-coastline.sh/d' \
-    "$fixture/clients/apple/scripts/generate-project.sh"
+mutate "$fixture/clients/apple/scripts/generate-project.sh" '/build-situation-coastline.sh/d'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted a generator that skips an archive the style needs" >&2
@@ -243,8 +340,7 @@ fi
 
 cp "$root/crates/pilotage-terrain-build/examples/build_situation_fixture.rs" \
     "$fixture/crates/pilotage-terrain-build/examples/"
-sed -i.bak '/- path: Resources/d' \
-    "$fixture/clients/apple/project.yml"
+mutate "$fixture/clients/apple/project.yml" '/- path: Resources/d'
 if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
     echo "the terrain guard accepted an application without the terrain resource" >&2
@@ -259,5 +355,80 @@ if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
     echo "the terrain guard accepted an SVS database dependency" >&2
     exit 1
 fi
+# Every case leaves the fixture as it found it, so a case added after this
+# one reads a fixture the guard accepts rather than one an earlier case
+# poisoned.
+cp "$root/crates/pilotage-terrain-build/Cargo.toml" \
+    "$fixture/crates/pilotage-terrain-build/"
 
+# The archive checks only run where an archive exists, and the archive is a
+# build artifact no gate builds. Without this case the headline invariant of
+# the coverage change has only ever executed on a machine that happened to
+# have built one. A synthetic archive is enough: the check counts tiles.
+archive_case() {
+    local tiles="$1"
+    local expected="$2"
+    local archive="$fixture/clients/apple/Resources/SituationCoastline.mbtiles"
+    local manifest="$fixture/clients/apple/Resources/SituationCoastline.manifest.json"
+    rm -f "$archive"
+    python3 - "$archive" "$tiles" <<'BUILD'
+import sqlite3
+import sys
+
+archive, tiles = sys.argv[1], int(sys.argv[2])
+db = sqlite3.connect(archive)
+db.execute("CREATE TABLE metadata (name text, value text);")
+db.execute(
+    "CREATE TABLE tiles (zoom_level integer, tile_column integer,"
+    " tile_row integer, tile_data blob);"
+)
+db.execute(
+    "INSERT INTO metadata VALUES ('json', ?);",
+    ('{"vector_layers":[{"id":"ocean"},{"id":"land"},{"id":"lakes"}]}',),
+)
+db.executemany(
+    "INSERT INTO tiles VALUES (7, ?, 0, x'00');",
+    ((column,) for column in range(tiles)),
+)
+db.commit()
+db.close()
+BUILD
+    python3 - "$archive" "$manifest" <<'SYNC'
+import hashlib
+import json
+import sys
+
+archive, manifest_path = sys.argv[1], sys.argv[2]
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+manifest["archive_sha256"] = hashlib.sha256(open(archive, "rb").read()).hexdigest()
+json.dump(manifest, open(manifest_path, "w", encoding="utf-8"), indent=2)
+open(manifest_path, "a", encoding="utf-8").write("\n")
+SYNC
+    local output
+    output="$(PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
+        bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" 2>&1)" && local ok=1 || local ok=0
+    if [ "$expected" = "accept" ] && [ "$ok" != "1" ]; then
+        echo "the terrain guard refused an archive that covers the world:" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+    if [ "$expected" = "reject" ]; then
+        if [ "$ok" = "1" ]; then
+            echo "the terrain guard accepted an archive that covers a corner of the world" >&2
+            exit 1
+        fi
+        if ! printf '%s' "$output" |
+            grep -Fq "the coastline archive does not cover the world at its deepest zoom"; then
+            echo "the terrain guard refused the sparse archive for another reason:" >&2
+            printf '%s\n' "$output" >&2
+            exit 1
+        fi
+    fi
+    rm -f "$archive"
+    cp "$root/clients/apple/Resources/SituationCoastline.manifest.json" "$manifest"
+}
+
+# Half of 4^7 is 8192. One tile short of it is a plan the build did not keep.
+archive_case 8191 reject
+archive_case 8192 accept
 echo "Terrain base layer guard self-test: OK"


### PR DESCRIPTION
Stacked on #516 and #520.

**This replaces the earlier "world floor" approach in this PR.** The floor
was a second, shallower archive drawn under the detailed one. Review found
that its coarse water painted over detailed land — 14.8 km² in one window,
up to 150 m inland — so hydrography was drawn from the detailed source
only, and that left the flat rectangle of background over the Atlantic that
started this rework. Two sources at two resolutions could not both be
correct at the seam. There is now one source and no seam.

## What was wrong

A raster tile the terrain archive does not hold is drawn from the tile
above it, stretched. A vector tile the coastline archive does not hold
draws **nothing**, and no shallower tile stands in for it. The archive held
a global band only to zoom 5 and deeper bands only over one region, so past
zoom 5 outside that region the land and the sea stopped being drawn.

## What this does

The archive is one band and that band covers the world, zoom 0 through 7.
Above zoom 7 the renderer stretches the tiles it has, so the picture
changes with the zoom and never with where the reader is looking.

Depth is what completeness costs: zoom 7 over the world is 21845 tiles and
about 13 MB; each deeper zoom multiplies both by four; and Natural Earth
1:10m carries no more shape than zoom 7 draws.

## Guard

The invariant is now stated rather than approximated: every zoom the plan
declares covers the world, exactly one band covers each zoom, and the
closest zoom is the deepest band. When an archive is present the guard also
reads it, and fails if the deepest zoom holds fewer tiles than global
coverage produces.

The self-test gained a `mutate` helper that fails when a mutation changes
nothing. That is not hypothetical: a stale `closest_zoom: 15` pattern had
stopped matching the plan, so the guard read an untouched fixture, accepted
it correctly, and the case reported a hole that was not there.

## Measured

Archive: 21845 tiles, 13.3 MB, full 4^z count at every zoom 0–7.
Exported TileJSON declares `maxzoom: 7`, which is what makes the renderer
overzoom instead of requesting a tile that does not exist.

Frames captured with `gl.readPixels`, counting pixels still showing the
style's background colour:

| view | zoom | bare background |
|---|---|---|
| Atlantic, off New Jersey | 7 | 0.00% |
| Atlantic, off New Jersey | 10 | 0.00% |
| Zurich | 12 | 0.00% |
| mid-Pacific | 9 | 0.00% |
| Indian Ocean | 4 | 0.00% |

Every one of those lay outside the old regional and local bands, and three
are deeper than the archive's deepest tile.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>