### PR TITLE
Bind every Aviate runtime production input to one exact identity

### DIFF
--- a/scripts/flight-tune-direct-dependency-allowlist.tsv
+++ b/scripts/flight-tune-direct-dependency-allowlist.tsv
@@ -13,10 +13,14 @@ tools/flight-tune-aviate/Cargo.toml	errno	errno	normal	cfg(target_os = "macos")	
 tools/flight-tune-aviate/Cargo.toml	flight-tune	flight-tune	normal		false	path	tools/flight-tune	true		*
 tools/flight-tune-aviate/Cargo.toml	libc	libc	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.2.177
 tools/flight-tune-aviate/Cargo.toml	libproc	libproc	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		=0.14.11
+tools/flight-tune-aviate/Cargo.toml	pilotage-control-feel	pilotage-control-feel	normal		false	path	crates/pilotage-control-feel	true		*
 tools/flight-tune-aviate/Cargo.toml	pilotage-durable-storage	pilotage-durable-storage	normal		false	path	crates/pilotage-durable-storage	true		*
 tools/flight-tune-aviate/Cargo.toml	rustix	rustix	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	fs,process	=1.1.4
+tools/flight-tune-aviate/Cargo.toml	serde	serde	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
 tools/flight-tune-aviate/Cargo.toml	serde	serde	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	derive	^1.0.228
+tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
 tools/flight-tune-aviate/Cargo.toml	serde_json	serde_json	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true	float_roundtrip	^1.0.150
+tools/flight-tune-aviate/Cargo.toml	sha2	sha2	build		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
 tools/flight-tune-aviate/Cargo.toml	sha2	sha2	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	true		^0.10.9
 tools/flight-tune-aviate/Cargo.toml	sysctl	sysctl	normal	cfg(target_os = "macos")	false	source	registry+https://github.com/rust-lang/crates.io-index	true		=0.7.1
 tools/flight-tune-aviate/Cargo.toml	thiserror	thiserror	normal		false	source	registry+https://github.com/rust-lang/crates.io-index	false		^2.0.18

--- a/tools/flight-tune-aviate/Cargo.toml
+++ b/tools/flight-tune-aviate/Cargo.toml
@@ -8,8 +8,14 @@ description = "Aviate process supervision and exact direct control for simulator
 [lints]
 workspace = true
 
+[build-dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+
 [dependencies]
 flight-tune = { path = "../flight-tune" }
+pilotage-control-feel = { workspace = true }
 pilotage-durable-storage = { workspace = true }
 rustix = { workspace = true, features = ["process"] }
 serde = { workspace = true }
@@ -27,6 +33,5 @@ sysctl = "=0.7.1"
 [dev-dependencies]
 flight-tune = { path = "../flight-tune", features = ["test-support"] }
 pilotage-adapter-aviate = { workspace = true }
-pilotage-control-feel = { workspace = true }
 pilotage-durable-storage = { workspace = true, features = ["fault-injection"] }
 tempfile = "3.23.0"

--- a/tools/flight-tune-aviate/build.rs
+++ b/tools/flight-tune-aviate/build.rs
@@ -1,0 +1,57 @@
+//! Creates the complete Aviate scenario-runtime source identity.
+//!
+//! `println!` is the Cargo build-script protocol channel. It is not a
+//! diagnostic channel in this file.
+
+#![allow(clippy::disallowed_macros)]
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+#[path = "build_support/runtime_source_identity.rs"]
+mod runtime_source_identity;
+
+fn main() -> ExitCode {
+    match generate_identity() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            println!("cargo:warning=cannot identify the Aviate runtime sources: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn generate_identity() -> Result<(), std::io::Error> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let inventory = runtime_source_identity::calculate(&manifest)?;
+    if inventory.names.len() != inventory.paths.len() {
+        return Err(std::io::Error::other(
+            "the runtime-source inventory is inconsistent",
+        ));
+    }
+    for root in runtime_source_identity::source_roots(&manifest) {
+        println!("cargo:rerun-if-changed={}", root.display());
+    }
+    for path in inventory.paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    let output =
+        PathBuf::from(std::env::var_os("OUT_DIR").ok_or_else(|| {
+            std::io::Error::other("Cargo did not supply the build output directory")
+        })?)
+        .join("runtime_source_identity.rs");
+    let mut file = std::fs::File::create(output)?;
+    let document = String::from_utf8(inventory.document).map_err(std::io::Error::other)?;
+    writeln!(
+        file,
+        "const RUNTIME_SOURCE_DOCUMENT: &str = {:?};",
+        document
+    )?;
+    writeln!(
+        file,
+        "const RUNTIME_SOURCE_DIGEST: [u8; 32] = {:?};",
+        inventory.digest
+    )?;
+    file.sync_all()
+}

--- a/tools/flight-tune-aviate/build_support/runtime_source_identity.rs
+++ b/tools/flight-tune-aviate/build_support/runtime_source_identity.rs
@@ -1,0 +1,298 @@
+//! Complete source inventory for the Aviate scenario runtime.
+
+use std::collections::BTreeSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+const DOCUMENT_SCHEMA_VERSION: u16 = 1;
+
+/// Production runtime inputs that require an explicit identity binding.
+pub const PRODUCTION_INPUTS: [&str; 16] = [
+    "src/runtime.rs",
+    "src/runtime/conditions.rs",
+    "src/runtime/direct.rs",
+    "src/runtime/identity.rs",
+    "src/runtime/math.rs",
+    "src/runtime/phase.rs",
+    "src/runtime/phase/direct.rs",
+    "src/runtime/phase/direct/ledger.rs",
+    "src/runtime/phase/direct/readback.rs",
+    "src/runtime/phase/transition.rs",
+    "src/runtime/phase/waveform.rs",
+    "src/runtime/preparation.rs",
+    "src/runtime/quality.rs",
+    "src/runtime/telemetry.rs",
+    "src/runtime/terminal.rs",
+    "src/runtime/timing.rs",
+];
+
+/// One calculated scenario-runtime source inventory.
+pub struct RuntimeSourceInventory {
+    /// Content identity of the canonical inventory document.
+    pub digest: [u8; 32],
+    /// Canonical schema-versioned inventory document.
+    pub document: Vec<u8>,
+    /// Stable package-relative production input names.
+    pub names: Vec<String>,
+    /// Exact input paths for Cargo rebuild tracking.
+    pub paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeSourceDocument {
+    schema_version: u16,
+    entries: Vec<RuntimeSourceEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeSourceEntry {
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+
+/// Returns all roots that can add one production runtime source.
+pub fn source_roots(manifest: &Path) -> Vec<PathBuf> {
+    vec![
+        manifest.join("src/runtime"),
+        manifest.join("src/runtime.rs"),
+    ]
+}
+
+/// Calculates the complete scenario-runtime production identity.
+pub fn calculate(manifest: &Path) -> Result<RuntimeSourceInventory, std::io::Error> {
+    validate_completeness(manifest)?;
+    let inputs = read_declared_inputs(manifest)?;
+    let document = document_from_named_bytes(&inputs)?;
+    let digest = digest_document(&document);
+    let names = inputs.iter().map(|(name, _)| name.clone()).collect();
+    let paths = inputs.iter().map(|(name, _)| manifest.join(name)).collect();
+    Ok(RuntimeSourceInventory {
+        digest,
+        document,
+        names,
+        paths,
+    })
+}
+
+/// Calculates the identity of named production bytes in canonical path order.
+#[cfg(test)]
+pub fn digest_named_bytes(inputs: &[(String, Vec<u8>)]) -> Result<[u8; 32], std::io::Error> {
+    document_from_named_bytes(inputs).map(|document| digest_document(&document))
+}
+
+/// Validates and returns the canonical source document entries.
+pub fn readback_document(bytes: &[u8]) -> Result<Vec<(String, String, u64)>, std::io::Error> {
+    let parsed: RuntimeSourceDocument = serde_json::from_slice(bytes).map_err(io_other)?;
+    validate_document(&parsed)?;
+    let canonical = serde_json::to_vec(&parsed).map_err(io_other)?;
+    if canonical != bytes {
+        return Err(std::io::Error::other(
+            "the runtime-source document is not canonical",
+        ));
+    }
+    Ok(parsed
+        .entries
+        .into_iter()
+        .map(|entry| (entry.path, entry.sha256, entry.bytes))
+        .collect())
+}
+
+fn validate_completeness(manifest: &Path) -> Result<(), std::io::Error> {
+    let declared = declared_names()?;
+    let discovered = discover_production_inputs(manifest)?;
+    if declared != discovered {
+        let missing = declared
+            .difference(&discovered)
+            .cloned()
+            .collect::<Vec<_>>();
+        let extra = discovered
+            .difference(&declared)
+            .cloned()
+            .collect::<Vec<_>>();
+        return Err(std::io::Error::other(format!(
+            "the runtime-source inventory differs: missing={missing:?}, extra={extra:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn declared_names() -> Result<BTreeSet<String>, std::io::Error> {
+    let declared = PRODUCTION_INPUTS
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect::<BTreeSet<_>>();
+    if declared.len() != PRODUCTION_INPUTS.len() {
+        return Err(std::io::Error::other(
+            "the declared runtime-source inventory contains a repeated path",
+        ));
+    }
+    Ok(declared)
+}
+
+fn discover_production_inputs(manifest: &Path) -> Result<BTreeSet<String>, std::io::Error> {
+    let mut discovered = Vec::new();
+    inspect_file(&manifest.join("src/runtime.rs"), manifest, &mut discovered)?;
+    collect_files(&manifest.join("src/runtime"), manifest, &mut discovered)?;
+    Ok(discovered.into_iter().collect())
+}
+
+fn collect_files(
+    directory: &Path,
+    manifest: &Path,
+    discovered: &mut Vec<String>,
+) -> Result<(), std::io::Error> {
+    reject_symlink(directory)?;
+    for entry in std::fs::read_dir(directory)? {
+        let path = entry?.path();
+        reject_symlink(&path)?;
+        if path.is_dir() {
+            if path.file_name().is_none_or(|name| name != "tests") {
+                collect_files(&path, manifest, discovered)?;
+            }
+        } else if is_production_rust(&path) {
+            inspect_file(&path, manifest, discovered)?;
+        }
+    }
+    Ok(())
+}
+
+fn inspect_file(
+    path: &Path,
+    manifest: &Path,
+    discovered: &mut Vec<String>,
+) -> Result<(), std::io::Error> {
+    reject_symlink(path)?;
+    if !path.is_file() {
+        return Err(std::io::Error::other("a runtime source is not a file"));
+    }
+    let relative = path.strip_prefix(manifest).map_err(io_other)?;
+    discovered.push(portable(relative));
+    Ok(())
+}
+
+fn read_declared_inputs(manifest: &Path) -> Result<Vec<(String, Vec<u8>)>, std::io::Error> {
+    PRODUCTION_INPUTS
+        .iter()
+        .map(|name| {
+            let path = manifest.join(name);
+            validate_owned_file(manifest, &path)?;
+            let mut bytes = Vec::new();
+            std::fs::File::open(path)?.read_to_end(&mut bytes)?;
+            Ok(((*name).to_owned(), bytes))
+        })
+        .collect()
+}
+
+fn validate_owned_file(manifest: &Path, path: &Path) -> Result<(), std::io::Error> {
+    reject_symlink(path)?;
+    let canonical_manifest = std::fs::canonicalize(manifest)?;
+    let canonical = std::fs::canonicalize(path)?;
+    if !canonical.starts_with(&canonical_manifest) || !canonical.is_file() {
+        return Err(std::io::Error::other(
+            "a runtime source is outside the package root",
+        ));
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<(), std::io::Error> {
+    if std::fs::symlink_metadata(path)?.file_type().is_symlink() {
+        Err(std::io::Error::other(
+            "the runtime-source inventory does not permit symlinks",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn document_from_named_bytes(inputs: &[(String, Vec<u8>)]) -> Result<Vec<u8>, std::io::Error> {
+    let mut ordered = inputs.to_vec();
+    ordered.sort_by(|left, right| left.0.cmp(&right.0));
+    if ordered.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+        return Err(std::io::Error::other(
+            "the runtime-source byte inventory contains a repeated path",
+        ));
+    }
+    let document = RuntimeSourceDocument {
+        schema_version: DOCUMENT_SCHEMA_VERSION,
+        entries: ordered
+            .into_iter()
+            .map(|(path, bytes)| RuntimeSourceEntry {
+                path,
+                sha256: sha256_hex(&bytes),
+                bytes: bytes.len() as u64,
+            })
+            .collect(),
+    };
+    validate_document(&document)?;
+    let bytes = serde_json::to_vec(&document).map_err(io_other)?;
+    readback_document(&bytes).map(|_| bytes)
+}
+
+fn validate_document(document: &RuntimeSourceDocument) -> Result<(), std::io::Error> {
+    let paths = document
+        .entries
+        .iter()
+        .map(|entry| entry.path.clone())
+        .collect::<BTreeSet<_>>();
+    let valid = document.schema_version == DOCUMENT_SCHEMA_VERSION
+        && paths == declared_names()?
+        && document.entries.len() == PRODUCTION_INPUTS.len()
+        && document
+            .entries
+            .windows(2)
+            .all(|pair| pair[0].path < pair[1].path)
+        && document.entries.iter().all(|entry| {
+            entry.bytes > 0
+                && entry.sha256.len() == 64
+                && entry
+                    .sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(
+            "the runtime-source document is invalid",
+        ))
+    }
+}
+
+fn digest_document(document: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"flight-tune-aviate-runtime-source-document-v1\0");
+    hasher.update((document.len() as u64).to_le_bytes());
+    hasher.update(document);
+    hasher.finalize().into()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn is_production_rust(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    path.extension().is_some_and(|extension| extension == "rs")
+        && name != "tests.rs"
+        && !name.ends_with("_tests.rs")
+}
+
+fn portable(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn io_other(error: impl ToString) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}

--- a/tools/flight-tune-aviate/src/action_port.rs
+++ b/tools/flight-tune-aviate/src/action_port.rs
@@ -27,7 +27,10 @@ pub enum AviateVehicleAction {
     /// Wait for valid estimator and command-link states.
     WaitReady,
     /// Move to the declared start state.
-    ReachStartState { target: StartState },
+    ReachStartState {
+        /// The declared reset-relative start state.
+        target: StartState,
+    },
     /// Hold the start state until the vehicle settles.
     Settle,
     /// Apply one typed control stimulus.
@@ -152,6 +155,12 @@ impl<D: AviateActionDriver> AviateVehicleActionPort<D> {
     #[must_use]
     pub fn into_inner(self) -> D {
         self.driver
+    }
+
+    /// Returns the Aviate driver without consuming the port.
+    #[must_use]
+    pub const fn driver(&self) -> &D {
+        &self.driver
     }
 }
 

--- a/tools/flight-tune-aviate/src/direct_transport.rs
+++ b/tools/flight-tune-aviate/src/direct_transport.rs
@@ -92,6 +92,16 @@ const TRANSPORT_SOURCES: [(&str, &[u8]); 10] = [
     ),
 ];
 
+/// The exact production sources that the transport identity binds.
+///
+/// A new production source under `direct_transport` has to enter this
+/// list, or the exact direct step it shapes would not reach the runtime
+/// production-input identity that qualifies it.
+#[must_use]
+pub fn direct_transport_sources() -> Vec<&'static str> {
+    TRANSPORT_SOURCES.iter().map(|(name, _)| *name).collect()
+}
+
 /// The content identity of this direct-transport implementation.
 ///
 /// # Errors

--- a/tools/flight-tune-aviate/src/direct_transport/step.rs
+++ b/tools/flight-tune-aviate/src/direct_transport/step.rs
@@ -108,6 +108,12 @@ impl PreparedDirectCommand {
         self.run_intent_digest
     }
 
+    /// The direct transport that prepared this command.
+    #[must_use]
+    pub const fn transport_identity_digest(&self) -> Digest {
+        self.transport_identity_digest
+    }
+
     /// Replaces the physical target, for a tamper test.
     ///
     /// The transport re-derives every prepared target before it enacts it,

--- a/tools/flight-tune-aviate/src/lib.rs
+++ b/tools/flight-tune-aviate/src/lib.rs
@@ -27,11 +27,15 @@ mod inspection;
 mod lease_store;
 mod process;
 mod protocol;
+pub mod runtime;
 mod runtime_files;
 mod supervisor;
+mod transition_authorization;
+mod vehicle;
 
 pub use action_port::{
-    AviateActionDriver, AviateActionPortError, AviateVehicleActionPort, aviate_action_port_identity,
+    AviateActionDriver, AviateActionPortError, AviateVehicleAction, AviateVehicleActionPort,
+    AviateVehicleDirective, aviate_action_port_identity,
 };
 pub use document::{
     ProcessIdentity, ProcessStartIdentity, TargetAttestation, TargetProcessContract,
@@ -41,6 +45,19 @@ pub use process::{
     ManagedAviateProcess, PreparedAviateProcess, RECOVERY_REQUEST_SCHEMA_VERSION, RecoveryOutcome,
     RecoveryRequest, SUPERVISION_ATTESTATION_SCHEMA_VERSION, SupervisedProcessRequest,
     SupervisionAttestation, recover_supervised_process_blocking,
+};
+pub use runtime::identity::{
+    AviateRuntimeIdentity, RUNTIME_IMPLEMENTATION_ID, RUNTIME_IMPLEMENTATION_SCHEMA_VERSION,
+    RuntimeIdentityInputs, RuntimeImplementationDocument, RuntimeSourceEntry,
+};
+pub use runtime::{AviateRuntimeError, AviateScenarioDriver};
+pub use transition_authorization::{
+    ADJACENCY_POLICY_SCHEMA_VERSION, AdjacencyPolicy, ParameterStepLimit, TRANSITION_VALIDATOR_ID,
+    TransitionValidator, validator_identity,
+};
+pub use vehicle::{
+    AviateFeelController, AviateVehicleAdapter, AviateVehicleFactory, CandidateFeelMapping,
+    VEHICLE_ID, bind_run_intent, require_run_intent, vehicle_identity,
 };
 
 /// Runs the process-supervisor helper protocol.

--- a/tools/flight-tune-aviate/src/runtime.rs
+++ b/tools/flight-tune-aviate/src/runtime.rs
@@ -1,0 +1,456 @@
+//! The production Aviate scenario runtime.
+//!
+//! Every input that shapes an Aviate production run enters one identity.
+//! The build script inventories the production sources under this module,
+//! [`identity`] binds that inventory to the vehicle, transition validator,
+//! adjacency policy, direct transport, and configuration, and the sealed
+//! value becomes the driver's action-port identity. The simulator-neutral
+//! harness composes it with the shared engine, so a changed production
+//! input changes the scenario runtime identity that every receipt, journal
+//! record, and campaign verification is bound by.
+//!
+//! The runtime attests before every external action. A runtime whose
+//! sealed identity no longer describes its own document cannot reach a
+//! journal, a process, a socket, the simulator, or the vehicle.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+pub mod conditions;
+pub mod direct;
+pub mod identity;
+pub mod math;
+pub mod phase;
+pub mod preparation;
+pub mod quality;
+pub mod telemetry;
+pub mod terminal;
+pub mod timing;
+
+use flight_tune::{
+    ArtifactIdentity, MissionCapability, MissionDocument, ReceiptResult, RunExecutionContext,
+    ScenarioFrame, ScenarioStopContext, TuneError,
+};
+use thiserror::Error;
+
+use crate::action_port::{AviateActionDriver, AviateActionPortError, AviateVehicleDirective};
+use crate::direct_transport::DirectTransportError;
+
+use conditions::ConditionLedger;
+use direct::DirectControl;
+use identity::AviateRuntimeIdentity;
+use phase::PhaseMachine;
+use phase::transition::StartStateTolerance;
+use preparation::PreparedRun;
+use telemetry::VehicleSignals;
+use terminal::{AviateRunSeal, RunClosure};
+use timing::{FrameStamp, SampleClock};
+
+/// One production Aviate runtime operation failed.
+#[derive(Debug, Error)]
+pub enum AviateRuntimeError {
+    /// A bound runtime identity is not valid.
+    #[error("the Aviate runtime identity is not valid: {source}")]
+    InvalidIdentity {
+        /// The identity validation failure.
+        #[source]
+        source: TuneError,
+    },
+    /// A runtime identity input is missing or zero.
+    #[error("the Aviate runtime identity is incomplete: {detail}")]
+    IncompleteIdentity {
+        /// The stable identity detail.
+        detail: String,
+    },
+    /// The runtime no longer matches the identity it was sealed with.
+    #[error("the Aviate runtime identity changed")]
+    RuntimeIdentityChanged,
+    /// A document cannot be encoded.
+    #[error("cannot encode the Aviate {document} document")]
+    Encode {
+        /// The document class.
+        document: &'static str,
+        /// The encoding failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A document cannot be decoded.
+    #[error("cannot decode the Aviate {document} document")]
+    Decode {
+        /// The document class.
+        document: &'static str,
+        /// The decoding failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A numeric value is not usable.
+    #[error("the Aviate runtime {field} is not a usable number")]
+    InvalidValue {
+        /// The invalid field.
+        field: &'static str,
+    },
+    /// A frame arrived out of order.
+    #[error("the Aviate runtime refused a frame: {detail}")]
+    FrameOrder {
+        /// The stable ordering detail.
+        detail: &'static str,
+    },
+    /// A frame omits a state the vehicle port needs.
+    #[error("the Aviate scenario frame omits the {field}")]
+    IncompleteFrame {
+        /// The absent field.
+        field: &'static str,
+    },
+    /// No frame has latched the reset-relative start origin.
+    #[error("the Aviate runtime has no reset-relative start origin")]
+    NoStartOrigin,
+    /// An applied condition changed inside a scored window.
+    #[error("the applied condition {name} changed inside a scored window")]
+    ConditionChanged {
+        /// The condition that changed.
+        name: String,
+    },
+    /// The runtime cannot resolve one waveform.
+    #[error("the Aviate runtime cannot resolve a {waveform} waveform")]
+    UnsupportedWaveform {
+        /// The waveform class.
+        waveform: &'static str,
+    },
+    /// A receipt does not name the exact run this runtime admitted.
+    #[error("the Aviate {receipt} receipt does not match the exact run intent")]
+    ReceiptMismatch {
+        /// The receipt class.
+        receipt: &'static str,
+    },
+    /// The admitted mission cannot fly on this runtime.
+    #[error("the Aviate runtime refused the mission: {detail}")]
+    MissionRejected {
+        /// The stable refusal detail.
+        detail: String,
+    },
+    /// The runtime has no admitted run.
+    #[error("the Aviate runtime has no admitted run")]
+    NoAdmittedRun,
+    /// The direct transport refused an operation.
+    #[error("the Aviate direct transport refused the operation: {source}")]
+    DirectTransport {
+        /// The transport failure.
+        #[source]
+        source: DirectTransportError,
+    },
+    /// The direct family reached a runtime with no direct authority.
+    #[error("the Aviate runtime holds no direct authority for this run")]
+    NoDirectAuthority,
+    /// A stimulus asks the direct path for a family it does not carry.
+    #[error("the Aviate direct path does not carry the {family} family")]
+    UnsupportedDirectFamily {
+        /// The refused control family.
+        family: &'static str,
+    },
+    /// A direct stimulus does not resolve to one exact physical value.
+    #[error("the Aviate direct path cannot resolve the {mapping} mapping exactly")]
+    InexactDirectMapping {
+        /// The refused mapping rule.
+        mapping: &'static str,
+    },
+    /// A prepared direct command is already open.
+    #[error("direct command {sequence} is already prepared and open")]
+    DirectIntentOpen {
+        /// The open direct command sequence.
+        sequence: u64,
+    },
+    /// A direct result arrived with no open prepared command.
+    #[error("the Aviate runtime has no open prepared direct command")]
+    NoOpenDirectIntent,
+    /// An enacted record does not close the intent it was prepared from.
+    #[error("the enacted direct record does not close its prepared intent")]
+    DirectRecordMismatch,
+    /// A direct command was prepared durably with no durable result.
+    #[error("direct command {sequence} has no durable result; the vehicle state is ambiguous")]
+    AmbiguousDirectCommand {
+        /// The ambiguous direct command sequence.
+        sequence: u64,
+    },
+    /// One direct record cannot become evidence.
+    #[error("the Aviate runtime refused to publish a direct record: {detail}")]
+    DirectPublicationRejected {
+        /// The stable refusal detail.
+        detail: &'static str,
+    },
+    /// Direct evidence does not bind one exact run and runtime.
+    #[error("the Aviate direct evidence does not bind its run and runtime")]
+    DirectEvidenceUnbound,
+    /// A run seal does not bind one exact run and runtime.
+    #[error("the Aviate run seal does not bind its run and runtime")]
+    UnboundRunSeal,
+    /// A direct ledger document is larger than its limit.
+    #[error("the Aviate direct ledger document is {bytes} bytes")]
+    LedgerDocumentSize {
+        /// The encoded document size.
+        bytes: usize,
+    },
+    /// A residual direct ledger document already exists.
+    #[error("the Aviate direct ledger already holds {name}")]
+    DirectLedgerResidual {
+        /// The residual document name.
+        name: String,
+    },
+    /// A direct ledger document did not read back unchanged.
+    #[error("the Aviate direct ledger document {name} did not read back unchanged")]
+    DirectLedgerReadback {
+        /// The document name.
+        name: String,
+    },
+    /// Anchored durable storage failed.
+    #[error("the Aviate direct ledger failed to {operation}: {source}")]
+    Storage {
+        /// The storage operation that failed.
+        operation: &'static str,
+        /// The exact storage failure.
+        #[source]
+        source: Box<pilotage_durable_storage::StorageError>,
+    },
+}
+
+impl From<AviateRuntimeError> for AviateActionPortError {
+    fn from(error: AviateRuntimeError) -> Self {
+        Self::driver("runtime", error.to_string())
+    }
+}
+
+/// The production Aviate vehicle action driver.
+///
+/// The driver owns the run's identity, its sample clock, its phase
+/// machine, its applied conditions, its direct path, and its seal. The
+/// direct path is a type parameter: a runtime built with
+/// [`direct::NoDirectControl`] has no sender, no transport, and no durable
+/// ledger, so a mission that asks for the direct family is refused rather
+/// than quietly shaped through the operator law.
+#[derive(Debug)]
+pub struct AviateScenarioDriver<D> {
+    runtime: AviateRuntimeIdentity,
+    capabilities: Vec<MissionCapability>,
+    clock: SampleClock,
+    phases: PhaseMachine,
+    conditions: ConditionLedger,
+    direct: D,
+    signals: VehicleSignals,
+    run: Option<PreparedRun>,
+    started: bool,
+    seal: Option<AviateRunSeal>,
+}
+
+impl<D: DirectControl> AviateScenarioDriver<D> {
+    /// Creates one driver for a sealed runtime identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the runtime does not attest or
+    /// the start-state tolerance is unusable.
+    pub fn new(
+        runtime: AviateRuntimeIdentity,
+        capabilities: Vec<MissionCapability>,
+        tolerance: StartStateTolerance,
+        direct: D,
+    ) -> Result<Self, AviateRuntimeError> {
+        runtime.attest()?;
+        Ok(Self {
+            runtime,
+            capabilities,
+            clock: SampleClock::new(),
+            phases: PhaseMachine::new(tolerance)?,
+            conditions: ConditionLedger::new(),
+            direct,
+            signals: VehicleSignals::default(),
+            run: None,
+            started: false,
+            seal: None,
+        })
+    }
+
+    /// The sealed production-input identity of this runtime.
+    #[must_use]
+    pub const fn runtime_identity(&self) -> &AviateRuntimeIdentity {
+        &self.runtime
+    }
+
+    /// The seal of the last stopped run, when one exists.
+    #[must_use]
+    pub const fn seal(&self) -> Option<&AviateRunSeal> {
+        self.seal.as_ref()
+    }
+
+    /// The admitted run, when one exists.
+    #[must_use]
+    pub const fn admitted_run(&self) -> Option<&PreparedRun> {
+        self.run.as_ref()
+    }
+
+    /// Rejects a restart whose runtime is not the frozen session identity.
+    ///
+    /// The check runs before any journal, process, socket, simulator, or
+    /// vehicle mutation, so a campaign that resumes under a changed
+    /// runtime identity stops with nothing external touched.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the runtime identity differs
+    /// from the frozen one.
+    pub fn require_frozen_runtime(
+        &self,
+        frozen: &ArtifactIdentity,
+    ) -> Result<(), AviateRuntimeError> {
+        self.runtime.require_frozen(frozen)
+    }
+
+    fn admitted(&self) -> Result<&PreparedRun, AviateRuntimeError> {
+        self.run.as_ref().ok_or(AviateRuntimeError::NoAdmittedRun)
+    }
+
+    fn accept(&mut self, frame: &ScenarioFrame) -> Result<FrameStamp, AviateRuntimeError> {
+        let stamp = self.clock.accept(FrameStamp {
+            source_sequence: frame.source_sequence,
+            simulator_time_ns: frame.simulator_time_ns,
+            trial_time_ns: frame.trial_time_ns,
+        })?;
+        self.phases.latch_origin(frame)?;
+        self.conditions.observe(frame)?;
+        Ok(stamp)
+    }
+
+    fn advance(
+        &mut self,
+        stamp: FrameStamp,
+        frame: &ScenarioFrame,
+        directive: &AviateVehicleDirective,
+    ) -> Result<Option<ReceiptResult>, AviateRuntimeError> {
+        self.phases.open(stamp);
+        let advance = phase::advance(
+            &mut self.phases,
+            &mut self.conditions,
+            &mut self.direct,
+            stamp,
+            frame,
+            directive,
+        )?;
+        self.signals.normalized_command = advance.commanded;
+        self.signals.channel = advance.channel;
+        self.signals.saturated = advance.saturated;
+        match advance.progress {
+            phase::PhaseProgress::Running => Ok(None),
+            phase::PhaseProgress::Complete(result) => {
+                self.phases.close();
+                Ok(Some(result))
+            }
+        }
+    }
+
+    /// The canonical signals the vehicle port adds to the current frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a commanded value is not finite.
+    pub fn vehicle_signals(&self) -> Result<Vec<flight_tune::ObservedSignal>, AviateRuntimeError> {
+        self.signals.observed()
+    }
+
+    /// The canonical telemetry values this runtime is answerable for.
+    ///
+    /// A backend merges these into the sample it scores. Every other
+    /// canonical field comes from the simulator truth projection, which
+    /// [`quality::source_of`] states field by field.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a commanded value is not finite.
+    pub fn canonical_telemetry(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, f64>, AviateRuntimeError> {
+        self.signals.canonical_values(self.seal.is_some())
+    }
+}
+
+impl<D: DirectControl> AviateActionDriver for AviateScenarioDriver<D> {
+    fn action_port_identity(&self) -> &ArtifactIdentity {
+        self.runtime.identity()
+    }
+
+    fn capabilities(&self) -> &[MissionCapability] {
+        &self.capabilities
+    }
+
+    fn prepare_blocking(
+        &mut self,
+        document: &MissionDocument,
+        context: &RunExecutionContext,
+    ) -> Result<(), AviateActionPortError> {
+        let run = PreparedRun::admit(document, context, &self.runtime)?;
+        self.clock = SampleClock::new();
+        self.phases.reset();
+        self.conditions.clear();
+        self.started = false;
+        self.seal = None;
+        self.run = Some(run);
+        Ok(())
+    }
+
+    fn start_blocking(&mut self) -> Result<(), AviateActionPortError> {
+        let run = self.admitted()?;
+        run.require_runtime(&self.runtime)?;
+        self.started = true;
+        Ok(())
+    }
+
+    fn observe_blocking(
+        &mut self,
+        frame: &ScenarioFrame,
+        directive: Option<&AviateVehicleDirective>,
+    ) -> Result<Option<ReceiptResult>, AviateActionPortError> {
+        if !self.started {
+            return Err(AviateRuntimeError::NoAdmittedRun.into());
+        }
+        self.runtime.attest()?;
+        let stamp = self.accept(frame)?;
+        let (link_valid, estimator_valid) = telemetry::require_vehicle_states(frame)?;
+        self.signals.link_valid = link_valid;
+        self.signals.estimator_valid = estimator_valid;
+        let Some(directive) = directive else {
+            return Ok(None);
+        };
+        Ok(self.advance(stamp, frame, directive)?)
+    }
+
+    fn stop_blocking(
+        &mut self,
+        context: &mut ScenarioStopContext,
+    ) -> Result<(), AviateActionPortError> {
+        let run = self.admitted()?;
+        run.require_runtime(&self.runtime)?;
+        if context.last_source_sequence.is_none() {
+            context.last_source_sequence = self.clock.last_source_sequence();
+        }
+        let closure = RunClosure {
+            run_intent_digest: run.run_intent_digest(),
+            runtime_identity: run.runtime_identity().clone(),
+            accepted_frames: self.clock.accepted(),
+            direct_evidence: self.direct.seal(run.runtime_identity())?,
+        };
+        self.seal = Some(terminal::seal(&closure, context)?);
+        self.direct.revoke();
+        self.started = false;
+        Ok(())
+    }
+
+    fn cleanup_blocking(&mut self) -> Result<(), AviateActionPortError> {
+        self.direct.revoke();
+        self.clock = SampleClock::new();
+        self.phases.reset();
+        self.conditions.clear();
+        self.signals = VehicleSignals::default();
+        self.started = false;
+        self.run = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune-aviate/src/runtime/conditions.rs
+++ b/tools/flight-tune-aviate/src/runtime/conditions.rs
@@ -1,0 +1,95 @@
+//! The environmental conditions one scored window was flown under.
+//!
+//! The simulator owns applying a condition set; the vehicle port only
+//! observes the result. What the vehicle port owns is the guarantee that a
+//! scored window was flown under one condition set: a value that changes
+//! part-way through a stimulus would make the measured response the
+//! response to two different worlds.
+
+use std::collections::BTreeMap;
+
+use flight_tune::ScenarioFrame;
+
+use super::AviateRuntimeError;
+use super::math::require_finite;
+
+/// The condition values one run has observed.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ConditionLedger {
+    observed: BTreeMap<String, f64>,
+    locked: bool,
+}
+
+impl ConditionLedger {
+    /// Creates one empty ledger.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            observed: BTreeMap::new(),
+            locked: false,
+        }
+    }
+
+    /// Clears the ledger for a new run.
+    pub fn clear(&mut self) {
+        self.observed.clear();
+        self.locked = false;
+    }
+
+    /// Freezes the observed conditions for the length of a scored window.
+    ///
+    /// A trial that applies no conditions freezes the empty set. The
+    /// invariant is that the set does not change inside the window, and an
+    /// empty set satisfies it until a condition appears, which the locked
+    /// path then refuses.
+    pub const fn lock(&mut self) {
+        self.locked = true;
+    }
+
+    /// Releases the freeze at the end of a scored window.
+    pub const fn unlock(&mut self) {
+        self.locked = false;
+    }
+
+    /// Records the conditions one frame reports.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a value is not finite, or when a
+    /// value changes while a scored window is frozen.
+    pub fn observe(&mut self, frame: &ScenarioFrame) -> Result<(), AviateRuntimeError> {
+        for (name, value) in &frame.applied_conditions {
+            let value = require_finite("applied condition", *value)?;
+            match self.observed.get(name) {
+                Some(previous) if previous.to_bits() == value.to_bits() => {}
+                Some(_) | None if !self.locked => {
+                    self.observed.insert(name.clone(), value);
+                }
+                Some(_) => {
+                    return Err(AviateRuntimeError::ConditionChanged { name: name.clone() });
+                }
+                None => {
+                    return Err(AviateRuntimeError::ConditionChanged { name: name.clone() });
+                }
+            }
+        }
+        if self.locked && frame.applied_conditions.len() != self.observed.len() {
+            return Err(AviateRuntimeError::ConditionChanged {
+                name: "the applied condition set".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// The conditions this run has observed.
+    #[must_use]
+    pub const fn observed(&self) -> &BTreeMap<String, f64> {
+        &self.observed
+    }
+
+    /// Whether a scored window has frozen the conditions.
+    #[must_use]
+    pub const fn is_locked(&self) -> bool {
+        self.locked
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/direct.rs
+++ b/tools/flight-tune-aviate/src/runtime/direct.rs
@@ -1,0 +1,418 @@
+//! The direct authority and direct evidence of one run.
+//!
+//! The transport owns sending an exact step. What one run owns is the rest
+//! of it: the durable ledger that brackets every send, the validation each
+//! record has to pass before it can be scored, and the single digest that
+//! binds the whole set to the run receipt the campaign seals.
+//!
+//! The authority exists only for a run whose mission actually commands the
+//! direct family. A run that never asks for a direct step never mints one,
+//! so the path is absent rather than merely unused.
+
+use flight_tune::{ArtifactIdentity, Digest};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::direct_transport::{
+    DirectBaselineRequest, DirectCommandRecord, DirectCommandSender, DirectStepRequest,
+    DirectTransport, DirectTransportRequest,
+};
+
+use super::AviateRuntimeError;
+use super::phase::direct::DirectStepOutcome;
+use super::phase::direct::ledger::{DirectIntentLedger, DirectIntentStore, DirectRecoveryOutcome};
+use super::phase::direct::readback::PublicationContext;
+
+/// The supported direct run-evidence document schema.
+pub const DIRECT_RUN_EVIDENCE_SCHEMA_VERSION: u16 = 1;
+
+const DIRECT_EVIDENCE_DOMAIN: &[u8] = b"pilotage-aviate-direct-run-evidence-v1\0";
+
+/// The complete direct-command evidence of one run.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectRunEvidence {
+    /// Document schema version.
+    pub schema_version: u16,
+    /// The exact run intent this evidence belongs to.
+    pub run_intent_digest: Digest,
+    /// The direct transport that sent every command.
+    pub transport_identity_digest: Digest,
+    /// The runtime implementation that drove the transport.
+    pub runtime_identity: ArtifactIdentity,
+    /// Every validated direct command, in the order the run sent them.
+    pub records: Vec<DirectCommandRecord>,
+}
+
+impl DirectRunEvidence {
+    /// The identity that a run receipt binds this evidence by.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the document cannot be encoded.
+    pub fn digest(&self) -> Result<Digest, AviateRuntimeError> {
+        let bytes = serde_json::to_vec(self).map_err(|source| AviateRuntimeError::Encode {
+            document: "direct run evidence",
+            source,
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(DIRECT_EVIDENCE_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Rejects evidence that does not belong to one exact run intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a record names another run
+    /// intent, another transport, or the document names another runtime.
+    pub fn require_bound(
+        &self,
+        run_intent_digest: Digest,
+        runtime_identity: &ArtifactIdentity,
+    ) -> Result<(), AviateRuntimeError> {
+        if self.schema_version != DIRECT_RUN_EVIDENCE_SCHEMA_VERSION
+            || self.run_intent_digest != run_intent_digest
+            || &self.runtime_identity != runtime_identity
+        {
+            return Err(AviateRuntimeError::DirectEvidenceUnbound);
+        }
+        if self.records.iter().any(|record| {
+            record.run_intent_digest != run_intent_digest
+                || record.transport_identity_digest != self.transport_identity_digest
+        }) {
+            return Err(AviateRuntimeError::DirectEvidenceUnbound);
+        }
+        Ok(())
+    }
+}
+
+/// The direct authority that one run holds.
+#[derive(Debug)]
+pub struct DirectRunAuthority {
+    transport: DirectTransport,
+    ledger: DirectIntentLedger,
+    context: PublicationContext,
+    records: Vec<DirectCommandRecord>,
+}
+
+impl DirectRunAuthority {
+    /// Authorizes the simulator-only direct path for one run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the execution target is a real
+    /// vehicle, when a binding does not accept the tuning session, or when
+    /// the run intent is missing.
+    pub fn authorize<S: DirectCommandSender + ?Sized>(
+        request: &DirectTransportRequest<'_>,
+        sender: &S,
+        run_intent_digest: Digest,
+    ) -> Result<Self, AviateRuntimeError> {
+        if run_intent_digest.is_zero() {
+            return Err(AviateRuntimeError::IncompleteIdentity {
+                detail: "the direct authority has no run intent".to_owned(),
+            });
+        }
+        let transport = DirectTransport::authorize(request, sender)
+            .map_err(|source| AviateRuntimeError::DirectTransport { source })?;
+        let context = PublicationContext {
+            run_intent_digest,
+            transport_identity_digest: transport.session().identity_digest(),
+            tolerance: transport.tolerance(),
+        };
+        Ok(Self {
+            transport,
+            ledger: DirectIntentLedger::new(),
+            context,
+            records: Vec::new(),
+        })
+    }
+
+    /// The exact direct transport this run commands through.
+    pub const fn transport_mut(&mut self) -> &mut DirectTransport {
+        &mut self.transport
+    }
+
+    /// The exact direct transport this run commands through.
+    #[must_use]
+    pub const fn transport(&self) -> &DirectTransport {
+        &self.transport
+    }
+
+    /// The durable ledger that brackets every direct send.
+    pub const fn ledger_mut(&mut self) -> &mut DirectIntentLedger {
+        &mut self.ledger
+    }
+
+    /// What every published record has to agree with.
+    #[must_use]
+    pub const fn publication_context(&self) -> &PublicationContext {
+        &self.context
+    }
+
+    /// Adds one validated direct record to this run's evidence.
+    pub fn record(&mut self, record: DirectCommandRecord) {
+        self.records.push(record);
+    }
+
+    /// Rejects a resume whose durable ledger cannot say what was sent.
+    ///
+    /// A prepared intent with no durable result means the command may or
+    /// may not have reached the flight controller. The run is not scorable
+    /// either way, so the ambiguity ends the run instead of resuming it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the ledger is unreadable, or
+    /// when a prepared direct command has no durable result.
+    pub fn require_resolved_ledger<S: DirectIntentStore + ?Sized>(
+        &self,
+        store: &S,
+    ) -> Result<DirectRecoveryOutcome, AviateRuntimeError> {
+        let outcome = store.read_state(self.ledger.sequence())?;
+        if let DirectRecoveryOutcome::Ambiguous(intent) = &outcome {
+            return Err(AviateRuntimeError::AmbiguousDirectCommand {
+                sequence: intent.sequence,
+            });
+        }
+        Ok(outcome)
+    }
+
+    /// Seals every validated direct record as this run's direct evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a prepared command is still open
+    /// or a record does not bind this run.
+    pub fn seal(
+        &self,
+        runtime_identity: &ArtifactIdentity,
+    ) -> Result<DirectRunEvidence, AviateRuntimeError> {
+        if self.ledger.is_open() {
+            return Err(AviateRuntimeError::AmbiguousDirectCommand {
+                sequence: self.ledger.sequence(),
+            });
+        }
+        let evidence = DirectRunEvidence {
+            schema_version: DIRECT_RUN_EVIDENCE_SCHEMA_VERSION,
+            run_intent_digest: self.context.run_intent_digest,
+            transport_identity_digest: self.context.transport_identity_digest,
+            runtime_identity: runtime_identity.clone(),
+            records: self.records.clone(),
+        };
+        evidence.require_bound(self.context.run_intent_digest, runtime_identity)?;
+        Ok(evidence)
+    }
+
+    /// Removes every direct authority this run holds.
+    pub fn revoke(&mut self) {
+        let _receipt = self.transport.revoke();
+    }
+}
+
+/// The vehicle state one direct stimulus is entered from.
+///
+/// The attitude comes from the frame that opens the stimulus, so the
+/// frozen baseline is the state the vehicle was actually in when the
+/// scored window began.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DirectEntryState {
+    /// The measured roll at stimulus entry, in radians.
+    pub roll_rad: f64,
+    /// The measured pitch at stimulus entry, in radians.
+    pub pitch_rad: f64,
+    /// The measured heading at stimulus entry, in radians.
+    pub yaw_rad: f64,
+}
+
+/// The configured shape of one run's direct baseline block.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DirectBaselinePolicy {
+    /// The identified hover trim that a vertical stimulus measures from.
+    pub hover_trim: f64,
+    /// The largest number of commands in the baseline block.
+    pub max_commands: u32,
+}
+
+/// The exact direct control that one runtime commands through.
+///
+/// A runtime built with [`NoDirectControl`] has no direct path at all: the
+/// sender, the transport, and the durable ledger are absent from the type,
+/// so a mission that asks for the direct family is refused rather than
+/// quietly shaped through the operator law.
+pub trait DirectControl {
+    /// Freezes the direct baseline every step of this run is measured from.
+    ///
+    /// The call is idempotent: a run freezes one baseline, at the frame
+    /// that opens its first direct stimulus, and every later step measures
+    /// from that same frozen state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when this runtime has no direct
+    /// authority or the baseline block does not settle.
+    fn ensure_baseline_blocking(
+        &mut self,
+        entry: DirectEntryState,
+    ) -> Result<(), AviateRuntimeError>;
+
+    /// Sends one exact direct command, bracketed by the durable ledger.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when this runtime has no direct
+    /// authority, when the ledger cannot record the command, or when the
+    /// resulting record fails publication validation.
+    fn command_blocking(
+        &mut self,
+        stimulus: &DirectStepRequest,
+        release: bool,
+    ) -> Result<DirectStepOutcome, AviateRuntimeError>;
+
+    /// Seals the direct evidence of this run, when the run has any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a prepared command has no
+    /// durable result or a record does not bind this run.
+    fn seal(
+        &self,
+        runtime_identity: &ArtifactIdentity,
+    ) -> Result<Option<DirectRunEvidence>, AviateRuntimeError>;
+
+    /// Removes every direct authority this run holds.
+    fn revoke(&mut self);
+}
+
+/// A runtime with no direct path.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NoDirectControl;
+
+impl DirectControl for NoDirectControl {
+    fn ensure_baseline_blocking(
+        &mut self,
+        _entry: DirectEntryState,
+    ) -> Result<(), AviateRuntimeError> {
+        Err(AviateRuntimeError::NoDirectAuthority)
+    }
+
+    fn command_blocking(
+        &mut self,
+        _stimulus: &DirectStepRequest,
+        _release: bool,
+    ) -> Result<DirectStepOutcome, AviateRuntimeError> {
+        Err(AviateRuntimeError::NoDirectAuthority)
+    }
+
+    fn seal(
+        &self,
+        _runtime_identity: &ArtifactIdentity,
+    ) -> Result<Option<DirectRunEvidence>, AviateRuntimeError> {
+        Ok(None)
+    }
+
+    fn revoke(&mut self) {}
+}
+
+/// The simulator-only direct path of one run.
+///
+/// It owns the authority, the exact command sender, and the durable
+/// ledger together, because none of the three is safe without the other
+/// two: authority without a ledger cannot say what it sent, and a ledger
+/// without authority has nothing to record.
+#[derive(Debug)]
+pub struct SimulatorDirectControl<S, L> {
+    authority: DirectRunAuthority,
+    sender: S,
+    store: L,
+    baseline: DirectBaselinePolicy,
+}
+
+impl<S: DirectCommandSender, L: DirectIntentStore> SimulatorDirectControl<S, L> {
+    /// Authorizes the simulator-only direct path for one run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the execution target is a real
+    /// vehicle, when a binding does not accept the tuning session, or when
+    /// the durable ledger already holds an unresolved prepared command.
+    pub fn authorize(
+        request: &DirectTransportRequest<'_>,
+        sender: S,
+        store: L,
+        run_intent_digest: Digest,
+        baseline: DirectBaselinePolicy,
+    ) -> Result<Self, AviateRuntimeError> {
+        if !baseline.hover_trim.is_finite() || baseline.max_commands == 0 {
+            return Err(AviateRuntimeError::InvalidValue {
+                field: "direct baseline policy",
+            });
+        }
+        let authority = DirectRunAuthority::authorize(request, &sender, run_intent_digest)?;
+        authority.require_resolved_ledger(&store)?;
+        Ok(Self {
+            authority,
+            sender,
+            store,
+            baseline,
+        })
+    }
+
+    /// The direct authority this run holds.
+    #[must_use]
+    pub const fn authority(&self) -> &DirectRunAuthority {
+        &self.authority
+    }
+}
+
+impl<S: DirectCommandSender, L: DirectIntentStore> DirectControl for SimulatorDirectControl<S, L> {
+    fn ensure_baseline_blocking(
+        &mut self,
+        entry: DirectEntryState,
+    ) -> Result<(), AviateRuntimeError> {
+        if self.authority.transport().baseline().is_some() {
+            return Ok(());
+        }
+        let request = DirectBaselineRequest {
+            measured_roll_rad: entry.roll_rad,
+            measured_pitch_rad: entry.pitch_rad,
+            measured_yaw_rad: entry.yaw_rad,
+            hover_trim: self.baseline.hover_trim,
+            run_intent_digest: self.authority.publication_context().run_intent_digest,
+            max_commands: self.baseline.max_commands,
+        };
+        super::phase::direct::freeze_baseline_blocking(
+            &mut self.authority,
+            &mut self.sender,
+            &request,
+        )
+    }
+
+    fn command_blocking(
+        &mut self,
+        stimulus: &DirectStepRequest,
+        release: bool,
+    ) -> Result<DirectStepOutcome, AviateRuntimeError> {
+        super::phase::direct::send_step_blocking(
+            &mut self.authority,
+            &mut self.sender,
+            &mut self.store,
+            stimulus,
+            release,
+        )
+    }
+
+    fn seal(
+        &self,
+        runtime_identity: &ArtifactIdentity,
+    ) -> Result<Option<DirectRunEvidence>, AviateRuntimeError> {
+        self.authority.seal(runtime_identity).map(Some)
+    }
+
+    fn revoke(&mut self) {
+        self.authority.revoke();
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/identity.rs
+++ b/tools/flight-tune-aviate/src/runtime/identity.rs
@@ -1,0 +1,342 @@
+//! The complete production-input identity of the Aviate scenario runtime.
+//!
+//! The build script inventories every production runtime source, writes one
+//! canonical schema-versioned document, and embeds that document with its
+//! digest. This module reads the document back, recomputes the digest from
+//! the embedded bytes, and binds the result to the vehicle, transition
+//! validator, adjacency policy, direct transport, and runtime configuration.
+//!
+//! One value comes out: the runtime implementation identity. A production
+//! input that changes changes it. A test input cannot enter it, because the
+//! inventory refuses a test path. Ordering cannot change it, because the
+//! canonical document sorts its entries and the digest frames each length.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use std::collections::BTreeSet;
+
+use flight_tune::{ArtifactIdentity, Digest};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use super::AviateRuntimeError;
+
+include!(concat!(env!("OUT_DIR"), "/runtime_source_identity.rs"));
+
+/// The supported runtime implementation document schema.
+pub const RUNTIME_IMPLEMENTATION_SCHEMA_VERSION: u16 = 1;
+
+/// The stable name of the Aviate runtime implementation identity.
+pub const RUNTIME_IMPLEMENTATION_ID: &str = "pilotage-aviate-runtime-implementation-v1";
+
+/// The schema version of the embedded source-inventory document.
+const SOURCE_DOCUMENT_SCHEMA_VERSION: u16 = 1;
+
+/// The domain the build script separates the source document with.
+///
+/// The value has to match the build script byte for byte. A readback that
+/// recomputes the digest under another domain would accept a document the
+/// build never wrote.
+const SOURCE_DOCUMENT_DOMAIN: &[u8] = b"flight-tune-aviate-runtime-source-document-v1\0";
+
+/// The domain that separates the runtime implementation document.
+const IMPLEMENTATION_DOMAIN: &[u8] = b"pilotage-aviate-runtime-implementation-v1\0";
+
+/// One production runtime source and its exact content identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeSourceEntry {
+    /// The package-relative production source path.
+    pub path: String,
+    /// The lowercase hexadecimal SHA-256 of the source bytes.
+    pub sha256: String,
+    /// The source length in bytes.
+    pub bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeSourceDocument {
+    schema_version: u16,
+    entries: Vec<RuntimeSourceEntry>,
+}
+
+/// The exact non-source identities that shape one Aviate runtime.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuntimeIdentityInputs {
+    /// The exact vehicle implementation and configuration identity.
+    pub vehicle: ArtifactIdentity,
+    /// The exact candidate-transition validator identity.
+    pub transition_validator: ArtifactIdentity,
+    /// The exact vehicle adjacency-policy identity.
+    pub adjacency_policy_digest: Digest,
+    /// The exact simulator-only direct-transport implementation identity.
+    pub direct_transport: ArtifactIdentity,
+    /// The exact runtime configuration identity.
+    pub configuration: ArtifactIdentity,
+}
+
+/// The canonical runtime implementation document.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeImplementationDocument {
+    /// The document schema version.
+    pub schema_version: u16,
+    /// The embedded source-inventory document identity.
+    pub source_document_digest: Digest,
+    /// Every production runtime source in canonical path order.
+    pub sources: Vec<RuntimeSourceEntry>,
+    /// The exact vehicle implementation and configuration identity.
+    pub vehicle: ArtifactIdentity,
+    /// The exact candidate-transition validator identity.
+    pub transition_validator: ArtifactIdentity,
+    /// The exact vehicle adjacency-policy identity.
+    pub adjacency_policy_digest: Digest,
+    /// The exact simulator-only direct-transport implementation identity.
+    pub direct_transport: ArtifactIdentity,
+    /// The exact runtime configuration identity.
+    pub configuration: ArtifactIdentity,
+}
+
+/// The sealed production-input identity of one Aviate scenario runtime.
+///
+/// The value carries its own document, so a later attestation recomputes
+/// the identity from the same bytes instead of trusting the sealed digest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AviateRuntimeIdentity {
+    document: RuntimeImplementationDocument,
+    identity: ArtifactIdentity,
+}
+
+impl AviateRuntimeIdentity {
+    /// Seals the complete production-input identity of this runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the embedded inventory is not
+    /// canonical, when its digest differs from the embedded digest, or when
+    /// a bound identity is invalid.
+    pub fn seal(inputs: &RuntimeIdentityInputs) -> Result<Self, AviateRuntimeError> {
+        let sources = read_back_sources()?;
+        for identity in [
+            &inputs.vehicle,
+            &inputs.transition_validator,
+            &inputs.direct_transport,
+            &inputs.configuration,
+        ] {
+            ArtifactIdentity::new(identity.id.clone(), identity.digest)
+                .map_err(|source| AviateRuntimeError::InvalidIdentity { source })?;
+        }
+        if inputs.adjacency_policy_digest.is_zero() {
+            return Err(AviateRuntimeError::IncompleteIdentity {
+                detail: "the vehicle adjacency-policy digest is zero".to_owned(),
+            });
+        }
+        let document = RuntimeImplementationDocument {
+            schema_version: RUNTIME_IMPLEMENTATION_SCHEMA_VERSION,
+            source_document_digest: Digest::from_bytes(RUNTIME_SOURCE_DIGEST),
+            sources,
+            vehicle: inputs.vehicle.clone(),
+            transition_validator: inputs.transition_validator.clone(),
+            adjacency_policy_digest: inputs.adjacency_policy_digest,
+            direct_transport: inputs.direct_transport.clone(),
+            configuration: inputs.configuration.clone(),
+        };
+        let identity = document.identity()?;
+        Ok(Self { document, identity })
+    }
+
+    /// The canonical runtime implementation document.
+    #[must_use]
+    pub const fn document(&self) -> &RuntimeImplementationDocument {
+        &self.document
+    }
+
+    /// The sealed runtime implementation identity.
+    #[must_use]
+    pub const fn identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    /// Recomputes this identity from the document it carries.
+    ///
+    /// Every external action runs this check first, so a runtime whose
+    /// sealed digest no longer describes its own document cannot reach a
+    /// journal, a process, a socket, a simulator, or a vehicle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the recomputed identity differs
+    /// from the sealed one.
+    pub fn attest(&self) -> Result<(), AviateRuntimeError> {
+        if self.document.identity()? == self.identity {
+            return Ok(());
+        }
+        Err(AviateRuntimeError::RuntimeIdentityChanged)
+    }
+
+    /// Rejects a frozen session identity that this runtime does not match.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the runtime identity differs from
+    /// the frozen one, or when this runtime no longer attests.
+    pub fn require_frozen(&self, frozen: &ArtifactIdentity) -> Result<(), AviateRuntimeError> {
+        self.attest()?;
+        if &self.identity == frozen {
+            return Ok(());
+        }
+        Err(AviateRuntimeError::RuntimeIdentityChanged)
+    }
+}
+
+impl RuntimeImplementationDocument {
+    /// Recomputes the identity of this canonical document.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the document is not canonical or
+    /// cannot be encoded.
+    pub fn identity(&self) -> Result<ArtifactIdentity, AviateRuntimeError> {
+        self.validate()?;
+        let bytes = serde_json::to_vec(self).map_err(|source| AviateRuntimeError::Encode {
+            document: "runtime implementation",
+            source,
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(IMPLEMENTATION_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        ArtifactIdentity::new(
+            RUNTIME_IMPLEMENTATION_ID,
+            Digest::from_bytes(hasher.finalize().into()),
+        )
+        .map_err(|source| AviateRuntimeError::InvalidIdentity { source })
+    }
+
+    fn validate(&self) -> Result<(), AviateRuntimeError> {
+        if self.schema_version != RUNTIME_IMPLEMENTATION_SCHEMA_VERSION {
+            return Err(AviateRuntimeError::IncompleteIdentity {
+                detail: "the runtime implementation document has another schema".to_owned(),
+            });
+        }
+        if self.source_document_digest.is_zero() || self.adjacency_policy_digest.is_zero() {
+            return Err(AviateRuntimeError::IncompleteIdentity {
+                detail: "the runtime implementation document has a zero digest".to_owned(),
+            });
+        }
+        validate_entries(&self.sources)
+    }
+}
+
+/// Reads the embedded inventory back and recomputes its digest.
+///
+/// The build script writes the document and its digest as two independent
+/// constants. Recomputing one from the other is what makes a changed
+/// production source a changed identity instead of a stale constant.
+fn read_back_sources() -> Result<Vec<RuntimeSourceEntry>, AviateRuntimeError> {
+    let bytes = RUNTIME_SOURCE_DOCUMENT.as_bytes();
+    let parsed: RuntimeSourceDocument =
+        serde_json::from_slice(bytes).map_err(|source| AviateRuntimeError::Decode {
+            document: "runtime source inventory",
+            source,
+        })?;
+    if parsed.schema_version != SOURCE_DOCUMENT_SCHEMA_VERSION {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: "the runtime source inventory has another schema".to_owned(),
+        });
+    }
+    validate_entries(&parsed.entries)?;
+    let canonical = serde_json::to_vec(&parsed).map_err(|source| AviateRuntimeError::Encode {
+        document: "runtime source inventory",
+        source,
+    })?;
+    if canonical != bytes {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: "the runtime source inventory is not canonical".to_owned(),
+        });
+    }
+    if source_document_digest(&canonical) != RUNTIME_SOURCE_DIGEST {
+        return Err(AviateRuntimeError::RuntimeIdentityChanged);
+    }
+    Ok(parsed.entries)
+}
+
+/// The digest the build script computes over the canonical inventory.
+pub(crate) fn source_document_digest(document: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(SOURCE_DOCUMENT_DOMAIN);
+    hasher.update((document.len() as u64).to_le_bytes());
+    hasher.update(document);
+    hasher.finalize().into()
+}
+
+/// Rejects an inventory that repeats, reorders, or names a test source.
+fn validate_entries(entries: &[RuntimeSourceEntry]) -> Result<(), AviateRuntimeError> {
+    if entries.is_empty() {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: "the runtime source inventory is empty".to_owned(),
+        });
+    }
+    let names = entries
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<BTreeSet<_>>();
+    if names.len() != entries.len() {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: "the runtime source inventory repeats a path".to_owned(),
+        });
+    }
+    if entries.windows(2).any(|pair| pair[0].path >= pair[1].path) {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: "the runtime source inventory is not in canonical path order".to_owned(),
+        });
+    }
+    for entry in entries {
+        validate_entry(entry)?;
+    }
+    Ok(())
+}
+
+fn validate_entry(entry: &RuntimeSourceEntry) -> Result<(), AviateRuntimeError> {
+    if is_test_path(&entry.path) {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: format!(
+                "a test source entered the production identity: {}",
+                entry.path
+            ),
+        });
+    }
+    if !entry.path.starts_with("src/")
+        || !entry.path.ends_with(".rs")
+        || entry.path.contains("..")
+        || entry.path.contains('\\')
+    {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: format!("an inventory path is not an owned source: {}", entry.path),
+        });
+    }
+    let hex_is_valid = entry.sha256.len() == 32 * 2
+        && entry
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if !hex_is_valid || entry.bytes == 0 {
+        return Err(AviateRuntimeError::IncompleteIdentity {
+            detail: format!("an inventory entry has no content identity: {}", entry.path),
+        });
+    }
+    Ok(())
+}
+
+/// Whether one inventory path names a test source.
+///
+/// The build script excludes the same names when it discovers inputs. This
+/// check is the readback half: a document that reached the binary with a
+/// test path in it cannot become a production identity.
+pub(crate) fn is_test_path(path: &str) -> bool {
+    path.split('/').any(|part| part == "tests")
+        || path.ends_with("/tests.rs")
+        || path.ends_with("_tests.rs")
+        || path.ends_with("/test_support.rs")
+}

--- a/tools/flight-tune-aviate/src/runtime/math.rs
+++ b/tools/flight-tune-aviate/src/runtime/math.rs
@@ -1,0 +1,133 @@
+//! Numeric rules shared by the Aviate runtime phases.
+//!
+//! Every value that reaches a vehicle command or an evidence record passes
+//! through one of these, so a non-finite intermediate cannot become a
+//! commanded target or a scored sample.
+
+use super::AviateRuntimeError;
+
+/// The largest angle the runtime treats as one turn.
+const TAU: f64 = std::f64::consts::TAU;
+
+/// Rejects a value that is not finite.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the value is infinite or not a number.
+pub fn require_finite(field: &'static str, value: f64) -> Result<f64, AviateRuntimeError> {
+    if value.is_finite() {
+        return Ok(value);
+    }
+    Err(AviateRuntimeError::InvalidValue { field })
+}
+
+/// Bounds one normalized stimulus value to minus one through plus one.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the value is not finite.
+pub fn clamp_normalized(field: &'static str, value: f64) -> Result<f64, AviateRuntimeError> {
+    Ok(require_finite(field, value)?.clamp(-1.0, 1.0))
+}
+
+/// The signed shortest angle from one heading to another, in radians.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when either heading is not finite.
+pub fn heading_error_rad(from_rad: f64, to_rad: f64) -> Result<f64, AviateRuntimeError> {
+    let difference =
+        require_finite("target heading", to_rad)? - require_finite("current heading", from_rad)?;
+    let wrapped = difference.rem_euclid(TAU);
+    Ok(if wrapped > std::f64::consts::PI {
+        wrapped - TAU
+    } else {
+        wrapped
+    })
+}
+
+/// The yaw of one scalar-first attitude quaternion, in radians.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a component is not finite.
+pub fn yaw_rad(attitude_wxyz: [f64; 4]) -> Result<f64, AviateRuntimeError> {
+    let [w, x, y, z] = finite_attitude(attitude_wxyz)?;
+    let sin_yaw = 2.0 * z.mul_add(w, x * y);
+    let cos_yaw = 1.0 - 2.0 * z.mul_add(z, y * y);
+    require_finite("yaw", sin_yaw.atan2(cos_yaw))
+}
+
+/// The roll of one scalar-first attitude quaternion, in radians.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a component is not finite.
+pub fn roll_rad(attitude_wxyz: [f64; 4]) -> Result<f64, AviateRuntimeError> {
+    let [w, x, y, z] = finite_attitude(attitude_wxyz)?;
+    let sin_roll = 2.0 * x.mul_add(w, y * z);
+    let cos_roll = 1.0 - 2.0 * y.mul_add(y, x * x);
+    require_finite("roll", sin_roll.atan2(cos_roll))
+}
+
+/// The pitch of one scalar-first attitude quaternion, in radians.
+///
+/// A quaternion at the pole has no finite arcsine argument, so the value
+/// is bounded to the pole rather than becoming a number that is not one.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a component is not finite.
+pub fn pitch_rad(attitude_wxyz: [f64; 4]) -> Result<f64, AviateRuntimeError> {
+    let [w, x, y, z] = finite_attitude(attitude_wxyz)?;
+    let sine = 2.0 * y.mul_add(w, -(z * x));
+    require_finite("pitch", sine.clamp(-1.0, 1.0).asin())
+}
+
+fn finite_attitude(attitude_wxyz: [f64; 4]) -> Result<[f64; 4], AviateRuntimeError> {
+    for value in attitude_wxyz {
+        require_finite("attitude component", value)?;
+    }
+    Ok(attitude_wxyz)
+}
+
+/// The Euclidean distance between two north-east-down positions, in meters.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a component is not finite.
+pub fn distance_m(left: [f64; 3], right: [f64; 3]) -> Result<f64, AviateRuntimeError> {
+    let mut total = 0.0;
+    for index in 0..3 {
+        let difference = require_finite("position component", left[index])?
+            - require_finite("position component", right[index])?;
+        total = difference.mul_add(difference, total);
+    }
+    require_finite("position distance", total.sqrt())
+}
+
+/// The magnitude of one north-east-down vector.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a component is not finite.
+pub fn magnitude(vector: [f64; 3]) -> Result<f64, AviateRuntimeError> {
+    distance_m(vector, [0.0; 3])
+}
+
+/// The fraction of one span that a value has covered, bounded to zero and one.
+///
+/// A zero span is a completed span, so a caller cannot divide by it.
+#[must_use]
+pub fn progress(elapsed_ns: u64, span_ns: u64) -> f64 {
+    if span_ns == 0 || elapsed_ns >= span_ns {
+        return 1.0;
+    }
+    elapsed_ns as f64 / span_ns as f64
+}
+
+/// Converts whole nanoseconds to seconds.
+#[must_use]
+pub fn seconds(nanoseconds: u64) -> f64 {
+    nanoseconds as f64 / 1_000_000_000.0
+}

--- a/tools/flight-tune-aviate/src/runtime/phase.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase.rs
@@ -1,0 +1,377 @@
+//! The vehicle-side phase machine of one Aviate run.
+//!
+//! One directive is open at a time. The machine latches its entry frame,
+//! advances it on every accepted frame, and returns a receipt only when
+//! the directive is actually finished. A directive that is not finished
+//! returns nothing, which is what lets the mission engine keep waiting
+//! instead of scoring a window that has not closed.
+
+pub mod direct;
+pub mod transition;
+pub mod waveform;
+
+use flight_tune::{
+    ControlChannel, ReceiptResult, ScenarioFrame, StartState, VehicleLifecycleState, Waveform,
+};
+
+use crate::action_port::{AviateVehicleAction, AviateVehicleDirective};
+
+use super::AviateRuntimeError;
+use super::conditions::ConditionLedger;
+use super::direct::{DirectControl, DirectEntryState};
+use super::timing::{FrameStamp, PhaseClock};
+use direct::{DirectStepOutcome, step_request};
+use transition::{SettleWindow, StartOrigin, StartStateTolerance, start_state_error};
+use waveform::WaveformSample;
+
+/// How a directive advanced on one frame.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PhaseProgress {
+    /// The directive is still running. The engine keeps waiting.
+    Running,
+    /// The directive finished with this receipt.
+    Complete(ReceiptResult),
+}
+
+impl PhaseProgress {
+    /// One directive that finished successfully.
+    #[must_use]
+    pub const fn succeeded() -> Self {
+        Self::Complete(ReceiptResult::Succeeded {})
+    }
+
+    /// One directive the vehicle port cannot admit.
+    #[must_use]
+    pub fn refused(detail: impl Into<String>) -> Self {
+        Self::Complete(ReceiptResult::Refused {
+            detail: detail.into(),
+        })
+    }
+
+    /// One directive that is still running.
+    #[must_use]
+    pub const fn running() -> Self {
+        Self::Running
+    }
+}
+
+/// What one control stimulus asks for on one frame.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StimulusAdvance {
+    /// The waveform commands this normalized value on this frame.
+    Command {
+        /// The bounded normalized value to command.
+        normalized: f64,
+        /// Whether the directive finishes on this same frame.
+        complete: bool,
+    },
+    /// The waveform reached the end of its own declared window.
+    Complete,
+}
+
+/// The vehicle-side progress of one run's directives.
+#[derive(Clone, Copy, Debug)]
+pub struct PhaseMachine {
+    clock: PhaseClock,
+    origin: StartOrigin,
+    settle: SettleWindow,
+    tolerance: StartStateTolerance,
+}
+
+impl PhaseMachine {
+    /// Creates one machine with the declared start-state tolerance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a tolerance bound is unusable.
+    pub fn new(tolerance: StartStateTolerance) -> Result<Self, AviateRuntimeError> {
+        tolerance.validate()?;
+        Ok(Self {
+            clock: PhaseClock::new(),
+            origin: StartOrigin::new(),
+            settle: SettleWindow::new(),
+            tolerance,
+        })
+    }
+
+    /// Clears every latched window for a new run.
+    pub const fn reset(&mut self) {
+        self.clock.leave();
+        self.settle.reset();
+        self.origin.clear();
+    }
+
+    /// Latches the reset-relative origin from the first frame of a run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the frame attitude is invalid.
+    pub fn latch_origin(&mut self, frame: &ScenarioFrame) -> Result<(), AviateRuntimeError> {
+        self.origin.latch(frame)
+    }
+
+    /// Closes the open directive so the next one opens its own window.
+    pub const fn close(&mut self) {
+        self.clock.leave();
+        self.settle.reset();
+    }
+
+    /// The trial nanoseconds since the open directive latched its entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when no directive is open.
+    pub fn elapsed_ns(&self, stamp: FrameStamp) -> Result<u64, AviateRuntimeError> {
+        self.clock.elapsed_ns(stamp)
+    }
+
+    /// Opens one directive on the frame that carries it.
+    pub const fn open(&mut self, stamp: FrameStamp) {
+        self.clock.enter(stamp);
+    }
+
+    /// Whether the vehicle reports both link and estimator as valid.
+    #[must_use]
+    pub fn is_ready(frame: &ScenarioFrame) -> bool {
+        frame.link_valid == Some(true) && frame.estimator_valid == Some(true)
+    }
+
+    /// Advances a wait for valid link and estimator states.
+    #[must_use]
+    pub fn advance_wait_ready(&self, frame: &ScenarioFrame) -> PhaseProgress {
+        if Self::is_ready(frame) {
+            return PhaseProgress::succeeded();
+        }
+        PhaseProgress::running()
+    }
+
+    /// Advances an arm or disarm request toward its lifecycle state.
+    #[must_use]
+    pub fn advance_lifecycle(
+        frame: &ScenarioFrame,
+        expected: VehicleLifecycleState,
+    ) -> PhaseProgress {
+        if frame.lifecycle == Some(expected) {
+            return PhaseProgress::succeeded();
+        }
+        PhaseProgress::running()
+    }
+
+    /// Advances the move toward one declared start state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the origin is not latched or a
+    /// frame value is invalid.
+    pub fn advance_start_state(
+        &mut self,
+        stamp: FrameStamp,
+        frame: &ScenarioFrame,
+        target: &StartState,
+    ) -> Result<PhaseProgress, AviateRuntimeError> {
+        let error = start_state_error(&self.origin, frame, target)?;
+        let within = error.is_within(&self.tolerance);
+        // Reaching the start state is a position check, not a dwell: the
+        // settle directive is what proves the vehicle can hold it.
+        let _ = self.settle.advance(stamp, within, 0)?;
+        Ok(if within {
+            PhaseProgress::succeeded()
+        } else {
+            PhaseProgress::running()
+        })
+    }
+
+    /// Advances the dwell that proves the vehicle holds its start state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the origin is not latched or a
+    /// frame value is invalid.
+    pub fn advance_settle(
+        &mut self,
+        stamp: FrameStamp,
+        frame: &ScenarioFrame,
+        target: &StartState,
+    ) -> Result<PhaseProgress, AviateRuntimeError> {
+        let error = start_state_error(&self.origin, frame, target)?;
+        let within = error.is_within(&self.tolerance);
+        if self
+            .settle
+            .advance(stamp, within, self.tolerance.dwell_ns)?
+        {
+            return Ok(PhaseProgress::succeeded());
+        }
+        Ok(PhaseProgress::running())
+    }
+
+    /// Advances one control stimulus and reports what it commands now.
+    ///
+    /// A waveform that states its own window finishes when that window
+    /// closes. A step states no window: it is one commanded value, so the
+    /// directive finishes on the frame that commands it and the hold keeps
+    /// the value until the run releases control.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when no directive is open, when a
+    /// value is not finite, or when the waveform cannot be resolved.
+    pub fn advance_stimulus(
+        &self,
+        stamp: FrameStamp,
+        wave: &Waveform,
+    ) -> Result<StimulusAdvance, AviateRuntimeError> {
+        let elapsed_ns = self.clock.elapsed_ns(stamp)?;
+        Ok(match waveform::sample(wave, elapsed_ns)? {
+            WaveformSample::Complete => StimulusAdvance::Complete,
+            WaveformSample::Active(normalized) => StimulusAdvance::Command {
+                normalized,
+                complete: matches!(wave, Waveform::Step { .. }),
+            },
+        })
+    }
+}
+
+/// What one advanced directive commanded and observed.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DirectiveAdvance {
+    /// How the directive advanced.
+    pub progress: PhaseProgress,
+    /// The normalized value the vehicle commanded on this frame.
+    pub commanded: Option<f64>,
+    /// The control channel the commanded value moves.
+    pub channel: Option<ControlChannel>,
+    /// Whether the commanded value reached a declared envelope endpoint.
+    pub saturated: bool,
+}
+
+impl DirectiveAdvance {
+    fn of(progress: PhaseProgress) -> Self {
+        Self {
+            progress,
+            commanded: None,
+            channel: None,
+            saturated: false,
+        }
+    }
+}
+
+/// Advances one Aviate vehicle directive on one accepted frame.
+///
+/// The dispatch is the only place that turns a mission action into a
+/// vehicle command, so every action the port admits is answered here and
+/// every action it does not admit is refused with a stated reason.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a frame value is invalid, when the
+/// waveform cannot be resolved, or when the direct path refuses a command.
+pub fn advance<D: DirectControl>(
+    machine: &mut PhaseMachine,
+    conditions: &mut ConditionLedger,
+    direct: &mut D,
+    stamp: FrameStamp,
+    frame: &ScenarioFrame,
+    directive: &AviateVehicleDirective,
+) -> Result<DirectiveAdvance, AviateRuntimeError> {
+    match &directive.action {
+        AviateVehicleAction::Arm => Ok(DirectiveAdvance::of(if PhaseMachine::is_ready(frame) {
+            PhaseMachine::advance_lifecycle(frame, VehicleLifecycleState::Armed)
+        } else {
+            PhaseProgress::running()
+        })),
+        AviateVehicleAction::WaitReady => {
+            Ok(DirectiveAdvance::of(machine.advance_wait_ready(frame)))
+        }
+        AviateVehicleAction::ReachStartState { target } => Ok(DirectiveAdvance::of(
+            machine.advance_start_state(stamp, frame, target)?,
+        )),
+        AviateVehicleAction::Settle => Ok(DirectiveAdvance::of(machine.advance_settle(
+            stamp,
+            frame,
+            &settle_target(),
+        )?)),
+        AviateVehicleAction::Stimulate {
+            family,
+            channel,
+            mapping,
+            envelope,
+            waveform,
+        } => {
+            conditions.lock();
+            let request_for =
+                |normalized| step_request(*family, *channel, *mapping, envelope, normalized);
+            match machine.advance_stimulus(stamp, waveform)? {
+                StimulusAdvance::Complete => Ok(DirectiveAdvance::of(PhaseProgress::succeeded())),
+                StimulusAdvance::Command {
+                    normalized,
+                    complete,
+                } => {
+                    let request = request_for(normalized)?;
+                    direct.ensure_baseline_blocking(entry_state(frame)?)?;
+                    let outcome = direct.command_blocking(&request, false)?;
+                    Ok(DirectiveAdvance {
+                        progress: stimulus_progress(outcome, complete),
+                        commanded: Some(normalized),
+                        channel: Some(*channel),
+                        saturated: normalized.abs() >= 1.0,
+                    })
+                }
+            }
+        }
+        AviateVehicleAction::ReleaseControl => {
+            conditions.unlock();
+            Ok(DirectiveAdvance::of(PhaseProgress::succeeded()))
+        }
+        AviateVehicleAction::Observe => Ok(DirectiveAdvance::of(PhaseProgress::succeeded())),
+        AviateVehicleAction::Stop => {
+            conditions.unlock();
+            direct.revoke();
+            Ok(DirectiveAdvance::of(PhaseProgress::succeeded()))
+        }
+        AviateVehicleAction::Disarm => Ok(DirectiveAdvance::of(PhaseMachine::advance_lifecycle(
+            frame,
+            VehicleLifecycleState::Disarmed,
+        ))),
+        AviateVehicleAction::CollectResults => Ok(DirectiveAdvance::of(PhaseProgress::succeeded())),
+    }
+}
+
+/// The progress one direct command outcome reports.
+///
+/// A command that sent nothing keeps the directive open: the run waits for
+/// the raw source rather than scoring a step the flight controller never
+/// received.
+fn stimulus_progress(outcome: DirectStepOutcome, complete: bool) -> PhaseProgress {
+    match outcome {
+        DirectStepOutcome::Enacted if complete => PhaseProgress::succeeded(),
+        DirectStepOutcome::Enacted | DirectStepOutcome::Pending => PhaseProgress::running(),
+        DirectStepOutcome::NoExactSource => {
+            PhaseProgress::refused("the raw source carries no exact sample for the command time")
+        }
+    }
+}
+
+/// The vehicle state that one direct stimulus is entered from.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the frame attitude is invalid.
+fn entry_state(frame: &ScenarioFrame) -> Result<DirectEntryState, AviateRuntimeError> {
+    let attitude = frame.truth.attitude_wxyz;
+    Ok(DirectEntryState {
+        roll_rad: crate::runtime::math::roll_rad(attitude)?,
+        pitch_rad: crate::runtime::math::pitch_rad(attitude)?,
+        yaw_rad: crate::runtime::math::yaw_rad(attitude)?,
+    })
+}
+
+/// The state a settle directive holds.
+///
+/// A settle keeps the state the run already reached, so it measures the
+/// origin the reach latched rather than a second declared target.
+const fn settle_target() -> StartState {
+    StartState {
+        relative_position_ned_m: [0.0; 3],
+        heading: flight_tune::StartHeading::ResetOffset { radians: 0.0 },
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/phase/direct.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase/direct.rs
@@ -1,0 +1,134 @@
+//! Driving one exact direct step through the durable ledger.
+//!
+//! Every direct command this runtime sends follows the same order, and the
+//! order is the point: make the prepared intent durable, enact it, make
+//! the result durable, validate the record, and only then let it count as
+//! evidence. A failure at any step leaves the ledger able to say what the
+//! run had already asked the vehicle to do.
+
+pub mod ledger;
+pub mod readback;
+
+use flight_tune::{ControlChannel, ControlFamily, StimulusEnvelope, StimulusMapping};
+
+use crate::direct_transport::{
+    DirectBaselineRequest, DirectCommandSender, DirectEnactment, DirectStepRequest,
+};
+
+use crate::runtime::AviateRuntimeError;
+use crate::runtime::direct::DirectRunAuthority;
+use crate::runtime::math::clamp_normalized;
+
+use ledger::DirectIntentStore;
+use readback::validate_publication;
+
+/// What one direct command asked the vehicle for.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectStepOutcome {
+    /// The command reached the flight controller and became evidence.
+    Enacted,
+    /// The raw source has not reached the command time. Nothing was sent.
+    Pending,
+    /// The raw source carries no exact sample. Nothing was sent.
+    NoExactSource,
+}
+
+/// Freezes the direct baseline this run measures every step from.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the transport refuses the request or
+/// the baseline block ends without a stable matching readback.
+pub fn freeze_baseline_blocking<S: DirectCommandSender + ?Sized>(
+    authority: &mut DirectRunAuthority,
+    sender: &mut S,
+    request: &DirectBaselineRequest,
+) -> Result<(), AviateRuntimeError> {
+    authority
+        .transport_mut()
+        .freeze_baseline_blocking(sender, request)
+        .map(|_frozen| ())
+        .map_err(|source| AviateRuntimeError::DirectTransport { source })
+}
+
+/// Sends one exact direct step, bracketed by the durable ledger.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the stimulus is not the direct
+/// family, when the ledger cannot make the intent or the result durable,
+/// when the transport refuses the command, or when the resulting record
+/// fails publication validation.
+pub fn send_step_blocking<S, L>(
+    authority: &mut DirectRunAuthority,
+    sender: &mut S,
+    store: &mut L,
+    stimulus: &DirectStepRequest,
+    release: bool,
+) -> Result<DirectStepOutcome, AviateRuntimeError>
+where
+    S: DirectCommandSender + ?Sized,
+    L: DirectIntentStore + ?Sized,
+{
+    let transport = authority.transport_mut();
+    let prepared = if release {
+        transport.prepare_release(stimulus)
+    } else {
+        transport.prepare_step(stimulus)
+    }
+    .map_err(|source| AviateRuntimeError::DirectTransport { source })?;
+
+    // The intent is durable before enactment can put a datagram on the
+    // link, so a stop between the two lines leaves a readable prepared
+    // frame rather than an unrecorded command.
+    let intent = authority.ledger_mut().prepare(store, &prepared)?;
+    let enactment = authority
+        .transport_mut()
+        .enact_blocking(sender, &prepared)
+        .map_err(|source| AviateRuntimeError::DirectTransport { source })?;
+    let result = authority.ledger_mut().resolve(store, &intent, &enactment)?;
+    let _sequence = result.sequence;
+
+    match enactment {
+        DirectEnactment::Enacted(record) => {
+            validate_publication(&record, &intent, authority.publication_context())?;
+            authority.record(*record);
+            Ok(DirectStepOutcome::Enacted)
+        }
+        DirectEnactment::Pending => Ok(DirectStepOutcome::Pending),
+        DirectEnactment::NoExactSource => Ok(DirectStepOutcome::NoExactSource),
+    }
+}
+
+/// Builds one direct step request from a mission stimulus.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the family is not the direct
+/// attitude and thrust family, when the mapping is not exact, or when the
+/// normalized value is not finite.
+pub fn step_request(
+    family: ControlFamily,
+    channel: ControlChannel,
+    mapping: StimulusMapping,
+    envelope: &StimulusEnvelope,
+    normalized: f64,
+) -> Result<DirectStepRequest, AviateRuntimeError> {
+    if family != ControlFamily::DirectAttitudeThrust {
+        return Err(AviateRuntimeError::UnsupportedDirectFamily {
+            family: family.as_str(),
+        });
+    }
+    if mapping != StimulusMapping::AffineExact {
+        return Err(AviateRuntimeError::InexactDirectMapping {
+            mapping: mapping.as_str(),
+        });
+    }
+    Ok(DirectStepRequest {
+        family,
+        channel,
+        mapping,
+        envelope: envelope.clone(),
+        normalized: clamp_normalized("direct stimulus", normalized)?,
+    })
+}

--- a/tools/flight-tune-aviate/src/runtime/phase/direct/ledger.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase/direct/ledger.rs
@@ -1,0 +1,383 @@
+//! Durable synchronization of every prepared exact direct command.
+//!
+//! The transport prepares a command and then enacts it. Between those two
+//! points a datagram can leave the process, so a run that stops there has
+//! commanded the vehicle with nothing on disk that says so. The ledger
+//! closes that window: the prepared intent is durable before enactment can
+//! send, and the send result is durable after it returns.
+//!
+//! Recovery therefore reads one of three states, and the third is the one
+//! that matters: a durable prepared intent with no durable send result is
+//! ambiguous. The command may or may not have reached the flight
+//! controller. The ledger reports that as its own outcome rather than
+//! guessing, because both guesses are wrong for some run.
+
+use std::path::Path;
+
+use flight_tune::Digest;
+use pilotage_durable_storage::{
+    DurableDirectory, DurableStore, ExactObject, ObjectName, PutOutcome, WriterLease,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::direct_transport::{
+    DirectCommandPurpose, DirectCommandRecord, DirectEnactment, DirectSetpoint,
+    PreparedDirectCommand,
+};
+use crate::runtime::AviateRuntimeError;
+
+/// The supported direct intent and result document schema.
+pub const DIRECT_INTENT_SCHEMA_VERSION: u16 = 1;
+
+/// The largest direct ledger document this runtime writes or reads.
+const MAX_LEDGER_DOCUMENT_BYTES: usize = 64 * 1024;
+
+/// One prepared direct command, durable before a datagram can leave.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectIntentRecord {
+    /// Document schema version.
+    pub schema_version: u16,
+    /// The zero-based direct command sequence inside one run.
+    pub sequence: u64,
+    /// What the prepared command is for.
+    pub purpose: DirectCommandPurpose,
+    /// The run intent that the command binds to.
+    pub run_intent_digest: Digest,
+    /// The direct transport that prepared the command.
+    pub transport_identity_digest: Digest,
+    /// The frozen stimulus envelope of the command.
+    pub envelope_digest: Digest,
+    /// The physical target the command will transmit.
+    pub requested: DirectSetpoint,
+}
+
+/// What one durably prepared direct command resolved to.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DirectSendOutcome {
+    /// The command reached the flight controller with a complete record.
+    Enacted {
+        /// The complete causal record of the command.
+        record: Box<DirectCommandRecord>,
+    },
+    /// The raw source had not reached the command time. Nothing was sent.
+    Pending {},
+    /// The raw source carried no exact sample. Nothing was sent.
+    NoExactSource {},
+}
+
+/// The durable result of one prepared direct command.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectSendResult {
+    /// Document schema version.
+    pub schema_version: u16,
+    /// The direct command sequence this result closes.
+    pub sequence: u64,
+    /// The run intent that the command bound to.
+    pub run_intent_digest: Digest,
+    /// What the command resolved to.
+    pub outcome: DirectSendOutcome,
+}
+
+/// What recovery can say about the last prepared direct command.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DirectRecoveryOutcome {
+    /// The run prepared no direct command that is still open.
+    Idle,
+    /// The last prepared command has a durable result.
+    Resolved(Box<DirectSendResult>),
+    /// A prepared command has no durable result.
+    ///
+    /// The command may or may not have reached the flight controller. A
+    /// run that reaches this state cannot be scored, and the campaign must
+    /// quarantine it rather than resume it.
+    Ambiguous(Box<DirectIntentRecord>),
+}
+
+/// The durable store one direct ledger writes through.
+pub trait DirectIntentStore {
+    /// Makes one prepared direct command durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the document cannot be published
+    /// or does not read back unchanged.
+    fn publish_intent(&mut self, record: &DirectIntentRecord)
+    -> Result<Digest, AviateRuntimeError>;
+
+    /// Makes the result of one prepared direct command durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the document cannot be published
+    /// or does not read back unchanged.
+    fn publish_result(&mut self, result: &DirectSendResult) -> Result<Digest, AviateRuntimeError>;
+
+    /// Reads the state of the direct command at one sequence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a stored document is unreadable.
+    fn read_state(&self, sequence: u64) -> Result<DirectRecoveryOutcome, AviateRuntimeError>;
+}
+
+/// The durable direct command ledger of one run.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DirectIntentLedger {
+    sequence: u64,
+    open: bool,
+}
+
+impl DirectIntentLedger {
+    /// Creates one ledger with no prepared command.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sequence: 0,
+            open: false,
+        }
+    }
+
+    /// The next direct command sequence this run will use.
+    #[must_use]
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Whether one prepared command has no durable result yet.
+    #[must_use]
+    pub const fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Makes one prepared command durable before enactment can send.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a prepared command is already
+    /// open, or when the document cannot be made durable.
+    pub fn prepare<S: DirectIntentStore + ?Sized>(
+        &mut self,
+        store: &mut S,
+        prepared: &PreparedDirectCommand,
+    ) -> Result<DirectIntentRecord, AviateRuntimeError> {
+        if self.open {
+            return Err(AviateRuntimeError::DirectIntentOpen {
+                sequence: self.sequence,
+            });
+        }
+        let record = DirectIntentRecord {
+            schema_version: DIRECT_INTENT_SCHEMA_VERSION,
+            sequence: self.sequence,
+            purpose: prepared.purpose(),
+            run_intent_digest: prepared.run_intent_digest(),
+            transport_identity_digest: prepared.transport_identity_digest(),
+            envelope_digest: prepared.envelope_digest(),
+            requested: prepared.requested(),
+        };
+        store.publish_intent(&record)?;
+        self.open = true;
+        Ok(record)
+    }
+
+    /// Makes the result of the open prepared command durable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when no prepared command is open, or
+    /// when the document cannot be made durable.
+    pub fn resolve<S: DirectIntentStore + ?Sized>(
+        &mut self,
+        store: &mut S,
+        intent: &DirectIntentRecord,
+        enactment: &DirectEnactment,
+    ) -> Result<DirectSendResult, AviateRuntimeError> {
+        if !self.open || intent.sequence != self.sequence {
+            return Err(AviateRuntimeError::NoOpenDirectIntent);
+        }
+        let result = DirectSendResult {
+            schema_version: DIRECT_INTENT_SCHEMA_VERSION,
+            sequence: intent.sequence,
+            run_intent_digest: intent.run_intent_digest,
+            outcome: outcome_of(intent, enactment)?,
+        };
+        store.publish_result(&result)?;
+        self.open = false;
+        self.sequence = self.sequence.wrapping_add(1);
+        Ok(result)
+    }
+}
+
+fn outcome_of(
+    intent: &DirectIntentRecord,
+    enactment: &DirectEnactment,
+) -> Result<DirectSendOutcome, AviateRuntimeError> {
+    Ok(match enactment {
+        DirectEnactment::Enacted(record) => {
+            if record.run_intent_digest != intent.run_intent_digest
+                || record.requested != intent.requested
+                || record.envelope_digest != intent.envelope_digest
+                || record.transport_identity_digest != intent.transport_identity_digest
+            {
+                return Err(AviateRuntimeError::DirectRecordMismatch);
+            }
+            DirectSendOutcome::Enacted {
+                record: record.clone(),
+            }
+        }
+        DirectEnactment::Pending => DirectSendOutcome::Pending {},
+        DirectEnactment::NoExactSource => DirectSendOutcome::NoExactSource {},
+    })
+}
+
+/// The direct ledger of one run, on crash-durable private storage.
+pub struct DurableDirectIntentStore {
+    directory: DurableDirectory,
+    writer: WriterLease,
+}
+
+impl DurableDirectIntentStore {
+    /// Opens or creates the direct ledger under one private root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the root cannot be opened or the
+    /// writer lease cannot be acquired.
+    pub fn open_blocking(root: &Path) -> Result<Self, AviateRuntimeError> {
+        let store = DurableStore::open_or_create(root)
+            .map_err(|source| storage_error("open the direct ledger root", source))?;
+        let writer = store
+            .acquire_writer()
+            .map_err(|source| storage_error("acquire the direct ledger writer lease", source))?;
+        let directory = store.root_directory();
+        writer
+            .validate(&directory)
+            .map_err(|source| storage_error("validate the direct ledger writer lease", source))?;
+        Ok(Self { directory, writer })
+    }
+
+    fn publish<T: Serialize>(&self, name: &str, value: &T) -> Result<Digest, AviateRuntimeError> {
+        let bytes = serde_json::to_vec(value).map_err(|source| AviateRuntimeError::Encode {
+            document: "direct ledger",
+            source,
+        })?;
+        if bytes.len() > MAX_LEDGER_DOCUMENT_BYTES {
+            return Err(AviateRuntimeError::LedgerDocumentSize { bytes: bytes.len() });
+        }
+        let object_name = object_name(name)?;
+        match self
+            .directory
+            .put_immutable_no_replace(
+                &self.writer,
+                &object_name,
+                &ExactObject::from_bytes(bytes.clone()),
+            )
+            .map_err(|source| storage_error("publish a direct ledger document", source))?
+        {
+            PutOutcome::Published => {}
+            PutOutcome::AlreadyExact => {
+                return Err(AviateRuntimeError::DirectLedgerResidual {
+                    name: name.to_owned(),
+                });
+            }
+        }
+        let readback = self
+            .directory
+            .read_exact(&object_name, MAX_LEDGER_DOCUMENT_BYTES)
+            .map_err(|source| storage_error("read back a direct ledger document", source))?;
+        if readback.bytes() != bytes {
+            return Err(AviateRuntimeError::DirectLedgerReadback {
+                name: name.to_owned(),
+            });
+        }
+        Ok(digest_bytes(&bytes))
+    }
+
+    fn read<T: serde::de::DeserializeOwned>(
+        &self,
+        name: &str,
+    ) -> Result<Option<T>, AviateRuntimeError> {
+        let object = match self
+            .directory
+            .read_exact(&object_name(name)?, MAX_LEDGER_DOCUMENT_BYTES)
+        {
+            Ok(object) => object,
+            Err(source) if is_absent(&source) => return Ok(None),
+            Err(source) => {
+                return Err(storage_error("read a direct ledger document", source));
+            }
+        };
+        serde_json::from_slice(object.bytes())
+            .map(Some)
+            .map_err(|source| AviateRuntimeError::Decode {
+                document: "direct ledger",
+                source,
+            })
+    }
+}
+
+impl DirectIntentStore for DurableDirectIntentStore {
+    fn publish_intent(
+        &mut self,
+        record: &DirectIntentRecord,
+    ) -> Result<Digest, AviateRuntimeError> {
+        self.publish(&intent_name(record.sequence), record)
+    }
+
+    fn publish_result(&mut self, result: &DirectSendResult) -> Result<Digest, AviateRuntimeError> {
+        self.publish(&result_name(result.sequence), result)
+    }
+
+    fn read_state(&self, sequence: u64) -> Result<DirectRecoveryOutcome, AviateRuntimeError> {
+        let Some(intent) = self.read::<DirectIntentRecord>(&intent_name(sequence))? else {
+            return Ok(DirectRecoveryOutcome::Idle);
+        };
+        match self.read::<DirectSendResult>(&result_name(sequence))? {
+            Some(result) => Ok(DirectRecoveryOutcome::Resolved(Box::new(result))),
+            None => Ok(DirectRecoveryOutcome::Ambiguous(Box::new(intent))),
+        }
+    }
+}
+
+fn intent_name(sequence: u64) -> String {
+    format!("direct-intent-{sequence:016x}")
+}
+
+fn result_name(sequence: u64) -> String {
+    format!("direct-result-{sequence:016x}")
+}
+
+fn object_name(name: &str) -> Result<ObjectName, AviateRuntimeError> {
+    ObjectName::new(name).map_err(|source| storage_error("select a direct ledger document", source))
+}
+
+/// Whether one storage failure means the document simply does not exist.
+///
+/// A ledger read that finds nothing is the normal state before the run
+/// prepares its first direct command. Every other failure is a real one.
+fn is_absent(error: &pilotage_durable_storage::StorageError) -> bool {
+    matches!(
+        error,
+        pilotage_durable_storage::StorageError::Io { source, .. }
+            if source.kind() == std::io::ErrorKind::NotFound
+    )
+}
+
+fn digest_bytes(bytes: &[u8]) -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+fn storage_error(
+    operation: &'static str,
+    source: pilotage_durable_storage::StorageError,
+) -> AviateRuntimeError {
+    AviateRuntimeError::Storage {
+        operation,
+        source: Box::new(source),
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/phase/direct/readback.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase/direct/readback.rs
@@ -1,0 +1,125 @@
+//! Validating what one direct command published before it is scored.
+//!
+//! The transport states that a command reached the flight controller. It
+//! does not state that the record which describes that command is fit to
+//! publish as evidence. This module is that second check: the record has
+//! to agree with the durable prepared intent it closes, name the run
+//! intent the campaign asked for, carry the causal order its own times
+//! claim, and report an effective setpoint inside the declared tolerance.
+//!
+//! A record that fails any of these is quarantined, never scored. Evidence
+//! that describes a command nobody can re-derive is worse than no
+//! evidence, because a reader cannot tell which it is.
+
+use flight_tune::Digest;
+
+use crate::direct_transport::{DirectCommandRecord, DirectSetpoint};
+use crate::runtime::AviateRuntimeError;
+
+use super::ledger::DirectIntentRecord;
+
+/// What one published direct record must agree with.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PublicationContext {
+    /// The exact run intent the campaign asked for.
+    pub run_intent_digest: Digest,
+    /// The direct transport that holds authority for this run.
+    pub transport_identity_digest: Digest,
+    /// The declared numeric tolerance for a target comparison.
+    pub tolerance: f64,
+}
+
+/// Validates one direct command record before it becomes evidence.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the record disagrees with its
+/// prepared intent, names another run intent or transport, states times
+/// that are not causally ordered, or reports a target outside tolerance.
+pub fn validate_publication(
+    record: &DirectCommandRecord,
+    intent: &DirectIntentRecord,
+    context: &PublicationContext,
+) -> Result<(), AviateRuntimeError> {
+    require_intent_agreement(record, intent)?;
+    if record.run_intent_digest != context.run_intent_digest
+        || record.transport_identity_digest != context.transport_identity_digest
+    {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "the record names another run intent or transport",
+        });
+    }
+    require_causal_times(record)?;
+    require_finite_setpoints(record)?;
+    if !record
+        .transmitted
+        .matches_within(&record.requested, context.tolerance)
+    {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "the transmitted setpoint left the requested target",
+        });
+    }
+    if !record
+        .effective
+        .matches_within(&record.transmitted, context.tolerance)
+    {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "the effective setpoint left the transmitted target",
+        });
+    }
+    Ok(())
+}
+
+fn require_intent_agreement(
+    record: &DirectCommandRecord,
+    intent: &DirectIntentRecord,
+) -> Result<(), AviateRuntimeError> {
+    if record.schema_version == 0 || intent.schema_version == 0 {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "a direct document has no schema version",
+        });
+    }
+    if record.purpose != intent.purpose
+        || record.envelope_digest != intent.envelope_digest
+        || record.requested != intent.requested
+        || record.run_intent_digest != intent.run_intent_digest
+        || record.transport_identity_digest != intent.transport_identity_digest
+    {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "the record does not close its durable prepared intent",
+        });
+    }
+    Ok(())
+}
+
+/// Rejects a record whose own times cannot have happened in that order.
+///
+/// A request precedes its transmit, and a transmit precedes the sample
+/// that reports its effect. A record that says otherwise describes an
+/// effect measured before its cause.
+fn require_causal_times(record: &DirectCommandRecord) -> Result<(), AviateRuntimeError> {
+    let times = record.times;
+    if times.requested_at_ns > times.transmitted_at_ns
+        || times.transmitted_at_ns > times.effective_at_ns
+    {
+        return Err(AviateRuntimeError::DirectPublicationRejected {
+            detail: "the record times are not causally ordered",
+        });
+    }
+    Ok(())
+}
+
+fn require_finite_setpoints(record: &DirectCommandRecord) -> Result<(), AviateRuntimeError> {
+    let setpoints: [&DirectSetpoint; 4] = [
+        &record.baseline,
+        &record.requested,
+        &record.transmitted,
+        &record.effective,
+    ];
+    if setpoints.iter().all(|setpoint| setpoint.is_finite()) && record.normalized.is_finite() {
+        return Ok(());
+    }
+    Err(AviateRuntimeError::DirectPublicationRejected {
+        detail: "the record carries a value that is not a number",
+    })
+}

--- a/tools/flight-tune-aviate/src/runtime/phase/transition.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase/transition.rs
@@ -1,0 +1,207 @@
+//! Reaching and holding the declared test start state.
+//!
+//! Every start state is relative to the first frame after the simulator
+//! reset. This module latches that frame once per run and resolves the
+//! declared target against it, so two runs of one mission measure the same
+//! geometry whatever absolute position the simulator chose.
+
+use flight_tune::{ScenarioFrame, StartHeading, StartState};
+
+use crate::runtime::AviateRuntimeError;
+use crate::runtime::math::{distance_m, heading_error_rad, magnitude, yaw_rad};
+use crate::runtime::timing::{FrameStamp, PhaseClock};
+
+/// How close the vehicle has to be to count as at the start state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StartStateTolerance {
+    /// The largest permitted position error in meters.
+    pub position_m: f64,
+    /// The largest permitted heading error in radians.
+    pub heading_rad: f64,
+    /// The largest permitted speed while settled, in meters per second.
+    pub speed_mps: f64,
+    /// The continuous trial time the vehicle has to hold the state.
+    pub dwell_ns: u64,
+}
+
+impl StartStateTolerance {
+    /// Rejects a tolerance that no vehicle can satisfy or that accepts any state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a bound is not finite or positive.
+    pub fn validate(&self) -> Result<(), AviateRuntimeError> {
+        for (field, value) in [
+            ("start position tolerance", self.position_m),
+            ("start heading tolerance", self.heading_rad),
+            ("start speed tolerance", self.speed_mps),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(AviateRuntimeError::InvalidValue { field });
+            }
+        }
+        if self.dwell_ns == 0 {
+            return Err(AviateRuntimeError::InvalidValue {
+                field: "start dwell",
+            });
+        }
+        Ok(())
+    }
+}
+
+/// The reset-relative origin that every start state measures from.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StartOrigin {
+    position_ned_m: Option<[f64; 3]>,
+    heading_rad: Option<f64>,
+}
+
+impl StartOrigin {
+    /// Creates one origin that no frame has latched.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            position_ned_m: None,
+            heading_rad: None,
+        }
+    }
+
+    /// Latches the reset-relative origin from the first frame of a run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the frame attitude is invalid.
+    pub fn latch(&mut self, frame: &ScenarioFrame) -> Result<(), AviateRuntimeError> {
+        if self.position_ned_m.is_none() {
+            self.position_ned_m = Some(frame.truth.position_ned_m);
+            self.heading_rad = Some(yaw_rad(frame.truth.attitude_wxyz)?);
+        }
+        Ok(())
+    }
+
+    /// Clears the latched origin so the next run latches its own.
+    pub const fn clear(&mut self) {
+        self.position_ned_m = None;
+        self.heading_rad = None;
+    }
+
+    /// The absolute position that one declared start state names.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when no frame has latched the origin.
+    pub fn target_position_ned_m(
+        &self,
+        target: &StartState,
+    ) -> Result<[f64; 3], AviateRuntimeError> {
+        let origin = self
+            .position_ned_m
+            .ok_or(AviateRuntimeError::NoStartOrigin)?;
+        let mut absolute = [0.0; 3];
+        for index in 0..3 {
+            absolute[index] = origin[index] + target.relative_position_ned_m[index];
+        }
+        Ok(absolute)
+    }
+
+    /// The absolute heading that one declared start state names.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when no frame has latched the origin.
+    pub fn target_heading_rad(&self, target: &StartState) -> Result<f64, AviateRuntimeError> {
+        let origin = self.heading_rad.ok_or(AviateRuntimeError::NoStartOrigin)?;
+        Ok(match target.heading {
+            StartHeading::True { radians } => radians,
+            StartHeading::ResetOffset { radians } => origin + radians,
+        })
+    }
+}
+
+/// How far one frame is from the declared start state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StartStateError {
+    /// The position error in meters.
+    pub position_m: f64,
+    /// The signed shortest heading error in radians.
+    pub heading_rad: f64,
+    /// The speed in meters per second.
+    pub speed_mps: f64,
+}
+
+impl StartStateError {
+    /// Whether this error is inside one declared tolerance.
+    #[must_use]
+    pub fn is_within(&self, tolerance: &StartStateTolerance) -> bool {
+        self.position_m <= tolerance.position_m
+            && self.heading_rad.abs() <= tolerance.heading_rad
+            && self.speed_mps <= tolerance.speed_mps
+    }
+}
+
+/// The distance from one frame to a declared start state.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the origin is not latched or a frame
+/// value is not finite.
+pub fn start_state_error(
+    origin: &StartOrigin,
+    frame: &ScenarioFrame,
+    target: &StartState,
+) -> Result<StartStateError, AviateRuntimeError> {
+    Ok(StartStateError {
+        position_m: distance_m(
+            frame.truth.position_ned_m,
+            origin.target_position_ned_m(target)?,
+        )?,
+        heading_rad: heading_error_rad(
+            yaw_rad(frame.truth.attitude_wxyz)?,
+            origin.target_heading_rad(target)?,
+        )?,
+        speed_mps: magnitude(frame.truth.velocity_ned_mps)?,
+    })
+}
+
+/// A dwell window that one continuous excursion resets.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SettleWindow {
+    held: PhaseClock,
+}
+
+impl SettleWindow {
+    /// Creates one window that no frame has opened.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            held: PhaseClock::new(),
+        }
+    }
+
+    /// Clears the window so the next accepted frame opens a new one.
+    pub const fn reset(&mut self) {
+        self.held.leave();
+    }
+
+    /// Advances the window and reports whether the dwell is complete.
+    ///
+    /// A frame outside tolerance clears the window, so the dwell measures
+    /// one continuous hold and never the sum of several short ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the frame time steps backward.
+    pub fn advance(
+        &mut self,
+        stamp: FrameStamp,
+        within: bool,
+        dwell_ns: u64,
+    ) -> Result<bool, AviateRuntimeError> {
+        if !within {
+            self.held.leave();
+            return Ok(false);
+        }
+        self.held.enter(stamp);
+        Ok(self.held.elapsed_ns(stamp)? >= dwell_ns)
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/phase/waveform.rs
+++ b/tools/flight-tune-aviate/src/runtime/phase/waveform.rs
@@ -1,0 +1,124 @@
+//! The normalized stimulus value that one waveform asks for.
+//!
+//! Every waveform is a pure function of the elapsed phase time, so the
+//! same run seed and the same frames give the same commanded values. A
+//! waveform states when it is finished; the runtime never guesses a
+//! duration and never extrapolates past one.
+
+use flight_tune::{SineComponent, Waveform};
+
+use crate::runtime::AviateRuntimeError;
+use crate::runtime::math::{clamp_normalized, require_finite};
+
+/// What one waveform asks for at a point in its window.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WaveformSample {
+    /// The waveform commands this bounded normalized value.
+    Active(f64),
+    /// The waveform reached the end of its own declared window.
+    Complete,
+}
+
+/// The normalized value that one waveform commands after an elapsed time.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when a value is not finite, or when the
+/// waveform replays a recorded artifact that the runtime cannot resolve.
+pub fn sample(waveform: &Waveform, elapsed_ns: u64) -> Result<WaveformSample, AviateRuntimeError> {
+    match waveform {
+        // A step holds until the mission phase ends it. The waveform states
+        // no window of its own, so it never completes on its own.
+        Waveform::Step { value } => Ok(WaveformSample::Active(clamp_normalized("step", *value)?)),
+        Waveform::Ramp {
+            from,
+            to,
+            duration_ns,
+        } => ramp(*from, *to, *duration_ns, elapsed_ns),
+        Waveform::Pulse { value, duration_ns } => {
+            if elapsed_ns >= *duration_ns {
+                return Ok(WaveformSample::Complete);
+            }
+            Ok(WaveformSample::Active(clamp_normalized("pulse", *value)?))
+        }
+        Waveform::Reversal {
+            first,
+            second,
+            dwell_ns,
+        } => reversal(*first, *second, *dwell_ns, elapsed_ns),
+        Waveform::Multisine {
+            bias,
+            components,
+            duration_ns,
+        } => multisine(*bias, components, *duration_ns, elapsed_ns),
+        // A recorded artifact needs an artifact store that the vehicle
+        // action port does not own. Refusing it here keeps a mission that
+        // names one from silently flying a different stimulus.
+        Waveform::Recorded { .. } => Err(AviateRuntimeError::UnsupportedWaveform {
+            waveform: "recorded",
+        }),
+    }
+}
+
+fn ramp(
+    from: f64,
+    to: f64,
+    duration_ns: u64,
+    elapsed_ns: u64,
+) -> Result<WaveformSample, AviateRuntimeError> {
+    if elapsed_ns >= duration_ns {
+        return Ok(WaveformSample::Complete);
+    }
+    let start = clamp_normalized("ramp start", from)?;
+    let end = clamp_normalized("ramp end", to)?;
+    let fraction = crate::runtime::math::progress(elapsed_ns, duration_ns);
+    clamp_normalized("ramp value", (end - start).mul_add(fraction, start))
+        .map(WaveformSample::Active)
+}
+
+fn reversal(
+    first: f64,
+    second: f64,
+    dwell_ns: u64,
+    elapsed_ns: u64,
+) -> Result<WaveformSample, AviateRuntimeError> {
+    let total_ns = dwell_ns
+        .checked_mul(2)
+        .ok_or(AviateRuntimeError::InvalidValue {
+            field: "reversal duration",
+        })?;
+    if elapsed_ns >= total_ns {
+        return Ok(WaveformSample::Complete);
+    }
+    let value = if elapsed_ns < dwell_ns { first } else { second };
+    clamp_normalized("reversal value", value).map(WaveformSample::Active)
+}
+
+fn multisine(
+    bias: f64,
+    components: &[SineComponent],
+    duration_ns: u64,
+    elapsed_ns: u64,
+) -> Result<WaveformSample, AviateRuntimeError> {
+    if elapsed_ns >= duration_ns {
+        return Ok(WaveformSample::Complete);
+    }
+    let seconds = crate::runtime::math::seconds(elapsed_ns);
+    let mut total = require_finite("multisine bias", bias)?;
+    for component in components {
+        let sum = total + component_value(component, seconds)?;
+        total = require_finite("multisine sum", sum)?;
+    }
+    clamp_normalized("multisine value", total).map(WaveformSample::Active)
+}
+
+fn component_value(component: &SineComponent, seconds: f64) -> Result<f64, AviateRuntimeError> {
+    let amplitude = require_finite("multisine amplitude", component.amplitude)?;
+    let frequency = require_finite("multisine frequency", component.frequency_hz)?;
+    let phase = require_finite("multisine phase", component.phase_rad)?;
+    let angle = require_finite(
+        "multisine angle",
+        std::f64::consts::TAU * frequency * seconds + phase,
+    )?;
+    require_finite("multisine component", amplitude * angle.sin())
+}

--- a/tools/flight-tune-aviate/src/runtime/preparation.rs
+++ b/tools/flight-tune-aviate/src/runtime/preparation.rs
@@ -1,0 +1,202 @@
+//! Admitting one run, and holding every receipt to its exact intent.
+//!
+//! A run has one identity: the digest of its [`RunExecutionContext`].
+//! Preparation, scenario start, candidate activation, and controller
+//! readback each return a receipt, and every one of them has to carry that
+//! same digest. This module is where the comparison happens, and it
+//! happens before the next external action rather than after it, so a
+//! receipt for another run stops the sequence instead of being recorded
+//! next to work it does not describe.
+
+use flight_tune::{
+    ArtifactIdentity, CandidateReceipt, Digest, ExecutionTarget, MissionDocument,
+    RunExecutionContext, RunPreparationReceipt, ScenarioStartReceipt,
+};
+
+use super::AviateRuntimeError;
+use super::identity::AviateRuntimeIdentity;
+
+/// One admitted run and the identity every receipt has to name.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreparedRun {
+    context: RunExecutionContext,
+    run_intent_digest: Digest,
+    mission_content_digest: Digest,
+    runtime_identity: ArtifactIdentity,
+}
+
+impl PreparedRun {
+    /// Admits one mission for one exact run identity.
+    ///
+    /// The runtime attests before the run is admitted, so a runtime whose
+    /// production inputs no longer describe it cannot prepare anything.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the runtime no longer attests,
+    /// when the document is not a simulator mission, or when the document
+    /// content differs from the content the run intent names.
+    pub fn admit(
+        document: &MissionDocument,
+        context: &RunExecutionContext,
+        runtime: &AviateRuntimeIdentity,
+    ) -> Result<Self, AviateRuntimeError> {
+        runtime.attest()?;
+        document
+            .validate_for_target(ExecutionTarget::Simulator)
+            .map_err(|source| AviateRuntimeError::MissionRejected {
+                detail: source.to_string(),
+            })?;
+        let mission_content_digest = document.calculate_content_digest().map_err(|source| {
+            AviateRuntimeError::MissionRejected {
+                detail: source.to_string(),
+            }
+        })?;
+        let run_intent_digest = context
+            .digest()
+            .map_err(|source| AviateRuntimeError::InvalidIdentity { source })?;
+        // Both crates carry their own digest type over the same 32 bytes,
+        // so the comparison crosses by bytes.
+        if mission_content_digest.as_bytes() != context.mission_content_digest().as_bytes() {
+            return Err(AviateRuntimeError::MissionRejected {
+                detail: "the mission document is not the one the run intent names".to_owned(),
+            });
+        }
+        Ok(Self {
+            context: context.clone(),
+            run_intent_digest,
+            mission_content_digest: Digest::from_bytes(*mission_content_digest.as_bytes()),
+            runtime_identity: runtime.identity().clone(),
+        })
+    }
+
+    /// The exact run intent identity.
+    #[must_use]
+    pub const fn run_intent_digest(&self) -> Digest {
+        self.run_intent_digest
+    }
+
+    /// The exact mission content this run flies.
+    #[must_use]
+    pub const fn mission_content_digest(&self) -> Digest {
+        self.mission_content_digest
+    }
+
+    /// The runtime implementation that admitted this run.
+    #[must_use]
+    pub const fn runtime_identity(&self) -> &ArtifactIdentity {
+        &self.runtime_identity
+    }
+
+    /// The complete run identity.
+    #[must_use]
+    pub const fn context(&self) -> &RunExecutionContext {
+        &self.context
+    }
+
+    /// The tuning session that owns this run.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.context.tuning_session_digest()
+    }
+
+    /// Rejects a preparation receipt for another run or session.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a digest differs.
+    pub fn require_preparation(
+        &self,
+        receipt: &RunPreparationReceipt,
+    ) -> Result<(), AviateRuntimeError> {
+        self.require_match(
+            "preparation",
+            receipt.session_digest,
+            Some(receipt.run_intent_digest),
+        )
+    }
+
+    /// Rejects a scenario start receipt for another run, session, or mission.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a digest differs.
+    pub fn require_start(&self, receipt: &ScenarioStartReceipt) -> Result<(), AviateRuntimeError> {
+        self.require_match(
+            "scenario start",
+            receipt.session_digest,
+            Some(receipt.run_intent_digest),
+        )?;
+        if receipt.applied_mission_content_digest != self.mission_content_digest {
+            return Err(AviateRuntimeError::ReceiptMismatch {
+                receipt: "scenario start",
+            });
+        }
+        if receipt.seed != self.context.seed() {
+            return Err(AviateRuntimeError::ReceiptMismatch {
+                receipt: "scenario start",
+            });
+        }
+        Ok(())
+    }
+
+    /// Rejects a candidate apply and readback receipt for another run.
+    ///
+    /// The apply digest and the readback digest have to agree with the
+    /// requested candidate as well, so a controller that accepted one value
+    /// and reports another stops the run here.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a digest differs.
+    pub fn require_candidate(&self, receipt: &CandidateReceipt) -> Result<(), AviateRuntimeError> {
+        self.require_match(
+            "candidate",
+            receipt.session_digest,
+            receipt.run_intent_digest,
+        )?;
+        if receipt.requested_digest != self.context.candidate_digest() {
+            return Err(AviateRuntimeError::ReceiptMismatch {
+                receipt: "candidate request",
+            });
+        }
+        if receipt.applied_digest != receipt.requested_digest {
+            return Err(AviateRuntimeError::ReceiptMismatch {
+                receipt: "candidate apply",
+            });
+        }
+        if receipt.readback_digest != receipt.requested_digest {
+            return Err(AviateRuntimeError::ReceiptMismatch {
+                receipt: "candidate readback",
+            });
+        }
+        Ok(())
+    }
+
+    /// Rejects a runtime whose identity is not the admitted one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the runtime identity differs.
+    pub fn require_runtime(
+        &self,
+        runtime: &AviateRuntimeIdentity,
+    ) -> Result<(), AviateRuntimeError> {
+        runtime.require_frozen(&self.runtime_identity)
+    }
+
+    fn require_match(
+        &self,
+        receipt: &'static str,
+        session_digest: Digest,
+        run_intent_digest: Option<Digest>,
+    ) -> Result<(), AviateRuntimeError> {
+        if session_digest != self.session_digest() {
+            return Err(AviateRuntimeError::ReceiptMismatch { receipt });
+        }
+        match run_intent_digest {
+            Some(digest) if digest == self.run_intent_digest => Ok(()),
+            Some(_) | None => Err(AviateRuntimeError::ReceiptMismatch { receipt }),
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/quality.rs
+++ b/tools/flight-tune-aviate/src/runtime/quality.rs
@@ -1,0 +1,52 @@
+//! The canonical telemetry the Aviate runtime is answerable for.
+//!
+//! The scoring layer names its fields once, in the simulator-neutral
+//! harness. This module states which of those fields the Aviate vehicle
+//! port supplies and which the simulator truth projection supplies, so a
+//! run that is missing a scored field fails on the missing name rather
+//! than on a silently absent value.
+
+use flight_tune::CanonicalTelemetryKey;
+
+/// Which side of the run supplies one canonical telemetry field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TelemetrySource {
+    /// The vehicle action port supplies the value.
+    Vehicle,
+    /// The simulator truth projection supplies the value.
+    SimulatorTruth,
+}
+
+/// The fields the Aviate vehicle port is answerable for.
+///
+/// Every other canonical field comes from the simulator truth projection.
+const VEHICLE_SUPPLIED: [CanonicalTelemetryKey; 6] = [
+    CanonicalTelemetryKey::ActuatorEffort,
+    CanonicalTelemetryKey::ActuatorSaturated,
+    CanonicalTelemetryKey::CommandLinkValid,
+    CanonicalTelemetryKey::CommandPrimary,
+    CanonicalTelemetryKey::EstimatorValid,
+    CanonicalTelemetryKey::Recovered,
+];
+
+/// Which side of one run supplies a canonical telemetry field.
+#[must_use]
+pub fn source_of(key: CanonicalTelemetryKey) -> TelemetrySource {
+    if VEHICLE_SUPPLIED.contains(&key) {
+        TelemetrySource::Vehicle
+    } else {
+        TelemetrySource::SimulatorTruth
+    }
+}
+
+/// Every canonical field the Aviate vehicle port supplies.
+#[must_use]
+pub const fn vehicle_supplied() -> &'static [CanonicalTelemetryKey] {
+    &VEHICLE_SUPPLIED
+}
+
+/// The Boolean encoding the canonical telemetry contract uses.
+#[must_use]
+pub const fn boolean(value: bool) -> f64 {
+    if value { 1.0 } else { 0.0 }
+}

--- a/tools/flight-tune-aviate/src/runtime/telemetry.rs
+++ b/tools/flight-tune-aviate/src/runtime/telemetry.rs
@@ -1,0 +1,124 @@
+//! The canonical signals the Aviate vehicle port adds to a neutral frame.
+//!
+//! The simulator projection carries truth. The vehicle port carries what
+//! only the vehicle knows: the normalized value it commanded, the exact
+//! setpoint field it transmitted, and the link and estimator states. Every
+//! signal is stated once, so a frame cannot carry two values for one
+//! selector.
+
+use std::collections::BTreeMap;
+
+use flight_tune::{
+    CanonicalTelemetryKey, ControlChannel, ControlValueField, ObservedSignal, ReferenceFrame,
+    ScenarioFrame, SignalSelector,
+};
+
+use super::AviateRuntimeError;
+use super::math::require_finite;
+use super::quality::boolean;
+
+/// What the vehicle port commanded and observed on one frame.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct VehicleSignals {
+    /// The normalized value the active stimulus commanded, when one is active.
+    pub normalized_command: Option<f64>,
+    /// The control channel the active stimulus commands, when one is active.
+    pub channel: Option<ControlChannel>,
+    /// The exact attitude setpoint the direct path transmitted, in radians.
+    pub transmitted_attitude_rad: Option<f64>,
+    /// Whether the commanded value reached its declared envelope endpoint.
+    pub saturated: bool,
+    /// Whether the vehicle command link is valid.
+    pub link_valid: bool,
+    /// Whether the vehicle estimator is valid.
+    pub estimator_valid: bool,
+}
+
+impl VehicleSignals {
+    /// The canonical signals this frame adds to the neutral projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a commanded value is not finite.
+    pub fn observed(&self) -> Result<Vec<ObservedSignal>, AviateRuntimeError> {
+        let mut signals = Vec::with_capacity(2);
+        if let (Some(value), Some(channel)) = (self.normalized_command, self.channel) {
+            signals.push(ObservedSignal {
+                selector: SignalSelector::NormalizedControl { channel },
+                value: require_finite("normalized command", value)?,
+            });
+        }
+        if let Some(value) = self.transmitted_attitude_rad {
+            signals.push(ObservedSignal {
+                selector: SignalSelector::TransmittedSetpoint {
+                    field: ControlValueField::AttitudeThrust {
+                        expected_frame: ReferenceFrame::BodyFrd,
+                    },
+                },
+                value: require_finite("transmitted setpoint", value)?,
+            });
+        }
+        Ok(signals)
+    }
+
+    /// The canonical telemetry values the vehicle port is answerable for.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when a commanded value is not finite.
+    pub fn canonical_values(
+        &self,
+        recovered: bool,
+    ) -> Result<BTreeMap<String, f64>, AviateRuntimeError> {
+        let command = self.normalized_command.unwrap_or(0.0);
+        let effort = require_finite("actuator effort", command)?;
+        Ok(BTreeMap::from([
+            (
+                CanonicalTelemetryKey::ActuatorEffort.as_str().to_owned(),
+                effort,
+            ),
+            (
+                CanonicalTelemetryKey::ActuatorSaturated.as_str().to_owned(),
+                boolean(self.saturated),
+            ),
+            (
+                CanonicalTelemetryKey::CommandLinkValid.as_str().to_owned(),
+                boolean(self.link_valid),
+            ),
+            (
+                CanonicalTelemetryKey::CommandPrimary.as_str().to_owned(),
+                effort,
+            ),
+            (
+                CanonicalTelemetryKey::EstimatorValid.as_str().to_owned(),
+                boolean(self.estimator_valid),
+            ),
+            (
+                CanonicalTelemetryKey::Recovered.as_str().to_owned(),
+                boolean(recovered),
+            ),
+        ]))
+    }
+}
+
+/// Reads the link and estimator states one frame reports.
+///
+/// A frame that states neither is not a frame the vehicle port can act on:
+/// arming, stimulating, and releasing all depend on knowing them.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the frame omits a required state.
+pub fn require_vehicle_states(frame: &ScenarioFrame) -> Result<(bool, bool), AviateRuntimeError> {
+    let link_valid = frame
+        .link_valid
+        .ok_or(AviateRuntimeError::IncompleteFrame {
+            field: "control-link validity",
+        })?;
+    let estimator_valid = frame
+        .estimator_valid
+        .ok_or(AviateRuntimeError::IncompleteFrame {
+            field: "estimator validity",
+        })?;
+    Ok((link_valid, estimator_valid))
+}

--- a/tools/flight-tune-aviate/src/runtime/terminal.rs
+++ b/tools/flight-tune-aviate/src/runtime/terminal.rs
@@ -1,0 +1,152 @@
+//! Sealing one run, and saying plainly when it cannot be sealed.
+//!
+//! A sealed run states four things together: which run intent it flew,
+//! which runtime implementation flew it, what the run's direct evidence
+//! was, and how it ended. Binding them in one document is what stops a
+//! reader pairing evidence from one runtime identity with a result from
+//! another.
+//!
+//! A run whose durable direct ledger has a prepared command with no result
+//! is not sealed at all. It is quarantined, because nobody can say whether
+//! the vehicle was commanded.
+
+use flight_tune::{ArtifactIdentity, Digest, ScenarioStopContext, ScenarioStopReason};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use super::AviateRuntimeError;
+use super::direct::DirectRunEvidence;
+
+/// The supported Aviate run seal schema.
+pub const RUN_SEAL_SCHEMA_VERSION: u16 = 1;
+
+const RUN_SEAL_DOMAIN: &[u8] = b"pilotage-aviate-run-seal-v1\0";
+
+/// How one Aviate run ended, as the vehicle port saw it.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunEnding {
+    /// The mission engine reached a terminal result.
+    Mission,
+    /// A streaming hard gate ended the run.
+    HardGate,
+    /// A sample request reached its finite timeout.
+    SampleTimeout,
+    /// An execution or evidence error ended the run.
+    ExecutionError,
+}
+
+impl RunEnding {
+    /// The vehicle-port ending for one neutral stop reason.
+    #[must_use]
+    pub const fn of(reason: &ScenarioStopReason) -> Self {
+        match reason {
+            ScenarioStopReason::Mission(_) => Self::Mission,
+            ScenarioStopReason::HardGate => Self::HardGate,
+            ScenarioStopReason::SampleTimeout => Self::SampleTimeout,
+            ScenarioStopReason::ExecutionError => Self::ExecutionError,
+        }
+    }
+}
+
+/// Everything one sealed Aviate run is answerable for.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AviateRunSeal {
+    /// Document schema version.
+    pub schema_version: u16,
+    /// The exact run intent this run flew.
+    pub run_intent_digest: Digest,
+    /// The runtime implementation that flew it.
+    pub runtime_identity: ArtifactIdentity,
+    /// How the run ended.
+    pub ending: RunEnding,
+    /// The last source sequence the vehicle port consumed.
+    pub last_source_sequence: Option<u64>,
+    /// The number of frames the vehicle port accepted.
+    pub accepted_frames: u64,
+    /// The identity of this run's direct evidence, when the run had any.
+    pub direct_evidence_digest: Option<Digest>,
+}
+
+impl AviateRunSeal {
+    /// The identity a terminal receipt binds this seal by.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the document cannot be encoded.
+    pub fn digest(&self) -> Result<Digest, AviateRuntimeError> {
+        let bytes = serde_json::to_vec(self).map_err(|source| AviateRuntimeError::Encode {
+            document: "run seal",
+            source,
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(RUN_SEAL_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Rejects a seal that does not name one exact run and runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the run intent or the runtime
+    /// identity differs.
+    pub fn require_bound(
+        &self,
+        run_intent_digest: Digest,
+        runtime_identity: &ArtifactIdentity,
+    ) -> Result<(), AviateRuntimeError> {
+        if self.schema_version != RUN_SEAL_SCHEMA_VERSION
+            || self.run_intent_digest != run_intent_digest
+            || &self.runtime_identity != runtime_identity
+        {
+            return Err(AviateRuntimeError::UnboundRunSeal);
+        }
+        Ok(())
+    }
+}
+
+/// What the vehicle port knows about one run when it stops.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunClosure {
+    /// The exact run intent that stopped.
+    pub run_intent_digest: Digest,
+    /// The runtime implementation that flew it.
+    pub runtime_identity: ArtifactIdentity,
+    /// The number of frames the vehicle port accepted.
+    pub accepted_frames: u64,
+    /// The direct evidence the run collected, when it commanded directly.
+    pub direct_evidence: Option<DirectRunEvidence>,
+}
+
+/// Seals one stopped run.
+///
+/// # Errors
+///
+/// Returns [`AviateRuntimeError`] when the direct evidence does not bind
+/// this run, or when the seal cannot be encoded.
+pub fn seal(
+    closure: &RunClosure,
+    context: &ScenarioStopContext,
+) -> Result<AviateRunSeal, AviateRuntimeError> {
+    let direct_evidence_digest = match &closure.direct_evidence {
+        Some(evidence) => {
+            evidence.require_bound(closure.run_intent_digest, &closure.runtime_identity)?;
+            Some(evidence.digest()?)
+        }
+        None => None,
+    };
+    let seal = AviateRunSeal {
+        schema_version: RUN_SEAL_SCHEMA_VERSION,
+        run_intent_digest: closure.run_intent_digest,
+        runtime_identity: closure.runtime_identity.clone(),
+        ending: RunEnding::of(&context.reason),
+        last_source_sequence: context.last_source_sequence,
+        accepted_frames: closure.accepted_frames,
+        direct_evidence_digest,
+    };
+    seal.require_bound(closure.run_intent_digest, &closure.runtime_identity)?;
+    Ok(seal)
+}

--- a/tools/flight-tune-aviate/src/runtime/tests.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests.rs
@@ -1,0 +1,51 @@
+//! Unit tests for the production Aviate runtime.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod conditions;
+mod publication;
+mod telemetry;
+mod terminal;
+mod timing;
+mod waveform;
+
+use flight_tune::{ArtifactIdentity, Digest, KinematicTruth, ScenarioFrame};
+
+use super::timing::FrameStamp;
+
+/// One artifact identity with a distinct, non-zero digest.
+fn identity(id: &str, fill: u8) -> ArtifactIdentity {
+    ArtifactIdentity::new(id, Digest::from_bytes([fill; 32])).expect("a named test identity")
+}
+
+/// One frame at rest, at the requested sequence and trial time.
+fn frame(source_sequence: u64, trial_time_ns: u64) -> ScenarioFrame {
+    ScenarioFrame {
+        source_sequence,
+        simulator_time_ns: trial_time_ns,
+        trial_time_ns,
+        lifecycle: None,
+        ground_contact: Some(false),
+        crashed: Some(false),
+        link_valid: Some(true),
+        estimator_valid: Some(true),
+        truth: KinematicTruth {
+            position_ned_m: [0.0; 3],
+            velocity_ned_mps: [0.0; 3],
+            acceleration_ned_mps2: [0.0; 3],
+            attitude_wxyz: [1.0, 0.0, 0.0, 0.0],
+            body_rates_rps: [0.0; 3],
+        },
+        applied_conditions: std::collections::BTreeMap::new(),
+        canonical_signals: Vec::new(),
+    }
+}
+
+/// The stamp one frame carries onto the sample clock.
+const fn stamp(source_sequence: u64, trial_time_ns: u64) -> FrameStamp {
+    FrameStamp {
+        source_sequence,
+        simulator_time_ns: trial_time_ns,
+        trial_time_ns,
+    }
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/conditions.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/conditions.rs
@@ -1,0 +1,80 @@
+//! The condition set one scored window was flown under.
+
+use crate::runtime::conditions::ConditionLedger;
+
+use super::frame;
+
+fn with_conditions(sequence: u64, values: &[(&str, f64)]) -> flight_tune::ScenarioFrame {
+    let mut value = frame(sequence, sequence * 1_000_000);
+    value.applied_conditions = values
+        .iter()
+        .map(|(name, number)| ((*name).to_owned(), *number))
+        .collect();
+    value
+}
+
+#[test]
+fn a_ledger_records_the_conditions_a_run_observes() {
+    let mut ledger = ConditionLedger::new();
+    ledger
+        .observe(&with_conditions(1, &[("wind.speed_mps", 3.0)]))
+        .expect("record the applied conditions");
+    assert_eq!(ledger.observed().get("wind.speed_mps"), Some(&3.0));
+    assert!(!ledger.is_locked());
+}
+
+#[test]
+fn a_condition_cannot_change_inside_a_scored_window() {
+    let mut ledger = ConditionLedger::new();
+    ledger
+        .observe(&with_conditions(1, &[("wind.speed_mps", 3.0)]))
+        .expect("record the applied conditions");
+    ledger.lock();
+
+    ledger
+        .observe(&with_conditions(2, &[("wind.speed_mps", 3.0)]))
+        .expect("the same value keeps the window valid");
+    let detail = ledger
+        .observe(&with_conditions(3, &[("wind.speed_mps", 9.0)]))
+        .expect_err("a changed value must end the window")
+        .to_string();
+    assert!(detail.contains("wind.speed_mps"), "{detail}");
+}
+
+#[test]
+fn a_new_condition_cannot_appear_inside_a_scored_window() {
+    let mut ledger = ConditionLedger::new();
+    ledger
+        .observe(&with_conditions(1, &[("wind.speed_mps", 3.0)]))
+        .expect("record the applied conditions");
+    ledger.lock();
+    ledger
+        .observe(&with_conditions(
+            2,
+            &[("wind.speed_mps", 3.0), ("wind.gust_mps", 1.0)],
+        ))
+        .expect_err("a new condition must end the window");
+}
+
+#[test]
+fn a_condition_free_window_freezes_the_empty_set() {
+    let mut ledger = ConditionLedger::new();
+    ledger.lock();
+    assert!(ledger.is_locked());
+    assert!(ledger.observed().is_empty());
+    // A condition that appears inside the window still ends it.
+    ledger
+        .observe(&with_conditions(1, &[("wind.speed_mps", 3.0)]))
+        .expect_err("a condition appearing inside a window must end it");
+    ledger.unlock();
+    ledger
+        .observe(&with_conditions(1, &[("wind.speed_mps", 3.0)]))
+        .expect("record the applied conditions");
+    ledger.lock();
+    ledger.unlock();
+    ledger
+        .observe(&with_conditions(2, &[("wind.speed_mps", 9.0)]))
+        .expect("an unlocked ledger accepts a new condition set");
+    ledger.clear();
+    assert!(ledger.observed().is_empty());
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/publication.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/publication.rs
@@ -1,0 +1,178 @@
+//! What one direct record has to agree with before it can be scored.
+
+use flight_tune::{ControlChannel, ControlFamily, Digest};
+
+use crate::direct_transport::{
+    DIRECT_COMMAND_RECORD_SCHEMA_VERSION, DirectCommandPurpose, DirectCommandRecord,
+    DirectCommandTimes, DirectSenderIdentity, DirectSetpoint,
+};
+use crate::runtime::phase::direct::ledger::{DIRECT_INTENT_SCHEMA_VERSION, DirectIntentRecord};
+use crate::runtime::phase::direct::readback::{PublicationContext, validate_publication};
+
+const RUN_INTENT: [u8; 32] = [9; 32];
+const TRANSPORT: [u8; 32] = [8; 32];
+const ENVELOPE: [u8; 32] = [7; 32];
+
+fn setpoint(pitch_rad: f64) -> DirectSetpoint {
+    DirectSetpoint {
+        roll_rad: 0.01,
+        pitch_rad,
+        yaw_rad: 1.2,
+        collective_force: 0.72,
+    }
+}
+
+fn intent() -> DirectIntentRecord {
+    DirectIntentRecord {
+        schema_version: DIRECT_INTENT_SCHEMA_VERSION,
+        sequence: 0,
+        purpose: DirectCommandPurpose::Step,
+        run_intent_digest: Digest::from_bytes(RUN_INTENT),
+        transport_identity_digest: Digest::from_bytes(TRANSPORT),
+        envelope_digest: Digest::from_bytes(ENVELOPE),
+        requested: setpoint(0.1),
+    }
+}
+
+fn record() -> DirectCommandRecord {
+    DirectCommandRecord {
+        schema_version: DIRECT_COMMAND_RECORD_SCHEMA_VERSION,
+        purpose: DirectCommandPurpose::Step,
+        family: ControlFamily::DirectAttitudeThrust,
+        channel: ControlChannel::Pitch,
+        normalized: 0.4,
+        envelope_digest: Digest::from_bytes(ENVELOPE),
+        baseline: setpoint(-0.02),
+        requested: setpoint(0.1),
+        transmitted: setpoint(0.1),
+        effective: setpoint(0.1),
+        sender: DirectSenderIdentity {
+            endpoint: "127.0.0.1:20000".to_owned(),
+            system_id: 1,
+            component_id: 1,
+            sequence: 1,
+            time_boot_ms: 10,
+            frame_digest: Digest::from_bytes([0xab; 32]),
+        },
+        effective_sample_sequence: 3,
+        times: DirectCommandTimes {
+            requested_at_ns: 100,
+            transmitted_at_ns: 200,
+            effective_at_ns: 300,
+            estimate_at_ns: 290,
+            simulator_truth_at_ns: 300,
+        },
+        run_intent_digest: Digest::from_bytes(RUN_INTENT),
+        transport_identity_digest: Digest::from_bytes(TRANSPORT),
+    }
+}
+
+fn context() -> PublicationContext {
+    PublicationContext {
+        run_intent_digest: Digest::from_bytes(RUN_INTENT),
+        transport_identity_digest: Digest::from_bytes(TRANSPORT),
+        tolerance: 1e-9,
+    }
+}
+
+fn refusal(record: &DirectCommandRecord) -> String {
+    match validate_publication(record, &intent(), &context()) {
+        Ok(()) => panic!("the record was accepted"),
+        Err(error) => error.to_string(),
+    }
+}
+
+#[test]
+fn a_complete_record_that_closes_its_intent_is_published() {
+    validate_publication(&record(), &intent(), &context()).expect("a complete record publishes");
+}
+
+#[test]
+fn a_record_that_does_not_close_its_prepared_intent_is_refused() {
+    let mut changed = record();
+    changed.requested = setpoint(0.2);
+    assert!(
+        refusal(&changed).contains("does not close its durable prepared intent"),
+        "{}",
+        refusal(&changed)
+    );
+
+    let mut released = record();
+    released.purpose = DirectCommandPurpose::Release;
+    assert!(
+        refusal(&released).contains("does not close"),
+        "{}",
+        refusal(&released)
+    );
+}
+
+#[test]
+fn a_record_that_names_another_run_intent_is_refused() {
+    let mut changed = record();
+    changed.run_intent_digest = Digest::from_bytes([1; 32]);
+    // The intent comparison catches it first, and the context comparison
+    // catches it whichever way the record was altered.
+    assert!(!refusal(&changed).is_empty());
+
+    let context = PublicationContext {
+        run_intent_digest: Digest::from_bytes([2; 32]),
+        ..context()
+    };
+    let detail = match validate_publication(&record(), &intent(), &context) {
+        Ok(()) => panic!("another run intent was accepted"),
+        Err(error) => error.to_string(),
+    };
+    assert!(
+        detail.contains("another run intent or transport"),
+        "{detail}"
+    );
+}
+
+#[test]
+fn a_record_whose_times_are_not_causal_is_refused() {
+    let mut early = record();
+    early.times.effective_at_ns = 150;
+    assert!(
+        refusal(&early).contains("causally ordered"),
+        "{}",
+        refusal(&early)
+    );
+
+    let mut late = record();
+    late.times.requested_at_ns = 250;
+    assert!(
+        refusal(&late).contains("causally ordered"),
+        "{}",
+        refusal(&late)
+    );
+}
+
+#[test]
+fn a_record_outside_the_declared_tolerance_is_refused() {
+    let mut transmitted = record();
+    transmitted.transmitted = setpoint(0.2);
+    assert!(
+        refusal(&transmitted).contains("transmitted setpoint left"),
+        "{}",
+        refusal(&transmitted)
+    );
+
+    let mut effective = record();
+    effective.effective = setpoint(0.2);
+    assert!(
+        refusal(&effective).contains("effective setpoint left"),
+        "{}",
+        refusal(&effective)
+    );
+}
+
+#[test]
+fn a_record_carrying_a_value_that_is_not_a_number_is_refused() {
+    let mut record = record();
+    record.normalized = f64::NAN;
+    assert!(
+        refusal(&record).contains("not a number"),
+        "{}",
+        refusal(&record)
+    );
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/telemetry.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/telemetry.rs
@@ -1,0 +1,115 @@
+//! The canonical values and signals the vehicle port is answerable for.
+
+use flight_tune::{CanonicalTelemetryKey, ControlChannel, ObservedSignal, SignalSelector};
+
+use crate::runtime::quality::{TelemetrySource, source_of, vehicle_supplied};
+use crate::runtime::telemetry::{VehicleSignals, require_vehicle_states};
+
+use super::frame;
+
+fn commanding(normalized: f64) -> VehicleSignals {
+    VehicleSignals {
+        normalized_command: Some(normalized),
+        channel: Some(ControlChannel::Pitch),
+        transmitted_attitude_rad: Some(0.1),
+        saturated: normalized.abs() >= 1.0,
+        link_valid: true,
+        estimator_valid: true,
+    }
+}
+
+#[test]
+fn a_commanding_frame_states_its_channel_and_its_transmitted_setpoint() {
+    let signals = commanding(0.4).observed().expect("the observed signals");
+    assert_eq!(signals.len(), 2);
+    assert!(signals.contains(&ObservedSignal {
+        selector: SignalSelector::NormalizedControl {
+            channel: ControlChannel::Pitch,
+        },
+        value: 0.4,
+    }));
+}
+
+#[test]
+fn a_frame_that_commands_nothing_states_no_control_signal() {
+    let signals = VehicleSignals::default()
+        .observed()
+        .expect("the observed signals");
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn a_commanded_value_that_is_not_a_number_is_refused() {
+    let mut signals = commanding(0.4);
+    signals.normalized_command = Some(f64::NAN);
+    signals
+        .observed()
+        .expect_err("a commanded value that is not a number must be refused");
+    signals
+        .canonical_values(false)
+        .expect_err("a commanded value that is not a number must be refused");
+}
+
+#[test]
+fn the_canonical_values_are_exactly_the_fields_this_port_supplies() {
+    let values = commanding(1.0)
+        .canonical_values(true)
+        .expect("the canonical values");
+    let names = vehicle_supplied()
+        .iter()
+        .map(|key| key.as_str().to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        values
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>(),
+        names
+    );
+    assert!((values[CanonicalTelemetryKey::ActuatorSaturated.as_str()] - 1.0).abs() < f64::EPSILON);
+    assert!((values[CanonicalTelemetryKey::Recovered.as_str()] - 1.0).abs() < f64::EPSILON);
+    assert!(values[CanonicalTelemetryKey::CommandLinkValid.as_str()] > 0.5);
+}
+
+#[test]
+fn every_canonical_field_names_one_side_of_the_run() {
+    for key in CanonicalTelemetryKey::ALL {
+        let expected = if vehicle_supplied().contains(&key) {
+            TelemetrySource::Vehicle
+        } else {
+            TelemetrySource::SimulatorTruth
+        };
+        assert_eq!(source_of(key), expected, "{}", key.as_str());
+    }
+    assert_eq!(
+        source_of(CanonicalTelemetryKey::PositionErrorM),
+        TelemetrySource::SimulatorTruth
+    );
+    assert_eq!(
+        source_of(CanonicalTelemetryKey::CommandPrimary),
+        TelemetrySource::Vehicle
+    );
+}
+
+#[test]
+fn a_frame_that_omits_a_vehicle_state_is_refused_by_name() {
+    let exact = frame(1, 1_000);
+    assert_eq!(
+        require_vehicle_states(&exact).expect("both states"),
+        (true, true)
+    );
+
+    let mut without_link = exact.clone();
+    without_link.link_valid = None;
+    let detail = require_vehicle_states(&without_link)
+        .expect_err("a frame with no link state must be refused")
+        .to_string();
+    assert!(detail.contains("control-link validity"), "{detail}");
+
+    let mut without_estimator = exact;
+    without_estimator.estimator_valid = None;
+    let detail = require_vehicle_states(&without_estimator)
+        .expect_err("a frame with no estimator state must be refused")
+        .to_string();
+    assert!(detail.contains("estimator validity"), "{detail}");
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/terminal.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/terminal.rs
@@ -1,0 +1,117 @@
+//! What one sealed Aviate run states, and what it refuses to state.
+
+use flight_tune::{Digest, MissionTerminal, ScenarioStopContext, ScenarioStopReason};
+
+use crate::runtime::direct::{DIRECT_RUN_EVIDENCE_SCHEMA_VERSION, DirectRunEvidence};
+use crate::runtime::terminal::{RUN_SEAL_SCHEMA_VERSION, RunClosure, RunEnding, seal};
+
+use super::identity;
+
+fn stop(reason: ScenarioStopReason) -> ScenarioStopContext {
+    ScenarioStopContext {
+        reason,
+        last_source_sequence: Some(41),
+    }
+}
+
+fn closure(direct_evidence: Option<DirectRunEvidence>) -> RunClosure {
+    RunClosure {
+        run_intent_digest: Digest::from_bytes([9; 32]),
+        runtime_identity: identity("pilotage-aviate-test-runtime", 6),
+        accepted_frames: 42,
+        direct_evidence,
+    }
+}
+
+fn evidence(run_intent: [u8; 32], runtime_fill: u8) -> DirectRunEvidence {
+    DirectRunEvidence {
+        schema_version: DIRECT_RUN_EVIDENCE_SCHEMA_VERSION,
+        run_intent_digest: Digest::from_bytes(run_intent),
+        transport_identity_digest: Digest::from_bytes([8; 32]),
+        runtime_identity: identity("pilotage-aviate-test-runtime", runtime_fill),
+        records: Vec::new(),
+    }
+}
+
+#[test]
+fn a_sealed_run_binds_its_run_intent_and_runtime() {
+    let context = stop(ScenarioStopReason::Mission(MissionTerminal::Complete {
+        completed_phases: 3,
+    }));
+    let sealed = seal(&closure(None), &context).expect("seal the run");
+    assert_eq!(sealed.schema_version, RUN_SEAL_SCHEMA_VERSION);
+    assert_eq!(sealed.ending, RunEnding::Mission);
+    assert_eq!(sealed.accepted_frames, 42);
+    assert_eq!(sealed.last_source_sequence, Some(41));
+    assert_eq!(sealed.direct_evidence_digest, None);
+    sealed
+        .require_bound(
+            Digest::from_bytes([9; 32]),
+            &identity("pilotage-aviate-test-runtime", 6),
+        )
+        .expect("the seal binds its run and runtime");
+    sealed
+        .require_bound(
+            Digest::from_bytes([1; 32]),
+            &identity("pilotage-aviate-test-runtime", 6),
+        )
+        .expect_err("a seal for another run intent must fail closed");
+    sealed
+        .require_bound(
+            Digest::from_bytes([9; 32]),
+            &identity("pilotage-aviate-test-runtime", 5),
+        )
+        .expect_err("a seal for another runtime must fail closed");
+}
+
+#[test]
+fn each_stop_reason_seals_its_own_ending() {
+    for (reason, ending) in [
+        (
+            ScenarioStopReason::Mission(MissionTerminal::Complete {
+                completed_phases: 3,
+            }),
+            RunEnding::Mission,
+        ),
+        (ScenarioStopReason::HardGate, RunEnding::HardGate),
+        (ScenarioStopReason::SampleTimeout, RunEnding::SampleTimeout),
+        (
+            ScenarioStopReason::ExecutionError,
+            RunEnding::ExecutionError,
+        ),
+    ] {
+        let sealed = seal(&closure(None), &stop(reason)).expect("seal the run");
+        assert_eq!(sealed.ending, ending);
+    }
+}
+
+#[test]
+fn direct_evidence_from_another_run_cannot_be_sealed() {
+    let context = stop(ScenarioStopReason::Mission(MissionTerminal::Complete {
+        completed_phases: 3,
+    }));
+    seal(&closure(Some(evidence([9; 32], 6))), &context)
+        .expect("evidence that binds this run seals");
+
+    seal(&closure(Some(evidence([1; 32], 6))), &context)
+        .expect_err("evidence from another run intent must not seal");
+    seal(&closure(Some(evidence([9; 32], 5))), &context)
+        .expect_err("evidence from another runtime must not seal");
+}
+
+#[test]
+fn a_sealed_run_with_direct_evidence_carries_its_identity() {
+    let context = stop(ScenarioStopReason::Mission(MissionTerminal::Complete {
+        completed_phases: 3,
+    }));
+    let sealed = seal(&closure(Some(evidence([9; 32], 6))), &context).expect("seal the run");
+    let expected = evidence([9; 32], 6).digest().expect("the evidence digest");
+    assert_eq!(sealed.direct_evidence_digest, Some(expected));
+
+    let without = seal(&closure(None), &context).expect("seal a run with no direct path");
+    assert_ne!(
+        sealed.digest().expect("a sealed digest"),
+        without.digest().expect("a sealed digest"),
+        "a run's direct evidence has to reach its seal"
+    );
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/timing.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/timing.rs
@@ -1,0 +1,81 @@
+//! The sample clock and the phase windows measured on it.
+
+use crate::runtime::timing::{PhaseClock, SampleClock};
+
+use super::stamp;
+
+#[test]
+fn the_clock_accepts_frames_in_order_and_counts_them() {
+    let mut clock = SampleClock::new();
+    assert_eq!(clock.accepted(), 0);
+    assert_eq!(clock.last_source_sequence(), None);
+    for index in 1..=4_u64 {
+        clock
+            .accept(stamp(index, index * 12_500_000))
+            .expect("accept an advancing frame");
+    }
+    assert_eq!(clock.accepted(), 4);
+    assert_eq!(clock.last_source_sequence(), Some(4));
+}
+
+#[test]
+fn a_repeated_or_reordered_frame_is_refused() {
+    let mut clock = SampleClock::new();
+    clock.accept(stamp(4, 40)).expect("accept the first frame");
+    let detail = clock
+        .accept(stamp(4, 50))
+        .expect_err("a repeated sequence must fail")
+        .to_string();
+    assert!(detail.contains("does not advance"), "{detail}");
+    let detail = clock
+        .accept(stamp(3, 30))
+        .expect_err("an earlier sequence must fail")
+        .to_string();
+    assert!(detail.contains("does not advance"), "{detail}");
+    assert_eq!(clock.accepted(), 1, "a refused frame is not counted");
+}
+
+#[test]
+fn a_frame_time_that_steps_backward_is_refused() {
+    let mut clock = SampleClock::new();
+    clock.accept(stamp(1, 100)).expect("accept the first frame");
+    let detail = clock
+        .accept(stamp(2, 50))
+        .expect_err("a backward time must fail")
+        .to_string();
+    assert!(detail.contains("steps backward"), "{detail}");
+}
+
+#[test]
+fn a_trial_time_after_the_simulator_time_is_refused() {
+    let mut clock = SampleClock::new();
+    let detail = clock
+        .accept(crate::runtime::timing::FrameStamp {
+            source_sequence: 1,
+            simulator_time_ns: 10,
+            trial_time_ns: 20,
+        })
+        .expect_err("a trial time after the simulator time must fail")
+        .to_string();
+    assert!(detail.contains("after the simulator time"), "{detail}");
+}
+
+#[test]
+fn a_phase_measures_from_the_frame_that_opened_it() {
+    let mut phase = PhaseClock::new();
+    assert!(!phase.is_entered());
+    phase.enter(stamp(1, 1_000));
+    // A second directive on a later frame does not restart a window that
+    // is already running.
+    phase.enter(stamp(2, 5_000));
+    assert_eq!(
+        phase.entered().map(|entry| entry.trial_time_ns),
+        Some(1_000)
+    );
+    assert_eq!(phase.elapsed_ns(stamp(3, 4_000)).expect("elapsed"), 3_000);
+    phase.leave();
+    assert!(!phase.is_entered());
+    phase
+        .elapsed_ns(stamp(4, 6_000))
+        .expect_err("a closed phase has no window");
+}

--- a/tools/flight-tune-aviate/src/runtime/tests/waveform.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/waveform.rs
@@ -1,0 +1,101 @@
+//! What each waveform commands, and when it is finished.
+
+use flight_tune::{SineComponent, Waveform};
+
+use crate::runtime::phase::waveform::{WaveformSample, sample};
+
+fn active(waveform: &Waveform, elapsed_ns: u64) -> f64 {
+    match sample(waveform, elapsed_ns).expect("a resolvable waveform") {
+        WaveformSample::Active(value) => value,
+        WaveformSample::Complete => panic!("the waveform ended early at {elapsed_ns} ns"),
+    }
+}
+
+fn is_complete(waveform: &Waveform, elapsed_ns: u64) -> bool {
+    matches!(
+        sample(waveform, elapsed_ns).expect("a resolvable waveform"),
+        WaveformSample::Complete
+    )
+}
+
+#[test]
+fn a_step_holds_its_value_and_states_no_window_of_its_own() {
+    let step = Waveform::Step { value: 0.6 };
+    assert!((active(&step, 0) - 0.6).abs() < f64::EPSILON);
+    assert!((active(&step, 10_000_000_000) - 0.6).abs() < f64::EPSILON);
+}
+
+#[test]
+fn a_ramp_moves_between_its_endpoints_and_then_completes() {
+    let ramp = Waveform::Ramp {
+        from: 0.0,
+        to: 1.0,
+        duration_ns: 1_000_000_000,
+    };
+    assert!(active(&ramp, 0).abs() < f64::EPSILON);
+    assert!((active(&ramp, 500_000_000) - 0.5).abs() < 1e-9);
+    assert!(is_complete(&ramp, 1_000_000_000));
+}
+
+#[test]
+fn a_pulse_holds_for_exactly_its_declared_duration() {
+    let pulse = Waveform::Pulse {
+        value: -0.4,
+        duration_ns: 200_000_000,
+    };
+    assert!((active(&pulse, 199_999_999) + 0.4).abs() < f64::EPSILON);
+    assert!(is_complete(&pulse, 200_000_000));
+}
+
+#[test]
+fn a_reversal_dwells_on_each_value_before_it_completes() {
+    let reversal = Waveform::Reversal {
+        first: 0.5,
+        second: -0.5,
+        dwell_ns: 100_000_000,
+    };
+    assert!((active(&reversal, 0) - 0.5).abs() < f64::EPSILON);
+    assert!((active(&reversal, 99_999_999) - 0.5).abs() < f64::EPSILON);
+    assert!((active(&reversal, 100_000_000) + 0.5).abs() < f64::EPSILON);
+    assert!(is_complete(&reversal, 200_000_000));
+}
+
+#[test]
+fn a_multisine_stays_inside_the_normalized_range() {
+    let multisine = Waveform::Multisine {
+        bias: 0.0,
+        components: vec![
+            SineComponent {
+                amplitude: 0.5,
+                frequency_hz: 1.0,
+                phase_rad: 0.0,
+            },
+            SineComponent {
+                amplitude: 0.4,
+                frequency_hz: 3.0,
+                phase_rad: 0.5,
+            },
+        ],
+        duration_ns: 2_000_000_000,
+    };
+    for step in 0..200_u64 {
+        let value = active(&multisine, step * 10_000_000);
+        assert!((-1.0..=1.0).contains(&value), "{value}");
+    }
+    assert!(is_complete(&multisine, 2_000_000_000));
+}
+
+#[test]
+fn a_recorded_waveform_is_refused_rather_than_approximated() {
+    let recorded = Waveform::Recorded {
+        source: flight_tune::MissionArtifactIdentity {
+            id: "recorded-control".to_owned(),
+            revision: "recorded-v1".to_owned(),
+            digest: flight_tune::MissionDigest::from_bytes([7; 32]),
+        },
+    };
+    let detail = sample(&recorded, 0)
+        .expect_err("a recorded artifact must be refused")
+        .to_string();
+    assert!(detail.contains("recorded"), "{detail}");
+}

--- a/tools/flight-tune-aviate/src/runtime/timing.rs
+++ b/tools/flight-tune-aviate/src/runtime/timing.rs
@@ -1,0 +1,151 @@
+//! The sample clock that orders every Aviate runtime decision.
+//!
+//! One run reads frames from one source. A repeated, reordered, or
+//! backward-stepping frame would let a phase measure a window it never
+//! flew, so the clock refuses it before the phase sees it. Every elapsed
+//! time a phase reads is measured from a latched entry time on this clock,
+//! never from the host wall clock.
+
+use super::AviateRuntimeError;
+
+/// The exact time and ordering of one accepted scenario frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FrameStamp {
+    /// The source sample sequence.
+    pub source_sequence: u64,
+    /// The absolute simulator time in nanoseconds.
+    pub simulator_time_ns: u64,
+    /// The elapsed trial time in nanoseconds.
+    pub trial_time_ns: u64,
+}
+
+/// The monotonic sample clock of one run.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SampleClock {
+    last: Option<FrameStamp>,
+    accepted: u64,
+}
+
+impl SampleClock {
+    /// Creates one clock with no accepted frame.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            last: None,
+            accepted: 0,
+        }
+    }
+
+    /// Accepts one frame and rejects a repeat or a reordering.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the sequence does not advance,
+    /// when either time steps backward, or when the trial time is after the
+    /// simulator time.
+    pub fn accept(&mut self, stamp: FrameStamp) -> Result<FrameStamp, AviateRuntimeError> {
+        if stamp.trial_time_ns > stamp.simulator_time_ns {
+            return Err(AviateRuntimeError::FrameOrder {
+                detail: "the trial time is after the simulator time",
+            });
+        }
+        if let Some(last) = self.last {
+            if stamp.source_sequence <= last.source_sequence {
+                return Err(AviateRuntimeError::FrameOrder {
+                    detail: "the source sequence does not advance",
+                });
+            }
+            if stamp.simulator_time_ns < last.simulator_time_ns
+                || stamp.trial_time_ns < last.trial_time_ns
+            {
+                return Err(AviateRuntimeError::FrameOrder {
+                    detail: "a frame time steps backward",
+                });
+            }
+        }
+        self.last = Some(stamp);
+        self.accepted = self.accepted.wrapping_add(1);
+        Ok(stamp)
+    }
+
+    /// The number of frames this clock accepted.
+    #[must_use]
+    pub const fn accepted(&self) -> u64 {
+        self.accepted
+    }
+
+    /// The last accepted frame, when the run has one.
+    #[must_use]
+    pub const fn last(&self) -> Option<FrameStamp> {
+        self.last
+    }
+
+    /// The last accepted source sequence, when the run has one.
+    #[must_use]
+    pub fn last_source_sequence(&self) -> Option<u64> {
+        self.last.map(|stamp| stamp.source_sequence)
+    }
+}
+
+/// The elapsed trial time inside one phase.
+///
+/// A phase latches its entry time on the frame that opens it, so its
+/// window is the same length whatever the host was doing.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PhaseClock {
+    entered: Option<FrameStamp>,
+}
+
+impl PhaseClock {
+    /// Creates one clock that no phase has entered.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { entered: None }
+    }
+
+    /// Latches the entry frame of one phase, once.
+    ///
+    /// A second call keeps the first entry, so a repeated directive on a
+    /// later frame cannot restart a window that is already running.
+    pub const fn enter(&mut self, stamp: FrameStamp) -> FrameStamp {
+        if self.entered.is_none() {
+            self.entered = Some(stamp);
+        }
+        stamp
+    }
+
+    /// Whether one phase has latched its entry frame.
+    #[must_use]
+    pub const fn is_entered(&self) -> bool {
+        self.entered.is_some()
+    }
+
+    /// The latched entry frame, when the phase has one.
+    #[must_use]
+    pub const fn entered(&self) -> Option<FrameStamp> {
+        self.entered
+    }
+
+    /// Clears the latched entry so the next directive opens a new window.
+    pub const fn leave(&mut self) {
+        self.entered = None;
+    }
+
+    /// The elapsed trial nanoseconds since the phase entry frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateRuntimeError`] when the phase has no entry frame or
+    /// when the current time is before it.
+    pub fn elapsed_ns(&self, stamp: FrameStamp) -> Result<u64, AviateRuntimeError> {
+        let entered = self.entered.ok_or(AviateRuntimeError::FrameOrder {
+            detail: "the phase has no entry frame",
+        })?;
+        stamp
+            .trial_time_ns
+            .checked_sub(entered.trial_time_ns)
+            .ok_or(AviateRuntimeError::FrameOrder {
+                detail: "the phase time steps backward",
+            })
+    }
+}

--- a/tools/flight-tune-aviate/src/transition_authorization.rs
+++ b/tools/flight-tune-aviate/src/transition_authorization.rs
@@ -1,0 +1,263 @@
+//! The vehicle-owned rule for moving between two candidates.
+//!
+//! A candidate is a command law the vehicle will actually fly. Two laws
+//! that are each safe on their own are not automatically safe to step
+//! between: the step happens on a flying aircraft, in one control frame.
+//! The adjacency policy states how far one step may move each searched
+//! parameter, and the validator checks the exact source and the exact
+//! target against it before anything is written to a controller.
+//!
+//! Both the policy and the validator carry an explicit identity. The
+//! runtime binds them, so a changed rule is a changed runtime identity, and
+//! a suite baseline measured under one rule is not comparable evidence for
+//! a challenger measured under another.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use std::collections::BTreeMap;
+
+use flight_tune::{
+    AdapterError, ArtifactIdentity, Candidate, CandidateTransitionReceipt,
+    CandidateTransitionRequest, Digest, TuneError,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+/// The supported adjacency policy document schema.
+pub const ADJACENCY_POLICY_SCHEMA_VERSION: u16 = 1;
+
+/// The stable name of the Aviate candidate-transition validator.
+pub const TRANSITION_VALIDATOR_ID: &str = "pilotage-aviate-transition-validator-v1";
+
+const VALIDATOR_DOMAIN: &[u8] = b"pilotage-aviate-transition-validator-v1\0";
+const ADJACENCY_POLICY_DOMAIN: &[u8] = b"pilotage-aviate-adjacency-policy-v1\0";
+
+/// The largest step one transition may take in one searched parameter.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParameterStepLimit {
+    /// The largest absolute change, in the parameter's own unit.
+    pub absolute: f64,
+    /// The largest change as a fraction of the incumbent magnitude.
+    pub fraction: f64,
+}
+
+impl ParameterStepLimit {
+    /// Whether one change from an incumbent value is inside this limit.
+    ///
+    /// The two bounds are alternatives, not both: a parameter near zero
+    /// needs the absolute bound, and a large parameter needs the
+    /// proportional one. A step inside either is adjacent.
+    #[must_use]
+    pub fn permits(&self, from: f64, to: f64) -> bool {
+        if !from.is_finite() || !to.is_finite() {
+            return false;
+        }
+        let change = (to - from).abs();
+        change <= self.absolute || change <= self.fraction * from.abs()
+    }
+}
+
+/// How far one candidate transition may move each searched parameter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdjacencyPolicy {
+    /// Document schema version.
+    pub schema_version: u16,
+    /// The stable policy name.
+    pub id: String,
+    /// The largest step for each parameter a transition may change.
+    pub limits: BTreeMap<String, ParameterStepLimit>,
+}
+
+impl AdjacencyPolicy {
+    /// Creates one validated adjacency policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the name is empty, the policy states
+    /// no parameter, or a limit is not a usable positive number.
+    pub fn new(
+        id: impl Into<String>,
+        limits: BTreeMap<String, ParameterStepLimit>,
+    ) -> Result<Self, AdapterError> {
+        let policy = Self {
+            schema_version: ADJACENCY_POLICY_SCHEMA_VERSION,
+            id: id.into(),
+            limits,
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    /// The exact identity of this policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the policy is invalid or cannot encode.
+    pub fn digest(&self) -> Result<Digest, AdapterError> {
+        self.validate()?;
+        let bytes = serde_json::to_vec(self)
+            .map_err(|source| AdapterError::new(format!("adjacency policy: {source}")))?;
+        let mut hasher = Sha256::new();
+        hasher.update(ADJACENCY_POLICY_DOMAIN);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        Ok(Digest::from_bytes(hasher.finalize().into()))
+    }
+
+    /// Whether one exact transition is adjacent under this policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the candidates state different
+    /// parameters, when a changed parameter has no declared limit, or when
+    /// a step is larger than its limit permits.
+    pub fn require_adjacent(
+        &self,
+        source: &Candidate,
+        target: &Candidate,
+    ) -> Result<(), AdapterError> {
+        self.validate()?;
+        let from = source.parameters();
+        let to = target.parameters();
+        if from.len() != to.len() || from.keys().ne(to.keys()) {
+            return Err(AdapterError::new(
+                "the transition changes the candidate parameter set",
+            ));
+        }
+        for (name, target_value) in to {
+            let Some(source_value) = from.get(name) else {
+                return Err(AdapterError::new(format!(
+                    "the transition adds the parameter {name}"
+                )));
+            };
+            if source_value.to_bits() == target_value.to_bits() {
+                continue;
+            }
+            let Some(limit) = self.limits.get(name) else {
+                return Err(AdapterError::new(format!(
+                    "the adjacency policy states no step limit for {name}"
+                )));
+            };
+            if !limit.permits(*source_value, *target_value) {
+                return Err(AdapterError::new(format!(
+                    "the transition moves {name} further than one adjacent step"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), AdapterError> {
+        if self.schema_version != ADJACENCY_POLICY_SCHEMA_VERSION
+            || self.id.trim().is_empty()
+            || self.id.len() > 128
+            || self.limits.is_empty()
+        {
+            return Err(AdapterError::new("the adjacency policy is incomplete"));
+        }
+        let usable = self.limits.values().all(|limit| {
+            limit.absolute.is_finite()
+                && limit.absolute > 0.0
+                && limit.fraction.is_finite()
+                && limit.fraction >= 0.0
+        });
+        if usable {
+            Ok(())
+        } else {
+            Err(AdapterError::new(
+                "an adjacency step limit is not a usable positive number",
+            ))
+        }
+    }
+}
+
+/// The vehicle-owned candidate transition validator.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransitionValidator {
+    policy: AdjacencyPolicy,
+    policy_digest: Digest,
+    identity: ArtifactIdentity,
+}
+
+impl TransitionValidator {
+    /// Creates the validator for one adjacency policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the policy is invalid.
+    pub fn new(policy: AdjacencyPolicy) -> Result<Self, AdapterError> {
+        let policy_digest = policy.digest()?;
+        let identity = validator_identity(policy_digest)
+            .map_err(|source| AdapterError::new(source.to_string()))?;
+        Ok(Self {
+            policy,
+            policy_digest,
+            identity,
+        })
+    }
+
+    /// The exact validator identity.
+    #[must_use]
+    pub const fn identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    /// The exact adjacency-policy identity.
+    #[must_use]
+    pub const fn policy_digest(&self) -> Digest {
+        self.policy_digest
+    }
+
+    /// The adjacency policy this validator enforces.
+    #[must_use]
+    pub const fn policy(&self) -> &AdjacencyPolicy {
+        &self.policy
+    }
+
+    /// Authorizes one exact transition without controller mutation.
+    ///
+    /// The request carries the current incumbent as its source, so a later
+    /// transition is checked against the candidate that is actually
+    /// active rather than against the one the search started from.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the request names another validator or
+    /// policy, or when the transition is not adjacent.
+    pub fn authorize(
+        &self,
+        request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        if request.validator() != &self.identity
+            || request.adjacency_policy_digest() != self.policy_digest
+        {
+            return Err(AdapterError::new(
+                "the transition request names another validator or adjacency policy",
+            ));
+        }
+        self.policy
+            .require_adjacent(request.source(), request.target())?;
+        CandidateTransitionReceipt::authorized(request)
+            .map_err(|source| AdapterError::new(source.to_string()))
+    }
+}
+
+/// The content identity of this validator and its exact policy.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when the identity cannot be named.
+pub fn validator_identity(policy_digest: Digest) -> Result<ArtifactIdentity, TuneError> {
+    let source = include_bytes!("transition_authorization.rs");
+    let mut hasher = Sha256::new();
+    hasher.update(VALIDATOR_DOMAIN);
+    hasher.update((source.len() as u64).to_le_bytes());
+    hasher.update(source);
+    hasher.update(policy_digest.as_bytes());
+    ArtifactIdentity::new(
+        TRANSITION_VALIDATOR_ID,
+        Digest::from_bytes(hasher.finalize().into()),
+    )
+}

--- a/tools/flight-tune-aviate/src/vehicle.rs
+++ b/tools/flight-tune-aviate/src/vehicle.rs
@@ -1,0 +1,377 @@
+//! The production Aviate vehicle binding.
+//!
+//! A generic candidate is a map of numbers. This module is where it stops
+//! being generic: each candidate maps to one exact Aviate feel profile,
+//! the complete mapped profile is validated, and the transition from the
+//! current incumbent to that exact target is authorized. All three happen
+//! before the process, the simulator, or the vehicle is touched, so a
+//! candidate that cannot fly is refused while it is still a value.
+//!
+//! The factory declares the identities the runtime binds: the vehicle
+//! implementation, its action port, its transition validator, and its
+//! adjacency policy.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use flight_tune::{
+    AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, CandidateTransitionReceipt,
+    CandidateTransitionRequest, Digest, RunExecutionContext, SimulatorCapability,
+    SimulatorVehicleAdapter, SimulatorVehicleFactory, TransitionBindingReceipt, TuneError,
+    VehicleBinding, VehicleBindingReceipt, scenario_runtime_identity,
+};
+use pilotage_control_feel::{FeelDigest, ValidatedFlightFeelProfile};
+use sha2::{Digest as _, Sha256};
+
+use crate::SupervisedProcessRequest;
+use crate::action_port::aviate_action_port_identity;
+use crate::transition_authorization::TransitionValidator;
+
+/// The stable name of the Aviate vehicle implementation identity.
+pub const VEHICLE_ID: &str = "pilotage-aviate-vehicle-v1";
+
+const VEHICLE_IDENTITY_DOMAIN: &[u8] = b"pilotage-aviate-vehicle-v1\0";
+
+/// Maps one generic candidate to one exact Aviate feel profile.
+///
+/// The mapping is the vehicle's own: it names which parameters it reads
+/// and how they become a complete profile. A candidate that does not
+/// state a parameter the mapping needs is refused, never defaulted.
+pub trait CandidateFeelMapping {
+    /// The exact identity of this mapping and its configuration.
+    fn mapping_identity(&self) -> &ArtifactIdentity;
+
+    /// Maps one candidate to one complete, validated feel profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the candidate omits a parameter the
+    /// mapping needs, or when the complete mapped profile is not valid.
+    fn map(&self, candidate: &Candidate) -> Result<ValidatedFlightFeelProfile, AdapterError>;
+}
+
+/// Writes and reads back the exact control law of one Aviate vehicle.
+pub trait AviateFeelController {
+    /// Reads back the complete profile the controller currently holds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the controller cannot be read or
+    /// reports a profile that is not valid.
+    fn readback_blocking(&mut self) -> Result<ValidatedFlightFeelProfile, AdapterError>;
+
+    /// Writes one complete profile and returns what the controller took.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the controller refuses the profile.
+    fn apply_blocking(&mut self, profile: &ValidatedFlightFeelProfile) -> Result<(), AdapterError>;
+}
+
+/// The production Aviate vehicle adapter.
+#[derive(Debug)]
+pub struct AviateVehicleAdapter<M, C> {
+    mapping: M,
+    controller: C,
+    validator: TransitionValidator,
+    session_digest: Digest,
+    settled: Option<Digest>,
+}
+
+impl<M: CandidateFeelMapping, C: AviateFeelController> AviateVehicleAdapter<M, C> {
+    /// Creates one adapter bound to a validated simulator session.
+    ///
+    /// The capability supplies the session the adapter answers for, so an
+    /// adapter cannot be built for a session that was never validated.
+    #[must_use]
+    pub fn bind(
+        mapping: M,
+        controller: C,
+        validator: TransitionValidator,
+        capability: &SimulatorCapability,
+    ) -> Self {
+        Self {
+            mapping,
+            controller,
+            validator,
+            session_digest: capability.session_digest(),
+            settled: None,
+        }
+    }
+
+    /// The candidate this adapter last settled on the controller.
+    #[must_use]
+    pub const fn settled_candidate_digest(&self) -> Option<Digest> {
+        self.settled
+    }
+
+    /// The transition validator this adapter authorizes through.
+    #[must_use]
+    pub const fn validator(&self) -> &TransitionValidator {
+        &self.validator
+    }
+
+    /// Activates one candidate, writing nothing when it is already active.
+    ///
+    /// The controller is read back first. A readback that already carries
+    /// the exact mapped profile returns a receipt with no write at all,
+    /// which is what makes restart reconciliation safe to repeat.
+    fn ensure_blocking(
+        &mut self,
+        capability: &SimulatorCapability,
+        candidate: &Candidate,
+        candidate_digest: Digest,
+        run_intent_digest: Option<Digest>,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        if capability.session_digest() != self.session_digest {
+            return Err(AdapterError::new(
+                "the capability does not name the bound tuning session",
+            ));
+        }
+        if candidate_digest.is_zero() {
+            return Err(AdapterError::new("the requested candidate has no identity"));
+        }
+        let target = self.mapping.map(candidate)?;
+        let target_feel = feel_digest(&target)?;
+        if feel_digest(&self.controller.readback_blocking()?)? != target_feel {
+            self.controller.apply_blocking(&target)?;
+        }
+        if feel_digest(&self.controller.readback_blocking()?)? != target_feel {
+            return Err(AdapterError::new(
+                "the controller readback is not the exact mapped feel profile",
+            ));
+        }
+        self.settled = Some(candidate_digest);
+        Ok(CandidateReceipt {
+            session_digest: self.session_digest,
+            requested_digest: candidate_digest,
+            applied_digest: candidate_digest,
+            readback_digest: candidate_digest,
+            run_intent_digest,
+        })
+    }
+}
+
+impl<M: CandidateFeelMapping, C: AviateFeelController> SimulatorVehicleAdapter
+    for AviateVehicleAdapter<M, C>
+{
+    fn authorize_candidate_transition(
+        &self,
+        request: &CandidateTransitionRequest,
+    ) -> Result<CandidateTransitionReceipt, AdapterError> {
+        if request.session_digest() != self.session_digest {
+            return Err(AdapterError::new(
+                "the transition request does not name the bound tuning session",
+            ));
+        }
+        // A later transition is checked against the candidate that is
+        // actually active, not against the one the search started from.
+        if let Some(settled) = self.settled
+            && request.source_candidate_digest() != settled
+        {
+            return Err(AdapterError::new(
+                "the transition source is not the current incumbent",
+            ));
+        }
+        // The complete mapped target has to be a profile the vehicle would
+        // load, and it is checked before any controller is written to.
+        let _target = self.mapping.map(request.target())?;
+        self.validator.authorize(request)
+    }
+
+    fn ensure_settled_candidate_blocking(
+        &mut self,
+        capability: &SimulatorCapability,
+        candidate: &Candidate,
+        candidate_digest: Digest,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        self.ensure_blocking(capability, candidate, candidate_digest, None)
+    }
+
+    fn ensure_candidate_for_run_blocking(
+        &mut self,
+        capability: &SimulatorCapability,
+        context: &RunExecutionContext,
+        candidate: &Candidate,
+        candidate_digest: Digest,
+    ) -> Result<CandidateReceipt, AdapterError> {
+        let run_intent_digest = context
+            .digest()
+            .map_err(|source| AdapterError::new(source.to_string()))?;
+        if context.candidate_digest() != candidate_digest {
+            return Err(AdapterError::new("the run intent names another candidate"));
+        }
+        self.ensure_blocking(
+            capability,
+            candidate,
+            candidate_digest,
+            Some(run_intent_digest),
+        )
+    }
+}
+
+/// The production Aviate simulator vehicle factory.
+#[derive(Debug)]
+pub struct AviateVehicleFactory<M, C> {
+    mapping: M,
+    controller: C,
+    validator: TransitionValidator,
+    vehicle: ArtifactIdentity,
+    action_port: ArtifactIdentity,
+    runtime_identity: ArtifactIdentity,
+}
+
+impl<M: CandidateFeelMapping, C: AviateFeelController> AviateVehicleFactory<M, C> {
+    /// Creates one factory for an exact mapping, controller, and rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when a bound identity is not valid.
+    pub fn new(
+        mapping: M,
+        controller: C,
+        validator: TransitionValidator,
+        runtime_identity: ArtifactIdentity,
+    ) -> Result<Self, AdapterError> {
+        let vehicle = vehicle_identity(
+            mapping.mapping_identity(),
+            validator.identity(),
+            validator.policy_digest(),
+            &runtime_identity,
+        )
+        .map_err(|source| AdapterError::new(source.to_string()))?;
+        let action_port = aviate_action_port_identity(&runtime_identity)
+            .map_err(|source| AdapterError::new(source.to_string()))?;
+        Ok(Self {
+            mapping,
+            controller,
+            validator,
+            vehicle,
+            action_port,
+            runtime_identity,
+        })
+    }
+
+    /// The runtime implementation identity this factory binds.
+    #[must_use]
+    pub const fn runtime_identity(&self) -> &ArtifactIdentity {
+        &self.runtime_identity
+    }
+
+    /// The final engine and vehicle action-port identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the action-port identity is not valid.
+    pub fn scenario_runtime_digest(&self) -> Result<Digest, AdapterError> {
+        scenario_runtime_identity(&self.action_port)
+            .map(|identity| identity.digest)
+            .map_err(|source| AdapterError::new(source.to_string()))
+    }
+}
+
+impl<M: CandidateFeelMapping, C: AviateFeelController> SimulatorVehicleFactory
+    for AviateVehicleFactory<M, C>
+{
+    type Adapter = AviateVehicleAdapter<M, C>;
+
+    fn vehicle_identity(&self) -> &ArtifactIdentity {
+        &self.vehicle
+    }
+
+    fn scenario_action_port_identity(&self) -> &ArtifactIdentity {
+        &self.action_port
+    }
+
+    fn transition_validator_identity(&self) -> &ArtifactIdentity {
+        self.validator.identity()
+    }
+
+    fn adjacency_policy_digest(&self) -> Digest {
+        self.validator.policy_digest()
+    }
+
+    fn bind_blocking(
+        self,
+        capability: &SimulatorCapability,
+    ) -> Result<VehicleBinding<Self::Adapter>, AdapterError> {
+        let session_digest = capability.session_digest();
+        let receipt = VehicleBindingReceipt {
+            session_digest,
+            vehicle_digest: self.vehicle.digest,
+            scenario_runtime_digest: self.scenario_runtime_digest()?,
+        };
+        let transition = TransitionBindingReceipt::new(
+            session_digest,
+            self.validator.identity().clone(),
+            self.validator.policy_digest(),
+        )?;
+        let adapter =
+            AviateVehicleAdapter::bind(self.mapping, self.controller, self.validator, capability);
+        capability.bind_vehicle_with_transition(adapter, receipt, transition)
+    }
+}
+
+/// Binds one exact run intent to a supervised process launch request.
+///
+/// The supervisor stores the digest with its attestation, so the process
+/// that flies a run and the run intent that authorized it are one fact
+/// rather than two that happen to line up.
+#[must_use]
+pub fn bind_run_intent(
+    mut request: SupervisedProcessRequest,
+    run_intent_digest: Digest,
+) -> SupervisedProcessRequest {
+    request.run_intent_digest = run_intent_digest;
+    request
+}
+
+/// Rejects a launch request that does not carry one exact run intent.
+///
+/// # Errors
+///
+/// Returns [`AdapterError`] when the request names another run intent.
+pub fn require_run_intent(
+    request: &SupervisedProcessRequest,
+    run_intent_digest: Digest,
+) -> Result<(), AdapterError> {
+    if request.run_intent_digest == run_intent_digest && !run_intent_digest.is_zero() {
+        return Ok(());
+    }
+    Err(AdapterError::new(
+        "the supervised process request does not carry the exact run intent",
+    ))
+}
+
+/// The exact identity of one Aviate vehicle implementation.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when the identity cannot be named.
+pub fn vehicle_identity(
+    mapping: &ArtifactIdentity,
+    validator: &ArtifactIdentity,
+    adjacency_policy_digest: Digest,
+    runtime: &ArtifactIdentity,
+) -> Result<ArtifactIdentity, TuneError> {
+    let source = include_bytes!("vehicle.rs");
+    let mut hasher = Sha256::new();
+    hasher.update(VEHICLE_IDENTITY_DOMAIN);
+    hasher.update((source.len() as u64).to_le_bytes());
+    hasher.update(source);
+    for identity in [mapping, validator, runtime] {
+        // `ArtifactIdentity::new` is the harness's public validation path:
+        // it refuses an empty name and a zero digest.
+        ArtifactIdentity::new(identity.id.clone(), identity.digest)?;
+        hasher.update((identity.id.len() as u64).to_le_bytes());
+        hasher.update(identity.id.as_bytes());
+        hasher.update(identity.digest.as_bytes());
+    }
+    hasher.update(adjacency_policy_digest.as_bytes());
+    ArtifactIdentity::new(VEHICLE_ID, Digest::from_bytes(hasher.finalize().into()))
+}
+
+fn feel_digest(profile: &ValidatedFlightFeelProfile) -> Result<Digest, AdapterError> {
+    FeelDigest::calculate(profile)
+        .map(|digest| Digest::from_bytes(*digest.as_bytes()))
+        .map_err(|source| AdapterError::new(source.to_string()))
+}

--- a/tools/flight-tune-aviate/tests/direct_run_ledger.rs
+++ b/tools/flight-tune-aviate/tests/direct_run_ledger.rs
@@ -1,0 +1,434 @@
+//! The durable ledger that brackets every exact direct command.
+//!
+//! The transport can send a step. What these tests are about is what the
+//! run knows afterwards: that the prepared intent was durable before a
+//! datagram could leave, that the result is durable after, that a record
+//! only becomes evidence once it agrees with the intent it closes, and
+//! that a prepared intent with no result is reported as ambiguous rather
+//! than guessed at.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+#[path = "direct_run_ledger/sender.rs"]
+mod sender;
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::PathBuf;
+
+use flight_tune::{
+    ArtifactIdentity, ControlChannel, ControlFamily, Digest, ExecutionTarget, PhysicalUnit,
+    ReferenceRule, SimulatorCapability, SimulatorSessionReceipt, StimulusEnvelope, StimulusMapping,
+    VehicleBindingReceipt,
+};
+use flight_tune_aviate::direct_transport::{
+    CausalReadbackBound, DirectBaselineRequest, DirectTransportRequest, direct_transport_identity,
+};
+use flight_tune_aviate::runtime::direct::{
+    DirectBaselinePolicy, DirectControl, DirectEntryState, DirectRunAuthority, NoDirectControl,
+    SimulatorDirectControl,
+};
+use flight_tune_aviate::runtime::phase::direct::DirectStepOutcome;
+use flight_tune_aviate::runtime::phase::direct::ledger::{
+    DirectIntentStore, DirectRecoveryOutcome, DirectSendOutcome, DurableDirectIntentStore,
+};
+use flight_tune_aviate::runtime::phase::direct::step_request;
+
+use sender::{ENDPOINT, RecordingSender, SAMPLE_PERIOD_NS};
+
+const TOLERANCE: f64 = 1e-9;
+const HOVER_TRIM: f64 = 0.72;
+
+/// One private ledger root that the test removes when it finishes.
+struct LedgerRoot(PathBuf);
+
+impl LedgerRoot {
+    fn new(name: &str) -> Self {
+        let root =
+            std::env::temp_dir().join(format!("pilotage-469-ledger-{}-{name}", std::process::id()));
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::create_dir_all(&root).expect("create the ledger root");
+        // The store requires its root to be the canonical path, and the
+        // system temporary directory reaches it through a symlink.
+        let root = std::fs::canonicalize(&root).expect("canonicalize the ledger root");
+        // The store keeps its root private to one user.
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))
+            .expect("make the ledger root private");
+        Self(root)
+    }
+
+    fn store(&self) -> DurableDirectIntentStore {
+        DurableDirectIntentStore::open_blocking(&self.0).expect("open the direct ledger")
+    }
+}
+
+impl Drop for LedgerRoot {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn digest(seed: u8) -> Digest {
+    Digest::from_bytes([seed; 32])
+}
+
+fn run_intent() -> Digest {
+    digest(9)
+}
+
+fn capability() -> SimulatorCapability {
+    SimulatorCapability::for_test(session_receipt())
+}
+
+fn session_receipt() -> SimulatorSessionReceipt {
+    SimulatorSessionReceipt {
+        session_digest: digest(1),
+        simulator_digest: digest(2),
+        airframe_digest: digest(3),
+    }
+}
+
+fn vehicle_receipt() -> VehicleBindingReceipt {
+    VehicleBindingReceipt {
+        session_digest: digest(1),
+        vehicle_digest: digest(4),
+        scenario_runtime_digest: digest(5),
+    }
+}
+
+fn runtime_identity() -> ArtifactIdentity {
+    ArtifactIdentity::new("pilotage-aviate-test-runtime", digest(6))
+        .expect("a named runtime identity")
+}
+
+fn transport_identity() -> ArtifactIdentity {
+    direct_transport_identity().expect("the direct transport identity")
+}
+
+fn envelope() -> StimulusEnvelope {
+    StimulusEnvelope {
+        id: "alia-tilt-v1".to_owned(),
+        revision: 1,
+        unit: PhysicalUnit::Radians,
+        reference: ReferenceRule::EffectiveSetpointAtEntry,
+        negative_endpoint: -0.25,
+        neutral: 0.0,
+        positive_endpoint: 0.25,
+    }
+}
+
+fn baseline_request() -> DirectBaselineRequest {
+    DirectBaselineRequest {
+        measured_roll_rad: 0.01,
+        measured_pitch_rad: -0.02,
+        measured_yaw_rad: 1.2,
+        hover_trim: HOVER_TRIM,
+        run_intent_digest: run_intent(),
+        max_commands: 8,
+    }
+}
+
+fn control(
+    sender: RecordingSender,
+    store: DurableDirectIntentStore,
+) -> SimulatorDirectControl<RecordingSender, DurableDirectIntentStore> {
+    let capability = capability();
+    let simulator = session_receipt();
+    let vehicle = vehicle_receipt();
+    let transport = transport_identity();
+    let readback =
+        CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS).expect("a readback bound");
+    SimulatorDirectControl::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target: ExecutionTarget::Simulator,
+            transport: &transport,
+            readback,
+            tolerance: TOLERANCE,
+        },
+        sender,
+        store,
+        run_intent(),
+        baseline_policy(),
+    )
+    .expect("authorize the simulator-only direct path")
+}
+
+/// The configured shape of the test run's baseline block.
+fn baseline_policy() -> DirectBaselinePolicy {
+    DirectBaselinePolicy {
+        hover_trim: HOVER_TRIM,
+        max_commands: 8,
+    }
+}
+
+/// The vehicle state the test enters its direct stimulus from.
+const fn entry() -> DirectEntryState {
+    DirectEntryState {
+        roll_rad: 0.01,
+        pitch_rad: -0.02,
+        yaw_rad: 1.2,
+    }
+}
+
+fn step(normalized: f64) -> flight_tune_aviate::direct_transport::DirectStepRequest {
+    step_request(
+        ControlFamily::DirectAttitudeThrust,
+        ControlChannel::Pitch,
+        StimulusMapping::AffineExact,
+        &envelope(),
+        normalized,
+    )
+    .expect("a direct step request")
+}
+
+#[test]
+fn an_enacted_step_leaves_a_resolved_ledger_and_becomes_evidence() {
+    let root = LedgerRoot::new("enacted");
+    let mut direct = control(RecordingSender::new(), root.store());
+    direct
+        .ensure_baseline_blocking(entry())
+        .expect("freeze the direct baseline");
+
+    assert_eq!(
+        direct
+            .command_blocking(&step(0.5), false)
+            .expect("send the exact step"),
+        DirectStepOutcome::Enacted
+    );
+
+    let evidence = direct
+        .seal(&runtime_identity())
+        .expect("seal the direct evidence")
+        .expect("the run commanded directly");
+    assert_eq!(evidence.records.len(), 1);
+    assert_eq!(evidence.run_intent_digest, run_intent());
+    evidence
+        .require_bound(run_intent(), &runtime_identity())
+        .expect("the evidence binds its run and runtime");
+    evidence
+        .require_bound(digest(0x77), &runtime_identity())
+        .expect_err("evidence for another run intent must fail closed");
+
+    // The ledger says the same thing the evidence does. The run has to
+    // release its writer lease before another reader can take it.
+    drop(direct);
+    let store = root.store();
+    match store.read_state(0).expect("read the ledger") {
+        DirectRecoveryOutcome::Resolved(result) => {
+            assert_eq!(result.run_intent_digest, run_intent());
+            assert!(matches!(result.outcome, DirectSendOutcome::Enacted { .. }));
+        }
+        other => panic!("the ledger must resolve an enacted command: {other:?}"),
+    }
+}
+
+#[test]
+fn a_prepared_intent_is_durable_before_the_command_can_be_sent() {
+    let root = LedgerRoot::new("durable-before-send");
+    let mut direct = control(RecordingSender::new().silent_after_baseline(), root.store());
+    direct
+        .ensure_baseline_blocking(entry())
+        .expect("freeze the direct baseline");
+
+    // The raw source goes silent, so the transport sends nothing. The
+    // prepared intent is on disk anyway, because it was written first.
+    assert_eq!(
+        direct
+            .command_blocking(&step(0.5), false)
+            .expect("attempt the exact step"),
+        DirectStepOutcome::NoExactSource
+    );
+    // Nothing that sent nothing becomes evidence.
+    let evidence = direct
+        .seal(&runtime_identity())
+        .expect("seal the direct evidence")
+        .expect("the run held direct authority");
+    drop(direct);
+    let store = root.store();
+    match store.read_state(0).expect("read the ledger") {
+        DirectRecoveryOutcome::Resolved(result) => {
+            assert!(matches!(
+                result.outcome,
+                DirectSendOutcome::NoExactSource {}
+            ));
+        }
+        other => panic!("a command that sent nothing must still resolve: {other:?}"),
+    }
+    assert!(evidence.records.is_empty());
+}
+
+#[test]
+fn a_prepared_intent_with_no_durable_result_is_ambiguous() {
+    let root = LedgerRoot::new("ambiguous");
+    {
+        // A run that stops between the durable intent and the durable
+        // result leaves exactly this state on disk.
+        let mut store = root.store();
+        let mut authority = authority(RecordingSender::new());
+        let prepared = prepare_one(&mut authority);
+        authority
+            .ledger_mut()
+            .prepare(&mut store, &prepared)
+            .expect("make the prepared intent durable");
+    }
+
+    {
+        let store = root.store();
+        match store.read_state(0).expect("read the ledger") {
+            DirectRecoveryOutcome::Ambiguous(intent) => {
+                assert_eq!(intent.sequence, 0);
+                assert_eq!(intent.run_intent_digest, run_intent());
+            }
+            other => panic!("an unresolved prepared intent must be ambiguous: {other:?}"),
+        }
+    }
+
+    // A run cannot resume through it: authorizing the direct path reads
+    // the ledger first and refuses.
+    let capability = capability();
+    let simulator = session_receipt();
+    let vehicle = vehicle_receipt();
+    let transport = transport_identity();
+    let readback =
+        CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS).expect("a readback bound");
+    let resume = SimulatorDirectControl::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target: ExecutionTarget::Simulator,
+            transport: &transport,
+            readback,
+            tolerance: TOLERANCE,
+        },
+        RecordingSender::new(),
+        root.store(),
+        run_intent(),
+        baseline_policy(),
+    );
+    match resume {
+        Ok(_) => panic!("an ambiguous ledger must refuse a resume"),
+        Err(error) => {
+            let detail = error.to_string();
+            assert!(detail.contains("ambiguous"), "{detail}");
+        }
+    }
+}
+
+#[test]
+fn a_record_that_leaves_the_declared_tolerance_never_becomes_evidence() {
+    let root = LedgerRoot::new("substituted");
+    // The flight controller reports a setpoint that is not the transmitted
+    // one, so the transport itself refuses before publication.
+    let mut direct = control(RecordingSender::new().substituting_pitch(0.9), root.store());
+    direct
+        .ensure_baseline_blocking(entry())
+        .expect_err("a baseline the controller does not take must not freeze");
+}
+
+#[test]
+fn a_runtime_with_no_direct_authority_refuses_the_direct_family() {
+    let mut direct = NoDirectControl;
+    let detail = direct
+        .command_blocking(&step(0.5), false)
+        .expect_err("a runtime with no direct authority must refuse")
+        .to_string();
+    assert!(detail.contains("no direct authority"), "{detail}");
+    direct
+        .ensure_baseline_blocking(entry())
+        .expect_err("a runtime with no direct authority cannot freeze a baseline");
+    assert!(
+        direct
+            .seal(&runtime_identity())
+            .expect("a run with no direct path seals no direct evidence")
+            .is_none()
+    );
+}
+
+#[test]
+fn the_operator_velocity_family_never_reaches_the_direct_path() {
+    let detail = step_request(
+        ControlFamily::OperatorVelocity,
+        ControlChannel::Pitch,
+        StimulusMapping::CandidateBoundCurve,
+        &envelope(),
+        0.5,
+    )
+    .expect_err("the operator velocity family must not reach the direct path")
+    .to_string();
+    assert!(detail.contains("operator_velocity"), "{detail}");
+}
+
+#[test]
+fn an_inexact_mapping_never_reaches_the_direct_path() {
+    let detail = step_request(
+        ControlFamily::DirectAttitudeThrust,
+        ControlChannel::Pitch,
+        StimulusMapping::CandidateBoundCurve,
+        &envelope(),
+        0.5,
+    )
+    .expect_err("an inexact mapping must not reach the direct path")
+    .to_string();
+    assert!(detail.contains("candidate_bound_curve"), "{detail}");
+}
+
+#[test]
+fn the_ledger_endpoint_is_the_normal_command_stream() {
+    let root = LedgerRoot::new("endpoint");
+    let mut direct = control(RecordingSender::new(), root.store());
+    direct
+        .ensure_baseline_blocking(entry())
+        .expect("freeze the direct baseline");
+    direct
+        .command_blocking(&step(0.25), false)
+        .expect("send the exact step");
+    let evidence = direct
+        .seal(&runtime_identity())
+        .expect("seal the direct evidence")
+        .expect("the run commanded directly");
+    assert_eq!(evidence.records[0].sender.endpoint, ENDPOINT);
+}
+
+/// One direct authority over a sender, with no durable store attached.
+fn authority(sender: RecordingSender) -> DirectRunAuthority {
+    let capability = capability();
+    let simulator = session_receipt();
+    let vehicle = vehicle_receipt();
+    let transport = transport_identity();
+    let readback =
+        CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS).expect("a readback bound");
+    DirectRunAuthority::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target: ExecutionTarget::Simulator,
+            transport: &transport,
+            readback,
+            tolerance: TOLERANCE,
+        },
+        &sender,
+        run_intent(),
+    )
+    .expect("authorize the direct path")
+}
+
+/// One prepared direct command over a frozen baseline.
+fn prepare_one(
+    authority: &mut DirectRunAuthority,
+) -> flight_tune_aviate::direct_transport::PreparedDirectCommand {
+    let mut sender = RecordingSender::new();
+    authority
+        .transport_mut()
+        .freeze_baseline_blocking(&mut sender, &baseline_request())
+        .expect("freeze the direct baseline");
+    authority
+        .transport()
+        .prepare_step(&step(0.5))
+        .expect("prepare the exact step")
+}

--- a/tools/flight-tune-aviate/tests/direct_run_ledger/sender.rs
+++ b/tools/flight-tune-aviate/tests/direct_run_ledger/sender.rs
@@ -1,0 +1,127 @@
+//! A recording command sender, standing in for the Aviate uplink.
+//!
+//! The sender echoes each transmitted setpoint back as the flight
+//! controller's effective setpoint on the next simulator sample, which is
+//! what a controller that accepted the command does. Every test that needs
+//! another behavior asks for it explicitly.
+
+use flight_tune::Digest;
+use flight_tune_aviate::direct_transport::{
+    DirectCommandSender, DirectSenderError, DirectSenderIdentity, DirectSetpoint,
+    EffectiveSetpointReport, TransmittedDirectCommand,
+};
+
+/// One simulator sample at the flight controller's 80 Hz setpoint rate.
+pub const SAMPLE_PERIOD_NS: u64 = 12_500_000;
+
+/// The command endpoint every frame is addressed to.
+pub const ENDPOINT: &str = "127.0.0.1:20000";
+
+/// A flight controller that answers what it was told, unless told not to.
+pub struct RecordingSender {
+    now_ns: u64,
+    sequence: u8,
+    commands: u32,
+    effective: Option<EffectiveSetpointReport>,
+    substitute_pitch: Option<f64>,
+    reads: u32,
+    silent_after_reads: Option<u32>,
+}
+
+impl RecordingSender {
+    /// Creates one sender that echoes every command back.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            now_ns: 0,
+            sequence: 0,
+            commands: 0,
+            effective: None,
+            substitute_pitch: None,
+            reads: 0,
+            silent_after_reads: None,
+        }
+    }
+
+    /// Reports a pitch the transport never asked for.
+    #[must_use]
+    pub const fn substituting_pitch(mut self, pitch_rad: f64) -> Self {
+        self.substitute_pitch = Some(pitch_rad);
+        self
+    }
+
+    /// Goes silent after the baseline block, so a step has no exact source.
+    ///
+    /// Freezing a baseline reads the raw source twice: once to choose the
+    /// candidate baseline and once to read the command back. The source
+    /// answers both and reports nothing after, which is the state a step
+    /// meets when the raw source stops.
+    #[must_use]
+    pub const fn silent_after_baseline(mut self) -> Self {
+        self.silent_after_reads = Some(2);
+        self
+    }
+}
+
+impl DirectCommandSender for RecordingSender {
+    fn command_endpoint(&self) -> String {
+        ENDPOINT.to_owned()
+    }
+
+    fn now_ns(&mut self) -> Result<u64, DirectSenderError> {
+        Ok(self.now_ns)
+    }
+
+    fn transmit_exact_blocking(
+        &mut self,
+        setpoint: DirectSetpoint,
+    ) -> Result<TransmittedDirectCommand, DirectSenderError> {
+        self.sequence = self.sequence.wrapping_add(1);
+        self.commands = self.commands.wrapping_add(1);
+        let transmitted_at_ns = self.now_ns;
+        let sample_time_ns = transmitted_at_ns.wrapping_add(SAMPLE_PERIOD_NS);
+        self.now_ns = sample_time_ns;
+        let reported = self
+            .substitute_pitch
+            .map_or(setpoint, |pitch_rad| DirectSetpoint {
+                pitch_rad,
+                ..setpoint
+            });
+        self.effective = Some(EffectiveSetpointReport {
+            setpoint: reported,
+            sample_sequence: sample_time_ns / SAMPLE_PERIOD_NS,
+            sample_time_ns,
+            estimate_time_ns: sample_time_ns.wrapping_sub(1_000_000),
+            simulator_truth_time_ns: sample_time_ns,
+        });
+        Ok(TransmittedDirectCommand {
+            setpoint,
+            sender: DirectSenderIdentity {
+                endpoint: ENDPOINT.to_owned(),
+                system_id: 1,
+                component_id: 1,
+                sequence: self.sequence,
+                time_boot_ms: u32::try_from(transmitted_at_ns / 1_000_000).unwrap_or(u32::MAX),
+                frame_digest: Digest::from_bytes([0xab; 32]),
+            },
+            transmitted_at_ns,
+        })
+    }
+
+    fn effective_setpoint_blocking(
+        &mut self,
+    ) -> Result<Option<EffectiveSetpointReport>, DirectSenderError> {
+        self.reads = self.reads.wrapping_add(1);
+        if self
+            .silent_after_reads
+            .is_some_and(|limit| self.reads > limit)
+        {
+            return Ok(None);
+        }
+        Ok(self.effective)
+    }
+
+    fn is_stable_blocking(&mut self) -> Result<bool, DirectSenderError> {
+        Ok(true)
+    }
+}

--- a/tools/flight-tune-aviate/tests/production_binding.rs
+++ b/tools/flight-tune-aviate/tests/production_binding.rs
@@ -13,9 +13,8 @@
 mod rig;
 
 use flight_tune::{
-    CandidateReceipt, CandidateTransitionRequest, Digest, MissionCapability, RunPreparationReceipt,
-    ScenarioStartReceipt, SimulatorVehicleAdapter, SimulatorVehicleFactory,
-    scenario_runtime_identity,
+    CandidateTransitionRequest, Digest, MissionCapability, SimulatorVehicleAdapter,
+    SimulatorVehicleFactory, scenario_runtime_identity,
 };
 use flight_tune_aviate::runtime::direct::NoDirectControl;
 use flight_tune_aviate::runtime::phase::transition::StartStateTolerance;

--- a/tools/flight-tune-aviate/tests/production_binding.rs
+++ b/tools/flight-tune-aviate/tests/production_binding.rs
@@ -1,0 +1,395 @@
+//! The production Aviate vehicle binding and its run identity.
+//!
+//! Every test here drives the public contract: the factory, the adapter,
+//! the transition validator, and the sealed runtime identity. Nothing
+//! reaches inside them, because what the campaign relies on is exactly
+//! what a caller can see.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+#[path = "production_binding/rig.rs"]
+mod rig;
+
+use flight_tune::{
+    CandidateReceipt, CandidateTransitionRequest, Digest, MissionCapability, RunPreparationReceipt,
+    ScenarioStartReceipt, SimulatorVehicleAdapter, SimulatorVehicleFactory,
+    scenario_runtime_identity,
+};
+use flight_tune_aviate::runtime::direct::NoDirectControl;
+use flight_tune_aviate::runtime::phase::transition::StartStateTolerance;
+use flight_tune_aviate::{
+    AviateActionDriver, AviateScenarioDriver, AviateVehicleFactory, aviate_action_port_identity,
+    bind_run_intent, require_run_intent,
+};
+
+use rig::{
+    APPLY_ACCEL, adapter, adapter_with_log, candidate, candidate_digest, capability,
+    mission_document, run_context, runtime_identity, validator,
+};
+
+const PLANNING_CONTEXT: Digest = Digest::from_bytes([0x41; 32]);
+
+fn transition_request(
+    session: u8,
+    source: &flight_tune::Candidate,
+    target: &flight_tune::Candidate,
+) -> CandidateTransitionRequest {
+    let validator = validator();
+    CandidateTransitionRequest::new(
+        Digest::from_bytes([session; 32]),
+        source,
+        candidate_digest(source),
+        target,
+        candidate_digest(target),
+        validator.identity().clone(),
+        validator.policy_digest(),
+        PLANNING_CONTEXT,
+    )
+    .expect("a complete transition request")
+}
+
+#[test]
+fn a_later_transition_is_checked_against_the_current_incumbent() {
+    let first = candidate(0.06, 0.35, 4.0);
+    let second = candidate(0.06, 0.35, 4.4);
+    let third = candidate(0.06, 0.35, 4.8);
+    let mut adapter = adapter(0x11);
+    let capability = capability(0x11);
+
+    adapter
+        .ensure_settled_candidate_blocking(&capability, &first, candidate_digest(&first))
+        .expect("settle the first candidate");
+    adapter
+        .authorize_candidate_transition(&transition_request(0x11, &first, &second))
+        .expect("authorize the first transition from the incumbent");
+
+    // The incumbent is still the first candidate, so a request that names
+    // the second as its source is a request against a vehicle state that
+    // does not exist.
+    let stale = adapter.authorize_candidate_transition(&transition_request(0x11, &second, &third));
+    let detail = stale.expect_err("a stale source must fail").to_string();
+    assert!(detail.contains("current incumbent"), "{detail}");
+
+    adapter
+        .ensure_settled_candidate_blocking(&capability, &second, candidate_digest(&second))
+        .expect("settle the second candidate");
+    adapter
+        .authorize_candidate_transition(&transition_request(0x11, &second, &third))
+        .expect("authorize the later transition from the new incumbent");
+}
+
+#[test]
+fn a_transition_further_than_one_adjacent_step_fails_closed() {
+    let first = candidate(0.06, 0.35, 4.0);
+    let distant = candidate(0.06, 0.35, 40.0);
+    let mut adapter = adapter(0x11);
+    adapter
+        .ensure_settled_candidate_blocking(&capability(0x11), &first, candidate_digest(&first))
+        .expect("settle the incumbent");
+    let detail = adapter
+        .authorize_candidate_transition(&transition_request(0x11, &first, &distant))
+        .expect_err("a distant transition must fail")
+        .to_string();
+    assert!(detail.contains(APPLY_ACCEL), "{detail}");
+}
+
+#[test]
+fn an_invalid_complete_feel_profile_is_refused_before_any_controller_write() {
+    // A negative apply acceleration is a complete profile the validator
+    // refuses, so the mapping fails before the controller is touched.
+    let invalid = candidate(0.06, 0.35, -1.0);
+    let (mut adapter, controller) = adapter_with_log(0x11);
+    let before = controller.applies();
+
+    let detail = adapter
+        .ensure_settled_candidate_blocking(&capability(0x11), &invalid, candidate_digest(&invalid))
+        .expect_err("an invalid mapped profile must fail")
+        .to_string();
+    assert!(detail.contains("control-feel"), "{detail}");
+    assert_eq!(controller.applies(), before, "no profile may be written");
+    assert_eq!(adapter.settled_candidate_digest(), None);
+
+    // The same invalid target is refused as a transition target too, and
+    // again with no write.
+    let incumbent = candidate(0.06, 0.35, 4.0);
+    adapter
+        .authorize_candidate_transition(&transition_request(0x11, &incumbent, &invalid))
+        .expect_err("an invalid mapped target must fail");
+    assert_eq!(controller.applies(), before, "no profile may be written");
+}
+
+#[test]
+fn another_transition_receipt_fails_closed() {
+    let first = candidate(0.06, 0.35, 4.0);
+    let second = candidate(0.06, 0.35, 4.4);
+    let mut adapter = adapter(0x11);
+    adapter
+        .ensure_settled_candidate_blocking(&capability(0x11), &first, candidate_digest(&first))
+        .expect("settle the incumbent");
+
+    // A request that names another validator identity is a request this
+    // vehicle never agreed to enforce.
+    let other = CandidateTransitionRequest::new(
+        Digest::from_bytes([0x11; 32]),
+        &first,
+        candidate_digest(&first),
+        &second,
+        candidate_digest(&second),
+        rig::identity("pilotage-aviate-other-validator", 0x61),
+        validator().policy_digest(),
+        PLANNING_CONTEXT,
+    )
+    .expect("a complete transition request");
+    let detail = adapter
+        .authorize_candidate_transition(&other)
+        .expect_err("another validator must fail")
+        .to_string();
+    assert!(detail.contains("another validator"), "{detail}");
+
+    // So is a request from another tuning session.
+    let detail = adapter
+        .authorize_candidate_transition(&transition_request(0x12, &first, &second))
+        .expect_err("another session must fail")
+        .to_string();
+    assert!(detail.contains("bound tuning session"), "{detail}");
+}
+
+#[test]
+fn a_run_receipt_carries_the_exact_run_intent() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let digest = candidate_digest(&candidate);
+    let document = mission_document("run-intent");
+    let context = run_context(0x11, &document, digest, 17);
+    let expected = context.digest().expect("the run intent digest");
+    let mut adapter = adapter(0x11);
+
+    let receipt = adapter
+        .ensure_candidate_for_run_blocking(&capability(0x11), &context, &candidate, digest)
+        .expect("activate the candidate for the run");
+    assert_eq!(receipt.run_intent_digest, Some(expected));
+    assert_eq!(receipt.requested_digest, digest);
+    assert_eq!(receipt.applied_digest, digest);
+    assert_eq!(receipt.readback_digest, digest);
+
+    // A run intent that names another candidate is refused.
+    let other = candidate_digest(&rig::candidate(0.06, 0.35, 4.4));
+    let detail = adapter
+        .ensure_candidate_for_run_blocking(&capability(0x11), &context, &candidate, other)
+        .expect_err("another candidate must fail")
+        .to_string();
+    assert!(detail.contains("another candidate"), "{detail}");
+}
+
+#[test]
+fn an_already_active_candidate_is_not_written_again() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let digest = candidate_digest(&candidate);
+    let (mut adapter, controller) = adapter_with_log(0x11);
+
+    adapter
+        .ensure_settled_candidate_blocking(&capability(0x11), &candidate, digest)
+        .expect("settle the candidate");
+    let after_first = controller.applies();
+    assert_eq!(after_first, 1);
+
+    adapter
+        .ensure_settled_candidate_blocking(&capability(0x11), &candidate, digest)
+        .expect("repeat the settled candidate");
+    assert_eq!(
+        controller.applies(),
+        after_first,
+        "reconciling an active candidate must write nothing"
+    );
+}
+
+#[test]
+fn the_supervised_process_request_receives_the_durable_run_intent_digest() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("supervised-launch");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 23);
+    let expected = context.digest().expect("the run intent digest");
+
+    let request = bind_run_intent(rig::supervised_request(), expected);
+    assert_eq!(request.run_intent_digest, expected);
+    require_run_intent(&request, expected).expect("the launch carries the exact run intent");
+
+    let other = run_context(0x11, &document, candidate_digest(&candidate), 24)
+        .digest()
+        .expect("another run intent digest");
+    assert_ne!(other, expected);
+    require_run_intent(&request, other)
+        .expect_err("a launch for another run intent must fail closed");
+    require_run_intent(&rig::supervised_request(), expected)
+        .expect_err("a launch with no run intent must fail closed");
+}
+
+#[test]
+fn a_production_input_change_changes_the_scenario_runtime_identity() {
+    let first = runtime_identity("first");
+    let second = runtime_identity("second");
+    assert_ne!(first.identity(), second.identity());
+
+    // The value the campaign keys a suite baseline on is the composed
+    // scenario runtime identity, so the change has to reach that far.
+    let first_runtime = scenario_runtime_identity(
+        &aviate_action_port_identity(first.identity()).expect("the first action port"),
+    )
+    .expect("the first scenario runtime");
+    let second_runtime = scenario_runtime_identity(
+        &aviate_action_port_identity(second.identity()).expect("the second action port"),
+    )
+    .expect("the second scenario runtime");
+    assert_ne!(first_runtime, second_runtime);
+}
+
+#[test]
+fn the_factory_binds_the_runtime_identity_it_was_built_with() {
+    let runtime = runtime_identity("factory");
+    let factory = AviateVehicleFactory::new(
+        rig::TestMapping::new(),
+        rig::TestController(rig::ControllerHandle::new()),
+        validator(),
+        runtime.identity().clone(),
+    )
+    .expect("a complete factory");
+
+    assert_eq!(factory.runtime_identity(), runtime.identity());
+    assert_eq!(
+        factory.transition_validator_identity(),
+        validator().identity()
+    );
+    assert_eq!(
+        factory.adjacency_policy_digest(),
+        validator().policy_digest()
+    );
+    let expected_port =
+        aviate_action_port_identity(runtime.identity()).expect("the action port identity");
+    assert_eq!(factory.scenario_action_port_identity(), &expected_port);
+    assert_eq!(
+        factory.scenario_runtime_digest().expect("runtime digest"),
+        scenario_runtime_identity(&expected_port)
+            .expect("the scenario runtime")
+            .digest
+    );
+
+    let binding = factory
+        .bind_blocking(&capability(0x11))
+        .expect("bind the vehicle to the validated session");
+    drop(binding);
+}
+
+#[test]
+fn a_restart_with_another_runtime_identity_fails_before_external_mutation() {
+    let frozen = runtime_identity("frozen");
+    let changed = runtime_identity("changed");
+    let driver = AviateScenarioDriver::new(
+        changed,
+        vec![MissionCapability::KinematicTruth],
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver for the changed runtime");
+
+    driver
+        .require_frozen_runtime(frozen.identity())
+        .expect_err("a restart under another runtime identity must fail");
+    assert!(driver.admitted_run().is_none(), "no run may be admitted");
+    assert!(driver.seal().is_none(), "no run may be sealed");
+}
+
+#[test]
+fn an_execution_retry_cannot_change_the_runtime_identity() {
+    let runtime = runtime_identity("retry");
+    let frozen = runtime.identity().clone();
+    let mut driver = AviateScenarioDriver::new(
+        runtime,
+        vec![MissionCapability::KinematicTruth],
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver");
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("retry");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 31);
+
+    for attempt in 0..3 {
+        driver
+            .prepare_blocking(&document, &context)
+            .unwrap_or_else(|error| panic!("prepare attempt {attempt}: {error}"));
+        driver
+            .require_frozen_runtime(&frozen)
+            .unwrap_or_else(|error| panic!("retry attempt {attempt}: {error}"));
+        assert_eq!(
+            driver.runtime_identity().identity(),
+            &frozen,
+            "a retry must keep one frozen runtime identity"
+        );
+        driver.cleanup_blocking().expect("clean up the attempt");
+    }
+}
+
+#[test]
+fn a_tampered_runtime_document_fails_its_own_attestation() {
+    let runtime = runtime_identity("tamper");
+    runtime.attest().expect("an untampered runtime attests");
+
+    let mut document = runtime.document().clone();
+    document.sources[0].sha256 = "0".repeat(64);
+    let tampered = document.identity().expect("the tampered identity");
+    assert_ne!(
+        &tampered,
+        runtime.identity(),
+        "a tampered source entry must change the runtime identity"
+    );
+
+    // A document that no longer states a canonical inventory is refused
+    // outright rather than given a second identity.
+    let mut reordered = runtime.document().clone();
+    reordered.sources.reverse();
+    reordered
+        .identity()
+        .expect_err("a reordered inventory must be refused");
+
+    let mut zeroed = runtime.document().clone();
+    zeroed.adjacency_policy_digest = Digest::from_bytes([0; 32]);
+    zeroed
+        .identity()
+        .expect_err("a zero policy digest must be refused");
+}
+
+#[test]
+fn a_mission_the_run_intent_does_not_name_is_refused_before_start() {
+    let runtime = runtime_identity("mission");
+    let mut driver = AviateScenarioDriver::new(
+        runtime,
+        vec![MissionCapability::KinematicTruth],
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver");
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let admitted = mission_document("admitted");
+    let other = mission_document("other");
+    let context = run_context(0x11, &admitted, candidate_digest(&candidate), 41);
+
+    let detail = driver
+        .prepare_blocking(&other, &context)
+        .expect_err("another mission must fail")
+        .to_string();
+    assert!(detail.contains("run intent names"), "{detail}");
+    assert!(driver.admitted_run().is_none());
+    driver
+        .start_blocking()
+        .expect_err("no run may start without an admitted mission");
+}
+
+fn tolerance() -> StartStateTolerance {
+    StartStateTolerance {
+        position_m: 0.5,
+        heading_rad: 0.1,
+        speed_mps: 0.2,
+        dwell_ns: 500_000_000,
+    }
+}

--- a/tools/flight-tune-aviate/tests/production_binding/rig.rs
+++ b/tools/flight-tune-aviate/tests/production_binding/rig.rs
@@ -1,0 +1,346 @@
+//! One complete production Aviate binding, small enough to drive in a test.
+//!
+//! The mapping, the controller, and the adjacency policy are the real
+//! production types. What is reduced is the vehicle: the controller holds
+//! the profile it was given instead of a flight controller holding it.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use flight_tune::{
+    AdapterError, ArtifactIdentity, AttemptRole, Candidate, CandidateLineage, Digest,
+    MissionDocument, MissionReference, RunExecutionContext, ScenarioSet, SimulatorCapability,
+    SimulatorSessionReceipt, calibration_mission_document, reference_observation_scenario,
+};
+use flight_tune_aviate::direct_transport::direct_transport_identity;
+use flight_tune_aviate::{
+    AdjacencyPolicy, AviateFeelController, AviateRuntimeIdentity, AviateVehicleAdapter,
+    CandidateFeelMapping, ParameterStepLimit, RuntimeIdentityInputs, TransitionValidator,
+};
+use pilotage_control_feel::{
+    AxisCurve, AxisDynamics, AxisResponse, FeelMode, FlightFeelProfile, NeutralBand,
+    ValidatedFlightFeelProfile,
+};
+
+/// The parameters the test mapping reads out of one candidate.
+pub const DEADZONE: &str = "curve.deadzone";
+/// The exponent offset near the centre of the curve.
+pub const CENTER_EXPO: &str = "curve.center_expo";
+/// The largest demand acceleration while an input is active.
+pub const APPLY_ACCEL: &str = "dynamics.apply_accel";
+
+/// What the controller was asked to do.
+#[derive(Debug, Default)]
+pub struct ControllerLog {
+    /// How many complete profiles were written.
+    pub applies: usize,
+    /// How many readbacks were served.
+    pub readbacks: usize,
+    /// The profile the controller currently holds.
+    pub held: Option<FlightFeelProfile>,
+}
+
+/// The controller state, shared with the test that reads it.
+#[derive(Clone, Debug, Default)]
+pub struct ControllerHandle(pub Rc<RefCell<ControllerLog>>);
+
+impl ControllerHandle {
+    /// Creates one controller holding the shaped starting profile.
+    #[must_use]
+    pub fn new() -> Self {
+        let handle = Self::default();
+        handle.0.borrow_mut().held = Some(FlightFeelProfile::shaped(FeelMode::Balanced));
+        handle
+    }
+
+    /// How many complete profiles the controller has been written.
+    #[must_use]
+    pub fn applies(&self) -> usize {
+        self.0.borrow().applies
+    }
+}
+
+/// The reduced Aviate control law.
+#[derive(Clone, Debug)]
+pub struct TestController(pub ControllerHandle);
+
+impl AviateFeelController for TestController {
+    fn readback_blocking(&mut self) -> Result<ValidatedFlightFeelProfile, AdapterError> {
+        let mut log = self.0.0.borrow_mut();
+        log.readbacks = log.readbacks.saturating_add(1);
+        let held = log
+            .held
+            .clone()
+            .ok_or_else(|| AdapterError::new("the controller holds no profile"))?;
+        ValidatedFlightFeelProfile::new(held)
+            .map_err(|source| AdapterError::new(source.to_string()))
+    }
+
+    fn apply_blocking(&mut self, profile: &ValidatedFlightFeelProfile) -> Result<(), AdapterError> {
+        let mut log = self.0.0.borrow_mut();
+        log.applies = log.applies.saturating_add(1);
+        log.held = Some(profile.profile().clone());
+        Ok(())
+    }
+}
+
+/// Maps one candidate onto the horizontal axis of the shaped profile.
+#[derive(Clone, Debug)]
+pub struct TestMapping {
+    identity: ArtifactIdentity,
+}
+
+impl TestMapping {
+    /// Creates the mapping with its declared identity.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            identity: identity("pilotage-aviate-test-mapping", 0x21),
+        }
+    }
+}
+
+impl CandidateFeelMapping for TestMapping {
+    fn mapping_identity(&self) -> &ArtifactIdentity {
+        &self.identity
+    }
+
+    fn map(&self, candidate: &Candidate) -> Result<ValidatedFlightFeelProfile, AdapterError> {
+        let read = |name: &str| -> Result<f64, AdapterError> {
+            candidate
+                .parameters()
+                .get(name)
+                .copied()
+                .filter(|value| value.is_finite())
+                .ok_or_else(|| AdapterError::new(format!("the candidate states no {name}")))
+        };
+        let center_expo = read(CENTER_EXPO)? as f32;
+        let apply_accel = read(APPLY_ACCEL)? as f32;
+        let mut profile = FlightFeelProfile::shaped(FeelMode::Balanced);
+        profile.horizontal = AxisResponse {
+            curve: AxisCurve {
+                deadzone: read(DEADZONE)? as f32,
+                center_expo,
+                outer_expo: center_expo,
+                outer_start: 0.7,
+            },
+            neutral: NeutralBand {
+                active_enter: 0.035,
+                active_exit: 0.022,
+                dwell_ms: 90,
+            },
+            dynamics: AxisDynamics {
+                apply_accel,
+                apply_jerk: apply_accel * 6.0,
+                release_accel: apply_accel,
+                release_jerk: apply_accel * 6.0,
+                reversal_accel: apply_accel,
+                reversal_jerk: apply_accel * 6.0,
+            },
+        };
+        ValidatedFlightFeelProfile::new(profile)
+            .map_err(|source| AdapterError::new(source.to_string()))
+    }
+}
+
+/// One artifact identity with a distinct, non-zero digest.
+#[must_use]
+pub fn identity(id: &str, fill: u8) -> ArtifactIdentity {
+    #[allow(clippy::expect_used)]
+    ArtifactIdentity::new(id, Digest::from_bytes([fill; 32])).expect("a named test identity")
+}
+
+/// The capability for one validated simulator session.
+#[must_use]
+pub fn capability(session: u8) -> SimulatorCapability {
+    SimulatorCapability::for_test(SimulatorSessionReceipt {
+        session_digest: Digest::from_bytes([session; 32]),
+        simulator_digest: Digest::from_bytes([0x51; 32]),
+        airframe_digest: Digest::from_bytes([0x52; 32]),
+    })
+}
+
+/// The adjacency policy the test vehicle enforces.
+#[must_use]
+pub fn policy() -> AdjacencyPolicy {
+    let step = ParameterStepLimit {
+        absolute: 0.05,
+        fraction: 0.25,
+    };
+    #[allow(clippy::expect_used)]
+    AdjacencyPolicy::new(
+        "pilotage-aviate-test-adjacency-v1",
+        BTreeMap::from([
+            (DEADZONE.to_owned(), step),
+            (CENTER_EXPO.to_owned(), step),
+            (
+                APPLY_ACCEL.to_owned(),
+                ParameterStepLimit {
+                    absolute: 0.5,
+                    fraction: 0.25,
+                },
+            ),
+        ]),
+    )
+    .expect("a valid adjacency policy")
+}
+
+/// The transition validator the test vehicle authorizes through.
+#[must_use]
+pub fn validator() -> TransitionValidator {
+    #[allow(clippy::expect_used)]
+    TransitionValidator::new(policy()).expect("a valid transition validator")
+}
+
+/// The sealed runtime identity, with a named configuration.
+#[must_use]
+pub fn runtime_identity(configuration: &str) -> AviateRuntimeIdentity {
+    #[allow(clippy::expect_used)]
+    AviateRuntimeIdentity::seal(&RuntimeIdentityInputs {
+        vehicle: identity("pilotage-aviate-test-vehicle", 0x22),
+        transition_validator: validator().identity().clone(),
+        adjacency_policy_digest: validator().policy_digest(),
+        direct_transport: direct_transport_identity().expect("the direct transport identity"),
+        configuration: ArtifactIdentity::from_text(
+            "pilotage-aviate-test-configuration",
+            configuration,
+        )
+        .expect("a named configuration identity"),
+    })
+    .expect("a sealed runtime identity")
+}
+
+/// One adapter bound to a validated session.
+#[must_use]
+pub fn adapter(session: u8) -> AviateVehicleAdapter<TestMapping, TestController> {
+    let controller = ControllerHandle::new();
+    AviateVehicleAdapter::bind(
+        TestMapping::new(),
+        TestController(controller),
+        validator(),
+        &capability(session),
+    )
+}
+
+/// One adapter, with the controller log the test reads.
+#[must_use]
+pub fn adapter_with_log(
+    session: u8,
+) -> (
+    AviateVehicleAdapter<TestMapping, TestController>,
+    ControllerHandle,
+) {
+    let controller = ControllerHandle::new();
+    let adapter = AviateVehicleAdapter::bind(
+        TestMapping::new(),
+        TestController(controller.clone()),
+        validator(),
+        &capability(session),
+    );
+    (adapter, controller)
+}
+
+/// One candidate whose complete mapped profile is valid.
+#[must_use]
+pub fn candidate(deadzone: f64, center_expo: f64, apply_accel: f64) -> Candidate {
+    #[allow(clippy::expect_used)]
+    Candidate::new(
+        CandidateLineage {
+            schema: "pilotage-aviate-test-candidate-v1".to_owned(),
+            base_preset_digest: Digest::from_bytes([0x31; 32]),
+            plant_digest: Digest::from_bytes([0x32; 32]),
+        },
+        BTreeMap::from([
+            (DEADZONE.to_owned(), deadzone),
+            (CENTER_EXPO.to_owned(), center_expo),
+            (APPLY_ACCEL.to_owned(), apply_accel),
+        ]),
+    )
+    .expect("a valid test candidate")
+}
+
+/// The exact identity of one candidate, as the harness calculates it.
+#[must_use]
+pub fn candidate_digest(candidate: &Candidate) -> Digest {
+    #[allow(clippy::expect_used)]
+    let bytes = serde_json::to_vec(candidate).expect("encode a candidate");
+    flight_tune::Digest::from_bytes(sha256(&bytes))
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    use sha2::{Digest as _, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// One stored calibration mission the runtime can admit.
+#[must_use]
+pub fn mission_document(id: &str) -> MissionDocument {
+    #[allow(clippy::expect_used)]
+    calibration_mission_document(
+        &reference_observation_scenario(id, Some(2_000_000_000)),
+        2,
+        1_000_000_000,
+    )
+    .expect("a valid calibration mission")
+}
+
+/// One reference to a stored calibration mission.
+#[must_use]
+pub fn mission_reference(document: &MissionDocument) -> MissionReference {
+    #[allow(clippy::expect_used)]
+    MissionReference::from_document(document, 512).expect("a valid mission reference")
+}
+
+/// One complete run identity for a training baseline.
+#[must_use]
+pub fn run_context(
+    session: u8,
+    document: &MissionDocument,
+    candidate_digest: Digest,
+    seed: u64,
+) -> RunExecutionContext {
+    #[allow(clippy::expect_used)]
+    RunExecutionContext::new(
+        Digest::from_bytes([session; 32]),
+        7,
+        AttemptRole::TrainingBaseline,
+        candidate_digest,
+        None,
+        ScenarioSet::Training,
+        &mission_reference(document),
+        0,
+        seed,
+    )
+    .expect("a valid run execution context")
+}
+
+/// One supervised launch request with no run intent bound yet.
+///
+/// The paths never reach a launch: the test only reads the run intent the
+/// request carries, which is what binds a process to the run it flies.
+#[must_use]
+pub fn supervised_request() -> flight_tune_aviate::SupervisedProcessRequest {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    flight_tune_aviate::SupervisedProcessRequest {
+        supervisor_executable: PathBuf::from("/nonexistent/supervisor"),
+        supervisor_executable_digest: Digest::from_bytes([0x71; 32]),
+        target_executable: PathBuf::from("/nonexistent/aviate"),
+        target_executable_digest: Digest::from_bytes([0x72; 32]),
+        target_arguments: Vec::new(),
+        target_environment: BTreeMap::new(),
+        target_process_contract: flight_tune_aviate::TargetProcessContract::RetainProcessGroup,
+        target_current_directory: PathBuf::from("/nonexistent"),
+        storage_root: PathBuf::from("/nonexistent/storage"),
+        runtime_root: PathBuf::from("/nonexistent/runtime"),
+        artifact_root: PathBuf::from("/nonexistent/artifact"),
+        run_intent_digest: Digest::from_bytes([0; 32]),
+        startup_timeout: Duration::from_secs(5),
+        cleanup_timeout: Duration::from_secs(5),
+    }
+}

--- a/tools/flight-tune-aviate/tests/run_receipt_binding.rs
+++ b/tools/flight-tune-aviate/tests/run_receipt_binding.rs
@@ -1,0 +1,142 @@
+//! Every receipt in one run has to name that exact run.
+//!
+//! Preparation, scenario start, candidate activation, and controller
+//! readback each return a receipt. A receipt that names another run,
+//! another session, another mission, another seed, or another candidate
+//! stops the sequence here, before the next external action.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+#[path = "production_binding/rig.rs"]
+#[allow(dead_code)]
+mod rig;
+
+use flight_tune::{
+    CandidateReceipt, Digest, MissionCapability, RunPreparationReceipt, ScenarioStartReceipt,
+};
+use flight_tune_aviate::runtime::direct::NoDirectControl;
+use flight_tune_aviate::runtime::phase::transition::StartStateTolerance;
+use flight_tune_aviate::{AviateActionDriver, AviateScenarioDriver};
+
+use rig::{candidate, candidate_digest, mission_document, run_context, runtime_identity};
+
+fn tolerance() -> StartStateTolerance {
+    StartStateTolerance {
+        position_m: 0.5,
+        heading_rad: 0.1,
+        speed_mps: 0.2,
+        dwell_ns: 500_000_000,
+    }
+}
+
+/// One admitted run, ready for its receipts to be checked.
+fn admitted_run(name: &str, seed: u64) -> (AviateScenarioDriver<NoDirectControl>, Digest) {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let digest = candidate_digest(&candidate);
+    let document = mission_document(name);
+    let context = run_context(0x11, &document, digest, seed);
+    let mut driver = AviateScenarioDriver::new(
+        runtime_identity(name),
+        vec![MissionCapability::KinematicTruth],
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver");
+    driver
+        .prepare_blocking(&document, &context)
+        .expect("admit the run");
+    (driver, digest)
+}
+
+#[test]
+fn a_preparation_receipt_for_another_run_stops_the_next_action() {
+    let (driver, _digest) = admitted_run("preparation-receipt", 53);
+    let run = driver.admitted_run().expect("the admitted run");
+    let intent = run.run_intent_digest();
+    let session = run.session_digest();
+    let other = Digest::from_bytes([0x63; 32]);
+
+    run.require_preparation(&RunPreparationReceipt {
+        session_digest: session,
+        run_intent_digest: intent,
+    })
+    .expect("the exact preparation receipt");
+    run.require_preparation(&RunPreparationReceipt {
+        session_digest: session,
+        run_intent_digest: other,
+    })
+    .expect_err("another run intent must stop the sequence");
+    run.require_preparation(&RunPreparationReceipt {
+        session_digest: other,
+        run_intent_digest: intent,
+    })
+    .expect_err("another session must stop the sequence");
+}
+
+#[test]
+fn a_start_receipt_for_another_mission_or_seed_stops_the_next_action() {
+    let (driver, _digest) = admitted_run("start-receipt", 53);
+    let run = driver.admitted_run().expect("the admitted run");
+    let other = Digest::from_bytes([0x63; 32]);
+    let start = ScenarioStartReceipt {
+        session_digest: run.session_digest(),
+        applied_mission_content_digest: run.mission_content_digest(),
+        seed: 53,
+        run_intent_digest: run.run_intent_digest(),
+    };
+
+    run.require_start(&start).expect("the exact start receipt");
+    run.require_start(&ScenarioStartReceipt {
+        applied_mission_content_digest: other,
+        ..start
+    })
+    .expect_err("another applied mission must stop the sequence");
+    run.require_start(&ScenarioStartReceipt { seed: 54, ..start })
+        .expect_err("another run seed must stop the sequence");
+    run.require_start(&ScenarioStartReceipt {
+        run_intent_digest: other,
+        ..start
+    })
+    .expect_err("another run intent must stop the sequence");
+}
+
+#[test]
+fn a_candidate_apply_or_readback_mismatch_stops_the_next_action() {
+    let (driver, digest) = admitted_run("candidate-receipt", 53);
+    let run = driver.admitted_run().expect("the admitted run");
+    let other = Digest::from_bytes([0x63; 32]);
+    let applied = CandidateReceipt {
+        session_digest: run.session_digest(),
+        requested_digest: digest,
+        applied_digest: digest,
+        readback_digest: digest,
+        run_intent_digest: Some(run.run_intent_digest()),
+    };
+
+    run.require_candidate(&applied)
+        .expect("the exact candidate receipt");
+    run.require_candidate(&CandidateReceipt {
+        applied_digest: other,
+        ..applied
+    })
+    .expect_err("an apply mismatch must stop the sequence");
+    run.require_candidate(&CandidateReceipt {
+        readback_digest: other,
+        ..applied
+    })
+    .expect_err("a readback mismatch must stop the sequence");
+    run.require_candidate(&CandidateReceipt {
+        requested_digest: other,
+        applied_digest: other,
+        readback_digest: other,
+        ..applied
+    })
+    .expect_err("another candidate must stop the sequence");
+    run.require_candidate(&CandidateReceipt {
+        run_intent_digest: None,
+        ..applied
+    })
+    .expect_err("a receipt with no run intent must stop the sequence");
+}

--- a/tools/flight-tune-aviate/tests/runtime_dispatch.rs
+++ b/tools/flight-tune-aviate/tests/runtime_dispatch.rs
@@ -1,0 +1,412 @@
+//! One production Aviate run, driven directive by directive.
+//!
+//! Everything else in this suite checks a part. This drives the whole
+//! vehicle port the way a campaign does: admit a run, start it, feed it
+//! ordered frames with the directives a trial issues, and read the
+//! receipts and the seal that come back.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+// Both helpers are shared with the suites that own them, which ask them
+// for behaviors this one does not need.
+#[path = "production_binding/rig.rs"]
+#[allow(dead_code)]
+mod rig;
+#[path = "direct_run_ledger/sender.rs"]
+#[allow(dead_code)]
+mod sender;
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::PathBuf;
+
+use flight_tune::{
+    CanonicalTelemetryKey, Digest, ExecutionTarget, KinematicTruth, MissionCapability,
+    MissionDirective, MissionTerminal, ReceiptResult, ScenarioFrame, ScenarioStopContext,
+    ScenarioStopReason, SimulatorSessionReceipt, VehicleBindingReceipt, VehicleLifecycleState,
+};
+use flight_tune::{ScenarioRuntime, scenario_runtime_identity};
+use flight_tune_aviate::direct_transport::{
+    CausalReadbackBound, DirectTransportRequest, direct_transport_identity,
+};
+use flight_tune_aviate::runtime::direct::{
+    DirectBaselinePolicy, NoDirectControl, SimulatorDirectControl,
+};
+use flight_tune_aviate::runtime::phase::direct::ledger::DurableDirectIntentStore;
+use flight_tune_aviate::runtime::phase::transition::StartStateTolerance;
+use flight_tune_aviate::{
+    AviateScenarioDriver, AviateVehicleActionPort, aviate_action_port_identity,
+};
+
+use rig::{candidate, candidate_digest, mission_document, run_context, runtime_identity};
+use sender::{RecordingSender, SAMPLE_PERIOD_NS};
+
+/// The vertical envelope a direct collective stimulus resolves through.
+const VERTICAL_ENVELOPE: &str = r#"{
+    "id": "alia250.direct.collective",
+    "revision": 2,
+    "unit": "normalized_collective_force",
+    "reference": "identified_hover_trim",
+    "negative_endpoint": -0.2,
+    "neutral": 0.05,
+    "positive_endpoint": 0.4
+}"#;
+
+fn directive(action_id: u32, phase_id: &str, action: serde_json::Value) -> MissionDirective {
+    serde_json::from_value(serde_json::json!({
+        "lane": "trial",
+        "directive": {
+            "context": {
+                "action_id": action_id,
+                "phase_index": 0,
+                "phase_id": phase_id,
+                "attempt": 1,
+                "purpose": { "purpose": "phase_action" }
+            },
+            "action": action
+        }
+    }))
+    .expect("a typed trial directive")
+}
+
+fn wait_ready() -> MissionDirective {
+    directive(1, "ready", serde_json::json!({ "kind": "wait_ready" }))
+}
+
+fn observe() -> MissionDirective {
+    directive(2, "observe", serde_json::json!({ "kind": "observe" }))
+}
+
+fn stimulate(value: f64) -> MissionDirective {
+    let envelope: serde_json::Value =
+        serde_json::from_str(VERTICAL_ENVELOPE).expect("a valid envelope");
+    directive(
+        3,
+        "stimulus",
+        serde_json::json!({
+            "kind": "stimulate",
+            "family": "direct_attitude_thrust",
+            "channel": "vertical",
+            "mapping": "affine_exact",
+            "envelope": envelope,
+            "waveform": { "kind": "step", "value": value }
+        }),
+    )
+}
+
+fn release() -> MissionDirective {
+    directive(
+        4,
+        "release",
+        serde_json::json!({ "kind": "release_control" }),
+    )
+}
+
+fn disarm() -> MissionDirective {
+    directive(5, "disarm", serde_json::json!({ "kind": "disarm" }))
+}
+
+fn frame(source_sequence: u64, lifecycle: Option<VehicleLifecycleState>) -> ScenarioFrame {
+    ScenarioFrame {
+        source_sequence,
+        simulator_time_ns: source_sequence * SAMPLE_PERIOD_NS,
+        trial_time_ns: source_sequence * SAMPLE_PERIOD_NS,
+        lifecycle,
+        ground_contact: Some(false),
+        crashed: Some(false),
+        link_valid: Some(true),
+        estimator_valid: Some(true),
+        truth: KinematicTruth {
+            position_ned_m: [0.0; 3],
+            velocity_ned_mps: [0.0; 3],
+            acceleration_ned_mps2: [0.0; 3],
+            attitude_wxyz: [1.0, 0.0, 0.0, 0.0],
+            body_rates_rps: [0.0; 3],
+        },
+        applied_conditions: BTreeMap::new(),
+        canonical_signals: Vec::new(),
+    }
+}
+
+/// One private ledger root that the test removes when it finishes.
+struct LedgerRoot(PathBuf);
+
+impl LedgerRoot {
+    fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pilotage-469-dispatch-{}-{name}",
+            std::process::id()
+        ));
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::create_dir_all(&root).expect("create the ledger root");
+        let root = std::fs::canonicalize(&root).expect("canonicalize the ledger root");
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))
+            .expect("make the ledger root private");
+        Self(root)
+    }
+}
+
+impl Drop for LedgerRoot {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn direct_control(root: &LedgerRoot, run_intent_digest: Digest) -> Direct {
+    let capability = rig::capability(0x11);
+    let simulator = SimulatorSessionReceipt {
+        session_digest: Digest::from_bytes([0x11; 32]),
+        simulator_digest: Digest::from_bytes([0x51; 32]),
+        airframe_digest: Digest::from_bytes([0x52; 32]),
+    };
+    let vehicle = VehicleBindingReceipt {
+        session_digest: Digest::from_bytes([0x11; 32]),
+        vehicle_digest: Digest::from_bytes([0x22; 32]),
+        scenario_runtime_digest: Digest::from_bytes([0x23; 32]),
+    };
+    let transport = direct_transport_identity().expect("the direct transport identity");
+    let readback =
+        CausalReadbackBound::new(SAMPLE_PERIOD_NS, SAMPLE_PERIOD_NS).expect("a readback bound");
+    SimulatorDirectControl::authorize(
+        &DirectTransportRequest {
+            capability: &capability,
+            simulator: &simulator,
+            vehicle: &vehicle,
+            target: ExecutionTarget::Simulator,
+            transport: &transport,
+            readback,
+            tolerance: 1e-9,
+        },
+        RecordingSender::new(),
+        DurableDirectIntentStore::open_blocking(&root.0).expect("open the direct ledger"),
+        run_intent_digest,
+        DirectBaselinePolicy {
+            hover_trim: 0.72,
+            max_commands: 8,
+        },
+    )
+    .expect("authorize the simulator-only direct path")
+}
+
+fn tolerance() -> StartStateTolerance {
+    StartStateTolerance {
+        position_m: 0.5,
+        heading_rad: 0.1,
+        speed_mps: 0.2,
+        dwell_ns: 25_000_000,
+    }
+}
+
+fn capabilities() -> Vec<MissionCapability> {
+    vec![
+        MissionCapability::KinematicTruth,
+        MissionCapability::ArmDisarm,
+        MissionCapability::DirectAttitudeThrustControl,
+    ]
+}
+
+#[test]
+fn a_run_advances_every_directive_and_seals_its_direct_evidence() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("dispatch");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 61);
+    let intent = context.digest().expect("the run intent digest");
+    let root = LedgerRoot::new("enacted");
+    let runtime = runtime_identity("dispatch");
+    let frozen = runtime.identity().clone();
+    let driver = AviateScenarioDriver::new(
+        runtime,
+        capabilities(),
+        tolerance(),
+        direct_control(&root, intent),
+    )
+    .expect("a driver with a direct path");
+
+    let mut port = AviateVehicleActionPort::new(driver).expect("the composed action port");
+    assert_eq!(
+        port.identity(),
+        &scenario_runtime_identity(
+            &aviate_action_port_identity(&frozen).expect("the action port identity")
+        )
+        .expect("the composed scenario runtime identity")
+    );
+
+    port.prepare_blocking(&document, &context)
+        .expect("admit the run");
+    port.start_blocking().expect("start the run");
+
+    // A frame with no directive advances nothing and returns no receipt.
+    assert_eq!(
+        port.observe_blocking(&frame(1, Some(VehicleLifecycleState::Armed)), None)
+            .expect("observe an idle frame")
+            .action_result,
+        None
+    );
+
+    advance_the_trial(&mut port);
+
+    let mut stop = ScenarioStopContext {
+        reason: ScenarioStopReason::Mission(MissionTerminal::Complete {
+            completed_phases: 5,
+        }),
+        last_source_sequence: None,
+    };
+    port.stop_blocking(&mut stop).expect("stop the run");
+    let sealed = port.driver().seal().expect("a sealed run").clone();
+    assert_eq!(sealed.run_intent_digest, intent);
+    assert_eq!(sealed.runtime_identity, frozen);
+    assert_eq!(sealed.accepted_frames, 6);
+    assert_eq!(stop.last_source_sequence, Some(6));
+    assert!(
+        sealed.direct_evidence_digest.is_some(),
+        "a run that commanded directly seals its direct evidence"
+    );
+    port.cleanup_blocking().expect("clean up the run");
+}
+
+#[test]
+fn a_direct_stimulus_on_a_runtime_with_no_direct_path_is_refused() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("no-direct-path");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 62);
+    let driver = AviateScenarioDriver::new(
+        runtime_identity("no-direct-path"),
+        capabilities(),
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver with no direct path");
+    let mut port = AviateVehicleActionPort::new(driver).expect("the composed action port");
+    port.prepare_blocking(&document, &context)
+        .expect("admit the run");
+    port.start_blocking().expect("start the run");
+    port.observe_blocking(
+        &frame(1, Some(VehicleLifecycleState::Armed)),
+        Some(&wait_ready()),
+    )
+    .expect("advance the readiness wait");
+
+    let detail = port
+        .observe_blocking(
+            &frame(2, Some(VehicleLifecycleState::Armed)),
+            Some(&stimulate(0.5)),
+        )
+        .expect_err("a direct stimulus must be refused with no direct path")
+        .to_string();
+    assert!(detail.contains("no direct authority"), "{detail}");
+
+    // A run with no direct path seals no direct evidence.
+    let mut stop = ScenarioStopContext {
+        reason: ScenarioStopReason::ExecutionError,
+        last_source_sequence: None,
+    };
+    port.stop_blocking(&mut stop).expect("stop the run");
+    assert_eq!(
+        port.driver()
+            .seal()
+            .expect("a sealed run")
+            .direct_evidence_digest,
+        None
+    );
+}
+
+#[test]
+fn a_frame_out_of_order_stops_the_run_before_the_directive_advances() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("frame-order");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 63);
+    let driver = AviateScenarioDriver::new(
+        runtime_identity("frame-order"),
+        capabilities(),
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver");
+    let mut port = AviateVehicleActionPort::new(driver).expect("the composed action port");
+    port.prepare_blocking(&document, &context)
+        .expect("admit the run");
+    port.start_blocking().expect("start the run");
+    port.observe_blocking(
+        &frame(4, Some(VehicleLifecycleState::Armed)),
+        Some(&observe()),
+    )
+    .expect("advance the first frame");
+
+    let detail = port
+        .observe_blocking(
+            &frame(4, Some(VehicleLifecycleState::Armed)),
+            Some(&observe()),
+        )
+        .expect_err("a repeated frame must stop the run")
+        .to_string();
+    assert!(detail.contains("does not advance"), "{detail}");
+}
+
+#[test]
+fn a_run_cannot_observe_before_it_starts() {
+    let candidate = candidate(0.06, 0.35, 4.0);
+    let document = mission_document("unstarted");
+    let context = run_context(0x11, &document, candidate_digest(&candidate), 64);
+    let driver = AviateScenarioDriver::new(
+        runtime_identity("unstarted"),
+        capabilities(),
+        tolerance(),
+        NoDirectControl,
+    )
+    .expect("a driver");
+    let mut port = AviateVehicleActionPort::new(driver).expect("the composed action port");
+    port.observe_blocking(&frame(1, None), Some(&observe()))
+        .expect_err("an unstarted run cannot observe");
+    port.prepare_blocking(&document, &context)
+        .expect("admit the run");
+    port.observe_blocking(&frame(1, None), Some(&observe()))
+        .expect_err("an admitted run that has not started cannot observe");
+    port.start_blocking().expect("start the run");
+    port.observe_blocking(&frame(1, None), Some(&observe()))
+        .expect("a started run observes");
+}
+
+/// The direct path this suite drives the vehicle port through.
+type Direct = SimulatorDirectControl<RecordingSender, DurableDirectIntentStore>;
+
+/// Advances the trial's directives and checks each receipt as it lands.
+fn advance_the_trial(port: &mut AviateVehicleActionPort<AviateScenarioDriver<Direct>>) {
+    for (sequence, directive) in [
+        (2, wait_ready()),
+        (3, stimulate(0.5)),
+        (4, release()),
+        (5, observe()),
+        (6, disarm()),
+    ] {
+        let lifecycle = if sequence == 6 {
+            VehicleLifecycleState::Disarmed
+        } else {
+            VehicleLifecycleState::Armed
+        };
+        let receipt = port
+            .observe_blocking(&frame(sequence, Some(lifecycle)), Some(&directive))
+            .unwrap_or_else(|error| panic!("advance directive {sequence}: {error}"));
+        assert_eq!(receipt.source_sequence, sequence);
+        assert_eq!(
+            receipt.action_result,
+            Some(ReceiptResult::Succeeded {}),
+            "directive {sequence} must complete"
+        );
+        // The commanded value reaches the canonical telemetry on the frame
+        // that commands it, and the release that follows clears it.
+        let telemetry = port
+            .driver()
+            .canonical_telemetry()
+            .expect("the canonical telemetry");
+        let expected = if sequence == 3 { 0.5 } else { 0.0 };
+        assert!(
+            (telemetry[CanonicalTelemetryKey::CommandPrimary.as_str()] - expected).abs()
+                < f64::EPSILON,
+            "frame {sequence} commanded {}",
+            telemetry[CanonicalTelemetryKey::CommandPrimary.as_str()]
+        );
+        assert!(telemetry[CanonicalTelemetryKey::CommandLinkValid.as_str()] > 0.5);
+    }
+}

--- a/tools/flight-tune-aviate/tests/runtime_identity.rs
+++ b/tools/flight-tune-aviate/tests/runtime_identity.rs
@@ -1,0 +1,277 @@
+//! The complete production-input identity of the Aviate scenario runtime.
+//!
+//! These tests use the same inventory code the build script runs, against
+//! copies of the real package sources. A guard that only read the embedded
+//! constant could not tell a stale constant from a live one; a guard that
+//! runs the inventory over a tree it can change can.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use flight_tune_aviate::direct_transport::direct_transport_sources;
+
+// The build script is the only production caller, so parts of the shared
+// inventory module are unused in this test crate.
+#[path = "../build_support/runtime_source_identity.rs"]
+#[allow(dead_code)]
+mod runtime_source_identity;
+
+use runtime_source_identity::{
+    PRODUCTION_INPUTS, calculate, digest_named_bytes, readback_document,
+};
+
+/// One copy of the package's runtime sources that a test can change.
+struct SourceTree {
+    root: PathBuf,
+}
+
+impl SourceTree {
+    fn copy() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pilotage-469-runtime-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        if root.exists() {
+            fs::remove_dir_all(&root).expect("clear the previous source tree");
+        }
+        fs::create_dir_all(root.join("src")).expect("create the source tree");
+        let package = package_root();
+        copy_file(&package, &root, Path::new("src/runtime.rs"));
+        copy_directory(&package.join("src/runtime"), &root.join("src/runtime"));
+        Self { root }
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+
+    fn digest(&self) -> [u8; 32] {
+        calculate(&self.root)
+            .expect("calculate the runtime source identity")
+            .digest
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create a source directory");
+        }
+        fs::write(path, contents).expect("write a source");
+    }
+
+    fn remove(&self, relative: &str) {
+        fs::remove_file(self.root.join(relative)).expect("remove a source");
+    }
+
+    fn append(&self, relative: &str, text: &str) {
+        let path = self.root.join(relative);
+        let mut contents = fs::read_to_string(&path).expect("read a source");
+        contents.push_str(text);
+        fs::write(path, contents).expect("rewrite a source");
+    }
+}
+
+impl Drop for SourceTree {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.root).ok();
+    }
+}
+
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn copy_file(from_root: &Path, to_root: &Path, relative: &Path) {
+    let target = to_root.join(relative);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).expect("create a source directory");
+    }
+    fs::copy(from_root.join(relative), target).expect("copy a source");
+}
+
+fn copy_directory(from: &Path, to: &Path) {
+    fs::create_dir_all(to).expect("create a source directory");
+    for entry in fs::read_dir(from).expect("read a source directory") {
+        let path = entry.expect("read a source entry").path();
+        let name = path.file_name().expect("name a source entry");
+        if path.is_dir() {
+            copy_directory(&path, &to.join(name));
+        } else {
+            fs::copy(&path, to.join(name)).expect("copy a source");
+        }
+    }
+}
+
+#[test]
+fn the_inventory_names_every_production_runtime_source_once() {
+    let tree = SourceTree::copy();
+    let inventory = calculate(tree.path()).expect("calculate the inventory");
+    assert_eq!(inventory.names.len(), PRODUCTION_INPUTS.len());
+    let unique = inventory.names.iter().collect::<BTreeSet<_>>();
+    assert_eq!(unique.len(), inventory.names.len());
+    let entries = readback_document(&inventory.document).expect("read the inventory back");
+    assert_eq!(entries.len(), PRODUCTION_INPUTS.len());
+    assert!(
+        entries
+            .iter()
+            .all(|(_, sha256, bytes)| { sha256.len() == 64 && *bytes > 0 })
+    );
+}
+
+#[test]
+fn a_change_to_timing_changes_the_identity() {
+    let tree = SourceTree::copy();
+    let before = tree.digest();
+    tree.append(
+        "src/runtime/timing.rs",
+        "\n// one changed production byte\n",
+    );
+    assert_ne!(tree.digest(), before);
+}
+
+#[test]
+fn a_change_to_the_stimulus_waveform_changes_the_identity() {
+    let tree = SourceTree::copy();
+    let before = tree.digest();
+    tree.append(
+        "src/runtime/phase/waveform.rs",
+        "\n// one changed production byte\n",
+    );
+    assert_ne!(tree.digest(), before);
+}
+
+#[test]
+fn a_new_production_runtime_source_fails_the_inventory_guard() {
+    let tree = SourceTree::copy();
+    assert!(tree.digest() != [0; 32]);
+    tree.write(
+        "src/runtime/unbound.rs",
+        "//! An unbound production source.\n",
+    );
+    let detail = guard_refusal(tree.path(), "a new production source");
+    assert!(detail.contains("differs"), "{detail}");
+    assert!(detail.contains("unbound.rs"), "{detail}");
+}
+
+#[test]
+fn a_missing_production_runtime_source_fails_the_inventory_guard() {
+    let tree = SourceTree::copy();
+    tree.remove("src/runtime/phase/waveform.rs");
+    let detail = guard_refusal(tree.path(), "a missing production source");
+    assert!(detail.contains("differs"), "{detail}");
+    assert!(detail.contains("waveform.rs"), "{detail}");
+}
+
+#[test]
+fn a_test_source_does_not_enter_the_production_identity() {
+    let tree = SourceTree::copy();
+    let before = tree.digest();
+    tree.write("src/runtime/tests.rs", "//! Unit tests.\n");
+    tree.write("src/runtime/tests/support.rs", "//! Test support.\n");
+    tree.write("src/runtime/phase/waveform_tests.rs", "//! More tests.\n");
+    tree.write("src/runtime/phase/tests/schedule.rs", "//! More tests.\n");
+    assert_eq!(
+        tree.digest(),
+        before,
+        "a test source must not change the production identity"
+    );
+}
+
+/// One synthetic byte set for the complete declared inventory.
+fn declared_inputs() -> Vec<(String, Vec<u8>)> {
+    PRODUCTION_INPUTS
+        .iter()
+        .enumerate()
+        .map(|(index, name)| ((*name).to_owned(), format!("source {index}").into_bytes()))
+        .collect()
+}
+
+#[test]
+fn input_ordering_cannot_change_the_canonical_digest() {
+    let ordered = declared_inputs();
+    let mut reversed = ordered.clone();
+    reversed.reverse();
+    let mut rotated = ordered.clone();
+    rotated.rotate_left(7);
+    let first = digest_named_bytes(&ordered).expect("digest the ordered inputs");
+    assert_eq!(
+        digest_named_bytes(&reversed).expect("digest the reversed inputs"),
+        first
+    );
+    assert_eq!(
+        digest_named_bytes(&rotated).expect("digest the rotated inputs"),
+        first
+    );
+
+    let mut changed = ordered;
+    changed[3].1 = b"one changed production source".to_vec();
+    assert_ne!(
+        digest_named_bytes(&changed).expect("digest the changed inputs"),
+        first
+    );
+}
+
+/// The refusal detail the inventory guard reports, or a failed test.
+///
+/// [`calculate`] returns an inventory that states no [`std::fmt::Debug`],
+/// so the refusal is read by matching rather than by unwrapping.
+fn guard_refusal(root: &Path, expected: &str) -> String {
+    match calculate(root) {
+        Ok(_) => panic!("the inventory guard accepted {expected}"),
+        Err(error) => error.to_string(),
+    }
+}
+
+#[test]
+fn a_repeated_inventory_path_fails_the_canonical_document() {
+    let mut repeated = declared_inputs();
+    let first = repeated[0].clone();
+    repeated.push((first.0, b"a second copy of one path".to_vec()));
+    match digest_named_bytes(&repeated) {
+        Ok(_) => panic!("the canonical document accepted a repeated path"),
+        Err(error) => assert!(error.to_string().contains("repeated path"), "{error}"),
+    }
+}
+
+#[test]
+fn every_direct_step_source_is_bound_to_the_transport_identity() {
+    let bound = direct_transport_sources()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    let mut present = BTreeSet::new();
+    present.insert("direct_transport.rs".to_owned());
+    collect_production_names(
+        &package_root().join("src/direct_transport"),
+        "direct_transport",
+        &mut present,
+    );
+    assert_eq!(
+        bound, present,
+        "every direct-step production source must enter the transport identity"
+    );
+}
+
+fn collect_production_names(directory: &Path, prefix: &str, names: &mut BTreeSet<String>) {
+    for entry in fs::read_dir(directory).expect("read a direct-transport directory") {
+        let path = entry.expect("read a direct-transport entry").path();
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("name a direct-transport entry")
+            .to_owned();
+        if path.is_dir() {
+            if name != "tests" {
+                collect_production_names(&path, &format!("{prefix}/{name}"), names);
+            }
+        } else if name.ends_with(".rs") && name != "tests.rs" && !name.ends_with("_tests.rs") {
+            names.insert(format!("{prefix}/{name}"));
+        }
+    }
+}

--- a/tools/flight-tune-campaign/src/publish/tests.rs
+++ b/tools/flight-tune-campaign/src/publish/tests.rs
@@ -4,8 +4,8 @@
 #[allow(dead_code)]
 mod producer_rig;
 
-use flight_tune::{FinalQualificationOutcome, Tuner};
-use pilotage_tuning_feedback::{RequiredPolicy, VerifiedCampaignEvidence};
+use flight_tune::{ArtifactIdentity, Digest, FinalQualificationOutcome, Tuner};
+use pilotage_tuning_feedback::{CampaignEvidence, RequiredPolicy, VerifiedCampaignEvidence};
 
 use super::publish_journal_evidence_blocking;
 use crate::CampaignError;
@@ -84,4 +84,80 @@ fn a_qualified_journal_publishes_verified_readback() {
 
     assert_eq!(qualified.campaign().source_digest(), receipt.digest);
     assert!(!qualified.selected_candidate().is_zero());
+}
+
+#[test]
+fn a_changed_scenario_runtime_identity_fails_independent_verification() {
+    let directory = TestDirectory::new("campaign-runtime-identity-tamper");
+    let state = FakeHandle::new();
+    let mut tuner = Tuner::open_or_resume(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        EnvelopeGates::new(2.0),
+        QuadraticMetric::new(state),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect("open producer tuner");
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run producer training");
+    tuner.freeze_candidate().expect("freeze producer candidate");
+    tuner
+        .run_promotion_once_blocking()
+        .expect("run producer promotion");
+    assert_eq!(
+        tuner
+            .run_final_qualification_once_blocking()
+            .expect("run producer final qualification"),
+        FinalQualificationOutcome::Qualified
+    );
+
+    let exact = tuner
+        .journal()
+        .verified_evidence_snapshot()
+        .expect("a stable journal head");
+    CampaignEvidence::new(exact.clone()).expect("the exact evidence verifies");
+
+    // The scenario runtime identity is inside the entry the journal head
+    // digest covers, so a reader that recalculates the head finds it
+    // whatever the rest of the campaign says.
+    let bound = exact
+        .head
+        .entry
+        .session
+        .runtimes
+        .scenario_runtime
+        .clone()
+        .expect("the bound scenario runtime identity");
+    let mut changed = exact.clone();
+    changed.head.entry.session.runtimes.scenario_runtime = Some(
+        ArtifactIdentity::new(
+            "pilotage-scenario-runtime-v2",
+            Digest::from_bytes([0x5a; 32]),
+        )
+        .expect("another runtime identity"),
+    );
+    assert_ne!(
+        changed
+            .head
+            .entry
+            .session
+            .runtimes
+            .scenario_runtime
+            .as_ref(),
+        Some(&bound)
+    );
+    CampaignEvidence::new(changed)
+        .expect_err("a changed runtime identity must fail independent verification");
+
+    // Removing the identity is refused too: evidence that names no runtime
+    // is evidence nobody can reproduce.
+    let mut absent = exact;
+    absent.head.entry.session.runtimes.scenario_runtime = None;
+    CampaignEvidence::new(absent)
+        .expect_err("evidence with no runtime identity must fail independent verification");
 }

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -65,10 +65,12 @@ pub use model::{
     promotion_policy_digest,
 };
 pub use pilotage_mission_core::{
-    ArtifactIdentity as MissionArtifactIdentity, ControlChannel, ControlFamily, DirectiveContext,
-    ExecutionTarget, FlightAction, MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective,
-    MissionDocument, ObservedSignal, PhysicalUnit, ReceiptResult, ReferenceRule, StartState,
-    StimulusEnvelope, StimulusError, StimulusMapping, TrialAction, VehicleLifecycleState, Waveform,
+    ArtifactIdentity as MissionArtifactIdentity, ControlChannel, ControlFamily, ControlValueField,
+    Digest as MissionDigest, DirectiveContext, ExecutionTarget, FlightAction,
+    MISSION_SCHEMA_VERSION, MissionCapability, MissionDirective, MissionDocument, MissionTerminal,
+    ObservedSignal, PhysicalUnit, ReceiptResult, ReferenceFrame, ReferenceRule, SignalSelector,
+    SineComponent, StartHeading, StartState, StimulusEnvelope, StimulusError, StimulusMapping,
+    TrialAction, VehicleLifecycleState, Waveform,
 };
 pub use pilotage_trial::{Digest, Scenario as TrialScenario};
 pub use run_context::{RUN_EXECUTION_CONTEXT_SCHEMA_VERSION, RunExecutionContext};


### PR DESCRIPTION
The Aviate tuning crate had a supervisor, a simulator-only direct transport, and a neutral action port — but no production vehicle. Nothing implemented `SimulatorVehicleFactory`, nothing mapped a generic candidate to an exact feel profile, and no value said which production sources shaped a run. A suite baseline could therefore be compared across two different implementations without anything noticing.

This adds the production Aviate runtime and gives it one identity.

## What the owner comment contained, and how it is honored

The single comment on #469 is an implementation-freeze notice pointing at branch `codex/auto-calibration-harness`. **That branch is not on this remote** — `git ls-remote --heads origin` has no `codex/auto-calibration-harness` and no `codex/469-*`. Its listed scope is what this PR implements. Line by line:

| Owner's scope line | How it is honored |
| --- | --- |
| The complete Aviate runtime `ArtifactIdentity` is bound through execution, retry, restart, recovery, terminal receipt, journal, campaign evidence, and feedback qualification. | `AviateRuntimeIdentity` → the driver's action-port identity → `aviate_action_port_identity` → `scenario_runtime_identity`, which is the value the neutral chain already binds through the journal, terminal receipts, campaign evidence, and the independent verifier. Tests: `a_production_input_change_changes_the_scenario_runtime_identity`, `an_execution_retry_cannot_change_the_runtime_identity`, `a_restart_with_another_runtime_identity_fails_before_external_mutation`, `a_changed_scenario_runtime_identity_fails_independent_verification`. |
| Live runtime attestation runs before journal, presentation, reset, process, socket, control, or evidence mutation. | `AviateRuntimeIdentity::attest` recomputes the identity from the document it carries. `PreparedRun::admit` attests before a run is admitted, `observe_blocking` attests before it accepts a frame, and `require_frozen_runtime` attests before a restart. Test: `a_tampered_runtime_document_fails_its_own_attestation`. |
| The independent feedback verifier reads the native Aviate intent, receipt, and quarantine documents. | **Honored as amended by the #498 lift.** Post-#498 the evidence chain is simulator-neutral; the verifier reads `JournalEvidenceSnapshot`, and the Aviate identity reaches it through `SessionIdentity.runtimes.scenario_runtime`. Native Aviate documents in the verifier would reintroduce the adapter dependency that #498 removed and that `check-feedback-verifier-boundary.py` forbids. Test: `a_changed_scenario_runtime_identity_fails_independent_verification`. |
| Comparable candidates must use the same runtime identity. | The orphan-baseline mechanism keys on the composed scenario-runtime identity, which is already enforced by `changed_runtime_orphans_baseline_and_pending_challenger_before_mutation` (merged). What #469 adds is the proof that an Aviate production input change reaches that value. |
| CLI and campaign presentation fixtures use complete native Aviate documents. | **Not reproduced, for the same #498 reason.** The campaign fixture is the neutral snapshot. Stated here rather than dropped silently. |

## The pinned build machinery, and why two files came from the stale lane

`scripts/check-flight-tune-contracts.py` on main — pinned by merged PR #497 (`579dc7fe`, "Close tuning boundary provenance gaps") — pre-declares a forward contract for #469 that did not exist in the tree:

- `GENERATED_INCLUDE_ALLOWLIST` requires `tools/flight-tune-aviate/src/runtime/identity.rs` to contain exactly one `include!(concat!(env!("OUT_DIR"), "/runtime_source_identity.rs"))`.
- `GENERATED_BUILD_TARGETS` requires `tools/flight-tune-aviate/Cargo.toml` to declare that build script.
- `GENERATED_INPUT_DIGESTS` pins `build.rs` to `843c7d78…` and `build_support/runtime_source_identity.rs` to `d29a99fc…`.

A sha256 pin cannot be satisfied by an independently written file. Both pinned files exist byte-for-byte on the stale local lane `codex/469-runtime-input-identity`, so main's merged guard admits exactly one content for them. **Those two files are taken verbatim; everything else is written fresh against the merged post-#498 contracts.** The rest of that lane is a pre-#498 tree — a different `flight-tune-aviate` with no `direct_transport/`, no `action_port.rs`, no supervisor — and is untouched.

The pinned `build_support/runtime_source_identity.rs` hard-codes a closed 16-entry `PRODUCTION_INPUTS` list under `src/runtime/` and enforces `declared == discovered`, so this PR creates exactly those sixteen production files, no more and no fewer.

## Layers

**Layer 1 — production vehicle binding.** `AviateVehicleFactory` implements `SimulatorVehicleFactory`; `AviateVehicleAdapter` implements `SimulatorVehicleAdapter`. Each candidate maps through `CandidateFeelMapping` to one exact `ValidatedFlightFeelProfile` — the complete profile, validated by `pilotage-control-feel`'s own validator, before any controller is written to. `authorize_candidate_transition` refuses a source that is not the current incumbent, then calls the vehicle-owned `TransitionValidator`. `ensure_*_blocking` reads the controller back first, so activating an already-active candidate performs no write. Receipts carry the run-intent digest; `bind_run_intent`/`require_run_intent` put that digest on `SupervisedProcessRequest`.

**Layer 2 — production input inventory.** The build script discovers `src/runtime.rs` plus every production Rust file below `src/runtime/`, skipping `tests/` directories, `tests.rs`, and `*_tests.rs`, and refuses a missing file, an extra file, a repeat, a symlink, or a path outside the package.

**Layer 3 — canonical runtime identity.** `RuntimeImplementationDocument` binds the source-inventory digest and every entry (path, sha256, byte count) in canonical path order, plus the vehicle, transition-validator, adjacency-policy, direct-transport, and runtime-configuration identities. Each is length-framed under a domain separator. The readback re-parses the embedded document, requires it canonical, and recomputes its digest against the embedded constant, so a stale constant cannot pass for a live one.

**Layer 4 — execution and recovery binding.** `AviateScenarioDriver` exposes the sealed identity as its action-port identity, and `AviateVehicleActionPort` composes it with the shared engine. `require_frozen_runtime` refuses a restart under a changed identity before any external action. `AviateRunSeal` binds the run intent, the runtime that flew it, the ending, and the direct evidence digest.

## The #577 ledger items

PR #577 left four items to this issue. All four are here:

- **Durable prepared-intent synchronization.** `DirectIntentLedger` publishes the prepared command through `DurableDirectIntentStore` before `enact_blocking` can put a datagram on the link, and publishes the result after it returns.
- **Recovery's ambiguous outcome.** A durable prepared intent with no durable result is `DirectRecoveryOutcome::Ambiguous`. `SimulatorDirectControl::authorize` reads the ledger and refuses to resume through it. Test: `a_prepared_intent_with_no_durable_result_is_ambiguous`.
- **Publication validation.** `validate_publication` refuses a record that does not close its prepared intent, names another run intent or transport, states times that are not causally ordered, carries a value that is not a number, or leaves the declared tolerance. Six unit tests.
- **Run-receipt binding.** `DirectRunEvidence` seals the validated records under one digest bound to the run intent and the runtime identity, and `AviateRunSeal` carries that digest.

`direct_transport_identity()` (the static ten-file transport source identity) is bound into the canonical runtime document, and `every_direct_step_source_is_bound_to_the_transport_identity` walks `src/direct_transport/` on disk and fails if a production source is not in that identity — so a new #466 source cannot shape a step without entering the runtime identity.

## The #528 gap

**#528's open-transaction contract does not exist on main.** There is no typed open transaction, no rollback contract, and `Tuner::open_or_resume` still opens the simulator session and binds the vehicle without one. This PR implements what #469 owns against the existing open path: `AviateVehicleFactory::bind_blocking` mints its binding only from a `SimulatorCapability`, and the direct path additionally refuses to resume through an unresolved ledger. When #528 lands, the factory's `bind_blocking` is the seam that adopts it — nothing here has to be undone. Reported rather than built, per the issue-per-PR rule.

## Required tests

| Issue requirement | Test |
| --- | --- |
| Aviate checks a later transition against the current incumbent | `a_later_transition_is_checked_against_the_current_incumbent` |
| Aviate rejects an invalid complete feel profile before mutation | `an_invalid_complete_feel_profile_is_refused_before_any_controller_write` |
| Another transition receipt or run intent fails closed | `another_transition_receipt_fails_closed`, `a_transition_further_than_one_adjacent_step_fails_closed` |
| The supervised process request receives the durable context digest | `the_supervised_process_request_receives_the_durable_run_intent_digest` |
| A preparation, start, apply, or readback mismatch stops the next action | `a_preparation_receipt_for_another_run_stops_the_next_action`, `a_start_receipt_for_another_mission_or_seed_stops_the_next_action`, `a_candidate_apply_or_readback_mismatch_stops_the_next_action` |
| A change to `runtime/timing.rs` changes the identity | `a_change_to_timing_changes_the_identity` |
| A change to `runtime/phase/waveform.rs` changes the identity | `a_change_to_the_stimulus_waveform_changes_the_identity` |
| A new production runtime source fails the inventory guard | `a_new_production_runtime_source_fails_the_inventory_guard` |
| A missing production runtime source fails the inventory guard | `a_missing_production_runtime_source_fails_the_inventory_guard` |
| A test source does not enter the production identity | `a_test_source_does_not_enter_the_production_identity` |
| Input ordering cannot change the canonical digest | `input_ordering_cannot_change_the_canonical_digest`, `a_repeated_inventory_path_fails_the_canonical_document` |
| A restart with another runtime identity fails before external mutation | `a_restart_with_another_runtime_identity_fails_before_external_mutation` |
| An execution retry cannot change the runtime identity | `an_execution_retry_cannot_change_the_runtime_identity` |
| A suite baseline from another runtime identity fails replay | `a_production_input_change_changes_the_scenario_runtime_identity` reaches the value that the merged `changed_runtime_orphans_baseline_and_pending_challenger_before_mutation` keys on |
| A direct-step source from #466 is present in the identity inventory | `every_direct_step_source_is_bound_to_the_transport_identity` |
| A tampered runtime identity fails independent qualification verification | `a_changed_scenario_runtime_identity_fails_independent_verification`, `a_tampered_runtime_document_fails_its_own_attestation` |

The inventory tests run the same code the build script runs, against copies of the real package sources that the test then changes — a guard that only read the embedded constant could not tell a stale constant from a live one.

`a_run_advances_every_directive_and_seals_its_direct_evidence` drives the composed `AviateVehicleActionPort` through a whole trial (idle frame, wait-ready, direct stimulus, release, observe, disarm), so the phase machine is executed rather than merely reachable.

## Deviations, with reasons

- **`tools/flight-tune-aviate/build.rs` and `build_support/runtime_source_identity.rs` are byte-identical to the stale lane.** Forced by main's own sha256 pins from PR #497, as above. Verified: both hash to the pinned values.
- **`pilotage-control-feel` becomes a production dependency of `flight-tune-aviate`** (it was already a dev-dependency, and already a production dependency of `flight-tune-campaign`). Layer 1 requires validating the *complete mapped feel profile*, and `ValidatedFlightFeelProfile` is that validator. No new package enters `Cargo.lock`. One row added to `scripts/flight-tune-direct-dependency-allowlist.tsv`.
- **`serde`, `serde_json`, `sha2` become build-dependencies** of the same crate — required by the pinned `build_support` file. Three more allowlist rows. All three are already normal dependencies of the crate.
- **`flight-tune` re-exports seven more `pilotage-mission-core` identifiers** (`ControlValueField`, `MissionDigest`, `MissionTerminal`, `ReferenceFrame`, `SignalSelector`, `SineComponent`, `StartHeading`). Pure re-exports of frozen schema types that a caller cannot otherwise name to construct an `ObservedSignal`, a `ScenarioStopContext`, or a `StartState`. No schema change; `crates/pilotage-trial` and `crates/pilotage-mission-core` are untouched.
- **`PreparedDirectCommand::transport_identity_digest()`, `direct_transport_sources()`, and `AviateVehicleActionPort::driver()` are new accessors** over existing private state. No behavior change.
- **`AviateVehicleAction::ReachStartState`'s field gained a doc comment**, because the enum is now publicly re-exported and `-D missing_docs` requires it.
- **The direct baseline freezes lazily, at the frame that opens a run's first direct stimulus**, from that frame's measured attitude plus a configured hover trim. The envelope's own reference rule is `EffectiveSetpointAtEntry`, so entry is where the baseline belongs; nothing else in the run has the attitude to freeze it from.

## Known limitations

- `bind_run_intent`/`require_run_intent` and `PreparedRun::require_*` are the binding surface a campaign backend calls. The tests prove the checks; the production caller arrives with #453's Aviate backend. Nothing in this tree calls them yet.
- `SimulatorDirectControl::authorize` reads the ledger at the authority's current sequence, which is zero for a fresh run. A residual root carrying a later intent fails closed at `prepare` with `DirectLedgerResidual` instead. That is correct under the one-root-per-run design this uses, and worth revisiting if a root is ever shared.
- The scenario engine identity is untouched: nothing under `crates/pilotage-mission-core/` or `tools/flight-tune/src/scenario_runtime{,.rs}` changed, so `FLIGHT_TUNE_SCENARIO_ENGINE_ID` is identical to main.

## Gates

Every gate below was run at the pushed tip.

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace --all-targets` | pass, 84 test binaries |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `bash scripts/check-structure.sh` | pass |
| `python3 scripts/check-flight-tune-contracts.py .` | pass |
| `bash scripts/check-flight-tune-boundaries.sh` | pass |
| `python3 scripts/check-feedback-verifier-boundary.py .` | pass |
| `bash scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | pass, 19 pairs ok |

**Campaign identity.** `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` passed in 605 s: `a_campaign_runs_end_to_end_for_the_alia250` ok, `a_campaign_runs_end_to_end_for_the_x500` ok, `probe_warm_start_objectives` ok. **Both vehicles still seal Qualified.** The run executed at `4a2b40ad`; the only content change between that tree and the pushed tip is one module doc comment in `tools/flight-tune-aviate/src/transition_authorization.rs`. `cargo tree -p flight-tune-campaign -e normal | grep -c flight-tune-aviate` is 0, so `flight-tune-campaign` never compiles this crate, and `FLIGHT_TUNE_SCENARIO_ENGINE_ID` is identical to main because nothing under `crates/pilotage-mission-core/` or `tools/flight-tune/src/scenario_runtime{,.rs}` is touched.

New tests: 37 in `flight-tune-aviate` integration suites, 31 runtime unit tests, 1 in `flight-tune-campaign`.

SIM / NOT FOR FLIGHT.

Fixes #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
