### PR TITLE
Give the base map an aeronautical chart look

### DIFF
--- a/clients/apple/Resources/SituationCoastline.manifest.json
+++ b/clients/apple/Resources/SituationCoastline.manifest.json
@@ -1,8 +1,8 @@
 {
-  "plan_sha256": "ba97418e145471e7aac00e217a6b22e2d4c8be6a3d3fda902f82ca480f77d69c",
-  "archive_sha256": "9cf9cbefca1fea731b873888da82110207492f920677f7811190d104a3432df7",
+  "plan_sha256": "b550edbe89de100b4f296dc17e054aa19510ac038394a972b66916a5b3490170",
+  "archive_sha256": "0f0b52d3bf0109052b0fca9b8690853b9c66c88e6ead9fd027596678dd42eaec",
   "tiles_written": 21845,
-  "archive_bytes": 13955072,
+  "archive_bytes": 20758528,
   "source_name": "Natural Earth",
   "dataset_scale": "1:10m",
   "attribution": "Made with Natural Earth. Free vector and raster map data at naturalearthdata.com.",
@@ -28,6 +28,51 @@
       "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes.zip",
       "sha256": "0803a06f9c3cb4671d89b68c48b142aad9366ba40f665245e12a913fbc61722a",
       "shapefile": "ne_10m_lakes.shp"
+    },
+    {
+      "name": "lakes_europe",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes_europe.zip",
+      "sha256": "c0b1f0da4dce6af3b27c49b3ed11a664d801ff3d140ca5b9814e7e85a35c1de1",
+      "shapefile": "ne_10m_lakes_europe.shp",
+      "layer": "lakes"
+    },
+    {
+      "name": "lakes_north_america",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes_north_america.zip",
+      "sha256": "96c824a2f2646ea8b16fe6711f7906ba690788a547f51e391654c8e94271ffba",
+      "shapefile": "ne_10m_lakes_north_america.shp",
+      "layer": "lakes"
+    },
+    {
+      "name": "rivers",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_lake_centerlines_scale_rank.zip",
+      "sha256": "a6fc02f8d663a0cb451b2564fbc361174410cd65d14c59d11ffb870ebb8c8566",
+      "shapefile": "ne_10m_rivers_lake_centerlines_scale_rank.shp",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
+    },
+    {
+      "name": "rivers_europe",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_europe.zip",
+      "sha256": "c730ccb4cbe21c1f03d006de4032a0dc69ade342de941d10aa1facab59019dbf",
+      "shapefile": "ne_10m_rivers_europe.shp",
+      "layer": "rivers",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
+    },
+    {
+      "name": "rivers_north_america",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_north_america.zip",
+      "sha256": "7fbe85a2acbf1f3ef4361a16bb39677ad1ea86f888be1689f7a4caeafc7529e8",
+      "shapefile": "ne_10m_rivers_north_america.shp",
+      "layer": "rivers",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
     }
   ],
   "bands": [

--- a/clients/apple/Resources/SituationCoastline.plan.json
+++ b/clients/apple/Resources/SituationCoastline.plan.json
@@ -24,6 +24,51 @@
       "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes.zip",
       "sha256": "0803a06f9c3cb4671d89b68c48b142aad9366ba40f665245e12a913fbc61722a",
       "shapefile": "ne_10m_lakes.shp"
+    },
+    {
+      "name": "lakes_europe",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes_europe.zip",
+      "sha256": "c0b1f0da4dce6af3b27c49b3ed11a664d801ff3d140ca5b9814e7e85a35c1de1",
+      "shapefile": "ne_10m_lakes_europe.shp",
+      "layer": "lakes"
+    },
+    {
+      "name": "lakes_north_america",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_lakes_north_america.zip",
+      "sha256": "96c824a2f2646ea8b16fe6711f7906ba690788a547f51e391654c8e94271ffba",
+      "shapefile": "ne_10m_lakes_north_america.shp",
+      "layer": "lakes"
+    },
+    {
+      "name": "rivers",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_lake_centerlines_scale_rank.zip",
+      "sha256": "a6fc02f8d663a0cb451b2564fbc361174410cd65d14c59d11ffb870ebb8c8566",
+      "shapefile": "ne_10m_rivers_lake_centerlines_scale_rank.shp",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
+    },
+    {
+      "name": "rivers_europe",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_europe.zip",
+      "sha256": "c730ccb4cbe21c1f03d006de4032a0dc69ade342de941d10aa1facab59019dbf",
+      "shapefile": "ne_10m_rivers_europe.shp",
+      "layer": "rivers",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
+    },
+    {
+      "name": "rivers_north_america",
+      "version": "5.1.1",
+      "url": "https://naturalearth.s3.amazonaws.com/5.1.1/10m_physical/ne_10m_rivers_north_america.zip",
+      "sha256": "7fbe85a2acbf1f3ef4361a16bb39677ad1ea86f888be1689f7a4caeafc7529e8",
+      "shapefile": "ne_10m_rivers_north_america.shp",
+      "layer": "rivers",
+      "geometry_type": "MULTILINESTRING",
+      "select": "featurecla,scalerank"
     }
   ],
   "bands": [

--- a/clients/apple/Resources/SituationCoastline.provenance.md
+++ b/clients/apple/Resources/SituationCoastline.provenance.md
@@ -1,7 +1,7 @@
 # Situation coastline archive
 
-This archive holds coastline data for the situation map. Coastline data means the ocean,
-land, and lake polygons that classify the map surface.
+This archive holds the surface data for the situation map: the ocean, land, and lake
+polygons that classify the map surface, and the river lines that draw its drainage.
 
 ## Source
 
@@ -39,3 +39,18 @@ verified source archive under `clients/apple/.build/coastline-sources`.
 
 The script writes `SituationCoastline.manifest.json`. The manifest records the plan
 checksum, the archive checksum, the tile count, and the source data.
+
+Each source in the plan declares the geometry it carries and the attributes it keeps. The
+river sources carry lines; the others carry polygons. GDAL writes a line source into a
+polygon layer with only a warning, and that layer then draws nothing.
+
+More than one source can feed one layer. The global 1:10m files give the world its shape.
+The regional files for Europe and North America give the flown areas the drainage density
+of a chart. The rank of a feature is a drawing scale, and not a name for the file that
+holds it: the global file holds mostly rank 0 to 9 and some dozens of features above it,
+and the regional files hold rank 10 to 12 only. The style reads the rank.
+
+Sources that feed one layer must select the same fields and the same geometry. GDAL writes
+appended features into the fields the layer was made with, and gives no message. A source
+that selects fewer fields than the source before it thus deletes a field from each feature
+in the layer.

--- a/clients/apple/Resources/SituationStyle.json
+++ b/clients/apple/Resources/SituationStyle.json
@@ -24,7 +24,7 @@
       "id": "background",
       "type": "background",
       "paint": {
-        "background-color": "#02060a"
+        "background-color": "#dfe3e6"
       }
     },
     {
@@ -43,7 +43,7 @@
       "source": "pilotage-coastline",
       "source-layer": "land",
       "paint": {
-        "fill-color": "#526044",
+        "fill-color": "#dfe7c4",
         "fill-opacity": 1
       }
     },
@@ -62,7 +62,7 @@
       "type": "color-relief",
       "source": "pilotage-terrain",
       "paint": {
-        "color-relief-opacity": 0.6,
+        "color-relief-opacity": 0.9,
         "color-relief-color": [
           "interpolate",
           [
@@ -72,41 +72,49 @@
             "elevation"
           ],
           -11000,
-          "#01040a",
-          -4000,
-          "#02070e",
-          -1000,
-          "#030b14",
-          -200,
-          "#394537",
-          -20,
-          "#4a563c",
+          "#7fb2c8",
+          -400,
+          "#a8cfe0",
+          -80,
+          "#cfdeae",
+          -2,
+          "#cfdeae",
           -1,
-          "#4f5f3e",
+          "#dfe7c4",
           0,
-          "#4f5f3e",
-          60,
-          "#6a7649",
-          200,
-          "#828a58",
-          500,
-          "#9a9668",
-          900,
-          "#ab9b73",
-          1400,
-          "#ac8b63",
-          2000,
-          "#98724c",
-          2800,
-          "#7f5836",
-          3600,
-          "#6a4830",
-          4500,
-          "#7d6a5c",
-          5200,
-          "#a99c92",
-          6000,
-          "#e8e8e8",
+          "#dfe7c4",
+          304.6,
+          "#dfe7c4",
+          304.8,
+          "#cfdeae",
+          609.4,
+          "#cfdeae",
+          609.6,
+          "#fff4db",
+          914.2,
+          "#fff4db",
+          914.4,
+          "#f7e8b8",
+          1523.8,
+          "#f7e8b8",
+          1524.0,
+          "#f2d58b",
+          2133.4,
+          "#f2d58b",
+          2133.6,
+          "#e4bf9b",
+          2743.0,
+          "#e4bf9b",
+          2743.2,
+          "#eeb47f",
+          3657.4,
+          "#eeb47f",
+          3657.6,
+          "#b48e3f",
+          5983.9,
+          "#b48e3f",
+          5984.1,
+          "#ffffff",
           8850,
           "#ffffff"
         ]
@@ -117,12 +125,166 @@
       "type": "hillshade",
       "source": "pilotage-terrain",
       "paint": {
-        "hillshade-exaggeration": 0.35,
+        "hillshade-exaggeration": 0.5,
         "hillshade-shadow-color": "#241f16",
         "hillshade-highlight-color": "#cfc9b4",
         "hillshade-accent-color": "#3a3226",
         "hillshade-illumination-direction": 315,
-        "hillshade-illumination-anchor": "map"
+        "hillshade-illumination-anchor": "map",
+        "hillshade-method": "igor"
+      }
+    },
+    {
+      "id": "pilotage-ocean-water",
+      "type": "fill",
+      "source": "pilotage-coastline",
+      "source-layer": "ocean",
+      "paint": {
+        "fill-color": "#e1eef5",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "pilotage-lake-water",
+      "type": "fill",
+      "source": "pilotage-coastline",
+      "source-layer": "lakes",
+      "paint": {
+        "fill-color": "#93cde5",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "pilotage-river",
+      "type": "line",
+      "source": "pilotage-coastline",
+      "source-layer": "rivers",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#93cde5",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          2,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              3
+            ],
+            0.4,
+            0
+          ],
+          5,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              5
+            ],
+            0.6,
+            0
+          ],
+          8,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              8
+            ],
+            1.0,
+            0
+          ],
+          9,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              4
+            ],
+            1.6,
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              9
+            ],
+            1.2,
+            0
+          ],
+          11,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              4
+            ],
+            2.6,
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              9
+            ],
+            1.8,
+            1.1
+          ],
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              4
+            ],
+            5.0,
+            [
+              "<=",
+              [
+                "get",
+                "scalerank"
+              ],
+              9
+            ],
+            3.4,
+            2.0
+          ]
+        ]
       }
     }
   ]

--- a/clients/apple/scripts/build-situation-coastline.sh
+++ b/clients/apple/scripts/build-situation-coastline.sh
@@ -60,34 +60,53 @@ jq -r '.sources[].name' "$plan" |
     while read -r source_name; do
         shapefile=$(jq -r --arg name "$source_name" \
             '.sources[] | select(.name == $name) | .shapefile' "$plan")
-        jq -r '.bands[] | [.name, .min_zoom, .max_zoom, .min_lat_deg, .max_lat_deg, .min_lon_deg, .max_lon_deg] | @tsv' "$plan" |
-            while IFS="$(printf '\t')" read -r band_name _min_zoom _max_zoom min_lat max_lat min_lon max_lon; do
-                layer_name="${source_name}_${band_name}"
-                if [ -f "$geopackage" ]; then
-                    ogr2ogr -update -nln "$layer_name" \
-                        -clipsrc "$min_lon" "$min_lat" "$max_lon" "$max_lat" \
-                        -select featurecla -nlt MULTIPOLYGON -dim XY -makevalid \
-                        "$geopackage" "$work/$source_name/$shapefile"
-                else
-                    ogr2ogr -f GPKG -nln "$layer_name" \
-                        -clipsrc "$min_lon" "$min_lat" "$max_lon" "$max_lat" \
-                        -select featurecla -nlt MULTIPOLYGON -dim XY -makevalid \
-                        "$geopackage" "$work/$source_name/$shapefile"
-                fi
-            done
+        # Several sources can feed one layer: a global file gives the world
+        # its shape, and a regional file gives the flown area the density a
+        # chart is read at. The layer is what the style names.
+        layer_name=$(jq -r --arg name "$source_name" \
+            '.sources[] | select(.name == $name) | .layer // .name' "$plan")
+        # Each source states the geometry it carries and the attributes it
+        # keeps. GDAL writes a line source into a polygon layer anyway, with
+        # only a warning, and that layer then draws nothing.
+        geometry_type=$(jq -r --arg name "$source_name" \
+            '.sources[] | select(.name == $name) | .geometry_type // "MULTIPOLYGON"' "$plan")
+        select_fields=$(jq -r --arg name "$source_name" \
+            '.sources[] | select(.name == $name) | .select // "featurecla"' "$plan")
+        # Repair of a ring is an operation on a polygon. It discards a line.
+        makevalid=""
+        if [ "$geometry_type" = "MULTIPOLYGON" ]; then
+            makevalid="-makevalid"
+        fi
+        # The fields are chosen with a query rather than with -select,
+        # because GDAL refuses -select on an append and the first source of
+        # a layer must choose the same fields as the ones that follow it.
+        query="SELECT $select_fields FROM ${shapefile%.shp}"
+        if [ -f "$geopackage" ]; then
+            # shellcheck disable=SC2086
+            ogr2ogr -update -append -nln "$layer_name" \
+                -sql "$query" -nlt "$geometry_type" -dim XY $makevalid \
+                "$geopackage" "$work/$source_name/$shapefile"
+        else
+            # shellcheck disable=SC2086
+            ogr2ogr -f GPKG -nln "$layer_name" \
+                -sql "$query" -nlt "$geometry_type" -dim XY $makevalid \
+                "$geopackage" "$work/$source_name/$shapefile"
+        fi
     done
 
 jq '
     [
-        .sources[] as $source |
-        .bands[] as $band |
+        (.sources | group_by(.layer // .name) | .[]) as $group |
+        ($group[0].layer // $group[0].name) as $layer |
         {
-            key: ($source.name + "_" + $band.name),
+            key: $layer,
             value: {
-                target_name: $source.name,
-                description: ($source.name + " polygons"),
-                minzoom: $band.min_zoom,
-                maxzoom: $band.max_zoom
+                target_name: $layer,
+                description: ($layer + " " +
+                    (if ($group[0].geometry_type // "MULTIPOLYGON") == "MULTIPOLYGON"
+                     then "polygons" else "lines" end)),
+                minzoom: ([.bands[].min_zoom] | min),
+                maxzoom: ([.bands[].max_zoom] | max)
             }
         }
     ] | from_entries

--- a/clients/web/situation-style.js
+++ b/clients/web/situation-style.js
@@ -3,7 +3,7 @@
 // One style file drives the Apple renderer and the web renderer
 // (clients/apple/Resources/SituationStyle.json, exported verbatim by
 // scripts/build-web-situation-assets.sh). This module substitutes the
-// style's three __PILOTAGE_*__ URL tokens for the exported asset URLs,
+// style's __PILOTAGE_*__ URL tokens for the exported asset URLs,
 // mirroring the Apple client's SituationStyleResource: an invalid template
 // is a typed error, a missing font set costs the labels and never the map,
 // and the closest zoom derives from the terrain manifest rather than a

--- a/docs/web-situation-map.md
+++ b/docs/web-situation-map.md
@@ -7,8 +7,9 @@ declares the globe projection. The web renderer draws the globe by default.
 
 ## One style, two renderers
 
-The style document carries three `__PILOTAGE_*__` URL tokens. Each client
-substitutes the tokens at run time:
+The style document carries a `__PILOTAGE_*__` URL token for each archive
+it reads and for its fonts. Each client substitutes the tokens at run
+time:
 
 - The Apple client points the tokens at the bundled MBTiles archives and the
   bundled fonts (`SituationStyleResource.swift`).
@@ -24,6 +25,54 @@ longitude −76.5, zoom 6, pitch 55°, minimum zoom 0. The closest zoom derives
 from `SituationTerrain.manifest.json`: the deepest band plus two overzoom
 steps. `clients/web/situation-style.test.mjs` reads the Apple sources and
 fails when one side changes a value without the other.
+
+## Palette
+
+The base map reads as an aeronautical chart. The elevation tints follow
+the FAA VFR sectional ladder, from the sectional's sea-level green through
+cream and tan to brown. The band edges are the sectional's own: 1000,
+2000, 3000, 5000, 7000, 9000, and 12 000 ft, converted to metres. The two
+water tones are the sectional's "Open Water" and "Inland Water".
+
+We read these values from the legend of the FAA Aeronautical Chart User's
+Guide, because the FAA publishes no colour table. Two editions of the
+guide agree to within a few steps of 255. The ramp continues above the
+sectional's highest band and below sea level, where the sectional's legend
+stops; those parts are ours, not the FAA's. Below sea level the ramp
+reuses the tint of the 1000 to 2000 ft band, as the sectional does, so a
+tint alone does not say which of the two a reader is looking at.
+
+Water draws over the terrain relief and over the hillshade. An elevation
+ramp cannot distinguish a lake at 500 m from ground at 500 m, so the
+polygon that carries that information keeps its own colour instead of
+taking the tint of the height below it.
+
+The hillshade uses the Igor method, which darkens a slope without a stain
+on the tint below it. It lights the terrain from the north west, as a
+chart does.
+
+## Drainage
+
+The rivers are centre lines, and they stay centre lines at every zoom.
+Natural Earth publishes no river areas, so a river has a width only where
+a lake polygon gives it one. A sectional chart draws its rivers the same
+way, and thins them by rank; the style follows that, and widens a line
+with the zoom rather than pretending to a shape the data does not carry.
+
+Three files feed the river layer: the global 1:10m network, and the
+regional files for Europe and North America. The lakes layer takes the two
+regional files as well.
+
+The rank is a drawing scale, not a name for which file a feature came from.
+The global file holds mostly rank 0 to 9 and a few dozen features above it;
+the regional files hold rank 10 to 12 only. The ladder therefore reads the
+rank and not the file: it draws nothing above rank 9 below zoom 9, and
+fades those features in between zoom 9 and zoom 11.
+
+The shape of the coast is generalized at 1:10,000,000. It disagrees with
+the terrain relief by some hundred metres. The disagreement is visible when
+a reader zooms in far, and it is the same everywhere, because one source
+draws the whole world.
 
 ## Build steps
 
@@ -62,9 +111,10 @@ that reason complete over the world at every zoom it holds. Above its
 deepest zoom the renderer stretches the tiles that it has, so the picture
 changes with the zoom and never with the position of the reader.
 
-The cost of that completeness sets the depth. Zoom 7 over the world is
-21845 tiles and about 13 MB. Each deeper zoom multiplies both by four, and
-the 1:10m source data does not carry more shape than zoom 7 shows.
+The cost of that completeness sets the depth. The archive stops at zoom 7:
+each deeper zoom multiplies the tile count and the size by four, and the
+1:10m source data does not carry more shape than zoom 7 shows. The
+manifest records what the build produced.
 
 Serve the repository root statically and open the viewer:
 

--- a/scripts/check-terrain-base-layer.sh
+++ b/scripts/check-terrain-base-layer.sh
@@ -148,12 +148,17 @@ if [ -f "$coastline_archive" ]; then
     fi
 fi
 
+# The land polygon is what a reader sees through the relief, which is drawn
+# at part opacity: it is what classifies ground as ground. The water
+# polygons under the relief are covered by the water polygons above it and
+# are there for the shoreline they give the fills beneath, so their tone is
+# pinned but not their visibility.
 if ! jq -e '
     ([.layers[] | select(.id == "pilotage-ocean-fill") |
         select(.paint["fill-color"] == "#061927" and .paint["fill-opacity"] == 1)] |
         length == 1) and
     ([.layers[] | select(.id == "pilotage-land-fill") |
-        select(.paint["fill-color"] == "#526044" and .paint["fill-opacity"] == 1)] |
+        select(.paint["fill-color"] == "#dfe7c4" and .paint["fill-opacity"] == 1)] |
         length == 1) and
     ([.layers[] | select(.id == "pilotage-lake-fill") |
         select(.paint["fill-color"] == "#061927" and .paint["fill-opacity"] == 1)] |
@@ -162,7 +167,51 @@ if ! jq -e '
         select(.paint["color-relief-opacity"] > 0 and
             .paint["color-relief-opacity"] < 1)] | length == 1)
 ' "$style" >/dev/null; then
-    echo "FORBIDDEN: coastline polygons must remain visible below terrain relief" >&2
+    echo "FORBIDDEN: the land polygon must remain visible below terrain relief" >&2
+    status=1
+fi
+
+# Water reads as water. An elevation ramp cannot distinguish a lake at
+# 500 m from ground at 500 m, so the polygon that carries that information
+# draws OVER the relief and the hillshade and keeps its own colour. Below
+# either, water takes the tint of the height below it and a reader meets
+# green where the chart says open water.
+#
+# The two tones are pinned exactly and they differ, which is what makes
+# open water and inland water read apart. A separate inequality assertion
+# would be a rule nothing can break on its own.
+if ! jq -e '
+    ([.layers[] | select(
+        .id == "pilotage-ocean-water" and .type == "fill" and
+        .source == "pilotage-coastline" and .["source-layer"] == "ocean" and
+        .paint["fill-color"] == "#e1eef5" and .paint["fill-opacity"] == 1
+    )] | length == 1) and
+    ([.layers[] | select(
+        .id == "pilotage-lake-water" and .type == "fill" and
+        .source == "pilotage-coastline" and .["source-layer"] == "lakes" and
+        .paint["fill-color"] == "#93cde5" and .paint["fill-opacity"] == 1
+    )] | length == 1) and
+    ([.layers[] | select(
+        .id == "pilotage-river" and .type == "line" and
+        .source == "pilotage-coastline" and .["source-layer"] == "rivers" and
+        .paint["line-color"] == "#93cde5"
+    )] | length == 1) and
+    (.layers | map(.id)) as $order |
+    (["pilotage-ocean-water", "pilotage-lake-water", "pilotage-river"] | all(. as $id |
+        ($order | index($id)) != null and
+        ($order | index($id)) > ($order | index("pilotage-terrain-hillshade"))))
+' "$style" >/dev/null; then
+    echo "FORBIDDEN: hydrography must draw over the relief" >&2
+    status=1
+fi
+
+# Drainage thins with zoom. Without the rank the whole world's drainage
+# draws as a web of hairlines at the zooms the world band covers.
+if ! jq -e '
+    [.layers[] | select(.id == "pilotage-river") | .paint["line-width"] |
+        .. | select(type == "string" and . == "scalerank")] | length > 0
+' "$style" >/dev/null; then
+    echo "FORBIDDEN: river width must thin by the rank the data carries" >&2
     status=1
 fi
 
@@ -276,7 +325,7 @@ fi
 if ! jq -e '
     .dataset_scale == "1:10m" and
     .closest_zoom == ([.bands[].max_zoom] | max) and
-    ([.sources[].name] | sort) == ["lakes", "land", "ocean"] and
+    ([.sources[] | .layer // .name] | unique) == ["lakes", "land", "ocean", "rivers"] and
     all(.sources[];
         (.url | startswith("https://naturalearth.s3.amazonaws.com/")) and
         (.sha256 | test("^[0-9a-f]{64}$")) and
@@ -289,6 +338,25 @@ if ! jq -e '
     (.attribution | length > 0)
 ' "$coastline_plan" >/dev/null; then
     echo "FORBIDDEN: the coastline plan must define verified data for each map zoom" >&2
+    status=1
+fi
+
+# Several sources can feed one layer. GDAL writes the appended features
+# into whatever fields the layer was created with, silently, so a source
+# that names fewer fields than the one before it deletes the missing field
+# from every feature in the layer. The rank the river ladder reads is such
+# a field: without it the ladder's own fallback is never reached, the width
+# property falls back to the renderer's default of 1, and the whole world's
+# drainage draws as hairlines at every zoom.
+if ! jq -e '
+    [.sources[] | {layer: (.layer // .name),
+                   select: (.select // "featurecla"),
+                   geometry: (.geometry_type // "MULTIPOLYGON")}]
+    | group_by(.layer)
+    | all(.[0] as $first | all(.[]; .select == $first.select and
+                                     .geometry == $first.geometry))
+' "$coastline_plan" >/dev/null; then
+    echo "FORBIDDEN: sources feeding one layer must agree on fields and geometry" >&2
     status=1
 fi
 
@@ -367,9 +435,9 @@ if [ -f "$coastline_archive" ]; then
     fi
     if ! sqlite3 "$coastline_archive" \
         "SELECT value FROM metadata WHERE name = 'json';" | jq -e '
-            [.vector_layers[].id] | sort == ["lakes", "land", "ocean"]
+            [.vector_layers[].id] | sort == ["lakes", "land", "ocean", "rivers"]
         ' >/dev/null; then
-        echo "FORBIDDEN: the coastline archive must contain ocean, land, and lakes" >&2
+        echo "FORBIDDEN: the coastline archive must contain ocean, land, lakes, and rivers" >&2
         status=1
     fi
 fi

--- a/scripts/test-check-terrain-base-layer.sh
+++ b/scripts/test-check-terrain-base-layer.sh
@@ -118,6 +118,15 @@ RESYNC
 }
 
 reject_style() {
+    # A mutation that changed nothing leaves the guard reading the committed
+    # style, which it accepts correctly. The case would then report a hole
+    # that is not there, so an edit that stops finding what it edits fails
+    # here instead.
+    if cmp -s "$root/clients/apple/Resources/SituationStyle.json" \
+        "$fixture/clients/apple/Resources/SituationStyle.json"; then
+        echo "the mutation for $1 changed nothing in the style" >&2
+        exit 1
+    fi
     if PILOTAGE_TERRAIN_SKIP_REBUILD=1 \
         bash "$fixture/scripts/check-terrain-base-layer.sh" "$fixture" >/dev/null 2>&1; then
         echo "the terrain guard accepted $1" >&2
@@ -361,6 +370,71 @@ fi
 cp "$root/crates/pilotage-terrain-build/Cargo.toml" \
     "$fixture/crates/pilotage-terrain-build/"
 
+# Water reads as water only while it draws over the relief, from the source
+# whose shape is exact where it draws, in its own tone.
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'WATER_UNDER'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+order = [layer["id"] for layer in style["layers"]]
+water = order.index("pilotage-ocean-water")
+relief = order.index("pilotage-terrain-relief")
+style["layers"].insert(relief, style["layers"].pop(water))
+json.dump(style, open(path, "w"))
+WATER_UNDER
+reject_style "water drawn under the terrain relief"
+
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'WATER_TONE'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-ocean-water":
+        layer["paint"]["fill-color"] = "#ff00ff"
+json.dump(style, open(path, "w"))
+WATER_TONE
+reject_style "an open-water tone no guard pins"
+
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'WATER_SAME'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+ids = [layer["id"] for layer in style["layers"]]
+ocean = style["layers"][ids.index("pilotage-ocean-water")]["paint"]["fill-color"]
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-lake-water":
+        layer["paint"]["fill-color"] = ocean
+json.dump(style, open(path, "w"))
+WATER_SAME
+reject_style "inland water that reads as open water"
+
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'WATER_LAND'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-ocean-water":
+        layer["source-layer"] = "land"
+json.dump(style, open(path, "w"))
+WATER_LAND
+reject_style "open water drawn from the land polygons"
+
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'RIVER_FLAT'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-river":
+        layer["paint"]["line-width"] = 1.0
+json.dump(style, open(path, "w"))
+RIVER_FLAT
+reject_style "a drainage that never thins"
+
 # The archive checks only run where an archive exists, and the archive is a
 # build artifact no gate builds. Without this case the headline invariant of
 # the coverage change has only ever executed on a machine that happened to
@@ -384,7 +458,7 @@ db.execute(
 )
 db.execute(
     "INSERT INTO metadata VALUES ('json', ?);",
-    ('{"vector_layers":[{"id":"ocean"},{"id":"land"},{"id":"lakes"}]}',),
+    ('{"vector_layers":[{"id":"ocean"},{"id":"land"},{"id":"lakes"},{"id":"rivers"}]}',),
 )
 db.executemany(
     "INSERT INTO tiles VALUES (7, ?, 0, x'00');",
@@ -427,6 +501,54 @@ SYNC
     rm -f "$archive"
     cp "$root/clients/apple/Resources/SituationCoastline.manifest.json" "$manifest"
 }
+
+# GDAL writes appended features into whatever fields the layer was created
+# with and says nothing. A river source that names fewer fields than the one
+# before it deletes the rank from every feature in the layer, and the ladder
+# that reads the rank then falls back to the renderer's default width of 1
+# for the whole world's drainage at every zoom.
+python3 - "$fixture/clients/apple/Resources/SituationCoastline.plan.json" <<'FIELD_DRIFT'
+import json
+import sys
+path = sys.argv[1]
+plan = json.load(open(path))
+for source in plan["sources"]:
+    if source.get("layer") == "rivers" and source["name"] != "rivers":
+        source["select"] = "featurecla"
+        break
+else:
+    raise SystemExit("no regional river source to edit")
+json.dump(plan, open(path, "w"))
+FIELD_DRIFT
+reject_plan "sources feeding one layer must agree on fields and geometry"
+
+# The land polygon is what a reader sees through the relief, which draws at
+# part opacity. Its tone classifies ground as ground; the relief's ramp
+# alone cannot, because an elevation is not a land-or-water statement.
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'LAND_TONE'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-land-fill":
+        layer["paint"]["fill-color"] = "#ff00ff"
+json.dump(style, open(path, "w"))
+LAND_TONE
+reject_style "a land tone no guard pins"
+
+python3 - "$fixture/clients/apple/Resources/SituationStyle.json" <<'RELIEF_OPAQUE'
+import json
+import sys
+path = sys.argv[1]
+style = json.load(open(path))
+for layer in style["layers"]:
+    if layer["id"] == "pilotage-terrain-relief":
+        layer["paint"]["color-relief-opacity"] = 1
+json.dump(style, open(path, "w"))
+RELIEF_OPAQUE
+reject_style "a relief that hides the polygon beneath it"
+
 
 # Half of 4^7 is 8192. One tile short of it is a plan the build did not keep.
 archive_case 8191 reject


### PR DESCRIPTION
Stacked on #516, #520, #521. Rebased after #521 was reworked from a world
floor to a globally complete archive; the floor-specific commit in this PR
became obsolete and is gone.

## Palette

The elevation tints follow the FAA VFR sectional ladder, with the
sectional's own band edges at 1000, 2000, 3000, 5000, 7000, 9000, and
12 000 ft converted to metres. The values come from the legend of the FAA
Aeronautical Chart User's Guide, because the FAA publishes no colour table;
two editions agree to within a few steps of 255. Above the sectional's
highest band and below sea level the ladder is ours, and the docs say so.

Hillshade uses the Igor method — it darkens a slope without staining the
tint under it — lit from the north west as a chart is.

## Water reads as water

Water draws **over** the relief and the hillshade. An elevation ramp cannot
tell a lake at 500 m from ground at 500 m, so the polygon that knows keeps
its own colour. Open water and inland water read apart.

## Drainage

Three files feed the river layer. The global 1:10m network ranks 0–9 and
draws from the zoom its rank earns. The regional files for Europe and North
America carry the minor drainage a chart is read by and rank 10–12, so the
ladder holds them back until zoom 9. The lakes layer takes the two regional
files too.

**Stated limit:** the rivers are centre lines and stay centre lines.
Natural Earth publishes no river areas, so a river has width only where a
lake polygon gives it one. A sectional chart draws rivers the same way and
thins them by rank; this style follows that, and widens a line with the
zoom rather than pretending to a shape the data does not carry. At zoom 13
a centre line visibly disagrees with the valley the relief shows — the
source is generalised at 1:10,000,000. The provenance and the docs both say
so rather than leaving a reader to discover it.

## Builder

Each source now declares the geometry it carries and the fields it keeps.
GDAL writes a line source into a polygon layer with only a warning, and
that layer then draws nothing. Fields are chosen with `-sql` rather than
`-select`, because GDAL refuses `-select` on an append and several sources
now feed one layer.

## Guards

New: hydrography draws over the relief; open and inland water read apart;
river width thins by the rank the data carries; the plan's layer set is
exactly ocean/land/lakes/rivers however many sources feed them; the built
archive carries all four vector layers.

The self-test gained five style mutations and a check that a style mutation
which changes nothing fails the case instead of reading as a guard hole.

## Measured

Archive: 21845 tiles, 19.8 MB, vector layers `["ocean","land","lakes","rivers"]`.
A zoom-7 tile over Zurich carries rivers at ranks 2, 4, 8, 10, 11 — the
regional supplement reaches the tiles.

Frames captured with `gl.readPixels`, bare-background share:

| view | zoom | bare background |
|---|---|---|
| Zurich | 9 | 0.00% |
| Zurich | 12 | 0.00% |
| Rhine at Waldshut | 11 | 0.00% |
| Aare | 13 | 0.00% |
| Atlantic | 10 | 0.00% |
| Europe | 3 | 0.00% |

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>