### PR TITLE
TUNE-12: supervise Aviate tuning children across host failure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ xtask = "run -q -p xtask --"
 
 [net]
 git-fetch-with-cli = true
+
+[env]
+BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin = "--target=aarch64-apple-darwin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,12 @@ jobs:
       - name: flight tuning boundary guard
         run: bash scripts/check-flight-tune-boundaries.sh
 
+      - name: Aviate supervision boundary guard self-test
+        run: bash scripts/test-check-aviate-supervision-boundary.sh
+
+      - name: Aviate supervision boundary guard
+        run: bash scripts/check-aviate-supervision-boundary.sh
+
       - name: check-structure self-test
         run: bash scripts/test-check-structure.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -398,6 +431,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -660,6 +704,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +797,25 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror",
+]
+
+[[package]]
+name = "flight-tune-aviate"
+version = "0.1.0"
+dependencies = [
+ "errno",
+ "flight-tune",
+ "libc",
+ "libproc",
+ "pilotage-durable-storage",
+ "rustix",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sysctl",
+ "tempfile",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1302,6 +1377,15 @@ source = "git+https://github.com/luofang34/Indicate.git?rev=985eb3390d3e09abf83d
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1345,10 +1429,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2283,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2302,7 +2407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2675,6 +2780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,6 +2943,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -2991,6 +3111,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca424247104946a59dacd27eaad296223b7feec3d168a6dd04585183091eb0b"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -3417,6 +3551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3647,15 @@ checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "adapters/px4",
     "tools/hid-probe",
     "tools/flight-tune",
+    "tools/flight-tune-aviate",
     "tools/loopback-probe",
     "tools/xtask",
     "hosts/session-host",

--- a/crates/pilotage-durable-storage/src/non_unix.rs
+++ b/crates/pilotage-durable-storage/src/non_unix.rs
@@ -30,6 +30,11 @@ impl DurableStore {
         Err(StorageError::unsupported_at(path))
     }
 
+    /// Refuse a weaker existing-storage implementation.
+    pub fn open_existing_blocking(path: &Path) -> StorageResult<Self> {
+        Err(StorageError::unsupported_at(path))
+    }
+
     /// Refuse a fault-enabled weaker storage implementation.
     #[cfg(any(test, feature = "fault-injection"))]
     pub fn open_or_create_with_faults(
@@ -107,6 +112,26 @@ impl DurableDirectory {
         _name: &ObjectName,
         _object: &ExactObject,
     ) -> StorageResult<PutOutcome> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse immutable-publication repair on an unsupported platform.
+    pub fn repair_immutable_publication_blocking(
+        &self,
+        _lease: &WriterLease,
+        _name: &ObjectName,
+        _maximum_bytes: usize,
+    ) -> StorageResult<Option<ExactObject>> {
+        Err(StorageError::unsupported())
+    }
+
+    /// Refuse temporary recovery on an unsupported platform.
+    pub fn cleanup_unlinked_temporaries_blocking(
+        &self,
+        _lease: &WriterLease,
+        _maximum_objects: usize,
+        _maximum_bytes: usize,
+    ) -> StorageResult<usize> {
         Err(StorageError::unsupported())
     }
 

--- a/crates/pilotage-durable-storage/src/tests.rs
+++ b/crates/pilotage-durable-storage/src/tests.rs
@@ -4,6 +4,7 @@ mod attacks;
 mod cas;
 mod faults;
 mod lease;
+mod publication_recovery;
 mod removal_recovery;
 
 use std::error::Error;

--- a/crates/pilotage-durable-storage/src/tests/attacks.rs
+++ b/crates/pilotage-durable-storage/src/tests/attacks.rs
@@ -6,6 +6,28 @@ use crate::{
 };
 
 #[test]
+fn open_existing_does_not_create_a_missing_root() -> TestResult {
+    let temporary = tempfile::tempdir_in(test_parent()?)?;
+    let root = temporary.path().join("missing-store");
+
+    assert!(DurableStore::open_existing_blocking(&root).is_err());
+    assert!(!root.try_exists()?);
+    Ok(())
+}
+
+#[test]
+fn open_existing_rejects_a_root_symlink() -> TestResult {
+    let temporary = tempfile::tempdir_in(test_parent()?)?;
+    let root = temporary.path().join("store");
+    let link = temporary.path().join("store-link");
+    let _store = DurableStore::open_or_create(&root)?;
+    std::os::unix::fs::symlink(&root, &link)?;
+
+    assert!(DurableStore::open_existing_blocking(&link).is_err());
+    Ok(())
+}
+
+#[test]
 fn root_symlink_and_symlinked_tmp_ancestor_are_rejected() -> TestResult {
     let temporary = tempfile::Builder::new()
         .prefix("pilotage-root-link-")

--- a/crates/pilotage-durable-storage/src/tests/publication_recovery.rs
+++ b/crates/pilotage-durable-storage/src/tests/publication_recovery.rs
@@ -1,0 +1,234 @@
+use super::{TestResult, name, test_parent};
+use crate::{
+    DurabilityStep, DurableStore, ExactObject, FaultAction, FaultController, FaultRule, ObjectName,
+    StorageError, StorageOperation,
+};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn recovery_apis_reject_a_cross_root_lease_without_mutation() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-repair-cross-root-")
+        .tempdir_in(test_parent()?)?;
+    let lease_root = temporary.path().join("lease-store");
+    let empty_root = temporary.path().join("empty-store");
+    let lease_store = DurableStore::open_or_create(&lease_root)?;
+    let lease = lease_store.acquire_writer()?;
+    let empty_store = DurableStore::open_or_create(&empty_root)?;
+    let empty_directory = empty_store.root_directory();
+    let before = store_entry_paths(&empty_root)?;
+    assert!(before.is_empty());
+
+    let object_name = name("absent")?;
+    let repair_error = empty_directory
+        .repair_immutable_publication_blocking(&lease, &object_name, 1)
+        .expect_err("a cross-root lease must not repair an absent publication");
+    assert!(matches!(
+        repair_error,
+        StorageError::Corruption {
+            reason: "writer lease belongs to a different storage root",
+            ..
+        }
+    ));
+    assert_eq!(store_entry_paths(&empty_root)?, before);
+
+    let cleanup_error = empty_directory
+        .cleanup_unlinked_temporaries_blocking(&lease, 1, 1)
+        .expect_err("a cross-root lease must not scan an empty store");
+    assert!(matches!(
+        cleanup_error,
+        StorageError::Corruption {
+            reason: "writer lease belongs to a different storage root",
+            ..
+        }
+    ));
+    assert_eq!(store_entry_paths(&empty_root)?, before);
+    Ok(())
+}
+
+#[test]
+fn writer_held_repair_recovers_linked_publication_after_reopen() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-repair-publication-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let object_name = name("object")?;
+    let expected = ExactObject::from_bytes(b"durable publication".to_vec());
+    leave_linked_publication(&root_path, &object_name, &expected)?;
+
+    let linked_temporary = one_temporary_path(&root_path)?;
+    let destination = root_path.join(object_name.as_os_str());
+    let destination_metadata = std::fs::metadata(&destination)?;
+    let temporary_metadata = std::fs::metadata(&linked_temporary)?;
+    assert_eq!(destination_metadata.dev(), temporary_metadata.dev());
+    assert_eq!(destination_metadata.ino(), temporary_metadata.ino());
+    assert_eq!(destination_metadata.nlink(), 2);
+    assert_eq!(temporary_metadata.nlink(), 2);
+
+    let reopened = DurableStore::open_existing_blocking(&root_path)?;
+    let lease = reopened.acquire_writer()?;
+    let root = reopened.root_directory();
+    let repaired = root
+        .repair_immutable_publication_blocking(&lease, &object_name, expected.bytes().len())?
+        .ok_or_else(|| std::io::Error::other("the committed object was not found"))?;
+
+    assert_eq!(repaired.bytes(), expected.bytes());
+    assert_eq!(repaired.digest(), expected.digest());
+    assert_eq!(std::fs::metadata(destination)?.nlink(), 1);
+    assert!(!linked_temporary.exists());
+    Ok(())
+}
+
+#[test]
+fn unlinked_temporary_cleanup_respects_the_byte_limit() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-repair-temporary-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    let bytes = b"uncommitted bytes";
+    leave_unlinked_temporary(&root_path, &name("object")?, bytes)?;
+    let temporary_path = one_temporary_path(&root_path)?;
+    assert_eq!(std::fs::metadata(&temporary_path)?.nlink(), 1);
+
+    let reopened = DurableStore::open_existing_blocking(&root_path)?;
+    let lease = reopened.acquire_writer()?;
+    let root = reopened.root_directory();
+    let error = root
+        .cleanup_unlinked_temporaries_blocking(&lease, 1, bytes.len() - 1)
+        .expect_err("an undersized byte limit must stop cleanup");
+    assert!(matches!(
+        error,
+        StorageError::ObjectTooLarge {
+            limit,
+            actual,
+            ..
+        } if limit == bytes.len() - 1 && actual == bytes.len() as u64
+    ));
+    assert!(temporary_path.exists());
+
+    assert_eq!(
+        root.cleanup_unlinked_temporaries_blocking(&lease, 1, bytes.len())?,
+        1
+    );
+    assert!(!temporary_path.exists());
+    Ok(())
+}
+
+#[test]
+fn unlinked_temporary_cleanup_respects_the_object_limit() -> TestResult {
+    let temporary = tempfile::Builder::new()
+        .prefix("pilotage-repair-temporary-count-")
+        .tempdir_in(test_parent()?)?;
+    let root_path = temporary.path().join("store");
+    leave_unlinked_temporary(&root_path, &name("first")?, b"first")?;
+    leave_unlinked_temporary(&root_path, &name("second")?, b"second")?;
+    let temporary_paths = temporary_paths(&root_path)?;
+    assert_eq!(temporary_paths.len(), 2);
+
+    let reopened = DurableStore::open_existing_blocking(&root_path)?;
+    let lease = reopened.acquire_writer()?;
+    let root = reopened.root_directory();
+    let error = root
+        .cleanup_unlinked_temporaries_blocking(&lease, 1, 6)
+        .expect_err("an undersized object limit must stop cleanup");
+    assert!(matches!(
+        error,
+        StorageError::Corruption {
+            reason: "the temporary object count exceeds the recovery limit",
+            ..
+        }
+    ));
+    assert!(temporary_paths.iter().all(|path| path.exists()));
+
+    assert_eq!(root.cleanup_unlinked_temporaries_blocking(&lease, 2, 6)?, 2);
+    assert!(temporary_paths.iter().all(|path| !path.exists()));
+    Ok(())
+}
+
+fn leave_linked_publication(
+    root_path: &Path,
+    object_name: &ObjectName,
+    object: &ExactObject,
+) -> TestResult {
+    let faults = FaultController::new([
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectPublication,
+            FaultAction::LoseAckAfter,
+        ),
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+            FaultAction::FailBefore,
+        ),
+    ]);
+    let store = DurableStore::open_or_create_with_faults(root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let error = store
+        .root_directory()
+        .put_immutable_no_replace(&lease, object_name, object)
+        .expect_err("the readback fault must leave an ambiguous publication");
+    assert!(matches!(error, StorageError::AmbiguousCommit { .. }));
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+fn leave_unlinked_temporary(
+    root_path: &Path,
+    object_name: &ObjectName,
+    bytes: &[u8],
+) -> TestResult {
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectData,
+        FaultAction::FailBefore,
+    )]);
+    let store = DurableStore::open_or_create_with_faults(root_path, faults.clone())?;
+    let lease = store.acquire_writer()?;
+    let error = store
+        .root_directory()
+        .put_immutable_no_replace(
+            &lease,
+            object_name,
+            &ExactObject::from_bytes(bytes.to_vec()),
+        )
+        .expect_err("the data fault must leave an unlinked temporary object");
+    assert!(matches!(error, StorageError::InjectedFault { .. }));
+    assert!(faults.is_exhausted()?);
+    Ok(())
+}
+
+fn one_temporary_path(root_path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut paths = temporary_paths(root_path)?;
+    if paths.len() != 1 {
+        return Err(std::io::Error::other("the store does not contain one temporary").into());
+    }
+    paths
+        .pop()
+        .ok_or_else(|| std::io::Error::other("the temporary object disappeared").into())
+}
+
+fn temporary_paths(root_path: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(root_path)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".pilotage-tmp-")
+        {
+            paths.push(entry.path());
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn store_entry_paths(root_path: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut paths = std::fs::read_dir(root_path)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort();
+    Ok(paths)
+}

--- a/crates/pilotage-durable-storage/src/unix/directory.rs
+++ b/crates/pilotage-durable-storage/src/unix/directory.rs
@@ -172,6 +172,26 @@ impl DurableDirectory {
         objects::put_immutable(self, lease, name, object)
     }
 
+    /// Repair and read one committed immutable publication.
+    pub fn repair_immutable_publication_blocking(
+        &self,
+        lease: &WriterLease,
+        name: &ObjectName,
+        maximum_bytes: usize,
+    ) -> StorageResult<Option<ExactObject>> {
+        objects::repair_immutable_publication(self, lease, name, maximum_bytes)
+    }
+
+    /// Remove bounded uncommitted temporary objects.
+    pub fn cleanup_unlinked_temporaries_blocking(
+        &self,
+        lease: &WriterLease,
+        maximum_objects: usize,
+        maximum_bytes: usize,
+    ) -> StorageResult<usize> {
+        temporary::cleanup_unlinked(self, lease, maximum_objects, maximum_bytes)
+    }
+
     /// Inspect a private temporary object created by this store.
     pub fn inspect_owned_temporary(
         &self,

--- a/crates/pilotage-durable-storage/src/unix/objects.rs
+++ b/crates/pilotage-durable-storage/src/unix/objects.rs
@@ -212,6 +212,57 @@ pub(crate) fn put_immutable(
     Ok(PutOutcome::Published)
 }
 
+pub(crate) fn repair_immutable_publication(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    name: &ObjectName,
+    maximum_bytes: usize,
+) -> StorageResult<Option<ExactObject>> {
+    let context = directory.handle.context(
+        Some(name),
+        StorageOperation::PublishImmutable,
+        DurabilityStep::BeforeMutation,
+    );
+    lease.validate_for(&directory.handle, &context)?;
+    let stat = match statat(
+        &directory.handle.fd,
+        name.as_os_str(),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        Ok(stat) => stat,
+        Err(rustix::io::Errno::NOENT) => {
+            lease.validate_for(&directory.handle, &context)?;
+            return Ok(None);
+        }
+        Err(source) => {
+            return Err(StorageError::Io {
+                context,
+                source: source.into(),
+            });
+        }
+    };
+    let inspected = inspect_temporary(&stat, &context)?;
+    let object = match inspected.link_count {
+        1 => read_exact(&directory.handle, name, maximum_bytes)?,
+        2 => read_exact_with_links(&directory.handle, name, maximum_bytes, 2)?,
+        actual => return Err(StorageError::LinkedObject { actual, context }),
+    };
+    temporary::reject_reserved_destination(
+        directory,
+        name,
+        &object,
+        StorageOperation::PublishImmutable,
+    )?;
+    if inspected.link_count == 2
+        && !temporary::recover_linked_publication(directory, lease, name, &object)?
+    {
+        return Err(StorageError::ContentMismatch { context });
+    }
+    make_existing_durable(&directory.handle, name, &object)?;
+    lease.validate_for(&directory.handle, &context)?;
+    Ok(Some(object))
+}
+
 pub(crate) fn verify_exact(
     directory: &DirectoryHandle,
     name: &ObjectName,

--- a/crates/pilotage-durable-storage/src/unix/store.rs
+++ b/crates/pilotage-durable-storage/src/unix/store.rs
@@ -29,6 +29,24 @@ impl DurableStore {
         Self::open_with_controller(path, FaultController::default())
     }
 
+    /// Open one exact private Unix storage root without creating it.
+    pub fn open_existing_blocking(path: &Path) -> StorageResult<Self> {
+        let context = StorageContext::root_open_at(path);
+        let (parent, leaf) = open_parent(path, &context)?;
+        let mut selected = context.clone();
+        selected.component = Some(leaf.clone());
+        let root_fd = open_existing_root(&parent, &leaf, &selected)?;
+        Self::bind_open_root(
+            path,
+            parent,
+            leaf,
+            root_fd,
+            FaultController::default(),
+            context,
+            false,
+        )
+    }
+
     /// Open or create a store with deterministic storage faults.
     #[cfg(any(test, feature = "fault-injection"))]
     pub fn open_or_create_with_faults(path: &Path, faults: FaultController) -> StorageResult<Self> {
@@ -56,6 +74,18 @@ impl DurableStore {
         let context = StorageContext::root_open_at(path);
         let (parent, leaf) = open_parent(path, &context)?;
         let root_fd = open_or_create_root(&parent, &leaf, &faults, &context)?;
+        Self::bind_open_root(path, parent, leaf, root_fd, faults, context, true)
+    }
+
+    fn bind_open_root(
+        path: &Path,
+        parent: OwnedFd,
+        leaf: ObjectName,
+        root_fd: OwnedFd,
+        faults: FaultController,
+        context: StorageContext,
+        sync_open: bool,
+    ) -> StorageResult<Self> {
         let mut selected = context.clone();
         selected.component = Some(leaf.clone());
         let stat = fstat(&root_fd).map_err(|source| StorageError::Io {
@@ -78,16 +108,18 @@ impl DurableStore {
                 context: bound,
             });
         }
-        let root_barrier = StorageContext {
-            step: DurabilityStep::ObjectData,
-            ..bound.clone()
-        };
-        sync_directory(&root_fd, &faults, &root_barrier)?;
-        let parent_barrier = StorageContext {
-            step: DurabilityStep::ParentDirectory,
-            ..bound
-        };
-        sync_directory(&parent, &faults, &parent_barrier)?;
+        if sync_open {
+            let root_barrier = StorageContext {
+                step: DurabilityStep::ObjectData,
+                ..bound.clone()
+            };
+            sync_directory(&root_fd, &faults, &root_barrier)?;
+            let parent_barrier = StorageContext {
+                step: DurabilityStep::ParentDirectory,
+                ..bound.clone()
+            };
+            sync_directory(&parent, &faults, &parent_barrier)?;
+        }
         let anchor = Arc::new(Anchor {
             root_parent: parent,
             root_leaf: leaf,

--- a/crates/pilotage-durable-storage/src/unix/temporary.rs
+++ b/crates/pilotage-durable-storage/src/unix/temporary.rs
@@ -143,6 +143,46 @@ pub(crate) fn cleanup(
     )
 }
 
+pub(crate) fn cleanup_unlinked(
+    directory: &DurableDirectory,
+    lease: &WriterLease,
+    maximum_objects: usize,
+    maximum_bytes: usize,
+) -> StorageResult<usize> {
+    let before = directory.handle.context(
+        None,
+        StorageOperation::RemoveTemporary,
+        DurabilityStep::BeforeMutation,
+    );
+    lease.validate_for(&directory.handle, &before)?;
+    let temporaries = directory
+        .list()?
+        .into_iter()
+        .filter(is_temporary_name)
+        .collect::<Vec<_>>();
+    if temporaries.len() > maximum_objects {
+        return Err(StorageError::Corruption {
+            reason: "the temporary object count exceeds the recovery limit",
+            context: directory.handle.context(
+                None,
+                StorageOperation::RemoveTemporary,
+                DurabilityStep::Selection,
+            ),
+        });
+    }
+    for name in &temporaries {
+        let temporary = inspect_owned(directory, name, maximum_bytes)?;
+        cleanup(directory, lease, &temporary)?;
+    }
+    let after = directory.handle.context(
+        None,
+        StorageOperation::RemoveTemporary,
+        DurabilityStep::AfterMutation,
+    );
+    lease.validate_for(&directory.handle, &after)?;
+    Ok(temporaries.len())
+}
+
 fn create_unique(
     directory: &DurableDirectory,
     lease: &WriterLease,

--- a/scripts/check-aviate-supervision-boundary.sh
+++ b/scripts/check-aviate-supervision-boundary.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Keep destructive process control inside the Aviate supervisor.
+set -euo pipefail
+
+default_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root="${1:-$default_root}"
+root="$(cd "$root" && pwd)"
+source_root="$root/tools/flight-tune-aviate/src"
+interface="tools/flight-tune-aviate/src/supervisor/process_control.rs"
+work="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-aviate-supervision-boundary.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+status=0
+
+report() {
+    echo "FORBIDDEN: $1" >&2
+    status=1
+}
+
+relative_path() {
+    printf '%s\n' "${1#"$root"/}"
+}
+
+is_production_rust_path() {
+    case "$1" in
+        */tests.rs|*/tests/*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+collect_production_files() {
+    local file link
+    find "$source_root" -type l -print > "$work/links"
+    while IFS= read -r link; do
+        if is_production_rust_path "$link"; then
+            report "production Rust source path $(relative_path "$link") is a symlink"
+        fi
+    done < "$work/links"
+    find "$source_root" -type f -name '*.rs' -print > "$work/files"
+    while IFS= read -r file; do
+        if is_production_rust_path "$file"; then
+            printf '%s\n' "$file"
+        fi
+    done < "$work/files"
+}
+
+check_raw_process_control() {
+    local file relative matches match_status
+    while IFS= read -r file; do
+        relative="$(relative_path "$file")"
+        matches="$work/raw-$(printf '%s' "$relative" | tr '/.' '__')"
+        match_status=0
+        grep -nE \
+            'rustix::process::kill_current_process_group|rustix::process::kill_process_group|rustix::process::kill_process[[:space:]]*\(|(std::process::)?Child::kill[[:space:]]*\(|\.kill[[:space:]]*\(' \
+            "$file" > "$matches" || match_status=$?
+        if [ "$match_status" -gt 1 ]; then
+            report "$relative cannot be scanned for process-control primitives"
+            continue
+        fi
+        if [ "$relative" != "$interface" ]; then
+            while IFS=: read -r line_number _source; do
+                [ -n "$line_number" ] \
+                    && report "$relative:$line_number uses a raw process-control primitive"
+            done < "$matches"
+        fi
+    done < "$work/production-files"
+}
+
+allowed_entry_point() {
+    local relative="$1" reference="$2"
+    case "$relative:$reference" in
+        tools/flight-tune-aviate/src/supervisor/gate.rs:process_control::stop_child) return 0 ;;
+        tools/flight-tune-aviate/src/supervisor/gate.rs:process_control::signal_current_process_group) return 0 ;;
+        tools/flight-tune-aviate/src/supervisor/owner/cleanup.rs:process_control::signal_process_group) return 0 ;;
+        tools/flight-tune-aviate/src/supervisor/owner/launch.rs:process_control::stop_child) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+check_process_control_entry_points() {
+    local file relative matches match_status line_number reference
+    while IFS= read -r file; do
+        relative="$(relative_path "$file")"
+        matches="$work/entry-$(printf '%s' "$relative" | tr '/.' '__')"
+        match_status=0
+        grep -nEo 'process_control::[a-z_][a-z0-9_]*' \
+            "$file" > "$matches" || match_status=$?
+        if [ "$match_status" -gt 1 ]; then
+            report "$relative cannot be scanned for process-control entry points"
+            continue
+        fi
+        while IFS=: read -r line_number reference; do
+            [ -n "$line_number" ] || continue
+            if ! allowed_entry_point "$relative" "$reference"; then
+                report "$relative:$line_number uses an unowned process-control entry point"
+            fi
+        done < "$matches"
+    done < "$work/production-files"
+}
+
+if [ ! -f "$root/$interface" ]; then
+    report "$interface is missing"
+fi
+collect_production_files | LC_ALL=C sort -u > "$work/production-files"
+check_raw_process_control
+check_process_control_entry_points
+
+if [ "$status" -ne 0 ]; then
+    echo "check-aviate-supervision-boundary: FAILED" >&2
+    exit 1
+fi
+
+echo "check-aviate-supervision-boundary: OK"

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -468,8 +468,16 @@ GENERATED_BUILD_TARGETS = {
 TEST_ONLY_MODULE_NAMES = {"tests", "test_support"}
 NON_PRODUCTION_TARGET_KINDS = {"bench", "custom-build", "example", "test"}
 CRATES_IO_SOURCE = "registry+https://github.com/rust-lang/crates.io-index"
+BINDGEN_TARGET_ENV_KEY = "BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin"
+BINDGEN_TARGET_ENV_VALUE = "--target=aarch64-apple-darwin"
 CARGO_LOCK_PACKAGE_ALLOWLIST = frozenset(
     {
+        (
+            "errno",
+            "0.3.14",
+            CRATES_IO_SOURCE,
+            "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
+        ),
         (
             "libc",
             "0.2.186",
@@ -525,6 +533,12 @@ CARGO_LOCK_PACKAGE_ALLOWLIST = frozenset(
             "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4",
         ),
         (
+            "sysctl",
+            "0.7.1",
+            CRATES_IO_SOURCE,
+            "cca424247104946a59dacd27eaad296223b7feec3d168a6dd04585183091eb0b",
+        ),
+        (
             "thiserror",
             "2.0.18",
             CRATES_IO_SOURCE,
@@ -566,6 +580,7 @@ CARGO_LOCK_TRACKED_PACKAGES = frozenset(
     record[0] for record in CARGO_LOCK_PACKAGE_ALLOWLIST
 )
 CARGO_LOCK_REQUIRED_VERSIONS = {
+    "errno": "0.3.14",
     "libc": "0.2.186",
     "libm": "0.2.16",
     "libproc": "0.14.11",
@@ -574,6 +589,7 @@ CARGO_LOCK_REQUIRED_VERSIONS = {
     "serde_derive": "1.0.228",
     "serde_json": "1.0.150",
     "sha2": "0.10.9",
+    "sysctl": "0.7.1",
     "thiserror": "2.0.18",
     "thiserror-impl": "2.0.18",
     "tokio": "1.52.3",
@@ -704,8 +720,9 @@ def read_direct_dependency_allowlist(
 
 
 def check_cargo_source_overrides(root: Path) -> bool:
-    """Reject project-controlled Cargo source substitution routes."""
+    """Check Cargo source controls and the macOS bindgen target."""
     valid = True
+    bindgen_target_is_exact = False
     manifest = root / "Cargo.toml"
     try:
         workspace_document = tomllib.loads(manifest.read_text(encoding="utf-8"))
@@ -735,6 +752,19 @@ def check_cargo_source_overrides(root: Path) -> bool:
         ):
             report(f"{relative} has an unreviewed dependency source override")
             valid = False
+        if relative == ".cargo/config.toml":
+            environment = document.get("env")
+            bindgen_target_is_exact = (
+                isinstance(environment, dict)
+                and environment.get(BINDGEN_TARGET_ENV_KEY)
+                == BINDGEN_TARGET_ENV_VALUE
+            )
+    if not bindgen_target_is_exact:
+        report(
+            f".cargo/config.toml must set {BINDGEN_TARGET_ENV_KEY} "
+            f'to "{BINDGEN_TARGET_ENV_VALUE}"'
+        )
+        valid = False
     return valid
 
 
@@ -2313,7 +2343,7 @@ def main() -> int:
         (root / "tools/flight-tune/Cargo.toml", frozenset()),
         (
             root / "tools/flight-tune-aviate/Cargo.toml",
-            frozenset(FORBIDDEN_PACKAGES),
+            frozenset(),
         ),
         (
             root / "tools/flight-tune-campaign/Cargo.toml",

--- a/scripts/flight-tune-direct-dependency-allowlist.tsv
+++ b/scripts/flight-tune-direct-dependency-allowlist.tsv
@@ -3,27 +3,17 @@ crates/pilotage-trial/Cargo.toml	serde	serde	normal		false	source	registry+https
 crates/pilotage-trial/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
 crates/pilotage-trial/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
 crates/pilotage-trial/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
+tools/flight-tune-aviate/Cargo.toml	errno	errno	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		=0.3.14
 tools/flight-tune-aviate/Cargo.toml	flight-tune	flight-tune	normal		false	path	tools/flight-tune	true		*
-tools/flight-tune-aviate/Cargo.toml	flight-tune-xplane	flight-tune-xplane	normal		false	path	tools/flight-tune-xplane	true		*
-tools/flight-tune-aviate/Cargo.toml	libm	libm	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.2.16
-tools/flight-tune-aviate/Cargo.toml	pilotage-adapter-api	pilotage-adapter-api	normal		false	path	crates/pilotage-adapter-api	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-adapter-aviate	pilotage-adapter-aviate	normal		false	path	adapters/aviate	false	sim	*
-tools/flight-tune-aviate/Cargo.toml	pilotage-control-feel	pilotage-control-feel	normal		false	path	crates/pilotage-control-feel	true		*
+tools/flight-tune-aviate/Cargo.toml	libc	libc	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.2.177
+tools/flight-tune-aviate/Cargo.toml	libproc	libproc	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		=0.14.11
 tools/flight-tune-aviate/Cargo.toml	pilotage-durable-storage	pilotage-durable-storage	normal		false	path	crates/pilotage-durable-storage	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-mavlink	pilotage-mavlink	normal		false	path	crates/pilotage-mavlink	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-protocol	pilotage-protocol	normal		false	path	crates/pilotage-protocol	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-timing	pilotage-timing	normal		false	path	crates/pilotage-timing	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-trial	pilotage-trial	normal		false	path	crates/pilotage-trial	true		*
-tools/flight-tune-aviate/Cargo.toml	pilotage-xplane-trial	pilotage-xplane-trial	normal		false	path	crates/pilotage-xplane-trial	true		*
-tools/flight-tune-aviate/Cargo.toml	serde	serde	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune-aviate/Cargo.toml	rustix	rustix	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	fs,process	=1.1.4
 tools/flight-tune-aviate/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
-tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
 tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
-tools/flight-tune-aviate/Cargo.toml	sha2	sha2	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
 tools/flight-tune-aviate/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
+tools/flight-tune-aviate/Cargo.toml	sysctl	sysctl	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		=0.7.1
 tools/flight-tune-aviate/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18
-tools/flight-tune-aviate/Cargo.toml	tokio	tokio	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	net,rt,time	^1.48.0
-tools/flight-tune-aviate/Cargo.toml	toml	toml	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^1.1.4
 tools/flight-tune-aviate/Cargo.toml	tracing	tracing	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.1.44
 tools/flight-tune-campaign/Cargo.toml	flight-tune	flight-tune	normal		false	path	tools/flight-tune	true		*
 tools/flight-tune-campaign/Cargo.toml	flight-tune-aviate	flight-tune-aviate	normal		false	path	tools/flight-tune-aviate	true		*

--- a/scripts/test-check-aviate-supervision-boundary.sh
+++ b/scripts/test-check-aviate-supervision-boundary.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Prove that the Aviate supervision guard rejects signal ownership changes.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$repo_root/scripts/check-aviate-supervision-boundary.sh"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/pilotage-aviate-supervision-test.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+interface="$fixture/tools/flight-tune-aviate/src/supervisor/process_control.rs"
+gate="$fixture/tools/flight-tune-aviate/src/supervisor/gate.rs"
+owner_cleanup="$fixture/tools/flight-tune-aviate/src/supervisor/owner/cleanup.rs"
+owner_launch="$fixture/tools/flight-tune-aviate/src/supervisor/owner/launch.rs"
+recovery="$fixture/tools/flight-tune-aviate/src/process/recovery/cleanup.rs"
+test_source="$fixture/tools/flight-tune-aviate/src/process/recovery/tests.rs"
+
+mkdir -p \
+    "$(dirname "$interface")" \
+    "$(dirname "$owner_cleanup")" \
+    "$(dirname "$recovery")"
+
+write_clean_fixture() {
+    printf '%s\n' \
+        'fn stop_child(child: &mut std::process::Child) { child.kill(); }' \
+        'fn signal_current_process_group() {' \
+        '    rustix::process::kill_current_process_group(Signal::KILL);' \
+        '}' \
+        'fn signal_process_group(group: Pid) {' \
+        '    rustix::process::kill_process_group(group, Signal::KILL);' \
+        '}' \
+        > "$interface"
+    printf '%s\n' \
+        'fn contain(child: &mut Child) { process_control::stop_child(child); }' \
+        'fn fail() { process_control::signal_current_process_group(); }' \
+        > "$gate"
+    printf '%s\n' \
+        'fn stop(group: u32) { process_control::signal_process_group(group); }' \
+        > "$owner_cleanup"
+    printf '%s\n' \
+        'fn stop(child: &mut Child) { process_control::stop_child(child); }' \
+        > "$owner_launch"
+    printf '%s\n' 'fn recover() {}' > "$recovery"
+    printf '%s\n' \
+        'fn teardown(child: &mut Child) { child.kill(); }' \
+        > "$test_source"
+}
+
+expect_failure() {
+    local name="$1" expected="$2" output
+    if output="$(bash "$guard" "$fixture" 2>&1)"; then
+        echo "the Aviate supervision guard accepted $name" >&2
+        exit 1
+    fi
+    if ! grep -Fq "$expected" <<<"$output"; then
+        echo "the Aviate supervision guard gave the wrong result for $name" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+write_clean_fixture
+bash "$guard" "$fixture" >/dev/null
+
+printf '%s\n' 'fn recover(child: &mut Child) { child.kill(); }' > "$recovery"
+expect_failure \
+    'a raw recovery signal' \
+    'uses a raw process-control primitive'
+
+write_clean_fixture
+printf '%s\n' \
+    'fn recover(group: u32) { process_control::signal_process_group(group); }' \
+    > "$recovery"
+expect_failure \
+    'a recovery signal entry point' \
+    'uses an unowned process-control entry point'
+
+write_clean_fixture
+printf '%s\n' 'fn stop(child: &mut Child) { child.kill(); }' > "$owner_cleanup"
+expect_failure \
+    'a raw owner signal' \
+    'uses a raw process-control primitive'
+
+write_clean_fixture
+printf '%s\n' \
+    'fn stop(group: u32) { process_control::signal_process_group(group); }' \
+    > "$gate"
+expect_failure \
+    'a signal entry point with the wrong owner' \
+    'uses an unowned process-control entry point'
+
+write_clean_fixture
+printf '%s\n' \
+    'fn recover(pid: Pid) {' \
+    '    rustix::process::kill_process(pid, Signal::KILL);' \
+    '}' \
+    > "$recovery"
+expect_failure \
+    'a direct process signal' \
+    'uses a raw process-control primitive'
+
+write_clean_fixture
+printf '%s\n' \
+    'fn recover(child: &mut Child) { std::process::Child::kill(child); }' \
+    > "$recovery"
+expect_failure \
+    'a UFCS child signal' \
+    'uses a raw process-control primitive'
+
+write_clean_fixture
+printf '%s\n' \
+    'fn terminate_pid(pid: Pid) {' \
+    '    rustix::process::kill_process(pid, Signal::KILL);' \
+    '}' \
+    >> "$interface"
+printf '%s\n' \
+    'fn recover(pid: Pid) { process_control::terminate_pid(pid); }' \
+    > "$recovery"
+expect_failure \
+    'an unreviewed process-control wrapper' \
+    'uses an unowned process-control entry point'
+
+echo "check-aviate-supervision-boundary self-test: OK"

--- a/scripts/test-check-flight-tune-boundaries.sh
+++ b/scripts/test-check-flight-tune-boundaries.sh
@@ -18,7 +18,10 @@ mkdir -p \
     "$fixture/tools/flight-tune-aviate/src/bin" \
     "$fixture/tools/flight-tune-aviate/src/support" \
     "$fixture/tools/flight-tune-aviate/src/tests" \
-    "$fixture/tools/flight-tune-campaign/src/config"
+    "$fixture/tools/flight-tune-campaign/src/config" \
+    "$fixture/vendor/errno/src" \
+    "$fixture/vendor/libproc/src" \
+    "$fixture/vendor/sysctl/src"
 
 write_workspace() {
     printf '%s\n' \
@@ -31,6 +34,9 @@ write_workspace() {
         '    "tools/flight-tune",' \
         '    "tools/flight-tune-aviate",' \
         '    "tools/flight-tune-campaign",' \
+        '    "vendor/errno",' \
+        '    "vendor/libproc",' \
+        '    "vendor/sysctl",' \
         ']' \
         'resolver = "2"' \
         > "$fixture/Cargo.toml"
@@ -63,6 +69,59 @@ write_adapter_packages() {
         > "$fixture/injected/Cargo.toml"
     printf '%s\n' 'extern crate proc_macro;' \
         > "$fixture/injected/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "errno"' \
+        'version = "0.3.14"' \
+        'edition = "2021"' \
+        > "$fixture/vendor/errno/Cargo.toml"
+    printf '%s\n' 'pub fn fixture() {}' \
+        > "$fixture/vendor/errno/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "libproc"' \
+        'version = "0.14.11"' \
+        'edition = "2021"' \
+        > "$fixture/vendor/libproc/Cargo.toml"
+    printf '%s\n' 'pub fn fixture() {}' \
+        > "$fixture/vendor/libproc/src/lib.rs"
+    printf '%s\n' \
+        '[package]' \
+        'name = "sysctl"' \
+        'version = "0.7.1"' \
+        'edition = "2021"' \
+        > "$fixture/vendor/sysctl/Cargo.toml"
+    printf '%s\n' 'pub fn fixture() {}' \
+        > "$fixture/vendor/sysctl/src/lib.rs"
+}
+
+write_clean_cargo_config() {
+    mkdir -p "$fixture/.cargo"
+    printf '%s\n' \
+        '[env]' \
+        'BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin = "--target=aarch64-apple-darwin"' \
+        > "$fixture/.cargo/config.toml"
+}
+
+write_aviate_manifest() {
+    local errno_version="$1" libproc_version="$2" sysctl_version="$3"
+    local normal_dependency="${4:-}"
+    {
+        printf '%s\n' \
+            '[package]' \
+            'name = "flight-tune-aviate"' \
+            'version = "0.0.0"' \
+            'edition = "2021"' \
+            '[dependencies]'
+        if [ -n "$normal_dependency" ]; then
+            printf '%s\n' "$normal_dependency"
+        fi
+        printf '%s\n' \
+            '[target.'\''cfg(target_os = "macos")'\''.dependencies]' \
+            "errno = { version = \"$errno_version\", path = \"../../vendor/errno\" }" \
+            "libproc = { version = \"$libproc_version\", path = \"../../vendor/libproc\" }" \
+            "sysctl = { version = \"$sysctl_version\", path = \"../../vendor/sysctl\" }"
+    } > "$fixture/tools/flight-tune-aviate/Cargo.toml"
 }
 
 write_clean_manifests() {
@@ -80,15 +139,7 @@ write_clean_manifests() {
         'edition = "2021"' \
         '[dependencies]' \
         > "$fixture/tools/flight-tune/Cargo.toml"
-    printf '%s\n' \
-        '[package]' \
-        'name = "flight-tune-aviate"' \
-        'version = "0.0.0"' \
-        'edition = "2021"' \
-        '[dependencies]' \
-        'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }' \
-        'pilotage-xplane-trial = { path = "../../adapters/pilotage-xplane-trial" }' \
-        > "$fixture/tools/flight-tune-aviate/Cargo.toml"
+    write_aviate_manifest '=0.3.14' '=0.14.11' '=0.7.1'
     printf '%s\n' 'pub fn host() {}' \
         > "$fixture/tools/flight-tune-aviate/src/lib.rs"
     printf '%s\n' \
@@ -103,11 +154,19 @@ write_clean_manifests() {
 }
 
 write_dependency_allowlist() {
-    printf '%s\n' \
-        $'manifest\tdependency_key\tactual_package\tkind\ttarget\toptional\tsource_kind\tsource_ref\tdefault_features\tfeatures\tversion_req' \
-        $'tools/flight-tune-aviate/Cargo.toml\tflight-tune-xplane\tflight-tune-xplane\tnormal\t\tfalse\tpath\tadapters/flight-tune-xplane\ttrue\t\t*' \
-        $'tools/flight-tune-aviate/Cargo.toml\tpilotage-xplane-trial\tpilotage-xplane-trial\tnormal\t\tfalse\tpath\tadapters/pilotage-xplane-trial\ttrue\t\t*' \
-        > "$fixture/scripts/flight-tune-direct-dependency-allowlist.tsv"
+    local include_xplane="${1:-false}"
+    {
+        printf '%s\n' \
+            $'manifest\tdependency_key\tactual_package\tkind\ttarget\toptional\tsource_kind\tsource_ref\tdefault_features\tfeatures\tversion_req' \
+            $'tools/flight-tune-aviate/Cargo.toml\terrno\terrno\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/errno\ttrue\t\t=0.3.14'
+        if [ "$include_xplane" = true ]; then
+            printf '%s\n' \
+                $'tools/flight-tune-aviate/Cargo.toml\tflight-tune-xplane\tflight-tune-xplane\tnormal\t\tfalse\tpath\tadapters/flight-tune-xplane\ttrue\t\t*'
+        fi
+        printf '%s\n' \
+            $'tools/flight-tune-aviate/Cargo.toml\tlibproc\tlibproc\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/libproc\ttrue\t\t=0.14.11' \
+            $'tools/flight-tune-aviate/Cargo.toml\tsysctl\tsysctl\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/sysctl\ttrue\t\t=0.7.1'
+    } > "$fixture/scripts/flight-tune-direct-dependency-allowlist.tsv"
 }
 
 write_allowlisted_import() {
@@ -187,6 +246,7 @@ expect_failure_with_all() {
 
 write_workspace
 write_adapter_packages
+write_clean_cargo_config
 write_clean_manifests
 write_dependency_allowlist
 write_allowlisted_import
@@ -212,7 +272,7 @@ printf '%s\n' 'paths = ["../injected"]' \
 expect_failure \
     'a Cargo configuration path source override' \
     '.cargo/config.toml has an unreviewed dependency source override'
-rm "$fixture/.cargo/config.toml"
+write_clean_cargo_config
 
 printf '%s\n' 'include = ["source-override.toml"]' \
     > "$fixture/.cargo/config.toml"
@@ -223,8 +283,26 @@ printf '%s\n' \
 expect_failure \
     'an included Cargo configuration source override' \
     '.cargo/config.toml has an unreviewed dependency source override'
-rm "$fixture/.cargo/config.toml"
 rm "$fixture/.cargo/source-override.toml"
+write_clean_cargo_config
+
+printf '%s\n' \
+    '[env]' \
+    'BINDGEN_EXTRA_CLANG_ARGS_AARCH64_APPLE_DARWIN = "--target=aarch64-apple-darwin"' \
+    > "$fixture/.cargo/config.toml"
+expect_failure \
+    'a changed macOS bindgen environment key' \
+    '.cargo/config.toml must set BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin'
+write_clean_cargo_config
+
+printf '%s\n' \
+    '[env]' \
+    'BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin = "--target=x86_64-apple-darwin"' \
+    > "$fixture/.cargo/config.toml"
+expect_failure \
+    'a changed macOS bindgen environment value' \
+    '.cargo/config.toml must set BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin'
+write_clean_cargo_config
 
 printf '%s\n' \
     'version = 4' \
@@ -239,6 +317,51 @@ expect_failure \
     'an unreviewed Cargo lockfile registry identity' \
     'Cargo.lock has an unreviewed registry identity for serde'
 rm "$fixture/Cargo.lock"
+
+printf '%s\n' \
+    $'manifest\tdependency_key\tactual_package\tkind\ttarget\toptional\tsource_kind\tsource_ref\tdefault_features\tfeatures\tversion_req' \
+    $'tools/flight-tune-aviate/Cargo.toml\tsysctl\tsysctl\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/sysctl\ttrue\t\t=0.7.1' \
+    $'tools/flight-tune-aviate/Cargo.toml\terrno\terrno\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/errno\ttrue\t\t=0.3.14' \
+    $'tools/flight-tune-aviate/Cargo.toml\tlibproc\tlibproc\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/libproc\ttrue\t\t=0.14.11' \
+    > "$fixture/scripts/flight-tune-direct-dependency-allowlist.tsv"
+expect_failure \
+    'an unsorted direct dependency allowlist' \
+    'direct dependency allowlist is not sorted or has a duplicate'
+write_dependency_allowlist
+
+printf '%s\n' \
+    $'tools/flight-tune-aviate/Cargo.toml\terrno\terrno\tnormal\tcfg(target_os = "macos")\tfalse\tpath\tvendor/errno\ttrue\t\t=0.3.14' \
+    >> "$fixture/scripts/flight-tune-direct-dependency-allowlist.tsv"
+expect_failure \
+    'a duplicate direct dependency allowlist record' \
+    'direct dependency allowlist is not sorted or has a duplicate'
+write_dependency_allowlist
+
+write_aviate_manifest '^0.3.14' '=0.14.11' '=0.7.1'
+expect_failure \
+    'a non-exact macOS errno pin' \
+    'has unreviewed direct production dependency errno'
+write_aviate_manifest '=0.3.14' '^0.14.11' '=0.7.1'
+expect_failure \
+    'a non-exact macOS libproc pin' \
+    'has unreviewed direct production dependency libproc'
+write_aviate_manifest '=0.3.14' '=0.14.11' '^0.7.1'
+expect_failure \
+    'a non-exact macOS sysctl pin' \
+    'has unreviewed direct production dependency sysctl'
+write_aviate_manifest '=0.3.14' '=0.14.11' '=0.7.1'
+
+write_aviate_manifest \
+    '=0.3.14' \
+    '=0.14.11' \
+    '=0.7.1' \
+    'flight-tune-xplane = { path = "../../adapters/flight-tune-xplane" }'
+write_dependency_allowlist true
+expect_failure \
+    'a reviewed Aviate flight-tune-xplane runtime dependency' \
+    'noncanonical runtime dependency flight-tune-xplane'
+write_clean_manifests
+write_dependency_allowlist
 
 printf '%s\n' 'pub fn marker() {}' \
     > "$fixture/tools/flight-tune-aviate/src/driver.rs"
@@ -507,6 +630,9 @@ printf '%s\n' \
         '    "tools/flight-tune",' \
         '    "tools/flight-tune-aviate",' \
         '    "tools/flight-tune-campaign",' \
+        '    "vendor/errno",' \
+        '    "vendor/libproc",' \
+        '    "vendor/sysctl",' \
     ']' \
     'resolver = "2"' \
     '[workspace.dependencies]' \

--- a/tools/flight-tune-aviate/Cargo.toml
+++ b/tools/flight-tune-aviate/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "flight-tune-aviate"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "Crash-contained Aviate process supervision for simulator tuning"
+
+[lints]
+workspace = true
+
+[dependencies]
+flight-tune = { path = "../flight-tune" }
+pilotage-durable-storage = { workspace = true }
+rustix = { workspace = true, features = ["process"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+errno = "=0.3.14"
+libc = { workspace = true }
+libproc = "=0.14.11"
+sysctl = "=0.7.1"
+
+[dev-dependencies]
+pilotage-durable-storage = { workspace = true, features = ["fault-injection"] }
+tempfile = "3.23.0"

--- a/tools/flight-tune-aviate/src/artifact.rs
+++ b/tools/flight-tune-aviate/src/artifact.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use crate::AviateSupervisorError;
+
+mod removal;
+mod root;
+mod staging;
+
+pub(crate) use removal::{remove_artifact_root, remove_staged, stabilize_absent_artifact_root};
+pub(crate) use root::{create_artifact_root, inspect_directory, validate_directory};
+pub(crate) use staging::{inspect_staged, stage_executable};
+
+pub(crate) const SUPERVISOR_ARTIFACT: &str = "supervisor";
+pub(crate) const TARGET_ARTIFACT: &str = "target";
+
+pub(super) fn io_error(
+    operation: &'static str,
+    path: &Path,
+    source: std::io::Error,
+) -> AviateSupervisorError {
+    AviateSupervisorError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}

--- a/tools/flight-tune-aviate/src/artifact/removal.rs
+++ b/tools/flight-tune-aviate/src/artifact/removal.rs
@@ -1,0 +1,77 @@
+use std::fs::File;
+
+use super::io_error;
+use super::root::validate_directory;
+use super::staging::inspect_staged;
+use crate::AviateSupervisorError;
+use crate::document::{AnchoredDirectory, AnchoredExecutable};
+
+pub(crate) fn remove_staged(
+    root: &AnchoredDirectory,
+    identity: &AnchoredExecutable,
+) -> Result<(), AviateSupervisorError> {
+    validate_directory(root, true)?;
+    let actual = inspect_staged(&identity.path, identity.digest)?;
+    if actual != *identity || identity.path.parent() != Some(root.path.as_path()) {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the staged executable identity changed".to_owned(),
+        });
+    }
+    std::fs::remove_file(&identity.path)
+        .map_err(|source| io_error("remove staged executable", &identity.path, source))?;
+    sync_directory(&root.path)?;
+    validate_directory(root, true)
+}
+
+pub(crate) fn remove_artifact_root(root: &AnchoredDirectory) -> Result<(), AviateSupervisorError> {
+    validate_directory(root, true)?;
+    let mut entries = std::fs::read_dir(&root.path)
+        .map_err(|source| io_error("scan launch-artifact root", &root.path, source))?;
+    if entries
+        .next()
+        .transpose()
+        .map_err(|source| io_error("read launch-artifact root", &root.path, source))?
+        .is_some()
+    {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the launch-artifact root is not empty".to_owned(),
+        });
+    }
+    validate_directory(root, true)?;
+    std::fs::remove_dir(&root.path)
+        .map_err(|source| io_error("remove launch-artifact root", &root.path, source))?;
+    let parent = root.path.parent().ok_or_else(|| {
+        AviateSupervisorError::invalid_request("the launch-artifact root has no parent")
+    })?;
+    sync_directory(parent)
+}
+
+pub(crate) fn stabilize_absent_artifact_root(
+    root: &AnchoredDirectory,
+) -> Result<(), AviateSupervisorError> {
+    match std::fs::symlink_metadata(&root.path) {
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => {
+            return Err(AviateSupervisorError::RecoveryBlocked {
+                detail: "the launch-artifact root is still present".to_owned(),
+            });
+        }
+        Err(source) => {
+            return Err(io_error(
+                "inspect absent launch-artifact root",
+                &root.path,
+                source,
+            ));
+        }
+    }
+    let parent = root.path.parent().ok_or_else(|| {
+        AviateSupervisorError::invalid_request("the launch-artifact root has no parent")
+    })?;
+    sync_directory(parent)
+}
+
+fn sync_directory(path: &std::path::Path) -> Result<(), AviateSupervisorError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| io_error("sync launch-artifact directory", path, source))
+}

--- a/tools/flight-tune-aviate/src/artifact/root.rs
+++ b/tools/flight-tune-aviate/src/artifact/root.rs
@@ -1,0 +1,251 @@
+use std::fs::File;
+use std::path::{Component, Path};
+
+use super::io_error;
+use crate::AviateSupervisorError;
+use crate::document::AnchoredDirectory;
+
+struct OwnedRoot {
+    directory: File,
+    identity: AnchoredDirectory,
+}
+
+pub(crate) fn create_artifact_root(
+    root: &Path,
+) -> Result<AnchoredDirectory, AviateSupervisorError> {
+    validate_absent_root_path(root)?;
+    create_private_directory(root)?;
+    let owned = match bind_owned_root(root) {
+        Ok(owned) => owned,
+        Err(source) => return cleanup_unbound_root(root, source),
+    };
+    match finish_root_creation(&owned) {
+        Ok(()) => Ok(owned.identity),
+        Err(source) => cleanup_owned_root(&owned, source),
+    }
+}
+
+pub(crate) fn inspect_directory(
+    path: &Path,
+    private: bool,
+) -> Result<AnchoredDirectory, AviateSupervisorError> {
+    if !is_normal_absolute(path) {
+        return Err(AviateSupervisorError::invalid_request(
+            "an anchored directory path is not normalized absolute",
+        ));
+    }
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|source| io_error("canonicalize anchored directory", path, source))?;
+    if canonical != path {
+        return Err(AviateSupervisorError::invalid_request(
+            "an anchored directory path is not canonical",
+        ));
+    }
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|source| io_error("inspect anchored directory", path, source))?;
+    directory_identity(path, &metadata, private)
+}
+
+pub(crate) fn validate_directory(
+    expected: &AnchoredDirectory,
+    private: bool,
+) -> Result<(), AviateSupervisorError> {
+    let actual = inspect_directory(&expected.path, private)?;
+    if actual != *expected {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "an anchored directory identity changed",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_absent_root_path(root: &Path) -> Result<(), AviateSupervisorError> {
+    if !is_normal_absolute(root) {
+        return Err(AviateSupervisorError::invalid_request(
+            "the launch-artifact root is not normalized absolute",
+        ));
+    }
+    let parent = root.parent().ok_or_else(|| {
+        AviateSupervisorError::invalid_request("the launch-artifact root has no parent")
+    })?;
+    let canonical_parent = std::fs::canonicalize(parent)
+        .map_err(|source| io_error("canonicalize launch-artifact parent", parent, source))?;
+    if canonical_parent != parent {
+        return Err(AviateSupervisorError::invalid_request(
+            "the launch-artifact parent is not canonical",
+        ));
+    }
+    match std::fs::symlink_metadata(root) {
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Ok(_) => Err(AviateSupervisorError::invalid_request(
+            "the launch-artifact root already exists",
+        )),
+        Err(source) => Err(io_error("inspect launch-artifact root", root, source)),
+    }
+}
+
+fn finish_root_creation(owned: &OwnedRoot) -> Result<(), AviateSupervisorError> {
+    validate_owned_root(owned)?;
+    owned
+        .directory
+        .sync_all()
+        .map_err(|source| io_error("sync launch-artifact root", &owned.identity.path, source))?;
+    sync_parent(&owned.identity.path)?;
+    validate_owned_root(owned)
+}
+
+fn cleanup_owned_root<T>(
+    owned: &OwnedRoot,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let cleanup = validate_owned_root(owned)
+        .and_then(|()| require_empty(&owned.identity.path))
+        .and_then(|()| {
+            std::fs::remove_dir(&owned.identity.path).map_err(|error| {
+                io_error(
+                    "remove partial launch-artifact root",
+                    &owned.identity.path,
+                    error,
+                )
+            })
+        })
+        .and_then(|()| sync_parent(&owned.identity.path));
+    combine_cleanup(source, cleanup)
+}
+
+fn cleanup_unbound_root<T>(
+    root: &Path,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let cleanup = inspect_directory(root, true)
+        .and_then(|_| require_empty(root))
+        .and_then(|()| {
+            std::fs::remove_dir(root)
+                .map_err(|error| io_error("remove unbound launch-artifact root", root, error))
+        })
+        .and_then(|()| sync_parent(root));
+    combine_cleanup(source, cleanup)
+}
+
+fn combine_cleanup<T>(
+    source: AviateSupervisorError,
+    cleanup: Result<(), AviateSupervisorError>,
+) -> Result<T, AviateSupervisorError> {
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+fn require_empty(root: &Path) -> Result<(), AviateSupervisorError> {
+    let mut entries = std::fs::read_dir(root)
+        .map_err(|source| io_error("scan launch-artifact root", root, source))?;
+    if entries
+        .next()
+        .transpose()
+        .map_err(|source| io_error("read launch-artifact root entry", root, source))?
+        .is_some()
+    {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the launch-artifact root gained an unknown entry".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn create_private_directory(path: &Path) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder
+        .create(path)
+        .map_err(|source| io_error("create launch-artifact root", path, source))
+}
+
+fn bind_owned_root(path: &Path) -> Result<OwnedRoot, AviateSupervisorError> {
+    let directory =
+        File::open(path).map_err(|source| io_error("open launch-artifact root", path, source))?;
+    let metadata = directory
+        .metadata()
+        .map_err(|source| io_error("inspect held launch-artifact root", path, source))?;
+    let identity = directory_identity(path, &metadata, true)?;
+    Ok(OwnedRoot {
+        directory,
+        identity,
+    })
+}
+
+fn validate_owned_root(owned: &OwnedRoot) -> Result<(), AviateSupervisorError> {
+    let held = owned.directory.metadata().map_err(|source| {
+        io_error(
+            "inspect held launch-artifact root",
+            &owned.identity.path,
+            source,
+        )
+    })?;
+    let held = directory_identity(&owned.identity.path, &held, true)?;
+    let named = inspect_directory(&owned.identity.path, true)?;
+    if held != owned.identity || named != owned.identity {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the owned launch-artifact root identity changed".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn directory_identity(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    private: bool,
+) -> Result<AnchoredDirectory, AviateSupervisorError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mode = metadata.permissions().mode() & 0o777;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() || (private && mode != 0o700) {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "an anchored directory has invalid metadata",
+        ));
+    }
+    Ok(AnchoredDirectory {
+        path: path.to_path_buf(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        mode,
+    })
+}
+
+fn is_normal_absolute(path: &Path) -> bool {
+    path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+}
+
+fn sync_parent(path: &Path) -> Result<(), AviateSupervisorError> {
+    let parent = path.parent().ok_or_else(|| {
+        AviateSupervisorError::invalid_request("the launch-artifact root has no parent")
+    })?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| io_error("sync launch-artifact parent", parent, source))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn create_private_directory(_path: &Path) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn directory_identity(
+    _path: &Path,
+    _metadata: &std::fs::Metadata,
+    _private: bool,
+) -> Result<AnchoredDirectory, AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}

--- a/tools/flight-tune-aviate/src/artifact/staging.rs
+++ b/tools/flight-tune-aviate/src/artifact/staging.rs
@@ -1,0 +1,364 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read as _, Write as _};
+use std::path::Path;
+
+use sha2::{Digest as _, Sha256};
+
+use super::io_error;
+use super::root::validate_directory;
+use crate::AviateSupervisorError;
+use crate::document::{AnchoredDirectory, AnchoredExecutable};
+
+const MAX_ARTIFACT_BYTES: u64 = 512 * 1024 * 1024;
+
+struct OwnedPartial {
+    file: File,
+    path: std::path::PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+pub(crate) fn stage_executable(
+    root: &AnchoredDirectory,
+    source_path: &Path,
+    expected_digest: flight_tune::Digest,
+    name: &'static str,
+) -> Result<AnchoredExecutable, AviateSupervisorError> {
+    stage(root, source_path, Some(expected_digest), name)
+}
+
+fn stage(
+    root: &AnchoredDirectory,
+    source_path: &Path,
+    expected_digest: Option<flight_tune::Digest>,
+    name: &'static str,
+) -> Result<AnchoredExecutable, AviateSupervisorError> {
+    validate_directory(root, true)?;
+    let source_metadata = inspect_source(source_path)?;
+    validate_source_size(source_metadata.len())?;
+    let mut source = open_same_source(source_path, &source_metadata)?;
+    let destination = root.path.join(name);
+    let digest = copy_to_stage(&mut source, &source_metadata, expected_digest, &destination)?;
+    validate_directory(root, true)?;
+    sync_directory(&root.path)?;
+    let identity = inspect_staged(&destination, digest)?;
+    validate_directory(root, true)?;
+    Ok(identity)
+}
+
+pub(crate) fn inspect_staged(
+    path: &Path,
+    expected_digest: flight_tune::Digest,
+) -> Result<AnchoredExecutable, AviateSupervisorError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|source| io_error("inspect staged executable", path, source))?;
+    validate_staged_metadata(path, &metadata)?;
+    let digest = crate::inspection::digest_file(path)?;
+    if digest != expected_digest {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the staged executable digest changed",
+        ));
+    }
+    anchored_executable(path, digest, &metadata)
+}
+
+fn inspect_source(path: &Path) -> Result<std::fs::Metadata, AviateSupervisorError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|source| io_error("inspect launch source", path, source))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AviateSupervisorError::invalid_request(
+            "a launch source is not one regular non-symlink file",
+        ));
+    }
+    Ok(metadata)
+}
+
+fn open_same_source(
+    path: &Path,
+    expected: &std::fs::Metadata,
+) -> Result<File, AviateSupervisorError> {
+    let source = File::open(path).map_err(|error| io_error("open launch source", path, error))?;
+    let actual = source
+        .metadata()
+        .map_err(|error| io_error("inspect opened launch source", path, error))?;
+    validate_same_file(expected, &actual)?;
+    Ok(source)
+}
+
+fn copy_to_stage(
+    source: &mut File,
+    source_metadata: &std::fs::Metadata,
+    expected_digest: Option<flight_tune::Digest>,
+    destination: &Path,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut partial = create_destination(destination)?;
+    let result = write_staged(source, source_metadata, expected_digest, &mut partial);
+    match result {
+        Ok(digest) => Ok(digest),
+        Err(error) => cleanup_owned_partial(&partial, error),
+    }
+}
+
+fn write_staged(
+    source: &mut File,
+    source_metadata: &std::fs::Metadata,
+    expected_digest: Option<flight_tune::Digest>,
+    partial: &mut OwnedPartial,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let (digest, bytes) = copy_and_digest(source, &mut partial.file, &partial.path)?;
+    validate_source_end(source, source_metadata, bytes, &partial.path)?;
+    if expected_digest.is_some_and(|expected| expected != digest) {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the staged executable bytes differ from the requested digest",
+        ));
+    }
+    set_executable_mode(&partial.file, &partial.path)?;
+    partial
+        .file
+        .sync_all()
+        .map_err(|error| io_error("sync staged executable", &partial.path, error))?;
+    Ok(digest)
+}
+
+fn copy_and_digest(
+    source: &mut File,
+    destination: &mut File,
+    path: &Path,
+) -> Result<(flight_tune::Digest, u64), AviateSupervisorError> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut total = 0_u64;
+    loop {
+        let count = source
+            .read(&mut buffer)
+            .map_err(|error| io_error("read launch source", path, error))?;
+        if count == 0 {
+            break;
+        }
+        total = add_count(total, count)?;
+        hasher.update(&buffer[..count]);
+        destination
+            .write_all(&buffer[..count])
+            .map_err(|error| io_error("write staged executable", path, error))?;
+    }
+    Ok((
+        flight_tune::Digest::from_bytes(hasher.finalize().into()),
+        total,
+    ))
+}
+
+fn add_count(total: u64, count: usize) -> Result<u64, AviateSupervisorError> {
+    let count = u64::try_from(count).map_err(|_| {
+        AviateSupervisorError::invalid_request("an executable read count exceeds limits")
+    })?;
+    let total = total.checked_add(count).ok_or_else(|| {
+        AviateSupervisorError::invalid_request("an executable byte count overflowed")
+    })?;
+    validate_source_size(total)?;
+    Ok(total)
+}
+
+fn validate_source_size(bytes: u64) -> Result<(), AviateSupervisorError> {
+    if bytes == 0 || bytes > MAX_ARTIFACT_BYTES {
+        return Err(AviateSupervisorError::invalid_request(
+            "a launch source exceeds the executable byte limits",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_source_end(
+    source: &File,
+    initial: &std::fs::Metadata,
+    bytes: u64,
+    path: &Path,
+) -> Result<(), AviateSupervisorError> {
+    let final_metadata = source
+        .metadata()
+        .map_err(|error| io_error("inspect copied launch source", path, error))?;
+    validate_same_file(initial, &final_metadata)?;
+    if final_metadata.len() != bytes {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the launch source size changed during staging",
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_owned_partial<T>(
+    partial: &OwnedPartial,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let cleanup = validate_owned_partial(partial)
+        .and_then(|()| {
+            std::fs::remove_file(&partial.path)
+                .map_err(|error| io_error("remove partial staged executable", &partial.path, error))
+        })
+        .and_then(|()| sync_parent(&partial.path));
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn create_destination(path: &Path) -> Result<OwnedPartial, AviateSupervisorError> {
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o500)
+        .open(path)
+        .map_err(|source| io_error("create staged executable", path, source))?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| io_error("inspect partial staged executable", path, source))?;
+    Ok(OwnedPartial {
+        file,
+        path: path.to_path_buf(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn set_executable_mode(file: &File, path: &Path) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    file.set_permissions(std::fs::Permissions::from_mode(0o500))
+        .map_err(|source| io_error("set staged executable mode", path, source))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn validate_owned_partial(partial: &OwnedPartial) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let metadata = std::fs::symlink_metadata(&partial.path)
+        .map_err(|source| io_error("inspect partial staged executable", &partial.path, source))?;
+    let held = partial
+        .file
+        .metadata()
+        .map_err(|source| io_error("inspect held staged executable", &partial.path, source))?;
+    if !metadata.is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.dev() != partial.device
+        || metadata.ino() != partial.inode
+        || held.dev() != partial.device
+        || held.ino() != partial.inode
+        || metadata.nlink() != 1
+        || metadata.permissions().mode() & 0o777 != 0o500
+    {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the owned partial executable identity changed".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn validate_same_file(
+    first: &std::fs::Metadata,
+    second: &std::fs::Metadata,
+) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    if first.dev() != second.dev() || first.ino() != second.ino() {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the launch source changed while it was opened",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn validate_staged_metadata(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    if metadata.file_type().is_symlink()
+        || !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.permissions().mode() & 0o777 != 0o500
+    {
+        return Err(AviateSupervisorError::identity_mismatch(format!(
+            "the staged executable metadata is invalid: {path:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn anchored_executable(
+    path: &Path,
+    digest: flight_tune::Digest,
+    metadata: &std::fs::Metadata,
+) -> Result<AnchoredExecutable, AviateSupervisorError> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    Ok(AnchoredExecutable {
+        path: path.to_path_buf(),
+        digest,
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        bytes: metadata.len(),
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn create_destination(_path: &Path) -> Result<OwnedPartial, AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn set_executable_mode(_file: &File, _path: &Path) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn validate_owned_partial(_partial: &OwnedPartial) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn validate_same_file(
+    _first: &std::fs::Metadata,
+    _second: &std::fs::Metadata,
+) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn validate_staged_metadata(
+    _path: &Path,
+    _metadata: &std::fs::Metadata,
+) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn anchored_executable(
+    _path: &Path,
+    _digest: flight_tune::Digest,
+    _metadata: &std::fs::Metadata,
+) -> Result<AnchoredExecutable, AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+fn sync_directory(path: &Path) -> Result<(), AviateSupervisorError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| io_error("sync launch-artifact directory", path, source))
+}
+
+fn sync_parent(path: &Path) -> Result<(), AviateSupervisorError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| AviateSupervisorError::invalid_request("an artifact path has no parent"))?;
+    sync_directory(parent)
+}

--- a/tools/flight-tune-aviate/src/bin/flight_tune_aviate_supervisor.rs
+++ b/tools/flight-tune-aviate/src/bin/flight_tune_aviate_supervisor.rs
@@ -1,0 +1,5 @@
+//! Process-owner and launch-gate helper for Aviate simulator tuning.
+
+fn main() -> Result<(), flight_tune_aviate::AviateSupervisorError> {
+    flight_tune_aviate::supervisor_main_blocking()
+}

--- a/tools/flight-tune-aviate/src/document.rs
+++ b/tools/flight-tune-aviate/src/document.rs
@@ -1,0 +1,213 @@
+use std::path::PathBuf;
+
+use flight_tune::Digest;
+use serde::{Deserialize, Serialize};
+
+pub(crate) const SCHEMA_VERSION: u16 = 1;
+pub(crate) const SPAWN_INTENT_NAME: &str = "supervisor-spawn-intent.json";
+pub(crate) const PROCESS_IDENTITY_NAME: &str = "supervisor-process-identity.json";
+pub(crate) const TARGET_ATTESTATION_NAME: &str = "supervisor-target-attestation.json";
+pub(crate) const TERMINAL_RECEIPT_NAME: &str = "supervisor-terminal-receipt.json";
+pub(crate) const RECOVERY_RECEIPT_NAME: &str = "supervisor-recovery-receipt.json";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnchoredExecutable {
+    pub(crate) path: PathBuf,
+    pub(crate) digest: Digest,
+    pub(crate) device: u64,
+    pub(crate) inode: u64,
+    pub(crate) bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnchoredDirectory {
+    pub(crate) path: PathBuf,
+    pub(crate) device: u64,
+    pub(crate) inode: u64,
+    pub(crate) mode: u32,
+}
+
+/// A high-resolution operating-system process start identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "platform", rename_all = "snake_case")]
+pub enum ProcessStartIdentity {
+    /// Linux boot identity and `/proc/<pid>/stat` clock tick.
+    Linux {
+        /// Kernel boot identity.
+        boot_id: String,
+        /// Process start clock tick since boot.
+        start_ticks: u64,
+    },
+    /// Darwin process start time from `proc_pidinfo` and `proc_pid_rusage`.
+    MacOs {
+        /// Darwin boot-session UUID.
+        boot_session_uuid: String,
+        /// Whole seconds since the Unix epoch.
+        seconds: u64,
+        /// Microseconds within the start second.
+        microseconds: u32,
+        /// Mach absolute time at process start.
+        start_abstime: u64,
+    },
+}
+
+/// One operating-system boot identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "platform", rename_all = "snake_case")]
+pub(crate) enum BootIdentity {
+    /// Linux kernel boot identity.
+    Linux {
+        /// Kernel boot identity.
+        boot_id: String,
+    },
+    /// Darwin boot-session identity.
+    MacOs {
+        /// Darwin boot-session UUID.
+        boot_session_uuid: String,
+    },
+}
+
+impl ProcessStartIdentity {
+    pub(crate) fn boot_identity(&self) -> BootIdentity {
+        match self {
+            Self::Linux { boot_id, .. } => BootIdentity::Linux {
+                boot_id: boot_id.clone(),
+            },
+            Self::MacOs {
+                boot_session_uuid, ..
+            } => BootIdentity::MacOs {
+                boot_session_uuid: boot_session_uuid.clone(),
+            },
+        }
+    }
+}
+
+impl BootIdentity {
+    pub(crate) fn is_valid(&self) -> bool {
+        let value = match self {
+            Self::Linux { boot_id } => boot_id,
+            Self::MacOs { boot_session_uuid } => boot_session_uuid,
+        };
+        value.len() == 36
+            && value == &value.to_ascii_lowercase()
+            && value.bytes().enumerate().all(|(index, byte)| {
+                if matches!(index, 8 | 13 | 18 | 23) {
+                    byte == b'-'
+                } else {
+                    byte.is_ascii_hexdigit()
+                }
+            })
+            && value.bytes().any(|byte| byte != b'0' && byte != b'-')
+    }
+}
+
+/// One exact operating-system process identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessIdentity {
+    /// Process identifier.
+    pub pid: u32,
+    /// Process-group identifier.
+    pub process_group: u32,
+    /// Session identifier.
+    pub session_id: u32,
+    /// Parent process identifier observed by the operating system.
+    pub parent_pid: u32,
+    /// Real user identifier observed by the operating system.
+    pub real_user_id: u32,
+    /// High-resolution process lifetime identity.
+    pub start: ProcessStartIdentity,
+    /// Canonical executable path observed for the process.
+    pub executable: PathBuf,
+    /// SHA-256 digest of the observed executable bytes.
+    pub executable_digest: Digest,
+    /// SHA-256 digest of the canonical argument vector bound at launch.
+    pub launch_argv_digest: Digest,
+    /// SHA-256 digest of the operating-system argument vector, when available.
+    pub observed_argv_digest: Option<Digest>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SpawnIntent {
+    pub(crate) schema_version: u16,
+    pub(crate) run_intent_digest: Digest,
+    pub(crate) correlation_nonce: Digest,
+    pub(crate) release_secret_digest: Digest,
+    pub(crate) supervisor_executable: AnchoredExecutable,
+    pub(crate) target_executable: AnchoredExecutable,
+    pub(crate) target_arguments: Vec<String>,
+    pub(crate) target_argv_digest: Digest,
+    pub(crate) target_environment_digest: Digest,
+    pub(crate) target_current_directory: AnchoredDirectory,
+    pub(crate) target_stdio: TargetStdio,
+    pub(crate) target_process_contract: TargetProcessContract,
+    pub(crate) cleanup_timeout_millis: u64,
+    pub(crate) runtime_root: AnchoredDirectory,
+    pub(crate) artifact_root: AnchoredDirectory,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TargetStdio {
+    Null,
+}
+
+/// Process-tree behavior required from one supervised target.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetProcessContract {
+    /// The target and all descendants stay in the launch process group until exit.
+    ///
+    /// The target must not use `setsid`, change its process group, or start a
+    /// detached descendant. The caller must bind this contract to a reviewed
+    /// executable digest before it releases the target.
+    RetainProcessGroup,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProcessIdentityDocument {
+    pub(crate) schema_version: u16,
+    pub(crate) run_intent_digest: Digest,
+    pub(crate) spawn_intent_digest: Digest,
+    pub(crate) correlation_nonce: Digest,
+    pub(crate) supervisor: ProcessIdentity,
+    pub(crate) target_gate: ProcessIdentity,
+}
+
+/// The exact target identity observed after the launch gate opened.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TargetAttestation {
+    /// Process document schema version.
+    pub schema_version: u16,
+    /// Exact run intent that authorized this target.
+    pub run_intent_digest: Digest,
+    /// Exact target identity after `exec`.
+    pub target: ProcessIdentity,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TerminalReceipt {
+    pub(crate) schema_version: u16,
+    pub(crate) run_intent_digest: Digest,
+    pub(crate) spawn_intent_digest: Digest,
+    pub(crate) process_identity_digest: Digest,
+    pub(crate) target_attestation_digest: Option<Digest>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RecoveryReceipt {
+    pub(crate) schema_version: u16,
+    pub(crate) run_intent_digest: Digest,
+    pub(crate) spawn_intent_digest: Digest,
+    pub(crate) process_identity_digest: Digest,
+    pub(crate) target_attestation_digest: Option<Digest>,
+    pub(crate) prior_boot_identity: BootIdentity,
+    pub(crate) recovery_boot_identity: BootIdentity,
+}

--- a/tools/flight-tune-aviate/src/error.rs
+++ b/tools/flight-tune-aviate/src/error.rs
@@ -1,0 +1,168 @@
+use std::path::PathBuf;
+use std::process::ExitStatus;
+
+/// A supervised Aviate process operation failed.
+#[derive(Debug, thiserror::Error)]
+pub enum AviateSupervisorError {
+    /// The selected platform cannot provide the required process identity.
+    #[error("Aviate process supervision is not supported on this platform")]
+    UnsupportedPlatform,
+    /// A supplied process request is incomplete or unsafe.
+    #[error("invalid Aviate process supervision request: {detail}")]
+    InvalidRequest {
+        /// Stable validation detail.
+        detail: String,
+    },
+    /// Anchored durable storage failed.
+    #[error("Aviate process supervision storage failed during {operation}: {source}")]
+    Storage {
+        /// Storage operation that failed.
+        operation: &'static str,
+        /// Exact storage failure.
+        #[source]
+        source: Box<pilotage_durable_storage::StorageError>,
+    },
+    /// A file-system operation failed.
+    #[error("Aviate process supervision {operation} failed for {path:?}: {source}")]
+    Io {
+        /// Operation that failed.
+        operation: &'static str,
+        /// Exact path selected by the operation.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A process operation failed.
+    #[error("Aviate process supervision {operation} failed: {source}")]
+    ProcessIo {
+        /// Process operation that failed.
+        operation: &'static str,
+        /// Operating-system failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A durable process document is invalid.
+    #[error("invalid Aviate supervisor {document}: {detail}")]
+    InvalidDocument {
+        /// Document class.
+        document: &'static str,
+        /// Stable validation detail.
+        detail: String,
+        /// JSON failure that caused the invalid document, when present.
+        #[source]
+        source: Option<serde_json::Error>,
+    },
+    /// A live process differs from its durable identity.
+    #[error("Aviate process identity mismatch: {detail}")]
+    IdentityMismatch {
+        /// Stable mismatch detail.
+        detail: String,
+    },
+    /// The supervisor protocol rejected a message.
+    #[error("invalid Aviate supervisor protocol: {detail}")]
+    Protocol {
+        /// Stable protocol detail.
+        detail: String,
+        /// JSON failure that caused the protocol error, when present.
+        #[source]
+        source: Option<serde_json::Error>,
+    },
+    /// A bounded process operation did not finish.
+    #[error("Aviate process supervision timed out during {operation}")]
+    Timeout {
+        /// Bounded operation that timed out.
+        operation: &'static str,
+    },
+    /// The supervisor stopped before it completed the requested operation.
+    #[error("Aviate process supervisor stopped with {status}")]
+    SupervisorExited {
+        /// Supervisor exit status.
+        status: ExitStatus,
+    },
+    /// Another live supervisor holds the exact storage writer lease.
+    #[error("another Aviate process supervisor holds the writer lease")]
+    SupervisorActive,
+    /// Recovery found a process or process group that it cannot safely classify.
+    #[error("Aviate process recovery stopped: {detail}")]
+    RecoveryBlocked {
+        /// Stable fail-closed detail.
+        detail: String,
+    },
+    /// A Darwin system-control operation failed.
+    #[cfg(target_os = "macos")]
+    #[error("Aviate process supervision Darwin {operation} failed: {source}")]
+    DarwinSystemControl {
+        /// System-control operation.
+        operation: &'static str,
+        /// Darwin system-control failure.
+        #[source]
+        source: sysctl::SysctlError,
+    },
+    /// Startup failed and the owner could not report the exact rejection.
+    #[error("Aviate process startup failed: {source}; report to parent failed: {notification}")]
+    ReleaseNotification {
+        /// Startup failure.
+        #[source]
+        source: Box<AviateSupervisorError>,
+        /// Parent-notification failure.
+        notification: Box<AviateSupervisorError>,
+    },
+    /// Startup failed and bounded cleanup also failed.
+    #[error("Aviate process startup failed: {source}; cleanup also failed: {cleanup}")]
+    StartupCleanup {
+        /// Startup failure.
+        #[source]
+        source: Box<AviateSupervisorError>,
+        /// Cleanup failure.
+        cleanup: Box<AviateSupervisorError>,
+    },
+}
+
+impl AviateSupervisorError {
+    pub(crate) fn invalid_request(detail: impl Into<String>) -> Self {
+        Self::InvalidRequest {
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn invalid_document(document: &'static str, detail: impl Into<String>) -> Self {
+        Self::InvalidDocument {
+            document,
+            detail: detail.into(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn invalid_json_document(
+        document: &'static str,
+        operation: &'static str,
+        source: serde_json::Error,
+    ) -> Self {
+        Self::InvalidDocument {
+            document,
+            detail: format!("JSON {operation} failed"),
+            source: Some(source),
+        }
+    }
+
+    pub(crate) fn identity_mismatch(detail: impl Into<String>) -> Self {
+        Self::IdentityMismatch {
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn protocol(detail: impl Into<String>) -> Self {
+        Self::Protocol {
+            detail: detail.into(),
+            source: None,
+        }
+    }
+
+    pub(crate) fn json_protocol(operation: &'static str, source: serde_json::Error) -> Self {
+        Self::Protocol {
+            detail: format!("JSON {operation} failed"),
+            source: Some(source),
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/inspection.rs
+++ b/tools/flight-tune-aviate/src/inspection.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::Read as _;
 use std::path::Path;
+use std::time::Instant;
 
 use sha2::{Digest as _, Sha256};
 
@@ -39,6 +40,31 @@ pub(crate) struct ProcessGroupSnapshot {
     pub(crate) unclassified_pids: Vec<u32>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct InspectionDeadline {
+    deadline: Instant,
+    operation: &'static str,
+}
+
+impl InspectionDeadline {
+    pub(crate) const fn new(deadline: Instant, operation: &'static str) -> Self {
+        Self {
+            deadline,
+            operation,
+        }
+    }
+
+    pub(crate) fn check(self) -> Result<(), AviateSupervisorError> {
+        if Instant::now() >= self.deadline {
+            Err(AviateSupervisorError::Timeout {
+                operation: self.operation,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
 impl ProcessGroupSnapshot {
     pub(crate) fn is_empty(&self) -> bool {
         self.raw_pids.is_empty()
@@ -62,6 +88,27 @@ pub(crate) fn inspect_process(
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         let _ = (pid, launch_argv_digest);
+        Err(AviateSupervisorError::UnsupportedPlatform)
+    }
+}
+
+pub(crate) fn inspect_process_before(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+    deadline: Instant,
+    operation: &'static str,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        platform::inspect_process_before(
+            pid,
+            launch_argv_digest,
+            InspectionDeadline::new(deadline, operation),
+        )
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (pid, launch_argv_digest, deadline, operation);
         Err(AviateSupervisorError::UnsupportedPlatform)
     }
 }
@@ -113,7 +160,7 @@ pub(crate) fn process_group_is_absent(process_group: u32) -> Result<bool, Aviate
 pub(crate) fn digest_file(path: &Path) -> Result<flight_tune::Digest, AviateSupervisorError> {
     let mut file =
         File::open(path).map_err(|source| io_error("open executable for hashing", path, source))?;
-    digest_reader(&mut file).map_err(|source| io_error("hash executable", path, source))
+    digest_open_file(&mut file).map_err(|source| io_error("hash executable", path, source))
 }
 
 pub(crate) fn digest_arguments(arguments: &[String]) -> flight_tune::Digest {
@@ -195,7 +242,7 @@ pub(crate) fn digest_argument_bytes<'a>(
     flight_tune::Digest::from_bytes(hasher.finalize().into())
 }
 
-fn digest_reader(reader: &mut File) -> std::io::Result<flight_tune::Digest> {
+pub(crate) fn digest_open_file(reader: &mut File) -> std::io::Result<flight_tune::Digest> {
     let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 64 * 1024];
     loop {
@@ -206,6 +253,38 @@ fn digest_reader(reader: &mut File) -> std::io::Result<flight_tune::Digest> {
         hasher.update(&buffer[..count]);
     }
     Ok(flight_tune::Digest::from_bytes(hasher.finalize().into()))
+}
+
+pub(crate) fn digest_open_file_before(
+    reader: &mut File,
+    path: &Path,
+    deadline: InspectionDeadline,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        deadline.check()?;
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|source| io_error("hash executable before deadline", path, source))?;
+        if count == 0 {
+            deadline.check()?;
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(flight_tune::Digest::from_bytes(hasher.finalize().into()))
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn digest_file_before(
+    path: &Path,
+    deadline: InspectionDeadline,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    deadline.check()?;
+    let mut file = File::open(path)
+        .map_err(|source| io_error("open executable before deadline", path, source))?;
+    digest_open_file_before(&mut file, path, deadline)
 }
 
 #[cfg(test)]

--- a/tools/flight-tune-aviate/src/inspection.rs
+++ b/tools/flight-tune-aviate/src/inspection.rs
@@ -1,0 +1,213 @@
+use std::fs::File;
+use std::io::Read as _;
+use std::path::Path;
+
+use sha2::{Digest as _, Sha256};
+
+use crate::AviateSupervisorError;
+use crate::document::{BootIdentity, ProcessIdentity, ProcessStartIdentity};
+
+#[cfg(target_os = "linux")]
+#[path = "inspection/linux.rs"]
+mod platform;
+#[cfg(target_os = "macos")]
+#[path = "inspection/macos.rs"]
+mod platform;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LifetimeIdentity {
+    pub(crate) pid: u32,
+    pub(crate) process_group: u32,
+    pub(crate) session_id: u32,
+    pub(crate) parent_pid: u32,
+    pub(crate) real_user_id: u32,
+    pub(crate) start: ProcessStartIdentity,
+    pub(crate) is_zombie: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExitedGroupMember {
+    pub(crate) pid: u32,
+    pub(crate) start_abstime: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessGroupSnapshot {
+    pub(crate) raw_pids: Vec<u32>,
+    pub(crate) observed: Vec<LifetimeIdentity>,
+    pub(crate) exited: Vec<ExitedGroupMember>,
+    pub(crate) unclassified_pids: Vec<u32>,
+}
+
+impl ProcessGroupSnapshot {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.raw_pids.is_empty()
+    }
+
+    pub(crate) fn is_quiescent(&self) -> bool {
+        self.unclassified_pids.is_empty()
+            && self.observed.iter().all(|member| member.is_zombie)
+            && self.raw_pids.len() == self.observed.len().wrapping_add(self.exited.len())
+    }
+}
+
+pub(crate) fn inspect_process(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        platform::inspect_process(pid, launch_argv_digest)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (pid, launch_argv_digest);
+        Err(AviateSupervisorError::UnsupportedPlatform)
+    }
+}
+
+pub(crate) fn inspect_lifetime(
+    pid: u32,
+) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        platform::inspect_lifetime(pid)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = pid;
+        Err(AviateSupervisorError::UnsupportedPlatform)
+    }
+}
+
+pub(crate) fn process_group_snapshot(
+    process_group: u32,
+) -> Result<ProcessGroupSnapshot, AviateSupervisorError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        platform::process_group_snapshot(process_group)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = process_group;
+        Err(AviateSupervisorError::UnsupportedPlatform)
+    }
+}
+
+pub(crate) fn process_group_is_absent(process_group: u32) -> Result<bool, AviateSupervisorError> {
+    let raw = i32::try_from(process_group).map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the process group exceeds POSIX limits")
+    })?;
+    let group = rustix::process::Pid::from_raw(raw)
+        .ok_or_else(|| AviateSupervisorError::identity_mismatch("the process group is zero"))?;
+    match rustix::process::test_kill_process_group(group) {
+        Ok(()) => Ok(false),
+        Err(rustix::io::Errno::SRCH) => Ok(true),
+        Err(source) => Err(process_io(
+            "test exact process-group absence",
+            std::io::Error::from_raw_os_error(source.raw_os_error()),
+        )),
+    }
+}
+
+pub(crate) fn digest_file(path: &Path) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut file =
+        File::open(path).map_err(|source| io_error("open executable for hashing", path, source))?;
+    digest_reader(&mut file).map_err(|source| io_error("hash executable", path, source))
+}
+
+pub(crate) fn digest_arguments(arguments: &[String]) -> flight_tune::Digest {
+    digest_argument_bytes(arguments.iter().map(String::as_bytes))
+}
+
+pub(crate) fn validate_same_lifetime(
+    expected: &ProcessIdentity,
+    actual: &ProcessIdentity,
+    process: &'static str,
+) -> Result<(), AviateSupervisorError> {
+    if expected.pid != actual.pid
+        || expected.process_group != actual.process_group
+        || expected.session_id != actual.session_id
+        || expected.parent_pid != actual.parent_pid
+        || expected.real_user_id != actual.real_user_id
+        || expected.start != actual.start
+    {
+        return Err(AviateSupervisorError::identity_mismatch(format!(
+            "the {process} process lifetime changed"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_absent_or_exact(
+    expected: &ProcessIdentity,
+    actual: Option<LifetimeIdentity>,
+    process: &'static str,
+) -> Result<bool, AviateSupervisorError> {
+    match actual {
+        None => Ok(true),
+        Some(actual)
+            if actual.pid == expected.pid
+                && actual.process_group == expected.process_group
+                && actual.session_id == expected.session_id
+                && actual.start == expected.start =>
+        {
+            Ok(false)
+        }
+        Some(_) => Err(AviateSupervisorError::RecoveryBlocked {
+            detail: format!("the {process} process identifier names another lifetime"),
+        }),
+    }
+}
+
+pub(crate) fn current_boot_identity() -> Result<BootIdentity, AviateSupervisorError> {
+    let current = inspect_lifetime(std::process::id())?.ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch("the current process identity is unavailable")
+    })?;
+    Ok(current.start.boot_identity())
+}
+
+pub(crate) fn process_io(operation: &'static str, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::ProcessIo { operation, source }
+}
+
+pub(crate) fn io_error(
+    operation: &'static str,
+    path: &Path,
+    source: std::io::Error,
+) -> AviateSupervisorError {
+    AviateSupervisorError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+pub(crate) fn digest_argument_bytes<'a>(
+    arguments: impl IntoIterator<Item = &'a [u8]>,
+) -> flight_tune::Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(b"flight-tune-aviate-argv-v1\0");
+    for argument in arguments {
+        hasher.update((argument.len() as u64).to_be_bytes());
+        hasher.update(argument);
+    }
+    flight_tune::Digest::from_bytes(hasher.finalize().into())
+}
+
+fn digest_reader(reader: &mut File) -> std::io::Result<flight_tune::Digest> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(flight_tune::Digest::from_bytes(hasher.finalize().into()))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests;

--- a/tools/flight-tune-aviate/src/inspection/linux.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux.rs
@@ -1,0 +1,275 @@
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt as _;
+use std::path::{Path, PathBuf};
+
+use crate::AviateSupervisorError;
+use crate::document::{ProcessIdentity, ProcessStartIdentity};
+use crate::inspection::{
+    LifetimeIdentity, ProcessGroupSnapshot, digest_argument_bytes, digest_file, io_error,
+    process_io,
+};
+
+pub(super) fn inspect_process(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    let Some(lifetime) = inspect_lifetime(pid)? else {
+        return Ok(None);
+    };
+    let executable_link = PathBuf::from(format!("/proc/{pid}/exe"));
+    let executable = match std::fs::read_link(&executable_link) {
+        Ok(path) => path,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(io_error(
+                "read live executable link",
+                &executable_link,
+                source,
+            ));
+        }
+    };
+    let executable_digest = digest_file(&executable_link)?;
+    let command_path = PathBuf::from(format!("/proc/{pid}/cmdline"));
+    let command = std::fs::read(&command_path)
+        .map_err(|source| io_error("read live argument vector", &command_path, source))?;
+    let mut arguments = command.split(|byte| *byte == 0).collect::<Vec<_>>();
+    if arguments.last().is_some_and(|argument| argument.is_empty()) {
+        arguments.pop();
+    }
+    let argv_digest = digest_argument_bytes(arguments);
+    if argv_digest != launch_argv_digest {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the observed Linux arguments differ from the launch arguments",
+        ));
+    }
+    let Some(final_lifetime) = inspect_lifetime(pid)? else {
+        return Ok(None);
+    };
+    if final_lifetime != lifetime {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process lifetime changed during inspection",
+        ));
+    }
+    Ok(Some(ProcessIdentity {
+        pid,
+        process_group: lifetime.process_group,
+        session_id: lifetime.session_id,
+        parent_pid: lifetime.parent_pid,
+        real_user_id: lifetime.real_user_id,
+        start: lifetime.start,
+        executable,
+        executable_digest,
+        launch_argv_digest,
+        observed_argv_digest: Some(argv_digest),
+    }))
+}
+
+pub(super) fn inspect_lifetime(
+    pid: u32,
+) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+    let stat_path = PathBuf::from(format!("/proc/{pid}/stat"));
+    let Some(first_stat) = read_stat(&stat_path)? else {
+        return Ok(None);
+    };
+    let (_, parent_pid, process_group, session_id, start_ticks) = parse_stat(&first_stat)?;
+    let status_path = PathBuf::from(format!("/proc/{pid}/status"));
+    let status = match std::fs::read_to_string(&status_path) {
+        Ok(status) => status,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(io_error("inspect process owner", &status_path, source)),
+    };
+    let first_user_id = parse_real_user_id(&status)?;
+    let Some(second_stat) = read_stat(&stat_path)? else {
+        return Ok(None);
+    };
+    let (_, second_parent, second_group, second_session, second_start) = parse_stat(&second_stat)?;
+    if (parent_pid, process_group, session_id, start_ticks)
+        != (second_parent, second_group, second_session, second_start)
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process lifetime changed during inspection",
+        ));
+    }
+    let final_status = match std::fs::read_to_string(&status_path) {
+        Ok(status) => status,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(io_error("reinspect process owner", &status_path, source)),
+    };
+    let real_user_id = parse_real_user_id(&final_status)?;
+    let Some(final_stat) = read_stat(&stat_path)? else {
+        return Ok(None);
+    };
+    let (state, final_parent, final_group, final_session, final_start) = parse_stat(&final_stat)?;
+    if first_user_id != real_user_id
+        || (parent_pid, process_group, session_id, start_ticks)
+            != (final_parent, final_group, final_session, final_start)
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process identity changed during inspection",
+        ));
+    }
+    Ok(Some(lifetime(
+        pid,
+        parent_pid,
+        process_group,
+        session_id,
+        real_user_id,
+        start_ticks,
+        state == "Z",
+    )?))
+}
+
+fn read_stat(path: &Path) -> Result<Option<String>, AviateSupervisorError> {
+    match std::fs::read_to_string(path) {
+        Ok(stat) => Ok(Some(stat)),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(io_error("read process lifetime", path, source)),
+    }
+}
+
+pub(super) fn process_group_snapshot(
+    process_group: u32,
+) -> Result<ProcessGroupSnapshot, AviateSupervisorError> {
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|source| process_io("scan Linux process table", source))?;
+    let mut members = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| process_io("read Linux process table", source))?;
+        let bytes = entry.file_name();
+        let Some(pid) = parse_pid(bytes.as_os_str()) else {
+            continue;
+        };
+        if let Some(identity) = inspect_lifetime(pid)?
+            && identity.process_group == process_group
+        {
+            members.push(identity);
+        }
+    }
+    members.sort_by_key(|identity| identity.pid);
+    let raw_pids = members.iter().map(|identity| identity.pid).collect();
+    Ok(ProcessGroupSnapshot {
+        raw_pids,
+        observed: members,
+        exited: Vec::new(),
+        unclassified_pids: Vec::new(),
+    })
+}
+
+fn parse_stat(stat: &str) -> Result<(&str, u32, u32, u32, u64), AviateSupervisorError> {
+    let close = stat.rfind(')').ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch("the Linux process stat has no command boundary")
+    })?;
+    let fields = stat
+        .get(close.saturating_add(2)..)
+        .ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch("the Linux process stat is truncated")
+        })?
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    if fields.len() <= 19 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process stat has too few fields",
+        ));
+    }
+    let process_group = fields[2].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process group is invalid")
+    })?;
+    let parent_pid = fields[1].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux parent process is invalid")
+    })?;
+    let session_id = fields[3].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process session is invalid")
+    })?;
+    let start_ticks = fields[19].parse::<u64>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process start tick is invalid")
+    })?;
+    Ok((
+        fields[0],
+        parent_pid,
+        process_group,
+        session_id,
+        start_ticks,
+    ))
+}
+
+fn lifetime(
+    pid: u32,
+    parent_pid: u32,
+    process_group: u32,
+    session_id: u32,
+    real_user_id: u32,
+    start_ticks: u64,
+    is_zombie: bool,
+) -> Result<LifetimeIdentity, AviateSupervisorError> {
+    let boot_path = Path::new("/proc/sys/kernel/random/boot_id");
+    let boot_id = std::fs::read_to_string(boot_path)
+        .map_err(|source| io_error("read Linux boot identity", boot_path, source))?
+        .trim()
+        .to_owned();
+    if boot_id.is_empty() || start_ticks == 0 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process start identity is incomplete",
+        ));
+    }
+    let start = ProcessStartIdentity::Linux {
+        boot_id,
+        start_ticks,
+    };
+    if !start.boot_identity().is_valid() {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux boot identity is invalid",
+        ));
+    }
+    Ok(LifetimeIdentity {
+        pid,
+        process_group,
+        session_id,
+        parent_pid,
+        real_user_id,
+        start,
+        is_zombie,
+    })
+}
+
+fn parse_pid(name: &OsStr) -> Option<u32> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(bytes).ok()?.parse().ok()
+}
+
+fn parse_real_user_id(status: &str) -> Result<u32, AviateSupervisorError> {
+    let value = status
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:"))
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch(
+                "the Linux process status has no real user identity",
+            )
+        })?;
+    value.parse().map_err(|_| {
+        AviateSupervisorError::identity_mismatch(
+            "the Linux process status has an invalid real user identity",
+        )
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::parse_stat;
+
+    #[test]
+    fn stat_parser_uses_the_last_command_boundary() {
+        let mut fields = vec!["S", "42", "43", "44"];
+        fields.extend(std::iter::repeat_n("0", 15));
+        fields.push("99");
+        let stat = format!("77 (name) with ) marks) {}", fields.join(" "));
+
+        let parsed = parse_stat(&stat).expect("valid stat");
+
+        assert_eq!(parsed, ("S", 42, 43, 44, 99));
+    }
+}

--- a/tools/flight-tune-aviate/src/inspection/linux.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux.rs
@@ -1,37 +1,132 @@
 use std::ffi::OsStr;
+use std::fs::File;
 use std::os::unix::ffi::OsStrExt as _;
+use std::os::unix::fs::MetadataExt as _;
+use std::os::unix::io::AsRawFd as _;
 use std::path::{Path, PathBuf};
 
 use crate::AviateSupervisorError;
 use crate::document::{ProcessIdentity, ProcessStartIdentity};
 use crate::inspection::{
-    LifetimeIdentity, ProcessGroupSnapshot, digest_argument_bytes, digest_file, io_error,
-    process_io,
+    InspectionDeadline, LifetimeIdentity, ProcessGroupSnapshot, digest_argument_bytes,
+    digest_open_file, digest_open_file_before, io_error, process_io,
 };
+
+const STABLE_SNAPSHOT_ATTEMPTS: usize = 3;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ExecutableObservation {
+    path: PathBuf,
+    digest: flight_tune::Digest,
+    device: u64,
+    inode: u64,
+    bytes: u64,
+}
+
+trait ProcessSource {
+    fn check_deadline(&mut self) -> Result<(), AviateSupervisorError>;
+    fn lifetime(&mut self, pid: u32) -> Result<Option<LifetimeIdentity>, AviateSupervisorError>;
+    fn command(&mut self, pid: u32) -> Result<Option<Vec<u8>>, AviateSupervisorError>;
+    fn executable(
+        &mut self,
+        pid: u32,
+    ) -> Result<Option<ExecutableObservation>, AviateSupervisorError>;
+}
+
+struct Procfs {
+    deadline: Option<InspectionDeadline>,
+}
+
+enum StableSnapshot {
+    Missing,
+    Unstable {
+        lifetime: LifetimeIdentity,
+    },
+    Stable {
+        lifetime: LifetimeIdentity,
+        command: Vec<u8>,
+        executable: ExecutableObservation,
+    },
+}
 
 pub(super) fn inspect_process(
     pid: u32,
     launch_argv_digest: flight_tune::Digest,
 ) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
-    let Some(lifetime) = inspect_lifetime(pid)? else {
-        return Ok(None);
-    };
-    let executable_link = PathBuf::from(format!("/proc/{pid}/exe"));
-    let executable = match std::fs::read_link(&executable_link) {
-        Ok(path) => path,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => {
-            return Err(io_error(
-                "read live executable link",
-                &executable_link,
-                source,
-            ));
+    inspect_process_from(&mut Procfs { deadline: None }, pid, launch_argv_digest)
+}
+
+pub(super) fn inspect_process_before(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+    deadline: InspectionDeadline,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    inspect_process_from(
+        &mut Procfs {
+            deadline: Some(deadline),
+        },
+        pid,
+        launch_argv_digest,
+    )
+}
+
+fn inspect_process_from(
+    source: &mut impl ProcessSource,
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    let mut lifetime_anchor = None;
+    for _ in 0..STABLE_SNAPSHOT_ATTEMPTS {
+        source.check_deadline()?;
+        match read_stable_snapshot(source, pid)? {
+            StableSnapshot::Missing => return Ok(None),
+            StableSnapshot::Unstable { lifetime } => {
+                bind_lifetime_anchor(&mut lifetime_anchor, &lifetime)?;
+            }
+            StableSnapshot::Stable {
+                lifetime,
+                command,
+                executable,
+            } => {
+                bind_lifetime_anchor(&mut lifetime_anchor, &lifetime)?;
+                return build_process_identity(
+                    pid,
+                    launch_argv_digest,
+                    lifetime,
+                    command,
+                    executable,
+                );
+            }
         }
-    };
-    let executable_digest = digest_file(&executable_link)?;
-    let command_path = PathBuf::from(format!("/proc/{pid}/cmdline"));
-    let command = std::fs::read(&command_path)
-        .map_err(|source| io_error("read live argument vector", &command_path, source))?;
+    }
+    Err(AviateSupervisorError::identity_mismatch(
+        "the Linux process image did not stabilize during inspection",
+    ))
+}
+
+fn bind_lifetime_anchor(
+    anchor: &mut Option<LifetimeIdentity>,
+    actual: &LifetimeIdentity,
+) -> Result<(), AviateSupervisorError> {
+    match anchor {
+        Some(expected) if expected != actual => Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process lifetime changed between inspection attempts",
+        )),
+        Some(_) => Ok(()),
+        None => {
+            *anchor = Some(actual.clone());
+            Ok(())
+        }
+    }
+}
+
+fn build_process_identity(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+    lifetime: LifetimeIdentity,
+    command: Vec<u8>,
+    executable: ExecutableObservation,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
     let mut arguments = command.split(|byte| *byte == 0).collect::<Vec<_>>();
     if arguments.last().is_some_and(|argument| argument.is_empty()) {
         arguments.pop();
@@ -42,14 +137,6 @@ pub(super) fn inspect_process(
             "the observed Linux arguments differ from the launch arguments",
         ));
     }
-    let Some(final_lifetime) = inspect_lifetime(pid)? else {
-        return Ok(None);
-    };
-    if final_lifetime != lifetime {
-        return Err(AviateSupervisorError::identity_mismatch(
-            "the Linux process lifetime changed during inspection",
-        ));
-    }
     Ok(Some(ProcessIdentity {
         pid,
         process_group: lifetime.process_group,
@@ -57,11 +144,148 @@ pub(super) fn inspect_process(
         parent_pid: lifetime.parent_pid,
         real_user_id: lifetime.real_user_id,
         start: lifetime.start,
-        executable,
-        executable_digest,
+        executable: executable.path,
+        executable_digest: executable.digest,
         launch_argv_digest,
         observed_argv_digest: Some(argv_digest),
     }))
+}
+
+fn read_stable_snapshot(
+    source: &mut impl ProcessSource,
+    pid: u32,
+) -> Result<StableSnapshot, AviateSupervisorError> {
+    source.check_deadline()?;
+    let Some(before) = source.lifetime(pid)? else {
+        return Ok(StableSnapshot::Missing);
+    };
+    let Some(first_command) = source.command(pid)? else {
+        return classify_missing(source, pid, &before);
+    };
+    let Some(first_executable) = source.executable(pid)? else {
+        return classify_missing(source, pid, &before);
+    };
+    let Some(final_command) = source.command(pid)? else {
+        return classify_missing(source, pid, &before);
+    };
+    let Some(final_executable) = source.executable(pid)? else {
+        return classify_missing(source, pid, &before);
+    };
+    let Some(after) = source.lifetime(pid)? else {
+        return Ok(StableSnapshot::Missing);
+    };
+    source.check_deadline()?;
+    if before != after {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process lifetime changed during inspection",
+        ));
+    }
+    if first_command != final_command || first_executable != final_executable {
+        return Ok(StableSnapshot::Unstable { lifetime: after });
+    }
+    Ok(StableSnapshot::Stable {
+        lifetime: after,
+        command: final_command,
+        executable: final_executable,
+    })
+}
+
+fn classify_missing(
+    source: &mut impl ProcessSource,
+    pid: u32,
+    before: &LifetimeIdentity,
+) -> Result<StableSnapshot, AviateSupervisorError> {
+    match source.lifetime(pid)? {
+        Some(after) if after == *before => Ok(StableSnapshot::Unstable { lifetime: after }),
+        Some(_) => Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process lifetime changed during inspection",
+        )),
+        None => Ok(StableSnapshot::Missing),
+    }
+}
+
+impl ProcessSource for Procfs {
+    fn check_deadline(&mut self) -> Result<(), AviateSupervisorError> {
+        self.deadline.map_or(Ok(()), InspectionDeadline::check)
+    }
+
+    fn lifetime(&mut self, pid: u32) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let lifetime = inspect_lifetime(pid)?;
+        self.check_deadline()?;
+        Ok(lifetime)
+    }
+
+    fn command(&mut self, pid: u32) -> Result<Option<Vec<u8>>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let path = PathBuf::from(format!("/proc/{pid}/cmdline"));
+        let command = match std::fs::read(&path) {
+            Ok(command) => Ok(Some(command)),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(io_error("read live argument vector", &path, source)),
+        }?;
+        self.check_deadline()?;
+        Ok(command)
+    }
+
+    fn executable(
+        &mut self,
+        pid: u32,
+    ) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let executable = observe_executable(pid, self.deadline)?;
+        self.check_deadline()?;
+        Ok(executable)
+    }
+}
+
+fn observe_executable(
+    pid: u32,
+    deadline: Option<InspectionDeadline>,
+) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
+    let live_path = PathBuf::from(format!("/proc/{pid}/exe"));
+    if let Some(deadline) = deadline {
+        deadline.check()?;
+    }
+    let file = match File::open(&live_path) {
+        Ok(file) => file,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(io_error("open live executable", &live_path, source)),
+    };
+    observe_open_executable_with_deadline(file, &live_path, deadline).map(Some)
+}
+
+#[cfg(test)]
+fn observe_open_executable(
+    file: File,
+    live_path: &Path,
+) -> Result<ExecutableObservation, AviateSupervisorError> {
+    observe_open_executable_with_deadline(file, live_path, None)
+}
+
+fn observe_open_executable_with_deadline(
+    mut file: File,
+    live_path: &Path,
+    deadline: Option<InspectionDeadline>,
+) -> Result<ExecutableObservation, AviateSupervisorError> {
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+    let path = std::fs::read_link(&fd_path)
+        .map_err(|source| io_error("read held executable link", &fd_path, source))?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| io_error("inspect held executable", live_path, source))?;
+    let digest = match deadline {
+        Some(deadline) => digest_open_file_before(&mut file, live_path, deadline)?,
+        None => digest_open_file(&mut file)
+            .map_err(|source| io_error("hash held executable", live_path, source))?,
+    };
+    Ok(ExecutableObservation {
+        path,
+        digest,
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        bytes: metadata.len(),
+    })
 }
 
 pub(super) fn inspect_lifetime(
@@ -257,19 +481,5 @@ fn parse_real_user_id(status: &str) -> Result<u32, AviateSupervisorError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
-mod tests {
-    use super::parse_stat;
-
-    #[test]
-    fn stat_parser_uses_the_last_command_boundary() {
-        let mut fields = vec!["S", "42", "43", "44"];
-        fields.extend(std::iter::repeat_n("0", 15));
-        fields.push("99");
-        let stat = format!("77 (name) with ) marks) {}", fields.join(" "));
-
-        let parsed = parse_stat(&stat).expect("valid stat");
-
-        assert_eq!(parsed, ("S", 42, 43, 44, 99));
-    }
-}
+#[path = "linux/tests.rs"]
+mod tests;

--- a/tools/flight-tune-aviate/src/inspection/linux/tests.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux/tests.rs
@@ -1,0 +1,308 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::VecDeque;
+
+use super::{
+    ExecutableObservation, ProcessSource, STABLE_SNAPSHOT_ATTEMPTS, inspect_process_from,
+    observe_open_executable, parse_stat,
+};
+use crate::AviateSupervisorError;
+use crate::document::ProcessStartIdentity;
+use crate::inspection::LifetimeIdentity;
+
+#[test]
+fn stat_parser_uses_the_last_command_boundary() {
+    let mut fields = vec!["S", "42", "43", "44"];
+    fields.extend(std::iter::repeat_n("0", 15));
+    fields.push("99");
+    let stat = format!("77 (name) with ) marks) {}", fields.join(" "));
+
+    let parsed = parse_stat(&stat).expect("valid stat");
+
+    assert_eq!(parsed, ("S", 42, 43, 44, 99));
+}
+
+#[test]
+fn inspection_discards_an_exec_surface_change() {
+    let lifetime = lifetime();
+    let target_command = command("/target");
+    let old_executable = executable("/old", 1);
+    let new_executable = executable("/new", 2);
+    let mut source = ScriptedSource::new(
+        vec![
+            Some(lifetime.clone()),
+            Some(lifetime.clone()),
+            Some(lifetime.clone()),
+            Some(lifetime),
+        ],
+        vec![target_command.clone(); 4],
+        vec![
+            old_executable,
+            new_executable.clone(),
+            new_executable.clone(),
+            new_executable.clone(),
+        ],
+    );
+    let digest = crate::inspection::digest_argument_bytes(
+        target_command
+            .split(|byte| *byte == 0)
+            .filter(|value| !value.is_empty()),
+    );
+
+    let identity = inspect_process_from(&mut source, 77, digest)
+        .expect("inspect stable process")
+        .expect("stable process is present");
+
+    assert_eq!(identity.executable, new_executable.path);
+    assert_eq!(identity.executable_digest, new_executable.digest);
+    assert!(source.is_empty(), "inspection consumes both attempts");
+}
+
+#[test]
+fn inspection_rejects_bounded_process_image_churn() {
+    let lifetime = lifetime();
+    let mut lifetimes = Vec::new();
+    let mut commands = Vec::new();
+    let mut executables = Vec::new();
+    for _ in 0..STABLE_SNAPSHOT_ATTEMPTS {
+        lifetimes.extend([Some(lifetime.clone()), Some(lifetime.clone())]);
+        commands.extend([command("/old"), command("/new")]);
+        executables.extend([executable("/old", 1), executable("/new", 2)]);
+    }
+    let mut source = ScriptedSource::new(lifetimes, commands, executables);
+    let digest = crate::inspection::digest_argument_bytes([b"/new".as_slice()]);
+
+    let error = inspect_process_from(&mut source, 77, digest)
+        .expect_err("reject an unstable process image");
+
+    assert!(matches!(
+        error,
+        AviateSupervisorError::IdentityMismatch { .. }
+    ));
+    assert!(
+        source.is_empty(),
+        "inspection uses the bounded attempt count"
+    );
+}
+
+#[test]
+fn inspection_rejects_pid_reuse_after_a_missing_image_surface() {
+    let mut replacement = lifetime();
+    replacement.start = ProcessStartIdentity::Linux {
+        boot_id: "11111111-1111-1111-1111-111111111111".to_owned(),
+        start_ticks: 100,
+    };
+    let mut source = ScriptedSource {
+        lifetimes: [Some(lifetime()), Some(replacement)].into(),
+        commands: [None].into(),
+        executables: VecDeque::new(),
+    };
+    let digest = crate::inspection::digest_argument_bytes([b"/new".as_slice()]);
+
+    let error = inspect_process_from(&mut source, 77, digest)
+        .expect_err("reject a replacement process lifetime");
+
+    assert!(matches!(
+        error,
+        AviateSupervisorError::IdentityMismatch { .. }
+    ));
+    assert!(source.is_empty(), "inspection stops at the reused lifetime");
+}
+
+#[test]
+fn inspection_rejects_pid_reuse_between_snapshot_attempts() {
+    let first = lifetime();
+    let mut replacement = lifetime();
+    replacement.start = ProcessStartIdentity::Linux {
+        boot_id: "11111111-1111-1111-1111-111111111111".to_owned(),
+        start_ticks: 100,
+    };
+    let target_command = command("/target");
+    let mut source = ScriptedSource::new(
+        vec![
+            Some(first.clone()),
+            Some(first),
+            Some(replacement.clone()),
+            Some(replacement),
+        ],
+        vec![target_command.clone(); 4],
+        vec![
+            executable("/old", 1),
+            executable("/new", 2),
+            executable("/new", 2),
+            executable("/new", 2),
+        ],
+    );
+    let digest = crate::inspection::digest_argument_bytes(
+        target_command
+            .split(|byte| *byte == 0)
+            .filter(|value| !value.is_empty()),
+    );
+
+    let error = inspect_process_from(&mut source, 77, digest)
+        .expect_err("reject process reuse between attempts");
+
+    assert!(matches!(
+        error,
+        AviateSupervisorError::IdentityMismatch { .. }
+    ));
+    assert!(source.is_empty(), "inspection stops at the reused lifetime");
+}
+
+#[test]
+fn inspection_retries_a_missing_surface_for_the_same_lifetime() {
+    let target_command = command("/target");
+    let target_executable = executable("/target", 3);
+    let mut source = ScriptedSource {
+        lifetimes: [
+            Some(lifetime()),
+            Some(lifetime()),
+            Some(lifetime()),
+            Some(lifetime()),
+        ]
+        .into(),
+        commands: [
+            None,
+            Some(target_command.clone()),
+            Some(target_command.clone()),
+        ]
+        .into(),
+        executables: [
+            Some(target_executable.clone()),
+            Some(target_executable.clone()),
+        ]
+        .into(),
+    };
+    let digest = crate::inspection::digest_argument_bytes(
+        target_command
+            .split(|byte| *byte == 0)
+            .filter(|value| !value.is_empty()),
+    );
+
+    let identity = inspect_process_from(&mut source, 77, digest)
+        .expect("retry same-lifetime missing surface")
+        .expect("same process remains present");
+
+    assert_eq!(identity.executable, target_executable.path);
+    assert!(source.is_empty(), "inspection consumes the retry surface");
+}
+
+#[test]
+fn inspection_accepts_confirmed_absence_after_a_missing_surface() {
+    let mut source = ScriptedSource {
+        lifetimes: [Some(lifetime()), None].into(),
+        commands: [None].into(),
+        executables: VecDeque::new(),
+    };
+
+    let identity = inspect_process_from(
+        &mut source,
+        77,
+        crate::inspection::digest_argument_bytes([b"/target".as_slice()]),
+    )
+    .expect("inspect absent process");
+
+    assert!(identity.is_none(), "confirmed absence has no identity");
+    assert!(source.is_empty(), "absence stops the inspection");
+}
+
+#[test]
+fn held_executable_keeps_its_path_and_digest_when_a_link_changes() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("create executable observation root");
+    let first = root.path().join("first");
+    let second = root.path().join("second");
+    let active = root.path().join("active");
+    std::fs::write(&first, b"first executable").expect("write first executable");
+    std::fs::write(&second, b"second executable").expect("write second executable");
+    symlink(&first, &active).expect("link first executable");
+    let held = std::fs::File::open(&active).expect("hold first executable");
+    std::fs::remove_file(&active).expect("remove first executable link");
+    symlink(&second, &active).expect("link second executable");
+
+    let observation =
+        observe_open_executable(held, &active).expect("observe held executable identity");
+
+    assert_eq!(observation.path, first);
+    assert_eq!(
+        observation.digest,
+        crate::inspection::digest_file(&first).expect("digest first executable")
+    );
+}
+
+struct ScriptedSource {
+    lifetimes: VecDeque<Option<LifetimeIdentity>>,
+    commands: VecDeque<Option<Vec<u8>>>,
+    executables: VecDeque<Option<ExecutableObservation>>,
+}
+
+impl ScriptedSource {
+    fn new(
+        lifetimes: Vec<Option<LifetimeIdentity>>,
+        commands: Vec<Vec<u8>>,
+        executables: Vec<ExecutableObservation>,
+    ) -> Self {
+        Self {
+            lifetimes: lifetimes.into(),
+            commands: commands.into_iter().map(Some).collect(),
+            executables: executables.into_iter().map(Some).collect(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lifetimes.is_empty() && self.commands.is_empty() && self.executables.is_empty()
+    }
+}
+
+impl ProcessSource for ScriptedSource {
+    fn check_deadline(&mut self) -> Result<(), AviateSupervisorError> {
+        Ok(())
+    }
+
+    fn lifetime(&mut self, _pid: u32) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+        Ok(self.lifetimes.pop_front().expect("scripted lifetime"))
+    }
+
+    fn command(&mut self, _pid: u32) -> Result<Option<Vec<u8>>, AviateSupervisorError> {
+        Ok(self.commands.pop_front().expect("scripted command"))
+    }
+
+    fn executable(
+        &mut self,
+        _pid: u32,
+    ) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
+        Ok(self.executables.pop_front().expect("scripted executable"))
+    }
+}
+
+fn lifetime() -> LifetimeIdentity {
+    LifetimeIdentity {
+        pid: 77,
+        process_group: 77,
+        session_id: 77,
+        parent_pid: 42,
+        real_user_id: 501,
+        start: ProcessStartIdentity::Linux {
+            boot_id: "11111111-1111-1111-1111-111111111111".to_owned(),
+            start_ticks: 99,
+        },
+        is_zombie: false,
+    }
+}
+
+fn command(executable: &str) -> Vec<u8> {
+    let mut command = executable.as_bytes().to_vec();
+    command.push(0);
+    command
+}
+
+fn executable(path: &str, byte: u8) -> ExecutableObservation {
+    ExecutableObservation {
+        path: path.into(),
+        digest: flight_tune::Digest::from_bytes([byte; 32]),
+        device: 1,
+        inode: u64::from(byte),
+        bytes: 1024,
+    }
+}

--- a/tools/flight-tune-aviate/src/inspection/macos.rs
+++ b/tools/flight-tune-aviate/src/inspection/macos.rs
@@ -9,13 +9,33 @@ use sysctl::Sysctl as _;
 use crate::AviateSupervisorError;
 use crate::document::{ProcessIdentity, ProcessStartIdentity};
 use crate::inspection::{
-    ExitedGroupMember, LifetimeIdentity, ProcessGroupSnapshot, digest_file, process_io,
+    ExitedGroupMember, InspectionDeadline, LifetimeIdentity, ProcessGroupSnapshot, digest_file,
+    digest_file_before, process_io,
 };
 
 pub(super) fn inspect_process(
     pid: u32,
     launch_argv_digest: flight_tune::Digest,
 ) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    inspect_process_with_deadline(pid, launch_argv_digest, None)
+}
+
+pub(super) fn inspect_process_before(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+    deadline: InspectionDeadline,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    inspect_process_with_deadline(pid, launch_argv_digest, Some(deadline))
+}
+
+fn inspect_process_with_deadline(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+    deadline: Option<InspectionDeadline>,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    if let Some(deadline) = deadline {
+        deadline.check()?;
+    }
     let Some(lifetime) = inspect_lifetime(pid)? else {
         return Ok(None);
     };
@@ -32,10 +52,16 @@ pub(super) fn inspect_process(
             )));
         }
     };
-    let executable_digest = digest_file(&executable)?;
+    let executable_digest = match deadline {
+        Some(deadline) => digest_file_before(&executable, deadline)?,
+        None => digest_file(&executable)?,
+    };
     let Some(final_lifetime) = inspect_lifetime(pid)? else {
         return Ok(None);
     };
+    if let Some(deadline) = deadline {
+        deadline.check()?;
+    }
     if final_lifetime != lifetime {
         return Err(AviateSupervisorError::identity_mismatch(
             "the Darwin process lifetime changed during inspection",

--- a/tools/flight-tune-aviate/src/inspection/macos.rs
+++ b/tools/flight-tune-aviate/src/inspection/macos.rs
@@ -1,0 +1,379 @@
+use std::path::PathBuf;
+
+use libproc::bsd_info::BSDInfo;
+use libproc::pid_rusage::{RUsageInfoV2, pidrusage};
+use libproc::proc_pid::{pidinfo, pidpath};
+use libproc::processes::{ProcFilter, pids_by_type};
+use sysctl::Sysctl as _;
+
+use crate::AviateSupervisorError;
+use crate::document::{ProcessIdentity, ProcessStartIdentity};
+use crate::inspection::{
+    ExitedGroupMember, LifetimeIdentity, ProcessGroupSnapshot, digest_file, process_io,
+};
+
+pub(super) fn inspect_process(
+    pid: u32,
+    launch_argv_digest: flight_tune::Digest,
+) -> Result<Option<ProcessIdentity>, AviateSupervisorError> {
+    let Some(lifetime) = inspect_lifetime(pid)? else {
+        return Ok(None);
+    };
+    let pid_i32 = pid_value(pid)?;
+    clear_errno();
+    let executable = match pidpath(pid_i32) {
+        Ok(path) => PathBuf::from(path),
+        Err(detail) => {
+            if inspect_lifetime(pid)?.is_none() {
+                return Ok(None);
+            }
+            return Err(AviateSupervisorError::identity_mismatch(format!(
+                "Darwin did not return the executable path: {detail}"
+            )));
+        }
+    };
+    let executable_digest = digest_file(&executable)?;
+    let Some(final_lifetime) = inspect_lifetime(pid)? else {
+        return Ok(None);
+    };
+    if final_lifetime != lifetime {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Darwin process lifetime changed during inspection",
+        ));
+    }
+    Ok(Some(ProcessIdentity {
+        pid,
+        process_group: lifetime.process_group,
+        session_id: lifetime.session_id,
+        parent_pid: lifetime.parent_pid,
+        real_user_id: lifetime.real_user_id,
+        start: lifetime.start,
+        executable,
+        executable_digest,
+        launch_argv_digest,
+        observed_argv_digest: None,
+    }))
+}
+
+pub(super) fn inspect_lifetime(
+    pid: u32,
+) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+    let pid_i32 = pid_value(pid)?;
+    let Some(first_session) = process_session(pid_i32)? else {
+        return Ok(None);
+    };
+    let Some(first) = read_bsd_info(pid_i32, pid)? else {
+        return Ok(None);
+    };
+    let Some(start_abstime) = process_start_abstime(pid_i32)? else {
+        return Ok(None);
+    };
+    let Some(info) = read_bsd_info(pid_i32, pid)? else {
+        return Ok(None);
+    };
+    if !same_bsd_lifetime(&first, &info) {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Darwin process lifetime changed during lifetime inspection",
+        ));
+    }
+    let Some(session_id) = process_session(pid_i32)? else {
+        return Ok(None);
+    };
+    if session_id != first_session {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Darwin process session changed during lifetime inspection",
+        ));
+    }
+    let Some(final_start_abstime) = process_start_abstime(pid_i32)? else {
+        return Ok(None);
+    };
+    if final_start_abstime != start_abstime {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Darwin process start identity changed during inspection",
+        ));
+    }
+    let microseconds = u32::try_from(info.pbi_start_tvusec).map_err(|_| {
+        AviateSupervisorError::identity_mismatch("Darwin returned an invalid start microsecond")
+    })?;
+    Ok(Some(LifetimeIdentity {
+        pid,
+        process_group: info.pbi_pgid,
+        session_id,
+        parent_pid: info.pbi_ppid,
+        real_user_id: info.pbi_ruid,
+        start: ProcessStartIdentity::MacOs {
+            boot_session_uuid: boot_session_uuid()?,
+            seconds: info.pbi_start_tvsec,
+            microseconds,
+            start_abstime,
+        },
+        is_zombie: info.pbi_status == libc::SZOMB,
+    }))
+}
+
+fn process_session(pid: i32) -> Result<Option<u32>, AviateSupervisorError> {
+    let process = rustix::process::Pid::from_raw(pid).ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch("Darwin returned a zero process identifier")
+    })?;
+    match rustix::process::getsid(Some(process)) {
+        Ok(session) => u32::try_from(session.as_raw_pid()).map(Some).map_err(|_| {
+            AviateSupervisorError::identity_mismatch("Darwin returned an invalid process session")
+        }),
+        Err(rustix::io::Errno::SRCH) => Ok(None),
+        Err(source) => Err(process_io(
+            "inspect Darwin process session",
+            std::io::Error::from_raw_os_error(source.raw_os_error()),
+        )),
+    }
+}
+
+pub(super) fn process_group_snapshot(
+    process_group: u32,
+) -> Result<ProcessGroupSnapshot, AviateSupervisorError> {
+    let mut raw_pids = list_processes(ProcFilter::ByProgramGroup {
+        pgrpid: process_group,
+    })?;
+    raw_pids.sort_unstable();
+    let mut observed = Vec::new();
+    let mut exited = Vec::new();
+    let mut unclassified_pids = Vec::new();
+    for pid in raw_pids.iter().copied() {
+        if let Some(identity) = inspect_lifetime(pid)? {
+            if identity.process_group != process_group {
+                return Err(AviateSupervisorError::identity_mismatch(
+                    "a Darwin process changed groups during inspection",
+                ));
+            }
+            observed.push(identity);
+        } else if let Some(member) = inspect_exited_group_member(pid)? {
+            exited.push(member);
+        } else {
+            unclassified_pids.push(pid);
+        }
+    }
+    observed.sort_by_key(|identity| identity.pid);
+    exited.sort_by_key(|identity| identity.pid);
+    Ok(ProcessGroupSnapshot {
+        raw_pids,
+        observed,
+        exited,
+        unclassified_pids,
+    })
+}
+
+fn validate_bsd_info(pid: u32, info: &BSDInfo) -> Result<(), AviateSupervisorError> {
+    if info.pbi_pid != pid || info.pbi_pgid == 0 || info.pbi_start_tvsec == 0 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "Darwin returned an incomplete process lifetime",
+        ));
+    }
+    if info.pbi_start_tvusec >= 1_000_000 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "Darwin returned an out-of-range start microsecond",
+        ));
+    }
+    Ok(())
+}
+
+fn read_bsd_info(pid: i32, expected: u32) -> Result<Option<BSDInfo>, AviateSupervisorError> {
+    clear_errno();
+    match pidinfo::<BSDInfo>(pid, 0) {
+        Ok(info) => {
+            validate_bsd_info(expected, &info)?;
+            Ok(Some(info))
+        }
+        Err(_) if errno::errno().0 == libc::ESRCH => Ok(None),
+        Err(detail) => Err(AviateSupervisorError::identity_mismatch(format!(
+            "Darwin did not return the process lifetime: {detail}"
+        ))),
+    }
+}
+
+fn same_bsd_lifetime(first: &BSDInfo, second: &BSDInfo) -> bool {
+    first.pbi_pid == second.pbi_pid
+        && first.pbi_pgid == second.pbi_pgid
+        && first.pbi_ppid == second.pbi_ppid
+        && first.pbi_ruid == second.pbi_ruid
+        && first.pbi_start_tvsec == second.pbi_start_tvsec
+        && first.pbi_start_tvusec == second.pbi_start_tvusec
+}
+
+fn process_start_abstime(pid: i32) -> Result<Option<u64>, AviateSupervisorError> {
+    clear_errno();
+    match pidrusage::<RUsageInfoV2>(pid) {
+        Ok(usage) if usage.ri_proc_start_abstime != 0 => Ok(Some(usage.ri_proc_start_abstime)),
+        Ok(_) => Err(AviateSupervisorError::identity_mismatch(
+            "Darwin returned an empty absolute process start time",
+        )),
+        Err(_) if errno::errno().0 == libc::ESRCH => Ok(None),
+        Err(detail) => Err(AviateSupervisorError::identity_mismatch(format!(
+            "Darwin did not return the absolute process start time: {detail}"
+        ))),
+    }
+}
+
+fn inspect_exited_group_member(
+    pid: u32,
+) -> Result<Option<ExitedGroupMember>, AviateSupervisorError> {
+    clear_errno();
+    match pidrusage::<RUsageInfoV2>(pid_value(pid)?) {
+        Ok(usage) if usage.ri_proc_start_abstime != 0 && usage.ri_proc_exit_abstime != 0 => {
+            Ok(Some(ExitedGroupMember {
+                pid,
+                start_abstime: usage.ri_proc_start_abstime,
+            }))
+        }
+        Ok(_) => Err(AviateSupervisorError::RecoveryBlocked {
+            detail: format!("Darwin cannot classify listed process-group member {pid}"),
+        }),
+        Err(_) if errno::errno().0 == libc::ESRCH => Ok(None),
+        Err(detail) => Err(AviateSupervisorError::identity_mismatch(format!(
+            "Darwin did not classify an exited process-group member: {detail}"
+        ))),
+    }
+}
+
+fn boot_session_uuid() -> Result<String, AviateSupervisorError> {
+    let control = sysctl::Ctl::new("kern.bootsessionuuid").map_err(|source| {
+        AviateSupervisorError::DarwinSystemControl {
+            operation: "select boot-session identity",
+            source,
+        }
+    })?;
+    let value =
+        control
+            .value_string()
+            .map_err(|source| AviateSupervisorError::DarwinSystemControl {
+                operation: "read boot-session identity",
+                source,
+            })?;
+    if !valid_uuid(&value) {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "Darwin returned an invalid boot-session identity",
+        ));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn valid_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        })
+        && value.bytes().any(|byte| byte != b'0' && byte != b'-')
+}
+
+fn list_processes(filter: ProcFilter) -> Result<Vec<u32>, AviateSupervisorError> {
+    clear_errno();
+    pids_by_type(filter).map_err(|source| process_io("verify Darwin process existence", source))
+}
+
+fn clear_errno() {
+    errno::set_errno(errno::Errno(0));
+}
+
+fn pid_value(pid: u32) -> Result<i32, AviateSupervisorError> {
+    i32::try_from(pid).map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the process identifier exceeds Darwin limits")
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::process::{Command, Stdio};
+
+    use super::{inspect_lifetime, list_processes, process_group_snapshot, valid_uuid};
+    use libproc::processes::ProcFilter;
+
+    #[test]
+    fn boot_session_uuid_has_exact_shape() {
+        assert!(valid_uuid("01234567-89ab-cdef-0123-456789abcdef"));
+        assert!(!valid_uuid("0123456789ab-cdef-0123-456789abcdef"));
+        assert!(!valid_uuid("01234567-89ab-cdef-0123-456789abcdeg"));
+        assert!(!valid_uuid("00000000-0000-0000-0000-000000000000"));
+    }
+
+    #[test]
+    fn empty_group_ignores_stale_errno() {
+        errno::set_errno(errno::Errno(libc::ESRCH));
+        let pids = list_processes(ProcFilter::ByProgramGroup { pgrpid: u32::MAX })
+            .expect("empty group scan");
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn ordinary_user_observes_self_and_synchronized_child() {
+        let own = inspect_lifetime(std::process::id())
+            .expect("inspect self")
+            .expect("self exists");
+        assert_ne!(
+            own.start,
+            crate::document::ProcessStartIdentity::MacOs {
+                boot_session_uuid: String::new(),
+                seconds: 0,
+                microseconds: 0,
+                start_abstime: 0,
+            }
+        );
+
+        let mut child = Command::new("/bin/cat")
+            .env_clear()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn synchronized child");
+        let observed = inspect_lifetime(child.id())
+            .expect("inspect child")
+            .expect("child exists");
+        assert_eq!(observed.parent_pid, std::process::id());
+        drop(child.stdin.take());
+        child.wait().expect("reap synchronized child");
+    }
+
+    #[test]
+    fn exited_unreaped_member_keeps_group_nonempty() {
+        use std::os::unix::process::CommandExt as _;
+
+        let mut child = Command::new("/usr/bin/true")
+            .env_clear()
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0)
+            .spawn()
+            .expect("spawn unreaped child");
+        let raw_pid = i32::try_from(child.id()).expect("child PID fits POSIX");
+        let pid = rustix::process::Pid::from_raw(raw_pid).expect("child PID is nonzero");
+        let status = rustix::process::waitid(
+            rustix::process::WaitId::Pid(pid),
+            rustix::process::WaitIdOptions::EXITED | rustix::process::WaitIdOptions::NOWAIT,
+        )
+        .expect("wait for child exit without reaping")
+        .expect("child exit status exists");
+        assert_eq!(status.exit_status(), Some(0));
+
+        let snapshot = process_group_snapshot(child.id()).expect("inspect unreaped child group");
+        assert_eq!(snapshot.raw_pids, [child.id()]);
+        assert!(snapshot.is_quiescent());
+        assert!(!snapshot.is_empty());
+        assert!(snapshot.unclassified_pids.is_empty());
+        assert!(
+            snapshot.observed.iter().any(|member| member.is_zombie)
+                || snapshot
+                    .exited
+                    .iter()
+                    .any(|member| member.pid == child.id())
+        );
+
+        let exit = child.wait().expect("reap synchronized child");
+        assert!(exit.success());
+        let empty = process_group_snapshot(child.id()).expect("inspect reaped child group");
+        assert!(empty.is_empty());
+    }
+}

--- a/tools/flight-tune-aviate/src/inspection/tests.rs
+++ b/tools/flight-tune-aviate/src/inspection/tests.rs
@@ -1,6 +1,8 @@
 use std::os::unix::process::CommandExt as _;
 
-use super::{digest_arguments, process_group_is_absent};
+use super::{
+    InspectionDeadline, digest_arguments, digest_open_file_before, process_group_is_absent,
+};
 
 #[test]
 fn canonical_arguments_keep_space_boundaries() {
@@ -32,4 +34,22 @@ fn process_group_absence_requires_kernel_esrch() {
     reap.expect("reap isolated group member");
     assert!(!present_probe.expect("probe live process group"));
     assert!(process_group_is_absent(group).expect("probe absent process group"));
+}
+
+#[test]
+fn executable_hash_refuses_an_expired_inspection_deadline() {
+    let mut file = tempfile::tempfile().expect("create executable fixture");
+    let error = digest_open_file_before(
+        &mut file,
+        std::path::Path::new("executable-fixture"),
+        InspectionDeadline::new(std::time::Instant::now(), "inspect test executable"),
+    )
+    .expect_err("reject expired executable inspection");
+
+    assert!(matches!(
+        error,
+        crate::AviateSupervisorError::Timeout {
+            operation: "inspect test executable"
+        }
+    ));
 }

--- a/tools/flight-tune-aviate/src/inspection/tests.rs
+++ b/tools/flight-tune-aviate/src/inspection/tests.rs
@@ -1,0 +1,35 @@
+use std::os::unix::process::CommandExt as _;
+
+use super::{digest_arguments, process_group_is_absent};
+
+#[test]
+fn canonical_arguments_keep_space_boundaries() {
+    assert_ne!(
+        digest_arguments(&["a b".to_owned(), "c".to_owned()]),
+        digest_arguments(&["a".to_owned(), "b c".to_owned()])
+    );
+}
+
+#[test]
+fn canonical_arguments_keep_empty_arguments() {
+    assert_ne!(
+        digest_arguments(&["a".to_owned(), String::new(), "b".to_owned()]),
+        digest_arguments(&["a".to_owned(), "b".to_owned()])
+    );
+}
+
+#[test]
+fn process_group_absence_requires_kernel_esrch() {
+    let mut child = std::process::Command::new("/bin/sleep");
+    child.arg("60").process_group(0);
+    let mut child = child.spawn().expect("spawn isolated group member");
+    let group = child.id();
+    let present_probe = process_group_is_absent(group);
+    let stop = child.kill();
+    let reap = child.wait();
+
+    stop.expect("stop isolated group member");
+    reap.expect("reap isolated group member");
+    assert!(!present_probe.expect("probe live process group"));
+    assert!(process_group_is_absent(group).expect("probe absent process group"));
+}

--- a/tools/flight-tune-aviate/src/lease_store.rs
+++ b/tools/flight-tune-aviate/src/lease_store.rs
@@ -1,0 +1,250 @@
+use std::path::Path;
+
+use pilotage_durable_storage::{
+    DurableDirectory, DurableStore, ExactObject, ObjectName, PutOutcome, WriterLease,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest as _, Sha256};
+
+use crate::AviateSupervisorError;
+
+const MAX_DOCUMENT_BYTES: usize = 64 * 1024;
+const MAX_RECOVERY_TEMPORARIES: usize = 16;
+const WRITER_LOCK_NAME: &str = ".pilotage-writer-lock";
+
+pub(crate) struct LeaseStore {
+    directory: DurableDirectory,
+    writer: WriterLease,
+}
+
+impl LeaseStore {
+    pub(crate) fn create_fresh(root: &Path) -> Result<Self, AviateSupervisorError> {
+        let store = open_store(root)?;
+        Self::bind_fresh(store)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn create_fresh_with_faults(
+        root: &Path,
+        faults: pilotage_durable_storage::FaultController,
+    ) -> Result<Self, AviateSupervisorError> {
+        let store = DurableStore::open_or_create_with_faults(root, faults)
+            .map_err(|source| storage_error("open faulted process lease root", source))?;
+        Self::bind_fresh(store)
+    }
+
+    fn bind_fresh(store: DurableStore) -> Result<Self, AviateSupervisorError> {
+        let writer = acquire_writer(&store)?;
+        let directory = store.root_directory();
+        writer
+            .validate(&directory)
+            .map_err(|source| storage_error("validate new writer lease", source))?;
+        let entries = directory
+            .list()
+            .map_err(|source| storage_error("scan new process lease", source))?;
+        let is_fresh =
+            entries.len() == 1 && entries[0].as_os_str() == std::ffi::OsStr::new(WRITER_LOCK_NAME);
+        if !is_fresh {
+            return Err(AviateSupervisorError::invalid_document(
+                "process lease",
+                "the new lease root contains residual process artifacts",
+            ));
+        }
+        Ok(Self { directory, writer })
+    }
+
+    pub(crate) fn open_existing(root: &Path) -> Result<Self, AviateSupervisorError> {
+        let store = open_existing_store(root)?;
+        let writer = store.acquire_writer().map_err(|source| {
+            if source.is_writer_locked() {
+                AviateSupervisorError::SupervisorActive
+            } else {
+                storage_error("acquire recovery writer lease", source)
+            }
+        })?;
+        let directory = store.root_directory();
+        writer
+            .validate(&directory)
+            .map_err(|source| storage_error("validate recovery writer lease", source))?;
+        Ok(Self { directory, writer })
+    }
+
+    pub(crate) fn publish<T: Serialize>(
+        &self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<flight_tune::Digest, AviateSupervisorError> {
+        let bytes = serde_json::to_vec(value).map_err(|source| {
+            AviateSupervisorError::invalid_json_document(name, "encoding", source)
+        })?;
+        if bytes.len() > MAX_DOCUMENT_BYTES {
+            return Err(AviateSupervisorError::invalid_document(
+                name,
+                "the encoded document exceeds its byte limit",
+            ));
+        }
+        let object_name = object_name(name)?;
+        let object = ExactObject::from_bytes(bytes.clone());
+        match self
+            .directory
+            .put_immutable_no_replace(&self.writer, &object_name, &object)
+            .map_err(|source| storage_error("publish process document", source))?
+        {
+            PutOutcome::Published => {}
+            PutOutcome::AlreadyExact => {
+                return Err(AviateSupervisorError::invalid_document(
+                    name,
+                    "a residual exact document already exists",
+                ));
+            }
+        }
+        let readback = self
+            .directory
+            .read_exact(&object_name, MAX_DOCUMENT_BYTES)
+            .map_err(|source| storage_error("read back process document", source))?;
+        if readback.bytes() != bytes {
+            return Err(AviateSupervisorError::invalid_document(
+                name,
+                "durable readback changed the document bytes",
+            ));
+        }
+        Ok(digest_bytes(&bytes))
+    }
+
+    pub(crate) fn read<T: DeserializeOwned + Serialize>(
+        &self,
+        name: &'static str,
+    ) -> Result<(T, flight_tune::Digest), AviateSupervisorError> {
+        let object_name = object_name(name)?;
+        let object = self
+            .directory
+            .read_exact(&object_name, MAX_DOCUMENT_BYTES)
+            .map_err(|source| storage_error("read process document", source))?;
+        decode_document(name, &object)
+    }
+
+    pub(crate) fn repair<T: DeserializeOwned + Serialize>(
+        &self,
+        name: &'static str,
+    ) -> Result<(T, flight_tune::Digest), AviateSupervisorError> {
+        self.repair_optional(name)?.ok_or_else(|| {
+            AviateSupervisorError::invalid_document(name, "the required document is absent")
+        })
+    }
+
+    pub(crate) fn repair_optional<T: DeserializeOwned + Serialize>(
+        &self,
+        name: &'static str,
+    ) -> Result<Option<(T, flight_tune::Digest)>, AviateSupervisorError> {
+        let object = self
+            .directory
+            .repair_immutable_publication_blocking(
+                &self.writer,
+                &object_name(name)?,
+                MAX_DOCUMENT_BYTES,
+            )
+            .map_err(|source| storage_error("repair process document", source))?;
+        object
+            .as_ref()
+            .map(|object| decode_document(name, object))
+            .transpose()
+    }
+
+    pub(crate) fn finish_recovery_scan(
+        &self,
+        document_names: &[&'static str],
+    ) -> Result<(), AviateSupervisorError> {
+        self.directory
+            .cleanup_unlinked_temporaries_blocking(
+                &self.writer,
+                MAX_RECOVERY_TEMPORARIES,
+                MAX_DOCUMENT_BYTES,
+            )
+            .map_err(|source| storage_error("clean recovery temporary objects", source))?;
+        let entries = self
+            .directory
+            .list()
+            .map_err(|source| storage_error("validate recovery document set", source))?;
+        let valid = entries.iter().all(|entry| {
+            entry.as_os_str() == std::ffi::OsStr::new(WRITER_LOCK_NAME)
+                || document_names
+                    .iter()
+                    .any(|name| entry.as_os_str() == std::ffi::OsStr::new(name))
+        });
+        if !valid {
+            return Err(AviateSupervisorError::invalid_document(
+                "process lease",
+                "the recovery document set contains an unknown object",
+            ));
+        }
+        self.writer
+            .validate(&self.directory)
+            .map_err(|source| storage_error("validate recovery document set", source))
+    }
+}
+
+pub(crate) fn read_without_writer<T: DeserializeOwned + Serialize>(
+    root: &Path,
+    name: &'static str,
+) -> Result<(T, flight_tune::Digest), AviateSupervisorError> {
+    let store = open_existing_store(root)?;
+    let directory = store.root_directory();
+    let object = directory
+        .read_exact(&object_name(name)?, MAX_DOCUMENT_BYTES)
+        .map_err(|source| storage_error("read active process document", source))?;
+    decode_document(name, &object)
+}
+
+pub(crate) fn digest_bytes(bytes: &[u8]) -> flight_tune::Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    flight_tune::Digest::from_bytes(hasher.finalize().into())
+}
+
+fn decode_document<T: DeserializeOwned + Serialize>(
+    name: &'static str,
+    object: &ExactObject,
+) -> Result<(T, flight_tune::Digest), AviateSupervisorError> {
+    let value = serde_json::from_slice(object.bytes())
+        .map_err(|source| AviateSupervisorError::invalid_json_document(name, "parsing", source))?;
+    let canonical = serde_json::to_vec(&value).map_err(|source| {
+        AviateSupervisorError::invalid_json_document(name, "re-encoding", source)
+    })?;
+    if canonical != object.bytes() {
+        return Err(AviateSupervisorError::invalid_document(
+            name,
+            "the document is not canonical JSON",
+        ));
+    }
+    Ok((value, digest_bytes(&canonical)))
+}
+
+fn open_store(root: &Path) -> Result<DurableStore, AviateSupervisorError> {
+    DurableStore::open_or_create(root)
+        .map_err(|source| storage_error("open process lease root", source))
+}
+
+fn open_existing_store(root: &Path) -> Result<DurableStore, AviateSupervisorError> {
+    DurableStore::open_existing_blocking(root)
+        .map_err(|source| storage_error("open existing process lease root", source))
+}
+
+fn acquire_writer(store: &DurableStore) -> Result<WriterLease, AviateSupervisorError> {
+    store
+        .acquire_writer()
+        .map_err(|source| storage_error("acquire process writer lease", source))
+}
+
+fn object_name(name: &'static str) -> Result<ObjectName, AviateSupervisorError> {
+    ObjectName::new(name).map_err(|source| storage_error("select process document", source))
+}
+
+fn storage_error(
+    operation: &'static str,
+    source: pilotage_durable_storage::StorageError,
+) -> AviateSupervisorError {
+    AviateSupervisorError::Storage {
+        operation,
+        source: Box::new(source),
+    }
+}

--- a/tools/flight-tune-aviate/src/lib.rs
+++ b/tools/flight-tune-aviate/src/lib.rs
@@ -1,0 +1,43 @@
+//! Crash-contained Aviate process supervision for simulator tuning.
+//!
+//! The supervisor keeps one target behind a launch gate until it stores and
+//! reads back the exact process identity. A parent-lifetime pipe requests
+//! cleanup after parent failure. Recovery does not send process signals. The
+//! launch gate and its owner contain the exact private process group.
+//!
+//! This crate supports only Linux and macOS.
+//!
+//! Isolate runtime, storage, and artifact roots from non-cooperating code that
+//! runs as the same user.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![forbid(unsafe_code)]
+
+mod artifact;
+mod document;
+mod error;
+mod inspection;
+mod lease_store;
+mod process;
+mod protocol;
+mod runtime_files;
+mod supervisor;
+
+pub use document::{
+    ProcessIdentity, ProcessStartIdentity, TargetAttestation, TargetProcessContract,
+};
+pub use error::AviateSupervisorError;
+pub use process::{
+    ManagedAviateProcess, PreparedAviateProcess, RECOVERY_REQUEST_SCHEMA_VERSION, RecoveryOutcome,
+    RecoveryRequest, SUPERVISION_ATTESTATION_SCHEMA_VERSION, SupervisedProcessRequest,
+    SupervisionAttestation, recover_supervised_process_blocking,
+};
+
+/// Runs the process-supervisor helper protocol.
+///
+/// The workspace helper binary is the only intended caller.
+#[doc(hidden)]
+pub fn supervisor_main_blocking() -> Result<(), AviateSupervisorError> {
+    supervisor::run_from_arguments()
+}

--- a/tools/flight-tune-aviate/src/process.rs
+++ b/tools/flight-tune-aviate/src/process.rs
@@ -1,0 +1,190 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::ChildStdin;
+use std::time::Duration;
+
+use crate::AviateSupervisorError;
+use crate::document::{ProcessIdentity, TargetProcessContract};
+
+mod reaper;
+mod recovery;
+mod startup;
+
+pub use recovery::{
+    RECOVERY_REQUEST_SCHEMA_VERSION, RecoveryOutcome, RecoveryRequest,
+    recover_supervised_process_blocking,
+};
+
+/// Schema version for one external supervision attestation.
+pub const SUPERVISION_ATTESTATION_SCHEMA_VERSION: u16 = 1;
+
+/// One exact process-supervision launch request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SupervisedProcessRequest {
+    /// Process-supervisor helper executable.
+    pub supervisor_executable: PathBuf,
+    /// Required SHA-256 digest of the helper executable.
+    pub supervisor_executable_digest: flight_tune::Digest,
+    /// Target executable.
+    pub target_executable: PathBuf,
+    /// Required SHA-256 digest of the target executable.
+    pub target_executable_digest: flight_tune::Digest,
+    /// Complete target argument vector after argument zero.
+    pub target_arguments: Vec<String>,
+    /// Complete target environment. The launcher clears the inherited environment.
+    pub target_environment: BTreeMap<String, String>,
+    /// Required process-tree behavior for the authorized target executable.
+    pub target_process_contract: TargetProcessContract,
+    /// Exact target current directory.
+    pub target_current_directory: PathBuf,
+    /// New durable supervisor-document root.
+    pub storage_root: PathBuf,
+    /// Existing empty mode-0700 runtime root.
+    pub runtime_root: PathBuf,
+    /// Absent private executable-artifact root.
+    pub artifact_root: PathBuf,
+    /// Digest of the exact run intent that authorizes this launch.
+    pub run_intent_digest: flight_tune::Digest,
+    /// Maximum duration for target authorization.
+    pub startup_timeout: Duration,
+    /// Maximum duration for exact process-group cleanup.
+    pub cleanup_timeout: Duration,
+}
+
+/// Exact durable digests that authorize recovery of one supervised run.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisionAttestation {
+    /// Attestation schema version.
+    pub schema_version: u16,
+    /// Digest of the exact run intent.
+    pub run_intent_digest: flight_tune::Digest,
+    /// Digest of the exact spawn intent.
+    pub spawn_intent_digest: flight_tune::Digest,
+    /// Digest of the exact owner and launch-gate identity document.
+    pub process_identity_digest: flight_tune::Digest,
+    /// Exact process owner identity.
+    pub supervisor_identity: ProcessIdentity,
+    /// Exact launch-gate identity.
+    pub target_gate_identity: ProcessIdentity,
+    /// Recovery request that binds the external campaign journal to this run.
+    pub recovery_request: RecoveryRequest,
+}
+
+/// One armed launch that cannot start its target before explicit release.
+#[must_use = "persist the attestation before release or drop the prepared launch"]
+pub struct PreparedAviateProcess {
+    launch: Option<startup::PreparedLaunch>,
+    attestation: SupervisionAttestation,
+}
+
+impl PreparedAviateProcess {
+    /// Arm one exact owner and launch gate without starting the target.
+    pub fn prepare_blocking(
+        request: SupervisedProcessRequest,
+    ) -> Result<Self, AviateSupervisorError> {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            let launch = startup::prepare_supported(request)?;
+            let attestation = startup::prepared_attestation(&launch).clone();
+            Ok(Self {
+                launch: Some(launch),
+                attestation,
+            })
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let _ = request;
+            Err(AviateSupervisorError::UnsupportedPlatform)
+        }
+    }
+
+    /// Get the pre-release evidence for the external campaign journal.
+    #[must_use]
+    pub const fn supervision_attestation(&self) -> &SupervisionAttestation {
+        &self.attestation
+    }
+
+    /// Release the target after the caller durably stores the attestation.
+    pub fn release_blocking(mut self) -> Result<ManagedAviateProcess, AviateSupervisorError> {
+        let launch = self.launch.take().ok_or_else(|| {
+            AviateSupervisorError::protocol("the prepared launch was already consumed")
+        })?;
+        startup::release_supported(launch)
+    }
+
+    /// Close the launch gate and wait for durable cleanup evidence.
+    pub fn cancel_blocking(mut self) -> Result<RecoveryOutcome, AviateSupervisorError> {
+        let launch = self.launch.take().ok_or_else(|| {
+            AviateSupervisorError::protocol("the prepared launch was already consumed")
+        })?;
+        startup::cancel_supported(launch)
+    }
+}
+
+impl Drop for PreparedAviateProcess {
+    fn drop(&mut self) {
+        if let Some(launch) = self.launch.as_mut() {
+            startup::cancel_prepared(launch);
+        }
+    }
+}
+
+/// One running target whose owner holds its durable writer lease.
+#[must_use = "dropping the handle requests cleanup but does not wait for evidence"]
+pub struct ManagedAviateProcess {
+    supervisor: reaper::ReapableOwner,
+    parent_lifetime: Option<ChildStdin>,
+    supervisor_identity: ProcessIdentity,
+    target_identity: ProcessIdentity,
+    attestation: SupervisionAttestation,
+    recovery: RecoveryRequest,
+    cleanup_timeout: Duration,
+    terminated: bool,
+}
+
+impl ManagedAviateProcess {
+    /// Verify that the exact supervisor and target lifetimes are still live.
+    pub fn ensure_running_blocking(&self) -> Result<(), AviateSupervisorError> {
+        startup::verify_live(&self.supervisor_identity, "supervisor")?;
+        startup::verify_live(&self.target_identity, "target")
+    }
+
+    /// Request cleanup and wait for its durable terminal receipt.
+    pub fn terminate_blocking(&mut self) -> Result<RecoveryOutcome, AviateSupervisorError> {
+        self.parent_lifetime.take();
+        let supervisor = self.supervisor.child_mut()?;
+        startup::wait_for_supervisor_terminal(
+            supervisor,
+            &self.supervisor_identity,
+            self.cleanup_timeout,
+        )?;
+        let outcome = recover_supervised_process_blocking(&self.recovery)?;
+        self.terminated = true;
+        Ok(outcome)
+    }
+
+    /// Get the exact attested target identity.
+    #[must_use]
+    pub const fn target_identity(&self) -> &ProcessIdentity {
+        &self.target_identity
+    }
+
+    /// Get the exact durable supervision attestation.
+    #[must_use]
+    pub const fn supervision_attestation(&self) -> &SupervisionAttestation {
+        &self.attestation
+    }
+}
+
+impl Drop for ManagedAviateProcess {
+    fn drop(&mut self) {
+        if !self.terminated {
+            self.parent_lifetime.take();
+            tracing::warn!(
+                supervisor_pid = self.supervisor_identity.pid,
+                "Aviate process handle dropped; cleanup continues in the owner"
+            );
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/process/reaper.rs
+++ b/tools/flight-tune-aviate/src/process/reaper.rs
@@ -1,0 +1,124 @@
+use std::process::Child;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::AviateSupervisorError;
+
+pub(super) struct ReapableOwner {
+    child: Option<Child>,
+    reaper: Option<OwnerReaper>,
+}
+
+impl ReapableOwner {
+    pub(super) fn spawn(
+        spawn_child: impl FnOnce() -> Result<Child, AviateSupervisorError>,
+    ) -> Result<Self, AviateSupervisorError> {
+        spawn_with_reaper(OwnerReaper::spawn, spawn_child)
+    }
+
+    pub(super) fn child_mut(&mut self) -> Result<&mut Child, AviateSupervisorError> {
+        self.child
+            .as_mut()
+            .ok_or_else(|| AviateSupervisorError::protocol("the process owner is missing"))
+    }
+
+    pub(super) fn id(&self) -> Result<u32, AviateSupervisorError> {
+        self.child
+            .as_ref()
+            .map(Child::id)
+            .ok_or_else(|| AviateSupervisorError::protocol("the process owner is missing"))
+    }
+}
+
+impl Drop for ReapableOwner {
+    fn drop(&mut self) {
+        let Some(child) = self.child.take() else {
+            return;
+        };
+        let Some(reaper) = self.reaper.take() else {
+            tracing::error!(pid = child.id(), "process-owner reaper is missing");
+            reap_owner_blocking(child);
+            return;
+        };
+        reaper.handoff(child);
+    }
+}
+
+struct OwnerReaper {
+    sender: mpsc::Sender<Child>,
+}
+
+impl OwnerReaper {
+    fn spawn() -> Result<Self, AviateSupervisorError> {
+        Self::spawn_worker(None)
+    }
+
+    fn spawn_worker(completion: Option<mpsc::Sender<()>>) -> Result<Self, AviateSupervisorError> {
+        let (sender, receiver) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("aviate-owner-reaper".to_owned())
+            .spawn(move || run_reaper_blocking(receiver, completion))
+            .map_err(|source| AviateSupervisorError::ProcessIo {
+                operation: "spawn process-owner reaper",
+                source,
+            })?;
+        Ok(Self { sender })
+    }
+
+    fn handoff(self, child: Child) {
+        if let Err(error) = self.sender.send(child) {
+            let child = error.0;
+            tracing::error!(pid = child.id(), "process-owner reaper channel closed");
+            reap_owner_blocking(child);
+        }
+    }
+}
+
+fn spawn_with_reaper(
+    spawn_reaper: impl FnOnce() -> Result<OwnerReaper, AviateSupervisorError>,
+    spawn_child: impl FnOnce() -> Result<Child, AviateSupervisorError>,
+) -> Result<ReapableOwner, AviateSupervisorError> {
+    let reaper = spawn_reaper()?;
+    let child = spawn_child()?;
+    Ok(ReapableOwner {
+        child: Some(child),
+        reaper: Some(reaper),
+    })
+}
+
+fn run_reaper_blocking(receiver: mpsc::Receiver<Child>, completion: Option<mpsc::Sender<()>>) {
+    let Ok(child) = receiver.recv() else {
+        return;
+    };
+    reap_owner_blocking(child);
+    if let Some(completion) = completion
+        && completion.send(()).is_err()
+    {
+        tracing::debug!("process-owner reap observer is closed");
+    }
+}
+
+fn reap_owner_blocking(mut child: Child) {
+    let pid = child.id();
+    let mut reported_failure = false;
+    loop {
+        match child.wait() {
+            Ok(status) => {
+                tracing::debug!(pid, %status, "reaped Aviate process owner");
+                return;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => {
+                if !reported_failure {
+                    tracing::error!(pid, %error, "Aviate process-owner reap failed; retrying");
+                    reported_failure = true;
+                }
+                std::thread::park_timeout(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "reaper/tests.rs"]
+mod tests;

--- a/tools/flight-tune-aviate/src/process/reaper/tests.rs
+++ b/tools/flight-tune-aviate/src/process/reaper/tests.rs
@@ -66,6 +66,44 @@ fn repeated_owner_drop_reaps_each_child() {
     }
 }
 
+#[test]
+fn owner_drop_hands_off_a_live_child_without_blocking() {
+    let (child, input) = spawn_blocking_child();
+    let pid = child.id();
+    let (reaped_sender, reaped) = mpsc::channel();
+    let reaper = OwnerReaper::spawn_worker(Some(reaped_sender)).expect("spawn named reaper");
+    let owner = ReapableOwner {
+        child: Some(child),
+        reaper: Some(reaper),
+    };
+    let (drop_sender, dropped) = mpsc::channel();
+    let dropper = std::thread::spawn(move || {
+        drop(owner);
+        drop_sender.send(()).expect("report owner drop");
+    });
+
+    dropped
+        .recv_timeout(Duration::from_secs(5))
+        .expect("owner drop returns while the child is live");
+    assert!(
+        crate::inspection::inspect_lifetime(pid)
+            .expect("inspect handed-off child")
+            .is_some(),
+        "the reaper owns the live child"
+    );
+    drop(input);
+    reaped
+        .recv_timeout(Duration::from_secs(5))
+        .expect("observe handed-off child reap");
+    assert!(
+        crate::inspection::inspect_lifetime(pid)
+            .expect("inspect reaped handed-off child")
+            .is_none(),
+        "the reaper removes the handed-off child lifetime"
+    );
+    dropper.join().expect("join owner dropper");
+}
+
 fn spawn_blocking_child() -> (Child, ChildStdin) {
     let mut child = Command::new(std::env::current_exe().expect("find test executable"))
         .args([

--- a/tools/flight-tune-aviate/src/process/reaper/tests.rs
+++ b/tools/flight-tune-aviate/src/process/reaper/tests.rs
@@ -1,0 +1,84 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::io::Read as _;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use super::{OwnerReaper, ReapableOwner, spawn_with_reaper};
+use crate::AviateSupervisorError;
+
+const REAPER_FIXTURE_ENV: &str = "PILOTAGE_OWNER_REAPER_FIXTURE";
+
+#[test]
+fn blocking_child_fixture() {
+    if std::env::var_os(REAPER_FIXTURE_ENV).is_none() {
+        return;
+    }
+    let mut input = std::io::stdin();
+    let mut bytes = Vec::new();
+    input.read_to_end(&mut bytes).expect("read fixture input");
+}
+
+#[test]
+fn reaper_failure_prevents_child_spawn() {
+    let child_spawned = std::sync::atomic::AtomicBool::new(false);
+
+    let result = spawn_with_reaper(
+        || Err(AviateSupervisorError::protocol("injected reaper failure")),
+        || {
+            child_spawned.store(true, std::sync::atomic::Ordering::SeqCst);
+            Err(AviateSupervisorError::protocol("unexpected child spawn"))
+        },
+    );
+    let Err(error) = result else {
+        panic!("the launch must stop before child spawn");
+    };
+
+    assert!(matches!(error, AviateSupervisorError::Protocol { .. }));
+    assert!(!child_spawned.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn repeated_owner_drop_reaps_each_child() {
+    for _ in 0..3 {
+        let (child, input) = spawn_blocking_child();
+        let pid = child.id();
+        let (completion, completed) = mpsc::channel();
+        let reaper = OwnerReaper::spawn_worker(Some(completion)).expect("spawn named reaper");
+        let owner = ReapableOwner {
+            child: Some(child),
+            reaper: Some(reaper),
+        };
+
+        drop(input);
+        drop(owner);
+        completed
+            .recv_timeout(Duration::from_secs(5))
+            .expect("observe exact child reap");
+
+        assert!(
+            crate::inspection::inspect_lifetime(pid)
+                .expect("inspect reaped child")
+                .is_none(),
+            "the named reaper removes the exact child lifetime"
+        );
+    }
+}
+
+fn spawn_blocking_child() -> (Child, ChildStdin) {
+    let mut child = Command::new(std::env::current_exe().expect("find test executable"))
+        .args([
+            "--exact",
+            "process::reaper::tests::blocking_child_fixture",
+            "--nocapture",
+        ])
+        .env(REAPER_FIXTURE_ENV, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn blocking fixture");
+    let input = child.stdin.take().expect("take fixture input");
+    (child, input)
+}

--- a/tools/flight-tune-aviate/src/process/recovery.rs
+++ b/tools/flight-tune-aviate/src/process/recovery.rs
@@ -1,0 +1,195 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::AviateSupervisorError;
+use crate::document::{
+    BootIdentity, ProcessIdentityDocument, RecoveryReceipt, SCHEMA_VERSION, SpawnIntent,
+    TERMINAL_RECEIPT_NAME, TargetAttestation, TerminalReceipt,
+};
+use crate::lease_store::LeaseStore;
+
+mod cleanup;
+mod documents;
+
+/// Schema version for one external recovery request.
+pub const RECOVERY_REQUEST_SCHEMA_VERSION: u16 = 1;
+
+/// One exact recovery request for a supervised process family.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryRequest {
+    /// Recovery-request schema version.
+    pub schema_version: u16,
+    /// Existing durable supervisor-document root.
+    pub storage_root: PathBuf,
+    /// Required run-intent digest.
+    pub run_intent_digest: flight_tune::Digest,
+    /// Required process-supervisor executable digest.
+    pub supervisor_executable_digest: flight_tune::Digest,
+    /// Required target executable digest.
+    pub target_executable_digest: flight_tune::Digest,
+    /// Exact spawn-intent digest from launch authorization.
+    pub expected_spawn_intent_digest: flight_tune::Digest,
+    /// Exact process-identity digest from launch authorization.
+    pub expected_process_identity_digest: flight_tune::Digest,
+    /// Maximum duration for one recovery cleanup operation.
+    pub cleanup_timeout_millis: u64,
+}
+
+/// Durable evidence that permits the caller to archive one stopped run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "recovery evidence must be retained by the caller"]
+pub enum RecoveryOutcome {
+    /// Exact same-boot or owner cleanup has a durable receipt.
+    Terminal {
+        /// Digest of the terminal receipt.
+        receipt_digest: flight_tune::Digest,
+    },
+    /// A different operating-system boot has a durable cleanup receipt.
+    BootChange {
+        /// Digest of the boot-change recovery receipt.
+        receipt_digest: flight_tune::Digest,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct TargetEvidence {
+    pub(super) attestation: TargetAttestation,
+    pub(super) digest: flight_tune::Digest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct RecoveryState {
+    pub(super) intent: SpawnIntent,
+    pub(super) intent_digest: flight_tune::Digest,
+    pub(super) processes: ProcessIdentityDocument,
+    pub(super) process_digest: flight_tune::Digest,
+    pub(super) target: Option<TargetEvidence>,
+}
+
+/// Recover one exact supervised run under its durable writer lease.
+pub fn recover_supervised_process_blocking(
+    request: &RecoveryRequest,
+) -> Result<RecoveryOutcome, AviateSupervisorError> {
+    validate_request(request)?;
+    let store = LeaseStore::open_existing(&request.storage_root)?;
+    let loaded = documents::load(&store, request)?;
+    let current_boot = crate::inspection::current_boot_identity()?;
+    let prior_boot = loaded.state.processes.supervisor.start.boot_identity();
+    if !prior_boot.is_valid() || !current_boot.is_valid() {
+        return Err(AviateSupervisorError::invalid_document(
+            "boot identity",
+            "the recovery boot identity is invalid",
+        ));
+    }
+    if let Some(outcome) = documents::existing_outcome(request, &loaded, &current_boot)? {
+        if prior_boot == current_boot {
+            cleanup::recover_same_boot(
+                &loaded.state,
+                Duration::from_millis(request.cleanup_timeout_millis),
+            )?;
+        }
+        cleanup::verify_resources_clean(&loaded.state)?;
+        return Ok(outcome);
+    }
+    if prior_boot == current_boot {
+        cleanup::recover_same_boot(
+            &loaded.state,
+            Duration::from_millis(request.cleanup_timeout_millis),
+        )?;
+        cleanup::cleanup_resources(&loaded.state)?;
+        publish_terminal(&store, request, &loaded.state)
+    } else {
+        cleanup::cleanup_resources(&loaded.state)?;
+        publish_boot_change(&store, request, &loaded.state, prior_boot, current_boot)
+    }
+}
+
+fn validate_request(request: &RecoveryRequest) -> Result<(), AviateSupervisorError> {
+    if request.schema_version != RECOVERY_REQUEST_SCHEMA_VERSION
+        || request.run_intent_digest.is_zero()
+        || request.supervisor_executable_digest.is_zero()
+        || request.target_executable_digest.is_zero()
+        || request.expected_spawn_intent_digest.is_zero()
+        || request.expected_process_identity_digest.is_zero()
+        || request.cleanup_timeout_millis == 0
+    {
+        return Err(AviateSupervisorError::invalid_request(
+            "the recovery request is incomplete",
+        ));
+    }
+    Ok(())
+}
+
+fn publish_terminal(
+    store: &LeaseStore,
+    request: &RecoveryRequest,
+    state: &RecoveryState,
+) -> Result<RecoveryOutcome, AviateSupervisorError> {
+    let receipt = TerminalReceipt {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: request.run_intent_digest,
+        spawn_intent_digest: state.intent_digest,
+        process_identity_digest: state.process_digest,
+        target_attestation_digest: state.target.as_ref().map(|target| target.digest),
+    };
+    let digest = store.publish(TERMINAL_RECEIPT_NAME, &receipt)?;
+    verify_terminal_readback(store, &receipt, digest)?;
+    Ok(RecoveryOutcome::Terminal {
+        receipt_digest: digest,
+    })
+}
+
+fn verify_terminal_readback(
+    store: &LeaseStore,
+    expected: &TerminalReceipt,
+    expected_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    let (actual, actual_digest): (TerminalReceipt, _) = store.read(TERMINAL_RECEIPT_NAME)?;
+    if actual != *expected || actual_digest != expected_digest {
+        return Err(AviateSupervisorError::invalid_document(
+            "terminal receipt",
+            "the terminal receipt readback changed",
+        ));
+    }
+    Ok(())
+}
+
+fn publish_boot_change(
+    store: &LeaseStore,
+    request: &RecoveryRequest,
+    state: &RecoveryState,
+    prior_boot: BootIdentity,
+    recovery_boot: BootIdentity,
+) -> Result<RecoveryOutcome, AviateSupervisorError> {
+    let receipt = RecoveryReceipt {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: request.run_intent_digest,
+        spawn_intent_digest: state.intent_digest,
+        process_identity_digest: state.process_digest,
+        target_attestation_digest: state.target.as_ref().map(|target| target.digest),
+        prior_boot_identity: prior_boot,
+        recovery_boot_identity: recovery_boot,
+    };
+    let digest = store.publish(crate::document::RECOVERY_RECEIPT_NAME, &receipt)?;
+    verify_boot_change_readback(store, &receipt, digest)?;
+    Ok(RecoveryOutcome::BootChange {
+        receipt_digest: digest,
+    })
+}
+
+fn verify_boot_change_readback(
+    store: &LeaseStore,
+    expected: &RecoveryReceipt,
+    expected_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    let (actual, actual_digest): (RecoveryReceipt, _) =
+        store.read(crate::document::RECOVERY_RECEIPT_NAME)?;
+    if actual != *expected || actual_digest != expected_digest {
+        return Err(AviateSupervisorError::invalid_document(
+            "recovery receipt",
+            "the recovery receipt readback changed",
+        ));
+    }
+    Ok(())
+}

--- a/tools/flight-tune-aviate/src/process/recovery/cleanup.rs
+++ b/tools/flight-tune-aviate/src/process/recovery/cleanup.rs
@@ -1,0 +1,280 @@
+use std::time::{Duration, Instant};
+
+use crate::AviateSupervisorError;
+use crate::document::{ProcessIdentity, ProcessStartIdentity};
+use crate::inspection::{LifetimeIdentity, ProcessGroupSnapshot};
+
+use super::RecoveryState;
+
+pub(super) fn recover_same_boot(
+    state: &RecoveryState,
+    timeout: Duration,
+) -> Result<(), AviateSupervisorError> {
+    let target = state
+        .target
+        .as_ref()
+        .map(|evidence| &evidence.attestation.target);
+    let mut wait = SystemWaitControl;
+    recover_processes_same_boot_blocking(
+        &state.processes.supervisor,
+        &state.processes.target_gate,
+        target,
+        timeout,
+        &mut wait,
+    )
+}
+
+fn recover_processes_same_boot_blocking(
+    owner: &ProcessIdentity,
+    gate: &ProcessIdentity,
+    target: Option<&ProcessIdentity>,
+    timeout: Duration,
+    wait: &mut impl WaitControl,
+) -> Result<(), AviateSupervisorError> {
+    let deadline = wait
+        .now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout {
+            operation: "wait for recovered process removal",
+        })?;
+    wait_for_owner_ended(owner, deadline, wait)?;
+    let snapshot = crate::inspection::process_group_snapshot(gate.process_group)?;
+    if !snapshot.is_empty() {
+        validate_group(gate, &snapshot)?;
+        if !snapshot.is_quiescent() {
+            require_live_group_anchor(gate, target, &snapshot)?;
+        }
+    }
+    wait_for_group_empty(gate, deadline, wait)?;
+    require_process_ended(gate, "launch gate")?;
+    if let Some(target) = target {
+        require_process_ended(target, "target")?;
+    }
+    require_group_absent(gate.process_group)?;
+    Ok(())
+}
+
+trait WaitControl {
+    fn now(&mut self) -> Instant;
+    fn park_for_poll_blocking(&mut self, duration: Duration);
+}
+
+struct SystemWaitControl;
+
+impl WaitControl for SystemWaitControl {
+    fn now(&mut self) -> Instant {
+        Instant::now()
+    }
+
+    fn park_for_poll_blocking(&mut self, duration: Duration) {
+        std::thread::park_timeout(duration.min(Duration::from_millis(1)));
+    }
+}
+
+pub(super) fn cleanup_resources(state: &RecoveryState) -> Result<(), AviateSupervisorError> {
+    crate::artifact::validate_directory(&state.intent.runtime_root, true)?;
+    crate::runtime_files::remove_exact_socket(&crate::runtime_files::socket_path(
+        &state.intent.runtime_root.path,
+        crate::runtime_files::PARENT_READY_SOCKET,
+    ))?;
+    crate::runtime_files::require_entries(&state.intent.runtime_root.path, &[])?;
+    cleanup_artifacts(state)
+}
+
+pub(super) fn verify_resources_clean(state: &RecoveryState) -> Result<(), AviateSupervisorError> {
+    crate::artifact::validate_directory(&state.intent.runtime_root, true)?;
+    crate::runtime_files::require_entries(&state.intent.runtime_root.path, &[])?;
+    if path_exists(&state.intent.artifact_root.path)? {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the launch-artifact root exists after the durable outcome".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn cleanup_artifacts(state: &RecoveryState) -> Result<(), AviateSupervisorError> {
+    if !path_exists(&state.intent.artifact_root.path)? {
+        return crate::artifact::stabilize_absent_artifact_root(&state.intent.artifact_root);
+    }
+    crate::artifact::validate_directory(&state.intent.artifact_root, true)?;
+    for executable in [
+        &state.intent.target_executable,
+        &state.intent.supervisor_executable,
+    ] {
+        if path_exists(&executable.path)? {
+            crate::artifact::remove_staged(&state.intent.artifact_root, executable)?;
+        }
+    }
+    crate::artifact::remove_artifact_root(&state.intent.artifact_root)
+}
+
+fn path_exists(path: &std::path::Path) -> Result<bool, AviateSupervisorError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(crate::inspection::io_error(
+            "inspect recovery resource",
+            path,
+            source,
+        )),
+    }
+}
+
+fn wait_for_owner_ended(
+    expected: &ProcessIdentity,
+    deadline: Instant,
+    wait: &mut impl WaitControl,
+) -> Result<(), AviateSupervisorError> {
+    loop {
+        match crate::inspection::inspect_lifetime(expected.pid)? {
+            Some(actual) if same_incarnation(expected, &actual) => {}
+            Some(_) | None => return Ok(()),
+        }
+        let now = wait.now();
+        if now >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "wait for recovered process owner removal",
+            });
+        }
+        wait.park_for_poll_blocking(deadline.saturating_duration_since(now));
+    }
+}
+
+fn require_process_ended(
+    expected: &ProcessIdentity,
+    process: &'static str,
+) -> Result<(), AviateSupervisorError> {
+    match crate::inspection::inspect_lifetime(expected.pid)? {
+        Some(actual) if same_incarnation(expected, &actual) => {
+            Err(AviateSupervisorError::RecoveryBlocked {
+                detail: format!("the exact {process} lifetime is still present"),
+            })
+        }
+        Some(_) | None => Ok(()),
+    }
+}
+
+fn validate_group(
+    gate: &ProcessIdentity,
+    snapshot: &ProcessGroupSnapshot,
+) -> Result<(), AviateSupervisorError> {
+    let invalid = !snapshot.unclassified_pids.is_empty()
+        || snapshot.raw_pids.len() != snapshot.observed.len().wrapping_add(snapshot.exited.len())
+        || snapshot.observed.iter().any(|member| {
+            member.process_group != gate.process_group
+                || member.session_id != gate.session_id
+                || member.real_user_id != gate.real_user_id
+                || member.start.boot_identity() != gate.start.boot_identity()
+        });
+    if invalid {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the recovery group has a member outside the isolated launch session"
+                .to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn require_live_group_anchor(
+    gate: &ProcessIdentity,
+    target: Option<&ProcessIdentity>,
+    snapshot: &ProcessGroupSnapshot,
+) -> Result<(), AviateSupervisorError> {
+    let gate_anchor = snapshot
+        .observed
+        .iter()
+        .any(|actual| same_contained_lifetime(gate, actual))
+        && exact_live_identity(gate)?;
+    let target_anchor = if let Some(expected) = target {
+        snapshot
+            .observed
+            .iter()
+            .any(|actual| same_contained_lifetime(expected, actual))
+            && exact_live_identity(expected)?
+    } else {
+        false
+    };
+    if !gate_anchor && !target_anchor {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the live recovery group has no exact process anchor".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn exact_live_identity(expected: &ProcessIdentity) -> Result<bool, AviateSupervisorError> {
+    let Some(actual) =
+        crate::inspection::inspect_process(expected.pid, expected.launch_argv_digest)?
+    else {
+        return Ok(false);
+    };
+    if !same_recovery_identity(expected, &actual) {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "a live recovery anchor changed executable identity",
+        ));
+    }
+    Ok(true)
+}
+
+fn same_recovery_identity(expected: &ProcessIdentity, actual: &ProcessIdentity) -> bool {
+    expected.pid == actual.pid
+        && expected.process_group == actual.process_group
+        && expected.session_id == actual.session_id
+        && expected.real_user_id == actual.real_user_id
+        && expected.start == actual.start
+        && expected.executable == actual.executable
+        && expected.executable_digest == actual.executable_digest
+        && expected.launch_argv_digest == actual.launch_argv_digest
+        && expected.observed_argv_digest == actual.observed_argv_digest
+}
+
+fn wait_for_group_empty(
+    gate: &ProcessIdentity,
+    deadline: Instant,
+    wait: &mut impl WaitControl,
+) -> Result<(), AviateSupervisorError> {
+    loop {
+        let snapshot = crate::inspection::process_group_snapshot(gate.process_group)?;
+        if snapshot.is_empty() && crate::inspection::process_group_is_absent(gate.process_group)? {
+            return Ok(());
+        }
+        validate_group(gate, &snapshot)?;
+        let now = wait.now();
+        if now >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "wait for recovered process group removal",
+            });
+        }
+        wait.park_for_poll_blocking(deadline.saturating_duration_since(now));
+    }
+}
+
+fn require_group_absent(process_group: u32) -> Result<(), AviateSupervisorError> {
+    if crate::inspection::process_group_is_absent(process_group)? {
+        Ok(())
+    } else {
+        Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the exact recovery process group is still present".to_owned(),
+        })
+    }
+}
+
+fn same_contained_lifetime(expected: &ProcessIdentity, actual: &LifetimeIdentity) -> bool {
+    same_incarnation(expected, actual)
+        && actual.process_group == expected.process_group
+        && actual.session_id == expected.session_id
+}
+
+fn same_incarnation(expected: &ProcessIdentity, actual: &LifetimeIdentity) -> bool {
+    actual.pid == expected.pid
+        && actual.real_user_id == expected.real_user_id
+        && same_start(&expected.start, &actual.start)
+}
+
+fn same_start(expected: &ProcessStartIdentity, actual: &ProcessStartIdentity) -> bool {
+    expected == actual
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/tools/flight-tune-aviate/src/process/recovery/cleanup/tests.rs
+++ b/tools/flight-tune-aviate/src/process/recovery/cleanup/tests.rs
@@ -1,0 +1,171 @@
+use std::os::unix::process::CommandExt as _;
+
+use crate::document::ProcessStartIdentity;
+use crate::{AviateSupervisorError, inspection};
+
+use super::{
+    WaitControl, recover_processes_same_boot_blocking, require_live_group_anchor, validate_group,
+};
+
+#[test]
+fn reused_process_group_with_another_start_token_is_not_signaled() {
+    let arguments = vec!["/bin/sleep".to_owned(), "60".to_owned()];
+    let argument_digest = inspection::digest_arguments(&arguments);
+    let mut command = std::process::Command::new(&arguments[0]);
+    command.arg(&arguments[1]).process_group(0);
+    let mut child = ReapedChild::spawn(command);
+    let actual = inspection::inspect_process(child.id(), argument_digest)
+        .expect("inspect isolated group member")
+        .expect("isolated group member is live");
+    let snapshot =
+        inspection::process_group_snapshot(child.id()).expect("inspect isolated process group");
+    let mut stale = actual;
+    change_start_token(&mut stale.start);
+
+    validate_group(&stale, &snapshot).expect("the reused group has the expected containment");
+    let result = require_live_group_anchor(&stale, None, &snapshot);
+    let still_running = child.is_running();
+    child.stop_and_wait();
+
+    assert!(matches!(
+        result,
+        Err(AviateSupervisorError::RecoveryBlocked { .. })
+    ));
+    assert!(still_running, "recovery does not signal the reused group");
+}
+
+#[test]
+fn owner_and_group_waits_share_one_deadline() {
+    let arguments = vec!["/bin/sleep".to_owned(), "60".to_owned()];
+    let argument_digest = inspection::digest_arguments(&arguments);
+    let mut owner = spawn_group_member(&arguments);
+    let mut gate = spawn_group_member(&arguments);
+    let owner_identity = inspect_group_member(&owner, argument_digest);
+    let gate_identity = inspect_group_member(&gate, argument_digest);
+    let mut wait = OwnerExitWait::new(&mut owner);
+
+    let result = recover_processes_same_boot_blocking(
+        &owner_identity,
+        &gate_identity,
+        None,
+        std::time::Duration::from_millis(1),
+        &mut wait,
+    );
+
+    assert!(matches!(
+        result,
+        Err(AviateSupervisorError::Timeout {
+            operation: "wait for recovered process group removal",
+        })
+    ));
+    assert_eq!(
+        wait.park_calls, 1,
+        "the group wait cannot restart the deadline"
+    );
+    assert!(
+        gate.is_running(),
+        "recovery does not stop the live gate group"
+    );
+    gate.stop_and_wait();
+}
+
+struct OwnerExitWait<'a> {
+    now: std::time::Instant,
+    owner: &'a mut ReapedChild,
+    park_calls: u32,
+}
+
+impl<'a> OwnerExitWait<'a> {
+    fn new(owner: &'a mut ReapedChild) -> Self {
+        Self {
+            now: std::time::Instant::now(),
+            owner,
+            park_calls: 0,
+        }
+    }
+}
+
+impl WaitControl for OwnerExitWait<'_> {
+    fn now(&mut self) -> std::time::Instant {
+        self.now
+    }
+
+    fn park_for_poll_blocking(&mut self, duration: std::time::Duration) {
+        self.park_calls = self.park_calls.wrapping_add(1);
+        self.now = self.now.checked_add(duration).expect("advance fake clock");
+        if self.park_calls == 1 {
+            self.owner.stop_and_wait();
+        }
+    }
+}
+
+fn spawn_group_member(arguments: &[String]) -> ReapedChild {
+    let mut command = std::process::Command::new(&arguments[0]);
+    command.arg(&arguments[1]).process_group(0);
+    ReapedChild::spawn(command)
+}
+
+fn inspect_group_member(
+    child: &ReapedChild,
+    argument_digest: flight_tune::Digest,
+) -> crate::document::ProcessIdentity {
+    inspection::inspect_process(child.id(), argument_digest)
+        .expect("inspect group member")
+        .expect("group member is live")
+}
+
+fn change_start_token(start: &mut ProcessStartIdentity) {
+    match start {
+        ProcessStartIdentity::Linux { start_ticks, .. } => {
+            *start_ticks = start_ticks.wrapping_add(1);
+        }
+        ProcessStartIdentity::MacOs { start_abstime, .. } => {
+            *start_abstime = start_abstime.wrapping_add(1);
+        }
+    }
+}
+
+struct ReapedChild {
+    child: std::process::Child,
+    reaped: bool,
+}
+
+impl ReapedChild {
+    fn spawn(mut command: std::process::Command) -> Self {
+        Self {
+            child: command.spawn().expect("spawn isolated group member"),
+            reaped: false,
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn is_running(&mut self) -> bool {
+        self.child
+            .try_wait()
+            .expect("inspect isolated group member")
+            .is_none()
+    }
+
+    fn stop_and_wait(&mut self) {
+        self.child.kill().expect("stop isolated group member");
+        self.child.wait().expect("reap isolated group member");
+        self.reaped = true;
+    }
+}
+
+impl Drop for ReapedChild {
+    fn drop(&mut self) {
+        if self.reaped {
+            return;
+        }
+        match self.child.kill() {
+            Ok(()) | Err(_) => {}
+        }
+        match self.child.wait() {
+            Ok(_) | Err(_) => {}
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/process/recovery/documents.rs
+++ b/tools/flight-tune-aviate/src/process/recovery/documents.rs
@@ -1,0 +1,335 @@
+use crate::AviateSupervisorError;
+use crate::document::{
+    BootIdentity, PROCESS_IDENTITY_NAME, ProcessIdentity, ProcessIdentityDocument,
+    RECOVERY_RECEIPT_NAME, RecoveryReceipt, SCHEMA_VERSION, SPAWN_INTENT_NAME, SpawnIntent,
+    TARGET_ATTESTATION_NAME, TERMINAL_RECEIPT_NAME, TargetAttestation, TerminalReceipt,
+};
+use crate::lease_store::LeaseStore;
+
+use super::{RecoveryOutcome, RecoveryRequest, RecoveryState, TargetEvidence};
+
+const DOCUMENT_NAMES: &[&str] = &[
+    SPAWN_INTENT_NAME,
+    PROCESS_IDENTITY_NAME,
+    TARGET_ATTESTATION_NAME,
+    TERMINAL_RECEIPT_NAME,
+    RECOVERY_RECEIPT_NAME,
+];
+
+pub(super) struct LoadedRecovery {
+    pub(super) state: RecoveryState,
+    terminal: Option<(TerminalReceipt, flight_tune::Digest)>,
+    boot_change: Option<(RecoveryReceipt, flight_tune::Digest)>,
+}
+
+pub(super) fn load(
+    store: &LeaseStore,
+    request: &RecoveryRequest,
+) -> Result<LoadedRecovery, AviateSupervisorError> {
+    let (intent, intent_digest): (SpawnIntent, _) = store.repair(SPAWN_INTENT_NAME)?;
+    let (processes, process_digest): (ProcessIdentityDocument, _) =
+        store.repair(PROCESS_IDENTITY_NAME)?;
+    validate_intent(request, &intent)?;
+    validate_state_digests(request, intent_digest, process_digest)?;
+    validate_processes(request, &intent, intent_digest, &processes)?;
+    let target = repair_target(store)?;
+    let terminal = store.repair_optional(TERMINAL_RECEIPT_NAME)?;
+    let boot_change = store.repair_optional(RECOVERY_RECEIPT_NAME)?;
+    store.finish_recovery_scan(DOCUMENT_NAMES)?;
+    if let Some(target) = &target {
+        validate_target(request, &intent, &processes, target)?;
+    }
+    Ok(LoadedRecovery {
+        state: RecoveryState {
+            intent,
+            intent_digest,
+            processes,
+            process_digest,
+            target,
+        },
+        terminal,
+        boot_change,
+    })
+}
+
+pub(super) fn existing_outcome(
+    request: &RecoveryRequest,
+    loaded: &LoadedRecovery,
+    current_boot: &BootIdentity,
+) -> Result<Option<RecoveryOutcome>, AviateSupervisorError> {
+    match (&loaded.terminal, &loaded.boot_change) {
+        (Some(_), Some(_)) => Err(AviateSupervisorError::invalid_document(
+            "process outcome",
+            "terminal and boot-change receipts both exist",
+        )),
+        (Some((receipt, digest)), None) => {
+            validate_terminal(request, &loaded.state, receipt)?;
+            Ok(Some(RecoveryOutcome::Terminal {
+                receipt_digest: *digest,
+            }))
+        }
+        (None, Some((receipt, digest))) => {
+            validate_boot_change(request, &loaded.state, receipt, current_boot)?;
+            Ok(Some(RecoveryOutcome::BootChange {
+                receipt_digest: *digest,
+            }))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+fn repair_target(store: &LeaseStore) -> Result<Option<TargetEvidence>, AviateSupervisorError> {
+    let repaired: Option<(TargetAttestation, _)> =
+        store.repair_optional(TARGET_ATTESTATION_NAME)?;
+    Ok(repaired.map(|(attestation, digest)| TargetEvidence {
+        attestation,
+        digest,
+    }))
+}
+
+fn validate_intent(
+    request: &RecoveryRequest,
+    intent: &SpawnIntent,
+) -> Result<(), AviateSupervisorError> {
+    let target_path = intent
+        .artifact_root
+        .path
+        .join(crate::artifact::TARGET_ARTIFACT);
+    let supervisor_path = intent
+        .artifact_root
+        .path
+        .join(crate::artifact::SUPERVISOR_ARTIFACT);
+    if intent.schema_version != SCHEMA_VERSION
+        || intent.run_intent_digest != request.run_intent_digest
+        || intent.supervisor_executable.digest != request.supervisor_executable_digest
+        || intent.target_executable.digest != request.target_executable_digest
+        || intent.supervisor_executable.path != supervisor_path
+        || intent.target_executable.path != target_path
+        || intent.cleanup_timeout_millis != request.cleanup_timeout_millis
+        || intent.correlation_nonce.is_zero()
+        || intent.release_secret_digest.is_zero()
+        || intent.target_argv_digest != target_argv_digest(intent)?
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "spawn intent",
+            "the durable spawn intent differs from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_state_digests(
+    request: &RecoveryRequest,
+    intent_digest: flight_tune::Digest,
+    process_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    if intent_digest != request.expected_spawn_intent_digest
+        || process_digest != request.expected_process_identity_digest
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "supervision attestation",
+            "the durable supervision digests differ from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_processes(
+    request: &RecoveryRequest,
+    intent: &SpawnIntent,
+    intent_digest: flight_tune::Digest,
+    processes: &ProcessIdentityDocument,
+) -> Result<(), AviateSupervisorError> {
+    let owner_argv = owner_argv_digest(request, intent)?;
+    let gate_argv = gate_argv_digest(intent)?;
+    let owner = &processes.supervisor;
+    let gate = &processes.target_gate;
+    if processes.schema_version != SCHEMA_VERSION
+        || processes.run_intent_digest != request.run_intent_digest
+        || processes.spawn_intent_digest != intent_digest
+        || processes.correlation_nonce != intent.correlation_nonce
+        || owner.executable != intent.supervisor_executable.path
+        || owner.executable_digest != request.supervisor_executable_digest
+        || !argv_matches(owner, owner_argv)
+        || gate.executable != intent.supervisor_executable.path
+        || gate.executable_digest != request.supervisor_executable_digest
+        || !argv_matches(gate, gate_argv)
+        || gate.parent_pid != owner.pid
+        || gate.pid == owner.pid
+        || gate.pid != gate.process_group
+        || gate.pid != gate.session_id
+        || gate.real_user_id != owner.real_user_id
+        || gate.start.boot_identity() != owner.start.boot_identity()
+        || !owner.start.boot_identity().is_valid()
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "process identity",
+            "the durable process identity differs from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target(
+    request: &RecoveryRequest,
+    intent: &SpawnIntent,
+    processes: &ProcessIdentityDocument,
+    evidence: &TargetEvidence,
+) -> Result<(), AviateSupervisorError> {
+    let value = &evidence.attestation;
+    let target = &value.target;
+    let gate = &processes.target_gate;
+    if value.schema_version != SCHEMA_VERSION
+        || value.run_intent_digest != request.run_intent_digest
+        || target.pid == gate.pid
+        || target.parent_pid != gate.pid
+        || target.process_group != gate.process_group
+        || target.session_id != gate.session_id
+        || target.real_user_id != gate.real_user_id
+        || target.start.boot_identity() != gate.start.boot_identity()
+        || target.executable != intent.target_executable.path
+        || target.executable_digest != request.target_executable_digest
+        || !argv_matches(target, intent.target_argv_digest)
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "target attestation",
+            "the target attestation differs from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_terminal(
+    request: &RecoveryRequest,
+    state: &RecoveryState,
+    terminal: &TerminalReceipt,
+) -> Result<(), AviateSupervisorError> {
+    let expected_target = state.target.as_ref().map(|target| target.digest);
+    if terminal.schema_version != SCHEMA_VERSION
+        || terminal.run_intent_digest != request.run_intent_digest
+        || terminal.spawn_intent_digest != state.intent_digest
+        || terminal.process_identity_digest != state.process_digest
+        || terminal.target_attestation_digest != expected_target
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "terminal receipt",
+            "the terminal receipt differs from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_boot_change(
+    request: &RecoveryRequest,
+    state: &RecoveryState,
+    receipt: &RecoveryReceipt,
+    current_boot: &BootIdentity,
+) -> Result<(), AviateSupervisorError> {
+    let expected_target = state.target.as_ref().map(|target| target.digest);
+    if receipt.schema_version != SCHEMA_VERSION
+        || receipt.run_intent_digest != request.run_intent_digest
+        || receipt.spawn_intent_digest != state.intent_digest
+        || receipt.process_identity_digest != state.process_digest
+        || receipt.target_attestation_digest != expected_target
+        || receipt.prior_boot_identity != state.processes.supervisor.start.boot_identity()
+        || !valid_boot_transition(
+            &receipt.prior_boot_identity,
+            &receipt.recovery_boot_identity,
+            current_boot,
+        )
+    {
+        return Err(AviateSupervisorError::invalid_document(
+            "recovery receipt",
+            "the boot-change receipt differs from the recovery request",
+        ));
+    }
+    Ok(())
+}
+
+fn valid_boot_transition(
+    prior: &BootIdentity,
+    recovery: &BootIdentity,
+    current: &BootIdentity,
+) -> bool {
+    prior != recovery
+        && current != prior
+        && prior.is_valid()
+        && recovery.is_valid()
+        && current.is_valid()
+}
+
+fn argv_matches(identity: &ProcessIdentity, expected: flight_tune::Digest) -> bool {
+    identity.launch_argv_digest == expected
+        && identity
+            .observed_argv_digest
+            .is_none_or(|actual| actual == expected)
+}
+
+fn target_argv_digest(intent: &SpawnIntent) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut arguments = Vec::with_capacity(intent.target_arguments.len().wrapping_add(1));
+    arguments.push(utf8_path(&intent.target_executable.path)?);
+    arguments.extend(intent.target_arguments.iter().cloned());
+    Ok(crate::inspection::digest_arguments(&arguments))
+}
+
+fn owner_argv_digest(
+    request: &RecoveryRequest,
+    intent: &SpawnIntent,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    argv_digest(
+        &intent.supervisor_executable.path,
+        &["supervise"],
+        &[&request.storage_root, &intent.runtime_root.path],
+    )
+}
+
+fn gate_argv_digest(intent: &SpawnIntent) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    argv_digest(&intent.supervisor_executable.path, &["gate"], &[])
+}
+
+fn argv_digest(
+    executable: &std::path::Path,
+    fixed: &[&str],
+    paths: &[&std::path::Path],
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut arguments = vec![utf8_path(executable)?];
+    arguments.extend(fixed.iter().map(|value| (*value).to_owned()));
+    for path in paths {
+        arguments.push(utf8_path(path)?);
+    }
+    Ok(crate::inspection::digest_arguments(&arguments))
+}
+
+fn utf8_path(path: &std::path::Path) -> Result<String, AviateSupervisorError> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| AviateSupervisorError::invalid_request("a recovery path is not UTF-8"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BootIdentity, valid_boot_transition};
+
+    #[test]
+    fn boot_change_replay_rejects_the_prior_boot() {
+        let prior = linux_boot("11111111-1111-1111-1111-111111111111");
+        let recovery = linux_boot("22222222-2222-2222-2222-222222222222");
+        let later = linux_boot("33333333-3333-3333-3333-333333333333");
+
+        assert!(!valid_boot_transition(&prior, &recovery, &prior));
+        assert!(valid_boot_transition(&prior, &recovery, &recovery));
+        assert!(valid_boot_transition(&prior, &recovery, &later));
+        assert!(!valid_boot_transition(&prior, &prior, &later));
+        assert!(!valid_boot_transition(
+            &linux_boot("invalid"),
+            &recovery,
+            &later
+        ));
+    }
+
+    fn linux_boot(value: &str) -> BootIdentity {
+        BootIdentity::Linux {
+            boot_id: value.to_owned(),
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/process/startup.rs
+++ b/tools/flight-tune-aviate/src/process/startup.rs
@@ -1,0 +1,461 @@
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use super::SupervisedProcessRequest;
+use crate::AviateSupervisorError;
+use crate::document::ProcessIdentity;
+use crate::protocol::encode_line;
+use crate::supervisor::SupervisorBootstrap;
+
+#[path = "startup/attestation.rs"]
+mod attestation;
+#[path = "startup/prepared.rs"]
+mod prepared;
+#[path = "startup/resources.rs"]
+mod resources;
+
+use resources::LaunchArtifacts;
+
+pub(crate) use prepared::{
+    PreparedLaunch, cancel_prepared, cancel_supported, prepare_supported, prepared_attestation,
+    release_supported,
+};
+
+fn write_bootstrap(
+    parent_lifetime: &mut ChildStdin,
+    bootstrap: &SupervisorBootstrap,
+) -> Result<(), AviateSupervisorError> {
+    parent_lifetime
+        .write_all(&encode_line(bootstrap)?)
+        .and_then(|()| parent_lifetime.flush())
+        .map_err(|source| process_io("write owner bootstrap", source))
+}
+
+fn spawn_owner(
+    request: &SupervisedProcessRequest,
+    artifacts: &LaunchArtifacts,
+) -> Result<super::reaper::ReapableOwner, AviateSupervisorError> {
+    let mut command = Command::new(&artifacts.supervisor.path);
+    command
+        .arg("supervise")
+        .arg(&request.storage_root)
+        .arg(&request.runtime_root)
+        .env_clear()
+        .current_dir(&artifacts.root.path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    super::reaper::ReapableOwner::spawn(|| {
+        command
+            .spawn()
+            .map_err(|source| process_io("spawn exact process owner", source))
+    })
+}
+
+fn wait_parent_message<T: for<'de> serde::Deserialize<'de>>(
+    listener: &std::os::unix::net::UnixListener,
+    supervisor: &mut Child,
+    timeout: Duration,
+) -> Result<T, AviateSupervisorError> {
+    let deadline = checked_deadline(timeout, "wait for owner readiness")?;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                return crate::protocol::read_message_until_blocking(stream, deadline);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(source) => return Err(process_io("accept owner readiness", source)),
+        }
+        reject_exited_supervisor(supervisor)?;
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "wait for owner readiness",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn reject_exited_supervisor(supervisor: &mut Child) -> Result<(), AviateSupervisorError> {
+    if let Some(identity) = crate::inspection::inspect_lifetime(supervisor.id())?
+        && identity.is_zombie
+    {
+        let status = supervisor
+            .wait()
+            .map_err(|source| process_io("reap failed process owner", source))?;
+        return Err(AviateSupervisorError::SupervisorExited { status });
+    }
+    Ok(())
+}
+
+pub(super) fn verify_live(
+    expected: &ProcessIdentity,
+    process: &'static str,
+) -> Result<(), AviateSupervisorError> {
+    let Some(actual) =
+        crate::inspection::inspect_process(expected.pid, expected.launch_argv_digest)?
+    else {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: format!("the exact {process} process is not running"),
+        });
+    };
+    crate::inspection::validate_same_lifetime(expected, &actual, process)?;
+    if actual != *expected {
+        return Err(AviateSupervisorError::identity_mismatch(format!(
+            "the exact {process} process identity changed"
+        )));
+    }
+    let lifetime = crate::inspection::inspect_lifetime(expected.pid)?;
+    if lifetime.is_none_or(|identity| identity.is_zombie) {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: format!("the exact {process} process is not running"),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn wait_for_supervisor_terminal(
+    supervisor: &mut Child,
+    identity: &ProcessIdentity,
+    timeout: Duration,
+) -> Result<(), AviateSupervisorError> {
+    let deadline = checked_deadline(timeout, "wait for supervisor cleanup")?;
+    loop {
+        let actual = crate::inspection::inspect_lifetime(identity.pid)?;
+        if terminal_owner_state(supervisor, identity, actual)? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "wait for supervisor cleanup",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn terminal_owner_state(
+    supervisor: &mut Child,
+    identity: &ProcessIdentity,
+    actual: Option<crate::inspection::LifetimeIdentity>,
+) -> Result<bool, AviateSupervisorError> {
+    match actual {
+        Some(actual)
+            if actual.pid == identity.pid
+                && actual.process_group == identity.process_group
+                && actual.session_id == identity.session_id
+                && actual.start == identity.start
+                && actual.is_zombie =>
+        {
+            supervisor
+                .wait()
+                .map_err(|source| process_io("reap exact process owner", source))?;
+            Ok(true)
+        }
+        Some(actual)
+            if actual.pid == identity.pid
+                && actual.process_group == identity.process_group
+                && actual.session_id == identity.session_id
+                && actual.start == identity.start =>
+        {
+            Ok(false)
+        }
+        Some(_) => Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the owner process identifier names another lifetime".to_owned(),
+        }),
+        None => {
+            supervisor
+                .wait()
+                .map_err(|source| process_io("reap exact process owner", source))?;
+            Ok(true)
+        }
+    }
+}
+
+fn wait_for_unattested_supervisor(
+    supervisor: &mut Child,
+    timeout: Duration,
+) -> Result<std::process::ExitStatus, AviateSupervisorError> {
+    let deadline = checked_deadline(timeout, "clean failed process owner")?;
+    loop {
+        match crate::inspection::inspect_lifetime(supervisor.id())? {
+            Some(identity) if !identity.is_zombie => {}
+            Some(_) | None => {
+                return supervisor
+                    .wait()
+                    .map_err(|source| process_io("reap failed process owner", source));
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "clean failed process owner",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn validate_supervisor_cleanup_status(
+    status: std::process::ExitStatus,
+) -> Result<(), AviateSupervisorError> {
+    if status.success() {
+        Ok(())
+    } else {
+        Err(AviateSupervisorError::SupervisorExited { status })
+    }
+}
+
+fn validate_request(request: &SupervisedProcessRequest) -> Result<(), AviateSupervisorError> {
+    if request.supervisor_executable_digest.is_zero()
+        || request.target_executable_digest.is_zero()
+        || request.run_intent_digest.is_zero()
+        || request.startup_timeout.is_zero()
+        || request.cleanup_timeout.is_zero()
+    {
+        return Err(AviateSupervisorError::invalid_request(
+            "the process supervision request is incomplete",
+        ));
+    }
+    duration_millis(request.startup_timeout)?;
+    duration_millis(request.cleanup_timeout)?;
+    for path in [
+        &request.supervisor_executable,
+        &request.target_executable,
+        &request.storage_root,
+        &request.runtime_root,
+        &request.artifact_root,
+        &request.target_current_directory,
+    ] {
+        if !is_normal_absolute_path(path) {
+            return Err(AviateSupervisorError::invalid_request(
+                "a process supervision path is not normalized absolute UTF-8",
+            ));
+        }
+    }
+    require_canonical_existing(&request.supervisor_executable)?;
+    require_canonical_existing(&request.target_executable)?;
+    require_canonical_existing(&request.runtime_root)?;
+    require_canonical_existing(&request.target_current_directory)?;
+    validate_disjoint_roots(request)
+}
+
+fn is_normal_absolute_path(path: &Path) -> bool {
+    let Some(text) = path.to_str() else {
+        return false;
+    };
+    path.is_absolute()
+        && !text
+            .split(std::path::MAIN_SEPARATOR)
+            .any(|component| matches!(component, "." | ".."))
+        && path.components().all(|component| {
+            matches!(
+                component,
+                std::path::Component::RootDir | std::path::Component::Normal(_)
+            )
+        })
+}
+
+fn validate_disjoint_roots(
+    request: &SupervisedProcessRequest,
+) -> Result<(), AviateSupervisorError> {
+    let roots = [
+        resolve_root(&request.storage_root)?,
+        resolve_root(&request.runtime_root)?,
+        resolve_root(&request.artifact_root)?,
+        resolve_root(&request.target_current_directory)?,
+    ];
+    for (index, root) in roots.iter().enumerate() {
+        for other in roots.iter().skip(index.wrapping_add(1)) {
+            if root.starts_with(other) || other.starts_with(root) {
+                return Err(AviateSupervisorError::invalid_request(
+                    "a private root overlaps another root or the target current directory",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn require_canonical_existing(path: &Path) -> Result<(), AviateSupervisorError> {
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|source| crate::inspection::io_error("canonicalize launch path", path, source))?;
+    if canonical != path {
+        return Err(AviateSupervisorError::invalid_request(
+            "an existing launch path is not canonical",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_root(path: &Path) -> Result<std::path::PathBuf, AviateSupervisorError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {
+            require_canonical_existing(path)?;
+            Ok(path.to_path_buf())
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            let parent = path.parent().ok_or_else(|| {
+                AviateSupervisorError::invalid_request("an absent root has no parent")
+            })?;
+            require_canonical_existing(parent)?;
+            Ok(path.to_path_buf())
+        }
+        Err(source) => Err(crate::inspection::io_error(
+            "inspect launch root",
+            path,
+            source,
+        )),
+    }
+}
+
+fn cleanup_unbootstrapped<T>(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    artifacts: &LaunchArtifacts,
+    supervisor: &mut Child,
+    timeout: Duration,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let owner_cleanup = match wait_for_unattested_supervisor(supervisor, timeout) {
+        Ok(status) => validate_supervisor_cleanup_status(status),
+        Err(cleanup) => return combine_cleanup_results(source, Err(cleanup)),
+    };
+    let local_cleanup = cleanup_parent_resources(listener, listener_path, artifacts);
+    combine_cleanup_results(source, merge_cleanup(owner_cleanup, local_cleanup))
+}
+
+fn cleanup_started_failure<T>(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    artifacts: &LaunchArtifacts,
+    supervisor: &mut Child,
+    timeout: Duration,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let owner_cleanup = match wait_for_unattested_supervisor(supervisor, timeout) {
+        Ok(status) => validate_supervisor_cleanup_status(status),
+        Err(cleanup) => return combine_cleanup_results(source, Err(cleanup)),
+    };
+    let local_cleanup = cleanup_parent_resources_after_owner(listener, listener_path, artifacts);
+    combine_cleanup_results(source, merge_cleanup(owner_cleanup, local_cleanup))
+}
+
+fn cleanup_unstarted<T>(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    artifacts: &LaunchArtifacts,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    combine_cleanup_results(
+        source,
+        cleanup_parent_resources(listener, listener_path, artifacts),
+    )
+}
+
+fn cleanup_socket_only<T>(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    drop(listener);
+    combine_cleanup_results(
+        source,
+        crate::runtime_files::remove_exact_socket(listener_path),
+    )
+}
+
+fn cleanup_parent_resources(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    artifacts: &LaunchArtifacts,
+) -> Result<(), AviateSupervisorError> {
+    drop(listener);
+    let socket = crate::runtime_files::remove_exact_socket(listener_path);
+    let artifacts = resources::cleanup_launch_artifacts(artifacts);
+    merge_cleanup(socket, artifacts)
+}
+
+fn cleanup_parent_resources_after_owner(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: &Path,
+    artifacts: &LaunchArtifacts,
+) -> Result<(), AviateSupervisorError> {
+    drop(listener);
+    let socket = crate::runtime_files::remove_exact_socket(listener_path);
+    let artifacts = resources::cleanup_launch_artifacts_after_owner(artifacts);
+    merge_cleanup(socket, artifacts)
+}
+
+fn merge_cleanup(
+    first: Result<(), AviateSupervisorError>,
+    second: Result<(), AviateSupervisorError>,
+) -> Result<(), AviateSupervisorError> {
+    match (first, second) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(first), Err(second)) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(first),
+            cleanup: Box::new(second),
+        }),
+    }
+}
+
+fn combine_cleanup_results<T>(
+    source: AviateSupervisorError,
+    cleanup: Result<(), AviateSupervisorError>,
+) -> Result<T, AviateSupervisorError> {
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+pub(super) fn duration_millis(duration: Duration) -> Result<u64, AviateSupervisorError> {
+    let milliseconds = u64::try_from(duration.as_millis()).map_err(|_| {
+        AviateSupervisorError::invalid_request("a process timeout exceeds supported limits")
+    })?;
+    if milliseconds == 0 {
+        return Err(AviateSupervisorError::invalid_request(
+            "a process timeout is less than one millisecond",
+        ));
+    }
+    Ok(milliseconds)
+}
+
+fn checked_deadline(
+    timeout: Duration,
+    operation: &'static str,
+) -> Result<Instant, AviateSupervisorError> {
+    Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout { operation })
+}
+
+fn random_release_secret() -> Result<String, AviateSupervisorError> {
+    use std::io::Read as _;
+
+    let path = Path::new("/dev/urandom");
+    let mut source = std::fs::File::open(path).map_err(|error| AviateSupervisorError::Io {
+        operation: "open parent random source",
+        path: path.to_path_buf(),
+        source: error,
+    })?;
+    let mut bytes = [0_u8; 32];
+    source
+        .read_exact(&mut bytes)
+        .map_err(|error| AviateSupervisorError::Io {
+            operation: "read parent random source",
+            path: path.to_path_buf(),
+            source: error,
+        })?;
+    Ok(flight_tune::Digest::from_bytes(bytes).to_string())
+}
+
+fn process_io(operation: &'static str, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::ProcessIo { operation, source }
+}

--- a/tools/flight-tune-aviate/src/process/startup/attestation.rs
+++ b/tools/flight-tune-aviate/src/process/startup/attestation.rs
@@ -1,0 +1,382 @@
+use std::path::Path;
+
+use super::SupervisedProcessRequest;
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::document::{
+    PROCESS_IDENTITY_NAME, ProcessIdentity, ProcessIdentityDocument, SCHEMA_VERSION,
+    SPAWN_INTENT_NAME, SpawnIntent, TARGET_ATTESTATION_NAME, TargetAttestation, TargetStdio,
+};
+use crate::inspection::{LifetimeIdentity, ProcessGroupSnapshot};
+use crate::lease_store::{digest_bytes, read_without_writer};
+use crate::process::{RecoveryRequest, SupervisionAttestation};
+use crate::protocol::{ArmedMessage, TargetReadyMessage};
+
+pub(super) fn validate_armed(
+    request: &SupervisedProcessRequest,
+    owner_pid: u32,
+    message: &ArmedMessage,
+    release_secret: &str,
+) -> Result<SupervisionAttestation, AviateSupervisorError> {
+    let evidence = read_supervision_evidence(request)?;
+    if message.correlation_nonce != evidence.processes.correlation_nonce
+        || message.spawn_intent_digest != evidence.intent_digest
+        || message.process_identity_digest != evidence.process_digest
+        || digest_bytes(release_secret.as_bytes()) != evidence.intent.release_secret_digest
+    {
+        return Err(invalid_process_document(
+            "the armed message differs from the durable supervision evidence",
+        ));
+    }
+    validate_supervision_live(request, owner_pid, &evidence)?;
+    let snapshot =
+        crate::inspection::process_group_snapshot(evidence.processes.target_gate.process_group)?;
+    validate_armed_group(&snapshot, &evidence.processes.target_gate)?;
+    Ok(SupervisionAttestation {
+        schema_version: crate::process::SUPERVISION_ATTESTATION_SCHEMA_VERSION,
+        run_intent_digest: request.run_intent_digest,
+        spawn_intent_digest: evidence.intent_digest,
+        process_identity_digest: evidence.process_digest,
+        supervisor_identity: evidence.processes.supervisor,
+        target_gate_identity: evidence.processes.target_gate,
+        recovery_request: RecoveryRequest {
+            schema_version: crate::process::RECOVERY_REQUEST_SCHEMA_VERSION,
+            storage_root: request.storage_root.clone(),
+            run_intent_digest: request.run_intent_digest,
+            supervisor_executable_digest: request.supervisor_executable_digest,
+            target_executable_digest: request.target_executable_digest,
+            expected_spawn_intent_digest: evidence.intent_digest,
+            expected_process_identity_digest: evidence.process_digest,
+            cleanup_timeout_millis: duration_millis(request.cleanup_timeout)?,
+        },
+    })
+}
+
+pub(super) fn validate_target_ready(
+    request: &SupervisedProcessRequest,
+    message: &TargetReadyMessage,
+    expected_supervisor: &ProcessIdentity,
+) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let evidence = read_supervision_evidence(request)?;
+    validate_supervision_live(request, expected_supervisor.pid, &evidence)?;
+    if evidence.processes.supervisor != *expected_supervisor
+        || message.correlation_nonce != evidence.processes.correlation_nonce
+        || message.process_identity_digest != evidence.process_digest
+    {
+        return Err(invalid_process_document(
+            "the target-ready message differs from the durable supervision evidence",
+        ));
+    }
+    let (attestation, digest): (TargetAttestation, _) =
+        read_without_writer(&request.storage_root, TARGET_ATTESTATION_NAME)?;
+    if digest != message.target_attestation_digest {
+        return Err(invalid_process_document(
+            "the target-ready message has a different target attestation digest",
+        ));
+    }
+    validate_target_attestation(request, &evidence, &attestation)?;
+    Ok(attestation.target)
+}
+
+struct SupervisionEvidence {
+    intent: SpawnIntent,
+    intent_digest: flight_tune::Digest,
+    processes: ProcessIdentityDocument,
+    process_digest: flight_tune::Digest,
+}
+
+fn read_supervision_evidence(
+    request: &SupervisedProcessRequest,
+) -> Result<SupervisionEvidence, AviateSupervisorError> {
+    let (intent, intent_digest) = read_without_writer(&request.storage_root, SPAWN_INTENT_NAME)?;
+    validate_spawn_intent(request, &intent)?;
+    let (processes, process_digest) =
+        read_without_writer(&request.storage_root, PROCESS_IDENTITY_NAME)?;
+    validate_process_document(request, &intent, intent_digest, &processes)?;
+    Ok(SupervisionEvidence {
+        intent,
+        intent_digest,
+        processes,
+        process_digest,
+    })
+}
+
+fn validate_spawn_intent(
+    request: &SupervisedProcessRequest,
+    intent: &SpawnIntent,
+) -> Result<(), AviateSupervisorError> {
+    let target_argv =
+        target_argv_digest(&intent.target_executable.path, &request.target_arguments)?;
+    let environment = crate::supervisor::config::digest_environment(&request.target_environment);
+    let current_directory = artifact::inspect_directory(&request.target_current_directory, false)?;
+    let runtime = artifact::inspect_directory(&request.runtime_root, true)?;
+    if intent.schema_version != SCHEMA_VERSION
+        || intent.run_intent_digest != request.run_intent_digest
+        || intent.supervisor_executable.digest != request.supervisor_executable_digest
+        || intent.target_executable.digest != request.target_executable_digest
+        || intent.target_arguments != request.target_arguments
+        || intent.target_argv_digest != target_argv
+        || intent.target_environment_digest != environment
+        || intent.target_current_directory != current_directory
+        || intent.runtime_root != runtime
+        || intent.artifact_root.path != request.artifact_root
+        || intent.target_stdio != TargetStdio::Null
+        || intent.target_process_contract != request.target_process_contract
+        || intent.cleanup_timeout_millis != duration_millis(request.cleanup_timeout)?
+        || intent.correlation_nonce.is_zero()
+        || intent.release_secret_digest.is_zero()
+    {
+        return Err(invalid_spawn_intent(
+            "the durable spawn intent differs from the launch request",
+        ));
+    }
+    validate_staged_artifacts(intent)
+}
+
+fn duration_millis(duration: std::time::Duration) -> Result<u64, AviateSupervisorError> {
+    u64::try_from(duration.as_millis()).map_err(|_| {
+        AviateSupervisorError::invalid_request("the cleanup timeout exceeds its encoded limit")
+    })
+}
+
+fn validate_staged_artifacts(intent: &SpawnIntent) -> Result<(), AviateSupervisorError> {
+    artifact::validate_directory(&intent.artifact_root, true)?;
+    for (name, expected) in [
+        (
+            crate::artifact::SUPERVISOR_ARTIFACT,
+            &intent.supervisor_executable,
+        ),
+        (crate::artifact::TARGET_ARTIFACT, &intent.target_executable),
+    ] {
+        if expected.path != intent.artifact_root.path.join(name)
+            || artifact::inspect_staged(&expected.path, expected.digest)? != *expected
+        {
+            return Err(AviateSupervisorError::identity_mismatch(
+                "a durable staged executable identity changed",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_process_document(
+    request: &SupervisedProcessRequest,
+    intent: &SpawnIntent,
+    intent_digest: flight_tune::Digest,
+    processes: &ProcessIdentityDocument,
+) -> Result<(), AviateSupervisorError> {
+    let parent = current_lifetime()?;
+    let owner_argv = owner_argv_digest(&intent.supervisor_executable.path, request)?;
+    let gate_argv = gate_argv_digest(&intent.supervisor_executable.path)?;
+    if processes.schema_version != SCHEMA_VERSION
+        || processes.run_intent_digest != request.run_intent_digest
+        || processes.spawn_intent_digest != intent_digest
+        || processes.correlation_nonce != intent.correlation_nonce
+        || processes.supervisor.parent_pid != std::process::id()
+        || processes.supervisor.session_id != parent.session_id
+        || processes.supervisor.real_user_id != parent.real_user_id
+        || processes.supervisor.start.boot_identity() != parent.start.boot_identity()
+        || processes.supervisor.executable != intent.supervisor_executable.path
+        || processes.supervisor.executable_digest != intent.supervisor_executable.digest
+        || processes.supervisor.launch_argv_digest != owner_argv
+        || processes.target_gate.parent_pid != processes.supervisor.pid
+        || processes.target_gate.pid != processes.target_gate.process_group
+        || processes.target_gate.pid != processes.target_gate.session_id
+        || processes.target_gate.real_user_id != parent.real_user_id
+        || processes.target_gate.start.boot_identity() != parent.start.boot_identity()
+        || processes.target_gate.executable != intent.supervisor_executable.path
+        || processes.target_gate.executable_digest != intent.supervisor_executable.digest
+        || processes.target_gate.launch_argv_digest != gate_argv
+    {
+        return Err(invalid_process_document(
+            "the durable owner or launch-gate identity is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_supervision_live(
+    request: &SupervisedProcessRequest,
+    owner_pid: u32,
+    evidence: &SupervisionEvidence,
+) -> Result<(), AviateSupervisorError> {
+    if evidence.processes.supervisor.pid != owner_pid {
+        return Err(invalid_process_document(
+            "the durable owner PID differs from the held child",
+        ));
+    }
+    validate_live_process(&evidence.processes.supervisor, "owner")?;
+    validate_live_process(&evidence.processes.target_gate, "launch gate")?;
+    validate_process_document(
+        request,
+        &evidence.intent,
+        evidence.intent_digest,
+        &evidence.processes,
+    )
+}
+
+fn validate_live_process(
+    expected: &ProcessIdentity,
+    process: &'static str,
+) -> Result<(), AviateSupervisorError> {
+    let actual = crate::inspection::inspect_process(expected.pid, expected.launch_argv_digest)?
+        .ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch(format!("the exact {process} is absent"))
+        })?;
+    crate::inspection::validate_same_lifetime(expected, &actual, process)?;
+    if actual != *expected {
+        return Err(AviateSupervisorError::identity_mismatch(format!(
+            "the exact {process} identity changed"
+        )));
+    }
+    let lifetime = crate::inspection::inspect_lifetime(expected.pid)?.ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch(format!("the exact {process} is absent"))
+    })?;
+    if lifetime.is_zombie {
+        return Err(AviateSupervisorError::identity_mismatch(format!(
+            "the exact {process} is a zombie"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_armed_group(
+    snapshot: &ProcessGroupSnapshot,
+    expected_gate: &ProcessIdentity,
+) -> Result<(), AviateSupervisorError> {
+    if snapshot.raw_pids != [expected_gate.pid]
+        || !snapshot.exited.is_empty()
+        || !snapshot.unclassified_pids.is_empty()
+        || snapshot.observed.len() != 1
+        || !same_lifetime(&snapshot.observed[0], expected_gate)
+        || snapshot.observed[0].is_zombie
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the armed launch-gate group has unexpected members",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target_attestation(
+    request: &SupervisedProcessRequest,
+    evidence: &SupervisionEvidence,
+    attestation: &TargetAttestation,
+) -> Result<(), AviateSupervisorError> {
+    let target = &attestation.target;
+    if attestation.schema_version != SCHEMA_VERSION
+        || attestation.run_intent_digest != request.run_intent_digest
+        || target.parent_pid != evidence.processes.target_gate.pid
+        || target.process_group != evidence.processes.target_gate.process_group
+        || target.session_id != evidence.processes.target_gate.session_id
+        || target.real_user_id != evidence.processes.target_gate.real_user_id
+        || target.start.boot_identity() != evidence.processes.target_gate.start.boot_identity()
+        || target.executable != evidence.intent.target_executable.path
+        || target.executable_digest != request.target_executable_digest
+        || target.launch_argv_digest != evidence.intent.target_argv_digest
+    {
+        return Err(invalid_process_document(
+            "the target attestation differs from the authorized launch",
+        ));
+    }
+    validate_live_process(target, "target")?;
+    let snapshot = crate::inspection::process_group_snapshot(target.process_group)?;
+    validate_ready_group(&snapshot, &evidence.processes.target_gate, target)
+}
+
+fn validate_ready_group(
+    snapshot: &ProcessGroupSnapshot,
+    gate: &ProcessIdentity,
+    target: &ProcessIdentity,
+) -> Result<(), AviateSupervisorError> {
+    let has_gate = snapshot
+        .observed
+        .iter()
+        .any(|actual| same_lifetime(actual, gate));
+    let has_target = snapshot
+        .observed
+        .iter()
+        .any(|actual| same_lifetime(actual, target));
+    if !has_gate
+        || !has_target
+        || !snapshot.exited.is_empty()
+        || !snapshot.unclassified_pids.is_empty()
+        || snapshot.observed.iter().any(|member| {
+            member.is_zombie
+                || member.session_id != gate.session_id
+                || member.real_user_id != gate.real_user_id
+        })
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the ready target group is incomplete or not live",
+        ));
+    }
+    Ok(())
+}
+
+fn current_lifetime() -> Result<LifetimeIdentity, AviateSupervisorError> {
+    crate::inspection::inspect_lifetime(std::process::id())?.ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch("the parent process identity is unavailable")
+    })
+}
+
+fn same_lifetime(actual: &LifetimeIdentity, expected: &ProcessIdentity) -> bool {
+    actual.pid == expected.pid
+        && actual.process_group == expected.process_group
+        && actual.session_id == expected.session_id
+        && actual.parent_pid == expected.parent_pid
+        && actual.real_user_id == expected.real_user_id
+        && actual.start == expected.start
+}
+
+fn owner_argv_digest(
+    executable: &Path,
+    request: &SupervisedProcessRequest,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    argv_digest(
+        executable,
+        &["supervise"],
+        &[&request.storage_root, &request.runtime_root],
+    )
+}
+
+fn gate_argv_digest(executable: &Path) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    argv_digest(executable, &["gate"], &[])
+}
+
+fn argv_digest(
+    executable: &Path,
+    fixed: &[&str],
+    paths: &[&Path],
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut arguments = vec![utf8_path(executable)?];
+    arguments.extend(fixed.iter().map(|value| (*value).to_owned()));
+    for path in paths {
+        arguments.push(utf8_path(path)?);
+    }
+    Ok(crate::inspection::digest_arguments(&arguments))
+}
+
+fn target_argv_digest(
+    executable: &Path,
+    arguments: &[String],
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let mut argv = Vec::with_capacity(arguments.len().wrapping_add(1));
+    argv.push(utf8_path(executable)?);
+    argv.extend(arguments.iter().cloned());
+    Ok(crate::inspection::digest_arguments(&argv))
+}
+
+fn utf8_path(path: &Path) -> Result<String, AviateSupervisorError> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| AviateSupervisorError::invalid_request("a launch path is not UTF-8"))
+}
+
+fn invalid_spawn_intent(detail: &'static str) -> AviateSupervisorError {
+    AviateSupervisorError::invalid_document("spawn intent", detail)
+}
+
+fn invalid_process_document(detail: &'static str) -> AviateSupervisorError {
+    AviateSupervisorError::invalid_document("process identity", detail)
+}

--- a/tools/flight-tune-aviate/src/process/startup/prepared.rs
+++ b/tools/flight-tune-aviate/src/process/startup/prepared.rs
@@ -1,0 +1,317 @@
+use std::io::Write as _;
+use std::process::ChildStdin;
+
+use super::resources::LaunchArtifacts;
+use super::{
+    attestation, cleanup_socket_only, cleanup_started_failure, cleanup_unbootstrapped,
+    cleanup_unstarted, random_release_secret, spawn_owner, wait_parent_message, write_bootstrap,
+};
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::document::ProcessIdentity;
+use crate::process::reaper::ReapableOwner;
+use crate::process::{
+    ManagedAviateProcess, RecoveryOutcome, SupervisedProcessRequest, SupervisionAttestation,
+};
+use crate::protocol::{
+    ArmedMessage, ReleaseMessage, TargetReadyMessage, TargetReleaseMessage, encode_line,
+};
+use crate::runtime_files::{PARENT_READY_SOCKET, socket_path};
+use crate::supervisor::SupervisorBootstrap;
+
+pub(crate) struct PreparedLaunch {
+    request: SupervisedProcessRequest,
+    listener: std::os::unix::net::UnixListener,
+    supervisor: Option<ReapableOwner>,
+    parent_lifetime: Option<ChildStdin>,
+    release_secret: String,
+    correlation_nonce: flight_tune::Digest,
+    attestation: SupervisionAttestation,
+}
+
+impl Drop for PreparedLaunch {
+    fn drop(&mut self) {
+        self.parent_lifetime.take();
+    }
+}
+
+pub(crate) fn prepare_supported(
+    request: SupervisedProcessRequest,
+) -> Result<PreparedLaunch, AviateSupervisorError> {
+    super::validate_request(&request)?;
+    crate::runtime_files::validate_private_root(&request.runtime_root)?;
+    crate::runtime_files::require_entries(&request.runtime_root, &[])?;
+    let current_directory = artifact::inspect_directory(&request.target_current_directory, false)?;
+    let runtime = artifact::inspect_directory(&request.runtime_root, true)?;
+    let release_secret = random_release_secret()?;
+    let release_digest = crate::lease_store::digest_bytes(release_secret.as_bytes());
+    let listener_path = socket_path(&request.runtime_root, PARENT_READY_SOCKET);
+    let listener = crate::runtime_files::bind_socket(&listener_path)?;
+    let artifacts = match super::resources::stage_launch_artifacts(&request) {
+        Ok(artifacts) => artifacts,
+        Err(source) => return cleanup_socket_only(listener, &listener_path, source),
+    };
+    let bootstrap = match super::resources::build_bootstrap(
+        &request,
+        &artifacts,
+        runtime,
+        current_directory,
+        release_digest,
+    ) {
+        Ok(bootstrap) => bootstrap,
+        Err(source) => return cleanup_unstarted(listener, &listener_path, &artifacts, source),
+    };
+    prepare_staged(request, artifacts, listener, bootstrap, release_secret)
+}
+
+fn prepare_staged(
+    request: SupervisedProcessRequest,
+    artifacts: LaunchArtifacts,
+    listener: std::os::unix::net::UnixListener,
+    bootstrap: SupervisorBootstrap,
+    release_secret: String,
+) -> Result<PreparedLaunch, AviateSupervisorError> {
+    let listener_path = socket_path(&request.runtime_root, PARENT_READY_SOCKET);
+    let mut supervisor = match spawn_owner(&request, &artifacts) {
+        Ok(supervisor) => supervisor,
+        Err(source) => return cleanup_unstarted(listener, &listener_path, &artifacts, source),
+    };
+    let Some(mut parent_lifetime) = supervisor.child_mut()?.stdin.take() else {
+        return cleanup_missing_pipe(listener, listener_path, artifacts, supervisor, &request);
+    };
+    if let Err(source) = write_bootstrap(&mut parent_lifetime, &bootstrap) {
+        drop(parent_lifetime);
+        return cleanup_unbootstrapped(
+            listener,
+            &listener_path,
+            &artifacts,
+            supervisor.child_mut()?,
+            request.cleanup_timeout,
+            source,
+        );
+    }
+    finish_prepare(
+        request,
+        artifacts,
+        listener,
+        supervisor,
+        parent_lifetime,
+        release_secret,
+    )
+}
+
+fn cleanup_missing_pipe(
+    listener: std::os::unix::net::UnixListener,
+    listener_path: std::path::PathBuf,
+    artifacts: LaunchArtifacts,
+    mut supervisor: ReapableOwner,
+    request: &SupervisedProcessRequest,
+) -> Result<PreparedLaunch, AviateSupervisorError> {
+    cleanup_unbootstrapped(
+        listener,
+        &listener_path,
+        &artifacts,
+        supervisor.child_mut()?,
+        request.cleanup_timeout,
+        AviateSupervisorError::protocol("the owner parent-lifetime pipe is missing"),
+    )
+}
+
+fn finish_prepare(
+    request: SupervisedProcessRequest,
+    artifacts: LaunchArtifacts,
+    listener: std::os::unix::net::UnixListener,
+    mut supervisor: ReapableOwner,
+    parent_lifetime: ChildStdin,
+    release_secret: String,
+) -> Result<PreparedLaunch, AviateSupervisorError> {
+    let armed: ArmedMessage =
+        match wait_parent_message(&listener, supervisor.child_mut()?, request.startup_timeout) {
+            Ok(message) => message,
+            Err(source) => {
+                drop(parent_lifetime);
+                return cleanup_started_failure(
+                    listener,
+                    &socket_path(&request.runtime_root, PARENT_READY_SOCKET),
+                    &artifacts,
+                    supervisor.child_mut()?,
+                    request.cleanup_timeout,
+                    source,
+                );
+            }
+        };
+    let attestation =
+        match attestation::validate_armed(&request, supervisor.id()?, &armed, &release_secret) {
+            Ok(value) => value,
+            Err(source) => {
+                drop(parent_lifetime);
+                return cleanup_started_failure(
+                    listener,
+                    &socket_path(&request.runtime_root, PARENT_READY_SOCKET),
+                    &artifacts,
+                    supervisor.child_mut()?,
+                    request.cleanup_timeout,
+                    source,
+                );
+            }
+        };
+    Ok(PreparedLaunch {
+        request,
+        listener,
+        supervisor: Some(supervisor),
+        parent_lifetime: Some(parent_lifetime),
+        release_secret,
+        correlation_nonce: armed.correlation_nonce,
+        attestation,
+    })
+}
+
+pub(crate) fn prepared_attestation(launch: &PreparedLaunch) -> &SupervisionAttestation {
+    &launch.attestation
+}
+
+pub(crate) fn cancel_prepared(launch: &mut PreparedLaunch) {
+    launch.parent_lifetime.take();
+    tracing::warn!(
+        supervisor_pid = launch.attestation.supervisor_identity.pid,
+        "prepared Aviate launch dropped; target release remains closed"
+    );
+}
+
+pub(crate) fn cancel_supported(
+    mut launch: PreparedLaunch,
+) -> Result<RecoveryOutcome, AviateSupervisorError> {
+    launch.parent_lifetime.take();
+    let supervisor = launch
+        .supervisor
+        .as_mut()
+        .ok_or_else(|| AviateSupervisorError::protocol("the prepared process owner is missing"))?;
+    super::wait_for_supervisor_terminal(
+        supervisor.child_mut()?,
+        &launch.attestation.supervisor_identity,
+        launch.request.cleanup_timeout,
+    )?;
+    crate::process::recover_supervised_process_blocking(&launch.attestation.recovery_request)
+}
+
+pub(crate) fn release_supported(
+    mut launch: PreparedLaunch,
+) -> Result<ManagedAviateProcess, AviateSupervisorError> {
+    let target_identity = match release_target(&mut launch) {
+        Ok(identity) => identity,
+        Err(source) => return fail_prepared_release(&mut launch, source),
+    };
+    let (supervisor, parent_lifetime) = take_managed_processes(&mut launch)?;
+    Ok(ManagedAviateProcess {
+        supervisor,
+        parent_lifetime: Some(parent_lifetime),
+        supervisor_identity: launch.attestation.supervisor_identity.clone(),
+        target_identity,
+        attestation: launch.attestation.clone(),
+        recovery: launch.attestation.recovery_request.clone(),
+        cleanup_timeout: launch.request.cleanup_timeout,
+        terminated: false,
+    })
+}
+
+fn release_target(launch: &mut PreparedLaunch) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let release = ReleaseMessage {
+        correlation_nonce: launch.correlation_nonce,
+        release_secret: launch.release_secret.clone(),
+    };
+    let parent_lifetime = launch.parent_lifetime.as_mut().ok_or_else(|| {
+        AviateSupervisorError::protocol("the prepared parent-lifetime pipe is missing")
+    })?;
+    parent_lifetime
+        .write_all(&encode_line(&release)?)
+        .and_then(|()| parent_lifetime.flush())
+        .map_err(|source| super::process_io("send parent release authorization", source))?;
+    let supervisor = launch
+        .supervisor
+        .as_mut()
+        .ok_or_else(|| AviateSupervisorError::protocol("the prepared process owner is missing"))?;
+    let response: TargetReleaseMessage = wait_parent_message(
+        &launch.listener,
+        supervisor.child_mut()?,
+        launch.request.startup_timeout,
+    )?;
+    let ready = parse_target_release(response, launch.correlation_nonce)?;
+    attestation::validate_target_ready(
+        &launch.request,
+        &ready,
+        &launch.attestation.supervisor_identity,
+    )
+}
+
+fn parse_target_release(
+    response: TargetReleaseMessage,
+    expected_nonce: flight_tune::Digest,
+) -> Result<TargetReadyMessage, AviateSupervisorError> {
+    match response {
+        TargetReleaseMessage::Ready {
+            correlation_nonce,
+            process_identity_digest,
+            target_attestation_digest,
+        } => Ok(TargetReadyMessage {
+            correlation_nonce,
+            process_identity_digest,
+            target_attestation_digest,
+        }),
+        TargetReleaseMessage::RejectedIdentityMismatch {
+            correlation_nonce,
+            detail,
+        } if correlation_nonce == expected_nonce && !detail.is_empty() => {
+            Err(AviateSupervisorError::identity_mismatch(detail))
+        }
+        TargetReleaseMessage::RejectedIdentityMismatch { .. } => Err(
+            AviateSupervisorError::protocol("the target rejection message is invalid"),
+        ),
+    }
+}
+
+fn fail_prepared_release<T>(
+    launch: &mut PreparedLaunch,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    launch.parent_lifetime.take();
+    let Some(supervisor) = launch.supervisor.as_mut() else {
+        return Err(source);
+    };
+    let cleanup = super::wait_for_supervisor_terminal(
+        supervisor.child_mut()?,
+        &launch.attestation.supervisor_identity,
+        launch.request.cleanup_timeout,
+    )
+    .and_then(|()| {
+        match crate::process::recover_supervised_process_blocking(
+            &launch.attestation.recovery_request,
+        )? {
+            RecoveryOutcome::Terminal { .. } => Ok(()),
+            RecoveryOutcome::BootChange { .. } => Err(AviateSupervisorError::RecoveryBlocked {
+                detail: "a boot-change receipt cannot confirm same-boot startup cleanup".to_owned(),
+            }),
+        }
+    });
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+fn take_managed_processes(
+    launch: &mut PreparedLaunch,
+) -> Result<(ReapableOwner, ChildStdin), AviateSupervisorError> {
+    match (launch.supervisor.take(), launch.parent_lifetime.take()) {
+        (Some(supervisor), Some(parent_lifetime)) => Ok((supervisor, parent_lifetime)),
+        (supervisor, parent_lifetime) => {
+            launch.supervisor = supervisor;
+            launch.parent_lifetime = parent_lifetime;
+            Err(AviateSupervisorError::protocol(
+                "the prepared process ownership is incomplete",
+            ))
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/process/startup/resources.rs
+++ b/tools/flight-tune-aviate/src/process/startup/resources.rs
@@ -1,0 +1,127 @@
+use std::path::Path;
+
+use super::super::SupervisedProcessRequest;
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::supervisor::SupervisorBootstrap;
+
+pub(super) struct LaunchArtifacts {
+    pub(super) root: crate::document::AnchoredDirectory,
+    pub(super) supervisor: crate::document::AnchoredExecutable,
+    pub(super) target: crate::document::AnchoredExecutable,
+}
+
+pub(super) fn stage_launch_artifacts(
+    request: &SupervisedProcessRequest,
+) -> Result<LaunchArtifacts, AviateSupervisorError> {
+    let root = artifact::create_artifact_root(&request.artifact_root)?;
+    let supervisor = match artifact::stage_executable(
+        &root,
+        &request.supervisor_executable,
+        request.supervisor_executable_digest,
+        artifact::SUPERVISOR_ARTIFACT,
+    ) {
+        Ok(supervisor) => supervisor,
+        Err(source) => {
+            let cleanup = artifact::remove_artifact_root(&root);
+            return combine_cleanup(source, cleanup);
+        }
+    };
+    let target = match artifact::stage_executable(
+        &root,
+        &request.target_executable,
+        request.target_executable_digest,
+        artifact::TARGET_ARTIFACT,
+    ) {
+        Ok(target) => target,
+        Err(source) => return cleanup_one_artifact(root, supervisor, source),
+    };
+    Ok(LaunchArtifacts {
+        root,
+        supervisor,
+        target,
+    })
+}
+
+pub(super) fn build_bootstrap(
+    request: &SupervisedProcessRequest,
+    artifacts: &LaunchArtifacts,
+    runtime_root: crate::document::AnchoredDirectory,
+    target_current_directory: crate::document::AnchoredDirectory,
+    release_secret_digest: flight_tune::Digest,
+) -> Result<SupervisorBootstrap, AviateSupervisorError> {
+    Ok(SupervisorBootstrap {
+        schema_version: crate::supervisor::BOOTSTRAP_SCHEMA_VERSION,
+        run_intent_digest: request.run_intent_digest,
+        release_secret_digest,
+        supervisor_executable: artifacts.supervisor.clone(),
+        target_executable: artifacts.target.clone(),
+        artifact_root: artifacts.root.clone(),
+        runtime_root,
+        target_arguments: request.target_arguments.clone(),
+        target_environment: request.target_environment.clone(),
+        target_process_contract: request.target_process_contract.clone(),
+        target_current_directory,
+        startup_timeout_millis: super::duration_millis(request.startup_timeout)?,
+        cleanup_timeout_millis: super::duration_millis(request.cleanup_timeout)?,
+    })
+}
+
+pub(super) fn cleanup_launch_artifacts(
+    artifacts: &LaunchArtifacts,
+) -> Result<(), AviateSupervisorError> {
+    artifact::remove_staged(&artifacts.root, &artifacts.target)?;
+    artifact::remove_staged(&artifacts.root, &artifacts.supervisor)?;
+    artifact::remove_artifact_root(&artifacts.root)
+}
+
+pub(super) fn cleanup_launch_artifacts_after_owner(
+    artifacts: &LaunchArtifacts,
+) -> Result<(), AviateSupervisorError> {
+    if !path_exists(
+        &artifacts.root.path,
+        "inspect returned launch-artifact root",
+    )? {
+        return Ok(());
+    }
+    for executable in [&artifacts.target, &artifacts.supervisor] {
+        if path_exists(
+            &executable.path,
+            "inspect returned staged launch executable",
+        )? {
+            artifact::remove_staged(&artifacts.root, executable)?;
+        }
+    }
+    artifact::remove_artifact_root(&artifacts.root)
+}
+
+fn path_exists(path: &Path, operation: &'static str) -> Result<bool, AviateSupervisorError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(crate::inspection::io_error(operation, path, source)),
+    }
+}
+
+fn cleanup_one_artifact<T>(
+    root: crate::document::AnchoredDirectory,
+    executable: crate::document::AnchoredExecutable,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let cleanup = artifact::remove_staged(&root, &executable)
+        .and_then(|()| artifact::remove_artifact_root(&root));
+    combine_cleanup(source, cleanup)
+}
+
+fn combine_cleanup<T>(
+    source: AviateSupervisorError,
+    cleanup: Result<(), AviateSupervisorError>,
+) -> Result<T, AviateSupervisorError> {
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}

--- a/tools/flight-tune-aviate/src/protocol.rs
+++ b/tools/flight-tune-aviate/src/protocol.rs
@@ -1,0 +1,174 @@
+use std::io::{Read, Write as _};
+use std::path::Path;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::AviateSupervisorError;
+
+const MAX_MESSAGE_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ArmedMessage {
+    pub(crate) correlation_nonce: flight_tune::Digest,
+    pub(crate) spawn_intent_digest: flight_tune::Digest,
+    pub(crate) process_identity_digest: flight_tune::Digest,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReleaseMessage {
+    pub(crate) correlation_nonce: flight_tune::Digest,
+    pub(crate) release_secret: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TargetReadyMessage {
+    pub(crate) correlation_nonce: flight_tune::Digest,
+    pub(crate) process_identity_digest: flight_tune::Digest,
+    pub(crate) target_attestation_digest: flight_tune::Digest,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
+pub(crate) enum TargetReleaseMessage {
+    Ready {
+        correlation_nonce: flight_tune::Digest,
+        process_identity_digest: flight_tune::Digest,
+        target_attestation_digest: flight_tune::Digest,
+    },
+    RejectedIdentityMismatch {
+        correlation_nonce: flight_tune::Digest,
+        detail: String,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
+pub(crate) enum GateEvent {
+    TargetStarted { pid: u32 },
+    TargetContained { pid: u32 },
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn connect_and_write<T: Serialize>(
+    path: &Path,
+    message: &T,
+    timeout: Duration,
+) -> Result<(), AviateSupervisorError> {
+    let stream = std::os::unix::net::UnixStream::connect(path)
+        .map_err(|source| protocol_io("connect to supervisor socket", source))?;
+    write_message(stream, message, timeout)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn read_message_until_blocking<R: for<'de> Deserialize<'de>>(
+    mut stream: std::os::unix::net::UnixStream,
+    deadline: std::time::Instant,
+) -> Result<R, AviateSupervisorError> {
+    stream
+        .set_nonblocking(true)
+        .map_err(|source| protocol_io("configure supervisor message read", source))?;
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) => return decode(&bytes),
+            Ok(count) => {
+                bytes.extend_from_slice(&buffer[..count]);
+                if bytes.len() as u64 > MAX_MESSAGE_BYTES {
+                    return Err(AviateSupervisorError::protocol(
+                        "the supervisor message is too large",
+                    ));
+                }
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(AviateSupervisorError::Timeout {
+                        operation: "read owner readiness",
+                    });
+                }
+                std::thread::park_timeout(Duration::from_millis(1));
+            }
+            Err(source) => return Err(protocol_io("read supervisor message", source)),
+        }
+    }
+}
+
+pub(crate) fn decode<R: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+) -> Result<R, AviateSupervisorError> {
+    if bytes.is_empty() || bytes.len() as u64 > MAX_MESSAGE_BYTES {
+        return Err(AviateSupervisorError::protocol(
+            "the supervisor message has an invalid length",
+        ));
+    }
+    serde_json::from_slice(bytes)
+        .map_err(|source| AviateSupervisorError::json_protocol("decoding", source))
+}
+
+pub(crate) fn encode_line<T: Serialize>(message: &T) -> Result<Vec<u8>, AviateSupervisorError> {
+    let mut bytes = serde_json::to_vec(message)
+        .map_err(|source| AviateSupervisorError::json_protocol("encoding", source))?;
+    if bytes.is_empty() || bytes.len() as u64 >= MAX_MESSAGE_BYTES {
+        return Err(AviateSupervisorError::protocol(
+            "the supervisor message has an invalid length",
+        ));
+    }
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+pub(crate) fn read_line_blocking(reader: &mut impl Read) -> Result<Vec<u8>, AviateSupervisorError> {
+    let mut bytes = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        let count = reader
+            .read(&mut byte)
+            .map_err(|source| protocol_io("read anonymous process pipe", source))?;
+        if count == 0 {
+            return Err(AviateSupervisorError::protocol(
+                "an anonymous process pipe closed before one message",
+            ));
+        }
+        if byte[0] == b'\n' {
+            return Ok(bytes);
+        }
+        bytes.push(byte[0]);
+        if bytes.len() as u64 > MAX_MESSAGE_BYTES {
+            return Err(AviateSupervisorError::protocol(
+                "an anonymous process pipe message is too large",
+            ));
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn write_message<T: Serialize>(
+    mut stream: std::os::unix::net::UnixStream,
+    message: &T,
+    timeout: Duration,
+) -> Result<(), AviateSupervisorError> {
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|source| protocol_io("configure supervisor write timeout", source))?;
+    let bytes = serde_json::to_vec(message)
+        .map_err(|source| AviateSupervisorError::json_protocol("encoding", source))?;
+    if bytes.is_empty() || bytes.len() as u64 > MAX_MESSAGE_BYTES {
+        return Err(AviateSupervisorError::protocol(
+            "the supervisor message has an invalid length",
+        ));
+    }
+    stream
+        .write_all(&bytes)
+        .map_err(|source| protocol_io("write supervisor message", source))?;
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .map_err(|source| protocol_io("finish supervisor message", source))
+}
+
+fn protocol_io(operation: &'static str, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::ProcessIo { operation, source }
+}

--- a/tools/flight-tune-aviate/src/runtime_files.rs
+++ b/tools/flight-tune-aviate/src/runtime_files.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+
+use crate::AviateSupervisorError;
+
+pub(crate) const PARENT_READY_SOCKET: &str = "parent-ready.sock";
+
+pub(crate) fn validate_private_root(root: &Path) -> Result<(), AviateSupervisorError> {
+    if !root.is_absolute() {
+        return Err(AviateSupervisorError::invalid_request(
+            "the supervisor runtime root is not absolute",
+        ));
+    }
+    let metadata = std::fs::symlink_metadata(root)
+        .map_err(|source| io_error("inspect supervisor runtime root", root, source))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(AviateSupervisorError::invalid_request(
+            "the supervisor runtime root is not one real directory",
+        ));
+    }
+    let canonical = std::fs::canonicalize(root)
+        .map_err(|source| io_error("canonicalize supervisor runtime root", root, source))?;
+    if canonical != root {
+        return Err(AviateSupervisorError::invalid_request(
+            "the supervisor runtime root is not its canonical path",
+        ));
+    }
+    validate_mode(root, &metadata)?;
+    Ok(())
+}
+
+pub(crate) fn require_entries(root: &Path, expected: &[&str]) -> Result<(), AviateSupervisorError> {
+    let mut entries = std::fs::read_dir(root)
+        .map_err(|source| io_error("scan supervisor runtime root", root, source))?
+        .map(|entry| {
+            entry
+                .map(|value| value.file_name())
+                .map_err(|source| io_error("read supervisor runtime entry", root, source))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort();
+    let mut expected = expected
+        .iter()
+        .map(std::ffi::OsString::from)
+        .collect::<Vec<_>>();
+    expected.sort();
+    if entries != expected {
+        return Err(AviateSupervisorError::invalid_request(
+            "the supervisor runtime root contains residual entries",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn bind_socket(
+    path: &Path,
+) -> Result<std::os::unix::net::UnixListener, AviateSupervisorError> {
+    let listener = std::os::unix::net::UnixListener::bind(path)
+        .map_err(|source| io_error("bind supervisor socket", path, source))?;
+    if let Err(source) = listener.set_nonblocking(true) {
+        drop(listener);
+        let source = io_error("configure supervisor socket", path, source);
+        return match remove_exact_socket(path) {
+            Ok(()) => Err(source),
+            Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+                source: Box::new(source),
+                cleanup: Box::new(cleanup),
+            }),
+        };
+    }
+    Ok(listener)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn bind_socket(_path: &Path) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+pub(crate) fn remove_exact_socket(path: &Path) -> Result<(), AviateSupervisorError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return sync_socket_parent(path);
+        }
+        Err(source) => return Err(io_error("inspect supervisor socket", path, source)),
+    };
+    if !is_socket(&metadata) {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: format!("the runtime entry is not an exact socket: {path:?}"),
+        });
+    }
+    std::fs::remove_file(path)
+        .map_err(|source| io_error("remove supervisor socket", path, source))?;
+    sync_socket_parent(path)
+}
+
+pub(crate) fn socket_path(root: &Path, name: &'static str) -> PathBuf {
+    root.join(name)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn validate_mode(root: &Path, metadata: &std::fs::Metadata) -> Result<(), AviateSupervisorError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    if metadata.permissions().mode() & 0o777 != 0o700 {
+        return Err(AviateSupervisorError::invalid_request(format!(
+            "the supervisor runtime root is not mode 0700: {root:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn validate_mode(_root: &Path, _metadata: &std::fs::Metadata) -> Result<(), AviateSupervisorError> {
+    Err(AviateSupervisorError::UnsupportedPlatform)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn is_socket(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::FileTypeExt as _;
+
+    metadata.file_type().is_socket()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn is_socket(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+fn io_error(operation: &'static str, path: &Path, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+fn sync_socket_parent(path: &Path) -> Result<(), AviateSupervisorError> {
+    let parent = path.parent().ok_or_else(|| {
+        AviateSupervisorError::invalid_request("the supervisor socket has no parent")
+    })?;
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| io_error("sync supervisor runtime root", parent, source))
+}

--- a/tools/flight-tune-aviate/src/supervisor.rs
+++ b/tools/flight-tune-aviate/src/supervisor.rs
@@ -1,0 +1,23 @@
+//! Internal owner and launch-gate entry points.
+
+pub(crate) mod config;
+mod gate;
+mod owner;
+mod process_control;
+
+pub(crate) use config::{BOOTSTRAP_SCHEMA_VERSION, SupervisorBootstrap};
+
+use crate::AviateSupervisorError;
+
+pub(crate) fn run_from_arguments() -> Result<(), AviateSupervisorError> {
+    let mode = std::env::args()
+        .nth(1)
+        .ok_or_else(|| AviateSupervisorError::invalid_request("the supervisor mode is missing"))?;
+    match mode.as_str() {
+        "supervise" => owner::run(),
+        "gate" => gate::run(),
+        _ => Err(AviateSupervisorError::invalid_request(
+            "the supervisor mode is invalid",
+        )),
+    }
+}

--- a/tools/flight-tune-aviate/src/supervisor/config.rs
+++ b/tools/flight-tune-aviate/src/supervisor/config.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::AviateSupervisorError;
+use crate::document::TargetProcessContract;
+use crate::document::{AnchoredDirectory, AnchoredExecutable};
+
+pub(crate) const BOOTSTRAP_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SupervisorBootstrap {
+    pub(crate) schema_version: u16,
+    pub(crate) run_intent_digest: flight_tune::Digest,
+    pub(crate) release_secret_digest: flight_tune::Digest,
+    pub(crate) supervisor_executable: AnchoredExecutable,
+    pub(crate) target_executable: AnchoredExecutable,
+    pub(crate) artifact_root: AnchoredDirectory,
+    pub(crate) runtime_root: AnchoredDirectory,
+    pub(crate) target_arguments: Vec<String>,
+    pub(crate) target_environment: BTreeMap<String, String>,
+    pub(crate) target_process_contract: TargetProcessContract,
+    pub(crate) target_current_directory: AnchoredDirectory,
+    pub(crate) startup_timeout_millis: u64,
+    pub(crate) cleanup_timeout_millis: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GateConfig {
+    pub(super) schema_version: u16,
+    pub(super) release_secret_digest: flight_tune::Digest,
+    pub(super) target_executable: AnchoredExecutable,
+    pub(super) artifact_root: AnchoredDirectory,
+    pub(super) target_arguments: Vec<String>,
+    pub(super) target_environment: BTreeMap<String, String>,
+    pub(super) target_environment_digest: flight_tune::Digest,
+    pub(super) target_current_directory: AnchoredDirectory,
+    pub(super) target_argv_digest: flight_tune::Digest,
+    pub(super) target_process_contract: TargetProcessContract,
+}
+
+pub(super) fn validate_bootstrap(
+    bootstrap: &SupervisorBootstrap,
+) -> Result<(), AviateSupervisorError> {
+    if bootstrap.schema_version != BOOTSTRAP_SCHEMA_VERSION
+        || bootstrap.run_intent_digest.is_zero()
+        || bootstrap.release_secret_digest.is_zero()
+        || bootstrap.startup_timeout_millis == 0
+        || bootstrap.cleanup_timeout_millis == 0
+    {
+        return Err(AviateSupervisorError::invalid_request(
+            "the supervisor bootstrap is incomplete",
+        ));
+    }
+    validate_arguments(&bootstrap.target_arguments)?;
+    validate_environment(&bootstrap.target_environment)
+}
+
+pub(super) fn validate_gate_config(config: &GateConfig) -> Result<(), AviateSupervisorError> {
+    if config.schema_version != BOOTSTRAP_SCHEMA_VERSION
+        || config.release_secret_digest.is_zero()
+        || config.target_environment_digest != digest_environment(&config.target_environment)
+    {
+        return Err(AviateSupervisorError::invalid_request(
+            "the launch-gate configuration is incomplete",
+        ));
+    }
+    validate_arguments(&config.target_arguments)?;
+    validate_environment(&config.target_environment)
+}
+
+pub(crate) fn digest_environment(environment: &BTreeMap<String, String>) -> flight_tune::Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(b"flight-tune-aviate-env-v1\0");
+    for (name, value) in environment {
+        hash_field(&mut hasher, name.as_bytes());
+        hash_field(&mut hasher, value.as_bytes());
+    }
+    flight_tune::Digest::from_bytes(hasher.finalize().into())
+}
+
+fn validate_arguments(arguments: &[String]) -> Result<(), AviateSupervisorError> {
+    if arguments.len() > 256 || arguments.iter().any(|value| value.contains('\0')) {
+        return Err(AviateSupervisorError::invalid_request(
+            "the target argument vector is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_environment(
+    environment: &BTreeMap<String, String>,
+) -> Result<(), AviateSupervisorError> {
+    if environment.len() > 256
+        || environment.iter().any(|(name, value)| {
+            name.is_empty() || name.contains(['=', '\0']) || value.contains('\0')
+        })
+    {
+        return Err(AviateSupervisorError::invalid_request(
+            "the explicit target environment is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn hash_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}

--- a/tools/flight-tune-aviate/src/supervisor/gate.rs
+++ b/tools/flight-tune-aviate/src/supervisor/gate.rs
@@ -1,0 +1,199 @@
+use std::io::Write as _;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+
+use super::config::{GateConfig, validate_gate_config};
+use super::process_control;
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::lease_store;
+use crate::protocol::{GateEvent, decode, encode_line, read_line_blocking};
+
+enum GateWait {
+    SupervisorClosed,
+}
+
+pub(super) fn run() -> Result<(), AviateSupervisorError> {
+    require_exact_arguments()?;
+    enter_private_session()?;
+    let mut input = std::io::stdin();
+    let config: GateConfig = decode(&read_line_blocking(&mut input)?)?;
+    validate_gate_config(&config)?;
+    validate_launch_context(&config)?;
+    let release = read_line_blocking(&mut input)?;
+    if lease_store::digest_bytes(&release) != config.release_secret_digest {
+        return Err(AviateSupervisorError::protocol(
+            "the anonymous release capability is invalid",
+        ));
+    }
+    let mut target = spawn_target(&config)?;
+    let supervision = supervise_spawned_target(&mut target, input);
+    match supervision {
+        Ok(()) => {
+            if let Err(error) = contain_spawned_target(&mut target) {
+                hold_failed_containment(target, error);
+            }
+            if let Err(error) = report_contained_target(&target) {
+                tracing::error!(%error, "launch-gate containment report failed");
+                signal_own_group();
+            }
+            hold_contained_group();
+        }
+        Err(error) => {
+            tracing::error!(%error, "launch-gate supervision failed");
+            if let Err(error) = contain_spawned_target(&mut target) {
+                hold_failed_containment(target, error);
+            }
+            if let Err(error) = report_contained_target(&target) {
+                tracing::error!(%error, "launch-gate containment report failed");
+            }
+            signal_own_group();
+        }
+    }
+}
+
+fn enter_private_session() -> Result<(), AviateSupervisorError> {
+    let session = rustix::process::setsid().map_err(|source| {
+        process_io(
+            "create isolated launch-gate session",
+            std::io::Error::from_raw_os_error(source.raw_os_error()),
+        )
+    })?;
+    let own_pid = i32::try_from(std::process::id()).map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the launch-gate PID exceeds POSIX limits")
+    })?;
+    if session.as_raw_pid() != own_pid {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the launch gate did not become its session leader",
+        ));
+    }
+    Ok(())
+}
+
+fn supervise_spawned_target(
+    target: &mut Child,
+    input: std::io::Stdin,
+) -> Result<(), AviateSupervisorError> {
+    write_event(&GateEvent::TargetStarted { pid: target.id() })?;
+    let (sender, receiver) = mpsc::channel();
+    spawn_input_monitor(input, sender)?;
+    match receiver
+        .recv()
+        .map_err(|_| AviateSupervisorError::protocol("the launch-gate event channel closed"))?
+    {
+        GateWait::SupervisorClosed => Ok(()),
+    }
+}
+
+fn require_exact_arguments() -> Result<(), AviateSupervisorError> {
+    if std::env::args_os().count() != 2 {
+        return Err(AviateSupervisorError::invalid_request(
+            "the launch gate received unexpected command arguments",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_launch_context(config: &GateConfig) -> Result<(), AviateSupervisorError> {
+    artifact::validate_directory(&config.artifact_root, true)?;
+    artifact::validate_directory(&config.target_current_directory, false)?;
+    let target = artifact::inspect_staged(
+        &config.target_executable.path,
+        config.target_executable.digest,
+    )?;
+    if target != config.target_executable {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "a launch-gate executable identity changed",
+        ));
+    }
+    Ok(())
+}
+
+fn spawn_target(config: &GateConfig) -> Result<Child, AviateSupervisorError> {
+    artifact::validate_directory(&config.target_current_directory, false)?;
+    let mut command = Command::new(&config.target_executable.path);
+    command
+        .args(&config.target_arguments)
+        .env_clear()
+        .envs(&config.target_environment)
+        .current_dir(&config.target_current_directory.path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+        .spawn()
+        .map_err(|source| process_io("spawn exact supervised target", source))
+}
+
+fn spawn_input_monitor(
+    mut input: std::io::Stdin,
+    sender: mpsc::Sender<GateWait>,
+) -> Result<(), AviateSupervisorError> {
+    std::thread::Builder::new()
+        .name("aviate-gate-owner-eof".to_owned())
+        .spawn(move || {
+            drop(read_line_blocking(&mut input).ok());
+            if sender.send(GateWait::SupervisorClosed).is_err() {
+                tracing::debug!("launch-gate owner channel is already closed");
+            }
+        })
+        .map(|_| ())
+        .map_err(|source| process_io("spawn launch-gate owner monitor", source))
+}
+
+fn write_event(event: &GateEvent) -> Result<(), AviateSupervisorError> {
+    let bytes = encode_line(event)?;
+    let mut output = std::io::stdout().lock();
+    output
+        .write_all(&bytes)
+        .and_then(|()| output.flush())
+        .map_err(|source| process_io("write launch-gate event", source))
+}
+
+fn contain_spawned_target(target: &mut Child) -> Result<(), AviateSupervisorError> {
+    match process_control::stop_child(target) {
+        Ok(()) => tracing::debug!(target_pid = target.id(), "launch gate stopped exact target"),
+        Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => {
+            tracing::debug!(
+                target_pid = target.id(),
+                "launch-gate target already stopped"
+            );
+        }
+        Err(error) => {
+            return Err(process_io("stop exact supervised target", error));
+        }
+    }
+    target
+        .wait()
+        .map(|_| ())
+        .map_err(|source| process_io("reap exact supervised target", source))
+}
+
+fn report_contained_target(target: &Child) -> Result<(), AviateSupervisorError> {
+    write_event(&GateEvent::TargetContained { pid: target.id() })
+}
+
+fn hold_failed_containment(_target: Child, error: AviateSupervisorError) -> ! {
+    tracing::error!(%error, "launch gate uses group containment after exact target cleanup failed");
+    signal_own_group()
+}
+
+fn hold_contained_group() -> ! {
+    loop {
+        std::thread::park();
+    }
+}
+
+fn signal_own_group() -> ! {
+    loop {
+        match process_control::signal_current_process_group() {
+            Ok(()) => tracing::error!("launch-gate containment signal returned"),
+            Err(error) => tracing::error!(%error, "launch-gate containment signal failed"),
+        }
+        std::thread::park_timeout(std::time::Duration::from_millis(100));
+    }
+}
+
+fn process_io(operation: &'static str, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::ProcessIo { operation, source }
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner.rs
@@ -1,0 +1,85 @@
+use std::process::{Child, ChildStdin};
+use std::sync::mpsc;
+
+use super::config::SupervisorBootstrap;
+use crate::AviateSupervisorError;
+use crate::document::{ProcessIdentity, ProcessIdentityDocument, TargetAttestation};
+use crate::lease_store::LeaseStore;
+use crate::protocol::{GateEvent, ReleaseMessage};
+
+mod cleanup;
+mod handshake;
+mod launch;
+
+pub(super) enum OwnerEvent {
+    ParentClosed,
+    ParentRelease(Result<ReleaseMessage, AviateSupervisorError>),
+    Gate(Result<GateEvent, AviateSupervisorError>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum TargetPublicationState {
+    NotAttempted,
+    Candidate(TargetAttestation),
+    Published {
+        attestation: TargetAttestation,
+        digest: flight_tune::Digest,
+    },
+}
+
+pub(super) struct PreparedOwner {
+    pub(super) bootstrap: SupervisorBootstrap,
+    pub(super) store: LeaseStore,
+    pub(super) spawn_intent_digest: flight_tune::Digest,
+    pub(super) process_identity_digest: Option<flight_tune::Digest>,
+    pub(super) target_publication: TargetPublicationState,
+    pub(super) process_identity: ProcessIdentityDocument,
+    pub(super) target_pid: Option<u32>,
+    pub(super) target_release_sent: bool,
+    pub(super) target_identity: Option<ProcessIdentity>,
+    pub(super) target_contained: bool,
+    pub(super) gate_failed: bool,
+    pub(super) gate: Child,
+    pub(super) gate_input: Option<ChildStdin>,
+    pub(super) events: mpsc::Receiver<OwnerEvent>,
+}
+
+pub(super) fn run() -> Result<(), AviateSupervisorError> {
+    let owner = launch::prepare()?;
+    handshake::run_prepared(owner)
+}
+
+pub(super) fn process_io(operation: &'static str, source: std::io::Error) -> AviateSupervisorError {
+    AviateSupervisorError::ProcessIo { operation, source }
+}
+
+pub(super) fn validate_gate_lifetime(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let expected = &owner.process_identity.target_gate;
+    if let Some(actual) = crate::inspection::inspect_lifetime(expected.pid)? {
+        return crate::inspection::validate_absent_or_exact(expected, Some(actual), "launch gate")
+            .map(|_| ());
+    }
+    let snapshot = crate::inspection::process_group_snapshot(expected.process_group)?;
+    let expected_start = match expected.start {
+        crate::document::ProcessStartIdentity::MacOs { start_abstime, .. } => Some(start_abstime),
+        crate::document::ProcessStartIdentity::Linux { .. } => None,
+    };
+    if expected_start.is_some_and(|start| {
+        snapshot
+            .exited
+            .iter()
+            .any(|member| member.pid == expected.pid && member.start_abstime == start)
+    }) {
+        return Ok(());
+    }
+    Err(AviateSupervisorError::RecoveryBlocked {
+        detail: "the held launch-gate lifetime cannot be proved".to_owned(),
+    })
+}
+
+pub(super) fn attest_target(
+    owner: &mut PreparedOwner,
+    pid: u32,
+) -> Result<TargetAttestation, AviateSupervisorError> {
+    launch::attest_target(owner, pid)
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner/cleanup.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/cleanup.rs
@@ -1,0 +1,372 @@
+use std::time::{Duration, Instant};
+
+use super::{
+    OwnerEvent, PreparedOwner, TargetPublicationState, process_io, validate_gate_lifetime,
+};
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::document::{
+    SCHEMA_VERSION, TARGET_ATTESTATION_NAME, TERMINAL_RECEIPT_NAME, TargetAttestation,
+    TerminalReceipt,
+};
+use crate::protocol::GateEvent;
+use crate::runtime_files::{PARENT_READY_SOCKET, remove_exact_socket, socket_path};
+use crate::supervisor::process_control::{self, ProcessGroupSignal};
+
+pub(super) fn finish_or_hold(mut owner: PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let result = finish(&mut owner);
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) => hold_failed_cleanup(owner, error),
+    }
+}
+
+pub(super) fn finish_after_error<T>(
+    owner: PreparedOwner,
+    error: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    match finish_or_hold(owner) {
+        Ok(()) => Err(error),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(error),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+fn finish(owner: &mut PreparedOwner) -> Result<(), AviateSupervisorError> {
+    request_gate_containment(owner)?;
+    owner
+        .gate
+        .wait()
+        .map_err(|source| process_io("reap exact launch-gate leader", source))?;
+    wait_for_group_empty(owner)?;
+    wait_for_exact_target_absent(owner)?;
+    cleanup_runtime_and_artifacts(owner)?;
+    let Some(process_identity_digest) = owner.process_identity_digest else {
+        return Ok(());
+    };
+    let target_attestation_digest =
+        resolve_target_publication(&owner.store, &mut owner.target_publication)?;
+    let receipt = TerminalReceipt {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: owner.bootstrap.run_intent_digest,
+        spawn_intent_digest: owner.spawn_intent_digest,
+        process_identity_digest,
+        target_attestation_digest,
+    };
+    owner.store.publish(TERMINAL_RECEIPT_NAME, &receipt)?;
+    Ok(())
+}
+
+fn resolve_target_publication(
+    store: &crate::lease_store::LeaseStore,
+    state: &mut TargetPublicationState,
+) -> Result<Option<flight_tune::Digest>, AviateSupervisorError> {
+    match state.clone() {
+        TargetPublicationState::NotAttempted => {
+            let actual: Option<(TargetAttestation, _)> =
+                store.repair_optional(TARGET_ATTESTATION_NAME)?;
+            if actual.is_some() {
+                return Err(AviateSupervisorError::invalid_document(
+                    "target attestation",
+                    "a target attestation exists without a publication attempt",
+                ));
+            }
+            Ok(None)
+        }
+        TargetPublicationState::Candidate(expected) => {
+            let actual: Option<(TargetAttestation, _)> =
+                store.repair_optional(TARGET_ATTESTATION_NAME)?;
+            resolve_candidate(state, expected, actual)
+        }
+        TargetPublicationState::Published {
+            attestation,
+            digest,
+        } => {
+            let (actual, actual_digest): (TargetAttestation, _) =
+                store.repair(TARGET_ATTESTATION_NAME)?;
+            if actual != attestation || actual_digest != digest {
+                return Err(AviateSupervisorError::invalid_document(
+                    "target attestation",
+                    "the published target attestation changed",
+                ));
+            }
+            Ok(Some(digest))
+        }
+    }
+}
+
+fn resolve_candidate(
+    state: &mut TargetPublicationState,
+    expected: TargetAttestation,
+    actual: Option<(TargetAttestation, flight_tune::Digest)>,
+) -> Result<Option<flight_tune::Digest>, AviateSupervisorError> {
+    let Some((attestation, digest)) = actual else {
+        *state = TargetPublicationState::NotAttempted;
+        return Ok(None);
+    };
+    if attestation != expected {
+        return Err(AviateSupervisorError::invalid_document(
+            "target attestation",
+            "the repaired target attestation differs from the verified candidate",
+        ));
+    }
+    *state = TargetPublicationState::Published {
+        attestation,
+        digest,
+    };
+    Ok(Some(digest))
+}
+
+fn request_gate_containment(owner: &mut PreparedOwner) -> Result<(), AviateSupervisorError> {
+    owner.gate_input.take();
+    if owner.target_pid.is_some() {
+        return match wait_for_target_contained(owner) {
+            Ok(()) => {
+                wait_for_exact_target_absent(owner)?;
+                stop_target_group(owner)
+            }
+            Err(initial) => contain_after_gate_failure(owner, initial),
+        };
+    }
+    if owner.target_release_sent {
+        return contain_after_gate_failure(
+            owner,
+            AviateSupervisorError::protocol(
+                "the target release did not produce an exact target identity",
+            ),
+        );
+    }
+    if owner.gate_failed {
+        return contain_after_gate_failure(
+            owner,
+            AviateSupervisorError::protocol(
+                "the launch gate stopped before it reported the target identity",
+            ),
+        );
+    }
+    match wait_for_gate_quiescence(owner) {
+        Ok(()) => Ok(()),
+        Err(initial) => {
+            if let Err(fallback) = signal_group(owner) {
+                return Err(AviateSupervisorError::StartupCleanup {
+                    source: Box::new(initial),
+                    cleanup: Box::new(fallback),
+                });
+            }
+            wait_for_gate_quiescence(owner)
+        }
+    }
+}
+
+fn contain_after_gate_failure(
+    owner: &PreparedOwner,
+    initial: AviateSupervisorError,
+) -> Result<(), AviateSupervisorError> {
+    tracing::warn!(%initial, "launch-gate confirmation failed; owner uses anchored group cleanup");
+    match stop_target_group(owner).and_then(|()| wait_for_exact_target_absent(owner)) {
+        Ok(()) => Ok(()),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(initial),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+fn stop_target_group(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    signal_group(owner)?;
+    wait_for_gate_quiescence(owner)
+}
+
+fn wait_for_target_contained(owner: &mut PreparedOwner) -> Result<(), AviateSupervisorError> {
+    if owner.target_contained {
+        return Ok(());
+    }
+    if owner.gate_failed {
+        return Err(AviateSupervisorError::protocol(
+            "the launch gate stopped before containment confirmation",
+        ));
+    }
+    let timeout = Duration::from_millis(owner.bootstrap.cleanup_timeout_millis);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout {
+            operation: "wait for exact target containment",
+        })?;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let event = owner
+            .events
+            .recv_timeout(remaining)
+            .map_err(|error| match error {
+                std::sync::mpsc::RecvTimeoutError::Timeout => AviateSupervisorError::Timeout {
+                    operation: "wait for exact target containment",
+                },
+                std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                    AviateSupervisorError::protocol("the owner event channel closed")
+                }
+            })?;
+        match event {
+            OwnerEvent::Gate(Ok(GateEvent::TargetContained { pid })) => {
+                if owner.target_pid != Some(pid) {
+                    return Err(AviateSupervisorError::protocol(
+                        "the launch gate contained another target PID",
+                    ));
+                }
+                owner.target_contained = true;
+                return Ok(());
+            }
+            OwnerEvent::ParentClosed => {}
+            OwnerEvent::ParentRelease(_) => {
+                return Err(AviateSupervisorError::protocol(
+                    "the parent sent duplicate release authorization",
+                ));
+            }
+            OwnerEvent::Gate(Ok(GateEvent::TargetStarted { .. })) => {
+                return Err(AviateSupervisorError::protocol(
+                    "the launch gate sent duplicate target identity",
+                ));
+            }
+            OwnerEvent::Gate(Err(error)) => {
+                owner.gate_failed = true;
+                return Err(error);
+            }
+        }
+    }
+}
+
+fn wait_for_exact_target_absent(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let Some(pid) = owner.target_pid else {
+        return Ok(());
+    };
+    let timeout = Duration::from_millis(owner.bootstrap.cleanup_timeout_millis);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout {
+            operation: "wait for exact target removal",
+        })?;
+    loop {
+        let actual = crate::inspection::inspect_lifetime(pid)?;
+        match (&owner.target_identity, actual) {
+            (_, None) => return Ok(()),
+            (Some(expected), Some(actual)) => {
+                crate::inspection::validate_absent_or_exact(expected, Some(actual), "target")?;
+            }
+            (None, Some(_)) => {
+                return Err(AviateSupervisorError::RecoveryBlocked {
+                    detail: "the target PID is live without an attested lifetime".to_owned(),
+                });
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "wait for exact target removal",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn signal_group(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    validate_gate_lifetime(owner)?;
+    validate_target_group(owner)?;
+    let group = owner.process_identity.target_gate.process_group;
+    match process_control::signal_process_group(group)? {
+        ProcessGroupSignal::Delivered => Ok(()),
+        ProcessGroupSignal::GroupMissing
+            if crate::inspection::process_group_snapshot(
+                owner.process_identity.target_gate.process_group,
+            )?
+            .is_quiescent() =>
+        {
+            Ok(())
+        }
+        ProcessGroupSignal::GroupMissing => Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the target process group disappeared before it became quiescent".to_owned(),
+        }),
+    }
+}
+
+fn validate_target_group(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let expected = &owner.process_identity.target_gate;
+    let snapshot = crate::inspection::process_group_snapshot(expected.process_group)?;
+    let has_untrusted_member = !snapshot.unclassified_pids.is_empty()
+        || snapshot.raw_pids.len() != snapshot.observed.len().wrapping_add(snapshot.exited.len())
+        || snapshot.observed.iter().any(|member| {
+            member.session_id != expected.session_id
+                || member.real_user_id != expected.real_user_id
+                || member.start.boot_identity() != expected.start.boot_identity()
+        });
+    if has_untrusted_member {
+        return Err(AviateSupervisorError::RecoveryBlocked {
+            detail: "the target group has a member outside the isolated launch session".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn wait_for_gate_quiescence(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    wait_for_members(owner, "wait for target group quiescence", |snapshot| {
+        Ok(snapshot.is_quiescent())
+    })
+}
+
+fn wait_for_group_empty(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    wait_for_members(owner, "wait for target group removal", |snapshot| {
+        Ok(snapshot.is_empty()
+            && crate::inspection::process_group_is_absent(
+                owner.process_identity.target_gate.process_group,
+            )?)
+    })
+}
+
+fn wait_for_members(
+    owner: &PreparedOwner,
+    operation: &'static str,
+    complete: impl Fn(&crate::inspection::ProcessGroupSnapshot) -> Result<bool, AviateSupervisorError>,
+) -> Result<(), AviateSupervisorError> {
+    let timeout = Duration::from_millis(owner.bootstrap.cleanup_timeout_millis);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout { operation })?;
+    loop {
+        let snapshot = crate::inspection::process_group_snapshot(
+            owner.process_identity.target_gate.process_group,
+        )?;
+        if complete(&snapshot)? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout { operation });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn cleanup_runtime_and_artifacts(owner: &PreparedOwner) -> Result<(), AviateSupervisorError> {
+    artifact::validate_directory(&owner.bootstrap.runtime_root, true)?;
+    remove_exact_socket(&socket_path(
+        &owner.bootstrap.runtime_root.path,
+        PARENT_READY_SOCKET,
+    ))?;
+    crate::runtime_files::require_entries(&owner.bootstrap.runtime_root.path, &[])?;
+    for executable in [
+        &owner.bootstrap.target_executable,
+        &owner.bootstrap.supervisor_executable,
+    ] {
+        artifact::remove_staged(&owner.bootstrap.artifact_root, executable)?;
+    }
+    artifact::remove_artifact_root(&owner.bootstrap.artifact_root)
+}
+
+fn hold_failed_cleanup(_owner: PreparedOwner, error: AviateSupervisorError) -> ! {
+    tracing::error!(%error, "Aviate cleanup failed; the owner keeps the writer lease");
+    loop {
+        std::thread::park();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests;

--- a/tools/flight-tune-aviate/src/supervisor/owner/cleanup/tests.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/cleanup/tests.rs
@@ -1,0 +1,143 @@
+use pilotage_durable_storage::{
+    DurabilityStep, FaultAction, FaultController, FaultRule, StorageError, StorageOperation,
+};
+
+use crate::AviateSupervisorError;
+use crate::document::{
+    ProcessIdentity, ProcessStartIdentity, SCHEMA_VERSION, TARGET_ATTESTATION_NAME,
+    TargetAttestation,
+};
+use crate::lease_store::{LeaseStore, digest_bytes};
+use crate::supervisor::owner::TargetPublicationState;
+
+use super::resolve_target_publication;
+
+#[test]
+fn ambiguous_target_publication_resolves_to_its_exact_digest() {
+    let temporary = test_root("target-linked-publication");
+    let root = temporary.path().join("storage");
+    let faults = FaultController::new([
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectPublication,
+            FaultAction::LoseAckAfter,
+        ),
+        FaultRule::once(
+            StorageOperation::PublishImmutable,
+            DurabilityStep::ObjectReadback,
+            FaultAction::FailBefore,
+        ),
+    ]);
+    let store = LeaseStore::create_fresh_with_faults(&root, faults.clone())
+        .expect("create faulted target store");
+    let expected = target_attestation();
+    let mut state = TargetPublicationState::Candidate(expected.clone());
+
+    let error = store
+        .publish(TARGET_ATTESTATION_NAME, &expected)
+        .expect_err("lose the linked publication acknowledgement");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::Storage { source, .. }
+            if matches!(source.as_ref(), StorageError::AmbiguousCommit { .. })
+    ));
+    let expected_bytes = serde_json::to_vec(&expected).expect("encode expected attestation");
+    let expected_digest = digest_bytes(&expected_bytes);
+    let resolved =
+        resolve_target_publication(&store, &mut state).expect("repair target publication");
+
+    assert_eq!(resolved, Some(expected_digest));
+    assert_eq!(
+        state,
+        TargetPublicationState::Published {
+            attestation: expected.clone(),
+            digest: expected_digest,
+        }
+    );
+    let (stored, stored_digest): (TargetAttestation, _) = store
+        .read(TARGET_ATTESTATION_NAME)
+        .expect("read repaired target attestation");
+    assert_eq!(stored, expected);
+    assert_eq!(stored_digest, expected_digest);
+    assert_eq!(temporary_object_count(&root), 0);
+    assert!(faults.is_exhausted().expect("inspect target faults"));
+}
+
+#[test]
+fn uncommitted_target_candidate_resolves_to_absence() {
+    let temporary = test_root("target-uncommitted-publication");
+    let root = temporary.path().join("storage");
+    let faults = FaultController::new([FaultRule::once(
+        StorageOperation::PublishImmutable,
+        DurabilityStep::ObjectData,
+        FaultAction::FailBefore,
+    )]);
+    let store = LeaseStore::create_fresh_with_faults(&root, faults.clone())
+        .expect("create faulted target store");
+    let expected = target_attestation();
+    let mut state = TargetPublicationState::Candidate(expected.clone());
+
+    let error = store
+        .publish(TARGET_ATTESTATION_NAME, &expected)
+        .expect_err("stop target publication before commit");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::Storage { source, .. }
+            if matches!(source.as_ref(), StorageError::InjectedFault { .. })
+    ));
+    let resolved =
+        resolve_target_publication(&store, &mut state).expect("classify absent target publication");
+
+    assert_eq!(resolved, None);
+    assert_eq!(state, TargetPublicationState::NotAttempted);
+    assert!(!root.join(TARGET_ATTESTATION_NAME).exists());
+    assert!(faults.is_exhausted().expect("inspect target faults"));
+}
+
+fn target_attestation() -> TargetAttestation {
+    let argument_digest = fixed_digest(3);
+    TargetAttestation {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: fixed_digest(1),
+        target: ProcessIdentity {
+            pid: 13,
+            process_group: 11,
+            session_id: 11,
+            parent_pid: 11,
+            real_user_id: 501,
+            start: ProcessStartIdentity::Linux {
+                boot_id: "12345678-1234-1234-1234-123456789abc".to_owned(),
+                start_ticks: 17,
+            },
+            executable: "/private/target".into(),
+            executable_digest: fixed_digest(2),
+            launch_argv_digest: argument_digest,
+            observed_argv_digest: Some(argument_digest),
+        },
+    }
+}
+
+fn fixed_digest(byte: u8) -> flight_tune::Digest {
+    flight_tune::Digest::from_bytes([byte; 32])
+}
+
+fn test_root(prefix: &str) -> tempfile::TempDir {
+    let temporary_parent = std::fs::canonicalize("/tmp").expect("canonical temporary parent");
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(temporary_parent)
+        .expect("create target publication root")
+}
+
+fn temporary_object_count(root: &std::path::Path) -> usize {
+    std::fs::read_dir(root)
+        .expect("read target publication root")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".pilotage-tmp-")
+        })
+        .count()
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner/handshake.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/handshake.rs
@@ -1,0 +1,295 @@
+use std::io::Write as _;
+use std::time::{Duration, Instant};
+
+use super::super::config::GateConfig;
+use super::{
+    OwnerEvent, PreparedOwner, TargetPublicationState, attest_target, cleanup, launch, process_io,
+};
+use crate::AviateSupervisorError;
+use crate::document::{PROCESS_IDENTITY_NAME, TARGET_ATTESTATION_NAME};
+use crate::protocol::{ArmedMessage, GateEvent, ReleaseMessage, TargetReleaseMessage, encode_line};
+use crate::runtime_files::{PARENT_READY_SOCKET, socket_path};
+
+pub(super) fn run_prepared(mut owner: PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let release = match wait_for_parent_release(&mut owner) {
+        Ok(release) => release,
+        Err(error) => return cleanup::finish_after_error(owner, error),
+    };
+    match authorize_target(&mut owner, &release) {
+        Ok(()) => serve(owner),
+        Err(error) => reject_and_finish(owner, error),
+    }
+}
+
+fn reject_and_finish(
+    owner: PreparedOwner,
+    error: AviateSupervisorError,
+) -> Result<(), AviateSupervisorError> {
+    let notification = match &error {
+        AviateSupervisorError::IdentityMismatch { detail } => send_target_rejection(&owner, detail),
+        _ => Ok(()),
+    };
+    let error = match notification {
+        Ok(()) => error,
+        Err(notification) => AviateSupervisorError::ReleaseNotification {
+            source: Box::new(error),
+            notification: Box::new(notification),
+        },
+    };
+    cleanup::finish_after_error(owner, error)
+}
+
+pub(super) fn arm_owner(
+    owner: &mut PreparedOwner,
+    release_secret_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    let config = launch::gate_config(&owner.bootstrap, release_secret_digest)?;
+    let gate_input = owner
+        .gate_input
+        .as_mut()
+        .ok_or_else(|| AviateSupervisorError::protocol("the launch-gate input pipe is missing"))?;
+    write_gate_config(gate_input, &config)?;
+    let digest = owner
+        .store
+        .publish(PROCESS_IDENTITY_NAME, &owner.process_identity)?;
+    owner.process_identity_digest = Some(digest);
+    send_armed(owner, digest)
+}
+
+fn write_gate_config(
+    gate_input: &mut std::process::ChildStdin,
+    config: &GateConfig,
+) -> Result<(), AviateSupervisorError> {
+    gate_input
+        .write_all(&encode_line(config)?)
+        .and_then(|()| gate_input.flush())
+        .map_err(|source| process_io("write launch-gate configuration", source))
+}
+
+fn wait_for_parent_release(
+    owner: &mut PreparedOwner,
+) -> Result<ReleaseMessage, AviateSupervisorError> {
+    let timeout = Duration::from_millis(owner.bootstrap.startup_timeout_millis);
+    match owner.events.recv_timeout(timeout) {
+        Ok(OwnerEvent::ParentRelease(result)) => result,
+        Ok(OwnerEvent::ParentClosed) => Err(AviateSupervisorError::protocol(
+            "the parent closed before release authorization",
+        )),
+        Ok(OwnerEvent::Gate(Err(error))) => {
+            owner.gate_failed = true;
+            Err(error)
+        }
+        Ok(OwnerEvent::Gate(Ok(_))) => Err(AviateSupervisorError::protocol(
+            "the launch gate ran before parent authorization",
+        )),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(AviateSupervisorError::Timeout {
+            operation: "wait for parent release authorization",
+        }),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(
+            AviateSupervisorError::protocol("the owner event channel closed"),
+        ),
+    }
+}
+
+fn authorize_target(
+    owner: &mut PreparedOwner,
+    release: &ReleaseMessage,
+) -> Result<(), AviateSupervisorError> {
+    if release.correlation_nonce != owner.process_identity.correlation_nonce
+        || crate::lease_store::digest_bytes(release.release_secret.as_bytes())
+            != owner.bootstrap.release_secret_digest
+    {
+        return Err(AviateSupervisorError::protocol(
+            "the parent release capability is invalid",
+        ));
+    }
+    let gate_input = owner
+        .gate_input
+        .as_mut()
+        .ok_or_else(|| AviateSupervisorError::protocol("the launch-gate input pipe is missing"))?;
+    gate_input
+        .write_all(release.release_secret.as_bytes())
+        .and_then(|()| gate_input.write_all(b"\n"))
+        .and_then(|()| gate_input.flush())
+        .map_err(|source| process_io("release exact launch gate", source))?;
+    owner.target_release_sent = true;
+    let started = wait_for_target_start(owner)?;
+    owner.target_pid = Some(started.pid);
+    if started.parent_closed {
+        return Err(AviateSupervisorError::protocol(
+            "the parent closed after target release authorization",
+        ));
+    }
+    let attestation = attest_target(owner, started.pid)?;
+    owner.target_publication = TargetPublicationState::Candidate(attestation.clone());
+    let digest = owner.store.publish(TARGET_ATTESTATION_NAME, &attestation)?;
+    owner.target_publication = TargetPublicationState::Published {
+        attestation,
+        digest,
+    };
+    send_target_ready(owner, digest)?;
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct StartedTarget {
+    pid: u32,
+    parent_closed: bool,
+}
+
+fn wait_for_target_start(
+    owner: &mut PreparedOwner,
+) -> Result<StartedTarget, AviateSupervisorError> {
+    let timeout = Duration::from_millis(owner.bootstrap.startup_timeout_millis);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout {
+            operation: "wait for launch-gate target identity",
+        })?;
+    let events = &owner.events;
+    let gate_failed = &mut owner.gate_failed;
+    let gate_input = &mut owner.gate_input;
+    receive_target_start(events, deadline, gate_failed, || {
+        gate_input.take();
+    })
+}
+
+fn receive_target_start(
+    events: &std::sync::mpsc::Receiver<OwnerEvent>,
+    deadline: Instant,
+    gate_failed: &mut bool,
+    mut request_containment: impl FnMut(),
+) -> Result<StartedTarget, AviateSupervisorError> {
+    let mut parent_closed = false;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let event = events
+            .recv_timeout(remaining)
+            .map_err(|error| match error {
+                std::sync::mpsc::RecvTimeoutError::Timeout => AviateSupervisorError::Timeout {
+                    operation: "wait for launch-gate target identity",
+                },
+                std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                    AviateSupervisorError::protocol("the owner event channel closed")
+                }
+            })?;
+        match event {
+            OwnerEvent::Gate(Ok(GateEvent::TargetStarted { pid })) => {
+                return Ok(StartedTarget { pid, parent_closed });
+            }
+            OwnerEvent::Gate(Ok(GateEvent::TargetContained { .. })) => {
+                return Err(AviateSupervisorError::protocol(
+                    "the launch gate contained a target before it reported the target identity",
+                ));
+            }
+            OwnerEvent::ParentClosed => {
+                if !parent_closed {
+                    request_containment();
+                    parent_closed = true;
+                }
+            }
+            OwnerEvent::ParentRelease(_) => {
+                return Err(AviateSupervisorError::protocol(
+                    "the parent sent duplicate release authorization",
+                ));
+            }
+            OwnerEvent::Gate(Err(error)) => {
+                *gate_failed = true;
+                return Err(error);
+            }
+        }
+    }
+}
+
+fn serve(mut owner: PreparedOwner) -> Result<(), AviateSupervisorError> {
+    let event = match owner.events.recv() {
+        Ok(event) => event,
+        Err(_) => {
+            return cleanup::finish_after_error(
+                owner,
+                AviateSupervisorError::protocol("the owner event channel closed"),
+            );
+        }
+    };
+    match event {
+        OwnerEvent::ParentClosed => cleanup::finish_or_hold(owner),
+        OwnerEvent::ParentRelease(_) => cleanup::finish_after_error(
+            owner,
+            AviateSupervisorError::protocol("the parent sent duplicate release authorization"),
+        ),
+        OwnerEvent::Gate(Ok(GateEvent::TargetStarted { .. })) => cleanup::finish_after_error(
+            owner,
+            AviateSupervisorError::protocol("the launch gate sent duplicate target identity"),
+        ),
+        OwnerEvent::Gate(Ok(GateEvent::TargetContained { pid })) => {
+            if owner.target_pid == Some(pid) {
+                owner.target_contained = true;
+            }
+            cleanup::finish_after_error(
+                owner,
+                AviateSupervisorError::protocol(
+                    "the launch gate contained the target before parent closure",
+                ),
+            )
+        }
+        OwnerEvent::Gate(Err(error)) => {
+            owner.gate_failed = true;
+            cleanup::finish_after_error(owner, error)
+        }
+    }
+}
+
+fn send_armed(
+    owner: &PreparedOwner,
+    process_identity_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    let message = ArmedMessage {
+        correlation_nonce: owner.process_identity.correlation_nonce,
+        spawn_intent_digest: owner.spawn_intent_digest,
+        process_identity_digest,
+    };
+    send_parent_message(owner, &message)
+}
+
+fn send_target_ready(
+    owner: &PreparedOwner,
+    target_attestation_digest: flight_tune::Digest,
+) -> Result<(), AviateSupervisorError> {
+    let process_identity_digest = owner.process_identity_digest.ok_or_else(|| {
+        AviateSupervisorError::invalid_document(
+            "process identity",
+            "the process identity was not durably published",
+        )
+    })?;
+    let message = TargetReleaseMessage::Ready {
+        correlation_nonce: owner.process_identity.correlation_nonce,
+        process_identity_digest,
+        target_attestation_digest,
+    };
+    send_parent_message(owner, &message)
+}
+
+fn send_target_rejection(owner: &PreparedOwner, detail: &str) -> Result<(), AviateSupervisorError> {
+    send_parent_message(
+        owner,
+        &TargetReleaseMessage::RejectedIdentityMismatch {
+            correlation_nonce: owner.process_identity.correlation_nonce,
+            detail: detail.to_owned(),
+        },
+    )
+}
+
+#[cfg(test)]
+#[path = "handshake/tests.rs"]
+mod tests;
+
+fn send_parent_message(
+    owner: &PreparedOwner,
+    message: &impl serde::Serialize,
+) -> Result<(), AviateSupervisorError> {
+    crate::protocol::connect_and_write(
+        &socket_path(&owner.bootstrap.runtime_root.path, PARENT_READY_SOCKET),
+        message,
+        Duration::from_millis(owner.bootstrap.startup_timeout_millis),
+    )
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner/handshake/tests.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/handshake/tests.rs
@@ -1,0 +1,43 @@
+#![allow(clippy::expect_used)]
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use super::{GateEvent, OwnerEvent, StartedTarget, receive_target_start};
+
+#[test]
+fn parent_close_requests_containment_before_target_start() {
+    let (sender, events) = mpsc::channel();
+    let (containment, contained) = mpsc::channel();
+    sender
+        .send(OwnerEvent::ParentClosed)
+        .expect("queue parent closure");
+    let gate = std::thread::Builder::new()
+        .name("aviate-parent-close-test-gate".to_owned())
+        .spawn(move || {
+            contained.recv().expect("observe containment request");
+            sender
+                .send(OwnerEvent::Gate(Ok(GateEvent::TargetStarted { pid: 41 })))
+                .expect("queue target identity");
+        })
+        .expect("spawn test gate");
+    let mut gate_failed = false;
+    let deadline = Instant::now()
+        .checked_add(Duration::from_secs(1))
+        .expect("make target-start deadline");
+
+    let started = receive_target_start(&events, deadline, &mut gate_failed, || {
+        containment.send(()).expect("request target containment");
+    })
+    .expect("retain target identity after parent closure");
+    gate.join().expect("test gate completes");
+
+    assert_eq!(
+        started,
+        StartedTarget {
+            pid: 41,
+            parent_closed: true,
+        }
+    );
+    assert!(!gate_failed);
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner/launch.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/launch.rs
@@ -1,0 +1,482 @@
+use std::io::{BufRead as _, Read as _};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use super::super::config::{
+    BOOTSTRAP_SCHEMA_VERSION, GateConfig, SupervisorBootstrap, digest_environment,
+    validate_bootstrap,
+};
+use super::super::process_control;
+use super::{OwnerEvent, PreparedOwner, TargetPublicationState, cleanup, handshake, process_io};
+use crate::AviateSupervisorError;
+use crate::artifact;
+use crate::document::{
+    ProcessIdentity, ProcessIdentityDocument, SCHEMA_VERSION, SPAWN_INTENT_NAME, SpawnIntent,
+    TargetAttestation, TargetStdio,
+};
+use crate::inspection;
+use crate::lease_store::LeaseStore;
+use crate::protocol::{GateEvent, ReleaseMessage, decode, read_line_blocking};
+use crate::runtime_files::PARENT_READY_SOCKET;
+
+pub(super) fn prepare() -> Result<PreparedOwner, AviateSupervisorError> {
+    let (storage_root, runtime_root) = parse_paths()?;
+    let mut input = std::io::stdin();
+    let bootstrap: SupervisorBootstrap = decode(&read_line_blocking(&mut input)?)?;
+    validate_bootstrap(&bootstrap)?;
+    validate_paths(&bootstrap, &runtime_root)?;
+    validate_artifacts(&bootstrap)?;
+    let (event_sender, events) = start_event_channel(input)?;
+    prepare_owner(storage_root, bootstrap, event_sender, events)
+}
+
+fn prepare_owner(
+    storage_root: PathBuf,
+    bootstrap: SupervisorBootstrap,
+    event_sender: mpsc::Sender<OwnerEvent>,
+    events: mpsc::Receiver<OwnerEvent>,
+) -> Result<PreparedOwner, AviateSupervisorError> {
+    let store = LeaseStore::create_fresh(&storage_root)?;
+    let correlation_nonce = random_digest()?;
+    let release_secret_digest = bootstrap.release_secret_digest;
+    let intent = spawn_intent(&bootstrap, correlation_nonce, release_secret_digest)?;
+    let spawn_intent_digest = store.publish(SPAWN_INTENT_NAME, &intent)?;
+    let self_identity = inspect_self(&bootstrap)?;
+    let (gate, gate_input, gate_output, gate_identity) = spawn_gate(&bootstrap)?;
+    let identity = ProcessIdentityDocument {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: bootstrap.run_intent_digest,
+        spawn_intent_digest,
+        correlation_nonce,
+        supervisor: self_identity,
+        target_gate: gate_identity,
+    };
+    let mut owner = PreparedOwner {
+        bootstrap,
+        store,
+        spawn_intent_digest,
+        process_identity_digest: None,
+        target_publication: TargetPublicationState::NotAttempted,
+        process_identity: identity,
+        target_pid: None,
+        target_release_sent: false,
+        target_identity: None,
+        target_contained: false,
+        gate_failed: false,
+        gate,
+        gate_input: Some(gate_input),
+        events,
+    };
+    if let Err(error) = start_gate_monitor(gate_output, event_sender) {
+        return cleanup::finish_after_error(owner, error);
+    }
+    if let Err(error) = handshake::arm_owner(&mut owner, release_secret_digest) {
+        return cleanup::finish_after_error(owner, error);
+    }
+    Ok(owner)
+}
+
+pub(super) fn attest_target(
+    owner: &mut PreparedOwner,
+    pid: u32,
+) -> Result<TargetAttestation, AviateSupervisorError> {
+    let digest = target_argv_digest(&owner.bootstrap)?;
+    let target = wait_for_process(
+        pid,
+        digest,
+        Duration::from_millis(owner.bootstrap.startup_timeout_millis),
+    )?;
+    owner.target_identity = Some(target.clone());
+    if target.parent_pid != owner.process_identity.target_gate.pid
+        || target.process_group != owner.process_identity.target_gate.process_group
+        || target.session_id != owner.process_identity.target_gate.session_id
+        || target.executable != owner.bootstrap.target_executable.path
+        || target.executable_digest != owner.bootstrap.target_executable.digest
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the live target differs from the authorized launch",
+        ));
+    }
+    Ok(TargetAttestation {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: owner.bootstrap.run_intent_digest,
+        target,
+    })
+}
+
+pub(super) fn target_argv_digest(
+    bootstrap: &SupervisorBootstrap,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let executable =
+        bootstrap.target_executable.path.to_str().ok_or_else(|| {
+            AviateSupervisorError::invalid_request("the target path is not UTF-8")
+        })?;
+    let mut arguments = Vec::with_capacity(bootstrap.target_arguments.len().wrapping_add(1));
+    arguments.push(executable.to_owned());
+    arguments.extend(bootstrap.target_arguments.iter().cloned());
+    Ok(inspection::digest_arguments(&arguments))
+}
+
+fn spawn_intent(
+    bootstrap: &SupervisorBootstrap,
+    correlation_nonce: flight_tune::Digest,
+    release_secret_digest: flight_tune::Digest,
+) -> Result<SpawnIntent, AviateSupervisorError> {
+    Ok(SpawnIntent {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: bootstrap.run_intent_digest,
+        correlation_nonce,
+        release_secret_digest,
+        supervisor_executable: bootstrap.supervisor_executable.clone(),
+        target_executable: bootstrap.target_executable.clone(),
+        target_arguments: bootstrap.target_arguments.clone(),
+        target_argv_digest: target_argv_digest(bootstrap)?,
+        target_environment_digest: digest_environment(&bootstrap.target_environment),
+        target_current_directory: bootstrap.target_current_directory.clone(),
+        target_stdio: TargetStdio::Null,
+        target_process_contract: bootstrap.target_process_contract.clone(),
+        cleanup_timeout_millis: bootstrap.cleanup_timeout_millis,
+        runtime_root: bootstrap.runtime_root.clone(),
+        artifact_root: bootstrap.artifact_root.clone(),
+    })
+}
+
+pub(super) fn gate_config(
+    bootstrap: &SupervisorBootstrap,
+    release_secret_digest: flight_tune::Digest,
+) -> Result<GateConfig, AviateSupervisorError> {
+    Ok(GateConfig {
+        schema_version: BOOTSTRAP_SCHEMA_VERSION,
+        release_secret_digest,
+        target_executable: bootstrap.target_executable.clone(),
+        artifact_root: bootstrap.artifact_root.clone(),
+        target_arguments: bootstrap.target_arguments.clone(),
+        target_environment: bootstrap.target_environment.clone(),
+        target_environment_digest: digest_environment(&bootstrap.target_environment),
+        target_current_directory: bootstrap.target_current_directory.clone(),
+        target_argv_digest: target_argv_digest(bootstrap)?,
+        target_process_contract: bootstrap.target_process_contract.clone(),
+    })
+}
+
+fn spawn_gate(
+    bootstrap: &SupervisorBootstrap,
+) -> Result<
+    (
+        Child,
+        ChildStdin,
+        std::process::ChildStdout,
+        ProcessIdentity,
+    ),
+    AviateSupervisorError,
+> {
+    let mut command = Command::new(&bootstrap.supervisor_executable.path);
+    command
+        .arg("gate")
+        .env_clear()
+        .current_dir(&bootstrap.artifact_root.path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let child = command
+        .spawn()
+        .map_err(|source| process_io("spawn exact target launch gate", source))?;
+    finish_gate_spawn(bootstrap, child)
+}
+
+fn finish_gate_spawn(
+    bootstrap: &SupervisorBootstrap,
+    mut child: Child,
+) -> Result<
+    (
+        Child,
+        ChildStdin,
+        std::process::ChildStdout,
+        ProcessIdentity,
+    ),
+    AviateSupervisorError,
+> {
+    let result = take_gate_pipes(&mut child).and_then(|(input, output)| {
+        let argv = vec![
+            bootstrap
+                .supervisor_executable
+                .path
+                .to_string_lossy()
+                .into_owned(),
+            "gate".to_owned(),
+        ];
+        let identity = wait_for_gate_process(
+            child.id(),
+            inspection::digest_arguments(&argv),
+            Duration::from_millis(bootstrap.startup_timeout_millis),
+        )?;
+        validate_gate_identity(bootstrap, &identity)?;
+        Ok((input, output, identity))
+    });
+    match result {
+        Ok((input, output, identity)) => Ok((child, input, output, identity)),
+        Err(error) => cleanup_unconfigured_gate(child, error),
+    }
+}
+
+fn wait_for_gate_process(
+    pid: u32,
+    argv_digest: flight_tune::Digest,
+    timeout: Duration,
+) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let deadline = checked_deadline(timeout, "inspect isolated launch gate")?;
+    loop {
+        let isolated = match inspection::inspect_lifetime(pid) {
+            Ok(Some(identity)) => identity.process_group == pid && identity.session_id == pid,
+            Ok(None) | Err(AviateSupervisorError::IdentityMismatch { .. }) => false,
+            Err(error) => return Err(error),
+        };
+        if isolated {
+            match inspection::inspect_process(pid, argv_digest) {
+                Ok(Some(identity))
+                    if identity.process_group == pid && identity.session_id == pid =>
+                {
+                    return Ok(identity);
+                }
+                Ok(_) | Err(AviateSupervisorError::IdentityMismatch { .. }) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "inspect isolated launch gate",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn take_gate_pipes(
+    child: &mut Child,
+) -> Result<(ChildStdin, std::process::ChildStdout), AviateSupervisorError> {
+    let input = child
+        .stdin
+        .take()
+        .ok_or_else(|| AviateSupervisorError::protocol("the launch-gate input pipe is missing"))?;
+    let output = child
+        .stdout
+        .take()
+        .ok_or_else(|| AviateSupervisorError::protocol("the launch-gate event pipe is missing"))?;
+    Ok((input, output))
+}
+
+fn validate_gate_identity(
+    bootstrap: &SupervisorBootstrap,
+    identity: &ProcessIdentity,
+) -> Result<(), AviateSupervisorError> {
+    if identity.process_group != identity.pid
+        || identity.session_id != identity.pid
+        || identity.executable != bootstrap.supervisor_executable.path
+        || identity.executable_digest != bootstrap.supervisor_executable.digest
+        || identity.parent_pid != std::process::id()
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the target launch-gate identity is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_unconfigured_gate<T>(
+    mut child: Child,
+    source: AviateSupervisorError,
+) -> Result<T, AviateSupervisorError> {
+    let stop = match process_control::stop_child(&mut child) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => Ok(()),
+        Err(error) => Err(process_io("stop unconfigured launch gate", error)),
+    };
+    let reap = child
+        .wait()
+        .map(|_| ())
+        .map_err(|error| process_io("reap unconfigured launch gate", error));
+    let cleanup = match (stop, reap) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(source), Err(cleanup)) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    };
+    match cleanup {
+        Ok(()) => Err(source),
+        Err(cleanup) => Err(AviateSupervisorError::StartupCleanup {
+            source: Box::new(source),
+            cleanup: Box::new(cleanup),
+        }),
+    }
+}
+
+fn inspect_self(bootstrap: &SupervisorBootstrap) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let arguments = std::env::args().collect::<Vec<_>>();
+    let identity =
+        inspection::inspect_process(std::process::id(), inspection::digest_arguments(&arguments))?
+            .ok_or_else(|| {
+                AviateSupervisorError::identity_mismatch("the supervisor disappeared")
+            })?;
+    if identity.executable != bootstrap.supervisor_executable.path
+        || identity.executable_digest != bootstrap.supervisor_executable.digest
+    {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the supervisor executable identity is invalid",
+        ));
+    }
+    Ok(identity)
+}
+
+fn wait_for_process(
+    pid: u32,
+    argv_digest: flight_tune::Digest,
+    timeout: Duration,
+) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let deadline = checked_deadline(timeout, "inspect spawned process")?;
+    loop {
+        if let Some(identity) = inspection::inspect_process(pid, argv_digest)? {
+            return Ok(identity);
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "inspect spawned process",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn validate_artifacts(bootstrap: &SupervisorBootstrap) -> Result<(), AviateSupervisorError> {
+    artifact::validate_directory(&bootstrap.artifact_root, true)?;
+    artifact::validate_directory(&bootstrap.target_current_directory, false)?;
+    for executable in [
+        &bootstrap.supervisor_executable,
+        &bootstrap.target_executable,
+    ] {
+        if artifact::inspect_staged(&executable.path, executable.digest)? != *executable {
+            return Err(AviateSupervisorError::identity_mismatch(
+                "a staged launch executable identity changed",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_paths(
+    bootstrap: &SupervisorBootstrap,
+    runtime_root: &Path,
+) -> Result<(), AviateSupervisorError> {
+    if runtime_root != bootstrap.runtime_root.path {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the runtime path differs from the anonymous bootstrap",
+        ));
+    }
+    crate::runtime_files::validate_private_root(runtime_root)?;
+    artifact::validate_directory(&bootstrap.runtime_root, true)?;
+    crate::runtime_files::require_entries(runtime_root, &[PARENT_READY_SOCKET])
+}
+
+fn parse_paths() -> Result<(PathBuf, PathBuf), AviateSupervisorError> {
+    let arguments = std::env::args_os().collect::<Vec<_>>();
+    if arguments.len() != 4 {
+        return Err(AviateSupervisorError::invalid_request(
+            "the process owner received unexpected command arguments",
+        ));
+    }
+    Ok((PathBuf::from(&arguments[2]), PathBuf::from(&arguments[3])))
+}
+
+fn start_event_channel(
+    mut input: std::io::Stdin,
+) -> Result<(mpsc::Sender<OwnerEvent>, mpsc::Receiver<OwnerEvent>), AviateSupervisorError> {
+    let (sender, receiver) = mpsc::channel();
+    let monitor_sender = sender.clone();
+    std::thread::Builder::new()
+        .name("aviate-owner-parent-eof".to_owned())
+        .spawn(move || monitor_parent(&mut input, &monitor_sender))
+        .map(|_| (sender, receiver))
+        .map_err(|source| process_io("spawn owner parent monitor", source))
+}
+
+fn monitor_parent(input: &mut std::io::Stdin, sender: &mpsc::Sender<OwnerEvent>) {
+    match read_line_blocking(input) {
+        Ok(bytes) => {
+            if sender
+                .send(OwnerEvent::ParentRelease(decode::<ReleaseMessage>(&bytes)))
+                .is_err()
+            {
+                return;
+            }
+        }
+        Err(_) => {
+            if sender.send(OwnerEvent::ParentClosed).is_err() {
+                tracing::debug!("owner parent channel is already closed");
+            }
+            return;
+        }
+    }
+    let mut remainder = Vec::new();
+    if let Err(error) = input.read_to_end(&mut remainder) {
+        tracing::error!(%error, "owner parent pipe read failed");
+    }
+    if sender.send(OwnerEvent::ParentClosed).is_err() {
+        tracing::debug!("owner parent channel is already closed");
+    }
+}
+
+fn start_gate_monitor(
+    output: std::process::ChildStdout,
+    sender: mpsc::Sender<OwnerEvent>,
+) -> Result<(), AviateSupervisorError> {
+    std::thread::Builder::new()
+        .name("aviate-owner-gate-events".to_owned())
+        .spawn(move || monitor_gate(output, &sender))
+        .map(|_| ())
+        .map_err(|source| process_io("spawn launch-gate event monitor", source))
+}
+
+fn monitor_gate(output: std::process::ChildStdout, sender: &mpsc::Sender<OwnerEvent>) {
+    let mut reader = std::io::BufReader::new(output);
+    loop {
+        let mut line = String::new();
+        let event = match reader.read_line(&mut line) {
+            Ok(0) => Err(AviateSupervisorError::protocol(
+                "the launch-gate event pipe closed",
+            )),
+            Ok(_) => decode::<GateEvent>(line.as_bytes()),
+            Err(source) => Err(process_io("read launch-gate event", source)),
+        };
+        let terminal = event.is_err();
+        if sender.send(OwnerEvent::Gate(event)).is_err() || terminal {
+            break;
+        }
+    }
+}
+
+fn random_digest() -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let path = Path::new("/dev/urandom");
+    let mut random = std::fs::File::open(path).map_err(|source| {
+        inspection::io_error("open operating-system random source", path, source)
+    })?;
+    let mut bytes = [0_u8; 32];
+    random.read_exact(&mut bytes).map_err(|source| {
+        inspection::io_error("read operating-system random source", path, source)
+    })?;
+    Ok(flight_tune::Digest::from_bytes(bytes))
+}
+
+fn checked_deadline(
+    timeout: Duration,
+    operation: &'static str,
+) -> Result<Instant, AviateSupervisorError> {
+    Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout { operation })
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune-aviate/src/supervisor/owner/launch.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/launch.rs
@@ -21,6 +21,16 @@ use crate::lease_store::LeaseStore;
 use crate::protocol::{GateEvent, ReleaseMessage, decode, read_line_blocking};
 use crate::runtime_files::PARENT_READY_SOCKET;
 
+#[path = "launch/target.rs"]
+mod target;
+
+pub(super) fn attest_target(
+    owner: &mut PreparedOwner,
+    pid: u32,
+) -> Result<TargetAttestation, AviateSupervisorError> {
+    target::attest(owner, pid)
+}
+
 pub(super) fn prepare() -> Result<PreparedOwner, AviateSupervisorError> {
     let (storage_root, runtime_root) = parse_paths()?;
     let mut input = std::io::stdin();
@@ -78,47 +88,6 @@ fn prepare_owner(
     Ok(owner)
 }
 
-pub(super) fn attest_target(
-    owner: &mut PreparedOwner,
-    pid: u32,
-) -> Result<TargetAttestation, AviateSupervisorError> {
-    let digest = target_argv_digest(&owner.bootstrap)?;
-    let target = wait_for_process(
-        pid,
-        digest,
-        Duration::from_millis(owner.bootstrap.startup_timeout_millis),
-    )?;
-    owner.target_identity = Some(target.clone());
-    if target.parent_pid != owner.process_identity.target_gate.pid
-        || target.process_group != owner.process_identity.target_gate.process_group
-        || target.session_id != owner.process_identity.target_gate.session_id
-        || target.executable != owner.bootstrap.target_executable.path
-        || target.executable_digest != owner.bootstrap.target_executable.digest
-    {
-        return Err(AviateSupervisorError::identity_mismatch(
-            "the live target differs from the authorized launch",
-        ));
-    }
-    Ok(TargetAttestation {
-        schema_version: SCHEMA_VERSION,
-        run_intent_digest: owner.bootstrap.run_intent_digest,
-        target,
-    })
-}
-
-pub(super) fn target_argv_digest(
-    bootstrap: &SupervisorBootstrap,
-) -> Result<flight_tune::Digest, AviateSupervisorError> {
-    let executable =
-        bootstrap.target_executable.path.to_str().ok_or_else(|| {
-            AviateSupervisorError::invalid_request("the target path is not UTF-8")
-        })?;
-    let mut arguments = Vec::with_capacity(bootstrap.target_arguments.len().wrapping_add(1));
-    arguments.push(executable.to_owned());
-    arguments.extend(bootstrap.target_arguments.iter().cloned());
-    Ok(inspection::digest_arguments(&arguments))
-}
-
 fn spawn_intent(
     bootstrap: &SupervisorBootstrap,
     correlation_nonce: flight_tune::Digest,
@@ -132,7 +101,7 @@ fn spawn_intent(
         supervisor_executable: bootstrap.supervisor_executable.clone(),
         target_executable: bootstrap.target_executable.clone(),
         target_arguments: bootstrap.target_arguments.clone(),
-        target_argv_digest: target_argv_digest(bootstrap)?,
+        target_argv_digest: target::argv_digest(bootstrap)?,
         target_environment_digest: digest_environment(&bootstrap.target_environment),
         target_current_directory: bootstrap.target_current_directory.clone(),
         target_stdio: TargetStdio::Null,
@@ -156,7 +125,7 @@ pub(super) fn gate_config(
         target_environment: bootstrap.target_environment.clone(),
         target_environment_digest: digest_environment(&bootstrap.target_environment),
         target_current_directory: bootstrap.target_current_directory.clone(),
-        target_argv_digest: target_argv_digest(bootstrap)?,
+        target_argv_digest: target::argv_digest(bootstrap)?,
         target_process_contract: bootstrap.target_process_contract.clone(),
     })
 }
@@ -234,7 +203,12 @@ fn wait_for_gate_process(
             Err(error) => return Err(error),
         };
         if isolated {
-            match inspection::inspect_process(pid, argv_digest) {
+            match inspection::inspect_process_before(
+                pid,
+                argv_digest,
+                deadline,
+                "inspect isolated launch gate",
+            ) {
                 Ok(Some(identity))
                     if identity.process_group == pid && identity.session_id == pid =>
                 {
@@ -329,25 +303,6 @@ fn inspect_self(bootstrap: &SupervisorBootstrap) -> Result<ProcessIdentity, Avia
         ));
     }
     Ok(identity)
-}
-
-fn wait_for_process(
-    pid: u32,
-    argv_digest: flight_tune::Digest,
-    timeout: Duration,
-) -> Result<ProcessIdentity, AviateSupervisorError> {
-    let deadline = checked_deadline(timeout, "inspect spawned process")?;
-    loop {
-        if let Some(identity) = inspection::inspect_process(pid, argv_digest)? {
-            return Ok(identity);
-        }
-        if Instant::now() >= deadline {
-            return Err(AviateSupervisorError::Timeout {
-                operation: "inspect spawned process",
-            });
-        }
-        std::thread::park_timeout(Duration::from_millis(1));
-    }
 }
 
 fn validate_artifacts(bootstrap: &SupervisorBootstrap) -> Result<(), AviateSupervisorError> {

--- a/tools/flight-tune-aviate/src/supervisor/owner/launch/target.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/launch/target.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use super::super::PreparedOwner;
+use crate::AviateSupervisorError;
+use crate::document::{BootIdentity, ProcessIdentity, SCHEMA_VERSION, TargetAttestation};
+use crate::supervisor::SupervisorBootstrap;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TargetExpectation {
+    parent_pid: u32,
+    process_group: u32,
+    session_id: u32,
+    real_user_id: u32,
+    boot_identity: BootIdentity,
+    executable: PathBuf,
+    executable_digest: flight_tune::Digest,
+}
+
+pub(super) fn attest(
+    owner: &mut PreparedOwner,
+    pid: u32,
+) -> Result<TargetAttestation, AviateSupervisorError> {
+    let expectation = TargetExpectation::from_owner(owner);
+    let target = wait_for_expected_process(
+        pid,
+        argv_digest(&owner.bootstrap)?,
+        &expectation,
+        Duration::from_millis(owner.bootstrap.startup_timeout_millis),
+    )?;
+    owner.target_identity = Some(target.clone());
+    Ok(TargetAttestation {
+        schema_version: SCHEMA_VERSION,
+        run_intent_digest: owner.bootstrap.run_intent_digest,
+        target,
+    })
+}
+
+pub(super) fn argv_digest(
+    bootstrap: &SupervisorBootstrap,
+) -> Result<flight_tune::Digest, AviateSupervisorError> {
+    let executable =
+        bootstrap.target_executable.path.to_str().ok_or_else(|| {
+            AviateSupervisorError::invalid_request("the target path is not UTF-8")
+        })?;
+    let mut arguments = Vec::with_capacity(bootstrap.target_arguments.len().wrapping_add(1));
+    arguments.push(executable.to_owned());
+    arguments.extend(bootstrap.target_arguments.iter().cloned());
+    Ok(crate::inspection::digest_arguments(&arguments))
+}
+
+impl TargetExpectation {
+    fn from_owner(owner: &PreparedOwner) -> Self {
+        let gate = &owner.process_identity.target_gate;
+        Self {
+            parent_pid: gate.pid,
+            process_group: gate.process_group,
+            session_id: gate.session_id,
+            real_user_id: gate.real_user_id,
+            boot_identity: gate.start.boot_identity(),
+            executable: owner.bootstrap.target_executable.path.clone(),
+            executable_digest: owner.bootstrap.target_executable.digest,
+        }
+    }
+}
+
+fn wait_for_expected_process(
+    pid: u32,
+    argv_digest: flight_tune::Digest,
+    expected: &TargetExpectation,
+    timeout: Duration,
+) -> Result<ProcessIdentity, AviateSupervisorError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(AviateSupervisorError::Timeout {
+            operation: "inspect authorized target",
+        })?;
+    loop {
+        if let Some(identity) = crate::inspection::inspect_process_before(
+            pid,
+            argv_digest,
+            deadline,
+            "inspect authorized target",
+        )? {
+            validate_target(&identity, expected)?;
+            return Ok(identity);
+        }
+        if Instant::now() >= deadline {
+            return Err(AviateSupervisorError::Timeout {
+                operation: "inspect authorized target",
+            });
+        }
+        std::thread::park_timeout(Duration::from_millis(1));
+    }
+}
+
+fn validate_target(
+    actual: &ProcessIdentity,
+    expected: &TargetExpectation,
+) -> Result<(), AviateSupervisorError> {
+    let detail = if actual.parent_pid != expected.parent_pid {
+        Some("the target parent process differs from the launch gate")
+    } else if actual.process_group != expected.process_group {
+        Some("the target process group differs from the launch gate")
+    } else if actual.session_id != expected.session_id {
+        Some("the target session differs from the launch gate")
+    } else if actual.real_user_id != expected.real_user_id {
+        Some("the target user differs from the launch gate")
+    } else if actual.start.boot_identity() != expected.boot_identity {
+        Some("the target boot identity differs from the launch gate")
+    } else if actual.executable != expected.executable {
+        Some("the target executable path differs from the authorized launch")
+    } else if actual.executable_digest != expected.executable_digest {
+        Some("the target executable digest differs from the authorized launch")
+    } else {
+        None
+    };
+    detail.map_or(Ok(()), |detail| {
+        Err(AviateSupervisorError::identity_mismatch(detail))
+    })
+}

--- a/tools/flight-tune-aviate/src/supervisor/owner/launch/tests.rs
+++ b/tools/flight-tune-aviate/src/supervisor/owner/launch/tests.rs
@@ -1,0 +1,28 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::process::{Command, Stdio};
+
+use super::cleanup_unconfigured_gate;
+use crate::AviateSupervisorError;
+
+#[test]
+fn cleanup_accepts_an_already_reaped_gate() {
+    let mut child = Command::new(std::env::current_exe().expect("find test executable"))
+        .arg("--help")
+        .env_clear()
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn short test process");
+    child.wait().expect("reap short test process");
+    let result = cleanup_unconfigured_gate::<()>(
+        child,
+        AviateSupervisorError::protocol("test startup failure"),
+    );
+
+    assert!(matches!(
+        result,
+        Err(AviateSupervisorError::Protocol { detail, .. }) if detail == "test startup failure"
+    ));
+}

--- a/tools/flight-tune-aviate/src/supervisor/process_control.rs
+++ b/tools/flight-tune-aviate/src/supervisor/process_control.rs
@@ -1,0 +1,57 @@
+use std::process::Child;
+
+use crate::AviateSupervisorError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProcessGroupSignal {
+    Delivered,
+    GroupMissing,
+}
+
+pub(super) fn stop_child(child: &mut Child) -> std::io::Result<()> {
+    child.kill()
+}
+
+pub(super) fn signal_current_process_group() -> std::io::Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        rustix::process::kill_current_process_group(rustix::process::Signal::KILL)
+            .map_err(|source| std::io::Error::from_raw_os_error(source.raw_os_error()))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "process-group signals require Linux or macOS",
+        ))
+    }
+}
+
+pub(super) fn signal_process_group(
+    process_group: u32,
+) -> Result<ProcessGroupSignal, AviateSupervisorError> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let raw = i32::try_from(process_group).map_err(|_| {
+            AviateSupervisorError::identity_mismatch(
+                "the target process group exceeds POSIX limits",
+            )
+        })?;
+        let group = rustix::process::Pid::from_raw(raw).ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch("the target process group is zero")
+        })?;
+        match rustix::process::kill_process_group(group, rustix::process::Signal::KILL) {
+            Ok(()) => Ok(ProcessGroupSignal::Delivered),
+            Err(rustix::io::Errno::SRCH) => Ok(ProcessGroupSignal::GroupMissing),
+            Err(source) => Err(AviateSupervisorError::ProcessIo {
+                operation: "signal exact target process group",
+                source: std::io::Error::from_raw_os_error(source.raw_os_error()),
+            }),
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = process_group;
+        Err(AviateSupervisorError::UnsupportedPlatform)
+    }
+}

--- a/tools/flight-tune-aviate/tests/process_supervision.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision.rs
@@ -180,27 +180,6 @@ fn owner_sigkill_after_release_recovers_the_complete_group() {
 }
 
 #[test]
-fn drop_reaps_a_sigkilled_owner_before_recovery() {
-    let fixture = TestLaunch::new("owner-sigkill-drop");
-    let target = FifoWatch::new(fixture.target_fifo());
-    let prepared =
-        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare owner drop run");
-    let managed = prepared
-        .release_blocking()
-        .expect("release owner drop target");
-    let attestation = managed.supervision_attestation().clone();
-    target.expect_open("the owner drop target starts");
-
-    support::kill_process(attestation.supervisor_identity.pid);
-    target.expect_eof("the failed owner closes the exact target");
-    drop(managed);
-    let outcome = recover_supervised_process_blocking(&attestation.recovery_request)
-        .expect("recovery continues after the owner is reaped");
-
-    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
-}
-
-#[test]
 fn gate_sigkill_after_release_uses_owner_fallback() {
     let fixture = TestLaunch::new("gate-sigkill-released");
     let target = FifoWatch::new(fixture.target_fifo());

--- a/tools/flight-tune-aviate/tests/process_supervision.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision.rs
@@ -1,0 +1,284 @@
+//! Public process-supervision lifecycle tests with real child processes.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use flight_tune_aviate::{
+    AviateSupervisorError, PreparedAviateProcess, RecoveryOutcome, SupervisionAttestation,
+    recover_supervised_process_blocking,
+};
+
+#[path = "process_supervision/recovery_cases.rs"]
+mod recovery_cases;
+#[path = "process_supervision/support.rs"]
+mod support;
+
+use support::{DescendantControl, DriverProcess, FifoWatch, TestLaunch, UnrelatedProcess};
+
+#[test]
+fn supervised_target_fixture() {
+    support::run_target_fixture();
+}
+
+#[test]
+fn supervision_driver_fixture() {
+    support::run_driver_fixture();
+}
+
+#[test]
+fn unrelated_process_fixture() {
+    support::run_unrelated_fixture();
+}
+
+#[test]
+fn stubborn_descendant_fixture() {
+    support::run_stubborn_descendant_fixture();
+}
+
+#[test]
+fn prepared_launch_requires_release_and_cleans_exact_target() {
+    let fixture = TestLaunch::new("release");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare launch");
+    target.expect_no_event("the target remains behind the launch gate");
+    let encoded = serde_json::to_vec(prepared.supervision_attestation()).expect("encode evidence");
+    let persisted: SupervisionAttestation =
+        serde_json::from_slice(&encoded).expect("read external evidence");
+    assert_eq!(&persisted, prepared.supervision_attestation());
+
+    let mut managed = prepared.release_blocking().expect("release exact target");
+    target.expect_open("the released target starts");
+    managed
+        .ensure_running_blocking()
+        .expect("target is running");
+    let outcome = managed.terminate_blocking().expect("clean exact target");
+
+    target.expect_eof("the exact target stops");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn prepared_launch_can_close_without_starting_target() {
+    let fixture = TestLaunch::new("cancel");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare launch");
+
+    let outcome = prepared.cancel_blocking().expect("cancel prepared launch");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+    target.expect_unused("cancel keeps the target closed");
+}
+
+#[test]
+fn cleanup_kills_a_stubborn_same_group_descendant() {
+    let fixture = TestLaunch::new("descendant");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let descendant = FifoWatch::new(fixture.descendant_fifo());
+    let mut control = DescendantControl::new(fixture.descendant_control_fifo());
+    let prepared = PreparedAviateProcess::prepare_blocking(fixture.descendant_request())
+        .expect("prepare descendant launch");
+    let mut managed = prepared
+        .release_blocking()
+        .expect("release descendant launch");
+    target.expect_open("the target starts");
+    descendant.expect_open("the stubborn descendant starts");
+    control.connect();
+
+    let mut initial_error = None;
+    let outcome = match managed.terminate_blocking() {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            initial_error = Some(error);
+            control.release();
+            managed
+                .terminate_blocking()
+                .expect("clean the group after the fixture releases its descendant")
+        }
+    };
+
+    control.release();
+    target.expect_eof("the exact target stops");
+    descendant.expect_eof("the stubborn descendant stops");
+    if let Some(error) = initial_error {
+        panic!("production cleanup required the fixture fallback: {error}");
+    }
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn driver_crash_before_release_never_starts_the_target() {
+    let fixture = TestLaunch::new("driver-crash");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let lifecycle = FifoWatch::new(fixture.lifecycle_fifo());
+    let mut driver = DriverProcess::spawn(&fixture);
+    lifecycle.expect_open("the driver process family starts");
+    let attestation = driver.read_attestation();
+    target.expect_no_event("the prepared driver keeps the target closed");
+
+    driver.kill_and_wait();
+    lifecycle.expect_eof("the owner and launch gate stop after driver failure");
+    let outcome = recover_supervised_process_blocking(&attestation.recovery_request)
+        .expect("read terminal evidence after driver failure");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+    target.expect_unused("driver failure does not start the target");
+}
+
+#[test]
+fn driver_crash_after_release_cleans_the_complete_group() {
+    let fixture = TestLaunch::new("released-driver-crash");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let descendant = FifoWatch::new(fixture.descendant_fifo());
+    let mut control = DescendantControl::new(fixture.descendant_control_fifo());
+    let lifecycle = FifoWatch::new(fixture.lifecycle_fifo());
+    let mut driver = DriverProcess::spawn_released_descendant(&fixture);
+    lifecycle.expect_open("the released driver process family starts");
+    let attestation = driver.read_attestation();
+    target.expect_open("the released driver target starts");
+    descendant.expect_open("the released driver descendant starts");
+    control.connect();
+
+    driver.kill_and_wait();
+    target.expect_eof("driver failure stops the target");
+    descendant.expect_eof("driver failure stops the descendant");
+    lifecycle.expect_eof("driver failure stops the complete process family");
+    control.release();
+    let outcome = recover_supervised_process_blocking(&attestation.recovery_request)
+        .expect("read terminal evidence after released driver failure");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn owner_sigkill_after_release_recovers_the_complete_group() {
+    let fixture = TestLaunch::new("owner-sigkill-released");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let descendant = FifoWatch::new(fixture.descendant_fifo());
+    let mut control = DescendantControl::new(fixture.descendant_control_fifo());
+    let prepared = PreparedAviateProcess::prepare_blocking(fixture.descendant_request())
+        .expect("prepare owner crash launch");
+    let mut managed = prepared
+        .release_blocking()
+        .expect("release owner crash launch");
+    target.expect_open("the owner crash target starts");
+    descendant.expect_open("the owner crash descendant starts");
+    control.connect();
+    managed
+        .ensure_running_blocking()
+        .expect("the process family is live");
+
+    support::kill_process(managed.supervision_attestation().supervisor_identity.pid);
+    target.expect_eof("the gate stops the target after owner failure");
+    descendant.expect_eof("the gate stops the descendant after owner failure");
+    control.release();
+    let outcome = managed
+        .terminate_blocking()
+        .expect("same-boot recovery publishes terminal evidence");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn drop_reaps_a_sigkilled_owner_before_recovery() {
+    let fixture = TestLaunch::new("owner-sigkill-drop");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare owner drop run");
+    let managed = prepared
+        .release_blocking()
+        .expect("release owner drop target");
+    let attestation = managed.supervision_attestation().clone();
+    target.expect_open("the owner drop target starts");
+
+    support::kill_process(attestation.supervisor_identity.pid);
+    target.expect_eof("the failed owner closes the exact target");
+    drop(managed);
+    let outcome = recover_supervised_process_blocking(&attestation.recovery_request)
+        .expect("recovery continues after the owner is reaped");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn gate_sigkill_after_release_uses_owner_fallback() {
+    let fixture = TestLaunch::new("gate-sigkill-released");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let descendant = FifoWatch::new(fixture.descendant_fifo());
+    let mut control = DescendantControl::new(fixture.descendant_control_fifo());
+    let prepared = PreparedAviateProcess::prepare_blocking(fixture.descendant_request())
+        .expect("prepare gate crash launch");
+    let mut managed = prepared
+        .release_blocking()
+        .expect("release gate crash launch");
+    target.expect_open("the gate crash target starts");
+    descendant.expect_open("the gate crash descendant starts");
+    control.connect();
+
+    support::kill_process(managed.supervision_attestation().target_gate_identity.pid);
+    let outcome = managed
+        .terminate_blocking()
+        .expect("the owner fallback publishes terminal evidence");
+    control.release();
+    target.expect_eof("the owner fallback stops the target");
+    descendant.expect_eof("the owner fallback stops the descendant");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+#[test]
+fn gate_sigkill_before_release_keeps_target_closed() {
+    let fixture = TestLaunch::new("gate-sigkill-prepared");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare gate crash");
+    support::kill_process(prepared.supervision_attestation().target_gate_identity.pid);
+
+    let outcome = prepared
+        .cancel_blocking()
+        .expect("the owner records pre-release gate cleanup");
+
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+    target.expect_unused("a failed gate cannot start its target");
+}
+
+#[test]
+fn target_process_group_escape_is_detected_and_contained() {
+    let fixture = TestLaunch::new("target-group-escape");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let mut request = fixture.request();
+    request
+        .target_environment
+        .insert(support::TARGET_ESCAPE_GROUP_ENV.to_owned(), "1".to_owned());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(request).expect("prepare escaped target");
+    let recovery = prepared.supervision_attestation().recovery_request.clone();
+
+    let error = match prepared.release_blocking() {
+        Err(error) => {
+            target.expect_open("the target attempts to leave the authorized group");
+            target.expect_eof("the launch gate contains the rejected exact target");
+            error
+        }
+        Ok(mut managed) => {
+            target.expect_open("the released target leaves the authorized group");
+            let error = managed
+                .ensure_running_blocking()
+                .expect_err("the runtime identity check rejects the escaped target");
+            let outcome = managed
+                .terminate_blocking()
+                .expect("contain the escaped target");
+            assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+            target.expect_eof("the launch gate contains the escaped exact target");
+            error
+        }
+    };
+
+    assert!(
+        matches!(error, AviateSupervisorError::IdentityMismatch { .. }),
+        "unexpected escaped-target error: {error:?}"
+    );
+    let outcome =
+        recover_supervised_process_blocking(&recovery).expect("read escape cleanup evidence");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}

--- a/tools/flight-tune-aviate/tests/process_supervision/descendant.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/descendant.rs
@@ -1,0 +1,64 @@
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+const FIXTURE_ENV: &str = "PILOTAGE_STUBBORN_DESCENDANT_FIXTURE";
+const EVENT_FIFO_ENV: &str = "PILOTAGE_STUBBORN_DESCENDANT_EVENT_FIFO";
+const CONTROL_FIFO_ENV: &str = "PILOTAGE_STUBBORN_DESCENDANT_CONTROL_FIFO";
+
+pub(crate) struct DescendantControl {
+    path: PathBuf,
+    writer: Option<std::fs::File>,
+}
+
+impl DescendantControl {
+    pub(crate) fn new(path: &Path) -> Self {
+        super::create_fifo(path);
+        Self {
+            path: path.to_owned(),
+            writer: None,
+        }
+    }
+
+    pub(crate) fn connect(&mut self) {
+        self.writer = Some(super::open_fifo_writer(&self.path));
+    }
+
+    pub(crate) fn release(&mut self) {
+        self.writer.take();
+    }
+}
+
+pub(super) fn spawn_stubborn_descendant(event: &Path, control: &Path) -> Child {
+    let executable = std::env::current_exe().expect("staged test executable");
+    Command::new("/bin/sh")
+        .args([
+            "-c",
+            "trap '' TERM; program=$1; shift; exec \"$program\" \"$@\"",
+            "aviate-descendant",
+        ])
+        .arg(&executable)
+        .args(["--exact", "stubborn_descendant_fixture", "--nocapture"])
+        .env(FIXTURE_ENV, "1")
+        .env(EVENT_FIFO_ENV, event)
+        .env(CONTROL_FIFO_ENV, control)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn stubborn descendant")
+}
+
+pub(crate) fn run_stubborn_descendant_fixture() {
+    if std::env::var_os(FIXTURE_ENV).is_none() {
+        return;
+    }
+    let event = super::environment_path(EVENT_FIFO_ENV);
+    let control = super::environment_path(CONTROL_FIFO_ENV);
+    let _lifetime = super::open_fifo_writer(&event);
+    let mut input = std::fs::File::open(control).expect("open descendant control FIFO");
+    let mut sink = Vec::new();
+    input
+        .read_to_end(&mut sink)
+        .expect("wait for descendant control EOF");
+}

--- a/tools/flight-tune-aviate/tests/process_supervision/driver.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/driver.rs
@@ -5,7 +5,8 @@ use std::sync::mpsc;
 use std::thread::JoinHandle;
 
 use flight_tune_aviate::{
-    ManagedAviateProcess, PreparedAviateProcess, RecoveryOutcome, SupervisionAttestation,
+    AviateSupervisorError, ManagedAviateProcess, PreparedAviateProcess, RecoveryOutcome,
+    SupervisionAttestation,
 };
 
 use super::{RequestParts, TestLaunch};
@@ -15,6 +16,13 @@ const MODE_ENV: &str = "PILOTAGE_DRIVER_MODE";
 const READY_FIFO_ENV: &str = "PILOTAGE_DRIVER_READY_FIFO";
 const DESCENDANT_EVENT_ENV: &str = "PILOTAGE_DRIVER_DESCENDANT_EVENT_FIFO";
 const DESCENDANT_CONTROL_ENV: &str = "PILOTAGE_DRIVER_DESCENDANT_CONTROL_FIFO";
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+enum DriverReport {
+    Ready(Box<SupervisionAttestation>),
+    Failed { detail: String },
+}
 
 #[derive(Clone, Copy)]
 enum DriverMode {
@@ -62,16 +70,25 @@ impl DriverProcess {
     }
 
     pub(crate) fn read_attestation(&mut self) -> SupervisionAttestation {
-        let bytes = self
-            .attestation
-            .recv_timeout(super::EVENT_TIMEOUT)
-            .expect("driver returns supervision evidence");
+        let timeout = super::EVENT_TIMEOUT
+            .saturating_mul(5)
+            .saturating_add(std::time::Duration::from_secs(5));
+        let bytes = match self.attestation.recv_timeout(timeout) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                self.stop_after_report_failure();
+                panic!("driver report channel failed: {error}");
+            }
+        };
         self.ready_reader
             .take()
             .expect("driver evidence reader is present")
             .join()
             .expect("driver evidence reader completes");
-        serde_json::from_slice(&bytes).expect("decode driver supervision evidence")
+        match serde_json::from_slice(&bytes).expect("decode driver supervision report") {
+            DriverReport::Ready(attestation) => *attestation,
+            DriverReport::Failed { detail } => self.reap_reported_failure(&detail),
+        }
     }
 
     pub(crate) fn kill_and_wait(&mut self) {
@@ -80,6 +97,28 @@ impl DriverProcess {
         let status = self.child.wait().expect("reap supervision driver");
         assert!(!status.success(), "the driver receives a forced stop");
     }
+
+    fn stop_after_report_failure(&mut self) {
+        if self
+            .child
+            .try_wait()
+            .expect("inspect failed supervision driver")
+            .is_none()
+        {
+            self.child.kill().expect("stop failed supervision driver");
+        }
+        self.input.take();
+        self.child.wait().expect("reap failed supervision driver");
+    }
+
+    fn reap_reported_failure(&mut self, detail: &str) -> ! {
+        self.input.take();
+        let status = self
+            .child
+            .wait()
+            .expect("reap reporting supervision driver");
+        panic!("supervision driver failed with {status}: {detail}");
+    }
 }
 
 pub(crate) fn run_driver_fixture() {
@@ -87,33 +126,64 @@ pub(crate) fn run_driver_fixture() {
         return;
     }
     let parts = RequestParts::from_environment();
-    match std::env::var(MODE_ENV).expect("driver mode").as_str() {
-        "prepared" => run_prepared(parts),
-        "released_descendant" => run_released_descendant(parts),
-        mode => panic!("unknown driver mode: {mode}"),
+    let result = match std::env::var(MODE_ENV).expect("driver mode").as_str() {
+        "prepared" => prepare_launch(parts),
+        "released_descendant" => release_descendant(parts),
+        mode => Err(AviateSupervisorError::InvalidRequest {
+            detail: format!("unknown driver mode: {mode}"),
+        }),
+    };
+    match result {
+        Ok(launch) => {
+            publish_report(&DriverReport::Ready(Box::new(launch.attestation().clone())));
+            wait_for_input_eof();
+            launch.finish();
+        }
+        Err(error) => publish_report(&DriverReport::Failed {
+            detail: error.to_string(),
+        }),
     }
 }
 
-fn run_prepared(parts: RequestParts) {
-    let request = super::make_request(&parts, None);
-    let prepared =
-        PreparedAviateProcess::prepare_blocking(request).expect("driver prepares launch");
-    publish_attestation(prepared.supervision_attestation());
-    wait_for_input_eof();
-    let outcome = prepared.cancel_blocking().expect("cancel driver launch");
-    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+enum DriverLaunch {
+    Prepared(Box<PreparedAviateProcess>),
+    Released(Box<ManagedAviateProcess>),
 }
 
-fn run_released_descendant(parts: RequestParts) {
+impl DriverLaunch {
+    fn attestation(&self) -> &SupervisionAttestation {
+        match self {
+            Self::Prepared(process) => process.supervision_attestation(),
+            Self::Released(process) => process.supervision_attestation(),
+        }
+    }
+
+    fn finish(self) {
+        match self {
+            Self::Prepared(process) => {
+                let outcome = (*process).cancel_blocking().expect("cancel driver launch");
+                assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+            }
+            Self::Released(mut process) => terminate_managed(&mut process),
+        }
+    }
+}
+
+fn prepare_launch(parts: RequestParts) -> Result<DriverLaunch, AviateSupervisorError> {
+    let request = super::make_request(&parts, None);
+    PreparedAviateProcess::prepare_blocking(request)
+        .map(Box::new)
+        .map(DriverLaunch::Prepared)
+}
+
+fn release_descendant(parts: RequestParts) -> Result<DriverLaunch, AviateSupervisorError> {
     let event = super::environment_path(DESCENDANT_EVENT_ENV);
     let control = super::environment_path(DESCENDANT_CONTROL_ENV);
     let request = super::make_request(&parts, Some((&event, &control)));
-    let prepared =
-        PreparedAviateProcess::prepare_blocking(request).expect("driver prepares launch");
-    let mut managed = prepared.release_blocking().expect("driver releases launch");
-    publish_attestation(managed.supervision_attestation());
-    wait_for_input_eof();
-    terminate_managed(&mut managed);
+    PreparedAviateProcess::prepare_blocking(request)?
+        .release_blocking()
+        .map(Box::new)
+        .map(DriverLaunch::Released)
 }
 
 fn terminate_managed(managed: &mut ManagedAviateProcess) {
@@ -123,11 +193,11 @@ fn terminate_managed(managed: &mut ManagedAviateProcess) {
     assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
 }
 
-fn publish_attestation(attestation: &SupervisionAttestation) {
-    let encoded = serde_json::to_vec(attestation).expect("encode driver evidence");
+fn publish_report(report: &DriverReport) {
+    let encoded = serde_json::to_vec(report).expect("encode driver report");
     let ready_fifo = super::environment_path(READY_FIFO_ENV);
     let mut ready = super::open_fifo_writer(&ready_fifo);
-    ready.write_all(&encoded).expect("write driver evidence");
+    ready.write_all(&encoded).expect("write driver report");
 }
 
 fn wait_for_input_eof() {

--- a/tools/flight-tune-aviate/tests/process_supervision/driver.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/driver.rs
@@ -1,0 +1,169 @@
+use std::io::{Read as _, Write as _};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use flight_tune_aviate::{
+    ManagedAviateProcess, PreparedAviateProcess, RecoveryOutcome, SupervisionAttestation,
+};
+
+use super::{RequestParts, TestLaunch};
+
+const FIXTURE_ENV: &str = "PILOTAGE_DRIVER_FIXTURE";
+const MODE_ENV: &str = "PILOTAGE_DRIVER_MODE";
+const READY_FIFO_ENV: &str = "PILOTAGE_DRIVER_READY_FIFO";
+const DESCENDANT_EVENT_ENV: &str = "PILOTAGE_DRIVER_DESCENDANT_EVENT_FIFO";
+const DESCENDANT_CONTROL_ENV: &str = "PILOTAGE_DRIVER_DESCENDANT_CONTROL_FIFO";
+
+#[derive(Clone, Copy)]
+enum DriverMode {
+    Prepared,
+    ReleasedDescendant,
+}
+
+impl DriverMode {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Prepared => "prepared",
+            Self::ReleasedDescendant => "released_descendant",
+        }
+    }
+}
+
+pub(crate) struct DriverProcess {
+    child: Child,
+    input: Option<ChildStdin>,
+    attestation: mpsc::Receiver<Vec<u8>>,
+    ready_reader: Option<JoinHandle<()>>,
+}
+
+impl DriverProcess {
+    pub(crate) fn spawn(launch: &TestLaunch) -> Self {
+        Self::spawn_mode(launch, DriverMode::Prepared)
+    }
+
+    pub(crate) fn spawn_released_descendant(launch: &TestLaunch) -> Self {
+        Self::spawn_mode(launch, DriverMode::ReleasedDescendant)
+    }
+
+    fn spawn_mode(launch: &TestLaunch, mode: DriverMode) -> Self {
+        let ready_fifo = launch.driver_ready_fifo();
+        let (attestation, ready_reader) = super::read_fifo_payload(&ready_fifo);
+        let mut command = driver_command(launch, &ready_fifo, mode);
+        let mut child = command.spawn().expect("spawn supervision driver");
+        let input = child.stdin.take().expect("driver input pipe");
+        Self {
+            child,
+            input: Some(input),
+            attestation,
+            ready_reader: Some(ready_reader),
+        }
+    }
+
+    pub(crate) fn read_attestation(&mut self) -> SupervisionAttestation {
+        let bytes = self
+            .attestation
+            .recv_timeout(super::EVENT_TIMEOUT)
+            .expect("driver returns supervision evidence");
+        self.ready_reader
+            .take()
+            .expect("driver evidence reader is present")
+            .join()
+            .expect("driver evidence reader completes");
+        serde_json::from_slice(&bytes).expect("decode driver supervision evidence")
+    }
+
+    pub(crate) fn kill_and_wait(&mut self) {
+        self.child.kill().expect("kill supervision driver");
+        self.input.take();
+        let status = self.child.wait().expect("reap supervision driver");
+        assert!(!status.success(), "the driver receives a forced stop");
+    }
+}
+
+pub(crate) fn run_driver_fixture() {
+    if std::env::var_os(FIXTURE_ENV).is_none() {
+        return;
+    }
+    let parts = RequestParts::from_environment();
+    match std::env::var(MODE_ENV).expect("driver mode").as_str() {
+        "prepared" => run_prepared(parts),
+        "released_descendant" => run_released_descendant(parts),
+        mode => panic!("unknown driver mode: {mode}"),
+    }
+}
+
+fn run_prepared(parts: RequestParts) {
+    let request = super::make_request(&parts, None);
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(request).expect("driver prepares launch");
+    publish_attestation(prepared.supervision_attestation());
+    wait_for_input_eof();
+    let outcome = prepared.cancel_blocking().expect("cancel driver launch");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+fn run_released_descendant(parts: RequestParts) {
+    let event = super::environment_path(DESCENDANT_EVENT_ENV);
+    let control = super::environment_path(DESCENDANT_CONTROL_ENV);
+    let request = super::make_request(&parts, Some((&event, &control)));
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(request).expect("driver prepares launch");
+    let mut managed = prepared.release_blocking().expect("driver releases launch");
+    publish_attestation(managed.supervision_attestation());
+    wait_for_input_eof();
+    terminate_managed(&mut managed);
+}
+
+fn terminate_managed(managed: &mut ManagedAviateProcess) {
+    let outcome = managed
+        .terminate_blocking()
+        .expect("clean released driver launch");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+}
+
+fn publish_attestation(attestation: &SupervisionAttestation) {
+    let encoded = serde_json::to_vec(attestation).expect("encode driver evidence");
+    let ready_fifo = super::environment_path(READY_FIFO_ENV);
+    let mut ready = super::open_fifo_writer(&ready_fifo);
+    ready.write_all(&encoded).expect("write driver evidence");
+}
+
+fn wait_for_input_eof() {
+    let mut sink = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut sink)
+        .expect("wait for driver input closure");
+}
+
+fn driver_command(launch: &TestLaunch, ready_fifo: &Path, mode: DriverMode) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("exec 9>\"$1\"; shift; exec \"$@\"")
+        .arg("aviate-driver")
+        .arg(&launch.lifecycle_fifo)
+        .arg(&launch.target)
+        .args(["--exact", "supervision_driver_fixture", "--nocapture"])
+        .env(FIXTURE_ENV, "1")
+        .env(MODE_ENV, mode.name())
+        .env(READY_FIFO_ENV, ready_fifo)
+        .env("PILOTAGE_DRIVER_HELPER", &launch.helper)
+        .env("PILOTAGE_DRIVER_TARGET", &launch.target)
+        .env("PILOTAGE_DRIVER_STORAGE_ROOT", &launch.storage_root)
+        .env("PILOTAGE_DRIVER_RUNTIME_ROOT", &launch.runtime_root)
+        .env("PILOTAGE_DRIVER_ARTIFACT_ROOT", &launch.artifact_root)
+        .env(
+            "PILOTAGE_DRIVER_TARGET_CWD",
+            &launch.target_current_directory,
+        )
+        .env("PILOTAGE_DRIVER_TARGET_FIFO", &launch.target_fifo)
+        .env(DESCENDANT_EVENT_ENV, &launch.descendant_fifo)
+        .env(DESCENDANT_CONTROL_ENV, &launch.descendant_control_fifo)
+        .env("PILOTAGE_DRIVER_NAME", &launch.name)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}

--- a/tools/flight-tune-aviate/tests/process_supervision/evidence_fixtures.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/evidence_fixtures.rs
@@ -1,0 +1,116 @@
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use flight_tune_aviate::{ProcessStartIdentity, SupervisionAttestation};
+use sha2::{Digest as _, Sha256};
+
+pub(crate) fn digest_bytes(bytes: &[u8]) -> flight_tune::Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    flight_tune::Digest::from_bytes(hasher.finalize().into())
+}
+
+pub(crate) fn add_linked_temporary(destination: &Path, counter: u64) -> PathBuf {
+    let path = destination
+        .parent()
+        .expect("document has a parent")
+        .join(temporary_name(counter));
+    std::fs::hard_link(destination, &path).expect("create linked publication state");
+    path
+}
+
+pub(crate) fn add_unlinked_temporary(root: &Path, counter: u64) -> PathBuf {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let path = root.join(temporary_name(counter));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .expect("create unlinked temporary state");
+    file.write_all(b"uncommitted recovery object")
+        .expect("write unlinked temporary state");
+    file.sync_all().expect("sync unlinked temporary state");
+    path
+}
+
+pub(crate) fn add_conflicting_recovery_receipt(
+    root: &Path,
+    attestation: &SupervisionAttestation,
+) -> PathBuf {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let prior_boot = boot_identity_json(&attestation.supervisor_identity.start);
+    let bytes = format!(
+        concat!(
+            "{{\"schema_version\":1,",
+            "\"run_intent_digest\":{},",
+            "\"spawn_intent_digest\":{},",
+            "\"process_identity_digest\":{},",
+            "\"target_attestation_digest\":null,",
+            "\"prior_boot_identity\":{},",
+            "\"recovery_boot_identity\":{}}}"
+        ),
+        serde_json::to_string(&attestation.run_intent_digest).expect("encode run digest"),
+        serde_json::to_string(&attestation.spawn_intent_digest).expect("encode spawn digest"),
+        serde_json::to_string(&attestation.process_identity_digest).expect("encode process digest"),
+        prior_boot,
+        prior_boot,
+    );
+    let path = root.join("supervisor-recovery-receipt.json");
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .expect("create conflicting recovery receipt");
+    file.write_all(bytes.as_bytes())
+        .expect("write conflicting recovery receipt");
+    file.sync_all().expect("sync conflicting recovery receipt");
+    path
+}
+
+pub(crate) fn add_unknown_storage_object(root: &Path) -> PathBuf {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let path = root.join("unknown-object.json");
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .expect("create unknown storage object");
+    file.write_all(b"{}").expect("write unknown storage object");
+    file.sync_all().expect("sync unknown storage object");
+    path
+}
+
+pub(crate) fn replace_file_bytes(path: &Path, bytes: &[u8]) {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .expect("open test document for replacement");
+    file.write_all(bytes).expect("replace test document bytes");
+    file.sync_all().expect("sync replaced test document");
+}
+
+fn boot_identity_json(start: &ProcessStartIdentity) -> String {
+    match start {
+        ProcessStartIdentity::Linux { boot_id, .. } => format!(
+            "{{\"platform\":\"linux\",\"boot_id\":{}}}",
+            serde_json::to_string(boot_id).expect("encode Linux boot identity")
+        ),
+        ProcessStartIdentity::MacOs {
+            boot_session_uuid, ..
+        } => format!(
+            "{{\"platform\":\"mac_os\",\"boot_session_uuid\":{}}}",
+            serde_json::to_string(boot_session_uuid).expect("encode Darwin boot identity")
+        ),
+    }
+}
+
+fn temporary_name(counter: u64) -> String {
+    format!(".pilotage-tmp-{}-{counter:016x}", std::process::id())
+}

--- a/tools/flight-tune-aviate/tests/process_supervision/recovery_cases.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/recovery_cases.rs
@@ -1,0 +1,339 @@
+use std::os::unix::fs::MetadataExt as _;
+
+use super::*;
+
+#[test]
+fn recovery_repairs_linked_receipt_and_cleans_orphan_temporary() {
+    let fixture = TestLaunch::new("receipt-repair");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare repair run");
+    let recovery = prepared.supervision_attestation().recovery_request.clone();
+    let initial = prepared
+        .cancel_blocking()
+        .expect("publish initial terminal receipt");
+    let receipt = fixture
+        .storage_root()
+        .join("supervisor-terminal-receipt.json");
+    let linked = support::add_linked_temporary(&receipt, 1);
+    let orphan = support::add_unlinked_temporary(fixture.storage_root(), 2);
+    assert_eq!(
+        std::fs::metadata(&receipt)
+            .expect("inspect receipt")
+            .nlink(),
+        2
+    );
+
+    let replay =
+        recover_supervised_process_blocking(&recovery).expect("repair terminal publication");
+
+    assert_eq!(replay, initial);
+    assert_eq!(
+        std::fs::metadata(receipt).expect("inspect repair").nlink(),
+        1
+    );
+    assert!(!linked.exists(), "the linked temporary is removed");
+    assert!(!orphan.exists(), "the unlinked temporary is removed");
+}
+
+#[test]
+fn invalid_recovery_does_not_repair_optional_documents() {
+    let fixture = TestLaunch::new("invalid-recovery-mutation");
+    let target_watch = FifoWatch::new(fixture.target_fifo());
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare mutation proof");
+    let attestation = prepared.supervision_attestation().clone();
+    let recovery = attestation.recovery_request.clone();
+    let mut managed = prepared
+        .release_blocking()
+        .expect("release mutation-proof target");
+    target_watch.expect_open("the mutation-proof target starts");
+    let initial = managed
+        .terminate_blocking()
+        .expect("publish mutation proof");
+    target_watch.expect_eof("the mutation-proof target stops");
+    let receipt = fixture
+        .storage_root()
+        .join("supervisor-terminal-receipt.json");
+    let target = fixture
+        .storage_root()
+        .join("supervisor-target-attestation.json");
+    let linked_receipt = support::add_linked_temporary(&receipt, 3);
+    let linked_target = support::add_linked_temporary(&target, 4);
+    let boot_receipt =
+        support::add_conflicting_recovery_receipt(fixture.storage_root(), &attestation);
+    let linked_boot_receipt = support::add_linked_temporary(&boot_receipt, 5);
+    let orphan = support::add_unlinked_temporary(fixture.storage_root(), 6);
+    for invalid in changed_recovery_requests(&recovery) {
+        let error = recover_supervised_process_blocking(&invalid)
+            .expect_err("reject recovery before optional repair");
+        assert!(matches!(
+            error,
+            AviateSupervisorError::InvalidDocument { .. }
+                | AviateSupervisorError::InvalidRequest { .. }
+        ));
+    }
+    assert_optional_publications_unrepaired(
+        &[&receipt, &target, &boot_receipt],
+        &[
+            &linked_receipt,
+            &linked_target,
+            &linked_boot_receipt,
+            &orphan,
+        ],
+    );
+
+    std::fs::remove_file(boot_receipt).expect("remove test boot receipt");
+    std::fs::remove_file(linked_boot_receipt).expect("remove linked test boot receipt");
+
+    let replay = recover_supervised_process_blocking(&recovery)
+        .expect("valid recovery repairs optional documents");
+    assert_eq!(replay, initial);
+    assert!(
+        !linked_receipt.exists(),
+        "valid recovery removes the linked terminal receipt"
+    );
+    assert!(
+        !linked_target.exists(),
+        "valid recovery removes the linked target attestation"
+    );
+    assert!(
+        !orphan.exists(),
+        "valid recovery removes the orphan temporary"
+    );
+}
+
+fn assert_optional_publications_unrepaired(
+    publications: &[&std::path::Path],
+    temporaries: &[&std::path::Path],
+) {
+    for publication in publications {
+        assert_eq!(
+            std::fs::metadata(publication)
+                .expect("inspect optional publication")
+                .nlink(),
+            2
+        );
+    }
+    for temporary in temporaries {
+        assert!(
+            temporary.exists(),
+            "the optional temporary remains unchanged"
+        );
+    }
+}
+
+fn changed_recovery_requests(
+    recovery: &flight_tune_aviate::RecoveryRequest,
+) -> Vec<flight_tune_aviate::RecoveryRequest> {
+    let mut schema = recovery.clone();
+    schema.schema_version = schema.schema_version.wrapping_add(1);
+    let mut run = recovery.clone();
+    run.run_intent_digest = support::digest_bytes(b"wrong run intent");
+    let mut supervisor = recovery.clone();
+    supervisor.supervisor_executable_digest = support::digest_bytes(b"wrong supervisor");
+    let mut target = recovery.clone();
+    target.target_executable_digest = support::digest_bytes(b"wrong target");
+    let mut spawn = recovery.clone();
+    spawn.expected_spawn_intent_digest = support::digest_bytes(b"wrong spawn intent");
+    let mut process = recovery.clone();
+    process.expected_process_identity_digest = support::digest_bytes(b"wrong process identity");
+    let mut timeout = recovery.clone();
+    timeout.cleanup_timeout_millis = timeout.cleanup_timeout_millis.wrapping_add(1);
+    vec![schema, run, supervisor, target, spawn, process, timeout]
+}
+
+#[test]
+fn outcome_replay_rechecks_runtime_cleanup() {
+    let fixture = TestLaunch::new("outcome-replay-cleanup");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare replay run");
+    let recovery = prepared.supervision_attestation().recovery_request.clone();
+    let initial = prepared
+        .cancel_blocking()
+        .expect("publish replay terminal receipt");
+    let replay =
+        recover_supervised_process_blocking(&recovery).expect("replay verifies empty resources");
+    assert_eq!(replay, initial);
+    let socket = fixture.runtime_root().join("parent-ready.sock");
+    let listener =
+        std::os::unix::net::UnixListener::bind(&socket).expect("bind a replacement runtime socket");
+    drop(listener);
+
+    let error =
+        recover_supervised_process_blocking(&recovery).expect_err("reject replacement socket");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidRequest { .. }
+    ));
+    assert!(
+        socket.exists(),
+        "replay does not remove a replacement socket"
+    );
+    std::fs::remove_file(&socket).expect("clean test-only replacement socket");
+    let unknown = fixture.runtime_root().join("unknown-entry");
+    std::fs::write(&unknown, b"unknown").expect("create unknown runtime entry");
+    let error =
+        recover_supervised_process_blocking(&recovery).expect_err("reject unknown runtime entry");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidRequest { .. }
+    ));
+    assert!(
+        unknown.exists(),
+        "recovery does not remove an unknown entry"
+    );
+    std::fs::remove_file(unknown).expect("clean test-only unknown entry");
+}
+
+#[test]
+fn recovery_rejects_conflicting_terminal_and_boot_receipts() {
+    let fixture = TestLaunch::new("conflicting-outcomes");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare conflict run");
+    let attestation = prepared.supervision_attestation().clone();
+    let _terminal = prepared
+        .cancel_blocking()
+        .expect("publish terminal receipt");
+    support::add_conflicting_recovery_receipt(fixture.storage_root(), &attestation);
+
+    let error = recover_supervised_process_blocking(&attestation.recovery_request)
+        .expect_err("reject two durable outcomes");
+
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidDocument {
+            document: "process outcome",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn terminal_replay_binds_digest_canonical_bytes_and_closed_set() {
+    let fixture = TestLaunch::new("terminal-replay-validation");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare replay proof");
+    let recovery = prepared.supervision_attestation().recovery_request.clone();
+    let outcome = prepared.cancel_blocking().expect("publish replay proof");
+    let receipt = fixture
+        .storage_root()
+        .join("supervisor-terminal-receipt.json");
+    let bytes = std::fs::read(&receipt).expect("read terminal receipt bytes");
+    let receipt_digest = match outcome {
+        RecoveryOutcome::Terminal { receipt_digest } => receipt_digest,
+        RecoveryOutcome::BootChange { .. } => panic!("same-boot cancel returns terminal evidence"),
+    };
+    assert_eq!(receipt_digest, support::digest_bytes(&bytes));
+
+    let mut invalid_request = recovery.clone();
+    invalid_request.expected_process_identity_digest = support::digest_bytes(b"wrong process");
+    let error =
+        recover_supervised_process_blocking(&invalid_request).expect_err("reject wrong digest");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidDocument {
+            document: "supervision attestation",
+            ..
+        }
+    ));
+
+    let unknown = support::add_unknown_storage_object(fixture.storage_root());
+    let error =
+        recover_supervised_process_blocking(&recovery).expect_err("reject unknown storage object");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidDocument { .. }
+    ));
+    assert!(
+        unknown.exists(),
+        "recovery does not remove an unknown object"
+    );
+    std::fs::remove_file(unknown).expect("clean test-only unknown object");
+
+    let mut noncanonical = bytes;
+    noncanonical.push(b'\n');
+    support::replace_file_bytes(&receipt, &noncanonical);
+    let error =
+        recover_supervised_process_blocking(&recovery).expect_err("reject noncanonical receipt");
+    assert!(matches!(
+        error,
+        AviateSupervisorError::InvalidDocument {
+            document: "supervisor-terminal-receipt.json",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn invalid_recovery_does_not_signal_live_processes() {
+    let fixture = TestLaunch::new("invalid-recovery");
+    let target = FifoWatch::new(fixture.target_fifo());
+    let unrelated_watch = FifoWatch::new(fixture.unrelated_fifo());
+    let mut unrelated = UnrelatedProcess::spawn(fixture.unrelated_fifo());
+    unrelated_watch.expect_open("the unrelated process starts");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare launch");
+    let mut managed = prepared.release_blocking().expect("release exact target");
+    target.expect_open("the supervised target starts");
+    let mut invalid = managed.supervision_attestation().recovery_request.clone();
+    invalid.expected_process_identity_digest = support::digest_bytes(b"wrong process");
+
+    let error = recover_supervised_process_blocking(&invalid).expect_err("reject invalid recovery");
+
+    assert!(matches!(error, AviateSupervisorError::SupervisorActive));
+    managed
+        .ensure_running_blocking()
+        .expect("the supervised target remains live");
+    unrelated.expect_running();
+    unrelated.stop_and_wait();
+    unrelated_watch.expect_eof("the unrelated process exits only on request");
+    let outcome = managed
+        .terminate_blocking()
+        .expect("clean supervised target");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+    target.expect_eof("the supervised target stops on request");
+}
+
+#[test]
+fn released_writer_rejects_changed_authorization_without_signaling() {
+    let fixture = TestLaunch::new("changed-recovery-authorization");
+    let unrelated_watch = FifoWatch::new(fixture.unrelated_fifo());
+    let mut unrelated = UnrelatedProcess::spawn(fixture.unrelated_fifo());
+    unrelated_watch.expect_open("the unrelated process starts");
+    let prepared =
+        PreparedAviateProcess::prepare_blocking(fixture.request()).expect("prepare launch");
+    let recovery = prepared.supervision_attestation().recovery_request.clone();
+    let outcome = prepared
+        .cancel_blocking()
+        .expect("release the recovery writer");
+    assert!(matches!(outcome, RecoveryOutcome::Terminal { .. }));
+
+    let mut changed_run = recovery.clone();
+    changed_run.run_intent_digest = support::digest_bytes(b"changed run intent");
+    let mut changed_supervisor = recovery.clone();
+    changed_supervisor.supervisor_executable_digest =
+        support::digest_bytes(b"changed supervisor executable");
+    let mut changed_target = recovery.clone();
+    changed_target.target_executable_digest = support::digest_bytes(b"changed target executable");
+    let mut changed_process = recovery;
+    changed_process.expected_process_identity_digest =
+        support::digest_bytes(b"changed process identity");
+
+    for invalid in [
+        changed_run,
+        changed_supervisor,
+        changed_target,
+        changed_process,
+    ] {
+        let error = recover_supervised_process_blocking(&invalid)
+            .expect_err("reject changed recovery authorization");
+        assert!(matches!(
+            error,
+            AviateSupervisorError::InvalidDocument { .. }
+        ));
+        unrelated.expect_running();
+    }
+
+    unrelated.stop_and_wait();
+    unrelated_watch.expect_eof("the unrelated process exits only on request");
+}

--- a/tools/flight-tune-aviate/tests/process_supervision/support.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/support.rs
@@ -1,0 +1,419 @@
+use std::collections::BTreeMap;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use flight_tune_aviate::{SupervisedProcessRequest, TargetProcessContract};
+
+#[path = "descendant.rs"]
+mod descendant;
+#[path = "driver.rs"]
+mod driver;
+#[path = "evidence_fixtures.rs"]
+mod evidence_fixtures;
+
+pub(super) use descendant::{DescendantControl, run_stubborn_descendant_fixture};
+pub(super) use driver::{DriverProcess, run_driver_fixture};
+pub(super) use evidence_fixtures::{
+    add_conflicting_recovery_receipt, add_linked_temporary, add_unknown_storage_object,
+    add_unlinked_temporary, digest_bytes, replace_file_bytes,
+};
+
+const EVENT_TIMEOUT: Duration = Duration::from_secs(15);
+const CLOSED_GATE_TIMEOUT: Duration = Duration::from_millis(250);
+const TARGET_FIFO_ENV: &str = "PILOTAGE_TARGET_FIFO";
+pub(super) const TARGET_ESCAPE_GROUP_ENV: &str = "PILOTAGE_TARGET_ESCAPE_GROUP";
+const DESCENDANT_FIFO_ENV: &str = "PILOTAGE_DESCENDANT_FIFO";
+const DESCENDANT_CONTROL_FIFO_ENV: &str = "PILOTAGE_DESCENDANT_CONTROL_FIFO";
+const UNRELATED_FIFO_ENV: &str = "PILOTAGE_UNRELATED_FIFO";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FifoEvent {
+    Open,
+    Eof,
+}
+
+pub(super) struct FifoWatch {
+    path: PathBuf,
+    events: mpsc::Receiver<FifoEvent>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl FifoWatch {
+    pub(super) fn new(path: &Path) -> Self {
+        create_fifo(path);
+        let path = path.to_owned();
+        let reader_path = path.clone();
+        let (sender, events) = mpsc::channel();
+        let reader = std::thread::Builder::new()
+            .name("aviate-test-fifo-watch".to_owned())
+            .spawn(move || watch_fifo(&reader_path, &sender))
+            .expect("spawn FIFO watcher");
+        Self {
+            path,
+            events,
+            reader: Some(reader),
+        }
+    }
+
+    pub(super) fn expect_open(&self, detail: &str) {
+        self.expect_event(FifoEvent::Open, detail);
+    }
+
+    pub(super) fn expect_no_event(&self, detail: &str) {
+        let result = self.events.recv_timeout(CLOSED_GATE_TIMEOUT);
+        assert!(
+            matches!(result, Err(mpsc::RecvTimeoutError::Timeout)),
+            "{detail}"
+        );
+    }
+
+    pub(super) fn expect_eof(mut self, detail: &str) {
+        self.expect_event(FifoEvent::Eof, detail);
+        self.join_reader();
+    }
+
+    pub(super) fn expect_unused(mut self, detail: &str) {
+        assert!(
+            matches!(self.events.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "{detail}"
+        );
+        let writer = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .expect("open unused FIFO");
+        self.expect_event(FifoEvent::Open, "the FIFO watcher accepts the test writer");
+        drop(writer);
+        self.expect_event(FifoEvent::Eof, "the unused FIFO test writer closes");
+        self.join_reader();
+    }
+
+    fn expect_event(&self, expected: FifoEvent, detail: &str) {
+        let event = self
+            .events
+            .recv_timeout(EVENT_TIMEOUT)
+            .unwrap_or_else(|_| panic!("timed out: {detail}"));
+        assert_eq!(event, expected, "{detail}");
+    }
+
+    fn join_reader(&mut self) {
+        self.reader
+            .take()
+            .expect("FIFO watcher is present")
+            .join()
+            .expect("FIFO watcher completes");
+    }
+}
+
+pub(super) struct TestLaunch {
+    _root: tempfile::TempDir,
+    helper: PathBuf,
+    target: PathBuf,
+    storage_root: PathBuf,
+    runtime_root: PathBuf,
+    artifact_root: PathBuf,
+    target_current_directory: PathBuf,
+    target_fifo: PathBuf,
+    descendant_fifo: PathBuf,
+    descendant_control_fifo: PathBuf,
+    lifecycle_fifo: PathBuf,
+    unrelated_fifo: PathBuf,
+    name: String,
+}
+
+impl TestLaunch {
+    pub(super) fn new(name: &str) -> Self {
+        let temporary_parent = std::fs::canonicalize("/tmp").expect("canonical temporary parent");
+        let root = tempfile::Builder::new()
+            .prefix("aviate-supervision-")
+            .tempdir_in(temporary_parent)
+            .expect("create test root");
+        let runtime_root = root.path().join("runtime");
+        let target_current_directory = root.path().join("target-cwd");
+        create_private_directory(&runtime_root);
+        create_private_directory(&target_current_directory);
+        let helper = std::fs::canonicalize(env!("CARGO_BIN_EXE_flight_tune_aviate_supervisor"))
+            .expect("canonical helper");
+        let target = std::fs::canonicalize(std::env::current_exe().expect("test executable"))
+            .expect("canonical target");
+        Self {
+            storage_root: root.path().join("storage"),
+            artifact_root: root.path().join("artifacts"),
+            target_fifo: root.path().join("target.fifo"),
+            descendant_fifo: root.path().join("descendant.fifo"),
+            descendant_control_fifo: root.path().join("descendant-control.fifo"),
+            lifecycle_fifo: root.path().join("lifecycle.fifo"),
+            unrelated_fifo: root.path().join("unrelated.fifo"),
+            _root: root,
+            helper,
+            target,
+            runtime_root,
+            target_current_directory,
+            name: name.to_owned(),
+        }
+    }
+
+    pub(super) fn request(&self) -> SupervisedProcessRequest {
+        make_request(&RequestParts::from_launch(self), None)
+    }
+
+    pub(super) fn descendant_request(&self) -> SupervisedProcessRequest {
+        make_request(
+            &RequestParts::from_launch(self),
+            Some((&self.descendant_fifo, &self.descendant_control_fifo)),
+        )
+    }
+
+    pub(super) fn target_fifo(&self) -> &Path {
+        &self.target_fifo
+    }
+
+    pub(super) fn descendant_fifo(&self) -> &Path {
+        &self.descendant_fifo
+    }
+
+    pub(super) fn descendant_control_fifo(&self) -> &Path {
+        &self.descendant_control_fifo
+    }
+
+    pub(super) fn lifecycle_fifo(&self) -> &Path {
+        &self.lifecycle_fifo
+    }
+
+    pub(super) fn unrelated_fifo(&self) -> &Path {
+        &self.unrelated_fifo
+    }
+
+    pub(super) fn storage_root(&self) -> &Path {
+        &self.storage_root
+    }
+
+    pub(super) fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    fn driver_ready_fifo(&self) -> PathBuf {
+        self._root.path().join("driver-ready.fifo")
+    }
+}
+
+struct RequestParts {
+    helper: PathBuf,
+    target: PathBuf,
+    storage_root: PathBuf,
+    runtime_root: PathBuf,
+    artifact_root: PathBuf,
+    target_current_directory: PathBuf,
+    target_fifo: PathBuf,
+    name: String,
+}
+
+impl RequestParts {
+    fn from_launch(launch: &TestLaunch) -> Self {
+        Self {
+            helper: launch.helper.clone(),
+            target: launch.target.clone(),
+            storage_root: launch.storage_root.clone(),
+            runtime_root: launch.runtime_root.clone(),
+            artifact_root: launch.artifact_root.clone(),
+            target_current_directory: launch.target_current_directory.clone(),
+            target_fifo: launch.target_fifo.clone(),
+            name: launch.name.clone(),
+        }
+    }
+
+    fn from_environment() -> Self {
+        Self {
+            helper: environment_path("PILOTAGE_DRIVER_HELPER"),
+            target: environment_path("PILOTAGE_DRIVER_TARGET"),
+            storage_root: environment_path("PILOTAGE_DRIVER_STORAGE_ROOT"),
+            runtime_root: environment_path("PILOTAGE_DRIVER_RUNTIME_ROOT"),
+            artifact_root: environment_path("PILOTAGE_DRIVER_ARTIFACT_ROOT"),
+            target_current_directory: environment_path("PILOTAGE_DRIVER_TARGET_CWD"),
+            target_fifo: environment_path("PILOTAGE_DRIVER_TARGET_FIFO"),
+            name: std::env::var("PILOTAGE_DRIVER_NAME").expect("driver run name"),
+        }
+    }
+}
+
+pub(super) struct UnrelatedProcess {
+    child: Child,
+    input: Option<ChildStdin>,
+}
+
+impl UnrelatedProcess {
+    pub(super) fn spawn(fifo: &Path) -> Self {
+        let mut child = Command::new(std::env::current_exe().expect("test executable"))
+            .args(["--exact", "unrelated_process_fixture", "--nocapture"])
+            .env(UNRELATED_FIFO_ENV, fifo)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn unrelated process");
+        let input = child.stdin.take().expect("unrelated input pipe");
+        Self {
+            child,
+            input: Some(input),
+        }
+    }
+
+    pub(super) fn expect_running(&mut self) {
+        assert!(
+            self.child
+                .try_wait()
+                .expect("inspect unrelated process")
+                .is_none(),
+            "invalid recovery does not stop the unrelated process"
+        );
+    }
+
+    pub(super) fn stop_and_wait(&mut self) {
+        self.input.take();
+        let status = self.child.wait().expect("reap unrelated process");
+        assert!(status.success(), "the unrelated process exits normally");
+    }
+}
+
+pub(super) fn run_target_fixture() {
+    let Some(path) = std::env::var_os(TARGET_FIFO_ENV) else {
+        return;
+    };
+    if std::env::var_os(TARGET_ESCAPE_GROUP_ENV).is_some() {
+        let session = rustix::process::setsid().expect("target creates escaped session");
+        let own_pid = i32::try_from(std::process::id()).expect("target PID fits POSIX");
+        assert_eq!(session.as_raw_pid(), own_pid);
+    }
+    let _target_lifetime = open_fifo_writer(Path::new(&path));
+    let _descendant = match (
+        std::env::var_os(DESCENDANT_FIFO_ENV),
+        std::env::var_os(DESCENDANT_CONTROL_FIFO_ENV),
+    ) {
+        (Some(event), Some(control)) => Some(descendant::spawn_stubborn_descendant(
+            Path::new(&event),
+            Path::new(&control),
+        )),
+        _ => None,
+    };
+    loop {
+        std::thread::park();
+    }
+}
+
+pub(super) fn run_unrelated_fixture() {
+    let Some(path) = std::env::var_os(UNRELATED_FIFO_ENV) else {
+        return;
+    };
+    let _lifetime = open_fifo_writer(Path::new(&path));
+    let mut sink = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut sink)
+        .expect("wait for unrelated process input closure");
+}
+
+fn make_request(
+    parts: &RequestParts,
+    descendant_fifos: Option<(&Path, &Path)>,
+) -> SupervisedProcessRequest {
+    let mut environment = BTreeMap::new();
+    environment.insert(
+        TARGET_FIFO_ENV.to_owned(),
+        utf8_path(&parts.target_fifo).to_owned(),
+    );
+    if let Some((event, control)) = descendant_fifos {
+        environment.insert(DESCENDANT_FIFO_ENV.to_owned(), utf8_path(event).to_owned());
+        environment.insert(
+            DESCENDANT_CONTROL_FIFO_ENV.to_owned(),
+            utf8_path(control).to_owned(),
+        );
+    }
+    SupervisedProcessRequest {
+        supervisor_executable: parts.helper.clone(),
+        supervisor_executable_digest: digest_file(&parts.helper),
+        target_executable: parts.target.clone(),
+        target_executable_digest: digest_file(&parts.target),
+        target_arguments: vec![
+            "--exact".to_owned(),
+            "supervised_target_fixture".to_owned(),
+            "--nocapture".to_owned(),
+        ],
+        target_environment: environment,
+        target_process_contract: TargetProcessContract::RetainProcessGroup,
+        target_current_directory: parts.target_current_directory.clone(),
+        storage_root: parts.storage_root.clone(),
+        runtime_root: parts.runtime_root.clone(),
+        artifact_root: parts.artifact_root.clone(),
+        run_intent_digest: digest_bytes(format!("integration-{}", parts.name).as_bytes()),
+        startup_timeout: EVENT_TIMEOUT,
+        cleanup_timeout: EVENT_TIMEOUT,
+    }
+}
+
+pub(super) fn create_fifo(path: &Path) {
+    let status = Command::new("mkfifo")
+        .arg(path)
+        .status()
+        .expect("run mkfifo");
+    assert!(status.success(), "mkfifo creates the event channel");
+}
+
+fn watch_fifo(path: &Path, sender: &mpsc::Sender<FifoEvent>) {
+    let mut file = std::fs::File::open(path).expect("open FIFO reader");
+    sender.send(FifoEvent::Open).expect("send FIFO open event");
+    let mut sink = Vec::new();
+    file.read_to_end(&mut sink).expect("read FIFO to EOF");
+    sender.send(FifoEvent::Eof).expect("send FIFO EOF event");
+}
+
+fn read_fifo_payload(path: &Path) -> (mpsc::Receiver<Vec<u8>>, JoinHandle<()>) {
+    create_fifo(path);
+    let path = path.to_owned();
+    let (sender, receiver) = mpsc::channel();
+    let reader = std::thread::Builder::new()
+        .name("aviate-test-fifo-payload".to_owned())
+        .spawn(move || {
+            let mut file = std::fs::File::open(path).expect("open FIFO payload reader");
+            let mut payload = Vec::new();
+            file.read_to_end(&mut payload).expect("read FIFO payload");
+            sender.send(payload).expect("send FIFO payload");
+        })
+        .expect("spawn FIFO payload reader");
+    (receiver, reader)
+}
+
+pub(super) fn open_fifo_writer(path: &Path) -> std::fs::File {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open FIFO writer")
+}
+
+fn create_private_directory(path: &Path) {
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder.create(path).expect("create private directory");
+}
+
+fn digest_file(path: &Path) -> flight_tune::Digest {
+    digest_bytes(&std::fs::read(path).expect("read executable"))
+}
+
+pub(super) fn kill_process(pid: u32) {
+    let raw = i32::try_from(pid).expect("test process PID fits POSIX");
+    let pid = rustix::process::Pid::from_raw(raw).expect("test process PID is nonzero");
+    rustix::process::kill_process(pid, rustix::process::Signal::KILL)
+        .expect("signal exact test process");
+}
+
+pub(super) fn environment_path(name: &str) -> PathBuf {
+    PathBuf::from(std::env::var_os(name).unwrap_or_else(|| panic!("missing {name}")))
+}
+
+fn utf8_path(path: &Path) -> &str {
+    path.to_str().expect("test path is UTF-8")
+}


### PR DESCRIPTION
Closes #454.

## Scope

- Add a staged Aviate process owner and launch gate.
- Keep the target closed until durable process evidence passes readback.
- Bind the owner, gate, target, executable digests, argument vector, and run intent.
- Contain the exact private process group after parent or gate failure.
- Make recovery observation-only. Recovery does not send a process signal.
- Repair ambiguous immutable publications under the writer lease.
- Add Linux and macOS process inspection.
- Add a CI boundary for destructive process control.

## Safety properties

- The owner creates the private session before it starts the target.
- The gate does not release the target before durable authorization.
- Parent closure requests immediate containment.
- Recovery waits for exact lifetime absence.
- Recovery uses one shared deadline.
- PID reuse, digest changes, malformed evidence, and unknown process state fail closed.
- RetainProcessGroup permits only the reviewed target executable contract.
- Runtime, storage, and artifact roots are private and separate.

The issue permits recovery to signal the saved group. This change uses a stricter ownership boundary. Only the owner and gate can signal. Recovery can validate, wait, repair evidence, and fail closed.

## Verification

- Full local CI passed. This includes format, Clippy, all-target tests, strict documentation, and release build.
- flight-tune-aviate passed 19 unit tests.
- flight-tune-aviate passed 20 real-process integration tests on macOS.
- Linux cross-target check and Clippy passed.
- WASM and Thumb checks passed.
- All repository quality gates passed.
- Web tests passed 42 Node tests and 4 browser tests.
- Buf checks and Apple instrument consumer checks passed locally.
- No Aviate supervision test process remained after the test suite.

SIM / NOT FOR FLIGHT.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #527
- <kbd>&nbsp;1&nbsp;</kbd> #525 👈 
<!-- GitButler Footer Boundary Bottom -->