### PR TITLE
TUNE-13: authorize every candidate transition before execution

### DIFF
--- a/tools/flight-tune/src/adapter.rs
+++ b/tools/flight-tune/src/adapter.rs
@@ -5,7 +5,15 @@ use std::time::Duration;
 
 use pilotage_trial::Digest;
 
-use crate::{ArtifactIdentity, Candidate, ScenarioRef};
+use crate::{ArtifactIdentity, Candidate, RunExecutionContext, ScenarioRef};
+
+mod transition;
+
+pub(crate) use transition::planning_context_digest;
+pub use transition::{
+    CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION, CandidateTransitionReceipt,
+    CandidateTransitionReference, CandidateTransitionRequest,
+};
 
 /// A typed error from a simulator or vehicle adapter.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,7 +130,38 @@ impl SimulatorCapability {
                 "vehicle binding did not accept the simulator session",
             ));
         }
-        Ok(VehicleBinding { adapter, receipt })
+        Ok(VehicleBinding {
+            adapter,
+            receipt,
+            transition: None,
+        })
+    }
+
+    /// Binds a vehicle adapter and its transition policy to this capability.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when a binding does not match this session or
+    /// has an invalid transition identity.
+    pub fn bind_vehicle_with_transition<A>(
+        &self,
+        adapter: A,
+        receipt: VehicleBindingReceipt,
+        transition: TransitionBindingReceipt,
+    ) -> Result<VehicleBinding<A>, AdapterError> {
+        if receipt.session_digest != self.session_digest
+            || transition.session_digest() != self.session_digest
+        {
+            return Err(AdapterError::new(
+                "vehicle binding did not accept the simulator session",
+            ));
+        }
+        transition.validate()?;
+        Ok(VehicleBinding {
+            adapter,
+            receipt,
+            transition: Some(transition),
+        })
     }
 }
 
@@ -135,10 +174,82 @@ pub struct VehicleBindingReceipt {
     pub vehicle_digest: Digest,
 }
 
+/// The transition policy that is fixed to one simulator session binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionBindingReceipt {
+    session_digest: Digest,
+    validator: ArtifactIdentity,
+    adjacency_policy_digest: Digest,
+}
+
+impl TransitionBindingReceipt {
+    /// Creates a transition-policy binding for one simulator session.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when an identity is invalid.
+    pub fn new(
+        session_digest: Digest,
+        validator: ArtifactIdentity,
+        adjacency_policy_digest: Digest,
+    ) -> Result<Self, AdapterError> {
+        let receipt = Self {
+            session_digest,
+            validator,
+            adjacency_policy_digest,
+        };
+        receipt.validate()?;
+        Ok(receipt)
+    }
+
+    /// Returns the bound simulator session identity.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the bound transition validator identity.
+    #[must_use]
+    pub const fn validator(&self) -> &ArtifactIdentity {
+        &self.validator
+    }
+
+    /// Returns the bound adjacency-policy identity.
+    #[must_use]
+    pub const fn adjacency_policy_digest(&self) -> Digest {
+        self.adjacency_policy_digest
+    }
+
+    fn validate(&self) -> Result<(), AdapterError> {
+        if self.session_digest.is_zero()
+            || self.adjacency_policy_digest.is_zero()
+            || self.validator.validate().is_err()
+        {
+            return Err(AdapterError::new(
+                "candidate-transition binding has an invalid identity",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_request(&self, request: &CandidateTransitionRequest) -> Result<(), AdapterError> {
+        if request.session_digest() != self.session_digest
+            || request.validator() != &self.validator
+            || request.adjacency_policy_digest() != self.adjacency_policy_digest
+        {
+            return Err(AdapterError::new(
+                "candidate-transition request differs from the vehicle binding",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// A vehicle adapter that has a validated simulator session binding.
 pub struct VehicleBinding<A> {
     adapter: A,
     receipt: VehicleBindingReceipt,
+    transition: Option<TransitionBindingReceipt>,
 }
 
 impl<A> VehicleBinding<A> {
@@ -146,8 +257,35 @@ impl<A> VehicleBinding<A> {
         self.receipt
     }
 
+    pub(crate) const fn transition_receipt(&self) -> Option<&TransitionBindingReceipt> {
+        self.transition.as_ref()
+    }
+
     pub(crate) fn adapter_mut(&mut self) -> &mut A {
         &mut self.adapter
+    }
+}
+
+impl<A: SimulatorVehicleAdapter> VehicleBinding<A> {
+    /// Authorizes one exact transition without controller mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the session or policy binding differs,
+    /// or when the adapter rejects the transition.
+    pub(crate) fn authorize_candidate_transition(
+        &self,
+        request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        let transition = self.transition.as_ref().ok_or_else(|| {
+            AdapterError::new("vehicle binding has no candidate-transition policy")
+        })?;
+        transition.validate_request(request)?;
+        let receipt = self.adapter.authorize_candidate_transition(request)?;
+        receipt
+            .validate_for(request)
+            .map_err(|error| AdapterError::new(error.to_string()))?;
+        Ok(receipt)
     }
 }
 
@@ -162,6 +300,17 @@ pub struct CandidateReceipt {
     pub applied_digest: Digest,
     /// The digest reconstructed from controller readback.
     pub readback_digest: Digest,
+    /// The exact run intent, or no intent for idle reconciliation.
+    pub run_intent_digest: Option<Digest>,
+}
+
+/// The receipt for a prepared simulator run intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunPreparationReceipt {
+    /// The tuning session that owns the run.
+    pub session_digest: Digest,
+    /// The exact prepared run intent digest.
+    pub run_intent_digest: Digest,
 }
 
 /// The receipt for the scenario that started in the simulator.
@@ -173,6 +322,8 @@ pub struct ScenarioStartReceipt {
     pub applied_scenario_digest: Digest,
     /// The applied deterministic run seed.
     pub seed: u64,
+    /// The exact started run intent digest.
+    pub run_intent_digest: Digest,
 }
 
 /// One ordered simulator telemetry sample.
@@ -211,18 +362,19 @@ pub trait SimulatorBackend {
         challenge: &SessionChallenge,
     ) -> Result<SimulatorSessionReceipt, AdapterError>;
 
-    /// Prepares a clean simulator run.
+    /// Prepares one exact durable run intent.
     fn prepare_blocking(
         &mut self,
         capability: &SimulatorCapability,
+        context: &RunExecutionContext,
         scenario: &ScenarioRef,
-        seed: u64,
-    ) -> Result<(), AdapterError>;
+    ) -> Result<RunPreparationReceipt, AdapterError>;
 
     /// Starts the prepared scenario and returns the applied artifact receipt.
     fn start_blocking(
         &mut self,
         capability: &SimulatorCapability,
+        context: &RunExecutionContext,
     ) -> Result<ScenarioStartReceipt, AdapterError>;
 
     /// Requests the next telemetry sample with a finite timeout.
@@ -237,17 +389,49 @@ pub trait SimulatorBackend {
 
 /// A vehicle adapter that can activate a candidate only with a simulator binding.
 pub trait SimulatorVehicleAdapter {
-    /// Ensures that a candidate is active and returns exact readback digests.
+    /// Validates one exact candidate transition without external mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source, target, or adjacency policy rejects
+    /// the transition. The default rejects adapters that do not implement the
+    /// transition contract.
+    fn authorize_candidate_transition(
+        &self,
+        _request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        Err(AdapterError::new(
+            "vehicle adapter has no candidate-transition validator",
+        ))
+    }
+
+    /// Ensures that the settled candidate is active during reconciliation.
     ///
     /// The operation must not write controller state when the requested
     /// candidate is already active. This rule makes restart reconciliation
     /// safe to repeat.
-    fn ensure_candidate_blocking(
+    fn ensure_settled_candidate_blocking(
         &mut self,
         capability: &SimulatorCapability,
         candidate: &Candidate,
         candidate_digest: Digest,
     ) -> Result<CandidateReceipt, AdapterError>;
+
+    /// Ensures that a candidate is active for one exact durable run intent.
+    ///
+    /// The receipt must include the digest of `context`. The operation must
+    /// not write controller state when the requested candidate is active.
+    fn ensure_candidate_for_run_blocking(
+        &mut self,
+        _capability: &SimulatorCapability,
+        _context: &RunExecutionContext,
+        _candidate: &Candidate,
+        _candidate_digest: Digest,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        Err(AdapterError::new(
+            "vehicle adapter has no run-intent candidate activation",
+        ))
+    }
 }
 
 /// A factory that binds a vehicle adapter to a validated simulator session.
@@ -257,6 +441,12 @@ pub trait SimulatorVehicleFactory {
 
     /// Returns the exact vehicle implementation identity.
     fn vehicle_identity(&self) -> &ArtifactIdentity;
+
+    /// Returns the exact candidate-transition validator identity.
+    fn transition_validator_identity(&self) -> &ArtifactIdentity;
+
+    /// Returns the exact vehicle adjacency-policy identity.
+    fn adjacency_policy_digest(&self) -> Digest;
 
     /// Creates a vehicle binding for the validated simulator session.
     fn bind_blocking(

--- a/tools/flight-tune/src/adapter/transition.rs
+++ b/tools/flight-tune/src/adapter/transition.rs
@@ -1,0 +1,462 @@
+use pilotage_trial::Digest;
+use serde::{Deserialize, Serialize};
+
+use crate::{ArtifactIdentity, Candidate, TuneError};
+
+mod digest;
+
+pub(crate) use digest::planning_context_digest;
+use digest::{ReceiptDocument, receipt_digest, validate_candidate_digest};
+
+/// The supported candidate-transition receipt schema.
+pub const CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION: u16 = 1;
+
+/// The exact input to one vehicle-specific candidate transition check.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateTransitionRequest {
+    schema_version: u16,
+    session_digest: Digest,
+    source: Candidate,
+    source_candidate_digest: Digest,
+    target: Candidate,
+    target_candidate_digest: Digest,
+    validator: ArtifactIdentity,
+    adjacency_policy_digest: Digest,
+    planning_context_digest: Digest,
+}
+
+/// An immutable vehicle-specific candidate transition authorization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateTransitionReceipt {
+    schema_version: u16,
+    session_digest: Digest,
+    source_candidate_digest: Digest,
+    target_candidate_digest: Digest,
+    validator: ArtifactIdentity,
+    adjacency_policy_digest: Digest,
+    planning_context_digest: Digest,
+    receipt_digest: Digest,
+}
+
+/// The exact receipt fields carried by a downstream execution identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CandidateTransitionReference {
+    schema_version: u16,
+    session_digest: Digest,
+    source_candidate_digest: Digest,
+    target_candidate_digest: Digest,
+    validator_digest: Digest,
+    adjacency_policy_digest: Digest,
+    planning_context_digest: Digest,
+    receipt_digest: Digest,
+}
+
+impl CandidateTransitionRequest {
+    /// Creates one complete transition check request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when an identity is invalid, a candidate digest
+    /// differs, or the candidates are not adjacent forms of one parameter set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_digest: Digest,
+        source: &Candidate,
+        source_candidate_digest: Digest,
+        target: &Candidate,
+        target_candidate_digest: Digest,
+        validator: ArtifactIdentity,
+        adjacency_policy_digest: Digest,
+        planning_context_digest: Digest,
+    ) -> Result<Self, TuneError> {
+        validate_request_identities(
+            session_digest,
+            source_candidate_digest,
+            target_candidate_digest,
+            &validator,
+            adjacency_policy_digest,
+            planning_context_digest,
+        )?;
+        source.validate()?;
+        target.validate()?;
+        validate_candidate_pair(source, target)?;
+        validate_candidate_digest(source, source_candidate_digest, "source")?;
+        validate_candidate_digest(target, target_candidate_digest, "target")?;
+        Ok(Self {
+            schema_version: CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION,
+            session_digest,
+            source: source.clone(),
+            source_candidate_digest,
+            target: target.clone(),
+            target_candidate_digest,
+            validator,
+            adjacency_policy_digest,
+            planning_context_digest,
+        })
+    }
+
+    /// Returns the tuning session identity.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the exact source candidate.
+    #[must_use]
+    pub const fn source(&self) -> &Candidate {
+        &self.source
+    }
+
+    /// Returns the source candidate identity.
+    #[must_use]
+    pub const fn source_candidate_digest(&self) -> Digest {
+        self.source_candidate_digest
+    }
+
+    /// Returns the exact target candidate.
+    #[must_use]
+    pub const fn target(&self) -> &Candidate {
+        &self.target
+    }
+
+    /// Returns the target candidate identity.
+    #[must_use]
+    pub const fn target_candidate_digest(&self) -> Digest {
+        self.target_candidate_digest
+    }
+
+    /// Returns the transition validator identity.
+    #[must_use]
+    pub const fn validator(&self) -> &ArtifactIdentity {
+        &self.validator
+    }
+
+    /// Returns the exact adjacency-policy identity.
+    #[must_use]
+    pub const fn adjacency_policy_digest(&self) -> Digest {
+        self.adjacency_policy_digest
+    }
+
+    /// Returns the opaque planning-context identity.
+    #[must_use]
+    pub const fn planning_context_digest(&self) -> Digest {
+        self.planning_context_digest
+    }
+}
+
+impl CandidateTransitionReceipt {
+    /// Creates a receipt after a vehicle adapter accepts the request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when canonical receipt encoding fails.
+    pub fn authorized(request: &CandidateTransitionRequest) -> Result<Self, TuneError> {
+        validate_request(request)?;
+        let mut receipt = Self {
+            schema_version: request.schema_version,
+            session_digest: request.session_digest,
+            source_candidate_digest: request.source_candidate_digest,
+            target_candidate_digest: request.target_candidate_digest,
+            validator: request.validator.clone(),
+            adjacency_policy_digest: request.adjacency_policy_digest,
+            planning_context_digest: request.planning_context_digest,
+            receipt_digest: Digest::from_bytes([0; 32]),
+        };
+        receipt.receipt_digest = receipt.recompute_digest()?;
+        Ok(receipt)
+    }
+
+    /// Validates the receipt against the exact requested transition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when a field or the canonical digest differs.
+    pub fn validate_for(&self, request: &CandidateTransitionRequest) -> Result<(), TuneError> {
+        let expected = Self::authorized(request)?;
+        if self == &expected {
+            Ok(())
+        } else {
+            Err(receipt_mismatch(
+                "the transition receipt does not match the exact request",
+            ))
+        }
+    }
+
+    /// Recomputes the domain-separated canonical receipt identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when canonical receipt encoding fails.
+    pub fn recompute_digest(&self) -> Result<Digest, TuneError> {
+        receipt_digest(&ReceiptDocument {
+            schema_version: self.schema_version,
+            session_digest: self.session_digest,
+            source_candidate_digest: self.source_candidate_digest,
+            target_candidate_digest: self.target_candidate_digest,
+            validator: &self.validator,
+            adjacency_policy_digest: self.adjacency_policy_digest,
+            planning_context_digest: self.planning_context_digest,
+        })
+    }
+
+    /// Returns the receipt schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns the tuning session identity.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the source candidate identity.
+    #[must_use]
+    pub const fn source_candidate_digest(&self) -> Digest {
+        self.source_candidate_digest
+    }
+
+    /// Returns the target candidate identity.
+    #[must_use]
+    pub const fn target_candidate_digest(&self) -> Digest {
+        self.target_candidate_digest
+    }
+
+    /// Returns the transition validator identity.
+    #[must_use]
+    pub const fn validator(&self) -> &ArtifactIdentity {
+        &self.validator
+    }
+
+    /// Returns the adjacency-policy identity.
+    #[must_use]
+    pub const fn adjacency_policy_digest(&self) -> Digest {
+        self.adjacency_policy_digest
+    }
+
+    /// Returns the opaque planning-context identity.
+    #[must_use]
+    pub const fn planning_context_digest(&self) -> Digest {
+        self.planning_context_digest
+    }
+
+    /// Returns the complete receipt identity.
+    #[must_use]
+    pub const fn receipt_digest(&self) -> Digest {
+        self.receipt_digest
+    }
+
+    /// Returns the downstream reference for this receipt.
+    #[must_use]
+    pub const fn reference(&self) -> CandidateTransitionReference {
+        CandidateTransitionReference {
+            schema_version: self.schema_version,
+            session_digest: self.session_digest,
+            source_candidate_digest: self.source_candidate_digest,
+            target_candidate_digest: self.target_candidate_digest,
+            validator_digest: self.validator.digest,
+            adjacency_policy_digest: self.adjacency_policy_digest,
+            planning_context_digest: self.planning_context_digest,
+            receipt_digest: self.receipt_digest,
+        }
+    }
+}
+
+impl CandidateTransitionReference {
+    /// Reports whether the reference has valid fields for one target.
+    ///
+    /// This check does not authorize the reference. Replay must also call
+    /// [`Self::validate_for_runtime`] with the frozen runtime identities.
+    #[must_use]
+    pub fn is_valid_for_target(self, target_candidate_digest: Digest) -> bool {
+        self.schema_version == CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION
+            && !self.session_digest.is_zero()
+            && !self.source_candidate_digest.is_zero()
+            && self.target_candidate_digest == target_candidate_digest
+            && !self.target_candidate_digest.is_zero()
+            && self.source_candidate_digest != self.target_candidate_digest
+            && !self.validator_digest.is_zero()
+            && !self.adjacency_policy_digest.is_zero()
+            && !self.planning_context_digest.is_zero()
+            && !self.receipt_digest.is_zero()
+    }
+
+    /// Validates this reference against one runtime transition contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when a field or the canonical digest differs.
+    pub fn validate_for_runtime(
+        self,
+        session_digest: Digest,
+        source_candidate_digest: Digest,
+        target_candidate_digest: Digest,
+        validator: &ArtifactIdentity,
+        adjacency_policy_digest: Digest,
+        planning_context_digest: Digest,
+    ) -> Result<(), TuneError> {
+        validator.validate()?;
+        let receipt = CandidateTransitionReceipt {
+            schema_version: self.schema_version,
+            session_digest,
+            source_candidate_digest,
+            target_candidate_digest,
+            validator: validator.clone(),
+            adjacency_policy_digest,
+            planning_context_digest,
+            receipt_digest: self.receipt_digest,
+        };
+        let expected = receipt.recompute_digest()?;
+        if self.schema_version == CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION
+            && self.session_digest == session_digest
+            && !self.session_digest.is_zero()
+            && self.source_candidate_digest == source_candidate_digest
+            && !source_candidate_digest.is_zero()
+            && self.target_candidate_digest == target_candidate_digest
+            && !self.target_candidate_digest.is_zero()
+            && self.validator_digest == validator.digest
+            && self.adjacency_policy_digest == adjacency_policy_digest
+            && !self.adjacency_policy_digest.is_zero()
+            && self.planning_context_digest == planning_context_digest
+            && !self.planning_context_digest.is_zero()
+            && self.source_candidate_digest != self.target_candidate_digest
+            && !self.receipt_digest.is_zero()
+            && self.receipt_digest == expected
+        {
+            Ok(())
+        } else {
+            Err(receipt_mismatch(
+                "the transition reference does not match the runtime contract",
+            ))
+        }
+    }
+
+    /// Returns the receipt schema version.
+    #[must_use]
+    pub const fn schema_version(self) -> u16 {
+        self.schema_version
+    }
+
+    /// Returns the tuning session identity.
+    #[must_use]
+    pub const fn session_digest(self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the source candidate identity.
+    #[must_use]
+    pub const fn source_candidate_digest(self) -> Digest {
+        self.source_candidate_digest
+    }
+
+    /// Returns the target candidate identity.
+    #[must_use]
+    pub const fn target_candidate_digest(self) -> Digest {
+        self.target_candidate_digest
+    }
+
+    /// Returns the transition validator identity.
+    #[must_use]
+    pub const fn validator_digest(self) -> Digest {
+        self.validator_digest
+    }
+
+    /// Returns the adjacency-policy identity.
+    #[must_use]
+    pub const fn adjacency_policy_digest(self) -> Digest {
+        self.adjacency_policy_digest
+    }
+
+    /// Returns the opaque planning-context identity.
+    #[must_use]
+    pub const fn planning_context_digest(self) -> Digest {
+        self.planning_context_digest
+    }
+
+    /// Returns the complete receipt identity.
+    #[must_use]
+    pub const fn receipt_digest(self) -> Digest {
+        self.receipt_digest
+    }
+}
+
+fn validate_request(request: &CandidateTransitionRequest) -> Result<(), TuneError> {
+    if request.schema_version != CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION {
+        return Err(receipt_mismatch(
+            "the transition request schema is not supported",
+        ));
+    }
+    validate_request_identities(
+        request.session_digest,
+        request.source_candidate_digest,
+        request.target_candidate_digest,
+        &request.validator,
+        request.adjacency_policy_digest,
+        request.planning_context_digest,
+    )?;
+    request.source.validate()?;
+    request.target.validate()?;
+    validate_candidate_pair(&request.source, &request.target)?;
+    validate_candidate_digest(&request.source, request.source_candidate_digest, "source")?;
+    validate_candidate_digest(&request.target, request.target_candidate_digest, "target")
+}
+
+fn validate_request_identities(
+    session_digest: Digest,
+    source_candidate_digest: Digest,
+    target_candidate_digest: Digest,
+    validator: &ArtifactIdentity,
+    adjacency_policy_digest: Digest,
+    planning_context_digest: Digest,
+) -> Result<(), TuneError> {
+    validator.validate()?;
+    if session_digest.is_zero()
+        || source_candidate_digest.is_zero()
+        || target_candidate_digest.is_zero()
+        || source_candidate_digest == target_candidate_digest
+        || adjacency_policy_digest.is_zero()
+        || planning_context_digest.is_zero()
+    {
+        return Err(TuneError::InvalidIdentity {
+            detail: "the candidate transition request is incomplete".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_candidate_pair(source: &Candidate, target: &Candidate) -> Result<(), TuneError> {
+    if source == target {
+        return Err(invalid_candidate("the candidate transition is unchanged"));
+    }
+    if source.lineage() != target.lineage() {
+        return Err(invalid_candidate(
+            "the candidate transition changed candidate lineage",
+        ));
+    }
+    if source.parameters().keys().ne(target.parameters().keys()) {
+        return Err(invalid_candidate(
+            "the candidate transition changed the parameter set",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_candidate(detail: impl Into<String>) -> TuneError {
+    TuneError::InvalidCandidate {
+        detail: detail.into(),
+    }
+}
+
+fn receipt_mismatch(detail: impl Into<String>) -> TuneError {
+    TuneError::ReceiptMismatch {
+        operation: "authorize candidate transition",
+        detail: detail.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune/src/adapter/transition/digest.rs
+++ b/tools/flight-tune/src/adapter/transition/digest.rs
@@ -1,0 +1,84 @@
+use pilotage_trial::Digest;
+use serde::Serialize;
+use sha2::{Digest as ShaDigest, Sha256};
+
+use crate::identity::digest_bytes;
+use crate::{ArtifactIdentity, Candidate, TuneError};
+
+const RECEIPT_DOMAIN: &[u8] = b"pilotage.flight-tune.candidate-transition-receipt.v1\0";
+const PLANNING_CONTEXT_DOMAIN: &[u8] =
+    b"pilotage.flight-tune.candidate-transition-planning-context.v1\0";
+
+#[derive(Serialize)]
+pub(super) struct ReceiptDocument<'a> {
+    pub(super) schema_version: u16,
+    pub(super) session_digest: Digest,
+    pub(super) source_candidate_digest: Digest,
+    pub(super) target_candidate_digest: Digest,
+    pub(super) validator: &'a ArtifactIdentity,
+    pub(super) adjacency_policy_digest: Digest,
+    pub(super) planning_context_digest: Digest,
+}
+
+#[derive(Serialize)]
+struct PlanningContextDocument {
+    schema_version: u16,
+    stage_digest: Digest,
+    plan_digest: Digest,
+}
+
+pub(super) fn validate_candidate_digest(
+    candidate: &Candidate,
+    expected: Digest,
+    role: &'static str,
+) -> Result<(), TuneError> {
+    let bytes = serde_json::to_vec(candidate).map_err(|source| TuneError::Encode {
+        document: "candidate transition candidate",
+        source,
+    })?;
+    if digest_bytes(&bytes) != expected {
+        return Err(TuneError::InvalidIdentity {
+            detail: format!("the {role} candidate digest does not match its exact candidate"),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn receipt_digest(document: &ReceiptDocument<'_>) -> Result<Digest, TuneError> {
+    domain_digest(RECEIPT_DOMAIN, document, "candidate transition receipt")
+}
+
+pub(crate) fn planning_context_digest(
+    stage_digest: Digest,
+    plan_digest: Digest,
+) -> Result<Digest, TuneError> {
+    if stage_digest.is_zero() || plan_digest.is_zero() {
+        return Err(TuneError::InvalidIdentity {
+            detail: "the candidate transition planning context is incomplete".to_owned(),
+        });
+    }
+    domain_digest(
+        PLANNING_CONTEXT_DOMAIN,
+        &PlanningContextDocument {
+            schema_version: 1,
+            stage_digest,
+            plan_digest,
+        },
+        "candidate transition planning context",
+    )
+}
+
+fn domain_digest(
+    domain: &[u8],
+    document: &impl Serialize,
+    name: &'static str,
+) -> Result<Digest, TuneError> {
+    let bytes = serde_json::to_vec(document).map_err(|source| TuneError::Encode {
+        document: name,
+        source,
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(bytes);
+    Ok(Digest::from_bytes(hasher.finalize().into()))
+}

--- a/tools/flight-tune/src/adapter/transition/tests.rs
+++ b/tools/flight-tune/src/adapter/transition/tests.rs
@@ -1,0 +1,265 @@
+#![allow(clippy::expect_used)]
+
+use std::cell::Cell;
+use std::collections::BTreeMap;
+
+use super::super::TransitionBindingReceipt;
+use super::*;
+use crate::identity::digest_bytes;
+use crate::{
+    AdapterError, CandidateLineage, CandidateReceipt, SimulatorCapability, SimulatorSessionReceipt,
+    SimulatorVehicleAdapter, VehicleBindingReceipt,
+};
+
+#[test]
+fn receipt_binds_every_transition_input() {
+    let request = request(candidate(1.0), candidate(2.0));
+    let receipt = CandidateTransitionReceipt::authorized(&request).expect("create receipt");
+    assert!(receipt.validate_for(&request).is_ok());
+    assert_eq!(
+        receipt.recompute_digest().expect("digest"),
+        receipt.receipt_digest()
+    );
+    assert!(
+        receipt
+            .reference()
+            .validate_for_runtime(
+                digest(1),
+                request.source_candidate_digest(),
+                request.target_candidate_digest(),
+                &validator(),
+                digest(3),
+                digest(4)
+            )
+            .is_ok()
+    );
+    assert!(
+        receipt
+            .reference()
+            .validate_for_runtime(
+                digest(1),
+                digest(9),
+                request.target_candidate_digest(),
+                &validator(),
+                digest(3),
+                digest(4)
+            )
+            .is_err()
+    );
+
+    let other = CandidateTransitionRequest::new(
+        digest(1),
+        request.source(),
+        request.source_candidate_digest(),
+        &candidate(3.0),
+        candidate_digest(&candidate(3.0)),
+        validator(),
+        digest(3),
+        digest(4),
+    )
+    .expect("other request");
+    assert!(receipt.validate_for(&other).is_err());
+}
+
+#[test]
+fn unchanged_lineage_and_parameter_name_changes_fail_closed() {
+    let source = candidate(1.0);
+    assert!(make_request(&source, &source).is_err());
+
+    let changed_lineage = Candidate::new(
+        CandidateLineage {
+            schema: "other".to_owned(),
+            base_preset_digest: digest(7),
+            plant_digest: digest(8),
+        },
+        BTreeMap::from([("gain".to_owned(), 2.0)]),
+    )
+    .expect("candidate");
+    assert!(make_request(&source, &changed_lineage).is_err());
+
+    let changed_name = Candidate::new(
+        source.lineage().clone(),
+        BTreeMap::from([("rate".to_owned(), 2.0)]),
+    )
+    .expect("candidate");
+    assert!(make_request(&source, &changed_name).is_err());
+}
+
+#[test]
+fn candidate_digest_mismatch_fails_closed() {
+    let source = candidate(1.0);
+    let target = candidate(2.0);
+    for (source_digest, target_digest) in [
+        (digest(9), candidate_digest(&target)),
+        (candidate_digest(&source), digest(9)),
+    ] {
+        assert!(
+            CandidateTransitionRequest::new(
+                digest(1),
+                &source,
+                source_digest,
+                &target,
+                target_digest,
+                validator(),
+                digest(3),
+                digest(4),
+            )
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn receipt_schema_and_unknown_fields_fail_closed() {
+    let request = request(candidate(1.0), candidate(2.0));
+    let receipt = CandidateTransitionReceipt::authorized(&request).expect("create receipt");
+    let mut value = serde_json::to_value(&receipt).expect("encode receipt");
+    value["schema_version"] = serde_json::json!(0);
+    let downgraded: CandidateTransitionReceipt =
+        serde_json::from_value(value.clone()).expect("decode receipt");
+    assert!(downgraded.validate_for(&request).is_err());
+    value["unknown"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<CandidateTransitionReceipt>(value).is_err());
+}
+
+#[test]
+fn binding_checks_session_validator_and_policy_before_adapter_call() {
+    let calls = Cell::new(0);
+    let capability = SimulatorCapability::new(SimulatorSessionReceipt {
+        session_digest: digest(1),
+        simulator_digest: digest(5),
+        airframe_digest: digest(6),
+    });
+    let binding = capability
+        .bind_vehicle_with_transition(
+            AcceptingAdapter { calls: &calls },
+            VehicleBindingReceipt {
+                session_digest: digest(1),
+                vehicle_digest: digest(2),
+            },
+            TransitionBindingReceipt::new(digest(1), validator(), digest(3))
+                .expect("transition binding"),
+        )
+        .expect("vehicle binding");
+    let request = request(candidate(1.0), candidate(2.0));
+    assert!(binding.authorize_candidate_transition(&request).is_ok());
+    assert_eq!(calls.get(), 1);
+
+    let wrong_policy = CandidateTransitionRequest::new(
+        digest(1),
+        request.source(),
+        request.source_candidate_digest(),
+        request.target(),
+        request.target_candidate_digest(),
+        validator(),
+        digest(9),
+        digest(4),
+    )
+    .expect("request");
+    assert!(
+        binding
+            .authorize_candidate_transition(&wrong_policy)
+            .is_err()
+    );
+    assert_eq!(calls.get(), 1);
+}
+
+#[test]
+fn transition_binding_rejects_another_session() {
+    let capability = SimulatorCapability::new(SimulatorSessionReceipt {
+        session_digest: digest(1),
+        simulator_digest: digest(5),
+        airframe_digest: digest(6),
+    });
+    assert!(
+        capability
+            .bind_vehicle_with_transition(
+                AcceptingAdapter {
+                    calls: &Cell::new(0)
+                },
+                VehicleBindingReceipt {
+                    session_digest: digest(1),
+                    vehicle_digest: digest(2),
+                },
+                TransitionBindingReceipt::new(digest(9), validator(), digest(3))
+                    .expect("transition binding"),
+            )
+            .is_err()
+    );
+}
+
+#[test]
+fn planning_context_is_domain_separated_and_complete() {
+    let context = planning_context_digest(digest(1), digest(2)).expect("planning context");
+    assert!(!context.is_zero());
+    assert_ne!(context, digest_bytes(&[1; 32]));
+    assert!(planning_context_digest(digest(0), digest(2)).is_err());
+}
+
+struct AcceptingAdapter<'a> {
+    calls: &'a Cell<u32>,
+}
+
+impl SimulatorVehicleAdapter for AcceptingAdapter<'_> {
+    fn authorize_candidate_transition(
+        &self,
+        request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        self.calls.set(self.calls.get().wrapping_add(1));
+        CandidateTransitionReceipt::authorized(request)
+            .map_err(|error| AdapterError::new(error.to_string()))
+    }
+
+    fn ensure_settled_candidate_blocking(
+        &mut self,
+        _capability: &SimulatorCapability,
+        _candidate: &Candidate,
+        _candidate_digest: Digest,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        Err(AdapterError::new("test does not apply a candidate"))
+    }
+}
+
+fn request(source: Candidate, target: Candidate) -> CandidateTransitionRequest {
+    make_request(&source, &target).expect("request")
+}
+
+fn make_request(
+    source: &Candidate,
+    target: &Candidate,
+) -> Result<CandidateTransitionRequest, TuneError> {
+    CandidateTransitionRequest::new(
+        digest(1),
+        source,
+        candidate_digest(source),
+        target,
+        candidate_digest(target),
+        validator(),
+        digest(3),
+        digest(4),
+    )
+}
+
+fn candidate(value: f64) -> Candidate {
+    Candidate::new(
+        CandidateLineage {
+            schema: "test".to_owned(),
+            base_preset_digest: digest(7),
+            plant_digest: digest(8),
+        },
+        BTreeMap::from([("gain".to_owned(), value)]),
+    )
+    .expect("candidate")
+}
+
+fn candidate_digest(candidate: &Candidate) -> Digest {
+    digest_bytes(&serde_json::to_vec(candidate).expect("encode candidate"))
+}
+
+fn validator() -> ArtifactIdentity {
+    ArtifactIdentity::new("test-transition-validator", digest(10)).expect("validator")
+}
+
+const fn digest(value: u8) -> Digest {
+    Digest::from_bytes([value; 32])
+}

--- a/tools/flight-tune/src/engine.rs
+++ b/tools/flight-tune/src/engine.rs
@@ -6,6 +6,7 @@ mod promotion;
 mod qualification;
 mod reconcile;
 mod session;
+mod transition;
 
 #[cfg(test)]
 mod tests;
@@ -16,10 +17,10 @@ pub(crate) use qualification::final_outcome;
 
 use crate::journal::{AttemptRole, CampaignPhase};
 use crate::{
-    Candidate, CandidateEvaluation, Digest, FinalQualificationOutcome, GateEvaluator, Journal,
-    MetricEvaluator, PromotionDecision, ProposalContext, ProposalStrategy, SearchStage,
-    SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter, TrainingView, TuneError,
-    VehicleBinding,
+    Candidate, CandidateEvaluation, CandidateTransitionReference, Digest,
+    FinalQualificationOutcome, GateEvaluator, Journal, MetricEvaluator, PromotionDecision,
+    ProposalContext, ProposalStrategy, SearchStage, SimulatorBackend, SimulatorCapability,
+    SimulatorVehicleAdapter, TrainingView, TuneError, VehicleBinding,
 };
 
 /// Why one bounded training search call stopped.
@@ -218,6 +219,14 @@ where
     }
 
     fn run_one_training_challenger_blocking(&mut self) -> Result<bool, TuneError> {
+        if let Some(authorized) = self.journal.authorized_training_transition().cloned() {
+            let candidate = self.journal.read_candidate(authorized.candidate)?;
+            let role = AttemptRole::TrainingChallenger {
+                attempt_index: authorized.attempt_index,
+            };
+            self.run_attempt_blocking(role, &candidate, Some(authorized.reference))?;
+            return Ok(true);
+        }
         let incumbent = self.journal.training_incumbent()?;
         let history = self.journal.training_history();
         let context = ProposalContext {
@@ -249,10 +258,18 @@ where
             return Ok(false);
         };
         validate_proposal(&self.stage, &incumbent, &proposal, &history)?;
-        let role = AttemptRole::TrainingChallenger {
-            attempt_index: self.journal.training_attempt_count(),
-        };
-        self.run_new_attempt_blocking(role, &proposal.candidate)?;
+        let attempt_index = self.journal.training_attempt_count();
+        let role = AttemptRole::TrainingChallenger { attempt_index };
+        let transition = transition::authorize_new(
+            &mut self.journal,
+            &self.stage,
+            &self.vehicle,
+            &incumbent,
+            &proposal.candidate,
+            attempt_index,
+            &proposal.reason,
+        )?;
+        self.run_attempt_blocking(role, &proposal.candidate, Some(transition))?;
         Ok(true)
     }
 
@@ -270,10 +287,21 @@ where
         role: AttemptRole,
         candidate: &Candidate,
     ) -> Result<(), TuneError> {
+        self.run_attempt_blocking(role, candidate, None)
+    }
+
+    fn run_attempt_blocking(
+        &mut self,
+        role: AttemptRole,
+        candidate: &Candidate,
+        transition: Option<CandidateTransitionReference>,
+    ) -> Result<(), TuneError> {
         let digest = evaluate::candidate_digest(candidate)?;
         let plan =
             evaluate::plan_digest(&self.stage, role, digest, self.journal.session().fixed_seed)?;
-        let (trial_id, stored_digest) = self.journal.prepare_attempt(role, candidate, plan)?;
+        let (trial_id, stored_digest) = self
+            .journal
+            .prepare_attempt(role, candidate, plan, transition)?;
         if stored_digest != digest {
             return Err(TuneError::DigestMismatch { expected: digest });
         }
@@ -284,6 +312,7 @@ where
             role,
             candidate,
             digest,
+            transition,
             &mut self.backend,
             &mut self.vehicle,
             &self.capability,

--- a/tools/flight-tune/src/engine/evaluate.rs
+++ b/tools/flight-tune/src/engine/evaluate.rs
@@ -1,21 +1,20 @@
 mod cleanup;
 mod contract;
 mod record;
-
-use std::time::Duration;
+mod stream;
 
 use crate::identity::digest_bytes;
-use crate::journal::{AttemptRole, OperationStatus};
+use crate::journal::AttemptRole;
 use crate::model::derive_seed;
-use crate::score::{validate_gate_outcomes, validate_metric};
 use crate::{
-    Candidate, Digest, GateEvaluator, GateOutcome, HardGateFailure, Journal, MetricEvaluator,
-    SampleEvent, SearchStage, SimulatorBackend, SimulatorCapability, SimulatorVehicleAdapter,
-    TelemetrySample, TuneError, VehicleBinding,
+    Candidate, CandidateTransitionReference, Digest, GateEvaluator, Journal, MetricEvaluator,
+    RunExecutionContext, SearchStage, SimulatorBackend, SimulatorCapability,
+    SimulatorVehicleAdapter, TuneError, VehicleBinding,
 };
 use cleanup::{cleanup_status, finish_cleanup, operation_status, quarantine_after_error};
 use contract::*;
 use record::{RunProgress, record_terminal};
+use stream::stream_samples;
 
 pub(super) fn plan_digest(
     stage: &SearchStage,
@@ -34,7 +33,7 @@ pub(super) fn candidate_digest(candidate: &Candidate) -> Result<Digest, TuneErro
     Ok(digest_bytes(&bytes))
 }
 
-pub(super) fn ensure_candidate_blocking<V>(
+pub(super) fn ensure_settled_candidate_blocking<V>(
     journal: &Journal,
     vehicle: &mut VehicleBinding<V>,
     capability: &SimulatorCapability,
@@ -45,11 +44,39 @@ where
     V: SimulatorVehicleAdapter,
 {
     journal.ensure_usable()?;
-    let receipt =
-        vehicle
-            .adapter_mut()
-            .ensure_candidate_blocking(capability, candidate, candidate_digest);
-    validate_candidate_receipt(receipt, capability, candidate_digest)?;
+    let receipt = vehicle.adapter_mut().ensure_settled_candidate_blocking(
+        capability,
+        candidate,
+        candidate_digest,
+    );
+    validate_candidate_receipt(receipt, capability, candidate_digest, None)?;
+    journal.ensure_usable()
+}
+
+fn ensure_candidate_for_run_blocking<V>(
+    journal: &Journal,
+    vehicle: &mut VehicleBinding<V>,
+    capability: &SimulatorCapability,
+    context: &RunContext<'_>,
+    candidate: &Candidate,
+    candidate_digest: Digest,
+) -> Result<(), TuneError>
+where
+    V: SimulatorVehicleAdapter,
+{
+    journal.ensure_usable()?;
+    let receipt = vehicle.adapter_mut().ensure_candidate_for_run_blocking(
+        capability,
+        &context.execution,
+        candidate,
+        candidate_digest,
+    );
+    validate_candidate_receipt(
+        receipt,
+        capability,
+        candidate_digest,
+        Some(context.run_intent_digest),
+    )?;
     journal.ensure_usable()
 }
 
@@ -96,6 +123,7 @@ pub(super) fn run_prepared_blocking<B, V, G, M>(
     role: AttemptRole,
     candidate: &Candidate,
     candidate_digest: Digest,
+    transition: Option<CandidateTransitionReference>,
     backend: &mut B,
     vehicle: &mut VehicleBinding<V>,
     capability: &SimulatorCapability,
@@ -113,16 +141,21 @@ where
     let scenario_count = scenarios(stage, set).len();
     let expected_runs = scenario_count * stage.repetitions as usize;
     let mut runs = Vec::new();
+    let mut run_index = 0_u64;
     for scenario in scenarios(stage, set) {
         for repetition in 0..stage.repetitions {
-            journal.ensure_usable()?;
-            let seed = derive_seed(journal.session().fixed_seed, set, scenario, repetition);
-            let context = RunContext {
+            let context = prepare_run_context(
+                journal,
+                trial_id,
+                role,
+                candidate_digest,
+                transition,
                 set,
                 scenario,
                 repetition,
-                seed,
-            };
+                run_index,
+            )?;
+            run_index = run_index.wrapping_add(1);
             let terminal = run_until_terminal(
                 journal,
                 stage,
@@ -160,6 +193,42 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
+fn prepare_run_context<'a>(
+    journal: &mut Journal,
+    trial_id: u64,
+    role: AttemptRole,
+    candidate_digest: Digest,
+    transition: Option<CandidateTransitionReference>,
+    set: crate::ScenarioSet,
+    scenario: &'a crate::ScenarioRef,
+    repetition: u32,
+    run_index: u64,
+) -> Result<RunContext<'a>, TuneError> {
+    journal.ensure_usable()?;
+    let seed = derive_seed(journal.session().fixed_seed, set, scenario, repetition);
+    let execution = RunExecutionContext::new(
+        journal.session_digest()?,
+        trial_id,
+        role,
+        candidate_digest,
+        transition,
+        set,
+        scenario,
+        repetition,
+        seed,
+    )?;
+    let run_intent_digest = journal.prepare_run(run_index, &execution)?;
+    Ok(RunContext {
+        execution,
+        run_intent_digest,
+        set,
+        scenario,
+        repetition,
+        seed,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 fn run_until_terminal<B, V, G, M>(
     journal: &Journal,
     stage: &SearchStage,
@@ -184,15 +253,20 @@ where
             started: false,
         };
     }
-    if let Err(source) = backend.prepare_blocking(capability, context.scenario, context.seed) {
+    if let Err(error) = prepare_backend_run(backend, capability, context) {
         return RunTerminal::Failed {
-            error: adapter_error(backend, "prepare", source),
+            error,
             started: false,
         };
     }
-    if let Err(error) =
-        ensure_candidate_blocking(journal, vehicle, capability, candidate, candidate_digest)
-    {
+    if let Err(error) = ensure_candidate_for_run_blocking(
+        journal,
+        vehicle,
+        capability,
+        context,
+        candidate,
+        candidate_digest,
+    ) {
         return RunTerminal::Failed {
             error,
             started: false,
@@ -210,7 +284,7 @@ where
             started: false,
         };
     }
-    let receipt = match backend.start_blocking(capability) {
+    let receipt = match backend.start_blocking(capability, &context.execution) {
         Ok(receipt) => receipt,
         Err(source) => {
             return RunTerminal::Failed {
@@ -228,256 +302,16 @@ where
     stream_samples(journal, stage, context, backend, gates, metric)
 }
 
-fn stream_samples<B, G, M>(
-    journal: &Journal,
-    stage: &SearchStage,
-    context: &RunContext<'_>,
+fn prepare_backend_run<B>(
     backend: &mut B,
-    gates: &mut G,
-    metric: &mut M,
-) -> RunTerminal
+    capability: &SimulatorCapability,
+    context: &RunContext<'_>,
+) -> Result<(), TuneError>
 where
     B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
 {
-    let timeout = Duration::from_millis(u64::from(context.scenario.sample_timeout_ms));
-    let mut position = StreamPosition::default();
-    loop {
-        if let Err(error) = journal.ensure_usable() {
-            return RunTerminal::Failed {
-                error,
-                started: true,
-            };
-        }
-        match backend.sample_blocking(timeout) {
-            Ok(SampleEvent::Sample(sample)) => {
-                if let Some(terminal) = process_sample(
-                    journal,
-                    stage,
-                    context,
-                    sample,
-                    &mut position,
-                    gates,
-                    metric,
-                ) {
-                    return terminal;
-                }
-            }
-            Ok(SampleEvent::Complete) => {
-                return finish_stream_blocking(
-                    journal,
-                    context,
-                    position.expected_sequence,
-                    backend,
-                    gates,
-                    metric,
-                );
-            }
-            Ok(SampleEvent::TimedOut) => {
-                return hard_failure(
-                    context,
-                    position.expected_sequence,
-                    position.elapsed_ms,
-                    GateOutcome::fail(
-                        "core.sample_timeout",
-                        "the simulator did not supply a sample before the timeout",
-                    ),
-                );
-            }
-            Err(source) => {
-                return RunTerminal::Failed {
-                    error: adapter_error(backend, "sample", source),
-                    started: true,
-                };
-            }
-        }
-    }
-}
-
-#[derive(Default)]
-struct StreamPosition {
-    expected_sequence: u64,
-    elapsed_ms: u64,
-}
-
-#[allow(clippy::too_many_arguments)]
-fn process_sample<G, M>(
-    journal: &Journal,
-    stage: &SearchStage,
-    context: &RunContext<'_>,
-    sample: TelemetrySample,
-    position: &mut StreamPosition,
-    gates: &mut G,
-    metric: &mut M,
-) -> Option<RunTerminal>
-where
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    if position.expected_sequence >= u64::from(context.scenario.max_samples) {
-        return Some(hard_failure(
-            context,
-            sample.sequence,
-            sample.elapsed_ms,
-            GateOutcome::fail(
-                "core.sample_limit",
-                "the simulator exceeded the scenario sample limit",
-            ),
-        ));
-    }
-    if let Err(error) = validate_sample(&sample, position.expected_sequence, position.elapsed_ms) {
-        return Some(RunTerminal::Failed {
-            error,
-            started: true,
-        });
-    }
-    position.elapsed_ms = sample.elapsed_ms;
-    position.expected_sequence = position.expected_sequence.wrapping_add(1);
-    match evaluate_sample(journal, stage, &sample, gates, metric) {
-        Ok(Some(gate)) => Some(hard_failure(
-            context,
-            sample.sequence,
-            sample.elapsed_ms,
-            gate,
-        )),
-        Ok(None) => None,
-        Err(error) => Some(RunTerminal::Failed {
-            error,
-            started: true,
-        }),
-    }
-}
-
-fn finish_stream_blocking<B, G, M>(
-    journal: &Journal,
-    context: &RunContext<'_>,
-    sample_count: u64,
-    backend: &mut B,
-    gates: &mut G,
-    metric: &mut M,
-) -> RunTerminal
-where
-    B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    if sample_count == 0 {
-        return hard_failure(
-            context,
-            0,
-            0,
-            GateOutcome::fail(
-                "core.no_samples",
-                "the simulator completed without telemetry samples",
-            ),
-        );
-    }
-    finish_normal_run_blocking(journal, backend, gates, metric)
-}
-
-fn evaluate_sample<G, M>(
-    journal: &Journal,
-    stage: &SearchStage,
-    sample: &TelemetrySample,
-    gates: &mut G,
-    metric: &mut M,
-) -> Result<Option<GateOutcome>, TuneError>
-where
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    journal.ensure_usable()?;
-    let outcomes = gates
-        .evaluate(sample)
-        .map_err(|source| evaluator_error(gates.identity(), "evaluate hard gates", source))?;
-    if let Some(failure) = validate_gate_outcomes(&stage.required_hard_gates, &outcomes)? {
-        return Ok(Some(failure));
-    }
-    journal.ensure_usable()?;
-    metric
-        .observe(sample)
-        .map_err(|source| evaluator_error(metric.identity(), "observe metric", source))?;
-    Ok(None)
-}
-
-fn finish_normal_run_blocking<B, G, M>(
-    journal: &Journal,
-    backend: &mut B,
-    gates: &mut G,
-    metric: &mut M,
-) -> RunTerminal
-where
-    B: SimulatorBackend,
-    G: GateEvaluator,
-    M: MetricEvaluator,
-{
-    if let Err(error) = journal.ensure_usable() {
-        return RunTerminal::Failed {
-            error,
-            started: true,
-        };
-    }
-    if let Err(source) = backend.stop_blocking() {
-        return RunTerminal::Failed {
-            error: adapter_error(backend, "stop", source),
-            started: true,
-        };
-    }
-    if let Err(error) = journal.ensure_usable() {
-        return RunTerminal::Failed {
-            error,
-            started: false,
-        };
-    }
-    if let Err(source) = gates.finish() {
-        return RunTerminal::Failed {
-            error: evaluator_error(gates.identity(), "finish hard gates", source),
-            started: false,
-        };
-    }
-    if let Err(error) = journal.ensure_usable() {
-        return RunTerminal::Failed {
-            error,
-            started: false,
-        };
-    }
-    let values = match metric.finish() {
-        Ok(values) => values,
-        Err(source) => {
-            return RunTerminal::Failed {
-                error: evaluator_error(metric.identity(), "finish metric", source),
-                started: false,
-            };
-        }
-    };
-    if let Err(error) = validate_metric(&values) {
-        return RunTerminal::Failed {
-            error,
-            started: false,
-        };
-    }
-    RunTerminal::Passed {
-        values,
-        stop: OperationStatus::Succeeded,
-    }
-}
-
-fn hard_failure(
-    context: &RunContext<'_>,
-    sample_sequence: u64,
-    elapsed_ms: u64,
-    gate: GateOutcome,
-) -> RunTerminal {
-    RunTerminal::HardGate {
-        failure: HardGateFailure {
-            scenario_set: context.set,
-            scenario_id: context.scenario.id.clone(),
-            repetition: context.repetition,
-            seed: context.seed,
-            sample_sequence,
-            elapsed_ms,
-            gate,
-        },
-    }
+    let receipt = backend
+        .prepare_blocking(capability, &context.execution, context.scenario)
+        .map_err(|source| adapter_error(backend, "prepare", source))?;
+    validate_run_preparation_receipt(receipt, capability, context.run_intent_digest)
 }

--- a/tools/flight-tune/src/engine/evaluate/contract.rs
+++ b/tools/flight-tune/src/engine/evaluate/contract.rs
@@ -1,11 +1,14 @@
 use crate::journal::AttemptRole;
 use crate::{
     CandidateEvaluation, CandidateReceipt, Digest, GateEvaluator, Journal, MetricEvaluator,
-    MetricValues, OperationStatus, RunRecord, ScenarioRef, ScenarioSet, ScenarioStartReceipt,
-    SearchStage, SimulatorBackend, SimulatorCapability, TelemetrySample, TuneError,
+    MetricValues, OperationStatus, RunExecutionContext, RunPreparationReceipt, RunRecord,
+    ScenarioRef, ScenarioSet, ScenarioStartReceipt, SearchStage, SimulatorBackend,
+    SimulatorCapability, TelemetrySample, TuneError,
 };
 
 pub(super) struct RunContext<'a> {
+    pub(super) execution: RunExecutionContext,
+    pub(super) run_intent_digest: Digest,
     pub(super) set: ScenarioSet,
     pub(super) scenario: &'a ScenarioRef,
     pub(super) repetition: u32,
@@ -66,6 +69,7 @@ pub(super) fn validate_candidate_receipt(
     receipt: Result<CandidateReceipt, crate::AdapterError>,
     capability: &SimulatorCapability,
     expected: Digest,
+    expected_run_intent: Option<Digest>,
 ) -> Result<(), TuneError> {
     let receipt = receipt.map_err(|source| TuneError::Adapter {
         adapter: "bound simulator vehicle".to_owned(),
@@ -76,10 +80,27 @@ pub(super) fn validate_candidate_receipt(
         || receipt.requested_digest != expected
         || receipt.applied_digest != expected
         || receipt.readback_digest != expected
+        || receipt.run_intent_digest != expected_run_intent
     {
         return Err(TuneError::ReceiptMismatch {
             operation: "ensure candidate",
-            detail: "applied or readback candidate digest does not match".to_owned(),
+            detail: "candidate or run intent readback does not match".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_run_preparation_receipt(
+    receipt: RunPreparationReceipt,
+    capability: &SimulatorCapability,
+    expected_run_intent: Digest,
+) -> Result<(), TuneError> {
+    if receipt.session_digest != capability.session_digest()
+        || receipt.run_intent_digest != expected_run_intent
+    {
+        return Err(TuneError::ReceiptMismatch {
+            operation: "prepare run intent",
+            detail: "the prepared run intent does not match".to_owned(),
         });
     }
     Ok(())
@@ -93,10 +114,11 @@ pub(super) fn validate_scenario_receipt(
     if receipt.session_digest != capability.session_digest()
         || receipt.applied_scenario_digest != context.scenario.digest
         || receipt.seed != context.seed
+        || receipt.run_intent_digest != context.run_intent_digest
     {
         return Err(TuneError::ReceiptMismatch {
             operation: "start scenario",
-            detail: "applied scenario digest or seed does not match".to_owned(),
+            detail: "scenario, seed, or run intent readback does not match".to_owned(),
         });
     }
     Ok(())

--- a/tools/flight-tune/src/engine/evaluate/stream.rs
+++ b/tools/flight-tune/src/engine/evaluate/stream.rs
@@ -1,0 +1,263 @@
+use std::time::Duration;
+
+use crate::score::{validate_gate_outcomes, validate_metric};
+use crate::{
+    GateEvaluator, GateOutcome, HardGateFailure, Journal, MetricEvaluator, OperationStatus,
+    SampleEvent, SearchStage, SimulatorBackend, TelemetrySample, TuneError,
+};
+
+use super::contract::{RunContext, RunTerminal, adapter_error, evaluator_error, validate_sample};
+
+pub(super) fn stream_samples<B, G, M>(
+    journal: &Journal,
+    stage: &SearchStage,
+    context: &RunContext<'_>,
+    backend: &mut B,
+    gates: &mut G,
+    metric: &mut M,
+) -> RunTerminal
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    let timeout = Duration::from_millis(u64::from(context.scenario.sample_timeout_ms));
+    let mut position = StreamPosition::default();
+    loop {
+        if let Err(error) = journal.ensure_usable() {
+            return RunTerminal::Failed {
+                error,
+                started: true,
+            };
+        }
+        match backend.sample_blocking(timeout) {
+            Ok(SampleEvent::Sample(sample)) => {
+                if let Some(terminal) = process_sample(
+                    journal,
+                    stage,
+                    context,
+                    sample,
+                    &mut position,
+                    gates,
+                    metric,
+                ) {
+                    return terminal;
+                }
+            }
+            Ok(SampleEvent::Complete) => {
+                return finish_stream_blocking(
+                    journal,
+                    context,
+                    position.expected_sequence,
+                    backend,
+                    gates,
+                    metric,
+                );
+            }
+            Ok(SampleEvent::TimedOut) => {
+                return hard_failure(
+                    context,
+                    position.expected_sequence,
+                    position.elapsed_ms,
+                    GateOutcome::fail(
+                        "core.sample_timeout",
+                        "the simulator did not supply a sample before the timeout",
+                    ),
+                );
+            }
+            Err(source) => {
+                return RunTerminal::Failed {
+                    error: adapter_error(backend, "sample", source),
+                    started: true,
+                };
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct StreamPosition {
+    expected_sequence: u64,
+    elapsed_ms: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_sample<G, M>(
+    journal: &Journal,
+    stage: &SearchStage,
+    context: &RunContext<'_>,
+    sample: TelemetrySample,
+    position: &mut StreamPosition,
+    gates: &mut G,
+    metric: &mut M,
+) -> Option<RunTerminal>
+where
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    if position.expected_sequence >= u64::from(context.scenario.max_samples) {
+        return Some(hard_failure(
+            context,
+            sample.sequence,
+            sample.elapsed_ms,
+            GateOutcome::fail(
+                "core.sample_limit",
+                "the simulator exceeded the scenario sample limit",
+            ),
+        ));
+    }
+    if let Err(error) = validate_sample(&sample, position.expected_sequence, position.elapsed_ms) {
+        return Some(RunTerminal::Failed {
+            error,
+            started: true,
+        });
+    }
+    position.elapsed_ms = sample.elapsed_ms;
+    position.expected_sequence = position.expected_sequence.wrapping_add(1);
+    match evaluate_sample(journal, stage, &sample, gates, metric) {
+        Ok(Some(gate)) => Some(hard_failure(
+            context,
+            sample.sequence,
+            sample.elapsed_ms,
+            gate,
+        )),
+        Ok(None) => None,
+        Err(error) => Some(RunTerminal::Failed {
+            error,
+            started: true,
+        }),
+    }
+}
+
+fn finish_stream_blocking<B, G, M>(
+    journal: &Journal,
+    context: &RunContext<'_>,
+    sample_count: u64,
+    backend: &mut B,
+    gates: &mut G,
+    metric: &mut M,
+) -> RunTerminal
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    if sample_count == 0 {
+        return hard_failure(
+            context,
+            0,
+            0,
+            GateOutcome::fail(
+                "core.no_samples",
+                "the simulator completed without telemetry samples",
+            ),
+        );
+    }
+    finish_normal_run_blocking(journal, backend, gates, metric)
+}
+
+fn evaluate_sample<G, M>(
+    journal: &Journal,
+    stage: &SearchStage,
+    sample: &TelemetrySample,
+    gates: &mut G,
+    metric: &mut M,
+) -> Result<Option<GateOutcome>, TuneError>
+where
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    journal.ensure_usable()?;
+    let outcomes = gates
+        .evaluate(sample)
+        .map_err(|source| evaluator_error(gates.identity(), "evaluate hard gates", source))?;
+    if let Some(failure) = validate_gate_outcomes(&stage.required_hard_gates, &outcomes)? {
+        return Ok(Some(failure));
+    }
+    journal.ensure_usable()?;
+    metric
+        .observe(sample)
+        .map_err(|source| evaluator_error(metric.identity(), "observe metric", source))?;
+    Ok(None)
+}
+
+fn finish_normal_run_blocking<B, G, M>(
+    journal: &Journal,
+    backend: &mut B,
+    gates: &mut G,
+    metric: &mut M,
+) -> RunTerminal
+where
+    B: SimulatorBackend,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: true,
+        };
+    }
+    if let Err(source) = backend.stop_blocking() {
+        return RunTerminal::Failed {
+            error: adapter_error(backend, "stop", source),
+            started: true,
+        };
+    }
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
+    if let Err(source) = gates.finish() {
+        return RunTerminal::Failed {
+            error: evaluator_error(gates.identity(), "finish hard gates", source),
+            started: false,
+        };
+    }
+    if let Err(error) = journal.ensure_usable() {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
+    let values = match metric.finish() {
+        Ok(values) => values,
+        Err(source) => {
+            return RunTerminal::Failed {
+                error: evaluator_error(metric.identity(), "finish metric", source),
+                started: false,
+            };
+        }
+    };
+    if let Err(error) = validate_metric(&values) {
+        return RunTerminal::Failed {
+            error,
+            started: false,
+        };
+    }
+    RunTerminal::Passed {
+        values,
+        stop: OperationStatus::Succeeded,
+    }
+}
+
+fn hard_failure(
+    context: &RunContext<'_>,
+    sample_sequence: u64,
+    elapsed_ms: u64,
+    gate: GateOutcome,
+) -> RunTerminal {
+    RunTerminal::HardGate {
+        failure: HardGateFailure {
+            scenario_set: context.set,
+            scenario_id: context.scenario.id.clone(),
+            repetition: context.repetition,
+            seed: context.seed,
+            sample_sequence,
+            elapsed_ms,
+            gate,
+        },
+    }
+}

--- a/tools/flight-tune/src/engine/open.rs
+++ b/tools/flight-tune/src/engine/open.rs
@@ -6,7 +6,7 @@ use crate::{
     SimulatorVehicleFactory, TuneError,
 };
 
-use super::{Tuner, evaluate, session};
+use super::{Tuner, evaluate, session, transition};
 
 impl<B, V, G, M, P> Tuner<B, V, G, M, P>
 where
@@ -132,6 +132,7 @@ where
             })?;
         session::validate_vehicle_binding(&journal, &vehicle)?;
         evaluate::recover_pending_blocking(&mut journal, &mut backend, &mut gates, &mut metric)?;
+        transition::reauthorize_saved(&journal, &stage, &vehicle)?;
         let mut tuner = Self {
             stage,
             backend,

--- a/tools/flight-tune/src/engine/reconcile.rs
+++ b/tools/flight-tune/src/engine/reconcile.rs
@@ -24,7 +24,7 @@ where
         }
         let digest = self.settled_candidate_digest();
         let candidate = self.journal.read_candidate(digest)?;
-        evaluate::ensure_candidate_blocking(
+        evaluate::ensure_settled_candidate_blocking(
             &self.journal,
             &mut self.vehicle,
             &self.capability,

--- a/tools/flight-tune/src/engine/session.rs
+++ b/tools/flight-tune/src/engine/session.rs
@@ -22,6 +22,7 @@ where
         backend.simulator_identity(),
         backend.airframe_identity(),
         factory.vehicle_identity(),
+        factory.transition_validator_identity(),
         gates.identity(),
         metric.identity(),
         strategy.identity(),
@@ -31,6 +32,11 @@ where
                 detail: "a runtime component identity is incomplete".to_owned(),
             });
         }
+    }
+    if factory.adjacency_policy_digest().is_zero() {
+        return Err(TuneError::InvalidIdentity {
+            detail: "the vehicle adjacency-policy identity is incomplete".to_owned(),
+        });
     }
     Ok(())
 }
@@ -57,6 +63,8 @@ where
         simulator: backend.simulator_identity().clone(),
         airframe: backend.airframe_identity().clone(),
         vehicle: factory.vehicle_identity().clone(),
+        transition_validator: factory.transition_validator_identity().clone(),
+        adjacency_policy_digest: factory.adjacency_policy_digest(),
     }
 }
 
@@ -82,12 +90,22 @@ pub(super) fn validate_vehicle_binding<V>(
     vehicle: &VehicleBinding<V>,
 ) -> Result<(), TuneError> {
     let receipt = vehicle.receipt();
+    let transition = vehicle
+        .transition_receipt()
+        .ok_or_else(|| TuneError::ReceiptMismatch {
+            operation: "bind simulator vehicle",
+            detail: "the vehicle binding has no transition policy".to_owned(),
+        })?;
     if receipt.session_digest != journal.session_digest()?
         || receipt.vehicle_digest != journal.session().runtimes.vehicle.digest
+        || transition.session_digest() != receipt.session_digest
+        || transition.validator() != &journal.session().runtimes.transition_validator
+        || transition.adjacency_policy_digest()
+            != journal.session().runtimes.adjacency_policy_digest
     {
         return Err(TuneError::ReceiptMismatch {
             operation: "bind simulator vehicle",
-            detail: "vehicle session or build digest does not match".to_owned(),
+            detail: "vehicle session, build, or transition policy does not match".to_owned(),
         });
     }
     Ok(())

--- a/tools/flight-tune/src/engine/tests/journal_poison.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison.rs
@@ -1,5 +1,6 @@
 mod authorization;
 mod catalog;
+mod durable_publication;
 mod evidence;
 mod external_action;
 mod prospective_authorization;
@@ -61,7 +62,7 @@ fn an_ambiguous_preparation_poison_stops_all_external_action() {
 #[test]
 fn an_ambiguous_cleanup_poison_skips_candidate_reconciliation() {
     let directory = TestDirectory::new("cleanup-head-poison");
-    let faults = head_faults(4);
+    let faults = head_faults(6);
     let state = FakeHandle::new();
     let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
 
@@ -75,15 +76,15 @@ fn an_ambiguous_cleanup_poison_skips_candidate_reconciliation() {
         ActionSnapshot::new(&state, &proposals),
         completed_baseline_actions()
     );
-    assert_eq!(tuner.journal().entries().len(), 3);
+    assert_eq!(tuner.journal().entries().len(), 5);
     let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
     assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
     drop(tuner);
 
     let reopened = reopen_journal(&directory, state);
-    assert_eq!(reopened.entries().len(), 4);
+    assert_eq!(reopened.entries().len(), 6);
     assert!(matches!(
-        reopened.entries()[3].event,
+        reopened.entries()[5].event,
         JournalEvent::CleanupRecorded { .. }
     ));
     assert!(reopened.state().pending.is_none());
@@ -93,7 +94,7 @@ fn an_ambiguous_cleanup_poison_skips_candidate_reconciliation() {
 #[test]
 fn an_ambiguous_completion_poison_skips_cleanup_and_reconciliation() {
     let directory = TestDirectory::new("completed-head-poison");
-    let faults = head_faults(3);
+    let faults = head_faults(5);
     let state = FakeHandle::new();
     let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
 
@@ -107,15 +108,15 @@ fn an_ambiguous_completion_poison_skips_cleanup_and_reconciliation() {
         ActionSnapshot::new(&state, &proposals),
         completed_without_final_cleanup_actions()
     );
-    assert_eq!(tuner.journal().entries().len(), 2);
+    assert_eq!(tuner.journal().entries().len(), 4);
     let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
     assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
     drop(tuner);
 
     let reopened = reopen_journal(&directory, state);
-    assert_eq!(reopened.entries().len(), 3);
+    assert_eq!(reopened.entries().len(), 5);
     assert!(matches!(
-        reopened.entries()[2].event,
+        reopened.entries()[4].event,
         JournalEvent::AttemptCompleted { .. }
     ));
     let pending = reopened.state().pending.as_ref().expect("pending attempt");
@@ -125,10 +126,14 @@ fn an_ambiguous_completion_poison_skips_cleanup_and_reconciliation() {
 #[test]
 fn an_ambiguous_quarantine_preserves_the_primary_error() {
     let directory = TestDirectory::new("quarantine-head-poison");
-    let faults = head_faults(3);
+    let faults = head_faults(4);
     let state = FakeHandle::new();
     let (mut tuner, proposals) = open_with_faults(&directory, state.clone(), faults.clone());
-    state.0.borrow_mut().bad_candidate_readback_on_ensure = Some(2);
+    state
+        .0
+        .borrow_mut()
+        .vehicle
+        .bad_candidate_readback_on_ensure = Some(2);
 
     let error = tuner
         .run_training_attempts_blocking(0)
@@ -138,20 +143,20 @@ fn an_ambiguous_quarantine_preserves_the_primary_error() {
     assert!(faults.is_exhausted().expect("read fault state"));
     let actions = state.0.borrow();
     assert_eq!(actions.prepare_count, 1);
-    assert_eq!(actions.ensure_count, 2);
+    assert_eq!(actions.vehicle.ensure_count, 2);
     assert_eq!(actions.start_count, 0);
     assert_eq!(actions.stop_count, 0);
     assert_eq!(actions.cleanup_count, 0);
     drop(actions);
-    assert_eq!(tuner.journal().entries().len(), 2);
+    assert_eq!(tuner.journal().entries().len(), 3);
     let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
     assert_poisoned_operations(&mut tuner, &directory, &state, &proposals, &poisoned);
     drop(tuner);
 
     let reopened = reopen_journal(&directory, state);
-    assert_eq!(reopened.entries().len(), 3);
+    assert_eq!(reopened.entries().len(), 4);
     assert!(matches!(
-        reopened.entries()[2].event,
+        reopened.entries()[3].event,
         JournalEvent::AttemptQuarantined { .. }
     ));
 }

--- a/tools/flight-tune/src/engine/tests/journal_poison/authorization.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/authorization.rs
@@ -22,12 +22,12 @@ fn a_changed_head_stops_pending_outcome_recovery_before_external_action() {
     let directory = TestDirectory::new("pending-outcome-head-change");
     let state = FakeHandle::new();
     let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
-    state.0.borrow_mut().panic_on_cleanup = Some(2);
+    state.0.borrow_mut().cleanup_fault.panic_on(2);
     let stopped = catch_unwind(AssertUnwindSafe(|| {
         tuner.run_training_attempts_blocking(0).ok();
     }));
     assert!(stopped.is_err());
-    state.0.borrow_mut().panic_on_cleanup = None;
+    state.0.borrow_mut().cleanup_fault.clear();
     let pending = tuner
         .journal()
         .state()

--- a/tools/flight-tune/src/engine/tests/journal_poison/durable_publication.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/durable_publication.rs
@@ -1,0 +1,440 @@
+mod storage;
+
+use pilotage_durable_storage::{
+    DurabilityStep, FaultAction, FaultController, FaultRule, StorageError, StorageOperation,
+};
+
+use super::evidence::ActionSnapshot;
+use super::rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    candidate, stage,
+};
+use super::{
+    Journal, JournalEvent, TestDirectory, TestTuner, Tuner, assert_ambiguous, assert_poisoned,
+};
+use crate::{AttemptRole, Digest, JournalEntry, TuneError};
+use storage::{PublicationSnapshot, assert_head_matches, assert_publication_objects};
+
+#[derive(Clone, Copy)]
+enum PublicationFault {
+    BeforeRename,
+    AmbiguousAfterRename,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MutationCounts {
+    backend: [usize; 7],
+    vehicle: [usize; 3],
+    gates: [usize; 4],
+    metric: [usize; 4],
+}
+
+#[test]
+fn candidate_authorization_failure_leaves_an_inert_exact_entry() {
+    check_candidate_authorization_publication(PublicationFault::BeforeRename);
+}
+
+#[test]
+fn candidate_authorization_ambiguity_recovers_the_exact_entry() {
+    check_candidate_authorization_publication(PublicationFault::AmbiguousAfterRename);
+}
+
+#[test]
+fn run_preparation_failure_prevents_all_run_side_effects() {
+    check_run_preparation_publication(PublicationFault::BeforeRename);
+}
+
+#[test]
+fn run_preparation_ambiguity_prevents_all_run_side_effects() {
+    check_run_preparation_publication(PublicationFault::AmbiguousAfterRename);
+}
+
+fn check_candidate_authorization_publication(fault: PublicationFault) {
+    let directory = TestDirectory::new(&fault.label("candidate-authorization"));
+    let state = FakeHandle::new();
+    let mut tuner = open_tuner(&directory, state.clone(), vec![0.5]);
+    tuner
+        .run_training_attempts_blocking(0)
+        .expect("complete the training baseline");
+    let actions_before = MutationCounts::new(&state);
+    let proposals_before = tuner.strategy.views.borrow().len();
+    let authorizations_before = state.0.borrow().transition.authorization_count;
+    let publication_before = PublicationSnapshot::new(&directory);
+    let faults = fault.controller();
+    let mut tuner = reopen_tuner_with_faults(tuner, &directory, faults.clone());
+
+    let error = tuner
+        .run_one_training_challenger_blocking()
+        .expect_err("reject the authorization publication");
+
+    fault.assert_error(error);
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(MutationCounts::new(&state), actions_before);
+    assert_eq!(tuner.strategy.views.borrow().len(), proposals_before + 1);
+    assert_eq!(
+        state.0.borrow().transition.authorization_count,
+        authorizations_before + 1
+    );
+    let target = crate::engine::evaluate::candidate_digest(&candidate(0.5))
+        .expect("digest target candidate");
+    let publication_after = PublicationSnapshot::new(&directory);
+    let orphan = assert_publication_objects(
+        &directory,
+        &publication_before,
+        &publication_after,
+        Some(target),
+    );
+    let source = crate::engine::evaluate::candidate_digest(&candidate(0.0))
+        .expect("digest source candidate");
+    assert_authorization_entry(&orphan, source, target);
+    assert_eq!(authorization_count(tuner.journal()), 0);
+    let poisoned_actions = MutationCounts::new(&state);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_eq!(MutationCounts::new(&state), poisoned_actions);
+    finish_candidate_recovery(
+        fault,
+        tuner,
+        &directory,
+        source,
+        target,
+        &publication_before,
+    );
+}
+
+fn check_run_preparation_publication(fault: PublicationFault) {
+    let directory = TestDirectory::new(&fault.label("run-preparation"));
+    let state = FakeHandle::new();
+    let mut tuner = open_tuner(&directory, state.clone(), Vec::new());
+    let initial = candidate(0.0);
+    let digest = crate::engine::evaluate::candidate_digest(&initial).expect("digest candidate");
+    let plan = AttemptRole::TrainingBaseline
+        .plan_digest(&tuner.stage, digest, tuner.journal.session().fixed_seed)
+        .expect("create run plan");
+    let (trial_id, stored) = tuner
+        .journal
+        .prepare_attempt(AttemptRole::TrainingBaseline, &initial, plan, None)
+        .expect("prepare the attempt");
+    assert_eq!(stored, digest);
+    let actions_before = ActionSnapshot::new(&state, &tuner.strategy.views);
+    let contexts_before = transition_context_counts(&state);
+    let publication_before = PublicationSnapshot::new(&directory);
+    let faults = fault.controller();
+    let mut tuner = reopen_tuner_with_faults(tuner, &directory, faults.clone());
+
+    let error = run_prepared_baseline(&mut tuner, trial_id, &initial, digest)
+        .expect_err("reject the run preparation publication");
+
+    fault.assert_error(error);
+    assert!(faults.is_exhausted().expect("read fault state"));
+    assert_eq!(
+        ActionSnapshot::new(&state, &tuner.strategy.views),
+        actions_before
+    );
+    assert_eq!(transition_context_counts(&state), contexts_before);
+    let publication_after = PublicationSnapshot::new(&directory);
+    let orphan =
+        assert_publication_objects(&directory, &publication_before, &publication_after, None);
+    assert_run_prepared_entry(&orphan, trial_id, digest);
+    assert_eq!(run_prepared_count(tuner.journal()), 0);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_eq!(
+        ActionSnapshot::new(&state, &tuner.strategy.views),
+        actions_before
+    );
+    finish_run_recovery(
+        fault,
+        tuner,
+        &directory,
+        trial_id,
+        digest,
+        &publication_before,
+    );
+}
+
+fn run_prepared_baseline(
+    tuner: &mut TestTuner,
+    trial_id: u64,
+    initial: &crate::Candidate,
+    digest: Digest,
+) -> Result<(), TuneError> {
+    crate::engine::evaluate::run_prepared_blocking(
+        &mut tuner.journal,
+        &tuner.stage,
+        trial_id,
+        AttemptRole::TrainingBaseline,
+        initial,
+        digest,
+        None,
+        &mut tuner.backend,
+        &mut tuner.vehicle,
+        &tuner.capability,
+        &mut tuner.gates,
+        &mut tuner.metric,
+    )
+}
+
+fn open_tuner(directory: &TestDirectory, state: FakeHandle, values: Vec<f64>) -> TestTuner {
+    Tuner::open_or_resume(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        SequenceStrategy::new(values),
+    )
+    .expect("open tuner")
+}
+
+fn reopen_tuner_with_faults(
+    tuner: TestTuner,
+    directory: &TestDirectory,
+    faults: FaultController,
+) -> TestTuner {
+    let Tuner {
+        stage,
+        backend,
+        vehicle,
+        capability,
+        gates,
+        metric,
+        strategy,
+        journal,
+    } = tuner;
+    let runtimes = journal.session().runtimes.clone();
+    let fixed_seed = journal.session().fixed_seed;
+    let initial_digest = journal.session().initial_candidate_digest;
+    let initial = journal
+        .read_candidate(initial_digest)
+        .expect("read initial candidate");
+    drop(journal);
+    let journal = Journal::open_or_create_with_faults(
+        directory.path(),
+        &stage,
+        fixed_seed,
+        runtimes,
+        &initial,
+        faults,
+    )
+    .expect("reopen journal with a publication fault");
+    Tuner {
+        stage,
+        backend,
+        vehicle,
+        capability,
+        gates,
+        metric,
+        strategy,
+        journal,
+    }
+}
+
+fn finish_candidate_recovery(
+    fault: PublicationFault,
+    tuner: TestTuner,
+    directory: &TestDirectory,
+    source: Digest,
+    target: Digest,
+    before: &PublicationSnapshot,
+) {
+    let journal = reopen_durable_journal(tuner, directory);
+    match fault {
+        PublicationFault::BeforeRename => {
+            assert_eq!(authorization_count(&journal), 0);
+            assert_eq!(PublicationSnapshot::new(directory).head, before.head);
+        }
+        PublicationFault::AmbiguousAfterRename => {
+            assert_eq!(authorization_count(&journal), 1);
+            let entry = journal.entries().last().expect("authorization entry");
+            assert_authorization_entry(entry, source, target);
+            assert_head_matches(directory, entry);
+        }
+    }
+}
+
+fn finish_run_recovery(
+    fault: PublicationFault,
+    tuner: TestTuner,
+    directory: &TestDirectory,
+    trial_id: u64,
+    candidate_digest: Digest,
+    before: &PublicationSnapshot,
+) {
+    let journal = reopen_durable_journal(tuner, directory);
+    match fault {
+        PublicationFault::BeforeRename => {
+            assert_eq!(run_prepared_count(&journal), 0);
+            assert_eq!(PublicationSnapshot::new(directory).head, before.head);
+        }
+        PublicationFault::AmbiguousAfterRename => {
+            assert_eq!(run_prepared_count(&journal), 1);
+            let entry = journal.entries().last().expect("run preparation entry");
+            assert_run_prepared_entry(entry, trial_id, candidate_digest);
+            assert_head_matches(directory, entry);
+        }
+    }
+}
+
+fn reopen_durable_journal(tuner: TestTuner, directory: &TestDirectory) -> Journal {
+    let runtimes = tuner.journal.session().runtimes.clone();
+    let fixed_seed = tuner.journal.session().fixed_seed;
+    let campaign_stage = tuner.stage.clone();
+    let initial = candidate(0.0);
+    drop(tuner);
+    Journal::open_or_create(
+        directory.path(),
+        &campaign_stage,
+        fixed_seed,
+        runtimes,
+        &initial,
+    )
+    .expect("reopen durable journal")
+}
+
+impl MutationCounts {
+    fn new(state: &FakeHandle) -> Self {
+        let state = state.0.borrow();
+        Self {
+            backend: [
+                state.open_session_count,
+                state.prepare_count,
+                state.start_count,
+                state.sample_poll_count,
+                state.sample_count,
+                state.stop_count,
+                state.cleanup_count,
+            ],
+            vehicle: [
+                state.vehicle.bind_count,
+                state.vehicle.ensure_count,
+                state.vehicle.apply_count,
+            ],
+            gates: [
+                state.gate_begin_count,
+                state.gate_evaluate_count,
+                state.gate_finish_count,
+                state.gate_cancel_count,
+            ],
+            metric: [
+                state.metric_begin_count,
+                state.metric_observe_count,
+                state.metric_finish_count,
+                state.metric_cancel_count,
+            ],
+        }
+    }
+}
+
+impl PublicationFault {
+    fn label(self, event: &str) -> String {
+        let mode = match self {
+            Self::BeforeRename => "failure",
+            Self::AmbiguousAfterRename => "ambiguity",
+        };
+        format!("{event}-{mode}")
+    }
+
+    fn controller(self) -> FaultController {
+        match self {
+            Self::BeforeRename => FaultController::new([FaultRule::once(
+                StorageOperation::CompareExchange,
+                DurabilityStep::AuthorizationRename,
+                FaultAction::FailBefore,
+            )]),
+            Self::AmbiguousAfterRename => FaultController::new([
+                FaultRule::once(
+                    StorageOperation::CompareExchange,
+                    DurabilityStep::ParentDirectory,
+                    FaultAction::LoseAckAfter,
+                ),
+                FaultRule::once(
+                    StorageOperation::CompareExchange,
+                    DurabilityStep::RecoveryBarrier,
+                    FaultAction::LoseAckAfter,
+                ),
+            ]),
+        }
+    }
+
+    fn assert_error(self, error: TuneError) {
+        match self {
+            Self::BeforeRename => assert!(matches!(
+                error,
+                TuneError::Storage { source }
+                    if matches!(source.as_ref(), StorageError::InjectedFault { context }
+                        if context.operation == StorageOperation::CompareExchange
+                            && context.step == DurabilityStep::AuthorizationRename)
+            )),
+            Self::AmbiguousAfterRename => assert_ambiguous(error),
+        }
+    }
+}
+
+fn transition_context_counts(state: &FakeHandle) -> [usize; 3] {
+    let state = state.0.borrow();
+    [
+        state.transition.prepared_contexts.len(),
+        state.transition.started_contexts.len(),
+        state.transition.vehicle_contexts.len(),
+    ]
+}
+
+fn authorization_count(journal: &Journal) -> usize {
+    journal
+        .entries()
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry.event,
+                JournalEvent::CandidateTransitionAuthorized { .. }
+            )
+        })
+        .count()
+}
+
+fn run_prepared_count(journal: &Journal) -> usize {
+    journal
+        .entries()
+        .iter()
+        .filter(|entry| matches!(entry.event, JournalEvent::RunPrepared { .. }))
+        .count()
+}
+
+fn assert_authorization_entry(entry: &JournalEntry, source: Digest, target: Digest) {
+    let JournalEvent::CandidateTransitionAuthorized {
+        candidate, receipt, ..
+    } = &entry.event
+    else {
+        panic!("expected a candidate transition authorization");
+    };
+    assert_eq!(*candidate, target);
+    assert_eq!(receipt.source_candidate_digest(), source);
+    assert_eq!(receipt.target_candidate_digest(), target);
+    let reference = receipt.reference();
+    assert_eq!(reference.source_candidate_digest(), source);
+    assert_eq!(reference.target_candidate_digest(), target);
+    assert!(reference.is_valid_for_target(target));
+}
+
+fn assert_run_prepared_entry(entry: &JournalEntry, trial_id: u64, candidate_digest: Digest) {
+    let JournalEvent::RunPrepared {
+        trial_id: saved_trial,
+        context,
+        run_intent_digest,
+        ..
+    } = &entry.event
+    else {
+        panic!("expected a run preparation");
+    };
+    assert_eq!(*saved_trial, trial_id);
+    assert_eq!(context.trial_id(), trial_id);
+    assert_eq!(context.role(), AttemptRole::TrainingBaseline);
+    assert_eq!(context.candidate_digest(), candidate_digest);
+    assert_eq!(context.transition_authorization(), None);
+    assert_eq!(
+        *run_intent_digest,
+        context.digest().expect("digest run context")
+    );
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/durable_publication/storage.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/durable_publication/storage.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+
+use super::super::TestDirectory;
+use crate::{Digest, JournalEntry};
+
+#[derive(Debug)]
+pub(super) struct PublicationSnapshot {
+    pub(super) head: Vec<u8>,
+    entries: BTreeSet<OsString>,
+    candidates: BTreeSet<OsString>,
+    stages: BTreeSet<OsString>,
+    temporary_count: usize,
+}
+
+impl PublicationSnapshot {
+    pub(super) fn new(directory: &TestDirectory) -> Self {
+        Self {
+            head: fs::read(directory.path().join("HEAD.json")).expect("read journal head"),
+            entries: names(directory.path().join("entries")),
+            candidates: names(directory.path().join("candidates")),
+            stages: names(directory.path().join("stages")),
+            temporary_count: temporary_count(directory.path()),
+        }
+    }
+}
+
+pub(super) fn assert_publication_objects(
+    directory: &TestDirectory,
+    before: &PublicationSnapshot,
+    after: &PublicationSnapshot,
+    candidate: Option<Digest>,
+) -> JournalEntry {
+    assert_eq!(after.entries.len(), before.entries.len() + 1);
+    assert_eq!(
+        after.candidates.len(),
+        before.candidates.len() + usize::from(candidate.is_some())
+    );
+    assert_eq!(after.stages, before.stages);
+    assert_eq!(before.temporary_count, 0);
+    assert_eq!(after.temporary_count, 0);
+    let entry_name = single_new_name(&before.entries, &after.entries);
+    let entry = read_content_addressed(
+        directory.path().join("entries").join(&entry_name),
+        &entry_name,
+    );
+    if let Some(expected) = candidate {
+        let candidate_name = single_new_name(&before.candidates, &after.candidates);
+        let digest = content_addressed_digest(
+            directory.path().join("candidates").join(&candidate_name),
+            &candidate_name,
+        );
+        assert_eq!(digest, expected);
+    }
+    entry
+}
+
+pub(super) fn assert_head_matches(directory: &TestDirectory, entry: &JournalEntry) {
+    let expected =
+        crate::identity::digest_bytes(&serde_json::to_vec(entry).expect("encode journal entry"));
+    let head: serde_json::Value = serde_json::from_slice(
+        &fs::read(directory.path().join("HEAD.json")).expect("read journal head"),
+    )
+    .expect("decode journal head");
+    assert_eq!(
+        head.get("digest"),
+        Some(&serde_json::to_value(expected).expect("encode digest"))
+    );
+}
+
+fn read_content_addressed(path: impl AsRef<Path>, name: &OsString) -> JournalEntry {
+    let bytes = fs::read(path).expect("read new journal entry");
+    assert_content_addressed_name(name, &bytes);
+    serde_json::from_slice(&bytes).expect("decode new journal entry")
+}
+
+fn content_addressed_digest(path: impl AsRef<Path>, name: &OsString) -> crate::Digest {
+    let bytes = fs::read(path).expect("read new candidate");
+    assert_content_addressed_name(name, &bytes)
+}
+
+fn assert_content_addressed_name(name: &OsString, bytes: &[u8]) -> crate::Digest {
+    let digest = crate::identity::digest_bytes(bytes);
+    assert_eq!(name, &OsString::from(format!("{digest}.json")));
+    digest
+}
+
+fn single_new_name(before: &BTreeSet<OsString>, after: &BTreeSet<OsString>) -> OsString {
+    let names = after.difference(before).cloned().collect::<Vec<_>>();
+    assert_eq!(names.len(), 1);
+    names[0].clone()
+}
+
+fn names(path: impl AsRef<Path>) -> BTreeSet<OsString> {
+    fs::read_dir(path)
+        .expect("read object directory")
+        .map(|entry| entry.expect("read object entry").file_name())
+        .collect()
+}
+
+fn temporary_count(path: &Path) -> usize {
+    fs::read_dir(path)
+        .expect("read durable directory")
+        .map(|entry| entry.expect("read durable entry"))
+        .map(|entry| {
+            let own = usize::from(
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(".pilotage-tmp-")),
+            );
+            own + temporary_count_if_directory(&entry.path())
+        })
+        .sum()
+}
+
+fn temporary_count_if_directory(path: &Path) -> usize {
+    if path.is_dir() {
+        temporary_count(path)
+    } else {
+        0
+    }
+}

--- a/tools/flight-tune/src/engine/tests/journal_poison/evidence.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/evidence.rs
@@ -120,7 +120,11 @@ impl ActionSnapshot {
                 state.stop_count,
                 state.cleanup_count,
             ],
-            vehicle: [state.bind_count, state.ensure_count, state.apply_count],
+            vehicle: [
+                state.vehicle.bind_count,
+                state.vehicle.ensure_count,
+                state.vehicle.apply_count,
+            ],
             gates: [
                 state.gate_begin_count,
                 state.gate_evaluate_count,

--- a/tools/flight-tune/src/engine/tests/journal_poison/external_action.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/external_action.rs
@@ -70,7 +70,7 @@ fn action_counts(state: &FakeHandle) -> ActionCounts {
     let state = state.0.borrow();
     ActionCounts {
         prepare: state.prepare_count,
-        ensure: state.ensure_count,
+        ensure: state.vehicle.ensure_count,
         gate_begin: state.gate_begin_count,
         metric_begin: state.metric_begin_count,
         start: state.start_count,

--- a/tools/flight-tune/src/engine/tests/journal_poison/prospective_authorization.rs
+++ b/tools/flight-tune/src/engine/tests/journal_poison/prospective_authorization.rs
@@ -36,6 +36,7 @@ fn a_missing_head_entry_before_cas_keeps_the_old_head_and_poisons() {
             AttemptRole::TrainingBaseline,
             &initial,
             plan,
+            None,
             || {
                 assert_eq!(root_temporary_count(&directory), 1);
                 fs::remove_file(&started_path).expect("remove current head entry");
@@ -67,7 +68,7 @@ fn a_missing_pending_candidate_before_cas_keeps_the_old_head_and_poisons() {
         .expect("create run plan");
     let (trial_id, prepared_candidate) = tuner
         .journal
-        .prepare_attempt(AttemptRole::TrainingBaseline, &initial, plan)
+        .prepare_attempt(AttemptRole::TrainingBaseline, &initial, plan, None)
         .expect("prepare pending attempt");
     let candidate_path = directory
         .path()

--- a/tools/flight-tune/src/engine/transition.rs
+++ b/tools/flight-tune/src/engine/transition.rs
@@ -1,0 +1,126 @@
+use crate::{
+    AttemptRole, Candidate, CandidateTransitionReceipt, CandidateTransitionReference,
+    CandidateTransitionRequest, Digest, Journal, JournalEvent, SearchStage,
+    SimulatorVehicleAdapter, TuneError, VehicleBinding,
+};
+
+pub(super) fn authorize_new<V>(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    vehicle: &VehicleBinding<V>,
+    source: &Candidate,
+    target: &Candidate,
+    attempt_index: u64,
+    reason: &str,
+) -> Result<CandidateTransitionReference, TuneError>
+where
+    V: SimulatorVehicleAdapter,
+{
+    let source_digest = super::evaluate::candidate_digest(source)?;
+    let target_digest = super::evaluate::candidate_digest(target)?;
+    let request = transition_request(
+        journal,
+        stage,
+        source,
+        source_digest,
+        target,
+        target_digest,
+        attempt_index,
+    )?;
+    journal.ensure_usable()?;
+    let receipt = authorize_with_vehicle(journal, vehicle, &request)?;
+    journal.ensure_usable()?;
+    journal.authorize_training_transition(attempt_index, reason, target, receipt)
+}
+
+pub(super) fn reauthorize_saved<V>(
+    journal: &Journal,
+    stage: &SearchStage,
+    vehicle: &VehicleBinding<V>,
+) -> Result<(), TuneError>
+where
+    V: SimulatorVehicleAdapter,
+{
+    let authorizations = saved_authorizations(journal);
+    for (attempt_index, receipt) in authorizations {
+        journal.ensure_usable()?;
+        let source = journal.read_candidate(receipt.source_candidate_digest())?;
+        let target = journal.read_candidate(receipt.target_candidate_digest())?;
+        let request = transition_request(
+            journal,
+            stage,
+            &source,
+            receipt.source_candidate_digest(),
+            &target,
+            receipt.target_candidate_digest(),
+            attempt_index,
+        )?;
+        receipt.validate_for(&request)?;
+        let observed = authorize_with_vehicle(journal, vehicle, &request)?;
+        if observed != receipt {
+            return Err(TuneError::ReceiptMismatch {
+                operation: "reauthorize candidate transition",
+                detail: "the vehicle did not reproduce the saved authorization".to_owned(),
+            });
+        }
+    }
+    journal.ensure_usable()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn transition_request(
+    journal: &Journal,
+    stage: &SearchStage,
+    source: &Candidate,
+    source_digest: Digest,
+    target: &Candidate,
+    target_digest: Digest,
+    attempt_index: u64,
+) -> Result<CandidateTransitionRequest, TuneError> {
+    let role = AttemptRole::TrainingChallenger { attempt_index };
+    let plan_digest = role.plan_digest(stage, target_digest, journal.session().fixed_seed)?;
+    let planning_context =
+        crate::adapter::planning_context_digest(journal.session().stage_digest, plan_digest)?;
+    CandidateTransitionRequest::new(
+        journal.session_digest()?,
+        source,
+        source_digest,
+        target,
+        target_digest,
+        journal.session().runtimes.transition_validator.clone(),
+        journal.session().runtimes.adjacency_policy_digest,
+        planning_context,
+    )
+}
+
+fn authorize_with_vehicle<V>(
+    journal: &Journal,
+    vehicle: &VehicleBinding<V>,
+    request: &CandidateTransitionRequest,
+) -> Result<CandidateTransitionReceipt, TuneError>
+where
+    V: SimulatorVehicleAdapter,
+{
+    vehicle
+        .authorize_candidate_transition(request)
+        .map_err(|source| TuneError::Adapter {
+            adapter: journal.session().runtimes.transition_validator.id.clone(),
+            operation: "authorize candidate transition",
+            source,
+        })
+}
+
+fn saved_authorizations(journal: &Journal) -> Vec<(u64, CandidateTransitionReceipt)> {
+    journal
+        .entries()
+        .iter()
+        .filter_map(|entry| match &entry.event {
+            JournalEvent::CandidateTransitionAuthorized {
+                attempt_index,
+                receipt,
+                ..
+            } => Some((*attempt_index, receipt.clone())),
+            _ => None,
+        })
+        .collect()
+}

--- a/tools/flight-tune/src/identity.rs
+++ b/tools/flight-tune/src/identity.rs
@@ -98,6 +98,10 @@ pub struct RuntimeIdentities {
     pub airframe: ArtifactIdentity,
     /// The vehicle controller build and adapter configuration.
     pub vehicle: ArtifactIdentity,
+    /// The candidate-transition validator and its exact configuration.
+    pub transition_validator: ArtifactIdentity,
+    /// The exact vehicle adjacency-policy digest.
+    pub adjacency_policy_digest: Digest,
 }
 
 impl RuntimeIdentities {
@@ -110,8 +114,14 @@ impl RuntimeIdentities {
             &self.simulator,
             &self.airframe,
             &self.vehicle,
+            &self.transition_validator,
         ] {
             identity.validate()?;
+        }
+        if self.adjacency_policy_digest.is_zero() {
+            return Err(TuneError::InvalidIdentity {
+                detail: "the vehicle adjacency-policy digest is zero".to_owned(),
+            });
         }
         Ok(())
     }

--- a/tools/flight-tune/src/journal.rs
+++ b/tools/flight-tune/src/journal.rs
@@ -3,6 +3,7 @@
 mod event;
 mod replay;
 mod storage;
+mod transition;
 
 pub use event::{
     AttemptRole, CampaignPhase, FinalQualificationOutcome, JournalEvent, OperationStatus,
@@ -16,12 +17,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::identity::harness_build_identity;
 use crate::{
-    Candidate, CandidateEvaluation, CandidateLineage, Digest, RuntimeIdentities, SearchStage,
-    TrainingObservation, TuneError,
+    Candidate, CandidateEvaluation, CandidateLineage, CandidateTransitionReference, Digest,
+    RuntimeIdentities, SearchStage, TrainingObservation, TuneError,
 };
 use replay::{JournalState, replay};
 
-const JOURNAL_SCHEMA_VERSION: u32 = 2;
+const JOURNAL_SCHEMA_VERSION: u32 = 3;
 
 /// The immutable identity of one tuning session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -251,8 +252,9 @@ impl Journal {
         role: AttemptRole,
         candidate: &Candidate,
         plan_digest: Digest,
+        transition: Option<CandidateTransitionReference>,
     ) -> Result<(u64, Digest), TuneError> {
-        self.prepare_attempt_with_hook(role, candidate, plan_digest, || {})
+        self.prepare_attempt_with_hook(role, candidate, plan_digest, transition, || {})
     }
 
     #[cfg(test)]
@@ -261,9 +263,16 @@ impl Journal {
         role: AttemptRole,
         candidate: &Candidate,
         plan_digest: Digest,
+        transition: Option<CandidateTransitionReference>,
         before_authorization: impl FnOnce(),
     ) -> Result<(u64, Digest), TuneError> {
-        self.prepare_attempt_with_hook(role, candidate, plan_digest, before_authorization)
+        self.prepare_attempt_with_hook(
+            role,
+            candidate,
+            plan_digest,
+            transition,
+            before_authorization,
+        )
     }
 
     fn prepare_attempt_with_hook(
@@ -271,6 +280,7 @@ impl Journal {
         role: AttemptRole,
         candidate: &Candidate,
         plan_digest: Digest,
+        transition: Option<CandidateTransitionReference>,
         before_authorization: impl FnOnce(),
     ) -> Result<(u64, Digest), TuneError> {
         self.ensure_usable()?;
@@ -287,6 +297,7 @@ impl Journal {
                 role,
                 candidate: candidate_digest,
                 plan_digest,
+                transition,
             },
             before_authorization,
         )?;

--- a/tools/flight-tune/src/journal/event.rs
+++ b/tools/flight-tune/src/journal/event.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::identity::digest_bytes;
-use crate::{CandidateEvaluation, Digest, ScenarioRef, ScenarioSet, SearchStage, TuneError};
+use crate::{
+    CandidateEvaluation, CandidateTransitionReceipt, CandidateTransitionReference, Digest,
+    RunExecutionContext, ScenarioRef, ScenarioSet, SearchStage, TuneError,
+};
 
 #[derive(Serialize)]
 struct RunPlan<'a> {
@@ -175,6 +178,17 @@ pub enum JournalEvent {
         /// The initial candidate digest.
         candidate: Digest,
     },
+    /// One vehicle validator authorized an exact training transition.
+    CandidateTransitionAuthorized {
+        /// The zero-based challenger index.
+        attempt_index: u64,
+        /// The stable proposal reason.
+        reason: String,
+        /// The immutable target candidate digest.
+        candidate: Digest,
+        /// The complete vehicle authorization receipt.
+        receipt: CandidateTransitionReceipt,
+    },
     /// One complete evaluation was durable before simulator mutation.
     AttemptPrepared {
         /// The monotonic trial identity.
@@ -185,6 +199,19 @@ pub enum JournalEvent {
         candidate: Digest,
         /// The digest of the complete ordered run plan.
         plan_digest: Digest,
+        /// The exact training transition authorization, if this is a challenger.
+        transition: Option<CandidateTransitionReference>,
+    },
+    /// One exact run identity became durable before external mutation.
+    RunPrepared {
+        /// The campaign trial identity.
+        trial_id: u64,
+        /// The zero-based run index in the attempt plan.
+        run_index: u64,
+        /// The complete simulator-neutral run identity.
+        context: RunExecutionContext,
+        /// The canonical digest of the run identity.
+        run_intent_digest: Digest,
     },
     /// One evaluation produced a score or hard gate result.
     AttemptCompleted {

--- a/tools/flight-tune/src/journal/replay.rs
+++ b/tools/flight-tune/src/journal/replay.rs
@@ -1,16 +1,26 @@
 use crate::journal::{
     AttemptRole, CampaignPhase, FinalQualificationOutcome, JOURNAL_SCHEMA_VERSION, JournalEntry,
-    JournalEvent, OperationStatus, PromotionDecision,
+    JournalEvent, OperationStatus, PromotionDecision, SessionIdentity,
 };
-use crate::{CandidateEvaluation, Digest, SearchStage, TrainingObservation, TuneError};
+use crate::{
+    CandidateEvaluation, CandidateTransitionReference, Digest, SearchStage, TrainingObservation,
+    TuneError,
+};
 
 mod plan;
+mod run;
+pub(crate) mod transition;
+
+use super::transition::AuthorizedTrainingTransition;
+use run::PreparedRun;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PendingAttempt {
     pub(crate) trial_id: u64,
     pub(crate) role: AttemptRole,
     pub(crate) candidate: Digest,
+    pub(crate) transition: Option<CandidateTransitionReference>,
+    pub(crate) prepared_runs: Vec<PreparedRun>,
     pub(crate) outcome: Option<PendingOutcome>,
 }
 
@@ -29,6 +39,7 @@ pub(crate) struct JournalState {
     pub(crate) training_attempt_count: u64,
     pub(crate) training_history: Vec<TrainingObservation>,
     pub(crate) next_trial_id: u64,
+    pub(crate) authorized_transition: Option<AuthorizedTrainingTransition>,
     pub(crate) pending: Option<PendingAttempt>,
     pub(crate) frozen_candidate: Option<Digest>,
     pub(crate) promotion_baseline: Option<CandidateEvaluation>,
@@ -39,14 +50,6 @@ pub(crate) struct JournalState {
 }
 
 impl JournalState {
-    pub(crate) fn pending_role(&self, trial_id: u64) -> Result<AttemptRole, TuneError> {
-        self.pending
-            .as_ref()
-            .filter(|pending| pending.trial_id == trial_id && pending.outcome.is_none())
-            .map(|pending| pending.role)
-            .ok_or_else(|| invalid("the trial is not pending or already has an outcome"))
-    }
-
     pub(crate) fn selected_release_candidate(&self, initial: Digest) -> Digest {
         if self
             .promotion_decision
@@ -87,13 +90,7 @@ pub(super) fn replay(
             Some(entry_digests[index - 1]),
             &first.session,
         )?;
-        apply_event(
-            &mut state,
-            &entry.event,
-            stage,
-            candidate,
-            first.session.fixed_seed,
-        )?;
+        apply_event(&mut state, &entry.event, stage, &first.session)?;
     }
     Ok(state)
 }
@@ -107,6 +104,7 @@ fn initial_state(candidate: Digest) -> JournalState {
         training_attempt_count: 0,
         training_history: Vec::new(),
         next_trial_id: 0,
+        authorized_transition: None,
         pending: None,
         frozen_candidate: None,
         promotion_baseline: None,
@@ -140,26 +138,42 @@ fn apply_event(
     state: &mut JournalState,
     event: &JournalEvent,
     stage: &SearchStage,
-    initial: Digest,
-    fixed_seed: u64,
+    session: &SessionIdentity,
 ) -> Result<(), TuneError> {
+    let initial = session.initial_candidate_digest;
+    let fixed_seed = session.fixed_seed;
+    if state.authorized_transition.is_some()
+        && !matches!(event, JournalEvent::AttemptPrepared { .. })
+    {
+        return Err(invalid(
+            "a transition authorization must be followed by its attempt",
+        ));
+    }
     match event {
         JournalEvent::Started { .. } => Err(invalid("the journal has two start events")),
+        event @ JournalEvent::CandidateTransitionAuthorized { .. } => {
+            transition::authorize_event(state, event, stage, session)
+        }
         JournalEvent::AttemptPrepared {
             trial_id,
             role,
             candidate,
             plan_digest,
+            transition,
         } => prepare(
             state,
             *trial_id,
             *role,
             *candidate,
             *plan_digest,
+            transition.as_ref(),
             stage,
             initial,
             fixed_seed,
         ),
+        event @ JournalEvent::RunPrepared { .. } => {
+            run::prepare_event(state, event, stage, session)
+        }
         JournalEvent::AttemptCompleted {
             trial_id,
             evaluation,
@@ -198,6 +212,7 @@ fn prepare(
     role: AttemptRole,
     candidate: Digest,
     plan_digest: Digest,
+    transition_reference: Option<&CandidateTransitionReference>,
     stage: &SearchStage,
     initial: Digest,
     fixed_seed: u64,
@@ -213,12 +228,16 @@ fn prepare(
             "an attempt preparation has invalid state or identity",
         ));
     }
+    transition::validate_attempt(state, role, candidate, transition_reference)?;
     state.pending = Some(PendingAttempt {
         trial_id,
         role,
         candidate,
+        transition: transition_reference.cloned(),
+        prepared_runs: Vec::new(),
         outcome: None,
     });
+    state.authorized_transition = None;
     state.next_trial_id = state.next_trial_id.wrapping_add(1);
     Ok(())
 }
@@ -237,7 +256,7 @@ fn role_allowed(
         }
         AttemptRole::TrainingChallenger { attempt_index } => {
             state.phase == CampaignPhase::Searching
-                && state.training_baseline.is_some()
+                && has_passed_training_baseline_and_incumbent(state)
                 && attempt_index == state.training_attempt_count
         }
         AttemptRole::PromotionBaseline => {
@@ -259,6 +278,16 @@ fn role_allowed(
     }
 }
 
+fn has_passed_training_baseline_and_incumbent(state: &JournalState) -> bool {
+    matches!(
+        &state.training_baseline,
+        Some(CandidateEvaluation::Passed { .. })
+    ) && matches!(
+        &state.training_incumbent_evaluation,
+        Some(CandidateEvaluation::Passed { .. })
+    )
+}
+
 fn complete(
     state: &mut JournalState,
     trial_id: u64,
@@ -274,6 +303,11 @@ fn complete(
         .map(|pending| pending.role)
         .ok_or_else(|| invalid("the attempt is not pending or already has an outcome"))?;
     plan::validate_evaluation(evaluation, role, stage, fixed_seed)?;
+    let pending = state
+        .pending
+        .as_ref()
+        .ok_or_else(|| invalid("the attempt lost its run preparation"))?;
+    run::validate_outcome(pending, evaluation)?;
     validate_training_selection(state, role, evaluation, selected)?;
     let pending = pending_without_outcome(state, trial_id)?;
     pending.outcome = Some(PendingOutcome {

--- a/tools/flight-tune/src/journal/replay/run.rs
+++ b/tools/flight-tune/src/journal/replay/run.rs
@@ -1,0 +1,159 @@
+use crate::journal::replay::{JournalState, PendingAttempt, invalid};
+use crate::journal::{JournalEvent, SessionIdentity};
+use crate::model::derive_seed;
+use crate::{
+    CandidateEvaluation, Digest, RunExecutionContext, ScenarioRef, ScenarioSet, SearchStage,
+    TuneError,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedRun {
+    pub(super) run_index: u64,
+    pub(super) context: RunExecutionContext,
+    pub(super) run_intent_digest: Digest,
+}
+
+impl JournalState {
+    pub(crate) fn pending_role(&self, trial_id: u64) -> Result<crate::AttemptRole, TuneError> {
+        self.pending
+            .as_ref()
+            .filter(|pending| pending.trial_id == trial_id && pending.outcome.is_none())
+            .map(|pending| pending.role)
+            .ok_or_else(|| invalid("the trial is not pending or already has an outcome"))
+    }
+}
+
+pub(super) fn prepare_event(
+    state: &mut JournalState,
+    event: &JournalEvent,
+    stage: &SearchStage,
+    session: &SessionIdentity,
+) -> Result<(), TuneError> {
+    let JournalEvent::RunPrepared {
+        trial_id,
+        run_index,
+        context,
+        run_intent_digest,
+    } = event
+    else {
+        return Err(invalid("the event is not a run preparation"));
+    };
+    prepare(
+        state,
+        *trial_id,
+        *run_index,
+        context,
+        *run_intent_digest,
+        stage,
+        session,
+    )
+}
+
+pub(super) fn prepare(
+    state: &mut JournalState,
+    trial_id: u64,
+    run_index: u64,
+    context: &RunExecutionContext,
+    run_intent_digest: Digest,
+    stage: &SearchStage,
+    session: &SessionIdentity,
+) -> Result<(), TuneError> {
+    context
+        .validate()
+        .map_err(|_| invalid("a prepared run context is not valid during replay"))?;
+    let context_digest = context
+        .digest()
+        .map_err(|_| invalid("a prepared run context digest cannot be recomputed"))?;
+    let pending = state
+        .pending
+        .as_mut()
+        .filter(|pending| pending.outcome.is_none())
+        .ok_or_else(|| invalid("run preparation has no active attempt"))?;
+    let expected_index = u64::try_from(pending.prepared_runs.len())
+        .map_err(|_| invalid("prepared run index overflow"))?;
+    let session_digest = super::super::storage::document_digest("session identity", session)?;
+    let expected_scenario = expected_scenario(stage, pending.role.scenario_set(), run_index)?;
+    let expected_seed = derive_seed(
+        session.fixed_seed,
+        pending.role.scenario_set(),
+        expected_scenario.0,
+        expected_scenario.1,
+    );
+    if trial_id != pending.trial_id
+        || run_index != expected_index
+        || context.tuning_session_digest() != session_digest
+        || context.trial_id() != pending.trial_id
+        || context.role() != pending.role
+        || context.candidate_digest() != pending.candidate
+        || context.transition_authorization() != pending.transition
+        || context.scenario_set() != pending.role.scenario_set()
+        || context.scenario_id() != expected_scenario.0.id
+        || context.scenario_digest() != expected_scenario.0.digest
+        || context.repetition() != expected_scenario.1
+        || context.seed() != expected_seed
+        || run_intent_digest.is_zero()
+        || context_digest != run_intent_digest
+    {
+        return Err(invalid("a prepared run does not match its attempt plan"));
+    }
+    pending.prepared_runs.push(PreparedRun {
+        run_index,
+        context: context.clone(),
+        run_intent_digest,
+    });
+    Ok(())
+}
+
+pub(super) fn validate_outcome(
+    pending: &PendingAttempt,
+    evaluation: &CandidateEvaluation,
+) -> Result<(), TuneError> {
+    let prepared_identity_is_exact =
+        pending
+            .prepared_runs
+            .iter()
+            .enumerate()
+            .all(|(index, run)| {
+                u64::try_from(index) == Ok(run.run_index)
+                    && run
+                        .context
+                        .digest()
+                        .is_ok_and(|digest| digest == run.run_intent_digest)
+            });
+    let prepared_count = pending.prepared_runs.len();
+    let count_matches = match evaluation {
+        CandidateEvaluation::Passed { runs, .. } => prepared_count == runs.len(),
+        CandidateEvaluation::HardGateFailed { completed_runs, .. } => {
+            prepared_count == completed_runs.len().saturating_add(1)
+        }
+        CandidateEvaluation::Quarantined { .. } => true,
+    };
+    if count_matches && prepared_identity_is_exact {
+        Ok(())
+    } else {
+        Err(invalid(
+            "an attempt outcome does not match its prepared run count",
+        ))
+    }
+}
+
+fn expected_scenario(
+    stage: &SearchStage,
+    set: ScenarioSet,
+    run_index: u64,
+) -> Result<(&ScenarioRef, u32), TuneError> {
+    let repetitions = u64::from(stage.repetitions);
+    let scenario_index = usize::try_from(run_index / repetitions)
+        .map_err(|_| invalid("prepared run scenario index overflow"))?;
+    let repetition = u32::try_from(run_index % repetitions)
+        .map_err(|_| invalid("prepared run repetition overflow"))?;
+    let scenarios = match set {
+        ScenarioSet::Training => &stage.training_scenarios,
+        ScenarioSet::Promotion => &stage.promotion_scenarios,
+        ScenarioSet::FinalQualification => &stage.final_qualification_scenarios,
+    };
+    scenarios
+        .get(scenario_index)
+        .map(|scenario| (scenario, repetition))
+        .ok_or_else(|| invalid("prepared run exceeds the attempt plan"))
+}

--- a/tools/flight-tune/src/journal/replay/transition.rs
+++ b/tools/flight-tune/src/journal/replay/transition.rs
@@ -1,0 +1,136 @@
+use crate::journal::replay::{JournalState, invalid};
+use crate::journal::transition::AuthorizedTrainingTransition;
+use crate::journal::{AttemptRole, CampaignPhase, JournalEvent, SessionIdentity};
+use crate::{
+    CandidateTransitionReceipt, CandidateTransitionReference, Digest, SearchStage, TuneError,
+};
+
+#[cfg(test)]
+#[path = "transition/tests.rs"]
+mod tests;
+
+pub(super) fn authorize_event(
+    state: &mut JournalState,
+    event: &JournalEvent,
+    stage: &SearchStage,
+    session: &SessionIdentity,
+) -> Result<(), TuneError> {
+    let JournalEvent::CandidateTransitionAuthorized {
+        attempt_index,
+        reason,
+        candidate,
+        receipt,
+    } = event
+    else {
+        return Err(invalid("the event is not a transition authorization"));
+    };
+    authorize(
+        state,
+        *attempt_index,
+        reason,
+        *candidate,
+        receipt,
+        stage,
+        session,
+    )
+}
+
+pub(super) fn authorize(
+    state: &mut JournalState,
+    attempt_index: u64,
+    reason: &str,
+    candidate: Digest,
+    receipt: &CandidateTransitionReceipt,
+    stage: &SearchStage,
+    session: &SessionIdentity,
+) -> Result<(), TuneError> {
+    if state.phase != CampaignPhase::Searching
+        || !super::has_passed_training_baseline_and_incumbent(state)
+        || state.pending.is_some()
+        || state.authorized_transition.is_some()
+        || attempt_index != state.training_attempt_count
+        || reason.trim().is_empty()
+        || reason.len() > 4_096
+        || candidate.is_zero()
+        || candidate == state.training_incumbent
+        || state
+            .training_history
+            .iter()
+            .any(|observation| observation.candidate_digest == candidate)
+    {
+        return Err(invalid(
+            "candidate transition authorization has invalid campaign state",
+        ));
+    }
+    let session_digest = super::super::storage::document_digest("session identity", session)?;
+    let role = AttemptRole::TrainingChallenger { attempt_index };
+    let plan_digest = role.plan_digest(stage, candidate, session.fixed_seed)?;
+    let expected_planning_context =
+        crate::adapter::planning_context_digest(session.stage_digest, plan_digest)?;
+    let reference = receipt.reference();
+    reference
+        .validate_for_runtime(
+            session_digest,
+            state.training_incumbent,
+            candidate,
+            &session.runtimes.transition_validator,
+            session.runtimes.adjacency_policy_digest,
+            expected_planning_context,
+        )
+        .map_err(|_| invalid("candidate transition reference is not valid during replay"))?;
+    let recomputed = receipt
+        .recompute_digest()
+        .map_err(|_| invalid("candidate transition receipt cannot be recomputed"))?;
+    if receipt.source_candidate_digest() != state.training_incumbent
+        || receipt.target_candidate_digest() != candidate
+        || receipt.validator() != &session.runtimes.transition_validator
+        || receipt.adjacency_policy_digest() != session.runtimes.adjacency_policy_digest
+        || receipt.planning_context_digest() != expected_planning_context
+        || recomputed != receipt.receipt_digest()
+    {
+        return Err(invalid(
+            "candidate transition receipt does not match the replay identity",
+        ));
+    }
+    state.authorized_transition = Some(AuthorizedTrainingTransition {
+        attempt_index,
+        candidate,
+        reference,
+    });
+    Ok(())
+}
+
+pub(super) fn validate_attempt(
+    state: &JournalState,
+    role: AttemptRole,
+    candidate: Digest,
+    reference: Option<&CandidateTransitionReference>,
+) -> Result<(), TuneError> {
+    match role {
+        AttemptRole::TrainingChallenger { attempt_index } => {
+            let authorized = state
+                .authorized_transition
+                .as_ref()
+                .ok_or_else(|| invalid("a training challenger has no transition authorization"))?;
+            if authorized.attempt_index != attempt_index
+                || authorized.candidate != candidate
+                || Some(&authorized.reference) != reference
+            {
+                return Err(invalid(
+                    "a training challenger changed its transition authorization",
+                ));
+            }
+        }
+        AttemptRole::TrainingBaseline
+        | AttemptRole::PromotionBaseline
+        | AttemptRole::PromotionFrozen
+        | AttemptRole::FinalQualification => {
+            if reference.is_some() || state.authorized_transition.is_some() {
+                return Err(invalid(
+                    "a non-challenger attempt has a transition authorization",
+                ));
+            }
+        }
+    }
+    Ok(())
+}

--- a/tools/flight-tune/src/journal/replay/transition/tests.rs
+++ b/tools/flight-tune/src/journal/replay/transition/tests.rs
@@ -1,0 +1,326 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use super::{authorize, validate_attempt};
+use crate::adapter::planning_context_digest;
+use crate::identity::harness_build_identity;
+use crate::journal::replay::run;
+use crate::journal::replay::{PendingAttempt, initial_state};
+use crate::journal::storage::document_digest;
+use crate::model::derive_seed;
+use crate::{
+    ArtifactIdentity, AttemptRole, Candidate, CandidateEvaluation, CandidateLineage,
+    CandidateTransitionReceipt, CandidateTransitionRequest, ConfidenceInterval, Digest,
+    ParameterBounds, PromotionPolicy, QualificationPolicy, RunExecutionContext, RuntimeIdentities,
+    ScenarioRef, ScoreAggregate, SearchStage, SessionIdentity, TuneError,
+};
+
+#[test]
+fn replay_keeps_the_exact_authorized_target_and_reference() {
+    let fixture = fixture();
+    let receipt = receipt(&fixture, fixture.policy, fixture.planning);
+    let reference = receipt.reference();
+    let mut state = searching_state(fixture.source_digest);
+
+    authorize(
+        &mut state,
+        0,
+        "increase gain",
+        fixture.target_digest,
+        &receipt,
+        &fixture.stage,
+        &fixture.session,
+    )
+    .expect("authorize exact transition");
+
+    let authorized = state
+        .authorized_transition
+        .as_ref()
+        .expect("keep authorization for crash recovery");
+    assert_eq!(authorized.attempt_index, 0);
+    assert_eq!(authorized.candidate, fixture.target_digest);
+    assert_eq!(authorized.reference, reference);
+    validate_attempt(
+        &state,
+        AttemptRole::TrainingChallenger { attempt_index: 0 },
+        fixture.target_digest,
+        Some(&reference),
+    )
+    .expect("bind exact authorization to attempt");
+}
+
+#[test]
+fn replay_rejects_a_self_consistent_forged_policy_and_context() {
+    let fixture = fixture();
+    let forged = receipt(&fixture, digest(91), digest(92));
+    let mut state = searching_state(fixture.source_digest);
+
+    let error = authorize(
+        &mut state,
+        0,
+        "increase gain",
+        fixture.target_digest,
+        &forged,
+        &fixture.stage,
+        &fixture.session,
+    )
+    .expect_err("reject forged policy and context");
+
+    assert!(matches!(error, TuneError::InvalidJournal { .. }));
+    assert!(state.authorized_transition.is_none());
+}
+
+#[test]
+fn replay_rejects_a_challenger_without_one_matching_authorization() {
+    let fixture = fixture();
+    let state = searching_state(fixture.source_digest);
+
+    let error = validate_attempt(
+        &state,
+        AttemptRole::TrainingChallenger { attempt_index: 0 },
+        fixture.target_digest,
+        None,
+    )
+    .expect_err("reject missing authorization");
+
+    assert!(matches!(error, TuneError::InvalidJournal { .. }));
+}
+
+#[test]
+fn challenger_role_requires_a_passed_baseline_and_incumbent() {
+    let fixture = fixture();
+    let role = AttemptRole::TrainingChallenger { attempt_index: 0 };
+    let mut state = searching_state(fixture.source_digest);
+    assert!(super::super::role_allowed(
+        &state,
+        role,
+        fixture.target_digest,
+        fixture.source_digest,
+    ));
+
+    state.training_incumbent_evaluation = None;
+    assert!(!super::super::role_allowed(
+        &state,
+        role,
+        fixture.target_digest,
+        fixture.source_digest,
+    ));
+
+    state.training_incumbent_evaluation = Some(passed_evaluation());
+    state.training_baseline = Some(CandidateEvaluation::Quarantined {
+        reason: "unsafe baseline".to_owned(),
+    });
+    assert!(!super::super::role_allowed(
+        &state,
+        role,
+        fixture.target_digest,
+        fixture.source_digest,
+    ));
+}
+
+#[test]
+fn replay_rejects_a_coherently_forged_run_transition_reference() {
+    let fixture = fixture();
+    let exact_receipt = receipt(&fixture, fixture.policy, fixture.planning);
+    let exact_reference = exact_receipt.reference();
+    let forged_reference = receipt(&fixture, digest(91), digest(92)).reference();
+    let role = AttemptRole::TrainingChallenger { attempt_index: 0 };
+    let mut state = searching_state(fixture.source_digest);
+    state.pending = Some(PendingAttempt {
+        trial_id: 0,
+        role,
+        candidate: fixture.target_digest,
+        transition: Some(exact_reference),
+        prepared_runs: Vec::new(),
+        outcome: None,
+    });
+    let scenario = &fixture.stage.training_scenarios[0];
+    let context = RunExecutionContext::new(
+        document_digest("session identity", &fixture.session).expect("session digest"),
+        0,
+        role,
+        fixture.target_digest,
+        Some(forged_reference),
+        crate::ScenarioSet::Training,
+        scenario,
+        0,
+        derive_seed(
+            fixture.session.fixed_seed,
+            crate::ScenarioSet::Training,
+            scenario,
+            0,
+        ),
+    )
+    .expect("self-consistent forged run context");
+    let forged_digest = context.digest().expect("forged run digest");
+
+    let error = run::prepare(
+        &mut state,
+        0,
+        0,
+        &context,
+        forged_digest,
+        &fixture.stage,
+        &fixture.session,
+    )
+    .expect_err("reject changed transition reference");
+
+    assert!(matches!(error, TuneError::InvalidJournal { .. }));
+    assert!(
+        state
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.prepared_runs.is_empty())
+    );
+}
+
+struct Fixture {
+    source: Candidate,
+    source_digest: Digest,
+    target: Candidate,
+    target_digest: Digest,
+    stage: SearchStage,
+    session: SessionIdentity,
+    policy: Digest,
+    planning: Digest,
+}
+
+fn fixture() -> Fixture {
+    let lineage = CandidateLineage {
+        schema: "test-candidate-v1".to_owned(),
+        base_preset_digest: digest(1),
+        plant_digest: digest(2),
+    };
+    let source = candidate(&lineage, 0.4);
+    let target = candidate(&lineage, 0.5);
+    let source_digest = document_digest("candidate", &source).expect("source digest");
+    let target_digest = document_digest("candidate", &target).expect("target digest");
+    let stage = stage();
+    let stage_digest = document_digest("search stage", &stage).expect("stage digest");
+    let policy = digest(19);
+    let session = SessionIdentity {
+        stage_digest,
+        initial_candidate_digest: source_digest,
+        candidate_lineage: lineage,
+        fixed_seed: 41,
+        runtimes: runtimes(policy),
+    };
+    let plan = AttemptRole::TrainingChallenger { attempt_index: 0 }
+        .plan_digest(&stage, target_digest, session.fixed_seed)
+        .expect("plan digest");
+    let planning = planning_context_digest(stage_digest, plan).expect("planning context");
+    Fixture {
+        source,
+        source_digest,
+        target,
+        target_digest,
+        stage,
+        session,
+        policy,
+        planning,
+    }
+}
+
+fn receipt(fixture: &Fixture, policy: Digest, planning: Digest) -> CandidateTransitionReceipt {
+    let session_digest = document_digest("session identity", &fixture.session).expect("session");
+    let request = CandidateTransitionRequest::new(
+        session_digest,
+        &fixture.source,
+        fixture.source_digest,
+        &fixture.target,
+        fixture.target_digest,
+        fixture.session.runtimes.transition_validator.clone(),
+        policy,
+        planning,
+    )
+    .expect("transition request");
+    CandidateTransitionReceipt::authorized(&request).expect("transition receipt")
+}
+
+fn searching_state(source: Digest) -> crate::journal::replay::JournalState {
+    let mut state = initial_state(source);
+    let evaluation = passed_evaluation();
+    state.training_baseline = Some(evaluation.clone());
+    state.training_incumbent_evaluation = Some(evaluation);
+    state
+}
+
+fn passed_evaluation() -> CandidateEvaluation {
+    CandidateEvaluation::Passed {
+        aggregate: ScoreAggregate {
+            run_count: 2,
+            mean_loss: 0.5,
+            p95_loss: 0.5,
+            loss_variance: 0.0,
+            loss_confidence_95: ConfidenceInterval {
+                lower: 0.5,
+                upper: 0.5,
+            },
+            mean_control_effort: 0.2,
+        },
+        runs: Vec::new(),
+    }
+}
+
+fn candidate(lineage: &CandidateLineage, gain: f64) -> Candidate {
+    Candidate::new(lineage.clone(), BTreeMap::from([("gain".to_owned(), gain)])).expect("candidate")
+}
+
+fn stage() -> SearchStage {
+    let scenario = ScenarioRef {
+        id: "training".to_owned(),
+        digest: digest(3),
+        max_samples: 8,
+        sample_timeout_ms: 100,
+    };
+    SearchStage {
+        id: "transition-stage".to_owned(),
+        allowlist: BTreeMap::from([(
+            "gain".to_owned(),
+            ParameterBounds {
+                minimum: 0.0,
+                maximum: 1.0,
+            },
+        )]),
+        fixed_parameters: BTreeMap::new(),
+        required_hard_gates: vec!["envelope".to_owned()],
+        training_scenarios: vec![scenario.clone()],
+        promotion_scenarios: vec![scenario.clone()],
+        final_qualification_scenarios: vec![scenario],
+        repetitions: 1,
+        promotion: PromotionPolicy {
+            minimum_loss_improvement: 0.0,
+            minimum_relative_loss_improvement: 0.0,
+            maximum_control_effort_increase: 0.0,
+        },
+        qualification: QualificationPolicy {
+            maximum_loss_confidence_upper: 1.0,
+            maximum_p95_loss: 1.0,
+            maximum_mean_control_effort: 1.0,
+            objective_maxima: BTreeMap::new(),
+        },
+    }
+}
+
+fn runtimes(policy: Digest) -> RuntimeIdentities {
+    RuntimeIdentities {
+        harness_build: harness_build_identity(),
+        strategy: identity("strategy", 11),
+        metric: identity("metric", 12),
+        hard_gates: identity("hard-gates", 13),
+        simulator: identity("simulator", 14),
+        airframe: identity("airframe", 15),
+        vehicle: identity("vehicle", 16),
+        transition_validator: identity("transition-validator", 17),
+        adjacency_policy_digest: policy,
+    }
+}
+
+fn identity(id: &str, byte: u8) -> ArtifactIdentity {
+    ArtifactIdentity::new(id, digest(byte)).expect("artifact identity")
+}
+
+fn digest(byte: u8) -> Digest {
+    Digest::from_bytes([byte; 32])
+}

--- a/tools/flight-tune/src/journal/storage.rs
+++ b/tools/flight-tune/src/journal/storage.rs
@@ -210,7 +210,8 @@ fn candidate_digests_to_verify(initial: Digest, entries: &[JournalEntry]) -> Vec
     entries
         .iter()
         .filter_map(|entry| match entry.event {
-            crate::JournalEvent::AttemptPrepared { candidate, .. } => Some(candidate),
+            crate::JournalEvent::CandidateTransitionAuthorized { candidate, .. }
+            | crate::JournalEvent::AttemptPrepared { candidate, .. } => Some(candidate),
             _ => None,
         })
         .filter(|candidate| seen.insert(*candidate))

--- a/tools/flight-tune/src/journal/storage/append.rs
+++ b/tools/flight-tune/src/journal/storage/append.rs
@@ -238,6 +238,7 @@ fn verify_prospective_entry_references(
     stage.validate_challenger(&initial, &initial)?;
     match &entry.event {
         JournalEvent::Started { candidate }
+        | JournalEvent::CandidateTransitionAuthorized { candidate, .. }
         | JournalEvent::AttemptPrepared { candidate, .. }
         | JournalEvent::Sealed { candidate, .. } => {
             verify_candidate_reference(storage, &stage, &initial, *candidate)
@@ -250,6 +251,7 @@ fn verify_prospective_entry_references(
             verify_candidate_reference(storage, &stage, &initial, *candidate)
         }
         JournalEvent::AttemptCompleted { .. }
+        | JournalEvent::RunPrepared { .. }
         | JournalEvent::AttemptQuarantined { .. }
         | JournalEvent::CleanupRecorded { .. }
         | JournalEvent::PromotionClosed { .. } => Ok(()),

--- a/tools/flight-tune/src/journal/storage/tests/prospective.rs
+++ b/tools/flight-tune/src/journal/storage/tests/prospective.rs
@@ -10,9 +10,14 @@ use super::super::{
 use super::TestDirectory;
 use crate::identity::harness_build_identity;
 use crate::journal::{JOURNAL_SCHEMA_VERSION, JournalEntry, JournalEvent, SessionIdentity};
+use crate::model::derive_seed;
+use crate::score::aggregate_runs;
 use crate::{
-    ArtifactIdentity, AttemptRole, Candidate, CandidateLineage, Digest, ParameterBounds,
-    PromotionPolicy, QualificationPolicy, RuntimeIdentities, ScenarioRef, SearchStage, TuneError,
+    ArtifactIdentity, AttemptRole, Candidate, CandidateEvaluation, CandidateLineage,
+    CandidateTransitionReceipt, CandidateTransitionRequest, Digest, GateOutcome, HardGateFailure,
+    Journal, OperationStatus, ParameterBounds, PromotionPolicy, QualificationPolicy,
+    RunExecutionContext, RunRecord, RuntimeIdentities, ScenarioRef, ScenarioSet, SearchStage,
+    TuneError,
 };
 
 #[test]
@@ -61,6 +66,105 @@ fn a_changed_prospective_candidate_cannot_publish_a_head() {
 }
 
 #[test]
+fn resume_reads_an_authorized_target_before_attempt_preparation() {
+    let directory = TestDirectory::new("authorized-target-resume");
+    let stage = test_stage();
+    let initial = test_candidate();
+    let target = initial
+        .with_parameter("gain", 0.5)
+        .expect("transition target");
+    let runtimes = test_runtimes();
+    let mut journal =
+        Journal::open_or_create(directory.path(), &stage, 91, runtimes.clone(), &initial)
+            .expect("start journal");
+    record_passing_baseline(&mut journal, &stage, &initial);
+    let initial_digest = document_digest("candidate", &initial).expect("initial digest");
+    let target_digest = document_digest("candidate", &target).expect("target digest");
+    let role = AttemptRole::TrainingChallenger { attempt_index: 0 };
+    let plan = role
+        .plan_digest(&stage, target_digest, 91)
+        .expect("challenger plan");
+    let planning = crate::adapter::planning_context_digest(journal.session().stage_digest, plan)
+        .expect("planning context");
+    let request = CandidateTransitionRequest::new(
+        journal.session_digest().expect("session digest"),
+        &initial,
+        initial_digest,
+        &target,
+        target_digest,
+        runtimes.transition_validator.clone(),
+        runtimes.adjacency_policy_digest,
+        planning,
+    )
+    .expect("transition request");
+    let receipt = CandidateTransitionReceipt::authorized(&request).expect("transition receipt");
+    journal
+        .authorize_training_transition(0, "increase gain", &target, receipt)
+        .expect("save transition authorization");
+    drop(journal);
+    change_bytes(
+        &directory
+            .path()
+            .join("candidates")
+            .join(format!("{target_digest}.json")),
+    );
+
+    let error = Journal::open_or_create(directory.path(), &stage, 91, runtimes, &initial)
+        .err()
+        .expect("reject changed authorized target");
+
+    assert!(matches!(error, TuneError::Storage { .. }));
+}
+
+#[test]
+fn a_hard_gate_failed_baseline_cannot_authorize_a_challenger() {
+    let directory = TestDirectory::new("hard-gate-baseline-authorization");
+    let stage = test_stage();
+    let initial = test_candidate();
+    let target = initial
+        .with_parameter("gain", 0.5)
+        .expect("transition target");
+    let runtimes = test_runtimes();
+    let mut journal =
+        Journal::open_or_create(directory.path(), &stage, 91, runtimes.clone(), &initial)
+            .expect("start journal");
+    record_hard_gate_failed_baseline(&mut journal, &stage, &initial);
+
+    reject_challenger_authorization(&mut journal, &stage, &initial, &target);
+    drop(journal);
+
+    let resumed = Journal::open_or_create(directory.path(), &stage, 91, runtimes, &initial)
+        .expect("resume failed baseline");
+    assert_no_transition_authorization(&resumed);
+}
+
+#[test]
+fn a_quarantined_baseline_cannot_authorize_a_challenger() {
+    let directory = TestDirectory::new("quarantined-baseline-authorization");
+    let stage = test_stage();
+    let initial = test_candidate();
+    let target = initial
+        .with_parameter("gain", 0.5)
+        .expect("transition target");
+    let runtimes = test_runtimes();
+    let mut journal =
+        Journal::open_or_create(directory.path(), &stage, 91, runtimes.clone(), &initial)
+            .expect("start journal");
+    let (trial_id, _) = prepare_baseline(&mut journal, &stage, &initial);
+    journal
+        .quarantine_attempt(trial_id, "baseline simulator failure")
+        .expect("quarantine baseline");
+    record_successful_cleanup(&mut journal, trial_id);
+
+    reject_challenger_authorization(&mut journal, &stage, &initial, &target);
+    drop(journal);
+
+    let resumed = Journal::open_or_create(directory.path(), &stage, 91, runtimes, &initial)
+        .expect("resume quarantined baseline");
+    assert_no_transition_authorization(&resumed);
+}
+
+#[test]
 fn candidate_audit_reads_each_digest_once_in_entry_order() {
     let initial = Digest::from_bytes([21; 32]);
     let first = Digest::from_bytes([22; 32]);
@@ -80,6 +184,7 @@ fn candidate_audit_reads_each_digest_once_in_entry_order() {
                 role: AttemptRole::TrainingBaseline,
                 candidate,
                 plan_digest: Digest::from_bytes([24; 32]),
+                transition: None,
             },
         })
         .collect::<Vec<_>>();
@@ -88,6 +193,174 @@ fn candidate_audit_reads_each_digest_once_in_entry_order() {
         candidate_digests_to_verify(initial, &entries),
         vec![first, second]
     );
+}
+
+fn record_passing_baseline(journal: &mut Journal, stage: &SearchStage, candidate: &Candidate) {
+    let (trial_id, candidate_digest) = prepare_baseline(journal, stage, candidate);
+    let scenario = &stage.training_scenarios[0];
+    let runs = (0..stage.repetitions)
+        .map(|repetition| {
+            let seed = prepare_training_run(journal, stage, trial_id, candidate_digest, repetition);
+            RunRecord {
+                scenario_set: ScenarioSet::Training,
+                scenario_id: scenario.id.clone(),
+                repetition,
+                seed,
+                loss: 0.5,
+                control_effort: 0.2,
+                objectives: BTreeMap::new(),
+                passed_hard_gates: stage.required_hard_gates.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    let aggregate = aggregate_runs(&runs, ScenarioSet::Training).expect("aggregate baseline");
+    journal
+        .complete_attempt(
+            trial_id,
+            CandidateEvaluation::Passed { aggregate, runs },
+            Some(true),
+        )
+        .expect("complete passing baseline");
+    record_successful_cleanup(journal, trial_id);
+}
+
+fn record_hard_gate_failed_baseline(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    candidate: &Candidate,
+) {
+    let (trial_id, candidate_digest) = prepare_baseline(journal, stage, candidate);
+    let scenario = &stage.training_scenarios[0];
+    let seed = prepare_training_run(journal, stage, trial_id, candidate_digest, 0);
+    let failure = HardGateFailure {
+        scenario_set: ScenarioSet::Training,
+        scenario_id: scenario.id.clone(),
+        repetition: 0,
+        seed,
+        sample_sequence: 1,
+        elapsed_ms: 10,
+        gate: GateOutcome::fail("envelope", "the vehicle left the test envelope"),
+    };
+    journal
+        .complete_attempt(
+            trial_id,
+            CandidateEvaluation::HardGateFailed {
+                failure,
+                completed_runs: Vec::new(),
+            },
+            Some(false),
+        )
+        .expect("complete failed baseline");
+    record_successful_cleanup(journal, trial_id);
+}
+
+fn prepare_baseline(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    candidate: &Candidate,
+) -> (u64, Digest) {
+    let candidate_digest = document_digest("candidate", candidate).expect("candidate digest");
+    let role = AttemptRole::TrainingBaseline;
+    let plan = role
+        .plan_digest(stage, candidate_digest, journal.session().fixed_seed)
+        .expect("baseline plan");
+    journal
+        .prepare_attempt(role, candidate, plan, None)
+        .expect("prepare baseline")
+}
+
+fn prepare_training_run(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    trial_id: u64,
+    candidate_digest: Digest,
+    repetition: u32,
+) -> u64 {
+    let scenario = &stage.training_scenarios[0];
+    let seed = derive_seed(
+        journal.session().fixed_seed,
+        ScenarioSet::Training,
+        scenario,
+        repetition,
+    );
+    let context = RunExecutionContext::new(
+        journal.session_digest().expect("session digest"),
+        trial_id,
+        AttemptRole::TrainingBaseline,
+        candidate_digest,
+        None,
+        ScenarioSet::Training,
+        scenario,
+        repetition,
+        seed,
+    )
+    .expect("baseline run context");
+    journal
+        .prepare_run(u64::from(repetition), &context)
+        .expect("prepare baseline run");
+    seed
+}
+
+fn reject_challenger_authorization(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    source: &Candidate,
+    target: &Candidate,
+) {
+    let receipt = transition_receipt(journal, stage, source, target, 0);
+    let entry_count = journal.entries().len();
+    let error = journal
+        .authorize_training_transition(0, "increase gain", target, receipt)
+        .expect_err("reject challenger authorization");
+
+    assert!(matches!(error, TuneError::InvalidJournal { .. }));
+    assert_eq!(journal.entries().len(), entry_count);
+    assert_no_transition_authorization(journal);
+}
+
+fn transition_receipt(
+    journal: &Journal,
+    stage: &SearchStage,
+    source: &Candidate,
+    target: &Candidate,
+    attempt_index: u64,
+) -> CandidateTransitionReceipt {
+    let source_digest = document_digest("candidate", source).expect("source digest");
+    let target_digest = document_digest("candidate", target).expect("target digest");
+    let plan = AttemptRole::TrainingChallenger { attempt_index }
+        .plan_digest(stage, target_digest, journal.session().fixed_seed)
+        .expect("challenger plan");
+    let planning = crate::adapter::planning_context_digest(journal.session().stage_digest, plan)
+        .expect("planning context");
+    let request = CandidateTransitionRequest::new(
+        journal.session_digest().expect("session digest"),
+        source,
+        source_digest,
+        target,
+        target_digest,
+        journal.session().runtimes.transition_validator.clone(),
+        journal.session().runtimes.adjacency_policy_digest,
+        planning,
+    )
+    .expect("transition request");
+    CandidateTransitionReceipt::authorized(&request).expect("transition receipt")
+}
+
+fn record_successful_cleanup(journal: &mut Journal, trial_id: u64) {
+    journal
+        .record_cleanup(
+            trial_id,
+            OperationStatus::Succeeded,
+            OperationStatus::Succeeded,
+        )
+        .expect("record successful cleanup");
+}
+
+fn assert_no_transition_authorization(journal: &Journal) {
+    assert!(journal.entries().iter().all(|entry| !matches!(
+        entry.event,
+        JournalEvent::CandidateTransitionAuthorized { .. }
+    )));
 }
 
 fn started_entry(
@@ -172,6 +445,8 @@ fn test_runtimes() -> RuntimeIdentities {
         simulator: identity("simulator", 14),
         airframe: identity("airframe", 15),
         vehicle: identity("vehicle", 16),
+        transition_validator: identity("transition-validator", 17),
+        adjacency_policy_digest: Digest::from_bytes([18; 32]),
     }
 }
 

--- a/tools/flight-tune/src/journal/transition.rs
+++ b/tools/flight-tune/src/journal/transition.rs
@@ -1,0 +1,102 @@
+use crate::journal::{AttemptRole, SessionIdentity};
+use crate::{
+    Candidate, CandidateTransitionReceipt, CandidateTransitionReference, Digest,
+    RunExecutionContext, SearchStage, TuneError,
+};
+
+use super::{Journal, JournalEvent, storage};
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuthorizedTrainingTransition {
+    pub(crate) attempt_index: u64,
+    pub(crate) candidate: Digest,
+    pub(crate) reference: CandidateTransitionReference,
+}
+
+impl Journal {
+    pub(crate) fn authorized_training_transition(&self) -> Option<&AuthorizedTrainingTransition> {
+        self.state.authorized_transition.as_ref()
+    }
+
+    pub(crate) fn authorize_training_transition(
+        &mut self,
+        attempt_index: u64,
+        reason: impl Into<String>,
+        candidate: &Candidate,
+        receipt: CandidateTransitionReceipt,
+    ) -> Result<CandidateTransitionReference, TuneError> {
+        self.ensure_usable()?;
+        candidate.validate()?;
+        let target = self.record_storage_result(storage::store_candidate(
+            &self.storage,
+            &self.writer,
+            candidate,
+        ))?;
+        let source_candidate = self.read_candidate(self.state.training_incumbent)?;
+        let reference = validate_authorization(
+            self.session(),
+            &self.stage,
+            attempt_index,
+            &source_candidate,
+            self.state.training_incumbent,
+            candidate,
+            target,
+            &receipt,
+        )?;
+        self.append(JournalEvent::CandidateTransitionAuthorized {
+            attempt_index,
+            reason: reason.into(),
+            candidate: target,
+            receipt,
+        })?;
+        Ok(reference)
+    }
+
+    pub(crate) fn prepare_run(
+        &mut self,
+        run_index: u64,
+        context: &RunExecutionContext,
+    ) -> Result<Digest, TuneError> {
+        self.ensure_usable()?;
+        let run_intent_digest = context.digest()?;
+        self.append(JournalEvent::RunPrepared {
+            trial_id: context.trial_id(),
+            run_index,
+            context: context.clone(),
+            run_intent_digest,
+        })?;
+        Ok(run_intent_digest)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn validate_authorization(
+    session: &SessionIdentity,
+    stage: &SearchStage,
+    attempt_index: u64,
+    source: &Candidate,
+    source_digest: Digest,
+    target: &Candidate,
+    target_digest: Digest,
+    receipt: &CandidateTransitionReceipt,
+) -> Result<CandidateTransitionReference, TuneError> {
+    let plan_digest = AttemptRole::TrainingChallenger { attempt_index }.plan_digest(
+        stage,
+        target_digest,
+        session.fixed_seed,
+    )?;
+    let planning_context_digest =
+        crate::adapter::planning_context_digest(session.stage_digest, plan_digest)?;
+    let request = crate::CandidateTransitionRequest::new(
+        super::storage::document_digest("session identity", session)?,
+        source,
+        source_digest,
+        target,
+        target_digest,
+        session.runtimes.transition_validator.clone(),
+        session.runtimes.adjacency_policy_digest,
+        planning_context_digest,
+    )?;
+    receipt.validate_for(&request)?;
+    Ok(receipt.reference())
+}

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -19,13 +19,16 @@ mod flight_quality;
 mod identity;
 mod journal;
 mod model;
+mod run_context;
 mod score;
 mod strategy;
 
 pub use adapter::{
-    AdapterError, CandidateReceipt, EvaluatorError, SampleEvent, ScenarioStartReceipt,
-    SessionChallenge, SimulatorBackend, SimulatorCapability, SimulatorSessionReceipt,
-    SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample, VehicleBinding,
+    AdapterError, CANDIDATE_TRANSITION_RECEIPT_SCHEMA_VERSION, CandidateReceipt,
+    CandidateTransitionReceipt, CandidateTransitionReference, CandidateTransitionRequest,
+    EvaluatorError, RunPreparationReceipt, SampleEvent, ScenarioStartReceipt, SessionChallenge,
+    SimulatorBackend, SimulatorCapability, SimulatorSessionReceipt, SimulatorVehicleAdapter,
+    SimulatorVehicleFactory, TelemetrySample, TransitionBindingReceipt, VehicleBinding,
     VehicleBindingReceipt,
 };
 pub use engine::{StopReason, Tuner, TuningSummary};
@@ -45,6 +48,7 @@ pub use model::{
     Candidate, ParameterBounds, PromotionPolicy, QualificationPolicy, ScenarioRef, SearchStage,
 };
 pub use pilotage_trial::Digest;
+pub use run_context::{RUN_EXECUTION_CONTEXT_SCHEMA_VERSION, RunExecutionContext};
 pub use score::{
     CandidateEvaluation, ConfidenceInterval, GateEvaluator, GateOutcome, HardGateFailure,
     MetricEvaluator, MetricValues, RunRecord, ScenarioSet, ScoreAggregate,

--- a/tools/flight-tune/src/run_context.rs
+++ b/tools/flight-tune/src/run_context.rs
@@ -1,0 +1,179 @@
+use serde::{Deserialize, Serialize};
+
+use crate::identity::digest_bytes;
+use crate::{
+    AttemptRole, CandidateTransitionReference, Digest, ScenarioRef, ScenarioSet, TuneError,
+};
+
+/// The supported run execution context schema.
+pub const RUN_EXECUTION_CONTEXT_SCHEMA_VERSION: u16 = 1;
+
+const RUN_CONTEXT_DOMAIN: &[u8] = b"flight-tune:run-execution-context:v1\0";
+
+/// The immutable identity of one simulator run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunExecutionContext {
+    schema_version: u16,
+    tuning_session_digest: Digest,
+    trial_id: u64,
+    role: AttemptRole,
+    candidate_digest: Digest,
+    transition_authorization: Option<CandidateTransitionReference>,
+    scenario_set: ScenarioSet,
+    scenario_id: String,
+    scenario_digest: Digest,
+    repetition: u32,
+    seed: u64,
+}
+
+impl RunExecutionContext {
+    /// Creates one complete run identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when an identity is incomplete or inconsistent.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tuning_session_digest: Digest,
+        trial_id: u64,
+        role: AttemptRole,
+        candidate_digest: Digest,
+        transition_authorization: Option<CandidateTransitionReference>,
+        scenario_set: ScenarioSet,
+        scenario: &ScenarioRef,
+        repetition: u32,
+        seed: u64,
+    ) -> Result<Self, TuneError> {
+        let context = Self {
+            schema_version: RUN_EXECUTION_CONTEXT_SCHEMA_VERSION,
+            tuning_session_digest,
+            trial_id,
+            role,
+            candidate_digest,
+            transition_authorization,
+            scenario_set,
+            scenario_id: scenario.id.clone(),
+            scenario_digest: scenario.digest,
+            repetition,
+            seed,
+        };
+        context.validate()?;
+        Ok(context)
+    }
+
+    /// Validates the structure and internal consistency of this run identity.
+    ///
+    /// This method does not authorize a candidate transition. Journal replay
+    /// must validate the transition reference against the frozen runtime
+    /// contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when an identity is incomplete or inconsistent.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        let transition_matches = match self.role {
+            AttemptRole::TrainingChallenger { .. } => self
+                .transition_authorization
+                .is_some_and(|reference| reference.is_valid_for_target(self.candidate_digest)),
+            AttemptRole::TrainingBaseline
+            | AttemptRole::PromotionBaseline
+            | AttemptRole::PromotionFrozen
+            | AttemptRole::FinalQualification => self.transition_authorization.is_none(),
+        };
+        if self.schema_version != RUN_EXECUTION_CONTEXT_SCHEMA_VERSION
+            || self.tuning_session_digest.is_zero()
+            || self.candidate_digest.is_zero()
+            || self.role.scenario_set() != self.scenario_set
+            || !transition_matches
+            || self.scenario_id.trim().is_empty()
+            || self.scenario_id.len() > 128
+            || self.scenario_digest.is_zero()
+        {
+            return Err(TuneError::InvalidIdentity {
+                detail: "the run execution context is incomplete or inconsistent".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Returns the canonical run intent identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when validation or encoding fails.
+    pub fn digest(&self) -> Result<Digest, TuneError> {
+        self.validate()?;
+        let document = serde_json::to_vec(self).map_err(|source| TuneError::Encode {
+            document: "run execution context",
+            source,
+        })?;
+        let mut bytes = Vec::with_capacity(RUN_CONTEXT_DOMAIN.len().saturating_add(document.len()));
+        bytes.extend_from_slice(RUN_CONTEXT_DOMAIN);
+        bytes.extend_from_slice(&document);
+        Ok(digest_bytes(&bytes))
+    }
+
+    /// Returns the tuning session identity.
+    #[must_use]
+    pub const fn tuning_session_digest(&self) -> Digest {
+        self.tuning_session_digest
+    }
+
+    /// Returns the campaign trial identity.
+    #[must_use]
+    pub const fn trial_id(&self) -> u64 {
+        self.trial_id
+    }
+
+    /// Returns the attempt role.
+    #[must_use]
+    pub const fn role(&self) -> AttemptRole {
+        self.role
+    }
+
+    /// Returns the candidate identity.
+    #[must_use]
+    pub const fn candidate_digest(&self) -> Digest {
+        self.candidate_digest
+    }
+
+    /// Returns the transition authorization for this run.
+    #[must_use]
+    pub const fn transition_authorization(&self) -> Option<CandidateTransitionReference> {
+        self.transition_authorization
+    }
+
+    /// Returns the scenario partition.
+    #[must_use]
+    pub const fn scenario_set(&self) -> ScenarioSet {
+        self.scenario_set
+    }
+
+    /// Returns the scenario name.
+    #[must_use]
+    pub fn scenario_id(&self) -> &str {
+        &self.scenario_id
+    }
+
+    /// Returns the scenario artifact identity.
+    #[must_use]
+    pub const fn scenario_digest(&self) -> Digest {
+        self.scenario_digest
+    }
+
+    /// Returns the zero-based scenario repetition.
+    #[must_use]
+    pub const fn repetition(&self) -> u32 {
+        self.repetition
+    }
+
+    /// Returns the deterministic run seed.
+    #[must_use]
+    pub const fn seed(&self) -> u64 {
+        self.seed
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune/src/run_context/tests.rs
+++ b/tools/flight-tune/src/run_context/tests.rs
@@ -1,0 +1,97 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+use super::*;
+use crate::{ArtifactIdentity, CandidateLineage, CandidateTransitionReceipt};
+
+#[test]
+fn transition_identity_changes_the_run_intent() {
+    let first = context(transition(2));
+    let second = context(transition(3));
+
+    assert_ne!(
+        first.digest().expect("first digest"),
+        second.digest().expect("second digest")
+    );
+}
+
+#[test]
+fn a_non_challenger_cannot_carry_a_transition() {
+    let mut value = context(transition(2));
+    value.role = AttemptRole::TrainingBaseline;
+
+    assert!(value.validate().is_err());
+}
+
+#[test]
+fn strict_schema_rejects_an_unknown_field() {
+    let value = context(transition(2));
+    let mut document = serde_json::to_value(value).expect("encode context");
+    document
+        .as_object_mut()
+        .expect("context object")
+        .insert("extra".to_owned(), serde_json::json!(true));
+
+    assert!(serde_json::from_value::<RunExecutionContext>(document).is_err());
+}
+
+fn context(reference: CandidateTransitionReference) -> RunExecutionContext {
+    RunExecutionContext::new(
+        digest(1),
+        4,
+        AttemptRole::TrainingChallenger { attempt_index: 0 },
+        reference.target_candidate_digest(),
+        Some(reference),
+        ScenarioSet::Training,
+        &ScenarioRef {
+            id: "calm".to_owned(),
+            digest: digest(9),
+            max_samples: 10,
+            sample_timeout_ms: 20,
+        },
+        0,
+        22,
+    )
+    .expect("run context")
+}
+
+fn transition(target: u8) -> CandidateTransitionReference {
+    let source = candidate(1);
+    let target = candidate(target);
+    let request = crate::CandidateTransitionRequest::new(
+        digest(4),
+        &source,
+        candidate_digest(&source),
+        &target,
+        candidate_digest(&target),
+        ArtifactIdentity::from_text("validator", "validator-v1").expect("validator"),
+        digest(7),
+        digest(8),
+    )
+    .expect("transition request");
+    CandidateTransitionReceipt::authorized(&request)
+        .expect("transition receipt")
+        .reference()
+}
+
+fn candidate_digest(candidate: &crate::Candidate) -> Digest {
+    let bytes = serde_json::to_vec(candidate).expect("encode candidate");
+    crate::identity::digest_bytes(&bytes)
+}
+
+fn candidate(value: u8) -> crate::Candidate {
+    crate::Candidate::new(
+        CandidateLineage {
+            schema: "candidate-v1".to_owned(),
+            base_preset_digest: digest(5),
+            plant_digest: digest(6),
+        },
+        BTreeMap::from([("gain".to_owned(), f64::from(value))]),
+    )
+    .expect("candidate")
+}
+
+const fn digest(value: u8) -> Digest {
+    Digest::from_bytes([value; 32])
+}

--- a/tools/flight-tune/tests/tuner.rs
+++ b/tools/flight-tune/tests/tuner.rs
@@ -8,8 +8,14 @@ mod journal_storage;
 mod no_samples;
 #[path = "tuner/reconciliation.rs"]
 mod reconciliation;
+#[path = "tuner/recovery_order.rs"]
+mod recovery_order;
 #[path = "tuner/test_rig.rs"]
 mod test_rig;
+#[path = "tuner/transition_authorization.rs"]
+mod transition_authorization;
+#[path = "tuner/transition_chain_tamper.rs"]
+mod transition_chain_tamper;
 
 use std::path::Path;
 
@@ -51,7 +57,7 @@ fn training_cannot_observe_hidden_sets_and_the_campaign_seals_once() {
     tuner.freeze_candidate().expect("freeze candidate");
     let promotion = tuner.run_promotion_once_blocking().expect("run promotion");
     assert!(matches!(promotion, PromotionDecision::Promoted { .. }));
-    assert_eq!(state.0.borrow().gain, 0.5);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.5);
     let runs_after_promotion = state.0.borrow().scenario_runs.len();
     assert_eq!(
         tuner.run_promotion_once_blocking().expect("read promotion"),
@@ -77,7 +83,7 @@ fn training_cannot_observe_hidden_sets_and_the_campaign_seals_once() {
         tuner.qualified_candidate().expect("qualified candidate"),
         candidate(0.5)
     );
-    assert_eq!(state.0.borrow().gain, 0.5);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.5);
     assert!(matches!(
         tuner.run_training_attempts_blocking(1),
         Err(TuneError::InvalidState { .. })
@@ -141,7 +147,7 @@ fn final_qualification_rejects_a_named_objective_limit() {
             metric: "test.response".to_owned(),
         }
     );
-    assert_eq!(state.0.borrow().gain, 0.0);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.0);
 }
 
 #[test]
@@ -243,13 +249,13 @@ fn recovery_quarantines_a_prepared_candidate_without_replaying_it() {
     }));
     assert!(stopped.is_err());
     drop(tuner);
-    assert_eq!(state.0.borrow().apply_count, 1);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 1);
     state.0.borrow_mut().panic_on_prepare = None;
 
     let mut resumed = open(directory.path(), state.clone(), strategy, 2.0).expect("resume tuner");
 
     assert_eq!(resumed.journal().training_attempt_count(), 1);
-    assert_eq!(state.0.borrow().apply_count, 1);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 1);
     assert!(
         resumed
             .journal()
@@ -281,7 +287,11 @@ fn candidate_readback_mismatch_is_quarantined_before_cleanup() {
         2.0,
     )
     .expect("open tuner");
-    state.0.borrow_mut().bad_candidate_readback_on_ensure = Some(2);
+    state
+        .0
+        .borrow_mut()
+        .vehicle
+        .bad_candidate_readback_on_ensure = Some(2);
 
     let error = tuner
         .run_training_attempts_blocking(0)
@@ -352,7 +362,7 @@ fn a_hardware_like_factory_cannot_get_a_simulator_binding() {
     );
 
     assert!(matches!(result, Err(TuneError::Adapter { .. })));
-    assert_eq!(state.0.borrow().apply_count, 0);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 0);
 }
 
 #[test]
@@ -367,7 +377,7 @@ fn changed_strategy_identity_cannot_resume_the_session() {
     )
     .expect("open tuner");
     drop(tuner);
-    let apply_count = state.0.borrow().apply_count;
+    let apply_count = state.0.borrow().vehicle.apply_count;
 
     let result = open(
         directory.path(),
@@ -377,7 +387,7 @@ fn changed_strategy_identity_cannot_resume_the_session() {
     );
 
     assert!(matches!(result, Err(TuneError::JournalSessionMismatch)));
-    assert_eq!(state.0.borrow().apply_count, apply_count);
+    assert_eq!(state.0.borrow().vehicle.apply_count, apply_count);
 }
 
 #[test]

--- a/tools/flight-tune/tests/tuner/reconciliation.rs
+++ b/tools/flight-tune/tests/tuner/reconciliation.rs
@@ -20,8 +20,8 @@ fn hard_gate_rejection_restores_the_training_incumbent() {
         .run_training_attempts_blocking(1)
         .expect("evaluate rejected challenger");
 
-    assert_eq!(state.0.borrow().gain, 0.0);
-    assert_eq!(state.0.borrow().apply_count, 3);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.0);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 3);
     assert_eq!(
         tuner
             .journal()
@@ -47,8 +47,8 @@ fn passing_but_worse_challenger_restores_the_later_incumbent() {
         .run_training_attempts_blocking(2)
         .expect("evaluate two challengers");
 
-    assert_eq!(state.0.borrow().gain, 1.0);
-    assert_eq!(state.0.borrow().apply_count, 4);
+    assert_eq!(state.0.borrow().vehicle.gain, 1.0);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 4);
     assert_eq!(
         tuner
             .journal()
@@ -74,8 +74,8 @@ fn selected_challenger_does_not_get_a_second_controller_write() {
         .run_training_attempts_blocking(1)
         .expect("select challenger");
 
-    assert_eq!(state.0.borrow().gain, 0.5);
-    assert_eq!(state.0.borrow().apply_count, 2);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.5);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 2);
 }
 
 #[test]
@@ -98,14 +98,14 @@ fn rejected_promotion_restores_the_initial_release_candidate() {
         tuner.run_promotion_once_blocking().expect("run promotion"),
         PromotionDecision::RejectedNoImprovement { .. }
     ));
-    assert_eq!(state.0.borrow().gain, 0.0);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.0);
 }
 
 #[test]
 fn reconciliation_readback_failure_stops_before_the_next_candidate() {
     let directory = TestDirectory::new("reconciliation-readback-stops-search");
     let state = FakeHandle::new();
-    state.0.borrow_mut().bad_candidate_readback_on_apply = Some(3);
+    state.0.borrow_mut().vehicle.bad_candidate_readback_on_apply = Some(3);
     let mut tuner = open(
         directory.path(),
         state.clone(),
@@ -140,19 +140,19 @@ fn restart_restores_once_after_candidate_activation() {
         tuner.run_training_attempts_blocking(1).ok();
     }));
     assert!(stopped.is_err());
-    assert_eq!(state.0.borrow().gain, 0.5);
-    assert_eq!(state.0.borrow().apply_count, 2);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.5);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 2);
     drop(tuner);
     state.0.borrow_mut().panic_on_start = None;
 
     let resumed =
         open(directory.path(), state.clone(), strategy.clone(), 2.0).expect("resume tuner");
-    assert_eq!(state.0.borrow().gain, 0.0);
-    assert_eq!(state.0.borrow().apply_count, 3);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.0);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 3);
     drop(resumed);
 
     let reopened = open(directory.path(), state.clone(), strategy, 2.0).expect("reopen tuner");
-    assert_eq!(state.0.borrow().gain, 0.0);
-    assert_eq!(state.0.borrow().apply_count, 3);
+    assert_eq!(state.0.borrow().vehicle.gain, 0.0);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 3);
     drop(reopened);
 }

--- a/tools/flight-tune/tests/tuner/recovery_order.rs
+++ b/tools/flight-tune/tests/tuner/recovery_order.rs
@@ -1,0 +1,120 @@
+use flight_tune::{JournalEvent, TuneError};
+
+use super::open;
+use super::test_rig::{FakeHandle, SequenceStrategy, TestDirectory};
+
+#[test]
+fn recovery_contains_a_pending_run_before_transition_reauthorization() {
+    let (directory, state, strategy) = pending_challenger("recovery-before-reauthorization");
+    let stop_before = state.0.borrow().stop_count;
+    let cleanup_before = state.0.borrow().cleanup_count;
+    let lifecycle_before = state.0.borrow().lifecycle.len();
+    state.0.borrow_mut().transition.maximum_delta = Some(0.1);
+
+    let result = open(directory.path(), state.clone(), strategy.clone(), 2.0);
+    let Err(error) = result else {
+        panic!("changed transition behavior resumed the campaign");
+    };
+
+    assert!(matches!(error, TuneError::Adapter { .. }));
+    assert_eq!(state.0.borrow().stop_count, stop_before.wrapping_add(1));
+    assert_eq!(
+        state.0.borrow().cleanup_count,
+        cleanup_before.wrapping_add(1)
+    );
+    let lifecycle = state.0.borrow().lifecycle[lifecycle_before..].to_vec();
+    let stop_order = lifecycle
+        .iter()
+        .position(|action| action == "stop")
+        .expect("pending stop action");
+    let cleanup_order = lifecycle
+        .iter()
+        .position(|action| action == "cleanup")
+        .expect("pending cleanup action");
+    let authorization_order = lifecycle
+        .iter()
+        .position(|action| action == "authorize_transition")
+        .expect("transition reauthorization action");
+    assert!(stop_order < cleanup_order);
+    assert!(cleanup_order < authorization_order);
+    state.0.borrow_mut().transition.maximum_delta = None;
+    let stop_after_failure = state.0.borrow().stop_count;
+    let cleanup_after_failure = state.0.borrow().cleanup_count;
+    let resumed =
+        open(directory.path(), state.clone(), strategy, 2.0).expect("open contained campaign");
+    assert_eq!(state.0.borrow().stop_count, stop_after_failure);
+    assert_eq!(state.0.borrow().cleanup_count, cleanup_after_failure);
+    let quarantine = resumed
+        .journal()
+        .entries()
+        .iter()
+        .position(|entry| matches!(entry.event, JournalEvent::AttemptQuarantined { .. }))
+        .expect("quarantine event");
+    let cleanup = resumed
+        .journal()
+        .entries()
+        .iter()
+        .enumerate()
+        .skip(quarantine.wrapping_add(1))
+        .find_map(|(index, entry)| {
+            matches!(entry.event, JournalEvent::CleanupRecorded { .. }).then_some(index)
+        })
+        .expect("cleanup event");
+    assert!(quarantine < cleanup);
+}
+
+#[test]
+fn cleanup_failure_prevents_transition_reauthorization() {
+    let (directory, state, strategy) = pending_challenger("cleanup-failure-before-reauthorization");
+    let lifecycle_before = state.0.borrow().lifecycle.len();
+    let authorizations_before = state.0.borrow().transition.authorization_count;
+    state.0.borrow_mut().cleanup_fault.return_error();
+
+    let result = open(directory.path(), state.clone(), strategy, 2.0);
+    let Err(error) = result else {
+        panic!("cleanup failure resumed the campaign");
+    };
+
+    assert!(matches!(
+        error,
+        TuneError::InvalidState {
+            operation: "recover pending attempt",
+            ..
+        }
+    ));
+    assert_eq!(
+        state.0.borrow().transition.authorization_count,
+        authorizations_before
+    );
+    let lifecycle = state.0.borrow().lifecycle[lifecycle_before..].to_vec();
+    let stop_order = lifecycle
+        .iter()
+        .position(|action| action == "stop")
+        .expect("pending stop action");
+    let cleanup_order = lifecycle
+        .iter()
+        .position(|action| action == "cleanup")
+        .expect("pending cleanup action");
+    assert!(stop_order < cleanup_order);
+    assert!(
+        lifecycle
+            .iter()
+            .all(|action| action != "authorize_transition")
+    );
+}
+
+fn pending_challenger(label: &str) -> (TestDirectory, FakeHandle, SequenceStrategy) {
+    let directory = TestDirectory::new(label);
+    let state = FakeHandle::new();
+    state.0.borrow_mut().panic_on_prepare = Some(3);
+    let strategy = SequenceStrategy::new(vec![0.5]);
+    let mut tuner =
+        open(directory.path(), state.clone(), strategy.clone(), 2.0).expect("open tuner");
+    let stopped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tuner.run_training_attempts_blocking(1).ok();
+    }));
+    assert!(stopped.is_err());
+    drop(tuner);
+    state.0.borrow_mut().panic_on_prepare = None;
+    (directory, state, strategy)
+}

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -6,30 +6,33 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use flight_tune::{
-    AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, Digest, SampleEvent, ScenarioRef,
-    ScenarioStartReceipt, SessionChallenge, SimulatorBackend, SimulatorCapability,
+    AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, CandidateTransitionReceipt,
+    CandidateTransitionRequest, Digest, RunExecutionContext, RunPreparationReceipt, SampleEvent,
+    ScenarioRef, ScenarioStartReceipt, SessionChallenge, SimulatorBackend, SimulatorCapability,
     SimulatorSessionReceipt, SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample,
-    VehicleBinding, VehicleBindingReceipt,
+    TransitionBindingReceipt, VehicleBinding, VehicleBindingReceipt,
 };
 
+#[path = "test_rig/cleanup_fault.rs"]
+mod cleanup_fault;
 #[path = "test_rig/scoring.rs"]
 mod scoring;
+#[path = "test_rig/vehicle_state.rs"]
+mod vehicle_state;
 
+pub use cleanup_fault::FakeCleanupFault;
 #[allow(unused_imports)]
 pub use scoring::{
     EnvelopeGates, ObservedViews, QuadraticMetric, SequenceStrategy, assert_receipt_error,
     candidate, stage,
 };
+pub use vehicle_state::FakeVehicleState;
 
 #[derive(Debug, Default)]
 pub struct FakeState {
-    pub gain: f64,
-    pub active_candidate_digest: Option<Digest>,
+    pub vehicle: FakeVehicleState,
     pub open_session_count: usize,
     pub prepare_count: usize,
-    pub bind_count: usize,
-    pub ensure_count: usize,
-    pub apply_count: usize,
     pub start_count: usize,
     pub sample_count: usize,
     pub sample_poll_count: usize,
@@ -44,19 +47,31 @@ pub struct FakeState {
     pub metric_finish_count: usize,
     pub metric_cancel_count: usize,
     pub scenario_runs: Vec<(String, u64, f64)>,
+    pub transition: FakeTransitionState,
     pub lifecycle: Vec<String>,
     pub current_scenario: Option<ScenarioRef>,
     pub current_seed: u64,
     pub next_sequence: u64,
     pub panic_on_prepare: Option<usize>,
     pub panic_on_start: Option<usize>,
-    pub panic_on_cleanup: Option<usize>,
+    pub cleanup_fault: FakeCleanupFault,
     pub change_head_on_prepare: Option<PathBuf>,
-    pub bad_candidate_readback_on_ensure: Option<usize>,
-    pub bad_candidate_readback_on_apply: Option<usize>,
     pub bad_scenario_readback: bool,
     pub timeout_next_sample: bool,
     pub complete_without_sample: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct FakeTransitionState {
+    pub authorization_count: usize,
+    pub checks: Vec<(f64, f64)>,
+    pub maximum_delta: Option<f64>,
+    pub prepared_contexts: Vec<RunExecutionContext>,
+    pub started_contexts: Vec<RunExecutionContext>,
+    pub vehicle_contexts: Vec<RunExecutionContext>,
+    pub bad_preparation_intent: bool,
+    pub bad_start_intent: bool,
+    pub bad_vehicle_intent: bool,
 }
 
 #[derive(Clone)]
@@ -114,34 +129,56 @@ impl SimulatorBackend for FakeBackend {
 
     fn prepare_blocking(
         &mut self,
-        _capability: &SimulatorCapability,
+        capability: &SimulatorCapability,
+        context: &RunExecutionContext,
         scenario: &ScenarioRef,
-        seed: u64,
-    ) -> Result<(), AdapterError> {
+    ) -> Result<RunPreparationReceipt, AdapterError> {
+        let run_intent_digest = context
+            .digest()
+            .map_err(|error| AdapterError::new(error.to_string()))?;
         let mut state = self.state.0.borrow_mut();
         state.prepare_count = state.prepare_count.wrapping_add(1);
         state.lifecycle.push("prepare".to_owned());
+        state.transition.prepared_contexts.push(context.clone());
         if state.panic_on_prepare == Some(state.prepare_count) {
             panic!("simulated process stop after AttemptPrepared");
         }
         let head_change = state.change_head_on_prepare.take();
         state.current_scenario = Some(scenario.clone());
-        state.current_seed = seed;
+        state.current_seed = context.seed();
         state.next_sequence = 0;
+        let receipt_intent = if state.transition.bad_preparation_intent {
+            Digest::from_bytes([97; 32])
+        } else {
+            run_intent_digest
+        };
         drop(state);
         if let Some(root) = head_change {
             change_head_digest(&root);
         }
-        Ok(())
+        Ok(RunPreparationReceipt {
+            session_digest: capability.session_digest(),
+            run_intent_digest: receipt_intent,
+        })
     }
 
     fn start_blocking(
         &mut self,
         capability: &SimulatorCapability,
+        context: &RunExecutionContext,
     ) -> Result<ScenarioStartReceipt, AdapterError> {
+        let run_intent_digest = context
+            .digest()
+            .map_err(|error| AdapterError::new(error.to_string()))?;
         let mut state = self.state.0.borrow_mut();
         state.start_count = state.start_count.wrapping_add(1);
         state.lifecycle.push("start".to_owned());
+        if state.transition.prepared_contexts.last() != Some(context) {
+            return Err(AdapterError::new(
+                "started run intent differs from prepared run intent",
+            ));
+        }
+        state.transition.started_contexts.push(context.clone());
         if state.panic_on_start == Some(state.start_count) {
             panic!("simulated process stop after candidate activation");
         }
@@ -150,17 +187,23 @@ impl SimulatorBackend for FakeBackend {
             .clone()
             .ok_or_else(|| AdapterError::new("scenario was not prepared"))?;
         let seed = state.current_seed;
-        let gain = state.gain;
+        let gain = state.vehicle.gain;
         state.scenario_runs.push((scenario.id.clone(), seed, gain));
         let applied_scenario_digest = if state.bad_scenario_readback {
             Digest::from_bytes([98; 32])
         } else {
             scenario.digest
         };
+        let receipt_intent = if state.transition.bad_start_intent {
+            Digest::from_bytes([96; 32])
+        } else {
+            run_intent_digest
+        };
         Ok(ScenarioStartReceipt {
             session_digest: capability.session_digest(),
             applied_scenario_digest,
             seed,
+            run_intent_digest: receipt_intent,
         })
     }
 
@@ -184,7 +227,7 @@ impl SimulatorBackend for FakeBackend {
         Ok(SampleEvent::Sample(TelemetrySample {
             sequence,
             elapsed_ms: 10,
-            values: BTreeMap::from([("gain".to_owned(), state.gain)]),
+            values: BTreeMap::from([("gain".to_owned(), state.vehicle.gain)]),
         }))
     }
 
@@ -199,10 +242,7 @@ impl SimulatorBackend for FakeBackend {
         let mut state = self.state.0.borrow_mut();
         state.cleanup_count = state.cleanup_count.wrapping_add(1);
         state.lifecycle.push("cleanup".to_owned());
-        if state.panic_on_cleanup == Some(state.cleanup_count) {
-            panic!("simulated process stop after outcome publication");
-        }
-        Ok(())
+        state.cleanup_fault.finish(state.cleanup_count)
     }
 }
 
@@ -223,46 +263,111 @@ pub struct FakeVehicle {
 }
 
 impl SimulatorVehicleAdapter for FakeVehicle {
-    fn ensure_candidate_blocking(
+    fn authorize_candidate_transition(
+        &self,
+        request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        let source = candidate_gain(request.source())?;
+        let target = candidate_gain(request.target())?;
+        let mut state = self.state.0.borrow_mut();
+        state.transition.authorization_count = state.transition.authorization_count.wrapping_add(1);
+        state.lifecycle.push("authorize_transition".to_owned());
+        state.transition.checks.push((source, target));
+        if state
+            .transition
+            .maximum_delta
+            .is_some_and(|limit| (target - source).abs() > limit)
+        {
+            return Err(AdapterError::new(
+                "the candidate transition exceeds the vehicle adjacency limit",
+            ));
+        }
+        drop(state);
+        CandidateTransitionReceipt::authorized(request)
+            .map_err(|error| AdapterError::new(error.to_string()))
+    }
+
+    fn ensure_settled_candidate_blocking(
         &mut self,
         capability: &SimulatorCapability,
         candidate: &Candidate,
         candidate_digest: Digest,
     ) -> Result<CandidateReceipt, AdapterError> {
-        let gain = candidate
-            .parameters()
-            .get("gain")
-            .copied()
-            .ok_or_else(|| AdapterError::new("candidate has no gain"))?;
-        let mut state = self.state.0.borrow_mut();
-        state.ensure_count = state.ensure_count.wrapping_add(1);
-        let wrote_candidate = state.active_candidate_digest != Some(candidate_digest);
-        if wrote_candidate {
-            state.gain = gain;
-            state.active_candidate_digest = Some(candidate_digest);
-            state.apply_count = state.apply_count.wrapping_add(1);
-            state.lifecycle.push("apply".to_owned());
-        }
-        let bad_readback = state.bad_candidate_readback_on_ensure == Some(state.ensure_count)
-            || (wrote_candidate
-                && state.bad_candidate_readback_on_apply == Some(state.apply_count));
-        let readback = if bad_readback {
-            Digest::from_bytes([99; 32])
-        } else {
-            candidate_digest
-        };
-        Ok(CandidateReceipt {
-            session_digest: capability.session_digest(),
-            requested_digest: candidate_digest,
-            applied_digest: candidate_digest,
-            readback_digest: readback,
-        })
+        activate_candidate(&self.state, capability, candidate, candidate_digest, None)
     }
+
+    fn ensure_candidate_for_run_blocking(
+        &mut self,
+        capability: &SimulatorCapability,
+        context: &RunExecutionContext,
+        candidate: &Candidate,
+        candidate_digest: Digest,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        let run_intent_digest = context
+            .digest()
+            .map_err(|error| AdapterError::new(error.to_string()))?;
+        let mut state = self.state.0.borrow_mut();
+        state.transition.vehicle_contexts.push(context.clone());
+        let receipt_intent = if state.transition.bad_vehicle_intent {
+            Digest::from_bytes([95; 32])
+        } else {
+            run_intent_digest
+        };
+        drop(state);
+        activate_candidate(
+            &self.state,
+            capability,
+            candidate,
+            candidate_digest,
+            Some(receipt_intent),
+        )
+    }
+}
+
+fn activate_candidate(
+    handle: &FakeHandle,
+    capability: &SimulatorCapability,
+    candidate: &Candidate,
+    candidate_digest: Digest,
+    run_intent_digest: Option<Digest>,
+) -> Result<CandidateReceipt, AdapterError> {
+    let gain = candidate
+        .parameters()
+        .get("gain")
+        .copied()
+        .ok_or_else(|| AdapterError::new("candidate has no gain"))?;
+    let mut state = handle.0.borrow_mut();
+    state.vehicle.ensure_count = state.vehicle.ensure_count.wrapping_add(1);
+    let wrote_candidate = state.vehicle.active_candidate_digest != Some(candidate_digest);
+    if wrote_candidate {
+        state.vehicle.gain = gain;
+        state.vehicle.active_candidate_digest = Some(candidate_digest);
+        state.vehicle.apply_count = state.vehicle.apply_count.wrapping_add(1);
+        state.lifecycle.push("apply".to_owned());
+    }
+    let bad_readback = state.vehicle.bad_candidate_readback_on_ensure
+        == Some(state.vehicle.ensure_count)
+        || (wrote_candidate
+            && state.vehicle.bad_candidate_readback_on_apply == Some(state.vehicle.apply_count));
+    let readback = if bad_readback {
+        Digest::from_bytes([99; 32])
+    } else {
+        candidate_digest
+    };
+    Ok(CandidateReceipt {
+        session_digest: capability.session_digest(),
+        requested_digest: candidate_digest,
+        applied_digest: candidate_digest,
+        readback_digest: readback,
+        run_intent_digest,
+    })
 }
 
 pub struct FakeFactory {
     state: FakeHandle,
     identity: ArtifactIdentity,
+    transition_validator: ArtifactIdentity,
+    adjacency_policy_digest: Digest,
     allow_binding: bool,
 }
 
@@ -271,6 +376,8 @@ impl FakeFactory {
         Self {
             state,
             identity: identity("vehicle", "fake-controller-v1"),
+            transition_validator: identity("transition-validator", "fake-validator-v1"),
+            adjacency_policy_digest: digest_text("fake-adjacency-policy-v1"),
             allow_binding: true,
         }
     }
@@ -279,8 +386,22 @@ impl FakeFactory {
         Self {
             state,
             identity: identity("vehicle", "hardware-like-controller"),
+            transition_validator: identity("transition-validator", "hardware-validator-v1"),
+            adjacency_policy_digest: digest_text("hardware-adjacency-policy-v1"),
             allow_binding: false,
         }
+    }
+
+    pub fn with_transition_validator(state: FakeHandle, content: &str) -> Self {
+        let mut factory = Self::new(state);
+        factory.transition_validator = identity("transition-validator", content);
+        factory
+    }
+
+    pub fn with_adjacency_policy(state: FakeHandle, content: &str) -> Self {
+        let mut factory = Self::new(state);
+        factory.adjacency_policy_digest = digest_text(content);
+        factory
     }
 }
 
@@ -291,32 +412,56 @@ impl SimulatorVehicleFactory for FakeFactory {
         &self.identity
     }
 
+    fn transition_validator_identity(&self) -> &ArtifactIdentity {
+        &self.transition_validator
+    }
+
+    fn adjacency_policy_digest(&self) -> Digest {
+        self.adjacency_policy_digest
+    }
+
     fn bind_blocking(
         self,
         capability: &SimulatorCapability,
     ) -> Result<VehicleBinding<Self::Adapter>, AdapterError> {
         let mut state = self.state.0.borrow_mut();
-        state.bind_count = state.bind_count.wrapping_add(1);
+        state.vehicle.bind_count = state.vehicle.bind_count.wrapping_add(1);
         drop(state);
         if !self.allow_binding {
             return Err(AdapterError::new(
                 "hardware-like adapter has no simulator session binding",
             ));
         }
-        capability.bind_vehicle(
+        let transition = TransitionBindingReceipt::new(
+            capability.session_digest(),
+            self.transition_validator,
+            self.adjacency_policy_digest,
+        )?;
+        capability.bind_vehicle_with_transition(
             FakeVehicle { state: self.state },
             VehicleBindingReceipt {
                 session_digest: capability.session_digest(),
                 vehicle_digest: self.identity.digest,
             },
+            transition,
         )
     }
+}
+
+fn candidate_gain(candidate: &Candidate) -> Result<f64, AdapterError> {
+    candidate
+        .parameters()
+        .get("gain")
+        .copied()
+        .ok_or_else(|| AdapterError::new("candidate has no gain"))
 }
 
 fn identity(id: &str, content: &str) -> ArtifactIdentity {
     ArtifactIdentity::from_text(id, content).expect("artifact identity")
 }
-
+fn digest_text(content: &str) -> Digest {
+    identity("digest", content).digest
+}
 pub struct TestDirectory {
     path: PathBuf,
 }

--- a/tools/flight-tune/tests/tuner/test_rig/cleanup_fault.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/cleanup_fault.rs
@@ -1,0 +1,35 @@
+use flight_tune::AdapterError;
+
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub enum FakeCleanupFault {
+    #[default]
+    None,
+    PanicOn(usize),
+    ReturnError,
+}
+
+#[allow(dead_code)]
+impl FakeCleanupFault {
+    pub fn panic_on(&mut self, occurrence: usize) {
+        *self = Self::PanicOn(occurrence);
+    }
+
+    pub fn return_error(&mut self) {
+        *self = Self::ReturnError;
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::None;
+    }
+
+    pub(super) fn finish(&self, occurrence: usize) -> Result<(), AdapterError> {
+        match self {
+            Self::PanicOn(expected) if *expected == occurrence => {
+                panic!("simulated process stop after outcome publication");
+            }
+            Self::ReturnError => Err(AdapterError::new("simulated cleanup failure")),
+            Self::None | Self::PanicOn(_) => Ok(()),
+        }
+    }
+}

--- a/tools/flight-tune/tests/tuner/test_rig/scoring.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/scoring.rs
@@ -205,7 +205,7 @@ impl ProposalStrategy for SequenceStrategy {
 pub fn candidate(gain: f64) -> Candidate {
     Candidate::new(
         CandidateLineage {
-            schema: "aviate-candidate-v1".to_owned(),
+            schema: "generic-candidate-v1".to_owned(),
             base_preset_digest: Digest::from_bytes([7; 32]),
             plant_digest: Digest::from_bytes([8; 32]),
         },

--- a/tools/flight-tune/tests/tuner/test_rig/vehicle_state.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/vehicle_state.rs
@@ -1,0 +1,12 @@
+use flight_tune::Digest;
+
+#[derive(Debug, Default)]
+pub struct FakeVehicleState {
+    pub gain: f64,
+    pub active_candidate_digest: Option<Digest>,
+    pub bind_count: usize,
+    pub ensure_count: usize,
+    pub apply_count: usize,
+    pub bad_candidate_readback_on_ensure: Option<usize>,
+    pub bad_candidate_readback_on_apply: Option<usize>,
+}

--- a/tools/flight-tune/tests/tuner/transition_authorization.rs
+++ b/tools/flight-tune/tests/tuner/transition_authorization.rs
@@ -1,0 +1,499 @@
+use std::fs;
+
+use flight_tune::{AttemptRole, Digest, JournalEntry, JournalEvent, TuneError, Tuner};
+use serde::Serialize;
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::test_rig::{
+    EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
+    TestDirectory, candidate, stage,
+};
+
+#[path = "transition_authorization/durable_tree.rs"]
+mod durable_tree;
+
+use durable_tree::DurableTreeSnapshot;
+
+#[test]
+fn a_non_aviate_adapter_authorizes_each_training_transition() {
+    let directory = TestDirectory::new("generic-transition-adapter");
+    let state = FakeHandle::new();
+    let mut tuner = open(
+        &directory,
+        state.clone(),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5, 0.75]),
+    )
+    .expect("open tuner");
+
+    tuner
+        .run_training_attempts_blocking(2)
+        .expect("run two transitions");
+
+    assert_eq!(state.0.borrow().transition.authorization_count, 2);
+    assert_eq!(
+        state.0.borrow().transition.checks,
+        vec![(0.0, 0.5), (0.5, 0.75)]
+    );
+    assert_eq!(transition_entries(&tuner).count(), 2);
+}
+
+#[test]
+fn later_incumbent_rejection_has_no_external_side_effect() {
+    let directory = TestDirectory::new("later-incumbent-adjacency");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().transition.maximum_delta = Some(0.25);
+    let mut tuner = Tuner::open_or_resume(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.5),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state.clone()),
+        SequenceStrategy::new(vec![0.7, 0.3]),
+    )
+    .expect("open tuner");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("accept adjacent transition");
+    let before = ExternalMutations::capture(&state);
+    let journal_length = tuner.journal().entries().len();
+    let durable_before = DurableTreeSnapshot::capture(directory.path());
+
+    let error = tuner
+        .run_training_attempts_blocking(1)
+        .expect_err("reject nonadjacent transition");
+
+    assert!(matches!(error, TuneError::Adapter { .. }));
+    assert_eq!(ExternalMutations::capture(&state), before);
+    assert_eq!(tuner.journal().entries().len(), journal_length);
+    durable_before.assert_unchanged(directory.path());
+    assert_eq!(
+        state.0.borrow().transition.checks,
+        vec![(0.5, 0.7), (0.7, 0.3)]
+    );
+}
+
+#[test]
+fn one_transition_reference_closes_the_execution_chain() {
+    let directory = TestDirectory::new("transition-execution-chain");
+    let state = FakeHandle::new();
+    let mut tuner = open(
+        &directory,
+        state.clone(),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("open tuner");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run challenger");
+
+    let entries = tuner.journal().entries();
+    let (authorization_index, reference) = entries
+        .iter()
+        .enumerate()
+        .find_map(|(index, entry)| match &entry.event {
+            JournalEvent::CandidateTransitionAuthorized { receipt, .. } => {
+                Some((index, receipt.reference()))
+            }
+            _ => None,
+        })
+        .expect("transition authorization");
+    let (attempt_index, candidate_digest) = entries
+        .iter()
+        .enumerate()
+        .find_map(|(index, entry)| match &entry.event {
+            JournalEvent::AttemptPrepared {
+                role: AttemptRole::TrainingChallenger { .. },
+                candidate,
+                transition,
+                ..
+            } => {
+                assert_eq!(*transition, Some(reference));
+                Some((index, *candidate))
+            }
+            _ => None,
+        })
+        .expect("challenger attempt");
+    let runs = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| match &entry.event {
+            JournalEvent::RunPrepared {
+                context,
+                run_intent_digest,
+                ..
+            } if matches!(context.role(), AttemptRole::TrainingChallenger { .. }) => {
+                Some((index, context, *run_intent_digest))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(!runs.is_empty());
+    assert!(authorization_index < attempt_index);
+    let durable_contexts = entries
+        .iter()
+        .filter_map(|entry| match &entry.event {
+            JournalEvent::RunPrepared { context, .. } => Some(context.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    for (run_index, context, run_intent_digest) in runs {
+        assert!(attempt_index < run_index);
+        assert_eq!(context.candidate_digest(), candidate_digest);
+        assert_eq!(context.transition_authorization(), Some(reference));
+        assert_eq!(context.digest().expect("context digest"), run_intent_digest);
+    }
+    assert_observed_contexts(&state, &durable_contexts);
+}
+
+#[test]
+fn preparation_intent_mismatch_stops_vehicle_and_start_mutation() {
+    assert_intent_mismatch(IntentFault::Preparation);
+}
+
+#[test]
+fn vehicle_intent_mismatch_stops_start_mutation() {
+    assert_intent_mismatch(IntentFault::Vehicle);
+}
+
+#[test]
+fn start_intent_mismatch_stops_sampling() {
+    assert_intent_mismatch(IntentFault::Start);
+}
+
+#[test]
+fn resume_consumes_the_exact_saved_target_without_reproposal() {
+    let directory = TestDirectory::new("resume-saved-transition");
+    let state = FakeHandle::new();
+    let strategy = SequenceStrategy::new(vec![0.5]);
+    let views = strategy.views.clone();
+    let mut tuner = open(
+        &directory,
+        state.clone(),
+        FakeFactory::new(state.clone()),
+        strategy.clone(),
+    )
+    .expect("open tuner");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("create complete transition");
+    let authorization = tuner
+        .journal()
+        .entries()
+        .iter()
+        .find(|entry| {
+            matches!(
+                entry.event,
+                JournalEvent::CandidateTransitionAuthorized { .. }
+            )
+        })
+        .cloned()
+        .expect("saved transition authorization");
+    let reference = match &authorization.event {
+        JournalEvent::CandidateTransitionAuthorized { receipt, .. } => receipt.reference(),
+        _ => panic!("saved event is not an authorization"),
+    };
+    let authorization_digest = document_digest(&authorization);
+    drop(tuner);
+    write_head(directory.path(), authorization_digest);
+    let proposals_before_resume = views.borrow().len();
+
+    let mut resumed = open(
+        &directory,
+        state.clone(),
+        FakeFactory::new(state.clone()),
+        strategy,
+    )
+    .expect("resume tuner");
+    resumed
+        .run_training_attempts_blocking(1)
+        .expect("consume saved transition");
+
+    assert_eq!(views.borrow().len(), proposals_before_resume);
+    assert_eq!(
+        resumed
+            .journal()
+            .training_incumbent()
+            .expect("training incumbent"),
+        candidate(0.5)
+    );
+    assert_eq!(state.0.borrow().transition.checks.len(), 2);
+    assert_resumed_reference(&resumed, reference);
+}
+
+fn assert_resumed_reference(
+    tuner: &super::TestTuner,
+    reference: flight_tune::CandidateTransitionReference,
+) {
+    let entries = tuner.journal().entries();
+    assert_eq!(
+        entries
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry.event,
+                    JournalEvent::CandidateTransitionAuthorized { .. }
+                )
+            })
+            .count(),
+        1
+    );
+    let attempt_reference = entries.iter().find_map(|entry| match &entry.event {
+        JournalEvent::AttemptPrepared {
+            role: AttemptRole::TrainingChallenger { .. },
+            transition,
+            ..
+        } => *transition,
+        _ => None,
+    });
+    assert_eq!(attempt_reference, Some(reference));
+    let run_references = entries
+        .iter()
+        .filter_map(|entry| match &entry.event {
+            JournalEvent::RunPrepared { context, .. }
+                if matches!(context.role(), AttemptRole::TrainingChallenger { .. }) =>
+            {
+                context.transition_authorization()
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(!run_references.is_empty());
+    assert!(run_references.iter().all(|saved| *saved == reference));
+}
+
+#[test]
+fn changed_validator_or_policy_cannot_resume() {
+    for changed_factory in [
+        FakeFactory::with_transition_validator as fn(FakeHandle, &str) -> FakeFactory,
+        FakeFactory::with_adjacency_policy,
+    ] {
+        let directory = TestDirectory::new("changed-transition-runtime");
+        let state = FakeHandle::new();
+        let tuner = open(
+            &directory,
+            state.clone(),
+            FakeFactory::new(state.clone()),
+            SequenceStrategy::new(Vec::new()),
+        )
+        .expect("open tuner");
+        drop(tuner);
+        let before = OpenMutations::capture(&state);
+
+        let result = open(
+            &directory,
+            state.clone(),
+            changed_factory(state.clone(), "changed-transition-runtime"),
+            SequenceStrategy::new(Vec::new()),
+        );
+
+        assert!(matches!(result, Err(TuneError::JournalSessionMismatch)));
+        assert_eq!(OpenMutations::capture(&state), before);
+    }
+}
+
+fn open(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    factory: FakeFactory,
+    strategy: SequenceStrategy,
+) -> Result<super::TestTuner, TuneError> {
+    Tuner::open_or_resume(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        factory,
+        EnvelopeGates::tracked(2.0, state.clone()),
+        QuadraticMetric::new(state),
+        strategy,
+    )
+}
+
+fn transition_entries(tuner: &super::TestTuner) -> impl Iterator<Item = &JournalEntry> {
+    tuner.journal().entries().iter().filter(|entry| {
+        matches!(
+            entry.event,
+            JournalEvent::CandidateTransitionAuthorized { .. }
+        )
+    })
+}
+
+fn challenger_contexts(
+    contexts: &[flight_tune::RunExecutionContext],
+) -> Vec<flight_tune::RunExecutionContext> {
+    contexts
+        .iter()
+        .filter(|context| matches!(context.role(), AttemptRole::TrainingChallenger { .. }))
+        .cloned()
+        .collect()
+}
+
+fn assert_observed_contexts(state: &FakeHandle, durable: &[flight_tune::RunExecutionContext]) {
+    let observed = &state.0.borrow().transition;
+    assert_eq!(observed.prepared_contexts, durable);
+    assert_eq!(observed.vehicle_contexts, durable);
+    assert_eq!(observed.started_contexts, durable);
+}
+
+#[derive(Clone, Copy)]
+enum IntentFault {
+    Preparation,
+    Vehicle,
+    Start,
+}
+
+fn assert_intent_mismatch(fault: IntentFault) {
+    let directory = TestDirectory::new("run-intent-mismatch");
+    let state = FakeHandle::new();
+    let mut tuner = open(
+        &directory,
+        state.clone(),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("open tuner");
+    tuner
+        .run_training_attempts_blocking(0)
+        .expect("run safe baseline");
+    let before = ExternalMutations::capture(&state);
+    {
+        let mut state = state.0.borrow_mut();
+        match fault {
+            IntentFault::Preparation => state.transition.bad_preparation_intent = true,
+            IntentFault::Vehicle => state.transition.bad_vehicle_intent = true,
+            IntentFault::Start => state.transition.bad_start_intent = true,
+        }
+    }
+
+    let error = tuner
+        .run_training_attempts_blocking(1)
+        .expect_err("reject mismatched run intent receipt");
+
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+    let observed = state.0.borrow();
+    assert_eq!(observed.sample_poll_count, before.sample_poll);
+    assert_eq!(observed.cleanup_count, before.cleanup.wrapping_add(1));
+    let prepared_challengers = challenger_contexts(&observed.transition.prepared_contexts);
+    assert_eq!(prepared_challengers.len(), 1);
+    assert!(prepared_challengers[0].transition_authorization().is_some());
+    match fault {
+        IntentFault::Preparation => {
+            assert!(challenger_contexts(&observed.transition.vehicle_contexts).is_empty());
+            assert!(challenger_contexts(&observed.transition.started_contexts).is_empty());
+            assert_eq!(observed.stop_count, before.stop);
+        }
+        IntentFault::Vehicle => {
+            assert!(challenger_contexts(&observed.transition.started_contexts).is_empty());
+            assert_eq!(observed.stop_count, before.stop);
+        }
+        IntentFault::Start => {
+            assert_eq!(
+                challenger_contexts(&observed.transition.started_contexts).len(),
+                1
+            );
+            assert_eq!(observed.stop_count, before.stop.wrapping_add(1));
+        }
+    }
+    drop(observed);
+    assert_quarantine_before_cleanup(tuner.journal().entries());
+}
+
+fn assert_quarantine_before_cleanup(entries: &[JournalEntry]) {
+    let quarantine = entries
+        .iter()
+        .position(|entry| matches!(entry.event, JournalEvent::AttemptQuarantined { .. }))
+        .expect("quarantine event");
+    let cleanup = entries
+        .iter()
+        .enumerate()
+        .skip(quarantine.wrapping_add(1))
+        .find_map(|(index, entry)| {
+            matches!(entry.event, JournalEvent::CleanupRecorded { .. }).then_some(index)
+        })
+        .expect("cleanup event");
+    assert!(quarantine < cleanup);
+}
+
+fn document_digest(value: &impl Serialize) -> Digest {
+    let bytes = serde_json::to_vec(value).expect("encode journal entry");
+    Digest::from_bytes(Sha256::digest(bytes).into())
+}
+
+fn write_head(root: &std::path::Path, digest: Digest) {
+    let bytes =
+        serde_json::to_vec(&serde_json::json!({ "digest": digest })).expect("encode journal head");
+    fs::write(root.join("HEAD.json"), bytes).expect("rewind journal head");
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExternalMutations {
+    prepare: usize,
+    ensure: usize,
+    apply: usize,
+    start: usize,
+    sample_poll: usize,
+    stop: usize,
+    cleanup: usize,
+    gate_begin: usize,
+    gate_evaluate: usize,
+    gate_finish: usize,
+    gate_cancel: usize,
+    metric_begin: usize,
+    metric_observe: usize,
+    metric_finish: usize,
+    metric_cancel: usize,
+}
+
+impl ExternalMutations {
+    fn capture(handle: &FakeHandle) -> Self {
+        let state = handle.0.borrow();
+        Self {
+            prepare: state.prepare_count,
+            ensure: state.vehicle.ensure_count,
+            apply: state.vehicle.apply_count,
+            start: state.start_count,
+            sample_poll: state.sample_poll_count,
+            stop: state.stop_count,
+            cleanup: state.cleanup_count,
+            gate_begin: state.gate_begin_count,
+            gate_evaluate: state.gate_evaluate_count,
+            gate_finish: state.gate_finish_count,
+            gate_cancel: state.gate_cancel_count,
+            metric_begin: state.metric_begin_count,
+            metric_observe: state.metric_observe_count,
+            metric_finish: state.metric_finish_count,
+            metric_cancel: state.metric_cancel_count,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OpenMutations {
+    open_session: usize,
+    bind: usize,
+    authorize_transition: usize,
+    external: ExternalMutations,
+}
+
+impl OpenMutations {
+    fn capture(handle: &FakeHandle) -> Self {
+        let state = handle.0.borrow();
+        let open_session = state.open_session_count;
+        let bind = state.vehicle.bind_count;
+        let authorize_transition = state.transition.authorization_count;
+        drop(state);
+        Self {
+            open_session,
+            bind,
+            authorize_transition,
+            external: ExternalMutations::capture(handle),
+        }
+    }
+}

--- a/tools/flight-tune/tests/tuner/transition_authorization/durable_tree.rs
+++ b/tools/flight-tune/tests/tuner/transition_authorization/durable_tree.rs
@@ -1,0 +1,42 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct DurableTreeSnapshot {
+    directories: BTreeSet<PathBuf>,
+    files: BTreeMap<PathBuf, Vec<u8>>,
+}
+
+impl DurableTreeSnapshot {
+    pub(super) fn capture(root: &Path) -> Self {
+        let mut snapshot = Self {
+            directories: BTreeSet::new(),
+            files: BTreeMap::new(),
+        };
+        snapshot.capture_directory(root, root);
+        snapshot
+    }
+
+    pub(super) fn assert_unchanged(&self, root: &Path) {
+        assert_eq!(&Self::capture(root), self);
+    }
+
+    fn capture_directory(&mut self, root: &Path, directory: &Path) {
+        for entry in fs::read_dir(directory).expect("read durable tree") {
+            let entry = entry.expect("read durable tree entry");
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("make durable path relative")
+                .to_path_buf();
+            if path.is_dir() {
+                self.directories.insert(relative);
+                self.capture_directory(root, &path);
+            } else {
+                self.files
+                    .insert(relative, fs::read(&path).expect("read durable object"));
+            }
+        }
+    }
+}

--- a/tools/flight-tune/tests/tuner/transition_chain_tamper.rs
+++ b/tools/flight-tune/tests/tuner/transition_chain_tamper.rs
@@ -1,0 +1,245 @@
+use std::fs;
+
+use flight_tune::{
+    AttemptRole, CandidateTransitionReceipt, CandidateTransitionReference, Digest, JournalEntry,
+    JournalEvent, RunExecutionContext, TuneError,
+};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::open;
+use super::test_rig::{FakeHandle, SequenceStrategy, TestDirectory};
+
+#[test]
+fn replay_rejects_a_coherent_forged_transition_receipt_chain() {
+    let (directory, state, strategy, mut entries) = campaign("forged-transition-receipt");
+    let index = entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                entry.event,
+                JournalEvent::CandidateTransitionAuthorized { .. }
+            )
+        })
+        .expect("transition authorization");
+    let replacement = match &entries[index].event {
+        JournalEvent::CandidateTransitionAuthorized {
+            attempt_index,
+            reason,
+            candidate,
+            receipt,
+        } => JournalEvent::CandidateTransitionAuthorized {
+            attempt_index: *attempt_index,
+            reason: reason.clone(),
+            candidate: *candidate,
+            receipt: forged_receipt(receipt),
+        },
+        _ => panic!("selected event is not a transition authorization"),
+    };
+    entries[index].event = replacement;
+    rewrite_chain(directory.path(), &mut entries, index);
+
+    assert_replay_rejects_without_external_action(&directory, &state, strategy);
+}
+
+#[test]
+fn replay_rejects_a_coherent_forged_run_context_chain() {
+    let (directory, state, strategy, mut entries) = campaign("forged-run-context");
+    let forged_reference = entries
+        .iter()
+        .find_map(|entry| match &entry.event {
+            JournalEvent::CandidateTransitionAuthorized { receipt, .. } => {
+                Some(forged_receipt(receipt).reference())
+            }
+            _ => None,
+        })
+        .expect("transition receipt");
+    let index = entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.event,
+                JournalEvent::RunPrepared { context, .. }
+                    if matches!(context.role(), AttemptRole::TrainingChallenger { .. })
+            )
+        })
+        .expect("challenger run preparation");
+    entries[index].event = forged_run_event(&entries[index].event, forged_reference);
+    rewrite_chain(directory.path(), &mut entries, index);
+
+    assert_replay_rejects_without_external_action(&directory, &state, strategy);
+}
+
+fn campaign(
+    label: &str,
+) -> (
+    TestDirectory,
+    FakeHandle,
+    SequenceStrategy,
+    Vec<JournalEntry>,
+) {
+    let directory = TestDirectory::new(label);
+    let state = FakeHandle::new();
+    let strategy = SequenceStrategy::new(vec![0.5]);
+    let mut tuner =
+        open(directory.path(), state.clone(), strategy.clone(), 2.0).expect("open tuner");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("create challenger evidence");
+    let entries = tuner.journal().entries().to_vec();
+    drop(tuner);
+    (directory, state, strategy, entries)
+}
+
+fn forged_receipt(receipt: &CandidateTransitionReceipt) -> CandidateTransitionReceipt {
+    let mut document = serde_json::to_value(receipt).expect("encode transition receipt");
+    document["adjacency_policy_digest"] = digest_value(91);
+    document["planning_context_digest"] = digest_value(92);
+    let forged: CandidateTransitionReceipt =
+        serde_json::from_value(document.clone()).expect("decode forged transition receipt");
+    document["receipt_digest"] = serde_json::to_value(
+        forged
+            .recompute_digest()
+            .expect("recompute forged transition receipt"),
+    )
+    .expect("encode forged receipt digest");
+    let receipt: CandidateTransitionReceipt =
+        serde_json::from_value(document).expect("decode coherent forged transition receipt");
+    assert_eq!(
+        receipt.recompute_digest().expect("verify forged receipt"),
+        receipt.receipt_digest()
+    );
+    receipt
+}
+
+fn forged_run_event(event: &JournalEvent, reference: CandidateTransitionReference) -> JournalEvent {
+    let JournalEvent::RunPrepared {
+        trial_id,
+        run_index,
+        context,
+        ..
+    } = event
+    else {
+        panic!("selected event is not a run preparation");
+    };
+    let context = forged_context(context, reference);
+    let run_intent_digest = context.digest().expect("recompute forged run intent");
+    JournalEvent::RunPrepared {
+        trial_id: *trial_id,
+        run_index: *run_index,
+        context,
+        run_intent_digest,
+    }
+}
+
+fn forged_context(
+    context: &RunExecutionContext,
+    reference: CandidateTransitionReference,
+) -> RunExecutionContext {
+    let mut document = serde_json::to_value(context).expect("encode run context");
+    document["transition_authorization"] =
+        serde_json::to_value(reference).expect("encode forged transition reference");
+    serde_json::from_value(document).expect("decode coherent forged run context")
+}
+
+fn rewrite_chain(root: &std::path::Path, entries: &mut [JournalEntry], changed: usize) {
+    let mut previous = None;
+    for (index, entry) in entries.iter_mut().enumerate() {
+        entry.previous = previous;
+        let bytes = serde_json::to_vec(entry).expect("encode rebuilt journal entry");
+        let digest = digest_bytes(&bytes);
+        if index >= changed {
+            let path = root.join("entries").join(format!("{digest}.json"));
+            fs::write(&path, bytes).expect("write rebuilt journal entry");
+            set_private_file(&path);
+        }
+        previous = Some(digest);
+    }
+    let head = previous.expect("rebuilt journal head");
+    let bytes = serde_json::to_vec(&serde_json::json!({ "digest": head }))
+        .expect("encode rebuilt journal head");
+    fs::write(root.join("HEAD.json"), bytes).expect("write rebuilt journal head");
+}
+
+#[cfg(unix)]
+fn set_private_file(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .expect("set private journal object mode");
+}
+
+#[cfg(not(unix))]
+fn set_private_file(_path: &std::path::Path) {}
+
+fn assert_replay_rejects_without_external_action(
+    directory: &TestDirectory,
+    state: &FakeHandle,
+    strategy: SequenceStrategy,
+) {
+    let before = ActionSnapshot::capture(state);
+    let result = open(directory.path(), state.clone(), strategy, 2.0);
+    assert!(matches!(result, Err(TuneError::InvalidJournal { .. })));
+    assert_eq!(ActionSnapshot::capture(state), before);
+}
+
+fn digest_value(byte: u8) -> serde_json::Value {
+    serde_json::to_value(Digest::from_bytes([byte; 32])).expect("encode digest")
+}
+
+fn digest_bytes(bytes: &[u8]) -> Digest {
+    Digest::from_bytes(Sha256::digest(bytes).into())
+}
+
+#[derive(Debug, PartialEq)]
+struct ActionSnapshot {
+    gain: f64,
+    active_candidate: Option<Digest>,
+    open_session: usize,
+    bind: usize,
+    authorize: usize,
+    prepare: usize,
+    ensure: usize,
+    apply: usize,
+    start: usize,
+    sample_poll: usize,
+    stop: usize,
+    cleanup: usize,
+    gate_begin: usize,
+    gate_evaluate: usize,
+    gate_finish: usize,
+    gate_cancel: usize,
+    metric_begin: usize,
+    metric_observe: usize,
+    metric_finish: usize,
+    metric_cancel: usize,
+    lifecycle: Vec<String>,
+}
+
+impl ActionSnapshot {
+    fn capture(handle: &FakeHandle) -> Self {
+        let state = handle.0.borrow();
+        Self {
+            gain: state.vehicle.gain,
+            active_candidate: state.vehicle.active_candidate_digest,
+            open_session: state.open_session_count,
+            bind: state.vehicle.bind_count,
+            authorize: state.transition.authorization_count,
+            prepare: state.prepare_count,
+            ensure: state.vehicle.ensure_count,
+            apply: state.vehicle.apply_count,
+            start: state.start_count,
+            sample_poll: state.sample_poll_count,
+            stop: state.stop_count,
+            cleanup: state.cleanup_count,
+            gate_begin: state.gate_begin_count,
+            gate_evaluate: state.gate_evaluate_count,
+            gate_finish: state.gate_finish_count,
+            gate_cancel: state.gate_cancel_count,
+            metric_begin: state.metric_begin_count,
+            metric_observe: state.metric_observe_count,
+            metric_finish: state.metric_finish_count,
+            metric_cancel: state.metric_cancel_count,
+            lifecycle: state.lifecycle.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Closes #455.

## Summary

- Add a strict candidate transition request, receipt, and reference.
- Store each authorization and run intent before simulator or vehicle mutation.
- Bind backend preparation, vehicle activation, and scenario start to one durable RunExecutionContext.
- Recompute frozen identities during replay and reject changed or forged chains.
- Contain and clean a pending run before transition reauthorization.

## Scope

This PR adds the simulator-neutral contract. It does not add the production Aviate handoff. Issue #469 owns that work after #498.

## Validation

- Full workspace format, clippy, all-target tests, strict documentation, and release build passed.
- flight-tune passed 66 unit tests and 33 integration tests.
- All repository quality gates passed.
- wasm, thumb, dependency boundary, web build, 38 Node, and 4 Chromium checks passed.
- Three independent reviews found no P0, P1, or P2 defect.

SIM / NOT FOR FLIGHT.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #527 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #525
<!-- GitButler Footer Boundary Bottom -->