### PR TITLE
Bind and verify executed uncertainty evidence end to end (#484)

### DIFF
--- a/crates/pilotage-trial/src/condition/sensor/reference.rs
+++ b/crates/pilotage-trial/src/condition/sensor/reference.rs
@@ -121,6 +121,19 @@ impl SensorNoiseReference {
     }
 }
 
+impl SensorNoiseLane {
+    /// Returns the lane, the executor-unit peak amplitude, and the interval.
+    ///
+    /// A caller that states what one run declared needs the amplitude in the
+    /// unit the executor applies, not the unit the artifact writes. The
+    /// conversion has one implementation, so a stated declaration and an
+    /// applied offset cannot disagree about which unit they mean.
+    #[must_use]
+    pub fn reference_values(self) -> (SensorReferenceLane, f32, u32) {
+        request_values(self)
+    }
+}
+
 /// Resolves one lane request into its derivation inputs.
 ///
 /// The amplitude leaves this function in the flight-controller lane unit. A

--- a/crates/pilotage-tuning-feedback/src/lib.rs
+++ b/crates/pilotage-tuning-feedback/src/lib.rs
@@ -13,6 +13,7 @@ mod evidence;
 mod policy;
 mod qualification;
 mod storage;
+mod uncertainty;
 
 pub use error::FeedbackError;
 pub use evidence::{
@@ -20,3 +21,4 @@ pub use evidence::{
     VerifiedQualifiedEvidence,
 };
 pub use policy::RequiredPolicy;
+pub use uncertainty::{VerifiedExecutedUncertainty, verify_executed_uncertainty};

--- a/crates/pilotage-tuning-feedback/src/uncertainty.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty.rs
@@ -1,0 +1,246 @@
+//! Independent recomputation of the executed uncertainty relation.
+//!
+//! Nothing here reads a count, an offset, a schedule, or a decision out of
+//! the receipt the run states. Every value is derived again from the sample
+//! stream and the declaration, and the stated receipt is then required to be
+//! exactly that.
+//!
+//! A run that says it flew under uncertainty is answerable for two things:
+//! that the identities it launched with are the identities it flew under,
+//! and that every sample states the decision the declaration required. A
+//! receipt whose counts no sample produced is refused here, which is what a
+//! reader who never watched the run needs before trusting one.
+
+use flight_tune::{
+    Digest, ExecutedLaunchIdentity, ExecutedSample, ExecutedUncertaintyDeclaration,
+    ExecutedUncertaintyLedger, ExecutedUncertaintyReceipt,
+};
+use serde::Serialize;
+use sha2::{Digest as ShaDigest, Sha256};
+
+mod actuator;
+mod counts;
+mod derivation;
+mod relation;
+
+use crate::{FeedbackError, digest, error::invalid};
+
+/// The receipt schema this verifier reproduces.
+const RECEIPT_SCHEMA_VERSION: u16 = 1;
+
+/// The domain the core binds one executed uncertainty receipt under.
+const RECEIPT_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-receipt.v1\0";
+
+/// The domain the core chains one sample stream under.
+const SAMPLE_STREAM_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-sample.v1\0";
+
+/// The basis-point value that requests no scaling.
+const NOMINAL_BASIS_POINTS: u16 = 10_000;
+
+/// One run whose executed uncertainty was derived again and agreed.
+pub struct VerifiedExecutedUncertainty {
+    receipt_digest: Digest,
+    run_intent_digest: Digest,
+    sample_count: u64,
+}
+
+impl VerifiedExecutedUncertainty {
+    /// Returns the identity a run seal binds this receipt by.
+    #[must_use]
+    pub const fn receipt_digest(&self) -> Digest {
+        self.receipt_digest
+    }
+
+    /// Returns the run intent this uncertainty was executed for.
+    #[must_use]
+    pub const fn run_intent_digest(&self) -> Digest {
+        self.run_intent_digest
+    }
+
+    /// Returns how many samples the derived relation accepted.
+    #[must_use]
+    pub const fn sample_count(&self) -> u64 {
+        self.sample_count
+    }
+}
+
+#[derive(Serialize)]
+struct ReceiptDocument<'a> {
+    schema_version: u16,
+    launch: &'a ExecutedLaunchIdentity,
+    declaration: &'a ExecutedUncertaintyDeclaration,
+    ledger: &'a ExecutedUncertaintyLedger,
+    sample_stream_digest: Digest,
+}
+
+/// Derives one run's executed uncertainty again and requires agreement.
+///
+/// The samples are the only source. The stated ledger, the stated sample
+/// stream identity, and the stated receipt identity are each required to be
+/// the derived one, so a receipt cannot answer for itself.
+///
+/// # Errors
+///
+/// Returns [`FeedbackError`] when the receipt schema changed, when the
+/// launch identities do not name the declared condition, when the sample
+/// stream is not the one the receipt names, when any sample does not state
+/// the decision the declaration required, or when the counts differ.
+pub fn verify_executed_uncertainty(
+    receipt: &ExecutedUncertaintyReceipt,
+    samples: &[ExecutedSample],
+) -> Result<VerifiedExecutedUncertainty, FeedbackError> {
+    if receipt.schema_version != RECEIPT_SCHEMA_VERSION
+        || receipt.declaration.schema_version != RECEIPT_SCHEMA_VERSION
+        || receipt.launch.schema_version != RECEIPT_SCHEMA_VERSION
+        || receipt.ledger.schema_version != RECEIPT_SCHEMA_VERSION
+    {
+        return Err(invalid("the executed uncertainty schema changed"));
+    }
+    require_bound(receipt)?;
+    relation::require_digest(
+        stream_digest(samples)?,
+        receipt.sample_stream_digest,
+        "the receipt does not name the samples it travels with",
+    )?;
+    let derived = relation::walk(&receipt.declaration, samples, RECEIPT_SCHEMA_VERSION)?;
+    if derived != receipt.ledger {
+        return Err(invalid(
+            "the executed uncertainty counts do not follow from the samples",
+        ));
+    }
+    relation::require_digest(
+        receipt_digest(receipt)?,
+        receipt.receipt_digest,
+        "an executed uncertainty receipt does not cover its own content",
+    )?;
+    Ok(VerifiedExecutedUncertainty {
+        receipt_digest: receipt.receipt_digest,
+        run_intent_digest: receipt.launch.run_intent_digest,
+        sample_count: derived.sample_count,
+    })
+}
+
+/// Requires the launch, the declaration, and the ledger to name one run.
+fn require_bound(receipt: &ExecutedUncertaintyReceipt) -> Result<(), FeedbackError> {
+    let launch = &receipt.launch;
+    let declaration = &receipt.declaration;
+    if launch.run_intent_digest.is_zero()
+        || launch.artifact_digest.is_zero()
+        || launch.condition_digest.is_zero()
+        || launch.artifact_digest == launch.condition_digest
+    {
+        return Err(invalid(
+            "a launch identity is absent or names one value twice",
+        ));
+    }
+    if launch.condition_digest != declaration.condition_digest
+        || launch.artifact_digest != declaration.artifact_digest
+        || launch.run_seed != declaration.run_seed
+        || launch.required_capabilities != declaration.required_capabilities
+    {
+        return Err(invalid(
+            "a receipt launch does not name the condition it declared",
+        ));
+    }
+    require_declared(declaration)?;
+    let declared = declaration
+        .sensor_lanes
+        .iter()
+        .map(|lane| lane.lane_tag)
+        .collect::<Vec<_>>();
+    let counted = receipt
+        .ledger
+        .sensor_lanes
+        .iter()
+        .map(|lane| lane.lane_tag)
+        .collect::<Vec<_>>();
+    if declared != counted {
+        return Err(invalid(
+            "a receipt ledger does not count the declared lanes",
+        ));
+    }
+    Ok(())
+}
+
+/// Requires the declared factors to be the ones the capabilities name.
+///
+/// A declaration that asks for a capability no factor needs, or that hides a
+/// factor behind a capability it never asked for, would let a run claim
+/// coverage of an uncertainty it did not execute.
+fn require_declared(declaration: &ExecutedUncertaintyDeclaration) -> Result<(), FeedbackError> {
+    let mut expected: Vec<&'static str> = Vec::new();
+    if declaration.authority_scale_basis_points != NOMINAL_BASIS_POINTS {
+        expected.push("actuator_authority");
+    }
+    if declaration.command_hold.is_some() {
+        expected.push("command_hold");
+    }
+    if declaration.hover_scale_basis_points != NOMINAL_BASIS_POINTS {
+        expected.push("hover_trim_uncertainty");
+    }
+    if !declaration.sensor_lanes.is_empty() {
+        expected.push("sensor_perturbation");
+    }
+    if expected.is_empty() {
+        return Err(invalid(
+            "a nominal condition states no executed uncertainty",
+        ));
+    }
+    let stated = declaration
+        .required_capabilities
+        .iter()
+        .map(|capability| capability.as_str())
+        .collect::<Vec<_>>();
+    if stated != expected {
+        return Err(invalid(
+            "the required capabilities do not follow from the declared factors",
+        ));
+    }
+    let mut previous: Option<u8> = None;
+    for lane in &declaration.sensor_lanes {
+        if previous.is_some_and(|prior| prior >= lane.lane_tag)
+            || usize::from(lane.lane_tag) >= derivation::SENSOR_LANE_COUNT
+        {
+            return Err(invalid("the declared sensor lanes are not in lane order"));
+        }
+        previous = Some(lane.lane_tag);
+    }
+    Ok(())
+}
+
+/// Chains the identity of the exact ordered samples.
+fn stream_digest(samples: &[ExecutedSample]) -> Result<Digest, FeedbackError> {
+    let mut chained = {
+        let mut hasher = Sha256::new();
+        hasher.update(SAMPLE_STREAM_DOMAIN);
+        Digest::from_bytes(hasher.finalize().into())
+    };
+    for sample in samples {
+        let bytes = digest::encode("executed uncertainty sample", sample)?;
+        let mut hasher = Sha256::new();
+        hasher.update(SAMPLE_STREAM_DOMAIN);
+        hasher.update(chained.as_bytes());
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+        chained = Digest::from_bytes(hasher.finalize().into());
+    }
+    Ok(chained)
+}
+
+/// Rebuilds the identity the receipt content produces.
+fn receipt_digest(receipt: &ExecutedUncertaintyReceipt) -> Result<Digest, FeedbackError> {
+    digest::domain(
+        "executed uncertainty receipt",
+        RECEIPT_DOMAIN,
+        &ReceiptDocument {
+            schema_version: receipt.schema_version,
+            launch: &receipt.launch,
+            declaration: &receipt.declaration,
+            ledger: &receipt.ledger,
+            sample_stream_digest: receipt.sample_stream_digest,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pilotage-tuning-feedback/src/uncertainty/actuator.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/actuator.rs
@@ -1,0 +1,294 @@
+//! Deriving every actuator decision one stream states.
+//!
+//! An eligible command is scaled and then either accepted or replaced by the
+//! last accepted command; which of the two is a seeded decision the
+//! declaration fixes. A bypassed command reaches the actuator exactly as the
+//! controller wrote it, so a safety command that arrives scaled or held is a
+//! command the controller never sent.
+
+use flight_tune::{
+    Digest, ExecutedActuatorApplication, ExecutedEligibility, ExecutedSample,
+    ExecutedUncertaintyDeclaration,
+};
+
+use super::derivation;
+use crate::{FeedbackError, error::invalid};
+
+const ACTUATOR_LANE_COUNT: usize = 16;
+
+type LaneBits = [u32; ACTUATOR_LANE_COUNT];
+
+/// The open command hold and the last command it may replay.
+pub(super) struct ActuatorState {
+    last_accepted: Option<LaneBits>,
+    interval: Option<OpenInterval>,
+}
+
+struct OpenInterval {
+    identity: Digest,
+    epoch: u64,
+    index: u64,
+    position: u32,
+    decisions: Vec<bool>,
+}
+
+impl ActuatorState {
+    pub(super) const fn new() -> Self {
+        Self {
+            last_accepted: None,
+            interval: None,
+        }
+    }
+
+    /// Reports whether a command hold can still replay a command.
+    pub(super) const fn holds_a_command(&self) -> bool {
+        self.interval.is_some()
+    }
+
+    /// Derives every actuator decision one sample states.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FeedbackError`] when a stated value is not the derived one.
+    pub(super) fn accept(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+    ) -> Result<bool, FeedbackError> {
+        let Some(actuator) = sample.actuator else {
+            return Ok(false);
+        };
+        if usize::from(actuator.lane_count) > ACTUATOR_LANE_COUNT || actuator.lane_count == 0 {
+            return Err(invalid("an actuator sample states no active lane"));
+        }
+        match actuator.eligibility {
+            ExecutedEligibility::Bypass(_) => {
+                if actuator.authority_scaled_lane_bits != actuator.requested_lane_bits
+                    || actuator.effective_lane_bits != actuator.requested_lane_bits
+                    || actuator.selected_hold
+                    || actuator.applied_hold
+                {
+                    return Err(invalid(
+                        "a bypassed command did not reach the actuator as the controller wrote it",
+                    ));
+                }
+                self.last_accepted = None;
+                self.interval = None;
+                Ok(false)
+            }
+            ExecutedEligibility::Eligible => self.eligible(declaration, sample, &actuator),
+        }
+    }
+
+    fn eligible(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+        actuator: &ExecutedActuatorApplication,
+    ) -> Result<bool, FeedbackError> {
+        let scaled = require_scaled(declaration, actuator)?;
+        let Some(hold) = declaration.command_hold else {
+            return self.untouched(actuator).map(|()| scaled);
+        };
+        if self.last_accepted.is_none() {
+            return self.prime(actuator).map(|()| scaled);
+        }
+        if actuator.prime {
+            return Err(invalid("a command hold primed its history a second time"));
+        }
+        let decisions = self.open(
+            declaration,
+            sample,
+            actuator,
+            hold.fraction_basis_points,
+            hold.decision_interval_samples,
+        )?;
+        self.decide(actuator, &decisions)?;
+        self.advance(actuator, hold.decision_interval_samples)?;
+        Ok(scaled)
+    }
+
+    fn untouched(&mut self, actuator: &ExecutedActuatorApplication) -> Result<(), FeedbackError> {
+        if actuator.selected_hold
+            || actuator.applied_hold
+            || actuator.prime
+            || actuator.interval_identity.is_some()
+            || actuator.effective_lane_bits != actuator.authority_scaled_lane_bits
+        {
+            return Err(invalid("an undeclared command hold was applied"));
+        }
+        self.last_accepted = Some(actuator.effective_lane_bits);
+        Ok(())
+    }
+
+    fn prime(&mut self, actuator: &ExecutedActuatorApplication) -> Result<(), FeedbackError> {
+        if !actuator.prime
+            || actuator.selected_hold
+            || actuator.applied_hold
+            || actuator.interval_identity.is_some()
+            || actuator.effective_lane_bits != actuator.authority_scaled_lane_bits
+        {
+            return Err(invalid(
+                "the first eligible command of an epoch did not prime the hold history",
+            ));
+        }
+        self.last_accepted = Some(actuator.effective_lane_bits);
+        Ok(())
+    }
+
+    fn open(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+        actuator: &ExecutedActuatorApplication,
+        fraction_basis_points: u16,
+        decision_interval_samples: u32,
+    ) -> Result<Vec<bool>, FeedbackError> {
+        let (epoch, index, position, identity) = stated(actuator)?;
+        if let Some(open) = &self.interval
+            && open.epoch == epoch
+            && open.index == index
+        {
+            if open.position != position || open.identity != identity {
+                return Err(invalid("a command hold interval lost its own position"));
+            }
+            return Ok(open.decisions.clone());
+        }
+        if position != 0 {
+            return Err(invalid(
+                "a command hold interval started away from its first position",
+            ));
+        }
+        let first_sequence = sample.global_sample_sequence;
+        if derivation::interval_identity(
+            declaration.condition_digest,
+            declaration.run_seed,
+            epoch,
+            index,
+            first_sequence,
+        ) != identity
+        {
+            return Err(invalid(
+                "a command hold interval does not carry its derived identity",
+            ));
+        }
+        let decisions = derivation::hold_schedule(
+            declaration.condition_digest,
+            declaration.run_seed,
+            epoch,
+            index,
+            first_sequence,
+            fraction_basis_points,
+            decision_interval_samples,
+        )?;
+        self.interval = Some(OpenInterval {
+            identity,
+            epoch,
+            index,
+            position,
+            decisions: decisions.clone(),
+        });
+        Ok(decisions)
+    }
+
+    fn decide(
+        &mut self,
+        actuator: &ExecutedActuatorApplication,
+        decisions: &[bool],
+    ) -> Result<(), FeedbackError> {
+        let position = actuator
+            .interval_position
+            .ok_or_else(|| invalid("a command hold states no interval position"))?;
+        let selected = decisions
+            .get(usize::try_from(position).unwrap_or(usize::MAX))
+            .copied()
+            .ok_or_else(|| invalid("a command hold reached a position it never scheduled"))?;
+        if selected != actuator.selected_hold || selected != actuator.applied_hold {
+            return Err(invalid(
+                "a command hold decision is not the one its schedule states",
+            ));
+        }
+        let accepted = self
+            .last_accepted
+            .ok_or_else(|| invalid("a command hold has no accepted command to replay"))?;
+        let required = if selected {
+            accepted
+        } else {
+            actuator.authority_scaled_lane_bits
+        };
+        if actuator.effective_lane_bits != required {
+            return Err(invalid(
+                "a held command did not replay the last accepted command",
+            ));
+        }
+        if !selected {
+            self.last_accepted = Some(actuator.effective_lane_bits);
+        }
+        Ok(())
+    }
+
+    fn advance(
+        &mut self,
+        actuator: &ExecutedActuatorApplication,
+        interval_samples: u32,
+    ) -> Result<(), FeedbackError> {
+        let Some(open) = &mut self.interval else {
+            return Err(invalid("a command hold advanced no interval"));
+        };
+        let next = open.position.wrapping_add(1);
+        let complete = next >= interval_samples;
+        if complete != actuator.interval_complete {
+            return Err(invalid(
+                "a command hold interval did not end where it was scheduled to",
+            ));
+        }
+        if complete {
+            self.interval = None;
+        } else {
+            open.position = next;
+        }
+        Ok(())
+    }
+}
+
+/// Requires every active lane to carry the declared authority scale.
+fn require_scaled(
+    declaration: &ExecutedUncertaintyDeclaration,
+    actuator: &ExecutedActuatorApplication,
+) -> Result<bool, FeedbackError> {
+    let active = usize::from(actuator.lane_count);
+    let mut changed = false;
+    for lane in 0..ACTUATOR_LANE_COUNT {
+        let requested = actuator.requested_lane_bits[lane];
+        let required = if lane < active {
+            derivation::scaled_authority(requested, declaration.authority_scale_basis_points)
+        } else {
+            requested
+        };
+        if actuator.authority_scaled_lane_bits[lane] != required {
+            return Err(invalid(
+                "an actuator lane does not carry the declared authority scale",
+            ));
+        }
+        changed |= required != requested;
+    }
+    Ok(changed)
+}
+
+fn stated(
+    actuator: &ExecutedActuatorApplication,
+) -> Result<(u64, u64, u32, Digest), FeedbackError> {
+    match (
+        actuator.interval_epoch,
+        actuator.interval_index,
+        actuator.interval_position,
+        actuator.interval_identity,
+    ) {
+        (Some(epoch), Some(index), Some(position), Some(identity)) => {
+            Ok((epoch, index, position, identity))
+        }
+        _ => Err(invalid(
+            "an eligible command states no command hold interval",
+        )),
+    }
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/counts.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/counts.rs
@@ -1,0 +1,145 @@
+//! The counts this verifier folds for itself from the verified samples.
+//!
+//! Nothing is read out of the ledger the run states. Every count is built
+//! again from the samples, and the stated ledger is then required to be
+//! exactly that, so a run cannot state a count no sample produced.
+
+use flight_tune::{
+    ExecutedActuatorCounts, ExecutedBypassCounts, ExecutedBypassReason, ExecutedEligibility,
+    ExecutedSample, ExecutedSensorLaneCounts, ExecutedUncertaintyLedger,
+};
+
+/// The counts one walked stream produces.
+pub(super) struct DerivedCounts {
+    sample_count: u64,
+    first_global_sample_sequence: u64,
+    last_global_sample_sequence: u64,
+    sensor_lanes: Vec<ExecutedSensorLaneCounts>,
+    actuator: ExecutedActuatorCounts,
+}
+
+impl DerivedCounts {
+    /// Opens empty counts for the declared lanes.
+    pub(super) fn opened(lane_tags: &[u8]) -> Self {
+        Self {
+            sample_count: 0,
+            first_global_sample_sequence: 0,
+            last_global_sample_sequence: 0,
+            sensor_lanes: lane_tags
+                .iter()
+                .map(|lane_tag| ExecutedSensorLaneCounts {
+                    lane_tag: *lane_tag,
+                    eligible: 0,
+                    changed: 0,
+                    held: 0,
+                })
+                .collect(),
+            actuator: ExecutedActuatorCounts {
+                commanded: 0,
+                eligible: 0,
+                primed: 0,
+                selected_hold: 0,
+                applied_hold: 0,
+                scaled: 0,
+                clamped: 0,
+                bypassed: ExecutedBypassCounts {
+                    missing_answer: 0,
+                    invalid_actuator_count: 0,
+                    backup: 0,
+                    direct: 0,
+                    failsafe: 0,
+                    fallback_mask: 0,
+                    arm_transition: 0,
+                    disarmed: 0,
+                    emergency_termination: 0,
+                },
+            },
+        }
+    }
+
+    /// Counts one sample the relation accepted.
+    pub(super) fn count(&mut self, sample: &ExecutedSample, drawn: &[bool], scaled: bool) {
+        if self.sample_count == 0 {
+            self.first_global_sample_sequence = sample.global_sample_sequence;
+        }
+        self.sample_count = self.sample_count.wrapping_add(1);
+        self.last_global_sample_sequence = sample.global_sample_sequence;
+        self.count_sensor(sample, drawn);
+        self.count_actuator(sample, scaled);
+    }
+
+    /// States the ledger these samples produced.
+    pub(super) fn stated(self, schema_version: u16) -> ExecutedUncertaintyLedger {
+        ExecutedUncertaintyLedger {
+            schema_version,
+            sample_count: self.sample_count,
+            first_global_sample_sequence: self.first_global_sample_sequence,
+            last_global_sample_sequence: self.last_global_sample_sequence,
+            sensor_lanes: self.sensor_lanes,
+            actuator: self.actuator,
+        }
+    }
+
+    fn count_sensor(&mut self, sample: &ExecutedSample, drawn: &[bool]) {
+        let Some(sensor) = sample.sensor else {
+            return;
+        };
+        for (index, lane) in self.sensor_lanes.iter_mut().enumerate() {
+            let bit = 1_u16 << lane.lane_tag;
+            if sensor.presence_mask & bit == 0 {
+                continue;
+            }
+            lane.eligible = lane.eligible.wrapping_add(1);
+            if sensor.changed_mask & bit != 0 {
+                lane.changed = lane.changed.wrapping_add(1);
+            }
+            if !drawn.get(index).copied().unwrap_or(true) {
+                lane.held = lane.held.wrapping_add(1);
+            }
+        }
+    }
+
+    fn count_actuator(&mut self, sample: &ExecutedSample, scaled: bool) {
+        let Some(actuator) = sample.actuator else {
+            return;
+        };
+        let counts = &mut self.actuator;
+        counts.commanded = counts.commanded.wrapping_add(1);
+        if sample.constraints.clamped() {
+            counts.clamped = counts.clamped.wrapping_add(1);
+        }
+        match actuator.eligibility {
+            ExecutedEligibility::Bypass(reason) => count_bypass(&mut counts.bypassed, reason),
+            ExecutedEligibility::Eligible => {
+                counts.eligible = counts.eligible.wrapping_add(1);
+                if actuator.prime {
+                    counts.primed = counts.primed.wrapping_add(1);
+                }
+                if actuator.selected_hold {
+                    counts.selected_hold = counts.selected_hold.wrapping_add(1);
+                }
+                if actuator.applied_hold {
+                    counts.applied_hold = counts.applied_hold.wrapping_add(1);
+                }
+                if scaled {
+                    counts.scaled = counts.scaled.wrapping_add(1);
+                }
+            }
+        }
+    }
+}
+
+fn count_bypass(counts: &mut ExecutedBypassCounts, reason: ExecutedBypassReason) {
+    let slot = match reason {
+        ExecutedBypassReason::MissingAnswer => &mut counts.missing_answer,
+        ExecutedBypassReason::InvalidActuatorCount => &mut counts.invalid_actuator_count,
+        ExecutedBypassReason::Backup => &mut counts.backup,
+        ExecutedBypassReason::Direct => &mut counts.direct,
+        ExecutedBypassReason::Failsafe => &mut counts.failsafe,
+        ExecutedBypassReason::FallbackMask => &mut counts.fallback_mask,
+        ExecutedBypassReason::ArmTransition => &mut counts.arm_transition,
+        ExecutedBypassReason::Disarmed => &mut counts.disarmed,
+        ExecutedBypassReason::EmergencyTermination => &mut counts.emergency_termination,
+    };
+    *slot = slot.wrapping_add(1);
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/derivation.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/derivation.rs
@@ -1,0 +1,178 @@
+//! The seeded decisions this verifier derives for itself.
+//!
+//! Nothing here calls the core. Every domain string, every preimage order,
+//! and every narrowing is written out again, so a change on the producing
+//! side that this file does not also make is a difference the relation
+//! reports rather than a change both sides agree to silently.
+
+use flight_tune::Digest;
+use sha2::{Digest as ShaDigest, Sha256};
+
+use crate::{FeedbackError, error::invalid};
+
+/// The domain the executing contract draws sensor noise under.
+const SENSOR_NOISE_DOMAIN: &[u8] = b"pilotage-sensor-noise-v1";
+
+/// The domain the executing contract draws command holds under.
+const COMMAND_HOLD_DOMAIN: &[u8] = b"pilotage-command-hold-v1";
+
+/// The domain the executing contract identifies a sensor sample under.
+const EFFECTIVE_SENSOR_DOMAIN: &[u8] = b"aviate-effective-sensor-v1";
+
+/// The nominal basis-point value, which requests no scaling.
+const NOMINAL_BASIS_POINTS: u16 = 10_000;
+
+/// The number of flight-controller sensor lanes the contract names.
+pub(super) const SENSOR_LANE_COUNT: usize = 12;
+
+/// Derives the held offset for one lane and one update bucket.
+pub(super) fn sensor_offset(
+    condition_digest: Digest,
+    run_seed: u64,
+    lane_tag: u8,
+    update_bucket: u64,
+    peak_amplitude: f32,
+) -> f32 {
+    let mut hasher = Sha256::new();
+    hasher.update(SENSOR_NOISE_DOMAIN);
+    hasher.update(condition_digest.as_bytes());
+    hasher.update(run_seed.to_le_bytes());
+    hasher.update([lane_tag]);
+    hasher.update(update_bucket.to_le_bytes());
+    let bytes = hasher.finalize();
+    let sample = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let unit = f64::from(sample) / f64::from(u32::MAX);
+    (unit.mul_add(2.0, -1.0) * f64::from(peak_amplitude)) as f32
+}
+
+/// Derives the identity of one complete command-hold interval.
+pub(super) fn interval_identity(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+) -> Digest {
+    let hasher = interval_hasher(
+        condition_digest,
+        run_seed,
+        interval_epoch,
+        interval_index,
+        first_sequence,
+    );
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+/// Derives the exact held positions of one complete decision interval.
+///
+/// # Errors
+///
+/// Returns [`FeedbackError`] when the declared interval cannot address its
+/// own positions on this platform.
+pub(super) fn hold_schedule(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+    fraction_basis_points: u16,
+    decision_interval_samples: u32,
+) -> Result<Vec<bool>, FeedbackError> {
+    let size = usize::try_from(decision_interval_samples)
+        .map_err(|_| invalid("a declared decision interval is not addressable"))?;
+    let mut positions = (0..size).collect::<Vec<_>>();
+    for cursor in (1..positions.len()).rev() {
+        let encoded = u64::try_from(cursor)
+            .map_err(|_| invalid("a decision interval position is not addressable"))?;
+        let value = permutation_value(
+            condition_digest,
+            run_seed,
+            interval_epoch,
+            interval_index,
+            first_sequence,
+            encoded,
+        );
+        let swap = usize::try_from(value % encoded.wrapping_add(1))
+            .map_err(|_| invalid("a decision interval swap is not addressable"))?;
+        positions.swap(cursor, swap);
+    }
+    let count = u64::from(fraction_basis_points) * u64::from(decision_interval_samples)
+        / u64::from(NOMINAL_BASIS_POINTS);
+    let count =
+        usize::try_from(count).map_err(|_| invalid("a declared hold count is not addressable"))?;
+    let mut decisions = vec![false; size];
+    for position in positions.into_iter().take(count) {
+        decisions[position] = true;
+    }
+    Ok(decisions)
+}
+
+/// Derives the identity of one exact sensor sample.
+pub(super) fn sensor_sample_digest(
+    presence_mask: u16,
+    values: &[Option<u32>; SENSOR_LANE_COUNT],
+) -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(EFFECTIVE_SENSOR_DOMAIN);
+    hasher.update(presence_mask.to_le_bytes());
+    for value in values {
+        hasher.update(value.unwrap_or(0).to_le_bytes());
+    }
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+/// Derives the value one lane carries after the authority scale.
+pub(super) fn scaled_authority(lane_bits: u32, basis_points: u16) -> u32 {
+    scaled(lane_bits, basis_points)
+}
+
+/// Derives the hover force one declared scale produces from one baseline.
+pub(super) fn scaled_hover_force(baseline_bits: u32, basis_points: u16) -> u32 {
+    scaled(baseline_bits, basis_points)
+}
+
+fn scaled(bits: u32, basis_points: u16) -> u32 {
+    let value = f32::from_bits(bits);
+    let result =
+        (f64::from(value) * f64::from(basis_points) / f64::from(NOMINAL_BASIS_POINTS)) as f32;
+    result.to_bits()
+}
+
+fn interval_hasher(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+) -> Sha256 {
+    let mut hasher = Sha256::new();
+    hasher.update(COMMAND_HOLD_DOMAIN);
+    hasher.update(condition_digest.as_bytes());
+    hasher.update(run_seed.to_le_bytes());
+    hasher.update(interval_epoch.to_le_bytes());
+    hasher.update(interval_index.to_le_bytes());
+    hasher.update(first_sequence.to_le_bytes());
+    hasher
+}
+
+fn permutation_value(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+    cursor: u64,
+) -> u64 {
+    let mut hasher = interval_hasher(
+        condition_digest,
+        run_seed,
+        interval_epoch,
+        interval_index,
+        first_sequence,
+    );
+    hasher.update(cursor.to_le_bytes());
+    let bytes = hasher.finalize();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/relation.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/relation.rs
@@ -1,0 +1,292 @@
+//! Walking one sample stream and deriving every decision it states.
+//!
+//! The walk is the whole relation restated: sequence discipline, the lane
+//! offsets, both sensor identities, the authority scale, the seeded hold
+//! schedule, the interval identity, and the hover force. A stated value that
+//! this walk does not derive ends the verification.
+
+use flight_tune::{
+    Digest, ExecutedHoverInitialization, ExecutedSample, ExecutedSensorApplication,
+    ExecutedUncertaintyDeclaration, ExecutedUncertaintyLedger,
+};
+
+use super::actuator::ActuatorState;
+use super::counts::DerivedCounts;
+use super::derivation::{self, SENSOR_LANE_COUNT};
+use crate::{FeedbackError, error::invalid};
+
+/// Derives the ledger one declaration and one ordered stream produce.
+///
+/// # Errors
+///
+/// Returns [`FeedbackError`] when the stream repeats, skips, or rewinds a
+/// sequence, when a sample has no completed lockstep answer, when the hover
+/// initialization moves, or when any stated value is not the derived one.
+pub(super) fn walk(
+    declaration: &ExecutedUncertaintyDeclaration,
+    samples: &[ExecutedSample],
+    schema_version: u16,
+) -> Result<ExecutedUncertaintyLedger, FeedbackError> {
+    let lane_tags = declaration
+        .sensor_lanes
+        .iter()
+        .map(|lane| lane.lane_tag)
+        .collect::<Vec<_>>();
+    let mut walk = Walk {
+        counts: DerivedCounts::opened(&lane_tags),
+        actuator: ActuatorState::new(),
+        drawn_buckets: [None; SENSOR_LANE_COUNT],
+        hover: None,
+        last_sequence: None,
+        last_global_sample_sequence: None,
+        last_timestamp_us: None,
+    };
+    for sample in samples {
+        walk.accept(declaration, sample)?;
+    }
+    if walk.actuator.holds_a_command() {
+        return Err(invalid("the stream ended with an active command hold"));
+    }
+    Ok(walk.counts.stated(schema_version))
+}
+
+struct Walk {
+    counts: DerivedCounts,
+    actuator: ActuatorState,
+    drawn_buckets: [Option<u64>; SENSOR_LANE_COUNT],
+    hover: Option<ExecutedHoverInitialization>,
+    last_sequence: Option<u64>,
+    last_global_sample_sequence: Option<u64>,
+    last_timestamp_us: Option<u64>,
+}
+
+impl Walk {
+    fn accept(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+    ) -> Result<(), FeedbackError> {
+        self.advance(sample)?;
+        self.require_hover(declaration, sample)?;
+        require_send(sample)?;
+        let drawn = self.sensor(declaration, sample)?;
+        let scaled = self.actuator.accept(declaration, sample)?;
+        self.counts.count(sample, &drawn, scaled);
+        Ok(())
+    }
+
+    fn advance(&mut self, sample: &ExecutedSample) -> Result<(), FeedbackError> {
+        require_step(self.last_sequence, sample.sequence, "trace sequence")?;
+        require_step(
+            self.last_global_sample_sequence,
+            sample.global_sample_sequence,
+            "sample sequence",
+        )?;
+        if self
+            .last_timestamp_us
+            .is_some_and(|previous| sample.simulator_timestamp_us < previous)
+        {
+            return Err(invalid("a sample rewinds the simulation time"));
+        }
+        self.last_sequence = Some(sample.sequence);
+        self.last_global_sample_sequence = Some(sample.global_sample_sequence);
+        self.last_timestamp_us = Some(sample.simulator_timestamp_us);
+        Ok(())
+    }
+
+    fn require_hover(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+    ) -> Result<(), FeedbackError> {
+        let hover = sample.hover;
+        if hover.scale_basis_points != declaration.hover_scale_basis_points
+            || !hover.estimator_disabled
+        {
+            return Err(invalid(
+                "a sample does not state the declared hover initialization",
+            ));
+        }
+        if derivation::scaled_hover_force(hover.baseline_force_bits, hover.scale_basis_points)
+            != hover.effective_force_bits
+        {
+            return Err(invalid(
+                "the hover force does not follow from its baseline and scale",
+            ));
+        }
+        match self.hover {
+            Some(first) if first != hover => {
+                Err(invalid("the hover initialization changed inside one run"))
+            }
+            Some(_) => Ok(()),
+            None => {
+                self.hover = Some(hover);
+                Ok(())
+            }
+        }
+    }
+
+    fn sensor(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+    ) -> Result<Vec<bool>, FeedbackError> {
+        let Some(sensor) = sample.sensor else {
+            if !declaration.sensor_lanes.is_empty() && sample.armed {
+                return Err(invalid(
+                    "an armed sample carries no sensor evidence for a declared lane",
+                ));
+            }
+            return Ok(vec![false; declaration.sensor_lanes.len()]);
+        };
+        require_identity(&sensor)?;
+        require_undeclared_unchanged(declaration, &sensor)?;
+        let mut drawn = Vec::with_capacity(declaration.sensor_lanes.len());
+        for declared in &declaration.sensor_lanes {
+            drawn.push(self.lane(
+                declaration,
+                sample,
+                &sensor,
+                declared.lane_tag,
+                declared.peak_amplitude_bits,
+                declared.update_interval_samples,
+            )?);
+        }
+        Ok(drawn)
+    }
+
+    fn lane(
+        &mut self,
+        declaration: &ExecutedUncertaintyDeclaration,
+        sample: &ExecutedSample,
+        sensor: &ExecutedSensorApplication,
+        lane_tag: u8,
+        peak_amplitude_bits: u32,
+        update_interval_samples: u32,
+    ) -> Result<bool, FeedbackError> {
+        let lane = usize::from(lane_tag);
+        let bit = 1_u16 << lane_tag;
+        if sensor.presence_mask & bit == 0 {
+            if sensor.update_buckets[lane].is_some() {
+                return Err(invalid("an absent sensor lane drew an offset"));
+            }
+            return Ok(false);
+        }
+        if update_interval_samples == 0 {
+            return Err(invalid("a declared sensor lane holds no offset"));
+        }
+        let bucket = sample.global_sample_sequence / u64::from(update_interval_samples);
+        if sensor.update_buckets[lane] != Some(bucket) {
+            return Err(invalid(
+                "a sensor lane states another held-offset bucket than the declared one",
+            ));
+        }
+        let raw = sensor.raw_value_bits[lane]
+            .ok_or_else(|| invalid("a present sensor lane carries no value"))?;
+        let value = f32::from_bits(raw);
+        if !value.is_finite() {
+            return Err(invalid("a declared sensor lane carries no value"));
+        }
+        let offset = derivation::sensor_offset(
+            declaration.condition_digest,
+            declaration.run_seed,
+            lane_tag,
+            bucket,
+            f32::from_bits(peak_amplitude_bits),
+        );
+        let required = (value + offset).to_bits();
+        if sensor.effective_value_bits[lane] != Some(required)
+            || (sensor.changed_mask & bit != 0) != (required != raw)
+        {
+            return Err(invalid("a sensor lane does not carry its declared value"));
+        }
+        let drew = self.drawn_buckets[lane] != Some(bucket);
+        self.drawn_buckets[lane] = Some(bucket);
+        Ok(drew)
+    }
+}
+
+/// Requires both sensor identities to cover the values they travel with.
+fn require_identity(sensor: &ExecutedSensorApplication) -> Result<(), FeedbackError> {
+    if derivation::sensor_sample_digest(sensor.presence_mask, &sensor.raw_value_bits)
+        != sensor.raw_digest
+    {
+        return Err(invalid(
+            "the raw sensor identity does not cover its own values",
+        ));
+    }
+    if derivation::sensor_sample_digest(sensor.presence_mask, &sensor.effective_value_bits)
+        != sensor.effective_digest
+    {
+        return Err(invalid(
+            "the effective sensor identity does not cover its own values",
+        ));
+    }
+    Ok(())
+}
+
+/// Requires a lane the declaration never named to reach the controller whole.
+fn require_undeclared_unchanged(
+    declaration: &ExecutedUncertaintyDeclaration,
+    sensor: &ExecutedSensorApplication,
+) -> Result<(), FeedbackError> {
+    for lane in 0..SENSOR_LANE_COUNT {
+        let tag = u8::try_from(lane).map_err(|_| invalid("a sensor lane is not addressable"))?;
+        if declaration.lane(tag).is_some() {
+            continue;
+        }
+        if sensor.update_buckets[lane].is_some() {
+            return Err(invalid("an undeclared sensor lane drew an offset"));
+        }
+        if sensor.raw_value_bits[lane] != sensor.effective_value_bits[lane]
+            || sensor.changed_mask & (1 << lane) != 0
+        {
+            return Err(invalid("an undeclared sensor lane changed"));
+        }
+    }
+    Ok(())
+}
+
+/// Requires one sample to carry exactly one completed lockstep answer.
+fn require_send(sample: &ExecutedSample) -> Result<(), FeedbackError> {
+    let send = sample.send;
+    if !send.attempted || !send.succeeded || !send.lockstep {
+        return Err(invalid("a sample has no completed lockstep actuator send"));
+    }
+    if send.echoed_timestamp_us != sample.simulator_timestamp_us {
+        return Err(invalid("a sample send answered another sensor sample"));
+    }
+    if sample.constraints.trace_failure {
+        return Err(invalid("a sample reports its own trace failure"));
+    }
+    Ok(())
+}
+
+/// Requires one counter to advance by exactly one step.
+fn require_step(previous: Option<u64>, current: u64, name: &str) -> Result<(), FeedbackError> {
+    let Some(previous) = previous else {
+        return Ok(());
+    };
+    if current == previous {
+        return Err(invalid(format!("a sample repeats one {name}")));
+    }
+    if current < previous {
+        return Err(invalid(format!("a sample rewinds the {name}")));
+    }
+    if current.wrapping_sub(previous) != 1 {
+        return Err(invalid(format!("a sample skips a {name}")));
+    }
+    Ok(())
+}
+
+/// Requires one derived identity to equal the stated one.
+pub(super) fn require_digest(
+    derived: Digest,
+    stated: Digest,
+    detail: &'static str,
+) -> Result<(), FeedbackError> {
+    if derived == stated {
+        return Ok(());
+    }
+    Err(invalid(detail))
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/relation.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/relation.rs
@@ -248,13 +248,14 @@ fn require_undeclared_unchanged(
 }
 
 /// Requires one sample to carry exactly one completed lockstep answer.
+///
+/// The echoed time is the transport's own confirmation of what it put on
+/// the wire, drawn from a clock this side never sees, so it is carried as
+/// evidence rather than derived.
 fn require_send(sample: &ExecutedSample) -> Result<(), FeedbackError> {
     let send = sample.send;
     if !send.attempted || !send.succeeded || !send.lockstep {
         return Err(invalid("a sample has no completed lockstep actuator send"));
-    }
-    if send.echoed_timestamp_us != sample.simulator_timestamp_us {
-        return Err(invalid("a sample send answered another sensor sample"));
     }
     if sample.constraints.trace_failure {
         return Err(invalid("a sample reports its own trace failure"));

--- a/crates/pilotage-tuning-feedback/src/uncertainty/tests.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/tests.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use flight_tune::{Digest, ExecutedSample, ExecutedUncertaintyReceipt};
+
+use super::verify_executed_uncertainty;
+
+#[path = "tests/support.rs"]
+mod support;
+
+use support::{RUN_SEED, sealed};
+
+#[test]
+fn a_run_the_core_sealed_is_derived_again_and_agrees() {
+    let run = sealed(21);
+
+    let verified = verify_executed_uncertainty(&run.receipt, &run.samples)
+        .expect("the derived relation agrees");
+
+    assert_eq!(verified.sample_count(), 21);
+    assert_eq!(verified.receipt_digest(), run.receipt.receipt_digest);
+    assert_eq!(
+        verified.run_intent_digest(),
+        run.receipt.launch.run_intent_digest
+    );
+}
+
+#[test]
+fn a_receipt_that_states_a_count_no_sample_produced_is_refused() {
+    assert_refused(|receipt, _| {
+        receipt.ledger.actuator.applied_hold = receipt.ledger.actuator.applied_hold.wrapping_add(1);
+    });
+}
+
+#[test]
+fn a_receipt_that_states_a_lane_change_no_sample_made_is_refused() {
+    assert_refused(|receipt, _| {
+        receipt.ledger.sensor_lanes[0].changed = 0;
+    });
+}
+
+#[test]
+fn a_receipt_that_hides_a_held_sample_is_refused() {
+    assert_refused(|receipt, _| {
+        receipt.ledger.sensor_lanes[0].held = 0;
+    });
+}
+
+#[test]
+fn a_sample_stream_that_lost_a_sample_is_refused() {
+    assert_refused(|_, samples| {
+        samples.pop();
+    });
+}
+
+#[test]
+fn a_sample_that_states_a_value_it_did_not_derive_is_refused() {
+    assert_refused(|_, samples| {
+        let mut sensor = samples[5].sensor.expect("sensor evidence");
+        sensor.effective_value_bits[0] = sensor.raw_value_bits[0];
+        samples[5].sensor = Some(sensor);
+    });
+}
+
+#[test]
+fn a_hold_decision_the_schedule_never_stated_is_refused() {
+    assert_refused(|_, samples| {
+        let mut actuator = samples[5].actuator.expect("actuator evidence");
+        actuator.selected_hold = !actuator.selected_hold;
+        actuator.applied_hold = actuator.selected_hold;
+        samples[5].actuator = Some(actuator);
+    });
+}
+
+#[test]
+fn an_actuator_lane_that_carries_another_scale_is_refused() {
+    assert_refused(|_, samples| {
+        let mut actuator = samples[5].actuator.expect("actuator evidence");
+        actuator.authority_scaled_lane_bits[0] = actuator.requested_lane_bits[0];
+        samples[5].actuator = Some(actuator);
+    });
+}
+
+#[test]
+fn a_launch_that_names_another_seed_than_the_declaration_is_refused() {
+    assert_refused(|receipt, _| {
+        receipt.launch.run_seed = RUN_SEED.wrapping_add(1);
+    });
+}
+
+#[test]
+fn a_declaration_whose_capabilities_do_not_follow_from_its_factors_is_refused() {
+    assert_refused(|receipt, _| {
+        receipt.declaration.required_capabilities.pop();
+        receipt.launch.required_capabilities.pop();
+    });
+}
+
+#[test]
+fn an_active_online_hover_estimator_is_refused() {
+    assert_refused(|_, samples| {
+        for sample in samples.iter_mut() {
+            sample.hover.estimator_disabled = false;
+        }
+    });
+}
+
+#[test]
+fn a_receipt_whose_identity_does_not_cover_its_content_is_refused() {
+    let run = sealed(21);
+    let mut receipt = run.receipt.clone();
+    receipt.receipt_digest = Digest::from_bytes([3; 32]);
+
+    assert!(verify_executed_uncertainty(&receipt, &run.samples).is_err());
+}
+
+/// Changes one verified run and requires the derived relation to refuse it.
+///
+/// The receipt is sealed again over the changed content, so a refusal is the
+/// relation failing rather than an identity that no longer covers its own
+/// document.
+fn assert_refused(change: impl FnOnce(&mut ExecutedUncertaintyReceipt, &mut Vec<ExecutedSample>)) {
+    let run = sealed(21);
+    assert!(
+        verify_executed_uncertainty(&run.receipt, &run.samples).is_ok(),
+        "the unchanged run must verify"
+    );
+
+    let mut receipt = run.receipt;
+    let mut samples = run.samples;
+    change(&mut receipt, &mut samples);
+    receipt.sample_stream_digest = super::stream_digest(&samples).expect("stream identity");
+    receipt.receipt_digest = super::receipt_digest(&receipt).expect("receipt identity");
+
+    assert!(
+        verify_executed_uncertainty(&receipt, &samples).is_err(),
+        "the changed run must be refused"
+    );
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/tests/support.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/tests/support.rs
@@ -1,0 +1,271 @@
+//! One executor stream the attacks start from.
+//!
+//! The stream is built to satisfy the core relation and is sealed through
+//! the core receipt, so an attack below changes a run that really verified
+//! rather than one this file only claims would.
+
+use flight_tune::{
+    ConditionSet, Digest, ExecutedActuatorApplication, ExecutedConstraintFlags,
+    ExecutedEligibility, ExecutedHoverInitialization, ExecutedLaunchIdentity, ExecutedSample,
+    ExecutedSendEvidence, ExecutedSensorApplication, ExecutedStream,
+    ExecutedUncertaintyDeclaration, ExecutedUncertaintyReceipt, derivation,
+};
+
+pub(super) const RUN_SEED: u64 = 0x1112_1314_1516_1718;
+const BASELINE_FORCE_BITS: u32 = 0x3f00_0000;
+const HOLD_INTERVAL: u32 = 10;
+const LANE_COUNT: u8 = 4;
+const ARTIFACT_FILL: u8 = 0xcd;
+const RUN_INTENT_FILL: u8 = 0x21;
+
+const CONDITION: &str = concat!(
+    r#"{"schema_version":4,"id":"executed-uncertainty-verified","revision":1,"seed":11,"#,
+    r#""wind":{"steady":{"speed_mps":0.0,"direction_deg":0.0},"gusts":[],"#,
+    r#""turbulence":{"kind":"none"}},"#,
+    r#""timing":{"estimate_delay_ns":0,"update_jitter":{"kind":"none"}},"#,
+    r#""sensor":{"kind":"bounded_noise","lanes":["#,
+    r#"{"sensor":"accelerometer","axis":"x","peak_amplitude_mps2":2.0,"#,
+    r#""update_interval_samples":2}]},"#,
+    r#""actuator":{"authority_scale_basis_points":12000,"#,
+    r#""command_loss":{"kind":"seeded_zero_order_hold","fraction_basis_points":1000,"#,
+    r#""decision_interval_samples":10}},"#,
+    r#""controller_initialization":{"hover_thrust_force":{"kind":"scale_baseline","#,
+    r#""scale_basis_points":9000}},"#,
+    r#""plant":{"payload_mass_delta_kg":0.0,"longitudinal_cg_offset_m":0.0,"#,
+    r#""lateral_cg_offset_m":0.0,"hover_thrust_expectation":{"kind":"measured_weight_ratio"}}}"#,
+);
+
+/// One run the core sealed after verifying every sample it carries.
+pub(super) struct SealedRun {
+    pub(super) receipt: ExecutedUncertaintyReceipt,
+    pub(super) samples: Vec<ExecutedSample>,
+}
+
+/// Seals one complete run of the given length.
+pub(super) fn sealed(count: u64) -> SealedRun {
+    let declaration = declaration();
+    let samples = stream(&declaration, count);
+    let mut verified = ExecutedStream::open(&declaration).expect("open the core stream");
+    for sample in &samples {
+        verified.accept(sample).expect("the core stream verifies");
+    }
+    let summary = verified.close().expect("the core stream seals");
+    let launch = ExecutedLaunchIdentity::new(
+        Digest::from_bytes([RUN_INTENT_FILL; 32]),
+        declaration.artifact_digest,
+        declaration.condition_digest,
+        declaration.run_seed,
+        declaration.required_capabilities.clone(),
+        3,
+    )
+    .expect("launch identity");
+    let receipt = ExecutedUncertaintyReceipt::new(
+        launch,
+        declaration,
+        summary.ledger,
+        summary.sample_stream_digest,
+    )
+    .expect("seal the receipt");
+    SealedRun { receipt, samples }
+}
+
+pub(super) fn declaration() -> ExecutedUncertaintyDeclaration {
+    let condition = ConditionSet::from_json(CONDITION.as_bytes()).expect("condition");
+    ExecutedUncertaintyDeclaration::from_condition(
+        &condition,
+        Digest::from_bytes([ARTIFACT_FILL; 32]),
+        RUN_SEED,
+    )
+    .expect("declaration")
+}
+
+fn stream(declaration: &ExecutedUncertaintyDeclaration, count: u64) -> Vec<ExecutedSample> {
+    let mut executor = Executor {
+        declaration: declaration.clone(),
+        last_accepted: None,
+        interval_index: 0,
+        interval_position: 0,
+        interval_first_sequence: 0,
+        decisions: Vec::new(),
+    };
+    (0..count).map(|index| executor.sample(index)).collect()
+}
+
+struct Executor {
+    declaration: ExecutedUncertaintyDeclaration,
+    last_accepted: Option<[u32; 16]>,
+    interval_index: u64,
+    interval_position: u32,
+    interval_first_sequence: u64,
+    decisions: Vec<bool>,
+}
+
+impl Executor {
+    fn sample(&mut self, sequence: u64) -> ExecutedSample {
+        ExecutedSample {
+            sequence,
+            global_sample_sequence: sequence,
+            simulator_timestamp_us: sequence.wrapping_mul(10_000),
+            sensor: Some(self.sensor(sequence)),
+            actuator: Some(self.actuator(sequence)),
+            constraints: ExecutedConstraintFlags {
+                injection_clamp: false,
+                invalid_actuator_count: false,
+                missing_actuator_answer: false,
+                collective_rate: false,
+                mean_ceiling: false,
+                lane_ceiling: false,
+                ground_squeeze: false,
+                trace_failure: false,
+            },
+            hover: ExecutedHoverInitialization {
+                baseline_force_bits: BASELINE_FORCE_BITS,
+                effective_force_bits: derivation::scaled_hover_force(
+                    BASELINE_FORCE_BITS,
+                    self.declaration.hover_scale_basis_points,
+                ),
+                scale_basis_points: self.declaration.hover_scale_basis_points,
+                estimator_disabled: true,
+                kernel_config_hash: 0x0102_0304_0506_0708,
+            },
+            send: ExecutedSendEvidence {
+                attempted: true,
+                succeeded: true,
+                echoed_timestamp_us: sequence.wrapping_mul(10_000),
+                lockstep: true,
+            },
+            armed: true,
+        }
+    }
+
+    fn sensor(&self, sequence: u64) -> ExecutedSensorApplication {
+        let presence_mask = 0b1001_u16;
+        let mut raw = [None; 12];
+        #[allow(clippy::cast_precision_loss)]
+        let reading = 1.0_f32 + (sequence % 7) as f32;
+        raw[0] = Some(reading.to_bits());
+        raw[3] = Some(0x4000_0000);
+        let mut effective = raw;
+        let mut update_buckets = [None; 12];
+        let mut changed_mask = 0_u16;
+        for declared in &self.declaration.sensor_lanes {
+            let lane = usize::from(declared.lane_tag);
+            let bucket = sequence / u64::from(declared.update_interval_samples);
+            update_buckets[lane] = Some(bucket);
+            let offset = derivation::sensor_offset(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                declared.lane_tag,
+                bucket,
+                f32::from_bits(declared.peak_amplitude_bits),
+            );
+            let value = f32::from_bits(raw[lane].unwrap_or(0));
+            let applied = (value + offset).to_bits();
+            effective[lane] = Some(applied);
+            if applied != raw[lane].unwrap_or(0) {
+                changed_mask |= 1 << declared.lane_tag;
+            }
+        }
+        ExecutedSensorApplication {
+            raw_digest: derivation::sensor_sample_digest(presence_mask, &raw),
+            effective_digest: derivation::sensor_sample_digest(presence_mask, &effective),
+            presence_mask,
+            changed_mask,
+            update_buckets,
+            raw_value_bits: raw,
+            effective_value_bits: effective,
+        }
+    }
+
+    fn actuator(&mut self, sequence: u64) -> ExecutedActuatorApplication {
+        let mut requested = [0_u32; 16];
+        #[allow(clippy::cast_precision_loss)]
+        let command = 0.1_f32 * ((sequence % 5) as f32 + 1.0);
+        for lane in requested.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane = command.to_bits();
+        }
+        let mut scaled = requested;
+        for lane in scaled.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane =
+                derivation::scaled_authority(*lane, self.declaration.authority_scale_basis_points);
+        }
+        let base = ExecutedActuatorApplication {
+            requested_lane_bits: requested,
+            authority_scaled_lane_bits: scaled,
+            effective_lane_bits: scaled,
+            lane_count: LANE_COUNT,
+            eligibility: ExecutedEligibility::Eligible,
+            prime: false,
+            interval_epoch: None,
+            interval_index: None,
+            interval_position: None,
+            interval_identity: None,
+            selected_hold: false,
+            applied_hold: false,
+            interval_complete: false,
+        };
+        if self.last_accepted.is_none() {
+            self.last_accepted = Some(scaled);
+            return ExecutedActuatorApplication {
+                prime: true,
+                ..base
+            };
+        }
+        self.hold(base, scaled, sequence)
+    }
+
+    fn hold(
+        &mut self,
+        base: ExecutedActuatorApplication,
+        scaled: [u32; 16],
+        sequence: u64,
+    ) -> ExecutedActuatorApplication {
+        let hold = self.declaration.command_hold.expect("declared hold");
+        if self.interval_position == 0 {
+            self.interval_first_sequence = sequence;
+            self.decisions = derivation::hold_schedule(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                0,
+                self.interval_index,
+                sequence,
+                hold,
+            )
+            .expect("hold schedule");
+        }
+        let position = self.interval_position;
+        let selected = self.decisions[usize::try_from(position).expect("position")];
+        let effective = if selected {
+            self.last_accepted.expect("accepted command")
+        } else {
+            self.last_accepted = Some(scaled);
+            scaled
+        };
+        let identity = derivation::interval_identity(
+            self.declaration.condition_digest,
+            self.declaration.run_seed,
+            0,
+            self.interval_index,
+            self.interval_first_sequence,
+        );
+        let index = self.interval_index;
+        let complete = position.wrapping_add(1) >= HOLD_INTERVAL;
+        if complete {
+            self.interval_index = self.interval_index.wrapping_add(1);
+            self.interval_position = 0;
+        } else {
+            self.interval_position = position.wrapping_add(1);
+        }
+        ExecutedActuatorApplication {
+            effective_lane_bits: effective,
+            interval_epoch: Some(0),
+            interval_index: Some(index),
+            interval_position: Some(position),
+            interval_identity: Some(identity),
+            selected_hold: selected,
+            applied_hold: selected,
+            interval_complete: complete,
+            ..base
+        }
+    }
+}

--- a/crates/pilotage-tuning-feedback/src/uncertainty/tests/support.rs
+++ b/crates/pilotage-tuning-feedback/src/uncertainty/tests/support.rs
@@ -131,7 +131,9 @@ impl Executor {
             send: ExecutedSendEvidence {
                 attempted: true,
                 succeeded: true,
-                echoed_timestamp_us: sequence.wrapping_mul(10_000),
+                // The transport echoes its own link clock, never the
+                // sample time.
+                echoed_timestamp_us: sequence.wrapping_mul(9_973).wrapping_add(7),
                 lockstep: true,
             },
             armed: true,

--- a/tools/flight-tune-aviate/src/condition.rs
+++ b/tools/flight-tune-aviate/src/condition.rs
@@ -1,0 +1,24 @@
+//! Launching and verifying one deterministic uncertainty condition.
+//!
+//! A non-nominal run states its uncertainty once, as one content-addressed
+//! artifact and the identities that name it. The executor returns those
+//! identities before it arms, then states every sample it flew. Nothing here
+//! trusts a summary: each sample is answered only after the decision it
+//! states has been derived again from the declaration.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+mod error;
+mod frame;
+mod launch;
+mod projection;
+pub mod protocol;
+mod session;
+
+pub use error::AviateConditionError;
+pub use frame::MAX_FRAME_BYTES;
+pub use launch::{ConditionLaunch, TUNING_TRACE_SCHEMA_VERSION};
+pub use session::{ConditionTracePath, accept_timeout};
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune-aviate/src/condition/error.rs
+++ b/tools/flight-tune-aviate/src/condition/error.rs
@@ -1,0 +1,101 @@
+//! Why one uncertainty condition cannot launch, arm, or stay armed.
+
+use std::path::PathBuf;
+
+/// A condition launch, handshake, or trace failure.
+#[derive(Debug, thiserror::Error)]
+pub enum AviateConditionError {
+    /// The backend cannot execute the requested uncertainty.
+    #[error("condition {condition} is not executable on this backend: {source}")]
+    Unsupported {
+        /// The condition-set identifier.
+        condition: String,
+        /// The capability contract failure.
+        #[source]
+        source: flight_tune::ValidationError,
+    },
+    /// The condition or its declaration is not valid.
+    #[error("condition evidence refused: {source}")]
+    Evidence {
+        /// The contract failure.
+        #[source]
+        source: flight_tune::TuneError,
+    },
+    /// The canonical artifact could not be encoded.
+    #[error("condition artifact could not be encoded: {source}")]
+    Encode {
+        /// The encoding failure.
+        #[source]
+        source: flight_tune::CodecError,
+    },
+    /// A file operation on the artifact or its directory failed.
+    #[error("{operation} failed for {path}: {source}")]
+    Artifact {
+        /// The attempted operation.
+        operation: &'static str,
+        /// The path the operation named.
+        path: PathBuf,
+        /// The operating-system failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A trace socket operation failed.
+    #[error("{operation} failed on the condition trace path: {source}")]
+    Trace {
+        /// The attempted operation.
+        operation: &'static str,
+        /// The operating-system failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A trace frame could not be encoded or decoded.
+    #[error("a condition trace frame is not readable: {source}")]
+    Frame {
+        /// The serialization failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A trace frame is larger than the protocol permits.
+    #[error("a condition trace frame states {bytes} bytes")]
+    FrameTooLarge {
+        /// The stated frame size.
+        bytes: usize,
+    },
+    /// The executor spoke a protocol this launch does not speak.
+    #[error("the executor trace protocol is not the launched one: {detail}")]
+    Protocol {
+        /// The refusal detail.
+        detail: String,
+    },
+    /// The executor returned identities other than the launched ones.
+    #[error("the executor returned other run identities: {detail}")]
+    Identity {
+        /// The refusal detail.
+        detail: String,
+    },
+    /// A sample does not state the decision the declaration required.
+    #[error("the executed uncertainty relation failed: {source}")]
+    Relation {
+        /// The relation failure.
+        #[source]
+        source: flight_tune::TuneError,
+    },
+}
+
+impl AviateConditionError {
+    pub(crate) fn protocol(detail: impl Into<String>) -> Self {
+        Self::Protocol {
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn identity(detail: impl Into<String>) -> Self {
+        Self::Identity {
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn trace(operation: &'static str, source: std::io::Error) -> Self {
+        Self::Trace { operation, source }
+    }
+}

--- a/tools/flight-tune-aviate/src/condition/frame.rs
+++ b/tools/flight-tune-aviate/src/condition/frame.rs
@@ -1,0 +1,63 @@
+//! The length-prefixed frames the trace path carries.
+//!
+//! Every frame is a four-byte big-endian length and that many bytes of
+//! compact JSON. The launcher answers every frame before the executor sends
+//! another, so a refused frame stops the run at the sample that caused it.
+
+use std::io::{Read as _, Write as _};
+use std::net::TcpStream;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::error::AviateConditionError;
+
+/// The largest frame the protocol carries.
+pub const MAX_FRAME_BYTES: usize = 65_536;
+
+/// Reads one frame.
+///
+/// # Errors
+///
+/// Returns [`AviateConditionError`] when the socket fails, when the stated
+/// length is larger than the protocol permits, or when the payload is not
+/// the expected document.
+pub fn read<T: DeserializeOwned>(stream: &mut TcpStream) -> Result<T, AviateConditionError> {
+    let mut length = [0_u8; 4];
+    stream
+        .read_exact(&mut length)
+        .map_err(|source| AviateConditionError::trace("read a frame length", source))?;
+    let length = u32::from_be_bytes(length) as usize;
+    if length > MAX_FRAME_BYTES {
+        return Err(AviateConditionError::FrameTooLarge { bytes: length });
+    }
+    let mut payload = vec![0_u8; length];
+    stream
+        .read_exact(&mut payload)
+        .map_err(|source| AviateConditionError::trace("read a frame payload", source))?;
+    serde_json::from_slice(&payload).map_err(|source| AviateConditionError::Frame { source })
+}
+
+/// Writes one frame.
+///
+/// # Errors
+///
+/// Returns [`AviateConditionError`] when the document cannot be encoded,
+/// when it is larger than the protocol permits, or when the socket fails.
+pub fn write<T: Serialize>(stream: &mut TcpStream, frame: &T) -> Result<(), AviateConditionError> {
+    let payload =
+        serde_json::to_vec(frame).map_err(|source| AviateConditionError::Frame { source })?;
+    let length = u32::try_from(payload.len()).map_err(|_| AviateConditionError::FrameTooLarge {
+        bytes: payload.len(),
+    })?;
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(AviateConditionError::FrameTooLarge {
+            bytes: payload.len(),
+        });
+    }
+    stream
+        .write_all(&length.to_be_bytes())
+        .and_then(|()| stream.write_all(&payload))
+        .and_then(|()| stream.flush())
+        .map_err(|source| AviateConditionError::trace("write a frame", source))
+}

--- a/tools/flight-tune-aviate/src/condition/launch.rs
+++ b/tools/flight-tune-aviate/src/condition/launch.rs
@@ -1,0 +1,198 @@
+//! The one content-addressed artifact a non-nominal run launches with.
+//!
+//! The executor receives the artifact path, the identity of its exact bytes,
+//! the canonical condition identity inside them, the run seed, and the
+//! capability set the condition needs. It receives them as explicit launch
+//! arguments, so no part of the run's uncertainty can arrive through a name
+//! the launcher never stated.
+//!
+//! Nothing is written before the backend has been asked whether it can
+//! execute the condition at all. A backend that declares no uncertainty
+//! capability refuses the condition before the artifact exists.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use flight_tune::{
+    ConditionAdmission, ConditionSet, Digest, ExecutedLaunchIdentity,
+    ExecutedUncertaintyDeclaration, executed_run_seed,
+};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::error::AviateConditionError;
+
+/// The trace protocol version this launch speaks.
+pub const TUNING_TRACE_SCHEMA_VERSION: u16 = 3;
+
+const ARTIFACT_NAME: &str = "condition.json";
+const MANIFEST_NAME: &str = "run-manifest.toml";
+
+/// One prepared non-nominal condition launch.
+#[derive(Clone, Debug)]
+pub struct ConditionLaunch {
+    identity: ExecutedLaunchIdentity,
+    declaration: ExecutedUncertaintyDeclaration,
+    artifact_path: PathBuf,
+    manifest_path: PathBuf,
+    trace_endpoint: SocketAddr,
+}
+
+impl ConditionLaunch {
+    /// Prepares one condition for launch after the backend admits it.
+    ///
+    /// The admission runs first, so a backend that cannot execute the
+    /// condition refuses it before any file exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateConditionError`] when the backend cannot execute the
+    /// condition, when the condition is nominal, when the artifact cannot be
+    /// encoded, or when it cannot be made durable.
+    pub fn prepare_blocking(
+        condition: &ConditionSet,
+        admission: &ConditionAdmission,
+        run_intent_digest: Digest,
+        directory: &Path,
+        trace_endpoint: SocketAddr,
+    ) -> Result<Self, AviateConditionError> {
+        admission
+            .prepare(condition)
+            .map_err(|source| unsupported(condition, source))?;
+        let run_seed = executed_run_seed(run_intent_digest);
+        let bytes = artifact_bytes(condition)?;
+        let artifact_digest = Digest::from_bytes(Sha256::digest(&bytes).into());
+        let declaration =
+            ExecutedUncertaintyDeclaration::from_condition(condition, artifact_digest, run_seed)
+                .map_err(|source| AviateConditionError::Evidence { source })?;
+        if declaration.is_nominal() {
+            return Err(AviateConditionError::protocol(
+                "a nominal condition needs no launch artifact",
+            ));
+        }
+        let identity = ExecutedLaunchIdentity::new(
+            run_intent_digest,
+            artifact_digest,
+            declaration.condition_digest,
+            run_seed,
+            declaration.required_capabilities.clone(),
+            TUNING_TRACE_SCHEMA_VERSION,
+        )
+        .map_err(|source| AviateConditionError::Evidence { source })?;
+        let artifact_path = directory.join(ARTIFACT_NAME);
+        write_artifact_blocking(&artifact_path, &bytes)?;
+        Ok(Self {
+            identity,
+            declaration,
+            artifact_path,
+            manifest_path: directory.join(MANIFEST_NAME),
+            trace_endpoint,
+        })
+    }
+
+    /// Returns the complete condition arguments, after argument zero.
+    ///
+    /// The executor accepts the five condition arguments together or not at
+    /// all, and refuses a condition run that names no trace path or run
+    /// manifest, so the whole set is one value.
+    #[must_use]
+    pub fn arguments(&self) -> Vec<String> {
+        vec![
+            "--condition-artifact".to_owned(),
+            self.artifact_path.to_string_lossy().into_owned(),
+            "--condition-artifact-sha256".to_owned(),
+            self.identity.artifact_digest.to_string(),
+            "--condition-digest".to_owned(),
+            self.identity.condition_digest.to_string(),
+            "--run-seed".to_owned(),
+            self.identity.run_seed.to_string(),
+            "--required-perturbation-capabilities".to_owned(),
+            capability_argument(&self.identity),
+            "--tuning-trace-endpoint".to_owned(),
+            self.trace_endpoint.to_string(),
+            "--run-manifest".to_owned(),
+            self.manifest_path.to_string_lossy().into_owned(),
+        ]
+    }
+
+    /// Returns the identities the executor must return before arming.
+    #[must_use]
+    pub const fn identity(&self) -> &ExecutedLaunchIdentity {
+        &self.identity
+    }
+
+    /// Returns what this launch declared the run would execute.
+    #[must_use]
+    pub const fn declaration(&self) -> &ExecutedUncertaintyDeclaration {
+        &self.declaration
+    }
+
+    /// Returns the path of the exact artifact the executor must load.
+    #[must_use]
+    pub fn artifact_path(&self) -> &Path {
+        &self.artifact_path
+    }
+
+    /// Returns the path the executor must write its run manifest to.
+    #[must_use]
+    pub fn manifest_path(&self) -> &Path {
+        &self.manifest_path
+    }
+}
+
+/// Joins the capability names the executor must supply.
+///
+/// The executor parses this value without trimming and requires it to be
+/// strictly ascending by name, so the separator carries no space and the
+/// order is the declared one.
+fn capability_argument(identity: &ExecutedLaunchIdentity) -> String {
+    identity
+        .required_capabilities
+        .iter()
+        .map(|capability| capability.as_str())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Encodes the exact bytes the artifact file carries.
+///
+/// The file is the canonical condition document and one closing line end.
+/// The line end keeps the identity of the bytes separate from the identity
+/// of the document inside them, so an argument that names one cannot pass
+/// for the other.
+fn artifact_bytes(condition: &ConditionSet) -> Result<Vec<u8>, AviateConditionError> {
+    let mut bytes = condition
+        .to_canonical_json()
+        .map_err(|source| AviateConditionError::Encode { source })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn write_artifact_blocking(path: &Path, bytes: &[u8]) -> Result<(), AviateConditionError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| AviateConditionError::Artifact {
+            operation: "create the condition artifact directory",
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    std::fs::write(path, bytes).map_err(|source| AviateConditionError::Artifact {
+        operation: "write the condition artifact",
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn unsupported(
+    condition: &ConditionSet,
+    source: flight_tune::ScenarioRuntimeError,
+) -> AviateConditionError {
+    match source {
+        flight_tune::ScenarioRuntimeError::UnsupportedCondition { source, .. } => {
+            AviateConditionError::Unsupported {
+                condition: condition.id.clone(),
+                source,
+            }
+        }
+        other => AviateConditionError::protocol(other.to_string()),
+    }
+}

--- a/tools/flight-tune-aviate/src/condition/projection.rs
+++ b/tools/flight-tune-aviate/src/condition/projection.rs
@@ -1,0 +1,134 @@
+//! Projecting one executor frame onto the evidence this launcher answers for.
+//!
+//! The executor states more about a sample than the uncertainty relation
+//! needs. The projection keeps exactly the values the relation is derived
+//! from, so a field this repository cannot check never enters the counts it
+//! publishes.
+
+use flight_tune::{
+    Digest, ExecutedActuatorApplication, ExecutedBypassReason, ExecutedConstraintFlags,
+    ExecutedEligibility, ExecutedHoverInitialization, ExecutedSample, ExecutedSendEvidence,
+    ExecutedSensorApplication,
+};
+
+use super::error::AviateConditionError;
+use super::protocol::{
+    TuningActuatorApplication, TuningActuatorBypassReason, TuningActuatorEligibility,
+    TuningControlObservation, TuningFrameType, TuningSensorApplication,
+};
+
+/// Projects one observation onto the sample the relation is derived from.
+///
+/// # Errors
+///
+/// Returns [`AviateConditionError`] when the frame is not an observation,
+/// when it speaks another protocol version, or when it reports its own
+/// trace failure.
+pub fn sample(
+    observation: &TuningControlObservation,
+    schema_version: u16,
+    estimator_disabled: bool,
+) -> Result<ExecutedSample, AviateConditionError> {
+    if observation.frame_type != TuningFrameType::AviateControlObservation {
+        return Err(AviateConditionError::protocol(
+            "a trace frame is not an observation",
+        ));
+    }
+    if observation.schema_version != schema_version {
+        return Err(AviateConditionError::protocol(
+            "an observation speaks another trace protocol version",
+        ));
+    }
+    if observation.constraint_flags.tuning_trace_failure {
+        return Err(AviateConditionError::protocol(
+            "an observation reports its own trace failure",
+        ));
+    }
+    Ok(ExecutedSample {
+        sequence: observation.sequence,
+        global_sample_sequence: observation.global_sample_sequence,
+        simulator_timestamp_us: observation.simulator_timestamp_us,
+        sensor: observation.sensor_application.map(sensor),
+        actuator: observation.actuator_application.map(actuator),
+        constraints: constraints(observation),
+        hover: ExecutedHoverInitialization {
+            baseline_force_bits: observation.hover_initialization.baseline_force_bits,
+            effective_force_bits: observation.hover_initialization.effective_force_bits,
+            scale_basis_points: observation.hover_initialization.scale_basis_points,
+            estimator_disabled,
+            kernel_config_hash: observation.hover_initialization.kernel_config_hash,
+        },
+        send: ExecutedSendEvidence {
+            attempted: observation.send.reply_attempted,
+            succeeded: observation.send.reply_succeeded,
+            echoed_timestamp_us: observation.send.echoed_timestamp_us,
+            lockstep: observation.send.lockstep,
+        },
+        armed: observation.armed,
+    })
+}
+
+fn sensor(application: TuningSensorApplication) -> ExecutedSensorApplication {
+    ExecutedSensorApplication {
+        raw_digest: Digest::from_bytes(application.raw_digest),
+        effective_digest: Digest::from_bytes(application.effective_digest),
+        presence_mask: application.presence_mask,
+        changed_mask: application.changed_mask,
+        update_buckets: application.update_buckets,
+        raw_value_bits: application.raw_value_bits,
+        effective_value_bits: application.effective_value_bits,
+    }
+}
+
+fn actuator(application: TuningActuatorApplication) -> ExecutedActuatorApplication {
+    ExecutedActuatorApplication {
+        requested_lane_bits: application.requested_lane_bits,
+        authority_scaled_lane_bits: application.authority_scaled_lane_bits,
+        effective_lane_bits: application.effective_lane_bits,
+        lane_count: application.lane_count,
+        eligibility: eligibility(application.eligibility),
+        prime: application.prime,
+        interval_epoch: application.interval_epoch,
+        interval_index: application.interval_index,
+        interval_position: application.interval_position,
+        interval_identity: application.interval_identity.map(Digest::from_bytes),
+        selected_hold: application.selected_hold,
+        applied_hold: application.applied_hold,
+        interval_complete: application.interval_complete,
+    }
+}
+
+const fn eligibility(value: TuningActuatorEligibility) -> ExecutedEligibility {
+    match value {
+        TuningActuatorEligibility::Eligible => ExecutedEligibility::Eligible,
+        TuningActuatorEligibility::Bypass(reason) => ExecutedEligibility::Bypass(match reason {
+            TuningActuatorBypassReason::MissingAnswer => ExecutedBypassReason::MissingAnswer,
+            TuningActuatorBypassReason::InvalidActuatorCount => {
+                ExecutedBypassReason::InvalidActuatorCount
+            }
+            TuningActuatorBypassReason::Backup => ExecutedBypassReason::Backup,
+            TuningActuatorBypassReason::Direct => ExecutedBypassReason::Direct,
+            TuningActuatorBypassReason::Failsafe => ExecutedBypassReason::Failsafe,
+            TuningActuatorBypassReason::FallbackMask => ExecutedBypassReason::FallbackMask,
+            TuningActuatorBypassReason::ArmTransition => ExecutedBypassReason::ArmTransition,
+            TuningActuatorBypassReason::Disarmed => ExecutedBypassReason::Disarmed,
+            TuningActuatorBypassReason::EmergencyTermination => {
+                ExecutedBypassReason::EmergencyTermination
+            }
+        }),
+    }
+}
+
+const fn constraints(observation: &TuningControlObservation) -> ExecutedConstraintFlags {
+    let flags = observation.constraint_flags;
+    ExecutedConstraintFlags {
+        injection_clamp: flags.injection_clamp,
+        invalid_actuator_count: flags.invalid_actuator_count,
+        missing_actuator_answer: flags.missing_actuator_answer,
+        collective_rate: flags.collective_rate,
+        mean_ceiling: flags.mean_ceiling,
+        lane_ceiling: flags.lane_ceiling,
+        ground_squeeze: flags.ground_squeeze,
+        trace_failure: flags.tuning_trace_failure,
+    }
+}

--- a/tools/flight-tune-aviate/src/condition/projection.rs
+++ b/tools/flight-tune-aviate/src/condition/projection.rs
@@ -22,12 +22,13 @@ use super::protocol::{
 /// # Errors
 ///
 /// Returns [`AviateConditionError`] when the frame is not an observation,
-/// when it speaks another protocol version, or when it reports its own
-/// trace failure.
+/// when it speaks another protocol version, when it reports its own trace
+/// failure, or when it names a kernel other than the handshake one.
 pub fn sample(
     observation: &TuningControlObservation,
     schema_version: u16,
     estimator_disabled: bool,
+    kernel_config_hash: u64,
 ) -> Result<ExecutedSample, AviateConditionError> {
     if observation.frame_type != TuningFrameType::AviateControlObservation {
         return Err(AviateConditionError::protocol(
@@ -42,6 +43,11 @@ pub fn sample(
     if observation.constraint_flags.tuning_trace_failure {
         return Err(AviateConditionError::protocol(
             "an observation reports its own trace failure",
+        ));
+    }
+    if observation.hover_initialization.kernel_config_hash != kernel_config_hash {
+        return Err(AviateConditionError::identity(
+            "a sample names another kernel than the one the handshake stated",
         ));
     }
     Ok(ExecutedSample {

--- a/tools/flight-tune-aviate/src/condition/protocol.rs
+++ b/tools/flight-tune-aviate/src/condition/protocol.rs
@@ -1,0 +1,286 @@
+//! The trace frames the executor and this launcher exchange.
+//!
+//! The shapes here match the executing contract by value: every serialized
+//! name, every tag, and every encoding is the one the executor writes. A
+//! field the launcher does not answer for is not mirrored, so the observation
+//! carries the projection this repository is accountable for rather than the
+//! executor's complete record.
+
+use serde::{Deserialize, Serialize};
+
+/// The frames the trace protocol names.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TuningFrameType {
+    /// The executor states its run identities.
+    AviateTuningHandshake,
+    /// The launcher accepts those identities.
+    AviateTuningReady,
+    /// The executor states one sample.
+    AviateControlObservation,
+    /// The launcher accepts one sample.
+    AviateTuningObservationAck,
+}
+
+/// One Aviate-owned perturbation capability.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TuningPerturbationCapability {
+    /// Scale eligible actuator commands.
+    ActuatorAuthority,
+    /// Apply a deterministic command hold.
+    CommandHold,
+    /// Scale the controller hover-force initialization.
+    HoverTrimUncertainty,
+    /// Apply deterministic bounded sensor perturbations.
+    SensorPerturbation,
+}
+
+/// The online hover-estimator state for one run.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TuningHoverEstimatorMode {
+    /// The estimator can write over the hover force.
+    Online,
+    /// No online component changes the hover force.
+    Disabled,
+    /// The estimator keeps one fixed value.
+    Frozen,
+}
+
+/// The run identities the executor states before its first sample.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TuningHandshake {
+    /// The frame kind.
+    #[serde(rename = "type")]
+    pub frame_type: TuningFrameType,
+    /// The trace protocol version.
+    pub schema_version: u16,
+    /// The identity of the exact run manifest text.
+    pub run_manifest_digest: String,
+    /// The identity of the resolved kernel.
+    pub kernel_config_hash: String,
+    /// The path of the loaded condition artifact.
+    #[serde(default)]
+    pub condition_artifact_path: Option<String>,
+    /// The identity of the exact condition artifact bytes.
+    #[serde(default)]
+    pub condition_artifact_sha256: Option<String>,
+    /// The identity of the canonical condition document.
+    #[serde(default)]
+    pub condition_digest: Option<String>,
+    /// The seed for every deterministic decision in this run.
+    #[serde(default)]
+    pub condition_run_seed: Option<u64>,
+    /// The capabilities the loaded condition needs, in ascending name order.
+    #[serde(default)]
+    pub condition_required_capabilities: Option<Vec<TuningPerturbationCapability>>,
+    /// The preset hover-force baseline.
+    pub hover_baseline_force_bits: u32,
+    /// The hover force the controller was built with.
+    pub hover_effective_force_bits: u32,
+    /// The applied hover-force scale.
+    pub hover_scale_basis_points: u16,
+    /// The online hover-estimator state for this run.
+    pub hover_estimator_mode: TuningHoverEstimatorMode,
+    /// The kernel identity that carries the hover force.
+    pub hover_kernel_config_hash: String,
+}
+
+/// The launcher's acceptance of one handshake.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningReady {
+    /// The frame kind.
+    #[serde(rename = "type")]
+    pub frame_type: TuningFrameType,
+    /// The trace protocol version.
+    pub schema_version: u16,
+    /// The run manifest identity the handshake stated.
+    pub run_manifest_digest: String,
+}
+
+/// The launcher's acceptance of one sample.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningObservationAck {
+    /// The frame kind.
+    #[serde(rename = "type")]
+    pub frame_type: TuningFrameType,
+    /// The trace protocol version.
+    pub schema_version: u16,
+    /// The run manifest identity the handshake stated.
+    pub run_manifest_digest: String,
+    /// The sequence this acceptance answers.
+    pub sequence: u64,
+}
+
+/// Sensor values before and after one deterministic perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningSensorApplication {
+    /// The identity of the values read before any change.
+    pub raw_digest: [u8; 32],
+    /// The identity of the values the controller received.
+    pub effective_digest: [u8; 32],
+    /// The lanes this sample carried, in stable lane order.
+    pub presence_mask: u16,
+    /// The lanes whose exact value moved.
+    pub changed_mask: u16,
+    /// The held-offset bucket for each configured and present lane.
+    pub update_buckets: [Option<u64>; 12],
+    /// The exact values read, in stable lane order.
+    pub raw_value_bits: [Option<u32>; 12],
+    /// The exact values the controller received, in stable lane order.
+    pub effective_value_bits: [Option<u32>; 12],
+}
+
+/// Why one sample carried no actuator perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TuningActuatorBypassReason {
+    /// The controller supplied no actuator answer.
+    MissingAnswer,
+    /// The answer named a different number of lanes.
+    InvalidActuatorCount,
+    /// A backup path produced the command.
+    Backup,
+    /// A direct command reached the actuator.
+    Direct,
+    /// A failsafe produced the command.
+    Failsafe,
+    /// The controller raised a fallback lane.
+    FallbackMask,
+    /// The armed state changed on this sample.
+    ArmTransition,
+    /// The vehicle was not armed.
+    Disarmed,
+    /// An emergency termination produced the command.
+    EmergencyTermination,
+}
+
+/// Whether one sample was eligible for an actuator perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "reason", rename_all = "kebab-case")]
+pub enum TuningActuatorEligibility {
+    /// The sample was eligible.
+    Eligible,
+    /// The sample bypassed every perturbation policy.
+    Bypass(TuningActuatorBypassReason),
+}
+
+/// Actuator values before the plant constraints and transforms.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningActuatorApplication {
+    /// The exact values the controller requested.
+    pub requested_lane_bits: [u32; 16],
+    /// The exact values after the authority scale.
+    pub authority_scaled_lane_bits: [u32; 16],
+    /// The exact values the plant boundary received.
+    pub effective_lane_bits: [u32; 16],
+    /// The number of active actuator lanes.
+    pub lane_count: u8,
+    /// The armed state in the actuator answer.
+    pub actuator_answer_armed: bool,
+    /// The controller fallback lanes this sample raised.
+    pub kernel_fallback_mask: u8,
+    /// Whether this sample was eligible for a perturbation.
+    pub eligibility: TuningActuatorEligibility,
+    /// Whether this sample only primed the accepted-command history.
+    pub prime: bool,
+    /// The interval epoch, which a bypass advances.
+    pub interval_epoch: Option<u64>,
+    /// The interval index inside the current epoch.
+    pub interval_index: Option<u64>,
+    /// The zero-based position inside the current interval.
+    pub interval_position: Option<u32>,
+    /// The identity of the current interval.
+    pub interval_identity: Option<[u8; 32]>,
+    /// Whether the seeded schedule selected a hold at this position.
+    pub selected_hold: bool,
+    /// Whether the executor applied a hold at this position.
+    pub applied_hold: bool,
+    /// Whether this sample completed the interval.
+    pub interval_complete: bool,
+}
+
+/// The plant constraints one sample reported.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningConstraintFlags {
+    /// A requested injection did not reach the plant unchanged.
+    pub injection_clamp: bool,
+    /// The answer named a different number of lanes.
+    pub invalid_actuator_count: bool,
+    /// The controller supplied no actuator answer.
+    pub missing_actuator_answer: bool,
+    /// A collective rate limit changed a lane.
+    pub collective_rate: bool,
+    /// A mean ceiling changed a lane.
+    pub mean_ceiling: bool,
+    /// A single-lane ceiling changed a lane.
+    pub lane_ceiling: bool,
+    /// A ground constraint changed a lane.
+    pub ground_squeeze: bool,
+    /// The trace path itself failed on this sample.
+    pub tuning_trace_failure: bool,
+}
+
+/// The controller hover initialization one sample repeats.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningHoverInitialization {
+    /// The preset force-domain baseline.
+    pub baseline_force_bits: u32,
+    /// The force-domain value the controller was built with.
+    pub effective_force_bits: u32,
+    /// The applied hover-force scale.
+    pub scale_basis_points: u16,
+    /// The resolved kernel identity that carries this value.
+    pub kernel_config_hash: u64,
+}
+
+/// The one actuator send this sample attempted.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TuningSendEvidence {
+    /// Whether the executor attempted the send.
+    pub reply_attempted: bool,
+    /// Whether the send completed.
+    pub reply_succeeded: bool,
+    /// The sample time the send echoed.
+    pub echoed_timestamp_us: u64,
+    /// Whether the send answered the sensor sample in lockstep.
+    pub lockstep: bool,
+}
+
+/// One high-rate observation the launcher answers for.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TuningControlObservation {
+    /// The frame kind.
+    #[serde(rename = "type")]
+    pub frame_type: TuningFrameType,
+    /// The trace protocol version.
+    pub schema_version: u16,
+    /// The gap-free sequence the trace publisher assigned.
+    pub sequence: u64,
+    /// The simulator sample time.
+    pub simulator_timestamp_us: u64,
+    /// The global sample sequence every seeded decision uses.
+    pub global_sample_sequence: u64,
+    /// The sensor evidence, when this sample carried sensor values.
+    #[serde(default)]
+    pub sensor_application: Option<TuningSensorApplication>,
+    /// The actuator evidence, when this sample commanded the actuator.
+    #[serde(default)]
+    pub actuator_application: Option<TuningActuatorApplication>,
+    /// The plant constraints this sample reported.
+    pub constraint_flags: TuningConstraintFlags,
+    /// The repeated controller hover initialization.
+    pub hover_initialization: TuningHoverInitialization,
+    /// The one send this sample attempted.
+    pub send: TuningSendEvidence,
+    /// The kernel armed state after this sample.
+    pub armed: bool,
+}

--- a/tools/flight-tune-aviate/src/condition/session.rs
+++ b/tools/flight-tune-aviate/src/condition/session.rs
@@ -1,0 +1,302 @@
+//! The trace path one non-nominal run is verified over.
+//!
+//! The launcher binds a loopback port before the executor starts, so the
+//! endpoint the executor connects to is one the launch stated. The executor
+//! opens the connection and states its run identities; the launcher accepts
+//! them only when they are the identities it launched, and it acknowledges a
+//! sample only after deriving every decision that sample states.
+//!
+//! An unacknowledged sample stops the executor, so a refusal here ends the
+//! run rather than leaving a run that looks complete.
+
+use std::io::ErrorKind;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::time::Duration;
+
+use flight_tune::{
+    Digest, ExecutedLaunchIdentity, ExecutedStream, ExecutedUncertaintyReceipt, derivation,
+};
+
+use super::error::AviateConditionError;
+use super::launch::ConditionLaunch;
+use super::protocol::{
+    TuningControlObservation, TuningFrameType, TuningHandshake, TuningHoverEstimatorMode,
+    TuningObservationAck, TuningPerturbationCapability, TuningReady,
+};
+use super::{frame, projection};
+
+const ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
+const FRAME_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One bound loopback trace path, before the executor starts.
+#[derive(Debug)]
+pub struct ConditionTracePath {
+    listener: TcpListener,
+    endpoint: SocketAddr,
+}
+
+impl ConditionTracePath {
+    /// Binds one loopback trace path.
+    ///
+    /// The executor refuses an endpoint that is not on the loopback address,
+    /// and the port is chosen by the operating system, so the launch states
+    /// an endpoint no other run can hold.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateConditionError`] when the socket cannot be bound.
+    pub fn bind_blocking() -> Result<Self, AviateConditionError> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .map_err(|source| AviateConditionError::trace("bind the trace path", source))?;
+        let endpoint = listener
+            .local_addr()
+            .map_err(|source| AviateConditionError::trace("read the trace endpoint", source))?;
+        Ok(Self { listener, endpoint })
+    }
+
+    /// Returns the endpoint the launch must state.
+    #[must_use]
+    pub const fn endpoint(&self) -> SocketAddr {
+        self.endpoint
+    }
+
+    /// Verifies one complete run and seals what it executed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AviateConditionError`] when the executor never connects,
+    /// when it returns other identities, when the trace path fails, or when
+    /// any sample does not state the decision the declaration required.
+    pub fn verify_blocking(
+        self,
+        launch: &ConditionLaunch,
+    ) -> Result<ExecutedUncertaintyReceipt, AviateConditionError> {
+        let mut stream = self.accept_blocking()?;
+        let handshake = frame::read::<TuningHandshake>(&mut stream)?;
+        let returned = require_handshake(&handshake, launch)?;
+        launch
+            .identity()
+            .require_returned(&returned)
+            .map_err(|source| AviateConditionError::identity(source.to_string()))?;
+        frame::write(
+            &mut stream,
+            &TuningReady {
+                frame_type: TuningFrameType::AviateTuningReady,
+                schema_version: launch.identity().trace_schema_version,
+                run_manifest_digest: handshake.run_manifest_digest.clone(),
+            },
+        )?;
+        self::verify_samples(&mut stream, launch, &handshake)
+    }
+
+    fn accept_blocking(&self) -> Result<TcpStream, AviateConditionError> {
+        self.listener
+            .set_nonblocking(false)
+            .map_err(|source| AviateConditionError::trace("arm the trace path", source))?;
+        let (stream, peer) = self
+            .listener
+            .accept()
+            .map_err(|source| AviateConditionError::trace("accept the trace path", source))?;
+        if !peer.ip().is_loopback() {
+            return Err(AviateConditionError::protocol(
+                "a trace connection arrived from outside the loopback address",
+            ));
+        }
+        stream
+            .set_read_timeout(Some(FRAME_TIMEOUT))
+            .and_then(|()| stream.set_write_timeout(Some(FRAME_TIMEOUT)))
+            .and_then(|()| stream.set_nodelay(true))
+            .map_err(|source| AviateConditionError::trace("arm the trace connection", source))?;
+        Ok(stream)
+    }
+}
+
+/// Reads and verifies every sample until the executor closes the path.
+fn verify_samples(
+    stream: &mut TcpStream,
+    launch: &ConditionLaunch,
+    handshake: &TuningHandshake,
+) -> Result<ExecutedUncertaintyReceipt, AviateConditionError> {
+    let declaration = launch.declaration();
+    let mut verified = ExecutedStream::open(declaration)
+        .map_err(|source| AviateConditionError::Relation { source })?;
+    let estimator_disabled = handshake.hover_estimator_mode != TuningHoverEstimatorMode::Online;
+    loop {
+        let observation = match frame::read::<TuningControlObservation>(stream) {
+            Ok(observation) => observation,
+            Err(AviateConditionError::Trace { source, .. })
+                if source.kind() == ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(error) => return Err(error),
+        };
+        let sample = projection::sample(
+            &observation,
+            launch.identity().trace_schema_version,
+            estimator_disabled,
+        )?;
+        verified
+            .accept(&sample)
+            .map_err(|source| AviateConditionError::Relation { source })?;
+        frame::write(
+            stream,
+            &TuningObservationAck {
+                frame_type: TuningFrameType::AviateTuningObservationAck,
+                schema_version: launch.identity().trace_schema_version,
+                run_manifest_digest: handshake.run_manifest_digest.clone(),
+                sequence: observation.sequence,
+            },
+        )?;
+    }
+    let summary = verified
+        .close()
+        .map_err(|source| AviateConditionError::Relation { source })?;
+    ExecutedUncertaintyReceipt::new(
+        launch.identity().clone(),
+        declaration.clone(),
+        summary.ledger,
+        summary.sample_stream_digest,
+    )
+    .map_err(|source| AviateConditionError::Evidence { source })
+}
+
+/// Reads the identities one handshake returns.
+///
+/// The handshake must state the trace protocol, one complete condition
+/// identity set, and a hover initialization the launcher can derive. A
+/// handshake that omits any of these states nothing about the run.
+fn require_handshake(
+    handshake: &TuningHandshake,
+    launch: &ConditionLaunch,
+) -> Result<ExecutedLaunchIdentity, AviateConditionError> {
+    let expected = launch.identity();
+    if handshake.frame_type != TuningFrameType::AviateTuningHandshake
+        || handshake.schema_version != expected.trace_schema_version
+    {
+        return Err(AviateConditionError::protocol(
+            "the executor opened another trace protocol",
+        ));
+    }
+    require_hover(handshake, launch)?;
+    require_artifact_path(handshake, launch)?;
+    let capabilities = handshake
+        .condition_required_capabilities
+        .as_ref()
+        .ok_or_else(|| AviateConditionError::identity("the executor loaded no condition"))?;
+    ExecutedLaunchIdentity::new(
+        expected.run_intent_digest,
+        require_digest(handshake.condition_artifact_sha256.as_deref(), "artifact")?,
+        require_digest(handshake.condition_digest.as_deref(), "condition")?,
+        handshake
+            .condition_run_seed
+            .ok_or_else(|| AviateConditionError::identity("the executor states no run seed"))?,
+        capabilities.iter().copied().map(capability).collect(),
+        handshake.schema_version,
+    )
+    .map_err(|source| AviateConditionError::identity(source.to_string()))
+}
+
+/// Requires the hover initialization the executor states to be derivable.
+fn require_hover(
+    handshake: &TuningHandshake,
+    launch: &ConditionLaunch,
+) -> Result<(), AviateConditionError> {
+    if handshake.hover_estimator_mode == TuningHoverEstimatorMode::Online {
+        return Err(AviateConditionError::identity(
+            "the executor states an active online hover estimator",
+        ));
+    }
+    if handshake.hover_kernel_config_hash != handshake.kernel_config_hash {
+        return Err(AviateConditionError::identity(
+            "the hover force is not carried by the resolved kernel",
+        ));
+    }
+    if handshake.hover_scale_basis_points != launch.declaration().hover_scale_basis_points {
+        return Err(AviateConditionError::identity(
+            "the executor applied another hover force scale than the declared one",
+        ));
+    }
+    let derived = derivation::scaled_hover_force(
+        handshake.hover_baseline_force_bits,
+        handshake.hover_scale_basis_points,
+    );
+    if derived != handshake.hover_effective_force_bits {
+        return Err(AviateConditionError::identity(
+            "the hover force does not follow from its baseline and scale",
+        ));
+    }
+    Ok(())
+}
+
+/// Requires the executor to name the artifact this launch wrote.
+fn require_artifact_path(
+    handshake: &TuningHandshake,
+    launch: &ConditionLaunch,
+) -> Result<(), AviateConditionError> {
+    let stated = handshake
+        .condition_artifact_path
+        .as_deref()
+        .ok_or_else(|| {
+            AviateConditionError::identity("the executor names no condition artifact")
+        })?;
+    if stated != launch.artifact_path().to_string_lossy() {
+        return Err(AviateConditionError::identity(
+            "the executor loaded another condition artifact",
+        ));
+    }
+    Ok(())
+}
+
+const fn capability(value: TuningPerturbationCapability) -> flight_tune::BackendCapability {
+    match value {
+        TuningPerturbationCapability::ActuatorAuthority => {
+            flight_tune::BackendCapability::ActuatorAuthority
+        }
+        TuningPerturbationCapability::CommandHold => flight_tune::BackendCapability::CommandHold,
+        TuningPerturbationCapability::HoverTrimUncertainty => {
+            flight_tune::BackendCapability::HoverTrimUncertainty
+        }
+        TuningPerturbationCapability::SensorPerturbation => {
+            flight_tune::BackendCapability::SensorPerturbation
+        }
+    }
+}
+
+/// Reads one 64-character lowercase identity the executor states.
+fn require_digest(
+    stated: Option<&str>,
+    name: &'static str,
+) -> Result<Digest, AviateConditionError> {
+    let stated = stated
+        .ok_or_else(|| AviateConditionError::identity(format!("the executor states no {name}")))?;
+    let mut bytes = [0_u8; 32];
+    if stated.len() != 64 {
+        return Err(AviateConditionError::identity(format!(
+            "the executor {name} identity is not one digest"
+        )));
+    }
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        let pair = stated
+            .get(index * 2..index * 2 + 2)
+            .ok_or_else(|| AviateConditionError::identity("an identity is not readable"))?;
+        if pair
+            .bytes()
+            .any(|value| !value.is_ascii_lowercase() && !value.is_ascii_digit())
+        {
+            return Err(AviateConditionError::identity(format!(
+                "the executor {name} identity is not lowercase"
+            )));
+        }
+        *byte = u8::from_str_radix(pair, 16).map_err(|_| {
+            AviateConditionError::identity(format!("the executor {name} identity is not a digest"))
+        })?;
+    }
+    Ok(Digest::from_bytes(bytes))
+}
+
+/// The time the launcher waits for the executor to open the trace path.
+#[must_use]
+pub const fn accept_timeout() -> Duration {
+    ACCEPT_TIMEOUT
+}

--- a/tools/flight-tune-aviate/src/condition/session.rs
+++ b/tools/flight-tune-aviate/src/condition/session.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use flight_tune::{
     Digest, ExecutedLaunchIdentity, ExecutedStream, ExecutedUncertaintyReceipt, derivation,
 };
+use sha2::{Digest as ShaDigest, Sha256};
 
 use super::error::AviateConditionError;
 use super::launch::ConditionLaunch;
@@ -121,6 +122,7 @@ fn verify_samples(
     let mut verified = ExecutedStream::open(declaration)
         .map_err(|source| AviateConditionError::Relation { source })?;
     let estimator_disabled = handshake.hover_estimator_mode != TuningHoverEstimatorMode::Online;
+    let kernel_config_hash = require_kernel_hash(&handshake.kernel_config_hash)?;
     loop {
         let observation = match frame::read::<TuningControlObservation>(stream) {
             Ok(observation) => observation,
@@ -135,6 +137,7 @@ fn verify_samples(
             &observation,
             launch.identity().trace_schema_version,
             estimator_disabled,
+            kernel_config_hash,
         )?;
         verified
             .accept(&sample)
@@ -180,6 +183,7 @@ fn require_handshake(
     }
     require_hover(handshake, launch)?;
     require_artifact_path(handshake, launch)?;
+    require_manifest(handshake, launch)?;
     let capabilities = handshake
         .condition_required_capabilities
         .as_ref()
@@ -261,6 +265,66 @@ const fn capability(value: TuningPerturbationCapability) -> flight_tune::Backend
             flight_tune::BackendCapability::SensorPerturbation
         }
     }
+}
+
+/// Reads the resolved kernel identity the executor states.
+///
+/// The identity travels as text in the handshake and as a fixed-width value
+/// in every sample. Reading it once here lets a sample that names another
+/// kernel be refused rather than counted.
+fn require_kernel_hash(stated: &str) -> Result<u64, AviateConditionError> {
+    if stated.len() != 16 || stated.bytes().any(|value| !is_lower_hex(value)) {
+        return Err(AviateConditionError::identity(
+            "the executor kernel identity is not one lowercase value",
+        ));
+    }
+    u64::from_str_radix(stated, 16)
+        .map_err(|_| AviateConditionError::identity("the executor kernel identity is not readable"))
+}
+
+/// Requires the executor to have hashed the manifest this launch can read.
+///
+/// The manifest carries the same five condition values a second time. It is
+/// written before the executor opens this path, so reading it here binds
+/// every acknowledgement to a document that was on disk rather than to a
+/// value the launcher only echoes back.
+fn require_manifest(
+    handshake: &TuningHandshake,
+    launch: &ConditionLaunch,
+) -> Result<(), AviateConditionError> {
+    let path = launch.manifest_path();
+    let bytes = std::fs::read(path).map_err(|source| AviateConditionError::Artifact {
+        operation: "read the executor run manifest",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let stated = Digest::from_bytes(Sha256::digest(&bytes).into());
+    if stated.to_string() != handshake.run_manifest_digest {
+        return Err(AviateConditionError::identity(
+            "the executor hashed another run manifest than the one it wrote",
+        ));
+    }
+    let text = String::from_utf8_lossy(&bytes);
+    let identity = launch.identity();
+    for line in [
+        format!(
+            "condition_artifact_sha256 = \"{}\"",
+            identity.artifact_digest
+        ),
+        format!("condition_digest = \"{}\"", identity.condition_digest),
+        format!("condition_run_seed = {}", identity.run_seed),
+    ] {
+        if !text.contains(&line) {
+            return Err(AviateConditionError::identity(
+                "the executor run manifest does not name this condition",
+            ));
+        }
+    }
+    Ok(())
+}
+
+const fn is_lower_hex(value: u8) -> bool {
+    value.is_ascii_digit() || matches!(value, b'a'..=b'f')
 }
 
 /// Reads one 64-character lowercase identity the executor states.

--- a/tools/flight-tune-aviate/src/condition/tests.rs
+++ b/tools/flight-tune-aviate/src/condition/tests.rs
@@ -1,0 +1,270 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use std::path::Path;
+
+use flight_tune::{
+    BackendCapability, ConditionAdmission, ConditionSet, Digest, HoverEstimatorMode,
+    UncertaintyDeclaration,
+};
+
+use super::*;
+
+#[path = "tests/executor.rs"]
+mod executor;
+
+use executor::{Executor, Fault};
+
+const RUN_INTENT: [u8; 32] = [0x21; 32];
+const CONDITION: &str = concat!(
+    r#"{"schema_version":4,"id":"executed-uncertainty-launch","revision":1,"seed":11,"#,
+    r#""wind":{"steady":{"speed_mps":0.0,"direction_deg":0.0},"gusts":[],"#,
+    r#""turbulence":{"kind":"none"}},"#,
+    r#""timing":{"estimate_delay_ns":0,"update_jitter":{"kind":"none"}},"#,
+    r#""sensor":{"kind":"bounded_noise","lanes":["#,
+    r#"{"sensor":"accelerometer","axis":"x","peak_amplitude_mps2":2.0,"#,
+    r#""update_interval_samples":2}]},"#,
+    r#""actuator":{"authority_scale_basis_points":12000,"#,
+    r#""command_loss":{"kind":"seeded_zero_order_hold","fraction_basis_points":1000,"#,
+    r#""decision_interval_samples":10}},"#,
+    r#""controller_initialization":{"hover_thrust_force":{"kind":"scale_baseline","#,
+    r#""scale_basis_points":9000}},"#,
+    r#""plant":{"payload_mass_delta_kg":0.0,"longitudinal_cg_offset_m":0.0,"#,
+    r#""lateral_cg_offset_m":0.0,"hover_thrust_expectation":{"kind":"measured_weight_ratio"}}}"#,
+);
+
+#[test]
+fn a_launch_states_every_condition_value_as_an_explicit_argument() {
+    let directory = temporary_directory("launch-arguments");
+    let launch = prepare(&directory).expect("prepared launch");
+    let arguments = launch.arguments();
+
+    let named = |flag: &str| {
+        arguments
+            .iter()
+            .position(|value| value == flag)
+            .and_then(|index| arguments.get(index.wrapping_add(1)))
+            .cloned()
+            .unwrap_or_else(|| panic!("{flag} is not stated"))
+    };
+
+    assert_eq!(
+        named("--condition-artifact"),
+        launch.artifact_path().to_string_lossy()
+    );
+    assert_eq!(
+        named("--condition-artifact-sha256"),
+        launch.identity().artifact_digest.to_string()
+    );
+    assert_eq!(
+        named("--condition-digest"),
+        launch.identity().condition_digest.to_string()
+    );
+    assert_eq!(named("--run-seed"), launch.identity().run_seed.to_string());
+    assert_eq!(
+        named("--required-perturbation-capabilities"),
+        "actuator_authority,command_hold,hover_trim_uncertainty,sensor_perturbation"
+    );
+    assert!(named("--tuning-trace-endpoint").starts_with("127.0.0.1:"));
+    assert_eq!(
+        named("--run-manifest"),
+        launch.manifest_path().to_string_lossy()
+    );
+    std::fs::remove_dir_all(&directory).ok();
+}
+
+#[test]
+fn the_artifact_identity_is_not_the_identity_of_the_document_inside_it() {
+    let directory = temporary_directory("artifact-identity");
+    let launch = prepare(&directory).expect("prepared launch");
+    let bytes = std::fs::read(launch.artifact_path()).expect("artifact bytes");
+    let condition = condition();
+
+    assert_ne!(
+        launch.identity().artifact_digest,
+        launch.identity().condition_digest
+    );
+    assert_eq!(
+        bytes,
+        [
+            condition.to_canonical_json().expect("canonical"),
+            b"\n".to_vec()
+        ]
+        .concat()
+    );
+    assert_eq!(
+        ConditionSet::from_json(&bytes)
+            .expect("artifact parses")
+            .canonical_digest()
+            .expect("identity"),
+        launch.identity().condition_digest
+    );
+    std::fs::remove_dir_all(&directory).ok();
+}
+
+#[test]
+fn a_backend_that_declares_no_uncertainty_refuses_before_the_artifact_exists() {
+    let directory = temporary_directory("no-capability");
+    let path = ConditionTracePath::bind_blocking().expect("trace path");
+    let admission = ConditionAdmission::new(UncertaintyDeclaration::new(
+        Vec::new(),
+        HoverEstimatorMode::Online,
+    ));
+
+    let refused = ConditionLaunch::prepare_blocking(
+        &condition(),
+        &admission,
+        Digest::from_bytes(RUN_INTENT),
+        &directory,
+        path.endpoint(),
+    );
+
+    assert!(matches!(
+        refused,
+        Err(AviateConditionError::Unsupported { .. })
+    ));
+    assert!(!directory.join("condition.json").exists());
+    std::fs::remove_dir_all(&directory).ok();
+}
+
+#[test]
+fn a_complete_run_over_the_trace_path_seals_what_it_executed() {
+    let receipt = flown("complete-run", 21, Fault::None).expect("sealed receipt");
+
+    receipt.validate().expect("valid receipt");
+    assert_eq!(receipt.ledger.sample_count, 21);
+    assert_eq!(receipt.ledger.actuator.applied_hold, 2);
+    assert_eq!(receipt.ledger.sensor_lanes[0].eligible, 21);
+    assert_eq!(receipt.ledger.sensor_lanes[0].held, 10);
+}
+
+#[test]
+fn an_executor_that_loaded_another_condition_cannot_arm() {
+    assert!(matches!(
+        flown("changed-condition", 21, Fault::ChangedConditionDigest),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
+fn an_executor_that_drew_from_another_seed_cannot_arm() {
+    assert!(matches!(
+        flown("changed-seed", 21, Fault::ChangedRunSeed),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
+fn an_executor_that_supplies_fewer_capabilities_cannot_arm() {
+    assert!(matches!(
+        flown("missing-capability", 21, Fault::MissingCapability),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
+fn an_executor_with_an_active_hover_estimator_cannot_arm() {
+    assert!(matches!(
+        flown("active-estimator", 21, Fault::ActiveHoverEstimator),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
+fn a_trace_sequence_gap_ends_the_run() {
+    assert!(matches!(
+        flown("sequence-gap", 21, Fault::SequenceGap),
+        Err(AviateConditionError::Relation { .. })
+    ));
+}
+
+#[test]
+fn a_sample_that_states_a_value_it_did_not_derive_ends_the_run() {
+    assert!(matches!(
+        flown("changed-value", 21, Fault::ChangedSensorValue),
+        Err(AviateConditionError::Relation { .. })
+    ));
+}
+
+#[test]
+fn a_hover_force_that_moves_inside_one_run_ends_the_run() {
+    assert!(matches!(
+        flown("moved-hover", 21, Fault::MovedHoverForce),
+        Err(AviateConditionError::Relation { .. })
+    ));
+}
+
+#[test]
+fn an_executor_that_stops_inside_a_decision_interval_is_not_sealed() {
+    assert!(matches!(
+        flown("short-run", 21, Fault::ShortRun),
+        Err(AviateConditionError::Relation { .. })
+    ));
+}
+
+/// Runs one complete executor against one launch over a real loopback path.
+fn flown(
+    name: &str,
+    samples: u64,
+    fault: Fault,
+) -> Result<flight_tune::ExecutedUncertaintyReceipt, AviateConditionError> {
+    let directory = temporary_directory(name);
+    let path = ConditionTracePath::bind_blocking().expect("trace path");
+    let endpoint = path.endpoint();
+    let launch = ConditionLaunch::prepare_blocking(
+        &condition(),
+        &admission(),
+        Digest::from_bytes(RUN_INTENT),
+        &directory,
+        endpoint,
+    )
+    .expect("prepared launch");
+    let executor = Executor::new(
+        launch.declaration(),
+        launch.artifact_path().to_path_buf(),
+        samples,
+        fault,
+    );
+    let child = std::thread::spawn(move || executor.run_blocking(endpoint));
+    let sealed = path.verify_blocking(&launch);
+    // The executor stops when a sample goes unanswered, which is the
+    // failure policy rather than a fault in the test.
+    child.join().expect("the executor thread finished").ok();
+    std::fs::remove_dir_all(&directory).ok();
+    sealed
+}
+
+fn prepare(directory: &Path) -> Result<ConditionLaunch, AviateConditionError> {
+    let path = ConditionTracePath::bind_blocking().expect("trace path");
+    ConditionLaunch::prepare_blocking(
+        &condition(),
+        &admission(),
+        Digest::from_bytes(RUN_INTENT),
+        directory,
+        path.endpoint(),
+    )
+}
+
+fn admission() -> ConditionAdmission {
+    ConditionAdmission::new(UncertaintyDeclaration::new(
+        vec![
+            BackendCapability::SensorPerturbation,
+            BackendCapability::ActuatorAuthority,
+            BackendCapability::CommandHold,
+            BackendCapability::HoverTrimUncertainty,
+        ],
+        HoverEstimatorMode::Disabled,
+    ))
+}
+
+fn condition() -> ConditionSet {
+    ConditionSet::from_json(CONDITION.as_bytes()).expect("condition")
+}
+
+fn temporary_directory(name: &str) -> std::path::PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "pilotage-executed-uncertainty-{name}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&directory).expect("test directory");
+    directory
+}

--- a/tools/flight-tune-aviate/src/condition/tests.rs
+++ b/tools/flight-tune-aviate/src/condition/tests.rs
@@ -194,6 +194,22 @@ fn a_hover_force_that_moves_inside_one_run_ends_the_run() {
 }
 
 #[test]
+fn an_executor_that_hashed_another_run_manifest_cannot_arm() {
+    assert!(matches!(
+        flown("changed-manifest", 21, Fault::ChangedManifest),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
+fn a_sample_that_names_another_kernel_ends_the_run() {
+    assert!(matches!(
+        flown("changed-kernel", 21, Fault::ChangedSampleKernel),
+        Err(AviateConditionError::Identity { .. })
+    ));
+}
+
+#[test]
 fn an_executor_that_stops_inside_a_decision_interval_is_not_sealed() {
     assert!(matches!(
         flown("short-run", 21, Fault::ShortRun),
@@ -221,6 +237,7 @@ fn flown(
     let executor = Executor::new(
         launch.declaration(),
         launch.artifact_path().to_path_buf(),
+        launch.manifest_path().to_path_buf(),
         samples,
         fault,
     );

--- a/tools/flight-tune-aviate/src/condition/tests/executor.rs
+++ b/tools/flight-tune-aviate/src/condition/tests/executor.rs
@@ -1,0 +1,340 @@
+//! One executor that speaks the trace protocol over a real loopback path.
+//!
+//! It answers exactly what the declaration requires, so a test that changes
+//! one value changes only that value and the refusal names it.
+
+use std::net::{SocketAddr, TcpStream};
+use std::path::PathBuf;
+
+use flight_tune::{ExecutedUncertaintyDeclaration, derivation};
+
+use super::super::frame;
+use super::super::protocol::{
+    TuningActuatorApplication, TuningActuatorEligibility, TuningConstraintFlags,
+    TuningControlObservation, TuningFrameType, TuningHandshake, TuningHoverEstimatorMode,
+    TuningHoverInitialization, TuningObservationAck, TuningPerturbationCapability, TuningReady,
+    TuningSendEvidence, TuningSensorApplication,
+};
+
+pub(super) const BASELINE_FORCE_BITS: u32 = 0x3f00_0000;
+pub(super) const KERNEL_HASH: u64 = 0x0102_0304_0506_0708;
+pub(super) const LANE_COUNT: u8 = 4;
+const MANIFEST_DIGEST: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const KERNEL_HASH_TEXT: &str = "0102030405060708";
+
+/// What one executor states other than the truth.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Fault {
+    /// The executor answers exactly.
+    None,
+    /// The executor loaded another condition document.
+    ChangedConditionDigest,
+    /// The executor drew from another seed.
+    ChangedRunSeed,
+    /// The executor supplies fewer capabilities than the condition needs.
+    MissingCapability,
+    /// The executor states an active online hover estimator.
+    ActiveHoverEstimator,
+    /// The executor skips one sample sequence.
+    SequenceGap,
+    /// The executor states a value it did not derive.
+    ChangedSensorValue,
+    /// The executor stops inside a decision interval.
+    ShortRun,
+    /// The executor states another hover force part way through.
+    MovedHoverForce,
+}
+
+/// One executor run over the trace path.
+pub(super) struct Executor {
+    declaration: ExecutedUncertaintyDeclaration,
+    artifact_path: PathBuf,
+    samples: u64,
+    fault: Fault,
+    last_accepted: Option<[u32; 16]>,
+    interval_index: u64,
+    interval_position: u32,
+    interval_first_sequence: u64,
+    decisions: Vec<bool>,
+}
+
+impl Executor {
+    pub(super) fn new(
+        declaration: &ExecutedUncertaintyDeclaration,
+        artifact_path: PathBuf,
+        samples: u64,
+        fault: Fault,
+    ) -> Self {
+        Self {
+            declaration: declaration.clone(),
+            artifact_path,
+            samples,
+            fault,
+            last_accepted: None,
+            interval_index: 0,
+            interval_position: 0,
+            interval_first_sequence: 0,
+            decisions: Vec::new(),
+        }
+    }
+
+    /// Connects, states the run, and answers every sample it is asked for.
+    pub(super) fn run_blocking(mut self, endpoint: SocketAddr) -> Result<(), String> {
+        let mut stream = TcpStream::connect(endpoint).map_err(|error| error.to_string())?;
+        frame::write(&mut stream, &self.handshake()).map_err(|error| error.to_string())?;
+        let ready: TuningReady = frame::read(&mut stream).map_err(|error| error.to_string())?;
+        if ready.frame_type != TuningFrameType::AviateTuningReady {
+            return Err("the launcher did not accept the run".to_owned());
+        }
+        let samples = if self.fault == Fault::ShortRun {
+            self.samples.saturating_sub(6)
+        } else {
+            self.samples
+        };
+        for index in 0..samples {
+            let observation = self.observation(index);
+            frame::write(&mut stream, &observation).map_err(|error| error.to_string())?;
+            let ack: TuningObservationAck =
+                frame::read(&mut stream).map_err(|error| error.to_string())?;
+            if ack.sequence != observation.sequence {
+                return Err("the launcher answered another sample".to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    fn handshake(&self) -> TuningHandshake {
+        let identity = &self.declaration;
+        let mut condition_digest = identity.condition_digest.to_string();
+        if self.fault == Fault::ChangedConditionDigest {
+            condition_digest = "0".repeat(64);
+        }
+        let mut capabilities = identity
+            .required_capabilities
+            .iter()
+            .map(|capability| match capability.as_str() {
+                "actuator_authority" => TuningPerturbationCapability::ActuatorAuthority,
+                "command_hold" => TuningPerturbationCapability::CommandHold,
+                "hover_trim_uncertainty" => TuningPerturbationCapability::HoverTrimUncertainty,
+                _ => TuningPerturbationCapability::SensorPerturbation,
+            })
+            .collect::<Vec<_>>();
+        if self.fault == Fault::MissingCapability {
+            capabilities.pop();
+        }
+        TuningHandshake {
+            frame_type: TuningFrameType::AviateTuningHandshake,
+            schema_version: super::super::TUNING_TRACE_SCHEMA_VERSION,
+            run_manifest_digest: MANIFEST_DIGEST.to_owned(),
+            kernel_config_hash: KERNEL_HASH_TEXT.to_owned(),
+            condition_artifact_path: Some(self.artifact_path.to_string_lossy().into_owned()),
+            condition_artifact_sha256: Some(identity.artifact_digest.to_string()),
+            condition_digest: Some(condition_digest),
+            condition_run_seed: Some(match self.fault {
+                Fault::ChangedRunSeed => identity.run_seed.wrapping_add(1),
+                _ => identity.run_seed,
+            }),
+            condition_required_capabilities: Some(capabilities),
+            hover_baseline_force_bits: BASELINE_FORCE_BITS,
+            hover_effective_force_bits: derivation::scaled_hover_force(
+                BASELINE_FORCE_BITS,
+                identity.hover_scale_basis_points,
+            ),
+            hover_scale_basis_points: identity.hover_scale_basis_points,
+            hover_estimator_mode: match self.fault {
+                Fault::ActiveHoverEstimator => TuningHoverEstimatorMode::Online,
+                _ => TuningHoverEstimatorMode::Disabled,
+            },
+            hover_kernel_config_hash: KERNEL_HASH_TEXT.to_owned(),
+        }
+    }
+
+    fn observation(&mut self, index: u64) -> TuningControlObservation {
+        let sequence = match self.fault {
+            Fault::SequenceGap if index >= 5 => index.wrapping_add(1),
+            _ => index,
+        };
+        TuningControlObservation {
+            frame_type: TuningFrameType::AviateControlObservation,
+            schema_version: super::super::TUNING_TRACE_SCHEMA_VERSION,
+            sequence,
+            simulator_timestamp_us: index.wrapping_mul(10_000),
+            global_sample_sequence: sequence,
+            sensor_application: Some(self.sensor(sequence, index)),
+            actuator_application: Some(self.actuator(sequence)),
+            constraint_flags: TuningConstraintFlags::default(),
+            hover_initialization: self.hover(index),
+            send: TuningSendEvidence {
+                reply_attempted: true,
+                reply_succeeded: true,
+                echoed_timestamp_us: index.wrapping_mul(10_000),
+                lockstep: true,
+            },
+            armed: true,
+        }
+    }
+
+    fn hover(&self, index: u64) -> TuningHoverInitialization {
+        let baseline = if self.fault == Fault::MovedHoverForce && index >= 5 {
+            0x3f40_0000
+        } else {
+            BASELINE_FORCE_BITS
+        };
+        TuningHoverInitialization {
+            baseline_force_bits: baseline,
+            effective_force_bits: derivation::scaled_hover_force(
+                baseline,
+                self.declaration.hover_scale_basis_points,
+            ),
+            scale_basis_points: self.declaration.hover_scale_basis_points,
+            kernel_config_hash: KERNEL_HASH,
+        }
+    }
+
+    fn sensor(&self, sequence: u64, index: u64) -> TuningSensorApplication {
+        let presence_mask = 0b1001_u16;
+        let mut raw = [None; 12];
+        #[allow(clippy::cast_precision_loss)]
+        let reading = 1.0_f32 + (sequence % 7) as f32;
+        raw[0] = Some(reading.to_bits());
+        raw[3] = Some(0x4000_0000);
+        let mut effective = raw;
+        let mut update_buckets = [None; 12];
+        let mut changed_mask = 0_u16;
+        for declared in &self.declaration.sensor_lanes {
+            let lane = usize::from(declared.lane_tag);
+            let bucket = sequence / u64::from(declared.update_interval_samples);
+            update_buckets[lane] = Some(bucket);
+            let offset = derivation::sensor_offset(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                declared.lane_tag,
+                bucket,
+                f32::from_bits(declared.peak_amplitude_bits),
+            );
+            let value = f32::from_bits(raw[lane].unwrap_or(0));
+            let mut applied = (value + offset).to_bits();
+            if self.fault == Fault::ChangedSensorValue && index >= 5 {
+                applied = value.to_bits();
+            }
+            effective[lane] = Some(applied);
+            if applied != raw[lane].unwrap_or(0) {
+                changed_mask |= 1 << declared.lane_tag;
+            }
+        }
+        TuningSensorApplication {
+            raw_digest: *derivation::sensor_sample_digest(presence_mask, &raw).as_bytes(),
+            effective_digest: *derivation::sensor_sample_digest(presence_mask, &effective)
+                .as_bytes(),
+            presence_mask,
+            changed_mask,
+            update_buckets,
+            raw_value_bits: raw,
+            effective_value_bits: effective,
+        }
+    }
+
+    fn actuator(&mut self, sequence: u64) -> TuningActuatorApplication {
+        let mut requested = [0_u32; 16];
+        #[allow(clippy::cast_precision_loss)]
+        let command = 0.1_f32 * ((sequence % 5) as f32 + 1.0);
+        for lane in requested.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane = command.to_bits();
+        }
+        let mut scaled = requested;
+        for lane in scaled.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane =
+                derivation::scaled_authority(*lane, self.declaration.authority_scale_basis_points);
+        }
+        let base = TuningActuatorApplication {
+            requested_lane_bits: requested,
+            authority_scaled_lane_bits: scaled,
+            effective_lane_bits: scaled,
+            lane_count: LANE_COUNT,
+            actuator_answer_armed: true,
+            kernel_fallback_mask: 0,
+            eligibility: TuningActuatorEligibility::Eligible,
+            prime: false,
+            interval_epoch: None,
+            interval_index: None,
+            interval_position: None,
+            interval_identity: None,
+            selected_hold: false,
+            applied_hold: false,
+            interval_complete: false,
+        };
+        if self.last_accepted.is_none() {
+            self.last_accepted = Some(scaled);
+            return TuningActuatorApplication {
+                prime: true,
+                ..base
+            };
+        }
+        self.hold(base, scaled, sequence)
+    }
+
+    fn hold(
+        &mut self,
+        base: TuningActuatorApplication,
+        scaled: [u32; 16],
+        sequence: u64,
+    ) -> TuningActuatorApplication {
+        let hold = self
+            .declaration
+            .command_hold
+            .unwrap_or(flight_tune::DeclaredCommandHold {
+                fraction_basis_points: 1_000,
+                decision_interval_samples: 10,
+            });
+        if self.interval_position == 0 {
+            self.interval_first_sequence = sequence;
+            self.decisions = derivation::hold_schedule(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                0,
+                self.interval_index,
+                sequence,
+                hold,
+            )
+            .unwrap_or_default();
+        }
+        let position = self.interval_position;
+        let selected = self
+            .decisions
+            .get(usize::try_from(position).unwrap_or(0))
+            .copied()
+            .unwrap_or(false);
+        let effective = if selected {
+            self.last_accepted.unwrap_or(scaled)
+        } else {
+            self.last_accepted = Some(scaled);
+            scaled
+        };
+        let identity = derivation::interval_identity(
+            self.declaration.condition_digest,
+            self.declaration.run_seed,
+            0,
+            self.interval_index,
+            self.interval_first_sequence,
+        );
+        let index = self.interval_index;
+        let complete = position.wrapping_add(1) >= hold.decision_interval_samples;
+        if complete {
+            self.interval_index = self.interval_index.wrapping_add(1);
+            self.interval_position = 0;
+        } else {
+            self.interval_position = position.wrapping_add(1);
+        }
+        TuningActuatorApplication {
+            effective_lane_bits: effective,
+            interval_epoch: Some(0),
+            interval_index: Some(index),
+            interval_position: Some(position),
+            interval_identity: Some(*identity.as_bytes()),
+            selected_hold: selected,
+            applied_hold: selected,
+            interval_complete: complete,
+            ..base
+        }
+    }
+}

--- a/tools/flight-tune-aviate/src/condition/tests/executor.rs
+++ b/tools/flight-tune-aviate/src/condition/tests/executor.rs
@@ -6,7 +6,8 @@
 use std::net::{SocketAddr, TcpStream};
 use std::path::PathBuf;
 
-use flight_tune::{ExecutedUncertaintyDeclaration, derivation};
+use flight_tune::{Digest, ExecutedUncertaintyDeclaration, derivation};
+use sha2::{Digest as ShaDigest, Sha256};
 
 use super::super::frame;
 use super::super::protocol::{
@@ -19,7 +20,6 @@ use super::super::protocol::{
 pub(super) const BASELINE_FORCE_BITS: u32 = 0x3f00_0000;
 pub(super) const KERNEL_HASH: u64 = 0x0102_0304_0506_0708;
 pub(super) const LANE_COUNT: u8 = 4;
-const MANIFEST_DIGEST: &str = "1111111111111111111111111111111111111111111111111111111111111111";
 const KERNEL_HASH_TEXT: &str = "0102030405060708";
 
 /// What one executor states other than the truth.
@@ -43,12 +43,18 @@ pub(super) enum Fault {
     ShortRun,
     /// The executor states another hover force part way through.
     MovedHoverForce,
+    /// The executor hashed a run manifest other than the one it wrote.
+    ChangedManifest,
+    /// The executor names another kernel in one sample than in its handshake.
+    ChangedSampleKernel,
 }
 
 /// One executor run over the trace path.
 pub(super) struct Executor {
     declaration: ExecutedUncertaintyDeclaration,
     artifact_path: PathBuf,
+    manifest_path: PathBuf,
+    manifest_digest: String,
     samples: u64,
     fault: Fault,
     last_accepted: Option<[u32; 16]>,
@@ -62,12 +68,15 @@ impl Executor {
     pub(super) fn new(
         declaration: &ExecutedUncertaintyDeclaration,
         artifact_path: PathBuf,
+        manifest_path: PathBuf,
         samples: u64,
         fault: Fault,
     ) -> Self {
         Self {
             declaration: declaration.clone(),
             artifact_path,
+            manifest_path,
+            manifest_digest: String::new(),
             samples,
             fault,
             last_accepted: None,
@@ -80,6 +89,7 @@ impl Executor {
 
     /// Connects, states the run, and answers every sample it is asked for.
     pub(super) fn run_blocking(mut self, endpoint: SocketAddr) -> Result<(), String> {
+        self.write_manifest()?;
         let mut stream = TcpStream::connect(endpoint).map_err(|error| error.to_string())?;
         frame::write(&mut stream, &self.handshake()).map_err(|error| error.to_string())?;
         let ready: TuningReady = frame::read(&mut stream).map_err(|error| error.to_string())?;
@@ -100,6 +110,31 @@ impl Executor {
                 return Err("the launcher answered another sample".to_owned());
             }
         }
+        Ok(())
+    }
+
+    /// Writes the run manifest the launcher reads back, then states its
+    /// identity in the handshake.
+    fn write_manifest(&mut self) -> Result<(), String> {
+        let identity = &self.declaration;
+        let text = format!(
+            "schema_version = 3\n\
+             application_id = \"pilotage-executed-uncertainty-fake\"\n\
+             condition_artifact_path = \"{}\"\n\
+             condition_artifact_sha256 = \"{}\"\n\
+             condition_digest = \"{}\"\n\
+             condition_run_seed = {}\n",
+            self.artifact_path.to_string_lossy(),
+            identity.artifact_digest,
+            identity.condition_digest,
+            identity.run_seed,
+        );
+        std::fs::write(&self.manifest_path, &text).map_err(|error| error.to_string())?;
+        self.manifest_digest = if self.fault == Fault::ChangedManifest {
+            "2".repeat(64)
+        } else {
+            Digest::from_bytes(Sha256::digest(text.as_bytes()).into()).to_string()
+        };
         Ok(())
     }
 
@@ -125,7 +160,7 @@ impl Executor {
         TuningHandshake {
             frame_type: TuningFrameType::AviateTuningHandshake,
             schema_version: super::super::TUNING_TRACE_SCHEMA_VERSION,
-            run_manifest_digest: MANIFEST_DIGEST.to_owned(),
+            run_manifest_digest: self.manifest_digest.clone(),
             kernel_config_hash: KERNEL_HASH_TEXT.to_owned(),
             condition_artifact_path: Some(self.artifact_path.to_string_lossy().into_owned()),
             condition_artifact_sha256: Some(identity.artifact_digest.to_string()),
@@ -167,7 +202,9 @@ impl Executor {
             send: TuningSendEvidence {
                 reply_attempted: true,
                 reply_succeeded: true,
-                echoed_timestamp_us: index.wrapping_mul(10_000),
+                // The transport echoes what its own link clock last saw, so
+                // this value is never the sample time.
+                echoed_timestamp_us: index.wrapping_mul(9_973).wrapping_add(7),
                 lockstep: true,
             },
             armed: true,
@@ -180,6 +217,11 @@ impl Executor {
         } else {
             BASELINE_FORCE_BITS
         };
+        let kernel_config_hash = if self.fault == Fault::ChangedSampleKernel && index >= 5 {
+            KERNEL_HASH.wrapping_add(1)
+        } else {
+            KERNEL_HASH
+        };
         TuningHoverInitialization {
             baseline_force_bits: baseline,
             effective_force_bits: derivation::scaled_hover_force(
@@ -187,7 +229,7 @@ impl Executor {
                 self.declaration.hover_scale_basis_points,
             ),
             scale_basis_points: self.declaration.hover_scale_basis_points,
-            kernel_config_hash: KERNEL_HASH,
+            kernel_config_hash,
         }
     }
 

--- a/tools/flight-tune-aviate/src/lib.rs
+++ b/tools/flight-tune-aviate/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod action_port;
 mod artifact;
+pub mod condition;
 pub mod direct_transport;
 mod document;
 mod error;
@@ -36,6 +37,9 @@ mod vehicle;
 pub use action_port::{
     AviateActionDriver, AviateActionPortError, AviateVehicleAction, AviateVehicleActionPort,
     AviateVehicleDirective, aviate_action_port_identity,
+};
+pub use condition::{
+    AviateConditionError, ConditionLaunch, ConditionTracePath, TUNING_TRACE_SCHEMA_VERSION,
 };
 pub use document::{
     ProcessIdentity, ProcessStartIdentity, TargetAttestation, TargetProcessContract,

--- a/tools/flight-tune-aviate/src/runtime.rs
+++ b/tools/flight-tune-aviate/src/runtime.rs
@@ -182,6 +182,13 @@ pub enum AviateRuntimeError {
     /// A run seal does not bind one exact run and runtime.
     #[error("the Aviate run seal does not bind its run and runtime")]
     UnboundRunSeal,
+    /// An executed uncertainty receipt does not answer for its own content.
+    #[error("the executed uncertainty receipt is refused: {source}")]
+    UnboundUncertaintyReceipt {
+        /// The contract failure.
+        #[source]
+        source: flight_tune::TuneError,
+    },
     /// A direct ledger document is larger than its limit.
     #[error("the Aviate direct ledger document is {bytes} bytes")]
     LedgerDocumentSize {
@@ -237,6 +244,7 @@ pub struct AviateScenarioDriver<D> {
     run: Option<PreparedRun>,
     started: bool,
     seal: Option<AviateRunSeal>,
+    executed_uncertainty: Option<flight_tune::ExecutedUncertaintyReceipt>,
 }
 
 impl<D: DirectControl> AviateScenarioDriver<D> {
@@ -264,6 +272,7 @@ impl<D: DirectControl> AviateScenarioDriver<D> {
             run: None,
             started: false,
             seal: None,
+            executed_uncertainty: None,
         })
     }
 
@@ -277,6 +286,21 @@ impl<D: DirectControl> AviateScenarioDriver<D> {
     #[must_use]
     pub const fn seal(&self) -> Option<&AviateRunSeal> {
         self.seal.as_ref()
+    }
+
+    /// Binds the verified uncertainty this run executed.
+    ///
+    /// The receipt is bound before the run stops, so a seal cannot be
+    /// written for a non-nominal run whose trace path was never verified.
+    pub fn bind_executed_uncertainty(
+        &mut self,
+        receipt: flight_tune::ExecutedUncertaintyReceipt,
+    ) -> Result<(), AviateRuntimeError> {
+        receipt
+            .validate()
+            .map_err(|source| AviateRuntimeError::UnboundUncertaintyReceipt { source })?;
+        self.executed_uncertainty = Some(receipt);
+        Ok(())
     }
 
     /// The admitted run, when one exists.
@@ -433,6 +457,7 @@ impl<D: DirectControl> AviateActionDriver for AviateScenarioDriver<D> {
             runtime_identity: run.runtime_identity().clone(),
             accepted_frames: self.clock.accepted(),
             direct_evidence: self.direct.seal(run.runtime_identity())?,
+            executed_uncertainty: self.executed_uncertainty.clone(),
         };
         self.seal = Some(terminal::seal(&closure, context)?);
         self.direct.revoke();

--- a/tools/flight-tune-aviate/src/runtime/terminal.rs
+++ b/tools/flight-tune-aviate/src/runtime/terminal.rs
@@ -1,16 +1,18 @@
 //! Sealing one run, and saying plainly when it cannot be sealed.
 //!
-//! A sealed run states four things together: which run intent it flew,
+//! A sealed run states five things together: which run intent it flew,
 //! which runtime implementation flew it, what the run's direct evidence
-//! was, and how it ended. Binding them in one document is what stops a
-//! reader pairing evidence from one runtime identity with a result from
-//! another.
+//! was, what uncertainty it executed, and how it ended. Binding them in one
+//! document is what stops a reader pairing evidence from one runtime
+//! identity with a result from another.
 //!
 //! A run whose durable direct ledger has a prepared command with no result
 //! is not sealed at all. It is quarantined, because nobody can say whether
 //! the vehicle was commanded.
 
-use flight_tune::{ArtifactIdentity, Digest, ScenarioStopContext, ScenarioStopReason};
+use flight_tune::{
+    ArtifactIdentity, Digest, ExecutedUncertaintyReceipt, ScenarioStopContext, ScenarioStopReason,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
@@ -18,9 +20,9 @@ use super::AviateRuntimeError;
 use super::direct::DirectRunEvidence;
 
 /// The supported Aviate run seal schema.
-pub const RUN_SEAL_SCHEMA_VERSION: u16 = 1;
+pub const RUN_SEAL_SCHEMA_VERSION: u16 = 2;
 
-const RUN_SEAL_DOMAIN: &[u8] = b"pilotage-aviate-run-seal-v1\0";
+const RUN_SEAL_DOMAIN: &[u8] = b"pilotage-aviate-run-seal-v2\0";
 
 /// How one Aviate run ended, as the vehicle port saw it.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -67,6 +69,11 @@ pub struct AviateRunSeal {
     pub accepted_frames: u64,
     /// The identity of this run's direct evidence, when the run had any.
     pub direct_evidence_digest: Option<Digest>,
+    /// The identity of the uncertainty this run executed, when it flew any.
+    ///
+    /// A nominal run states none. A non-nominal run that states none never
+    /// proved that the controller received what the condition requested.
+    pub executed_uncertainty_digest: Option<Digest>,
 }
 
 impl AviateRunSeal {
@@ -119,6 +126,8 @@ pub struct RunClosure {
     pub accepted_frames: u64,
     /// The direct evidence the run collected, when it commanded directly.
     pub direct_evidence: Option<DirectRunEvidence>,
+    /// The verified uncertainty receipt, when the run flew a condition.
+    pub executed_uncertainty: Option<ExecutedUncertaintyReceipt>,
 }
 
 /// Seals one stopped run.
@@ -138,6 +147,18 @@ pub fn seal(
         }
         None => None,
     };
+    let executed_uncertainty_digest = match &closure.executed_uncertainty {
+        Some(receipt) => {
+            receipt
+                .validate()
+                .map_err(|source| AviateRuntimeError::UnboundUncertaintyReceipt { source })?;
+            if receipt.launch.run_intent_digest != closure.run_intent_digest {
+                return Err(AviateRuntimeError::UnboundRunSeal);
+            }
+            Some(receipt.digest())
+        }
+        None => None,
+    };
     let seal = AviateRunSeal {
         schema_version: RUN_SEAL_SCHEMA_VERSION,
         run_intent_digest: closure.run_intent_digest,
@@ -146,6 +167,7 @@ pub fn seal(
         last_source_sequence: context.last_source_sequence,
         accepted_frames: closure.accepted_frames,
         direct_evidence_digest,
+        executed_uncertainty_digest,
     };
     seal.require_bound(closure.run_intent_digest, &closure.runtime_identity)?;
     Ok(seal)

--- a/tools/flight-tune-aviate/src/runtime/tests/terminal.rs
+++ b/tools/flight-tune-aviate/src/runtime/tests/terminal.rs
@@ -20,6 +20,7 @@ fn closure(direct_evidence: Option<DirectRunEvidence>) -> RunClosure {
         runtime_identity: identity("pilotage-aviate-test-runtime", 6),
         accepted_frames: 42,
         direct_evidence,
+        executed_uncertainty: None,
     }
 }
 
@@ -44,6 +45,7 @@ fn a_sealed_run_binds_its_run_intent_and_runtime() {
     assert_eq!(sealed.accepted_frames, 42);
     assert_eq!(sealed.last_source_sequence, Some(41));
     assert_eq!(sealed.direct_evidence_digest, None);
+    assert_eq!(sealed.executed_uncertainty_digest, None);
     sealed
         .require_bound(
             Digest::from_bytes([9; 32]),

--- a/tools/flight-tune/src/contract_api.rs
+++ b/tools/flight-tune/src/contract_api.rs
@@ -4,6 +4,15 @@
 //! trial contracts. Re-exporting them here gives every host one name for each
 //! contract type and one crate to depend on.
 
+pub use crate::terminal::uncertainty::{
+    DeclaredCommandHold, DeclaredSensorLane, EXECUTED_ACTUATOR_LANE_COUNT,
+    EXECUTED_SENSOR_LANE_COUNT, EXECUTED_UNCERTAINTY_SCHEMA_VERSION, ExecutedActuatorApplication,
+    ExecutedActuatorCounts, ExecutedBypassCounts, ExecutedBypassReason, ExecutedConstraintFlags,
+    ExecutedEligibility, ExecutedHoverInitialization, ExecutedLaunchIdentity, ExecutedSample,
+    ExecutedSendEvidence, ExecutedSensorApplication, ExecutedSensorLaneCounts, ExecutedStream,
+    ExecutedStreamSummary, ExecutedUncertaintyDeclaration, ExecutedUncertaintyLedger,
+    ExecutedUncertaintyReceipt, NOMINAL_BASIS_POINTS, executed_run_seed, lane_tag,
+};
 pub use pilotage_mission_core::{
     ArtifactIdentity as MissionArtifactIdentity, ControlChannel, ControlFamily, ControlValueField,
     Digest as MissionDigest, DirectiveContext, ExecutionTarget, FlightAction,

--- a/tools/flight-tune/src/contract_api.rs
+++ b/tools/flight-tune/src/contract_api.rs
@@ -4,6 +4,7 @@
 //! trial contracts. Re-exporting them here gives every host one name for each
 //! contract type and one crate to depend on.
 
+pub use crate::terminal::uncertainty::derivation;
 pub use crate::terminal::uncertainty::{
     DeclaredCommandHold, DeclaredSensorLane, EXECUTED_ACTUATOR_LANE_COUNT,
     EXECUTED_SENSOR_LANE_COUNT, EXECUTED_UNCERTAINTY_SCHEMA_VERSION, ExecutedActuatorApplication,
@@ -22,6 +23,6 @@ pub use pilotage_mission_core::{
     StimulusMapping, TrialAction, VehicleLifecycleState, Waveform,
 };
 pub use pilotage_trial::{
-    BackendCapability, CONDITION_SET_SCHEMA_VERSION, ConditionSet, Digest, HoverEstimatorMode,
-    Scenario as TrialScenario,
+    BackendCapability, CONDITION_SET_SCHEMA_VERSION, CodecError, ConditionSet, Digest,
+    HoverEstimatorMode, Scenario as TrialScenario, ValidationError,
 };

--- a/tools/flight-tune/src/terminal.rs
+++ b/tools/flight-tune/src/terminal.rs
@@ -8,6 +8,7 @@ mod intent;
 mod plan;
 mod receipt;
 mod report;
+pub(crate) mod uncertainty;
 
 pub use binding::{RUN_BINDING_RECEIPT_SCHEMA_VERSION, RunBindingReceipt};
 pub use class::{

--- a/tools/flight-tune/src/terminal/uncertainty.rs
+++ b/tools/flight-tune/src/terminal/uncertainty.rs
@@ -1,0 +1,292 @@
+//! What one run declared it would execute under uncertainty.
+//!
+//! A run intent binds a condition identity. That alone does not say the
+//! controller received the requested uncertainty: a backend can accept a
+//! condition, start, and apply nothing. The declaration here states the
+//! executable content of one condition in the units the executor applies,
+//! so a later reader can derive every seeded decision again and compare it
+//! with what the run reports.
+//!
+//! Nothing in this module reads an executed value. It states the declared
+//! side of the relation only. SIM / NOT FOR FLIGHT.
+
+use pilotage_trial::{BackendCapability, CommandLossPolicy, ConditionSet, SensorReferenceLane};
+use serde::{Deserialize, Serialize};
+
+use super::digest::domain_digest;
+use super::invalid_terminal;
+use crate::{Digest, TuneError};
+
+pub mod derivation;
+mod launch;
+mod ledger;
+mod receipt;
+mod sample;
+mod stream;
+
+pub use launch::{ExecutedLaunchIdentity, executed_run_seed};
+pub use ledger::{
+    ExecutedActuatorCounts, ExecutedBypassCounts, ExecutedSensorLaneCounts,
+    ExecutedUncertaintyLedger,
+};
+pub use receipt::ExecutedUncertaintyReceipt;
+pub use sample::{
+    EXECUTED_ACTUATOR_LANE_COUNT, ExecutedActuatorApplication, ExecutedBypassReason,
+    ExecutedConstraintFlags, ExecutedEligibility, ExecutedHoverInitialization, ExecutedSample,
+    ExecutedSendEvidence, ExecutedSensorApplication,
+};
+pub use stream::{ExecutedStream, ExecutedStreamSummary};
+
+/// The supported executed-uncertainty evidence schema.
+pub const EXECUTED_UNCERTAINTY_SCHEMA_VERSION: u16 = 1;
+
+/// The number of flight-controller sensor lanes the contract names.
+pub const EXECUTED_SENSOR_LANE_COUNT: usize = 12;
+
+/// The basis-point value that requests no scaling.
+pub const NOMINAL_BASIS_POINTS: u16 = 10_000;
+
+const DECLARATION_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-declaration.v1\0";
+
+/// One declared sensor noise lane, in the unit the executor applies.
+///
+/// The artifact declares gauss and hectopascals; the flight controller reads
+/// microtesla and pascal. The amplitude is stated here in the executor unit
+/// so a reader never has to know which side of the conversion it holds.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredSensorLane {
+    /// The one-byte lane tag in the noise preimage.
+    pub lane_tag: u8,
+    /// The executor-unit peak amplitude as its exact binary form.
+    pub peak_amplitude_bits: u32,
+    /// The number of samples one drawn offset is held for.
+    pub update_interval_samples: u32,
+}
+
+/// The declared deterministic command hold.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredCommandHold {
+    /// The held fraction of one complete decision interval.
+    pub fraction_basis_points: u16,
+    /// The number of eligible commands in one decision interval.
+    pub decision_interval_samples: u32,
+}
+
+/// Everything one run declared it would execute.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedUncertaintyDeclaration {
+    /// Declaration schema version.
+    pub schema_version: u16,
+    /// The canonical condition identity every decision is seeded from.
+    pub condition_digest: Digest,
+    /// The exact bytes of the artifact the executor loaded.
+    pub artifact_digest: Digest,
+    /// The seed that separates one execution of this condition from another.
+    pub run_seed: u64,
+    /// The declared sensor lanes, in ascending lane-tag order.
+    pub sensor_lanes: Vec<DeclaredSensorLane>,
+    /// The declared eligible-command authority scale.
+    pub authority_scale_basis_points: u16,
+    /// The declared command hold, when the condition requests one.
+    pub command_hold: Option<DeclaredCommandHold>,
+    /// The declared hover feed-forward scale.
+    pub hover_scale_basis_points: u16,
+    /// The capabilities the executor must supply, in ascending name order.
+    pub required_capabilities: Vec<BackendCapability>,
+}
+
+impl ExecutedUncertaintyDeclaration {
+    /// States what one verified condition and run seed will execute.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the condition is not valid, when it names
+    /// a lane twice, or when an identity is absent.
+    pub fn from_condition(
+        condition: &ConditionSet,
+        artifact_digest: Digest,
+        run_seed: u64,
+    ) -> Result<Self, TuneError> {
+        let condition_digest = condition
+            .canonical_digest()
+            .map_err(|source| invalid_terminal(format!("condition identity refused: {source}")))?;
+        let mut required_capabilities = condition.required_capabilities();
+        required_capabilities.sort_unstable_by_key(|capability| capability.as_str());
+        let declaration = Self {
+            schema_version: EXECUTED_UNCERTAINTY_SCHEMA_VERSION,
+            condition_digest,
+            artifact_digest,
+            run_seed,
+            sensor_lanes: declared_lanes(condition),
+            authority_scale_basis_points: condition.actuator.authority_scale_basis_points,
+            command_hold: declared_hold(&condition.actuator.command_loss),
+            hover_scale_basis_points: hover_scale(condition),
+            required_capabilities,
+        };
+        declaration.validate()?;
+        Ok(declaration)
+    }
+
+    /// Rejects a declaration that cannot seed a deterministic decision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the schema differs, when an identity is
+    /// absent, when a lane tag repeats or is out of range, or when a
+    /// declared interval is zero.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if self.schema_version != EXECUTED_UNCERTAINTY_SCHEMA_VERSION {
+            return Err(invalid_terminal("the executed uncertainty schema changed"));
+        }
+        if self.condition_digest.is_zero() || self.artifact_digest.is_zero() {
+            return Err(invalid_terminal(
+                "an executed uncertainty declaration has no condition identity",
+            ));
+        }
+        self.validate_lanes()?;
+        if let Some(hold) = self.command_hold
+            && (hold.decision_interval_samples == 0 || hold.fraction_basis_points == 0)
+        {
+            return Err(invalid_terminal("a declared command hold holds nothing"));
+        }
+        self.validate_capabilities()
+    }
+
+    /// Returns the identity a run receipt binds this declaration by.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the declaration cannot be encoded.
+    pub fn declaration_digest(&self) -> Result<Digest, TuneError> {
+        domain_digest(DECLARATION_DOMAIN, self, "executed uncertainty declaration")
+    }
+
+    /// Returns the declared lane for one lane tag.
+    #[must_use]
+    pub fn lane(&self, lane_tag: u8) -> Option<DeclaredSensorLane> {
+        self.sensor_lanes
+            .iter()
+            .copied()
+            .find(|lane| lane.lane_tag == lane_tag)
+    }
+
+    /// Reports whether this declaration requests no executable uncertainty.
+    #[must_use]
+    pub fn is_nominal(&self) -> bool {
+        self.sensor_lanes.is_empty()
+            && self.command_hold.is_none()
+            && self.authority_scale_basis_points == NOMINAL_BASIS_POINTS
+            && self.hover_scale_basis_points == NOMINAL_BASIS_POINTS
+    }
+
+    fn validate_lanes(&self) -> Result<(), TuneError> {
+        if self.sensor_lanes.len() > EXECUTED_SENSOR_LANE_COUNT {
+            return Err(invalid_terminal(
+                "a declaration names more lanes than the contract has",
+            ));
+        }
+        let mut previous: Option<u8> = None;
+        for lane in &self.sensor_lanes {
+            if usize::from(lane.lane_tag) >= EXECUTED_SENSOR_LANE_COUNT
+                || lane.update_interval_samples == 0
+                || !f32::from_bits(lane.peak_amplitude_bits).is_finite()
+            {
+                return Err(invalid_terminal("a declared sensor lane is not executable"));
+            }
+            if previous.is_some_and(|prior| prior >= lane.lane_tag) {
+                return Err(invalid_terminal(
+                    "the declared sensor lanes are not in lane order",
+                ));
+            }
+            previous = Some(lane.lane_tag);
+        }
+        Ok(())
+    }
+
+    fn validate_capabilities(&self) -> Result<(), TuneError> {
+        let mut previous: Option<&'static str> = None;
+        for capability in &self.required_capabilities {
+            let name = capability.as_str();
+            if previous.is_some_and(|prior| prior >= name) {
+                return Err(invalid_terminal(
+                    "the required capabilities are not in name order",
+                ));
+            }
+            previous = Some(name);
+        }
+        let expected = self.derived_capabilities();
+        if self.required_capabilities != expected {
+            return Err(invalid_terminal(
+                "the required capabilities do not follow from the declared factors",
+            ));
+        }
+        Ok(())
+    }
+
+    fn derived_capabilities(&self) -> Vec<BackendCapability> {
+        let mut derived = Vec::new();
+        if self.authority_scale_basis_points != NOMINAL_BASIS_POINTS {
+            derived.push(BackendCapability::ActuatorAuthority);
+        }
+        if self.command_hold.is_some() {
+            derived.push(BackendCapability::CommandHold);
+        }
+        if self.hover_scale_basis_points != NOMINAL_BASIS_POINTS {
+            derived.push(BackendCapability::HoverTrimUncertainty);
+        }
+        if !self.sensor_lanes.is_empty() {
+            derived.push(BackendCapability::SensorPerturbation);
+        }
+        derived
+    }
+}
+
+fn declared_lanes(condition: &ConditionSet) -> Vec<DeclaredSensorLane> {
+    let mut lanes = condition
+        .sensor
+        .noise_lanes()
+        .iter()
+        .map(|request| {
+            let (lane, amplitude, interval) = request.reference_values();
+            DeclaredSensorLane {
+                lane_tag: lane_tag(lane),
+                peak_amplitude_bits: amplitude.to_bits(),
+                update_interval_samples: interval,
+            }
+        })
+        .collect::<Vec<_>>();
+    lanes.sort_unstable_by_key(|lane| lane.lane_tag);
+    lanes
+}
+
+fn declared_hold(policy: &CommandLossPolicy) -> Option<DeclaredCommandHold> {
+    match policy {
+        CommandLossPolicy::None {} => None,
+        CommandLossPolicy::SeededZeroOrderHold {
+            fraction_basis_points,
+            decision_interval_samples,
+        } => Some(DeclaredCommandHold {
+            fraction_basis_points: *fraction_basis_points,
+            decision_interval_samples: *decision_interval_samples,
+        }),
+    }
+}
+
+fn hover_scale(condition: &ConditionSet) -> u16 {
+    condition
+        .controller_initialization
+        .hover_thrust_force
+        .scale_basis_points()
+}
+
+/// Returns the one-byte preimage tag for one sensor lane.
+#[must_use]
+pub const fn lane_tag(lane: SensorReferenceLane) -> u8 {
+    lane as u8
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/flight-tune/src/terminal/uncertainty/derivation.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/derivation.rs
@@ -1,0 +1,231 @@
+//! The seeded decisions one declaration states, derived again.
+//!
+//! Every decision under uncertainty is a pure function of the condition
+//! identity, the run seed, and a position in the run. Nothing here reads a
+//! clock, a counter, or a reported result, so a reader holding only the
+//! declaration can state what the executor was required to do and compare
+//! it with what the executor says it did.
+//!
+//! The derivation is a cross-repository contract. It is stated here in the
+//! primitive terms one declaration carries; the contract crate states the
+//! same values from the artifact request, and a test requires the two to
+//! agree on a golden condition.
+
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::super::invalid_terminal;
+use super::{DeclaredCommandHold, EXECUTED_SENSOR_LANE_COUNT, NOMINAL_BASIS_POINTS};
+use crate::{Digest, TuneError};
+
+const SENSOR_NOISE_DOMAIN: &[u8] = b"pilotage-sensor-noise-v1";
+const COMMAND_HOLD_DOMAIN: &[u8] = b"pilotage-command-hold-v1";
+const EFFECTIVE_SENSOR_DOMAIN: &[u8] = b"aviate-effective-sensor-v1";
+const SAMPLE_STREAM_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-sample.v1\0";
+
+/// Derives the held offset for one lane and one update bucket.
+///
+/// The preimage is the noise domain, the condition identity, the run seed,
+/// the one-byte lane tag, and the bucket. The first four digest bytes are an
+/// unsigned sample that maps onto the closed interval from minus one through
+/// one and then scales by the peak amplitude. Neither the amplitude nor the
+/// interval enters the digest, so only the lane tag separates two lanes.
+#[must_use]
+pub fn sensor_offset(
+    condition_digest: Digest,
+    run_seed: u64,
+    lane_tag: u8,
+    update_bucket: u64,
+    peak_amplitude: f32,
+) -> f32 {
+    let mut hasher = Sha256::new();
+    hasher.update(SENSOR_NOISE_DOMAIN);
+    hasher.update(condition_digest.as_bytes());
+    hasher.update(run_seed.to_le_bytes());
+    hasher.update([lane_tag]);
+    hasher.update(update_bucket.to_le_bytes());
+    let bytes = hasher.finalize();
+    let sample = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let unit = f64::from(sample) / f64::from(u32::MAX);
+    (unit.mul_add(2.0, -1.0) * f64::from(peak_amplitude)) as f32
+}
+
+/// Derives the identity of one complete command-hold interval.
+#[must_use]
+pub fn interval_identity(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+) -> Digest {
+    let hasher = interval_hasher(
+        condition_digest,
+        run_seed,
+        interval_epoch,
+        interval_index,
+        first_sequence,
+    );
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+/// Derives the exact held positions of one complete decision interval.
+///
+/// The positions come from a descending shuffle whose swap targets are
+/// digest words of the interval identity preimage. The shuffle takes the
+/// remainder without rejection, so the same slight bias must appear in
+/// every implementation of this contract.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when the declared interval cannot address its own
+/// positions on this platform.
+pub fn hold_schedule(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+    hold: DeclaredCommandHold,
+) -> Result<Vec<bool>, TuneError> {
+    let size = usize::try_from(hold.decision_interval_samples)
+        .map_err(|_| invalid_terminal("a declared decision interval is not addressable"))?;
+    let mut positions = (0..size).collect::<Vec<_>>();
+    for cursor in (1..positions.len()).rev() {
+        let encoded = u64::try_from(cursor)
+            .map_err(|_| invalid_terminal("a decision interval position is not addressable"))?;
+        let value = permutation_value(
+            condition_digest,
+            run_seed,
+            interval_epoch,
+            interval_index,
+            first_sequence,
+            encoded,
+        );
+        let swap = usize::try_from(value % encoded.wrapping_add(1))
+            .map_err(|_| invalid_terminal("a decision interval swap is not addressable"))?;
+        positions.swap(cursor, swap);
+    }
+    let count = u64::from(hold.fraction_basis_points) * u64::from(hold.decision_interval_samples)
+        / u64::from(NOMINAL_BASIS_POINTS);
+    let count = usize::try_from(count)
+        .map_err(|_| invalid_terminal("a declared hold count is not addressable"))?;
+    let mut decisions = vec![false; size];
+    for position in positions.into_iter().take(count) {
+        decisions[position] = true;
+    }
+    Ok(decisions)
+}
+
+/// Derives the identity of one exact sensor sample.
+///
+/// The preimage is the effective-sensor domain, the presence mask, and the
+/// twelve lane values in stable order. An absent lane contributes a zero
+/// word, so a sample that drops a lane cannot carry the identity of one
+/// that kept it.
+#[must_use]
+pub fn sensor_sample_digest(
+    presence_mask: u16,
+    values: &[Option<u32>; EXECUTED_SENSOR_LANE_COUNT],
+) -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(EFFECTIVE_SENSOR_DOMAIN);
+    hasher.update(presence_mask.to_le_bytes());
+    for value in values {
+        hasher.update(value.unwrap_or(0).to_le_bytes());
+    }
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+/// Derives the value one lane carries after the authority scale.
+///
+/// The scale is a ratio of basis points taken in the wider domain with one
+/// narrowing at the end, so an implementation that scales in the narrow
+/// domain produces a different last bit and is refused.
+#[must_use]
+pub fn scaled_authority(lane_bits: u32, basis_points: u16) -> u32 {
+    let lane = f32::from_bits(lane_bits);
+    let scaled =
+        (f64::from(lane) * f64::from(basis_points) / f64::from(NOMINAL_BASIS_POINTS)) as f32;
+    scaled.to_bits()
+}
+
+/// Derives the hover force one declared scale produces from one baseline.
+#[must_use]
+pub fn scaled_hover_force(baseline_bits: u32, basis_points: u16) -> u32 {
+    let baseline = f32::from_bits(baseline_bits);
+    let effective =
+        (f64::from(baseline) * f64::from(basis_points) / f64::from(NOMINAL_BASIS_POINTS)) as f32;
+    effective.to_bits()
+}
+
+/// Extends one sample-stream identity by the next sample.
+///
+/// The chain covers every sample in order, so a stream that drops, adds, or
+/// reorders one sample carries another identity than the one its receipt
+/// states.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when the sample cannot be encoded.
+pub fn extend_sample_stream(
+    previous: Digest,
+    sample: &super::ExecutedSample,
+) -> Result<Digest, TuneError> {
+    let bytes = serde_json::to_vec(sample).map_err(|source| TuneError::Encode {
+        document: "executed uncertainty sample",
+        source,
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(SAMPLE_STREAM_DOMAIN);
+    hasher.update(previous.as_bytes());
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(&bytes);
+    Ok(Digest::from_bytes(hasher.finalize().into()))
+}
+
+/// Returns the identity of an empty sample stream.
+#[must_use]
+pub fn empty_sample_stream() -> Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(SAMPLE_STREAM_DOMAIN);
+    Digest::from_bytes(hasher.finalize().into())
+}
+
+fn interval_hasher(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+) -> Sha256 {
+    let mut hasher = Sha256::new();
+    hasher.update(COMMAND_HOLD_DOMAIN);
+    hasher.update(condition_digest.as_bytes());
+    hasher.update(run_seed.to_le_bytes());
+    hasher.update(interval_epoch.to_le_bytes());
+    hasher.update(interval_index.to_le_bytes());
+    hasher.update(first_sequence.to_le_bytes());
+    hasher
+}
+
+fn permutation_value(
+    condition_digest: Digest,
+    run_seed: u64,
+    interval_epoch: u64,
+    interval_index: u64,
+    first_sequence: u64,
+    cursor: u64,
+) -> u64 {
+    let mut hasher = interval_hasher(
+        condition_digest,
+        run_seed,
+        interval_epoch,
+        interval_index,
+        first_sequence,
+    );
+    hasher.update(cursor.to_le_bytes());
+    let bytes = hasher.finalize();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
+}

--- a/tools/flight-tune/src/terminal/uncertainty/launch.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/launch.rs
@@ -1,0 +1,140 @@
+//! The identities one uncertainty run states before it can arm.
+//!
+//! An executor receives these values as explicit launch arguments and hands
+//! them back in its handshake. A run arms only when both sides state the
+//! same identities, so a controller that loaded another artifact, another
+//! seed, or another capability set cannot fly under this run's name.
+
+use pilotage_trial::BackendCapability;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::super::invalid_terminal;
+use super::EXECUTED_UNCERTAINTY_SCHEMA_VERSION;
+use crate::{Digest, TuneError};
+
+const RUN_SEED_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-run-seed.v1\0";
+
+/// Derives the executor run seed for one exact run intent.
+///
+/// Two executions of one experimental condition differ only in their retry
+/// index, and the run intent covers that index. Seeding from the run intent
+/// therefore gives a replacement execution a stream its quarantined source
+/// never drew, while a repeated read of one run intent gives one seed.
+#[must_use]
+pub fn executed_run_seed(run_intent_digest: Digest) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(RUN_SEED_DOMAIN);
+    hasher.update(run_intent_digest.as_bytes());
+    let bytes: [u8; 32] = hasher.finalize().into();
+    u64::from_le_bytes([
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+    ])
+}
+
+/// The exact identities a launch states and a handshake must return.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedLaunchIdentity {
+    /// Launch identity schema version.
+    pub schema_version: u16,
+    /// The run intent that authorizes this launch.
+    pub run_intent_digest: Digest,
+    /// The exact bytes of the artifact the executor must load.
+    pub artifact_digest: Digest,
+    /// The canonical condition identity inside those bytes.
+    pub condition_digest: Digest,
+    /// The seed for every deterministic decision in this run.
+    pub run_seed: u64,
+    /// The capabilities the executor must supply, in ascending name order.
+    pub required_capabilities: Vec<BackendCapability>,
+    /// The trace schema the executor must speak.
+    pub trace_schema_version: u16,
+}
+
+impl ExecutedLaunchIdentity {
+    /// States the identities one launch will pass and check.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when an identity is absent or the capability
+    /// order is not the stated one.
+    pub fn new(
+        run_intent_digest: Digest,
+        artifact_digest: Digest,
+        condition_digest: Digest,
+        run_seed: u64,
+        required_capabilities: Vec<BackendCapability>,
+        trace_schema_version: u16,
+    ) -> Result<Self, TuneError> {
+        let identity = Self {
+            schema_version: EXECUTED_UNCERTAINTY_SCHEMA_VERSION,
+            run_intent_digest,
+            artifact_digest,
+            condition_digest,
+            run_seed,
+            required_capabilities,
+            trace_schema_version,
+        };
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    /// Rejects a launch identity that cannot name one exact execution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the schema differs, when an identity is
+    /// absent, when the artifact and condition identities are the same
+    /// value, or when a capability repeats or is out of name order.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if self.schema_version != EXECUTED_UNCERTAINTY_SCHEMA_VERSION {
+            return Err(invalid_terminal("the launch identity schema changed"));
+        }
+        if self.run_intent_digest.is_zero()
+            || self.artifact_digest.is_zero()
+            || self.condition_digest.is_zero()
+        {
+            return Err(invalid_terminal("a launch identity is absent"));
+        }
+        if self.artifact_digest == self.condition_digest {
+            return Err(invalid_terminal(
+                "the artifact and condition identities are one value",
+            ));
+        }
+        if self.trace_schema_version == 0 {
+            return Err(invalid_terminal("a launch states no trace schema"));
+        }
+        if self.required_capabilities.is_empty() {
+            return Err(invalid_terminal(
+                "a launch identity requires no executable capability",
+            ));
+        }
+        let mut previous: Option<&'static str> = None;
+        for capability in &self.required_capabilities {
+            let name = capability.as_str();
+            if previous.is_some_and(|prior| prior >= name) {
+                return Err(invalid_terminal(
+                    "the launch capabilities are not in name order",
+                ));
+            }
+            previous = Some(name);
+        }
+        Ok(())
+    }
+
+    /// Requires one returned handshake to state these exact identities.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when any returned identity differs.
+    pub fn require_returned(&self, returned: &Self) -> Result<(), TuneError> {
+        self.validate()?;
+        if self != returned {
+            return Err(invalid_terminal(
+                "the executor returned other launch identities",
+            ));
+        }
+        Ok(())
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/ledger.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/ledger.rs
@@ -1,0 +1,264 @@
+//! What one complete sample stream counted, by factor and by lane.
+//!
+//! The counts are the terminal statement of a run: how many samples each
+//! factor could have changed, how many it did change, how many it held, how
+//! many bypassed every policy, and how many the plant constrained. They are
+//! folded from the verified stream and never read back from the executor,
+//! so a count can only say what the samples say.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::invalid_terminal;
+use super::EXECUTED_UNCERTAINTY_SCHEMA_VERSION;
+use super::sample::{ExecutedBypassReason, ExecutedSample};
+use crate::TuneError;
+
+/// What one declared sensor lane did across a complete stream.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedSensorLaneCounts {
+    /// The one-byte lane tag this count answers for.
+    pub lane_tag: u8,
+    /// Samples in which the lane was present and could be changed.
+    pub eligible: u64,
+    /// Samples in which the exact lane value moved.
+    pub changed: u64,
+    /// Samples that reused an offset an earlier sample drew.
+    pub held: u64,
+}
+
+/// How many samples each bypass reason answered for.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedBypassCounts {
+    /// The controller supplied no actuator answer.
+    pub missing_answer: u64,
+    /// The answer named a different number of lanes.
+    pub invalid_actuator_count: u64,
+    /// A backup path produced the command.
+    pub backup: u64,
+    /// A direct command reached the actuator.
+    pub direct: u64,
+    /// A failsafe produced the command.
+    pub failsafe: u64,
+    /// The controller raised a fallback lane.
+    pub fallback_mask: u64,
+    /// The armed state changed on the sample.
+    pub arm_transition: u64,
+    /// The vehicle was not armed.
+    pub disarmed: u64,
+    /// An emergency termination produced the command.
+    pub emergency_termination: u64,
+}
+
+impl ExecutedBypassCounts {
+    /// Returns the total number of bypassed samples.
+    #[must_use]
+    pub const fn total(self) -> u64 {
+        self.missing_answer
+            .wrapping_add(self.invalid_actuator_count)
+            .wrapping_add(self.backup)
+            .wrapping_add(self.direct)
+            .wrapping_add(self.failsafe)
+            .wrapping_add(self.fallback_mask)
+            .wrapping_add(self.arm_transition)
+            .wrapping_add(self.disarmed)
+            .wrapping_add(self.emergency_termination)
+    }
+
+    fn count(&mut self, reason: ExecutedBypassReason) {
+        let slot = match reason {
+            ExecutedBypassReason::MissingAnswer => &mut self.missing_answer,
+            ExecutedBypassReason::InvalidActuatorCount => &mut self.invalid_actuator_count,
+            ExecutedBypassReason::Backup => &mut self.backup,
+            ExecutedBypassReason::Direct => &mut self.direct,
+            ExecutedBypassReason::Failsafe => &mut self.failsafe,
+            ExecutedBypassReason::FallbackMask => &mut self.fallback_mask,
+            ExecutedBypassReason::ArmTransition => &mut self.arm_transition,
+            ExecutedBypassReason::Disarmed => &mut self.disarmed,
+            ExecutedBypassReason::EmergencyTermination => &mut self.emergency_termination,
+        };
+        *slot = slot.wrapping_add(1);
+    }
+}
+
+/// What the actuator factors did across a complete stream.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedActuatorCounts {
+    /// Samples that carried actuator evidence.
+    pub commanded: u64,
+    /// Samples eligible for an actuator perturbation.
+    pub eligible: u64,
+    /// Samples that only primed the accepted-command history.
+    pub primed: u64,
+    /// Samples the seeded schedule selected for a hold.
+    pub selected_hold: u64,
+    /// Samples on which a hold was applied.
+    pub applied_hold: u64,
+    /// Samples the authority scale changed.
+    pub scaled: u64,
+    /// Samples a plant constraint changed.
+    pub clamped: u64,
+    /// Samples that bypassed every perturbation policy.
+    pub bypassed: ExecutedBypassCounts,
+}
+
+/// The terminal counts one complete sample stream states.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedUncertaintyLedger {
+    /// Ledger schema version.
+    pub schema_version: u16,
+    /// The number of samples the stream carried.
+    pub sample_count: u64,
+    /// The first global sample sequence the stream carried.
+    pub first_global_sample_sequence: u64,
+    /// The last global sample sequence the stream carried.
+    pub last_global_sample_sequence: u64,
+    /// The per-lane sensor counts, in ascending lane-tag order.
+    pub sensor_lanes: Vec<ExecutedSensorLaneCounts>,
+    /// The actuator counts.
+    pub actuator: ExecutedActuatorCounts,
+}
+
+impl ExecutedUncertaintyLedger {
+    /// Opens an empty ledger for the declared lanes.
+    #[must_use]
+    pub fn opened(lane_tags: &[u8]) -> Self {
+        Self {
+            schema_version: EXECUTED_UNCERTAINTY_SCHEMA_VERSION,
+            sample_count: 0,
+            first_global_sample_sequence: 0,
+            last_global_sample_sequence: 0,
+            sensor_lanes: lane_tags
+                .iter()
+                .map(|lane_tag| ExecutedSensorLaneCounts {
+                    lane_tag: *lane_tag,
+                    ..ExecutedSensorLaneCounts::default()
+                })
+                .collect(),
+            actuator: ExecutedActuatorCounts::default(),
+        }
+    }
+
+    /// Counts one verified sample.
+    pub fn count(&mut self, sample: &ExecutedSample, drawn: &[bool], scaled: bool) {
+        if self.sample_count == 0 {
+            self.first_global_sample_sequence = sample.global_sample_sequence;
+        }
+        self.sample_count = self.sample_count.wrapping_add(1);
+        self.last_global_sample_sequence = sample.global_sample_sequence;
+        self.count_sensor(sample, drawn);
+        self.count_actuator(sample, scaled);
+    }
+
+    /// Rejects a ledger that no complete stream could have produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the schema differs, when the lane order
+    /// is not the declared one, when the sequence span cannot hold the
+    /// counted samples, or when an actuator total exceeds its population.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if self.schema_version != EXECUTED_UNCERTAINTY_SCHEMA_VERSION {
+            return Err(invalid_terminal(
+                "the executed uncertainty ledger schema changed",
+            ));
+        }
+        self.validate_span()?;
+        let mut previous: Option<u8> = None;
+        for lane in &self.sensor_lanes {
+            if previous.is_some_and(|prior| prior >= lane.lane_tag) {
+                return Err(invalid_terminal("the ledger lanes are not in lane order"));
+            }
+            previous = Some(lane.lane_tag);
+            if lane.changed > lane.eligible || lane.held > lane.eligible {
+                return Err(invalid_terminal("a lane counted more changes than samples"));
+            }
+        }
+        self.validate_actuator()
+    }
+
+    fn validate_span(&self) -> Result<(), TuneError> {
+        if self.sample_count == 0 {
+            return Err(invalid_terminal("an executed uncertainty stream is empty"));
+        }
+        let span = self
+            .last_global_sample_sequence
+            .checked_sub(self.first_global_sample_sequence)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| invalid_terminal("the ledger sample sequence span rewinds"))?;
+        if span != self.sample_count {
+            return Err(invalid_terminal(
+                "the ledger sample count does not span its sequence",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_actuator(&self) -> Result<(), TuneError> {
+        let actuator = self.actuator;
+        if actuator.commanded > self.sample_count
+            || actuator.eligible.wrapping_add(actuator.bypassed.total()) != actuator.commanded
+            || actuator.applied_hold > actuator.selected_hold
+            || actuator.selected_hold > actuator.eligible
+            || actuator.primed > actuator.eligible
+            || actuator.scaled > actuator.eligible
+            || actuator.clamped > self.sample_count
+        {
+            return Err(invalid_terminal(
+                "the ledger actuator counts do not answer for their samples",
+            ));
+        }
+        Ok(())
+    }
+
+    fn count_sensor(&mut self, sample: &ExecutedSample, drawn: &[bool]) {
+        let Some(sensor) = sample.sensor else {
+            return;
+        };
+        for (index, lane) in self.sensor_lanes.iter_mut().enumerate() {
+            let bit = 1_u16 << lane.lane_tag;
+            if sensor.presence_mask & bit == 0 {
+                continue;
+            }
+            lane.eligible = lane.eligible.wrapping_add(1);
+            if sensor.changed_mask & bit != 0 {
+                lane.changed = lane.changed.wrapping_add(1);
+            }
+            if !drawn.get(index).copied().unwrap_or(true) {
+                lane.held = lane.held.wrapping_add(1);
+            }
+        }
+    }
+
+    fn count_actuator(&mut self, sample: &ExecutedSample, scaled: bool) {
+        let Some(actuator) = sample.actuator else {
+            return;
+        };
+        let counts = &mut self.actuator;
+        counts.commanded = counts.commanded.wrapping_add(1);
+        if sample.constraints.clamped() {
+            counts.clamped = counts.clamped.wrapping_add(1);
+        }
+        match actuator.eligibility {
+            super::sample::ExecutedEligibility::Bypass(reason) => counts.bypassed.count(reason),
+            super::sample::ExecutedEligibility::Eligible => {
+                counts.eligible = counts.eligible.wrapping_add(1);
+                if actuator.prime {
+                    counts.primed = counts.primed.wrapping_add(1);
+                }
+                if actuator.selected_hold {
+                    counts.selected_hold = counts.selected_hold.wrapping_add(1);
+                }
+                if actuator.applied_hold {
+                    counts.applied_hold = counts.applied_hold.wrapping_add(1);
+                }
+                if scaled {
+                    counts.scaled = counts.scaled.wrapping_add(1);
+                }
+            }
+        }
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/receipt.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/receipt.rs
@@ -1,0 +1,159 @@
+//! The one document a run states about the uncertainty it executed.
+//!
+//! The receipt binds four things that must travel together: the run intent
+//! that authorized the launch, the identities the launch passed and the
+//! executor returned, what the condition declared, and what the verified
+//! sample stream counted. A reader that holds only this document can derive
+//! the counts again from the samples the stream identity names.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::digest::domain_digest;
+use super::super::invalid_terminal;
+use super::launch::ExecutedLaunchIdentity;
+use super::ledger::ExecutedUncertaintyLedger;
+use super::{EXECUTED_UNCERTAINTY_SCHEMA_VERSION, ExecutedUncertaintyDeclaration};
+use crate::{Digest, TuneError};
+
+const RECEIPT_DOMAIN: &[u8] = b"pilotage.flight-tune.executed-uncertainty-receipt.v1\0";
+
+/// Everything one run is answerable for under uncertainty.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedUncertaintyReceipt {
+    /// Receipt schema version.
+    pub schema_version: u16,
+    /// The identities the launch passed and the executor returned.
+    pub launch: ExecutedLaunchIdentity,
+    /// What the condition declared it would execute.
+    pub declaration: ExecutedUncertaintyDeclaration,
+    /// What the verified sample stream counted.
+    pub ledger: ExecutedUncertaintyLedger,
+    /// The identity of the exact ordered samples the counts came from.
+    pub sample_stream_digest: Digest,
+    /// The identity of this receipt.
+    pub receipt_digest: Digest,
+}
+
+#[derive(Serialize)]
+struct ReceiptDocument<'a> {
+    schema_version: u16,
+    launch: &'a ExecutedLaunchIdentity,
+    declaration: &'a ExecutedUncertaintyDeclaration,
+    ledger: &'a ExecutedUncertaintyLedger,
+    sample_stream_digest: Digest,
+}
+
+impl ExecutedUncertaintyReceipt {
+    /// Seals one verified run under its own identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the launch and the declaration do not name
+    /// one condition, when the ledger cannot answer for the declaration, or
+    /// when the document cannot be encoded.
+    pub fn new(
+        launch: ExecutedLaunchIdentity,
+        declaration: ExecutedUncertaintyDeclaration,
+        ledger: ExecutedUncertaintyLedger,
+        sample_stream_digest: Digest,
+    ) -> Result<Self, TuneError> {
+        let mut receipt = Self {
+            schema_version: EXECUTED_UNCERTAINTY_SCHEMA_VERSION,
+            launch,
+            declaration,
+            ledger,
+            sample_stream_digest,
+            receipt_digest: Digest::from_bytes([0; 32]),
+        };
+        receipt.validate_content()?;
+        receipt.receipt_digest = receipt.recomputed_digest()?;
+        Ok(receipt)
+    }
+
+    /// Rejects a receipt whose content is not the content it names.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the schema differs, when a bound identity
+    /// disagrees, or when the stated identity does not cover the content.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        self.validate_content()?;
+        if self.receipt_digest != self.recomputed_digest()? {
+            return Err(invalid_terminal(
+                "an executed uncertainty receipt does not cover its own content",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Returns the identity a run seal binds this receipt by.
+    #[must_use]
+    pub const fn digest(&self) -> Digest {
+        self.receipt_digest
+    }
+
+    fn validate_content(&self) -> Result<(), TuneError> {
+        if self.schema_version != EXECUTED_UNCERTAINTY_SCHEMA_VERSION {
+            return Err(invalid_terminal(
+                "the executed uncertainty receipt schema changed",
+            ));
+        }
+        self.launch.validate()?;
+        self.declaration.validate()?;
+        self.ledger.validate()?;
+        if self.sample_stream_digest.is_zero() {
+            return Err(invalid_terminal("a receipt names no sample stream"));
+        }
+        self.validate_binding()
+    }
+
+    fn validate_binding(&self) -> Result<(), TuneError> {
+        if self.launch.condition_digest != self.declaration.condition_digest
+            || self.launch.artifact_digest != self.declaration.artifact_digest
+            || self.launch.run_seed != self.declaration.run_seed
+            || self.launch.required_capabilities != self.declaration.required_capabilities
+        {
+            return Err(invalid_terminal(
+                "a receipt launch does not name the condition it declared",
+            ));
+        }
+        if self.declaration.is_nominal() {
+            return Err(invalid_terminal(
+                "a nominal condition states no executed uncertainty",
+            ));
+        }
+        let declared = self
+            .declaration
+            .sensor_lanes
+            .iter()
+            .map(|lane| lane.lane_tag)
+            .collect::<Vec<_>>();
+        let counted = self
+            .ledger
+            .sensor_lanes
+            .iter()
+            .map(|lane| lane.lane_tag)
+            .collect::<Vec<_>>();
+        if declared != counted {
+            return Err(invalid_terminal(
+                "a receipt ledger does not count the declared lanes",
+            ));
+        }
+        Ok(())
+    }
+
+    fn recomputed_digest(&self) -> Result<Digest, TuneError> {
+        domain_digest(
+            RECEIPT_DOMAIN,
+            &ReceiptDocument {
+                schema_version: self.schema_version,
+                launch: &self.launch,
+                declaration: &self.declaration,
+                ledger: &self.ledger,
+                sample_stream_digest: self.sample_stream_digest,
+            },
+            "executed uncertainty receipt",
+        )
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/sample.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/sample.rs
@@ -1,0 +1,314 @@
+//! One sample of executed-uncertainty evidence.
+//!
+//! The executor states, for every simulation sample, what it read, what it
+//! changed, what it commanded, and what it sent. A sample carries the raw
+//! and effective values themselves rather than a summary, so a reader can
+//! derive the requested decision again and compare it with the applied one.
+//!
+//! The types here state shape only. The relation between a declaration and
+//! these values is derived elsewhere, so a sample can never answer for
+//! itself.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::invalid_terminal;
+use super::EXECUTED_SENSOR_LANE_COUNT;
+use crate::{Digest, TuneError};
+
+/// Sensor values before and after one deterministic perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedSensorApplication {
+    /// The identity of the values read before any change.
+    pub raw_digest: Digest,
+    /// The identity of the values the controller received.
+    pub effective_digest: Digest,
+    /// The lanes this sample carried, in stable lane order.
+    pub presence_mask: u16,
+    /// The lanes whose exact value moved.
+    pub changed_mask: u16,
+    /// The held-offset bucket for each configured and present lane.
+    pub update_buckets: [Option<u64>; EXECUTED_SENSOR_LANE_COUNT],
+    /// The exact values read, in stable lane order.
+    pub raw_value_bits: [Option<u32>; EXECUTED_SENSOR_LANE_COUNT],
+    /// The exact values the controller received, in stable lane order.
+    pub effective_value_bits: [Option<u32>; EXECUTED_SENSOR_LANE_COUNT],
+}
+
+/// Why one sample carried no actuator perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExecutedBypassReason {
+    /// The controller supplied no actuator answer.
+    MissingAnswer,
+    /// The answer named a different number of lanes.
+    InvalidActuatorCount,
+    /// A backup path produced the command.
+    Backup,
+    /// A direct command reached the actuator without external provenance.
+    Direct,
+    /// A failsafe produced the command.
+    Failsafe,
+    /// The controller raised a fallback lane.
+    FallbackMask,
+    /// The armed state changed on this sample.
+    ArmTransition,
+    /// The vehicle was not armed.
+    Disarmed,
+    /// An emergency termination produced the command.
+    EmergencyTermination,
+}
+
+impl ExecutedBypassReason {
+    /// Gets the stable reason name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingAnswer => "missing-answer",
+            Self::InvalidActuatorCount => "invalid-actuator-count",
+            Self::Backup => "backup",
+            Self::Direct => "direct",
+            Self::Failsafe => "failsafe",
+            Self::FallbackMask => "fallback-mask",
+            Self::ArmTransition => "arm-transition",
+            Self::Disarmed => "disarmed",
+            Self::EmergencyTermination => "emergency-termination",
+        }
+    }
+
+    /// Reports whether this reason is a safety path.
+    ///
+    /// A safety command must reach the actuator as the controller wrote it,
+    /// so it bypasses the hold and the authority scale together.
+    #[must_use]
+    pub const fn is_safety(self) -> bool {
+        matches!(
+            self,
+            Self::Failsafe | Self::EmergencyTermination | Self::Disarmed | Self::ArmTransition
+        )
+    }
+}
+
+/// Whether one sample was eligible for an actuator perturbation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "reason", rename_all = "kebab-case")]
+pub enum ExecutedEligibility {
+    /// The sample was eligible.
+    Eligible,
+    /// The sample bypassed every perturbation policy.
+    Bypass(ExecutedBypassReason),
+}
+
+/// The number of actuator lanes the contract states.
+pub const EXECUTED_ACTUATOR_LANE_COUNT: usize = 16;
+
+/// Actuator values before the plant constraints and transforms.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedActuatorApplication {
+    /// The exact force-domain values the controller requested.
+    pub requested_lane_bits: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+    /// The exact values after the authority scale.
+    pub authority_scaled_lane_bits: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+    /// The exact values the plant boundary received.
+    pub effective_lane_bits: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+    /// The number of active actuator lanes.
+    pub lane_count: u8,
+    /// Whether this sample was eligible for a perturbation.
+    pub eligibility: ExecutedEligibility,
+    /// Whether this sample only primed the accepted-command history.
+    pub prime: bool,
+    /// The interval epoch, which a bypass advances.
+    pub interval_epoch: Option<u64>,
+    /// The interval index inside the current epoch.
+    pub interval_index: Option<u64>,
+    /// The zero-based position inside the current interval.
+    pub interval_position: Option<u32>,
+    /// The identity of the current interval.
+    pub interval_identity: Option<Digest>,
+    /// Whether the seeded schedule selected a hold at this position.
+    pub selected_hold: bool,
+    /// Whether the executor applied a hold at this position.
+    pub applied_hold: bool,
+    /// Whether this sample completed the interval.
+    pub interval_complete: bool,
+}
+
+/// The plant constraints one sample reported.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedConstraintFlags {
+    /// A requested injection did not reach the plant unchanged.
+    pub injection_clamp: bool,
+    /// The answer named a different number of lanes.
+    pub invalid_actuator_count: bool,
+    /// The controller supplied no actuator answer.
+    pub missing_actuator_answer: bool,
+    /// A collective rate limit changed a lane.
+    pub collective_rate: bool,
+    /// A mean ceiling changed a lane.
+    pub mean_ceiling: bool,
+    /// A single-lane ceiling changed a lane.
+    pub lane_ceiling: bool,
+    /// A ground constraint changed a lane.
+    pub ground_squeeze: bool,
+    /// The trace path itself failed on this sample.
+    pub trace_failure: bool,
+}
+
+impl ExecutedConstraintFlags {
+    /// Reports whether any constraint changed a commanded value.
+    #[must_use]
+    pub const fn clamped(self) -> bool {
+        self.injection_clamp
+            || self.collective_rate
+            || self.mean_ceiling
+            || self.lane_ceiling
+            || self.ground_squeeze
+    }
+}
+
+/// The controller hover initialization one sample repeats.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedHoverInitialization {
+    /// The preset force-domain baseline.
+    pub baseline_force_bits: u32,
+    /// The force-domain value the controller was built with.
+    pub effective_force_bits: u32,
+    /// The applied hover-force scale.
+    pub scale_basis_points: u16,
+    /// Whether no online component can write the hover force.
+    pub estimator_disabled: bool,
+    /// The resolved kernel identity that carries this value.
+    pub kernel_config_hash: u64,
+}
+
+/// The one actuator send this sample attempted.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedSendEvidence {
+    /// Whether the executor attempted the send.
+    pub attempted: bool,
+    /// Whether the send completed.
+    pub succeeded: bool,
+    /// The sample time the send echoed.
+    pub echoed_timestamp_us: u64,
+    /// Whether the send answered the sensor sample in lockstep.
+    pub lockstep: bool,
+}
+
+/// One complete sample of executed-uncertainty evidence.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutedSample {
+    /// The gap-free sequence the trace publisher assigned.
+    pub sequence: u64,
+    /// The global sample sequence every seeded decision uses.
+    pub global_sample_sequence: u64,
+    /// The simulator sample time.
+    pub simulator_timestamp_us: u64,
+    /// The sensor evidence, when this sample carried sensor values.
+    pub sensor: Option<ExecutedSensorApplication>,
+    /// The actuator evidence, when this sample commanded the actuator.
+    pub actuator: Option<ExecutedActuatorApplication>,
+    /// The plant constraints this sample reported.
+    pub constraints: ExecutedConstraintFlags,
+    /// The repeated controller hover initialization.
+    pub hover: ExecutedHoverInitialization,
+    /// The one send this sample attempted.
+    pub send: ExecutedSendEvidence,
+    /// The kernel armed state after this sample.
+    pub armed: bool,
+}
+
+impl ExecutedSample {
+    /// Rejects a sample whose own values contradict each other.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when a mask names an absent lane, when a
+    /// present lane carries no value, when the actuator lane count is out
+    /// of range, or when the interval state is only partly stated.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if self.constraints.trace_failure {
+            return Err(invalid_terminal("a sample reports its own trace failure"));
+        }
+        if let Some(sensor) = self.sensor {
+            sensor.validate()?;
+        }
+        if let Some(actuator) = self.actuator {
+            actuator.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl ExecutedSensorApplication {
+    /// Rejects sensor evidence whose masks and values disagree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when a changed lane is absent, when a present
+    /// lane carries no value, or when an absent lane carries one.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if self.raw_digest.is_zero() || self.effective_digest.is_zero() {
+            return Err(invalid_terminal("a sensor sample has no value identity"));
+        }
+        if self.changed_mask & !self.presence_mask != 0 {
+            return Err(invalid_terminal("a sensor sample changed an absent lane"));
+        }
+        for lane in 0..EXECUTED_SENSOR_LANE_COUNT {
+            let present = self.presence_mask & (1 << lane) != 0;
+            if present != self.raw_value_bits[lane].is_some()
+                || present != self.effective_value_bits[lane].is_some()
+            {
+                return Err(invalid_terminal(
+                    "a sensor lane presence bit does not match its value",
+                ));
+            }
+            if !present && self.update_buckets[lane].is_some() {
+                return Err(invalid_terminal("an absent sensor lane holds an offset"));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ExecutedActuatorApplication {
+    /// Rejects actuator evidence whose own state is not complete.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the lane count is out of range, when the
+    /// interval state is only partly stated, or when a bypassed sample
+    /// still claims a schedule position.
+    pub fn validate(&self) -> Result<(), TuneError> {
+        if usize::from(self.lane_count) > EXECUTED_ACTUATOR_LANE_COUNT || self.lane_count == 0 {
+            return Err(invalid_terminal("an actuator sample states no active lane"));
+        }
+        let stated = [
+            self.interval_epoch.is_some(),
+            self.interval_index.is_some(),
+            self.interval_position.is_some(),
+            self.interval_identity.is_some(),
+        ];
+        if stated.iter().any(|part| *part) && !stated.iter().all(|part| *part) {
+            return Err(invalid_terminal("an interval identity is only part stated"));
+        }
+        if self.interval_identity.is_some_and(Digest::is_zero) {
+            return Err(invalid_terminal("an interval identity is absent"));
+        }
+        if self.eligibility != ExecutedEligibility::Eligible
+            && (self.selected_hold || self.applied_hold || stated[0])
+        {
+            return Err(invalid_terminal(
+                "a bypassed sample claims a hold schedule position",
+            ));
+        }
+        if self.prime && (self.selected_hold || self.applied_hold) {
+            return Err(invalid_terminal("a priming sample claims a hold"));
+        }
+        Ok(())
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/stream.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/stream.rs
@@ -1,0 +1,210 @@
+//! The relation between what one run declared and what it executed.
+//!
+//! A stream accepts samples in order and derives, for each one, the decision
+//! the declaration required. Nothing is taken on the executor's word: the
+//! offsets, the digests, the scale, the schedule, and the counts are all
+//! derived again here, and a sample that states anything else ends the run.
+//!
+//! The stream is the only place a ledger is produced, so a count cannot
+//! exist without the samples that made it.
+
+use super::super::invalid_terminal;
+use super::ledger::ExecutedUncertaintyLedger;
+use super::sample::{ExecutedHoverInitialization, ExecutedSample};
+use super::{ExecutedUncertaintyDeclaration, derivation};
+use crate::{Digest, TuneError};
+
+mod actuator;
+mod sensor;
+
+use actuator::ActuatorState;
+use sensor::SensorState;
+
+/// What one closed stream states about the run it verified.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExecutedStreamSummary {
+    /// The counts the verified samples produced.
+    pub ledger: ExecutedUncertaintyLedger,
+    /// The identity of the exact ordered samples the counts came from.
+    pub sample_stream_digest: Digest,
+}
+
+/// One complete stream of executed-uncertainty evidence.
+pub struct ExecutedStream<'a> {
+    declaration: &'a ExecutedUncertaintyDeclaration,
+    ledger: ExecutedUncertaintyLedger,
+    sample_stream_digest: Digest,
+    sensor: SensorState,
+    actuator: ActuatorState,
+    hover: Option<ExecutedHoverInitialization>,
+    last_sequence: Option<u64>,
+    last_global_sample_sequence: Option<u64>,
+    last_timestamp_us: Option<u64>,
+}
+
+impl<'a> ExecutedStream<'a> {
+    /// Opens one stream against the declaration it must answer for.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the declaration is not valid.
+    pub fn open(declaration: &'a ExecutedUncertaintyDeclaration) -> Result<Self, TuneError> {
+        declaration.validate()?;
+        let lane_tags = declaration
+            .sensor_lanes
+            .iter()
+            .map(|lane| lane.lane_tag)
+            .collect::<Vec<_>>();
+        Ok(Self {
+            declaration,
+            ledger: ExecutedUncertaintyLedger::opened(&lane_tags),
+            sample_stream_digest: derivation::empty_sample_stream(),
+            sensor: SensorState::new(),
+            actuator: ActuatorState::new(),
+            hover: None,
+            last_sequence: None,
+            last_global_sample_sequence: None,
+            last_timestamp_us: None,
+        })
+    }
+
+    /// Accepts one sample after deriving every decision it states.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the sample repeats, skips, or rewinds a
+    /// sequence, when its send is not the one lockstep answer, when the
+    /// hover initialization moves, or when any derived value differs from
+    /// the stated one.
+    pub fn accept(&mut self, sample: &ExecutedSample) -> Result<(), TuneError> {
+        sample.validate()?;
+        self.advance(sample)?;
+        self.require_hover(sample)?;
+        require_send(sample)?;
+        let drawn = sensor::verify(&mut self.sensor, self.declaration, sample)?;
+        let scaled = actuator::verify(&mut self.actuator, self.declaration, sample)?;
+        self.sample_stream_digest =
+            derivation::extend_sample_stream(self.sample_stream_digest, sample)?;
+        self.ledger.count(sample, &drawn, scaled);
+        Ok(())
+    }
+
+    /// Closes the stream and states the counts its samples produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the stream carried no sample, when the
+    /// counts do not answer for it, or when a perturbation is still active.
+    pub fn close(self) -> Result<ExecutedStreamSummary, TuneError> {
+        if self.actuator.holds_a_command() {
+            return Err(invalid_terminal(
+                "the stream ended with an active command hold",
+            ));
+        }
+        self.ledger.validate()?;
+        Ok(ExecutedStreamSummary {
+            ledger: self.ledger,
+            sample_stream_digest: self.sample_stream_digest,
+        })
+    }
+
+    /// Returns the counts folded so far.
+    #[must_use]
+    pub const fn ledger(&self) -> &ExecutedUncertaintyLedger {
+        &self.ledger
+    }
+
+    fn advance(&mut self, sample: &ExecutedSample) -> Result<(), TuneError> {
+        require_step(self.last_sequence, sample.sequence, "trace sequence")?;
+        require_step(
+            self.last_global_sample_sequence,
+            sample.global_sample_sequence,
+            "sample sequence",
+        )?;
+        if self
+            .last_timestamp_us
+            .is_some_and(|previous| sample.simulator_timestamp_us < previous)
+        {
+            return Err(invalid_terminal("a sample rewinds the simulation time"));
+        }
+        self.last_sequence = Some(sample.sequence);
+        self.last_global_sample_sequence = Some(sample.global_sample_sequence);
+        self.last_timestamp_us = Some(sample.simulator_timestamp_us);
+        Ok(())
+    }
+
+    fn require_hover(&mut self, sample: &ExecutedSample) -> Result<(), TuneError> {
+        let hover = sample.hover;
+        if hover.scale_basis_points != self.declaration.hover_scale_basis_points {
+            return Err(invalid_terminal(
+                "a sample states another hover force scale than the declared one",
+            ));
+        }
+        if !hover.estimator_disabled {
+            return Err(invalid_terminal(
+                "a sample states an active online hover estimator",
+            ));
+        }
+        let derived =
+            derivation::scaled_hover_force(hover.baseline_force_bits, hover.scale_basis_points);
+        if derived != hover.effective_force_bits {
+            return Err(invalid_terminal(
+                "the hover force does not follow from its baseline and scale",
+            ));
+        }
+        match self.hover {
+            Some(first) if first != hover => Err(invalid_terminal(
+                "the hover initialization changed inside one run",
+            )),
+            Some(_) => Ok(()),
+            None => {
+                self.hover = Some(hover);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Requires one sample to carry exactly one completed lockstep answer.
+fn require_send(sample: &ExecutedSample) -> Result<(), TuneError> {
+    let send = sample.send;
+    if !send.attempted || !send.succeeded {
+        return Err(invalid_terminal("a sample has no completed actuator send"));
+    }
+    if !send.lockstep {
+        return Err(invalid_terminal(
+            "a sample answered outside the sensor lockstep",
+        ));
+    }
+    if send.echoed_timestamp_us != sample.simulator_timestamp_us {
+        return Err(invalid_terminal(
+            "a sample send answered another sensor sample",
+        ));
+    }
+    Ok(())
+}
+
+/// Requires one counter to advance by exactly one step.
+fn require_step(previous: Option<u64>, current: u64, name: &'static str) -> Result<(), TuneError> {
+    let Some(previous) = previous else {
+        return Ok(());
+    };
+    if current == previous {
+        return Err(invalid_terminal(format!("a sample repeats one {name}")));
+    }
+    if current < previous {
+        return Err(invalid_terminal(format!("a sample rewinds the {name}")));
+    }
+    if current.wrapping_sub(previous) != 1 {
+        return Err(invalid_terminal(format!("a sample skips a {name}")));
+    }
+    Ok(())
+}
+
+/// Requires one derived digest to equal the stated one.
+fn require_digest(derived: Digest, stated: Digest, detail: &'static str) -> Result<(), TuneError> {
+    if derived == stated {
+        return Ok(());
+    }
+    Err(invalid_terminal(detail))
+}

--- a/tools/flight-tune/src/terminal/uncertainty/stream.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/stream.rs
@@ -166,6 +166,12 @@ impl<'a> ExecutedStream<'a> {
 }
 
 /// Requires one sample to carry exactly one completed lockstep answer.
+///
+/// The echoed time is the transport's own confirmation of what it put on
+/// the wire, drawn from a clock this side never sees, so it is carried as
+/// evidence rather than derived. What the hold policy needs is that every
+/// sensor sample received one answer and that the answer was in lockstep,
+/// which is what the sequence discipline and these three flags state.
 fn require_send(sample: &ExecutedSample) -> Result<(), TuneError> {
     let send = sample.send;
     if !send.attempted || !send.succeeded {
@@ -174,11 +180,6 @@ fn require_send(sample: &ExecutedSample) -> Result<(), TuneError> {
     if !send.lockstep {
         return Err(invalid_terminal(
             "a sample answered outside the sensor lockstep",
-        ));
-    }
-    if send.echoed_timestamp_us != sample.simulator_timestamp_us {
-        return Err(invalid_terminal(
-            "a sample send answered another sensor sample",
         ));
     }
     Ok(())

--- a/tools/flight-tune/src/terminal/uncertainty/stream/actuator.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/stream/actuator.rs
@@ -1,0 +1,305 @@
+//! Deriving what one declaration required of every actuator command.
+//!
+//! An eligible command is scaled and then either accepted or replaced by the
+//! last accepted command, and which of the two is a seeded decision the
+//! declaration fixes. A bypassed command reaches the actuator exactly as the
+//! controller wrote it: no scale and no hold, because a safety command that
+//! arrives changed is not the command the controller sent.
+
+use super::super::super::invalid_terminal;
+use super::super::sample::{
+    EXECUTED_ACTUATOR_LANE_COUNT, ExecutedActuatorApplication, ExecutedEligibility, ExecutedSample,
+};
+use super::super::{ExecutedUncertaintyDeclaration, derivation};
+use crate::{Digest, TuneError};
+
+type LaneBits = [u32; EXECUTED_ACTUATOR_LANE_COUNT];
+
+/// The open command hold and the last command it may replay.
+pub(super) struct ActuatorState {
+    last_accepted: Option<LaneBits>,
+    interval: Option<OpenInterval>,
+}
+
+struct OpenInterval {
+    identity: Digest,
+    epoch: u64,
+    index: u64,
+    position: u32,
+    decisions: Vec<bool>,
+}
+
+impl ActuatorState {
+    pub(super) const fn new() -> Self {
+        Self {
+            last_accepted: None,
+            interval: None,
+        }
+    }
+
+    /// Reports whether a command hold can still replay a command.
+    pub(super) const fn holds_a_command(&self) -> bool {
+        self.interval.is_some()
+    }
+}
+
+/// Derives every actuator decision one sample states.
+///
+/// Returns whether the declared authority scale changed a commanded lane.
+pub(super) fn verify(
+    state: &mut ActuatorState,
+    declaration: &ExecutedUncertaintyDeclaration,
+    sample: &ExecutedSample,
+) -> Result<bool, TuneError> {
+    let Some(actuator) = sample.actuator else {
+        return Ok(false);
+    };
+    match actuator.eligibility {
+        ExecutedEligibility::Bypass(_) => {
+            require_untouched(&actuator)?;
+            state.last_accepted = None;
+            state.interval = None;
+            Ok(false)
+        }
+        ExecutedEligibility::Eligible => verify_eligible(state, declaration, sample, &actuator),
+    }
+}
+
+/// Requires a bypassed command to reach the actuator as it was written.
+fn require_untouched(actuator: &ExecutedActuatorApplication) -> Result<(), TuneError> {
+    if actuator.authority_scaled_lane_bits != actuator.requested_lane_bits
+        || actuator.effective_lane_bits != actuator.requested_lane_bits
+    {
+        return Err(invalid_terminal(
+            "a bypassed command did not reach the actuator as the controller wrote it",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_eligible(
+    state: &mut ActuatorState,
+    declaration: &ExecutedUncertaintyDeclaration,
+    sample: &ExecutedSample,
+    actuator: &ExecutedActuatorApplication,
+) -> Result<bool, TuneError> {
+    let scaled = require_scaled(declaration, actuator)?;
+    let Some(hold) = declaration.command_hold else {
+        return require_no_hold(state, actuator).map(|()| scaled);
+    };
+    if state.last_accepted.is_none() {
+        return require_prime(state, actuator).map(|()| scaled);
+    }
+    if actuator.prime {
+        return Err(invalid_terminal(
+            "a command hold primed its history a second time",
+        ));
+    }
+    let decisions = open_interval(state, declaration, sample, actuator, hold)?;
+    require_decision(state, actuator, &decisions)?;
+    advance(state, actuator, hold.decision_interval_samples)?;
+    Ok(scaled)
+}
+
+/// Requires every active lane to carry the declared authority scale.
+fn require_scaled(
+    declaration: &ExecutedUncertaintyDeclaration,
+    actuator: &ExecutedActuatorApplication,
+) -> Result<bool, TuneError> {
+    let active = usize::from(actuator.lane_count);
+    let mut changed = false;
+    for lane in 0..EXECUTED_ACTUATOR_LANE_COUNT {
+        let requested = actuator.requested_lane_bits[lane];
+        let required = if lane < active {
+            derivation::scaled_authority(requested, declaration.authority_scale_basis_points)
+        } else {
+            requested
+        };
+        if actuator.authority_scaled_lane_bits[lane] != required {
+            return Err(invalid_terminal(
+                "an actuator lane does not carry the declared authority scale",
+            ));
+        }
+        changed |= required != requested;
+    }
+    Ok(changed)
+}
+
+/// Requires a run that declared no hold to command the scaled value.
+fn require_no_hold(
+    state: &mut ActuatorState,
+    actuator: &ExecutedActuatorApplication,
+) -> Result<(), TuneError> {
+    if actuator.selected_hold || actuator.applied_hold || actuator.prime {
+        return Err(invalid_terminal("an undeclared command hold was applied"));
+    }
+    if actuator.interval_identity.is_some() {
+        return Err(invalid_terminal(
+            "an undeclared command hold opened an interval",
+        ));
+    }
+    if actuator.effective_lane_bits != actuator.authority_scaled_lane_bits {
+        return Err(invalid_terminal(
+            "an eligible command did not reach the actuator scaled",
+        ));
+    }
+    state.last_accepted = Some(actuator.effective_lane_bits);
+    Ok(())
+}
+
+/// Requires the first eligible command of an epoch to only prime the history.
+fn require_prime(
+    state: &mut ActuatorState,
+    actuator: &ExecutedActuatorApplication,
+) -> Result<(), TuneError> {
+    if !actuator.prime || actuator.selected_hold || actuator.applied_hold {
+        return Err(invalid_terminal(
+            "the first eligible command of an epoch did not prime the hold history",
+        ));
+    }
+    if actuator.interval_identity.is_some() {
+        return Err(invalid_terminal("a priming command opened an interval"));
+    }
+    if actuator.effective_lane_bits != actuator.authority_scaled_lane_bits {
+        return Err(invalid_terminal(
+            "a priming command did not reach the actuator scaled",
+        ));
+    }
+    state.last_accepted = Some(actuator.effective_lane_bits);
+    Ok(())
+}
+
+/// Derives the schedule the stated interval identity must carry.
+fn open_interval(
+    state: &mut ActuatorState,
+    declaration: &ExecutedUncertaintyDeclaration,
+    sample: &ExecutedSample,
+    actuator: &ExecutedActuatorApplication,
+    hold: super::super::DeclaredCommandHold,
+) -> Result<Vec<bool>, TuneError> {
+    let (epoch, index, position, identity) = stated_interval(actuator)?;
+    if let Some(open) = &state.interval
+        && open.epoch == epoch
+        && open.index == index
+    {
+        if open.position != position || open.identity != identity {
+            return Err(invalid_terminal(
+                "a command hold interval lost its own position",
+            ));
+        }
+        return Ok(open.decisions.clone());
+    }
+    if position != 0 {
+        return Err(invalid_terminal(
+            "a command hold interval started away from its first position",
+        ));
+    }
+    let first_sequence = sample.global_sample_sequence;
+    let derived = derivation::interval_identity(
+        declaration.condition_digest,
+        declaration.run_seed,
+        epoch,
+        index,
+        first_sequence,
+    );
+    if derived != identity {
+        return Err(invalid_terminal(
+            "a command hold interval does not carry its derived identity",
+        ));
+    }
+    let decisions = derivation::hold_schedule(
+        declaration.condition_digest,
+        declaration.run_seed,
+        epoch,
+        index,
+        first_sequence,
+        hold,
+    )?;
+    state.interval = Some(OpenInterval {
+        identity,
+        epoch,
+        index,
+        position,
+        decisions: decisions.clone(),
+    });
+    Ok(decisions)
+}
+
+/// Requires the stated hold decision to be the one the schedule holds.
+fn require_decision(
+    state: &mut ActuatorState,
+    actuator: &ExecutedActuatorApplication,
+    decisions: &[bool],
+) -> Result<(), TuneError> {
+    let position = actuator
+        .interval_position
+        .ok_or_else(|| invalid_terminal("a command hold states no interval position"))?;
+    let selected = decisions
+        .get(usize::try_from(position).unwrap_or(usize::MAX))
+        .copied()
+        .ok_or_else(|| invalid_terminal("a command hold reached a position it never scheduled"))?;
+    if selected != actuator.selected_hold || selected != actuator.applied_hold {
+        return Err(invalid_terminal(
+            "a command hold decision is not the one its schedule states",
+        ));
+    }
+    let accepted = state
+        .last_accepted
+        .ok_or_else(|| invalid_terminal("a command hold has no accepted command to replay"))?;
+    let required = if selected {
+        accepted
+    } else {
+        actuator.authority_scaled_lane_bits
+    };
+    if actuator.effective_lane_bits != required {
+        return Err(invalid_terminal(
+            "a held command did not replay the last accepted command",
+        ));
+    }
+    if !selected {
+        state.last_accepted = Some(actuator.effective_lane_bits);
+    }
+    Ok(())
+}
+
+/// Advances or closes the open interval after one counted decision.
+fn advance(
+    state: &mut ActuatorState,
+    actuator: &ExecutedActuatorApplication,
+    interval_samples: u32,
+) -> Result<(), TuneError> {
+    let Some(open) = &mut state.interval else {
+        return Err(invalid_terminal("a command hold advanced no interval"));
+    };
+    let next = open.position.wrapping_add(1);
+    let complete = next >= interval_samples;
+    if complete != actuator.interval_complete {
+        return Err(invalid_terminal(
+            "a command hold interval did not end where it was scheduled to",
+        ));
+    }
+    if complete {
+        state.interval = None;
+    } else {
+        open.position = next;
+    }
+    Ok(())
+}
+
+fn stated_interval(
+    actuator: &ExecutedActuatorApplication,
+) -> Result<(u64, u64, u32, Digest), TuneError> {
+    match (
+        actuator.interval_epoch,
+        actuator.interval_index,
+        actuator.interval_position,
+        actuator.interval_identity,
+    ) {
+        (Some(epoch), Some(index), Some(position), Some(identity)) => {
+            Ok((epoch, index, position, identity))
+        }
+        _ => Err(invalid_terminal(
+            "an eligible command states no command hold interval",
+        )),
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/stream/sensor.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/stream/sensor.rs
@@ -1,0 +1,155 @@
+//! Deriving what one declaration required of each sensor lane.
+//!
+//! A declared lane holds one drawn offset for a complete update interval, so
+//! the required effective value follows from the raw value the sample states
+//! and nothing else. A lane the declaration never named must arrive at the
+//! controller unchanged, which is what keeps a sensor request out of the
+//! simulator truth evidence stream.
+
+use super::super::super::invalid_terminal;
+use super::super::sample::{ExecutedSample, ExecutedSensorApplication};
+use super::super::{
+    DeclaredSensorLane, EXECUTED_SENSOR_LANE_COUNT, ExecutedUncertaintyDeclaration, derivation,
+};
+use super::require_digest;
+use crate::TuneError;
+
+/// The update bucket each declared lane last drew an offset for.
+pub(super) struct SensorState {
+    drawn_buckets: [Option<u64>; EXECUTED_SENSOR_LANE_COUNT],
+}
+
+impl SensorState {
+    pub(super) const fn new() -> Self {
+        Self {
+            drawn_buckets: [None; EXECUTED_SENSOR_LANE_COUNT],
+        }
+    }
+}
+
+/// Derives every sensor decision one sample states.
+///
+/// Returns, for each declared lane in declaration order, whether this sample
+/// drew a new offset rather than holding one an earlier sample drew.
+pub(super) fn verify(
+    state: &mut SensorState,
+    declaration: &ExecutedUncertaintyDeclaration,
+    sample: &ExecutedSample,
+) -> Result<Vec<bool>, TuneError> {
+    let Some(sensor) = sample.sensor else {
+        if !declaration.sensor_lanes.is_empty() && sample.armed {
+            return Err(invalid_terminal(
+                "an armed sample carries no sensor evidence for a declared lane",
+            ));
+        }
+        return Ok(vec![false; declaration.sensor_lanes.len()]);
+    };
+    require_digest(
+        derivation::sensor_sample_digest(sensor.presence_mask, &sensor.raw_value_bits),
+        sensor.raw_digest,
+        "the raw sensor identity does not cover its own values",
+    )?;
+    require_digest(
+        derivation::sensor_sample_digest(sensor.presence_mask, &sensor.effective_value_bits),
+        sensor.effective_digest,
+        "the effective sensor identity does not cover its own values",
+    )?;
+    require_undeclared_unchanged(declaration, &sensor)?;
+    declaration
+        .sensor_lanes
+        .iter()
+        .map(|declared| verify_lane(state, declaration, sample, &sensor, *declared))
+        .collect()
+}
+
+/// Requires a lane the declaration never named to reach the controller whole.
+fn require_undeclared_unchanged(
+    declaration: &ExecutedUncertaintyDeclaration,
+    sensor: &ExecutedSensorApplication,
+) -> Result<(), TuneError> {
+    for lane in 0..EXECUTED_SENSOR_LANE_COUNT {
+        let tag = u8::try_from(lane)
+            .map_err(|_| invalid_terminal("a sensor lane tag is not addressable"))?;
+        if declaration.lane(tag).is_some() {
+            continue;
+        }
+        if sensor.update_buckets[lane].is_some() {
+            return Err(invalid_terminal("an undeclared sensor lane drew an offset"));
+        }
+        if sensor.raw_value_bits[lane] != sensor.effective_value_bits[lane]
+            || sensor.changed_mask & (1 << lane) != 0
+        {
+            return Err(invalid_terminal("an undeclared sensor lane changed"));
+        }
+    }
+    Ok(())
+}
+
+/// Derives the one value a declared lane must carry, and states whether it
+/// drew a new offset for this sample.
+fn verify_lane(
+    state: &mut SensorState,
+    declaration: &ExecutedUncertaintyDeclaration,
+    sample: &ExecutedSample,
+    sensor: &ExecutedSensorApplication,
+    declared: DeclaredSensorLane,
+) -> Result<bool, TuneError> {
+    let lane = usize::from(declared.lane_tag);
+    let bit = 1_u16 << declared.lane_tag;
+    let present = sensor.presence_mask & bit != 0;
+    let stated_bucket = sensor.update_buckets[lane];
+    if !present {
+        if stated_bucket.is_some() {
+            return Err(invalid_terminal("an absent sensor lane drew an offset"));
+        }
+        return Ok(false);
+    }
+    let update_bucket = sample.global_sample_sequence / u64::from(declared.update_interval_samples);
+    if stated_bucket != Some(update_bucket) {
+        return Err(invalid_terminal(
+            "a sensor lane states another held-offset bucket than the declared one",
+        ));
+    }
+    let raw = sensor.raw_value_bits[lane]
+        .ok_or_else(|| invalid_terminal("a present sensor lane carries no value"))?;
+    require_effective(declaration, declared, update_bucket, raw, sensor, lane, bit)?;
+    let drew = state.drawn_buckets[lane] != Some(update_bucket);
+    state.drawn_buckets[lane] = Some(update_bucket);
+    Ok(drew)
+}
+
+/// Requires one present declared lane to carry its derived value exactly.
+#[allow(clippy::too_many_arguments)]
+fn require_effective(
+    declaration: &ExecutedUncertaintyDeclaration,
+    declared: DeclaredSensorLane,
+    update_bucket: u64,
+    raw: u32,
+    sensor: &ExecutedSensorApplication,
+    lane: usize,
+    bit: u16,
+) -> Result<(), TuneError> {
+    let value = f32::from_bits(raw);
+    if !value.is_finite() {
+        return Err(invalid_terminal("a declared sensor lane carries no value"));
+    }
+    let offset = derivation::sensor_offset(
+        declaration.condition_digest,
+        declaration.run_seed,
+        declared.lane_tag,
+        update_bucket,
+        f32::from_bits(declared.peak_amplitude_bits),
+    );
+    let required = (value + offset).to_bits();
+    if sensor.effective_value_bits[lane] != Some(required) {
+        return Err(invalid_terminal(
+            "a sensor lane does not carry its declared value",
+        ));
+    }
+    if (sensor.changed_mask & bit != 0) != (required != raw) {
+        return Err(invalid_terminal(
+            "a sensor lane change flag does not match its own values",
+        ));
+    }
+    Ok(())
+}

--- a/tools/flight-tune/src/terminal/uncertainty/tests.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests.rs
@@ -153,8 +153,8 @@ fn the_sensor_sample_identity_covers_its_own_preimage() {
     let mut hasher = Sha256::new();
     hasher.update(b"aviate-effective-sensor-v1");
     hasher.update(presence_mask.to_le_bytes());
-    for lane in 0..EXECUTED_SENSOR_LANE_COUNT {
-        hasher.update(values[lane].unwrap_or(0_u32).to_le_bytes());
+    for value in &values {
+        hasher.update(value.unwrap_or(0_u32).to_le_bytes());
     }
     let expected: [u8; 32] = hasher.finalize().into();
 

--- a/tools/flight-tune/src/terminal/uncertainty/tests.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests.rs
@@ -1,0 +1,233 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use pilotage_trial::ConditionSet;
+use sha2::{Digest as ShaDigest, Sha256};
+
+use super::*;
+
+#[path = "tests/stream.rs"]
+mod stream_tests;
+#[path = "tests/support.rs"]
+mod support;
+
+use support::{GOLDEN_RUN_SEED, cross_repository_digest, golden_condition};
+
+#[test]
+fn a_declaration_states_every_factor_the_condition_executes() {
+    let condition = golden_condition();
+    let declaration = declaration(&condition);
+
+    assert_eq!(declaration.authority_scale_basis_points, 12_000);
+    assert_eq!(declaration.hover_scale_basis_points, 9_000);
+    assert_eq!(
+        declaration.command_hold,
+        Some(DeclaredCommandHold {
+            fraction_basis_points: 100,
+            decision_interval_samples: 100,
+        })
+    );
+    assert_eq!(declaration.sensor_lanes.len(), 6);
+    assert_eq!(
+        declaration
+            .required_capabilities
+            .iter()
+            .map(|capability| capability.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "actuator_authority",
+            "command_hold",
+            "hover_trim_uncertainty",
+            "sensor_perturbation",
+        ]
+    );
+}
+
+#[test]
+fn a_declared_amplitude_is_the_unit_the_executor_applies() {
+    let condition = golden_condition();
+    let declaration = declaration(&condition);
+
+    // The artifact declares 0.02 gauss and 1.0 hectopascal; the controller
+    // reads microtesla and pascal.
+    let magnetometer = declaration.lane(8).expect("magnetometer z lane");
+    let absolute_pressure = declaration.lane(9).expect("absolute pressure lane");
+
+    assert!((f32::from_bits(magnetometer.peak_amplitude_bits) - 2.0).abs() < 1e-6);
+    assert!((f32::from_bits(absolute_pressure.peak_amplitude_bits) - 100.0).abs() < 1e-4);
+}
+
+#[test]
+fn the_declared_offset_is_the_one_the_contract_crate_derives() {
+    let condition = golden_condition();
+    let declaration = declaration(&condition);
+    let references = condition
+        .sensor_references_for_sample(GOLDEN_RUN_SEED, 123)
+        .expect("contract references");
+
+    for reference in references {
+        let declared = declaration
+            .lane(lane_tag(reference.lane()))
+            .expect("declared lane");
+        let derived = derivation::sensor_offset(
+            declaration.condition_digest,
+            declaration.run_seed,
+            declared.lane_tag,
+            reference.update_bucket(),
+            f32::from_bits(declared.peak_amplitude_bits),
+        );
+        assert_eq!(
+            derived.to_bits(),
+            reference.offset().to_bits(),
+            "lane {} offset",
+            declared.lane_tag
+        );
+    }
+}
+
+#[test]
+fn the_sensor_derivation_matches_the_cross_repository_golden() {
+    // Accelerometer X, sample 10, interval 2, peak 2 m/s squared, raw 1.0.
+    let offset = derivation::sensor_offset(cross_repository_digest(), GOLDEN_RUN_SEED, 0, 5, 2.0);
+    assert_eq!((1.0_f32 + offset).to_bits(), 0x403c_4a40);
+
+    // Differential pressure, sample 10, interval 1, peak 200 Pa, raw 500.0.
+    let offset =
+        derivation::sensor_offset(cross_repository_digest(), GOLDEN_RUN_SEED, 10, 10, 200.0);
+    assert_eq!((500.0_f32 + offset).to_bits(), 0x43c4_6996);
+}
+
+#[test]
+fn the_interval_identity_matches_the_cross_repository_golden() {
+    let identity = derivation::interval_identity(
+        cross_repository_digest(),
+        GOLDEN_RUN_SEED,
+        0x2122_2324_2526_2728,
+        0x3132_3334_3536_3738,
+        0x4142_4344_4546_4748,
+    );
+
+    assert_eq!(
+        identity.to_string(),
+        "94ab1093b990a952b30ec29395a88314347304a5b21ed170c862d2725d99bd6c"
+    );
+}
+
+#[test]
+fn the_hold_schedule_matches_the_one_the_contract_crate_derives() {
+    let condition = golden_condition();
+    let declaration = declaration(&condition);
+    let hold = declaration.command_hold.expect("declared hold");
+
+    let derived = derivation::hold_schedule(
+        declaration.condition_digest,
+        declaration.run_seed,
+        2,
+        3,
+        1_001,
+        hold,
+    )
+    .expect("hold schedule");
+    let contract = condition
+        .command_hold_decisions_for_interval(GOLDEN_RUN_SEED, 2, 3, 1_001)
+        .expect("contract schedule");
+
+    assert_eq!(derived, contract);
+    assert_eq!(
+        derived
+            .iter()
+            .enumerate()
+            .filter(|(_, held)| **held)
+            .map(|(position, _)| position)
+            .collect::<Vec<_>>(),
+        vec![89]
+    );
+}
+
+#[test]
+fn the_sensor_sample_identity_covers_its_own_preimage() {
+    let mut values = [None; EXECUTED_SENSOR_LANE_COUNT];
+    values[0] = Some(0x3f80_0000);
+    values[3] = Some(0x4000_0000);
+    let presence_mask = 0b1001_u16;
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"aviate-effective-sensor-v1");
+    hasher.update(presence_mask.to_le_bytes());
+    for lane in 0..EXECUTED_SENSOR_LANE_COUNT {
+        hasher.update(values[lane].unwrap_or(0_u32).to_le_bytes());
+    }
+    let expected: [u8; 32] = hasher.finalize().into();
+
+    assert_eq!(
+        derivation::sensor_sample_digest(presence_mask, &values),
+        Digest::from_bytes(expected)
+    );
+}
+
+#[test]
+fn the_authority_scale_narrows_once_at_the_end() {
+    // A scale taken wholly in the narrow domain gives another last bit, so
+    // the wider intermediate is part of the contract rather than a detail.
+    let lane = f32::from_bits(0x38d1_b717);
+    let narrow = lane * (12_000.0 / 10_000.0);
+
+    assert_eq!(
+        derivation::scaled_authority(lane.to_bits(), 12_000),
+        0x38fb_a882
+    );
+    assert_eq!(narrow.to_bits(), 0x38fb_a883);
+}
+
+#[test]
+fn a_run_seed_separates_one_retry_from_the_execution_it_replaces() {
+    let source = executed_run_seed(Digest::from_bytes([7; 32]));
+    let replacement = executed_run_seed(Digest::from_bytes([8; 32]));
+
+    assert_ne!(source, replacement);
+    assert_eq!(source, executed_run_seed(Digest::from_bytes([7; 32])));
+}
+
+#[test]
+fn a_declaration_that_omits_a_required_capability_is_refused() {
+    let condition = golden_condition();
+    let mut declaration = declaration(&condition);
+    declaration.required_capabilities.remove(0);
+
+    assert!(declaration.validate().is_err());
+}
+
+#[test]
+fn a_declaration_whose_lanes_are_out_of_order_is_refused() {
+    let condition = golden_condition();
+    let mut declaration = declaration(&condition);
+    declaration.sensor_lanes.swap(0, 1);
+
+    assert!(declaration.validate().is_err());
+}
+
+#[test]
+fn a_launch_that_names_one_value_for_two_identities_is_refused() {
+    let condition = golden_condition();
+    let declaration = declaration(&condition);
+
+    assert!(
+        ExecutedLaunchIdentity::new(
+            Digest::from_bytes([1; 32]),
+            declaration.condition_digest,
+            declaration.condition_digest,
+            declaration.run_seed,
+            declaration.required_capabilities.clone(),
+            3,
+        )
+        .is_err()
+    );
+}
+
+fn declaration(condition: &ConditionSet) -> ExecutedUncertaintyDeclaration {
+    ExecutedUncertaintyDeclaration::from_condition(
+        condition,
+        Digest::from_bytes([0xab; 32]),
+        GOLDEN_RUN_SEED,
+    )
+    .expect("declaration")
+}

--- a/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
@@ -310,7 +310,9 @@ impl<'a> Executor<'a> {
             send: ExecutedSendEvidence {
                 attempted: true,
                 succeeded: true,
-                echoed_timestamp_us: sequence.wrapping_mul(10_000),
+                // The transport echoes its own link clock, never the
+                // sample time.
+                echoed_timestamp_us: sequence.wrapping_mul(9_973).wrapping_add(7),
                 lockstep: true,
             },
             armed: true,

--- a/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
@@ -290,7 +290,7 @@ impl<'a> Executor<'a> {
     fn next(&mut self) -> ExecutedSample {
         let sequence = self.sequence;
         self.sequence = self.sequence.wrapping_add(1);
-        let sample = ExecutedSample {
+        ExecutedSample {
             sequence,
             global_sample_sequence: sequence,
             simulator_timestamp_us: sequence.wrapping_mul(10_000),
@@ -314,8 +314,7 @@ impl<'a> Executor<'a> {
                 lockstep: true,
             },
             armed: true,
-        };
-        sample
+        }
     }
 
     fn sensor(&self, sequence: u64) -> ExecutedSensorApplication {

--- a/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests/stream.rs
@@ -1,0 +1,466 @@
+//! What a stream accepts, and every way one sample can fail to answer.
+
+use super::super::*;
+use super::support::{GOLDEN_RUN_SEED, stream_condition};
+use crate::Digest;
+
+const BASELINE_FORCE_BITS: u32 = 0x3f00_0000;
+const HOLD_INTERVAL: u32 = 10;
+const LANE_COUNT: u8 = 4;
+
+#[test]
+fn a_complete_stream_counts_every_factor_it_verified() {
+    let declaration = declaration();
+    let samples = run(&declaration, 21);
+    let summary = accept_all(&declaration, &samples).expect("verified stream");
+
+    assert_eq!(summary.ledger.sample_count, 21);
+    assert_eq!(summary.ledger.actuator.commanded, 21);
+    assert_eq!(summary.ledger.actuator.eligible, 21);
+    assert_eq!(summary.ledger.actuator.primed, 1);
+    assert_eq!(summary.ledger.actuator.selected_hold, 2);
+    assert_eq!(summary.ledger.actuator.applied_hold, 2);
+    assert_eq!(summary.ledger.actuator.scaled, 21);
+    assert_eq!(summary.ledger.actuator.bypassed.total(), 0);
+
+    let lane = summary.ledger.sensor_lanes[0];
+    assert_eq!(lane.lane_tag, 0);
+    assert_eq!(lane.eligible, 21);
+    // One offset is drawn every two samples and held for the second.
+    assert_eq!(lane.held, 10);
+    assert!(lane.changed > 0);
+}
+
+#[test]
+fn a_receipt_binds_the_counts_to_the_samples_that_made_them() {
+    let declaration = declaration();
+    let samples = run(&declaration, 21);
+    let summary = accept_all(&declaration, &samples).expect("verified stream");
+    let receipt = receipt(&declaration, &summary);
+
+    receipt.validate().expect("sealed receipt");
+
+    let mut changed = receipt.clone();
+    changed.ledger.actuator.applied_hold = 1;
+    assert!(changed.validate().is_err());
+}
+
+#[test]
+fn a_repeated_sample_sequence_is_refused() {
+    assert_refused(|samples| samples[5] = samples[4]);
+}
+
+#[test]
+fn a_sample_sequence_gap_is_refused() {
+    assert_refused(|samples| {
+        samples[5].sequence = samples[5].sequence.wrapping_add(1);
+    });
+}
+
+#[test]
+fn a_sample_sequence_rewind_is_refused() {
+    assert_refused(|samples| samples[5].global_sample_sequence = 0);
+}
+
+#[test]
+fn a_changed_effective_sensor_value_is_refused() {
+    assert_refused(|samples| {
+        let mut sensor = samples[5].sensor.expect("sensor evidence");
+        sensor.effective_value_bits[0] = Some(0x3f80_0000);
+        sensor.effective_digest =
+            derivation::sensor_sample_digest(sensor.presence_mask, &sensor.effective_value_bits);
+        samples[5].sensor = Some(sensor);
+    });
+}
+
+#[test]
+fn a_sensor_identity_that_does_not_cover_its_values_is_refused() {
+    assert_refused(|samples| {
+        let mut sensor = samples[5].sensor.expect("sensor evidence");
+        sensor.effective_digest = Digest::from_bytes([9; 32]);
+        samples[5].sensor = Some(sensor);
+    });
+}
+
+#[test]
+fn a_changed_undeclared_sensor_lane_is_refused() {
+    assert_refused(|samples| {
+        let mut sensor = samples[5].sensor.expect("sensor evidence");
+        sensor.effective_value_bits[3] = Some(0x4048_0000);
+        sensor.changed_mask |= 1 << 3;
+        sensor.effective_digest =
+            derivation::sensor_sample_digest(sensor.presence_mask, &sensor.effective_value_bits);
+        samples[5].sensor = Some(sensor);
+    });
+}
+
+#[test]
+fn a_hold_decision_the_schedule_never_stated_is_refused() {
+    assert_refused(|samples| {
+        let mut actuator = samples[5].actuator.expect("actuator evidence");
+        actuator.selected_hold = !actuator.selected_hold;
+        actuator.applied_hold = actuator.selected_hold;
+        samples[5].actuator = Some(actuator);
+    });
+}
+
+#[test]
+fn an_interval_identity_that_was_not_derived_is_refused() {
+    assert_refused(|samples| {
+        for sample in samples.iter_mut() {
+            let Some(mut actuator) = sample.actuator else {
+                continue;
+            };
+            if actuator.interval_identity.is_some() {
+                actuator.interval_identity = Some(Digest::from_bytes([4; 32]));
+                sample.actuator = Some(actuator);
+                return;
+            }
+        }
+    });
+}
+
+#[test]
+fn a_bypassed_command_that_was_scaled_is_refused() {
+    assert_refused(|samples| {
+        let mut actuator = samples[5].actuator.expect("actuator evidence");
+        actuator.eligibility = ExecutedEligibility::Bypass(ExecutedBypassReason::Failsafe);
+        actuator.selected_hold = false;
+        actuator.applied_hold = false;
+        actuator.interval_epoch = None;
+        actuator.interval_index = None;
+        actuator.interval_position = None;
+        actuator.interval_identity = None;
+        samples[5].actuator = Some(actuator);
+    });
+}
+
+#[test]
+fn a_safety_command_that_reaches_the_actuator_whole_is_accepted() {
+    let declaration = declaration();
+    let mut samples = run(&declaration, 21);
+    let mut actuator = samples[5].actuator.expect("actuator evidence");
+    actuator.eligibility = ExecutedEligibility::Bypass(ExecutedBypassReason::Failsafe);
+    actuator.authority_scaled_lane_bits = actuator.requested_lane_bits;
+    actuator.effective_lane_bits = actuator.requested_lane_bits;
+    actuator.selected_hold = false;
+    actuator.applied_hold = false;
+    actuator.interval_epoch = None;
+    actuator.interval_index = None;
+    actuator.interval_position = None;
+    actuator.interval_identity = None;
+    actuator.interval_complete = false;
+    samples[5].actuator = Some(actuator);
+
+    // Every later sample belongs to the epoch the bypass reset, so the
+    // stream stops at the first sample that carries the old one.
+    let mut stream = ExecutedStream::open(&declaration).expect("stream");
+    for sample in samples.iter().take(6) {
+        stream.accept(sample).expect("accepted through the bypass");
+    }
+    assert_eq!(stream.ledger().actuator.bypassed.failsafe, 1);
+    assert_eq!(stream.ledger().actuator.eligible, 5);
+}
+
+#[test]
+fn an_active_online_hover_estimator_is_refused() {
+    assert_refused(|samples| samples[5].hover.estimator_disabled = false);
+}
+
+#[test]
+fn a_hover_force_that_moves_inside_one_run_is_refused() {
+    assert_refused(|samples| {
+        samples[5].hover.baseline_force_bits = 0x3f40_0000;
+        samples[5].hover.effective_force_bits = derivation::scaled_hover_force(
+            samples[5].hover.baseline_force_bits,
+            samples[5].hover.scale_basis_points,
+        );
+    });
+}
+
+#[test]
+fn a_hover_scale_the_declaration_never_stated_is_refused() {
+    assert_refused(|samples| {
+        samples[5].hover.scale_basis_points = 10_000;
+        samples[5].hover.effective_force_bits =
+            derivation::scaled_hover_force(samples[5].hover.baseline_force_bits, 10_000);
+    });
+}
+
+#[test]
+fn a_sample_with_no_completed_lockstep_answer_is_refused() {
+    assert_refused(|samples| samples[5].send.lockstep = false);
+}
+
+#[test]
+fn a_stream_that_ends_inside_an_interval_is_refused() {
+    let declaration = declaration();
+    let samples = run(&declaration, 15);
+
+    assert!(accept_all(&declaration, &samples).is_err());
+}
+
+fn assert_refused(change: impl FnOnce(&mut Vec<ExecutedSample>)) {
+    let declaration = declaration();
+    let samples = run(&declaration, 21);
+    assert!(
+        accept_all(&declaration, &samples).is_ok(),
+        "the unchanged stream must verify"
+    );
+
+    let mut changed = samples;
+    change(&mut changed);
+    assert!(
+        accept_all(&declaration, &changed).is_err(),
+        "the changed stream must be refused"
+    );
+}
+
+fn accept_all(
+    declaration: &ExecutedUncertaintyDeclaration,
+    samples: &[ExecutedSample],
+) -> Result<ExecutedStreamSummary, crate::TuneError> {
+    let mut stream = ExecutedStream::open(declaration)?;
+    for sample in samples {
+        stream.accept(sample)?;
+    }
+    stream.close()
+}
+
+fn receipt(
+    declaration: &ExecutedUncertaintyDeclaration,
+    summary: &ExecutedStreamSummary,
+) -> ExecutedUncertaintyReceipt {
+    let launch = ExecutedLaunchIdentity::new(
+        Digest::from_bytes([5; 32]),
+        declaration.artifact_digest,
+        declaration.condition_digest,
+        declaration.run_seed,
+        declaration.required_capabilities.clone(),
+        3,
+    )
+    .expect("launch identity");
+    ExecutedUncertaintyReceipt::new(
+        launch,
+        declaration.clone(),
+        summary.ledger.clone(),
+        summary.sample_stream_digest,
+    )
+    .expect("receipt")
+}
+
+fn declaration() -> ExecutedUncertaintyDeclaration {
+    ExecutedUncertaintyDeclaration::from_condition(
+        &stream_condition(),
+        Digest::from_bytes([0xcd; 32]),
+        GOLDEN_RUN_SEED,
+    )
+    .expect("declaration")
+}
+
+/// Plays the executor: produces the exact stream the declaration requires.
+fn run(declaration: &ExecutedUncertaintyDeclaration, count: u64) -> Vec<ExecutedSample> {
+    let mut executor = Executor::new(declaration);
+    (0..count).map(|_| executor.next()).collect()
+}
+
+struct Executor<'a> {
+    declaration: &'a ExecutedUncertaintyDeclaration,
+    sequence: u64,
+    last_accepted: Option<[u32; EXECUTED_ACTUATOR_LANE_COUNT]>,
+    interval_index: u64,
+    interval_position: u32,
+    interval_first_sequence: u64,
+    decisions: Vec<bool>,
+}
+
+impl<'a> Executor<'a> {
+    fn new(declaration: &'a ExecutedUncertaintyDeclaration) -> Self {
+        Self {
+            declaration,
+            sequence: 0,
+            last_accepted: None,
+            interval_index: 0,
+            interval_position: 0,
+            interval_first_sequence: 0,
+            decisions: Vec::new(),
+        }
+    }
+
+    fn next(&mut self) -> ExecutedSample {
+        let sequence = self.sequence;
+        self.sequence = self.sequence.wrapping_add(1);
+        let sample = ExecutedSample {
+            sequence,
+            global_sample_sequence: sequence,
+            simulator_timestamp_us: sequence.wrapping_mul(10_000),
+            sensor: Some(self.sensor(sequence)),
+            actuator: Some(self.actuator(sequence)),
+            constraints: ExecutedConstraintFlags::default(),
+            hover: ExecutedHoverInitialization {
+                baseline_force_bits: BASELINE_FORCE_BITS,
+                effective_force_bits: derivation::scaled_hover_force(
+                    BASELINE_FORCE_BITS,
+                    self.declaration.hover_scale_basis_points,
+                ),
+                scale_basis_points: self.declaration.hover_scale_basis_points,
+                estimator_disabled: true,
+                kernel_config_hash: 0x0102_0304_0506_0708,
+            },
+            send: ExecutedSendEvidence {
+                attempted: true,
+                succeeded: true,
+                echoed_timestamp_us: sequence.wrapping_mul(10_000),
+                lockstep: true,
+            },
+            armed: true,
+        };
+        sample
+    }
+
+    fn sensor(&self, sequence: u64) -> ExecutedSensorApplication {
+        let presence_mask = 0b1001_u16;
+        let mut raw = [None; EXECUTED_SENSOR_LANE_COUNT];
+        #[allow(clippy::cast_precision_loss)]
+        let reading = 1.0_f32 + (sequence % 7) as f32;
+        raw[0] = Some(reading.to_bits());
+        raw[3] = Some(0x4000_0000);
+        let mut effective = raw;
+        let mut update_buckets = [None; EXECUTED_SENSOR_LANE_COUNT];
+        let mut changed_mask = 0_u16;
+        for declared in &self.declaration.sensor_lanes {
+            let lane = usize::from(declared.lane_tag);
+            let bucket = sequence / u64::from(declared.update_interval_samples);
+            update_buckets[lane] = Some(bucket);
+            let offset = derivation::sensor_offset(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                declared.lane_tag,
+                bucket,
+                f32::from_bits(declared.peak_amplitude_bits),
+            );
+            let value = f32::from_bits(raw[lane].expect("declared lane value"));
+            let applied = (value + offset).to_bits();
+            effective[lane] = Some(applied);
+            if applied != raw[lane].expect("declared lane value") {
+                changed_mask |= 1 << declared.lane_tag;
+            }
+        }
+        ExecutedSensorApplication {
+            raw_digest: derivation::sensor_sample_digest(presence_mask, &raw),
+            effective_digest: derivation::sensor_sample_digest(presence_mask, &effective),
+            presence_mask,
+            changed_mask,
+            update_buckets,
+            raw_value_bits: raw,
+            effective_value_bits: effective,
+        }
+    }
+
+    fn actuator(&mut self, sequence: u64) -> ExecutedActuatorApplication {
+        let mut requested = [0_u32; EXECUTED_ACTUATOR_LANE_COUNT];
+        #[allow(clippy::cast_precision_loss)]
+        let command = 0.1_f32 * ((sequence % 5) as f32 + 1.0);
+        for lane in requested.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane = command.to_bits();
+        }
+        let mut scaled = requested;
+        for lane in scaled.iter_mut().take(usize::from(LANE_COUNT)) {
+            *lane =
+                derivation::scaled_authority(*lane, self.declaration.authority_scale_basis_points);
+        }
+        self.command(requested, scaled, sequence)
+    }
+
+    fn command(
+        &mut self,
+        requested: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+        scaled: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+        sequence: u64,
+    ) -> ExecutedActuatorApplication {
+        let base = ExecutedActuatorApplication {
+            requested_lane_bits: requested,
+            authority_scaled_lane_bits: scaled,
+            effective_lane_bits: scaled,
+            lane_count: LANE_COUNT,
+            eligibility: ExecutedEligibility::Eligible,
+            prime: false,
+            interval_epoch: None,
+            interval_index: None,
+            interval_position: None,
+            interval_identity: None,
+            selected_hold: false,
+            applied_hold: false,
+            interval_complete: false,
+        };
+        if self.last_accepted.is_none() {
+            self.last_accepted = Some(scaled);
+            return ExecutedActuatorApplication {
+                prime: true,
+                ..base
+            };
+        }
+        self.hold(base, scaled, sequence)
+    }
+
+    fn hold(
+        &mut self,
+        base: ExecutedActuatorApplication,
+        scaled: [u32; EXECUTED_ACTUATOR_LANE_COUNT],
+        sequence: u64,
+    ) -> ExecutedActuatorApplication {
+        if self.interval_position == 0 {
+            self.interval_first_sequence = sequence;
+            self.decisions = derivation::hold_schedule(
+                self.declaration.condition_digest,
+                self.declaration.run_seed,
+                0,
+                self.interval_index,
+                sequence,
+                self.declaration.command_hold.expect("declared hold"),
+            )
+            .expect("hold schedule");
+        }
+        let position = self.interval_position;
+        let selected = self.decisions[usize::try_from(position).expect("position")];
+        let effective = if selected {
+            self.last_accepted.expect("accepted command")
+        } else {
+            self.last_accepted = Some(scaled);
+            scaled
+        };
+        let identity = derivation::interval_identity(
+            self.declaration.condition_digest,
+            self.declaration.run_seed,
+            0,
+            self.interval_index,
+            self.interval_first_sequence,
+        );
+        let complete = position.wrapping_add(1) >= HOLD_INTERVAL;
+        if complete {
+            self.interval_index = self.interval_index.wrapping_add(1);
+            self.interval_position = 0;
+        } else {
+            self.interval_position = position.wrapping_add(1);
+        }
+        ExecutedActuatorApplication {
+            effective_lane_bits: effective,
+            interval_epoch: Some(0),
+            interval_index: Some(base_index(self.interval_index, complete)),
+            interval_position: Some(position),
+            interval_identity: Some(identity),
+            selected_hold: selected,
+            applied_hold: selected,
+            interval_complete: complete,
+            ..base
+        }
+    }
+}
+
+const fn base_index(next_index: u64, complete: bool) -> u64 {
+    if complete {
+        next_index.wrapping_sub(1)
+    } else {
+        next_index
+    }
+}

--- a/tools/flight-tune/src/terminal/uncertainty/tests/support.rs
+++ b/tools/flight-tune/src/terminal/uncertainty/tests/support.rs
@@ -1,0 +1,76 @@
+//! Fixtures the executed-uncertainty tests share.
+
+use pilotage_trial::ConditionSet;
+
+use crate::Digest;
+
+/// The run seed the cross-repository contract pins.
+pub(super) const GOLDEN_RUN_SEED: u64 = 0x1112_1314_1516_1718;
+
+/// The condition the executor and this repository both pin, byte for byte.
+const GOLDEN_CONDITION: &str = concat!(
+    r#"{"schema_version":4,"id":"condition-v4-golden","revision":7,"#,
+    r#""seed":72623859790382856,"#,
+    r#""wind":{"steady":{"speed_mps":0.0,"direction_deg":0.0},"gusts":[],"#,
+    r#""turbulence":{"kind":"none"}},"#,
+    r#""timing":{"estimate_delay_ns":30000000,"#,
+    r#""update_jitter":{"kind":"sample_and_hold","maximum_delay_ns":20000000,"#,
+    r#""interval_ns":100000000}},"#,
+    r#""sensor":{"kind":"bounded_noise","lanes":["#,
+    r#"{"sensor":"accelerometer","axis":"x","peak_amplitude_mps2":0.05,"#,
+    r#""update_interval_samples":10},"#,
+    r#"{"sensor":"gyroscope","axis":"y","peak_amplitude_rad_s":0.01,"#,
+    r#""update_interval_samples":20},"#,
+    r#"{"sensor":"magnetometer","axis":"z","peak_amplitude_gauss":0.02,"#,
+    r#""update_interval_samples":30},"#,
+    r#"{"sensor":"absolute_pressure","peak_amplitude_hpa":1.0,"#,
+    r#""update_interval_samples":40},"#,
+    r#"{"sensor":"differential_pressure","peak_amplitude_hpa":0.5,"#,
+    r#""update_interval_samples":50},"#,
+    r#"{"sensor":"pressure_altitude","peak_amplitude_m":2.0,"#,
+    r#""update_interval_samples":60}]},"#,
+    r#""actuator":{"authority_scale_basis_points":12000,"#,
+    r#""command_loss":{"kind":"seeded_zero_order_hold","fraction_basis_points":100,"#,
+    r#""decision_interval_samples":100}},"#,
+    r#""controller_initialization":{"hover_thrust_force":{"kind":"scale_baseline","#,
+    r#""scale_basis_points":9000}},"#,
+    r#""plant":{"payload_mass_delta_kg":0.0,"longitudinal_cg_offset_m":0.0,"#,
+    r#""lateral_cg_offset_m":0.0,"hover_thrust_expectation":{"kind":"measured_weight_ratio"}}}"#,
+);
+
+/// Reads the pinned condition every executed-uncertainty test starts from.
+pub(super) fn golden_condition() -> ConditionSet {
+    ConditionSet::from_json(GOLDEN_CONDITION.as_bytes()).expect("golden condition")
+}
+
+/// The condition identity the cross-repository derivation goldens use.
+pub(super) fn cross_repository_digest() -> Digest {
+    let mut bytes = [0_u8; 32];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        *byte = u8::try_from(index).expect("lane index fits one byte");
+    }
+    Digest::from_bytes(bytes)
+}
+
+/// A short condition whose command hold completes inside a test stream.
+const STREAM_CONDITION: &str = concat!(
+    r#"{"schema_version":4,"id":"executed-uncertainty-stream","revision":1,"seed":11,"#,
+    r#""wind":{"steady":{"speed_mps":0.0,"direction_deg":0.0},"gusts":[],"#,
+    r#""turbulence":{"kind":"none"}},"#,
+    r#""timing":{"estimate_delay_ns":0,"update_jitter":{"kind":"none"}},"#,
+    r#""sensor":{"kind":"bounded_noise","lanes":["#,
+    r#"{"sensor":"accelerometer","axis":"x","peak_amplitude_mps2":2.0,"#,
+    r#""update_interval_samples":2}]},"#,
+    r#""actuator":{"authority_scale_basis_points":12000,"#,
+    r#""command_loss":{"kind":"seeded_zero_order_hold","fraction_basis_points":1000,"#,
+    r#""decision_interval_samples":10}},"#,
+    r#""controller_initialization":{"hover_thrust_force":{"kind":"scale_baseline","#,
+    r#""scale_basis_points":9000}},"#,
+    r#""plant":{"payload_mass_delta_kg":0.0,"longitudinal_cg_offset_m":0.0,"#,
+    r#""lateral_cg_offset_m":0.0,"hover_thrust_expectation":{"kind":"measured_weight_ratio"}}}"#,
+);
+
+/// Reads the condition the stream tests fly.
+pub(super) fn stream_condition() -> ConditionSet {
+    ConditionSet::from_json(STREAM_CONDITION.as_bytes()).expect("stream condition")
+}


### PR DESCRIPTION
## What this changes

A run intent binds a condition identity. That alone never said the controller
received the requested uncertainty: a backend could accept a condition, start,
and apply nothing, and the campaign would read the declaration as complete.

This lands the Pilotage launch-and-verify chain for that gap.

1. **One content-addressed artifact.** A non-nominal run writes the canonical
   condition document plus one closing line end. The identity of those bytes
   and the identity of the document inside them are therefore different values,
   so an argument that names one cannot pass for the other.
2. **A typed launch.** `ConditionLaunch::arguments()` renders the seven
   arguments the executor parses, by value: the artifact path, its identity,
   the condition identity, the run seed, the capability set, the trace
   endpoint, and the run-manifest path. Nothing arrives through a name the
   launch never stated.
3. **An identity gate before arming.** The launcher binds a loopback port
   before the executor starts. The executor returns its identities on that
   path; a returned identity that differs, a capability it does not supply, an
   active online hover estimator, a hover force that does not follow from its
   own baseline and scale, or a run manifest it did not hash stops the run
   before the first sample.
4. **Per-sample recomputation, then acknowledgement.** Every sample is answered
   only after the decision it states has been derived again: the lane offset,
   both sensor identities, the authority scale, the seeded hold schedule, the
   interval identity, and the hover force. An unacknowledged sample stops the
   executor, so a refusal ends the run instead of leaving one that looks
   complete.
5. **Counts folded from the stream, and an independent mirror.** The terminal
   counts exist only where the samples that made them do. `pilotage-tuning-feedback`
   restates the whole relation — its own domain strings, preimage orders,
   narrowing, and shuffle — reads no count out of the receipt, and requires the
   stated ledger to be the derived one.

## Owner comment disposition

luofang34, on #485 / Aviate#321 (independent source-to-controller provenance for
sensor lanes 0 through 11): **acknowledged, no action here.** The comment states
that the follow-up does not change the deterministic equation replay in this
issue, and it does not. This change derives the lane offsets and both sensor
identities from the declaration; where the raw value *came from* is the boundary
fact #485 adds, and nothing here forecloses it.

## The chain, and how each link is proven

| Link | Proof method |
|---|---|
| Canonical artifact bytes and their two distinct identities | Unit test: the file is the canonical document plus one line end, parses back to the stated condition identity, and the two identities differ |
| The seven launch arguments | Unit test against the executor's parser rules by value: exact flag spellings, lowercase hex, decimal seed, comma-joined capability names in ascending name order, loopback endpoint |
| Backend refuses an unsupported condition before any mutation | Unit test: a declaration with no capability refuses and the artifact file does not exist |
| The seeded derivations | Three by-value goldens taken from the executor's own cross-repository test (interval identity `94ab1093…`, two per-lane effective bit patterns), plus agreement with `pilotage-trial` on a golden condition for both the offsets and the hold schedule |
| The effective-sensor identity | Unit test that writes the 76-byte preimage by hand |
| The authority scale narrowing | Unit test on a value where the narrow-domain product differs in its last bit |
| Handshake identity gate | Real loopback TCP with an executor that speaks the wire protocol by value. Five faults refused before the first sample: changed condition identity, changed run seed, missing capability, active hover estimator, a run manifest the executor did not hash |
| Per-sample verification and the fold | Same socket, five more faults: a trace sequence gap, a value the executor did not derive, a hover force that moves mid-run, a sample naming another kernel, and stopping inside a decision interval |
| Independent mirror | 12 attack cases; each changed run is sealed again under the mirror's own identity, so a refusal is the relation failing rather than an identity that stopped covering its document |

Everything above runs headless. **No link is proven against a live X-Plane
session or a real Aviate child**; that is Aviate #320's open half.

## Owned-file mapping

The issue names paths that do not exist in this tree. What each became:

| Issue path | Landed as |
|---|---|
| `src/evidence/intent.rs` | `tools/flight-tune/src/terminal/uncertainty/launch.rs` |
| `src/driver/launch.rs` | `tools/flight-tune-aviate/src/condition/launch.rs` |
| `src/trace/protocol.rs` | `tools/flight-tune-aviate/src/condition/protocol.rs` + `condition/frame.rs` |
| `src/trace/handshake.rs` | `tools/flight-tune-aviate/src/condition/session.rs` |
| `src/manifest.rs` | Not created. The manifest is the executor's output; it is read, hashed, and bound in `condition/session.rs` |
| `src/process.rs` | Unchanged. The argument vector is caller-supplied through `SupervisedProcessRequest.target_arguments`, which `ConditionLaunch::arguments()` produces |
| campaign publication, recovery, terminal receipt, qualification | Only the Aviate run seal. See the remainder |

## Identity resets

| Identity | Before | After | Who is affected |
|---|---|---|---|
| `RUN_SEAL_SCHEMA_VERSION` and its domain | `1`, `pilotage-aviate-run-seal-v1\0` | `2`, `pilotage-aviate-run-seal-v2\0` | Every Aviate run seal, nominal ones included. No golden pinned a seal identity, and the seal is produced per run rather than stored across runs |
| Executor run seed | Not derived | `H("…executed-uncertainty-run-seed.v1\0" ‖ run_intent_digest)[0..8]` | New value. Stated as a decision below |
| `flight_tune` public surface | — | `contract_api` also re-exports `CodecError`, `ValidationError`, and the `derivation` module | Additive |
| `pilotage-trial` public surface | — | `SensorNoiseLane::reference_values` | Additive. No schema shape changed |

## Decisions and deviations

- **The run seed is derived from the run intent, not taken from the run
  context.** `RunExecutionContext` gives two executions of one experimental
  condition the same seed and separates them only by retry index. The issue
  requires a retry to draw a stream its quarantined source never drew, so the
  executor seed is a domain hash of the run intent identity, which covers the
  retry index. A repeated read of one run intent gives one seed. If the intent
  was that the executor reuse `context.seed`, this is the line to change.
- **The send echo is not checked against the sample time.** The executor's
  echoed time is the last sensor time the MAVLink link received, or the link
  clock when it has received none. The board's own `feed_sensor_packet` path
  never sets that value, so it is not the sample time and the launcher never
  observes the clock it comes from. Requiring equality would refuse every real
  run. The check now states what the executor does guarantee: one attempted
  send, one completed send, and the lockstep flag, which the executor sets
  unconditionally on a successful send. The kernel identity and the run
  manifest were bound in its place.
- **`AviateVehicleActionPort` still declares no uncertainty capability.** The
  production path is therefore fail-closed: it refuses every non-nominal
  condition at admission today. Declaring the capabilities before the spawn
  wiring exists would be exactly the false completeness this issue is about, so
  the declaration lands with that wiring.
- **`pilotage-trial` was touched additively only.** Schema 4 and mission 3 keep
  their shapes.
- **The first four commits carry a `Claude Fable 5` trailer and the last carries
  `Claude Fable 5.1`**, because the attribution guidance changed part way
  through and applies forward.
- **No contracts-script pin covers launch, handshake, evidence, receipt, trace,
  uncertainty, capability, or quarantine.** I checked the whole file before
  writing: the pins whose subject is `launch` or `receipt` all name
  `tools/flight-tune-campaign/src/deployment*` files that do not exist in this
  tree, so no pre-pin constrained these surfaces and none was added.

## Open remainder

- **Qualification coverage does not yet read this evidence.** The receipt
  reaches `AviateRunSeal` and stops there. `flight-tune-aviate` implements no
  `RunTerminalAdapter`, so the seal does not reach
  `RunTerminalReceipt.causal_evidence_digest`, the campaign evidence graph, or
  `verify_all`. `verify_executed_uncertainty` is a public entry point nothing in
  the graph walks yet.
- **Nothing calls the launcher in production.** `ConditionLaunch`,
  `ConditionTracePath`, and `bind_executed_uncertainty` are proven building
  blocks; the supervisor's argument vector is not yet fed from `arguments()`.
- **Live X-Plane execution is out of reach here** — Aviate #320 keeps the
  0.9 / 1.0 / 1.1 mass and centre-of-gravity comparison.
- **`plant` is not executed by the executor**, so "plant mass and centre of
  gravity stay nominal for the isolated hover cases" is not checkable on this
  path.
- **Retry is proven as a seed property, not through a campaign.** Distinct run
  intents give distinct seeds; no real quarantine-and-replace run exercises it.
- **"Cleanup reports an active perturbation"** is covered only as a stream that
  ends inside a decision interval, not as a cleanup step.

## Gates

Run in `/private/tmp/pilotage-484` at `e14bdf42`.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace --all-targets` | 1 failure, see below |
| `cargo doc` with `-D missing_docs -D rustdoc::broken_intra_doc_links` | pass |
| `cargo build --release` | pass, 1 m 13 s |
| `scripts/check-structure.sh` | OK |
| `scripts/check-flight-tune-contracts.py` | OK |
| `scripts/check-flight-tune-boundaries.sh` | OK |
| `scripts/check-feedback-verifier-boundary.py` | OK |
| `scripts/check-monotonic-counter-arithmetic.sh` | OK |
| `cargo run -p xtask -- guards` | 20 pairs ok |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | pass, see certification |

### Certification

Both vehicles still seal `Qualified`.

```
test bench::tests::a_campaign_runs_end_to_end_for_the_x500 ... ok
test bench::tests::a_campaign_runs_end_to_end_for_the_alia250 ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 40 filtered out; finished in 2329.08s
```

**Wall time: 38 m 50 s** (2329.08 s inside the harness, at `--test-threads 2`).

The certification ran at `bc31903a`, one commit before the branch head. It is
not re-run at `e14bdf42` because that commit cannot reach the bench campaign,
and this is checkable rather than assumed: `e14bdf42` touches eight files, all
under `tools/flight-tune/src/terminal/uncertainty/`,
`crates/pilotage-tuning-feedback/src/uncertainty/`, and
`tools/flight-tune-aviate/src/condition/`. `flight-tune-campaign` depends on
neither `pilotage-tuning-feedback` nor `flight-tune-aviate`, and grepping its
sources for `Executed`, `ConditionLaunch`, and `derivation::` returns only its
own `UncertaintyFactor` scenario-matrix enum, which is unrelated to any type
here.

**The one workspace-test failure**, reported as observed rather than dismissed:
`flight-tune-campaign` `bench::tests::a_campaign_smokes_the_whole_chain` failed
on a `MissionWall` deadline — `deadline_ns: 280028372375, observed_ns:
280099938250`, over by 71.6 ms on a 280-second budget — during a fully parallel
575-second workspace run. Re-run alone it passes in 758 s. The mission engine's
wall deadline is real time, and nothing in this change is reachable from the
bench campaign, so this is machine load rather than a regression.

Refs #484. The launch surface, the identity gate, the per-sample recomputation,
the folded counts, and the independent mirror are all headless and green. The
receipt reaches the Aviate run seal and stops there, nothing in production calls
the launcher yet, and the live X-Plane half stays with luofang34/Aviate#320, so
the issue is not closed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
