### PR TITLE
Produce the X-Plane runtime handshake as its own xtask command

### DIFF
--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -236,6 +236,21 @@ struct BackendEntry {
     make: fn() -> Box<dyn SimBackend>,
 }
 
+/// Where the sibling Aviate checkout lives: `AVIATE_DIR`, else
+/// `../Aviate` next to this repository. A directory convention, never a
+/// source dependency.
+fn aviate_dir(repo_root: &std::path::Path) -> PathBuf {
+    std::env::var_os("AVIATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root.join("../Aviate"))
+}
+
+/// The Alia X-Plane simulator-model preset inside the Aviate checkout —
+/// the one document every handshake producer must agree on.
+fn alia_xplane_preset(repo_root: &std::path::Path) -> PathBuf {
+    aviate_dir(repo_root).join("presets/alia250-xplane.toml")
+}
+
 /// Produces the Alia X-Plane runtime handshake without launching a
 /// session, for harnesses that run the flight controller themselves.
 /// Blocks until the trial plugin inside X-Plane states its own identity,
@@ -251,10 +266,7 @@ pub(crate) fn produce_xplane_handshake_blocking(
     out_dir: &std::path::Path,
 ) -> Result<PathBuf, XtaskError> {
     let root = xplane_simulator::xplane_root()?;
-    let aviate = std::env::var_os("AVIATE_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| repo_root.join("../Aviate"));
-    xplane_handshake::produce_blocking(&root, &aviate.join("presets/alia250-xplane.toml"), out_dir)
+    xplane_handshake::produce_blocking(&root, &alia_xplane_preset(repo_root), out_dir)
 }
 
 /// Resolves `--fc` to a backend, fail-closed on unknown names.

--- a/tools/xtask/src/backend.rs
+++ b/tools/xtask/src/backend.rs
@@ -236,6 +236,27 @@ struct BackendEntry {
     make: fn() -> Box<dyn SimBackend>,
 }
 
+/// Produces the Alia X-Plane runtime handshake without launching a
+/// session, for harnesses that run the flight controller themselves.
+/// Blocks until the trial plugin inside X-Plane states its own identity,
+/// exactly as a session launch does — the run is bound to the simulator
+/// that is actually running, not to one a caller claimed was.
+///
+/// # Errors
+///
+/// Returns a typed [`XtaskError`] when X-Plane is not reachable, the
+/// plugins do not verify, or the handshake cannot be written.
+pub(crate) fn produce_xplane_handshake_blocking(
+    repo_root: &std::path::Path,
+    out_dir: &std::path::Path,
+) -> Result<PathBuf, XtaskError> {
+    let root = xplane_simulator::xplane_root()?;
+    let aviate = std::env::var_os("AVIATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root.join("../Aviate"));
+    xplane_handshake::produce_blocking(&root, &aviate.join("presets/alia250-xplane.toml"), out_dir)
+}
+
 /// Resolves `--fc` to a backend, fail-closed on unknown names.
 ///
 /// # Errors

--- a/tools/xtask/src/backend/aviate_gz.rs
+++ b/tools/xtask/src/backend/aviate_gz.rs
@@ -2,7 +2,7 @@
 //! code — headless gz with the Aviate plugin, then the SITL FC over the
 //! versioned shm block, each gated on its own readiness signal.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use super::{SessionContext, SimBackend, Stage};
 use crate::error::XtaskError;
@@ -53,7 +53,7 @@ impl SimBackend for AviateGz {
     }
 
     fn plan(&self, ctx: &SessionContext) -> Result<Vec<Stage>, XtaskError> {
-        plan_with_aviate_dir(ctx, &aviate_dir(&ctx.repo_root))
+        plan_with_aviate_dir(ctx, &super::aviate_dir(&ctx.repo_root))
     }
 
     fn stale_process_patterns(&self) -> Vec<&'static str> {
@@ -80,15 +80,6 @@ impl SimBackend for AviateGz {
             })
         }
     }
-}
-
-/// Where the sibling Aviate checkout lives: `AVIATE_DIR`, else
-/// `../Aviate` next to this repository. A directory convention, never a
-/// source dependency.
-fn aviate_dir(repo_root: &Path) -> PathBuf {
-    std::env::var_os("AVIATE_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| repo_root.join("../Aviate"))
 }
 
 /// `PATH` for spawned tools, with Homebrew's prefix appended when it

--- a/tools/xtask/src/backend/aviate_xplane.rs
+++ b/tools/xtask/src/backend/aviate_xplane.rs
@@ -11,7 +11,7 @@
 //! dials the host. That is what makes the gimbal scope real here: the
 //! adapter aims a rendered view, not a servo.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use super::xplane_simulator::{
     airframe_for, ensure_xplane_plugins_blocking, prepare_xplane_runtime_blocking,
@@ -102,7 +102,7 @@ impl SimBackend for AviateXPlane {
         let airframe = airframe_for(Some(&airframe_key()))?;
         let root = xplane_root()?;
         validate_xplane_install(&root, airframe)?;
-        let aviate = aviate_dir(&ctx.repo_root);
+        let aviate = super::aviate_dir(&ctx.repo_root);
         let binary = aviate.join(APP_BINARY);
         if !binary.is_file() {
             return Err(XtaskError::MissingArtifact {
@@ -119,7 +119,7 @@ impl SimBackend for AviateXPlane {
         // not to one a launcher claimed was.
         let handshake = super::xplane_handshake::produce_blocking(
             &root,
-            &aviate.join("presets/alia250-xplane.toml"),
+            &super::alia_xplane_preset(&ctx.repo_root),
             &ctx.log_dir,
         )?;
         Ok(vec![Stage {
@@ -162,7 +162,7 @@ impl SimBackend for AviateXPlane {
         //
         // The paths are taken now and owned by the returned work, so it can
         // wait for the simulator without holding the runtime thread.
-        let preset = aviate_dir(&ctx.repo_root).join("presets/alia250-xplane.toml");
+        let preset = super::alia_xplane_preset(&ctx.repo_root);
         let log_dir = ctx.log_dir.clone();
         Some(Box::new(move || {
             let root = xplane_root()?;
@@ -222,7 +222,7 @@ impl SimBackend for AviateXPlane {
             // path; a checkout resolved through AVIATE_DIR would
             // silently escape a hardcoded pattern and the reset latch
             // would never clear.
-            .env("AVIATE_DIR", aviate_dir(repo_root))
+            .env("AVIATE_DIR", super::aviate_dir(repo_root))
             .status()
             .map_err(|source| XtaskError::Io {
                 context: "running the X-Plane reset script",
@@ -237,15 +237,6 @@ impl SimBackend for AviateXPlane {
             })
         }
     }
-}
-
-/// Where the Aviate checkout lives: `AVIATE_DIR`, else `../Aviate` next
-/// to this repository. A directory convention, never a source
-/// dependency.
-fn aviate_dir(repo_root: &Path) -> PathBuf {
-    std::env::var_os("AVIATE_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| repo_root.join("../Aviate"))
 }
 
 #[cfg(test)]

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -1,4 +1,5 @@
-//! Argument parsing for the xtask entry point: `sim`, `reset`, `help`.
+//! Argument parsing for the xtask entry point: `sim`, `reset`,
+//! `handshake`, `help`.
 
 use crate::error::XtaskError;
 
@@ -92,7 +93,7 @@ pub fn parse_args(args: &[String]) -> Result<Command, XtaskError> {
 }
 
 fn parse_handshake(args: &[String]) -> Result<std::path::PathBuf, XtaskError> {
-    let mut out_dir = std::path::PathBuf::from("target/xtask-sim");
+    let mut out_dir = std::path::PathBuf::from(crate::session::SESSION_DIR);
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -63,6 +63,8 @@ pub enum Command {
     Sim(SimArgs),
     /// Reset the running simulation world and FC of the named backend.
     Reset(String),
+    /// Produce the Alia X-Plane runtime handshake into a directory.
+    Handshake(std::path::PathBuf),
     /// Print usage.
     Help,
 }
@@ -81,11 +83,35 @@ pub fn parse_args(args: &[String]) -> Result<Command, XtaskError> {
     match command.as_str() {
         "sim" => Ok(Command::Sim(parse_sim(rest)?)),
         "reset" => Ok(Command::Reset(parse_reset(rest)?)),
+        "handshake" => Ok(Command::Handshake(parse_handshake(rest)?)),
         "help" | "--help" | "-h" => Ok(Command::Help),
         other => Err(XtaskError::Usage {
-            message: format!("unknown command {other:?} (expected sim, reset, or help)"),
+            message: format!("unknown command {other:?} (expected sim, reset, handshake, or help)"),
         }),
     }
+}
+
+fn parse_handshake(args: &[String]) -> Result<std::path::PathBuf, XtaskError> {
+    let mut out_dir = std::path::PathBuf::from("target/xtask-sim");
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--out-dir" => {
+                out_dir =
+                    std::path::PathBuf::from(iter.next().ok_or_else(|| XtaskError::Usage {
+                        message: "--out-dir requires a value".to_owned(),
+                    })?);
+            }
+            other => {
+                return Err(XtaskError::Usage {
+                    message: format!(
+                        "unknown handshake argument {other:?} (expected --out-dir <dir>)"
+                    ),
+                });
+            }
+        }
+    }
+    Ok(out_dir)
 }
 
 fn parse_reset(args: &[String]) -> Result<String, XtaskError> {
@@ -198,6 +224,15 @@ commands:
 
       --fc <name>          FC backend (default: aviate)
 
+  handshake [options]
+      Produce the Alia X-Plane runtime handshake document and print its
+      path, without launching a session. For harnesses that run the
+      flight controller themselves; X-Plane must be running with the
+      trial plugin loaded.
+
+      --out-dir <dir>      directory to write into (default:
+                           target/xtask-sim)
+
   help
       Print this help text.";
 
@@ -228,16 +263,19 @@ mod tests {
     fn help_groups_each_command_once_and_matches_parser_defaults() {
         let sim_heading = "  sim [options]\n";
         let reset_heading = "  reset [options]\n";
+        let handshake_heading = "  handshake [options]\n";
         let help_heading = "  help\n";
 
-        for heading in [sim_heading, reset_heading, help_heading] {
+        for heading in [sim_heading, reset_heading, handshake_heading, help_heading] {
             assert_eq!(USAGE.matches(heading).count(), 1, "heading {heading:?}");
         }
 
         let sim_start = USAGE.find(sim_heading).expect("sim heading");
         let reset_start = USAGE.find(reset_heading).expect("reset heading");
+        let handshake_start = USAGE.find(handshake_heading).expect("handshake heading");
         let help_start = USAGE.find(help_heading).expect("help heading");
-        assert!(sim_start < reset_start && reset_start < help_start);
+        assert!(sim_start < reset_start && reset_start < handshake_start);
+        assert!(handshake_start < help_start);
 
         let sim_help = &USAGE[sim_start..reset_start];
         assert!(sim_help.contains("aviate-gz (alias aviate, default)"));
@@ -249,10 +287,36 @@ mod tests {
         assert!(sim_help.contains("--no-open"));
         assert!(sim_help.contains("--lan"));
 
-        let reset_help = &USAGE[reset_start..help_start];
+        let reset_help = &USAGE[reset_start..handshake_start];
         assert!(reset_help.contains("--fc <name>"));
         assert!(reset_help.contains("default: aviate"));
         assert!(!reset_help.contains("--profile"));
+
+        let handshake_help = &USAGE[handshake_start..help_start];
+        assert!(handshake_help.contains("--out-dir <dir>"));
+        assert!(handshake_help.contains("target/xtask-sim"));
+    }
+
+    #[test]
+    fn handshake_out_dir_parses_and_malformed_flags_fail_closed() {
+        assert_eq!(
+            parse_args(&args(&["handshake"])).expect("default handshake parses"),
+            Command::Handshake(std::path::PathBuf::from("target/xtask-sim"))
+        );
+        assert_eq!(
+            parse_args(&args(&["handshake", "--out-dir", "/tmp/attempt"]))
+                .expect("explicit out-dir parses"),
+            Command::Handshake(std::path::PathBuf::from("/tmp/attempt"))
+        );
+        for malformed in [
+            args(&["handshake", "--out-dir"]),
+            args(&["handshake", "--dir", "/tmp/attempt"]),
+        ] {
+            assert!(matches!(
+                parse_args(&malformed),
+                Err(XtaskError::Usage { .. })
+            ));
+        }
     }
 
     #[test]

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -38,6 +38,7 @@ fn run(args: &[String]) -> Result<(), error::XtaskError> {
             Ok(())
         }
         Command::Reset(fc) => session::run_reset(&fc),
+        Command::Handshake(out_dir) => session::run_handshake(&out_dir),
         Command::Sim(sim) => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -233,6 +233,29 @@ fn prepared_log_dir(repo_root: &std::path::Path) -> Result<PathBuf, XtaskError> 
     Ok(log_dir)
 }
 
+/// Produces the Alia X-Plane runtime handshake and prints its path.
+///
+/// # Errors
+///
+/// Returns a typed [`XtaskError`] when X-Plane is unreachable or the
+/// handshake cannot be produced.
+pub fn run_handshake(out_dir: &Path) -> Result<(), XtaskError> {
+    let repo_root = repo_root()?;
+    let out = if out_dir.is_absolute() {
+        out_dir.to_path_buf()
+    } else {
+        repo_root.join(out_dir)
+    };
+    std::fs::create_dir_all(&out).map_err(|source| XtaskError::Io {
+        context: "creating the handshake output directory",
+        source,
+    })?;
+    let path = crate::backend::produce_xplane_handshake_blocking(&repo_root, &out)?;
+    print_line(&path.display().to_string());
+    Ok(())
+}
+
+/// Cargo sets `CARGO_MANIFEST_DIR` in the invoking process's
 /// environment, pointing at the invoking workspace's `tools/xtask` — so a
 /// binary cached from another checkout (a worktree, a moved clone) still
 /// operates on the repository the user is standing in. The compile-time

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -213,13 +213,14 @@ pub fn run_reset(fc: &str) -> Result<(), XtaskError> {
     backend.reset(&repo_root()?)
 }
 
-/// This repository's root: the checkout `cargo xtask` was INVOKED from.
-///
-/// `cargo run` exports `CARGO_MANIFEST_DIR` into the child's runtime
+/// The session working directory, relative to the repository root.
+/// Stage logs and the standalone handshake default land in one place.
+pub(crate) const SESSION_DIR: &str = "target/xtask-sim";
+
 /// Ensures the stage-log directory exists with the previous run's logs
 /// preserved out of the way, announcing where they went.
 fn prepared_log_dir(repo_root: &std::path::Path) -> Result<PathBuf, XtaskError> {
-    let log_dir = repo_root.join("target/xtask-sim");
+    let log_dir = repo_root.join(SESSION_DIR);
     std::fs::create_dir_all(&log_dir).map_err(|source| XtaskError::Io {
         context: "creating the session log directory",
         source,
@@ -255,7 +256,9 @@ pub fn run_handshake(out_dir: &Path) -> Result<(), XtaskError> {
     Ok(())
 }
 
-/// Cargo sets `CARGO_MANIFEST_DIR` in the invoking process's
+/// This repository's root: the checkout `cargo xtask` was INVOKED from.
+///
+/// `cargo run` exports `CARGO_MANIFEST_DIR` into the child's runtime
 /// environment, pointing at the invoking workspace's `tools/xtask` — so a
 /// binary cached from another checkout (a worktree, a moved clone) still
 /// operates on the repository the user is standing in. The compile-time


### PR DESCRIPTION
## What

`cargo xtask handshake [--out-dir <dir>]` (default `target/xtask-sim`) produces the Alia X-Plane runtime handshake document and prints its path, without launching a session.

## Why

The Alia flight controller refuses to start without a Pilotage-issued runtime handshake, and only xtask can produce one — it must interrogate the trial plugin inside the running simulator. Until now the only producer was a full `cargo xtask sim` session launch, so any harness that runs the flight controller itself — a tuning campaign, a diagnosis rig, an identification flight — had no way to obtain the document. This command is the missing producer: it blocks on the simulator's own identity statement exactly as a session launch does, so the run stays bound to the simulator actually running, never to one a caller claimed was.

This is the command the Alia VTOL diagnosis/tuning harness has been exercising: every traced flight in the porpoise root-cause and the identification sequence obtained its handshake through it.

## Guardrails

- Parser tests pin the default directory, the `--out-dir` override, and fail-closed unknown flags.
- The usage-text test now pins the `handshake` heading's presence, uniqueness, position, and documented default.

Also repairs a pre-existing truncated doc comment on `session::repo_root` (it began mid-sentence on main).

## Verification

`cargo fmt`, `cargo clippy -p xtask --all-targets -- -D warnings`, `cargo test -p xtask` (74 passed) all clean; the command itself verified live against a running X-Plane across the tuning-harness runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APxgrXXpfmivZa2JqANHNr