### PR TITLE
Run every guard pair through one discovering runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,29 +128,10 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Production Rust lint guard self-test
-        run: sh scripts/test-check-production-rust-lints.sh
-
-      - name: Production Rust lint guard
-        run: sh scripts/check-production-rust-lints.sh
-
-      - name: Monotonic counter arithmetic guard self-test
-        run: bash scripts/test-check-monotonic-counter-arithmetic.sh
-
-      - name: Monotonic counter arithmetic guard
-        run: bash scripts/check-monotonic-counter-arithmetic.sh
-
-      - name: Aviate control-feel boundary guard self-test
-        run: bash scripts/test-check-aviate-control-feel-boundary.sh
-
-      - name: Aviate control-feel boundary guard
-        run: bash scripts/check-aviate-control-feel-boundary.sh
-
-      - name: flight-tune journal storage boundary self-test
-        run: bash scripts/test-check-flight-tune-journal-storage-boundary.sh
-
-      - name: flight-tune journal storage boundary
-        run: bash scripts/check-flight-tune-journal-storage-boundary.sh
+      - name: Repository guards
+        # Every scripts/check-*.sh with a test-check-*.sh self-test,
+        # discovered and run as pairs; adding a guard never edits CI.
+        run: cargo run -p xtask --quiet -- guards
 
       - name: cargo test
         run: cargo test --all-targets
@@ -168,18 +149,6 @@ jobs:
       - name: SituationView dependency boundary
         run: bash scripts/check-situation-view-boundary.sh
 
-      - name: AirspaceView contract self-test
-        run: bash scripts/test-check-airspace-view-contract.sh
-
-      - name: AirspaceView contract
-        run: bash scripts/check-airspace-view-contract.sh
-
-      - name: Navdata tile bundle guard self-test
-        run: bash scripts/test-check-navdata-tile-bundle.sh
-
-      - name: Navdata tile bundle guard
-        run: bash scripts/check-navdata-tile-bundle.sh
-
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D missing_docs -D rustdoc::broken_intra_doc_links"
@@ -196,81 +165,6 @@ jobs:
 
       - name: X-Plane reset order
         run: bash scripts/test-reset-xplane-order.sh
-
-      - name: flight build carries no simulation-only code
-        run: bash scripts/check-flight-build.sh
-
-      - name: flight tuning boundary guard self-test
-        run: bash scripts/test-check-flight-tune-boundaries.sh
-
-      - name: flight tuning boundary guard
-        run: bash scripts/check-flight-tune-boundaries.sh
-
-      - name: Aviate supervision boundary guard self-test
-        run: bash scripts/test-check-aviate-supervision-boundary.sh
-
-      - name: Aviate supervision boundary guard
-        run: bash scripts/check-aviate-supervision-boundary.sh
-
-      - name: check-structure self-test
-        run: bash scripts/test-check-structure.sh
-
-      - name: check-structure
-        run: bash scripts/check-structure.sh
-
-      - name: situation presentation boundary self-test
-        run: bash scripts/test-check-situation-presentation-boundary.sh
-
-      - name: situation presentation boundary
-        run: bash scripts/check-situation-presentation-boundary.sh
-
-      - name: situation layer controls self-test
-        run: bash scripts/test-check-situation-layer-controls.sh
-
-      - name: situation layer controls
-        run: bash scripts/check-situation-layer-controls.sh
-
-      - name: situation map attribution self-test
-        run: bash scripts/test-check-situation-map-attribution.sh
-
-      - name: situation map attribution
-        run: bash scripts/check-situation-map-attribution.sh
-
-      - name: situation ownship wiring self-test
-        run: bash scripts/test-check-situation-ownship-wiring.sh
-
-      - name: situation ownship wiring
-        run: bash scripts/check-situation-ownship-wiring.sh
-
-      - name: Apple client guard self-test
-        run: bash scripts/test-check-apple-client.sh
-
-      - name: Apple client guard
-        run: bash scripts/check-apple-client.sh
-
-      - name: Terrain base layer guard self-test
-        run: bash scripts/test-check-terrain-base-layer.sh
-
-      - name: Terrain base layer guard
-        run: bash scripts/check-terrain-base-layer.sh
-
-      - name: Web situation map guard self-test
-        run: bash scripts/test-check-web-situation-map.sh
-
-      - name: Web situation map guard
-        run: bash scripts/check-web-situation-map.sh
-
-      - name: Geodetic datum code guard self-test
-        run: bash scripts/test-check-geodetic-datum-codes.sh
-
-      - name: Geodetic datum code bijection
-        run: bash scripts/check-geodetic-datum-codes.sh
-
-      - name: ADR supersession lifecycle tests
-        run: bash scripts/test-check-adr-supersession.sh
-
-      - name: ADR supersession lifecycle
-        run: bash scripts/check-adr-supersession.sh
 
       - name: certification-claim guard (AIR-03)
         # Fail on any tracked doc/UI artifact that asserts a certification,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,11 @@ English.
 
 Do not copy noncompliant legacy text into a new document. Record a broad legacy
 rewrite as separate work.
+
+## Shell scripts
+
+Use a shell script only to start programs and to connect their inputs and
+outputs. Do not put a decision in a shell script. Write each decision in Rust
+in the xtask tool, with tests. A new repository guard is a Rust function with
+its own tests. When you change an old guard script, move it to Rust in the
+same change and delete its shell self-test.

--- a/scripts/check-geodetic-datum-codes.sh
+++ b/scripts/check-geodetic-datum-codes.sh
@@ -196,10 +196,24 @@ fi
 # The guardrails only hold while CI runs them.
 ci="$root/.github/workflows/ci.yml"
 for step in 'clients/web/geodetic-fix.test.mjs' 'scripts/check-geodetic-datum-codes.sh'; do
-    if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
-        echo "FORBIDDEN: CI must run $step" >&2
-        status=1
-    fi
+    case "$step" in
+        # A paired guard reaches CI through the discovering runner; the
+        # obligation is that CI runs the runner, not that it names the
+        # script.
+        scripts/check-*.sh|scripts/test-check-*.sh)
+            if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq -- '-- guards' \
+                && ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
+                echo "FORBIDDEN: CI must run $step" >&2
+                status=1
+            fi
+            ;;
+        *)
+            if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
+                echo "FORBIDDEN: CI must run $step" >&2
+                status=1
+            fi
+            ;;
+    esac
 done
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/check-web-situation-map.sh
+++ b/scripts/check-web-situation-map.sh
@@ -289,10 +289,24 @@ for step in 'clients/web/situation-style.test.mjs' \
     'scripts/vendor-maplibre-web.sh' \
     'scripts/check-web-situation-map.sh' \
     'scripts/test-check-web-situation-map.sh'; do
-    if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
-        echo "FORBIDDEN: CI must run $step" >&2
-        status=1
-    fi
+    case "$step" in
+        # A paired guard reaches CI through the discovering runner; the
+        # obligation is that CI runs the runner, not that it names the
+        # script.
+        scripts/check-*.sh|scripts/test-check-*.sh)
+            if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq -- '-- guards' \
+                && ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
+                echo "FORBIDDEN: CI must run $step" >&2
+                status=1
+            fi
+            ;;
+        *)
+            if ! grep -E '^[[:space:]]*run:' "$ci" | grep -Fq "$step"; then
+                echo "FORBIDDEN: CI must run $step" >&2
+                status=1
+            fi
+            ;;
+    esac
 done
 
 if [ "$status" -ne 0 ]; then

--- a/tools/xtask/src/cli.rs
+++ b/tools/xtask/src/cli.rs
@@ -66,6 +66,8 @@ pub enum Command {
     Reset(String),
     /// Produce the Alia X-Plane runtime handshake into a directory.
     Handshake(std::path::PathBuf),
+    /// Run every guard pair the repository declares.
+    Guards,
     /// Print usage.
     Help,
 }
@@ -85,9 +87,19 @@ pub fn parse_args(args: &[String]) -> Result<Command, XtaskError> {
         "sim" => Ok(Command::Sim(parse_sim(rest)?)),
         "reset" => Ok(Command::Reset(parse_reset(rest)?)),
         "handshake" => Ok(Command::Handshake(parse_handshake(rest)?)),
+        "guards" => {
+            if let Some(extra) = rest.first() {
+                return Err(XtaskError::Usage {
+                    message: format!("unknown guards argument {extra:?}"),
+                });
+            }
+            Ok(Command::Guards)
+        }
         "help" | "--help" | "-h" => Ok(Command::Help),
         other => Err(XtaskError::Usage {
-            message: format!("unknown command {other:?} (expected sim, reset, handshake, or help)"),
+            message: format!(
+                "unknown command {other:?} (expected sim, reset, handshake, guards, or help)"
+            ),
         }),
     }
 }
@@ -233,6 +245,11 @@ commands:
 
       --out-dir <dir>      directory to write into (default:
                            target/xtask-sim)
+
+  guards
+      Discover every scripts/check-<name>.sh with its
+      scripts/test-check-<name>.sh self-test, run each pair, and name
+      every failing guard.
 
   help
       Print this help text.";

--- a/tools/xtask/src/error.rs
+++ b/tools/xtask/src/error.rs
@@ -11,6 +11,20 @@ pub enum XtaskError {
         /// What was wrong with the arguments.
         message: String,
     },
+    /// At least one guard failed its self-test or its check. Every
+    /// failing guard is named, so one red run reports them all.
+    #[error("guards failed: {}", names.join(", "))]
+    GuardsFailed {
+        /// Every failing guard, in discovery order.
+        names: Vec<String>,
+    },
+    /// Guard discovery found no pairs at all. An empty result means
+    /// the runner is looking at the wrong tree, not at a clean one.
+    #[error("no guard pairs were discovered under {}", scripts.display())]
+    NoGuardPairs {
+        /// The directory discovery searched.
+        scripts: PathBuf,
+    },
     /// `--fc` named a backend this launcher does not know. Unknown
     /// backends fail closed instead of guessing.
     #[error("unknown --fc backend {name:?} (expected: aviate)")]

--- a/tools/xtask/src/guards.rs
+++ b/tools/xtask/src/guards.rs
@@ -1,0 +1,114 @@
+//! Runs every guard the repository declares, each proven by its own
+//! self-test first.
+//!
+//! A guard is a pair by convention: `scripts/check-<name>.sh` and its
+//! sibling `scripts/test-check-<name>.sh`. The runner discovers the
+//! pairs instead of reading a list, so adding a guard never edits CI —
+//! and a guard whose self-test is missing stays a manual step until it
+//! earns the pairing. Every pair runs even after one fails, so a red
+//! run names every failing guard at once.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::XtaskError;
+use crate::output::print_line;
+
+#[cfg(test)]
+mod tests;
+
+/// Discovers and runs every guard pair under `scripts/`.
+///
+/// # Errors
+///
+/// Returns a typed [`XtaskError`] naming every failing guard, or the
+/// discovery failure when the scripts directory cannot be read.
+pub fn run_guards(repo_root: &Path) -> Result<(), XtaskError> {
+    let pairs = discover_pairs(&repo_root.join("scripts"))?;
+    if pairs.is_empty() {
+        return Err(XtaskError::Usage {
+            message: "no guard pairs were discovered under scripts/".to_owned(),
+        });
+    }
+    let mut failed = Vec::new();
+    for pair in &pairs {
+        let outcome = run_pair(repo_root, pair);
+        match outcome {
+            Ok(()) => print_line(&format!("guard {}: ok", pair.name)),
+            Err(stage) => {
+                print_line(&format!("guard {}: FAILED at {stage}", pair.name));
+                failed.push(pair.name.clone());
+            }
+        }
+    }
+    if failed.is_empty() {
+        print_line(&format!("guards: {} pairs ok", pairs.len()));
+        Ok(())
+    } else {
+        Err(XtaskError::Usage {
+            message: format!("guards failed: {}", failed.join(", ")),
+        })
+    }
+}
+
+/// One discovered guard: the check script and the self-test that
+/// proves the check can still fail.
+pub(crate) struct GuardPair {
+    pub(crate) name: String,
+    pub(crate) check: PathBuf,
+    pub(crate) self_test: PathBuf,
+}
+
+pub(crate) fn discover_pairs(scripts: &Path) -> Result<Vec<GuardPair>, XtaskError> {
+    let entries = std::fs::read_dir(scripts).map_err(|source| XtaskError::Io {
+        context: "reading the scripts directory for guard discovery",
+        source,
+    })?;
+    let mut pairs = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| XtaskError::Io {
+            context: "reading a scripts directory entry",
+            source,
+        })?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name
+            .to_str()
+            .and_then(|value| value.strip_prefix("check-"))
+            .and_then(|value| value.strip_suffix(".sh"))
+        else {
+            continue;
+        };
+        let self_test = scripts.join(format!("test-check-{name}.sh"));
+        if self_test.is_file() {
+            pairs.push(GuardPair {
+                name: name.to_owned(),
+                check: entry.path(),
+                self_test,
+            });
+        }
+    }
+    pairs.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(pairs)
+}
+
+/// Runs the self-test, then the check. The self-test goes first
+/// because a guard that cannot fail proves nothing — a check script
+/// whose refusal path rotted would pass every tree.
+fn run_pair(repo_root: &Path, pair: &GuardPair) -> Result<(), &'static str> {
+    if !bash_passes(repo_root, &pair.self_test) {
+        return Err("its self-test");
+    }
+    if !bash_passes(repo_root, &pair.check) {
+        return Err("the check");
+    }
+    Ok(())
+}
+
+fn bash_passes(repo_root: &Path, script: &Path) -> bool {
+    Command::new("bash")
+        .arg(script)
+        .current_dir(repo_root)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}

--- a/tools/xtask/src/guards.rs
+++ b/tools/xtask/src/guards.rs
@@ -24,11 +24,10 @@ mod tests;
 /// Returns a typed [`XtaskError`] naming every failing guard, or the
 /// discovery failure when the scripts directory cannot be read.
 pub fn run_guards(repo_root: &Path) -> Result<(), XtaskError> {
-    let pairs = discover_pairs(&repo_root.join("scripts"))?;
+    let scripts = repo_root.join("scripts");
+    let pairs = discover_pairs(&scripts)?;
     if pairs.is_empty() {
-        return Err(XtaskError::Usage {
-            message: "no guard pairs were discovered under scripts/".to_owned(),
-        });
+        return Err(XtaskError::NoGuardPairs { scripts });
     }
     let mut failed = Vec::new();
     for pair in &pairs {
@@ -45,9 +44,7 @@ pub fn run_guards(repo_root: &Path) -> Result<(), XtaskError> {
         print_line(&format!("guards: {} pairs ok", pairs.len()));
         Ok(())
     } else {
-        Err(XtaskError::Usage {
-            message: format!("guards failed: {}", failed.join(", ")),
-        })
+        Err(XtaskError::GuardsFailed { names: failed })
     }
 }
 
@@ -105,10 +102,20 @@ fn run_pair(repo_root: &Path, pair: &GuardPair) -> Result<(), &'static str> {
 }
 
 fn bash_passes(repo_root: &Path, script: &Path) -> bool {
-    Command::new("bash")
+    match Command::new("bash")
         .arg(script)
         .current_dir(repo_root)
         .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+    {
+        Ok(status) => status.success(),
+        Err(source) => {
+            // A script that never started must not read as a script
+            // that refused: name the spawn failure before failing.
+            print_line(&format!(
+                "guard script {} did not start: {source}",
+                script.display()
+            ));
+            false
+        }
+    }
 }

--- a/tools/xtask/src/guards/tests.rs
+++ b/tools/xtask/src/guards/tests.rs
@@ -26,9 +26,11 @@ fn discovery_pairs_checks_with_their_self_tests() {
     std::fs::remove_dir_all(&scripts).ok();
 }
 
-/// The real repository's convention holds: the guards CI has always
-/// run are discovered, including the Apple-client static guard that
-/// runs on Linux, and none of them lost its self-test.
+/// Every pair CI relies on is pinned by name. Discovery wires a guard
+/// into CI only while its self-test exists, so deleting a self-test
+/// would silently drop its guard from CI; this floor turns that into
+/// a loud failure. Migrating a guard to Rust deletes its pair and must
+/// remove its name here in the same change.
 #[test]
 fn repository_guards_are_discovered() {
     let scripts = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -38,11 +40,25 @@ fn repository_guards_are_discovered() {
     let pairs = discover_pairs(&scripts).expect("discover");
     let names: Vec<&str> = pairs.iter().map(|pair| pair.name.as_str()).collect();
     for expected in [
-        "structure",
-        "monotonic-counter-arithmetic",
-        "production-rust-lints",
+        "adr-supersession",
+        "airspace-view-contract",
         "apple-client",
+        "aviate-control-feel-boundary",
+        "aviate-supervision-boundary",
+        "flight-build",
         "flight-tune-boundaries",
+        "flight-tune-journal-storage-boundary",
+        "geodetic-datum-codes",
+        "monotonic-counter-arithmetic",
+        "navdata-tile-bundle",
+        "production-rust-lints",
+        "situation-layer-controls",
+        "situation-map-attribution",
+        "situation-ownship-wiring",
+        "situation-presentation-boundary",
+        "structure",
+        "terrain-base-layer",
+        "web-situation-map",
     ] {
         assert!(
             names.contains(&expected),

--- a/tools/xtask/src/guards/tests.rs
+++ b/tools/xtask/src/guards/tests.rs
@@ -1,0 +1,52 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::discover_pairs;
+
+/// Discovery is by convention: a check with a self-test is a pair, a
+/// check without one is not, and nothing else qualifies.
+#[test]
+fn discovery_pairs_checks_with_their_self_tests() {
+    let scripts =
+        std::env::temp_dir().join(format!("xtask-guards-discovery-{}", std::process::id()));
+    std::fs::create_dir_all(&scripts).expect("create scratch scripts dir");
+    for file in [
+        "check-paired.sh",
+        "test-check-paired.sh",
+        "check-unpaired.sh",
+        "test-check-orphan-self-test.sh",
+        "unrelated.sh",
+    ] {
+        std::fs::write(scripts.join(file), "#!/bin/sh\n").expect("write script");
+    }
+
+    let pairs = discover_pairs(&scripts).expect("discover");
+    let names: Vec<&str> = pairs.iter().map(|pair| pair.name.as_str()).collect();
+    assert_eq!(names, vec!["paired"]);
+
+    std::fs::remove_dir_all(&scripts).ok();
+}
+
+/// The real repository's convention holds: the guards CI has always
+/// run are discovered, including the Apple-client static guard that
+/// runs on Linux, and none of them lost its self-test.
+#[test]
+fn repository_guards_are_discovered() {
+    let scripts = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts")
+        .canonicalize()
+        .expect("scripts directory");
+    let pairs = discover_pairs(&scripts).expect("discover");
+    let names: Vec<&str> = pairs.iter().map(|pair| pair.name.as_str()).collect();
+    for expected in [
+        "structure",
+        "monotonic-counter-arithmetic",
+        "production-rust-lints",
+        "apple-client",
+        "flight-tune-boundaries",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "{expected} missing from {names:?}"
+        );
+    }
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -7,6 +7,7 @@ use std::process::ExitCode;
 mod backend;
 mod cli;
 mod error;
+mod guards;
 mod log_archive;
 mod output;
 mod process;
@@ -39,6 +40,7 @@ fn run(args: &[String]) -> Result<(), error::XtaskError> {
         }
         Command::Reset(fc) => session::run_reset(&fc),
         Command::Handshake(out_dir) => session::run_handshake(&out_dir),
+        Command::Guards => guards::run_guards(&session::repo_root()?),
         Command::Sim(sim) => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/tools/xtask/src/session.rs
+++ b/tools/xtask/src/session.rs
@@ -263,7 +263,7 @@ pub fn run_handshake(out_dir: &Path) -> Result<(), XtaskError> {
 /// binary cached from another checkout (a worktree, a moved clone) still
 /// operates on the repository the user is standing in. The compile-time
 /// path is only the fallback for running the binary outside cargo.
-fn repo_root() -> Result<PathBuf, XtaskError> {
+pub(crate) fn repo_root() -> Result<PathBuf, XtaskError> {
     let runtime_manifest = std::env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
     let manifest = resolve_manifest(
         runtime_manifest.as_deref(),


### PR DESCRIPTION
## Stage D of the agreed CI redesign

- **`cargo xtask guards`**: discovers every `scripts/check-<name>.sh` with a `scripts/test-check-<name>.sh` sibling (19 pairs today), runs each self-test before its check, and continues past failures so one red run names every failing guard. Discovery is the contract: **adding a guard never edits CI again.**
- **ci.yml**: 37 steps replaced by one (19 pairs; one self-test — `test-check-flight-build.sh` — existed on disk but was never wired into the workflow, so the runner *adds* that coverage).
- **Policy in AGENTS.md** (STE): shell starts programs; decisions live in Rust with tests; migrate-on-touch for old guards, deleting the shell self-test in the same change — per the agreed design, the debt stops growing now and drains at the rate guards actually change.
- Tests: a synthetic-directory discovery test (pairing semantics) and a real-repository test pinning that the known guards — including the Linux-run apple-client static guard — are discovered.

## Verification

`cargo xtask guards` locally: **19 pairs ok** (full output in the run log). clippy `-D warnings` clean, fmt clean, check-structure OK, xtask tests 79/79, workflow parses, zero paired invocations remain in ci.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APxgrXXpfmivZa2JqANHNr