### PR TITLE
MENG-04: implement deterministic mission engine core

### DIFF
--- a/crates/pilotage-mission-core/src/action.rs
+++ b/crates/pilotage-mission-core/src/action.rs
@@ -157,7 +157,7 @@ impl FlightAction {
         }
     }
 
-    const fn name(&self) -> &'static str {
+    pub(crate) const fn name(&self) -> &'static str {
         match self {
             Self::Arm {} => "flight.arm",
             Self::Climb { .. } => "flight.climb",
@@ -197,7 +197,7 @@ impl TrialAction {
         }
     }
 
-    const fn name(&self) -> &'static str {
+    pub(crate) const fn name(&self) -> &'static str {
         match self {
             Self::Reset {} => "trial.reset",
             Self::WaitReady {} => "trial.wait_ready",

--- a/crates/pilotage-mission-core/src/document.rs
+++ b/crates/pilotage-mission-core/src/document.rs
@@ -3,9 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CodecError, Digest, MAX_CAPABILITIES, MAX_PHASE_CONDITIONS, MAX_PHASES, MISSION_SCHEMA_VERSION,
-    MissionAction, MissionCondition, MissionIdentity, NavigationDataIdentity, TransportLane,
-    ValidationError, canonical, validation,
+    CodecError, Digest, MAX_CAPABILITIES, MAX_CLEANUP_ACTIONS, MAX_PHASE_CONDITIONS, MAX_PHASES,
+    MISSION_SCHEMA_VERSION, MissionAction, MissionCondition, MissionIdentity,
+    NavigationDataIdentity, TransportLane, ValidationError, canonical, validation,
 };
 
 /// A mission execution target.
@@ -24,6 +24,10 @@ pub enum ExecutionTarget {
 pub struct ExecutionPolicy {
     /// The target that can execute the document.
     pub target: ExecutionTarget,
+    /// The maximum number of retries after the first directive attempt.
+    pub retry_limit: u16,
+    /// The maximum caller wall-clock wait for one directive receipt.
+    pub receipt_timeout_ns: u64,
 }
 
 /// A capability required by a mission phase.
@@ -72,6 +76,8 @@ pub struct MissionPhase {
     pub entry_conditions: Vec<MissionCondition>,
     /// The one action for the phase.
     pub action: MissionAction,
+    /// The actions to attempt during abort cleanup.
+    pub cleanup_actions: Vec<MissionAction>,
     /// The conditions that complete the phase.
     pub completion_conditions: Vec<MissionCondition>,
     /// The conditions that abort the mission.
@@ -170,6 +176,7 @@ impl MissionDocument {
     /// Returns an error if the host target is not permitted or content is invalid.
     pub fn validate_for_target(&self, target: ExecutionTarget) -> Result<(), ValidationError> {
         self.identity.validate_fields()?;
+        self.execution_policy.validate()?;
         self.validate_phases()?;
         self.validate_admission(target)?;
         if self.execution_policy.target != target {
@@ -183,6 +190,7 @@ impl MissionDocument {
 
     fn validate_content(&self) -> Result<(), ValidationError> {
         self.identity.validate_content_fields()?;
+        self.execution_policy.validate()?;
         self.validate_phases()
     }
 
@@ -208,17 +216,19 @@ impl MissionDocument {
             return Ok(());
         }
         for phase in &self.phases {
-            if phase.action.transport_lane() == TransportLane::SimulatorOnly {
-                return Err(ValidationError::SimulatorOnlyAction {
-                    phase_id: phase.id.clone(),
-                    action: phase.action.name(),
-                });
+            for action in std::iter::once(&phase.action).chain(&phase.cleanup_actions) {
+                if action.transport_lane() == TransportLane::SimulatorOnly {
+                    return Err(ValidationError::SimulatorOnlyAction {
+                        phase_id: phase.id.clone(),
+                        action: action.name(),
+                    });
+                }
             }
         }
         Ok(())
     }
 
-    fn verify_content_digest(&self) -> Result<(), CodecError> {
+    pub(crate) fn verify_content_digest(&self) -> Result<(), CodecError> {
         self.identity.validate_fields()?;
         let calculated = self.calculate_content_digest()?;
         if self.identity.content_digest != calculated {
@@ -249,7 +259,11 @@ impl MissionPhase {
         self.validate_capability_list()?;
         self.validate_conditions(&field)?;
         self.action.validate(&field)?;
-        self.validate_plan_identity(navigation_data)?;
+        self.validate_cleanup_actions(&field)?;
+        self.validate_plan_identity(&self.action, navigation_data)?;
+        for action in &self.cleanup_actions {
+            self.validate_plan_identity(action, navigation_data)?;
+        }
         self.validate_capability_declarations()
     }
 
@@ -278,11 +292,24 @@ impl MissionPhase {
         validate_condition_list(field, "abort_conditions", &self.abort_conditions)
     }
 
+    fn validate_cleanup_actions(&self, field: &str) -> Result<(), ValidationError> {
+        validation::count_with_limit(
+            &format!("{field}.cleanup_actions"),
+            self.cleanup_actions.len(),
+            MAX_CLEANUP_ACTIONS,
+        )?;
+        for (index, action) in self.cleanup_actions.iter().enumerate() {
+            action.validate(&format!("{field}.cleanup_actions[{index}]"))?;
+        }
+        Ok(())
+    }
+
     fn validate_plan_identity(
         &self,
+        action: &MissionAction,
         navigation_data: &NavigationDataIdentity,
     ) -> Result<(), ValidationError> {
-        if let Some(plan) = self.action.flight_plan()
+        if let Some(plan) = action.flight_plan()
             && plan.navigation_data_identity != *navigation_data
         {
             return Err(ValidationError::NavigationDataMismatch {
@@ -297,6 +324,11 @@ impl MissionPhase {
         self.require_declared(MissionCapability::SimulatorTime)?;
         if let Some(capability) = self.action.required_capability() {
             self.require_declared(capability)?;
+        }
+        for action in &self.cleanup_actions {
+            if let Some(capability) = action.required_capability() {
+                self.require_declared(capability)?;
+            }
         }
         for condition in self
             .entry_conditions
@@ -319,6 +351,15 @@ impl MissionPhase {
             phase_id: self.id.clone(),
             capability,
         })
+    }
+}
+
+impl ExecutionPolicy {
+    fn validate(&self) -> Result<(), ValidationError> {
+        validation::nonzero_u64(
+            "mission.execution_policy.receipt_timeout_ns",
+            self.receipt_timeout_ns,
+        )
     }
 }
 

--- a/crates/pilotage-mission-core/src/engine.rs
+++ b/crates/pilotage-mission-core/src/engine.rs
@@ -1,0 +1,199 @@
+//! Deterministic mission sequencing with caller-supplied input and clocks.
+
+mod cleanup;
+mod condition;
+mod directive;
+mod error;
+mod observation;
+mod outcome;
+mod run;
+mod runtime;
+
+pub use directive::{
+    ActionId, DirectiveContext, DirectivePurpose, DirectiveReceipt, FlightDirective,
+    MissionDirective, ReceiptResult, TrialDirective,
+};
+pub use error::{EngineInputError, EngineStartError};
+pub use observation::{
+    EngineStart, MissionObservation, NavigationObservation, ObservedSignal, TickInput,
+    VehicleObservation, WallDeadline,
+};
+pub use outcome::{
+    AbortCause, CleanupFailure, CleanupFailureKind, DeadlineClass, EngineEvent, EngineState,
+    MissionTerminal, PhaseStage, TickOutput,
+};
+
+use crate::MissionDocument;
+use runtime::{PhaseProgress, RunState, TickCollector, TickContext};
+
+/// One deterministic mission sequencing core.
+///
+/// The core does not perform input or output. A host supplies time,
+/// observations, and receipts to [`MissionEngine::tick`].
+#[derive(Clone, Debug)]
+pub struct MissionEngine {
+    document: MissionDocument,
+    wall_deadline: WallDeadline,
+    last_simulator_time_ns: u64,
+    last_wall_time_ns: u64,
+    last_action_id: u32,
+    entered_phases: Vec<usize>,
+    run_state: RunState,
+}
+
+impl MissionEngine {
+    /// Validates a mission for the host and starts one run.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if admission, identity, or wall-deadline validation
+    /// fails.
+    pub fn start(document: MissionDocument, start: EngineStart) -> Result<Self, EngineStartError> {
+        document
+            .validate_for_target(start.host_target)
+            .map_err(|source| EngineStartError::Admission { source })?;
+        document
+            .verify_content_digest()
+            .map_err(|source| EngineStartError::DocumentIdentity { source })?;
+        validate_wall_deadline(&document, start)?;
+        Ok(Self {
+            document,
+            wall_deadline: start.wall_deadline,
+            last_simulator_time_ns: start.simulator_time_ns,
+            last_wall_time_ns: start.wall_time_ns,
+            last_action_id: 0,
+            entered_phases: Vec::new(),
+            run_state: RunState::Running(runtime::RunningState {
+                phase_index: 0,
+                phase_started_at_ns: start.simulator_time_ns,
+                progress: PhaseProgress::Entry,
+            }),
+        })
+    }
+
+    /// Advances the engine with one complete caller input.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error without changing engine state if a clock regresses,
+    /// an observation is invalid, or a receipt does not match the outstanding
+    /// directive.
+    pub fn tick(&mut self, input: TickInput) -> Result<TickOutput, EngineInputError> {
+        self.validate_input(&input)?;
+        self.last_simulator_time_ns = input.simulator_time_ns;
+        self.last_wall_time_ns = input.wall_time_ns;
+        let mut collector = TickCollector::default();
+        let context = TickContext {
+            document: &self.document,
+            entered_phases: &mut self.entered_phases,
+            last_action_id: &mut self.last_action_id,
+            input: &input,
+            collector: &mut collector,
+        };
+        let transition = match &mut self.run_state {
+            RunState::Running(state) => run::tick_running(self.wall_deadline, state, context),
+            RunState::CleaningUp(state) => cleanup::tick_cleanup(state, context),
+            RunState::Terminal(_) => None,
+        };
+        if let Some(state) = transition {
+            self.run_state = state;
+        }
+        Ok(TickOutput {
+            directives: collector.directives,
+            events: collector.events,
+            state: self.state(),
+        })
+    }
+
+    /// Gets a public snapshot of the current engine state.
+    #[must_use]
+    pub fn state(&self) -> EngineState {
+        match &self.run_state {
+            RunState::Running(state) => runtime::running_snapshot(&self.document, state),
+            RunState::CleaningUp(state) => runtime::cleanup_snapshot(state),
+            RunState::Terminal(result) => EngineState::Terminal {
+                result: result.clone(),
+            },
+        }
+    }
+
+    fn validate_input(&self, input: &TickInput) -> Result<(), EngineInputError> {
+        if matches!(self.run_state, RunState::Terminal(_)) {
+            return Err(EngineInputError::Terminal {});
+        }
+        validate_clocks(self, input)?;
+        input.observation.validate()?;
+        validate_receipts(input, self.outstanding_action_id())
+    }
+
+    fn outstanding_action_id(&self) -> Option<ActionId> {
+        match &self.run_state {
+            RunState::Running(state) => match &state.progress {
+                PhaseProgress::Receipt(pending) => Some(pending.directive.context().action_id),
+                PhaseProgress::Entry | PhaseProgress::Completion => None,
+            },
+            RunState::CleaningUp(state) => state
+                .pending
+                .as_ref()
+                .map(|pending| pending.directive.context().action_id),
+            RunState::Terminal(_) => None,
+        }
+    }
+}
+
+fn validate_wall_deadline(
+    document: &MissionDocument,
+    start: EngineStart,
+) -> Result<(), EngineStartError> {
+    let expected = document.identity.content_digest;
+    let actual = start.wall_deadline.mission_content_digest;
+    if actual != expected {
+        return Err(EngineStartError::WallDeadlineIdentity { expected, actual });
+    }
+    if start.wall_deadline.expires_at_ns <= start.wall_time_ns {
+        return Err(EngineStartError::WallDeadlineExpired {
+            wall_time_ns: start.wall_time_ns,
+            deadline_ns: start.wall_deadline.expires_at_ns,
+        });
+    }
+    Ok(())
+}
+
+fn validate_clocks(engine: &MissionEngine, input: &TickInput) -> Result<(), EngineInputError> {
+    if input.simulator_time_ns < engine.last_simulator_time_ns {
+        return Err(EngineInputError::SimulatorClockRegressed {
+            previous_ns: engine.last_simulator_time_ns,
+            current_ns: input.simulator_time_ns,
+        });
+    }
+    if input.wall_time_ns < engine.last_wall_time_ns {
+        return Err(EngineInputError::WallClockRegressed {
+            previous_ns: engine.last_wall_time_ns,
+            current_ns: input.wall_time_ns,
+        });
+    }
+    Ok(())
+}
+
+fn validate_receipts(
+    input: &TickInput,
+    outstanding: Option<ActionId>,
+) -> Result<(), EngineInputError> {
+    if input.receipts.len() > 1 {
+        return Err(EngineInputError::TooManyReceipts {
+            count: input.receipts.len(),
+        });
+    }
+    if let Some(receipt) = input.receipts.first()
+        && Some(receipt.action_id) != outstanding
+    {
+        return Err(EngineInputError::StaleReceipt {
+            received: receipt.action_id,
+            outstanding,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-mission-core/src/engine/cleanup.rs
+++ b/crates/pilotage-mission-core/src/engine/cleanup.rs
@@ -1,0 +1,180 @@
+//! Reverse-phase attempt-all cleanup.
+
+use super::runtime::{
+    CleanupState, CleanupStep, PendingTerminal, RunState, TickContext, emit, new_pending,
+    terminal_state,
+};
+use super::{CleanupFailure, CleanupFailureKind, DirectivePurpose, EngineEvent, ReceiptResult};
+
+pub(super) fn start_cleanup(cause: PendingTerminal, context: &mut TickContext<'_>) -> RunState {
+    let steps = cleanup_steps(context);
+    let mut state = CleanupState {
+        cause,
+        steps,
+        cursor: 0,
+        pending: None,
+        failures: Vec::new(),
+    };
+    issue_or_finish(&mut state, context)
+}
+
+pub(super) fn tick_cleanup(
+    state: &mut CleanupState,
+    mut context: TickContext<'_>,
+) -> Option<RunState> {
+    let Some(pending) = &state.pending else {
+        return Some(issue_or_finish(state, &mut context));
+    };
+    if let Some(receipt) = context.input.receipts.first() {
+        let result = receipt.result.clone();
+        context.collector.events.push(EngineEvent::ReceiptAccepted {
+            context: pending.directive.context().clone(),
+            result: result.clone(),
+        });
+        return process_receipt(state, result, &mut context);
+    }
+    let elapsed = context
+        .input
+        .wall_time_ns
+        .saturating_sub(pending.emitted_at_wall_ns);
+    if elapsed < context.document.execution_policy.receipt_timeout_ns {
+        return None;
+    }
+    let action_id = pending.directive.context().action_id;
+    record_failure(
+        state,
+        CleanupFailureKind::ReceiptTimeout { action_id },
+        context.collector,
+    );
+    Some(advance(state, &mut context))
+}
+
+fn cleanup_steps(context: &TickContext<'_>) -> Vec<CleanupStep> {
+    let mut steps = Vec::new();
+    for phase_index in context.entered_phases.iter().rev().copied() {
+        let phase = &context.document.phases[phase_index];
+        for (cleanup_index, action) in phase.cleanup_actions.iter().enumerate() {
+            steps.push(CleanupStep {
+                phase_index,
+                phase_id: phase.id.clone(),
+                cleanup_index,
+                action: action.clone(),
+            });
+        }
+    }
+    steps
+}
+
+fn process_receipt(
+    state: &mut CleanupState,
+    result: ReceiptResult,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    match result {
+        ReceiptResult::Succeeded {} => Some(advance(state, context)),
+        ReceiptResult::Retryable { detail } => retry(state, detail, context),
+        ReceiptResult::Refused { detail } => {
+            record_failure(
+                state,
+                CleanupFailureKind::Refused { detail },
+                context.collector,
+            );
+            Some(advance(state, context))
+        }
+        ReceiptResult::Failed { detail } => {
+            record_failure(
+                state,
+                CleanupFailureKind::Failed { detail },
+                context.collector,
+            );
+            Some(advance(state, context))
+        }
+    }
+}
+
+fn retry(
+    state: &mut CleanupState,
+    detail: String,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    let pending = state.pending.as_ref()?;
+    if pending.retries_used >= context.document.execution_policy.retry_limit {
+        record_failure(
+            state,
+            CleanupFailureKind::RetryLimitExceeded {
+                detail,
+                retry_limit: context.document.execution_policy.retry_limit,
+            },
+            context.collector,
+        );
+        return Some(advance(state, context));
+    }
+    let previous_action_id = pending.directive.context().action_id;
+    let retries_used = pending.retries_used.wrapping_add(1);
+    let step = &state.steps[state.cursor];
+    let retry = new_pending(
+        context,
+        step.phase_index,
+        DirectivePurpose::Cleanup {
+            cleanup_index: step.cleanup_index,
+        },
+        step.action.clone(),
+        retries_used,
+    );
+    context
+        .collector
+        .events
+        .push(EngineEvent::DirectiveRetried {
+            previous_action_id,
+            directive: retry.directive.clone(),
+        });
+    emit(&retry.directive, context.collector);
+    state.pending = Some(retry);
+    None
+}
+
+fn record_failure(
+    state: &mut CleanupState,
+    failure: CleanupFailureKind,
+    collector: &mut super::runtime::TickCollector,
+) {
+    let step = &state.steps[state.cursor];
+    let failure = CleanupFailure {
+        phase_index: step.phase_index,
+        phase_id: step.phase_id.clone(),
+        cleanup_index: step.cleanup_index,
+        action: step.action.name().to_owned(),
+        failure,
+    };
+    collector.events.push(EngineEvent::CleanupFailed {
+        failure: failure.clone(),
+    });
+    state.failures.push(failure);
+}
+
+fn advance(state: &mut CleanupState, context: &mut TickContext<'_>) -> RunState {
+    state.cursor = state.cursor.wrapping_add(1);
+    state.pending = None;
+    issue_or_finish(state, context)
+}
+
+fn issue_or_finish(state: &mut CleanupState, context: &mut TickContext<'_>) -> RunState {
+    let Some(step) = state.steps.get(state.cursor) else {
+        return terminal_state(
+            state.cause.clone().finish(state.failures.clone()),
+            context.collector,
+        );
+    };
+    let pending = new_pending(
+        context,
+        step.phase_index,
+        DirectivePurpose::Cleanup {
+            cleanup_index: step.cleanup_index,
+        },
+        step.action.clone(),
+        0,
+    );
+    emit(&pending.directive, context.collector);
+    state.pending = Some(pending);
+    RunState::CleaningUp(Box::new(state.clone()))
+}

--- a/crates/pilotage-mission-core/src/engine/condition.rs
+++ b/crates/pilotage-mission-core/src/engine/condition.rs
@@ -1,0 +1,113 @@
+//! Deterministic condition evaluation for caller observations.
+
+use crate::{
+    Comparison, MissionCondition, MissionObservation, NavigationCondition, SignalCondition,
+    SimulatorCondition, VehicleCondition,
+};
+
+pub(crate) fn all_match(
+    conditions: &[MissionCondition],
+    simulator_time_ns: u64,
+    observation: &MissionObservation,
+) -> bool {
+    conditions
+        .iter()
+        .all(|condition| matches(condition, simulator_time_ns, observation))
+}
+
+pub(crate) fn first_match(
+    conditions: &[MissionCondition],
+    simulator_time_ns: u64,
+    observation: &MissionObservation,
+) -> Option<usize> {
+    conditions
+        .iter()
+        .position(|condition| matches(condition, simulator_time_ns, observation))
+}
+
+fn matches(
+    condition: &MissionCondition,
+    simulator_time_ns: u64,
+    observation: &MissionObservation,
+) -> bool {
+    match condition {
+        MissionCondition::Always {} => true,
+        MissionCondition::Navigation(condition) => navigation(condition, observation),
+        MissionCondition::Vehicle(condition) => vehicle(condition, observation),
+        MissionCondition::Simulator(condition) => simulator(condition, simulator_time_ns),
+        MissionCondition::Signal(condition) => signal(condition, observation),
+    }
+}
+
+fn navigation(condition: &NavigationCondition, observation: &MissionObservation) -> bool {
+    match condition {
+        NavigationCondition::GuidanceValid { expected } => {
+            observation.navigation.guidance_valid == Some(*expected)
+        }
+        NavigationCondition::PlanComplete { expected } => {
+            observation.navigation.plan_complete == Some(*expected)
+        }
+        NavigationCondition::Altitude {
+            comparison,
+            value_m,
+        } => observation
+            .navigation
+            .altitude_m
+            .is_some_and(|actual| compare(*comparison, actual, *value_m)),
+    }
+}
+
+fn vehicle(condition: &VehicleCondition, observation: &MissionObservation) -> bool {
+    match condition {
+        VehicleCondition::Lifecycle { state } => observation.vehicle.lifecycle == Some(*state),
+        VehicleCondition::GroundContact { expected } => {
+            observation.vehicle.ground_contact == Some(*expected)
+        }
+        VehicleCondition::Crashed { expected } => observation.vehicle.crashed == Some(*expected),
+        VehicleCondition::LinkValid { expected } => {
+            observation.vehicle.link_valid == Some(*expected)
+        }
+        VehicleCondition::EstimatorValid { expected } => {
+            observation.vehicle.estimator_valid == Some(*expected)
+        }
+    }
+}
+
+fn simulator(condition: &SimulatorCondition, simulator_time_ns: u64) -> bool {
+    let SimulatorCondition::Time {
+        comparison,
+        value_ns,
+    } = condition;
+    compare_u64(*comparison, simulator_time_ns, *value_ns)
+}
+
+fn signal(condition: &SignalCondition, observation: &MissionObservation) -> bool {
+    let SignalCondition::Value {
+        selector,
+        comparison,
+        value,
+    } = condition;
+    observation
+        .signal(selector)
+        .is_some_and(|actual| compare(*comparison, actual, *value))
+}
+
+fn compare(comparison: Comparison, actual: f64, expected: f64) -> bool {
+    match comparison {
+        Comparison::LessThan => actual < expected,
+        Comparison::LessOrEqual => actual <= expected,
+        Comparison::GreaterThan => actual > expected,
+        Comparison::GreaterOrEqual => actual >= expected,
+        Comparison::AbsoluteLessOrEqual => actual.abs() <= expected,
+        Comparison::AbsoluteGreaterOrEqual => actual.abs() >= expected,
+    }
+}
+
+fn compare_u64(comparison: Comparison, actual: u64, expected: u64) -> bool {
+    match comparison {
+        Comparison::LessThan => actual < expected,
+        Comparison::LessOrEqual | Comparison::AbsoluteLessOrEqual => actual <= expected,
+        Comparison::GreaterThan => actual > expected,
+        Comparison::GreaterOrEqual | Comparison::AbsoluteGreaterOrEqual => actual >= expected,
+    }
+}

--- a/crates/pilotage-mission-core/src/engine/directive.rs
+++ b/crates/pilotage-mission-core/src/engine/directive.rs
@@ -1,0 +1,142 @@
+//! Typed mission directives and correlated receipts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{FlightAction, MissionAction, TrialAction};
+
+/// A nonzero identifier for one directive attempt.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ActionId(pub(crate) u32);
+
+impl ActionId {
+    /// Gets the identifier value.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// The reason that the engine emitted a directive.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "purpose", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DirectivePurpose {
+    /// Execute the main action of a phase.
+    PhaseAction {},
+    /// Execute one declared cleanup action.
+    Cleanup {
+        /// The zero-based index in the phase cleanup list.
+        cleanup_index: usize,
+    },
+}
+
+/// Correlation and phase data for one directive.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectiveContext {
+    /// The identifier that a receipt must return.
+    pub action_id: ActionId,
+    /// The zero-based phase index.
+    pub phase_index: usize,
+    /// The stable phase identifier.
+    pub phase_id: String,
+    /// The one-based attempt number for this action.
+    pub attempt: u32,
+    /// The reason for the directive.
+    pub purpose: DirectivePurpose,
+}
+
+/// An operational flight directive.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlightDirective {
+    /// The directive context.
+    pub context: DirectiveContext,
+    /// The flight action for a host handler.
+    pub action: FlightAction,
+}
+
+/// A simulator-only trial directive.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrialDirective {
+    /// The directive context.
+    pub context: DirectiveContext,
+    /// The trial action for a host handler.
+    pub action: TrialAction,
+}
+
+/// A typed directive on one transport lane.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "lane", content = "directive", rename_all = "snake_case")]
+pub enum MissionDirective {
+    /// A directive for the operational command path.
+    Flight(FlightDirective),
+    /// A directive for the simulator-only command path.
+    Trial(TrialDirective),
+}
+
+/// The host result for one directive attempt.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReceiptResult {
+    /// The host completed the directive.
+    Succeeded {},
+    /// The host asks the engine to retry the directive.
+    Retryable {
+        /// The host detail for evidence.
+        detail: String,
+    },
+    /// The host does not support or admit the directive.
+    Refused {
+        /// The host refusal detail.
+        detail: String,
+    },
+    /// The host attempted and failed the directive.
+    Failed {
+        /// The host failure detail.
+        detail: String,
+    },
+}
+
+/// A receipt correlated to one directive attempt.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectiveReceipt {
+    /// The identifier from the directive.
+    pub action_id: ActionId,
+    /// The host result.
+    pub result: ReceiptResult,
+}
+
+impl MissionDirective {
+    pub(crate) fn new(context: DirectiveContext, action: MissionAction) -> Self {
+        match action {
+            MissionAction::Flight(action) => Self::Flight(FlightDirective { context, action }),
+            MissionAction::Trial(action) => Self::Trial(TrialDirective { context, action }),
+        }
+    }
+
+    /// Gets the directive context.
+    #[must_use]
+    pub const fn context(&self) -> &DirectiveContext {
+        match self {
+            Self::Flight(directive) => &directive.context,
+            Self::Trial(directive) => &directive.context,
+        }
+    }
+
+    pub(crate) const fn action_name(&self) -> &'static str {
+        match self {
+            Self::Flight(directive) => directive.action.name(),
+            Self::Trial(directive) => directive.action.name(),
+        }
+    }
+
+    pub(crate) fn action(&self) -> MissionAction {
+        match self {
+            Self::Flight(directive) => MissionAction::Flight(directive.action.clone()),
+            Self::Trial(directive) => MissionAction::Trial(directive.action.clone()),
+        }
+    }
+}

--- a/crates/pilotage-mission-core/src/engine/error.rs
+++ b/crates/pilotage-mission-core/src/engine/error.rs
@@ -1,0 +1,90 @@
+//! Mission engine admission and input errors.
+
+use thiserror::Error;
+
+use crate::{ActionId, CodecError, Digest, ValidationError};
+
+/// An error that prevents a mission engine from starting.
+#[derive(Debug, Error)]
+pub enum EngineStartError {
+    /// The mission document is not valid for the host.
+    #[error("the mission document is not valid for the host: {source}")]
+    Admission {
+        /// The document validation error.
+        #[source]
+        source: ValidationError,
+    },
+    /// The mission content digest is not valid.
+    #[error("the mission document digest is not valid: {source}")]
+    DocumentIdentity {
+        /// The document codec error.
+        #[source]
+        source: CodecError,
+    },
+    /// The wall deadline belongs to a different mission.
+    #[error("wall deadline mission digest {actual} does not match {expected}")]
+    WallDeadlineIdentity {
+        /// The mission document digest.
+        expected: Digest,
+        /// The deadline mission digest.
+        actual: Digest,
+    },
+    /// The wall deadline is not later than the admission clock.
+    #[error("wall deadline {deadline_ns} is not later than start wall time {wall_time_ns}")]
+    WallDeadlineExpired {
+        /// The wall clock at admission.
+        wall_time_ns: u64,
+        /// The supplied absolute deadline.
+        deadline_ns: u64,
+    },
+}
+
+/// An invalid input to one engine tick.
+#[derive(Debug, Error, PartialEq)]
+pub enum EngineInputError {
+    /// A caller tick followed a terminal result.
+    #[error("the mission engine is terminal")]
+    Terminal {},
+    /// The simulator clock moved backwards.
+    #[error("simulator clock moved backwards from {previous_ns} to {current_ns}")]
+    SimulatorClockRegressed {
+        /// The last accepted simulator clock.
+        previous_ns: u64,
+        /// The supplied simulator clock.
+        current_ns: u64,
+    },
+    /// The wall clock moved backwards.
+    #[error("wall clock moved backwards from {previous_ns} to {current_ns}")]
+    WallClockRegressed {
+        /// The last accepted wall clock.
+        previous_ns: u64,
+        /// The supplied wall clock.
+        current_ns: u64,
+    },
+    /// A tick supplied more than one receipt for the one outstanding directive.
+    #[error("a tick supplied {count} receipts; at most one receipt is permitted")]
+    TooManyReceipts {
+        /// The supplied receipt count.
+        count: usize,
+    },
+    /// A receipt does not identify the outstanding directive.
+    #[error("receipt action id {received:?} does not match outstanding id {outstanding:?}")]
+    StaleReceipt {
+        /// The received identifier.
+        received: ActionId,
+        /// The outstanding identifier, when one exists.
+        outstanding: Option<ActionId>,
+    },
+    /// An observation contains a non-finite number.
+    #[error("{field} must be finite")]
+    NonFiniteObservation {
+        /// The invalid observation field.
+        field: String,
+    },
+    /// An observation repeats one exact signal selector.
+    #[error("observation signal at index {index} repeats an earlier selector")]
+    RepeatedSignal {
+        /// The second signal index.
+        index: usize,
+    },
+}

--- a/crates/pilotage-mission-core/src/engine/observation.rs
+++ b/crates/pilotage-mission-core/src/engine/observation.rs
@@ -1,0 +1,131 @@
+//! Caller-supplied clocks, observations, and tick input.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Digest, DirectiveReceipt, EngineInputError, ExecutionTarget, SignalSelector,
+    VehicleLifecycleState,
+};
+
+/// One absolute wall deadline bound to a mission identity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WallDeadline {
+    /// The mission content digest that owns the deadline.
+    pub mission_content_digest: Digest,
+    /// The absolute caller wall-clock value when the deadline expires.
+    pub expires_at_ns: u64,
+}
+
+/// Caller-supplied values that start one engine run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EngineStart {
+    /// The host execution target.
+    pub host_target: ExecutionTarget,
+    /// The simulator clock at mission admission.
+    pub simulator_time_ns: u64,
+    /// The wall clock at mission admission.
+    pub wall_time_ns: u64,
+    /// The identity-bound wall deadline.
+    pub wall_deadline: WallDeadline,
+}
+
+/// Navigation values in one observation frame.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NavigationObservation {
+    /// The guidance validity, when available.
+    pub guidance_valid: Option<bool>,
+    /// The active-plan completion state, when available.
+    pub plan_complete: Option<bool>,
+    /// The observed altitude in meters, when available.
+    pub altitude_m: Option<f64>,
+}
+
+/// Vehicle values in one observation frame.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VehicleObservation {
+    /// The lifecycle state, when available.
+    pub lifecycle: Option<VehicleLifecycleState>,
+    /// The ground-contact state, when available.
+    pub ground_contact: Option<bool>,
+    /// The crash state, when available.
+    pub crashed: Option<bool>,
+    /// The control-link validity, when available.
+    pub link_valid: Option<bool>,
+    /// The estimator validity, when available.
+    pub estimator_valid: Option<bool>,
+}
+
+/// One exact scalar signal value in an observation frame.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservedSignal {
+    /// The exact signal selector.
+    pub selector: SignalSelector,
+    /// The observed scalar value.
+    pub value: f64,
+}
+
+/// The non-clock observations for one engine tick.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MissionObservation {
+    /// Navigation observations.
+    pub navigation: NavigationObservation,
+    /// Vehicle observations.
+    pub vehicle: VehicleObservation,
+    /// Exact scalar signal observations.
+    pub signals: Vec<ObservedSignal>,
+}
+
+/// All caller-supplied input for one engine tick.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TickInput {
+    /// The current simulator clock.
+    pub simulator_time_ns: u64,
+    /// The current wall clock.
+    pub wall_time_ns: u64,
+    /// The current observation frame.
+    pub observation: MissionObservation,
+    /// Receipts that arrived before this tick.
+    pub receipts: Vec<DirectiveReceipt>,
+}
+
+impl MissionObservation {
+    pub(crate) fn validate(&self) -> Result<(), EngineInputError> {
+        if self
+            .navigation
+            .altitude_m
+            .is_some_and(|value| !value.is_finite())
+        {
+            return Err(EngineInputError::NonFiniteObservation {
+                field: "observation.navigation.altitude_m".to_owned(),
+            });
+        }
+        for (index, signal) in self.signals.iter().enumerate() {
+            if !signal.value.is_finite() {
+                return Err(EngineInputError::NonFiniteObservation {
+                    field: format!("observation.signals[{index}].value"),
+                });
+            }
+            if self.signals[..index]
+                .iter()
+                .any(|prior| prior.selector == signal.selector)
+            {
+                return Err(EngineInputError::RepeatedSignal { index });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn signal(&self, selector: &SignalSelector) -> Option<f64> {
+        self.signals
+            .iter()
+            .find(|signal| signal.selector == *selector)
+            .map(|signal| signal.value)
+    }
+}

--- a/crates/pilotage-mission-core/src/engine/outcome.rs
+++ b/crates/pilotage-mission-core/src/engine/outcome.rs
@@ -1,0 +1,290 @@
+//! Engine states, evidence events, and typed terminal results.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActionId, DirectiveContext, MissionDirective, ReceiptResult};
+
+/// The deadline class that stopped a mission.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "class", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DeadlineClass {
+    /// The active phase used all of its simulator-time duration.
+    PhaseSimulatorTime {
+        /// The phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The configured phase duration.
+        limit_ns: u64,
+        /// The observed duration when the engine stopped the phase.
+        elapsed_ns: u64,
+    },
+    /// The mission reached its absolute caller wall deadline.
+    MissionWall {
+        /// The absolute deadline value.
+        deadline_ns: u64,
+        /// The caller wall clock that reached the deadline.
+        observed_ns: u64,
+    },
+}
+
+/// The reason for an aborted terminal result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "cause", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AbortCause {
+    /// One declared abort condition matched.
+    Condition {
+        /// The zero-based condition index.
+        condition_index: usize,
+    },
+    /// A host attempted the action and reported a failure.
+    ActionFailed {
+        /// The host failure detail.
+        detail: String,
+    },
+    /// Retryable receipts used all permitted retries.
+    RetryLimitExceeded {
+        /// The last host retry detail.
+        detail: String,
+        /// The configured retry limit.
+        retry_limit: u16,
+    },
+}
+
+/// The failure class for one cleanup step.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "failure", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CleanupFailureKind {
+    /// The host refused the cleanup action.
+    Refused {
+        /// The host refusal detail.
+        detail: String,
+    },
+    /// The host attempted and failed the cleanup action.
+    Failed {
+        /// The host failure detail.
+        detail: String,
+    },
+    /// Retryable receipts used all permitted retries.
+    RetryLimitExceeded {
+        /// The last host retry detail.
+        detail: String,
+        /// The configured retry limit.
+        retry_limit: u16,
+    },
+    /// The cleanup action did not produce a receipt in time.
+    ReceiptTimeout {
+        /// The timed-out directive identifier.
+        action_id: ActionId,
+    },
+}
+
+/// One failed cleanup step in an unsuccessful mission result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CleanupFailure {
+    /// The phase index that owns the cleanup action.
+    pub phase_index: usize,
+    /// The stable phase identifier.
+    pub phase_id: String,
+    /// The zero-based index in the phase cleanup list.
+    pub cleanup_index: usize,
+    /// The stable cleanup action name.
+    pub action: String,
+    /// The cleanup failure class.
+    pub failure: CleanupFailureKind,
+}
+
+/// The one typed terminal result for a mission run.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "terminal", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MissionTerminal {
+    /// All mission phases completed.
+    Complete {
+        /// The number of completed phases.
+        completed_phases: usize,
+    },
+    /// A mission abort condition or action failure stopped the run.
+    Aborted {
+        /// The phase index at the stop.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The stable phase action name.
+        action: String,
+        /// The abort cause.
+        cause: AbortCause,
+        /// All cleanup failures.
+        cleanup_failures: Vec<CleanupFailure>,
+    },
+    /// The host refused a phase action.
+    Refused {
+        /// The refusing phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The stable refused action name.
+        action: String,
+        /// The host refusal detail.
+        detail: String,
+        /// All cleanup failures.
+        cleanup_failures: Vec<CleanupFailure>,
+    },
+    /// A simulator-time or wall deadline stopped the run.
+    DeadlineExceeded {
+        /// The distinct deadline class and values.
+        deadline: DeadlineClass,
+        /// All cleanup failures.
+        cleanup_failures: Vec<CleanupFailure>,
+    },
+    /// A phase action did not produce a receipt in time.
+    ReceiptTimeout {
+        /// The phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The stable action name.
+        action: String,
+        /// The timed-out directive identifier.
+        action_id: ActionId,
+        /// All cleanup failures.
+        cleanup_failures: Vec<CleanupFailure>,
+    },
+}
+
+/// The progress stage of the active mission phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PhaseStage {
+    /// The engine waits for all entry conditions.
+    WaitingForEntry {},
+    /// The engine waits for the current action receipt.
+    WaitingForReceipt {
+        /// The outstanding directive identifier.
+        action_id: ActionId,
+    },
+    /// The engine waits for all completion conditions.
+    WaitingForCompletion {},
+}
+
+/// A public snapshot of mission engine state.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EngineState {
+    /// The engine is executing one mission phase.
+    Running {
+        /// The active phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The active phase progress stage.
+        stage: PhaseStage,
+    },
+    /// The engine is attempting all remaining cleanup steps.
+    CleaningUp {
+        /// The number of steps not yet completed or failed.
+        remaining_steps: usize,
+        /// The outstanding cleanup directive, when present.
+        outstanding_action_id: Option<ActionId>,
+    },
+    /// The mission has one final result.
+    Terminal {
+        /// The typed terminal result.
+        result: MissionTerminal,
+    },
+}
+
+/// A typed evidence event from one engine tick.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EngineEvent {
+    /// All entry conditions permitted a phase to start.
+    PhaseEntered {
+        /// The phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The caller simulator clock.
+        simulator_time_ns: u64,
+    },
+    /// All completion conditions completed a phase.
+    PhaseCompleted {
+        /// The phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The caller simulator clock.
+        simulator_time_ns: u64,
+    },
+    /// One abort condition matched.
+    AbortConditionMatched {
+        /// The phase index.
+        phase_index: usize,
+        /// The stable phase identifier.
+        phase_id: String,
+        /// The zero-based abort condition index.
+        condition_index: usize,
+    },
+    /// The engine emitted one typed directive.
+    DirectiveEmitted {
+        /// The complete emitted directive.
+        directive: MissionDirective,
+    },
+    /// The engine accepted one exactly correlated receipt.
+    ReceiptAccepted {
+        /// The directive context.
+        context: DirectiveContext,
+        /// The accepted host result.
+        result: ReceiptResult,
+    },
+    /// A retryable receipt caused another directive attempt.
+    DirectiveRetried {
+        /// The resolved directive identifier.
+        previous_action_id: ActionId,
+        /// The new retry directive.
+        directive: MissionDirective,
+    },
+    /// A host refusal stopped the mission action.
+    Refusal {
+        /// The refused directive context.
+        context: DirectiveContext,
+        /// The stable refused action name.
+        action: String,
+        /// The host refusal detail.
+        detail: String,
+    },
+    /// One of the two deadline classes stopped the mission.
+    DeadlineExceeded {
+        /// The deadline class and values.
+        deadline: DeadlineClass,
+    },
+    /// A phase directive did not produce a receipt in time.
+    ReceiptTimedOut {
+        /// The timed-out directive context.
+        context: DirectiveContext,
+        /// The stable action name.
+        action: String,
+    },
+    /// One cleanup step failed and cleanup continued.
+    CleanupFailed {
+        /// The typed cleanup failure.
+        failure: CleanupFailure,
+    },
+    /// The engine produced its one terminal result.
+    Terminal {
+        /// The complete terminal result.
+        result: MissionTerminal,
+    },
+}
+
+/// Directives, evidence, and state returned by one pure tick.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TickOutput {
+    /// Directives for host execution.
+    pub directives: Vec<MissionDirective>,
+    /// Typed evidence events in deterministic order.
+    pub events: Vec<EngineEvent>,
+    /// The engine state after the tick.
+    pub state: EngineState,
+}

--- a/crates/pilotage-mission-core/src/engine/run.rs
+++ b/crates/pilotage-mission-core/src/engine/run.rs
@@ -1,0 +1,317 @@
+//! Active-phase sequencing and terminal-cause selection.
+
+use super::cleanup::start_cleanup;
+use super::runtime::{
+    PendingDirective, PendingTerminal, PhaseProgress, RunState, RunningState, TickContext, emit,
+    new_pending, terminal_state,
+};
+use super::{
+    AbortCause, DeadlineClass, DirectivePurpose, EngineEvent, MissionTerminal, ReceiptResult,
+    WallDeadline,
+};
+
+pub(super) fn tick_running(
+    wall_deadline: WallDeadline,
+    state: &mut RunningState,
+    mut context: TickContext<'_>,
+) -> Option<RunState> {
+    if context.input.wall_time_ns >= wall_deadline.expires_at_ns {
+        let deadline = DeadlineClass::MissionWall {
+            deadline_ns: wall_deadline.expires_at_ns,
+            observed_ns: context.input.wall_time_ns,
+        };
+        context
+            .collector
+            .events
+            .push(EngineEvent::DeadlineExceeded {
+                deadline: deadline.clone(),
+            });
+        return Some(start_cleanup(
+            PendingTerminal::DeadlineExceeded(deadline),
+            &mut context,
+        ));
+    }
+    let phase = &context.document.phases[state.phase_index];
+    let elapsed = context
+        .input
+        .simulator_time_ns
+        .saturating_sub(state.phase_started_at_ns);
+    if elapsed >= phase.simulator_time_deadline_ns {
+        return Some(phase_deadline(state.phase_index, elapsed, &mut context));
+    }
+    if let Some(index) = abort_condition(state.phase_index, &context) {
+        return Some(abort(state.phase_index, index, &mut context));
+    }
+    let phase_started_at_ns = state.phase_started_at_ns;
+    match &mut state.progress {
+        PhaseProgress::Entry => enter_if_ready(state, &mut context),
+        PhaseProgress::Receipt(pending) => process_receipt(
+            state.phase_index,
+            phase_started_at_ns,
+            pending.as_mut(),
+            &mut context,
+        ),
+        PhaseProgress::Completion => complete_if_ready(state, &mut context),
+    }
+}
+
+fn enter_if_ready(state: &mut RunningState, context: &mut TickContext<'_>) -> Option<RunState> {
+    let phase = &context.document.phases[state.phase_index];
+    if !super::condition::all_match(
+        &phase.entry_conditions,
+        context.input.simulator_time_ns,
+        &context.input.observation,
+    ) {
+        return None;
+    }
+    let phase_id = phase.id.clone();
+    let action = phase.action.clone();
+    context.entered_phases.push(state.phase_index);
+    context.collector.events.push(EngineEvent::PhaseEntered {
+        phase_index: state.phase_index,
+        phase_id,
+        simulator_time_ns: context.input.simulator_time_ns,
+    });
+    let pending = new_pending(
+        context,
+        state.phase_index,
+        DirectivePurpose::PhaseAction {},
+        action,
+        0,
+    );
+    emit(&pending.directive, context.collector);
+    state.progress = PhaseProgress::Receipt(Box::new(pending));
+    None
+}
+
+fn process_receipt(
+    phase_index: usize,
+    phase_started_at_ns: u64,
+    pending: &mut PendingDirective,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    let Some(receipt) = context.input.receipts.first() else {
+        return receipt_timeout(phase_index, pending, context);
+    };
+    let result = receipt.result.clone();
+    let directive_context = pending.directive.context().clone();
+    context.collector.events.push(EngineEvent::ReceiptAccepted {
+        context: directive_context.clone(),
+        result: result.clone(),
+    });
+    match result {
+        ReceiptResult::Succeeded {} => {
+            complete_after_receipt(phase_index, phase_started_at_ns, context)
+        }
+        ReceiptResult::Retryable { detail } => retry_action(phase_index, pending, &detail, context),
+        ReceiptResult::Refused { detail } => Some(refused(
+            phase_index,
+            directive_context,
+            pending.directive.action_name(),
+            detail,
+            context,
+        )),
+        ReceiptResult::Failed { detail } => Some(action_failed(phase_index, detail, context)),
+    }
+}
+
+fn complete_after_receipt(
+    phase_index: usize,
+    phase_started_at_ns: u64,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    let mut state = RunningState {
+        phase_index,
+        phase_started_at_ns,
+        progress: PhaseProgress::Completion,
+    };
+    complete_if_ready(&mut state, context).or(Some(RunState::Running(state)))
+}
+
+fn retry_action(
+    phase_index: usize,
+    pending: &mut PendingDirective,
+    detail: &str,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    if pending.retries_used >= context.document.execution_policy.retry_limit {
+        let phase = &context.document.phases[phase_index];
+        let cause = PendingTerminal::Aborted {
+            phase_index,
+            phase_id: phase.id.clone(),
+            action: phase.action.name().to_owned(),
+            cause: AbortCause::RetryLimitExceeded {
+                detail: detail.to_owned(),
+                retry_limit: context.document.execution_policy.retry_limit,
+            },
+        };
+        return Some(start_cleanup(cause, context));
+    }
+    let previous_action_id = pending.directive.context().action_id;
+    let retries_used = pending.retries_used.wrapping_add(1);
+    let action = pending.directive.action();
+    let retry = new_pending(
+        context,
+        phase_index,
+        DirectivePurpose::PhaseAction {},
+        action,
+        retries_used,
+    );
+    context
+        .collector
+        .events
+        .push(EngineEvent::DirectiveRetried {
+            previous_action_id,
+            directive: retry.directive.clone(),
+        });
+    emit(&retry.directive, context.collector);
+    *pending = retry;
+    None
+}
+
+fn receipt_timeout(
+    phase_index: usize,
+    pending: &PendingDirective,
+    context: &mut TickContext<'_>,
+) -> Option<RunState> {
+    let elapsed = context
+        .input
+        .wall_time_ns
+        .saturating_sub(pending.emitted_at_wall_ns);
+    if elapsed < context.document.execution_policy.receipt_timeout_ns {
+        return None;
+    }
+    let directive_context = pending.directive.context().clone();
+    let action = pending.directive.action_name().to_owned();
+    context.collector.events.push(EngineEvent::ReceiptTimedOut {
+        context: directive_context.clone(),
+        action: action.clone(),
+    });
+    Some(start_cleanup(
+        PendingTerminal::ReceiptTimeout {
+            phase_index,
+            phase_id: context.document.phases[phase_index].id.clone(),
+            action,
+            action_id: directive_context.action_id,
+        },
+        context,
+    ))
+}
+
+fn complete_if_ready(state: &mut RunningState, context: &mut TickContext<'_>) -> Option<RunState> {
+    let phase = &context.document.phases[state.phase_index];
+    if !super::condition::all_match(
+        &phase.completion_conditions,
+        context.input.simulator_time_ns,
+        &context.input.observation,
+    ) {
+        return None;
+    }
+    context.collector.events.push(EngineEvent::PhaseCompleted {
+        phase_index: state.phase_index,
+        phase_id: phase.id.clone(),
+        simulator_time_ns: context.input.simulator_time_ns,
+    });
+    let next = state.phase_index.wrapping_add(1);
+    if next == context.document.phases.len() {
+        return Some(terminal_state(
+            MissionTerminal::Complete {
+                completed_phases: context.document.phases.len(),
+            },
+            context.collector,
+        ));
+    }
+    state.phase_index = next;
+    state.phase_started_at_ns = context.input.simulator_time_ns;
+    state.progress = PhaseProgress::Entry;
+    activate_new_phase(state, context)
+}
+
+fn activate_new_phase(state: &mut RunningState, context: &mut TickContext<'_>) -> Option<RunState> {
+    if let Some(index) = abort_condition(state.phase_index, context) {
+        return Some(abort(state.phase_index, index, context));
+    }
+    enter_if_ready(state, context)
+}
+
+fn abort_condition(phase_index: usize, context: &TickContext<'_>) -> Option<usize> {
+    super::condition::first_match(
+        &context.document.phases[phase_index].abort_conditions,
+        context.input.simulator_time_ns,
+        &context.input.observation,
+    )
+}
+
+fn phase_deadline(phase_index: usize, elapsed_ns: u64, context: &mut TickContext<'_>) -> RunState {
+    let phase = &context.document.phases[phase_index];
+    let deadline = DeadlineClass::PhaseSimulatorTime {
+        phase_index,
+        phase_id: phase.id.clone(),
+        limit_ns: phase.simulator_time_deadline_ns,
+        elapsed_ns,
+    };
+    context
+        .collector
+        .events
+        .push(EngineEvent::DeadlineExceeded {
+            deadline: deadline.clone(),
+        });
+    start_cleanup(PendingTerminal::DeadlineExceeded(deadline), context)
+}
+
+fn abort(phase_index: usize, condition_index: usize, context: &mut TickContext<'_>) -> RunState {
+    let phase = &context.document.phases[phase_index];
+    let phase_id = phase.id.clone();
+    let action = phase.action.name().to_owned();
+    context
+        .collector
+        .events
+        .push(EngineEvent::AbortConditionMatched {
+            phase_index,
+            phase_id: phase_id.clone(),
+            condition_index,
+        });
+    start_cleanup(
+        PendingTerminal::Aborted {
+            phase_index,
+            phase_id,
+            action,
+            cause: AbortCause::Condition { condition_index },
+        },
+        context,
+    )
+}
+
+fn refused(
+    phase_index: usize,
+    directive_context: super::DirectiveContext,
+    action: &str,
+    detail: String,
+    context: &mut TickContext<'_>,
+) -> RunState {
+    context.collector.events.push(EngineEvent::Refusal {
+        context: directive_context,
+        action: action.to_owned(),
+        detail: detail.clone(),
+    });
+    start_cleanup(
+        PendingTerminal::Refused {
+            phase_index,
+            phase_id: context.document.phases[phase_index].id.clone(),
+            action: action.to_owned(),
+            detail,
+        },
+        context,
+    )
+}
+
+fn action_failed(phase_index: usize, detail: String, context: &mut TickContext<'_>) -> RunState {
+    let phase = &context.document.phases[phase_index];
+    let cause = PendingTerminal::Aborted {
+        phase_index,
+        phase_id: phase.id.clone(),
+        action: phase.action.name().to_owned(),
+        cause: AbortCause::ActionFailed { detail },
+    };
+    start_cleanup(cause, context)
+}

--- a/crates/pilotage-mission-core/src/engine/runtime.rs
+++ b/crates/pilotage-mission-core/src/engine/runtime.rs
@@ -1,0 +1,206 @@
+//! Shared runtime state for sequencing and cleanup.
+
+use crate::{MissionAction, MissionDocument};
+
+use super::{
+    AbortCause, ActionId, CleanupFailure, DirectiveContext, DirectivePurpose, EngineEvent,
+    EngineState, MissionDirective, MissionTerminal, PhaseStage, TickInput,
+};
+
+#[derive(Clone, Debug)]
+pub(super) enum RunState {
+    Running(RunningState),
+    CleaningUp(Box<CleanupState>),
+    Terminal(MissionTerminal),
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct RunningState {
+    pub(super) phase_index: usize,
+    pub(super) phase_started_at_ns: u64,
+    pub(super) progress: PhaseProgress,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum PhaseProgress {
+    Entry,
+    Receipt(Box<PendingDirective>),
+    Completion,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PendingDirective {
+    pub(super) directive: MissionDirective,
+    pub(super) emitted_at_wall_ns: u64,
+    pub(super) retries_used: u16,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CleanupStep {
+    pub(super) phase_index: usize,
+    pub(super) phase_id: String,
+    pub(super) cleanup_index: usize,
+    pub(super) action: MissionAction,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CleanupState {
+    pub(super) cause: PendingTerminal,
+    pub(super) steps: Vec<CleanupStep>,
+    pub(super) cursor: usize,
+    pub(super) pending: Option<PendingDirective>,
+    pub(super) failures: Vec<CleanupFailure>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum PendingTerminal {
+    Aborted {
+        phase_index: usize,
+        phase_id: String,
+        action: String,
+        cause: AbortCause,
+    },
+    Refused {
+        phase_index: usize,
+        phase_id: String,
+        action: String,
+        detail: String,
+    },
+    DeadlineExceeded(super::DeadlineClass),
+    ReceiptTimeout {
+        phase_index: usize,
+        phase_id: String,
+        action: String,
+        action_id: ActionId,
+    },
+}
+
+#[derive(Default)]
+pub(super) struct TickCollector {
+    pub(super) directives: Vec<MissionDirective>,
+    pub(super) events: Vec<EngineEvent>,
+}
+
+pub(super) struct TickContext<'a> {
+    pub(super) document: &'a MissionDocument,
+    pub(super) entered_phases: &'a mut Vec<usize>,
+    pub(super) last_action_id: &'a mut u32,
+    pub(super) input: &'a TickInput,
+    pub(super) collector: &'a mut TickCollector,
+}
+
+pub(super) fn new_pending(
+    context: &mut TickContext<'_>,
+    phase_index: usize,
+    purpose: DirectivePurpose,
+    action: MissionAction,
+    retries_used: u16,
+) -> PendingDirective {
+    let action_id = next_action_id(context.last_action_id);
+    let directive_context = DirectiveContext {
+        action_id,
+        phase_index,
+        phase_id: context.document.phases[phase_index].id.clone(),
+        attempt: u32::from(retries_used).wrapping_add(1),
+        purpose,
+    };
+    PendingDirective {
+        directive: MissionDirective::new(directive_context, action),
+        emitted_at_wall_ns: context.input.wall_time_ns,
+        retries_used,
+    }
+}
+
+pub(super) fn emit(directive: &MissionDirective, collector: &mut TickCollector) {
+    collector.directives.push(directive.clone());
+    collector.events.push(EngineEvent::DirectiveEmitted {
+        directive: directive.clone(),
+    });
+}
+
+pub(super) fn terminal_state(result: MissionTerminal, collector: &mut TickCollector) -> RunState {
+    collector.events.push(EngineEvent::Terminal {
+        result: result.clone(),
+    });
+    RunState::Terminal(result)
+}
+
+pub(super) fn running_snapshot(document: &MissionDocument, state: &RunningState) -> EngineState {
+    let stage = match &state.progress {
+        PhaseProgress::Entry => PhaseStage::WaitingForEntry {},
+        PhaseProgress::Receipt(pending) => PhaseStage::WaitingForReceipt {
+            action_id: pending.directive.context().action_id,
+        },
+        PhaseProgress::Completion => PhaseStage::WaitingForCompletion {},
+    };
+    EngineState::Running {
+        phase_index: state.phase_index,
+        phase_id: document.phases[state.phase_index].id.clone(),
+        stage,
+    }
+}
+
+pub(super) fn cleanup_snapshot(state: &CleanupState) -> EngineState {
+    EngineState::CleaningUp {
+        remaining_steps: state.steps.len().saturating_sub(state.cursor),
+        outstanding_action_id: state
+            .pending
+            .as_ref()
+            .map(|pending| pending.directive.context().action_id),
+    }
+}
+
+fn next_action_id(last_action_id: &mut u32) -> ActionId {
+    *last_action_id = last_action_id.wrapping_add(1);
+    if *last_action_id == 0 {
+        *last_action_id = last_action_id.wrapping_add(1);
+    }
+    ActionId(*last_action_id)
+}
+
+impl PendingTerminal {
+    pub(super) fn finish(self, cleanup_failures: Vec<CleanupFailure>) -> MissionTerminal {
+        match self {
+            Self::Aborted {
+                phase_index,
+                phase_id,
+                action,
+                cause,
+            } => MissionTerminal::Aborted {
+                phase_index,
+                phase_id,
+                action,
+                cause,
+                cleanup_failures,
+            },
+            Self::Refused {
+                phase_index,
+                phase_id,
+                action,
+                detail,
+            } => MissionTerminal::Refused {
+                phase_index,
+                phase_id,
+                action,
+                detail,
+                cleanup_failures,
+            },
+            Self::DeadlineExceeded(deadline) => MissionTerminal::DeadlineExceeded {
+                deadline,
+                cleanup_failures,
+            },
+            Self::ReceiptTimeout {
+                phase_index,
+                phase_id,
+                action,
+                action_id,
+            } => MissionTerminal::ReceiptTimeout {
+                phase_index,
+                phase_id,
+                action,
+                action_id,
+                cleanup_failures,
+            },
+        }
+    }
+}

--- a/crates/pilotage-mission-core/src/engine/tests.rs
+++ b/crates/pilotage-mission-core/src/engine/tests.rs
@@ -1,0 +1,6 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod cleanup;
+mod determinism;
+mod support;
+mod transitions;

--- a/crates/pilotage-mission-core/src/engine/tests/cleanup.rs
+++ b/crates/pilotage-mission-core/src/engine/tests/cleanup.rs
@@ -1,0 +1,122 @@
+use crate::{
+    DirectivePurpose, DirectiveReceipt, FlightAction, MissionAction, MissionCondition,
+    MissionObservation, MissionTerminal, ReceiptResult, VehicleCondition,
+};
+
+use super::support::{document, engine, phase, succeeded, terminal, tick};
+
+#[test]
+fn abort_cleanup_reverses_phases_attempts_all_steps_and_aggregates_failures() {
+    let mut first = phase("first");
+    first.cleanup_actions = vec![MissionAction::Flight(FlightAction::Land {})];
+    first.abort_conditions = vec![crash_condition()];
+    first
+        .required_capabilities
+        .push(crate::MissionCapability::FlightControl);
+    let mut second = phase("second");
+    second.cleanup_actions = vec![
+        MissionAction::Flight(FlightAction::Hold {}),
+        MissionAction::Flight(FlightAction::Disarm {}),
+    ];
+    second.abort_conditions = vec![crash_condition()];
+    second
+        .required_capabilities
+        .push(crate::MissionCapability::FlightControl);
+    let mut engine = engine(document(vec![first, second]));
+
+    let first_action = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let second_action = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![succeeded(&first_action)],
+    );
+    assert_eq!(second_action.directives[0].context().phase_id, "second");
+
+    let first_cleanup = tick(&mut engine, 2, 2, crashed_observation(), Vec::new());
+    assert_cleanup(&first_cleanup, 1, "second", 0, "flight.hold");
+    let second_cleanup = tick(
+        &mut engine,
+        3,
+        3,
+        MissionObservation::default(),
+        vec![receipt(
+            &first_cleanup,
+            ReceiptResult::Failed {
+                detail: "hold failed".to_owned(),
+            },
+        )],
+    );
+    assert_cleanup(&second_cleanup, 1, "second", 1, "flight.disarm");
+    let third_cleanup = tick(
+        &mut engine,
+        4,
+        4,
+        MissionObservation::default(),
+        vec![receipt(&second_cleanup, ReceiptResult::Succeeded {})],
+    );
+    assert_cleanup(&third_cleanup, 0, "first", 0, "flight.land");
+    let finished = tick(
+        &mut engine,
+        5,
+        5,
+        MissionObservation::default(),
+        vec![receipt(
+            &third_cleanup,
+            ReceiptResult::Refused {
+                detail: "land refused".to_owned(),
+            },
+        )],
+    );
+    assert!(matches!(
+        terminal(&finished),
+        MissionTerminal::Aborted {
+            cleanup_failures,
+            ..
+        } if cleanup_failures.len() == 2
+            && cleanup_failures[0].action == "flight.hold"
+            && cleanup_failures[1].action == "flight.land"
+    ));
+}
+
+fn crash_condition() -> MissionCondition {
+    MissionCondition::Vehicle(VehicleCondition::Crashed { expected: true })
+}
+
+fn crashed_observation() -> MissionObservation {
+    MissionObservation {
+        vehicle: crate::VehicleObservation {
+            crashed: Some(true),
+            ..crate::VehicleObservation::default()
+        },
+        ..MissionObservation::default()
+    }
+}
+
+fn receipt(output: &crate::TickOutput, result: ReceiptResult) -> DirectiveReceipt {
+    DirectiveReceipt {
+        action_id: output.directives[0].context().action_id,
+        result,
+    }
+}
+
+fn assert_cleanup(
+    output: &crate::TickOutput,
+    phase_index: usize,
+    phase_id: &str,
+    cleanup_index: usize,
+    action_name: &str,
+) {
+    assert_eq!(output.directives.len(), 1);
+    let directive = &output.directives[0];
+    assert_eq!(directive.context().phase_index, phase_index);
+    assert_eq!(directive.context().phase_id, phase_id);
+    assert_eq!(directive.action_name(), action_name);
+    assert!(matches!(
+        directive.context().purpose,
+        DirectivePurpose::Cleanup {
+            cleanup_index: actual
+        } if actual == cleanup_index
+    ));
+}

--- a/crates/pilotage-mission-core/src/engine/tests/determinism.rs
+++ b/crates/pilotage-mission-core/src/engine/tests/determinism.rs
@@ -1,0 +1,130 @@
+use crate::{
+    ActionId, DirectiveReceipt, EngineInputError, EngineStart, EngineStartError, EngineState,
+    ExecutionTarget, MissionDocument, MissionEngine, MissionObservation, ReceiptResult, TickInput,
+    WallDeadline,
+};
+
+use super::support::{WALL_DEADLINE_NS, digest, document, engine, phase, succeeded, tick};
+
+#[test]
+fn identical_document_bytes_and_inputs_produce_identical_outputs() {
+    let bytes = document(vec![phase("only")])
+        .to_canonical_json()
+        .expect("canonical mission");
+    let first = run_bytes(&bytes);
+    let second = run_bytes(&bytes);
+    assert_eq!(first, second);
+    assert!(matches!(
+        first[1].state,
+        EngineState::Terminal {
+            result: crate::MissionTerminal::Complete { .. }
+        }
+    ));
+}
+
+fn run_bytes(bytes: &[u8]) -> Vec<crate::TickOutput> {
+    let document = MissionDocument::from_json(bytes).expect("decode mission");
+    let mut engine = engine(document);
+    let first = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let second = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![succeeded(&first)],
+    );
+    vec![first, second]
+}
+
+#[test]
+fn stale_receipt_is_rejected_without_changing_state() {
+    let mut engine = engine(document(vec![phase("only")]));
+    let first = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let expected = engine.state();
+    let error = engine
+        .tick(TickInput {
+            simulator_time_ns: 1,
+            wall_time_ns: 1,
+            observation: MissionObservation::default(),
+            receipts: vec![DirectiveReceipt {
+                action_id: ActionId(99),
+                result: ReceiptResult::Succeeded {},
+            }],
+        })
+        .expect_err("stale receipt");
+    assert!(matches!(error, EngineInputError::StaleReceipt { .. }));
+    assert_eq!(engine.state(), expected);
+    let correct = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![succeeded(&first)],
+    );
+    assert!(matches!(correct.state, EngineState::Terminal { .. }));
+}
+
+#[test]
+fn action_identifier_wrap_skips_zero_and_replaces_the_resolved_attempt() {
+    let mut engine = engine(document(vec![phase("wrap")]));
+    engine.last_action_id = u32::MAX.wrapping_sub(1);
+    let first = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let first_id = first.directives[0].context().action_id;
+    assert_eq!(first_id.get(), u32::MAX);
+    let retry = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![DirectiveReceipt {
+            action_id: first_id,
+            result: ReceiptResult::Retryable {
+                detail: "try again".to_owned(),
+            },
+        }],
+    );
+    let retry_id = retry.directives[0].context().action_id;
+    assert_eq!(retry_id.get(), 1);
+    assert_ne!(retry_id, first_id);
+    assert!(matches!(
+        retry.state,
+        EngineState::Running {
+            stage: crate::PhaseStage::WaitingForReceipt { action_id },
+            ..
+        } if action_id == retry_id
+    ));
+    let stale = engine
+        .tick(TickInput {
+            simulator_time_ns: 2,
+            wall_time_ns: 2,
+            observation: MissionObservation::default(),
+            receipts: vec![DirectiveReceipt {
+                action_id: first_id,
+                result: ReceiptResult::Succeeded {},
+            }],
+        })
+        .expect_err("resolved identifier must be stale");
+    assert!(matches!(stale, EngineInputError::StaleReceipt { .. }));
+}
+
+#[test]
+fn wall_deadline_identity_must_match_the_mission_digest() {
+    let document = document(vec![phase("identity")]);
+    let error = MissionEngine::start(
+        document,
+        EngineStart {
+            host_target: ExecutionTarget::Simulator,
+            simulator_time_ns: 0,
+            wall_time_ns: 0,
+            wall_deadline: WallDeadline {
+                mission_content_digest: digest(99),
+                expires_at_ns: WALL_DEADLINE_NS,
+            },
+        },
+    )
+    .expect_err("deadline identity mismatch");
+    assert!(matches!(
+        error,
+        EngineStartError::WallDeadlineIdentity { .. }
+    ));
+}

--- a/crates/pilotage-mission-core/src/engine/tests/support.rs
+++ b/crates/pilotage-mission-core/src/engine/tests/support.rs
@@ -1,0 +1,110 @@
+use crate::{
+    Digest, DirectiveReceipt, EngineStart, EngineState, ExecutionPolicy, ExecutionTarget,
+    FlightAction, MissionAction, MissionCapability, MissionCondition, MissionDocument,
+    MissionEngine, MissionObservation, MissionPhase, MissionTerminal, NavigationDataIdentity,
+    ReceiptResult, TickInput, TickOutput, WallDeadline,
+};
+
+pub(super) const PHASE_DEADLINE_NS: u64 = 100;
+pub(super) const RECEIPT_TIMEOUT_NS: u64 = 20;
+pub(super) const WALL_DEADLINE_NS: u64 = 1_000;
+
+pub(super) fn digest(byte: u8) -> Digest {
+    Digest::from_bytes([byte; 32])
+}
+
+pub(super) fn phase(id: &str) -> MissionPhase {
+    MissionPhase {
+        id: id.to_owned(),
+        required_capabilities: vec![
+            MissionCapability::SimulatorTime,
+            MissionCapability::ArmDisarm,
+            MissionCapability::ContactState,
+        ],
+        entry_conditions: Vec::new(),
+        action: MissionAction::Flight(FlightAction::Arm {}),
+        cleanup_actions: Vec::new(),
+        completion_conditions: Vec::new(),
+        abort_conditions: Vec::new(),
+        simulator_time_deadline_ns: PHASE_DEADLINE_NS,
+    }
+}
+
+pub(super) fn document(phases: Vec<MissionPhase>) -> MissionDocument {
+    MissionDocument::new(
+        "engine-mission-1".to_owned(),
+        NavigationDataIdentity {
+            cycle: "2608".to_owned(),
+            snapshot_id: "nav-engine-1".to_owned(),
+            snapshot_digest: digest(7),
+        },
+        ExecutionPolicy {
+            target: ExecutionTarget::Simulator,
+            retry_limit: 1,
+            receipt_timeout_ns: RECEIPT_TIMEOUT_NS,
+        },
+        phases,
+    )
+    .expect("test mission")
+}
+
+pub(super) fn engine(document: MissionDocument) -> MissionEngine {
+    let mission_content_digest = document.identity.content_digest;
+    MissionEngine::start(
+        document,
+        EngineStart {
+            host_target: ExecutionTarget::Simulator,
+            simulator_time_ns: 0,
+            wall_time_ns: 0,
+            wall_deadline: WallDeadline {
+                mission_content_digest,
+                expires_at_ns: WALL_DEADLINE_NS,
+            },
+        },
+    )
+    .expect("start test mission")
+}
+
+pub(super) fn tick(
+    engine: &mut MissionEngine,
+    simulator_time_ns: u64,
+    wall_time_ns: u64,
+    observation: MissionObservation,
+    receipts: Vec<DirectiveReceipt>,
+) -> TickOutput {
+    engine
+        .tick(TickInput {
+            simulator_time_ns,
+            wall_time_ns,
+            observation,
+            receipts,
+        })
+        .expect("valid tick")
+}
+
+pub(super) fn succeeded(output: &TickOutput) -> DirectiveReceipt {
+    DirectiveReceipt {
+        action_id: output.directives[0].context().action_id,
+        result: ReceiptResult::Succeeded {},
+    }
+}
+
+pub(super) fn terminal(output: &TickOutput) -> &MissionTerminal {
+    let EngineState::Terminal { result } = &output.state else {
+        panic!("expected terminal output: {output:?}");
+    };
+    result
+}
+
+pub(super) fn condition_phase(
+    entry_conditions: Vec<MissionCondition>,
+    completion_conditions: Vec<MissionCondition>,
+    abort_conditions: Vec<MissionCondition>,
+) -> MissionPhase {
+    MissionPhase {
+        entry_conditions,
+        completion_conditions,
+        abort_conditions,
+        ..phase("condition-phase")
+    }
+}

--- a/crates/pilotage-mission-core/src/engine/tests/transitions.rs
+++ b/crates/pilotage-mission-core/src/engine/tests/transitions.rs
@@ -1,0 +1,261 @@
+use crate::{
+    Comparison, DeadlineClass, DirectiveReceipt, EngineState, MissionCondition, MissionObservation,
+    MissionTerminal, ReceiptResult, SimulatorCondition, VehicleCondition,
+};
+
+use super::support::{
+    PHASE_DEADLINE_NS, RECEIPT_TIMEOUT_NS, WALL_DEADLINE_NS, condition_phase, document, engine,
+    phase, succeeded, terminal, tick,
+};
+
+#[test]
+fn entry_and_completion_conditions_gate_their_transitions() {
+    let phase = condition_phase(
+        vec![MissionCondition::Vehicle(VehicleCondition::LinkValid {
+            expected: true,
+        })],
+        vec![MissionCondition::Vehicle(VehicleCondition::GroundContact {
+            expected: true,
+        })],
+        Vec::new(),
+    );
+    let mut engine = engine(document(vec![phase]));
+    let waiting = tick(&mut engine, 0, 0, observation(false, false), Vec::new());
+    assert!(waiting.directives.is_empty());
+    assert!(matches!(
+        waiting.state,
+        EngineState::Running {
+            stage: crate::PhaseStage::WaitingForEntry {},
+            ..
+        }
+    ));
+    let entered = tick(&mut engine, 1, 1, observation(true, false), Vec::new());
+    assert_eq!(entered.directives.len(), 1);
+    let acknowledged = tick(
+        &mut engine,
+        2,
+        2,
+        observation(true, false),
+        vec![succeeded(&entered)],
+    );
+    assert!(matches!(
+        acknowledged.state,
+        EngineState::Running {
+            stage: crate::PhaseStage::WaitingForCompletion {},
+            ..
+        }
+    ));
+    let complete = tick(&mut engine, 3, 3, observation(true, true), Vec::new());
+    assert!(matches!(
+        terminal(&complete),
+        MissionTerminal::Complete { .. }
+    ));
+}
+
+#[test]
+fn abort_condition_gates_the_aborted_terminal() {
+    let phase = condition_phase(
+        Vec::new(),
+        vec![MissionCondition::Vehicle(VehicleCondition::GroundContact {
+            expected: true,
+        })],
+        vec![MissionCondition::Vehicle(VehicleCondition::Crashed {
+            expected: true,
+        })],
+    );
+    let mut engine = engine(document(vec![phase]));
+    let active = tick(&mut engine, 0, 0, observation(true, false), Vec::new());
+    let waiting = tick(
+        &mut engine,
+        1,
+        1,
+        observation(true, false),
+        vec![succeeded(&active)],
+    );
+    assert!(matches!(waiting.state, EngineState::Running { .. }));
+    let aborted = tick(&mut engine, 2, 2, crashed_observation(), Vec::new());
+    assert!(matches!(
+        terminal(&aborted),
+        MissionTerminal::Aborted {
+            cause: crate::AbortCause::Condition { condition_index: 0 },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn refused_receipt_names_the_refusing_phase_and_action() {
+    let mut engine = engine(document(vec![phase("refusing-phase")]));
+    let emitted = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let refused = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![DirectiveReceipt {
+            action_id: emitted.directives[0].context().action_id,
+            result: ReceiptResult::Refused {
+                detail: "unsupported action".to_owned(),
+            },
+        }],
+    );
+    assert!(matches!(
+        terminal(&refused),
+        MissionTerminal::Refused {
+            phase_id,
+            action,
+            detail,
+            ..
+        } if phase_id == "refusing-phase"
+            && action == "flight.arm"
+            && detail == "unsupported action"
+    ));
+}
+
+#[test]
+fn phase_and_wall_deadlines_have_distinct_typed_classes() {
+    let mut phase_engine = engine(document(vec![phase("phase-deadline")]));
+    let phase_output = tick(
+        &mut phase_engine,
+        PHASE_DEADLINE_NS,
+        1,
+        MissionObservation::default(),
+        Vec::new(),
+    );
+    assert!(matches!(
+        terminal(&phase_output),
+        MissionTerminal::DeadlineExceeded {
+            deadline: DeadlineClass::PhaseSimulatorTime { .. },
+            ..
+        }
+    ));
+
+    let mut wall_engine = engine(document(vec![phase("wall-deadline")]));
+    let wall_output = tick(
+        &mut wall_engine,
+        1,
+        WALL_DEADLINE_NS,
+        MissionObservation::default(),
+        Vec::new(),
+    );
+    assert!(matches!(
+        terminal(&wall_output),
+        MissionTerminal::DeadlineExceeded {
+            deadline: DeadlineClass::MissionWall { .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn entry_wait_is_part_of_the_phase_deadline() {
+    let phase = condition_phase(
+        vec![MissionCondition::Simulator(SimulatorCondition::Time {
+            comparison: Comparison::GreaterThan,
+            value_ns: PHASE_DEADLINE_NS,
+        })],
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut engine = engine(document(vec![phase]));
+    let waiting = tick(
+        &mut engine,
+        PHASE_DEADLINE_NS.wrapping_sub(1),
+        1,
+        MissionObservation::default(),
+        Vec::new(),
+    );
+    assert!(waiting.directives.is_empty());
+    let deadline = tick(
+        &mut engine,
+        PHASE_DEADLINE_NS,
+        2,
+        MissionObservation::default(),
+        Vec::new(),
+    );
+    assert!(matches!(
+        terminal(&deadline),
+        MissionTerminal::DeadlineExceeded {
+            deadline: DeadlineClass::PhaseSimulatorTime { .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn missing_receipt_has_its_own_terminal_class() {
+    let mut engine = engine(document(vec![phase("receipt-timeout")]));
+    let emitted = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let action_id = emitted.directives[0].context().action_id;
+    let timeout = tick(
+        &mut engine,
+        1,
+        RECEIPT_TIMEOUT_NS,
+        MissionObservation::default(),
+        Vec::new(),
+    );
+    assert!(matches!(
+        terminal(&timeout),
+        MissionTerminal::ReceiptTimeout {
+            action_id: timed_out,
+            ..
+        } if *timed_out == action_id
+    ));
+}
+
+#[test]
+fn retryable_receipts_stop_at_the_document_retry_limit() {
+    let mut engine = engine(document(vec![phase("bounded-retry")]));
+    let first = tick(&mut engine, 0, 0, MissionObservation::default(), Vec::new());
+    let retry = tick(
+        &mut engine,
+        1,
+        1,
+        MissionObservation::default(),
+        vec![retryable(&first, "first retry")],
+    );
+    let stopped = tick(
+        &mut engine,
+        2,
+        2,
+        MissionObservation::default(),
+        vec![retryable(&retry, "limit reached")],
+    );
+    assert!(matches!(
+        terminal(&stopped),
+        MissionTerminal::Aborted {
+            cause: crate::AbortCause::RetryLimitExceeded { retry_limit: 1, .. },
+            ..
+        }
+    ));
+}
+
+fn retryable(output: &crate::TickOutput, detail: &str) -> DirectiveReceipt {
+    DirectiveReceipt {
+        action_id: output.directives[0].context().action_id,
+        result: ReceiptResult::Retryable {
+            detail: detail.to_owned(),
+        },
+    }
+}
+
+fn observation(link_valid: bool, ground_contact: bool) -> MissionObservation {
+    MissionObservation {
+        vehicle: crate::VehicleObservation {
+            link_valid: Some(link_valid),
+            ground_contact: Some(ground_contact),
+            ..crate::VehicleObservation::default()
+        },
+        ..MissionObservation::default()
+    }
+}
+
+fn crashed_observation() -> MissionObservation {
+    MissionObservation {
+        vehicle: crate::VehicleObservation {
+            crashed: Some(true),
+            ..crate::VehicleObservation::default()
+        },
+        ..MissionObservation::default()
+    }
+}

--- a/crates/pilotage-mission-core/src/lib.rs
+++ b/crates/pilotage-mission-core/src/lib.rs
@@ -5,6 +5,7 @@ mod canonical;
 mod condition;
 mod digest;
 mod document;
+mod engine;
 mod error;
 mod identity;
 mod signal;
@@ -20,6 +21,13 @@ pub use digest::Digest;
 pub use document::{
     ExecutionPolicy, ExecutionTarget, MissionCapability, MissionDocument, MissionPhase,
 };
+pub use engine::{
+    AbortCause, ActionId, CleanupFailure, CleanupFailureKind, DeadlineClass, DirectiveContext,
+    DirectivePurpose, DirectiveReceipt, EngineEvent, EngineInputError, EngineStart,
+    EngineStartError, EngineState, FlightDirective, MissionDirective, MissionEngine,
+    MissionObservation, MissionTerminal, NavigationObservation, ObservedSignal, PhaseStage,
+    ReceiptResult, TickInput, TickOutput, TrialDirective, VehicleObservation, WallDeadline,
+};
 pub use error::{CodecError, ValidationError};
 pub use identity::{
     ArtifactIdentity, FlightPlanReference, MissionIdentity, NavigationDataIdentity,
@@ -31,7 +39,7 @@ pub use signal::{
 pub use trial::{SineComponent, StartHeading, StartState, Waveform};
 
 /// The mission document schema version supported by this crate.
-pub const MISSION_SCHEMA_VERSION: u16 = 1;
+pub const MISSION_SCHEMA_VERSION: u16 = 2;
 
 /// The maximum encoded mission document size.
 pub const MAX_DOCUMENT_BYTES: usize = 1_048_576;
@@ -44,6 +52,9 @@ pub const MAX_PHASE_CONDITIONS: usize = 64;
 
 /// The maximum number of capabilities in one phase.
 pub const MAX_CAPABILITIES: usize = 32;
+
+/// The maximum number of cleanup actions in one phase.
+pub const MAX_CLEANUP_ACTIONS: usize = 32;
 
 /// The maximum number of bytes in one text field.
 pub const MAX_TEXT_BYTES: usize = 256;

--- a/crates/pilotage-mission-core/src/tests.rs
+++ b/crates/pilotage-mission-core/src/tests.rs
@@ -8,13 +8,15 @@ use crate::{
 };
 
 const CANONICAL_FIXTURE: &[u8] = concat!(
-    "{\"identity\":{\"revision_id\":\"mission-1\",\"schema_version\":1,",
-    "\"content_digest\":\"058815dfb94ec2a28ba81f67ed6493cffcbdc2ea3de8921e7afeeccea51b22d8\",",
+    "{\"identity\":{\"revision_id\":\"mission-1\",\"schema_version\":2,",
+    "\"content_digest\":\"39948a4de2c0ffe060c45b243e82eb575d9cddb68204f097b36c5f3995c9b996\",",
     "\"navigation_data_identity\":{\"cycle\":\"2608\",\"snapshot_id\":\"nav-1\",",
     "\"snapshot_digest\":\"0101010101010101010101010101010101010101010101010101010101010101\"}},",
-    "\"execution_policy\":{\"target\":\"real_vehicle\"},\"phases\":[{\"id\":\"phase-1\",",
+    "\"execution_policy\":{\"target\":\"real_vehicle\",\"retry_limit\":2,",
+    "\"receipt_timeout_ns\":500000},\"phases\":[{\"id\":\"phase-1\",",
     "\"required_capabilities\":[\"simulator_time\",\"arm_disarm\"],\"entry_conditions\":[],",
     "\"action\":{\"domain\":\"flight\",\"action\":{\"kind\":\"arm\"}},",
+    "\"cleanup_actions\":[],",
     "\"completion_conditions\":[],\"abort_conditions\":[],",
     "\"simulator_time_deadline_ns\":1000000}]}"
 )
@@ -44,6 +46,7 @@ fn phase(id: &str, action: MissionAction) -> MissionPhase {
         required_capabilities,
         entry_conditions: Vec::new(),
         action,
+        cleanup_actions: Vec::new(),
         completion_conditions: Vec::new(),
         abort_conditions: Vec::new(),
         simulator_time_deadline_ns: 1_000_000,
@@ -57,7 +60,11 @@ fn document_for(
     MissionDocument::new(
         "mission-1".to_owned(),
         navigation_data(1),
-        ExecutionPolicy { target },
+        ExecutionPolicy {
+            target,
+            retry_limit: 2,
+            receipt_timeout_ns: 500_000,
+        },
         vec![phase("phase-1", action)],
     )
 }
@@ -135,7 +142,7 @@ fn identity_and_policy_field_groups_change_digest() {
         original
     );
     let mut schema = document.clone();
-    schema.identity.schema_version = 2;
+    schema.identity.schema_version = 3;
     assert_ne!(schema.calculate_content_digest().expect("digest"), original);
     let mut navdata = document.clone();
     navdata.identity.navigation_data_identity.cycle = "2609".to_owned();
@@ -146,6 +153,24 @@ fn identity_and_policy_field_groups_change_digest() {
     let mut policy = document;
     policy.execution_policy.target = ExecutionTarget::Simulator;
     assert_ne!(policy.calculate_content_digest().expect("digest"), original);
+    let mut timeout = valid_document();
+    timeout.execution_policy.receipt_timeout_ns =
+        timeout.execution_policy.receipt_timeout_ns.wrapping_add(1);
+    assert_ne!(
+        timeout.calculate_content_digest().expect("digest"),
+        original
+    );
+}
+
+#[test]
+fn retry_limit_change_changes_content_digest() {
+    let mut document = valid_document();
+    let original = document.calculate_content_digest().expect("digest");
+    document.execution_policy.retry_limit = document.execution_policy.retry_limit.wrapping_add(1);
+    assert_ne!(
+        document.calculate_content_digest().expect("digest"),
+        original
+    );
 }
 
 #[test]
@@ -154,6 +179,14 @@ fn each_phase_field_group_changes_digest() {
     let original = document.calculate_content_digest().expect("digest");
     let mut changed = document.clone();
     changed.phases[0].id.push_str("-changed");
+    assert_ne!(
+        changed.calculate_content_digest().expect("digest"),
+        original
+    );
+    changed = document.clone();
+    changed.phases[0]
+        .cleanup_actions
+        .push(MissionAction::Flight(FlightAction::Disarm {}));
     assert_ne!(
         changed.calculate_content_digest().expect("digest"),
         original
@@ -292,6 +325,12 @@ fn validation_rejects_missing_deadline_and_capability() {
             ..
         })
     ));
+    let mut document = valid_document();
+    document.execution_policy.receipt_timeout_ns = 0;
+    assert!(matches!(
+        document.validate(),
+        Err(ValidationError::ZeroDuration { .. })
+    ));
 }
 
 #[test]
@@ -307,12 +346,29 @@ fn real_vehicle_admission_rejects_each_trial_action() {
 }
 
 #[test]
+fn real_vehicle_admission_rejects_a_trial_cleanup_action() {
+    let mut document = valid_document();
+    document.phases[0]
+        .required_capabilities
+        .push(MissionCapability::Reset);
+    document.phases[0]
+        .cleanup_actions
+        .push(MissionAction::Trial(TrialAction::Reset {}));
+    assert!(matches!(
+        document.validate_for_target(ExecutionTarget::RealVehicle),
+        Err(ValidationError::SimulatorOnlyAction { .. })
+    ));
+}
+
+#[test]
 fn phase_order_is_preserved_by_canonical_serialization() {
     let document = MissionDocument::new(
         "mission-ordered".to_owned(),
         navigation_data(1),
         ExecutionPolicy {
             target: ExecutionTarget::RealVehicle,
+            retry_limit: 2,
+            receipt_timeout_ns: 500_000,
         },
         vec![
             phase("first", MissionAction::Flight(FlightAction::Arm {})),

--- a/crates/pilotage-mission-core/src/validation.rs
+++ b/crates/pilotage-mission-core/src/validation.rs
@@ -82,6 +82,15 @@ pub(crate) fn finite(field: &str, value: f64) -> Result<(), ValidationError> {
     Ok(())
 }
 
+pub(crate) fn nonzero_u64(field: &str, value: u64) -> Result<(), ValidationError> {
+    if value == 0 {
+        return Err(ValidationError::ZeroDuration {
+            field: field.to_owned(),
+        });
+    }
+    Ok(())
+}
+
 pub(crate) fn range(
     field: &str,
     value: f64,


### PR DESCRIPTION
## Summary

- Add a pure mission engine with caller-supplied clocks and observations.
- Correlate typed directives and receipts. Enforce phase deadlines, the mission wall deadline, and bounded retries.
- Add schema version 2 cleanup actions. Run cleanup in reverse phase order, attempt all steps, and report typed events and terminal results.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps`
- `cargo build --workspace --release`

Closes #558.

SIM / NOT FOR FLIGHT.