### PR TITLE
Adopt mission core for operational routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,9 @@ dependencies = [
  "navigate-fusion",
  "navigate-geodesy",
  "navigate-guidance",
+ "pilotage-mission-core",
  "pilotage-protocol",
+ "sha2 0.10.9",
  "thiserror",
 ]
 

--- a/crates/pilotage-mission/Cargo.toml
+++ b/crates/pilotage-mission/Cargo.toml
@@ -17,5 +17,7 @@ aerocontext-core = { workspace = true }
 aerocontext-planning = { workspace = true }
 aerocontext-navdata = { workspace = true }
 chrono = { workspace = true }
+pilotage-mission-core = { path = "../pilotage-mission-core" }
 pilotage-protocol = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pilotage-mission/src/config.rs
+++ b/crates/pilotage-mission/src/config.rs
@@ -46,8 +46,8 @@ pub struct MissionConfig {
     /// (ADR-0030); nothing downstream ever sees degrees.
     pub anchor: GeodeticPosition,
     /// Cruise height above the anchor altitude, meters. Default 15.0.
-    /// `0.0` disables the climb phase: the mission goes straight from
-    /// arming to enroute guidance.
+    /// `0.0` disables climb behavior. The mission starts enroute guidance
+    /// after the arm receipt.
     pub cruise_height_m: f64,
     /// Commanded climb rate during the climb phase, m/s. Default 0.8.
     pub climb_rate_mps: f64,

--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -2,6 +2,7 @@
 //! actions out. All time is caller-supplied; nothing here reads a clock
 //! or performs I/O.
 
+mod document;
 mod nav_guidance;
 mod output;
 mod tick;
@@ -19,6 +20,11 @@ use navigate_fpl::{ExecutionConfig, PlanExecution};
 use navigate_fusion::{FusionConfig, NavigationFilter, Observation, ObservationValue};
 use navigate_geodesy::{LocalTangentPlane, NedOffset};
 use navigate_guidance::{GuidanceRefusal, VelocityGuidanceConfig};
+use pilotage_mission_core::{
+    ActionId, DirectiveReceipt, EngineState as CoreEngineState, FlightAction as CoreFlightAction,
+    FlightPlanReference, MissionDocument, MissionEngine as CoreMissionEngine,
+    MissionTerminal as CoreMissionTerminal, PhaseStage, ReceiptResult,
+};
 
 pub use nav_guidance::{NavGuidance, NavQuality};
 pub use output::{MissionAction, MissionCounters, MissionEvent, MissionOutput, MissionState};
@@ -32,13 +38,13 @@ use crate::provenance::{MissionPlanRecord, SnapshotProvenance};
 /// observations with.
 const OWNSHIP_SOURCE: SourceId = SourceId::new(1);
 
-/// A deterministic mission executor over the Navigate stack.
+/// A Navigate-backed operational handler around the shared mission core.
 ///
 /// The host owns the boundary: it converts telemetry into
-/// [`OwnshipSample`]s, frames the emitted intents/actions onto the
-/// session wire, and supplies every `now` on the configured clock
-/// domain. The engine owns the judgment: admission, sequencing,
-/// guidance, and the phase machine.
+/// [`OwnshipSample`]s, frames the emitted intents and actions onto the
+/// session wire, and supplies each `now` on the configured clock domain.
+/// The shared core owns phase transitions. This handler owns Navigate
+/// observations, guidance, and directive interpretation.
 #[derive(Debug)]
 pub struct MissionEngine {
     config: MissionConfig,
@@ -46,20 +52,23 @@ pub struct MissionEngine {
     filter: NavigationFilter,
     execution: PlanExecution,
     guidance: VelocityGuidanceConfig,
-    state: MissionState,
+    document: MissionDocument,
+    plan_reference: FlightPlanReference,
+    core: Option<CoreMissionEngine>,
+    core_failed: bool,
+    active_action: Option<CoreFlightAction>,
+    pending_receipt: Option<DirectiveReceipt>,
+    outstanding_arm: Option<ActionId>,
+    plan_complete: bool,
     counters: MissionCounters,
     /// The solution the last tick published, backing the display-facing
     /// guidance view. A tick whose filter published nothing clears it, so
     /// [`MissionEngine::nav_guidance`] cannot serve stale geometry.
     last_solution: Option<NavigationSolution>,
-    pending_events: Vec<MissionEvent>,
     /// The latest known heading. `None` until a sample carries an
     /// attitude group: intents need the NED→body rotation, and guessing
     /// zero would silently rotate every command to due north.
     last_yaw_rad: Option<f64>,
-    next_action_id: u64,
-    outstanding_arm: Option<u64>,
-    arm_needs_send: bool,
     last_refusal: Option<Discriminant<GuidanceRefusal>>,
 }
 
@@ -95,18 +104,24 @@ impl MissionEngine {
         }
         let waypoints = build_waypoints(&expanded.points, &config);
         let expanded_idents: Vec<String> = waypoints.iter().map(|wp| wp.ident.clone()).collect();
-        let record = MissionPlanRecord {
-            provenance,
-            route_input: config.route.clone(),
-            waypoint_count: waypoints.len(),
-            expanded_idents,
-        };
         let plan = FlightPlan::new(
             format!("mission:{}", config.route),
             PlanRole::Mission,
             waypoints,
         );
         let execution = PlanExecution::new(plan, ExecutionConfig::default())?;
+        let (document, plan_reference) = document::build_document(
+            execution.plan(),
+            &config,
+            provenance.navigation_data_identity.clone(),
+        )?;
+        let record = MissionPlanRecord {
+            provenance,
+            route_input: config.route.clone(),
+            waypoint_count: expanded_idents.len(),
+            expanded_idents,
+            mission_identity: document.identity.clone(),
+        };
         let plane = LocalTangentPlane::new(config.anchor)?;
         let filter = NavigationFilter::new(FusionConfig::default(), config.clock);
         let guidance = guidance_config(&config);
@@ -116,14 +131,17 @@ impl MissionEngine {
             filter,
             execution,
             guidance,
-            state: MissionState::AwaitSolution,
+            document,
+            plan_reference,
+            core: None,
+            core_failed: false,
+            active_action: None,
+            pending_receipt: None,
+            outstanding_arm: None,
+            plan_complete: false,
             counters: MissionCounters::default(),
             last_solution: None,
-            pending_events: Vec::new(),
             last_yaw_rad: None,
-            next_action_id: 0,
-            outstanding_arm: None,
-            arm_needs_send: false,
             last_refusal: None,
         };
         Ok((engine, record))
@@ -168,30 +186,29 @@ impl MissionEngine {
     }
 
     /// Reports the correlated result of a previously emitted action.
-    /// Acceptance advances the phase machine; rejection schedules a
-    /// re-send with a fresh id on the next tick. Results for unknown
-    /// ids, or outside the arming phase, are inert.
+    /// Acceptance completes the correlated core directive. Rejection is
+    /// a retryable receipt, so the core emits a fresh identifier on the
+    /// next tick. Results for unknown identifiers are inert.
     pub fn on_action_result(&mut self, action_id: u64, accepted: bool) {
-        if self.state != MissionState::Arming || self.outstanding_arm != Some(action_id) {
+        let Some(outstanding) = self.outstanding_arm else {
+            return;
+        };
+        if u64::from(outstanding.get()) != action_id {
             return;
         }
         self.outstanding_arm = None;
-        if accepted {
-            self.pending_events
-                .push(MissionEvent::ArmAccepted { action_id });
-            if self.config.cruise_height_m > 0.0 {
-                self.state = MissionState::Climb;
-                self.pending_events.push(MissionEvent::ClimbStarted);
-            } else {
-                self.state = MissionState::Enroute;
-                self.pending_events.push(MissionEvent::EnrouteStarted);
-            }
+        let result = if accepted {
+            ReceiptResult::Succeeded {}
         } else {
             self.counters.arm_rejected = self.counters.arm_rejected.wrapping_add(1);
-            self.arm_needs_send = true;
-            self.pending_events
-                .push(MissionEvent::ArmRejected { action_id });
-        }
+            ReceiptResult::Retryable {
+                detail: "the vehicle rejected the arm action".to_owned(),
+            }
+        };
+        self.pending_receipt = Some(DirectiveReceipt {
+            action_id: outstanding,
+            result,
+        });
     }
 
     /// The named refusal/rejection counters.
@@ -202,8 +219,43 @@ impl MissionEngine {
 
     /// The current mission phase.
     #[must_use]
-    pub const fn state(&self) -> MissionState {
-        self.state
+    pub fn state(&self) -> MissionState {
+        if self.core_failed {
+            return MissionState::Failed;
+        }
+        let Some(core) = self.core.as_ref() else {
+            return MissionState::AwaitSolution;
+        };
+        match core.state() {
+            CoreEngineState::Running {
+                phase_id, stage, ..
+            } if phase_id == document::ARM_PHASE_ID => match stage {
+                PhaseStage::WaitingForEntry {} => MissionState::AwaitSolution,
+                PhaseStage::WaitingForReceipt { .. } | PhaseStage::WaitingForCompletion {} => {
+                    MissionState::Arming
+                }
+            },
+            CoreEngineState::Running { phase_id, .. } if phase_id == document::CLIMB_PHASE_ID => {
+                MissionState::Climb
+            }
+            CoreEngineState::Running { phase_id, .. }
+                if phase_id == document::FOLLOW_PLAN_PHASE_ID =>
+            {
+                MissionState::Enroute
+            }
+            CoreEngineState::Terminal {
+                result: CoreMissionTerminal::Complete { .. },
+            } => MissionState::Complete,
+            CoreEngineState::CleaningUp { .. }
+            | CoreEngineState::Running { .. }
+            | CoreEngineState::Terminal { .. } => MissionState::Failed,
+        }
+    }
+
+    /// Gets the validated mission document that owns phase transitions.
+    #[must_use]
+    pub const fn mission_document(&self) -> &MissionDocument {
+        &self.document
     }
 }
 

--- a/crates/pilotage-mission/src/engine/document.rs
+++ b/crates/pilotage-mission/src/engine/document.rs
@@ -1,0 +1,202 @@
+//! Operational mission-document generation and flight-plan identity.
+
+use navigate_contract::{AltitudeConstraint, FlightPlan, PlanRole, TurnType, Waypoint};
+use pilotage_mission_core::{
+    Comparison, Digest, ExecutionPolicy, ExecutionTarget, FlightAction, FlightPlanReference,
+    MissionAction, MissionCapability, MissionCondition, MissionDocument, MissionPhase,
+    NavigationCondition, NavigationDataIdentity,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::MissionConfig;
+use crate::error::MissionBuildError;
+use crate::policy::{
+    ARM_PHASE_DEADLINE_NS, CLIMB_PHASE_DEADLINE_NS, FOLLOW_PLAN_PHASE_DEADLINE_NS,
+    OPERATIONAL_RECEIPT_TIMEOUT_NS, OPERATIONAL_RETRY_LIMIT,
+};
+
+pub(super) const ARM_PHASE_ID: &str = "arm";
+pub(super) const CLIMB_PHASE_ID: &str = "climb";
+pub(super) const FOLLOW_PLAN_PHASE_ID: &str = "follow-plan";
+
+/// Altitude margin below the target that completes the climb, in meters.
+pub(super) const CLIMB_CAPTURE_MARGIN_M: f64 = 1.0;
+
+const PLAN_DIGEST_DOMAIN: &[u8] = b"pilotage.flight-plan.v1\0";
+const MISSION_REVISION_PREFIX: &str = "operational-route-v1";
+
+pub(super) fn build_document(
+    plan: &FlightPlan,
+    config: &MissionConfig,
+    navigation_data_identity: NavigationDataIdentity,
+) -> Result<(MissionDocument, FlightPlanReference), MissionBuildError> {
+    let plan_content_digest = plan_digest(plan)?;
+    let plan_reference = FlightPlanReference {
+        plan_id: plan.id.clone(),
+        plan_content_digest,
+        navigation_data_identity: navigation_data_identity.clone(),
+    };
+    let revision_id = format!("{MISSION_REVISION_PREFIX}:{plan_content_digest}");
+    let document = MissionDocument::new(
+        revision_id,
+        navigation_data_identity,
+        ExecutionPolicy {
+            target: ExecutionTarget::Simulator,
+            retry_limit: OPERATIONAL_RETRY_LIMIT,
+            receipt_timeout_ns: OPERATIONAL_RECEIPT_TIMEOUT_NS,
+        },
+        vec![
+            arm_phase(),
+            climb_phase(config),
+            follow_plan_phase(plan_reference.clone()),
+        ],
+    )?;
+    Ok((document, plan_reference))
+}
+
+fn arm_phase() -> MissionPhase {
+    MissionPhase {
+        id: ARM_PHASE_ID.to_owned(),
+        required_capabilities: vec![
+            MissionCapability::SimulatorTime,
+            MissionCapability::ArmDisarm,
+            MissionCapability::NavigationState,
+        ],
+        entry_conditions: vec![MissionCondition::Navigation(
+            NavigationCondition::GuidanceValid { expected: true },
+        )],
+        action: MissionAction::Flight(FlightAction::Arm {}),
+        cleanup_actions: Vec::new(),
+        completion_conditions: vec![MissionCondition::Always {}],
+        abort_conditions: Vec::new(),
+        simulator_time_deadline_ns: ARM_PHASE_DEADLINE_NS,
+    }
+}
+
+fn climb_phase(config: &MissionConfig) -> MissionPhase {
+    let target_altitude_m = config.anchor.altitude_m + config.cruise_height_m;
+    MissionPhase {
+        id: CLIMB_PHASE_ID.to_owned(),
+        required_capabilities: vec![
+            MissionCapability::SimulatorTime,
+            MissionCapability::FlightControl,
+            MissionCapability::NavigationState,
+        ],
+        entry_conditions: vec![MissionCondition::Always {}],
+        action: MissionAction::Flight(FlightAction::Climb { target_altitude_m }),
+        cleanup_actions: Vec::new(),
+        completion_conditions: vec![MissionCondition::Navigation(
+            NavigationCondition::Altitude {
+                comparison: Comparison::GreaterOrEqual,
+                value_m: target_altitude_m - CLIMB_CAPTURE_MARGIN_M,
+            },
+        )],
+        abort_conditions: Vec::new(),
+        simulator_time_deadline_ns: CLIMB_PHASE_DEADLINE_NS,
+    }
+}
+
+fn follow_plan_phase(plan: FlightPlanReference) -> MissionPhase {
+    MissionPhase {
+        id: FOLLOW_PLAN_PHASE_ID.to_owned(),
+        required_capabilities: vec![
+            MissionCapability::SimulatorTime,
+            MissionCapability::FlightPlan,
+            MissionCapability::NavigationState,
+        ],
+        entry_conditions: vec![MissionCondition::Always {}],
+        action: MissionAction::Flight(FlightAction::FollowPlan { plan }),
+        cleanup_actions: Vec::new(),
+        completion_conditions: vec![MissionCondition::Navigation(
+            NavigationCondition::PlanComplete { expected: true },
+        )],
+        abort_conditions: Vec::new(),
+        simulator_time_deadline_ns: FOLLOW_PLAN_PHASE_DEADLINE_NS,
+    }
+}
+
+fn plan_digest(plan: &FlightPlan) -> Result<Digest, MissionBuildError> {
+    let mut hasher = Sha256::new();
+    hasher.update(PLAN_DIGEST_DOMAIN);
+    hash_string(&mut hasher, &plan.id);
+    let role = match plan.role {
+        PlanRole::Mission => 1,
+        PlanRole::LossOfComm => 2,
+        PlanRole::Contingency => 3,
+        other => return Err(unsupported("role", other)),
+    };
+    hasher.update([role]);
+    hash_len(&mut hasher, plan.waypoints.len());
+    for waypoint in &plan.waypoints {
+        hash_waypoint(&mut hasher, waypoint)?;
+    }
+    Ok(Digest::from_bytes(hasher.finalize().into()))
+}
+
+fn hash_waypoint(hasher: &mut Sha256, waypoint: &Waypoint) -> Result<(), MissionBuildError> {
+    hash_string(hasher, &waypoint.ident);
+    hash_f64(hasher, waypoint.position.latitude_rad);
+    hash_f64(hasher, waypoint.position.longitude_rad);
+    hash_f64(hasher, waypoint.position.altitude_m);
+    hash_altitude(hasher, waypoint.altitude)?;
+    let turn = match waypoint.turn {
+        TurnType::FlyBy => 1,
+        TurnType::FlyOver => 2,
+        other => return Err(unsupported("waypoint.turn", other)),
+    };
+    hasher.update([turn]);
+    hash_optional_f64(hasher, waypoint.max_speed_mps);
+    hash_optional_f64(hasher, waypoint.gradient);
+    Ok(())
+}
+
+fn hash_altitude(
+    hasher: &mut Sha256,
+    constraint: Option<AltitudeConstraint>,
+) -> Result<(), MissionBuildError> {
+    match constraint {
+        None => hasher.update([0]),
+        Some(AltitudeConstraint::At(value)) => hash_tagged_f64(hasher, 1, value),
+        Some(AltitudeConstraint::AtOrAbove(value)) => hash_tagged_f64(hasher, 2, value),
+        Some(AltitudeConstraint::AtOrBelow(value)) => hash_tagged_f64(hasher, 3, value),
+        Some(AltitudeConstraint::Window { lower_m, upper_m }) => {
+            hasher.update([4]);
+            hash_f64(hasher, lower_m);
+            hash_f64(hasher, upper_m);
+        }
+        Some(other) => return Err(unsupported("waypoint.altitude", other)),
+    }
+    Ok(())
+}
+
+fn hash_optional_f64(hasher: &mut Sha256, value: Option<f64>) {
+    match value {
+        Some(value) => hash_tagged_f64(hasher, 1, value),
+        None => hasher.update([0]),
+    }
+}
+
+fn hash_tagged_f64(hasher: &mut Sha256, tag: u8, value: f64) {
+    hasher.update([tag]);
+    hash_f64(hasher, value);
+}
+
+fn hash_f64(hasher: &mut Sha256, value: f64) {
+    hasher.update(value.to_bits().to_be_bytes());
+}
+
+fn hash_string(hasher: &mut Sha256, value: &str) {
+    hash_len(hasher, value.len());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_len(hasher: &mut Sha256, len: usize) {
+    hasher.update(u64::try_from(len).unwrap_or(u64::MAX).to_be_bytes());
+}
+
+fn unsupported(field: &'static str, value: impl core::fmt::Debug) -> MissionBuildError {
+    MissionBuildError::PlanIdentity {
+        field,
+        value: format!("{value:?}"),
+    }
+}

--- a/crates/pilotage-mission/src/engine/nav_guidance.rs
+++ b/crates/pilotage-mission/src/engine/nav_guidance.rs
@@ -87,8 +87,11 @@ impl MissionEngine {
     #[must_use]
     pub fn nav_guidance(&self) -> Option<NavGuidance> {
         let solution = self.last_solution.as_ref()?;
-        match self.state {
-            MissionState::AwaitSolution | MissionState::Arming | MissionState::Complete => None,
+        match self.state() {
+            MissionState::AwaitSolution
+            | MissionState::Arming
+            | MissionState::Complete
+            | MissionState::Failed => None,
             MissionState::Climb | MissionState::Enroute => {
                 let leg = self.execution.active_leg()?;
                 Some(leg_guidance(

--- a/crates/pilotage-mission/src/engine/output.rs
+++ b/crates/pilotage-mission/src/engine/output.rs
@@ -19,6 +19,8 @@ pub enum MissionState {
     /// The plan is complete; every tick commands zero velocity so the
     /// adapter's brake-then-hold takes over.
     Complete,
+    /// The core refused or stopped the mission before plan completion.
+    Failed,
 }
 
 /// A discrete action the host must send as a `ControlActionCommand` on
@@ -68,6 +70,16 @@ pub enum MissionEvent {
     },
     /// The final waypoint captured; emitted exactly once.
     MissionComplete,
+    /// The sequencing core stopped the mission with a typed result.
+    MissionFailed {
+        /// The typed core terminal result.
+        result: pilotage_mission_core::MissionTerminal,
+    },
+    /// The sequencing core refused one host input.
+    MissionEngineRefused {
+        /// The core error detail for the operational log.
+        detail: String,
+    },
     /// Guidance refused to issue a setpoint this tick; no intent was
     /// emitted (the host's silence watchdog is the backstop). Repeats of
     /// the same refusal kind are counted but not re-surfaced until the

--- a/crates/pilotage-mission/src/engine/tick.rs
+++ b/crates/pilotage-mission/src/engine/tick.rs
@@ -1,5 +1,4 @@
-//! The tick: one caller-supplied `now` becomes at most one intent, at
-//! most one action, and the events the phase machine surfaced.
+//! One operational tick through the shared sequencing core.
 
 use core::mem::discriminant;
 
@@ -8,96 +7,287 @@ use navigate_contract::{
 };
 use navigate_fpl::SequenceEvent;
 use navigate_guidance::guide_velocity;
+use pilotage_mission_core::{
+    DirectiveReceipt, EngineEvent as CoreEvent, EngineStart, ExecutionTarget,
+    FlightAction as CoreFlightAction, MissionDirective, MissionEngine as CoreMissionEngine,
+    MissionObservation as CoreObservation, MissionTerminal as CoreTerminal, NavigationObservation,
+    ReceiptResult, TickInput, TickOutput as CoreTickOutput, VehicleObservation, WallDeadline,
+};
 use pilotage_protocol::{ControlAction, ControlIntent, ReferenceFrame, VelocityIntent};
 
 use crate::body_frame::{bearing_rad, cap_horizontal, clamp_symmetric, ned_to_body, wrap_to_pi};
+use crate::policy::OPERATIONAL_WALL_DEADLINE_NS;
 
+use super::document::{ARM_PHASE_ID, CLIMB_CAPTURE_MARGIN_M};
 use super::{MissionAction, MissionEngine, MissionEvent, MissionOutput, MissionState};
 
-/// Altitude margin below the cruise target at which the climb phase
-/// hands over to enroute guidance, meters.
-const CLIMB_CAPTURE_MARGIN_M: f64 = 1.0;
-
-/// Commanded horizontal speed below which the course is numerically
-/// meaningless and the yaw rate is held at zero, m/s.
+/// Commanded horizontal speed below which course has no useful direction.
 const YAW_COURSE_FLOOR_MPS: f64 = 0.05;
 
 impl MissionEngine {
-    /// Advances the mission one step at `now` (engine clock domain).
+    /// Advances the operational mission with one caller clock value.
     ///
-    /// A tick that emits no intent is deliberate — a guidance refusal or
-    /// a not-yet-initialized filter — and the host's holder-silence
-    /// watchdog is the backstop for a stretch of them.
+    /// The wrapper supplies the same monotonic value as simulator time and
+    /// wall time. It performs no clock read and no input or output operation.
     pub fn tick(&mut self, now: MonotonicNanos) -> MissionOutput {
-        let mut events = core::mem::take(&mut self.pending_events);
-        let mut intent = None;
-        let mut action = None;
-        match self.state {
-            MissionState::AwaitSolution => {
-                if self.publish_solution(now).is_some() {
-                    self.state = MissionState::Arming;
-                    action = Some(self.send_arm(&mut events));
-                }
-            }
-            MissionState::Arming => {
-                if self.arm_needs_send {
-                    action = Some(self.send_arm(&mut events));
-                }
-            }
-            MissionState::Climb => intent = self.climb_tick(now, &mut events),
-            MissionState::Enroute => intent = self.enroute_tick(now, &mut events),
-            MissionState::Complete => intent = Some(zero_velocity_intent()),
+        match self.state() {
+            MissionState::Complete => return terminal_output(MissionState::Complete),
+            MissionState::Failed => return terminal_output(MissionState::Failed),
+            MissionState::AwaitSolution
+            | MissionState::Arming
+            | MissionState::Climb
+            | MissionState::Enroute => {}
         }
+        let mut events = Vec::new();
+        let solution = self.publish_solution(now);
+        let mut plan_advanced = false;
+        if self.state() == MissionState::Enroute {
+            plan_advanced = self.advance_active_plan(solution.as_ref(), &mut events);
+        }
+        let observation = self.core_observation(solution.as_ref());
+        let Some(core_output) = self.tick_core(now, observation, &mut events) else {
+            return failed_output(events);
+        };
+        let mut action = self.apply_core_output(&core_output, &mut events);
+        let mut state = self.state();
+        if state == MissionState::Climb && self.climb_is_captured(solution.as_ref()) {
+            let Some(extra_action) = self.continue_core(now, solution.as_ref(), &mut events) else {
+                return failed_output(events);
+            };
+            if action.is_none() {
+                action = extra_action;
+            }
+            state = self.state();
+        }
+        if state == MissionState::Enroute && !plan_advanced {
+            self.advance_active_plan(solution.as_ref(), &mut events);
+        }
+        if self.plan_complete && state == MissionState::Enroute {
+            let Some(extra_action) = self.continue_core(now, solution.as_ref(), &mut events) else {
+                return failed_output(events);
+            };
+            if action.is_none() {
+                action = extra_action;
+            }
+            state = self.state();
+        }
+        let intent = self.intent_for_state(state, solution.as_ref(), now, &mut events);
         MissionOutput {
             intent,
             action,
-            state: self.state,
+            state,
             events,
         }
     }
 
-    /// Publishes the filter's solution for `now` and remembers it as the
-    /// basis of the display-facing guidance view. A tick that publishes
-    /// nothing forgets the previous solution: guidance that cannot be
-    /// recomputed must disappear rather than age on an instrument.
-    fn publish_solution(&mut self, now: MonotonicNanos) -> Option<NavigationSolution> {
-        self.last_solution = self.filter.tick(now);
-        self.last_solution
-    }
-
-    /// Emits an arm action under a fresh nonzero wrapping id. The action
-    /// goes out once; only a rejected result schedules another send.
-    fn send_arm(&mut self, events: &mut Vec<MissionEvent>) -> MissionAction {
-        self.next_action_id = self.next_action_id.wrapping_add(1);
-        if self.next_action_id == 0 {
-            // The session wire reserves zero; skip it on wrap.
-            self.next_action_id = 1;
-        }
-        let action_id = self.next_action_id;
-        self.outstanding_arm = Some(action_id);
-        self.arm_needs_send = false;
-        events.push(MissionEvent::ArmRequested { action_id });
-        MissionAction {
-            action: ControlAction::Arm,
-            action_id,
-        }
-    }
-
-    /// Climb straight up until the solution altitude reaches the cruise
-    /// target (within [`CLIMB_CAPTURE_MARGIN_M`]), then hand over to
-    /// enroute guidance on the same tick so no tick goes intent-less at
-    /// the seam.
-    fn climb_tick(
+    fn continue_core(
         &mut self,
+        now: MonotonicNanos,
+        solution: Option<&NavigationSolution>,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<Option<MissionAction>> {
+        let observation = self.core_observation(solution);
+        let output = self.tick_core(now, observation, events)?;
+        Some(self.apply_core_output(&output, events))
+    }
+
+    fn tick_core(
+        &mut self,
+        now: MonotonicNanos,
+        observation: CoreObservation,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<CoreTickOutput> {
+        if self.core.is_none() && !self.start_core(now, events) {
+            return None;
+        }
+        let input = TickInput {
+            simulator_time_ns: now.as_nanos(),
+            wall_time_ns: now.as_nanos(),
+            observation,
+            receipts: self.pending_receipt.take().into_iter().collect(),
+        };
+        let result = self.core.as_mut()?.tick(input);
+        match result {
+            Ok(output) => Some(output),
+            Err(error) => {
+                self.refuse_core(error.to_string(), events);
+                None
+            }
+        }
+    }
+
+    fn start_core(&mut self, now: MonotonicNanos, events: &mut Vec<MissionEvent>) -> bool {
+        let now_ns = now.as_nanos();
+        let expires_at_ns = now_ns.saturating_add(OPERATIONAL_WALL_DEADLINE_NS);
+        let start = EngineStart {
+            host_target: ExecutionTarget::Simulator,
+            simulator_time_ns: now_ns,
+            wall_time_ns: now_ns,
+            wall_deadline: WallDeadline {
+                mission_content_digest: self.document.identity.content_digest,
+                expires_at_ns,
+            },
+        };
+        match CoreMissionEngine::start(self.document.clone(), start) {
+            Ok(core) => {
+                self.core = Some(core);
+                true
+            }
+            Err(error) => {
+                self.refuse_core(error.to_string(), events);
+                false
+            }
+        }
+    }
+
+    fn refuse_core(&mut self, detail: String, events: &mut Vec<MissionEvent>) {
+        self.core_failed = true;
+        self.active_action = None;
+        self.outstanding_arm = None;
+        events.push(MissionEvent::MissionEngineRefused { detail });
+    }
+
+    fn core_observation(&self, solution: Option<&NavigationSolution>) -> CoreObservation {
+        CoreObservation {
+            navigation: NavigationObservation {
+                guidance_valid: Some(solution.is_some()),
+                plan_complete: Some(self.plan_complete),
+                altitude_m: solution.map(|value| value.position.altitude_m),
+            },
+            vehicle: VehicleObservation::default(),
+            signals: Vec::new(),
+        }
+    }
+
+    fn apply_core_output(
+        &mut self,
+        output: &CoreTickOutput,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<MissionAction> {
+        let mut action = None;
+        for event in &output.events {
+            match event {
+                CoreEvent::PhaseCompleted { .. } => self.active_action = None,
+                CoreEvent::ReceiptAccepted {
+                    context, result, ..
+                } if context.phase_id == ARM_PHASE_ID => {
+                    self.arm_receipt_event(context.action_id.get(), result, events);
+                }
+                CoreEvent::DirectiveEmitted { directive } => {
+                    action = self.interpret_directive(directive, events);
+                }
+                CoreEvent::Terminal { result } => {
+                    self.active_action = None;
+                    self.outstanding_arm = None;
+                    match result {
+                        CoreTerminal::Complete { .. } => {
+                            events.push(MissionEvent::MissionComplete);
+                        }
+                        other => events.push(MissionEvent::MissionFailed {
+                            result: other.clone(),
+                        }),
+                    }
+                }
+                _ => {}
+            }
+        }
+        action
+    }
+
+    fn arm_receipt_event(
+        &self,
+        action_id: u32,
+        result: &ReceiptResult,
+        events: &mut Vec<MissionEvent>,
+    ) {
+        let action_id = u64::from(action_id);
+        match result {
+            ReceiptResult::Succeeded {} => events.push(MissionEvent::ArmAccepted { action_id }),
+            ReceiptResult::Retryable { .. } => events.push(MissionEvent::ArmRejected { action_id }),
+            ReceiptResult::Refused { .. } | ReceiptResult::Failed { .. } => {}
+        }
+    }
+
+    fn interpret_directive(
+        &mut self,
+        directive: &MissionDirective,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<MissionAction> {
+        let MissionDirective::Flight(directive) = directive else {
+            self.queue_receipt(
+                directive.context().action_id,
+                ReceiptResult::Refused {
+                    detail: "the operational host does not execute trial directives".to_owned(),
+                },
+            );
+            return None;
+        };
+        match &directive.action {
+            CoreFlightAction::Arm {} => {
+                let action_id = directive.context.action_id;
+                self.active_action = Some(directive.action.clone());
+                self.outstanding_arm = Some(action_id);
+                events.push(MissionEvent::ArmRequested {
+                    action_id: u64::from(action_id.get()),
+                });
+                Some(MissionAction {
+                    action: ControlAction::Arm,
+                    action_id: u64::from(action_id.get()),
+                })
+            }
+            CoreFlightAction::Climb { .. } => {
+                self.active_action = Some(directive.action.clone());
+                self.queue_receipt(directive.context.action_id, ReceiptResult::Succeeded {});
+                if self.config.cruise_height_m > 0.0 {
+                    events.push(MissionEvent::ClimbStarted);
+                }
+                None
+            }
+            CoreFlightAction::FollowPlan { plan } if *plan == self.plan_reference => {
+                self.active_action = Some(directive.action.clone());
+                self.queue_receipt(directive.context.action_id, ReceiptResult::Succeeded {});
+                events.push(MissionEvent::EnrouteStarted);
+                None
+            }
+            action => {
+                self.queue_receipt(
+                    directive.context.action_id,
+                    ReceiptResult::Refused {
+                        detail: format!("the operational host cannot execute {action:?}"),
+                    },
+                );
+                None
+            }
+        }
+    }
+
+    fn queue_receipt(&mut self, action_id: pilotage_mission_core::ActionId, result: ReceiptResult) {
+        self.pending_receipt = Some(DirectiveReceipt { action_id, result });
+    }
+
+    fn intent_for_state(
+        &mut self,
+        state: MissionState,
+        solution: Option<&NavigationSolution>,
         now: MonotonicNanos,
         events: &mut Vec<MissionEvent>,
     ) -> Option<ControlIntent> {
-        let solution = self.publish_solution(now)?;
-        let target_m = self.config.anchor.altitude_m + self.config.cruise_height_m;
-        if solution.position.altitude_m >= target_m - CLIMB_CAPTURE_MARGIN_M {
-            self.state = MissionState::Enroute;
-            events.push(MissionEvent::EnrouteStarted);
-            return self.guide(&solution, now, events);
+        match state {
+            MissionState::Climb => self.climb_intent(solution),
+            MissionState::Enroute => self.follow_plan_intent(solution, now, events),
+            MissionState::Complete => Some(zero_velocity_intent()),
+            MissionState::AwaitSolution | MissionState::Arming | MissionState::Failed => None,
+        }
+    }
+
+    fn climb_intent(&self, solution: Option<&NavigationSolution>) -> Option<ControlIntent> {
+        let solution = solution?;
+        let Some(CoreFlightAction::Climb { target_altitude_m }) = self.active_action.as_ref()
+        else {
+            return None;
+        };
+        if solution.position.altitude_m >= *target_altitude_m - CLIMB_CAPTURE_MARGIN_M {
+            return None;
         }
         let up_mps = clamp_symmetric(
             self.config.climb_rate_mps,
@@ -112,46 +302,85 @@ impl MissionEngine {
         }))
     }
 
-    fn enroute_tick(
-        &mut self,
-        now: MonotonicNanos,
-        events: &mut Vec<MissionEvent>,
-    ) -> Option<ControlIntent> {
-        let solution = self.publish_solution(now)?;
-        self.guide(&solution, now, events)
+    fn climb_is_captured(&self, solution: Option<&NavigationSolution>) -> bool {
+        let Some(solution) = solution else {
+            return false;
+        };
+        let Some(CoreFlightAction::Climb { target_altitude_m }) = self.active_action.as_ref()
+        else {
+            return false;
+        };
+        solution.position.altitude_m >= *target_altitude_m - CLIMB_CAPTURE_MARGIN_M
     }
 
-    /// Sequences the plan on the solution position, then derives one
-    /// velocity intent toward the active leg.
-    fn guide(
+    fn follow_plan_intent(
         &mut self,
-        solution: &NavigationSolution,
+        solution: Option<&NavigationSolution>,
         now: MonotonicNanos,
         events: &mut Vec<MissionEvent>,
     ) -> Option<ControlIntent> {
+        let solution = solution?;
+        if !matches!(
+            self.active_action,
+            Some(CoreFlightAction::FollowPlan { .. })
+        ) {
+            return None;
+        }
+        if self.plan_complete {
+            return Some(zero_velocity_intent());
+        }
+        self.guide_active_leg(solution, now, events)
+    }
+
+    fn advance_active_plan(
+        &mut self,
+        solution: Option<&NavigationSolution>,
+        events: &mut Vec<MissionEvent>,
+    ) -> bool {
+        let Some(solution) = solution else {
+            return false;
+        };
+        if !matches!(
+            self.active_action,
+            Some(CoreFlightAction::FollowPlan { .. })
+        ) {
+            return false;
+        }
+        self.advance_plan(solution, events);
+        true
+    }
+
+    fn advance_plan(&mut self, solution: &NavigationSolution, events: &mut Vec<MissionEvent>) {
+        if self.plan_complete {
+            return;
+        }
         match self
             .execution
             .advance(&solution.position, self.commanded_groundspeed_mps())
         {
             SequenceEvent::LegAdvanced {
                 to_index, reason, ..
-            } => {
-                events.push(MissionEvent::LegAdvanced { to_index, reason });
-            }
-            SequenceEvent::PlanComplete { .. } => {
-                self.state = MissionState::Complete;
-                events.push(MissionEvent::MissionComplete);
-                return Some(zero_velocity_intent());
-            }
-            // Non-exhaustive upstream: any event that neither advances
-            // nor completes leaves the active leg unchanged.
+            } => events.push(MissionEvent::LegAdvanced { to_index, reason }),
+            SequenceEvent::PlanComplete { .. } => self.plan_complete = true,
             _ => {}
         }
-        // Owned copies release the borrow of the execution before the
-        // counters and refusal latch are touched below.
+    }
+
+    /// Publishes the filter solution for `now` and clears stale display data.
+    fn publish_solution(&mut self, now: MonotonicNanos) -> Option<NavigationSolution> {
+        self.last_solution = self.filter.tick(now);
+        self.last_solution
+    }
+
+    fn guide_active_leg(
+        &mut self,
+        solution: &NavigationSolution,
+        now: MonotonicNanos,
+        events: &mut Vec<MissionEvent>,
+    ) -> Option<ControlIntent> {
         let (leg_from, leg_to): (Option<GeodeticPosition>, Waypoint) = {
             let leg = self.execution.active_leg()?;
-            (leg.from.map(|wp| wp.position), leg.to.clone())
+            (leg.from.map(|waypoint| waypoint.position), leg.to.clone())
         };
         let guided = guide_velocity(
             solution,
@@ -162,23 +391,7 @@ impl MissionEngine {
             &self.guidance,
         );
         match guided {
-            Ok(command) => {
-                self.last_refusal = None;
-                let GuidanceSetpoint::Velocity { velocity } = command.setpoint else {
-                    // guide_velocity only issues velocity setpoints; a
-                    // foreign shape is refused rather than misread.
-                    self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
-                    return None;
-                };
-                let Some(yaw) = self.last_yaw_rad else {
-                    // Without a known heading the NED command cannot be
-                    // rotated into the body frame honestly; a guessed
-                    // zero would steer every command toward due north.
-                    self.counters.missing_yaw = self.counters.missing_yaw.wrapping_add(1);
-                    return None;
-                };
-                Some(self.compose_intent(&velocity, yaw))
-            }
+            Ok(command) => self.guided_intent(command.setpoint),
             Err(refusal) => {
                 self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
                 let kind = discriminant(&refusal);
@@ -191,31 +404,25 @@ impl MissionEngine {
         }
     }
 
-    /// The groundspeed the sequencer sizes fly-by turn anticipation on:
-    /// the along-track speed this engine commands, cruise bounded by the
-    /// horizontal ceiling. A host that tightens the ceiling below cruise
-    /// would otherwise have its turns anticipated at a speed the vehicle
-    /// is never commanded to fly.
-    ///
-    /// Anticipation only matters when it exceeds the capture radius, and
-    /// the capture radius sits outside guidance's arrival-slowdown
-    /// radius — so wherever anticipation can fire, the approach taper
-    /// has not begun and commanded cruise is the speed being flown.
-    /// A cross-track correction can push the composed groundspeed above
-    /// this value (up to the ceiling), under-sizing the anticipation
-    /// toward a later turn; the sequencer's capture radius bounds that
-    /// error.
+    fn guided_intent(&mut self, setpoint: GuidanceSetpoint) -> Option<ControlIntent> {
+        self.last_refusal = None;
+        let GuidanceSetpoint::Velocity { velocity } = setpoint else {
+            self.counters.guidance_refused = self.counters.guidance_refused.wrapping_add(1);
+            return None;
+        };
+        let Some(yaw) = self.last_yaw_rad else {
+            self.counters.missing_yaw = self.counters.missing_yaw.wrapping_add(1);
+            return None;
+        };
+        Some(self.compose_intent(&velocity, yaw))
+    }
+
     fn commanded_groundspeed_mps(&self) -> f64 {
         self.config
             .cruise_mps
             .min(self.config.limits.max_horizontal_mps)
     }
 
-    /// Clamps the commanded NED velocity to the mission limits, rotates
-    /// it into body FRD at the latest sample yaw, and commands a yaw
-    /// rate toward the course of the commanded horizontal velocity —
-    /// chosen over the leg course so the nose also follows cross-track
-    /// corrections and stays defined on direct-to legs.
     fn compose_intent(&self, velocity: &NedVelocity, yaw_rad: f64) -> ControlIntent {
         let limits = &self.config.limits;
         let (vn, ve) = cap_horizontal(
@@ -245,8 +452,24 @@ impl MissionEngine {
     }
 }
 
-/// The zero-velocity intent completion holds: the adapter's
-/// brake-then-hold takes over from an explicit stationary command.
+fn terminal_output(state: MissionState) -> MissionOutput {
+    MissionOutput {
+        intent: (state == MissionState::Complete).then(zero_velocity_intent),
+        action: None,
+        state,
+        events: Vec::new(),
+    }
+}
+
+fn failed_output(events: Vec<MissionEvent>) -> MissionOutput {
+    MissionOutput {
+        intent: None,
+        action: None,
+        state: MissionState::Failed,
+        events,
+    }
+}
+
 fn zero_velocity_intent() -> ControlIntent {
     ControlIntent::Velocity(VelocityIntent {
         frame: ReferenceFrame::BodyFrd,

--- a/crates/pilotage-mission/src/error.rs
+++ b/crates/pilotage-mission/src/error.rs
@@ -6,6 +6,7 @@ use aerocontext_planning::route::RouteError;
 use chrono::NaiveDate;
 use navigate_fpl::PlanActivationError;
 use navigate_geodesy::GeodesyError;
+use pilotage_mission_core::CodecError;
 
 /// Why a mission could not be built. Every variant carries the context
 /// an operator needs to act on the refusal.
@@ -46,4 +47,15 @@ pub enum MissionBuildError {
     /// under the floor, a leg no longer than the capture radius).
     #[error("mission plan cannot be activated: {0}")]
     PlanActivation(#[from] PlanActivationError),
+    /// The operational mission document did not validate or encode.
+    #[error("mission document rejected")]
+    MissionDocument(#[from] CodecError),
+    /// A Navigate plan value has no canonical identity encoding.
+    #[error("flight-plan identity cannot encode {field} value {value}")]
+    PlanIdentity {
+        /// The unsupported flight-plan field.
+        field: &'static str,
+        /// The unsupported value.
+        value: String,
+    },
 }

--- a/crates/pilotage-mission/src/lib.rs
+++ b/crates/pilotage-mission/src/lib.rs
@@ -1,9 +1,9 @@
-//! Sans-IO mission engine: a packed navdata snapshot plus a route
-//! string becomes a validated flight plan, and truth-role ownship
-//! samples become typed velocity intents and discrete actions toward
-//! the Pilotage control boundary.
+//! Operational mission handler: a packed navdata snapshot plus a route
+//! string becomes a validated flight plan and mission document. The shared
+//! mission core sequences the document. Navigate interprets active flight
+//! directives as typed velocity intents and discrete actions.
 //!
-//! Nothing here reads a clock or performs I/O. `now` is always a
+//! The handler does not read a clock or perform input or output. `now` is a
 //! caller-supplied [`navigate_contract::MonotonicNanos`] on the single
 //! clock domain fixed in [`MissionConfig`]; telemetry arrives as
 //! host-converted [`OwnshipSample`]s; outputs are
@@ -16,6 +16,7 @@ pub mod engine;
 pub mod error;
 pub mod fixture;
 pub mod ownship;
+pub mod policy;
 pub mod provenance;
 
 mod body_frame;

--- a/crates/pilotage-mission/src/policy.rs
+++ b/crates/pilotage-mission/src/policy.rs
@@ -1,0 +1,37 @@
+//! Fixed policy for the operational mission document.
+
+/// Maximum retries after the first arm attempt.
+///
+/// Three retries permit four total attempts. This limit handles short
+/// rejection bursts and prevents an unlimited action loop.
+pub const OPERATIONAL_RETRY_LIMIT: u16 = 3;
+
+/// Maximum wall-clock wait for one directive receipt, in nanoseconds.
+///
+/// Five seconds is longer than the reliable local action round trip. It
+/// still stops a run promptly when the action path does not answer.
+pub const OPERATIONAL_RECEIPT_TIMEOUT_NS: u64 = 5_000_000_000;
+
+/// Maximum wall-clock duration of one operational mission, in nanoseconds.
+///
+/// The 24-hour limit permits a full-day session. It also prevents an
+/// operational run from having an unlimited lifetime.
+pub const OPERATIONAL_WALL_DEADLINE_NS: u64 = 86_400_000_000_000;
+
+/// Maximum simulator-time duration of the arm phase, in nanoseconds.
+///
+/// The two-minute limit includes the wait for a navigation solution and the
+/// reliable arm receipt.
+pub const ARM_PHASE_DEADLINE_NS: u64 = 120_000_000_000;
+
+/// Maximum simulator-time duration of the climb phase, in nanoseconds.
+///
+/// The 30-minute limit is larger than the configured operational climb and
+/// still bounds a vehicle that cannot capture altitude.
+pub const CLIMB_PHASE_DEADLINE_NS: u64 = 1_800_000_000_000;
+
+/// Maximum simulator-time duration of the follow-plan phase, in nanoseconds.
+///
+/// The 23-hour limit permits a long route. The 24-hour mission wall deadline
+/// remains the final bound for the complete run.
+pub const FOLLOW_PLAN_PHASE_DEADLINE_NS: u64 = 82_800_000_000_000;

--- a/crates/pilotage-mission/src/provenance.rs
+++ b/crates/pilotage-mission/src/provenance.rs
@@ -4,6 +4,7 @@
 use aerocontext_core::NavDataSnapshot;
 use aerocontext_navdata::blob;
 use chrono::NaiveDate;
+use pilotage_mission_core::{Digest, MissionIdentity, NavigationDataIdentity};
 
 use crate::error::MissionBuildError;
 
@@ -22,6 +23,8 @@ pub struct SnapshotProvenance {
     pub next_effective_on: NaiveDate,
     /// Verified SHA-256 of the blob payload, lowercase hex.
     pub sha256_hex: String,
+    /// Identity of the immutable navigation-data snapshot.
+    pub navigation_data_identity: NavigationDataIdentity,
     /// Whether the snapshot is a generated fixture rather than published
     /// data; a fixture-built plan must never be mistaken for one packed
     /// from an authority's cycle.
@@ -41,11 +44,20 @@ pub fn decode_snapshot(
     fixture: bool,
 ) -> Result<(NavDataSnapshot, SnapshotProvenance), MissionBuildError> {
     let info = blob::inspect(bytes)?;
+    let authority = info.snapshot.cycle.authority.slug().to_owned();
+    let effective_on = info.snapshot.cycle.effective_on;
+    let sha256_hex = info.sha256_hex();
+    let cycle = format!("{authority}:{effective_on}");
     let provenance = SnapshotProvenance {
-        authority: info.snapshot.cycle.authority.slug().to_owned(),
-        effective_on: info.snapshot.cycle.effective_on,
+        authority,
+        effective_on,
         next_effective_on: info.snapshot.cycle.next_effective_on,
-        sha256_hex: info.sha256_hex(),
+        sha256_hex: sha256_hex.clone(),
+        navigation_data_identity: NavigationDataIdentity {
+            cycle: cycle.clone(),
+            snapshot_id: format!("{cycle}:sha256:{sha256_hex}"),
+            snapshot_digest: Digest::from_bytes(info.sha256),
+        },
         fixture,
     };
     Ok((info.snapshot, provenance))
@@ -65,4 +77,6 @@ pub struct MissionPlanRecord {
     pub expanded_idents: Vec<String>,
     /// Number of waypoints in the built plan.
     pub waypoint_count: usize,
+    /// Identity of the mission document that owns the plan execution.
+    pub mission_identity: MissionIdentity,
 }

--- a/crates/pilotage-mission/tests/arm_receipts.rs
+++ b/crates/pilotage-mission/tests/arm_receipts.rs
@@ -1,0 +1,148 @@
+//! Correlated arm receipt and resend tests.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use navigate_contract::{ClockDomainId, GeodeticPosition, MonotonicNanos};
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+use pilotage_mission::{
+    MissionConfig, MissionEngine, MissionEvent, MissionState, OwnshipSample, TruthRole,
+    decode_snapshot,
+};
+
+const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+const STEP_NS: u64 = 50_000_000;
+
+fn engine_with_cruise_height(cruise_height_m: f64) -> MissionEngine {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let anchor = GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    );
+    let mut config = MissionConfig::new(
+        fixture::DEMO_ROUTE.to_owned(),
+        anchor,
+        ClockDomainId::new(7),
+    );
+    config.cruise_height_m = cruise_height_m;
+    MissionEngine::new(&snapshot, provenance, config)
+        .expect("mission builds")
+        .0
+}
+
+fn engine() -> MissionEngine {
+    engine_with_cruise_height(15.0)
+}
+
+fn sample(now: MonotonicNanos, sequence: u32) -> OwnshipSample {
+    OwnshipSample {
+        ned: [0.0; 3],
+        ned_velocity: [0.0; 3],
+        yaw_rad: Some(0.0),
+        role: TruthRole::SimulationTruth,
+        acquired_at: now,
+        sequence,
+    }
+}
+
+fn tick_with_sample(
+    engine: &mut MissionEngine,
+    now_ns: &mut u64,
+    sequence: &mut u32,
+) -> pilotage_mission::MissionOutput {
+    *now_ns = now_ns.wrapping_add(STEP_NS);
+    *sequence = sequence.wrapping_add(1);
+    let now = MonotonicNanos::from_nanos(*now_ns);
+    engine.on_ownship(&sample(now, *sequence), now);
+    engine.tick(now)
+}
+
+#[test]
+fn a_rejected_arm_receipt_resends_with_a_fresh_correlated_id() {
+    let mut engine = engine();
+    let mut now_ns = 1_000_000_000;
+    let mut sequence = 0;
+    let first = loop {
+        let output = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+        if let Some(action) = output.action {
+            break action;
+        }
+    };
+    assert_ne!(first.action_id, 0);
+
+    engine.on_action_result(first.action_id, false);
+    let retry = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+    let second = retry.action.expect("the rejected action is retried");
+    assert_ne!(second.action_id, first.action_id);
+    assert!(retry.events.iter().any(|event| matches!(
+        event,
+        MissionEvent::ArmRejected { action_id } if *action_id == first.action_id
+    )));
+    assert!(retry.events.iter().any(|event| matches!(
+        event,
+        MissionEvent::ArmRequested { action_id } if *action_id == second.action_id
+    )));
+
+    engine.on_action_result(first.action_id, true);
+    let waiting = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+    assert_eq!(waiting.state, MissionState::Arming);
+    assert!(waiting.action.is_none(), "the stale receipt is inert");
+
+    engine.on_action_result(second.action_id, true);
+    let accepted = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+    assert_eq!(accepted.state, MissionState::Climb);
+    assert!(accepted.events.iter().any(|event| matches!(
+        event,
+        MissionEvent::ArmAccepted { action_id } if *action_id == second.action_id
+    )));
+    assert!(
+        accepted
+            .events
+            .iter()
+            .any(|event| matches!(event, MissionEvent::ClimbStarted))
+    );
+    assert_eq!(engine.counters().arm_rejected, 1);
+}
+
+#[test]
+fn zero_height_starts_enroute_guidance_on_the_arm_receipt_tick() {
+    let mut engine = engine_with_cruise_height(0.0);
+    let mut now_ns = 1_000_000_000;
+    let mut sequence = 0;
+    let arm = loop {
+        let output = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+        if let Some(action) = output.action {
+            break action;
+        }
+    };
+
+    engine.on_action_result(arm.action_id, true);
+    let output = tick_with_sample(&mut engine, &mut now_ns, &mut sequence);
+
+    assert_eq!(output.state, MissionState::Enroute);
+    assert!(
+        output.intent.is_some(),
+        "enroute guidance has no empty frame"
+    );
+    assert!(output.events.iter().any(|event| matches!(
+        event,
+        MissionEvent::ArmAccepted { action_id } if *action_id == arm.action_id
+    )));
+    assert!(
+        output
+            .events
+            .iter()
+            .any(|event| matches!(event, MissionEvent::EnrouteStarted))
+    );
+    assert!(
+        !output
+            .events
+            .iter()
+            .any(|event| matches!(event, MissionEvent::ClimbStarted))
+    );
+}

--- a/crates/pilotage-mission/tests/fixture_roundtrip.rs
+++ b/crates/pilotage-mission/tests/fixture_roundtrip.rs
@@ -29,6 +29,23 @@ fn demo_blob_round_trips_with_faithful_provenance() {
     );
     assert_eq!(provenance.sha256_hex.len(), 64);
     assert!(provenance.sha256_hex.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(
+        provenance.navigation_data_identity.cycle,
+        "faa-nasr:2026-01-22"
+    );
+    assert!(
+        provenance
+            .navigation_data_identity
+            .snapshot_id
+            .ends_with(&provenance.sha256_hex)
+    );
+    assert_eq!(
+        provenance
+            .navigation_data_identity
+            .snapshot_digest
+            .to_string(),
+        provenance.sha256_hex
+    );
 }
 
 #[test]

--- a/crates/pilotage-mission/tests/mission_document.rs
+++ b/crates/pilotage-mission/tests/mission_document.rs
@@ -1,0 +1,239 @@
+//! Operational mission-document generation and identity tests.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use navigate_contract::{ClockDomainId, GeodeticPosition};
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+use pilotage_mission::policy::{
+    ARM_PHASE_DEADLINE_NS, CLIMB_PHASE_DEADLINE_NS, FOLLOW_PLAN_PHASE_DEADLINE_NS,
+    OPERATIONAL_RECEIPT_TIMEOUT_NS, OPERATIONAL_RETRY_LIMIT, OPERATIONAL_WALL_DEADLINE_NS,
+};
+use pilotage_mission::{MissionConfig, MissionEngine, decode_snapshot};
+use pilotage_mission_core::{
+    DirectiveReceipt, EngineStart, EngineState, ExecutionTarget, FlightAction, MissionAction,
+    MissionCondition, MissionEngine as CoreMissionEngine, MissionObservation, MissionTerminal,
+    NavigationCondition, NavigationObservation, ReceiptResult, TickInput, VehicleObservation,
+    WallDeadline,
+};
+
+const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+
+fn build(cruise_height_m: f64) -> (MissionEngine, pilotage_mission::MissionPlanRecord) {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let anchor = GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    );
+    let mut config = MissionConfig::new(
+        fixture::DEMO_ROUTE.to_owned(),
+        anchor,
+        ClockDomainId::new(7),
+    );
+    config.cruise_height_m = cruise_height_m;
+    MissionEngine::new(&snapshot, provenance, config).expect("mission builds")
+}
+
+#[test]
+fn route_config_produces_the_three_bounded_action_phases() {
+    let (engine, record) = build(15.0);
+    let document = engine.mission_document();
+    document.validate().expect("document validates");
+    document
+        .to_canonical_json()
+        .expect("document has a verified digest");
+    assert_eq!(record.mission_identity, document.identity);
+    assert_eq!(
+        document.execution_policy.retry_limit,
+        OPERATIONAL_RETRY_LIMIT
+    );
+    assert_eq!(
+        document.execution_policy.receipt_timeout_ns,
+        OPERATIONAL_RECEIPT_TIMEOUT_NS
+    );
+    assert_eq!(OPERATIONAL_WALL_DEADLINE_NS, 24 * 60 * 60 * 1_000_000_000);
+    assert_eq!(document.phases.len(), 3);
+    assert_eq!(document.phases[0].id, "arm");
+    assert_eq!(document.phases[1].id, "climb");
+    assert_eq!(document.phases[2].id, "follow-plan");
+    assert_eq!(
+        document.phases[0].simulator_time_deadline_ns,
+        ARM_PHASE_DEADLINE_NS
+    );
+    assert_eq!(
+        document.phases[1].simulator_time_deadline_ns,
+        CLIMB_PHASE_DEADLINE_NS
+    );
+    assert_eq!(
+        document.phases[2].simulator_time_deadline_ns,
+        FOLLOW_PLAN_PHASE_DEADLINE_NS
+    );
+    assert!(
+        document
+            .phases
+            .iter()
+            .all(|phase| { !matches!(phase.action, MissionAction::Flight(FlightAction::Hold {})) })
+    );
+}
+
+#[test]
+fn navigation_solution_altitude_and_plan_completion_are_document_conditions() {
+    let (engine, _) = build(15.0);
+    let phases = &engine.mission_document().phases;
+    assert!(matches!(
+        phases[0].entry_conditions.as_slice(),
+        [MissionCondition::Navigation(
+            NavigationCondition::GuidanceValid { expected: true }
+        )]
+    ));
+    assert!(matches!(
+        phases[1].action,
+        MissionAction::Flight(FlightAction::Climb {
+            target_altitude_m: 515.0
+        })
+    ));
+    assert!(matches!(
+        phases[1].completion_conditions.as_slice(),
+        [MissionCondition::Navigation(
+            NavigationCondition::Altitude { value_m: 514.0, .. }
+        )]
+    ));
+    assert!(matches!(
+        phases[2].completion_conditions.as_slice(),
+        [MissionCondition::Navigation(
+            NavigationCondition::PlanComplete { expected: true }
+        )]
+    ));
+}
+
+#[test]
+fn built_plan_and_navdata_identities_bind_the_document() {
+    let (first, first_record) = build(15.0);
+    let (higher, _) = build(20.0);
+    let first_document = first.mission_document();
+    let higher_document = higher.mission_document();
+    let MissionAction::Flight(FlightAction::FollowPlan { plan: first_plan }) =
+        &first_document.phases[2].action
+    else {
+        panic!("the final action follows the plan");
+    };
+    let MissionAction::Flight(FlightAction::FollowPlan { plan: higher_plan }) =
+        &higher_document.phases[2].action
+    else {
+        panic!("the final action follows the plan");
+    };
+    assert_eq!(
+        first_plan.navigation_data_identity,
+        first_record.provenance.navigation_data_identity
+    );
+    assert_eq!(
+        first_document.identity.navigation_data_identity,
+        first_plan.navigation_data_identity
+    );
+    assert!(!first_plan.plan_content_digest.is_zero());
+    assert_ne!(
+        first_plan.plan_content_digest, higher_plan.plan_content_digest,
+        "a changed built altitude profile changes the plan digest"
+    );
+    assert_ne!(
+        first_document.identity.content_digest,
+        higher_document.identity.content_digest
+    );
+}
+
+#[test]
+fn plan_completion_before_the_follow_deadline_is_complete() {
+    let (engine, _) = build(15.0);
+    let document = engine.mission_document().clone();
+    let start_ns = 1_000_000_000;
+    let mut core = CoreMissionEngine::start(
+        document.clone(),
+        EngineStart {
+            host_target: ExecutionTarget::Simulator,
+            simulator_time_ns: start_ns,
+            wall_time_ns: start_ns,
+            wall_deadline: WallDeadline {
+                mission_content_digest: document.identity.content_digest,
+                expires_at_ns: start_ns + OPERATIONAL_WALL_DEADLINE_NS,
+            },
+        },
+    )
+    .expect("core starts");
+
+    let arm = tick_core(&mut core, start_ns, observation(true, 500.0, false), None);
+    let climb = tick_core(
+        &mut core,
+        start_ns,
+        observation(true, 515.0, false),
+        Some(succeeded_receipt(&arm)),
+    );
+    let follow = tick_core(
+        &mut core,
+        start_ns,
+        observation(true, 515.0, false),
+        Some(succeeded_receipt(&climb)),
+    );
+    tick_core(
+        &mut core,
+        start_ns,
+        observation(true, 515.0, false),
+        Some(succeeded_receipt(&follow)),
+    );
+
+    let boundary_ns = start_ns + FOLLOW_PLAN_PHASE_DEADLINE_NS - 1;
+    let completed = tick_core(&mut core, boundary_ns, observation(true, 515.0, true), None);
+    assert!(matches!(
+        completed.state,
+        EngineState::Terminal {
+            result: MissionTerminal::Complete {
+                completed_phases: 3
+            }
+        }
+    ));
+}
+
+fn observation(guidance_valid: bool, altitude_m: f64, plan_complete: bool) -> MissionObservation {
+    MissionObservation {
+        navigation: NavigationObservation {
+            guidance_valid: Some(guidance_valid),
+            plan_complete: Some(plan_complete),
+            altitude_m: Some(altitude_m),
+        },
+        vehicle: VehicleObservation::default(),
+        signals: Vec::new(),
+    }
+}
+
+fn succeeded_receipt(output: &pilotage_mission_core::TickOutput) -> DirectiveReceipt {
+    let action_id = output
+        .directives
+        .first()
+        .expect("phase emits a directive")
+        .context()
+        .action_id;
+    DirectiveReceipt {
+        action_id,
+        result: ReceiptResult::Succeeded {},
+    }
+}
+
+fn tick_core(
+    engine: &mut CoreMissionEngine,
+    now_ns: u64,
+    observation: MissionObservation,
+    receipt: Option<DirectiveReceipt>,
+) -> pilotage_mission_core::TickOutput {
+    engine
+        .tick(TickInput {
+            simulator_time_ns: now_ns,
+            wall_time_ns: now_ns,
+            observation,
+            receipts: receipt.into_iter().collect(),
+        })
+        .expect("tick is accepted")
+}

--- a/crates/pilotage-mission/tests/mission_engine.rs
+++ b/crates/pilotage-mission/tests/mission_engine.rs
@@ -110,7 +110,7 @@ fn step(
     now: &mut MonotonicNanos,
     arm_requests: &mut u32,
     events: &mut Vec<MissionEvent>,
-) {
+) -> pilotage_mission::MissionOutput {
     *now = MonotonicNanos::from_nanos(now.as_nanos() + STEP_NANOS);
     truth.sequence = truth.sequence.wrapping_add(1);
     engine.on_ownship(&truth.sample(*now), *now);
@@ -120,11 +120,19 @@ fn step(
         *arm_requests += 1;
         engine.on_action_result(action.action_id, true);
     }
-    if let Some(intent) = out.intent {
-        assert_within_limits(&intent);
-        truth.integrate(&intent);
+    if let Some(intent) = out.intent.as_ref() {
+        assert_within_limits(intent);
+        truth.integrate(intent);
     }
-    events.extend(out.events);
+    events.extend(out.events.iter().cloned());
+    out
+}
+
+fn is_zero_velocity(intent: &ControlIntent) -> bool {
+    let ControlIntent::Velocity(velocity) = intent else {
+        return false;
+    };
+    velocity.vx == 0.0 && velocity.vy == 0.0 && velocity.vz == 0.0 && velocity.yaw_rate == 0.0
 }
 
 fn count<F: Fn(&MissionEvent) -> bool>(events: &[MissionEvent], predicate: F) -> usize {
@@ -191,14 +199,24 @@ fn mission_arms_once_climbs_flies_the_route_and_completes() {
     let mut events = Vec::new();
     let mut completed = false;
     for _ in 0..20_000 {
-        step(
+        let output = step(
             &mut engine,
             &mut truth,
             &mut now,
             &mut arm_requests,
             &mut events,
         );
-        if engine.state() == MissionState::Complete {
+        let held_before_terminal = output.state == MissionState::Enroute
+            && output.intent.as_ref().is_some_and(is_zero_velocity);
+        assert!(!held_before_terminal, "no enroute hold tick is permitted");
+        if output.state == MissionState::Complete {
+            assert!(
+                output
+                    .events
+                    .iter()
+                    .any(|event| matches!(event, MissionEvent::MissionComplete)),
+                "the first terminal tick surfaces mission completion"
+            );
             completed = true;
             break;
         }

--- a/hosts/session-host/src/runtime/automation.rs
+++ b/hosts/session-host/src/runtime/automation.rs
@@ -129,6 +129,12 @@ pub(crate) fn prepare(options: &MissionOptions) -> Result<MissionPlan, HostError
         effective_on = %record.provenance.effective_on,
         sha256 = %record.provenance.sha256_hex,
         fixture = record.provenance.fixture,
+        mission_revision = %record.mission_identity.revision_id,
+        mission_schema = record.mission_identity.schema_version,
+        mission_digest = %record.mission_identity.content_digest,
+        navdata_cycle = %record.mission_identity.navigation_data_identity.cycle,
+        navdata_snapshot = %record.mission_identity.navigation_data_identity.snapshot_id,
+        navdata_digest = %record.mission_identity.navigation_data_identity.snapshot_digest,
         "mission packed for flight"
     );
     Ok(plan)


### PR DESCRIPTION
## Summary

- Generate a validated and digested mission document from the route configuration.
- Use the shared mission core for all phase transitions.
- Keep Navigate fusion, plan execution, guidance, and body conversion in the operational handler.
- Preserve arm correlation and rejection-driven retries through directive receipts.
- Record the mission and navigation-data identities in mission provenance.
- End the mission at plan completion. The host keeps the indefinite zero-velocity hold.

## Operational policy

- Permit three retries after the first directive attempt.
- Require a receipt in five seconds.
- Limit the arm phase to two minutes of simulator time.
- Limit the climb phase to 30 minutes of simulator time.
- Limit the follow-plan phase to 23 hours of simulator time.
- Limit the mission to 24 hours of wall time.

## Verification

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- documentation with missing-doc and broken-link denies
- cargo build --release
- repository guards: 19 pairs passed
- independent review: approved with no remaining findings

SIM / NOT FOR FLIGHT.

Closes #560