### PR TITLE
feat(flight-tune): make the open of a session and a binding transactional (#528)

### DIFF
--- a/tools/flight-tune-aviate/src/lib.rs
+++ b/tools/flight-tune-aviate/src/lib.rs
@@ -56,8 +56,8 @@ pub use transition_authorization::{
     TransitionValidator, validator_identity,
 };
 pub use vehicle::{
-    AviateFeelController, AviateVehicleAdapter, AviateVehicleFactory, CandidateFeelMapping,
-    VEHICLE_ID, bind_run_intent, require_run_intent, vehicle_identity,
+    AviateFeelController, AviateVehicleAdapter, AviateVehicleBindingRollback, AviateVehicleFactory,
+    CandidateFeelMapping, VEHICLE_ID, bind_run_intent, require_run_intent, vehicle_identity,
 };
 
 /// Runs the process-supervisor helper protocol.

--- a/tools/flight-tune-aviate/src/vehicle.rs
+++ b/tools/flight-tune-aviate/src/vehicle.rs
@@ -17,7 +17,8 @@ use flight_tune::{
     AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, CandidateTransitionReceipt,
     CandidateTransitionRequest, Digest, RunExecutionContext, SimulatorCapability,
     SimulatorVehicleAdapter, SimulatorVehicleFactory, TransitionBindingReceipt, TuneError,
-    VehicleBinding, VehicleBindingReceipt, scenario_runtime_identity,
+    VehicleBinding, VehicleBindingAcquisition, VehicleBindingReceipt, VehicleBindingRollback,
+    scenario_runtime_identity,
 };
 use pilotage_control_feel::{FeelDigest, ValidatedFlightFeelProfile};
 use sha2::{Digest as _, Sha256};
@@ -269,13 +270,64 @@ impl<M: CandidateFeelMapping, C: AviateFeelController> AviateVehicleFactory<M, C
     }
 }
 
+/// Releases or contains one exact Aviate vehicle binding.
+///
+/// The Aviate bind maps identities and moves values: it computes the
+/// action-port digest, mints the transition receipt, and hands the
+/// controller to an adapter. None of those reach the controller, which is
+/// written only by candidate activation, and activation needs the binding
+/// the failed open never handed over. So a bind that fails at any step
+/// leaves nothing outside the value it did not return.
+///
+/// Release states that fact for one exact acquisition. It refuses an
+/// acquisition that names another vehicle or another action port, because
+/// a binding this factory did not create is not this factory's to release.
+#[derive(Debug, Clone)]
+pub struct AviateVehicleBindingRollback {
+    vehicle_digest: Digest,
+    scenario_runtime_digest: Digest,
+}
+
+impl VehicleBindingRollback for AviateVehicleBindingRollback {
+    fn release_binding_blocking(
+        &mut self,
+        acquisition: &VehicleBindingAcquisition,
+    ) -> Result<(), AdapterError> {
+        if acquisition.session_digest().is_zero() {
+            return Err(AdapterError::new(
+                "the vehicle acquisition names no tuning session",
+            ));
+        }
+        if acquisition.vehicle_digest() != self.vehicle_digest
+            || acquisition.scenario_runtime_digest() != self.scenario_runtime_digest
+        {
+            return Err(AdapterError::new(
+                "the vehicle acquisition names another Aviate vehicle binding",
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl<M: CandidateFeelMapping, C: AviateFeelController> SimulatorVehicleFactory
     for AviateVehicleFactory<M, C>
 {
     type Adapter = AviateVehicleAdapter<M, C>;
+    type Rollback = AviateVehicleBindingRollback;
 
     fn vehicle_identity(&self) -> &ArtifactIdentity {
         &self.vehicle
+    }
+
+    fn rollback_handle(&self) -> Self::Rollback {
+        AviateVehicleBindingRollback {
+            vehicle_digest: self.vehicle.digest,
+            // A factory whose action port has no valid identity cannot bind
+            // at all, so an acquisition can never match this zero digest.
+            scenario_runtime_digest: self
+                .scenario_runtime_digest()
+                .unwrap_or_else(|_| Digest::from_bytes([0; 32])),
+        }
     }
 
     fn scenario_action_port_identity(&self) -> &ArtifactIdentity {

--- a/tools/flight-tune-aviate/tests/open_rollback.rs
+++ b/tools/flight-tune-aviate/tests/open_rollback.rs
@@ -1,0 +1,103 @@
+//! The production Aviate factory keeps the open-rollback contract.
+//!
+//! The suite is the simulator-neutral one the harness states, run here
+//! against the real Aviate factory rather than against a reference one.
+//!
+//! SIM / NOT FOR FLIGHT.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+// The rig is shared with the binding tests, which use more of it.
+#[allow(dead_code)]
+#[path = "production_binding/rig.rs"]
+mod rig;
+
+use flight_tune::conformance::check_vehicle_binding_rollback;
+use flight_tune::{
+    Digest, SimulatorVehicleFactory, VehicleBindingAcquisition, VehicleBindingRollback,
+};
+use flight_tune_aviate::AviateVehicleFactory;
+
+use rig::{runtime_identity, validator};
+
+const SESSION: Digest = Digest::from_bytes([0x53; 32]);
+
+fn factory() -> AviateVehicleFactory<rig::TestMapping, rig::TestController> {
+    AviateVehicleFactory::new(
+        rig::TestMapping::new(),
+        rig::TestController(rig::ControllerHandle::new()),
+        validator(),
+        runtime_identity("open-rollback").identity().clone(),
+    )
+    .expect("a complete factory")
+}
+
+fn owned_acquisition(
+    factory: &AviateVehicleFactory<rig::TestMapping, rig::TestController>,
+) -> VehicleBindingAcquisition {
+    VehicleBindingAcquisition::new(
+        SESSION,
+        factory.vehicle_identity().digest,
+        factory
+            .scenario_runtime_digest()
+            .expect("the action port identity"),
+    )
+}
+
+#[test]
+fn the_production_factory_passes_the_open_rollback_suite() {
+    let factory = factory();
+    let owned = owned_acquisition(&factory);
+    let foreign = VehicleBindingAcquisition::new(
+        SESSION,
+        Digest::from_bytes([0x11; 32]),
+        Digest::from_bytes([0x13; 32]),
+    );
+    let mut rollback = factory.rollback_handle();
+
+    check_vehicle_binding_rollback(&mut rollback, &owned, &foreign)
+        .expect("the Aviate factory keeps the open rollback contract");
+}
+
+#[test]
+fn a_release_refuses_an_acquisition_with_another_action_port() {
+    let factory = factory();
+    let owned = owned_acquisition(&factory);
+    let mut rollback = factory.rollback_handle();
+    let other_port = VehicleBindingAcquisition::new(
+        SESSION,
+        owned.vehicle_digest(),
+        Digest::from_bytes([0x17; 32]),
+    );
+
+    assert!(rollback.release_binding_blocking(&other_port).is_err());
+    assert!(rollback.release_binding_blocking(&owned).is_ok());
+}
+
+#[test]
+fn a_release_refuses_an_acquisition_with_no_tuning_session() {
+    let factory = factory();
+    let owned = owned_acquisition(&factory);
+    let mut rollback = factory.rollback_handle();
+    let no_session = VehicleBindingAcquisition::new(
+        Digest::from_bytes([0; 32]),
+        owned.vehicle_digest(),
+        owned.scenario_runtime_digest(),
+    );
+
+    assert!(rollback.release_binding_blocking(&no_session).is_err());
+}
+
+#[test]
+fn a_rollback_handle_survives_the_bind_that_consumes_its_factory() {
+    let factory = factory();
+    let owned = owned_acquisition(&factory);
+    let mut rollback = factory.rollback_handle();
+
+    // The bind takes the factory. The handle taken before it still names
+    // the exact binding that bind could have created.
+    let binding = factory.bind_blocking(&rig::capability(0x53));
+
+    assert!(binding.is_ok());
+    assert!(rollback.release_binding_blocking(&owned).is_ok());
+}

--- a/tools/flight-tune-campaign/Cargo.toml
+++ b/tools/flight-tune-campaign/Cargo.toml
@@ -17,5 +17,8 @@ pilotage-tuning-feedback = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+# The bench open-rollback tests drive a session lifecycle directly, which
+# needs the harness-minted challenge that `test-support` exposes.
+flight-tune = { workspace = true, features = ["test-support"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/flight-tune-campaign/src/bench.rs
+++ b/tools/flight-tune-campaign/src/bench.rs
@@ -29,14 +29,14 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use flight_tune::{
-    AdapterError, ArtifactIdentity, CampaignBackend, Candidate, Digest, KinematicTruth,
-    MissionCapability, MissionDirective, MissionDocument, MissionReference, ReceiptResult,
-    RunExecutionContext, RunPreparationReceipt, SampleEvent, ScenarioFrame,
-    ScenarioObservationReceipt, ScenarioRuntime, ScenarioRuntimeError, ScenarioStartReceipt,
-    ScenarioStopContext, SessionChallenge, SimulatorCapability, SimulatorSessionReceipt,
-    TelemetrySample, scenario_runtime_identity,
+    AdapterError, ArtifactIdentity, CampaignBackend, Digest, KinematicTruth, MissionCapability,
+    MissionDirective, MissionDocument, MissionReference, ReceiptResult, RunExecutionContext,
+    RunPreparationReceipt, SampleEvent, ScenarioFrame, ScenarioObservationReceipt, ScenarioRuntime,
+    ScenarioRuntimeError, ScenarioStartReceipt, ScenarioStopContext, SessionChallenge,
+    SimulatorCapability, SimulatorSessionAcquisition, SimulatorSessionReceipt, TelemetrySample,
+    scenario_runtime_identity,
 };
-use pilotage_control_feel::{AxisCurve, AxisDemandShaper, AxisDynamics, AxisResponse, NeutralBand};
+use pilotage_control_feel::{AxisDemandShaper, AxisResponse};
 
 use crate::scoring::channel;
 
@@ -125,59 +125,6 @@ struct Settled {
 #[derive(Debug, Clone, Default)]
 pub struct BenchHandle(Rc<RefCell<Settled>>);
 
-/// Reads one candidate's parameters as an axis response.
-///
-/// # Errors
-///
-/// Returns [`AdapterError`] when a parameter is absent or not finite.
-fn response_from(candidate: &Candidate) -> Result<AxisResponse, AdapterError> {
-    let read = |name: &str| -> Result<f64, AdapterError> {
-        candidate
-            .parameters()
-            .get(name)
-            .copied()
-            .filter(|value| value.is_finite())
-            .ok_or_else(|| AdapterError::new(format!("the candidate states no {name}")))
-    };
-    let apply_accel = read(parameter::APPLY_ACCEL)?;
-    let apply_jerk = read(parameter::APPLY_JERK)?;
-    let release_factor = read(parameter::RELEASE_FACTOR)?;
-    let enter = read(parameter::NEUTRAL_ENTER)?;
-    let center_expo = read(parameter::CENTER_EXPO)? as f32;
-    Ok(AxisResponse {
-        curve: AxisCurve {
-            deadzone: read(parameter::DEADZONE)? as f32,
-            center_expo,
-            // The profile validator refuses an outer expo above the
-            // center one; folding the search there keeps every sealed
-            // winner a law a real profile will load. The outer blend
-            // begins where the shipped law's does, so the trial's firm
-            // input exercises it.
-            outer_expo: (read(parameter::OUTER_EXPO)? as f32).min(center_expo),
-            outer_start: 0.7,
-        },
-        neutral: NeutralBand {
-            active_enter: enter as f32,
-            // Leaving is harder than staying, or an input on the edge chatters.
-            // The search sets the entry and the exit follows it, so no
-            // candidate can propose a band with no hysteresis in it.
-            active_exit: (enter * 0.65) as f32,
-            dwell_ms: read(parameter::NEUTRAL_DWELL_MS)?.max(0.0) as u32,
-        },
-        dynamics: AxisDynamics {
-            apply_accel: apply_accel as f32,
-            apply_jerk: apply_jerk as f32,
-            // Letting go is never slower than asking, whatever the search
-            // proposes: a release that lagged the apply would take longer to
-            // stop commanding than to start.
-            release_accel: (apply_accel * release_factor.max(1.0)) as f32,
-            release_jerk: (apply_jerk * release_factor.max(1.0)) as f32,
-            reversal_accel: apply_accel as f32,
-            reversal_jerk: apply_jerk as f32,
-        },
-    })
-}
-
 /// The simulator half: it flies the trial and reports the channels.
 #[derive(Debug)]
 pub struct BenchBackend {
@@ -186,6 +133,7 @@ pub struct BenchBackend {
     simulator: ArtifactIdentity,
     airframe: ArtifactIdentity,
     scenario_runtime: ArtifactIdentity,
+    session: Option<Digest>,
     run: Option<Run>,
 }
 
@@ -222,6 +170,7 @@ impl BenchBackend {
             airframe: build(airframe_id, airframe_digest)?,
             scenario_runtime: scenario_runtime_identity(&bench_action_port_identity()?)
                 .map_err(to_adapter)?,
+            session: None,
             run: None,
         })
     }
@@ -296,11 +245,39 @@ impl CampaignBackend for BenchBackend {
         &mut self,
         challenge: &SessionChallenge,
     ) -> Result<SimulatorSessionReceipt, AdapterError> {
+        self.session = Some(challenge.session_digest());
         Ok(SimulatorSessionReceipt {
             session_digest: challenge.session_digest(),
             simulator_digest: self.simulator.digest,
             airframe_digest: self.airframe.digest,
         })
+    }
+
+    fn close_session_blocking(
+        &mut self,
+        acquisition: &SimulatorSessionAcquisition,
+    ) -> Result<(), AdapterError> {
+        if acquisition.simulator_digest() != self.simulator.digest
+            || acquisition.airframe_digest() != self.airframe.digest
+        {
+            return Err(AdapterError::new(
+                "the acquisition names another bench simulator or airframe",
+            ));
+        }
+        if self
+            .session
+            .is_some_and(|digest| digest != acquisition.session_digest())
+        {
+            return Err(AdapterError::new(
+                "the acquisition names another bench tuning session",
+            ));
+        }
+        // The bench plant is one process and one struct. Dropping the
+        // session and the run is the whole of its cleanup, and repeating
+        // it on a backend that holds neither is the same success.
+        self.session = None;
+        self.run = None;
+        Ok(())
     }
 
     fn prepare_blocking(
@@ -488,13 +465,16 @@ pub(super) fn to_adapter(error: flight_tune::TuneError) -> AdapterError {
 
 mod adapter;
 mod qualifying;
+mod response;
 
 pub use adapter::BenchVehicleAdapter;
+
 pub use qualifying::{
-    BENCH_FINAL_TRIAL_ID, BENCH_PROMOTION_TRIAL_ID, BenchGates, BenchVehicleFactory,
-    bench_mission_revision_id, bench_physical_target, bench_response_targets, bench_scenario,
-    bench_stage, bench_stored_mission, warm_start_parameters,
+    BENCH_FINAL_TRIAL_ID, BENCH_PROMOTION_TRIAL_ID, BenchGates, BenchVehicleBindingRollback,
+    BenchVehicleFactory, bench_mission_revision_id, bench_physical_target, bench_response_targets,
+    bench_scenario, bench_stage, bench_stored_mission, warm_start_parameters,
 };
+use response::response_from;
 
 #[cfg(test)]
 mod tests;

--- a/tools/flight-tune-campaign/src/bench/qualifying.rs
+++ b/tools/flight-tune-campaign/src/bench/qualifying.rs
@@ -7,7 +7,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use flight_tune::{
     AdapterError, ArtifactIdentity, Digest, EvaluatorError, GateEvaluator, GateOutcome,
     MissionReference, SimulatorCapability, SimulatorVehicleFactory, TelemetrySample,
-    TransitionBindingReceipt, VehicleBinding, VehicleBindingReceipt,
+    TransitionBindingReceipt, VehicleBinding, VehicleBindingAcquisition, VehicleBindingReceipt,
+    VehicleBindingRollback,
 };
 
 use super::parameter;
@@ -56,11 +57,61 @@ impl BenchVehicleFactory {
     }
 }
 
+/// Releases or contains one exact bench vehicle binding.
+///
+/// The bench vehicle is one settled command law over shared state.
+/// Releasing the binding drops that law, so an open that failed after the
+/// bind leaves no candidate active for the next open to inherit.
+#[derive(Debug)]
+pub struct BenchVehicleBindingRollback {
+    handle: BenchHandle,
+    vehicle_digest: Digest,
+    scenario_runtime_digest: Digest,
+}
+
+impl VehicleBindingRollback for BenchVehicleBindingRollback {
+    fn release_binding_blocking(
+        &mut self,
+        acquisition: &VehicleBindingAcquisition,
+    ) -> Result<(), AdapterError> {
+        if acquisition.session_digest().is_zero() {
+            return Err(AdapterError::new(
+                "the vehicle acquisition names no tuning session",
+            ));
+        }
+        if acquisition.vehicle_digest() != self.vehicle_digest
+            || acquisition.scenario_runtime_digest() != self.scenario_runtime_digest
+        {
+            return Err(AdapterError::new(
+                "the vehicle acquisition names another bench vehicle binding",
+            ));
+        }
+        let mut settled = self.handle.0.borrow_mut();
+        settled.response = None;
+        settled.digest = None;
+        Ok(())
+    }
+}
+
 impl SimulatorVehicleFactory for BenchVehicleFactory {
     type Adapter = BenchVehicleAdapter;
+    type Rollback = BenchVehicleBindingRollback;
 
     fn vehicle_identity(&self) -> &ArtifactIdentity {
         &self.identity
+    }
+
+    fn rollback_handle(&self) -> Self::Rollback {
+        BenchVehicleBindingRollback {
+            handle: self.handle.clone(),
+            vehicle_digest: self.identity.digest,
+            // A factory whose action port has no valid identity cannot
+            // bind, so no acquisition can match this zero digest.
+            scenario_runtime_digest: flight_tune::scenario_runtime_identity(
+                &self.action_port_identity,
+            )
+            .map_or_else(|_| Digest::from_bytes([0; 32]), |identity| identity.digest),
+        }
     }
 
     fn scenario_action_port_identity(&self) -> &ArtifactIdentity {

--- a/tools/flight-tune-campaign/src/bench/response.rs
+++ b/tools/flight-tune-campaign/src/bench/response.rs
@@ -1,0 +1,59 @@
+//! The candidate-to-command-law mapping the bench vehicle flies.
+
+use flight_tune::{AdapterError, Candidate};
+use pilotage_control_feel::{AxisCurve, AxisDynamics, AxisResponse, NeutralBand};
+
+use super::parameter;
+
+/// Reads one candidate's parameters as an axis response.
+///
+/// # Errors
+///
+/// Returns [`AdapterError`] when a parameter is absent or not finite.
+pub(super) fn response_from(candidate: &Candidate) -> Result<AxisResponse, AdapterError> {
+    let read = |name: &str| -> Result<f64, AdapterError> {
+        candidate
+            .parameters()
+            .get(name)
+            .copied()
+            .filter(|value| value.is_finite())
+            .ok_or_else(|| AdapterError::new(format!("the candidate states no {name}")))
+    };
+    let apply_accel = read(parameter::APPLY_ACCEL)?;
+    let apply_jerk = read(parameter::APPLY_JERK)?;
+    let release_factor = read(parameter::RELEASE_FACTOR)?;
+    let enter = read(parameter::NEUTRAL_ENTER)?;
+    let center_expo = read(parameter::CENTER_EXPO)? as f32;
+    Ok(AxisResponse {
+        curve: AxisCurve {
+            deadzone: read(parameter::DEADZONE)? as f32,
+            center_expo,
+            // The profile validator refuses an outer expo above the
+            // center one; folding the search there keeps every sealed
+            // winner a law a real profile will load. The outer blend
+            // begins where the shipped law's does, so the trial's firm
+            // input exercises it.
+            outer_expo: (read(parameter::OUTER_EXPO)? as f32).min(center_expo),
+            outer_start: 0.7,
+        },
+        neutral: NeutralBand {
+            active_enter: enter as f32,
+            // Leaving is harder than staying, or an input on the edge chatters.
+            // The search sets the entry and the exit follows it, so no
+            // candidate can propose a band with no hysteresis in it.
+            active_exit: (enter * 0.65) as f32,
+            dwell_ms: read(parameter::NEUTRAL_DWELL_MS)?.max(0.0) as u32,
+        },
+        dynamics: AxisDynamics {
+            apply_accel: apply_accel as f32,
+            apply_jerk: apply_jerk as f32,
+            // Letting go is never slower than asking, whatever the search
+            // proposes: a release that lagged the apply would take longer to
+            // stop commanding than to start.
+            release_accel: (apply_accel * release_factor.max(1.0)) as f32,
+            release_jerk: (apply_jerk * release_factor.max(1.0)) as f32,
+            reversal_accel: apply_accel as f32,
+            reversal_jerk: apply_jerk as f32,
+        },
+    })
+}

--- a/tools/flight-tune-campaign/src/bench/tests.rs
+++ b/tools/flight-tune-campaign/src/bench/tests.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
+mod open_rollback;
+
 use std::path::PathBuf;
 
-use flight_tune::{BoundedCoordinateSearch, CandidateLineage, FinalQualificationOutcome, Tuner};
+use flight_tune::{
+    BoundedCoordinateSearch, Candidate, CandidateLineage, FinalQualificationOutcome, Tuner,
+};
 use pilotage_control_feel::FeelMode;
 
 use super::*;

--- a/tools/flight-tune-campaign/src/bench/tests/open_rollback.rs
+++ b/tools/flight-tune-campaign/src/bench/tests/open_rollback.rs
@@ -1,0 +1,125 @@
+//! The bench adapters keep the simulator-neutral open-rollback contract.
+//!
+//! This is the second implementation the suite runs against: the bench
+//! backend and the bench vehicle factory are not the harness reference
+//! adapters, and the contract does not change for them.
+
+use flight_tune::conformance::check_open_rollback;
+use flight_tune::{
+    CampaignBackend, Digest, SessionChallenge, SimulatorSessionAcquisition,
+    SimulatorVehicleFactory, VehicleBindingAcquisition, VehicleBindingRollback,
+};
+
+use super::super::{BenchBackend, BenchHandle, BenchVehicle, BenchVehicleFactory};
+
+const SESSION: Digest = Digest::from_bytes([0x2b; 32]);
+
+fn backend(handle: BenchHandle) -> BenchBackend {
+    BenchBackend::new(
+        handle,
+        BenchVehicle::alia250(),
+        "bench-airframe",
+        Digest::from_bytes([0x3d; 32]),
+    )
+    .expect("a complete bench backend")
+}
+
+fn owned_session(backend: &BenchBackend) -> SimulatorSessionAcquisition {
+    SimulatorSessionAcquisition::new(
+        SESSION,
+        backend.simulator_identity().digest,
+        backend.airframe_identity().digest,
+    )
+}
+
+fn owned_binding(factory: &BenchVehicleFactory) -> VehicleBindingAcquisition {
+    VehicleBindingAcquisition::new(
+        SESSION,
+        factory.vehicle_identity().digest,
+        flight_tune::scenario_runtime_identity(factory.scenario_action_port_identity())
+            .expect("the bench action port identity")
+            .digest,
+    )
+}
+
+fn foreign_session() -> SimulatorSessionAcquisition {
+    SimulatorSessionAcquisition::new(
+        SESSION,
+        Digest::from_bytes([0x51; 32]),
+        Digest::from_bytes([0x59; 32]),
+    )
+}
+
+fn foreign_binding() -> VehicleBindingAcquisition {
+    VehicleBindingAcquisition::new(
+        SESSION,
+        Digest::from_bytes([0x61; 32]),
+        Digest::from_bytes([0x67; 32]),
+    )
+}
+
+#[test]
+fn the_bench_adapters_pass_the_open_rollback_suite() {
+    let handle = BenchHandle::default();
+    let mut backend = backend(handle.clone());
+    let factory = BenchVehicleFactory::new(handle, "bench-vehicle").expect("a complete factory");
+    let session = owned_session(&backend);
+    let binding = owned_binding(&factory);
+    let mut rollback = factory.rollback_handle();
+
+    check_open_rollback(
+        &mut backend,
+        &mut rollback,
+        &session,
+        &foreign_session(),
+        &binding,
+        &foreign_binding(),
+    )
+    .expect("the bench adapters keep the open rollback contract");
+}
+
+#[test]
+fn a_session_close_ends_the_open_bench_session() {
+    let handle = BenchHandle::default();
+    let mut backend = backend(handle);
+    let acquisition = owned_session(&backend);
+    backend
+        .open_session_blocking(&SessionChallenge::for_test(SESSION))
+        .expect("open a bench session");
+
+    backend
+        .close_session_blocking(&acquisition)
+        .expect("close the bench session");
+
+    backend
+        .close_session_blocking(&acquisition)
+        .expect("a repeated close is the same success");
+}
+
+#[test]
+fn a_session_close_refuses_a_foreign_tuning_session() {
+    let handle = BenchHandle::default();
+    let mut backend = backend(handle);
+    let acquisition = owned_session(&backend);
+    backend
+        .open_session_blocking(&SessionChallenge::for_test(Digest::from_bytes([0x71; 32])))
+        .expect("open a bench session");
+
+    assert!(backend.close_session_blocking(&acquisition).is_err());
+}
+
+#[test]
+fn a_binding_release_drops_the_settled_command_law() {
+    let handle = BenchHandle::default();
+    let factory = BenchVehicleFactory::new(handle.clone(), "bench-vehicle").expect("a factory");
+    let acquisition = owned_binding(&factory);
+    let mut rollback = factory.rollback_handle();
+    handle.0.borrow_mut().digest = Some(Digest::from_bytes([0x79; 32]));
+
+    rollback
+        .release_binding_blocking(&acquisition)
+        .expect("release the binding");
+
+    assert!(handle.0.borrow().digest.is_none());
+    assert!(handle.0.borrow().response.is_none());
+}

--- a/tools/flight-tune-campaign/src/lib.rs
+++ b/tools/flight-tune-campaign/src/lib.rs
@@ -13,9 +13,9 @@ mod vehicle_policy;
 
 pub use bench::{
     BENCH_FINAL_TRIAL_ID, BENCH_PROMOTION_TRIAL_ID, BenchBackend, BenchGates, BenchHandle,
-    BenchVehicle, BenchVehicleAdapter, BenchVehicleFactory, bench_mission_revision_id,
-    bench_physical_target, bench_response_targets, bench_scenario, bench_stage, parameter,
-    warm_start_parameters,
+    BenchVehicle, BenchVehicleAdapter, BenchVehicleBindingRollback, BenchVehicleFactory,
+    bench_mission_revision_id, bench_physical_target, bench_response_targets, bench_scenario,
+    bench_stage, parameter, warm_start_parameters,
 };
 pub use error::CampaignError;
 pub use publish::publish_journal_evidence_blocking;

--- a/tools/flight-tune/src/adapter.rs
+++ b/tools/flight-tune/src/adapter.rs
@@ -5,13 +5,19 @@ use pilotage_trial::Digest;
 
 use crate::ArtifactIdentity;
 
+pub mod conformance;
+
 mod lifecycle;
+mod rollback;
 mod terminal;
 mod transition;
 
 pub use lifecycle::{
     CampaignBackend, CandidateReceipt, RunPreparationReceipt, SampleEvent, ScenarioStartReceipt,
     SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample,
+};
+pub use rollback::{
+    SimulatorSessionAcquisition, VehicleBindingAcquisition, VehicleBindingRollback,
 };
 pub use terminal::{RunTerminalAdapter, RunTerminalCapabilities};
 pub(crate) use transition::planning_context_digest;
@@ -75,6 +81,18 @@ pub struct SessionChallenge {
 }
 
 impl SessionChallenge {
+    /// Mints a session challenge for a downstream test.
+    ///
+    /// The harness mints the real one from the journal session identity. A
+    /// crate that has to drive a backend's session lifecycle in isolation
+    /// enables the `test-support` feature; a release build does not
+    /// compile this function at all.
+    #[cfg(feature = "test-support")]
+    #[must_use]
+    pub const fn for_test(session_digest: Digest) -> Self {
+        Self::new(session_digest)
+    }
+
     pub(crate) const fn new(session_digest: Digest) -> Self {
         Self { session_digest }
     }

--- a/tools/flight-tune/src/adapter/conformance.rs
+++ b/tools/flight-tune/src/adapter/conformance.rs
@@ -1,0 +1,149 @@
+//! The simulator-neutral open-rollback conformance suite.
+//!
+//! Every backend and every vehicle factory answers for the resources it
+//! creates during one open attempt. The rules are the same whichever
+//! simulator is behind them, so the checks live here once and each
+//! implementation runs them against its own adapters.
+
+use std::fmt;
+
+use super::{
+    CampaignBackend, SimulatorSessionAcquisition, VehicleBindingAcquisition, VehicleBindingRollback,
+};
+
+/// One conformance rule that an adapter did not keep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceFailure {
+    rule: &'static str,
+    detail: String,
+}
+
+impl ConformanceFailure {
+    /// Returns the stable name of the rule the adapter did not keep.
+    #[must_use]
+    pub const fn rule(&self) -> &'static str {
+        self.rule
+    }
+
+    /// Returns what the adapter did instead.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    fn new(rule: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            rule,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for ConformanceFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.rule, self.detail)
+    }
+}
+
+impl std::error::Error for ConformanceFailure {}
+
+/// Checks one simulator-session rollback against the open contract.
+///
+/// `owned` names a session this backend answers for. `foreign` names one
+/// it does not. The backend must hold no session for `owned` when the
+/// checks finish.
+///
+/// # Errors
+///
+/// Returns [`ConformanceFailure`] when the rollback is not idempotent, or
+/// when it accepts an acquisition it does not own.
+pub fn check_simulator_session_rollback<B: CampaignBackend>(
+    backend: &mut B,
+    owned: &SimulatorSessionAcquisition,
+    foreign: &SimulatorSessionAcquisition,
+) -> Result<(), ConformanceFailure> {
+    if owned == foreign {
+        return Err(ConformanceFailure::new(
+            "session rollback fixture",
+            "the owned and foreign acquisitions are the same",
+        ));
+    }
+    backend.close_session_blocking(owned).map_err(|source| {
+        ConformanceFailure::new(
+            "session rollback proves absence",
+            format!("the first close refused an owned acquisition: {source}"),
+        )
+    })?;
+    backend.close_session_blocking(owned).map_err(|source| {
+        ConformanceFailure::new(
+            "session rollback is idempotent",
+            format!("a repeated close changed the result: {source}"),
+        )
+    })?;
+    if backend.close_session_blocking(foreign).is_ok() {
+        return Err(ConformanceFailure::new(
+            "session rollback refuses a foreign acquisition",
+            "the close accepted an acquisition the backend does not own",
+        ));
+    }
+    Ok(())
+}
+
+/// Checks one vehicle-binding rollback against the open contract.
+///
+/// `owned` names a binding this handle answers for. `foreign` names one it
+/// does not. The handle must hold no binding for `owned` when the checks
+/// finish.
+///
+/// # Errors
+///
+/// Returns [`ConformanceFailure`] when the rollback is not idempotent, or
+/// when it accepts an acquisition it does not own.
+pub fn check_vehicle_binding_rollback<R: VehicleBindingRollback>(
+    rollback: &mut R,
+    owned: &VehicleBindingAcquisition,
+    foreign: &VehicleBindingAcquisition,
+) -> Result<(), ConformanceFailure> {
+    if owned == foreign {
+        return Err(ConformanceFailure::new(
+            "vehicle rollback fixture",
+            "the owned and foreign acquisitions are the same",
+        ));
+    }
+    rollback.release_binding_blocking(owned).map_err(|source| {
+        ConformanceFailure::new(
+            "vehicle rollback proves absence",
+            format!("the first release refused an owned acquisition: {source}"),
+        )
+    })?;
+    rollback.release_binding_blocking(owned).map_err(|source| {
+        ConformanceFailure::new(
+            "vehicle rollback is idempotent",
+            format!("a repeated release changed the result: {source}"),
+        )
+    })?;
+    if rollback.release_binding_blocking(foreign).is_ok() {
+        return Err(ConformanceFailure::new(
+            "vehicle rollback refuses a foreign acquisition",
+            "the release accepted an acquisition the handle does not own",
+        ));
+    }
+    Ok(())
+}
+
+/// Checks both halves of one open rollback in reverse acquisition order.
+///
+/// # Errors
+///
+/// Returns [`ConformanceFailure`] when either half breaks the contract.
+pub fn check_open_rollback<B: CampaignBackend, R: VehicleBindingRollback>(
+    backend: &mut B,
+    rollback: &mut R,
+    owned_session: &SimulatorSessionAcquisition,
+    foreign_session: &SimulatorSessionAcquisition,
+    owned_vehicle: &VehicleBindingAcquisition,
+    foreign_vehicle: &VehicleBindingAcquisition,
+) -> Result<(), ConformanceFailure> {
+    check_vehicle_binding_rollback(rollback, owned_vehicle, foreign_vehicle)?;
+    check_simulator_session_rollback(backend, owned_session, foreign_session)
+}

--- a/tools/flight-tune/src/adapter/lifecycle.rs
+++ b/tools/flight-tune/src/adapter/lifecycle.rs
@@ -5,7 +5,8 @@ use pilotage_trial::Digest;
 
 use super::{
     AdapterError, CandidateTransitionReceipt, CandidateTransitionRequest, SessionChallenge,
-    SimulatorCapability, SimulatorSessionReceipt, VehicleBinding,
+    SimulatorCapability, SimulatorSessionAcquisition, SimulatorSessionReceipt, VehicleBinding,
+    VehicleBindingRollback,
 };
 use crate::{
     ArtifactIdentity, Candidate, MissionDocument, MissionReference, RunExecutionContext,
@@ -109,6 +110,21 @@ pub trait CampaignBackend {
         challenge: &SessionChallenge,
     ) -> Result<SimulatorSessionReceipt, AdapterError>;
 
+    /// Idempotently closes the simulator session this acquisition names.
+    ///
+    /// Success means no session for this acquisition remains, so an open
+    /// that never completed leaves nothing to inherit. The target is one
+    /// tuning session, not the runtime an operator owns and keeps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the acquisition names another tuning
+    /// session, simulator, or airframe, or when absence is not provable.
+    fn close_session_blocking(
+        &mut self,
+        acquisition: &SimulatorSessionAcquisition,
+    ) -> Result<(), AdapterError>;
+
     /// Prepares one exact durable run intent.
     fn prepare_blocking(
         &mut self,
@@ -192,8 +208,19 @@ pub trait SimulatorVehicleFactory {
     /// The bound adapter type.
     type Adapter: SimulatorVehicleAdapter;
 
+    /// The owner that releases a binding this factory can have created.
+    type Rollback: VehicleBindingRollback;
+
     /// Returns the exact vehicle implementation identity.
     fn vehicle_identity(&self) -> &ArtifactIdentity;
+
+    /// Returns the rollback owner for a binding this factory can create.
+    ///
+    /// The bind operation consumes the factory, so a bind that fails part
+    /// way through has no factory left to clean up after it. The owner is
+    /// taken before the bind starts, which is the only point at which both
+    /// still exist.
+    fn rollback_handle(&self) -> Self::Rollback;
 
     /// Returns the exact vehicle action-port identity for scenario execution.
     fn scenario_action_port_identity(&self) -> &ArtifactIdentity {

--- a/tools/flight-tune/src/adapter/rollback.rs
+++ b/tools/flight-tune/src/adapter/rollback.rs
@@ -1,0 +1,119 @@
+use pilotage_trial::Digest;
+
+use super::AdapterError;
+
+/// The exact identity of one simulator session an open attempt can hold.
+///
+/// Cleanup names its target by the identities that authorized the
+/// acquisition. A process name or a socket name is a guess about which
+/// resource belongs to which attempt; these digests are the attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimulatorSessionAcquisition {
+    session_digest: Digest,
+    simulator_digest: Digest,
+    airframe_digest: Digest,
+}
+
+impl SimulatorSessionAcquisition {
+    /// Names one simulator session by tuning session, simulator, and airframe.
+    #[must_use]
+    pub const fn new(
+        session_digest: Digest,
+        simulator_digest: Digest,
+        airframe_digest: Digest,
+    ) -> Self {
+        Self {
+            session_digest,
+            simulator_digest,
+            airframe_digest,
+        }
+    }
+
+    /// Returns the tuning session this acquisition belongs to.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the simulator implementation this acquisition names.
+    #[must_use]
+    pub const fn simulator_digest(&self) -> Digest {
+        self.simulator_digest
+    }
+
+    /// Returns the airframe this acquisition names.
+    #[must_use]
+    pub const fn airframe_digest(&self) -> Digest {
+        self.airframe_digest
+    }
+}
+
+/// The exact identity of one vehicle binding a factory can have created.
+///
+/// The identity exists before the bind starts, so a bind that fails part
+/// way through still has an exact cleanup target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VehicleBindingAcquisition {
+    session_digest: Digest,
+    vehicle_digest: Digest,
+    scenario_runtime_digest: Digest,
+}
+
+impl VehicleBindingAcquisition {
+    /// Names one vehicle binding by tuning session, vehicle, and runtime.
+    #[must_use]
+    pub const fn new(
+        session_digest: Digest,
+        vehicle_digest: Digest,
+        scenario_runtime_digest: Digest,
+    ) -> Self {
+        Self {
+            session_digest,
+            vehicle_digest,
+            scenario_runtime_digest,
+        }
+    }
+
+    /// Returns the tuning session this acquisition belongs to.
+    #[must_use]
+    pub const fn session_digest(&self) -> Digest {
+        self.session_digest
+    }
+
+    /// Returns the vehicle implementation this acquisition names.
+    #[must_use]
+    pub const fn vehicle_digest(&self) -> Digest {
+        self.vehicle_digest
+    }
+
+    /// Returns the engine and action-port identity this acquisition names.
+    #[must_use]
+    pub const fn scenario_runtime_digest(&self) -> Digest {
+        self.scenario_runtime_digest
+    }
+}
+
+/// Releases or contains one exact vehicle binding.
+///
+/// A factory is consumed by its own bind operation, so the owner of a
+/// partial bind has to exist before the bind starts. This handle is that
+/// owner.
+pub trait VehicleBindingRollback {
+    /// Releases or contains the vehicle binding this acquisition names.
+    ///
+    /// The operation is idempotent: a repeat after an uncertain
+    /// acknowledgement keeps the same state and returns the same success.
+    /// It returns success only when it proves that no binding for this
+    /// acquisition remains. It must not release a resource that another
+    /// acquisition owns, and it must not stop an operator-owned runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdapterError`] when the acquisition names a foreign
+    /// binding, or when the operation cannot prove that the binding is
+    /// absent.
+    fn release_binding_blocking(
+        &mut self,
+        acquisition: &VehicleBindingAcquisition,
+    ) -> Result<(), AdapterError>;
+}

--- a/tools/flight-tune/src/campaign/open.rs
+++ b/tools/flight-tune/src/campaign/open.rs
@@ -2,11 +2,15 @@ use std::path::Path;
 
 use crate::{
     CampaignBackend, Candidate, GateEvaluator, Journal, MetricEvaluator, ProposalStrategy,
-    RunTerminalAdapter, RuntimeIdentities, SearchStage, SessionChallenge, SimulatorCapability,
-    SimulatorVehicleAdapter, SimulatorVehicleFactory, TuneError,
+    RunTerminalAdapter, RuntimeIdentities, SearchStage, SimulatorCapability,
+    SimulatorVehicleAdapter, SimulatorVehicleFactory, TuneError, VehicleBinding,
 };
 
-use super::{Tuner, evaluate, session};
+use super::{Tuner, evaluate, reconcile, session};
+
+mod transaction;
+
+use transaction::OpenTransaction;
 
 impl<B, V, G, M, P> Tuner<B, V, G, M, P>
 where
@@ -18,8 +22,9 @@ where
 {
     /// Opens a matching campaign or creates a new campaign.
     ///
-    /// The constructor binds the vehicle adapter to the validated simulator
-    /// session. It also cleans and quarantines an incomplete prepared attempt.
+    /// One open transaction owns the simulator session and the vehicle
+    /// binding until every open check passes. A check that fails first
+    /// releases what the attempt acquired, in reverse acquisition order.
     ///
     /// # Errors
     ///
@@ -99,7 +104,7 @@ where
 
     fn finish_open<F>(
         stage: SearchStage,
-        mut backend: B,
+        backend: B,
         vehicle_factory: F,
         mut gates: G,
         mut metric: M,
@@ -109,50 +114,65 @@ where
     where
         F: SimulatorVehicleFactory<Adapter = V>,
     {
-        let vehicle_identity = vehicle_factory.vehicle_identity().clone();
         journal.ensure_usable()?;
-        let session_digest = journal.session_digest()?;
-        let challenge = SessionChallenge::new(session_digest);
-        let receipt = backend
-            .open_session_blocking(&challenge)
-            .map_err(|source| TuneError::Adapter {
-                adapter: backend.simulator_identity().id.clone(),
-                operation: "open simulator session",
-                source,
-            })?;
-        session::validate_simulator_receipt(&journal, receipt)?;
-        let capability = SimulatorCapability::new(receipt);
-        journal.ensure_usable()?;
-        let mut vehicle = vehicle_factory
-            .bind_blocking(&capability)
-            .map_err(|source| TuneError::Adapter {
-                adapter: vehicle_identity.id,
-                operation: "bind simulator vehicle",
-                source,
-            })?;
-        session::validate_vehicle_binding(&journal, &vehicle)?;
-        evaluate::recover_pending_for_open_blocking(
+        let mut transaction = OpenTransaction::begin(backend, &vehicle_factory, &journal)?;
+        transaction.reconcile_prior_open_blocking()?;
+        let capability = transaction.open_session_blocking(&journal)?;
+        if let Err(unusable) = journal.ensure_usable() {
+            return Err(transaction.fail(unusable));
+        }
+        let mut vehicle =
+            transaction.bind_vehicle_blocking(&journal, vehicle_factory, &capability)?;
+        let remaining = complete_open_checks_blocking(
             &mut journal,
             &stage,
-            &mut backend,
+            transaction.backend_mut(),
             &mut vehicle,
             &capability,
             &mut gates,
             &mut metric,
-        )?;
-        let mut tuner = Self {
+        );
+        if let Err(primary) = remaining {
+            return Err(transaction.fail(primary));
+        }
+        Ok(Self {
             stage,
-            backend,
+            backend: transaction.commit(),
             vehicle,
             capability,
             gates,
             metric,
             strategy,
             journal,
-        };
-        tuner.reconcile_settled_candidate_blocking()?;
-        Ok(tuner)
+        })
     }
+}
+
+/// Runs every open check that needs both acquired resources.
+///
+/// These checks are the last ones before the commit. They read and write
+/// the simulator and the vehicle, so a failure here still has to release
+/// both, which is why they run inside the transaction rather than on a
+/// tuner that already owns them.
+fn complete_open_checks_blocking<B, V, G, M>(
+    journal: &mut Journal,
+    stage: &SearchStage,
+    backend: &mut B,
+    vehicle: &mut VehicleBinding<V>,
+    capability: &SimulatorCapability,
+    gates: &mut G,
+    metric: &mut M,
+) -> Result<(), TuneError>
+where
+    B: CampaignBackend,
+    V: SimulatorVehicleAdapter + RunTerminalAdapter,
+    G: GateEvaluator,
+    M: MetricEvaluator,
+{
+    evaluate::recover_pending_for_open_blocking(
+        journal, stage, backend, vehicle, capability, gates, metric,
+    )?;
+    reconcile::settled_candidate_blocking(journal, vehicle, capability)
 }
 
 pub(crate) fn validate_open_components<B, F, G, M, P>(

--- a/tools/flight-tune/src/campaign/open/transaction.rs
+++ b/tools/flight-tune/src/campaign/open/transaction.rs
@@ -1,0 +1,207 @@
+use crate::{
+    CampaignBackend, Journal, OpenRollbackOperation, OpenRollbackReport, SessionChallenge,
+    SimulatorCapability, SimulatorSessionAcquisition, SimulatorVehicleFactory, TuneError,
+    VehicleBinding, VehicleBindingAcquisition, VehicleBindingRollback,
+};
+
+use super::super::session;
+
+/// One open attempt that owns every resource it acquires until it commits.
+///
+/// The transaction holds the simulator session and the vehicle binding.
+/// Neither reaches a tuner before every open check passes, and any check
+/// that fails first runs the reverse cleanup for whatever the attempt can
+/// have acquired.
+///
+/// A resource counts as acquired from the moment the operation that
+/// creates it starts, not from the moment it returns. An operation that
+/// fails can still have left the resource behind, and an acquisition
+/// identity that names nothing is cleaned up at no cost.
+pub(super) struct OpenTransaction<B, F: SimulatorVehicleFactory> {
+    backend: B,
+    rollback: F::Rollback,
+    session: SimulatorSessionAcquisition,
+    vehicle: VehicleBindingAcquisition,
+    holds_session: bool,
+    holds_vehicle: bool,
+}
+
+impl<B, F> OpenTransaction<B, F>
+where
+    B: CampaignBackend,
+    F: SimulatorVehicleFactory,
+{
+    /// Starts one open attempt against the identities the journal states.
+    ///
+    /// Every acquisition identity comes from the journal session, so an
+    /// attempt names the same resources that every earlier attempt on this
+    /// campaign named, before it acquires anything.
+    pub(super) fn begin(backend: B, factory: &F, journal: &Journal) -> Result<Self, TuneError> {
+        let runtimes = &journal.session().runtimes;
+        let scenario_runtime =
+            runtimes
+                .scenario_runtime
+                .as_ref()
+                .ok_or_else(|| TuneError::InvalidIdentity {
+                    detail: "the journal session states no scenario runtime identity".to_owned(),
+                })?;
+        let session_digest = journal.session_digest()?;
+        Ok(Self {
+            backend,
+            rollback: factory.rollback_handle(),
+            session: SimulatorSessionAcquisition::new(
+                session_digest,
+                runtimes.simulator.digest,
+                runtimes.airframe.digest,
+            ),
+            vehicle: VehicleBindingAcquisition::new(
+                session_digest,
+                runtimes.vehicle.digest,
+                scenario_runtime.digest,
+            ),
+            holds_session: false,
+            holds_vehicle: false,
+        })
+    }
+
+    /// Proves that no earlier open attempt left a resource behind.
+    ///
+    /// A rollback that ended in an uncertain acknowledgement leaves the
+    /// same acquisition identities this attempt would use. The adapters
+    /// answer for their own resources, so the attempt asks them to prove
+    /// absence in reverse acquisition order and refuses to acquire
+    /// anything until they do.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError::OpenNotReconciled`] when either adapter cannot
+    /// prove that the earlier resource is absent.
+    pub(super) fn reconcile_prior_open_blocking(&mut self) -> Result<(), TuneError> {
+        let mut report = OpenRollbackReport::new();
+        report.record(
+            OpenRollbackOperation::VehicleBinding,
+            self.rollback.release_binding_blocking(&self.vehicle),
+        );
+        report.record(
+            OpenRollbackOperation::SimulatorSession,
+            self.backend.close_session_blocking(&self.session),
+        );
+        if report.is_complete() {
+            Ok(())
+        } else {
+            Err(TuneError::OpenNotReconciled { report })
+        }
+    }
+
+    /// Opens one simulator session and validates its exact receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the simulator refuses the challenge or
+    /// answers with a receipt that names another session, simulator, or
+    /// airframe. Either failure rolls the attempt back first.
+    pub(super) fn open_session_blocking(
+        &mut self,
+        journal: &Journal,
+    ) -> Result<SimulatorCapability, TuneError> {
+        let challenge = SessionChallenge::new(self.session.session_digest());
+        self.holds_session = true;
+        let receipt = match self.backend.open_session_blocking(&challenge) {
+            Ok(receipt) => receipt,
+            Err(source) => {
+                return Err(self.fail(TuneError::Adapter {
+                    adapter: self.backend.simulator_identity().id.clone(),
+                    operation: "open simulator session",
+                    source,
+                }));
+            }
+        };
+        if let Err(mismatch) = session::validate_simulator_receipt(journal, receipt) {
+            return Err(self.fail(mismatch));
+        }
+        Ok(SimulatorCapability::new(receipt))
+    }
+
+    /// Binds one vehicle and validates its exact binding receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuneError`] when the factory refuses the capability or
+    /// returns a binding that names another session, vehicle, or
+    /// transition policy. Either failure rolls the attempt back first.
+    pub(super) fn bind_vehicle_blocking(
+        &mut self,
+        journal: &Journal,
+        factory: F,
+        capability: &SimulatorCapability,
+    ) -> Result<VehicleBinding<F::Adapter>, TuneError> {
+        let vehicle_id = factory.vehicle_identity().id.clone();
+        self.holds_vehicle = true;
+        let binding = match factory.bind_blocking(capability) {
+            Ok(binding) => binding,
+            Err(source) => {
+                return Err(self.fail(TuneError::Adapter {
+                    adapter: vehicle_id,
+                    operation: "bind simulator vehicle",
+                    source,
+                }));
+            }
+        };
+        if let Err(mismatch) = session::validate_vehicle_binding(journal, &binding) {
+            return Err(self.fail(mismatch));
+        }
+        Ok(binding)
+    }
+
+    /// Returns the backend for the open checks that run before the commit.
+    pub(super) fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
+    }
+
+    /// Rolls the attempt back and states the primary failure with it.
+    ///
+    /// Cleanup runs in reverse acquisition order, and every applicable
+    /// operation runs even after an earlier one fails. The primary failure
+    /// stands alone when cleanup proved absence, because there is then
+    /// nothing further to state.
+    pub(super) fn fail(&mut self, primary: TuneError) -> TuneError {
+        let report = self.roll_back_blocking();
+        if report.is_complete() {
+            primary
+        } else {
+            TuneError::OpenAndRollbackFailed {
+                primary: Box::new(primary),
+                rollback: report,
+            }
+        }
+    }
+
+    /// Transfers every acquired resource out of the transaction.
+    ///
+    /// The transaction is consumed here, so nothing it held can be rolled
+    /// back after the tuner owns it.
+    pub(super) fn commit(self) -> B {
+        self.backend
+    }
+
+    fn roll_back_blocking(&mut self) -> OpenRollbackReport {
+        let mut report = OpenRollbackReport::new();
+        if self.holds_vehicle {
+            report.record(
+                OpenRollbackOperation::VehicleBinding,
+                self.rollback.release_binding_blocking(&self.vehicle),
+            );
+        }
+        if self.holds_session {
+            report.record(
+                OpenRollbackOperation::SimulatorSession,
+                self.backend.close_session_blocking(&self.session),
+            );
+        }
+        if report.is_complete() {
+            self.holds_vehicle = false;
+            self.holds_session = false;
+        }
+        report
+    }
+}

--- a/tools/flight-tune/src/campaign/reconcile.rs
+++ b/tools/flight-tune/src/campaign/reconcile.rs
@@ -1,10 +1,56 @@
 use crate::journal::CampaignPhase;
 use crate::{
-    CampaignBackend, FinalQualificationOutcome, GateEvaluator, MetricEvaluator, ProposalStrategy,
-    RunTerminalAdapter, SimulatorVehicleAdapter, TuneError,
+    CampaignBackend, FinalQualificationOutcome, GateEvaluator, Journal, MetricEvaluator,
+    ProposalStrategy, RunTerminalAdapter, SimulatorCapability, SimulatorVehicleAdapter, TuneError,
+    VehicleBinding,
 };
 
 use super::{Tuner, evaluate, invalid_state};
+
+/// Reactivates the candidate the journal states is settled.
+///
+/// The open transaction runs this before it commits and the tuner runs it
+/// after every operation, so it takes the parts rather than a tuner: at
+/// open there is no tuner to take.
+///
+/// # Errors
+///
+/// Returns [`TuneError`] when an attempt is still pending, when the
+/// candidate cannot be read, or when the vehicle refuses it.
+pub(super) fn settled_candidate_blocking<V>(
+    journal: &Journal,
+    vehicle: &mut VehicleBinding<V>,
+    capability: &SimulatorCapability,
+) -> Result<(), TuneError>
+where
+    V: SimulatorVehicleAdapter,
+{
+    journal.ensure_usable()?;
+    if journal.state().pending.is_some() {
+        return Err(invalid_state(
+            "reconcile active candidate",
+            "an attempt still requires cleanup",
+        ));
+    }
+    let digest = settled_candidate_digest(journal);
+    let candidate = journal.read_candidate(digest)?;
+    evaluate::ensure_settled_candidate_blocking(journal, vehicle, capability, &candidate, digest)
+}
+
+fn settled_candidate_digest(journal: &Journal) -> crate::Digest {
+    let initial = journal.session().initial_candidate_digest;
+    match journal.phase() {
+        CampaignPhase::Searching => journal.state().training_incumbent,
+        CampaignPhase::Frozen => initial,
+        CampaignPhase::PromotionClosed => journal.state().settlement_candidate(initial),
+        CampaignPhase::Sealed
+            if journal.state().final_outcome == Some(FinalQualificationOutcome::Qualified) =>
+        {
+            journal.state().settlement_candidate(initial)
+        }
+        CampaignPhase::Sealed => initial,
+    }
+}
 
 impl<B, V, G, M, P> Tuner<B, V, G, M, P>
 where
@@ -15,22 +61,7 @@ where
     P: ProposalStrategy,
 {
     pub(super) fn reconcile_settled_candidate_blocking(&mut self) -> Result<(), TuneError> {
-        self.journal.ensure_usable()?;
-        if self.journal.state().pending.is_some() {
-            return Err(invalid_state(
-                "reconcile active candidate",
-                "an attempt still requires cleanup",
-            ));
-        }
-        let digest = self.settled_candidate_digest();
-        let candidate = self.journal.read_candidate(digest)?;
-        evaluate::ensure_settled_candidate_blocking(
-            &self.journal,
-            &mut self.vehicle,
-            &self.capability,
-            &candidate,
-            digest,
-        )
+        settled_candidate_blocking(&self.journal, &mut self.vehicle, &self.capability)
     }
 
     pub(super) fn finish_with_candidate_reconciliation_blocking(
@@ -64,22 +95,6 @@ where
                     reconciliation: Box::new(reconciliation),
                 })
             }
-        }
-    }
-
-    fn settled_candidate_digest(&self) -> crate::Digest {
-        let initial = self.journal.session().initial_candidate_digest;
-        match self.journal.phase() {
-            CampaignPhase::Searching => self.journal.state().training_incumbent,
-            CampaignPhase::Frozen => initial,
-            CampaignPhase::PromotionClosed => self.journal.state().settlement_candidate(initial),
-            CampaignPhase::Sealed
-                if self.journal.state().final_outcome
-                    == Some(FinalQualificationOutcome::Qualified) =>
-            {
-                self.journal.state().settlement_candidate(initial)
-            }
-            CampaignPhase::Sealed => initial,
         }
     }
 }

--- a/tools/flight-tune/src/error.rs
+++ b/tools/flight-tune/src/error.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+mod open_rollback;
+
+pub use open_rollback::{OpenRollbackOperation, OpenRollbackReport};
+
 use crate::{AdapterError, Digest, EvaluatorError};
 
 /// An error from tuner validation, execution, or storage.
@@ -85,6 +89,26 @@ pub enum TuneError {
         /// The terminal sequence error.
         #[source]
         terminal: Box<TuneError>,
+    },
+    /// An open transaction failed and its reverse cleanup did not complete.
+    ///
+    /// The primary failure is the reason the open stopped. The report
+    /// states every cleanup operation that ran after it, so a vehicle
+    /// rollback failure cannot hide a simulator-session rollback failure.
+    #[error("open transaction failed: {primary}; reverse cleanup did not complete: {rollback}")]
+    OpenAndRollbackFailed {
+        /// The failure that stopped the open.
+        primary: Box<TuneError>,
+        /// Every cleanup operation, in the order it ran.
+        #[source]
+        rollback: OpenRollbackReport,
+    },
+    /// A prior open left a resource that this open cannot prove absent.
+    #[error("a prior open transaction is not reconciled: {report}")]
+    OpenNotReconciled {
+        /// Every reconciliation operation, in the order it ran.
+        #[source]
+        report: OpenRollbackReport,
     },
     /// A gate or metric evaluator operation failed.
     #[error("{implementation} failed during {operation}: {source}")]

--- a/tools/flight-tune/src/error/open_rollback.rs
+++ b/tools/flight-tune/src/error/open_rollback.rs
@@ -1,0 +1,107 @@
+use std::error::Error;
+use std::fmt;
+
+use crate::AdapterError;
+
+/// One reverse-cleanup operation of an open transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenRollbackOperation {
+    /// Release or contain the vehicle binding.
+    VehicleBinding,
+    /// Close the simulator session.
+    SimulatorSession,
+}
+
+impl OpenRollbackOperation {
+    /// Returns the stable diagnostic name of this operation.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::VehicleBinding => "release vehicle binding",
+            Self::SimulatorSession => "close simulator session",
+        }
+    }
+}
+
+impl fmt::Display for OpenRollbackOperation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.name())
+    }
+}
+
+/// Every reverse-cleanup operation one open attempt ran, in its order.
+///
+/// A later operation runs after an earlier failure, so the report states
+/// each outcome rather than the first one. An empty report states that the
+/// attempt held nothing to release.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpenRollbackReport {
+    outcomes: Vec<(OpenRollbackOperation, Option<AdapterError>)>,
+}
+
+impl OpenRollbackReport {
+    /// Creates a report for an attempt that has released nothing.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            outcomes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn record(
+        &mut self,
+        operation: OpenRollbackOperation,
+        result: Result<(), AdapterError>,
+    ) {
+        self.outcomes.push((operation, result.err()));
+    }
+
+    /// Returns every operation this cleanup ran, in the order it ran them.
+    pub fn operations(&self) -> impl Iterator<Item = OpenRollbackOperation> + '_ {
+        self.outcomes.iter().map(|(operation, _)| *operation)
+    }
+
+    /// Returns every operation that failed, in the order it ran.
+    pub fn failures(&self) -> impl Iterator<Item = (OpenRollbackOperation, &AdapterError)> + '_ {
+        self.outcomes
+            .iter()
+            .filter_map(|(operation, error)| error.as_ref().map(|error| (*operation, error)))
+    }
+
+    /// States whether every operation this cleanup ran proved absence.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.failures().next().is_none()
+    }
+
+    /// States whether this cleanup ran no operation at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.outcomes.is_empty()
+    }
+}
+
+impl fmt::Display for OpenRollbackReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return formatter.write_str("no open resource required cleanup");
+        }
+        let mut separator = "";
+        for (operation, error) in &self.outcomes {
+            match error {
+                Some(error) => write!(formatter, "{separator}{operation} failed: {error}")?,
+                None => write!(formatter, "{separator}{operation} succeeded")?,
+            }
+            separator = "; ";
+        }
+        Ok(())
+    }
+}
+
+impl Error for OpenRollbackReport {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.failures()
+            .next()
+            .map(|(_, error)| error as &(dyn Error + 'static))
+    }
+}

--- a/tools/flight-tune/src/lib.rs
+++ b/tools/flight-tune/src/lib.rs
@@ -30,15 +30,16 @@ pub use adapter::{
     CandidateTransitionReceipt, CandidateTransitionReference, CandidateTransitionRequest,
     EvaluatorError, RunPreparationReceipt, RunTerminalAdapter, RunTerminalCapabilities,
     SampleEvent, ScenarioStartReceipt, SessionChallenge, SimulatorCapability,
-    SimulatorSessionReceipt, SimulatorVehicleAdapter, SimulatorVehicleFactory, TelemetrySample,
-    TransitionBindingReceipt, VehicleBinding, VehicleBindingReceipt,
+    SimulatorSessionAcquisition, SimulatorSessionReceipt, SimulatorVehicleAdapter,
+    SimulatorVehicleFactory, TelemetrySample, TransitionBindingReceipt, VehicleBinding,
+    VehicleBindingAcquisition, VehicleBindingReceipt, VehicleBindingRollback, conformance,
 };
 pub use campaign::{StopReason, Tuner, TuningSummary};
 pub use campaign_config::{
     CAMPAIGN_CONFIG_SCHEMA_VERSION, CampaignAdapterDocuments, CampaignConfig,
 };
 pub use contract_api::*;
-pub use error::TuneError;
+pub use error::{OpenRollbackOperation, OpenRollbackReport, TuneError};
 pub use flight_quality::{
     CanonicalTelemetryKey, EVALUATOR_IMPLEMENTATION_SCHEMA_VERSION, FlightQualityGate,
     FlightQualityGateConfig, FlightQualityGateEvaluator, FlightQualityMetricConfig,

--- a/tools/flight-tune/tests/tuner.rs
+++ b/tools/flight-tune/tests/tuner.rs
@@ -10,6 +10,8 @@ mod final_objectives;
 mod journal_storage;
 #[path = "tuner/no_samples.rs"]
 mod no_samples;
+#[path = "tuner/open_transaction.rs"]
+mod open_transaction;
 #[path = "tuner/orphan_baseline.rs"]
 mod orphan_baseline;
 #[path = "tuner/promotion_chain_tamper.rs"]

--- a/tools/flight-tune/tests/tuner/open_transaction.rs
+++ b/tools/flight-tune/tests/tuner/open_transaction.rs
@@ -1,0 +1,319 @@
+//! The open transaction owns every resource it acquires until it commits.
+
+use flight_tune::{
+    CampaignBackend, Digest, OpenRollbackOperation, SimulatorSessionAcquisition,
+    SimulatorVehicleFactory, TuneError, VehicleBindingAcquisition, VehicleBindingRollback,
+    conformance,
+};
+
+use super::open;
+use super::test_rig::{FakeBackend, FakeFactory, FakeHandle, FakeRuntimeLease, SequenceStrategy};
+use super::{TestDirectory, TestTuner};
+
+#[path = "open_transaction/residue.rs"]
+mod residue;
+
+/// A session digest that no journal in these tests produces.
+///
+/// The rollback tests below drive the adapters directly, so they name a
+/// session of their own rather than one an open transaction minted.
+const STANDALONE_SESSION: Digest = Digest::from_bytes([17; 32]);
+
+fn open_once(directory: &TestDirectory, state: &FakeHandle) -> Result<TestTuner, TuneError> {
+    open(
+        directory.path(),
+        state.clone(),
+        SequenceStrategy::new(Vec::new()),
+        2.0,
+    )
+}
+
+/// Returns the open path after the entries a completed open already wrote.
+fn open_path_after(state: &FakeHandle, start: usize) -> Vec<String> {
+    state.0.borrow().open_order[start..].to_vec()
+}
+
+/// Takes the failure of an open that must not return a tuner.
+fn expect_open_error(result: Result<TestTuner, TuneError>, reason: &str) -> TuneError {
+    match result {
+        Ok(_) => panic!("the open completed: {reason}"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn a_simulator_receipt_mismatch_rolls_back_the_session_and_never_binds() {
+    let directory = TestDirectory::new("open-session-receipt-mismatch");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().bad_session_receipt = true;
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the session receipt");
+
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+    assert_eq!(
+        open_path_after(&state, 0),
+        [
+            "release_binding",
+            "close_session",
+            "open_session",
+            "close_session"
+        ]
+    );
+    assert_eq!(state.0.borrow().vehicle.bind_count, 0);
+    assert!(!state.0.borrow().session_open);
+    assert!(!state.0.borrow().vehicle.bound);
+}
+
+#[test]
+fn a_factory_bind_error_rolls_back_the_partial_binding_and_the_session() {
+    let directory = TestDirectory::new("open-bind-error");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().vehicle.fail_bind = true;
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    assert!(matches!(error, TuneError::Adapter { .. }));
+    assert_eq!(
+        open_path_after(&state, 2),
+        ["open_session", "bind", "release_binding", "close_session"]
+    );
+    assert!(!state.0.borrow().session_open);
+    assert!(!state.0.borrow().vehicle.bound);
+}
+
+#[test]
+fn a_vehicle_binding_mismatch_rolls_back_the_binding_and_the_session() {
+    let directory = TestDirectory::new("open-binding-receipt-mismatch");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().vehicle.bad_binding_receipt = true;
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the binding receipt");
+
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+    assert_eq!(
+        open_path_after(&state, 2),
+        ["open_session", "bind", "release_binding", "close_session"]
+    );
+    assert!(!state.0.borrow().session_open);
+    assert!(!state.0.borrow().vehicle.bound);
+}
+
+#[test]
+fn a_later_open_check_error_rolls_back_both_open_resources() {
+    let directory = TestDirectory::new("open-late-check-error");
+    let state = FakeHandle::new();
+    state
+        .0
+        .borrow_mut()
+        .vehicle
+        .bad_candidate_readback_on_ensure = Some(1);
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the settled readback");
+
+    assert!(matches!(error, TuneError::ReceiptMismatch { .. }));
+    let path = open_path_after(&state, 2);
+    assert_eq!(path.first().map(String::as_str), Some("open_session"));
+    assert_eq!(
+        path[path.len().wrapping_sub(2)..],
+        ["release_binding", "close_session"]
+    );
+    assert!(!state.0.borrow().session_open);
+    assert!(!state.0.borrow().vehicle.bound);
+}
+
+#[test]
+fn cleanup_releases_the_vehicle_binding_before_the_simulator_session() {
+    let directory = TestDirectory::new("open-reverse-order");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().vehicle.fail_bind = true;
+
+    expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    let path = open_path_after(&state, 2);
+    let release = path
+        .iter()
+        .position(|step| step == "release_binding")
+        .expect("a vehicle release");
+    let close = path
+        .iter()
+        .position(|step| step == "close_session")
+        .expect("a session close");
+    assert!(release < close);
+}
+
+#[test]
+fn a_vehicle_rollback_error_does_not_stop_the_session_rollback() {
+    let directory = TestDirectory::new("open-release-error");
+    let state = FakeHandle::new();
+    {
+        let mut fake = state.0.borrow_mut();
+        fake.vehicle.fail_bind = true;
+        // The reconciliation release is the first; the cleanup release is
+        // the second.
+        fake.vehicle.fail_release_on = Some(2);
+    }
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    let TuneError::OpenAndRollbackFailed { primary, rollback } = error else {
+        panic!("a failed rollback did not reach the result");
+    };
+    assert!(matches!(*primary, TuneError::Adapter { .. }));
+    assert_eq!(
+        rollback.operations().collect::<Vec<_>>(),
+        [
+            OpenRollbackOperation::VehicleBinding,
+            OpenRollbackOperation::SimulatorSession
+        ]
+    );
+    assert_eq!(
+        rollback
+            .failures()
+            .map(|(operation, _)| operation)
+            .collect::<Vec<_>>(),
+        [OpenRollbackOperation::VehicleBinding]
+    );
+    // The session closed even though the release before it failed.
+    assert!(!state.0.borrow().session_open);
+}
+
+#[test]
+fn one_result_preserves_the_primary_error_and_every_rollback_error() {
+    let directory = TestDirectory::new("open-every-rollback-error");
+    let state = FakeHandle::new();
+    {
+        let mut fake = state.0.borrow_mut();
+        fake.vehicle.fail_bind = true;
+        fake.vehicle.fail_release_on = Some(2);
+        fake.fail_session_close_on = Some(2);
+    }
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    let TuneError::OpenAndRollbackFailed { primary, rollback } = error else {
+        panic!("the rollback failures did not reach the result");
+    };
+    let TuneError::Adapter { operation, .. } = *primary else {
+        panic!("the primary failure did not reach the result");
+    };
+    assert_eq!(operation, "bind simulator vehicle");
+    assert_eq!(
+        rollback
+            .failures()
+            .map(|(operation, _)| operation)
+            .collect::<Vec<_>>(),
+        [
+            OpenRollbackOperation::VehicleBinding,
+            OpenRollbackOperation::SimulatorSession
+        ]
+    );
+    assert!(!rollback.is_complete());
+}
+
+#[test]
+fn a_repeated_rollback_has_the_same_result_and_no_further_effect() {
+    let state = FakeHandle::new();
+    let factory = FakeFactory::new(state.clone());
+    let mut backend = FakeBackend::new(state.clone());
+    let mut rollback = factory.rollback_handle();
+    let session = backend.session_acquisition(STANDALONE_SESSION);
+    let binding = factory.binding_acquisition(STANDALONE_SESSION);
+    state.0.borrow_mut().vehicle.gain = 0.75;
+
+    let first = (
+        rollback.release_binding_blocking(&binding),
+        backend.close_session_blocking(&session),
+    );
+    let second = (
+        rollback.release_binding_blocking(&binding),
+        backend.close_session_blocking(&session),
+    );
+
+    assert_eq!(first, second);
+    assert!(first.0.is_ok() && first.1.is_ok());
+    // A repeat writes nothing that a first release did not already write.
+    assert_eq!(state.0.borrow().vehicle.gain, 0.75);
+    assert_eq!(state.0.borrow().vehicle.apply_count, 0);
+}
+
+#[test]
+fn a_rollback_refuses_a_foreign_acquisition_identity() {
+    let state = FakeHandle::new();
+    let factory = FakeFactory::new(state.clone());
+    let mut backend = FakeBackend::new(state.clone());
+    let mut rollback = factory.rollback_handle();
+    assert!(backend.close_session_blocking(&foreign_session()).is_err());
+    assert!(
+        rollback
+            .release_binding_blocking(&foreign_binding())
+            .is_err()
+    );
+}
+
+#[test]
+fn the_reference_backend_and_factory_pass_the_open_rollback_suite() {
+    let state = FakeHandle::new();
+    let factory = FakeFactory::new(state.clone());
+    let mut backend = FakeBackend::new(state.clone());
+    let owned_session = backend.session_acquisition(STANDALONE_SESSION);
+    let owned_binding = factory.binding_acquisition(STANDALONE_SESSION);
+    let mut rollback = factory.rollback_handle();
+
+    conformance::check_open_rollback(
+        &mut backend,
+        &mut rollback,
+        &owned_session,
+        &foreign_session(),
+        &owned_binding,
+        &foreign_binding(),
+    )
+    .expect("the reference adapters keep the open rollback contract");
+}
+
+#[test]
+fn an_open_never_takes_a_second_runtime_lease_or_stops_the_operator_runtime() {
+    let directory = TestDirectory::new("open-runtime-lease");
+    let state = FakeHandle::new();
+    {
+        let mut fake = state.0.borrow_mut();
+        fake.runtime_lease = Some(FakeRuntimeLease::acquired());
+        fake.vehicle.fail_bind = true;
+    }
+
+    expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    {
+        let fake = state.0.borrow();
+        let lease = fake.runtime_lease.as_ref().expect("the armed lease");
+        assert_eq!(lease.acquisitions, 1);
+        assert!(lease.held);
+    }
+    state.0.borrow_mut().vehicle.fail_bind = false;
+
+    // The operator runtime survived the cleanup, so a later open still has
+    // one to open a session against.
+    open_once(&directory, &state).expect("open after a failed attempt");
+
+    let fake = state.0.borrow();
+    let lease = fake.runtime_lease.as_ref().expect("the armed lease");
+    assert_eq!(lease.acquisitions, 1);
+    assert!(lease.held);
+}
+
+/// Names a session no reference backend in these tests answers for.
+fn foreign_session() -> SimulatorSessionAcquisition {
+    SimulatorSessionAcquisition::new(
+        STANDALONE_SESSION,
+        Digest::from_bytes([29; 32]),
+        Digest::from_bytes([31; 32]),
+    )
+}
+
+/// Names a binding no reference factory in these tests answers for.
+fn foreign_binding() -> VehicleBindingAcquisition {
+    VehicleBindingAcquisition::new(
+        STANDALONE_SESSION,
+        Digest::from_bytes([37; 32]),
+        Digest::from_bytes([41; 32]),
+    )
+}

--- a/tools/flight-tune/tests/tuner/open_transaction/residue.rs
+++ b/tools/flight-tune/tests/tuner/open_transaction/residue.rs
@@ -1,0 +1,88 @@
+//! A later open inherits nothing from an open that did not commit.
+
+use flight_tune::TuneError;
+
+use super::super::TestDirectory;
+use super::super::test_rig::FakeHandle;
+use super::{expect_open_error, open_once};
+
+#[test]
+fn a_second_open_inherits_no_session_or_binding_from_a_failed_open() {
+    let directory = TestDirectory::new("open-residue-none");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().vehicle.fail_bind = true;
+
+    expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    assert!(!state.0.borrow().session_open);
+    assert!(!state.0.borrow().vehicle.bound);
+    let sessions_before = state.0.borrow().open_session_count;
+    state.0.borrow_mut().vehicle.fail_bind = false;
+
+    open_once(&directory, &state).expect("open after a failed attempt");
+
+    // The second open took its own session rather than an inherited one.
+    assert_eq!(
+        state.0.borrow().open_session_count,
+        sessions_before.wrapping_add(1)
+    );
+    assert!(state.0.borrow().session_open);
+}
+
+#[test]
+fn a_second_open_reconciles_an_ambiguous_rollback_before_it_acquires() {
+    let directory = TestDirectory::new("open-residue-ambiguous");
+    let state = FakeHandle::new();
+    {
+        let mut fake = state.0.borrow_mut();
+        fake.vehicle.fail_bind = true;
+        // The reconciliation close is the first; the cleanup close is the
+        // second, and it leaves the session in an uncertain state.
+        fake.fail_session_close_on = Some(2);
+    }
+
+    let error = expect_open_error(open_once(&directory, &state), "refuse the partial bind");
+
+    assert!(matches!(error, TuneError::OpenAndRollbackFailed { .. }));
+    assert!(state.0.borrow().session_open);
+    let resumed_at = state.0.borrow().open_order.len();
+    state.0.borrow_mut().vehicle.fail_bind = false;
+
+    open_once(&directory, &state).expect("open after an ambiguous rollback");
+
+    let path = state.0.borrow().open_order[resumed_at..].to_vec();
+    assert_eq!(
+        path.first().map(String::as_str),
+        Some("release_binding"),
+        "the second open reconciled the vehicle binding first"
+    );
+    assert_eq!(
+        path.get(1).map(String::as_str),
+        Some("close_session"),
+        "the second open closed the uncertain session next"
+    );
+    assert_eq!(
+        path.get(2).map(String::as_str),
+        Some("open_session"),
+        "the second open acquired only after it proved absence"
+    );
+}
+
+#[test]
+fn an_open_acquires_nothing_until_the_prior_session_is_proven_absent() {
+    let directory = TestDirectory::new("open-residue-fail-closed");
+    let state = FakeHandle::new();
+    state.0.borrow_mut().fail_session_close_on = Some(1);
+
+    let error = expect_open_error(
+        open_once(&directory, &state),
+        "refuse an unproven prior session",
+    );
+
+    let TuneError::OpenNotReconciled { report } = error else {
+        panic!("an unreconciled prior open did not fail closed");
+    };
+    assert!(!report.is_complete());
+    assert_eq!(state.0.borrow().open_session_count, 0);
+    assert_eq!(state.0.borrow().vehicle.bind_count, 0);
+}

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -169,13 +169,46 @@ pub use scoring::{
 pub use terminal_head_poison::TerminalExternalAction;
 #[allow(unused_imports)]
 pub use terminal_state::{FakeTerminalReadbackFault, FakeTerminalSealFault, FakeTerminalState};
-pub use vehicle::{FakeFactory, FakeVehicle};
+#[allow(unused_imports)]
+pub use vehicle::{FakeFactory, FakeVehicle, FakeVehicleRollback};
 pub use vehicle_state::FakeVehicleState;
+
+/// The outer runtime lease an operator holds across every open attempt.
+///
+/// The lease stands for the ownership proof that lives above the open
+/// transaction. A cleanup that reached past its own acquisition would
+/// release it, and the next open would then have no runtime to talk to.
+#[derive(Debug, Default)]
+pub struct FakeRuntimeLease {
+    pub acquisitions: usize,
+    pub held: bool,
+}
+
+impl FakeRuntimeLease {
+    pub fn acquired() -> Self {
+        Self {
+            acquisitions: 1,
+            held: true,
+        }
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct FakeState {
     pub vehicle: FakeVehicleState,
     pub terminal: FakeTerminalState,
+    /// Every acquisition and release of the open path, in order.
+    pub open_order: Vec<String>,
+    /// Whether the simulator holds a session the backend has to close.
+    pub session_open: bool,
+    /// Every session close the backend has answered.
+    pub session_close_count: usize,
+    /// The session close at this one-based count fails.
+    pub fail_session_close_on: Option<usize>,
+    /// The session receipt names another airframe.
+    pub bad_session_receipt: bool,
+    /// The operator-owned runtime lease, when a test arms one.
+    pub runtime_lease: Option<FakeRuntimeLease>,
     pub open_session_count: usize,
     pub prepare_count: usize,
     pub start_count: usize,

--- a/tools/flight-tune/tests/tuner/test_rig/backend.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/backend.rs
@@ -7,7 +7,8 @@ use flight_tune::{
     MissionDirective, MissionDocument, MissionReference, ReceiptResult, RunExecutionContext,
     RunPreparationReceipt, SampleEvent, ScenarioFrame, ScenarioObservationReceipt, ScenarioRuntime,
     ScenarioRuntimeError, ScenarioStartReceipt, ScenarioStopContext, SessionChallenge,
-    SimulatorCapability, SimulatorSessionReceipt, TelemetrySample, scenario_runtime_identity,
+    SimulatorCapability, SimulatorSessionAcquisition, SimulatorSessionReceipt, TelemetrySample,
+    scenario_runtime_identity,
 };
 use serde::Deserialize;
 
@@ -46,6 +47,15 @@ impl FakeBackend {
             scenario_runtime_identity(&backend.action_port_identity)
                 .expect("scenario runtime identity");
         backend
+    }
+
+    /// Names the session acquisition this backend answers for.
+    pub fn session_acquisition(&self, session_digest: Digest) -> SimulatorSessionAcquisition {
+        SimulatorSessionAcquisition::new(
+            session_digest,
+            self.simulator.digest,
+            self.airframe.digest,
+        )
     }
 }
 
@@ -114,12 +124,53 @@ impl CampaignBackend for FakeBackend {
         let mut state = self.state.0.borrow_mut();
         state.open_session_count = state.open_session_count.wrapping_add(1);
         state.lifecycle.push("open_session".to_owned());
+        state.open_order.push("open_session".to_owned());
+        // A backend cannot talk to a runtime the operator has not leased,
+        // so a cleanup that released the lease shows up as the next open
+        // having nothing to open a session against.
+        if state
+            .runtime_lease
+            .as_ref()
+            .is_some_and(|lease| !lease.held)
+        {
+            return Err(AdapterError::new("no operator runtime lease is held"));
+        }
+        state.session_open = true;
+        let bad_receipt = state.bad_session_receipt;
         drop(state);
         Ok(SimulatorSessionReceipt {
             session_digest: challenge.session_digest(),
             simulator_digest: self.simulator.digest,
-            airframe_digest: self.airframe.digest,
+            airframe_digest: if bad_receipt {
+                Digest::from_bytes([73; 32])
+            } else {
+                self.airframe.digest
+            },
         })
+    }
+
+    fn close_session_blocking(
+        &mut self,
+        acquisition: &SimulatorSessionAcquisition,
+    ) -> Result<(), AdapterError> {
+        if acquisition.simulator_digest() != self.simulator.digest
+            || acquisition.airframe_digest() != self.airframe.digest
+            || acquisition.session_digest().is_zero()
+        {
+            return Err(AdapterError::new(
+                "the acquisition names another simulator session",
+            ));
+        }
+        let mut state = self.state.0.borrow_mut();
+        state.open_order.push("close_session".to_owned());
+        state.session_close_count = state.session_close_count.wrapping_add(1);
+        if state.fail_session_close_on == Some(state.session_close_count) {
+            return Err(AdapterError::new(
+                "the simulator did not acknowledge the session close",
+            ));
+        }
+        state.session_open = false;
+        Ok(())
     }
 
     fn prepare_blocking(

--- a/tools/flight-tune/tests/tuner/test_rig/vehicle.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/vehicle.rs
@@ -2,7 +2,7 @@ use flight_tune::{
     AdapterError, ArtifactIdentity, Candidate, CandidateReceipt, CandidateTransitionReceipt,
     CandidateTransitionRequest, Digest, RunExecutionContext, SimulatorCapability,
     SimulatorVehicleAdapter, SimulatorVehicleFactory, TransitionBindingReceipt, VehicleBinding,
-    VehicleBindingReceipt,
+    VehicleBindingAcquisition, VehicleBindingReceipt, VehicleBindingRollback,
 };
 
 use super::{FakeHandle, identity};
@@ -163,13 +163,64 @@ impl FakeFactory {
         factory.adjacency_policy_digest = digest_text(content);
         factory
     }
+
+    /// Names the binding acquisition this factory answers for.
+    pub fn binding_acquisition(&self, session_digest: Digest) -> VehicleBindingAcquisition {
+        VehicleBindingAcquisition::new(
+            session_digest,
+            self.identity.digest,
+            runtime_digest(&self.action_port_identity),
+        )
+    }
+}
+
+/// Releases or contains one exact fake vehicle binding.
+pub struct FakeVehicleRollback {
+    state: FakeHandle,
+    vehicle_digest: Digest,
+    scenario_runtime_digest: Digest,
+}
+
+impl VehicleBindingRollback for FakeVehicleRollback {
+    fn release_binding_blocking(
+        &mut self,
+        acquisition: &VehicleBindingAcquisition,
+    ) -> Result<(), AdapterError> {
+        if acquisition.session_digest().is_zero()
+            || acquisition.vehicle_digest() != self.vehicle_digest
+            || acquisition.scenario_runtime_digest() != self.scenario_runtime_digest
+        {
+            return Err(AdapterError::new(
+                "the acquisition names another vehicle binding",
+            ));
+        }
+        let mut state = self.state.0.borrow_mut();
+        state.open_order.push("release_binding".to_owned());
+        state.vehicle.release_count = state.vehicle.release_count.wrapping_add(1);
+        if state.vehicle.fail_release_on == Some(state.vehicle.release_count) {
+            return Err(AdapterError::new(
+                "the vehicle did not acknowledge the binding release",
+            ));
+        }
+        state.vehicle.bound = false;
+        Ok(())
+    }
 }
 
 impl SimulatorVehicleFactory for FakeFactory {
     type Adapter = FakeVehicle;
+    type Rollback = FakeVehicleRollback;
 
     fn vehicle_identity(&self) -> &ArtifactIdentity {
         &self.identity
+    }
+
+    fn rollback_handle(&self) -> Self::Rollback {
+        FakeVehicleRollback {
+            state: self.state.clone(),
+            vehicle_digest: self.identity.digest,
+            scenario_runtime_digest: runtime_digest(&self.action_port_identity),
+        }
     }
 
     fn scenario_action_port_identity(&self) -> &ArtifactIdentity {
@@ -190,7 +241,18 @@ impl SimulatorVehicleFactory for FakeFactory {
     ) -> Result<VehicleBinding<Self::Adapter>, AdapterError> {
         let mut state = self.state.0.borrow_mut();
         state.vehicle.bind_count = state.vehicle.bind_count.wrapping_add(1);
+        state.open_order.push("bind".to_owned());
+        // The binding exists from here on, whether or not the rest of the
+        // bind completes, so a failure below is a partial bind.
+        state.vehicle.bound = true;
+        let fail_bind = state.vehicle.fail_bind;
+        let bad_receipt = state.vehicle.bad_binding_receipt;
         drop(state);
+        if fail_bind {
+            return Err(AdapterError::new(
+                "the vehicle stopped part way through the binding",
+            ));
+        }
         if !self.allow_binding {
             return Err(AdapterError::new(
                 "hardware-like adapter has no simulator session binding",
@@ -206,15 +268,21 @@ impl SimulatorVehicleFactory for FakeFactory {
             VehicleBindingReceipt {
                 session_digest: capability.session_digest(),
                 vehicle_digest: self.identity.digest,
-                scenario_runtime_digest: flight_tune::scenario_runtime_identity(
-                    &self.action_port_identity,
-                )
-                .map_err(|error| AdapterError::new(error.to_string()))?
-                .digest,
+                scenario_runtime_digest: if bad_receipt {
+                    Digest::from_bytes([61; 32])
+                } else {
+                    runtime_digest(&self.action_port_identity)
+                },
             },
             transition,
         )
     }
+}
+
+fn runtime_digest(action_port: &ArtifactIdentity) -> Digest {
+    flight_tune::scenario_runtime_identity(action_port)
+        .expect("scenario runtime identity")
+        .digest
 }
 
 fn candidate_gain(candidate: &Candidate) -> Result<f64, AdapterError> {

--- a/tools/flight-tune/tests/tuner/test_rig/vehicle_state.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/vehicle_state.rs
@@ -9,4 +9,14 @@ pub struct FakeVehicleState {
     pub apply_count: usize,
     pub bad_candidate_readback_on_ensure: Option<usize>,
     pub bad_candidate_readback_on_apply: Option<usize>,
+    /// Whether a bind left a vehicle binding the factory has to release.
+    pub bound: bool,
+    /// Every release the factory rollback handle has answered.
+    pub release_count: usize,
+    /// The bind fails after it records a partial binding.
+    pub fail_bind: bool,
+    /// The binding receipt names another scenario runtime.
+    pub bad_binding_receipt: bool,
+    /// The release at this one-based count fails.
+    pub fail_release_on: Option<usize>,
 }


### PR DESCRIPTION
## What this changes

`Tuner::open_or_resume` opened a simulator session, bound a vehicle, and could
then return an error with either resource still alive. Nothing required a
rollback, so a partial open could leave a session or a binding for the next
open to inherit or trip over.

This adds one typed open transaction that owns both resources until every open
check passes, and releases in reverse acquisition order when a check fails.

## Owner comment dispositions

`gh issue view 528 --json comments` returns an empty list: the issue carries no
comments, so every requirement here comes from the issue body. No owner
direction was overridden.

One interpretation had to be made and is stated rather than assumed:

- **Where the "exact incomplete open rollback" of step 3 lives.** The issue says
  a later open "must reconcile the exact incomplete rollback before it acquires
  a new session" and that it "must not acquire a new resource until the adapter
  proves that the prior resource is absent". Both acquisition identities are a
  pure function of the journal session identity — session digest, simulator
  digest, airframe digest, vehicle digest, scenario-runtime digest — so they are
  identical for every open of the same campaign and are known the moment the
  journal opens, before anything is acquired. Step 3 therefore runs the reverse
  cleanup for those exact identities unconditionally and requires the adapters
  to prove absence. This needs no second durable ledger beside the journal, and
  it keeps the journal schema and the journal verification path untouched.

## Transaction ordering

`OpenTransaction` in `tools/flight-tune/src/campaign/open/transaction.rs` runs
the issue's order:

1. `validate_open_components` — static component identities.
2. `Journal::open_or_create`.
3. `reconcile_prior_open_blocking` — release the vehicle binding, then close the
   simulator session, for the identities the journal names. Fail closed on
   either failure with `TuneError::OpenNotReconciled`; nothing is acquired.
4. `open_session_blocking`.
5. `validate_simulator_receipt`.
6. `bind_blocking` through the factory.
7. `validate_vehicle_binding`.
8. `complete_open_checks_blocking` — pending recovery and settled-candidate
   reconciliation, which previously ran on an already-constructed `Tuner`.
9. `commit` — the transaction is consumed and the tuner takes the resources.

A resource counts as acquired from the moment the operation that creates it
*starts*, not when it returns: the issue's rule for the vehicle ("when the
factory can have created one") applies to the session as well, so an
`open_session_blocking` that returns an error still runs the session rollback.

Step 8 does not change a candidate. `settled_candidate_blocking` restores the
candidate the journal already states is settled, and the adapter contract
forbids a controller write when that candidate is active; it proposes nothing
and it ran in this position before this change. It moved inside the transaction
because a failure there has to release both resources, which it could not do
while it ran on an already-constructed `Tuner`.

## Rollback proof

Reverse cleanup runs vehicle binding first, simulator session second, and every
applicable operation runs after an earlier one fails. Each operation takes a
typed acquisition identity and refuses a foreign one; no process name or socket
name is cleanup authority anywhere in the contract.

`tools/flight-tune/tests/tuner/open_transaction.rs` and its `residue.rs`
submodule cover every required test. Each one drives the real `open_or_resume`
and asserts the reference adapters hold nothing afterwards:

| Required test | Test |
| --- | --- |
| Receipt mismatch rolls back the session | `a_simulator_receipt_mismatch_rolls_back_the_session_and_never_binds` |
| Receipt mismatch does not call the factory | same test (`bind_count == 0`) |
| Factory bind error rolls back both | `a_factory_bind_error_rolls_back_the_partial_binding_and_the_session` |
| Binding mismatch rolls back both | `a_vehicle_binding_mismatch_rolls_back_the_binding_and_the_session` |
| Later open-check error rolls back both | `a_later_open_check_error_rolls_back_both_open_resources` |
| Vehicle rollback before session rollback | `cleanup_releases_the_vehicle_binding_before_the_simulator_session` |
| Vehicle rollback error does not stop the session rollback | `a_vehicle_rollback_error_does_not_stop_the_session_rollback` |
| One result preserves primary and all rollback errors | `one_result_preserves_the_primary_error_and_every_rollback_error` |
| Repeated rollback, same result, no further effect | `a_repeated_rollback_has_the_same_result_and_no_further_effect` |
| Rollback refuses a foreign acquisition | `a_rollback_refuses_a_foreign_acquisition_identity` |
| No residual session or binding at the second open | `residue::a_second_open_inherits_no_session_or_binding_from_a_failed_open` |
| Second open reconciles an ambiguous rollback first | `residue::a_second_open_reconciles_an_ambiguous_rollback_before_it_acquires` |
| Reference backend and factory pass the suite | `the_reference_backend_and_factory_pass_the_open_rollback_suite` |
| Lease fixture: no second runtime lease, operator runtime is not a target | `an_open_never_takes_a_second_runtime_lease_or_stops_the_operator_runtime` |

Fail-closed behaviour has its own test:
`residue::an_open_acquires_nothing_until_the_prior_session_is_proven_absent`
asserts `open_session_count == 0` and `bind_count == 0` when reconciliation
cannot prove absence.

The tests were checked against three mutations of the implementation:

- removing the reverse cleanup from `fail()` — 9 of 14 fail;
- swapping the cleanup order — 6 of 14 fail;
- letting the fake session close release the operator's runtime lease — the
  lease test fails and only that one.

The lease fixture is behavioural rather than an absence assertion: the fake
backend refuses `open_session_blocking` when the lease is not held, so a
cleanup that reached past its own acquisition breaks the *next* open.

## Conformance suite

`flight_tune::conformance` states the rollback contract once — proves absence,
is idempotent, refuses a foreign acquisition — and returns a typed
`ConformanceFailure` rather than panicking. It contains no simulator-specific
or vehicle-specific type. It calls only public trait methods, so it needs no
feature gate and any adapter crate can run it; `test-support` still gates only
the two capability minters, `SimulatorCapability::for_test` and the new
`SessionChallenge::for_test`. `Cargo.lock` is unchanged and no dependency was
added.

Three implementations run it:

- the reference backend and factory, in `flight-tune`'s own tests;
- the bench backend and bench vehicle factory (the second backend
  implementation), in `tools/flight-tune-campaign/src/bench/tests/open_rollback.rs`;
- the production Aviate vehicle factory, in
  `tools/flight-tune-aviate/tests/open_rollback.rs`.

## Pre-pin finding

Neither the verbatim (#469) rule nor the adapt-content (#468) rule applies:
`scripts/check-flight-tune-contracts.py` holds no source-digest pin, use-statement
pin, or identifier pin on any surface this change touches.
`SHARED_SIMULATOR_SOURCE_DIGESTS` pins only
`tools/flight-tune/src/bin/flight-tune-feedback/feedback/arguments.rs`, and the
generated-identity inventories cover only `flight_quality/**`,
`crates/pilotage-flight-quality/src/**` and `flight-tune-aviate/src/runtime/**` —
none of which this change touches. `check-flight-tune-contracts.py` passes
unchanged.

## Identity consequences

- `AviateVehicleFactory` gains `rollback_handle`, and
  `flight_tune_aviate::vehicle_identity` hashes `include_bytes!("vehicle.rs")`,
  so the Aviate vehicle identity digest changes. That is the intended signal:
  the vehicle's binding contract changed. No test, document, or manifest pins
  that digest as a literal, so nothing else moves. A journal opened by an older
  build will refuse to resume with `JournalSessionMismatch`, which is the same
  behaviour any change to a bound identity already has.
- `CampaignBackend` gains a required `close_session_blocking`, and
  `SimulatorVehicleFactory` gains `type Rollback` and `rollback_handle`. Three
  factories and two backends implement them; there is no Aviate or X-Plane
  `CampaignBackend` on main.
- `TuneError` gains `OpenAndRollbackFailed` and `OpenNotReconciled`. An open that
  fails and cleans up successfully still returns its primary error unchanged, so
  no existing error assertion moves.
- `SessionChallenge::for_test` joins `SimulatorCapability::for_test` behind
  `test-support`, so a downstream test can drive a backend's session lifecycle.
  A release build compiles neither.

## Structure

`check-structure.sh` forced three splits that ship with the change:
`OpenRollbackOperation` and `OpenRollbackReport` moved to
`tools/flight-tune/src/error/open_rollback.rs` (the report implements `Error` and
is a `TuneError` field, so it belongs with the error contract), the conformance
suite sits at `adapter/conformance.rs` beside the contract it checks, and the
bench candidate-to-command-law mapping moved to
`tools/flight-tune-campaign/src/bench/response.rs`.

## Gates

All run in an isolated worktree at `/private/tmp/pilotage-528`.

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass (run last, after every source change) |
| `cargo test --workspace --all-targets` | pass — 86 suites, 0 failures |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `scripts/check-structure.sh` | pass |
| `scripts/check-flight-tune-contracts.py` | pass |
| `scripts/check-flight-tune-boundaries.sh` | pass |
| `scripts/check-feedback-verifier-boundary.py` | pass |
| `scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | pass — 20 pairs |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | pass — both vehicles seal `Qualified` |

**Certification:** `a_campaign_runs_end_to_end_for_the_alia250` and
`a_campaign_runs_end_to_end_for_the_x500` both pass; each asserts
`FinalQualificationOutcome::Qualified` and a published evidence directory. Wall
time 2282 s (38 min) for the pair at `--test-threads 2`. That number is an upper
bound rather than a clean measurement: another agent's campaign test binary was
saturating the same machine throughout the run.

The workspace test run finished before three manifest-and-gating changes
(ungating the conformance suite, dropping a self dev-dependency, and a test
rename). `flight-tune` and `flight-tune-aviate` were re-run in full afterwards
and pass; `flight-tune-campaign` is covered by the certification run above,
which came after those changes. Clippy, the release build, and every script gate
ran on the final tree.

## Scope

This change does not touch simulator process discovery, socket ownership (#478),
runtime lease acquisition, scenario execution, or run terminal classification
(#457). No file under `tools/flight-tune/src/journal/**` changed.

## Refs, not Fixes

`Refs #528.`

Every acceptance criterion is met except one, and the exception is a fact about
main rather than a shortfall here: the issue says #469 "implements the
production Aviate session and vehicle rollback operations", and there is no
Aviate or X-Plane `CampaignBackend` on main to host a session rollback — the
only two implementations are the harness reference backend and the bench
backend. Every production Aviate surface that does exist,
`AviateVehicleFactory`, adopts the contract and runs the conformance suite. If
that reads as complete, this can close #528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
