### PR TITLE
Refuse a mission route that carries an unexecuted procedure

### DIFF
--- a/crates/pilotage-mission/src/engine.rs
+++ b/crates/pilotage-mission/src/engine.rs
@@ -10,7 +10,7 @@ mod tick;
 use core::mem::Discriminant;
 
 use aerocontext_core::NavDataSnapshot;
-use aerocontext_planning::route::expand_str;
+use aerocontext_planning::route::{RouteToken, expand_str};
 use navigate_contract::{
     AltitudeConstraint, FlightPlan, GeodeticPosition, MonotonicNanos, NavigationSolution,
     ObservationStamp, PlanRole, SensorClass, SourceComposition, SourceEpoch, SourceId,
@@ -83,8 +83,9 @@ impl MissionEngine {
     /// # Errors
     ///
     /// Any [`MissionBuildError`]: expansion failure (with cycle
-    /// context), an empty expansion, an implausible anchor, or a plan
-    /// the sequencer refuses to activate.
+    /// context), a route carrying an unexecuted SID/STAR procedure, an
+    /// empty expansion, an implausible anchor, or a plan the sequencer
+    /// refuses to activate.
     pub fn new(
         snapshot: &NavDataSnapshot,
         provenance: SnapshotProvenance,
@@ -97,6 +98,16 @@ impl MissionEngine {
                 source,
             }
         })?;
+        if !expanded.procedures.is_empty() {
+            return Err(MissionBuildError::UnexecutedProcedure {
+                route: config.route.clone(),
+                procedures: expanded
+                    .procedures
+                    .iter()
+                    .map(procedure_token_name)
+                    .collect(),
+            });
+        }
         if expanded.points.is_empty() {
             return Err(MissionBuildError::EmptyRoute {
                 route: config.route.clone(),
@@ -256,6 +267,18 @@ impl MissionEngine {
     #[must_use]
     pub const fn mission_document(&self) -> &MissionDocument {
         &self.document
+    }
+}
+
+/// Names a recognized-but-unresolved procedure token for the operator,
+/// e.g. `"TRUKN2"` or `"BLUES2.IIU"`.
+fn procedure_token_name(token: &RouteToken) -> String {
+    match token {
+        RouteToken::Procedure { name, transition } => match transition {
+            Some(transition) => format!("{name}.{transition}"),
+            None => name.clone(),
+        },
+        other => format!("{other:?}"),
     }
 }
 

--- a/crates/pilotage-mission/src/error.rs
+++ b/crates/pilotage-mission/src/error.rs
@@ -32,11 +32,23 @@ pub enum MissionBuildError {
         #[source]
         source: RouteError,
     },
-    /// The route expanded to no geometry (e.g. procedure-only tokens).
+    /// The route expanded to no geometry (e.g. a `DCT`-only route).
     #[error("route {route:?} expanded to no points")]
     EmptyRoute {
         /// The route string as given.
         route: String,
+    },
+    /// The route carries a SID/STAR procedure token. The expander
+    /// recognizes such a token but contributes no geometry for it (no
+    /// procedure engine), so flying the built mission would silently
+    /// omit the procedure.
+    #[error("route {route:?} carries unexecuted procedure(s): {procedures:?}")]
+    UnexecutedProcedure {
+        /// The route string as given.
+        route: String,
+        /// Each procedure token the expansion recognized but could not
+        /// resolve to geometry, e.g. `"TRUKN2"` or `"BLUES2.IIU"`.
+        procedures: Vec<String>,
     },
     /// The mission anchor cannot anchor a local tangent plane.
     #[error("mission anchor rejected by geodesy")]

--- a/crates/pilotage-mission/tests/mission_build_refusal.rs
+++ b/crates/pilotage-mission/tests/mission_build_refusal.rs
@@ -1,0 +1,51 @@
+//! Mission-build refusals: a route string that cannot become a mission
+//! must fail typed, naming what is wrong, rather than build a mission
+//! that silently omits part of the route.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use navigate_contract::{ClockDomainId, GeodeticPosition};
+use pilotage_mission::fixture::{self, GeoPointDegrees};
+use pilotage_mission::{MissionBuildError, MissionConfig, MissionEngine, decode_snapshot};
+
+/// The anchor every scenario flies from, matching the closed-loop tests
+/// in `mission_engine.rs` so both suites read the same geometry.
+const ANCHOR: GeoPointDegrees = GeoPointDegrees {
+    lat_deg: 47.0,
+    lon_deg: 8.0,
+    alt_m: 500.0,
+};
+
+#[test]
+fn mission_build_refuses_a_route_with_an_unexecuted_procedure() {
+    let blob = fixture::demo_blob(ANCHOR).expect("demo blob encodes");
+    let (snapshot, provenance) = decode_snapshot(&blob, true).expect("demo blob decodes");
+    let anchor = GeodeticPosition::new(
+        ANCHOR.lat_deg.to_radians(),
+        ANCHOR.lon_deg.to_radians(),
+        ANCHOR.alt_m,
+    );
+    // BLUES2.IIU is dot-notation, recognized as a procedure token
+    // wherever it appears. TRUKN2 is not in the demo snapshot; as an
+    // edge token ending in a digit, the expander reclassifies it as a
+    // SID/STAR computer code rather than failing the expansion.
+    let route = format!("{} BLUES2.IIU TRUKN2", fixture::DEMO_ROUTE);
+    let config = MissionConfig::new(route.clone(), anchor, ClockDomainId::new(7));
+
+    let error = MissionEngine::new(&snapshot, provenance, config)
+        .expect_err("a route carrying an unexecuted procedure must be refused");
+
+    match error {
+        MissionBuildError::UnexecutedProcedure {
+            route: got_route,
+            procedures,
+        } => {
+            assert_eq!(got_route, route);
+            assert_eq!(
+                procedures,
+                vec!["BLUES2.IIU".to_owned(), "TRUKN2".to_owned()]
+            );
+        }
+        other => panic!("expected UnexecutedProcedure, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## World found: (a) — the defect is real

The pinned expander source confirms the review's claim. In
`~/.cargo/registry/src/*/aerocontext-planning-0.4.5/src/route/expand.rs`,
the `expand` function handles a procedure token by parking it, not by
failing:

```rust
RouteToken::Procedure { .. } => route.procedures.push(current.clone()),
```

An edge token that fails ident resolution and ends in a digit is also
reclassified as a procedure rather than surfacing `UnresolvedIdent`
(same file, `resolve_ident` error arm). Both paths return `Ok(route)`.
The crate's own `route.rs` module doc confirms the intent: SID/STAR
tokens "are recognized and reported but contribute no geometry (no
procedure engine)."

`crates/pilotage-mission/src/engine.rs` (`MissionEngine::new`, the sole
mission-construction entry point) called `expand_str` and checked only
`expanded.points.is_empty()` — never `expanded.procedures`. So a route
carrying a procedure token, alongside resolvable points, built a
mission that silently dropped the procedure: fail-open.

## Fix

- `crates/pilotage-mission/src/error.rs`: added
  `MissionBuildError::UnexecutedProcedure { route, procedures }`,
  naming every unresolved procedure token.
- `crates/pilotage-mission/src/engine.rs`: `MissionEngine::new` now
  refuses construction when `expanded.procedures` is non-empty, before
  the existing `EmptyRoute` check. Added `procedure_token_name` to
  format both the bare (`"TRUKN2"`) and dot-transition
  (`"BLUES2.IIU"`) forms for the error.
- `crates/pilotage-mission/tests/mission_build_refusal.rs` (new
  standalone integration test, keeping `mission_engine.rs` under the
  500-line file cap): builds a route with both a dot-notation procedure
  token mid-route and an edge-digit-reclassified token, and asserts the
  typed refusal names both.

## Fail-before proof

Stashed only the `engine.rs` check (keeping the new error variant) and
re-ran the test against the old fail-open path. It failed with the
mission having built successfully, silently dropping both procedures:

```
thread '...' panicked ...: a route carrying an unexecuted procedure must be refused: (MissionEngine { ...
route_input: "DEMOA V901 DEMOC BLUES2.IIU TRUKN2",
expanded_idents: ["DEMOA", "DEMOB", "DEMOC"], waypoint_count: 3, ... })
```

Restoring `engine.rs` turns the test green:

```
test mission_build_refuses_a_route_with_an_unexecuted_procedure ... ok
```

## Gates (all pass at the final commit)

- `cargo fmt --all -- --check` — OK
- `cargo clippy --workspace --all-targets -- -D warnings` — OK
- `cargo test -p pilotage-mission --all-targets` — OK (all suites, including the new test)
- `cargo test --workspace --all-targets` — OK (78/78 test binaries, 0 failed)
- `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` — OK
- `cargo build --release` — OK
- `bash scripts/check-structure.sh` — OK

Fixes #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S