### PR TITLE
Identify every trial stimulus by physical control family

### DIFF
--- a/crates/pilotage-mission-core/src/action.rs
+++ b/crates/pilotage-mission-core/src/action.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ArtifactIdentity, ControlChannel};
 use crate::{
-    FlightPlanReference, MissionCapability, ValidationError,
+    ControlFamily, FlightPlanReference, MissionCapability, StimulusEnvelope, StimulusMapping,
+    ValidationError,
     trial::{StartState, Waveform},
 };
 
@@ -50,7 +51,7 @@ pub enum FlightAction {
         plan: FlightPlanReference,
     },
     /// Hold the current flight target.
-    Hold {},
+    MaintainTarget {},
     /// Land the vehicle.
     Land {},
     /// Disarm the vehicle.
@@ -79,8 +80,14 @@ pub enum TrialAction {
     Settle {},
     /// Apply one control stimulus.
     Stimulate {
+        /// The physical control family that the stimulus commands.
+        family: ControlFamily,
         /// The control channel.
         channel: ControlChannel,
+        /// The rule that resolves a normalized value to a physical command.
+        mapping: StimulusMapping,
+        /// The versioned physical envelope of the normalized range.
+        envelope: StimulusEnvelope,
         /// The stimulus waveform.
         waveform: Waveform,
     },
@@ -150,7 +157,7 @@ impl FlightAction {
     const fn required_capability(&self) -> Option<MissionCapability> {
         match self {
             Self::Arm {} | Self::Disarm {} => Some(MissionCapability::ArmDisarm),
-            Self::Climb { .. } | Self::Hold {} | Self::Land {} => {
+            Self::Climb { .. } | Self::MaintainTarget {} | Self::Land {} => {
                 Some(MissionCapability::FlightControl)
             }
             Self::FollowPlan { .. } => Some(MissionCapability::FlightPlan),
@@ -162,7 +169,7 @@ impl FlightAction {
             Self::Arm {} => "flight.arm",
             Self::Climb { .. } => "flight.climb",
             Self::FollowPlan { .. } => "flight.follow_plan",
-            Self::Hold {} => "flight.hold",
+            Self::MaintainTarget {} => "flight.maintain_target",
             Self::Land {} => "flight.land",
             Self::Disarm {} => "flight.disarm",
         }
@@ -176,7 +183,20 @@ impl TrialAction {
                 condition_set.validate(&format!("{field}.action.condition_set"))
             }
             Self::ReachStartState { target } => target.validate(field),
-            Self::Stimulate { waveform, .. } => {
+            Self::Stimulate {
+                family,
+                channel,
+                mapping,
+                envelope,
+                waveform,
+            } => {
+                crate::trial::validate_stimulus(
+                    &format!("{field}.action"),
+                    *family,
+                    *channel,
+                    *mapping,
+                    envelope,
+                )?;
                 waveform.validate(&format!("{field}.action.waveform"))
             }
             _ => Ok(()),
@@ -189,9 +209,8 @@ impl TrialAction {
             Self::WaitReady {} => Some(MissionCapability::LifecycleState),
             Self::ApplyConditions { .. } => Some(MissionCapability::ConditionControl),
             Self::ReachStartState { .. } => Some(MissionCapability::KinematicTruth),
-            Self::Stimulate { .. } | Self::ReleaseControl {} | Self::Stop {} => {
-                Some(MissionCapability::SimulatorControl)
-            }
+            Self::Stimulate { family, .. } => Some(family.capability()),
+            Self::ReleaseControl {} | Self::Stop {} => Some(MissionCapability::SimulatorControl),
             Self::Disarm {} => Some(MissionCapability::ArmDisarm),
             Self::Settle {} | Self::Observe {} | Self::CollectResults {} => None,
         }

--- a/crates/pilotage-mission-core/src/document.rs
+++ b/crates/pilotage-mission-core/src/document.rs
@@ -62,6 +62,10 @@ pub enum MissionCapability {
     NavigationState,
     /// Apply simulator-only trial control.
     SimulatorControl,
+    /// Command the operator velocity control family.
+    OperatorVelocityControl,
+    /// Command the direct attitude and thrust control family.
+    DirectAttitudeThrustControl,
 }
 
 /// One bounded phase in a mission document.

--- a/crates/pilotage-mission-core/src/engine/tests/cleanup.rs
+++ b/crates/pilotage-mission-core/src/engine/tests/cleanup.rs
@@ -15,7 +15,7 @@ fn abort_cleanup_reverses_phases_attempts_all_steps_and_aggregates_failures() {
         .push(crate::MissionCapability::FlightControl);
     let mut second = phase("second");
     second.cleanup_actions = vec![
-        MissionAction::Flight(FlightAction::Hold {}),
+        MissionAction::Flight(FlightAction::MaintainTarget {}),
         MissionAction::Flight(FlightAction::Disarm {}),
     ];
     second.abort_conditions = vec![crash_condition()];
@@ -35,7 +35,7 @@ fn abort_cleanup_reverses_phases_attempts_all_steps_and_aggregates_failures() {
     assert_eq!(second_action.directives[0].context().phase_id, "second");
 
     let first_cleanup = tick(&mut engine, 2, 2, crashed_observation(), Vec::new());
-    assert_cleanup(&first_cleanup, 1, "second", 0, "flight.hold");
+    assert_cleanup(&first_cleanup, 1, "second", 0, "flight.maintain_target");
     let second_cleanup = tick(
         &mut engine,
         3,
@@ -44,7 +44,7 @@ fn abort_cleanup_reverses_phases_attempts_all_steps_and_aggregates_failures() {
         vec![receipt(
             &first_cleanup,
             ReceiptResult::Failed {
-                detail: "hold failed".to_owned(),
+                detail: "maintain target failed".to_owned(),
             },
         )],
     );
@@ -75,7 +75,7 @@ fn abort_cleanup_reverses_phases_attempts_all_steps_and_aggregates_failures() {
             cleanup_failures,
             ..
         } if cleanup_failures.len() == 2
-            && cleanup_failures[0].action == "flight.hold"
+            && cleanup_failures[0].action == "flight.maintain_target"
             && cleanup_failures[1].action == "flight.land"
     ));
 }

--- a/crates/pilotage-mission-core/src/error.rs
+++ b/crates/pilotage-mission-core/src/error.rs
@@ -107,6 +107,15 @@ pub enum ValidationError {
         /// The maximum value.
         maximum: f64,
     },
+    /// A stimulus does not name one valid physical command.
+    #[error("{field} has an invalid stimulus: {source}")]
+    InvalidStimulus {
+        /// The field path.
+        field: String,
+        /// The physical contract failure.
+        #[source]
+        source: crate::StimulusError,
+    },
     /// A flight plan uses different navigation data from the mission.
     #[error("phase {phase_id} flight plan {plan_id} has different navigation-data identity")]
     NavigationDataMismatch {

--- a/crates/pilotage-mission-core/src/lib.rs
+++ b/crates/pilotage-mission-core/src/lib.rs
@@ -36,10 +36,13 @@ pub use signal::{
     ControlChannel, ControlValueField, QuaternionComponent, ReferenceFrame, SignalSelector,
     VectorComponent,
 };
-pub use trial::{SineComponent, StartHeading, StartState, Waveform};
+pub use trial::{
+    ControlFamily, PhysicalUnit, ReferenceRule, SineComponent, StartHeading, StartState,
+    StimulusEnvelope, StimulusError, StimulusMapping, Waveform,
+};
 
 /// The mission document schema version supported by this crate.
-pub const MISSION_SCHEMA_VERSION: u16 = 2;
+pub const MISSION_SCHEMA_VERSION: u16 = 3;
 
 /// The maximum encoded mission document size.
 pub const MAX_DOCUMENT_BYTES: usize = 1_048_576;

--- a/crates/pilotage-mission-core/src/tests.rs
+++ b/crates/pilotage-mission-core/src/tests.rs
@@ -1,15 +1,18 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+mod stimulus;
+
 use crate::{
-    ArtifactIdentity, CodecError, Comparison, ControlChannel, Digest, ExecutionPolicy,
-    ExecutionTarget, FlightAction, FlightPlanReference, MissionAction, MissionCapability,
-    MissionCondition, MissionDocument, MissionPhase, NavigationDataIdentity, SignalCondition,
-    SignalSelector, StartHeading, StartState, TrialAction, ValidationError, Waveform,
+    ArtifactIdentity, CodecError, Comparison, ControlChannel, ControlFamily, Digest,
+    ExecutionPolicy, ExecutionTarget, FlightAction, FlightPlanReference, MissionAction,
+    MissionCapability, MissionCondition, MissionDocument, MissionPhase, NavigationDataIdentity,
+    PhysicalUnit, ReferenceRule, SignalCondition, SignalSelector, StartHeading, StartState,
+    StimulusEnvelope, StimulusMapping, TrialAction, ValidationError, Waveform,
 };
 
 const CANONICAL_FIXTURE: &[u8] = concat!(
-    "{\"identity\":{\"revision_id\":\"mission-1\",\"schema_version\":2,",
-    "\"content_digest\":\"39948a4de2c0ffe060c45b243e82eb575d9cddb68204f097b36c5f3995c9b996\",",
+    "{\"identity\":{\"revision_id\":\"mission-1\",\"schema_version\":3,",
+    "\"content_digest\":\"f1a8b82556d74cebf50216fd1d20cd01504d5e4ba22ec439bcad33f8ff1b08d9\",",
     "\"navigation_data_identity\":{\"cycle\":\"2608\",\"snapshot_id\":\"nav-1\",",
     "\"snapshot_digest\":\"0101010101010101010101010101010101010101010101010101010101010101\"}},",
     "\"execution_policy\":{\"target\":\"real_vehicle\",\"retry_limit\":2,",
@@ -100,7 +103,10 @@ fn trial_actions() -> Vec<TrialAction> {
         },
         TrialAction::Settle {},
         TrialAction::Stimulate {
+            family: ControlFamily::OperatorVelocity,
             channel: ControlChannel::Pitch,
+            mapping: StimulusMapping::CandidateBoundCurve,
+            envelope: operator_envelope(),
             waveform: Waveform::Step { value: 0.2 },
         },
         TrialAction::ReleaseControl {},
@@ -109,6 +115,18 @@ fn trial_actions() -> Vec<TrialAction> {
         TrialAction::Disarm {},
         TrialAction::CollectResults {},
     ]
+}
+
+fn operator_envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "bench.operator.pitch".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::MetersPerSecond,
+        reference: ReferenceRule::Zero,
+        negative_endpoint: -5.0,
+        neutral: 0.0,
+        positive_endpoint: 5.0,
+    }
 }
 
 fn recalculate(document: &mut MissionDocument) {
@@ -142,7 +160,7 @@ fn identity_and_policy_field_groups_change_digest() {
         original
     );
     let mut schema = document.clone();
-    schema.identity.schema_version = 3;
+    schema.identity.schema_version = crate::MISSION_SCHEMA_VERSION.wrapping_add(1);
     assert_ne!(schema.calculate_content_digest().expect("digest"), original);
     let mut navdata = document.clone();
     navdata.identity.navigation_data_identity.cycle = "2609".to_owned();

--- a/crates/pilotage-mission-core/src/tests/stimulus.rs
+++ b/crates/pilotage-mission-core/src/tests/stimulus.rs
@@ -1,0 +1,124 @@
+//! Document-level checks for the physical stimulus contract.
+
+use crate::{
+    CodecError, ControlChannel, ControlFamily, ExecutionTarget, MissionAction, MissionCapability,
+    PhysicalUnit, ReferenceRule, StimulusEnvelope, StimulusError, TrialAction, ValidationError,
+    Waveform,
+};
+
+use super::{document_for, operator_envelope, recalculate};
+
+fn direct_envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "bench.direct.pitch".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::Radians,
+        reference: ReferenceRule::EffectiveSetpointAtEntry,
+        negative_endpoint: -0.25,
+        neutral: 0.0,
+        positive_endpoint: 0.25,
+    }
+}
+
+fn stimulate(family: ControlFamily, envelope: StimulusEnvelope) -> MissionAction {
+    MissionAction::Trial(TrialAction::Stimulate {
+        family,
+        channel: ControlChannel::Pitch,
+        mapping: family.mapping(),
+        envelope,
+        waveform: Waveform::Step { value: 0.2 },
+    })
+}
+
+#[test]
+fn a_stimulus_phase_declares_its_control_family_capability() {
+    for (family, envelope, capability) in [
+        (
+            ControlFamily::OperatorVelocity,
+            operator_envelope(),
+            MissionCapability::OperatorVelocityControl,
+        ),
+        (
+            ControlFamily::DirectAttitudeThrust,
+            direct_envelope(),
+            MissionCapability::DirectAttitudeThrustControl,
+        ),
+    ] {
+        let action = stimulate(family, envelope);
+        assert_eq!(action.required_capability(), Some(capability));
+        let mut document = document_for(action, ExecutionTarget::Simulator)
+            .expect("the stimulus mission must be valid");
+        document.phases[0]
+            .required_capabilities
+            .retain(|value| *value != capability);
+        recalculate(&mut document);
+        assert!(matches!(
+            document.validate(),
+            Err(ValidationError::UndeclaredCapability { .. })
+        ));
+    }
+}
+
+#[test]
+fn a_document_stimulus_rejects_a_substituted_unit() {
+    let mut envelope = operator_envelope();
+    envelope.unit = PhysicalUnit::Radians;
+
+    let result = document_for(
+        stimulate(ControlFamily::OperatorVelocity, envelope),
+        ExecutionTarget::Simulator,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CodecError::Validation(ValidationError::InvalidStimulus {
+            source: StimulusError::UnitMismatch { .. },
+            ..
+        }))
+    ));
+}
+
+#[test]
+fn a_changed_control_family_changes_the_content_digest() {
+    let operator = document_for(
+        stimulate(ControlFamily::OperatorVelocity, operator_envelope()),
+        ExecutionTarget::Simulator,
+    )
+    .expect("the operator mission must be valid");
+    let direct = document_for(
+        stimulate(ControlFamily::DirectAttitudeThrust, direct_envelope()),
+        ExecutionTarget::Simulator,
+    )
+    .expect("the direct mission must be valid");
+
+    assert_ne!(
+        operator.identity.content_digest,
+        direct.identity.content_digest
+    );
+}
+
+#[test]
+fn a_changed_envelope_changes_the_content_digest_and_the_envelope_digest() {
+    let base = operator_envelope();
+    let mut wider = base.clone();
+    wider.positive_endpoint = 6.0;
+    let document = document_for(
+        stimulate(ControlFamily::OperatorVelocity, base.clone()),
+        ExecutionTarget::Simulator,
+    )
+    .expect("the base mission must be valid");
+    let changed = document_for(
+        stimulate(ControlFamily::OperatorVelocity, wider.clone()),
+        ExecutionTarget::Simulator,
+    )
+    .expect("the changed mission must be valid");
+
+    assert_ne!(
+        base.canonical_digest().expect("base envelope digest"),
+        wider.canonical_digest().expect("wider envelope digest")
+    );
+    assert_ne!(
+        document.identity.content_digest,
+        changed.identity.content_digest
+    );
+}

--- a/crates/pilotage-mission-core/src/trial.rs
+++ b/crates/pilotage-mission-core/src/trial.rs
@@ -1,8 +1,16 @@
 //! Trial action value types.
 
+mod stimulus;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{ArtifactIdentity, ValidationError, validation::range};
+
+pub use stimulus::{
+    ControlFamily, PhysicalUnit, ReferenceRule, StimulusEnvelope, StimulusError, StimulusMapping,
+};
+
+pub(crate) use stimulus::validate as validate_stimulus;
 
 const MAX_WAVE_COMPONENTS: usize = 64;
 

--- a/crates/pilotage-mission-core/src/trial/stimulus.rs
+++ b/crates/pilotage-mission-core/src/trial/stimulus.rs
@@ -1,0 +1,274 @@
+//! The physical control family and envelope that give a stimulus its meaning.
+//!
+//! The document binds the same physical contract that the authored trial
+//! scenario declares, so the mission content digest covers the exact command
+//! that a normalized waveform value requests.
+
+mod combination;
+mod error;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use crate::{
+    CodecError, ControlChannel, Digest, MissionCapability, ValidationError, canonical,
+    validation::text,
+};
+
+pub use error::StimulusError;
+
+const ENVELOPE_DIGEST_DOMAIN: &[u8] = b"pilotage.trial.stimulus-envelope.v1\0";
+
+/// The physical control family that one stimulus commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlFamily {
+    /// The stimulus commands an operator velocity input.
+    OperatorVelocity,
+    /// The stimulus commands a direct attitude and thrust setpoint.
+    DirectAttitudeThrust,
+}
+
+/// The rule that turns a normalized stimulus value into a physical command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StimulusMapping {
+    /// The envelope bounds the output of the candidate response curve.
+    ///
+    /// The document freezes the normalized input and the physical bound. The
+    /// run binds the candidate feel profile that shapes the values between the
+    /// endpoints.
+    CandidateBoundCurve,
+    /// The envelope resolves the output with a two-segment affine map.
+    AffineExact,
+}
+
+/// The physical unit of one stimulus envelope.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PhysicalUnit {
+    /// A linear speed in meters per second.
+    MetersPerSecond,
+    /// An angular rate in radians per second.
+    RadiansPerSecond,
+    /// An angle in radians.
+    Radians,
+    /// A collective force normalized against the vehicle hover force.
+    NormalizedCollectiveForce,
+}
+
+/// The value that the envelope endpoints measure from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceRule {
+    /// The endpoints measure from zero.
+    Zero,
+    /// The endpoints measure from the effective setpoint at stimulus entry.
+    EffectiveSetpointAtEntry,
+    /// The endpoints measure from the identified hover trim of the vehicle.
+    IdentifiedHoverTrim,
+}
+
+/// A versioned physical envelope for one stimulus.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StimulusEnvelope {
+    /// The stable envelope identifier.
+    pub id: String,
+    /// The envelope revision number.
+    pub revision: u32,
+    /// The physical unit of the three envelope values.
+    pub unit: PhysicalUnit,
+    /// The value that the endpoints measure from.
+    pub reference: ReferenceRule,
+    /// The physical value at normalized minus one.
+    pub negative_endpoint: f64,
+    /// The physical value at normalized zero.
+    pub neutral: f64,
+    /// The physical value at normalized plus one.
+    pub positive_endpoint: f64,
+}
+
+impl ControlFamily {
+    /// Gets the stable control-family name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatorVelocity => "operator_velocity",
+            Self::DirectAttitudeThrust => "direct_attitude_thrust",
+        }
+    }
+
+    /// Gets the mission capability that the family needs.
+    #[must_use]
+    pub const fn capability(self) -> MissionCapability {
+        match self {
+            Self::OperatorVelocity => MissionCapability::OperatorVelocityControl,
+            Self::DirectAttitudeThrust => MissionCapability::DirectAttitudeThrustControl,
+        }
+    }
+
+    /// Gets the one mapping rule that the family permits.
+    #[must_use]
+    pub const fn mapping(self) -> StimulusMapping {
+        match self {
+            Self::OperatorVelocity => StimulusMapping::CandidateBoundCurve,
+            Self::DirectAttitudeThrust => StimulusMapping::AffineExact,
+        }
+    }
+}
+
+impl StimulusMapping {
+    /// Gets the stable mapping-rule name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CandidateBoundCurve => "candidate_bound_curve",
+            Self::AffineExact => "affine_exact",
+        }
+    }
+
+    /// Resolves the exact physical command for one normalized value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the mapping needs a candidate feel profile, when
+    /// the envelope is invalid, or when the normalized value is outside
+    /// minus one through plus one.
+    pub fn resolve_exact(
+        self,
+        envelope: &StimulusEnvelope,
+        normalized: f64,
+    ) -> Result<f64, StimulusError> {
+        match self {
+            Self::AffineExact => envelope.map_affine(normalized),
+            Self::CandidateBoundCurve => Err(StimulusError::InexactMapping {
+                mapping: self.as_str(),
+            }),
+        }
+    }
+}
+
+impl PhysicalUnit {
+    /// Gets the stable unit name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MetersPerSecond => "meters_per_second",
+            Self::RadiansPerSecond => "radians_per_second",
+            Self::Radians => "radians",
+            Self::NormalizedCollectiveForce => "normalized_collective_force",
+        }
+    }
+}
+
+impl ReferenceRule {
+    /// Gets the stable reference-rule name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Zero => "zero",
+            Self::EffectiveSetpointAtEntry => "effective_setpoint_at_entry",
+            Self::IdentifiedHoverTrim => "identified_hover_trim",
+        }
+    }
+}
+
+impl StimulusEnvelope {
+    /// Calculates the digest of the canonical envelope bytes.
+    ///
+    /// The digest covers every envelope field, so a changed identifier,
+    /// revision, unit, reference rule, or endpoint changes the value. The
+    /// domain and the field order match the authored trial envelope, so a
+    /// lossless projection keeps the envelope identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the envelope cannot be encoded.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        let bytes = canonical::encode(self)?;
+        let mut hasher = Sha256::new();
+        hasher.update(ENVELOPE_DIGEST_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Maps one normalized value with the two-segment affine rule.
+    ///
+    /// The negative segment covers minus one through zero and the positive
+    /// segment covers zero through plus one. Both segments meet at the neutral
+    /// value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the envelope values are invalid or when the
+    /// normalized value is outside minus one through plus one.
+    pub fn map_affine(&self, normalized: f64) -> Result<f64, StimulusError> {
+        self.validate_values()?;
+        if !(-1.0..=1.0).contains(&normalized) {
+            return Err(StimulusError::NormalizedOutOfRange { value: normalized });
+        }
+        let span = if normalized < 0.0 {
+            self.neutral - self.negative_endpoint
+        } else {
+            self.positive_endpoint - self.neutral
+        };
+        Ok(self.neutral + normalized * span)
+    }
+
+    /// Checks the envelope values without a family or channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a value that is not finite, for reversed
+    /// endpoints, for a zero physical span, and for a neutral value that the
+    /// endpoints do not contain.
+    pub fn validate_values(&self) -> Result<(), StimulusError> {
+        for (name, value) in [
+            ("negative_endpoint", self.negative_endpoint),
+            ("neutral", self.neutral),
+            ("positive_endpoint", self.positive_endpoint),
+        ] {
+            if !value.is_finite() {
+                return Err(StimulusError::NonFiniteValue { name });
+            }
+        }
+        if self.negative_endpoint > self.positive_endpoint {
+            return Err(StimulusError::ReversedEndpoints {
+                negative: self.negative_endpoint,
+                positive: self.positive_endpoint,
+            });
+        }
+        if self.negative_endpoint == self.positive_endpoint {
+            return Err(StimulusError::ZeroSpan {
+                value: self.negative_endpoint,
+            });
+        }
+        if self.neutral <= self.negative_endpoint || self.neutral >= self.positive_endpoint {
+            return Err(StimulusError::NeutralOutsideEndpoints {
+                neutral: self.neutral,
+                negative: self.negative_endpoint,
+                positive: self.positive_endpoint,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Checks the complete physical meaning of one stimulus.
+pub(crate) fn validate(
+    field: &str,
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: &StimulusEnvelope,
+) -> Result<(), ValidationError> {
+    text(&format!("{field}.envelope.id"), &envelope.id)?;
+    let wrap = |source| ValidationError::InvalidStimulus {
+        field: field.to_owned(),
+        source,
+    };
+    envelope.validate_values().map_err(wrap)?;
+    combination::validate(family, channel, mapping, envelope).map_err(wrap)
+}

--- a/crates/pilotage-mission-core/src/trial/stimulus/combination.rs
+++ b/crates/pilotage-mission-core/src/trial/stimulus/combination.rs
@@ -1,0 +1,80 @@
+//! The permitted control family, channel, unit, and reference combinations.
+
+use super::{
+    ControlFamily, PhysicalUnit, ReferenceRule, StimulusEnvelope, StimulusError, StimulusMapping,
+};
+use crate::ControlChannel;
+
+/// Checks one stimulus against the permitted physical combinations.
+pub(super) fn validate(
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: &StimulusEnvelope,
+) -> Result<(), StimulusError> {
+    let (unit, reference) = required_physics(family, channel);
+    if envelope.unit != unit {
+        return Err(StimulusError::UnitMismatch {
+            family: family.as_str(),
+            channel: channel_name(channel),
+            expected: unit.as_str(),
+            actual: envelope.unit.as_str(),
+        });
+    }
+    if envelope.reference != reference {
+        return Err(StimulusError::ReferenceMismatch {
+            family: family.as_str(),
+            channel: channel_name(channel),
+            expected: reference.as_str(),
+            actual: envelope.reference.as_str(),
+        });
+    }
+    let required = family.mapping();
+    if mapping != required {
+        return Err(StimulusError::MappingMismatch {
+            family: family.as_str(),
+            expected: required.as_str(),
+            actual: mapping.as_str(),
+        });
+    }
+    Ok(())
+}
+
+/// Gets the one unit and reference rule that a family and channel permit.
+///
+/// The match is exhaustive over both enums, so a combination that this table
+/// does not name cannot exist.
+const fn required_physics(
+    family: ControlFamily,
+    channel: ControlChannel,
+) -> (PhysicalUnit, ReferenceRule) {
+    match (family, channel) {
+        (
+            ControlFamily::OperatorVelocity,
+            ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Vertical,
+        ) => (PhysicalUnit::MetersPerSecond, ReferenceRule::Zero),
+        (ControlFamily::OperatorVelocity, ControlChannel::Yaw) => {
+            (PhysicalUnit::RadiansPerSecond, ReferenceRule::Zero)
+        }
+        (
+            ControlFamily::DirectAttitudeThrust,
+            ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Yaw,
+        ) => (
+            PhysicalUnit::Radians,
+            ReferenceRule::EffectiveSetpointAtEntry,
+        ),
+        (ControlFamily::DirectAttitudeThrust, ControlChannel::Vertical) => (
+            PhysicalUnit::NormalizedCollectiveForce,
+            ReferenceRule::IdentifiedHoverTrim,
+        ),
+    }
+}
+
+const fn channel_name(channel: ControlChannel) -> &'static str {
+    match channel {
+        ControlChannel::Roll => "roll",
+        ControlChannel::Pitch => "pitch",
+        ControlChannel::Vertical => "vertical",
+        ControlChannel::Yaw => "yaw",
+    }
+}

--- a/crates/pilotage-mission-core/src/trial/stimulus/error.rs
+++ b/crates/pilotage-mission-core/src/trial/stimulus/error.rs
@@ -1,0 +1,84 @@
+//! Errors for the physical stimulus contract in a mission document.
+
+use thiserror::Error;
+
+/// An error in the physical meaning of one stimulus.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum StimulusError {
+    /// An envelope endpoint or neutral value is not finite.
+    #[error("the {name} value must be finite")]
+    NonFiniteValue {
+        /// The envelope value name.
+        name: &'static str,
+    },
+    /// The negative endpoint is above the positive endpoint.
+    #[error("the negative endpoint {negative} is above the positive endpoint {positive}")]
+    ReversedEndpoints {
+        /// The negative endpoint.
+        negative: f64,
+        /// The positive endpoint.
+        positive: f64,
+    },
+    /// The two endpoints describe no physical span.
+    #[error("both endpoints are {value}, which is a zero physical span")]
+    ZeroSpan {
+        /// The value that both endpoints have.
+        value: f64,
+    },
+    /// The neutral value is not between the two endpoints.
+    #[error("the neutral value {neutral} must be between {negative} and {positive}")]
+    NeutralOutsideEndpoints {
+        /// The neutral value.
+        neutral: f64,
+        /// The negative endpoint.
+        negative: f64,
+        /// The positive endpoint.
+        positive: f64,
+    },
+    /// The physical unit does not belong to the control family and channel.
+    #[error("family {family} channel {channel} uses unit {expected}, not {actual}")]
+    UnitMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The control channel name.
+        channel: &'static str,
+        /// The unit that the combination requires.
+        expected: &'static str,
+        /// The supplied unit.
+        actual: &'static str,
+    },
+    /// The reference rule does not belong to the control family and channel.
+    #[error("family {family} channel {channel} uses reference {expected}, not {actual}")]
+    ReferenceMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The control channel name.
+        channel: &'static str,
+        /// The reference rule that the combination requires.
+        expected: &'static str,
+        /// The supplied reference rule.
+        actual: &'static str,
+    },
+    /// The mapping rule does not belong to the control family.
+    #[error("family {family} uses mapping {expected}, not {actual}")]
+    MappingMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The mapping rule that the family requires.
+        expected: &'static str,
+        /// The supplied mapping rule.
+        actual: &'static str,
+    },
+    /// The mapping rule resolves no exact value at authoring time.
+    #[error("mapping {mapping} needs a candidate feel profile to resolve one exact value")]
+    InexactMapping {
+        /// The mapping rule name.
+        mapping: &'static str,
+    },
+    /// A normalized value is outside minus one through plus one.
+    #[error("the normalized value {value} is outside minus one through plus one")]
+    NormalizedOutOfRange {
+        /// The supplied normalized value.
+        value: f64,
+    },
+}

--- a/crates/pilotage-mission/tests/mission_document.rs
+++ b/crates/pilotage-mission/tests/mission_document.rs
@@ -73,12 +73,12 @@ fn route_config_produces_the_three_bounded_action_phases() {
         document.phases[2].simulator_time_deadline_ns,
         FOLLOW_PLAN_PHASE_DEADLINE_NS
     );
-    assert!(
-        document
-            .phases
-            .iter()
-            .all(|phase| { !matches!(phase.action, MissionAction::Flight(FlightAction::Hold {})) })
-    );
+    assert!(document.phases.iter().all(|phase| {
+        !matches!(
+            phase.action,
+            MissionAction::Flight(FlightAction::MaintainTarget {})
+        )
+    }));
 }
 
 #[test]

--- a/crates/pilotage-trial/src/error.rs
+++ b/crates/pilotage-trial/src/error.rs
@@ -189,6 +189,15 @@ pub enum ValidationError {
         /// The permitted difference from one.
         tolerance: f64,
     },
+    /// A stimulus does not name one valid physical command.
+    #[error("{field} has an invalid stimulus: {source}")]
+    InvalidStimulus {
+        /// The field path.
+        field: String,
+        /// The physical contract failure.
+        #[source]
+        source: crate::StimulusError,
+    },
     /// A phase needs a capability that the backend does not supply.
     #[error("phase {phase} needs unsupported capability {capability}")]
     UnsupportedCapability {

--- a/crates/pilotage-trial/src/lib.rs
+++ b/crates/pilotage-trial/src/lib.rs
@@ -29,8 +29,8 @@ pub use limits::{
     BACKEND_CAPABILITIES_SCHEMA_VERSION, CONDITION_SET_SCHEMA_VERSION, MAX_ACTUATOR_VALUES,
     MAX_CAPABILITIES, MAX_CLOCK_MAPPINGS, MAX_CONDITION_VALUES, MAX_GUST_EVENTS,
     MAX_MANIFEST_BYTES, MAX_PHASE_CONDITIONS, MAX_PHASES, MAX_RAW_AXES, MAX_RAW_BUTTONS,
-    MAX_SAMPLE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS, SCENARIO_SCHEMA_VERSION,
-    TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
+    MAX_SAMPLE_BYTES, MAX_STIMULUS_ENVELOPE_BYTES, MAX_TEXT_BYTES, MAX_WAVE_COMPONENTS,
+    SCENARIO_SCHEMA_VERSION, TRIAL_MANIFEST_SCHEMA_VERSION, TRIAL_SAMPLE_SCHEMA_VERSION,
 };
 pub use manifest::TrialManifest;
 pub use sample::{
@@ -39,7 +39,8 @@ pub use sample::{
     Observed, Quaternion, RawInput, ReferenceFrame, SampleTime, TrialSample, Vector3,
 };
 pub use scenario::{
-    BackendCapabilities, BackendCapability, Comparison, ControlChannel, ControlValueField, Phase,
-    PhaseAction, PhaseCondition, QuaternionComponent, Scenario, SignalSelectionError,
-    SignalSelector, SineComponent, StartHeading, StartState, VectorComponent, Waveform,
+    BackendCapabilities, BackendCapability, Comparison, ControlChannel, ControlFamily,
+    ControlValueField, Phase, PhaseAction, PhaseCondition, PhysicalUnit, QuaternionComponent,
+    ReferenceRule, Scenario, SignalSelectionError, SignalSelector, SineComponent, StartHeading,
+    StartState, StimulusEnvelope, StimulusError, StimulusMapping, VectorComponent, Waveform,
 };

--- a/crates/pilotage-trial/src/limits.rs
+++ b/crates/pilotage-trial/src/limits.rs
@@ -5,7 +5,7 @@ pub const TRIAL_MANIFEST_SCHEMA_VERSION: u16 = 1;
 /// The supported run identity schema version.
 pub const RUN_IDENTITY_SCHEMA_VERSION: u16 = 1;
 /// The supported scenario schema version.
-pub const SCENARIO_SCHEMA_VERSION: u16 = 2;
+pub const SCENARIO_SCHEMA_VERSION: u16 = 3;
 /// The supported backend capabilities schema version.
 pub const BACKEND_CAPABILITIES_SCHEMA_VERSION: u16 = 1;
 /// The supported trial sample schema version.
@@ -19,6 +19,8 @@ pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 pub const MAX_RUN_IDENTITY_BYTES: usize = 64 * 1024;
 /// The maximum trial sample JSON size.
 pub const MAX_SAMPLE_BYTES: usize = 64 * 1024;
+/// The maximum stimulus envelope JSON size.
+pub const MAX_STIMULUS_ENVELOPE_BYTES: usize = 4 * 1024;
 /// The maximum UTF-8 byte count for one text value.
 pub const MAX_TEXT_BYTES: usize = 256;
 /// The maximum number of phases in one scenario.

--- a/crates/pilotage-trial/src/scenario.rs
+++ b/crates/pilotage-trial/src/scenario.rs
@@ -3,6 +3,7 @@
 mod backend;
 mod phase;
 mod selector;
+mod stimulus;
 mod waveform;
 
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,9 @@ pub use phase::{Comparison, Phase, PhaseAction, PhaseCondition, StartHeading, St
 pub use selector::{
     ControlChannel, ControlValueField, QuaternionComponent, SignalSelectionError, SignalSelector,
     VectorComponent,
+};
+pub use stimulus::{
+    ControlFamily, PhysicalUnit, ReferenceRule, StimulusEnvelope, StimulusError, StimulusMapping,
 };
 pub use waveform::{SineComponent, Waveform};
 

--- a/crates/pilotage-trial/src/scenario/backend.rs
+++ b/crates/pilotage-trial/src/scenario/backend.rs
@@ -32,6 +32,10 @@ pub enum BackendCapability {
     WindControl,
     /// Apply controlled turbulence.
     TurbulenceControl,
+    /// Command the operator velocity control family.
+    OperatorVelocityControl,
+    /// Command the direct attitude and thrust control family.
+    DirectAttitudeThrustControl,
 }
 
 impl BackendCapability {
@@ -49,6 +53,8 @@ impl BackendCapability {
             Self::ContactState => "contact_state",
             Self::WindControl => "wind_control",
             Self::TurbulenceControl => "turbulence_control",
+            Self::OperatorVelocityControl => "operator_velocity_control",
+            Self::DirectAttitudeThrustControl => "direct_attitude_thrust_control",
         }
     }
 }

--- a/crates/pilotage-trial/src/scenario/phase.rs
+++ b/crates/pilotage-trial/src/scenario/phase.rs
@@ -2,7 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{BackendCapability, ControlChannel, SignalSelector, Waveform};
+use super::{
+    BackendCapability, ControlChannel, ControlFamily, SignalSelector, StimulusEnvelope,
+    StimulusMapping, Waveform, stimulus,
+};
 use crate::{
     ArtifactIdentity, MAX_CAPABILITIES, MAX_PHASE_CONDITIONS, MAX_TEXT_BYTES, ValidationError,
     validation::{count, duration, finite, range, text, unique},
@@ -99,8 +102,14 @@ pub enum PhaseAction {
     Settle,
     /// Apply one control stimulus.
     Stimulus {
+        /// The physical control family that the stimulus commands.
+        family: ControlFamily,
         /// The control channel.
         channel: ControlChannel,
+        /// The rule that resolves a normalized value to a physical command.
+        mapping: StimulusMapping,
+        /// The versioned physical envelope of the normalized range.
+        envelope: StimulusEnvelope,
         /// The stimulus waveform.
         waveform: Waveform,
     },
@@ -167,7 +176,20 @@ impl Phase {
                 condition_set.validate(&format!("{field}.action.condition_set"))
             }
             PhaseAction::ReachStartState { target } => target.validate(field),
-            PhaseAction::Stimulus { waveform, .. } => {
+            PhaseAction::Stimulus {
+                family,
+                channel,
+                mapping,
+                envelope,
+                waveform,
+            } => {
+                stimulus::validate(
+                    &format!("{field}.action"),
+                    *family,
+                    *channel,
+                    *mapping,
+                    envelope,
+                )?;
                 waveform.validate(&format!("{field}.action.waveform"))
             }
             _ => Ok(()),
@@ -298,6 +320,7 @@ const fn action_capability(action: &PhaseAction) -> Option<BackendCapability> {
         PhaseAction::ApplyConditions { .. } => Some(BackendCapability::ConditionControl),
         PhaseAction::Arm | PhaseAction::Disarm => Some(BackendCapability::ArmDisarm),
         PhaseAction::ReachStartState { .. } => Some(BackendCapability::KinematicTruth),
+        PhaseAction::Stimulus { family, .. } => Some(family.capability()),
         _ => None,
     }
 }

--- a/crates/pilotage-trial/src/scenario/stimulus.rs
+++ b/crates/pilotage-trial/src/scenario/stimulus.rs
@@ -1,0 +1,281 @@
+//! The physical control family and envelope that give a stimulus its meaning.
+//!
+//! A stimulus waveform carries normalized values only. The control family, the
+//! mapping rule, and the versioned envelope state which physical command those
+//! values request. A runtime that cannot command the family refuses the
+//! scenario before it touches a simulator.
+
+mod combination;
+mod error;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::{BackendCapability, ControlChannel};
+use crate::{
+    CodecError, Digest, MAX_STIMULUS_ENVELOPE_BYTES, MAX_TEXT_BYTES, ValidationError, canonical,
+    validation::text,
+};
+
+pub use error::StimulusError;
+
+const ENVELOPE_DIGEST_DOMAIN: &[u8] = b"pilotage.trial.stimulus-envelope.v1\0";
+
+/// The physical control family that one stimulus commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlFamily {
+    /// The stimulus commands an operator velocity input.
+    OperatorVelocity,
+    /// The stimulus commands a direct attitude and thrust setpoint.
+    DirectAttitudeThrust,
+}
+
+/// The rule that turns a normalized stimulus value into a physical command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StimulusMapping {
+    /// The envelope bounds the output of the candidate response curve.
+    ///
+    /// The scenario freezes the normalized input and the physical bound. The
+    /// run binds the candidate feel profile that shapes the values between the
+    /// endpoints.
+    CandidateBoundCurve,
+    /// The envelope resolves the output with a two-segment affine map.
+    AffineExact,
+}
+
+/// The physical unit of one stimulus envelope.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PhysicalUnit {
+    /// A linear speed in meters per second.
+    MetersPerSecond,
+    /// An angular rate in radians per second.
+    RadiansPerSecond,
+    /// An angle in radians.
+    Radians,
+    /// A collective force normalized against the vehicle hover force.
+    NormalizedCollectiveForce,
+}
+
+/// The value that the envelope endpoints measure from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceRule {
+    /// The endpoints measure from zero.
+    Zero,
+    /// The endpoints measure from the effective setpoint at stimulus entry.
+    EffectiveSetpointAtEntry,
+    /// The endpoints measure from the identified hover trim of the vehicle.
+    IdentifiedHoverTrim,
+}
+
+/// A versioned physical envelope for one stimulus.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StimulusEnvelope {
+    /// The stable envelope identifier.
+    pub id: String,
+    /// The envelope revision number.
+    pub revision: u32,
+    /// The physical unit of the three envelope values.
+    pub unit: PhysicalUnit,
+    /// The value that the endpoints measure from.
+    pub reference: ReferenceRule,
+    /// The physical value at normalized minus one.
+    pub negative_endpoint: f64,
+    /// The physical value at normalized zero.
+    pub neutral: f64,
+    /// The physical value at normalized plus one.
+    pub positive_endpoint: f64,
+}
+
+impl ControlFamily {
+    /// Gets the stable control-family name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OperatorVelocity => "operator_velocity",
+            Self::DirectAttitudeThrust => "direct_attitude_thrust",
+        }
+    }
+
+    /// Gets the backend capability that the family needs.
+    #[must_use]
+    pub const fn capability(self) -> BackendCapability {
+        match self {
+            Self::OperatorVelocity => BackendCapability::OperatorVelocityControl,
+            Self::DirectAttitudeThrust => BackendCapability::DirectAttitudeThrustControl,
+        }
+    }
+
+    /// Gets the one mapping rule that the family permits.
+    #[must_use]
+    pub const fn mapping(self) -> StimulusMapping {
+        match self {
+            Self::OperatorVelocity => StimulusMapping::CandidateBoundCurve,
+            Self::DirectAttitudeThrust => StimulusMapping::AffineExact,
+        }
+    }
+}
+
+impl StimulusMapping {
+    /// Gets the stable mapping-rule name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CandidateBoundCurve => "candidate_bound_curve",
+            Self::AffineExact => "affine_exact",
+        }
+    }
+
+    /// Resolves the exact physical command for one normalized value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the mapping needs a candidate feel profile, when
+    /// the envelope is invalid, or when the normalized value is outside
+    /// minus one through plus one.
+    pub fn resolve_exact(
+        self,
+        envelope: &StimulusEnvelope,
+        normalized: f64,
+    ) -> Result<f64, StimulusError> {
+        match self {
+            Self::AffineExact => envelope.map_affine(normalized),
+            Self::CandidateBoundCurve => Err(StimulusError::InexactMapping {
+                mapping: self.as_str(),
+            }),
+        }
+    }
+}
+
+impl PhysicalUnit {
+    /// Gets the stable unit name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MetersPerSecond => "meters_per_second",
+            Self::RadiansPerSecond => "radians_per_second",
+            Self::Radians => "radians",
+            Self::NormalizedCollectiveForce => "normalized_collective_force",
+        }
+    }
+}
+
+impl ReferenceRule {
+    /// Gets the stable reference-rule name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Zero => "zero",
+            Self::EffectiveSetpointAtEntry => "effective_setpoint_at_entry",
+            Self::IdentifiedHoverTrim => "identified_hover_trim",
+        }
+    }
+}
+
+impl StimulusEnvelope {
+    /// Calculates the digest of the canonical envelope bytes.
+    ///
+    /// The digest covers every envelope field, so a changed identifier,
+    /// revision, unit, reference rule, or endpoint changes the value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the envelope cannot be encoded.
+    pub fn canonical_digest(&self) -> Result<Digest, CodecError> {
+        let bytes = canonical::encode("stimulus envelope", self, MAX_STIMULUS_ENVELOPE_BYTES)?;
+        let mut hasher = Sha256::new();
+        hasher.update(ENVELOPE_DIGEST_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Maps one normalized value with the two-segment affine rule.
+    ///
+    /// The negative segment covers minus one through zero and the positive
+    /// segment covers zero through plus one. Both segments meet at the neutral
+    /// value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the envelope values are invalid or when the
+    /// normalized value is outside minus one through plus one.
+    pub fn map_affine(&self, normalized: f64) -> Result<f64, StimulusError> {
+        self.validate_values()?;
+        if !(-1.0..=1.0).contains(&normalized) {
+            return Err(StimulusError::NormalizedOutOfRange { value: normalized });
+        }
+        let span = if normalized < 0.0 {
+            self.neutral - self.negative_endpoint
+        } else {
+            self.positive_endpoint - self.neutral
+        };
+        Ok(self.neutral + normalized * span)
+    }
+
+    /// Checks the envelope values without a family or channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a value that is not finite, for reversed
+    /// endpoints, for a zero physical span, and for a neutral value that the
+    /// endpoints do not contain.
+    pub fn validate_values(&self) -> Result<(), StimulusError> {
+        for (name, value) in [
+            ("negative_endpoint", self.negative_endpoint),
+            ("neutral", self.neutral),
+            ("positive_endpoint", self.positive_endpoint),
+        ] {
+            if !value.is_finite() {
+                return Err(StimulusError::NonFiniteValue { name });
+            }
+        }
+        if self.negative_endpoint > self.positive_endpoint {
+            return Err(StimulusError::ReversedEndpoints {
+                negative: self.negative_endpoint,
+                positive: self.positive_endpoint,
+            });
+        }
+        if self.negative_endpoint == self.positive_endpoint {
+            return Err(StimulusError::ZeroSpan {
+                value: self.negative_endpoint,
+            });
+        }
+        if self.neutral <= self.negative_endpoint || self.neutral >= self.positive_endpoint {
+            return Err(StimulusError::NeutralOutsideEndpoints {
+                neutral: self.neutral,
+                negative: self.negative_endpoint,
+                positive: self.positive_endpoint,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Checks the complete physical meaning of one stimulus.
+pub(super) fn validate(
+    field: &str,
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: &StimulusEnvelope,
+) -> Result<(), ValidationError> {
+    text(
+        &format!("{field}.envelope.id"),
+        &envelope.id,
+        MAX_TEXT_BYTES,
+    )?;
+    let wrap = |source| ValidationError::InvalidStimulus {
+        field: field.to_owned(),
+        source,
+    };
+    envelope.validate_values().map_err(wrap)?;
+    combination::validate(family, channel, mapping, envelope).map_err(wrap)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-trial/src/scenario/stimulus/combination.rs
+++ b/crates/pilotage-trial/src/scenario/stimulus/combination.rs
@@ -1,0 +1,80 @@
+//! The permitted control family, channel, unit, and reference combinations.
+
+use super::{
+    ControlFamily, PhysicalUnit, ReferenceRule, StimulusEnvelope, StimulusError, StimulusMapping,
+};
+use crate::ControlChannel;
+
+/// Checks one stimulus against the permitted physical combinations.
+pub(super) fn validate(
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: &StimulusEnvelope,
+) -> Result<(), StimulusError> {
+    let (unit, reference) = required_physics(family, channel);
+    if envelope.unit != unit {
+        return Err(StimulusError::UnitMismatch {
+            family: family.as_str(),
+            channel: channel_name(channel),
+            expected: unit.as_str(),
+            actual: envelope.unit.as_str(),
+        });
+    }
+    if envelope.reference != reference {
+        return Err(StimulusError::ReferenceMismatch {
+            family: family.as_str(),
+            channel: channel_name(channel),
+            expected: reference.as_str(),
+            actual: envelope.reference.as_str(),
+        });
+    }
+    let required = family.mapping();
+    if mapping != required {
+        return Err(StimulusError::MappingMismatch {
+            family: family.as_str(),
+            expected: required.as_str(),
+            actual: mapping.as_str(),
+        });
+    }
+    Ok(())
+}
+
+/// Gets the one unit and reference rule that a family and channel permit.
+///
+/// The match is exhaustive over both enums, so a combination that this table
+/// does not name cannot exist.
+const fn required_physics(
+    family: ControlFamily,
+    channel: ControlChannel,
+) -> (PhysicalUnit, ReferenceRule) {
+    match (family, channel) {
+        (
+            ControlFamily::OperatorVelocity,
+            ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Vertical,
+        ) => (PhysicalUnit::MetersPerSecond, ReferenceRule::Zero),
+        (ControlFamily::OperatorVelocity, ControlChannel::Yaw) => {
+            (PhysicalUnit::RadiansPerSecond, ReferenceRule::Zero)
+        }
+        (
+            ControlFamily::DirectAttitudeThrust,
+            ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Yaw,
+        ) => (
+            PhysicalUnit::Radians,
+            ReferenceRule::EffectiveSetpointAtEntry,
+        ),
+        (ControlFamily::DirectAttitudeThrust, ControlChannel::Vertical) => (
+            PhysicalUnit::NormalizedCollectiveForce,
+            ReferenceRule::IdentifiedHoverTrim,
+        ),
+    }
+}
+
+const fn channel_name(channel: ControlChannel) -> &'static str {
+    match channel {
+        ControlChannel::Roll => "roll",
+        ControlChannel::Pitch => "pitch",
+        ControlChannel::Vertical => "vertical",
+        ControlChannel::Yaw => "yaw",
+    }
+}

--- a/crates/pilotage-trial/src/scenario/stimulus/error.rs
+++ b/crates/pilotage-trial/src/scenario/stimulus/error.rs
@@ -1,0 +1,84 @@
+//! Errors for the physical stimulus contract.
+
+use thiserror::Error;
+
+/// An error in the physical meaning of one stimulus.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum StimulusError {
+    /// An envelope endpoint or neutral value is not finite.
+    #[error("the {name} value must be finite")]
+    NonFiniteValue {
+        /// The envelope value name.
+        name: &'static str,
+    },
+    /// The negative endpoint is above the positive endpoint.
+    #[error("the negative endpoint {negative} is above the positive endpoint {positive}")]
+    ReversedEndpoints {
+        /// The negative endpoint.
+        negative: f64,
+        /// The positive endpoint.
+        positive: f64,
+    },
+    /// The two endpoints describe no physical span.
+    #[error("both endpoints are {value}, which is a zero physical span")]
+    ZeroSpan {
+        /// The value that both endpoints have.
+        value: f64,
+    },
+    /// The neutral value is not between the two endpoints.
+    #[error("the neutral value {neutral} must be between {negative} and {positive}")]
+    NeutralOutsideEndpoints {
+        /// The neutral value.
+        neutral: f64,
+        /// The negative endpoint.
+        negative: f64,
+        /// The positive endpoint.
+        positive: f64,
+    },
+    /// The physical unit does not belong to the control family and channel.
+    #[error("family {family} channel {channel} uses unit {expected}, not {actual}")]
+    UnitMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The control channel name.
+        channel: &'static str,
+        /// The unit that the combination requires.
+        expected: &'static str,
+        /// The supplied unit.
+        actual: &'static str,
+    },
+    /// The reference rule does not belong to the control family and channel.
+    #[error("family {family} channel {channel} uses reference {expected}, not {actual}")]
+    ReferenceMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The control channel name.
+        channel: &'static str,
+        /// The reference rule that the combination requires.
+        expected: &'static str,
+        /// The supplied reference rule.
+        actual: &'static str,
+    },
+    /// The mapping rule does not belong to the control family.
+    #[error("family {family} uses mapping {expected}, not {actual}")]
+    MappingMismatch {
+        /// The control family name.
+        family: &'static str,
+        /// The mapping rule that the family requires.
+        expected: &'static str,
+        /// The supplied mapping rule.
+        actual: &'static str,
+    },
+    /// The mapping rule resolves no exact value at authoring time.
+    #[error("mapping {mapping} needs a candidate feel profile to resolve one exact value")]
+    InexactMapping {
+        /// The mapping rule name.
+        mapping: &'static str,
+    },
+    /// A normalized value is outside minus one through plus one.
+    #[error("the normalized value {value} is outside minus one through plus one")]
+    NormalizedOutOfRange {
+        /// The supplied normalized value.
+        value: f64,
+    },
+}

--- a/crates/pilotage-trial/src/scenario/stimulus/tests.rs
+++ b/crates/pilotage-trial/src/scenario/stimulus/tests.rs
@@ -1,0 +1,403 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::*;
+use crate::{
+    BackendCapability, Comparison, Phase, PhaseAction, PhaseCondition, SCENARIO_SCHEMA_VERSION,
+    Scenario, Waveform,
+};
+
+fn operator_envelope(channel: ControlChannel) -> StimulusEnvelope {
+    let (unit, endpoint) = match channel {
+        ControlChannel::Yaw => (PhysicalUnit::RadiansPerSecond, 1.5),
+        _ => (PhysicalUnit::MetersPerSecond, 5.0),
+    };
+    StimulusEnvelope {
+        id: "alia250.operator".to_owned(),
+        revision: 1,
+        unit,
+        reference: ReferenceRule::Zero,
+        negative_endpoint: -endpoint,
+        neutral: 0.0,
+        positive_endpoint: endpoint,
+    }
+}
+
+fn direct_envelope(channel: ControlChannel) -> StimulusEnvelope {
+    match channel {
+        ControlChannel::Vertical => StimulusEnvelope {
+            id: "alia250.direct.collective".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::NormalizedCollectiveForce,
+            reference: ReferenceRule::IdentifiedHoverTrim,
+            negative_endpoint: -0.3,
+            neutral: 0.0,
+            positive_endpoint: 0.3,
+        },
+        _ => StimulusEnvelope {
+            id: "alia250.direct.attitude".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::Radians,
+            reference: ReferenceRule::EffectiveSetpointAtEntry,
+            negative_endpoint: -0.25,
+            neutral: 0.0,
+            positive_endpoint: 0.25,
+        },
+    }
+}
+
+fn envelope_for(family: ControlFamily, channel: ControlChannel) -> StimulusEnvelope {
+    match family {
+        ControlFamily::OperatorVelocity => operator_envelope(channel),
+        ControlFamily::DirectAttitudeThrust => direct_envelope(channel),
+    }
+}
+
+fn stimulus_scenario(
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: StimulusEnvelope,
+) -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "stimulus-identity".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "stimulus".to_owned(),
+            max_sim_time_ns: 2_000_000_000,
+            required_capabilities: vec![BackendCapability::SimulatorTime, family.capability()],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::Stimulus {
+                family,
+                channel,
+                mapping,
+                envelope,
+                waveform: Waveform::Pulse {
+                    value: 0.5,
+                    duration_ns: 500_000_000,
+                },
+            },
+            exit_conditions: vec![PhaseCondition::SimulatorTime {
+                comparison: Comparison::GreaterOrEqual,
+                value_ns: 1_000_000_000,
+            }],
+            abort_conditions: Vec::new(),
+        }],
+    }
+}
+
+fn valid_scenario(family: ControlFamily, channel: ControlChannel) -> Scenario {
+    stimulus_scenario(
+        family,
+        channel,
+        family.mapping(),
+        envelope_for(family, channel),
+    )
+}
+
+const FAMILIES: [ControlFamily; 2] = [
+    ControlFamily::OperatorVelocity,
+    ControlFamily::DirectAttitudeThrust,
+];
+
+const CHANNELS: [ControlChannel; 4] = [
+    ControlChannel::Roll,
+    ControlChannel::Pitch,
+    ControlChannel::Vertical,
+    ControlChannel::Yaw,
+];
+
+#[test]
+fn each_family_and_channel_has_a_canonical_round_trip() {
+    for family in FAMILIES {
+        for channel in CHANNELS {
+            let scenario = valid_scenario(family, channel);
+            let json = scenario
+                .to_canonical_json()
+                .unwrap_or_else(|error| panic!("{family:?} {channel:?} encodes: {error}"));
+            let decoded = Scenario::from_json(&json)
+                .unwrap_or_else(|error| panic!("{family:?} {channel:?} decodes: {error}"));
+            assert_eq!(decoded, scenario, "{family:?} {channel:?} round trip");
+        }
+    }
+}
+
+#[test]
+fn a_changed_family_changes_the_scenario_digest() {
+    let operator = valid_scenario(ControlFamily::OperatorVelocity, ControlChannel::Roll);
+    let direct = valid_scenario(ControlFamily::DirectAttitudeThrust, ControlChannel::Roll);
+
+    assert_ne!(
+        operator.canonical_digest().expect("operator digest"),
+        direct.canonical_digest().expect("direct digest")
+    );
+}
+
+#[test]
+fn a_changed_envelope_changes_both_digests() {
+    let scenario = valid_scenario(ControlFamily::OperatorVelocity, ControlChannel::Roll);
+    let base_scenario_digest = scenario.canonical_digest().expect("base scenario digest");
+    let base_envelope = operator_envelope(ControlChannel::Roll);
+    let base_envelope_digest = base_envelope
+        .canonical_digest()
+        .expect("base envelope digest");
+
+    let mut wider = base_envelope.clone();
+    wider.positive_endpoint = 6.0;
+    let mut revised = base_envelope.clone();
+    revised.revision = 2;
+
+    for changed in [wider, revised] {
+        assert_ne!(
+            base_envelope_digest,
+            changed.canonical_digest().expect("changed envelope digest")
+        );
+        let changed_scenario = stimulus_scenario(
+            ControlFamily::OperatorVelocity,
+            ControlChannel::Roll,
+            StimulusMapping::CandidateBoundCurve,
+            changed,
+        );
+        assert_ne!(
+            base_scenario_digest,
+            changed_scenario
+                .canonical_digest()
+                .expect("changed scenario digest")
+        );
+    }
+}
+
+#[test]
+fn a_unit_substitution_fails_validation() {
+    let mut envelope = operator_envelope(ControlChannel::Roll);
+    envelope.unit = PhysicalUnit::RadiansPerSecond;
+    let scenario = stimulus_scenario(
+        ControlFamily::OperatorVelocity,
+        ControlChannel::Roll,
+        StimulusMapping::CandidateBoundCurve,
+        envelope,
+    );
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::InvalidStimulus {
+            source: StimulusError::UnitMismatch {
+                expected: "meters_per_second",
+                actual: "radians_per_second",
+                ..
+            },
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_reference_substitution_fails_validation() {
+    let mut envelope = direct_envelope(ControlChannel::Vertical);
+    envelope.reference = ReferenceRule::Zero;
+    let scenario = stimulus_scenario(
+        ControlFamily::DirectAttitudeThrust,
+        ControlChannel::Vertical,
+        StimulusMapping::AffineExact,
+        envelope,
+    );
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::InvalidStimulus {
+            source: StimulusError::ReferenceMismatch {
+                expected: "identified_hover_trim",
+                actual: "zero",
+                ..
+            },
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_family_and_mapping_mismatch_fails_validation() {
+    let scenario = stimulus_scenario(
+        ControlFamily::OperatorVelocity,
+        ControlChannel::Roll,
+        StimulusMapping::AffineExact,
+        operator_envelope(ControlChannel::Roll),
+    );
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::InvalidStimulus {
+            source: StimulusError::MappingMismatch {
+                expected: "candidate_bound_curve",
+                actual: "affine_exact",
+                ..
+            },
+            ..
+        })
+    ));
+}
+
+#[test]
+fn an_invalid_envelope_shape_fails_validation() {
+    let base = direct_envelope(ControlChannel::Roll);
+    let mut reversed = base.clone();
+    reversed.negative_endpoint = 0.5;
+    let mut zero_span = base.clone();
+    zero_span.negative_endpoint = 0.0;
+    zero_span.positive_endpoint = 0.0;
+    let mut outside = base.clone();
+    outside.neutral = 0.25;
+    let mut infinite = base;
+    infinite.positive_endpoint = f64::INFINITY;
+
+    assert!(matches!(
+        reversed.validate_values(),
+        Err(StimulusError::ReversedEndpoints { .. })
+    ));
+    assert!(matches!(
+        zero_span.validate_values(),
+        Err(StimulusError::ZeroSpan { .. })
+    ));
+    assert!(matches!(
+        outside.validate_values(),
+        Err(StimulusError::NeutralOutsideEndpoints { .. })
+    ));
+    assert!(matches!(
+        infinite.validate_values(),
+        Err(StimulusError::NonFiniteValue {
+            name: "positive_endpoint"
+        })
+    ));
+}
+
+#[test]
+fn an_exact_mapping_resolves_two_affine_segments() {
+    let envelope = StimulusEnvelope {
+        id: "asymmetric.collective".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::NormalizedCollectiveForce,
+        reference: ReferenceRule::IdentifiedHoverTrim,
+        negative_endpoint: -0.2,
+        neutral: 0.1,
+        positive_endpoint: 0.5,
+    };
+
+    let mapping = StimulusMapping::AffineExact;
+    assert!((mapping.resolve_exact(&envelope, -1.0).expect("minimum") + 0.2).abs() < 1.0e-12);
+    assert!((mapping.resolve_exact(&envelope, 0.0).expect("neutral") - 0.1).abs() < 1.0e-12);
+    assert!((mapping.resolve_exact(&envelope, 1.0).expect("maximum") - 0.5).abs() < 1.0e-12);
+    assert!((mapping.resolve_exact(&envelope, -0.5).expect("half low") + 0.05).abs() < 1.0e-12);
+    assert!((mapping.resolve_exact(&envelope, 0.5).expect("half high") - 0.3).abs() < 1.0e-12);
+    assert!(matches!(
+        mapping.resolve_exact(&envelope, 1.5),
+        Err(StimulusError::NormalizedOutOfRange { .. })
+    ));
+}
+
+#[test]
+fn a_candidate_bound_mapping_resolves_no_exact_value() {
+    let envelope = operator_envelope(ControlChannel::Roll);
+
+    assert!(matches!(
+        StimulusMapping::CandidateBoundCurve.resolve_exact(&envelope, 0.5),
+        Err(StimulusError::InexactMapping {
+            mapping: "candidate_bound_curve"
+        })
+    ));
+}
+
+#[test]
+fn a_stimulus_phase_must_declare_its_family_capability() {
+    let mut scenario = valid_scenario(ControlFamily::DirectAttitudeThrust, ControlChannel::Yaw);
+    scenario.phases[0].required_capabilities = vec![
+        BackendCapability::SimulatorTime,
+        BackendCapability::OperatorVelocityControl,
+    ];
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::UnsupportedCapability { .. })
+    ));
+}
+
+#[test]
+fn a_document_without_a_family_fails_decode() {
+    let scenario = valid_scenario(ControlFamily::OperatorVelocity, ControlChannel::Pitch);
+    let json = scenario.to_canonical_json().expect("scenario JSON");
+    let mut document: serde_json::Value = serde_json::from_slice(&json).expect("JSON value");
+    let action = document["phases"][0]["action"]
+        .as_object_mut()
+        .expect("action object");
+    assert_eq!(action["family"], "operator_velocity");
+    action.remove("family");
+    let without_family = serde_json::to_vec(&document).expect("missing-family JSON");
+
+    assert!(Scenario::from_json(&without_family).is_err());
+}
+
+#[test]
+fn an_envelope_rejects_an_unknown_field_and_an_unknown_enum_value() {
+    let scenario = valid_scenario(ControlFamily::OperatorVelocity, ControlChannel::Vertical);
+    let json = scenario.to_canonical_json().expect("scenario JSON");
+    let mut extra: serde_json::Value = serde_json::from_slice(&json).expect("JSON value");
+    extra["phases"][0]["action"]["envelope"]["hover_trim"] = serde_json::json!(0.5);
+    let mut unknown_unit: serde_json::Value = serde_json::from_slice(&json).expect("JSON value");
+    unknown_unit["phases"][0]["action"]["envelope"]["unit"] = serde_json::json!("knots");
+
+    assert!(
+        Scenario::from_json(&serde_json::to_vec(&extra).expect("extra JSON")).is_err(),
+        "an unknown envelope field is refused"
+    );
+    assert!(
+        Scenario::from_json(&serde_json::to_vec(&unknown_unit).expect("unit JSON")).is_err(),
+        "an unknown unit is refused"
+    );
+}
+
+#[test]
+fn a_second_vehicle_uses_its_own_valid_envelope() {
+    let x500 = StimulusEnvelope {
+        id: "x500.operator.vertical".to_owned(),
+        revision: 3,
+        unit: PhysicalUnit::MetersPerSecond,
+        reference: ReferenceRule::Zero,
+        negative_endpoint: -2.5,
+        neutral: 0.0,
+        positive_endpoint: 1.5,
+    };
+    let alia = operator_envelope(ControlChannel::Vertical);
+    let scenario = stimulus_scenario(
+        ControlFamily::OperatorVelocity,
+        ControlChannel::Vertical,
+        StimulusMapping::CandidateBoundCurve,
+        x500.clone(),
+    );
+
+    assert!(scenario.validate().is_ok());
+    assert_ne!(
+        x500.canonical_digest().expect("second vehicle digest"),
+        alia.canonical_digest().expect("first vehicle digest")
+    );
+    let json = scenario.to_canonical_json().expect("scenario JSON");
+    assert_eq!(
+        Scenario::from_json(&json).expect("scenario decode"),
+        scenario
+    );
+}
+
+#[test]
+fn a_waveform_value_outside_the_normalized_range_fails_validation() {
+    let mut scenario = valid_scenario(ControlFamily::OperatorVelocity, ControlChannel::Roll);
+    scenario.phases[0].action = PhaseAction::Stimulus {
+        family: ControlFamily::OperatorVelocity,
+        channel: ControlChannel::Roll,
+        mapping: StimulusMapping::CandidateBoundCurve,
+        envelope: operator_envelope(ControlChannel::Roll),
+        waveform: Waveform::Step { value: 1.5 },
+    };
+
+    assert!(matches!(
+        scenario.validate(),
+        Err(ValidationError::OutOfRange { .. })
+    ));
+}

--- a/crates/pilotage-trial/src/scenario/tests.rs
+++ b/crates/pilotage-trial/src/scenario/tests.rs
@@ -234,10 +234,24 @@ fn a_multisine_rejects_an_excessive_composed_envelope() {
         phases: vec![Phase {
             id: "stimulus".to_owned(),
             max_sim_time_ns: 1_000_000_000,
-            required_capabilities: vec![BackendCapability::SimulatorTime],
+            required_capabilities: vec![
+                BackendCapability::SimulatorTime,
+                BackendCapability::OperatorVelocityControl,
+            ],
             entry_conditions: vec![PhaseCondition::Always],
             action: PhaseAction::Stimulus {
+                family: ControlFamily::OperatorVelocity,
                 channel: ControlChannel::Roll,
+                mapping: StimulusMapping::CandidateBoundCurve,
+                envelope: StimulusEnvelope {
+                    id: "bounded-multisine.roll".to_owned(),
+                    revision: 1,
+                    unit: PhysicalUnit::MetersPerSecond,
+                    reference: ReferenceRule::Zero,
+                    negative_endpoint: -4.0,
+                    neutral: 0.0,
+                    positive_endpoint: 4.0,
+                },
                 waveform,
             },
             exit_conditions: vec![PhaseCondition::Always],

--- a/crates/pilotage-tuning-feedback/src/qualification/stage.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/stage.rs
@@ -12,7 +12,7 @@ const MAX_SCENARIOS_PER_SET: usize = 64;
 /// they bound the same set of measured objectives.
 const MAX_POLICY_OBJECTIVES: usize = 64;
 const PROMOTION_POLICY_SCHEMA_VERSION: u16 = 1;
-const MISSION_SCHEMA_VERSION: u16 = 2;
+const MISSION_SCHEMA_VERSION: u16 = 3;
 const MAX_SAMPLE_TIMEOUT_NS: u64 = 60_000_000_000;
 
 pub(super) fn verify(stage: &SearchStage) -> Result<(), FeedbackError> {

--- a/crates/pilotage-tuning-feedback/src/qualification/tests.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests.rs
@@ -113,7 +113,7 @@ fn canonical_source_digest_is_fixed() {
         .expect("verify evidence");
     assert_eq!(
         verified.source_digest().to_string(),
-        "ee78d67d92f0e51cdbd55b37f54e45e46ab3480744f679956ef32bddc39ca79d"
+        "e043cdad5f47a68208c6f6191833379bf97a73e51a10efe8affeb0df4bb529e7"
     );
 }
 

--- a/tools/flight-tune-aviate/src/action_port.rs
+++ b/tools/flight-tune-aviate/src/action_port.rs
@@ -1,8 +1,9 @@
 use flight_tune::{
-    ArtifactIdentity, ControlChannel, Digest, DirectiveContext, FlightAction, MissionCapability,
-    MissionDirective, MissionDocument, ReceiptResult, RunExecutionContext, ScenarioFrame,
-    ScenarioObservationReceipt, ScenarioRuntime, ScenarioRuntimeError, ScenarioStopContext,
-    StartState, TrialAction, TuneError, Waveform, scenario_runtime_identity,
+    ArtifactIdentity, ControlChannel, ControlFamily, Digest, DirectiveContext, FlightAction,
+    MissionCapability, MissionDirective, MissionDocument, ReceiptResult, RunExecutionContext,
+    ScenarioFrame, ScenarioObservationReceipt, ScenarioRuntime, ScenarioRuntimeError,
+    ScenarioStopContext, StartState, StimulusEnvelope, StimulusMapping, TrialAction, TuneError,
+    Waveform, scenario_runtime_identity,
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
@@ -31,8 +32,14 @@ pub enum AviateVehicleAction {
     Settle,
     /// Apply one typed control stimulus.
     Stimulate {
+        /// The physical control family that the stimulus commands.
+        family: ControlFamily,
         /// The control channel.
         channel: ControlChannel,
+        /// The rule that resolves a normalized value to a physical command.
+        mapping: StimulusMapping,
+        /// The versioned physical envelope of the normalized range.
+        envelope: StimulusEnvelope,
         /// The stimulus waveform.
         waveform: Waveform,
     },
@@ -249,7 +256,7 @@ fn project_vehicle_directive(
                 FlightAction::Disarm {} => AviateVehicleAction::Disarm,
                 FlightAction::Climb { .. }
                 | FlightAction::FollowPlan { .. }
-                | FlightAction::Hold {}
+                | FlightAction::MaintainTarget {}
                 | FlightAction::Land {} => return Err(refused("unsupported operational action")),
             };
             (directive.context.clone(), action)
@@ -264,8 +271,17 @@ fn project_vehicle_directive(
                     AviateVehicleAction::ReachStartState { target: *target }
                 }
                 TrialAction::Settle {} => AviateVehicleAction::Settle,
-                TrialAction::Stimulate { channel, waveform } => AviateVehicleAction::Stimulate {
+                TrialAction::Stimulate {
+                    family,
+                    channel,
+                    mapping,
+                    envelope,
+                    waveform,
+                } => AviateVehicleAction::Stimulate {
+                    family: *family,
                     channel: *channel,
+                    mapping: *mapping,
+                    envelope: envelope.clone(),
                     waveform: waveform.clone(),
                 },
                 TrialAction::ReleaseControl {} => AviateVehicleAction::ReleaseControl,

--- a/tools/flight-tune-aviate/src/action_port/tests.rs
+++ b/tools/flight-tune-aviate/src/action_port/tests.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::expect_used)]
+#![allow(clippy::expect_used, clippy::panic)]
 
 use std::collections::BTreeMap;
 
@@ -100,6 +100,73 @@ fn port_preserves_the_typed_directive_and_frame_sequence() {
     assert_eq!(projected.len(), 1);
     assert_eq!(projected[0].context, directive.context().clone());
     assert_eq!(projected[0].action, AviateVehicleAction::Observe);
+}
+
+#[test]
+fn the_port_carries_the_typed_control_family_and_envelope_to_the_driver() {
+    let driver_identity = ArtifactIdentity::new("aviate-driver", Digest::from_bytes([7; 32]))
+        .expect("driver identity");
+    let mut port = AviateVehicleActionPort::new(RecordingDriver {
+        identity: driver_identity,
+        directives: Vec::new(),
+    })
+    .expect("action port");
+    let directive: MissionDirective = serde_json::from_value(serde_json::json!({
+        "lane": "trial",
+        "directive": {
+            "context": {
+                "action_id": 4,
+                "phase_index": 0,
+                "phase_id": "stimulus",
+                "attempt": 1,
+                "purpose": { "purpose": "phase_action" }
+            },
+            "action": {
+                "kind": "stimulate",
+                "family": "direct_attitude_thrust",
+                "channel": "vertical",
+                "mapping": "affine_exact",
+                "envelope": {
+                    "id": "alia250.direct.collective",
+                    "revision": 2,
+                    "unit": "normalized_collective_force",
+                    "reference": "identified_hover_trim",
+                    "negative_endpoint": -0.2,
+                    "neutral": 0.05,
+                    "positive_endpoint": 0.4
+                },
+                "waveform": { "kind": "step", "value": 0.5 }
+            }
+        }
+    }))
+    .expect("typed stimulus directive");
+
+    let receipt = ScenarioRuntime::observe_blocking(&mut port, &frame(21), Some(&directive))
+        .expect("observe directive");
+
+    assert_eq!(receipt.action_result, Some(ReceiptResult::Succeeded {}));
+    let projected = port.into_inner().directives;
+    let AviateVehicleAction::Stimulate {
+        family,
+        channel,
+        mapping,
+        envelope,
+        ..
+    } = &projected[0].action
+    else {
+        panic!("the port must carry the stimulus to the driver");
+    };
+    assert_eq!(*family, ControlFamily::DirectAttitudeThrust);
+    assert_eq!(*channel, ControlChannel::Vertical);
+    assert_eq!(*mapping, StimulusMapping::AffineExact);
+    assert!(
+        (mapping
+            .resolve_exact(envelope, 1.0)
+            .expect("resolve the positive endpoint")
+            - 0.4)
+            .abs()
+            < 1.0e-12
+    );
 }
 
 #[test]

--- a/tools/flight-tune-xplane/src/runtime/tests.rs
+++ b/tools/flight-tune-xplane/src/runtime/tests.rs
@@ -5,7 +5,8 @@ use pilotage_mission_core::{
     NavigationDataIdentity, ReceiptResult, WallDeadline,
 };
 use pilotage_trial::{
-    BackendCapability, Phase, PhaseAction, PhaseCondition, SCENARIO_SCHEMA_VERSION, Scenario,
+    BackendCapability, ControlChannel, ControlFamily, Phase, PhaseAction, PhaseCondition,
+    PhysicalUnit, ReferenceRule, SCENARIO_SCHEMA_VERSION, Scenario, StimulusEnvelope, Waveform,
 };
 
 use super::*;
@@ -17,6 +18,23 @@ use flight_tune::{
 
 struct RecordingRuntime {
     identity: ArtifactIdentity,
+    capabilities: Vec<MissionCapability>,
+    prepare_count: u32,
+}
+
+impl RecordingRuntime {
+    fn new(identity: ArtifactIdentity) -> Self {
+        Self {
+            identity,
+            capabilities: vec![MissionCapability::SimulatorTime],
+            prepare_count: 0,
+        }
+    }
+
+    fn with_capability(mut self, capability: MissionCapability) -> Self {
+        self.capabilities.push(capability);
+        self
+    }
 }
 
 #[derive(Default)]
@@ -45,7 +63,7 @@ impl ScenarioRuntime for RecordingRuntime {
     }
 
     fn capabilities(&self) -> &[MissionCapability] {
-        &[MissionCapability::SimulatorTime]
+        &self.capabilities
     }
 
     fn prepare_blocking(
@@ -53,6 +71,7 @@ impl ScenarioRuntime for RecordingRuntime {
         _document: &pilotage_mission_core::MissionDocument,
         _context: &RunExecutionContext,
     ) -> Result<(), ScenarioRuntimeError> {
+        self.prepare_count = self.prepare_count.wrapping_add(1);
         Ok(())
     }
 
@@ -106,9 +125,7 @@ fn reference_and_xplane_frames_produce_the_same_directives() {
         flight_tune::Digest::from_bytes([7; 32]),
     )
     .expect("runtime identity");
-    let mut reference_port = RecordingRuntime {
-        identity: identity.clone(),
-    };
+    let mut reference_port = RecordingRuntime::new(identity.clone());
     let mut reference = CampaignMissionRuntime::start_blocking(
         document.clone(),
         start(&document),
@@ -117,9 +134,7 @@ fn reference_and_xplane_frames_produce_the_same_directives() {
         &context(),
     )
     .expect("reference runtime");
-    let mut xplane_port = RecordingRuntime {
-        identity: identity.clone(),
-    };
+    let mut xplane_port = RecordingRuntime::new(identity.clone());
     let mut xplane = CampaignMissionRuntime::start_blocking(
         document.clone(),
         start(&document),
@@ -150,7 +165,7 @@ fn reference_and_xplane_frames_produce_the_same_directives() {
 fn xplane_dispatches_reset_without_sending_it_to_the_vehicle_port() {
     let identity =
         ArtifactIdentity::new("runtime", Digest::from_bytes([7; 32])).expect("runtime identity");
-    let vehicle = RecordingRuntime { identity };
+    let vehicle = RecordingRuntime::new(identity);
     let mut runtime = XPlaneScenarioRuntime::new(RecordingSimulatorActions::default(), vehicle);
     let directive: MissionDirective = serde_json::from_value(serde_json::json!({
         "lane": "trial",
@@ -174,6 +189,51 @@ fn xplane_dispatches_reset_without_sending_it_to_the_vehicle_port() {
 
     assert_eq!(receipt.action_result, Some(ReceiptResult::Succeeded {}));
     assert_eq!(simulator.actions, vec![XPlaneSimulatorAction::Reset]);
+}
+
+#[test]
+fn a_composed_runtime_admits_only_the_control_family_that_it_declares() {
+    let identity =
+        ArtifactIdentity::new("runtime", Digest::from_bytes([7; 32])).expect("runtime identity");
+    let vehicle = RecordingRuntime::new(identity.clone())
+        .with_capability(MissionCapability::OperatorVelocityControl);
+    let mut runtime = XPlaneScenarioRuntime::new(RecordingSimulatorActions::default(), vehicle);
+    let operator = mission_document_from_scenario(
+        &stimulus_scenario(ControlFamily::OperatorVelocity),
+        navigation(),
+        0,
+        1_000_000_000,
+    )
+    .expect("operator document");
+    let direct = mission_document_from_scenario(
+        &stimulus_scenario(ControlFamily::DirectAttitudeThrust),
+        navigation(),
+        0,
+        1_000_000_000,
+    )
+    .expect("direct document");
+
+    CampaignMissionRuntime::attest_capabilities(&operator, &runtime)
+        .expect("the declared operator family is admitted");
+    let refused = CampaignMissionRuntime::start_blocking(
+        direct.clone(),
+        start(&direct),
+        &identity,
+        &mut runtime,
+        &context(),
+    )
+    .map(|_| ());
+
+    assert!(matches!(
+        refused,
+        Err(ScenarioRuntimeError::MissingCapability {
+            capability: MissionCapability::DirectAttitudeThrustControl,
+            ..
+        })
+    ));
+    let (simulator, vehicle) = runtime.into_inner();
+    assert_eq!(vehicle.prepare_count, 0);
+    assert!(simulator.actions.is_empty());
 }
 
 #[test]
@@ -205,6 +265,49 @@ fn rejected_frame_does_not_latch_the_run_origin() {
         .expect("valid frame");
 
     assert_eq!(accepted.truth.position_ned_m, [0.0; 3]);
+}
+
+fn stimulus_scenario(family: ControlFamily) -> Scenario {
+    let envelope = match family {
+        ControlFamily::OperatorVelocity => StimulusEnvelope {
+            id: "conformance.operator.roll".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::MetersPerSecond,
+            reference: ReferenceRule::Zero,
+            negative_endpoint: -3.0,
+            neutral: 0.0,
+            positive_endpoint: 3.0,
+        },
+        ControlFamily::DirectAttitudeThrust => StimulusEnvelope {
+            id: "conformance.direct.roll".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::Radians,
+            reference: ReferenceRule::EffectiveSetpointAtEntry,
+            negative_endpoint: -0.2,
+            neutral: 0.0,
+            positive_endpoint: 0.2,
+        },
+    };
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "family-admission".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "stimulus".to_owned(),
+            max_sim_time_ns: 2_000_000_000,
+            required_capabilities: vec![BackendCapability::SimulatorTime, family.capability()],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::Stimulus {
+                family,
+                channel: ControlChannel::Roll,
+                mapping: family.mapping(),
+                envelope,
+                waveform: Waveform::Step { value: 0.4 },
+            },
+            exit_conditions: vec![PhaseCondition::Always],
+            abort_conditions: Vec::new(),
+        }],
+    }
 }
 
 fn sample(sequence: u64) -> XPlaneTruthSample {

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -65,9 +65,10 @@ pub use model::{
     promotion_policy_digest,
 };
 pub use pilotage_mission_core::{
-    ArtifactIdentity as MissionArtifactIdentity, ControlChannel, DirectiveContext, FlightAction,
-    MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective, MissionDocument, ObservedSignal,
-    ReceiptResult, StartState, TrialAction, VehicleLifecycleState, Waveform,
+    ArtifactIdentity as MissionArtifactIdentity, ControlChannel, ControlFamily, DirectiveContext,
+    FlightAction, MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective, MissionDocument,
+    ObservedSignal, PhysicalUnit, ReceiptResult, ReferenceRule, StartState, StimulusEnvelope,
+    StimulusError, StimulusMapping, TrialAction, VehicleLifecycleState, Waveform,
 };
 pub use pilotage_trial::{Digest, Scenario as TrialScenario};
 pub use run_context::{RUN_EXECUTION_CONTEXT_SCHEMA_VERSION, RunExecutionContext};

--- a/tools/flight-tune/src/scenario_runtime/document.rs
+++ b/tools/flight-tune/src/scenario_runtime/document.rs
@@ -107,9 +107,7 @@ fn project_phase(phase: &pilotage_trial::Phase) -> Result<MissionPhase, Scenario
         transcode(&phase.required_capabilities)?;
     if matches!(
         &action,
-        MissionAction::Trial(
-            TrialAction::Stimulate { .. } | TrialAction::ReleaseControl {} | TrialAction::Stop {}
-        )
+        MissionAction::Trial(TrialAction::ReleaseControl {} | TrialAction::Stop {})
     ) && !required_capabilities.contains(&MissionCapability::SimulatorControl)
     {
         required_capabilities.push(MissionCapability::SimulatorControl);
@@ -201,8 +199,17 @@ fn project_action(action: &PhaseAction) -> Result<MissionAction, ScenarioRuntime
             target: transcode(target)?,
         },
         PhaseAction::Settle => TrialAction::Settle {},
-        PhaseAction::Stimulus { channel, waveform } => TrialAction::Stimulate {
+        PhaseAction::Stimulus {
+            family,
+            channel,
+            mapping,
+            envelope,
+            waveform,
+        } => TrialAction::Stimulate {
+            family: transcode(family)?,
             channel: transcode(channel)?,
+            mapping: transcode(mapping)?,
+            envelope: transcode(envelope)?,
             waveform: transcode(waveform)?,
         },
         PhaseAction::ReleaseControl => TrialAction::ReleaseControl {},

--- a/tools/flight-tune/src/scenario_runtime/tests.rs
+++ b/tools/flight-tune/src/scenario_runtime/tests.rs
@@ -1,17 +1,15 @@
-#![allow(clippy::expect_used)]
+#![allow(clippy::expect_used, clippy::panic)]
 
 use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use pilotage_mission_core::{
-    Digest as MissionDigest, EngineStart, EngineState, ExecutionTarget, MissionAction,
-    MissionCapability, MissionDirective, NavigationDataIdentity, ReceiptResult, TrialAction,
-    WallDeadline,
+    Digest as MissionDigest, EngineStart, EngineState, ExecutionTarget, MissionCapability,
+    MissionDirective, NavigationDataIdentity, ReceiptResult, WallDeadline,
 };
 use pilotage_trial::{
-    BackendCapability, Comparison, ControlChannel, Phase, PhaseAction, PhaseCondition,
-    SCENARIO_SCHEMA_VERSION, Scenario, Waveform,
+    BackendCapability, Phase, PhaseAction, PhaseCondition, SCENARIO_SCHEMA_VERSION, Scenario,
 };
 
 use super::*;
@@ -26,6 +24,7 @@ mod source_identity;
 #[derive(Default)]
 struct ReferenceRuntime {
     identity: Option<ArtifactIdentity>,
+    capabilities: Vec<MissionCapability>,
     prepared: bool,
     started: bool,
     directives: Vec<MissionDirective>,
@@ -39,16 +38,21 @@ impl ReferenceRuntime {
     fn new(identity: ArtifactIdentity) -> Self {
         Self {
             identity: Some(identity),
+            capabilities: vec![MissionCapability::SimulatorTime],
             ..Self::default()
         }
     }
 
     fn tracked(identity: ArtifactIdentity, mutations: Rc<Cell<u32>>) -> Self {
         Self {
-            identity: Some(identity),
             mutations: Some(mutations),
-            ..Self::default()
+            ..Self::new(identity)
         }
+    }
+
+    fn with_capability(mut self, capability: MissionCapability) -> Self {
+        self.capabilities.push(capability);
+        self
     }
 }
 
@@ -58,7 +62,7 @@ impl ScenarioRuntime for ReferenceRuntime {
     }
 
     fn capabilities(&self) -> &[MissionCapability] {
-        &[MissionCapability::SimulatorTime]
+        &self.capabilities
     }
 
     fn prepare_blocking(
@@ -169,40 +173,7 @@ fn identity_mismatch_precedes_action_port_mutation() {
     assert_eq!(mutations.get(), 0);
 }
 
-#[test]
-fn unsupported_capability_precedes_action_port_mutation() {
-    let mut scenario = one_phase_scenario();
-    scenario.phases[0].action = PhaseAction::Stimulus {
-        channel: ControlChannel::Roll,
-        waveform: Waveform::Pulse {
-            value: 0.25,
-            duration_ns: 1,
-        },
-    };
-    let document = mission_document_from_scenario(&scenario, navigation(), 0, 1_000_000)
-        .expect("project scenario");
-    let identity =
-        ArtifactIdentity::new("runtime", Digest::from_bytes([9; 32])).expect("runtime identity");
-    let mutations = Rc::new(Cell::new(0));
-    let mut action_port = ReferenceRuntime::tracked(identity.clone(), mutations.clone());
-
-    let result = CampaignMissionRuntime::start_blocking(
-        document.clone(),
-        start(&document),
-        &identity,
-        &mut action_port,
-        &context(),
-    );
-
-    assert!(matches!(
-        result,
-        Err(ScenarioRuntimeError::MissingCapability {
-            capability: MissionCapability::SimulatorControl,
-            ..
-        })
-    ));
-    assert_eq!(mutations.get(), 0);
-}
+mod stimulus;
 
 #[test]
 fn uncertain_start_failure_stops_and_cleans_the_action_port() {
@@ -317,46 +288,6 @@ fn production_identity_changes_for_engine_input_and_ignores_test_input() {
             source_identity::digest_named_for_test(&changed).expect("production identity")
         );
     }
-}
-
-#[test]
-fn projection_adds_the_neutral_simulator_control_capability() {
-    let scenario = Scenario {
-        schema_version: SCENARIO_SCHEMA_VERSION,
-        id: "stimulus-scenario".to_owned(),
-        revision: 1,
-        phases: vec![Phase {
-            id: "stimulus".to_owned(),
-            max_sim_time_ns: 2_000_000,
-            required_capabilities: vec![BackendCapability::SimulatorTime],
-            entry_conditions: vec![PhaseCondition::Always],
-            action: PhaseAction::Stimulus {
-                channel: ControlChannel::Roll,
-                waveform: Waveform::Pulse {
-                    value: 0.25,
-                    duration_ns: 1_000_000,
-                },
-            },
-            exit_conditions: vec![PhaseCondition::SimulatorTime {
-                comparison: Comparison::GreaterOrEqual,
-                value_ns: 1_000_000,
-            }],
-            abort_conditions: Vec::new(),
-        }],
-    };
-
-    let document = mission_document_from_scenario(&scenario, navigation(), 0, 1_000_000)
-        .expect("project stimulus");
-
-    assert!(
-        document.phases[0]
-            .required_capabilities
-            .contains(&MissionCapability::SimulatorControl)
-    );
-    assert!(matches!(
-        document.phases[0].action,
-        MissionAction::Trial(TrialAction::Stimulate { .. })
-    ));
 }
 
 fn one_phase_scenario() -> Scenario {

--- a/tools/flight-tune/src/scenario_runtime/tests/stimulus.rs
+++ b/tools/flight-tune/src/scenario_runtime/tests/stimulus.rs
@@ -1,0 +1,225 @@
+//! Control-family admission and projection checks.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use pilotage_mission_core::{MissionAction, MissionCapability, TrialAction};
+use pilotage_trial::{
+    BackendCapability, Comparison, ControlChannel, ControlFamily, Phase, PhaseAction,
+    PhaseCondition, PhysicalUnit, ReferenceRule, SCENARIO_SCHEMA_VERSION, Scenario,
+    StimulusEnvelope, Waveform,
+};
+
+use super::{
+    CampaignMissionRuntime, ReferenceRuntime, ScenarioRuntimeError, context,
+    mission_document_from_scenario, navigation, start,
+};
+use crate::{ArtifactIdentity, Digest};
+
+#[test]
+fn an_unsupported_control_family_precedes_action_port_mutation() {
+    for (family, capability) in [
+        (
+            ControlFamily::OperatorVelocity,
+            MissionCapability::OperatorVelocityControl,
+        ),
+        (
+            ControlFamily::DirectAttitudeThrust,
+            MissionCapability::DirectAttitudeThrustControl,
+        ),
+    ] {
+        let document = mission_document_from_scenario(
+            &stimulus_scenario(family, ControlChannel::Roll),
+            navigation(),
+            0,
+            1_000_000,
+        )
+        .expect("project scenario");
+        let identity = ArtifactIdentity::new("runtime", Digest::from_bytes([9; 32]))
+            .expect("runtime identity");
+        let mutations = Rc::new(Cell::new(0));
+        let mut action_port = ReferenceRuntime::tracked(identity.clone(), mutations.clone())
+            .with_capability(MissionCapability::SimulatorControl);
+
+        let result = CampaignMissionRuntime::start_blocking(
+            document.clone(),
+            start(&document),
+            &identity,
+            &mut action_port,
+            &context(),
+        );
+
+        match result.map(|_| ()) {
+            Err(ScenarioRuntimeError::MissingCapability {
+                capability: missing,
+                ..
+            }) => assert_eq!(missing, capability),
+            other => panic!("{family:?} must be refused before mutation: {other:?}"),
+        }
+        assert_eq!(mutations.get(), 0);
+    }
+}
+
+#[test]
+fn a_generic_runtime_admits_each_declared_control_family() {
+    for (family, capability) in [
+        (
+            ControlFamily::OperatorVelocity,
+            MissionCapability::OperatorVelocityControl,
+        ),
+        (
+            ControlFamily::DirectAttitudeThrust,
+            MissionCapability::DirectAttitudeThrustControl,
+        ),
+    ] {
+        let document = mission_document_from_scenario(
+            &stimulus_scenario(family, ControlChannel::Yaw),
+            navigation(),
+            0,
+            1_000_000,
+        )
+        .expect("project scenario");
+        let identity = ArtifactIdentity::new("runtime", Digest::from_bytes([9; 32]))
+            .expect("runtime identity");
+        let action_port = ReferenceRuntime::new(identity).with_capability(capability);
+
+        CampaignMissionRuntime::attest_capabilities(&document, &action_port)
+            .unwrap_or_else(|error| panic!("{family:?} must be admitted: {error}"));
+    }
+}
+
+#[test]
+fn projection_carries_the_control_family_and_envelope_without_loss() {
+    let scenario = stimulus_scenario(
+        ControlFamily::DirectAttitudeThrust,
+        ControlChannel::Vertical,
+    );
+    let authored = trial_envelope(
+        ControlFamily::DirectAttitudeThrust,
+        ControlChannel::Vertical,
+    );
+
+    let document = mission_document_from_scenario(&scenario, navigation(), 0, 1_000_000)
+        .expect("project stimulus");
+
+    assert!(
+        document.phases[0]
+            .required_capabilities
+            .contains(&MissionCapability::DirectAttitudeThrustControl)
+    );
+    let MissionAction::Trial(TrialAction::Stimulate {
+        family,
+        channel,
+        mapping,
+        envelope,
+        ..
+    }) = &document.phases[0].action
+    else {
+        panic!("the projection must keep the stimulate action");
+    };
+    assert_eq!(
+        *family,
+        pilotage_mission_core::ControlFamily::DirectAttitudeThrust
+    );
+    assert_eq!(*channel, pilotage_mission_core::ControlChannel::Vertical);
+    assert_eq!(
+        *mapping,
+        pilotage_mission_core::StimulusMapping::AffineExact
+    );
+    assert_eq!(
+        envelope
+            .canonical_digest()
+            .expect("document envelope digest")
+            .as_bytes(),
+        authored
+            .canonical_digest()
+            .expect("authored envelope digest")
+            .as_bytes(),
+        "the projection keeps the envelope identity"
+    );
+}
+
+#[test]
+fn a_stimulus_phase_does_not_gain_the_neutral_simulator_control_capability() {
+    let scenario = stimulus_scenario(ControlFamily::OperatorVelocity, ControlChannel::Pitch);
+
+    let document = mission_document_from_scenario(&scenario, navigation(), 0, 1_000_000)
+        .expect("project stimulus");
+
+    assert!(
+        !document.phases[0]
+            .required_capabilities
+            .contains(&MissionCapability::SimulatorControl),
+        "the family capability replaces the neutral simulator-control capability"
+    );
+}
+
+fn trial_envelope(family: ControlFamily, channel: ControlChannel) -> StimulusEnvelope {
+    match (family, channel) {
+        (ControlFamily::OperatorVelocity, ControlChannel::Yaw) => StimulusEnvelope {
+            id: "reference.operator.yaw".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::RadiansPerSecond,
+            reference: ReferenceRule::Zero,
+            negative_endpoint: -1.2,
+            neutral: 0.0,
+            positive_endpoint: 1.2,
+        },
+        (ControlFamily::OperatorVelocity, _) => StimulusEnvelope {
+            id: "reference.operator.linear".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::MetersPerSecond,
+            reference: ReferenceRule::Zero,
+            negative_endpoint: -4.0,
+            neutral: 0.0,
+            positive_endpoint: 4.0,
+        },
+        (ControlFamily::DirectAttitudeThrust, ControlChannel::Vertical) => StimulusEnvelope {
+            id: "reference.direct.collective".to_owned(),
+            revision: 2,
+            unit: PhysicalUnit::NormalizedCollectiveForce,
+            reference: ReferenceRule::IdentifiedHoverTrim,
+            negative_endpoint: -0.2,
+            neutral: 0.05,
+            positive_endpoint: 0.4,
+        },
+        (ControlFamily::DirectAttitudeThrust, _) => StimulusEnvelope {
+            id: "reference.direct.attitude".to_owned(),
+            revision: 1,
+            unit: PhysicalUnit::Radians,
+            reference: ReferenceRule::EffectiveSetpointAtEntry,
+            negative_endpoint: -0.3,
+            neutral: 0.0,
+            positive_endpoint: 0.3,
+        },
+    }
+}
+
+fn stimulus_scenario(family: ControlFamily, channel: ControlChannel) -> Scenario {
+    Scenario {
+        schema_version: SCENARIO_SCHEMA_VERSION,
+        id: "stimulus-scenario".to_owned(),
+        revision: 1,
+        phases: vec![Phase {
+            id: "stimulus".to_owned(),
+            max_sim_time_ns: 2_000_000,
+            required_capabilities: vec![BackendCapability::SimulatorTime, family.capability()],
+            entry_conditions: vec![PhaseCondition::Always],
+            action: PhaseAction::Stimulus {
+                family,
+                channel,
+                mapping: family.mapping(),
+                envelope: trial_envelope(family, channel),
+                waveform: Waveform::Pulse {
+                    value: 0.25,
+                    duration_ns: 1_000_000,
+                },
+            },
+            exit_conditions: vec![PhaseCondition::SimulatorTime {
+                comparison: Comparison::GreaterOrEqual,
+                value_ns: 1_000_000,
+            }],
+            abort_conditions: Vec::new(),
+        }],
+    }
+}

--- a/tools/flight-tune/tests/tuner/orphan_baseline.rs
+++ b/tools/flight-tune/tests/tuner/orphan_baseline.rs
@@ -1,8 +1,8 @@
 use std::fs;
 
 use flight_tune::{
-    AttemptRole, Digest, JournalEntry, JournalEvent, SearchStage, SimulatorVehicleFactory,
-    TuneError, Tuner, scenario_runtime_identity,
+    AttemptRole, ControlFamily, Digest, JournalEntry, JournalEvent, SearchStage,
+    SimulatorVehicleFactory, TuneError, Tuner, scenario_runtime_identity,
 };
 use serde::Deserialize;
 
@@ -10,6 +10,7 @@ use super::TestTuner;
 use super::test_rig::{
     EnvelopeGates, FakeBackend, FakeFactory, FakeHandle, QuadraticMetric, SequenceStrategy,
     TestDirectory, candidate, stage, stage_with_changed_training_mission,
+    stage_with_stimulus_family,
 };
 
 #[test]
@@ -136,6 +137,63 @@ fn changed_mission_document_orphans_baseline_before_mutation() {
     new_tuner
         .run_training_attempts_blocking(1)
         .expect("run changed mission baseline and challenger");
+    assert!(state.0.borrow().scenario_runs.len() > runs_before);
+    assert_eq!(new_tuner.journal().training_attempt_count(), 1);
+}
+
+#[test]
+fn changed_stimulus_control_family_orphans_baseline_before_mutation() {
+    let directory = TestDirectory::new("orphan-baseline-old-family");
+    let state = FakeHandle::new();
+    let operator = stage_with_stimulus_family(ControlFamily::OperatorVelocity);
+    let direct = stage_with_stimulus_family(ControlFamily::DirectAttitudeThrust);
+    assert_ne!(
+        operator.training_scenarios[0].content_digest,
+        direct.training_scenarios[0].content_digest
+    );
+    let mut tuner = open_with_stage(
+        &directory,
+        state.clone(),
+        operator,
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("open operator-family session");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run operator-family training");
+    drop(tuner);
+
+    let old_head = read_head_entry(&directory);
+    let before = ExternalMutations::capture(&state);
+    let result = open_with_stage(
+        &directory,
+        state.clone(),
+        direct.clone(),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    );
+
+    assert!(matches!(result, Err(TuneError::JournalSessionMismatch)));
+    assert_eq!(ExternalMutations::capture(&state), before);
+    assert_eq!(read_head_entry(&directory), old_head);
+
+    let new_directory = TestDirectory::new("orphan-baseline-new-family");
+    let runs_before = state.0.borrow().scenario_runs.len();
+    let mut new_tuner = open_with_stage(
+        &new_directory,
+        state.clone(),
+        direct,
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("start direct-family session");
+    new_tuner
+        .run_training_attempts_blocking(1)
+        .expect("run direct-family baseline and challenger");
     assert!(state.0.borrow().scenario_runs.len() > runs_before);
     assert_eq!(new_tuner.journal().training_attempt_count(), 1);
 }

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -4,8 +4,9 @@ use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use flight_tune::{
-    ArtifactIdentity, Digest, MissionDocument, MissionReference, RunExecutionContext,
-    calibration_mission_document, reference_observation_scenario,
+    ArtifactIdentity, ControlFamily, Digest, MissionDocument, MissionReference,
+    RunExecutionContext, TrialScenario, calibration_mission_document,
+    reference_observation_scenario,
 };
 
 /// The sample ceiling every fake mission runs under.
@@ -29,7 +30,14 @@ pub const FAKE_MISSION_IDS: [&str; 3] = ["training-calm", "promotion-gust", "fin
 pub fn fake_stored_mission(mission: &MissionReference) -> Option<MissionDocument> {
     FAKE_MISSION_IDS
         .into_iter()
-        .flat_map(|id| [fake_mission_document(id), changed_fake_mission_document(id)])
+        .flat_map(|id| {
+            [
+                fake_mission_document(id),
+                changed_fake_mission_document(id),
+                fake_stimulus_mission_document(id, ControlFamily::OperatorVelocity),
+                fake_stimulus_mission_document(id, ControlFamily::DirectAttitudeThrust),
+            ]
+        })
         .find(|document| {
             Digest::from_bytes(*document.identity.content_digest.as_bytes())
                 == mission.content_digest
@@ -55,6 +63,55 @@ fn fake_mission_document_with_retry(id: &str, retry_limit: u16) -> MissionDocume
     .expect("fake mission document")
 }
 
+/// Builds the stored mission document for one trial name and control family.
+///
+/// The two family variants differ in the physical command that the stimulus
+/// requests, so each variant is a separate stored artifact.
+pub fn fake_stimulus_mission_document(id: &str, family: ControlFamily) -> MissionDocument {
+    calibration_mission_document(
+        &fake_stimulus_scenario(id, family),
+        0,
+        FAKE_RECEIPT_TIMEOUT_NS,
+    )
+    .expect("fake stimulus mission document")
+}
+
+/// Decodes the authored scenario that one stimulus mission projects.
+///
+/// The rig writes the scenario as schema bytes rather than as constructed
+/// values, so the fixture also pins the encoded stimulus shape. Crates that
+/// include this rig reach the scenario codec through `flight-tune`.
+fn fake_stimulus_scenario(id: &str, family: ControlFamily) -> TrialScenario {
+    let (capability, mapping, envelope) = match family {
+        ControlFamily::OperatorVelocity => (
+            "operator_velocity_control",
+            "candidate_bound_curve",
+            r#"{"id":"fake.operator.roll","revision":1,"unit":"meters_per_second",
+                "reference":"zero","negative_endpoint":-3.0,"neutral":0.0,
+                "positive_endpoint":3.0}"#,
+        ),
+        ControlFamily::DirectAttitudeThrust => (
+            "direct_attitude_thrust_control",
+            "affine_exact",
+            r#"{"id":"fake.direct.roll","revision":1,"unit":"radians",
+                "reference":"effective_setpoint_at_entry","negative_endpoint":-0.2,
+                "neutral":0.0,"positive_endpoint":0.2}"#,
+        ),
+    };
+    let document = format!(
+        r#"{{"schema_version":3,"id":"{id}","revision":1,"phases":[
+            {{"id":"stimulus","max_sim_time_ns":2000000000,
+              "required_capabilities":["simulator_time","{capability}"],
+              "entry_conditions":[{{"kind":"always"}}],
+              "action":{{"kind":"stimulus","family":"{family_name}","channel":"roll",
+                        "mapping":"{mapping}","envelope":{envelope},
+                        "waveform":{{"kind":"step","value":0.5}}}},
+              "exit_conditions":[{{"kind":"always"}}],"abort_conditions":[]}}]}}"#,
+        family_name = family.as_str(),
+    );
+    TrialScenario::from_json(document.as_bytes()).expect("fake stimulus scenario")
+}
+
 #[path = "test_rig/backend.rs"]
 mod backend;
 #[path = "test_rig/cleanup_fault.rs"]
@@ -77,7 +134,7 @@ pub use cleanup_fault::FakeCleanupFault;
 #[allow(unused_imports)]
 pub use scoring::{
     EnvelopeGates, ObservedViews, QuadraticMetric, SequenceStrategy, assert_receipt_error,
-    candidate, stage, stage_with_changed_training_mission,
+    candidate, stage, stage_with_changed_training_mission, stage_with_stimulus_family,
 };
 #[allow(unused_imports)]
 pub use terminal_head_poison::TerminalExternalAction;

--- a/tools/flight-tune/tests/tuner/test_rig/backend.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/backend.rs
@@ -271,7 +271,11 @@ impl ScenarioRuntime for FakeBackend {
     }
 
     fn capabilities(&self) -> &[MissionCapability] {
-        &[MissionCapability::SimulatorTime]
+        &[
+            MissionCapability::SimulatorTime,
+            MissionCapability::OperatorVelocityControl,
+            MissionCapability::DirectAttitudeThrustControl,
+        ]
     }
 
     fn prepare_blocking(

--- a/tools/flight-tune/tests/tuner/test_rig/scoring.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/scoring.rs
@@ -252,6 +252,19 @@ fn scenario(id: &str) -> MissionReference {
         .expect("mission reference")
 }
 
+/// The same stage with a training mission that commands one control family.
+pub fn stage_with_stimulus_family(family: flight_tune::ControlFamily) -> SearchStage {
+    let training = MissionReference::from_document(
+        &super::fake_stimulus_mission_document(super::FAKE_MISSION_IDS[0], family),
+        FAKE_MAX_SAMPLES,
+    )
+    .expect("stimulus mission reference");
+    SearchStage {
+        training_scenarios: vec![training],
+        ..stage()
+    }
+}
+
 /// The same stage with one changed training mission document.
 pub fn stage_with_changed_training_mission() -> SearchStage {
     let changed = MissionReference::from_document(


### PR DESCRIPTION
`PhaseAction::Stimulus` carried a control channel and a normalized waveform and nothing else. A runtime could not tell whether `0.5` on the roll channel asked for an operator velocity or a direct attitude setpoint, a metric could not state the physical command that a normalized value requested, and the scenario digest therefore did not bind the control meaning.

Every stimulus now carries one explicit `ControlFamily`, one `StimulusMapping`, and one versioned `StimulusEnvelope`. The envelope holds a stable identifier, a revision, a physical unit, a reference rule, and the three physical values that the normalized minus-one-through-plus-one range spans. The family fixes the mapping rule: `operator_velocity` uses `candidate_bound_curve`, where the envelope bounds the output and the candidate feel profile that the search tunes shapes the values between the endpoints; `direct_attitude_thrust` uses `affine_exact`, an exact two-segment affine map whose segments meet at the neutral value. Applying the piecewise affine rule to the operator family would erase the response curve the feel search exists to tune, so validation refuses a family and mapping mismatch.

## The four surfaces

1. **`crates/pilotage-trial`** — `PhaseAction::Stimulus` gains `family`, `mapping`, and `envelope`. The scenario schema moves to version 3. `BackendCapability` gains `operator_velocity_control` and `direct_attitude_thrust_control`, and a stimulus phase must declare the capability for its family. `StimulusEnvelope::canonical_digest` exposes the envelope identity through a typed method.
2. **`crates/pilotage-mission-core`** — `TrialAction::Stimulate` carries the same fields, so the digested document binds the complete control meaning. `MISSION_SCHEMA_VERSION` moves to 3 and `MissionCapability` gains the two family capabilities. Document validation mirrors the trial rules. Both crates use one envelope digest domain and one field order, so a lossless projection keeps the envelope identity.
3. **`tools/flight-tune/src/scenario_runtime/document.rs`** — the trial-to-mission projection carries the family, mapping, and envelope through without loss, and a stimulus phase now requires its family capability instead of the neutral `simulator_control` capability.
4. **Both action ports** — `flight-tune-aviate` carries the typed family, mapping, and envelope to its driver, and the composed `flight-tune-xplane` runtime declares its vehicle port's families. Capability admission refuses an unsupported family before the runtime resets a simulator, applies a condition, applies a vehicle change, or starts a process.

This PR does not implement the direct transport, which is #466. The `direct_attitude_thrust` family exists, validates, digests, and is refusable by capability. A port that does not declare the capability refuses it, which is the correct end state until #466 lands.

## The enforced combination table

The table is one exhaustive match over the family and channel product, so a combination it does not name cannot exist.

| Family | Channel | Unit | Reference | Mapping |
|---|---|---|---|---|
| `operator_velocity` | roll, pitch, vertical | `meters_per_second` | `zero` | `candidate_bound_curve` |
| `operator_velocity` | yaw | `radians_per_second` | `zero` | `candidate_bound_curve` |
| `direct_attitude_thrust` | roll, pitch, yaw | `radians` | `effective_setpoint_at_entry` | `affine_exact` |
| `direct_attitude_thrust` | vertical | `normalized_collective_force` | `identified_hover_trim` | `affine_exact` |

Validation also refuses an endpoint that is not finite, reversed endpoints, a zero physical span, a neutral value that the endpoints do not contain, a waveform value outside minus one through plus one, an unknown field, and an unknown enum value. A schema-3 document without a family fails decode. There is no implicit family.

Tests cover a canonical round trip for each of the eight family and channel pairs, a family change and an envelope change each moving the scenario digest and the mission content digest, an envelope revision change moving the envelope digest, unit and reference and mapping substitutions, each invalid envelope shape, a second vehicle with its own valid envelope, a generic non-simulator-specific runtime admitting each declared family, and both families refused before the first external mutation with a mutation count of zero.

## Rider: `FlightAction::Hold` becomes `FlightAction::MaintainTarget`

Decision from #564: an aviation holding procedure is a future leg type (a `HoldSpec` on a resolved leg), never a `FlightAction`. `FlightAction::Hold` means "hold the current flight target" and the name collided with the procedure. The doc text stays "Hold the current flight target." and the stable name becomes `flight.maintain_target`. Behaviour, capability mapping, and transport lane do not change. The rename rides inside this schema window because it changes production-source identity.

## Identity reset

Both schema versions change, so every scenario digest, every mission content digest, and the stage identity change, and prior bench seals orphan. This is the second and final planned identity churn before live campaigns.

`changed_stimulus_control_family_orphans_baseline_before_mutation` applies the orphan-baseline rule: a training mission whose control family changed refuses the prior journal with `JournalSessionMismatch` before any external action, leaves the journal head untouched, and a fresh session then runs under the new identity. The independent feedback verifier mirrors the new mission schema version and re-records its pinned canonical source digest.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace --all-targets` | pass, 2231 passed, 0 failed |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `scripts/check-structure.sh` | pass |
| `scripts/check-flight-tune-contracts.py` | pass |
| `scripts/check-flight-tune-boundaries.sh` | pass |
| `scripts/check-feedback-verifier-boundary.py` | pass |
| `scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | pass, 19 pairs ok |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | pass, 3 passed, 0 failed, 590.48 s |

The closing gate is the seal: `a_campaign_runs_end_to_end_for_the_alia250` and `a_campaign_runs_end_to_end_for_the_x500` both reach `FinalQualificationOutcome::Qualified` and publish verified evidence under the new identity. Live campaigns build on this seal.

Fixes #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
