### PR TITLE
Read an empty Linux command line as in flight, not as an impostor

### DIFF
--- a/tools/flight-tune-aviate/src/inspection/linux.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux.rs
@@ -12,7 +12,13 @@ use crate::inspection::{
     digest_open_file, digest_open_file_before, io_error, process_io,
 };
 
-const STABLE_SNAPSHOT_ATTEMPTS: usize = 3;
+const STABLE_SNAPSHOT_ATTEMPTS: usize = 5;
+
+/// Rest between unstable snapshots. Three instantaneous procfs reads
+/// fit inside one execve, so an unpaced retry loop resolves nothing;
+/// paced attempts span the window in which a process's command line is
+/// legitimately in flight.
+const SNAPSHOT_RETRY_PACE: std::time::Duration = std::time::Duration::from_millis(10);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ExecutableObservation {
@@ -82,6 +88,7 @@ fn inspect_process_from(
             StableSnapshot::Missing => return Ok(None),
             StableSnapshot::Unstable { lifetime } => {
                 bind_lifetime_anchor(&mut lifetime_anchor, &lifetime)?;
+                std::thread::sleep(SNAPSHOT_RETRY_PACE);
             }
             StableSnapshot::Stable {
                 lifetime,
@@ -89,6 +96,16 @@ fn inspect_process_from(
                 executable,
             } => {
                 bind_lifetime_anchor(&mut lifetime_anchor, &lifetime)?;
+                // An EMPTY command line is not a different process — it
+                // is the kernel's own statement that the image is in
+                // flight (mid-exec) or gone (zombie), and both resolve
+                // within the paced attempts or refuse as unstabilized.
+                // Only a command line that says something DIFFERENT is a
+                // mismatch.
+                if arguments::split(&command).is_empty() {
+                    std::thread::sleep(SNAPSHOT_RETRY_PACE);
+                    continue;
+                }
                 return build_process_identity(
                     pid,
                     launch_argv_digest,

--- a/tools/flight-tune-aviate/src/inspection/linux.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux.rs
@@ -1,15 +1,10 @@
-use std::ffi::OsStr;
-use std::fs::File;
-use std::os::unix::ffi::OsStrExt as _;
-use std::os::unix::fs::MetadataExt as _;
-use std::os::unix::io::AsRawFd as _;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::AviateSupervisorError;
-use crate::document::{ProcessIdentity, ProcessStartIdentity};
+use crate::document::ProcessIdentity;
 use crate::inspection::{
-    InspectionDeadline, LifetimeIdentity, ProcessGroupSnapshot, digest_argument_bytes,
-    digest_open_file, digest_open_file_before, io_error, process_io,
+    InspectionDeadline, LifetimeIdentity, ProcessGroupSnapshot, digest_argument_bytes, io_error,
+    process_io,
 };
 
 const STABLE_SNAPSHOT_ATTEMPTS: usize = 5;
@@ -126,6 +121,9 @@ fn inspect_process_from(
 /// that module — `platform/`, which nobody creates.
 #[path = "linux/arguments.rs"]
 mod arguments;
+#[path = "linux/procfs.rs"]
+mod procfs;
+use procfs::{lifetime, parse_pid, parse_real_user_id, parse_stat, read_stat};
 
 fn bind_lifetime_anchor(
     anchor: &mut Option<LifetimeIdentity>,
@@ -230,90 +228,6 @@ fn classify_missing(
     }
 }
 
-impl ProcessSource for Procfs {
-    fn check_deadline(&mut self) -> Result<(), AviateSupervisorError> {
-        self.deadline.map_or(Ok(()), InspectionDeadline::check)
-    }
-
-    fn lifetime(&mut self, pid: u32) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
-        self.check_deadline()?;
-        let lifetime = inspect_lifetime(pid)?;
-        self.check_deadline()?;
-        Ok(lifetime)
-    }
-
-    fn command(&mut self, pid: u32) -> Result<Option<Vec<u8>>, AviateSupervisorError> {
-        self.check_deadline()?;
-        let path = PathBuf::from(format!("/proc/{pid}/cmdline"));
-        let command = match std::fs::read(&path) {
-            Ok(command) => Ok(Some(command)),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(source) => Err(io_error("read live argument vector", &path, source)),
-        }?;
-        self.check_deadline()?;
-        Ok(command)
-    }
-
-    fn executable(
-        &mut self,
-        pid: u32,
-    ) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
-        self.check_deadline()?;
-        let executable = observe_executable(pid, self.deadline)?;
-        self.check_deadline()?;
-        Ok(executable)
-    }
-}
-
-fn observe_executable(
-    pid: u32,
-    deadline: Option<InspectionDeadline>,
-) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
-    let live_path = PathBuf::from(format!("/proc/{pid}/exe"));
-    if let Some(deadline) = deadline {
-        deadline.check()?;
-    }
-    let file = match File::open(&live_path) {
-        Ok(file) => file,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => return Err(io_error("open live executable", &live_path, source)),
-    };
-    observe_open_executable_with_deadline(file, &live_path, deadline).map(Some)
-}
-
-#[cfg(test)]
-fn observe_open_executable(
-    file: File,
-    live_path: &Path,
-) -> Result<ExecutableObservation, AviateSupervisorError> {
-    observe_open_executable_with_deadline(file, live_path, None)
-}
-
-fn observe_open_executable_with_deadline(
-    mut file: File,
-    live_path: &Path,
-    deadline: Option<InspectionDeadline>,
-) -> Result<ExecutableObservation, AviateSupervisorError> {
-    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
-    let path = std::fs::read_link(&fd_path)
-        .map_err(|source| io_error("read held executable link", &fd_path, source))?;
-    let metadata = file
-        .metadata()
-        .map_err(|source| io_error("inspect held executable", live_path, source))?;
-    let digest = match deadline {
-        Some(deadline) => digest_open_file_before(&mut file, live_path, deadline)?,
-        None => digest_open_file(&mut file)
-            .map_err(|source| io_error("hash held executable", live_path, source))?,
-    };
-    Ok(ExecutableObservation {
-        path,
-        digest,
-        device: metadata.dev(),
-        inode: metadata.ino(),
-        bytes: metadata.len(),
-    })
-}
-
 pub(super) fn inspect_lifetime(
     pid: u32,
 ) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
@@ -369,14 +283,6 @@ pub(super) fn inspect_lifetime(
     )?))
 }
 
-fn read_stat(path: &Path) -> Result<Option<String>, AviateSupervisorError> {
-    match std::fs::read_to_string(path) {
-        Ok(stat) => Ok(Some(stat)),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(source) => Err(io_error("read process lifetime", path, source)),
-    }
-}
-
 pub(super) fn process_group_snapshot(
     process_group: u32,
 ) -> Result<ProcessGroupSnapshot, AviateSupervisorError> {
@@ -402,107 +308,6 @@ pub(super) fn process_group_snapshot(
         observed: members,
         exited: Vec::new(),
         unclassified_pids: Vec::new(),
-    })
-}
-
-fn parse_stat(stat: &str) -> Result<(&str, u32, u32, u32, u64), AviateSupervisorError> {
-    let close = stat.rfind(')').ok_or_else(|| {
-        AviateSupervisorError::identity_mismatch("the Linux process stat has no command boundary")
-    })?;
-    let fields = stat
-        .get(close.saturating_add(2)..)
-        .ok_or_else(|| {
-            AviateSupervisorError::identity_mismatch("the Linux process stat is truncated")
-        })?
-        .split_whitespace()
-        .collect::<Vec<_>>();
-    if fields.len() <= 19 {
-        return Err(AviateSupervisorError::identity_mismatch(
-            "the Linux process stat has too few fields",
-        ));
-    }
-    let process_group = fields[2].parse::<u32>().map_err(|_| {
-        AviateSupervisorError::identity_mismatch("the Linux process group is invalid")
-    })?;
-    let parent_pid = fields[1].parse::<u32>().map_err(|_| {
-        AviateSupervisorError::identity_mismatch("the Linux parent process is invalid")
-    })?;
-    let session_id = fields[3].parse::<u32>().map_err(|_| {
-        AviateSupervisorError::identity_mismatch("the Linux process session is invalid")
-    })?;
-    let start_ticks = fields[19].parse::<u64>().map_err(|_| {
-        AviateSupervisorError::identity_mismatch("the Linux process start tick is invalid")
-    })?;
-    Ok((
-        fields[0],
-        parent_pid,
-        process_group,
-        session_id,
-        start_ticks,
-    ))
-}
-
-fn lifetime(
-    pid: u32,
-    parent_pid: u32,
-    process_group: u32,
-    session_id: u32,
-    real_user_id: u32,
-    start_ticks: u64,
-    is_zombie: bool,
-) -> Result<LifetimeIdentity, AviateSupervisorError> {
-    let boot_path = Path::new("/proc/sys/kernel/random/boot_id");
-    let boot_id = std::fs::read_to_string(boot_path)
-        .map_err(|source| io_error("read Linux boot identity", boot_path, source))?
-        .trim()
-        .to_owned();
-    if boot_id.is_empty() || start_ticks == 0 {
-        return Err(AviateSupervisorError::identity_mismatch(
-            "the Linux process start identity is incomplete",
-        ));
-    }
-    let start = ProcessStartIdentity::Linux {
-        boot_id,
-        start_ticks,
-    };
-    if !start.boot_identity().is_valid() {
-        return Err(AviateSupervisorError::identity_mismatch(
-            "the Linux boot identity is invalid",
-        ));
-    }
-    Ok(LifetimeIdentity {
-        pid,
-        process_group,
-        session_id,
-        parent_pid,
-        real_user_id,
-        start,
-        is_zombie,
-    })
-}
-
-fn parse_pid(name: &OsStr) -> Option<u32> {
-    let bytes = name.as_bytes();
-    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
-        return None;
-    }
-    std::str::from_utf8(bytes).ok()?.parse().ok()
-}
-
-fn parse_real_user_id(status: &str) -> Result<u32, AviateSupervisorError> {
-    let value = status
-        .lines()
-        .find_map(|line| line.strip_prefix("Uid:"))
-        .and_then(|line| line.split_whitespace().next())
-        .ok_or_else(|| {
-            AviateSupervisorError::identity_mismatch(
-                "the Linux process status has no real user identity",
-            )
-        })?;
-    value.parse().map_err(|_| {
-        AviateSupervisorError::identity_mismatch(
-            "the Linux process status has an invalid real user identity",
-        )
     })
 }
 

--- a/tools/flight-tune-aviate/src/inspection/linux/procfs.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux/procfs.rs
@@ -1,0 +1,211 @@
+//! The procfs half of the Linux inspection: reading and parsing what
+//! the kernel publishes about a process. The inspection LOGIC — what
+//! counts as stable, matching, or in flight — lives in the parent.
+
+use std::ffi::OsStr;
+use std::fs::File;
+use std::os::unix::ffi::OsStrExt as _;
+use std::os::unix::fs::MetadataExt as _;
+use std::os::unix::io::AsRawFd as _;
+use std::path::{Path, PathBuf};
+
+use super::{
+    ExecutableObservation, InspectionDeadline, LifetimeIdentity, ProcessSource, Procfs,
+    inspect_lifetime,
+};
+use crate::AviateSupervisorError;
+use crate::document::ProcessStartIdentity;
+use crate::inspection::{digest_open_file, digest_open_file_before, io_error};
+
+impl ProcessSource for Procfs {
+    fn check_deadline(&mut self) -> Result<(), AviateSupervisorError> {
+        self.deadline.map_or(Ok(()), InspectionDeadline::check)
+    }
+
+    fn lifetime(&mut self, pid: u32) -> Result<Option<LifetimeIdentity>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let lifetime = inspect_lifetime(pid)?;
+        self.check_deadline()?;
+        Ok(lifetime)
+    }
+
+    fn command(&mut self, pid: u32) -> Result<Option<Vec<u8>>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let path = PathBuf::from(format!("/proc/{pid}/cmdline"));
+        let command = match std::fs::read(&path) {
+            Ok(command) => Ok(Some(command)),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(io_error("read live argument vector", &path, source)),
+        }?;
+        self.check_deadline()?;
+        Ok(command)
+    }
+
+    fn executable(
+        &mut self,
+        pid: u32,
+    ) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
+        self.check_deadline()?;
+        let executable = observe_executable(pid, self.deadline)?;
+        self.check_deadline()?;
+        Ok(executable)
+    }
+}
+
+pub(super) fn observe_executable(
+    pid: u32,
+    deadline: Option<InspectionDeadline>,
+) -> Result<Option<ExecutableObservation>, AviateSupervisorError> {
+    let live_path = PathBuf::from(format!("/proc/{pid}/exe"));
+    if let Some(deadline) = deadline {
+        deadline.check()?;
+    }
+    let file = match File::open(&live_path) {
+        Ok(file) => file,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(io_error("open live executable", &live_path, source)),
+    };
+    observe_open_executable_with_deadline(file, &live_path, deadline).map(Some)
+}
+
+#[cfg(test)]
+pub(super) fn observe_open_executable(
+    file: File,
+    live_path: &Path,
+) -> Result<ExecutableObservation, AviateSupervisorError> {
+    observe_open_executable_with_deadline(file, live_path, None)
+}
+
+pub(super) fn observe_open_executable_with_deadline(
+    mut file: File,
+    live_path: &Path,
+    deadline: Option<InspectionDeadline>,
+) -> Result<ExecutableObservation, AviateSupervisorError> {
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+    let path = std::fs::read_link(&fd_path)
+        .map_err(|source| io_error("read held executable link", &fd_path, source))?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| io_error("inspect held executable", live_path, source))?;
+    let digest = match deadline {
+        Some(deadline) => digest_open_file_before(&mut file, live_path, deadline)?,
+        None => digest_open_file(&mut file)
+            .map_err(|source| io_error("hash held executable", live_path, source))?,
+    };
+    Ok(ExecutableObservation {
+        path,
+        digest,
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        bytes: metadata.len(),
+    })
+}
+
+pub(super) fn read_stat(path: &Path) -> Result<Option<String>, AviateSupervisorError> {
+    match std::fs::read_to_string(path) {
+        Ok(stat) => Ok(Some(stat)),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(io_error("read process lifetime", path, source)),
+    }
+}
+
+pub(super) fn parse_stat(stat: &str) -> Result<(&str, u32, u32, u32, u64), AviateSupervisorError> {
+    let close = stat.rfind(')').ok_or_else(|| {
+        AviateSupervisorError::identity_mismatch("the Linux process stat has no command boundary")
+    })?;
+    let fields = stat
+        .get(close.saturating_add(2)..)
+        .ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch("the Linux process stat is truncated")
+        })?
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    if fields.len() <= 19 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process stat has too few fields",
+        ));
+    }
+    let process_group = fields[2].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process group is invalid")
+    })?;
+    let parent_pid = fields[1].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux parent process is invalid")
+    })?;
+    let session_id = fields[3].parse::<u32>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process session is invalid")
+    })?;
+    let start_ticks = fields[19].parse::<u64>().map_err(|_| {
+        AviateSupervisorError::identity_mismatch("the Linux process start tick is invalid")
+    })?;
+    Ok((
+        fields[0],
+        parent_pid,
+        process_group,
+        session_id,
+        start_ticks,
+    ))
+}
+
+pub(super) fn lifetime(
+    pid: u32,
+    parent_pid: u32,
+    process_group: u32,
+    session_id: u32,
+    real_user_id: u32,
+    start_ticks: u64,
+    is_zombie: bool,
+) -> Result<LifetimeIdentity, AviateSupervisorError> {
+    let boot_path = Path::new("/proc/sys/kernel/random/boot_id");
+    let boot_id = std::fs::read_to_string(boot_path)
+        .map_err(|source| io_error("read Linux boot identity", boot_path, source))?
+        .trim()
+        .to_owned();
+    if boot_id.is_empty() || start_ticks == 0 {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux process start identity is incomplete",
+        ));
+    }
+    let start = ProcessStartIdentity::Linux {
+        boot_id,
+        start_ticks,
+    };
+    if !start.boot_identity().is_valid() {
+        return Err(AviateSupervisorError::identity_mismatch(
+            "the Linux boot identity is invalid",
+        ));
+    }
+    Ok(LifetimeIdentity {
+        pid,
+        process_group,
+        session_id,
+        parent_pid,
+        real_user_id,
+        start,
+        is_zombie,
+    })
+}
+
+pub(super) fn parse_pid(name: &OsStr) -> Option<u32> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(bytes).ok()?.parse().ok()
+}
+
+pub(super) fn parse_real_user_id(status: &str) -> Result<u32, AviateSupervisorError> {
+    let value = status
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:"))
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| {
+            AviateSupervisorError::identity_mismatch(
+                "the Linux process status has no real user identity",
+            )
+        })?;
+    value.parse().map_err(|_| {
+        AviateSupervisorError::identity_mismatch(
+            "the Linux process status has an invalid real user identity",
+        )
+    })
+}

--- a/tools/flight-tune-aviate/src/inspection/linux/tests.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux/tests.rs
@@ -2,10 +2,8 @@
 
 use std::collections::VecDeque;
 
-use super::{
-    ExecutableObservation, ProcessSource, STABLE_SNAPSHOT_ATTEMPTS, inspect_process_from,
-    observe_open_executable, parse_stat,
-};
+use super::procfs::{observe_open_executable, parse_stat};
+use super::{ExecutableObservation, ProcessSource, STABLE_SNAPSHOT_ATTEMPTS, inspect_process_from};
 use crate::AviateSupervisorError;
 use crate::document::ProcessStartIdentity;
 use crate::inspection::LifetimeIdentity;

--- a/tools/flight-tune-aviate/src/inspection/linux/tests.rs
+++ b/tools/flight-tune-aviate/src/inspection/linux/tests.rs
@@ -276,6 +276,75 @@ impl ProcessSource for ScriptedSource {
     }
 }
 
+#[test]
+fn inspection_outwaits_a_command_line_in_flight() {
+    // A freshly-spawned process reports an EMPTY command line until its
+    // execve completes; the kernel is saying "in flight", not "someone
+    // else". The inspection must wait it out, not call it a mismatch.
+    let lifetime_value = lifetime();
+    let target_command = command("/target");
+    let target_executable = executable("/target", 3);
+    let mut source = ScriptedSource::new(
+        vec![
+            Some(lifetime_value.clone()),
+            Some(lifetime_value.clone()),
+            Some(lifetime_value.clone()),
+            Some(lifetime_value),
+        ],
+        vec![
+            Vec::new(),
+            Vec::new(),
+            target_command.clone(),
+            target_command.clone(),
+        ],
+        vec![
+            target_executable.clone(),
+            target_executable.clone(),
+            target_executable.clone(),
+            target_executable,
+        ],
+    );
+    let digest = crate::inspection::digest_argument_bytes(
+        target_command
+            .split(|byte| *byte == 0)
+            .filter(|value| !value.is_empty()),
+    );
+
+    let identity = inspect_process_from(&mut source, 77, digest)
+        .expect("outwait the exec window")
+        .expect("the process is present");
+
+    assert_eq!(identity.observed_argv_digest, Some(digest));
+    assert!(source.is_empty(), "inspection consumes both snapshots");
+}
+
+#[test]
+fn a_command_line_that_never_arrives_refuses_as_unstabilized() {
+    // A permanently empty command line (a zombie, a kernel thread) is
+    // indeterminate, and an indeterminate identity must refuse as one —
+    // never as "the arguments differ", which accuses a live process of
+    // being somebody else.
+    let mut lifetimes = Vec::new();
+    let mut commands = Vec::new();
+    let mut executables = Vec::new();
+    for _ in 0..STABLE_SNAPSHOT_ATTEMPTS {
+        lifetimes.extend([Some(lifetime()), Some(lifetime())]);
+        commands.extend([Vec::new(), Vec::new()]);
+        executables.extend([executable("/target", 3), executable("/target", 3)]);
+    }
+    let mut source = ScriptedSource::new(lifetimes, commands, executables);
+    let digest = crate::inspection::digest_argument_bytes([b"/target".as_slice()]);
+
+    let error = inspect_process_from(&mut source, 77, digest)
+        .expect_err("refuse a command line that never arrives");
+
+    let text = error.to_string();
+    assert!(
+        text.contains("stabilize") && !text.contains("differ"),
+        "{text}"
+    );
+}
+
 fn lifetime() -> LifetimeIdentity {
     LifetimeIdentity {
         pid: 77,


### PR DESCRIPTION
## What

The Linux process inspection treated a consistently-EMPTY `/proc/<pid>/cmdline` as a stable observation and then failed it as an identity mismatch ("pid N reports 0 argument(s)"). But an empty command line is the kernel's own statement that the image is in flight (mid-execve) or gone (zombie/kernel thread) — never that the process is somebody else.

- Empty argv in a stable snapshot now re-enters the retry loop.
- Retries are PACED (10 ms): three instantaneous procfs reads fit inside one execve, so the unpaced loop could never resolve the window it existed to resolve.
- A command line that never arrives refuses as "did not stabilize" — indeterminate — rather than as a mismatch accusing a live process.

## Why now

This exact signature has produced repeated CI flakes in the supervision suites (`reports 0 argument(s)` from freshly-spawned fixture processes on loaded runners) — most recently failing #544's quality-gates run on a crate that PR does not touch.

## Guardrails

Two mock-source tests pin the semantics: `inspection_outwaits_a_command_line_in_flight` (empty→real argv resolves to the real identity) and `a_command_line_that_never_arrives_refuses_as_unstabilized` (permanently empty refuses with "stabilize", asserted to NOT say "differ").

## Verification

`cargo check -p flight-tune-aviate --all-targets --target x86_64-unknown-linux-gnu` clean (the module is Linux-gated; host is macOS); macOS-visible suite 19/19 + process_supervision 20/20 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APxgrXXpfmivZa2JqANHNr