### PR TITLE
feat(flight-tune): bind evaluator inputs to one exact identity (#468)

### DIFF
--- a/crates/pilotage-tuning-feedback/src/qualification/campaign.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/campaign.rs
@@ -10,6 +10,16 @@ pub(super) mod retry;
 const JOURNAL_SCHEMA_VERSION: u32 = 8;
 const SNAPSHOT_SCHEMA_VERSION: u16 = 5;
 
+/// The name the tuning harness gives one flight-quality metric evaluator.
+///
+/// The value mirrors the harness byte for byte. The verifier keeps its own
+/// copy, so a harness that renamed an evaluator cannot also rename the bar it
+/// is measured against.
+pub(super) const METRIC_IMPLEMENTATION_ID: &str = "pilotage-flight-quality-streaming-metrics-v2";
+
+/// The name the tuning harness gives one flight-quality hard-gate evaluator.
+pub(super) const GATE_IMPLEMENTATION_ID: &str = "pilotage-flight-quality-streaming-gates-v2";
+
 pub(super) struct CampaignIdentity {
     pub(super) session_digest: Digest,
     pub(super) authority: VerifiedAuthority,
@@ -70,6 +80,26 @@ fn verify_runtimes(runtimes: &RuntimeIdentities) -> Result<(), FeedbackError> {
         (&runtimes.transition_validator, "transition validator"),
     ] {
         stage::verify_artifact(artifact, name)?;
+    }
+    verify_evaluators(runtimes)
+}
+
+/// Rejects a session where one evaluator stands in for the other.
+///
+/// The metric evaluator and the hard-gate evaluator hold separate production
+/// inventories, so they cannot share a name or a value. A pair that does, or a
+/// pair that carries the two flight-quality names the wrong way round, states
+/// an evaluator the campaign never ran.
+fn verify_evaluators(runtimes: &RuntimeIdentities) -> Result<(), FeedbackError> {
+    if runtimes.metric.id == runtimes.hard_gates.id
+        || runtimes.metric.digest == runtimes.hard_gates.digest
+    {
+        return Err(invalid("one evaluator identity stands in for the other"));
+    }
+    if runtimes.metric.id == GATE_IMPLEMENTATION_ID
+        || runtimes.hard_gates.id == METRIC_IMPLEMENTATION_ID
+    {
+        return Err(invalid("the evaluator identities are exchanged"));
     }
     Ok(())
 }

--- a/crates/pilotage-tuning-feedback/src/qualification/tests.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests.rs
@@ -2,6 +2,7 @@
 
 mod aggregate_attacks;
 mod attacks;
+mod evaluator_attacks;
 mod fixture;
 #[path = "../../../../tools/flight-tune/tests/tuner/test_rig.rs"]
 #[allow(dead_code)]
@@ -112,14 +113,12 @@ fn journal_producer_snapshot_qualifies_independently() {
 
 /// The pinned identity is re-recorded whenever the evidence schema changes.
 ///
-/// It moved when every objective limit left the two policies for the scoped
-/// response target table. The stage carries the table, the policies declare
-/// names instead of numbers, the promotion comparison states one result group
-/// for each scenario, and the crash gate became the first required gate. The
-/// journal entry, the evidence snapshot, and the promotion closure all take
-/// new schema versions with it, because each embeds a shape that changed.
-/// Every run intent, every receipt, and the whole chain take new identities,
-/// which is the point of the change rather than a side effect of it.
+/// It moved when the golden campaign started naming the two evaluators it ran.
+/// The fixture states the exact flight-quality metric and hard-gate
+/// implementation names instead of two placeholder names, so the session
+/// identity changes and the sealed chain changes with it. A campaign that
+/// cannot say which evaluator produced a score cannot be qualified against
+/// one, which is the point of the change rather than a side effect of it.
 #[test]
 fn canonical_source_digest_is_fixed() {
     let evidence = fixture();
@@ -128,7 +127,7 @@ fn canonical_source_digest_is_fixed() {
         .expect("verify evidence");
     assert_eq!(
         verified.source_digest().to_string(),
-        "2d8f49e7774c0a2764de95618a5d5b3941a6b1e7130199ce4e97d37ee7d39aaf"
+        "077f3df8c005b63f27802e10c7ab249ba4004216d4d5f29037336e5a24950c5c"
     );
 }
 

--- a/crates/pilotage-tuning-feedback/src/qualification/tests/evaluator_attacks.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests/evaluator_attacks.rs
@@ -1,0 +1,103 @@
+//! Independent qualification of the exact flight-quality evaluator identities.
+//!
+//! Each case starts from the sealed golden campaign and changes one evaluator
+//! identity. A case that reseals the chain proves the verifier's own structural
+//! rule; a case that does not reseal proves the identity is bound into the
+//! authenticated chain rather than read beside it.
+
+use flight_tune::{ArtifactIdentity, Digest};
+
+use super::fixture::{fixture, try_fixture_with_evaluators};
+use super::verify;
+
+/// The verifier keeps its own copy of each evaluator name.
+///
+/// A mirror that drifted would measure a campaign against a name the harness
+/// no longer writes, so the two sides are compared here directly.
+#[test]
+fn the_verifier_mirrors_each_evaluator_name_byte_for_byte() {
+    assert_eq!(
+        super::super::campaign::METRIC_IMPLEMENTATION_ID,
+        flight_tune::METRIC_IMPLEMENTATION_ID
+    );
+    assert_eq!(
+        super::super::campaign::GATE_IMPLEMENTATION_ID,
+        flight_tune::GATE_IMPLEMENTATION_ID
+    );
+}
+
+#[test]
+fn the_sealed_golden_campaign_states_both_evaluator_identities() {
+    let evidence = fixture();
+    let runtimes = &evidence.journal.head.entry.session.runtimes;
+
+    assert_eq!(runtimes.metric.id, flight_tune::METRIC_IMPLEMENTATION_ID);
+    assert_eq!(runtimes.hard_gates.id, flight_tune::GATE_IMPLEMENTATION_ID);
+    assert_ne!(runtimes.metric.digest, runtimes.hard_gates.digest);
+    verify(&evidence).expect("the unchanged campaign qualifies");
+}
+
+#[test]
+fn a_changed_metric_identity_fails_independent_qualification() {
+    let mut evidence = fixture();
+    evidence.journal.head.entry.session.runtimes.metric = identity(
+        flight_tune::METRIC_IMPLEMENTATION_ID,
+        Digest::from_bytes([73; 32]),
+    );
+
+    verify(&evidence).expect_err("a changed metric identity is refused");
+}
+
+#[test]
+fn a_changed_hard_gate_identity_fails_independent_qualification() {
+    let mut evidence = fixture();
+    evidence.journal.head.entry.session.runtimes.hard_gates = identity(
+        flight_tune::GATE_IMPLEMENTATION_ID,
+        Digest::from_bytes([74; 32]),
+    );
+
+    verify(&evidence).expect_err("a changed hard gate identity is refused");
+}
+
+#[test]
+fn exchanged_evaluator_identities_fail_independent_qualification() {
+    let sealed = try_fixture_with_evaluators(
+        identity(
+            flight_tune::GATE_IMPLEMENTATION_ID,
+            Digest::from_bytes([33; 32]),
+        ),
+        identity(
+            flight_tune::METRIC_IMPLEMENTATION_ID,
+            Digest::from_bytes([34; 32]),
+        ),
+    );
+    let Err(error) = sealed else {
+        panic!("exchanged evaluator identities are refused");
+    };
+
+    assert!(
+        error.to_string().contains("exchanged"),
+        "the refusal names another cause: {error}"
+    );
+}
+
+#[test]
+fn one_evaluator_identity_cannot_stand_in_for_the_other() {
+    let shared = Digest::from_bytes([33; 32]);
+    let sealed = try_fixture_with_evaluators(
+        identity(flight_tune::METRIC_IMPLEMENTATION_ID, shared),
+        identity(flight_tune::GATE_IMPLEMENTATION_ID, shared),
+    );
+    let Err(error) = sealed else {
+        panic!("a shared evaluator digest is refused");
+    };
+
+    assert!(
+        error.to_string().contains("stands in for"),
+        "the refusal names another cause: {error}"
+    );
+}
+
+fn identity(id: &str, digest: Digest) -> ArtifactIdentity {
+    ArtifactIdentity::new(id, digest).expect("create an evaluator identity")
+}

--- a/crates/pilotage-tuning-feedback/src/qualification/tests/fixture.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests/fixture.rs
@@ -33,8 +33,25 @@ struct Point {
 }
 
 pub(super) fn fixture() -> CampaignEvidence {
+    try_fixture_with_evaluators(
+        artifact(flight_tune::METRIC_IMPLEMENTATION_ID, 33),
+        artifact(flight_tune::GATE_IMPLEMENTATION_ID, 34),
+    )
+    .expect("create verified campaign fixture")
+}
+
+/// Seals one golden campaign that names the two evaluators it ran.
+///
+/// A case about the evaluator identities has to state them before the chain is
+/// sealed. Changing them afterwards breaks every proof that binds the session,
+/// so the campaign would fail for the chain rather than for the rule the case
+/// names.
+pub(super) fn try_fixture_with_evaluators(
+    metric: ArtifactIdentity,
+    hard_gates: ArtifactIdentity,
+) -> Result<CampaignEvidence, crate::FeedbackError> {
     let stage = stage();
-    let session = session(&stage);
+    let session = session(&stage, metric, hard_gates);
     let session_digest = digest::document("session identity", &session).expect("session digest");
     let baseline = proof(
         &stage,
@@ -148,7 +165,11 @@ fn stage() -> SearchStage {
     }
 }
 
-fn session(stage: &SearchStage) -> SessionIdentity {
+fn session(
+    stage: &SearchStage,
+    metric: ArtifactIdentity,
+    hard_gates: ArtifactIdentity,
+) -> SessionIdentity {
     SessionIdentity {
         stage_digest: digest::document("search stage", stage).expect("stage digest"),
         initial_candidate_digest: candidate_digest(0.0),
@@ -161,8 +182,8 @@ fn session(stage: &SearchStage) -> SessionIdentity {
         runtimes: RuntimeIdentities {
             harness_build: artifact("harness", 31),
             strategy: artifact("strategy", 32),
-            metric: artifact("metric", 33),
-            hard_gates: artifact("gates", 34),
+            metric,
+            hard_gates,
             scenario_runtime: None,
             simulator: artifact("simulator", 35),
             airframe: artifact("airframe", 36),

--- a/crates/pilotage-tuning-feedback/src/qualification/tests/fixture/authority.rs
+++ b/crates/pilotage-tuning-feedback/src/qualification/tests/fixture/authority.rs
@@ -31,7 +31,7 @@ pub(super) fn sealed_campaign(
     closure: PromotionClosure,
     final_proof: AuthenticatedEvaluationProof,
     frozen_candidate: Digest,
-) -> CampaignEvidence {
+) -> Result<CampaignEvidence, crate::FeedbackError> {
     let (authority, head) = campaign_authority(
         &stage,
         &session,
@@ -52,7 +52,6 @@ pub(super) fn sealed_campaign(
         final_proof: Some(final_proof),
         final_outcome: Some(FinalQualificationOutcome::Qualified),
     })
-    .expect("create verified campaign fixture")
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/scripts/check-flight-tune-contracts.py
+++ b/scripts/check-flight-tune-contracts.py
@@ -446,12 +446,16 @@ GENERATED_INPUT_DIGESTS = {
     "tools/flight-tune/build.rs": frozenset(
         {
             "b56dd4918f6443ceb9804f5e4fb04d464268cb29ebeba76b7dc69a5a07a475cd",
+            "850a570ee9246b7961046e0712c7a5590f220a3d8faee54f55a9d511ff706d5c",
             "e4a5a3ef9d5d36ac52b5dacab7bd6eeebcef2d118490bd0831c9a8b462e1d176",
             "f0424a1bc2c4cc2fe118246db46bd3b912f6c5c5460e487c53285f93629c0aac",
         }
     ),
     "tools/flight-tune/build_support/evaluator_source_identity.rs": frozenset(
-        {"ce2adf92e3954858395151639c9bfd38234debd19157d1eaa94e96c47a223915"}
+        {
+            "31e6d4055f827129d0bc99dcede52ea2e6ad31068ea17652187b0d1aef760a05",
+            "ce2adf92e3954858395151639c9bfd38234debd19157d1eaa94e96c47a223915",
+        }
     ),
     "tools/flight-tune-aviate/build.rs": frozenset(
         {"843c7d7845f1342e41b4fc457654da121d2b22120e0ea3ff5cc3a6c1c1dc23f7"}

--- a/tools/flight-tune/build.rs
+++ b/tools/flight-tune/build.rs
@@ -5,41 +5,106 @@
 
 #![allow(clippy::disallowed_macros)]
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use sha2::{Digest as _, Sha256};
 
+#[path = "build_support/evaluator_source_identity.rs"]
+mod evaluator_source_identity;
 #[path = "build_support/scenario_runtime_identity.rs"]
 mod scenario_runtime_identity;
 
 fn main() -> ExitCode {
-    match source_identity() {
-        Ok(identity) => {
-            println!("cargo:rustc-env=FLIGHT_TUNE_BUILD_ID={identity}");
-            match scenario_runtime_identity::calculate(&workspace_root()) {
-                Ok(runtime) => {
-                    println!(
-                        "cargo:rustc-env=FLIGHT_TUNE_SCENARIO_ENGINE_ID={}",
-                        hex(&runtime.digest)
-                    );
-                    for path in runtime.paths {
-                        println!("cargo:rerun-if-changed={}", path.display());
-                    }
-                    ExitCode::SUCCESS
-                }
-                Err(error) => {
-                    println!("cargo:warning=cannot identify scenario runtime sources: {error}");
-                    ExitCode::FAILURE
-                }
-            }
-        }
+    match generate_build_inputs() {
+        Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            println!("cargo:warning=cannot identify flight-tune sources: {error}");
+            println!("cargo:warning={error}");
             ExitCode::FAILURE
         }
     }
+}
+
+fn generate_build_inputs() -> Result<(), std::io::Error> {
+    let workspace = workspace_root();
+    generate_evaluator_identities(&workspace)
+        .map_err(|error| labelled("cannot identify flight-quality evaluator sources", &error))?;
+    generate_scenario_runtime_identity(&workspace)
+        .map_err(|error| labelled("cannot identify scenario runtime sources", &error))?;
+    let identity = source_identity()
+        .map_err(|error| labelled("cannot identify flight-tune sources", &error))?;
+    println!("cargo:rustc-env=FLIGHT_TUNE_BUILD_ID={identity}");
+    Ok(())
+}
+
+fn labelled(detail: &str, error: &std::io::Error) -> std::io::Error {
+    std::io::Error::other(format!("{detail}: {error}"))
+}
+
+fn generate_scenario_runtime_identity(workspace: &Path) -> Result<(), std::io::Error> {
+    let runtime = scenario_runtime_identity::calculate(workspace)?;
+    println!(
+        "cargo:rustc-env=FLIGHT_TUNE_SCENARIO_ENGINE_ID={}",
+        hex(&runtime.digest)
+    );
+    for path in runtime.paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    Ok(())
+}
+
+/// Writes the closed evaluator inventories the crate reads back at run time.
+///
+/// Both inventories are calculated before either is written. A partial file
+/// would let a build that failed completeness still compile against a stale
+/// constant from an earlier run.
+fn generate_evaluator_identities(workspace: &Path) -> Result<(), std::io::Error> {
+    let metric = evaluator_source_identity::calculate(
+        workspace,
+        evaluator_source_identity::EvaluatorKind::Metric,
+    )?;
+    let gates = evaluator_source_identity::calculate(
+        workspace,
+        evaluator_source_identity::EvaluatorKind::Gate,
+    )?;
+    for root in evaluator_source_identity::source_roots(workspace) {
+        println!("cargo:rerun-if-changed={}", root.display());
+    }
+    for path in metric.paths.iter().chain(&gates.paths) {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    let output = output_directory()?.join("evaluator_source_identity.rs");
+    let mut file = std::fs::File::create(output)?;
+    write_inventory(&mut file, "METRIC", metric)?;
+    write_inventory(&mut file, "GATE", gates)?;
+    file.sync_all()
+}
+
+fn output_directory() -> Result<PathBuf, std::io::Error> {
+    std::env::var_os("OUT_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| std::io::Error::other("Cargo did not supply the build output directory"))
+}
+
+fn write_inventory(
+    file: &mut std::fs::File,
+    name: &str,
+    inventory: evaluator_source_identity::EvaluatorSourceInventory,
+) -> Result<(), std::io::Error> {
+    if inventory.names.len() != inventory.paths.len() {
+        return Err(std::io::Error::other(
+            "an evaluator source inventory is inconsistent",
+        ));
+    }
+    let document = String::from_utf8(inventory.document).map_err(std::io::Error::other)?;
+    writeln!(file, "const {name}_SOURCE_DOCUMENT: &str = {document:?};")?;
+    writeln!(
+        file,
+        "const {name}_SOURCE_DIGEST: [u8; 32] = {:?};",
+        inventory.digest
+    )?;
+    Ok(())
 }
 
 fn workspace_root() -> PathBuf {

--- a/tools/flight-tune/build_support/evaluator_source_identity.rs
+++ b/tools/flight-tune/build_support/evaluator_source_identity.rs
@@ -1,0 +1,398 @@
+//! Complete production-source inventories for flight-quality evaluators.
+
+use std::collections::BTreeSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+const DOCUMENT_SCHEMA_VERSION: u16 = 1;
+const METRIC_DOMAIN: &[u8] = b"flight-tune-metric-source-document-v1\0";
+const GATE_DOMAIN: &[u8] = b"flight-tune-gate-source-document-v1\0";
+
+/// Metric production inputs in canonical repository-relative order.
+pub const METRIC_PRODUCTION_INPUTS: [&str; 19] = [
+    "crates/pilotage-flight-quality/src/angular.rs",
+    "crates/pilotage-flight-quality/src/angular_release.rs",
+    "crates/pilotage-flight-quality/src/collective.rs",
+    "crates/pilotage-flight-quality/src/control.rs",
+    "crates/pilotage-flight-quality/src/error.rs",
+    "crates/pilotage-flight-quality/src/lib.rs",
+    "crates/pilotage-flight-quality/src/release.rs",
+    "crates/pilotage-flight-quality/src/response.rs",
+    "crates/pilotage-flight-quality/src/sample.rs",
+    "crates/pilotage-flight-quality/src/series.rs",
+    "crates/pilotage-flight-quality/src/signal.rs",
+    "crates/pilotage-flight-quality/src/vocabulary.rs",
+    "tools/flight-tune/build.rs",
+    "tools/flight-tune/build_support/evaluator_source_identity.rs",
+    "tools/flight-tune/src/flight_quality.rs",
+    "tools/flight-tune/src/flight_quality/config.rs",
+    "tools/flight-tune/src/flight_quality/identity.rs",
+    "tools/flight-tune/src/flight_quality/metrics.rs",
+    "tools/flight-tune/src/flight_quality/telemetry.rs",
+];
+
+/// Hard-gate production inputs in canonical repository-relative order.
+pub const GATE_PRODUCTION_INPUTS: [&str; 10] = [
+    "crates/pilotage-flight-quality/src/error.rs",
+    "crates/pilotage-flight-quality/src/gate.rs",
+    "crates/pilotage-flight-quality/src/lib.rs",
+    "tools/flight-tune/build.rs",
+    "tools/flight-tune/build_support/evaluator_source_identity.rs",
+    "tools/flight-tune/src/flight_quality.rs",
+    "tools/flight-tune/src/flight_quality/config.rs",
+    "tools/flight-tune/src/flight_quality/gates.rs",
+    "tools/flight-tune/src/flight_quality/identity.rs",
+    "tools/flight-tune/src/flight_quality/telemetry.rs",
+];
+
+/// One evaluator source class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvaluatorKind {
+    /// Continuous flight-quality metrics.
+    Metric,
+    /// Fail-fast flight-quality gates.
+    Gate,
+}
+
+/// One calculated evaluator source inventory.
+pub struct EvaluatorSourceInventory {
+    /// Content identity of the canonical inventory document.
+    pub digest: [u8; 32],
+    /// Canonical schema-versioned inventory document.
+    pub document: Vec<u8>,
+    /// Stable repository-relative production input names.
+    pub names: Vec<String>,
+    /// Exact input paths for Cargo rebuild tracking.
+    pub paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceDocument {
+    schema_version: u16,
+    evaluator: String,
+    entries: Vec<SourceEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceEntry {
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+
+/// Returns all roots that can add one evaluator production source.
+pub fn source_roots(workspace: &Path) -> [PathBuf; 5] {
+    [
+        workspace.join("tools/flight-tune/build.rs"),
+        workspace.join("tools/flight-tune/build_support/evaluator_source_identity.rs"),
+        workspace.join("tools/flight-tune/src/flight_quality.rs"),
+        workspace.join("tools/flight-tune/src/flight_quality"),
+        workspace.join("crates/pilotage-flight-quality/src"),
+    ]
+}
+
+/// Calculates one complete evaluator production identity.
+pub fn calculate(
+    workspace: &Path,
+    kind: EvaluatorKind,
+) -> Result<EvaluatorSourceInventory, std::io::Error> {
+    validate_completeness(workspace)?;
+    let inputs = read_declared_inputs(workspace, kind)?;
+    let document = document_from_named_bytes(kind, &inputs)?;
+    let digest = digest_document(kind, &document)?;
+    let names = inputs.iter().map(|(name, _)| name.clone()).collect();
+    let paths = inputs
+        .iter()
+        .map(|(name, _)| workspace.join(name))
+        .collect();
+    Ok(EvaluatorSourceInventory {
+        digest,
+        document,
+        names,
+        paths,
+    })
+}
+
+/// Calculates an identity from named source bytes for inventory tests.
+#[cfg(test)]
+pub fn digest_named_bytes(
+    kind: EvaluatorKind,
+    inputs: &[(String, Vec<u8>)],
+) -> Result<[u8; 32], std::io::Error> {
+    let document = document_from_named_bytes(kind, inputs)?;
+    digest_document(kind, &document)
+}
+
+/// Validates one generated document and recomputes its digest.
+pub fn digest_document(kind: EvaluatorKind, bytes: &[u8]) -> Result<[u8; 32], std::io::Error> {
+    let document = readback_document(kind, bytes)?;
+    let mut hasher = Sha256::new();
+    hasher.update(domain(kind));
+    append_frame(&mut hasher, &document.schema_version.to_le_bytes());
+    append_frame(&mut hasher, document.evaluator.as_bytes());
+    for entry in document.entries {
+        append_frame(&mut hasher, entry.path.as_bytes());
+        append_frame(&mut hasher, &decode_sha256(&entry.sha256)?);
+        append_frame(&mut hasher, &entry.bytes.to_le_bytes());
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn validate_completeness(workspace: &Path) -> Result<(), std::io::Error> {
+    let metric = declared_names(EvaluatorKind::Metric)?;
+    let gates = declared_names(EvaluatorKind::Gate)?;
+    let declared = metric.union(&gates).cloned().collect::<BTreeSet<_>>();
+    let discovered = discover_production_inputs(workspace)?;
+    if declared == discovered {
+        return Ok(());
+    }
+    let missing = declared
+        .difference(&discovered)
+        .cloned()
+        .collect::<Vec<_>>();
+    let extra = discovered
+        .difference(&declared)
+        .cloned()
+        .collect::<Vec<_>>();
+    Err(std::io::Error::other(format!(
+        "the evaluator source inventory differs: missing={missing:?}, extra={extra:?}"
+    )))
+}
+
+fn declared_names(kind: EvaluatorKind) -> Result<BTreeSet<String>, std::io::Error> {
+    let inputs = declared(kind);
+    let names = inputs
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect::<BTreeSet<_>>();
+    if names.len() != inputs.len() {
+        return Err(std::io::Error::other(
+            "an evaluator inventory contains a repeated path",
+        ));
+    }
+    if inputs.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(std::io::Error::other(
+            "an evaluator inventory is not in canonical path order",
+        ));
+    }
+    Ok(names)
+}
+
+fn discover_production_inputs(workspace: &Path) -> Result<BTreeSet<String>, std::io::Error> {
+    let mut discovered = Vec::new();
+    for root in source_roots(workspace) {
+        if root.is_dir() {
+            collect_files(&root, workspace, &mut discovered)?;
+        } else {
+            inspect_file(&root, workspace, &mut discovered)?;
+        }
+    }
+    let unique = discovered.iter().cloned().collect::<BTreeSet<_>>();
+    if unique.len() != discovered.len() {
+        return Err(std::io::Error::other(
+            "the evaluator source roots discover a repeated path",
+        ));
+    }
+    Ok(unique)
+}
+
+fn collect_files(
+    directory: &Path,
+    workspace: &Path,
+    discovered: &mut Vec<String>,
+) -> Result<(), std::io::Error> {
+    reject_symlink(directory)?;
+    for entry in std::fs::read_dir(directory)? {
+        let path = entry?.path();
+        reject_symlink(&path)?;
+        if path.is_dir() {
+            if path.file_name().is_none_or(|name| name != "tests") {
+                collect_files(&path, workspace, discovered)?;
+            }
+        } else if is_production_rust(&path) {
+            inspect_file(&path, workspace, discovered)?;
+        }
+    }
+    Ok(())
+}
+
+fn inspect_file(
+    path: &Path,
+    workspace: &Path,
+    discovered: &mut Vec<String>,
+) -> Result<(), std::io::Error> {
+    reject_symlink(path)?;
+    validate_owned_file(workspace, path)?;
+    let relative = path.strip_prefix(workspace).map_err(io_other)?;
+    discovered.push(portable(relative));
+    Ok(())
+}
+
+fn read_declared_inputs(
+    workspace: &Path,
+    kind: EvaluatorKind,
+) -> Result<Vec<(String, Vec<u8>)>, std::io::Error> {
+    declared(kind)
+        .iter()
+        .map(|name| {
+            let path = workspace.join(name);
+            validate_owned_file(workspace, &path)?;
+            let mut bytes = Vec::new();
+            std::fs::File::open(path)?.read_to_end(&mut bytes)?;
+            Ok(((*name).to_owned(), bytes))
+        })
+        .collect()
+}
+
+fn validate_owned_file(workspace: &Path, path: &Path) -> Result<(), std::io::Error> {
+    reject_symlink(path)?;
+    let canonical_workspace = std::fs::canonicalize(workspace)?;
+    let canonical = std::fs::canonicalize(path)?;
+    if !canonical.starts_with(&canonical_workspace) || !canonical.is_file() {
+        return Err(std::io::Error::other(
+            "an evaluator source is outside the workspace root",
+        ));
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<(), std::io::Error> {
+    if std::fs::symlink_metadata(path)?.file_type().is_symlink() {
+        Err(std::io::Error::other(
+            "the evaluator source inventory does not permit symlinks",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn document_from_named_bytes(
+    kind: EvaluatorKind,
+    inputs: &[(String, Vec<u8>)],
+) -> Result<Vec<u8>, std::io::Error> {
+    let expected = declared_names(kind)?;
+    let mut ordered = inputs.to_vec();
+    ordered.sort_by(|left, right| left.0.cmp(&right.0));
+    let names = ordered
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<BTreeSet<_>>();
+    if names != expected || names.len() != ordered.len() {
+        return Err(std::io::Error::other(
+            "the evaluator byte inventory does not match its declared paths",
+        ));
+    }
+    let document = SourceDocument {
+        schema_version: DOCUMENT_SCHEMA_VERSION,
+        evaluator: label(kind).to_owned(),
+        entries: ordered
+            .into_iter()
+            .map(|(path, bytes)| SourceEntry {
+                path,
+                sha256: sha256_hex(&bytes),
+                bytes: bytes.len() as u64,
+            })
+            .collect(),
+    };
+    let bytes = serde_json::to_vec(&document).map_err(io_other)?;
+    readback_document(kind, &bytes).map(|_| bytes)
+}
+
+fn readback_document(kind: EvaluatorKind, bytes: &[u8]) -> Result<SourceDocument, std::io::Error> {
+    let document: SourceDocument = serde_json::from_slice(bytes).map_err(io_other)?;
+    let canonical = serde_json::to_vec(&document).map_err(io_other)?;
+    let names = document
+        .entries
+        .iter()
+        .map(|entry| entry.path.clone())
+        .collect::<BTreeSet<_>>();
+    let valid = canonical == bytes
+        && document.schema_version == DOCUMENT_SCHEMA_VERSION
+        && document.evaluator == label(kind)
+        && names == declared_names(kind)?
+        && names.len() == document.entries.len()
+        && document
+            .entries
+            .windows(2)
+            .all(|pair| pair[0].path < pair[1].path)
+        && document.entries.iter().all(|entry| {
+            entry.bytes > 0
+                && entry.sha256.len() == 64
+                && entry
+                    .sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    if valid {
+        Ok(document)
+    } else {
+        Err(std::io::Error::other(
+            "the evaluator source document is not canonical and complete",
+        ))
+    }
+}
+
+fn declared(kind: EvaluatorKind) -> &'static [&'static str] {
+    match kind {
+        EvaluatorKind::Metric => &METRIC_PRODUCTION_INPUTS,
+        EvaluatorKind::Gate => &GATE_PRODUCTION_INPUTS,
+    }
+}
+
+fn domain(kind: EvaluatorKind) -> &'static [u8] {
+    match kind {
+        EvaluatorKind::Metric => METRIC_DOMAIN,
+        EvaluatorKind::Gate => GATE_DOMAIN,
+    }
+}
+
+fn label(kind: EvaluatorKind) -> &'static str {
+    match kind {
+        EvaluatorKind::Metric => "metric",
+        EvaluatorKind::Gate => "hard_gates",
+    }
+}
+
+fn append_frame(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn decode_sha256(value: &str) -> Result<[u8; 32], std::io::Error> {
+    let mut bytes = [0_u8; 32];
+    for (index, output) in bytes.iter_mut().enumerate() {
+        let start = index * 2;
+        *output = u8::from_str_radix(&value[start..start + 2], 16).map_err(io_other)?;
+    }
+    Ok(bytes)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn is_production_rust(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    path.extension().is_some_and(|extension| extension == "rs")
+        && name != "tests.rs"
+        && !name.ends_with("_tests.rs")
+        && !name.starts_with("test_")
+}
+
+fn portable(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn io_other(error: impl ToString) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}

--- a/tools/flight-tune/src/error.rs
+++ b/tools/flight-tune/src/error.rs
@@ -25,6 +25,12 @@ pub enum TuneError {
         /// The validation detail.
         detail: String,
     },
+    /// An evaluator identity is not the one the frozen plan states.
+    #[error("evaluator identity rejected: {detail}")]
+    EvaluatorIdentityChanged {
+        /// The rejection detail.
+        detail: String,
+    },
     /// A hard gate, metric, aggregate, or paired comparison is not valid.
     #[error("score validation failed: {detail}")]
     InvalidScore {

--- a/tools/flight-tune/src/flight_quality.rs
+++ b/tools/flight-tune/src/flight_quality.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod gates;
+mod identity;
 mod metrics;
 mod telemetry;
 
@@ -11,6 +12,9 @@ pub use config::{
     WindPlan,
 };
 pub use gates::FlightQualityGateEvaluator;
+pub use identity::{
+    EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION, GATE_IMPLEMENTATION_ID, METRIC_IMPLEMENTATION_ID,
+};
 pub use metrics::{FlightQualityMetricEvaluator, FlightQualityReport};
 pub use telemetry::CanonicalTelemetryKey;
 

--- a/tools/flight-tune/src/flight_quality/config.rs
+++ b/tools/flight-tune/src/flight_quality/config.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::identity::digest_bytes;
+use crate::flight_quality::identity::{EvaluatorClass, evaluator_identity};
 use crate::{ArtifactIdentity, EvaluatorError};
 
 /// The one hard gate every campaign must evaluate, and evaluate first.
@@ -226,56 +226,13 @@ impl FlightQualityMetricConfig {
 pub(super) fn gate_identity(
     config: &FlightQualityGateConfig,
 ) -> Result<ArtifactIdentity, EvaluatorError> {
-    implementation_identity(
-        "pilotage-flight-quality-streaming-gates",
-        config,
-        &[
-            include_str!("config.rs"),
-            include_str!("gates.rs"),
-            include_str!("telemetry.rs"),
-        ],
-    )
+    evaluator_identity(EvaluatorClass::Gate, config)
 }
 
 pub(super) fn metric_identity(
     config: &FlightQualityMetricConfig,
 ) -> Result<ArtifactIdentity, EvaluatorError> {
-    implementation_identity(
-        "pilotage-flight-quality-streaming-metrics",
-        config,
-        &[
-            include_str!("config.rs"),
-            include_str!("metrics.rs"),
-            include_str!("telemetry.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/control.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/release.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/response.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/signal.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/series.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/sample.rs"),
-            include_str!("../../../../crates/pilotage-flight-quality/src/error.rs"),
-        ],
-    )
-}
-
-fn implementation_identity<T: Serialize>(
-    id: &'static str,
-    config: &T,
-    sources: &[&str],
-) -> Result<ArtifactIdentity, EvaluatorError> {
-    let config = serde_json::to_vec(config)
-        .map_err(|error| invalid(format!("cannot encode evaluator configuration: {error}")))?;
-    let mut bytes = Vec::with_capacity(config.len());
-    append_document(&mut bytes, &config);
-    for source in sources {
-        append_document(&mut bytes, source.as_bytes());
-    }
-    ArtifactIdentity::new(id, digest_bytes(&bytes)).map_err(|error| invalid(error.to_string()))
-}
-
-fn append_document(output: &mut Vec<u8>, document: &[u8]) {
-    output.extend_from_slice(&(document.len() as u64).to_le_bytes());
-    output.extend_from_slice(document);
+    evaluator_identity(EvaluatorClass::Metric, config)
 }
 
 fn active_weight(weights: FlightQualityWeights, scenario: &FlightQualityScenario) -> f64 {

--- a/tools/flight-tune/src/flight_quality/identity.rs
+++ b/tools/flight-tune/src/flight_quality/identity.rs
@@ -1,0 +1,355 @@
+//! The complete production-input identity of the flight-quality evaluators.
+//!
+//! The build script inventories every production source of the metric
+//! evaluator and of the hard-gate evaluator, writes one canonical
+//! schema-versioned document for each, and embeds each document together with
+//! its digest. This module reads a document back, recomputes the digest from
+//! the embedded bytes, and binds the result to the exact evaluator
+//! configuration.
+//!
+//! Two values come out: the metric implementation identity and the hard-gate
+//! implementation identity. A production source that changes changes the
+//! identity of each evaluator that declares it. A test source cannot enter an
+//! identity, because the inventory refuses a test path. Order cannot change an
+//! identity, because the canonical document sorts its entries and the digest
+//! frames each length. One inventory cannot stand in for the other, because
+//! each document names its evaluator and each digest uses its own domain.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+use std::collections::BTreeSet;
+
+use pilotage_trial::Digest;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::{ArtifactIdentity, EvaluatorError};
+
+include!(concat!(env!("OUT_DIR"), "/evaluator_source_identity.rs"));
+
+/// The stable name of the metric implementation identity.
+pub const METRIC_IMPLEMENTATION_ID: &str = "pilotage-flight-quality-streaming-metrics-v2";
+
+/// The stable name of the hard-gate implementation identity.
+pub const GATE_IMPLEMENTATION_ID: &str = "pilotage-flight-quality-streaming-gates-v2";
+
+/// The supported evaluator implementation document schema.
+pub const EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION: u16 = 1;
+
+/// The schema version of the embedded source-inventory documents.
+const SOURCE_DOCUMENT_SCHEMA_VERSION: u16 = 1;
+
+/// The domain the build script separates the metric inventory with.
+///
+/// The value has to match the build script byte for byte. A readback that
+/// recomputes the digest under another domain would accept a document the
+/// build never wrote.
+const METRIC_SOURCE_DOMAIN: &[u8] = b"flight-tune-metric-source-document-v1\0";
+
+/// The domain the build script separates the hard-gate inventory with.
+const GATE_SOURCE_DOMAIN: &[u8] = b"flight-tune-gate-source-document-v1\0";
+
+/// The domain that separates one metric implementation document.
+const METRIC_IMPLEMENTATION_DOMAIN: &[u8] = b"pilotage-flight-quality-streaming-metrics-v2\0";
+
+/// The domain that separates one hard-gate implementation document.
+const GATE_IMPLEMENTATION_DOMAIN: &[u8] = b"pilotage-flight-quality-streaming-gates-v2\0";
+
+/// The repository roots that can hold one evaluator production source.
+const OWNED_ROOTS: [&str; 5] = [
+    "crates/pilotage-flight-quality/src/",
+    "tools/flight-tune/build.rs",
+    "tools/flight-tune/build_support/evaluator_source_identity.rs",
+    "tools/flight-tune/src/flight_quality.rs",
+    "tools/flight-tune/src/flight_quality/",
+];
+
+/// One flight-quality evaluator class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EvaluatorClass {
+    /// The continuous metric evaluator.
+    Metric,
+    /// The streaming hard-gate evaluator.
+    Gate,
+}
+
+/// One production evaluator source and its exact content identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluatorSourceEntry {
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluatorSourceDocument {
+    schema_version: u16,
+    evaluator: String,
+    entries: Vec<EvaluatorSourceEntry>,
+}
+
+/// The canonical document that one evaluator identity is the digest of.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EvaluatorImplementationDocument {
+    schema_version: u16,
+    evaluator: String,
+    source_document_digest: Digest,
+    sources: Vec<EvaluatorSourceEntry>,
+    configuration: Digest,
+}
+
+/// Binds one evaluator implementation to its exact configuration document.
+pub(super) fn evaluator_identity<T: Serialize>(
+    class: EvaluatorClass,
+    config: &T,
+) -> Result<ArtifactIdentity, EvaluatorError> {
+    let sources = read_back_sources(class)?;
+    let document = EvaluatorImplementationDocument {
+        schema_version: EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION,
+        evaluator: label(class).to_owned(),
+        source_document_digest: Digest::from_bytes(embedded_digest(class)),
+        sources,
+        configuration: configuration_digest(config)?,
+    };
+    document.identity(class)
+}
+
+impl EvaluatorImplementationDocument {
+    fn identity(&self, class: EvaluatorClass) -> Result<ArtifactIdentity, EvaluatorError> {
+        self.validate(class)?;
+        let bytes = serde_json::to_vec(self).map_err(|error| {
+            invalid(format!(
+                "cannot encode the evaluator implementation document: {error}"
+            ))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(implementation_domain(class));
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        ArtifactIdentity::new(
+            implementation_id(class),
+            Digest::from_bytes(hasher.finalize().into()),
+        )
+        .map_err(|error| invalid(error.to_string()))
+    }
+
+    fn validate(&self, class: EvaluatorClass) -> Result<(), EvaluatorError> {
+        if self.schema_version != EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION
+            || self.evaluator != label(class)
+        {
+            return Err(invalid(
+                "the evaluator implementation document has another schema",
+            ));
+        }
+        if self.source_document_digest.is_zero() || self.configuration.is_zero() {
+            return Err(invalid(
+                "the evaluator implementation document has a zero digest",
+            ));
+        }
+        validate_entries(&self.sources)
+    }
+}
+
+/// Reads one embedded inventory back and recomputes its digest.
+///
+/// The build script writes the document and its digest as two independent
+/// constants. Recomputing one from the other is what makes a changed
+/// production source a changed identity instead of a stale constant.
+fn read_back_sources(class: EvaluatorClass) -> Result<Vec<EvaluatorSourceEntry>, EvaluatorError> {
+    let bytes = embedded_document(class).as_bytes();
+    let parsed: EvaluatorSourceDocument = serde_json::from_slice(bytes).map_err(|error| {
+        invalid(format!(
+            "cannot read the evaluator source inventory back: {error}"
+        ))
+    })?;
+    if parsed.schema_version != SOURCE_DOCUMENT_SCHEMA_VERSION || parsed.evaluator != label(class) {
+        return Err(invalid("the evaluator source inventory has another schema"));
+    }
+    validate_entries(&parsed.entries)?;
+    let canonical = serde_json::to_vec(&parsed).map_err(|error| {
+        invalid(format!(
+            "cannot encode the evaluator source inventory: {error}"
+        ))
+    })?;
+    if canonical != bytes {
+        return Err(invalid("the evaluator source inventory is not canonical"));
+    }
+    if source_document_digest(class, &parsed)? != embedded_digest(class) {
+        return Err(invalid(
+            "the evaluator source inventory does not match its embedded digest",
+        ));
+    }
+    Ok(parsed.entries)
+}
+
+/// The digest the build script computes over one canonical inventory.
+///
+/// The build script frames each field rather than the encoded document. A
+/// readback that hashed the JSON bytes instead would refuse every inventory
+/// the build wrote.
+fn source_document_digest(
+    class: EvaluatorClass,
+    document: &EvaluatorSourceDocument,
+) -> Result<[u8; 32], EvaluatorError> {
+    let mut hasher = Sha256::new();
+    hasher.update(source_domain(class));
+    append_frame(&mut hasher, &document.schema_version.to_le_bytes());
+    append_frame(&mut hasher, document.evaluator.as_bytes());
+    for entry in &document.entries {
+        append_frame(&mut hasher, entry.path.as_bytes());
+        append_frame(&mut hasher, &decode_sha256(&entry.sha256)?);
+        append_frame(&mut hasher, &entry.bytes.to_le_bytes());
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn append_frame(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn decode_sha256(value: &str) -> Result<[u8; 32], EvaluatorError> {
+    let mut bytes = [0_u8; 32];
+    for (index, output) in bytes.iter_mut().enumerate() {
+        let start = index * 2;
+        let pair = value
+            .get(start..start + 2)
+            .ok_or_else(|| invalid("an inventory entry has a short content identity"))?;
+        *output = u8::from_str_radix(pair, 16)
+            .map_err(|error| invalid(format!("an inventory entry is not hexadecimal: {error}")))?;
+    }
+    Ok(bytes)
+}
+
+fn configuration_digest<T: Serialize>(config: &T) -> Result<Digest, EvaluatorError> {
+    let bytes = serde_json::to_vec(config)
+        .map_err(|error| invalid(format!("cannot encode evaluator configuration: {error}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(&bytes);
+    Ok(Digest::from_bytes(hasher.finalize().into()))
+}
+
+/// Rejects an inventory that repeats, reorders, or names a test source.
+fn validate_entries(entries: &[EvaluatorSourceEntry]) -> Result<(), EvaluatorError> {
+    if entries.is_empty() {
+        return Err(invalid("the evaluator source inventory is empty"));
+    }
+    let names = entries
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<BTreeSet<_>>();
+    if names.len() != entries.len() {
+        return Err(invalid("the evaluator source inventory repeats a path"));
+    }
+    if entries.windows(2).any(|pair| pair[0].path >= pair[1].path) {
+        return Err(invalid(
+            "the evaluator source inventory is not in canonical path order",
+        ));
+    }
+    for entry in entries {
+        validate_entry(entry)?;
+    }
+    Ok(())
+}
+
+fn validate_entry(entry: &EvaluatorSourceEntry) -> Result<(), EvaluatorError> {
+    if is_test_path(&entry.path) {
+        return Err(invalid(format!(
+            "a test source entered the production identity: {}",
+            entry.path
+        )));
+    }
+    if !is_owned_path(&entry.path) {
+        return Err(invalid(format!(
+            "an inventory path is not an owned source: {}",
+            entry.path
+        )));
+    }
+    let hex_is_valid = entry.sha256.len() == 32 * 2
+        && entry
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if !hex_is_valid || entry.bytes == 0 {
+        return Err(invalid(format!(
+            "an inventory entry has no content identity: {}",
+            entry.path
+        )));
+    }
+    Ok(())
+}
+
+/// Whether one inventory path stays inside the owned evaluator roots.
+fn is_owned_path(path: &str) -> bool {
+    path.ends_with(".rs")
+        && !path.contains("..")
+        && !path.contains('\\')
+        && OWNED_ROOTS.iter().any(|root| path.starts_with(root))
+}
+
+/// Whether one inventory path names a test source.
+///
+/// The build script excludes the same names when it discovers inputs. This
+/// check is the readback half: a document that reached the binary with a test
+/// path in it cannot become a production identity.
+fn is_test_path(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    path.split('/').any(|part| part == "tests")
+        || name == "tests.rs"
+        || name.ends_with("_tests.rs")
+        || name.starts_with("test_")
+}
+
+const fn label(class: EvaluatorClass) -> &'static str {
+    match class {
+        EvaluatorClass::Metric => "metric",
+        EvaluatorClass::Gate => "hard_gates",
+    }
+}
+
+const fn implementation_id(class: EvaluatorClass) -> &'static str {
+    match class {
+        EvaluatorClass::Metric => METRIC_IMPLEMENTATION_ID,
+        EvaluatorClass::Gate => GATE_IMPLEMENTATION_ID,
+    }
+}
+
+const fn source_domain(class: EvaluatorClass) -> &'static [u8] {
+    match class {
+        EvaluatorClass::Metric => METRIC_SOURCE_DOMAIN,
+        EvaluatorClass::Gate => GATE_SOURCE_DOMAIN,
+    }
+}
+
+const fn implementation_domain(class: EvaluatorClass) -> &'static [u8] {
+    match class {
+        EvaluatorClass::Metric => METRIC_IMPLEMENTATION_DOMAIN,
+        EvaluatorClass::Gate => GATE_IMPLEMENTATION_DOMAIN,
+    }
+}
+
+const fn embedded_document(class: EvaluatorClass) -> &'static str {
+    match class {
+        EvaluatorClass::Metric => METRIC_SOURCE_DOCUMENT,
+        EvaluatorClass::Gate => GATE_SOURCE_DOCUMENT,
+    }
+}
+
+const fn embedded_digest(class: EvaluatorClass) -> [u8; 32] {
+    match class {
+        EvaluatorClass::Metric => METRIC_SOURCE_DIGEST,
+        EvaluatorClass::Gate => GATE_SOURCE_DIGEST,
+    }
+}
+
+fn invalid(detail: impl Into<String>) -> EvaluatorError {
+    EvaluatorError::new(detail)
+}
+
+#[cfg(test)]
+#[path = "identity/tests.rs"]
+mod tests;

--- a/tools/flight-tune/src/flight_quality/identity/tests.rs
+++ b/tools/flight-tune/src/flight_quality/identity/tests.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use super::{
+    EvaluatorClass, EvaluatorSourceEntry, GATE_IMPLEMENTATION_ID, METRIC_IMPLEMENTATION_ID,
+    embedded_document, read_back_sources, validate_entries,
+};
+
+#[test]
+fn each_embedded_inventory_matches_its_embedded_digest() {
+    for class in [EvaluatorClass::Metric, EvaluatorClass::Gate] {
+        read_back_sources(class).expect("the build inventory reads back");
+    }
+}
+
+#[test]
+fn the_metric_inventory_names_every_angular_and_timing_source() {
+    let entries = read_back_sources(EvaluatorClass::Metric).expect("metric inventory");
+    let paths = entries
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<Vec<_>>();
+
+    for expected in [
+        "crates/pilotage-flight-quality/src/angular.rs",
+        "crates/pilotage-flight-quality/src/angular_release.rs",
+        "crates/pilotage-flight-quality/src/collective.rs",
+        "crates/pilotage-flight-quality/src/response.rs",
+        "crates/pilotage-flight-quality/src/series.rs",
+        "crates/pilotage-flight-quality/src/vocabulary.rs",
+    ] {
+        assert!(paths.contains(&expected), "{expected} is not bound");
+    }
+}
+
+#[test]
+fn the_gate_inventory_holds_no_metric_only_source() {
+    let entries = read_back_sources(EvaluatorClass::Gate).expect("gate inventory");
+    let paths = entries
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(paths.contains(&"crates/pilotage-flight-quality/src/gate.rs"));
+    assert!(!paths.contains(&"crates/pilotage-flight-quality/src/angular.rs"));
+    assert!(!paths.contains(&"tools/flight-tune/src/flight_quality/metrics.rs"));
+}
+
+#[test]
+fn one_inventory_cannot_stand_in_for_the_other() {
+    assert_ne!(
+        embedded_document(EvaluatorClass::Metric),
+        embedded_document(EvaluatorClass::Gate)
+    );
+    assert_ne!(METRIC_IMPLEMENTATION_ID, GATE_IMPLEMENTATION_ID);
+
+    let metric = read_back_sources(EvaluatorClass::Metric).expect("metric inventory");
+    let gates = read_back_sources(EvaluatorClass::Gate).expect("gate inventory");
+    assert_ne!(metric, gates);
+}
+
+#[test]
+fn a_test_source_cannot_enter_a_production_identity() {
+    for path in [
+        "tools/flight-tune/src/flight_quality/tests.rs",
+        "tools/flight-tune/src/flight_quality/tests/metrics.rs",
+        "crates/pilotage-flight-quality/src/angular_tests.rs",
+        "crates/pilotage-flight-quality/src/test_trace.rs",
+    ] {
+        let error = validate_entries(&[entry(path)]).expect_err("a test path is refused");
+        assert!(
+            error.to_string().contains("test source"),
+            "{path} was refused for another reason: {error}"
+        );
+    }
+}
+
+#[test]
+fn a_source_outside_the_owned_roots_is_refused() {
+    for path in [
+        "tools/flight-tune/src/journal.rs",
+        "crates/pilotage-trial/src/lib.rs",
+        "crates/pilotage-flight-quality/src/../../../etc/passwd.rs",
+    ] {
+        let error = validate_entries(&[entry(path)]).expect_err("an unowned path is refused");
+        assert!(
+            error.to_string().contains("owned source"),
+            "{path} was refused for another reason: {error}"
+        );
+    }
+}
+
+#[test]
+fn a_repeated_path_is_refused() {
+    let path = "crates/pilotage-flight-quality/src/angular.rs";
+    let error =
+        validate_entries(&[entry(path), entry(path)]).expect_err("a repeated path is refused");
+
+    assert!(error.to_string().contains("repeats a path"));
+}
+
+#[test]
+fn an_unordered_inventory_is_refused() {
+    let entries = [
+        entry("crates/pilotage-flight-quality/src/control.rs"),
+        entry("crates/pilotage-flight-quality/src/angular.rs"),
+    ];
+    let error = validate_entries(&entries).expect_err("an unordered inventory is refused");
+
+    assert!(error.to_string().contains("canonical path order"));
+}
+
+#[test]
+fn an_entry_without_a_content_identity_is_refused() {
+    let mut short = entry("crates/pilotage-flight-quality/src/angular.rs");
+    short.sha256.truncate(63);
+    let mut empty = entry("crates/pilotage-flight-quality/src/angular.rs");
+    empty.bytes = 0;
+
+    for candidate in [short, empty] {
+        let error = validate_entries(&[candidate]).expect_err("an empty entry is refused");
+        assert!(error.to_string().contains("no content identity"));
+    }
+}
+
+#[test]
+fn an_empty_inventory_is_refused() {
+    let error = validate_entries(&[]).expect_err("an empty inventory is refused");
+
+    assert!(error.to_string().contains("is empty"));
+}
+
+fn entry(path: &str) -> EvaluatorSourceEntry {
+    EvaluatorSourceEntry {
+        path: path.to_owned(),
+        sha256: "0".repeat(64),
+        bytes: 1,
+    }
+}

--- a/tools/flight-tune/src/identity.rs
+++ b/tools/flight-tune/src/identity.rs
@@ -50,6 +50,78 @@ impl ArtifactIdentity {
     }
 }
 
+/// The exact evaluator implementations one session is frozen to.
+///
+/// The metric evaluator and the hard-gate evaluator have separate production
+/// inventories, so the two identities cannot hold the same value. A pair that
+/// does would let one evaluator stand in for the other.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluatorIdentities {
+    /// The continuous metric implementation and its configuration.
+    pub metric: ArtifactIdentity,
+    /// The streaming hard gate implementation and its configuration.
+    pub hard_gates: ArtifactIdentity,
+}
+
+impl EvaluatorIdentities {
+    /// Creates one validated evaluator identity pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when one evaluator identity is not valid, or when
+    /// the two identities cannot describe separate evaluators.
+    pub fn new(metric: ArtifactIdentity, hard_gates: ArtifactIdentity) -> Result<Self, TuneError> {
+        let identities = Self { metric, hard_gates };
+        identities.validate()?;
+        Ok(identities)
+    }
+
+    /// Rejects a pair that cannot describe two separate evaluators.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when one evaluator identity is not valid, or when
+    /// the two identities share a name or a digest.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        self.metric.validate()?;
+        self.hard_gates.validate()?;
+        if self.metric.id == self.hard_gates.id || self.metric.digest == self.hard_gates.digest {
+            return Err(TuneError::EvaluatorIdentityChanged {
+                detail: "one evaluator identity stands in for the other".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Rejects evaluators that are not the ones the plan froze.
+    ///
+    /// A restart, a retry, a suite comparison, a promotion, and a final
+    /// qualification all read the frozen plan first. This check runs before
+    /// any of them, so a rebuilt evaluator cannot reach a simulator, a
+    /// process, a vehicle, or a journal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when one pair is not valid, or when the two pairs
+    /// differ.
+    pub fn require_frozen(&self, frozen: &Self) -> Result<(), TuneError> {
+        self.validate()?;
+        frozen.validate()?;
+        if self.metric != frozen.metric {
+            return Err(TuneError::EvaluatorIdentityChanged {
+                detail: "the metric evaluator is not the one the plan froze".to_owned(),
+            });
+        }
+        if self.hard_gates != frozen.hard_gates {
+            return Err(TuneError::EvaluatorIdentityChanged {
+                detail: "the hard gate evaluator is not the one the plan froze".to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
 /// The immutable source identity for all candidates in one session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -110,7 +182,17 @@ pub struct RuntimeIdentities {
 }
 
 impl RuntimeIdentities {
+    /// Returns the evaluator identities this session is frozen to.
+    #[must_use]
+    pub fn evaluator_identities(&self) -> EvaluatorIdentities {
+        EvaluatorIdentities {
+            metric: self.metric.clone(),
+            hard_gates: self.hard_gates.clone(),
+        }
+    }
+
     pub(crate) fn validate(&self) -> Result<(), TuneError> {
+        self.evaluator_identities().validate()?;
         for identity in [
             &self.harness_build,
             &self.strategy,

--- a/tools/flight-tune/src/journal.rs
+++ b/tools/flight-tune/src/journal.rs
@@ -384,6 +384,12 @@ impl Journal {
     ) -> Result<Self, TuneError> {
         let stored_entries = storage::load_entries(&storage)?;
         let (entry_digests, entries): (Vec<_>, Vec<_>) = stored_entries.into_iter().unzip();
+        if let Some(frozen) = entries.first() {
+            session
+                .runtimes
+                .evaluator_identities()
+                .require_frozen(&frozen.session.runtimes.evaluator_identities())?;
+        }
         if entries.first().map(|entry| &entry.session) != Some(&session)
             || storage::read_stage(&storage, session.stage_digest)? != stage
         {

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -40,14 +40,15 @@ pub use campaign_config::{
 pub use contract_api::*;
 pub use error::TuneError;
 pub use flight_quality::{
-    CanonicalTelemetryKey, FlightQualityGate, FlightQualityGateConfig, FlightQualityGateEvaluator,
-    FlightQualityMetricConfig, FlightQualityMetricEvaluator, FlightQualityReport,
-    FlightQualityScales, FlightQualityScenario, FlightQualityWeights, MANDATORY_CRASH_GATE_ID,
-    ReleasePlan, StepPlan, WindPlan,
+    CanonicalTelemetryKey, EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION, FlightQualityGate,
+    FlightQualityGateConfig, FlightQualityGateEvaluator, FlightQualityMetricConfig,
+    FlightQualityMetricEvaluator, FlightQualityReport, FlightQualityScales, FlightQualityScenario,
+    FlightQualityWeights, GATE_IMPLEMENTATION_ID, MANDATORY_CRASH_GATE_ID,
+    METRIC_IMPLEMENTATION_ID, ReleasePlan, StepPlan, WindPlan,
 };
 pub use identity::{
-    ArtifactIdentity, CandidateLineage, RuntimeIdentities, scenario_engine_identity,
-    scenario_runtime_identity,
+    ArtifactIdentity, CandidateLineage, EvaluatorIdentities, RuntimeIdentities,
+    scenario_engine_identity, scenario_runtime_identity,
 };
 pub use journal::{
     ATTEMPT_PROJECTION_SCHEMA_VERSION, AUTHENTICATED_EVALUATION_PROOF_SCHEMA_VERSION,

--- a/tools/flight-tune/tests/evaluator_identity.rs
+++ b/tools/flight-tune/tests/evaluator_identity.rs
@@ -1,0 +1,293 @@
+//! The complete production-input identity of the flight-quality evaluators.
+//!
+//! These tests run the same inventory code the build script runs, against
+//! copies of the real workspace sources. A guard that only read the embedded
+//! constant could not tell a stale constant from a live one; a guard that runs
+//! the inventory over a tree it can change can.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// The build script is the only production caller, so parts of the shared
+// inventory module are unused in this test crate.
+#[path = "../build_support/evaluator_source_identity.rs"]
+#[allow(dead_code)]
+mod evaluator_source_identity;
+
+use evaluator_source_identity::{
+    EvaluatorKind, GATE_PRODUCTION_INPUTS, METRIC_PRODUCTION_INPUTS, calculate, digest_document,
+    digest_named_bytes,
+};
+
+/// The metric source that measures yaw and angular step response.
+const ANGULAR_SOURCE: &str = "crates/pilotage-flight-quality/src/angular.rs";
+
+/// The metric source that measures delay, rise, and settling windows.
+///
+/// The timing windows and the event markers that bound them live with the step
+/// response rules rather than in a module of their own.
+const TIMING_SOURCE: &str = "crates/pilotage-flight-quality/src/response.rs";
+
+/// One copy of the workspace evaluator sources that a test can change.
+struct SourceTree {
+    root: PathBuf,
+}
+
+impl SourceTree {
+    fn copy() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "pilotage-468-evaluator-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        if root.exists() {
+            fs::remove_dir_all(&root).expect("clear the previous source tree");
+        }
+        let workspace = workspace_root();
+        for relative in [
+            "tools/flight-tune/build.rs",
+            "tools/flight-tune/build_support/evaluator_source_identity.rs",
+            "tools/flight-tune/src/flight_quality.rs",
+        ] {
+            copy_file(&workspace, &root, Path::new(relative));
+        }
+        for relative in [
+            "tools/flight-tune/src/flight_quality",
+            "crates/pilotage-flight-quality/src",
+        ] {
+            copy_directory(&workspace.join(relative), &root.join(relative));
+        }
+        Self { root }
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+
+    fn digest(&self, kind: EvaluatorKind) -> [u8; 32] {
+        calculate(&self.root, kind)
+            .expect("calculate the evaluator source identity")
+            .digest
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create a source directory");
+        }
+        fs::write(path, contents).expect("write a source");
+    }
+
+    fn remove(&self, relative: &str) {
+        fs::remove_file(self.root.join(relative)).expect("remove a source");
+    }
+
+    fn append(&self, relative: &str, text: &str) {
+        let path = self.root.join(relative);
+        let mut contents = fs::read_to_string(&path).expect("read a source");
+        contents.push_str(text);
+        fs::write(path, contents).expect("rewrite a source");
+    }
+}
+
+impl Drop for SourceTree {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.root).ok();
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn copy_file(from_root: &Path, to_root: &Path, relative: &Path) {
+    let target = to_root.join(relative);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).expect("create a source directory");
+    }
+    fs::copy(from_root.join(relative), target).expect("copy a source");
+}
+
+fn copy_directory(from: &Path, to: &Path) {
+    fs::create_dir_all(to).expect("create a source directory");
+    for entry in fs::read_dir(from).expect("read a source directory") {
+        let path = entry.expect("read a source entry").path();
+        let name = path.file_name().expect("name a source entry");
+        if path.is_dir() {
+            copy_directory(&path, &to.join(name));
+        } else {
+            fs::copy(&path, to.join(name)).expect("copy a source");
+        }
+    }
+}
+
+fn named_bytes(inputs: &[&str]) -> Vec<(String, Vec<u8>)> {
+    inputs
+        .iter()
+        .map(|name| {
+            (
+                (*name).to_owned(),
+                format!("contents of {name}").into_bytes(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn the_metric_inventory_names_every_production_metric_source_once() {
+    let tree = SourceTree::copy();
+
+    let inventory = calculate(tree.path(), EvaluatorKind::Metric).expect("metric inventory");
+
+    assert_eq!(inventory.names.len(), METRIC_PRODUCTION_INPUTS.len());
+    let unique = inventory.names.iter().collect::<BTreeSet<_>>();
+    assert_eq!(unique.len(), inventory.names.len());
+    assert!(inventory.names.iter().any(|name| name == ANGULAR_SOURCE));
+    assert!(inventory.names.iter().any(|name| name == TIMING_SOURCE));
+}
+
+#[test]
+fn a_change_to_the_angular_source_changes_only_the_metric_identity() {
+    let tree = SourceTree::copy();
+    let metric = tree.digest(EvaluatorKind::Metric);
+    let gates = tree.digest(EvaluatorKind::Gate);
+
+    tree.append(ANGULAR_SOURCE, "\n// one changed angular rule\n");
+
+    assert_ne!(tree.digest(EvaluatorKind::Metric), metric);
+    assert_eq!(tree.digest(EvaluatorKind::Gate), gates);
+}
+
+#[test]
+fn a_change_to_the_timing_source_changes_only_the_metric_identity() {
+    let tree = SourceTree::copy();
+    let metric = tree.digest(EvaluatorKind::Metric);
+    let gates = tree.digest(EvaluatorKind::Gate);
+
+    tree.append(TIMING_SOURCE, "\n// one changed settling window\n");
+
+    assert_ne!(tree.digest(EvaluatorKind::Metric), metric);
+    assert_eq!(tree.digest(EvaluatorKind::Gate), gates);
+}
+
+#[test]
+fn every_declared_production_source_changes_its_evaluator_identity() {
+    for (kind, inputs) in [
+        (EvaluatorKind::Metric, METRIC_PRODUCTION_INPUTS.as_slice()),
+        (EvaluatorKind::Gate, GATE_PRODUCTION_INPUTS.as_slice()),
+    ] {
+        for input in inputs {
+            let tree = SourceTree::copy();
+            let before = tree.digest(kind);
+
+            tree.append(input, "\n// one changed production rule\n");
+
+            assert_ne!(tree.digest(kind), before, "{input} does not bind {kind:?}");
+        }
+    }
+}
+
+#[test]
+fn a_new_production_metric_source_fails_the_inventory_guard() {
+    let tree = SourceTree::copy();
+    tree.digest(EvaluatorKind::Metric);
+
+    tree.write(
+        "tools/flight-tune/src/flight_quality/overshoot.rs",
+        "//! One unbound production metric rule.\n",
+    );
+
+    let Err(error) = calculate(tree.path(), EvaluatorKind::Metric) else {
+        panic!("an extra source is refused");
+    };
+    let detail = error.to_string();
+    assert!(detail.contains("extra"), "{detail}");
+    assert!(detail.contains("overshoot.rs"), "{detail}");
+}
+
+#[test]
+fn a_missing_production_metric_source_fails_the_inventory_guard() {
+    let tree = SourceTree::copy();
+    tree.digest(EvaluatorKind::Metric);
+
+    tree.remove(ANGULAR_SOURCE);
+
+    let Err(error) = calculate(tree.path(), EvaluatorKind::Metric) else {
+        panic!("a missing source is refused");
+    };
+    let detail = error.to_string();
+    assert!(detail.contains("missing"), "{detail}");
+    assert!(detail.contains("angular.rs"), "{detail}");
+}
+
+#[test]
+fn a_test_source_does_not_enter_a_production_identity() {
+    let tree = SourceTree::copy();
+    let metric = tree.digest(EvaluatorKind::Metric);
+    let gates = tree.digest(EvaluatorKind::Gate);
+
+    tree.write(
+        "crates/pilotage-flight-quality/src/overshoot_tests.rs",
+        "//! One added unit test.\n",
+    );
+    tree.write(
+        "tools/flight-tune/src/flight_quality/tests/overshoot.rs",
+        "//! One added test module.\n",
+    );
+    tree.write(
+        "tools/flight-tune/src/flight_quality/test_support.rs",
+        "//! One added test helper.\n",
+    );
+    tree.append(
+        "tools/flight-tune/src/flight_quality/tests.rs",
+        "\n// one changed assertion\n",
+    );
+
+    assert_eq!(tree.digest(EvaluatorKind::Metric), metric);
+    assert_eq!(tree.digest(EvaluatorKind::Gate), gates);
+}
+
+#[test]
+fn input_order_cannot_change_the_canonical_digest() {
+    for (kind, inputs) in [
+        (EvaluatorKind::Metric, METRIC_PRODUCTION_INPUTS.as_slice()),
+        (EvaluatorKind::Gate, GATE_PRODUCTION_INPUTS.as_slice()),
+    ] {
+        let sorted = named_bytes(inputs);
+        let mut reversed = sorted.clone();
+        reversed.reverse();
+
+        assert_eq!(
+            digest_named_bytes(kind, &sorted).expect("sorted digest"),
+            digest_named_bytes(kind, &reversed).expect("reversed digest")
+        );
+    }
+}
+
+#[test]
+fn the_metric_and_gate_inventories_cannot_substitute_for_each_other() {
+    let metric = named_bytes(METRIC_PRODUCTION_INPUTS.as_slice());
+    let gates = named_bytes(GATE_PRODUCTION_INPUTS.as_slice());
+
+    assert_ne!(
+        digest_named_bytes(EvaluatorKind::Metric, &metric).expect("metric digest"),
+        digest_named_bytes(EvaluatorKind::Gate, &gates).expect("gate digest")
+    );
+    digest_named_bytes(EvaluatorKind::Metric, &gates).expect_err("the gate inventory is refused");
+    digest_named_bytes(EvaluatorKind::Gate, &metric).expect_err("the metric inventory is refused");
+}
+
+#[test]
+fn one_evaluator_document_cannot_be_read_as_the_other() {
+    let tree = SourceTree::copy();
+    let metric = calculate(tree.path(), EvaluatorKind::Metric).expect("metric inventory");
+
+    digest_document(EvaluatorKind::Metric, &metric.document).expect("the metric document reads");
+    digest_document(EvaluatorKind::Gate, &metric.document)
+        .expect_err("the metric document is not a gate document");
+}

--- a/tools/flight-tune/tests/tuner/execution_retry.rs
+++ b/tools/flight-tune/tests/tuner/execution_retry.rs
@@ -65,6 +65,31 @@ fn prepared_contexts(tuner: &TestTuner) -> Vec<&RunExecutionContext> {
 }
 
 #[test]
+fn an_execution_retry_cannot_change_an_evaluator_identity() {
+    let directory = TestDirectory::new("execution-retry-frozen-evaluators");
+    let state = FakeHandle::new();
+    let mut tuner =
+        open_with_failing_start(&directory, &state, 1, 1).expect("open a retrying tuner");
+    let frozen = tuner.journal().session().runtimes.evaluator_identities();
+
+    tuner
+        .run_training_attempts_blocking(0)
+        .expect("the replacement settles the training baseline");
+
+    assert_eq!(quarantine_count(&tuner), 1);
+    let entries = tuner.journal().entries();
+    assert!(entries.len() > 1, "a retry writes more than one entry");
+    for entry in entries {
+        entry
+            .session
+            .runtimes
+            .evaluator_identities()
+            .require_frozen(&frozen)
+            .expect("every retry entry keeps the frozen evaluators");
+    }
+}
+
+#[test]
 fn a_quarantined_execution_receives_one_replacement_that_keeps_its_condition() {
     let directory = TestDirectory::new("execution-retry-one-replacement");
     let state = FakeHandle::new();

--- a/tools/flight-tune/tests/tuner/orphan_baseline.rs
+++ b/tools/flight-tune/tests/tuner/orphan_baseline.rs
@@ -269,6 +269,91 @@ fn changed_training_suite_orphans_baseline_before_mutation() {
     assert_eq!(new_tuner.journal().training_attempt_count(), 1);
 }
 
+#[test]
+fn changed_metric_identity_orphans_baseline_before_mutation() {
+    let directory = TestDirectory::new("orphan-baseline-changed-metric");
+    let state = FakeHandle::new();
+    let (old_head, before) = run_one_attempt(&directory, &state, "open the first metric session");
+
+    let result = open_with_evaluators(
+        &directory,
+        state.clone(),
+        EnvelopeGates::new(2.0),
+        QuadraticMetric::with_implementation(state.clone(), "quadratic-target-two"),
+    );
+
+    assert!(matches!(
+        result,
+        Err(TuneError::EvaluatorIdentityChanged { .. })
+    ));
+    assert_eq!(ExternalMutations::capture(&state), before);
+    assert_eq!(read_head_entry(&directory), old_head);
+}
+
+#[test]
+fn changed_hard_gate_identity_orphans_baseline_before_mutation() {
+    let directory = TestDirectory::new("orphan-baseline-changed-gates");
+    let state = FakeHandle::new();
+    let (old_head, before) = run_one_attempt(&directory, &state, "open the first gate session");
+
+    let result = open_with_evaluators(
+        &directory,
+        state.clone(),
+        EnvelopeGates::new(3.0),
+        QuadraticMetric::new(state.clone()),
+    );
+
+    assert!(matches!(
+        result,
+        Err(TuneError::EvaluatorIdentityChanged { .. })
+    ));
+    assert_eq!(ExternalMutations::capture(&state), before);
+    assert_eq!(read_head_entry(&directory), old_head);
+}
+
+/// Seals one training attempt and reports the state a restart cannot move.
+fn run_one_attempt(
+    directory: &TestDirectory,
+    state: &FakeHandle,
+    detail: &str,
+) -> (JournalEntry, ExternalMutations) {
+    let mut tuner = open_with_factory(
+        directory,
+        state.clone(),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state.clone()),
+        SequenceStrategy::new(vec![0.5]),
+    )
+    .expect(detail);
+    tuner
+        .run_training_attempts_blocking(1)
+        .expect("run the baseline and challenger");
+    drop(tuner);
+    (
+        read_head_entry(directory),
+        ExternalMutations::capture(state),
+    )
+}
+
+fn open_with_evaluators(
+    directory: &TestDirectory,
+    state: FakeHandle,
+    gates: EnvelopeGates,
+    metric: QuadraticMetric,
+) -> Result<TestTuner, TuneError> {
+    Tuner::open_or_resume(
+        directory.path(),
+        stage(),
+        91,
+        candidate(0.0),
+        FakeBackend::new(state.clone()),
+        FakeFactory::new(state),
+        gates,
+        metric,
+        SequenceStrategy::new(vec![0.5]),
+    )
+}
+
 fn open_with_factory(
     directory: &TestDirectory,
     state: FakeHandle,

--- a/tools/flight-tune/tests/tuner/test_rig/scoring.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/scoring.rs
@@ -106,6 +106,16 @@ impl QuadraticMetric {
             gain: None,
         }
     }
+
+    /// Keeps the quadratic rule and states another implementation identity.
+    #[allow(dead_code)]
+    pub fn with_implementation(state: FakeHandle, implementation: &str) -> Self {
+        Self {
+            identity: identity("metric", implementation),
+            state,
+            gain: None,
+        }
+    }
 }
 
 impl MetricEvaluator for QuadraticMetric {


### PR DESCRIPTION
Every flight-quality evaluator identity now covers one closed, versioned
inventory of its production sources. A rebuilt evaluator that changes a score
changes its identity.

## What the manual list missed

`metric_identity` in `tools/flight-tune/src/flight_quality/config.rs` listed its
production sources by hand with `include_str!`. The list named seven files in
`crates/pilotage-flight-quality/src`. The crate holds twelve. The three the list
never named are the ones that changed most recently:

| Production metric source | In the manual list | In the new inventory |
| --- | --- | --- |
| `crates/pilotage-flight-quality/src/angular.rs` | no | yes |
| `crates/pilotage-flight-quality/src/collective.rs` | no | yes |
| `crates/pilotage-flight-quality/src/vocabulary.rs` | no | yes |
| `crates/pilotage-flight-quality/src/angular_release.rs` | no | yes |
| `control.rs`, `release.rs`, `response.rs`, `signal.rs`, `series.rs`, `sample.rs`, `error.rs` | yes | yes |
| `crates/pilotage-flight-quality/src/lib.rs` | no | yes |

`angular.rs` calculates yaw and angular step response. `collective.rs`
calculates collective response. `vocabulary.rs` states which metrics a scenario
can produce. A change to any of them moved a score and kept the identity.

## Layer 1: the inventories

`tools/flight-tune/build_support/evaluator_source_identity.rs` declares one
versioned inventory for each evaluator: nineteen metric inputs and ten hard-gate
inputs. The build script walks the owned roots and refuses to build unless the
declared set equals the discovered set. A new production module fails the build
until it is declared; a declared module that disappears fails the build too.
Test files never enter either set: the walker skips `tests` directories,
`tests.rs`, `*_tests.rs`, and `test_*.rs`, and the readback refuses the same
names again.

The two inventories stay separate. Their union is exactly what the walker
discovers, so `gate.rs` and `gates.rs` are the only inputs the hard-gate
inventory adds.

## Layer 2: the canonical identities

Each inventory becomes one canonical schema-versioned JSON document that sorts
its entries by repository-relative path and frames every field with its length.
The build script writes the document and its digest as two independent
constants. `tools/flight-tune/src/flight_quality/identity.rs` reads the document
back, recomputes the digest from the embedded bytes, and refuses a document that
does not reproduce it, so a stale constant is detectable rather than trusted.
The evaluator identity is then the domain-separated digest of that inventory
bound to the exact configuration document. No directory order, modification
time, or absolute host path enters it.

## Layer 3: the frozen plan

`EvaluatorIdentities::require_frozen` rejects evaluators that are not the ones
the plan froze. `Journal::resume` runs it before it compares anything else, and
`Journal::open_or_create` runs its validation before the journal storage opens,
before the simulator session opens, and before the vehicle binds. A restart with
another evaluator therefore fails with no external mutation at all. A retry
reuses the frozen session, so no attempt can change an evaluator identity.

The independent verifier keeps its own copy of both evaluator names and refuses
a session whose two evaluator identities share a name or a digest, or that
carries the two flight-quality names the wrong way round.

Suite comparison, promotion, and final qualification read one frozen session
inside one process, so there is no second evaluator identity there for the first
to differ from. The two places where a rebuilt evaluator can meet a frozen plan
are the session open or resume, and independent verification of sealed evidence.
Both refuse it, so the coverage is complete without comparisons that could never
differ. Response-target qualification runs only after `campaign::verify` has
checked the evaluator pair, and every authenticated proof binds the session
digest that binds the metric identity, so a response target is always qualified
against the exact metric that produced the score.

## Identity reset

| Identity | Before | After |
| --- | --- | --- |
| Metric implementation | `pilotage-flight-quality-streaming-metrics` | `pilotage-flight-quality-streaming-metrics-v2` |
| Hard-gate implementation | `pilotage-flight-quality-streaming-gates` | `pilotage-flight-quality-streaming-gates-v2` |
| Metric source document domain | none | `flight-tune-metric-source-document-v1\0` |
| Hard-gate source document domain | none | `flight-tune-gate-source-document-v1\0` |
| Metric implementation domain | none | `pilotage-flight-quality-streaming-metrics-v2\0` |
| Hard-gate implementation domain | none | `pilotage-flight-quality-streaming-gates-v2\0` |

Both identity values change, which is the point of the change rather than a side
effect of it. The names carry `-v2`, so evidence sealed under the prior domain
stays readable and is not admitted.

The pinned golden-evidence digest in `crates/pilotage-tuning-feedback` moved from
`2d8f49e777…` to `077f3df8c0…` because the golden campaign now names the two
evaluators it ran instead of two placeholders. The reason is recorded in the
test's doc comment.

## Deviations, with reasons

1. **The pre-pinned `evaluator_source_identity.rs` digest is not reachable on
   `main`.** `scripts/check-flight-tune-contracts.py` pinned one digest,
   `ce2adf92…`, for a file that did not exist. That content declares twenty-six
   metric inputs under a decomposition that never merged: it names
   `tools/flight-tune/src/flight_quality/metrics/{angular,loss,measure,objectives,timing}.rs`,
   `metrics/measure/{release,series,step,wind}.rs`, and `config/collective.rs`,
   none of which exist, and it does not name
   `crates/pilotage-flight-quality/src/{angular,collective,vocabulary}.rs`, which
   the merged decomposition put in the shared crate. Its own completeness rule
   requires declared to equal discovered, so those bytes cannot build here.
   Reproducing them would mean undoing the merged decomposition and moving
   public API out of a crate `flight-tune-campaign` depends on.

   This change keeps that file's mechanism byte for byte — schema version, both
   domain separators, the length-framed digest, the canonical readback, the
   symlink and owned-root refusals — and changes only
   `METRIC_PRODUCTION_INPUTS`, from the twenty-six declared paths to the
   nineteen that exist. `GATE_PRODUCTION_INPUTS` already matched and is
   untouched. The new digest is appended beside the pinned one, which is the
   established pattern for that table.

2. **`tools/flight-tune/build.rs` needs a fourth reviewed digest.** The three
   pinned values are the original file, the current file after scenario-runtime
   generation landed, and a file that has evaluator generation but no
   scenario-runtime generation. A build script with both generators, which
   `scenario_runtime.rs`'s own pinned include requires, matches none of them and
   exists nowhere in the repository history. A digest append was unavoidable in
   every branch of this decision, including a full restructure.

3. **The issue names `metrics/angular.rs` and `metrics/timing.rs`.** Neither
   path exists. Angular maps to
   `crates/pilotage-flight-quality/src/angular.rs`. Timing maps to
   `crates/pilotage-flight-quality/src/response.rs`, which holds the delay,
   rise, and settling windows and their event markers. Both are named as
   constants in `tools/flight-tune/tests/evaluator_identity.rs`, and a third
   case proves that *every* declared source changes its evaluator identity, so
   the mapping cannot silently exclude one.

4. **No new dependency.** `serde` and `serde_json` were already declared as
   `flight-tune` build dependencies on `main`, and
   `scripts/flight-tune-direct-dependency-allowlist.tsv` already allowed them.

5. **The hard-gate restart case changes the gate limit rather than a separate
   implementation name.** The gate identity binds implementation and
   configuration together, so a changed limit is a changed identity, and the
   restart is refused before the limit could affect a run. This avoided a second
   test-rig constructor that pushed `test_rig/scoring.rs` past the 500-line cap.

## Tests

Every case the issue requires:

| Required case | Where |
| --- | --- |
| A change to the angular source changes the metric identity | `tools/flight-tune/tests/evaluator_identity.rs` |
| A change to the timing source changes the metric identity | same file |
| A new production metric source fails the inventory guard | same file |
| A missing production metric source fails the inventory guard | same file |
| A test source does not enter the production identity | same file, and `flight_quality/identity/tests.rs` |
| Input order cannot change the canonical digest | same file |
| Metric and gate inventories cannot substitute for each other | same file, and `flight_quality/identity/tests.rs` |
| A restart with another metric identity fails before external mutation | `tools/flight-tune/tests/tuner/orphan_baseline.rs` |
| An execution retry cannot change an evaluator identity | `tools/flight-tune/tests/tuner/execution_retry.rs` |
| A suite baseline from another evaluator identity fails replay | `crates/pilotage-tuning-feedback/src/qualification/tests/evaluator_attacks.rs` |
| A tampered evaluator identity fails independent qualification | same file |

The restart cases assert that the simulator open, prepare, start, stop, cleanup,
vehicle bind, vehicle apply, transition authorization, and scenario-run counts
are all unchanged, and that the journal head is byte-identical, so "before
external mutation" is measured rather than asserted.

## Local gates

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, no diagnostics |
| `cargo test --workspace --all-targets` | pass, 85 test binaries green |
| `cargo doc --no-deps` with `-D missing_docs -D rustdoc::broken_intra_doc_links` | pass |
| `cargo build --release` | pass |
| `scripts/check-structure.sh` | pass |
| `scripts/check-flight-tune-contracts.py` | pass |
| `scripts/check-flight-tune-boundaries.sh` | pass |
| `scripts/check-feedback-verifier-boundary.py` | pass |
| `scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | pass, 20 guard pairs |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | pass, 3 passed, 0 failed, 2239.71 s |

Certification wall time is 2239.71 s, which is 37 minutes 20 seconds, for the
two end-to-end vehicle campaigns and the warm-start probe at two test threads.
Both vehicles still seal `Qualified`: `a_campaign_runs_end_to_end_for_the_alia250`
and `a_campaign_runs_end_to_end_for_the_x500` each assert
`FinalQualificationOutcome::Qualified` and each publish their evidence. The
identity reset therefore starts a new baseline without lowering a bar.

Fixes #468.

SIM / NOT FOR FLIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
