### PR TITLE
Publish the simulator oracle's position on the Earth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "pilotage-adapter-api",
  "pilotage-control-feel",
  "pilotage-control-web",
+ "pilotage-geo",
  "pilotage-input",
  "pilotage-mavlink",
  "pilotage-protocol",

--- a/adapters/aviate/Cargo.toml
+++ b/adapters/aviate/Cargo.toml
@@ -14,6 +14,7 @@ aviate-xil-shm = { workspace = true, optional = true }
 getrandom = { version = "0.3.4", features = ["std"] }
 pilotage-adapter-api = { workspace = true }
 pilotage-control-feel = { workspace = true }
+pilotage-geo = { workspace = true }
 pilotage-mavlink = { workspace = true }
 pilotage-sim-video = { workspace = true, optional = true }
 pilotage-protocol = { workspace = true }

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -3,15 +3,19 @@
 use std::sync::{Arc, Mutex};
 
 use pilotage_adapter_api::{
-    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, Pose2d, SourceRole,
-    TelemetryBatch, TelemetrySample,
+    AvionicsAttitudeSample, AvionicsKinematicsSample, AvionicsSample, GeodeticFixSample, Pose2d,
+    SourceRole, TelemetryBatch, TelemetrySample,
 };
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
 use super::WITHHOLD_AFTER;
+use pilotage_geo::{
+    BaroSettingId, DatumRealizationId, GeodeticPosition, HorizontalDatum, LocalOriginId,
+    PositionQuality, SIMULATOR_GEOID_MODEL_ID, TerrainRefId, VerticalDatum, VerticalPosition,
+};
 use pilotage_mavlink::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
-use pilotage_mavlink::link::{AttitudeUpdate, KinematicsUpdate, LinkState};
+use pilotage_mavlink::link::{AttitudeUpdate, KinematicsUpdate, LinkState, SimTruthUpdate};
 
 /// Yaw extracted from the body→NED quaternion (heading, radians
 /// clockwise from north).
@@ -136,21 +140,66 @@ fn effective_authorization(
     (flags, quality)
 }
 
+/// The simulator's stated position as a typed fix.
+///
+/// The report gives latitude and longitude in degrees·1e7 and an altitude
+/// in millimetres it documents as MSL, and it names no geoid. An MSL height
+/// with no separation is uninterpretable, so the height declares the
+/// simulator's own separation: it stays traceable to a simulator and can
+/// never be read as a surveyed height. A report the contract refuses is no
+/// fix at all — the sample keeps its local frame and declares no position.
+fn truth_geodetic_fix(
+    truth: &SimTruthUpdate,
+    stamp: pilotage_adapter_api::MeasurementStamp,
+) -> Option<GeodeticFixSample> {
+    // A report whose whole geodetic triple is zero is a simulator that has
+    // not stated a position, not a vehicle at Null Island. The value is
+    // legal — 0,0 is a real place off the coast of Africa — so the typed
+    // contract cannot refuse it and this is the only place that can. A
+    // frame short of its geodetic bytes decodes to the same zeros, so a
+    // truncated report is refused here too.
+    if truth.lat_lon_alt == [0, 0, 0] {
+        return None;
+    }
+    let vertical = VerticalPosition::new(
+        f64::from(truth.lat_lon_alt[2]) * 1e-3,
+        VerticalDatum::Msl,
+        SIMULATOR_GEOID_MODEL_ID,
+        TerrainRefId::UNDECLARED,
+        BaroSettingId::UNDECLARED,
+        LocalOriginId::UNDECLARED,
+    )
+    .ok()?;
+    let position = GeodeticPosition::new(
+        f64::from(truth.lat_lon_alt[0]) * 1e-7,
+        f64::from(truth.lat_lon_alt[1]) * 1e-7,
+        HorizontalDatum::Wgs84,
+        DatumRealizationId::UNDECLARED,
+        vertical,
+    )
+    .ok()?;
+    Some(GeodeticFixSample {
+        position,
+        // The simulator states no accuracy. Zero is the honest reading of a
+        // value taken from the model rather than measured: it is the
+        // oracle, and a reader derives health from the datum identities
+        // above rather than from a number the producer invented.
+        quality: PositionQuality {
+            horizontal_mm: 0,
+            vertical_mm: 0,
+        },
+        stamp,
+    })
+}
+
 /// The fresh simulation-truth sample, stamped with its own source role so
 /// a consumer can never mistake it for the FC's operational estimate.
 fn sim_truth_sample(latest: &LinkState) -> Option<pilotage_adapter_api::SimTruthSample> {
     latest
         .sim_truth
         .filter(|truth| truth.received_at.elapsed() <= WITHHOLD_AFTER)
-        .map(|truth| pilotage_adapter_api::SimTruthSample {
-            geodetic: None,
-            quat_wxyz: truth.quat_wxyz,
-            pos_ned_m: truth.pos_ned_m,
-            vel_ned_mps: truth.vel_ned_mps,
-            // Attitude, position, and velocity are all carried;
-            // the truth stream has no body-rate report.
-            valid_flags: 0b1101,
-            stamp: pilotage_adapter_api::MeasurementStamp {
+        .map(|truth| {
+            let stamp = pilotage_adapter_api::MeasurementStamp {
                 role: pilotage_adapter_api::SourceRole::SimulationTruth,
                 integrity: pilotage_adapter_api::SourceIntegrity::ChecksummedOnly,
                 source_id: latest.source_id,
@@ -159,7 +208,19 @@ fn sim_truth_sample(latest: &LinkState) -> Option<pilotage_adapter_api::SimTruth
                 sequence: truth.sequence,
                 acquired_at_ns: truth.time_usec.wrapping_mul(1_000),
                 clock: pilotage_adapter_api::MeasurementClock::Simulation,
-            },
+            };
+            pilotage_adapter_api::SimTruthSample {
+                // The same observation the NED group was projected from, so
+                // it rides this sample's stamp.
+                geodetic: truth_geodetic_fix(&truth, stamp),
+                quat_wxyz: truth.quat_wxyz,
+                pos_ned_m: truth.pos_ned_m,
+                vel_ned_mps: truth.vel_ned_mps,
+                // Attitude, position, and velocity are all carried;
+                // the truth stream has no body-rate report.
+                valid_flags: 0b1101,
+                stamp,
+            }
         })
 }
 
@@ -282,3 +343,6 @@ fn validated_velocity(kinematics: KinematicsUpdate) -> Option<[f32; 3]> {
     let finite = kinematics.vel_ned_mps.iter().all(|v| v.is_finite());
     (declared_valid && finite).then_some(kinematics.vel_ned_mps)
 }
+
+#[cfg(test)]
+mod tests;

--- a/adapters/aviate/src/adapter/sampling.rs
+++ b/adapters/aviate/src/adapter/sampling.rs
@@ -9,13 +9,15 @@ use pilotage_adapter_api::{
 use pilotage_protocol::VehicleId;
 use pilotage_timing::SimTick;
 
-use super::WITHHOLD_AFTER;
 use pilotage_geo::{
     BaroSettingId, DatumRealizationId, GeodeticPosition, HorizontalDatum, LocalOriginId,
     PositionQuality, SIMULATOR_GEOID_MODEL_ID, TerrainRefId, VerticalDatum, VerticalPosition,
 };
 use pilotage_mavlink::link::estimator::{QUALITY_DEGRADED, QUALITY_UNUSABLE};
 use pilotage_mavlink::link::{AttitudeUpdate, KinematicsUpdate, LinkState, SimTruthUpdate};
+use tracing::warn;
+
+use super::WITHHOLD_AFTER;
 
 /// Yaw extracted from the body→NED quaternion (heading, radians
 /// clockwise from north).
@@ -143,21 +145,23 @@ fn effective_authorization(
 /// The simulator's stated position as a typed fix.
 ///
 /// The report gives latitude and longitude in degrees·1e7 and an altitude
-/// in millimetres it documents as MSL, and it names no geoid. An MSL height
-/// with no separation is uninterpretable, so the height declares the
-/// simulator's own separation: it stays traceable to a simulator and can
-/// never be read as a surveyed height. A report the contract refuses is no
-/// fix at all — the sample keeps its local frame and declares no position.
+/// in millimetres. The message definition names no reference surface for
+/// that altitude at all; the senders this lane reads feed it from their
+/// own above-mean-sea-level solution, which is why it is labelled MSL here
+/// and not in the decoder. An MSL height with no separation is
+/// uninterpretable, so the height declares the simulator's own separation:
+/// it stays traceable to a simulator and can never be read as a surveyed
+/// height. A report the contract refuses is no fix at all — the sample
+/// keeps its local frame and declares no position.
 fn truth_geodetic_fix(
     truth: &SimTruthUpdate,
     stamp: pilotage_adapter_api::MeasurementStamp,
 ) -> Option<GeodeticFixSample> {
     // A report whose whole geodetic triple is zero is a simulator that has
-    // not stated a position, not a vehicle at Null Island. The value is
-    // legal — 0,0 is a real place off the coast of Africa — so the typed
-    // contract cannot refuse it and this is the only place that can. A
-    // frame short of its geodetic bytes decodes to the same zeros, so a
-    // truncated report is refused here too.
+    // not stated a position, not a vehicle at Null Island. The link refuses
+    // such a report outright, because the local frame is that position
+    // projected; this stays as the contract's own statement at the place
+    // that builds the typed value.
     if truth.lat_lon_alt == [0, 0, 0] {
         return None;
     }
@@ -169,6 +173,9 @@ fn truth_geodetic_fix(
         BaroSettingId::UNDECLARED,
         LocalOriginId::UNDECLARED,
     )
+    .inspect_err(|error| {
+        warn!(%error, "simulator height refused by the contract; no position published");
+    })
     .ok()?;
     let position = GeodeticPosition::new(
         f64::from(truth.lat_lon_alt[0]) * 1e-7,
@@ -177,13 +184,19 @@ fn truth_geodetic_fix(
         DatumRealizationId::UNDECLARED,
         vertical,
     )
+    .inspect_err(|error| {
+        warn!(%error, "simulator position refused by the contract; no position published");
+    })
     .ok()?;
     Some(GeodeticFixSample {
         position,
         // The simulator states no accuracy. Zero is the honest reading of a
         // value taken from the model rather than measured: it is the
         // oracle, and a reader derives health from the datum identities
-        // above rather than from a number the producer invented.
+        // above rather than from a number the producer invented. A grader
+        // that read zero as a metre count would read it as perfect, so
+        // this value is safe only while the simulator separation keeps it
+        // inside the truth role.
         quality: PositionQuality {
             horizontal_mm: 0,
             vertical_mm: 0,

--- a/adapters/aviate/src/adapter/sampling/tests.rs
+++ b/adapters/aviate/src/adapter/sampling/tests.rs
@@ -1,0 +1,115 @@
+//! The simulator oracle's position on the Earth, as it reaches the sample.
+//!
+//! The link projects each truth report into the local frame against an
+//! origin it latches from the first report. The projection is one-way
+//! without that origin, and a map needs the position itself, so the report
+//! travels beside the projection rather than being replaced by it. These
+//! checks pin that the position that arrives is the one the simulator sent,
+//! under the truth role, with a datum a reader can interpret.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use pilotage_adapter_api::SourceRole;
+use pilotage_geo::{HorizontalDatum, SIMULATOR_GEOID_MODEL_ID, VerticalDatum};
+use pilotage_mavlink::link::{LinkState, SimTruthUpdate};
+
+use super::sim_truth_sample;
+
+/// Zurich, the datum the flight-deck world declares, at 488.227 m.
+const REPORTED: [i32; 3] = [473_977_419, 85_455_938, 488_227];
+
+fn state_with_truth(lat_lon_alt: [i32; 3], age: Duration) -> Arc<Mutex<LinkState>> {
+    let state = LinkState {
+        source_id: 4,
+        sim_truth: Some(SimTruthUpdate {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            lat_lon_alt,
+            time_usec: 1_000,
+            sequence: 3,
+            received_at: Instant::now() - age,
+        }),
+        ..LinkState::default()
+    };
+    Arc::new(Mutex::new(state))
+}
+
+#[test]
+fn the_oracle_reports_the_position_the_simulator_sent() {
+    let state = state_with_truth(REPORTED, Duration::ZERO);
+    let latest = state.lock().expect("link state");
+    let sample = sim_truth_sample(&latest).expect("a fresh truth sample");
+    let fix = sample.geodetic.expect("the oracle declares a position");
+
+    assert!((fix.position.latitude_deg - 47.397_741_9).abs() < 1e-9);
+    assert!((fix.position.longitude_deg - 8.545_593_8).abs() < 1e-9);
+    assert!((fix.position.vertical.height_m - 488.227).abs() < 1e-6);
+    assert_eq!(fix.position.horizontal_datum, HorizontalDatum::Wgs84);
+    assert_eq!(fix.position.vertical.datum, VerticalDatum::Msl);
+    assert_eq!(
+        fix.position.vertical.geoid, SIMULATOR_GEOID_MODEL_ID,
+        "a simulated MSL height names the separation it came from"
+    );
+}
+
+#[test]
+fn the_fix_rides_the_truth_role_and_the_samples_own_stamp() {
+    let state = state_with_truth(REPORTED, Duration::ZERO);
+    let latest = state.lock().expect("link state");
+    let sample = sim_truth_sample(&latest).expect("a fresh truth sample");
+    let fix = sample.geodetic.expect("the oracle declares a position");
+
+    assert_eq!(
+        fix.stamp.role,
+        SourceRole::SimulationTruth,
+        "an oracle position is never an operational estimate"
+    );
+    assert_eq!(
+        fix.stamp, sample.stamp,
+        "the fix and the projection are one observation, so they share a stamp"
+    );
+}
+
+#[test]
+fn a_position_the_contract_refuses_is_no_position() {
+    // A latitude past the pole cannot be a place. The sample keeps its
+    // local frame; it does not carry a position the reader would draw.
+    let state = state_with_truth([910_000_000, 0, 0], Duration::ZERO);
+    let latest = state.lock().expect("link state");
+    let sample = sim_truth_sample(&latest).expect("a fresh truth sample");
+    assert!(
+        sample.geodetic.is_none(),
+        "a refused report leaves no position behind"
+    );
+    assert_eq!(sample.valid_flags, 0b1101, "the local frame still arrives");
+}
+
+#[test]
+fn a_stale_report_carries_no_position_because_it_carries_no_sample() {
+    let state = state_with_truth(REPORTED, Duration::from_secs(5));
+    let latest = state.lock().expect("link state");
+    assert!(
+        sim_truth_sample(&latest).is_none(),
+        "a withheld truth report publishes nothing at all"
+    );
+}
+
+#[test]
+fn a_report_that_states_no_position_is_not_null_island() {
+    // A truth frame whose whole geodetic triple is zero is a simulator
+    // that has not stated a position. 0,0 is a real place off the coast of
+    // Africa, and the typed contract accepts it, so nothing below this
+    // point could tell the two apart.
+    let state = state_with_truth([0, 0, 0], Duration::ZERO);
+    let latest = state.lock().expect("link state");
+    let sample = sim_truth_sample(&latest).expect("a fresh truth sample");
+    assert!(
+        sample.geodetic.is_none(),
+        "a simulator that stated no position declares none"
+    );
+    assert_eq!(sample.valid_flags, 0b1101, "the local frame still arrives");
+}

--- a/adapters/aviate/src/adapter/tests/source_roles.rs
+++ b/adapters/aviate/src/adapter/tests/source_roles.rs
@@ -220,3 +220,43 @@ fn mislabeled_estimate_roles_cannot_seed_a_control_setpoint() {
         Disposition::Rejected(RejectReason::MeasurementUnavailable)
     );
 }
+
+/// The X-Plane lane's only truth path.
+///
+/// X-Plane publishes no shared-memory block, so no oracle attaches and the
+/// simulator's ground truth reaches the adapter the one way it can: the
+/// flight controller forwards the truth frame over the estimate link. The
+/// position the simulator stated has to survive that path, or an X-Plane
+/// session draws no vehicle on the map while a Gazebo session does.
+#[test]
+fn the_x_plane_lane_publishes_the_position_the_flight_controller_forwarded() {
+    // Zurich, so a reader can tell this apart from a projection of the
+    // estimate fixture's local pose.
+    const REPORTED: [i32; 3] = [473_977_419, 85_455_938, 488_227];
+    let state = state_with(Duration::ZERO, Duration::ZERO);
+    {
+        let mut latest = state.lock().expect("lock");
+        latest.sim_truth = Some(pilotage_mavlink::link::SimTruthUpdate {
+            quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+            pos_ned_m: [0.0; 3],
+            vel_ned_mps: [0.0; 3],
+            lat_lon_alt: REPORTED,
+            time_usec: 1_000,
+            sequence: 3,
+            received_at: std::time::Instant::now(),
+        });
+    }
+    let mut adapter = AviateAdapter::from_state(VehicleId::new(1), state);
+    // No oracle is attached: that IS the X-Plane shape.
+    assert!(adapter.truth.is_none());
+
+    let batch = adapter.sample_telemetry();
+    let truth = batch.samples[0]
+        .sim_truth
+        .expect("the forwarded truth frame");
+    let fix = truth.geodetic.expect("the position the simulator stated");
+
+    assert!((fix.position.latitude_deg - 47.397_741_9).abs() < 1e-7);
+    assert!((fix.position.longitude_deg - 8.545_593_8).abs() < 1e-7);
+    assert_eq!(fix.stamp.role, SourceRole::SimulationTruth);
+}

--- a/crates/pilotage-mavlink/src/codec.rs
+++ b/crates/pilotage-mavlink/src/codec.rs
@@ -319,4 +319,4 @@ pub fn parse_datagram(bytes: &[u8], out: &mut Vec<(FrameSource, FcMessage)>) -> 
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/pilotage-mavlink/src/codec/tests.rs
+++ b/crates/pilotage-mavlink/src/codec/tests.rs
@@ -461,38 +461,6 @@ fn gimbal_rate_setpoint_locks_the_wire_layout() {
     assert_eq!(super::compute_crc(&frame[1..45], 123), wire_crc);
 }
 
-#[test]
-fn decodes_scaled_pressure_and_sim_truth() {
-    // SCALED_PRESSURE: time u32, press_abs f32 (hPa), press_diff f32,
-    // temperature i16 — standard-datum sea level, 25.00 °C.
-    let mut pressure = Vec::new();
-    pressure.extend_from_slice(&1000_u32.to_le_bytes());
-    pressure.extend_from_slice(&1013.25_f32.to_le_bytes());
-    pressure.extend_from_slice(&0.0_f32.to_le_bytes());
-    pressure.extend_from_slice(&2500_i16.to_le_bytes());
-    let mut datagram = encode_frame(super::SCALED_PRESSURE_ID, &pressure, true);
-
-    // HIL_STATE_QUATERNION with identity attitude, 1 m/s north, and a
-    // fix at 47.0°/8.0°/500 m.
-    let mut truth = vec![0_u8; 64];
-    truth[0..8].copy_from_slice(&2_000_000_u64.to_le_bytes());
-    truth[8..12].copy_from_slice(&1.0_f32.to_le_bytes());
-    truth[36..40].copy_from_slice(&470_000_000_i32.to_le_bytes());
-    truth[40..44].copy_from_slice(&80_000_000_i32.to_le_bytes());
-    truth[44..48].copy_from_slice(&500_000_i32.to_le_bytes());
-    truth[48..50].copy_from_slice(&100_i16.to_le_bytes());
-    datagram.extend_from_slice(&encode_frame(super::HIL_STATE_QUATERNION_ID, &truth, true));
-
-    let mut out = Vec::new();
-    let stats = parse_datagram(&datagram, &mut out);
-    assert_eq!(stats.crc_failures, 0, "both new ids must verify");
-    assert_eq!(stats.decoded, 2, "both frames decode: {out:?}");
-    assert!(matches!(
-        out[0].1,
-        super::FcMessage::ScaledPressure { press_abs_hpa, .. } if (press_abs_hpa - 1013.25).abs() < 0.01
-    ));
-    assert!(matches!(
-        out[1].1,
-        super::FcMessage::SimTruth { vel_ned_mps, .. } if (vel_ned_mps[0] - 1.0).abs() < 0.01
-    ));
-}
+/// The truth lane: the payload a simulator's ground-truth report arrives
+/// in, and what a report short of that payload decodes to.
+mod sim_truth;

--- a/crates/pilotage-mavlink/src/codec/tests.rs
+++ b/crates/pilotage-mavlink/src/codec/tests.rs
@@ -14,7 +14,7 @@ const SOURCE: FrameSource = FrameSource {
 /// Test-side serializer: builds a MAVLink 2.0 frame the way Aviate's
 /// `aviate-link` does, optionally truncating trailing zero payload bytes
 /// (the v2 wire optimization the parser must zero-extend back).
-fn encode_frame(msg_id: u32, payload: &[u8], truncate: bool) -> Vec<u8> {
+pub(crate) fn encode_frame(msg_id: u32, payload: &[u8], truncate: bool) -> Vec<u8> {
     let mut p = payload.to_vec();
     if truncate {
         while p.len() > 1 && p.last() == Some(&0) {

--- a/crates/pilotage-mavlink/src/codec/tests/sim_truth.rs
+++ b/crates/pilotage-mavlink/src/codec/tests/sim_truth.rs
@@ -1,0 +1,82 @@
+//! The truth lane's own frames: the barometric and ground-truth payloads
+//! the link reads, and what a report short of its position decodes to.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::encode_frame;
+use crate::codec::{FcMessage, HIL_STATE_QUATERNION_ID, SCALED_PRESSURE_ID, parse_datagram};
+
+#[test]
+fn decodes_scaled_pressure_and_sim_truth() {
+    // SCALED_PRESSURE: time u32, press_abs f32 (hPa), press_diff f32,
+    // temperature i16 — standard-datum sea level, 25.00 °C.
+    let mut pressure = Vec::new();
+    pressure.extend_from_slice(&1000_u32.to_le_bytes());
+    pressure.extend_from_slice(&1013.25_f32.to_le_bytes());
+    pressure.extend_from_slice(&0.0_f32.to_le_bytes());
+    pressure.extend_from_slice(&2500_i16.to_le_bytes());
+    let mut datagram = encode_frame(SCALED_PRESSURE_ID, &pressure, true);
+
+    // HIL_STATE_QUATERNION with identity attitude, 1 m/s north, and a
+    // fix at 47.0°/8.0°/500 m.
+    let mut truth = vec![0_u8; 64];
+    truth[0..8].copy_from_slice(&2_000_000_u64.to_le_bytes());
+    truth[8..12].copy_from_slice(&1.0_f32.to_le_bytes());
+    truth[36..40].copy_from_slice(&470_000_000_i32.to_le_bytes());
+    truth[40..44].copy_from_slice(&80_000_000_i32.to_le_bytes());
+    truth[44..48].copy_from_slice(&500_000_i32.to_le_bytes());
+    truth[48..50].copy_from_slice(&100_i16.to_le_bytes());
+    datagram.extend_from_slice(&encode_frame(HIL_STATE_QUATERNION_ID, &truth, true));
+
+    let mut out = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.crc_failures, 0, "both new ids must verify");
+    assert_eq!(stats.decoded, 2, "both frames decode: {out:?}");
+    assert!(matches!(
+        out[0].1,
+        FcMessage::ScaledPressure { press_abs_hpa, .. } if (press_abs_hpa - 1013.25).abs() < 0.01
+    ));
+    assert!(matches!(
+        out[1].1,
+        FcMessage::SimTruth { vel_ned_mps, .. } if (vel_ned_mps[0] - 1.0).abs() < 0.01
+    ));
+    // The geodetic triple is read at fixed offsets and every position the
+    // map draws comes from them. An offset read one field early decodes a
+    // plausible place that is not the one the simulator stated, and the
+    // velocity assertion above does not move.
+    assert!(matches!(
+        out[1].1,
+        FcMessage::SimTruth { lat_lon_alt, .. }
+            if lat_lon_alt == [470_000_000, 80_000_000, 500_000]
+    ));
+}
+
+/// MAVLink 2 trims trailing zero bytes and every reader zero-extends them
+/// back. That trimming can cut into the middle of a value whose high bytes
+/// are zero, so no offset can be required to be present: a vehicle at rest
+/// at 47N 8E and 500 m sends a report whose acceleration and velocity
+/// fields are zero and whose altitude's most significant byte is zero, and
+/// a length gate at the end of the geodetic triple drops the whole frame —
+/// costing the attitude and the velocity along with the position.
+#[test]
+fn a_truth_report_trimmed_to_its_last_meaning_byte_still_decodes() {
+    let mut payload = vec![0_u8; 64];
+    payload[0..8].copy_from_slice(&2_000_000_u64.to_le_bytes());
+    payload[8..12].copy_from_slice(&1.0_f32.to_le_bytes());
+    payload[36..40].copy_from_slice(&473_977_419_i32.to_le_bytes());
+    payload[40..44].copy_from_slice(&85_455_938_i32.to_le_bytes());
+    payload[44..48].copy_from_slice(&500_000_i32.to_le_bytes());
+    // 500_000 millimetres is 0x0007_A120: its most significant byte is
+    // zero, so a real sender trims the frame to 47 bytes.
+    let datagram = encode_frame(HIL_STATE_QUATERNION_ID, &payload, true);
+
+    let mut out = Vec::new();
+    let stats = parse_datagram(&datagram, &mut out);
+    assert_eq!(stats.crc_failures, 0, "the trimmed frame verifies");
+    assert_eq!(out.len(), 1, "a vehicle at rest is still a report: {out:?}");
+    assert!(matches!(
+        out[0].1,
+        FcMessage::SimTruth { lat_lon_alt, .. }
+            if lat_lon_alt == [473_977_419, 85_455_938, 500_000]
+    ));
+}

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -144,11 +144,16 @@ fn apply_sim_truth(
     now: Instant,
 ) {
     const METRES_PER_DEGREE: f64 = 111_111.0;
-    // The origin is latched once and holds for the life of the link, so a
-    // report that states no position must not become it: every later
-    // position would be measured from Null Island and the frame could
-    // never recover.
-    if lat_lon_alt == [0, 0, 0] && latest.truth_origin.is_none() {
+    // A report whose whole geodetic triple is zero states no position. The
+    // value is legal — 0,0 is a real place off the coast of Africa — so
+    // nothing downstream can tell it from a vehicle that is there, and a
+    // frame short of its geodetic bytes decodes to the same zeros. The
+    // whole report is refused, not only its geodetic half: the local frame
+    // is that position projected, so a projection of no position is a
+    // position too. Projected against a latched origin it reads thousands
+    // of kilometres from the vehicle, under a flag that says the position
+    // is valid.
+    if lat_lon_alt == [0, 0, 0] {
         return;
     }
     let origin = *latest
@@ -159,9 +164,12 @@ fn apply_sim_truth(
             alt_mm: lat_lon_alt[2],
             lon_scale: METRES_PER_DEGREE * (f64::from(lat_lon_alt[0]) * 1e-7).to_radians().cos(),
         });
-    let north = f64::from(lat_lon_alt[0] - origin.lat_1e7) * 1e-7 * METRES_PER_DEGREE;
-    let east = f64::from(lat_lon_alt[1] - origin.lon_1e7) * 1e-7 * origin.lon_scale;
-    let down = f64::from(origin.alt_mm - lat_lon_alt[2]) * 1e-3;
+    // The wire carries these as i32 and a difference of two of them does
+    // not fit one. The subtraction is done in f64, where the whole i32
+    // range is exact.
+    let north = (f64::from(lat_lon_alt[0]) - f64::from(origin.lat_1e7)) * 1e-7 * METRES_PER_DEGREE;
+    let east = (f64::from(lat_lon_alt[1]) - f64::from(origin.lon_1e7)) * 1e-7 * origin.lon_scale;
+    let down = (f64::from(origin.alt_mm) - f64::from(lat_lon_alt[2])) * 1e-3;
     let sequence = latest
         .sim_truth
         .map_or(0, |update| update.sequence.wrapping_add(1));

--- a/crates/pilotage-mavlink/src/link/apply.rs
+++ b/crates/pilotage-mavlink/src/link/apply.rs
@@ -144,6 +144,13 @@ fn apply_sim_truth(
     now: Instant,
 ) {
     const METRES_PER_DEGREE: f64 = 111_111.0;
+    // The origin is latched once and holds for the life of the link, so a
+    // report that states no position must not become it: every later
+    // position would be measured from Null Island and the frame could
+    // never recover.
+    if lat_lon_alt == [0, 0, 0] && latest.truth_origin.is_none() {
+        return;
+    }
     let origin = *latest
         .truth_origin
         .get_or_insert_with(|| crate::link::TruthOrigin {
@@ -162,6 +169,7 @@ fn apply_sim_truth(
         quat_wxyz,
         pos_ned_m: [north as f32, east as f32, down as f32],
         vel_ned_mps,
+        lat_lon_alt,
         time_usec,
         sequence,
         received_at: now,

--- a/crates/pilotage-mavlink/src/link/measurement.rs
+++ b/crates/pilotage-mavlink/src/link/measurement.rs
@@ -52,6 +52,14 @@ fn begin_source_epoch(latest: &mut LinkState, time_boot_ms: u32) {
     latest.attitude = None;
     latest.kinematics = None;
     latest.estimator_status = None;
+    // A simulator that restarted may have restarted into another world.
+    // The origin is latched once and holds for the life of the link, so an
+    // origin carried across a restart measures the new world's positions
+    // from the old world's datum: the geodetic fix then reports where the
+    // vehicle is while the local frame reports where it is not, in the
+    // same sample, with nothing to choose between them.
+    latest.truth_origin = None;
+    latest.sim_truth = None;
     latest.source_resets = latest.source_resets.wrapping_add(1);
     warn!(
         source_epoch = latest.source_epoch,

--- a/crates/pilotage-mavlink/src/link/tests.rs
+++ b/crates/pilotage-mavlink/src/link/tests.rs
@@ -461,3 +461,5 @@ fn current_epoch_progress_cancels_an_unconfirmed_reset() {
     assert_eq!(latest.attitude.expect("current").time_boot_ms, 60_010);
     assert!(latest.pending_reset.is_none());
 }
+
+mod truth_origin;

--- a/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
+++ b/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
@@ -87,3 +87,112 @@ fn a_real_truth_frame_carries_its_position_into_the_cache() {
     let truth = latest.sim_truth.expect("the forwarded truth report");
     assert_eq!(truth.lat_lon_alt, REPORTED);
 }
+
+/// The local frame is the stated position projected, so a report that
+/// states no position states no frame either. Refusing only the geodetic
+/// half leaves the projection: measured against a latched origin, an
+/// all-zero triple reads thousands of kilometres from the vehicle, under a
+/// flag that says the position is valid. A frame short of its geodetic
+/// bytes decodes to the same zeros, and MAVLink 2 trims trailing zero bytes
+/// on the wire, so this is a report a simulator can really send.
+#[test]
+fn a_report_with_no_position_is_refused_after_the_origin_is_latched() {
+    const REPORTED: [i32; 3] = [473_977_419, 85_455_938, 488_227];
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    let truth = |lat_lon_alt| {
+        (
+            SELECTED,
+            FcMessage::SimTruth {
+                time_usec: 1_000,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                vel_ned_mps: [0.0; 3],
+                lat_lon_alt,
+            },
+        )
+    };
+    apply_at(&state, &[truth(REPORTED)], now);
+    apply_at(&state, &[truth([0, 0, 0])], now);
+
+    let latest = state.lock().expect("link state");
+    let update = latest.sim_truth.expect("the latched report");
+    assert_eq!(
+        update.lat_lon_alt, REPORTED,
+        "the report that stated no position left no trace"
+    );
+    assert_eq!(
+        update.pos_ned_m,
+        [0.0, 0.0, 0.0],
+        "the frame still measures the position the simulator did state"
+    );
+}
+
+/// The origin is latched once and holds for the life of the link. A
+/// simulator that restarted may have restarted into another world, and an
+/// origin carried across the restart measures the new world's positions
+/// from the old world's datum.
+#[test]
+fn a_new_source_epoch_releases_the_latched_origin() {
+    const ZURICH: [i32; 3] = [473_977_419, 85_455_938, 488_227];
+    let state = state(ResetPolicy::SimulatorHeuristic);
+    let now = Instant::now();
+    super::apply_at(&state, &[super::attitude_at(60_000, 0.5)], now);
+    apply_at(
+        &state,
+        &[(
+            SELECTED,
+            FcMessage::SimTruth {
+                time_usec: 1_000,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                vel_ned_mps: [0.0; 3],
+                lat_lon_alt: ZURICH,
+            },
+        )],
+        now,
+    );
+    assert!(state.lock().expect("link state").truth_origin.is_some());
+
+    // The restart is detected the way the link really detects one: the
+    // acquisition clock rewinds and the new stream holds for the dwell.
+    super::confirm_attitude_reset(&state, now, 100);
+
+    let latest = state.lock().expect("link state");
+    assert_eq!(latest.source_epoch, 2, "the link saw the restart");
+    assert!(
+        latest.truth_origin.is_none(),
+        "a restart releases the origin the old world latched"
+    );
+    assert!(latest.sim_truth.is_none());
+}
+
+/// The projection subtracts two wire values that each span the whole i32
+/// range. Their difference does not fit one: a debug build panics and a
+/// release build wraps into a frame measured from nowhere. Longitude is
+/// where a real flight reaches the ends — a vehicle crossing the
+/// antimeridian reports +179.9 and then -179.9 degrees.
+#[test]
+fn a_frame_across_the_antimeridian_does_not_overflow_the_projection() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    let truth = |lat_lon_alt| {
+        (
+            SELECTED,
+            FcMessage::SimTruth {
+                time_usec: 1_000,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                vel_ned_mps: [0.0; 3],
+                lat_lon_alt,
+            },
+        )
+    };
+    apply_at(&state, &[truth([0, 1_799_000_000, 0])], now);
+    apply_at(&state, &[truth([0, -1_799_000_000, 0])], now);
+
+    let latest = state.lock().expect("link state");
+    let update = latest.sim_truth.expect("the second report");
+    assert!(
+        update.pos_ned_m[1].is_finite(),
+        "the east offset is a number: {:?}",
+        update.pos_ned_m,
+    );
+}

--- a/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
+++ b/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
@@ -51,3 +51,39 @@ fn a_truth_report_with_no_position_latches_no_origin() {
         "the first stated position is the origin, so it sits at the origin"
     );
 }
+
+/// The whole lane an X-Plane session delivers, from the bytes on the wire.
+///
+/// The simulator's own satellite navigation reaches the flight controller,
+/// and the controller forwards it in HIL_STATE_QUATERNION. Every value the
+/// map draws from is read out of that payload at a fixed offset, so an
+/// offset read one field early would publish a plausible position that is
+/// not the one the simulator stated. The frame here is built and framed the
+/// way the link receives one.
+#[test]
+fn a_real_truth_frame_carries_its_position_into_the_cache() {
+    // Zurich, the datum the flight-deck world declares, at 488.227 m.
+    const REPORTED: [i32; 3] = [473_977_419, 85_455_938, 488_227];
+
+    let mut payload = vec![0_u8; 64];
+    payload[0..8].copy_from_slice(&2_000_000_u64.to_le_bytes());
+    payload[8..12].copy_from_slice(&1.0_f32.to_le_bytes());
+    payload[36..40].copy_from_slice(&REPORTED[0].to_le_bytes());
+    payload[40..44].copy_from_slice(&REPORTED[1].to_le_bytes());
+    payload[44..48].copy_from_slice(&REPORTED[2].to_le_bytes());
+    payload[48..50].copy_from_slice(&100_i16.to_le_bytes());
+    let datagram =
+        crate::codec::tests::encode_frame(crate::codec::HIL_STATE_QUATERNION_ID, &payload, true);
+
+    let mut messages = Vec::new();
+    let stats = crate::codec::parse_datagram(&datagram, &mut messages);
+    assert_eq!(stats.crc_failures, 0, "the frame verifies");
+    assert_eq!(messages.len(), 1, "the frame decodes: {messages:?}");
+
+    let state = state(ResetPolicy::Conservative);
+    crate::link::apply_messages_at(&state, &messages, 0, 0, Instant::now());
+
+    let latest = state.lock().expect("link state");
+    let truth = latest.sim_truth.expect("the forwarded truth report");
+    assert_eq!(truth.lat_lon_alt, REPORTED);
+}

--- a/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
+++ b/crates/pilotage-mavlink/src/link/tests/truth_origin.rs
@@ -1,0 +1,53 @@
+//! The frame a simulator's truth reports are measured in.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::time::Instant;
+
+use crate::codec::FcMessage;
+use crate::link::ResetPolicy;
+
+use super::{SELECTED, apply_at, state};
+
+/// The truth origin is latched once and holds for the life of the link, so
+/// a report that states no position must not become it. Every later
+/// position would then be measured from Null Island — a real place off the
+/// coast of Africa — and the frame could never recover.
+#[test]
+fn a_truth_report_with_no_position_latches_no_origin() {
+    let state = state(ResetPolicy::Conservative);
+    let now = Instant::now();
+    let truth = |lat_lon_alt| {
+        (
+            SELECTED,
+            FcMessage::SimTruth {
+                time_usec: 1_000,
+                quat_wxyz: [1.0, 0.0, 0.0, 0.0],
+                vel_ned_mps: [0.0; 3],
+                lat_lon_alt,
+            },
+        )
+    };
+
+    apply_at(&state, &[truth([0, 0, 0])], now);
+    {
+        let latest = state.lock().expect("link state");
+        assert!(
+            latest.truth_origin.is_none(),
+            "a report with no position latches no origin"
+        );
+        assert!(latest.sim_truth.is_none(), "and publishes no truth");
+    }
+
+    // A stated position latches, and the frame it defines is its own.
+    apply_at(&state, &[truth([473_977_419, 85_455_938, 488_227])], now);
+    let latest = state.lock().expect("link state");
+    let origin = latest.truth_origin.expect("a stated position latches");
+    assert_eq!(origin.lat_1e7, 473_977_419);
+    let published = latest.sim_truth.expect("truth publishes");
+    assert_eq!(published.lat_lon_alt, [473_977_419, 85_455_938, 488_227]);
+    assert!(
+        published.pos_ned_m.iter().all(|value| value.abs() < 1e-3),
+        "the first stated position is the origin, so it sits at the origin"
+    );
+}

--- a/crates/pilotage-mavlink/src/link/updates.rs
+++ b/crates/pilotage-mavlink/src/link/updates.rs
@@ -57,6 +57,13 @@ pub struct SimTruthUpdate {
     pub pos_ned_m: [f32; 3],
     /// True NED velocity, m/s.
     pub vel_ned_mps: [f32; 3],
+    /// The report's own geodetic position, as the simulator stated it:
+    /// latitude and longitude in degrees·1e7 and altitude in millimeters.
+    /// The NED group above is this position projected against the latched
+    /// origin, so the two are one observation; this is what it was before
+    /// the projection, kept because a projection cannot be undone without
+    /// the origin and the reader of a map needs the position itself.
+    pub lat_lon_alt: [i32; 3],
     /// Microseconds on the simulation clock.
     pub time_usec: u64,
     /// Wrapping publication sequence for the truth stream.

--- a/docs/link/evidence-artifacts/link04/adapter.run.txt
+++ b/docs/link/evidence-artifacts/link04/adapter.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: adapter source-role acceptance
 command: cargo test -p pilotage-adapter-aviate source_roles
-config-digest: 3800e447f01d08c32e10248b2ba5e5b2ff3204c1
+config-digest: 6bedcd00d78727155bf1eadded13d60b432fdb6c
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:3800e447f01d08c32e10248b2ba5e5b2ff3204c1
+run-id: local:6bedcd00d78727155bf1eadded13d60b432fdb6c
 outcome: pass
 summary:
 test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 113 filtered out; finished in 0.00s

--- a/docs/link/evidence-artifacts/link04/adapter.run.txt
+++ b/docs/link/evidence-artifacts/link04/adapter.run.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: LINK-04
 suite: adapter source-role acceptance
 command: cargo test -p pilotage-adapter-aviate source_roles
-config-digest: a06be9513007911cd726e2a76416b4389b036c15
+config-digest: 3800e447f01d08c32e10248b2ba5e5b2ff3204c1
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:a06be9513007911cd726e2a76416b4389b036c15
+run-id: local:3800e447f01d08c32e10248b2ba5e5b2ff3204c1
 outcome: pass
 summary:
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out; finished in 0.00s
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 113 filtered out; finished in 0.00s

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -184,12 +184,12 @@ attr test testDuplicateStatusDowngradeIsNotReversibleByANewerNumeric
 node RESULT-LINK-ADAPTER verification-result
 title adapter source-role acceptance suite — recorded pass
 attr command cargo test -p pilotage-adapter-aviate source_roles
-attr config-digest 3800e447f01d08c32e10248b2ba5e5b2ff3204c1
+attr config-digest 6bedcd00d78727155bf1eadded13d60b432fdb6c
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:ae29996705acf675446063e84541129d61283fe1
 attr artifact docs/link/evidence-artifacts/link04/adapter.run.txt
-attr output-digest sha256:abc803b70bbfec8bea92c23267a0950905636227a6b6dd3e6adc1712377b323c
-attr run-id local:3800e447f01d08c32e10248b2ba5e5b2ff3204c1
+attr output-digest sha256:b1421073ea4e016e0830cb2f6cdbf2a4e836ad833b5317ad0c4de668d88015c7
+attr run-id local:6bedcd00d78727155bf1eadded13d60b432fdb6c
 attr outcome pass
 
 node RESULT-LINK-WIRE verification-result
@@ -252,8 +252,8 @@ attr outcome pass
 node CFG-LINK-EXTRACTION configuration-item
 title committed code baseline of the re-recorded adapter suite (the MAVLink extraction commit)
 attr scm git
-attr commit a06be9513007911cd726e2a76416b4389b036c15
-attr tree 202df9f54fdef93e367a99d902d3f5c041b4cc5f
+attr commit 6bedcd00d78727155bf1eadded13d60b432fdb6c
+attr tree 219a3d59d0062642069c39544fa50d92291ba2da
 
 node CFG-LINK-WORKTREE configuration-item
 title committed code baseline the recorded results were produced against (engineering SCM, not certified SCM)

--- a/docs/link/evidence-graph.evg
+++ b/docs/link/evidence-graph.evg
@@ -184,12 +184,12 @@ attr test testDuplicateStatusDowngradeIsNotReversibleByANewerNumeric
 node RESULT-LINK-ADAPTER verification-result
 title adapter source-role acceptance suite — recorded pass
 attr command cargo test -p pilotage-adapter-aviate source_roles
-attr config-digest a06be9513007911cd726e2a76416b4389b036c15
+attr config-digest 3800e447f01d08c32e10248b2ba5e5b2ff3204c1
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:aab8e146252f94229733a7d22f49481dd5d23470
+attr source-digest git-blob:ae29996705acf675446063e84541129d61283fe1
 attr artifact docs/link/evidence-artifacts/link04/adapter.run.txt
-attr output-digest sha256:67b753585fb73f0dc60582e0460e7b686aa349a5df04c3f5ca4c271e6a07be52
-attr run-id local:a06be9513007911cd726e2a76416b4389b036c15
+attr output-digest sha256:abc803b70bbfec8bea92c23267a0950905636227a6b6dd3e6adc1712377b323c
+attr run-id local:3800e447f01d08c32e10248b2ba5e5b2ff3204c1
 attr outcome pass
 
 node RESULT-LINK-WIRE verification-result


### PR DESCRIPTION
Stacked on #523.

## What was wrong

The link already decoded latitude, longitude, and altitude from every
HIL_STATE_QUATERNION report. It projected them into the local frame against
an origin latched from the first report, then dropped the report itself, so
the position the simulator stated could not reach any client.

## What this does

The report travels beside the projection, as a typed fix under the same
stamp, because the fix and the local frame are one observation.

**A report that states no position is refused whole**, not only its
geodetic half. The local frame is that position projected, so a projection
of no position is a position too: measured against a latched origin an
all-zero report published a point 5266 km from the vehicle, under a flag
that says the position is valid, beside a geodetic half that correctly
refused it. The refusal now runs at the front, where both halves are still
one observation.

**The projection subtracts in f64.** Two wire i32 values differ by more
than an i32 holds: a debug build panicked at the ends of the range and a
release build wrapped into a garbage frame. A vehicle crossing the
antimeridian reaches those ends, and a test now holds it.

**A restart releases the latched origin.** Every other cached group was
cleared on a new acquisition epoch and this one was not, so a simulator that
restarted into another world measured the new world's positions from the old
world's datum — the geodetic fix saying where the vehicle was and the local
frame saying where it was not, in the same sample.

**No length gate.** An earlier revision required 48 payload bytes so a
truncated report could not invent a position. Review showed that wrong both
ways: MAVLink 2 trims trailing zero BYTES and can cut into the middle of a
value, so a vehicle at rest at 500 m sends a 47-byte frame that the gate
dropped entirely — costing the attitude and the velocity too — while a
full-length report at a zero longitude still latched the origin at
Greenwich. What a zero means is settled per field instead, and a test holds
the trimmed frame.

## This is the X-Plane lane

X-Plane publishes no shared-memory block, so no truth oracle attaches and
the forwarded frame stays authoritative — true before this PR and asserted
nowhere. Two tests now chain wire bytes → link cache → published typed fix,
each proven to fail when broken:

- `a_real_truth_frame_carries_its_position_into_the_cache` fails when
  latitude is read from longitude's offset. The velocity assertion the codec
  suite already carried does not move under that mutation.
- `the_x_plane_lane_publishes_the_position_the_flight_controller_forwarded`
  fails when an absent oracle's sample is made authoritative.

Offsets and CRC_EXTRA were verified against the reference implementation
(pymavlink), not read off a documentation page: id 115, CRC_EXTRA 4,
lat/lon/alt at 36/40/44 as degE7/degE7/mm.

## Simulation only

`sampling.rs` compiles in a flight build but only reads what the link
decoded; nothing here adds a simulation dependency.
`scripts/check-flight-build.sh` runs in CI at `ci.yml:162`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>