### PR TITLE
Reference scenarios by mission document identity

### DIFF
--- a/crates/pilotage-tuning-feedback/src/qualification/evaluation.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/evaluation.rs
@@ -268,7 +268,7 @@ fn verify_failure(
     };
     if saved != failure
         || failure.scenario_set != expected.scenario_set
-        || failure.scenario_id != expected.scenario.id
+        || failure.mission_revision_id != expected.scenario.revision_id
         || failure.repetition != expected.repetition
         || failure.seed != expected.seed
         || failure.gate.passed

--- a/crates/pilotage-tuning-feedback/src/qualification/plan.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/plan.rs
@@ -1,9 +1,11 @@
-use flight_tune::{AttemptRole, Digest, RunTerminalReceipt, ScenarioRef, ScenarioSet, SearchStage};
+use flight_tune::{
+    AttemptRole, Digest, MissionReference, RunTerminalReceipt, ScenarioSet, SearchStage,
+};
 use serde::Serialize;
 
 use crate::{FeedbackError, digest, error::invalid};
 
-const RUN_CONTEXT_DOMAIN: &[u8] = b"flight-tune:run-execution-context:v1\0";
+const RUN_CONTEXT_DOMAIN: &[u8] = b"flight-tune:run-execution-context:v2\0";
 
 #[derive(Clone, Copy)]
 pub(super) struct ExpectedRun<'a> {
@@ -11,7 +13,7 @@ pub(super) struct ExpectedRun<'a> {
     pub(super) candidate: Digest,
     pub(super) trial_id: u64,
     pub(super) scenario_set: ScenarioSet,
-    pub(super) scenario: &'a ScenarioRef,
+    pub(super) scenario: &'a MissionReference,
     pub(super) repetition: u32,
     pub(super) seed: u64,
     pub(super) session_digest: Digest,
@@ -22,7 +24,7 @@ struct RunPlanDocument<'a> {
     role: AttemptRole,
     candidate: Digest,
     scenario_set: ScenarioSet,
-    scenarios: &'a [ScenarioRef],
+    scenarios: &'a [MissionReference],
     repetitions: u32,
     fixed_seed: u64,
 }
@@ -89,8 +91,8 @@ pub(super) fn verify_receipt_context(
         || context.candidate_digest() != expected.candidate
         || context.transition_authorization().is_some()
         || context.scenario_set() != expected.scenario_set
-        || context.scenario_id() != expected.scenario.id
-        || context.scenario_digest() != expected.scenario.digest
+        || context.mission_revision_id() != expected.scenario.revision_id
+        || context.mission_content_digest() != expected.scenario.content_digest
         || context.repetition() != expected.repetition
         || context.seed() != expected.seed
         || receipt.intent().run_intent_digest() != intent_digest
@@ -112,7 +114,7 @@ pub(super) const fn scenario_set(role: AttemptRole) -> ScenarioSet {
     }
 }
 
-fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[ScenarioRef] {
+fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[MissionReference] {
     match set {
         ScenarioSet::Training => &stage.training_scenarios,
         ScenarioSet::Promotion => &stage.promotion_scenarios,
@@ -120,13 +122,18 @@ fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[ScenarioRef] {
     }
 }
 
-fn derive_seed(fixed_seed: u64, set: ScenarioSet, scenario: &ScenarioRef, repetition: u32) -> u64 {
+fn derive_seed(
+    fixed_seed: u64,
+    set: ScenarioSet,
+    scenario: &MissionReference,
+    repetition: u32,
+) -> u64 {
     let partition = match set {
         ScenarioSet::Training => 0x243f_6a88_85a3_08d3,
         ScenarioSet::Promotion => 0x1319_8a2e_0370_7344,
         ScenarioSet::FinalQualification => 0xa409_3822_299f_31d0,
     };
-    let bytes = scenario.digest.as_bytes();
+    let bytes = scenario.content_digest.as_bytes();
     let key = digest_word(bytes, 0)
         ^ digest_word(bytes, 8).rotate_left(13)
         ^ digest_word(bytes, 16).rotate_left(29)
@@ -156,17 +163,18 @@ fn split_mix(mut value: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use flight_tune::{Digest, ScenarioRef, ScenarioSet};
+    use flight_tune::{Digest, MissionReference, ScenarioSet};
 
     use super::derive_seed;
 
     #[test]
     fn promotion_seed_v1_outputs_are_fixed() {
-        let scenario = ScenarioRef {
-            id: "promotion-calm".to_owned(),
-            digest: Digest::from_bytes([12; 32]),
+        let scenario = MissionReference {
+            revision_id: "promotion-calm".to_owned(),
+            schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+            content_digest: Digest::from_bytes([12; 32]),
             max_samples: 100,
-            sample_timeout_ms: 20,
+            sample_timeout_ns: 20_000_000,
         };
         let seeds = (0..3)
             .map(|repetition| derive_seed(23, ScenarioSet::Promotion, &scenario, repetition))

--- a/crates/pilotage-tuning-feedback/src/qualification/stage.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/stage.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashSet};
 
-use flight_tune::{ArtifactIdentity, Digest, PromotionSeedPolicy, ScenarioRef, SearchStage};
+use flight_tune::{ArtifactIdentity, Digest, MissionReference, PromotionSeedPolicy, SearchStage};
 
 use crate::{FeedbackError, error::invalid};
 
@@ -12,6 +12,8 @@ const MAX_SCENARIOS_PER_SET: usize = 64;
 /// they bound the same set of measured objectives.
 const MAX_POLICY_OBJECTIVES: usize = 64;
 const PROMOTION_POLICY_SCHEMA_VERSION: u16 = 1;
+const MISSION_SCHEMA_VERSION: u16 = 2;
+const MAX_SAMPLE_TIMEOUT_NS: u64 = 60_000_000_000;
 
 pub(super) fn verify(stage: &SearchStage) -> Result<(), FeedbackError> {
     verify_name(&stage.id, "stage")?;
@@ -90,21 +92,22 @@ fn verify_scenarios(stage: &SearchStage) -> Result<(), FeedbackError> {
 }
 
 fn verify_scenario(
-    scenario: &ScenarioRef,
+    mission: &MissionReference,
     ids: &mut BTreeSet<String>,
     digests: &mut HashSet<Digest>,
 ) -> Result<(), FeedbackError> {
-    verify_name(&scenario.id, "scenario")?;
-    if !ids.insert(scenario.id.clone())
-        || !digests.insert(scenario.digest)
-        || scenario.digest.is_zero()
-        || scenario.max_samples == 0
-        || scenario.sample_timeout_ms == 0
-        || scenario.sample_timeout_ms > 60_000
+    verify_name(&mission.revision_id, "mission")?;
+    if !ids.insert(mission.revision_id.clone())
+        || !digests.insert(mission.content_digest)
+        || mission.schema_version != MISSION_SCHEMA_VERSION
+        || mission.content_digest.is_zero()
+        || mission.max_samples == 0
+        || mission.sample_timeout_ns == 0
+        || mission.sample_timeout_ns > MAX_SAMPLE_TIMEOUT_NS
     {
         return Err(invalid(format!(
-            "scenario {} is repeated or has invalid limits",
-            scenario.id
+            "mission {} is repeated or has invalid limits",
+            mission.revision_id
         )));
     }
     Ok(())

--- a/crates/pilotage-tuning-feedback/src/qualification/tests.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests.rs
@@ -113,7 +113,7 @@ fn canonical_source_digest_is_fixed() {
         .expect("verify evidence");
     assert_eq!(
         verified.source_digest().to_string(),
-        "fd8f60cca54d07428cf39b5b7f4784beaec6d2016c429314f2c28e2480f8f303"
+        "ee78d67d92f0e51cdbd55b37f54e45e46ab3480744f679956ef32bddc39ca79d"
     );
 }
 

--- a/crates/pilotage-tuning-feedback/src/qualification/tests/fixture.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests/fixture.rs
@@ -4,9 +4,9 @@ use std::collections::BTreeMap;
 
 use flight_tune::{
     ArtifactIdentity, AttemptRole, AuthenticatedEvaluationProof, Candidate, CandidateEvaluation,
-    CandidateLineage, CandidateTransitionReference, Digest, JournalEvent, ParameterBounds,
-    PromotionPolicy, PromotionSeedPolicy, QualificationPolicy, RunTerminalDisposition,
-    RunTerminalQuarantine, RuntimeIdentities, ScenarioRef, SearchStage, SessionIdentity,
+    CandidateLineage, CandidateTransitionReference, Digest, JournalEvent, MissionReference,
+    ParameterBounds, PromotionPolicy, PromotionSeedPolicy, QualificationPolicy,
+    RunTerminalDisposition, RunTerminalQuarantine, RuntimeIdentities, SearchStage, SessionIdentity,
 };
 
 use crate::CampaignEvidence;
@@ -440,12 +440,13 @@ fn quarantine_reason(digest: Digest, class: RunTerminalQuarantine) -> String {
     format!("terminal receipt {digest} has quarantine class {name}")
 }
 
-fn scenario(id: &str, value: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: fixed_digest(value),
+fn scenario(id: &str, value: u8) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(value),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     }
 }
 

--- a/crates/pilotage-tuning-feedback/src/qualification/tests/fixture/terminal.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests/fixture/terminal.rs
@@ -20,7 +20,7 @@ pub(super) fn run(
 ) -> RunRecord {
     RunRecord {
         scenario_set: expected.scenario_set,
-        scenario_id: expected.scenario.id.clone(),
+        mission_revision_id: expected.scenario.revision_id.clone(),
         repetition: expected.repetition,
         seed: expected.seed,
         loss: point.loss,
@@ -83,13 +83,13 @@ fn terminal_receipt(
         &context,
         digest::domain(
             "run execution context",
-            b"flight-tune:run-execution-context:v1\0",
+            b"flight-tune:run-execution-context:v2\0",
             &context,
         )
         .expect("run intent digest"),
         RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: expected.candidate,
-            scenario_digest: expected.scenario.digest,
+            mission_content_digest: expected.scenario.content_digest,
             run,
         },
     )

--- a/tools/flight-tune-campaign/src/bench.rs
+++ b/tools/flight-tune-campaign/src/bench.rs
@@ -30,11 +30,11 @@ use std::time::Duration;
 
 use flight_tune::{
     AdapterError, ArtifactIdentity, CampaignBackend, Candidate, Digest, KinematicTruth,
-    MissionCapability, MissionDirective, MissionDocument, ReceiptResult, RunExecutionContext,
-    RunPreparationReceipt, SampleEvent, ScenarioFrame, ScenarioObservationReceipt, ScenarioRef,
-    ScenarioRuntime, ScenarioRuntimeError, ScenarioStartReceipt, ScenarioStopContext,
-    SessionChallenge, SimulatorCapability, SimulatorSessionReceipt, TelemetrySample, TrialScenario,
-    reference_observation_scenario, scenario_runtime_identity,
+    MissionCapability, MissionDirective, MissionDocument, MissionReference, ReceiptResult,
+    RunExecutionContext, RunPreparationReceipt, SampleEvent, ScenarioFrame,
+    ScenarioObservationReceipt, ScenarioRuntime, ScenarioRuntimeError, ScenarioStartReceipt,
+    ScenarioStopContext, SessionChallenge, SimulatorCapability, SimulatorSessionReceipt,
+    TelemetrySample, scenario_runtime_identity,
 };
 use pilotage_control_feel::{AxisCurve, AxisDemandShaper, AxisDynamics, AxisResponse, NeutralBand};
 
@@ -278,14 +278,11 @@ impl CampaignBackend for BenchBackend {
         }
     }
 
-    fn scenario_document_blocking(
+    fn mission_document_blocking(
         &self,
-        scenario: &ScenarioRef,
-    ) -> Result<TrialScenario, AdapterError> {
-        Ok(reference_observation_scenario(
-            scenario,
-            Some(10_480_000_000),
-        ))
+        mission: &MissionReference,
+    ) -> Result<MissionDocument, AdapterError> {
+        bench_stored_mission(mission)
     }
 
     fn project_scenario_frame(
@@ -310,7 +307,7 @@ impl CampaignBackend for BenchBackend {
         &mut self,
         capability: &SimulatorCapability,
         context: &RunExecutionContext,
-        scenario: &ScenarioRef,
+        scenario: &MissionReference,
     ) -> Result<RunPreparationReceipt, AdapterError> {
         let _ = scenario;
         Ok(RunPreparationReceipt {
@@ -344,7 +341,7 @@ impl CampaignBackend for BenchBackend {
         });
         Ok(ScenarioStartReceipt {
             session_digest: capability.session_digest(),
-            applied_scenario_digest: context.scenario_digest(),
+            applied_mission_content_digest: context.mission_content_digest(),
             seed: context.seed(),
             run_intent_digest: context.digest().map_err(to_adapter)?,
         })
@@ -482,7 +479,8 @@ mod qualifying;
 
 pub use adapter::BenchVehicleAdapter;
 pub use qualifying::{
-    BenchGates, BenchVehicleFactory, bench_scenario, bench_stage, warm_start_parameters,
+    BenchGates, BenchVehicleFactory, bench_scenario, bench_stage, bench_stored_mission,
+    warm_start_parameters,
 };
 
 #[cfg(test)]

--- a/tools/flight-tune-campaign/src/bench/qualifying.rs
+++ b/tools/flight-tune-campaign/src/bench/qualifying.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use flight_tune::{
     AdapterError, ArtifactIdentity, Digest, EvaluatorError, GateEvaluator, GateOutcome,
-    ScenarioRef, SimulatorCapability, SimulatorVehicleFactory, TelemetrySample,
-    TransitionBindingReceipt, VehicleBinding, VehicleBindingReceipt,
+    MissionDocument, MissionReference, SimulatorCapability, SimulatorVehicleFactory,
+    TelemetrySample, TransitionBindingReceipt, VehicleBinding, VehicleBindingReceipt,
 };
 
 use super::parameter;
@@ -130,7 +130,7 @@ impl GateEvaluator for BenchGates {
         &self.identity
     }
 
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, _scenario: &MissionReference) -> Result<(), EvaluatorError> {
         Ok(())
     }
 
@@ -235,7 +235,7 @@ pub fn warm_start_parameters(mode: FeelMode) -> BTreeMap<String, f64> {
 ///
 /// # Errors
 ///
-/// Returns an error when a scenario identity cannot be calculated.
+/// Returns an error when a mission identity cannot be calculated.
 pub fn bench_stage(
     id: &str,
     promotion: flight_tune::PromotionPolicy,
@@ -263,32 +263,63 @@ pub fn bench_stage(
         // Training, promotion and final qualification fly separate scenarios.
         // The bar that decides what ships is measured on runs the search never
         // saw, so a candidate cannot be fitted to the scenario that judges it.
-        training_scenarios: vec![bench_scenario("training-step", 21)?],
-        promotion_scenarios: vec![bench_scenario("promotion-step", 22)?],
-        final_qualification_scenarios: vec![bench_scenario("final-step", 23)?],
+        training_scenarios: vec![bench_scenario(BENCH_TRIAL_IDS[0])?],
+        promotion_scenarios: vec![bench_scenario(BENCH_TRIAL_IDS[1])?],
+        final_qualification_scenarios: vec![bench_scenario(BENCH_TRIAL_IDS[2])?],
         repetitions: 2,
         promotion,
         qualification,
     })
 }
 
-/// One trial of the bench, as a scenario reference.
+/// The ceiling covers the whole trial at the bench's sample rate with room for
+/// the completion event.
+const BENCH_MAX_SAMPLES: u32 = 700;
+
+const BENCH_RECEIPT_TIMEOUT_NS: u64 = 200_000_000;
+
+const BENCH_COMPLETION_TIME_NS: u64 = 10_480_000_000;
+
+/// The trial names that the bench stores as mission documents.
+const BENCH_TRIAL_IDS: [&str; 3] = ["training-step", "promotion-step", "final-step"];
+
+/// Resolves the stored bench mission that one reference names.
 ///
 /// # Errors
 ///
-/// Returns an error when the canonical scenario identity cannot be calculated.
-pub fn bench_scenario(id: &str, digest_byte: u8) -> Result<ScenarioRef, AdapterError> {
-    let mut reference = ScenarioRef {
-        id: id.to_owned(),
-        digest: Digest::from_bytes([digest_byte; 32]),
-        // The ceiling covers the whole trial at the bench's sample rate
-        // with room for the completion event.
-        max_samples: 700,
-        sample_timeout_ms: 200,
-    };
-    reference.digest =
-        flight_tune::reference_observation_scenario(&reference, Some(10_480_000_000))
-            .canonical_digest()
-            .map_err(|error| AdapterError::new(error.to_string()))?;
-    Ok(reference)
+/// Returns an error when the bench stores no mission with that revision.
+pub fn bench_stored_mission(mission: &MissionReference) -> Result<MissionDocument, AdapterError> {
+    for id in BENCH_TRIAL_IDS {
+        let document = bench_mission(id)?;
+        if document.identity.revision_id == mission.revision_id {
+            return Ok(document);
+        }
+    }
+    Err(AdapterError::new(
+        "the bench stores no mission document with that revision",
+    ))
+}
+
+/// One trial of the bench, as its stored mission document.
+///
+/// The trial scenario becomes a mission document once. The reference names
+/// that document, so the campaign schedule and the executed mission carry one
+/// identity.
+fn bench_mission(id: &str) -> Result<MissionDocument, AdapterError> {
+    flight_tune::calibration_mission_document(
+        &flight_tune::reference_observation_scenario(id, Some(BENCH_COMPLETION_TIME_NS)),
+        0,
+        BENCH_RECEIPT_TIMEOUT_NS,
+    )
+    .map_err(|error| AdapterError::new(error.to_string()))
+}
+
+/// One trial of the bench, as a mission reference.
+///
+/// # Errors
+///
+/// Returns an error when the mission identity cannot be calculated.
+pub fn bench_scenario(id: &str) -> Result<MissionReference, AdapterError> {
+    MissionReference::from_document(&bench_mission(id)?, BENCH_MAX_SAMPLES)
+        .map_err(|error| AdapterError::new(error.to_string()))
 }

--- a/tools/flight-tune-campaign/src/bench/tests.rs
+++ b/tools/flight-tune-campaign/src/bench/tests.rs
@@ -255,7 +255,7 @@ fn probe_warm_start_objectives() {
         let mut evaluator =
             FlightQualityEvaluator::new(Digest::from_bytes([9; 32])).expect("evaluator");
         evaluator
-            .begin(&bench_scenario("probe", 9).expect("build scenario"))
+            .begin(&bench_scenario("probe").expect("build scenario"))
             .expect("begin");
         let (mut velocity, mut position, mut previous) = (0.0_f64, 0.0_f64, 0.0_f64);
         let mut step: u32 = 0;

--- a/tools/flight-tune-campaign/src/scoring.rs
+++ b/tools/flight-tune-campaign/src/scoring.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeMap;
 
 use flight_tune::{
-    ArtifactIdentity, Digest, EvaluatorError, MetricEvaluator, MetricValues, ScenarioRef,
+    ArtifactIdentity, Digest, EvaluatorError, MetricEvaluator, MetricValues, MissionReference,
     TelemetrySample,
 };
 use pilotage_flight_quality::{
@@ -120,7 +120,7 @@ impl MetricEvaluator for FlightQualityEvaluator {
         &self.identity
     }
 
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, _scenario: &MissionReference) -> Result<(), EvaluatorError> {
         self.trace = Trace::default();
         self.active = true;
         Ok(())

--- a/tools/flight-tune-campaign/src/scoring/tests.rs
+++ b/tools/flight-tune-campaign/src/scoring/tests.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use flight_tune::{Digest, MetricEvaluator, ScenarioRef, TelemetrySample};
+use flight_tune::{Digest, MetricEvaluator, MissionReference, TelemetrySample};
 
 use super::{FlightQualityEvaluator, channel};
 
@@ -48,12 +48,13 @@ fn trial() -> Vec<TelemetrySample> {
     samples
 }
 
-fn scenario() -> ScenarioRef {
-    ScenarioRef {
-        id: "step-hold-release".to_owned(),
-        digest: Digest::from_bytes([7; 32]),
+fn scenario() -> MissionReference {
+    MissionReference {
+        revision_id: "step-hold-release".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: Digest::from_bytes([7; 32]),
         max_samples: 1_000,
-        sample_timeout_ms: 200,
+        sample_timeout_ns: 200_000_000,
     }
 }
 

--- a/tools/flight-tune-xplane/src/runtime/tests.rs
+++ b/tools/flight-tune-xplane/src/runtime/tests.rs
@@ -10,9 +10,9 @@ use pilotage_trial::{
 
 use super::*;
 use flight_tune::{
-    ArtifactIdentity, AttemptRole, CampaignMissionRuntime, Digest, RunExecutionContext,
-    ScenarioObservationReceipt, ScenarioRef, ScenarioRuntime, ScenarioRuntimeError, ScenarioSet,
-    ScenarioStopContext, mission_document_from_scenario,
+    ArtifactIdentity, AttemptRole, CampaignMissionRuntime, Digest, MissionReference,
+    RunExecutionContext, ScenarioObservationReceipt, ScenarioRuntime, ScenarioRuntimeError,
+    ScenarioSet, ScenarioStopContext, mission_document_from_scenario,
 };
 
 struct RecordingRuntime {
@@ -269,11 +269,12 @@ fn context() -> RunExecutionContext {
         Digest::from_bytes([2; 32]),
         None,
         ScenarioSet::Training,
-        &ScenarioRef {
-            id: "projection-conformance".to_owned(),
-            digest: Digest::from_bytes([3; 32]),
+        &MissionReference {
+            revision_id: "projection-conformance".to_owned(),
+            schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+            content_digest: Digest::from_bytes([3; 32]),
             max_samples: 2,
-            sample_timeout_ms: 10,
+            sample_timeout_ns: 10_000_000,
         },
         0,
         4,

--- a/tools/flight-tune/src/adapter/lifecycle.rs
+++ b/tools/flight-tune/src/adapter/lifecycle.rs
@@ -8,7 +8,8 @@ use super::{
     SimulatorCapability, SimulatorSessionReceipt, VehicleBinding,
 };
 use crate::{
-    ArtifactIdentity, Candidate, RunExecutionContext, ScenarioFrame, ScenarioRef, ScenarioRuntime,
+    ArtifactIdentity, Candidate, MissionDocument, MissionReference, RunExecutionContext,
+    ScenarioFrame, ScenarioRuntime,
 };
 
 /// The receipt for an applied candidate and its controller readback.
@@ -40,8 +41,8 @@ pub struct RunPreparationReceipt {
 pub struct ScenarioStartReceipt {
     /// The tuning session that owns the run.
     pub session_digest: Digest,
-    /// The digest of the applied scenario artifact.
-    pub applied_scenario_digest: Digest,
+    /// The content digest of the applied mission document.
+    pub applied_mission_content_digest: Digest,
     /// The applied deterministic run seed.
     pub seed: u64,
     /// The exact started run intent digest.
@@ -90,11 +91,11 @@ pub trait CampaignBackend {
     /// Revalidates the live action runtime without external mutation.
     fn attest_scenario_runtime_blocking(&self) -> Result<(), AdapterError>;
 
-    /// Resolves one declarative scenario artifact.
-    fn scenario_document_blocking(
+    /// Resolves the stored mission document that one reference names.
+    fn mission_document_blocking(
         &self,
-        scenario: &ScenarioRef,
-    ) -> Result<pilotage_trial::Scenario, AdapterError>;
+        mission: &MissionReference,
+    ) -> Result<MissionDocument, AdapterError>;
 
     /// Projects one verified telemetry sample into the neutral runtime frame.
     fn project_scenario_frame(
@@ -113,10 +114,10 @@ pub trait CampaignBackend {
         &mut self,
         capability: &SimulatorCapability,
         context: &RunExecutionContext,
-        scenario: &ScenarioRef,
+        mission: &MissionReference,
     ) -> Result<RunPreparationReceipt, AdapterError>;
 
-    /// Starts the prepared scenario and returns the applied artifact receipt.
+    /// Starts the prepared mission and returns the applied artifact receipt.
     fn start_blocking(
         &mut self,
         capability: &SimulatorCapability,

--- a/tools/flight-tune/src/adapter/terminal/tests.rs
+++ b/tools/flight-tune/src/adapter/terminal/tests.rs
@@ -9,7 +9,7 @@ use crate::terminal::{
     RunTerminalSemanticOutcome,
 };
 use crate::{
-    ArtifactIdentity, AttemptRole, RunExecutionContext, ScenarioRef, ScenarioSet,
+    ArtifactIdentity, AttemptRole, MissionReference, RunExecutionContext, ScenarioSet,
     SimulatorSessionReceipt, VehicleBindingReceipt,
 };
 
@@ -295,11 +295,12 @@ fn run_binding(
 }
 
 fn run_context(session_digest: Digest) -> RunExecutionContext {
-    let scenario = ScenarioRef {
-        id: "terminal-reference".to_owned(),
-        digest: fixed_digest(3),
+    let scenario = MissionReference {
+        revision_id: "terminal-reference".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(3),
         max_samples: 10,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     };
     RunExecutionContext::new(
         session_digest,

--- a/tools/flight-tune/src/campaign/evaluate.rs
+++ b/tools/flight-tune/src/campaign/evaluate.rs
@@ -279,7 +279,7 @@ fn prepare_run_context<'a>(
     candidate_digest: Digest,
     transition: Option<CandidateTransitionReference>,
     set: crate::ScenarioSet,
-    scenario: &'a crate::ScenarioRef,
+    scenario: &'a crate::MissionReference,
     repetition: u32,
     run_index: u64,
 ) -> Result<RunContext<'a>, TuneError> {

--- a/tools/flight-tune/src/campaign/evaluate/contract.rs
+++ b/tools/flight-tune/src/campaign/evaluate/contract.rs
@@ -1,8 +1,8 @@
 use crate::journal::AttemptRole;
 use crate::{
     CampaignBackend, CandidateEvaluation, CandidateReceipt, Digest, GateEvaluator, Journal,
-    MetricEvaluator, MetricValues, RunExecutionContext, RunPreparationReceipt, RunRecord,
-    ScenarioRef, ScenarioSet, ScenarioStartReceipt, SearchStage, SimulatorCapability,
+    MetricEvaluator, MetricValues, MissionReference, RunExecutionContext, RunPreparationReceipt,
+    RunRecord, ScenarioSet, ScenarioStartReceipt, SearchStage, SimulatorCapability,
     TelemetrySample, TuneError,
 };
 
@@ -11,7 +11,7 @@ pub(super) struct RunContext<'a> {
     pub(super) execution: RunExecutionContext,
     pub(super) run_intent_digest: Digest,
     pub(super) set: ScenarioSet,
-    pub(super) scenario: &'a ScenarioRef,
+    pub(super) scenario: &'a MissionReference,
     pub(super) repetition: u32,
     pub(super) seed: u64,
 }
@@ -40,7 +40,7 @@ pub(super) fn validate_sample(
 
 pub(super) fn begin_evaluators<G, M>(
     journal: &Journal,
-    scenario: &ScenarioRef,
+    scenario: &MissionReference,
     gates: &mut G,
     metric: &mut M,
 ) -> Result<(), TuneError>
@@ -105,13 +105,13 @@ pub(super) fn validate_scenario_receipt(
     context: &RunContext<'_>,
 ) -> Result<(), TuneError> {
     if receipt.session_digest != capability.session_digest()
-        || receipt.applied_scenario_digest != context.scenario.digest
+        || receipt.applied_mission_content_digest != context.scenario.content_digest
         || receipt.seed != context.seed
         || receipt.run_intent_digest != context.run_intent_digest
     {
         return Err(TuneError::ReceiptMismatch {
-            operation: "start scenario",
-            detail: "scenario, seed, or run intent readback does not match".to_owned(),
+            operation: "start mission",
+            detail: "mission, seed, or run intent readback does not match".to_owned(),
         });
     }
     Ok(())
@@ -145,7 +145,7 @@ pub(super) fn run_record(
 ) -> RunRecord {
     RunRecord {
         scenario_set: context.set,
-        scenario_id: context.scenario.id.clone(),
+        mission_revision_id: context.scenario.revision_id.clone(),
         repetition: context.repetition,
         seed: context.seed,
         loss: values.loss,
@@ -155,7 +155,7 @@ pub(super) fn run_record(
     }
 }
 
-pub(super) fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[ScenarioRef] {
+pub(super) fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[MissionReference] {
     match set {
         ScenarioSet::Training => &stage.training_scenarios,
         ScenarioSet::Promotion => &stage.promotion_scenarios,

--- a/tools/flight-tune/src/campaign/evaluate/mission.rs
+++ b/tools/flight-tune/src/campaign/evaluate/mission.rs
@@ -1,10 +1,8 @@
-use pilotage_mission_core::{
-    Digest as MissionDigest, EngineStart, ExecutionTarget, NavigationDataIdentity, WallDeadline,
-};
+use pilotage_mission_core::{EngineStart, ExecutionTarget, WallDeadline};
 
 use crate::{
-    AdapterError, ArtifactIdentity, CampaignBackend, CampaignMissionRuntime, Digest, Journal,
-    ScenarioRuntime, ScenarioStopReason, TuneError, mission_document_from_scenario,
+    AdapterError, ArtifactIdentity, CampaignBackend, CampaignMissionRuntime, Journal,
+    ScenarioRuntime, ScenarioStopReason, TuneError,
 };
 
 use super::RunContext;
@@ -16,23 +14,13 @@ pub(super) fn admit_campaign_mission<B: CampaignBackend>(
 ) -> Result<CampaignMissionRuntime, TuneError> {
     journal.ensure_usable()?;
     attest_runtime(journal, backend)?;
-    let scenario = backend
-        .scenario_document_blocking(context.scenario)
-        .map_err(|source| runtime_adapter_error(backend, "resolve scenario document", source))?;
-    validate_scenario_artifact(context, &scenario)?;
-    let timeout_ns = u64::from(context.scenario.sample_timeout_ms).saturating_mul(1_000_000);
-    let document = mission_document_from_scenario(
-        &scenario,
-        navigation_identity(context.scenario.digest),
-        0,
-        timeout_ns,
-    )
-    .map_err(|source| mission_error(backend, "admit scenario document", source))?;
+    let document = backend
+        .mission_document_blocking(context.scenario)
+        .map_err(|source| runtime_adapter_error(backend, "resolve mission document", source))?;
+    context.scenario.verify_document(&document)?;
     CampaignMissionRuntime::attest_capabilities(&document, backend.scenario_runtime())
-        .map_err(|source| mission_error(backend, "admit scenario capabilities", source))?;
-    let duration_ns = timeout_ns
-        .saturating_mul(u64::from(context.scenario.max_samples))
-        .max(1);
+        .map_err(|source| mission_error(backend, "admit mission capabilities", source))?;
+    let duration_ns = context.scenario.run_duration_ns();
     CampaignMissionRuntime::admit(document.clone(), engine_start(&document, duration_ns))
         .map_err(|source| mission_error(backend, "start mission engine", source))
 }
@@ -94,33 +82,6 @@ fn attest_runtime<B: CampaignBackend>(journal: &Journal, backend: &B) -> Result<
         .map_err(|source| mission_error(backend, "attest scenario action port", source))
 }
 
-fn validate_scenario_artifact(
-    context: &RunContext<'_>,
-    scenario: &pilotage_trial::Scenario,
-) -> Result<(), TuneError> {
-    if scenario.id != context.scenario.id {
-        return Err(scenario_mismatch(
-            "the resolved scenario id differs from its reference",
-        ));
-    }
-    let digest = scenario.canonical_digest().map_err(|error| {
-        scenario_mismatch(&format!("cannot digest the resolved scenario: {error}"))
-    })?;
-    if digest != context.scenario.digest {
-        return Err(scenario_mismatch(
-            "the resolved scenario content differs from its reference",
-        ));
-    }
-    Ok(())
-}
-
-fn scenario_mismatch(detail: &str) -> TuneError {
-    TuneError::ReceiptMismatch {
-        operation: "resolve scenario document",
-        detail: detail.to_owned(),
-    }
-}
-
 fn engine_start(
     document: &pilotage_mission_core::MissionDocument,
     duration_ns: u64,
@@ -145,14 +106,6 @@ fn expected_scenario_runtime(journal: &Journal) -> Result<&ArtifactIdentity, Tun
         .ok_or_else(|| TuneError::InvalidIdentity {
             detail: "the scenario runtime uses the prior identity domain".to_owned(),
         })
-}
-
-fn navigation_identity(digest: Digest) -> NavigationDataIdentity {
-    NavigationDataIdentity {
-        cycle: "calibration".to_owned(),
-        snapshot_id: "scenario-artifact".to_owned(),
-        snapshot_digest: MissionDigest::from_bytes(*digest.as_bytes()),
-    }
 }
 
 fn mission_error<B: CampaignBackend>(

--- a/tools/flight-tune/src/campaign/evaluate/stream.rs
+++ b/tools/flight-tune/src/campaign/evaluate/stream.rs
@@ -24,7 +24,7 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
-    let timeout = Duration::from_millis(u64::from(context.scenario.sample_timeout_ms));
+    let timeout = Duration::from_nanos(context.scenario.sample_timeout_ns);
     let wall_start = Instant::now();
     let mut position = StreamPosition::default();
     let outcome = stream_loop(
@@ -419,7 +419,7 @@ fn hard_failure(
     RunTerminal::HardGate {
         failure: HardGateFailure {
             scenario_set: context.set,
-            scenario_id: context.scenario.id.clone(),
+            mission_revision_id: context.scenario.revision_id.clone(),
             repetition: context.repetition,
             seed: context.seed,
             sample_sequence,

--- a/tools/flight-tune/src/campaign/evaluate/terminal.rs
+++ b/tools/flight-tune/src/campaign/evaluate/terminal.rs
@@ -159,7 +159,7 @@ fn semantic_outcome(
         RunTerminal::Passed { values } => Ok((
             RunTerminalSemanticOutcome::ScenarioComplete {
                 candidate_digest: context.execution.candidate_digest(),
-                scenario_digest: context.execution.scenario_digest(),
+                mission_content_digest: context.execution.mission_content_digest(),
                 run: run_record(stage, context, values),
             },
             None,
@@ -167,7 +167,7 @@ fn semantic_outcome(
         RunTerminal::HardGate { failure } => Ok((
             RunTerminalSemanticOutcome::HardGateAbort {
                 candidate_digest: context.execution.candidate_digest(),
-                scenario_digest: context.execution.scenario_digest(),
+                mission_content_digest: context.execution.mission_content_digest(),
                 failure,
             },
             None,

--- a/tools/flight-tune/src/campaign/promotion/tests.rs
+++ b/tools/flight-tune/src/campaign/promotion/tests.rs
@@ -7,11 +7,11 @@ use crate::model::{
     PromotionSeedPolicy, expected_promotion_pairs,
 };
 use crate::{
-    ArtifactIdentity, Digest, ParameterBounds, PromotionPolicy, QualificationPolicy,
-    RUN_TERMINAL_OPERATION_ORDER, RunBindingReceipt, RunRecord, RunTerminalClass,
-    RunTerminalIntent, RunTerminalOperation, RunTerminalOperationOutcome, RunTerminalPlan,
-    RunTerminalReceipt, RunTerminalRecoveryState, RunTerminalReport, RunTerminalScope,
-    RunTerminalSemanticOutcome, ScenarioRef, ScenarioSet, SearchStage,
+    ArtifactIdentity, Digest, MissionReference, ParameterBounds, PromotionPolicy,
+    QualificationPolicy, RUN_TERMINAL_OPERATION_ORDER, RunBindingReceipt, RunRecord,
+    RunTerminalClass, RunTerminalIntent, RunTerminalOperation, RunTerminalOperationOutcome,
+    RunTerminalPlan, RunTerminalReceipt, RunTerminalRecoveryState, RunTerminalReport,
+    RunTerminalScope, RunTerminalSemanticOutcome, ScenarioSet, SearchStage,
 };
 
 #[path = "tests/boundaries.rs"]
@@ -176,7 +176,7 @@ fn receipt_with_gates(
         context,
         RunRecord {
             scenario_set: ScenarioSet::Promotion,
-            scenario_id: context.scenario_id().to_owned(),
+            mission_revision_id: context.mission_revision_id().to_owned(),
             repetition: context.repetition(),
             seed: context.seed(),
             loss: point.loss,
@@ -196,7 +196,7 @@ pub(super) fn receipt_for_context(
         context.digest().expect("digest run context"),
         RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             run,
         },
     )
@@ -229,12 +229,13 @@ fn successful_outcomes() -> Vec<RunTerminalOperationOutcome> {
         .collect()
 }
 
-fn scenario(id: &str, digest: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: fixed_digest(digest),
+fn scenario(id: &str, digest: u8) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(digest),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     }
 }
 

--- a/tools/flight-tune/src/campaign/promotion/tests/identity.rs
+++ b/tools/flight-tune/src/campaign/promotion/tests/identity.rs
@@ -5,8 +5,8 @@ use super::{
     MetricPoint, evidence, expected_pairs, fixed_digest, plan, receipt_for_context, stage,
 };
 use crate::{
-    AttemptRole, RunExecutionContext, RunRecord, RunTerminalClass, RunTerminalReceipt, ScenarioRef,
-    ScenarioSet,
+    AttemptRole, MissionReference, RunExecutionContext, RunRecord, RunTerminalClass,
+    RunTerminalReceipt, ScenarioSet,
 };
 
 #[derive(Clone, Copy)]
@@ -128,7 +128,7 @@ fn every_run_requires_the_exact_ordered_hard_gate_set() {
             context,
             RunRecord {
                 scenario_set: ScenarioSet::Promotion,
-                scenario_id: context.scenario_id().to_owned(),
+                mission_revision_id: context.mission_revision_id().to_owned(),
                 repetition: context.repetition(),
                 seed: context.seed(),
                 loss: MetricPoint::baseline().loss,
@@ -188,20 +188,21 @@ fn changed_context(expected: &RunExecutionContext, change: IdentityChange) -> Ru
     .expect("create changed context")
 }
 
-fn changed_scenario(expected: &RunExecutionContext, change: IdentityChange) -> ScenarioRef {
-    ScenarioRef {
-        id: if matches!(change, IdentityChange::ScenarioId) {
+fn changed_scenario(expected: &RunExecutionContext, change: IdentityChange) -> MissionReference {
+    MissionReference {
+        revision_id: if matches!(change, IdentityChange::ScenarioId) {
             "promotion-foreign".to_owned()
         } else {
-            expected.scenario_id().to_owned()
+            expected.mission_revision_id().to_owned()
         },
-        digest: if matches!(change, IdentityChange::ScenarioDigest) {
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: if matches!(change, IdentityChange::ScenarioDigest) {
             fixed_digest(72)
         } else {
-            expected.scenario_digest()
+            expected.mission_content_digest()
         },
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     }
 }
 
@@ -210,7 +211,7 @@ fn matching_receipt(context: &RunExecutionContext, point: MetricPoint) -> RunTer
         context,
         RunRecord {
             scenario_set: ScenarioSet::Promotion,
-            scenario_id: context.scenario_id().to_owned(),
+            mission_revision_id: context.mission_revision_id().to_owned(),
             repetition: context.repetition(),
             seed: context.seed(),
             loss: point.loss,

--- a/tools/flight-tune/src/campaign_config.rs
+++ b/tools/flight-tune/src/campaign_config.rs
@@ -65,8 +65,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Digest, PROMOTION_POLICY_SCHEMA_VERSION, ParameterBounds, PromotionPolicy,
-        PromotionSeedPolicy, QualificationPolicy, ScenarioRef,
+        Digest, MissionReference, PROMOTION_POLICY_SCHEMA_VERSION, ParameterBounds,
+        PromotionPolicy, PromotionSeedPolicy, QualificationPolicy,
     };
 
     #[test]
@@ -115,12 +115,13 @@ mod tests {
         }
     }
 
-    fn scenario(id: &str, byte: u8) -> ScenarioRef {
-        ScenarioRef {
-            id: id.to_owned(),
-            digest: Digest::from_bytes([byte; 32]),
+    fn scenario(id: &str, byte: u8) -> MissionReference {
+        MissionReference {
+            revision_id: id.to_owned(),
+            schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+            content_digest: Digest::from_bytes([byte; 32]),
             max_samples: 1,
-            sample_timeout_ms: 1,
+            sample_timeout_ns: 1_000_000,
         }
     }
 }

--- a/tools/flight-tune/src/flight_quality/gates.rs
+++ b/tools/flight-tune/src/flight_quality/gates.rs
@@ -1,7 +1,7 @@
 use crate::flight_quality::config::{FlightQualityGate, FlightQualityGateConfig, gate_identity};
 use crate::flight_quality::telemetry::{CanonicalTelemetryKey, finite_value, flag};
 use crate::{
-    ArtifactIdentity, EvaluatorError, GateEvaluator, GateOutcome, ScenarioRef, TelemetrySample,
+    ArtifactIdentity, EvaluatorError, GateEvaluator, GateOutcome, MissionReference, TelemetrySample,
 };
 
 /// A fail-fast streaming evaluator for canonical flight hard gates.
@@ -127,7 +127,7 @@ impl GateEvaluator for FlightQualityGateEvaluator {
         &self.identity
     }
 
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, _scenario: &MissionReference) -> Result<(), EvaluatorError> {
         if self.active {
             return Err(EvaluatorError::new("a gate run is already active"));
         }

--- a/tools/flight-tune/src/flight_quality/metrics.rs
+++ b/tools/flight-tune/src/flight_quality/metrics.rs
@@ -10,7 +10,8 @@ use crate::flight_quality::config::{
 };
 use crate::flight_quality::telemetry::CanonicalSample;
 use crate::{
-    ArtifactIdentity, EvaluatorError, MetricEvaluator, MetricValues, ScenarioRef, TelemetrySample,
+    ArtifactIdentity, EvaluatorError, MetricEvaluator, MetricValues, MissionReference,
+    TelemetrySample,
 };
 
 /// Detailed metrics for the last completed scenario run.
@@ -74,16 +75,21 @@ impl MetricEvaluator for FlightQualityMetricEvaluator {
         &self.identity
     }
 
-    fn begin(&mut self, scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, scenario: &MissionReference) -> Result<(), EvaluatorError> {
         if self.active.is_some() {
             return Err(invalid("a metric run is already active"));
         }
         let plan = self
             .config
             .scenarios
-            .get(&scenario.id)
+            .get(&scenario.revision_id)
             .cloned()
-            .ok_or_else(|| invalid(format!("scenario {} has no metric plan", scenario.id)))?;
+            .ok_or_else(|| {
+                invalid(format!(
+                    "scenario {} has no metric plan",
+                    scenario.revision_id
+                ))
+            })?;
         self.last_report = None;
         self.active = Some(ActiveRun {
             plan,

--- a/tools/flight-tune/src/flight_quality/tests.rs
+++ b/tools/flight-tune/src/flight_quality/tests.rs
@@ -9,7 +9,7 @@ use super::{
     FlightQualityMetricConfig, FlightQualityMetricEvaluator, FlightQualityScales,
     FlightQualityScenario, FlightQualityWeights, ReleasePlan, StepPlan, WindPlan,
 };
-use crate::{Digest, ScenarioRef, TelemetrySample};
+use crate::{Digest, MissionReference, TelemetrySample};
 
 #[test]
 fn the_first_hard_gate_failure_has_priority() {
@@ -223,14 +223,14 @@ fn observe_trace(evaluator: &mut FlightQualityMetricEvaluator, trace: &[(u64, Tr
 }
 
 fn wind_loss(
-    scenario_id: &str,
+    mission_revision_id: &str,
     plan: FlightQualityScenario,
     weights: FlightQualityWeights,
     error_m: f64,
 ) -> f64 {
-    let mut evaluator = metric_evaluator(scenario_id, plan, weights);
+    let mut evaluator = metric_evaluator(mission_revision_id, plan, weights);
     evaluator
-        .begin(&scenario(scenario_id))
+        .begin(&scenario(mission_revision_id))
         .expect("begin wind metric");
     let trace = [0_u64, 100, 200, 300].map(|elapsed_ms| {
         (
@@ -303,21 +303,21 @@ fn gate_config(required: Vec<FlightQualityGate>) -> FlightQualityGateConfig {
 }
 
 fn metric_evaluator(
-    scenario_id: &str,
+    mission_revision_id: &str,
     plan: FlightQualityScenario,
     weights: FlightQualityWeights,
 ) -> FlightQualityMetricEvaluator {
-    FlightQualityMetricEvaluator::new(metric_config(scenario_id, plan, weights))
+    FlightQualityMetricEvaluator::new(metric_config(mission_revision_id, plan, weights))
         .expect("metric evaluator")
 }
 
 fn metric_config(
-    scenario_id: &str,
+    mission_revision_id: &str,
     plan: FlightQualityScenario,
     weights: FlightQualityWeights,
 ) -> FlightQualityMetricConfig {
     FlightQualityMetricConfig {
-        scenarios: BTreeMap::from([(scenario_id.to_owned(), plan)]),
+        scenarios: BTreeMap::from([(mission_revision_id.to_owned(), plan)]),
         scales: FlightQualityScales {
             time_s: 1.0,
             position_m: 1.0,
@@ -343,11 +343,12 @@ const fn weights(
     }
 }
 
-fn scenario(id: &str) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: Digest::from_bytes([42; 32]),
+fn scenario(id: &str) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: Digest::from_bytes([42; 32]),
         max_samples: 128,
-        sample_timeout_ms: 100,
+        sample_timeout_ns: 100_000_000,
     }
 }

--- a/tools/flight-tune/src/journal/event.rs
+++ b/tools/flight-tune/src/journal/event.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::identity::digest_bytes;
 use crate::{
     AuthenticatedEvaluationProof, CandidateEvaluation, CandidateTransitionReceipt,
-    CandidateTransitionReference, Digest, PromotionClosure, RunBindingReceipt, RunExecutionContext,
-    RunTerminalClass, RunTerminalIntent, RunTerminalPlan, RunTerminalReceipt, RunTerminalReport,
-    ScenarioRef, ScenarioSet, SearchStage, TuneError,
+    CandidateTransitionReference, Digest, MissionReference, PromotionClosure, RunBindingReceipt,
+    RunExecutionContext, RunTerminalClass, RunTerminalIntent, RunTerminalPlan, RunTerminalReceipt,
+    RunTerminalReport, ScenarioSet, SearchStage, TuneError,
 };
 
 #[derive(Serialize)]
@@ -13,7 +13,7 @@ struct RunPlan<'a> {
     role: AttemptRole,
     candidate: Digest,
     scenario_set: ScenarioSet,
-    scenarios: &'a [ScenarioRef],
+    scenarios: &'a [MissionReference],
     repetitions: u32,
     fixed_seed: u64,
 }

--- a/tools/flight-tune/src/journal/evidence.rs
+++ b/tools/flight-tune/src/journal/evidence.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AttemptRole, AuthenticatedEvaluationProof, Digest, FinalQualificationOutcome, JournalEntry,
-    JournalEvent, PromotionClosure, PromotionDecision, RunExecutionContext, ScenarioRef,
+    JournalEvent, MissionReference, PromotionClosure, PromotionDecision, RunExecutionContext,
     ScenarioSet, SearchStage, TuneError,
 };
 
@@ -366,7 +366,7 @@ fn invalid(detail: impl Into<String>) -> TuneError {
     }
 }
 
-fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[ScenarioRef] {
+fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[MissionReference] {
     match set {
         ScenarioSet::Training => &stage.training_scenarios,
         ScenarioSet::Promotion => &stage.promotion_scenarios,

--- a/tools/flight-tune/src/journal/replay/plan.rs
+++ b/tools/flight-tune/src/journal/replay/plan.rs
@@ -1,7 +1,7 @@
 use crate::journal::AttemptRole;
 use crate::model::derive_seed;
 use crate::{
-    CandidateEvaluation, HardGateFailure, RunRecord, ScenarioRef, ScenarioSet, SearchStage,
+    CandidateEvaluation, HardGateFailure, MissionReference, RunRecord, ScenarioSet, SearchStage,
     TuneError,
 };
 
@@ -50,14 +50,14 @@ pub(crate) fn validate_evaluation(
 fn validate_run_prefix(
     runs: &[RunRecord],
     set: ScenarioSet,
-    scenarios: &[ScenarioRef],
+    scenarios: &[MissionReference],
     stage: &SearchStage,
     fixed_seed: u64,
 ) -> Result<(), TuneError> {
     for (index, run) in runs.iter().enumerate() {
         let (scenario, repetition) = expected_run(scenarios, stage.repetitions, index)?;
         if run.scenario_set != set
-            || run.scenario_id != scenario.id
+            || run.mission_revision_id != scenario.revision_id
             || run.repetition != repetition
             || run.seed != derive_seed(fixed_seed, set, scenario, repetition)
             || run.passed_hard_gates != stage.required_hard_gates
@@ -72,7 +72,7 @@ fn validate_failure(
     failure: &HardGateFailure,
     run_index: usize,
     set: ScenarioSet,
-    scenarios: &[ScenarioRef],
+    scenarios: &[MissionReference],
     stage: &SearchStage,
     fixed_seed: u64,
 ) -> Result<(), TuneError> {
@@ -84,7 +84,7 @@ fn validate_failure(
     let gate_is_valid = core_gate_is_valid(failure, scenario)
         .unwrap_or(gate_is_required && failure.sample_sequence < u64::from(scenario.max_samples));
     if failure.scenario_set != set
-        || failure.scenario_id != scenario.id
+        || failure.mission_revision_id != scenario.revision_id
         || failure.repetition != repetition
         || failure.seed != derive_seed(fixed_seed, set, scenario, repetition)
         || failure.gate.detail.trim().is_empty()
@@ -97,7 +97,7 @@ fn validate_failure(
     Ok(())
 }
 
-fn core_gate_is_valid(failure: &HardGateFailure, scenario: &ScenarioRef) -> Option<bool> {
+fn core_gate_is_valid(failure: &HardGateFailure, scenario: &MissionReference) -> Option<bool> {
     match failure.gate.id.as_str() {
         "core.no_samples" => Some(failure.sample_sequence == 0 && failure.elapsed_ms == 0),
         "core.sample_limit" => Some(failure.sample_sequence == u64::from(scenario.max_samples)),
@@ -107,10 +107,10 @@ fn core_gate_is_valid(failure: &HardGateFailure, scenario: &ScenarioRef) -> Opti
 }
 
 fn expected_run(
-    scenarios: &[ScenarioRef],
+    scenarios: &[MissionReference],
     repetitions: u32,
     index: usize,
-) -> Result<(&ScenarioRef, u32), TuneError> {
+) -> Result<(&MissionReference, u32), TuneError> {
     let repetition_count = repetitions as usize;
     let scenario = scenarios
         .get(index / repetition_count)
@@ -120,7 +120,7 @@ fn expected_run(
     Ok((scenario, repetition))
 }
 
-fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[ScenarioRef] {
+fn scenarios(stage: &SearchStage, set: ScenarioSet) -> &[MissionReference] {
     match set {
         ScenarioSet::Training => &stage.training_scenarios,
         ScenarioSet::Promotion => &stage.promotion_scenarios,

--- a/tools/flight-tune/src/journal/replay/plan/tests.rs
+++ b/tools/flight-tune/src/journal/replay/plan/tests.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 
 use crate::model::derive_seed;
 use crate::{
-    Digest, GateOutcome, HardGateFailure, ParameterBounds, PromotionPolicy, QualificationPolicy,
-    ScenarioRef, ScenarioSet, SearchStage,
+    Digest, GateOutcome, HardGateFailure, MissionReference, ParameterBounds, PromotionPolicy,
+    QualificationPolicy, ScenarioSet, SearchStage,
 };
 
 use super::validate_failure;
@@ -54,10 +54,10 @@ fn no_sample_failure_requires_the_exact_empty_stream_position() {
     );
 }
 
-fn failure(scenario: &ScenarioRef, sample_sequence: u64, elapsed_ms: u64) -> HardGateFailure {
+fn failure(scenario: &MissionReference, sample_sequence: u64, elapsed_ms: u64) -> HardGateFailure {
     HardGateFailure {
         scenario_set: ScenarioSet::Training,
-        scenario_id: scenario.id.clone(),
+        mission_revision_id: scenario.revision_id.clone(),
         repetition: 0,
         seed: derive_seed(91, ScenarioSet::Training, scenario, 0),
         sample_sequence,
@@ -70,11 +70,12 @@ fn failure(scenario: &ScenarioRef, sample_sequence: u64, elapsed_ms: u64) -> Har
 }
 
 fn stage() -> SearchStage {
-    let scenario = ScenarioRef {
-        id: "empty-stream".to_owned(),
-        digest: Digest::from_bytes([1; 32]),
+    let scenario = MissionReference {
+        revision_id: "empty-stream".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: Digest::from_bytes([1; 32]),
         max_samples: 8,
-        sample_timeout_ms: 100,
+        sample_timeout_ns: 100_000_000,
     };
     SearchStage {
         id: "empty-stream-stage".to_owned(),

--- a/tools/flight-tune/src/journal/replay/run.rs
+++ b/tools/flight-tune/src/journal/replay/run.rs
@@ -2,9 +2,9 @@ use crate::journal::replay::{JournalState, invalid};
 use crate::journal::{JournalEvent, SessionIdentity};
 use crate::model::derive_seed;
 use crate::{
-    Digest, RunBindingReceipt, RunExecutionContext, RunTerminalClass, RunTerminalCompletion,
-    RunTerminalDisposition, RunTerminalIntent, RunTerminalPlan, RunTerminalReceipt,
-    RunTerminalReport, ScenarioRef, ScenarioSet, SearchStage, TuneError,
+    Digest, MissionReference, RunBindingReceipt, RunExecutionContext, RunTerminalClass,
+    RunTerminalCompletion, RunTerminalDisposition, RunTerminalIntent, RunTerminalPlan,
+    RunTerminalReceipt, RunTerminalReport, ScenarioSet, SearchStage, TuneError,
 };
 
 #[derive(Debug, Clone)]
@@ -142,8 +142,8 @@ pub(super) fn prepare(
         || context.candidate_digest() != pending.candidate
         || context.transition_authorization() != pending.transition
         || context.scenario_set() != pending.role.scenario_set()
-        || context.scenario_id() != expected_scenario.0.id
-        || context.scenario_digest() != expected_scenario.0.digest
+        || context.mission_revision_id() != expected_scenario.0.revision_id
+        || context.mission_content_digest() != expected_scenario.0.content_digest
         || context.repetition() != expected_scenario.1
         || context.seed() != expected_seed
         || run_intent_digest.is_zero()
@@ -164,7 +164,7 @@ fn expected_scenario(
     stage: &SearchStage,
     set: ScenarioSet,
     run_index: u64,
-) -> Result<(&ScenarioRef, u32), TuneError> {
+) -> Result<(&MissionReference, u32), TuneError> {
     let repetitions = u64::from(stage.repetitions);
     let scenario_index = usize::try_from(run_index / repetitions)
         .map_err(|_| invalid("prepared run scenario index overflow"))?;

--- a/tools/flight-tune/src/journal/replay/terminal/tests.rs
+++ b/tools/flight-tune/src/journal/replay/terminal/tests.rs
@@ -8,12 +8,12 @@ use crate::journal::snapshot::{PendingAttemptSnapshot, RunTerminalSnapshot};
 use crate::journal::{AttemptRole, JournalEvent, SessionIdentity};
 use crate::model::derive_seed;
 use crate::{
-    ArtifactIdentity, CandidateLineage, Digest, GateOutcome, HardGateFailure, ParameterBounds,
-    PromotionPolicy, QualificationPolicy, RunBindingReceipt, RunExecutionContext, RunRecord,
-    RunTerminalClass, RunTerminalDiagnostic, RunTerminalIntent, RunTerminalOperation,
+    ArtifactIdentity, CandidateLineage, Digest, GateOutcome, HardGateFailure, MissionReference,
+    ParameterBounds, PromotionPolicy, QualificationPolicy, RunBindingReceipt, RunExecutionContext,
+    RunRecord, RunTerminalClass, RunTerminalDiagnostic, RunTerminalIntent, RunTerminalOperation,
     RunTerminalOperationOutcome, RunTerminalPlan, RunTerminalReceipt, RunTerminalRecoveryState,
     RunTerminalReport, RunTerminalScope, RunTerminalSemanticOutcome, RuntimeIdentities,
-    ScenarioRef, ScenarioSet, SearchStage,
+    ScenarioSet, SearchStage,
 };
 
 use super::{apply_event, quarantine_reason};
@@ -340,12 +340,12 @@ fn semantic_outcome(
     match case {
         SemanticCase::ScenarioComplete => RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             run: run_record(context, index),
         },
         SemanticCase::HardGateAbort => RunTerminalSemanticOutcome::HardGateAbort {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             failure: hard_gate_failure(context),
         },
         SemanticCase::ExecutionError => RunTerminalSemanticOutcome::ExecutionError {
@@ -358,7 +358,7 @@ fn semantic_outcome(
 pub(super) fn run_record(context: &RunExecutionContext, index: u64) -> RunRecord {
     RunRecord {
         scenario_set: context.scenario_set(),
-        scenario_id: context.scenario_id().to_owned(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
         repetition: context.repetition(),
         seed: context.seed(),
         loss: 0.2 + index as f64 / 10.0,
@@ -371,7 +371,7 @@ pub(super) fn run_record(context: &RunExecutionContext, index: u64) -> RunRecord
 pub(super) fn hard_gate_failure(context: &RunExecutionContext) -> HardGateFailure {
     HardGateFailure {
         scenario_set: context.scenario_set(),
-        scenario_id: context.scenario_id().to_owned(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
         repetition: context.repetition(),
         seed: context.seed(),
         sample_sequence: 5,
@@ -440,12 +440,13 @@ fn test_stage() -> SearchStage {
     }
 }
 
-fn scenario(id: &str, byte: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: fixed_digest(byte),
+fn scenario(id: &str, byte: u8) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(byte),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     }
 }
 

--- a/tools/flight-tune/src/journal/replay/transition/tests.rs
+++ b/tools/flight-tune/src/journal/replay/transition/tests.rs
@@ -12,8 +12,8 @@ use crate::model::derive_seed;
 use crate::{
     ArtifactIdentity, AttemptRole, Candidate, CandidateEvaluation, CandidateLineage,
     CandidateTransitionReceipt, CandidateTransitionRequest, ConfidenceInterval, Digest,
-    ParameterBounds, PromotionPolicy, QualificationPolicy, RunExecutionContext, RuntimeIdentities,
-    ScenarioRef, ScoreAggregate, SearchStage, SessionIdentity, TuneError,
+    MissionReference, ParameterBounds, PromotionPolicy, QualificationPolicy, RunExecutionContext,
+    RuntimeIdentities, ScoreAggregate, SearchStage, SessionIdentity, TuneError,
 };
 
 #[test]
@@ -275,11 +275,12 @@ fn candidate(lineage: &CandidateLineage, gain: f64) -> Candidate {
 }
 
 fn stage() -> SearchStage {
-    let scenario = ScenarioRef {
-        id: "training".to_owned(),
-        digest: digest(3),
+    let scenario = MissionReference {
+        revision_id: "training".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: digest(3),
         max_samples: 8,
-        sample_timeout_ms: 100,
+        sample_timeout_ns: 100_000_000,
     };
     SearchStage {
         id: "transition-stage".to_owned(),

--- a/tools/flight-tune/src/journal/storage/tests/prospective.rs
+++ b/tools/flight-tune/src/journal/storage/tests/prospective.rs
@@ -13,8 +13,8 @@ use crate::journal::snapshot::RunTerminalSnapshot;
 use crate::journal::{JOURNAL_SCHEMA_VERSION, JournalEntry, JournalEvent, SessionIdentity};
 use crate::{
     ArtifactIdentity, AttemptRole, Candidate, CandidateLineage, CandidateTransitionReceipt,
-    CandidateTransitionRequest, Digest, Journal, ParameterBounds, PromotionPolicy,
-    QualificationPolicy, RuntimeIdentities, ScenarioRef, SearchStage, TuneError,
+    CandidateTransitionRequest, Digest, Journal, MissionReference, ParameterBounds,
+    PromotionPolicy, QualificationPolicy, RuntimeIdentities, SearchStage, TuneError,
 };
 
 #[path = "prospective/campaign_fixture.rs"]
@@ -354,12 +354,13 @@ fn test_stage() -> SearchStage {
     }
 }
 
-fn scenario(id: &str, digest_byte: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: Digest::from_bytes([digest_byte; 32]),
+fn scenario(id: &str, digest_byte: u8) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: Digest::from_bytes([digest_byte; 32]),
         max_samples: 8,
-        sample_timeout_ms: 100,
+        sample_timeout_ns: 100_000_000,
     }
 }
 

--- a/tools/flight-tune/src/journal/storage/tests/prospective/campaign_fixture.rs
+++ b/tools/flight-tune/src/journal/storage/tests/prospective/campaign_fixture.rs
@@ -34,7 +34,7 @@ pub(super) fn record_passing_baseline(
                 &context,
                 RunTerminalSemanticOutcome::ScenarioComplete {
                     candidate_digest,
-                    scenario_digest: context.scenario_digest(),
+                    mission_content_digest: context.mission_content_digest(),
                     run: run.clone(),
                 },
             );
@@ -61,7 +61,7 @@ pub(super) fn record_hard_gate_failed_baseline(
     let context = prepare_training_run(journal, stage, trial_id, candidate_digest, 0);
     let failure = HardGateFailure {
         scenario_set: ScenarioSet::Training,
-        scenario_id: context.scenario_id().to_owned(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
         repetition: 0,
         seed: context.seed(),
         sample_sequence: 1,
@@ -74,7 +74,7 @@ pub(super) fn record_hard_gate_failed_baseline(
         &context,
         RunTerminalSemanticOutcome::HardGateAbort {
             candidate_digest,
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             failure: failure.clone(),
         },
     );
@@ -122,7 +122,7 @@ pub(super) fn record_evidence_failure_without_commit(
     let run = run_record(stage, &context, 0.5);
     let outcome = RunTerminalSemanticOutcome::ScenarioComplete {
         candidate_digest,
-        scenario_digest: context.scenario_digest(),
+        mission_content_digest: context.mission_content_digest(),
         run,
     };
     let plan = RunTerminalPlan::new(RunTerminalScope::Active).expect("create terminal plan");
@@ -314,7 +314,7 @@ fn successful_outcomes() -> Vec<RunTerminalOperationOutcome> {
 fn run_record(stage: &SearchStage, context: &RunExecutionContext, loss: f64) -> RunRecord {
     RunRecord {
         scenario_set: context.scenario_set(),
-        scenario_id: context.scenario_id().to_owned(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
         repetition: context.repetition(),
         seed: context.seed(),
         loss,

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -58,23 +58,23 @@ pub use journal::{
     PromotionClosure, PromotionDecision, SessionIdentity,
 };
 pub use model::{
-    Candidate, ExpectedPromotionPair, ExpectedPromotionRun, PROMOTION_POLICY_SCHEMA_VERSION,
-    ParameterBounds, PromotionCalculation, PromotionComparison, PromotionObjectiveResult,
-    PromotionPairedStatistics, PromotionPolicy, PromotionRunKey, PromotionRunPlan,
-    PromotionSeedPolicy, PromotionSelection, QualificationPolicy, ScenarioRef, SearchStage,
+    Candidate, ExpectedPromotionPair, ExpectedPromotionRun, MissionReference,
+    PROMOTION_POLICY_SCHEMA_VERSION, ParameterBounds, PromotionCalculation, PromotionComparison,
+    PromotionObjectiveResult, PromotionPairedStatistics, PromotionPolicy, PromotionRunKey,
+    PromotionRunPlan, PromotionSeedPolicy, PromotionSelection, QualificationPolicy, SearchStage,
     promotion_policy_digest,
 };
 pub use pilotage_mission_core::{
     ArtifactIdentity as MissionArtifactIdentity, ControlChannel, DirectiveContext, FlightAction,
-    MissionCapability, MissionDirective, MissionDocument, ObservedSignal, ReceiptResult,
-    StartState, TrialAction, VehicleLifecycleState, Waveform,
+    MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective, MissionDocument, ObservedSignal,
+    ReceiptResult, StartState, TrialAction, VehicleLifecycleState, Waveform,
 };
 pub use pilotage_trial::{Digest, Scenario as TrialScenario};
 pub use run_context::{RUN_EXECUTION_CONTEXT_SCHEMA_VERSION, RunExecutionContext};
 pub use scenario_runtime::{
     CampaignMissionRuntime, KinematicTruth, ScenarioFrame, ScenarioObservationReceipt,
     ScenarioRuntime, ScenarioRuntimeError, ScenarioStopContext, ScenarioStopReason,
-    mission_document_from_scenario, reference_observation_scenario,
+    calibration_mission_document, mission_document_from_scenario, reference_observation_scenario,
 };
 pub use score::{
     CandidateEvaluation, ConfidenceInterval, GateEvaluator, GateOutcome, HardGateFailure,

--- a/tools/flight-tune/src/model.rs
+++ b/tools/flight-tune/src/model.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{CandidateLineage, ScenarioSet, TuneError};
 
 mod promotion;
+mod reference;
 
 pub use promotion::{
     ExpectedPromotionPair, ExpectedPromotionRun, PROMOTION_POLICY_SCHEMA_VERSION,
@@ -14,6 +15,7 @@ pub use promotion::{
     promotion_policy_digest,
 };
 pub(crate) use promotion::{expected_promotion_pairs, required_improvement};
+pub use reference::MissionReference;
 
 const MAX_PARAMETERS: usize = 128;
 const MAX_SCENARIOS_PER_SET: usize = 64;
@@ -106,20 +108,6 @@ impl Candidate {
     }
 }
 
-/// A content-identified scenario for one simulator adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ScenarioRef {
-    /// The stable scenario name.
-    pub id: String,
-    /// The digest of the scenario artifact bytes.
-    pub digest: Digest,
-    /// The largest permitted sample count for one run.
-    pub max_samples: u32,
-    /// The timeout for each requested sample.
-    pub sample_timeout_ms: u32,
-}
-
 /// Absolute release limits for the untouched final partition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -146,13 +134,13 @@ pub struct SearchStage {
     pub fixed_parameters: BTreeMap<String, f64>,
     /// Hard gates in their evaluation priority order.
     pub required_hard_gates: Vec<String>,
-    /// Scenarios that supply adaptive search evidence.
-    pub training_scenarios: Vec<ScenarioRef>,
-    /// Hidden scenarios for the one promotion decision.
-    pub promotion_scenarios: Vec<ScenarioRef>,
-    /// Hidden scenarios for the final release decision.
-    pub final_qualification_scenarios: Vec<ScenarioRef>,
-    /// The run count for each scenario.
+    /// Missions that supply adaptive search evidence.
+    pub training_scenarios: Vec<MissionReference>,
+    /// Hidden missions for the one promotion decision.
+    pub promotion_scenarios: Vec<MissionReference>,
+    /// Hidden missions for the final release decision.
+    pub final_qualification_scenarios: Vec<MissionReference>,
+    /// The run count for each mission.
     pub repetitions: u32,
     /// The limits for the one promotion decision.
     pub promotion: PromotionPolicy,
@@ -326,25 +314,15 @@ impl SearchStage {
 }
 
 fn validate_scenario(
-    scenario: &ScenarioRef,
+    scenario: &MissionReference,
     ids: &mut BTreeSet<String>,
     digests: &mut HashSet<Digest>,
 ) -> Result<(), TuneError> {
-    validate_name(&scenario.id, "scenario").map_err(as_stage_error)?;
-    if !ids.insert(scenario.id.clone()) || !digests.insert(scenario.digest) {
+    scenario.validate()?;
+    if !ids.insert(scenario.revision_id.clone()) || !digests.insert(scenario.content_digest) {
         return Err(invalid_stage(format!(
-            "scenario {} is repeated across stage partitions",
-            scenario.id
-        )));
-    }
-    if scenario.digest.is_zero()
-        || scenario.max_samples == 0
-        || scenario.sample_timeout_ms == 0
-        || scenario.sample_timeout_ms > 60_000
-    {
-        return Err(invalid_stage(format!(
-            "scenario {} limits or digest are not valid",
-            scenario.id
+            "mission {} is repeated across stage partitions",
+            scenario.revision_id
         )));
     }
     Ok(())
@@ -353,7 +331,7 @@ fn validate_scenario(
 pub(crate) fn derive_seed(
     fixed_seed: u64,
     set: ScenarioSet,
-    scenario: &ScenarioRef,
+    scenario: &MissionReference,
     repetition: u32,
 ) -> u64 {
     let partition = match set {
@@ -361,7 +339,7 @@ pub(crate) fn derive_seed(
         ScenarioSet::Promotion => 0x1319_8a2e_0370_7344,
         ScenarioSet::FinalQualification => 0xa409_3822_299f_31d0,
     };
-    let bytes = scenario.digest.as_bytes();
+    let bytes = scenario.content_digest.as_bytes();
     let key = digest_word(bytes, 0)
         ^ digest_word(bytes, 8).rotate_left(13)
         ^ digest_word(bytes, 16).rotate_left(29)

--- a/tools/flight-tune/src/model/promotion.rs
+++ b/tools/flight-tune/src/model/promotion.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use super::{ScenarioRef, SearchStage, derive_seed};
+use super::{MissionReference, SearchStage, derive_seed};
 use crate::identity::digest_bytes;
 use crate::{AttemptRole, Digest, PromotionDecision, RunExecutionContext, TuneError};
 
@@ -118,10 +118,10 @@ pub struct PromotionRunKey {
     pub role: AttemptRole,
     /// The candidate identity.
     pub candidate_digest: Digest,
-    /// The stable scenario name.
-    pub scenario_id: String,
-    /// The exact scenario artifact identity.
-    pub scenario_digest: Digest,
+    /// The executed mission revision.
+    pub mission_revision_id: String,
+    /// The executed mission content identity.
+    pub mission_content_digest: Digest,
     /// The zero-based repetition.
     pub repetition: u32,
     /// The deterministic run seed.
@@ -184,8 +184,8 @@ impl ExpectedPromotionPair {
         let right = &self.frozen.key;
         if left.role != AttemptRole::PromotionBaseline
             || right.role != AttemptRole::PromotionFrozen
-            || left.scenario_id != right.scenario_id
-            || left.scenario_digest != right.scenario_digest
+            || left.mission_revision_id != right.mission_revision_id
+            || left.mission_content_digest != right.mission_content_digest
             || left.repetition != right.repetition
             || left.seed != right.seed
             || self.baseline.context.tuning_session_digest()
@@ -326,7 +326,7 @@ pub(crate) fn expected_promotion_pairs(
 fn expected_pair(
     policy: &PromotionPolicy,
     plan: PromotionRunPlan,
-    scenario: &ScenarioRef,
+    scenario: &MissionReference,
     repetition: u32,
 ) -> Result<ExpectedPromotionPair, TuneError> {
     let seed = match policy.seed_policy {
@@ -365,7 +365,7 @@ fn expected_run(
     role: AttemptRole,
     trial_id: u64,
     candidate_digest: Digest,
-    scenario: &ScenarioRef,
+    scenario: &MissionReference,
     repetition: u32,
     seed: u64,
 ) -> Result<ExpectedPromotionRun, TuneError> {
@@ -391,20 +391,20 @@ fn key_from_context(context: &RunExecutionContext) -> PromotionRunKey {
     PromotionRunKey {
         role: context.role(),
         candidate_digest: context.candidate_digest(),
-        scenario_id: context.scenario_id().to_owned(),
-        scenario_digest: context.scenario_digest(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
+        mission_content_digest: context.mission_content_digest(),
         repetition: context.repetition(),
         seed: context.seed(),
     }
 }
 
-fn validate_promotion_scenarios(scenarios: &[ScenarioRef]) -> Result<(), TuneError> {
+fn validate_promotion_scenarios(scenarios: &[MissionReference]) -> Result<(), TuneError> {
     let mut ids = BTreeSet::new();
     let mut digests = HashSet::new();
     if scenarios.is_empty()
-        || scenarios
-            .iter()
-            .any(|scenario| !ids.insert(scenario.id.as_str()) || !digests.insert(scenario.digest))
+        || scenarios.iter().any(|scenario| {
+            !ids.insert(scenario.revision_id.as_str()) || !digests.insert(scenario.content_digest)
+        })
     {
         return Err(invalid_policy("promotion scenarios are empty or repeated"));
     }

--- a/tools/flight-tune/src/model/promotion/tests.rs
+++ b/tools/flight-tune/src/model/promotion/tests.rs
@@ -9,7 +9,9 @@ use super::{
     PromotionSeedPolicy, digest_policy_content, expected_promotion_pairs, promotion_policy_digest,
 };
 use crate::identity::digest_bytes;
-use crate::{AttemptRole, Digest, ParameterBounds, QualificationPolicy, ScenarioRef, SearchStage};
+use crate::{
+    AttemptRole, Digest, MissionReference, ParameterBounds, QualificationPolicy, SearchStage,
+};
 
 #[test]
 fn policy_digest_is_domain_separated_and_covers_every_field() {
@@ -93,8 +95,8 @@ fn expected_pairs_bind_role_candidate_scenario_repetition_seed_and_intent() {
             pair.frozen.key.candidate_digest,
             plan.frozen_candidate_digest
         );
-        assert_eq!(pair.baseline.key.scenario_id, "promotion-calm");
-        assert_eq!(pair.baseline.key.scenario_digest, fixed_digest(12));
+        assert_eq!(pair.baseline.key.mission_revision_id, "promotion-calm");
+        assert_eq!(pair.baseline.key.mission_content_digest, fixed_digest(12));
         assert_eq!(pair.baseline.key.repetition, repetition as u32);
         assert_eq!(pair.baseline.key.seed, pair.frozen.key.seed);
         assert_eq!(
@@ -205,12 +207,13 @@ pub(super) fn plan() -> PromotionRunPlan {
     }
 }
 
-fn scenario(id: &str, digest: u8) -> ScenarioRef {
-    ScenarioRef {
-        id: id.to_owned(),
-        digest: fixed_digest(digest),
+fn scenario(id: &str, digest: u8) -> MissionReference {
+    MissionReference {
+        revision_id: id.to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(digest),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     }
 }
 

--- a/tools/flight-tune/src/model/reference.rs
+++ b/tools/flight-tune/src/model/reference.rs
@@ -1,0 +1,129 @@
+use pilotage_mission_core::{MISSION_SCHEMA_VERSION, MissionDocument};
+use pilotage_trial::Digest;
+use serde::{Deserialize, Serialize};
+
+use crate::TuneError;
+
+#[cfg(test)]
+#[path = "reference/tests.rs"]
+mod tests;
+
+const MAX_REVISION_ID_BYTES: usize = 128;
+const MAX_SAMPLE_TIMEOUT_NS: u64 = 60_000_000_000;
+
+/// A campaign reference to one canonical mission document.
+///
+/// The reference names the executed document by its identity. It also carries
+/// the run limits that the campaign schedule applies. The sample timeout
+/// repeats the document receipt timeout, so a stage cannot supply a limit that
+/// the mission content digest does not cover.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MissionReference {
+    /// The immutable mission revision identifier.
+    pub revision_id: String,
+    /// The mission document schema version.
+    pub schema_version: u16,
+    /// The digest of the canonical mission content.
+    pub content_digest: Digest,
+    /// The largest permitted sample count for one run.
+    pub max_samples: u32,
+    /// The receipt timeout for each requested sample.
+    pub sample_timeout_ns: u64,
+}
+
+impl MissionReference {
+    /// Creates one reference to a stored mission document.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the document identity or a run limit is not
+    /// valid.
+    pub fn from_document(document: &MissionDocument, max_samples: u32) -> Result<Self, TuneError> {
+        let reference = Self {
+            revision_id: document.identity.revision_id.clone(),
+            schema_version: document.identity.schema_version,
+            content_digest: from_mission_digest(document.identity.content_digest),
+            max_samples,
+            sample_timeout_ns: document.execution_policy.receipt_timeout_ns,
+        };
+        reference.validate()?;
+        Ok(reference)
+    }
+
+    /// Checks that one resolved document is the referenced mission.
+    ///
+    /// The check recalculates the content digest. A backend cannot present a
+    /// document whose declared identity differs from its own bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when an identity field or a run limit differs.
+    pub fn verify_document(&self, document: &MissionDocument) -> Result<(), TuneError> {
+        self.validate()?;
+        let calculated = document
+            .calculate_content_digest()
+            .map_err(|source| mismatch(format!("cannot digest the resolved mission: {source}")))?;
+        if document.identity.revision_id != self.revision_id {
+            return Err(mismatch("the resolved mission revision differs"));
+        }
+        if document.identity.schema_version != self.schema_version {
+            return Err(mismatch("the resolved mission schema version differs"));
+        }
+        if from_mission_digest(document.identity.content_digest) != self.content_digest
+            || from_mission_digest(calculated) != self.content_digest
+        {
+            return Err(mismatch("the resolved mission content differs"));
+        }
+        if document.execution_policy.receipt_timeout_ns != self.sample_timeout_ns {
+            return Err(mismatch("the resolved mission receipt timeout differs"));
+        }
+        Ok(())
+    }
+
+    /// Returns the wall-clock budget for one complete run.
+    #[must_use]
+    pub fn run_duration_ns(&self) -> u64 {
+        self.sample_timeout_ns
+            .saturating_mul(u64::from(self.max_samples))
+            .max(1)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), TuneError> {
+        if self.revision_id.trim().is_empty() || self.revision_id.len() > MAX_REVISION_ID_BYTES {
+            return Err(invalid(format!(
+                "a mission revision id needs 1 to {MAX_REVISION_ID_BYTES} bytes"
+            )));
+        }
+        if self.schema_version != MISSION_SCHEMA_VERSION {
+            return Err(invalid("the mission schema version is not supported"));
+        }
+        if self.content_digest.is_zero() {
+            return Err(invalid("the mission content digest is zero"));
+        }
+        if self.max_samples == 0 {
+            return Err(invalid("the mission sample ceiling is zero"));
+        }
+        if self.sample_timeout_ns == 0 || self.sample_timeout_ns > MAX_SAMPLE_TIMEOUT_NS {
+            return Err(invalid("the mission sample timeout is out of range"));
+        }
+        Ok(())
+    }
+}
+
+fn from_mission_digest(digest: pilotage_mission_core::Digest) -> Digest {
+    Digest::from_bytes(*digest.as_bytes())
+}
+
+fn invalid(detail: impl Into<String>) -> TuneError {
+    TuneError::InvalidStage {
+        detail: detail.into(),
+    }
+}
+
+fn mismatch(detail: impl Into<String>) -> TuneError {
+    TuneError::ReceiptMismatch {
+        operation: "resolve mission document",
+        detail: detail.into(),
+    }
+}

--- a/tools/flight-tune/src/model/reference/tests.rs
+++ b/tools/flight-tune/src/model/reference/tests.rs
@@ -1,0 +1,121 @@
+#![allow(clippy::expect_used)]
+
+use pilotage_mission_core::{Digest as MissionDigest, MissionDocument};
+
+use super::MissionReference;
+use crate::{TuneError, calibration_mission_document, reference_observation_scenario};
+
+const RECEIPT_TIMEOUT_NS: u64 = 20_000_000;
+const MAX_SAMPLES: u32 = 16;
+
+#[test]
+fn a_reference_repeats_the_document_identity_and_receipt_timeout() {
+    let document = mission("unit-mission", 0);
+    let reference = reference(&document);
+
+    assert_eq!(reference.revision_id, document.identity.revision_id);
+    assert_eq!(reference.schema_version, document.identity.schema_version);
+    assert_eq!(
+        *reference.content_digest.as_bytes(),
+        *document.identity.content_digest.as_bytes()
+    );
+    assert_eq!(
+        reference.sample_timeout_ns,
+        document.execution_policy.receipt_timeout_ns
+    );
+    assert!(reference.verify_document(&document).is_ok());
+}
+
+#[test]
+fn a_changed_mission_document_changes_the_reference_identity() {
+    let first = reference(&mission("unit-mission", 0));
+    let second = reference(&mission("unit-mission", 1));
+
+    assert_eq!(first.revision_id, second.revision_id);
+    assert_ne!(first.content_digest, second.content_digest);
+}
+
+#[test]
+fn a_reference_refuses_a_document_with_another_revision() {
+    let reference = reference(&mission("unit-mission", 0));
+
+    assert_mismatch(reference.verify_document(&mission("other-mission", 0)));
+}
+
+#[test]
+fn a_reference_refuses_a_document_with_another_schema_version() {
+    let document = mission("unit-mission", 0);
+    let reference = reference(&document);
+    let mut changed = document;
+    changed.identity.schema_version = changed.identity.schema_version.wrapping_add(1);
+
+    assert_mismatch(reference.verify_document(&changed));
+}
+
+#[test]
+fn a_reference_refuses_a_document_with_other_content() {
+    let reference = reference(&mission("unit-mission", 0));
+
+    assert_mismatch(reference.verify_document(&mission("unit-mission", 1)));
+}
+
+#[test]
+fn a_reference_recalculates_the_declared_content_digest() {
+    let mut tampered = mission("unit-mission", 0);
+    tampered.identity.content_digest = MissionDigest::from_bytes([9; 32]);
+    let reference = reference(&tampered);
+
+    assert_eq!(
+        *reference.content_digest.as_bytes(),
+        *tampered.identity.content_digest.as_bytes()
+    );
+    assert_mismatch(reference.verify_document(&tampered));
+}
+
+#[test]
+fn a_reference_refuses_a_sample_timeout_that_the_document_does_not_carry() {
+    let document = mission("unit-mission", 0);
+    let mut reference = reference(&document);
+    reference.sample_timeout_ns = reference.sample_timeout_ns.wrapping_add(1_000_000);
+
+    assert_mismatch(reference.verify_document(&document));
+}
+
+#[test]
+fn a_reference_needs_run_limits_inside_their_range() {
+    let document = mission("unit-mission", 0);
+
+    assert!(MissionReference::from_document(&document, 0).is_err());
+    let mut reference = reference(&document);
+    reference.sample_timeout_ns = 0;
+    assert!(reference.validate().is_err());
+    reference.sample_timeout_ns = 60_000_000_001;
+    assert!(reference.validate().is_err());
+}
+
+#[test]
+fn run_duration_covers_every_permitted_sample() {
+    let reference = reference(&mission("unit-mission", 0));
+
+    assert_eq!(
+        reference.run_duration_ns(),
+        RECEIPT_TIMEOUT_NS * u64::from(MAX_SAMPLES)
+    );
+}
+
+fn mission(id: &str, retry_limit: u16) -> MissionDocument {
+    calibration_mission_document(
+        &reference_observation_scenario(id, None),
+        retry_limit,
+        RECEIPT_TIMEOUT_NS,
+    )
+    .expect("mission document")
+}
+
+fn reference(document: &MissionDocument) -> MissionReference {
+    MissionReference::from_document(document, MAX_SAMPLES).expect("mission reference")
+}
+
+fn assert_mismatch(result: Result<(), TuneError>) {
+    assert!(matches!(result, Err(TuneError::ReceiptMismatch { .. })));
+}

--- a/tools/flight-tune/src/run_context.rs
+++ b/tools/flight-tune/src/run_context.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::identity::digest_bytes;
 use crate::{
-    AttemptRole, CandidateTransitionReference, Digest, ScenarioRef, ScenarioSet, TuneError,
+    AttemptRole, CandidateTransitionReference, Digest, MissionReference, ScenarioSet, TuneError,
 };
 
 /// The supported run execution context schema.
-pub const RUN_EXECUTION_CONTEXT_SCHEMA_VERSION: u16 = 1;
+pub const RUN_EXECUTION_CONTEXT_SCHEMA_VERSION: u16 = 2;
 
-const RUN_CONTEXT_DOMAIN: &[u8] = b"flight-tune:run-execution-context:v1\0";
+const RUN_CONTEXT_DOMAIN: &[u8] = b"flight-tune:run-execution-context:v2\0";
 
 /// The immutable identity of one simulator run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,8 +21,8 @@ pub struct RunExecutionContext {
     candidate_digest: Digest,
     transition_authorization: Option<CandidateTransitionReference>,
     scenario_set: ScenarioSet,
-    scenario_id: String,
-    scenario_digest: Digest,
+    mission_revision_id: String,
+    mission_content_digest: Digest,
     repetition: u32,
     seed: u64,
 }
@@ -41,7 +41,7 @@ impl RunExecutionContext {
         candidate_digest: Digest,
         transition_authorization: Option<CandidateTransitionReference>,
         scenario_set: ScenarioSet,
-        scenario: &ScenarioRef,
+        mission: &MissionReference,
         repetition: u32,
         seed: u64,
     ) -> Result<Self, TuneError> {
@@ -53,8 +53,8 @@ impl RunExecutionContext {
             candidate_digest,
             transition_authorization,
             scenario_set,
-            scenario_id: scenario.id.clone(),
-            scenario_digest: scenario.digest,
+            mission_revision_id: mission.revision_id.clone(),
+            mission_content_digest: mission.content_digest,
             repetition,
             seed,
         };
@@ -86,9 +86,9 @@ impl RunExecutionContext {
             || self.candidate_digest.is_zero()
             || self.role.scenario_set() != self.scenario_set
             || !transition_matches
-            || self.scenario_id.trim().is_empty()
-            || self.scenario_id.len() > 128
-            || self.scenario_digest.is_zero()
+            || self.mission_revision_id.trim().is_empty()
+            || self.mission_revision_id.len() > 128
+            || self.mission_content_digest.is_zero()
         {
             return Err(TuneError::InvalidIdentity {
                 detail: "the run execution context is incomplete or inconsistent".to_owned(),
@@ -150,16 +150,16 @@ impl RunExecutionContext {
         self.scenario_set
     }
 
-    /// Returns the scenario name.
+    /// Returns the executed mission revision.
     #[must_use]
-    pub fn scenario_id(&self) -> &str {
-        &self.scenario_id
+    pub fn mission_revision_id(&self) -> &str {
+        &self.mission_revision_id
     }
 
-    /// Returns the scenario artifact identity.
+    /// Returns the executed mission content identity.
     #[must_use]
-    pub const fn scenario_digest(&self) -> Digest {
-        self.scenario_digest
+    pub const fn mission_content_digest(&self) -> Digest {
+        self.mission_content_digest
     }
 
     /// Returns the zero-based scenario repetition.

--- a/tools/flight-tune/src/run_context/tests.rs
+++ b/tools/flight-tune/src/run_context/tests.rs
@@ -44,11 +44,12 @@ fn context(reference: CandidateTransitionReference) -> RunExecutionContext {
         reference.target_candidate_digest(),
         Some(reference),
         ScenarioSet::Training,
-        &ScenarioRef {
-            id: "calm".to_owned(),
-            digest: digest(9),
+        &MissionReference {
+            revision_id: "calm".to_owned(),
+            schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+            content_digest: digest(9),
             max_samples: 10,
-            sample_timeout_ms: 20,
+            sample_timeout_ns: 20_000_000,
         },
         0,
         22,

--- a/tools/flight-tune/src/scenario_runtime.rs
+++ b/tools/flight-tune/src/scenario_runtime.rs
@@ -5,7 +5,9 @@ mod frame;
 mod host;
 mod port;
 
-pub use document::{mission_document_from_scenario, reference_observation_scenario};
+pub use document::{
+    calibration_mission_document, mission_document_from_scenario, reference_observation_scenario,
+};
 pub use frame::{KinematicTruth, ScenarioFrame};
 pub use host::CampaignMissionRuntime;
 pub use port::{

--- a/tools/flight-tune/src/scenario_runtime/document.rs
+++ b/tools/flight-tune/src/scenario_runtime/document.rs
@@ -9,14 +9,9 @@ use pilotage_trial::{
     Scenario,
 };
 
-use crate::ScenarioRef;
-
 /// Creates the declarative observation scenario used by a reference backend.
 #[must_use]
-pub fn reference_observation_scenario(
-    reference: &ScenarioRef,
-    completion_time_ns: Option<u64>,
-) -> Scenario {
+pub fn reference_observation_scenario(id: &str, completion_time_ns: Option<u64>) -> Scenario {
     let exit_conditions = completion_time_ns.map_or_else(
         || vec![PhaseCondition::Always],
         |value_ns| {
@@ -28,7 +23,7 @@ pub fn reference_observation_scenario(
     );
     Scenario {
         schema_version: SCENARIO_SCHEMA_VERSION,
-        id: reference.id.clone(),
+        id: id.to_owned(),
         revision: 1,
         phases: vec![Phase {
             id: "observe".to_owned(),
@@ -45,6 +40,34 @@ pub fn reference_observation_scenario(
 }
 
 use super::ScenarioRuntimeError;
+
+/// Projects one trial scenario into its calibration mission document.
+///
+/// The navigation-data identity names the authored trial scenario, so a
+/// changed scenario changes the mission content digest.
+///
+/// # Errors
+///
+/// Returns an error when the trial scenario or projected mission is invalid.
+pub fn calibration_mission_document(
+    scenario: &Scenario,
+    retry_limit: u16,
+    receipt_timeout_ns: u64,
+) -> Result<MissionDocument, ScenarioRuntimeError> {
+    let source = scenario
+        .canonical_digest()
+        .map_err(|error| projection(error.to_string()))?;
+    mission_document_from_scenario(
+        scenario,
+        NavigationDataIdentity {
+            cycle: "calibration".to_owned(),
+            snapshot_id: "trial-scenario".to_owned(),
+            snapshot_digest: pilotage_mission_core::Digest::from_bytes(*source.as_bytes()),
+        },
+        retry_limit,
+        receipt_timeout_ns,
+    )
+}
 
 /// Projects one declarative trial scenario into the shared mission document.
 ///

--- a/tools/flight-tune/src/scenario_runtime/tests.rs
+++ b/tools/flight-tune/src/scenario_runtime/tests.rs
@@ -15,7 +15,9 @@ use pilotage_trial::{
 };
 
 use super::*;
-use crate::{ArtifactIdentity, AttemptRole, Digest, RunExecutionContext, ScenarioRef, ScenarioSet};
+use crate::{
+    ArtifactIdentity, AttemptRole, Digest, MissionReference, RunExecutionContext, ScenarioSet,
+};
 
 #[path = "../../build_support/scenario_runtime_identity.rs"]
 #[allow(dead_code)]
@@ -402,11 +404,12 @@ fn context() -> RunExecutionContext {
         Digest::from_bytes([2; 32]),
         None,
         ScenarioSet::Training,
-        &ScenarioRef {
-            id: "reference-scenario".to_owned(),
-            digest: Digest::from_bytes([3; 32]),
+        &MissionReference {
+            revision_id: "reference-scenario".to_owned(),
+            schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+            content_digest: Digest::from_bytes([3; 32]),
             max_samples: 2,
-            sample_timeout_ms: 10,
+            sample_timeout_ns: 10_000_000,
         },
         0,
         4,

--- a/tools/flight-tune/src/score.rs
+++ b/tools/flight-tune/src/score.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ArtifactIdentity, EvaluatorError, ScenarioRef, TelemetrySample, TuneError};
+use crate::{ArtifactIdentity, EvaluatorError, MissionReference, TelemetrySample, TuneError};
 
 #[cfg(test)]
 #[path = "score/tests.rs"]
@@ -47,8 +47,8 @@ pub trait GateEvaluator {
     /// Returns the exact gate implementation identity.
     fn identity(&self) -> &ArtifactIdentity;
 
-    /// Starts evaluation for one scenario run.
-    fn begin(&mut self, scenario: &ScenarioRef) -> Result<(), EvaluatorError>;
+    /// Starts evaluation for one mission run.
+    fn begin(&mut self, mission: &MissionReference) -> Result<(), EvaluatorError>;
 
     /// Evaluates hard gates in order through the first failure.
     fn evaluate(&mut self, sample: &TelemetrySample) -> Result<Vec<GateOutcome>, EvaluatorError>;
@@ -79,8 +79,8 @@ pub trait MetricEvaluator {
     /// Returns the exact metric implementation identity.
     fn identity(&self) -> &ArtifactIdentity;
 
-    /// Starts metric evaluation for one scenario run.
-    fn begin(&mut self, scenario: &ScenarioRef) -> Result<(), EvaluatorError>;
+    /// Starts metric evaluation for one mission run.
+    fn begin(&mut self, mission: &MissionReference) -> Result<(), EvaluatorError>;
 
     /// Adds one sample after all hard gates pass for that sample.
     fn observe(&mut self, sample: &TelemetrySample) -> Result<(), EvaluatorError>;
@@ -113,8 +113,8 @@ pub enum ScenarioSet {
 pub struct RunRecord {
     /// The isolated scenario partition.
     pub scenario_set: ScenarioSet,
-    /// The stable scenario identity.
-    pub scenario_id: String,
+    /// The executed mission revision.
+    pub mission_revision_id: String,
     /// The repeated-run index.
     pub repetition: u32,
     /// The deterministic run seed.
@@ -135,8 +135,8 @@ pub struct RunRecord {
 pub struct HardGateFailure {
     /// The isolated scenario partition.
     pub scenario_set: ScenarioSet,
-    /// The stable scenario identity.
-    pub scenario_id: String,
+    /// The executed mission revision.
+    pub mission_revision_id: String,
     /// The repeated-run index.
     pub repetition: u32,
     /// The deterministic run seed.

--- a/tools/flight-tune/src/strategy.rs
+++ b/tools/flight-tune/src/strategy.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use pilotage_trial::Digest;
 
-use crate::{ArtifactIdentity, Candidate, ParameterBounds, ScenarioRef};
+use crate::{ArtifactIdentity, Candidate, MissionReference, ParameterBounds};
 
 /// A prior training result that a proposal strategy can inspect.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,7 +35,7 @@ pub struct TrainingView<'a> {
     /// The only parameters that a proposal can change.
     pub allowlist: &'a BTreeMap<String, ParameterBounds>,
     /// The training scenarios.
-    pub scenarios: &'a [ScenarioRef],
+    pub scenarios: &'a [MissionReference],
     /// The repeated run count for each training scenario.
     pub repetitions: u32,
     /// The current training incumbent.

--- a/tools/flight-tune/src/terminal/intent.rs
+++ b/tools/flight-tune/src/terminal/intent.rs
@@ -21,8 +21,8 @@ pub enum RunTerminalSemanticOutcome {
     ScenarioComplete {
         /// The candidate that produced the result.
         candidate_digest: Digest,
-        /// The exact scenario artifact identity.
-        scenario_digest: Digest,
+        /// The executed mission content identity.
+        mission_content_digest: Digest,
         /// The exact passing run record.
         run: RunRecord,
     },
@@ -30,8 +30,8 @@ pub enum RunTerminalSemanticOutcome {
     HardGateAbort {
         /// The candidate that produced the failure.
         candidate_digest: Digest,
-        /// The exact scenario artifact identity.
-        scenario_digest: Digest,
+        /// The executed mission content identity.
+        mission_content_digest: Digest,
         /// The exact first hard gate failure.
         failure: HardGateFailure,
     },
@@ -171,14 +171,14 @@ fn validate_outcome(
     match outcome {
         RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest,
-            scenario_digest,
+            mission_content_digest,
             run,
-        } => validate_run(*candidate_digest, *scenario_digest, run, context),
+        } => validate_run(*candidate_digest, *mission_content_digest, run, context),
         RunTerminalSemanticOutcome::HardGateAbort {
             candidate_digest,
-            scenario_digest,
+            mission_content_digest,
             failure,
-        } => validate_failure(*candidate_digest, *scenario_digest, failure, context),
+        } => validate_failure(*candidate_digest, *mission_content_digest, failure, context),
         RunTerminalSemanticOutcome::ExecutionError { diagnostic } => diagnostic.validate(),
         RunTerminalSemanticOutcome::Recovery => Ok(()),
     }
@@ -186,13 +186,13 @@ fn validate_outcome(
 
 fn validate_run(
     candidate_digest: Digest,
-    scenario_digest: Digest,
+    mission_content_digest: Digest,
     run: &RunRecord,
     context: &RunExecutionContext,
 ) -> Result<(), TuneError> {
-    validate_semantic_identity(candidate_digest, scenario_digest, context)?;
+    validate_semantic_identity(candidate_digest, mission_content_digest, context)?;
     if run.scenario_set != context.scenario_set()
-        || run.scenario_id != context.scenario_id()
+        || run.mission_revision_id != context.mission_revision_id()
         || run.repetition != context.repetition()
         || run.seed != context.seed()
     {
@@ -210,13 +210,13 @@ fn validate_run(
 
 fn validate_failure(
     candidate_digest: Digest,
-    scenario_digest: Digest,
+    mission_content_digest: Digest,
     failure: &HardGateFailure,
     context: &RunExecutionContext,
 ) -> Result<(), TuneError> {
-    validate_semantic_identity(candidate_digest, scenario_digest, context)?;
+    validate_semantic_identity(candidate_digest, mission_content_digest, context)?;
     if failure.scenario_set != context.scenario_set()
-        || failure.scenario_id != context.scenario_id()
+        || failure.mission_revision_id != context.mission_revision_id()
         || failure.repetition != context.repetition()
         || failure.seed != context.seed()
         || failure.gate.passed
@@ -232,11 +232,11 @@ fn validate_failure(
 
 fn validate_semantic_identity(
     candidate_digest: Digest,
-    scenario_digest: Digest,
+    mission_content_digest: Digest,
     context: &RunExecutionContext,
 ) -> Result<(), TuneError> {
     if candidate_digest != context.candidate_digest()
-        || scenario_digest != context.scenario_digest()
+        || mission_content_digest != context.mission_content_digest()
     {
         return Err(invalid_terminal(
             "the semantic result artifact identity does not match its run context",

--- a/tools/flight-tune/src/terminal/tests.rs
+++ b/tools/flight-tune/src/terminal/tests.rs
@@ -3,8 +3,8 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    ArtifactIdentity, AttemptRole, Digest, GateOutcome, HardGateFailure, RunExecutionContext,
-    RunRecord, ScenarioRef, ScenarioSet,
+    ArtifactIdentity, AttemptRole, Digest, GateOutcome, HardGateFailure, MissionReference,
+    RunExecutionContext, RunRecord, ScenarioSet,
 };
 
 use super::{
@@ -28,11 +28,12 @@ pub(super) fn fixed_digest(value: u8) -> Digest {
 }
 
 pub(super) fn run_context() -> RunExecutionContext {
-    let scenario = ScenarioRef {
-        id: "step-calm".to_owned(),
-        digest: fixed_digest(2),
+    let scenario = MissionReference {
+        revision_id: "step-calm".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(2),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     };
     RunExecutionContext::new(
         fixed_digest(1),
@@ -53,12 +54,12 @@ pub(super) fn terminal_intent(case: SemanticCase) -> RunTerminalIntent {
     let outcome = match case {
         SemanticCase::ScenarioComplete => RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             run: run_record(),
         },
         SemanticCase::HardGateAbort => RunTerminalSemanticOutcome::HardGateAbort {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             failure: hard_gate_failure(),
         },
     };
@@ -116,7 +117,7 @@ pub(super) fn terminal_receipt(case: SemanticCase) -> RunTerminalReceipt {
 pub(super) fn run_record() -> RunRecord {
     RunRecord {
         scenario_set: ScenarioSet::Training,
-        scenario_id: "step-calm".to_owned(),
+        mission_revision_id: "step-calm".to_owned(),
         repetition: 0,
         seed: 41,
         loss: 0.2,
@@ -129,7 +130,7 @@ pub(super) fn run_record() -> RunRecord {
 pub(super) fn hard_gate_failure() -> HardGateFailure {
     HardGateFailure {
         scenario_set: ScenarioSet::Training,
-        scenario_id: "step-calm".to_owned(),
+        mission_revision_id: "step-calm".to_owned(),
         repetition: 0,
         seed: 41,
         sample_sequence: 5,

--- a/tools/flight-tune/src/terminal/tests/report.rs
+++ b/tools/flight-tune/src/terminal/tests/report.rs
@@ -257,7 +257,7 @@ fn a_semantic_result_must_match_the_run_context() {
 
 #[test]
 fn semantic_candidate_and_scenario_artifacts_must_match_context() {
-    for field in ["candidate_digest", "scenario_digest"] {
+    for field in ["candidate_digest", "mission_content_digest"] {
         let context = run_context();
         let mut outcome =
             serde_json::to_value(terminal_intent(SemanticCase::ScenarioComplete).outcome())
@@ -392,7 +392,7 @@ fn scenario_intent(run: crate::RunRecord) -> Result<RunTerminalIntent, crate::Tu
     let context = run_context();
     let outcome = RunTerminalSemanticOutcome::ScenarioComplete {
         candidate_digest: context.candidate_digest(),
-        scenario_digest: context.scenario_digest(),
+        mission_content_digest: context.mission_content_digest(),
         run,
     };
     new_intent(&context, outcome)
@@ -404,7 +404,7 @@ fn hard_gate_intent(
     let context = run_context();
     let outcome = RunTerminalSemanticOutcome::HardGateAbort {
         candidate_digest: context.candidate_digest(),
-        scenario_digest: context.scenario_digest(),
+        mission_content_digest: context.mission_content_digest(),
         failure,
     };
     new_intent(&context, outcome)

--- a/tools/flight-tune/src/terminal/tests/tamper.rs
+++ b/tools/flight-tune/src/terminal/tests/tamper.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::{
-    AttemptRole, CandidateTransitionReference, RunExecutionContext, ScenarioRef, ScenarioSet,
+    AttemptRole, CandidateTransitionReference, MissionReference, RunExecutionContext, ScenarioSet,
 };
 
 use super::{
@@ -168,11 +168,12 @@ fn challenger_intent() -> RunTerminalIntent {
         "receipt_digest": fixed_digest(7),
     }))
     .expect("decode transition reference");
-    let scenario = ScenarioRef {
-        id: "step-calm".to_owned(),
-        digest: fixed_digest(2),
+    let scenario = MissionReference {
+        revision_id: "step-calm".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(2),
         max_samples: 100,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     };
     let context = RunExecutionContext::new(
         fixed_digest(1),
@@ -191,7 +192,7 @@ fn challenger_intent() -> RunTerminalIntent {
         context.digest().expect("digest challenger context"),
         crate::terminal::RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             run: super::run_record(),
         },
     )

--- a/tools/flight-tune/tests/tuner.rs
+++ b/tools/flight-tune/tests/tuner.rs
@@ -59,7 +59,7 @@ fn training_cannot_observe_hidden_sets_and_the_campaign_seals_once() {
         .expect("run training");
 
     assert_eq!(views.borrow().len(), 1);
-    assert_eq!(views.borrow()[0].0, vec!["training-calm"]);
+    assert_eq!(views.borrow()[0].0, vec!["training-calm:1"]);
     assert!(views.borrow()[0].1.is_empty());
     assert!(
         state
@@ -67,7 +67,7 @@ fn training_cannot_observe_hidden_sets_and_the_campaign_seals_once() {
             .borrow()
             .scenario_runs
             .iter()
-            .all(|(id, _, _)| id == "training-calm")
+            .all(|(id, _, _)| id == "training-calm:1")
     );
 
     tuner.freeze_candidate().expect("freeze candidate");

--- a/tools/flight-tune/tests/tuner/orphan_baseline.rs
+++ b/tools/flight-tune/tests/tuner/orphan_baseline.rs
@@ -1,15 +1,15 @@
 use std::fs;
 
 use flight_tune::{
-    AttemptRole, Digest, JournalEntry, JournalEvent, SimulatorVehicleFactory, TuneError, Tuner,
-    scenario_runtime_identity,
+    AttemptRole, Digest, JournalEntry, JournalEvent, SearchStage, SimulatorVehicleFactory,
+    TuneError, Tuner, scenario_runtime_identity,
 };
 use serde::Deserialize;
 
 use super::TestTuner;
 use super::test_rig::{
     EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
-    TestDirectory, candidate, stage,
+    TestDirectory, candidate, stage, stage_with_changed_training_mission,
 };
 
 #[test]
@@ -83,6 +83,63 @@ fn changed_runtime_orphans_baseline_and_pending_challenger_before_mutation() {
     assert_eq!(new_tuner.journal().training_attempt_count(), 1);
 }
 
+#[test]
+fn changed_mission_document_orphans_baseline_before_mutation() {
+    let directory = TestDirectory::new("orphan-baseline-old-mission");
+    let state = FakeHandle::new();
+    let mut tuner = open_with_stage(
+        &directory,
+        state.clone(),
+        stage(),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("open old mission session");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run old mission training");
+    drop(tuner);
+
+    let old_head = read_head_entry(&directory);
+    let before = ExternalMutations::capture(&state);
+    let changed = stage_with_changed_training_mission();
+    assert_ne!(
+        changed.training_scenarios[0].content_digest,
+        stage().training_scenarios[0].content_digest
+    );
+
+    let result = open_with_stage(
+        &directory,
+        state.clone(),
+        changed.clone(),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    );
+
+    assert!(matches!(result, Err(TuneError::JournalSessionMismatch)));
+    assert_eq!(ExternalMutations::capture(&state), before);
+    assert_eq!(read_head_entry(&directory), old_head);
+
+    let new_directory = TestDirectory::new("orphan-baseline-new-mission");
+    let runs_before = state.0.borrow().scenario_runs.len();
+    let mut new_tuner = open_with_stage(
+        &new_directory,
+        state.clone(),
+        changed,
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("start changed mission session");
+    new_tuner
+        .run_training_attempts_blocking(1)
+        .expect("run changed mission baseline and challenger");
+    assert!(state.0.borrow().scenario_runs.len() > runs_before);
+    assert_eq!(new_tuner.journal().training_attempt_count(), 1);
+}
+
 fn open_with_factory(
     directory: &TestDirectory,
     state: FakeHandle,
@@ -90,9 +147,20 @@ fn open_with_factory(
     factory: FakeFactory,
     strategy: SequenceStrategy,
 ) -> Result<TestTuner, TuneError> {
+    open_with_stage(directory, state, stage(), backend, factory, strategy)
+}
+
+fn open_with_stage(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    stage: SearchStage,
+    backend: FakeBackend,
+    factory: FakeFactory,
+    strategy: SequenceStrategy,
+) -> Result<TestTuner, TuneError> {
     Tuner::open_or_resume(
         directory.path(),
-        stage(),
+        stage,
         91,
         candidate(0.0),
         backend,

--- a/tools/flight-tune/tests/tuner/promotion_evidence_tamper.rs
+++ b/tools/flight-tune/tests/tuner/promotion_evidence_tamper.rs
@@ -1,8 +1,8 @@
 use flight_tune::{
     ArtifactIdentity, AttemptRole, Digest, FinalQualificationOutcome, JournalEvent,
-    JournalEvidenceSnapshot, PromotionDecision, RunBindingReceipt, RunExecutionContext,
-    RunTerminalClass, RunTerminalIntent, RunTerminalReceipt, RunTerminalReport,
-    RunTerminalSemanticOutcome, ScenarioRef, ScenarioSet,
+    JournalEvidenceSnapshot, MissionReference, PromotionDecision, RunBindingReceipt,
+    RunExecutionContext, RunTerminalClass, RunTerminalIntent, RunTerminalReceipt,
+    RunTerminalReport, RunTerminalSemanticOutcome, ScenarioSet,
 };
 use sha2::{Digest as ShaDigest, Sha256};
 
@@ -245,15 +245,16 @@ fn refresh_head(snapshot: &mut JournalEvidenceSnapshot) {
 fn receipt_with_scenario_digest(
     snapshot: &JournalEvidenceSnapshot,
     receipt: &RunTerminalReceipt,
-    scenario_digest: Digest,
+    mission_content_digest: Digest,
 ) -> RunTerminalReceipt {
     let proof = &snapshot.promotion_baseline;
     let original = receipt.context();
-    let scenario = ScenarioRef {
-        id: original.scenario_id().to_owned(),
-        digest: scenario_digest,
+    let scenario = MissionReference {
+        revision_id: original.mission_revision_id().to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: mission_content_digest,
         max_samples: snapshot.stage.promotion_scenarios[0].max_samples,
-        sample_timeout_ms: snapshot.stage.promotion_scenarios[0].sample_timeout_ms,
+        sample_timeout_ns: snapshot.stage.promotion_scenarios[0].sample_timeout_ns,
     };
     let context = RunExecutionContext::new(
         snapshot
@@ -278,7 +279,7 @@ fn receipt_with_scenario_digest(
     };
     let outcome = RunTerminalSemanticOutcome::ScenarioComplete {
         candidate_digest: proof.candidate_digest,
-        scenario_digest,
+        mission_content_digest,
         run: run.clone(),
     };
     rebuild_receipt(receipt, &context, outcome)

--- a/tools/flight-tune/tests/tuner/promotion_snapshot_authority.rs
+++ b/tools/flight-tune/tests/tuner/promotion_snapshot_authority.rs
@@ -144,7 +144,7 @@ pub(super) fn assert_promotion_uses_paired_seeds(state: &FakeHandle) {
         .borrow()
         .scenario_runs
         .iter()
-        .filter(|(id, _, _)| id == "promotion-gust")
+        .filter(|(id, _, _)| id == "promotion-gust:1")
         .cloned()
         .collect::<Vec<_>>();
     assert_eq!(promotion.len(), 4);

--- a/tools/flight-tune/tests/tuner/scenario_admission.rs
+++ b/tools/flight-tune/tests/tuner/scenario_admission.rs
@@ -5,8 +5,21 @@ use super::open;
 use super::test_rig::{FakeHandle, SequenceStrategy};
 
 #[test]
-fn changed_scenario_content_fails_before_run_mutation() {
-    let directory = TestDirectory::new("changed-scenario-content");
+fn changed_mission_content_fails_before_run_mutation() {
+    assert_admission_refusal("changed-mission-content", |state| {
+        state.0.borrow_mut().bad_mission_content = true;
+    });
+}
+
+#[test]
+fn a_foreign_mission_revision_fails_before_run_mutation() {
+    assert_admission_refusal("foreign-mission-revision", |state| {
+        state.0.borrow_mut().bad_mission_revision = true;
+    });
+}
+
+fn assert_admission_refusal(label: &str, tamper: impl FnOnce(&FakeHandle)) {
+    let directory = TestDirectory::new(label);
     let state = FakeHandle::new();
     let mut tuner = open(
         directory.path(),
@@ -15,7 +28,7 @@ fn changed_scenario_content_fails_before_run_mutation() {
         2.0,
     )
     .expect("open tuner");
-    state.0.borrow_mut().bad_scenario_document = true;
+    tamper(&state);
 
     let result = tuner.run_training_attempts_blocking(0);
 

--- a/tools/flight-tune/tests/tuner/terminal/downstream.rs
+++ b/tools/flight-tune/tests/tuner/terminal/downstream.rs
@@ -2,9 +2,9 @@ use std::fs;
 
 use flight_tune::{
     ArtifactIdentity, AttemptRole, CampaignPhase, EvaluatorError, FinalQualificationOutcome,
-    GateEvaluator, GateOutcome, JournalEntry, JournalEvent, PromotionDecision,
+    GateEvaluator, GateOutcome, JournalEntry, JournalEvent, MissionReference, PromotionDecision,
     RunTerminalDisposition, RunTerminalOperation, RunTerminalQuarantine, RunTerminalReceipt,
-    ScenarioRef, TelemetrySample, TuneError, Tuner,
+    TelemetrySample, TuneError, Tuner,
 };
 
 use crate::open_stage;
@@ -210,8 +210,8 @@ impl GateEvaluator for PromotionGate {
         &self.identity
     }
 
-    fn begin(&mut self, scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
-        self.fail_current = scenario.id.starts_with("promotion-");
+    fn begin(&mut self, scenario: &MissionReference) -> Result<(), EvaluatorError> {
+        self.fail_current = scenario.revision_id.starts_with("promotion-");
         let mut state = self.state.0.borrow_mut();
         state.gate_begin_count = state.gate_begin_count.wrapping_add(1);
         Ok(())

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -3,7 +3,57 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use flight_tune::{ArtifactIdentity, RunExecutionContext, ScenarioRef};
+use flight_tune::{
+    ArtifactIdentity, Digest, MissionDocument, MissionReference, RunExecutionContext,
+    calibration_mission_document, reference_observation_scenario,
+};
+
+/// The sample ceiling every fake mission runs under.
+pub const FAKE_MAX_SAMPLES: u32 = 8;
+
+const FAKE_RECEIPT_TIMEOUT_NS: u64 = 100_000_000;
+
+/// The retry limit that separates the two stored variants of one trial.
+///
+/// The variants differ in mission content but not in run behaviour, so a
+/// changed document is an identity change and nothing else.
+const CHANGED_RETRY_LIMIT: u16 = 1;
+
+/// The trial names that the fake backend stores as mission documents.
+pub const FAKE_MISSION_IDS: [&str; 3] = ["training-calm", "promotion-gust", "final-crosswind"];
+
+/// Resolves the stored fake mission that one reference names.
+///
+/// The store is keyed by mission content, so a changed document is a
+/// different stored artifact rather than a replacement of the first.
+pub fn fake_stored_mission(mission: &MissionReference) -> Option<MissionDocument> {
+    FAKE_MISSION_IDS
+        .into_iter()
+        .flat_map(|id| [fake_mission_document(id), changed_fake_mission_document(id)])
+        .find(|document| {
+            Digest::from_bytes(*document.identity.content_digest.as_bytes())
+                == mission.content_digest
+        })
+}
+
+/// Builds the stored mission document that one fake trial name produces.
+pub fn fake_mission_document(id: &str) -> MissionDocument {
+    fake_mission_document_with_retry(id, 0)
+}
+
+/// Builds the second stored mission document for one fake trial name.
+pub fn changed_fake_mission_document(id: &str) -> MissionDocument {
+    fake_mission_document_with_retry(id, CHANGED_RETRY_LIMIT)
+}
+
+fn fake_mission_document_with_retry(id: &str, retry_limit: u16) -> MissionDocument {
+    calibration_mission_document(
+        &reference_observation_scenario(id, None),
+        retry_limit,
+        FAKE_RECEIPT_TIMEOUT_NS,
+    )
+    .expect("fake mission document")
+}
 
 #[path = "test_rig/backend.rs"]
 mod backend;
@@ -27,7 +77,7 @@ pub use cleanup_fault::FakeCleanupFault;
 #[allow(unused_imports)]
 pub use scoring::{
     EnvelopeGates, ObservedViews, QuadraticMetric, SequenceStrategy, assert_receipt_error,
-    candidate, stage,
+    candidate, stage, stage_with_changed_training_mission,
 };
 #[allow(unused_imports)]
 pub use terminal_head_poison::TerminalExternalAction;
@@ -62,7 +112,7 @@ pub struct FakeState {
     pub scenario_runs: Vec<(String, u64, f64)>,
     pub transition: FakeTransitionState,
     pub lifecycle: Vec<String>,
-    pub current_scenario: Option<ScenarioRef>,
+    pub current_scenario: Option<MissionReference>,
     pub current_seed: u64,
     pub next_sequence: u64,
     pub panic_on_prepare: Option<usize>,
@@ -73,7 +123,8 @@ pub struct FakeState {
     pub change_head_on_action_prepare: Option<PathBuf>,
     pub change_head_on_sample: Option<PathBuf>,
     pub bad_scenario_readback: bool,
-    pub bad_scenario_document: bool,
+    pub bad_mission_content: bool,
+    pub bad_mission_revision: bool,
     pub timeout_next_sample: bool,
     pub complete_without_sample: bool,
 }

--- a/tools/flight-tune/tests/tuner/test_rig/backend.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/backend.rs
@@ -4,11 +4,10 @@ use std::time::Duration;
 
 use flight_tune::{
     AdapterError, ArtifactIdentity, CampaignBackend, Digest, KinematicTruth, MissionCapability,
-    MissionDirective, MissionDocument, ReceiptResult, RunExecutionContext, RunPreparationReceipt,
-    SampleEvent, ScenarioFrame, ScenarioObservationReceipt, ScenarioRef, ScenarioRuntime,
+    MissionDirective, MissionDocument, MissionReference, ReceiptResult, RunExecutionContext,
+    RunPreparationReceipt, SampleEvent, ScenarioFrame, ScenarioObservationReceipt, ScenarioRuntime,
     ScenarioRuntimeError, ScenarioStartReceipt, ScenarioStopContext, SessionChallenge,
-    SimulatorCapability, SimulatorSessionReceipt, TelemetrySample, TrialScenario,
-    reference_observation_scenario, scenario_runtime_identity,
+    SimulatorCapability, SimulatorSessionReceipt, TelemetrySample, scenario_runtime_identity,
 };
 use serde::Deserialize;
 
@@ -81,13 +80,22 @@ impl CampaignBackend for FakeBackend {
         }
     }
 
-    fn scenario_document_blocking(
+    fn mission_document_blocking(
         &self,
-        scenario: &ScenarioRef,
-    ) -> Result<TrialScenario, AdapterError> {
-        let mut document = reference_observation_scenario(scenario, None);
-        if self.state.0.borrow().bad_scenario_document {
-            document.revision = document.revision.wrapping_add(1);
+        mission: &MissionReference,
+    ) -> Result<MissionDocument, AdapterError> {
+        let (bad_content, bad_revision) = {
+            let state = self.state.0.borrow();
+            (state.bad_mission_content, state.bad_mission_revision)
+        };
+        if bad_revision {
+            return Ok(super::fake_mission_document(super::FAKE_MISSION_IDS[2]));
+        }
+        let mut document = super::fake_stored_mission(mission)
+            .ok_or_else(|| AdapterError::new("the fake backend stores no such mission"))?;
+        if bad_content {
+            document.execution_policy.retry_limit =
+                document.execution_policy.retry_limit.wrapping_add(1);
         }
         Ok(document)
     }
@@ -118,7 +126,7 @@ impl CampaignBackend for FakeBackend {
         &mut self,
         capability: &SimulatorCapability,
         context: &RunExecutionContext,
-        scenario: &ScenarioRef,
+        scenario: &MissionReference,
     ) -> Result<RunPreparationReceipt, AdapterError> {
         let run_intent_digest = context
             .digest()
@@ -175,11 +183,13 @@ impl CampaignBackend for FakeBackend {
             .ok_or_else(|| AdapterError::new("scenario was not prepared"))?;
         let seed = state.current_seed;
         let gain = state.vehicle.gain;
-        state.scenario_runs.push((scenario.id.clone(), seed, gain));
-        let applied_scenario_digest = if state.bad_scenario_readback {
+        state
+            .scenario_runs
+            .push((scenario.revision_id.clone(), seed, gain));
+        let applied_mission_content_digest = if state.bad_scenario_readback {
             Digest::from_bytes([98; 32])
         } else {
-            scenario.digest
+            scenario.content_digest
         };
         let receipt_intent = if state.transition.bad_start_intent {
             Digest::from_bytes([96; 32])
@@ -188,7 +198,7 @@ impl CampaignBackend for FakeBackend {
         };
         Ok(ScenarioStartReceipt {
             session_digest: capability.session_digest(),
-            applied_scenario_digest,
+            applied_mission_content_digest,
             seed,
             run_intent_digest: receipt_intent,
         })

--- a/tools/flight-tune/tests/tuner/test_rig/scoring.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/scoring.rs
@@ -4,12 +4,12 @@ use std::rc::Rc;
 
 use flight_tune::{
     ArtifactIdentity, Candidate, CandidateLineage, Digest, EvaluatorError, GateEvaluator,
-    GateOutcome, MetricEvaluator, MetricValues, ParameterBounds, PromotionPolicy, Proposal,
-    ProposalContext, ProposalError, ProposalStrategy, QualificationPolicy, ScenarioRef,
-    SearchStage, TelemetrySample, TrainingObservation, TuneError, reference_observation_scenario,
+    GateOutcome, MetricEvaluator, MetricValues, MissionReference, ParameterBounds, PromotionPolicy,
+    Proposal, ProposalContext, ProposalError, ProposalStrategy, QualificationPolicy, SearchStage,
+    TelemetrySample, TrainingObservation, TuneError,
 };
 
-use super::{FakeHandle, FakeState, identity};
+use super::{FAKE_MAX_SAMPLES, FakeHandle, FakeState, identity};
 
 pub struct EnvelopeGates {
     identity: ArtifactIdentity,
@@ -47,7 +47,7 @@ impl GateEvaluator for EnvelopeGates {
         &self.identity
     }
 
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, _scenario: &MissionReference) -> Result<(), EvaluatorError> {
         self.record(|state| {
             state.gate_begin_count = state.gate_begin_count.wrapping_add(1);
         });
@@ -109,7 +109,7 @@ impl MetricEvaluator for QuadraticMetric {
         &self.identity
     }
 
-    fn begin(&mut self, _scenario: &ScenarioRef) -> Result<(), EvaluatorError> {
+    fn begin(&mut self, _scenario: &MissionReference) -> Result<(), EvaluatorError> {
         let mut state = self.state.0.borrow_mut();
         state.metric_begin_count = state.metric_begin_count.wrapping_add(1);
         drop(state);
@@ -179,7 +179,7 @@ impl ProposalStrategy for SequenceStrategy {
                 .training
                 .scenarios
                 .iter()
-                .map(|scenario| scenario.id.clone())
+                .map(|scenario| scenario.revision_id.clone())
                 .collect(),
             context.training.history.to_vec(),
         ));
@@ -226,9 +226,9 @@ pub fn stage() -> SearchStage {
         )]),
         fixed_parameters: BTreeMap::from([("mode".to_owned(), 1.0)]),
         required_hard_gates: vec!["envelope".to_owned()],
-        training_scenarios: vec![scenario("training-calm", 1)],
-        promotion_scenarios: vec![scenario("promotion-gust", 2)],
-        final_qualification_scenarios: vec![scenario("final-crosswind", 3)],
+        training_scenarios: vec![scenario(super::FAKE_MISSION_IDS[0])],
+        promotion_scenarios: vec![scenario(super::FAKE_MISSION_IDS[1])],
+        final_qualification_scenarios: vec![scenario(super::FAKE_MISSION_IDS[2])],
         repetitions: 2,
         promotion: PromotionPolicy {
             schema_version: flight_tune::PROMOTION_POLICY_SCHEMA_VERSION,
@@ -247,17 +247,22 @@ pub fn stage() -> SearchStage {
     }
 }
 
-fn scenario(id: &str, digest_byte: u8) -> ScenarioRef {
-    let mut reference = ScenarioRef {
-        id: id.to_owned(),
-        digest: Digest::from_bytes([digest_byte; 32]),
-        max_samples: 8,
-        sample_timeout_ms: 100,
-    };
-    reference.digest = reference_observation_scenario(&reference, None)
-        .canonical_digest()
-        .expect("reference scenario digest");
-    reference
+fn scenario(id: &str) -> MissionReference {
+    MissionReference::from_document(&super::fake_mission_document(id), FAKE_MAX_SAMPLES)
+        .expect("mission reference")
+}
+
+/// The same stage with one changed training mission document.
+pub fn stage_with_changed_training_mission() -> SearchStage {
+    let changed = MissionReference::from_document(
+        &super::changed_fake_mission_document(super::FAKE_MISSION_IDS[0]),
+        FAKE_MAX_SAMPLES,
+    )
+    .expect("changed mission reference");
+    SearchStage {
+        training_scenarios: vec![changed],
+        ..stage()
+    }
 }
 
 pub fn assert_receipt_error(error: TuneError) {

--- a/tools/flight-tune/tests/tuner/test_rig/terminal/tests.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/terminal/tests.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
 use flight_tune::{
-    ArtifactIdentity, AttemptRole, Digest, RunBindingReceipt, RunExecutionContext, RunRecord,
-    RunTerminalClass, RunTerminalOperation, RunTerminalOperationOutcome, RunTerminalPlan,
-    RunTerminalReceipt, RunTerminalRecoveryState, RunTerminalReport, RunTerminalScope,
-    RunTerminalSemanticOutcome, ScenarioRef, ScenarioSet,
+    ArtifactIdentity, AttemptRole, Digest, MissionReference, RunBindingReceipt,
+    RunExecutionContext, RunRecord, RunTerminalClass, RunTerminalOperation,
+    RunTerminalOperationOutcome, RunTerminalPlan, RunTerminalReceipt, RunTerminalRecoveryState,
+    RunTerminalReport, RunTerminalScope, RunTerminalSemanticOutcome, ScenarioSet,
 };
 
 use super::super::terminal_state::{
@@ -181,11 +181,12 @@ fn run_binding(
 }
 
 fn run_context(session_digest: Digest) -> RunExecutionContext {
-    let scenario = ScenarioRef {
-        id: "terminal-reference".to_owned(),
-        digest: fixed_digest(3),
+    let scenario = MissionReference {
+        revision_id: "terminal-reference".to_owned(),
+        schema_version: flight_tune::MISSION_SCHEMA_VERSION,
+        content_digest: fixed_digest(3),
         max_samples: 10,
-        sample_timeout_ms: 20,
+        sample_timeout_ns: 20_000_000,
     };
     RunExecutionContext::new(
         session_digest,
@@ -214,7 +215,7 @@ fn completed_receipt(binding: &RunBindingReceipt, plan: &RunTerminalPlan) -> Run
     let context = binding.context();
     let run = RunRecord {
         scenario_set: context.scenario_set(),
-        scenario_id: context.scenario_id().to_owned(),
+        mission_revision_id: context.mission_revision_id().to_owned(),
         repetition: context.repetition(),
         seed: context.seed(),
         loss: 0.2,
@@ -227,7 +228,7 @@ fn completed_receipt(binding: &RunBindingReceipt, plan: &RunTerminalPlan) -> Run
         plan,
         RunTerminalSemanticOutcome::ScenarioComplete {
             candidate_digest: context.candidate_digest(),
-            scenario_digest: context.scenario_digest(),
+            mission_content_digest: context.mission_content_digest(),
             run,
         },
         RunTerminalRecoveryState::Live,


### PR DESCRIPTION
## Summary

The campaign schedule named a derived adapter artifact. `ScenarioRef { id, digest, max_samples, sample_timeout_ms }` carried the digest of a trial scenario and two run limits that no digest covered, and the mission document that the runtime executed was rebuilt from that artifact on every run. The journal therefore bound the input to a projection rather than the executed document.

The canonical mission document is now the stored, identified scenario artifact.

- **`MissionReference` replaces `ScenarioRef`** (`tools/flight-tune/src/model/reference.rs`): `revision_id`, `schema_version`, `content_digest`, plus the run limits `max_samples` and `sample_timeout_ns`. `MissionReference::from_document` is the only constructor a producer needs; it reads the identity from the document and takes the sample timeout from `execution_policy.receipt_timeout_ns`, so no limit can enter the schedule through a channel the mission content digest does not cover.
- **The build step converts once.** A backend projects an authored `pilotage_trial::Scenario` into a `MissionDocument` at authoring time (`calibration_mission_document`) and stores it. `bench_scenario` in `flight-tune-campaign` now derives its reference from that stored document instead of digesting the trial scenario and patching the digest back in.
- **`CampaignBackend::scenario_document_blocking` becomes `mission_document_blocking`** and returns the stored `MissionDocument`. Admission calls `MissionReference::verify_document`, which recalculates the content digest and refuses a document whose revision, schema version, content, or receipt timeout differs from the reference. A backend cannot present a document whose declared identity differs from its own bytes.
- **The journal is rebound.** `RunExecutionContext`, `PromotionRunKey`, `RunRecord`, `HardGateFailure`, `RunTerminalSemanticOutcome`, and `ScenarioStartReceipt` now name `mission_revision_id` and `mission_content_digest`. The run execution context moves to schema 2 with domain `flight-tune:run-execution-context:v2`, and the independent verifier in `pilotage-tuning-feedback` mirrors both.
- `pilotage_trial::Scenario` is unchanged (that is #465).

## Identity reset

This is an intentional identity reset, and the #498 orphan-baseline rule applies again. The `SearchStage` shape, the run-context shape, and the scenario-runtime source identity all change, so every prior bench seal is orphan evidence.

`changed_mission_document_orphans_baseline_before_mutation` in `tools/flight-tune/tests/tuner/orphan_baseline.rs` proves both halves: a session opened against a changed mission document is refused with `JournalSessionMismatch` before any external action, with the journal head and every external counter unchanged; and a fresh session under the new identity runs its baseline and challenger through.

`tools/flight-tune/src/model/reference/tests.rs` adds the reference-level arms: a changed document changes the reference identity, and `verify_document` refuses a changed revision, a changed schema version, changed content, a declared digest the content does not produce, and a sample timeout the document does not carry. `tools/flight-tune/tests/tuner/scenario_admission.rs` covers the last two at campaign level.

## Deviations from the issue text

- **Task 3, "update the `scenario_runtime` document bridge to take the new mission reference".** The authoring order inverted instead: `reference_observation_scenario` now takes `id: &str` rather than a reference, because the reference is derived from the document, not the other way round. Keeping the old direction would have needed a reference with a placeholder digest that is patched after projection, which is the circularity this issue removes. The bridge that the campaign calls (`mission_document_blocking`) does take the new reference.
- **`RunExecutionContext` schema 1 to 2**, with a matching digest-domain bump. The serialized field names change, so an unbumped version would let two different shapes claim one schema. Both the constant and the domain are mirrored byte-for-byte in `pilotage-tuning-feedback`, which recomputes intent digests independently.
- **The pinned canonical source digest in `crates/pilotage-tuning-feedback/src/qualification/tests.rs` moved** from `fd8f60cc…` to `ee78d67d…`. That pin is a fixture of the evidence shape; the shape changed, so the pin changed with it.
- **`PromotionSeedPolicy::PairedScenarioDigestV1` is kept.** The seed input is now the mission content digest, but the pairing algorithm and its fixed seed vectors are unchanged, so a policy-schema bump would reset identity for no behavioural difference.
- `ScenarioSet` and the `training_scenarios` / `promotion_scenarios` / `final_qualification_scenarios` field names are kept. They name the campaign's isolation partitions, which this issue does not own.

## Verification

Every gate below was run locally on the pushed commit.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, no warnings |
| `cargo test --workspace --all-targets` | pass, 77 suites green, 0 failures |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `bash scripts/check-structure.sh` | `check-structure: OK` |
| `python3 scripts/check-flight-tune-contracts.py .` | pass |
| `bash scripts/check-flight-tune-boundaries.sh` | `check-flight-tune-boundaries: OK` |
| `python3 scripts/check-feedback-verifier-boundary.py .` | pass |
| `bash scripts/check-monotonic-counter-arithmetic.sh` | `monotonic counter arithmetic: OK` |
| `cargo run -p xtask -- guards` | `guards: 19 pairs ok` |
| `cargo check -p pilotage-durable-storage --tests --target wasm32-unknown-unknown` | pass |
| `cargo check -p flight-tune --target wasm32-unknown-unknown` | pass |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | **pass, 3 passed in 635s** |

The closing proof is the last row: `a_campaign_runs_end_to_end_for_the_alia250` and `a_campaign_runs_end_to_end_for_the_x500` both seal `FinalQualificationOutcome::Qualified` under the new identity, and both publish evidence that the independent verifier reads back.

One note on the workspace test run: a first pass reported `pilotage_xplane_trial::tests::a_changed_aircraft_file_is_rejected_before_configuration` as failed while a second heavy build was running on the same machine. That test binds a loopback socket with a two-second accept deadline and is untouched by this branch. It passes on its own and in the clean full run recorded above.

`rg "ScenarioRef"` returns no hits anywhere in the tree.

Fixes #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
