### PR TITLE
Send exact simulator-only direct steps to Aviate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,8 @@ dependencies = [
  "flight-tune",
  "libc",
  "libproc",
+ "pilotage-adapter-aviate",
+ "pilotage-control-feel",
  "pilotage-durable-storage",
  "rustix",
  "serde",

--- a/adapters/aviate/src/adapter/tests.rs
+++ b/adapters/aviate/src/adapter/tests.rs
@@ -12,6 +12,7 @@ use pilotage_mavlink::link::KinematicsUpdate;
 
 mod control_feel;
 mod direct_flight;
+mod exact_direct;
 mod fixtures;
 mod flight_control;
 mod hid_pipeline;

--- a/adapters/aviate/src/adapter/tests/exact_direct.rs
+++ b/adapters/aviate/src/adapter/tests/exact_direct.rs
@@ -1,0 +1,378 @@
+//! The simulator-only exact direct path, beside the shaped operator paths
+//! it must not disturb.
+//!
+//! Every test here drives ONE uplink. The exact path and the shaped paths
+//! share the socket, the frame sequence, and the control-feel envelope, so
+//! a comparison between them is a comparison of laws and not of rigs.
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use pilotage_control_feel::{FeelMode, FlightFeelProfile, ValidatedFlightFeelProfile};
+
+use crate::adapter::AviateProfile;
+use crate::uplink::FlightUplink;
+use crate::{ExactDirectError, ExactDirectSetpoint, SimulatorDirectAuthority};
+
+/// A tilt step large enough that a rate limit cannot deliver it in one
+/// frame, and small enough to stay inside the direct tilt envelope.
+const STEP_RAD: f32 = 0.3;
+/// One simulator sample at the shaped path's frame rate.
+const SAMPLE: Duration = Duration::from_millis(20);
+
+fn fake_fc() -> UdpSocket {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+    socket
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .expect("read timeout");
+    socket
+}
+
+fn uplink_for(fc: &UdpSocket, mode: FeelMode) -> FlightUplink {
+    let profile = ValidatedFlightFeelProfile::new(FlightFeelProfile::shaped(mode))
+        .expect("valid Alia profile");
+    let mut uplink = FlightUplink::new_with_profile(profile).expect("uplink");
+    uplink.set_target(fc.local_addr().expect("FC address"));
+    uplink.use_manual_clock();
+    uplink.open_setpoint_stream(&authority());
+    uplink
+}
+
+fn authority() -> SimulatorDirectAuthority {
+    SimulatorDirectAuthority::for_profile(AviateProfile::Simulation).expect("simulation authority")
+}
+
+fn field(frame: &[u8], offset: usize) -> f32 {
+    let start = 10 + offset;
+    let bytes = frame.get(start..start + 4).expect("payload field");
+    f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+/// Recovers roll, pitch, yaw and collective from one SET_ATTITUDE_TARGET.
+fn attitude_of(frame: &[u8]) -> (f32, f32, f32, f32) {
+    assert_eq!(frame[7], 82, "SET_ATTITUDE_TARGET id");
+    let (qw, qx, qy, qz) = (
+        field(frame, 4),
+        field(frame, 8),
+        field(frame, 12),
+        field(frame, 16),
+    );
+    let roll = (2.0 * (qw * qx + qy * qz)).atan2(1.0 - 2.0 * (qx * qx + qy * qy));
+    let pitch = (2.0 * (qw * qy - qz * qx)).asin();
+    let yaw = (2.0 * (qw * qz + qx * qy)).atan2(1.0 - 2.0 * (qy * qy + qz * qz));
+    (roll, pitch, yaw, field(frame, 32))
+}
+
+fn next_frame(fc: &UdpSocket) -> Vec<u8> {
+    let mut buffer = [0_u8; 128];
+    let (len, _) = fc.recv_from(&mut buffer).expect("a frame reached the FC");
+    buffer[..len].to_vec()
+}
+
+fn assert_link_silent(fc: &UdpSocket) {
+    let mut buffer = [0_u8; 128];
+    fc.set_read_timeout(Some(Duration::from_millis(50)))
+        .expect("read timeout");
+    let received = fc.recv_from(&mut buffer);
+    fc.set_read_timeout(Some(Duration::from_millis(250)))
+        .expect("read timeout");
+    assert!(
+        received.is_err(),
+        "a refused exact step must not put a frame on the command link"
+    );
+}
+
+/// Seeds the shaped direct law at level attitude and drains the frame it
+/// sends, so the next shaped frame measures shaping alone.
+fn seed_shaped_direct(uplink: &mut FlightUplink, fc: &UdpSocket) {
+    uplink.send_attitude_frame(0.0, 0.0, 0.0, 0.72);
+    let _seed = next_frame(fc);
+}
+
+#[test]
+fn the_normal_direct_path_still_applies_its_declared_shaping() {
+    let fc = fake_fc();
+    let mut uplink = uplink_for(&fc, FeelMode::Balanced);
+    seed_shaped_direct(&mut uplink, &fc);
+
+    uplink.advance_clock(SAMPLE);
+    uplink.send_attitude_frame(STEP_RAD, 0.0, 0.0, 0.72);
+    let (roll, ..) = attitude_of(&next_frame(&fc));
+
+    // The Balanced law bounds the tilt rate at 1.2 rad/s, so one 20 ms
+    // sample can deliver at most 0.024 rad of the 0.3 rad request.
+    assert!(
+        roll < STEP_RAD * 0.2,
+        "the shaped path must ramp, not step: {roll} rad"
+    );
+    assert!(roll > 0.0, "the shaped path must still respond: {roll} rad");
+}
+
+#[test]
+fn the_simulator_direct_path_sends_an_exact_target_in_one_sample() {
+    let fc = fake_fc();
+    let mut uplink = uplink_for(&fc, FeelMode::Balanced);
+    seed_shaped_direct(&mut uplink, &fc);
+
+    uplink.advance_clock(SAMPLE);
+    let transmitted = uplink
+        .send_exact_direct_setpoint(
+            &authority(),
+            ExactDirectSetpoint {
+                roll_rad: STEP_RAD,
+                pitch_rad: 0.0,
+                yaw_rad: 0.0,
+                collective_force: 0.72,
+            },
+        )
+        .expect("exact step");
+    let (roll, ..) = attitude_of(&next_frame(&fc));
+
+    assert_eq!(
+        transmitted.setpoint.roll_rad, STEP_RAD,
+        "the transmitted setpoint IS the requested target"
+    );
+    assert!(
+        (roll - STEP_RAD).abs() < 1e-6,
+        "the exact path must reach the target in one sample: {roll} rad"
+    );
+}
+
+#[test]
+fn an_exact_step_keeps_every_unrelated_axis_at_its_requested_value() {
+    let fc = fake_fc();
+    let mut uplink = uplink_for(&fc, FeelMode::Balanced);
+    seed_shaped_direct(&mut uplink, &fc);
+
+    uplink.advance_clock(SAMPLE);
+    uplink
+        .send_exact_direct_setpoint(
+            &authority(),
+            ExactDirectSetpoint {
+                roll_rad: STEP_RAD,
+                pitch_rad: -0.1,
+                yaw_rad: 0.4,
+                collective_force: 0.61,
+            },
+        )
+        .expect("exact step");
+    let (roll, pitch, yaw, collective) = attitude_of(&next_frame(&fc));
+
+    assert!((roll - STEP_RAD).abs() < 1e-6, "roll {roll}");
+    assert!((pitch + 0.1).abs() < 1e-6, "pitch {pitch}");
+    assert!((yaw - 0.4).abs() < 1e-6, "yaw {yaw}");
+    assert!((collective - 0.61).abs() < 1e-6, "collective {collective}");
+}
+
+#[test]
+fn a_changed_default_feel_profile_is_not_necessary_for_a_direct_step() {
+    // The compatibility profile is the launch default. An exact step needs
+    // no other profile, so a trial never has to change operator feel to
+    // measure the direct controller.
+    let fc = fake_fc();
+    let mut uplink = FlightUplink::new().expect("default uplink");
+    uplink.set_target(fc.local_addr().expect("FC address"));
+    uplink.use_manual_clock();
+    uplink.open_setpoint_stream(&authority());
+
+    uplink
+        .send_exact_direct_setpoint(
+            &authority(),
+            ExactDirectSetpoint {
+                roll_rad: STEP_RAD,
+                pitch_rad: 0.0,
+                yaw_rad: 0.0,
+                collective_force: 0.72,
+            },
+        )
+        .expect("exact step on the default profile");
+    let (roll, ..) = attitude_of(&next_frame(&fc));
+
+    assert!((roll - STEP_RAD).abs() < 1e-6, "roll {roll}");
+    assert_eq!(
+        uplink.active_profile_for_test().profile().mode,
+        FeelMode::LegacyCompatibility,
+        "the exact step must not install another profile"
+    );
+}
+
+#[test]
+fn the_simulator_direct_path_leaves_the_shaped_direct_law_untouched() {
+    // Two uplinks run the same shaped sequence. One takes an exact step in
+    // the middle. If the exact path touched the shaped law's integrators,
+    // seed, or heading, the shaped frames would diverge.
+    let control_fc = fake_fc();
+    let subject_fc = fake_fc();
+    let mut control = uplink_for(&control_fc, FeelMode::Balanced);
+    let mut subject = uplink_for(&subject_fc, FeelMode::Balanced);
+    seed_shaped_direct(&mut control, &control_fc);
+    seed_shaped_direct(&mut subject, &subject_fc);
+
+    subject
+        .send_exact_direct_setpoint(
+            &authority(),
+            ExactDirectSetpoint {
+                roll_rad: STEP_RAD,
+                pitch_rad: 0.0,
+                yaw_rad: 0.0,
+                collective_force: 0.9,
+            },
+        )
+        .expect("exact step");
+    let _exact = next_frame(&subject_fc);
+
+    for _ in 0..3 {
+        control.advance_clock(SAMPLE);
+        subject.advance_clock(SAMPLE);
+        control.send_attitude_frame(STEP_RAD, 0.0, 0.0, 0.72);
+        subject.send_attitude_frame(STEP_RAD, 0.0, 0.0, 0.72);
+        assert_eq!(
+            attitude_of(&next_frame(&control_fc)),
+            attitude_of(&next_frame(&subject_fc)),
+            "an exact step must not move the shaped direct law"
+        );
+    }
+}
+
+#[test]
+fn the_operator_velocity_path_still_uses_normal_shaping() {
+    // The same proof for the operator family: an exact direct step must not
+    // change the velocity law's response curve, apply dynamics, or
+    // integrated heading.
+    let control_fc = fake_fc();
+    let subject_fc = fake_fc();
+    let mut control = uplink_for(&control_fc, FeelMode::Balanced);
+    let mut subject = uplink_for(&subject_fc, FeelMode::Balanced);
+
+    let stick = |uplink: &mut FlightUplink| {
+        uplink.send_stick_frame(0.0, 1.0, 0.6, 0.5, 0.0, [0.0; 3], Some([0.0; 3]), None);
+    };
+    stick(&mut control);
+    stick(&mut subject);
+    let _control_seed = next_frame(&control_fc);
+    let _subject_seed = next_frame(&subject_fc);
+
+    subject
+        .send_exact_direct_setpoint(
+            &authority(),
+            ExactDirectSetpoint {
+                roll_rad: STEP_RAD,
+                pitch_rad: 0.0,
+                yaw_rad: 0.0,
+                collective_force: 0.9,
+            },
+        )
+        .expect("exact step");
+    let _exact = next_frame(&subject_fc);
+
+    let mut commanded = false;
+    for _ in 0..3 {
+        control.advance_clock(SAMPLE);
+        subject.advance_clock(SAMPLE);
+        stick(&mut control);
+        stick(&mut subject);
+        let control_frame = next_frame(&control_fc);
+        let subject_frame = next_frame(&subject_fc);
+        assert_eq!(
+            control_frame[7], subject_frame[7],
+            "the operator family must keep its own message"
+        );
+        // A velocity setpoint carries vx/vy/vz at payload offsets 16..28
+        // and the absolute heading at 40.
+        for offset in [16, 20, 24, 40] {
+            let expected = field(&control_frame, offset);
+            commanded = commanded || expected != 0.0;
+            assert_eq!(
+                expected,
+                field(&subject_frame, offset),
+                "an exact step must not move the operator velocity law"
+            );
+        }
+    }
+    assert!(
+        commanded,
+        "the operator law must have commanded something for this comparison to mean anything"
+    );
+}
+
+#[test]
+fn a_hardware_target_cannot_mint_exact_direct_authority() {
+    assert!(SimulatorDirectAuthority::for_profile(AviateProfile::Physical).is_none());
+    assert!(SimulatorDirectAuthority::for_profile(AviateProfile::OracleOnly).is_none());
+    assert_eq!(
+        authority().profile(),
+        AviateProfile::Simulation,
+        "only the simulation profile carries exact direct authority"
+    );
+}
+
+#[test]
+fn a_constrained_exact_target_is_refused_before_any_frame_leaves() {
+    let fc = fake_fc();
+    let mut uplink = uplink_for(&fc, FeelMode::Balanced);
+    let level = ExactDirectSetpoint {
+        roll_rad: 0.0,
+        pitch_rad: 0.0,
+        yaw_rad: 0.0,
+        collective_force: 0.72,
+    };
+
+    let refusals = [
+        (
+            ExactDirectSetpoint {
+                roll_rad: 1.5,
+                ..level
+            },
+            "roll outside the tilt envelope",
+        ),
+        (
+            ExactDirectSetpoint {
+                pitch_rad: f32::NAN,
+                ..level
+            },
+            "pitch is not finite",
+        ),
+        (
+            ExactDirectSetpoint {
+                yaw_rad: 7.0,
+                ..level
+            },
+            "heading outside one revolution",
+        ),
+        (
+            ExactDirectSetpoint {
+                collective_force: 1.4,
+                ..level
+            },
+            "collective outside the normalized range",
+        ),
+    ];
+    for (setpoint, reason) in refusals {
+        let result = uplink.send_exact_direct_setpoint(&authority(), setpoint);
+        assert!(result.is_err(), "{reason} must be refused");
+        assert_link_silent(&fc);
+    }
+}
+
+#[test]
+fn a_closed_setpoint_stream_refuses_an_exact_step() {
+    let fc = fake_fc();
+    let profile = ValidatedFlightFeelProfile::new(FlightFeelProfile::shaped(FeelMode::Balanced))
+        .expect("valid Alia profile");
+    let mut uplink = FlightUplink::new_with_profile(profile).expect("uplink");
+    uplink.set_target(fc.local_addr().expect("FC address"));
+    uplink.use_manual_clock();
+
+    let result = uplink.send_exact_direct_setpoint(
+        &authority(),
+        ExactDirectSetpoint {
+            roll_rad: 0.0,
+            pitch_rad: 0.0,
+            yaw_rad: 0.0,
+            collective_force: 0.72,
+        },
+    );
+
+    assert_eq!(result, Err(ExactDirectError::StreamClosed));
+    assert_link_silent(&fc);
+}

--- a/adapters/aviate/src/lib.rs
+++ b/adapters/aviate/src/lib.rs
@@ -29,7 +29,10 @@ pub use adapter::{
 pub use error::AviateAdapterError;
 pub use incarnation::{IncarnationProvider, OsIncarnationProvider};
 pub use pilotage_mavlink::link::{LinkConfig, ResetPolicy};
-pub use uplink::FlightUplink;
+pub use uplink::{
+    ATTITUDE_SETPOINT_FRAME_BYTES, ExactDirectError, ExactDirectSetpoint, FlightUplink,
+    SimulatorDirectAuthority, TransmittedDirectSetpoint,
+};
 
 /// Canonical control-feel artifact for the default Alia launch.
 pub const ALIA250_DEFAULT_CONTROL_FEEL_JSON: &str =

--- a/adapters/aviate/src/uplink.rs
+++ b/adapters/aviate/src/uplink.rs
@@ -19,10 +19,16 @@ use pilotage_control_feel::{FeelDigest, FlightFeelProfile, ValidatedFlightFeelPr
 use pilotage_mavlink::codec::{encode_arm_command, encode_velocity_setpoint};
 
 mod control;
+mod direct;
 mod fc_replies;
 mod feel;
 #[cfg(test)]
 mod tests;
+
+pub use direct::{
+    ATTITUDE_SETPOINT_FRAME_BYTES, ExactDirectError, ExactDirectSetpoint, SimulatorDirectAuthority,
+    TransmittedDirectSetpoint,
+};
 
 /// Longest believable gap between control frames when integrating the
 /// yaw-rate stick; anything longer is a stall, not a dt.
@@ -102,13 +108,31 @@ impl FlightUplink {
     /// Returns an error if the profile does not match Alia or the socket
     /// cannot initialize.
     pub(crate) fn new_with_profile(profile: ValidatedFlightFeelProfile) -> std::io::Result<Self> {
+        Self::bind_with_profile(profile, default_command_endpoint())
+    }
+
+    /// Binds an ephemeral socket toward an explicit FC command endpoint.
+    ///
+    /// A tuning trial names the endpoint it commands, because that endpoint
+    /// is part of the direct-transport identity. Reading it from the ambient
+    /// environment would leave the identity unbound.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the default profile or socket cannot initialize.
+    pub fn bind_to(command_endpoint: SocketAddr) -> std::io::Result<Self> {
+        let profile = ValidatedFlightFeelProfile::new(FlightFeelProfile::legacy_compatibility())
+            .map_err(std::io::Error::other)?;
+        Self::bind_with_profile(profile, command_endpoint)
+    }
+
+    fn bind_with_profile(
+        profile: ValidatedFlightFeelProfile,
+        target: SocketAddr,
+    ) -> std::io::Result<Self> {
         crate::adapter::validate_aviate_profile_bindings(&profile)
             .map_err(std::io::Error::other)?;
         let feel_digest = FeelDigest::calculate(&profile).map_err(std::io::Error::other)?;
-        let target = std::env::var("PILOTAGE_AVIATE_FC_ADDR")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 20000)));
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.set_nonblocking(true)?;
         info!(
@@ -154,6 +178,11 @@ impl FlightUplink {
 
     pub(crate) fn monotonic_now(&self) -> Instant {
         self.clock.now()
+    }
+
+    /// The FC command endpoint every uplink frame is addressed to.
+    pub const fn command_endpoint(&self) -> SocketAddr {
+        self.target
     }
 
     /// Selects the MAVLink system/component whose replies may affect state.
@@ -318,4 +347,11 @@ impl FlightUplink {
         self.hold_pos_ned = None;
         self.feel.reset();
     }
+}
+
+fn default_command_endpoint() -> SocketAddr {
+    std::env::var("PILOTAGE_AVIATE_FC_ADDR")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 20000)))
 }

--- a/adapters/aviate/src/uplink/control.rs
+++ b/adapters/aviate/src/uplink/control.rs
@@ -258,7 +258,7 @@ impl FlightUplink {
         (dt_s, dt_s)
     }
 
-    fn in_quiet_interval(&mut self, now: Instant) -> bool {
+    pub(super) fn in_quiet_interval(&mut self, now: Instant) -> bool {
         if let Some(quiet) = self.quiet_until {
             if now < quiet {
                 return true;
@@ -333,7 +333,7 @@ impl FlightUplink {
         }
     }
 
-    fn time_boot_ms(&self) -> u32 {
+    pub(super) fn time_boot_ms(&self) -> u32 {
         self.clock
             .now()
             .saturating_duration_since(self.started)

--- a/adapters/aviate/src/uplink/direct.rs
+++ b/adapters/aviate/src/uplink/direct.rs
@@ -1,0 +1,262 @@
+//! The simulator-only exact direct attitude and collective-force path.
+//!
+//! The operator direct path shapes every request with attitude-rate,
+//! attitude-acceleration, thrust-rate, and thrust-acceleration limits, so a
+//! requested step arrives at the flight controller as a ramp. A direct
+//! controller cannot be measured through that shaping.
+//!
+//! This module sends one exact setpoint through the same command sender:
+//! the same socket, the same frame sequence, the same boot time, and the
+//! same MAVLink source identity that every other uplink frame uses. It
+//! keeps no state of its own, so it cannot change what the operator path
+//! does on the next frame.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use std::net::SocketAddr;
+
+use pilotage_control_feel::DemandEnvelope;
+use pilotage_mavlink::codec::{AttitudeTarget, encode_attitude_setpoint};
+use thiserror::Error;
+
+use crate::adapter::AviateProfile;
+
+use super::FlightUplink;
+
+/// Wire length of one encoded SET_ATTITUDE_TARGET frame.
+pub const ATTITUDE_SETPOINT_FRAME_BYTES: usize = 51;
+
+/// Proof that one uplink may carry exact direct test setpoints.
+///
+/// Only a simulation profile can mint this value, so the exact path is
+/// structurally absent on a physical vehicle rather than merely refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimulatorDirectAuthority {
+    profile: AviateProfile,
+}
+
+impl SimulatorDirectAuthority {
+    /// Mints exact direct authority for a simulation profile.
+    ///
+    /// Returns `None` for every other profile.
+    #[must_use]
+    pub const fn for_profile(profile: AviateProfile) -> Option<Self> {
+        match profile {
+            AviateProfile::Simulation => Some(Self { profile }),
+            AviateProfile::Physical | AviateProfile::OracleOnly => None,
+        }
+    }
+
+    /// The profile that authorized the exact direct path.
+    #[must_use]
+    pub const fn profile(&self) -> AviateProfile {
+        self.profile
+    }
+
+    const fn require_simulation(self) -> Result<(), ExactDirectError> {
+        match self.profile {
+            AviateProfile::Simulation => Ok(()),
+            AviateProfile::Physical | AviateProfile::OracleOnly => {
+                Err(ExactDirectError::NotSimulated)
+            }
+        }
+    }
+}
+
+/// One exact direct attitude and collective-force setpoint.
+///
+/// Every axis is absolute. The caller supplies all four values, so the
+/// uplink applies no heading integration and no axis of its own.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ExactDirectSetpoint {
+    /// Absolute roll setpoint in radians.
+    pub roll_rad: f32,
+    /// Absolute pitch setpoint in radians.
+    pub pitch_rad: f32,
+    /// Absolute heading setpoint in radians.
+    pub yaw_rad: f32,
+    /// Normalized collective force in `[0, 1]`.
+    pub collective_force: f32,
+}
+
+impl ExactDirectSetpoint {
+    fn validate(&self, envelope: DemandEnvelope) -> Result<(), ExactDirectError> {
+        for (axis, value) in [
+            ("roll", self.roll_rad),
+            ("pitch", self.pitch_rad),
+            ("yaw", self.yaw_rad),
+            ("collective", self.collective_force),
+        ] {
+            if !value.is_finite() {
+                return Err(ExactDirectError::NotFinite { axis });
+            }
+        }
+        for (axis, value) in [("roll", self.roll_rad), ("pitch", self.pitch_rad)] {
+            if value.abs() > envelope.direct_tilt_rad {
+                return Err(ExactDirectError::OutsideTiltEnvelope {
+                    axis,
+                    value_rad: value,
+                    limit_rad: envelope.direct_tilt_rad,
+                });
+            }
+        }
+        if self.yaw_rad.abs() > core::f32::consts::PI {
+            return Err(ExactDirectError::OutsideHeadingRange {
+                value_rad: self.yaw_rad,
+            });
+        }
+        if !(0.0..=1.0).contains(&self.collective_force) {
+            return Err(ExactDirectError::OutsideCollectiveRange {
+                value: self.collective_force,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// The exact frame that one direct setpoint put on the command link.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TransmittedDirectSetpoint {
+    /// The setpoint the encoder wrote into the frame.
+    pub setpoint: ExactDirectSetpoint,
+    /// The MAVLink frame sequence the sender used.
+    pub sequence: u8,
+    /// The sender's boot time in milliseconds.
+    pub time_boot_ms: u32,
+    /// The MAVLink system identity of the sender.
+    pub system_id: u8,
+    /// The MAVLink component identity of the sender.
+    pub component_id: u8,
+    /// The command endpoint the frame was addressed to.
+    pub endpoint: SocketAddr,
+    /// The exact transmitted frame bytes.
+    pub frame: [u8; ATTITUDE_SETPOINT_FRAME_BYTES],
+}
+
+/// One exact direct setpoint did not reach the flight controller.
+///
+/// The shaped operator path reports a constrained request as a boolean
+/// beside a frame that still went out. An exact step has no such outcome:
+/// a request that cannot be sent unchanged is a failed command, because a
+/// silently altered step would be recorded as controller response.
+#[derive(Debug, Clone, Copy, PartialEq, Error)]
+pub enum ExactDirectError {
+    /// The authority does not name a simulation profile.
+    #[error("exact direct setpoints are simulator-only")]
+    NotSimulated,
+    /// One setpoint value is not a finite number.
+    #[error("the {axis} setpoint is not a finite number")]
+    NotFinite {
+        /// The axis that carries the value.
+        axis: &'static str,
+    },
+    /// One attitude setpoint leaves the direct tilt envelope.
+    #[error("the {axis} setpoint {value_rad} rad leaves the {limit_rad} rad direct tilt envelope")]
+    OutsideTiltEnvelope {
+        /// The axis that carries the value.
+        axis: &'static str,
+        /// The requested value.
+        value_rad: f32,
+        /// The envelope limit.
+        limit_rad: f32,
+    },
+    /// The heading setpoint is not a wrapped absolute heading.
+    #[error("the heading setpoint {value_rad} rad is outside one wrapped revolution")]
+    OutsideHeadingRange {
+        /// The requested value.
+        value_rad: f32,
+    },
+    /// The collective force leaves the normalized range.
+    #[error("the collective force {value} is outside the normalized range")]
+    OutsideCollectiveRange {
+        /// The requested value.
+        value: f32,
+    },
+    /// The command link is inside the quiet interval after an arm command.
+    #[error("the command link is inside the post-arm quiet interval")]
+    QuietInterval,
+    /// The setpoint stream is closed because the vehicle is not airborne.
+    #[error("the setpoint stream is closed until the vehicle is airborne")]
+    StreamClosed,
+    /// The command sender refused the datagram.
+    #[error("the command sender refused the datagram for {endpoint}")]
+    SendRefused {
+        /// The command endpoint that refused the frame.
+        endpoint: SocketAddr,
+    },
+}
+
+impl FlightUplink {
+    /// Sends one exact direct setpoint without curve or temporal shaping.
+    ///
+    /// The transmitted setpoint reaches the requested target in this one
+    /// frame. The call reads the control-feel envelope to bound the
+    /// request, and it neither reads nor writes any operator control-feel
+    /// state: the response curve, neutral hysteresis, apply and release
+    /// dynamics, integrated heading, and captured position hold all keep
+    /// the values they had before the call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExactDirectError`] when the authority is not a simulation
+    /// authority, when a requested value would be constrained, when the
+    /// command link is quiet or its setpoint stream is closed, or when the
+    /// sender refused the datagram.
+    pub fn send_exact_direct_setpoint(
+        &mut self,
+        authority: &SimulatorDirectAuthority,
+        setpoint: ExactDirectSetpoint,
+    ) -> Result<TransmittedDirectSetpoint, ExactDirectError> {
+        authority.require_simulation()?;
+        setpoint.validate(self.feel.envelope())?;
+        let now = self.clock.now();
+        if self.in_quiet_interval(now) {
+            return Err(ExactDirectError::QuietInterval);
+        }
+        if !self.airborne {
+            return Err(ExactDirectError::StreamClosed);
+        }
+        let sequence = self.seq;
+        let time_boot_ms = self.time_boot_ms();
+        let frame = encode_attitude_setpoint(
+            sequence,
+            time_boot_ms,
+            AttitudeTarget {
+                roll_rad: setpoint.roll_rad,
+                pitch_rad: setpoint.pitch_rad,
+                yaw_rad: setpoint.yaw_rad,
+                thrust: setpoint.collective_force,
+                system_id: self.expected_system_id,
+                component_id: self.expected_component_id,
+            },
+        );
+        let failures_before = self.send_failures;
+        self.send(&frame);
+        if self.send_failures != failures_before {
+            return Err(ExactDirectError::SendRefused {
+                endpoint: self.target,
+            });
+        }
+        Ok(TransmittedDirectSetpoint {
+            setpoint,
+            sequence,
+            time_boot_ms,
+            system_id: self.expected_system_id,
+            component_id: self.expected_component_id,
+            endpoint: self.target,
+            frame,
+        })
+    }
+
+    /// Opens the setpoint stream without an operator climb command.
+    ///
+    /// A trial reaches its start state through the normal path before it
+    /// enters direct mode. This entry point exists for a rig that binds the
+    /// uplink directly, so the exact path's closed-stream refusal stays
+    /// reachable instead of being worked around with a shaped frame.
+    pub fn open_setpoint_stream(&mut self, authority: &SimulatorDirectAuthority) {
+        if authority.require_simulation().is_ok() {
+            self.airborne = true;
+        }
+    }
+}

--- a/tools/flight-tune-aviate/Cargo.toml
+++ b/tools/flight-tune-aviate/Cargo.toml
@@ -3,7 +3,7 @@ name = "flight-tune-aviate"
 version = "0.1.0"
 edition.workspace = true
 publish = false
-description = "Crash-contained Aviate process supervision for simulator tuning"
+description = "Aviate process supervision and exact direct control for simulator tuning"
 
 [lints]
 workspace = true
@@ -25,5 +25,8 @@ libproc = "=0.14.11"
 sysctl = "=0.7.1"
 
 [dev-dependencies]
+flight-tune = { path = "../flight-tune", features = ["test-support"] }
+pilotage-adapter-aviate = { workspace = true }
+pilotage-control-feel = { workspace = true }
 pilotage-durable-storage = { workspace = true, features = ["fault-injection"] }
 tempfile = "3.23.0"

--- a/tools/flight-tune-aviate/src/direct_transport.rs
+++ b/tools/flight-tune-aviate/src/direct_transport.rs
@@ -1,0 +1,266 @@
+//! The simulator-only exact direct transport for an Aviate vehicle.
+//!
+//! The normal Pilotage direct path rate-limits and jerk-limits every
+//! request, so a requested step arrives at the flight controller as a
+//! ramp. Evidence collected through it measures Pilotage shaping and not
+//! the direct controller. This transport delivers the step itself.
+//!
+//! It is not reachable from the normal application control interface. It
+//! exists only where a validated tuning session, a verified simulator
+//! binding, and a simulator execution target all agree, and it owns no
+//! socket: it borrows the command sender that already carries the
+//! vehicle's normal command stream.
+//!
+//! The operator velocity family keeps the normal control-feel path with
+//! its response curve, neutral hysteresis, apply dynamics, release
+//! dynamics, and hold transition. This transport refuses that family.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+mod baseline;
+mod command;
+mod error;
+mod port;
+mod readback;
+mod record;
+mod revoke;
+mod session;
+mod step;
+#[cfg(test)]
+mod tests;
+
+use flight_tune::{
+    ArtifactIdentity, ControlFamily, Digest, ExecutionTarget, SimulatorCapability,
+    SimulatorSessionReceipt, TuneError, VehicleBindingReceipt,
+};
+use sha2::{Digest as _, Sha256};
+
+pub use baseline::{DirectBaseline, DirectBaselineRequest};
+pub use error::DirectTransportError;
+pub use port::{
+    DirectCommandSender, DirectSenderError, DirectSenderIdentity, DirectSetpoint,
+    EffectiveSetpointReport, TransmittedDirectCommand,
+};
+pub use readback::{CausalReadbackBound, ReadbackSelection};
+pub use record::{DIRECT_COMMAND_RECORD_SCHEMA_VERSION, DirectCommandRecord, DirectCommandTimes};
+pub use revoke::DirectRevokeReceipt;
+pub use session::{
+    DIRECT_TRANSPORT_IDENTITY_SCHEMA_VERSION, DirectTransportIdentity, DirectTransportSession,
+};
+pub use step::{DirectCommandPurpose, DirectStepRequest, PreparedDirectCommand};
+
+const TRANSPORT_IDENTITY_DOMAIN: &[u8] = b"pilotage-aviate-direct-transport-v1\0";
+
+/// The exact source files of the direct-transport implementation.
+const TRANSPORT_SOURCES: [(&str, &[u8]); 10] = [
+    ("direct_transport.rs", include_bytes!("direct_transport.rs")),
+    (
+        "direct_transport/baseline.rs",
+        include_bytes!("direct_transport/baseline.rs"),
+    ),
+    (
+        "direct_transport/command.rs",
+        include_bytes!("direct_transport/command.rs"),
+    ),
+    (
+        "direct_transport/error.rs",
+        include_bytes!("direct_transport/error.rs"),
+    ),
+    (
+        "direct_transport/port.rs",
+        include_bytes!("direct_transport/port.rs"),
+    ),
+    (
+        "direct_transport/readback.rs",
+        include_bytes!("direct_transport/readback.rs"),
+    ),
+    (
+        "direct_transport/record.rs",
+        include_bytes!("direct_transport/record.rs"),
+    ),
+    (
+        "direct_transport/revoke.rs",
+        include_bytes!("direct_transport/revoke.rs"),
+    ),
+    (
+        "direct_transport/session.rs",
+        include_bytes!("direct_transport/session.rs"),
+    ),
+    (
+        "direct_transport/step.rs",
+        include_bytes!("direct_transport/step.rs"),
+    ),
+];
+
+/// The content identity of this direct-transport implementation.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when the identity cannot be named.
+pub fn direct_transport_identity() -> Result<ArtifactIdentity, TuneError> {
+    let mut hasher = Sha256::new();
+    hasher.update(TRANSPORT_IDENTITY_DOMAIN);
+    for (name, source) in TRANSPORT_SOURCES {
+        hasher.update((name.len() as u64).to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update((source.len() as u64).to_le_bytes());
+        hasher.update(source);
+    }
+    ArtifactIdentity::new(
+        "pilotage-aviate-direct-transport-v1",
+        Digest::from_bytes(hasher.finalize().into()),
+    )
+}
+
+/// What one simulator-only direct transport is authorized from.
+#[derive(Clone, Copy, Debug)]
+pub struct DirectTransportRequest<'binding> {
+    /// The capability for the validated tuning session.
+    pub capability: &'binding SimulatorCapability,
+    /// The verified simulator handshake receipt.
+    pub simulator: &'binding SimulatorSessionReceipt,
+    /// The verified vehicle binding receipt.
+    pub vehicle: &'binding VehicleBindingReceipt,
+    /// The mission execution target.
+    pub target: ExecutionTarget,
+    /// The direct-transport implementation identity.
+    pub transport: &'binding ArtifactIdentity,
+    /// The causal rule for accepting a raw readback sample.
+    pub readback: CausalReadbackBound,
+    /// The declared numeric tolerance for a target comparison.
+    pub tolerance: f64,
+}
+
+/// The outcome of enacting one prepared direct command.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DirectEnactment {
+    /// The command reached the flight controller with a complete record.
+    Enacted(Box<DirectCommandRecord>),
+    /// The raw source has not reached the command time. Nothing was sent.
+    Pending,
+    /// The raw source carries no exact sample for the command time.
+    ///
+    /// Nothing was sent, and no step or release marker was recorded. The
+    /// direct phase never falls back to a delayed estimate.
+    NoExactSource,
+}
+
+/// One simulator-only exact direct transport.
+#[derive(Debug)]
+pub struct DirectTransport {
+    session: DirectTransportSession,
+    readback: CausalReadbackBound,
+    tolerance: f64,
+    baseline: Option<DirectBaseline>,
+    revoked: bool,
+}
+
+impl DirectTransport {
+    /// Authorizes one simulator-only direct transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the execution target is a real
+    /// vehicle, when a binding does not accept the tuning session, when a
+    /// bound identity is missing, or when the tolerance is unusable.
+    pub fn authorize<S: DirectCommandSender + ?Sized>(
+        request: &DirectTransportRequest<'_>,
+        sender: &S,
+    ) -> Result<Self, DirectTransportError> {
+        if !request.tolerance.is_finite() || request.tolerance < 0.0 {
+            return Err(DirectTransportError::InvalidValue {
+                field: "numeric tolerance",
+            });
+        }
+        let session = DirectTransportSession::authorize(
+            request.capability,
+            request.simulator,
+            request.vehicle,
+            request.target,
+            &sender.command_endpoint(),
+            request.transport,
+        )?;
+        Ok(Self {
+            session,
+            readback: request.readback,
+            tolerance: request.tolerance,
+            baseline: None,
+            revoked: false,
+        })
+    }
+
+    /// The authenticated authority this transport holds.
+    #[must_use]
+    pub const fn session(&self) -> &DirectTransportSession {
+        &self.session
+    }
+
+    /// The frozen direct baseline, once the run has one.
+    #[must_use]
+    pub const fn baseline(&self) -> Option<&DirectBaseline> {
+        self.baseline.as_ref()
+    }
+
+    /// The causal rule for accepting a raw readback sample.
+    #[must_use]
+    pub const fn readback_bound(&self) -> CausalReadbackBound {
+        self.readback
+    }
+
+    /// The declared numeric tolerance for a target comparison.
+    #[must_use]
+    pub const fn tolerance(&self) -> f64 {
+        self.tolerance
+    }
+
+    /// Whether this transport still holds direct authority.
+    #[must_use]
+    pub const fn is_revoked(&self) -> bool {
+        self.revoked
+    }
+
+    /// Rejects a session or runtime identity that changed after authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when a binding no longer matches or
+    /// the authority is revoked.
+    pub fn require_binding(
+        &self,
+        capability: &SimulatorCapability,
+        vehicle: &VehicleBindingReceipt,
+    ) -> Result<(), DirectTransportError> {
+        self.require_authority()?;
+        self.session.require_unchanged(capability, vehicle)
+    }
+
+    /// Removes every direct authority this transport holds.
+    ///
+    /// The operation is idempotent. A second call removes nothing and
+    /// returns the same receipt.
+    pub fn revoke(&mut self) -> DirectRevokeReceipt {
+        let removed_authority = !self.revoked;
+        let released_baseline = self.baseline.take().is_some();
+        self.revoked = true;
+        DirectRevokeReceipt::new(
+            self.session.identity_digest(),
+            removed_authority,
+            released_baseline,
+        )
+    }
+
+    pub(crate) const fn require_authority(&self) -> Result<(), DirectTransportError> {
+        if self.revoked {
+            return Err(DirectTransportError::Revoked);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn require_direct_stimulus(
+        &self,
+        family: ControlFamily,
+    ) -> Result<(), DirectTransportError> {
+        self.require_authority()?;
+        step::require_direct_family(family)
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/baseline.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/baseline.rs
@@ -1,0 +1,154 @@
+//! The frozen direct baseline for one run.
+//!
+//! A scored step is an offset from a known state, so the state has to be
+//! known before the step. The transport enters direct mode, sends one
+//! exact baseline as a continuous block until the flight controller reads
+//! it back and the vehicle is stable, and then freezes it for the run. A
+//! frozen baseline binds to its run intent: another run cannot reuse it.
+
+use flight_tune::Digest;
+
+use super::error::DirectTransportError;
+use super::port::DirectSetpoint;
+
+/// What the transport builds a direct baseline from.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DirectBaselineRequest {
+    /// The measured attitude, used when no direct setpoint is active.
+    pub measured_roll_rad: f64,
+    /// The measured pitch attitude in radians.
+    pub measured_pitch_rad: f64,
+    /// The measured heading in radians.
+    pub measured_yaw_rad: f64,
+    /// The identified hover trim for neutral collective force.
+    pub hover_trim: f64,
+    /// The run intent that the frozen baseline binds to.
+    pub run_intent_digest: Digest,
+    /// The largest number of commands in the baseline block.
+    pub max_commands: u32,
+}
+
+impl DirectBaselineRequest {
+    pub(super) fn validate(&self) -> Result<(), DirectTransportError> {
+        for (field, value) in [
+            ("measured roll", self.measured_roll_rad),
+            ("measured pitch", self.measured_pitch_rad),
+            ("measured heading", self.measured_yaw_rad),
+            ("hover trim", self.hover_trim),
+        ] {
+            if !value.is_finite() {
+                return Err(DirectTransportError::InvalidValue { field });
+            }
+        }
+        if self.run_intent_digest.is_zero() {
+            return Err(DirectTransportError::IncompleteIdentity {
+                detail: "the run intent digest is zero".to_owned(),
+            });
+        }
+        if self.max_commands == 0 {
+            return Err(DirectTransportError::InvalidValue {
+                field: "baseline block length",
+            });
+        }
+        Ok(())
+    }
+
+    /// The candidate baseline when no direct setpoint is active.
+    pub(super) const fn measured_baseline(&self) -> DirectSetpoint {
+        DirectSetpoint {
+            roll_rad: self.measured_roll_rad,
+            pitch_rad: self.measured_pitch_rad,
+            yaw_rad: self.measured_yaw_rad,
+            collective_force: self.hover_trim,
+        }
+    }
+
+    /// The candidate baseline when a direct setpoint is already active.
+    ///
+    /// The attitude axes come from the effective flight-controller
+    /// setpoint. The collective always comes from the identified hover
+    /// trim, because the trim is what a vertical stimulus measures from.
+    pub(super) const fn effective_baseline(&self, effective: DirectSetpoint) -> DirectSetpoint {
+        DirectSetpoint {
+            roll_rad: effective.roll_rad,
+            pitch_rad: effective.pitch_rad,
+            yaw_rad: effective.yaw_rad,
+            collective_force: self.hover_trim,
+        }
+    }
+}
+
+/// The frozen direct baseline of one run.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DirectBaseline {
+    setpoint: DirectSetpoint,
+    hover_trim: f64,
+    run_intent_digest: Digest,
+    frozen_at_ns: u64,
+    commands: u32,
+}
+
+impl DirectBaseline {
+    pub(super) const fn new(
+        setpoint: DirectSetpoint,
+        hover_trim: f64,
+        run_intent_digest: Digest,
+        frozen_at_ns: u64,
+        commands: u32,
+    ) -> Self {
+        Self {
+            setpoint,
+            hover_trim,
+            run_intent_digest,
+            frozen_at_ns,
+            commands,
+        }
+    }
+
+    /// The frozen baseline setpoint.
+    #[must_use]
+    pub const fn setpoint(&self) -> DirectSetpoint {
+        self.setpoint
+    }
+
+    /// The identified hover trim that the collective baseline came from.
+    #[must_use]
+    pub const fn hover_trim(&self) -> f64 {
+        self.hover_trim
+    }
+
+    /// The run intent that this baseline binds to.
+    #[must_use]
+    pub const fn run_intent_digest(&self) -> Digest {
+        self.run_intent_digest
+    }
+
+    /// The simulator time at which the baseline froze.
+    #[must_use]
+    pub const fn frozen_at_ns(&self) -> u64 {
+        self.frozen_at_ns
+    }
+
+    /// The number of commands the baseline block sent before it froze.
+    #[must_use]
+    pub const fn commands(&self) -> u32 {
+        self.commands
+    }
+
+    /// Rejects a run intent that is not the one this baseline froze for.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the run intent changed.
+    pub fn require_run_intent(
+        &self,
+        run_intent_digest: Digest,
+    ) -> Result<(), DirectTransportError> {
+        if run_intent_digest == self.run_intent_digest {
+            return Ok(());
+        }
+        Err(DirectTransportError::ChangedPreparedCommand {
+            detail: "the frozen run intent",
+        })
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/command.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/command.rs
@@ -258,9 +258,7 @@ impl DirectTransport {
                 ReadbackOutcome::Absent => break,
             }
         }
-        Err(DirectTransportError::EffectiveTargetMismatch {
-            tolerance: self.tolerance,
-        })
+        Err(DirectTransportError::NoEffectiveReadback)
     }
 
     fn source_for<S: DirectCommandSender + ?Sized>(

--- a/tools/flight-tune-aviate/src/direct_transport/command.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/command.rs
@@ -1,0 +1,328 @@
+//! Freezing the direct baseline, preparing exact commands, enacting them.
+//!
+//! Preparation and enactment are separate on purpose. A prepared command
+//! is complete and self-describing before any datagram can leave the
+//! process, and enactment re-derives it from the transport's own frozen
+//! state. A target, channel, family, envelope, baseline, or run intent
+//! that changed between the two is refused while the command is still a
+//! value in memory.
+
+use super::baseline::{DirectBaseline, DirectBaselineRequest};
+use super::error::DirectTransportError;
+use super::port::{
+    DirectCommandSender, DirectSetpoint, EffectiveSetpointReport, TransmittedDirectCommand,
+};
+use super::readback::ReadbackSelection;
+use super::record::{
+    DIRECT_COMMAND_RECORD_SCHEMA_VERSION, DirectCommandRecord, DirectCommandTimes,
+};
+use super::step::{
+    DirectCommandPurpose, DirectStepRequest, PreparedDirectCommand, envelope_digest,
+    require_direct_family, resolve_exact_target,
+};
+use super::{DirectEnactment, DirectTransport};
+
+/// How many times an enacted command re-reads a raw source that has not
+/// reached the command time yet. A future sample waits; it does not answer.
+const READBACK_POLL_LIMIT: u32 = 64;
+
+/// What the raw source can say about one query time.
+enum ReadbackOutcome {
+    Exact(EffectiveSetpointReport),
+    Pending,
+    Absent,
+}
+
+impl DirectTransport {
+    /// Enters direct mode and freezes the direct baseline for this run.
+    ///
+    /// The baseline comes from the effective flight-controller setpoint
+    /// when a direct setpoint is already active, and from the measured
+    /// attitude when none is. The collective baseline is always the
+    /// identified hover trim. The transport sends that exact baseline as a
+    /// continuous block until the flight controller reads it back and the
+    /// vehicle is stable, and then freezes it against the run intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the authority is revoked, when
+    /// a baseline is already frozen, when the request is incomplete, when
+    /// the command endpoint changed, or when the block ends without a
+    /// stable matching readback.
+    pub fn freeze_baseline_blocking<S: DirectCommandSender + ?Sized>(
+        &mut self,
+        sender: &mut S,
+        request: &DirectBaselineRequest,
+    ) -> Result<DirectBaseline, DirectTransportError> {
+        self.require_authority()?;
+        if self.baseline.is_some() {
+            return Err(DirectTransportError::BaselineFrozen);
+        }
+        request.validate()?;
+        self.session.require_endpoint(&sender.command_endpoint())?;
+        let candidate = match sender.effective_setpoint_blocking()? {
+            Some(report) => request.effective_baseline(report.setpoint),
+            None => request.measured_baseline(),
+        };
+        let mut commands = 0_u32;
+        while commands < request.max_commands {
+            commands = commands.wrapping_add(1);
+            let transmitted = self.transmit_exact(sender, candidate)?;
+            let ReadbackOutcome::Exact(report) =
+                self.read_back(sender, transmitted.transmitted_at_ns)?
+            else {
+                continue;
+            };
+            if report.setpoint.matches_within(&candidate, self.tolerance)
+                && sender.is_stable_blocking()?
+            {
+                let frozen = DirectBaseline::new(
+                    candidate,
+                    request.hover_trim,
+                    request.run_intent_digest,
+                    report.sample_time_ns,
+                    commands,
+                );
+                self.baseline = Some(frozen);
+                return Ok(frozen);
+            }
+        }
+        Err(DirectTransportError::BaselineNotSettled { commands })
+    }
+
+    /// Prepares the scored exact step for one direct stimulus.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the authority is revoked, when
+    /// the family is not the direct attitude and thrust family, when no
+    /// baseline is frozen, or when the envelope cannot resolve the value.
+    pub fn prepare_step(
+        &self,
+        stimulus: &DirectStepRequest,
+    ) -> Result<PreparedDirectCommand, DirectTransportError> {
+        self.prepare(DirectCommandPurpose::Step, stimulus)
+    }
+
+    /// Prepares the family-aware release back to the frozen baseline.
+    ///
+    /// A direct return test releases by sending the frozen direct baseline
+    /// as one exact step. Direct mode stays until data collection ends, so
+    /// no mode change can be counted as direct-controller response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the authority is revoked, when
+    /// the family is not the direct attitude and thrust family, or when no
+    /// baseline is frozen.
+    pub fn prepare_release(
+        &self,
+        stimulus: &DirectStepRequest,
+    ) -> Result<PreparedDirectCommand, DirectTransportError> {
+        self.prepare(DirectCommandPurpose::Release, stimulus)
+    }
+
+    /// Enacts one prepared direct command.
+    ///
+    /// The command is re-derived from the transport's own frozen state
+    /// before a datagram can leave the process. With no exact raw source
+    /// for the command time, nothing is sent and nothing is recorded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the authority is revoked, when
+    /// the prepared command no longer matches this transport, when the
+    /// endpoint changed, or when the transmitted or effective setpoint
+    /// leaves the requested target by more than the declared tolerance.
+    pub fn enact_blocking<S: DirectCommandSender + ?Sized>(
+        &mut self,
+        sender: &mut S,
+        prepared: &PreparedDirectCommand,
+    ) -> Result<DirectEnactment, DirectTransportError> {
+        self.require_authority()?;
+        self.session.require_endpoint(&sender.command_endpoint())?;
+        self.verify_prepared(prepared)?;
+        let requested_at_ns = sender.now_ns()?;
+        match self.source_for(sender, requested_at_ns)? {
+            ReadbackOutcome::Exact(_) => {}
+            ReadbackOutcome::Pending => return Ok(DirectEnactment::Pending),
+            ReadbackOutcome::Absent => return Ok(DirectEnactment::NoExactSource),
+        }
+        let transmitted = self.transmit_exact(sender, prepared.requested)?;
+        let effective = self.await_readback(sender, transmitted.transmitted_at_ns)?;
+        if !effective
+            .setpoint
+            .matches_within(&transmitted.setpoint, self.tolerance)
+        {
+            return Err(DirectTransportError::EffectiveTargetMismatch {
+                tolerance: self.tolerance,
+            });
+        }
+        Ok(DirectEnactment::Enacted(Box::new(record_for(
+            prepared,
+            &transmitted,
+            &effective,
+            requested_at_ns,
+        ))))
+    }
+
+    fn prepare(
+        &self,
+        purpose: DirectCommandPurpose,
+        stimulus: &DirectStepRequest,
+    ) -> Result<PreparedDirectCommand, DirectTransportError> {
+        self.require_direct_stimulus(stimulus.family)?;
+        let baseline = self.baseline.ok_or(DirectTransportError::NoBaseline)?;
+        Ok(PreparedDirectCommand {
+            purpose,
+            envelope_digest: envelope_digest(&stimulus.envelope)?,
+            baseline: baseline.setpoint(),
+            requested: target_for(purpose, stimulus, baseline.setpoint())?,
+            run_intent_digest: baseline.run_intent_digest(),
+            transport_identity_digest: self.session.identity_digest(),
+            stimulus: stimulus.clone(),
+        })
+    }
+
+    fn verify_prepared(
+        &self,
+        prepared: &PreparedDirectCommand,
+    ) -> Result<(), DirectTransportError> {
+        if prepared.transport_identity_digest != self.session.identity_digest() {
+            return Err(DirectTransportError::ChangedPreparedCommand {
+                detail: "the transport identity",
+            });
+        }
+        let baseline = self.baseline.ok_or(DirectTransportError::NoBaseline)?;
+        baseline.require_run_intent(prepared.run_intent_digest)?;
+        if prepared.baseline != baseline.setpoint() {
+            return Err(DirectTransportError::ChangedPreparedCommand {
+                detail: "the frozen direct baseline",
+            });
+        }
+        require_direct_family(prepared.stimulus.family)?;
+        if envelope_digest(&prepared.stimulus.envelope)? != prepared.envelope_digest {
+            return Err(DirectTransportError::ChangedPreparedCommand {
+                detail: "the frozen stimulus envelope",
+            });
+        }
+        if target_for(prepared.purpose, &prepared.stimulus, baseline.setpoint())?
+            != prepared.requested
+        {
+            return Err(DirectTransportError::ChangedPreparedCommand {
+                detail: "the re-derived physical target",
+            });
+        }
+        Ok(())
+    }
+
+    fn transmit_exact<S: DirectCommandSender + ?Sized>(
+        &self,
+        sender: &mut S,
+        requested: DirectSetpoint,
+    ) -> Result<TransmittedDirectCommand, DirectTransportError> {
+        let transmitted = sender.transmit_exact_blocking(requested)?;
+        if !transmitted
+            .setpoint
+            .matches_within(&requested, self.tolerance)
+        {
+            return Err(DirectTransportError::TransmittedTargetMismatch {
+                tolerance: self.tolerance,
+            });
+        }
+        Ok(transmitted)
+    }
+
+    /// The raw source outcome for the one sample after a transmit.
+    fn read_back<S: DirectCommandSender + ?Sized>(
+        &self,
+        sender: &mut S,
+        transmitted_at_ns: u64,
+    ) -> Result<ReadbackOutcome, DirectTransportError> {
+        let query_at_ns = self.readback.next_sample_after(transmitted_at_ns)?;
+        self.source_for(sender, query_at_ns)
+    }
+
+    /// Waits out a raw source that has not reached the command time.
+    fn await_readback<S: DirectCommandSender + ?Sized>(
+        &self,
+        sender: &mut S,
+        transmitted_at_ns: u64,
+    ) -> Result<EffectiveSetpointReport, DirectTransportError> {
+        let mut polls = 0_u32;
+        while polls < READBACK_POLL_LIMIT {
+            polls = polls.wrapping_add(1);
+            match self.read_back(sender, transmitted_at_ns)? {
+                ReadbackOutcome::Exact(report) => return Ok(report),
+                ReadbackOutcome::Pending => {}
+                ReadbackOutcome::Absent => break,
+            }
+        }
+        Err(DirectTransportError::EffectiveTargetMismatch {
+            tolerance: self.tolerance,
+        })
+    }
+
+    fn source_for<S: DirectCommandSender + ?Sized>(
+        &self,
+        sender: &mut S,
+        query_at_ns: u64,
+    ) -> Result<ReadbackOutcome, DirectTransportError> {
+        let Some(report) = sender.effective_setpoint_blocking()? else {
+            return Ok(ReadbackOutcome::Absent);
+        };
+        Ok(match self.readback.select(query_at_ns, &report)? {
+            ReadbackSelection::Exact => ReadbackOutcome::Exact(report),
+            ReadbackSelection::Pending => ReadbackOutcome::Pending,
+            ReadbackSelection::Absent => ReadbackOutcome::Absent,
+        })
+    }
+}
+
+/// The physical target that one command purpose asks for.
+fn target_for(
+    purpose: DirectCommandPurpose,
+    stimulus: &DirectStepRequest,
+    baseline: DirectSetpoint,
+) -> Result<DirectSetpoint, DirectTransportError> {
+    match purpose {
+        DirectCommandPurpose::Step => resolve_exact_target(stimulus, baseline),
+        // A baseline command and a release both command the frozen
+        // baseline itself, so neither resolves the envelope.
+        DirectCommandPurpose::Baseline | DirectCommandPurpose::Release => {
+            require_direct_family(stimulus.family)?;
+            Ok(baseline)
+        }
+    }
+}
+
+fn record_for(
+    prepared: &PreparedDirectCommand,
+    transmitted: &TransmittedDirectCommand,
+    effective: &EffectiveSetpointReport,
+    requested_at_ns: u64,
+) -> DirectCommandRecord {
+    DirectCommandRecord {
+        schema_version: DIRECT_COMMAND_RECORD_SCHEMA_VERSION,
+        purpose: prepared.purpose,
+        family: prepared.stimulus.family,
+        channel: prepared.stimulus.channel,
+        normalized: prepared.stimulus.normalized,
+        envelope_digest: prepared.envelope_digest,
+        baseline: prepared.baseline,
+        requested: prepared.requested,
+        transmitted: transmitted.setpoint,
+        effective: effective.setpoint,
+        sender: transmitted.sender.clone(),
+        effective_sample_sequence: effective.sample_sequence,
+        times: DirectCommandTimes {
+            requested_at_ns,
+            transmitted_at_ns: transmitted.transmitted_at_ns,
+            effective_at_ns: effective.sample_time_ns,
+            estimate_at_ns: effective.estimate_time_ns,
+            simulator_truth_at_ns: effective.simulator_truth_time_ns,
+        },
+        run_intent_digest: prepared.run_intent_digest,
+        transport_identity_digest: prepared.transport_identity_digest,
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/error.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/error.rs
@@ -103,6 +103,12 @@ pub enum DirectTransportError {
         /// The declared numeric tolerance.
         tolerance: f64,
     },
+    /// A transmitted command never got an exact effective readback.
+    ///
+    /// The command is already on the link, so the run cannot continue
+    /// unscored: it quarantines instead.
+    #[error("a transmitted direct command has no exact effective readback")]
+    NoEffectiveReadback,
     /// One supplied value is not a usable number.
     #[error("the direct transport received an unusable {field} value")]
     InvalidValue {

--- a/tools/flight-tune-aviate/src/direct_transport/error.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/error.rs
@@ -1,0 +1,141 @@
+//! Typed refusals from the simulator-only direct transport.
+
+use flight_tune::TuneError;
+
+use super::port::DirectSenderError;
+
+/// A simulator-only direct transport operation failed.
+///
+/// Every variant refuses a command. The transport has no outcome that
+/// alters a request and sends it anyway: an altered direct target would be
+/// recorded as flight-controller response.
+#[derive(Debug, thiserror::Error)]
+pub enum DirectTransportError {
+    /// The execution target is not a simulator.
+    #[error("the direct transport requires a simulator execution target")]
+    HardwareTarget,
+    /// One binding receipt does not accept the authenticated tuning session.
+    #[error("the {binding} binding did not accept the tuning session")]
+    UnverifiedBinding {
+        /// The binding that failed.
+        binding: &'static str,
+    },
+    /// One bound identity is missing.
+    #[error("the direct transport identity is incomplete: {detail}")]
+    IncompleteIdentity {
+        /// Stable validation detail.
+        detail: String,
+    },
+    /// One bound identity changed after the transport was authorized.
+    #[error("the {binding} identity changed after the direct transport was authorized")]
+    ChangedBinding {
+        /// The binding that changed.
+        binding: &'static str,
+    },
+    /// The transport no longer holds direct authority.
+    #[error("the direct transport authority is revoked")]
+    Revoked,
+    /// The stimulus does not command the direct attitude and thrust family.
+    #[error("the direct transport carries no {family} stimulus")]
+    UnsupportedFamily {
+        /// The refused control family.
+        family: String,
+    },
+    /// The stimulus mapping does not resolve an exact physical value.
+    #[error("the direct transport needs an exact stimulus mapping")]
+    InexactMapping,
+    /// The envelope physics do not match the control channel.
+    #[error("the {channel} envelope declares {detail}")]
+    EnvelopePhysics {
+        /// The control channel.
+        channel: String,
+        /// The mismatch that the envelope declares.
+        detail: String,
+    },
+    /// The stimulus envelope refused the normalized value.
+    #[error("the stimulus envelope refused the normalized value: {source}")]
+    Envelope {
+        /// The exact envelope failure.
+        #[source]
+        source: flight_tune::StimulusError,
+    },
+    /// The transport has no frozen direct baseline.
+    #[error("the direct transport has no frozen direct baseline")]
+    NoBaseline,
+    /// The direct baseline is already frozen for this run.
+    #[error("the direct baseline is already frozen for this run")]
+    BaselineFrozen,
+    /// The direct baseline did not settle inside its command block.
+    #[error("the direct baseline did not reach a stable readback in {commands} commands")]
+    BaselineNotSettled {
+        /// The number of baseline commands the block sent.
+        commands: u32,
+    },
+    /// A prepared command does not match the transport that must enact it.
+    #[error("the prepared direct command does not match {detail}")]
+    ChangedPreparedCommand {
+        /// The part of the transport state that the command left.
+        detail: &'static str,
+    },
+    /// The raw readback sample is not on the simulator sample grid.
+    #[error("the raw readback sample time {sample_time_ns} ns is off the {period_ns} ns grid")]
+    InvalidReadbackAlignment {
+        /// The reported sample time.
+        sample_time_ns: u64,
+        /// The declared sample period.
+        period_ns: u64,
+    },
+    /// A causal readback bound is not usable.
+    #[error("the causal readback bound is not usable: {detail}")]
+    InvalidReadbackBound {
+        /// Stable validation detail.
+        detail: &'static str,
+    },
+    /// The transmitted setpoint left the requested target.
+    #[error("the transmitted setpoint left the requested target by more than {tolerance}")]
+    TransmittedTargetMismatch {
+        /// The declared numeric tolerance.
+        tolerance: f64,
+    },
+    /// The effective flight-controller setpoint left the transmitted target.
+    #[error("the effective setpoint left the transmitted target by more than {tolerance}")]
+    EffectiveTargetMismatch {
+        /// The declared numeric tolerance.
+        tolerance: f64,
+    },
+    /// One supplied value is not a usable number.
+    #[error("the direct transport received an unusable {field} value")]
+    InvalidValue {
+        /// The field that carries the value.
+        field: &'static str,
+    },
+    /// A canonical document could not be encoded for its digest.
+    #[error("the direct transport could not calculate its {artifact} digest: {source}")]
+    Digest {
+        /// The artifact that has no digest.
+        artifact: &'static str,
+        /// The exact encoding failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// One artifact identity is invalid.
+    #[error("the direct transport identity is invalid: {source}")]
+    InvalidIdentity {
+        /// The exact identity failure.
+        #[source]
+        source: TuneError,
+    },
+    /// The exact direct command sender failed.
+    #[error("the direct command sender failed: {source}")]
+    Sender {
+        /// The exact sender failure.
+        #[source]
+        source: DirectSenderError,
+    },
+}
+
+impl From<DirectSenderError> for DirectTransportError {
+    fn from(source: DirectSenderError) -> Self {
+        Self::Sender { source }
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/port.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/port.rs
@@ -1,0 +1,176 @@
+//! The exact direct command sender port.
+//!
+//! The transport owns no socket. It borrows the command sender that
+//! already carries the vehicle's normal command stream, so every direct
+//! command keeps that stream's endpoint, MAVLink source identity, frame
+//! sequence, and boot time. A second sender would give the trial a second
+//! provenance, and a record could then no longer name which link the
+//! flight controller answered.
+
+use flight_tune::Digest;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// One absolute direct attitude and collective-force setpoint.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectSetpoint {
+    /// Absolute roll setpoint in radians.
+    pub roll_rad: f64,
+    /// Absolute pitch setpoint in radians.
+    pub pitch_rad: f64,
+    /// Absolute heading setpoint in radians.
+    pub yaw_rad: f64,
+    /// Normalized collective force.
+    pub collective_force: f64,
+}
+
+impl DirectSetpoint {
+    /// The four axes in a fixed order, for axis-by-axis comparison.
+    #[must_use]
+    pub const fn axes(&self) -> [f64; 4] {
+        [
+            self.roll_rad,
+            self.pitch_rad,
+            self.yaw_rad,
+            self.collective_force,
+        ]
+    }
+
+    /// Whether every axis is a finite number.
+    #[must_use]
+    pub fn is_finite(&self) -> bool {
+        self.axes().iter().all(|axis| axis.is_finite())
+    }
+
+    /// Whether every axis of `other` sits within `tolerance` of this one.
+    ///
+    /// A non-finite axis on either side never matches.
+    #[must_use]
+    pub fn matches_within(&self, other: &Self, tolerance: f64) -> bool {
+        if !tolerance.is_finite() || tolerance < 0.0 {
+            return false;
+        }
+        self.axes()
+            .iter()
+            .zip(other.axes())
+            .all(|(left, right)| (left - right).abs() <= tolerance)
+    }
+}
+
+/// The exact command sender that transmitted one direct command.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectSenderIdentity {
+    /// The command endpoint that every frame is addressed to.
+    pub endpoint: String,
+    /// The MAVLink system identity of the sender.
+    pub system_id: u8,
+    /// The MAVLink component identity of the sender.
+    pub component_id: u8,
+    /// The MAVLink frame sequence of this command.
+    pub sequence: u8,
+    /// The sender's boot time in milliseconds.
+    pub time_boot_ms: u32,
+    /// The digest of the exact transmitted frame bytes.
+    pub frame_digest: Digest,
+}
+
+/// What one exact direct command put on the command link.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransmittedDirectCommand {
+    /// The setpoint the sender encoded into the frame.
+    pub setpoint: DirectSetpoint,
+    /// The exact sender identity of the frame.
+    pub sender: DirectSenderIdentity,
+    /// The sender clock when the frame left the process, nanoseconds.
+    pub transmitted_at_ns: u64,
+}
+
+/// One raw source sample that reports the flight controller's setpoint.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EffectiveSetpointReport {
+    /// The setpoint the flight controller reports as active.
+    pub setpoint: DirectSetpoint,
+    /// The raw source sample sequence that carries the report.
+    pub sample_sequence: u64,
+    /// The raw source sample time in nanoseconds.
+    pub sample_time_ns: u64,
+    /// The vehicle estimate time for the same sample, nanoseconds.
+    pub estimate_time_ns: u64,
+    /// The simulator truth time for the same sample, nanoseconds.
+    pub simulator_truth_time_ns: u64,
+}
+
+/// The exact direct command sender for one simulator vehicle.
+///
+/// An implementation owns the flight-controller command link and the raw
+/// sample source that reports the controller's effective setpoint.
+pub trait DirectCommandSender {
+    /// The command endpoint that every frame is addressed to.
+    fn command_endpoint(&self) -> String;
+
+    /// The sender clock, in nanoseconds on the simulator sample grid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectSenderError`] when the clock is unreadable.
+    fn now_ns(&mut self) -> Result<u64, DirectSenderError>;
+
+    /// Transmits one exact setpoint and reports what reached the link.
+    ///
+    /// An implementation must transmit the setpoint unchanged or fail. It
+    /// must not clamp, shape, or rate-limit the request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectSenderError`] when the frame did not leave the
+    /// process unchanged.
+    fn transmit_exact_blocking(
+        &mut self,
+        setpoint: DirectSetpoint,
+    ) -> Result<TransmittedDirectCommand, DirectSenderError>;
+
+    /// The newest flight-controller setpoint report on the raw source.
+    ///
+    /// Returns `None` when the raw source carries no direct report.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectSenderError`] when the raw source is unreadable.
+    fn effective_setpoint_blocking(
+        &mut self,
+    ) -> Result<Option<EffectiveSetpointReport>, DirectSenderError>;
+
+    /// Whether the vehicle is stable enough to freeze a direct baseline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectSenderError`] when stability is not observable.
+    fn is_stable_blocking(&mut self) -> Result<bool, DirectSenderError>;
+}
+
+/// One exact direct command sender operation failed.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("the exact direct command sender failed during {operation}: {detail}")]
+pub struct DirectSenderError {
+    operation: &'static str,
+    detail: String,
+}
+
+impl DirectSenderError {
+    /// Creates a sender error with stable diagnostic text.
+    #[must_use]
+    pub fn new(operation: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            operation,
+            detail: detail.into(),
+        }
+    }
+
+    /// The sender operation that failed.
+    #[must_use]
+    pub const fn operation(&self) -> &'static str {
+        self.operation
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/readback.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/readback.rs
@@ -1,0 +1,131 @@
+//! Causal selection of the raw sample that reports one effective setpoint.
+//!
+//! A direct step is scored against the flight controller's own setpoint,
+//! so the sample that reports it has to be the sample the command reached.
+//! A sample from after the query time cannot answer for the query time: it
+//! waits, and is never promoted to the answer. A sample from further back
+//! than the maximum skew has lost the causal link and is never substituted
+//! either. The direct phase does not fall back to a delayed estimate: with
+//! no exact source the transport sends no direct demand and records no
+//! step or release marker at all.
+
+use super::error::DirectTransportError;
+use super::port::EffectiveSetpointReport;
+
+/// The causal alignment rule for one raw direct readback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CausalReadbackBound {
+    sample_period_ns: u64,
+    max_skew_ns: u64,
+}
+
+/// The outcome of one causal readback selection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadbackSelection {
+    /// The sample is the exact source for the query time.
+    Exact,
+    /// No sample has reached the query time. The caller waits.
+    Pending,
+    /// No exact source exists inside the causal bound.
+    Absent,
+}
+
+impl CausalReadbackBound {
+    /// Creates a causal readback bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the sample period is zero.
+    pub const fn new(
+        sample_period_ns: u64,
+        max_skew_ns: u64,
+    ) -> Result<Self, DirectTransportError> {
+        if sample_period_ns == 0 {
+            return Err(DirectTransportError::InvalidReadbackBound {
+                detail: "the simulator sample period is zero",
+            });
+        }
+        Ok(Self {
+            sample_period_ns,
+            max_skew_ns,
+        })
+    }
+
+    /// The simulator sample period in nanoseconds.
+    #[must_use]
+    pub const fn sample_period_ns(&self) -> u64 {
+        self.sample_period_ns
+    }
+
+    /// The largest permitted skew between a query time and its sample.
+    #[must_use]
+    pub const fn max_skew_ns(&self) -> u64 {
+        self.max_skew_ns
+    }
+
+    /// The first sample time strictly after `transmitted_at_ns`.
+    ///
+    /// This is the one sample in which an exact step must have reached the
+    /// flight controller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the next sample time would
+    /// leave the clock range.
+    pub const fn next_sample_after(
+        &self,
+        transmitted_at_ns: u64,
+    ) -> Result<u64, DirectTransportError> {
+        let elapsed = transmitted_at_ns % self.sample_period_ns;
+        let Some(next) = transmitted_at_ns.checked_add(self.sample_period_ns - elapsed) else {
+            return Err(DirectTransportError::InvalidReadbackBound {
+                detail: "the next sample time leaves the clock range",
+            });
+        };
+        Ok(next)
+    }
+
+    /// Selects one raw sample as the source for `query_at_ns`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the sample sequence and the
+    /// sample time do not describe the same instant on the sample clock.
+    pub fn select(
+        &self,
+        query_at_ns: u64,
+        report: &EffectiveSetpointReport,
+    ) -> Result<ReadbackSelection, DirectTransportError> {
+        self.require_alignment(report)?;
+        // A sample from after the query time answers for a later state of
+        // the vehicle. It waits; it is never promoted to this answer.
+        if report.sample_time_ns > query_at_ns {
+            return Ok(ReadbackSelection::Pending);
+        }
+        if query_at_ns - report.sample_time_ns <= self.max_skew_ns {
+            return Ok(ReadbackSelection::Exact);
+        }
+        Ok(ReadbackSelection::Absent)
+    }
+
+    /// A raw sample's sequence and time must describe the same instant.
+    ///
+    /// A report whose two clocks disagree cannot be placed against a
+    /// command, so it fails closed instead of being placed approximately.
+    const fn require_alignment(
+        &self,
+        report: &EffectiveSetpointReport,
+    ) -> Result<(), DirectTransportError> {
+        let misaligned = DirectTransportError::InvalidReadbackAlignment {
+            sample_time_ns: report.sample_time_ns,
+            period_ns: self.sample_period_ns,
+        };
+        let Some(expected) = report.sample_sequence.checked_mul(self.sample_period_ns) else {
+            return Err(misaligned);
+        };
+        if expected != report.sample_time_ns {
+            return Err(misaligned);
+        }
+        Ok(())
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/record.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/record.rs
@@ -3,8 +3,9 @@
 //! The record carries the whole causal chain of one command: what the
 //! scenario asked for, what the transport calculated, what the sender put
 //! on the link, and what the flight controller reported back, with the
-//! time of each. #469 binds this record to raw samples, the terminal
-//! receipt, the trace digest, and the campaign journal.
+//! time of each. The production scenario runtime binds this record to raw
+//! samples, the terminal receipt, the trace digest, and the campaign
+//! journal; the transport itself owns none of that.
 
 use flight_tune::{ControlChannel, ControlFamily, Digest};
 use serde::{Deserialize, Serialize};

--- a/tools/flight-tune-aviate/src/direct_transport/record.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/record.rs
@@ -1,0 +1,68 @@
+//! The causal record of one direct command.
+//!
+//! The record carries the whole causal chain of one command: what the
+//! scenario asked for, what the transport calculated, what the sender put
+//! on the link, and what the flight controller reported back, with the
+//! time of each. #469 binds this record to raw samples, the terminal
+//! receipt, the trace digest, and the campaign journal.
+
+use flight_tune::{ControlChannel, ControlFamily, Digest};
+use serde::{Deserialize, Serialize};
+
+use super::port::{DirectSenderIdentity, DirectSetpoint};
+use super::step::DirectCommandPurpose;
+
+/// Schema version of the direct command record.
+pub const DIRECT_COMMAND_RECORD_SCHEMA_VERSION: u16 = 1;
+
+/// The causal times of one direct command, in simulator nanoseconds.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectCommandTimes {
+    /// When the transport prepared the request.
+    pub requested_at_ns: u64,
+    /// When the frame left the process.
+    pub transmitted_at_ns: u64,
+    /// The raw sample that reported the effective setpoint.
+    pub effective_at_ns: u64,
+    /// The vehicle estimate time of that same sample.
+    pub estimate_at_ns: u64,
+    /// The simulator truth time of that same sample.
+    pub simulator_truth_at_ns: u64,
+}
+
+/// The complete causal record of one direct command.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectCommandRecord {
+    /// Record schema version.
+    pub schema_version: u16,
+    /// What this command is for.
+    pub purpose: DirectCommandPurpose,
+    /// The physical control family that the command commands.
+    pub family: ControlFamily,
+    /// The control channel that the command moves.
+    pub channel: ControlChannel,
+    /// The normalized stimulus value.
+    pub normalized: f64,
+    /// The frozen physical envelope of the normalized range.
+    pub envelope_digest: Digest,
+    /// The frozen direct baseline that the command was built from.
+    pub baseline: DirectSetpoint,
+    /// The physical target the transport calculated.
+    pub requested: DirectSetpoint,
+    /// The setpoint the sender put on the command link.
+    pub transmitted: DirectSetpoint,
+    /// The setpoint the flight controller reported as active.
+    pub effective: DirectSetpoint,
+    /// The exact command sender identity.
+    pub sender: DirectSenderIdentity,
+    /// The raw source sample that carried the effective readback.
+    pub effective_sample_sequence: u64,
+    /// The causal times of the command.
+    pub times: DirectCommandTimes,
+    /// The run intent that the command binds to.
+    pub run_intent_digest: Digest,
+    /// The direct transport that sent the command.
+    pub transport_identity_digest: Digest,
+}

--- a/tools/flight-tune-aviate/src/direct_transport/revoke.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/revoke.rs
@@ -1,0 +1,53 @@
+//! One idempotent removal of every direct authority.
+//!
+//! Revoke is not release. A release sends the frozen baseline and keeps
+//! direct mode through the observation window. Revoke removes the
+//! authority itself: after it, the transport prepares nothing, enacts
+//! nothing, and freezes nothing, and a command prepared before the revoke
+//! can no longer be enacted. #469 calls it from terminal and recovery
+//! paths, where the only safe assumption is that it may already have run.
+
+use flight_tune::Digest;
+
+/// The result of revoking one direct transport's authority.
+///
+/// The receipt is stable across calls: a second revoke returns the same
+/// value, and reports that it removed nothing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DirectRevokeReceipt {
+    transport_identity_digest: Digest,
+    removed_authority: bool,
+    released_baseline: bool,
+}
+
+impl DirectRevokeReceipt {
+    pub(super) const fn new(
+        transport_identity_digest: Digest,
+        removed_authority: bool,
+        released_baseline: bool,
+    ) -> Self {
+        Self {
+            transport_identity_digest,
+            removed_authority,
+            released_baseline,
+        }
+    }
+
+    /// The transport whose authority the revoke removed.
+    #[must_use]
+    pub const fn transport_identity_digest(&self) -> Digest {
+        self.transport_identity_digest
+    }
+
+    /// Whether this call was the one that removed the authority.
+    #[must_use]
+    pub const fn removed_authority(&self) -> bool {
+        self.removed_authority
+    }
+
+    /// Whether this call was the one that released a frozen baseline.
+    #[must_use]
+    pub const fn released_baseline(&self) -> bool {
+        self.released_baseline
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/revoke.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/revoke.rs
@@ -4,8 +4,9 @@
 //! direct mode through the observation window. Revoke removes the
 //! authority itself: after it, the transport prepares nothing, enacts
 //! nothing, and freezes nothing, and a command prepared before the revoke
-//! can no longer be enacted. #469 calls it from terminal and recovery
-//! paths, where the only safe assumption is that it may already have run.
+//! can no longer be enacted. The production runtime calls it from terminal
+//! and recovery paths, where the only safe assumption is that it may
+//! already have run.
 
 use flight_tune::Digest;
 

--- a/tools/flight-tune-aviate/src/direct_transport/session.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/session.rs
@@ -1,0 +1,198 @@
+//! The authenticated, simulator-only authority for one direct transport.
+//!
+//! A direct transport exists only where a validated tuning session, a
+//! verified simulator binding, and a simulator execution target all agree.
+//! Its identity names every part that could change what a direct command
+//! means, so a record can be read back against the exact thing that sent
+//! it.
+
+use flight_tune::{
+    ArtifactIdentity, Digest, ExecutionTarget, SimulatorCapability, SimulatorSessionReceipt,
+    VehicleBindingReceipt,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use super::error::DirectTransportError;
+
+/// Schema version of the direct-transport identity document.
+pub const DIRECT_TRANSPORT_IDENTITY_SCHEMA_VERSION: u16 = 1;
+
+const IDENTITY_DIGEST_DOMAIN: &[u8] = b"pilotage-aviate-direct-transport-identity-v1\0";
+
+/// The immutable identity of one simulator-only direct transport.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectTransportIdentity {
+    /// Identity document schema version.
+    pub schema_version: u16,
+    /// The validated tuning session.
+    pub session_digest: Digest,
+    /// The running simulator.
+    pub simulator_digest: Digest,
+    /// The loaded airframe.
+    pub airframe_digest: Digest,
+    /// The bound vehicle adapter.
+    pub vehicle_digest: Digest,
+    /// The final engine and vehicle action-port runtime.
+    pub scenario_runtime_digest: Digest,
+    /// The flight-controller command endpoint.
+    pub command_endpoint: String,
+    /// The direct-transport implementation.
+    pub transport: ArtifactIdentity,
+}
+
+impl DirectTransportIdentity {
+    /// The digest of this identity document.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the document cannot encode.
+    pub fn digest(&self) -> Result<Digest, DirectTransportError> {
+        let bytes = serde_json::to_vec(self).map_err(|source| DirectTransportError::Digest {
+            artifact: "identity",
+            source,
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(IDENTITY_DIGEST_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+}
+
+/// The authenticated authority that one direct transport is built from.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectTransportSession {
+    identity: DirectTransportIdentity,
+    identity_digest: Digest,
+}
+
+impl DirectTransportSession {
+    /// Authorizes one simulator-only direct transport.
+    ///
+    /// The simulator receipt and the vehicle binding must both name the
+    /// tuning session that the capability validated, and the execution
+    /// target must be a simulator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the target is a real vehicle,
+    /// when a binding does not accept the session, or when a bound identity
+    /// is missing.
+    pub fn authorize(
+        capability: &SimulatorCapability,
+        simulator: &SimulatorSessionReceipt,
+        vehicle: &VehicleBindingReceipt,
+        target: ExecutionTarget,
+        command_endpoint: &str,
+        transport: &ArtifactIdentity,
+    ) -> Result<Self, DirectTransportError> {
+        if target != ExecutionTarget::Simulator {
+            return Err(DirectTransportError::HardwareTarget);
+        }
+        let session_digest = capability.session_digest();
+        if simulator.session_digest != session_digest {
+            return Err(DirectTransportError::UnverifiedBinding {
+                binding: "simulator",
+            });
+        }
+        if vehicle.session_digest != session_digest {
+            return Err(DirectTransportError::UnverifiedBinding { binding: "vehicle" });
+        }
+        // `ArtifactIdentity::new` is the harness's public validation path:
+        // it refuses an empty name and a zero digest.
+        ArtifactIdentity::new(transport.id.clone(), transport.digest)
+            .map_err(|source| DirectTransportError::InvalidIdentity { source })?;
+        let identity = DirectTransportIdentity {
+            schema_version: DIRECT_TRANSPORT_IDENTITY_SCHEMA_VERSION,
+            session_digest,
+            simulator_digest: simulator.simulator_digest,
+            airframe_digest: simulator.airframe_digest,
+            vehicle_digest: vehicle.vehicle_digest,
+            scenario_runtime_digest: vehicle.scenario_runtime_digest,
+            command_endpoint: command_endpoint.to_owned(),
+            transport: transport.clone(),
+        };
+        identity.require_complete()?;
+        let identity_digest = identity.digest()?;
+        Ok(Self {
+            identity,
+            identity_digest,
+        })
+    }
+
+    /// The bound transport identity.
+    #[must_use]
+    pub const fn identity(&self) -> &DirectTransportIdentity {
+        &self.identity
+    }
+
+    /// The digest of the bound transport identity.
+    #[must_use]
+    pub const fn identity_digest(&self) -> Digest {
+        self.identity_digest
+    }
+
+    /// Rejects a session or runtime identity that changed after authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when a binding no longer matches.
+    pub fn require_unchanged(
+        &self,
+        capability: &SimulatorCapability,
+        vehicle: &VehicleBindingReceipt,
+    ) -> Result<(), DirectTransportError> {
+        if capability.session_digest() != self.identity.session_digest
+            || vehicle.session_digest != self.identity.session_digest
+        {
+            return Err(DirectTransportError::ChangedBinding { binding: "session" });
+        }
+        if vehicle.scenario_runtime_digest != self.identity.scenario_runtime_digest {
+            return Err(DirectTransportError::ChangedBinding { binding: "runtime" });
+        }
+        if vehicle.vehicle_digest != self.identity.vehicle_digest {
+            return Err(DirectTransportError::ChangedBinding { binding: "vehicle" });
+        }
+        Ok(())
+    }
+
+    /// Rejects a command endpoint that is not the bound one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirectTransportError`] when the endpoint changed.
+    pub fn require_endpoint(&self, endpoint: &str) -> Result<(), DirectTransportError> {
+        if endpoint == self.identity.command_endpoint {
+            return Ok(());
+        }
+        Err(DirectTransportError::ChangedBinding {
+            binding: "command endpoint",
+        })
+    }
+}
+
+impl DirectTransportIdentity {
+    fn require_complete(&self) -> Result<(), DirectTransportError> {
+        for (name, digest) in [
+            ("session", self.session_digest),
+            ("simulator", self.simulator_digest),
+            ("airframe", self.airframe_digest),
+            ("vehicle", self.vehicle_digest),
+            ("scenario runtime", self.scenario_runtime_digest),
+        ] {
+            if digest.is_zero() {
+                return Err(DirectTransportError::IncompleteIdentity {
+                    detail: format!("the {name} digest is zero"),
+                });
+            }
+        }
+        if self.command_endpoint.trim().is_empty() || self.command_endpoint.len() > 256 {
+            return Err(DirectTransportError::IncompleteIdentity {
+                detail: "the command endpoint is not a short, non-empty name".to_owned(),
+            });
+        }
+        Ok(())
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/step.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/step.rs
@@ -1,0 +1,265 @@
+//! Exact physical targets, and the prepared command that carries one.
+//!
+//! A prepared command is complete before any datagram can leave the
+//! process. The transport re-derives it at enactment and refuses a target
+//! that changed, so a substituted target, channel, or family is caught
+//! while the command is still a value in memory.
+
+use flight_tune::{
+    ControlChannel, ControlFamily, Digest, PhysicalUnit, ReferenceRule, StimulusEnvelope,
+    StimulusMapping,
+};
+use serde::{Deserialize, Serialize};
+
+use super::error::DirectTransportError;
+use super::port::DirectSetpoint;
+
+/// What one direct command is for.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectCommandPurpose {
+    /// One command in the block that establishes the frozen baseline.
+    Baseline,
+    /// The scored exact step.
+    Step,
+    /// The family-aware release back to the frozen baseline.
+    Release,
+}
+
+impl DirectCommandPurpose {
+    /// The stable name of this purpose.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Step => "step",
+            Self::Release => "release",
+        }
+    }
+}
+
+/// One requested exact direct step.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DirectStepRequest {
+    /// The physical control family that the stimulus commands.
+    pub family: ControlFamily,
+    /// The control channel that the step moves.
+    pub channel: ControlChannel,
+    /// The rule that resolves a normalized value to a physical command.
+    pub mapping: StimulusMapping,
+    /// The frozen physical envelope of the normalized range.
+    pub envelope: StimulusEnvelope,
+    /// The normalized stimulus value.
+    pub normalized: f64,
+}
+
+/// One direct command, complete before any datagram leaves the process.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedDirectCommand {
+    pub(super) purpose: DirectCommandPurpose,
+    pub(super) stimulus: DirectStepRequest,
+    pub(super) envelope_digest: Digest,
+    pub(super) baseline: DirectSetpoint,
+    pub(super) requested: DirectSetpoint,
+    pub(super) run_intent_digest: Digest,
+    pub(super) transport_identity_digest: Digest,
+}
+
+impl PreparedDirectCommand {
+    /// What this command is for.
+    #[must_use]
+    pub const fn purpose(&self) -> DirectCommandPurpose {
+        self.purpose
+    }
+
+    /// The stimulus that this command resolves.
+    #[must_use]
+    pub const fn stimulus(&self) -> &DirectStepRequest {
+        &self.stimulus
+    }
+
+    /// The control channel that this command moves.
+    #[must_use]
+    pub const fn channel(&self) -> ControlChannel {
+        self.stimulus.channel
+    }
+
+    /// The frozen stimulus envelope of this command.
+    #[must_use]
+    pub const fn envelope_digest(&self) -> Digest {
+        self.envelope_digest
+    }
+
+    /// The physical target that the command must transmit unchanged.
+    #[must_use]
+    pub const fn requested(&self) -> DirectSetpoint {
+        self.requested
+    }
+
+    /// The frozen direct baseline that this command was built from.
+    #[must_use]
+    pub const fn baseline(&self) -> DirectSetpoint {
+        self.baseline
+    }
+
+    /// The run intent that this command binds to.
+    #[must_use]
+    pub const fn run_intent_digest(&self) -> Digest {
+        self.run_intent_digest
+    }
+
+    /// Replaces the physical target, for a tamper test.
+    ///
+    /// The transport re-derives every prepared target before it enacts it,
+    /// so this exists to prove that the re-derivation refuses a changed
+    /// target while the command is still a value in memory.
+    #[must_use]
+    pub const fn with_requested_for_test(mut self, requested: DirectSetpoint) -> Self {
+        self.requested = requested;
+        self
+    }
+
+    /// Replaces the stimulus, for a tamper test.
+    ///
+    /// A substituted family, channel, envelope, or normalized value has to
+    /// be caught by the same re-derivation.
+    #[must_use]
+    pub fn with_stimulus_for_test(mut self, stimulus: DirectStepRequest) -> Self {
+        self.stimulus = stimulus;
+        self
+    }
+}
+
+/// Applies one exact physical offset to a frozen direct baseline.
+///
+/// The envelope resolves an offset from its reference rule, so every
+/// channel other than the commanded one keeps its frozen baseline value
+/// bit for bit.
+///
+/// # Errors
+///
+/// Returns [`DirectTransportError`] when the family is not the direct
+/// attitude and thrust family, when the mapping is not exact, when the
+/// envelope physics do not match the channel, or when the envelope refuses
+/// the normalized value.
+pub fn resolve_exact_target(
+    request: &DirectStepRequest,
+    baseline: DirectSetpoint,
+) -> Result<DirectSetpoint, DirectTransportError> {
+    require_direct_family(request.family)?;
+    if request.mapping != StimulusMapping::AffineExact {
+        return Err(DirectTransportError::InexactMapping);
+    }
+    require_channel_physics(request.channel, &request.envelope)?;
+    let offset = request
+        .mapping
+        .resolve_exact(&request.envelope, request.normalized)
+        .map_err(|source| DirectTransportError::Envelope { source })?;
+    if !offset.is_finite() {
+        return Err(DirectTransportError::InvalidValue {
+            field: "physical offset",
+        });
+    }
+    let target = match request.channel {
+        ControlChannel::Roll => DirectSetpoint {
+            roll_rad: baseline.roll_rad + offset,
+            ..baseline
+        },
+        ControlChannel::Pitch => DirectSetpoint {
+            pitch_rad: baseline.pitch_rad + offset,
+            ..baseline
+        },
+        ControlChannel::Yaw => DirectSetpoint {
+            yaw_rad: baseline.yaw_rad + offset,
+            ..baseline
+        },
+        // The frozen baseline collective IS the identified hover trim, so
+        // the vertical offset measures from the same value its reference
+        // rule names.
+        ControlChannel::Vertical => DirectSetpoint {
+            collective_force: baseline.collective_force + offset,
+            ..baseline
+        },
+    };
+    if !target.is_finite() {
+        return Err(DirectTransportError::InvalidValue {
+            field: "physical target",
+        });
+    }
+    Ok(target)
+}
+
+/// Rejects a control family that the direct transport does not carry.
+///
+/// # Errors
+///
+/// Returns [`DirectTransportError`] for the operator velocity family,
+/// which keeps its own shaped path.
+pub fn require_direct_family(family: ControlFamily) -> Result<(), DirectTransportError> {
+    match family {
+        ControlFamily::DirectAttitudeThrust => Ok(()),
+        ControlFamily::OperatorVelocity => Err(DirectTransportError::UnsupportedFamily {
+            family: family.as_str().to_owned(),
+        }),
+    }
+}
+
+/// The digest of one frozen stimulus envelope.
+///
+/// # Errors
+///
+/// Returns [`DirectTransportError`] when the envelope cannot be encoded.
+pub fn envelope_digest(envelope: &StimulusEnvelope) -> Result<Digest, DirectTransportError> {
+    // The mission document and the tuning harness each carry their own
+    // digest type over the same 32 bytes, so the value crosses by bytes.
+    let canonical =
+        envelope
+            .canonical_digest()
+            .map_err(|error| DirectTransportError::IncompleteIdentity {
+                detail: format!("the stimulus envelope has no canonical digest: {error}"),
+            })?;
+    Ok(Digest::from_bytes(*canonical.as_bytes()))
+}
+
+/// The envelope physics that each direct channel must declare.
+///
+/// The authored document is validated upstream. The transport checks the
+/// same rule again because it is the last place that can refuse a stimulus
+/// before a datagram commands the vehicle.
+fn require_channel_physics(
+    channel: ControlChannel,
+    envelope: &StimulusEnvelope,
+) -> Result<(), DirectTransportError> {
+    let (unit, reference) = match channel {
+        ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Yaw => (
+            PhysicalUnit::Radians,
+            ReferenceRule::EffectiveSetpointAtEntry,
+        ),
+        ControlChannel::Vertical => (
+            PhysicalUnit::NormalizedCollectiveForce,
+            ReferenceRule::IdentifiedHoverTrim,
+        ),
+    };
+    if envelope.unit != unit {
+        return Err(DirectTransportError::EnvelopePhysics {
+            channel: channel_name(channel).to_owned(),
+            detail: "another physical unit".to_owned(),
+        });
+    }
+    if envelope.reference != reference {
+        return Err(DirectTransportError::EnvelopePhysics {
+            channel: channel_name(channel).to_owned(),
+            detail: "another reference rule".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+pub(super) const fn channel_name(channel: ControlChannel) -> &'static str {
+    match channel {
+        ControlChannel::Roll => "roll",
+        ControlChannel::Pitch => "pitch",
+        ControlChannel::Yaw => "yaw",
+        ControlChannel::Vertical => "vertical",
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests.rs
@@ -1,0 +1,155 @@
+//! Conformance tests for the simulator-only direct transport.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod authority;
+mod baseline;
+mod readback;
+mod revoke;
+mod sender;
+mod step;
+
+use flight_tune::{
+    ArtifactIdentity, ControlChannel, ControlFamily, Digest, ExecutionTarget, PhysicalUnit,
+    ReferenceRule, SimulatorCapability, SimulatorSessionReceipt, StimulusEnvelope, StimulusMapping,
+    VehicleBindingReceipt,
+};
+
+use super::{
+    CausalReadbackBound, DirectBaselineRequest, DirectStepRequest, DirectTransport,
+    DirectTransportError, DirectTransportRequest, direct_transport_identity,
+};
+use sender::RecordingSender;
+
+/// One simulator sample at the flight controller's 80 Hz setpoint rate.
+const SAMPLE_PERIOD_NS: u64 = 12_500_000;
+/// The identified hover trim of the test airframe.
+const HOVER_TRIM: f64 = 0.72;
+/// The declared numeric tolerance for a target comparison.
+const TOLERANCE: f64 = 1e-9;
+
+fn digest(seed: u8) -> Digest {
+    Digest::from_bytes([seed; 32])
+}
+
+fn session_receipt() -> SimulatorSessionReceipt {
+    SimulatorSessionReceipt {
+        session_digest: digest(1),
+        simulator_digest: digest(2),
+        airframe_digest: digest(3),
+    }
+}
+
+fn vehicle_receipt() -> VehicleBindingReceipt {
+    VehicleBindingReceipt {
+        session_digest: digest(1),
+        vehicle_digest: digest(4),
+        scenario_runtime_digest: digest(5),
+    }
+}
+
+fn capability() -> SimulatorCapability {
+    SimulatorCapability::for_test(session_receipt())
+}
+
+fn transport_identity() -> ArtifactIdentity {
+    direct_transport_identity().expect("transport identity")
+}
+
+fn readback_bound() -> CausalReadbackBound {
+    CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS).expect("readback bound")
+}
+
+fn authorize(sender: &RecordingSender) -> DirectTransport {
+    authorize_with(
+        sender,
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &vehicle_receipt(),
+    )
+    .expect("authorized transport")
+}
+
+fn authorize_with(
+    sender: &RecordingSender,
+    target: ExecutionTarget,
+    simulator: &SimulatorSessionReceipt,
+    vehicle: &VehicleBindingReceipt,
+) -> Result<DirectTransport, DirectTransportError> {
+    let capability = capability();
+    let transport = transport_identity();
+    DirectTransport::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator,
+            vehicle,
+            target,
+            transport: &transport,
+            readback: readback_bound(),
+            tolerance: TOLERANCE,
+        },
+        sender,
+    )
+}
+
+fn baseline_request() -> DirectBaselineRequest {
+    DirectBaselineRequest {
+        measured_roll_rad: 0.01,
+        measured_pitch_rad: -0.02,
+        measured_yaw_rad: 1.2,
+        hover_trim: HOVER_TRIM,
+        run_intent_digest: digest(9),
+        max_commands: 8,
+    }
+}
+
+/// An envelope whose neutral is zero, so a normalized zero resolves to the
+/// frozen baseline itself.
+fn attitude_envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "alia-tilt-v1".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::Radians,
+        reference: ReferenceRule::EffectiveSetpointAtEntry,
+        negative_endpoint: -0.25,
+        neutral: 0.0,
+        positive_endpoint: 0.25,
+    }
+}
+
+fn collective_envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "alia-collective-v1".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::NormalizedCollectiveForce,
+        reference: ReferenceRule::IdentifiedHoverTrim,
+        negative_endpoint: -0.1,
+        neutral: 0.0,
+        positive_endpoint: 0.1,
+    }
+}
+
+fn step_request(channel: ControlChannel, normalized: f64) -> DirectStepRequest {
+    let envelope = match channel {
+        ControlChannel::Vertical => collective_envelope(),
+        ControlChannel::Roll | ControlChannel::Pitch | ControlChannel::Yaw => attitude_envelope(),
+    };
+    DirectStepRequest {
+        family: ControlFamily::DirectAttitudeThrust,
+        channel,
+        mapping: StimulusMapping::AffineExact,
+        envelope,
+        normalized,
+    }
+}
+
+/// A transport with a frozen baseline, and the sender it froze against.
+fn frozen() -> (DirectTransport, RecordingSender) {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    sender.clear_transmitted();
+    (transport, sender)
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests.rs
@@ -70,11 +70,34 @@ fn authorize(sender: &RecordingSender) -> DirectTransport {
     .expect("authorized transport")
 }
 
+/// A transport that accepts only a sample at exactly the query time.
+fn authorize_without_skew(sender: &RecordingSender) -> DirectTransport {
+    let bound = CausalReadbackBound::new(SAMPLE_PERIOD_NS, 0).expect("readback bound");
+    authorize_bound(
+        sender,
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &vehicle_receipt(),
+        bound,
+    )
+    .expect("authorized transport")
+}
+
 fn authorize_with(
     sender: &RecordingSender,
     target: ExecutionTarget,
     simulator: &SimulatorSessionReceipt,
     vehicle: &VehicleBindingReceipt,
+) -> Result<DirectTransport, DirectTransportError> {
+    authorize_bound(sender, target, simulator, vehicle, readback_bound())
+}
+
+fn authorize_bound(
+    sender: &RecordingSender,
+    target: ExecutionTarget,
+    simulator: &SimulatorSessionReceipt,
+    vehicle: &VehicleBindingReceipt,
+    readback: CausalReadbackBound,
 ) -> Result<DirectTransport, DirectTransportError> {
     let capability = capability();
     let transport = transport_identity();
@@ -85,7 +108,7 @@ fn authorize_with(
             vehicle,
             target,
             transport: &transport,
-            readback: readback_bound(),
+            readback,
             tolerance: TOLERANCE,
         },
         sender,

--- a/tools/flight-tune-aviate/src/direct_transport/tests/authority.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/authority.rs
@@ -1,0 +1,248 @@
+//! The one authenticated, simulator-only authority the transport needs.
+
+use flight_tune::{ArtifactIdentity, Digest, ExecutionTarget};
+
+use super::super::{DirectTransport, DirectTransportError, DirectTransportRequest};
+use super::sender::RecordingSender;
+use super::{
+    TOLERANCE, authorize, authorize_with, capability, digest, readback_bound, session_receipt,
+    transport_identity, vehicle_receipt,
+};
+
+#[test]
+fn a_hardware_target_cannot_construct_the_simulator_transport() {
+    let sender = RecordingSender::new();
+
+    let result = authorize_with(
+        &sender,
+        ExecutionTarget::RealVehicle,
+        &session_receipt(),
+        &vehicle_receipt(),
+    );
+
+    assert!(matches!(result, Err(DirectTransportError::HardwareTarget)));
+    assert!(
+        sender.transmitted().is_empty(),
+        "a refused authority must not command the vehicle"
+    );
+}
+
+#[test]
+fn an_unverified_simulator_binding_fails_before_any_command() {
+    let sender = RecordingSender::new();
+    let mut simulator = session_receipt();
+    simulator.session_digest = digest(0x7f);
+
+    let result = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &simulator,
+        &vehicle_receipt(),
+    );
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::UnverifiedBinding {
+            binding: "simulator"
+        })
+    ));
+    assert!(sender.transmitted().is_empty());
+}
+
+#[test]
+fn an_unverified_vehicle_binding_fails_before_any_command() {
+    let sender = RecordingSender::new();
+    let mut vehicle = vehicle_receipt();
+    vehicle.session_digest = digest(0x7f);
+
+    let result = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &vehicle,
+    );
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::UnverifiedBinding { binding: "vehicle" })
+    ));
+    assert!(sender.transmitted().is_empty());
+}
+
+#[test]
+fn an_incomplete_bound_identity_fails_before_any_command() {
+    let sender = RecordingSender::new();
+    let mut simulator = session_receipt();
+    simulator.airframe_digest = Digest::from_bytes([0; 32]);
+
+    let result = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &simulator,
+        &vehicle_receipt(),
+    );
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::IncompleteIdentity { .. })
+    ));
+}
+
+#[test]
+fn an_invalid_transport_implementation_identity_is_refused() {
+    let sender = RecordingSender::new();
+    let simulator = session_receipt();
+    let vehicle = vehicle_receipt();
+    let capability = capability();
+    let transport = ArtifactIdentity {
+        id: "pilotage-aviate-direct-transport-v1".to_owned(),
+        digest: Digest::from_bytes([0; 32]),
+    };
+
+    let result = DirectTransport::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target: ExecutionTarget::Simulator,
+            transport: &transport,
+            readback: readback_bound(),
+            tolerance: TOLERANCE,
+        },
+        &sender,
+    );
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::InvalidIdentity { .. })
+    ));
+}
+
+#[test]
+fn the_transport_identity_binds_every_part_of_the_run() {
+    let sender = RecordingSender::new();
+    let baseline = authorize(&sender);
+    let bound = baseline.session().identity_digest();
+
+    let mut other_simulator = session_receipt();
+    other_simulator.simulator_digest = digest(0x21);
+    let changed_simulator = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &other_simulator,
+        &vehicle_receipt(),
+    )
+    .expect("authorized transport");
+
+    let mut other_airframe = session_receipt();
+    other_airframe.airframe_digest = digest(0x22);
+    let changed_airframe = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &other_airframe,
+        &vehicle_receipt(),
+    )
+    .expect("authorized transport");
+
+    let mut other_vehicle = vehicle_receipt();
+    other_vehicle.vehicle_digest = digest(0x23);
+    let changed_vehicle = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &other_vehicle,
+    )
+    .expect("authorized transport");
+
+    let mut other_runtime = vehicle_receipt();
+    other_runtime.scenario_runtime_digest = digest(0x24);
+    let changed_runtime = authorize_with(
+        &sender,
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &other_runtime,
+    )
+    .expect("authorized transport");
+
+    let changed_endpoint = authorize_with(
+        &RecordingSender::new().with_endpoint("127.0.0.1:20001"),
+        ExecutionTarget::Simulator,
+        &session_receipt(),
+        &vehicle_receipt(),
+    )
+    .expect("authorized transport");
+
+    for (name, other) in [
+        ("simulator", &changed_simulator),
+        ("airframe", &changed_airframe),
+        ("vehicle", &changed_vehicle),
+        ("scenario runtime", &changed_runtime),
+        ("command endpoint", &changed_endpoint),
+    ] {
+        assert_ne!(
+            bound,
+            other.session().identity_digest(),
+            "a changed {name} must change the transport identity"
+        );
+    }
+    assert_eq!(
+        baseline.session().identity().transport,
+        transport_identity(),
+        "the transport implementation identity is bound"
+    );
+}
+
+#[test]
+fn a_changed_session_or_runtime_identity_rejects_the_transport() {
+    let sender = RecordingSender::new();
+    let transport = authorize(&sender);
+
+    transport
+        .require_binding(&capability(), &vehicle_receipt())
+        .expect("the unchanged binding stays valid");
+
+    let mut changed_runtime = vehicle_receipt();
+    changed_runtime.scenario_runtime_digest = digest(0x31);
+    assert!(matches!(
+        transport.require_binding(&capability(), &changed_runtime),
+        Err(DirectTransportError::ChangedBinding { binding: "runtime" })
+    ));
+
+    let mut changed_session = vehicle_receipt();
+    changed_session.session_digest = digest(0x32);
+    assert!(matches!(
+        transport.require_binding(&capability(), &changed_session),
+        Err(DirectTransportError::ChangedBinding { binding: "session" })
+    ));
+
+    let mut changed_vehicle = vehicle_receipt();
+    changed_vehicle.vehicle_digest = digest(0x33);
+    assert!(matches!(
+        transport.require_binding(&capability(), &changed_vehicle),
+        Err(DirectTransportError::ChangedBinding { binding: "vehicle" })
+    ));
+}
+
+#[test]
+fn a_command_endpoint_that_is_not_the_bound_one_is_refused() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    let mut moved = RecordingSender::new().with_endpoint("127.0.0.1:20099");
+
+    transport
+        .freeze_baseline_blocking(&mut sender, &super::baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&super::step_request(flight_tune::ControlChannel::Roll, 0.5))
+        .expect("prepared step");
+
+    let result = transport.enact_blocking(&mut moved, &prepared);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::ChangedBinding {
+            binding: "command endpoint"
+        })
+    ));
+    assert!(moved.transmitted().is_empty());
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/baseline.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/baseline.rs
@@ -1,0 +1,150 @@
+//! Freezing the direct baseline for one run.
+
+use super::super::{DirectSetpoint, DirectTransportError, EffectiveSetpointReport};
+use super::sender::RecordingSender;
+use super::{HOVER_TRIM, SAMPLE_PERIOD_NS, authorize, baseline_request};
+
+fn active_direct_setpoint() -> DirectSetpoint {
+    DirectSetpoint {
+        roll_rad: 0.14,
+        pitch_rad: -0.09,
+        yaw_rad: 2.1,
+        collective_force: 0.55,
+    }
+}
+
+fn active_report() -> EffectiveSetpointReport {
+    EffectiveSetpointReport {
+        setpoint: active_direct_setpoint(),
+        sample_sequence: 0,
+        sample_time_ns: 0,
+        estimate_time_ns: 0,
+        simulator_truth_time_ns: 0,
+    }
+}
+
+#[test]
+fn a_direct_step_starts_from_the_recorded_effective_setpoint() {
+    let mut sender = RecordingSender::new().reporting(active_report());
+    let mut transport = authorize(&sender);
+
+    let baseline = transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+
+    let active = active_direct_setpoint();
+    assert_eq!(baseline.setpoint().roll_rad, active.roll_rad);
+    assert_eq!(baseline.setpoint().pitch_rad, active.pitch_rad);
+    assert_eq!(baseline.setpoint().yaw_rad, active.yaw_rad);
+    assert_eq!(
+        baseline.setpoint().collective_force,
+        HOVER_TRIM,
+        "neutral collective force is the identified hover trim"
+    );
+    assert_eq!(baseline.hover_trim(), HOVER_TRIM);
+}
+
+#[test]
+fn a_baseline_uses_the_measured_attitude_when_no_direct_setpoint_is_active() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    let request = baseline_request();
+
+    let baseline = transport
+        .freeze_baseline_blocking(&mut sender, &request)
+        .expect("frozen baseline");
+
+    assert_eq!(baseline.setpoint().roll_rad, request.measured_roll_rad);
+    assert_eq!(baseline.setpoint().pitch_rad, request.measured_pitch_rad);
+    assert_eq!(baseline.setpoint().yaw_rad, request.measured_yaw_rad);
+    assert_eq!(baseline.setpoint().collective_force, HOVER_TRIM);
+}
+
+#[test]
+fn the_baseline_block_sends_the_exact_baseline_until_the_vehicle_is_stable() {
+    let mut sender = RecordingSender::new().unstable_for(2);
+    let mut transport = authorize(&sender);
+
+    let baseline = transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+
+    assert_eq!(baseline.commands(), 3, "the block is continuous");
+    assert_eq!(sender.transmitted().len(), 3);
+    for sent in sender.transmitted() {
+        assert_eq!(
+            *sent,
+            baseline.setpoint(),
+            "every command in the block is the same exact baseline"
+        );
+    }
+    assert_eq!(baseline.frozen_at_ns(), 3 * SAMPLE_PERIOD_NS);
+}
+
+#[test]
+fn a_baseline_that_never_settles_fails_closed() {
+    let mut sender = RecordingSender::new().unstable_for(100);
+    let mut transport = authorize(&sender);
+    let mut request = baseline_request();
+    request.max_commands = 4;
+
+    let result = transport.freeze_baseline_blocking(&mut sender, &request);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::BaselineNotSettled { commands: 4 })
+    ));
+    assert!(transport.baseline().is_none());
+}
+
+#[test]
+fn a_baseline_whose_readback_never_matches_fails_closed() {
+    let substitute = DirectSetpoint {
+        roll_rad: 9.0,
+        pitch_rad: 9.0,
+        yaw_rad: 9.0,
+        collective_force: 0.9,
+    };
+    let mut sender = RecordingSender::new().substituting(substitute);
+    let mut transport = authorize(&sender);
+    let mut request = baseline_request();
+    request.max_commands = 3;
+
+    let result = transport.freeze_baseline_blocking(&mut sender, &request);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::BaselineNotSettled { commands: 3 })
+    ));
+}
+
+#[test]
+fn a_frozen_baseline_cannot_be_frozen_again_for_the_run() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+
+    let result = transport.freeze_baseline_blocking(&mut sender, &baseline_request());
+
+    assert!(matches!(result, Err(DirectTransportError::BaselineFrozen)));
+}
+
+#[test]
+fn an_incomplete_baseline_request_is_refused() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    let mut request = baseline_request();
+    request.hover_trim = f64::NAN;
+
+    let result = transport.freeze_baseline_blocking(&mut sender, &request);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::InvalidValue {
+            field: "hover trim"
+        })
+    ));
+    assert!(sender.transmitted().is_empty());
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/readback.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/readback.rs
@@ -1,0 +1,153 @@
+//! The causal maximum-skew bound on the raw direct readback.
+
+use flight_tune::ControlChannel;
+
+use super::super::{
+    CausalReadbackBound, DirectEnactment, DirectSetpoint, DirectTransportError,
+    EffectiveSetpointReport, ReadbackSelection,
+};
+use super::sender::RecordingSender;
+use super::{SAMPLE_PERIOD_NS, authorize, baseline_request, readback_bound, step_request};
+
+const MICROSECOND_NS: u64 = 1_000;
+
+fn report_at(sample_index: u64) -> EffectiveSetpointReport {
+    EffectiveSetpointReport {
+        setpoint: DirectSetpoint {
+            roll_rad: 0.0,
+            pitch_rad: 0.0,
+            yaw_rad: 0.0,
+            collective_force: 0.72,
+        },
+        sample_sequence: sample_index,
+        sample_time_ns: sample_index * SAMPLE_PERIOD_NS,
+        estimate_time_ns: sample_index * SAMPLE_PERIOD_NS,
+        simulator_truth_time_ns: sample_index * SAMPLE_PERIOD_NS,
+    }
+}
+
+#[test]
+fn a_sample_at_the_inclusive_bound_is_the_exact_source() {
+    let bound = readback_bound();
+    let report = report_at(4);
+    let query = report.sample_time_ns + bound.max_skew_ns();
+
+    assert_eq!(
+        bound.select(query, &report).expect("selection"),
+        ReadbackSelection::Exact
+    );
+}
+
+#[test]
+fn a_sample_one_microsecond_past_the_bound_has_no_exact_source() {
+    let bound = readback_bound();
+    let report = report_at(4);
+    let query = report.sample_time_ns + bound.max_skew_ns() + MICROSECOND_NS;
+
+    assert_eq!(
+        bound.select(query, &report).expect("selection"),
+        ReadbackSelection::Absent
+    );
+}
+
+#[test]
+fn a_future_sample_waits() {
+    let bound = readback_bound();
+    let report = report_at(4);
+    let query = report.sample_time_ns - MICROSECOND_NS;
+
+    assert_eq!(
+        bound.select(query, &report).expect("selection"),
+        ReadbackSelection::Pending
+    );
+}
+
+#[test]
+fn an_invalid_alignment_fails_closed() {
+    let bound = readback_bound();
+    let mut report = report_at(4);
+    report.sample_time_ns += MICROSECOND_NS;
+
+    let result = bound.select(report.sample_time_ns, &report);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::InvalidReadbackAlignment { .. })
+    ));
+}
+
+#[test]
+fn a_zero_sample_period_is_not_a_usable_bound() {
+    assert!(matches!(
+        CausalReadbackBound::new(0, 0),
+        Err(DirectTransportError::InvalidReadbackBound { .. })
+    ));
+}
+
+#[test]
+fn the_exact_next_sample_after_a_transmit_is_one_sample_later() {
+    let bound = readback_bound();
+
+    assert_eq!(
+        bound.next_sample_after(0).expect("next sample"),
+        SAMPLE_PERIOD_NS
+    );
+    assert_eq!(
+        bound.next_sample_after(SAMPLE_PERIOD_NS).expect("next"),
+        2 * SAMPLE_PERIOD_NS,
+        "a transmit exactly on a sample still waits for the NEXT one"
+    );
+    assert_eq!(
+        bound.next_sample_after(SAMPLE_PERIOD_NS + 1).expect("next"),
+        2 * SAMPLE_PERIOD_NS
+    );
+}
+
+#[test]
+fn a_valid_delayed_source_with_no_exact_source_sends_nothing_and_records_nothing() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    sender.clear_transmitted();
+    // The source stays valid but stops advancing, so the clock leaves it
+    // further behind than the causal bound allows.
+    let mut delayed = RecordingSender::new()
+        .reporting(report_at(1))
+        .holding_sample();
+    delayed.advance(8);
+
+    let outcome = transport
+        .enact_blocking(&mut delayed, &prepared)
+        .expect("a delayed source is not an error");
+
+    assert_eq!(outcome, DirectEnactment::NoExactSource);
+    assert!(
+        delayed.transmitted().is_empty(),
+        "no exact source means no direct demand"
+    );
+}
+
+#[test]
+fn a_silent_raw_source_sends_nothing_and_records_nothing() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    let mut silent = RecordingSender::new().silent();
+
+    let outcome = transport
+        .enact_blocking(&mut silent, &prepared)
+        .expect("a silent source is not an error");
+
+    assert_eq!(outcome, DirectEnactment::NoExactSource);
+    assert!(silent.transmitted().is_empty());
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/readback.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/readback.rs
@@ -7,7 +7,10 @@ use super::super::{
     EffectiveSetpointReport, ReadbackSelection,
 };
 use super::sender::RecordingSender;
-use super::{SAMPLE_PERIOD_NS, authorize, baseline_request, readback_bound, step_request};
+use super::{
+    SAMPLE_PERIOD_NS, authorize, authorize_without_skew, baseline_request, readback_bound,
+    step_request,
+};
 
 const MICROSECOND_NS: u64 = 1_000;
 
@@ -129,6 +132,60 @@ fn a_valid_delayed_source_with_no_exact_source_sends_nothing_and_records_nothing
     assert!(
         delayed.transmitted().is_empty(),
         "no exact source means no direct demand"
+    );
+}
+
+#[test]
+fn a_raw_source_that_has_not_reached_the_command_time_waits() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    // The only sample the source carries is later than the command time.
+    let mut ahead = RecordingSender::new()
+        .reporting(report_at(4))
+        .holding_sample();
+
+    let outcome = transport
+        .enact_blocking(&mut ahead, &prepared)
+        .expect("waiting is not an error");
+
+    assert_eq!(outcome, DirectEnactment::Pending);
+    assert!(
+        ahead.transmitted().is_empty(),
+        "a future sample waits; it does not command the vehicle"
+    );
+}
+
+#[test]
+fn a_transmitted_command_without_an_exact_readback_quarantines_the_run() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize_without_skew(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    // The source is exact for the pre-send check and then stops advancing,
+    // so the command leaves the process and never gets its readback.
+    sender.hold_sample_from_now();
+    sender.clear_transmitted();
+
+    let result = transport.enact_blocking(&mut sender, &prepared);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::NoEffectiveReadback)
+    ));
+    assert_eq!(
+        sender.transmitted().len(),
+        1,
+        "the command was already on the link when the readback failed"
     );
 }
 

--- a/tools/flight-tune-aviate/src/direct_transport/tests/revoke.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/revoke.rs
@@ -1,0 +1,97 @@
+//! One idempotent revoke removes every direct authority.
+
+use flight_tune::ControlChannel;
+
+use super::super::DirectTransportError;
+use super::sender::RecordingSender;
+use super::{authorize, capability, frozen, step_request, vehicle_receipt};
+
+#[test]
+fn one_revoke_removes_every_direct_authority() {
+    let (mut transport, mut sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+
+    let receipt = transport.revoke();
+
+    assert!(receipt.removed_authority());
+    assert!(receipt.released_baseline());
+    assert!(transport.is_revoked());
+    assert!(
+        transport.baseline().is_none(),
+        "the frozen baseline is gone"
+    );
+    assert!(matches!(
+        transport.prepare_step(&step_request(ControlChannel::Roll, 1.0)),
+        Err(DirectTransportError::Revoked)
+    ));
+    assert!(matches!(
+        transport.prepare_release(&step_request(ControlChannel::Roll, 1.0)),
+        Err(DirectTransportError::Revoked)
+    ));
+    assert!(matches!(
+        transport.freeze_baseline_blocking(&mut sender, &super::baseline_request()),
+        Err(DirectTransportError::Revoked)
+    ));
+    assert!(matches!(
+        transport.require_binding(&capability(), &vehicle_receipt()),
+        Err(DirectTransportError::Revoked)
+    ));
+    assert!(matches!(
+        transport.enact_blocking(&mut sender, &prepared),
+        Err(DirectTransportError::Revoked)
+    ));
+    assert!(
+        sender.transmitted().is_empty(),
+        "a revoked transport commands nothing"
+    );
+}
+
+#[test]
+fn a_second_revoke_removes_nothing_and_returns_the_same_receipt() {
+    let (mut transport, _sender) = frozen();
+
+    let first = transport.revoke();
+    let second = transport.revoke();
+    let third = transport.revoke();
+
+    assert!(first.removed_authority());
+    assert!(!second.removed_authority());
+    assert!(!second.released_baseline());
+    assert_eq!(second, third, "revoke is idempotent");
+    assert_eq!(
+        first.transport_identity_digest(),
+        second.transport_identity_digest(),
+        "the receipt keeps naming the same transport"
+    );
+}
+
+#[test]
+fn a_revoke_before_any_baseline_still_removes_the_authority() {
+    let sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+
+    let receipt = transport.revoke();
+
+    assert!(receipt.removed_authority());
+    assert!(
+        !receipt.released_baseline(),
+        "there was no frozen baseline to release"
+    );
+    assert!(transport.is_revoked());
+}
+
+#[test]
+fn a_command_prepared_before_a_revoke_cannot_be_enacted_after_it() {
+    let (mut transport, mut sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Vertical, 0.5))
+        .expect("prepared step");
+
+    transport.revoke();
+    let result = transport.enact_blocking(&mut sender, &prepared);
+
+    assert!(matches!(result, Err(DirectTransportError::Revoked)));
+    assert!(sender.transmitted().is_empty());
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/sender.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/sender.rs
@@ -1,0 +1,159 @@
+//! A recording command sender, standing in for the Aviate uplink.
+//!
+//! The sender echoes each transmitted setpoint back as the flight
+//! controller's effective setpoint on the next simulator sample, which is
+//! what a controller that accepted the command does. Every test that needs
+//! a different behavior asks for it explicitly.
+
+use flight_tune::Digest;
+
+use super::super::DirectCommandSender;
+use super::super::{
+    DirectSenderError, DirectSenderIdentity, DirectSetpoint, EffectiveSetpointReport,
+    TransmittedDirectCommand,
+};
+use super::SAMPLE_PERIOD_NS;
+
+pub(super) const ENDPOINT: &str = "127.0.0.1:20000";
+
+pub(super) struct RecordingSender {
+    endpoint: String,
+    now_ns: u64,
+    sequence: u8,
+    transmitted: Vec<DirectSetpoint>,
+    effective: Option<EffectiveSetpointReport>,
+    unstable_commands: u32,
+    /// Reports this setpoint instead of the transmitted one, so a test can
+    /// stage a flight controller that constrained the command.
+    substitute_effective: Option<DirectSetpoint>,
+    /// Reports no raw source at all.
+    silent_source: bool,
+    /// Keeps the reported sample where it is, however far the clock runs.
+    hold_sample: bool,
+}
+
+impl RecordingSender {
+    pub(super) fn new() -> Self {
+        Self {
+            endpoint: ENDPOINT.to_owned(),
+            now_ns: 0,
+            sequence: 0,
+            transmitted: Vec::new(),
+            effective: None,
+            unstable_commands: 0,
+            substitute_effective: None,
+            silent_source: false,
+            hold_sample: false,
+        }
+    }
+
+    pub(super) fn with_endpoint(mut self, endpoint: &str) -> Self {
+        self.endpoint = endpoint.to_owned();
+        self
+    }
+
+    /// Reports the vehicle as unsettled for the first `commands` commands.
+    pub(super) const fn unstable_for(mut self, commands: u32) -> Self {
+        self.unstable_commands = commands;
+        self
+    }
+
+    /// Reports a flight-controller setpoint that is not the transmitted one.
+    pub(super) const fn substituting(mut self, effective: DirectSetpoint) -> Self {
+        self.substitute_effective = Some(effective);
+        self
+    }
+
+    /// Reports no raw direct source at all.
+    pub(super) const fn silent(mut self) -> Self {
+        self.silent_source = true;
+        self
+    }
+
+    /// Seeds an already-active effective setpoint before the first command.
+    pub(super) const fn reporting(mut self, report: EffectiveSetpointReport) -> Self {
+        self.effective = Some(report);
+        self
+    }
+
+    /// Keeps the reported sample where it is, so the clock can run past the
+    /// causal bound without the source ever catching up.
+    pub(super) const fn holding_sample(mut self) -> Self {
+        self.hold_sample = true;
+        self
+    }
+
+    pub(super) fn transmitted(&self) -> &[DirectSetpoint] {
+        &self.transmitted
+    }
+
+    pub(super) fn clear_transmitted(&mut self) {
+        self.transmitted.clear();
+    }
+
+    /// Runs the clock forward without a command.
+    pub(super) fn advance(&mut self, samples: u64) {
+        self.now_ns = self
+            .now_ns
+            .wrapping_add(samples.wrapping_mul(SAMPLE_PERIOD_NS));
+    }
+}
+
+impl DirectCommandSender for RecordingSender {
+    fn command_endpoint(&self) -> String {
+        self.endpoint.clone()
+    }
+
+    fn now_ns(&mut self) -> Result<u64, DirectSenderError> {
+        Ok(self.now_ns)
+    }
+
+    fn transmit_exact_blocking(
+        &mut self,
+        setpoint: DirectSetpoint,
+    ) -> Result<TransmittedDirectCommand, DirectSenderError> {
+        self.transmitted.push(setpoint);
+        self.sequence = self.sequence.wrapping_add(1);
+        let transmitted_at_ns = self.now_ns;
+        let sample_time_ns = transmitted_at_ns.wrapping_add(SAMPLE_PERIOD_NS);
+        self.now_ns = sample_time_ns;
+        if !self.hold_sample {
+            self.effective = Some(EffectiveSetpointReport {
+                setpoint: self.substitute_effective.unwrap_or(setpoint),
+                sample_sequence: sample_time_ns / SAMPLE_PERIOD_NS,
+                sample_time_ns,
+                estimate_time_ns: sample_time_ns.wrapping_sub(1_000_000),
+                simulator_truth_time_ns: sample_time_ns,
+            });
+        }
+        Ok(TransmittedDirectCommand {
+            setpoint,
+            sender: DirectSenderIdentity {
+                endpoint: self.endpoint.clone(),
+                system_id: 1,
+                component_id: 1,
+                sequence: self.sequence,
+                time_boot_ms: u32::try_from(transmitted_at_ns / 1_000_000).unwrap_or(u32::MAX),
+                frame_digest: Digest::from_bytes([0xab; 32]),
+            },
+            transmitted_at_ns,
+        })
+    }
+
+    fn effective_setpoint_blocking(
+        &mut self,
+    ) -> Result<Option<EffectiveSetpointReport>, DirectSenderError> {
+        if self.silent_source {
+            return Ok(None);
+        }
+        Ok(self.effective)
+    }
+
+    fn is_stable_blocking(&mut self) -> Result<bool, DirectSenderError> {
+        if self.unstable_commands == 0 {
+            return Ok(true);
+        }
+        self.unstable_commands = self.unstable_commands.wrapping_sub(1);
+        Ok(false)
+    }
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/sender.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/sender.rs
@@ -91,6 +91,11 @@ impl RecordingSender {
         self.transmitted.clear();
     }
 
+    /// Stops the reported sample from advancing past the one it holds now.
+    pub(super) const fn hold_sample_from_now(&mut self) {
+        self.hold_sample = true;
+    }
+
     /// Runs the clock forward without a command.
     pub(super) fn advance(&mut self, samples: u64) {
         self.now_ns = self

--- a/tools/flight-tune-aviate/src/direct_transport/tests/step.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/step.rs
@@ -1,0 +1,328 @@
+//! The exact step: one target, in one sample, with every other axis frozen.
+
+use flight_tune::{ControlChannel, ControlFamily, StimulusMapping};
+
+use super::super::{
+    DirectCommandPurpose, DirectCommandSender, DirectEnactment, DirectSetpoint,
+    DirectTransportError,
+};
+use super::sender::RecordingSender;
+use super::{
+    HOVER_TRIM, attitude_envelope, authorize, baseline_request, collective_envelope, digest,
+    frozen, step_request,
+};
+
+fn enacted(outcome: DirectEnactment) -> super::super::DirectCommandRecord {
+    match outcome {
+        DirectEnactment::Enacted(record) => *record,
+        other => panic!("expected an enacted command, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_neutral_stimulus_targets_the_frozen_baseline_exactly() {
+    let (transport, _sender) = frozen();
+    let baseline = transport.baseline().expect("frozen baseline").setpoint();
+
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 0.0))
+        .expect("prepared step");
+
+    assert_eq!(
+        prepared.requested(),
+        baseline,
+        "a zero normalized value on a zero-neutral envelope IS the baseline"
+    );
+}
+
+#[test]
+fn each_channel_moves_only_its_own_axis_from_the_frozen_baseline() {
+    let (transport, _sender) = frozen();
+    let baseline = transport.baseline().expect("frozen baseline").setpoint();
+
+    for (channel, index, span) in [
+        (ControlChannel::Roll, 0_usize, 0.25),
+        (ControlChannel::Pitch, 1, 0.25),
+        (ControlChannel::Yaw, 2, 0.25),
+        (ControlChannel::Vertical, 3, 0.1),
+    ] {
+        let prepared = transport
+            .prepare_step(&step_request(channel, 0.5))
+            .expect("prepared step");
+        let target = prepared.requested().axes();
+        let expected = baseline.axes();
+        for axis in 0..4 {
+            if axis == index {
+                assert_eq!(
+                    target[axis],
+                    expected[axis] + 0.5 * span,
+                    "the commanded axis takes the exact offset"
+                );
+            } else {
+                assert_eq!(
+                    target[axis], expected[axis],
+                    "an unrelated axis keeps its frozen baseline value"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn a_vertical_step_measures_from_the_identified_hover_trim() {
+    let (transport, _sender) = frozen();
+
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Vertical, -1.0))
+        .expect("prepared step");
+
+    assert_eq!(
+        prepared.requested().collective_force,
+        HOVER_TRIM - 0.1,
+        "the vertical offset applies to the hover trim baseline"
+    );
+}
+
+#[test]
+fn the_operator_velocity_family_cannot_reach_the_direct_transport() {
+    let (transport, _sender) = frozen();
+    let mut stimulus = step_request(ControlChannel::Roll, 0.5);
+    stimulus.family = ControlFamily::OperatorVelocity;
+
+    let step = transport.prepare_step(&stimulus);
+    let release = transport.prepare_release(&stimulus);
+
+    for result in [step, release] {
+        match result {
+            Err(DirectTransportError::UnsupportedFamily { family }) => {
+                assert_eq!(family, "operator_velocity");
+            }
+            other => panic!("expected a family refusal, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn an_inexact_mapping_is_refused() {
+    let (transport, _sender) = frozen();
+    let mut stimulus = step_request(ControlChannel::Roll, 0.5);
+    stimulus.mapping = StimulusMapping::CandidateBoundCurve;
+
+    let result = transport.prepare_step(&stimulus);
+
+    assert!(matches!(result, Err(DirectTransportError::InexactMapping)));
+}
+
+#[test]
+fn an_envelope_whose_physics_do_not_match_the_channel_is_refused() {
+    let (transport, _sender) = frozen();
+    let mut wrong_unit = step_request(ControlChannel::Roll, 0.5);
+    wrong_unit.envelope = collective_envelope();
+    let mut wrong_reference = step_request(ControlChannel::Vertical, 0.5);
+    wrong_reference.envelope = attitude_envelope();
+
+    for stimulus in [wrong_unit, wrong_reference] {
+        assert!(matches!(
+            transport.prepare_step(&stimulus),
+            Err(DirectTransportError::EnvelopePhysics { .. })
+        ));
+    }
+}
+
+#[test]
+fn a_normalized_value_outside_the_declared_range_is_refused() {
+    let (transport, _sender) = frozen();
+
+    let result = transport.prepare_step(&step_request(ControlChannel::Roll, 1.5));
+
+    assert!(matches!(result, Err(DirectTransportError::Envelope { .. })));
+}
+
+#[test]
+fn an_exact_step_reaches_its_target_in_one_simulator_sample() {
+    let (mut transport, mut sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    let requested = prepared.requested();
+
+    let record = enacted(
+        transport
+            .enact_blocking(&mut sender, &prepared)
+            .expect("enacted step"),
+    );
+
+    assert_eq!(sender.transmitted(), [requested], "one command, one sample");
+    assert_eq!(record.transmitted, requested);
+    assert_eq!(record.effective, requested);
+    assert_eq!(record.purpose, DirectCommandPurpose::Step);
+    assert_eq!(record.channel, ControlChannel::Roll);
+    assert_eq!(record.family, ControlFamily::DirectAttitudeThrust);
+    assert_eq!(
+        record.times.effective_at_ns,
+        record.times.transmitted_at_ns + super::SAMPLE_PERIOD_NS,
+        "the effective readback is the exact next sample"
+    );
+    assert!(record.times.requested_at_ns <= record.times.transmitted_at_ns);
+    assert_eq!(record.sender.endpoint, super::sender::ENDPOINT);
+    assert_eq!(record.run_intent_digest, digest(9));
+    assert_eq!(
+        record.transport_identity_digest,
+        transport.session().identity_digest()
+    );
+}
+
+#[test]
+fn a_release_sends_the_frozen_baseline_as_one_exact_step() {
+    let (mut transport, mut sender) = frozen();
+    let baseline = transport.baseline().expect("frozen baseline").setpoint();
+    let stimulus = step_request(ControlChannel::Roll, 1.0);
+    let step = transport.prepare_step(&stimulus).expect("prepared step");
+    transport
+        .enact_blocking(&mut sender, &step)
+        .expect("enacted step");
+    sender.clear_transmitted();
+
+    let release = transport
+        .prepare_release(&stimulus)
+        .expect("prepared release");
+    let record = enacted(
+        transport
+            .enact_blocking(&mut sender, &release)
+            .expect("enacted release"),
+    );
+
+    assert_eq!(release.purpose(), DirectCommandPurpose::Release);
+    assert_eq!(sender.transmitted(), [baseline]);
+    assert_eq!(record.transmitted, baseline);
+    assert_eq!(
+        record.effective, baseline,
+        "direct mode still holds the baseline after the release"
+    );
+}
+
+#[test]
+fn a_changed_prepared_target_fails_before_a_datagram_leaves_the_process() {
+    let (mut transport, mut sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step")
+        .with_requested_for_test(DirectSetpoint {
+            roll_rad: 0.9,
+            pitch_rad: 0.0,
+            yaw_rad: 0.0,
+            collective_force: 0.9,
+        });
+
+    let result = transport.enact_blocking(&mut sender, &prepared);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::ChangedPreparedCommand {
+            detail: "the re-derived physical target"
+        })
+    ));
+    assert!(
+        sender.transmitted().is_empty(),
+        "no datagram may leave for a changed prepared target"
+    );
+}
+
+#[test]
+fn a_substituted_channel_family_or_envelope_is_refused_before_the_send() {
+    let (mut transport, mut sender) = frozen();
+    let honest = step_request(ControlChannel::Roll, 1.0);
+    let mut other_envelope = attitude_envelope();
+    other_envelope.positive_endpoint = 0.4;
+
+    let substitutions = [
+        step_request(ControlChannel::Pitch, 1.0),
+        step_request(ControlChannel::Roll, 0.25),
+        {
+            let mut stimulus = honest.clone();
+            stimulus.envelope = other_envelope;
+            stimulus
+        },
+        {
+            let mut stimulus = honest.clone();
+            stimulus.family = ControlFamily::OperatorVelocity;
+            stimulus
+        },
+    ];
+    for stimulus in substitutions {
+        let prepared = transport
+            .prepare_step(&honest)
+            .expect("prepared step")
+            .with_stimulus_for_test(stimulus);
+
+        let result = transport.enact_blocking(&mut sender, &prepared);
+
+        assert!(result.is_err(), "a substituted stimulus must be refused");
+        assert!(sender.transmitted().is_empty());
+    }
+}
+
+#[test]
+fn a_stale_run_binding_cannot_reuse_the_direct_baseline_or_target() {
+    let (transport, _sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+
+    let mut later_sender = RecordingSender::new();
+    let mut later = authorize(&later_sender);
+    let mut later_run = baseline_request();
+    later_run.run_intent_digest = digest(0x5a);
+    later
+        .freeze_baseline_blocking(&mut later_sender, &later_run)
+        .expect("frozen baseline");
+    later_sender.clear_transmitted();
+
+    let result = later.enact_blocking(&mut later_sender, &prepared);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::ChangedPreparedCommand {
+            detail: "the frozen run intent"
+        })
+    ));
+    assert!(later_sender.transmitted().is_empty());
+}
+
+#[test]
+fn a_command_prepared_without_a_frozen_baseline_is_refused() {
+    let sender = RecordingSender::new();
+    let transport = authorize(&sender);
+
+    let result = transport.prepare_step(&step_request(ControlChannel::Roll, 1.0));
+
+    assert!(matches!(result, Err(DirectTransportError::NoBaseline)));
+}
+
+#[test]
+fn an_effective_setpoint_that_left_the_transmitted_target_quarantines_the_run() {
+    let mut sender = RecordingSender::new();
+    let mut transport = authorize(&sender);
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Roll, 1.0))
+        .expect("prepared step");
+    let mut constrained = RecordingSender::new().substituting(DirectSetpoint {
+        roll_rad: 0.0,
+        pitch_rad: 0.0,
+        yaw_rad: 0.0,
+        collective_force: HOVER_TRIM,
+    });
+    // Seed the raw source so the pre-send causal check has an exact sample.
+    DirectCommandSender::transmit_exact_blocking(&mut constrained, prepared.baseline())
+        .expect("seed the raw source");
+
+    let result = transport.enact_blocking(&mut constrained, &prepared);
+
+    assert!(matches!(
+        result,
+        Err(DirectTransportError::EffectiveTargetMismatch { .. })
+    ));
+}

--- a/tools/flight-tune-aviate/src/direct_transport/tests/step.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/tests/step.rs
@@ -173,6 +173,27 @@ fn an_exact_step_reaches_its_target_in_one_simulator_sample() {
 }
 
 #[test]
+fn a_causal_record_survives_the_document_round_trip() {
+    // The production runtime carries this record into durable evidence, so
+    // every field it needs has to survive encoding.
+    let (mut transport, mut sender) = frozen();
+    let prepared = transport
+        .prepare_step(&step_request(ControlChannel::Yaw, -0.5))
+        .expect("prepared step");
+    let record = enacted(
+        transport
+            .enact_blocking(&mut sender, &prepared)
+            .expect("enacted step"),
+    );
+
+    let bytes = serde_json::to_vec(&record).expect("encoded record");
+    let restored: super::super::DirectCommandRecord =
+        serde_json::from_slice(&bytes).expect("decoded record");
+
+    assert_eq!(restored, record);
+}
+
+#[test]
 fn a_release_sends_the_frozen_baseline_as_one_exact_step() {
     let (mut transport, mut sender) = frozen();
     let baseline = transport.baseline().expect("frozen baseline").setpoint();

--- a/tools/flight-tune-aviate/src/lib.rs
+++ b/tools/flight-tune-aviate/src/lib.rs
@@ -1,9 +1,13 @@
-//! Crash-contained Aviate process supervision for simulator tuning.
+//! Aviate process supervision and direct control for simulator tuning.
 //!
 //! The supervisor keeps one target behind a launch gate until it stores and
 //! reads back the exact process identity. A parent-lifetime pipe requests
 //! cleanup after parent failure. Recovery does not send process signals. The
 //! launch gate and its owner contain the exact private process group.
+//!
+//! [`direct_transport`] carries the simulator-only exact direct setpoints
+//! that qualify a direct controller. It is not reachable from the normal
+//! application control interface.
 //!
 //! This crate supports only Linux and macOS.
 //!
@@ -16,6 +20,7 @@
 
 mod action_port;
 mod artifact;
+pub mod direct_transport;
 mod document;
 mod error;
 mod inspection;

--- a/tools/flight-tune-aviate/tests/direct_transport.rs
+++ b/tools/flight-tune-aviate/tests/direct_transport.rs
@@ -1,0 +1,399 @@
+//! The direct transport driving the real Aviate command sender.
+//!
+//! The transport owns no socket, so its unit tests drive a recording
+//! sender. This suite closes that gap: it binds the transport's command
+//! port to the real [`FlightUplink`], reads the MAVLink datagram that
+//! reaches a fake flight controller, and reports the decoded wire values
+//! back as the effective setpoint. What the transport verifies is
+//! therefore what actually left the process.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use flight_tune::{
+    ArtifactIdentity, ControlChannel, ControlFamily, Digest, ExecutionTarget, PhysicalUnit,
+    ReferenceRule, SimulatorCapability, SimulatorSessionReceipt, StimulusEnvelope, StimulusMapping,
+    VehicleBindingReceipt,
+};
+use flight_tune_aviate::direct_transport::{
+    CausalReadbackBound, DirectBaselineRequest, DirectCommandSender, DirectEnactment,
+    DirectSenderError, DirectSenderIdentity, DirectSetpoint, DirectStepRequest, DirectTransport,
+    DirectTransportRequest, EffectiveSetpointReport, TransmittedDirectCommand,
+    direct_transport_identity,
+};
+use pilotage_adapter_aviate::{
+    AviateProfile, ExactDirectSetpoint, FlightUplink, SimulatorDirectAuthority,
+};
+use sha2::{Digest as _, Sha256};
+
+/// One simulator sample at the flight controller's setpoint rate.
+const SAMPLE_PERIOD_NS: u64 = 12_500_000;
+/// The identified hover trim of the test airframe.
+const HOVER_TRIM: f64 = 0.72;
+/// A single-precision MAVLink attitude frame round-trips through a
+/// quaternion, so the declared tolerance is a float tolerance and not zero.
+const TOLERANCE: f64 = 1e-5;
+
+/// The transport's command port over the real Aviate uplink.
+///
+/// The effective setpoint is decoded from the datagram the fake flight
+/// controller received, so a shaped or clamped command could not report
+/// itself as the requested target.
+struct AviateDirectSender {
+    uplink: FlightUplink,
+    authority: SimulatorDirectAuthority,
+    flight_controller: UdpSocket,
+    now_ns: u64,
+    effective: Option<EffectiveSetpointReport>,
+}
+
+impl AviateDirectSender {
+    fn bind() -> Self {
+        let flight_controller = UdpSocket::bind("127.0.0.1:0").expect("bind fake FC");
+        flight_controller
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("read timeout");
+        let authority = SimulatorDirectAuthority::for_profile(AviateProfile::Simulation)
+            .expect("simulation authority");
+        let mut uplink = FlightUplink::bind_to(flight_controller.local_addr().expect("FC address"))
+            .expect("uplink");
+        uplink.open_setpoint_stream(&authority);
+        Self {
+            uplink,
+            authority,
+            flight_controller,
+            now_ns: 0,
+            effective: None,
+        }
+    }
+
+    fn receive(&self) -> Vec<u8> {
+        let mut buffer = [0_u8; 128];
+        let (len, _) = self
+            .flight_controller
+            .recv_from(&mut buffer)
+            .expect("a frame reached the FC");
+        buffer[..len].to_vec()
+    }
+
+    fn expect_silence(&self) {
+        let mut buffer = [0_u8; 128];
+        self.flight_controller
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .expect("read timeout");
+        let received = self.flight_controller.recv_from(&mut buffer);
+        self.flight_controller
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("read timeout");
+        assert!(received.is_err(), "no datagram may have left the process");
+    }
+}
+
+fn field(frame: &[u8], offset: usize) -> f32 {
+    let start = 10 + offset;
+    let bytes = frame.get(start..start + 4).expect("payload field");
+    f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+/// Recovers one direct setpoint from a received SET_ATTITUDE_TARGET frame.
+fn decode_setpoint(frame: &[u8]) -> DirectSetpoint {
+    assert_eq!(frame[7], 82, "SET_ATTITUDE_TARGET id");
+    let (qw, qx, qy, qz) = (
+        field(frame, 4),
+        field(frame, 8),
+        field(frame, 12),
+        field(frame, 16),
+    );
+    DirectSetpoint {
+        roll_rad: f64::from((2.0 * (qw * qx + qy * qz)).atan2(1.0 - 2.0 * (qx * qx + qy * qy))),
+        pitch_rad: f64::from((2.0 * (qw * qy - qz * qx)).asin()),
+        yaw_rad: f64::from((2.0 * (qw * qz + qx * qy)).atan2(1.0 - 2.0 * (qy * qy + qz * qz))),
+        collective_force: f64::from(field(frame, 32)),
+    }
+}
+
+impl DirectCommandSender for AviateDirectSender {
+    fn command_endpoint(&self) -> String {
+        self.uplink.command_endpoint().to_string()
+    }
+
+    fn now_ns(&mut self) -> Result<u64, DirectSenderError> {
+        Ok(self.now_ns)
+    }
+
+    fn transmit_exact_blocking(
+        &mut self,
+        setpoint: DirectSetpoint,
+    ) -> Result<TransmittedDirectCommand, DirectSenderError> {
+        let transmitted = self
+            .uplink
+            .send_exact_direct_setpoint(
+                &self.authority,
+                ExactDirectSetpoint {
+                    roll_rad: setpoint.roll_rad as f32,
+                    pitch_rad: setpoint.pitch_rad as f32,
+                    yaw_rad: setpoint.yaw_rad as f32,
+                    collective_force: setpoint.collective_force as f32,
+                },
+            )
+            .map_err(|error| DirectSenderError::new("transmit", error.to_string()))?;
+        let wire = decode_setpoint(&self.receive());
+        let transmitted_at_ns = self.now_ns;
+        let sample_time_ns = transmitted_at_ns + SAMPLE_PERIOD_NS;
+        self.now_ns = sample_time_ns;
+        self.effective = Some(EffectiveSetpointReport {
+            setpoint: wire,
+            sample_sequence: sample_time_ns / SAMPLE_PERIOD_NS,
+            sample_time_ns,
+            estimate_time_ns: sample_time_ns,
+            simulator_truth_time_ns: sample_time_ns,
+        });
+        Ok(TransmittedDirectCommand {
+            setpoint: wire,
+            sender: DirectSenderIdentity {
+                endpoint: self.command_endpoint(),
+                system_id: self.uplink.expected_source().0,
+                component_id: self.uplink.expected_source().1,
+                sequence: transmitted.sequence,
+                time_boot_ms: transmitted.time_boot_ms,
+                frame_digest: Digest::from_bytes(Sha256::digest(transmitted.frame).into()),
+            },
+            transmitted_at_ns,
+        })
+    }
+
+    fn effective_setpoint_blocking(
+        &mut self,
+    ) -> Result<Option<EffectiveSetpointReport>, DirectSenderError> {
+        Ok(self.effective)
+    }
+
+    fn is_stable_blocking(&mut self) -> Result<bool, DirectSenderError> {
+        Ok(true)
+    }
+}
+
+fn digest(seed: u8) -> Digest {
+    Digest::from_bytes([seed; 32])
+}
+
+fn session_receipt() -> SimulatorSessionReceipt {
+    SimulatorSessionReceipt {
+        session_digest: digest(1),
+        simulator_digest: digest(2),
+        airframe_digest: digest(3),
+    }
+}
+
+fn vehicle_receipt() -> VehicleBindingReceipt {
+    VehicleBindingReceipt {
+        session_digest: digest(1),
+        vehicle_digest: digest(4),
+        scenario_runtime_digest: digest(5),
+    }
+}
+
+fn authorize(sender: &AviateDirectSender, target: ExecutionTarget) -> Option<DirectTransport> {
+    let capability = SimulatorCapability::for_test(session_receipt());
+    let simulator = session_receipt();
+    let vehicle = vehicle_receipt();
+    let transport: ArtifactIdentity = direct_transport_identity().expect("transport identity");
+    DirectTransport::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target,
+            transport: &transport,
+            readback: CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS)
+                .expect("readback bound"),
+            tolerance: TOLERANCE,
+        },
+        sender,
+    )
+    .ok()
+}
+
+fn baseline_request() -> DirectBaselineRequest {
+    DirectBaselineRequest {
+        measured_roll_rad: 0.0,
+        measured_pitch_rad: 0.0,
+        measured_yaw_rad: 0.0,
+        hover_trim: HOVER_TRIM,
+        run_intent_digest: digest(9),
+        max_commands: 4,
+    }
+}
+
+fn tilt_envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "alia-tilt-v1".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::Radians,
+        reference: ReferenceRule::EffectiveSetpointAtEntry,
+        negative_endpoint: -0.25,
+        neutral: 0.0,
+        positive_endpoint: 0.25,
+    }
+}
+
+fn roll_step(normalized: f64) -> DirectStepRequest {
+    DirectStepRequest {
+        family: ControlFamily::DirectAttitudeThrust,
+        channel: ControlChannel::Roll,
+        mapping: StimulusMapping::AffineExact,
+        envelope: tilt_envelope(),
+        normalized,
+    }
+}
+
+#[test]
+fn the_transport_drives_the_real_command_sender_to_an_exact_target() {
+    let mut sender = AviateDirectSender::bind();
+    let mut transport = authorize(&sender, ExecutionTarget::Simulator).expect("authorized");
+    let baseline = transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    assert_eq!(baseline.setpoint().collective_force, HOVER_TRIM);
+
+    let prepared = transport.prepare_step(&roll_step(1.0)).expect("prepared");
+    let outcome = transport
+        .enact_blocking(&mut sender, &prepared)
+        .expect("enacted step");
+
+    let DirectEnactment::Enacted(record) = outcome else {
+        panic!("expected an enacted command, got {outcome:?}");
+    };
+    assert_eq!(
+        prepared.requested().roll_rad,
+        0.25,
+        "the envelope resolves the full-scale roll target"
+    );
+    // The effective setpoint here IS the decoded wire value, so this is a
+    // statement about the datagram and not about the transport's own copy.
+    assert!(
+        (record.effective.roll_rad - 0.25).abs() < TOLERANCE,
+        "the wire carried {} rad",
+        record.effective.roll_rad
+    );
+    assert!((record.effective.pitch_rad).abs() < TOLERANCE);
+    assert!((record.effective.collective_force - HOVER_TRIM).abs() < TOLERANCE);
+    assert_eq!(
+        record.times.effective_at_ns,
+        record.times.transmitted_at_ns + SAMPLE_PERIOD_NS,
+        "the readback is the exact next simulator sample"
+    );
+    assert_eq!(record.sender.endpoint, sender.command_endpoint());
+    assert_eq!(record.channel, ControlChannel::Roll);
+    assert_eq!(record.family, ControlFamily::DirectAttitudeThrust);
+    assert_ne!(record.sender.frame_digest, Digest::from_bytes([0; 32]));
+}
+
+#[test]
+fn a_hardware_target_cannot_bind_the_real_command_sender() {
+    let sender = AviateDirectSender::bind();
+
+    assert!(
+        authorize(&sender, ExecutionTarget::RealVehicle).is_none(),
+        "a real-vehicle target must not reach the exact direct path"
+    );
+    sender.expect_silence();
+}
+
+#[test]
+fn a_changed_prepared_target_never_reaches_the_command_link() {
+    let mut sender = AviateDirectSender::bind();
+    let mut transport = authorize(&sender, ExecutionTarget::Simulator).expect("authorized");
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let tampered = transport
+        .prepare_step(&roll_step(1.0))
+        .expect("prepared")
+        .with_requested_for_test(DirectSetpoint {
+            roll_rad: 0.5,
+            pitch_rad: 0.0,
+            yaw_rad: 0.0,
+            collective_force: HOVER_TRIM,
+        });
+
+    let result = transport.enact_blocking(&mut sender, &tampered);
+
+    assert!(result.is_err(), "a changed prepared target must be refused");
+    sender.expect_silence();
+}
+
+#[test]
+fn the_operator_family_still_reaches_the_flight_controller_after_a_direct_step() {
+    // The operator law keeps its own message and its own path. The exact
+    // direct step must leave that path working; the adapter suite proves
+    // the shaped numbers themselves are untouched, on a controlled clock.
+    let mut sender = AviateDirectSender::bind();
+    let mut transport = authorize(&sender, ExecutionTarget::Simulator).expect("authorized");
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let prepared = transport.prepare_step(&roll_step(1.0)).expect("prepared");
+    transport
+        .enact_blocking(&mut sender, &prepared)
+        .expect("enacted step");
+
+    sender
+        .uplink
+        .send_stick_frame(0.0, 1.0, 0.6, 0.5, 0.0, [0.0; 3], Some([0.0; 3]), None);
+    let frame = sender.receive();
+
+    assert_eq!(
+        frame[7], 84,
+        "the operator family still sends SET_POSITION_TARGET_LOCAL_NED"
+    );
+    assert_eq!(
+        sender.uplink.send_failures(),
+        0,
+        "no command was refused by the link"
+    );
+}
+
+#[test]
+fn the_transport_refuses_a_stimulus_the_real_sender_could_not_carry_exactly() {
+    let mut sender = AviateDirectSender::bind();
+    let mut transport = authorize(&sender, ExecutionTarget::Simulator).expect("authorized");
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    // The uplink's direct tilt envelope stops well short of this target, so
+    // a shaped path would clamp it and report the clamped value as the
+    // command. The exact path has no such outcome.
+    let mut beyond_envelope = roll_step(1.0);
+    beyond_envelope.envelope.positive_endpoint = 1.4;
+
+    let prepared = transport
+        .prepare_step(&beyond_envelope)
+        .expect("prepared step");
+    let result = transport.enact_blocking(&mut sender, &prepared);
+
+    assert!(
+        result.is_err(),
+        "a target the sender cannot carry exactly must fail, not clamp"
+    );
+    sender.expect_silence();
+}
+
+#[test]
+fn the_operator_velocity_family_cannot_reach_the_real_command_sender() {
+    let mut sender = AviateDirectSender::bind();
+    let mut transport = authorize(&sender, ExecutionTarget::Simulator).expect("authorized");
+    transport
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("frozen baseline");
+    let mut operator = roll_step(1.0);
+    operator.family = ControlFamily::OperatorVelocity;
+
+    assert!(transport.prepare_step(&operator).is_err());
+    assert!(transport.prepare_release(&operator).is_err());
+    sender.expect_silence();
+}

--- a/tools/flight-tune/Cargo.toml
+++ b/tools/flight-tune/Cargo.toml
@@ -8,6 +8,13 @@ description = "Deterministic host-side flight parameter search and promotion"
 [lints]
 workspace = true
 
+[features]
+default = []
+# Lets a downstream test mint the simulator session capability that the
+# harness normally hands to an adapter after it validates the handshake.
+# A release build never enables it, so no shipped code can mint one.
+test-support = []
+
 [dependencies]
 pilotage-durable-storage = { workspace = true }
 pilotage-flight-quality = { workspace = true }

--- a/tools/flight-tune/src/adapter.rs
+++ b/tools/flight-tune/src/adapter.rs
@@ -106,6 +106,18 @@ pub struct SimulatorCapability {
 }
 
 impl SimulatorCapability {
+    /// Mints a capability for one simulator session, for a downstream test.
+    ///
+    /// The harness mints the real one only after the simulator answers a
+    /// session challenge. A crate that has to exercise a capability-gated
+    /// path in isolation enables the `test-support` feature; a release
+    /// build does not compile this function at all.
+    #[cfg(feature = "test-support")]
+    #[must_use]
+    pub const fn for_test(receipt: SimulatorSessionReceipt) -> Self {
+        Self::new(receipt)
+    }
+
     pub(crate) const fn new(receipt: SimulatorSessionReceipt) -> Self {
         Self {
             session_digest: receipt.session_digest,

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -66,9 +66,9 @@ pub use model::{
 };
 pub use pilotage_mission_core::{
     ArtifactIdentity as MissionArtifactIdentity, ControlChannel, ControlFamily, DirectiveContext,
-    FlightAction, MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective, MissionDocument,
-    ObservedSignal, PhysicalUnit, ReceiptResult, ReferenceRule, StartState, StimulusEnvelope,
-    StimulusError, StimulusMapping, TrialAction, VehicleLifecycleState, Waveform,
+    ExecutionTarget, FlightAction, MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective,
+    MissionDocument, ObservedSignal, PhysicalUnit, ReceiptResult, ReferenceRule, StartState,
+    StimulusEnvelope, StimulusError, StimulusMapping, TrialAction, VehicleLifecycleState, Waveform,
 };
 pub use pilotage_trial::{Digest, Scenario as TrialScenario};
 pub use run_context::{RUN_EXECUTION_CONTEXT_SCHEMA_VERSION, RunExecutionContext};


### PR DESCRIPTION
The normal Pilotage direct path calls `UplinkFeel::step_direct`, which applies attitude-rate, attitude-acceleration, thrust-rate and thrust-acceleration limits. A requested step therefore arrives at the flight controller as a ramp, and evidence collected through it measures Pilotage shaping rather than the direct controller. This adds the simulator-only transport that delivers the step itself.

**The frozen branch that issue comment 4 describes is not on this remote.** I checked every remote branch; no `codex/466-*` or equivalent exists. This PR implements the scoped slice fresh rather than duplicating near-landed work.

## What the four issue comments added to the spec

1. **"Depends on #465, blocks #467."** Honored structurally: the transport consumes the `ControlFamily`/`StimulusMapping::AffineExact`/`StimulusEnvelope` vocabulary that #465 landed, and refuses anything else.
2. **"This exact direct-step implementation must enter the complete Aviate runtime production-input identity owned by #469."** The transport identity is a first-class, digestible document (`DirectTransportIdentity`) binding session, simulator, airframe, vehicle, scenario-runtime, command endpoint and transport-implementation identities, so #469 can fold it into the production input identity without reconstructing it.
3. **Verified sub-slice update (causal readback).** Implemented as `CausalReadbackBound`, with the comment's five named cases as five tests:

   | Comment 3 case | Test |
   | --- | --- |
   | inclusive bound | `a_sample_at_the_inclusive_bound_is_the_exact_source` |
   | bound plus one microsecond | `a_sample_one_microsecond_past_the_bound_has_no_exact_source` |
   | future input waits | `a_future_sample_waits` |
   | invalid alignment fails closed | `an_invalid_alignment_fails_closed` |
   | valid delayed source, no exact source | `a_valid_delayed_source_with_no_exact_source_sends_nothing_and_records_nothing` |

   The last one asserts what the comment demands: no direct demand is sent and no step or release marker is recorded. Alignment is sample-sequence/sample-time coherence, which is what lets "bound plus one microsecond" and "invalid alignment" be two distinct outcomes rather than one.
4. **Implementation freeze.** In this slice: exact sender identity on every record (endpoint, system id, component id, MAVLink sequence, boot time, frame digest), prepare/enact with a changed prepared target failing before a datagram can leave the process, continuous baseline send blocks, a family-aware release as one exact step, and the causal command record. Out of this slice, and left to #469 per the reviewer's scope boundary: durable prepared-intent synchronization, recovery's ambiguous outcome for a durable prepared frame with no durable send result, publication validation, and run-receipt binding.

## Authority boundary

`DirectTransport::authorize` is the only constructor. It requires `ExecutionTarget::Simulator`, a `SimulatorCapability` for a validated tuning session, and simulator plus vehicle binding receipts that both name that session. The transport is never reachable from `VehicleAdapter::apply` or any `ScopedControlFrame`. On the adapter side, the exact send is gated by `SimulatorDirectAuthority`, which only `AviateProfile::Simulation` can mint, so the path is structurally absent on a physical or oracle-only vehicle rather than merely refused.

The transport owns no socket. It borrows the command sender through `DirectCommandSender`, so every direct command keeps the normal command stream's endpoint, MAVLink source identity, frame sequence and boot time. There is no second sender.

## One-sample step proof

Two independent proofs, both against the real `FlightUplink`:

- `adapters/aviate/src/adapter/tests/exact_direct.rs` drives **one** uplink with **one** profile and **one** target two ways. `the_normal_direct_path_still_applies_its_declared_shaping` shows the shaped law delivering under a fifth of a 0.3 rad request in a 20 ms sample; `the_simulator_direct_path_sends_an_exact_target_in_one_sample` shows the exact path landing on 0.3 rad in that same sample. Same rig, same envelope: the difference is the law.
- `tools/flight-tune-aviate/tests/direct_transport.rs` binds the transport's port to a real `FlightUplink` over a real UDP socket, **decodes the MAVLink datagram the fake flight controller received**, and reports those decoded wire values back as the effective setpoint. `the_transport_drives_the_real_command_sender_to_an_exact_target` is therefore a statement about the bytes that left the process, not about the transport's own copy.

## Operator-path regression evidence

`the_operator_velocity_path_still_uses_normal_shaping` and `the_simulator_direct_path_leaves_the_shaped_direct_law_untouched` run two uplinks in lockstep on the manual clock; one takes an exact step in the middle. Every velocity component and the absolute heading must stay bit-identical, and the test asserts the operator law actually commanded something so the comparison cannot pass vacuously. `a_changed_default_feel_profile_is_not_necessary_for_a_direct_step` shows the launch-default compatibility profile delivering an exact step with no profile change.

The exact send reads the control-feel envelope to bound the request and writes no control-feel state at all: no mode select, no seed, no integrated heading, no captured hold, no frame timestamp.

## Deviations from the issue's expected-files list, with reasons

- **No `adapters/aviate/build.rs` or `build_support/direct_transport_identity.rs`.** `scripts/check-flight-tune-contracts.py` pre-pins `tools/flight-tune-aviate/build.rs` and `build_support/runtime_source_identity.rs` to sha256 values whose content is not in this tree, so creating build-script machinery under that name fails the guard. `direct_transport_identity()` instead follows the existing `aviate_action_port_identity` idiom: a domain constant over `include_bytes!` of all ten transport source files. Same property, no pinned-hash conflict.
- **New `adapters/aviate/src/adapter/tests/exact_direct.rs` rather than extending `direct_flight.rs`.** The exact path is its own concern and `direct_flight.rs` covers the operator direct *scope*.
- **`adapters/aviate/src/adapter/control.rs` and `adapters/aviate/Cargo.toml` untouched.** The gating lives in `uplink/direct.rs` where the sender is, and `adapter.rs` is at 487 of its 500-line limit. No new dependency was needed.
- **`flight-tune` gains a `test-support` feature and `SimulatorCapability::for_test`.** `SimulatorCapability::new` is `pub(crate)`, so no crate outside `flight-tune` can mint one, and the capability-gated authority path would otherwise be untestable from `flight-tune-aviate`. This follows the existing `pilotage-durable-storage` `fault-injection` precedent: a dev-dependency enables it, and `cargo build --release` does not compile the function at all.
- **`flight-tune` re-exports `ExecutionTarget`** (one identifier), which the issue's simulator-target requirement needs.
- **`pilotage-adapter-aviate` is a dev-dependency of `flight-tune-aviate`, not a production one.** The production edge would drag tokio and the protocol stack into a supervisor crate; the dev edge is what lets the conformance test prove the port and the real sender actually meet. Production wiring is #469's.
- **The cross-crate operator-path comparison was replaced.** `FlightUplink`'s manual clock is `#[cfg(test)]` and so crate-internal; on the system clock the two uplinks' shaped output diverged by wall-clock jitter alone (0.0001500 vs 0.0001613 m/s). That regression is proven deterministically in the adapter suite instead, and the integration suite asserts the operator family still reaches the flight controller after a direct step.
- **`READBACK_POLL_LIMIT` and `NoEffectiveReadback`.** A future sample waits, bounded; a command already on the link that never gets an exact readback quarantines rather than being scored.

## Revoke

`DirectTransport::revoke` is idempotent and public. It removes the authority and the frozen baseline; afterwards prepare, release, freeze, enact and binding checks all refuse, including for a command prepared before the revoke. A second call removes nothing and returns an equal receipt.

## Gates

Every gate below was run at the pushed tip `8e7f459e`.

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace --all-targets` | pass |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `bash scripts/check-structure.sh` | pass |
| `python3 scripts/check-flight-tune-contracts.py .` | pass |
| `bash scripts/check-flight-tune-boundaries.sh` | pass |
| `python3 scripts/check-feedback-verifier-boundary.py .` | pass |
| `bash scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | pass, 19 pairs ok |

New tests: 44 transport unit tests, 6 public conformance tests, 9 adapter exact-direct tests.

**Campaign identity.** `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` passed in 616 s: `a_campaign_runs_end_to_end_for_the_alia250` ok, `a_campaign_runs_end_to_end_for_the_x500` ok, `probe_warm_start_objectives` ok — both vehicles still seal. That run was at `34f465a5`; every commit since touches only `tools/flight-tune-aviate/src/direct_transport/**`, and `flight-tune-campaign` does not depend on `flight-tune-aviate`, so the run is valid evidence for the tip. Scenario execution is unchanged either way: nothing under `crates/pilotage-mission-core/` or `tools/flight-tune/src/scenario_runtime/` is touched, so `FLIGHT_TUNE_SCENARIO_ENGINE_ID` is identical to main.

SIM / NOT FOR FLIGHT.

Fixes #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
