### PR TITLE
Start each vehicle on its own control-feel law

### DIFF
--- a/hosts/session-host/src/runtime/aviate_profile.rs
+++ b/hosts/session-host/src/runtime/aviate_profile.rs
@@ -113,6 +113,21 @@ mod tests {
                 "alia250-shaped-agile-v1.json",
                 pilotage_control_feel::FeelMode::Agile,
             ),
+            // The X500's, which the launcher names by path for a gazebo
+            // session. This host is what reads that path, so a file it
+            // cannot load is a session that does not start.
+            (
+                "x500-shaped-precision-v1.json",
+                pilotage_control_feel::FeelMode::Precision,
+            ),
+            (
+                "x500-shaped-balanced-v1.json",
+                pilotage_control_feel::FeelMode::Balanced,
+            ),
+            (
+                "x500-shaped-agile-v1.json",
+                pilotage_control_feel::FeelMode::Agile,
+            ),
         ] {
             let path = profiles.join(file);
             let loaded = control_feel_from_env_blocking(

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -137,6 +137,66 @@ mod tests {
     use super::backend_for;
     use crate::error::XtaskError;
 
+    /// Every Aviate backend must name a control-feel law belonging to the
+    /// aircraft it actually launches.
+    ///
+    /// The host cannot check this for itself: both backends hand it
+    /// `--adapter aviate`, so absent an explicit profile it loads one
+    /// compiled-in default for every vehicle. That default is the Alia's,
+    /// and the X500 flew on it — a law qualified for another airframe.
+    /// The launcher is the only component that knows which aircraft it
+    /// started, so this is where the binding is asserted.
+    #[test]
+    fn each_aviate_backend_names_its_own_vehicles_control_feel() {
+        use super::SessionContext;
+        use crate::cli::Profile;
+        use std::path::{Path, PathBuf};
+
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root is two levels above tools/xtask")
+            .to_path_buf();
+        let ctx = SessionContext {
+            repo_root: repo_root.clone(),
+            host_port: 4433,
+            viewer_port: 8080,
+            profile: Profile::Simulation,
+            log_dir: repo_root.join("target/xtask-sim"),
+            lan: false,
+        };
+
+        // Backend name -> the substring its profile's file name must carry.
+        for (backend, vehicle) in [("aviate-gz", "x500"), ("aviate-xplane", "alia250")] {
+            let env = backend_for(backend).expect("known backend").host_env(&ctx);
+            let (_, value) = env
+                .iter()
+                .find(|(key, _)| key == "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{backend} names no control-feel law, so the host falls back to \
+                         whatever single default it was compiled with"
+                    )
+                });
+
+            let path = PathBuf::from(value);
+            let name = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or_default();
+            assert!(
+                name.starts_with(vehicle),
+                "{backend} launches {vehicle} but names the control-feel law {name:?}, \
+                 which is another aircraft's"
+            );
+            assert!(
+                path.is_file(),
+                "{backend} names a control-feel law at {} that does not exist",
+                path.display()
+            );
+        }
+    }
+
     #[test]
     fn backend_selection_fails_closed() {
         assert_eq!(backend_for("aviate").expect("known").name(), "aviate-gz");

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -111,6 +111,14 @@ pub trait SimBackend {
     fn reset(&self, repo_root: &std::path::Path) -> Result<(), XtaskError>;
 }
 
+/// The variable the host reads a control-feel law from.
+///
+/// A bare string on this side and another on the host's
+/// (`runtime/adapter_launch.rs`); the two crates share no dependency that
+/// could hold one constant, so renaming either alone leaves this silently
+/// naming nothing.
+const CONTROL_FEEL_ENV: &str = "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE";
+
 /// Names the control-feel law a simulated vehicle flies on.
 ///
 /// The host cannot choose this for itself: every Aviate backend hands it
@@ -118,18 +126,41 @@ pub trait SimBackend {
 /// for all of them. The launcher is the only component that knows which
 /// aircraft it started.
 ///
-/// Returns NOTHING for a physical session. There the host refuses a named
-/// law outright — `AviatePhysicalControlFeelOverride` — because a real
-/// aircraft must fly the qualified compiled-in artifact rather than one a
-/// launcher pointed at, so naming one does not merely go unused, it fails
-/// the session. Encoded once here so a backend added later cannot
-/// reintroduce that by writing the variable itself.
+/// Yields NOTHING in two cases, both of which would do harm rather than
+/// nothing:
+///
+/// * An operator who already names a law keeps it. Stage environment is
+///   applied ON TOP of what the launcher inherited, so a value written
+///   here replaces theirs with no diagnostic anywhere — the vehicle would
+///   fly a law nobody chose and nothing would say so. A tuning session
+///   pointing at its own artifact is exactly this path.
+/// * A physical session gets no name at all. The host refuses one
+///   outright there — `AviatePhysicalControlFeelOverride` — because a real
+///   aircraft must fly the qualified compiled-in artifact rather than one
+///   a launcher pointed at, so naming one does not go unused, it fails the
+///   session.
+///
+/// Both live here rather than in each backend so a backend added later
+/// cannot reintroduce either by writing the variable itself.
 pub(crate) fn control_feel_env(ctx: &SessionContext, profile_path: &str) -> Vec<(String, String)> {
-    if ctx.profile == Profile::Physical {
+    control_feel_env_given(ctx, profile_path, std::env::var_os(CONTROL_FEEL_ENV))
+}
+
+/// The decision itself, with the operator's value passed in.
+///
+/// Reading the environment is the caller's job so this stays a function of
+/// its arguments: the alternative is a test that sets a process-wide
+/// variable, and the workspace forbids the `unsafe` that now requires.
+fn control_feel_env_given(
+    ctx: &SessionContext,
+    profile_path: &str,
+    ambient: Option<std::ffi::OsString>,
+) -> Vec<(String, String)> {
+    if ctx.profile == Profile::Physical || ambient.is_some() {
         return Vec::new();
     }
     vec![(
-        "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
+        CONTROL_FEEL_ENV.to_owned(),
         ctx.repo_root.join(profile_path).display().to_string(),
     )]
 }
@@ -164,11 +195,15 @@ mod tests {
     /// aircraft it actually launches.
     ///
     /// The host cannot check this for itself: both backends hand it
-    /// `--adapter aviate`, so absent an explicit profile it loads one
-    /// compiled-in default for every vehicle. That default is the Alia's,
-    /// and the X500 flew on it — a law qualified for another airframe.
-    /// The launcher is the only component that knows which aircraft it
-    /// started, so this is where the binding is asserted.
+    /// `--adapter aviate`, so absent an explicit name it loads one
+    /// compiled-in default for every vehicle — a law qualified for a
+    /// different airframe. The launcher is the only component that knows
+    /// which aircraft it started, so this is where the binding is asserted.
+    ///
+    /// Asserts a SINGLE entry, not merely a correct one. Stage environment
+    /// is applied in order and the last write wins, so a correct entry
+    /// followed by a stale one launches the stale law — which a shared
+    /// "common host env" helper appending a default is enough to produce.
     #[test]
     fn each_aviate_backend_names_its_own_vehicles_control_feel() {
         use super::SessionContext;
@@ -192,17 +227,24 @@ mod tests {
         // Backend name -> the substring its profile's file name must carry.
         for (backend, vehicle) in [("aviate-gz", "x500"), ("aviate-xplane", "alia250")] {
             let env = backend_for(backend).expect("known backend").host_env(&ctx);
-            let (_, value) = env
+            let named: Vec<_> = env
                 .iter()
-                .find(|(key, _)| key == "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE")
-                .unwrap_or_else(|| {
-                    panic!(
-                        "{backend} names no control-feel law, so the host falls back to \
-                         whatever single default it was compiled with"
-                    )
-                });
+                .filter(|(key, _)| key == super::CONTROL_FEEL_ENV)
+                .collect();
+            assert!(
+                !named.is_empty(),
+                "{backend} names no control-feel law, so the host falls back to \
+                 whatever single default it was compiled with"
+            );
+            assert_eq!(
+                named.len(),
+                1,
+                "{backend} names the control-feel law {} times; the last write is the \
+                 one that reaches the host, so a correct entry does not make this safe",
+                named.len()
+            );
 
-            let path = PathBuf::from(value);
+            let path = PathBuf::from(named[0].1.clone());
             let name = path
                 .file_name()
                 .and_then(std::ffi::OsStr::to_str)
@@ -245,12 +287,61 @@ mod tests {
             };
             let env = backend_for(backend).expect("known backend").host_env(&ctx);
             assert!(
-                !env.iter()
-                    .any(|(key, _)| key == "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE"),
+                !env.iter().any(|(key, _)| key == super::CONTROL_FEEL_ENV),
                 "{backend} names a control-feel law for a physical session, which the \
                  host refuses with AviatePhysicalControlFeelOverride"
             );
         }
+    }
+
+    /// An operator who already names a law keeps it.
+    ///
+    /// Stage environment is applied on top of what the launcher inherited,
+    /// so a value written by a backend REPLACES the operator's with no
+    /// diagnostic on either side: the vehicle flies a law nobody chose and
+    /// nothing says so. That is the same failure this whole change exists
+    /// to prevent, pointed the other way.
+    ///
+    #[test]
+    fn an_operators_own_control_feel_law_is_not_replaced() {
+        use super::{CONTROL_FEEL_ENV, SessionContext, control_feel_env_given};
+        use crate::cli::Profile;
+        use std::path::PathBuf;
+
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let ctx = SessionContext {
+            repo_root: repo_root.clone(),
+            host_port: 4433,
+            viewer_port: 8080,
+            profile: Profile::Simulation,
+            log_dir: repo_root.join("target/xtask-sim"),
+            lan: false,
+        };
+
+        let operators = std::ffi::OsString::from("/tmp/an-operators-own-tuning.json");
+        assert!(
+            control_feel_env_given(
+                &ctx,
+                "adapters/aviate/profiles/x500-shaped-balanced-v1.json",
+                Some(operators)
+            )
+            .is_empty(),
+            "the launcher writes {CONTROL_FEEL_ENV} over the operator's own value, which \
+             the child inherits and would otherwise have used"
+        );
+
+        // The same call with nothing ambient must still bind, or the guard
+        // above would be satisfied by never naming a law at all.
+        assert_eq!(
+            control_feel_env_given(
+                &ctx,
+                "adapters/aviate/profiles/x500-shaped-balanced-v1.json",
+                None
+            )
+            .len(),
+            1,
+            "with no operator value the launcher must name the vehicle's law"
+        );
     }
 
     #[test]

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -111,6 +111,29 @@ pub trait SimBackend {
     fn reset(&self, repo_root: &std::path::Path) -> Result<(), XtaskError>;
 }
 
+/// Names the control-feel law a simulated vehicle flies on.
+///
+/// The host cannot choose this for itself: every Aviate backend hands it
+/// `--adapter aviate`, so absent a name it loads one compiled-in default
+/// for all of them. The launcher is the only component that knows which
+/// aircraft it started.
+///
+/// Returns NOTHING for a physical session. There the host refuses a named
+/// law outright — `AviatePhysicalControlFeelOverride` — because a real
+/// aircraft must fly the qualified compiled-in artifact rather than one a
+/// launcher pointed at, so naming one does not merely go unused, it fails
+/// the session. Encoded once here so a backend added later cannot
+/// reintroduce that by writing the variable itself.
+pub(crate) fn control_feel_env(ctx: &SessionContext, profile_path: &str) -> Vec<(String, String)> {
+    if ctx.profile == Profile::Physical {
+        return Vec::new();
+    }
+    vec![(
+        "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
+        ctx.repo_root.join(profile_path).display().to_string(),
+    )]
+}
+
 /// Resolves `--fc` to a backend, fail-closed on unknown names.
 ///
 /// # Errors
@@ -193,6 +216,39 @@ mod tests {
                 path.is_file(),
                 "{backend} names a control-feel law at {} that does not exist",
                 path.display()
+            );
+        }
+    }
+
+    /// A physical session must be handed NO control-feel law.
+    ///
+    /// The host does not ignore one there, it refuses the session
+    /// outright, so a launcher that names a law unconditionally turns a
+    /// working `--profile physical` run into a startup failure. Naming
+    /// the law per vehicle is what introduced that risk, and this is the
+    /// test that keeps it from coming back.
+    #[test]
+    fn a_physical_session_is_handed_no_control_feel_law() {
+        use super::SessionContext;
+        use crate::cli::Profile;
+        use std::path::PathBuf;
+
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        for backend in ["aviate-gz", "aviate-xplane"] {
+            let ctx = SessionContext {
+                repo_root: repo_root.clone(),
+                host_port: 4433,
+                viewer_port: 8080,
+                profile: Profile::Physical,
+                log_dir: repo_root.join("target/xtask-sim"),
+                lan: false,
+            };
+            let env = backend_for(backend).expect("known backend").host_env(&ctx);
+            assert!(
+                !env.iter()
+                    .any(|(key, _)| key == "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE"),
+                "{backend} names a control-feel law for a physical session, which the \
+                 host refuses with AviatePhysicalControlFeelOverride"
             );
         }
     }

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -21,10 +21,6 @@ const WORLD_NAME: &str = "aviate_sitl";
 /// in the session.
 const CONTROL_FEEL_PROFILE: &str = "adapters/aviate/profiles/x500-shaped-balanced-v1.json";
 
-fn control_feel_profile_path(repo_root: &Path) -> PathBuf {
-    repo_root.join(CONTROL_FEEL_PROFILE)
-}
-
 /// The Aviate + Gazebo SITL backend.
 #[derive(Debug)]
 pub struct AviateGz;
@@ -39,27 +35,16 @@ impl SimBackend for AviateGz {
     }
 
     fn host_env(&self, ctx: &SessionContext) -> Vec<(String, String)> {
-        vec![
+        let mut env = vec![
             // The camera sidecar discovers gz topics through this.
             ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
             // A sensor's topic is scoped by the world it is in. The
             // launcher is what chooses the world, so it is what says which
             // one rather than the host guessing a name.
             ("PILOTAGE_GZ_WORLD".to_owned(), WORLD_NAME.to_owned()),
-            // The host cannot tell one Aviate vehicle from another: both
-            // backends hand it `--adapter aviate` and the only other thing
-            // it learns is the session profile. Absent this it falls back
-            // to a single compiled-in default, which is the ALIA's law —
-            // so the X500 flew on another aircraft's control feel. The
-            // launcher is what picks the vehicle, so it is what says which
-            // law that vehicle has.
-            (
-                "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
-                control_feel_profile_path(&ctx.repo_root)
-                    .display()
-                    .to_string(),
-            ),
-        ]
+        ];
+        env.extend(super::control_feel_env(ctx, CONTROL_FEEL_PROFILE));
+        env
     }
 
     fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -17,8 +17,11 @@ const WORLD_NAME: &str = "aviate_sitl";
 /// The X500's own control-feel law.
 ///
 /// Balanced rather than agile or precision: it is the law an operator who
-/// has asked for nothing should get, and the other two remain selectable
-/// in the session.
+/// has asked for nothing should get.
+///
+/// This binds the law the vehicle STARTS on. A runtime feel-mode request
+/// does not reach these files — it shapes one from the mode alone — so
+/// asking for another mode moves the vehicle off its fitted law.
 const CONTROL_FEEL_PROFILE: &str = "adapters/aviate/profiles/x500-shaped-balanced-v1.json";
 
 /// The Aviate + Gazebo SITL backend.

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -14,6 +14,17 @@ use crate::readiness::{Readiness, stage_log};
 const WORLD: &str = "sim/worlds/x500_flightdeck.sdf";
 const WORLD_NAME: &str = "aviate_sitl";
 
+/// The X500's own control-feel law.
+///
+/// Balanced rather than agile or precision: it is the law an operator who
+/// has asked for nothing should get, and the other two remain selectable
+/// in the session.
+const CONTROL_FEEL_PROFILE: &str = "adapters/aviate/profiles/x500-shaped-balanced-v1.json";
+
+fn control_feel_profile_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(CONTROL_FEEL_PROFILE)
+}
+
 /// The Aviate + Gazebo SITL backend.
 #[derive(Debug)]
 pub struct AviateGz;
@@ -27,7 +38,7 @@ impl SimBackend for AviateGz {
         "aviate"
     }
 
-    fn host_env(&self, _ctx: &SessionContext) -> Vec<(String, String)> {
+    fn host_env(&self, ctx: &SessionContext) -> Vec<(String, String)> {
         vec![
             // The camera sidecar discovers gz topics through this.
             ("GZ_IP".to_owned(), "127.0.0.1".to_owned()),
@@ -35,6 +46,19 @@ impl SimBackend for AviateGz {
             // launcher is what chooses the world, so it is what says which
             // one rather than the host guessing a name.
             ("PILOTAGE_GZ_WORLD".to_owned(), WORLD_NAME.to_owned()),
+            // The host cannot tell one Aviate vehicle from another: both
+            // backends hand it `--adapter aviate` and the only other thing
+            // it learns is the session profile. Absent this it falls back
+            // to a single compiled-in default, which is the ALIA's law —
+            // so the X500 flew on another aircraft's control feel. The
+            // launcher is what picks the vehicle, so it is what says which
+            // law that vehicle has.
+            (
+                "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
+                control_feel_profile_path(&ctx.repo_root)
+                    .display()
+                    .to_string(),
+            ),
         ]
     }
 

--- a/tools/xtask/src/backend/aviate_xplane.rs
+++ b/tools/xtask/src/backend/aviate_xplane.rs
@@ -61,7 +61,7 @@ impl SimBackend for AviateXPlane {
     }
 
     fn host_env(&self, ctx: &SessionContext) -> Vec<(String, String)> {
-        vec![
+        let mut env = vec![
             (
                 "PILOTAGE_AVIATE_PROFILE".to_owned(),
                 ctx.profile.as_env_value().to_owned(),
@@ -73,20 +73,15 @@ impl SimBackend for AviateXPlane {
                 "xplane-plugin".to_owned(),
             ),
             (
-                "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
-                ctx.repo_root
-                    .join(CONTROL_FEEL_PROFILE)
-                    .display()
-                    .to_string(),
-            ),
-            (
                 "PILOTAGE_RESET_CMD".to_owned(),
                 ctx.repo_root
                     .join("scripts/reset-xplane-sim.sh")
                     .display()
                     .to_string(),
             ),
-        ]
+        ];
+        env.extend(super::control_feel_env(ctx, CONTROL_FEEL_PROFILE));
+        env
     }
 
     fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {

--- a/tools/xtask/src/backend/aviate_xplane.rs
+++ b/tools/xtask/src/backend/aviate_xplane.rs
@@ -38,6 +38,15 @@ fn airframe_key() -> String {
     std::env::var("PILOTAGE_XPLANE_AIRFRAME").unwrap_or_else(|_| AIRFRAME.to_owned())
 }
 
+/// The Alia's own control-feel law.
+///
+/// This is the same artifact the host falls back to when nothing names
+/// one, but it reaches the Alia there by being the single compiled-in
+/// default rather than by being this aircraft's law — which is how the
+/// X500 came to fly on it too. Named here, each backend answers for its
+/// own vehicle.
+const CONTROL_FEEL_PROFILE: &str = "adapters/aviate/profiles/alia250-legacy-v1.json";
+
 /// The Aviate + X-Plane SITL backend.
 #[derive(Debug)]
 pub struct AviateXPlane;
@@ -62,6 +71,13 @@ impl SimBackend for AviateXPlane {
             (
                 "PILOTAGE_AVIATE_CAMERA".to_owned(),
                 "xplane-plugin".to_owned(),
+            ),
+            (
+                "PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE".to_owned(),
+                ctx.repo_root
+                    .join(CONTROL_FEEL_PROFILE)
+                    .display()
+                    .to_string(),
             ),
             (
                 "PILOTAGE_RESET_CMD".to_owned(),

--- a/tools/xtask/src/backend/aviate_xplane.rs
+++ b/tools/xtask/src/backend/aviate_xplane.rs
@@ -38,13 +38,17 @@ fn airframe_key() -> String {
     std::env::var("PILOTAGE_XPLANE_AIRFRAME").unwrap_or_else(|_| AIRFRAME.to_owned())
 }
 
-/// The Alia's own control-feel law.
+/// The law the Alia starts on.
 ///
-/// This is the same artifact the host falls back to when nothing names
-/// one, but it reaches the Alia there by being the single compiled-in
-/// default rather than by being this aircraft's law — which is how the
-/// X500 came to fly on it too. Named here, each backend answers for its
-/// own vehicle.
+/// The same artifact the host falls back to when nothing names one, but it
+/// reaches the Alia there by being the single compiled-in default rather
+/// than by being this aircraft's — which is the property that lets it
+/// reach every OTHER vehicle too. Named here, each backend answers for
+/// what it launches.
+///
+/// This is the compatibility law, not a fitted one: it belongs to no
+/// airframe, and `alia250-shaped-*` exist beside it. Moving to one of
+/// those changes what the aircraft does and wants a flight behind it.
 const CONTROL_FEEL_PROFILE: &str = "adapters/aviate/profiles/alia250-legacy-v1.json";
 
 /// The Aviate + X-Plane SITL backend.


### PR DESCRIPTION
## What shipped

`hosts/session-host/src/runtime/aviate_profile.rs` picks the control-feel artifact with no vehicle in the decision:

```rust
None => ValidatedFlightFeelProfile::from_json_str(ALIA250_DEFAULT_CONTROL_FEEL_JSON)
```

Both backends hand the host `--adapter aviate`, so it cannot tell the vehicles apart. Absent an override every session loaded that one compiled-in default — the Alia's law. **The X500 in gazebo started on it**, confirmed in its own logs:

```
aviate-gz    (x500): feel_profile_id=alia250-legacy-v1
aviate-xplane(Alia): feel_profile_id=alia250-legacy-v1
```

Three shaped X500 laws were already in `adapters/aviate/profiles/` with nothing to select them, and the override the host reads already existed. Only the wiring was missing.

## Why the launcher

Independently confirmed during review: the host hardcodes `HOST_VEHICLE: VehicleId::new(1)` for every adapter, and nothing in the Aviate adapter's production code, the link, or the FC handshake carries an airframe identity the host could switch on. Deriving it host-side needs new Aviate-side plumbing. The launcher is the only component that knows which aircraft it started.

## Scope — this binds the START law only

A runtime feel-mode request does **not** reach these files. `request_feel_mode_under` builds `FlightFeelProfile::shaped(mode)` — not `shaped_for(airframe, mode)`, which production code never calls — and `shaped` hardcodes `alia250-shaped-{mode}-v1` with unfitted numbers.

So the X500 starts on its fitted law and moves off it the moment an operator touches the feel control. My own verification session shows exactly that:

```
2  alia250-shaped-agile-v1
2  alia250-shaped-balanced-v1
2  alia250-shaped-precision-v1
```

This is a pre-existing hole in the adapter, not introduced here, and this PR does not fix it — `request_feel_mode` cannot be fixed from the launcher. Stated so the binding is not read as more durable than it is. Follow-up: carry airframe identity to the adapter so `shaped_for` is reachable.

## Corrections to an earlier version of this PR

An earlier body claimed this fixed `pose Missing` / `velocity Missing` / `MeasurementUnavailable`. **That claim was wrong and has been removed.**

The decisive fact: `pose Missing` and `velocity Missing` are literals in the BROWSER — `clients/web/telemetry-display.js:43` and `:49` — and appear zero times in any Rust source. The table quoted the web client rendering a null field, which is in no position to know which artifact the host loaded.

Host-side, those fields come from `planar_projection`, gated on attitude and kinematics freshness within `WITHHOLD_AFTER`, an estimator-status observation having been published, skew coherence, and the FC's velocity valid bit — every input a field of `LinkState`, fed by MAVLink from the FC. The control-feel profile is installed on the UPLINK, the outbound command path. It never writes `LinkState` and never participates in sampling.

The third row was the same cause again: `apply_flight` returns `MeasurementUnavailable` on a missing pose BEFORE reaching `answer_feel_requests`, so all three rows were one condition printed three times.

Both runs also loaded a valid artifact through the identical validator, and a rejected one would have exited the host at startup — no session at all, rather than a session with degraded telemetry.

Worst of all, the PR contradicted itself: it argued the feel layer shapes command into setpoint and so cannot explain divergence with nothing commanded, then four paragraphs earlier claimed it explained missing measurements. Measurement availability is upstream of the feel layer and on the opposite direction of flow.

Likely confounds between the two sessions: estimator warm-up or FC bring-up timing, a `source_epoch` mismatch after a sim reset, or simply a different Aviate binary — #538 and #539 landed immediately before this branch.

The provenance argument stands on its own and is the whole justification.

## Two defects this PR introduced, both fixed here

1. **`--profile physical` regression** (`d5a3429e`). The host does not ignore a named law there — it refuses the session with `AviatePhysicalControlFeelOverride`. `aviate-gz` is the only backend without a `plan()` profile gate, so that was a live working path that would have become a startup failure. `aviate-xplane` was never exposed.

2. **Clobbering the operator's own law** (`a4eafa61`). Stage env is applied on top of the inherited environment, so writing the key replaced an operator's `PILOTAGE_AVIATE_CONTROL_FEEL_PROFILE` with no diagnostic anywhere — the same "law nobody chose" failure, pointed the other way, and the path a tuning session uses. Now defers to an ambient value, as `RUST_LOG` and `PILOTAGE_XPLANE_AIRFRAME` already do.

## Guardrails — all three verified fail-before

- `each_aviate_backend_names_its_own_vehicles_control_feel` — each backend names a law that exists and belongs to the aircraft it launches. Asserts **exactly one** entry: env applies in order and the last write wins, so a correct entry followed by a stale one launches the stale law. Review demonstrated that mutation surviving the first version; it now fails with `names the control-feel law 2 times`.
- `a_physical_session_is_handed_no_control_feel_law`
- `an_operators_own_control_feel_law_is_not_replaced` — and asserts the no-ambient case still binds, so it cannot be satisfied by never naming a law.

The host-side loader test now covers all six shipped laws, not just the three Alia ones.

## Known residual

The env key is a bare string in two crates that share no dependency, so renaming it host-side leaves the launcher naming nothing while the tests stay green. Noted in a comment at the constant; closing it properly wants a shared crate.

Also: naming the Alia's file converts a compiled-in guarantee into a runtime file read, so a missing file now yields `AviateControlFeelRead` where it previously could not fail. The Alia stays on the compatibility law — which belongs to no airframe — deliberately, because moving it to `alia250-shaped-*` changes what the aircraft does and wants a flight behind it.

## Checks

`fmt --check` clean, `clippy -p xtask --all-targets -D warnings` zero, `rustdoc -D broken_intra_doc_links` clean, 73/73 xtask tests, host profile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APxgrXXpfmivZa2JqANHNr
